### PR TITLE
[clang-format] Add SpacesInComments option for block comments

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -7405,9 +7405,9 @@ the configuration (without a prefix: ``Auto``).
 
 .. _SpacesInBlockComments:
 
-**SpacesInBlockComments** (``SpacesInBlockCommentsStyle``) :versionbadge:`clang-format 23` :ref:`¶ <SpacesInBlockComments>`
-  The SpacesInBlockCommentsStyle to use for single-line ordinary block
-  comments. Documentation comments such as ``/** ... */`` and ``/*! ... */``
+**SpacesInBlockComments** (``SpacesInBlockCommentsStyle``) :versionbadge:`clang-format 24` :ref:`¶ <SpacesInBlockComments>`
+  The SpacesInBlockCommentsStyle to use for ordinary block comments.
+  Documentation comments such as ``/** ... */`` and ``/*! ... */``
   and parameter comments ending with ``=`` before the closing ``*/`` are
   left unchanged.
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -7403,6 +7403,35 @@ the configuration (without a prefix: ``Auto``).
 
 
 
+.. _SpacesInBlockComments:
+
+**SpacesInBlockComments** (``SpacesInBlockCommentsStyle``) :versionbadge:`clang-format 23` :ref:`¶ <SpacesInBlockComments>`
+  The SpacesInBlockCommentsStyle to use for single-line ordinary block
+  comments. Documentation comments such as ``/** ... */`` and ``/*! ... */``
+  and parameter comments ending with ``=`` before the closing ``*/`` are
+  left unchanged.
+
+  Possible values:
+
+  * ``SIBCS_Never`` (in configuration: ``Never``)
+    Remove spaces after ``/*`` and before ``*/``.
+
+    .. code-block:: c++
+
+       /*comment*/
+
+  * ``SIBCS_Always`` (in configuration: ``Always``)
+    Add spaces after ``/*`` and before ``*/``.
+
+    .. code-block:: c++
+
+       /* comment */
+
+  * ``SIBCS_Leave`` (in configuration: ``Leave``)
+    Leave existing spaces unchanged.
+
+
+
 .. _SpacesInCStyleCastParentheses:
 
 **SpacesInCStyleCastParentheses** (``Boolean``) :versionbadge:`clang-format 3.7` :ref:`¶ <SpacesInCStyleCastParentheses>`

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -490,6 +490,9 @@ features cannot lower the translation-unit ABI level;
 
 ### clang-format
 
+- Add `SpacesInBlockComments` option to control spacing after `/*` and
+  before `*/` in ordinary block comments.
+
 ### libclang
 
 - visit identifier initializers in lambda capture as VarDecl instead of VariableRef. Warning: this changes behaviour.

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5599,6 +5599,30 @@ struct FormatStyle {
   /// \version 3.4
   SpacesInAnglesStyle SpacesInAngles;
 
+  /// Styles for controlling spacing after ``/*`` and before ``*/`` in block
+  /// comments.
+  enum SpacesInCommentsStyle : int8_t {
+    /// Remove spaces after ``/*`` and before ``*/``.
+    /// \code
+    ///    /*comment*/
+    /// \endcode
+    SICS_Never,
+    /// Add spaces after ``/*`` and before ``*/``.
+    /// \code
+    ///    /* comment */
+    /// \endcode
+    SICS_Always,
+    /// Leave existing spaces unchanged.
+    SICS_Leave
+  };
+
+  /// The SpacesInCommentsStyle to use for single-line ordinary block comments.
+  /// Documentation comments such as ``/** ... */`` and ``/*! ... */`` and
+  /// parameter comments ending with ``=`` before the closing ``*/`` are left
+  /// unchanged.
+  /// \version 23
+  SpacesInCommentsStyle SpacesInComments;
+
   /// If ``true``, spaces will be inserted around if/for/switch/while
   /// conditions.
   /// This option is **deprecated**. See ``InConditionalStatements`` of
@@ -6250,6 +6274,7 @@ struct FormatStyle {
            SpaceInEmptyBraces == R.SpaceInEmptyBraces &&
            SpacesBeforeTrailingComments == R.SpacesBeforeTrailingComments &&
            SpacesInAngles == R.SpacesInAngles &&
+           SpacesInComments == R.SpacesInComments &&
            SpacesInContainerLiterals == R.SpacesInContainerLiterals &&
            SpacesInLineCommentPrefix.Minimum ==
                R.SpacesInLineCommentPrefix.Minimum &&

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5616,11 +5616,11 @@ struct FormatStyle {
     SIBCS_Leave
   };
 
-  /// The SpacesInBlockCommentsStyle to use for single-line ordinary block
-  /// comments. Documentation comments such as ``/** ... */`` and ``/*! ... */``
+  /// The SpacesInBlockCommentsStyle to use for ordinary block comments.
+  /// Documentation comments such as ``/** ... */`` and ``/*! ... */``
   /// and parameter comments ending with ``=`` before the closing ``*/`` are
   /// left unchanged.
-  /// \version 23
+  /// \version 24
   SpacesInBlockCommentsStyle SpacesInBlockComments;
 
   /// If ``true``, spaces will be inserted around if/for/switch/while

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5601,27 +5601,27 @@ struct FormatStyle {
 
   /// Styles for controlling spacing after ``/*`` and before ``*/`` in block
   /// comments.
-  enum SpacesInCommentsStyle : int8_t {
+  enum SpacesInBlockCommentsStyle : int8_t {
     /// Remove spaces after ``/*`` and before ``*/``.
     /// \code
     ///    /*comment*/
     /// \endcode
-    SICS_Never,
+    SIBCS_Never,
     /// Add spaces after ``/*`` and before ``*/``.
     /// \code
     ///    /* comment */
     /// \endcode
-    SICS_Always,
+    SIBCS_Always,
     /// Leave existing spaces unchanged.
-    SICS_Leave
+    SIBCS_Leave
   };
 
-  /// The SpacesInCommentsStyle to use for single-line ordinary block comments.
-  /// Documentation comments such as ``/** ... */`` and ``/*! ... */`` and
-  /// parameter comments ending with ``=`` before the closing ``*/`` are left
-  /// unchanged.
+  /// The SpacesInBlockCommentsStyle to use for single-line ordinary block
+  /// comments. Documentation comments such as ``/** ... */`` and ``/*! ... */``
+  /// and parameter comments ending with ``=`` before the closing ``*/`` are
+  /// left unchanged.
   /// \version 23
-  SpacesInCommentsStyle SpacesInComments;
+  SpacesInBlockCommentsStyle SpacesInBlockComments;
 
   /// If ``true``, spaces will be inserted around if/for/switch/while
   /// conditions.
@@ -6274,7 +6274,7 @@ struct FormatStyle {
            SpaceInEmptyBraces == R.SpaceInEmptyBraces &&
            SpacesBeforeTrailingComments == R.SpacesBeforeTrailingComments &&
            SpacesInAngles == R.SpacesInAngles &&
-           SpacesInComments == R.SpacesInComments &&
+           SpacesInBlockComments == R.SpacesInBlockComments &&
            SpacesInContainerLiterals == R.SpacesInContainerLiterals &&
            SpacesInLineCommentPrefix.Minimum ==
                R.SpacesInLineCommentPrefix.Minimum &&

--- a/clang/lib/Format/BreakableToken.cpp
+++ b/clang/lib/Format/BreakableToken.cpp
@@ -779,21 +779,22 @@ void BreakableBlockComment::adaptStartOfLine(
     unsigned LineIndex, WhitespaceManager &Whitespaces) const {
   if (LineIndex == 0) {
     StringRef Text = tokenAt(LineIndex).TokenText;
-    if (Style.SpacesInComments != FormatStyle::SICS_Leave &&
+    if (Style.SpacesInBlockComments != FormatStyle::SIBCS_Leave &&
         Lines.size() == 1 && Text.size() >= 4) {
       const bool IsDocComment =
           Text.starts_with("/**") || Text.starts_with("/*!");
       const bool IsParamComment = Text.drop_back(2).trim(Blanks).ends_with("=");
       if (!IsDocComment && !IsParamComment) {
-        StringRef AfterOpening = Text.drop_front(2);
-        if (!AfterOpening.empty()) {
+        if (StringRef AfterOpening = Text.drop_front(2);
+            !AfterOpening.empty()) {
           const bool HasSpace = isWhitespace(AfterOpening.front());
-          if (Style.SpacesInComments == FormatStyle::SICS_Always && !HasSpace) {
+          if (Style.SpacesInBlockComments == FormatStyle::SIBCS_Always &&
+              !HasSpace) {
             Whitespaces.replaceWhitespaceInToken(
                 tokenAt(LineIndex), /*Offset=*/2, /*ReplaceChars=*/0,
                 /*PreviousPostfix=*/"", /*CurrentPrefix=*/"", InPPDirective,
                 /*Newlines=*/0, /*Spaces=*/1);
-          } else if (Style.SpacesInComments == FormatStyle::SICS_Never &&
+          } else if (Style.SpacesInBlockComments == FormatStyle::SIBCS_Never &&
                      HasSpace) {
             Whitespaces.replaceWhitespaceInToken(
                 tokenAt(LineIndex), /*Offset=*/2, /*ReplaceChars=*/1,
@@ -802,15 +803,16 @@ void BreakableBlockComment::adaptStartOfLine(
           }
         }
 
-        StringRef BeforeClosing = Text.drop_back(2);
-        if (!BeforeClosing.empty()) {
+        if (StringRef BeforeClosing = Text.drop_back(2);
+            !BeforeClosing.empty()) {
           const bool HasSpace = isWhitespace(BeforeClosing.back());
-          if (Style.SpacesInComments == FormatStyle::SICS_Always && !HasSpace) {
+          if (Style.SpacesInBlockComments == FormatStyle::SIBCS_Always &&
+              !HasSpace) {
             Whitespaces.replaceWhitespaceInToken(
                 tokenAt(LineIndex), Text.size() - 2, /*ReplaceChars=*/0,
                 /*PreviousPostfix=*/"", /*CurrentPrefix=*/"", InPPDirective,
                 /*Newlines=*/0, /*Spaces=*/1);
-          } else if (Style.SpacesInComments == FormatStyle::SICS_Never &&
+          } else if (Style.SpacesInBlockComments == FormatStyle::SIBCS_Never &&
                      HasSpace) {
             Whitespaces.replaceWhitespaceInToken(
                 tokenAt(LineIndex), Text.size() - 3, /*ReplaceChars=*/1,

--- a/clang/lib/Format/BreakableToken.cpp
+++ b/clang/lib/Format/BreakableToken.cpp
@@ -778,6 +778,48 @@ void BreakableBlockComment::reflow(unsigned LineIndex,
 void BreakableBlockComment::adaptStartOfLine(
     unsigned LineIndex, WhitespaceManager &Whitespaces) const {
   if (LineIndex == 0) {
+    StringRef Text = tokenAt(LineIndex).TokenText;
+    if (Style.SpacesInComments != FormatStyle::SICS_Leave &&
+        Lines.size() == 1 && Text.size() >= 4) {
+      const bool IsDocComment =
+          Text.starts_with("/**") || Text.starts_with("/*!");
+      const bool IsParamComment = Text.drop_back(2).trim(Blanks).ends_with("=");
+      if (!IsDocComment && !IsParamComment) {
+        StringRef AfterOpening = Text.drop_front(2);
+        if (!AfterOpening.empty()) {
+          const bool HasSpace = isWhitespace(AfterOpening.front());
+          if (Style.SpacesInComments == FormatStyle::SICS_Always && !HasSpace) {
+            Whitespaces.replaceWhitespaceInToken(
+                tokenAt(LineIndex), /*Offset=*/2, /*ReplaceChars=*/0,
+                /*PreviousPostfix=*/"", /*CurrentPrefix=*/"", InPPDirective,
+                /*Newlines=*/0, /*Spaces=*/1);
+          } else if (Style.SpacesInComments == FormatStyle::SICS_Never &&
+                     HasSpace) {
+            Whitespaces.replaceWhitespaceInToken(
+                tokenAt(LineIndex), /*Offset=*/2, /*ReplaceChars=*/1,
+                /*PreviousPostfix=*/"", /*CurrentPrefix=*/"", InPPDirective,
+                /*Newlines=*/0, /*Spaces=*/0);
+          }
+        }
+
+        StringRef BeforeClosing = Text.drop_back(2);
+        if (!BeforeClosing.empty()) {
+          const bool HasSpace = isWhitespace(BeforeClosing.back());
+          if (Style.SpacesInComments == FormatStyle::SICS_Always && !HasSpace) {
+            Whitespaces.replaceWhitespaceInToken(
+                tokenAt(LineIndex), Text.size() - 2, /*ReplaceChars=*/0,
+                /*PreviousPostfix=*/"", /*CurrentPrefix=*/"", InPPDirective,
+                /*Newlines=*/0, /*Spaces=*/1);
+          } else if (Style.SpacesInComments == FormatStyle::SICS_Never &&
+                     HasSpace) {
+            Whitespaces.replaceWhitespaceInToken(
+                tokenAt(LineIndex), Text.size() - 3, /*ReplaceChars=*/1,
+                /*PreviousPostfix=*/"", /*CurrentPrefix=*/"", InPPDirective,
+                /*Newlines=*/0, /*Spaces=*/0);
+          }
+        }
+      }
+    }
     if (DelimitersOnNewline) {
       // Since we're breaking at index 1 below, the break position and the
       // break length are the same.

--- a/clang/lib/Format/BreakableToken.cpp
+++ b/clang/lib/Format/BreakableToken.cpp
@@ -780,7 +780,7 @@ void BreakableBlockComment::adaptStartOfLine(
   if (LineIndex == 0) {
     StringRef Text = tokenAt(LineIndex).TokenText;
     if (Style.SpacesInBlockComments != FormatStyle::SIBCS_Leave &&
-        Lines.size() == 1 && Text.size() >= 4) {
+        Text.size() >= 4) {
       const bool IsDocComment =
           Text.starts_with("/**") || Text.starts_with("/*!");
       const bool IsParamComment = Text.drop_back(2).trim(Blanks).ends_with("=");

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -972,6 +972,14 @@ template <> struct ScalarEnumerationTraits<FormatStyle::SpacesInAnglesStyle> {
   }
 };
 
+template <> struct ScalarEnumerationTraits<FormatStyle::SpacesInCommentsStyle> {
+  static void enumeration(IO &IO, FormatStyle::SpacesInCommentsStyle &Value) {
+    IO.enumCase(Value, "Never", FormatStyle::SICS_Never);
+    IO.enumCase(Value, "Always", FormatStyle::SICS_Always);
+    IO.enumCase(Value, "Leave", FormatStyle::SICS_Leave);
+  }
+};
+
 template <> struct MappingTraits<FormatStyle::SpacesInLineComment> {
   static void mapping(IO &IO, FormatStyle::SpacesInLineComment &Space) {
     // Transform the maximum to signed, to parse "-1" correctly
@@ -1505,6 +1513,7 @@ template <> struct MappingTraits<FormatStyle> {
     IO.mapOptional("SpacesBeforeTrailingComments",
                    Style.SpacesBeforeTrailingComments);
     IO.mapOptional("SpacesInAngles", Style.SpacesInAngles);
+    IO.mapOptional("SpacesInComments", Style.SpacesInComments);
     IO.mapOptional("SpacesInContainerLiterals",
                    Style.SpacesInContainerLiterals);
     IO.mapOptional("SpacesInLineCommentPrefix",
@@ -2029,6 +2038,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.SpaceInEmptyBraces = FormatStyle::SIEB_Never;
   LLVMStyle.SpacesBeforeTrailingComments = 1;
   LLVMStyle.SpacesInAngles = FormatStyle::SIAS_Never;
+  LLVMStyle.SpacesInComments = FormatStyle::SICS_Leave;
   LLVMStyle.SpacesInContainerLiterals = true;
   LLVMStyle.SpacesInLineCommentPrefix = {
       /*Minimum=*/1, /*Maximum=*/std::numeric_limits<unsigned>::max()};

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -972,11 +972,13 @@ template <> struct ScalarEnumerationTraits<FormatStyle::SpacesInAnglesStyle> {
   }
 };
 
-template <> struct ScalarEnumerationTraits<FormatStyle::SpacesInCommentsStyle> {
-  static void enumeration(IO &IO, FormatStyle::SpacesInCommentsStyle &Value) {
-    IO.enumCase(Value, "Never", FormatStyle::SICS_Never);
-    IO.enumCase(Value, "Always", FormatStyle::SICS_Always);
-    IO.enumCase(Value, "Leave", FormatStyle::SICS_Leave);
+template <>
+struct ScalarEnumerationTraits<FormatStyle::SpacesInBlockCommentsStyle> {
+  static void enumeration(IO &IO,
+                          FormatStyle::SpacesInBlockCommentsStyle &Value) {
+    IO.enumCase(Value, "Never", FormatStyle::SIBCS_Never);
+    IO.enumCase(Value, "Always", FormatStyle::SIBCS_Always);
+    IO.enumCase(Value, "Leave", FormatStyle::SIBCS_Leave);
   }
 };
 
@@ -1513,7 +1515,7 @@ template <> struct MappingTraits<FormatStyle> {
     IO.mapOptional("SpacesBeforeTrailingComments",
                    Style.SpacesBeforeTrailingComments);
     IO.mapOptional("SpacesInAngles", Style.SpacesInAngles);
-    IO.mapOptional("SpacesInComments", Style.SpacesInComments);
+    IO.mapOptional("SpacesInBlockComments", Style.SpacesInBlockComments);
     IO.mapOptional("SpacesInContainerLiterals",
                    Style.SpacesInContainerLiterals);
     IO.mapOptional("SpacesInLineCommentPrefix",
@@ -2038,7 +2040,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.SpaceInEmptyBraces = FormatStyle::SIEB_Never;
   LLVMStyle.SpacesBeforeTrailingComments = 1;
   LLVMStyle.SpacesInAngles = FormatStyle::SIAS_Never;
-  LLVMStyle.SpacesInComments = FormatStyle::SICS_Leave;
+  LLVMStyle.SpacesInBlockComments = FormatStyle::SIBCS_Leave;
   LLVMStyle.SpacesInContainerLiterals = true;
   LLVMStyle.SpacesInLineCommentPrefix = {
       /*Minimum=*/1, /*Maximum=*/std::numeric_limits<unsigned>::max()};

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -1253,6 +1253,14 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("SpacesInAngles: false", SpacesInAngles, FormatStyle::SIAS_Never);
   CHECK_PARSE("SpacesInAngles: true", SpacesInAngles, FormatStyle::SIAS_Always);
 
+  Style.SpacesInBlockComments = FormatStyle::SIBCS_Always;
+  CHECK_PARSE("SpacesInBlockComments: Never", SpacesInBlockComments,
+              FormatStyle::SIBCS_Never);
+  CHECK_PARSE("SpacesInBlockComments: Always", SpacesInBlockComments,
+              FormatStyle::SIBCS_Always);
+  CHECK_PARSE("SpacesInBlockComments: Leave", SpacesInBlockComments,
+              FormatStyle::SIBCS_Leave);
+
   CHECK_PARSE("RequiresClausePosition: WithPreceding", RequiresClausePosition,
               FormatStyle::RCPS_WithPreceding);
   CHECK_PARSE("RequiresClausePosition: WithFollowing", RequiresClausePosition,

--- a/clang/unittests/Format/FormatTestComments.cpp
+++ b/clang/unittests/Format/FormatTestComments.cpp
@@ -373,18 +373,18 @@ TEST_F(FormatTestComments, RemovesTrailingWhitespaceOfComments) {
 TEST_F(FormatTestComments, SpacesInBlockComments) {
   FormatStyle Style = getLLVMStyle();
 
-  Style.SpacesInComments = FormatStyle::SICS_Always;
+  Style.SpacesInBlockComments = FormatStyle::SIBCS_Always;
   verifyFormat("/* comment */", "/* comment*/", Style);
   verifyFormat("/* comment */", "/*comment */", Style);
   verifyFormat("/* comment */", "/*comment*/", Style);
 
-  Style.SpacesInComments = FormatStyle::SICS_Leave;
+  Style.SpacesInBlockComments = FormatStyle::SIBCS_Leave;
   verifyFormat("/*comment*/", Style);
   verifyFormat("/* comment*/", Style);
   verifyFormat("/*comment */", Style);
   verifyFormat("/* comment */", Style);
 
-  Style.SpacesInComments = FormatStyle::SICS_Never;
+  Style.SpacesInBlockComments = FormatStyle::SIBCS_Never;
   verifyFormat("/*comment*/", "/* comment */", Style);
   verifyFormat("/*comment*/", "/* comment*/", Style);
   verifyFormat("/*comment*/", "/*comment */", Style);
@@ -393,12 +393,12 @@ TEST_F(FormatTestComments, SpacesInBlockComments) {
 TEST_F(FormatTestComments, SpacesInBlockCommentsIgnoreParamAndDocComments) {
   FormatStyle Style = getLLVMStyle();
 
-  Style.SpacesInComments = FormatStyle::SICS_Always;
+  Style.SpacesInBlockComments = FormatStyle::SIBCS_Always;
   verifyFormat("foo(/*Arg=*/value);", Style);
   verifyFormat("/**doc*/", Style);
   verifyFormat("/*!doc*/", Style);
 
-  Style.SpacesInComments = FormatStyle::SICS_Never;
+  Style.SpacesInBlockComments = FormatStyle::SIBCS_Never;
   verifyFormat("foo(/*Arg=*/value);", Style);
   verifyFormat("/** doc */", Style);
   verifyFormat("/*! doc */", Style);

--- a/clang/unittests/Format/FormatTestComments.cpp
+++ b/clang/unittests/Format/FormatTestComments.cpp
@@ -370,6 +370,40 @@ TEST_F(FormatTestComments, RemovesTrailingWhitespaceOfComments) {
   verifyFormat("// comment    \\\n", "// comment    \\\n  \t \v   \f   ");
 }
 
+TEST_F(FormatTestComments, SpacesInBlockComments) {
+  FormatStyle Style = getLLVMStyle();
+
+  Style.SpacesInComments = FormatStyle::SICS_Always;
+  verifyFormat("/* comment */", "/* comment*/", Style);
+  verifyFormat("/* comment */", "/*comment */", Style);
+  verifyFormat("/* comment */", "/*comment*/", Style);
+
+  Style.SpacesInComments = FormatStyle::SICS_Leave;
+  verifyFormat("/*comment*/", Style);
+  verifyFormat("/* comment*/", Style);
+  verifyFormat("/*comment */", Style);
+  verifyFormat("/* comment */", Style);
+
+  Style.SpacesInComments = FormatStyle::SICS_Never;
+  verifyFormat("/*comment*/", "/* comment */", Style);
+  verifyFormat("/*comment*/", "/* comment*/", Style);
+  verifyFormat("/*comment*/", "/*comment */", Style);
+}
+
+TEST_F(FormatTestComments, SpacesInBlockCommentsIgnoreParamAndDocComments) {
+  FormatStyle Style = getLLVMStyle();
+
+  Style.SpacesInComments = FormatStyle::SICS_Always;
+  verifyFormat("foo(/*Arg=*/value);", Style);
+  verifyFormat("/**doc*/", Style);
+  verifyFormat("/*!doc*/", Style);
+
+  Style.SpacesInComments = FormatStyle::SICS_Never;
+  verifyFormat("foo(/*Arg=*/value);", Style);
+  verifyFormat("/** doc */", Style);
+  verifyFormat("/*! doc */", Style);
+}
+
 TEST_F(FormatTestComments, UnderstandsBlockComments) {
   verifyFormat("f(/*noSpaceAfterParameterNamingComment=*/true);");
   verifyFormat("void f() { g(/*aaa=*/x, /*bbb=*/!y, /*c=*/::c); }");

--- a/clang/unittests/Format/FormatTestComments.cpp
+++ b/clang/unittests/Format/FormatTestComments.cpp
@@ -390,6 +390,25 @@ TEST_F(FormatTestComments, SpacesInBlockComments) {
   verifyFormat("/*comment*/", "/*comment */", Style);
 }
 
+TEST_F(FormatTestComments, SpacesInMultilineBlockComments) {
+  FormatStyle Style = getLLVMStyleWithColumns(20);
+  Style.ReflowComments = FormatStyle::RCS_IndentOnly;
+
+  Style.SpacesInBlockComments = FormatStyle::SIBCS_Always;
+  verifyFormat("/* aaaaaaaaa aaaaaaaaaa aaaaaaaaaa\n"
+               " * aaaaaaaaa */",
+               "/*aaaaaaaaa aaaaaaaaaa aaaaaaaaaa\n"
+               " * aaaaaaaaa*/",
+               Style);
+
+  Style.SpacesInBlockComments = FormatStyle::SIBCS_Never;
+  verifyFormat("/*aaaaaaaaa aaaaaaaaaa aaaaaaaaaa\n"
+               " * aaaaaaaaa*/",
+               "/* aaaaaaaaa aaaaaaaaaa aaaaaaaaaa\n"
+               " * aaaaaaaaa */",
+               Style);
+}
+
 TEST_F(FormatTestComments, SpacesInBlockCommentsIgnoreParamAndDocComments) {
   FormatStyle Style = getLLVMStyle();
 


### PR DESCRIPTION
Adds a new `SpacesInBlockComments` clang-format option to control spacing after `/*` and before `*/` in ordinary block comments.

Supported values:

* Always: formats `/*comment*/` as `/* comment */`
* Never: formats `/* comment */` as `/*comment*/`
* Leave: preserves existing spacing

Documentation comments such as `/** ... */` and `/*! ... */`, and parameter comments such as `/*Arg=*/`, are left unchanged.

Tests added for all option values, multiline block comments, and excluded parameter/doc comments.

Addresses #160682