### PR TITLE
[Xtensa] Call isUInt<8> in range-check asserts

### DIFF
--- a/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaInstPrinter.cpp
+++ b/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaInstPrinter.cpp
@@ -314,7 +314,7 @@ void XtensaInstPrinter::printOffset8m8_AsmOperand(const MCInst *MI, int OpNum,
                                                   raw_ostream &O) {
   if (MI->getOperand(OpNum).isImm()) {
     int64_t Value = MI->getOperand(OpNum).getImm();
-    assert(isUInt<8> && "Invalid argument, value must be in range [0,255]");
+    assert(isUInt<8>(Value) && "Invalid argument, value must be in range [0,255]");
     O << Value;
   } else
     printOperand(MI, OpNum, O);

--- a/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaInstPrinter.cpp
+++ b/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaInstPrinter.cpp
@@ -314,7 +314,8 @@ void XtensaInstPrinter::printOffset8m8_AsmOperand(const MCInst *MI, int OpNum,
                                                   raw_ostream &O) {
   if (MI->getOperand(OpNum).isImm()) {
     int64_t Value = MI->getOperand(OpNum).getImm();
-    assert(isUInt<8>(Value) && "Invalid argument, value must be in range [0,255]");
+    assert(isUInt<8>(Value) &&
+           "Invalid argument, value must be in range [0,255]");
     O << Value;
   } else
     printOperand(MI, OpNum, O);

--- a/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaMCCodeEmitter.cpp
+++ b/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaMCCodeEmitter.cpp
@@ -618,7 +618,7 @@ XtensaMCCodeEmitter::getSelect_256OpValue(const MCInst &MI, unsigned OpNo,
   const MCOperand &MO = MI.getOperand(OpNo);
   uint8_t Res = static_cast<uint8_t>(MO.getImm());
 
-  assert(isUInt<8> && "Unexpected operand value!");
+  assert(isUInt<8>(Res) && "Unexpected operand value!");
 
   return Res;
 }


### PR DESCRIPTION
`printOffset8m8_AsmOperand` and `getSelect_256OpValue` assert on `isUInt<8>` without calling it, so the expression takes the function's address and the range check never runs. This also trips `-Werror,-Wpointer-bool-conversion` in builds with assertions enabled. Pass the operand value so the bound is actually checked.