### PR TITLE
[SelectionDAG] Fix isKnownNeverNaN OR-logic for FMINNUM/FMAXNUM with SNaN

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -6423,10 +6423,20 @@ bool SelectionDAG::isKnownNeverNaN(SDValue Op, const APInt &DemandedElts,
   case ISD::FMAXNUM:
   case ISD::FMINIMUMNUM:
   case ISD::FMAXIMUMNUM: {
-    // Only one needs to be known not-nan, since it will be returned if the
-    // other ends up being one.
-    return isKnownNeverNaN(Op.getOperand(0), DemandedElts, SNaN, Depth + 1) ||
-           isKnownNeverNaN(Op.getOperand(1), DemandedElts, SNaN, Depth + 1);
+    // The result is a NaN only if both operands are NaN, so it is never NaN
+    // (and hence never a signaling NaN) if either operand is known to never be
+    // NaN.
+    if (isKnownNeverNaN(Op.getOperand(0), DemandedElts, false, Depth + 1) ||
+        isKnownNeverNaN(Op.getOperand(1), DemandedElts, false, Depth + 1))
+      return true;
+    // Otherwise, for the signaling-NaN query, these do not quiet a signaling
+    // NaN: an input signaling NaN may be returned unchanged, so the result is
+    // never a signaling NaN only if both operands are known to never be one.
+    if (SNaN &&
+        isKnownNeverNaN(Op.getOperand(0), DemandedElts, true, Depth + 1) &&
+        isKnownNeverNaN(Op.getOperand(1), DemandedElts, true, Depth + 1))
+      return true;
+    return false;
   }
   case ISD::FMINNUM_IEEE:
   case ISD::FMAXNUM_IEEE: {

--- a/llvm/test/CodeGen/AArch64/fminmaxnum-snan-isknownnevernan.ll
+++ b/llvm/test/CodeGen/AArch64/fminmaxnum-snan-isknownnevernan.ll
@@ -1,0 +1,44 @@
+; RUN: llc -mtriple=aarch64-unknown-linux-gnu < %s | FileCheck %s
+
+;; SelectionDAG::isKnownNeverNaN answers "is this value never a signaling NaN?"
+;; for FMINNUM/FMAXNUM/FMINIMUMNUM/FMAXIMUMNUM. These do not quiet a signaling
+;; NaN: when an operand is a signaling NaN it may be returned unchanged, so the
+;; result is known-never-signaling only if *both* operands are. The old code
+;; used OR (it sufficed for one operand to be known never-NaN), which is correct
+;; for the plain "never any NaN" query but unsound for the signaling query.
+;;
+;; This is observable through the bf16 narrowing in FP_TO_BF16 expansion, which
+;; inserts an FCANONICALIZE (quieting) step unless the source is known never to
+;; be a signaling NaN. On AArch64 that quieting lowers to setting the f32 quiet
+;; bit (orr #0x400000) under an unordered check (fcmp + csel vs).
+
+;; One operand is canonicalized (known never-sNaN), the other is unknown. The
+;; minnum result may be the unknown operand, so a signaling NaN can survive and
+;; the narrowing must quiet it. With the buggy OR-logic the source was wrongly
+;; proven never-sNaN and the quieting was dropped.
+; CHECK-LABEL: mixed:
+; CHECK:       fminnm s0, s0, s1
+; CHECK:       orr {{w[0-9]+}}, {{w[0-9]+}}, #0x400000
+; CHECK:       csel {{w[0-9]+}}, {{w[0-9]+}}, {{w[0-9]+}}, vs
+define bfloat @mixed(float %a, float %b) {
+  %na = call float @llvm.canonicalize.f32(float %a)
+  %m  = call float @llvm.minnum.f32(float %na, float %b)
+  %r  = fptrunc float %m to bfloat
+  ret bfloat %r
+}
+
+;; Both operands are canonicalized, so the minnum result really is never a
+;; signaling NaN and the narrowing may skip quieting. This guards against the
+;; fix becoming over-broad (the AND must still fold to true here).
+; CHECK-LABEL: both:
+; CHECK-NOT:   #0x400000
+define bfloat @both(float %a, float %b) {
+  %na = call float @llvm.canonicalize.f32(float %a)
+  %nb = call float @llvm.canonicalize.f32(float %b)
+  %m  = call float @llvm.minnum.f32(float %na, float %nb)
+  %r  = fptrunc float %m to bfloat
+  ret bfloat %r
+}
+
+declare float @llvm.canonicalize.f32(float)
+declare float @llvm.minnum.f32(float, float)


### PR DESCRIPTION
`isKnownNeverNaN` for `FMINNUM`/`FMAXNUM`/`FMINIMUMNUM`/`FMAXIMUMNUM` uses the same OR-logic for both the "never any NaN" query (`SNaN=false`) and the "never signaling NaN" query (`SNaN=true`): it returns true if *either* operand is proven safe.

This is correct for the any-NaN question—if at least one operand is a real number, the result cannot be NaN. But it is unsound for the signaling-NaN question: when `op0` is known never-SNaN (but may be QNaN) and `op1` is an unproven SNaN, both operands are NaN and LangRef permits the result to be `op1`'s signaling NaN passed through unchanged (the non-deterministic sNaN rule does not guarantee quieting).

The fix splits the logic: keep OR for the any-NaN case, switch to AND for the signaling-NaN case, so we only claim the result is never-SNaN when *neither* operand can be one.

Found via @jlebar's X86 LLVM bug-hunt / FuzzX effort:
https://github.com/SemiAnalysisAI/FuzzX/tree/master/x86/bugs/034-isKnownNeverNaN-fminnum-snan-or-incorrect

cc @jlebar 