### PR TITLE
[mlir][IR] Fix typo in code example of DenseTypedElementsAttr

### DIFF
--- a/mlir/include/mlir/IR/BuiltinAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinAttributes.td
@@ -271,7 +271,7 @@ def Builtin_DenseTypedElementsAttr : Builtin_Attr<
     dense<tensor<2xi32> : 10 : i32>
 
     // Type-first syntax: A tensor of 2 float32 elements.
-    dense<tensor<2xf32> : [10.0, 11.0]>
+    dense<tensor<2xf32> : [10.0 : f32, 11.0 : f32]>
     ```
 
     Note: The literal-first syntax is supported only for complex, float, index,


### PR DESCRIPTION
There was a typo in the type-first syntax code example.
