### PR TITLE
[PSI] Drop AllowSynthetic parameter to getProfileCount

### DIFF
--- a/llvm/include/llvm/Analysis/ProfileSummaryInfo.h
+++ b/llvm/include/llvm/Analysis/ProfileSummaryInfo.h
@@ -102,8 +102,7 @@ public:
 
   /// Returns the profile count for \p CallInst.
   LLVM_ABI std::optional<uint64_t>
-  getProfileCount(const CallBase &CallInst, BlockFrequencyInfo *BFI,
-                  bool AllowSynthetic = false) const;
+  getProfileCount(const CallBase &CallInst, BlockFrequencyInfo *BFI) const;
   /// Returns true if module \c M has partial-profile sample profile.
   LLVM_ABI bool hasPartialSampleProfile() const;
   /// Returns true if the working set size of the code is considered huge.

--- a/llvm/lib/Analysis/ProfileSummaryInfo.cpp
+++ b/llvm/lib/Analysis/ProfileSummaryInfo.cpp
@@ -75,8 +75,9 @@ void ProfileSummaryInfo::refresh(std::unique_ptr<ProfileSummary> &&Other) {
   computeThresholds();
 }
 
-std::optional<uint64_t> ProfileSummaryInfo::getProfileCount(
-    const CallBase &Call, BlockFrequencyInfo *BFI, bool AllowSynthetic) const {
+std::optional<uint64_t>
+ProfileSummaryInfo::getProfileCount(const CallBase &Call,
+                                    BlockFrequencyInfo *BFI) const {
   assert((isa<CallInst>(Call) || isa<InvokeInst>(Call)) &&
          "We can only get profile count for call/invoke instruction.");
   if (hasSampleProfile()) {
@@ -90,7 +91,7 @@ std::optional<uint64_t> ProfileSummaryInfo::getProfileCount(
     return std::nullopt;
   }
   if (BFI)
-    return BFI->getBlockProfileCount(Call.getParent(), AllowSynthetic);
+    return BFI->getBlockProfileCount(Call.getParent());
   return std::nullopt;
 }
 


### PR DESCRIPTION
This was not set anywhere and synthetic profile counts are not
emitted/used anywhere, so remove it.
