### PR TITLE
[compiler-rt][ARM] Fix underflow handling in new divdf3.S

### DIFF
--- a/compiler-rt/lib/builtins/arm/divdf3.S
+++ b/compiler-rt/lib/builtins/arm/divdf3.S
@@ -497,11 +497,11 @@ LOCAL_LABEL(ddiv_underflow):
   // was rounded up), or negative if the quotient was rounded down. But we must
   // also distinguish the third case of the residual being exactly zero.
   add     xh, xh, #0x60000000     // apply IEEE 754 exponent bias for __dunder
-  orrs    r12, r6, r8             // set r12=0 and Z=1 if quotient was exact
-  movne   r12, #1                 // otherwise, set r12 = +1
-  orrne   r12, r12, r6, asr #31   // and change to -1 if residual is negative
+  orrs    r2, r6, r8              // set r2=0 and Z=1 if quotient was exact
+  mvnne   r2, r6, asr #31         // otherwise, r2 = {-1,0} for {+,-} residual
+  orrne   r2, r2, #1              // and then turn that into {-1,+1}
   pop     {r4,r5,r6,r7,r8,lr}     // pop all locally saved registers
-  b       SYMBOL_NAME(__compiler_rt_dunder)                // and tailcall __dunder to finish
+  b       SYMBOL_NAME(__compiler_rt_dunder) // and tailcall dunder to finish
 
 LOCAL_LABEL(ddiv_zerodenorm):
   // We come here if either input had exponent 0, so there's at least one zero

--- a/compiler-rt/test/builtins/Unit/divdf3new_test.c
+++ b/compiler-rt/test/builtins/Unit/divdf3new_test.c
@@ -108,6 +108,24 @@ int main(void) {
   status |=
       test__divdf3(0x0000000000000009, 0xc022000000000000, 0x8000000000000001);
   status |=
+      test__divdf3(0x0008000000000092, 0x4010000000000000, 0x0002000000000024);
+  status |=
+      test__divdf3(0x0010000000000008, 0x4030000040000000, 0x0000fffffc000010);
+  status |=
+      test__divdf3(0x0010000000000008, 0x4030000080000000, 0x0000fffff8000040);
+  status |=
+      test__divdf3(0x0010000000000018, 0x4030000040000000, 0x0000fffffc000011);
+  status |=
+      test__divdf3(0x0010000000000018, 0x4030000080000000, 0x0000fffff8000041);
+  status |=
+      test__divdf3(0x0010000001000008, 0x401fffff80000000, 0x0002000008200022);
+  status |=
+      test__divdf3(0x0010000001000010, 0x401fffff80000000, 0x0002000008200023);
+  status |=
+      test__divdf3(0x001000000f00000a, 0x401fffff40000000, 0x000200000de00055);
+  status |=
+      test__divdf3(0x001000000f000012, 0x401fffff40000000, 0x000200000de00056);
+  status |=
       test__divdf3(0x000ffffffffffff7, 0x3feffffffffffffe, 0x000ffffffffffff8);
   status |=
       test__divdf3(0x000ffffffffffffe, 0x3feffffffffffffe, 0x000fffffffffffff);


### PR DESCRIPTION
The code which calculates the 'errsign' parameter to pass to `__compiler_rt_dunder` was wrong in two ways. It calculated the value with the wrong sign, and also in the wrong register, r12 rather than r2! In this code's original context, both of those things made sense (the 'dunder' function had a nonstandard ABI). Somehow none of the existing test cases detected the problem.

We found this bug in a test case downstream that only failed big-endian (because that changes which half of the denominator mantissa is left in r2 to be accidentally used as errsign). However, the new test cases here are designed to detect the failure in both endiannesses.