### PR TITLE
[Polly] Fix invariant load hoisting when ancestor SAI is written in scop

### DIFF
--- a/polly/include/polly/ScopBuilder.h
+++ b/polly/include/polly/ScopBuilder.h
@@ -674,7 +674,9 @@ class ScopBuilder final {
   }
 
   /// Check if the base ptr of @p MA is in the SCoP but not hoistable.
-  bool hasNonHoistableBasePtrInScop(MemoryAccess *MA, isl::union_map Writes);
+  bool hasNonHoistableBasePtrInScop(
+      MemoryAccess *MA, isl::union_map Writes,
+      const llvm::DenseSet<const ScopArrayInfo *> &WrittenSAIs);
 
   /// Return the context under which the access cannot be hoisted.
   ///
@@ -683,7 +685,9 @@ class ScopBuilder final {
   ///
   /// @return Return the context under which the access cannot be hoisted or a
   ///         nullptr if it cannot be hoisted at all.
-  isl::set getNonHoistableCtx(MemoryAccess *Access, isl::union_map Writes);
+  isl::set
+  getNonHoistableCtx(MemoryAccess *Access, isl::union_map Writes,
+                     const llvm::DenseSet<const ScopArrayInfo *> &WrittenSAIs);
 
   /// Build the access relation of all memory accesses of @p Stmt.
   void buildAccessRelations(ScopStmt &Stmt);

--- a/polly/lib/Analysis/ScopBuilder.cpp
+++ b/polly/lib/Analysis/ScopBuilder.cpp
@@ -2843,11 +2843,20 @@ void ScopBuilder::hoistInvariantLoads() {
     return;
 
   isl::union_map Writes = scop->getWrites();
+
+  // Collect the set of all ScopArrayInfo objects that have any write access
+  // anywhere in the scop.
+  DenseSet<const ScopArrayInfo *> WrittenSAIs;
+  for (const ScopStmt &Stmt : *scop)
+    for (const MemoryAccess *MA : Stmt)
+      if (MA->isWrite())
+        WrittenSAIs.insert(MA->getScopArrayInfo());
+
   for (ScopStmt &Stmt : *scop) {
     InvariantAccessesTy InvariantAccesses;
 
     for (MemoryAccess *Access : Stmt) {
-      isl::set NHCtx = getNonHoistableCtx(Access, Writes);
+      isl::set NHCtx = getNonHoistableCtx(Access, Writes, WrittenSAIs);
       if (!NHCtx.is_null())
         InvariantAccesses.push_back({Access, NHCtx});
     }
@@ -2885,10 +2894,11 @@ static bool isAccessRangeTooComplex(isl::set AccessRange) {
   return false;
 }
 
-bool ScopBuilder::hasNonHoistableBasePtrInScop(MemoryAccess *MA,
-                                               isl::union_map Writes) {
+bool ScopBuilder::hasNonHoistableBasePtrInScop(
+    MemoryAccess *MA, isl::union_map Writes,
+    const DenseSet<const ScopArrayInfo *> &WrittenSAIs) {
   if (auto *BasePtrMA = scop->lookupBasePtrAccess(MA)) {
-    return getNonHoistableCtx(BasePtrMA, Writes).is_null();
+    return getNonHoistableCtx(BasePtrMA, Writes, WrittenSAIs).is_null();
   }
 
   Value *BaseAddr = MA->getOriginalBaseAddr();
@@ -2940,8 +2950,9 @@ void ScopBuilder::addUserContext() {
   scop->setContext(newContext);
 }
 
-isl::set ScopBuilder::getNonHoistableCtx(MemoryAccess *Access,
-                                         isl::union_map Writes) {
+isl::set ScopBuilder::getNonHoistableCtx(
+    MemoryAccess *Access, isl::union_map Writes,
+    const DenseSet<const ScopArrayInfo *> &WrittenSAIs) {
   // TODO: Loads that are not loop carried, hence are in a statement with
   //       zero iterators, are by construction invariant, though we
   //       currently "hoist" them anyway. This is necessary because we allow
@@ -2965,8 +2976,19 @@ isl::set ScopBuilder::getNonHoistableCtx(MemoryAccess *Access,
   // no base pointer origin we check that the base pointer is defined
   // outside the region.
   auto *LI = cast<LoadInst>(Access->getAccessInstruction());
-  if (hasNonHoistableBasePtrInScop(Access, Writes))
+  if (hasNonHoistableBasePtrInScop(Access, Writes, WrittenSAIs))
     return {};
+
+  // Walk the full BasePtrOriginSAI chain. If any ancestor's storage location
+  // is written anywhere in the scop, hoisting the derived load is not safe
+  // since a mid-region write to the ancestor SAI can change the pointer value
+  // that was hoisted to region entry, leaving the derived address stale.
+  for (const ScopArrayInfo *BaseSAI =
+           Access->getScopArrayInfo()->getBasePtrOriginSAI();
+       BaseSAI != nullptr; BaseSAI = BaseSAI->getBasePtrOriginSAI()) {
+    if (WrittenSAIs.count(BaseSAI))
+      return {};
+  }
 
   isl::map AccessRelation = Access->getAccessRelation();
   assert(!AccessRelation.is_empty());

--- a/polly/test/CodeGen/invariant_load_base_pointer_overwritten.ll
+++ b/polly/test/CodeGen/invariant_load_base_pointer_overwritten.ll
@@ -1,0 +1,32 @@
+; RUN: opt %loadNPMPolly '-passes=polly<no-default-opts>' -polly-invariant-load-hoisting=true -polly-process-unprofitable -S < %s | FileCheck %s
+;
+; Verify that a derived load (MemRef1, BasePtrOriginSAI = MemRef0) is not hoisted
+; when the ancestor MemRef0 is written inside the scop.  The ptr load (MemRef0)
+; is still hoisted correctly. The i32 load (MemRef1) must not appear in the
+; speculative preload path.
+;
+; CHECK-LABEL: polly.preload.exec:
+; CHECK-NEXT:    %.load = load ptr
+; CHECK-NOT:     load i32
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnu"
+
+define fastcc void @foo(i32 %arg) {
+bb:
+  br label %bb1
+
+bb1:
+  %getelementptr = getelementptr i8, ptr null, i64 32
+  %load          = load ptr, ptr %getelementptr, align 8
+  %load2         = load i32, ptr %load,          align 4
+  %icmp          = icmp ugt i32 %arg, 0
+  br i1 %icmp, label %bb3, label %bb4
+
+bb3:
+  store ptr null, ptr null, align 8
+  br label %bb4
+
+bb4:
+  ret void
+}


### PR DESCRIPTION
getNonHoistableCtx checks whether a load is safe to hoist by intersecting the scop's write map with the load's access range. It does not check whether a write anywhere in the scop is to an ancestor in the load's BasePtrOriginSAI chain. In such cases the base pointer value that was hoisted to region entry may be stale after the write making the derived load's address invalid.

This chain introduces a WrittenSAIs set built in hoistInvariantLoads over all statement-level write accesses and in getNonHoistableCtx, walks through the BasePtrOriginSAI chain. It blocks the hoisting if any ancestor SAI appears in WrittenSAIs.

Fixes #204279