### PR TITLE
[ISel] Improve `clmul` fallback implementation

### DIFF
--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -3100,12 +3100,22 @@ public:
       InstructionCost MulCost =
           thisT()->getArithmeticInstrCost(Instruction::Mul, RetTy, CostKind);
 
-      // When the multiplication with holes approach is used, that emits 16
-      // MULs, 8 + 4 ANDs, 12 XORs and 3 ORs.
-      if (BW >= 32 && BW <= 64 &&
-          TLI->isOperationLegalOrCustom(ISD::MUL,
-                                        TLI->getValueType(DL, RetTy))) {
-        return 16 * MulCost + 12 * AndCost + 12 * XorCost + 3 * OrCost;
+      // When the multiplication with holes approach is used, it splits the
+      // operands into S phases (the smallest stride with ceil(BW/S) <= 2^S) and
+      // emits S*S MULs, 3*S ANDs, S*(S-1) XORs and S-1 ORs.
+      //
+      // * BW <= 8 uses S = 2
+      // * BW <= 24 uses S = 3
+      // * BW <= 64 uses S = 4
+      // * BW <= 160 uses S = 5
+      // * BW <= 384 uses S = 6
+      unsigned S = 1;
+      while (S < 32 && divideCeil(BW, S) > (1u << S))
+        ++S;
+      if (S * S < BW && TLI->isOperationLegalOrCustom(
+                            ISD::MUL, TLI->getValueType(DL, RetTy))) {
+        return S * S * MulCost + 3 * S * AndCost + S * (S - 1) * XorCost +
+               (S - 1) * OrCost;
       }
 
       InstructionCost PerBitCostMul = AndCost + MulCost + XorCost;

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8903,37 +8903,94 @@ SDValue TargetLowering::expandCLMUL(SDNode *Node, SelectionDAG &DAG) const {
     // do occur, they wind up in a "hole" and are subsequently masked out of the
     // result.
     //
-    // A hole of 3 bits is optimal for 32-bit and 64-bit inputs. 128-bit
-    // integers need a larger hole, and for smaller integers the fallback below
-    // is more efficient.
+    // https://www.bearssl.org/constanttime.html#ghash-for-gcm describes this
+    // approach.
+
+    // Stride S handles operands up to S·2^S bits using S² multiplies.
     //
-    // Based on bmul64 in bearssl and bmul in the rust polyval crate.
-    if (BW >= 32 && BW <= 64 &&
+    // * BW <= 8 uses S = 2  (holes of 1 bit)
+    // * BW <= 24 uses S = 3 (holes of 2 bits)
+    // * BW <= 64 uses S = 4 (holes of 3 bits)
+    // * BW <= 160 uses S = 5 (holes of 4 bits)
+    // * BW <= 384 uses S = 6 (holes of 5 bits)
+    //
+    // We distribute the BW bits over S phases:
+    //
+    //   phase 0 keeps bits: 0, S, 2S, ...
+    //   phase 1 keeps bits: 1, S + 1, 2S + 1, ...
+    //   ...
+    //
+    // Each phase has up to n = ceil(BW / S) bits set, and the holes are S-1
+    // bits wide.
+    //
+    // Take BW = 4, S = 2, n = 2. The worst case is a fully populated phase (all
+    // non-hole bits are set to 1) multiplied by itself, 0b0101 * 0b0101. Each
+    // set bit of one operand shifts a copy of the other, and we add the copies:
+    //
+    //              col: 4 3 2 1 0
+    //     0b0101 << 0:  0 0 1 0 1
+    //     0b0101 << 2:  1 0 1 0 0
+    //            ----------------- +
+    //     count:        1 0 2 0 1
+    //
+    // Counting the number of one-bits in each column gives a triangle: the
+    // counts climb 1, 2, ..., n and back down (here 1, 2, 1 across the data
+    // columns). So a column holds at most n one-bits, and that maximum n is
+    // reached in only one column: the peak. Every other column holds at most n
+    // - 1 one-bits.
+    //
+    // A stack of one-bits in a column turns into carries: column 2 above really
+    // stores the value 1 + 1 = 2 = n. A column spans S bits, its kept bit
+    // plus S-1 hole bits, and the count is written from the kept bit upward,
+    // so any count <= 2^S - 1 stays within the column and never interferes with
+    // the next data bit S positions up. Every non-peak column holds at most n -
+    // 1, so they all fit as soon as n - 1 <= 2^S - 1.
+    //
+    // That leaves only the peak column. Because both operands set all data
+    // bits, the triangle peaks at the top of the word at the highest data bit
+    // still inside BW. Here the count reaches exactly n = 2^S and overflows.
+    // But its carry lands at bit n*S >= BW, off the top, where it (and the
+    // whole descending half of the triangle) is truncated.
+    //
+    // Hence the holes suffice exactly when n = ceil(BW / S) <= 2^S, i.e. BW <=
+    // S*2^S.
+    //
+    // Here we find the smallest S that satisfies this inequality.
+    unsigned S = 1;
+    while (S < 32 && divideCeil(BW, S) > (1u << S))
+      ++S;
+
+    // Continue to use the naive fallback below if it seems cheaper. We compare
+    // the number of multiplications here (S * S) versus the number of
+    // iterations there (BW). The naive fallback is still used for i1, i3, i4
+    // and i9, and when multiplication isn't available.
+    if (S * S < BW &&
         isOperationLegalOrCustom(ISD::MUL, getTypeToTransformTo(Ctx, VT))) {
 
-      // Set every fourth bit of each nibble, equivalent to 0b00010001...0001.
-      APInt MaskVal = APInt::getSplat(BW, APInt(4, 0b0001));
+      // Set a bit every S positions, e.g. for S = 4 this is equivalent to
+      // 0b...00010001...0001.
+      APInt MaskVal = APInt::getSplat(BW, APInt(S, 1));
 
-      // Create versions of X and Y that keep only the I-th bit of
-      // each nibble.
-      SDValue M[4], Xp[4], Yp[4];
-      for (unsigned I = 0; I < 4; ++I) {
+      // Create versions of X and Y that keep only the I-th bit of each S-bit
+      // slice.
+      SmallVector<SDValue, 4> M(S), Xp(S), Yp(S);
+      for (unsigned I = 0; I < S; ++I) {
         M[I] = DAG.getConstant(MaskVal.shl(I), DL, VT);
         Xp[I] = DAG.getNode(ISD::AND, DL, VT, X, M[I]);
         Yp[I] = DAG.getNode(ISD::AND, DL, VT, Y, M[I]);
       }
 
-      // Codegens these expressions (16 multiplications):
+      // Codegens these expressions (S*S multiplications), e.g. for S=4:
       //
       // z0 = (x0 * y0) ^ (x1 * y3) ^ (x2 * y2) ^ (x3 * y1);
       // z1 = (x0 * y1) ^ (x1 * y0) ^ (x2 * y3) ^ (x3 * y2);
       // z2 = (x0 * y2) ^ (x1 * y1) ^ (x2 * y0) ^ (x3 * y3);
       // z3 = (x0 * y3) ^ (x1 * y2) ^ (x2 * y1) ^ (x3 * y0);
       SDValue Res = DAG.getConstant(0, DL, VT);
-      for (unsigned I = 0; I < 4; ++I) {
+      for (unsigned I = 0; I < S; ++I) {
         SDValue Zi = DAG.getConstant(0, DL, VT);
-        for (unsigned J = 0; J < 4; ++J) {
-          unsigned K = (I + 4 - J) % 4;
+        for (unsigned J = 0; J < S; ++J) {
+          unsigned K = (I + S - J) % S;
           SDValue P = DAG.getNode(ISD::MUL, DL, VT, Xp[J], Yp[K]);
           Zi = DAG.getNode(ISD::XOR, DL, VT, Zi, P);
         }

--- a/llvm/test/Analysis/CostModel/AArch64/clmul-fixed.ll
+++ b/llvm/test/Analysis/CostModel/AArch64/clmul-fixed.ll
@@ -10,8 +10,8 @@ define void @clmul_fixed() {
 ; NOAES-NEXT:  Cost Model: Found an estimated cost of 43 for instruction: %c1 = call <1 x i64> @llvm.clmul.v1i64(<1 x i64> poison, <1 x i64> poison)
 ; NOAES-NEXT:  Cost Model: Found an estimated cost of 43 for instruction: %c32 = call <4 x i32> @llvm.clmul.v4i32(<4 x i32> poison, <4 x i32> poison)
 ; NOAES-NEXT:  Cost Model: Found an estimated cost of 43 for instruction: %c2 = call <2 x i32> @llvm.clmul.v2i32(<2 x i32> poison, <2 x i32> poison)
-; NOAES-NEXT:  Cost Model: Found an estimated cost of 48 for instruction: %c16 = call <4 x i16> @llvm.clmul.v4i16(<4 x i16> poison, <4 x i16> poison)
-; NOAES-NEXT:  Cost Model: Found an estimated cost of 48 for instruction: %c16x8 = call <8 x i16> @llvm.clmul.v8i16(<8 x i16> poison, <8 x i16> poison)
+; NOAES-NEXT:  Cost Model: Found an estimated cost of 26 for instruction: %c16 = call <4 x i16> @llvm.clmul.v4i16(<4 x i16> poison, <4 x i16> poison)
+; NOAES-NEXT:  Cost Model: Found an estimated cost of 26 for instruction: %c16x8 = call <8 x i16> @llvm.clmul.v8i16(<8 x i16> poison, <8 x i16> poison)
 ; NOAES-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret void
 ;
 ; AES-LABEL: 'clmul_fixed'
@@ -21,8 +21,8 @@ define void @clmul_fixed() {
 ; AES-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %c1 = call <1 x i64> @llvm.clmul.v1i64(<1 x i64> poison, <1 x i64> poison)
 ; AES-NEXT:  Cost Model: Found an estimated cost of 43 for instruction: %c32 = call <4 x i32> @llvm.clmul.v4i32(<4 x i32> poison, <4 x i32> poison)
 ; AES-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %c2 = call <2 x i32> @llvm.clmul.v2i32(<2 x i32> poison, <2 x i32> poison)
-; AES-NEXT:  Cost Model: Found an estimated cost of 48 for instruction: %c16 = call <4 x i16> @llvm.clmul.v4i16(<4 x i16> poison, <4 x i16> poison)
-; AES-NEXT:  Cost Model: Found an estimated cost of 48 for instruction: %c16x8 = call <8 x i16> @llvm.clmul.v8i16(<8 x i16> poison, <8 x i16> poison)
+; AES-NEXT:  Cost Model: Found an estimated cost of 26 for instruction: %c16 = call <4 x i16> @llvm.clmul.v4i16(<4 x i16> poison, <4 x i16> poison)
+; AES-NEXT:  Cost Model: Found an estimated cost of 26 for instruction: %c16x8 = call <8 x i16> @llvm.clmul.v8i16(<8 x i16> poison, <8 x i16> poison)
 ; AES-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret void
 ;
   %c8 = call <16 x i8> @llvm.clmul.v16i8(<16 x i8> poison, <16 x i8> poison)

--- a/llvm/test/Analysis/CostModel/AArch64/clmul-scalable.ll
+++ b/llvm/test/Analysis/CostModel/AArch64/clmul-scalable.ll
@@ -8,15 +8,15 @@
 
 define void @clmul_scalable() {
 ; SVE-LABEL: 'clmul_scalable'
-; SVE-NEXT:  Cost Model: Found an estimated cost of 24 for instruction: %c8 = call <vscale x 16 x i8> @llvm.clmul.nxv16i8(<vscale x 16 x i8> poison, <vscale x 16 x i8> poison)
-; SVE-NEXT:  Cost Model: Found an estimated cost of 48 for instruction: %c16 = call <vscale x 8 x i16> @llvm.clmul.nxv8i16(<vscale x 8 x i16> poison, <vscale x 8 x i16> poison)
+; SVE-NEXT:  Cost Model: Found an estimated cost of 13 for instruction: %c8 = call <vscale x 16 x i8> @llvm.clmul.nxv16i8(<vscale x 16 x i8> poison, <vscale x 16 x i8> poison)
+; SVE-NEXT:  Cost Model: Found an estimated cost of 26 for instruction: %c16 = call <vscale x 8 x i16> @llvm.clmul.nxv8i16(<vscale x 8 x i16> poison, <vscale x 8 x i16> poison)
 ; SVE-NEXT:  Cost Model: Found an estimated cost of 43 for instruction: %c32 = call <vscale x 4 x i32> @llvm.clmul.nxv4i32(<vscale x 4 x i32> poison, <vscale x 4 x i32> poison)
 ; SVE-NEXT:  Cost Model: Found an estimated cost of 192 for instruction: %c64 = call <vscale x 2 x i64> @llvm.clmul.nxv2i64(<vscale x 2 x i64> poison, <vscale x 2 x i64> poison)
 ; SVE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret void
 ;
 ; SVE-AES-LABEL: 'clmul_scalable'
-; SVE-AES-NEXT:  Cost Model: Found an estimated cost of 24 for instruction: %c8 = call <vscale x 16 x i8> @llvm.clmul.nxv16i8(<vscale x 16 x i8> poison, <vscale x 16 x i8> poison)
-; SVE-AES-NEXT:  Cost Model: Found an estimated cost of 48 for instruction: %c16 = call <vscale x 8 x i16> @llvm.clmul.nxv8i16(<vscale x 8 x i16> poison, <vscale x 8 x i16> poison)
+; SVE-AES-NEXT:  Cost Model: Found an estimated cost of 13 for instruction: %c8 = call <vscale x 16 x i8> @llvm.clmul.nxv16i8(<vscale x 16 x i8> poison, <vscale x 16 x i8> poison)
+; SVE-AES-NEXT:  Cost Model: Found an estimated cost of 26 for instruction: %c16 = call <vscale x 8 x i16> @llvm.clmul.nxv8i16(<vscale x 8 x i16> poison, <vscale x 8 x i16> poison)
 ; SVE-AES-NEXT:  Cost Model: Found an estimated cost of 43 for instruction: %c32 = call <vscale x 4 x i32> @llvm.clmul.nxv4i32(<vscale x 4 x i32> poison, <vscale x 4 x i32> poison)
 ; SVE-AES-NEXT:  Cost Model: Found an estimated cost of 3 for instruction: %c64 = call <vscale x 2 x i64> @llvm.clmul.nxv2i64(<vscale x 2 x i64> poison, <vscale x 2 x i64> poison)
 ; SVE-AES-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret void

--- a/llvm/test/Analysis/CostModel/X86/clmul.ll
+++ b/llvm/test/Analysis/CostModel/X86/clmul.ll
@@ -16,8 +16,8 @@ define void @clmul(i128 %a128, i128 %b128, i64 %a64, i64 %b64, i32 %a32, i32 %b3
 ; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 768 for instruction: %call_i128 = call i128 @llvm.clmul.i128(i128 %a128, i128 %b128)
 ; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 59 for instruction: %call_i64 = call i64 @llvm.clmul.i64(i64 %a64, i64 %b64)
 ; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 43 for instruction: %call_i32 = call i32 @llvm.clmul.i32(i32 %a32, i32 %b32)
-; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 48 for instruction: %call_i16 = call i16 @llvm.clmul.i16(i16 %a16, i16 %b16)
-; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 24 for instruction: %call_i8 = call i8 @llvm.clmul.i8(i8 %a8, i8 %b8)
+; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 35 for instruction: %call_i16 = call i16 @llvm.clmul.i16(i16 %a16, i16 %b16)
+; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 21 for instruction: %call_i8 = call i8 @llvm.clmul.i8(i8 %a8, i8 %b8)
 ; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret void
 ;
   %call_i128 = call i128 @llvm.clmul.i128(i128 %a128, i128 %b128)
@@ -33,16 +33,16 @@ define void @clmul_128(<1 x i128> %a128, <1 x i128> %b128, <2 x i64> %a64, <2 x 
 ; PCLMUL-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %call_i128 = call <1 x i128> @llvm.clmul.v1i128(<1 x i128> %a128, <1 x i128> %b128)
 ; PCLMUL-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %call_i64 = call <2 x i64> @llvm.clmul.v2i64(<2 x i64> %a64, <2 x i64> %b64)
 ; PCLMUL-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %call_i32 = call <4 x i32> @llvm.clmul.v4i32(<4 x i32> %a32, <4 x i32> %b32)
-; PCLMUL-NEXT:  Cost Model: Found an estimated cost of 48 for instruction: %call_i16 = call <8 x i16> @llvm.clmul.v8i16(<8 x i16> %a16, <8 x i16> %b16)
-; PCLMUL-NEXT:  Cost Model: Found an estimated cost of 40 for instruction: %call_i8 = call <16 x i8> @llvm.clmul.v16i8(<16 x i8> %a8, <16 x i8> %b8)
+; PCLMUL-NEXT:  Cost Model: Found an estimated cost of 26 for instruction: %call_i16 = call <8 x i16> @llvm.clmul.v8i16(<8 x i16> %a16, <8 x i16> %b16)
+; PCLMUL-NEXT:  Cost Model: Found an estimated cost of 33 for instruction: %call_i8 = call <16 x i8> @llvm.clmul.v16i8(<16 x i8> %a8, <16 x i8> %b8)
 ; PCLMUL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret void
 ;
 ; NO-PCLMUL-LABEL: 'clmul_128'
 ; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 768 for instruction: %call_i128 = call <1 x i128> @llvm.clmul.v1i128(<1 x i128> %a128, <1 x i128> %b128)
 ; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 139 for instruction: %call_i64 = call <2 x i64> @llvm.clmul.v2i64(<2 x i64> %a64, <2 x i64> %b64)
 ; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 123 for instruction: %call_i32 = call <4 x i32> @llvm.clmul.v4i32(<4 x i32> %a32, <4 x i32> %b32)
-; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 48 for instruction: %call_i16 = call <8 x i16> @llvm.clmul.v8i16(<8 x i16> %a16, <8 x i16> %b16)
-; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 40 for instruction: %call_i8 = call <16 x i8> @llvm.clmul.v16i8(<16 x i8> %a8, <16 x i8> %b8)
+; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 26 for instruction: %call_i16 = call <8 x i16> @llvm.clmul.v8i16(<8 x i16> %a16, <8 x i16> %b16)
+; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 33 for instruction: %call_i8 = call <16 x i8> @llvm.clmul.v16i8(<16 x i8> %a8, <16 x i8> %b8)
 ; NO-PCLMUL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret void
 ;
   %call_i128 = call <1 x i128> @llvm.clmul.v1i128(<1 x i128> %a128, <1 x i128> %b128)

--- a/llvm/test/CodeGen/AArch64/clmul-scalable.ll
+++ b/llvm/test/CodeGen/AArch64/clmul-scalable.ll
@@ -10,71 +10,45 @@ define <vscale x 16 x i8> @clmul_nxv16i8(<vscale x 16 x i8> %x, <vscale x 16 x i
 ; CHECK-SVE-LABEL: clmul_nxv16i8:
 ; CHECK-SVE:       // %bb.0:
 ; CHECK-SVE-NEXT:    movprfx z2, z1
-; CHECK-SVE-NEXT:    and z2.b, z2.b, #0x2
-; CHECK-SVE-NEXT:    movprfx z3, z1
-; CHECK-SVE-NEXT:    and z3.b, z3.b, #0x1
-; CHECK-SVE-NEXT:    movprfx z4, z1
-; CHECK-SVE-NEXT:    and z4.b, z4.b, #0x4
-; CHECK-SVE-NEXT:    movprfx z5, z1
-; CHECK-SVE-NEXT:    and z5.b, z5.b, #0x8
-; CHECK-SVE-NEXT:    movprfx z6, z1
-; CHECK-SVE-NEXT:    and z6.b, z6.b, #0x10
-; CHECK-SVE-NEXT:    movprfx z7, z1
-; CHECK-SVE-NEXT:    and z7.b, z7.b, #0x20
+; CHECK-SVE-NEXT:    and z2.b, z2.b, #0x55
+; CHECK-SVE-NEXT:    movprfx z3, z0
+; CHECK-SVE-NEXT:    and z3.b, z3.b, #0xaa
+; CHECK-SVE-NEXT:    and z1.b, z1.b, #0xaa
+; CHECK-SVE-NEXT:    and z0.b, z0.b, #0x55
 ; CHECK-SVE-NEXT:    ptrue p0.b
-; CHECK-SVE-NEXT:    movprfx z24, z1
-; CHECK-SVE-NEXT:    and z24.b, z24.b, #0x40
-; CHECK-SVE-NEXT:    and z1.b, z1.b, #0x80
-; CHECK-SVE-NEXT:    mul z2.b, p0/m, z2.b, z0.b
-; CHECK-SVE-NEXT:    mul z3.b, p0/m, z3.b, z0.b
-; CHECK-SVE-NEXT:    mul z4.b, p0/m, z4.b, z0.b
-; CHECK-SVE-NEXT:    mul z5.b, p0/m, z5.b, z0.b
-; CHECK-SVE-NEXT:    mul z6.b, p0/m, z6.b, z0.b
-; CHECK-SVE-NEXT:    mul z7.b, p0/m, z7.b, z0.b
-; CHECK-SVE-NEXT:    mul z24.b, p0/m, z24.b, z0.b
-; CHECK-SVE-NEXT:    mul z0.b, p0/m, z0.b, z1.b
-; CHECK-SVE-NEXT:    eor z2.d, z3.d, z2.d
-; CHECK-SVE-NEXT:    eor z3.d, z4.d, z5.d
-; CHECK-SVE-NEXT:    eor z4.d, z6.d, z7.d
-; CHECK-SVE-NEXT:    eor z2.d, z2.d, z3.d
-; CHECK-SVE-NEXT:    eor z3.d, z4.d, z24.d
-; CHECK-SVE-NEXT:    eor z1.d, z2.d, z3.d
-; CHECK-SVE-NEXT:    eor z0.d, z1.d, z0.d
+; CHECK-SVE-NEXT:    movprfx z4, z3
+; CHECK-SVE-NEXT:    mul z4.b, p0/m, z4.b, z2.b
+; CHECK-SVE-NEXT:    movprfx z5, z0
+; CHECK-SVE-NEXT:    mul z5.b, p0/m, z5.b, z1.b
+; CHECK-SVE-NEXT:    mul z1.b, p0/m, z1.b, z3.b
+; CHECK-SVE-NEXT:    mul z0.b, p0/m, z0.b, z2.b
+; CHECK-SVE-NEXT:    eor z2.d, z5.d, z4.d
+; CHECK-SVE-NEXT:    eor z0.d, z0.d, z1.d
+; CHECK-SVE-NEXT:    and z2.b, z2.b, #0xaa
+; CHECK-SVE-NEXT:    and z0.b, z0.b, #0x55
+; CHECK-SVE-NEXT:    orr z0.d, z0.d, z2.d
 ; CHECK-SVE-NEXT:    ret
 ;
 ; CHECK-SVE-AES-LABEL: clmul_nxv16i8:
 ; CHECK-SVE-AES:       // %bb.0:
 ; CHECK-SVE-AES-NEXT:    movprfx z2, z1
-; CHECK-SVE-AES-NEXT:    and z2.b, z2.b, #0x2
-; CHECK-SVE-AES-NEXT:    movprfx z3, z1
-; CHECK-SVE-AES-NEXT:    and z3.b, z3.b, #0x1
-; CHECK-SVE-AES-NEXT:    movprfx z4, z1
-; CHECK-SVE-AES-NEXT:    and z4.b, z4.b, #0x4
-; CHECK-SVE-AES-NEXT:    movprfx z5, z1
-; CHECK-SVE-AES-NEXT:    and z5.b, z5.b, #0x8
-; CHECK-SVE-AES-NEXT:    movprfx z6, z1
-; CHECK-SVE-AES-NEXT:    and z6.b, z6.b, #0x10
-; CHECK-SVE-AES-NEXT:    movprfx z7, z1
-; CHECK-SVE-AES-NEXT:    and z7.b, z7.b, #0x20
+; CHECK-SVE-AES-NEXT:    and z2.b, z2.b, #0x55
+; CHECK-SVE-AES-NEXT:    movprfx z3, z0
+; CHECK-SVE-AES-NEXT:    and z3.b, z3.b, #0xaa
+; CHECK-SVE-AES-NEXT:    and z1.b, z1.b, #0xaa
+; CHECK-SVE-AES-NEXT:    and z0.b, z0.b, #0x55
 ; CHECK-SVE-AES-NEXT:    ptrue p0.b
-; CHECK-SVE-AES-NEXT:    movprfx z24, z1
-; CHECK-SVE-AES-NEXT:    and z24.b, z24.b, #0x40
-; CHECK-SVE-AES-NEXT:    and z1.b, z1.b, #0x80
-; CHECK-SVE-AES-NEXT:    mul z2.b, p0/m, z2.b, z0.b
-; CHECK-SVE-AES-NEXT:    mul z3.b, p0/m, z3.b, z0.b
-; CHECK-SVE-AES-NEXT:    mul z4.b, p0/m, z4.b, z0.b
-; CHECK-SVE-AES-NEXT:    mul z5.b, p0/m, z5.b, z0.b
-; CHECK-SVE-AES-NEXT:    mul z6.b, p0/m, z6.b, z0.b
-; CHECK-SVE-AES-NEXT:    mul z7.b, p0/m, z7.b, z0.b
-; CHECK-SVE-AES-NEXT:    mul z24.b, p0/m, z24.b, z0.b
-; CHECK-SVE-AES-NEXT:    mul z0.b, p0/m, z0.b, z1.b
-; CHECK-SVE-AES-NEXT:    eor z2.d, z3.d, z2.d
-; CHECK-SVE-AES-NEXT:    eor z3.d, z4.d, z5.d
-; CHECK-SVE-AES-NEXT:    eor z4.d, z6.d, z7.d
-; CHECK-SVE-AES-NEXT:    eor z2.d, z2.d, z3.d
-; CHECK-SVE-AES-NEXT:    eor z3.d, z4.d, z24.d
-; CHECK-SVE-AES-NEXT:    eor z1.d, z2.d, z3.d
-; CHECK-SVE-AES-NEXT:    eor z0.d, z1.d, z0.d
+; CHECK-SVE-AES-NEXT:    movprfx z4, z3
+; CHECK-SVE-AES-NEXT:    mul z4.b, p0/m, z4.b, z2.b
+; CHECK-SVE-AES-NEXT:    movprfx z5, z0
+; CHECK-SVE-AES-NEXT:    mul z5.b, p0/m, z5.b, z1.b
+; CHECK-SVE-AES-NEXT:    mul z1.b, p0/m, z1.b, z3.b
+; CHECK-SVE-AES-NEXT:    mul z0.b, p0/m, z0.b, z2.b
+; CHECK-SVE-AES-NEXT:    eor z2.d, z5.d, z4.d
+; CHECK-SVE-AES-NEXT:    eor z0.d, z0.d, z1.d
+; CHECK-SVE-AES-NEXT:    and z2.b, z2.b, #0xaa
+; CHECK-SVE-AES-NEXT:    and z0.b, z0.b, #0x55
+; CHECK-SVE-AES-NEXT:    orr z0.d, z0.d, z2.d
 ; CHECK-SVE-AES-NEXT:    ret
 ;
 ; CHECK-SME-STREAMING-LABEL: clmul_nxv16i8:
@@ -103,136 +77,84 @@ define <vscale x 16 x i8> @clmul_nxv16i8(<vscale x 16 x i8> %x, <vscale x 16 x i
 define <vscale x 8 x i16> @clmul_nxv8i16(<vscale x 8 x i16> %x, <vscale x 8 x i16> %y) {
 ; CHECK-SVE-LABEL: clmul_nxv8i16:
 ; CHECK-SVE:       // %bb.0:
-; CHECK-SVE-NEXT:    movprfx z2, z1
-; CHECK-SVE-NEXT:    and z2.h, z2.h, #0x2
-; CHECK-SVE-NEXT:    movprfx z3, z1
-; CHECK-SVE-NEXT:    and z3.h, z3.h, #0x1
-; CHECK-SVE-NEXT:    movprfx z4, z1
-; CHECK-SVE-NEXT:    and z4.h, z4.h, #0x4
-; CHECK-SVE-NEXT:    movprfx z5, z1
-; CHECK-SVE-NEXT:    and z5.h, z5.h, #0x8
+; CHECK-SVE-NEXT:    mov w8, #37449 // =0x9249
 ; CHECK-SVE-NEXT:    ptrue p0.h
-; CHECK-SVE-NEXT:    movprfx z6, z1
-; CHECK-SVE-NEXT:    and z6.h, z6.h, #0x10
-; CHECK-SVE-NEXT:    movprfx z7, z1
-; CHECK-SVE-NEXT:    and z7.h, z7.h, #0x20
-; CHECK-SVE-NEXT:    movprfx z24, z1
-; CHECK-SVE-NEXT:    and z24.h, z24.h, #0x80
-; CHECK-SVE-NEXT:    movprfx z25, z1
-; CHECK-SVE-NEXT:    and z25.h, z25.h, #0x100
-; CHECK-SVE-NEXT:    movprfx z26, z1
-; CHECK-SVE-NEXT:    and z26.h, z26.h, #0x800
-; CHECK-SVE-NEXT:    movprfx z27, z1
-; CHECK-SVE-NEXT:    and z27.h, z27.h, #0x1000
-; CHECK-SVE-NEXT:    mul z2.h, p0/m, z2.h, z0.h
-; CHECK-SVE-NEXT:    mul z3.h, p0/m, z3.h, z0.h
-; CHECK-SVE-NEXT:    mul z4.h, p0/m, z4.h, z0.h
-; CHECK-SVE-NEXT:    movprfx z28, z1
-; CHECK-SVE-NEXT:    and z28.h, z28.h, #0x40
-; CHECK-SVE-NEXT:    mul z5.h, p0/m, z5.h, z0.h
-; CHECK-SVE-NEXT:    mul z6.h, p0/m, z6.h, z0.h
-; CHECK-SVE-NEXT:    movprfx z29, z1
-; CHECK-SVE-NEXT:    and z29.h, z29.h, #0x200
+; CHECK-SVE-NEXT:    mov z2.h, w8
+; CHECK-SVE-NEXT:    mov w8, #9362 // =0x2492
+; CHECK-SVE-NEXT:    mov z3.h, w8
+; CHECK-SVE-NEXT:    mov w8, #18724 // =0x4924
+; CHECK-SVE-NEXT:    mov z4.h, w8
+; CHECK-SVE-NEXT:    and z5.d, z1.d, z2.d
+; CHECK-SVE-NEXT:    and z24.d, z0.d, z2.d
+; CHECK-SVE-NEXT:    and z6.d, z0.d, z3.d
+; CHECK-SVE-NEXT:    and z7.d, z1.d, z3.d
+; CHECK-SVE-NEXT:    and z1.d, z1.d, z4.d
+; CHECK-SVE-NEXT:    and z0.d, z0.d, z4.d
+; CHECK-SVE-NEXT:    movprfx z28, z24
+; CHECK-SVE-NEXT:    mul z28.h, p0/m, z28.h, z5.h
+; CHECK-SVE-NEXT:    movprfx z25, z6
+; CHECK-SVE-NEXT:    mul z25.h, p0/m, z25.h, z5.h
+; CHECK-SVE-NEXT:    movprfx z26, z24
+; CHECK-SVE-NEXT:    mul z26.h, p0/m, z26.h, z7.h
+; CHECK-SVE-NEXT:    movprfx z27, z6
+; CHECK-SVE-NEXT:    mul z27.h, p0/m, z27.h, z1.h
+; CHECK-SVE-NEXT:    mul z24.h, p0/m, z24.h, z1.h
+; CHECK-SVE-NEXT:    mul z1.h, p0/m, z1.h, z0.h
+; CHECK-SVE-NEXT:    mul z6.h, p0/m, z6.h, z7.h
 ; CHECK-SVE-NEXT:    mul z7.h, p0/m, z7.h, z0.h
-; CHECK-SVE-NEXT:    mul z24.h, p0/m, z24.h, z0.h
-; CHECK-SVE-NEXT:    movprfx z30, z1
-; CHECK-SVE-NEXT:    and z30.h, z30.h, #0x2000
-; CHECK-SVE-NEXT:    mul z25.h, p0/m, z25.h, z0.h
-; CHECK-SVE-NEXT:    mul z26.h, p0/m, z26.h, z0.h
-; CHECK-SVE-NEXT:    mul z27.h, p0/m, z27.h, z0.h
-; CHECK-SVE-NEXT:    eor z2.d, z3.d, z2.d
-; CHECK-SVE-NEXT:    mul z28.h, p0/m, z28.h, z0.h
-; CHECK-SVE-NEXT:    eor z3.d, z4.d, z5.d
-; CHECK-SVE-NEXT:    mul z29.h, p0/m, z29.h, z0.h
-; CHECK-SVE-NEXT:    movprfx z4, z1
-; CHECK-SVE-NEXT:    and z4.h, z4.h, #0x400
-; CHECK-SVE-NEXT:    mul z30.h, p0/m, z30.h, z0.h
-; CHECK-SVE-NEXT:    movprfx z5, z1
-; CHECK-SVE-NEXT:    and z5.h, z5.h, #0x4000
-; CHECK-SVE-NEXT:    eor z6.d, z6.d, z7.d
-; CHECK-SVE-NEXT:    eor z7.d, z24.d, z25.d
-; CHECK-SVE-NEXT:    and z1.h, z1.h, #0x8000
-; CHECK-SVE-NEXT:    eor z24.d, z26.d, z27.d
-; CHECK-SVE-NEXT:    mul z4.h, p0/m, z4.h, z0.h
-; CHECK-SVE-NEXT:    eor z2.d, z2.d, z3.d
-; CHECK-SVE-NEXT:    mul z5.h, p0/m, z5.h, z0.h
-; CHECK-SVE-NEXT:    eor z3.d, z6.d, z28.d
-; CHECK-SVE-NEXT:    eor z6.d, z7.d, z29.d
-; CHECK-SVE-NEXT:    mul z0.h, p0/m, z0.h, z1.h
-; CHECK-SVE-NEXT:    eor z7.d, z24.d, z30.d
-; CHECK-SVE-NEXT:    eor z1.d, z2.d, z3.d
-; CHECK-SVE-NEXT:    eor z2.d, z6.d, z4.d
-; CHECK-SVE-NEXT:    eor z3.d, z7.d, z5.d
-; CHECK-SVE-NEXT:    eor z1.d, z1.d, z2.d
-; CHECK-SVE-NEXT:    eor z0.d, z3.d, z0.d
-; CHECK-SVE-NEXT:    eor z0.d, z1.d, z0.d
+; CHECK-SVE-NEXT:    mul z0.h, p0/m, z0.h, z5.h
+; CHECK-SVE-NEXT:    eor z25.d, z26.d, z25.d
+; CHECK-SVE-NEXT:    eor z26.d, z28.d, z27.d
+; CHECK-SVE-NEXT:    eor z6.d, z24.d, z6.d
+; CHECK-SVE-NEXT:    eor z1.d, z25.d, z1.d
+; CHECK-SVE-NEXT:    eor z5.d, z26.d, z7.d
+; CHECK-SVE-NEXT:    eor z0.d, z6.d, z0.d
+; CHECK-SVE-NEXT:    and z1.d, z1.d, z3.d
+; CHECK-SVE-NEXT:    and z2.d, z5.d, z2.d
+; CHECK-SVE-NEXT:    and z0.d, z0.d, z4.d
+; CHECK-SVE-NEXT:    orr z1.d, z2.d, z1.d
+; CHECK-SVE-NEXT:    orr z0.d, z1.d, z0.d
 ; CHECK-SVE-NEXT:    ret
 ;
 ; CHECK-SVE-AES-LABEL: clmul_nxv8i16:
 ; CHECK-SVE-AES:       // %bb.0:
-; CHECK-SVE-AES-NEXT:    movprfx z2, z1
-; CHECK-SVE-AES-NEXT:    and z2.h, z2.h, #0x2
-; CHECK-SVE-AES-NEXT:    movprfx z3, z1
-; CHECK-SVE-AES-NEXT:    and z3.h, z3.h, #0x1
-; CHECK-SVE-AES-NEXT:    movprfx z4, z1
-; CHECK-SVE-AES-NEXT:    and z4.h, z4.h, #0x4
-; CHECK-SVE-AES-NEXT:    movprfx z5, z1
-; CHECK-SVE-AES-NEXT:    and z5.h, z5.h, #0x8
+; CHECK-SVE-AES-NEXT:    mov w8, #37449 // =0x9249
 ; CHECK-SVE-AES-NEXT:    ptrue p0.h
-; CHECK-SVE-AES-NEXT:    movprfx z6, z1
-; CHECK-SVE-AES-NEXT:    and z6.h, z6.h, #0x10
-; CHECK-SVE-AES-NEXT:    movprfx z7, z1
-; CHECK-SVE-AES-NEXT:    and z7.h, z7.h, #0x20
-; CHECK-SVE-AES-NEXT:    movprfx z24, z1
-; CHECK-SVE-AES-NEXT:    and z24.h, z24.h, #0x80
-; CHECK-SVE-AES-NEXT:    movprfx z25, z1
-; CHECK-SVE-AES-NEXT:    and z25.h, z25.h, #0x100
-; CHECK-SVE-AES-NEXT:    movprfx z26, z1
-; CHECK-SVE-AES-NEXT:    and z26.h, z26.h, #0x800
-; CHECK-SVE-AES-NEXT:    movprfx z27, z1
-; CHECK-SVE-AES-NEXT:    and z27.h, z27.h, #0x1000
-; CHECK-SVE-AES-NEXT:    mul z2.h, p0/m, z2.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z3.h, p0/m, z3.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z4.h, p0/m, z4.h, z0.h
-; CHECK-SVE-AES-NEXT:    movprfx z28, z1
-; CHECK-SVE-AES-NEXT:    and z28.h, z28.h, #0x40
-; CHECK-SVE-AES-NEXT:    mul z5.h, p0/m, z5.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z6.h, p0/m, z6.h, z0.h
-; CHECK-SVE-AES-NEXT:    movprfx z29, z1
-; CHECK-SVE-AES-NEXT:    and z29.h, z29.h, #0x200
+; CHECK-SVE-AES-NEXT:    mov z2.h, w8
+; CHECK-SVE-AES-NEXT:    mov w8, #9362 // =0x2492
+; CHECK-SVE-AES-NEXT:    mov z3.h, w8
+; CHECK-SVE-AES-NEXT:    mov w8, #18724 // =0x4924
+; CHECK-SVE-AES-NEXT:    mov z4.h, w8
+; CHECK-SVE-AES-NEXT:    and z5.d, z1.d, z2.d
+; CHECK-SVE-AES-NEXT:    and z24.d, z0.d, z2.d
+; CHECK-SVE-AES-NEXT:    and z6.d, z0.d, z3.d
+; CHECK-SVE-AES-NEXT:    and z7.d, z1.d, z3.d
+; CHECK-SVE-AES-NEXT:    and z1.d, z1.d, z4.d
+; CHECK-SVE-AES-NEXT:    and z0.d, z0.d, z4.d
+; CHECK-SVE-AES-NEXT:    movprfx z28, z24
+; CHECK-SVE-AES-NEXT:    mul z28.h, p0/m, z28.h, z5.h
+; CHECK-SVE-AES-NEXT:    movprfx z25, z6
+; CHECK-SVE-AES-NEXT:    mul z25.h, p0/m, z25.h, z5.h
+; CHECK-SVE-AES-NEXT:    movprfx z26, z24
+; CHECK-SVE-AES-NEXT:    mul z26.h, p0/m, z26.h, z7.h
+; CHECK-SVE-AES-NEXT:    movprfx z27, z6
+; CHECK-SVE-AES-NEXT:    mul z27.h, p0/m, z27.h, z1.h
+; CHECK-SVE-AES-NEXT:    mul z24.h, p0/m, z24.h, z1.h
+; CHECK-SVE-AES-NEXT:    mul z1.h, p0/m, z1.h, z0.h
+; CHECK-SVE-AES-NEXT:    mul z6.h, p0/m, z6.h, z7.h
 ; CHECK-SVE-AES-NEXT:    mul z7.h, p0/m, z7.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z24.h, p0/m, z24.h, z0.h
-; CHECK-SVE-AES-NEXT:    movprfx z30, z1
-; CHECK-SVE-AES-NEXT:    and z30.h, z30.h, #0x2000
-; CHECK-SVE-AES-NEXT:    mul z25.h, p0/m, z25.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z26.h, p0/m, z26.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z27.h, p0/m, z27.h, z0.h
-; CHECK-SVE-AES-NEXT:    eor z2.d, z3.d, z2.d
-; CHECK-SVE-AES-NEXT:    mul z28.h, p0/m, z28.h, z0.h
-; CHECK-SVE-AES-NEXT:    eor z3.d, z4.d, z5.d
-; CHECK-SVE-AES-NEXT:    mul z29.h, p0/m, z29.h, z0.h
-; CHECK-SVE-AES-NEXT:    movprfx z4, z1
-; CHECK-SVE-AES-NEXT:    and z4.h, z4.h, #0x400
-; CHECK-SVE-AES-NEXT:    mul z30.h, p0/m, z30.h, z0.h
-; CHECK-SVE-AES-NEXT:    movprfx z5, z1
-; CHECK-SVE-AES-NEXT:    and z5.h, z5.h, #0x4000
-; CHECK-SVE-AES-NEXT:    eor z6.d, z6.d, z7.d
-; CHECK-SVE-AES-NEXT:    eor z7.d, z24.d, z25.d
-; CHECK-SVE-AES-NEXT:    and z1.h, z1.h, #0x8000
-; CHECK-SVE-AES-NEXT:    eor z24.d, z26.d, z27.d
-; CHECK-SVE-AES-NEXT:    mul z4.h, p0/m, z4.h, z0.h
-; CHECK-SVE-AES-NEXT:    eor z2.d, z2.d, z3.d
-; CHECK-SVE-AES-NEXT:    mul z5.h, p0/m, z5.h, z0.h
-; CHECK-SVE-AES-NEXT:    eor z3.d, z6.d, z28.d
-; CHECK-SVE-AES-NEXT:    eor z6.d, z7.d, z29.d
-; CHECK-SVE-AES-NEXT:    mul z0.h, p0/m, z0.h, z1.h
-; CHECK-SVE-AES-NEXT:    eor z7.d, z24.d, z30.d
-; CHECK-SVE-AES-NEXT:    eor z1.d, z2.d, z3.d
-; CHECK-SVE-AES-NEXT:    eor z2.d, z6.d, z4.d
-; CHECK-SVE-AES-NEXT:    eor z3.d, z7.d, z5.d
-; CHECK-SVE-AES-NEXT:    eor z1.d, z1.d, z2.d
-; CHECK-SVE-AES-NEXT:    eor z0.d, z3.d, z0.d
-; CHECK-SVE-AES-NEXT:    eor z0.d, z1.d, z0.d
+; CHECK-SVE-AES-NEXT:    mul z0.h, p0/m, z0.h, z5.h
+; CHECK-SVE-AES-NEXT:    eor z25.d, z26.d, z25.d
+; CHECK-SVE-AES-NEXT:    eor z26.d, z28.d, z27.d
+; CHECK-SVE-AES-NEXT:    eor z6.d, z24.d, z6.d
+; CHECK-SVE-AES-NEXT:    eor z1.d, z25.d, z1.d
+; CHECK-SVE-AES-NEXT:    eor z5.d, z26.d, z7.d
+; CHECK-SVE-AES-NEXT:    eor z0.d, z6.d, z0.d
+; CHECK-SVE-AES-NEXT:    and z1.d, z1.d, z3.d
+; CHECK-SVE-AES-NEXT:    and z2.d, z5.d, z2.d
+; CHECK-SVE-AES-NEXT:    and z0.d, z0.d, z4.d
+; CHECK-SVE-AES-NEXT:    orr z1.d, z2.d, z1.d
+; CHECK-SVE-AES-NEXT:    orr z0.d, z1.d, z0.d
 ; CHECK-SVE-AES-NEXT:    ret
 ;
 ; CHECK-SME-STREAMING-LABEL: clmul_nxv8i16:
@@ -584,42 +506,46 @@ define <vscale x 2 x i64> @clmul_nxv2i64(<vscale x 2 x i64> %x, <vscale x 2 x i6
 define <vscale x 16 x i8> @clmul_nxv16i8_zext(<vscale x 16 x i4> %x, <vscale x 16 x i4> %y) {
 ; CHECK-SVE-LABEL: clmul_nxv16i8_zext:
 ; CHECK-SVE:       // %bb.0:
-; CHECK-SVE-NEXT:    and z0.b, z0.b, #0xf
-; CHECK-SVE-NEXT:    movprfx z2, z1
-; CHECK-SVE-NEXT:    and z2.b, z2.b, #0x2
-; CHECK-SVE-NEXT:    movprfx z3, z1
-; CHECK-SVE-NEXT:    and z3.b, z3.b, #0x1
-; CHECK-SVE-NEXT:    movprfx z4, z1
-; CHECK-SVE-NEXT:    and z4.b, z4.b, #0x4
-; CHECK-SVE-NEXT:    and z1.b, z1.b, #0x8
+; CHECK-SVE-NEXT:    mov z2.b, #5 // =0x5
+; CHECK-SVE-NEXT:    mov z3.b, #10 // =0xa
 ; CHECK-SVE-NEXT:    ptrue p0.b
-; CHECK-SVE-NEXT:    mul z2.b, p0/m, z2.b, z0.b
-; CHECK-SVE-NEXT:    mul z3.b, p0/m, z3.b, z0.b
-; CHECK-SVE-NEXT:    mul z4.b, p0/m, z4.b, z0.b
-; CHECK-SVE-NEXT:    mul z0.b, p0/m, z0.b, z1.b
-; CHECK-SVE-NEXT:    eor z1.d, z3.d, z2.d
-; CHECK-SVE-NEXT:    eor z0.d, z4.d, z0.d
-; CHECK-SVE-NEXT:    eor z0.d, z1.d, z0.d
+; CHECK-SVE-NEXT:    and z4.d, z1.d, z2.d
+; CHECK-SVE-NEXT:    and z5.d, z0.d, z3.d
+; CHECK-SVE-NEXT:    and z1.d, z1.d, z3.d
+; CHECK-SVE-NEXT:    and z0.d, z0.d, z2.d
+; CHECK-SVE-NEXT:    movprfx z2, z5
+; CHECK-SVE-NEXT:    mul z2.b, p0/m, z2.b, z4.b
+; CHECK-SVE-NEXT:    movprfx z3, z0
+; CHECK-SVE-NEXT:    mul z3.b, p0/m, z3.b, z1.b
+; CHECK-SVE-NEXT:    mul z1.b, p0/m, z1.b, z5.b
+; CHECK-SVE-NEXT:    mul z0.b, p0/m, z0.b, z4.b
+; CHECK-SVE-NEXT:    eor z2.d, z3.d, z2.d
+; CHECK-SVE-NEXT:    eor z0.d, z0.d, z1.d
+; CHECK-SVE-NEXT:    and z2.b, z2.b, #0xaa
+; CHECK-SVE-NEXT:    and z0.b, z0.b, #0x55
+; CHECK-SVE-NEXT:    orr z0.d, z0.d, z2.d
 ; CHECK-SVE-NEXT:    ret
 ;
 ; CHECK-SVE-AES-LABEL: clmul_nxv16i8_zext:
 ; CHECK-SVE-AES:       // %bb.0:
-; CHECK-SVE-AES-NEXT:    and z0.b, z0.b, #0xf
-; CHECK-SVE-AES-NEXT:    movprfx z2, z1
-; CHECK-SVE-AES-NEXT:    and z2.b, z2.b, #0x2
-; CHECK-SVE-AES-NEXT:    movprfx z3, z1
-; CHECK-SVE-AES-NEXT:    and z3.b, z3.b, #0x1
-; CHECK-SVE-AES-NEXT:    movprfx z4, z1
-; CHECK-SVE-AES-NEXT:    and z4.b, z4.b, #0x4
-; CHECK-SVE-AES-NEXT:    and z1.b, z1.b, #0x8
+; CHECK-SVE-AES-NEXT:    mov z2.b, #5 // =0x5
+; CHECK-SVE-AES-NEXT:    mov z3.b, #10 // =0xa
 ; CHECK-SVE-AES-NEXT:    ptrue p0.b
-; CHECK-SVE-AES-NEXT:    mul z2.b, p0/m, z2.b, z0.b
-; CHECK-SVE-AES-NEXT:    mul z3.b, p0/m, z3.b, z0.b
-; CHECK-SVE-AES-NEXT:    mul z4.b, p0/m, z4.b, z0.b
-; CHECK-SVE-AES-NEXT:    mul z0.b, p0/m, z0.b, z1.b
-; CHECK-SVE-AES-NEXT:    eor z1.d, z3.d, z2.d
-; CHECK-SVE-AES-NEXT:    eor z0.d, z4.d, z0.d
-; CHECK-SVE-AES-NEXT:    eor z0.d, z1.d, z0.d
+; CHECK-SVE-AES-NEXT:    and z4.d, z1.d, z2.d
+; CHECK-SVE-AES-NEXT:    and z5.d, z0.d, z3.d
+; CHECK-SVE-AES-NEXT:    and z1.d, z1.d, z3.d
+; CHECK-SVE-AES-NEXT:    and z0.d, z0.d, z2.d
+; CHECK-SVE-AES-NEXT:    movprfx z2, z5
+; CHECK-SVE-AES-NEXT:    mul z2.b, p0/m, z2.b, z4.b
+; CHECK-SVE-AES-NEXT:    movprfx z3, z0
+; CHECK-SVE-AES-NEXT:    mul z3.b, p0/m, z3.b, z1.b
+; CHECK-SVE-AES-NEXT:    mul z1.b, p0/m, z1.b, z5.b
+; CHECK-SVE-AES-NEXT:    mul z0.b, p0/m, z0.b, z4.b
+; CHECK-SVE-AES-NEXT:    eor z2.d, z3.d, z2.d
+; CHECK-SVE-AES-NEXT:    eor z0.d, z0.d, z1.d
+; CHECK-SVE-AES-NEXT:    and z2.b, z2.b, #0xaa
+; CHECK-SVE-AES-NEXT:    and z0.b, z0.b, #0x55
+; CHECK-SVE-AES-NEXT:    orr z0.d, z0.d, z2.d
 ; CHECK-SVE-AES-NEXT:    ret
 ;
 ; CHECK-SME-STREAMING-LABEL: clmul_nxv16i8_zext:
@@ -658,74 +584,92 @@ define <vscale x 16 x i8> @clmul_nxv16i8_zext(<vscale x 16 x i4> %x, <vscale x 1
 define <vscale x 8 x i16> @clmul_nxv8i16_zext(<vscale x 8 x i8> %x, <vscale x 8 x i8> %y) {
 ; CHECK-SVE-LABEL: clmul_nxv8i16_zext:
 ; CHECK-SVE:       // %bb.0:
-; CHECK-SVE-NEXT:    and z0.h, z0.h, #0xff
-; CHECK-SVE-NEXT:    movprfx z2, z1
-; CHECK-SVE-NEXT:    and z2.h, z2.h, #0x2
-; CHECK-SVE-NEXT:    movprfx z3, z1
-; CHECK-SVE-NEXT:    and z3.h, z3.h, #0x1
-; CHECK-SVE-NEXT:    movprfx z4, z1
-; CHECK-SVE-NEXT:    and z4.h, z4.h, #0x4
-; CHECK-SVE-NEXT:    movprfx z5, z1
-; CHECK-SVE-NEXT:    and z5.h, z5.h, #0x8
-; CHECK-SVE-NEXT:    movprfx z6, z1
-; CHECK-SVE-NEXT:    and z6.h, z6.h, #0x10
-; CHECK-SVE-NEXT:    movprfx z7, z1
-; CHECK-SVE-NEXT:    and z7.h, z7.h, #0x20
+; CHECK-SVE-NEXT:    mov w8, #146 // =0x92
+; CHECK-SVE-NEXT:    mov z2.h, #73 // =0x49
+; CHECK-SVE-NEXT:    mov z4.h, #36 // =0x24
+; CHECK-SVE-NEXT:    mov z3.h, w8
 ; CHECK-SVE-NEXT:    ptrue p0.h
-; CHECK-SVE-NEXT:    movprfx z24, z1
-; CHECK-SVE-NEXT:    and z24.h, z24.h, #0x40
-; CHECK-SVE-NEXT:    and z1.h, z1.h, #0x80
-; CHECK-SVE-NEXT:    mul z2.h, p0/m, z2.h, z0.h
-; CHECK-SVE-NEXT:    mul z3.h, p0/m, z3.h, z0.h
-; CHECK-SVE-NEXT:    mul z4.h, p0/m, z4.h, z0.h
+; CHECK-SVE-NEXT:    mov w8, #9362 // =0x2492
+; CHECK-SVE-NEXT:    and z5.d, z1.d, z2.d
+; CHECK-SVE-NEXT:    and z2.d, z0.d, z2.d
+; CHECK-SVE-NEXT:    and z6.d, z0.d, z3.d
+; CHECK-SVE-NEXT:    and z3.d, z1.d, z3.d
+; CHECK-SVE-NEXT:    and z1.d, z1.d, z4.d
+; CHECK-SVE-NEXT:    and z0.d, z0.d, z4.d
+; CHECK-SVE-NEXT:    movprfx z24, z2
+; CHECK-SVE-NEXT:    mul z24.h, p0/m, z24.h, z5.h
+; CHECK-SVE-NEXT:    movprfx z4, z6
+; CHECK-SVE-NEXT:    mul z4.h, p0/m, z4.h, z5.h
+; CHECK-SVE-NEXT:    movprfx z7, z2
+; CHECK-SVE-NEXT:    mul z7.h, p0/m, z7.h, z3.h
+; CHECK-SVE-NEXT:    movprfx z25, z6
+; CHECK-SVE-NEXT:    mul z25.h, p0/m, z25.h, z1.h
+; CHECK-SVE-NEXT:    mul z2.h, p0/m, z2.h, z1.h
+; CHECK-SVE-NEXT:    mul z1.h, p0/m, z1.h, z0.h
 ; CHECK-SVE-NEXT:    mul z5.h, p0/m, z5.h, z0.h
-; CHECK-SVE-NEXT:    mul z6.h, p0/m, z6.h, z0.h
-; CHECK-SVE-NEXT:    mul z7.h, p0/m, z7.h, z0.h
-; CHECK-SVE-NEXT:    mul z24.h, p0/m, z24.h, z0.h
-; CHECK-SVE-NEXT:    mul z0.h, p0/m, z0.h, z1.h
-; CHECK-SVE-NEXT:    eor z2.d, z3.d, z2.d
-; CHECK-SVE-NEXT:    eor z3.d, z4.d, z5.d
-; CHECK-SVE-NEXT:    eor z4.d, z6.d, z7.d
+; CHECK-SVE-NEXT:    mul z0.h, p0/m, z0.h, z3.h
+; CHECK-SVE-NEXT:    mul z3.h, p0/m, z3.h, z6.h
+; CHECK-SVE-NEXT:    eor z4.d, z7.d, z4.d
+; CHECK-SVE-NEXT:    eor z7.d, z24.d, z25.d
+; CHECK-SVE-NEXT:    mov z24.h, w8
+; CHECK-SVE-NEXT:    mov w8, #37449 // =0x9249
+; CHECK-SVE-NEXT:    eor z2.d, z2.d, z5.d
+; CHECK-SVE-NEXT:    eor z1.d, z4.d, z1.d
+; CHECK-SVE-NEXT:    mov z4.h, w8
+; CHECK-SVE-NEXT:    eor z0.d, z7.d, z0.d
+; CHECK-SVE-NEXT:    mov w8, #18724 // =0x4924
 ; CHECK-SVE-NEXT:    eor z2.d, z2.d, z3.d
-; CHECK-SVE-NEXT:    eor z3.d, z4.d, z24.d
-; CHECK-SVE-NEXT:    eor z1.d, z2.d, z3.d
-; CHECK-SVE-NEXT:    eor z0.d, z1.d, z0.d
+; CHECK-SVE-NEXT:    mov z3.h, w8
+; CHECK-SVE-NEXT:    and z1.d, z1.d, z24.d
+; CHECK-SVE-NEXT:    and z0.d, z0.d, z4.d
+; CHECK-SVE-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-SVE-NEXT:    and z1.d, z2.d, z3.d
+; CHECK-SVE-NEXT:    orr z0.d, z0.d, z1.d
 ; CHECK-SVE-NEXT:    ret
 ;
 ; CHECK-SVE-AES-LABEL: clmul_nxv8i16_zext:
 ; CHECK-SVE-AES:       // %bb.0:
-; CHECK-SVE-AES-NEXT:    and z0.h, z0.h, #0xff
-; CHECK-SVE-AES-NEXT:    movprfx z2, z1
-; CHECK-SVE-AES-NEXT:    and z2.h, z2.h, #0x2
-; CHECK-SVE-AES-NEXT:    movprfx z3, z1
-; CHECK-SVE-AES-NEXT:    and z3.h, z3.h, #0x1
-; CHECK-SVE-AES-NEXT:    movprfx z4, z1
-; CHECK-SVE-AES-NEXT:    and z4.h, z4.h, #0x4
-; CHECK-SVE-AES-NEXT:    movprfx z5, z1
-; CHECK-SVE-AES-NEXT:    and z5.h, z5.h, #0x8
-; CHECK-SVE-AES-NEXT:    movprfx z6, z1
-; CHECK-SVE-AES-NEXT:    and z6.h, z6.h, #0x10
-; CHECK-SVE-AES-NEXT:    movprfx z7, z1
-; CHECK-SVE-AES-NEXT:    and z7.h, z7.h, #0x20
+; CHECK-SVE-AES-NEXT:    mov w8, #146 // =0x92
+; CHECK-SVE-AES-NEXT:    mov z2.h, #73 // =0x49
+; CHECK-SVE-AES-NEXT:    mov z4.h, #36 // =0x24
+; CHECK-SVE-AES-NEXT:    mov z3.h, w8
 ; CHECK-SVE-AES-NEXT:    ptrue p0.h
-; CHECK-SVE-AES-NEXT:    movprfx z24, z1
-; CHECK-SVE-AES-NEXT:    and z24.h, z24.h, #0x40
-; CHECK-SVE-AES-NEXT:    and z1.h, z1.h, #0x80
-; CHECK-SVE-AES-NEXT:    mul z2.h, p0/m, z2.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z3.h, p0/m, z3.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z4.h, p0/m, z4.h, z0.h
+; CHECK-SVE-AES-NEXT:    mov w8, #9362 // =0x2492
+; CHECK-SVE-AES-NEXT:    and z5.d, z1.d, z2.d
+; CHECK-SVE-AES-NEXT:    and z2.d, z0.d, z2.d
+; CHECK-SVE-AES-NEXT:    and z6.d, z0.d, z3.d
+; CHECK-SVE-AES-NEXT:    and z3.d, z1.d, z3.d
+; CHECK-SVE-AES-NEXT:    and z1.d, z1.d, z4.d
+; CHECK-SVE-AES-NEXT:    and z0.d, z0.d, z4.d
+; CHECK-SVE-AES-NEXT:    movprfx z24, z2
+; CHECK-SVE-AES-NEXT:    mul z24.h, p0/m, z24.h, z5.h
+; CHECK-SVE-AES-NEXT:    movprfx z4, z6
+; CHECK-SVE-AES-NEXT:    mul z4.h, p0/m, z4.h, z5.h
+; CHECK-SVE-AES-NEXT:    movprfx z7, z2
+; CHECK-SVE-AES-NEXT:    mul z7.h, p0/m, z7.h, z3.h
+; CHECK-SVE-AES-NEXT:    movprfx z25, z6
+; CHECK-SVE-AES-NEXT:    mul z25.h, p0/m, z25.h, z1.h
+; CHECK-SVE-AES-NEXT:    mul z2.h, p0/m, z2.h, z1.h
+; CHECK-SVE-AES-NEXT:    mul z1.h, p0/m, z1.h, z0.h
 ; CHECK-SVE-AES-NEXT:    mul z5.h, p0/m, z5.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z6.h, p0/m, z6.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z7.h, p0/m, z7.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z24.h, p0/m, z24.h, z0.h
-; CHECK-SVE-AES-NEXT:    mul z0.h, p0/m, z0.h, z1.h
-; CHECK-SVE-AES-NEXT:    eor z2.d, z3.d, z2.d
-; CHECK-SVE-AES-NEXT:    eor z3.d, z4.d, z5.d
-; CHECK-SVE-AES-NEXT:    eor z4.d, z6.d, z7.d
+; CHECK-SVE-AES-NEXT:    mul z0.h, p0/m, z0.h, z3.h
+; CHECK-SVE-AES-NEXT:    mul z3.h, p0/m, z3.h, z6.h
+; CHECK-SVE-AES-NEXT:    eor z4.d, z7.d, z4.d
+; CHECK-SVE-AES-NEXT:    eor z7.d, z24.d, z25.d
+; CHECK-SVE-AES-NEXT:    mov z24.h, w8
+; CHECK-SVE-AES-NEXT:    mov w8, #37449 // =0x9249
+; CHECK-SVE-AES-NEXT:    eor z2.d, z2.d, z5.d
+; CHECK-SVE-AES-NEXT:    eor z1.d, z4.d, z1.d
+; CHECK-SVE-AES-NEXT:    mov z4.h, w8
+; CHECK-SVE-AES-NEXT:    eor z0.d, z7.d, z0.d
+; CHECK-SVE-AES-NEXT:    mov w8, #18724 // =0x4924
 ; CHECK-SVE-AES-NEXT:    eor z2.d, z2.d, z3.d
-; CHECK-SVE-AES-NEXT:    eor z3.d, z4.d, z24.d
-; CHECK-SVE-AES-NEXT:    eor z1.d, z2.d, z3.d
-; CHECK-SVE-AES-NEXT:    eor z0.d, z1.d, z0.d
+; CHECK-SVE-AES-NEXT:    mov z3.h, w8
+; CHECK-SVE-AES-NEXT:    and z1.d, z1.d, z24.d
+; CHECK-SVE-AES-NEXT:    and z0.d, z0.d, z4.d
+; CHECK-SVE-AES-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-SVE-AES-NEXT:    and z1.d, z2.d, z3.d
+; CHECK-SVE-AES-NEXT:    orr z0.d, z0.d, z1.d
 ; CHECK-SVE-AES-NEXT:    ret
 ;
 ; CHECK-SME-STREAMING-LABEL: clmul_nxv8i16_zext:

--- a/llvm/test/CodeGen/AArch64/clmul.ll
+++ b/llvm/test/CodeGen/AArch64/clmul.ll
@@ -17,53 +17,35 @@ define i8 @clmul_i8(i8 %x, i8 %y) {
 define i16 @clmul_i16(i16 %x, i16 %y) {
 ; CHECK-NEON-LABEL: clmul_i16:
 ; CHECK-NEON:       // %bb.0:
-; CHECK-NEON-NEXT:    and w8, w1, #0x2
-; CHECK-NEON-NEXT:    and w9, w1, #0x1
-; CHECK-NEON-NEXT:    and w10, w1, #0x4
-; CHECK-NEON-NEXT:    mul w8, w0, w8
-; CHECK-NEON-NEXT:    and w11, w1, #0x8
-; CHECK-NEON-NEXT:    and w12, w1, #0x10
-; CHECK-NEON-NEXT:    mul w9, w0, w9
-; CHECK-NEON-NEXT:    and w13, w1, #0x20
-; CHECK-NEON-NEXT:    and w15, w1, #0x80
-; CHECK-NEON-NEXT:    mul w10, w0, w10
-; CHECK-NEON-NEXT:    and w16, w1, #0x100
-; CHECK-NEON-NEXT:    and w2, w1, #0x800
-; CHECK-NEON-NEXT:    mul w11, w0, w11
-; CHECK-NEON-NEXT:    and w14, w1, #0x40
-; CHECK-NEON-NEXT:    and w17, w1, #0x200
-; CHECK-NEON-NEXT:    mul w12, w0, w12
-; CHECK-NEON-NEXT:    eor w8, w9, w8
-; CHECK-NEON-NEXT:    and w9, w1, #0x1000
-; CHECK-NEON-NEXT:    mul w13, w0, w13
-; CHECK-NEON-NEXT:    and w18, w1, #0x400
-; CHECK-NEON-NEXT:    mul w15, w0, w15
-; CHECK-NEON-NEXT:    eor w10, w10, w11
-; CHECK-NEON-NEXT:    and w11, w1, #0x2000
-; CHECK-NEON-NEXT:    mul w16, w0, w16
-; CHECK-NEON-NEXT:    eor w8, w8, w10
-; CHECK-NEON-NEXT:    and w10, w1, #0x4000
-; CHECK-NEON-NEXT:    mul w2, w0, w2
-; CHECK-NEON-NEXT:    eor w12, w12, w13
-; CHECK-NEON-NEXT:    and w13, w1, #0xffff8000
-; CHECK-NEON-NEXT:    mul w9, w0, w9
-; CHECK-NEON-NEXT:    mul w14, w0, w14
-; CHECK-NEON-NEXT:    eor w15, w15, w16
-; CHECK-NEON-NEXT:    mul w17, w0, w17
-; CHECK-NEON-NEXT:    mul w11, w0, w11
-; CHECK-NEON-NEXT:    eor w9, w2, w9
-; CHECK-NEON-NEXT:    mul w18, w0, w18
-; CHECK-NEON-NEXT:    eor w12, w12, w14
-; CHECK-NEON-NEXT:    mul w10, w0, w10
-; CHECK-NEON-NEXT:    eor w14, w15, w17
-; CHECK-NEON-NEXT:    eor w8, w8, w12
-; CHECK-NEON-NEXT:    mul w13, w0, w13
-; CHECK-NEON-NEXT:    eor w9, w9, w11
-; CHECK-NEON-NEXT:    eor w11, w14, w18
-; CHECK-NEON-NEXT:    eor w9, w9, w10
-; CHECK-NEON-NEXT:    eor w8, w8, w11
-; CHECK-NEON-NEXT:    eor w9, w9, w13
-; CHECK-NEON-NEXT:    eor w0, w8, w9
+; CHECK-NEON-NEXT:    mov w8, #-28087 // =0xffff9249
+; CHECK-NEON-NEXT:    mov w9, #9362 // =0x2492
+; CHECK-NEON-NEXT:    mov w15, #18724 // =0x4924
+; CHECK-NEON-NEXT:    and w10, w1, w8
+; CHECK-NEON-NEXT:    and w11, w0, w9
+; CHECK-NEON-NEXT:    and w12, w1, w9
+; CHECK-NEON-NEXT:    and w13, w0, w8
+; CHECK-NEON-NEXT:    and w17, w1, w15
+; CHECK-NEON-NEXT:    and w18, w0, w15
+; CHECK-NEON-NEXT:    mul w14, w11, w10
+; CHECK-NEON-NEXT:    mul w16, w13, w12
+; CHECK-NEON-NEXT:    mul w0, w18, w17
+; CHECK-NEON-NEXT:    mul w1, w11, w17
+; CHECK-NEON-NEXT:    mul w17, w13, w17
+; CHECK-NEON-NEXT:    eor w14, w16, w14
+; CHECK-NEON-NEXT:    mul w13, w13, w10
+; CHECK-NEON-NEXT:    eor w14, w14, w0
+; CHECK-NEON-NEXT:    mul w11, w11, w12
+; CHECK-NEON-NEXT:    and w9, w14, w9
+; CHECK-NEON-NEXT:    mul w12, w18, w12
+; CHECK-NEON-NEXT:    mul w10, w18, w10
+; CHECK-NEON-NEXT:    eor w13, w13, w1
+; CHECK-NEON-NEXT:    eor w11, w17, w11
+; CHECK-NEON-NEXT:    eor w12, w13, w12
+; CHECK-NEON-NEXT:    and w8, w12, w8
+; CHECK-NEON-NEXT:    eor w10, w11, w10
+; CHECK-NEON-NEXT:    orr w8, w8, w9
+; CHECK-NEON-NEXT:    and w9, w10, w15
+; CHECK-NEON-NEXT:    orr w0, w8, w9
 ; CHECK-NEON-NEXT:    ret
 ;
 ; CHECK-AES-LABEL: clmul_i16:
@@ -473,30 +455,38 @@ define i128 @clmul_i128(i128 %x, i128 %y) {
 define i16 @clmul_i16_zext(i8 %x, i8 %y) {
 ; CHECK-NEON-LABEL: clmul_i16_zext:
 ; CHECK-NEON:       // %bb.0:
-; CHECK-NEON-NEXT:    and w8, w0, #0xff
-; CHECK-NEON-NEXT:    and w9, w1, #0x2
-; CHECK-NEON-NEXT:    and w10, w1, #0x1
-; CHECK-NEON-NEXT:    mul w9, w8, w9
-; CHECK-NEON-NEXT:    and w11, w1, #0x4
-; CHECK-NEON-NEXT:    and w12, w1, #0x8
-; CHECK-NEON-NEXT:    mul w10, w8, w10
-; CHECK-NEON-NEXT:    and w13, w1, #0x10
-; CHECK-NEON-NEXT:    and w14, w1, #0x20
-; CHECK-NEON-NEXT:    mul w11, w8, w11
-; CHECK-NEON-NEXT:    and w15, w1, #0x40
-; CHECK-NEON-NEXT:    mul w12, w8, w12
-; CHECK-NEON-NEXT:    mul w13, w8, w13
-; CHECK-NEON-NEXT:    eor w9, w10, w9
-; CHECK-NEON-NEXT:    and w10, w1, #0x80
-; CHECK-NEON-NEXT:    mul w14, w8, w14
+; CHECK-NEON-NEXT:    mov w8, #73 // =0x49
+; CHECK-NEON-NEXT:    mov w9, #146 // =0x92
+; CHECK-NEON-NEXT:    mov w13, #36 // =0x24
+; CHECK-NEON-NEXT:    and w10, w1, w8
+; CHECK-NEON-NEXT:    and w11, w0, w9
+; CHECK-NEON-NEXT:    and w9, w1, w9
+; CHECK-NEON-NEXT:    and w8, w0, w8
+; CHECK-NEON-NEXT:    and w15, w1, w13
+; CHECK-NEON-NEXT:    and w13, w0, w13
+; CHECK-NEON-NEXT:    mul w12, w11, w10
+; CHECK-NEON-NEXT:    mul w14, w8, w9
+; CHECK-NEON-NEXT:    mul w16, w13, w15
+; CHECK-NEON-NEXT:    mul w17, w11, w15
 ; CHECK-NEON-NEXT:    mul w15, w8, w15
-; CHECK-NEON-NEXT:    eor w11, w11, w12
+; CHECK-NEON-NEXT:    eor w12, w14, w12
+; CHECK-NEON-NEXT:    mov w14, #9362 // =0x2492
 ; CHECK-NEON-NEXT:    mul w8, w8, w10
-; CHECK-NEON-NEXT:    eor w9, w9, w11
-; CHECK-NEON-NEXT:    eor w12, w13, w14
-; CHECK-NEON-NEXT:    eor w10, w12, w15
-; CHECK-NEON-NEXT:    eor w9, w9, w10
-; CHECK-NEON-NEXT:    eor w0, w9, w8
+; CHECK-NEON-NEXT:    eor w12, w12, w16
+; CHECK-NEON-NEXT:    mul w11, w11, w9
+; CHECK-NEON-NEXT:    and w12, w12, w14
+; CHECK-NEON-NEXT:    mul w9, w13, w9
+; CHECK-NEON-NEXT:    mul w10, w13, w10
+; CHECK-NEON-NEXT:    eor w8, w8, w17
+; CHECK-NEON-NEXT:    eor w11, w15, w11
+; CHECK-NEON-NEXT:    eor w8, w8, w9
+; CHECK-NEON-NEXT:    mov w9, #4681 // =0x1249
+; CHECK-NEON-NEXT:    and w8, w8, w9
+; CHECK-NEON-NEXT:    eor w9, w11, w10
+; CHECK-NEON-NEXT:    mov w10, #18724 // =0x4924
+; CHECK-NEON-NEXT:    orr w8, w8, w12
+; CHECK-NEON-NEXT:    and w9, w9, w10
+; CHECK-NEON-NEXT:    orr w0, w8, w9
 ; CHECK-NEON-NEXT:    ret
 ;
 ; CHECK-AES-LABEL: clmul_i16_zext:

--- a/llvm/test/CodeGen/PowerPC/clmul-vector.ll
+++ b/llvm/test/CodeGen/PowerPC/clmul-vector.ll
@@ -6,116 +6,70 @@ define <16 x i8> @clmul_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; BE-LABEL: clmul_v16i8:
 ; BE:       # %bb.0:
 ; BE-NEXT:    addis 3, 2, .LCPI0_0@toc@ha
-; BE-NEXT:    vspltisb 4, 2
 ; BE-NEXT:    addi 3, 3, .LCPI0_0@toc@l
-; BE-NEXT:    vand 4, 3, 4
-; BE-NEXT:    lvx 10, 0, 3
+; BE-NEXT:    lvx 4, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI0_1@toc@ha
-; BE-NEXT:    vspltisb 5, 1
 ; BE-NEXT:    addi 3, 3, .LCPI0_1@toc@l
-; BE-NEXT:    vspltisb 0, 4
-; BE-NEXT:    vand 5, 3, 5
-; BE-NEXT:    vspltisb 6, 8
-; BE-NEXT:    vspltisb 8, -1
-; BE-NEXT:    vmuloub 9, 2, 4
-; BE-NEXT:    vmuleub 4, 2, 4
-; BE-NEXT:    vand 1, 3, 0
-; BE-NEXT:    vperm 4, 4, 9, 10
-; BE-NEXT:    vmuloub 9, 2, 5
-; BE-NEXT:    vmuleub 5, 2, 5
-; BE-NEXT:    vand 7, 3, 6
-; BE-NEXT:    vaddubm 6, 6, 6
-; BE-NEXT:    vperm 5, 5, 9, 10
-; BE-NEXT:    vmuloub 9, 2, 1
-; BE-NEXT:    vmuleub 1, 2, 1
-; BE-NEXT:    vperm 1, 1, 9, 10
-; BE-NEXT:    vmuloub 9, 2, 7
-; BE-NEXT:    vmuleub 7, 2, 7
-; BE-NEXT:    vand 6, 3, 6
-; BE-NEXT:    vperm 7, 7, 9, 10
-; BE-NEXT:    vmuloub 9, 2, 6
-; BE-NEXT:    vmuleub 6, 2, 6
-; BE-NEXT:    vperm 6, 6, 9, 10
-; BE-NEXT:    lvx 9, 0, 3
-; BE-NEXT:    vslb 0, 0, 0
-; BE-NEXT:    vslb 8, 8, 8
-; BE-NEXT:    vand 0, 3, 0
-; BE-NEXT:    vand 8, 3, 8
-; BE-NEXT:    vand 3, 3, 9
-; BE-NEXT:    vmuloub 9, 2, 0
-; BE-NEXT:    vmuleub 0, 2, 0
-; BE-NEXT:    vxor 4, 5, 4
-; BE-NEXT:    vperm 0, 0, 9, 10
-; BE-NEXT:    vmuloub 9, 2, 8
-; BE-NEXT:    vmuleub 8, 2, 8
-; BE-NEXT:    vmuloub 5, 2, 3
-; BE-NEXT:    vmuleub 2, 2, 3
-; BE-NEXT:    vxor 3, 4, 1
-; BE-NEXT:    vxor 3, 3, 7
-; BE-NEXT:    vperm 2, 2, 5, 10
-; BE-NEXT:    vxor 3, 3, 6
-; BE-NEXT:    vxor 2, 3, 2
-; BE-NEXT:    vperm 8, 8, 9, 10
-; BE-NEXT:    vxor 2, 2, 0
-; BE-NEXT:    vxor 2, 2, 8
+; BE-NEXT:    lvx 0, 0, 3
+; BE-NEXT:    addis 3, 2, .LCPI0_2@toc@ha
+; BE-NEXT:    vand 5, 3, 4
+; BE-NEXT:    addi 3, 3, .LCPI0_2@toc@l
+; BE-NEXT:    vand 1, 2, 0
+; BE-NEXT:    vand 3, 3, 0
+; BE-NEXT:    vand 2, 2, 4
+; BE-NEXT:    vmuloub 6, 1, 5
+; BE-NEXT:    vmuleub 7, 1, 5
+; BE-NEXT:    vmuloub 8, 2, 3
+; BE-NEXT:    vmuleub 9, 2, 3
+; BE-NEXT:    vmuloub 10, 1, 3
+; BE-NEXT:    vmuleub 3, 1, 3
+; BE-NEXT:    vmuloub 1, 2, 5
+; BE-NEXT:    vmuleub 2, 2, 5
+; BE-NEXT:    lvx 5, 0, 3
+; BE-NEXT:    vperm 6, 7, 6, 5
+; BE-NEXT:    vperm 7, 9, 8, 5
+; BE-NEXT:    vperm 3, 3, 10, 5
+; BE-NEXT:    vperm 2, 2, 1, 5
+; BE-NEXT:    vxor 5, 7, 6
+; BE-NEXT:    vxor 2, 2, 3
+; BE-NEXT:    vand 3, 5, 0
+; BE-NEXT:    vand 2, 2, 4
+; BE-NEXT:    vor 2, 2, 3
 ; BE-NEXT:    blr
 ;
 ; LE-LABEL: clmul_v16i8:
 ; LE:       # %bb.0:
-; LE-NEXT:    vspltisb 4, 2
 ; LE-NEXT:    addis 3, 2, .LCPI0_0@toc@ha
-; LE-NEXT:    vspltisb 5, 1
 ; LE-NEXT:    addi 3, 3, .LCPI0_0@toc@l
-; LE-NEXT:    xxland 36, 35, 36
-; LE-NEXT:    xxland 37, 35, 37
-; LE-NEXT:    vspltisb 0, 4
-; LE-NEXT:    vspltisb 1, 8
 ; LE-NEXT:    lxvd2x 0, 0, 3
-; LE-NEXT:    vmuloub 7, 2, 4
-; LE-NEXT:    vmuleub 4, 2, 4
 ; LE-NEXT:    addis 3, 2, .LCPI0_1@toc@ha
 ; LE-NEXT:    addi 3, 3, .LCPI0_1@toc@l
-; LE-NEXT:    xxswapd 38, 0
-; LE-NEXT:    lxvd2x 0, 0, 3
-; LE-NEXT:    vperm 4, 4, 7, 6
-; LE-NEXT:    vmuloub 7, 2, 5
-; LE-NEXT:    vmuleub 5, 2, 5
-; LE-NEXT:    vperm 5, 5, 7, 6
-; LE-NEXT:    xxland 39, 35, 32
-; LE-NEXT:    vslb 0, 0, 0
-; LE-NEXT:    vmuloub 8, 2, 7
-; LE-NEXT:    vmuleub 7, 2, 7
-; LE-NEXT:    xxland 32, 35, 32
-; LE-NEXT:    vperm 7, 7, 8, 6
-; LE-NEXT:    xxland 40, 35, 33
-; LE-NEXT:    vaddubm 1, 1, 1
-; LE-NEXT:    vmuloub 9, 2, 8
-; LE-NEXT:    vmuleub 8, 2, 8
-; LE-NEXT:    xxland 33, 35, 33
-; LE-NEXT:    vperm 8, 8, 9, 6
-; LE-NEXT:    vmuloub 9, 2, 1
-; LE-NEXT:    vmuleub 1, 2, 1
-; LE-NEXT:    vperm 1, 1, 9, 6
-; LE-NEXT:    xxland 41, 35, 0
-; LE-NEXT:    xxlxor 0, 37, 36
-; LE-NEXT:    vmuloub 10, 2, 9
-; LE-NEXT:    vmuleub 9, 2, 9
-; LE-NEXT:    xxlxor 0, 0, 39
-; LE-NEXT:    xxlxor 0, 0, 40
-; LE-NEXT:    xxlxor 0, 0, 33
-; LE-NEXT:    vperm 9, 9, 10, 6
-; LE-NEXT:    vmuloub 10, 2, 0
-; LE-NEXT:    vmuleub 0, 2, 0
-; LE-NEXT:    xxlxor 0, 0, 41
-; LE-NEXT:    vperm 0, 0, 10, 6
-; LE-NEXT:    xxleqv 42, 42, 42
-; LE-NEXT:    vslb 10, 10, 10
-; LE-NEXT:    xxlxor 0, 0, 32
-; LE-NEXT:    xxland 35, 35, 42
-; LE-NEXT:    vmuloub 10, 2, 3
-; LE-NEXT:    vmuleub 2, 2, 3
-; LE-NEXT:    vperm 2, 2, 10, 6
-; LE-NEXT:    xxlxor 34, 0, 34
+; LE-NEXT:    lxvd2x 1, 0, 3
+; LE-NEXT:    addis 3, 2, .LCPI0_2@toc@ha
+; LE-NEXT:    xxland 37, 35, 0
+; LE-NEXT:    addi 3, 3, .LCPI0_2@toc@l
+; LE-NEXT:    lxvd2x 2, 0, 3
+; LE-NEXT:    xxland 32, 34, 1
+; LE-NEXT:    xxland 35, 35, 1
+; LE-NEXT:    xxland 34, 34, 0
+; LE-NEXT:    vmuloub 1, 0, 5
+; LE-NEXT:    vmuleub 6, 0, 5
+; LE-NEXT:    vmuloub 7, 2, 3
+; LE-NEXT:    xxswapd 36, 2
+; LE-NEXT:    vperm 1, 6, 1, 4
+; LE-NEXT:    vmuloub 6, 0, 3
+; LE-NEXT:    vmuleub 0, 0, 3
+; LE-NEXT:    vmuleub 3, 2, 3
+; LE-NEXT:    vperm 0, 0, 6, 4
+; LE-NEXT:    vmuloub 6, 2, 5
+; LE-NEXT:    vmuleub 2, 2, 5
+; LE-NEXT:    vperm 3, 3, 7, 4
+; LE-NEXT:    xxlxor 2, 35, 33
+; LE-NEXT:    xxland 1, 2, 1
+; LE-NEXT:    vperm 2, 2, 6, 4
+; LE-NEXT:    xxlxor 2, 34, 32
+; LE-NEXT:    xxland 0, 2, 0
+; LE-NEXT:    xxlor 34, 0, 1
 ; LE-NEXT:    blr
   %res = call <16 x i8> @llvm.clmul.v16i8(<16 x i8> %a, <16 x i8> %b)
   ret <16 x i8> %res
@@ -125,159 +79,81 @@ define <8 x i16> @clmul_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; BE-LABEL: clmul_v8i16:
 ; BE:       # %bb.0:
 ; BE-NEXT:    addis 3, 2, .LCPI1_0@toc@ha
-; BE-NEXT:    vspltish 6, 2
+; BE-NEXT:    vxor 4, 4, 4
 ; BE-NEXT:    addi 3, 3, .LCPI1_0@toc@l
-; BE-NEXT:    vand 4, 3, 6
-; BE-NEXT:    lvx 13, 0, 3
+; BE-NEXT:    lvx 5, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI1_1@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI1_1@toc@l
-; BE-NEXT:    vspltish 7, 1
-; BE-NEXT:    lvx 14, 0, 3
+; BE-NEXT:    lvx 1, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI1_2@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI1_2@toc@l
-; BE-NEXT:    vspltish 8, 4
-; BE-NEXT:    lvx 15, 0, 3
-; BE-NEXT:    addis 3, 2, .LCPI1_3@toc@ha
-; BE-NEXT:    addi 3, 3, .LCPI1_3@toc@l
-; BE-NEXT:    vspltish 9, 8
-; BE-NEXT:    vand 5, 3, 7
-; BE-NEXT:    lvx 16, 0, 3
-; BE-NEXT:    addis 3, 2, .LCPI1_4@toc@ha
-; BE-NEXT:    addi 3, 3, .LCPI1_4@toc@l
-; BE-NEXT:    vspltisb 12, -1
-; BE-NEXT:    lvx 17, 0, 3
-; BE-NEXT:    vand 0, 3, 8
-; BE-NEXT:    vand 1, 3, 9
-; BE-NEXT:    vslh 10, 8, 8
-; BE-NEXT:    vsldoi 7, 7, 7, 1
-; BE-NEXT:    vsldoi 6, 6, 6, 1
-; BE-NEXT:    vsldoi 8, 8, 8, 1
-; BE-NEXT:    vslh 11, 9, 9
-; BE-NEXT:    vadduhm 9, 9, 9
-; BE-NEXT:    vslh 12, 12, 12
-; BE-NEXT:    vand 9, 3, 9
-; BE-NEXT:    vand 10, 3, 10
-; BE-NEXT:    vand 7, 3, 7
-; BE-NEXT:    vand 6, 3, 6
-; BE-NEXT:    vand 8, 3, 8
-; BE-NEXT:    vand 11, 3, 11
-; BE-NEXT:    vand 12, 3, 12
-; BE-NEXT:    vand 13, 3, 13
-; BE-NEXT:    vand 14, 3, 14
-; BE-NEXT:    vand 15, 3, 15
-; BE-NEXT:    vand 16, 3, 16
-; BE-NEXT:    vand 3, 3, 17
-; BE-NEXT:    vxor 17, 17, 17
-; BE-NEXT:    vmladduhm 4, 2, 4, 17
-; BE-NEXT:    vmladduhm 5, 2, 5, 17
-; BE-NEXT:    vmladduhm 0, 2, 0, 17
-; BE-NEXT:    vmladduhm 1, 2, 1, 17
-; BE-NEXT:    vmladduhm 9, 2, 9, 17
-; BE-NEXT:    vmladduhm 10, 2, 10, 17
-; BE-NEXT:    vmladduhm 7, 2, 7, 17
-; BE-NEXT:    vmladduhm 6, 2, 6, 17
-; BE-NEXT:    vmladduhm 8, 2, 8, 17
-; BE-NEXT:    vmladduhm 11, 2, 11, 17
-; BE-NEXT:    vmladduhm 12, 2, 12, 17
-; BE-NEXT:    vmladduhm 13, 2, 13, 17
-; BE-NEXT:    vmladduhm 14, 2, 14, 17
-; BE-NEXT:    vmladduhm 15, 2, 15, 17
-; BE-NEXT:    vmladduhm 16, 2, 16, 17
-; BE-NEXT:    vmladduhm 2, 2, 3, 17
-; BE-NEXT:    vxor 3, 5, 4
-; BE-NEXT:    vxor 3, 3, 0
-; BE-NEXT:    vxor 3, 3, 1
-; BE-NEXT:    vxor 3, 3, 9
-; BE-NEXT:    vxor 3, 3, 13
-; BE-NEXT:    vxor 3, 3, 10
-; BE-NEXT:    vxor 3, 3, 14
-; BE-NEXT:    vxor 3, 3, 7
+; BE-NEXT:    lvx 9, 0, 3
+; BE-NEXT:    vand 0, 3, 5
+; BE-NEXT:    vand 6, 2, 1
+; BE-NEXT:    vand 7, 3, 1
+; BE-NEXT:    vand 8, 2, 5
+; BE-NEXT:    vand 3, 3, 9
+; BE-NEXT:    vand 2, 2, 9
+; BE-NEXT:    vmladduhm 10, 6, 0, 4
+; BE-NEXT:    vmladduhm 11, 8, 7, 4
+; BE-NEXT:    vmladduhm 12, 2, 3, 4
+; BE-NEXT:    vmladduhm 13, 6, 3, 4
+; BE-NEXT:    vmladduhm 3, 8, 3, 4
+; BE-NEXT:    vmladduhm 8, 8, 0, 4
+; BE-NEXT:    vmladduhm 6, 6, 7, 4
+; BE-NEXT:    vmladduhm 7, 2, 7, 4
+; BE-NEXT:    vmladduhm 2, 2, 0, 4
+; BE-NEXT:    vxor 4, 11, 10
+; BE-NEXT:    vxor 0, 8, 13
 ; BE-NEXT:    vxor 3, 3, 6
-; BE-NEXT:    vxor 3, 3, 8
-; BE-NEXT:    vxor 3, 3, 11
-; BE-NEXT:    vxor 3, 3, 15
-; BE-NEXT:    vxor 3, 3, 16
+; BE-NEXT:    vxor 4, 4, 12
+; BE-NEXT:    vxor 0, 0, 7
 ; BE-NEXT:    vxor 2, 3, 2
-; BE-NEXT:    vxor 2, 2, 12
+; BE-NEXT:    vand 3, 4, 1
+; BE-NEXT:    vand 4, 0, 5
+; BE-NEXT:    vand 2, 2, 9
+; BE-NEXT:    vor 3, 4, 3
+; BE-NEXT:    vor 2, 3, 2
 ; BE-NEXT:    blr
 ;
 ; LE-LABEL: clmul_v8i16:
 ; LE:       # %bb.0:
-; LE-NEXT:    vspltish 5, 2
-; LE-NEXT:    vspltish 0, 1
 ; LE-NEXT:    addis 3, 2, .LCPI1_0@toc@ha
-; LE-NEXT:    xxland 41, 35, 37
-; LE-NEXT:    vspltish 1, 4
-; LE-NEXT:    vspltish 4, 8
+; LE-NEXT:    vxor 0, 0, 0
 ; LE-NEXT:    addi 3, 3, .LCPI1_0@toc@l
-; LE-NEXT:    lxvd2x 1, 0, 3
-; LE-NEXT:    vsldoi 6, 0, 0, 1
-; LE-NEXT:    xxland 32, 35, 32
-; LE-NEXT:    vsldoi 7, 5, 5, 1
-; LE-NEXT:    vxor 5, 5, 5
-; LE-NEXT:    vmladduhm 9, 2, 9, 5
-; LE-NEXT:    vmladduhm 0, 2, 0, 5
+; LE-NEXT:    lxvd2x 0, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI1_1@toc@ha
 ; LE-NEXT:    addi 3, 3, .LCPI1_1@toc@l
-; LE-NEXT:    vsldoi 8, 1, 1, 1
-; LE-NEXT:    xxlxor 0, 32, 41
-; LE-NEXT:    xxland 32, 35, 33
-; LE-NEXT:    vmladduhm 0, 2, 0, 5
-; LE-NEXT:    xxlxor 0, 0, 32
-; LE-NEXT:    xxland 32, 35, 36
-; LE-NEXT:    vmladduhm 0, 2, 0, 5
-; LE-NEXT:    xxlxor 0, 0, 32
-; LE-NEXT:    vadduhm 0, 4, 4
-; LE-NEXT:    vslh 4, 4, 4
-; LE-NEXT:    xxland 32, 35, 32
-; LE-NEXT:    xxland 36, 35, 36
-; LE-NEXT:    vmladduhm 0, 2, 0, 5
-; LE-NEXT:    vmladduhm 4, 2, 4, 5
-; LE-NEXT:    xxlxor 0, 0, 32
-; LE-NEXT:    xxland 32, 35, 1
 ; LE-NEXT:    lxvd2x 1, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI1_2@toc@ha
-; LE-NEXT:    vmladduhm 0, 2, 0, 5
+; LE-NEXT:    xxland 36, 35, 0
+; LE-NEXT:    xxland 39, 34, 0
 ; LE-NEXT:    addi 3, 3, .LCPI1_2@toc@l
-; LE-NEXT:    xxlxor 0, 0, 32
-; LE-NEXT:    vslh 0, 1, 1
-; LE-NEXT:    xxland 32, 35, 32
-; LE-NEXT:    vmladduhm 0, 2, 0, 5
-; LE-NEXT:    xxlxor 0, 0, 32
-; LE-NEXT:    xxland 32, 35, 1
-; LE-NEXT:    lxvd2x 1, 0, 3
-; LE-NEXT:    addis 3, 2, .LCPI1_3@toc@ha
-; LE-NEXT:    vmladduhm 0, 2, 0, 5
-; LE-NEXT:    addi 3, 3, .LCPI1_3@toc@l
-; LE-NEXT:    xxlxor 0, 0, 32
-; LE-NEXT:    xxland 32, 35, 38
-; LE-NEXT:    vmladduhm 0, 2, 0, 5
-; LE-NEXT:    xxlxor 0, 0, 32
-; LE-NEXT:    xxland 32, 35, 39
-; LE-NEXT:    vmladduhm 0, 2, 0, 5
-; LE-NEXT:    xxlxor 0, 0, 32
-; LE-NEXT:    xxland 32, 35, 40
-; LE-NEXT:    vmladduhm 0, 2, 0, 5
-; LE-NEXT:    xxlxor 0, 0, 32
-; LE-NEXT:    xxlxor 0, 0, 36
-; LE-NEXT:    xxland 36, 35, 1
-; LE-NEXT:    lxvd2x 1, 0, 3
-; LE-NEXT:    addis 3, 2, .LCPI1_4@toc@ha
-; LE-NEXT:    vmladduhm 4, 2, 4, 5
-; LE-NEXT:    addi 3, 3, .LCPI1_4@toc@l
-; LE-NEXT:    xxlxor 0, 0, 36
-; LE-NEXT:    xxland 36, 35, 1
-; LE-NEXT:    lxvd2x 1, 0, 3
-; LE-NEXT:    vmladduhm 4, 2, 4, 5
-; LE-NEXT:    xxlxor 0, 0, 36
-; LE-NEXT:    xxland 36, 35, 1
-; LE-NEXT:    vmladduhm 4, 2, 4, 5
-; LE-NEXT:    xxlxor 0, 0, 36
-; LE-NEXT:    xxleqv 36, 36, 36
-; LE-NEXT:    vslh 4, 4, 4
-; LE-NEXT:    xxland 35, 35, 36
-; LE-NEXT:    vmladduhm 2, 2, 3, 5
-; LE-NEXT:    xxlxor 34, 0, 34
+; LE-NEXT:    lxvd2x 3, 0, 3
+; LE-NEXT:    xxland 37, 34, 1
+; LE-NEXT:    xxland 38, 35, 1
+; LE-NEXT:    vmladduhm 1, 5, 4, 0
+; LE-NEXT:    vmladduhm 8, 7, 6, 0
+; LE-NEXT:    xxland 35, 35, 3
+; LE-NEXT:    xxland 34, 34, 3
+; LE-NEXT:    xxlxor 2, 40, 33
+; LE-NEXT:    vmladduhm 1, 2, 3, 0
+; LE-NEXT:    vmladduhm 8, 7, 4, 0
+; LE-NEXT:    xxlxor 2, 2, 33
+; LE-NEXT:    vmladduhm 1, 5, 3, 0
+; LE-NEXT:    vmladduhm 5, 5, 6, 0
+; LE-NEXT:    vmladduhm 3, 7, 3, 0
+; LE-NEXT:    xxland 1, 2, 1
+; LE-NEXT:    xxlxor 2, 40, 33
+; LE-NEXT:    vmladduhm 1, 2, 6, 0
+; LE-NEXT:    vmladduhm 2, 2, 4, 0
+; LE-NEXT:    xxlxor 2, 2, 33
+; LE-NEXT:    xxland 0, 2, 0
+; LE-NEXT:    xxlor 0, 0, 1
+; LE-NEXT:    xxlxor 1, 35, 37
+; LE-NEXT:    xxlxor 1, 1, 34
+; LE-NEXT:    xxland 1, 1, 3
+; LE-NEXT:    xxlor 34, 0, 1
 ; LE-NEXT:    blr
   %res = call <8 x i16> @llvm.clmul.v8i16(<8 x i16> %a, <8 x i16> %b)
   ret <8 x i16> %res
@@ -1370,119 +1246,84 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 define <16 x i8> @clmulr_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; BE-LABEL: clmulr_v16i8:
 ; BE:       # %bb.0:
-; BE-NEXT:    li 3, -48
 ; BE-NEXT:    vspltisb 4, 4
-; BE-NEXT:    stvx 29, 1, 3 # 16-byte Folded Spill
-; BE-NEXT:    li 3, -32
-; BE-NEXT:    vsrb 1, 3, 4
-; BE-NEXT:    vspltisb 5, 15
-; BE-NEXT:    stvx 30, 1, 3 # 16-byte Folded Spill
-; BE-NEXT:    li 3, -16
-; BE-NEXT:    vspltisb 7, -1
-; BE-NEXT:    stvx 31, 1, 3 # 16-byte Folded Spill
 ; BE-NEXT:    addis 3, 2, .LCPI4_0@toc@ha
+; BE-NEXT:    vsrb 0, 3, 4
 ; BE-NEXT:    addi 3, 3, .LCPI4_0@toc@l
+; BE-NEXT:    vspltisb 5, 15
 ; BE-NEXT:    vand 3, 3, 5
-; BE-NEXT:    vspltisb 13, 8
 ; BE-NEXT:    vslb 3, 3, 4
-; BE-NEXT:    vsrb 0, 2, 4
+; BE-NEXT:    vsrb 1, 2, 4
 ; BE-NEXT:    vand 2, 2, 5
-; BE-NEXT:    vor 1, 1, 3
+; BE-NEXT:    vor 0, 0, 3
 ; BE-NEXT:    lvx 3, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI4_1@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI4_1@toc@l
-; BE-NEXT:    vslb 2, 2, 4
-; BE-NEXT:    vor 0, 0, 2
-; BE-NEXT:    vspltisb 2, 2
-; BE-NEXT:    vsrb 9, 1, 2
-; BE-NEXT:    vand 1, 1, 3
-; BE-NEXT:    vand 9, 9, 3
-; BE-NEXT:    vslb 1, 1, 2
-; BE-NEXT:    vsrb 8, 0, 2
-; BE-NEXT:    vand 0, 0, 3
-; BE-NEXT:    vor 9, 9, 1
-; BE-NEXT:    lvx 1, 0, 3
-; BE-NEXT:    addis 3, 2, .LCPI4_3@toc@ha
-; BE-NEXT:    addi 3, 3, .LCPI4_3@toc@l
-; BE-NEXT:    lvx 15, 0, 3
+; BE-NEXT:    lvx 8, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI4_2@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI4_2@toc@l
-; BE-NEXT:    vand 8, 8, 3
+; BE-NEXT:    vslb 2, 2, 4
+; BE-NEXT:    vor 1, 1, 2
+; BE-NEXT:    vspltisb 2, 2
+; BE-NEXT:    vsrb 6, 0, 2
+; BE-NEXT:    vsrb 7, 1, 2
+; BE-NEXT:    vand 0, 0, 3
+; BE-NEXT:    vand 1, 1, 3
+; BE-NEXT:    vand 6, 6, 3
+; BE-NEXT:    vand 7, 7, 3
 ; BE-NEXT:    vslb 0, 0, 2
-; BE-NEXT:    vor 8, 8, 0
-; BE-NEXT:    vspltisb 0, 1
-; BE-NEXT:    vsrb 11, 9, 0
-; BE-NEXT:    vand 9, 9, 1
-; BE-NEXT:    vaddubm 9, 9, 9
-; BE-NEXT:    vand 11, 11, 1
-; BE-NEXT:    vsrb 10, 8, 0
-; BE-NEXT:    vand 8, 8, 1
-; BE-NEXT:    vaddubm 8, 8, 8
-; BE-NEXT:    vor 9, 11, 9
-; BE-NEXT:    vslb 6, 4, 4
-; BE-NEXT:    vslb 7, 7, 7
-; BE-NEXT:    vand 10, 10, 1
-; BE-NEXT:    vand 14, 9, 13
-; BE-NEXT:    vaddubm 13, 13, 13
-; BE-NEXT:    vor 8, 10, 8
-; BE-NEXT:    vand 10, 9, 2
-; BE-NEXT:    vand 11, 9, 0
-; BE-NEXT:    vand 12, 9, 4
-; BE-NEXT:    vand 13, 9, 13
-; BE-NEXT:    vand 15, 9, 15
-; BE-NEXT:    vand 6, 9, 6
-; BE-NEXT:    vand 7, 9, 7
-; BE-NEXT:    vmuloub 9, 8, 10
-; BE-NEXT:    vmuleub 10, 8, 10
-; BE-NEXT:    vmuloub 16, 8, 11
-; BE-NEXT:    vmuleub 11, 8, 11
-; BE-NEXT:    vmuloub 17, 8, 12
-; BE-NEXT:    vmuleub 12, 8, 12
-; BE-NEXT:    vmuloub 18, 8, 14
-; BE-NEXT:    vmuleub 14, 8, 14
-; BE-NEXT:    vmuloub 19, 8, 13
-; BE-NEXT:    vmuleub 13, 8, 13
-; BE-NEXT:    vmuloub 31, 8, 15
-; BE-NEXT:    vmuleub 15, 8, 15
-; BE-NEXT:    vmuloub 30, 8, 6
-; BE-NEXT:    vmuleub 6, 8, 6
-; BE-NEXT:    vmuloub 29, 8, 7
-; BE-NEXT:    vmuleub 7, 8, 7
-; BE-NEXT:    lvx 8, 0, 3
-; BE-NEXT:    li 3, -16
-; BE-NEXT:    vperm 9, 10, 9, 8
-; BE-NEXT:    vperm 10, 11, 16, 8
-; BE-NEXT:    vperm 11, 12, 17, 8
-; BE-NEXT:    vperm 12, 14, 18, 8
-; BE-NEXT:    vperm 13, 13, 19, 8
-; BE-NEXT:    vperm 14, 15, 31, 8
-; BE-NEXT:    lvx 31, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -32
-; BE-NEXT:    vperm 6, 6, 30, 8
-; BE-NEXT:    lvx 30, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -48
-; BE-NEXT:    vperm 7, 7, 29, 8
-; BE-NEXT:    lvx 29, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    vxor 8, 10, 9
-; BE-NEXT:    vxor 8, 8, 11
-; BE-NEXT:    vxor 8, 8, 12
-; BE-NEXT:    vxor 8, 8, 13
-; BE-NEXT:    vxor 8, 8, 14
-; BE-NEXT:    vxor 6, 8, 6
-; BE-NEXT:    vxor 6, 6, 7
-; BE-NEXT:    vand 5, 6, 5
-; BE-NEXT:    vsrb 7, 6, 4
+; BE-NEXT:    vslb 1, 1, 2
+; BE-NEXT:    vor 0, 6, 0
+; BE-NEXT:    vspltisb 6, 1
+; BE-NEXT:    vor 1, 7, 1
+; BE-NEXT:    vsrb 9, 1, 6
+; BE-NEXT:    vand 1, 1, 8
+; BE-NEXT:    vaddubm 1, 1, 1
+; BE-NEXT:    vand 9, 9, 8
+; BE-NEXT:    vsrb 7, 0, 6
+; BE-NEXT:    vand 0, 0, 8
+; BE-NEXT:    vaddubm 0, 0, 0
+; BE-NEXT:    vor 1, 9, 1
+; BE-NEXT:    lvx 9, 0, 3
+; BE-NEXT:    addis 3, 2, .LCPI4_3@toc@ha
+; BE-NEXT:    addi 3, 3, .LCPI4_3@toc@l
+; BE-NEXT:    vand 7, 7, 8
+; BE-NEXT:    vor 0, 7, 0
+; BE-NEXT:    vand 7, 0, 8
+; BE-NEXT:    vand 10, 1, 9
+; BE-NEXT:    vand 0, 0, 9
+; BE-NEXT:    vand 1, 1, 8
+; BE-NEXT:    vmuloub 11, 10, 7
+; BE-NEXT:    vmuleub 12, 10, 7
+; BE-NEXT:    vmuloub 13, 1, 0
+; BE-NEXT:    vmuleub 14, 1, 0
+; BE-NEXT:    vmuloub 15, 10, 0
+; BE-NEXT:    vmuleub 0, 10, 0
+; BE-NEXT:    vmuloub 10, 1, 7
+; BE-NEXT:    vmuleub 1, 1, 7
+; BE-NEXT:    lvx 7, 0, 3
+; BE-NEXT:    vperm 11, 12, 11, 7
+; BE-NEXT:    vperm 12, 14, 13, 7
+; BE-NEXT:    vperm 0, 0, 15, 7
+; BE-NEXT:    vperm 1, 1, 10, 7
+; BE-NEXT:    vxor 7, 12, 11
+; BE-NEXT:    vxor 0, 1, 0
+; BE-NEXT:    vand 1, 7, 9
+; BE-NEXT:    vand 0, 0, 8
+; BE-NEXT:    vor 0, 0, 1
+; BE-NEXT:    vand 5, 0, 5
+; BE-NEXT:    vsrb 1, 0, 4
 ; BE-NEXT:    vslb 4, 5, 4
-; BE-NEXT:    vor 4, 7, 4
+; BE-NEXT:    vor 4, 1, 4
 ; BE-NEXT:    vand 5, 4, 3
 ; BE-NEXT:    vsrb 4, 4, 2
 ; BE-NEXT:    vslb 2, 5, 2
 ; BE-NEXT:    vand 3, 4, 3
 ; BE-NEXT:    vor 2, 3, 2
-; BE-NEXT:    vsrb 3, 2, 0
-; BE-NEXT:    vand 2, 2, 1
+; BE-NEXT:    vsrb 3, 2, 6
+; BE-NEXT:    vand 2, 2, 8
 ; BE-NEXT:    vaddubm 2, 2, 2
-; BE-NEXT:    vand 3, 3, 1
+; BE-NEXT:    vand 3, 3, 8
 ; BE-NEXT:    vor 2, 3, 2
 ; BE-NEXT:    blr
 ;
@@ -1503,77 +1344,54 @@ define <16 x i8> @clmulr_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; LE-NEXT:    vspltisb 0, 1
 ; LE-NEXT:    addi 3, 3, .LCPI4_1@toc@l
 ; LE-NEXT:    vsrb 1, 3, 5
-; LE-NEXT:    vsrb 7, 2, 5
-; LE-NEXT:    vspltisb 6, 8
+; LE-NEXT:    vsrb 6, 2, 5
 ; LE-NEXT:    lxvd2x 1, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI4_2@toc@ha
 ; LE-NEXT:    xxland 35, 35, 0
 ; LE-NEXT:    xxland 34, 34, 0
 ; LE-NEXT:    xxland 2, 33, 0
-; LE-NEXT:    xxland 3, 39, 0
+; LE-NEXT:    xxland 3, 38, 0
 ; LE-NEXT:    addi 3, 3, .LCPI4_2@toc@l
 ; LE-NEXT:    vslb 3, 3, 5
 ; LE-NEXT:    vslb 2, 2, 5
 ; LE-NEXT:    xxlor 35, 2, 35
 ; LE-NEXT:    xxlor 34, 3, 34
-; LE-NEXT:    lxvd2x 3, 0, 3
+; LE-NEXT:    lxvd2x 2, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI4_3@toc@ha
 ; LE-NEXT:    vsrb 1, 3, 0
 ; LE-NEXT:    xxland 35, 35, 1
-; LE-NEXT:    vsrb 7, 2, 0
+; LE-NEXT:    vsrb 6, 2, 0
 ; LE-NEXT:    xxland 34, 34, 1
 ; LE-NEXT:    addi 3, 3, .LCPI4_3@toc@l
-; LE-NEXT:    xxland 2, 33, 1
+; LE-NEXT:    xxland 3, 33, 1
 ; LE-NEXT:    vaddubm 3, 3, 3
+; LE-NEXT:    xxland 4, 38, 1
 ; LE-NEXT:    vaddubm 2, 2, 2
-; LE-NEXT:    xxlor 2, 2, 35
-; LE-NEXT:    xxland 35, 2, 37
-; LE-NEXT:    xxswapd 33, 3
-; LE-NEXT:    xxland 3, 39, 1
-; LE-NEXT:    xxlor 34, 3, 34
-; LE-NEXT:    lxvd2x 3, 0, 3
-; LE-NEXT:    vmuloub 7, 2, 3
-; LE-NEXT:    vmuleub 3, 2, 3
-; LE-NEXT:    vperm 3, 3, 7, 1
-; LE-NEXT:    xxland 39, 2, 32
-; LE-NEXT:    vmuloub 8, 2, 7
-; LE-NEXT:    vmuleub 7, 2, 7
-; LE-NEXT:    vperm 7, 7, 8, 1
-; LE-NEXT:    xxland 40, 2, 36
-; LE-NEXT:    vmuloub 9, 2, 8
-; LE-NEXT:    vmuleub 8, 2, 8
-; LE-NEXT:    vperm 8, 8, 9, 1
-; LE-NEXT:    xxland 41, 2, 38
-; LE-NEXT:    vaddubm 6, 6, 6
-; LE-NEXT:    vmuloub 10, 2, 9
-; LE-NEXT:    vmuleub 9, 2, 9
-; LE-NEXT:    xxland 38, 2, 38
-; LE-NEXT:    vperm 9, 9, 10, 1
-; LE-NEXT:    vmuloub 10, 2, 6
-; LE-NEXT:    vmuleub 6, 2, 6
-; LE-NEXT:    vperm 6, 6, 10, 1
-; LE-NEXT:    xxland 42, 2, 3
-; LE-NEXT:    vmuloub 11, 2, 10
-; LE-NEXT:    vmuleub 10, 2, 10
-; LE-NEXT:    vperm 10, 10, 11, 1
-; LE-NEXT:    vslb 11, 4, 4
-; LE-NEXT:    xxland 43, 2, 43
-; LE-NEXT:    vmuloub 12, 2, 11
-; LE-NEXT:    vmuleub 11, 2, 11
-; LE-NEXT:    vperm 11, 11, 12, 1
-; LE-NEXT:    xxleqv 44, 44, 44
-; LE-NEXT:    vslb 12, 12, 12
-; LE-NEXT:    xxland 44, 2, 44
-; LE-NEXT:    xxlxor 2, 39, 35
-; LE-NEXT:    xxlxor 2, 2, 40
-; LE-NEXT:    vmuloub 13, 2, 12
-; LE-NEXT:    vmuleub 2, 2, 12
-; LE-NEXT:    xxlxor 2, 2, 41
-; LE-NEXT:    xxlxor 2, 2, 38
-; LE-NEXT:    xxlxor 2, 2, 42
-; LE-NEXT:    xxlxor 2, 2, 43
-; LE-NEXT:    vperm 2, 2, 13, 1
-; LE-NEXT:    xxlxor 34, 2, 34
+; LE-NEXT:    lxvd2x 5, 0, 3
+; LE-NEXT:    xxlor 3, 3, 35
+; LE-NEXT:    xxlor 4, 4, 34
+; LE-NEXT:    xxland 35, 3, 1
+; LE-NEXT:    xxland 33, 4, 2
+; LE-NEXT:    xxland 38, 3, 2
+; LE-NEXT:    xxland 39, 4, 1
+; LE-NEXT:    vmuloub 8, 1, 3
+; LE-NEXT:    vmuleub 9, 1, 3
+; LE-NEXT:    vmuloub 10, 7, 6
+; LE-NEXT:    xxswapd 34, 5
+; LE-NEXT:    vperm 8, 9, 8, 2
+; LE-NEXT:    vmuloub 9, 1, 6
+; LE-NEXT:    vmuleub 1, 1, 6
+; LE-NEXT:    vmuleub 6, 7, 6
+; LE-NEXT:    vperm 1, 1, 9, 2
+; LE-NEXT:    vmuloub 9, 7, 3
+; LE-NEXT:    vmuleub 3, 7, 3
+; LE-NEXT:    vperm 6, 6, 10, 2
+; LE-NEXT:    xxlxor 3, 38, 40
+; LE-NEXT:    xxland 2, 3, 2
+; LE-NEXT:    vperm 2, 3, 9, 2
+; LE-NEXT:    xxlxor 3, 34, 33
+; LE-NEXT:    xxland 3, 3, 1
+; LE-NEXT:    xxlor 34, 3, 2
 ; LE-NEXT:    vslb 3, 2, 4
 ; LE-NEXT:    vsrb 2, 2, 4
 ; LE-NEXT:    xxlor 34, 34, 35
@@ -1599,288 +1417,194 @@ define <16 x i8> @clmulr_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 define <8 x i16> @clmulr_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; BE-LABEL: clmulr_v8i16:
 ; BE:       # %bb.0:
-; BE-NEXT:    li 3, -80
-; BE-NEXT:    vspltisb 5, -1
-; BE-NEXT:    stvx 27, 1, 3 # 16-byte Folded Spill
-; BE-NEXT:    li 3, -64
-; BE-NEXT:    vslh 16, 5, 5
-; BE-NEXT:    vspltish 4, 4
-; BE-NEXT:    stvx 28, 1, 3 # 16-byte Folded Spill
-; BE-NEXT:    li 3, -48
-; BE-NEXT:    vspltish 8, 1
-; BE-NEXT:    stvx 29, 1, 3 # 16-byte Folded Spill
-; BE-NEXT:    li 3, -32
-; BE-NEXT:    vspltish 14, 2
-; BE-NEXT:    vslh 0, 4, 4
-; BE-NEXT:    stvx 30, 1, 3 # 16-byte Folded Spill
 ; BE-NEXT:    li 3, -16
-; BE-NEXT:    vspltish 15, 8
+; BE-NEXT:    vxor 1, 1, 1
 ; BE-NEXT:    stvx 31, 1, 3 # 16-byte Folded Spill
 ; BE-NEXT:    addis 3, 2, .LCPI5_0@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI5_0@toc@l
-; BE-NEXT:    lvx 5, 0, 3
+; BE-NEXT:    lvx 4, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI5_1@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI5_1@toc@l
-; BE-NEXT:    vsldoi 7, 8, 8, 1
-; BE-NEXT:    vperm 1, 2, 2, 5
-; BE-NEXT:    vspltisb 2, 4
-; BE-NEXT:    vperm 6, 3, 3, 5
+; BE-NEXT:    vperm 5, 3, 3, 4
 ; BE-NEXT:    vspltisb 3, 15
-; BE-NEXT:    vsrb 10, 1, 2
-; BE-NEXT:    vand 1, 1, 3
-; BE-NEXT:    vslb 1, 1, 2
-; BE-NEXT:    vsrb 12, 6, 2
-; BE-NEXT:    vand 6, 6, 3
-; BE-NEXT:    vor 10, 10, 1
-; BE-NEXT:    lvx 1, 0, 3
+; BE-NEXT:    vperm 0, 2, 2, 4
+; BE-NEXT:    vspltisb 2, 4
+; BE-NEXT:    vsrb 6, 5, 2
+; BE-NEXT:    vand 5, 5, 3
+; BE-NEXT:    vslb 5, 5, 2
+; BE-NEXT:    vsrb 7, 0, 2
+; BE-NEXT:    vand 0, 0, 3
+; BE-NEXT:    vor 6, 6, 5
+; BE-NEXT:    lvx 5, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI5_2@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI5_2@toc@l
-; BE-NEXT:    vslb 6, 6, 2
-; BE-NEXT:    vor 12, 12, 6
-; BE-NEXT:    vspltisb 6, 2
-; BE-NEXT:    vand 18, 12, 1
-; BE-NEXT:    vsrb 12, 12, 6
-; BE-NEXT:    vslb 18, 18, 6
-; BE-NEXT:    vand 12, 12, 1
-; BE-NEXT:    vand 17, 10, 1
-; BE-NEXT:    vsrb 10, 10, 6
-; BE-NEXT:    vor 18, 12, 18
-; BE-NEXT:    lvx 12, 0, 3
+; BE-NEXT:    vslb 0, 0, 2
+; BE-NEXT:    vor 7, 7, 0
+; BE-NEXT:    vspltisb 0, 2
+; BE-NEXT:    vand 9, 7, 5
+; BE-NEXT:    vsrb 7, 7, 0
+; BE-NEXT:    vslb 9, 9, 0
+; BE-NEXT:    vand 7, 7, 5
+; BE-NEXT:    vand 8, 6, 5
+; BE-NEXT:    vsrb 6, 6, 0
+; BE-NEXT:    vor 9, 7, 9
+; BE-NEXT:    lvx 7, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI5_3@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI5_3@toc@l
-; BE-NEXT:    vslb 17, 17, 6
-; BE-NEXT:    vand 10, 10, 1
-; BE-NEXT:    vor 17, 10, 17
-; BE-NEXT:    vspltisb 10, 1
-; BE-NEXT:    vsrb 31, 18, 10
-; BE-NEXT:    vand 18, 18, 12
-; BE-NEXT:    vaddubm 18, 18, 18
-; BE-NEXT:    vand 31, 31, 12
-; BE-NEXT:    vor 18, 31, 18
-; BE-NEXT:    lvx 31, 0, 3
+; BE-NEXT:    vslb 8, 8, 0
+; BE-NEXT:    vand 6, 6, 5
+; BE-NEXT:    vor 8, 6, 8
+; BE-NEXT:    vspltisb 6, 1
+; BE-NEXT:    vsrb 10, 8, 6
+; BE-NEXT:    vand 8, 8, 7
+; BE-NEXT:    vaddubm 8, 8, 8
+; BE-NEXT:    vand 10, 10, 7
+; BE-NEXT:    vor 8, 10, 8
+; BE-NEXT:    lvx 10, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI5_4@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI5_4@toc@l
-; BE-NEXT:    lvx 30, 0, 3
+; BE-NEXT:    lvx 12, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI5_5@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI5_5@toc@l
-; BE-NEXT:    lvx 29, 0, 3
-; BE-NEXT:    addis 3, 2, .LCPI5_6@toc@ha
-; BE-NEXT:    addi 3, 3, .LCPI5_6@toc@l
-; BE-NEXT:    vsrb 19, 17, 10
-; BE-NEXT:    lvx 28, 0, 3
-; BE-NEXT:    addis 3, 2, .LCPI5_7@toc@ha
-; BE-NEXT:    addi 3, 3, .LCPI5_7@toc@l
-; BE-NEXT:    lvx 27, 0, 3
+; BE-NEXT:    lvx 16, 0, 3
 ; BE-NEXT:    li 3, -16
-; BE-NEXT:    vand 17, 17, 12
-; BE-NEXT:    vaddubm 17, 17, 17
-; BE-NEXT:    vand 19, 19, 12
-; BE-NEXT:    vsldoi 9, 14, 14, 1
-; BE-NEXT:    vsldoi 11, 4, 4, 1
-; BE-NEXT:    vslh 13, 15, 15
-; BE-NEXT:    vor 17, 19, 17
-; BE-NEXT:    vand 19, 18, 15
-; BE-NEXT:    vadduhm 15, 15, 15
-; BE-NEXT:    vand 14, 18, 14
-; BE-NEXT:    vand 8, 18, 8
-; BE-NEXT:    vand 4, 18, 4
-; BE-NEXT:    vand 15, 18, 15
-; BE-NEXT:    vand 31, 18, 31
-; BE-NEXT:    vand 0, 18, 0
-; BE-NEXT:    vand 30, 18, 30
-; BE-NEXT:    vand 7, 18, 7
-; BE-NEXT:    vand 9, 18, 9
-; BE-NEXT:    vand 11, 18, 11
-; BE-NEXT:    vand 13, 18, 13
-; BE-NEXT:    vand 29, 18, 29
-; BE-NEXT:    vand 28, 18, 28
-; BE-NEXT:    vand 27, 18, 27
-; BE-NEXT:    vand 16, 18, 16
-; BE-NEXT:    vxor 18, 18, 18
-; BE-NEXT:    vmladduhm 14, 17, 14, 18
-; BE-NEXT:    vmladduhm 8, 17, 8, 18
-; BE-NEXT:    vmladduhm 4, 17, 4, 18
-; BE-NEXT:    vxor 8, 8, 14
-; BE-NEXT:    vmladduhm 19, 17, 19, 18
-; BE-NEXT:    vxor 4, 8, 4
-; BE-NEXT:    vmladduhm 15, 17, 15, 18
-; BE-NEXT:    vxor 4, 4, 19
-; BE-NEXT:    vmladduhm 31, 17, 31, 18
-; BE-NEXT:    vxor 4, 4, 15
-; BE-NEXT:    vmladduhm 0, 17, 0, 18
-; BE-NEXT:    vxor 4, 4, 31
+; BE-NEXT:    vsrb 11, 9, 6
+; BE-NEXT:    vand 9, 9, 7
+; BE-NEXT:    vaddubm 9, 9, 9
+; BE-NEXT:    vand 11, 11, 7
+; BE-NEXT:    vor 9, 11, 9
+; BE-NEXT:    vand 11, 8, 10
+; BE-NEXT:    vand 13, 9, 12
+; BE-NEXT:    vand 14, 8, 12
+; BE-NEXT:    vand 15, 9, 10
+; BE-NEXT:    vand 8, 8, 16
+; BE-NEXT:    vand 9, 9, 16
+; BE-NEXT:    vmladduhm 17, 13, 11, 1
+; BE-NEXT:    vmladduhm 18, 15, 14, 1
+; BE-NEXT:    vmladduhm 19, 9, 8, 1
+; BE-NEXT:    vmladduhm 31, 13, 8, 1
+; BE-NEXT:    vmladduhm 8, 15, 8, 1
+; BE-NEXT:    vmladduhm 15, 15, 11, 1
+; BE-NEXT:    vmladduhm 13, 13, 14, 1
+; BE-NEXT:    vmladduhm 14, 9, 14, 1
+; BE-NEXT:    vmladduhm 1, 9, 11, 1
+; BE-NEXT:    vxor 9, 18, 17
+; BE-NEXT:    vxor 11, 15, 31
 ; BE-NEXT:    lvx 31, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -32
-; BE-NEXT:    vmladduhm 30, 17, 30, 18
-; BE-NEXT:    vxor 4, 4, 0
-; BE-NEXT:    vmladduhm 7, 17, 7, 18
-; BE-NEXT:    vxor 4, 4, 30
-; BE-NEXT:    lvx 30, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -48
-; BE-NEXT:    vmladduhm 9, 17, 9, 18
-; BE-NEXT:    vxor 4, 4, 7
-; BE-NEXT:    vmladduhm 11, 17, 11, 18
-; BE-NEXT:    vxor 4, 4, 9
-; BE-NEXT:    vmladduhm 13, 17, 13, 18
-; BE-NEXT:    vxor 4, 4, 11
-; BE-NEXT:    vmladduhm 29, 17, 29, 18
-; BE-NEXT:    vxor 4, 4, 13
-; BE-NEXT:    vmladduhm 28, 17, 28, 18
-; BE-NEXT:    vxor 4, 4, 29
-; BE-NEXT:    lvx 29, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -64
-; BE-NEXT:    vmladduhm 27, 17, 27, 18
-; BE-NEXT:    vxor 4, 4, 28
-; BE-NEXT:    lvx 28, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -80
-; BE-NEXT:    vmladduhm 16, 17, 16, 18
-; BE-NEXT:    vxor 4, 4, 27
-; BE-NEXT:    lvx 27, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    vxor 4, 4, 16
-; BE-NEXT:    vperm 4, 4, 4, 5
+; BE-NEXT:    vxor 8, 8, 13
+; BE-NEXT:    vxor 9, 9, 19
+; BE-NEXT:    vxor 11, 11, 14
+; BE-NEXT:    vxor 1, 8, 1
+; BE-NEXT:    vand 8, 9, 12
+; BE-NEXT:    vand 9, 11, 10
+; BE-NEXT:    vand 1, 1, 16
+; BE-NEXT:    vor 8, 9, 8
+; BE-NEXT:    vor 1, 8, 1
+; BE-NEXT:    vperm 4, 1, 1, 4
 ; BE-NEXT:    vand 3, 4, 3
-; BE-NEXT:    vsrb 5, 4, 2
+; BE-NEXT:    vsrb 1, 4, 2
 ; BE-NEXT:    vslb 2, 3, 2
-; BE-NEXT:    vor 2, 5, 2
-; BE-NEXT:    vand 3, 2, 1
-; BE-NEXT:    vsrb 2, 2, 6
-; BE-NEXT:    vslb 3, 3, 6
-; BE-NEXT:    vand 2, 2, 1
+; BE-NEXT:    vor 2, 1, 2
+; BE-NEXT:    vand 3, 2, 5
+; BE-NEXT:    vsrb 2, 2, 0
+; BE-NEXT:    vslb 3, 3, 0
+; BE-NEXT:    vand 2, 2, 5
 ; BE-NEXT:    vor 2, 2, 3
-; BE-NEXT:    vsrb 3, 2, 10
-; BE-NEXT:    vand 2, 2, 12
+; BE-NEXT:    vsrb 3, 2, 6
+; BE-NEXT:    vand 2, 2, 7
 ; BE-NEXT:    vaddubm 2, 2, 2
-; BE-NEXT:    vand 3, 3, 12
+; BE-NEXT:    vand 3, 3, 7
 ; BE-NEXT:    vor 2, 3, 2
 ; BE-NEXT:    blr
 ;
 ; LE-LABEL: clmulr_v8i16:
 ; LE:       # %bb.0:
 ; LE-NEXT:    addis 3, 2, .LCPI5_0@toc@ha
-; LE-NEXT:    vspltisb 5, 4
-; LE-NEXT:    vspltish 7, 2
+; LE-NEXT:    vspltisb 5, 2
 ; LE-NEXT:    addi 3, 3, .LCPI5_0@toc@l
-; LE-NEXT:    vspltish 8, 1
-; LE-NEXT:    vspltish 1, 4
-; LE-NEXT:    vspltish 0, 8
 ; LE-NEXT:    lxvd2x 0, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI5_1@toc@ha
 ; LE-NEXT:    addi 3, 3, .LCPI5_1@toc@l
-; LE-NEXT:    vsldoi 9, 8, 8, 1
-; LE-NEXT:    vsldoi 13, 1, 1, 1
 ; LE-NEXT:    xxswapd 36, 0
 ; LE-NEXT:    lxvd2x 0, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI5_2@toc@ha
 ; LE-NEXT:    addi 3, 3, .LCPI5_2@toc@l
-; LE-NEXT:    vperm 10, 2, 2, 4
-; LE-NEXT:    vperm 6, 3, 3, 4
-; LE-NEXT:    vspltisb 3, 2
+; LE-NEXT:    vperm 0, 3, 3, 4
+; LE-NEXT:    vspltisb 3, 4
+; LE-NEXT:    vperm 1, 2, 2, 4
 ; LE-NEXT:    vspltisb 2, 1
-; LE-NEXT:    vslb 11, 10, 5
-; LE-NEXT:    vsrb 12, 10, 5
-; LE-NEXT:    xxlor 43, 44, 43
-; LE-NEXT:    xxland 44, 43, 0
-; LE-NEXT:    vsrb 11, 11, 3
-; LE-NEXT:    vsldoi 10, 7, 7, 1
-; LE-NEXT:    vslb 12, 12, 3
-; LE-NEXT:    xxland 1, 43, 0
-; LE-NEXT:    xxlor 43, 1, 44
+; LE-NEXT:    vslb 6, 0, 3
+; LE-NEXT:    vsrb 0, 0, 3
+; LE-NEXT:    xxlor 32, 32, 38
+; LE-NEXT:    xxland 38, 32, 0
+; LE-NEXT:    vsrb 0, 0, 5
+; LE-NEXT:    vslb 6, 6, 5
+; LE-NEXT:    xxland 1, 32, 0
+; LE-NEXT:    xxlor 32, 1, 38
 ; LE-NEXT:    lxvd2x 1, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI5_3@toc@ha
-; LE-NEXT:    vsrb 12, 11, 2
+; LE-NEXT:    vsrb 6, 0, 2
 ; LE-NEXT:    addi 3, 3, .LCPI5_3@toc@l
-; LE-NEXT:    lxvd2x 4, 0, 3
+; LE-NEXT:    lxvd2x 3, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI5_4@toc@ha
-; LE-NEXT:    xxland 2, 44, 1
-; LE-NEXT:    vslb 12, 6, 5
-; LE-NEXT:    vsrb 6, 6, 5
+; LE-NEXT:    xxland 2, 38, 1
+; LE-NEXT:    vslb 6, 1, 3
+; LE-NEXT:    vsrb 1, 1, 3
+; LE-NEXT:    xxland 32, 32, 1
 ; LE-NEXT:    addi 3, 3, .LCPI5_4@toc@l
-; LE-NEXT:    xxlor 38, 38, 44
-; LE-NEXT:    xxland 44, 38, 0
-; LE-NEXT:    vsrb 6, 6, 3
-; LE-NEXT:    vslb 12, 12, 3
-; LE-NEXT:    xxland 3, 38, 0
-; LE-NEXT:    xxlor 44, 3, 44
-; LE-NEXT:    vsrb 6, 12, 2
-; LE-NEXT:    xxland 3, 38, 1
-; LE-NEXT:    xxland 38, 43, 1
-; LE-NEXT:    xxland 43, 44, 1
-; LE-NEXT:    vaddubm 6, 6, 6
-; LE-NEXT:    vaddubm 11, 11, 11
-; LE-NEXT:    xxlor 38, 2, 38
-; LE-NEXT:    xxlor 2, 3, 43
-; LE-NEXT:    xxland 43, 2, 39
-; LE-NEXT:    xxland 40, 2, 40
-; LE-NEXT:    vxor 7, 7, 7
-; LE-NEXT:    vmladduhm 11, 6, 11, 7
-; LE-NEXT:    vmladduhm 8, 6, 8, 7
-; LE-NEXT:    xxlxor 3, 40, 43
-; LE-NEXT:    xxland 40, 2, 33
-; LE-NEXT:    vslh 1, 1, 1
-; LE-NEXT:    vmladduhm 8, 6, 8, 7
-; LE-NEXT:    xxland 33, 2, 33
-; LE-NEXT:    vmladduhm 1, 6, 1, 7
-; LE-NEXT:    xxlxor 3, 3, 40
-; LE-NEXT:    xxland 40, 2, 32
-; LE-NEXT:    vmladduhm 8, 6, 8, 7
-; LE-NEXT:    xxlxor 3, 3, 40
-; LE-NEXT:    vadduhm 8, 0, 0
-; LE-NEXT:    vslh 0, 0, 0
-; LE-NEXT:    xxland 40, 2, 40
-; LE-NEXT:    xxland 32, 2, 32
-; LE-NEXT:    vmladduhm 8, 6, 8, 7
-; LE-NEXT:    vmladduhm 0, 6, 0, 7
-; LE-NEXT:    xxlxor 3, 3, 40
-; LE-NEXT:    xxland 40, 2, 4
-; LE-NEXT:    lxvd2x 4, 0, 3
+; LE-NEXT:    xxlor 33, 33, 38
+; LE-NEXT:    vaddubm 0, 0, 0
+; LE-NEXT:    lxvd2x 5, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI5_5@toc@ha
-; LE-NEXT:    vmladduhm 8, 6, 8, 7
+; LE-NEXT:    xxland 38, 33, 0
+; LE-NEXT:    vsrb 1, 1, 5
+; LE-NEXT:    xxlor 2, 2, 32
 ; LE-NEXT:    addi 3, 3, .LCPI5_5@toc@l
-; LE-NEXT:    xxlxor 3, 3, 40
-; LE-NEXT:    xxlxor 3, 3, 33
-; LE-NEXT:    xxland 33, 2, 4
-; LE-NEXT:    lxvd2x 4, 0, 3
-; LE-NEXT:    addis 3, 2, .LCPI5_6@toc@ha
-; LE-NEXT:    vmladduhm 1, 6, 1, 7
-; LE-NEXT:    addi 3, 3, .LCPI5_6@toc@l
-; LE-NEXT:    xxlxor 3, 3, 33
-; LE-NEXT:    xxland 33, 2, 41
-; LE-NEXT:    vmladduhm 1, 6, 1, 7
-; LE-NEXT:    xxlxor 3, 3, 33
-; LE-NEXT:    xxland 33, 2, 42
-; LE-NEXT:    vmladduhm 1, 6, 1, 7
-; LE-NEXT:    xxlxor 3, 3, 33
-; LE-NEXT:    xxland 33, 2, 45
-; LE-NEXT:    vmladduhm 1, 6, 1, 7
-; LE-NEXT:    xxlxor 3, 3, 33
+; LE-NEXT:    vslb 6, 6, 5
+; LE-NEXT:    xxland 4, 33, 0
+; LE-NEXT:    xxland 32, 2, 3
+; LE-NEXT:    lxvd2x 7, 0, 3
+; LE-NEXT:    xxlor 33, 4, 38
+; LE-NEXT:    xxland 40, 2, 5
+; LE-NEXT:    vsrb 6, 1, 2
+; LE-NEXT:    xxland 33, 33, 1
+; LE-NEXT:    xxland 4, 38, 1
+; LE-NEXT:    vaddubm 1, 1, 1
+; LE-NEXT:    vxor 6, 6, 6
+; LE-NEXT:    xxlor 4, 4, 33
+; LE-NEXT:    xxland 33, 4, 5
+; LE-NEXT:    xxland 41, 4, 3
+; LE-NEXT:    vmladduhm 7, 1, 0, 6
+; LE-NEXT:    vmladduhm 10, 9, 8, 6
+; LE-NEXT:    vmladduhm 12, 9, 0, 6
+; LE-NEXT:    xxlxor 6, 42, 39
+; LE-NEXT:    xxland 39, 2, 7
+; LE-NEXT:    xxland 42, 4, 7
+; LE-NEXT:    vmladduhm 11, 10, 7, 6
+; LE-NEXT:    vmladduhm 0, 10, 0, 6
+; LE-NEXT:    xxlxor 2, 6, 43
+; LE-NEXT:    vmladduhm 11, 1, 7, 6
+; LE-NEXT:    vmladduhm 1, 1, 8, 6
+; LE-NEXT:    vmladduhm 7, 9, 7, 6
+; LE-NEXT:    xxland 2, 2, 5
+; LE-NEXT:    xxlxor 4, 44, 43
+; LE-NEXT:    vmladduhm 11, 10, 8, 6
+; LE-NEXT:    xxlxor 4, 4, 43
+; LE-NEXT:    xxland 3, 4, 3
+; LE-NEXT:    xxlor 2, 3, 2
+; LE-NEXT:    xxlxor 3, 39, 33
 ; LE-NEXT:    xxlxor 3, 3, 32
-; LE-NEXT:    xxland 32, 2, 4
-; LE-NEXT:    lxvd2x 4, 0, 3
-; LE-NEXT:    addis 3, 2, .LCPI5_7@toc@ha
-; LE-NEXT:    vmladduhm 0, 6, 0, 7
-; LE-NEXT:    addi 3, 3, .LCPI5_7@toc@l
-; LE-NEXT:    xxlxor 3, 3, 32
-; LE-NEXT:    xxland 32, 2, 4
-; LE-NEXT:    lxvd2x 4, 0, 3
-; LE-NEXT:    vmladduhm 0, 6, 0, 7
-; LE-NEXT:    xxlxor 3, 3, 32
-; LE-NEXT:    xxland 32, 2, 4
-; LE-NEXT:    vmladduhm 0, 6, 0, 7
-; LE-NEXT:    xxlxor 3, 3, 32
-; LE-NEXT:    xxleqv 32, 32, 32
-; LE-NEXT:    vslh 0, 0, 0
-; LE-NEXT:    xxland 32, 2, 32
-; LE-NEXT:    vmladduhm 0, 6, 0, 7
-; LE-NEXT:    xxlxor 32, 3, 32
+; LE-NEXT:    xxland 3, 3, 7
+; LE-NEXT:    xxlor 32, 2, 3
 ; LE-NEXT:    vperm 4, 0, 0, 4
-; LE-NEXT:    vslb 0, 4, 5
-; LE-NEXT:    vsrb 4, 4, 5
-; LE-NEXT:    xxlor 36, 36, 32
-; LE-NEXT:    xxland 37, 36, 0
-; LE-NEXT:    vslb 5, 5, 3
+; LE-NEXT:    vslb 0, 4, 3
 ; LE-NEXT:    vsrb 3, 4, 3
+; LE-NEXT:    xxlor 35, 35, 32
+; LE-NEXT:    xxland 36, 35, 0
+; LE-NEXT:    vsrb 3, 3, 5
+; LE-NEXT:    vslb 4, 4, 5
 ; LE-NEXT:    xxland 0, 35, 0
-; LE-NEXT:    xxlor 35, 0, 37
+; LE-NEXT:    xxlor 35, 0, 36
 ; LE-NEXT:    vsrb 2, 3, 2
 ; LE-NEXT:    xxland 0, 34, 1
 ; LE-NEXT:    xxland 34, 35, 1
@@ -3944,119 +3668,84 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 define <16 x i8> @clmulh_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; BE-LABEL: clmulh_v16i8:
 ; BE:       # %bb.0:
-; BE-NEXT:    li 3, -48
 ; BE-NEXT:    vspltisb 4, 4
-; BE-NEXT:    stvx 29, 1, 3 # 16-byte Folded Spill
-; BE-NEXT:    li 3, -32
-; BE-NEXT:    vsrb 1, 3, 4
-; BE-NEXT:    vspltisb 5, 15
-; BE-NEXT:    stvx 30, 1, 3 # 16-byte Folded Spill
-; BE-NEXT:    li 3, -16
-; BE-NEXT:    vspltisb 7, -1
-; BE-NEXT:    stvx 31, 1, 3 # 16-byte Folded Spill
 ; BE-NEXT:    addis 3, 2, .LCPI8_0@toc@ha
+; BE-NEXT:    vsrb 0, 3, 4
 ; BE-NEXT:    addi 3, 3, .LCPI8_0@toc@l
+; BE-NEXT:    vspltisb 5, 15
 ; BE-NEXT:    vand 3, 3, 5
-; BE-NEXT:    vspltisb 13, 8
 ; BE-NEXT:    vslb 3, 3, 4
-; BE-NEXT:    vsrb 0, 2, 4
+; BE-NEXT:    vsrb 1, 2, 4
 ; BE-NEXT:    vand 2, 2, 5
-; BE-NEXT:    vor 1, 1, 3
+; BE-NEXT:    vor 0, 0, 3
 ; BE-NEXT:    lvx 3, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI8_1@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI8_1@toc@l
-; BE-NEXT:    vslb 2, 2, 4
-; BE-NEXT:    vor 0, 0, 2
-; BE-NEXT:    vspltisb 2, 2
-; BE-NEXT:    vsrb 9, 1, 2
-; BE-NEXT:    vand 1, 1, 3
-; BE-NEXT:    vand 9, 9, 3
-; BE-NEXT:    vslb 1, 1, 2
-; BE-NEXT:    vsrb 8, 0, 2
-; BE-NEXT:    vand 0, 0, 3
-; BE-NEXT:    vor 9, 9, 1
-; BE-NEXT:    lvx 1, 0, 3
-; BE-NEXT:    addis 3, 2, .LCPI8_3@toc@ha
-; BE-NEXT:    addi 3, 3, .LCPI8_3@toc@l
-; BE-NEXT:    lvx 15, 0, 3
+; BE-NEXT:    lvx 8, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI8_2@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI8_2@toc@l
-; BE-NEXT:    vand 8, 8, 3
+; BE-NEXT:    vslb 2, 2, 4
+; BE-NEXT:    vor 1, 1, 2
+; BE-NEXT:    vspltisb 2, 2
+; BE-NEXT:    vsrb 6, 0, 2
+; BE-NEXT:    vsrb 7, 1, 2
+; BE-NEXT:    vand 0, 0, 3
+; BE-NEXT:    vand 1, 1, 3
+; BE-NEXT:    vand 6, 6, 3
+; BE-NEXT:    vand 7, 7, 3
 ; BE-NEXT:    vslb 0, 0, 2
-; BE-NEXT:    vor 8, 8, 0
+; BE-NEXT:    vslb 1, 1, 2
+; BE-NEXT:    vor 6, 6, 0
 ; BE-NEXT:    vspltisb 0, 1
-; BE-NEXT:    vsrb 11, 9, 0
-; BE-NEXT:    vand 9, 9, 1
-; BE-NEXT:    vaddubm 9, 9, 9
-; BE-NEXT:    vand 11, 11, 1
-; BE-NEXT:    vsrb 10, 8, 0
-; BE-NEXT:    vand 8, 8, 1
-; BE-NEXT:    vaddubm 8, 8, 8
-; BE-NEXT:    vor 9, 11, 9
-; BE-NEXT:    vslb 6, 4, 4
-; BE-NEXT:    vslb 7, 7, 7
-; BE-NEXT:    vand 10, 10, 1
-; BE-NEXT:    vand 14, 9, 13
-; BE-NEXT:    vaddubm 13, 13, 13
-; BE-NEXT:    vor 8, 10, 8
-; BE-NEXT:    vand 10, 9, 2
-; BE-NEXT:    vand 11, 9, 0
-; BE-NEXT:    vand 12, 9, 4
-; BE-NEXT:    vand 13, 9, 13
-; BE-NEXT:    vand 15, 9, 15
-; BE-NEXT:    vand 6, 9, 6
-; BE-NEXT:    vand 7, 9, 7
-; BE-NEXT:    vmuloub 9, 8, 10
-; BE-NEXT:    vmuleub 10, 8, 10
-; BE-NEXT:    vmuloub 16, 8, 11
-; BE-NEXT:    vmuleub 11, 8, 11
-; BE-NEXT:    vmuloub 17, 8, 12
-; BE-NEXT:    vmuleub 12, 8, 12
-; BE-NEXT:    vmuloub 18, 8, 14
-; BE-NEXT:    vmuleub 14, 8, 14
-; BE-NEXT:    vmuloub 19, 8, 13
-; BE-NEXT:    vmuleub 13, 8, 13
-; BE-NEXT:    vmuloub 31, 8, 15
-; BE-NEXT:    vmuleub 15, 8, 15
-; BE-NEXT:    vmuloub 30, 8, 6
-; BE-NEXT:    vmuleub 6, 8, 6
-; BE-NEXT:    vmuloub 29, 8, 7
-; BE-NEXT:    vmuleub 7, 8, 7
-; BE-NEXT:    lvx 8, 0, 3
-; BE-NEXT:    li 3, -16
-; BE-NEXT:    vperm 9, 10, 9, 8
-; BE-NEXT:    vperm 10, 11, 16, 8
-; BE-NEXT:    vperm 11, 12, 17, 8
-; BE-NEXT:    vperm 12, 14, 18, 8
-; BE-NEXT:    vperm 13, 13, 19, 8
-; BE-NEXT:    vperm 14, 15, 31, 8
-; BE-NEXT:    lvx 31, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -32
-; BE-NEXT:    vperm 6, 6, 30, 8
-; BE-NEXT:    lvx 30, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -48
-; BE-NEXT:    vperm 7, 7, 29, 8
-; BE-NEXT:    lvx 29, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    vxor 8, 10, 9
-; BE-NEXT:    vxor 8, 8, 11
-; BE-NEXT:    vxor 8, 8, 12
-; BE-NEXT:    vxor 8, 8, 13
-; BE-NEXT:    vxor 8, 8, 14
-; BE-NEXT:    vxor 6, 8, 6
-; BE-NEXT:    vxor 6, 6, 7
-; BE-NEXT:    vand 5, 6, 5
-; BE-NEXT:    vsrb 7, 6, 4
+; BE-NEXT:    vor 1, 7, 1
+; BE-NEXT:    vsrb 9, 1, 0
+; BE-NEXT:    vand 1, 1, 8
+; BE-NEXT:    vaddubm 1, 1, 1
+; BE-NEXT:    vand 9, 9, 8
+; BE-NEXT:    vsrb 7, 6, 0
+; BE-NEXT:    vand 6, 6, 8
+; BE-NEXT:    vaddubm 6, 6, 6
+; BE-NEXT:    vor 1, 9, 1
+; BE-NEXT:    lvx 9, 0, 3
+; BE-NEXT:    addis 3, 2, .LCPI8_3@toc@ha
+; BE-NEXT:    addi 3, 3, .LCPI8_3@toc@l
+; BE-NEXT:    vand 7, 7, 8
+; BE-NEXT:    vor 6, 7, 6
+; BE-NEXT:    vand 7, 6, 8
+; BE-NEXT:    vand 10, 1, 9
+; BE-NEXT:    vand 6, 6, 9
+; BE-NEXT:    vand 1, 1, 8
+; BE-NEXT:    vmuloub 11, 10, 7
+; BE-NEXT:    vmuleub 12, 10, 7
+; BE-NEXT:    vmuloub 13, 1, 6
+; BE-NEXT:    vmuleub 14, 1, 6
+; BE-NEXT:    vmuloub 15, 10, 6
+; BE-NEXT:    vmuleub 6, 10, 6
+; BE-NEXT:    vmuloub 10, 1, 7
+; BE-NEXT:    vmuleub 1, 1, 7
+; BE-NEXT:    lvx 7, 0, 3
+; BE-NEXT:    vperm 11, 12, 11, 7
+; BE-NEXT:    vperm 12, 14, 13, 7
+; BE-NEXT:    vperm 6, 6, 15, 7
+; BE-NEXT:    vperm 1, 1, 10, 7
+; BE-NEXT:    vxor 7, 12, 11
+; BE-NEXT:    vxor 1, 1, 6
+; BE-NEXT:    vand 6, 7, 9
+; BE-NEXT:    vand 1, 1, 8
+; BE-NEXT:    vor 1, 1, 6
+; BE-NEXT:    vand 5, 1, 5
+; BE-NEXT:    vsrb 6, 1, 4
 ; BE-NEXT:    vslb 4, 5, 4
-; BE-NEXT:    vor 4, 7, 4
+; BE-NEXT:    vor 4, 6, 4
 ; BE-NEXT:    vand 5, 4, 3
 ; BE-NEXT:    vsrb 4, 4, 2
 ; BE-NEXT:    vslb 2, 5, 2
 ; BE-NEXT:    vand 3, 4, 3
 ; BE-NEXT:    vor 2, 3, 2
 ; BE-NEXT:    vsrb 3, 2, 0
-; BE-NEXT:    vand 2, 2, 1
+; BE-NEXT:    vand 2, 2, 8
 ; BE-NEXT:    vaddubm 2, 2, 2
-; BE-NEXT:    vand 3, 3, 1
+; BE-NEXT:    vand 3, 3, 8
 ; BE-NEXT:    vor 2, 3, 2
 ; BE-NEXT:    vsrb 2, 2, 0
 ; BE-NEXT:    blr
@@ -4078,77 +3767,54 @@ define <16 x i8> @clmulh_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; LE-NEXT:    vspltisb 0, 1
 ; LE-NEXT:    addi 3, 3, .LCPI8_1@toc@l
 ; LE-NEXT:    vsrb 1, 3, 5
-; LE-NEXT:    vsrb 7, 2, 5
-; LE-NEXT:    vspltisb 6, 8
+; LE-NEXT:    vsrb 6, 2, 5
 ; LE-NEXT:    lxvd2x 1, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI8_2@toc@ha
 ; LE-NEXT:    xxland 35, 35, 0
 ; LE-NEXT:    xxland 34, 34, 0
 ; LE-NEXT:    xxland 2, 33, 0
-; LE-NEXT:    xxland 3, 39, 0
+; LE-NEXT:    xxland 3, 38, 0
 ; LE-NEXT:    addi 3, 3, .LCPI8_2@toc@l
 ; LE-NEXT:    vslb 3, 3, 5
 ; LE-NEXT:    vslb 2, 2, 5
 ; LE-NEXT:    xxlor 35, 2, 35
 ; LE-NEXT:    xxlor 34, 3, 34
-; LE-NEXT:    lxvd2x 3, 0, 3
+; LE-NEXT:    lxvd2x 2, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI8_3@toc@ha
 ; LE-NEXT:    vsrb 1, 3, 0
 ; LE-NEXT:    xxland 35, 35, 1
-; LE-NEXT:    vsrb 7, 2, 0
+; LE-NEXT:    vsrb 6, 2, 0
 ; LE-NEXT:    xxland 34, 34, 1
 ; LE-NEXT:    addi 3, 3, .LCPI8_3@toc@l
-; LE-NEXT:    xxland 2, 33, 1
+; LE-NEXT:    xxland 3, 33, 1
 ; LE-NEXT:    vaddubm 3, 3, 3
+; LE-NEXT:    xxland 4, 38, 1
 ; LE-NEXT:    vaddubm 2, 2, 2
-; LE-NEXT:    xxlor 2, 2, 35
-; LE-NEXT:    xxland 35, 2, 37
-; LE-NEXT:    xxswapd 33, 3
-; LE-NEXT:    xxland 3, 39, 1
-; LE-NEXT:    xxlor 34, 3, 34
-; LE-NEXT:    lxvd2x 3, 0, 3
-; LE-NEXT:    vmuloub 7, 2, 3
-; LE-NEXT:    vmuleub 3, 2, 3
-; LE-NEXT:    vperm 3, 3, 7, 1
-; LE-NEXT:    xxland 39, 2, 32
-; LE-NEXT:    vmuloub 8, 2, 7
-; LE-NEXT:    vmuleub 7, 2, 7
-; LE-NEXT:    vperm 7, 7, 8, 1
-; LE-NEXT:    xxland 40, 2, 36
-; LE-NEXT:    vmuloub 9, 2, 8
-; LE-NEXT:    vmuleub 8, 2, 8
-; LE-NEXT:    vperm 8, 8, 9, 1
-; LE-NEXT:    xxland 41, 2, 38
-; LE-NEXT:    vaddubm 6, 6, 6
-; LE-NEXT:    vmuloub 10, 2, 9
-; LE-NEXT:    vmuleub 9, 2, 9
-; LE-NEXT:    xxland 38, 2, 38
-; LE-NEXT:    vperm 9, 9, 10, 1
-; LE-NEXT:    vmuloub 10, 2, 6
-; LE-NEXT:    vmuleub 6, 2, 6
-; LE-NEXT:    vperm 6, 6, 10, 1
-; LE-NEXT:    xxland 42, 2, 3
-; LE-NEXT:    vmuloub 11, 2, 10
-; LE-NEXT:    vmuleub 10, 2, 10
-; LE-NEXT:    vperm 10, 10, 11, 1
-; LE-NEXT:    vslb 11, 4, 4
-; LE-NEXT:    xxland 43, 2, 43
-; LE-NEXT:    vmuloub 12, 2, 11
-; LE-NEXT:    vmuleub 11, 2, 11
-; LE-NEXT:    vperm 11, 11, 12, 1
-; LE-NEXT:    xxleqv 44, 44, 44
-; LE-NEXT:    vslb 12, 12, 12
-; LE-NEXT:    xxland 44, 2, 44
-; LE-NEXT:    xxlxor 2, 39, 35
-; LE-NEXT:    xxlxor 2, 2, 40
-; LE-NEXT:    vmuloub 13, 2, 12
-; LE-NEXT:    vmuleub 2, 2, 12
-; LE-NEXT:    xxlxor 2, 2, 41
-; LE-NEXT:    xxlxor 2, 2, 38
-; LE-NEXT:    xxlxor 2, 2, 42
-; LE-NEXT:    xxlxor 2, 2, 43
-; LE-NEXT:    vperm 2, 2, 13, 1
-; LE-NEXT:    xxlxor 34, 2, 34
+; LE-NEXT:    lxvd2x 5, 0, 3
+; LE-NEXT:    xxlor 3, 3, 35
+; LE-NEXT:    xxlor 4, 4, 34
+; LE-NEXT:    xxland 35, 3, 1
+; LE-NEXT:    xxland 33, 4, 2
+; LE-NEXT:    xxland 38, 3, 2
+; LE-NEXT:    xxland 39, 4, 1
+; LE-NEXT:    vmuloub 8, 1, 3
+; LE-NEXT:    vmuleub 9, 1, 3
+; LE-NEXT:    vmuloub 10, 7, 6
+; LE-NEXT:    xxswapd 34, 5
+; LE-NEXT:    vperm 8, 9, 8, 2
+; LE-NEXT:    vmuloub 9, 1, 6
+; LE-NEXT:    vmuleub 1, 1, 6
+; LE-NEXT:    vmuleub 6, 7, 6
+; LE-NEXT:    vperm 1, 1, 9, 2
+; LE-NEXT:    vmuloub 9, 7, 3
+; LE-NEXT:    vmuleub 3, 7, 3
+; LE-NEXT:    vperm 6, 6, 10, 2
+; LE-NEXT:    xxlxor 3, 38, 40
+; LE-NEXT:    xxland 2, 3, 2
+; LE-NEXT:    vperm 2, 3, 9, 2
+; LE-NEXT:    xxlxor 3, 34, 33
+; LE-NEXT:    xxland 3, 3, 1
+; LE-NEXT:    xxlor 34, 3, 2
 ; LE-NEXT:    vslb 3, 2, 4
 ; LE-NEXT:    vsrb 2, 2, 4
 ; LE-NEXT:    xxlor 34, 34, 35
@@ -4175,293 +3841,197 @@ define <16 x i8> @clmulh_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 define <8 x i16> @clmulh_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; BE-LABEL: clmulh_v8i16:
 ; BE:       # %bb.0:
-; BE-NEXT:    li 3, -96
-; BE-NEXT:    vspltisb 1, -1
-; BE-NEXT:    vxor 5, 5, 5
-; BE-NEXT:    stvx 26, 1, 3 # 16-byte Folded Spill
-; BE-NEXT:    li 3, -80
-; BE-NEXT:    vspltish 0, 4
-; BE-NEXT:    stvx 27, 1, 3 # 16-byte Folded Spill
-; BE-NEXT:    li 3, -64
-; BE-NEXT:    vspltish 4, 1
-; BE-NEXT:    stvx 28, 1, 3 # 16-byte Folded Spill
-; BE-NEXT:    li 3, -48
-; BE-NEXT:    vslh 17, 1, 1
-; BE-NEXT:    vspltish 15, 2
-; BE-NEXT:    stvx 29, 1, 3 # 16-byte Folded Spill
-; BE-NEXT:    li 3, -32
-; BE-NEXT:    vspltish 16, 8
-; BE-NEXT:    stvx 30, 1, 3 # 16-byte Folded Spill
 ; BE-NEXT:    li 3, -16
+; BE-NEXT:    vxor 1, 1, 1
 ; BE-NEXT:    stvx 31, 1, 3 # 16-byte Folded Spill
 ; BE-NEXT:    addis 3, 2, .LCPI9_0@toc@ha
-; BE-NEXT:    vslh 6, 0, 0
 ; BE-NEXT:    addi 3, 3, .LCPI9_0@toc@l
-; BE-NEXT:    lvx 1, 0, 3
+; BE-NEXT:    lvx 4, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI9_1@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI9_1@toc@l
-; BE-NEXT:    vperm 7, 2, 2, 1
-; BE-NEXT:    vspltisb 2, 4
-; BE-NEXT:    vperm 8, 3, 3, 1
+; BE-NEXT:    vperm 5, 3, 3, 4
 ; BE-NEXT:    vspltisb 3, 15
-; BE-NEXT:    vsrb 11, 7, 2
-; BE-NEXT:    vand 7, 7, 3
-; BE-NEXT:    vslb 7, 7, 2
-; BE-NEXT:    vsrb 13, 8, 2
-; BE-NEXT:    vand 8, 8, 3
-; BE-NEXT:    vor 11, 11, 7
-; BE-NEXT:    lvx 7, 0, 3
+; BE-NEXT:    vperm 0, 2, 2, 4
+; BE-NEXT:    vspltisb 2, 4
+; BE-NEXT:    vsrb 6, 5, 2
+; BE-NEXT:    vand 5, 5, 3
+; BE-NEXT:    vslb 5, 5, 2
+; BE-NEXT:    vsrb 7, 0, 2
+; BE-NEXT:    vand 0, 0, 3
+; BE-NEXT:    vor 6, 6, 5
+; BE-NEXT:    lvx 5, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI9_2@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI9_2@toc@l
-; BE-NEXT:    vslb 8, 8, 2
-; BE-NEXT:    vor 13, 13, 8
-; BE-NEXT:    vspltisb 8, 2
-; BE-NEXT:    vand 19, 13, 7
-; BE-NEXT:    vsrb 13, 13, 8
-; BE-NEXT:    vslb 19, 19, 8
-; BE-NEXT:    vand 13, 13, 7
-; BE-NEXT:    vand 18, 11, 7
-; BE-NEXT:    vsrb 11, 11, 8
-; BE-NEXT:    vor 19, 13, 19
-; BE-NEXT:    lvx 13, 0, 3
+; BE-NEXT:    vslb 0, 0, 2
+; BE-NEXT:    vor 7, 7, 0
+; BE-NEXT:    vspltisb 0, 2
+; BE-NEXT:    vand 9, 7, 5
+; BE-NEXT:    vsrb 7, 7, 0
+; BE-NEXT:    vslb 9, 9, 0
+; BE-NEXT:    vand 7, 7, 5
+; BE-NEXT:    vand 8, 6, 5
+; BE-NEXT:    vsrb 6, 6, 0
+; BE-NEXT:    vor 9, 7, 9
+; BE-NEXT:    lvx 7, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI9_3@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI9_3@toc@l
-; BE-NEXT:    vslb 18, 18, 8
-; BE-NEXT:    vand 11, 11, 7
-; BE-NEXT:    vor 18, 11, 18
-; BE-NEXT:    vspltisb 11, 1
-; BE-NEXT:    vsrb 30, 19, 11
-; BE-NEXT:    vand 19, 19, 13
-; BE-NEXT:    vaddubm 19, 19, 19
-; BE-NEXT:    vand 30, 30, 13
-; BE-NEXT:    vor 19, 30, 19
-; BE-NEXT:    lvx 30, 0, 3
+; BE-NEXT:    vslb 8, 8, 0
+; BE-NEXT:    vand 6, 6, 5
+; BE-NEXT:    vor 8, 6, 8
+; BE-NEXT:    vspltisb 6, 1
+; BE-NEXT:    vsrb 10, 8, 6
+; BE-NEXT:    vand 8, 8, 7
+; BE-NEXT:    vaddubm 8, 8, 8
+; BE-NEXT:    vand 10, 10, 7
+; BE-NEXT:    vor 8, 10, 8
+; BE-NEXT:    lvx 10, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI9_4@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI9_4@toc@l
-; BE-NEXT:    lvx 29, 0, 3
+; BE-NEXT:    lvx 12, 0, 3
 ; BE-NEXT:    addis 3, 2, .LCPI9_5@toc@ha
 ; BE-NEXT:    addi 3, 3, .LCPI9_5@toc@l
-; BE-NEXT:    lvx 28, 0, 3
-; BE-NEXT:    addis 3, 2, .LCPI9_6@toc@ha
-; BE-NEXT:    addi 3, 3, .LCPI9_6@toc@l
-; BE-NEXT:    vsrb 31, 18, 11
-; BE-NEXT:    lvx 27, 0, 3
-; BE-NEXT:    addis 3, 2, .LCPI9_7@toc@ha
-; BE-NEXT:    addi 3, 3, .LCPI9_7@toc@l
-; BE-NEXT:    lvx 26, 0, 3
+; BE-NEXT:    lvx 16, 0, 3
 ; BE-NEXT:    li 3, -16
-; BE-NEXT:    vand 18, 18, 13
-; BE-NEXT:    vaddubm 18, 18, 18
-; BE-NEXT:    vand 31, 31, 13
-; BE-NEXT:    vsldoi 9, 4, 4, 1
-; BE-NEXT:    vsldoi 10, 15, 15, 1
-; BE-NEXT:    vsldoi 12, 0, 0, 1
-; BE-NEXT:    vslh 14, 16, 16
-; BE-NEXT:    vor 18, 31, 18
-; BE-NEXT:    vand 31, 19, 16
-; BE-NEXT:    vadduhm 16, 16, 16
-; BE-NEXT:    vand 15, 19, 15
-; BE-NEXT:    vand 0, 19, 0
-; BE-NEXT:    vand 16, 19, 16
-; BE-NEXT:    vand 30, 19, 30
-; BE-NEXT:    vand 6, 19, 6
-; BE-NEXT:    vand 29, 19, 29
-; BE-NEXT:    vand 9, 19, 9
-; BE-NEXT:    vand 10, 19, 10
-; BE-NEXT:    vand 12, 19, 12
-; BE-NEXT:    vand 14, 19, 14
-; BE-NEXT:    vand 28, 19, 28
-; BE-NEXT:    vand 27, 19, 27
-; BE-NEXT:    vand 26, 19, 26
-; BE-NEXT:    vand 17, 19, 17
-; BE-NEXT:    vand 19, 19, 4
-; BE-NEXT:    vmladduhm 15, 18, 15, 5
-; BE-NEXT:    vmladduhm 19, 18, 19, 5
-; BE-NEXT:    vmladduhm 0, 18, 0, 5
-; BE-NEXT:    vxor 15, 19, 15
-; BE-NEXT:    vmladduhm 31, 18, 31, 5
-; BE-NEXT:    vxor 0, 15, 0
-; BE-NEXT:    vmladduhm 16, 18, 16, 5
-; BE-NEXT:    vxor 0, 0, 31
+; BE-NEXT:    vsrb 11, 9, 6
+; BE-NEXT:    vand 9, 9, 7
+; BE-NEXT:    vaddubm 9, 9, 9
+; BE-NEXT:    vand 11, 11, 7
+; BE-NEXT:    vor 9, 11, 9
+; BE-NEXT:    vand 11, 8, 10
+; BE-NEXT:    vand 13, 9, 12
+; BE-NEXT:    vand 14, 8, 12
+; BE-NEXT:    vand 15, 9, 10
+; BE-NEXT:    vand 8, 8, 16
+; BE-NEXT:    vand 9, 9, 16
+; BE-NEXT:    vmladduhm 17, 13, 11, 1
+; BE-NEXT:    vmladduhm 18, 15, 14, 1
+; BE-NEXT:    vmladduhm 19, 9, 8, 1
+; BE-NEXT:    vmladduhm 31, 13, 8, 1
+; BE-NEXT:    vmladduhm 8, 15, 8, 1
+; BE-NEXT:    vmladduhm 15, 15, 11, 1
+; BE-NEXT:    vmladduhm 13, 13, 14, 1
+; BE-NEXT:    vmladduhm 14, 9, 14, 1
+; BE-NEXT:    vmladduhm 1, 9, 11, 1
+; BE-NEXT:    vxor 9, 18, 17
+; BE-NEXT:    vxor 11, 15, 31
 ; BE-NEXT:    lvx 31, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -32
-; BE-NEXT:    vmladduhm 30, 18, 30, 5
-; BE-NEXT:    vxor 0, 0, 16
-; BE-NEXT:    vmladduhm 6, 18, 6, 5
-; BE-NEXT:    vxor 0, 0, 30
-; BE-NEXT:    lvx 30, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -48
-; BE-NEXT:    vmladduhm 29, 18, 29, 5
-; BE-NEXT:    vxor 0, 0, 6
-; BE-NEXT:    vmladduhm 9, 18, 9, 5
-; BE-NEXT:    vxor 0, 0, 29
-; BE-NEXT:    lvx 29, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -64
-; BE-NEXT:    vmladduhm 10, 18, 10, 5
-; BE-NEXT:    vxor 0, 0, 9
-; BE-NEXT:    vmladduhm 12, 18, 12, 5
-; BE-NEXT:    vxor 0, 0, 10
-; BE-NEXT:    vmladduhm 14, 18, 14, 5
-; BE-NEXT:    vxor 0, 0, 12
-; BE-NEXT:    vmladduhm 28, 18, 28, 5
-; BE-NEXT:    vxor 0, 0, 14
-; BE-NEXT:    vmladduhm 27, 18, 27, 5
-; BE-NEXT:    vxor 0, 0, 28
-; BE-NEXT:    lvx 28, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -80
-; BE-NEXT:    vmladduhm 26, 18, 26, 5
-; BE-NEXT:    vxor 0, 0, 27
-; BE-NEXT:    lvx 27, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    li 3, -96
-; BE-NEXT:    vmladduhm 5, 18, 17, 5
-; BE-NEXT:    vxor 0, 0, 26
-; BE-NEXT:    lvx 26, 1, 3 # 16-byte Folded Reload
-; BE-NEXT:    vxor 5, 0, 5
-; BE-NEXT:    vperm 5, 5, 5, 1
-; BE-NEXT:    vand 3, 5, 3
-; BE-NEXT:    vsrb 0, 5, 2
+; BE-NEXT:    vxor 8, 8, 13
+; BE-NEXT:    vxor 9, 9, 19
+; BE-NEXT:    vxor 11, 11, 14
+; BE-NEXT:    vxor 1, 8, 1
+; BE-NEXT:    vand 8, 9, 12
+; BE-NEXT:    vand 9, 11, 10
+; BE-NEXT:    vand 1, 1, 16
+; BE-NEXT:    vor 8, 9, 8
+; BE-NEXT:    vor 1, 8, 1
+; BE-NEXT:    vperm 4, 1, 1, 4
+; BE-NEXT:    vand 3, 4, 3
+; BE-NEXT:    vsrb 1, 4, 2
 ; BE-NEXT:    vslb 2, 3, 2
-; BE-NEXT:    vor 2, 0, 2
-; BE-NEXT:    vand 3, 2, 7
-; BE-NEXT:    vsrb 2, 2, 8
-; BE-NEXT:    vslb 3, 3, 8
-; BE-NEXT:    vand 2, 2, 7
+; BE-NEXT:    vor 2, 1, 2
+; BE-NEXT:    vand 3, 2, 5
+; BE-NEXT:    vsrb 2, 2, 0
+; BE-NEXT:    vslb 3, 3, 0
+; BE-NEXT:    vand 2, 2, 5
 ; BE-NEXT:    vor 2, 2, 3
-; BE-NEXT:    vsrb 3, 2, 11
-; BE-NEXT:    vand 2, 2, 13
+; BE-NEXT:    vsrb 3, 2, 6
+; BE-NEXT:    vand 2, 2, 7
 ; BE-NEXT:    vaddubm 2, 2, 2
-; BE-NEXT:    vand 3, 3, 13
+; BE-NEXT:    vand 3, 3, 7
 ; BE-NEXT:    vor 2, 3, 2
-; BE-NEXT:    vsrh 2, 2, 4
+; BE-NEXT:    vspltish 3, 1
+; BE-NEXT:    vsrh 2, 2, 3
 ; BE-NEXT:    blr
 ;
 ; LE-LABEL: clmulh_v8i16:
 ; LE:       # %bb.0:
 ; LE-NEXT:    addis 3, 2, .LCPI9_0@toc@ha
-; LE-NEXT:    vspltisb 5, 4
-; LE-NEXT:    vspltish 9, 2
+; LE-NEXT:    vspltisb 5, 2
 ; LE-NEXT:    addi 3, 3, .LCPI9_0@toc@l
-; LE-NEXT:    vspltish 0, 1
-; LE-NEXT:    vspltish 6, 4
-; LE-NEXT:    vspltish 1, 8
 ; LE-NEXT:    lxvd2x 0, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI9_1@toc@ha
-; LE-NEXT:    vsldoi 11, 9, 9, 1
 ; LE-NEXT:    addi 3, 3, .LCPI9_1@toc@l
-; LE-NEXT:    vsldoi 13, 6, 6, 1
-; LE-NEXT:    vsldoi 10, 0, 0, 1
 ; LE-NEXT:    xxswapd 36, 0
 ; LE-NEXT:    lxvd2x 0, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI9_2@toc@ha
 ; LE-NEXT:    addi 3, 3, .LCPI9_2@toc@l
-; LE-NEXT:    vperm 8, 2, 2, 4
-; LE-NEXT:    vperm 7, 3, 3, 4
-; LE-NEXT:    vspltisb 3, 2
+; LE-NEXT:    vperm 0, 3, 3, 4
+; LE-NEXT:    vspltisb 3, 4
+; LE-NEXT:    vperm 1, 2, 2, 4
 ; LE-NEXT:    vspltisb 2, 1
-; LE-NEXT:    vslb 12, 8, 5
-; LE-NEXT:    vsrb 8, 8, 5
-; LE-NEXT:    xxlor 40, 40, 44
-; LE-NEXT:    xxland 44, 40, 0
-; LE-NEXT:    vsrb 8, 8, 3
-; LE-NEXT:    vslb 12, 12, 3
-; LE-NEXT:    xxland 1, 40, 0
-; LE-NEXT:    xxlor 40, 1, 44
+; LE-NEXT:    vslb 6, 0, 3
+; LE-NEXT:    vsrb 0, 0, 3
+; LE-NEXT:    xxlor 32, 32, 38
+; LE-NEXT:    xxland 38, 32, 0
+; LE-NEXT:    vsrb 0, 0, 5
+; LE-NEXT:    vslb 6, 6, 5
+; LE-NEXT:    xxland 1, 32, 0
+; LE-NEXT:    xxlor 32, 1, 38
 ; LE-NEXT:    lxvd2x 1, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI9_3@toc@ha
-; LE-NEXT:    vsrb 12, 8, 2
+; LE-NEXT:    vsrb 6, 0, 2
 ; LE-NEXT:    addi 3, 3, .LCPI9_3@toc@l
-; LE-NEXT:    lxvd2x 4, 0, 3
+; LE-NEXT:    lxvd2x 3, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI9_4@toc@ha
-; LE-NEXT:    xxland 2, 44, 1
-; LE-NEXT:    vslb 12, 7, 5
-; LE-NEXT:    vsrb 7, 7, 5
-; LE-NEXT:    xxland 40, 40, 1
+; LE-NEXT:    xxland 2, 38, 1
+; LE-NEXT:    vslb 6, 1, 3
+; LE-NEXT:    vsrb 1, 1, 3
+; LE-NEXT:    xxland 32, 32, 1
 ; LE-NEXT:    addi 3, 3, .LCPI9_4@toc@l
-; LE-NEXT:    xxlor 39, 39, 44
-; LE-NEXT:    vaddubm 8, 8, 8
-; LE-NEXT:    xxland 44, 39, 0
-; LE-NEXT:    vsrb 7, 7, 3
-; LE-NEXT:    xxlor 40, 2, 40
-; LE-NEXT:    vslb 12, 12, 3
-; LE-NEXT:    xxland 2, 39, 0
-; LE-NEXT:    xxlor 39, 2, 44
-; LE-NEXT:    vsrb 12, 7, 2
-; LE-NEXT:    xxland 39, 39, 1
-; LE-NEXT:    xxland 2, 44, 1
-; LE-NEXT:    vaddubm 7, 7, 7
-; LE-NEXT:    xxlor 2, 2, 39
-; LE-NEXT:    vxor 7, 7, 7
-; LE-NEXT:    xxland 41, 2, 41
-; LE-NEXT:    xxland 44, 2, 32
-; LE-NEXT:    vmladduhm 9, 8, 9, 7
-; LE-NEXT:    vmladduhm 12, 8, 12, 7
-; LE-NEXT:    xxlxor 3, 44, 41
-; LE-NEXT:    xxland 41, 2, 38
-; LE-NEXT:    vslh 6, 6, 6
-; LE-NEXT:    vmladduhm 9, 8, 9, 7
-; LE-NEXT:    xxland 38, 2, 38
-; LE-NEXT:    vmladduhm 6, 8, 6, 7
-; LE-NEXT:    xxlxor 3, 3, 41
-; LE-NEXT:    xxland 41, 2, 33
-; LE-NEXT:    vmladduhm 9, 8, 9, 7
-; LE-NEXT:    xxlxor 3, 3, 41
-; LE-NEXT:    vadduhm 9, 1, 1
-; LE-NEXT:    vslh 1, 1, 1
-; LE-NEXT:    xxland 41, 2, 41
-; LE-NEXT:    xxland 33, 2, 33
-; LE-NEXT:    vmladduhm 9, 8, 9, 7
-; LE-NEXT:    vmladduhm 1, 8, 1, 7
-; LE-NEXT:    xxlxor 3, 3, 41
-; LE-NEXT:    xxland 41, 2, 4
-; LE-NEXT:    lxvd2x 4, 0, 3
+; LE-NEXT:    xxlor 33, 33, 38
+; LE-NEXT:    vaddubm 0, 0, 0
+; LE-NEXT:    lxvd2x 5, 0, 3
 ; LE-NEXT:    addis 3, 2, .LCPI9_5@toc@ha
-; LE-NEXT:    vmladduhm 9, 8, 9, 7
+; LE-NEXT:    xxland 38, 33, 0
+; LE-NEXT:    vsrb 1, 1, 5
+; LE-NEXT:    xxlor 2, 2, 32
 ; LE-NEXT:    addi 3, 3, .LCPI9_5@toc@l
-; LE-NEXT:    xxlxor 3, 3, 41
-; LE-NEXT:    xxlxor 3, 3, 38
-; LE-NEXT:    xxland 38, 2, 4
-; LE-NEXT:    lxvd2x 4, 0, 3
-; LE-NEXT:    addis 3, 2, .LCPI9_6@toc@ha
-; LE-NEXT:    vmladduhm 6, 8, 6, 7
-; LE-NEXT:    addi 3, 3, .LCPI9_6@toc@l
-; LE-NEXT:    xxlxor 3, 3, 38
-; LE-NEXT:    xxland 38, 2, 42
-; LE-NEXT:    vmladduhm 6, 8, 6, 7
-; LE-NEXT:    xxlxor 3, 3, 38
-; LE-NEXT:    xxland 38, 2, 43
-; LE-NEXT:    vmladduhm 6, 8, 6, 7
-; LE-NEXT:    xxlxor 3, 3, 38
-; LE-NEXT:    xxland 38, 2, 45
-; LE-NEXT:    vmladduhm 6, 8, 6, 7
-; LE-NEXT:    xxlxor 3, 3, 38
-; LE-NEXT:    xxlxor 3, 3, 33
-; LE-NEXT:    xxland 33, 2, 4
-; LE-NEXT:    lxvd2x 4, 0, 3
-; LE-NEXT:    addis 3, 2, .LCPI9_7@toc@ha
-; LE-NEXT:    vmladduhm 1, 8, 1, 7
-; LE-NEXT:    addi 3, 3, .LCPI9_7@toc@l
-; LE-NEXT:    xxlxor 3, 3, 33
-; LE-NEXT:    xxland 33, 2, 4
-; LE-NEXT:    lxvd2x 4, 0, 3
-; LE-NEXT:    vmladduhm 1, 8, 1, 7
-; LE-NEXT:    xxlxor 3, 3, 33
-; LE-NEXT:    xxland 33, 2, 4
-; LE-NEXT:    vmladduhm 1, 8, 1, 7
-; LE-NEXT:    xxlxor 3, 3, 33
-; LE-NEXT:    xxleqv 33, 33, 33
-; LE-NEXT:    vslh 1, 1, 1
-; LE-NEXT:    xxland 33, 2, 33
-; LE-NEXT:    vmladduhm 1, 8, 1, 7
-; LE-NEXT:    xxlxor 33, 3, 33
-; LE-NEXT:    vperm 4, 1, 1, 4
-; LE-NEXT:    vslb 1, 4, 5
-; LE-NEXT:    vsrb 4, 4, 5
-; LE-NEXT:    xxlor 36, 36, 33
-; LE-NEXT:    xxland 37, 36, 0
-; LE-NEXT:    vslb 5, 5, 3
+; LE-NEXT:    vslb 6, 6, 5
+; LE-NEXT:    xxland 4, 33, 0
+; LE-NEXT:    xxland 32, 2, 3
+; LE-NEXT:    lxvd2x 7, 0, 3
+; LE-NEXT:    xxlor 33, 4, 38
+; LE-NEXT:    xxland 40, 2, 5
+; LE-NEXT:    vsrb 6, 1, 2
+; LE-NEXT:    xxland 33, 33, 1
+; LE-NEXT:    xxland 4, 38, 1
+; LE-NEXT:    vaddubm 1, 1, 1
+; LE-NEXT:    vxor 6, 6, 6
+; LE-NEXT:    xxlor 4, 4, 33
+; LE-NEXT:    xxland 33, 4, 5
+; LE-NEXT:    xxland 41, 4, 3
+; LE-NEXT:    vmladduhm 7, 1, 0, 6
+; LE-NEXT:    vmladduhm 10, 9, 8, 6
+; LE-NEXT:    vmladduhm 12, 9, 0, 6
+; LE-NEXT:    xxlxor 6, 42, 39
+; LE-NEXT:    xxland 39, 2, 7
+; LE-NEXT:    xxland 42, 4, 7
+; LE-NEXT:    vmladduhm 11, 10, 7, 6
+; LE-NEXT:    vmladduhm 0, 10, 0, 6
+; LE-NEXT:    xxlxor 2, 6, 43
+; LE-NEXT:    vmladduhm 11, 1, 7, 6
+; LE-NEXT:    vmladduhm 1, 1, 8, 6
+; LE-NEXT:    vmladduhm 7, 9, 7, 6
+; LE-NEXT:    xxland 2, 2, 5
+; LE-NEXT:    xxlxor 4, 44, 43
+; LE-NEXT:    vmladduhm 11, 10, 8, 6
+; LE-NEXT:    xxlxor 4, 4, 43
+; LE-NEXT:    xxland 3, 4, 3
+; LE-NEXT:    xxlor 2, 3, 2
+; LE-NEXT:    xxlxor 3, 39, 33
+; LE-NEXT:    xxlxor 3, 3, 32
+; LE-NEXT:    xxland 3, 3, 7
+; LE-NEXT:    xxlor 32, 2, 3
+; LE-NEXT:    vperm 4, 0, 0, 4
+; LE-NEXT:    vspltish 0, 1
+; LE-NEXT:    vslb 1, 4, 3
 ; LE-NEXT:    vsrb 3, 4, 3
+; LE-NEXT:    xxlor 35, 35, 33
+; LE-NEXT:    xxland 36, 35, 0
+; LE-NEXT:    vsrb 3, 3, 5
+; LE-NEXT:    vslb 4, 4, 5
 ; LE-NEXT:    xxland 0, 35, 0
-; LE-NEXT:    xxlor 35, 0, 37
+; LE-NEXT:    xxlor 35, 0, 36
 ; LE-NEXT:    vsrb 2, 3, 2
 ; LE-NEXT:    xxland 0, 34, 1
 ; LE-NEXT:    xxland 34, 35, 1

--- a/llvm/test/CodeGen/RISCV/clmul.ll
+++ b/llvm/test/CodeGen/RISCV/clmul.ll
@@ -235,177 +235,39 @@ define i8 @clmul_i8(i8 %a, i8 %b) nounwind {
 ; RV64I-NEXT:    xor a0, a2, a0
 ; RV64I-NEXT:    ret
 ;
-; RV32IM-LABEL: clmul_i8:
-; RV32IM:       # %bb.0:
-; RV32IM-NEXT:    slli a2, a0, 1
-; RV32IM-NEXT:    slli a3, a1, 30
-; RV32IM-NEXT:    slli a4, a1, 31
-; RV32IM-NEXT:    srai a3, a3, 31
-; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    and a2, a3, a2
-; RV32IM-NEXT:    slli a3, a1, 29
-; RV32IM-NEXT:    slli a5, a0, 2
-; RV32IM-NEXT:    srai a3, a3, 31
-; RV32IM-NEXT:    and a3, a3, a5
-; RV32IM-NEXT:    slli a5, a1, 28
-; RV32IM-NEXT:    slli a6, a0, 3
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    and a4, a4, a0
-; RV32IM-NEXT:    and a5, a5, a6
-; RV32IM-NEXT:    xor a2, a4, a2
-; RV32IM-NEXT:    xor a3, a3, a5
-; RV32IM-NEXT:    xor a2, a2, a3
-; RV32IM-NEXT:    slli a3, a0, 4
-; RV32IM-NEXT:    slli a4, a1, 27
-; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    slli a5, a1, 26
-; RV32IM-NEXT:    slli a6, a0, 5
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    and a3, a4, a3
-; RV32IM-NEXT:    and a4, a5, a6
-; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    slli a4, a1, 25
-; RV32IM-NEXT:    slli a5, a0, 6
-; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    and a4, a4, a5
-; RV32IM-NEXT:    andi a1, a1, 128
-; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    seqz a1, a1
-; RV32IM-NEXT:    slli a0, a0, 7
-; RV32IM-NEXT:    addi a1, a1, -1
-; RV32IM-NEXT:    xor a2, a2, a3
-; RV32IM-NEXT:    and a0, a1, a0
-; RV32IM-NEXT:    xor a0, a2, a0
-; RV32IM-NEXT:    ret
+; CHECK-M-LABEL: clmul_i8:
+; CHECK-M:       # %bb.0:
+; CHECK-M-NEXT:    andi a2, a1, 85
+; CHECK-M-NEXT:    andi a3, a0, -86
+; CHECK-M-NEXT:    andi a1, a1, -86
+; CHECK-M-NEXT:    andi a0, a0, 85
+; CHECK-M-NEXT:    mul a4, a3, a2
+; CHECK-M-NEXT:    mul a5, a0, a1
+; CHECK-M-NEXT:    mul a1, a3, a1
+; CHECK-M-NEXT:    mul a0, a0, a2
+; CHECK-M-NEXT:    xor a4, a5, a4
+; CHECK-M-NEXT:    xor a0, a0, a1
+; CHECK-M-NEXT:    andi a1, a4, -86
+; CHECK-M-NEXT:    andi a0, a0, 85
+; CHECK-M-NEXT:    or a0, a0, a1
+; CHECK-M-NEXT:    ret
 ;
-; RV64IM-LABEL: clmul_i8:
-; RV64IM:       # %bb.0:
-; RV64IM-NEXT:    slli a2, a0, 1
-; RV64IM-NEXT:    slli a3, a1, 62
-; RV64IM-NEXT:    slli a4, a1, 63
-; RV64IM-NEXT:    srai a3, a3, 63
-; RV64IM-NEXT:    srai a4, a4, 63
-; RV64IM-NEXT:    and a2, a3, a2
-; RV64IM-NEXT:    slli a3, a1, 61
-; RV64IM-NEXT:    slli a5, a0, 2
-; RV64IM-NEXT:    srai a3, a3, 63
-; RV64IM-NEXT:    and a3, a3, a5
-; RV64IM-NEXT:    slli a5, a1, 60
-; RV64IM-NEXT:    slli a6, a0, 3
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    and a4, a4, a0
-; RV64IM-NEXT:    and a5, a5, a6
-; RV64IM-NEXT:    xor a2, a4, a2
-; RV64IM-NEXT:    xor a3, a3, a5
-; RV64IM-NEXT:    xor a2, a2, a3
-; RV64IM-NEXT:    slli a3, a0, 4
-; RV64IM-NEXT:    slli a4, a1, 59
-; RV64IM-NEXT:    srai a4, a4, 63
-; RV64IM-NEXT:    slli a5, a1, 58
-; RV64IM-NEXT:    slli a6, a0, 5
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    and a3, a4, a3
-; RV64IM-NEXT:    and a4, a5, a6
-; RV64IM-NEXT:    xor a3, a3, a4
-; RV64IM-NEXT:    slli a4, a1, 57
-; RV64IM-NEXT:    slli a5, a0, 6
-; RV64IM-NEXT:    srai a4, a4, 63
-; RV64IM-NEXT:    and a4, a4, a5
-; RV64IM-NEXT:    andi a1, a1, 128
-; RV64IM-NEXT:    xor a3, a3, a4
-; RV64IM-NEXT:    seqz a1, a1
-; RV64IM-NEXT:    slli a0, a0, 7
-; RV64IM-NEXT:    addi a1, a1, -1
-; RV64IM-NEXT:    xor a2, a2, a3
-; RV64IM-NEXT:    and a0, a1, a0
-; RV64IM-NEXT:    xor a0, a2, a0
-; RV64IM-NEXT:    ret
-;
-; RV32IMZBS-LABEL: clmul_i8:
-; RV32IMZBS:       # %bb.0:
-; RV32IMZBS-NEXT:    slli a2, a0, 1
-; RV32IMZBS-NEXT:    slli a3, a1, 30
-; RV32IMZBS-NEXT:    slli a4, a1, 31
-; RV32IMZBS-NEXT:    srai a3, a3, 31
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    and a2, a3, a2
-; RV32IMZBS-NEXT:    slli a3, a1, 29
-; RV32IMZBS-NEXT:    slli a5, a0, 2
-; RV32IMZBS-NEXT:    srai a3, a3, 31
-; RV32IMZBS-NEXT:    and a3, a3, a5
-; RV32IMZBS-NEXT:    slli a5, a1, 28
-; RV32IMZBS-NEXT:    slli a6, a0, 3
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    and a4, a4, a0
-; RV32IMZBS-NEXT:    and a5, a5, a6
-; RV32IMZBS-NEXT:    xor a2, a4, a2
-; RV32IMZBS-NEXT:    xor a3, a3, a5
-; RV32IMZBS-NEXT:    xor a2, a2, a3
-; RV32IMZBS-NEXT:    slli a3, a0, 4
-; RV32IMZBS-NEXT:    slli a4, a1, 27
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    slli a5, a1, 26
-; RV32IMZBS-NEXT:    slli a6, a0, 5
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    and a3, a4, a3
-; RV32IMZBS-NEXT:    and a4, a5, a6
-; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    slli a4, a1, 25
-; RV32IMZBS-NEXT:    slli a5, a0, 6
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    and a4, a4, a5
-; RV32IMZBS-NEXT:    andi a1, a1, 128
-; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    seqz a1, a1
-; RV32IMZBS-NEXT:    slli a0, a0, 7
-; RV32IMZBS-NEXT:    addi a1, a1, -1
-; RV32IMZBS-NEXT:    xor a2, a2, a3
-; RV32IMZBS-NEXT:    and a0, a1, a0
-; RV32IMZBS-NEXT:    xor a0, a2, a0
-; RV32IMZBS-NEXT:    ret
-;
-; RV64IMZBS-LABEL: clmul_i8:
-; RV64IMZBS:       # %bb.0:
-; RV64IMZBS-NEXT:    slli a2, a0, 1
-; RV64IMZBS-NEXT:    slli a3, a1, 62
-; RV64IMZBS-NEXT:    slli a4, a1, 63
-; RV64IMZBS-NEXT:    srai a3, a3, 63
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    and a2, a3, a2
-; RV64IMZBS-NEXT:    slli a3, a1, 61
-; RV64IMZBS-NEXT:    slli a5, a0, 2
-; RV64IMZBS-NEXT:    srai a3, a3, 63
-; RV64IMZBS-NEXT:    and a3, a3, a5
-; RV64IMZBS-NEXT:    slli a5, a1, 60
-; RV64IMZBS-NEXT:    slli a6, a0, 3
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    and a4, a4, a0
-; RV64IMZBS-NEXT:    and a5, a5, a6
-; RV64IMZBS-NEXT:    xor a2, a4, a2
-; RV64IMZBS-NEXT:    xor a3, a3, a5
-; RV64IMZBS-NEXT:    xor a2, a2, a3
-; RV64IMZBS-NEXT:    slli a3, a0, 4
-; RV64IMZBS-NEXT:    slli a4, a1, 59
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    slli a5, a1, 58
-; RV64IMZBS-NEXT:    slli a6, a0, 5
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    and a3, a4, a3
-; RV64IMZBS-NEXT:    and a4, a5, a6
-; RV64IMZBS-NEXT:    xor a3, a3, a4
-; RV64IMZBS-NEXT:    slli a4, a1, 57
-; RV64IMZBS-NEXT:    slli a5, a0, 6
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    and a4, a4, a5
-; RV64IMZBS-NEXT:    andi a1, a1, 128
-; RV64IMZBS-NEXT:    xor a3, a3, a4
-; RV64IMZBS-NEXT:    seqz a1, a1
-; RV64IMZBS-NEXT:    slli a0, a0, 7
-; RV64IMZBS-NEXT:    addi a1, a1, -1
-; RV64IMZBS-NEXT:    xor a2, a2, a3
-; RV64IMZBS-NEXT:    and a0, a1, a0
-; RV64IMZBS-NEXT:    xor a0, a2, a0
-; RV64IMZBS-NEXT:    ret
+; CHECK-ZBS-LABEL: clmul_i8:
+; CHECK-ZBS:       # %bb.0:
+; CHECK-ZBS-NEXT:    andi a2, a1, 85
+; CHECK-ZBS-NEXT:    andi a3, a0, -86
+; CHECK-ZBS-NEXT:    andi a1, a1, -86
+; CHECK-ZBS-NEXT:    andi a0, a0, 85
+; CHECK-ZBS-NEXT:    mul a4, a3, a2
+; CHECK-ZBS-NEXT:    mul a5, a0, a1
+; CHECK-ZBS-NEXT:    mul a1, a3, a1
+; CHECK-ZBS-NEXT:    mul a0, a0, a2
+; CHECK-ZBS-NEXT:    xor a4, a5, a4
+; CHECK-ZBS-NEXT:    xor a0, a0, a1
+; CHECK-ZBS-NEXT:    andi a1, a4, -86
+; CHECK-ZBS-NEXT:    andi a0, a0, 85
+; CHECK-ZBS-NEXT:    or a0, a0, a1
+; CHECK-ZBS-NEXT:    ret
   %res = call i8 @llvm.clmul.i8(i8 %a, i8 %b)
   ret i8 %res
 }
@@ -579,327 +441,77 @@ define i16 @clmul_i16(i16 %a, i16 %b) nounwind {
 ; RV64I-NEXT:    xor a0, a2, a0
 ; RV64I-NEXT:    ret
 ;
-; RV32IM-LABEL: clmul_i16:
-; RV32IM:       # %bb.0:
-; RV32IM-NEXT:    slli a2, a0, 1
-; RV32IM-NEXT:    slli a3, a1, 30
-; RV32IM-NEXT:    slli a4, a1, 31
-; RV32IM-NEXT:    srai a3, a3, 31
-; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    and a2, a3, a2
-; RV32IM-NEXT:    and a4, a4, a0
-; RV32IM-NEXT:    xor a2, a4, a2
-; RV32IM-NEXT:    slli a3, a0, 2
-; RV32IM-NEXT:    slli a4, a1, 29
-; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    slli a5, a1, 28
-; RV32IM-NEXT:    slli a6, a0, 3
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    and a3, a4, a3
-; RV32IM-NEXT:    and a4, a5, a6
-; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    slli a4, a1, 27
-; RV32IM-NEXT:    slli a5, a0, 4
-; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    and a4, a4, a5
-; RV32IM-NEXT:    slli a5, a1, 26
-; RV32IM-NEXT:    slli a6, a0, 5
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    and a5, a5, a6
-; RV32IM-NEXT:    slli a6, a1, 25
-; RV32IM-NEXT:    slli a7, a0, 6
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    and a5, a6, a7
-; RV32IM-NEXT:    xor a2, a2, a3
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    slli a3, a0, 7
-; RV32IM-NEXT:    slli a5, a1, 24
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    slli a6, a1, 23
-; RV32IM-NEXT:    slli a7, a0, 8
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    and a3, a5, a3
-; RV32IM-NEXT:    and a5, a6, a7
-; RV32IM-NEXT:    xor a3, a3, a5
-; RV32IM-NEXT:    slli a5, a0, 9
-; RV32IM-NEXT:    slli a6, a1, 22
-; RV32IM-NEXT:    li a7, 1
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    slli a7, a7, 11
-; RV32IM-NEXT:    and a5, a6, a5
-; RV32IM-NEXT:    and a6, a1, a7
-; RV32IM-NEXT:    lui a7, 1
-; RV32IM-NEXT:    lui t0, 2
-; RV32IM-NEXT:    and a7, a1, a7
-; RV32IM-NEXT:    and t0, a1, t0
-; RV32IM-NEXT:    lui t1, 4
-; RV32IM-NEXT:    lui t2, 1048568
-; RV32IM-NEXT:    and t1, a1, t1
-; RV32IM-NEXT:    and t2, a1, t2
-; RV32IM-NEXT:    slli a1, a1, 21
-; RV32IM-NEXT:    mul a7, a0, a7
-; RV32IM-NEXT:    mul t0, a0, t0
-; RV32IM-NEXT:    mul t1, a0, t1
-; RV32IM-NEXT:    mul a6, a0, a6
-; RV32IM-NEXT:    mul t2, a0, t2
-; RV32IM-NEXT:    slli a0, a0, 10
-; RV32IM-NEXT:    srai a1, a1, 31
-; RV32IM-NEXT:    xor a3, a3, a5
-; RV32IM-NEXT:    and a0, a1, a0
-; RV32IM-NEXT:    xor a2, a2, a4
-; RV32IM-NEXT:    xor a0, a3, a0
-; RV32IM-NEXT:    xor a0, a2, a0
-; RV32IM-NEXT:    xor a0, a0, a7
-; RV32IM-NEXT:    xor a1, t0, t1
-; RV32IM-NEXT:    xor a0, a0, a6
-; RV32IM-NEXT:    xor a1, a1, t2
-; RV32IM-NEXT:    xor a0, a0, a1
-; RV32IM-NEXT:    ret
+; CHECK-M-LABEL: clmul_i16:
+; CHECK-M:       # %bb.0:
+; CHECK-M-NEXT:    lui a2, 1048569
+; CHECK-M-NEXT:    lui a3, 2
+; CHECK-M-NEXT:    addi a2, a2, 585
+; CHECK-M-NEXT:    addi a3, a3, 1170
+; CHECK-M-NEXT:    and a4, a1, a2
+; CHECK-M-NEXT:    and a5, a0, a3
+; CHECK-M-NEXT:    mul a6, a5, a4
+; CHECK-M-NEXT:    and a7, a1, a3
+; CHECK-M-NEXT:    and t0, a0, a2
+; CHECK-M-NEXT:    lui t1, 5
+; CHECK-M-NEXT:    mul t2, t0, a7
+; CHECK-M-NEXT:    addi t1, t1, -1756
+; CHECK-M-NEXT:    and a1, a1, t1
+; CHECK-M-NEXT:    and a0, a0, t1
+; CHECK-M-NEXT:    mul t3, a0, a1
+; CHECK-M-NEXT:    mul t4, a5, a1
+; CHECK-M-NEXT:    mul a1, t0, a1
+; CHECK-M-NEXT:    mul t0, t0, a4
+; CHECK-M-NEXT:    mul a5, a5, a7
+; CHECK-M-NEXT:    mul a7, a0, a7
+; CHECK-M-NEXT:    mul a0, a0, a4
+; CHECK-M-NEXT:    xor a4, t2, a6
+; CHECK-M-NEXT:    xor a4, a4, t3
+; CHECK-M-NEXT:    and a3, a4, a3
+; CHECK-M-NEXT:    xor a4, t0, t4
+; CHECK-M-NEXT:    xor a4, a4, a7
+; CHECK-M-NEXT:    xor a1, a1, a5
+; CHECK-M-NEXT:    and a2, a4, a2
+; CHECK-M-NEXT:    xor a0, a1, a0
+; CHECK-M-NEXT:    or a2, a2, a3
+; CHECK-M-NEXT:    and a0, a0, t1
+; CHECK-M-NEXT:    or a0, a2, a0
+; CHECK-M-NEXT:    ret
 ;
-; RV64IM-LABEL: clmul_i16:
-; RV64IM:       # %bb.0:
-; RV64IM-NEXT:    slli a2, a0, 1
-; RV64IM-NEXT:    slli a3, a1, 62
-; RV64IM-NEXT:    slli a4, a1, 63
-; RV64IM-NEXT:    srai a3, a3, 63
-; RV64IM-NEXT:    srai a4, a4, 63
-; RV64IM-NEXT:    and a2, a3, a2
-; RV64IM-NEXT:    and a4, a4, a0
-; RV64IM-NEXT:    xor a2, a4, a2
-; RV64IM-NEXT:    slli a3, a0, 2
-; RV64IM-NEXT:    slli a4, a1, 61
-; RV64IM-NEXT:    srai a4, a4, 63
-; RV64IM-NEXT:    slli a5, a1, 60
-; RV64IM-NEXT:    slli a6, a0, 3
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    and a3, a4, a3
-; RV64IM-NEXT:    and a4, a5, a6
-; RV64IM-NEXT:    xor a3, a3, a4
-; RV64IM-NEXT:    slli a4, a1, 59
-; RV64IM-NEXT:    slli a5, a0, 4
-; RV64IM-NEXT:    srai a4, a4, 63
-; RV64IM-NEXT:    and a4, a4, a5
-; RV64IM-NEXT:    slli a5, a1, 58
-; RV64IM-NEXT:    slli a6, a0, 5
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    and a5, a5, a6
-; RV64IM-NEXT:    slli a6, a1, 57
-; RV64IM-NEXT:    slli a7, a0, 6
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    and a5, a6, a7
-; RV64IM-NEXT:    xor a2, a2, a3
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    slli a3, a0, 7
-; RV64IM-NEXT:    slli a5, a1, 56
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    slli a6, a1, 55
-; RV64IM-NEXT:    slli a7, a0, 8
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    and a3, a5, a3
-; RV64IM-NEXT:    and a5, a6, a7
-; RV64IM-NEXT:    xor a3, a3, a5
-; RV64IM-NEXT:    slli a5, a0, 9
-; RV64IM-NEXT:    slli a6, a1, 54
-; RV64IM-NEXT:    li a7, 1
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    slli a7, a7, 11
-; RV64IM-NEXT:    and a5, a6, a5
-; RV64IM-NEXT:    and a6, a1, a7
-; RV64IM-NEXT:    lui a7, 1
-; RV64IM-NEXT:    lui t0, 2
-; RV64IM-NEXT:    and a7, a1, a7
-; RV64IM-NEXT:    and t0, a1, t0
-; RV64IM-NEXT:    lui t1, 4
-; RV64IM-NEXT:    lui t2, 1048568
-; RV64IM-NEXT:    and t1, a1, t1
-; RV64IM-NEXT:    and t2, a1, t2
-; RV64IM-NEXT:    slli a1, a1, 53
-; RV64IM-NEXT:    mul a7, a0, a7
-; RV64IM-NEXT:    mul t0, a0, t0
-; RV64IM-NEXT:    mul t1, a0, t1
-; RV64IM-NEXT:    mul a6, a0, a6
-; RV64IM-NEXT:    mul t2, a0, t2
-; RV64IM-NEXT:    slli a0, a0, 10
-; RV64IM-NEXT:    srai a1, a1, 63
-; RV64IM-NEXT:    xor a3, a3, a5
-; RV64IM-NEXT:    and a0, a1, a0
-; RV64IM-NEXT:    xor a2, a2, a4
-; RV64IM-NEXT:    xor a0, a3, a0
-; RV64IM-NEXT:    xor a0, a2, a0
-; RV64IM-NEXT:    xor a0, a0, a7
-; RV64IM-NEXT:    xor a1, t0, t1
-; RV64IM-NEXT:    xor a0, a0, a6
-; RV64IM-NEXT:    xor a1, a1, t2
-; RV64IM-NEXT:    xor a0, a0, a1
-; RV64IM-NEXT:    ret
-;
-; RV32IMZBS-LABEL: clmul_i16:
-; RV32IMZBS:       # %bb.0:
-; RV32IMZBS-NEXT:    slli a2, a0, 1
-; RV32IMZBS-NEXT:    slli a3, a1, 30
-; RV32IMZBS-NEXT:    slli a4, a1, 31
-; RV32IMZBS-NEXT:    srai a3, a3, 31
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    and a2, a3, a2
-; RV32IMZBS-NEXT:    and a4, a4, a0
-; RV32IMZBS-NEXT:    xor a2, a4, a2
-; RV32IMZBS-NEXT:    slli a3, a0, 2
-; RV32IMZBS-NEXT:    slli a4, a1, 29
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    slli a5, a1, 28
-; RV32IMZBS-NEXT:    slli a6, a0, 3
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    and a3, a4, a3
-; RV32IMZBS-NEXT:    and a4, a5, a6
-; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    slli a4, a1, 27
-; RV32IMZBS-NEXT:    slli a5, a0, 4
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    and a4, a4, a5
-; RV32IMZBS-NEXT:    slli a5, a1, 26
-; RV32IMZBS-NEXT:    slli a6, a0, 5
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    and a5, a5, a6
-; RV32IMZBS-NEXT:    slli a6, a1, 25
-; RV32IMZBS-NEXT:    slli a7, a0, 6
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    and a5, a6, a7
-; RV32IMZBS-NEXT:    xor a2, a2, a3
-; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    xor a2, a2, a4
-; RV32IMZBS-NEXT:    slli a3, a1, 24
-; RV32IMZBS-NEXT:    slli a4, a0, 7
-; RV32IMZBS-NEXT:    srai a3, a3, 31
-; RV32IMZBS-NEXT:    and a3, a3, a4
-; RV32IMZBS-NEXT:    slli a4, a1, 23
-; RV32IMZBS-NEXT:    slli a5, a0, 8
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    and a4, a4, a5
-; RV32IMZBS-NEXT:    slli a5, a1, 22
-; RV32IMZBS-NEXT:    slli a6, a0, 9
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    and a4, a5, a6
-; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    slli a4, a1, 21
-; RV32IMZBS-NEXT:    slli a5, a0, 10
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    and a4, a4, a5
-; RV32IMZBS-NEXT:    slli a5, a1, 20
-; RV32IMZBS-NEXT:    slli a6, a0, 11
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    and a5, a5, a6
-; RV32IMZBS-NEXT:    slli a6, a1, 19
-; RV32IMZBS-NEXT:    slli a7, a0, 12
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    and a6, a6, a7
-; RV32IMZBS-NEXT:    slli a7, a1, 18
-; RV32IMZBS-NEXT:    slli t0, a0, 13
-; RV32IMZBS-NEXT:    srai a7, a7, 31
-; RV32IMZBS-NEXT:    xor a5, a5, a6
-; RV32IMZBS-NEXT:    and a6, a7, t0
-; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    xor a4, a5, a6
-; RV32IMZBS-NEXT:    slli a5, a0, 14
-; RV32IMZBS-NEXT:    slli a6, a1, 17
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    not a1, a1
-; RV32IMZBS-NEXT:    and a5, a6, a5
-; RV32IMZBS-NEXT:    bexti a1, a1, 15
-; RV32IMZBS-NEXT:    slli a0, a0, 15
-; RV32IMZBS-NEXT:    addi a1, a1, -1
-; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    and a0, a1, a0
-; RV32IMZBS-NEXT:    xor a2, a2, a3
-; RV32IMZBS-NEXT:    xor a0, a4, a0
-; RV32IMZBS-NEXT:    xor a0, a2, a0
-; RV32IMZBS-NEXT:    ret
-;
-; RV64IMZBS-LABEL: clmul_i16:
-; RV64IMZBS:       # %bb.0:
-; RV64IMZBS-NEXT:    slli a2, a0, 1
-; RV64IMZBS-NEXT:    slli a3, a1, 62
-; RV64IMZBS-NEXT:    slli a4, a1, 63
-; RV64IMZBS-NEXT:    srai a3, a3, 63
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    and a2, a3, a2
-; RV64IMZBS-NEXT:    and a4, a4, a0
-; RV64IMZBS-NEXT:    xor a2, a4, a2
-; RV64IMZBS-NEXT:    slli a3, a0, 2
-; RV64IMZBS-NEXT:    slli a4, a1, 61
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    slli a5, a1, 60
-; RV64IMZBS-NEXT:    slli a6, a0, 3
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    and a3, a4, a3
-; RV64IMZBS-NEXT:    and a4, a5, a6
-; RV64IMZBS-NEXT:    xor a3, a3, a4
-; RV64IMZBS-NEXT:    slli a4, a1, 59
-; RV64IMZBS-NEXT:    slli a5, a0, 4
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    and a4, a4, a5
-; RV64IMZBS-NEXT:    slli a5, a1, 58
-; RV64IMZBS-NEXT:    slli a6, a0, 5
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    and a5, a5, a6
-; RV64IMZBS-NEXT:    slli a6, a1, 57
-; RV64IMZBS-NEXT:    slli a7, a0, 6
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    xor a4, a4, a5
-; RV64IMZBS-NEXT:    and a5, a6, a7
-; RV64IMZBS-NEXT:    xor a2, a2, a3
-; RV64IMZBS-NEXT:    xor a4, a4, a5
-; RV64IMZBS-NEXT:    xor a2, a2, a4
-; RV64IMZBS-NEXT:    slli a3, a1, 56
-; RV64IMZBS-NEXT:    slli a4, a0, 7
-; RV64IMZBS-NEXT:    srai a3, a3, 63
-; RV64IMZBS-NEXT:    and a3, a3, a4
-; RV64IMZBS-NEXT:    slli a4, a1, 55
-; RV64IMZBS-NEXT:    slli a5, a0, 8
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    and a4, a4, a5
-; RV64IMZBS-NEXT:    slli a5, a1, 54
-; RV64IMZBS-NEXT:    slli a6, a0, 9
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    xor a3, a3, a4
-; RV64IMZBS-NEXT:    and a4, a5, a6
-; RV64IMZBS-NEXT:    xor a3, a3, a4
-; RV64IMZBS-NEXT:    slli a4, a1, 53
-; RV64IMZBS-NEXT:    slli a5, a0, 10
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    and a4, a4, a5
-; RV64IMZBS-NEXT:    slli a5, a1, 52
-; RV64IMZBS-NEXT:    slli a6, a0, 11
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    and a5, a5, a6
-; RV64IMZBS-NEXT:    slli a6, a1, 51
-; RV64IMZBS-NEXT:    slli a7, a0, 12
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    and a6, a6, a7
-; RV64IMZBS-NEXT:    slli a7, a1, 50
-; RV64IMZBS-NEXT:    slli t0, a0, 13
-; RV64IMZBS-NEXT:    srai a7, a7, 63
-; RV64IMZBS-NEXT:    xor a5, a5, a6
-; RV64IMZBS-NEXT:    and a6, a7, t0
-; RV64IMZBS-NEXT:    xor a3, a3, a4
-; RV64IMZBS-NEXT:    xor a4, a5, a6
-; RV64IMZBS-NEXT:    slli a5, a0, 14
-; RV64IMZBS-NEXT:    slli a6, a1, 49
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    not a1, a1
-; RV64IMZBS-NEXT:    and a5, a6, a5
-; RV64IMZBS-NEXT:    bexti a1, a1, 15
-; RV64IMZBS-NEXT:    slli a0, a0, 15
-; RV64IMZBS-NEXT:    addi a1, a1, -1
-; RV64IMZBS-NEXT:    xor a4, a4, a5
-; RV64IMZBS-NEXT:    and a0, a1, a0
-; RV64IMZBS-NEXT:    xor a2, a2, a3
-; RV64IMZBS-NEXT:    xor a0, a4, a0
-; RV64IMZBS-NEXT:    xor a0, a2, a0
-; RV64IMZBS-NEXT:    ret
+; CHECK-ZBS-LABEL: clmul_i16:
+; CHECK-ZBS:       # %bb.0:
+; CHECK-ZBS-NEXT:    lui a2, 1048569
+; CHECK-ZBS-NEXT:    lui a3, 2
+; CHECK-ZBS-NEXT:    addi a2, a2, 585
+; CHECK-ZBS-NEXT:    addi a3, a3, 1170
+; CHECK-ZBS-NEXT:    and a4, a1, a2
+; CHECK-ZBS-NEXT:    and a5, a0, a3
+; CHECK-ZBS-NEXT:    mul a6, a5, a4
+; CHECK-ZBS-NEXT:    and a7, a1, a3
+; CHECK-ZBS-NEXT:    and t0, a0, a2
+; CHECK-ZBS-NEXT:    lui t1, 5
+; CHECK-ZBS-NEXT:    mul t2, t0, a7
+; CHECK-ZBS-NEXT:    addi t1, t1, -1756
+; CHECK-ZBS-NEXT:    and a1, a1, t1
+; CHECK-ZBS-NEXT:    and a0, a0, t1
+; CHECK-ZBS-NEXT:    mul t3, a0, a1
+; CHECK-ZBS-NEXT:    mul t4, a5, a1
+; CHECK-ZBS-NEXT:    mul a1, t0, a1
+; CHECK-ZBS-NEXT:    mul t0, t0, a4
+; CHECK-ZBS-NEXT:    mul a5, a5, a7
+; CHECK-ZBS-NEXT:    mul a7, a0, a7
+; CHECK-ZBS-NEXT:    mul a0, a0, a4
+; CHECK-ZBS-NEXT:    xor a4, t2, a6
+; CHECK-ZBS-NEXT:    xor a4, a4, t3
+; CHECK-ZBS-NEXT:    and a3, a4, a3
+; CHECK-ZBS-NEXT:    xor a4, t0, t4
+; CHECK-ZBS-NEXT:    xor a4, a4, a7
+; CHECK-ZBS-NEXT:    xor a1, a1, a5
+; CHECK-ZBS-NEXT:    and a2, a4, a2
+; CHECK-ZBS-NEXT:    xor a0, a1, a0
+; CHECK-ZBS-NEXT:    or a2, a2, a3
+; CHECK-ZBS-NEXT:    and a0, a0, t1
+; CHECK-ZBS-NEXT:    or a0, a2, a0
+; CHECK-ZBS-NEXT:    ret
   %res = call i16 @llvm.clmul.i16(i16 %a, i16 %b)
   ret i16 %res
 }
@@ -3763,185 +3375,43 @@ define void @commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwind {
 ; RV64I-NEXT:    sb a0, 0(a3)
 ; RV64I-NEXT:    ret
 ;
-; RV32IM-LABEL: commutative_clmul_i8:
-; RV32IM:       # %bb.0:
-; RV32IM-NEXT:    slli a4, a1, 30
-; RV32IM-NEXT:    slli a5, a0, 1
-; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    and a4, a4, a5
-; RV32IM-NEXT:    slli a5, a1, 31
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    slli a6, a1, 29
-; RV32IM-NEXT:    slli a7, a0, 2
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    and a6, a6, a7
-; RV32IM-NEXT:    slli a7, a1, 28
-; RV32IM-NEXT:    slli t0, a0, 3
-; RV32IM-NEXT:    srai a7, a7, 31
-; RV32IM-NEXT:    and a5, a5, a0
-; RV32IM-NEXT:    and a7, a7, t0
-; RV32IM-NEXT:    xor a4, a5, a4
-; RV32IM-NEXT:    xor a5, a6, a7
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    slli a5, a0, 4
-; RV32IM-NEXT:    slli a6, a1, 27
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    slli a7, a1, 26
-; RV32IM-NEXT:    slli t0, a0, 5
-; RV32IM-NEXT:    srai a7, a7, 31
-; RV32IM-NEXT:    and a5, a6, a5
-; RV32IM-NEXT:    and a6, a7, t0
-; RV32IM-NEXT:    xor a5, a5, a6
-; RV32IM-NEXT:    slli a6, a1, 25
-; RV32IM-NEXT:    slli a7, a0, 6
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    and a6, a6, a7
-; RV32IM-NEXT:    andi a1, a1, 128
-; RV32IM-NEXT:    xor a5, a5, a6
-; RV32IM-NEXT:    seqz a1, a1
-; RV32IM-NEXT:    slli a0, a0, 7
-; RV32IM-NEXT:    addi a1, a1, -1
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    and a0, a1, a0
-; RV32IM-NEXT:    xor a0, a4, a0
-; RV32IM-NEXT:    sb a0, 0(a2)
-; RV32IM-NEXT:    sb a0, 0(a3)
-; RV32IM-NEXT:    ret
+; CHECK-M-LABEL: commutative_clmul_i8:
+; CHECK-M:       # %bb.0:
+; CHECK-M-NEXT:    andi a4, a1, 85
+; CHECK-M-NEXT:    andi a5, a0, -86
+; CHECK-M-NEXT:    andi a1, a1, -86
+; CHECK-M-NEXT:    andi a0, a0, 85
+; CHECK-M-NEXT:    mul a6, a5, a4
+; CHECK-M-NEXT:    mul a7, a0, a1
+; CHECK-M-NEXT:    mul a1, a5, a1
+; CHECK-M-NEXT:    mul a0, a0, a4
+; CHECK-M-NEXT:    xor a4, a7, a6
+; CHECK-M-NEXT:    xor a0, a0, a1
+; CHECK-M-NEXT:    andi a1, a4, -86
+; CHECK-M-NEXT:    andi a0, a0, 85
+; CHECK-M-NEXT:    or a0, a0, a1
+; CHECK-M-NEXT:    sb a0, 0(a2)
+; CHECK-M-NEXT:    sb a0, 0(a3)
+; CHECK-M-NEXT:    ret
 ;
-; RV64IM-LABEL: commutative_clmul_i8:
-; RV64IM:       # %bb.0:
-; RV64IM-NEXT:    slli a4, a1, 62
-; RV64IM-NEXT:    slli a5, a0, 1
-; RV64IM-NEXT:    srai a4, a4, 63
-; RV64IM-NEXT:    and a4, a4, a5
-; RV64IM-NEXT:    slli a5, a1, 63
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    slli a6, a1, 61
-; RV64IM-NEXT:    slli a7, a0, 2
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    and a6, a6, a7
-; RV64IM-NEXT:    slli a7, a1, 60
-; RV64IM-NEXT:    slli t0, a0, 3
-; RV64IM-NEXT:    srai a7, a7, 63
-; RV64IM-NEXT:    and a5, a5, a0
-; RV64IM-NEXT:    and a7, a7, t0
-; RV64IM-NEXT:    xor a4, a5, a4
-; RV64IM-NEXT:    xor a5, a6, a7
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    slli a5, a0, 4
-; RV64IM-NEXT:    slli a6, a1, 59
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    slli a7, a1, 58
-; RV64IM-NEXT:    slli t0, a0, 5
-; RV64IM-NEXT:    srai a7, a7, 63
-; RV64IM-NEXT:    and a5, a6, a5
-; RV64IM-NEXT:    and a6, a7, t0
-; RV64IM-NEXT:    xor a5, a5, a6
-; RV64IM-NEXT:    slli a6, a1, 57
-; RV64IM-NEXT:    slli a7, a0, 6
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    and a6, a6, a7
-; RV64IM-NEXT:    andi a1, a1, 128
-; RV64IM-NEXT:    xor a5, a5, a6
-; RV64IM-NEXT:    seqz a1, a1
-; RV64IM-NEXT:    slli a0, a0, 7
-; RV64IM-NEXT:    addi a1, a1, -1
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    and a0, a1, a0
-; RV64IM-NEXT:    xor a0, a4, a0
-; RV64IM-NEXT:    sb a0, 0(a2)
-; RV64IM-NEXT:    sb a0, 0(a3)
-; RV64IM-NEXT:    ret
-;
-; RV32IMZBS-LABEL: commutative_clmul_i8:
-; RV32IMZBS:       # %bb.0:
-; RV32IMZBS-NEXT:    slli a4, a1, 30
-; RV32IMZBS-NEXT:    slli a5, a0, 1
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    and a4, a4, a5
-; RV32IMZBS-NEXT:    slli a5, a1, 31
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    slli a6, a1, 29
-; RV32IMZBS-NEXT:    slli a7, a0, 2
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    and a6, a6, a7
-; RV32IMZBS-NEXT:    slli a7, a1, 28
-; RV32IMZBS-NEXT:    slli t0, a0, 3
-; RV32IMZBS-NEXT:    srai a7, a7, 31
-; RV32IMZBS-NEXT:    and a5, a5, a0
-; RV32IMZBS-NEXT:    and a7, a7, t0
-; RV32IMZBS-NEXT:    xor a4, a5, a4
-; RV32IMZBS-NEXT:    xor a5, a6, a7
-; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    slli a5, a0, 4
-; RV32IMZBS-NEXT:    slli a6, a1, 27
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    slli a7, a1, 26
-; RV32IMZBS-NEXT:    slli t0, a0, 5
-; RV32IMZBS-NEXT:    srai a7, a7, 31
-; RV32IMZBS-NEXT:    and a5, a6, a5
-; RV32IMZBS-NEXT:    and a6, a7, t0
-; RV32IMZBS-NEXT:    xor a5, a5, a6
-; RV32IMZBS-NEXT:    slli a6, a1, 25
-; RV32IMZBS-NEXT:    slli a7, a0, 6
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    and a6, a6, a7
-; RV32IMZBS-NEXT:    andi a1, a1, 128
-; RV32IMZBS-NEXT:    xor a5, a5, a6
-; RV32IMZBS-NEXT:    seqz a1, a1
-; RV32IMZBS-NEXT:    slli a0, a0, 7
-; RV32IMZBS-NEXT:    addi a1, a1, -1
-; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    and a0, a1, a0
-; RV32IMZBS-NEXT:    xor a0, a4, a0
-; RV32IMZBS-NEXT:    sb a0, 0(a2)
-; RV32IMZBS-NEXT:    sb a0, 0(a3)
-; RV32IMZBS-NEXT:    ret
-;
-; RV64IMZBS-LABEL: commutative_clmul_i8:
-; RV64IMZBS:       # %bb.0:
-; RV64IMZBS-NEXT:    slli a4, a1, 62
-; RV64IMZBS-NEXT:    slli a5, a0, 1
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    and a4, a4, a5
-; RV64IMZBS-NEXT:    slli a5, a1, 63
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    slli a6, a1, 61
-; RV64IMZBS-NEXT:    slli a7, a0, 2
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    and a6, a6, a7
-; RV64IMZBS-NEXT:    slli a7, a1, 60
-; RV64IMZBS-NEXT:    slli t0, a0, 3
-; RV64IMZBS-NEXT:    srai a7, a7, 63
-; RV64IMZBS-NEXT:    and a5, a5, a0
-; RV64IMZBS-NEXT:    and a7, a7, t0
-; RV64IMZBS-NEXT:    xor a4, a5, a4
-; RV64IMZBS-NEXT:    xor a5, a6, a7
-; RV64IMZBS-NEXT:    xor a4, a4, a5
-; RV64IMZBS-NEXT:    slli a5, a0, 4
-; RV64IMZBS-NEXT:    slli a6, a1, 59
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    slli a7, a1, 58
-; RV64IMZBS-NEXT:    slli t0, a0, 5
-; RV64IMZBS-NEXT:    srai a7, a7, 63
-; RV64IMZBS-NEXT:    and a5, a6, a5
-; RV64IMZBS-NEXT:    and a6, a7, t0
-; RV64IMZBS-NEXT:    xor a5, a5, a6
-; RV64IMZBS-NEXT:    slli a6, a1, 57
-; RV64IMZBS-NEXT:    slli a7, a0, 6
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    and a6, a6, a7
-; RV64IMZBS-NEXT:    andi a1, a1, 128
-; RV64IMZBS-NEXT:    xor a5, a5, a6
-; RV64IMZBS-NEXT:    seqz a1, a1
-; RV64IMZBS-NEXT:    slli a0, a0, 7
-; RV64IMZBS-NEXT:    addi a1, a1, -1
-; RV64IMZBS-NEXT:    xor a4, a4, a5
-; RV64IMZBS-NEXT:    and a0, a1, a0
-; RV64IMZBS-NEXT:    xor a0, a4, a0
-; RV64IMZBS-NEXT:    sb a0, 0(a2)
-; RV64IMZBS-NEXT:    sb a0, 0(a3)
-; RV64IMZBS-NEXT:    ret
+; CHECK-ZBS-LABEL: commutative_clmul_i8:
+; CHECK-ZBS:       # %bb.0:
+; CHECK-ZBS-NEXT:    andi a4, a1, 85
+; CHECK-ZBS-NEXT:    andi a5, a0, -86
+; CHECK-ZBS-NEXT:    andi a1, a1, -86
+; CHECK-ZBS-NEXT:    andi a0, a0, 85
+; CHECK-ZBS-NEXT:    mul a6, a5, a4
+; CHECK-ZBS-NEXT:    mul a7, a0, a1
+; CHECK-ZBS-NEXT:    mul a1, a5, a1
+; CHECK-ZBS-NEXT:    mul a0, a0, a4
+; CHECK-ZBS-NEXT:    xor a4, a7, a6
+; CHECK-ZBS-NEXT:    xor a0, a0, a1
+; CHECK-ZBS-NEXT:    andi a1, a4, -86
+; CHECK-ZBS-NEXT:    andi a0, a0, 85
+; CHECK-ZBS-NEXT:    or a0, a0, a1
+; CHECK-ZBS-NEXT:    sb a0, 0(a2)
+; CHECK-ZBS-NEXT:    sb a0, 0(a3)
+; CHECK-ZBS-NEXT:    ret
   %xy = call i8 @llvm.clmul.i8(i8 %x, i8 %y)
   %yx = call i8 @llvm.clmul.i8(i8 %y, i8 %x)
   store i8 %xy, ptr %p0
@@ -4069,45 +3539,19 @@ define void @mul_use_commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwi
 ; RV32IM-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw s1, 4(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv s0, a3
-; RV32IM-NEXT:    slli a3, a1, 30
-; RV32IM-NEXT:    slli a4, a0, 1
-; RV32IM-NEXT:    srai a3, a3, 31
-; RV32IM-NEXT:    and a3, a3, a4
-; RV32IM-NEXT:    slli a4, a1, 31
-; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    slli a5, a1, 29
-; RV32IM-NEXT:    slli a6, a0, 2
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    and a5, a5, a6
-; RV32IM-NEXT:    slli a6, a1, 28
-; RV32IM-NEXT:    slli a7, a0, 3
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    and a4, a4, a0
-; RV32IM-NEXT:    and a6, a6, a7
-; RV32IM-NEXT:    xor a3, a4, a3
-; RV32IM-NEXT:    xor a4, a5, a6
-; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    slli a4, a0, 4
-; RV32IM-NEXT:    slli a5, a1, 27
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    slli a6, a1, 26
-; RV32IM-NEXT:    slli a7, a0, 5
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    and a4, a5, a4
-; RV32IM-NEXT:    and a5, a6, a7
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    slli a5, a1, 25
-; RV32IM-NEXT:    slli a6, a0, 6
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    and a5, a5, a6
-; RV32IM-NEXT:    andi a1, a1, 128
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    seqz a1, a1
-; RV32IM-NEXT:    slli a0, a0, 7
-; RV32IM-NEXT:    addi a1, a1, -1
-; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    and a0, a1, a0
-; RV32IM-NEXT:    xor s1, a3, a0
+; RV32IM-NEXT:    andi a3, a1, 85
+; RV32IM-NEXT:    andi a4, a0, -86
+; RV32IM-NEXT:    andi a1, a1, -86
+; RV32IM-NEXT:    andi a0, a0, 85
+; RV32IM-NEXT:    mul a5, a4, a3
+; RV32IM-NEXT:    mul a6, a0, a1
+; RV32IM-NEXT:    mul a1, a4, a1
+; RV32IM-NEXT:    mul a0, a0, a3
+; RV32IM-NEXT:    xor a3, a6, a5
+; RV32IM-NEXT:    xor a0, a0, a1
+; RV32IM-NEXT:    andi a1, a3, -86
+; RV32IM-NEXT:    andi s1, a0, 85
+; RV32IM-NEXT:    or s1, s1, a1
 ; RV32IM-NEXT:    sb s1, 0(a2)
 ; RV32IM-NEXT:    mv a0, s1
 ; RV32IM-NEXT:    call use
@@ -4125,45 +3569,19 @@ define void @mul_use_commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwi
 ; RV64IM-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64IM-NEXT:    sd s1, 8(sp) # 8-byte Folded Spill
 ; RV64IM-NEXT:    mv s0, a3
-; RV64IM-NEXT:    slli a3, a1, 62
-; RV64IM-NEXT:    slli a4, a0, 1
-; RV64IM-NEXT:    srai a3, a3, 63
-; RV64IM-NEXT:    and a3, a3, a4
-; RV64IM-NEXT:    slli a4, a1, 63
-; RV64IM-NEXT:    srai a4, a4, 63
-; RV64IM-NEXT:    slli a5, a1, 61
-; RV64IM-NEXT:    slli a6, a0, 2
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    and a5, a5, a6
-; RV64IM-NEXT:    slli a6, a1, 60
-; RV64IM-NEXT:    slli a7, a0, 3
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    and a4, a4, a0
-; RV64IM-NEXT:    and a6, a6, a7
-; RV64IM-NEXT:    xor a3, a4, a3
-; RV64IM-NEXT:    xor a4, a5, a6
-; RV64IM-NEXT:    xor a3, a3, a4
-; RV64IM-NEXT:    slli a4, a0, 4
-; RV64IM-NEXT:    slli a5, a1, 59
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    slli a6, a1, 58
-; RV64IM-NEXT:    slli a7, a0, 5
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    and a4, a5, a4
-; RV64IM-NEXT:    and a5, a6, a7
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    slli a5, a1, 57
-; RV64IM-NEXT:    slli a6, a0, 6
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    and a5, a5, a6
-; RV64IM-NEXT:    andi a1, a1, 128
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    seqz a1, a1
-; RV64IM-NEXT:    slli a0, a0, 7
-; RV64IM-NEXT:    addi a1, a1, -1
-; RV64IM-NEXT:    xor a3, a3, a4
-; RV64IM-NEXT:    and a0, a1, a0
-; RV64IM-NEXT:    xor s1, a3, a0
+; RV64IM-NEXT:    andi a3, a1, 85
+; RV64IM-NEXT:    andi a4, a0, -86
+; RV64IM-NEXT:    andi a1, a1, -86
+; RV64IM-NEXT:    andi a0, a0, 85
+; RV64IM-NEXT:    mul a5, a4, a3
+; RV64IM-NEXT:    mul a6, a0, a1
+; RV64IM-NEXT:    mul a1, a4, a1
+; RV64IM-NEXT:    mul a0, a0, a3
+; RV64IM-NEXT:    xor a3, a6, a5
+; RV64IM-NEXT:    xor a0, a0, a1
+; RV64IM-NEXT:    andi a1, a3, -86
+; RV64IM-NEXT:    andi s1, a0, 85
+; RV64IM-NEXT:    or s1, s1, a1
 ; RV64IM-NEXT:    sb s1, 0(a2)
 ; RV64IM-NEXT:    mv a0, s1
 ; RV64IM-NEXT:    call use
@@ -4181,45 +3599,19 @@ define void @mul_use_commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwi
 ; RV32IMZBS-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw s1, 4(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv s0, a3
-; RV32IMZBS-NEXT:    slli a3, a1, 30
-; RV32IMZBS-NEXT:    slli a4, a0, 1
-; RV32IMZBS-NEXT:    srai a3, a3, 31
-; RV32IMZBS-NEXT:    and a3, a3, a4
-; RV32IMZBS-NEXT:    slli a4, a1, 31
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    slli a5, a1, 29
-; RV32IMZBS-NEXT:    slli a6, a0, 2
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    and a5, a5, a6
-; RV32IMZBS-NEXT:    slli a6, a1, 28
-; RV32IMZBS-NEXT:    slli a7, a0, 3
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    and a4, a4, a0
-; RV32IMZBS-NEXT:    and a6, a6, a7
-; RV32IMZBS-NEXT:    xor a3, a4, a3
-; RV32IMZBS-NEXT:    xor a4, a5, a6
-; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    slli a4, a0, 4
-; RV32IMZBS-NEXT:    slli a5, a1, 27
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    slli a6, a1, 26
-; RV32IMZBS-NEXT:    slli a7, a0, 5
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    and a4, a5, a4
-; RV32IMZBS-NEXT:    and a5, a6, a7
-; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    slli a5, a1, 25
-; RV32IMZBS-NEXT:    slli a6, a0, 6
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    and a5, a5, a6
-; RV32IMZBS-NEXT:    andi a1, a1, 128
-; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    seqz a1, a1
-; RV32IMZBS-NEXT:    slli a0, a0, 7
-; RV32IMZBS-NEXT:    addi a1, a1, -1
-; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    and a0, a1, a0
-; RV32IMZBS-NEXT:    xor s1, a3, a0
+; RV32IMZBS-NEXT:    andi a3, a1, 85
+; RV32IMZBS-NEXT:    andi a4, a0, -86
+; RV32IMZBS-NEXT:    andi a1, a1, -86
+; RV32IMZBS-NEXT:    andi a0, a0, 85
+; RV32IMZBS-NEXT:    mul a5, a4, a3
+; RV32IMZBS-NEXT:    mul a6, a0, a1
+; RV32IMZBS-NEXT:    mul a1, a4, a1
+; RV32IMZBS-NEXT:    mul a0, a0, a3
+; RV32IMZBS-NEXT:    xor a3, a6, a5
+; RV32IMZBS-NEXT:    xor a0, a0, a1
+; RV32IMZBS-NEXT:    andi a1, a3, -86
+; RV32IMZBS-NEXT:    andi s1, a0, 85
+; RV32IMZBS-NEXT:    or s1, s1, a1
 ; RV32IMZBS-NEXT:    sb s1, 0(a2)
 ; RV32IMZBS-NEXT:    mv a0, s1
 ; RV32IMZBS-NEXT:    call use
@@ -4237,45 +3629,19 @@ define void @mul_use_commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwi
 ; RV64IMZBS-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64IMZBS-NEXT:    sd s1, 8(sp) # 8-byte Folded Spill
 ; RV64IMZBS-NEXT:    mv s0, a3
-; RV64IMZBS-NEXT:    slli a3, a1, 62
-; RV64IMZBS-NEXT:    slli a4, a0, 1
-; RV64IMZBS-NEXT:    srai a3, a3, 63
-; RV64IMZBS-NEXT:    and a3, a3, a4
-; RV64IMZBS-NEXT:    slli a4, a1, 63
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    slli a5, a1, 61
-; RV64IMZBS-NEXT:    slli a6, a0, 2
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    and a5, a5, a6
-; RV64IMZBS-NEXT:    slli a6, a1, 60
-; RV64IMZBS-NEXT:    slli a7, a0, 3
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    and a4, a4, a0
-; RV64IMZBS-NEXT:    and a6, a6, a7
-; RV64IMZBS-NEXT:    xor a3, a4, a3
-; RV64IMZBS-NEXT:    xor a4, a5, a6
-; RV64IMZBS-NEXT:    xor a3, a3, a4
-; RV64IMZBS-NEXT:    slli a4, a0, 4
-; RV64IMZBS-NEXT:    slli a5, a1, 59
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    slli a6, a1, 58
-; RV64IMZBS-NEXT:    slli a7, a0, 5
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    and a4, a5, a4
-; RV64IMZBS-NEXT:    and a5, a6, a7
-; RV64IMZBS-NEXT:    xor a4, a4, a5
-; RV64IMZBS-NEXT:    slli a5, a1, 57
-; RV64IMZBS-NEXT:    slli a6, a0, 6
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    and a5, a5, a6
-; RV64IMZBS-NEXT:    andi a1, a1, 128
-; RV64IMZBS-NEXT:    xor a4, a4, a5
-; RV64IMZBS-NEXT:    seqz a1, a1
-; RV64IMZBS-NEXT:    slli a0, a0, 7
-; RV64IMZBS-NEXT:    addi a1, a1, -1
-; RV64IMZBS-NEXT:    xor a3, a3, a4
-; RV64IMZBS-NEXT:    and a0, a1, a0
-; RV64IMZBS-NEXT:    xor s1, a3, a0
+; RV64IMZBS-NEXT:    andi a3, a1, 85
+; RV64IMZBS-NEXT:    andi a4, a0, -86
+; RV64IMZBS-NEXT:    andi a1, a1, -86
+; RV64IMZBS-NEXT:    andi a0, a0, 85
+; RV64IMZBS-NEXT:    mul a5, a4, a3
+; RV64IMZBS-NEXT:    mul a6, a0, a1
+; RV64IMZBS-NEXT:    mul a1, a4, a1
+; RV64IMZBS-NEXT:    mul a0, a0, a3
+; RV64IMZBS-NEXT:    xor a3, a6, a5
+; RV64IMZBS-NEXT:    xor a0, a0, a1
+; RV64IMZBS-NEXT:    andi a1, a3, -86
+; RV64IMZBS-NEXT:    andi s1, a0, 85
+; RV64IMZBS-NEXT:    or s1, s1, a1
 ; RV64IMZBS-NEXT:    sb s1, 0(a2)
 ; RV64IMZBS-NEXT:    mv a0, s1
 ; RV64IMZBS-NEXT:    call use
@@ -4384,185 +3750,43 @@ define void @neg_commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwind {
 ; RV64I-NEXT:    sb a0, 0(a3)
 ; RV64I-NEXT:    ret
 ;
-; RV32IM-LABEL: neg_commutative_clmul_i8:
-; RV32IM:       # %bb.0:
-; RV32IM-NEXT:    slli a4, a1, 30
-; RV32IM-NEXT:    slli a5, a0, 1
-; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    and a4, a4, a5
-; RV32IM-NEXT:    slli a5, a1, 31
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    slli a6, a1, 29
-; RV32IM-NEXT:    slli a7, a0, 2
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    and a6, a6, a7
-; RV32IM-NEXT:    slli a7, a1, 28
-; RV32IM-NEXT:    slli t0, a0, 3
-; RV32IM-NEXT:    srai a7, a7, 31
-; RV32IM-NEXT:    and a5, a5, a0
-; RV32IM-NEXT:    and a7, a7, t0
-; RV32IM-NEXT:    xor a4, a5, a4
-; RV32IM-NEXT:    xor a5, a6, a7
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    slli a5, a0, 4
-; RV32IM-NEXT:    slli a6, a1, 27
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    slli a7, a1, 26
-; RV32IM-NEXT:    slli t0, a0, 5
-; RV32IM-NEXT:    srai a7, a7, 31
-; RV32IM-NEXT:    and a5, a6, a5
-; RV32IM-NEXT:    and a6, a7, t0
-; RV32IM-NEXT:    xor a5, a5, a6
-; RV32IM-NEXT:    slli a6, a1, 25
-; RV32IM-NEXT:    slli a7, a0, 6
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    and a6, a6, a7
-; RV32IM-NEXT:    andi a1, a1, 128
-; RV32IM-NEXT:    xor a5, a5, a6
-; RV32IM-NEXT:    seqz a1, a1
-; RV32IM-NEXT:    slli a0, a0, 7
-; RV32IM-NEXT:    addi a1, a1, -1
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    and a0, a1, a0
-; RV32IM-NEXT:    xor a0, a4, a0
-; RV32IM-NEXT:    sb a0, 0(a2)
-; RV32IM-NEXT:    sb a0, 0(a3)
-; RV32IM-NEXT:    ret
+; CHECK-M-LABEL: neg_commutative_clmul_i8:
+; CHECK-M:       # %bb.0:
+; CHECK-M-NEXT:    andi a4, a1, 85
+; CHECK-M-NEXT:    andi a5, a0, -86
+; CHECK-M-NEXT:    andi a1, a1, -86
+; CHECK-M-NEXT:    andi a0, a0, 85
+; CHECK-M-NEXT:    mul a6, a5, a4
+; CHECK-M-NEXT:    mul a7, a0, a1
+; CHECK-M-NEXT:    mul a1, a5, a1
+; CHECK-M-NEXT:    mul a0, a0, a4
+; CHECK-M-NEXT:    xor a4, a7, a6
+; CHECK-M-NEXT:    xor a0, a0, a1
+; CHECK-M-NEXT:    andi a1, a4, -86
+; CHECK-M-NEXT:    andi a0, a0, 85
+; CHECK-M-NEXT:    or a0, a0, a1
+; CHECK-M-NEXT:    sb a0, 0(a2)
+; CHECK-M-NEXT:    sb a0, 0(a3)
+; CHECK-M-NEXT:    ret
 ;
-; RV64IM-LABEL: neg_commutative_clmul_i8:
-; RV64IM:       # %bb.0:
-; RV64IM-NEXT:    slli a4, a1, 62
-; RV64IM-NEXT:    slli a5, a0, 1
-; RV64IM-NEXT:    srai a4, a4, 63
-; RV64IM-NEXT:    and a4, a4, a5
-; RV64IM-NEXT:    slli a5, a1, 63
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    slli a6, a1, 61
-; RV64IM-NEXT:    slli a7, a0, 2
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    and a6, a6, a7
-; RV64IM-NEXT:    slli a7, a1, 60
-; RV64IM-NEXT:    slli t0, a0, 3
-; RV64IM-NEXT:    srai a7, a7, 63
-; RV64IM-NEXT:    and a5, a5, a0
-; RV64IM-NEXT:    and a7, a7, t0
-; RV64IM-NEXT:    xor a4, a5, a4
-; RV64IM-NEXT:    xor a5, a6, a7
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    slli a5, a0, 4
-; RV64IM-NEXT:    slli a6, a1, 59
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    slli a7, a1, 58
-; RV64IM-NEXT:    slli t0, a0, 5
-; RV64IM-NEXT:    srai a7, a7, 63
-; RV64IM-NEXT:    and a5, a6, a5
-; RV64IM-NEXT:    and a6, a7, t0
-; RV64IM-NEXT:    xor a5, a5, a6
-; RV64IM-NEXT:    slli a6, a1, 57
-; RV64IM-NEXT:    slli a7, a0, 6
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    and a6, a6, a7
-; RV64IM-NEXT:    andi a1, a1, 128
-; RV64IM-NEXT:    xor a5, a5, a6
-; RV64IM-NEXT:    seqz a1, a1
-; RV64IM-NEXT:    slli a0, a0, 7
-; RV64IM-NEXT:    addi a1, a1, -1
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    and a0, a1, a0
-; RV64IM-NEXT:    xor a0, a4, a0
-; RV64IM-NEXT:    sb a0, 0(a2)
-; RV64IM-NEXT:    sb a0, 0(a3)
-; RV64IM-NEXT:    ret
-;
-; RV32IMZBS-LABEL: neg_commutative_clmul_i8:
-; RV32IMZBS:       # %bb.0:
-; RV32IMZBS-NEXT:    slli a4, a1, 30
-; RV32IMZBS-NEXT:    slli a5, a0, 1
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    and a4, a4, a5
-; RV32IMZBS-NEXT:    slli a5, a1, 31
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    slli a6, a1, 29
-; RV32IMZBS-NEXT:    slli a7, a0, 2
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    and a6, a6, a7
-; RV32IMZBS-NEXT:    slli a7, a1, 28
-; RV32IMZBS-NEXT:    slli t0, a0, 3
-; RV32IMZBS-NEXT:    srai a7, a7, 31
-; RV32IMZBS-NEXT:    and a5, a5, a0
-; RV32IMZBS-NEXT:    and a7, a7, t0
-; RV32IMZBS-NEXT:    xor a4, a5, a4
-; RV32IMZBS-NEXT:    xor a5, a6, a7
-; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    slli a5, a0, 4
-; RV32IMZBS-NEXT:    slli a6, a1, 27
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    slli a7, a1, 26
-; RV32IMZBS-NEXT:    slli t0, a0, 5
-; RV32IMZBS-NEXT:    srai a7, a7, 31
-; RV32IMZBS-NEXT:    and a5, a6, a5
-; RV32IMZBS-NEXT:    and a6, a7, t0
-; RV32IMZBS-NEXT:    xor a5, a5, a6
-; RV32IMZBS-NEXT:    slli a6, a1, 25
-; RV32IMZBS-NEXT:    slli a7, a0, 6
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    and a6, a6, a7
-; RV32IMZBS-NEXT:    andi a1, a1, 128
-; RV32IMZBS-NEXT:    xor a5, a5, a6
-; RV32IMZBS-NEXT:    seqz a1, a1
-; RV32IMZBS-NEXT:    slli a0, a0, 7
-; RV32IMZBS-NEXT:    addi a1, a1, -1
-; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    and a0, a1, a0
-; RV32IMZBS-NEXT:    xor a0, a4, a0
-; RV32IMZBS-NEXT:    sb a0, 0(a2)
-; RV32IMZBS-NEXT:    sb a0, 0(a3)
-; RV32IMZBS-NEXT:    ret
-;
-; RV64IMZBS-LABEL: neg_commutative_clmul_i8:
-; RV64IMZBS:       # %bb.0:
-; RV64IMZBS-NEXT:    slli a4, a1, 62
-; RV64IMZBS-NEXT:    slli a5, a0, 1
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    and a4, a4, a5
-; RV64IMZBS-NEXT:    slli a5, a1, 63
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    slli a6, a1, 61
-; RV64IMZBS-NEXT:    slli a7, a0, 2
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    and a6, a6, a7
-; RV64IMZBS-NEXT:    slli a7, a1, 60
-; RV64IMZBS-NEXT:    slli t0, a0, 3
-; RV64IMZBS-NEXT:    srai a7, a7, 63
-; RV64IMZBS-NEXT:    and a5, a5, a0
-; RV64IMZBS-NEXT:    and a7, a7, t0
-; RV64IMZBS-NEXT:    xor a4, a5, a4
-; RV64IMZBS-NEXT:    xor a5, a6, a7
-; RV64IMZBS-NEXT:    xor a4, a4, a5
-; RV64IMZBS-NEXT:    slli a5, a0, 4
-; RV64IMZBS-NEXT:    slli a6, a1, 59
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    slli a7, a1, 58
-; RV64IMZBS-NEXT:    slli t0, a0, 5
-; RV64IMZBS-NEXT:    srai a7, a7, 63
-; RV64IMZBS-NEXT:    and a5, a6, a5
-; RV64IMZBS-NEXT:    and a6, a7, t0
-; RV64IMZBS-NEXT:    xor a5, a5, a6
-; RV64IMZBS-NEXT:    slli a6, a1, 57
-; RV64IMZBS-NEXT:    slli a7, a0, 6
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    and a6, a6, a7
-; RV64IMZBS-NEXT:    andi a1, a1, 128
-; RV64IMZBS-NEXT:    xor a5, a5, a6
-; RV64IMZBS-NEXT:    seqz a1, a1
-; RV64IMZBS-NEXT:    slli a0, a0, 7
-; RV64IMZBS-NEXT:    addi a1, a1, -1
-; RV64IMZBS-NEXT:    xor a4, a4, a5
-; RV64IMZBS-NEXT:    and a0, a1, a0
-; RV64IMZBS-NEXT:    xor a0, a4, a0
-; RV64IMZBS-NEXT:    sb a0, 0(a2)
-; RV64IMZBS-NEXT:    sb a0, 0(a3)
-; RV64IMZBS-NEXT:    ret
+; CHECK-ZBS-LABEL: neg_commutative_clmul_i8:
+; CHECK-ZBS:       # %bb.0:
+; CHECK-ZBS-NEXT:    andi a4, a1, 85
+; CHECK-ZBS-NEXT:    andi a5, a0, -86
+; CHECK-ZBS-NEXT:    andi a1, a1, -86
+; CHECK-ZBS-NEXT:    andi a0, a0, 85
+; CHECK-ZBS-NEXT:    mul a6, a5, a4
+; CHECK-ZBS-NEXT:    mul a7, a0, a1
+; CHECK-ZBS-NEXT:    mul a1, a5, a1
+; CHECK-ZBS-NEXT:    mul a0, a0, a4
+; CHECK-ZBS-NEXT:    xor a4, a7, a6
+; CHECK-ZBS-NEXT:    xor a0, a0, a1
+; CHECK-ZBS-NEXT:    andi a1, a4, -86
+; CHECK-ZBS-NEXT:    andi a0, a0, 85
+; CHECK-ZBS-NEXT:    or a0, a0, a1
+; CHECK-ZBS-NEXT:    sb a0, 0(a2)
+; CHECK-ZBS-NEXT:    sb a0, 0(a3)
+; CHECK-ZBS-NEXT:    ret
   %xy = call i8 @llvm.clmul.i8(i8 %x, i8 %y)
   store i8 %xy, ptr %p0
   store i8 %xy, ptr %p1
@@ -13077,5 +12301,3 @@ define void @mul_use_commutative_clmul_v2i64(<2 x i64> %x, <2 x i64> %y, ptr %p0
 }
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
 ; CHECK-I: {{.*}}
-; CHECK-M: {{.*}}
-; CHECK-ZBS: {{.*}}

--- a/llvm/test/CodeGen/RISCV/clmulr.ll
+++ b/llvm/test/CodeGen/RISCV/clmulr.ll
@@ -2678,45 +2678,19 @@ define void @mul_use_commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwi
 ; RV32IM-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    sw s1, 4(sp) # 4-byte Folded Spill
 ; RV32IM-NEXT:    mv s0, a3
-; RV32IM-NEXT:    slli a3, a1, 30
-; RV32IM-NEXT:    slli a4, a0, 1
-; RV32IM-NEXT:    srai a3, a3, 31
-; RV32IM-NEXT:    and a3, a3, a4
-; RV32IM-NEXT:    slli a4, a1, 31
-; RV32IM-NEXT:    srai a4, a4, 31
-; RV32IM-NEXT:    slli a5, a1, 29
-; RV32IM-NEXT:    slli a6, a0, 2
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    and a5, a5, a6
-; RV32IM-NEXT:    slli a6, a1, 28
-; RV32IM-NEXT:    slli a7, a0, 3
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    and a4, a4, a0
-; RV32IM-NEXT:    and a6, a6, a7
-; RV32IM-NEXT:    xor a3, a4, a3
-; RV32IM-NEXT:    xor a4, a5, a6
-; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    slli a4, a0, 4
-; RV32IM-NEXT:    slli a5, a1, 27
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    slli a6, a1, 26
-; RV32IM-NEXT:    slli a7, a0, 5
-; RV32IM-NEXT:    srai a6, a6, 31
-; RV32IM-NEXT:    and a4, a5, a4
-; RV32IM-NEXT:    and a5, a6, a7
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    slli a5, a1, 25
-; RV32IM-NEXT:    slli a6, a0, 6
-; RV32IM-NEXT:    srai a5, a5, 31
-; RV32IM-NEXT:    and a5, a5, a6
-; RV32IM-NEXT:    andi a1, a1, 128
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    seqz a1, a1
-; RV32IM-NEXT:    slli a0, a0, 7
-; RV32IM-NEXT:    addi a1, a1, -1
-; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    and a0, a1, a0
-; RV32IM-NEXT:    xor s1, a3, a0
+; RV32IM-NEXT:    andi a3, a1, 85
+; RV32IM-NEXT:    andi a4, a0, -86
+; RV32IM-NEXT:    andi a1, a1, -86
+; RV32IM-NEXT:    andi a0, a0, 85
+; RV32IM-NEXT:    mul a5, a4, a3
+; RV32IM-NEXT:    mul a6, a0, a1
+; RV32IM-NEXT:    mul a1, a4, a1
+; RV32IM-NEXT:    mul a0, a0, a3
+; RV32IM-NEXT:    xor a3, a6, a5
+; RV32IM-NEXT:    xor a0, a0, a1
+; RV32IM-NEXT:    andi a1, a3, -86
+; RV32IM-NEXT:    andi s1, a0, 85
+; RV32IM-NEXT:    or s1, s1, a1
 ; RV32IM-NEXT:    sb s1, 0(a2)
 ; RV32IM-NEXT:    mv a0, s1
 ; RV32IM-NEXT:    call use
@@ -2734,45 +2708,19 @@ define void @mul_use_commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwi
 ; RV64IM-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64IM-NEXT:    sd s1, 8(sp) # 8-byte Folded Spill
 ; RV64IM-NEXT:    mv s0, a3
-; RV64IM-NEXT:    slli a3, a1, 62
-; RV64IM-NEXT:    slli a4, a0, 1
-; RV64IM-NEXT:    srai a3, a3, 63
-; RV64IM-NEXT:    and a3, a3, a4
-; RV64IM-NEXT:    slli a4, a1, 63
-; RV64IM-NEXT:    srai a4, a4, 63
-; RV64IM-NEXT:    slli a5, a1, 61
-; RV64IM-NEXT:    slli a6, a0, 2
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    and a5, a5, a6
-; RV64IM-NEXT:    slli a6, a1, 60
-; RV64IM-NEXT:    slli a7, a0, 3
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    and a4, a4, a0
-; RV64IM-NEXT:    and a6, a6, a7
-; RV64IM-NEXT:    xor a3, a4, a3
-; RV64IM-NEXT:    xor a4, a5, a6
-; RV64IM-NEXT:    xor a3, a3, a4
-; RV64IM-NEXT:    slli a4, a0, 4
-; RV64IM-NEXT:    slli a5, a1, 59
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    slli a6, a1, 58
-; RV64IM-NEXT:    slli a7, a0, 5
-; RV64IM-NEXT:    srai a6, a6, 63
-; RV64IM-NEXT:    and a4, a5, a4
-; RV64IM-NEXT:    and a5, a6, a7
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    slli a5, a1, 57
-; RV64IM-NEXT:    slli a6, a0, 6
-; RV64IM-NEXT:    srai a5, a5, 63
-; RV64IM-NEXT:    and a5, a5, a6
-; RV64IM-NEXT:    andi a1, a1, 128
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    seqz a1, a1
-; RV64IM-NEXT:    slli a0, a0, 7
-; RV64IM-NEXT:    addi a1, a1, -1
-; RV64IM-NEXT:    xor a3, a3, a4
-; RV64IM-NEXT:    and a0, a1, a0
-; RV64IM-NEXT:    xor s1, a3, a0
+; RV64IM-NEXT:    andi a3, a1, 85
+; RV64IM-NEXT:    andi a4, a0, -86
+; RV64IM-NEXT:    andi a1, a1, -86
+; RV64IM-NEXT:    andi a0, a0, 85
+; RV64IM-NEXT:    mul a5, a4, a3
+; RV64IM-NEXT:    mul a6, a0, a1
+; RV64IM-NEXT:    mul a1, a4, a1
+; RV64IM-NEXT:    mul a0, a0, a3
+; RV64IM-NEXT:    xor a3, a6, a5
+; RV64IM-NEXT:    xor a0, a0, a1
+; RV64IM-NEXT:    andi a1, a3, -86
+; RV64IM-NEXT:    andi s1, a0, 85
+; RV64IM-NEXT:    or s1, s1, a1
 ; RV64IM-NEXT:    sb s1, 0(a2)
 ; RV64IM-NEXT:    mv a0, s1
 ; RV64IM-NEXT:    call use
@@ -2790,45 +2738,19 @@ define void @mul_use_commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwi
 ; RV32IMZBS-NEXT:    sw s0, 8(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    sw s1, 4(sp) # 4-byte Folded Spill
 ; RV32IMZBS-NEXT:    mv s0, a3
-; RV32IMZBS-NEXT:    slli a3, a1, 30
-; RV32IMZBS-NEXT:    slli a4, a0, 1
-; RV32IMZBS-NEXT:    srai a3, a3, 31
-; RV32IMZBS-NEXT:    and a3, a3, a4
-; RV32IMZBS-NEXT:    slli a4, a1, 31
-; RV32IMZBS-NEXT:    srai a4, a4, 31
-; RV32IMZBS-NEXT:    slli a5, a1, 29
-; RV32IMZBS-NEXT:    slli a6, a0, 2
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    and a5, a5, a6
-; RV32IMZBS-NEXT:    slli a6, a1, 28
-; RV32IMZBS-NEXT:    slli a7, a0, 3
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    and a4, a4, a0
-; RV32IMZBS-NEXT:    and a6, a6, a7
-; RV32IMZBS-NEXT:    xor a3, a4, a3
-; RV32IMZBS-NEXT:    xor a4, a5, a6
-; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    slli a4, a0, 4
-; RV32IMZBS-NEXT:    slli a5, a1, 27
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    slli a6, a1, 26
-; RV32IMZBS-NEXT:    slli a7, a0, 5
-; RV32IMZBS-NEXT:    srai a6, a6, 31
-; RV32IMZBS-NEXT:    and a4, a5, a4
-; RV32IMZBS-NEXT:    and a5, a6, a7
-; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    slli a5, a1, 25
-; RV32IMZBS-NEXT:    slli a6, a0, 6
-; RV32IMZBS-NEXT:    srai a5, a5, 31
-; RV32IMZBS-NEXT:    and a5, a5, a6
-; RV32IMZBS-NEXT:    andi a1, a1, 128
-; RV32IMZBS-NEXT:    xor a4, a4, a5
-; RV32IMZBS-NEXT:    seqz a1, a1
-; RV32IMZBS-NEXT:    slli a0, a0, 7
-; RV32IMZBS-NEXT:    addi a1, a1, -1
-; RV32IMZBS-NEXT:    xor a3, a3, a4
-; RV32IMZBS-NEXT:    and a0, a1, a0
-; RV32IMZBS-NEXT:    xor s1, a3, a0
+; RV32IMZBS-NEXT:    andi a3, a1, 85
+; RV32IMZBS-NEXT:    andi a4, a0, -86
+; RV32IMZBS-NEXT:    andi a1, a1, -86
+; RV32IMZBS-NEXT:    andi a0, a0, 85
+; RV32IMZBS-NEXT:    mul a5, a4, a3
+; RV32IMZBS-NEXT:    mul a6, a0, a1
+; RV32IMZBS-NEXT:    mul a1, a4, a1
+; RV32IMZBS-NEXT:    mul a0, a0, a3
+; RV32IMZBS-NEXT:    xor a3, a6, a5
+; RV32IMZBS-NEXT:    xor a0, a0, a1
+; RV32IMZBS-NEXT:    andi a1, a3, -86
+; RV32IMZBS-NEXT:    andi s1, a0, 85
+; RV32IMZBS-NEXT:    or s1, s1, a1
 ; RV32IMZBS-NEXT:    sb s1, 0(a2)
 ; RV32IMZBS-NEXT:    mv a0, s1
 ; RV32IMZBS-NEXT:    call use
@@ -2846,45 +2768,19 @@ define void @mul_use_commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwi
 ; RV64IMZBS-NEXT:    sd s0, 16(sp) # 8-byte Folded Spill
 ; RV64IMZBS-NEXT:    sd s1, 8(sp) # 8-byte Folded Spill
 ; RV64IMZBS-NEXT:    mv s0, a3
-; RV64IMZBS-NEXT:    slli a3, a1, 62
-; RV64IMZBS-NEXT:    slli a4, a0, 1
-; RV64IMZBS-NEXT:    srai a3, a3, 63
-; RV64IMZBS-NEXT:    and a3, a3, a4
-; RV64IMZBS-NEXT:    slli a4, a1, 63
-; RV64IMZBS-NEXT:    srai a4, a4, 63
-; RV64IMZBS-NEXT:    slli a5, a1, 61
-; RV64IMZBS-NEXT:    slli a6, a0, 2
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    and a5, a5, a6
-; RV64IMZBS-NEXT:    slli a6, a1, 60
-; RV64IMZBS-NEXT:    slli a7, a0, 3
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    and a4, a4, a0
-; RV64IMZBS-NEXT:    and a6, a6, a7
-; RV64IMZBS-NEXT:    xor a3, a4, a3
-; RV64IMZBS-NEXT:    xor a4, a5, a6
-; RV64IMZBS-NEXT:    xor a3, a3, a4
-; RV64IMZBS-NEXT:    slli a4, a0, 4
-; RV64IMZBS-NEXT:    slli a5, a1, 59
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    slli a6, a1, 58
-; RV64IMZBS-NEXT:    slli a7, a0, 5
-; RV64IMZBS-NEXT:    srai a6, a6, 63
-; RV64IMZBS-NEXT:    and a4, a5, a4
-; RV64IMZBS-NEXT:    and a5, a6, a7
-; RV64IMZBS-NEXT:    xor a4, a4, a5
-; RV64IMZBS-NEXT:    slli a5, a1, 57
-; RV64IMZBS-NEXT:    slli a6, a0, 6
-; RV64IMZBS-NEXT:    srai a5, a5, 63
-; RV64IMZBS-NEXT:    and a5, a5, a6
-; RV64IMZBS-NEXT:    andi a1, a1, 128
-; RV64IMZBS-NEXT:    xor a4, a4, a5
-; RV64IMZBS-NEXT:    seqz a1, a1
-; RV64IMZBS-NEXT:    slli a0, a0, 7
-; RV64IMZBS-NEXT:    addi a1, a1, -1
-; RV64IMZBS-NEXT:    xor a3, a3, a4
-; RV64IMZBS-NEXT:    and a0, a1, a0
-; RV64IMZBS-NEXT:    xor s1, a3, a0
+; RV64IMZBS-NEXT:    andi a3, a1, 85
+; RV64IMZBS-NEXT:    andi a4, a0, -86
+; RV64IMZBS-NEXT:    andi a1, a1, -86
+; RV64IMZBS-NEXT:    andi a0, a0, 85
+; RV64IMZBS-NEXT:    mul a5, a4, a3
+; RV64IMZBS-NEXT:    mul a6, a0, a1
+; RV64IMZBS-NEXT:    mul a1, a4, a1
+; RV64IMZBS-NEXT:    mul a0, a0, a3
+; RV64IMZBS-NEXT:    xor a3, a6, a5
+; RV64IMZBS-NEXT:    xor a0, a0, a1
+; RV64IMZBS-NEXT:    andi a1, a3, -86
+; RV64IMZBS-NEXT:    andi s1, a0, 85
+; RV64IMZBS-NEXT:    or s1, s1, a1
 ; RV64IMZBS-NEXT:    sb s1, 0(a2)
 ; RV64IMZBS-NEXT:    mv a0, s1
 ; RV64IMZBS-NEXT:    call use

--- a/llvm/test/CodeGen/RISCV/rvv/clmul-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/clmul-sdnode.ll
@@ -9,66 +9,42 @@
 define <vscale x 1 x i8> @clmul_nxv1i8_vv(<vscale x 1 x i8> %va, <vscale x 1 x i8> %vb) nounwind {
 ; RV32V-LABEL: clmul_nxv1i8_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
-; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    li a0, 85
+; RV32V-NEXT:    li a1, 170
+; RV32V-NEXT:    vsetvli a2, zero, e8, mf8, ta, ma
+; RV32V-NEXT:    vand.vx v10, v9, a0
+; RV32V-NEXT:    vand.vx v11, v8, a1
+; RV32V-NEXT:    vand.vx v9, v9, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vmul.vv v12, v11, v10
+; RV32V-NEXT:    vmul.vv v13, v8, v9
+; RV32V-NEXT:    vmul.vv v9, v11, v9
+; RV32V-NEXT:    vmul.vv v8, v8, v10
+; RV32V-NEXT:    vxor.vv v10, v13, v12
+; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vand.vx v9, v10, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vor.vv v8, v8, v9
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv1i8_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
-; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    li a0, 85
+; RV64V-NEXT:    li a1, 170
+; RV64V-NEXT:    vsetvli a2, zero, e8, mf8, ta, ma
+; RV64V-NEXT:    vand.vx v10, v9, a0
+; RV64V-NEXT:    vand.vx v11, v8, a1
+; RV64V-NEXT:    vand.vx v9, v9, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vmul.vv v12, v11, v10
+; RV64V-NEXT:    vmul.vv v13, v8, v9
+; RV64V-NEXT:    vmul.vv v9, v11, v9
+; RV64V-NEXT:    vmul.vv v8, v8, v10
+; RV64V-NEXT:    vxor.vv v10, v13, v12
+; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vand.vx v9, v10, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vor.vv v8, v8, v9
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv1i8_vv:
@@ -119,66 +95,42 @@ define <vscale x 1 x i8> @clmul_nxv1i8_vx(<vscale x 1 x i8> %va, i8 %b) nounwind
 ; RV32V:       # %bb.0:
 ; RV32V-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
 ; RV32V-NEXT:    vmv.v.x v9, a0
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    li a0, 128
+; RV32V-NEXT:    li a0, 170
+; RV32V-NEXT:    li a1, 85
+; RV32V-NEXT:    vand.vx v10, v8, a0
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vand.vx v11, v9, a1
 ; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
-; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vmul.vv v12, v10, v11
+; RV32V-NEXT:    vmul.vv v13, v8, v9
+; RV32V-NEXT:    vmul.vv v9, v10, v9
+; RV32V-NEXT:    vmul.vv v8, v8, v11
+; RV32V-NEXT:    vxor.vv v10, v13, v12
+; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vand.vx v9, v10, a0
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vor.vv v8, v8, v9
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv1i8_vx:
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
 ; RV64V-NEXT:    vmv.v.x v9, a0
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    li a0, 128
+; RV64V-NEXT:    li a0, 170
+; RV64V-NEXT:    li a1, 85
+; RV64V-NEXT:    vand.vx v10, v8, a0
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vand.vx v11, v9, a1
 ; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
-; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vmul.vv v12, v10, v11
+; RV64V-NEXT:    vmul.vv v13, v8, v9
+; RV64V-NEXT:    vmul.vv v9, v10, v9
+; RV64V-NEXT:    vmul.vv v8, v8, v11
+; RV64V-NEXT:    vxor.vv v10, v13, v12
+; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vand.vx v9, v10, a0
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vor.vv v8, v8, v9
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv1i8_vx:
@@ -233,66 +185,42 @@ define <vscale x 1 x i8> @clmul_nxv1i8_vx(<vscale x 1 x i8> %va, i8 %b) nounwind
 define <vscale x 2 x i8> @clmul_nxv2i8_vv(<vscale x 2 x i8> %va, <vscale x 2 x i8> %vb) nounwind {
 ; RV32V-LABEL: clmul_nxv2i8_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vsetvli a1, zero, e8, mf4, ta, ma
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
-; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    li a0, 85
+; RV32V-NEXT:    li a1, 170
+; RV32V-NEXT:    vsetvli a2, zero, e8, mf4, ta, ma
+; RV32V-NEXT:    vand.vx v10, v9, a0
+; RV32V-NEXT:    vand.vx v11, v8, a1
+; RV32V-NEXT:    vand.vx v9, v9, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vmul.vv v12, v11, v10
+; RV32V-NEXT:    vmul.vv v13, v8, v9
+; RV32V-NEXT:    vmul.vv v9, v11, v9
+; RV32V-NEXT:    vmul.vv v8, v8, v10
+; RV32V-NEXT:    vxor.vv v10, v13, v12
+; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vand.vx v9, v10, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vor.vv v8, v8, v9
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv2i8_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vsetvli a1, zero, e8, mf4, ta, ma
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
-; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    li a0, 85
+; RV64V-NEXT:    li a1, 170
+; RV64V-NEXT:    vsetvli a2, zero, e8, mf4, ta, ma
+; RV64V-NEXT:    vand.vx v10, v9, a0
+; RV64V-NEXT:    vand.vx v11, v8, a1
+; RV64V-NEXT:    vand.vx v9, v9, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vmul.vv v12, v11, v10
+; RV64V-NEXT:    vmul.vv v13, v8, v9
+; RV64V-NEXT:    vmul.vv v9, v11, v9
+; RV64V-NEXT:    vmul.vv v8, v8, v10
+; RV64V-NEXT:    vxor.vv v10, v13, v12
+; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vand.vx v9, v10, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vor.vv v8, v8, v9
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv2i8_vv:
@@ -343,66 +271,42 @@ define <vscale x 2 x i8> @clmul_nxv2i8_vx(<vscale x 2 x i8> %va, i8 %b) nounwind
 ; RV32V:       # %bb.0:
 ; RV32V-NEXT:    vsetvli a1, zero, e8, mf4, ta, ma
 ; RV32V-NEXT:    vmv.v.x v9, a0
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    li a0, 128
+; RV32V-NEXT:    li a0, 170
+; RV32V-NEXT:    li a1, 85
+; RV32V-NEXT:    vand.vx v10, v8, a0
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vand.vx v11, v9, a1
 ; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
-; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vmul.vv v12, v10, v11
+; RV32V-NEXT:    vmul.vv v13, v8, v9
+; RV32V-NEXT:    vmul.vv v9, v10, v9
+; RV32V-NEXT:    vmul.vv v8, v8, v11
+; RV32V-NEXT:    vxor.vv v10, v13, v12
+; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vand.vx v9, v10, a0
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vor.vv v8, v8, v9
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv2i8_vx:
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    vsetvli a1, zero, e8, mf4, ta, ma
 ; RV64V-NEXT:    vmv.v.x v9, a0
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    li a0, 128
+; RV64V-NEXT:    li a0, 170
+; RV64V-NEXT:    li a1, 85
+; RV64V-NEXT:    vand.vx v10, v8, a0
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vand.vx v11, v9, a1
 ; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
-; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vmul.vv v12, v10, v11
+; RV64V-NEXT:    vmul.vv v13, v8, v9
+; RV64V-NEXT:    vmul.vv v9, v10, v9
+; RV64V-NEXT:    vmul.vv v8, v8, v11
+; RV64V-NEXT:    vxor.vv v10, v13, v12
+; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vand.vx v9, v10, a0
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vor.vv v8, v8, v9
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv2i8_vx:
@@ -457,66 +361,42 @@ define <vscale x 2 x i8> @clmul_nxv2i8_vx(<vscale x 2 x i8> %va, i8 %b) nounwind
 define <vscale x 4 x i8> @clmul_nxv4i8_vv(<vscale x 4 x i8> %va, <vscale x 4 x i8> %vb) nounwind {
 ; RV32V-LABEL: clmul_nxv4i8_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vsetvli a1, zero, e8, mf2, ta, ma
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
-; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    li a0, 85
+; RV32V-NEXT:    li a1, 170
+; RV32V-NEXT:    vsetvli a2, zero, e8, mf2, ta, ma
+; RV32V-NEXT:    vand.vx v10, v9, a0
+; RV32V-NEXT:    vand.vx v11, v8, a1
+; RV32V-NEXT:    vand.vx v9, v9, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vmul.vv v12, v11, v10
+; RV32V-NEXT:    vmul.vv v13, v8, v9
+; RV32V-NEXT:    vmul.vv v9, v11, v9
+; RV32V-NEXT:    vmul.vv v8, v8, v10
+; RV32V-NEXT:    vxor.vv v10, v13, v12
+; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vand.vx v9, v10, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vor.vv v8, v8, v9
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv4i8_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vsetvli a1, zero, e8, mf2, ta, ma
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
-; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    li a0, 85
+; RV64V-NEXT:    li a1, 170
+; RV64V-NEXT:    vsetvli a2, zero, e8, mf2, ta, ma
+; RV64V-NEXT:    vand.vx v10, v9, a0
+; RV64V-NEXT:    vand.vx v11, v8, a1
+; RV64V-NEXT:    vand.vx v9, v9, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vmul.vv v12, v11, v10
+; RV64V-NEXT:    vmul.vv v13, v8, v9
+; RV64V-NEXT:    vmul.vv v9, v11, v9
+; RV64V-NEXT:    vmul.vv v8, v8, v10
+; RV64V-NEXT:    vxor.vv v10, v13, v12
+; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vand.vx v9, v10, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vor.vv v8, v8, v9
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv4i8_vv:
@@ -567,66 +447,42 @@ define <vscale x 4 x i8> @clmul_nxv4i8_vx(<vscale x 4 x i8> %va, i8 %b) nounwind
 ; RV32V:       # %bb.0:
 ; RV32V-NEXT:    vsetvli a1, zero, e8, mf2, ta, ma
 ; RV32V-NEXT:    vmv.v.x v9, a0
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    li a0, 128
+; RV32V-NEXT:    li a0, 170
+; RV32V-NEXT:    li a1, 85
+; RV32V-NEXT:    vand.vx v10, v8, a0
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vand.vx v11, v9, a1
 ; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
-; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vmul.vv v12, v10, v11
+; RV32V-NEXT:    vmul.vv v13, v8, v9
+; RV32V-NEXT:    vmul.vv v9, v10, v9
+; RV32V-NEXT:    vmul.vv v8, v8, v11
+; RV32V-NEXT:    vxor.vv v10, v13, v12
+; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vand.vx v9, v10, a0
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vor.vv v8, v8, v9
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv4i8_vx:
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    vsetvli a1, zero, e8, mf2, ta, ma
 ; RV64V-NEXT:    vmv.v.x v9, a0
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    li a0, 128
+; RV64V-NEXT:    li a0, 170
+; RV64V-NEXT:    li a1, 85
+; RV64V-NEXT:    vand.vx v10, v8, a0
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vand.vx v11, v9, a1
 ; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
-; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vmul.vv v12, v10, v11
+; RV64V-NEXT:    vmul.vv v13, v8, v9
+; RV64V-NEXT:    vmul.vv v9, v10, v9
+; RV64V-NEXT:    vmul.vv v8, v8, v11
+; RV64V-NEXT:    vxor.vv v10, v13, v12
+; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vand.vx v9, v10, a0
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vor.vv v8, v8, v9
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv4i8_vx:
@@ -681,66 +537,42 @@ define <vscale x 4 x i8> @clmul_nxv4i8_vx(<vscale x 4 x i8> %va, i8 %b) nounwind
 define <vscale x 8 x i8> @clmul_nxv8i8_vv(<vscale x 8 x i8> %va, <vscale x 8 x i8> %vb) nounwind {
 ; RV32V-LABEL: clmul_nxv8i8_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
+; RV32V-NEXT:    li a0, 85
 ; RV32V-NEXT:    vsetvli a1, zero, e8, m1, ta, ma
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
-; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vand.vx v10, v9, a0
+; RV32V-NEXT:    li a1, 170
+; RV32V-NEXT:    vand.vx v11, v8, a1
+; RV32V-NEXT:    vand.vx v9, v9, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vmul.vv v12, v11, v10
+; RV32V-NEXT:    vmul.vv v13, v8, v9
+; RV32V-NEXT:    vmul.vv v9, v11, v9
+; RV32V-NEXT:    vmul.vv v8, v8, v10
+; RV32V-NEXT:    vxor.vv v10, v13, v12
+; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vand.vx v9, v10, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vor.vv v8, v8, v9
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv8i8_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
+; RV64V-NEXT:    li a0, 85
 ; RV64V-NEXT:    vsetvli a1, zero, e8, m1, ta, ma
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
-; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vand.vx v10, v9, a0
+; RV64V-NEXT:    li a1, 170
+; RV64V-NEXT:    vand.vx v11, v8, a1
+; RV64V-NEXT:    vand.vx v9, v9, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vmul.vv v12, v11, v10
+; RV64V-NEXT:    vmul.vv v13, v8, v9
+; RV64V-NEXT:    vmul.vv v9, v11, v9
+; RV64V-NEXT:    vmul.vv v8, v8, v10
+; RV64V-NEXT:    vxor.vv v10, v13, v12
+; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vand.vx v9, v10, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vor.vv v8, v8, v9
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv8i8_vv:
@@ -791,66 +623,42 @@ define <vscale x 8 x i8> @clmul_nxv8i8_vx(<vscale x 8 x i8> %va, i8 %b) nounwind
 ; RV32V:       # %bb.0:
 ; RV32V-NEXT:    vsetvli a1, zero, e8, m1, ta, ma
 ; RV32V-NEXT:    vmv.v.x v9, a0
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    li a0, 128
+; RV32V-NEXT:    li a0, 170
+; RV32V-NEXT:    vand.vx v10, v8, a0
+; RV32V-NEXT:    li a1, 85
+; RV32V-NEXT:    vand.vx v11, v9, a1
+; RV32V-NEXT:    vand.vx v8, v8, a1
 ; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
-; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vmul.vv v12, v10, v11
+; RV32V-NEXT:    vmul.vv v13, v8, v9
+; RV32V-NEXT:    vmul.vv v9, v10, v9
+; RV32V-NEXT:    vmul.vv v8, v8, v11
+; RV32V-NEXT:    vxor.vv v10, v13, v12
+; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vand.vx v9, v10, a0
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vor.vv v8, v8, v9
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv8i8_vx:
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    vsetvli a1, zero, e8, m1, ta, ma
 ; RV64V-NEXT:    vmv.v.x v9, a0
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    li a0, 128
+; RV64V-NEXT:    li a0, 170
+; RV64V-NEXT:    vand.vx v10, v8, a0
+; RV64V-NEXT:    li a1, 85
+; RV64V-NEXT:    vand.vx v11, v9, a1
+; RV64V-NEXT:    vand.vx v8, v8, a1
 ; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
-; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vmul.vv v12, v10, v11
+; RV64V-NEXT:    vmul.vv v13, v8, v9
+; RV64V-NEXT:    vmul.vv v9, v10, v9
+; RV64V-NEXT:    vmul.vv v8, v8, v11
+; RV64V-NEXT:    vxor.vv v10, v13, v12
+; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vand.vx v9, v10, a0
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vor.vv v8, v8, v9
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv8i8_vx:
@@ -905,130 +713,82 @@ define <vscale x 8 x i8> @clmul_nxv8i8_vx(<vscale x 8 x i8> %va, i8 %b) nounwind
 define <vscale x 16 x i8> @clmul_nxv16i8_vv(<vscale x 16 x i8> %va, <vscale x 16 x i8> %vb) nounwind {
 ; RV32V-LABEL: clmul_nxv16i8_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
+; RV32V-NEXT:    li a0, 85
 ; RV32V-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; RV32V-NEXT:    vand.vi v12, v10, 2
-; RV32V-NEXT:    vand.vi v14, v10, 1
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    vxor.vv v12, v14, v12
-; RV32V-NEXT:    vand.vi v14, v10, 4
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    vand.vi v16, v10, 8
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v10, v10, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v10
-; RV32V-NEXT:    vxor.vv v10, v12, v14
-; RV32V-NEXT:    vxor.vv v8, v10, v8
+; RV32V-NEXT:    vand.vx v12, v10, a0
+; RV32V-NEXT:    li a1, 170
+; RV32V-NEXT:    vand.vx v14, v8, a1
+; RV32V-NEXT:    vand.vx v10, v10, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vmul.vv v16, v14, v12
+; RV32V-NEXT:    vmul.vv v18, v8, v10
+; RV32V-NEXT:    vxor.vv v16, v18, v16
+; RV32V-NEXT:    vmul.vv v10, v14, v10
+; RV32V-NEXT:    vmul.vv v8, v8, v12
+; RV32V-NEXT:    vand.vx v12, v16, a1
+; RV32V-NEXT:    vxor.vv v8, v8, v10
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vor.vv v8, v8, v12
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv16i8_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
+; RV64V-NEXT:    li a0, 85
 ; RV64V-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; RV64V-NEXT:    vand.vi v12, v10, 2
-; RV64V-NEXT:    vand.vi v14, v10, 1
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    vxor.vv v12, v14, v12
-; RV64V-NEXT:    vand.vi v14, v10, 4
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    vand.vi v16, v10, 8
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v10, v10, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v10
-; RV64V-NEXT:    vxor.vv v10, v12, v14
-; RV64V-NEXT:    vxor.vv v8, v10, v8
+; RV64V-NEXT:    vand.vx v12, v10, a0
+; RV64V-NEXT:    li a1, 170
+; RV64V-NEXT:    vand.vx v14, v8, a1
+; RV64V-NEXT:    vand.vx v10, v10, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vmul.vv v16, v14, v12
+; RV64V-NEXT:    vmul.vv v18, v8, v10
+; RV64V-NEXT:    vxor.vv v16, v18, v16
+; RV64V-NEXT:    vmul.vv v10, v14, v10
+; RV64V-NEXT:    vmul.vv v8, v8, v12
+; RV64V-NEXT:    vand.vx v12, v16, a1
+; RV64V-NEXT:    vxor.vv v8, v8, v10
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vor.vv v8, v8, v12
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv16i8_vv:
 ; RV32ZVBC64:       # %bb.0:
-; RV32ZVBC64-NEXT:    li a0, 16
+; RV32ZVBC64-NEXT:    li a0, 85
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; RV32ZVBC64-NEXT:    vand.vi v12, v10, 2
-; RV32ZVBC64-NEXT:    vand.vi v14, v10, 1
-; RV32ZVBC64-NEXT:    vmul.vv v12, v8, v12
-; RV32ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV32ZVBC64-NEXT:    vxor.vv v12, v14, v12
-; RV32ZVBC64-NEXT:    vand.vi v14, v10, 4
-; RV32ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV32ZVBC64-NEXT:    vand.vi v16, v10, 8
-; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v12, v12, v14
-; RV32ZVBC64-NEXT:    vxor.vv v12, v12, v16
-; RV32ZVBC64-NEXT:    vand.vx v14, v10, a0
-; RV32ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v16, v10, a0
-; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v12, v12, v14
-; RV32ZVBC64-NEXT:    vxor.vv v12, v12, v16
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v14, v10, a0
-; RV32ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV32ZVBC64-NEXT:    li a0, 128
-; RV32ZVBC64-NEXT:    vand.vx v10, v10, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v10
-; RV32ZVBC64-NEXT:    vxor.vv v10, v12, v14
-; RV32ZVBC64-NEXT:    vxor.vv v8, v10, v8
+; RV32ZVBC64-NEXT:    vand.vx v12, v10, a0
+; RV32ZVBC64-NEXT:    li a1, 170
+; RV32ZVBC64-NEXT:    vand.vx v14, v8, a1
+; RV32ZVBC64-NEXT:    vand.vx v10, v10, a1
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV32ZVBC64-NEXT:    vmul.vv v16, v14, v12
+; RV32ZVBC64-NEXT:    vmul.vv v18, v8, v10
+; RV32ZVBC64-NEXT:    vxor.vv v16, v18, v16
+; RV32ZVBC64-NEXT:    vmul.vv v10, v14, v10
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v12
+; RV32ZVBC64-NEXT:    vand.vx v12, v16, a1
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v10
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v12
 ; RV32ZVBC64-NEXT:    ret
 ;
 ; RV64ZVBC64-LABEL: clmul_nxv16i8_vv:
 ; RV64ZVBC64:       # %bb.0:
-; RV64ZVBC64-NEXT:    li a0, 16
+; RV64ZVBC64-NEXT:    li a0, 85
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; RV64ZVBC64-NEXT:    vand.vi v12, v10, 2
-; RV64ZVBC64-NEXT:    vand.vi v14, v10, 1
-; RV64ZVBC64-NEXT:    vmul.vv v12, v8, v12
-; RV64ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV64ZVBC64-NEXT:    vxor.vv v12, v14, v12
-; RV64ZVBC64-NEXT:    vand.vi v14, v10, 4
-; RV64ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV64ZVBC64-NEXT:    vand.vi v16, v10, 8
-; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v12, v12, v14
-; RV64ZVBC64-NEXT:    vxor.vv v12, v12, v16
-; RV64ZVBC64-NEXT:    vand.vx v14, v10, a0
-; RV64ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v16, v10, a0
-; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v12, v12, v14
-; RV64ZVBC64-NEXT:    vxor.vv v12, v12, v16
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v14, v10, a0
-; RV64ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV64ZVBC64-NEXT:    li a0, 128
-; RV64ZVBC64-NEXT:    vand.vx v10, v10, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v10
-; RV64ZVBC64-NEXT:    vxor.vv v10, v12, v14
-; RV64ZVBC64-NEXT:    vxor.vv v8, v10, v8
+; RV64ZVBC64-NEXT:    vand.vx v12, v10, a0
+; RV64ZVBC64-NEXT:    li a1, 170
+; RV64ZVBC64-NEXT:    vand.vx v14, v8, a1
+; RV64ZVBC64-NEXT:    vand.vx v10, v10, a1
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV64ZVBC64-NEXT:    vmul.vv v16, v14, v12
+; RV64ZVBC64-NEXT:    vmul.vv v18, v8, v10
+; RV64ZVBC64-NEXT:    vxor.vv v16, v18, v16
+; RV64ZVBC64-NEXT:    vmul.vv v10, v14, v10
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v12
+; RV64ZVBC64-NEXT:    vand.vx v12, v16, a1
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v10
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v12
 ; RV64ZVBC64-NEXT:    ret
 ;
 ; RV32ZVBC32-LABEL: clmul_nxv16i8_vv:
@@ -1051,132 +811,84 @@ define <vscale x 16 x i8> @clmul_nxv16i8_vx(<vscale x 16 x i8> %va, i8 %b) nounw
 ; RV32V:       # %bb.0:
 ; RV32V-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
 ; RV32V-NEXT:    vmv.v.x v10, a0
-; RV32V-NEXT:    vand.vi v12, v10, 2
-; RV32V-NEXT:    vand.vi v14, v10, 1
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    vxor.vv v12, v14, v12
-; RV32V-NEXT:    vand.vi v14, v10, 4
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    vand.vi v16, v10, 8
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 128
+; RV32V-NEXT:    li a0, 170
+; RV32V-NEXT:    vand.vx v12, v8, a0
+; RV32V-NEXT:    li a1, 85
+; RV32V-NEXT:    vand.vx v14, v10, a1
+; RV32V-NEXT:    vand.vx v8, v8, a1
 ; RV32V-NEXT:    vand.vx v10, v10, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v10
-; RV32V-NEXT:    vxor.vv v10, v12, v14
-; RV32V-NEXT:    vxor.vv v8, v10, v8
+; RV32V-NEXT:    vmul.vv v16, v12, v14
+; RV32V-NEXT:    vmul.vv v18, v8, v10
+; RV32V-NEXT:    vxor.vv v16, v18, v16
+; RV32V-NEXT:    vmul.vv v10, v12, v10
+; RV32V-NEXT:    vmul.vv v8, v8, v14
+; RV32V-NEXT:    vand.vx v12, v16, a0
+; RV32V-NEXT:    vxor.vv v8, v8, v10
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vor.vv v8, v8, v12
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv16i8_vx:
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
 ; RV64V-NEXT:    vmv.v.x v10, a0
-; RV64V-NEXT:    vand.vi v12, v10, 2
-; RV64V-NEXT:    vand.vi v14, v10, 1
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    vxor.vv v12, v14, v12
-; RV64V-NEXT:    vand.vi v14, v10, 4
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    vand.vi v16, v10, 8
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 128
+; RV64V-NEXT:    li a0, 170
+; RV64V-NEXT:    vand.vx v12, v8, a0
+; RV64V-NEXT:    li a1, 85
+; RV64V-NEXT:    vand.vx v14, v10, a1
+; RV64V-NEXT:    vand.vx v8, v8, a1
 ; RV64V-NEXT:    vand.vx v10, v10, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v10
-; RV64V-NEXT:    vxor.vv v10, v12, v14
-; RV64V-NEXT:    vxor.vv v8, v10, v8
+; RV64V-NEXT:    vmul.vv v16, v12, v14
+; RV64V-NEXT:    vmul.vv v18, v8, v10
+; RV64V-NEXT:    vxor.vv v16, v18, v16
+; RV64V-NEXT:    vmul.vv v10, v12, v10
+; RV64V-NEXT:    vmul.vv v8, v8, v14
+; RV64V-NEXT:    vand.vx v12, v16, a0
+; RV64V-NEXT:    vxor.vv v8, v8, v10
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vor.vv v8, v8, v12
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv16i8_vx:
 ; RV32ZVBC64:       # %bb.0:
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
 ; RV32ZVBC64-NEXT:    vmv.v.x v10, a0
-; RV32ZVBC64-NEXT:    vand.vi v12, v10, 2
-; RV32ZVBC64-NEXT:    vand.vi v14, v10, 1
-; RV32ZVBC64-NEXT:    vmul.vv v12, v8, v12
-; RV32ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV32ZVBC64-NEXT:    vxor.vv v12, v14, v12
-; RV32ZVBC64-NEXT:    vand.vi v14, v10, 4
-; RV32ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV32ZVBC64-NEXT:    vand.vi v16, v10, 8
-; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v12, v12, v14
-; RV32ZVBC64-NEXT:    vxor.vv v12, v12, v16
-; RV32ZVBC64-NEXT:    li a0, 16
-; RV32ZVBC64-NEXT:    vand.vx v14, v10, a0
-; RV32ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v16, v10, a0
-; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v12, v12, v14
-; RV32ZVBC64-NEXT:    vxor.vv v12, v12, v16
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v14, v10, a0
-; RV32ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV32ZVBC64-NEXT:    li a0, 128
+; RV32ZVBC64-NEXT:    li a0, 170
+; RV32ZVBC64-NEXT:    vand.vx v12, v8, a0
+; RV32ZVBC64-NEXT:    li a1, 85
+; RV32ZVBC64-NEXT:    vand.vx v14, v10, a1
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV32ZVBC64-NEXT:    vand.vx v10, v10, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v10
-; RV32ZVBC64-NEXT:    vxor.vv v10, v12, v14
-; RV32ZVBC64-NEXT:    vxor.vv v8, v10, v8
+; RV32ZVBC64-NEXT:    vmul.vv v16, v12, v14
+; RV32ZVBC64-NEXT:    vmul.vv v18, v8, v10
+; RV32ZVBC64-NEXT:    vxor.vv v16, v18, v16
+; RV32ZVBC64-NEXT:    vmul.vv v10, v12, v10
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v14
+; RV32ZVBC64-NEXT:    vand.vx v12, v16, a0
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v10
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v12
 ; RV32ZVBC64-NEXT:    ret
 ;
 ; RV64ZVBC64-LABEL: clmul_nxv16i8_vx:
 ; RV64ZVBC64:       # %bb.0:
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
 ; RV64ZVBC64-NEXT:    vmv.v.x v10, a0
-; RV64ZVBC64-NEXT:    vand.vi v12, v10, 2
-; RV64ZVBC64-NEXT:    vand.vi v14, v10, 1
-; RV64ZVBC64-NEXT:    vmul.vv v12, v8, v12
-; RV64ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV64ZVBC64-NEXT:    vxor.vv v12, v14, v12
-; RV64ZVBC64-NEXT:    vand.vi v14, v10, 4
-; RV64ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV64ZVBC64-NEXT:    vand.vi v16, v10, 8
-; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v12, v12, v14
-; RV64ZVBC64-NEXT:    vxor.vv v12, v12, v16
-; RV64ZVBC64-NEXT:    li a0, 16
-; RV64ZVBC64-NEXT:    vand.vx v14, v10, a0
-; RV64ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v16, v10, a0
-; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v12, v12, v14
-; RV64ZVBC64-NEXT:    vxor.vv v12, v12, v16
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v14, v10, a0
-; RV64ZVBC64-NEXT:    vmul.vv v14, v8, v14
-; RV64ZVBC64-NEXT:    li a0, 128
+; RV64ZVBC64-NEXT:    li a0, 170
+; RV64ZVBC64-NEXT:    vand.vx v12, v8, a0
+; RV64ZVBC64-NEXT:    li a1, 85
+; RV64ZVBC64-NEXT:    vand.vx v14, v10, a1
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV64ZVBC64-NEXT:    vand.vx v10, v10, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v10
-; RV64ZVBC64-NEXT:    vxor.vv v10, v12, v14
-; RV64ZVBC64-NEXT:    vxor.vv v8, v10, v8
+; RV64ZVBC64-NEXT:    vmul.vv v16, v12, v14
+; RV64ZVBC64-NEXT:    vmul.vv v18, v8, v10
+; RV64ZVBC64-NEXT:    vxor.vv v16, v18, v16
+; RV64ZVBC64-NEXT:    vmul.vv v10, v12, v10
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v14
+; RV64ZVBC64-NEXT:    vand.vx v12, v16, a0
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v10
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v12
 ; RV64ZVBC64-NEXT:    ret
 ;
 ; RV32ZVBC32-LABEL: clmul_nxv16i8_vx:
@@ -1199,130 +911,82 @@ define <vscale x 16 x i8> @clmul_nxv16i8_vx(<vscale x 16 x i8> %va, i8 %b) nounw
 define <vscale x 32 x i8> @clmul_nxv32i8_vv(<vscale x 32 x i8> %va, <vscale x 32 x i8> %vb) nounwind {
 ; RV32V-LABEL: clmul_nxv32i8_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
+; RV32V-NEXT:    li a0, 85
 ; RV32V-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
-; RV32V-NEXT:    vand.vi v16, v12, 2
-; RV32V-NEXT:    vand.vi v20, v12, 1
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    vxor.vv v16, v20, v16
-; RV32V-NEXT:    vand.vi v20, v12, 4
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    vand.vi v24, v12, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v12, v12, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v12
-; RV32V-NEXT:    vxor.vv v12, v16, v20
-; RV32V-NEXT:    vxor.vv v8, v12, v8
+; RV32V-NEXT:    vand.vx v16, v12, a0
+; RV32V-NEXT:    li a1, 170
+; RV32V-NEXT:    vand.vx v20, v8, a1
+; RV32V-NEXT:    vand.vx v12, v12, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vmul.vv v24, v20, v16
+; RV32V-NEXT:    vmul.vv v28, v8, v12
+; RV32V-NEXT:    vxor.vv v24, v28, v24
+; RV32V-NEXT:    vmul.vv v12, v20, v12
+; RV32V-NEXT:    vmul.vv v8, v8, v16
+; RV32V-NEXT:    vand.vx v16, v24, a1
+; RV32V-NEXT:    vxor.vv v8, v8, v12
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vor.vv v8, v8, v16
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv32i8_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
+; RV64V-NEXT:    li a0, 85
 ; RV64V-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
-; RV64V-NEXT:    vand.vi v16, v12, 2
-; RV64V-NEXT:    vand.vi v20, v12, 1
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    vxor.vv v16, v20, v16
-; RV64V-NEXT:    vand.vi v20, v12, 4
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    vand.vi v24, v12, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v12, v12, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v12
-; RV64V-NEXT:    vxor.vv v12, v16, v20
-; RV64V-NEXT:    vxor.vv v8, v12, v8
+; RV64V-NEXT:    vand.vx v16, v12, a0
+; RV64V-NEXT:    li a1, 170
+; RV64V-NEXT:    vand.vx v20, v8, a1
+; RV64V-NEXT:    vand.vx v12, v12, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vmul.vv v24, v20, v16
+; RV64V-NEXT:    vmul.vv v28, v8, v12
+; RV64V-NEXT:    vxor.vv v24, v28, v24
+; RV64V-NEXT:    vmul.vv v12, v20, v12
+; RV64V-NEXT:    vmul.vv v8, v8, v16
+; RV64V-NEXT:    vand.vx v16, v24, a1
+; RV64V-NEXT:    vxor.vv v8, v8, v12
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vor.vv v8, v8, v16
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv32i8_vv:
 ; RV32ZVBC64:       # %bb.0:
-; RV32ZVBC64-NEXT:    li a0, 16
+; RV32ZVBC64-NEXT:    li a0, 85
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
-; RV32ZVBC64-NEXT:    vand.vi v16, v12, 2
-; RV32ZVBC64-NEXT:    vand.vi v20, v12, 1
-; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v20, v16
-; RV32ZVBC64-NEXT:    vand.vi v20, v12, 4
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    vand.vi v24, v12, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 128
-; RV32ZVBC64-NEXT:    vand.vx v12, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v12
-; RV32ZVBC64-NEXT:    vxor.vv v12, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v8, v12, v8
+; RV32ZVBC64-NEXT:    vand.vx v16, v12, a0
+; RV32ZVBC64-NEXT:    li a1, 170
+; RV32ZVBC64-NEXT:    vand.vx v20, v8, a1
+; RV32ZVBC64-NEXT:    vand.vx v12, v12, a1
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV32ZVBC64-NEXT:    vmul.vv v24, v20, v16
+; RV32ZVBC64-NEXT:    vmul.vv v28, v8, v12
+; RV32ZVBC64-NEXT:    vxor.vv v24, v28, v24
+; RV32ZVBC64-NEXT:    vmul.vv v12, v20, v12
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
+; RV32ZVBC64-NEXT:    vand.vx v16, v24, a1
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v12
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV32ZVBC64-NEXT:    ret
 ;
 ; RV64ZVBC64-LABEL: clmul_nxv32i8_vv:
 ; RV64ZVBC64:       # %bb.0:
-; RV64ZVBC64-NEXT:    li a0, 16
+; RV64ZVBC64-NEXT:    li a0, 85
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
-; RV64ZVBC64-NEXT:    vand.vi v16, v12, 2
-; RV64ZVBC64-NEXT:    vand.vi v20, v12, 1
-; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v20, v16
-; RV64ZVBC64-NEXT:    vand.vi v20, v12, 4
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    vand.vi v24, v12, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 128
-; RV64ZVBC64-NEXT:    vand.vx v12, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v12
-; RV64ZVBC64-NEXT:    vxor.vv v12, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v8, v12, v8
+; RV64ZVBC64-NEXT:    vand.vx v16, v12, a0
+; RV64ZVBC64-NEXT:    li a1, 170
+; RV64ZVBC64-NEXT:    vand.vx v20, v8, a1
+; RV64ZVBC64-NEXT:    vand.vx v12, v12, a1
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV64ZVBC64-NEXT:    vmul.vv v24, v20, v16
+; RV64ZVBC64-NEXT:    vmul.vv v28, v8, v12
+; RV64ZVBC64-NEXT:    vxor.vv v24, v28, v24
+; RV64ZVBC64-NEXT:    vmul.vv v12, v20, v12
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
+; RV64ZVBC64-NEXT:    vand.vx v16, v24, a1
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v12
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV64ZVBC64-NEXT:    ret
 ;
 ; RV32ZVBC32-LABEL: clmul_nxv32i8_vv:
@@ -1345,132 +1009,84 @@ define <vscale x 32 x i8> @clmul_nxv32i8_vx(<vscale x 32 x i8> %va, i8 %b) nounw
 ; RV32V:       # %bb.0:
 ; RV32V-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
 ; RV32V-NEXT:    vmv.v.x v12, a0
-; RV32V-NEXT:    vand.vi v16, v12, 2
-; RV32V-NEXT:    vand.vi v20, v12, 1
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    vxor.vv v16, v20, v16
-; RV32V-NEXT:    vand.vi v20, v12, 4
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    vand.vi v24, v12, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 128
+; RV32V-NEXT:    li a0, 170
+; RV32V-NEXT:    vand.vx v16, v8, a0
+; RV32V-NEXT:    li a1, 85
+; RV32V-NEXT:    vand.vx v20, v12, a1
+; RV32V-NEXT:    vand.vx v8, v8, a1
 ; RV32V-NEXT:    vand.vx v12, v12, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v12
-; RV32V-NEXT:    vxor.vv v12, v16, v20
-; RV32V-NEXT:    vxor.vv v8, v12, v8
+; RV32V-NEXT:    vmul.vv v24, v16, v20
+; RV32V-NEXT:    vmul.vv v28, v8, v12
+; RV32V-NEXT:    vxor.vv v24, v28, v24
+; RV32V-NEXT:    vmul.vv v12, v16, v12
+; RV32V-NEXT:    vmul.vv v8, v8, v20
+; RV32V-NEXT:    vand.vx v16, v24, a0
+; RV32V-NEXT:    vxor.vv v8, v8, v12
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vor.vv v8, v8, v16
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv32i8_vx:
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
 ; RV64V-NEXT:    vmv.v.x v12, a0
-; RV64V-NEXT:    vand.vi v16, v12, 2
-; RV64V-NEXT:    vand.vi v20, v12, 1
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    vxor.vv v16, v20, v16
-; RV64V-NEXT:    vand.vi v20, v12, 4
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    vand.vi v24, v12, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 128
+; RV64V-NEXT:    li a0, 170
+; RV64V-NEXT:    vand.vx v16, v8, a0
+; RV64V-NEXT:    li a1, 85
+; RV64V-NEXT:    vand.vx v20, v12, a1
+; RV64V-NEXT:    vand.vx v8, v8, a1
 ; RV64V-NEXT:    vand.vx v12, v12, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v12
-; RV64V-NEXT:    vxor.vv v12, v16, v20
-; RV64V-NEXT:    vxor.vv v8, v12, v8
+; RV64V-NEXT:    vmul.vv v24, v16, v20
+; RV64V-NEXT:    vmul.vv v28, v8, v12
+; RV64V-NEXT:    vxor.vv v24, v28, v24
+; RV64V-NEXT:    vmul.vv v12, v16, v12
+; RV64V-NEXT:    vmul.vv v8, v8, v20
+; RV64V-NEXT:    vand.vx v16, v24, a0
+; RV64V-NEXT:    vxor.vv v8, v8, v12
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vor.vv v8, v8, v16
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv32i8_vx:
 ; RV32ZVBC64:       # %bb.0:
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
 ; RV32ZVBC64-NEXT:    vmv.v.x v12, a0
-; RV32ZVBC64-NEXT:    vand.vi v16, v12, 2
-; RV32ZVBC64-NEXT:    vand.vi v20, v12, 1
-; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v20, v16
-; RV32ZVBC64-NEXT:    vand.vi v20, v12, 4
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    vand.vi v24, v12, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 16
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 128
+; RV32ZVBC64-NEXT:    li a0, 170
+; RV32ZVBC64-NEXT:    vand.vx v16, v8, a0
+; RV32ZVBC64-NEXT:    li a1, 85
+; RV32ZVBC64-NEXT:    vand.vx v20, v12, a1
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV32ZVBC64-NEXT:    vand.vx v12, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v12
-; RV32ZVBC64-NEXT:    vxor.vv v12, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v8, v12, v8
+; RV32ZVBC64-NEXT:    vmul.vv v24, v16, v20
+; RV32ZVBC64-NEXT:    vmul.vv v28, v8, v12
+; RV32ZVBC64-NEXT:    vxor.vv v24, v28, v24
+; RV32ZVBC64-NEXT:    vmul.vv v12, v16, v12
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v20
+; RV32ZVBC64-NEXT:    vand.vx v16, v24, a0
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v12
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV32ZVBC64-NEXT:    ret
 ;
 ; RV64ZVBC64-LABEL: clmul_nxv32i8_vx:
 ; RV64ZVBC64:       # %bb.0:
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
 ; RV64ZVBC64-NEXT:    vmv.v.x v12, a0
-; RV64ZVBC64-NEXT:    vand.vi v16, v12, 2
-; RV64ZVBC64-NEXT:    vand.vi v20, v12, 1
-; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v20, v16
-; RV64ZVBC64-NEXT:    vand.vi v20, v12, 4
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    vand.vi v24, v12, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 16
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 128
+; RV64ZVBC64-NEXT:    li a0, 170
+; RV64ZVBC64-NEXT:    vand.vx v16, v8, a0
+; RV64ZVBC64-NEXT:    li a1, 85
+; RV64ZVBC64-NEXT:    vand.vx v20, v12, a1
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV64ZVBC64-NEXT:    vand.vx v12, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v12
-; RV64ZVBC64-NEXT:    vxor.vv v12, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v8, v12, v8
+; RV64ZVBC64-NEXT:    vmul.vv v24, v16, v20
+; RV64ZVBC64-NEXT:    vmul.vv v28, v8, v12
+; RV64ZVBC64-NEXT:    vxor.vv v24, v28, v24
+; RV64ZVBC64-NEXT:    vmul.vv v12, v16, v12
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v20
+; RV64ZVBC64-NEXT:    vand.vx v16, v24, a0
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v12
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV64ZVBC64-NEXT:    ret
 ;
 ; RV32ZVBC32-LABEL: clmul_nxv32i8_vx:
@@ -1500,82 +1116,51 @@ define <vscale x 64 x i8> @clmul_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 64
 ; RV32V-NEXT:    slli a0, a0, 1
 ; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    sub sp, sp, a0
-; RV32V-NEXT:    li a0, 16
+; RV32V-NEXT:    li a0, 85
 ; RV32V-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV32V-NEXT:    vand.vi v24, v16, 2
-; RV32V-NEXT:    vand.vi v0, v16, 1
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 4
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v0, v16, 4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 3
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v24, v16, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a1, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 4
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 3
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a1, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 4
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 32
 ; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 4
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    li a1, 170
+; RV32V-NEXT:    vand.vx v0, v8, a1
+; RV32V-NEXT:    vand.vx v16, v16, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 4
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v0, v24
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 3
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v24, v8, v16
+; RV32V-NEXT:    addi a2, sp, 16
+; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v16, v0, v16
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 4
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v24
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 3
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    addi a2, sp, 16
+; RV32V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v16, v16, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v16
-; RV32V-NEXT:    vxor.vv v16, v24, v0
-; RV32V-NEXT:    vxor.vv v8, v16, v8
+; RV32V-NEXT:    vxor.vv v8, v8, v16
+; RV32V-NEXT:    vand.vx v16, v24, a1
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vor.vv v8, v8, v16
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    mv a1, a0
@@ -1594,82 +1179,51 @@ define <vscale x 64 x i8> @clmul_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 64
 ; RV64V-NEXT:    slli a0, a0, 1
 ; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    sub sp, sp, a0
-; RV64V-NEXT:    li a0, 16
+; RV64V-NEXT:    li a0, 85
 ; RV64V-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV64V-NEXT:    vand.vi v24, v16, 2
-; RV64V-NEXT:    vand.vi v0, v16, 1
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 4
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v0, v16, 4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 3
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v24, v16, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a1, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 4
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 3
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a1, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 4
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 32
 ; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 4
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    li a1, 170
+; RV64V-NEXT:    vand.vx v0, v8, a1
+; RV64V-NEXT:    vand.vx v16, v16, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 4
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v0, v24
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 3
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v24, v8, v16
+; RV64V-NEXT:    addi a2, sp, 16
+; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v16, v0, v16
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 4
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v24
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 3
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    addi a2, sp, 16
+; RV64V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v16, v16, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v16
-; RV64V-NEXT:    vxor.vv v16, v24, v0
-; RV64V-NEXT:    vxor.vv v8, v16, v8
+; RV64V-NEXT:    vxor.vv v8, v8, v16
+; RV64V-NEXT:    vand.vx v16, v24, a1
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vor.vv v8, v8, v16
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    mv a1, a0
@@ -1688,82 +1242,51 @@ define <vscale x 64 x i8> @clmul_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 64
 ; RV32ZVBC64-NEXT:    slli a0, a0, 1
 ; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    sub sp, sp, a0
-; RV32ZVBC64-NEXT:    li a0, 16
+; RV32ZVBC64-NEXT:    li a0, 85
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 4
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 3
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a1, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 4
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 3
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a1, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 4
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 32
 ; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 4
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    li a1, 170
+; RV32ZVBC64-NEXT:    vand.vx v0, v8, a1
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a1
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 4
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v0, v24
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 3
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v16
+; RV32ZVBC64-NEXT:    addi a2, sp, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v16, v0, v16
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 4
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 3
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    addi a2, sp, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    li a0, 128
-; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v16, v24, v0
-; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v16
+; RV32ZVBC64-NEXT:    vand.vx v16, v24, a1
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    mv a1, a0
@@ -1782,82 +1305,51 @@ define <vscale x 64 x i8> @clmul_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 64
 ; RV64ZVBC64-NEXT:    slli a0, a0, 1
 ; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    sub sp, sp, a0
-; RV64ZVBC64-NEXT:    li a0, 16
+; RV64ZVBC64-NEXT:    li a0, 85
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 4
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 3
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a1, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 4
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 3
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a1, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 4
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 32
 ; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 4
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    li a1, 170
+; RV64ZVBC64-NEXT:    vand.vx v0, v8, a1
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a1
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 4
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v0, v24
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 3
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v16
+; RV64ZVBC64-NEXT:    addi a2, sp, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v16, v0, v16
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 4
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 3
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    addi a2, sp, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    li a0, 128
-; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v16, v24, v0
-; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v16
+; RV64ZVBC64-NEXT:    vand.vx v16, v24, a1
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    mv a1, a0
@@ -1893,82 +1385,51 @@ define <vscale x 64 x i8> @clmul_nxv64i8_vx(<vscale x 64 x i8> %va, i8 %b) nounw
 ; RV32V-NEXT:    add a1, a1, a2
 ; RV32V-NEXT:    sub sp, sp, a1
 ; RV32V-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV32V-NEXT:    vmv.v.x v16, a0
-; RV32V-NEXT:    vand.vi v24, v16, 2
-; RV32V-NEXT:    vand.vi v0, v16, 1
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vmul.vv v0, v8, v0
+; RV32V-NEXT:    vmv.v.x v0, a0
+; RV32V-NEXT:    li a0, 170
+; RV32V-NEXT:    vand.vx v16, v8, a0
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 4
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    li a1, 85
+; RV32V-NEXT:    vand.vx v24, v0, a1
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vand.vx v0, v0, a0
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 4
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v16, v24
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 3
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v16, v8, v0
+; RV32V-NEXT:    addi a2, sp, 16
+; RV32V-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 4
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v16, v0
+; RV32V-NEXT:    vmul.vv v8, v8, v24
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 3
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    addi a2, sp, 16
+; RV32V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v0, v16, 4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v24, v16, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v16, v16, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v16
-; RV32V-NEXT:    vxor.vv v16, v24, v0
-; RV32V-NEXT:    vxor.vv v8, v16, v8
+; RV32V-NEXT:    vxor.vv v8, v8, v16
+; RV32V-NEXT:    vand.vx v16, v24, a0
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vor.vv v8, v8, v16
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    mv a1, a0
@@ -1988,82 +1449,51 @@ define <vscale x 64 x i8> @clmul_nxv64i8_vx(<vscale x 64 x i8> %va, i8 %b) nounw
 ; RV64V-NEXT:    add a1, a1, a2
 ; RV64V-NEXT:    sub sp, sp, a1
 ; RV64V-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV64V-NEXT:    vmv.v.x v16, a0
-; RV64V-NEXT:    vand.vi v24, v16, 2
-; RV64V-NEXT:    vand.vi v0, v16, 1
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vmul.vv v0, v8, v0
+; RV64V-NEXT:    vmv.v.x v0, a0
+; RV64V-NEXT:    li a0, 170
+; RV64V-NEXT:    vand.vx v16, v8, a0
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 4
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    li a1, 85
+; RV64V-NEXT:    vand.vx v24, v0, a1
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vand.vx v0, v0, a0
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 4
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v16, v24
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 3
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v16, v8, v0
+; RV64V-NEXT:    addi a2, sp, 16
+; RV64V-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 4
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v16, v0
+; RV64V-NEXT:    vmul.vv v8, v8, v24
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 3
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    addi a2, sp, 16
+; RV64V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v0, v16, 4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v24, v16, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v16, v16, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v16
-; RV64V-NEXT:    vxor.vv v16, v24, v0
-; RV64V-NEXT:    vxor.vv v8, v16, v8
+; RV64V-NEXT:    vxor.vv v8, v8, v16
+; RV64V-NEXT:    vand.vx v16, v24, a0
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vor.vv v8, v8, v16
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    mv a1, a0
@@ -2083,82 +1513,51 @@ define <vscale x 64 x i8> @clmul_nxv64i8_vx(<vscale x 64 x i8> %va, i8 %b) nounw
 ; RV32ZVBC64-NEXT:    add a1, a1, a2
 ; RV32ZVBC64-NEXT:    sub sp, sp, a1
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV32ZVBC64-NEXT:    vmv.v.x v16, a0
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
+; RV32ZVBC64-NEXT:    vmv.v.x v0, a0
+; RV32ZVBC64-NEXT:    li a0, 170
+; RV32ZVBC64-NEXT:    vand.vx v16, v8, a0
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 4
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    li a1, 85
+; RV32ZVBC64-NEXT:    vand.vx v24, v0, a1
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a0
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 4
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v16, v24
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 3
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v0
+; RV32ZVBC64-NEXT:    addi a2, sp, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 4
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v16, v0
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 3
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    addi a2, sp, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 16
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    li a0, 128
-; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v16, v24, v0
-; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v16
+; RV32ZVBC64-NEXT:    vand.vx v16, v24, a0
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    mv a1, a0
@@ -2178,82 +1577,51 @@ define <vscale x 64 x i8> @clmul_nxv64i8_vx(<vscale x 64 x i8> %va, i8 %b) nounw
 ; RV64ZVBC64-NEXT:    add a1, a1, a2
 ; RV64ZVBC64-NEXT:    sub sp, sp, a1
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV64ZVBC64-NEXT:    vmv.v.x v16, a0
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
+; RV64ZVBC64-NEXT:    vmv.v.x v0, a0
+; RV64ZVBC64-NEXT:    li a0, 170
+; RV64ZVBC64-NEXT:    vand.vx v16, v8, a0
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 4
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a1) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    li a1, 85
+; RV64ZVBC64-NEXT:    vand.vx v24, v0, a1
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a0
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 4
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v16, v24
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 3
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v0
+; RV64ZVBC64-NEXT:    addi a2, sp, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 4
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v16, v0
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 3
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    addi a2, sp, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 16
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    li a0, 128
-; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v16, v24, v0
-; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v16
+; RV64ZVBC64-NEXT:    vand.vx v16, v24, a0
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    mv a1, a0
@@ -2283,132 +1651,76 @@ define <vscale x 64 x i8> @clmul_nxv64i8_vx(<vscale x 64 x i8> %va, i8 %b) nounw
 define <vscale x 1 x i16> @clmul_nxv1i16_vv(<vscale x 1 x i16> %va, <vscale x 1 x i16> %vb) nounwind {
 ; RV32V-LABEL: clmul_nxv1i16_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v13, v9, 8
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vsetvli a2, zero, e16, mf4, ta, ma
+; RV32V-NEXT:    vand.vx v10, v9, a0
+; RV32V-NEXT:    vand.vx v11, v8, a1
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    vand.vx v12, v9, a1
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v13, v8, a0
+; RV32V-NEXT:    vand.vx v9, v9, a2
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vmul.vv v14, v11, v10
+; RV32V-NEXT:    vmul.vv v15, v13, v12
+; RV32V-NEXT:    vmul.vv v16, v11, v9
+; RV32V-NEXT:    vmul.vv v17, v13, v10
+; RV32V-NEXT:    vmul.vv v18, v8, v9
+; RV32V-NEXT:    vmul.vv v11, v11, v12
 ; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v12
-; RV32V-NEXT:    lui a0, 8
-; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
+; RV32V-NEXT:    vmul.vv v9, v13, v9
+; RV32V-NEXT:    vxor.vv v13, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v17, v16
+; RV32V-NEXT:    vmul.vv v8, v8, v10
+; RV32V-NEXT:    vxor.vv v10, v13, v18
+; RV32V-NEXT:    vxor.vv v12, v14, v12
+; RV32V-NEXT:    vxor.vv v9, v9, v11
+; RV32V-NEXT:    vand.vx v10, v10, a1
+; RV32V-NEXT:    vand.vx v11, v12, a0
 ; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vor.vv v9, v11, v10
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv1i16_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v13, v9, 8
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vsetvli a2, zero, e16, mf4, ta, ma
+; RV64V-NEXT:    vand.vx v10, v9, a0
+; RV64V-NEXT:    vand.vx v11, v8, a1
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    vand.vx v12, v9, a1
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v13, v8, a0
+; RV64V-NEXT:    vand.vx v9, v9, a2
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vmul.vv v14, v11, v10
+; RV64V-NEXT:    vmul.vv v15, v13, v12
+; RV64V-NEXT:    vmul.vv v16, v11, v9
+; RV64V-NEXT:    vmul.vv v17, v13, v10
+; RV64V-NEXT:    vmul.vv v18, v8, v9
+; RV64V-NEXT:    vmul.vv v11, v11, v12
 ; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v12
-; RV64V-NEXT:    lui a0, 8
-; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
+; RV64V-NEXT:    vmul.vv v9, v13, v9
+; RV64V-NEXT:    vxor.vv v13, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v17, v16
+; RV64V-NEXT:    vmul.vv v8, v8, v10
+; RV64V-NEXT:    vxor.vv v10, v13, v18
+; RV64V-NEXT:    vxor.vv v12, v14, v12
+; RV64V-NEXT:    vxor.vv v9, v9, v11
+; RV64V-NEXT:    vand.vx v10, v10, a1
+; RV64V-NEXT:    vand.vx v11, v12, a0
 ; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vor.vv v9, v11, v10
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv1i16_vv:
@@ -2453,134 +1765,78 @@ define <vscale x 1 x i16> @clmul_nxv1i16_vv(<vscale x 1 x i16> %va, <vscale x 1 
 define <vscale x 1 x i16> @clmul_nxv1i16_vx(<vscale x 1 x i16> %va, i16 %b) nounwind {
 ; RV32V-LABEL: clmul_nxv1i16_vx:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    vsetvli a2, zero, e16, mf4, ta, ma
 ; RV32V-NEXT:    vmv.v.x v9, a0
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vxor.vv v10, v10, v12
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    vand.vx v10, v8, a1
+; RV32V-NEXT:    vand.vx v11, v8, a0
+; RV32V-NEXT:    lui a2, 5
 ; RV32V-NEXT:    vand.vx v12, v9, a0
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v13, v9, a1
+; RV32V-NEXT:    vand.vx v9, v9, a2
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vmul.vv v14, v10, v12
+; RV32V-NEXT:    vmul.vv v15, v11, v13
+; RV32V-NEXT:    vmul.vv v16, v10, v9
+; RV32V-NEXT:    vmul.vv v17, v11, v12
+; RV32V-NEXT:    vmul.vv v18, v8, v9
+; RV32V-NEXT:    vmul.vv v10, v10, v13
 ; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v12
-; RV32V-NEXT:    lui a0, 8
-; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
+; RV32V-NEXT:    vmul.vv v9, v11, v9
+; RV32V-NEXT:    vxor.vv v11, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v17, v16
+; RV32V-NEXT:    vmul.vv v8, v8, v12
+; RV32V-NEXT:    vxor.vv v11, v11, v18
+; RV32V-NEXT:    vxor.vv v12, v14, v13
+; RV32V-NEXT:    vxor.vv v9, v9, v10
+; RV32V-NEXT:    vand.vx v10, v11, a1
+; RV32V-NEXT:    vand.vx v11, v12, a0
 ; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vor.vv v9, v11, v10
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv1i16_vx:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    vsetvli a2, zero, e16, mf4, ta, ma
 ; RV64V-NEXT:    vmv.v.x v9, a0
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vxor.vv v10, v10, v12
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    vand.vx v10, v8, a1
+; RV64V-NEXT:    vand.vx v11, v8, a0
+; RV64V-NEXT:    lui a2, 5
 ; RV64V-NEXT:    vand.vx v12, v9, a0
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v13, v9, a1
+; RV64V-NEXT:    vand.vx v9, v9, a2
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vmul.vv v14, v10, v12
+; RV64V-NEXT:    vmul.vv v15, v11, v13
+; RV64V-NEXT:    vmul.vv v16, v10, v9
+; RV64V-NEXT:    vmul.vv v17, v11, v12
+; RV64V-NEXT:    vmul.vv v18, v8, v9
+; RV64V-NEXT:    vmul.vv v10, v10, v13
 ; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v12
-; RV64V-NEXT:    lui a0, 8
-; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
+; RV64V-NEXT:    vmul.vv v9, v11, v9
+; RV64V-NEXT:    vxor.vv v11, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v17, v16
+; RV64V-NEXT:    vmul.vv v8, v8, v12
+; RV64V-NEXT:    vxor.vv v11, v11, v18
+; RV64V-NEXT:    vxor.vv v12, v14, v13
+; RV64V-NEXT:    vxor.vv v9, v9, v10
+; RV64V-NEXT:    vand.vx v10, v11, a1
+; RV64V-NEXT:    vand.vx v11, v12, a0
 ; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vor.vv v9, v11, v10
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv1i16_vx:
@@ -2631,132 +1887,76 @@ define <vscale x 1 x i16> @clmul_nxv1i16_vx(<vscale x 1 x i16> %va, i16 %b) noun
 define <vscale x 2 x i16> @clmul_nxv2i16_vv(<vscale x 2 x i16> %va, <vscale x 2 x i16> %vb) nounwind {
 ; RV32V-LABEL: clmul_nxv2i16_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vsetvli a1, zero, e16, mf2, ta, ma
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v13, v9, 8
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
+; RV32V-NEXT:    vand.vx v10, v9, a0
+; RV32V-NEXT:    vand.vx v11, v8, a1
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    vand.vx v12, v9, a1
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v13, v8, a0
+; RV32V-NEXT:    vand.vx v9, v9, a2
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vmul.vv v14, v11, v10
+; RV32V-NEXT:    vmul.vv v15, v13, v12
+; RV32V-NEXT:    vmul.vv v16, v11, v9
+; RV32V-NEXT:    vmul.vv v17, v13, v10
+; RV32V-NEXT:    vmul.vv v18, v8, v9
+; RV32V-NEXT:    vmul.vv v11, v11, v12
 ; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v12
-; RV32V-NEXT:    lui a0, 8
-; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
+; RV32V-NEXT:    vmul.vv v9, v13, v9
+; RV32V-NEXT:    vxor.vv v13, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v17, v16
+; RV32V-NEXT:    vmul.vv v8, v8, v10
+; RV32V-NEXT:    vxor.vv v10, v13, v18
+; RV32V-NEXT:    vxor.vv v12, v14, v12
+; RV32V-NEXT:    vxor.vv v9, v9, v11
+; RV32V-NEXT:    vand.vx v10, v10, a1
+; RV32V-NEXT:    vand.vx v11, v12, a0
 ; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vor.vv v9, v11, v10
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv2i16_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vsetvli a1, zero, e16, mf2, ta, ma
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v13, v9, 8
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
+; RV64V-NEXT:    vand.vx v10, v9, a0
+; RV64V-NEXT:    vand.vx v11, v8, a1
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    vand.vx v12, v9, a1
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v13, v8, a0
+; RV64V-NEXT:    vand.vx v9, v9, a2
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vmul.vv v14, v11, v10
+; RV64V-NEXT:    vmul.vv v15, v13, v12
+; RV64V-NEXT:    vmul.vv v16, v11, v9
+; RV64V-NEXT:    vmul.vv v17, v13, v10
+; RV64V-NEXT:    vmul.vv v18, v8, v9
+; RV64V-NEXT:    vmul.vv v11, v11, v12
 ; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v12
-; RV64V-NEXT:    lui a0, 8
-; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
+; RV64V-NEXT:    vmul.vv v9, v13, v9
+; RV64V-NEXT:    vxor.vv v13, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v17, v16
+; RV64V-NEXT:    vmul.vv v8, v8, v10
+; RV64V-NEXT:    vxor.vv v10, v13, v18
+; RV64V-NEXT:    vxor.vv v12, v14, v12
+; RV64V-NEXT:    vxor.vv v9, v9, v11
+; RV64V-NEXT:    vand.vx v10, v10, a1
+; RV64V-NEXT:    vand.vx v11, v12, a0
 ; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vor.vv v9, v11, v10
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv2i16_vv:
@@ -2801,134 +2001,78 @@ define <vscale x 2 x i16> @clmul_nxv2i16_vv(<vscale x 2 x i16> %va, <vscale x 2 
 define <vscale x 2 x i16> @clmul_nxv2i16_vx(<vscale x 2 x i16> %va, i16 %b) nounwind {
 ; RV32V-LABEL: clmul_nxv2i16_vx:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    vsetvli a1, zero, e16, mf2, ta, ma
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
 ; RV32V-NEXT:    vmv.v.x v9, a0
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vxor.vv v10, v10, v12
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    vand.vx v10, v8, a1
+; RV32V-NEXT:    vand.vx v11, v8, a0
+; RV32V-NEXT:    lui a2, 5
 ; RV32V-NEXT:    vand.vx v12, v9, a0
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v13, v9, a1
+; RV32V-NEXT:    vand.vx v9, v9, a2
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vmul.vv v14, v10, v12
+; RV32V-NEXT:    vmul.vv v15, v11, v13
+; RV32V-NEXT:    vmul.vv v16, v10, v9
+; RV32V-NEXT:    vmul.vv v17, v11, v12
+; RV32V-NEXT:    vmul.vv v18, v8, v9
+; RV32V-NEXT:    vmul.vv v10, v10, v13
 ; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v12
-; RV32V-NEXT:    lui a0, 8
-; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
+; RV32V-NEXT:    vmul.vv v9, v11, v9
+; RV32V-NEXT:    vxor.vv v11, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v17, v16
+; RV32V-NEXT:    vmul.vv v8, v8, v12
+; RV32V-NEXT:    vxor.vv v11, v11, v18
+; RV32V-NEXT:    vxor.vv v12, v14, v13
+; RV32V-NEXT:    vxor.vv v9, v9, v10
+; RV32V-NEXT:    vand.vx v10, v11, a1
+; RV32V-NEXT:    vand.vx v11, v12, a0
 ; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vor.vv v9, v11, v10
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv2i16_vx:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    vsetvli a1, zero, e16, mf2, ta, ma
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
 ; RV64V-NEXT:    vmv.v.x v9, a0
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vxor.vv v10, v10, v12
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    vand.vx v10, v8, a1
+; RV64V-NEXT:    vand.vx v11, v8, a0
+; RV64V-NEXT:    lui a2, 5
 ; RV64V-NEXT:    vand.vx v12, v9, a0
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v13, v9, a1
+; RV64V-NEXT:    vand.vx v9, v9, a2
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vmul.vv v14, v10, v12
+; RV64V-NEXT:    vmul.vv v15, v11, v13
+; RV64V-NEXT:    vmul.vv v16, v10, v9
+; RV64V-NEXT:    vmul.vv v17, v11, v12
+; RV64V-NEXT:    vmul.vv v18, v8, v9
+; RV64V-NEXT:    vmul.vv v10, v10, v13
 ; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v12
-; RV64V-NEXT:    lui a0, 8
-; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
+; RV64V-NEXT:    vmul.vv v9, v11, v9
+; RV64V-NEXT:    vxor.vv v11, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v17, v16
+; RV64V-NEXT:    vmul.vv v8, v8, v12
+; RV64V-NEXT:    vxor.vv v11, v11, v18
+; RV64V-NEXT:    vxor.vv v12, v14, v13
+; RV64V-NEXT:    vxor.vv v9, v9, v10
+; RV64V-NEXT:    vand.vx v10, v11, a1
+; RV64V-NEXT:    vand.vx v11, v12, a0
 ; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vor.vv v9, v11, v10
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv2i16_vx:
@@ -2979,132 +2123,76 @@ define <vscale x 2 x i16> @clmul_nxv2i16_vx(<vscale x 2 x i16> %va, i16 %b) noun
 define <vscale x 4 x i16> @clmul_nxv4i16_vv(<vscale x 4 x i16> %va, <vscale x 4 x i16> %vb) nounwind {
 ; RV32V-LABEL: clmul_nxv4i16_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v12, v8, v13
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v12, v8, v13
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v12, v8, v13
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v12, v8, v13
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    lui a0, 8
-; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
+; RV32V-NEXT:    vand.vx v10, v9, a0
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v11, v8, a1
+; RV32V-NEXT:    vand.vx v12, v9, a1
+; RV32V-NEXT:    vand.vx v13, v8, a0
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v9, v9, a2
+; RV32V-NEXT:    vmul.vv v14, v11, v10
+; RV32V-NEXT:    vmul.vv v15, v13, v12
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vmul.vv v16, v8, v9
+; RV32V-NEXT:    vmul.vv v17, v11, v9
+; RV32V-NEXT:    vmul.vv v18, v13, v10
+; RV32V-NEXT:    vxor.vv v14, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v14, v16
+; RV32V-NEXT:    vxor.vv v15, v18, v17
+; RV32V-NEXT:    vmul.vv v16, v8, v12
+; RV32V-NEXT:    vmul.vv v11, v11, v12
+; RV32V-NEXT:    vmul.vv v9, v13, v9
+; RV32V-NEXT:    vand.vx v12, v14, a1
+; RV32V-NEXT:    vmul.vv v8, v8, v10
+; RV32V-NEXT:    vxor.vv v10, v15, v16
+; RV32V-NEXT:    vxor.vv v9, v9, v11
+; RV32V-NEXT:    vand.vx v10, v10, a0
 ; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vor.vv v9, v10, v12
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv4i16_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v12, v8, v13
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v12, v8, v13
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v12, v8, v13
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v12, v8, v13
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    lui a0, 8
-; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
+; RV64V-NEXT:    vand.vx v10, v9, a0
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v11, v8, a1
+; RV64V-NEXT:    vand.vx v12, v9, a1
+; RV64V-NEXT:    vand.vx v13, v8, a0
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v9, v9, a2
+; RV64V-NEXT:    vmul.vv v14, v11, v10
+; RV64V-NEXT:    vmul.vv v15, v13, v12
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vmul.vv v16, v8, v9
+; RV64V-NEXT:    vmul.vv v17, v11, v9
+; RV64V-NEXT:    vmul.vv v18, v13, v10
+; RV64V-NEXT:    vxor.vv v14, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v14, v16
+; RV64V-NEXT:    vxor.vv v15, v18, v17
+; RV64V-NEXT:    vmul.vv v16, v8, v12
+; RV64V-NEXT:    vmul.vv v11, v11, v12
+; RV64V-NEXT:    vmul.vv v9, v13, v9
+; RV64V-NEXT:    vand.vx v12, v14, a1
+; RV64V-NEXT:    vmul.vv v8, v8, v10
+; RV64V-NEXT:    vxor.vv v10, v15, v16
+; RV64V-NEXT:    vxor.vv v9, v9, v11
+; RV64V-NEXT:    vand.vx v10, v10, a0
 ; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vor.vv v9, v10, v12
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv4i16_vv:
@@ -3149,134 +2237,78 @@ define <vscale x 4 x i16> @clmul_nxv4i16_vv(<vscale x 4 x i16> %va, <vscale x 4 
 define <vscale x 4 x i16> @clmul_nxv4i16_vx(<vscale x 4 x i16> %va, i16 %b) nounwind {
 ; RV32V-LABEL: clmul_nxv4i16_vx:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
 ; RV32V-NEXT:    vmv.v.x v9, a0
-; RV32V-NEXT:    vand.vi v10, v9, 2
-; RV32V-NEXT:    vand.vi v11, v9, 1
-; RV32V-NEXT:    vmul.vv v10, v8, v10
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vand.vi v12, v9, 4
-; RV32V-NEXT:    vand.vi v13, v9, 8
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vxor.vv v10, v11, v10
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v11, v9, a0
-; RV32V-NEXT:    vmul.vv v13, v8, v13
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    li a0, 32
+; RV32V-NEXT:    addi a0, a1, 1170
+; RV32V-NEXT:    lui a1, 9
+; RV32V-NEXT:    vand.vx v10, v8, a0
+; RV32V-NEXT:    addi a1, a1, 585
+; RV32V-NEXT:    vand.vx v11, v9, a1
 ; RV32V-NEXT:    vand.vx v12, v9, a0
-; RV32V-NEXT:    vmul.vv v11, v8, v11
-; RV32V-NEXT:    vxor.vv v10, v10, v13
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v12, v8, v13
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v12, v8, v13
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v12, v8, v13
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v12, v8, v13
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vand.vx v13, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v11
-; RV32V-NEXT:    vmul.vv v11, v8, v13
-; RV32V-NEXT:    lui a0, 8
-; RV32V-NEXT:    vand.vx v9, v9, a0
-; RV32V-NEXT:    vxor.vv v10, v10, v12
-; RV32V-NEXT:    vmul.vv v8, v8, v9
-; RV32V-NEXT:    vxor.vv v9, v10, v11
+; RV32V-NEXT:    vand.vx v13, v8, a1
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v9, v9, a2
+; RV32V-NEXT:    vmul.vv v14, v10, v11
+; RV32V-NEXT:    vmul.vv v15, v13, v12
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vmul.vv v16, v8, v9
+; RV32V-NEXT:    vmul.vv v17, v10, v9
+; RV32V-NEXT:    vmul.vv v18, v13, v11
+; RV32V-NEXT:    vxor.vv v14, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v14, v16
+; RV32V-NEXT:    vxor.vv v15, v18, v17
+; RV32V-NEXT:    vmul.vv v16, v8, v12
+; RV32V-NEXT:    vmul.vv v10, v10, v12
+; RV32V-NEXT:    vmul.vv v9, v13, v9
+; RV32V-NEXT:    vand.vx v12, v14, a0
+; RV32V-NEXT:    vmul.vv v8, v8, v11
+; RV32V-NEXT:    vxor.vv v11, v15, v16
+; RV32V-NEXT:    vxor.vv v9, v9, v10
+; RV32V-NEXT:    vand.vx v10, v11, a1
 ; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vor.vv v9, v10, v12
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv4i16_vx:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
 ; RV64V-NEXT:    vmv.v.x v9, a0
-; RV64V-NEXT:    vand.vi v10, v9, 2
-; RV64V-NEXT:    vand.vi v11, v9, 1
-; RV64V-NEXT:    vmul.vv v10, v8, v10
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vand.vi v12, v9, 4
-; RV64V-NEXT:    vand.vi v13, v9, 8
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vxor.vv v10, v11, v10
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v11, v9, a0
-; RV64V-NEXT:    vmul.vv v13, v8, v13
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    li a0, 32
+; RV64V-NEXT:    addi a0, a1, 1170
+; RV64V-NEXT:    lui a1, 9
+; RV64V-NEXT:    vand.vx v10, v8, a0
+; RV64V-NEXT:    addi a1, a1, 585
+; RV64V-NEXT:    vand.vx v11, v9, a1
 ; RV64V-NEXT:    vand.vx v12, v9, a0
-; RV64V-NEXT:    vmul.vv v11, v8, v11
-; RV64V-NEXT:    vxor.vv v10, v10, v13
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v12, v8, v13
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v12, v8, v13
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v12, v8, v13
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v12, v8, v13
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vand.vx v13, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v11
-; RV64V-NEXT:    vmul.vv v11, v8, v13
-; RV64V-NEXT:    lui a0, 8
-; RV64V-NEXT:    vand.vx v9, v9, a0
-; RV64V-NEXT:    vxor.vv v10, v10, v12
-; RV64V-NEXT:    vmul.vv v8, v8, v9
-; RV64V-NEXT:    vxor.vv v9, v10, v11
+; RV64V-NEXT:    vand.vx v13, v8, a1
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v9, v9, a2
+; RV64V-NEXT:    vmul.vv v14, v10, v11
+; RV64V-NEXT:    vmul.vv v15, v13, v12
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vmul.vv v16, v8, v9
+; RV64V-NEXT:    vmul.vv v17, v10, v9
+; RV64V-NEXT:    vmul.vv v18, v13, v11
+; RV64V-NEXT:    vxor.vv v14, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v14, v16
+; RV64V-NEXT:    vxor.vv v15, v18, v17
+; RV64V-NEXT:    vmul.vv v16, v8, v12
+; RV64V-NEXT:    vmul.vv v10, v10, v12
+; RV64V-NEXT:    vmul.vv v9, v13, v9
+; RV64V-NEXT:    vand.vx v12, v14, a0
+; RV64V-NEXT:    vmul.vv v8, v8, v11
+; RV64V-NEXT:    vxor.vv v11, v15, v16
+; RV64V-NEXT:    vxor.vv v9, v9, v10
+; RV64V-NEXT:    vand.vx v10, v11, a1
 ; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vor.vv v9, v10, v12
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv4i16_vx:
@@ -3327,132 +2359,76 @@ define <vscale x 4 x i16> @clmul_nxv4i16_vx(<vscale x 4 x i16> %va, i16 %b) noun
 define <vscale x 8 x i16> @clmul_nxv8i16_vv(<vscale x 8 x i16> %va, <vscale x 8 x i16> %vb) nounwind {
 ; RV32V-LABEL: clmul_nxv8i16_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a0, a0, 585
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m2, ta, ma
-; RV32V-NEXT:    vand.vi v12, v10, 2
-; RV32V-NEXT:    vand.vi v14, v10, 1
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    vxor.vv v12, v14, v12
-; RV32V-NEXT:    vand.vi v14, v10, 4
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    vand.vi v16, v10, 8
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    lui a0, 8
-; RV32V-NEXT:    vand.vx v10, v10, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v10
-; RV32V-NEXT:    vxor.vv v10, v12, v14
+; RV32V-NEXT:    vand.vx v12, v10, a0
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v14, v8, a1
+; RV32V-NEXT:    vand.vx v16, v10, a1
+; RV32V-NEXT:    vand.vx v18, v8, a0
+; RV32V-NEXT:    vmul.vv v20, v14, v12
+; RV32V-NEXT:    vmul.vv v22, v18, v16
+; RV32V-NEXT:    vxor.vv v20, v22, v20
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v10, v10, a2
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vmul.vv v22, v8, v10
+; RV32V-NEXT:    vmul.vv v24, v14, v10
+; RV32V-NEXT:    vmul.vv v26, v18, v12
+; RV32V-NEXT:    vxor.vv v20, v20, v22
+; RV32V-NEXT:    vxor.vv v22, v26, v24
+; RV32V-NEXT:    vmul.vv v24, v8, v16
+; RV32V-NEXT:    vand.vx v20, v20, a1
+; RV32V-NEXT:    vxor.vv v22, v22, v24
+; RV32V-NEXT:    vand.vx v22, v22, a0
+; RV32V-NEXT:    vor.vv v20, v22, v20
+; RV32V-NEXT:    vmul.vv v14, v14, v16
+; RV32V-NEXT:    vmul.vv v10, v18, v10
+; RV32V-NEXT:    vmul.vv v8, v8, v12
+; RV32V-NEXT:    vxor.vv v10, v10, v14
 ; RV32V-NEXT:    vxor.vv v8, v10, v8
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v20, v8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv8i16_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a0, a0, 585
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m2, ta, ma
-; RV64V-NEXT:    vand.vi v12, v10, 2
-; RV64V-NEXT:    vand.vi v14, v10, 1
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    vxor.vv v12, v14, v12
-; RV64V-NEXT:    vand.vi v14, v10, 4
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    vand.vi v16, v10, 8
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    lui a0, 8
-; RV64V-NEXT:    vand.vx v10, v10, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v10
-; RV64V-NEXT:    vxor.vv v10, v12, v14
+; RV64V-NEXT:    vand.vx v12, v10, a0
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v14, v8, a1
+; RV64V-NEXT:    vand.vx v16, v10, a1
+; RV64V-NEXT:    vand.vx v18, v8, a0
+; RV64V-NEXT:    vmul.vv v20, v14, v12
+; RV64V-NEXT:    vmul.vv v22, v18, v16
+; RV64V-NEXT:    vxor.vv v20, v22, v20
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v10, v10, a2
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vmul.vv v22, v8, v10
+; RV64V-NEXT:    vmul.vv v24, v14, v10
+; RV64V-NEXT:    vmul.vv v26, v18, v12
+; RV64V-NEXT:    vxor.vv v20, v20, v22
+; RV64V-NEXT:    vxor.vv v22, v26, v24
+; RV64V-NEXT:    vmul.vv v24, v8, v16
+; RV64V-NEXT:    vand.vx v20, v20, a1
+; RV64V-NEXT:    vxor.vv v22, v22, v24
+; RV64V-NEXT:    vand.vx v22, v22, a0
+; RV64V-NEXT:    vor.vv v20, v22, v20
+; RV64V-NEXT:    vmul.vv v14, v14, v16
+; RV64V-NEXT:    vmul.vv v10, v18, v10
+; RV64V-NEXT:    vmul.vv v8, v8, v12
+; RV64V-NEXT:    vxor.vv v10, v10, v14
 ; RV64V-NEXT:    vxor.vv v8, v10, v8
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v20, v8
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv8i16_vv:
@@ -3499,132 +2475,76 @@ define <vscale x 8 x i16> @clmul_nxv8i16_vx(<vscale x 8 x i16> %va, i16 %b) noun
 ; RV32V:       # %bb.0:
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m2, ta, ma
 ; RV32V-NEXT:    vmv.v.x v10, a0
-; RV32V-NEXT:    vand.vi v12, v10, 2
-; RV32V-NEXT:    vand.vi v14, v10, 1
-; RV32V-NEXT:    vmul.vv v12, v8, v12
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    vxor.vv v12, v14, v12
-; RV32V-NEXT:    vand.vi v14, v10, 4
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    vand.vi v16, v10, 8
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vand.vx v16, v10, a0
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vand.vx v14, v10, a0
-; RV32V-NEXT:    vmul.vv v14, v8, v14
-; RV32V-NEXT:    lui a0, 8
-; RV32V-NEXT:    vand.vx v10, v10, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v10
-; RV32V-NEXT:    vxor.vv v10, v12, v14
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    vand.vx v12, v10, a0
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v14, v8, a1
+; RV32V-NEXT:    vand.vx v16, v10, a1
+; RV32V-NEXT:    vand.vx v18, v8, a0
+; RV32V-NEXT:    vmul.vv v20, v14, v12
+; RV32V-NEXT:    vmul.vv v22, v18, v16
+; RV32V-NEXT:    vxor.vv v20, v22, v20
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v10, v10, a2
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vmul.vv v22, v8, v10
+; RV32V-NEXT:    vmul.vv v24, v14, v10
+; RV32V-NEXT:    vmul.vv v26, v18, v12
+; RV32V-NEXT:    vxor.vv v20, v20, v22
+; RV32V-NEXT:    vxor.vv v22, v26, v24
+; RV32V-NEXT:    vmul.vv v24, v8, v16
+; RV32V-NEXT:    vand.vx v20, v20, a1
+; RV32V-NEXT:    vxor.vv v22, v22, v24
+; RV32V-NEXT:    vand.vx v22, v22, a0
+; RV32V-NEXT:    vor.vv v20, v22, v20
+; RV32V-NEXT:    vmul.vv v14, v14, v16
+; RV32V-NEXT:    vmul.vv v10, v18, v10
+; RV32V-NEXT:    vmul.vv v8, v8, v12
+; RV32V-NEXT:    vxor.vv v10, v10, v14
 ; RV32V-NEXT:    vxor.vv v8, v10, v8
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v20, v8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv8i16_vx:
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m2, ta, ma
 ; RV64V-NEXT:    vmv.v.x v10, a0
-; RV64V-NEXT:    vand.vi v12, v10, 2
-; RV64V-NEXT:    vand.vi v14, v10, 1
-; RV64V-NEXT:    vmul.vv v12, v8, v12
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    vxor.vv v12, v14, v12
-; RV64V-NEXT:    vand.vi v14, v10, 4
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    vand.vi v16, v10, 8
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vand.vx v16, v10, a0
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vand.vx v14, v10, a0
-; RV64V-NEXT:    vmul.vv v14, v8, v14
-; RV64V-NEXT:    lui a0, 8
-; RV64V-NEXT:    vand.vx v10, v10, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v10
-; RV64V-NEXT:    vxor.vv v10, v12, v14
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    vand.vx v12, v10, a0
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v14, v8, a1
+; RV64V-NEXT:    vand.vx v16, v10, a1
+; RV64V-NEXT:    vand.vx v18, v8, a0
+; RV64V-NEXT:    vmul.vv v20, v14, v12
+; RV64V-NEXT:    vmul.vv v22, v18, v16
+; RV64V-NEXT:    vxor.vv v20, v22, v20
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v10, v10, a2
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vmul.vv v22, v8, v10
+; RV64V-NEXT:    vmul.vv v24, v14, v10
+; RV64V-NEXT:    vmul.vv v26, v18, v12
+; RV64V-NEXT:    vxor.vv v20, v20, v22
+; RV64V-NEXT:    vxor.vv v22, v26, v24
+; RV64V-NEXT:    vmul.vv v24, v8, v16
+; RV64V-NEXT:    vand.vx v20, v20, a1
+; RV64V-NEXT:    vxor.vv v22, v22, v24
+; RV64V-NEXT:    vand.vx v22, v22, a0
+; RV64V-NEXT:    vor.vv v20, v22, v20
+; RV64V-NEXT:    vmul.vv v14, v14, v16
+; RV64V-NEXT:    vmul.vv v10, v18, v10
+; RV64V-NEXT:    vmul.vv v8, v8, v12
+; RV64V-NEXT:    vxor.vv v10, v10, v14
 ; RV64V-NEXT:    vxor.vv v8, v10, v8
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v20, v8
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv8i16_vx:
@@ -3675,262 +2595,446 @@ define <vscale x 8 x i16> @clmul_nxv8i16_vx(<vscale x 8 x i16> %va, i16 %b) noun
 define <vscale x 16 x i16> @clmul_nxv16i16_vv(<vscale x 16 x i16> %va, <vscale x 16 x i16> %vb) nounwind {
 ; RV32V-LABEL: clmul_nxv16i16_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
+; RV32V-NEXT:    addi sp, sp, -16
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    mv a1, a0
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, a0, a1
+; RV32V-NEXT:    sub sp, sp, a0
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a0, a0, 585
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV32V-NEXT:    vand.vi v16, v12, 2
-; RV32V-NEXT:    vand.vi v20, v12, 1
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    vxor.vv v16, v20, v16
-; RV32V-NEXT:    vand.vi v20, v12, 4
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    vand.vi v24, v12, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    lui a0, 8
-; RV32V-NEXT:    vand.vx v12, v12, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v12
-; RV32V-NEXT:    vxor.vv v12, v16, v20
+; RV32V-NEXT:    vand.vx v16, v12, a0
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 2
+; RV32V-NEXT:    mv a2, a1
+; RV32V-NEXT:    slli a1, a1, 1
+; RV32V-NEXT:    add a1, a1, a2
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vs4r.v v16, (a1) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v20, v8, a1
+; RV32V-NEXT:    vand.vx v24, v12, a1
+; RV32V-NEXT:    vand.vx v28, v8, a0
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v12, v12, a2
+; RV32V-NEXT:    vmul.vv v16, v20, v16
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v0, v28, v24
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vmul.vv v16, v8, v12
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v0, v4
+; RV32V-NEXT:    vxor.vv v16, v0, v16
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v16, v20, v12
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v28, v4
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v16, v8, v24
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v16, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v16, v0
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vl4r.v v16, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v16, v0, v16
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vand.vx v0, v0, a1
+; RV32V-NEXT:    vand.vx v16, v16, a0
+; RV32V-NEXT:    vor.vv v16, v16, v0
+; RV32V-NEXT:    vmul.vv v20, v20, v24
+; RV32V-NEXT:    vmul.vv v12, v28, v12
+; RV32V-NEXT:    vmul.vv v8, v8, v4
+; RV32V-NEXT:    vxor.vv v12, v12, v20
 ; RV32V-NEXT:    vxor.vv v8, v12, v8
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v16, v8
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    mv a1, a0
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, a0, a1
+; RV32V-NEXT:    add sp, sp, a0
+; RV32V-NEXT:    addi sp, sp, 16
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv16i16_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
+; RV64V-NEXT:    addi sp, sp, -16
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    mv a1, a0
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, a0, a1
+; RV64V-NEXT:    sub sp, sp, a0
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a0, a0, 585
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV64V-NEXT:    vand.vi v16, v12, 2
-; RV64V-NEXT:    vand.vi v20, v12, 1
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    vxor.vv v16, v20, v16
-; RV64V-NEXT:    vand.vi v20, v12, 4
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    vand.vi v24, v12, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    lui a0, 8
-; RV64V-NEXT:    vand.vx v12, v12, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v12
-; RV64V-NEXT:    vxor.vv v12, v16, v20
+; RV64V-NEXT:    vand.vx v16, v12, a0
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 2
+; RV64V-NEXT:    mv a2, a1
+; RV64V-NEXT:    slli a1, a1, 1
+; RV64V-NEXT:    add a1, a1, a2
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vs4r.v v16, (a1) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v20, v8, a1
+; RV64V-NEXT:    vand.vx v24, v12, a1
+; RV64V-NEXT:    vand.vx v28, v8, a0
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v12, v12, a2
+; RV64V-NEXT:    vmul.vv v16, v20, v16
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v0, v28, v24
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vmul.vv v16, v8, v12
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v0, v4
+; RV64V-NEXT:    vxor.vv v16, v0, v16
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v16, v20, v12
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v28, v4
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v16, v8, v24
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v16, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v16, v0
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vl4r.v v16, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v16, v0, v16
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vand.vx v0, v0, a1
+; RV64V-NEXT:    vand.vx v16, v16, a0
+; RV64V-NEXT:    vor.vv v16, v16, v0
+; RV64V-NEXT:    vmul.vv v20, v20, v24
+; RV64V-NEXT:    vmul.vv v12, v28, v12
+; RV64V-NEXT:    vmul.vv v8, v8, v4
+; RV64V-NEXT:    vxor.vv v12, v12, v20
 ; RV64V-NEXT:    vxor.vv v8, v12, v8
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v16, v8
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    mv a1, a0
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, a0, a1
+; RV64V-NEXT:    add sp, sp, a0
+; RV64V-NEXT:    addi sp, sp, 16
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv16i16_vv:
 ; RV32ZVBC64:       # %bb.0:
-; RV32ZVBC64-NEXT:    li a0, 16
+; RV32ZVBC64-NEXT:    addi sp, sp, -16
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    mv a1, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, a0, a1
+; RV32ZVBC64-NEXT:    sub sp, sp, a0
+; RV32ZVBC64-NEXT:    lui a0, 9
+; RV32ZVBC64-NEXT:    addi a0, a0, 585
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV32ZVBC64-NEXT:    vand.vi v16, v12, 2
-; RV32ZVBC64-NEXT:    vand.vi v20, v12, 1
-; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v20, v16
-; RV32ZVBC64-NEXT:    vand.vi v20, v12, 4
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    vand.vi v24, v12, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 128
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 256
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 512
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 1024
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 1
-; RV32ZVBC64-NEXT:    slli a0, a0, 11
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    lui a0, 1
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    lui a0, 2
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    lui a0, 4
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    lui a0, 8
-; RV32ZVBC64-NEXT:    vand.vx v12, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v12
-; RV32ZVBC64-NEXT:    vxor.vv v12, v16, v20
+; RV32ZVBC64-NEXT:    vand.vx v16, v12, a0
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 2
+; RV32ZVBC64-NEXT:    mv a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 1
+; RV32ZVBC64-NEXT:    add a1, a1, a2
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vs4r.v v16, (a1) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    lui a1, 2
+; RV32ZVBC64-NEXT:    addi a1, a1, 1170
+; RV32ZVBC64-NEXT:    vand.vx v20, v8, a1
+; RV32ZVBC64-NEXT:    vand.vx v24, v12, a1
+; RV32ZVBC64-NEXT:    vand.vx v28, v8, a0
+; RV32ZVBC64-NEXT:    lui a2, 5
+; RV32ZVBC64-NEXT:    addi a2, a2, -1756
+; RV32ZVBC64-NEXT:    vand.vx v12, v12, a2
+; RV32ZVBC64-NEXT:    vmul.vv v16, v20, v16
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v0, v28, v24
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v12
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v4
+; RV32ZVBC64-NEXT:    vxor.vv v16, v0, v16
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v16, v20, v12
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v28, v4
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v24
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v16, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v16, v0
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vl4r.v v16, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v16, v0, v16
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a1
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
+; RV32ZVBC64-NEXT:    vor.vv v16, v16, v0
+; RV32ZVBC64-NEXT:    vmul.vv v20, v20, v24
+; RV32ZVBC64-NEXT:    vmul.vv v12, v28, v12
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v4
+; RV32ZVBC64-NEXT:    vxor.vv v12, v12, v20
 ; RV32ZVBC64-NEXT:    vxor.vv v8, v12, v8
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    mv a1, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, a0, a1
+; RV32ZVBC64-NEXT:    add sp, sp, a0
+; RV32ZVBC64-NEXT:    addi sp, sp, 16
 ; RV32ZVBC64-NEXT:    ret
 ;
 ; RV64ZVBC64-LABEL: clmul_nxv16i16_vv:
 ; RV64ZVBC64:       # %bb.0:
-; RV64ZVBC64-NEXT:    li a0, 16
+; RV64ZVBC64-NEXT:    addi sp, sp, -16
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    mv a1, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, a0, a1
+; RV64ZVBC64-NEXT:    sub sp, sp, a0
+; RV64ZVBC64-NEXT:    lui a0, 9
+; RV64ZVBC64-NEXT:    addi a0, a0, 585
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV64ZVBC64-NEXT:    vand.vi v16, v12, 2
-; RV64ZVBC64-NEXT:    vand.vi v20, v12, 1
-; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v20, v16
-; RV64ZVBC64-NEXT:    vand.vi v20, v12, 4
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    vand.vi v24, v12, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 128
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 256
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 512
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 1024
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 1
-; RV64ZVBC64-NEXT:    slli a0, a0, 11
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    lui a0, 1
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    lui a0, 2
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    lui a0, 4
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    lui a0, 8
-; RV64ZVBC64-NEXT:    vand.vx v12, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v12
-; RV64ZVBC64-NEXT:    vxor.vv v12, v16, v20
+; RV64ZVBC64-NEXT:    vand.vx v16, v12, a0
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 2
+; RV64ZVBC64-NEXT:    mv a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 1
+; RV64ZVBC64-NEXT:    add a1, a1, a2
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vs4r.v v16, (a1) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    lui a1, 2
+; RV64ZVBC64-NEXT:    addi a1, a1, 1170
+; RV64ZVBC64-NEXT:    vand.vx v20, v8, a1
+; RV64ZVBC64-NEXT:    vand.vx v24, v12, a1
+; RV64ZVBC64-NEXT:    vand.vx v28, v8, a0
+; RV64ZVBC64-NEXT:    lui a2, 5
+; RV64ZVBC64-NEXT:    addi a2, a2, -1756
+; RV64ZVBC64-NEXT:    vand.vx v12, v12, a2
+; RV64ZVBC64-NEXT:    vmul.vv v16, v20, v16
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v0, v28, v24
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v12
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v4
+; RV64ZVBC64-NEXT:    vxor.vv v16, v0, v16
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v16, v20, v12
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v28, v4
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v24
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vs4r.v v16, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v16, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v16, v0
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vl4r.v v16, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v16, v0, v16
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a1
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
+; RV64ZVBC64-NEXT:    vor.vv v16, v16, v0
+; RV64ZVBC64-NEXT:    vmul.vv v20, v20, v24
+; RV64ZVBC64-NEXT:    vmul.vv v12, v28, v12
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v4
+; RV64ZVBC64-NEXT:    vxor.vv v12, v12, v20
 ; RV64ZVBC64-NEXT:    vxor.vv v8, v12, v8
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    mv a1, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, a0, a1
+; RV64ZVBC64-NEXT:    add sp, sp, a0
+; RV64ZVBC64-NEXT:    addi sp, sp, 16
 ; RV64ZVBC64-NEXT:    ret
 ;
 ; RV32ZVBC32-LABEL: clmul_nxv16i16_vv:
@@ -3951,266 +3055,450 @@ define <vscale x 16 x i16> @clmul_nxv16i16_vv(<vscale x 16 x i16> %va, <vscale x
 define <vscale x 16 x i16> @clmul_nxv16i16_vx(<vscale x 16 x i16> %va, i16 %b) nounwind {
 ; RV32V-LABEL: clmul_nxv16i16_vx:
 ; RV32V:       # %bb.0:
+; RV32V-NEXT:    addi sp, sp, -16
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 2
+; RV32V-NEXT:    mv a2, a1
+; RV32V-NEXT:    slli a1, a1, 2
+; RV32V-NEXT:    add a1, a1, a2
+; RV32V-NEXT:    sub sp, sp, a1
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV32V-NEXT:    vmv.v.x v12, a0
-; RV32V-NEXT:    vand.vi v16, v12, 2
-; RV32V-NEXT:    vand.vi v20, v12, 1
-; RV32V-NEXT:    vmul.vv v16, v8, v16
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    vxor.vv v16, v20, v16
-; RV32V-NEXT:    vand.vi v20, v12, 4
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    vand.vi v24, v12, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vand.vx v24, v12, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vand.vx v20, v12, a0
-; RV32V-NEXT:    vmul.vv v20, v8, v20
-; RV32V-NEXT:    lui a0, 8
+; RV32V-NEXT:    vmv.v.x v28, a0
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    vand.vx v12, v28, a0
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 2
+; RV32V-NEXT:    mv a2, a1
+; RV32V-NEXT:    slli a1, a1, 1
+; RV32V-NEXT:    add a1, a1, a2
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vs4r.v v12, (a1) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v16, v8, a1
+; RV32V-NEXT:    vand.vx v20, v28, a1
+; RV32V-NEXT:    vand.vx v24, v8, a0
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v28, v28, a2
+; RV32V-NEXT:    vmul.vv v12, v16, v12
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v0, v24, v20
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vmul.vv v12, v8, v28
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v0, v4
+; RV32V-NEXT:    vxor.vv v12, v0, v12
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v12, v16, v28
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v12, v24, v4
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v12, v8, v20
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v12, v0
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v12, v0, v12
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vand.vx v0, v0, a1
 ; RV32V-NEXT:    vand.vx v12, v12, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v12
-; RV32V-NEXT:    vxor.vv v12, v16, v20
-; RV32V-NEXT:    vxor.vv v8, v12, v8
+; RV32V-NEXT:    vor.vv v12, v12, v0
+; RV32V-NEXT:    vmul.vv v16, v16, v20
+; RV32V-NEXT:    vmul.vv v20, v24, v28
+; RV32V-NEXT:    vmul.vv v8, v8, v4
+; RV32V-NEXT:    vxor.vv v16, v20, v16
+; RV32V-NEXT:    vxor.vv v8, v16, v8
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v12, v8
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    mv a1, a0
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, a0, a1
+; RV32V-NEXT:    add sp, sp, a0
+; RV32V-NEXT:    addi sp, sp, 16
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmul_nxv16i16_vx:
 ; RV64V:       # %bb.0:
+; RV64V-NEXT:    addi sp, sp, -16
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 2
+; RV64V-NEXT:    mv a2, a1
+; RV64V-NEXT:    slli a1, a1, 2
+; RV64V-NEXT:    add a1, a1, a2
+; RV64V-NEXT:    sub sp, sp, a1
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV64V-NEXT:    vmv.v.x v12, a0
-; RV64V-NEXT:    vand.vi v16, v12, 2
-; RV64V-NEXT:    vand.vi v20, v12, 1
-; RV64V-NEXT:    vmul.vv v16, v8, v16
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    vxor.vv v16, v20, v16
-; RV64V-NEXT:    vand.vi v20, v12, 4
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    vand.vi v24, v12, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vand.vx v24, v12, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vand.vx v20, v12, a0
-; RV64V-NEXT:    vmul.vv v20, v8, v20
-; RV64V-NEXT:    lui a0, 8
+; RV64V-NEXT:    vmv.v.x v28, a0
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    vand.vx v12, v28, a0
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 2
+; RV64V-NEXT:    mv a2, a1
+; RV64V-NEXT:    slli a1, a1, 1
+; RV64V-NEXT:    add a1, a1, a2
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vs4r.v v12, (a1) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v16, v8, a1
+; RV64V-NEXT:    vand.vx v20, v28, a1
+; RV64V-NEXT:    vand.vx v24, v8, a0
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v28, v28, a2
+; RV64V-NEXT:    vmul.vv v12, v16, v12
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v0, v24, v20
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vmul.vv v12, v8, v28
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v0, v4
+; RV64V-NEXT:    vxor.vv v12, v0, v12
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v12, v16, v28
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v12, v24, v4
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v12, v8, v20
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v12, v0
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v12, v0, v12
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vand.vx v0, v0, a1
 ; RV64V-NEXT:    vand.vx v12, v12, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v12
-; RV64V-NEXT:    vxor.vv v12, v16, v20
-; RV64V-NEXT:    vxor.vv v8, v12, v8
+; RV64V-NEXT:    vor.vv v12, v12, v0
+; RV64V-NEXT:    vmul.vv v16, v16, v20
+; RV64V-NEXT:    vmul.vv v20, v24, v28
+; RV64V-NEXT:    vmul.vv v8, v8, v4
+; RV64V-NEXT:    vxor.vv v16, v20, v16
+; RV64V-NEXT:    vxor.vv v8, v16, v8
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v12, v8
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    mv a1, a0
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, a0, a1
+; RV64V-NEXT:    add sp, sp, a0
+; RV64V-NEXT:    addi sp, sp, 16
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmul_nxv16i16_vx:
 ; RV32ZVBC64:       # %bb.0:
+; RV32ZVBC64-NEXT:    addi sp, sp, -16
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 2
+; RV32ZVBC64-NEXT:    mv a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 2
+; RV32ZVBC64-NEXT:    add a1, a1, a2
+; RV32ZVBC64-NEXT:    sub sp, sp, a1
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV32ZVBC64-NEXT:    vmv.v.x v12, a0
-; RV32ZVBC64-NEXT:    vand.vi v16, v12, 2
-; RV32ZVBC64-NEXT:    vand.vi v20, v12, 1
-; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v20, v16
-; RV32ZVBC64-NEXT:    vand.vi v20, v12, 4
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    vand.vi v24, v12, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 16
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 128
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 256
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 512
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 1024
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    li a0, 1
-; RV32ZVBC64-NEXT:    slli a0, a0, 11
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    lui a0, 1
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    lui a0, 2
-; RV32ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    lui a0, 4
-; RV32ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV32ZVBC64-NEXT:    lui a0, 8
+; RV32ZVBC64-NEXT:    vmv.v.x v28, a0
+; RV32ZVBC64-NEXT:    lui a0, 9
+; RV32ZVBC64-NEXT:    addi a0, a0, 585
+; RV32ZVBC64-NEXT:    vand.vx v12, v28, a0
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 2
+; RV32ZVBC64-NEXT:    mv a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 1
+; RV32ZVBC64-NEXT:    add a1, a1, a2
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vs4r.v v12, (a1) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    lui a1, 2
+; RV32ZVBC64-NEXT:    addi a1, a1, 1170
+; RV32ZVBC64-NEXT:    vand.vx v16, v8, a1
+; RV32ZVBC64-NEXT:    vand.vx v20, v28, a1
+; RV32ZVBC64-NEXT:    vand.vx v24, v8, a0
+; RV32ZVBC64-NEXT:    lui a2, 5
+; RV32ZVBC64-NEXT:    addi a2, a2, -1756
+; RV32ZVBC64-NEXT:    vand.vx v28, v28, a2
+; RV32ZVBC64-NEXT:    vmul.vv v12, v16, v12
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v0, v24, v20
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV32ZVBC64-NEXT:    vmul.vv v12, v8, v28
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v4
+; RV32ZVBC64-NEXT:    vxor.vv v12, v0, v12
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v12, v16, v28
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v12, v24, v4
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v12, v8, v20
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v12, v0
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v12, v0, v12
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a1
 ; RV32ZVBC64-NEXT:    vand.vx v12, v12, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v12
-; RV32ZVBC64-NEXT:    vxor.vv v12, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v8, v12, v8
+; RV32ZVBC64-NEXT:    vor.vv v12, v12, v0
+; RV32ZVBC64-NEXT:    vmul.vv v16, v16, v20
+; RV32ZVBC64-NEXT:    vmul.vv v20, v24, v28
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v4
+; RV32ZVBC64-NEXT:    vxor.vv v16, v20, v16
+; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV32ZVBC64-NEXT:    vor.vv v8, v12, v8
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    mv a1, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, a0, a1
+; RV32ZVBC64-NEXT:    add sp, sp, a0
+; RV32ZVBC64-NEXT:    addi sp, sp, 16
 ; RV32ZVBC64-NEXT:    ret
 ;
 ; RV64ZVBC64-LABEL: clmul_nxv16i16_vx:
 ; RV64ZVBC64:       # %bb.0:
+; RV64ZVBC64-NEXT:    addi sp, sp, -16
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 2
+; RV64ZVBC64-NEXT:    mv a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 2
+; RV64ZVBC64-NEXT:    add a1, a1, a2
+; RV64ZVBC64-NEXT:    sub sp, sp, a1
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV64ZVBC64-NEXT:    vmv.v.x v12, a0
-; RV64ZVBC64-NEXT:    vand.vi v16, v12, 2
-; RV64ZVBC64-NEXT:    vand.vi v20, v12, 1
-; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v16
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v20, v16
-; RV64ZVBC64-NEXT:    vand.vi v20, v12, 4
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    vand.vi v24, v12, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 16
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 128
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 256
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 512
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 1024
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    li a0, 1
-; RV64ZVBC64-NEXT:    slli a0, a0, 11
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    lui a0, 1
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    lui a0, 2
-; RV64ZVBC64-NEXT:    vand.vx v24, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    lui a0, 4
-; RV64ZVBC64-NEXT:    vand.vx v20, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v8, v20
-; RV64ZVBC64-NEXT:    lui a0, 8
+; RV64ZVBC64-NEXT:    vmv.v.x v28, a0
+; RV64ZVBC64-NEXT:    lui a0, 9
+; RV64ZVBC64-NEXT:    addi a0, a0, 585
+; RV64ZVBC64-NEXT:    vand.vx v12, v28, a0
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 2
+; RV64ZVBC64-NEXT:    mv a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 1
+; RV64ZVBC64-NEXT:    add a1, a1, a2
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vs4r.v v12, (a1) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    lui a1, 2
+; RV64ZVBC64-NEXT:    addi a1, a1, 1170
+; RV64ZVBC64-NEXT:    vand.vx v16, v8, a1
+; RV64ZVBC64-NEXT:    vand.vx v20, v28, a1
+; RV64ZVBC64-NEXT:    vand.vx v24, v8, a0
+; RV64ZVBC64-NEXT:    lui a2, 5
+; RV64ZVBC64-NEXT:    addi a2, a2, -1756
+; RV64ZVBC64-NEXT:    vand.vx v28, v28, a2
+; RV64ZVBC64-NEXT:    vmul.vv v12, v16, v12
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v0, v24, v20
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV64ZVBC64-NEXT:    vmul.vv v12, v8, v28
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v4
+; RV64ZVBC64-NEXT:    vxor.vv v12, v0, v12
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v12, v16, v28
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v12, v24, v4
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v12, v8, v20
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v12, v0
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v12, v0, v12
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a1
 ; RV64ZVBC64-NEXT:    vand.vx v12, v12, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v12
-; RV64ZVBC64-NEXT:    vxor.vv v12, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v8, v12, v8
+; RV64ZVBC64-NEXT:    vor.vv v12, v12, v0
+; RV64ZVBC64-NEXT:    vmul.vv v16, v16, v20
+; RV64ZVBC64-NEXT:    vmul.vv v20, v24, v28
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v4
+; RV64ZVBC64-NEXT:    vxor.vv v16, v20, v16
+; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV64ZVBC64-NEXT:    vor.vv v8, v12, v8
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    mv a1, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, a0, a1
+; RV64ZVBC64-NEXT:    add sp, sp, a0
+; RV64ZVBC64-NEXT:    addi sp, sp, 16
 ; RV64ZVBC64-NEXT:    ret
 ;
 ; RV32ZVBC32-LABEL: clmul_nxv16i16_vx:
@@ -4237,218 +3525,264 @@ define <vscale x 32 x i16> @clmul_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale x
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    mv a1, a0
-; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    sub sp, sp, a0
-; RV32V-NEXT:    li a0, 16
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a0, a0, 585
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV32V-NEXT:    vand.vi v24, v16, 2
-; RV32V-NEXT:    vand.vi v0, v16, 1
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    vxor.vv v24, v0, v24
+; RV32V-NEXT:    vand.vx v0, v16, a0
 ; RV32V-NEXT:    csrr a1, vlenb
 ; RV32V-NEXT:    slli a1, a1, 4
+; RV32V-NEXT:    mv a2, a1
+; RV32V-NEXT:    slli a1, a1, 1
+; RV32V-NEXT:    add a1, a1, a2
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vs8r.v v0, (a1) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a2, a1, 1170
+; RV32V-NEXT:    vand.vx v24, v16, a2
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 6
 ; RV32V-NEXT:    add a1, sp, a1
 ; RV32V-NEXT:    addi a1, a1, 16
 ; RV32V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v0, v16, 4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 3
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v24, v16, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a1, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 4
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 3
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a1, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 4
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
+; RV32V-NEXT:    lui a1, 5
+; RV32V-NEXT:    addi a1, a1, -1756
+; RV32V-NEXT:    vand.vx v16, v16, a1
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a4, a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v16, v8, a2
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v24, v8, a0
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v0, v16, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 6
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v0, v24, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a4, a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v8, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v16, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v0, v16
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a4, a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v0, v16, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v0, v24, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 6
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v0
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v8, v0
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v8, v0, v8
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v8, v0, a2
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 5
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v0, v0, a0
+; RV32V-NEXT:    vor.vv v0, v0, v8
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a2, a0
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, a0, a2
 ; RV32V-NEXT:    add a0, sp, a0
 ; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 6
+; RV32V-NEXT:    add a0, sp, a0
+; RV32V-NEXT:    addi a0, a0, 16
+; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v16, v0
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a2, a0
+; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    add a2, a2, a0
+; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    add a0, a0, a2
+; RV32V-NEXT:    add a0, sp, a0
+; RV32V-NEXT:    addi a0, a0, 16
+; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v24, v0
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 4
+; RV32V-NEXT:    mv a2, a0
+; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    add a0, a0, a2
 ; RV32V-NEXT:    add a0, sp, a0
 ; RV32V-NEXT:    addi a0, a0, 16
 ; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 4
 ; RV32V-NEXT:    add a0, sp, a0
 ; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    lui a0, 8
-; RV32V-NEXT:    vand.vx v16, v16, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v16
-; RV32V-NEXT:    vxor.vv v16, v24, v0
+; RV32V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v0
+; RV32V-NEXT:    vxor.vv v16, v24, v16
 ; RV32V-NEXT:    vxor.vv v8, v16, v8
+; RV32V-NEXT:    vand.vx v8, v8, a1
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    mv a1, a0
-; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, a0, a1
+; RV32V-NEXT:    add a0, sp, a0
+; RV32V-NEXT:    addi a0, a0, 16
+; RV32V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vor.vv v8, v16, v8
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a1, a0
+; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    add sp, sp, a0
 ; RV32V-NEXT:    addi sp, sp, 16
@@ -4460,218 +3794,264 @@ define <vscale x 32 x i16> @clmul_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale x
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    mv a1, a0
-; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    sub sp, sp, a0
-; RV64V-NEXT:    li a0, 16
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a0, a0, 585
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV64V-NEXT:    vand.vi v24, v16, 2
-; RV64V-NEXT:    vand.vi v0, v16, 1
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    vxor.vv v24, v0, v24
+; RV64V-NEXT:    vand.vx v0, v16, a0
 ; RV64V-NEXT:    csrr a1, vlenb
 ; RV64V-NEXT:    slli a1, a1, 4
+; RV64V-NEXT:    mv a2, a1
+; RV64V-NEXT:    slli a1, a1, 1
+; RV64V-NEXT:    add a1, a1, a2
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vs8r.v v0, (a1) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a2, a1, 1170
+; RV64V-NEXT:    vand.vx v24, v16, a2
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 6
 ; RV64V-NEXT:    add a1, sp, a1
 ; RV64V-NEXT:    addi a1, a1, 16
 ; RV64V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v0, v16, 4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 3
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v24, v16, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a1, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 4
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 3
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a1, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 4
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
+; RV64V-NEXT:    lui a1, 5
+; RV64V-NEXT:    addi a1, a1, -1756
+; RV64V-NEXT:    vand.vx v16, v16, a1
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a4, a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v16, v8, a2
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v24, v8, a0
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v0, v16, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 6
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v0, v24, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a4, a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v8, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v16, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v0, v16
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a4, a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v0, v16, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v0, v24, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 6
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v0
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v8, v0
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v8, v0, v8
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v8, v0, a2
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 5
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v0, v0, a0
+; RV64V-NEXT:    vor.vv v0, v0, v8
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a2, a0
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, a0, a2
 ; RV64V-NEXT:    add a0, sp, a0
 ; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 6
+; RV64V-NEXT:    add a0, sp, a0
+; RV64V-NEXT:    addi a0, a0, 16
+; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v16, v0
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a2, a0
+; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    add a2, a2, a0
+; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    add a0, a0, a2
+; RV64V-NEXT:    add a0, sp, a0
+; RV64V-NEXT:    addi a0, a0, 16
+; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v24, v0
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 4
+; RV64V-NEXT:    mv a2, a0
+; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    add a0, a0, a2
 ; RV64V-NEXT:    add a0, sp, a0
 ; RV64V-NEXT:    addi a0, a0, 16
 ; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 4
 ; RV64V-NEXT:    add a0, sp, a0
 ; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    lui a0, 8
-; RV64V-NEXT:    vand.vx v16, v16, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v16
-; RV64V-NEXT:    vxor.vv v16, v24, v0
+; RV64V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v0
+; RV64V-NEXT:    vxor.vv v16, v24, v16
 ; RV64V-NEXT:    vxor.vv v8, v16, v8
+; RV64V-NEXT:    vand.vx v8, v8, a1
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    mv a1, a0
-; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, a0, a1
+; RV64V-NEXT:    add a0, sp, a0
+; RV64V-NEXT:    addi a0, a0, 16
+; RV64V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vor.vv v8, v16, v8
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a1, a0
+; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    add sp, sp, a0
 ; RV64V-NEXT:    addi sp, sp, 16
@@ -4683,218 +4063,264 @@ define <vscale x 32 x i16> @clmul_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale x
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    mv a1, a0
-; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    sub sp, sp, a0
-; RV32ZVBC64-NEXT:    li a0, 16
+; RV32ZVBC64-NEXT:    lui a0, 9
+; RV32ZVBC64-NEXT:    addi a0, a0, 585
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
+; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
 ; RV32ZVBC64-NEXT:    csrr a1, vlenb
 ; RV32ZVBC64-NEXT:    slli a1, a1, 4
+; RV32ZVBC64-NEXT:    mv a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 1
+; RV32ZVBC64-NEXT:    add a1, a1, a2
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a1) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    lui a1, 2
+; RV32ZVBC64-NEXT:    addi a2, a1, 1170
+; RV32ZVBC64-NEXT:    vand.vx v24, v16, a2
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 6
 ; RV32ZVBC64-NEXT:    add a1, sp, a1
 ; RV32ZVBC64-NEXT:    addi a1, a1, 16
 ; RV32ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 3
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a1, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 4
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 3
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a1, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 4
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
+; RV32ZVBC64-NEXT:    lui a1, 5
+; RV32ZVBC64-NEXT:    addi a1, a1, -1756
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a1
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a4, a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v16, v8, a2
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v24, v8, a0
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 6
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v0, v24, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a4, a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v16, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v16
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a4, a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v0, v24, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 6
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v8, v0
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v8, v0, a2
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 5
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a0
+; RV32ZVBC64-NEXT:    vor.vv v0, v0, v8
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, a0, a2
 ; RV32ZVBC64-NEXT:    add a0, sp, a0
 ; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 6
+; RV32ZVBC64-NEXT:    add a0, sp, a0
+; RV32ZVBC64-NEXT:    addi a0, a0, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v16, v0
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    add a2, a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    add a0, a0, a2
+; RV32ZVBC64-NEXT:    add a0, sp, a0
+; RV32ZVBC64-NEXT:    addi a0, a0, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v24, v0
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 4
+; RV32ZVBC64-NEXT:    mv a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    add a0, a0, a2
 ; RV32ZVBC64-NEXT:    add a0, sp, a0
 ; RV32ZVBC64-NEXT:    addi a0, a0, 16
 ; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 4
 ; RV32ZVBC64-NEXT:    add a0, sp, a0
 ; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 128
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 256
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 512
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 1024
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 1
-; RV32ZVBC64-NEXT:    slli a0, a0, 11
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    lui a0, 1
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    lui a0, 2
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    lui a0, 4
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    lui a0, 8
-; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v16, v24, v0
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    vxor.vv v16, v24, v16
 ; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    mv a1, a0
-; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, a0, a1
+; RV32ZVBC64-NEXT:    add a0, sp, a0
+; RV32ZVBC64-NEXT:    addi a0, a0, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a1, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    add sp, sp, a0
 ; RV32ZVBC64-NEXT:    addi sp, sp, 16
@@ -4906,218 +4332,264 @@ define <vscale x 32 x i16> @clmul_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale x
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    mv a1, a0
-; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    sub sp, sp, a0
-; RV64ZVBC64-NEXT:    li a0, 16
+; RV64ZVBC64-NEXT:    lui a0, 9
+; RV64ZVBC64-NEXT:    addi a0, a0, 585
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
+; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
 ; RV64ZVBC64-NEXT:    csrr a1, vlenb
 ; RV64ZVBC64-NEXT:    slli a1, a1, 4
+; RV64ZVBC64-NEXT:    mv a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 1
+; RV64ZVBC64-NEXT:    add a1, a1, a2
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a1) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    lui a1, 2
+; RV64ZVBC64-NEXT:    addi a2, a1, 1170
+; RV64ZVBC64-NEXT:    vand.vx v24, v16, a2
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 6
 ; RV64ZVBC64-NEXT:    add a1, sp, a1
 ; RV64ZVBC64-NEXT:    addi a1, a1, 16
 ; RV64ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 3
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a1, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 4
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 3
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a1, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a1) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 4
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
+; RV64ZVBC64-NEXT:    lui a1, 5
+; RV64ZVBC64-NEXT:    addi a1, a1, -1756
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a1
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a4, a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v16, v8, a2
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v24, v8, a0
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 6
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v0, v24, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a4, a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v16, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v16
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a4, a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v0, v24, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 6
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v8, v0
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v8, v0, a2
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 5
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a0
+; RV64ZVBC64-NEXT:    vor.vv v0, v0, v8
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, a0, a2
 ; RV64ZVBC64-NEXT:    add a0, sp, a0
 ; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 6
+; RV64ZVBC64-NEXT:    add a0, sp, a0
+; RV64ZVBC64-NEXT:    addi a0, a0, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v16, v0
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    add a2, a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    add a0, a0, a2
+; RV64ZVBC64-NEXT:    add a0, sp, a0
+; RV64ZVBC64-NEXT:    addi a0, a0, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v24, v0
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 4
+; RV64ZVBC64-NEXT:    mv a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    add a0, a0, a2
 ; RV64ZVBC64-NEXT:    add a0, sp, a0
 ; RV64ZVBC64-NEXT:    addi a0, a0, 16
 ; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 4
 ; RV64ZVBC64-NEXT:    add a0, sp, a0
 ; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 128
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 256
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 512
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 1024
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 1
-; RV64ZVBC64-NEXT:    slli a0, a0, 11
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    lui a0, 1
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    lui a0, 2
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    lui a0, 4
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    lui a0, 8
-; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v16, v24, v0
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    vxor.vv v16, v24, v16
 ; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    mv a1, a0
-; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, a0, a1
+; RV64ZVBC64-NEXT:    add a0, sp, a0
+; RV64ZVBC64-NEXT:    addi a0, a0, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a1, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    add sp, sp, a0
 ; RV64ZVBC64-NEXT:    addi sp, sp, 16
@@ -5145,219 +4617,265 @@ define <vscale x 32 x i16> @clmul_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) n
 ; RV32V-NEXT:    csrr a1, vlenb
 ; RV32V-NEXT:    slli a1, a1, 3
 ; RV32V-NEXT:    mv a2, a1
-; RV32V-NEXT:    slli a1, a1, 1
+; RV32V-NEXT:    slli a1, a1, 3
 ; RV32V-NEXT:    add a1, a1, a2
 ; RV32V-NEXT:    sub sp, sp, a1
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
 ; RV32V-NEXT:    vmv.v.x v16, a0
-; RV32V-NEXT:    vand.vi v24, v16, 2
-; RV32V-NEXT:    vand.vi v0, v16, 1
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v0, v16, 4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    vand.vx v0, v16, a0
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 4
+; RV32V-NEXT:    mv a2, a1
+; RV32V-NEXT:    slli a1, a1, 1
+; RV32V-NEXT:    add a1, a1, a2
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vs8r.v v0, (a1) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a2, a1, 1170
+; RV32V-NEXT:    vand.vx v24, v16, a2
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 6
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    lui a1, 5
+; RV32V-NEXT:    addi a1, a1, -1756
+; RV32V-NEXT:    vand.vx v16, v16, a1
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a4, a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v16, v8, a2
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v24, v8, a0
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v0, v16, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 6
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v0, v24, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a4, a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v8, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v16, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v0, v16
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a4, a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v0, v16, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v0, v24, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 6
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v0
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v8, v0
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v8, v0, v8
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v8, v0, a2
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 5
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v0, v0, a0
+; RV32V-NEXT:    vor.vv v0, v0, v8
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a2, a0
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, a0, a2
 ; RV32V-NEXT:    add a0, sp, a0
 ; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v24, v16, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 6
+; RV32V-NEXT:    add a0, sp, a0
+; RV32V-NEXT:    addi a0, a0, 16
+; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v16, v0
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a2, a0
+; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    add a2, a2, a0
+; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    add a0, a0, a2
+; RV32V-NEXT:    add a0, sp, a0
+; RV32V-NEXT:    addi a0, a0, 16
+; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v24, v0
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 4
+; RV32V-NEXT:    mv a2, a0
+; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    add a0, a0, a2
 ; RV32V-NEXT:    add a0, sp, a0
 ; RV32V-NEXT:    addi a0, a0, 16
 ; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 4
 ; RV32V-NEXT:    add a0, sp, a0
 ; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 256
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 512
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 1024
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 1
-; RV32V-NEXT:    slli a0, a0, 11
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    lui a0, 1
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    lui a0, 2
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    lui a0, 4
-; RV32V-NEXT:    vand.vx v0, v16, a0
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    lui a0, 8
-; RV32V-NEXT:    vand.vx v16, v16, a0
-; RV32V-NEXT:    vmul.vv v8, v8, v16
-; RV32V-NEXT:    vxor.vv v16, v24, v0
+; RV32V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v0
+; RV32V-NEXT:    vxor.vv v16, v24, v16
 ; RV32V-NEXT:    vxor.vv v8, v16, v8
+; RV32V-NEXT:    vand.vx v8, v8, a1
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    mv a1, a0
-; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, a0, a1
+; RV32V-NEXT:    add a0, sp, a0
+; RV32V-NEXT:    addi a0, a0, 16
+; RV32V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vor.vv v8, v16, v8
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a1, a0
+; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    add sp, sp, a0
 ; RV32V-NEXT:    addi sp, sp, 16
@@ -5369,219 +4887,265 @@ define <vscale x 32 x i16> @clmul_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) n
 ; RV64V-NEXT:    csrr a1, vlenb
 ; RV64V-NEXT:    slli a1, a1, 3
 ; RV64V-NEXT:    mv a2, a1
-; RV64V-NEXT:    slli a1, a1, 1
+; RV64V-NEXT:    slli a1, a1, 3
 ; RV64V-NEXT:    add a1, a1, a2
 ; RV64V-NEXT:    sub sp, sp, a1
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
 ; RV64V-NEXT:    vmv.v.x v16, a0
-; RV64V-NEXT:    vand.vi v24, v16, 2
-; RV64V-NEXT:    vand.vi v0, v16, 1
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v0, v16, 4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    vand.vx v0, v16, a0
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 4
+; RV64V-NEXT:    mv a2, a1
+; RV64V-NEXT:    slli a1, a1, 1
+; RV64V-NEXT:    add a1, a1, a2
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vs8r.v v0, (a1) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a2, a1, 1170
+; RV64V-NEXT:    vand.vx v24, v16, a2
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 6
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    lui a1, 5
+; RV64V-NEXT:    addi a1, a1, -1756
+; RV64V-NEXT:    vand.vx v16, v16, a1
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a4, a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v16, v8, a2
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v24, v8, a0
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v0, v16, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 6
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v0, v24, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a4, a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v8, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v16, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v0, v16
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a4, a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v0, v16, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v0, v24, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 6
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v0
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v8, v0
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v8, v0, v8
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v8, v0, a2
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 5
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v0, v0, a0
+; RV64V-NEXT:    vor.vv v0, v0, v8
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a2, a0
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, a0, a2
 ; RV64V-NEXT:    add a0, sp, a0
 ; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v24, v16, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 6
+; RV64V-NEXT:    add a0, sp, a0
+; RV64V-NEXT:    addi a0, a0, 16
+; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v16, v0
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a2, a0
+; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    add a2, a2, a0
+; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    add a0, a0, a2
+; RV64V-NEXT:    add a0, sp, a0
+; RV64V-NEXT:    addi a0, a0, 16
+; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v24, v0
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 4
+; RV64V-NEXT:    mv a2, a0
+; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    add a0, a0, a2
 ; RV64V-NEXT:    add a0, sp, a0
 ; RV64V-NEXT:    addi a0, a0, 16
 ; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 4
 ; RV64V-NEXT:    add a0, sp, a0
 ; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 256
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 512
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 1024
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 1
-; RV64V-NEXT:    slli a0, a0, 11
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    lui a0, 1
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    lui a0, 2
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    lui a0, 4
-; RV64V-NEXT:    vand.vx v0, v16, a0
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    lui a0, 8
-; RV64V-NEXT:    vand.vx v16, v16, a0
-; RV64V-NEXT:    vmul.vv v8, v8, v16
-; RV64V-NEXT:    vxor.vv v16, v24, v0
+; RV64V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v0
+; RV64V-NEXT:    vxor.vv v16, v24, v16
 ; RV64V-NEXT:    vxor.vv v8, v16, v8
+; RV64V-NEXT:    vand.vx v8, v8, a1
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    mv a1, a0
-; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, a0, a1
+; RV64V-NEXT:    add a0, sp, a0
+; RV64V-NEXT:    addi a0, a0, 16
+; RV64V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vor.vv v8, v16, v8
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a1, a0
+; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    add sp, sp, a0
 ; RV64V-NEXT:    addi sp, sp, 16
@@ -5593,219 +5157,265 @@ define <vscale x 32 x i16> @clmul_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) n
 ; RV32ZVBC64-NEXT:    csrr a1, vlenb
 ; RV32ZVBC64-NEXT:    slli a1, a1, 3
 ; RV32ZVBC64-NEXT:    mv a2, a1
-; RV32ZVBC64-NEXT:    slli a1, a1, 1
+; RV32ZVBC64-NEXT:    slli a1, a1, 3
 ; RV32ZVBC64-NEXT:    add a1, a1, a2
 ; RV32ZVBC64-NEXT:    sub sp, sp, a1
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
 ; RV32ZVBC64-NEXT:    vmv.v.x v16, a0
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
+; RV32ZVBC64-NEXT:    lui a0, 9
+; RV32ZVBC64-NEXT:    addi a0, a0, 585
+; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 4
+; RV32ZVBC64-NEXT:    mv a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 1
+; RV32ZVBC64-NEXT:    add a1, a1, a2
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a1) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    lui a1, 2
+; RV32ZVBC64-NEXT:    addi a2, a1, 1170
+; RV32ZVBC64-NEXT:    vand.vx v24, v16, a2
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 6
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    lui a1, 5
+; RV32ZVBC64-NEXT:    addi a1, a1, -1756
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a1
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a4, a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v16, v8, a2
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v24, v8, a0
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 6
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v0, v24, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a4, a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v16, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v16
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a4, a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v0, v24, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 6
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v8, v0
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v8, v0, a2
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 5
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a0
+; RV32ZVBC64-NEXT:    vor.vv v0, v0, v8
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, a0, a2
 ; RV32ZVBC64-NEXT:    add a0, sp, a0
 ; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 6
+; RV32ZVBC64-NEXT:    add a0, sp, a0
+; RV32ZVBC64-NEXT:    addi a0, a0, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v16, v0
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    add a2, a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    add a0, a0, a2
+; RV32ZVBC64-NEXT:    add a0, sp, a0
+; RV32ZVBC64-NEXT:    addi a0, a0, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v24, v0
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 4
+; RV32ZVBC64-NEXT:    mv a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    add a0, a0, a2
 ; RV32ZVBC64-NEXT:    add a0, sp, a0
 ; RV32ZVBC64-NEXT:    addi a0, a0, 16
 ; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 4
 ; RV32ZVBC64-NEXT:    add a0, sp, a0
 ; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 16
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 128
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 256
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 512
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 1024
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 1
-; RV32ZVBC64-NEXT:    slli a0, a0, 11
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    lui a0, 1
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    lui a0, 2
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    lui a0, 4
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    lui a0, 8
-; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v16, v24, v0
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    vxor.vv v16, v24, v16
 ; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    mv a1, a0
-; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, a0, a1
+; RV32ZVBC64-NEXT:    add a0, sp, a0
+; RV32ZVBC64-NEXT:    addi a0, a0, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a1, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    add sp, sp, a0
 ; RV32ZVBC64-NEXT:    addi sp, sp, 16
@@ -5817,219 +5427,265 @@ define <vscale x 32 x i16> @clmul_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) n
 ; RV64ZVBC64-NEXT:    csrr a1, vlenb
 ; RV64ZVBC64-NEXT:    slli a1, a1, 3
 ; RV64ZVBC64-NEXT:    mv a2, a1
-; RV64ZVBC64-NEXT:    slli a1, a1, 1
+; RV64ZVBC64-NEXT:    slli a1, a1, 3
 ; RV64ZVBC64-NEXT:    add a1, a1, a2
 ; RV64ZVBC64-NEXT:    sub sp, sp, a1
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
 ; RV64ZVBC64-NEXT:    vmv.v.x v16, a0
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
+; RV64ZVBC64-NEXT:    lui a0, 9
+; RV64ZVBC64-NEXT:    addi a0, a0, 585
+; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 4
+; RV64ZVBC64-NEXT:    mv a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 1
+; RV64ZVBC64-NEXT:    add a1, a1, a2
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a1) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    lui a1, 2
+; RV64ZVBC64-NEXT:    addi a2, a1, 1170
+; RV64ZVBC64-NEXT:    vand.vx v24, v16, a2
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 6
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    lui a1, 5
+; RV64ZVBC64-NEXT:    addi a1, a1, -1756
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a1
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a4, a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v16, v8, a2
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v24, v8, a0
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 6
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v0, v24, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a4, a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v16, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v16
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a4, a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v0, v24, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 6
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v8, v0
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v8, v0, a2
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 5
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a0
+; RV64ZVBC64-NEXT:    vor.vv v0, v0, v8
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, a0, a2
 ; RV64ZVBC64-NEXT:    add a0, sp, a0
 ; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a0) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 6
+; RV64ZVBC64-NEXT:    add a0, sp, a0
+; RV64ZVBC64-NEXT:    addi a0, a0, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v16, v0
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    add a2, a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    add a0, a0, a2
+; RV64ZVBC64-NEXT:    add a0, sp, a0
+; RV64ZVBC64-NEXT:    addi a0, a0, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v24, v0
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 4
+; RV64ZVBC64-NEXT:    mv a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    add a0, a0, a2
 ; RV64ZVBC64-NEXT:    add a0, sp, a0
 ; RV64ZVBC64-NEXT:    addi a0, a0, 16
 ; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 4
 ; RV64ZVBC64-NEXT:    add a0, sp, a0
 ; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 16
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 128
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 256
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 512
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 1024
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 1
-; RV64ZVBC64-NEXT:    slli a0, a0, 11
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    lui a0, 1
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    lui a0, 2
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    lui a0, 4
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    lui a0, 8
-; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v16, v24, v0
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    vxor.vv v16, v24, v16
 ; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    mv a1, a0
-; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, a0, a1
+; RV64ZVBC64-NEXT:    add a0, sp, a0
+; RV64ZVBC64-NEXT:    addi a0, a0, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a1, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    add sp, sp, a0
 ; RV64ZVBC64-NEXT:    addi sp, sp, 16

--- a/llvm/test/CodeGen/RISCV/rvv/clmulh-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/clmulh-sdnode.ll
@@ -9,72 +9,82 @@
 define <vscale x 1 x i8> @clmulh_nxv1i8_vv(<vscale x 1 x i8> %va, <vscale x 1 x i8> %vb) nounwind {
 ; RV32V-LABEL: clmulh_nxv1i8_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; RV32V-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
 ; RV32V-NEXT:    vzext.vf2 v10, v9
 ; RV32V-NEXT:    vzext.vf2 v9, v8
-; RV32V-NEXT:    vand.vi v8, v10, 2
-; RV32V-NEXT:    vand.vi v11, v10, 1
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v8, v10, a0
+; RV32V-NEXT:    vand.vx v11, v9, a1
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    vand.vx v12, v10, a1
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v13, v9, a0
+; RV32V-NEXT:    vand.vx v10, v10, a2
+; RV32V-NEXT:    vand.vx v9, v9, a2
+; RV32V-NEXT:    vmul.vv v14, v11, v8
+; RV32V-NEXT:    vmul.vv v15, v13, v12
+; RV32V-NEXT:    vmul.vv v16, v11, v10
+; RV32V-NEXT:    vmul.vv v17, v13, v8
+; RV32V-NEXT:    vmul.vv v18, v9, v10
+; RV32V-NEXT:    vmul.vv v11, v11, v12
+; RV32V-NEXT:    vmul.vv v12, v9, v12
+; RV32V-NEXT:    vmul.vv v10, v13, v10
+; RV32V-NEXT:    vxor.vv v13, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v17, v16
 ; RV32V-NEXT:    vmul.vv v8, v9, v8
-; RV32V-NEXT:    vmul.vv v11, v9, v11
-; RV32V-NEXT:    vand.vi v12, v10, 4
-; RV32V-NEXT:    vand.vi v13, v10, 8
-; RV32V-NEXT:    vmul.vv v12, v9, v12
-; RV32V-NEXT:    vxor.vv v8, v11, v8
-; RV32V-NEXT:    vand.vx v11, v10, a0
-; RV32V-NEXT:    vmul.vv v13, v9, v13
-; RV32V-NEXT:    vxor.vv v8, v8, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vmul.vv v11, v9, v11
-; RV32V-NEXT:    vand.vx v12, v10, a0
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v8, v8, v13
-; RV32V-NEXT:    vand.vx v13, v10, a0
-; RV32V-NEXT:    vmul.vv v12, v9, v12
-; RV32V-NEXT:    vxor.vv v8, v8, v11
-; RV32V-NEXT:    vmul.vv v11, v9, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v10, v10, a0
-; RV32V-NEXT:    vxor.vv v8, v8, v12
-; RV32V-NEXT:    vmul.vv v9, v9, v10
-; RV32V-NEXT:    vxor.vv v8, v8, v11
-; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vxor.vv v9, v13, v18
+; RV32V-NEXT:    vxor.vv v12, v14, v12
+; RV32V-NEXT:    vxor.vv v10, v10, v11
+; RV32V-NEXT:    vand.vx v9, v9, a1
+; RV32V-NEXT:    vand.vx v11, v12, a0
+; RV32V-NEXT:    vxor.vv v8, v10, v8
+; RV32V-NEXT:    vor.vv v9, v11, v9
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmulh_nxv1i8_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; RV64V-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
 ; RV64V-NEXT:    vzext.vf2 v10, v9
 ; RV64V-NEXT:    vzext.vf2 v9, v8
-; RV64V-NEXT:    vand.vi v8, v10, 2
-; RV64V-NEXT:    vand.vi v11, v10, 1
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v8, v10, a0
+; RV64V-NEXT:    vand.vx v11, v9, a1
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    vand.vx v12, v10, a1
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v13, v9, a0
+; RV64V-NEXT:    vand.vx v10, v10, a2
+; RV64V-NEXT:    vand.vx v9, v9, a2
+; RV64V-NEXT:    vmul.vv v14, v11, v8
+; RV64V-NEXT:    vmul.vv v15, v13, v12
+; RV64V-NEXT:    vmul.vv v16, v11, v10
+; RV64V-NEXT:    vmul.vv v17, v13, v8
+; RV64V-NEXT:    vmul.vv v18, v9, v10
+; RV64V-NEXT:    vmul.vv v11, v11, v12
+; RV64V-NEXT:    vmul.vv v12, v9, v12
+; RV64V-NEXT:    vmul.vv v10, v13, v10
+; RV64V-NEXT:    vxor.vv v13, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v17, v16
 ; RV64V-NEXT:    vmul.vv v8, v9, v8
-; RV64V-NEXT:    vmul.vv v11, v9, v11
-; RV64V-NEXT:    vand.vi v12, v10, 4
-; RV64V-NEXT:    vand.vi v13, v10, 8
-; RV64V-NEXT:    vmul.vv v12, v9, v12
-; RV64V-NEXT:    vxor.vv v8, v11, v8
-; RV64V-NEXT:    vand.vx v11, v10, a0
-; RV64V-NEXT:    vmul.vv v13, v9, v13
-; RV64V-NEXT:    vxor.vv v8, v8, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vmul.vv v11, v9, v11
-; RV64V-NEXT:    vand.vx v12, v10, a0
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v8, v8, v13
-; RV64V-NEXT:    vand.vx v13, v10, a0
-; RV64V-NEXT:    vmul.vv v12, v9, v12
-; RV64V-NEXT:    vxor.vv v8, v8, v11
-; RV64V-NEXT:    vmul.vv v11, v9, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v10, v10, a0
-; RV64V-NEXT:    vxor.vv v8, v8, v12
-; RV64V-NEXT:    vmul.vv v9, v9, v10
-; RV64V-NEXT:    vxor.vv v8, v8, v11
-; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vxor.vv v9, v13, v18
+; RV64V-NEXT:    vxor.vv v12, v14, v12
+; RV64V-NEXT:    vxor.vv v10, v10, v11
+; RV64V-NEXT:    vand.vx v9, v9, a1
+; RV64V-NEXT:    vand.vx v11, v12, a0
+; RV64V-NEXT:    vxor.vv v8, v10, v8
+; RV64V-NEXT:    vor.vv v9, v11, v9
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV64V-NEXT:    ret
@@ -133,34 +143,39 @@ define <vscale x 1 x i8> @clmulh_nxv1i8_vx(<vscale x 1 x i8> %va, i8 %b) nounwin
 ; RV32V-NEXT:    vmv.v.x v9, a0
 ; RV32V-NEXT:    vsetvli zero, zero, e16, mf4, ta, ma
 ; RV32V-NEXT:    vzext.vf2 v10, v8
+; RV32V-NEXT:    lui a0, 2
 ; RV32V-NEXT:    vzext.vf2 v8, v9
-; RV32V-NEXT:    vand.vi v9, v8, 2
-; RV32V-NEXT:    vand.vi v11, v8, 1
-; RV32V-NEXT:    vmul.vv v9, v10, v9
-; RV32V-NEXT:    vmul.vv v11, v10, v11
-; RV32V-NEXT:    vand.vi v12, v8, 4
-; RV32V-NEXT:    vand.vi v13, v8, 8
-; RV32V-NEXT:    vmul.vv v12, v10, v12
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vxor.vv v9, v11, v9
-; RV32V-NEXT:    vand.vx v11, v8, a0
-; RV32V-NEXT:    vmul.vv v13, v10, v13
-; RV32V-NEXT:    vxor.vv v9, v9, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vmul.vv v11, v10, v11
-; RV32V-NEXT:    vand.vx v12, v8, a0
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v9, v9, v13
+; RV32V-NEXT:    lui a1, 9
+; RV32V-NEXT:    addi a0, a0, 1170
+; RV32V-NEXT:    addi a1, a1, 585
+; RV32V-NEXT:    vand.vx v9, v10, a0
+; RV32V-NEXT:    vand.vx v11, v10, a1
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    vand.vx v12, v8, a1
+; RV32V-NEXT:    addi a2, a2, -1756
 ; RV32V-NEXT:    vand.vx v13, v8, a0
-; RV32V-NEXT:    vmul.vv v12, v10, v12
-; RV32V-NEXT:    vxor.vv v9, v9, v11
-; RV32V-NEXT:    vmul.vv v11, v10, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v8, v8, a0
-; RV32V-NEXT:    vxor.vv v9, v9, v12
-; RV32V-NEXT:    vmul.vv v8, v10, v8
-; RV32V-NEXT:    vxor.vv v9, v9, v11
-; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vand.vx v10, v10, a2
+; RV32V-NEXT:    vmul.vv v14, v9, v12
+; RV32V-NEXT:    vmul.vv v15, v11, v13
+; RV32V-NEXT:    vmul.vv v16, v9, v8
+; RV32V-NEXT:    vmul.vv v17, v11, v12
+; RV32V-NEXT:    vmul.vv v18, v10, v8
+; RV32V-NEXT:    vmul.vv v9, v9, v13
+; RV32V-NEXT:    vmul.vv v13, v10, v13
+; RV32V-NEXT:    vmul.vv v8, v11, v8
+; RV32V-NEXT:    vxor.vv v11, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v17, v16
+; RV32V-NEXT:    vmul.vv v10, v10, v12
+; RV32V-NEXT:    vxor.vv v11, v11, v18
+; RV32V-NEXT:    vxor.vv v12, v14, v13
+; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vand.vx v9, v11, a0
+; RV32V-NEXT:    vand.vx v11, v12, a1
+; RV32V-NEXT:    vxor.vv v8, v8, v10
+; RV32V-NEXT:    vor.vv v9, v11, v9
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV32V-NEXT:    ret
@@ -171,34 +186,39 @@ define <vscale x 1 x i8> @clmulh_nxv1i8_vx(<vscale x 1 x i8> %va, i8 %b) nounwin
 ; RV64V-NEXT:    vmv.v.x v9, a0
 ; RV64V-NEXT:    vsetvli zero, zero, e16, mf4, ta, ma
 ; RV64V-NEXT:    vzext.vf2 v10, v8
+; RV64V-NEXT:    lui a0, 2
 ; RV64V-NEXT:    vzext.vf2 v8, v9
-; RV64V-NEXT:    vand.vi v9, v8, 2
-; RV64V-NEXT:    vand.vi v11, v8, 1
-; RV64V-NEXT:    vmul.vv v9, v10, v9
-; RV64V-NEXT:    vmul.vv v11, v10, v11
-; RV64V-NEXT:    vand.vi v12, v8, 4
-; RV64V-NEXT:    vand.vi v13, v8, 8
-; RV64V-NEXT:    vmul.vv v12, v10, v12
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vxor.vv v9, v11, v9
-; RV64V-NEXT:    vand.vx v11, v8, a0
-; RV64V-NEXT:    vmul.vv v13, v10, v13
-; RV64V-NEXT:    vxor.vv v9, v9, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vmul.vv v11, v10, v11
-; RV64V-NEXT:    vand.vx v12, v8, a0
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v9, v9, v13
+; RV64V-NEXT:    lui a1, 9
+; RV64V-NEXT:    addi a0, a0, 1170
+; RV64V-NEXT:    addi a1, a1, 585
+; RV64V-NEXT:    vand.vx v9, v10, a0
+; RV64V-NEXT:    vand.vx v11, v10, a1
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    vand.vx v12, v8, a1
+; RV64V-NEXT:    addi a2, a2, -1756
 ; RV64V-NEXT:    vand.vx v13, v8, a0
-; RV64V-NEXT:    vmul.vv v12, v10, v12
-; RV64V-NEXT:    vxor.vv v9, v9, v11
-; RV64V-NEXT:    vmul.vv v11, v10, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v8, v8, a0
-; RV64V-NEXT:    vxor.vv v9, v9, v12
-; RV64V-NEXT:    vmul.vv v8, v10, v8
-; RV64V-NEXT:    vxor.vv v9, v9, v11
-; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vand.vx v10, v10, a2
+; RV64V-NEXT:    vmul.vv v14, v9, v12
+; RV64V-NEXT:    vmul.vv v15, v11, v13
+; RV64V-NEXT:    vmul.vv v16, v9, v8
+; RV64V-NEXT:    vmul.vv v17, v11, v12
+; RV64V-NEXT:    vmul.vv v18, v10, v8
+; RV64V-NEXT:    vmul.vv v9, v9, v13
+; RV64V-NEXT:    vmul.vv v13, v10, v13
+; RV64V-NEXT:    vmul.vv v8, v11, v8
+; RV64V-NEXT:    vxor.vv v11, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v17, v16
+; RV64V-NEXT:    vmul.vv v10, v10, v12
+; RV64V-NEXT:    vxor.vv v11, v11, v18
+; RV64V-NEXT:    vxor.vv v12, v14, v13
+; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vand.vx v9, v11, a0
+; RV64V-NEXT:    vand.vx v11, v12, a1
+; RV64V-NEXT:    vxor.vv v8, v8, v10
+; RV64V-NEXT:    vor.vv v9, v11, v9
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    vsetvli zero, zero, e8, mf8, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV64V-NEXT:    ret
@@ -259,72 +279,82 @@ define <vscale x 1 x i8> @clmulh_nxv1i8_vx(<vscale x 1 x i8> %va, i8 %b) nounwin
 define <vscale x 2 x i8> @clmulh_nxv2i8_vv(<vscale x 2 x i8> %va, <vscale x 2 x i8> %vb) nounwind {
 ; RV32V-LABEL: clmulh_nxv2i8_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vsetvli a1, zero, e16, mf2, ta, ma
+; RV32V-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
 ; RV32V-NEXT:    vzext.vf2 v10, v9
 ; RV32V-NEXT:    vzext.vf2 v9, v8
-; RV32V-NEXT:    vand.vi v8, v10, 2
-; RV32V-NEXT:    vand.vi v11, v10, 1
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v8, v10, a0
+; RV32V-NEXT:    vand.vx v11, v9, a1
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    vand.vx v12, v10, a1
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v13, v9, a0
+; RV32V-NEXT:    vand.vx v10, v10, a2
+; RV32V-NEXT:    vand.vx v9, v9, a2
+; RV32V-NEXT:    vmul.vv v14, v11, v8
+; RV32V-NEXT:    vmul.vv v15, v13, v12
+; RV32V-NEXT:    vmul.vv v16, v11, v10
+; RV32V-NEXT:    vmul.vv v17, v13, v8
+; RV32V-NEXT:    vmul.vv v18, v9, v10
+; RV32V-NEXT:    vmul.vv v11, v11, v12
+; RV32V-NEXT:    vmul.vv v12, v9, v12
+; RV32V-NEXT:    vmul.vv v10, v13, v10
+; RV32V-NEXT:    vxor.vv v13, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v17, v16
 ; RV32V-NEXT:    vmul.vv v8, v9, v8
-; RV32V-NEXT:    vmul.vv v11, v9, v11
-; RV32V-NEXT:    vand.vi v12, v10, 4
-; RV32V-NEXT:    vand.vi v13, v10, 8
-; RV32V-NEXT:    vmul.vv v12, v9, v12
-; RV32V-NEXT:    vxor.vv v8, v11, v8
-; RV32V-NEXT:    vand.vx v11, v10, a0
-; RV32V-NEXT:    vmul.vv v13, v9, v13
-; RV32V-NEXT:    vxor.vv v8, v8, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vmul.vv v11, v9, v11
-; RV32V-NEXT:    vand.vx v12, v10, a0
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v8, v8, v13
-; RV32V-NEXT:    vand.vx v13, v10, a0
-; RV32V-NEXT:    vmul.vv v12, v9, v12
-; RV32V-NEXT:    vxor.vv v8, v8, v11
-; RV32V-NEXT:    vmul.vv v11, v9, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v10, v10, a0
-; RV32V-NEXT:    vxor.vv v8, v8, v12
-; RV32V-NEXT:    vmul.vv v9, v9, v10
-; RV32V-NEXT:    vxor.vv v8, v8, v11
-; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vxor.vv v9, v13, v18
+; RV32V-NEXT:    vxor.vv v12, v14, v12
+; RV32V-NEXT:    vxor.vv v10, v10, v11
+; RV32V-NEXT:    vand.vx v9, v9, a1
+; RV32V-NEXT:    vand.vx v11, v12, a0
+; RV32V-NEXT:    vxor.vv v8, v10, v8
+; RV32V-NEXT:    vor.vv v9, v11, v9
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmulh_nxv2i8_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vsetvli a1, zero, e16, mf2, ta, ma
+; RV64V-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
 ; RV64V-NEXT:    vzext.vf2 v10, v9
 ; RV64V-NEXT:    vzext.vf2 v9, v8
-; RV64V-NEXT:    vand.vi v8, v10, 2
-; RV64V-NEXT:    vand.vi v11, v10, 1
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v8, v10, a0
+; RV64V-NEXT:    vand.vx v11, v9, a1
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    vand.vx v12, v10, a1
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v13, v9, a0
+; RV64V-NEXT:    vand.vx v10, v10, a2
+; RV64V-NEXT:    vand.vx v9, v9, a2
+; RV64V-NEXT:    vmul.vv v14, v11, v8
+; RV64V-NEXT:    vmul.vv v15, v13, v12
+; RV64V-NEXT:    vmul.vv v16, v11, v10
+; RV64V-NEXT:    vmul.vv v17, v13, v8
+; RV64V-NEXT:    vmul.vv v18, v9, v10
+; RV64V-NEXT:    vmul.vv v11, v11, v12
+; RV64V-NEXT:    vmul.vv v12, v9, v12
+; RV64V-NEXT:    vmul.vv v10, v13, v10
+; RV64V-NEXT:    vxor.vv v13, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v17, v16
 ; RV64V-NEXT:    vmul.vv v8, v9, v8
-; RV64V-NEXT:    vmul.vv v11, v9, v11
-; RV64V-NEXT:    vand.vi v12, v10, 4
-; RV64V-NEXT:    vand.vi v13, v10, 8
-; RV64V-NEXT:    vmul.vv v12, v9, v12
-; RV64V-NEXT:    vxor.vv v8, v11, v8
-; RV64V-NEXT:    vand.vx v11, v10, a0
-; RV64V-NEXT:    vmul.vv v13, v9, v13
-; RV64V-NEXT:    vxor.vv v8, v8, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vmul.vv v11, v9, v11
-; RV64V-NEXT:    vand.vx v12, v10, a0
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v8, v8, v13
-; RV64V-NEXT:    vand.vx v13, v10, a0
-; RV64V-NEXT:    vmul.vv v12, v9, v12
-; RV64V-NEXT:    vxor.vv v8, v8, v11
-; RV64V-NEXT:    vmul.vv v11, v9, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v10, v10, a0
-; RV64V-NEXT:    vxor.vv v8, v8, v12
-; RV64V-NEXT:    vmul.vv v9, v9, v10
-; RV64V-NEXT:    vxor.vv v8, v8, v11
-; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vxor.vv v9, v13, v18
+; RV64V-NEXT:    vxor.vv v12, v14, v12
+; RV64V-NEXT:    vxor.vv v10, v10, v11
+; RV64V-NEXT:    vand.vx v9, v9, a1
+; RV64V-NEXT:    vand.vx v11, v12, a0
+; RV64V-NEXT:    vxor.vv v8, v10, v8
+; RV64V-NEXT:    vor.vv v9, v11, v9
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV64V-NEXT:    ret
@@ -383,34 +413,39 @@ define <vscale x 2 x i8> @clmulh_nxv2i8_vx(<vscale x 2 x i8> %va, i8 %b) nounwin
 ; RV32V-NEXT:    vmv.v.x v9, a0
 ; RV32V-NEXT:    vsetvli zero, zero, e16, mf2, ta, ma
 ; RV32V-NEXT:    vzext.vf2 v10, v8
+; RV32V-NEXT:    lui a0, 2
 ; RV32V-NEXT:    vzext.vf2 v8, v9
-; RV32V-NEXT:    vand.vi v9, v8, 2
-; RV32V-NEXT:    vand.vi v11, v8, 1
-; RV32V-NEXT:    vmul.vv v9, v10, v9
-; RV32V-NEXT:    vmul.vv v11, v10, v11
-; RV32V-NEXT:    vand.vi v12, v8, 4
-; RV32V-NEXT:    vand.vi v13, v8, 8
-; RV32V-NEXT:    vmul.vv v12, v10, v12
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vxor.vv v9, v11, v9
-; RV32V-NEXT:    vand.vx v11, v8, a0
-; RV32V-NEXT:    vmul.vv v13, v10, v13
-; RV32V-NEXT:    vxor.vv v9, v9, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vmul.vv v11, v10, v11
-; RV32V-NEXT:    vand.vx v12, v8, a0
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vxor.vv v9, v9, v13
+; RV32V-NEXT:    lui a1, 9
+; RV32V-NEXT:    addi a0, a0, 1170
+; RV32V-NEXT:    addi a1, a1, 585
+; RV32V-NEXT:    vand.vx v9, v10, a0
+; RV32V-NEXT:    vand.vx v11, v10, a1
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    vand.vx v12, v8, a1
+; RV32V-NEXT:    addi a2, a2, -1756
 ; RV32V-NEXT:    vand.vx v13, v8, a0
-; RV32V-NEXT:    vmul.vv v12, v10, v12
-; RV32V-NEXT:    vxor.vv v9, v9, v11
-; RV32V-NEXT:    vmul.vv v11, v10, v13
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v8, v8, a0
-; RV32V-NEXT:    vxor.vv v9, v9, v12
-; RV32V-NEXT:    vmul.vv v8, v10, v8
-; RV32V-NEXT:    vxor.vv v9, v9, v11
-; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vand.vx v10, v10, a2
+; RV32V-NEXT:    vmul.vv v14, v9, v12
+; RV32V-NEXT:    vmul.vv v15, v11, v13
+; RV32V-NEXT:    vmul.vv v16, v9, v8
+; RV32V-NEXT:    vmul.vv v17, v11, v12
+; RV32V-NEXT:    vmul.vv v18, v10, v8
+; RV32V-NEXT:    vmul.vv v9, v9, v13
+; RV32V-NEXT:    vmul.vv v13, v10, v13
+; RV32V-NEXT:    vmul.vv v8, v11, v8
+; RV32V-NEXT:    vxor.vv v11, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v17, v16
+; RV32V-NEXT:    vmul.vv v10, v10, v12
+; RV32V-NEXT:    vxor.vv v11, v11, v18
+; RV32V-NEXT:    vxor.vv v12, v14, v13
+; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vand.vx v9, v11, a0
+; RV32V-NEXT:    vand.vx v11, v12, a1
+; RV32V-NEXT:    vxor.vv v8, v8, v10
+; RV32V-NEXT:    vor.vv v9, v11, v9
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV32V-NEXT:    ret
@@ -421,34 +456,39 @@ define <vscale x 2 x i8> @clmulh_nxv2i8_vx(<vscale x 2 x i8> %va, i8 %b) nounwin
 ; RV64V-NEXT:    vmv.v.x v9, a0
 ; RV64V-NEXT:    vsetvli zero, zero, e16, mf2, ta, ma
 ; RV64V-NEXT:    vzext.vf2 v10, v8
+; RV64V-NEXT:    lui a0, 2
 ; RV64V-NEXT:    vzext.vf2 v8, v9
-; RV64V-NEXT:    vand.vi v9, v8, 2
-; RV64V-NEXT:    vand.vi v11, v8, 1
-; RV64V-NEXT:    vmul.vv v9, v10, v9
-; RV64V-NEXT:    vmul.vv v11, v10, v11
-; RV64V-NEXT:    vand.vi v12, v8, 4
-; RV64V-NEXT:    vand.vi v13, v8, 8
-; RV64V-NEXT:    vmul.vv v12, v10, v12
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vxor.vv v9, v11, v9
-; RV64V-NEXT:    vand.vx v11, v8, a0
-; RV64V-NEXT:    vmul.vv v13, v10, v13
-; RV64V-NEXT:    vxor.vv v9, v9, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vmul.vv v11, v10, v11
-; RV64V-NEXT:    vand.vx v12, v8, a0
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vxor.vv v9, v9, v13
+; RV64V-NEXT:    lui a1, 9
+; RV64V-NEXT:    addi a0, a0, 1170
+; RV64V-NEXT:    addi a1, a1, 585
+; RV64V-NEXT:    vand.vx v9, v10, a0
+; RV64V-NEXT:    vand.vx v11, v10, a1
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    vand.vx v12, v8, a1
+; RV64V-NEXT:    addi a2, a2, -1756
 ; RV64V-NEXT:    vand.vx v13, v8, a0
-; RV64V-NEXT:    vmul.vv v12, v10, v12
-; RV64V-NEXT:    vxor.vv v9, v9, v11
-; RV64V-NEXT:    vmul.vv v11, v10, v13
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v8, v8, a0
-; RV64V-NEXT:    vxor.vv v9, v9, v12
-; RV64V-NEXT:    vmul.vv v8, v10, v8
-; RV64V-NEXT:    vxor.vv v9, v9, v11
-; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vand.vx v10, v10, a2
+; RV64V-NEXT:    vmul.vv v14, v9, v12
+; RV64V-NEXT:    vmul.vv v15, v11, v13
+; RV64V-NEXT:    vmul.vv v16, v9, v8
+; RV64V-NEXT:    vmul.vv v17, v11, v12
+; RV64V-NEXT:    vmul.vv v18, v10, v8
+; RV64V-NEXT:    vmul.vv v9, v9, v13
+; RV64V-NEXT:    vmul.vv v13, v10, v13
+; RV64V-NEXT:    vmul.vv v8, v11, v8
+; RV64V-NEXT:    vxor.vv v11, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v17, v16
+; RV64V-NEXT:    vmul.vv v10, v10, v12
+; RV64V-NEXT:    vxor.vv v11, v11, v18
+; RV64V-NEXT:    vxor.vv v12, v14, v13
+; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vand.vx v9, v11, a0
+; RV64V-NEXT:    vand.vx v11, v12, a1
+; RV64V-NEXT:    vxor.vv v8, v8, v10
+; RV64V-NEXT:    vor.vv v9, v11, v9
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV64V-NEXT:    ret
@@ -509,72 +549,82 @@ define <vscale x 2 x i8> @clmulh_nxv2i8_vx(<vscale x 2 x i8> %va, i8 %b) nounwin
 define <vscale x 4 x i8> @clmulh_nxv4i8_vv(<vscale x 4 x i8> %va, <vscale x 4 x i8> %vb) nounwind {
 ; RV32V-LABEL: clmulh_nxv4i8_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
+; RV32V-NEXT:    lui a0, 9
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
 ; RV32V-NEXT:    vzext.vf2 v10, v9
 ; RV32V-NEXT:    vzext.vf2 v9, v8
-; RV32V-NEXT:    vand.vi v8, v10, 2
-; RV32V-NEXT:    vand.vi v11, v10, 1
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    vand.vx v8, v10, a0
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v11, v9, a1
+; RV32V-NEXT:    vand.vx v12, v10, a1
+; RV32V-NEXT:    vand.vx v13, v9, a0
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v10, v10, a2
+; RV32V-NEXT:    vmul.vv v14, v11, v8
+; RV32V-NEXT:    vmul.vv v15, v13, v12
+; RV32V-NEXT:    vand.vx v9, v9, a2
+; RV32V-NEXT:    vmul.vv v16, v9, v10
+; RV32V-NEXT:    vmul.vv v17, v11, v10
+; RV32V-NEXT:    vmul.vv v18, v13, v8
+; RV32V-NEXT:    vxor.vv v14, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v14, v16
+; RV32V-NEXT:    vxor.vv v15, v18, v17
+; RV32V-NEXT:    vmul.vv v16, v9, v12
+; RV32V-NEXT:    vmul.vv v11, v11, v12
+; RV32V-NEXT:    vmul.vv v10, v13, v10
+; RV32V-NEXT:    vand.vx v12, v14, a1
 ; RV32V-NEXT:    vmul.vv v8, v9, v8
-; RV32V-NEXT:    vmul.vv v11, v9, v11
-; RV32V-NEXT:    vand.vi v12, v10, 4
-; RV32V-NEXT:    vand.vi v13, v10, 8
-; RV32V-NEXT:    vmul.vv v12, v9, v12
-; RV32V-NEXT:    vxor.vv v8, v11, v8
-; RV32V-NEXT:    vand.vx v11, v10, a0
-; RV32V-NEXT:    vmul.vv v13, v9, v13
-; RV32V-NEXT:    vxor.vv v8, v8, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v12, v10, a0
-; RV32V-NEXT:    vmul.vv v11, v9, v11
-; RV32V-NEXT:    vxor.vv v8, v8, v13
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v13, v10, a0
-; RV32V-NEXT:    vmul.vv v12, v9, v12
-; RV32V-NEXT:    vxor.vv v8, v8, v11
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vmul.vv v11, v9, v13
-; RV32V-NEXT:    vand.vx v10, v10, a0
-; RV32V-NEXT:    vxor.vv v8, v8, v12
-; RV32V-NEXT:    vmul.vv v9, v9, v10
-; RV32V-NEXT:    vxor.vv v8, v8, v11
-; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vxor.vv v9, v15, v16
+; RV32V-NEXT:    vxor.vv v10, v10, v11
+; RV32V-NEXT:    vand.vx v9, v9, a0
+; RV32V-NEXT:    vxor.vv v8, v10, v8
+; RV32V-NEXT:    vor.vv v9, v9, v12
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    vsetvli zero, zero, e8, mf2, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmulh_nxv4i8_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
+; RV64V-NEXT:    lui a0, 9
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
 ; RV64V-NEXT:    vzext.vf2 v10, v9
 ; RV64V-NEXT:    vzext.vf2 v9, v8
-; RV64V-NEXT:    vand.vi v8, v10, 2
-; RV64V-NEXT:    vand.vi v11, v10, 1
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    vand.vx v8, v10, a0
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v11, v9, a1
+; RV64V-NEXT:    vand.vx v12, v10, a1
+; RV64V-NEXT:    vand.vx v13, v9, a0
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v10, v10, a2
+; RV64V-NEXT:    vmul.vv v14, v11, v8
+; RV64V-NEXT:    vmul.vv v15, v13, v12
+; RV64V-NEXT:    vand.vx v9, v9, a2
+; RV64V-NEXT:    vmul.vv v16, v9, v10
+; RV64V-NEXT:    vmul.vv v17, v11, v10
+; RV64V-NEXT:    vmul.vv v18, v13, v8
+; RV64V-NEXT:    vxor.vv v14, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v14, v16
+; RV64V-NEXT:    vxor.vv v15, v18, v17
+; RV64V-NEXT:    vmul.vv v16, v9, v12
+; RV64V-NEXT:    vmul.vv v11, v11, v12
+; RV64V-NEXT:    vmul.vv v10, v13, v10
+; RV64V-NEXT:    vand.vx v12, v14, a1
 ; RV64V-NEXT:    vmul.vv v8, v9, v8
-; RV64V-NEXT:    vmul.vv v11, v9, v11
-; RV64V-NEXT:    vand.vi v12, v10, 4
-; RV64V-NEXT:    vand.vi v13, v10, 8
-; RV64V-NEXT:    vmul.vv v12, v9, v12
-; RV64V-NEXT:    vxor.vv v8, v11, v8
-; RV64V-NEXT:    vand.vx v11, v10, a0
-; RV64V-NEXT:    vmul.vv v13, v9, v13
-; RV64V-NEXT:    vxor.vv v8, v8, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v12, v10, a0
-; RV64V-NEXT:    vmul.vv v11, v9, v11
-; RV64V-NEXT:    vxor.vv v8, v8, v13
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v13, v10, a0
-; RV64V-NEXT:    vmul.vv v12, v9, v12
-; RV64V-NEXT:    vxor.vv v8, v8, v11
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vmul.vv v11, v9, v13
-; RV64V-NEXT:    vand.vx v10, v10, a0
-; RV64V-NEXT:    vxor.vv v8, v8, v12
-; RV64V-NEXT:    vmul.vv v9, v9, v10
-; RV64V-NEXT:    vxor.vv v8, v8, v11
-; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vxor.vv v9, v15, v16
+; RV64V-NEXT:    vxor.vv v10, v10, v11
+; RV64V-NEXT:    vand.vx v9, v9, a0
+; RV64V-NEXT:    vxor.vv v8, v10, v8
+; RV64V-NEXT:    vor.vv v9, v9, v12
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    vsetvli zero, zero, e8, mf2, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV64V-NEXT:    ret
@@ -633,34 +683,39 @@ define <vscale x 4 x i8> @clmulh_nxv4i8_vx(<vscale x 4 x i8> %va, i8 %b) nounwin
 ; RV32V-NEXT:    vmv.v.x v9, a0
 ; RV32V-NEXT:    vsetvli zero, zero, e16, m1, ta, ma
 ; RV32V-NEXT:    vzext.vf2 v10, v8
+; RV32V-NEXT:    lui a0, 2
 ; RV32V-NEXT:    vzext.vf2 v8, v9
-; RV32V-NEXT:    vand.vi v9, v8, 2
-; RV32V-NEXT:    vand.vi v11, v8, 1
-; RV32V-NEXT:    vmul.vv v9, v10, v9
-; RV32V-NEXT:    vmul.vv v11, v10, v11
-; RV32V-NEXT:    vand.vi v12, v8, 4
-; RV32V-NEXT:    vand.vi v13, v8, 8
-; RV32V-NEXT:    vmul.vv v12, v10, v12
-; RV32V-NEXT:    vxor.vv v9, v11, v9
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v11, v8, a0
-; RV32V-NEXT:    vmul.vv v13, v10, v13
-; RV32V-NEXT:    vxor.vv v9, v9, v12
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v12, v8, a0
-; RV32V-NEXT:    vmul.vv v11, v10, v11
-; RV32V-NEXT:    vxor.vv v9, v9, v13
-; RV32V-NEXT:    li a0, 64
+; RV32V-NEXT:    addi a0, a0, 1170
+; RV32V-NEXT:    lui a1, 9
+; RV32V-NEXT:    vand.vx v9, v10, a0
+; RV32V-NEXT:    addi a1, a1, 585
+; RV32V-NEXT:    vand.vx v11, v8, a1
+; RV32V-NEXT:    vand.vx v12, v10, a1
 ; RV32V-NEXT:    vand.vx v13, v8, a0
-; RV32V-NEXT:    vmul.vv v12, v10, v12
-; RV32V-NEXT:    vxor.vv v9, v9, v11
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vmul.vv v11, v10, v13
-; RV32V-NEXT:    vand.vx v8, v8, a0
-; RV32V-NEXT:    vxor.vv v9, v9, v12
-; RV32V-NEXT:    vmul.vv v8, v10, v8
-; RV32V-NEXT:    vxor.vv v9, v9, v11
-; RV32V-NEXT:    vxor.vv v8, v9, v8
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v10, v10, a2
+; RV32V-NEXT:    vmul.vv v14, v9, v11
+; RV32V-NEXT:    vmul.vv v15, v12, v13
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vmul.vv v16, v10, v8
+; RV32V-NEXT:    vmul.vv v17, v9, v8
+; RV32V-NEXT:    vmul.vv v18, v12, v11
+; RV32V-NEXT:    vxor.vv v14, v15, v14
+; RV32V-NEXT:    vxor.vv v14, v14, v16
+; RV32V-NEXT:    vxor.vv v15, v18, v17
+; RV32V-NEXT:    vmul.vv v16, v10, v13
+; RV32V-NEXT:    vmul.vv v9, v9, v13
+; RV32V-NEXT:    vmul.vv v8, v12, v8
+; RV32V-NEXT:    vand.vx v12, v14, a0
+; RV32V-NEXT:    vmul.vv v10, v10, v11
+; RV32V-NEXT:    vxor.vv v11, v15, v16
+; RV32V-NEXT:    vxor.vv v8, v8, v9
+; RV32V-NEXT:    vand.vx v9, v11, a1
+; RV32V-NEXT:    vxor.vv v8, v8, v10
+; RV32V-NEXT:    vor.vv v9, v9, v12
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v9, v8
 ; RV32V-NEXT:    vsetvli zero, zero, e8, mf2, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV32V-NEXT:    ret
@@ -671,34 +726,39 @@ define <vscale x 4 x i8> @clmulh_nxv4i8_vx(<vscale x 4 x i8> %va, i8 %b) nounwin
 ; RV64V-NEXT:    vmv.v.x v9, a0
 ; RV64V-NEXT:    vsetvli zero, zero, e16, m1, ta, ma
 ; RV64V-NEXT:    vzext.vf2 v10, v8
+; RV64V-NEXT:    lui a0, 2
 ; RV64V-NEXT:    vzext.vf2 v8, v9
-; RV64V-NEXT:    vand.vi v9, v8, 2
-; RV64V-NEXT:    vand.vi v11, v8, 1
-; RV64V-NEXT:    vmul.vv v9, v10, v9
-; RV64V-NEXT:    vmul.vv v11, v10, v11
-; RV64V-NEXT:    vand.vi v12, v8, 4
-; RV64V-NEXT:    vand.vi v13, v8, 8
-; RV64V-NEXT:    vmul.vv v12, v10, v12
-; RV64V-NEXT:    vxor.vv v9, v11, v9
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v11, v8, a0
-; RV64V-NEXT:    vmul.vv v13, v10, v13
-; RV64V-NEXT:    vxor.vv v9, v9, v12
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v12, v8, a0
-; RV64V-NEXT:    vmul.vv v11, v10, v11
-; RV64V-NEXT:    vxor.vv v9, v9, v13
-; RV64V-NEXT:    li a0, 64
+; RV64V-NEXT:    addi a0, a0, 1170
+; RV64V-NEXT:    lui a1, 9
+; RV64V-NEXT:    vand.vx v9, v10, a0
+; RV64V-NEXT:    addi a1, a1, 585
+; RV64V-NEXT:    vand.vx v11, v8, a1
+; RV64V-NEXT:    vand.vx v12, v10, a1
 ; RV64V-NEXT:    vand.vx v13, v8, a0
-; RV64V-NEXT:    vmul.vv v12, v10, v12
-; RV64V-NEXT:    vxor.vv v9, v9, v11
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vmul.vv v11, v10, v13
-; RV64V-NEXT:    vand.vx v8, v8, a0
-; RV64V-NEXT:    vxor.vv v9, v9, v12
-; RV64V-NEXT:    vmul.vv v8, v10, v8
-; RV64V-NEXT:    vxor.vv v9, v9, v11
-; RV64V-NEXT:    vxor.vv v8, v9, v8
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v10, v10, a2
+; RV64V-NEXT:    vmul.vv v14, v9, v11
+; RV64V-NEXT:    vmul.vv v15, v12, v13
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vmul.vv v16, v10, v8
+; RV64V-NEXT:    vmul.vv v17, v9, v8
+; RV64V-NEXT:    vmul.vv v18, v12, v11
+; RV64V-NEXT:    vxor.vv v14, v15, v14
+; RV64V-NEXT:    vxor.vv v14, v14, v16
+; RV64V-NEXT:    vxor.vv v15, v18, v17
+; RV64V-NEXT:    vmul.vv v16, v10, v13
+; RV64V-NEXT:    vmul.vv v9, v9, v13
+; RV64V-NEXT:    vmul.vv v8, v12, v8
+; RV64V-NEXT:    vand.vx v12, v14, a0
+; RV64V-NEXT:    vmul.vv v10, v10, v11
+; RV64V-NEXT:    vxor.vv v11, v15, v16
+; RV64V-NEXT:    vxor.vv v8, v8, v9
+; RV64V-NEXT:    vand.vx v9, v11, a1
+; RV64V-NEXT:    vxor.vv v8, v8, v10
+; RV64V-NEXT:    vor.vv v9, v9, v12
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v9, v8
 ; RV64V-NEXT:    vsetvli zero, zero, e8, mf2, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v8, 8
 ; RV64V-NEXT:    ret
@@ -759,72 +819,82 @@ define <vscale x 4 x i8> @clmulh_nxv4i8_vx(<vscale x 4 x i8> %va, i8 %b) nounwin
 define <vscale x 8 x i8> @clmulh_nxv8i8_vv(<vscale x 8 x i8> %va, <vscale x 8 x i8> %vb) nounwind {
 ; RV32V-LABEL: clmulh_nxv8i8_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a0, a0, 585
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m2, ta, ma
-; RV32V-NEXT:    vzext.vf2 v10, v8
-; RV32V-NEXT:    vzext.vf2 v12, v9
-; RV32V-NEXT:    vand.vi v8, v12, 2
-; RV32V-NEXT:    vand.vi v14, v12, 1
-; RV32V-NEXT:    vmul.vv v8, v10, v8
-; RV32V-NEXT:    vmul.vv v14, v10, v14
-; RV32V-NEXT:    vxor.vv v8, v14, v8
-; RV32V-NEXT:    vand.vi v14, v12, 4
-; RV32V-NEXT:    vmul.vv v14, v10, v14
-; RV32V-NEXT:    vand.vi v16, v12, 8
-; RV32V-NEXT:    vmul.vv v16, v10, v16
-; RV32V-NEXT:    vxor.vv v8, v8, v14
-; RV32V-NEXT:    vxor.vv v8, v8, v16
-; RV32V-NEXT:    vand.vx v14, v12, a0
-; RV32V-NEXT:    vmul.vv v14, v10, v14
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v16, v12, a0
-; RV32V-NEXT:    vmul.vv v16, v10, v16
-; RV32V-NEXT:    vxor.vv v8, v8, v14
-; RV32V-NEXT:    vxor.vv v8, v8, v16
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v14, v12, a0
-; RV32V-NEXT:    vmul.vv v14, v10, v14
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v12, v12, a0
-; RV32V-NEXT:    vmul.vv v10, v10, v12
-; RV32V-NEXT:    vxor.vv v8, v8, v14
-; RV32V-NEXT:    vxor.vv v10, v8, v10
+; RV32V-NEXT:    vzext.vf2 v10, v9
+; RV32V-NEXT:    vand.vx v12, v10, a0
+; RV32V-NEXT:    vzext.vf2 v14, v8
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v8, v14, a1
+; RV32V-NEXT:    vand.vx v16, v10, a1
+; RV32V-NEXT:    vand.vx v18, v14, a0
+; RV32V-NEXT:    vmul.vv v20, v8, v12
+; RV32V-NEXT:    vmul.vv v22, v18, v16
+; RV32V-NEXT:    vxor.vv v20, v22, v20
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v10, v10, a2
+; RV32V-NEXT:    vand.vx v14, v14, a2
+; RV32V-NEXT:    vmul.vv v22, v14, v10
+; RV32V-NEXT:    vmul.vv v24, v8, v10
+; RV32V-NEXT:    vmul.vv v26, v18, v12
+; RV32V-NEXT:    vxor.vv v20, v20, v22
+; RV32V-NEXT:    vxor.vv v22, v26, v24
+; RV32V-NEXT:    vmul.vv v24, v14, v16
+; RV32V-NEXT:    vand.vx v20, v20, a1
+; RV32V-NEXT:    vxor.vv v22, v22, v24
+; RV32V-NEXT:    vand.vx v22, v22, a0
+; RV32V-NEXT:    vor.vv v20, v22, v20
+; RV32V-NEXT:    vmul.vv v8, v8, v16
+; RV32V-NEXT:    vmul.vv v10, v18, v10
+; RV32V-NEXT:    vmul.vv v12, v14, v12
+; RV32V-NEXT:    vxor.vv v8, v10, v8
+; RV32V-NEXT:    vxor.vv v8, v8, v12
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v10, v20, v8
 ; RV32V-NEXT:    vsetvli zero, zero, e8, m1, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v10, 8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmulh_nxv8i8_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a0, a0, 585
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m2, ta, ma
-; RV64V-NEXT:    vzext.vf2 v10, v8
-; RV64V-NEXT:    vzext.vf2 v12, v9
-; RV64V-NEXT:    vand.vi v8, v12, 2
-; RV64V-NEXT:    vand.vi v14, v12, 1
-; RV64V-NEXT:    vmul.vv v8, v10, v8
-; RV64V-NEXT:    vmul.vv v14, v10, v14
-; RV64V-NEXT:    vxor.vv v8, v14, v8
-; RV64V-NEXT:    vand.vi v14, v12, 4
-; RV64V-NEXT:    vmul.vv v14, v10, v14
-; RV64V-NEXT:    vand.vi v16, v12, 8
-; RV64V-NEXT:    vmul.vv v16, v10, v16
-; RV64V-NEXT:    vxor.vv v8, v8, v14
-; RV64V-NEXT:    vxor.vv v8, v8, v16
-; RV64V-NEXT:    vand.vx v14, v12, a0
-; RV64V-NEXT:    vmul.vv v14, v10, v14
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v16, v12, a0
-; RV64V-NEXT:    vmul.vv v16, v10, v16
-; RV64V-NEXT:    vxor.vv v8, v8, v14
-; RV64V-NEXT:    vxor.vv v8, v8, v16
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v14, v12, a0
-; RV64V-NEXT:    vmul.vv v14, v10, v14
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v12, v12, a0
-; RV64V-NEXT:    vmul.vv v10, v10, v12
-; RV64V-NEXT:    vxor.vv v8, v8, v14
-; RV64V-NEXT:    vxor.vv v10, v8, v10
+; RV64V-NEXT:    vzext.vf2 v10, v9
+; RV64V-NEXT:    vand.vx v12, v10, a0
+; RV64V-NEXT:    vzext.vf2 v14, v8
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v8, v14, a1
+; RV64V-NEXT:    vand.vx v16, v10, a1
+; RV64V-NEXT:    vand.vx v18, v14, a0
+; RV64V-NEXT:    vmul.vv v20, v8, v12
+; RV64V-NEXT:    vmul.vv v22, v18, v16
+; RV64V-NEXT:    vxor.vv v20, v22, v20
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v10, v10, a2
+; RV64V-NEXT:    vand.vx v14, v14, a2
+; RV64V-NEXT:    vmul.vv v22, v14, v10
+; RV64V-NEXT:    vmul.vv v24, v8, v10
+; RV64V-NEXT:    vmul.vv v26, v18, v12
+; RV64V-NEXT:    vxor.vv v20, v20, v22
+; RV64V-NEXT:    vxor.vv v22, v26, v24
+; RV64V-NEXT:    vmul.vv v24, v14, v16
+; RV64V-NEXT:    vand.vx v20, v20, a1
+; RV64V-NEXT:    vxor.vv v22, v22, v24
+; RV64V-NEXT:    vand.vx v22, v22, a0
+; RV64V-NEXT:    vor.vv v20, v22, v20
+; RV64V-NEXT:    vmul.vv v8, v8, v16
+; RV64V-NEXT:    vmul.vv v10, v18, v10
+; RV64V-NEXT:    vmul.vv v12, v14, v12
+; RV64V-NEXT:    vxor.vv v8, v10, v8
+; RV64V-NEXT:    vxor.vv v8, v8, v12
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v10, v20, v8
 ; RV64V-NEXT:    vsetvli zero, zero, e8, m1, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v10, 8
 ; RV64V-NEXT:    ret
@@ -879,76 +949,88 @@ define <vscale x 8 x i8> @clmulh_nxv8i8_vv(<vscale x 8 x i8> %va, <vscale x 8 x 
 define <vscale x 8 x i8> @clmulh_nxv8i8_vx(<vscale x 8 x i8> %va, i8 %b) nounwind {
 ; RV32V-LABEL: clmulh_nxv8i8_vx:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    vsetvli a1, zero, e8, m1, ta, ma
-; RV32V-NEXT:    vmv.v.x v12, a0
-; RV32V-NEXT:    vsetvli zero, zero, e16, m2, ta, ma
+; RV32V-NEXT:    vsetvli a1, zero, e16, m2, ta, ma
 ; RV32V-NEXT:    vzext.vf2 v10, v8
-; RV32V-NEXT:    vzext.vf2 v8, v12
-; RV32V-NEXT:    vand.vi v12, v8, 2
-; RV32V-NEXT:    vand.vi v14, v8, 1
-; RV32V-NEXT:    vmul.vv v12, v10, v12
-; RV32V-NEXT:    vmul.vv v14, v10, v14
-; RV32V-NEXT:    vxor.vv v12, v14, v12
-; RV32V-NEXT:    vand.vi v14, v8, 4
-; RV32V-NEXT:    vmul.vv v14, v10, v14
-; RV32V-NEXT:    vand.vi v16, v8, 8
-; RV32V-NEXT:    vmul.vv v16, v10, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v14, v8, a0
-; RV32V-NEXT:    vmul.vv v14, v10, v14
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v16, v8, a0
-; RV32V-NEXT:    vmul.vv v16, v10, v16
-; RV32V-NEXT:    vxor.vv v12, v12, v14
-; RV32V-NEXT:    vxor.vv v12, v12, v16
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v14, v8, a0
-; RV32V-NEXT:    vmul.vv v14, v10, v14
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v8, v8, a0
-; RV32V-NEXT:    vmul.vv v8, v10, v8
-; RV32V-NEXT:    vxor.vv v10, v12, v14
-; RV32V-NEXT:    vxor.vv v10, v10, v8
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    vsetvli zero, zero, e8, m1, ta, ma
+; RV32V-NEXT:    vmv.v.x v14, a0
+; RV32V-NEXT:    addi a0, a1, 1170
+; RV32V-NEXT:    vsetvli zero, zero, e16, m2, ta, ma
+; RV32V-NEXT:    vand.vx v8, v10, a0
+; RV32V-NEXT:    vzext.vf2 v12, v14
+; RV32V-NEXT:    lui a1, 9
+; RV32V-NEXT:    addi a1, a1, 585
+; RV32V-NEXT:    vand.vx v14, v12, a1
+; RV32V-NEXT:    vand.vx v16, v10, a1
+; RV32V-NEXT:    vand.vx v18, v12, a0
+; RV32V-NEXT:    vmul.vv v20, v8, v14
+; RV32V-NEXT:    vmul.vv v22, v16, v18
+; RV32V-NEXT:    vxor.vv v20, v22, v20
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v10, v10, a2
+; RV32V-NEXT:    vand.vx v12, v12, a2
+; RV32V-NEXT:    vmul.vv v22, v10, v12
+; RV32V-NEXT:    vmul.vv v24, v8, v12
+; RV32V-NEXT:    vmul.vv v26, v16, v14
+; RV32V-NEXT:    vxor.vv v20, v20, v22
+; RV32V-NEXT:    vxor.vv v22, v26, v24
+; RV32V-NEXT:    vmul.vv v24, v10, v18
+; RV32V-NEXT:    vand.vx v20, v20, a0
+; RV32V-NEXT:    vxor.vv v22, v22, v24
+; RV32V-NEXT:    vand.vx v22, v22, a1
+; RV32V-NEXT:    vor.vv v20, v22, v20
+; RV32V-NEXT:    vmul.vv v8, v8, v18
+; RV32V-NEXT:    vmul.vv v12, v16, v12
+; RV32V-NEXT:    vmul.vv v10, v10, v14
+; RV32V-NEXT:    vxor.vv v8, v12, v8
+; RV32V-NEXT:    vxor.vv v8, v8, v10
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v10, v20, v8
 ; RV32V-NEXT:    vsetvli zero, zero, e8, m1, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v10, 8
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmulh_nxv8i8_vx:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    vsetvli a1, zero, e8, m1, ta, ma
-; RV64V-NEXT:    vmv.v.x v12, a0
-; RV64V-NEXT:    vsetvli zero, zero, e16, m2, ta, ma
+; RV64V-NEXT:    vsetvli a1, zero, e16, m2, ta, ma
 ; RV64V-NEXT:    vzext.vf2 v10, v8
-; RV64V-NEXT:    vzext.vf2 v8, v12
-; RV64V-NEXT:    vand.vi v12, v8, 2
-; RV64V-NEXT:    vand.vi v14, v8, 1
-; RV64V-NEXT:    vmul.vv v12, v10, v12
-; RV64V-NEXT:    vmul.vv v14, v10, v14
-; RV64V-NEXT:    vxor.vv v12, v14, v12
-; RV64V-NEXT:    vand.vi v14, v8, 4
-; RV64V-NEXT:    vmul.vv v14, v10, v14
-; RV64V-NEXT:    vand.vi v16, v8, 8
-; RV64V-NEXT:    vmul.vv v16, v10, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v14, v8, a0
-; RV64V-NEXT:    vmul.vv v14, v10, v14
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v16, v8, a0
-; RV64V-NEXT:    vmul.vv v16, v10, v16
-; RV64V-NEXT:    vxor.vv v12, v12, v14
-; RV64V-NEXT:    vxor.vv v12, v12, v16
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v14, v8, a0
-; RV64V-NEXT:    vmul.vv v14, v10, v14
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v8, v8, a0
-; RV64V-NEXT:    vmul.vv v8, v10, v8
-; RV64V-NEXT:    vxor.vv v10, v12, v14
-; RV64V-NEXT:    vxor.vv v10, v10, v8
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    vsetvli zero, zero, e8, m1, ta, ma
+; RV64V-NEXT:    vmv.v.x v14, a0
+; RV64V-NEXT:    addi a0, a1, 1170
+; RV64V-NEXT:    vsetvli zero, zero, e16, m2, ta, ma
+; RV64V-NEXT:    vand.vx v8, v10, a0
+; RV64V-NEXT:    vzext.vf2 v12, v14
+; RV64V-NEXT:    lui a1, 9
+; RV64V-NEXT:    addi a1, a1, 585
+; RV64V-NEXT:    vand.vx v14, v12, a1
+; RV64V-NEXT:    vand.vx v16, v10, a1
+; RV64V-NEXT:    vand.vx v18, v12, a0
+; RV64V-NEXT:    vmul.vv v20, v8, v14
+; RV64V-NEXT:    vmul.vv v22, v16, v18
+; RV64V-NEXT:    vxor.vv v20, v22, v20
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v10, v10, a2
+; RV64V-NEXT:    vand.vx v12, v12, a2
+; RV64V-NEXT:    vmul.vv v22, v10, v12
+; RV64V-NEXT:    vmul.vv v24, v8, v12
+; RV64V-NEXT:    vmul.vv v26, v16, v14
+; RV64V-NEXT:    vxor.vv v20, v20, v22
+; RV64V-NEXT:    vxor.vv v22, v26, v24
+; RV64V-NEXT:    vmul.vv v24, v10, v18
+; RV64V-NEXT:    vand.vx v20, v20, a0
+; RV64V-NEXT:    vxor.vv v22, v22, v24
+; RV64V-NEXT:    vand.vx v22, v22, a1
+; RV64V-NEXT:    vor.vv v20, v22, v20
+; RV64V-NEXT:    vmul.vv v8, v8, v18
+; RV64V-NEXT:    vmul.vv v12, v16, v12
+; RV64V-NEXT:    vmul.vv v10, v10, v14
+; RV64V-NEXT:    vxor.vv v8, v12, v8
+; RV64V-NEXT:    vxor.vv v8, v8, v10
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v10, v20, v8
 ; RV64V-NEXT:    vsetvli zero, zero, e8, m1, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v10, 8
 ; RV64V-NEXT:    ret
@@ -1009,146 +1091,274 @@ define <vscale x 8 x i8> @clmulh_nxv8i8_vx(<vscale x 8 x i8> %va, i8 %b) nounwin
 define <vscale x 16 x i8> @clmulh_nxv16i8_vv(<vscale x 16 x i8> %va, <vscale x 16 x i8> %vb) nounwind {
 ; RV32V-LABEL: clmulh_nxv16i8_vv:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    li a0, 16
+; RV32V-NEXT:    addi sp, sp, -16
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    sub sp, sp, a0
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a0, a0, 585
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV32V-NEXT:    vzext.vf2 v12, v8
-; RV32V-NEXT:    vzext.vf2 v16, v10
-; RV32V-NEXT:    vand.vi v8, v16, 2
-; RV32V-NEXT:    vand.vi v20, v16, 1
-; RV32V-NEXT:    vmul.vv v8, v12, v8
-; RV32V-NEXT:    vmul.vv v20, v12, v20
-; RV32V-NEXT:    vxor.vv v8, v20, v8
-; RV32V-NEXT:    vand.vi v20, v16, 4
-; RV32V-NEXT:    vmul.vv v20, v12, v20
-; RV32V-NEXT:    vand.vi v24, v16, 8
-; RV32V-NEXT:    vmul.vv v24, v12, v24
+; RV32V-NEXT:    vzext.vf2 v24, v10
+; RV32V-NEXT:    vand.vx v12, v24, a0
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 2
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vs4r.v v12, (a1) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vzext.vf2 v28, v8
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v8, v28, a1
+; RV32V-NEXT:    vand.vx v16, v24, a1
+; RV32V-NEXT:    vand.vx v20, v28, a0
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v24, v24, a2
+; RV32V-NEXT:    vmul.vv v4, v8, v12
+; RV32V-NEXT:    vmul.vv v0, v20, v16
+; RV32V-NEXT:    vand.vx v28, v28, a2
+; RV32V-NEXT:    vmul.vv v12, v28, v24
+; RV32V-NEXT:    vxor.vv v0, v0, v4
+; RV32V-NEXT:    vxor.vv v12, v0, v12
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v0, v8, v24
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v4, v20, v12
+; RV32V-NEXT:    vmul.vv v12, v28, v16
+; RV32V-NEXT:    vxor.vv v4, v4, v0
+; RV32V-NEXT:    vxor.vv v12, v4, v12
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vand.vx v4, v4, a1
+; RV32V-NEXT:    vand.vx v12, v12, a0
+; RV32V-NEXT:    vor.vv v12, v12, v4
+; RV32V-NEXT:    vmul.vv v8, v8, v16
+; RV32V-NEXT:    vmul.vv v16, v20, v24
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, sp, a0
+; RV32V-NEXT:    addi a0, a0, 16
+; RV32V-NEXT:    vl4r.v v20, (a0) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v20, v28, v20
+; RV32V-NEXT:    vxor.vv v8, v16, v8
 ; RV32V-NEXT:    vxor.vv v8, v8, v20
-; RV32V-NEXT:    vxor.vv v8, v8, v24
-; RV32V-NEXT:    vand.vx v20, v16, a0
-; RV32V-NEXT:    vmul.vv v20, v12, v20
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v24, v16, a0
-; RV32V-NEXT:    vmul.vv v24, v12, v24
-; RV32V-NEXT:    vxor.vv v8, v8, v20
-; RV32V-NEXT:    vxor.vv v8, v8, v24
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v20, v16, a0
-; RV32V-NEXT:    vmul.vv v20, v12, v20
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v16, v16, a0
-; RV32V-NEXT:    vmul.vv v12, v12, v16
-; RV32V-NEXT:    vxor.vv v8, v8, v20
-; RV32V-NEXT:    vxor.vv v12, v8, v12
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v12, v12, v8
 ; RV32V-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v12, 8
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    add sp, sp, a0
+; RV32V-NEXT:    addi sp, sp, 16
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmulh_nxv16i8_vv:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    li a0, 16
+; RV64V-NEXT:    addi sp, sp, -16
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    sub sp, sp, a0
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a0, a0, 585
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV64V-NEXT:    vzext.vf2 v12, v8
-; RV64V-NEXT:    vzext.vf2 v16, v10
-; RV64V-NEXT:    vand.vi v8, v16, 2
-; RV64V-NEXT:    vand.vi v20, v16, 1
-; RV64V-NEXT:    vmul.vv v8, v12, v8
-; RV64V-NEXT:    vmul.vv v20, v12, v20
-; RV64V-NEXT:    vxor.vv v8, v20, v8
-; RV64V-NEXT:    vand.vi v20, v16, 4
-; RV64V-NEXT:    vmul.vv v20, v12, v20
-; RV64V-NEXT:    vand.vi v24, v16, 8
-; RV64V-NEXT:    vmul.vv v24, v12, v24
+; RV64V-NEXT:    vzext.vf2 v24, v10
+; RV64V-NEXT:    vand.vx v12, v24, a0
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 2
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vs4r.v v12, (a1) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vzext.vf2 v28, v8
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v8, v28, a1
+; RV64V-NEXT:    vand.vx v16, v24, a1
+; RV64V-NEXT:    vand.vx v20, v28, a0
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v24, v24, a2
+; RV64V-NEXT:    vmul.vv v4, v8, v12
+; RV64V-NEXT:    vmul.vv v0, v20, v16
+; RV64V-NEXT:    vand.vx v28, v28, a2
+; RV64V-NEXT:    vmul.vv v12, v28, v24
+; RV64V-NEXT:    vxor.vv v0, v0, v4
+; RV64V-NEXT:    vxor.vv v12, v0, v12
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v0, v8, v24
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v4, v20, v12
+; RV64V-NEXT:    vmul.vv v12, v28, v16
+; RV64V-NEXT:    vxor.vv v4, v4, v0
+; RV64V-NEXT:    vxor.vv v12, v4, v12
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vand.vx v4, v4, a1
+; RV64V-NEXT:    vand.vx v12, v12, a0
+; RV64V-NEXT:    vor.vv v12, v12, v4
+; RV64V-NEXT:    vmul.vv v8, v8, v16
+; RV64V-NEXT:    vmul.vv v16, v20, v24
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, sp, a0
+; RV64V-NEXT:    addi a0, a0, 16
+; RV64V-NEXT:    vl4r.v v20, (a0) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v20, v28, v20
+; RV64V-NEXT:    vxor.vv v8, v16, v8
 ; RV64V-NEXT:    vxor.vv v8, v8, v20
-; RV64V-NEXT:    vxor.vv v8, v8, v24
-; RV64V-NEXT:    vand.vx v20, v16, a0
-; RV64V-NEXT:    vmul.vv v20, v12, v20
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v24, v16, a0
-; RV64V-NEXT:    vmul.vv v24, v12, v24
-; RV64V-NEXT:    vxor.vv v8, v8, v20
-; RV64V-NEXT:    vxor.vv v8, v8, v24
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v20, v16, a0
-; RV64V-NEXT:    vmul.vv v20, v12, v20
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v16, v16, a0
-; RV64V-NEXT:    vmul.vv v12, v12, v16
-; RV64V-NEXT:    vxor.vv v8, v8, v20
-; RV64V-NEXT:    vxor.vv v12, v8, v12
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v12, v12, v8
 ; RV64V-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v12, 8
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    add sp, sp, a0
+; RV64V-NEXT:    addi sp, sp, 16
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmulh_nxv16i8_vv:
 ; RV32ZVBC64:       # %bb.0:
-; RV32ZVBC64-NEXT:    li a0, 16
+; RV32ZVBC64-NEXT:    addi sp, sp, -16
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    sub sp, sp, a0
+; RV32ZVBC64-NEXT:    lui a0, 9
+; RV32ZVBC64-NEXT:    addi a0, a0, 585
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV32ZVBC64-NEXT:    vzext.vf2 v12, v8
-; RV32ZVBC64-NEXT:    vzext.vf2 v16, v10
-; RV32ZVBC64-NEXT:    vand.vi v8, v16, 2
-; RV32ZVBC64-NEXT:    vand.vi v20, v16, 1
-; RV32ZVBC64-NEXT:    vmul.vv v8, v12, v8
-; RV32ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV32ZVBC64-NEXT:    vxor.vv v8, v20, v8
-; RV32ZVBC64-NEXT:    vand.vi v20, v16, 4
-; RV32ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v12, v24
+; RV32ZVBC64-NEXT:    vzext.vf2 v24, v10
+; RV32ZVBC64-NEXT:    vand.vx v12, v24, a0
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 2
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vs4r.v v12, (a1) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vzext.vf2 v28, v8
+; RV32ZVBC64-NEXT:    lui a1, 2
+; RV32ZVBC64-NEXT:    addi a1, a1, 1170
+; RV32ZVBC64-NEXT:    vand.vx v8, v28, a1
+; RV32ZVBC64-NEXT:    vand.vx v16, v24, a1
+; RV32ZVBC64-NEXT:    vand.vx v20, v28, a0
+; RV32ZVBC64-NEXT:    lui a2, 5
+; RV32ZVBC64-NEXT:    addi a2, a2, -1756
+; RV32ZVBC64-NEXT:    vand.vx v24, v24, a2
+; RV32ZVBC64-NEXT:    vmul.vv v4, v8, v12
+; RV32ZVBC64-NEXT:    vmul.vv v0, v20, v16
+; RV32ZVBC64-NEXT:    vand.vx v28, v28, a2
+; RV32ZVBC64-NEXT:    vmul.vv v12, v28, v24
+; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v4
+; RV32ZVBC64-NEXT:    vxor.vv v12, v0, v12
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v24
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v4, v20, v12
+; RV32ZVBC64-NEXT:    vmul.vv v12, v28, v16
+; RV32ZVBC64-NEXT:    vxor.vv v4, v4, v0
+; RV32ZVBC64-NEXT:    vxor.vv v12, v4, v12
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v4, v4, a1
+; RV32ZVBC64-NEXT:    vand.vx v12, v12, a0
+; RV32ZVBC64-NEXT:    vor.vv v12, v12, v4
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
+; RV32ZVBC64-NEXT:    vmul.vv v16, v20, v24
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, sp, a0
+; RV32ZVBC64-NEXT:    addi a0, a0, 16
+; RV32ZVBC64-NEXT:    vl4r.v v20, (a0) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v20, v28, v20
+; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
 ; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v20
-; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v24
-; RV32ZVBC64-NEXT:    vand.vx v20, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v12, v24
-; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v20
-; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v24
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v20, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV32ZVBC64-NEXT:    li a0, 128
-; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
-; RV32ZVBC64-NEXT:    vmul.vv v12, v12, v16
-; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v20
-; RV32ZVBC64-NEXT:    vxor.vv v12, v8, v12
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV32ZVBC64-NEXT:    vor.vv v12, v12, v8
 ; RV32ZVBC64-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
 ; RV32ZVBC64-NEXT:    vnsrl.wi v8, v12, 8
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    add sp, sp, a0
+; RV32ZVBC64-NEXT:    addi sp, sp, 16
 ; RV32ZVBC64-NEXT:    ret
 ;
 ; RV64ZVBC64-LABEL: clmulh_nxv16i8_vv:
 ; RV64ZVBC64:       # %bb.0:
-; RV64ZVBC64-NEXT:    li a0, 16
+; RV64ZVBC64-NEXT:    addi sp, sp, -16
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    sub sp, sp, a0
+; RV64ZVBC64-NEXT:    lui a0, 9
+; RV64ZVBC64-NEXT:    addi a0, a0, 585
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
-; RV64ZVBC64-NEXT:    vzext.vf2 v12, v8
-; RV64ZVBC64-NEXT:    vzext.vf2 v16, v10
-; RV64ZVBC64-NEXT:    vand.vi v8, v16, 2
-; RV64ZVBC64-NEXT:    vand.vi v20, v16, 1
-; RV64ZVBC64-NEXT:    vmul.vv v8, v12, v8
-; RV64ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV64ZVBC64-NEXT:    vxor.vv v8, v20, v8
-; RV64ZVBC64-NEXT:    vand.vi v20, v16, 4
-; RV64ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v12, v24
+; RV64ZVBC64-NEXT:    vzext.vf2 v24, v10
+; RV64ZVBC64-NEXT:    vand.vx v12, v24, a0
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 2
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vs4r.v v12, (a1) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vzext.vf2 v28, v8
+; RV64ZVBC64-NEXT:    lui a1, 2
+; RV64ZVBC64-NEXT:    addi a1, a1, 1170
+; RV64ZVBC64-NEXT:    vand.vx v8, v28, a1
+; RV64ZVBC64-NEXT:    vand.vx v16, v24, a1
+; RV64ZVBC64-NEXT:    vand.vx v20, v28, a0
+; RV64ZVBC64-NEXT:    lui a2, 5
+; RV64ZVBC64-NEXT:    addi a2, a2, -1756
+; RV64ZVBC64-NEXT:    vand.vx v24, v24, a2
+; RV64ZVBC64-NEXT:    vmul.vv v4, v8, v12
+; RV64ZVBC64-NEXT:    vmul.vv v0, v20, v16
+; RV64ZVBC64-NEXT:    vand.vx v28, v28, a2
+; RV64ZVBC64-NEXT:    vmul.vv v12, v28, v24
+; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v4
+; RV64ZVBC64-NEXT:    vxor.vv v12, v0, v12
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vs4r.v v12, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v24
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v12, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v4, v20, v12
+; RV64ZVBC64-NEXT:    vmul.vv v12, v28, v16
+; RV64ZVBC64-NEXT:    vxor.vv v4, v4, v0
+; RV64ZVBC64-NEXT:    vxor.vv v12, v4, v12
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v4, v4, a1
+; RV64ZVBC64-NEXT:    vand.vx v12, v12, a0
+; RV64ZVBC64-NEXT:    vor.vv v12, v12, v4
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
+; RV64ZVBC64-NEXT:    vmul.vv v16, v20, v24
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, sp, a0
+; RV64ZVBC64-NEXT:    addi a0, a0, 16
+; RV64ZVBC64-NEXT:    vl4r.v v20, (a0) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v20, v28, v20
+; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
 ; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v20
-; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v24
-; RV64ZVBC64-NEXT:    vand.vx v20, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v12, v24
-; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v20
-; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v24
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v20, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV64ZVBC64-NEXT:    li a0, 128
-; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
-; RV64ZVBC64-NEXT:    vmul.vv v12, v12, v16
-; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v20
-; RV64ZVBC64-NEXT:    vxor.vv v12, v8, v12
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV64ZVBC64-NEXT:    vor.vv v12, v12, v8
 ; RV64ZVBC64-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
 ; RV64ZVBC64-NEXT:    vnsrl.wi v8, v12, 8
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    add sp, sp, a0
+; RV64ZVBC64-NEXT:    addi sp, sp, 16
 ; RV64ZVBC64-NEXT:    ret
 ;
 ; RV32ZVBC32-LABEL: clmulh_nxv16i8_vv:
@@ -1173,154 +1383,538 @@ define <vscale x 16 x i8> @clmulh_nxv16i8_vv(<vscale x 16 x i8> %va, <vscale x 1
 define <vscale x 16 x i8> @clmulh_nxv16i8_vx(<vscale x 16 x i8> %va, i8 %b) nounwind {
 ; RV32V-LABEL: clmulh_nxv16i8_vx:
 ; RV32V:       # %bb.0:
-; RV32V-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; RV32V-NEXT:    vmv.v.x v16, a0
+; RV32V-NEXT:    addi sp, sp, -16
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 2
+; RV32V-NEXT:    mv a2, a1
+; RV32V-NEXT:    slli a1, a1, 2
+; RV32V-NEXT:    add a1, a1, a2
+; RV32V-NEXT:    sub sp, sp, a1
+; RV32V-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
+; RV32V-NEXT:    vzext.vf2 v24, v8
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v4, v24, a1
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 3
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vs4r.v v4, (a2) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
+; RV32V-NEXT:    vmv.v.x v8, a0
 ; RV32V-NEXT:    vsetvli zero, zero, e16, m4, ta, ma
-; RV32V-NEXT:    vzext.vf2 v12, v8
-; RV32V-NEXT:    vzext.vf2 v8, v16
-; RV32V-NEXT:    vand.vi v16, v8, 2
-; RV32V-NEXT:    vand.vi v20, v8, 1
-; RV32V-NEXT:    vmul.vv v16, v12, v16
-; RV32V-NEXT:    vmul.vv v20, v12, v20
-; RV32V-NEXT:    vxor.vv v16, v20, v16
-; RV32V-NEXT:    vand.vi v20, v8, 4
-; RV32V-NEXT:    vmul.vv v20, v12, v20
-; RV32V-NEXT:    vand.vi v24, v8, 8
-; RV32V-NEXT:    vmul.vv v24, v12, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v20, v8, a0
-; RV32V-NEXT:    vmul.vv v20, v12, v20
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v24, v8, a0
-; RV32V-NEXT:    vmul.vv v24, v12, v24
-; RV32V-NEXT:    vxor.vv v16, v16, v20
-; RV32V-NEXT:    vxor.vv v16, v16, v24
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v20, v8, a0
-; RV32V-NEXT:    vmul.vv v20, v12, v20
-; RV32V-NEXT:    li a0, 128
+; RV32V-NEXT:    vzext.vf2 v28, v8
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a0, a0, 585
+; RV32V-NEXT:    vand.vx v12, v28, a0
+; RV32V-NEXT:    vand.vx v16, v24, a0
+; RV32V-NEXT:    vand.vx v20, v28, a1
+; RV32V-NEXT:    lui a2, 5
+; RV32V-NEXT:    addi a2, a2, -1756
+; RV32V-NEXT:    vand.vx v24, v24, a2
+; RV32V-NEXT:    vmul.vv v8, v4, v12
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v8, v16, v20
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vand.vx v28, v28, a2
+; RV32V-NEXT:    vmul.vv v8, v24, v28
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v4, v0
+; RV32V-NEXT:    vxor.vv v8, v0, v8
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v4, v28
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v8, v16, v12
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v8, v24, v20
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v8, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v0, v8, v0
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vl4r.v v8, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v8, v0, v8
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32V-NEXT:    vand.vx v0, v0, a1
 ; RV32V-NEXT:    vand.vx v8, v8, a0
-; RV32V-NEXT:    vmul.vv v8, v12, v8
-; RV32V-NEXT:    vxor.vv v12, v16, v20
-; RV32V-NEXT:    vxor.vv v12, v12, v8
+; RV32V-NEXT:    vor.vv v8, v8, v0
+; RV32V-NEXT:    vmul.vv v20, v4, v20
+; RV32V-NEXT:    vmul.vv v16, v16, v28
+; RV32V-NEXT:    vmul.vv v12, v24, v12
+; RV32V-NEXT:    vxor.vv v16, v16, v20
+; RV32V-NEXT:    vxor.vv v12, v16, v12
+; RV32V-NEXT:    vand.vx v12, v12, a2
+; RV32V-NEXT:    vor.vv v12, v8, v12
 ; RV32V-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v12, 8
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    mv a1, a0
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, a0, a1
+; RV32V-NEXT:    add sp, sp, a0
+; RV32V-NEXT:    addi sp, sp, 16
 ; RV32V-NEXT:    ret
 ;
 ; RV64V-LABEL: clmulh_nxv16i8_vx:
 ; RV64V:       # %bb.0:
-; RV64V-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; RV64V-NEXT:    vmv.v.x v16, a0
+; RV64V-NEXT:    addi sp, sp, -16
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 2
+; RV64V-NEXT:    mv a2, a1
+; RV64V-NEXT:    slli a1, a1, 2
+; RV64V-NEXT:    add a1, a1, a2
+; RV64V-NEXT:    sub sp, sp, a1
+; RV64V-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
+; RV64V-NEXT:    vzext.vf2 v24, v8
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v4, v24, a1
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 3
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vs4r.v v4, (a2) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
+; RV64V-NEXT:    vmv.v.x v8, a0
 ; RV64V-NEXT:    vsetvli zero, zero, e16, m4, ta, ma
-; RV64V-NEXT:    vzext.vf2 v12, v8
-; RV64V-NEXT:    vzext.vf2 v8, v16
-; RV64V-NEXT:    vand.vi v16, v8, 2
-; RV64V-NEXT:    vand.vi v20, v8, 1
-; RV64V-NEXT:    vmul.vv v16, v12, v16
-; RV64V-NEXT:    vmul.vv v20, v12, v20
-; RV64V-NEXT:    vxor.vv v16, v20, v16
-; RV64V-NEXT:    vand.vi v20, v8, 4
-; RV64V-NEXT:    vmul.vv v20, v12, v20
-; RV64V-NEXT:    vand.vi v24, v8, 8
-; RV64V-NEXT:    vmul.vv v24, v12, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v20, v8, a0
-; RV64V-NEXT:    vmul.vv v20, v12, v20
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v24, v8, a0
-; RV64V-NEXT:    vmul.vv v24, v12, v24
-; RV64V-NEXT:    vxor.vv v16, v16, v20
-; RV64V-NEXT:    vxor.vv v16, v16, v24
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v20, v8, a0
-; RV64V-NEXT:    vmul.vv v20, v12, v20
-; RV64V-NEXT:    li a0, 128
+; RV64V-NEXT:    vzext.vf2 v28, v8
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a0, a0, 585
+; RV64V-NEXT:    vand.vx v12, v28, a0
+; RV64V-NEXT:    vand.vx v16, v24, a0
+; RV64V-NEXT:    vand.vx v20, v28, a1
+; RV64V-NEXT:    lui a2, 5
+; RV64V-NEXT:    addi a2, a2, -1756
+; RV64V-NEXT:    vand.vx v24, v24, a2
+; RV64V-NEXT:    vmul.vv v8, v4, v12
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v8, v16, v20
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vand.vx v28, v28, a2
+; RV64V-NEXT:    vmul.vv v8, v24, v28
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v4, v0
+; RV64V-NEXT:    vxor.vv v8, v0, v8
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v4, v28
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v8, v16, v12
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v8, v24, v20
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v8, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v0, v8, v0
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vl4r.v v8, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v8, v0, v8
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64V-NEXT:    vand.vx v0, v0, a1
 ; RV64V-NEXT:    vand.vx v8, v8, a0
-; RV64V-NEXT:    vmul.vv v8, v12, v8
-; RV64V-NEXT:    vxor.vv v12, v16, v20
-; RV64V-NEXT:    vxor.vv v12, v12, v8
+; RV64V-NEXT:    vor.vv v8, v8, v0
+; RV64V-NEXT:    vmul.vv v20, v4, v20
+; RV64V-NEXT:    vmul.vv v16, v16, v28
+; RV64V-NEXT:    vmul.vv v12, v24, v12
+; RV64V-NEXT:    vxor.vv v16, v16, v20
+; RV64V-NEXT:    vxor.vv v12, v16, v12
+; RV64V-NEXT:    vand.vx v12, v12, a2
+; RV64V-NEXT:    vor.vv v12, v8, v12
 ; RV64V-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v12, 8
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    mv a1, a0
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, a0, a1
+; RV64V-NEXT:    add sp, sp, a0
+; RV64V-NEXT:    addi sp, sp, 16
 ; RV64V-NEXT:    ret
 ;
 ; RV32ZVBC64-LABEL: clmulh_nxv16i8_vx:
 ; RV32ZVBC64:       # %bb.0:
-; RV32ZVBC64-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; RV32ZVBC64-NEXT:    vmv.v.x v16, a0
+; RV32ZVBC64-NEXT:    addi sp, sp, -16
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 2
+; RV32ZVBC64-NEXT:    mv a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 2
+; RV32ZVBC64-NEXT:    add a1, a1, a2
+; RV32ZVBC64-NEXT:    sub sp, sp, a1
+; RV32ZVBC64-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
+; RV32ZVBC64-NEXT:    vzext.vf2 v24, v8
+; RV32ZVBC64-NEXT:    lui a1, 2
+; RV32ZVBC64-NEXT:    addi a1, a1, 1170
+; RV32ZVBC64-NEXT:    vand.vx v4, v24, a1
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 3
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vs4r.v v4, (a2) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
+; RV32ZVBC64-NEXT:    vmv.v.x v8, a0
 ; RV32ZVBC64-NEXT:    vsetvli zero, zero, e16, m4, ta, ma
-; RV32ZVBC64-NEXT:    vzext.vf2 v12, v8
-; RV32ZVBC64-NEXT:    vzext.vf2 v8, v16
-; RV32ZVBC64-NEXT:    vand.vi v16, v8, 2
-; RV32ZVBC64-NEXT:    vand.vi v20, v8, 1
-; RV32ZVBC64-NEXT:    vmul.vv v16, v12, v16
-; RV32ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v20, v16
-; RV32ZVBC64-NEXT:    vand.vi v20, v8, 4
-; RV32ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV32ZVBC64-NEXT:    vand.vi v24, v8, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v12, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 16
-; RV32ZVBC64-NEXT:    vand.vx v20, v8, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v8, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v12, v24
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v20, v8, a0
-; RV32ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV32ZVBC64-NEXT:    li a0, 128
+; RV32ZVBC64-NEXT:    vzext.vf2 v28, v8
+; RV32ZVBC64-NEXT:    lui a0, 9
+; RV32ZVBC64-NEXT:    addi a0, a0, 585
+; RV32ZVBC64-NEXT:    vand.vx v12, v28, a0
+; RV32ZVBC64-NEXT:    vand.vx v16, v24, a0
+; RV32ZVBC64-NEXT:    vand.vx v20, v28, a1
+; RV32ZVBC64-NEXT:    lui a2, 5
+; RV32ZVBC64-NEXT:    addi a2, a2, -1756
+; RV32ZVBC64-NEXT:    vand.vx v24, v24, a2
+; RV32ZVBC64-NEXT:    vmul.vv v8, v4, v12
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v8, v16, v20
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v28, v28, a2
+; RV32ZVBC64-NEXT:    vmul.vv v8, v24, v28
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v4, v0
+; RV32ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v4, v28
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v8, v16, v12
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v8, v24, v20
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v8, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v0, v8, v0
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vl4r.v v8, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a1
 ; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v12, v8
-; RV32ZVBC64-NEXT:    vxor.vv v12, v16, v20
-; RV32ZVBC64-NEXT:    vxor.vv v12, v12, v8
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    vmul.vv v20, v4, v20
+; RV32ZVBC64-NEXT:    vmul.vv v16, v16, v28
+; RV32ZVBC64-NEXT:    vmul.vv v12, v24, v12
+; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v20
+; RV32ZVBC64-NEXT:    vxor.vv v12, v16, v12
+; RV32ZVBC64-NEXT:    vand.vx v12, v12, a2
+; RV32ZVBC64-NEXT:    vor.vv v12, v8, v12
 ; RV32ZVBC64-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
 ; RV32ZVBC64-NEXT:    vnsrl.wi v8, v12, 8
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    mv a1, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, a0, a1
+; RV32ZVBC64-NEXT:    add sp, sp, a0
+; RV32ZVBC64-NEXT:    addi sp, sp, 16
 ; RV32ZVBC64-NEXT:    ret
 ;
 ; RV64ZVBC64-LABEL: clmulh_nxv16i8_vx:
 ; RV64ZVBC64:       # %bb.0:
-; RV64ZVBC64-NEXT:    vsetvli a1, zero, e8, m2, ta, ma
-; RV64ZVBC64-NEXT:    vmv.v.x v16, a0
+; RV64ZVBC64-NEXT:    addi sp, sp, -16
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 2
+; RV64ZVBC64-NEXT:    mv a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 2
+; RV64ZVBC64-NEXT:    add a1, a1, a2
+; RV64ZVBC64-NEXT:    sub sp, sp, a1
+; RV64ZVBC64-NEXT:    vsetvli a1, zero, e16, m4, ta, ma
+; RV64ZVBC64-NEXT:    vzext.vf2 v24, v8
+; RV64ZVBC64-NEXT:    lui a1, 2
+; RV64ZVBC64-NEXT:    addi a1, a1, 1170
+; RV64ZVBC64-NEXT:    vand.vx v4, v24, a1
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 3
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vs4r.v v4, (a2) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
+; RV64ZVBC64-NEXT:    vmv.v.x v8, a0
 ; RV64ZVBC64-NEXT:    vsetvli zero, zero, e16, m4, ta, ma
-; RV64ZVBC64-NEXT:    vzext.vf2 v12, v8
-; RV64ZVBC64-NEXT:    vzext.vf2 v8, v16
-; RV64ZVBC64-NEXT:    vand.vi v16, v8, 2
-; RV64ZVBC64-NEXT:    vand.vi v20, v8, 1
-; RV64ZVBC64-NEXT:    vmul.vv v16, v12, v16
-; RV64ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v20, v16
-; RV64ZVBC64-NEXT:    vand.vi v20, v8, 4
-; RV64ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV64ZVBC64-NEXT:    vand.vi v24, v8, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v12, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 16
-; RV64ZVBC64-NEXT:    vand.vx v20, v8, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v8, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v12, v24
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v20, v8, a0
-; RV64ZVBC64-NEXT:    vmul.vv v20, v12, v20
-; RV64ZVBC64-NEXT:    li a0, 128
+; RV64ZVBC64-NEXT:    vzext.vf2 v28, v8
+; RV64ZVBC64-NEXT:    lui a0, 9
+; RV64ZVBC64-NEXT:    addi a0, a0, 585
+; RV64ZVBC64-NEXT:    vand.vx v12, v28, a0
+; RV64ZVBC64-NEXT:    vand.vx v16, v24, a0
+; RV64ZVBC64-NEXT:    vand.vx v20, v28, a1
+; RV64ZVBC64-NEXT:    lui a2, 5
+; RV64ZVBC64-NEXT:    addi a2, a2, -1756
+; RV64ZVBC64-NEXT:    vand.vx v24, v24, a2
+; RV64ZVBC64-NEXT:    vmul.vv v8, v4, v12
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v8, v16, v20
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v28, v28, a2
+; RV64ZVBC64-NEXT:    vmul.vv v8, v24, v28
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v4, v0
+; RV64ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v4, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v4, v28
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v8, v16, v12
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v8, v24, v20
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vs4r.v v8, (a3) # vscale x 32-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v8, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v0, v8, v0
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vl4r.v v8, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl4r.v v0, (a3) # vscale x 32-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a1
 ; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v12, v8
-; RV64ZVBC64-NEXT:    vxor.vv v12, v16, v20
-; RV64ZVBC64-NEXT:    vxor.vv v12, v12, v8
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    vmul.vv v20, v4, v20
+; RV64ZVBC64-NEXT:    vmul.vv v16, v16, v28
+; RV64ZVBC64-NEXT:    vmul.vv v12, v24, v12
+; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v20
+; RV64ZVBC64-NEXT:    vxor.vv v12, v16, v12
+; RV64ZVBC64-NEXT:    vand.vx v12, v12, a2
+; RV64ZVBC64-NEXT:    vor.vv v12, v8, v12
 ; RV64ZVBC64-NEXT:    vsetvli zero, zero, e8, m2, ta, ma
 ; RV64ZVBC64-NEXT:    vnsrl.wi v8, v12, 8
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    mv a1, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, a0, a1
+; RV64ZVBC64-NEXT:    add sp, sp, a0
+; RV64ZVBC64-NEXT:    addi sp, sp, 16
 ; RV64ZVBC64-NEXT:    ret
 ;
 ; RV32ZVBC32-LABEL: clmulh_nxv16i8_vx:
@@ -1351,93 +1945,268 @@ define <vscale x 32 x i8> @clmulh_nxv32i8_vv(<vscale x 32 x i8> %va, <vscale x 3
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    mv a1, a0
-; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    sub sp, sp, a0
-; RV32V-NEXT:    li a0, 16
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a0, a0, 585
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV32V-NEXT:    vzext.vf2 v16, v8
-; RV32V-NEXT:    vzext.vf2 v24, v12
-; RV32V-NEXT:    vand.vi v8, v24, 2
-; RV32V-NEXT:    vand.vi v0, v24, 1
-; RV32V-NEXT:    vmul.vv v8, v16, v8
-; RV32V-NEXT:    vmul.vv v0, v16, v0
-; RV32V-NEXT:    vxor.vv v8, v0, v8
+; RV32V-NEXT:    vzext.vf2 v16, v12
+; RV32V-NEXT:    vand.vx v24, v16, a0
 ; RV32V-NEXT:    csrr a1, vlenb
 ; RV32V-NEXT:    slli a1, a1, 4
+; RV32V-NEXT:    mv a2, a1
+; RV32V-NEXT:    slli a1, a1, 1
+; RV32V-NEXT:    add a1, a1, a2
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vzext.vf2 v0, v8
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a2, a1, 1170
+; RV32V-NEXT:    vand.vx v8, v16, a2
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 6
 ; RV32V-NEXT:    add a1, sp, a1
 ; RV32V-NEXT:    addi a1, a1, 16
 ; RV32V-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v0, v24, 4
-; RV32V-NEXT:    vmul.vv v8, v16, v0
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 3
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v8, v24, 8
-; RV32V-NEXT:    vmul.vv v8, v16, v8
-; RV32V-NEXT:    addi a1, sp, 16
-; RV32V-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 4
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 3
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v8
-; RV32V-NEXT:    addi a1, sp, 16
-; RV32V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v8, v0, v8
-; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 4
-; RV32V-NEXT:    add a1, sp, a1
-; RV32V-NEXT:    addi a1, a1, 16
-; RV32V-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vx v0, v24, a0
-; RV32V-NEXT:    vmul.vv v8, v16, v0
+; RV32V-NEXT:    lui a1, 5
+; RV32V-NEXT:    addi a1, a1, -1756
+; RV32V-NEXT:    vand.vx v8, v16, a1
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a4, a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v8, v0, a2
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v16, v0, a0
+; RV32V-NEXT:    vand.vx v0, v0, a1
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v24, v8, v24
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 6
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v16, v24
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a4, a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v0, v24
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v24, v8, v24
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v24, v24, v8
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a4, a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v8, v24
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v16, v24
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 6
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v0, v24
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v24, v0, v24
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v24, v24, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v0, v24, a2
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 5
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v24, v24, a0
+; RV32V-NEXT:    vor.vv v24, v24, v0
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a2, a0
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, a0, a2
 ; RV32V-NEXT:    add a0, sp, a0
 ; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v8, v24, a0
-; RV32V-NEXT:    vmul.vv v8, v16, v8
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 6
+; RV32V-NEXT:    add a0, sp, a0
+; RV32V-NEXT:    addi a0, a0, 16
+; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v24
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a2, a0
+; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    add a2, a2, a0
+; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    add a0, a0, a2
+; RV32V-NEXT:    add a0, sp, a0
+; RV32V-NEXT:    addi a0, a0, 16
+; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v16, v24
+; RV32V-NEXT:    csrr a0, vlenb
+; RV32V-NEXT:    slli a0, a0, 4
+; RV32V-NEXT:    mv a2, a0
+; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    add a0, a0, a2
+; RV32V-NEXT:    add a0, sp, a0
+; RV32V-NEXT:    addi a0, a0, 16
+; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 4
 ; RV32V-NEXT:    add a0, sp, a0
 ; RV32V-NEXT:    addi a0, a0, 16
 ; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v0, v0, v24
+; RV32V-NEXT:    vxor.vv v8, v16, v8
+; RV32V-NEXT:    vxor.vv v8, v8, v0
+; RV32V-NEXT:    vand.vx v8, v8, a1
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a1, a0
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    add a0, sp, a0
 ; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v8
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v8, v0, v8
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v0, v24, a0
-; RV32V-NEXT:    vmul.vv v0, v16, v0
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v24, v24, a0
-; RV32V-NEXT:    vmul.vv v16, v16, v24
-; RV32V-NEXT:    vxor.vv v8, v8, v0
-; RV32V-NEXT:    vxor.vv v16, v8, v16
+; RV32V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vor.vv v16, v16, v8
 ; RV32V-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v16, 8
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    mv a1, a0
-; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    add sp, sp, a0
 ; RV32V-NEXT:    addi sp, sp, 16
@@ -1449,93 +2218,268 @@ define <vscale x 32 x i8> @clmulh_nxv32i8_vv(<vscale x 32 x i8> %va, <vscale x 3
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    mv a1, a0
-; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    sub sp, sp, a0
-; RV64V-NEXT:    li a0, 16
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a0, a0, 585
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV64V-NEXT:    vzext.vf2 v16, v8
-; RV64V-NEXT:    vzext.vf2 v24, v12
-; RV64V-NEXT:    vand.vi v8, v24, 2
-; RV64V-NEXT:    vand.vi v0, v24, 1
-; RV64V-NEXT:    vmul.vv v8, v16, v8
-; RV64V-NEXT:    vmul.vv v0, v16, v0
-; RV64V-NEXT:    vxor.vv v8, v0, v8
+; RV64V-NEXT:    vzext.vf2 v16, v12
+; RV64V-NEXT:    vand.vx v24, v16, a0
 ; RV64V-NEXT:    csrr a1, vlenb
 ; RV64V-NEXT:    slli a1, a1, 4
+; RV64V-NEXT:    mv a2, a1
+; RV64V-NEXT:    slli a1, a1, 1
+; RV64V-NEXT:    add a1, a1, a2
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vzext.vf2 v0, v8
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a2, a1, 1170
+; RV64V-NEXT:    vand.vx v8, v16, a2
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 6
 ; RV64V-NEXT:    add a1, sp, a1
 ; RV64V-NEXT:    addi a1, a1, 16
 ; RV64V-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v0, v24, 4
-; RV64V-NEXT:    vmul.vv v8, v16, v0
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 3
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v8, v24, 8
-; RV64V-NEXT:    vmul.vv v8, v16, v8
-; RV64V-NEXT:    addi a1, sp, 16
-; RV64V-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 4
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 3
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v8
-; RV64V-NEXT:    addi a1, sp, 16
-; RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v8, v0, v8
-; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 4
-; RV64V-NEXT:    add a1, sp, a1
-; RV64V-NEXT:    addi a1, a1, 16
-; RV64V-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vx v0, v24, a0
-; RV64V-NEXT:    vmul.vv v8, v16, v0
+; RV64V-NEXT:    lui a1, 5
+; RV64V-NEXT:    addi a1, a1, -1756
+; RV64V-NEXT:    vand.vx v8, v16, a1
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a4, a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v8, v0, a2
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v16, v0, a0
+; RV64V-NEXT:    vand.vx v0, v0, a1
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v24, v8, v24
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 6
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v16, v24
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a4, a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v0, v24
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v24, v8, v24
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v24, v24, v8
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a4, a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v8, v24
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v16, v24
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 6
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v0, v24
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v24, v0, v24
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v24, v24, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v0, v24, a2
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 5
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v24, v24, a0
+; RV64V-NEXT:    vor.vv v24, v24, v0
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a2, a0
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, a0, a2
 ; RV64V-NEXT:    add a0, sp, a0
 ; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v8, v24, a0
-; RV64V-NEXT:    vmul.vv v8, v16, v8
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 6
+; RV64V-NEXT:    add a0, sp, a0
+; RV64V-NEXT:    addi a0, a0, 16
+; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v24
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a2, a0
+; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    add a2, a2, a0
+; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    add a0, a0, a2
+; RV64V-NEXT:    add a0, sp, a0
+; RV64V-NEXT:    addi a0, a0, 16
+; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v16, v24
+; RV64V-NEXT:    csrr a0, vlenb
+; RV64V-NEXT:    slli a0, a0, 4
+; RV64V-NEXT:    mv a2, a0
+; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    add a0, a0, a2
+; RV64V-NEXT:    add a0, sp, a0
+; RV64V-NEXT:    addi a0, a0, 16
+; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 4
 ; RV64V-NEXT:    add a0, sp, a0
 ; RV64V-NEXT:    addi a0, a0, 16
 ; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v0, v0, v24
+; RV64V-NEXT:    vxor.vv v8, v16, v8
+; RV64V-NEXT:    vxor.vv v8, v8, v0
+; RV64V-NEXT:    vand.vx v8, v8, a1
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a1, a0
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    add a0, sp, a0
 ; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v8
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v8, v0, v8
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v0, v24, a0
-; RV64V-NEXT:    vmul.vv v0, v16, v0
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v24, v24, a0
-; RV64V-NEXT:    vmul.vv v16, v16, v24
-; RV64V-NEXT:    vxor.vv v8, v8, v0
-; RV64V-NEXT:    vxor.vv v16, v8, v16
+; RV64V-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vor.vv v16, v16, v8
 ; RV64V-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v16, 8
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    mv a1, a0
-; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    add sp, sp, a0
 ; RV64V-NEXT:    addi sp, sp, 16
@@ -1547,93 +2491,268 @@ define <vscale x 32 x i8> @clmulh_nxv32i8_vv(<vscale x 32 x i8> %va, <vscale x 3
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    mv a1, a0
-; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    sub sp, sp, a0
-; RV32ZVBC64-NEXT:    li a0, 16
+; RV32ZVBC64-NEXT:    lui a0, 9
+; RV32ZVBC64-NEXT:    addi a0, a0, 585
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV32ZVBC64-NEXT:    vzext.vf2 v16, v8
-; RV32ZVBC64-NEXT:    vzext.vf2 v24, v12
-; RV32ZVBC64-NEXT:    vand.vi v8, v24, 2
-; RV32ZVBC64-NEXT:    vand.vi v0, v24, 1
-; RV32ZVBC64-NEXT:    vmul.vv v8, v16, v8
-; RV32ZVBC64-NEXT:    vmul.vv v0, v16, v0
-; RV32ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV32ZVBC64-NEXT:    vzext.vf2 v16, v12
+; RV32ZVBC64-NEXT:    vand.vx v24, v16, a0
 ; RV32ZVBC64-NEXT:    csrr a1, vlenb
 ; RV32ZVBC64-NEXT:    slli a1, a1, 4
+; RV32ZVBC64-NEXT:    mv a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 1
+; RV32ZVBC64-NEXT:    add a1, a1, a2
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vzext.vf2 v0, v8
+; RV32ZVBC64-NEXT:    lui a1, 2
+; RV32ZVBC64-NEXT:    addi a2, a1, 1170
+; RV32ZVBC64-NEXT:    vand.vx v8, v16, a2
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 6
 ; RV32ZVBC64-NEXT:    add a1, sp, a1
 ; RV32ZVBC64-NEXT:    addi a1, a1, 16
 ; RV32ZVBC64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v0, v24, 4
-; RV32ZVBC64-NEXT:    vmul.vv v8, v16, v0
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 3
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v8, v24, 8
-; RV32ZVBC64-NEXT:    vmul.vv v8, v16, v8
-; RV32ZVBC64-NEXT:    addi a1, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 4
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 3
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v8
-; RV32ZVBC64-NEXT:    addi a1, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v8, v0, v8
-; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 4
-; RV32ZVBC64-NEXT:    add a1, sp, a1
-; RV32ZVBC64-NEXT:    addi a1, a1, 16
-; RV32ZVBC64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vx v0, v24, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v16, v0
+; RV32ZVBC64-NEXT:    lui a1, 5
+; RV32ZVBC64-NEXT:    addi a1, a1, -1756
+; RV32ZVBC64-NEXT:    vand.vx v8, v16, a1
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a4, a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v8, v0, a2
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v16, v0, a0
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a1
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 6
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v16, v24
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a4, a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v0, v24
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v24, v8, v24
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v24, v24, v8
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a4, a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v16, v24
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 6
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v0, v24
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v24, v24, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v0, v24, a2
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 5
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v24, v24, a0
+; RV32ZVBC64-NEXT:    vor.vv v24, v24, v0
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, a0, a2
 ; RV32ZVBC64-NEXT:    add a0, sp, a0
 ; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v8, v24, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v16, v8
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 6
+; RV32ZVBC64-NEXT:    add a0, sp, a0
+; RV32ZVBC64-NEXT:    addi a0, a0, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    add a2, a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    add a0, a0, a2
+; RV32ZVBC64-NEXT:    add a0, sp, a0
+; RV32ZVBC64-NEXT:    addi a0, a0, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v16, v24
+; RV32ZVBC64-NEXT:    csrr a0, vlenb
+; RV32ZVBC64-NEXT:    slli a0, a0, 4
+; RV32ZVBC64-NEXT:    mv a2, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    add a0, a0, a2
+; RV32ZVBC64-NEXT:    add a0, sp, a0
+; RV32ZVBC64-NEXT:    addi a0, a0, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 4
 ; RV32ZVBC64-NEXT:    add a0, sp, a0
 ; RV32ZVBC64-NEXT:    addi a0, a0, 16
 ; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v0, v0, v24
+; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a1, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    add a0, sp, a0
 ; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v8
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v8, v0, v8
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v0, v24, a0
-; RV32ZVBC64-NEXT:    vmul.vv v0, v16, v0
-; RV32ZVBC64-NEXT:    li a0, 128
-; RV32ZVBC64-NEXT:    vand.vx v24, v24, a0
-; RV32ZVBC64-NEXT:    vmul.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v0
-; RV32ZVBC64-NEXT:    vxor.vv v16, v8, v16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vor.vv v16, v16, v8
 ; RV32ZVBC64-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV32ZVBC64-NEXT:    vnsrl.wi v8, v16, 8
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    mv a1, a0
-; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    add sp, sp, a0
 ; RV32ZVBC64-NEXT:    addi sp, sp, 16
@@ -1645,93 +2764,268 @@ define <vscale x 32 x i8> @clmulh_nxv32i8_vv(<vscale x 32 x i8> %va, <vscale x 3
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    mv a1, a0
-; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    sub sp, sp, a0
-; RV64ZVBC64-NEXT:    li a0, 16
+; RV64ZVBC64-NEXT:    lui a0, 9
+; RV64ZVBC64-NEXT:    addi a0, a0, 585
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV64ZVBC64-NEXT:    vzext.vf2 v16, v8
-; RV64ZVBC64-NEXT:    vzext.vf2 v24, v12
-; RV64ZVBC64-NEXT:    vand.vi v8, v24, 2
-; RV64ZVBC64-NEXT:    vand.vi v0, v24, 1
-; RV64ZVBC64-NEXT:    vmul.vv v8, v16, v8
-; RV64ZVBC64-NEXT:    vmul.vv v0, v16, v0
-; RV64ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV64ZVBC64-NEXT:    vzext.vf2 v16, v12
+; RV64ZVBC64-NEXT:    vand.vx v24, v16, a0
 ; RV64ZVBC64-NEXT:    csrr a1, vlenb
 ; RV64ZVBC64-NEXT:    slli a1, a1, 4
+; RV64ZVBC64-NEXT:    mv a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 1
+; RV64ZVBC64-NEXT:    add a1, a1, a2
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a1) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vzext.vf2 v0, v8
+; RV64ZVBC64-NEXT:    lui a1, 2
+; RV64ZVBC64-NEXT:    addi a2, a1, 1170
+; RV64ZVBC64-NEXT:    vand.vx v8, v16, a2
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 6
 ; RV64ZVBC64-NEXT:    add a1, sp, a1
 ; RV64ZVBC64-NEXT:    addi a1, a1, 16
 ; RV64ZVBC64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v0, v24, 4
-; RV64ZVBC64-NEXT:    vmul.vv v8, v16, v0
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 3
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v8, v24, 8
-; RV64ZVBC64-NEXT:    vmul.vv v8, v16, v8
-; RV64ZVBC64-NEXT:    addi a1, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 4
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 3
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v8
-; RV64ZVBC64-NEXT:    addi a1, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v8, v0, v8
-; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 4
-; RV64ZVBC64-NEXT:    add a1, sp, a1
-; RV64ZVBC64-NEXT:    addi a1, a1, 16
-; RV64ZVBC64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vx v0, v24, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v16, v0
+; RV64ZVBC64-NEXT:    lui a1, 5
+; RV64ZVBC64-NEXT:    addi a1, a1, -1756
+; RV64ZVBC64-NEXT:    vand.vx v8, v16, a1
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a4, a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v8, v0, a2
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v16, v0, a0
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a1
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 6
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v16, v24
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a4, a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v0, v24
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v24, v8, v24
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v24, v24, v8
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a4, a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v16, v24
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 6
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v0, v24
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v24, v24, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v0, v24, a2
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 5
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v24, v24, a0
+; RV64ZVBC64-NEXT:    vor.vv v24, v24, v0
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, a0, a2
 ; RV64ZVBC64-NEXT:    add a0, sp, a0
 ; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v8, v24, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v16, v8
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v8, (a0) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 6
+; RV64ZVBC64-NEXT:    add a0, sp, a0
+; RV64ZVBC64-NEXT:    addi a0, a0, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    add a2, a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    add a0, a0, a2
+; RV64ZVBC64-NEXT:    add a0, sp, a0
+; RV64ZVBC64-NEXT:    addi a0, a0, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v16, v24
+; RV64ZVBC64-NEXT:    csrr a0, vlenb
+; RV64ZVBC64-NEXT:    slli a0, a0, 4
+; RV64ZVBC64-NEXT:    mv a2, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    add a0, a0, a2
+; RV64ZVBC64-NEXT:    add a0, sp, a0
+; RV64ZVBC64-NEXT:    addi a0, a0, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 4
 ; RV64ZVBC64-NEXT:    add a0, sp, a0
 ; RV64ZVBC64-NEXT:    addi a0, a0, 16
 ; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v0, v0, v24
+; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a1, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    add a0, sp, a0
 ; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v8
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v8, v0, v8
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v0, v24, a0
-; RV64ZVBC64-NEXT:    vmul.vv v0, v16, v0
-; RV64ZVBC64-NEXT:    li a0, 128
-; RV64ZVBC64-NEXT:    vand.vx v24, v24, a0
-; RV64ZVBC64-NEXT:    vmul.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v0
-; RV64ZVBC64-NEXT:    vxor.vv v16, v8, v16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vor.vv v16, v16, v8
 ; RV64ZVBC64-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV64ZVBC64-NEXT:    vnsrl.wi v8, v16, 8
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    mv a1, a0
-; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    add sp, sp, a0
 ; RV64ZVBC64-NEXT:    addi sp, sp, 16
@@ -1763,95 +3057,279 @@ define <vscale x 32 x i8> @clmulh_nxv32i8_vx(<vscale x 32 x i8> %va, i8 %b) noun
 ; RV32V-NEXT:    csrr a1, vlenb
 ; RV32V-NEXT:    slli a1, a1, 3
 ; RV32V-NEXT:    mv a2, a1
-; RV32V-NEXT:    slli a1, a1, 1
+; RV32V-NEXT:    slli a1, a1, 3
 ; RV32V-NEXT:    add a1, a1, a2
 ; RV32V-NEXT:    sub sp, sp, a1
-; RV32V-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
+; RV32V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
+; RV32V-NEXT:    vzext.vf2 v16, v8
+; RV32V-NEXT:    lui a1, 2
+; RV32V-NEXT:    addi a1, a1, 1170
+; RV32V-NEXT:    vand.vx v8, v16, a1
+; RV32V-NEXT:    csrr a2, vlenb
+; RV32V-NEXT:    slli a2, a2, 6
+; RV32V-NEXT:    add a2, sp, a2
+; RV32V-NEXT:    addi a2, a2, 16
+; RV32V-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV32V-NEXT:    vmv.v.x v24, a0
 ; RV32V-NEXT:    vsetvli zero, zero, e16, m8, ta, ma
-; RV32V-NEXT:    vzext.vf2 v16, v8
 ; RV32V-NEXT:    vzext.vf2 v8, v24
-; RV32V-NEXT:    vand.vi v24, v8, 2
-; RV32V-NEXT:    vand.vi v0, v8, 1
-; RV32V-NEXT:    vmul.vv v24, v16, v24
-; RV32V-NEXT:    vmul.vv v0, v16, v0
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v0, v8, 4
-; RV32V-NEXT:    vmul.vv v24, v16, v0
+; RV32V-NEXT:    lui a0, 9
+; RV32V-NEXT:    addi a2, a0, 585
+; RV32V-NEXT:    vand.vx v24, v16, a2
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a3, a0
+; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    add a3, a3, a0
+; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    add a0, a0, a3
 ; RV32V-NEXT:    add a0, sp, a0
 ; RV32V-NEXT:    addi a0, a0, 16
 ; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v24, v8, 8
-; RV32V-NEXT:    vmul.vv v24, v16, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    lui a0, 5
+; RV32V-NEXT:    addi a0, a0, -1756
+; RV32V-NEXT:    vand.vx v16, v16, a0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v0, v8, a2
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v24, v8, a1
+; RV32V-NEXT:    vand.vx v16, v8, a0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 6
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a4, a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v24
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v16
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v8, v16, v8
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v8, v8, v16
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 6
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v16
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a4, a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v24
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v8, v0, v8
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v8, v8, v0
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a4, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v0, v8, a1
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 5
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vor.vv v8, v8, v0
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 3
+; RV32V-NEXT:    mv a2, a1
+; RV32V-NEXT:    slli a1, a1, 2
+; RV32V-NEXT:    add a1, a1, a2
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 6
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v8, v24
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 3
+; RV32V-NEXT:    mv a2, a1
+; RV32V-NEXT:    slli a1, a1, 1
+; RV32V-NEXT:    add a2, a2, a1
+; RV32V-NEXT:    slli a1, a1, 1
+; RV32V-NEXT:    add a1, a1, a2
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v8, v16
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 4
+; RV32V-NEXT:    mv a2, a1
+; RV32V-NEXT:    slli a1, a1, 1
+; RV32V-NEXT:    add a1, a1, a2
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a1, vlenb
+; RV32V-NEXT:    slli a1, a1, 4
+; RV32V-NEXT:    add a1, sp, a1
+; RV32V-NEXT:    addi a1, a1, 16
+; RV32V-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v0, v8, v0
+; RV32V-NEXT:    vxor.vv v16, v16, v24
+; RV32V-NEXT:    vxor.vv v16, v16, v0
+; RV32V-NEXT:    vand.vx v16, v16, a0
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a1, a0
+; RV32V-NEXT:    slli a0, a0, 2
+; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    add a0, sp, a0
 ; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 16
-; RV32V-NEXT:    vand.vx v0, v8, a0
-; RV32V-NEXT:    vmul.vv v24, v16, v0
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a0, 32
-; RV32V-NEXT:    vand.vx v24, v8, a0
-; RV32V-NEXT:    vmul.vv v24, v16, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 4
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    add a0, sp, a0
-; RV32V-NEXT:    addi a0, a0, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a0, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    li a0, 64
-; RV32V-NEXT:    vand.vx v0, v8, a0
-; RV32V-NEXT:    vmul.vv v0, v16, v0
-; RV32V-NEXT:    li a0, 128
-; RV32V-NEXT:    vand.vx v8, v8, a0
-; RV32V-NEXT:    vmul.vv v8, v16, v8
-; RV32V-NEXT:    vxor.vv v16, v24, v0
-; RV32V-NEXT:    vxor.vv v16, v16, v8
+; RV32V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vor.vv v16, v8, v16
 ; RV32V-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV32V-NEXT:    vnsrl.wi v8, v16, 8
 ; RV32V-NEXT:    csrr a0, vlenb
 ; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    mv a1, a0
-; RV32V-NEXT:    slli a0, a0, 1
+; RV32V-NEXT:    slli a0, a0, 3
 ; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    add sp, sp, a0
 ; RV32V-NEXT:    addi sp, sp, 16
@@ -1863,95 +3341,279 @@ define <vscale x 32 x i8> @clmulh_nxv32i8_vx(<vscale x 32 x i8> %va, i8 %b) noun
 ; RV64V-NEXT:    csrr a1, vlenb
 ; RV64V-NEXT:    slli a1, a1, 3
 ; RV64V-NEXT:    mv a2, a1
-; RV64V-NEXT:    slli a1, a1, 1
+; RV64V-NEXT:    slli a1, a1, 3
 ; RV64V-NEXT:    add a1, a1, a2
 ; RV64V-NEXT:    sub sp, sp, a1
-; RV64V-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
+; RV64V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
+; RV64V-NEXT:    vzext.vf2 v16, v8
+; RV64V-NEXT:    lui a1, 2
+; RV64V-NEXT:    addi a1, a1, 1170
+; RV64V-NEXT:    vand.vx v8, v16, a1
+; RV64V-NEXT:    csrr a2, vlenb
+; RV64V-NEXT:    slli a2, a2, 6
+; RV64V-NEXT:    add a2, sp, a2
+; RV64V-NEXT:    addi a2, a2, 16
+; RV64V-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV64V-NEXT:    vmv.v.x v24, a0
 ; RV64V-NEXT:    vsetvli zero, zero, e16, m8, ta, ma
-; RV64V-NEXT:    vzext.vf2 v16, v8
 ; RV64V-NEXT:    vzext.vf2 v8, v24
-; RV64V-NEXT:    vand.vi v24, v8, 2
-; RV64V-NEXT:    vand.vi v0, v8, 1
-; RV64V-NEXT:    vmul.vv v24, v16, v24
-; RV64V-NEXT:    vmul.vv v0, v16, v0
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v0, v8, 4
-; RV64V-NEXT:    vmul.vv v24, v16, v0
+; RV64V-NEXT:    lui a0, 9
+; RV64V-NEXT:    addi a2, a0, 585
+; RV64V-NEXT:    vand.vx v24, v16, a2
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a3, a0
+; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    add a3, a3, a0
+; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    add a0, a0, a3
 ; RV64V-NEXT:    add a0, sp, a0
 ; RV64V-NEXT:    addi a0, a0, 16
 ; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v24, v8, 8
-; RV64V-NEXT:    vmul.vv v24, v16, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    lui a0, 5
+; RV64V-NEXT:    addi a0, a0, -1756
+; RV64V-NEXT:    vand.vx v16, v16, a0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v0, v8, a2
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v24, v8, a1
+; RV64V-NEXT:    vand.vx v16, v8, a0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 6
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a4, a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v24
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v16
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v8, v16, v8
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v8, v8, v16
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 6
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v16
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a4, a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v24
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v8, v0, v8
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v8, v8, v0
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a4, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v0, v8, a1
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 5
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vor.vv v8, v8, v0
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 3
+; RV64V-NEXT:    mv a2, a1
+; RV64V-NEXT:    slli a1, a1, 2
+; RV64V-NEXT:    add a1, a1, a2
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 6
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v8, v24
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 3
+; RV64V-NEXT:    mv a2, a1
+; RV64V-NEXT:    slli a1, a1, 1
+; RV64V-NEXT:    add a2, a2, a1
+; RV64V-NEXT:    slli a1, a1, 1
+; RV64V-NEXT:    add a1, a1, a2
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v8, v16
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 4
+; RV64V-NEXT:    mv a2, a1
+; RV64V-NEXT:    slli a1, a1, 1
+; RV64V-NEXT:    add a1, a1, a2
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a1, vlenb
+; RV64V-NEXT:    slli a1, a1, 4
+; RV64V-NEXT:    add a1, sp, a1
+; RV64V-NEXT:    addi a1, a1, 16
+; RV64V-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v0, v8, v0
+; RV64V-NEXT:    vxor.vv v16, v16, v24
+; RV64V-NEXT:    vxor.vv v16, v16, v0
+; RV64V-NEXT:    vand.vx v16, v16, a0
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a1, a0
+; RV64V-NEXT:    slli a0, a0, 2
+; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    add a0, sp, a0
 ; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 16
-; RV64V-NEXT:    vand.vx v0, v8, a0
-; RV64V-NEXT:    vmul.vv v24, v16, v0
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a0, 32
-; RV64V-NEXT:    vand.vx v24, v8, a0
-; RV64V-NEXT:    vmul.vv v24, v16, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 4
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    add a0, sp, a0
-; RV64V-NEXT:    addi a0, a0, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a0, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    li a0, 64
-; RV64V-NEXT:    vand.vx v0, v8, a0
-; RV64V-NEXT:    vmul.vv v0, v16, v0
-; RV64V-NEXT:    li a0, 128
-; RV64V-NEXT:    vand.vx v8, v8, a0
-; RV64V-NEXT:    vmul.vv v8, v16, v8
-; RV64V-NEXT:    vxor.vv v16, v24, v0
-; RV64V-NEXT:    vxor.vv v16, v16, v8
+; RV64V-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vor.vv v16, v8, v16
 ; RV64V-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV64V-NEXT:    vnsrl.wi v8, v16, 8
 ; RV64V-NEXT:    csrr a0, vlenb
 ; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    mv a1, a0
-; RV64V-NEXT:    slli a0, a0, 1
+; RV64V-NEXT:    slli a0, a0, 3
 ; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    add sp, sp, a0
 ; RV64V-NEXT:    addi sp, sp, 16
@@ -1963,95 +3625,279 @@ define <vscale x 32 x i8> @clmulh_nxv32i8_vx(<vscale x 32 x i8> %va, i8 %b) noun
 ; RV32ZVBC64-NEXT:    csrr a1, vlenb
 ; RV32ZVBC64-NEXT:    slli a1, a1, 3
 ; RV32ZVBC64-NEXT:    mv a2, a1
-; RV32ZVBC64-NEXT:    slli a1, a1, 1
+; RV32ZVBC64-NEXT:    slli a1, a1, 3
 ; RV32ZVBC64-NEXT:    add a1, a1, a2
 ; RV32ZVBC64-NEXT:    sub sp, sp, a1
-; RV32ZVBC64-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
+; RV32ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
+; RV32ZVBC64-NEXT:    vzext.vf2 v16, v8
+; RV32ZVBC64-NEXT:    lui a1, 2
+; RV32ZVBC64-NEXT:    addi a1, a1, 1170
+; RV32ZVBC64-NEXT:    vand.vx v8, v16, a1
+; RV32ZVBC64-NEXT:    csrr a2, vlenb
+; RV32ZVBC64-NEXT:    slli a2, a2, 6
+; RV32ZVBC64-NEXT:    add a2, sp, a2
+; RV32ZVBC64-NEXT:    addi a2, a2, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV32ZVBC64-NEXT:    vmv.v.x v24, a0
 ; RV32ZVBC64-NEXT:    vsetvli zero, zero, e16, m8, ta, ma
-; RV32ZVBC64-NEXT:    vzext.vf2 v16, v8
 ; RV32ZVBC64-NEXT:    vzext.vf2 v8, v24
-; RV32ZVBC64-NEXT:    vand.vi v24, v8, 2
-; RV32ZVBC64-NEXT:    vand.vi v0, v8, 1
-; RV32ZVBC64-NEXT:    vmul.vv v24, v16, v24
-; RV32ZVBC64-NEXT:    vmul.vv v0, v16, v0
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v0, v8, 4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v16, v0
+; RV32ZVBC64-NEXT:    lui a0, 9
+; RV32ZVBC64-NEXT:    addi a2, a0, 585
+; RV32ZVBC64-NEXT:    vand.vx v24, v16, a2
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a3, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    add a0, a0, a3
 ; RV32ZVBC64-NEXT:    add a0, sp, a0
 ; RV32ZVBC64-NEXT:    addi a0, a0, 16
 ; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v24, v8, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v16, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    lui a0, 5
+; RV32ZVBC64-NEXT:    addi a0, a0, -1756
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v0, v8, a2
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v24, v8, a1
+; RV32ZVBC64-NEXT:    vand.vx v16, v8, a0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 6
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a4, a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v16
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 6
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a4, a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a4, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v0, v8, a1
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 5
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 3
+; RV32ZVBC64-NEXT:    mv a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 2
+; RV32ZVBC64-NEXT:    add a1, a1, a2
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 6
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 3
+; RV32ZVBC64-NEXT:    mv a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 1
+; RV32ZVBC64-NEXT:    add a2, a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 1
+; RV32ZVBC64-NEXT:    add a1, a1, a2
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v8, v16
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 4
+; RV32ZVBC64-NEXT:    mv a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 1
+; RV32ZVBC64-NEXT:    add a1, a1, a2
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a1, vlenb
+; RV32ZVBC64-NEXT:    slli a1, a1, 4
+; RV32ZVBC64-NEXT:    add a1, sp, a1
+; RV32ZVBC64-NEXT:    addi a1, a1, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
+; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v24
+; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v0
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a1, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 2
+; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    add a0, sp, a0
 ; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 16
-; RV32ZVBC64-NEXT:    vand.vx v0, v8, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v16, v0
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a0, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v8, a0
-; RV32ZVBC64-NEXT:    vmul.vv v24, v16, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 4
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    add a0, sp, a0
-; RV32ZVBC64-NEXT:    addi a0, a0, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a0, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    li a0, 64
-; RV32ZVBC64-NEXT:    vand.vx v0, v8, a0
-; RV32ZVBC64-NEXT:    vmul.vv v0, v16, v0
-; RV32ZVBC64-NEXT:    li a0, 128
-; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
-; RV32ZVBC64-NEXT:    vmul.vv v8, v16, v8
-; RV32ZVBC64-NEXT:    vxor.vv v16, v24, v0
-; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v8
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vor.vv v16, v8, v16
 ; RV32ZVBC64-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV32ZVBC64-NEXT:    vnsrl.wi v8, v16, 8
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
 ; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    mv a1, a0
-; RV32ZVBC64-NEXT:    slli a0, a0, 1
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
 ; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    add sp, sp, a0
 ; RV32ZVBC64-NEXT:    addi sp, sp, 16
@@ -2063,95 +3909,279 @@ define <vscale x 32 x i8> @clmulh_nxv32i8_vx(<vscale x 32 x i8> %va, i8 %b) noun
 ; RV64ZVBC64-NEXT:    csrr a1, vlenb
 ; RV64ZVBC64-NEXT:    slli a1, a1, 3
 ; RV64ZVBC64-NEXT:    mv a2, a1
-; RV64ZVBC64-NEXT:    slli a1, a1, 1
+; RV64ZVBC64-NEXT:    slli a1, a1, 3
 ; RV64ZVBC64-NEXT:    add a1, a1, a2
 ; RV64ZVBC64-NEXT:    sub sp, sp, a1
-; RV64ZVBC64-NEXT:    vsetvli a1, zero, e8, m4, ta, ma
+; RV64ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
+; RV64ZVBC64-NEXT:    vzext.vf2 v16, v8
+; RV64ZVBC64-NEXT:    lui a1, 2
+; RV64ZVBC64-NEXT:    addi a1, a1, 1170
+; RV64ZVBC64-NEXT:    vand.vx v8, v16, a1
+; RV64ZVBC64-NEXT:    csrr a2, vlenb
+; RV64ZVBC64-NEXT:    slli a2, a2, 6
+; RV64ZVBC64-NEXT:    add a2, sp, a2
+; RV64ZVBC64-NEXT:    addi a2, a2, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a2) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV64ZVBC64-NEXT:    vmv.v.x v24, a0
 ; RV64ZVBC64-NEXT:    vsetvli zero, zero, e16, m8, ta, ma
-; RV64ZVBC64-NEXT:    vzext.vf2 v16, v8
 ; RV64ZVBC64-NEXT:    vzext.vf2 v8, v24
-; RV64ZVBC64-NEXT:    vand.vi v24, v8, 2
-; RV64ZVBC64-NEXT:    vand.vi v0, v8, 1
-; RV64ZVBC64-NEXT:    vmul.vv v24, v16, v24
-; RV64ZVBC64-NEXT:    vmul.vv v0, v16, v0
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v0, v8, 4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v16, v0
+; RV64ZVBC64-NEXT:    lui a0, 9
+; RV64ZVBC64-NEXT:    addi a2, a0, 585
+; RV64ZVBC64-NEXT:    vand.vx v24, v16, a2
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a3, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    add a0, a0, a3
 ; RV64ZVBC64-NEXT:    add a0, sp, a0
 ; RV64ZVBC64-NEXT:    addi a0, a0, 16
 ; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v24, v8, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v16, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    lui a0, 5
+; RV64ZVBC64-NEXT:    addi a0, a0, -1756
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v0, v8, a2
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v24, v8, a1
+; RV64ZVBC64-NEXT:    vand.vx v16, v8, a0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 6
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a4, a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v16
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 6
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a4, a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v8, v0, v8
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a4, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v0, v8, a1
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 5
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 3
+; RV64ZVBC64-NEXT:    mv a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 2
+; RV64ZVBC64-NEXT:    add a1, a1, a2
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a1) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 6
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 3
+; RV64ZVBC64-NEXT:    mv a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 1
+; RV64ZVBC64-NEXT:    add a2, a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 1
+; RV64ZVBC64-NEXT:    add a1, a1, a2
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v8, v16
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 4
+; RV64ZVBC64-NEXT:    mv a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 1
+; RV64ZVBC64-NEXT:    add a1, a1, a2
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a1) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a1, vlenb
+; RV64ZVBC64-NEXT:    slli a1, a1, 4
+; RV64ZVBC64-NEXT:    add a1, sp, a1
+; RV64ZVBC64-NEXT:    addi a1, a1, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a1) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
+; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v24
+; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v0
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a1, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 2
+; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    add a0, sp, a0
 ; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 16
-; RV64ZVBC64-NEXT:    vand.vx v0, v8, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v16, v0
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a0, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v8, a0
-; RV64ZVBC64-NEXT:    vmul.vv v24, v16, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a0) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 4
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    add a0, sp, a0
-; RV64ZVBC64-NEXT:    addi a0, a0, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a0, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a0) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    li a0, 64
-; RV64ZVBC64-NEXT:    vand.vx v0, v8, a0
-; RV64ZVBC64-NEXT:    vmul.vv v0, v16, v0
-; RV64ZVBC64-NEXT:    li a0, 128
-; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
-; RV64ZVBC64-NEXT:    vmul.vv v8, v16, v8
-; RV64ZVBC64-NEXT:    vxor.vv v16, v24, v0
-; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v8
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a0) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vor.vv v16, v8, v16
 ; RV64ZVBC64-NEXT:    vsetvli zero, zero, e8, m4, ta, ma
 ; RV64ZVBC64-NEXT:    vnsrl.wi v8, v16, 8
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
 ; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    mv a1, a0
-; RV64ZVBC64-NEXT:    slli a0, a0, 1
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
 ; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    add sp, sp, a0
 ; RV64ZVBC64-NEXT:    addi sp, sp, 16
@@ -2183,27 +4213,10 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV32V:       # %bb.0:
 ; RV32V-NEXT:    addi sp, sp, -16
 ; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    mv a1, a0
-; RV32V-NEXT:    slli a0, a0, 1
-; RV32V-NEXT:    add a0, a0, a1
+; RV32V-NEXT:    slli a0, a0, 4
 ; RV32V-NEXT:    sub sp, sp, a0
 ; RV32V-NEXT:    li a0, 51
 ; RV32V-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV32V-NEXT:    vsll.vi v24, v8, 4
-; RV32V-NEXT:    vsrl.vi v8, v8, 4
-; RV32V-NEXT:    vor.vv v8, v8, v24
-; RV32V-NEXT:    vsrl.vi v24, v8, 2
-; RV32V-NEXT:    vand.vx v24, v24, a0
-; RV32V-NEXT:    vand.vx v8, v8, a0
-; RV32V-NEXT:    vsll.vi v8, v8, 2
-; RV32V-NEXT:    vor.vv v8, v24, v8
-; RV32V-NEXT:    vsrl.vi v24, v8, 1
-; RV32V-NEXT:    li a1, 85
-; RV32V-NEXT:    vand.vx v24, v24, a1
-; RV32V-NEXT:    vand.vx v8, v8, a1
-; RV32V-NEXT:    vadd.vv v8, v8, v8
-; RV32V-NEXT:    vor.vv v8, v24, v8
 ; RV32V-NEXT:    vsll.vi v24, v16, 4
 ; RV32V-NEXT:    vsrl.vi v16, v16, 4
 ; RV32V-NEXT:    vor.vv v16, v16, v24
@@ -2213,91 +4226,58 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV32V-NEXT:    vsll.vi v16, v16, 2
 ; RV32V-NEXT:    vor.vv v16, v24, v16
 ; RV32V-NEXT:    vsrl.vi v24, v16, 1
+; RV32V-NEXT:    li a1, 85
 ; RV32V-NEXT:    vand.vx v24, v24, a1
 ; RV32V-NEXT:    vand.vx v16, v16, a1
 ; RV32V-NEXT:    vadd.vv v16, v16, v16
-; RV32V-NEXT:    vor.vv v16, v24, v16
-; RV32V-NEXT:    vand.vi v24, v16, 2
-; RV32V-NEXT:    vand.vi v0, v16, 1
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 4
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v0, v16, 4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
+; RV32V-NEXT:    vor.vv v24, v24, v16
+; RV32V-NEXT:    vand.vx v16, v24, a1
 ; RV32V-NEXT:    csrr a2, vlenb
 ; RV32V-NEXT:    slli a2, a2, 3
 ; RV32V-NEXT:    add a2, sp, a2
 ; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v24, v16, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a2, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 4
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 3
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a2, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 4
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a2, 16
-; RV32V-NEXT:    vand.vx v0, v16, a2
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 3
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a2, 32
-; RV32V-NEXT:    vand.vx v24, v16, a2
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a2, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 4
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 3
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a2, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    li a2, 64
-; RV32V-NEXT:    vand.vx v0, v16, a2
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    li a2, 128
-; RV32V-NEXT:    vand.vx v16, v16, a2
+; RV32V-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vsll.vi v0, v8, 4
+; RV32V-NEXT:    vsrl.vi v8, v8, 4
+; RV32V-NEXT:    vor.vv v8, v8, v0
+; RV32V-NEXT:    vsrl.vi v0, v8, 2
+; RV32V-NEXT:    vand.vx v0, v0, a0
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vsll.vi v8, v8, 2
+; RV32V-NEXT:    vor.vv v8, v0, v8
+; RV32V-NEXT:    vsrl.vi v0, v8, 1
+; RV32V-NEXT:    vand.vx v0, v0, a1
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vadd.vv v8, v8, v8
+; RV32V-NEXT:    vor.vv v8, v0, v8
+; RV32V-NEXT:    li a2, 170
+; RV32V-NEXT:    vand.vx v16, v8, a2
+; RV32V-NEXT:    vand.vx v24, v24, a2
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v0, v16, v0
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v0, v8, v24
+; RV32V-NEXT:    vmul.vv v24, v16, v24
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    vmul.vv v8, v8, v16
-; RV32V-NEXT:    vxor.vv v16, v24, v0
-; RV32V-NEXT:    vxor.vv v8, v16, v8
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 4
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vsll.vi v16, v16, 4
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v16, v0, v16
+; RV32V-NEXT:    vxor.vv v8, v8, v24
+; RV32V-NEXT:    vand.vx v16, v16, a2
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vor.vv v8, v8, v16
+; RV32V-NEXT:    vsll.vi v16, v8, 4
 ; RV32V-NEXT:    vsrl.vi v8, v8, 4
 ; RV32V-NEXT:    vor.vv v8, v8, v16
 ; RV32V-NEXT:    vsrl.vi v16, v8, 2
@@ -2312,10 +4292,7 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV32V-NEXT:    vor.vv v8, v16, v8
 ; RV32V-NEXT:    vsrl.vi v8, v8, 1
 ; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 3
-; RV32V-NEXT:    mv a1, a0
-; RV32V-NEXT:    slli a0, a0, 1
-; RV32V-NEXT:    add a0, a0, a1
+; RV32V-NEXT:    slli a0, a0, 4
 ; RV32V-NEXT:    add sp, sp, a0
 ; RV32V-NEXT:    addi sp, sp, 16
 ; RV32V-NEXT:    ret
@@ -2324,27 +4301,10 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    addi sp, sp, -16
 ; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    mv a1, a0
-; RV64V-NEXT:    slli a0, a0, 1
-; RV64V-NEXT:    add a0, a0, a1
+; RV64V-NEXT:    slli a0, a0, 4
 ; RV64V-NEXT:    sub sp, sp, a0
 ; RV64V-NEXT:    li a0, 51
 ; RV64V-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV64V-NEXT:    vsll.vi v24, v8, 4
-; RV64V-NEXT:    vsrl.vi v8, v8, 4
-; RV64V-NEXT:    vor.vv v8, v8, v24
-; RV64V-NEXT:    vsrl.vi v24, v8, 2
-; RV64V-NEXT:    vand.vx v24, v24, a0
-; RV64V-NEXT:    vand.vx v8, v8, a0
-; RV64V-NEXT:    vsll.vi v8, v8, 2
-; RV64V-NEXT:    vor.vv v8, v24, v8
-; RV64V-NEXT:    vsrl.vi v24, v8, 1
-; RV64V-NEXT:    li a1, 85
-; RV64V-NEXT:    vand.vx v24, v24, a1
-; RV64V-NEXT:    vand.vx v8, v8, a1
-; RV64V-NEXT:    vadd.vv v8, v8, v8
-; RV64V-NEXT:    vor.vv v8, v24, v8
 ; RV64V-NEXT:    vsll.vi v24, v16, 4
 ; RV64V-NEXT:    vsrl.vi v16, v16, 4
 ; RV64V-NEXT:    vor.vv v16, v16, v24
@@ -2354,91 +4314,58 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV64V-NEXT:    vsll.vi v16, v16, 2
 ; RV64V-NEXT:    vor.vv v16, v24, v16
 ; RV64V-NEXT:    vsrl.vi v24, v16, 1
+; RV64V-NEXT:    li a1, 85
 ; RV64V-NEXT:    vand.vx v24, v24, a1
 ; RV64V-NEXT:    vand.vx v16, v16, a1
 ; RV64V-NEXT:    vadd.vv v16, v16, v16
-; RV64V-NEXT:    vor.vv v16, v24, v16
-; RV64V-NEXT:    vand.vi v24, v16, 2
-; RV64V-NEXT:    vand.vi v0, v16, 1
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 4
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v0, v16, 4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
+; RV64V-NEXT:    vor.vv v24, v24, v16
+; RV64V-NEXT:    vand.vx v16, v24, a1
 ; RV64V-NEXT:    csrr a2, vlenb
 ; RV64V-NEXT:    slli a2, a2, 3
 ; RV64V-NEXT:    add a2, sp, a2
 ; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v24, v16, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a2, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 4
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 3
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a2, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 4
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a2, 16
-; RV64V-NEXT:    vand.vx v0, v16, a2
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 3
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a2, 32
-; RV64V-NEXT:    vand.vx v24, v16, a2
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a2, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 4
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 3
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a2, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    li a2, 64
-; RV64V-NEXT:    vand.vx v0, v16, a2
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    li a2, 128
-; RV64V-NEXT:    vand.vx v16, v16, a2
+; RV64V-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vsll.vi v0, v8, 4
+; RV64V-NEXT:    vsrl.vi v8, v8, 4
+; RV64V-NEXT:    vor.vv v8, v8, v0
+; RV64V-NEXT:    vsrl.vi v0, v8, 2
+; RV64V-NEXT:    vand.vx v0, v0, a0
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vsll.vi v8, v8, 2
+; RV64V-NEXT:    vor.vv v8, v0, v8
+; RV64V-NEXT:    vsrl.vi v0, v8, 1
+; RV64V-NEXT:    vand.vx v0, v0, a1
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vadd.vv v8, v8, v8
+; RV64V-NEXT:    vor.vv v8, v0, v8
+; RV64V-NEXT:    li a2, 170
+; RV64V-NEXT:    vand.vx v16, v8, a2
+; RV64V-NEXT:    vand.vx v24, v24, a2
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v0, v16, v0
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v0, v8, v24
+; RV64V-NEXT:    vmul.vv v24, v16, v24
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    vmul.vv v8, v8, v16
-; RV64V-NEXT:    vxor.vv v16, v24, v0
-; RV64V-NEXT:    vxor.vv v8, v16, v8
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 4
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vsll.vi v16, v16, 4
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v16, v0, v16
+; RV64V-NEXT:    vxor.vv v8, v8, v24
+; RV64V-NEXT:    vand.vx v16, v16, a2
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vor.vv v8, v8, v16
+; RV64V-NEXT:    vsll.vi v16, v8, 4
 ; RV64V-NEXT:    vsrl.vi v8, v8, 4
 ; RV64V-NEXT:    vor.vv v8, v8, v16
 ; RV64V-NEXT:    vsrl.vi v16, v8, 2
@@ -2453,10 +4380,7 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV64V-NEXT:    vor.vv v8, v16, v8
 ; RV64V-NEXT:    vsrl.vi v8, v8, 1
 ; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 3
-; RV64V-NEXT:    mv a1, a0
-; RV64V-NEXT:    slli a0, a0, 1
-; RV64V-NEXT:    add a0, a0, a1
+; RV64V-NEXT:    slli a0, a0, 4
 ; RV64V-NEXT:    add sp, sp, a0
 ; RV64V-NEXT:    addi sp, sp, 16
 ; RV64V-NEXT:    ret
@@ -2465,27 +4389,10 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV32ZVBC64:       # %bb.0:
 ; RV32ZVBC64-NEXT:    addi sp, sp, -16
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    mv a1, a0
-; RV32ZVBC64-NEXT:    slli a0, a0, 1
-; RV32ZVBC64-NEXT:    add a0, a0, a1
+; RV32ZVBC64-NEXT:    slli a0, a0, 4
 ; RV32ZVBC64-NEXT:    sub sp, sp, a0
 ; RV32ZVBC64-NEXT:    li a0, 51
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV32ZVBC64-NEXT:    vsll.vi v24, v8, 4
-; RV32ZVBC64-NEXT:    vsrl.vi v8, v8, 4
-; RV32ZVBC64-NEXT:    vor.vv v8, v8, v24
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v8, 2
-; RV32ZVBC64-NEXT:    vand.vx v24, v24, a0
-; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
-; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 2
-; RV32ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v8, 1
-; RV32ZVBC64-NEXT:    li a1, 85
-; RV32ZVBC64-NEXT:    vand.vx v24, v24, a1
-; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
-; RV32ZVBC64-NEXT:    vadd.vv v8, v8, v8
-; RV32ZVBC64-NEXT:    vor.vv v8, v24, v8
 ; RV32ZVBC64-NEXT:    vsll.vi v24, v16, 4
 ; RV32ZVBC64-NEXT:    vsrl.vi v16, v16, 4
 ; RV32ZVBC64-NEXT:    vor.vv v16, v16, v24
@@ -2495,91 +4402,58 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV32ZVBC64-NEXT:    vsll.vi v16, v16, 2
 ; RV32ZVBC64-NEXT:    vor.vv v16, v24, v16
 ; RV32ZVBC64-NEXT:    vsrl.vi v24, v16, 1
+; RV32ZVBC64-NEXT:    li a1, 85
 ; RV32ZVBC64-NEXT:    vand.vx v24, v24, a1
 ; RV32ZVBC64-NEXT:    vand.vx v16, v16, a1
 ; RV32ZVBC64-NEXT:    vadd.vv v16, v16, v16
-; RV32ZVBC64-NEXT:    vor.vv v16, v24, v16
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 4
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
+; RV32ZVBC64-NEXT:    vor.vv v24, v24, v16
+; RV32ZVBC64-NEXT:    vand.vx v16, v24, a1
 ; RV32ZVBC64-NEXT:    csrr a2, vlenb
 ; RV32ZVBC64-NEXT:    slli a2, a2, 3
 ; RV32ZVBC64-NEXT:    add a2, sp, a2
 ; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a2, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 4
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 3
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a2, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 4
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a2, 16
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a2
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 3
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a2, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a2
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a2, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 4
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 3
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a2, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    li a2, 64
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a2
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    li a2, 128
-; RV32ZVBC64-NEXT:    vand.vx v16, v16, a2
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vsll.vi v0, v8, 4
+; RV32ZVBC64-NEXT:    vsrl.vi v8, v8, 4
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    vsrl.vi v0, v8, 2
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a0
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 2
+; RV32ZVBC64-NEXT:    vor.vv v8, v0, v8
+; RV32ZVBC64-NEXT:    vsrl.vi v0, v8, 1
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a1
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV32ZVBC64-NEXT:    vadd.vv v8, v8, v8
+; RV32ZVBC64-NEXT:    vor.vv v8, v0, v8
+; RV32ZVBC64-NEXT:    li a2, 170
+; RV32ZVBC64-NEXT:    vand.vx v16, v8, a2
+; RV32ZVBC64-NEXT:    vand.vx v24, v24, a2
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v24
+; RV32ZVBC64-NEXT:    vmul.vv v24, v16, v24
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v16, v24, v0
-; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 4
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vsll.vi v16, v16, 4
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v16, v0, v16
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v24
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a2
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v16
+; RV32ZVBC64-NEXT:    vsll.vi v16, v8, 4
 ; RV32ZVBC64-NEXT:    vsrl.vi v8, v8, 4
 ; RV32ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 2
@@ -2594,10 +4468,7 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
 ; RV32ZVBC64-NEXT:    vsrl.vi v8, v8, 1
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 3
-; RV32ZVBC64-NEXT:    mv a1, a0
-; RV32ZVBC64-NEXT:    slli a0, a0, 1
-; RV32ZVBC64-NEXT:    add a0, a0, a1
+; RV32ZVBC64-NEXT:    slli a0, a0, 4
 ; RV32ZVBC64-NEXT:    add sp, sp, a0
 ; RV32ZVBC64-NEXT:    addi sp, sp, 16
 ; RV32ZVBC64-NEXT:    ret
@@ -2606,27 +4477,10 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV64ZVBC64:       # %bb.0:
 ; RV64ZVBC64-NEXT:    addi sp, sp, -16
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    mv a1, a0
-; RV64ZVBC64-NEXT:    slli a0, a0, 1
-; RV64ZVBC64-NEXT:    add a0, a0, a1
+; RV64ZVBC64-NEXT:    slli a0, a0, 4
 ; RV64ZVBC64-NEXT:    sub sp, sp, a0
 ; RV64ZVBC64-NEXT:    li a0, 51
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e8, m8, ta, ma
-; RV64ZVBC64-NEXT:    vsll.vi v24, v8, 4
-; RV64ZVBC64-NEXT:    vsrl.vi v8, v8, 4
-; RV64ZVBC64-NEXT:    vor.vv v8, v8, v24
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v8, 2
-; RV64ZVBC64-NEXT:    vand.vx v24, v24, a0
-; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
-; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 2
-; RV64ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v8, 1
-; RV64ZVBC64-NEXT:    li a1, 85
-; RV64ZVBC64-NEXT:    vand.vx v24, v24, a1
-; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
-; RV64ZVBC64-NEXT:    vadd.vv v8, v8, v8
-; RV64ZVBC64-NEXT:    vor.vv v8, v24, v8
 ; RV64ZVBC64-NEXT:    vsll.vi v24, v16, 4
 ; RV64ZVBC64-NEXT:    vsrl.vi v16, v16, 4
 ; RV64ZVBC64-NEXT:    vor.vv v16, v16, v24
@@ -2636,91 +4490,58 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV64ZVBC64-NEXT:    vsll.vi v16, v16, 2
 ; RV64ZVBC64-NEXT:    vor.vv v16, v24, v16
 ; RV64ZVBC64-NEXT:    vsrl.vi v24, v16, 1
+; RV64ZVBC64-NEXT:    li a1, 85
 ; RV64ZVBC64-NEXT:    vand.vx v24, v24, a1
 ; RV64ZVBC64-NEXT:    vand.vx v16, v16, a1
 ; RV64ZVBC64-NEXT:    vadd.vv v16, v16, v16
-; RV64ZVBC64-NEXT:    vor.vv v16, v24, v16
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 4
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
+; RV64ZVBC64-NEXT:    vor.vv v24, v24, v16
+; RV64ZVBC64-NEXT:    vand.vx v16, v24, a1
 ; RV64ZVBC64-NEXT:    csrr a2, vlenb
 ; RV64ZVBC64-NEXT:    slli a2, a2, 3
 ; RV64ZVBC64-NEXT:    add a2, sp, a2
 ; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a2, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 4
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 3
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a2, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 4
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a2, 16
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a2
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 3
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a2, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a2
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a2, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 4
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 3
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a2, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    li a2, 64
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a2
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    li a2, 128
-; RV64ZVBC64-NEXT:    vand.vx v16, v16, a2
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a2) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vsll.vi v0, v8, 4
+; RV64ZVBC64-NEXT:    vsrl.vi v8, v8, 4
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    vsrl.vi v0, v8, 2
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a0
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 2
+; RV64ZVBC64-NEXT:    vor.vv v8, v0, v8
+; RV64ZVBC64-NEXT:    vsrl.vi v0, v8, 1
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a1
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV64ZVBC64-NEXT:    vadd.vv v8, v8, v8
+; RV64ZVBC64-NEXT:    vor.vv v8, v0, v8
+; RV64ZVBC64-NEXT:    li a2, 170
+; RV64ZVBC64-NEXT:    vand.vx v16, v8, a2
+; RV64ZVBC64-NEXT:    vand.vx v24, v24, a2
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v24
+; RV64ZVBC64-NEXT:    vmul.vv v24, v16, v24
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v16, v24, v0
-; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 4
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vsll.vi v16, v16, 4
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v16, v0, v16
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v24
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a2
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v16
+; RV64ZVBC64-NEXT:    vsll.vi v16, v8, 4
 ; RV64ZVBC64-NEXT:    vsrl.vi v8, v8, 4
 ; RV64ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 2
@@ -2735,10 +4556,7 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vv(<vscale x 64 x i8> %va, <vscale x 6
 ; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
 ; RV64ZVBC64-NEXT:    vsrl.vi v8, v8, 1
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 3
-; RV64ZVBC64-NEXT:    mv a1, a0
-; RV64ZVBC64-NEXT:    slli a0, a0, 1
-; RV64ZVBC64-NEXT:    add a0, a0, a1
+; RV64ZVBC64-NEXT:    slli a0, a0, 4
 ; RV64ZVBC64-NEXT:    add sp, sp, a0
 ; RV64ZVBC64-NEXT:    addi sp, sp, 16
 ; RV64ZVBC64-NEXT:    ret
@@ -2788,101 +4606,64 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vx(<vscale x 64 x i8> %va, i8 %b) noun
 ; RV32V-NEXT:    vand.vx v24, v24, a1
 ; RV32V-NEXT:    vand.vx v8, v8, a1
 ; RV32V-NEXT:    vadd.vv v8, v8, v8
-; RV32V-NEXT:    vor.vv v8, v24, v8
-; RV32V-NEXT:    vsll.vi v24, v16, 4
+; RV32V-NEXT:    vor.vv v24, v24, v8
+; RV32V-NEXT:    li a2, 170
+; RV32V-NEXT:    vand.vx v8, v24, a2
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vsll.vi v0, v16, 4
 ; RV32V-NEXT:    vsrl.vi v16, v16, 4
-; RV32V-NEXT:    vor.vv v16, v16, v24
-; RV32V-NEXT:    vsrl.vi v24, v16, 2
-; RV32V-NEXT:    vand.vx v24, v24, a0
+; RV32V-NEXT:    vor.vv v16, v16, v0
+; RV32V-NEXT:    vsrl.vi v0, v16, 2
+; RV32V-NEXT:    vand.vx v0, v0, a0
 ; RV32V-NEXT:    vand.vx v16, v16, a0
 ; RV32V-NEXT:    vsll.vi v16, v16, 2
-; RV32V-NEXT:    vor.vv v16, v24, v16
-; RV32V-NEXT:    vsrl.vi v24, v16, 1
-; RV32V-NEXT:    vand.vx v24, v24, a1
+; RV32V-NEXT:    vor.vv v16, v0, v16
+; RV32V-NEXT:    vsrl.vi v0, v16, 1
+; RV32V-NEXT:    vand.vx v0, v0, a1
 ; RV32V-NEXT:    vand.vx v16, v16, a1
 ; RV32V-NEXT:    vadd.vv v16, v16, v16
-; RV32V-NEXT:    vor.vv v16, v24, v16
-; RV32V-NEXT:    vand.vi v24, v16, 2
-; RV32V-NEXT:    vand.vi v0, v16, 1
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 4
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v0, v16, 4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 3
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v24, v16, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a2, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 4
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 3
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a2, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 4
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a2, 16
-; RV32V-NEXT:    vand.vx v0, v16, a2
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 3
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a2, 32
-; RV32V-NEXT:    vand.vx v24, v16, a2
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a2, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 4
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 3
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a2, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    li a2, 64
-; RV32V-NEXT:    vand.vx v0, v16, a2
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    li a2, 128
-; RV32V-NEXT:    vand.vx v16, v16, a2
-; RV32V-NEXT:    vmul.vv v8, v8, v16
-; RV32V-NEXT:    vxor.vv v16, v24, v0
-; RV32V-NEXT:    vxor.vv v8, v16, v8
-; RV32V-NEXT:    csrr a2, vlenb
-; RV32V-NEXT:    slli a2, a2, 4
-; RV32V-NEXT:    add a2, sp, a2
-; RV32V-NEXT:    addi a2, a2, 16
-; RV32V-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vsll.vi v16, v16, 4
+; RV32V-NEXT:    vor.vv v0, v0, v16
+; RV32V-NEXT:    vand.vx v8, v0, a1
+; RV32V-NEXT:    vand.vx v24, v24, a1
+; RV32V-NEXT:    vand.vx v0, v0, a2
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v16, v8
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vmul.vv v16, v24, v0
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v0, v16, v0
+; RV32V-NEXT:    vmul.vv v16, v24, v8
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    addi a3, sp, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v8, v24, v8
+; RV32V-NEXT:    vxor.vv v16, v16, v0
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vand.vx v16, v16, a1
+; RV32V-NEXT:    vor.vv v8, v16, v8
+; RV32V-NEXT:    vsll.vi v16, v8, 4
 ; RV32V-NEXT:    vsrl.vi v8, v8, 4
 ; RV32V-NEXT:    vor.vv v8, v8, v16
 ; RV32V-NEXT:    vsrl.vi v16, v8, 2
@@ -2930,101 +4711,64 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vx(<vscale x 64 x i8> %va, i8 %b) noun
 ; RV64V-NEXT:    vand.vx v24, v24, a1
 ; RV64V-NEXT:    vand.vx v8, v8, a1
 ; RV64V-NEXT:    vadd.vv v8, v8, v8
-; RV64V-NEXT:    vor.vv v8, v24, v8
-; RV64V-NEXT:    vsll.vi v24, v16, 4
+; RV64V-NEXT:    vor.vv v24, v24, v8
+; RV64V-NEXT:    li a2, 170
+; RV64V-NEXT:    vand.vx v8, v24, a2
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vsll.vi v0, v16, 4
 ; RV64V-NEXT:    vsrl.vi v16, v16, 4
-; RV64V-NEXT:    vor.vv v16, v16, v24
-; RV64V-NEXT:    vsrl.vi v24, v16, 2
-; RV64V-NEXT:    vand.vx v24, v24, a0
+; RV64V-NEXT:    vor.vv v16, v16, v0
+; RV64V-NEXT:    vsrl.vi v0, v16, 2
+; RV64V-NEXT:    vand.vx v0, v0, a0
 ; RV64V-NEXT:    vand.vx v16, v16, a0
 ; RV64V-NEXT:    vsll.vi v16, v16, 2
-; RV64V-NEXT:    vor.vv v16, v24, v16
-; RV64V-NEXT:    vsrl.vi v24, v16, 1
-; RV64V-NEXT:    vand.vx v24, v24, a1
+; RV64V-NEXT:    vor.vv v16, v0, v16
+; RV64V-NEXT:    vsrl.vi v0, v16, 1
+; RV64V-NEXT:    vand.vx v0, v0, a1
 ; RV64V-NEXT:    vand.vx v16, v16, a1
 ; RV64V-NEXT:    vadd.vv v16, v16, v16
-; RV64V-NEXT:    vor.vv v16, v24, v16
-; RV64V-NEXT:    vand.vi v24, v16, 2
-; RV64V-NEXT:    vand.vi v0, v16, 1
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 4
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v0, v16, 4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 3
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v24, v16, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a2, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 4
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 3
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a2, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 4
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a2, 16
-; RV64V-NEXT:    vand.vx v0, v16, a2
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 3
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a2, 32
-; RV64V-NEXT:    vand.vx v24, v16, a2
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a2, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 4
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 3
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a2, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    li a2, 64
-; RV64V-NEXT:    vand.vx v0, v16, a2
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    li a2, 128
-; RV64V-NEXT:    vand.vx v16, v16, a2
-; RV64V-NEXT:    vmul.vv v8, v8, v16
-; RV64V-NEXT:    vxor.vv v16, v24, v0
-; RV64V-NEXT:    vxor.vv v8, v16, v8
-; RV64V-NEXT:    csrr a2, vlenb
-; RV64V-NEXT:    slli a2, a2, 4
-; RV64V-NEXT:    add a2, sp, a2
-; RV64V-NEXT:    addi a2, a2, 16
-; RV64V-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vsll.vi v16, v16, 4
+; RV64V-NEXT:    vor.vv v0, v0, v16
+; RV64V-NEXT:    vand.vx v8, v0, a1
+; RV64V-NEXT:    vand.vx v24, v24, a1
+; RV64V-NEXT:    vand.vx v0, v0, a2
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v16, v8
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vmul.vv v16, v24, v0
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v0, v16, v0
+; RV64V-NEXT:    vmul.vv v16, v24, v8
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    addi a3, sp, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v8, v24, v8
+; RV64V-NEXT:    vxor.vv v16, v16, v0
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vand.vx v16, v16, a1
+; RV64V-NEXT:    vor.vv v8, v16, v8
+; RV64V-NEXT:    vsll.vi v16, v8, 4
 ; RV64V-NEXT:    vsrl.vi v8, v8, 4
 ; RV64V-NEXT:    vor.vv v8, v8, v16
 ; RV64V-NEXT:    vsrl.vi v16, v8, 2
@@ -3072,101 +4816,64 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vx(<vscale x 64 x i8> %va, i8 %b) noun
 ; RV32ZVBC64-NEXT:    vand.vx v24, v24, a1
 ; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV32ZVBC64-NEXT:    vadd.vv v8, v8, v8
-; RV32ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV32ZVBC64-NEXT:    vsll.vi v24, v16, 4
+; RV32ZVBC64-NEXT:    vor.vv v24, v24, v8
+; RV32ZVBC64-NEXT:    li a2, 170
+; RV32ZVBC64-NEXT:    vand.vx v8, v24, a2
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vsll.vi v0, v16, 4
 ; RV32ZVBC64-NEXT:    vsrl.vi v16, v16, 4
-; RV32ZVBC64-NEXT:    vor.vv v16, v16, v24
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v16, 2
-; RV32ZVBC64-NEXT:    vand.vx v24, v24, a0
+; RV32ZVBC64-NEXT:    vor.vv v16, v16, v0
+; RV32ZVBC64-NEXT:    vsrl.vi v0, v16, 2
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a0
 ; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
 ; RV32ZVBC64-NEXT:    vsll.vi v16, v16, 2
-; RV32ZVBC64-NEXT:    vor.vv v16, v24, v16
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v16, 1
-; RV32ZVBC64-NEXT:    vand.vx v24, v24, a1
+; RV32ZVBC64-NEXT:    vor.vv v16, v0, v16
+; RV32ZVBC64-NEXT:    vsrl.vi v0, v16, 1
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a1
 ; RV32ZVBC64-NEXT:    vand.vx v16, v16, a1
 ; RV32ZVBC64-NEXT:    vadd.vv v16, v16, v16
-; RV32ZVBC64-NEXT:    vor.vv v16, v24, v16
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 4
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 3
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a2, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 4
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 3
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a2, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 4
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a2, 16
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a2
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 3
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a2, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a2
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a2, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 4
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 3
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a2, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    li a2, 64
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a2
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    li a2, 128
-; RV32ZVBC64-NEXT:    vand.vx v16, v16, a2
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v16, v24, v0
-; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
-; RV32ZVBC64-NEXT:    csrr a2, vlenb
-; RV32ZVBC64-NEXT:    slli a2, a2, 4
-; RV32ZVBC64-NEXT:    add a2, sp, a2
-; RV32ZVBC64-NEXT:    addi a2, a2, 16
-; RV32ZVBC64-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vsll.vi v16, v16, 4
+; RV32ZVBC64-NEXT:    vor.vv v0, v0, v16
+; RV32ZVBC64-NEXT:    vand.vx v8, v0, a1
+; RV32ZVBC64-NEXT:    vand.vx v24, v24, a1
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a2
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v16, v8
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vmul.vv v16, v24, v0
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV32ZVBC64-NEXT:    vmul.vv v16, v24, v8
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    addi a3, sp, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v8, v24, v8
+; RV32ZVBC64-NEXT:    vxor.vv v16, v16, v0
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a1
+; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vsll.vi v16, v8, 4
 ; RV32ZVBC64-NEXT:    vsrl.vi v8, v8, 4
 ; RV32ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 2
@@ -3214,101 +4921,64 @@ define <vscale x 64 x i8> @clmulh_nxv64i8_vx(<vscale x 64 x i8> %va, i8 %b) noun
 ; RV64ZVBC64-NEXT:    vand.vx v24, v24, a1
 ; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV64ZVBC64-NEXT:    vadd.vv v8, v8, v8
-; RV64ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV64ZVBC64-NEXT:    vsll.vi v24, v16, 4
+; RV64ZVBC64-NEXT:    vor.vv v24, v24, v8
+; RV64ZVBC64-NEXT:    li a2, 170
+; RV64ZVBC64-NEXT:    vand.vx v8, v24, a2
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vsll.vi v0, v16, 4
 ; RV64ZVBC64-NEXT:    vsrl.vi v16, v16, 4
-; RV64ZVBC64-NEXT:    vor.vv v16, v16, v24
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v16, 2
-; RV64ZVBC64-NEXT:    vand.vx v24, v24, a0
+; RV64ZVBC64-NEXT:    vor.vv v16, v16, v0
+; RV64ZVBC64-NEXT:    vsrl.vi v0, v16, 2
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a0
 ; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
 ; RV64ZVBC64-NEXT:    vsll.vi v16, v16, 2
-; RV64ZVBC64-NEXT:    vor.vv v16, v24, v16
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v16, 1
-; RV64ZVBC64-NEXT:    vand.vx v24, v24, a1
+; RV64ZVBC64-NEXT:    vor.vv v16, v0, v16
+; RV64ZVBC64-NEXT:    vsrl.vi v0, v16, 1
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a1
 ; RV64ZVBC64-NEXT:    vand.vx v16, v16, a1
 ; RV64ZVBC64-NEXT:    vadd.vv v16, v16, v16
-; RV64ZVBC64-NEXT:    vor.vv v16, v24, v16
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 4
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 3
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a2, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 4
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 3
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a2, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 4
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a2, 16
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a2
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 3
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a2, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a2
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a2, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a2) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 4
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 3
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a2, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    li a2, 64
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a2
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    li a2, 128
-; RV64ZVBC64-NEXT:    vand.vx v16, v16, a2
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v16, v24, v0
-; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
-; RV64ZVBC64-NEXT:    csrr a2, vlenb
-; RV64ZVBC64-NEXT:    slli a2, a2, 4
-; RV64ZVBC64-NEXT:    add a2, sp, a2
-; RV64ZVBC64-NEXT:    addi a2, a2, 16
-; RV64ZVBC64-NEXT:    vl8r.v v16, (a2) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vsll.vi v16, v16, 4
+; RV64ZVBC64-NEXT:    vor.vv v0, v0, v16
+; RV64ZVBC64-NEXT:    vand.vx v8, v0, a1
+; RV64ZVBC64-NEXT:    vand.vx v24, v24, a1
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a2
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v16, v8
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vmul.vv v16, v24, v0
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v0, v16, v0
+; RV64ZVBC64-NEXT:    vmul.vv v16, v24, v8
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    addi a3, sp, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v8, v24, v8
+; RV64ZVBC64-NEXT:    vxor.vv v16, v16, v0
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a1
+; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vsll.vi v16, v8, 4
 ; RV64ZVBC64-NEXT:    vsrl.vi v8, v8, 4
 ; RV64ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 2
@@ -9929,33 +11599,14 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV32V:       # %bb.0:
 ; RV32V-NEXT:    addi sp, sp, -16
 ; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 5
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a1, a0
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    sub sp, sp, a0
-; RV32V-NEXT:    lui a3, 1
-; RV32V-NEXT:    addi a0, a3, -241
+; RV32V-NEXT:    lui a0, 1
+; RV32V-NEXT:    addi a0, a0, -241
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV32V-NEXT:    vsrl.vi v24, v8, 8
-; RV32V-NEXT:    vsll.vi v8, v8, 8
-; RV32V-NEXT:    vor.vv v8, v8, v24
-; RV32V-NEXT:    vsrl.vi v24, v8, 4
-; RV32V-NEXT:    vand.vx v24, v24, a0
-; RV32V-NEXT:    vand.vx v8, v8, a0
-; RV32V-NEXT:    vsll.vi v8, v8, 4
-; RV32V-NEXT:    vor.vv v8, v24, v8
-; RV32V-NEXT:    vsrl.vi v24, v8, 2
-; RV32V-NEXT:    lui a1, 3
-; RV32V-NEXT:    addi a1, a1, 819
-; RV32V-NEXT:    vand.vx v24, v24, a1
-; RV32V-NEXT:    vand.vx v8, v8, a1
-; RV32V-NEXT:    vsll.vi v8, v8, 2
-; RV32V-NEXT:    vor.vv v8, v24, v8
-; RV32V-NEXT:    vsrl.vi v24, v8, 1
-; RV32V-NEXT:    lui a2, 5
-; RV32V-NEXT:    addi a2, a2, 1365
-; RV32V-NEXT:    vand.vx v24, v24, a2
-; RV32V-NEXT:    vand.vx v8, v8, a2
-; RV32V-NEXT:    vadd.vv v8, v8, v8
-; RV32V-NEXT:    vor.vv v8, v24, v8
 ; RV32V-NEXT:    vsrl.vi v24, v16, 8
 ; RV32V-NEXT:    vsll.vi v16, v16, 8
 ; RV32V-NEXT:    vor.vv v16, v16, v24
@@ -9965,277 +11616,297 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV32V-NEXT:    vsll.vi v16, v16, 4
 ; RV32V-NEXT:    vor.vv v16, v24, v16
 ; RV32V-NEXT:    vsrl.vi v24, v16, 2
+; RV32V-NEXT:    lui a1, 3
+; RV32V-NEXT:    addi a1, a1, 819
 ; RV32V-NEXT:    vand.vx v24, v24, a1
 ; RV32V-NEXT:    vand.vx v16, v16, a1
 ; RV32V-NEXT:    vsll.vi v16, v16, 2
 ; RV32V-NEXT:    vor.vv v16, v24, v16
 ; RV32V-NEXT:    vsrl.vi v24, v16, 1
+; RV32V-NEXT:    lui a4, 5
+; RV32V-NEXT:    addi a2, a4, 1365
 ; RV32V-NEXT:    vand.vx v24, v24, a2
 ; RV32V-NEXT:    vand.vx v16, v16, a2
 ; RV32V-NEXT:    vadd.vv v16, v16, v16
-; RV32V-NEXT:    vor.vv v16, v24, v16
-; RV32V-NEXT:    vand.vi v24, v16, 2
-; RV32V-NEXT:    vand.vi v0, v16, 1
+; RV32V-NEXT:    vor.vv v24, v24, v16
+; RV32V-NEXT:    lui a3, 9
+; RV32V-NEXT:    addi a3, a3, 585
+; RV32V-NEXT:    vand.vx v16, v24, a3
+; RV32V-NEXT:    csrr a5, vlenb
+; RV32V-NEXT:    slli a5, a5, 6
+; RV32V-NEXT:    add a5, sp, a5
+; RV32V-NEXT:    addi a5, a5, 16
+; RV32V-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vsrl.vi v16, v8, 8
+; RV32V-NEXT:    vsll.vi v8, v8, 8
+; RV32V-NEXT:    vor.vv v8, v8, v16
+; RV32V-NEXT:    vsrl.vi v16, v8, 4
+; RV32V-NEXT:    vand.vx v16, v16, a0
+; RV32V-NEXT:    vand.vx v8, v8, a0
+; RV32V-NEXT:    vsll.vi v8, v8, 4
+; RV32V-NEXT:    vor.vv v8, v16, v8
+; RV32V-NEXT:    vsrl.vi v16, v8, 2
+; RV32V-NEXT:    vand.vx v16, v16, a1
+; RV32V-NEXT:    vand.vx v8, v8, a1
+; RV32V-NEXT:    vsll.vi v8, v8, 2
+; RV32V-NEXT:    vor.vv v8, v16, v8
+; RV32V-NEXT:    vsrl.vi v16, v8, 1
+; RV32V-NEXT:    vand.vx v16, v16, a2
+; RV32V-NEXT:    vand.vx v8, v8, a2
+; RV32V-NEXT:    vadd.vv v8, v8, v8
+; RV32V-NEXT:    vor.vv v0, v16, v8
+; RV32V-NEXT:    lui a5, 2
+; RV32V-NEXT:    addi a5, a5, 1170
+; RV32V-NEXT:    vand.vx v8, v24, a5
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a7, a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    addi a4, a4, -1756
+; RV32V-NEXT:    vand.vx v8, v24, a4
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 4
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v8, v0, a5
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v16, v0, a3
+; RV32V-NEXT:    vand.vx v0, v0, a4
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 4
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v0, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 6
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vmul.vv v0, v8, v0
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 2
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a7, a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v16, v24
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 5
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 4
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v0, v24
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 2
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 5
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v24, v8, v24
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v24, v24, v8
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 2
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 4
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v8, v24
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 5
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 6
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v16, v24
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a7, a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v0, v24
+; RV32V-NEXT:    addi a6, sp, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 5
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v0, v16, 4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v24, v16, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 16
-; RV32V-NEXT:    vand.vx v0, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 32
-; RV32V-NEXT:    vand.vx v24, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 64
-; RV32V-NEXT:    vand.vx v0, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 128
-; RV32V-NEXT:    vand.vx v24, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 256
-; RV32V-NEXT:    vand.vx v0, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 512
-; RV32V-NEXT:    vand.vx v24, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 1024
-; RV32V-NEXT:    vand.vx v24, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 1
-; RV32V-NEXT:    slli a4, a4, 11
-; RV32V-NEXT:    vand.vx v0, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    addi a4, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    addi a6, sp, 16
+; RV32V-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    vxor.vv v24, v24, v0
-; RV32V-NEXT:    addi a4, sp, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v24, v0
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vx v0, v16, a3
-; RV32V-NEXT:    vmul.vv v24, v8, v0
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 5
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 2
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v0, v24, a5
+; RV32V-NEXT:    csrr a5, vlenb
+; RV32V-NEXT:    slli a5, a5, 5
+; RV32V-NEXT:    add a5, sp, a5
+; RV32V-NEXT:    addi a5, a5, 16
+; RV32V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v24, v24, a3
+; RV32V-NEXT:    vor.vv v24, v24, v0
 ; RV32V-NEXT:    csrr a3, vlenb
 ; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a5, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a5
 ; RV32V-NEXT:    add a3, sp, a3
 ; RV32V-NEXT:    addi a3, a3, 16
 ; RV32V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    lui a3, 2
-; RV32V-NEXT:    vand.vx v24, v16, a3
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a3, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a5, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a5, a5, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v8, v24
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    mv a5, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v16, v24
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 6
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    csrr a3, vlenb
 ; RV32V-NEXT:    slli a3, a3, 4
 ; RV32V-NEXT:    add a3, sp, a3
 ; RV32V-NEXT:    addi a3, a3, 16
 ; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a3, vlenb
-; RV32V-NEXT:    slli a3, a3, 3
-; RV32V-NEXT:    add a3, sp, a3
-; RV32V-NEXT:    addi a3, a3, 16
-; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a3, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    lui a3, 4
-; RV32V-NEXT:    vand.vx v0, v16, a3
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    lui a3, 8
-; RV32V-NEXT:    vand.vx v16, v16, a3
-; RV32V-NEXT:    vmul.vv v8, v8, v16
-; RV32V-NEXT:    vxor.vv v16, v24, v0
+; RV32V-NEXT:    vmul.vv v0, v0, v24
 ; RV32V-NEXT:    vxor.vv v8, v16, v8
+; RV32V-NEXT:    vxor.vv v8, v8, v0
+; RV32V-NEXT:    vand.vx v8, v8, a4
 ; RV32V-NEXT:    csrr a3, vlenb
 ; RV32V-NEXT:    slli a3, a3, 3
 ; RV32V-NEXT:    mv a4, a3
-; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    slli a3, a3, 2
 ; RV32V-NEXT:    add a3, a3, a4
 ; RV32V-NEXT:    add a3, sp, a3
 ; RV32V-NEXT:    addi a3, a3, 16
 ; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vsll.vi v16, v16, 8
-; RV32V-NEXT:    vsrl.vi v8, v8, 8
 ; RV32V-NEXT:    vor.vv v8, v16, v8
+; RV32V-NEXT:    vsrl.vi v16, v8, 8
+; RV32V-NEXT:    vsll.vi v8, v8, 8
+; RV32V-NEXT:    vor.vv v8, v8, v16
 ; RV32V-NEXT:    vsrl.vi v16, v8, 4
 ; RV32V-NEXT:    vand.vx v16, v16, a0
 ; RV32V-NEXT:    vand.vx v8, v8, a0
@@ -10253,7 +11924,10 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV32V-NEXT:    vor.vv v8, v16, v8
 ; RV32V-NEXT:    vsrl.vi v8, v8, 1
 ; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 5
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a1, a0
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    add sp, sp, a0
 ; RV32V-NEXT:    addi sp, sp, 16
 ; RV32V-NEXT:    ret
@@ -10262,33 +11936,14 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    addi sp, sp, -16
 ; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 5
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a1, a0
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    sub sp, sp, a0
-; RV64V-NEXT:    lui a3, 1
-; RV64V-NEXT:    addi a0, a3, -241
+; RV64V-NEXT:    lui a0, 1
+; RV64V-NEXT:    addi a0, a0, -241
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV64V-NEXT:    vsrl.vi v24, v8, 8
-; RV64V-NEXT:    vsll.vi v8, v8, 8
-; RV64V-NEXT:    vor.vv v8, v8, v24
-; RV64V-NEXT:    vsrl.vi v24, v8, 4
-; RV64V-NEXT:    vand.vx v24, v24, a0
-; RV64V-NEXT:    vand.vx v8, v8, a0
-; RV64V-NEXT:    vsll.vi v8, v8, 4
-; RV64V-NEXT:    vor.vv v8, v24, v8
-; RV64V-NEXT:    vsrl.vi v24, v8, 2
-; RV64V-NEXT:    lui a1, 3
-; RV64V-NEXT:    addi a1, a1, 819
-; RV64V-NEXT:    vand.vx v24, v24, a1
-; RV64V-NEXT:    vand.vx v8, v8, a1
-; RV64V-NEXT:    vsll.vi v8, v8, 2
-; RV64V-NEXT:    vor.vv v8, v24, v8
-; RV64V-NEXT:    vsrl.vi v24, v8, 1
-; RV64V-NEXT:    lui a2, 5
-; RV64V-NEXT:    addi a2, a2, 1365
-; RV64V-NEXT:    vand.vx v24, v24, a2
-; RV64V-NEXT:    vand.vx v8, v8, a2
-; RV64V-NEXT:    vadd.vv v8, v8, v8
-; RV64V-NEXT:    vor.vv v8, v24, v8
 ; RV64V-NEXT:    vsrl.vi v24, v16, 8
 ; RV64V-NEXT:    vsll.vi v16, v16, 8
 ; RV64V-NEXT:    vor.vv v16, v16, v24
@@ -10298,277 +11953,297 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV64V-NEXT:    vsll.vi v16, v16, 4
 ; RV64V-NEXT:    vor.vv v16, v24, v16
 ; RV64V-NEXT:    vsrl.vi v24, v16, 2
+; RV64V-NEXT:    lui a1, 3
+; RV64V-NEXT:    addi a1, a1, 819
 ; RV64V-NEXT:    vand.vx v24, v24, a1
 ; RV64V-NEXT:    vand.vx v16, v16, a1
 ; RV64V-NEXT:    vsll.vi v16, v16, 2
 ; RV64V-NEXT:    vor.vv v16, v24, v16
 ; RV64V-NEXT:    vsrl.vi v24, v16, 1
+; RV64V-NEXT:    lui a4, 5
+; RV64V-NEXT:    addi a2, a4, 1365
 ; RV64V-NEXT:    vand.vx v24, v24, a2
 ; RV64V-NEXT:    vand.vx v16, v16, a2
 ; RV64V-NEXT:    vadd.vv v16, v16, v16
-; RV64V-NEXT:    vor.vv v16, v24, v16
-; RV64V-NEXT:    vand.vi v24, v16, 2
-; RV64V-NEXT:    vand.vi v0, v16, 1
+; RV64V-NEXT:    vor.vv v24, v24, v16
+; RV64V-NEXT:    lui a3, 9
+; RV64V-NEXT:    addi a3, a3, 585
+; RV64V-NEXT:    vand.vx v16, v24, a3
+; RV64V-NEXT:    csrr a5, vlenb
+; RV64V-NEXT:    slli a5, a5, 6
+; RV64V-NEXT:    add a5, sp, a5
+; RV64V-NEXT:    addi a5, a5, 16
+; RV64V-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vsrl.vi v16, v8, 8
+; RV64V-NEXT:    vsll.vi v8, v8, 8
+; RV64V-NEXT:    vor.vv v8, v8, v16
+; RV64V-NEXT:    vsrl.vi v16, v8, 4
+; RV64V-NEXT:    vand.vx v16, v16, a0
+; RV64V-NEXT:    vand.vx v8, v8, a0
+; RV64V-NEXT:    vsll.vi v8, v8, 4
+; RV64V-NEXT:    vor.vv v8, v16, v8
+; RV64V-NEXT:    vsrl.vi v16, v8, 2
+; RV64V-NEXT:    vand.vx v16, v16, a1
+; RV64V-NEXT:    vand.vx v8, v8, a1
+; RV64V-NEXT:    vsll.vi v8, v8, 2
+; RV64V-NEXT:    vor.vv v8, v16, v8
+; RV64V-NEXT:    vsrl.vi v16, v8, 1
+; RV64V-NEXT:    vand.vx v16, v16, a2
+; RV64V-NEXT:    vand.vx v8, v8, a2
+; RV64V-NEXT:    vadd.vv v8, v8, v8
+; RV64V-NEXT:    vor.vv v0, v16, v8
+; RV64V-NEXT:    lui a5, 2
+; RV64V-NEXT:    addi a5, a5, 1170
+; RV64V-NEXT:    vand.vx v8, v24, a5
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a7, a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    addi a4, a4, -1756
+; RV64V-NEXT:    vand.vx v8, v24, a4
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 4
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v8, v0, a5
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v16, v0, a3
+; RV64V-NEXT:    vand.vx v0, v0, a4
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 4
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v0, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 6
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vmul.vv v0, v8, v0
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 2
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a7, a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v16, v24
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 5
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 4
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v0, v24
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 2
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 5
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v24, v8, v24
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v24, v24, v8
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 2
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 4
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v8, v24
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 5
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 6
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v16, v24
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a7, a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v0, v24
+; RV64V-NEXT:    addi a6, sp, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 5
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v0, v16, 4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v24, v16, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 16
-; RV64V-NEXT:    vand.vx v0, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 32
-; RV64V-NEXT:    vand.vx v24, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 64
-; RV64V-NEXT:    vand.vx v0, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 128
-; RV64V-NEXT:    vand.vx v24, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 256
-; RV64V-NEXT:    vand.vx v0, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 512
-; RV64V-NEXT:    vand.vx v24, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 1024
-; RV64V-NEXT:    vand.vx v24, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 1
-; RV64V-NEXT:    slli a4, a4, 11
-; RV64V-NEXT:    vand.vx v0, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    addi a4, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    addi a6, sp, 16
+; RV64V-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    vxor.vv v24, v24, v0
-; RV64V-NEXT:    addi a4, sp, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v24, v0
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vx v0, v16, a3
-; RV64V-NEXT:    vmul.vv v24, v8, v0
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 5
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 2
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v0, v24, a5
+; RV64V-NEXT:    csrr a5, vlenb
+; RV64V-NEXT:    slli a5, a5, 5
+; RV64V-NEXT:    add a5, sp, a5
+; RV64V-NEXT:    addi a5, a5, 16
+; RV64V-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v24, v24, a3
+; RV64V-NEXT:    vor.vv v24, v24, v0
 ; RV64V-NEXT:    csrr a3, vlenb
 ; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a5, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a5
 ; RV64V-NEXT:    add a3, sp, a3
 ; RV64V-NEXT:    addi a3, a3, 16
 ; RV64V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    lui a3, 2
-; RV64V-NEXT:    vand.vx v24, v16, a3
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a3, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a5, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a5, a5, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v8, v24
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    mv a5, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v16, v24
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 6
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    csrr a3, vlenb
 ; RV64V-NEXT:    slli a3, a3, 4
 ; RV64V-NEXT:    add a3, sp, a3
 ; RV64V-NEXT:    addi a3, a3, 16
 ; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a3, vlenb
-; RV64V-NEXT:    slli a3, a3, 3
-; RV64V-NEXT:    add a3, sp, a3
-; RV64V-NEXT:    addi a3, a3, 16
-; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a3, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    lui a3, 4
-; RV64V-NEXT:    vand.vx v0, v16, a3
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    lui a3, 8
-; RV64V-NEXT:    vand.vx v16, v16, a3
-; RV64V-NEXT:    vmul.vv v8, v8, v16
-; RV64V-NEXT:    vxor.vv v16, v24, v0
+; RV64V-NEXT:    vmul.vv v0, v0, v24
 ; RV64V-NEXT:    vxor.vv v8, v16, v8
+; RV64V-NEXT:    vxor.vv v8, v8, v0
+; RV64V-NEXT:    vand.vx v8, v8, a4
 ; RV64V-NEXT:    csrr a3, vlenb
 ; RV64V-NEXT:    slli a3, a3, 3
 ; RV64V-NEXT:    mv a4, a3
-; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    slli a3, a3, 2
 ; RV64V-NEXT:    add a3, a3, a4
 ; RV64V-NEXT:    add a3, sp, a3
 ; RV64V-NEXT:    addi a3, a3, 16
 ; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vsll.vi v16, v16, 8
-; RV64V-NEXT:    vsrl.vi v8, v8, 8
 ; RV64V-NEXT:    vor.vv v8, v16, v8
+; RV64V-NEXT:    vsrl.vi v16, v8, 8
+; RV64V-NEXT:    vsll.vi v8, v8, 8
+; RV64V-NEXT:    vor.vv v8, v8, v16
 ; RV64V-NEXT:    vsrl.vi v16, v8, 4
 ; RV64V-NEXT:    vand.vx v16, v16, a0
 ; RV64V-NEXT:    vand.vx v8, v8, a0
@@ -10586,7 +12261,10 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV64V-NEXT:    vor.vv v8, v16, v8
 ; RV64V-NEXT:    vsrl.vi v8, v8, 1
 ; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 5
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a1, a0
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    add sp, sp, a0
 ; RV64V-NEXT:    addi sp, sp, 16
 ; RV64V-NEXT:    ret
@@ -10595,33 +12273,14 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV32ZVBC64:       # %bb.0:
 ; RV32ZVBC64-NEXT:    addi sp, sp, -16
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 5
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a1, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    sub sp, sp, a0
-; RV32ZVBC64-NEXT:    lui a3, 1
-; RV32ZVBC64-NEXT:    addi a0, a3, -241
+; RV32ZVBC64-NEXT:    lui a0, 1
+; RV32ZVBC64-NEXT:    addi a0, a0, -241
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v8, 8
-; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 8
-; RV32ZVBC64-NEXT:    vor.vv v8, v8, v24
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v8, 4
-; RV32ZVBC64-NEXT:    vand.vx v24, v24, a0
-; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
-; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 4
-; RV32ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v8, 2
-; RV32ZVBC64-NEXT:    lui a1, 3
-; RV32ZVBC64-NEXT:    addi a1, a1, 819
-; RV32ZVBC64-NEXT:    vand.vx v24, v24, a1
-; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
-; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 2
-; RV32ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v8, 1
-; RV32ZVBC64-NEXT:    lui a2, 5
-; RV32ZVBC64-NEXT:    addi a2, a2, 1365
-; RV32ZVBC64-NEXT:    vand.vx v24, v24, a2
-; RV32ZVBC64-NEXT:    vand.vx v8, v8, a2
-; RV32ZVBC64-NEXT:    vadd.vv v8, v8, v8
-; RV32ZVBC64-NEXT:    vor.vv v8, v24, v8
 ; RV32ZVBC64-NEXT:    vsrl.vi v24, v16, 8
 ; RV32ZVBC64-NEXT:    vsll.vi v16, v16, 8
 ; RV32ZVBC64-NEXT:    vor.vv v16, v16, v24
@@ -10631,277 +12290,297 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV32ZVBC64-NEXT:    vsll.vi v16, v16, 4
 ; RV32ZVBC64-NEXT:    vor.vv v16, v24, v16
 ; RV32ZVBC64-NEXT:    vsrl.vi v24, v16, 2
+; RV32ZVBC64-NEXT:    lui a1, 3
+; RV32ZVBC64-NEXT:    addi a1, a1, 819
 ; RV32ZVBC64-NEXT:    vand.vx v24, v24, a1
 ; RV32ZVBC64-NEXT:    vand.vx v16, v16, a1
 ; RV32ZVBC64-NEXT:    vsll.vi v16, v16, 2
 ; RV32ZVBC64-NEXT:    vor.vv v16, v24, v16
 ; RV32ZVBC64-NEXT:    vsrl.vi v24, v16, 1
+; RV32ZVBC64-NEXT:    lui a4, 5
+; RV32ZVBC64-NEXT:    addi a2, a4, 1365
 ; RV32ZVBC64-NEXT:    vand.vx v24, v24, a2
 ; RV32ZVBC64-NEXT:    vand.vx v16, v16, a2
 ; RV32ZVBC64-NEXT:    vadd.vv v16, v16, v16
-; RV32ZVBC64-NEXT:    vor.vv v16, v24, v16
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 1
+; RV32ZVBC64-NEXT:    vor.vv v24, v24, v16
+; RV32ZVBC64-NEXT:    lui a3, 9
+; RV32ZVBC64-NEXT:    addi a3, a3, 585
+; RV32ZVBC64-NEXT:    vand.vx v16, v24, a3
+; RV32ZVBC64-NEXT:    csrr a5, vlenb
+; RV32ZVBC64-NEXT:    slli a5, a5, 6
+; RV32ZVBC64-NEXT:    add a5, sp, a5
+; RV32ZVBC64-NEXT:    addi a5, a5, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 8
+; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 8
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v16
+; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 4
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 4
+; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 2
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a1
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 2
+; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 1
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a2
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV32ZVBC64-NEXT:    vadd.vv v8, v8, v8
+; RV32ZVBC64-NEXT:    vor.vv v0, v16, v8
+; RV32ZVBC64-NEXT:    lui a5, 2
+; RV32ZVBC64-NEXT:    addi a5, a5, 1170
+; RV32ZVBC64-NEXT:    vand.vx v8, v24, a5
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a7, a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    addi a4, a4, -1756
+; RV32ZVBC64-NEXT:    vand.vx v8, v24, a4
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 4
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v8, v0, a5
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v16, v0, a3
+; RV32ZVBC64-NEXT:    vand.vx v0, v0, a4
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 4
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 6
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 2
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a7, a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v16, v24
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 5
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 4
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v0, v24
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 2
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 5
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v24, v8, v24
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v24, v24, v8
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 2
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 4
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 5
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 6
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v16, v24
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a7, a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v0, v24
+; RV32ZVBC64-NEXT:    addi a6, sp, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 5
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 16
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 64
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 128
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 256
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 512
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 1024
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 1
-; RV32ZVBC64-NEXT:    slli a4, a4, 11
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    addi a4, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    addi a6, sp, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    vxor.vv v24, v24, v0
-; RV32ZVBC64-NEXT:    addi a4, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v24, v0
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a3
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 5
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 2
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v0, v24, a5
+; RV32ZVBC64-NEXT:    csrr a5, vlenb
+; RV32ZVBC64-NEXT:    slli a5, a5, 5
+; RV32ZVBC64-NEXT:    add a5, sp, a5
+; RV32ZVBC64-NEXT:    addi a5, a5, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v24, v24, a3
+; RV32ZVBC64-NEXT:    vor.vv v24, v24, v0
 ; RV32ZVBC64-NEXT:    csrr a3, vlenb
 ; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a5, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a5
 ; RV32ZVBC64-NEXT:    add a3, sp, a3
 ; RV32ZVBC64-NEXT:    addi a3, a3, 16
 ; RV32ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    lui a3, 2
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a3
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a3, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a5, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a5, a5, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    mv a5, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v16, v24
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 6
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    csrr a3, vlenb
 ; RV32ZVBC64-NEXT:    slli a3, a3, 4
 ; RV32ZVBC64-NEXT:    add a3, sp, a3
 ; RV32ZVBC64-NEXT:    addi a3, a3, 16
 ; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a3, vlenb
-; RV32ZVBC64-NEXT:    slli a3, a3, 3
-; RV32ZVBC64-NEXT:    add a3, sp, a3
-; RV32ZVBC64-NEXT:    addi a3, a3, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a3, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    lui a3, 4
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a3
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    lui a3, 8
-; RV32ZVBC64-NEXT:    vand.vx v16, v16, a3
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v16, v24, v0
+; RV32ZVBC64-NEXT:    vmul.vv v0, v0, v24
 ; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a4
 ; RV32ZVBC64-NEXT:    csrr a3, vlenb
 ; RV32ZVBC64-NEXT:    slli a3, a3, 3
 ; RV32ZVBC64-NEXT:    mv a4, a3
-; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
 ; RV32ZVBC64-NEXT:    add a3, a3, a4
 ; RV32ZVBC64-NEXT:    add a3, sp, a3
 ; RV32ZVBC64-NEXT:    addi a3, a3, 16
 ; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vsll.vi v16, v16, 8
-; RV32ZVBC64-NEXT:    vsrl.vi v8, v8, 8
 ; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 8
+; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 8
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 4
 ; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
 ; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
@@ -10919,7 +12598,10 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
 ; RV32ZVBC64-NEXT:    vsrl.vi v8, v8, 1
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 5
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a1, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    add sp, sp, a0
 ; RV32ZVBC64-NEXT:    addi sp, sp, 16
 ; RV32ZVBC64-NEXT:    ret
@@ -10928,33 +12610,14 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV64ZVBC64:       # %bb.0:
 ; RV64ZVBC64-NEXT:    addi sp, sp, -16
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 5
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a1, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    sub sp, sp, a0
-; RV64ZVBC64-NEXT:    lui a3, 1
-; RV64ZVBC64-NEXT:    addi a0, a3, -241
+; RV64ZVBC64-NEXT:    lui a0, 1
+; RV64ZVBC64-NEXT:    addi a0, a0, -241
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v8, 8
-; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 8
-; RV64ZVBC64-NEXT:    vor.vv v8, v8, v24
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v8, 4
-; RV64ZVBC64-NEXT:    vand.vx v24, v24, a0
-; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
-; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 4
-; RV64ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v8, 2
-; RV64ZVBC64-NEXT:    lui a1, 3
-; RV64ZVBC64-NEXT:    addi a1, a1, 819
-; RV64ZVBC64-NEXT:    vand.vx v24, v24, a1
-; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
-; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 2
-; RV64ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v8, 1
-; RV64ZVBC64-NEXT:    lui a2, 5
-; RV64ZVBC64-NEXT:    addi a2, a2, 1365
-; RV64ZVBC64-NEXT:    vand.vx v24, v24, a2
-; RV64ZVBC64-NEXT:    vand.vx v8, v8, a2
-; RV64ZVBC64-NEXT:    vadd.vv v8, v8, v8
-; RV64ZVBC64-NEXT:    vor.vv v8, v24, v8
 ; RV64ZVBC64-NEXT:    vsrl.vi v24, v16, 8
 ; RV64ZVBC64-NEXT:    vsll.vi v16, v16, 8
 ; RV64ZVBC64-NEXT:    vor.vv v16, v16, v24
@@ -10964,277 +12627,297 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV64ZVBC64-NEXT:    vsll.vi v16, v16, 4
 ; RV64ZVBC64-NEXT:    vor.vv v16, v24, v16
 ; RV64ZVBC64-NEXT:    vsrl.vi v24, v16, 2
+; RV64ZVBC64-NEXT:    lui a1, 3
+; RV64ZVBC64-NEXT:    addi a1, a1, 819
 ; RV64ZVBC64-NEXT:    vand.vx v24, v24, a1
 ; RV64ZVBC64-NEXT:    vand.vx v16, v16, a1
 ; RV64ZVBC64-NEXT:    vsll.vi v16, v16, 2
 ; RV64ZVBC64-NEXT:    vor.vv v16, v24, v16
 ; RV64ZVBC64-NEXT:    vsrl.vi v24, v16, 1
+; RV64ZVBC64-NEXT:    lui a4, 5
+; RV64ZVBC64-NEXT:    addi a2, a4, 1365
 ; RV64ZVBC64-NEXT:    vand.vx v24, v24, a2
 ; RV64ZVBC64-NEXT:    vand.vx v16, v16, a2
 ; RV64ZVBC64-NEXT:    vadd.vv v16, v16, v16
-; RV64ZVBC64-NEXT:    vor.vv v16, v24, v16
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 1
+; RV64ZVBC64-NEXT:    vor.vv v24, v24, v16
+; RV64ZVBC64-NEXT:    lui a3, 9
+; RV64ZVBC64-NEXT:    addi a3, a3, 585
+; RV64ZVBC64-NEXT:    vand.vx v16, v24, a3
+; RV64ZVBC64-NEXT:    csrr a5, vlenb
+; RV64ZVBC64-NEXT:    slli a5, a5, 6
+; RV64ZVBC64-NEXT:    add a5, sp, a5
+; RV64ZVBC64-NEXT:    addi a5, a5, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 8
+; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 8
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v16
+; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 4
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
+; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 4
+; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 2
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a1
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
+; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 2
+; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 1
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a2
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a2
+; RV64ZVBC64-NEXT:    vadd.vv v8, v8, v8
+; RV64ZVBC64-NEXT:    vor.vv v0, v16, v8
+; RV64ZVBC64-NEXT:    lui a5, 2
+; RV64ZVBC64-NEXT:    addi a5, a5, 1170
+; RV64ZVBC64-NEXT:    vand.vx v8, v24, a5
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a7, a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    addi a4, a4, -1756
+; RV64ZVBC64-NEXT:    vand.vx v8, v24, a4
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 4
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v8, v0, a5
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v16, v0, a3
+; RV64ZVBC64-NEXT:    vand.vx v0, v0, a4
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 4
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 6
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 2
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a7, a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v16, v24
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 5
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 4
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v0, v24
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 2
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 5
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v24, v8, v24
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v24, v24, v8
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 2
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 4
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 5
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 6
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v16, v24
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a7, a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v0, v24
+; RV64ZVBC64-NEXT:    addi a6, sp, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 5
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 16
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 64
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 128
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 256
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 512
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 1024
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 1
-; RV64ZVBC64-NEXT:    slli a4, a4, 11
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    addi a4, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    addi a6, sp, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    vxor.vv v24, v24, v0
-; RV64ZVBC64-NEXT:    addi a4, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v24, v0
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a3
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 5
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 2
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v0, v24, a5
+; RV64ZVBC64-NEXT:    csrr a5, vlenb
+; RV64ZVBC64-NEXT:    slli a5, a5, 5
+; RV64ZVBC64-NEXT:    add a5, sp, a5
+; RV64ZVBC64-NEXT:    addi a5, a5, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a5) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v24, v24, a3
+; RV64ZVBC64-NEXT:    vor.vv v24, v24, v0
 ; RV64ZVBC64-NEXT:    csrr a3, vlenb
 ; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a5, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a5
 ; RV64ZVBC64-NEXT:    add a3, sp, a3
 ; RV64ZVBC64-NEXT:    addi a3, a3, 16
 ; RV64ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    lui a3, 2
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a3
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a3, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a5, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a5, a5, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v24
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    mv a5, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v16, v24
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 6
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    csrr a3, vlenb
 ; RV64ZVBC64-NEXT:    slli a3, a3, 4
 ; RV64ZVBC64-NEXT:    add a3, sp, a3
 ; RV64ZVBC64-NEXT:    addi a3, a3, 16
 ; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a3, vlenb
-; RV64ZVBC64-NEXT:    slli a3, a3, 3
-; RV64ZVBC64-NEXT:    add a3, sp, a3
-; RV64ZVBC64-NEXT:    addi a3, a3, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a3, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    lui a3, 4
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a3
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    lui a3, 8
-; RV64ZVBC64-NEXT:    vand.vx v16, v16, a3
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v16, v24, v0
+; RV64ZVBC64-NEXT:    vmul.vv v0, v0, v24
 ; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a4
 ; RV64ZVBC64-NEXT:    csrr a3, vlenb
 ; RV64ZVBC64-NEXT:    slli a3, a3, 3
 ; RV64ZVBC64-NEXT:    mv a4, a3
-; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
 ; RV64ZVBC64-NEXT:    add a3, a3, a4
 ; RV64ZVBC64-NEXT:    add a3, sp, a3
 ; RV64ZVBC64-NEXT:    addi a3, a3, 16
 ; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vsll.vi v16, v16, 8
-; RV64ZVBC64-NEXT:    vsrl.vi v8, v8, 8
 ; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 8
+; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 8
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 4
 ; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
 ; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
@@ -11252,7 +12935,10 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vv(<vscale x 32 x i16> %va, <vscale 
 ; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
 ; RV64ZVBC64-NEXT:    vsrl.vi v8, v8, 1
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 5
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a1, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    add sp, sp, a0
 ; RV64ZVBC64-NEXT:    addi sp, sp, 16
 ; RV64ZVBC64-NEXT:    ret
@@ -11281,37 +12967,48 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV32V:       # %bb.0:
 ; RV32V-NEXT:    addi sp, sp, -16
 ; RV32V-NEXT:    csrr a1, vlenb
-; RV32V-NEXT:    slli a1, a1, 5
+; RV32V-NEXT:    slli a1, a1, 3
+; RV32V-NEXT:    mv a2, a1
+; RV32V-NEXT:    slli a1, a1, 3
+; RV32V-NEXT:    add a1, a1, a2
 ; RV32V-NEXT:    sub sp, sp, a1
 ; RV32V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV32V-NEXT:    vmv.v.x v16, a0
-; RV32V-NEXT:    vsrl.vi v24, v8, 8
+; RV32V-NEXT:    vmv.v.x v24, a0
+; RV32V-NEXT:    vsrl.vi v16, v8, 8
 ; RV32V-NEXT:    vsll.vi v8, v8, 8
-; RV32V-NEXT:    vor.vv v8, v8, v24
-; RV32V-NEXT:    vsrl.vi v24, v8, 4
-; RV32V-NEXT:    lui a3, 1
-; RV32V-NEXT:    addi a0, a3, -241
-; RV32V-NEXT:    vand.vx v24, v24, a0
+; RV32V-NEXT:    vor.vv v8, v8, v16
+; RV32V-NEXT:    vsrl.vi v16, v8, 4
+; RV32V-NEXT:    lui a0, 1
+; RV32V-NEXT:    addi a0, a0, -241
+; RV32V-NEXT:    vand.vx v16, v16, a0
 ; RV32V-NEXT:    vand.vx v8, v8, a0
 ; RV32V-NEXT:    vsll.vi v8, v8, 4
-; RV32V-NEXT:    vor.vv v8, v24, v8
-; RV32V-NEXT:    vsrl.vi v24, v8, 2
+; RV32V-NEXT:    vor.vv v8, v16, v8
+; RV32V-NEXT:    vsrl.vi v16, v8, 2
 ; RV32V-NEXT:    lui a1, 3
 ; RV32V-NEXT:    addi a1, a1, 819
-; RV32V-NEXT:    vand.vx v24, v24, a1
+; RV32V-NEXT:    vand.vx v16, v16, a1
 ; RV32V-NEXT:    vand.vx v8, v8, a1
 ; RV32V-NEXT:    vsll.vi v8, v8, 2
-; RV32V-NEXT:    vor.vv v8, v24, v8
-; RV32V-NEXT:    vsrl.vi v24, v8, 1
-; RV32V-NEXT:    lui a2, 5
-; RV32V-NEXT:    addi a2, a2, 1365
-; RV32V-NEXT:    vand.vx v24, v24, a2
+; RV32V-NEXT:    vor.vv v8, v16, v8
+; RV32V-NEXT:    vsrl.vi v16, v8, 1
+; RV32V-NEXT:    lui a4, 5
+; RV32V-NEXT:    addi a2, a4, 1365
+; RV32V-NEXT:    vand.vx v16, v16, a2
 ; RV32V-NEXT:    vand.vx v8, v8, a2
 ; RV32V-NEXT:    vadd.vv v8, v8, v8
-; RV32V-NEXT:    vor.vv v8, v24, v8
-; RV32V-NEXT:    vsrl.vi v24, v16, 8
-; RV32V-NEXT:    vsll.vi v16, v16, 8
-; RV32V-NEXT:    vor.vv v16, v16, v24
+; RV32V-NEXT:    vor.vv v8, v16, v8
+; RV32V-NEXT:    lui a3, 2
+; RV32V-NEXT:    addi a3, a3, 1170
+; RV32V-NEXT:    vand.vx v16, v8, a3
+; RV32V-NEXT:    csrr a5, vlenb
+; RV32V-NEXT:    slli a5, a5, 6
+; RV32V-NEXT:    add a5, sp, a5
+; RV32V-NEXT:    addi a5, a5, 16
+; RV32V-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vsrl.vi v16, v24, 8
+; RV32V-NEXT:    vsll.vi v24, v24, 8
+; RV32V-NEXT:    vor.vv v16, v24, v16
 ; RV32V-NEXT:    vsrl.vi v24, v16, 4
 ; RV32V-NEXT:    vand.vx v24, v24, a0
 ; RV32V-NEXT:    vand.vx v16, v16, a0
@@ -11327,268 +13024,258 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV32V-NEXT:    vand.vx v16, v16, a2
 ; RV32V-NEXT:    vadd.vv v16, v16, v16
 ; RV32V-NEXT:    vor.vv v16, v24, v16
-; RV32V-NEXT:    vand.vi v24, v16, 2
-; RV32V-NEXT:    vand.vi v0, v16, 1
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    vmul.vv v0, v8, v0
+; RV32V-NEXT:    lui a5, 9
+; RV32V-NEXT:    addi a5, a5, 585
+; RV32V-NEXT:    vand.vx v24, v8, a5
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a7, a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    addi a4, a4, -1756
+; RV32V-NEXT:    vand.vx v8, v8, a4
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 4
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v0, v16, a5
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 4
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v0, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v8, v16, a3
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    vand.vx v16, v16, a4
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 6
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v24, v0
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 2
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a7, a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v24, v8
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 5
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 4
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v24, v16
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 2
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 5
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v24, v8, v24
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vxor.vv v24, v24, v8
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 2
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 6
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v24, v16
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 5
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a7, a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v24, v0
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 4
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v24, v24, v8
+; RV32V-NEXT:    addi a6, sp, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 5
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 1
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v0, v16, 4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vi v24, v16, 8
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 16
-; RV32V-NEXT:    vand.vx v0, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 32
-; RV32V-NEXT:    vand.vx v24, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 64
-; RV32V-NEXT:    vand.vx v0, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 128
-; RV32V-NEXT:    vand.vx v24, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 256
-; RV32V-NEXT:    vand.vx v0, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 512
-; RV32V-NEXT:    vand.vx v24, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    mv a5, a4
-; RV32V-NEXT:    slli a4, a4, 1
-; RV32V-NEXT:    add a4, a4, a5
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 1024
-; RV32V-NEXT:    vand.vx v24, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    li a4, 1
-; RV32V-NEXT:    slli a4, a4, 11
-; RV32V-NEXT:    vand.vx v0, v16, a4
-; RV32V-NEXT:    vmul.vv v24, v8, v0
-; RV32V-NEXT:    addi a4, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 3
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    addi a6, sp, 16
+; RV32V-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    vxor.vv v24, v24, v0
-; RV32V-NEXT:    addi a4, sp, 16
-; RV32V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v24, v0
-; RV32V-NEXT:    csrr a4, vlenb
-; RV32V-NEXT:    slli a4, a4, 4
-; RV32V-NEXT:    add a4, sp, a4
-; RV32V-NEXT:    addi a4, a4, 16
-; RV32V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    vand.vx v0, v16, a3
-; RV32V-NEXT:    vmul.vv v24, v8, v0
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 5
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a6, vlenb
+; RV32V-NEXT:    slli a6, a6, 3
+; RV32V-NEXT:    mv a7, a6
+; RV32V-NEXT:    slli a6, a6, 2
+; RV32V-NEXT:    add a6, a6, a7
+; RV32V-NEXT:    add a6, sp, a6
+; RV32V-NEXT:    addi a6, a6, 16
+; RV32V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v0, v24, a3
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vand.vx v24, v24, a5
+; RV32V-NEXT:    vor.vv v24, v24, v0
 ; RV32V-NEXT:    csrr a3, vlenb
 ; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a5, a3
+; RV32V-NEXT:    slli a3, a3, 2
+; RV32V-NEXT:    add a3, a3, a5
 ; RV32V-NEXT:    add a3, sp, a3
 ; RV32V-NEXT:    addi a3, a3, 16
 ; RV32V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
-; RV32V-NEXT:    lui a3, 2
-; RV32V-NEXT:    vand.vx v24, v16, a3
-; RV32V-NEXT:    vmul.vv v24, v8, v24
-; RV32V-NEXT:    addi a3, sp, 16
-; RV32V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 6
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v8, v24, v8
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 3
+; RV32V-NEXT:    mv a5, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a5, a5, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32V-NEXT:    vmul.vv v16, v24, v16
+; RV32V-NEXT:    csrr a3, vlenb
+; RV32V-NEXT:    slli a3, a3, 4
+; RV32V-NEXT:    mv a5, a3
+; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    add a3, a3, a5
+; RV32V-NEXT:    add a3, sp, a3
+; RV32V-NEXT:    addi a3, a3, 16
+; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
 ; RV32V-NEXT:    csrr a3, vlenb
 ; RV32V-NEXT:    slli a3, a3, 4
 ; RV32V-NEXT:    add a3, sp, a3
 ; RV32V-NEXT:    addi a3, a3, 16
 ; RV32V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    csrr a3, vlenb
-; RV32V-NEXT:    slli a3, a3, 3
-; RV32V-NEXT:    add a3, sp, a3
-; RV32V-NEXT:    addi a3, a3, 16
-; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v0, v0, v24
-; RV32V-NEXT:    addi a3, sp, 16
-; RV32V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vxor.vv v24, v0, v24
-; RV32V-NEXT:    lui a3, 4
-; RV32V-NEXT:    vand.vx v0, v16, a3
-; RV32V-NEXT:    vmul.vv v0, v8, v0
-; RV32V-NEXT:    lui a3, 8
-; RV32V-NEXT:    vand.vx v16, v16, a3
-; RV32V-NEXT:    vmul.vv v8, v8, v16
-; RV32V-NEXT:    vxor.vv v16, v24, v0
+; RV32V-NEXT:    vmul.vv v0, v24, v0
 ; RV32V-NEXT:    vxor.vv v8, v16, v8
+; RV32V-NEXT:    vxor.vv v8, v8, v0
+; RV32V-NEXT:    vand.vx v8, v8, a4
 ; RV32V-NEXT:    csrr a3, vlenb
 ; RV32V-NEXT:    slli a3, a3, 3
 ; RV32V-NEXT:    mv a4, a3
-; RV32V-NEXT:    slli a3, a3, 1
+; RV32V-NEXT:    slli a3, a3, 2
 ; RV32V-NEXT:    add a3, a3, a4
 ; RV32V-NEXT:    add a3, sp, a3
 ; RV32V-NEXT:    addi a3, a3, 16
 ; RV32V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
-; RV32V-NEXT:    vsll.vi v16, v16, 8
-; RV32V-NEXT:    vsrl.vi v8, v8, 8
 ; RV32V-NEXT:    vor.vv v8, v16, v8
+; RV32V-NEXT:    vsrl.vi v16, v8, 8
+; RV32V-NEXT:    vsll.vi v8, v8, 8
+; RV32V-NEXT:    vor.vv v8, v8, v16
 ; RV32V-NEXT:    vsrl.vi v16, v8, 4
 ; RV32V-NEXT:    vand.vx v16, v16, a0
 ; RV32V-NEXT:    vand.vx v8, v8, a0
@@ -11606,7 +13293,10 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV32V-NEXT:    vor.vv v8, v16, v8
 ; RV32V-NEXT:    vsrl.vi v8, v8, 1
 ; RV32V-NEXT:    csrr a0, vlenb
-; RV32V-NEXT:    slli a0, a0, 5
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    mv a1, a0
+; RV32V-NEXT:    slli a0, a0, 3
+; RV32V-NEXT:    add a0, a0, a1
 ; RV32V-NEXT:    add sp, sp, a0
 ; RV32V-NEXT:    addi sp, sp, 16
 ; RV32V-NEXT:    ret
@@ -11615,37 +13305,48 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV64V:       # %bb.0:
 ; RV64V-NEXT:    addi sp, sp, -16
 ; RV64V-NEXT:    csrr a1, vlenb
-; RV64V-NEXT:    slli a1, a1, 5
+; RV64V-NEXT:    slli a1, a1, 3
+; RV64V-NEXT:    mv a2, a1
+; RV64V-NEXT:    slli a1, a1, 3
+; RV64V-NEXT:    add a1, a1, a2
 ; RV64V-NEXT:    sub sp, sp, a1
 ; RV64V-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV64V-NEXT:    vmv.v.x v16, a0
-; RV64V-NEXT:    vsrl.vi v24, v8, 8
+; RV64V-NEXT:    vmv.v.x v24, a0
+; RV64V-NEXT:    vsrl.vi v16, v8, 8
 ; RV64V-NEXT:    vsll.vi v8, v8, 8
-; RV64V-NEXT:    vor.vv v8, v8, v24
-; RV64V-NEXT:    vsrl.vi v24, v8, 4
-; RV64V-NEXT:    lui a3, 1
-; RV64V-NEXT:    addi a0, a3, -241
-; RV64V-NEXT:    vand.vx v24, v24, a0
+; RV64V-NEXT:    vor.vv v8, v8, v16
+; RV64V-NEXT:    vsrl.vi v16, v8, 4
+; RV64V-NEXT:    lui a0, 1
+; RV64V-NEXT:    addi a0, a0, -241
+; RV64V-NEXT:    vand.vx v16, v16, a0
 ; RV64V-NEXT:    vand.vx v8, v8, a0
 ; RV64V-NEXT:    vsll.vi v8, v8, 4
-; RV64V-NEXT:    vor.vv v8, v24, v8
-; RV64V-NEXT:    vsrl.vi v24, v8, 2
+; RV64V-NEXT:    vor.vv v8, v16, v8
+; RV64V-NEXT:    vsrl.vi v16, v8, 2
 ; RV64V-NEXT:    lui a1, 3
 ; RV64V-NEXT:    addi a1, a1, 819
-; RV64V-NEXT:    vand.vx v24, v24, a1
+; RV64V-NEXT:    vand.vx v16, v16, a1
 ; RV64V-NEXT:    vand.vx v8, v8, a1
 ; RV64V-NEXT:    vsll.vi v8, v8, 2
-; RV64V-NEXT:    vor.vv v8, v24, v8
-; RV64V-NEXT:    vsrl.vi v24, v8, 1
-; RV64V-NEXT:    lui a2, 5
-; RV64V-NEXT:    addi a2, a2, 1365
-; RV64V-NEXT:    vand.vx v24, v24, a2
+; RV64V-NEXT:    vor.vv v8, v16, v8
+; RV64V-NEXT:    vsrl.vi v16, v8, 1
+; RV64V-NEXT:    lui a4, 5
+; RV64V-NEXT:    addi a2, a4, 1365
+; RV64V-NEXT:    vand.vx v16, v16, a2
 ; RV64V-NEXT:    vand.vx v8, v8, a2
 ; RV64V-NEXT:    vadd.vv v8, v8, v8
-; RV64V-NEXT:    vor.vv v8, v24, v8
-; RV64V-NEXT:    vsrl.vi v24, v16, 8
-; RV64V-NEXT:    vsll.vi v16, v16, 8
-; RV64V-NEXT:    vor.vv v16, v16, v24
+; RV64V-NEXT:    vor.vv v8, v16, v8
+; RV64V-NEXT:    lui a3, 2
+; RV64V-NEXT:    addi a3, a3, 1170
+; RV64V-NEXT:    vand.vx v16, v8, a3
+; RV64V-NEXT:    csrr a5, vlenb
+; RV64V-NEXT:    slli a5, a5, 6
+; RV64V-NEXT:    add a5, sp, a5
+; RV64V-NEXT:    addi a5, a5, 16
+; RV64V-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vsrl.vi v16, v24, 8
+; RV64V-NEXT:    vsll.vi v24, v24, 8
+; RV64V-NEXT:    vor.vv v16, v24, v16
 ; RV64V-NEXT:    vsrl.vi v24, v16, 4
 ; RV64V-NEXT:    vand.vx v24, v24, a0
 ; RV64V-NEXT:    vand.vx v16, v16, a0
@@ -11661,268 +13362,258 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV64V-NEXT:    vand.vx v16, v16, a2
 ; RV64V-NEXT:    vadd.vv v16, v16, v16
 ; RV64V-NEXT:    vor.vv v16, v24, v16
-; RV64V-NEXT:    vand.vi v24, v16, 2
-; RV64V-NEXT:    vand.vi v0, v16, 1
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    vmul.vv v0, v8, v0
+; RV64V-NEXT:    lui a5, 9
+; RV64V-NEXT:    addi a5, a5, 585
+; RV64V-NEXT:    vand.vx v24, v8, a5
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a7, a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    addi a4, a4, -1756
+; RV64V-NEXT:    vand.vx v8, v8, a4
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 4
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v0, v16, a5
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 4
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v0, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v8, v16, a3
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    vand.vx v16, v16, a4
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 6
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v24, v0
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 2
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a7, a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v24, v8
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 5
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 4
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v24, v16
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 2
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 5
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v24, v8, v24
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vxor.vv v24, v24, v8
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 2
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 6
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v24, v16
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 5
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a7, a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v24, v0
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 4
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v24, v24, v8
+; RV64V-NEXT:    addi a6, sp, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 5
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 1
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v0, v16, 4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vi v24, v16, 8
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 16
-; RV64V-NEXT:    vand.vx v0, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 32
-; RV64V-NEXT:    vand.vx v24, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 64
-; RV64V-NEXT:    vand.vx v0, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 128
-; RV64V-NEXT:    vand.vx v24, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 256
-; RV64V-NEXT:    vand.vx v0, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 512
-; RV64V-NEXT:    vand.vx v24, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    mv a5, a4
-; RV64V-NEXT:    slli a4, a4, 1
-; RV64V-NEXT:    add a4, a4, a5
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 1024
-; RV64V-NEXT:    vand.vx v24, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    li a4, 1
-; RV64V-NEXT:    slli a4, a4, 11
-; RV64V-NEXT:    vand.vx v0, v16, a4
-; RV64V-NEXT:    vmul.vv v24, v8, v0
-; RV64V-NEXT:    addi a4, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 3
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    addi a6, sp, 16
+; RV64V-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    vxor.vv v24, v24, v0
-; RV64V-NEXT:    addi a4, sp, 16
-; RV64V-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v24, v0
-; RV64V-NEXT:    csrr a4, vlenb
-; RV64V-NEXT:    slli a4, a4, 4
-; RV64V-NEXT:    add a4, sp, a4
-; RV64V-NEXT:    addi a4, a4, 16
-; RV64V-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    vand.vx v0, v16, a3
-; RV64V-NEXT:    vmul.vv v24, v8, v0
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 5
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a6, vlenb
+; RV64V-NEXT:    slli a6, a6, 3
+; RV64V-NEXT:    mv a7, a6
+; RV64V-NEXT:    slli a6, a6, 2
+; RV64V-NEXT:    add a6, a6, a7
+; RV64V-NEXT:    add a6, sp, a6
+; RV64V-NEXT:    addi a6, a6, 16
+; RV64V-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v0, v24, a3
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vand.vx v24, v24, a5
+; RV64V-NEXT:    vor.vv v24, v24, v0
 ; RV64V-NEXT:    csrr a3, vlenb
 ; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a5, a3
+; RV64V-NEXT:    slli a3, a3, 2
+; RV64V-NEXT:    add a3, a3, a5
 ; RV64V-NEXT:    add a3, sp, a3
 ; RV64V-NEXT:    addi a3, a3, 16
 ; RV64V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
-; RV64V-NEXT:    lui a3, 2
-; RV64V-NEXT:    vand.vx v24, v16, a3
-; RV64V-NEXT:    vmul.vv v24, v8, v24
-; RV64V-NEXT:    addi a3, sp, 16
-; RV64V-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 6
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v8, v24, v8
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 3
+; RV64V-NEXT:    mv a5, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a5, a5, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64V-NEXT:    vmul.vv v16, v24, v16
+; RV64V-NEXT:    csrr a3, vlenb
+; RV64V-NEXT:    slli a3, a3, 4
+; RV64V-NEXT:    mv a5, a3
+; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    add a3, a3, a5
+; RV64V-NEXT:    add a3, sp, a3
+; RV64V-NEXT:    addi a3, a3, 16
+; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
 ; RV64V-NEXT:    csrr a3, vlenb
 ; RV64V-NEXT:    slli a3, a3, 4
 ; RV64V-NEXT:    add a3, sp, a3
 ; RV64V-NEXT:    addi a3, a3, 16
 ; RV64V-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    csrr a3, vlenb
-; RV64V-NEXT:    slli a3, a3, 3
-; RV64V-NEXT:    add a3, sp, a3
-; RV64V-NEXT:    addi a3, a3, 16
-; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v0, v0, v24
-; RV64V-NEXT:    addi a3, sp, 16
-; RV64V-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vxor.vv v24, v0, v24
-; RV64V-NEXT:    lui a3, 4
-; RV64V-NEXT:    vand.vx v0, v16, a3
-; RV64V-NEXT:    vmul.vv v0, v8, v0
-; RV64V-NEXT:    lui a3, 8
-; RV64V-NEXT:    vand.vx v16, v16, a3
-; RV64V-NEXT:    vmul.vv v8, v8, v16
-; RV64V-NEXT:    vxor.vv v16, v24, v0
+; RV64V-NEXT:    vmul.vv v0, v24, v0
 ; RV64V-NEXT:    vxor.vv v8, v16, v8
+; RV64V-NEXT:    vxor.vv v8, v8, v0
+; RV64V-NEXT:    vand.vx v8, v8, a4
 ; RV64V-NEXT:    csrr a3, vlenb
 ; RV64V-NEXT:    slli a3, a3, 3
 ; RV64V-NEXT:    mv a4, a3
-; RV64V-NEXT:    slli a3, a3, 1
+; RV64V-NEXT:    slli a3, a3, 2
 ; RV64V-NEXT:    add a3, a3, a4
 ; RV64V-NEXT:    add a3, sp, a3
 ; RV64V-NEXT:    addi a3, a3, 16
 ; RV64V-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
-; RV64V-NEXT:    vsll.vi v16, v16, 8
-; RV64V-NEXT:    vsrl.vi v8, v8, 8
 ; RV64V-NEXT:    vor.vv v8, v16, v8
+; RV64V-NEXT:    vsrl.vi v16, v8, 8
+; RV64V-NEXT:    vsll.vi v8, v8, 8
+; RV64V-NEXT:    vor.vv v8, v8, v16
 ; RV64V-NEXT:    vsrl.vi v16, v8, 4
 ; RV64V-NEXT:    vand.vx v16, v16, a0
 ; RV64V-NEXT:    vand.vx v8, v8, a0
@@ -11940,7 +13631,10 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV64V-NEXT:    vor.vv v8, v16, v8
 ; RV64V-NEXT:    vsrl.vi v8, v8, 1
 ; RV64V-NEXT:    csrr a0, vlenb
-; RV64V-NEXT:    slli a0, a0, 5
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    mv a1, a0
+; RV64V-NEXT:    slli a0, a0, 3
+; RV64V-NEXT:    add a0, a0, a1
 ; RV64V-NEXT:    add sp, sp, a0
 ; RV64V-NEXT:    addi sp, sp, 16
 ; RV64V-NEXT:    ret
@@ -11949,37 +13643,48 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV32ZVBC64:       # %bb.0:
 ; RV32ZVBC64-NEXT:    addi sp, sp, -16
 ; RV32ZVBC64-NEXT:    csrr a1, vlenb
-; RV32ZVBC64-NEXT:    slli a1, a1, 5
+; RV32ZVBC64-NEXT:    slli a1, a1, 3
+; RV32ZVBC64-NEXT:    mv a2, a1
+; RV32ZVBC64-NEXT:    slli a1, a1, 3
+; RV32ZVBC64-NEXT:    add a1, a1, a2
 ; RV32ZVBC64-NEXT:    sub sp, sp, a1
 ; RV32ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV32ZVBC64-NEXT:    vmv.v.x v16, a0
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v8, 8
+; RV32ZVBC64-NEXT:    vmv.v.x v24, a0
+; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 8
 ; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 8
-; RV32ZVBC64-NEXT:    vor.vv v8, v8, v24
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v8, 4
-; RV32ZVBC64-NEXT:    lui a3, 1
-; RV32ZVBC64-NEXT:    addi a0, a3, -241
-; RV32ZVBC64-NEXT:    vand.vx v24, v24, a0
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v16
+; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 4
+; RV32ZVBC64-NEXT:    lui a0, 1
+; RV32ZVBC64-NEXT:    addi a0, a0, -241
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
 ; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
 ; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 4
-; RV32ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v8, 2
+; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 2
 ; RV32ZVBC64-NEXT:    lui a1, 3
 ; RV32ZVBC64-NEXT:    addi a1, a1, 819
-; RV32ZVBC64-NEXT:    vand.vx v24, v24, a1
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a1
 ; RV32ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 2
-; RV32ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v8, 1
-; RV32ZVBC64-NEXT:    lui a2, 5
-; RV32ZVBC64-NEXT:    addi a2, a2, 1365
-; RV32ZVBC64-NEXT:    vand.vx v24, v24, a2
+; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 1
+; RV32ZVBC64-NEXT:    lui a4, 5
+; RV32ZVBC64-NEXT:    addi a2, a4, 1365
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a2
 ; RV32ZVBC64-NEXT:    vand.vx v8, v8, a2
 ; RV32ZVBC64-NEXT:    vadd.vv v8, v8, v8
-; RV32ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV32ZVBC64-NEXT:    vsrl.vi v24, v16, 8
-; RV32ZVBC64-NEXT:    vsll.vi v16, v16, 8
-; RV32ZVBC64-NEXT:    vor.vv v16, v16, v24
+; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    lui a3, 2
+; RV32ZVBC64-NEXT:    addi a3, a3, 1170
+; RV32ZVBC64-NEXT:    vand.vx v16, v8, a3
+; RV32ZVBC64-NEXT:    csrr a5, vlenb
+; RV32ZVBC64-NEXT:    slli a5, a5, 6
+; RV32ZVBC64-NEXT:    add a5, sp, a5
+; RV32ZVBC64-NEXT:    addi a5, a5, 16
+; RV32ZVBC64-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vsrl.vi v16, v24, 8
+; RV32ZVBC64-NEXT:    vsll.vi v24, v24, 8
+; RV32ZVBC64-NEXT:    vor.vv v16, v24, v16
 ; RV32ZVBC64-NEXT:    vsrl.vi v24, v16, 4
 ; RV32ZVBC64-NEXT:    vand.vx v24, v24, a0
 ; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
@@ -11995,268 +13700,258 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV32ZVBC64-NEXT:    vand.vx v16, v16, a2
 ; RV32ZVBC64-NEXT:    vadd.vv v16, v16, v16
 ; RV32ZVBC64-NEXT:    vor.vv v16, v24, v16
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
+; RV32ZVBC64-NEXT:    lui a5, 9
+; RV32ZVBC64-NEXT:    addi a5, a5, 585
+; RV32ZVBC64-NEXT:    vand.vx v24, v8, a5
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a7, a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    addi a4, a4, -1756
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a4
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 4
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v0, v16, a5
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 4
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v0, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v8, v16, a3
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    vand.vx v16, v16, a4
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 6
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v24, v0
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 2
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a7, a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v24, v8
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 5
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 4
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v24, v16
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 2
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 5
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v24, v8, v24
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vxor.vv v24, v24, v8
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 2
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 6
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v24, v16
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 5
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a7, a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v24, v0
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 4
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v24, v24, v8
+; RV32ZVBC64-NEXT:    addi a6, sp, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 5
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 1
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 16
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 32
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 64
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 128
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 256
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 512
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    mv a5, a4
-; RV32ZVBC64-NEXT:    slli a4, a4, 1
-; RV32ZVBC64-NEXT:    add a4, a4, a5
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 1024
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    li a4, 1
-; RV32ZVBC64-NEXT:    slli a4, a4, 11
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV32ZVBC64-NEXT:    addi a4, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 3
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    addi a6, sp, 16
+; RV32ZVBC64-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    vxor.vv v24, v24, v0
-; RV32ZVBC64-NEXT:    addi a4, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v24, v0
-; RV32ZVBC64-NEXT:    csrr a4, vlenb
-; RV32ZVBC64-NEXT:    slli a4, a4, 4
-; RV32ZVBC64-NEXT:    add a4, sp, a4
-; RV32ZVBC64-NEXT:    addi a4, a4, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a3
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v0
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 5
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a6, vlenb
+; RV32ZVBC64-NEXT:    slli a6, a6, 3
+; RV32ZVBC64-NEXT:    mv a7, a6
+; RV32ZVBC64-NEXT:    slli a6, a6, 2
+; RV32ZVBC64-NEXT:    add a6, a6, a7
+; RV32ZVBC64-NEXT:    add a6, sp, a6
+; RV32ZVBC64-NEXT:    addi a6, a6, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v0, v24, a3
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vand.vx v24, v24, a5
+; RV32ZVBC64-NEXT:    vor.vv v24, v24, v0
 ; RV32ZVBC64-NEXT:    csrr a3, vlenb
 ; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a5, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
+; RV32ZVBC64-NEXT:    add a3, a3, a5
 ; RV32ZVBC64-NEXT:    add a3, sp, a3
 ; RV32ZVBC64-NEXT:    addi a3, a3, 16
 ; RV32ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
-; RV32ZVBC64-NEXT:    lui a3, 2
-; RV32ZVBC64-NEXT:    vand.vx v24, v16, a3
-; RV32ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV32ZVBC64-NEXT:    addi a3, sp, 16
-; RV32ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 6
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v8, v24, v8
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 3
+; RV32ZVBC64-NEXT:    mv a5, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a5, a5, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV32ZVBC64-NEXT:    vmul.vv v16, v24, v16
+; RV32ZVBC64-NEXT:    csrr a3, vlenb
+; RV32ZVBC64-NEXT:    slli a3, a3, 4
+; RV32ZVBC64-NEXT:    mv a5, a3
+; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    add a3, a3, a5
+; RV32ZVBC64-NEXT:    add a3, sp, a3
+; RV32ZVBC64-NEXT:    addi a3, a3, 16
+; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
 ; RV32ZVBC64-NEXT:    csrr a3, vlenb
 ; RV32ZVBC64-NEXT:    slli a3, a3, 4
 ; RV32ZVBC64-NEXT:    add a3, sp, a3
 ; RV32ZVBC64-NEXT:    addi a3, a3, 16
 ; RV32ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    csrr a3, vlenb
-; RV32ZVBC64-NEXT:    slli a3, a3, 3
-; RV32ZVBC64-NEXT:    add a3, sp, a3
-; RV32ZVBC64-NEXT:    addi a3, a3, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV32ZVBC64-NEXT:    addi a3, sp, 16
-; RV32ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV32ZVBC64-NEXT:    lui a3, 4
-; RV32ZVBC64-NEXT:    vand.vx v0, v16, a3
-; RV32ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV32ZVBC64-NEXT:    lui a3, 8
-; RV32ZVBC64-NEXT:    vand.vx v16, v16, a3
-; RV32ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV32ZVBC64-NEXT:    vxor.vv v16, v24, v0
+; RV32ZVBC64-NEXT:    vmul.vv v0, v24, v0
 ; RV32ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vxor.vv v8, v8, v0
+; RV32ZVBC64-NEXT:    vand.vx v8, v8, a4
 ; RV32ZVBC64-NEXT:    csrr a3, vlenb
 ; RV32ZVBC64-NEXT:    slli a3, a3, 3
 ; RV32ZVBC64-NEXT:    mv a4, a3
-; RV32ZVBC64-NEXT:    slli a3, a3, 1
+; RV32ZVBC64-NEXT:    slli a3, a3, 2
 ; RV32ZVBC64-NEXT:    add a3, a3, a4
 ; RV32ZVBC64-NEXT:    add a3, sp, a3
 ; RV32ZVBC64-NEXT:    addi a3, a3, 16
 ; RV32ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
-; RV32ZVBC64-NEXT:    vsll.vi v16, v16, 8
-; RV32ZVBC64-NEXT:    vsrl.vi v8, v8, 8
 ; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 8
+; RV32ZVBC64-NEXT:    vsll.vi v8, v8, 8
+; RV32ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV32ZVBC64-NEXT:    vsrl.vi v16, v8, 4
 ; RV32ZVBC64-NEXT:    vand.vx v16, v16, a0
 ; RV32ZVBC64-NEXT:    vand.vx v8, v8, a0
@@ -12274,7 +13969,10 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV32ZVBC64-NEXT:    vor.vv v8, v16, v8
 ; RV32ZVBC64-NEXT:    vsrl.vi v8, v8, 1
 ; RV32ZVBC64-NEXT:    csrr a0, vlenb
-; RV32ZVBC64-NEXT:    slli a0, a0, 5
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    mv a1, a0
+; RV32ZVBC64-NEXT:    slli a0, a0, 3
+; RV32ZVBC64-NEXT:    add a0, a0, a1
 ; RV32ZVBC64-NEXT:    add sp, sp, a0
 ; RV32ZVBC64-NEXT:    addi sp, sp, 16
 ; RV32ZVBC64-NEXT:    ret
@@ -12283,37 +13981,48 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV64ZVBC64:       # %bb.0:
 ; RV64ZVBC64-NEXT:    addi sp, sp, -16
 ; RV64ZVBC64-NEXT:    csrr a1, vlenb
-; RV64ZVBC64-NEXT:    slli a1, a1, 5
+; RV64ZVBC64-NEXT:    slli a1, a1, 3
+; RV64ZVBC64-NEXT:    mv a2, a1
+; RV64ZVBC64-NEXT:    slli a1, a1, 3
+; RV64ZVBC64-NEXT:    add a1, a1, a2
 ; RV64ZVBC64-NEXT:    sub sp, sp, a1
 ; RV64ZVBC64-NEXT:    vsetvli a1, zero, e16, m8, ta, ma
-; RV64ZVBC64-NEXT:    vmv.v.x v16, a0
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v8, 8
+; RV64ZVBC64-NEXT:    vmv.v.x v24, a0
+; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 8
 ; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 8
-; RV64ZVBC64-NEXT:    vor.vv v8, v8, v24
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v8, 4
-; RV64ZVBC64-NEXT:    lui a3, 1
-; RV64ZVBC64-NEXT:    addi a0, a3, -241
-; RV64ZVBC64-NEXT:    vand.vx v24, v24, a0
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v16
+; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 4
+; RV64ZVBC64-NEXT:    lui a0, 1
+; RV64ZVBC64-NEXT:    addi a0, a0, -241
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
 ; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
 ; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 4
-; RV64ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v8, 2
+; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 2
 ; RV64ZVBC64-NEXT:    lui a1, 3
 ; RV64ZVBC64-NEXT:    addi a1, a1, 819
-; RV64ZVBC64-NEXT:    vand.vx v24, v24, a1
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a1
 ; RV64ZVBC64-NEXT:    vand.vx v8, v8, a1
 ; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 2
-; RV64ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v8, 1
-; RV64ZVBC64-NEXT:    lui a2, 5
-; RV64ZVBC64-NEXT:    addi a2, a2, 1365
-; RV64ZVBC64-NEXT:    vand.vx v24, v24, a2
+; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 1
+; RV64ZVBC64-NEXT:    lui a4, 5
+; RV64ZVBC64-NEXT:    addi a2, a4, 1365
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a2
 ; RV64ZVBC64-NEXT:    vand.vx v8, v8, a2
 ; RV64ZVBC64-NEXT:    vadd.vv v8, v8, v8
-; RV64ZVBC64-NEXT:    vor.vv v8, v24, v8
-; RV64ZVBC64-NEXT:    vsrl.vi v24, v16, 8
-; RV64ZVBC64-NEXT:    vsll.vi v16, v16, 8
-; RV64ZVBC64-NEXT:    vor.vv v16, v16, v24
+; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    lui a3, 2
+; RV64ZVBC64-NEXT:    addi a3, a3, 1170
+; RV64ZVBC64-NEXT:    vand.vx v16, v8, a3
+; RV64ZVBC64-NEXT:    csrr a5, vlenb
+; RV64ZVBC64-NEXT:    slli a5, a5, 6
+; RV64ZVBC64-NEXT:    add a5, sp, a5
+; RV64ZVBC64-NEXT:    addi a5, a5, 16
+; RV64ZVBC64-NEXT:    vs8r.v v16, (a5) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vsrl.vi v16, v24, 8
+; RV64ZVBC64-NEXT:    vsll.vi v24, v24, 8
+; RV64ZVBC64-NEXT:    vor.vv v16, v24, v16
 ; RV64ZVBC64-NEXT:    vsrl.vi v24, v16, 4
 ; RV64ZVBC64-NEXT:    vand.vx v24, v24, a0
 ; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
@@ -12329,268 +14038,258 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV64ZVBC64-NEXT:    vand.vx v16, v16, a2
 ; RV64ZVBC64-NEXT:    vadd.vv v16, v16, v16
 ; RV64ZVBC64-NEXT:    vor.vv v16, v24, v16
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 2
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 1
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
+; RV64ZVBC64-NEXT:    lui a5, 9
+; RV64ZVBC64-NEXT:    addi a5, a5, 585
+; RV64ZVBC64-NEXT:    vand.vx v24, v8, a5
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a7, a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    addi a4, a4, -1756
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a4
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 4
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v0, v16, a5
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 4
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v0, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v8, v16, a3
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    vand.vx v16, v16, a4
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 6
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v24, v0
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 2
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a7, a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v24, v8
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 5
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 4
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v24, v16
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v8, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 2
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 5
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v24, v8, v24
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vxor.vv v24, v24, v8
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 2
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 6
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v24, v16
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 5
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a7, a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v24, v0
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 4
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v8, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v24, v24, v8
+; RV64ZVBC64-NEXT:    addi a6, sp, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 5
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 1
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v0, v16, 4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vi v24, v16, 8
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 16
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 32
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 64
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 128
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 256
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 512
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    mv a5, a4
-; RV64ZVBC64-NEXT:    slli a4, a4, 1
-; RV64ZVBC64-NEXT:    add a4, a4, a5
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 1024
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    li a4, 1
-; RV64ZVBC64-NEXT:    slli a4, a4, 11
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a4
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
-; RV64ZVBC64-NEXT:    addi a4, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 3
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    addi a6, sp, 16
+; RV64ZVBC64-NEXT:    vl8r.v v0, (a6) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    vxor.vv v24, v24, v0
-; RV64ZVBC64-NEXT:    addi a4, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v0, (a4) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v24, v0
-; RV64ZVBC64-NEXT:    csrr a4, vlenb
-; RV64ZVBC64-NEXT:    slli a4, a4, 4
-; RV64ZVBC64-NEXT:    add a4, sp, a4
-; RV64ZVBC64-NEXT:    addi a4, a4, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a4) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a3
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v0
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 5
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vs8r.v v24, (a6) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a6, vlenb
+; RV64ZVBC64-NEXT:    slli a6, a6, 3
+; RV64ZVBC64-NEXT:    mv a7, a6
+; RV64ZVBC64-NEXT:    slli a6, a6, 2
+; RV64ZVBC64-NEXT:    add a6, a6, a7
+; RV64ZVBC64-NEXT:    add a6, sp, a6
+; RV64ZVBC64-NEXT:    addi a6, a6, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a6) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v0, v24, a3
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vand.vx v24, v24, a5
+; RV64ZVBC64-NEXT:    vor.vv v24, v24, v0
 ; RV64ZVBC64-NEXT:    csrr a3, vlenb
 ; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a5, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
+; RV64ZVBC64-NEXT:    add a3, a3, a5
 ; RV64ZVBC64-NEXT:    add a3, sp, a3
 ; RV64ZVBC64-NEXT:    addi a3, a3, 16
 ; RV64ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
-; RV64ZVBC64-NEXT:    lui a3, 2
-; RV64ZVBC64-NEXT:    vand.vx v24, v16, a3
-; RV64ZVBC64-NEXT:    vmul.vv v24, v8, v24
-; RV64ZVBC64-NEXT:    addi a3, sp, 16
-; RV64ZVBC64-NEXT:    vs8r.v v24, (a3) # vscale x 64-byte Folded Spill
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 6
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v8, v24, v8
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 3
+; RV64ZVBC64-NEXT:    mv a5, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a5, a5, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
+; RV64ZVBC64-NEXT:    vmul.vv v16, v24, v16
+; RV64ZVBC64-NEXT:    csrr a3, vlenb
+; RV64ZVBC64-NEXT:    slli a3, a3, 4
+; RV64ZVBC64-NEXT:    mv a5, a3
+; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    add a3, a3, a5
+; RV64ZVBC64-NEXT:    add a3, sp, a3
+; RV64ZVBC64-NEXT:    addi a3, a3, 16
+; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
 ; RV64ZVBC64-NEXT:    csrr a3, vlenb
 ; RV64ZVBC64-NEXT:    slli a3, a3, 4
 ; RV64ZVBC64-NEXT:    add a3, sp, a3
 ; RV64ZVBC64-NEXT:    addi a3, a3, 16
 ; RV64ZVBC64-NEXT:    vl8r.v v0, (a3) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    csrr a3, vlenb
-; RV64ZVBC64-NEXT:    slli a3, a3, 3
-; RV64ZVBC64-NEXT:    add a3, sp, a3
-; RV64ZVBC64-NEXT:    addi a3, a3, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v0, v0, v24
-; RV64ZVBC64-NEXT:    addi a3, sp, 16
-; RV64ZVBC64-NEXT:    vl8r.v v24, (a3) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vxor.vv v24, v0, v24
-; RV64ZVBC64-NEXT:    lui a3, 4
-; RV64ZVBC64-NEXT:    vand.vx v0, v16, a3
-; RV64ZVBC64-NEXT:    vmul.vv v0, v8, v0
-; RV64ZVBC64-NEXT:    lui a3, 8
-; RV64ZVBC64-NEXT:    vand.vx v16, v16, a3
-; RV64ZVBC64-NEXT:    vmul.vv v8, v8, v16
-; RV64ZVBC64-NEXT:    vxor.vv v16, v24, v0
+; RV64ZVBC64-NEXT:    vmul.vv v0, v24, v0
 ; RV64ZVBC64-NEXT:    vxor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vxor.vv v8, v8, v0
+; RV64ZVBC64-NEXT:    vand.vx v8, v8, a4
 ; RV64ZVBC64-NEXT:    csrr a3, vlenb
 ; RV64ZVBC64-NEXT:    slli a3, a3, 3
 ; RV64ZVBC64-NEXT:    mv a4, a3
-; RV64ZVBC64-NEXT:    slli a3, a3, 1
+; RV64ZVBC64-NEXT:    slli a3, a3, 2
 ; RV64ZVBC64-NEXT:    add a3, a3, a4
 ; RV64ZVBC64-NEXT:    add a3, sp, a3
 ; RV64ZVBC64-NEXT:    addi a3, a3, 16
 ; RV64ZVBC64-NEXT:    vl8r.v v16, (a3) # vscale x 64-byte Folded Reload
-; RV64ZVBC64-NEXT:    vsll.vi v16, v16, 8
-; RV64ZVBC64-NEXT:    vsrl.vi v8, v8, 8
 ; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
+; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 8
+; RV64ZVBC64-NEXT:    vsll.vi v8, v8, 8
+; RV64ZVBC64-NEXT:    vor.vv v8, v8, v16
 ; RV64ZVBC64-NEXT:    vsrl.vi v16, v8, 4
 ; RV64ZVBC64-NEXT:    vand.vx v16, v16, a0
 ; RV64ZVBC64-NEXT:    vand.vx v8, v8, a0
@@ -12608,7 +14307,10 @@ define <vscale x 32 x i16> @clmulh_nxv32i16_vx(<vscale x 32 x i16> %va, i16 %b) 
 ; RV64ZVBC64-NEXT:    vor.vv v8, v16, v8
 ; RV64ZVBC64-NEXT:    vsrl.vi v8, v8, 1
 ; RV64ZVBC64-NEXT:    csrr a0, vlenb
-; RV64ZVBC64-NEXT:    slli a0, a0, 5
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    mv a1, a0
+; RV64ZVBC64-NEXT:    slli a0, a0, 3
+; RV64ZVBC64-NEXT:    add a0, a0, a1
 ; RV64ZVBC64-NEXT:    add sp, sp, a0
 ; RV64ZVBC64-NEXT:    addi sp, sp, 16
 ; RV64ZVBC64-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-clmul.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-clmul.ll
@@ -1538,34 +1538,22 @@ define <8 x i64> @clmul_v8i64(<8 x i64> %x, <8 x i64> %y) nounwind {
 define <4 x i8> @clmul_v4i8(<4 x i8> %a, <4 x i8> %b) nounwind {
 ; CHECK-LABEL: clmul_v4i8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    li a0, 16
+; CHECK-NEXT:    li a0, 85
+; CHECK-NEXT:    li a1, 170
 ; CHECK-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; CHECK-NEXT:    vand.vi v10, v9, 2
-; CHECK-NEXT:    vand.vi v11, v9, 1
-; CHECK-NEXT:    vmul.vv v10, v8, v10
-; CHECK-NEXT:    vmul.vv v11, v8, v11
-; CHECK-NEXT:    vand.vi v12, v9, 4
-; CHECK-NEXT:    vand.vi v13, v9, 8
-; CHECK-NEXT:    vmul.vv v12, v8, v12
-; CHECK-NEXT:    vxor.vv v10, v11, v10
-; CHECK-NEXT:    vand.vx v11, v9, a0
-; CHECK-NEXT:    vmul.vv v13, v8, v13
-; CHECK-NEXT:    vxor.vv v10, v10, v12
-; CHECK-NEXT:    li a0, 32
-; CHECK-NEXT:    vmul.vv v11, v8, v11
-; CHECK-NEXT:    vand.vx v12, v9, a0
-; CHECK-NEXT:    li a0, 64
-; CHECK-NEXT:    vxor.vv v10, v10, v13
-; CHECK-NEXT:    vand.vx v13, v9, a0
-; CHECK-NEXT:    vmul.vv v12, v8, v12
-; CHECK-NEXT:    vxor.vv v10, v10, v11
-; CHECK-NEXT:    vmul.vv v11, v8, v13
-; CHECK-NEXT:    li a0, 128
-; CHECK-NEXT:    vand.vx v9, v9, a0
-; CHECK-NEXT:    vxor.vv v10, v10, v12
-; CHECK-NEXT:    vmul.vv v8, v8, v9
-; CHECK-NEXT:    vxor.vv v9, v10, v11
-; CHECK-NEXT:    vxor.vv v8, v9, v8
+; CHECK-NEXT:    vand.vx v10, v9, a0
+; CHECK-NEXT:    vand.vx v11, v8, a1
+; CHECK-NEXT:    vand.vx v9, v9, a1
+; CHECK-NEXT:    vand.vx v8, v8, a0
+; CHECK-NEXT:    vmul.vv v12, v11, v10
+; CHECK-NEXT:    vmul.vv v13, v8, v9
+; CHECK-NEXT:    vmul.vv v9, v11, v9
+; CHECK-NEXT:    vmul.vv v8, v8, v10
+; CHECK-NEXT:    vxor.vv v10, v13, v12
+; CHECK-NEXT:    vxor.vv v8, v8, v9
+; CHECK-NEXT:    vand.vx v9, v10, a1
+; CHECK-NEXT:    vand.vx v8, v8, a0
+; CHECK-NEXT:    vor.vv v8, v8, v9
 ; CHECK-NEXT:    ret
   %res = call <4 x i8> @llvm.clmul.v4i8(<4 x i8> %a, <4 x i8> %b)
   ret <4 x i8> %res
@@ -1574,67 +1562,39 @@ define <4 x i8> @clmul_v4i8(<4 x i8> %a, <4 x i8> %b) nounwind {
 define <4 x i16> @clmul_v4i16(<4 x i16> %a, <4 x i16> %b) nounwind {
 ; CHECK-LABEL: clmul_v4i16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    li a0, 16
+; CHECK-NEXT:    lui a0, 9
+; CHECK-NEXT:    lui a1, 2
+; CHECK-NEXT:    addi a0, a0, 585
+; CHECK-NEXT:    addi a1, a1, 1170
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vand.vi v10, v9, 2
-; CHECK-NEXT:    vand.vi v11, v9, 1
-; CHECK-NEXT:    vand.vi v12, v9, 4
-; CHECK-NEXT:    vmul.vv v10, v8, v10
-; CHECK-NEXT:    vmul.vv v11, v8, v11
-; CHECK-NEXT:    vand.vi v13, v9, 8
+; CHECK-NEXT:    vand.vx v10, v9, a0
+; CHECK-NEXT:    vand.vx v11, v8, a1
+; CHECK-NEXT:    lui a2, 5
+; CHECK-NEXT:    vand.vx v12, v9, a1
+; CHECK-NEXT:    addi a2, a2, -1756
+; CHECK-NEXT:    vand.vx v13, v8, a0
+; CHECK-NEXT:    vand.vx v9, v9, a2
+; CHECK-NEXT:    vand.vx v8, v8, a2
+; CHECK-NEXT:    vmul.vv v14, v11, v10
+; CHECK-NEXT:    vmul.vv v15, v13, v12
+; CHECK-NEXT:    vmul.vv v16, v11, v9
+; CHECK-NEXT:    vmul.vv v17, v13, v10
+; CHECK-NEXT:    vmul.vv v18, v8, v9
+; CHECK-NEXT:    vmul.vv v11, v11, v12
 ; CHECK-NEXT:    vmul.vv v12, v8, v12
-; CHECK-NEXT:    vxor.vv v10, v11, v10
-; CHECK-NEXT:    vmul.vv v11, v8, v13
-; CHECK-NEXT:    vand.vx v13, v9, a0
-; CHECK-NEXT:    li a0, 32
-; CHECK-NEXT:    vxor.vv v10, v10, v12
-; CHECK-NEXT:    vand.vx v12, v9, a0
-; CHECK-NEXT:    vmul.vv v13, v8, v13
-; CHECK-NEXT:    li a0, 64
-; CHECK-NEXT:    vxor.vv v10, v10, v11
-; CHECK-NEXT:    vand.vx v11, v9, a0
-; CHECK-NEXT:    vmul.vv v12, v8, v12
-; CHECK-NEXT:    vxor.vv v10, v10, v13
-; CHECK-NEXT:    li a0, 128
-; CHECK-NEXT:    vmul.vv v11, v8, v11
-; CHECK-NEXT:    vand.vx v13, v9, a0
-; CHECK-NEXT:    li a0, 256
-; CHECK-NEXT:    vxor.vv v10, v10, v12
-; CHECK-NEXT:    vand.vx v12, v9, a0
-; CHECK-NEXT:    vmul.vv v13, v8, v13
-; CHECK-NEXT:    li a0, 512
-; CHECK-NEXT:    vxor.vv v10, v10, v11
-; CHECK-NEXT:    vand.vx v11, v9, a0
-; CHECK-NEXT:    vmul.vv v12, v8, v12
-; CHECK-NEXT:    vxor.vv v10, v10, v13
-; CHECK-NEXT:    li a0, 1024
-; CHECK-NEXT:    vmul.vv v11, v8, v11
-; CHECK-NEXT:    vand.vx v13, v9, a0
-; CHECK-NEXT:    li a0, 1
-; CHECK-NEXT:    slli a0, a0, 11
-; CHECK-NEXT:    vxor.vv v10, v10, v12
-; CHECK-NEXT:    vand.vx v12, v9, a0
-; CHECK-NEXT:    vmul.vv v13, v8, v13
-; CHECK-NEXT:    lui a0, 1
-; CHECK-NEXT:    vxor.vv v10, v10, v11
-; CHECK-NEXT:    vand.vx v11, v9, a0
-; CHECK-NEXT:    vmul.vv v12, v8, v12
-; CHECK-NEXT:    vxor.vv v10, v10, v13
-; CHECK-NEXT:    lui a0, 2
-; CHECK-NEXT:    vmul.vv v11, v8, v11
-; CHECK-NEXT:    vand.vx v13, v9, a0
-; CHECK-NEXT:    lui a0, 4
-; CHECK-NEXT:    vxor.vv v10, v10, v12
-; CHECK-NEXT:    vand.vx v12, v9, a0
-; CHECK-NEXT:    vmul.vv v13, v8, v13
-; CHECK-NEXT:    vxor.vv v10, v10, v11
-; CHECK-NEXT:    vmul.vv v11, v8, v12
-; CHECK-NEXT:    lui a0, 8
-; CHECK-NEXT:    vand.vx v9, v9, a0
-; CHECK-NEXT:    vxor.vv v10, v10, v13
-; CHECK-NEXT:    vmul.vv v8, v8, v9
-; CHECK-NEXT:    vxor.vv v9, v10, v11
+; CHECK-NEXT:    vmul.vv v9, v13, v9
+; CHECK-NEXT:    vxor.vv v13, v15, v14
+; CHECK-NEXT:    vxor.vv v14, v17, v16
+; CHECK-NEXT:    vmul.vv v8, v8, v10
+; CHECK-NEXT:    vxor.vv v10, v13, v18
+; CHECK-NEXT:    vxor.vv v12, v14, v12
+; CHECK-NEXT:    vxor.vv v9, v9, v11
+; CHECK-NEXT:    vand.vx v10, v10, a1
+; CHECK-NEXT:    vand.vx v11, v12, a0
 ; CHECK-NEXT:    vxor.vv v8, v9, v8
+; CHECK-NEXT:    vor.vv v9, v11, v10
+; CHECK-NEXT:    vand.vx v8, v8, a2
+; CHECK-NEXT:    vor.vv v8, v9, v8
 ; CHECK-NEXT:    ret
   %res = call <4 x i16> @llvm.clmul.v4i16(<4 x i16> %a, <4 x i16> %b)
   ret <4 x i16> %res
@@ -1643,69 +1603,41 @@ define <4 x i16> @clmul_v4i16(<4 x i16> %a, <4 x i16> %b) nounwind {
 define <4 x i8> @clmulr_v4i8(<4 x i8> %a, <4 x i8> %b) nounwind {
 ; CHECK-LABEL: clmulr_v4i8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    li a0, 16
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vzext.vf2 v10, v9
 ; CHECK-NEXT:    vzext.vf2 v9, v8
-; CHECK-NEXT:    vand.vi v8, v10, 2
-; CHECK-NEXT:    vand.vi v11, v10, 1
-; CHECK-NEXT:    vand.vi v12, v10, 4
+; CHECK-NEXT:    lui a0, 9
+; CHECK-NEXT:    lui a1, 2
+; CHECK-NEXT:    addi a0, a0, 585
+; CHECK-NEXT:    addi a1, a1, 1170
+; CHECK-NEXT:    vand.vx v8, v10, a0
+; CHECK-NEXT:    vand.vx v11, v9, a1
+; CHECK-NEXT:    lui a2, 5
+; CHECK-NEXT:    vand.vx v12, v10, a1
+; CHECK-NEXT:    addi a2, a2, -1756
+; CHECK-NEXT:    vand.vx v13, v9, a0
+; CHECK-NEXT:    vand.vx v10, v10, a2
+; CHECK-NEXT:    vand.vx v9, v9, a2
+; CHECK-NEXT:    vmul.vv v14, v11, v8
+; CHECK-NEXT:    vmul.vv v15, v13, v12
+; CHECK-NEXT:    vmul.vv v16, v11, v10
+; CHECK-NEXT:    vmul.vv v17, v13, v8
+; CHECK-NEXT:    vmul.vv v18, v9, v10
+; CHECK-NEXT:    vmul.vv v11, v11, v12
+; CHECK-NEXT:    vmul.vv v12, v9, v12
+; CHECK-NEXT:    vmul.vv v10, v13, v10
+; CHECK-NEXT:    vxor.vv v13, v15, v14
+; CHECK-NEXT:    vxor.vv v14, v17, v16
 ; CHECK-NEXT:    vmul.vv v8, v9, v8
-; CHECK-NEXT:    vmul.vv v11, v9, v11
-; CHECK-NEXT:    vand.vi v13, v10, 8
-; CHECK-NEXT:    vmul.vv v12, v9, v12
-; CHECK-NEXT:    vxor.vv v8, v11, v8
-; CHECK-NEXT:    vmul.vv v11, v9, v13
-; CHECK-NEXT:    vand.vx v13, v10, a0
-; CHECK-NEXT:    li a0, 32
-; CHECK-NEXT:    vxor.vv v8, v8, v12
-; CHECK-NEXT:    vand.vx v12, v10, a0
-; CHECK-NEXT:    vmul.vv v13, v9, v13
-; CHECK-NEXT:    li a0, 64
-; CHECK-NEXT:    vxor.vv v8, v8, v11
-; CHECK-NEXT:    vand.vx v11, v10, a0
-; CHECK-NEXT:    vmul.vv v12, v9, v12
-; CHECK-NEXT:    vxor.vv v8, v8, v13
-; CHECK-NEXT:    li a0, 128
-; CHECK-NEXT:    vmul.vv v11, v9, v11
-; CHECK-NEXT:    vand.vx v13, v10, a0
-; CHECK-NEXT:    li a0, 256
-; CHECK-NEXT:    vxor.vv v8, v8, v12
-; CHECK-NEXT:    vand.vx v12, v10, a0
-; CHECK-NEXT:    vmul.vv v13, v9, v13
-; CHECK-NEXT:    li a0, 512
-; CHECK-NEXT:    vxor.vv v8, v8, v11
-; CHECK-NEXT:    vand.vx v11, v10, a0
-; CHECK-NEXT:    vmul.vv v12, v9, v12
-; CHECK-NEXT:    vxor.vv v8, v8, v13
-; CHECK-NEXT:    li a0, 1024
-; CHECK-NEXT:    vmul.vv v11, v9, v11
-; CHECK-NEXT:    vand.vx v13, v10, a0
-; CHECK-NEXT:    li a0, 1
-; CHECK-NEXT:    slli a0, a0, 11
-; CHECK-NEXT:    vxor.vv v8, v8, v12
-; CHECK-NEXT:    vand.vx v12, v10, a0
-; CHECK-NEXT:    vmul.vv v13, v9, v13
-; CHECK-NEXT:    lui a0, 1
-; CHECK-NEXT:    vxor.vv v8, v8, v11
-; CHECK-NEXT:    vand.vx v11, v10, a0
-; CHECK-NEXT:    vmul.vv v12, v9, v12
-; CHECK-NEXT:    vxor.vv v8, v8, v13
-; CHECK-NEXT:    lui a0, 2
-; CHECK-NEXT:    vmul.vv v11, v9, v11
-; CHECK-NEXT:    vand.vx v13, v10, a0
-; CHECK-NEXT:    lui a0, 4
-; CHECK-NEXT:    vxor.vv v8, v8, v12
-; CHECK-NEXT:    vand.vx v12, v10, a0
-; CHECK-NEXT:    vmul.vv v13, v9, v13
-; CHECK-NEXT:    vxor.vv v8, v8, v11
-; CHECK-NEXT:    vmul.vv v11, v9, v12
-; CHECK-NEXT:    lui a0, 8
-; CHECK-NEXT:    vand.vx v10, v10, a0
-; CHECK-NEXT:    vxor.vv v8, v8, v13
-; CHECK-NEXT:    vmul.vv v9, v9, v10
-; CHECK-NEXT:    vxor.vv v8, v8, v11
-; CHECK-NEXT:    vxor.vv v8, v8, v9
+; CHECK-NEXT:    vxor.vv v9, v13, v18
+; CHECK-NEXT:    vxor.vv v12, v14, v12
+; CHECK-NEXT:    vxor.vv v10, v10, v11
+; CHECK-NEXT:    vand.vx v9, v9, a1
+; CHECK-NEXT:    vand.vx v11, v12, a0
+; CHECK-NEXT:    vxor.vv v8, v10, v8
+; CHECK-NEXT:    vor.vv v9, v11, v9
+; CHECK-NEXT:    vand.vx v8, v8, a2
+; CHECK-NEXT:    vor.vv v8, v9, v8
 ; CHECK-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
 ; CHECK-NEXT:    vnsrl.wi v8, v8, 7
 ; CHECK-NEXT:    ret
@@ -1720,69 +1652,41 @@ define <4 x i8> @clmulr_v4i8(<4 x i8> %a, <4 x i8> %b) nounwind {
 define <4 x i8> @clmulh_v4i8(<4 x i8> %a, <4 x i8> %b) nounwind {
 ; CHECK-LABEL: clmulh_v4i8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    li a0, 16
 ; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
 ; CHECK-NEXT:    vzext.vf2 v10, v9
 ; CHECK-NEXT:    vzext.vf2 v9, v8
-; CHECK-NEXT:    vand.vi v8, v10, 2
-; CHECK-NEXT:    vand.vi v11, v10, 1
-; CHECK-NEXT:    vand.vi v12, v10, 4
+; CHECK-NEXT:    lui a0, 9
+; CHECK-NEXT:    lui a1, 2
+; CHECK-NEXT:    addi a0, a0, 585
+; CHECK-NEXT:    addi a1, a1, 1170
+; CHECK-NEXT:    vand.vx v8, v10, a0
+; CHECK-NEXT:    vand.vx v11, v9, a1
+; CHECK-NEXT:    lui a2, 5
+; CHECK-NEXT:    vand.vx v12, v10, a1
+; CHECK-NEXT:    addi a2, a2, -1756
+; CHECK-NEXT:    vand.vx v13, v9, a0
+; CHECK-NEXT:    vand.vx v10, v10, a2
+; CHECK-NEXT:    vand.vx v9, v9, a2
+; CHECK-NEXT:    vmul.vv v14, v11, v8
+; CHECK-NEXT:    vmul.vv v15, v13, v12
+; CHECK-NEXT:    vmul.vv v16, v11, v10
+; CHECK-NEXT:    vmul.vv v17, v13, v8
+; CHECK-NEXT:    vmul.vv v18, v9, v10
+; CHECK-NEXT:    vmul.vv v11, v11, v12
+; CHECK-NEXT:    vmul.vv v12, v9, v12
+; CHECK-NEXT:    vmul.vv v10, v13, v10
+; CHECK-NEXT:    vxor.vv v13, v15, v14
+; CHECK-NEXT:    vxor.vv v14, v17, v16
 ; CHECK-NEXT:    vmul.vv v8, v9, v8
-; CHECK-NEXT:    vmul.vv v11, v9, v11
-; CHECK-NEXT:    vand.vi v13, v10, 8
-; CHECK-NEXT:    vmul.vv v12, v9, v12
-; CHECK-NEXT:    vxor.vv v8, v11, v8
-; CHECK-NEXT:    vmul.vv v11, v9, v13
-; CHECK-NEXT:    vand.vx v13, v10, a0
-; CHECK-NEXT:    li a0, 32
-; CHECK-NEXT:    vxor.vv v8, v8, v12
-; CHECK-NEXT:    vand.vx v12, v10, a0
-; CHECK-NEXT:    vmul.vv v13, v9, v13
-; CHECK-NEXT:    li a0, 64
-; CHECK-NEXT:    vxor.vv v8, v8, v11
-; CHECK-NEXT:    vand.vx v11, v10, a0
-; CHECK-NEXT:    vmul.vv v12, v9, v12
-; CHECK-NEXT:    vxor.vv v8, v8, v13
-; CHECK-NEXT:    li a0, 128
-; CHECK-NEXT:    vmul.vv v11, v9, v11
-; CHECK-NEXT:    vand.vx v13, v10, a0
-; CHECK-NEXT:    li a0, 256
-; CHECK-NEXT:    vxor.vv v8, v8, v12
-; CHECK-NEXT:    vand.vx v12, v10, a0
-; CHECK-NEXT:    vmul.vv v13, v9, v13
-; CHECK-NEXT:    li a0, 512
-; CHECK-NEXT:    vxor.vv v8, v8, v11
-; CHECK-NEXT:    vand.vx v11, v10, a0
-; CHECK-NEXT:    vmul.vv v12, v9, v12
-; CHECK-NEXT:    vxor.vv v8, v8, v13
-; CHECK-NEXT:    li a0, 1024
-; CHECK-NEXT:    vmul.vv v11, v9, v11
-; CHECK-NEXT:    vand.vx v13, v10, a0
-; CHECK-NEXT:    li a0, 1
-; CHECK-NEXT:    slli a0, a0, 11
-; CHECK-NEXT:    vxor.vv v8, v8, v12
-; CHECK-NEXT:    vand.vx v12, v10, a0
-; CHECK-NEXT:    vmul.vv v13, v9, v13
-; CHECK-NEXT:    lui a0, 1
-; CHECK-NEXT:    vxor.vv v8, v8, v11
-; CHECK-NEXT:    vand.vx v11, v10, a0
-; CHECK-NEXT:    vmul.vv v12, v9, v12
-; CHECK-NEXT:    vxor.vv v8, v8, v13
-; CHECK-NEXT:    lui a0, 2
-; CHECK-NEXT:    vmul.vv v11, v9, v11
-; CHECK-NEXT:    vand.vx v13, v10, a0
-; CHECK-NEXT:    lui a0, 4
-; CHECK-NEXT:    vxor.vv v8, v8, v12
-; CHECK-NEXT:    vand.vx v12, v10, a0
-; CHECK-NEXT:    vmul.vv v13, v9, v13
-; CHECK-NEXT:    vxor.vv v8, v8, v11
-; CHECK-NEXT:    vmul.vv v11, v9, v12
-; CHECK-NEXT:    lui a0, 8
-; CHECK-NEXT:    vand.vx v10, v10, a0
-; CHECK-NEXT:    vxor.vv v8, v8, v13
-; CHECK-NEXT:    vmul.vv v9, v9, v10
-; CHECK-NEXT:    vxor.vv v8, v8, v11
-; CHECK-NEXT:    vxor.vv v8, v8, v9
+; CHECK-NEXT:    vxor.vv v9, v13, v18
+; CHECK-NEXT:    vxor.vv v12, v14, v12
+; CHECK-NEXT:    vxor.vv v10, v10, v11
+; CHECK-NEXT:    vand.vx v9, v9, a1
+; CHECK-NEXT:    vand.vx v11, v12, a0
+; CHECK-NEXT:    vxor.vv v8, v10, v8
+; CHECK-NEXT:    vor.vv v9, v11, v9
+; CHECK-NEXT:    vand.vx v8, v8, a2
+; CHECK-NEXT:    vor.vv v8, v9, v8
 ; CHECK-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
 ; CHECK-NEXT:    vnsrl.wi v8, v8, 8
 ; CHECK-NEXT:    ret

--- a/llvm/test/CodeGen/Thumb2/mve-clmul.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-clmul.ll
@@ -4,30 +4,22 @@
 define i8 @clmul_i8(i8 %x, i8 %y) {
 ; CHECK-LABEL: clmul_i8:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    and r2, r1, #2
-; CHECK-NEXT:    and r3, r1, #1
-; CHECK-NEXT:    muls r2, r0, r2
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #4
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #8
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #16
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #32
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #64
-; CHECK-NEXT:    bic r1, r1, #127
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    muls r0, r1, r0
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    eors r0, r2
-; CHECK-NEXT:    bx lr
+; CHECK-NEXT:    .save {r7, lr}
+; CHECK-NEXT:    push {r7, lr}
+; CHECK-NEXT:    and lr, r1, #85
+; CHECK-NEXT:    bic r3, r0, #85
+; CHECK-NEXT:    bic r1, r1, #85
+; CHECK-NEXT:    and r0, r0, #85
+; CHECK-NEXT:    mul r12, r3, lr
+; CHECK-NEXT:    mul r2, r0, r1
+; CHECK-NEXT:    muls r1, r3, r1
+; CHECK-NEXT:    mul r0, r0, lr
+; CHECK-NEXT:    eor.w r2, r2, r12
+; CHECK-NEXT:    bic r2, r2, #84
+; CHECK-NEXT:    eors r0, r1
+; CHECK-NEXT:    and r0, r0, #85
+; CHECK-NEXT:    add r0, r2
+; CHECK-NEXT:    pop {r7, pc}
   %a = call i8 @llvm.clmul.i8(i8 %x, i8 %y)
   ret i8 %a
 }
@@ -35,55 +27,39 @@ define i8 @clmul_i8(i8 %x, i8 %y) {
 define i16 @clmul_i16(i16 %x, i16 %y) {
 ; CHECK-LABEL: clmul_i16:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    and r2, r1, #2
-; CHECK-NEXT:    and r3, r1, #1
-; CHECK-NEXT:    muls r2, r0, r2
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #4
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #8
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #16
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #32
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #64
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #128
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #256
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #512
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #1024
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #2048
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #4096
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #8192
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #16384
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    movw r3, #32767
-; CHECK-NEXT:    bics r1, r3
-; CHECK-NEXT:    muls r0, r1, r0
-; CHECK-NEXT:    eors r0, r2
-; CHECK-NEXT:    bx lr
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, lr}
+; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, lr}
+; CHECK-NEXT:    movw r12, #37449
+; CHECK-NEXT:    movw lr, #9362
+; CHECK-NEXT:    movt r12, #65535
+; CHECK-NEXT:    and.w r3, r1, r12
+; CHECK-NEXT:    and.w r2, r0, lr
+; CHECK-NEXT:    and.w r5, r1, lr
+; CHECK-NEXT:    and.w r6, r0, r12
+; CHECK-NEXT:    movw r8, #18724
+; CHECK-NEXT:    mul r4, r2, r3
+; CHECK-NEXT:    and.w r1, r1, r8
+; CHECK-NEXT:    and.w r0, r0, r8
+; CHECK-NEXT:    mul r7, r6, r5
+; CHECK-NEXT:    eors r4, r7
+; CHECK-NEXT:    mul r7, r0, r1
+; CHECK-NEXT:    eors r4, r7
+; CHECK-NEXT:    mul r7, r6, r3
+; CHECK-NEXT:    and.w lr, lr, r4
+; CHECK-NEXT:    mul r4, r2, r1
+; CHECK-NEXT:    muls r2, r5, r2
+; CHECK-NEXT:    muls r1, r6, r1
+; CHECK-NEXT:    eors r4, r7
+; CHECK-NEXT:    mul r7, r0, r5
+; CHECK-NEXT:    muls r0, r3, r0
+; CHECK-NEXT:    eors r1, r2
+; CHECK-NEXT:    eors r4, r7
+; CHECK-NEXT:    and.w r7, r4, r12
+; CHECK-NEXT:    eors r0, r1
+; CHECK-NEXT:    add r7, lr
+; CHECK-NEXT:    and.w r0, r0, r8
+; CHECK-NEXT:    add r0, r7
+; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, pc}
   %a = call i16 @llvm.clmul.i16(i16 %x, i16 %y)
   ret i16 %a
 }
@@ -346,31 +322,38 @@ define i64 @clmul_i64(i64 %x, i64 %y) {
 define i16 @clmul_i16_zext(i8 %x, i8 %y) {
 ; CHECK-LABEL: clmul_i16_zext:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    and r2, r1, #2
-; CHECK-NEXT:    and r3, r1, #1
-; CHECK-NEXT:    uxtb r0, r0
-; CHECK-NEXT:    muls r2, r0, r2
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #4
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #8
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #16
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #32
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    and r3, r1, #64
-; CHECK-NEXT:    and r1, r1, #128
-; CHECK-NEXT:    muls r3, r0, r3
-; CHECK-NEXT:    muls r0, r1, r0
-; CHECK-NEXT:    eors r2, r3
-; CHECK-NEXT:    eors r0, r2
-; CHECK-NEXT:    bx lr
+; CHECK-NEXT:    .save {r4, r5, r6, lr}
+; CHECK-NEXT:    push {r4, r5, r6, lr}
+; CHECK-NEXT:    and lr, r1, #73
+; CHECK-NEXT:    and r3, r0, #146
+; CHECK-NEXT:    and r4, r0, #73
+; CHECK-NEXT:    and r2, r1, #146
+; CHECK-NEXT:    mul r12, r3, lr
+; CHECK-NEXT:    and r1, r1, #36
+; CHECK-NEXT:    and r0, r0, #36
+; CHECK-NEXT:    mul r5, r4, r2
+; CHECK-NEXT:    mul r6, r4, lr
+; CHECK-NEXT:    eor.w r12, r12, r5
+; CHECK-NEXT:    mul r5, r0, r1
+; CHECK-NEXT:    eor.w r12, r12, r5
+; CHECK-NEXT:    movw r5, #9362
+; CHECK-NEXT:    and.w r12, r12, r5
+; CHECK-NEXT:    mul r5, r3, r1
+; CHECK-NEXT:    muls r1, r4, r1
+; CHECK-NEXT:    eors r5, r6
+; CHECK-NEXT:    mul r6, r0, r2
+; CHECK-NEXT:    muls r2, r3, r2
+; CHECK-NEXT:    mul r0, r0, lr
+; CHECK-NEXT:    eors r5, r6
+; CHECK-NEXT:    movw r6, #4681
+; CHECK-NEXT:    ands r5, r6
+; CHECK-NEXT:    eors r1, r2
+; CHECK-NEXT:    add.w r6, r5, r12
+; CHECK-NEXT:    eors r0, r1
+; CHECK-NEXT:    movw r1, #18724
+; CHECK-NEXT:    ands r0, r1
+; CHECK-NEXT:    add r0, r6
+; CHECK-NEXT:    pop {r4, r5, r6, pc}
   %zextx = zext i8 %x to i16
   %zexty = zext i8 %y to i16
   %a = call i16 @llvm.clmul.i16(i16 %zextx, i16 %zexty)
@@ -955,37 +938,24 @@ define i128 @clmul_i128_zext(i64 %x, i64 %y) {
 define <16 x i8> @clmul_v16i8(<16 x i8> %x, <16 x i8> %y) {
 ; CHECK-LABEL: clmul_v16i8:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmov.i8 q2, #0x2
-; CHECK-NEXT:    vmov.i8 q3, #0x1
-; CHECK-NEXT:    vand q2, q1, q2
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q2, q0, q2
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q3, q2
-; CHECK-NEXT:    vmov.i8 q3, #0x4
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x8
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x10
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x20
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x40
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x80
-; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmul.i8 q0, q0, q1
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vmov.i8 q2, #0x55
+; CHECK-NEXT:    vmov.i8 q4, #0xaa
+; CHECK-NEXT:    vand q3, q1, q2
+; CHECK-NEXT:    vand q5, q0, q4
+; CHECK-NEXT:    vand q1, q1, q4
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vmul.i8 q7, q0, q1
+; CHECK-NEXT:    vmul.i8 q6, q5, q3
+; CHECK-NEXT:    vmul.i8 q1, q5, q1
+; CHECK-NEXT:    vmul.i8 q0, q0, q3
+; CHECK-NEXT:    veor q0, q0, q1
+; CHECK-NEXT:    veor q6, q7, q6
+; CHECK-NEXT:    vand q4, q6, q4
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vorr q0, q0, q4
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %a = call <16 x i8> @llvm.clmul.v16i8(<16 x i8> %x, <16 x i8> %y)
   ret <16 x i8> %a
@@ -994,37 +964,24 @@ define <16 x i8> @clmul_v16i8(<16 x i8> %x, <16 x i8> %y) {
 define <8 x i8> @clmul_v8i8(<8 x i8> %x, <8 x i8> %y) {
 ; CHECK-LABEL: clmul_v8i8:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmov.i16 q2, #0x2
-; CHECK-NEXT:    vmov.i16 q3, #0x1
-; CHECK-NEXT:    vand q2, q1, q2
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q3, q2
-; CHECK-NEXT:    vmov.i16 q3, #0x4
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x8
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x10
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x20
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x40
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x80
-; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmul.i16 q0, q0, q1
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vmov.i16 q2, #0x55
+; CHECK-NEXT:    vmov.i16 q4, #0xaa
+; CHECK-NEXT:    vand q3, q1, q2
+; CHECK-NEXT:    vand q5, q0, q4
+; CHECK-NEXT:    vand q1, q1, q4
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vmul.i16 q7, q0, q1
+; CHECK-NEXT:    vmul.i16 q6, q5, q3
+; CHECK-NEXT:    vmul.i16 q1, q5, q1
+; CHECK-NEXT:    vmul.i16 q0, q0, q3
+; CHECK-NEXT:    veor q0, q0, q1
+; CHECK-NEXT:    veor q6, q7, q6
+; CHECK-NEXT:    vand q4, q6, q4
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vorr q0, q0, q4
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %a = call <8 x i8> @llvm.clmul.v8i8(<8 x i8> %x, <8 x i8> %y)
   ret <8 x i8> %a
@@ -1033,69 +990,56 @@ define <8 x i8> @clmul_v8i8(<8 x i8> %x, <8 x i8> %y) {
 define <8 x i16> @clmul_v8i16(<8 x i16> %x, <8 x i16> %y) {
 ; CHECK-LABEL: clmul_v8i16:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmov.i16 q2, #0x2
-; CHECK-NEXT:    vmov.i16 q3, #0x1
-; CHECK-NEXT:    vand q2, q1, q2
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q3, q2
-; CHECK-NEXT:    vmov.i16 q3, #0x4
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x8
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x10
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x20
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x40
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x80
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x100
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x200
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x400
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x800
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x1000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x2000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x4000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x8000
-; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmul.i16 q0, q0, q1
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    .pad #64
+; CHECK-NEXT:    sub sp, #64
+; CHECK-NEXT:    movw r0, #37449
+; CHECK-NEXT:    vmov q2, q0
+; CHECK-NEXT:    vdup.16 q6, r0
+; CHECK-NEXT:    movw r0, #9362
+; CHECK-NEXT:    vdup.16 q0, r0
+; CHECK-NEXT:    vand q3, q1, q6
+; CHECK-NEXT:    vstrw.32 q6, [sp, #32] @ 16-byte Spill
+; CHECK-NEXT:    vand q4, q2, q0
+; CHECK-NEXT:    vand q5, q1, q0
+; CHECK-NEXT:    vand q6, q2, q6
+; CHECK-NEXT:    vstrw.32 q3, [sp, #48] @ 16-byte Spill
+; CHECK-NEXT:    vmul.i16 q3, q4, q3
+; CHECK-NEXT:    vmul.i16 q7, q6, q5
+; CHECK-NEXT:    movw r0, #18724
+; CHECK-NEXT:    veor q3, q7, q3
+; CHECK-NEXT:    vdup.16 q7, r0
+; CHECK-NEXT:    vstrw.32 q3, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vstrw.32 q4, [sp] @ 16-byte Spill
+; CHECK-NEXT:    vand q1, q1, q7
+; CHECK-NEXT:    vand q2, q2, q7
+; CHECK-NEXT:    vldrw.u32 q4, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q3, q2, q1
+; CHECK-NEXT:    veor q3, q4, q3
+; CHECK-NEXT:    vldrw.u32 q4, [sp] @ 16-byte Reload
+; CHECK-NEXT:    vand q0, q3, q0
+; CHECK-NEXT:    vstrw.32 q0, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q3, q4, q1
+; CHECK-NEXT:    vmul.i16 q1, q6, q1
+; CHECK-NEXT:    vmul.i16 q0, q6, q0
+; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmul.i16 q3, q2, q5
+; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    vand q0, q0, q3
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vorr q0, q0, q3
+; CHECK-NEXT:    vmul.i16 q3, q4, q5
+; CHECK-NEXT:    veor q1, q1, q3
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q2, q2, q3
+; CHECK-NEXT:    veor q1, q1, q2
+; CHECK-NEXT:    vand q1, q1, q7
+; CHECK-NEXT:    vorr q0, q0, q1
+; CHECK-NEXT:    add sp, #64
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %a = call <8 x i16> @llvm.clmul.v8i16(<8 x i16> %x, <8 x i16> %y)
   ret <8 x i16> %a
@@ -1104,69 +1048,56 @@ define <8 x i16> @clmul_v8i16(<8 x i16> %x, <8 x i16> %y) {
 define <4 x i16> @clmul_v4i16(<4 x i16> %x, <4 x i16> %y) {
 ; CHECK-LABEL: clmul_v4i16:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmov.i32 q2, #0x2
-; CHECK-NEXT:    vmov.i32 q3, #0x1
-; CHECK-NEXT:    vand q2, q1, q2
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q2, q0, q2
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q3, q2
-; CHECK-NEXT:    vmov.i32 q3, #0x4
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x8
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x10
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x20
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x40
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x80
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x100
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x200
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x400
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x800
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x1000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x2000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x4000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i32 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i32 q3, #0x8000
-; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmul.i32 q0, q0, q1
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    .pad #64
+; CHECK-NEXT:    sub sp, #64
+; CHECK-NEXT:    movw r0, #37449
+; CHECK-NEXT:    vmov q2, q0
+; CHECK-NEXT:    vdup.32 q6, r0
+; CHECK-NEXT:    movw r0, #9362
+; CHECK-NEXT:    vdup.32 q0, r0
+; CHECK-NEXT:    vand q3, q1, q6
+; CHECK-NEXT:    vstrw.32 q6, [sp, #32] @ 16-byte Spill
+; CHECK-NEXT:    vand q4, q2, q0
+; CHECK-NEXT:    vand q5, q1, q0
+; CHECK-NEXT:    vand q6, q2, q6
+; CHECK-NEXT:    vstrw.32 q3, [sp, #48] @ 16-byte Spill
+; CHECK-NEXT:    vmul.i32 q3, q4, q3
+; CHECK-NEXT:    vmul.i32 q7, q6, q5
+; CHECK-NEXT:    movw r0, #18724
+; CHECK-NEXT:    veor q3, q7, q3
+; CHECK-NEXT:    vdup.32 q7, r0
+; CHECK-NEXT:    vstrw.32 q3, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vstrw.32 q4, [sp] @ 16-byte Spill
+; CHECK-NEXT:    vand q1, q1, q7
+; CHECK-NEXT:    vand q2, q2, q7
+; CHECK-NEXT:    vldrw.u32 q4, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i32 q3, q2, q1
+; CHECK-NEXT:    veor q3, q4, q3
+; CHECK-NEXT:    vldrw.u32 q4, [sp] @ 16-byte Reload
+; CHECK-NEXT:    vand q0, q3, q0
+; CHECK-NEXT:    vstrw.32 q0, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i32 q3, q4, q1
+; CHECK-NEXT:    vmul.i32 q1, q6, q1
+; CHECK-NEXT:    vmul.i32 q0, q6, q0
+; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmul.i32 q3, q2, q5
+; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    vand q0, q0, q3
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vorr q0, q0, q3
+; CHECK-NEXT:    vmul.i32 q3, q4, q5
+; CHECK-NEXT:    veor q1, q1, q3
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i32 q2, q2, q3
+; CHECK-NEXT:    veor q1, q1, q2
+; CHECK-NEXT:    vand q1, q1, q7
+; CHECK-NEXT:    vorr q0, q0, q1
+; CHECK-NEXT:    add sp, #64
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %a = call <4 x i16> @llvm.clmul.v4i16(<4 x i16> %x, <4 x i16> %y)
   ret <4 x i16> %a
@@ -4873,39 +4804,57 @@ define <1 x i128> @clmul_v1i128(<1 x i128> %x, <1 x i128> %y) {
 define <8 x i16> @clmul_v8i16_zext(<8 x i8> %x, <8 x i8> %y) {
 ; CHECK-LABEL: clmul_v8i16_zext:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmovlb.u8 q1, q1
-; CHECK-NEXT:    vmov.i16 q2, #0x2
-; CHECK-NEXT:    vmov.i16 q3, #0x1
-; CHECK-NEXT:    vand q2, q1, q2
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    .pad #64
+; CHECK-NEXT:    sub sp, #64
+; CHECK-NEXT:    movw r0, #37449
+; CHECK-NEXT:    vmovlb.u8 q6, q1
+; CHECK-NEXT:    vdup.16 q4, r0
+; CHECK-NEXT:    movw r0, #9362
+; CHECK-NEXT:    vdup.16 q7, r0
 ; CHECK-NEXT:    vmovlb.u8 q0, q0
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q3, q2
-; CHECK-NEXT:    vmov.i16 q3, #0x4
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x8
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x10
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x20
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x40
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x80
-; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmul.i16 q0, q0, q1
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    vand q2, q6, q4
+; CHECK-NEXT:    vstrw.32 q4, [sp, #32] @ 16-byte Spill
+; CHECK-NEXT:    vand q1, q0, q7
+; CHECK-NEXT:    vand q3, q6, q7
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    vstrw.32 q1, [sp] @ 16-byte Spill
+; CHECK-NEXT:    vmul.i16 q1, q1, q2
+; CHECK-NEXT:    vmul.i16 q5, q4, q3
+; CHECK-NEXT:    vstrw.32 q2, [sp, #48] @ 16-byte Spill
+; CHECK-NEXT:    veor q2, q5, q1
+; CHECK-NEXT:    movw r0, #18724
+; CHECK-NEXT:    vstrw.32 q2, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vdup.16 q5, r0
+; CHECK-NEXT:    vldrw.u32 q1, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vand q6, q6, q5
+; CHECK-NEXT:    vand q0, q0, q5
+; CHECK-NEXT:    vmul.i16 q2, q0, q6
+; CHECK-NEXT:    veor q2, q1, q2
+; CHECK-NEXT:    vldrw.u32 q1, [sp] @ 16-byte Reload
+; CHECK-NEXT:    vand q2, q2, q7
+; CHECK-NEXT:    vstrw.32 q2, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q7, q1, q6
+; CHECK-NEXT:    vmul.i16 q1, q1, q3
+; CHECK-NEXT:    vmul.i16 q2, q4, q2
+; CHECK-NEXT:    veor q2, q2, q7
+; CHECK-NEXT:    vmul.i16 q7, q0, q3
+; CHECK-NEXT:    vmul.i16 q3, q4, q6
+; CHECK-NEXT:    veor q2, q2, q7
+; CHECK-NEXT:    vldrw.u32 q7, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    veor q1, q3, q1
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vand q2, q2, q7
+; CHECK-NEXT:    vldrw.u32 q7, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q0, q0, q3
+; CHECK-NEXT:    veor q0, q1, q0
+; CHECK-NEXT:    vorr q2, q2, q7
+; CHECK-NEXT:    vand q0, q0, q5
+; CHECK-NEXT:    vorr q0, q2, q0
+; CHECK-NEXT:    add sp, #64
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %zextx = zext <8 x i8> %x to <8 x i16>
   %zexty = zext <8 x i8> %y to <8 x i16>
@@ -4918,140 +4867,104 @@ define <16 x i16> @clmul_v16i16_zext(<16 x i8> %x, <16 x i8> %y) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEXT:    .pad #32
-; CHECK-NEXT:    sub sp, #32
-; CHECK-NEXT:    add r0, sp, #16
-; CHECK-NEXT:    mov r1, sp
+; CHECK-NEXT:    .pad #128
+; CHECK-NEXT:    sub sp, #128
+; CHECK-NEXT:    add r0, sp, #112
+; CHECK-NEXT:    movw r2, #37449
 ; CHECK-NEXT:    vstrw.32 q1, [r0]
+; CHECK-NEXT:    add r1, sp, #96
+; CHECK-NEXT:    vdup.16 q1, r2
 ; CHECK-NEXT:    vstrw.32 q0, [r1]
-; CHECK-NEXT:    vldrb.u16 q0, [r0]
-; CHECK-NEXT:    vmov.i16 q2, #0x1
-; CHECK-NEXT:    vmov.i16 q7, #0x2
-; CHECK-NEXT:    vldrb.u16 q6, [r1]
-; CHECK-NEXT:    vand q1, q0, q7
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q1, q6, q1
+; CHECK-NEXT:    vstrw.32 q1, [sp, #80] @ 16-byte Spill
+; CHECK-NEXT:    movw r2, #9362
+; CHECK-NEXT:    vldrb.u16 q7, [r0]
+; CHECK-NEXT:    vdup.16 q3, r2
+; CHECK-NEXT:    movw r2, #18724
+; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vstrw.32 q2, [sp, #64] @ 16-byte Spill
+; CHECK-NEXT:    vldrb.u16 q0, [r1]
+; CHECK-NEXT:    vand q4, q0, q3
+; CHECK-NEXT:    vand q6, q0, q1
+; CHECK-NEXT:    vmul.i16 q2, q4, q2
+; CHECK-NEXT:    vstrw.32 q4, [sp, #32] @ 16-byte Spill
+; CHECK-NEXT:    vstrw.32 q2, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vand q2, q7, q3
+; CHECK-NEXT:    vldrw.u32 q1, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vstrw.32 q2, [sp, #48] @ 16-byte Spill
 ; CHECK-NEXT:    vmul.i16 q2, q6, q2
 ; CHECK-NEXT:    veor q1, q2, q1
-; CHECK-NEXT:    vmov.i16 q2, #0x4
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmov.i16 q5, #0x2000
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    vmov.i16 q4, #0x4000
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov.i16 q2, #0x8
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmov.i16 q3, #0x8000
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov.i16 q2, #0x10
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov.i16 q2, #0x20
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov.i16 q2, #0x40
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov.i16 q2, #0x80
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov.i16 q2, #0x100
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov.i16 q2, #0x200
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov.i16 q2, #0x400
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov.i16 q2, #0x800
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov.i16 q2, #0x1000
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vand q2, q0, q5
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vand q2, q0, q4
-; CHECK-NEXT:    vand q0, q0, q3
-; CHECK-NEXT:    vmul.i16 q2, q6, q2
-; CHECK-NEXT:    vmul.i16 q0, q6, q0
-; CHECK-NEXT:    vldrb.u16 q6, [r0, #8]
-; CHECK-NEXT:    veor q2, q1, q2
-; CHECK-NEXT:    veor q2, q2, q0
-; CHECK-NEXT:    vand q1, q6, q7
-; CHECK-NEXT:    vmov.i16 q7, #0x1
-; CHECK-NEXT:    vldrb.u16 q0, [r1, #8]
-; CHECK-NEXT:    vand q7, q6, q7
-; CHECK-NEXT:    vand q5, q6, q5
-; CHECK-NEXT:    vmul.i16 q1, q0, q1
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    veor q1, q7, q1
-; CHECK-NEXT:    vmov.i16 q7, #0x4
-; CHECK-NEXT:    vand q7, q6, q7
-; CHECK-NEXT:    vand q4, q6, q4
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    vmul.i16 q5, q0, q5
-; CHECK-NEXT:    veor q1, q1, q7
-; CHECK-NEXT:    vmov.i16 q7, #0x8
-; CHECK-NEXT:    vand q7, q6, q7
+; CHECK-NEXT:    vdup.16 q2, r2
+; CHECK-NEXT:    vand q7, q7, q2
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vmul.i16 q4, q0, q7
+; CHECK-NEXT:    veor q4, q1, q4
+; CHECK-NEXT:    vand q1, q4, q3
+; CHECK-NEXT:    vstrw.32 q1, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q1, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q4, q1, q7
+; CHECK-NEXT:    vstrw.32 q4, [sp] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q4, [sp, #64] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q5, [sp] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q4, q6, q4
+; CHECK-NEXT:    vmul.i16 q6, q6, q7
+; CHECK-NEXT:    veor q5, q4, q5
+; CHECK-NEXT:    vldrw.u32 q4, [sp, #48] @ 16-byte Reload
 ; CHECK-NEXT:    vmul.i16 q4, q0, q4
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    vand q3, q6, q3
-; CHECK-NEXT:    veor q1, q1, q7
-; CHECK-NEXT:    vmov.i16 q7, #0x10
-; CHECK-NEXT:    vand q7, q6, q7
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    veor q1, q1, q7
-; CHECK-NEXT:    vmov.i16 q7, #0x20
-; CHECK-NEXT:    vand q7, q6, q7
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    veor q1, q1, q7
-; CHECK-NEXT:    vmov.i16 q7, #0x40
-; CHECK-NEXT:    vand q7, q6, q7
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    veor q1, q1, q7
-; CHECK-NEXT:    vmov.i16 q7, #0x80
-; CHECK-NEXT:    vand q7, q6, q7
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    veor q1, q1, q7
-; CHECK-NEXT:    vmov.i16 q7, #0x100
-; CHECK-NEXT:    vand q7, q6, q7
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    veor q1, q1, q7
-; CHECK-NEXT:    vmov.i16 q7, #0x200
-; CHECK-NEXT:    vand q7, q6, q7
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    veor q1, q1, q7
-; CHECK-NEXT:    vmov.i16 q7, #0x400
-; CHECK-NEXT:    vand q7, q6, q7
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    veor q1, q1, q7
-; CHECK-NEXT:    vmov.i16 q7, #0x800
-; CHECK-NEXT:    vand q7, q6, q7
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    veor q1, q1, q7
-; CHECK-NEXT:    vmov.i16 q7, #0x1000
-; CHECK-NEXT:    vand q7, q6, q7
-; CHECK-NEXT:    vmul.i16 q7, q0, q7
-; CHECK-NEXT:    vmul.i16 q0, q0, q3
-; CHECK-NEXT:    veor q1, q1, q7
-; CHECK-NEXT:    veor q1, q1, q5
-; CHECK-NEXT:    veor q1, q1, q4
-; CHECK-NEXT:    veor q1, q1, q0
-; CHECK-NEXT:    vmov q0, q2
-; CHECK-NEXT:    add sp, #32
+; CHECK-NEXT:    veor q4, q5, q4
+; CHECK-NEXT:    vldrw.u32 q5, [sp, #80] @ 16-byte Reload
+; CHECK-NEXT:    vand q4, q4, q5
+; CHECK-NEXT:    vldrw.u32 q5, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vorr q4, q4, q5
+; CHECK-NEXT:    vldrw.u32 q5, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q5, q1, q5
+; CHECK-NEXT:    vldrw.u32 q1, [sp, #80] @ 16-byte Reload
+; CHECK-NEXT:    veor q5, q6, q5
+; CHECK-NEXT:    vldrw.u32 q6, [sp, #64] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q0, q0, q6
+; CHECK-NEXT:    veor q0, q5, q0
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vorr q0, q4, q0
+; CHECK-NEXT:    vstrw.32 q0, [sp, #48] @ 16-byte Spill
+; CHECK-NEXT:    vldrb.u16 q6, [r0, #8]
+; CHECK-NEXT:    vand q0, q6, q1
+; CHECK-NEXT:    vstrw.32 q0, [sp, #64] @ 16-byte Spill
+; CHECK-NEXT:    vldrb.u16 q7, [r1, #8]
+; CHECK-NEXT:    vand q4, q7, q3
+; CHECK-NEXT:    vand q1, q7, q1
+; CHECK-NEXT:    vmul.i16 q0, q4, q0
+; CHECK-NEXT:    vstrw.32 q4, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vstrw.32 q0, [sp, #32] @ 16-byte Spill
+; CHECK-NEXT:    vand q0, q6, q3
+; CHECK-NEXT:    vldrw.u32 q5, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q4, q1, q0
+; CHECK-NEXT:    vand q6, q6, q2
+; CHECK-NEXT:    vand q7, q7, q2
+; CHECK-NEXT:    veor q5, q4, q5
+; CHECK-NEXT:    vmul.i16 q4, q7, q6
+; CHECK-NEXT:    veor q4, q5, q4
+; CHECK-NEXT:    vldrw.u32 q5, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vand q3, q4, q3
+; CHECK-NEXT:    vstrw.32 q3, [sp, #32] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #64] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q4, q5, q6
+; CHECK-NEXT:    vmul.i16 q3, q1, q3
+; CHECK-NEXT:    vmul.i16 q1, q1, q6
+; CHECK-NEXT:    veor q3, q3, q4
+; CHECK-NEXT:    vmul.i16 q4, q7, q0
+; CHECK-NEXT:    vmul.i16 q0, q5, q0
+; CHECK-NEXT:    veor q3, q3, q4
+; CHECK-NEXT:    vldrw.u32 q4, [sp, #80] @ 16-byte Reload
+; CHECK-NEXT:    veor q0, q1, q0
+; CHECK-NEXT:    vldrw.u32 q1, [sp, #64] @ 16-byte Reload
+; CHECK-NEXT:    vand q3, q3, q4
+; CHECK-NEXT:    vldrw.u32 q4, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q1, q7, q1
+; CHECK-NEXT:    veor q0, q0, q1
+; CHECK-NEXT:    vorr q3, q3, q4
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vorr q1, q3, q0
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    add sp, #128
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %zextx = zext <16 x i8> %x to <16 x i16>
@@ -9163,41 +9076,28 @@ define <2 x i128> @clmul_v2i128_zext(<2 x i64> %x, <2 x i64> %y) {
 define <16 x i8> @clmulr_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; CHECK-LABEL: clmulr_v16i8:
 ; CHECK:       @ %bb.0:
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    movs r0, #8
-; CHECK-NEXT:    vmov.i8 q2, #0x2
+; CHECK-NEXT:    vmov.i8 q2, #0x55
 ; CHECK-NEXT:    vbrsr.8 q1, q1, r0
-; CHECK-NEXT:    vmov.i8 q3, #0x1
 ; CHECK-NEXT:    vbrsr.8 q0, q0, r0
-; CHECK-NEXT:    vand q2, q1, q2
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q2, q0, q2
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q3, q2
-; CHECK-NEXT:    vmov.i8 q3, #0x4
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x8
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x10
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x20
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x40
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x80
-; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmul.i8 q0, q0, q1
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    vmov.i8 q4, #0xaa
+; CHECK-NEXT:    vand q3, q1, q2
+; CHECK-NEXT:    vand q5, q0, q4
+; CHECK-NEXT:    vand q1, q1, q4
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vmul.i8 q6, q5, q3
+; CHECK-NEXT:    vmul.i8 q7, q0, q1
+; CHECK-NEXT:    vmul.i8 q1, q5, q1
+; CHECK-NEXT:    vmul.i8 q0, q0, q3
+; CHECK-NEXT:    veor q6, q7, q6
+; CHECK-NEXT:    veor q0, q0, q1
+; CHECK-NEXT:    vand q4, q6, q4
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vorr q0, q0, q4
 ; CHECK-NEXT:    vbrsr.8 q0, q0, r0
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %a.ext = zext <16 x i8> %a to <16 x i16>
   %b.ext = zext <16 x i8> %b to <16 x i16>
@@ -9210,40 +9110,58 @@ define <16 x i8> @clmulr_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 define <8 x i8> @clmulr_v8i8(<8 x i8> %a, <8 x i8> %b) nounwind {
 ; CHECK-LABEL: clmulr_v8i8:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmovlb.u8 q1, q1
-; CHECK-NEXT:    vmov.i16 q2, #0x2
-; CHECK-NEXT:    vmov.i16 q3, #0x1
-; CHECK-NEXT:    vand q2, q1, q2
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    .pad #64
+; CHECK-NEXT:    sub sp, #64
+; CHECK-NEXT:    movw r0, #37449
+; CHECK-NEXT:    vmovlb.u8 q6, q1
+; CHECK-NEXT:    vdup.16 q4, r0
+; CHECK-NEXT:    movw r0, #9362
+; CHECK-NEXT:    vdup.16 q7, r0
 ; CHECK-NEXT:    vmovlb.u8 q0, q0
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q3, q2
-; CHECK-NEXT:    vmov.i16 q3, #0x4
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x8
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x10
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x20
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x40
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x80
-; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmul.i16 q0, q0, q1
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    vand q2, q6, q4
+; CHECK-NEXT:    vstrw.32 q4, [sp, #32] @ 16-byte Spill
+; CHECK-NEXT:    vand q1, q0, q7
+; CHECK-NEXT:    vand q3, q6, q7
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    vstrw.32 q1, [sp] @ 16-byte Spill
+; CHECK-NEXT:    vmul.i16 q1, q1, q2
+; CHECK-NEXT:    vmul.i16 q5, q4, q3
+; CHECK-NEXT:    vstrw.32 q2, [sp, #48] @ 16-byte Spill
+; CHECK-NEXT:    veor q2, q5, q1
+; CHECK-NEXT:    movw r0, #18724
+; CHECK-NEXT:    vstrw.32 q2, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vdup.16 q5, r0
+; CHECK-NEXT:    vldrw.u32 q1, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vand q6, q6, q5
+; CHECK-NEXT:    vand q0, q0, q5
+; CHECK-NEXT:    vmul.i16 q2, q0, q6
+; CHECK-NEXT:    veor q2, q1, q2
+; CHECK-NEXT:    vldrw.u32 q1, [sp] @ 16-byte Reload
+; CHECK-NEXT:    vand q2, q2, q7
+; CHECK-NEXT:    vstrw.32 q2, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q7, q1, q6
+; CHECK-NEXT:    vmul.i16 q1, q1, q3
+; CHECK-NEXT:    vmul.i16 q2, q4, q2
+; CHECK-NEXT:    veor q2, q2, q7
+; CHECK-NEXT:    vmul.i16 q7, q0, q3
+; CHECK-NEXT:    vmul.i16 q3, q4, q6
+; CHECK-NEXT:    veor q2, q2, q7
+; CHECK-NEXT:    vldrw.u32 q7, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    veor q1, q3, q1
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vand q2, q2, q7
+; CHECK-NEXT:    vldrw.u32 q7, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q0, q0, q3
+; CHECK-NEXT:    veor q0, q1, q0
+; CHECK-NEXT:    vorr q2, q2, q7
+; CHECK-NEXT:    vand q0, q0, q5
+; CHECK-NEXT:    vorr q0, q2, q0
 ; CHECK-NEXT:    vshr.u16 q0, q0, #7
+; CHECK-NEXT:    add sp, #64
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %a.ext = zext <8 x i8> %a to <8 x i16>
   %b.ext = zext <8 x i8> %b to <8 x i16>
@@ -9256,73 +9174,59 @@ define <8 x i8> @clmulr_v8i8(<8 x i8> %a, <8 x i8> %b) nounwind {
 define <8 x i16> @clmulr_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; CHECK-LABEL: clmulr_v8i16:
 ; CHECK:       @ %bb.0:
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    .pad #64
+; CHECK-NEXT:    sub sp, #64
+; CHECK-NEXT:    movw r1, #37449
 ; CHECK-NEXT:    movs r0, #16
-; CHECK-NEXT:    vmov.i16 q2, #0x2
-; CHECK-NEXT:    vbrsr.16 q1, q1, r0
-; CHECK-NEXT:    vmov.i16 q3, #0x1
+; CHECK-NEXT:    vdup.16 q4, r1
+; CHECK-NEXT:    movw r1, #9362
+; CHECK-NEXT:    vbrsr.16 q6, q1, r0
+; CHECK-NEXT:    vbrsr.16 q7, q0, r0
+; CHECK-NEXT:    vdup.16 q0, r1
+; CHECK-NEXT:    vand q2, q6, q4
+; CHECK-NEXT:    vstrw.32 q4, [sp, #32] @ 16-byte Spill
+; CHECK-NEXT:    vand q1, q7, q0
+; CHECK-NEXT:    vand q3, q6, q0
+; CHECK-NEXT:    vand q4, q7, q4
+; CHECK-NEXT:    vstrw.32 q1, [sp] @ 16-byte Spill
+; CHECK-NEXT:    vmul.i16 q1, q1, q2
+; CHECK-NEXT:    vmul.i16 q5, q4, q3
+; CHECK-NEXT:    vstrw.32 q2, [sp, #48] @ 16-byte Spill
+; CHECK-NEXT:    veor q2, q5, q1
+; CHECK-NEXT:    movw r1, #18724
+; CHECK-NEXT:    vdup.16 q5, r1
+; CHECK-NEXT:    vstrw.32 q2, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vand q6, q6, q5
+; CHECK-NEXT:    vand q7, q7, q5
+; CHECK-NEXT:    vldrw.u32 q1, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q2, q7, q6
+; CHECK-NEXT:    veor q2, q1, q2
+; CHECK-NEXT:    vldrw.u32 q1, [sp] @ 16-byte Reload
+; CHECK-NEXT:    vand q0, q2, q0
+; CHECK-NEXT:    vstrw.32 q0, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q2, q1, q6
+; CHECK-NEXT:    vmul.i16 q1, q1, q3
+; CHECK-NEXT:    vmul.i16 q0, q4, q0
+; CHECK-NEXT:    veor q0, q0, q2
+; CHECK-NEXT:    vmul.i16 q2, q7, q3
+; CHECK-NEXT:    veor q0, q0, q2
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vorr q0, q0, q2
+; CHECK-NEXT:    vmul.i16 q2, q4, q6
+; CHECK-NEXT:    veor q1, q2, q1
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q2, q7, q2
+; CHECK-NEXT:    veor q1, q1, q2
+; CHECK-NEXT:    vand q1, q1, q5
+; CHECK-NEXT:    vorr q0, q0, q1
 ; CHECK-NEXT:    vbrsr.16 q0, q0, r0
-; CHECK-NEXT:    vand q2, q1, q2
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q3, q2
-; CHECK-NEXT:    vmov.i16 q3, #0x4
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x8
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x10
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x20
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x40
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x80
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x100
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x200
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x400
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x800
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x1000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x2000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x4000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x8000
-; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmul.i16 q0, q0, q1
-; CHECK-NEXT:    veor q0, q2, q0
-; CHECK-NEXT:    vbrsr.16 q0, q0, r0
+; CHECK-NEXT:    add sp, #64
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %a.ext = zext <8 x i16> %a to <8 x i32>
   %b.ext = zext <8 x i16> %b to <8 x i32>
@@ -12359,42 +12263,29 @@ define <1 x i64> @clmulr_v1i64(<1 x i64> %a, <1 x i64> %b) nounwind {
 define <16 x i8> @clmulh_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; CHECK-LABEL: clmulh_v16i8:
 ; CHECK:       @ %bb.0:
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    movs r0, #8
-; CHECK-NEXT:    vmov.i8 q2, #0x2
+; CHECK-NEXT:    vmov.i8 q2, #0x55
 ; CHECK-NEXT:    vbrsr.8 q1, q1, r0
-; CHECK-NEXT:    vmov.i8 q3, #0x1
 ; CHECK-NEXT:    vbrsr.8 q0, q0, r0
-; CHECK-NEXT:    vand q2, q1, q2
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q2, q0, q2
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q3, q2
-; CHECK-NEXT:    vmov.i8 q3, #0x4
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x8
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x10
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x20
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x40
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i8 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i8 q3, #0x80
-; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmul.i8 q0, q0, q1
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    vmov.i8 q4, #0xaa
+; CHECK-NEXT:    vand q3, q1, q2
+; CHECK-NEXT:    vand q5, q0, q4
+; CHECK-NEXT:    vand q1, q1, q4
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vmul.i8 q6, q5, q3
+; CHECK-NEXT:    vmul.i8 q7, q0, q1
+; CHECK-NEXT:    vmul.i8 q1, q5, q1
+; CHECK-NEXT:    vmul.i8 q0, q0, q3
+; CHECK-NEXT:    veor q6, q7, q6
+; CHECK-NEXT:    veor q0, q0, q1
+; CHECK-NEXT:    vand q4, q6, q4
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vorr q0, q0, q4
 ; CHECK-NEXT:    vbrsr.8 q0, q0, r0
 ; CHECK-NEXT:    vshr.u8 q0, q0, #1
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %a.ext = zext <16 x i8> %a to <16 x i16>
   %b.ext = zext <16 x i8> %b to <16 x i16>
@@ -12407,40 +12298,58 @@ define <16 x i8> @clmulh_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 define <8 x i8> @clmulh_v8i8(<8 x i8> %a, <8 x i8> %b) nounwind {
 ; CHECK-LABEL: clmulh_v8i8:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vmovlb.u8 q1, q1
-; CHECK-NEXT:    vmov.i16 q2, #0x2
-; CHECK-NEXT:    vmov.i16 q3, #0x1
-; CHECK-NEXT:    vand q2, q1, q2
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    .pad #64
+; CHECK-NEXT:    sub sp, #64
+; CHECK-NEXT:    movw r0, #37449
+; CHECK-NEXT:    vmovlb.u8 q6, q1
+; CHECK-NEXT:    vdup.16 q4, r0
+; CHECK-NEXT:    movw r0, #9362
+; CHECK-NEXT:    vdup.16 q7, r0
 ; CHECK-NEXT:    vmovlb.u8 q0, q0
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q3, q2
-; CHECK-NEXT:    vmov.i16 q3, #0x4
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x8
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x10
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x20
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x40
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x80
-; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmul.i16 q0, q0, q1
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    vand q2, q6, q4
+; CHECK-NEXT:    vstrw.32 q4, [sp, #32] @ 16-byte Spill
+; CHECK-NEXT:    vand q1, q0, q7
+; CHECK-NEXT:    vand q3, q6, q7
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    vstrw.32 q1, [sp] @ 16-byte Spill
+; CHECK-NEXT:    vmul.i16 q1, q1, q2
+; CHECK-NEXT:    vmul.i16 q5, q4, q3
+; CHECK-NEXT:    vstrw.32 q2, [sp, #48] @ 16-byte Spill
+; CHECK-NEXT:    veor q2, q5, q1
+; CHECK-NEXT:    movw r0, #18724
+; CHECK-NEXT:    vstrw.32 q2, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vdup.16 q5, r0
+; CHECK-NEXT:    vldrw.u32 q1, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vand q6, q6, q5
+; CHECK-NEXT:    vand q0, q0, q5
+; CHECK-NEXT:    vmul.i16 q2, q0, q6
+; CHECK-NEXT:    veor q2, q1, q2
+; CHECK-NEXT:    vldrw.u32 q1, [sp] @ 16-byte Reload
+; CHECK-NEXT:    vand q2, q2, q7
+; CHECK-NEXT:    vstrw.32 q2, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q7, q1, q6
+; CHECK-NEXT:    vmul.i16 q1, q1, q3
+; CHECK-NEXT:    vmul.i16 q2, q4, q2
+; CHECK-NEXT:    veor q2, q2, q7
+; CHECK-NEXT:    vmul.i16 q7, q0, q3
+; CHECK-NEXT:    vmul.i16 q3, q4, q6
+; CHECK-NEXT:    veor q2, q2, q7
+; CHECK-NEXT:    vldrw.u32 q7, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    veor q1, q3, q1
+; CHECK-NEXT:    vldrw.u32 q3, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vand q2, q2, q7
+; CHECK-NEXT:    vldrw.u32 q7, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q0, q0, q3
+; CHECK-NEXT:    veor q0, q1, q0
+; CHECK-NEXT:    vorr q2, q2, q7
+; CHECK-NEXT:    vand q0, q0, q5
+; CHECK-NEXT:    vorr q0, q2, q0
 ; CHECK-NEXT:    vshr.u16 q0, q0, #8
+; CHECK-NEXT:    add sp, #64
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %a.ext = zext <8 x i8> %a to <8 x i16>
   %b.ext = zext <8 x i8> %b to <8 x i16>
@@ -12453,74 +12362,60 @@ define <8 x i8> @clmulh_v8i8(<8 x i8> %a, <8 x i8> %b) nounwind {
 define <8 x i16> @clmulh_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; CHECK-LABEL: clmulh_v8i16:
 ; CHECK:       @ %bb.0:
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEXT:    .pad #64
+; CHECK-NEXT:    sub sp, #64
+; CHECK-NEXT:    movw r1, #37449
 ; CHECK-NEXT:    movs r0, #16
-; CHECK-NEXT:    vmov.i16 q2, #0x2
-; CHECK-NEXT:    vbrsr.16 q1, q1, r0
-; CHECK-NEXT:    vmov.i16 q3, #0x1
-; CHECK-NEXT:    vbrsr.16 q0, q0, r0
-; CHECK-NEXT:    vand q2, q1, q2
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q2, q0, q2
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q3, q2
-; CHECK-NEXT:    vmov.i16 q3, #0x4
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x8
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x10
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x20
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x40
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x80
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x100
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x200
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x400
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x800
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x1000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x2000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x4000
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmul.i16 q3, q0, q3
-; CHECK-NEXT:    veor q2, q2, q3
-; CHECK-NEXT:    vmov.i16 q3, #0x8000
-; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmul.i16 q0, q0, q1
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    vdup.16 q4, r1
+; CHECK-NEXT:    movw r1, #9362
+; CHECK-NEXT:    vbrsr.16 q6, q1, r0
+; CHECK-NEXT:    vbrsr.16 q7, q0, r0
+; CHECK-NEXT:    vdup.16 q0, r1
+; CHECK-NEXT:    vand q2, q6, q4
+; CHECK-NEXT:    vstrw.32 q4, [sp, #32] @ 16-byte Spill
+; CHECK-NEXT:    vand q1, q7, q0
+; CHECK-NEXT:    vand q3, q6, q0
+; CHECK-NEXT:    vand q4, q7, q4
+; CHECK-NEXT:    vstrw.32 q1, [sp] @ 16-byte Spill
+; CHECK-NEXT:    vmul.i16 q1, q1, q2
+; CHECK-NEXT:    vmul.i16 q5, q4, q3
+; CHECK-NEXT:    vstrw.32 q2, [sp, #48] @ 16-byte Spill
+; CHECK-NEXT:    veor q2, q5, q1
+; CHECK-NEXT:    movw r1, #18724
+; CHECK-NEXT:    vdup.16 q5, r1
+; CHECK-NEXT:    vstrw.32 q2, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vand q6, q6, q5
+; CHECK-NEXT:    vand q7, q7, q5
+; CHECK-NEXT:    vldrw.u32 q1, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q2, q7, q6
+; CHECK-NEXT:    veor q2, q1, q2
+; CHECK-NEXT:    vldrw.u32 q1, [sp] @ 16-byte Reload
+; CHECK-NEXT:    vand q0, q2, q0
+; CHECK-NEXT:    vstrw.32 q0, [sp, #16] @ 16-byte Spill
+; CHECK-NEXT:    vldrw.u32 q0, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q2, q1, q6
+; CHECK-NEXT:    vmul.i16 q1, q1, q3
+; CHECK-NEXT:    vmul.i16 q0, q4, q0
+; CHECK-NEXT:    veor q0, q0, q2
+; CHECK-NEXT:    vmul.i16 q2, q7, q3
+; CHECK-NEXT:    veor q0, q0, q2
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    vand q0, q0, q2
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vorr q0, q0, q2
+; CHECK-NEXT:    vmul.i16 q2, q4, q6
+; CHECK-NEXT:    veor q1, q2, q1
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vmul.i16 q2, q7, q2
+; CHECK-NEXT:    veor q1, q1, q2
+; CHECK-NEXT:    vand q1, q1, q5
+; CHECK-NEXT:    vorr q0, q0, q1
 ; CHECK-NEXT:    vbrsr.16 q0, q0, r0
 ; CHECK-NEXT:    vshr.u16 q0, q0, #1
+; CHECK-NEXT:    add sp, #64
+; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    bx lr
   %a.ext = zext <8 x i16> %a to <8 x i32>
   %b.ext = zext <8 x i16> %b to <8 x i32>

--- a/llvm/test/CodeGen/X86/clmul-vector-256.ll
+++ b/llvm/test/CodeGen/X86/clmul-vector-256.ll
@@ -7,255 +7,138 @@
 define <32 x i8> @clmul_v32i8(<32 x i8> %a, <32 x i8> %b) nounwind {
 ; AVX1-LABEL: clmul_v32i8:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm2
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX1-NEXT:    vextractf128 $1, %ymm4, %xmm5
-; AVX1-NEXT:    vpmullw %xmm5, %xmm2, %xmm3
-; AVX1-NEXT:    vpmullw %xmm4, %xmm0, %xmm6
-; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm6, %ymm6
-; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm3 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
-; AVX1-NEXT:    vandps %ymm3, %ymm6, %ymm6
-; AVX1-NEXT:    vandnps %xmm4, %xmm3, %xmm4
-; AVX1-NEXT:    vpmaddubsw %xmm4, %xmm0, %xmm4
-; AVX1-NEXT:    vpsllw $8, %xmm4, %xmm4
-; AVX1-NEXT:    vandnps %xmm5, %xmm3, %xmm5
-; AVX1-NEXT:    vpmaddubsw %xmm5, %xmm2, %xmm5
-; AVX1-NEXT:    vpsllw $8, %xmm5, %xmm5
-; AVX1-NEXT:    vinsertf128 $1, %xmm5, %ymm4, %ymm4
-; AVX1-NEXT:    vorps %ymm4, %ymm6, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm7
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm8
-; AVX1-NEXT:    vinsertf128 $1, %xmm7, %ymm8, %ymm7
-; AVX1-NEXT:    vandps %ymm3, %ymm7, %ymm7
-; AVX1-NEXT:    vandnps %xmm5, %xmm3, %xmm5
-; AVX1-NEXT:    vpmaddubsw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vpsllw $8, %xmm5, %xmm5
-; AVX1-NEXT:    vandnps %xmm6, %xmm3, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm2, %xmm6
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm2 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX1-NEXT:    vandps %ymm2, %ymm1, %ymm3
+; AVX1-NEXT:    vextractf128 $1, %ymm3, %xmm4
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm10 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX1-NEXT:    vandps %ymm0, %ymm10, %ymm9
+; AVX1-NEXT:    vextractf128 $1, %ymm9, %xmm7
+; AVX1-NEXT:    vpmullw %xmm4, %xmm7, %xmm5
+; AVX1-NEXT:    vpmullw %xmm3, %xmm9, %xmm6
+; AVX1-NEXT:    vinsertf128 $1, %xmm5, %ymm6, %ymm6
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm5 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
+; AVX1-NEXT:    vandps %ymm5, %ymm6, %ymm11
+; AVX1-NEXT:    vandnps %xmm3, %xmm5, %xmm6
+; AVX1-NEXT:    vmovaps %xmm6, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
+; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm9, %xmm8
+; AVX1-NEXT:    vpsllw $8, %xmm8, %xmm12
+; AVX1-NEXT:    vandnps %xmm4, %xmm5, %xmm8
+; AVX1-NEXT:    vpmaddubsw %xmm8, %xmm7, %xmm13
+; AVX1-NEXT:    vpsllw $8, %xmm13, %xmm13
+; AVX1-NEXT:    vinsertf128 $1, %xmm13, %ymm12, %ymm12
+; AVX1-NEXT:    vorps %ymm12, %ymm11, %ymm11
+; AVX1-NEXT:    vandps %ymm1, %ymm10, %ymm10
+; AVX1-NEXT:    vextractf128 $1, %ymm10, %xmm12
+; AVX1-NEXT:    vandps %ymm2, %ymm0, %ymm1
+; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm0
+; AVX1-NEXT:    vpmullw %xmm0, %xmm12, %xmm13
+; AVX1-NEXT:    vpmullw %xmm1, %xmm10, %xmm14
+; AVX1-NEXT:    vinsertf128 $1, %xmm13, %ymm14, %ymm13
+; AVX1-NEXT:    vandnps %xmm10, %xmm5, %xmm14
+; AVX1-NEXT:    vpmaddubsw %xmm14, %xmm1, %xmm15
+; AVX1-NEXT:    vpsllw $8, %xmm15, %xmm15
+; AVX1-NEXT:    vandnps %xmm12, %xmm5, %xmm2
+; AVX1-NEXT:    vpmaddubsw %xmm2, %xmm0, %xmm6
 ; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vorps %ymm5, %ymm7, %ymm5
-; AVX1-NEXT:    vxorps %ymm4, %ymm5, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm7
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm8
-; AVX1-NEXT:    vinsertf128 $1, %xmm7, %ymm8, %ymm7
-; AVX1-NEXT:    vandps %ymm3, %ymm7, %ymm7
-; AVX1-NEXT:    vandnps %xmm5, %xmm3, %xmm5
-; AVX1-NEXT:    vpmaddubsw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vpsllw $8, %xmm5, %xmm5
-; AVX1-NEXT:    vandnps %xmm6, %xmm3, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm2, %xmm6
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vorps %ymm5, %ymm7, %ymm5
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm6
-; AVX1-NEXT:    vextractf128 $1, %ymm6, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm2, %xmm8
-; AVX1-NEXT:    vpmullw %xmm6, %xmm0, %xmm9
-; AVX1-NEXT:    vinsertf128 $1, %xmm8, %ymm9, %ymm8
-; AVX1-NEXT:    vandps %ymm3, %ymm8, %ymm8
-; AVX1-NEXT:    vandnps %xmm6, %xmm3, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm0, %xmm6
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vandnps %xmm7, %xmm3, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm2, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vinsertf128 $1, %xmm7, %ymm6, %ymm6
-; AVX1-NEXT:    vorps %ymm6, %ymm8, %ymm6
-; AVX1-NEXT:    vxorps %ymm6, %ymm5, %ymm5
-; AVX1-NEXT:    vxorps %ymm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm7
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm8
-; AVX1-NEXT:    vinsertf128 $1, %xmm7, %ymm8, %ymm7
-; AVX1-NEXT:    vandps %ymm3, %ymm7, %ymm7
-; AVX1-NEXT:    vandnps %xmm5, %xmm3, %xmm5
-; AVX1-NEXT:    vpmaddubsw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vpsllw $8, %xmm5, %xmm5
-; AVX1-NEXT:    vandnps %xmm6, %xmm3, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm2, %xmm6
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vorps %ymm5, %ymm7, %ymm5
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm6
-; AVX1-NEXT:    vextractf128 $1, %ymm6, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm2, %xmm8
-; AVX1-NEXT:    vpmullw %xmm6, %xmm0, %xmm9
-; AVX1-NEXT:    vinsertf128 $1, %xmm8, %ymm9, %ymm8
-; AVX1-NEXT:    vandps %ymm3, %ymm8, %ymm8
-; AVX1-NEXT:    vandnps %xmm6, %xmm3, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm0, %xmm6
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vandnps %xmm7, %xmm3, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm2, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vinsertf128 $1, %xmm7, %ymm6, %ymm6
-; AVX1-NEXT:    vorps %ymm6, %ymm8, %ymm6
-; AVX1-NEXT:    vxorps %ymm6, %ymm5, %ymm5
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm6
-; AVX1-NEXT:    vextractf128 $1, %ymm6, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm2, %xmm8
-; AVX1-NEXT:    vpmullw %xmm6, %xmm0, %xmm9
-; AVX1-NEXT:    vinsertf128 $1, %xmm8, %ymm9, %ymm8
-; AVX1-NEXT:    vandps %ymm3, %ymm8, %ymm8
-; AVX1-NEXT:    vandnps %xmm6, %xmm3, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm0, %xmm6
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vandnps %xmm7, %xmm3, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm2, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vinsertf128 $1, %xmm7, %ymm6, %ymm6
-; AVX1-NEXT:    vorps %ymm6, %ymm8, %ymm6
-; AVX1-NEXT:    vxorps %ymm6, %ymm5, %ymm5
-; AVX1-NEXT:    vxorps %ymm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm5
-; AVX1-NEXT:    vpmullw %xmm5, %xmm2, %xmm6
-; AVX1-NEXT:    vpmullw %xmm1, %xmm0, %xmm7
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm7, %ymm6
-; AVX1-NEXT:    vandps %ymm3, %ymm6, %ymm6
-; AVX1-NEXT:    vandnps %xmm1, %xmm3, %xmm1
-; AVX1-NEXT:    vpmaddubsw %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vpsllw $8, %xmm0, %xmm0
-; AVX1-NEXT:    vandnps %xmm5, %xmm3, %xmm1
-; AVX1-NEXT:    vpmaddubsw %xmm1, %xmm2, %xmm1
+; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm15, %ymm6
+; AVX1-NEXT:    vandps %ymm5, %ymm13, %ymm13
+; AVX1-NEXT:    vorps %ymm6, %ymm13, %ymm6
+; AVX1-NEXT:    vxorps %ymm6, %ymm11, %ymm6
+; AVX1-NEXT:    vpmullw %xmm7, %xmm12, %xmm11
+; AVX1-NEXT:    vpmullw %xmm10, %xmm9, %xmm10
+; AVX1-NEXT:    vinsertf128 $1, %xmm11, %ymm10, %ymm10
+; AVX1-NEXT:    vpmaddubsw %xmm14, %xmm9, %xmm9
+; AVX1-NEXT:    vpmaddubsw %xmm2, %xmm7, %xmm2
+; AVX1-NEXT:    vpsllw $8, %xmm9, %xmm7
+; AVX1-NEXT:    vpsllw $8, %xmm2, %xmm2
+; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm7, %ymm2
+; AVX1-NEXT:    vandps %ymm5, %ymm10, %ymm7
+; AVX1-NEXT:    vorps %ymm2, %ymm7, %ymm2
+; AVX1-NEXT:    vpmullw %xmm4, %xmm0, %xmm4
+; AVX1-NEXT:    vpmullw %xmm3, %xmm1, %xmm3
+; AVX1-NEXT:    vinsertf128 $1, %xmm4, %ymm3, %ymm3
+; AVX1-NEXT:    vandps %ymm5, %ymm3, %ymm3
+; AVX1-NEXT:    vpmaddubsw {{[-0-9]+}}(%r{{[sb]}}p), %xmm1, %xmm1 # 16-byte Folded Reload
+; AVX1-NEXT:    vpmaddubsw %xmm8, %xmm0, %xmm0
 ; AVX1-NEXT:    vpsllw $8, %xmm1, %xmm1
-; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
-; AVX1-NEXT:    vorps %ymm0, %ymm6, %ymm0
-; AVX1-NEXT:    vxorps %ymm0, %ymm4, %ymm0
+; AVX1-NEXT:    vpsllw $8, %xmm0, %xmm0
+; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
+; AVX1-NEXT:    vorps %ymm0, %ymm3, %ymm0
+; AVX1-NEXT:    vxorps %ymm2, %ymm0, %ymm0
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm2 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX1-NEXT:    vandnps %ymm6, %ymm2, %ymm1
+; AVX1-NEXT:    vandps %ymm2, %ymm0, %ymm0
+; AVX1-NEXT:    vorps %ymm1, %ymm0, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: clmul_v32i8:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm4
-; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm2 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
-; AVX2-NEXT:    vpand %ymm2, %ymm4, %ymm4
-; AVX2-NEXT:    vpandn %ymm3, %ymm2, %ymm3
-; AVX2-NEXT:    vpmaddubsw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpsllw $8, %ymm3, %ymm3
-; AVX2-NEXT:    vpor %ymm3, %ymm4, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm5
-; AVX2-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX2-NEXT:    vpandn %ymm4, %ymm2, %ymm4
-; AVX2-NEXT:    vpmaddubsw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpsllw $8, %ymm4, %ymm4
-; AVX2-NEXT:    vpor %ymm4, %ymm5, %ymm4
-; AVX2-NEXT:    vpxor %ymm3, %ymm4, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm5
-; AVX2-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX2-NEXT:    vpandn %ymm4, %ymm2, %ymm4
-; AVX2-NEXT:    vpmaddubsw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpsllw $8, %ymm4, %ymm4
-; AVX2-NEXT:    vpor %ymm4, %ymm5, %ymm4
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX2-NEXT:    vpmullw %ymm5, %ymm0, %ymm6
-; AVX2-NEXT:    vpand %ymm2, %ymm6, %ymm6
-; AVX2-NEXT:    vpandn %ymm5, %ymm2, %ymm5
-; AVX2-NEXT:    vpmaddubsw %ymm5, %ymm0, %ymm5
-; AVX2-NEXT:    vpsllw $8, %ymm5, %ymm5
-; AVX2-NEXT:    vpor %ymm5, %ymm6, %ymm5
-; AVX2-NEXT:    vpxor %ymm5, %ymm4, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm5
-; AVX2-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX2-NEXT:    vpandn %ymm4, %ymm2, %ymm4
-; AVX2-NEXT:    vpmaddubsw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpsllw $8, %ymm4, %ymm4
-; AVX2-NEXT:    vpor %ymm4, %ymm5, %ymm4
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX2-NEXT:    vpmullw %ymm5, %ymm0, %ymm6
-; AVX2-NEXT:    vpand %ymm2, %ymm6, %ymm6
-; AVX2-NEXT:    vpandn %ymm5, %ymm2, %ymm5
-; AVX2-NEXT:    vpmaddubsw %ymm5, %ymm0, %ymm5
-; AVX2-NEXT:    vpsllw $8, %ymm5, %ymm5
-; AVX2-NEXT:    vpor %ymm5, %ymm6, %ymm5
-; AVX2-NEXT:    vpxor %ymm5, %ymm4, %ymm4
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX2-NEXT:    vpmullw %ymm5, %ymm0, %ymm6
-; AVX2-NEXT:    vpand %ymm2, %ymm6, %ymm6
-; AVX2-NEXT:    vpandn %ymm5, %ymm2, %ymm5
-; AVX2-NEXT:    vpmaddubsw %ymm5, %ymm0, %ymm5
-; AVX2-NEXT:    vpsllw $8, %ymm5, %ymm5
-; AVX2-NEXT:    vpor %ymm5, %ymm6, %ymm5
-; AVX2-NEXT:    vpxor %ymm5, %ymm4, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
+; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm2 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm3
+; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm4 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm5
+; AVX2-NEXT:    vpmullw %ymm3, %ymm5, %ymm6
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm7 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
+; AVX2-NEXT:    vpand %ymm7, %ymm6, %ymm6
+; AVX2-NEXT:    vpandn %ymm3, %ymm7, %ymm8
+; AVX2-NEXT:    vpmaddubsw %ymm8, %ymm5, %ymm9
+; AVX2-NEXT:    vpsllw $8, %ymm9, %ymm9
+; AVX2-NEXT:    vpor %ymm6, %ymm9, %ymm6
+; AVX2-NEXT:    vpand %ymm4, %ymm1, %ymm1
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm0
 ; AVX2-NEXT:    vpmullw %ymm1, %ymm0, %ymm4
-; AVX2-NEXT:    vpand %ymm2, %ymm4, %ymm4
-; AVX2-NEXT:    vpandn %ymm1, %ymm2, %ymm1
-; AVX2-NEXT:    vpmaddubsw %ymm1, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm7, %ymm4, %ymm4
+; AVX2-NEXT:    vpandn %ymm1, %ymm7, %ymm9
+; AVX2-NEXT:    vpmaddubsw %ymm9, %ymm0, %ymm10
+; AVX2-NEXT:    vpsllw $8, %ymm10, %ymm10
+; AVX2-NEXT:    vpor %ymm4, %ymm10, %ymm4
+; AVX2-NEXT:    vpxor %ymm6, %ymm4, %ymm4
+; AVX2-NEXT:    vpandn %ymm4, %ymm2, %ymm4
+; AVX2-NEXT:    vpmullw %ymm1, %ymm5, %ymm1
+; AVX2-NEXT:    vpand %ymm7, %ymm1, %ymm1
+; AVX2-NEXT:    vpmaddubsw %ymm9, %ymm5, %ymm5
+; AVX2-NEXT:    vpsllw $8, %ymm5, %ymm5
+; AVX2-NEXT:    vpor %ymm5, %ymm1, %ymm1
+; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
+; AVX2-NEXT:    vpand %ymm7, %ymm3, %ymm3
+; AVX2-NEXT:    vpmaddubsw %ymm8, %ymm0, %ymm0
 ; AVX2-NEXT:    vpsllw $8, %ymm0, %ymm0
-; AVX2-NEXT:    vpor %ymm0, %ymm4, %ymm0
-; AVX2-NEXT:    vpxor %ymm0, %ymm3, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm3, %ymm0
+; AVX2-NEXT:    vpxor %ymm1, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpor %ymm4, %ymm0, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: clmul_v32i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm3
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm4 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
-; AVX512-NEXT:    vpandn %ymm2, %ymm4, %ymm2
-; AVX512-NEXT:    vpmaddubsw %ymm2, %ymm0, %ymm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm2 = [1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765]
+; AVX512-NEXT:    vpand %ymm2, %ymm1, %ymm3
+; AVX512-NEXT:    vpand %ymm2, %ymm0, %ymm2
+; AVX512-NEXT:    vpmullw %ymm3, %ymm2, %ymm4
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm5 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
+; AVX512-NEXT:    vpandn %ymm3, %ymm5, %ymm6
+; AVX512-NEXT:    vpmaddubsw %ymm6, %ymm2, %ymm7
+; AVX512-NEXT:    vpsllw $8, %ymm7, %ymm7
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm7 | (ymm4 & ymm5)
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm4 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX512-NEXT:    vpand %ymm4, %ymm1, %ymm1
+; AVX512-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm4
+; AVX512-NEXT:    vpand %ymm5, %ymm4, %ymm4
+; AVX512-NEXT:    vpandn %ymm1, %ymm5, %ymm8
+; AVX512-NEXT:    vpmaddubsw %ymm8, %ymm0, %ymm9
+; AVX512-NEXT:    vpsllw $8, %ymm9, %ymm9
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm9 = ymm7 ^ (ymm9 | ymm4)
+; AVX512-NEXT:    vpmullw %ymm1, %ymm2, %ymm1
+; AVX512-NEXT:    vpmaddubsw %ymm8, %ymm2, %ymm2
 ; AVX512-NEXT:    vpsllw $8, %ymm2, %ymm2
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm2 = ymm2 | (ymm3 & ymm4)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm5
-; AVX512-NEXT:    vpand %ymm4, %ymm5, %ymm5
-; AVX512-NEXT:    vpandn %ymm3, %ymm4, %ymm3
-; AVX512-NEXT:    vpmaddubsw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpsllw $8, %ymm3, %ymm3
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm3 = ymm2 ^ (ymm3 | ymm5)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm5
-; AVX512-NEXT:    vpand %ymm4, %ymm5, %ymm5
-; AVX512-NEXT:    vpandn %ymm2, %ymm4, %ymm2
-; AVX512-NEXT:    vpmaddubsw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpsllw $8, %ymm2, %ymm2
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm2 = ymm3 ^ (ymm2 | ymm5)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm5
-; AVX512-NEXT:    vpand %ymm4, %ymm5, %ymm5
-; AVX512-NEXT:    vpandn %ymm3, %ymm4, %ymm3
-; AVX512-NEXT:    vpmaddubsw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpsllw $8, %ymm3, %ymm3
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm3 = ymm2 ^ (ymm3 | ymm5)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm5
-; AVX512-NEXT:    vpand %ymm4, %ymm5, %ymm5
-; AVX512-NEXT:    vpandn %ymm2, %ymm4, %ymm2
-; AVX512-NEXT:    vpmaddubsw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpsllw $8, %ymm2, %ymm2
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm2 = ymm3 ^ (ymm2 | ymm5)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm5
-; AVX512-NEXT:    vpand %ymm4, %ymm5, %ymm5
-; AVX512-NEXT:    vpandn %ymm3, %ymm4, %ymm3
-; AVX512-NEXT:    vpmaddubsw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpsllw $8, %ymm3, %ymm3
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm3 = ymm2 ^ (ymm3 | ymm5)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm5
-; AVX512-NEXT:    vpand %ymm4, %ymm5, %ymm5
-; AVX512-NEXT:    vpandn %ymm2, %ymm4, %ymm2
-; AVX512-NEXT:    vpmaddubsw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpsllw $8, %ymm2, %ymm2
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm2 = ymm3 ^ (ymm2 | ymm5)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm1
-; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm3
-; AVX512-NEXT:    vpand %ymm4, %ymm3, %ymm3
-; AVX512-NEXT:    vpandn %ymm1, %ymm4, %ymm1
-; AVX512-NEXT:    vpmaddubsw %ymm1, %ymm0, %ymm0
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm2 = ymm2 | (ymm1 & ymm5)
+; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm1
+; AVX512-NEXT:    vpand %ymm5, %ymm1, %ymm1
+; AVX512-NEXT:    vpmaddubsw %ymm6, %ymm0, %ymm0
 ; AVX512-NEXT:    vpsllw $8, %ymm0, %ymm0
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm2 ^ (ymm0 | ymm3)
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm2 ^ (ymm0 | ymm1)
+; AVX512-NEXT:    vpternlogd {{.*#+}} ymm0 = ymm0 ^ (m32bcst & (ymm0 ^ ymm9))
 ; AVX512-NEXT:    retq
   %res = call <32 x i8> @llvm.clmul.v32i8(<32 x i8> %a, <32 x i8> %b)
   ret <32 x i8> %res
@@ -264,197 +147,120 @@ define <32 x i8> @clmul_v32i8(<32 x i8> %a, <32 x i8> %b) nounwind {
 define <16 x i16> @clmul_v16i16(<16 x i16> %a, <16 x i16> %b) nounwind {
 ; AVX1-LABEL: clmul_v16i16:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm2
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm2 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX1-NEXT:    vandps %ymm2, %ymm1, %ymm3
 ; AVX1-NEXT:    vextractf128 $1, %ymm3, %xmm4
-; AVX1-NEXT:    vpmullw %xmm4, %xmm2, %xmm4
-; AVX1-NEXT:    vpmullw %xmm3, %xmm0, %xmm3
-; AVX1-NEXT:    vinsertf128 $1, %xmm4, %ymm3, %ymm3
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX1-NEXT:    vextractf128 $1, %ymm4, %xmm5
-; AVX1-NEXT:    vpmullw %xmm5, %xmm2, %xmm5
-; AVX1-NEXT:    vpmullw %xmm4, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm5, %ymm4, %ymm4
-; AVX1-NEXT:    vxorps %ymm3, %ymm4, %ymm3
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX1-NEXT:    vextractf128 $1, %ymm4, %xmm5
-; AVX1-NEXT:    vpmullw %xmm5, %xmm2, %xmm5
-; AVX1-NEXT:    vpmullw %xmm4, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm13 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX1-NEXT:    vandps %ymm0, %ymm13, %ymm5
 ; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm6
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm5
+; AVX1-NEXT:    vpmullw %xmm4, %xmm6, %xmm7
+; AVX1-NEXT:    vpmullw %xmm3, %xmm5, %xmm8
+; AVX1-NEXT:    vinsertf128 $1, %xmm7, %ymm8, %ymm8
+; AVX1-NEXT:    vandps %ymm1, %ymm13, %ymm9
+; AVX1-NEXT:    vextractf128 $1, %ymm9, %xmm11
+; AVX1-NEXT:    vandps %ymm2, %ymm0, %ymm7
+; AVX1-NEXT:    vextractf128 $1, %ymm7, %xmm10
+; AVX1-NEXT:    vpmullw %xmm11, %xmm10, %xmm12
+; AVX1-NEXT:    vpmullw %xmm7, %xmm9, %xmm14
+; AVX1-NEXT:    vinsertf128 $1, %xmm12, %ymm14, %ymm12
+; AVX1-NEXT:    vxorps %ymm8, %ymm12, %ymm14
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm2 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX1-NEXT:    vandps %ymm2, %ymm1, %ymm12
+; AVX1-NEXT:    vextractf128 $1, %ymm12, %xmm15
+; AVX1-NEXT:    vandps %ymm2, %ymm0, %ymm0
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
+; AVX1-NEXT:    vpmullw %xmm1, %xmm15, %xmm2
+; AVX1-NEXT:    vpmullw %xmm0, %xmm12, %xmm8
+; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm8, %ymm2
+; AVX1-NEXT:    vxorps %ymm2, %ymm14, %ymm2
+; AVX1-NEXT:    vandps %ymm2, %ymm13, %ymm2
+; AVX1-NEXT:    vpmullw %xmm6, %xmm15, %xmm8
+; AVX1-NEXT:    vpmullw %xmm5, %xmm12, %xmm13
+; AVX1-NEXT:    vinsertf128 $1, %xmm8, %ymm13, %ymm8
+; AVX1-NEXT:    vpmullw %xmm4, %xmm10, %xmm13
+; AVX1-NEXT:    vpmullw %xmm3, %xmm7, %xmm14
+; AVX1-NEXT:    vinsertf128 $1, %xmm13, %ymm14, %ymm13
+; AVX1-NEXT:    vxorps %ymm8, %ymm13, %ymm8
+; AVX1-NEXT:    vpmullw %xmm1, %xmm11, %xmm13
+; AVX1-NEXT:    vpmullw %xmm0, %xmm9, %xmm14
+; AVX1-NEXT:    vinsertf128 $1, %xmm13, %ymm14, %ymm13
+; AVX1-NEXT:    vxorps %ymm13, %ymm8, %ymm8
+; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm8, %ymm8
+; AVX1-NEXT:    vorps %ymm2, %ymm8, %ymm2
+; AVX1-NEXT:    vpmullw %xmm6, %xmm11, %xmm6
+; AVX1-NEXT:    vpmullw %xmm5, %xmm9, %xmm5
 ; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vxorps %ymm5, %ymm4, %ymm4
-; AVX1-NEXT:    vxorps %ymm4, %ymm3, %ymm3
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX1-NEXT:    vextractf128 $1, %ymm4, %xmm5
-; AVX1-NEXT:    vpmullw %xmm5, %xmm2, %xmm5
-; AVX1-NEXT:    vpmullw %xmm4, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm6
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vxorps %ymm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm6
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vxorps %ymm5, %ymm4, %ymm4
-; AVX1-NEXT:    vxorps %ymm4, %ymm3, %ymm3
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX1-NEXT:    vextractf128 $1, %ymm4, %xmm5
-; AVX1-NEXT:    vpmullw %xmm5, %xmm2, %xmm5
-; AVX1-NEXT:    vpmullw %xmm4, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm6
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vxorps %ymm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm6
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vxorps %ymm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm6
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vxorps %ymm5, %ymm4, %ymm4
-; AVX1-NEXT:    vxorps %ymm4, %ymm3, %ymm3
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX1-NEXT:    vextractf128 $1, %ymm4, %xmm5
-; AVX1-NEXT:    vpmullw %xmm5, %xmm2, %xmm5
-; AVX1-NEXT:    vpmullw %xmm4, %xmm0, %xmm4
-; AVX1-NEXT:    vinsertf128 $1, %xmm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm6
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vxorps %ymm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm6
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vxorps %ymm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm5
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm2, %xmm6
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm5, %ymm5
-; AVX1-NEXT:    vxorps %ymm5, %ymm4, %ymm4
-; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm5
-; AVX1-NEXT:    vpmullw %xmm5, %xmm2, %xmm2
-; AVX1-NEXT:    vpmullw %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm0, %ymm0
-; AVX1-NEXT:    vxorps %ymm0, %ymm4, %ymm0
-; AVX1-NEXT:    vxorps %ymm0, %ymm3, %ymm0
+; AVX1-NEXT:    vpmullw %xmm15, %xmm10, %xmm6
+; AVX1-NEXT:    vpmullw %xmm7, %xmm12, %xmm7
+; AVX1-NEXT:    vinsertf128 $1, %xmm6, %ymm7, %ymm6
+; AVX1-NEXT:    vxorps %ymm5, %ymm6, %ymm5
+; AVX1-NEXT:    vpmullw %xmm4, %xmm1, %xmm1
+; AVX1-NEXT:    vpmullw %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
+; AVX1-NEXT:    vxorps %ymm0, %ymm5, %ymm0
+; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
+; AVX1-NEXT:    vorps %ymm0, %ymm2, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: clmul_v16i16:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm2
-; AVX2-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpxor %ymm2, %ymm3, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
-; AVX2-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpxor %ymm0, %ymm3, %ymm0
-; AVX2-NEXT:    vpxor %ymm0, %ymm2, %ymm0
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm2 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm3
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm4 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm5
+; AVX2-NEXT:    vpmullw %ymm3, %ymm5, %ymm6
+; AVX2-NEXT:    vpand %ymm4, %ymm1, %ymm7
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm8
+; AVX2-NEXT:    vpmullw %ymm7, %ymm8, %ymm9
+; AVX2-NEXT:    vpxor %ymm6, %ymm9, %ymm6
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm9 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX2-NEXT:    vpand %ymm1, %ymm9, %ymm1
+; AVX2-NEXT:    vpand %ymm0, %ymm9, %ymm0
+; AVX2-NEXT:    vpmullw %ymm1, %ymm0, %ymm10
+; AVX2-NEXT:    vpxor %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpand %ymm4, %ymm6, %ymm4
+; AVX2-NEXT:    vpmullw %ymm1, %ymm5, %ymm6
+; AVX2-NEXT:    vpmullw %ymm3, %ymm8, %ymm10
+; AVX2-NEXT:    vpxor %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpmullw %ymm7, %ymm0, %ymm10
+; AVX2-NEXT:    vpxor %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpand %ymm2, %ymm6, %ymm2
+; AVX2-NEXT:    vpor %ymm4, %ymm2, %ymm2
+; AVX2-NEXT:    vpmullw %ymm7, %ymm5, %ymm4
+; AVX2-NEXT:    vpmullw %ymm1, %ymm8, %ymm1
+; AVX2-NEXT:    vpxor %ymm4, %ymm1, %ymm1
+; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm0
+; AVX2-NEXT:    vpxor %ymm0, %ymm1, %ymm0
+; AVX2-NEXT:    vpand %ymm0, %ymm9, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: clmul_v16i16:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpxor %ymm2, %ymm3, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm4
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm4 = ymm4 ^ ymm2 ^ ymm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm3 = ymm3 ^ ymm4 ^ ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm4
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm4 = ymm4 ^ ymm3 ^ ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm3 = ymm3 ^ ymm4 ^ ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm4
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm4 = ymm4 ^ ymm3 ^ ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm3 = ymm3 ^ ymm4 ^ ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm1
-; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 ^ ymm3 ^ ymm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm2 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX512-NEXT:    vpand %ymm2, %ymm1, %ymm3
+; AVX512-NEXT:    vpand %ymm2, %ymm0, %ymm4
+; AVX512-NEXT:    vpmullw %ymm3, %ymm4, %ymm5
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm6 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX512-NEXT:    vpand %ymm6, %ymm1, %ymm7
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm8 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX512-NEXT:    vpand %ymm0, %ymm8, %ymm9
+; AVX512-NEXT:    vpmullw %ymm7, %ymm9, %ymm10
+; AVX512-NEXT:    vpand %ymm1, %ymm8, %ymm1
+; AVX512-NEXT:    vpand %ymm6, %ymm0, %ymm0
+; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm11
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm11 = ymm11 ^ ymm10 ^ ymm5
+; AVX512-NEXT:    vpmullw %ymm1, %ymm4, %ymm5
+; AVX512-NEXT:    vpmullw %ymm3, %ymm9, %ymm10
+; AVX512-NEXT:    vpmullw %ymm7, %ymm0, %ymm12
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm12 = ymm12 ^ ymm10 ^ ymm5
+; AVX512-NEXT:    vpmullw %ymm7, %ymm4, %ymm4
+; AVX512-NEXT:    vpmullw %ymm1, %ymm9, %ymm1
+; AVX512-NEXT:    vpxor %ymm4, %ymm1, %ymm1
+; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm0
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm8 & (ymm0 ^ ymm1)
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 | (ymm12 & ymm2)
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 | (ymm11 & ymm6)
 ; AVX512-NEXT:    retq
   %res = call <16 x i16> @llvm.clmul.v16i16(<16 x i16> %a, <16 x i16> %b)
   ret <16 x i16> %res
@@ -610,336 +416,247 @@ define <4 x i64> @clmul_v4i64(<4 x i64> %a, <4 x i64> %b) nounwind {
 define <32 x i8> @clmulr_v32i8(<32 x i8> %a, <32 x i8> %b) nounwind {
 ; AVX1-LABEL: clmulr_v32i8:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vmovdqa %ymm1, %ymm3
-; AVX1-NEXT:    vmovdqa %ymm0, %ymm1
-; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm4
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX1-NEXT:    vpand %xmm2, %xmm4, %xmm5
-; AVX1-NEXT:    vmovdqa {{.*#+}} xmm0 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
-; AVX1-NEXT:    vpshufb %xmm5, %xmm0, %xmm5
+; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm4
+; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm13 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX1-NEXT:    vpand %xmm4, %xmm13, %xmm5
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX1-NEXT:    vpshufb %xmm5, %xmm3, %xmm5
 ; AVX1-NEXT:    vpsrlw $4, %xmm4, %xmm4
-; AVX1-NEXT:    vpand %xmm2, %xmm4, %xmm6
+; AVX1-NEXT:    vpand %xmm4, %xmm13, %xmm6
 ; AVX1-NEXT:    vmovdqa {{.*#+}} xmm4 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
 ; AVX1-NEXT:    vpshufb %xmm6, %xmm4, %xmm6
-; AVX1-NEXT:    vpor %xmm6, %xmm5, %xmm14
-; AVX1-NEXT:    vextractf128 $1, %ymm3, %xmm10
-; AVX1-NEXT:    vpsrlw $4, %xmm10, %xmm5
-; AVX1-NEXT:    vpand %xmm2, %xmm5, %xmm5
-; AVX1-NEXT:    vpshufb %xmm5, %xmm4, %xmm11
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm11, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm14, %xmm8
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm5 = [255,255,255,255,255,255,255,255]
-; AVX1-NEXT:    vpand %xmm5, %xmm8, %xmm8
-; AVX1-NEXT:    vpandn %xmm7, %xmm5, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm14, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vpor %xmm7, %xmm8, %xmm8
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm11, %xmm9
-; AVX1-NEXT:    vpmullw %xmm9, %xmm14, %xmm12
-; AVX1-NEXT:    vpand %xmm5, %xmm12, %xmm12
-; AVX1-NEXT:    vpandn %xmm9, %xmm5, %xmm9
-; AVX1-NEXT:    vpmaddubsw %xmm9, %xmm14, %xmm9
-; AVX1-NEXT:    vpsllw $8, %xmm9, %xmm9
-; AVX1-NEXT:    vpor %xmm9, %xmm12, %xmm9
-; AVX1-NEXT:    vpxor %xmm8, %xmm9, %xmm12
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm8 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; AVX1-NEXT:    vpand %xmm8, %xmm11, %xmm9
-; AVX1-NEXT:    vpmullw %xmm9, %xmm14, %xmm13
-; AVX1-NEXT:    vpand %xmm5, %xmm13, %xmm13
-; AVX1-NEXT:    vpandn %xmm9, %xmm5, %xmm9
-; AVX1-NEXT:    vpmaddubsw %xmm9, %xmm14, %xmm9
-; AVX1-NEXT:    vpsllw $8, %xmm9, %xmm9
-; AVX1-NEXT:    vpor %xmm9, %xmm13, %xmm13
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm11, %xmm11
-; AVX1-NEXT:    vpmullw %xmm11, %xmm14, %xmm15
-; AVX1-NEXT:    vpand %xmm5, %xmm15, %xmm15
-; AVX1-NEXT:    vpandn %xmm11, %xmm5, %xmm11
-; AVX1-NEXT:    vpmaddubsw %xmm11, %xmm14, %xmm11
-; AVX1-NEXT:    vpsllw $8, %xmm11, %xmm11
-; AVX1-NEXT:    vpor %xmm11, %xmm15, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm13, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm12, %xmm13
-; AVX1-NEXT:    vpand %xmm2, %xmm10, %xmm10
-; AVX1-NEXT:    vmovdqa %xmm0, %xmm9
-; AVX1-NEXT:    vpshufb %xmm10, %xmm0, %xmm15
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm10 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; AVX1-NEXT:    vpand %xmm10, %xmm15, %xmm11
-; AVX1-NEXT:    vpmullw %xmm11, %xmm14, %xmm12
-; AVX1-NEXT:    vpand %xmm5, %xmm12, %xmm12
-; AVX1-NEXT:    vpandn %xmm11, %xmm5, %xmm11
-; AVX1-NEXT:    vpmaddubsw %xmm11, %xmm14, %xmm11
-; AVX1-NEXT:    vpsllw $8, %xmm11, %xmm11
-; AVX1-NEXT:    vpor %xmm11, %xmm12, %xmm12
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm11 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; AVX1-NEXT:    vpand %xmm11, %xmm15, %xmm0
-; AVX1-NEXT:    vpmullw %xmm0, %xmm14, %xmm6
-; AVX1-NEXT:    vpand %xmm5, %xmm6, %xmm6
-; AVX1-NEXT:    vpandn %xmm0, %xmm5, %xmm0
-; AVX1-NEXT:    vpmaddubsw %xmm0, %xmm14, %xmm0
-; AVX1-NEXT:    vpsllw $8, %xmm0, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm12, %xmm0
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm12 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; AVX1-NEXT:    vpand %xmm12, %xmm15, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm14, %xmm7
-; AVX1-NEXT:    vpand %xmm5, %xmm7, %xmm7
-; AVX1-NEXT:    vpandn %xmm6, %xmm5, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm14, %xmm6
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vpor %xmm6, %xmm7, %xmm6
-; AVX1-NEXT:    vpxor %xmm6, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm13, %xmm0
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm13 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-; AVX1-NEXT:    vpand %xmm13, %xmm15, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm14, %xmm7
-; AVX1-NEXT:    vpandn %xmm6, %xmm5, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm14, %xmm6
-; AVX1-NEXT:    vpand %xmm5, %xmm7, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vpor %xmm6, %xmm7, %xmm6
-; AVX1-NEXT:    vpxor %xmm6, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm6
-; AVX1-NEXT:    vpshufb %xmm6, %xmm9, %xmm6
-; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm4, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm6, %xmm14
-; AVX1-NEXT:    vpand %xmm2, %xmm1, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm9, %xmm0
+; AVX1-NEXT:    vpor %xmm6, %xmm5, %xmm10
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm2 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX1-NEXT:    vpand %xmm2, %xmm10, %xmm6
+; AVX1-NEXT:    vmovdqa %ymm2, %ymm11
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm7
+; AVX1-NEXT:    vpand %xmm7, %xmm13, %xmm8
+; AVX1-NEXT:    vmovdqa %xmm3, %xmm2
+; AVX1-NEXT:    vpshufb %xmm8, %xmm3, %xmm8
+; AVX1-NEXT:    vpsrlw $4, %xmm7, %xmm7
+; AVX1-NEXT:    vpand %xmm7, %xmm13, %xmm7
+; AVX1-NEXT:    vmovdqa %xmm4, %xmm5
+; AVX1-NEXT:    vpshufb %xmm7, %xmm4, %xmm7
+; AVX1-NEXT:    vpor %xmm7, %xmm8, %xmm12
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm4 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX1-NEXT:    vpand %xmm4, %xmm12, %xmm7
+; AVX1-NEXT:    vpmullw %xmm6, %xmm7, %xmm8
+; AVX1-NEXT:    vmovdqa %xmm6, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
+; AVX1-NEXT:    vpand %xmm1, %xmm13, %xmm9
+; AVX1-NEXT:    vpshufb %xmm9, %xmm3, %xmm9
 ; AVX1-NEXT:    vpsrlw $4, %xmm1, %xmm1
-; AVX1-NEXT:    vpand %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm4, %xmm1
-; AVX1-NEXT:    vpor %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vpsrlw $4, %xmm3, %xmm1
-; AVX1-NEXT:    vpand %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm4, %xmm1
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm0, %xmm7
-; AVX1-NEXT:    vpand %xmm5, %xmm7, %xmm7
-; AVX1-NEXT:    vpandn %xmm6, %xmm5, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm0, %xmm6
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vpor %xmm6, %xmm7, %xmm6
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm0, %xmm15
-; AVX1-NEXT:    vpand %xmm5, %xmm15, %xmm15
-; AVX1-NEXT:    vpandn %xmm7, %xmm5, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm0, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vpor %xmm7, %xmm15, %xmm7
-; AVX1-NEXT:    vpxor %xmm6, %xmm7, %xmm6
-; AVX1-NEXT:    vpand %xmm1, %xmm8, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm0, %xmm8
-; AVX1-NEXT:    vpand %xmm5, %xmm8, %xmm8
-; AVX1-NEXT:    vpandn %xmm7, %xmm5, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm0, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vpor %xmm7, %xmm8, %xmm7
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm1
-; AVX1-NEXT:    vpmullw %xmm1, %xmm0, %xmm8
-; AVX1-NEXT:    vpand %xmm5, %xmm8, %xmm8
-; AVX1-NEXT:    vpandn %xmm1, %xmm5, %xmm1
-; AVX1-NEXT:    vpmaddubsw %xmm1, %xmm0, %xmm1
-; AVX1-NEXT:    vpsllw $8, %xmm1, %xmm1
-; AVX1-NEXT:    vpor %xmm1, %xmm8, %xmm1
-; AVX1-NEXT:    vpxor %xmm1, %xmm7, %xmm1
-; AVX1-NEXT:    vpxor %xmm1, %xmm6, %xmm1
-; AVX1-NEXT:    vpand %xmm2, %xmm3, %xmm3
-; AVX1-NEXT:    vpshufb %xmm3, %xmm9, %xmm3
-; AVX1-NEXT:    vpand %xmm3, %xmm10, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm0, %xmm7
-; AVX1-NEXT:    vpand %xmm5, %xmm7, %xmm7
-; AVX1-NEXT:    vpandn %xmm6, %xmm5, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm0, %xmm6
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vpor %xmm6, %xmm7, %xmm6
-; AVX1-NEXT:    vpand %xmm3, %xmm11, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm0, %xmm8
-; AVX1-NEXT:    vpand %xmm5, %xmm8, %xmm8
-; AVX1-NEXT:    vpandn %xmm7, %xmm5, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm0, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vpor %xmm7, %xmm8, %xmm7
-; AVX1-NEXT:    vpxor %xmm7, %xmm6, %xmm6
-; AVX1-NEXT:    vpand %xmm3, %xmm12, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm0, %xmm8
-; AVX1-NEXT:    vpand %xmm5, %xmm8, %xmm8
-; AVX1-NEXT:    vpandn %xmm7, %xmm5, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm0, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vpor %xmm7, %xmm8, %xmm7
-; AVX1-NEXT:    vpxor %xmm7, %xmm6, %xmm6
-; AVX1-NEXT:    vpxor %xmm6, %xmm1, %xmm1
-; AVX1-NEXT:    vpand %xmm3, %xmm13, %xmm3
-; AVX1-NEXT:    vpmullw %xmm3, %xmm0, %xmm6
-; AVX1-NEXT:    vpand %xmm5, %xmm6, %xmm6
-; AVX1-NEXT:    vpandn %xmm3, %xmm5, %xmm3
-; AVX1-NEXT:    vpmaddubsw %xmm3, %xmm0, %xmm0
-; AVX1-NEXT:    vpsllw $8, %xmm0, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm9, %xmm1
+; AVX1-NEXT:    vpand %xmm1, %xmm13, %xmm1
+; AVX1-NEXT:    vpshufb %xmm1, %xmm5, %xmm1
+; AVX1-NEXT:    vpor %xmm1, %xmm9, %xmm14
+; AVX1-NEXT:    vpand %xmm11, %xmm14, %xmm3
+; AVX1-NEXT:    vpand %xmm0, %xmm13, %xmm9
+; AVX1-NEXT:    vpshufb %xmm9, %xmm2, %xmm9
 ; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
+; AVX1-NEXT:    vpand %xmm0, %xmm13, %xmm0
+; AVX1-NEXT:    vpshufb %xmm0, %xmm5, %xmm0
+; AVX1-NEXT:    vpor %xmm0, %xmm9, %xmm15
+; AVX1-NEXT:    vpand %xmm4, %xmm15, %xmm11
+; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm0
+; AVX1-NEXT:    vinsertf128 $1, %xmm8, %ymm0, %ymm2
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm1 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
+; AVX1-NEXT:    vpandn %xmm3, %xmm1, %xmm0
+; AVX1-NEXT:    vmovdqa %xmm0, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
+; AVX1-NEXT:    vpmaddubsw %xmm0, %xmm11, %xmm9
+; AVX1-NEXT:    vpsllw $8, %xmm9, %xmm0
+; AVX1-NEXT:    vpandn %xmm6, %xmm1, %xmm9
+; AVX1-NEXT:    vpmaddubsw %xmm9, %xmm7, %xmm5
+; AVX1-NEXT:    vpsllw $8, %xmm5, %xmm5
+; AVX1-NEXT:    vinsertf128 $1, %xmm5, %ymm0, %ymm0
+; AVX1-NEXT:    vandps %ymm1, %ymm2, %ymm2
+; AVX1-NEXT:    vorps %ymm0, %ymm2, %ymm6
+; AVX1-NEXT:    vpand %xmm4, %xmm10, %xmm2
+; AVX1-NEXT:    vpand %xmm4, %xmm14, %xmm4
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm0 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX1-NEXT:    vpand %xmm0, %xmm12, %xmm10
+; AVX1-NEXT:    vpand %xmm0, %xmm15, %xmm12
+; AVX1-NEXT:    vpmullw %xmm2, %xmm10, %xmm5
+; AVX1-NEXT:    vpmullw %xmm4, %xmm12, %xmm14
+; AVX1-NEXT:    vinsertf128 $1, %xmm5, %ymm14, %ymm5
+; AVX1-NEXT:    vpandn %xmm4, %xmm1, %xmm14
+; AVX1-NEXT:    vpmaddubsw %xmm14, %xmm12, %xmm15
+; AVX1-NEXT:    vpsllw $8, %xmm15, %xmm15
+; AVX1-NEXT:    vpandn %xmm2, %xmm1, %xmm0
+; AVX1-NEXT:    vpmaddubsw %xmm0, %xmm10, %xmm8
+; AVX1-NEXT:    vpsllw $8, %xmm8, %xmm8
+; AVX1-NEXT:    vinsertf128 $1, %xmm8, %ymm15, %ymm8
+; AVX1-NEXT:    vandps %ymm1, %ymm5, %ymm5
+; AVX1-NEXT:    vorps %ymm5, %ymm8, %ymm5
+; AVX1-NEXT:    vxorps %ymm6, %ymm5, %ymm5
+; AVX1-NEXT:    vpmullw %xmm2, %xmm7, %xmm2
+; AVX1-NEXT:    vpmullw %xmm4, %xmm11, %xmm4
+; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm4, %ymm2
+; AVX1-NEXT:    vpmaddubsw %xmm14, %xmm11, %xmm4
+; AVX1-NEXT:    vpmaddubsw %xmm0, %xmm7, %xmm0
+; AVX1-NEXT:    vpsllw $8, %xmm4, %xmm4
+; AVX1-NEXT:    vpsllw $8, %xmm0, %xmm0
+; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm4, %ymm0
+; AVX1-NEXT:    vandps %ymm1, %ymm2, %ymm2
+; AVX1-NEXT:    vorps %ymm0, %ymm2, %ymm0
+; AVX1-NEXT:    vpmullw {{[-0-9]+}}(%r{{[sb]}}p), %xmm10, %xmm2 # 16-byte Folded Reload
+; AVX1-NEXT:    vpmullw %xmm3, %xmm12, %xmm3
+; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm3, %ymm2
+; AVX1-NEXT:    vandps %ymm1, %ymm2, %ymm1
+; AVX1-NEXT:    vpmaddubsw {{[-0-9]+}}(%r{{[sb]}}p), %xmm12, %xmm2 # 16-byte Folded Reload
+; AVX1-NEXT:    vpmaddubsw %xmm9, %xmm10, %xmm3
+; AVX1-NEXT:    vpsllw $8, %xmm2, %xmm2
+; AVX1-NEXT:    vpsllw $8, %xmm3, %xmm3
+; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm2, %ymm2
+; AVX1-NEXT:    vorps %ymm2, %ymm1, %ymm1
+; AVX1-NEXT:    vxorps %ymm0, %ymm1, %ymm0
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm2 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX1-NEXT:    vandnps %ymm5, %ymm2, %ymm1
+; AVX1-NEXT:    vandps %ymm2, %ymm0, %ymm0
+; AVX1-NEXT:    vorps %ymm1, %ymm0, %ymm0
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
+; AVX1-NEXT:    vpand %xmm1, %xmm13, %xmm2
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX1-NEXT:    vpshufb %xmm2, %xmm3, %xmm2
+; AVX1-NEXT:    vpsrlw $4, %xmm1, %xmm1
+; AVX1-NEXT:    vpand %xmm1, %xmm13, %xmm1
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm4 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX1-NEXT:    vpshufb %xmm1, %xmm4, %xmm1
+; AVX1-NEXT:    vpor %xmm1, %xmm2, %xmm1
+; AVX1-NEXT:    vpand %xmm0, %xmm13, %xmm2
+; AVX1-NEXT:    vpshufb %xmm2, %xmm3, %xmm2
+; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
+; AVX1-NEXT:    vpand %xmm0, %xmm13, %xmm0
 ; AVX1-NEXT:    vpshufb %xmm0, %xmm4, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vinsertf128 $1, %xmm14, %ymm0, %ymm0
+; AVX1-NEXT:    vpor %xmm0, %xmm2, %xmm0
+; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: clmulr_v32i8:
 ; AVX2:       # %bb.0:
 ; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm4
+; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm4
 ; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
 ; AVX2-NEXT:    # ymm3 = mem[0,1,0,1]
 ; AVX2-NEXT:    vpshufb %ymm4, %ymm3, %ymm4
-; AVX2-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm5
-; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
-; AVX2-NEXT:    # ymm0 = mem[0,1,0,1]
-; AVX2-NEXT:    vpshufb %ymm5, %ymm0, %ymm5
-; AVX2-NEXT:    vpor %ymm5, %ymm4, %ymm4
-; AVX2-NEXT:    vpsrlw $4, %ymm1, %ymm5
-; AVX2-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX2-NEXT:    vpshufb %ymm5, %ymm0, %ymm6
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm7
-; AVX2-NEXT:    vpmullw %ymm7, %ymm4, %ymm8
-; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm5 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
-; AVX2-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX2-NEXT:    vpmaddubsw %ymm7, %ymm4, %ymm7
-; AVX2-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX2-NEXT:    vpor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm8
-; AVX2-NEXT:    vpmullw %ymm4, %ymm8, %ymm9
-; AVX2-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpandn %ymm8, %ymm5, %ymm8
-; AVX2-NEXT:    vpmaddubsw %ymm8, %ymm4, %ymm8
-; AVX2-NEXT:    vpsllw $8, %ymm8, %ymm8
-; AVX2-NEXT:    vpor %ymm8, %ymm9, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm8
-; AVX2-NEXT:    vpmullw %ymm4, %ymm8, %ymm9
-; AVX2-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpandn %ymm8, %ymm5, %ymm8
-; AVX2-NEXT:    vpmaddubsw %ymm8, %ymm4, %ymm8
-; AVX2-NEXT:    vpsllw $8, %ymm8, %ymm8
-; AVX2-NEXT:    vpor %ymm8, %ymm9, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm6
-; AVX2-NEXT:    vpmullw %ymm6, %ymm4, %ymm9
-; AVX2-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX2-NEXT:    vpmaddubsw %ymm6, %ymm4, %ymm6
-; AVX2-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX2-NEXT:    vpor %ymm6, %ymm9, %ymm6
-; AVX2-NEXT:    vpxor %ymm6, %ymm8, %ymm6
-; AVX2-NEXT:    vpxor %ymm6, %ymm7, %ymm6
-; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm1
-; AVX2-NEXT:    vpshufb %ymm1, %ymm3, %ymm1
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm7
-; AVX2-NEXT:    vpmullw %ymm7, %ymm4, %ymm8
-; AVX2-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX2-NEXT:    vpmaddubsw %ymm7, %ymm4, %ymm7
-; AVX2-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX2-NEXT:    vpor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm8
-; AVX2-NEXT:    vpmullw %ymm4, %ymm8, %ymm9
-; AVX2-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpandn %ymm8, %ymm5, %ymm8
-; AVX2-NEXT:    vpmaddubsw %ymm8, %ymm4, %ymm8
-; AVX2-NEXT:    vpsllw $8, %ymm8, %ymm8
-; AVX2-NEXT:    vpor %ymm8, %ymm9, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm8
-; AVX2-NEXT:    vpmullw %ymm4, %ymm8, %ymm9
-; AVX2-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpandn %ymm8, %ymm5, %ymm8
-; AVX2-NEXT:    vpmaddubsw %ymm8, %ymm4, %ymm8
-; AVX2-NEXT:    vpsllw $8, %ymm8, %ymm8
-; AVX2-NEXT:    vpor %ymm8, %ymm9, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpxor %ymm7, %ymm6, %ymm6
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
-; AVX2-NEXT:    vpmullw %ymm1, %ymm4, %ymm7
-; AVX2-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX2-NEXT:    vpandn %ymm1, %ymm5, %ymm1
-; AVX2-NEXT:    vpmaddubsw %ymm1, %ymm4, %ymm1
-; AVX2-NEXT:    vpsllw $8, %ymm1, %ymm1
-; AVX2-NEXT:    vpor %ymm1, %ymm7, %ymm1
-; AVX2-NEXT:    vpxor %ymm1, %ymm6, %ymm1
-; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm4
-; AVX2-NEXT:    vpshufb %ymm4, %ymm3, %ymm3
 ; AVX2-NEXT:    vpsrlw $4, %ymm1, %ymm1
-; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm1
-; AVX2-NEXT:    vpshufb %ymm1, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm5
+; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm1 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX2-NEXT:    # ymm1 = mem[0,1,0,1]
+; AVX2-NEXT:    vpshufb %ymm5, %ymm1, %ymm5
+; AVX2-NEXT:    vpor %ymm5, %ymm4, %ymm5
+; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm4 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX2-NEXT:    vpand %ymm4, %ymm5, %ymm6
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm7
+; AVX2-NEXT:    vpshufb %ymm7, %ymm3, %ymm7
+; AVX2-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpshufb %ymm0, %ymm1, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm7, %ymm0
+; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm7 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX2-NEXT:    vpand %ymm7, %ymm0, %ymm8
+; AVX2-NEXT:    vpmullw %ymm6, %ymm8, %ymm9
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm10 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
+; AVX2-NEXT:    vpand %ymm10, %ymm9, %ymm9
+; AVX2-NEXT:    vpandn %ymm6, %ymm10, %ymm11
+; AVX2-NEXT:    vpmaddubsw %ymm11, %ymm8, %ymm12
+; AVX2-NEXT:    vpsllw $8, %ymm12, %ymm12
+; AVX2-NEXT:    vpor %ymm12, %ymm9, %ymm9
+; AVX2-NEXT:    vpand %ymm7, %ymm5, %ymm5
+; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX2-NEXT:    vpmullw %ymm5, %ymm0, %ymm7
+; AVX2-NEXT:    vpand %ymm7, %ymm10, %ymm7
+; AVX2-NEXT:    vpandn %ymm5, %ymm10, %ymm12
+; AVX2-NEXT:    vpmaddubsw %ymm12, %ymm0, %ymm13
+; AVX2-NEXT:    vpsllw $8, %ymm13, %ymm13
+; AVX2-NEXT:    vpor %ymm7, %ymm13, %ymm7
+; AVX2-NEXT:    vpxor %ymm7, %ymm9, %ymm7
+; AVX2-NEXT:    vpandn %ymm7, %ymm4, %ymm7
+; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm5
+; AVX2-NEXT:    vpand %ymm5, %ymm10, %ymm5
+; AVX2-NEXT:    vpmaddubsw %ymm12, %ymm8, %ymm8
+; AVX2-NEXT:    vpsllw $8, %ymm8, %ymm8
+; AVX2-NEXT:    vpor %ymm5, %ymm8, %ymm5
+; AVX2-NEXT:    vpmullw %ymm6, %ymm0, %ymm6
+; AVX2-NEXT:    vpand %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpmaddubsw %ymm11, %ymm0, %ymm0
+; AVX2-NEXT:    vpsllw $8, %ymm0, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm6, %ymm0
+; AVX2-NEXT:    vpxor %ymm5, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX2-NEXT:    vpor %ymm7, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm4
+; AVX2-NEXT:    vpshufb %ymm4, %ymm3, %ymm3
+; AVX2-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpshufb %ymm0, %ymm1, %ymm0
 ; AVX2-NEXT:    vpor %ymm0, %ymm3, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: clmulr_v32i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm2 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero,xmm1[8],zero,xmm1[9],zero,xmm1[10],zero,xmm1[11],zero,xmm1[12],zero,xmm1[13],zero,xmm1[14],zero,xmm1[15],zero
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm3 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; AVX512-NEXT:    vpand %ymm3, %ymm2, %ymm4
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm5 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
-; AVX512-NEXT:    vpmullw %ymm4, %ymm5, %ymm4
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm6 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-; AVX512-NEXT:    vpand %ymm6, %ymm2, %ymm7
-; AVX512-NEXT:    vpmullw %ymm7, %ymm5, %ymm7
-; AVX512-NEXT:    vpxor %ymm4, %ymm7, %ymm4
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm7 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; AVX512-NEXT:    vpand %ymm7, %ymm2, %ymm8
-; AVX512-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm9 = [8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8]
-; AVX512-NEXT:    vpand %ymm2, %ymm9, %ymm10
-; AVX512-NEXT:    vpmullw %ymm5, %ymm10, %ymm10
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm10 = ymm10 ^ ymm4 ^ ymm8
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm4 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; AVX512-NEXT:    vpand %ymm4, %ymm2, %ymm8
-; AVX512-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm11 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; AVX512-NEXT:    vpand %ymm2, %ymm11, %ymm12
-; AVX512-NEXT:    vpmullw %ymm5, %ymm12, %ymm12
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm12 = ymm12 ^ ymm10 ^ ymm8
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm8 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; AVX512-NEXT:    vpand %ymm2, %ymm8, %ymm10
-; AVX512-NEXT:    vpmullw %ymm5, %ymm10, %ymm10
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm13 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-; AVX512-NEXT:    vpand %ymm2, %ymm13, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm5, %ymm2
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm2 = ymm2 ^ ymm12 ^ ymm10
-; AVX512-NEXT:    vpsrlw $7, %ymm2, %ymm2
-; AVX512-NEXT:    vpmovzxwd {{.*#+}} zmm2 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero,ymm2[8],zero,ymm2[9],zero,ymm2[10],zero,ymm2[11],zero,ymm2[12],zero,ymm2[13],zero,ymm2[14],zero,ymm2[15],zero
-; AVX512-NEXT:    vpmovdb %zmm2, %xmm2
-; AVX512-NEXT:    vextracti128 $1, %ymm1, %xmm1
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero,xmm1[8],zero,xmm1[9],zero,xmm1[10],zero,xmm1[11],zero,xmm1[12],zero,xmm1[13],zero,xmm1[14],zero,xmm1[15],zero
-; AVX512-NEXT:    vpand %ymm3, %ymm1, %ymm3
-; AVX512-NEXT:    vextracti128 $1, %ymm0, %xmm0
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpand %ymm6, %ymm1, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm0, %ymm5
-; AVX512-NEXT:    vpxor %ymm3, %ymm5, %ymm3
-; AVX512-NEXT:    vpand %ymm7, %ymm1, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm0, %ymm5
-; AVX512-NEXT:    vpand %ymm1, %ymm9, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm0, %ymm6
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm6 = ymm6 ^ ymm3 ^ ymm5
-; AVX512-NEXT:    vpand %ymm4, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpand %ymm1, %ymm11, %ymm4
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm4 = ymm4 ^ ymm6 ^ ymm3
-; AVX512-NEXT:    vpand %ymm1, %ymm8, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpand %ymm1, %ymm13, %ymm1
-; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 ^ ymm4 ^ ymm3
-; AVX512-NEXT:    vpsrlw $7, %ymm0, %ymm0
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} zmm16 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX512-NEXT:    vextracti128 $1, %ymm1, %xmm3
+; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm8 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero,xmm3[4],zero,xmm3[5],zero,xmm3[6],zero,xmm3[7],zero,xmm3[8],zero,xmm3[9],zero,xmm3[10],zero,xmm3[11],zero,xmm3[12],zero,xmm3[13],zero,xmm3[14],zero,xmm3[15],zero
+; AVX512-NEXT:    vpandq %ymm16, %ymm8, %ymm3
+; AVX512-NEXT:    vextracti128 $1, %ymm0, %xmm4
+; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm9 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero,xmm4[4],zero,xmm4[5],zero,xmm4[6],zero,xmm4[7],zero,xmm4[8],zero,xmm4[9],zero,xmm4[10],zero,xmm4[11],zero,xmm4[12],zero,xmm4[13],zero,xmm4[14],zero,xmm4[15],zero
+; AVX512-NEXT:    vpandq %ymm16, %ymm9, %ymm4
+; AVX512-NEXT:    vpmullw %ymm3, %ymm4, %ymm5
+; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm10 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero,xmm1[8],zero,xmm1[9],zero,xmm1[10],zero,xmm1[11],zero,xmm1[12],zero,xmm1[13],zero,xmm1[14],zero,xmm1[15],zero
+; AVX512-NEXT:    vpandq %ymm16, %ymm10, %ymm1
+; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm11 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
+; AVX512-NEXT:    vpandq %ymm16, %ymm11, %ymm0
+; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm6
+; AVX512-NEXT:    vinserti64x4 $1, %ymm5, %zmm6, %zmm12
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} zmm17 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX512-NEXT:    vpandq %ymm17, %ymm8, %ymm6
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} zmm18 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX512-NEXT:    vpandq %ymm18, %ymm9, %ymm5
+; AVX512-NEXT:    vpmullw %ymm6, %ymm5, %ymm15
+; AVX512-NEXT:    vpandq %ymm17, %ymm10, %ymm2
+; AVX512-NEXT:    vpandq %ymm18, %ymm11, %ymm7
+; AVX512-NEXT:    vpmullw %ymm2, %ymm7, %ymm13
+; AVX512-NEXT:    vinserti64x4 $1, %ymm15, %zmm13, %zmm13
+; AVX512-NEXT:    vpandq %ymm18, %ymm8, %ymm8
+; AVX512-NEXT:    vpandq %ymm17, %ymm9, %ymm9
+; AVX512-NEXT:    vpmullw %ymm8, %ymm9, %ymm15
+; AVX512-NEXT:    vpandq %ymm18, %ymm10, %ymm10
+; AVX512-NEXT:    vpandq %ymm17, %ymm11, %ymm11
+; AVX512-NEXT:    vpmullw %ymm10, %ymm11, %ymm14
+; AVX512-NEXT:    vinserti64x4 $1, %ymm15, %zmm14, %zmm14
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm14 = zmm14 ^ zmm13 ^ zmm12
+; AVX512-NEXT:    vpmullw %ymm4, %ymm8, %ymm12
+; AVX512-NEXT:    vpmullw %ymm0, %ymm10, %ymm13
+; AVX512-NEXT:    vinserti64x4 $1, %ymm12, %zmm13, %zmm12
+; AVX512-NEXT:    vpmullw %ymm3, %ymm5, %ymm13
+; AVX512-NEXT:    vmovdqa64 %ymm3, %ymm19
+; AVX512-NEXT:    vpmullw %ymm1, %ymm7, %ymm15
+; AVX512-NEXT:    vinserti64x4 $1, %ymm13, %zmm15, %zmm13
+; AVX512-NEXT:    vpmullw %ymm6, %ymm9, %ymm15
+; AVX512-NEXT:    vpmullw %ymm2, %ymm11, %ymm3
+; AVX512-NEXT:    vinserti64x4 $1, %ymm15, %zmm3, %zmm3
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm3 = zmm3 ^ zmm13 ^ zmm12
+; AVX512-NEXT:    vpmullw %ymm6, %ymm4, %ymm4
+; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm0
+; AVX512-NEXT:    vinserti64x4 $1, %ymm4, %zmm0, %zmm0
+; AVX512-NEXT:    vpmullw %ymm5, %ymm8, %ymm2
+; AVX512-NEXT:    vpmullw %ymm7, %ymm10, %ymm4
+; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm4, %zmm2
+; AVX512-NEXT:    vpxorq %zmm0, %zmm2, %zmm0
+; AVX512-NEXT:    vmovdqa64 %ymm19, %ymm2
+; AVX512-NEXT:    vpmullw %ymm2, %ymm9, %ymm2
+; AVX512-NEXT:    vpmullw %ymm1, %ymm11, %ymm1
+; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm18 & (zmm1 ^ zmm0)
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm1 | (zmm3 & zmm16)
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm1 | (zmm14 & zmm17)
+; AVX512-NEXT:    vpsrlw $7, %ymm1, %ymm0
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero,ymm0[8],zero,ymm0[9],zero,ymm0[10],zero,ymm0[11],zero,ymm0[12],zero,ymm0[13],zero,ymm0[14],zero,ymm0[15],zero
 ; AVX512-NEXT:    vpmovdb %zmm0, %xmm0
-; AVX512-NEXT:    vinserti128 $1, %xmm0, %ymm2, %ymm0
+; AVX512-NEXT:    vextracti64x4 $1, %zmm1, %ymm1
+; AVX512-NEXT:    vpsrlw $7, %ymm1, %ymm1
+; AVX512-NEXT:    vpmovzxwd {{.*#+}} zmm1 = ymm1[0],zero,ymm1[1],zero,ymm1[2],zero,ymm1[3],zero,ymm1[4],zero,ymm1[5],zero,ymm1[6],zero,ymm1[7],zero,ymm1[8],zero,ymm1[9],zero,ymm1[10],zero,ymm1[11],zero,ymm1[12],zero,ymm1[13],zero,ymm1[14],zero,ymm1[15],zero
+; AVX512-NEXT:    vpmovdb %zmm1, %xmm1
+; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
 ; AVX512-NEXT:    retq
   %a.ext = zext <32 x i8> %a to <32 x i16>
   %b.ext = zext <32 x i8> %b to <32 x i16>
@@ -952,231 +669,179 @@ define <32 x i8> @clmulr_v32i8(<32 x i8> %a, <32 x i8> %b) nounwind {
 define <16 x i16> @clmulr_v16i16(<16 x i16> %a, <16 x i16> %b) nounwind {
 ; AVX1-LABEL: clmulr_v16i16:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vmovdqa %ymm1, %ymm5
-; AVX1-NEXT:    vmovdqa %ymm0, %ymm4
-; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
-; AVX1-NEXT:    vmovdqa {{.*#+}} xmm12 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
-; AVX1-NEXT:    vpshufb %xmm12, %xmm0, %xmm0
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm3
-; AVX1-NEXT:    vmovdqa {{.*#+}} xmm8 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
-; AVX1-NEXT:    vpshufb %xmm3, %xmm8, %xmm3
+; AVX1-NEXT:    vmovdqa %ymm0, %ymm12
+; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm2
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm0 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
+; AVX1-NEXT:    vpshufb %xmm0, %xmm2, %xmm3
+; AVX1-NEXT:    vmovdqa %xmm0, %xmm2
+; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm7 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX1-NEXT:    vpand %xmm7, %xmm3, %xmm5
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm4 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX1-NEXT:    vpshufb %xmm5, %xmm4, %xmm6
+; AVX1-NEXT:    vpsrlw $4, %xmm3, %xmm3
+; AVX1-NEXT:    vpand %xmm7, %xmm3, %xmm3
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm0 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX1-NEXT:    vpshufb %xmm3, %xmm0, %xmm3
+; AVX1-NEXT:    vpor %xmm3, %xmm6, %xmm9
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm3 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX1-NEXT:    vpand %xmm3, %xmm9, %xmm5
+; AVX1-NEXT:    vmovdqa %xmm5, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
+; AVX1-NEXT:    vmovdqa %ymm3, %ymm6
+; AVX1-NEXT:    vextractf128 $1, %ymm12, %xmm3
+; AVX1-NEXT:    vpshufb %xmm2, %xmm3, %xmm3
+; AVX1-NEXT:    vpand %xmm7, %xmm3, %xmm8
+; AVX1-NEXT:    vpshufb %xmm8, %xmm4, %xmm8
+; AVX1-NEXT:    vpsrlw $4, %xmm3, %xmm3
+; AVX1-NEXT:    vpand %xmm7, %xmm3, %xmm3
+; AVX1-NEXT:    vpshufb %xmm3, %xmm0, %xmm3
+; AVX1-NEXT:    vpor %xmm3, %xmm8, %xmm14
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm10 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX1-NEXT:    vpand %xmm10, %xmm14, %xmm8
+; AVX1-NEXT:    vpmullw %xmm5, %xmm8, %xmm11
+; AVX1-NEXT:    vpshufb %xmm2, %xmm1, %xmm1
+; AVX1-NEXT:    vpand %xmm7, %xmm1, %xmm3
+; AVX1-NEXT:    vpshufb %xmm3, %xmm4, %xmm3
+; AVX1-NEXT:    vpsrlw $4, %xmm1, %xmm1
+; AVX1-NEXT:    vpand %xmm7, %xmm1, %xmm1
+; AVX1-NEXT:    vpshufb %xmm1, %xmm0, %xmm1
+; AVX1-NEXT:    vpor %xmm1, %xmm3, %xmm3
+; AVX1-NEXT:    vpand %xmm6, %xmm3, %xmm5
+; AVX1-NEXT:    vpshufb %xmm2, %xmm12, %xmm1
+; AVX1-NEXT:    vpand %xmm7, %xmm1, %xmm2
+; AVX1-NEXT:    vpshufb %xmm2, %xmm4, %xmm2
+; AVX1-NEXT:    vpsrlw $4, %xmm1, %xmm1
+; AVX1-NEXT:    vpand %xmm7, %xmm1, %xmm1
+; AVX1-NEXT:    vpshufb %xmm1, %xmm0, %xmm1
+; AVX1-NEXT:    vpor %xmm1, %xmm2, %xmm0
+; AVX1-NEXT:    vpand %xmm0, %xmm10, %xmm4
+; AVX1-NEXT:    vpmullw %xmm5, %xmm4, %xmm1
+; AVX1-NEXT:    vmovdqa %xmm5, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
+; AVX1-NEXT:    vinsertf128 $1, %xmm11, %ymm1, %ymm11
+; AVX1-NEXT:    vpand %xmm10, %xmm9, %xmm15
+; AVX1-NEXT:    vmovdqa %ymm10, %ymm7
+; AVX1-NEXT:    vpand %xmm6, %xmm14, %xmm12
+; AVX1-NEXT:    vpmullw %xmm15, %xmm12, %xmm1
+; AVX1-NEXT:    vpand %xmm7, %xmm3, %xmm2
+; AVX1-NEXT:    vpand %xmm6, %xmm0, %xmm13
+; AVX1-NEXT:    vpmullw %xmm2, %xmm13, %xmm6
+; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm6, %ymm1
+; AVX1-NEXT:    vxorps %ymm1, %ymm11, %ymm1
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm10 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX1-NEXT:    vpand %xmm10, %xmm9, %xmm6
+; AVX1-NEXT:    vpand %xmm10, %xmm14, %xmm9
+; AVX1-NEXT:    vpand %xmm3, %xmm10, %xmm3
+; AVX1-NEXT:    vpand %xmm0, %xmm10, %xmm14
+; AVX1-NEXT:    vpmullw %xmm6, %xmm9, %xmm0
+; AVX1-NEXT:    vpmullw %xmm3, %xmm14, %xmm10
+; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm10, %ymm0
+; AVX1-NEXT:    vxorps %ymm0, %ymm1, %ymm0
+; AVX1-NEXT:    vandps %ymm7, %ymm0, %ymm7
+; AVX1-NEXT:    vpmullw %xmm6, %xmm8, %xmm1
+; AVX1-NEXT:    vpmullw %xmm3, %xmm4, %xmm10
+; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm10, %ymm1
+; AVX1-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm0 # 16-byte Reload
+; AVX1-NEXT:    vpmullw %xmm0, %xmm12, %xmm10
+; AVX1-NEXT:    vpmullw %xmm5, %xmm13, %xmm11
+; AVX1-NEXT:    vinsertf128 $1, %xmm10, %ymm11, %ymm10
+; AVX1-NEXT:    vxorps %ymm1, %ymm10, %ymm1
+; AVX1-NEXT:    vpmullw %xmm15, %xmm9, %xmm10
+; AVX1-NEXT:    vpmullw %xmm2, %xmm14, %xmm11
+; AVX1-NEXT:    vinsertf128 $1, %xmm10, %ymm11, %ymm10
+; AVX1-NEXT:    vxorps %ymm1, %ymm10, %ymm1
+; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
+; AVX1-NEXT:    vorps %ymm7, %ymm1, %ymm5
+; AVX1-NEXT:    vpmullw %xmm15, %xmm8, %xmm1
+; AVX1-NEXT:    vpmullw %xmm2, %xmm4, %xmm2
+; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm2, %ymm1
+; AVX1-NEXT:    vpmullw %xmm6, %xmm12, %xmm2
+; AVX1-NEXT:    vpmullw %xmm3, %xmm13, %xmm3
+; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm3, %ymm2
+; AVX1-NEXT:    vxorps %ymm1, %ymm2, %ymm1
+; AVX1-NEXT:    vpmullw %xmm0, %xmm9, %xmm2
+; AVX1-NEXT:    vpmullw {{[-0-9]+}}(%r{{[sb]}}p), %xmm14, %xmm3 # 16-byte Folded Reload
+; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm3, %ymm2
+; AVX1-NEXT:    vxorps %ymm2, %ymm1, %ymm1
+; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
+; AVX1-NEXT:    vorps %ymm1, %ymm5, %ymm0
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm3 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
+; AVX1-NEXT:    vpshufb %xmm3, %xmm1, %xmm1
+; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm6 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX1-NEXT:    vpand %xmm6, %xmm1, %xmm2
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm4 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX1-NEXT:    vpshufb %xmm2, %xmm4, %xmm2
+; AVX1-NEXT:    vpsrlw $4, %xmm1, %xmm1
+; AVX1-NEXT:    vpand %xmm6, %xmm1, %xmm1
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm5 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX1-NEXT:    vpshufb %xmm1, %xmm5, %xmm1
+; AVX1-NEXT:    vpor %xmm1, %xmm2, %xmm1
+; AVX1-NEXT:    vpshufb %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vpand %xmm6, %xmm0, %xmm2
+; AVX1-NEXT:    vpshufb %xmm2, %xmm4, %xmm2
 ; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vmovdqa {{.*#+}} xmm6 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
-; AVX1-NEXT:    vpshufb %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm3, %xmm3
-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm0
-; AVX1-NEXT:    vpshufb %xmm12, %xmm0, %xmm0
-; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm7
-; AVX1-NEXT:    vpand %xmm2, %xmm7, %xmm7
-; AVX1-NEXT:    vpshufb %xmm7, %xmm6, %xmm7
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm14 = [2,2,2,2,2,2,2,2]
-; AVX1-NEXT:    vpand %xmm7, %xmm14, %xmm9
-; AVX1-NEXT:    vpmullw %xmm3, %xmm9, %xmm9
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm10
-; AVX1-NEXT:    vpmullw %xmm3, %xmm10, %xmm10
-; AVX1-NEXT:    vpxor %xmm9, %xmm10, %xmm9
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm10
-; AVX1-NEXT:    vpmullw %xmm3, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpxor %xmm10, %xmm9, %xmm9
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm8, %xmm0
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm10
-; AVX1-NEXT:    vpmullw %xmm3, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpxor %xmm10, %xmm9, %xmm9
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm10
-; AVX1-NEXT:    vpmullw %xmm3, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpxor %xmm10, %xmm9, %xmm1
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm13 = [2048,2048,2048,2048,2048,2048,2048,2048]
-; AVX1-NEXT:    vpand %xmm7, %xmm13, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm3, %xmm7
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm11 = [4096,4096,4096,4096,4096,4096,4096,4096]
-; AVX1-NEXT:    vpand %xmm0, %xmm11, %xmm9
-; AVX1-NEXT:    vpmullw %xmm3, %xmm9, %xmm9
-; AVX1-NEXT:    vpxor %xmm7, %xmm9, %xmm7
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm10 = [8192,8192,8192,8192,8192,8192,8192,8192]
-; AVX1-NEXT:    vpand %xmm0, %xmm10, %xmm9
-; AVX1-NEXT:    vpmullw %xmm3, %xmm9, %xmm9
-; AVX1-NEXT:    vpxor %xmm7, %xmm9, %xmm7
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm9 = [16384,16384,16384,16384,16384,16384,16384,16384]
-; AVX1-NEXT:    vpand %xmm0, %xmm9, %xmm15
-; AVX1-NEXT:    vpmullw %xmm3, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm7, %xmm15, %xmm15
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm7 = [32768,32768,32768,32768,32768,32768,32768,32768]
-; AVX1-NEXT:    vpand %xmm7, %xmm0, %xmm0
-; AVX1-NEXT:    vpmullw %xmm0, %xmm3, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm15, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vpshufb %xmm12, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm8, %xmm1
-; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm1, %xmm3
-; AVX1-NEXT:    vpshufb %xmm12, %xmm4, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm8, %xmm1
-; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vpshufb %xmm12, %xmm5, %xmm4
-; AVX1-NEXT:    vpsrlw $4, %xmm4, %xmm1
-; AVX1-NEXT:    vpand %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm6, %xmm1
-; AVX1-NEXT:    vpand %xmm1, %xmm14, %xmm5
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm5, %xmm15, %xmm5
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm14
-; AVX1-NEXT:    vpmullw %xmm0, %xmm14, %xmm14
-; AVX1-NEXT:    vpxor %xmm14, %xmm15, %xmm14
-; AVX1-NEXT:    vpxor %xmm5, %xmm14, %xmm5
-; AVX1-NEXT:    vpand %xmm2, %xmm4, %xmm4
-; AVX1-NEXT:    vpshufb %xmm4, %xmm8, %xmm4
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm4, %xmm14
-; AVX1-NEXT:    vpmullw %xmm0, %xmm14, %xmm14
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm4, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm15, %xmm14, %xmm14
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm4, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm15, %xmm14, %xmm14
-; AVX1-NEXT:    vpxor %xmm5, %xmm14, %xmm5
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm4, %xmm14
-; AVX1-NEXT:    vpmullw %xmm0, %xmm14, %xmm14
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm15, %xmm14, %xmm14
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm15, %xmm14, %xmm14
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm15, %xmm14, %xmm14
-; AVX1-NEXT:    vpxor %xmm5, %xmm14, %xmm5
-; AVX1-NEXT:    vpand %xmm1, %xmm13, %xmm1
-; AVX1-NEXT:    vpmullw %xmm1, %xmm0, %xmm1
-; AVX1-NEXT:    vpand %xmm4, %xmm11, %xmm11
-; AVX1-NEXT:    vpmullw %xmm0, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm1, %xmm11, %xmm1
-; AVX1-NEXT:    vpand %xmm4, %xmm10, %xmm10
-; AVX1-NEXT:    vpmullw %xmm0, %xmm10, %xmm10
-; AVX1-NEXT:    vpxor %xmm1, %xmm10, %xmm1
-; AVX1-NEXT:    vpand %xmm4, %xmm9, %xmm9
-; AVX1-NEXT:    vpmullw %xmm0, %xmm9, %xmm9
-; AVX1-NEXT:    vpxor %xmm1, %xmm9, %xmm1
-; AVX1-NEXT:    vpand %xmm7, %xmm4, %xmm4
-; AVX1-NEXT:    vpmullw %xmm4, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm5, %xmm0
-; AVX1-NEXT:    vpshufb %xmm12, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm8, %xmm1
-; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm0, %ymm0
+; AVX1-NEXT:    vpand %xmm6, %xmm0, %xmm0
+; AVX1-NEXT:    vpshufb %xmm0, %xmm5, %xmm0
+; AVX1-NEXT:    vpor %xmm0, %xmm2, %xmm0
+; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: clmulr_v16i16:
 ; AVX2:       # %bb.0:
 ; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm2 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14,1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
 ; AVX2-NEXT:    # ymm2 = mem[0,1,0,1]
-; AVX2-NEXT:    vpshufb %ymm2, %ymm0, %ymm4
-; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm0 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX2-NEXT:    vpand %ymm0, %ymm4, %ymm5
+; AVX2-NEXT:    vpshufb %ymm2, %ymm1, %ymm4
+; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm1 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX2-NEXT:    vpand %ymm1, %ymm4, %ymm5
 ; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
 ; AVX2-NEXT:    # ymm3 = mem[0,1,0,1]
 ; AVX2-NEXT:    vpshufb %ymm5, %ymm3, %ymm5
 ; AVX2-NEXT:    vpsrlw $4, %ymm4, %ymm4
-; AVX2-NEXT:    vpand %ymm0, %ymm4, %ymm6
+; AVX2-NEXT:    vpand %ymm1, %ymm4, %ymm6
 ; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
 ; AVX2-NEXT:    # ymm4 = mem[0,1,0,1]
 ; AVX2-NEXT:    vpshufb %ymm6, %ymm4, %ymm6
 ; AVX2-NEXT:    vpor %ymm6, %ymm5, %ymm5
-; AVX2-NEXT:    vpshufb %ymm2, %ymm1, %ymm6
-; AVX2-NEXT:    vpsrlw $4, %ymm6, %ymm1
-; AVX2-NEXT:    vpand %ymm0, %ymm1, %ymm1
-; AVX2-NEXT:    vpshufb %ymm1, %ymm4, %ymm1
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm7
-; AVX2-NEXT:    vpmullw %ymm7, %ymm5, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand %ymm0, %ymm6, %ymm6
-; AVX2-NEXT:    vpshufb %ymm6, %ymm3, %ymm6
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
-; AVX2-NEXT:    vpmullw %ymm1, %ymm5, %ymm1
-; AVX2-NEXT:    vpxor %ymm1, %ymm8, %ymm1
-; AVX2-NEXT:    vpxor %ymm1, %ymm7, %ymm1
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm7
-; AVX2-NEXT:    vpmullw %ymm7, %ymm5, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm6
-; AVX2-NEXT:    vpmullw %ymm6, %ymm5, %ymm5
-; AVX2-NEXT:    vpxor %ymm5, %ymm7, %ymm5
-; AVX2-NEXT:    vpxor %ymm5, %ymm1, %ymm1
-; AVX2-NEXT:    vpshufb %ymm2, %ymm1, %ymm1
-; AVX2-NEXT:    vpand %ymm0, %ymm1, %ymm2
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm6 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX2-NEXT:    vpand %ymm6, %ymm5, %ymm7
+; AVX2-NEXT:    vpshufb %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm1, %ymm0, %ymm8
+; AVX2-NEXT:    vpshufb %ymm8, %ymm3, %ymm8
+; AVX2-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm1, %ymm0, %ymm0
+; AVX2-NEXT:    vpshufb %ymm0, %ymm4, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm8, %ymm0
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm8 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX2-NEXT:    vpand %ymm0, %ymm8, %ymm9
+; AVX2-NEXT:    vpmullw %ymm7, %ymm9, %ymm10
+; AVX2-NEXT:    vpand %ymm5, %ymm8, %ymm11
+; AVX2-NEXT:    vpand %ymm6, %ymm0, %ymm12
+; AVX2-NEXT:    vpmullw %ymm11, %ymm12, %ymm13
+; AVX2-NEXT:    vpxor %ymm10, %ymm13, %ymm10
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm13 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX2-NEXT:    vpand %ymm5, %ymm13, %ymm5
+; AVX2-NEXT:    vpand %ymm0, %ymm13, %ymm0
+; AVX2-NEXT:    vpmullw %ymm5, %ymm0, %ymm14
+; AVX2-NEXT:    vpxor %ymm14, %ymm10, %ymm10
+; AVX2-NEXT:    vpand %ymm8, %ymm10, %ymm8
+; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm10
+; AVX2-NEXT:    vpmullw %ymm7, %ymm12, %ymm14
+; AVX2-NEXT:    vpxor %ymm10, %ymm14, %ymm10
+; AVX2-NEXT:    vpmullw %ymm0, %ymm11, %ymm14
+; AVX2-NEXT:    vpxor %ymm14, %ymm10, %ymm10
+; AVX2-NEXT:    vpand %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpor %ymm6, %ymm8, %ymm6
+; AVX2-NEXT:    vpmullw %ymm11, %ymm9, %ymm8
+; AVX2-NEXT:    vpmullw %ymm5, %ymm12, %ymm5
+; AVX2-NEXT:    vpxor %ymm5, %ymm8, %ymm5
+; AVX2-NEXT:    vpmullw %ymm7, %ymm0, %ymm0
+; AVX2-NEXT:    vpxor %ymm0, %ymm5, %ymm0
+; AVX2-NEXT:    vpand %ymm0, %ymm13, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm6, %ymm0
+; AVX2-NEXT:    vpshufb %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm1, %ymm0, %ymm2
 ; AVX2-NEXT:    vpshufb %ymm2, %ymm3, %ymm2
-; AVX2-NEXT:    vpsrlw $4, %ymm1, %ymm1
-; AVX2-NEXT:    vpand %ymm0, %ymm1, %ymm0
+; AVX2-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm1, %ymm0, %ymm0
 ; AVX2-NEXT:    vpshufb %ymm0, %ymm4, %ymm0
 ; AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX2-NEXT:    retq
@@ -1597,181 +1262,118 @@ define <4 x i64> @clmulr_v4i64(<4 x i64> %a, <4 x i64> %b) nounwind {
 define <32 x i8> @clmulh_v32i8(<32 x i8> %a, <32 x i8> %b) nounwind {
 ; AVX1-LABEL: clmulh_v32i8:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vmovdqa %ymm1, %ymm3
-; AVX1-NEXT:    vmovdqa %ymm0, %ymm1
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX1-NEXT:    vpand %xmm2, %xmm1, %xmm4
-; AVX1-NEXT:    vmovdqa {{.*#+}} xmm0 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
-; AVX1-NEXT:    vpshufb %xmm4, %xmm0, %xmm5
-; AVX1-NEXT:    vpsrlw $4, %xmm1, %xmm4
-; AVX1-NEXT:    vpand %xmm2, %xmm4, %xmm6
+; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm4
+; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm13 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX1-NEXT:    vpand %xmm4, %xmm13, %xmm5
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX1-NEXT:    vpshufb %xmm5, %xmm3, %xmm5
+; AVX1-NEXT:    vpsrlw $4, %xmm4, %xmm4
+; AVX1-NEXT:    vpand %xmm4, %xmm13, %xmm6
 ; AVX1-NEXT:    vmovdqa {{.*#+}} xmm4 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
 ; AVX1-NEXT:    vpshufb %xmm6, %xmm4, %xmm6
-; AVX1-NEXT:    vpor %xmm6, %xmm5, %xmm14
-; AVX1-NEXT:    vpsrlw $4, %xmm3, %xmm5
-; AVX1-NEXT:    vpand %xmm2, %xmm5, %xmm5
-; AVX1-NEXT:    vpshufb %xmm5, %xmm4, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm10, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm14, %xmm8
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm5 = [255,255,255,255,255,255,255,255]
-; AVX1-NEXT:    vpand %xmm5, %xmm8, %xmm8
-; AVX1-NEXT:    vpandn %xmm7, %xmm5, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm14, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vpor %xmm7, %xmm8, %xmm8
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm10, %xmm9
-; AVX1-NEXT:    vpmullw %xmm9, %xmm14, %xmm11
-; AVX1-NEXT:    vpand %xmm5, %xmm11, %xmm11
-; AVX1-NEXT:    vpandn %xmm9, %xmm5, %xmm9
-; AVX1-NEXT:    vpmaddubsw %xmm9, %xmm14, %xmm9
-; AVX1-NEXT:    vpsllw $8, %xmm9, %xmm9
-; AVX1-NEXT:    vpor %xmm9, %xmm11, %xmm9
-; AVX1-NEXT:    vpxor %xmm8, %xmm9, %xmm11
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm8 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; AVX1-NEXT:    vpand %xmm8, %xmm10, %xmm9
-; AVX1-NEXT:    vpmullw %xmm9, %xmm14, %xmm12
-; AVX1-NEXT:    vpand %xmm5, %xmm12, %xmm12
-; AVX1-NEXT:    vpandn %xmm9, %xmm5, %xmm9
-; AVX1-NEXT:    vpmaddubsw %xmm9, %xmm14, %xmm9
-; AVX1-NEXT:    vpsllw $8, %xmm9, %xmm9
-; AVX1-NEXT:    vpor %xmm9, %xmm12, %xmm12
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm10, %xmm10
-; AVX1-NEXT:    vpmullw %xmm10, %xmm14, %xmm13
-; AVX1-NEXT:    vpand %xmm5, %xmm13, %xmm13
-; AVX1-NEXT:    vpandn %xmm10, %xmm5, %xmm10
-; AVX1-NEXT:    vpmaddubsw %xmm10, %xmm14, %xmm10
-; AVX1-NEXT:    vpsllw $8, %xmm10, %xmm10
-; AVX1-NEXT:    vpor %xmm10, %xmm13, %xmm10
-; AVX1-NEXT:    vpxor %xmm10, %xmm12, %xmm10
-; AVX1-NEXT:    vpxor %xmm10, %xmm11, %xmm13
-; AVX1-NEXT:    vpand %xmm2, %xmm3, %xmm10
-; AVX1-NEXT:    vmovdqa %xmm0, %xmm9
-; AVX1-NEXT:    vpshufb %xmm10, %xmm0, %xmm15
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm10 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; AVX1-NEXT:    vpand %xmm10, %xmm15, %xmm11
-; AVX1-NEXT:    vpmullw %xmm11, %xmm14, %xmm12
-; AVX1-NEXT:    vpand %xmm5, %xmm12, %xmm12
-; AVX1-NEXT:    vpandn %xmm11, %xmm5, %xmm11
-; AVX1-NEXT:    vpmaddubsw %xmm11, %xmm14, %xmm11
-; AVX1-NEXT:    vpsllw $8, %xmm11, %xmm11
-; AVX1-NEXT:    vpor %xmm11, %xmm12, %xmm12
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm11 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; AVX1-NEXT:    vpand %xmm11, %xmm15, %xmm0
-; AVX1-NEXT:    vpmullw %xmm0, %xmm14, %xmm6
-; AVX1-NEXT:    vpand %xmm5, %xmm6, %xmm6
-; AVX1-NEXT:    vpandn %xmm0, %xmm5, %xmm0
-; AVX1-NEXT:    vpmaddubsw %xmm0, %xmm14, %xmm0
-; AVX1-NEXT:    vpsllw $8, %xmm0, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm12, %xmm0
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm12 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; AVX1-NEXT:    vpand %xmm12, %xmm15, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm14, %xmm7
-; AVX1-NEXT:    vpand %xmm5, %xmm7, %xmm7
-; AVX1-NEXT:    vpandn %xmm6, %xmm5, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm14, %xmm6
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vpor %xmm6, %xmm7, %xmm6
-; AVX1-NEXT:    vpxor %xmm6, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm13, %xmm0
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm13 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-; AVX1-NEXT:    vpand %xmm13, %xmm15, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm14, %xmm7
-; AVX1-NEXT:    vpandn %xmm6, %xmm5, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm14, %xmm6
-; AVX1-NEXT:    vpand %xmm5, %xmm7, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vpor %xmm6, %xmm7, %xmm6
-; AVX1-NEXT:    vpxor %xmm6, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm6
-; AVX1-NEXT:    vpshufb %xmm6, %xmm9, %xmm6
-; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm4, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm6, %xmm14
-; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm9, %xmm1
-; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm4, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vextractf128 $1, %ymm3, %xmm1
-; AVX1-NEXT:    vpsrlw $4, %xmm1, %xmm3
-; AVX1-NEXT:    vpand %xmm2, %xmm3, %xmm3
-; AVX1-NEXT:    vpshufb %xmm3, %xmm4, %xmm3
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm3, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm0, %xmm7
-; AVX1-NEXT:    vpand %xmm5, %xmm7, %xmm7
-; AVX1-NEXT:    vpandn %xmm6, %xmm5, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm0, %xmm6
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vpor %xmm6, %xmm7, %xmm6
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm3, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm0, %xmm15
-; AVX1-NEXT:    vpand %xmm5, %xmm15, %xmm15
-; AVX1-NEXT:    vpandn %xmm7, %xmm5, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm0, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vpor %xmm7, %xmm15, %xmm7
-; AVX1-NEXT:    vpxor %xmm6, %xmm7, %xmm6
-; AVX1-NEXT:    vpand %xmm3, %xmm8, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm0, %xmm8
-; AVX1-NEXT:    vpand %xmm5, %xmm8, %xmm8
-; AVX1-NEXT:    vpandn %xmm7, %xmm5, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm0, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vpor %xmm7, %xmm8, %xmm7
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm3, %xmm3
-; AVX1-NEXT:    vpmullw %xmm3, %xmm0, %xmm8
-; AVX1-NEXT:    vpand %xmm5, %xmm8, %xmm8
-; AVX1-NEXT:    vpandn %xmm3, %xmm5, %xmm3
-; AVX1-NEXT:    vpmaddubsw %xmm3, %xmm0, %xmm3
-; AVX1-NEXT:    vpsllw $8, %xmm3, %xmm3
-; AVX1-NEXT:    vpor %xmm3, %xmm8, %xmm3
-; AVX1-NEXT:    vpxor %xmm3, %xmm7, %xmm3
-; AVX1-NEXT:    vpxor %xmm3, %xmm6, %xmm3
-; AVX1-NEXT:    vpand %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm9, %xmm1
-; AVX1-NEXT:    vpand %xmm1, %xmm10, %xmm6
-; AVX1-NEXT:    vpmullw %xmm6, %xmm0, %xmm7
-; AVX1-NEXT:    vpand %xmm5, %xmm7, %xmm7
-; AVX1-NEXT:    vpandn %xmm6, %xmm5, %xmm6
-; AVX1-NEXT:    vpmaddubsw %xmm6, %xmm0, %xmm6
-; AVX1-NEXT:    vpsllw $8, %xmm6, %xmm6
-; AVX1-NEXT:    vpor %xmm6, %xmm7, %xmm6
-; AVX1-NEXT:    vpand %xmm1, %xmm11, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm0, %xmm8
-; AVX1-NEXT:    vpand %xmm5, %xmm8, %xmm8
-; AVX1-NEXT:    vpandn %xmm7, %xmm5, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm0, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vpor %xmm7, %xmm8, %xmm7
-; AVX1-NEXT:    vpxor %xmm7, %xmm6, %xmm6
-; AVX1-NEXT:    vpand %xmm1, %xmm12, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm0, %xmm8
-; AVX1-NEXT:    vpand %xmm5, %xmm8, %xmm8
-; AVX1-NEXT:    vpandn %xmm7, %xmm5, %xmm7
-; AVX1-NEXT:    vpmaddubsw %xmm7, %xmm0, %xmm7
-; AVX1-NEXT:    vpsllw $8, %xmm7, %xmm7
-; AVX1-NEXT:    vpor %xmm7, %xmm8, %xmm7
-; AVX1-NEXT:    vpxor %xmm7, %xmm6, %xmm6
-; AVX1-NEXT:    vpxor %xmm6, %xmm3, %xmm3
+; AVX1-NEXT:    vpor %xmm6, %xmm5, %xmm10
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm2 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX1-NEXT:    vpand %xmm2, %xmm10, %xmm6
+; AVX1-NEXT:    vmovdqa %ymm2, %ymm11
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm7
+; AVX1-NEXT:    vpand %xmm7, %xmm13, %xmm8
+; AVX1-NEXT:    vmovdqa %xmm3, %xmm2
+; AVX1-NEXT:    vpshufb %xmm8, %xmm3, %xmm8
+; AVX1-NEXT:    vpsrlw $4, %xmm7, %xmm7
+; AVX1-NEXT:    vpand %xmm7, %xmm13, %xmm7
+; AVX1-NEXT:    vmovdqa %xmm4, %xmm5
+; AVX1-NEXT:    vpshufb %xmm7, %xmm4, %xmm7
+; AVX1-NEXT:    vpor %xmm7, %xmm8, %xmm12
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm4 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX1-NEXT:    vpand %xmm4, %xmm12, %xmm7
+; AVX1-NEXT:    vpmullw %xmm6, %xmm7, %xmm8
+; AVX1-NEXT:    vmovdqa %xmm6, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
+; AVX1-NEXT:    vpand %xmm1, %xmm13, %xmm9
+; AVX1-NEXT:    vpshufb %xmm9, %xmm3, %xmm9
+; AVX1-NEXT:    vpsrlw $4, %xmm1, %xmm1
 ; AVX1-NEXT:    vpand %xmm1, %xmm13, %xmm1
-; AVX1-NEXT:    vpmullw %xmm1, %xmm0, %xmm6
-; AVX1-NEXT:    vpand %xmm5, %xmm6, %xmm6
-; AVX1-NEXT:    vpandn %xmm1, %xmm5, %xmm1
-; AVX1-NEXT:    vpmaddubsw %xmm1, %xmm0, %xmm0
-; AVX1-NEXT:    vpsllw $8, %xmm0, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm3, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm9, %xmm1
+; AVX1-NEXT:    vpshufb %xmm1, %xmm5, %xmm1
+; AVX1-NEXT:    vpor %xmm1, %xmm9, %xmm14
+; AVX1-NEXT:    vpand %xmm11, %xmm14, %xmm3
+; AVX1-NEXT:    vpand %xmm0, %xmm13, %xmm9
+; AVX1-NEXT:    vpshufb %xmm9, %xmm2, %xmm9
 ; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
+; AVX1-NEXT:    vpand %xmm0, %xmm13, %xmm0
+; AVX1-NEXT:    vpshufb %xmm0, %xmm5, %xmm0
+; AVX1-NEXT:    vpor %xmm0, %xmm9, %xmm15
+; AVX1-NEXT:    vpand %xmm4, %xmm15, %xmm11
+; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm0
+; AVX1-NEXT:    vinsertf128 $1, %xmm8, %ymm0, %ymm2
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm1 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
+; AVX1-NEXT:    vpandn %xmm3, %xmm1, %xmm0
+; AVX1-NEXT:    vmovdqa %xmm0, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
+; AVX1-NEXT:    vpmaddubsw %xmm0, %xmm11, %xmm9
+; AVX1-NEXT:    vpsllw $8, %xmm9, %xmm0
+; AVX1-NEXT:    vpandn %xmm6, %xmm1, %xmm9
+; AVX1-NEXT:    vpmaddubsw %xmm9, %xmm7, %xmm5
+; AVX1-NEXT:    vpsllw $8, %xmm5, %xmm5
+; AVX1-NEXT:    vinsertf128 $1, %xmm5, %ymm0, %ymm0
+; AVX1-NEXT:    vandps %ymm1, %ymm2, %ymm2
+; AVX1-NEXT:    vorps %ymm0, %ymm2, %ymm6
+; AVX1-NEXT:    vpand %xmm4, %xmm10, %xmm2
+; AVX1-NEXT:    vpand %xmm4, %xmm14, %xmm4
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm0 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX1-NEXT:    vpand %xmm0, %xmm12, %xmm10
+; AVX1-NEXT:    vpand %xmm0, %xmm15, %xmm12
+; AVX1-NEXT:    vpmullw %xmm2, %xmm10, %xmm5
+; AVX1-NEXT:    vpmullw %xmm4, %xmm12, %xmm14
+; AVX1-NEXT:    vinsertf128 $1, %xmm5, %ymm14, %ymm5
+; AVX1-NEXT:    vpandn %xmm4, %xmm1, %xmm14
+; AVX1-NEXT:    vpmaddubsw %xmm14, %xmm12, %xmm15
+; AVX1-NEXT:    vpsllw $8, %xmm15, %xmm15
+; AVX1-NEXT:    vpandn %xmm2, %xmm1, %xmm0
+; AVX1-NEXT:    vpmaddubsw %xmm0, %xmm10, %xmm8
+; AVX1-NEXT:    vpsllw $8, %xmm8, %xmm8
+; AVX1-NEXT:    vinsertf128 $1, %xmm8, %ymm15, %ymm8
+; AVX1-NEXT:    vandps %ymm1, %ymm5, %ymm5
+; AVX1-NEXT:    vorps %ymm5, %ymm8, %ymm5
+; AVX1-NEXT:    vxorps %ymm6, %ymm5, %ymm5
+; AVX1-NEXT:    vpmullw %xmm2, %xmm7, %xmm2
+; AVX1-NEXT:    vpmullw %xmm4, %xmm11, %xmm4
+; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm4, %ymm2
+; AVX1-NEXT:    vpmaddubsw %xmm14, %xmm11, %xmm4
+; AVX1-NEXT:    vpmaddubsw %xmm0, %xmm7, %xmm0
+; AVX1-NEXT:    vpsllw $8, %xmm4, %xmm4
+; AVX1-NEXT:    vpsllw $8, %xmm0, %xmm0
+; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm4, %ymm0
+; AVX1-NEXT:    vandps %ymm1, %ymm2, %ymm2
+; AVX1-NEXT:    vorps %ymm0, %ymm2, %ymm0
+; AVX1-NEXT:    vpmullw {{[-0-9]+}}(%r{{[sb]}}p), %xmm10, %xmm2 # 16-byte Folded Reload
+; AVX1-NEXT:    vpmullw %xmm3, %xmm12, %xmm3
+; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm3, %ymm2
+; AVX1-NEXT:    vandps %ymm1, %ymm2, %ymm1
+; AVX1-NEXT:    vpmaddubsw {{[-0-9]+}}(%r{{[sb]}}p), %xmm12, %xmm2 # 16-byte Folded Reload
+; AVX1-NEXT:    vpmaddubsw %xmm9, %xmm10, %xmm3
+; AVX1-NEXT:    vpsllw $8, %xmm2, %xmm2
+; AVX1-NEXT:    vpsllw $8, %xmm3, %xmm3
+; AVX1-NEXT:    vinsertf128 $1, %xmm3, %ymm2, %ymm2
+; AVX1-NEXT:    vorps %ymm2, %ymm1, %ymm1
+; AVX1-NEXT:    vxorps %ymm0, %ymm1, %ymm0
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm2 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX1-NEXT:    vandnps %ymm5, %ymm2, %ymm1
+; AVX1-NEXT:    vandps %ymm2, %ymm0, %ymm0
+; AVX1-NEXT:    vorps %ymm1, %ymm0, %ymm0
+; AVX1-NEXT:    vpand %xmm0, %xmm13, %xmm1
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX1-NEXT:    vpshufb %xmm1, %xmm3, %xmm1
+; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm2
+; AVX1-NEXT:    vpand %xmm2, %xmm13, %xmm2
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm4 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX1-NEXT:    vpshufb %xmm2, %xmm4, %xmm2
+; AVX1-NEXT:    vpor %xmm2, %xmm1, %xmm1
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; AVX1-NEXT:    vpand %xmm0, %xmm13, %xmm2
+; AVX1-NEXT:    vpshufb %xmm2, %xmm3, %xmm2
+; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
+; AVX1-NEXT:    vpand %xmm0, %xmm13, %xmm0
 ; AVX1-NEXT:    vpshufb %xmm0, %xmm4, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vpsrlw $1, %xmm14, %xmm1
+; AVX1-NEXT:    vpor %xmm0, %xmm2, %xmm0
+; AVX1-NEXT:    vpsrlw $1, %xmm1, %xmm1
 ; AVX1-NEXT:    vpsrlw $1, %xmm0, %xmm0
 ; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
 ; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
@@ -1780,90 +1382,61 @@ define <32 x i8> @clmulh_v32i8(<32 x i8> %a, <32 x i8> %b) nounwind {
 ; AVX2-LABEL: clmulh_v32i8:
 ; AVX2:       # %bb.0:
 ; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm4
+; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm4
 ; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
 ; AVX2-NEXT:    # ymm3 = mem[0,1,0,1]
 ; AVX2-NEXT:    vpshufb %ymm4, %ymm3, %ymm4
-; AVX2-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm5
-; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
-; AVX2-NEXT:    # ymm0 = mem[0,1,0,1]
-; AVX2-NEXT:    vpshufb %ymm5, %ymm0, %ymm5
-; AVX2-NEXT:    vpor %ymm5, %ymm4, %ymm4
-; AVX2-NEXT:    vpsrlw $4, %ymm1, %ymm5
-; AVX2-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX2-NEXT:    vpshufb %ymm5, %ymm0, %ymm6
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm7
-; AVX2-NEXT:    vpmullw %ymm7, %ymm4, %ymm8
-; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm5 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
-; AVX2-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX2-NEXT:    vpmaddubsw %ymm7, %ymm4, %ymm7
-; AVX2-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX2-NEXT:    vpor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm8
-; AVX2-NEXT:    vpmullw %ymm4, %ymm8, %ymm9
-; AVX2-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpandn %ymm8, %ymm5, %ymm8
-; AVX2-NEXT:    vpmaddubsw %ymm8, %ymm4, %ymm8
-; AVX2-NEXT:    vpsllw $8, %ymm8, %ymm8
-; AVX2-NEXT:    vpor %ymm8, %ymm9, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm8
-; AVX2-NEXT:    vpmullw %ymm4, %ymm8, %ymm9
-; AVX2-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpandn %ymm8, %ymm5, %ymm8
-; AVX2-NEXT:    vpmaddubsw %ymm8, %ymm4, %ymm8
-; AVX2-NEXT:    vpsllw $8, %ymm8, %ymm8
-; AVX2-NEXT:    vpor %ymm8, %ymm9, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm6
-; AVX2-NEXT:    vpmullw %ymm6, %ymm4, %ymm9
-; AVX2-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX2-NEXT:    vpmaddubsw %ymm6, %ymm4, %ymm6
-; AVX2-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX2-NEXT:    vpor %ymm6, %ymm9, %ymm6
-; AVX2-NEXT:    vpxor %ymm6, %ymm8, %ymm6
-; AVX2-NEXT:    vpxor %ymm6, %ymm7, %ymm6
-; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm1
-; AVX2-NEXT:    vpshufb %ymm1, %ymm3, %ymm1
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm7
-; AVX2-NEXT:    vpmullw %ymm7, %ymm4, %ymm8
-; AVX2-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX2-NEXT:    vpmaddubsw %ymm7, %ymm4, %ymm7
-; AVX2-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX2-NEXT:    vpor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm8
-; AVX2-NEXT:    vpmullw %ymm4, %ymm8, %ymm9
-; AVX2-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpandn %ymm8, %ymm5, %ymm8
-; AVX2-NEXT:    vpmaddubsw %ymm8, %ymm4, %ymm8
-; AVX2-NEXT:    vpsllw $8, %ymm8, %ymm8
-; AVX2-NEXT:    vpor %ymm8, %ymm9, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm8
-; AVX2-NEXT:    vpmullw %ymm4, %ymm8, %ymm9
-; AVX2-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpandn %ymm8, %ymm5, %ymm8
-; AVX2-NEXT:    vpmaddubsw %ymm8, %ymm4, %ymm8
-; AVX2-NEXT:    vpsllw $8, %ymm8, %ymm8
-; AVX2-NEXT:    vpor %ymm8, %ymm9, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpxor %ymm7, %ymm6, %ymm6
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
-; AVX2-NEXT:    vpmullw %ymm1, %ymm4, %ymm7
-; AVX2-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX2-NEXT:    vpandn %ymm1, %ymm5, %ymm1
-; AVX2-NEXT:    vpmaddubsw %ymm1, %ymm4, %ymm1
-; AVX2-NEXT:    vpsllw $8, %ymm1, %ymm1
-; AVX2-NEXT:    vpor %ymm1, %ymm7, %ymm1
-; AVX2-NEXT:    vpxor %ymm1, %ymm6, %ymm1
-; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm4
-; AVX2-NEXT:    vpshufb %ymm4, %ymm3, %ymm3
 ; AVX2-NEXT:    vpsrlw $4, %ymm1, %ymm1
-; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm1
-; AVX2-NEXT:    vpshufb %ymm1, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm5
+; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm1 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX2-NEXT:    # ymm1 = mem[0,1,0,1]
+; AVX2-NEXT:    vpshufb %ymm5, %ymm1, %ymm5
+; AVX2-NEXT:    vpor %ymm5, %ymm4, %ymm5
+; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm4 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX2-NEXT:    vpand %ymm4, %ymm5, %ymm6
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm7
+; AVX2-NEXT:    vpshufb %ymm7, %ymm3, %ymm7
+; AVX2-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpshufb %ymm0, %ymm1, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm7, %ymm0
+; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm7 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX2-NEXT:    vpand %ymm7, %ymm0, %ymm8
+; AVX2-NEXT:    vpmullw %ymm6, %ymm8, %ymm9
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm10 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
+; AVX2-NEXT:    vpand %ymm10, %ymm9, %ymm9
+; AVX2-NEXT:    vpandn %ymm6, %ymm10, %ymm11
+; AVX2-NEXT:    vpmaddubsw %ymm11, %ymm8, %ymm12
+; AVX2-NEXT:    vpsllw $8, %ymm12, %ymm12
+; AVX2-NEXT:    vpor %ymm12, %ymm9, %ymm9
+; AVX2-NEXT:    vpand %ymm7, %ymm5, %ymm5
+; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX2-NEXT:    vpmullw %ymm5, %ymm0, %ymm7
+; AVX2-NEXT:    vpand %ymm7, %ymm10, %ymm7
+; AVX2-NEXT:    vpandn %ymm5, %ymm10, %ymm12
+; AVX2-NEXT:    vpmaddubsw %ymm12, %ymm0, %ymm13
+; AVX2-NEXT:    vpsllw $8, %ymm13, %ymm13
+; AVX2-NEXT:    vpor %ymm7, %ymm13, %ymm7
+; AVX2-NEXT:    vpxor %ymm7, %ymm9, %ymm7
+; AVX2-NEXT:    vpandn %ymm7, %ymm4, %ymm7
+; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm5
+; AVX2-NEXT:    vpand %ymm5, %ymm10, %ymm5
+; AVX2-NEXT:    vpmaddubsw %ymm12, %ymm8, %ymm8
+; AVX2-NEXT:    vpsllw $8, %ymm8, %ymm8
+; AVX2-NEXT:    vpor %ymm5, %ymm8, %ymm5
+; AVX2-NEXT:    vpmullw %ymm6, %ymm0, %ymm6
+; AVX2-NEXT:    vpand %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpmaddubsw %ymm11, %ymm0, %ymm0
+; AVX2-NEXT:    vpsllw $8, %ymm0, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm6, %ymm0
+; AVX2-NEXT:    vpxor %ymm5, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX2-NEXT:    vpor %ymm7, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm4
+; AVX2-NEXT:    vpshufb %ymm4, %ymm3, %ymm3
+; AVX2-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpshufb %ymm0, %ymm1, %ymm0
 ; AVX2-NEXT:    vpor %ymm0, %ymm3, %ymm0
 ; AVX2-NEXT:    vpsrlw $1, %ymm0, %ymm0
 ; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
@@ -1871,63 +1444,66 @@ define <32 x i8> @clmulh_v32i8(<32 x i8> %a, <32 x i8> %b) nounwind {
 ;
 ; AVX512-LABEL: clmulh_v32i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vextracti128 $1, %ymm1, %xmm2
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero,xmm2[8],zero,xmm2[9],zero,xmm2[10],zero,xmm2[11],zero,xmm2[12],zero,xmm2[13],zero,xmm2[14],zero,xmm2[15],zero
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm3 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; AVX512-NEXT:    vpand %ymm3, %ymm2, %ymm4
-; AVX512-NEXT:    vextracti128 $1, %ymm0, %xmm5
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero,xmm5[4],zero,xmm5[5],zero,xmm5[6],zero,xmm5[7],zero,xmm5[8],zero,xmm5[9],zero,xmm5[10],zero,xmm5[11],zero,xmm5[12],zero,xmm5[13],zero,xmm5[14],zero,xmm5[15],zero
-; AVX512-NEXT:    vpmullw %ymm4, %ymm5, %ymm4
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm6 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-; AVX512-NEXT:    vpand %ymm6, %ymm2, %ymm7
-; AVX512-NEXT:    vpmullw %ymm7, %ymm5, %ymm7
-; AVX512-NEXT:    vpxor %ymm4, %ymm7, %ymm4
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm7 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; AVX512-NEXT:    vpand %ymm7, %ymm2, %ymm8
-; AVX512-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm9 = [8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8]
-; AVX512-NEXT:    vpand %ymm2, %ymm9, %ymm10
-; AVX512-NEXT:    vpmullw %ymm5, %ymm10, %ymm10
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm10 = ymm10 ^ ymm4 ^ ymm8
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm4 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; AVX512-NEXT:    vpand %ymm4, %ymm2, %ymm8
-; AVX512-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm11 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; AVX512-NEXT:    vpand %ymm2, %ymm11, %ymm12
-; AVX512-NEXT:    vpmullw %ymm5, %ymm12, %ymm12
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm12 = ymm12 ^ ymm10 ^ ymm8
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm8 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; AVX512-NEXT:    vpand %ymm2, %ymm8, %ymm10
-; AVX512-NEXT:    vpmullw %ymm5, %ymm10, %ymm10
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm13 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-; AVX512-NEXT:    vpand %ymm2, %ymm13, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm5, %ymm2
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm2 = ymm2 ^ ymm12 ^ ymm10
-; AVX512-NEXT:    vpsrlw $8, %ymm2, %ymm2
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero,xmm1[8],zero,xmm1[9],zero,xmm1[10],zero,xmm1[11],zero,xmm1[12],zero,xmm1[13],zero,xmm1[14],zero,xmm1[15],zero
-; AVX512-NEXT:    vpand %ymm3, %ymm1, %ymm3
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpand %ymm6, %ymm1, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm0, %ymm5
-; AVX512-NEXT:    vpxor %ymm3, %ymm5, %ymm3
-; AVX512-NEXT:    vpand %ymm7, %ymm1, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm0, %ymm5
-; AVX512-NEXT:    vpand %ymm1, %ymm9, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm0, %ymm6
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm6 = ymm6 ^ ymm3 ^ ymm5
-; AVX512-NEXT:    vpand %ymm4, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpand %ymm1, %ymm11, %ymm4
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm4 = ymm4 ^ ymm6 ^ ymm3
-; AVX512-NEXT:    vpand %ymm1, %ymm8, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpand %ymm1, %ymm13, %ymm1
-; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 ^ ymm4 ^ ymm3
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} zmm16 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX512-NEXT:    vextracti128 $1, %ymm1, %xmm3
+; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm8 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero,xmm3[4],zero,xmm3[5],zero,xmm3[6],zero,xmm3[7],zero,xmm3[8],zero,xmm3[9],zero,xmm3[10],zero,xmm3[11],zero,xmm3[12],zero,xmm3[13],zero,xmm3[14],zero,xmm3[15],zero
+; AVX512-NEXT:    vpandq %ymm16, %ymm8, %ymm3
+; AVX512-NEXT:    vextracti128 $1, %ymm0, %xmm4
+; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm9 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero,xmm4[4],zero,xmm4[5],zero,xmm4[6],zero,xmm4[7],zero,xmm4[8],zero,xmm4[9],zero,xmm4[10],zero,xmm4[11],zero,xmm4[12],zero,xmm4[13],zero,xmm4[14],zero,xmm4[15],zero
+; AVX512-NEXT:    vpandq %ymm16, %ymm9, %ymm4
+; AVX512-NEXT:    vpmullw %ymm3, %ymm4, %ymm5
+; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm10 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero,xmm1[8],zero,xmm1[9],zero,xmm1[10],zero,xmm1[11],zero,xmm1[12],zero,xmm1[13],zero,xmm1[14],zero,xmm1[15],zero
+; AVX512-NEXT:    vpandq %ymm16, %ymm10, %ymm1
+; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm11 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
+; AVX512-NEXT:    vpandq %ymm16, %ymm11, %ymm0
+; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm6
+; AVX512-NEXT:    vinserti64x4 $1, %ymm5, %zmm6, %zmm12
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} zmm17 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX512-NEXT:    vpandq %ymm17, %ymm8, %ymm6
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} zmm18 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX512-NEXT:    vpandq %ymm18, %ymm9, %ymm5
+; AVX512-NEXT:    vpmullw %ymm6, %ymm5, %ymm15
+; AVX512-NEXT:    vpandq %ymm17, %ymm10, %ymm2
+; AVX512-NEXT:    vpandq %ymm18, %ymm11, %ymm7
+; AVX512-NEXT:    vpmullw %ymm2, %ymm7, %ymm13
+; AVX512-NEXT:    vinserti64x4 $1, %ymm15, %zmm13, %zmm13
+; AVX512-NEXT:    vpandq %ymm18, %ymm8, %ymm8
+; AVX512-NEXT:    vpandq %ymm17, %ymm9, %ymm9
+; AVX512-NEXT:    vpmullw %ymm8, %ymm9, %ymm15
+; AVX512-NEXT:    vpandq %ymm18, %ymm10, %ymm10
+; AVX512-NEXT:    vpandq %ymm17, %ymm11, %ymm11
+; AVX512-NEXT:    vpmullw %ymm10, %ymm11, %ymm14
+; AVX512-NEXT:    vinserti64x4 $1, %ymm15, %zmm14, %zmm14
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm14 = zmm14 ^ zmm13 ^ zmm12
+; AVX512-NEXT:    vpmullw %ymm4, %ymm8, %ymm12
+; AVX512-NEXT:    vpmullw %ymm0, %ymm10, %ymm13
+; AVX512-NEXT:    vinserti64x4 $1, %ymm12, %zmm13, %zmm12
+; AVX512-NEXT:    vpmullw %ymm3, %ymm5, %ymm13
+; AVX512-NEXT:    vmovdqa64 %ymm3, %ymm19
+; AVX512-NEXT:    vpmullw %ymm1, %ymm7, %ymm15
+; AVX512-NEXT:    vinserti64x4 $1, %ymm13, %zmm15, %zmm13
+; AVX512-NEXT:    vpmullw %ymm6, %ymm9, %ymm15
+; AVX512-NEXT:    vpmullw %ymm2, %ymm11, %ymm3
+; AVX512-NEXT:    vinserti64x4 $1, %ymm15, %zmm3, %zmm3
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm3 = zmm3 ^ zmm13 ^ zmm12
+; AVX512-NEXT:    vpmullw %ymm6, %ymm4, %ymm4
+; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm0
+; AVX512-NEXT:    vinserti64x4 $1, %ymm4, %zmm0, %zmm0
+; AVX512-NEXT:    vpmullw %ymm5, %ymm8, %ymm2
+; AVX512-NEXT:    vpmullw %ymm7, %ymm10, %ymm4
+; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm4, %zmm2
+; AVX512-NEXT:    vpxorq %zmm0, %zmm2, %zmm0
+; AVX512-NEXT:    vmovdqa64 %ymm19, %ymm2
+; AVX512-NEXT:    vpmullw %ymm2, %ymm9, %ymm2
+; AVX512-NEXT:    vpmullw %ymm1, %ymm11, %ymm1
+; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm18 & (zmm1 ^ zmm0)
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm1 | (zmm3 & zmm16)
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm1 | (zmm14 & zmm17)
+; AVX512-NEXT:    vextracti64x4 $1, %zmm1, %ymm0
 ; AVX512-NEXT:    vpsrlw $8, %ymm0, %ymm0
-; AVX512-NEXT:    vpackuswb %ymm2, %ymm0, %ymm0
+; AVX512-NEXT:    vpsrlw $8, %ymm1, %ymm1
+; AVX512-NEXT:    vpackuswb %ymm0, %ymm1, %ymm0
 ; AVX512-NEXT:    vpermq {{.*#+}} ymm0 = ymm0[0,2,1,3]
 ; AVX512-NEXT:    retq
   %a.ext = zext <32 x i8> %a to <32 x i16>
@@ -1941,155 +1517,120 @@ define <32 x i8> @clmulh_v32i8(<32 x i8> %a, <32 x i8> %b) nounwind {
 define <16 x i16> @clmulh_v16i16(<16 x i16> %a, <16 x i16> %b) nounwind {
 ; AVX1-LABEL: clmulh_v16i16:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vmovdqa %ymm1, %ymm5
-; AVX1-NEXT:    vmovdqa %ymm0, %ymm4
-; AVX1-NEXT:    vmovdqa {{.*#+}} xmm12 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
-; AVX1-NEXT:    vpshufb %xmm12, %xmm4, %xmm0
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm3
-; AVX1-NEXT:    vmovdqa {{.*#+}} xmm8 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
-; AVX1-NEXT:    vpshufb %xmm3, %xmm8, %xmm3
+; AVX1-NEXT:    vmovdqa %ymm0, %ymm12
+; AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm2
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm0 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
+; AVX1-NEXT:    vpshufb %xmm0, %xmm2, %xmm3
+; AVX1-NEXT:    vmovdqa %xmm0, %xmm2
+; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm7 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX1-NEXT:    vpand %xmm7, %xmm3, %xmm5
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm4 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX1-NEXT:    vpshufb %xmm5, %xmm4, %xmm6
+; AVX1-NEXT:    vpsrlw $4, %xmm3, %xmm3
+; AVX1-NEXT:    vpand %xmm7, %xmm3, %xmm3
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm0 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX1-NEXT:    vpshufb %xmm3, %xmm0, %xmm3
+; AVX1-NEXT:    vpor %xmm3, %xmm6, %xmm9
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm3 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX1-NEXT:    vpand %xmm3, %xmm9, %xmm5
+; AVX1-NEXT:    vmovdqa %xmm5, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
+; AVX1-NEXT:    vmovdqa %ymm3, %ymm6
+; AVX1-NEXT:    vextractf128 $1, %ymm12, %xmm3
+; AVX1-NEXT:    vpshufb %xmm2, %xmm3, %xmm3
+; AVX1-NEXT:    vpand %xmm7, %xmm3, %xmm8
+; AVX1-NEXT:    vpshufb %xmm8, %xmm4, %xmm8
+; AVX1-NEXT:    vpsrlw $4, %xmm3, %xmm3
+; AVX1-NEXT:    vpand %xmm7, %xmm3, %xmm3
+; AVX1-NEXT:    vpshufb %xmm3, %xmm0, %xmm3
+; AVX1-NEXT:    vpor %xmm3, %xmm8, %xmm14
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm10 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX1-NEXT:    vpand %xmm10, %xmm14, %xmm8
+; AVX1-NEXT:    vpmullw %xmm5, %xmm8, %xmm11
+; AVX1-NEXT:    vpshufb %xmm2, %xmm1, %xmm1
+; AVX1-NEXT:    vpand %xmm7, %xmm1, %xmm3
+; AVX1-NEXT:    vpshufb %xmm3, %xmm4, %xmm3
+; AVX1-NEXT:    vpsrlw $4, %xmm1, %xmm1
+; AVX1-NEXT:    vpand %xmm7, %xmm1, %xmm1
+; AVX1-NEXT:    vpshufb %xmm1, %xmm0, %xmm1
+; AVX1-NEXT:    vpor %xmm1, %xmm3, %xmm3
+; AVX1-NEXT:    vpand %xmm6, %xmm3, %xmm5
+; AVX1-NEXT:    vpshufb %xmm2, %xmm12, %xmm1
+; AVX1-NEXT:    vpand %xmm7, %xmm1, %xmm2
+; AVX1-NEXT:    vpshufb %xmm2, %xmm4, %xmm2
+; AVX1-NEXT:    vpsrlw $4, %xmm1, %xmm1
+; AVX1-NEXT:    vpand %xmm7, %xmm1, %xmm1
+; AVX1-NEXT:    vpshufb %xmm1, %xmm0, %xmm1
+; AVX1-NEXT:    vpor %xmm1, %xmm2, %xmm0
+; AVX1-NEXT:    vpand %xmm0, %xmm10, %xmm4
+; AVX1-NEXT:    vpmullw %xmm5, %xmm4, %xmm1
+; AVX1-NEXT:    vmovdqa %xmm5, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
+; AVX1-NEXT:    vinsertf128 $1, %xmm11, %ymm1, %ymm11
+; AVX1-NEXT:    vpand %xmm10, %xmm9, %xmm15
+; AVX1-NEXT:    vmovdqa %ymm10, %ymm7
+; AVX1-NEXT:    vpand %xmm6, %xmm14, %xmm12
+; AVX1-NEXT:    vpmullw %xmm15, %xmm12, %xmm1
+; AVX1-NEXT:    vpand %xmm7, %xmm3, %xmm2
+; AVX1-NEXT:    vpand %xmm6, %xmm0, %xmm13
+; AVX1-NEXT:    vpmullw %xmm2, %xmm13, %xmm6
+; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm6, %ymm1
+; AVX1-NEXT:    vxorps %ymm1, %ymm11, %ymm1
+; AVX1-NEXT:    vbroadcastss {{.*#+}} ymm10 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX1-NEXT:    vpand %xmm10, %xmm9, %xmm6
+; AVX1-NEXT:    vpand %xmm10, %xmm14, %xmm9
+; AVX1-NEXT:    vpand %xmm3, %xmm10, %xmm3
+; AVX1-NEXT:    vpand %xmm0, %xmm10, %xmm14
+; AVX1-NEXT:    vpmullw %xmm6, %xmm9, %xmm0
+; AVX1-NEXT:    vpmullw %xmm3, %xmm14, %xmm10
+; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm10, %ymm0
+; AVX1-NEXT:    vxorps %ymm0, %ymm1, %ymm0
+; AVX1-NEXT:    vandps %ymm7, %ymm0, %ymm7
+; AVX1-NEXT:    vpmullw %xmm6, %xmm8, %xmm1
+; AVX1-NEXT:    vpmullw %xmm3, %xmm4, %xmm10
+; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm10, %ymm1
+; AVX1-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm0 # 16-byte Reload
+; AVX1-NEXT:    vpmullw %xmm0, %xmm12, %xmm10
+; AVX1-NEXT:    vpmullw %xmm5, %xmm13, %xmm11
+; AVX1-NEXT:    vinsertf128 $1, %xmm10, %ymm11, %ymm10
+; AVX1-NEXT:    vxorps %ymm1, %ymm10, %ymm1
+; AVX1-NEXT:    vpmullw %xmm15, %xmm9, %xmm10
+; AVX1-NEXT:    vpmullw %xmm2, %xmm14, %xmm11
+; AVX1-NEXT:    vinsertf128 $1, %xmm10, %ymm11, %ymm10
+; AVX1-NEXT:    vxorps %ymm1, %ymm10, %ymm1
+; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
+; AVX1-NEXT:    vorps %ymm7, %ymm1, %ymm5
+; AVX1-NEXT:    vpmullw %xmm15, %xmm8, %xmm1
+; AVX1-NEXT:    vpmullw %xmm2, %xmm4, %xmm2
+; AVX1-NEXT:    vinsertf128 $1, %xmm1, %ymm2, %ymm1
+; AVX1-NEXT:    vpmullw %xmm6, %xmm12, %xmm2
+; AVX1-NEXT:    vpmullw %xmm3, %xmm13, %xmm3
+; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm3, %ymm2
+; AVX1-NEXT:    vxorps %ymm1, %ymm2, %ymm1
+; AVX1-NEXT:    vpmullw %xmm0, %xmm9, %xmm2
+; AVX1-NEXT:    vpmullw {{[-0-9]+}}(%r{{[sb]}}p), %xmm14, %xmm3 # 16-byte Folded Reload
+; AVX1-NEXT:    vinsertf128 $1, %xmm2, %ymm3, %ymm2
+; AVX1-NEXT:    vxorps %ymm2, %ymm1, %ymm1
+; AVX1-NEXT:    vandps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
+; AVX1-NEXT:    vorps %ymm1, %ymm5, %ymm0
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm3 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
+; AVX1-NEXT:    vpshufb %xmm3, %xmm0, %xmm1
+; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm6 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX1-NEXT:    vpand %xmm6, %xmm1, %xmm2
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm4 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX1-NEXT:    vpshufb %xmm2, %xmm4, %xmm2
+; AVX1-NEXT:    vpsrlw $4, %xmm1, %xmm1
+; AVX1-NEXT:    vpand %xmm6, %xmm1, %xmm1
+; AVX1-NEXT:    vmovdqa {{.*#+}} xmm5 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX1-NEXT:    vpshufb %xmm1, %xmm5, %xmm1
+; AVX1-NEXT:    vpor %xmm1, %xmm2, %xmm1
+; AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; AVX1-NEXT:    vpshufb %xmm3, %xmm0, %xmm0
+; AVX1-NEXT:    vpand %xmm6, %xmm0, %xmm2
+; AVX1-NEXT:    vpshufb %xmm2, %xmm4, %xmm2
 ; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vmovdqa {{.*#+}} xmm6 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
-; AVX1-NEXT:    vpshufb %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm3, %xmm3
-; AVX1-NEXT:    vpshufb %xmm12, %xmm5, %xmm0
-; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm7
-; AVX1-NEXT:    vpand %xmm2, %xmm7, %xmm7
-; AVX1-NEXT:    vpshufb %xmm7, %xmm6, %xmm7
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm14 = [2,2,2,2,2,2,2,2]
-; AVX1-NEXT:    vpand %xmm7, %xmm14, %xmm9
-; AVX1-NEXT:    vpmullw %xmm3, %xmm9, %xmm9
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm10
-; AVX1-NEXT:    vpmullw %xmm3, %xmm10, %xmm10
-; AVX1-NEXT:    vpxor %xmm9, %xmm10, %xmm9
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm10
-; AVX1-NEXT:    vpmullw %xmm3, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpxor %xmm10, %xmm9, %xmm9
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm8, %xmm0
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm10
-; AVX1-NEXT:    vpmullw %xmm3, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpxor %xmm10, %xmm9, %xmm9
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm10
-; AVX1-NEXT:    vpmullw %xmm3, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7, %xmm11
-; AVX1-NEXT:    vpmullw %xmm3, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm11, %xmm10, %xmm10
-; AVX1-NEXT:    vpxor %xmm10, %xmm9, %xmm1
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm13 = [2048,2048,2048,2048,2048,2048,2048,2048]
-; AVX1-NEXT:    vpand %xmm7, %xmm13, %xmm7
-; AVX1-NEXT:    vpmullw %xmm7, %xmm3, %xmm7
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm11 = [4096,4096,4096,4096,4096,4096,4096,4096]
-; AVX1-NEXT:    vpand %xmm0, %xmm11, %xmm9
-; AVX1-NEXT:    vpmullw %xmm3, %xmm9, %xmm9
-; AVX1-NEXT:    vpxor %xmm7, %xmm9, %xmm7
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm10 = [8192,8192,8192,8192,8192,8192,8192,8192]
-; AVX1-NEXT:    vpand %xmm0, %xmm10, %xmm9
-; AVX1-NEXT:    vpmullw %xmm3, %xmm9, %xmm9
-; AVX1-NEXT:    vpxor %xmm7, %xmm9, %xmm7
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm9 = [16384,16384,16384,16384,16384,16384,16384,16384]
-; AVX1-NEXT:    vpand %xmm0, %xmm9, %xmm15
-; AVX1-NEXT:    vpmullw %xmm3, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm7, %xmm15, %xmm15
-; AVX1-NEXT:    vbroadcastss {{.*#+}} xmm7 = [32768,32768,32768,32768,32768,32768,32768,32768]
-; AVX1-NEXT:    vpand %xmm7, %xmm0, %xmm0
-; AVX1-NEXT:    vpmullw %xmm0, %xmm3, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm15, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vpshufb %xmm12, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm8, %xmm1
-; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm1, %xmm3
-; AVX1-NEXT:    vextractf128 $1, %ymm4, %xmm0
-; AVX1-NEXT:    vpshufb %xmm12, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm8, %xmm1
-; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vextractf128 $1, %ymm5, %xmm1
-; AVX1-NEXT:    vpshufb %xmm12, %xmm1, %xmm4
-; AVX1-NEXT:    vpsrlw $4, %xmm4, %xmm1
-; AVX1-NEXT:    vpand %xmm2, %xmm1, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm6, %xmm1
-; AVX1-NEXT:    vpand %xmm1, %xmm14, %xmm5
-; AVX1-NEXT:    vpmullw %xmm5, %xmm0, %xmm5
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm5, %xmm15, %xmm5
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm14
-; AVX1-NEXT:    vpmullw %xmm0, %xmm14, %xmm14
-; AVX1-NEXT:    vpxor %xmm14, %xmm15, %xmm14
-; AVX1-NEXT:    vpxor %xmm5, %xmm14, %xmm5
-; AVX1-NEXT:    vpand %xmm2, %xmm4, %xmm4
-; AVX1-NEXT:    vpshufb %xmm4, %xmm8, %xmm4
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm4, %xmm14
-; AVX1-NEXT:    vpmullw %xmm0, %xmm14, %xmm14
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm4, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm15, %xmm14, %xmm14
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm4, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm15, %xmm14, %xmm14
-; AVX1-NEXT:    vpxor %xmm5, %xmm14, %xmm5
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm4, %xmm14
-; AVX1-NEXT:    vpmullw %xmm0, %xmm14, %xmm14
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm15, %xmm14, %xmm14
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm15, %xmm14, %xmm14
-; AVX1-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm15
-; AVX1-NEXT:    vpmullw %xmm0, %xmm15, %xmm15
-; AVX1-NEXT:    vpxor %xmm15, %xmm14, %xmm14
-; AVX1-NEXT:    vpxor %xmm5, %xmm14, %xmm5
-; AVX1-NEXT:    vpand %xmm1, %xmm13, %xmm1
-; AVX1-NEXT:    vpmullw %xmm1, %xmm0, %xmm1
-; AVX1-NEXT:    vpand %xmm4, %xmm11, %xmm11
-; AVX1-NEXT:    vpmullw %xmm0, %xmm11, %xmm11
-; AVX1-NEXT:    vpxor %xmm1, %xmm11, %xmm1
-; AVX1-NEXT:    vpand %xmm4, %xmm10, %xmm10
-; AVX1-NEXT:    vpmullw %xmm0, %xmm10, %xmm10
-; AVX1-NEXT:    vpxor %xmm1, %xmm10, %xmm1
-; AVX1-NEXT:    vpand %xmm4, %xmm9, %xmm9
-; AVX1-NEXT:    vpmullw %xmm0, %xmm9, %xmm9
-; AVX1-NEXT:    vpxor %xmm1, %xmm9, %xmm1
-; AVX1-NEXT:    vpand %xmm7, %xmm4, %xmm4
-; AVX1-NEXT:    vpmullw %xmm4, %xmm0, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vpxor %xmm0, %xmm5, %xmm0
-; AVX1-NEXT:    vpshufb %xmm12, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm1
-; AVX1-NEXT:    vpshufb %xmm1, %xmm8, %xmm1
-; AVX1-NEXT:    vpsrlw $4, %xmm0, %xmm0
-; AVX1-NEXT:    vpand %xmm2, %xmm0, %xmm0
-; AVX1-NEXT:    vpshufb %xmm0, %xmm6, %xmm0
-; AVX1-NEXT:    vpor %xmm0, %xmm1, %xmm0
-; AVX1-NEXT:    vpsrlw $1, %xmm3, %xmm1
+; AVX1-NEXT:    vpand %xmm6, %xmm0, %xmm0
+; AVX1-NEXT:    vpshufb %xmm0, %xmm5, %xmm0
+; AVX1-NEXT:    vpor %xmm0, %xmm2, %xmm0
+; AVX1-NEXT:    vpsrlw $1, %xmm1, %xmm1
 ; AVX1-NEXT:    vpsrlw $1, %xmm0, %xmm0
 ; AVX1-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
 ; AVX1-NEXT:    retq
@@ -2098,76 +1639,59 @@ define <16 x i16> @clmulh_v16i16(<16 x i16> %a, <16 x i16> %b) nounwind {
 ; AVX2:       # %bb.0:
 ; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm2 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14,1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
 ; AVX2-NEXT:    # ymm2 = mem[0,1,0,1]
-; AVX2-NEXT:    vpshufb %ymm2, %ymm0, %ymm4
-; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm0 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX2-NEXT:    vpand %ymm0, %ymm4, %ymm5
+; AVX2-NEXT:    vpshufb %ymm2, %ymm1, %ymm4
+; AVX2-NEXT:    vpbroadcastb {{.*#+}} ymm1 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX2-NEXT:    vpand %ymm1, %ymm4, %ymm5
 ; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
 ; AVX2-NEXT:    # ymm3 = mem[0,1,0,1]
 ; AVX2-NEXT:    vpshufb %ymm5, %ymm3, %ymm5
 ; AVX2-NEXT:    vpsrlw $4, %ymm4, %ymm4
-; AVX2-NEXT:    vpand %ymm0, %ymm4, %ymm6
+; AVX2-NEXT:    vpand %ymm1, %ymm4, %ymm6
 ; AVX2-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
 ; AVX2-NEXT:    # ymm4 = mem[0,1,0,1]
 ; AVX2-NEXT:    vpshufb %ymm6, %ymm4, %ymm6
 ; AVX2-NEXT:    vpor %ymm6, %ymm5, %ymm5
-; AVX2-NEXT:    vpshufb %ymm2, %ymm1, %ymm6
-; AVX2-NEXT:    vpsrlw $4, %ymm6, %ymm1
-; AVX2-NEXT:    vpand %ymm0, %ymm1, %ymm1
-; AVX2-NEXT:    vpshufb %ymm1, %ymm4, %ymm1
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm7
-; AVX2-NEXT:    vpmullw %ymm7, %ymm5, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand %ymm0, %ymm6, %ymm6
-; AVX2-NEXT:    vpshufb %ymm6, %ymm3, %ymm6
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm9
-; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm9
-; AVX2-NEXT:    vpxor %ymm9, %ymm8, %ymm8
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
-; AVX2-NEXT:    vpmullw %ymm1, %ymm5, %ymm1
-; AVX2-NEXT:    vpxor %ymm1, %ymm8, %ymm1
-; AVX2-NEXT:    vpxor %ymm1, %ymm7, %ymm1
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm7
-; AVX2-NEXT:    vpmullw %ymm7, %ymm5, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm8
-; AVX2-NEXT:    vpmullw %ymm5, %ymm8, %ymm8
-; AVX2-NEXT:    vpxor %ymm7, %ymm8, %ymm7
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm6, %ymm6
-; AVX2-NEXT:    vpmullw %ymm6, %ymm5, %ymm5
-; AVX2-NEXT:    vpxor %ymm5, %ymm7, %ymm5
-; AVX2-NEXT:    vpxor %ymm5, %ymm1, %ymm1
-; AVX2-NEXT:    vpshufb %ymm2, %ymm1, %ymm1
-; AVX2-NEXT:    vpand %ymm0, %ymm1, %ymm2
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm6 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX2-NEXT:    vpand %ymm6, %ymm5, %ymm7
+; AVX2-NEXT:    vpshufb %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm1, %ymm0, %ymm8
+; AVX2-NEXT:    vpshufb %ymm8, %ymm3, %ymm8
+; AVX2-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm1, %ymm0, %ymm0
+; AVX2-NEXT:    vpshufb %ymm0, %ymm4, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm8, %ymm0
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm8 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX2-NEXT:    vpand %ymm0, %ymm8, %ymm9
+; AVX2-NEXT:    vpmullw %ymm7, %ymm9, %ymm10
+; AVX2-NEXT:    vpand %ymm5, %ymm8, %ymm11
+; AVX2-NEXT:    vpand %ymm6, %ymm0, %ymm12
+; AVX2-NEXT:    vpmullw %ymm11, %ymm12, %ymm13
+; AVX2-NEXT:    vpxor %ymm10, %ymm13, %ymm10
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm13 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX2-NEXT:    vpand %ymm5, %ymm13, %ymm5
+; AVX2-NEXT:    vpand %ymm0, %ymm13, %ymm0
+; AVX2-NEXT:    vpmullw %ymm5, %ymm0, %ymm14
+; AVX2-NEXT:    vpxor %ymm14, %ymm10, %ymm10
+; AVX2-NEXT:    vpand %ymm8, %ymm10, %ymm8
+; AVX2-NEXT:    vpmullw %ymm5, %ymm9, %ymm10
+; AVX2-NEXT:    vpmullw %ymm7, %ymm12, %ymm14
+; AVX2-NEXT:    vpxor %ymm10, %ymm14, %ymm10
+; AVX2-NEXT:    vpmullw %ymm0, %ymm11, %ymm14
+; AVX2-NEXT:    vpxor %ymm14, %ymm10, %ymm10
+; AVX2-NEXT:    vpand %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpor %ymm6, %ymm8, %ymm6
+; AVX2-NEXT:    vpmullw %ymm11, %ymm9, %ymm8
+; AVX2-NEXT:    vpmullw %ymm5, %ymm12, %ymm5
+; AVX2-NEXT:    vpxor %ymm5, %ymm8, %ymm5
+; AVX2-NEXT:    vpmullw %ymm7, %ymm0, %ymm0
+; AVX2-NEXT:    vpxor %ymm0, %ymm5, %ymm0
+; AVX2-NEXT:    vpand %ymm0, %ymm13, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm6, %ymm0
+; AVX2-NEXT:    vpshufb %ymm2, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm1, %ymm0, %ymm2
 ; AVX2-NEXT:    vpshufb %ymm2, %ymm3, %ymm2
-; AVX2-NEXT:    vpsrlw $4, %ymm1, %ymm1
-; AVX2-NEXT:    vpand %ymm0, %ymm1, %ymm0
+; AVX2-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm1, %ymm0, %ymm0
 ; AVX2-NEXT:    vpshufb %ymm0, %ymm4, %ymm0
 ; AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX2-NEXT:    vpsrlw $1, %ymm0, %ymm0

--- a/llvm/test/CodeGen/X86/clmul-vector-512.ll
+++ b/llvm/test/CodeGen/X86/clmul-vector-512.ll
@@ -3,219 +3,235 @@
 ; RUN: llc < %s -mtriple=x86_64-- -mattr=+avx512vl,+vpclmulqdq | FileCheck %s --check-prefixes=AVX512,AVX512VL
 
 define <64 x i8> @clmul_v64i8(<64 x i8> %a, <64 x i8> %b) nounwind {
-; AVX512-LABEL: clmul_v64i8:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    vextracti64x4 $1, %zmm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm4
-; AVX512-NEXT:    vextracti64x4 $1, %zmm4, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm2, %ymm3
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm6
-; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm6, %zmm6
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} zmm3 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
-; AVX512-NEXT:    vpandn %ymm4, %ymm3, %ymm4
-; AVX512-NEXT:    vpmaddubsw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpsllw $8, %ymm4, %ymm4
-; AVX512-NEXT:    vpandn %ymm5, %ymm3, %ymm5
-; AVX512-NEXT:    vpmaddubsw %ymm5, %ymm2, %ymm5
-; AVX512-NEXT:    vpsllw $8, %ymm5, %ymm5
-; AVX512-NEXT:    vinserti64x4 $1, %ymm5, %zmm4, %zmm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm4 | (zmm6 & zmm3)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm5
-; AVX512-NEXT:    vextracti64x4 $1, %zmm5, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm7
-; AVX512-NEXT:    vpmullw %ymm5, %ymm0, %ymm8
-; AVX512-NEXT:    vinserti64x4 $1, %ymm7, %zmm8, %zmm7
-; AVX512-NEXT:    vpandq %zmm3, %zmm7, %zmm7
-; AVX512-NEXT:    vpandn %ymm5, %ymm3, %ymm5
-; AVX512-NEXT:    vpmaddubsw %ymm5, %ymm0, %ymm5
-; AVX512-NEXT:    vpsllw $8, %ymm5, %ymm5
-; AVX512-NEXT:    vpandn %ymm6, %ymm3, %ymm6
-; AVX512-NEXT:    vpmaddubsw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm5, %zmm5
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm4 ^ (zmm5 | zmm7)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm4
-; AVX512-NEXT:    vextracti64x4 $1, %zmm4, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm7
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm8
-; AVX512-NEXT:    vinserti64x4 $1, %ymm7, %zmm8, %zmm7
-; AVX512-NEXT:    vpandq %zmm3, %zmm7, %zmm7
-; AVX512-NEXT:    vpandn %ymm4, %ymm3, %ymm4
-; AVX512-NEXT:    vpmaddubsw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpsllw $8, %ymm4, %ymm4
-; AVX512-NEXT:    vpandn %ymm6, %ymm3, %ymm6
-; AVX512-NEXT:    vpmaddubsw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm4, %zmm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm5 ^ (zmm4 | zmm7)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm5
-; AVX512-NEXT:    vextracti64x4 $1, %zmm5, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm7
-; AVX512-NEXT:    vpmullw %ymm5, %ymm0, %ymm8
-; AVX512-NEXT:    vinserti64x4 $1, %ymm7, %zmm8, %zmm7
-; AVX512-NEXT:    vpandq %zmm3, %zmm7, %zmm7
-; AVX512-NEXT:    vpandn %ymm5, %ymm3, %ymm5
-; AVX512-NEXT:    vpmaddubsw %ymm5, %ymm0, %ymm5
-; AVX512-NEXT:    vpsllw $8, %ymm5, %ymm5
-; AVX512-NEXT:    vpandn %ymm6, %ymm3, %ymm6
-; AVX512-NEXT:    vpmaddubsw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm5, %zmm5
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm4 ^ (zmm5 | zmm7)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm4
-; AVX512-NEXT:    vextracti64x4 $1, %zmm4, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm7
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm8
-; AVX512-NEXT:    vinserti64x4 $1, %ymm7, %zmm8, %zmm7
-; AVX512-NEXT:    vpandq %zmm3, %zmm7, %zmm7
-; AVX512-NEXT:    vpandn %ymm4, %ymm3, %ymm4
-; AVX512-NEXT:    vpmaddubsw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpsllw $8, %ymm4, %ymm4
-; AVX512-NEXT:    vpandn %ymm6, %ymm3, %ymm6
-; AVX512-NEXT:    vpmaddubsw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm4, %zmm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm5 ^ (zmm4 | zmm7)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm5
-; AVX512-NEXT:    vextracti64x4 $1, %zmm5, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm7
-; AVX512-NEXT:    vpmullw %ymm5, %ymm0, %ymm8
-; AVX512-NEXT:    vinserti64x4 $1, %ymm7, %zmm8, %zmm7
-; AVX512-NEXT:    vpandq %zmm3, %zmm7, %zmm7
-; AVX512-NEXT:    vpandn %ymm5, %ymm3, %ymm5
-; AVX512-NEXT:    vpmaddubsw %ymm5, %ymm0, %ymm5
-; AVX512-NEXT:    vpsllw $8, %ymm5, %ymm5
-; AVX512-NEXT:    vpandn %ymm6, %ymm3, %ymm6
-; AVX512-NEXT:    vpmaddubsw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm5, %zmm5
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm4 ^ (zmm5 | zmm7)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm4
-; AVX512-NEXT:    vextracti64x4 $1, %zmm4, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm7
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm8
-; AVX512-NEXT:    vinserti64x4 $1, %ymm7, %zmm8, %zmm7
-; AVX512-NEXT:    vpandq %zmm3, %zmm7, %zmm7
-; AVX512-NEXT:    vpandn %ymm4, %ymm3, %ymm4
-; AVX512-NEXT:    vpmaddubsw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpsllw $8, %ymm4, %ymm4
-; AVX512-NEXT:    vpandn %ymm6, %ymm3, %ymm6
-; AVX512-NEXT:    vpmaddubsw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm4, %zmm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm5 ^ (zmm4 | zmm7)
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm1
-; AVX512-NEXT:    vextracti64x4 $1, %zmm1, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm2, %ymm6
-; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm7
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm7, %zmm6
-; AVX512-NEXT:    vpandq %zmm3, %zmm6, %zmm6
-; AVX512-NEXT:    vpandn %ymm1, %ymm3, %ymm1
-; AVX512-NEXT:    vpmaddubsw %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpsllw $8, %ymm0, %ymm0
-; AVX512-NEXT:    vpandn %ymm5, %ymm3, %ymm1
-; AVX512-NEXT:    vpmaddubsw %ymm1, %ymm2, %ymm1
-; AVX512-NEXT:    vpsllw $8, %ymm1, %ymm1
-; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm4 ^ (zmm0 | zmm6)
-; AVX512-NEXT:    retq
+; AVX512F-LABEL: clmul_v64i8:
+; AVX512F:       # %bb.0:
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm4 = [1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765]
+; AVX512F-NEXT:    vpandq %zmm4, %zmm1, %zmm2
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm2, %ymm3
+; AVX512F-NEXT:    vpandq %zmm4, %zmm0, %zmm8
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm8, %ymm6
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm6, %ymm4
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm8, %ymm5
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm4, %zmm5, %zmm9
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm4 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
+; AVX512F-NEXT:    vpandn %ymm2, %ymm4, %ymm5
+; AVX512F-NEXT:    vmovdqu %ymm5, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512F-NEXT:    vpmaddubsw %ymm5, %ymm8, %ymm7
+; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm10
+; AVX512F-NEXT:    vpandn %ymm3, %ymm4, %ymm7
+; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm6, %ymm11
+; AVX512F-NEXT:    vpsllw $8, %ymm11, %ymm11
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm11, %zmm10, %zmm10
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm10 = zmm10 | (zmm9 & zmm4)
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm9 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX512F-NEXT:    vpandq %zmm9, %zmm1, %zmm11
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm11, %ymm12
+; AVX512F-NEXT:    vpandq %zmm9, %zmm0, %zmm1
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm1, %ymm0
+; AVX512F-NEXT:    vpmullw %ymm0, %ymm12, %ymm9
+; AVX512F-NEXT:    vpmullw %ymm1, %ymm11, %ymm13
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm9, %zmm13, %zmm9
+; AVX512F-NEXT:    vpandq %zmm4, %zmm9, %zmm9
+; AVX512F-NEXT:    vpandn %ymm11, %ymm4, %ymm13
+; AVX512F-NEXT:    vpmaddubsw %ymm13, %ymm1, %ymm14
+; AVX512F-NEXT:    vpsllw $8, %ymm14, %ymm14
+; AVX512F-NEXT:    vpandn %ymm12, %ymm4, %ymm15
+; AVX512F-NEXT:    vpmaddubsw %ymm15, %ymm0, %ymm5
+; AVX512F-NEXT:    vpsllw $8, %ymm5, %ymm5
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm5, %zmm14, %zmm5
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm10 ^ (zmm5 | zmm9)
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm12, %ymm9
+; AVX512F-NEXT:    vpmullw %ymm11, %ymm8, %ymm10
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm9, %zmm10, %zmm9
+; AVX512F-NEXT:    vpmaddubsw %ymm13, %ymm8, %ymm8
+; AVX512F-NEXT:    vpsllw $8, %ymm8, %ymm8
+; AVX512F-NEXT:    vpmaddubsw %ymm15, %ymm6, %ymm6
+; AVX512F-NEXT:    vpsllw $8, %ymm6, %ymm6
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm6, %zmm8, %zmm6
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm6 = zmm6 | (zmm9 & zmm4)
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm1, %ymm2
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
+; AVX512F-NEXT:    vpandq %zmm4, %zmm2, %zmm2
+; AVX512F-NEXT:    vpmaddubsw {{[-0-9]+}}(%r{{[sb]}}p), %ymm1, %ymm1 # 32-byte Folded Reload
+; AVX512F-NEXT:    vpsllw $8, %ymm1, %ymm1
+; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm0
+; AVX512F-NEXT:    vpsllw $8, %ymm0, %ymm0
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm0, %zmm1, %zmm0
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm6 ^ (zmm0 | zmm2)
+; AVX512F-NEXT:    vpternlogd {{.*#+}} zmm0 = zmm0 ^ (m32bcst & (zmm0 ^ zmm5))
+; AVX512F-NEXT:    retq
+;
+; AVX512VL-LABEL: clmul_v64i8:
+; AVX512VL:       # %bb.0:
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm4 = [1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765]
+; AVX512VL-NEXT:    vpandq %zmm4, %zmm1, %zmm2
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm2, %ymm3
+; AVX512VL-NEXT:    vpandq %zmm4, %zmm0, %zmm7
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm7, %ymm5
+; AVX512VL-NEXT:    vpmullw %ymm3, %ymm5, %ymm4
+; AVX512VL-NEXT:    vpmullw %ymm2, %ymm7, %ymm6
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm4, %zmm6, %zmm8
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm9 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
+; AVX512VL-NEXT:    vpandn %ymm2, %ymm9, %ymm4
+; AVX512VL-NEXT:    vpmaddubsw %ymm4, %ymm7, %ymm6
+; AVX512VL-NEXT:    vmovdqa64 %ymm4, %ymm16
+; AVX512VL-NEXT:    vpsllw $8, %ymm6, %ymm10
+; AVX512VL-NEXT:    vpandn %ymm3, %ymm9, %ymm6
+; AVX512VL-NEXT:    vpmaddubsw %ymm6, %ymm5, %ymm11
+; AVX512VL-NEXT:    vpsllw $8, %ymm11, %ymm11
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm11, %zmm10, %zmm10
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm10 = zmm10 | (zmm8 & zmm9)
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm8 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX512VL-NEXT:    vpandq %zmm8, %zmm1, %zmm11
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm11, %ymm12
+; AVX512VL-NEXT:    vpandq %zmm8, %zmm0, %zmm1
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm1, %ymm0
+; AVX512VL-NEXT:    vpmullw %ymm0, %ymm12, %ymm8
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm11, %ymm13
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm8, %zmm13, %zmm8
+; AVX512VL-NEXT:    vpandq %zmm9, %zmm8, %zmm8
+; AVX512VL-NEXT:    vpandn %ymm11, %ymm9, %ymm13
+; AVX512VL-NEXT:    vpmaddubsw %ymm13, %ymm1, %ymm14
+; AVX512VL-NEXT:    vpsllw $8, %ymm14, %ymm14
+; AVX512VL-NEXT:    vpandn %ymm12, %ymm9, %ymm15
+; AVX512VL-NEXT:    vpmaddubsw %ymm15, %ymm0, %ymm4
+; AVX512VL-NEXT:    vpsllw $8, %ymm4, %ymm4
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm4, %zmm14, %zmm4
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm10 ^ (zmm4 | zmm8)
+; AVX512VL-NEXT:    vpmullw %ymm5, %ymm12, %ymm8
+; AVX512VL-NEXT:    vpmullw %ymm7, %ymm11, %ymm10
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm8, %zmm10, %zmm8
+; AVX512VL-NEXT:    vpmaddubsw %ymm13, %ymm7, %ymm7
+; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm7
+; AVX512VL-NEXT:    vpmaddubsw %ymm15, %ymm5, %ymm5
+; AVX512VL-NEXT:    vpsllw $8, %ymm5, %ymm5
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm5, %zmm7, %zmm5
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm5 | (zmm8 & zmm9)
+; AVX512VL-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
+; AVX512VL-NEXT:    vpmullw %ymm2, %ymm1, %ymm2
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
+; AVX512VL-NEXT:    vpandq %zmm9, %zmm2, %zmm2
+; AVX512VL-NEXT:    vmovdqa64 %ymm16, %ymm3
+; AVX512VL-NEXT:    vpmaddubsw %ymm3, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpsllw $8, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpmaddubsw %ymm6, %ymm0, %ymm0
+; AVX512VL-NEXT:    vpsllw $8, %ymm0, %ymm0
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm0, %zmm1, %zmm0
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm5 ^ (zmm0 | zmm2)
+; AVX512VL-NEXT:    vpternlogd {{.*#+}} zmm0 = zmm0 ^ (m32bcst & (zmm0 ^ zmm4))
+; AVX512VL-NEXT:    retq
   %res = call <64 x i8> @llvm.clmul.v64i8(<64 x i8> %a, <64 x i8> %b)
   ret <64 x i8> %res
 }
 
 define <32 x i16> @clmul_v32i16(<32 x i16> %a, <32 x i16> %b) nounwind {
-; AVX512-LABEL: clmul_v32i16:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    vextracti64x4 $1, %zmm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm3
-; AVX512-NEXT:    vextracti64x4 $1, %zmm3, %ymm4
-; AVX512-NEXT:    vpmullw %ymm4, %ymm2, %ymm4
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vinserti64x4 $1, %ymm4, %zmm3, %zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm4
-; AVX512-NEXT:    vextracti64x4 $1, %zmm4, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm2, %ymm5
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vinserti64x4 $1, %ymm5, %zmm4, %zmm4
-; AVX512-NEXT:    vpxorq %zmm3, %zmm4, %zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm4
-; AVX512-NEXT:    vextracti64x4 $1, %zmm4, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm2, %ymm5
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vinserti64x4 $1, %ymm5, %zmm4, %zmm4
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm5
-; AVX512-NEXT:    vextracti64x4 $1, %zmm5, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpmullw %ymm5, %ymm0, %ymm5
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm5, %zmm5
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm5 ^ zmm3 ^ zmm4
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm3
-; AVX512-NEXT:    vextracti64x4 $1, %zmm3, %ymm4
-; AVX512-NEXT:    vpmullw %ymm4, %ymm2, %ymm4
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vinserti64x4 $1, %ymm4, %zmm3, %zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm4
-; AVX512-NEXT:    vextracti64x4 $1, %zmm4, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm4, %zmm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm4 ^ zmm5 ^ zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm3
-; AVX512-NEXT:    vextracti64x4 $1, %zmm3, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm2, %ymm5
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vinserti64x4 $1, %ymm5, %zmm3, %zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm5
-; AVX512-NEXT:    vextracti64x4 $1, %zmm5, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpmullw %ymm5, %ymm0, %ymm5
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm5, %zmm5
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm5 ^ zmm4 ^ zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm3
-; AVX512-NEXT:    vextracti64x4 $1, %zmm3, %ymm4
-; AVX512-NEXT:    vpmullw %ymm4, %ymm2, %ymm4
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vinserti64x4 $1, %ymm4, %zmm3, %zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm4
-; AVX512-NEXT:    vextracti64x4 $1, %zmm4, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm4, %zmm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm4 ^ zmm5 ^ zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm3
-; AVX512-NEXT:    vextracti64x4 $1, %zmm3, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm2, %ymm5
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vinserti64x4 $1, %ymm5, %zmm3, %zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm5
-; AVX512-NEXT:    vextracti64x4 $1, %zmm5, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpmullw %ymm5, %ymm0, %ymm5
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm5, %zmm5
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm5 ^ zmm4 ^ zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm3
-; AVX512-NEXT:    vextracti64x4 $1, %zmm3, %ymm4
-; AVX512-NEXT:    vpmullw %ymm4, %ymm2, %ymm4
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vinserti64x4 $1, %ymm4, %zmm3, %zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm4
-; AVX512-NEXT:    vextracti64x4 $1, %zmm4, %ymm6
-; AVX512-NEXT:    vpmullw %ymm6, %ymm2, %ymm6
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm4, %zmm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm4 ^ zmm5 ^ zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm3
-; AVX512-NEXT:    vextracti64x4 $1, %zmm3, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm2, %ymm5
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vinserti64x4 $1, %ymm5, %zmm3, %zmm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm1
-; AVX512-NEXT:    vextracti64x4 $1, %zmm1, %ymm5
-; AVX512-NEXT:    vpmullw %ymm5, %ymm2, %ymm2
-; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm0 ^ zmm4 ^ zmm3
-; AVX512-NEXT:    retq
+; AVX512F-LABEL: clmul_v32i16:
+; AVX512F:       # %bb.0:
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm16 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX512F-NEXT:    vpandq %zmm16, %zmm1, %zmm3
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm3, %ymm4
+; AVX512F-NEXT:    vpandq %zmm16, %zmm0, %zmm5
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm5, %ymm6
+; AVX512F-NEXT:    vpmullw %ymm4, %ymm6, %ymm7
+; AVX512F-NEXT:    vmovdqu %ymm4, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm5, %ymm8
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm7, %zmm8, %zmm11
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm17 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX512F-NEXT:    vpandq %zmm17, %zmm1, %zmm8
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm8, %ymm10
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm18 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX512F-NEXT:    vpandq %zmm18, %zmm0, %zmm7
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm7, %ymm9
+; AVX512F-NEXT:    vpmullw %ymm10, %ymm9, %ymm14
+; AVX512F-NEXT:    vpmullw %ymm7, %ymm8, %ymm15
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm14, %zmm15, %zmm14
+; AVX512F-NEXT:    vpandq %zmm18, %zmm1, %zmm1
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm1, %ymm15
+; AVX512F-NEXT:    vpandq %zmm17, %zmm0, %zmm0
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm2
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm15, %ymm12
+; AVX512F-NEXT:    vpmullw %ymm1, %ymm0, %ymm13
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm12, %zmm13, %zmm12
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm12 = zmm12 ^ zmm14 ^ zmm11
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm15, %ymm11
+; AVX512F-NEXT:    vpmullw %ymm1, %ymm5, %ymm13
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm11, %zmm13, %zmm11
+; AVX512F-NEXT:    vpmullw %ymm4, %ymm9, %ymm13
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm7, %ymm14
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm13, %zmm14, %zmm13
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm10, %ymm14
+; AVX512F-NEXT:    vpmullw %ymm0, %ymm8, %ymm4
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm14, %zmm4, %zmm4
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm4 ^ zmm13 ^ zmm11
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm10, %ymm6
+; AVX512F-NEXT:    vpmullw %ymm5, %ymm8, %ymm5
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm6, %zmm5, %zmm5
+; AVX512F-NEXT:    vpmullw %ymm15, %ymm9, %ymm6
+; AVX512F-NEXT:    vpmullw %ymm1, %ymm7, %ymm1
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm6, %zmm1, %zmm1
+; AVX512F-NEXT:    vpxorq %zmm5, %zmm1, %zmm1
+; AVX512F-NEXT:    vpmullw {{[-0-9]+}}(%r{{[sb]}}p), %ymm2, %ymm2 # 32-byte Folded Reload
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm0, %ymm0
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm18 & (zmm0 ^ zmm1)
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm0 | (zmm4 & zmm16)
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm0 | (zmm12 & zmm17)
+; AVX512F-NEXT:    retq
+;
+; AVX512VL-LABEL: clmul_v32i16:
+; AVX512VL:       # %bb.0:
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm16 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX512VL-NEXT:    vpandq %zmm16, %zmm1, %zmm3
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm3, %ymm4
+; AVX512VL-NEXT:    vpandq %zmm16, %zmm0, %zmm5
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm5, %ymm6
+; AVX512VL-NEXT:    vpmullw %ymm4, %ymm6, %ymm7
+; AVX512VL-NEXT:    vpmullw %ymm3, %ymm5, %ymm8
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm7, %zmm8, %zmm11
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm17 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX512VL-NEXT:    vpandq %zmm17, %zmm1, %zmm8
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm8, %ymm10
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm18 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX512VL-NEXT:    vpandq %zmm18, %zmm0, %zmm7
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm7, %ymm9
+; AVX512VL-NEXT:    vpmullw %ymm10, %ymm9, %ymm14
+; AVX512VL-NEXT:    vpmullw %ymm7, %ymm8, %ymm15
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm14, %zmm15, %zmm14
+; AVX512VL-NEXT:    vpandq %zmm18, %zmm1, %zmm1
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm1, %ymm15
+; AVX512VL-NEXT:    vpandq %zmm17, %zmm0, %zmm0
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm0, %ymm2
+; AVX512VL-NEXT:    vpmullw %ymm2, %ymm15, %ymm12
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm0, %ymm13
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm12, %zmm13, %zmm12
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm12 = zmm12 ^ zmm14 ^ zmm11
+; AVX512VL-NEXT:    vpmullw %ymm6, %ymm15, %ymm11
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm5, %ymm13
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm11, %zmm13, %zmm11
+; AVX512VL-NEXT:    vpmullw %ymm4, %ymm9, %ymm13
+; AVX512VL-NEXT:    vmovdqa64 %ymm4, %ymm19
+; AVX512VL-NEXT:    vpmullw %ymm3, %ymm7, %ymm14
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm13, %zmm14, %zmm13
+; AVX512VL-NEXT:    vpmullw %ymm2, %ymm10, %ymm14
+; AVX512VL-NEXT:    vpmullw %ymm0, %ymm8, %ymm4
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm14, %zmm4, %zmm4
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm4 ^ zmm13 ^ zmm11
+; AVX512VL-NEXT:    vpmullw %ymm6, %ymm10, %ymm6
+; AVX512VL-NEXT:    vpmullw %ymm5, %ymm8, %ymm5
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm6, %zmm5, %zmm5
+; AVX512VL-NEXT:    vpmullw %ymm15, %ymm9, %ymm6
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm7, %ymm1
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm6, %zmm1, %zmm1
+; AVX512VL-NEXT:    vpxorq %zmm5, %zmm1, %zmm1
+; AVX512VL-NEXT:    vmovdqa64 %ymm19, %ymm5
+; AVX512VL-NEXT:    vpmullw %ymm5, %ymm2, %ymm2
+; AVX512VL-NEXT:    vpmullw %ymm3, %ymm0, %ymm0
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm18 & (zmm0 ^ zmm1)
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm0 | (zmm4 & zmm16)
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm0 | (zmm12 & zmm17)
+; AVX512VL-NEXT:    retq
   %res = call <32 x i16> @llvm.clmul.v32i16(<32 x i16> %a, <32 x i16> %b)
   ret <32 x i16> %res
 }
@@ -303,188 +319,117 @@ define <8 x i64> @clmul_v8i64(<8 x i64> %a, <8 x i64> %b) nounwind {
 define <64 x i8> @clmulr_v64i8(<64 x i8> %a, <64 x i8> %b) nounwind {
 ; AVX512F-LABEL: clmulr_v64i8:
 ; AVX512F:       # %bb.0:
-; AVX512F-NEXT:    vmovdqa64 %zmm1, %zmm4
-; AVX512F-NEXT:    vmovdqa64 %zmm0, %zmm1
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm3
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX512F-NEXT:    vpand %ymm2, %ymm3, %ymm5
-; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
-; AVX512F-NEXT:    # ymm0 = mem[0,1,0,1]
-; AVX512F-NEXT:    vpshufb %ymm5, %ymm0, %ymm5
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm1, %ymm3
+; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm4 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX512F-NEXT:    vpand %ymm4, %ymm3, %ymm5
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm12 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX512F-NEXT:    # ymm12 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm5, %ymm12, %ymm5
 ; AVX512F-NEXT:    vpsrlw $4, %ymm3, %ymm3
-; AVX512F-NEXT:    vpand %ymm2, %ymm3, %ymm6
+; AVX512F-NEXT:    vpand %ymm4, %ymm3, %ymm6
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm2 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX512F-NEXT:    # ymm2 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm6, %ymm2, %ymm6
+; AVX512F-NEXT:    vpor %ymm6, %ymm5, %ymm11
+; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm10 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX512F-NEXT:    vpand %ymm10, %ymm11, %ymm6
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm5
+; AVX512F-NEXT:    vpand %ymm4, %ymm5, %ymm7
+; AVX512F-NEXT:    vpshufb %ymm7, %ymm12, %ymm7
+; AVX512F-NEXT:    vpsrlw $4, %ymm5, %ymm5
+; AVX512F-NEXT:    vpand %ymm4, %ymm5, %ymm5
+; AVX512F-NEXT:    vpshufb %ymm5, %ymm2, %ymm5
+; AVX512F-NEXT:    vpor %ymm5, %ymm7, %ymm13
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm3 = [1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765]
+; AVX512F-NEXT:    vpand %ymm3, %ymm13, %ymm7
+; AVX512F-NEXT:    vmovdqa64 %zmm3, %zmm5
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm7, %ymm8
+; AVX512F-NEXT:    vpand %ymm4, %ymm1, %ymm9
+; AVX512F-NEXT:    vpshufb %ymm9, %ymm12, %ymm9
+; AVX512F-NEXT:    vpsrlw $4, %ymm1, %ymm1
+; AVX512F-NEXT:    vpand %ymm4, %ymm1, %ymm1
+; AVX512F-NEXT:    vmovdqa %ymm2, %ymm3
+; AVX512F-NEXT:    vpshufb %ymm1, %ymm2, %ymm1
+; AVX512F-NEXT:    vpor %ymm1, %ymm9, %ymm14
+; AVX512F-NEXT:    vpand %ymm10, %ymm14, %ymm2
+; AVX512F-NEXT:    vpand %ymm4, %ymm0, %ymm9
+; AVX512F-NEXT:    vpshufb %ymm9, %ymm12, %ymm9
+; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX512F-NEXT:    vpand %ymm4, %ymm0, %ymm0
+; AVX512F-NEXT:    vpshufb %ymm0, %ymm3, %ymm0
+; AVX512F-NEXT:    vpor %ymm0, %ymm9, %ymm15
+; AVX512F-NEXT:    vpand %ymm5, %ymm15, %ymm12
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm12, %ymm0
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm8, %zmm0, %zmm16
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm1 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
+; AVX512F-NEXT:    vpandn %ymm2, %ymm1, %ymm0
+; AVX512F-NEXT:    vmovdqu %ymm0, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512F-NEXT:    vpmaddubsw %ymm0, %ymm12, %ymm9
+; AVX512F-NEXT:    vpsllw $8, %ymm9, %ymm0
+; AVX512F-NEXT:    vpandn %ymm6, %ymm1, %ymm9
+; AVX512F-NEXT:    vpmaddubsw %ymm9, %ymm7, %ymm3
+; AVX512F-NEXT:    vpsllw $8, %ymm3, %ymm3
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm3, %zmm0, %zmm0
+; AVX512F-NEXT:    vpand %ymm5, %ymm11, %ymm3
+; AVX512F-NEXT:    vpand %ymm10, %ymm13, %ymm11
+; AVX512F-NEXT:    vpand %ymm10, %ymm15, %ymm10
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm11, %ymm13
+; AVX512F-NEXT:    vpand %ymm5, %ymm14, %ymm14
+; AVX512F-NEXT:    vpmullw %ymm14, %ymm10, %ymm15
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm13, %zmm15, %zmm17
+; AVX512F-NEXT:    vpandn %ymm14, %ymm1, %ymm15
+; AVX512F-NEXT:    vpmaddubsw %ymm15, %ymm10, %ymm5
+; AVX512F-NEXT:    vpsllw $8, %ymm5, %ymm5
+; AVX512F-NEXT:    vpandn %ymm3, %ymm1, %ymm13
+; AVX512F-NEXT:    vpmaddubsw %ymm13, %ymm11, %ymm8
+; AVX512F-NEXT:    vpsllw $8, %ymm8, %ymm8
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm8, %zmm5, %zmm5
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm7, %ymm3
+; AVX512F-NEXT:    vpmullw %ymm14, %ymm12, %ymm8
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm3, %zmm8, %zmm3
+; AVX512F-NEXT:    vpmaddubsw %ymm15, %ymm12, %ymm8
+; AVX512F-NEXT:    vpmaddubsw %ymm13, %ymm7, %ymm7
+; AVX512F-NEXT:    vpsllw $8, %ymm8, %ymm8
+; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm7, %zmm8, %zmm7
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm11, %ymm6
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm10, %ymm2
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm6, %zmm2, %zmm2
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm0 | (zmm16 & zmm1)
+; AVX512F-NEXT:    vpandq %zmm1, %zmm17, %zmm6
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm7 = zmm7 | (zmm3 & zmm1)
+; AVX512F-NEXT:    vpandq %zmm1, %zmm2, %zmm1
+; AVX512F-NEXT:    vpmaddubsw {{[-0-9]+}}(%r{{[sb]}}p), %ymm10, %ymm2 # 32-byte Folded Reload
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm0 ^ (zmm5 | zmm6)
+; AVX512F-NEXT:    vpsllw $8, %ymm2, %ymm0
+; AVX512F-NEXT:    vpmaddubsw %ymm9, %ymm11, %ymm2
+; AVX512F-NEXT:    vpsllw $8, %ymm2, %ymm2
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm7 ^ (zmm0 | zmm1)
+; AVX512F-NEXT:    vpternlogd {{.*#+}} zmm0 = zmm5 ^ (m32bcst & (zmm0 ^ zmm5))
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
+; AVX512F-NEXT:    vpand %ymm4, %ymm1, %ymm2
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm5 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX512F-NEXT:    # ymm5 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm5, %ymm2
+; AVX512F-NEXT:    vpand %ymm4, %ymm0, %ymm3
+; AVX512F-NEXT:    vpshufb %ymm3, %ymm5, %ymm3
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm2, %zmm3, %zmm2
+; AVX512F-NEXT:    vpsrlw $4, %ymm1, %ymm1
+; AVX512F-NEXT:    vpand %ymm4, %ymm1, %ymm1
+; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX512F-NEXT:    vpand %ymm4, %ymm0, %ymm0
 ; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
 ; AVX512F-NEXT:    # ymm3 = mem[0,1,0,1]
-; AVX512F-NEXT:    vpshufb %ymm6, %ymm3, %ymm6
-; AVX512F-NEXT:    vpor %ymm6, %ymm5, %ymm9
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm4, %ymm11
-; AVX512F-NEXT:    vpsrlw $4, %ymm11, %ymm5
-; AVX512F-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX512F-NEXT:    vpshufb %ymm5, %ymm3, %ymm12
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm12, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm9, %ymm8
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm5 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
-; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512F-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm9, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512F-NEXT:    vpor %ymm7, %ymm8, %ymm8
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm12, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm10, %ymm9, %ymm13
-; AVX512F-NEXT:    vpand %ymm5, %ymm13, %ymm13
-; AVX512F-NEXT:    vpandn %ymm10, %ymm5, %ymm10
-; AVX512F-NEXT:    vpmaddubsw %ymm10, %ymm9, %ymm10
-; AVX512F-NEXT:    vpsllw $8, %ymm10, %ymm10
-; AVX512F-NEXT:    vpor %ymm10, %ymm13, %ymm10
-; AVX512F-NEXT:    vpxor %ymm8, %ymm10, %ymm13
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm8 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; AVX512F-NEXT:    vpand %ymm8, %ymm12, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm10, %ymm9, %ymm14
-; AVX512F-NEXT:    vpand %ymm5, %ymm14, %ymm14
-; AVX512F-NEXT:    vpandn %ymm10, %ymm5, %ymm10
-; AVX512F-NEXT:    vpmaddubsw %ymm10, %ymm9, %ymm10
-; AVX512F-NEXT:    vpsllw $8, %ymm10, %ymm10
-; AVX512F-NEXT:    vpor %ymm10, %ymm14, %ymm14
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm12, %ymm12
-; AVX512F-NEXT:    vpmullw %ymm12, %ymm9, %ymm15
-; AVX512F-NEXT:    vpand %ymm5, %ymm15, %ymm15
-; AVX512F-NEXT:    vpandn %ymm12, %ymm5, %ymm12
-; AVX512F-NEXT:    vpmaddubsw %ymm12, %ymm9, %ymm12
-; AVX512F-NEXT:    vpsllw $8, %ymm12, %ymm12
-; AVX512F-NEXT:    vpor %ymm12, %ymm15, %ymm12
-; AVX512F-NEXT:    vpxor %ymm12, %ymm14, %ymm12
-; AVX512F-NEXT:    vpxor %ymm12, %ymm13, %ymm14
-; AVX512F-NEXT:    vpand %ymm2, %ymm11, %ymm11
-; AVX512F-NEXT:    vmovdqa %ymm0, %ymm10
-; AVX512F-NEXT:    vpshufb %ymm11, %ymm0, %ymm15
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm11 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; AVX512F-NEXT:    vpand %ymm11, %ymm15, %ymm12
-; AVX512F-NEXT:    vpmullw %ymm12, %ymm9, %ymm13
-; AVX512F-NEXT:    vpand %ymm5, %ymm13, %ymm13
-; AVX512F-NEXT:    vpandn %ymm12, %ymm5, %ymm12
-; AVX512F-NEXT:    vpmaddubsw %ymm12, %ymm9, %ymm12
-; AVX512F-NEXT:    vpsllw $8, %ymm12, %ymm12
-; AVX512F-NEXT:    vpor %ymm12, %ymm13, %ymm13
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm12 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; AVX512F-NEXT:    vpand %ymm12, %ymm15, %ymm0
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm9, %ymm6
-; AVX512F-NEXT:    vpand %ymm5, %ymm6, %ymm6
-; AVX512F-NEXT:    vpandn %ymm0, %ymm5, %ymm0
-; AVX512F-NEXT:    vpmaddubsw %ymm0, %ymm9, %ymm0
-; AVX512F-NEXT:    vpsllw $8, %ymm0, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm6, %ymm0
-; AVX512F-NEXT:    vpxor %ymm0, %ymm13, %ymm0
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm13 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; AVX512F-NEXT:    vpand %ymm13, %ymm15, %ymm6
-; AVX512F-NEXT:    vpmullw %ymm6, %ymm9, %ymm7
-; AVX512F-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX512F-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512F-NEXT:    vpmaddubsw %ymm6, %ymm9, %ymm6
-; AVX512F-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512F-NEXT:    vpor %ymm6, %ymm7, %ymm6
-; AVX512F-NEXT:    vpxor %ymm6, %ymm0, %ymm0
-; AVX512F-NEXT:    vpxor %ymm0, %ymm14, %ymm0
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm14 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-; AVX512F-NEXT:    vpand %ymm14, %ymm15, %ymm6
-; AVX512F-NEXT:    vpmullw %ymm6, %ymm9, %ymm7
-; AVX512F-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512F-NEXT:    vpmaddubsw %ymm6, %ymm9, %ymm6
-; AVX512F-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512F-NEXT:    vpor %ymm6, %ymm7, %ymm6
-; AVX512F-NEXT:    vpxor %ymm6, %ymm0, %ymm9
-; AVX512F-NEXT:    vpand %ymm2, %ymm1, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm0, %ymm10, %ymm0
-; AVX512F-NEXT:    vpsrlw $4, %ymm1, %ymm1
-; AVX512F-NEXT:    vpand %ymm2, %ymm1, %ymm1
 ; AVX512F-NEXT:    vpshufb %ymm1, %ymm3, %ymm1
-; AVX512F-NEXT:    vpor %ymm1, %ymm0, %ymm0
-; AVX512F-NEXT:    vpsrlw $4, %ymm4, %ymm1
-; AVX512F-NEXT:    vpand %ymm2, %ymm1, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm3, %ymm1
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm6
-; AVX512F-NEXT:    vpmullw %ymm6, %ymm0, %ymm7
-; AVX512F-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX512F-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512F-NEXT:    vpmaddubsw %ymm6, %ymm0, %ymm6
-; AVX512F-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512F-NEXT:    vpor %ymm6, %ymm7, %ymm6
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm0, %ymm15
-; AVX512F-NEXT:    vpand %ymm5, %ymm15, %ymm15
-; AVX512F-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512F-NEXT:    vpor %ymm7, %ymm15, %ymm7
-; AVX512F-NEXT:    vpxor %ymm6, %ymm7, %ymm6
-; AVX512F-NEXT:    vpand %ymm1, %ymm8, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm0, %ymm8
-; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512F-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512F-NEXT:    vpor %ymm7, %ymm8, %ymm7
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm0, %ymm8
-; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512F-NEXT:    vpandn %ymm1, %ymm5, %ymm1
-; AVX512F-NEXT:    vpmaddubsw %ymm1, %ymm0, %ymm1
-; AVX512F-NEXT:    vpsllw $8, %ymm1, %ymm1
-; AVX512F-NEXT:    vpor %ymm1, %ymm8, %ymm1
-; AVX512F-NEXT:    vpxor %ymm1, %ymm7, %ymm1
-; AVX512F-NEXT:    vpxor %ymm1, %ymm6, %ymm1
-; AVX512F-NEXT:    vpand %ymm2, %ymm4, %ymm4
-; AVX512F-NEXT:    vpshufb %ymm4, %ymm10, %ymm4
-; AVX512F-NEXT:    vpand %ymm4, %ymm11, %ymm6
-; AVX512F-NEXT:    vpmullw %ymm6, %ymm0, %ymm7
-; AVX512F-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX512F-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512F-NEXT:    vpmaddubsw %ymm6, %ymm0, %ymm6
-; AVX512F-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512F-NEXT:    vpor %ymm6, %ymm7, %ymm6
-; AVX512F-NEXT:    vpand %ymm4, %ymm12, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm0, %ymm8
-; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512F-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512F-NEXT:    vpor %ymm7, %ymm8, %ymm7
-; AVX512F-NEXT:    vpxor %ymm7, %ymm6, %ymm6
-; AVX512F-NEXT:    vpand %ymm4, %ymm13, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm0, %ymm8
-; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512F-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512F-NEXT:    vpor %ymm7, %ymm8, %ymm7
-; AVX512F-NEXT:    vpxor %ymm7, %ymm6, %ymm6
-; AVX512F-NEXT:    vpxor %ymm6, %ymm1, %ymm1
-; AVX512F-NEXT:    vpand %ymm4, %ymm14, %ymm4
-; AVX512F-NEXT:    vpmullw %ymm4, %ymm0, %ymm6
-; AVX512F-NEXT:    vpand %ymm5, %ymm6, %ymm6
-; AVX512F-NEXT:    vpandn %ymm4, %ymm5, %ymm4
-; AVX512F-NEXT:    vpmaddubsw %ymm4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpsllw $8, %ymm0, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm6, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm9, %ymm4
-; AVX512F-NEXT:    vpshufb %ymm4, %ymm10, %ymm4
-; AVX512F-NEXT:    vpxor %ymm0, %ymm1, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm10, %ymm1
-; AVX512F-NEXT:    vinserti64x4 $1, %ymm4, %zmm1, %zmm1
-; AVX512F-NEXT:    vpsrlw $4, %ymm9, %ymm4
-; AVX512F-NEXT:    vpand %ymm2, %ymm4, %ymm4
-; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm4, %ymm3, %ymm2
 ; AVX512F-NEXT:    vpshufb %ymm0, %ymm3, %ymm0
-; AVX512F-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512F-NEXT:    vporq %zmm0, %zmm1, %zmm0
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
+; AVX512F-NEXT:    vporq %zmm0, %zmm2, %zmm0
 ; AVX512F-NEXT:    retq
 ;
 ; AVX512VL-LABEL: clmulr_v64i8:
 ; AVX512VL:       # %bb.0:
-; AVX512VL-NEXT:    vextracti64x4 $1, %zmm0, %ymm3
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm1, %ymm3
 ; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
 ; AVX512VL-NEXT:    vpand %ymm2, %ymm3, %ymm5
 ; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
@@ -495,155 +440,99 @@ define <64 x i8> @clmulr_v64i8(<64 x i8> %a, <64 x i8> %b) nounwind {
 ; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
 ; AVX512VL-NEXT:    # ymm3 = mem[0,1,0,1]
 ; AVX512VL-NEXT:    vpshufb %ymm6, %ymm3, %ymm6
-; AVX512VL-NEXT:    vpor %ymm6, %ymm5, %ymm8
-; AVX512VL-NEXT:    vextracti64x4 $1, %zmm1, %ymm11
-; AVX512VL-NEXT:    vpsrlw $4, %ymm11, %ymm5
+; AVX512VL-NEXT:    vpor %ymm6, %ymm5, %ymm10
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm11 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX512VL-NEXT:    vpand %ymm11, %ymm10, %ymm6
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm0, %ymm5
+; AVX512VL-NEXT:    vpand %ymm2, %ymm5, %ymm7
+; AVX512VL-NEXT:    vpshufb %ymm7, %ymm4, %ymm7
+; AVX512VL-NEXT:    vpsrlw $4, %ymm5, %ymm5
 ; AVX512VL-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX512VL-NEXT:    vpshufb %ymm5, %ymm3, %ymm12
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm16 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-; AVX512VL-NEXT:    vpandq %ymm16, %ymm12, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm8, %ymm9
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm5 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm8, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm10
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm10 = ymm10 | (ymm9 & ymm5)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm17 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; AVX512VL-NEXT:    vpandq %ymm17, %ymm12, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm9, %ymm8, %ymm13
-; AVX512VL-NEXT:    vpand %ymm5, %ymm13, %ymm13
-; AVX512VL-NEXT:    vpandn %ymm9, %ymm5, %ymm9
-; AVX512VL-NEXT:    vpmaddubsw %ymm9, %ymm8, %ymm9
-; AVX512VL-NEXT:    vpsllw $8, %ymm9, %ymm14
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm14 = ymm10 ^ (ymm14 | ymm13)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm18 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; AVX512VL-NEXT:    vpandq %ymm18, %ymm12, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm10, %ymm8, %ymm13
-; AVX512VL-NEXT:    vpand %ymm5, %ymm13, %ymm13
-; AVX512VL-NEXT:    vpandn %ymm10, %ymm5, %ymm10
-; AVX512VL-NEXT:    vpmaddubsw %ymm10, %ymm8, %ymm10
-; AVX512VL-NEXT:    vpsllw $8, %ymm10, %ymm15
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm15 = ymm14 ^ (ymm15 | ymm13)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm19 = [8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8]
-; AVX512VL-NEXT:    vpandq %ymm19, %ymm12, %ymm12
-; AVX512VL-NEXT:    vpmullw %ymm12, %ymm8, %ymm13
-; AVX512VL-NEXT:    vpand %ymm5, %ymm13, %ymm13
-; AVX512VL-NEXT:    vpandn %ymm12, %ymm5, %ymm12
-; AVX512VL-NEXT:    vpmaddubsw %ymm12, %ymm8, %ymm12
-; AVX512VL-NEXT:    vpsllw $8, %ymm12, %ymm12
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm12 = ymm15 ^ (ymm12 | ymm13)
-; AVX512VL-NEXT:    vpand %ymm2, %ymm11, %ymm11
-; AVX512VL-NEXT:    vpshufb %ymm11, %ymm4, %ymm14
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm11 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; AVX512VL-NEXT:    vpand %ymm11, %ymm14, %ymm13
-; AVX512VL-NEXT:    vpmullw %ymm13, %ymm8, %ymm15
-; AVX512VL-NEXT:    vpand %ymm5, %ymm15, %ymm15
-; AVX512VL-NEXT:    vpandn %ymm13, %ymm5, %ymm13
-; AVX512VL-NEXT:    vpmaddubsw %ymm13, %ymm8, %ymm13
-; AVX512VL-NEXT:    vpsllw $8, %ymm13, %ymm13
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm13 = ymm12 ^ (ymm13 | ymm15)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm12 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; AVX512VL-NEXT:    vpand %ymm12, %ymm14, %ymm15
-; AVX512VL-NEXT:    vpmullw %ymm15, %ymm8, %ymm6
-; AVX512VL-NEXT:    vpand %ymm5, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpandn %ymm15, %ymm5, %ymm15
-; AVX512VL-NEXT:    vpmaddubsw %ymm15, %ymm8, %ymm15
-; AVX512VL-NEXT:    vpsllw $8, %ymm15, %ymm15
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm15 = ymm13 ^ (ymm15 | ymm6)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm13 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; AVX512VL-NEXT:    vpand %ymm13, %ymm14, %ymm6
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm8, %ymm7
-; AVX512VL-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512VL-NEXT:    vpmaddubsw %ymm6, %ymm8, %ymm6
-; AVX512VL-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm6 = ymm15 ^ (ymm6 | ymm7)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm15 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-; AVX512VL-NEXT:    vpand %ymm15, %ymm14, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm8, %ymm14
-; AVX512VL-NEXT:    vpand %ymm5, %ymm14, %ymm14
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm8, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm8
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm8 = ymm6 ^ (ymm8 | ymm14)
-; AVX512VL-NEXT:    vpand %ymm2, %ymm8, %ymm6
-; AVX512VL-NEXT:    vpshufb %ymm6, %ymm4, %ymm14
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm6
-; AVX512VL-NEXT:    vpshufb %ymm6, %ymm4, %ymm6
-; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpshufb %ymm0, %ymm3, %ymm0
-; AVX512VL-NEXT:    vpor %ymm0, %ymm6, %ymm0
-; AVX512VL-NEXT:    vpsrlw $4, %ymm1, %ymm6
-; AVX512VL-NEXT:    vpand %ymm2, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpshufb %ymm6, %ymm3, %ymm6
-; AVX512VL-NEXT:    vpandq %ymm16, %ymm6, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm0, %ymm9
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm7 | (ymm9 & ymm5)
-; AVX512VL-NEXT:    vpandq %ymm17, %ymm6, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm10
-; AVX512VL-NEXT:    vpand %ymm5, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpandn %ymm9, %ymm5, %ymm9
-; AVX512VL-NEXT:    vpmaddubsw %ymm9, %ymm0, %ymm9
-; AVX512VL-NEXT:    vpsllw $8, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm9 = ymm7 ^ (ymm9 | ymm10)
-; AVX512VL-NEXT:    vpandq %ymm18, %ymm6, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm0, %ymm10
-; AVX512VL-NEXT:    vpand %ymm5, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm9 ^ (ymm7 | ymm10)
-; AVX512VL-NEXT:    vpandq %ymm19, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm0, %ymm9
-; AVX512VL-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512VL-NEXT:    vpmaddubsw %ymm6, %ymm0, %ymm6
-; AVX512VL-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm6 = ymm7 ^ (ymm6 | ymm9)
+; AVX512VL-NEXT:    vpshufb %ymm5, %ymm3, %ymm5
+; AVX512VL-NEXT:    vpor %ymm5, %ymm7, %ymm12
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm17 = [1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765]
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm12, %ymm7
+; AVX512VL-NEXT:    vpmullw %ymm6, %ymm7, %ymm8
+; AVX512VL-NEXT:    vpand %ymm2, %ymm1, %ymm9
+; AVX512VL-NEXT:    vpshufb %ymm9, %ymm4, %ymm9
+; AVX512VL-NEXT:    vpsrlw $4, %ymm1, %ymm1
 ; AVX512VL-NEXT:    vpand %ymm2, %ymm1, %ymm1
-; AVX512VL-NEXT:    vpshufb %ymm1, %ymm4, %ymm1
-; AVX512VL-NEXT:    vpand %ymm1, %ymm11, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm0, %ymm9
-; AVX512VL-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm6 ^ (ymm7 | ymm9)
-; AVX512VL-NEXT:    vpand %ymm1, %ymm12, %ymm6
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm0, %ymm9
-; AVX512VL-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512VL-NEXT:    vpmaddubsw %ymm6, %ymm0, %ymm6
-; AVX512VL-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm6 = ymm7 ^ (ymm6 | ymm9)
-; AVX512VL-NEXT:    vpand %ymm1, %ymm13, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm0, %ymm9
-; AVX512VL-NEXT:    vpand %ymm5, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm6 ^ (ymm7 | ymm9)
-; AVX512VL-NEXT:    vpand %ymm1, %ymm15, %ymm1
-; AVX512VL-NEXT:    vpmullw %ymm1, %ymm0, %ymm6
-; AVX512VL-NEXT:    vpand %ymm5, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpandn %ymm1, %ymm5, %ymm1
-; AVX512VL-NEXT:    vpmaddubsw %ymm1, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpsllw $8, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm7 ^ (ymm0 | ymm6)
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm1
-; AVX512VL-NEXT:    vpshufb %ymm1, %ymm4, %ymm1
-; AVX512VL-NEXT:    vinserti64x4 $1, %ymm14, %zmm1, %zmm1
-; AVX512VL-NEXT:    vpsrlw $4, %ymm8, %ymm4
-; AVX512VL-NEXT:    vpand %ymm2, %ymm4, %ymm4
-; AVX512VL-NEXT:    vpshufb %ymm4, %ymm3, %ymm4
+; AVX512VL-NEXT:    vpshufb %ymm1, %ymm3, %ymm1
+; AVX512VL-NEXT:    vpor %ymm1, %ymm9, %ymm13
+; AVX512VL-NEXT:    vpand %ymm11, %ymm13, %ymm1
+; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm9
+; AVX512VL-NEXT:    vpshufb %ymm9, %ymm4, %ymm9
+; AVX512VL-NEXT:    vmovdqa64 %ymm4, %ymm19
 ; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm0
 ; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm0
 ; AVX512VL-NEXT:    vpshufb %ymm0, %ymm3, %ymm0
-; AVX512VL-NEXT:    vinserti64x4 $1, %ymm4, %zmm0, %zmm0
+; AVX512VL-NEXT:    vmovdqa64 %ymm3, %ymm18
+; AVX512VL-NEXT:    vpor %ymm0, %ymm9, %ymm14
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm14, %ymm9
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm9, %ymm0
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm8, %zmm0, %zmm15
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm16 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
+; AVX512VL-NEXT:    vpandnq %ymm1, %ymm16, %ymm4
+; AVX512VL-NEXT:    vpmaddubsw %ymm4, %ymm9, %ymm8
+; AVX512VL-NEXT:    vpsllw $8, %ymm8, %ymm5
+; AVX512VL-NEXT:    vpandnq %ymm6, %ymm16, %ymm8
+; AVX512VL-NEXT:    vmovdqa64 %ymm6, %ymm20
+; AVX512VL-NEXT:    vpmaddubsw %ymm8, %ymm7, %ymm3
+; AVX512VL-NEXT:    vpsllw $8, %ymm3, %ymm3
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm3, %zmm5, %zmm3
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm3 = zmm3 | (zmm15 & zmm16)
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm10, %ymm5
+; AVX512VL-NEXT:    vpand %ymm11, %ymm12, %ymm10
+; AVX512VL-NEXT:    vpmullw %ymm5, %ymm10, %ymm12
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm13, %ymm13
+; AVX512VL-NEXT:    vpand %ymm11, %ymm14, %ymm11
+; AVX512VL-NEXT:    vpmullw %ymm13, %ymm11, %ymm14
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm12, %zmm14, %zmm12
+; AVX512VL-NEXT:    vpandq %zmm16, %zmm12, %zmm12
+; AVX512VL-NEXT:    vpandnq %ymm13, %ymm16, %ymm14
+; AVX512VL-NEXT:    vpmaddubsw %ymm14, %ymm11, %ymm15
+; AVX512VL-NEXT:    vpsllw $8, %ymm15, %ymm15
+; AVX512VL-NEXT:    vpandnq %ymm5, %ymm16, %ymm0
+; AVX512VL-NEXT:    vpmaddubsw %ymm0, %ymm10, %ymm6
+; AVX512VL-NEXT:    vpsllw $8, %ymm6, %ymm6
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm6, %zmm15, %zmm6
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm6 = zmm3 ^ (zmm6 | zmm12)
+; AVX512VL-NEXT:    vpmullw %ymm5, %ymm7, %ymm3
+; AVX512VL-NEXT:    vpmullw %ymm13, %ymm9, %ymm5
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm3, %zmm5, %zmm3
+; AVX512VL-NEXT:    vpmaddubsw %ymm14, %ymm9, %ymm5
+; AVX512VL-NEXT:    vpsllw $8, %ymm5, %ymm5
+; AVX512VL-NEXT:    vpmaddubsw %ymm0, %ymm7, %ymm0
+; AVX512VL-NEXT:    vpsllw $8, %ymm0, %ymm0
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm0, %zmm5, %zmm0
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm0 | (zmm3 & zmm16)
+; AVX512VL-NEXT:    vmovdqa64 %ymm20, %ymm3
+; AVX512VL-NEXT:    vpmullw %ymm3, %ymm10, %ymm3
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm11, %ymm1
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm3, %zmm1, %zmm1
+; AVX512VL-NEXT:    vpandq %zmm16, %zmm1, %zmm1
+; AVX512VL-NEXT:    vpmaddubsw %ymm4, %ymm11, %ymm3
+; AVX512VL-NEXT:    vpsllw $8, %ymm3, %ymm3
+; AVX512VL-NEXT:    vpmaddubsw %ymm8, %ymm10, %ymm4
+; AVX512VL-NEXT:    vpsllw $8, %ymm4, %ymm4
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm4, %zmm3, %zmm3
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm3 = zmm0 ^ (zmm3 | zmm1)
+; AVX512VL-NEXT:    vpternlogd {{.*#+}} zmm3 = zmm6 ^ (zmm17 & (zmm3 ^ zmm6))
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm3, %ymm0
+; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm1
+; AVX512VL-NEXT:    vmovdqa64 %ymm19, %ymm5
+; AVX512VL-NEXT:    vpshufb %ymm1, %ymm5, %ymm1
+; AVX512VL-NEXT:    vpand %ymm2, %ymm3, %ymm4
+; AVX512VL-NEXT:    vpshufb %ymm4, %ymm5, %ymm4
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm1, %zmm4, %zmm1
+; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm0
+; AVX512VL-NEXT:    vmovdqa64 %ymm18, %ymm4
+; AVX512VL-NEXT:    vpshufb %ymm0, %ymm4, %ymm0
+; AVX512VL-NEXT:    vpsrlw $4, %ymm3, %ymm3
+; AVX512VL-NEXT:    vpand %ymm2, %ymm3, %ymm2
+; AVX512VL-NEXT:    vpshufb %ymm2, %ymm4, %ymm2
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm0, %zmm2, %zmm0
 ; AVX512VL-NEXT:    vporq %zmm0, %zmm1, %zmm0
 ; AVX512VL-NEXT:    retq
   %a.ext = zext <64 x i8> %a to <64 x i16>
@@ -657,308 +546,230 @@ define <64 x i8> @clmulr_v64i8(<64 x i8> %a, <64 x i8> %b) nounwind {
 define <32 x i16> @clmulr_v32i16(<32 x i16> %a, <32 x i16> %b) nounwind {
 ; AVX512F-LABEL: clmulr_v32i16:
 ; AVX512F:       # %bb.0:
-; AVX512F-NEXT:    vmovdqa64 %zmm1, %zmm4
-; AVX512F-NEXT:    vmovdqa64 %zmm0, %zmm3
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm0
-; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm8 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14,1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
-; AVX512F-NEXT:    # ymm8 = mem[0,1,0,1]
-; AVX512F-NEXT:    vpshufb %ymm8, %ymm0, %ymm0
+; AVX512F-NEXT:    vmovdqa64 %zmm0, %zmm13
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm1, %ymm2
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14,1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
+; AVX512F-NEXT:    # ymm0 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm0, %ymm2, %ymm3
+; AVX512F-NEXT:    vmovdqa %ymm0, %ymm2
 ; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm5 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX512F-NEXT:    vpand %ymm5, %ymm0, %ymm1
-; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm6 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
-; AVX512F-NEXT:    # ymm6 = mem[0,1,0,1]
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm6, %ymm1
-; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm5, %ymm0, %ymm0
-; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm12 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
-; AVX512F-NEXT:    # ymm12 = mem[0,1,0,1]
-; AVX512F-NEXT:    vpshufb %ymm0, %ymm12, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm1, %ymm0
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm4, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm8, %ymm1, %ymm1
-; AVX512F-NEXT:    vpsrlw $4, %ymm1, %ymm7
-; AVX512F-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX512F-NEXT:    vpshufb %ymm7, %ymm12, %ymm7
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm14 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; AVX512F-NEXT:    vpand %ymm7, %ymm14, %ymm9
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512F-NEXT:    vpxor %ymm9, %ymm10, %ymm9
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpxor %ymm10, %ymm9, %ymm9
-; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm6, %ymm1
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpxor %ymm10, %ymm9, %ymm9
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpxor %ymm10, %ymm9, %ymm2
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm13 = [2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048]
-; AVX512F-NEXT:    vpand %ymm7, %ymm13, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm0, %ymm7
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm11 = [4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096]
-; AVX512F-NEXT:    vpand %ymm1, %ymm11, %ymm9
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512F-NEXT:    vpxor %ymm7, %ymm9, %ymm7
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm10 = [8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192]
-; AVX512F-NEXT:    vpand %ymm1, %ymm10, %ymm9
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512F-NEXT:    vpxor %ymm7, %ymm9, %ymm7
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm9 = [16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384]
-; AVX512F-NEXT:    vpand %ymm1, %ymm9, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm7, %ymm15, %ymm15
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm7 = [32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768]
-; AVX512F-NEXT:    vpand %ymm7, %ymm1, %ymm1
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX512F-NEXT:    vpxor %ymm0, %ymm15, %ymm0
-; AVX512F-NEXT:    vpxor %ymm0, %ymm2, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm8, %ymm3, %ymm1
-; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm2
-; AVX512F-NEXT:    vpshufb %ymm2, %ymm6, %ymm2
+; AVX512F-NEXT:    vpand %ymm5, %ymm3, %ymm6
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX512F-NEXT:    # ymm4 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm6, %ymm4, %ymm6
+; AVX512F-NEXT:    vpsrlw $4, %ymm3, %ymm3
+; AVX512F-NEXT:    vpand %ymm5, %ymm3, %ymm7
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX512F-NEXT:    # ymm0 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm7, %ymm0, %ymm7
+; AVX512F-NEXT:    vpor %ymm7, %ymm6, %ymm10
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm7 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX512F-NEXT:    vpand %ymm7, %ymm10, %ymm3
+; AVX512F-NEXT:    vmovdqu %ymm3, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm13, %ymm8
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm8, %ymm8
+; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm9
+; AVX512F-NEXT:    vmovdqa %ymm4, %ymm6
+; AVX512F-NEXT:    vpshufb %ymm9, %ymm4, %ymm9
+; AVX512F-NEXT:    vpsrlw $4, %ymm8, %ymm8
+; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm8
+; AVX512F-NEXT:    vpshufb %ymm8, %ymm0, %ymm8
+; AVX512F-NEXT:    vpor %ymm8, %ymm9, %ymm12
+; AVX512F-NEXT:    vpand %ymm7, %ymm12, %ymm8
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm8, %ymm9
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm1, %ymm1
+; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm11
+; AVX512F-NEXT:    vpshufb %ymm11, %ymm4, %ymm11
 ; AVX512F-NEXT:    vpsrlw $4, %ymm1, %ymm1
 ; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm12, %ymm1
-; AVX512F-NEXT:    vpor %ymm1, %ymm2, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm8, %ymm4, %ymm2
-; AVX512F-NEXT:    vpsrlw $4, %ymm2, %ymm3
+; AVX512F-NEXT:    vpshufb %ymm1, %ymm0, %ymm1
+; AVX512F-NEXT:    vpor %ymm1, %ymm11, %ymm1
+; AVX512F-NEXT:    vpand %ymm7, %ymm1, %ymm4
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm13, %ymm3
+; AVX512F-NEXT:    vpand %ymm5, %ymm3, %ymm11
+; AVX512F-NEXT:    vpshufb %ymm11, %ymm6, %ymm11
+; AVX512F-NEXT:    vpsrlw $4, %ymm3, %ymm3
 ; AVX512F-NEXT:    vpand %ymm5, %ymm3, %ymm3
-; AVX512F-NEXT:    vpshufb %ymm3, %ymm12, %ymm3
-; AVX512F-NEXT:    vpand %ymm3, %ymm14, %ymm4
-; AVX512F-NEXT:    vpmullw %ymm4, %ymm1, %ymm4
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm3, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm4, %ymm15, %ymm4
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm3, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm15, %ymm15
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm3, %ymm14
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm14, %ymm14
-; AVX512F-NEXT:    vpxor %ymm14, %ymm15, %ymm14
-; AVX512F-NEXT:    vpxor %ymm4, %ymm14, %ymm14
-; AVX512F-NEXT:    vpand %ymm5, %ymm2, %ymm2
-; AVX512F-NEXT:    vpshufb %ymm2, %ymm6, %ymm4
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm4, %ymm2
-; AVX512F-NEXT:    vpmullw %ymm2, %ymm1, %ymm2
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm4, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm2, %ymm15, %ymm2
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm4, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm2, %ymm15, %ymm2
-; AVX512F-NEXT:    vpxor %ymm2, %ymm14, %ymm2
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm4, %ymm14
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm14, %ymm14
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm3, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm15, %ymm14, %ymm14
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm3, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm15, %ymm14, %ymm14
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm3, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm15, %ymm14, %ymm14
-; AVX512F-NEXT:    vpxor %ymm2, %ymm14, %ymm2
-; AVX512F-NEXT:    vpand %ymm3, %ymm13, %ymm3
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm1, %ymm3
-; AVX512F-NEXT:    vpand %ymm4, %ymm11, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm3, %ymm11, %ymm3
-; AVX512F-NEXT:    vpand %ymm4, %ymm10, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm10, %ymm10
-; AVX512F-NEXT:    vpxor %ymm3, %ymm10, %ymm3
-; AVX512F-NEXT:    vpand %ymm4, %ymm9, %ymm9
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm9, %ymm9
-; AVX512F-NEXT:    vpxor %ymm3, %ymm9, %ymm3
-; AVX512F-NEXT:    vpand %ymm7, %ymm4, %ymm4
-; AVX512F-NEXT:    vpmullw %ymm4, %ymm1, %ymm1
-; AVX512F-NEXT:    vpxor %ymm1, %ymm3, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm8, %ymm0, %ymm0
-; AVX512F-NEXT:    vpxor %ymm1, %ymm2, %ymm1
-; AVX512F-NEXT:    vpand %ymm5, %ymm0, %ymm2
-; AVX512F-NEXT:    vpshufb %ymm2, %ymm6, %ymm2
-; AVX512F-NEXT:    vpshufb %ymm8, %ymm1, %ymm1
-; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm3
-; AVX512F-NEXT:    vpshufb %ymm3, %ymm6, %ymm3
+; AVX512F-NEXT:    vpshufb %ymm3, %ymm0, %ymm3
+; AVX512F-NEXT:    vpor %ymm3, %ymm11, %ymm0
+; AVX512F-NEXT:    vpand %ymm7, %ymm0, %ymm11
+; AVX512F-NEXT:    vpmullw %ymm4, %ymm11, %ymm3
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm9, %zmm3, %zmm16
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm7 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX512F-NEXT:    vpand %ymm7, %ymm10, %ymm14
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm9 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX512F-NEXT:    vpand %ymm9, %ymm12, %ymm13
+; AVX512F-NEXT:    vpmullw %ymm14, %ymm13, %ymm3
+; AVX512F-NEXT:    vpand %ymm7, %ymm1, %ymm2
+; AVX512F-NEXT:    vpand %ymm0, %ymm9, %ymm15
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm15, %ymm6
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm3, %zmm6, %zmm17
+; AVX512F-NEXT:    vpand %ymm9, %ymm10, %ymm6
+; AVX512F-NEXT:    vpand %ymm7, %ymm12, %ymm10
+; AVX512F-NEXT:    vpand %ymm1, %ymm9, %ymm1
+; AVX512F-NEXT:    vpand %ymm7, %ymm0, %ymm0
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm10, %ymm12
+; AVX512F-NEXT:    vpmullw %ymm1, %ymm0, %ymm3
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm12, %zmm3, %zmm19
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm8, %ymm12
+; AVX512F-NEXT:    vpmullw %ymm1, %ymm11, %ymm7
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm12, %zmm7, %zmm18
+; AVX512F-NEXT:    vmovdqu {{[-0-9]+}}(%r{{[sb]}}p), %ymm3 # 32-byte Reload
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm13, %ymm12
+; AVX512F-NEXT:    vpmullw %ymm4, %ymm15, %ymm7
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm12, %zmm7, %zmm7
+; AVX512F-NEXT:    vpmullw %ymm14, %ymm10, %ymm12
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm0, %ymm9
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm12, %zmm9, %zmm9
+; AVX512F-NEXT:    vpmullw %ymm14, %ymm8, %ymm8
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm11, %ymm2
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm8, %zmm2, %zmm2
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm13, %ymm6
+; AVX512F-NEXT:    vpmullw %ymm1, %ymm15, %ymm1
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm6, %zmm1, %zmm1
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm10, %ymm6
+; AVX512F-NEXT:    vpmullw %ymm4, %ymm0, %ymm0
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm6, %zmm0, %zmm0
+; AVX512F-NEXT:    vpxorq %zmm2, %zmm1, %zmm1
+; AVX512F-NEXT:    vpternlogd {{.*#+}} zmm0 = m32bcst & (zmm0 ^ zmm1)
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm19 = zmm19 ^ zmm17 ^ zmm16
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm9 = zmm9 ^ zmm7 ^ zmm18
+; AVX512F-NEXT:    vpternlogd {{.*#+}} zmm0 = zmm0 | (zmm9 & m32bcst)
+; AVX512F-NEXT:    vpternlogd {{.*#+}} zmm0 = zmm0 | (zmm19 & m32bcst)
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14,1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
+; AVX512F-NEXT:    # ymm3 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm3, %ymm1, %ymm1
+; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm2
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX512F-NEXT:    # ymm4 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm4, %ymm2
+; AVX512F-NEXT:    vpshufb %ymm3, %ymm0, %ymm0
+; AVX512F-NEXT:    vpand %ymm5, %ymm0, %ymm3
+; AVX512F-NEXT:    vpshufb %ymm3, %ymm4, %ymm3
 ; AVX512F-NEXT:    vinserti64x4 $1, %ymm2, %zmm3, %zmm2
-; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm5, %ymm0, %ymm0
 ; AVX512F-NEXT:    vpsrlw $4, %ymm1, %ymm1
 ; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm0, %ymm12, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm12, %ymm1
-; AVX512F-NEXT:    vinserti64x4 $1, %ymm0, %zmm1, %zmm0
+; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX512F-NEXT:    vpand %ymm5, %ymm0, %ymm0
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX512F-NEXT:    # ymm3 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm1, %ymm3, %ymm1
+; AVX512F-NEXT:    vpshufb %ymm0, %ymm3, %ymm0
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
 ; AVX512F-NEXT:    vporq %zmm0, %zmm2, %zmm0
 ; AVX512F-NEXT:    retq
 ;
 ; AVX512VL-LABEL: clmulr_v32i16:
 ; AVX512VL:       # %bb.0:
-; AVX512VL-NEXT:    vextracti64x4 $1, %zmm0, %ymm2
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm1, %ymm2
 ; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14,1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
 ; AVX512VL-NEXT:    # ymm4 = mem[0,1,0,1]
 ; AVX512VL-NEXT:    vpshufb %ymm4, %ymm2, %ymm3
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX512VL-NEXT:    vpand %ymm2, %ymm3, %ymm6
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm20 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm3, %ymm6
 ; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm5 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
 ; AVX512VL-NEXT:    # ymm5 = mem[0,1,0,1]
 ; AVX512VL-NEXT:    vpshufb %ymm6, %ymm5, %ymm6
 ; AVX512VL-NEXT:    vpsrlw $4, %ymm3, %ymm3
-; AVX512VL-NEXT:    vpand %ymm2, %ymm3, %ymm7
-; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
-; AVX512VL-NEXT:    # ymm3 = mem[0,1,0,1]
-; AVX512VL-NEXT:    vpshufb %ymm7, %ymm3, %ymm7
-; AVX512VL-NEXT:    vpor %ymm7, %ymm6, %ymm6
-; AVX512VL-NEXT:    vextracti64x4 $1, %zmm1, %ymm7
-; AVX512VL-NEXT:    vpshufb %ymm4, %ymm7, %ymm8
-; AVX512VL-NEXT:    vpsrlw $4, %ymm8, %ymm7
-; AVX512VL-NEXT:    vpand %ymm2, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpshufb %ymm7, %ymm3, %ymm7
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm18 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; AVX512VL-NEXT:    vpandq %ymm18, %ymm7, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm22 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-; AVX512VL-NEXT:    vpandq %ymm22, %ymm7, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpxor %ymm9, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm24 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; AVX512VL-NEXT:    vpandq %ymm24, %ymm7, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm11
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm25 = [8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8]
-; AVX512VL-NEXT:    vpandq %ymm25, %ymm7, %ymm12
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm12, %ymm12
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm12 = ymm12 ^ ymm10 ^ ymm11
-; AVX512VL-NEXT:    vpand %ymm2, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpshufb %ymm8, %ymm5, %ymm8
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm26 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; AVX512VL-NEXT:    vpandq %ymm26, %ymm8, %ymm11
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm11, %ymm13
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm27 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; AVX512VL-NEXT:    vpandq %ymm27, %ymm8, %ymm14
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm14, %ymm14
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm14 = ymm14 ^ ymm12 ^ ymm13
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm12 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; AVX512VL-NEXT:    vpand %ymm12, %ymm8, %ymm13
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm13, %ymm15
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm13 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-; AVX512VL-NEXT:    vpand %ymm13, %ymm8, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm9 = ymm9 ^ ymm14 ^ ymm15
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm14 = [256,256,256,256,256,256,256,256,256,256,256,256,256,256,256,256]
-; AVX512VL-NEXT:    vpand %ymm7, %ymm14, %ymm15
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm15, %ymm10
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm15 = [512,512,512,512,512,512,512,512,512,512,512,512,512,512,512,512]
-; AVX512VL-NEXT:    vpand %ymm7, %ymm15, %ymm11
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm11, %ymm11
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm11 = ymm11 ^ ymm9 ^ ymm10
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm16 = [1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024]
-; AVX512VL-NEXT:    vpandq %ymm16, %ymm7, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm17 = [2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048]
-; AVX512VL-NEXT:    vpandq %ymm17, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm6, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm7 ^ ymm11 ^ ymm9
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm19 = [4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096]
-; AVX512VL-NEXT:    vpandq %ymm19, %ymm8, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm20 = [8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192]
-; AVX512VL-NEXT:    vpandq %ymm20, %ymm8, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm10 = ymm10 ^ ymm7 ^ ymm9
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm21 = [16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384]
-; AVX512VL-NEXT:    vpandq %ymm21, %ymm8, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm6, %ymm7
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm23 = [32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768]
-; AVX512VL-NEXT:    vpandq %ymm23, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm8, %ymm6
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm6 = ymm6 ^ ymm10 ^ ymm7
-; AVX512VL-NEXT:    vpshufb %ymm4, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpand %ymm2, %ymm6, %ymm7
-; AVX512VL-NEXT:    vpshufb %ymm7, %ymm5, %ymm7
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm3, %ymm7
+; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm2 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX512VL-NEXT:    # ymm2 = mem[0,1,0,1]
+; AVX512VL-NEXT:    vpshufb %ymm7, %ymm2, %ymm7
+; AVX512VL-NEXT:    vpor %ymm7, %ymm6, %ymm12
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm19 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX512VL-NEXT:    vpandq %ymm19, %ymm12, %ymm7
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm0, %ymm8
+; AVX512VL-NEXT:    vpshufb %ymm4, %ymm8, %ymm8
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm8, %ymm9
+; AVX512VL-NEXT:    vpshufb %ymm9, %ymm5, %ymm9
+; AVX512VL-NEXT:    vpsrlw $4, %ymm8, %ymm8
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm8, %ymm8
+; AVX512VL-NEXT:    vpshufb %ymm8, %ymm2, %ymm8
+; AVX512VL-NEXT:    vpor %ymm8, %ymm9, %ymm13
+; AVX512VL-NEXT:    vpandq %ymm19, %ymm13, %ymm8
+; AVX512VL-NEXT:    vpmullw %ymm7, %ymm8, %ymm9
+; AVX512VL-NEXT:    vpshufb %ymm4, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm1, %ymm10
+; AVX512VL-NEXT:    vpshufb %ymm10, %ymm5, %ymm10
+; AVX512VL-NEXT:    vpsrlw $4, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpshufb %ymm1, %ymm2, %ymm1
+; AVX512VL-NEXT:    vpor %ymm1, %ymm10, %ymm14
+; AVX512VL-NEXT:    vpandq %ymm19, %ymm14, %ymm1
 ; AVX512VL-NEXT:    vpshufb %ymm4, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm8
-; AVX512VL-NEXT:    vpshufb %ymm8, %ymm5, %ymm8
+; AVX512VL-NEXT:    vmovdqa64 %ymm4, %ymm23
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm0, %ymm10
+; AVX512VL-NEXT:    vpshufb %ymm10, %ymm5, %ymm10
+; AVX512VL-NEXT:    vmovdqa64 %ymm5, %ymm24
 ; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm0
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm0, %ymm0
+; AVX512VL-NEXT:    vpshufb %ymm0, %ymm2, %ymm0
+; AVX512VL-NEXT:    vmovdqa64 %ymm2, %ymm22
+; AVX512VL-NEXT:    vpor %ymm0, %ymm10, %ymm15
+; AVX512VL-NEXT:    vpandq %ymm19, %ymm15, %ymm0
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm0, %ymm10
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm9, %zmm10, %zmm16
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm17 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm12, %ymm10
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm18 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX512VL-NEXT:    vpandq %ymm18, %ymm13, %ymm9
+; AVX512VL-NEXT:    vpmullw %ymm10, %ymm9, %ymm6
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm14, %ymm2
+; AVX512VL-NEXT:    vpandq %ymm18, %ymm15, %ymm11
+; AVX512VL-NEXT:    vpmullw %ymm2, %ymm11, %ymm3
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm6, %zmm3, %zmm21
+; AVX512VL-NEXT:    vpandq %ymm18, %ymm12, %ymm6
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm13, %ymm13
+; AVX512VL-NEXT:    vpmullw %ymm6, %ymm13, %ymm3
+; AVX512VL-NEXT:    vpandq %ymm18, %ymm14, %ymm14
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm15, %ymm12
+; AVX512VL-NEXT:    vpmullw %ymm14, %ymm12, %ymm15
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm3, %zmm15, %zmm3
+; AVX512VL-NEXT:    vpmullw %ymm6, %ymm8, %ymm15
+; AVX512VL-NEXT:    vpmullw %ymm0, %ymm14, %ymm4
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm15, %zmm4, %zmm25
+; AVX512VL-NEXT:    vpmullw %ymm7, %ymm9, %ymm15
+; AVX512VL-NEXT:    vmovdqa %ymm7, %ymm4
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm11, %ymm5
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm15, %zmm5, %zmm5
+; AVX512VL-NEXT:    vpmullw %ymm10, %ymm13, %ymm15
+; AVX512VL-NEXT:    vpmullw %ymm2, %ymm12, %ymm7
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm15, %zmm7, %zmm7
+; AVX512VL-NEXT:    vpmullw %ymm10, %ymm8, %ymm8
+; AVX512VL-NEXT:    vpmullw %ymm2, %ymm0, %ymm0
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm8, %zmm0, %zmm0
+; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm2
+; AVX512VL-NEXT:    vpmullw %ymm14, %ymm11, %ymm6
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm2, %zmm6, %zmm2
+; AVX512VL-NEXT:    vpmullw %ymm4, %ymm13, %ymm6
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm3 = zmm3 ^ zmm21 ^ zmm16
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm7 = zmm7 ^ zmm5 ^ zmm25
+; AVX512VL-NEXT:    vpxorq %zmm0, %zmm2, %zmm0
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm12, %ymm1
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm6, %zmm1, %zmm1
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm18 & (zmm1 ^ zmm0)
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm1 | (zmm7 & zmm19)
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm1 | (zmm3 & zmm17)
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm1, %ymm0
+; AVX512VL-NEXT:    vmovdqa64 %ymm23, %ymm3
+; AVX512VL-NEXT:    vpshufb %ymm3, %ymm0, %ymm0
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm0, %ymm2
+; AVX512VL-NEXT:    vmovdqa64 %ymm24, %ymm4
+; AVX512VL-NEXT:    vpshufb %ymm2, %ymm4, %ymm2
+; AVX512VL-NEXT:    vpshufb %ymm3, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm1, %ymm3
+; AVX512VL-NEXT:    vpshufb %ymm3, %ymm4, %ymm3
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm2, %zmm3, %zmm2
+; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm0, %ymm0
+; AVX512VL-NEXT:    vmovdqa64 %ymm22, %ymm3
 ; AVX512VL-NEXT:    vpshufb %ymm0, %ymm3, %ymm0
-; AVX512VL-NEXT:    vpor %ymm0, %ymm8, %ymm0
-; AVX512VL-NEXT:    vpshufb %ymm4, %ymm1, %ymm8
-; AVX512VL-NEXT:    vpsrlw $4, %ymm8, %ymm1
-; AVX512VL-NEXT:    vpand %ymm2, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpsrlw $4, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm1, %ymm1
 ; AVX512VL-NEXT:    vpshufb %ymm1, %ymm3, %ymm1
-; AVX512VL-NEXT:    vpandq %ymm18, %ymm1, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpandq %ymm22, %ymm1, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpxor %ymm9, %ymm10, %ymm9
-; AVX512VL-NEXT:    vpandq %ymm24, %ymm1, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpandq %ymm25, %ymm1, %ymm11
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm11, %ymm11
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm11 = ymm11 ^ ymm9 ^ ymm10
-; AVX512VL-NEXT:    vpand %ymm2, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpshufb %ymm8, %ymm5, %ymm8
-; AVX512VL-NEXT:    vpandq %ymm26, %ymm8, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpandq %ymm27, %ymm8, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm10 = ymm10 ^ ymm11 ^ ymm9
-; AVX512VL-NEXT:    vpand %ymm12, %ymm8, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpand %ymm13, %ymm8, %ymm11
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm11, %ymm11
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm11 = ymm11 ^ ymm10 ^ ymm9
-; AVX512VL-NEXT:    vpand %ymm1, %ymm14, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpand %ymm1, %ymm15, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm10 = ymm10 ^ ymm11 ^ ymm9
-; AVX512VL-NEXT:    vpandq %ymm16, %ymm1, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpandq %ymm17, %ymm1, %ymm1
-; AVX512VL-NEXT:    vpmullw %ymm1, %ymm0, %ymm1
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm1 = ymm1 ^ ymm10 ^ ymm9
-; AVX512VL-NEXT:    vpandq %ymm19, %ymm8, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpandq %ymm20, %ymm8, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm10 = ymm10 ^ ymm1 ^ ymm9
-; AVX512VL-NEXT:    vpandq %ymm21, %ymm8, %ymm1
-; AVX512VL-NEXT:    vpmullw %ymm1, %ymm0, %ymm1
-; AVX512VL-NEXT:    vpandq %ymm23, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm8, %ymm0
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 ^ ymm10 ^ ymm1
-; AVX512VL-NEXT:    vpshufb %ymm4, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm1
-; AVX512VL-NEXT:    vpshufb %ymm1, %ymm5, %ymm1
-; AVX512VL-NEXT:    vinserti64x4 $1, %ymm7, %zmm1, %zmm1
-; AVX512VL-NEXT:    vpsrlw $4, %ymm6, %ymm4
-; AVX512VL-NEXT:    vpand %ymm2, %ymm4, %ymm4
-; AVX512VL-NEXT:    vpshufb %ymm4, %ymm3, %ymm4
-; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpshufb %ymm0, %ymm3, %ymm0
-; AVX512VL-NEXT:    vinserti64x4 $1, %ymm4, %zmm0, %zmm0
-; AVX512VL-NEXT:    vporq %zmm0, %zmm1, %zmm0
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm0, %zmm1, %zmm0
+; AVX512VL-NEXT:    vporq %zmm0, %zmm2, %zmm0
 ; AVX512VL-NEXT:    retq
   %a.ext = zext <32 x i16> %a to <32 x i32>
   %b.ext = zext <32 x i16> %b to <32 x i32>
@@ -1167,183 +978,112 @@ define <8 x i64> @clmulr_v8i64(<8 x i64> %a, <8 x i64> %b) nounwind {
 define <64 x i8> @clmulh_v64i8(<64 x i8> %a, <64 x i8> %b) nounwind {
 ; AVX512F-LABEL: clmulh_v64i8:
 ; AVX512F:       # %bb.0:
-; AVX512F-NEXT:    vmovdqa64 %zmm1, %zmm3
-; AVX512F-NEXT:    vmovdqa64 %zmm0, %zmm1
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX512F-NEXT:    vpand %ymm2, %ymm1, %ymm4
-; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
-; AVX512F-NEXT:    # ymm0 = mem[0,1,0,1]
-; AVX512F-NEXT:    vpshufb %ymm4, %ymm0, %ymm5
-; AVX512F-NEXT:    vpsrlw $4, %ymm1, %ymm4
-; AVX512F-NEXT:    vpand %ymm2, %ymm4, %ymm6
-; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm1, %ymm4
+; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm3 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX512F-NEXT:    vpand %ymm3, %ymm4, %ymm5
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm2 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX512F-NEXT:    # ymm2 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm5, %ymm2, %ymm5
+; AVX512F-NEXT:    vpsrlw $4, %ymm4, %ymm4
+; AVX512F-NEXT:    vpand %ymm3, %ymm4, %ymm6
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm12 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX512F-NEXT:    # ymm12 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm6, %ymm12, %ymm6
+; AVX512F-NEXT:    vpor %ymm6, %ymm5, %ymm11
+; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm10 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX512F-NEXT:    vpand %ymm10, %ymm11, %ymm6
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm5
+; AVX512F-NEXT:    vpand %ymm3, %ymm5, %ymm7
+; AVX512F-NEXT:    vpshufb %ymm7, %ymm2, %ymm7
+; AVX512F-NEXT:    vpsrlw $4, %ymm5, %ymm5
+; AVX512F-NEXT:    vpand %ymm3, %ymm5, %ymm5
+; AVX512F-NEXT:    vpshufb %ymm5, %ymm12, %ymm5
+; AVX512F-NEXT:    vpor %ymm5, %ymm7, %ymm13
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm4 = [1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765]
+; AVX512F-NEXT:    vpand %ymm4, %ymm13, %ymm7
+; AVX512F-NEXT:    vmovdqa64 %zmm4, %zmm5
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm7, %ymm8
+; AVX512F-NEXT:    vpand %ymm3, %ymm1, %ymm9
+; AVX512F-NEXT:    vmovdqa %ymm2, %ymm4
+; AVX512F-NEXT:    vpshufb %ymm9, %ymm2, %ymm9
+; AVX512F-NEXT:    vpsrlw $4, %ymm1, %ymm1
+; AVX512F-NEXT:    vpand %ymm3, %ymm1, %ymm1
+; AVX512F-NEXT:    vpshufb %ymm1, %ymm12, %ymm1
+; AVX512F-NEXT:    vpor %ymm1, %ymm9, %ymm14
+; AVX512F-NEXT:    vpand %ymm10, %ymm14, %ymm2
+; AVX512F-NEXT:    vpand %ymm3, %ymm0, %ymm9
+; AVX512F-NEXT:    vpshufb %ymm9, %ymm4, %ymm9
+; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX512F-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; AVX512F-NEXT:    vpshufb %ymm0, %ymm12, %ymm0
+; AVX512F-NEXT:    vpor %ymm0, %ymm9, %ymm15
+; AVX512F-NEXT:    vpand %ymm5, %ymm15, %ymm12
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm12, %ymm0
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm8, %zmm0, %zmm16
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm1 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
+; AVX512F-NEXT:    vpandn %ymm2, %ymm1, %ymm0
+; AVX512F-NEXT:    vmovdqu %ymm0, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512F-NEXT:    vpmaddubsw %ymm0, %ymm12, %ymm9
+; AVX512F-NEXT:    vpsllw $8, %ymm9, %ymm0
+; AVX512F-NEXT:    vpandn %ymm6, %ymm1, %ymm9
+; AVX512F-NEXT:    vpmaddubsw %ymm9, %ymm7, %ymm4
+; AVX512F-NEXT:    vpsllw $8, %ymm4, %ymm4
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm4, %zmm0, %zmm0
+; AVX512F-NEXT:    vpand %ymm5, %ymm11, %ymm4
+; AVX512F-NEXT:    vpand %ymm10, %ymm13, %ymm11
+; AVX512F-NEXT:    vpand %ymm10, %ymm15, %ymm10
+; AVX512F-NEXT:    vpmullw %ymm4, %ymm11, %ymm13
+; AVX512F-NEXT:    vpand %ymm5, %ymm14, %ymm14
+; AVX512F-NEXT:    vpmullw %ymm14, %ymm10, %ymm15
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm13, %zmm15, %zmm17
+; AVX512F-NEXT:    vpandn %ymm14, %ymm1, %ymm15
+; AVX512F-NEXT:    vpmaddubsw %ymm15, %ymm10, %ymm5
+; AVX512F-NEXT:    vpsllw $8, %ymm5, %ymm5
+; AVX512F-NEXT:    vpandn %ymm4, %ymm1, %ymm13
+; AVX512F-NEXT:    vpmaddubsw %ymm13, %ymm11, %ymm8
+; AVX512F-NEXT:    vpsllw $8, %ymm8, %ymm8
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm8, %zmm5, %zmm5
+; AVX512F-NEXT:    vpmullw %ymm4, %ymm7, %ymm4
+; AVX512F-NEXT:    vpmullw %ymm14, %ymm12, %ymm8
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm4, %zmm8, %zmm4
+; AVX512F-NEXT:    vpmaddubsw %ymm15, %ymm12, %ymm8
+; AVX512F-NEXT:    vpmaddubsw %ymm13, %ymm7, %ymm7
+; AVX512F-NEXT:    vpsllw $8, %ymm8, %ymm8
+; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm7, %zmm8, %zmm7
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm11, %ymm6
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm10, %ymm2
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm6, %zmm2, %zmm2
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm0 | (zmm16 & zmm1)
+; AVX512F-NEXT:    vpandq %zmm1, %zmm17, %zmm6
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm7 = zmm7 | (zmm4 & zmm1)
+; AVX512F-NEXT:    vpandq %zmm1, %zmm2, %zmm1
+; AVX512F-NEXT:    vpmaddubsw {{[-0-9]+}}(%r{{[sb]}}p), %ymm10, %ymm2 # 32-byte Folded Reload
+; AVX512F-NEXT:    vpmaddubsw %ymm9, %ymm11, %ymm4
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm0 ^ (zmm5 | zmm6)
+; AVX512F-NEXT:    vpsllw $8, %ymm2, %ymm0
+; AVX512F-NEXT:    vpsllw $8, %ymm4, %ymm2
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm7 ^ (zmm0 | zmm1)
+; AVX512F-NEXT:    vpternlogd {{.*#+}} zmm0 = zmm5 ^ (m32bcst & (zmm0 ^ zmm5))
+; AVX512F-NEXT:    vpand %ymm3, %ymm0, %ymm1
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
 ; AVX512F-NEXT:    # ymm4 = mem[0,1,0,1]
-; AVX512F-NEXT:    vpshufb %ymm6, %ymm4, %ymm6
-; AVX512F-NEXT:    vpor %ymm6, %ymm5, %ymm14
-; AVX512F-NEXT:    vpsrlw $4, %ymm3, %ymm5
-; AVX512F-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX512F-NEXT:    vpshufb %ymm5, %ymm4, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm10, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm14, %ymm8
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm5 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
-; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512F-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm14, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512F-NEXT:    vpor %ymm7, %ymm8, %ymm8
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm10, %ymm9
-; AVX512F-NEXT:    vpmullw %ymm9, %ymm14, %ymm11
-; AVX512F-NEXT:    vpand %ymm5, %ymm11, %ymm11
-; AVX512F-NEXT:    vpandn %ymm9, %ymm5, %ymm9
-; AVX512F-NEXT:    vpmaddubsw %ymm9, %ymm14, %ymm9
-; AVX512F-NEXT:    vpsllw $8, %ymm9, %ymm9
-; AVX512F-NEXT:    vpor %ymm9, %ymm11, %ymm9
-; AVX512F-NEXT:    vpxor %ymm8, %ymm9, %ymm11
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm8 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; AVX512F-NEXT:    vpand %ymm8, %ymm10, %ymm9
-; AVX512F-NEXT:    vpmullw %ymm9, %ymm14, %ymm12
-; AVX512F-NEXT:    vpand %ymm5, %ymm12, %ymm12
-; AVX512F-NEXT:    vpandn %ymm9, %ymm5, %ymm9
-; AVX512F-NEXT:    vpmaddubsw %ymm9, %ymm14, %ymm9
-; AVX512F-NEXT:    vpsllw $8, %ymm9, %ymm9
-; AVX512F-NEXT:    vpor %ymm9, %ymm12, %ymm12
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm10, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm10, %ymm14, %ymm13
-; AVX512F-NEXT:    vpand %ymm5, %ymm13, %ymm13
-; AVX512F-NEXT:    vpandn %ymm10, %ymm5, %ymm10
-; AVX512F-NEXT:    vpmaddubsw %ymm10, %ymm14, %ymm10
-; AVX512F-NEXT:    vpsllw $8, %ymm10, %ymm10
-; AVX512F-NEXT:    vpor %ymm10, %ymm13, %ymm10
-; AVX512F-NEXT:    vpxor %ymm10, %ymm12, %ymm10
-; AVX512F-NEXT:    vpxor %ymm10, %ymm11, %ymm13
-; AVX512F-NEXT:    vpand %ymm2, %ymm3, %ymm10
-; AVX512F-NEXT:    vmovdqa %ymm0, %ymm9
-; AVX512F-NEXT:    vpshufb %ymm10, %ymm0, %ymm15
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm10 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; AVX512F-NEXT:    vpand %ymm10, %ymm15, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm11, %ymm14, %ymm12
-; AVX512F-NEXT:    vpand %ymm5, %ymm12, %ymm12
-; AVX512F-NEXT:    vpandn %ymm11, %ymm5, %ymm11
-; AVX512F-NEXT:    vpmaddubsw %ymm11, %ymm14, %ymm11
-; AVX512F-NEXT:    vpsllw $8, %ymm11, %ymm11
-; AVX512F-NEXT:    vpor %ymm11, %ymm12, %ymm12
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm11 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; AVX512F-NEXT:    vpand %ymm11, %ymm15, %ymm0
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm14, %ymm6
-; AVX512F-NEXT:    vpand %ymm5, %ymm6, %ymm6
-; AVX512F-NEXT:    vpandn %ymm0, %ymm5, %ymm0
-; AVX512F-NEXT:    vpmaddubsw %ymm0, %ymm14, %ymm0
-; AVX512F-NEXT:    vpsllw $8, %ymm0, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm6, %ymm0
-; AVX512F-NEXT:    vpxor %ymm0, %ymm12, %ymm0
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm12 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; AVX512F-NEXT:    vpand %ymm12, %ymm15, %ymm6
-; AVX512F-NEXT:    vpmullw %ymm6, %ymm14, %ymm7
-; AVX512F-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX512F-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512F-NEXT:    vpmaddubsw %ymm6, %ymm14, %ymm6
-; AVX512F-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512F-NEXT:    vpor %ymm6, %ymm7, %ymm6
-; AVX512F-NEXT:    vpxor %ymm6, %ymm0, %ymm0
-; AVX512F-NEXT:    vpxor %ymm0, %ymm13, %ymm0
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm13 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-; AVX512F-NEXT:    vpand %ymm13, %ymm15, %ymm6
-; AVX512F-NEXT:    vpmullw %ymm6, %ymm14, %ymm7
-; AVX512F-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512F-NEXT:    vpmaddubsw %ymm6, %ymm14, %ymm6
-; AVX512F-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512F-NEXT:    vpor %ymm6, %ymm7, %ymm6
-; AVX512F-NEXT:    vpxor %ymm6, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm6
-; AVX512F-NEXT:    vpshufb %ymm6, %ymm9, %ymm6
+; AVX512F-NEXT:    vpshufb %ymm1, %ymm4, %ymm1
+; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm2
+; AVX512F-NEXT:    vpand %ymm3, %ymm2, %ymm2
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm5 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX512F-NEXT:    # ymm5 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm5, %ymm2
+; AVX512F-NEXT:    vpor %ymm2, %ymm1, %ymm1
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm0
+; AVX512F-NEXT:    vpand %ymm3, %ymm0, %ymm2
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm4, %ymm2
 ; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm0, %ymm4, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm6, %ymm14
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm1, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm9, %ymm1
-; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm0, %ymm4, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm1, %ymm0
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm3, %ymm1
-; AVX512F-NEXT:    vpsrlw $4, %ymm1, %ymm3
-; AVX512F-NEXT:    vpand %ymm2, %ymm3, %ymm3
-; AVX512F-NEXT:    vpshufb %ymm3, %ymm4, %ymm3
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm3, %ymm6
-; AVX512F-NEXT:    vpmullw %ymm6, %ymm0, %ymm7
-; AVX512F-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX512F-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512F-NEXT:    vpmaddubsw %ymm6, %ymm0, %ymm6
-; AVX512F-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512F-NEXT:    vpor %ymm6, %ymm7, %ymm6
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm3, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm0, %ymm15
-; AVX512F-NEXT:    vpand %ymm5, %ymm15, %ymm15
-; AVX512F-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512F-NEXT:    vpor %ymm7, %ymm15, %ymm7
-; AVX512F-NEXT:    vpxor %ymm6, %ymm7, %ymm6
-; AVX512F-NEXT:    vpand %ymm3, %ymm8, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm0, %ymm8
-; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512F-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512F-NEXT:    vpor %ymm7, %ymm8, %ymm7
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm3, %ymm3
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm0, %ymm8
-; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512F-NEXT:    vpandn %ymm3, %ymm5, %ymm3
-; AVX512F-NEXT:    vpmaddubsw %ymm3, %ymm0, %ymm3
-; AVX512F-NEXT:    vpsllw $8, %ymm3, %ymm3
-; AVX512F-NEXT:    vpor %ymm3, %ymm8, %ymm3
-; AVX512F-NEXT:    vpxor %ymm3, %ymm7, %ymm3
-; AVX512F-NEXT:    vpxor %ymm3, %ymm6, %ymm3
-; AVX512F-NEXT:    vpand %ymm2, %ymm1, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm9, %ymm1
-; AVX512F-NEXT:    vpand %ymm1, %ymm10, %ymm6
-; AVX512F-NEXT:    vpmullw %ymm6, %ymm0, %ymm7
-; AVX512F-NEXT:    vpand %ymm5, %ymm7, %ymm7
-; AVX512F-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512F-NEXT:    vpmaddubsw %ymm6, %ymm0, %ymm6
-; AVX512F-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512F-NEXT:    vpor %ymm6, %ymm7, %ymm6
-; AVX512F-NEXT:    vpand %ymm1, %ymm11, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm0, %ymm8
-; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512F-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512F-NEXT:    vpor %ymm7, %ymm8, %ymm7
-; AVX512F-NEXT:    vpxor %ymm7, %ymm6, %ymm6
-; AVX512F-NEXT:    vpand %ymm1, %ymm12, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm0, %ymm8
-; AVX512F-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512F-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512F-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512F-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512F-NEXT:    vpor %ymm7, %ymm8, %ymm7
-; AVX512F-NEXT:    vpxor %ymm7, %ymm6, %ymm6
-; AVX512F-NEXT:    vpxor %ymm6, %ymm3, %ymm3
-; AVX512F-NEXT:    vpand %ymm1, %ymm13, %ymm1
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm0, %ymm6
-; AVX512F-NEXT:    vpand %ymm5, %ymm6, %ymm6
-; AVX512F-NEXT:    vpandn %ymm1, %ymm5, %ymm1
-; AVX512F-NEXT:    vpmaddubsw %ymm1, %ymm0, %ymm0
-; AVX512F-NEXT:    vpsllw $8, %ymm0, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm6, %ymm0
-; AVX512F-NEXT:    vpxor %ymm0, %ymm3, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm9, %ymm1
-; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm0, %ymm4, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm1, %ymm0
-; AVX512F-NEXT:    vpsrlw $1, %ymm14, %ymm1
+; AVX512F-NEXT:    vpand %ymm3, %ymm0, %ymm0
+; AVX512F-NEXT:    vpshufb %ymm0, %ymm5, %ymm0
+; AVX512F-NEXT:    vpor %ymm0, %ymm2, %ymm0
+; AVX512F-NEXT:    vpsrlw $1, %ymm1, %ymm1
 ; AVX512F-NEXT:    vpsrlw $1, %ymm0, %ymm0
 ; AVX512F-NEXT:    vinserti64x4 $1, %ymm0, %zmm1, %zmm0
 ; AVX512F-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm0, %zmm0
@@ -1351,169 +1091,113 @@ define <64 x i8> @clmulh_v64i8(<64 x i8> %a, <64 x i8> %b) nounwind {
 ;
 ; AVX512VL-LABEL: clmulh_v64i8:
 ; AVX512VL:       # %bb.0:
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm1, %ymm4
 ; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm4
+; AVX512VL-NEXT:    vpand %ymm2, %ymm4, %ymm5
 ; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
 ; AVX512VL-NEXT:    # ymm3 = mem[0,1,0,1]
-; AVX512VL-NEXT:    vpshufb %ymm4, %ymm3, %ymm5
-; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm4
+; AVX512VL-NEXT:    vpshufb %ymm5, %ymm3, %ymm5
+; AVX512VL-NEXT:    vpsrlw $4, %ymm4, %ymm4
 ; AVX512VL-NEXT:    vpand %ymm2, %ymm4, %ymm6
 ; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
 ; AVX512VL-NEXT:    # ymm4 = mem[0,1,0,1]
 ; AVX512VL-NEXT:    vpshufb %ymm6, %ymm4, %ymm6
-; AVX512VL-NEXT:    vpor %ymm6, %ymm5, %ymm14
-; AVX512VL-NEXT:    vpsrlw $4, %ymm1, %ymm5
+; AVX512VL-NEXT:    vpor %ymm6, %ymm5, %ymm10
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm11 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX512VL-NEXT:    vpand %ymm11, %ymm10, %ymm6
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm0, %ymm5
+; AVX512VL-NEXT:    vpand %ymm2, %ymm5, %ymm7
+; AVX512VL-NEXT:    vpshufb %ymm7, %ymm3, %ymm7
+; AVX512VL-NEXT:    vpsrlw $4, %ymm5, %ymm5
 ; AVX512VL-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX512VL-NEXT:    vpshufb %ymm5, %ymm4, %ymm10
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm16 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-; AVX512VL-NEXT:    vpandq %ymm16, %ymm10, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm14, %ymm8
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm5 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm14, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm9
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm9 = ymm9 | (ymm8 & ymm5)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm17 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; AVX512VL-NEXT:    vpandq %ymm17, %ymm10, %ymm8
-; AVX512VL-NEXT:    vpmullw %ymm8, %ymm14, %ymm11
-; AVX512VL-NEXT:    vpand %ymm5, %ymm11, %ymm11
-; AVX512VL-NEXT:    vpandn %ymm8, %ymm5, %ymm8
-; AVX512VL-NEXT:    vpmaddubsw %ymm8, %ymm14, %ymm8
-; AVX512VL-NEXT:    vpsllw $8, %ymm8, %ymm12
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm12 = ymm9 ^ (ymm12 | ymm11)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm18 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; AVX512VL-NEXT:    vpandq %ymm18, %ymm10, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm9, %ymm14, %ymm11
-; AVX512VL-NEXT:    vpand %ymm5, %ymm11, %ymm11
-; AVX512VL-NEXT:    vpandn %ymm9, %ymm5, %ymm9
-; AVX512VL-NEXT:    vpmaddubsw %ymm9, %ymm14, %ymm9
-; AVX512VL-NEXT:    vpsllw $8, %ymm9, %ymm13
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm13 = ymm12 ^ (ymm13 | ymm11)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm9 = [8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8]
-; AVX512VL-NEXT:    vpand %ymm9, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm10, %ymm14, %ymm11
-; AVX512VL-NEXT:    vpand %ymm5, %ymm11, %ymm11
-; AVX512VL-NEXT:    vpandn %ymm10, %ymm5, %ymm10
-; AVX512VL-NEXT:    vpmaddubsw %ymm10, %ymm14, %ymm10
-; AVX512VL-NEXT:    vpsllw $8, %ymm10, %ymm12
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm12 = ymm13 ^ (ymm12 | ymm11)
-; AVX512VL-NEXT:    vpand %ymm2, %ymm1, %ymm10
-; AVX512VL-NEXT:    vpshufb %ymm10, %ymm3, %ymm15
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm10 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; AVX512VL-NEXT:    vpand %ymm10, %ymm15, %ymm11
-; AVX512VL-NEXT:    vpmullw %ymm11, %ymm14, %ymm13
-; AVX512VL-NEXT:    vpand %ymm5, %ymm13, %ymm13
-; AVX512VL-NEXT:    vpandn %ymm11, %ymm5, %ymm11
-; AVX512VL-NEXT:    vpmaddubsw %ymm11, %ymm14, %ymm11
-; AVX512VL-NEXT:    vpsllw $8, %ymm11, %ymm6
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm6 = ymm12 ^ (ymm6 | ymm13)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm11 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; AVX512VL-NEXT:    vpand %ymm11, %ymm15, %ymm12
-; AVX512VL-NEXT:    vpmullw %ymm12, %ymm14, %ymm13
-; AVX512VL-NEXT:    vpand %ymm5, %ymm13, %ymm13
-; AVX512VL-NEXT:    vpandn %ymm12, %ymm5, %ymm12
-; AVX512VL-NEXT:    vpmaddubsw %ymm12, %ymm14, %ymm12
-; AVX512VL-NEXT:    vpsllw $8, %ymm12, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm6 ^ (ymm7 | ymm13)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm12 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; AVX512VL-NEXT:    vpand %ymm12, %ymm15, %ymm6
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm14, %ymm13
-; AVX512VL-NEXT:    vpand %ymm5, %ymm13, %ymm13
-; AVX512VL-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512VL-NEXT:    vpmaddubsw %ymm6, %ymm14, %ymm6
-; AVX512VL-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm6 = ymm7 ^ (ymm6 | ymm13)
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm13 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-; AVX512VL-NEXT:    vpand %ymm13, %ymm15, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm14, %ymm15
-; AVX512VL-NEXT:    vpand %ymm5, %ymm15, %ymm15
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm14, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm6 ^ (ymm7 | ymm15)
-; AVX512VL-NEXT:    vpand %ymm2, %ymm7, %ymm6
-; AVX512VL-NEXT:    vpshufb %ymm6, %ymm3, %ymm6
-; AVX512VL-NEXT:    vpsrlw $4, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpand %ymm2, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpshufb %ymm7, %ymm4, %ymm7
-; AVX512VL-NEXT:    vpor %ymm7, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpsrlw $1, %ymm6, %ymm14
-; AVX512VL-NEXT:    vextracti64x4 $1, %zmm0, %ymm0
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm6
-; AVX512VL-NEXT:    vpshufb %ymm6, %ymm3, %ymm6
-; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpshufb %ymm0, %ymm4, %ymm0
-; AVX512VL-NEXT:    vpor %ymm0, %ymm6, %ymm0
-; AVX512VL-NEXT:    vextracti64x4 $1, %zmm1, %ymm1
-; AVX512VL-NEXT:    vpsrlw $4, %ymm1, %ymm6
-; AVX512VL-NEXT:    vpand %ymm2, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpshufb %ymm6, %ymm4, %ymm6
-; AVX512VL-NEXT:    vpandq %ymm16, %ymm6, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm0, %ymm15
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm7 | (ymm15 & ymm5)
-; AVX512VL-NEXT:    vpandq %ymm17, %ymm6, %ymm15
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm15, %ymm8
-; AVX512VL-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpandn %ymm15, %ymm5, %ymm15
-; AVX512VL-NEXT:    vpmaddubsw %ymm15, %ymm0, %ymm15
-; AVX512VL-NEXT:    vpsllw $8, %ymm15, %ymm15
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm15 = ymm7 ^ (ymm15 | ymm8)
-; AVX512VL-NEXT:    vpandq %ymm18, %ymm6, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm0, %ymm8
-; AVX512VL-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm15 ^ (ymm7 | ymm8)
-; AVX512VL-NEXT:    vpand %ymm6, %ymm9, %ymm6
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm0, %ymm8
-; AVX512VL-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512VL-NEXT:    vpmaddubsw %ymm6, %ymm0, %ymm6
-; AVX512VL-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm6 = ymm7 ^ (ymm6 | ymm8)
+; AVX512VL-NEXT:    vpshufb %ymm5, %ymm4, %ymm5
+; AVX512VL-NEXT:    vpor %ymm5, %ymm7, %ymm12
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm17 = [1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765,1431655765]
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm12, %ymm7
+; AVX512VL-NEXT:    vpmullw %ymm6, %ymm7, %ymm8
+; AVX512VL-NEXT:    vpand %ymm2, %ymm1, %ymm9
+; AVX512VL-NEXT:    vpshufb %ymm9, %ymm3, %ymm9
+; AVX512VL-NEXT:    vpsrlw $4, %ymm1, %ymm1
 ; AVX512VL-NEXT:    vpand %ymm2, %ymm1, %ymm1
-; AVX512VL-NEXT:    vpshufb %ymm1, %ymm3, %ymm1
-; AVX512VL-NEXT:    vpand %ymm1, %ymm10, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm0, %ymm8
-; AVX512VL-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm6 ^ (ymm7 | ymm8)
-; AVX512VL-NEXT:    vpand %ymm1, %ymm11, %ymm6
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm0, %ymm8
-; AVX512VL-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpandn %ymm6, %ymm5, %ymm6
-; AVX512VL-NEXT:    vpmaddubsw %ymm6, %ymm0, %ymm6
-; AVX512VL-NEXT:    vpsllw $8, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm6 = ymm7 ^ (ymm6 | ymm8)
-; AVX512VL-NEXT:    vpand %ymm1, %ymm12, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm0, %ymm8
-; AVX512VL-NEXT:    vpand %ymm5, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpandn %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpmaddubsw %ymm7, %ymm0, %ymm7
-; AVX512VL-NEXT:    vpsllw $8, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm6 ^ (ymm7 | ymm8)
-; AVX512VL-NEXT:    vpand %ymm1, %ymm13, %ymm1
-; AVX512VL-NEXT:    vpmullw %ymm1, %ymm0, %ymm6
-; AVX512VL-NEXT:    vpand %ymm5, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpandn %ymm1, %ymm5, %ymm1
-; AVX512VL-NEXT:    vpmaddubsw %ymm1, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpsllw $8, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm7 ^ (ymm0 | ymm6)
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm1
-; AVX512VL-NEXT:    vpshufb %ymm1, %ymm3, %ymm1
+; AVX512VL-NEXT:    vpshufb %ymm1, %ymm4, %ymm1
+; AVX512VL-NEXT:    vpor %ymm1, %ymm9, %ymm13
+; AVX512VL-NEXT:    vpand %ymm11, %ymm13, %ymm1
+; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm9
+; AVX512VL-NEXT:    vpshufb %ymm9, %ymm3, %ymm9
+; AVX512VL-NEXT:    vmovdqa64 %ymm3, %ymm18
 ; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm0
 ; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm0
 ; AVX512VL-NEXT:    vpshufb %ymm0, %ymm4, %ymm0
-; AVX512VL-NEXT:    vpor %ymm0, %ymm1, %ymm0
+; AVX512VL-NEXT:    vmovdqa64 %ymm4, %ymm19
+; AVX512VL-NEXT:    vpor %ymm0, %ymm9, %ymm14
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm14, %ymm9
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm9, %ymm0
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm8, %zmm0, %zmm15
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm16 = [255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0]
+; AVX512VL-NEXT:    vpandnq %ymm1, %ymm16, %ymm4
+; AVX512VL-NEXT:    vpmaddubsw %ymm4, %ymm9, %ymm8
+; AVX512VL-NEXT:    vpsllw $8, %ymm8, %ymm5
+; AVX512VL-NEXT:    vpandnq %ymm6, %ymm16, %ymm8
+; AVX512VL-NEXT:    vmovdqa64 %ymm6, %ymm20
+; AVX512VL-NEXT:    vpmaddubsw %ymm8, %ymm7, %ymm3
+; AVX512VL-NEXT:    vpsllw $8, %ymm3, %ymm3
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm3, %zmm5, %zmm3
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm3 = zmm3 | (zmm15 & zmm16)
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm10, %ymm5
+; AVX512VL-NEXT:    vpand %ymm11, %ymm12, %ymm10
+; AVX512VL-NEXT:    vpmullw %ymm5, %ymm10, %ymm12
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm13, %ymm13
+; AVX512VL-NEXT:    vpand %ymm11, %ymm14, %ymm11
+; AVX512VL-NEXT:    vpmullw %ymm13, %ymm11, %ymm14
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm12, %zmm14, %zmm12
+; AVX512VL-NEXT:    vpandq %zmm16, %zmm12, %zmm12
+; AVX512VL-NEXT:    vpandnq %ymm13, %ymm16, %ymm14
+; AVX512VL-NEXT:    vpmaddubsw %ymm14, %ymm11, %ymm15
+; AVX512VL-NEXT:    vpsllw $8, %ymm15, %ymm15
+; AVX512VL-NEXT:    vpandnq %ymm5, %ymm16, %ymm0
+; AVX512VL-NEXT:    vpmaddubsw %ymm0, %ymm10, %ymm6
+; AVX512VL-NEXT:    vpsllw $8, %ymm6, %ymm6
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm6, %zmm15, %zmm6
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm6 = zmm3 ^ (zmm6 | zmm12)
+; AVX512VL-NEXT:    vpmullw %ymm5, %ymm7, %ymm3
+; AVX512VL-NEXT:    vpmullw %ymm13, %ymm9, %ymm5
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm3, %zmm5, %zmm3
+; AVX512VL-NEXT:    vpmaddubsw %ymm14, %ymm9, %ymm5
+; AVX512VL-NEXT:    vpsllw $8, %ymm5, %ymm5
+; AVX512VL-NEXT:    vpmaddubsw %ymm0, %ymm7, %ymm0
+; AVX512VL-NEXT:    vpsllw $8, %ymm0, %ymm0
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm0, %zmm5, %zmm0
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm0 | (zmm3 & zmm16)
+; AVX512VL-NEXT:    vmovdqa64 %ymm20, %ymm3
+; AVX512VL-NEXT:    vpmullw %ymm3, %ymm10, %ymm3
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm11, %ymm1
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm3, %zmm1, %zmm1
+; AVX512VL-NEXT:    vpandq %zmm16, %zmm1, %zmm1
+; AVX512VL-NEXT:    vpmaddubsw %ymm4, %ymm11, %ymm3
+; AVX512VL-NEXT:    vpsllw $8, %ymm3, %ymm3
+; AVX512VL-NEXT:    vpmaddubsw %ymm8, %ymm10, %ymm4
+; AVX512VL-NEXT:    vpsllw $8, %ymm4, %ymm4
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm4, %zmm3, %zmm3
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm3 = zmm0 ^ (zmm3 | zmm1)
+; AVX512VL-NEXT:    vpternlogd {{.*#+}} zmm3 = zmm6 ^ (zmm17 & (zmm3 ^ zmm6))
+; AVX512VL-NEXT:    vpand %ymm2, %ymm3, %ymm0
+; AVX512VL-NEXT:    vmovdqa64 %ymm18, %ymm4
+; AVX512VL-NEXT:    vpshufb %ymm0, %ymm4, %ymm0
+; AVX512VL-NEXT:    vpsrlw $4, %ymm3, %ymm1
+; AVX512VL-NEXT:    vpand %ymm2, %ymm1, %ymm1
+; AVX512VL-NEXT:    vmovdqa64 %ymm19, %ymm5
+; AVX512VL-NEXT:    vpshufb %ymm1, %ymm5, %ymm1
+; AVX512VL-NEXT:    vpor %ymm1, %ymm0, %ymm0
 ; AVX512VL-NEXT:    vpsrlw $1, %ymm0, %ymm0
-; AVX512VL-NEXT:    vinserti64x4 $1, %ymm0, %zmm14, %zmm0
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm3, %ymm1
+; AVX512VL-NEXT:    vpand %ymm2, %ymm1, %ymm3
+; AVX512VL-NEXT:    vpshufb %ymm3, %ymm4, %ymm3
+; AVX512VL-NEXT:    vpsrlw $4, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpand %ymm2, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpshufb %ymm1, %ymm5, %ymm1
+; AVX512VL-NEXT:    vpor %ymm1, %ymm3, %ymm1
+; AVX512VL-NEXT:    vpsrlw $1, %ymm1, %ymm1
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
 ; AVX512VL-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm0, %zmm0
 ; AVX512VL-NEXT:    retq
   %a.ext = zext <64 x i8> %a to <64 x i16>
@@ -1527,312 +1211,236 @@ define <64 x i8> @clmulh_v64i8(<64 x i8> %a, <64 x i8> %b) nounwind {
 define <32 x i16> @clmulh_v32i16(<32 x i16> %a, <32 x i16> %b) nounwind {
 ; AVX512F-LABEL: clmulh_v32i16:
 ; AVX512F:       # %bb.0:
-; AVX512F-NEXT:    vmovdqa64 %zmm1, %zmm5
-; AVX512F-NEXT:    vmovdqa64 %zmm0, %zmm4
-; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm12 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14,1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
-; AVX512F-NEXT:    # ymm12 = mem[0,1,0,1]
-; AVX512F-NEXT:    vpshufb %ymm12, %ymm4, %ymm0
-; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm3
-; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm8 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
-; AVX512F-NEXT:    # ymm8 = mem[0,1,0,1]
-; AVX512F-NEXT:    vpshufb %ymm3, %ymm8, %ymm3
-; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm0
+; AVX512F-NEXT:    vmovdqa64 %zmm0, %zmm13
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm1, %ymm2
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm0 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14,1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
+; AVX512F-NEXT:    # ymm0 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm0, %ymm2, %ymm5
+; AVX512F-NEXT:    vmovdqa %ymm0, %ymm2
+; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm0 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX512F-NEXT:    vpand %ymm0, %ymm5, %ymm6
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX512F-NEXT:    # ymm4 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm6, %ymm4, %ymm6
+; AVX512F-NEXT:    vpsrlw $4, %ymm5, %ymm5
+; AVX512F-NEXT:    vpand %ymm0, %ymm5, %ymm7
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX512F-NEXT:    # ymm3 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm7, %ymm3, %ymm7
+; AVX512F-NEXT:    vpor %ymm7, %ymm6, %ymm10
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm7 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX512F-NEXT:    vpand %ymm7, %ymm10, %ymm11
+; AVX512F-NEXT:    vmovdqu %ymm11, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm13, %ymm8
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm8, %ymm8
+; AVX512F-NEXT:    vpand %ymm0, %ymm8, %ymm9
+; AVX512F-NEXT:    vmovdqa %ymm4, %ymm5
+; AVX512F-NEXT:    vpshufb %ymm9, %ymm4, %ymm9
+; AVX512F-NEXT:    vpsrlw $4, %ymm8, %ymm8
+; AVX512F-NEXT:    vpand %ymm0, %ymm8, %ymm8
+; AVX512F-NEXT:    vmovdqa %ymm3, %ymm6
+; AVX512F-NEXT:    vpshufb %ymm8, %ymm3, %ymm8
+; AVX512F-NEXT:    vpor %ymm8, %ymm9, %ymm12
+; AVX512F-NEXT:    vpand %ymm7, %ymm12, %ymm8
+; AVX512F-NEXT:    vpmullw %ymm11, %ymm8, %ymm9
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm1, %ymm1
+; AVX512F-NEXT:    vpand %ymm0, %ymm1, %ymm11
+; AVX512F-NEXT:    vpshufb %ymm11, %ymm4, %ymm11
+; AVX512F-NEXT:    vpsrlw $4, %ymm1, %ymm1
+; AVX512F-NEXT:    vpand %ymm0, %ymm1, %ymm1
+; AVX512F-NEXT:    vpshufb %ymm1, %ymm3, %ymm1
+; AVX512F-NEXT:    vpor %ymm1, %ymm11, %ymm1
+; AVX512F-NEXT:    vpand %ymm7, %ymm1, %ymm4
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm13, %ymm3
+; AVX512F-NEXT:    vpand %ymm0, %ymm3, %ymm11
+; AVX512F-NEXT:    vpshufb %ymm11, %ymm5, %ymm11
+; AVX512F-NEXT:    vpsrlw $4, %ymm3, %ymm3
+; AVX512F-NEXT:    vpand %ymm0, %ymm3, %ymm3
+; AVX512F-NEXT:    vpshufb %ymm3, %ymm6, %ymm3
+; AVX512F-NEXT:    vpor %ymm3, %ymm11, %ymm0
+; AVX512F-NEXT:    vpand %ymm7, %ymm0, %ymm11
+; AVX512F-NEXT:    vpmullw %ymm4, %ymm11, %ymm3
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm9, %zmm3, %zmm16
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm5 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX512F-NEXT:    vpand %ymm5, %ymm10, %ymm14
+; AVX512F-NEXT:    vpbroadcastd {{.*#+}} zmm9 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX512F-NEXT:    vpand %ymm9, %ymm12, %ymm13
+; AVX512F-NEXT:    vpmullw %ymm14, %ymm13, %ymm3
+; AVX512F-NEXT:    vpand %ymm5, %ymm1, %ymm2
+; AVX512F-NEXT:    vpand %ymm0, %ymm9, %ymm15
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm15, %ymm6
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm3, %zmm6, %zmm17
+; AVX512F-NEXT:    vpand %ymm9, %ymm10, %ymm6
+; AVX512F-NEXT:    vpand %ymm5, %ymm12, %ymm10
+; AVX512F-NEXT:    vpand %ymm1, %ymm9, %ymm1
+; AVX512F-NEXT:    vpand %ymm5, %ymm0, %ymm0
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm10, %ymm12
+; AVX512F-NEXT:    vpmullw %ymm1, %ymm0, %ymm3
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm12, %zmm3, %zmm19
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm8, %ymm12
+; AVX512F-NEXT:    vpmullw %ymm1, %ymm11, %ymm5
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm12, %zmm5, %zmm18
+; AVX512F-NEXT:    vmovdqu {{[-0-9]+}}(%r{{[sb]}}p), %ymm3 # 32-byte Reload
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm13, %ymm12
+; AVX512F-NEXT:    vpmullw %ymm4, %ymm15, %ymm5
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm12, %zmm5, %zmm5
+; AVX512F-NEXT:    vpmullw %ymm14, %ymm10, %ymm12
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm0, %ymm7
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm12, %zmm7, %zmm7
+; AVX512F-NEXT:    vpmullw %ymm14, %ymm8, %ymm8
+; AVX512F-NEXT:    vpmullw %ymm2, %ymm11, %ymm2
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm8, %zmm2, %zmm2
+; AVX512F-NEXT:    vpmullw %ymm6, %ymm13, %ymm6
+; AVX512F-NEXT:    vpmullw %ymm1, %ymm15, %ymm1
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm6, %zmm1, %zmm1
+; AVX512F-NEXT:    vpmullw %ymm3, %ymm10, %ymm6
+; AVX512F-NEXT:    vpmullw %ymm4, %ymm0, %ymm0
+; AVX512F-NEXT:    vinserti64x4 $1, %ymm6, %zmm0, %zmm0
+; AVX512F-NEXT:    vpxorq %zmm2, %zmm1, %zmm1
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm9 & (zmm0 ^ zmm1)
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm19 = zmm19 ^ zmm17 ^ zmm16
+; AVX512F-NEXT:    vpternlogq {{.*#+}} zmm7 = zmm7 ^ zmm5 ^ zmm18
+; AVX512F-NEXT:    vpternlogd {{.*#+}} zmm0 = zmm0 | (zmm7 & m32bcst)
+; AVX512F-NEXT:    vpternlogd {{.*#+}} zmm0 = zmm0 | (zmm19 & m32bcst)
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14,1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
+; AVX512F-NEXT:    # ymm4 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm4, %ymm0, %ymm1
+; AVX512F-NEXT:    vpbroadcastb {{.*#+}} ymm3 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX512F-NEXT:    vpand %ymm3, %ymm1, %ymm2
+; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm5 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
+; AVX512F-NEXT:    # ymm5 = mem[0,1,0,1]
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm5, %ymm2
+; AVX512F-NEXT:    vpsrlw $4, %ymm1, %ymm1
+; AVX512F-NEXT:    vpand %ymm3, %ymm1, %ymm1
 ; AVX512F-NEXT:    vbroadcasti128 {{.*#+}} ymm6 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
 ; AVX512F-NEXT:    # ymm6 = mem[0,1,0,1]
-; AVX512F-NEXT:    vpshufb %ymm0, %ymm6, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm3, %ymm3
-; AVX512F-NEXT:    vpshufb %ymm12, %ymm5, %ymm0
-; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm7
-; AVX512F-NEXT:    vpand %ymm2, %ymm7, %ymm7
-; AVX512F-NEXT:    vpshufb %ymm7, %ymm6, %ymm7
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm14 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; AVX512F-NEXT:    vpand %ymm7, %ymm14, %ymm9
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm9, %ymm9
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm10, %ymm10
-; AVX512F-NEXT:    vpxor %ymm9, %ymm10, %ymm9
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpxor %ymm10, %ymm9, %ymm9
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm0, %ymm8, %ymm0
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpxor %ymm10, %ymm9, %ymm9
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm7, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm11, %ymm10, %ymm10
-; AVX512F-NEXT:    vpxor %ymm10, %ymm9, %ymm1
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm13 = [2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048]
-; AVX512F-NEXT:    vpand %ymm7, %ymm13, %ymm7
-; AVX512F-NEXT:    vpmullw %ymm7, %ymm3, %ymm7
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm11 = [4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096]
-; AVX512F-NEXT:    vpand %ymm0, %ymm11, %ymm9
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm9, %ymm9
-; AVX512F-NEXT:    vpxor %ymm7, %ymm9, %ymm7
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm10 = [8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192]
-; AVX512F-NEXT:    vpand %ymm0, %ymm10, %ymm9
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm9, %ymm9
-; AVX512F-NEXT:    vpxor %ymm7, %ymm9, %ymm7
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm9 = [16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384]
-; AVX512F-NEXT:    vpand %ymm0, %ymm9, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm3, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm7, %ymm15, %ymm15
-; AVX512F-NEXT:    vpbroadcastw {{.*#+}} ymm7 = [32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768]
-; AVX512F-NEXT:    vpand %ymm7, %ymm0, %ymm0
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm3, %ymm0
-; AVX512F-NEXT:    vpxor %ymm0, %ymm15, %ymm0
-; AVX512F-NEXT:    vpxor %ymm0, %ymm1, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm12, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm8, %ymm1
-; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm0, %ymm6, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm1, %ymm3
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm4, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm12, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm8, %ymm1
-; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm0, %ymm6, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm1, %ymm0
-; AVX512F-NEXT:    vextracti64x4 $1, %zmm5, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm12, %ymm1, %ymm4
-; AVX512F-NEXT:    vpsrlw $4, %ymm4, %ymm1
-; AVX512F-NEXT:    vpand %ymm2, %ymm1, %ymm1
 ; AVX512F-NEXT:    vpshufb %ymm1, %ymm6, %ymm1
-; AVX512F-NEXT:    vpand %ymm1, %ymm14, %ymm5
-; AVX512F-NEXT:    vpmullw %ymm5, %ymm0, %ymm5
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm5, %ymm15, %ymm5
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm15, %ymm15
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm14
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm14, %ymm14
-; AVX512F-NEXT:    vpxor %ymm14, %ymm15, %ymm14
-; AVX512F-NEXT:    vpxor %ymm5, %ymm14, %ymm5
-; AVX512F-NEXT:    vpand %ymm2, %ymm4, %ymm4
-; AVX512F-NEXT:    vpshufb %ymm4, %ymm8, %ymm4
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm4, %ymm14
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm14, %ymm14
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm4, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm15, %ymm14, %ymm14
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm4, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm15, %ymm14, %ymm14
-; AVX512F-NEXT:    vpxor %ymm5, %ymm14, %ymm5
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm4, %ymm14
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm14, %ymm14
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm15, %ymm14, %ymm14
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm15, %ymm14, %ymm14
-; AVX512F-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm15
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm15, %ymm15
-; AVX512F-NEXT:    vpxor %ymm15, %ymm14, %ymm14
-; AVX512F-NEXT:    vpxor %ymm5, %ymm14, %ymm5
-; AVX512F-NEXT:    vpand %ymm1, %ymm13, %ymm1
-; AVX512F-NEXT:    vpmullw %ymm1, %ymm0, %ymm1
-; AVX512F-NEXT:    vpand %ymm4, %ymm11, %ymm11
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm11, %ymm11
-; AVX512F-NEXT:    vpxor %ymm1, %ymm11, %ymm1
-; AVX512F-NEXT:    vpand %ymm4, %ymm10, %ymm10
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512F-NEXT:    vpxor %ymm1, %ymm10, %ymm1
-; AVX512F-NEXT:    vpand %ymm4, %ymm9, %ymm9
-; AVX512F-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512F-NEXT:    vpxor %ymm1, %ymm9, %ymm1
-; AVX512F-NEXT:    vpand %ymm7, %ymm4, %ymm4
-; AVX512F-NEXT:    vpmullw %ymm4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpxor %ymm0, %ymm1, %ymm0
-; AVX512F-NEXT:    vpxor %ymm0, %ymm5, %ymm0
-; AVX512F-NEXT:    vpshufb %ymm12, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm1
-; AVX512F-NEXT:    vpshufb %ymm1, %ymm8, %ymm1
+; AVX512F-NEXT:    vpor %ymm1, %ymm2, %ymm1
+; AVX512F-NEXT:    vextracti64x4 $1, %zmm0, %ymm0
+; AVX512F-NEXT:    vpshufb %ymm4, %ymm0, %ymm0
+; AVX512F-NEXT:    vpand %ymm3, %ymm0, %ymm2
+; AVX512F-NEXT:    vpshufb %ymm2, %ymm5, %ymm2
 ; AVX512F-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512F-NEXT:    vpand %ymm2, %ymm0, %ymm0
+; AVX512F-NEXT:    vpand %ymm3, %ymm0, %ymm0
 ; AVX512F-NEXT:    vpshufb %ymm0, %ymm6, %ymm0
-; AVX512F-NEXT:    vpor %ymm0, %ymm1, %ymm0
-; AVX512F-NEXT:    vpsrlw $1, %ymm3, %ymm1
+; AVX512F-NEXT:    vpor %ymm0, %ymm2, %ymm0
+; AVX512F-NEXT:    vpsrlw $1, %ymm1, %ymm1
 ; AVX512F-NEXT:    vpsrlw $1, %ymm0, %ymm0
 ; AVX512F-NEXT:    vinserti64x4 $1, %ymm0, %zmm1, %zmm0
 ; AVX512F-NEXT:    retq
 ;
 ; AVX512VL-LABEL: clmulh_v32i16:
 ; AVX512VL:       # %bb.0:
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm1, %ymm2
 ; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm3 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14,1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
 ; AVX512VL-NEXT:    # ymm3 = mem[0,1,0,1]
-; AVX512VL-NEXT:    vpshufb %ymm3, %ymm0, %ymm5
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; AVX512VL-NEXT:    vpand %ymm2, %ymm5, %ymm6
+; AVX512VL-NEXT:    vpshufb %ymm3, %ymm2, %ymm5
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm20 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm5, %ymm6
 ; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm4 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240,0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
 ; AVX512VL-NEXT:    # ymm4 = mem[0,1,0,1]
 ; AVX512VL-NEXT:    vpshufb %ymm6, %ymm4, %ymm6
 ; AVX512VL-NEXT:    vpsrlw $4, %ymm5, %ymm5
-; AVX512VL-NEXT:    vpand %ymm2, %ymm5, %ymm7
-; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm5 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
-; AVX512VL-NEXT:    # ymm5 = mem[0,1,0,1]
-; AVX512VL-NEXT:    vpshufb %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpor %ymm7, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpshufb %ymm3, %ymm1, %ymm8
-; AVX512VL-NEXT:    vpsrlw $4, %ymm8, %ymm7
-; AVX512VL-NEXT:    vpand %ymm2, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpshufb %ymm7, %ymm5, %ymm7
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm22 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; AVX512VL-NEXT:    vpandq %ymm22, %ymm7, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm23 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-; AVX512VL-NEXT:    vpandq %ymm23, %ymm7, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpxor %ymm9, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm24 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; AVX512VL-NEXT:    vpandq %ymm24, %ymm7, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm11
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm25 = [8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8]
-; AVX512VL-NEXT:    vpandq %ymm25, %ymm7, %ymm12
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm12, %ymm12
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm12 = ymm12 ^ ymm10 ^ ymm11
-; AVX512VL-NEXT:    vpand %ymm2, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpshufb %ymm8, %ymm4, %ymm8
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm26 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; AVX512VL-NEXT:    vpandq %ymm26, %ymm8, %ymm11
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm11, %ymm13
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm27 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; AVX512VL-NEXT:    vpandq %ymm27, %ymm8, %ymm14
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm14, %ymm14
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm14 = ymm14 ^ ymm12 ^ ymm13
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm12 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; AVX512VL-NEXT:    vpand %ymm12, %ymm8, %ymm13
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm13, %ymm15
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm13 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-; AVX512VL-NEXT:    vpand %ymm13, %ymm8, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm9 = ymm9 ^ ymm14 ^ ymm15
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm14 = [256,256,256,256,256,256,256,256,256,256,256,256,256,256,256,256]
-; AVX512VL-NEXT:    vpand %ymm7, %ymm14, %ymm15
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm15, %ymm10
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm15 = [512,512,512,512,512,512,512,512,512,512,512,512,512,512,512,512]
-; AVX512VL-NEXT:    vpand %ymm7, %ymm15, %ymm11
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm11, %ymm11
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm11 = ymm11 ^ ymm9 ^ ymm10
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm16 = [1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024,1024]
-; AVX512VL-NEXT:    vpandq %ymm16, %ymm7, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm17 = [2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048,2048]
-; AVX512VL-NEXT:    vpandq %ymm17, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm6, %ymm7
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm7 = ymm7 ^ ymm11 ^ ymm9
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm18 = [4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096,4096]
-; AVX512VL-NEXT:    vpandq %ymm18, %ymm8, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm19 = [8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192,8192]
-; AVX512VL-NEXT:    vpandq %ymm19, %ymm8, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm10 = ymm10 ^ ymm7 ^ ymm9
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm20 = [16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384,16384]
-; AVX512VL-NEXT:    vpandq %ymm20, %ymm8, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm6, %ymm7
-; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} ymm21 = [32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768,32768]
-; AVX512VL-NEXT:    vpandq %ymm21, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpmullw %ymm6, %ymm8, %ymm6
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm6 = ymm6 ^ ymm10 ^ ymm7
-; AVX512VL-NEXT:    vpshufb %ymm3, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpand %ymm2, %ymm6, %ymm7
-; AVX512VL-NEXT:    vpshufb %ymm7, %ymm4, %ymm7
-; AVX512VL-NEXT:    vpsrlw $4, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpand %ymm2, %ymm6, %ymm6
-; AVX512VL-NEXT:    vpshufb %ymm6, %ymm5, %ymm6
-; AVX512VL-NEXT:    vpor %ymm6, %ymm7, %ymm6
-; AVX512VL-NEXT:    vpsrlw $1, %ymm6, %ymm6
-; AVX512VL-NEXT:    vextracti64x4 $1, %zmm0, %ymm0
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm5, %ymm7
+; AVX512VL-NEXT:    vbroadcasti128 {{.*#+}} ymm2 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15,0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; AVX512VL-NEXT:    # ymm2 = mem[0,1,0,1]
+; AVX512VL-NEXT:    vpshufb %ymm7, %ymm2, %ymm7
+; AVX512VL-NEXT:    vpor %ymm7, %ymm6, %ymm12
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm19 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX512VL-NEXT:    vpandq %ymm19, %ymm12, %ymm5
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm0, %ymm8
+; AVX512VL-NEXT:    vpshufb %ymm3, %ymm8, %ymm8
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm8, %ymm9
+; AVX512VL-NEXT:    vpshufb %ymm9, %ymm4, %ymm9
+; AVX512VL-NEXT:    vpsrlw $4, %ymm8, %ymm8
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm8, %ymm8
+; AVX512VL-NEXT:    vpshufb %ymm8, %ymm2, %ymm8
+; AVX512VL-NEXT:    vpor %ymm8, %ymm9, %ymm13
+; AVX512VL-NEXT:    vpandq %ymm19, %ymm13, %ymm8
+; AVX512VL-NEXT:    vpmullw %ymm5, %ymm8, %ymm9
+; AVX512VL-NEXT:    vpshufb %ymm3, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm1, %ymm10
+; AVX512VL-NEXT:    vpshufb %ymm10, %ymm4, %ymm10
+; AVX512VL-NEXT:    vpsrlw $4, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpshufb %ymm1, %ymm2, %ymm1
+; AVX512VL-NEXT:    vpor %ymm1, %ymm10, %ymm14
+; AVX512VL-NEXT:    vpandq %ymm19, %ymm14, %ymm1
 ; AVX512VL-NEXT:    vpshufb %ymm3, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm7
-; AVX512VL-NEXT:    vpshufb %ymm7, %ymm4, %ymm7
+; AVX512VL-NEXT:    vmovdqa64 %ymm3, %ymm22
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm0, %ymm10
+; AVX512VL-NEXT:    vpshufb %ymm10, %ymm4, %ymm10
+; AVX512VL-NEXT:    vmovdqa64 %ymm4, %ymm23
 ; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm0
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm0, %ymm0
+; AVX512VL-NEXT:    vpshufb %ymm0, %ymm2, %ymm0
+; AVX512VL-NEXT:    vmovdqa64 %ymm2, %ymm24
+; AVX512VL-NEXT:    vpor %ymm0, %ymm10, %ymm15
+; AVX512VL-NEXT:    vpandq %ymm19, %ymm15, %ymm0
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm0, %ymm10
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm9, %zmm10, %zmm16
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm17 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm12, %ymm10
+; AVX512VL-NEXT:    vpbroadcastd {{.*#+}} zmm18 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX512VL-NEXT:    vpandq %ymm18, %ymm13, %ymm9
+; AVX512VL-NEXT:    vpmullw %ymm10, %ymm9, %ymm6
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm14, %ymm2
+; AVX512VL-NEXT:    vpandq %ymm18, %ymm15, %ymm11
+; AVX512VL-NEXT:    vpmullw %ymm2, %ymm11, %ymm3
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm6, %zmm3, %zmm21
+; AVX512VL-NEXT:    vpandq %ymm18, %ymm12, %ymm6
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm13, %ymm13
+; AVX512VL-NEXT:    vpmullw %ymm6, %ymm13, %ymm3
+; AVX512VL-NEXT:    vpandq %ymm18, %ymm14, %ymm14
+; AVX512VL-NEXT:    vpandq %ymm17, %ymm15, %ymm12
+; AVX512VL-NEXT:    vpmullw %ymm14, %ymm12, %ymm15
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm3, %zmm15, %zmm3
+; AVX512VL-NEXT:    vpmullw %ymm6, %ymm8, %ymm15
+; AVX512VL-NEXT:    vpmullw %ymm0, %ymm14, %ymm4
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm15, %zmm4, %zmm25
+; AVX512VL-NEXT:    vpmullw %ymm5, %ymm9, %ymm15
+; AVX512VL-NEXT:    vmovdqa %ymm5, %ymm4
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm11, %ymm5
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm15, %zmm5, %zmm5
+; AVX512VL-NEXT:    vpmullw %ymm10, %ymm13, %ymm15
+; AVX512VL-NEXT:    vpmullw %ymm2, %ymm12, %ymm7
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm15, %zmm7, %zmm7
+; AVX512VL-NEXT:    vpmullw %ymm10, %ymm8, %ymm8
+; AVX512VL-NEXT:    vpmullw %ymm2, %ymm0, %ymm0
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm8, %zmm0, %zmm0
+; AVX512VL-NEXT:    vpmullw %ymm6, %ymm9, %ymm2
+; AVX512VL-NEXT:    vpmullw %ymm14, %ymm11, %ymm6
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm2, %zmm6, %zmm2
+; AVX512VL-NEXT:    vpmullw %ymm4, %ymm13, %ymm6
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm3 = zmm3 ^ zmm21 ^ zmm16
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm7 = zmm7 ^ zmm5 ^ zmm25
+; AVX512VL-NEXT:    vpxorq %zmm0, %zmm2, %zmm0
+; AVX512VL-NEXT:    vpmullw %ymm1, %ymm12, %ymm1
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm6, %zmm1, %zmm1
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm18 & (zmm1 ^ zmm0)
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm1 | (zmm7 & zmm19)
+; AVX512VL-NEXT:    vpternlogq {{.*#+}} zmm1 = zmm1 | (zmm3 & zmm17)
+; AVX512VL-NEXT:    vmovdqa64 %ymm22, %ymm3
+; AVX512VL-NEXT:    vpshufb %ymm3, %ymm1, %ymm0
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm0, %ymm2
+; AVX512VL-NEXT:    vmovdqa64 %ymm23, %ymm4
+; AVX512VL-NEXT:    vpshufb %ymm2, %ymm4, %ymm2
+; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm0
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm0, %ymm0
+; AVX512VL-NEXT:    vmovdqa64 %ymm24, %ymm5
 ; AVX512VL-NEXT:    vpshufb %ymm0, %ymm5, %ymm0
-; AVX512VL-NEXT:    vpor %ymm0, %ymm7, %ymm0
+; AVX512VL-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX512VL-NEXT:    vextracti64x4 $1, %zmm1, %ymm1
-; AVX512VL-NEXT:    vpshufb %ymm3, %ymm1, %ymm7
-; AVX512VL-NEXT:    vpsrlw $4, %ymm7, %ymm1
-; AVX512VL-NEXT:    vpand %ymm2, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpshufb %ymm3, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm1, %ymm2
+; AVX512VL-NEXT:    vpshufb %ymm2, %ymm4, %ymm2
+; AVX512VL-NEXT:    vpsrlw $4, %ymm1, %ymm1
+; AVX512VL-NEXT:    vpandq %ymm20, %ymm1, %ymm1
 ; AVX512VL-NEXT:    vpshufb %ymm1, %ymm5, %ymm1
-; AVX512VL-NEXT:    vpandq %ymm22, %ymm1, %ymm8
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpandq %ymm23, %ymm1, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpxor %ymm8, %ymm9, %ymm8
-; AVX512VL-NEXT:    vpandq %ymm24, %ymm1, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpandq %ymm25, %ymm1, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm10 = ymm10 ^ ymm8 ^ ymm9
-; AVX512VL-NEXT:    vpand %ymm2, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpshufb %ymm7, %ymm4, %ymm7
-; AVX512VL-NEXT:    vpandq %ymm26, %ymm7, %ymm8
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpandq %ymm27, %ymm7, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm9 = ymm9 ^ ymm10 ^ ymm8
-; AVX512VL-NEXT:    vpand %ymm7, %ymm12, %ymm8
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpand %ymm7, %ymm13, %ymm10
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm10, %ymm10
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm10 = ymm10 ^ ymm9 ^ ymm8
-; AVX512VL-NEXT:    vpand %ymm1, %ymm14, %ymm8
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpand %ymm1, %ymm15, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm9 = ymm9 ^ ymm10 ^ ymm8
-; AVX512VL-NEXT:    vpandq %ymm16, %ymm1, %ymm8
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpandq %ymm17, %ymm1, %ymm1
-; AVX512VL-NEXT:    vpmullw %ymm1, %ymm0, %ymm1
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm1 = ymm1 ^ ymm9 ^ ymm8
-; AVX512VL-NEXT:    vpandq %ymm18, %ymm7, %ymm8
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm8, %ymm8
-; AVX512VL-NEXT:    vpandq %ymm19, %ymm7, %ymm9
-; AVX512VL-NEXT:    vpmullw %ymm0, %ymm9, %ymm9
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm9 = ymm9 ^ ymm1 ^ ymm8
-; AVX512VL-NEXT:    vpandq %ymm20, %ymm7, %ymm1
-; AVX512VL-NEXT:    vpmullw %ymm1, %ymm0, %ymm1
-; AVX512VL-NEXT:    vpandq %ymm21, %ymm7, %ymm7
-; AVX512VL-NEXT:    vpmullw %ymm7, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 ^ ymm9 ^ ymm1
-; AVX512VL-NEXT:    vpshufb %ymm3, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm1
-; AVX512VL-NEXT:    vpshufb %ymm1, %ymm4, %ymm1
-; AVX512VL-NEXT:    vpsrlw $4, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX512VL-NEXT:    vpshufb %ymm0, %ymm5, %ymm0
-; AVX512VL-NEXT:    vpor %ymm0, %ymm1, %ymm0
+; AVX512VL-NEXT:    vpor %ymm1, %ymm2, %ymm1
 ; AVX512VL-NEXT:    vpsrlw $1, %ymm0, %ymm0
-; AVX512VL-NEXT:    vinserti64x4 $1, %ymm0, %zmm6, %zmm0
+; AVX512VL-NEXT:    vpsrlw $1, %ymm1, %ymm1
+; AVX512VL-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
 ; AVX512VL-NEXT:    retq
   %a.ext = zext <32 x i16> %a to <32 x i32>
   %b.ext = zext <32 x i16> %b to <32 x i32>

--- a/llvm/test/CodeGen/X86/clmul-vector.ll
+++ b/llvm/test/CodeGen/X86/clmul-vector.ll
@@ -10,290 +10,161 @@
 define <16 x i8> @clmul_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; SSE2-LABEL: clmul_v16i8:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    movdqa %xmm0, %xmm2
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm2 = xmm2[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; SSE2-NEXT:    pand %xmm1, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm5
+; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; SSE2-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-NEXT:    pand %xmm3, %xmm4
+; SSE2-NEXT:    pand %xmm1, %xmm3
+; SSE2-NEXT:    pand %xmm2, %xmm1
+; SSE2-NEXT:    movdqa %xmm1, %xmm5
 ; SSE2-NEXT:    punpckhbw {{.*#+}} xmm5 = xmm5[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm2, %xmm5
-; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [255,255,255,255,255,255,255,255]
-; SSE2-NEXT:    pand %xmm3, %xmm5
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm4 = xmm4[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm4
-; SSE2-NEXT:    pand %xmm3, %xmm4
-; SSE2-NEXT:    packuswb %xmm5, %xmm4
-; SSE2-NEXT:    movdqa {{.*#+}} xmm5 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-; SSE2-NEXT:    pand %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm6
+; SSE2-NEXT:    movdqa %xmm4, %xmm9
+; SSE2-NEXT:    punpckhbw {{.*#+}} xmm9 = xmm9[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
+; SSE2-NEXT:    movdqa %xmm3, %xmm7
+; SSE2-NEXT:    punpckhbw {{.*#+}} xmm7 = xmm7[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
+; SSE2-NEXT:    pand %xmm2, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm6
 ; SSE2-NEXT:    punpckhbw {{.*#+}} xmm6 = xmm6[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm2, %xmm6
-; SSE2-NEXT:    pand %xmm3, %xmm6
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm5 = xmm5[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm5
-; SSE2-NEXT:    pand %xmm3, %xmm5
-; SSE2-NEXT:    packuswb %xmm6, %xmm5
-; SSE2-NEXT:    pxor %xmm4, %xmm5
-; SSE2-NEXT:    movdqa {{.*#+}} xmm6 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; SSE2-NEXT:    pand %xmm1, %xmm6
-; SSE2-NEXT:    movdqa %xmm6, %xmm4
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm4 = xmm4[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm2, %xmm4
-; SSE2-NEXT:    pand %xmm3, %xmm4
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm6 = xmm6[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm6
-; SSE2-NEXT:    pand %xmm3, %xmm6
-; SSE2-NEXT:    packuswb %xmm4, %xmm6
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8]
-; SSE2-NEXT:    pand %xmm1, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm7
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm7 = xmm7[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm2, %xmm7
-; SSE2-NEXT:    pand %xmm3, %xmm7
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm4 = xmm4[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm4
-; SSE2-NEXT:    pand %xmm3, %xmm4
-; SSE2-NEXT:    packuswb %xmm7, %xmm4
-; SSE2-NEXT:    pxor %xmm6, %xmm4
-; SSE2-NEXT:    pxor %xmm5, %xmm4
-; SSE2-NEXT:    movdqa {{.*#+}} xmm5 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; SSE2-NEXT:    pand %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm6
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm6 = xmm6[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm2, %xmm6
-; SSE2-NEXT:    pand %xmm3, %xmm6
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm5 = xmm5[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm5
-; SSE2-NEXT:    pand %xmm3, %xmm5
-; SSE2-NEXT:    packuswb %xmm6, %xmm5
-; SSE2-NEXT:    movdqa {{.*#+}} xmm6 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; SSE2-NEXT:    pand %xmm1, %xmm6
-; SSE2-NEXT:    movdqa %xmm6, %xmm7
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm7 = xmm7[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm2, %xmm7
-; SSE2-NEXT:    pand %xmm3, %xmm7
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm6 = xmm6[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm6
-; SSE2-NEXT:    pand %xmm3, %xmm6
-; SSE2-NEXT:    packuswb %xmm7, %xmm6
-; SSE2-NEXT:    pxor %xmm5, %xmm6
-; SSE2-NEXT:    movdqa {{.*#+}} xmm5 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; SSE2-NEXT:    pand %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm7
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm7 = xmm7[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm2, %xmm7
-; SSE2-NEXT:    pand %xmm3, %xmm7
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm5 = xmm5[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm5
-; SSE2-NEXT:    pand %xmm3, %xmm5
-; SSE2-NEXT:    packuswb %xmm7, %xmm5
-; SSE2-NEXT:    pxor %xmm6, %xmm5
-; SSE2-NEXT:    pxor %xmm4, %xmm5
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
-; SSE2-NEXT:    movdqa %xmm1, %xmm4
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm4 = xmm4[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm2, %xmm4
-; SSE2-NEXT:    pand %xmm3, %xmm4
+; SSE2-NEXT:    movdqa %xmm6, %xmm8
+; SSE2-NEXT:    pmullw %xmm7, %xmm8
+; SSE2-NEXT:    pmullw %xmm9, %xmm7
+; SSE2-NEXT:    movdqa %xmm9, %xmm10
+; SSE2-NEXT:    pmullw %xmm5, %xmm10
+; SSE2-NEXT:    movdqa {{.*#+}} xmm11 = [255,255,255,255,255,255,255,255]
+; SSE2-NEXT:    pand %xmm11, %xmm10
 ; SSE2-NEXT:    punpcklbw {{.*#+}} xmm1 = xmm1[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm4 = xmm4[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm3 = xmm3[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    movdqa %xmm0, %xmm9
+; SSE2-NEXT:    pmullw %xmm3, %xmm9
+; SSE2-NEXT:    pmullw %xmm4, %xmm3
+; SSE2-NEXT:    pmullw %xmm1, %xmm4
+; SSE2-NEXT:    pand %xmm11, %xmm4
+; SSE2-NEXT:    packuswb %xmm10, %xmm4
+; SSE2-NEXT:    pand %xmm11, %xmm8
+; SSE2-NEXT:    pand %xmm11, %xmm9
+; SSE2-NEXT:    packuswb %xmm8, %xmm9
+; SSE2-NEXT:    pxor %xmm4, %xmm9
+; SSE2-NEXT:    pand %xmm11, %xmm7
+; SSE2-NEXT:    pand %xmm11, %xmm3
+; SSE2-NEXT:    packuswb %xmm7, %xmm3
+; SSE2-NEXT:    pmullw %xmm5, %xmm6
+; SSE2-NEXT:    pand %xmm11, %xmm6
 ; SSE2-NEXT:    pmullw %xmm1, %xmm0
-; SSE2-NEXT:    pand %xmm3, %xmm0
-; SSE2-NEXT:    packuswb %xmm4, %xmm0
-; SSE2-NEXT:    pxor %xmm5, %xmm0
+; SSE2-NEXT:    pand %xmm11, %xmm0
+; SSE2-NEXT:    packuswb %xmm6, %xmm0
+; SSE2-NEXT:    pxor %xmm3, %xmm0
+; SSE2-NEXT:    pand %xmm2, %xmm0
+; SSE2-NEXT:    pandn %xmm9, %xmm2
+; SSE2-NEXT:    por %xmm2, %xmm0
 ; SSE2-NEXT:    retq
 ;
 ; SSE42-LABEL: clmul_v16i8:
 ; SSE42:       # %bb.0:
-; SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; SSE42-NEXT:    pand %xmm1, %xmm3
-; SSE42-NEXT:    movdqa %xmm0, %xmm4
-; SSE42-NEXT:    pmullw %xmm3, %xmm4
-; SSE42-NEXT:    pmovzxbw {{.*#+}} xmm2 = [255,255,255,255,255,255,255,255]
-; SSE42-NEXT:    pand %xmm2, %xmm4
-; SSE42-NEXT:    movdqa %xmm2, %xmm5
-; SSE42-NEXT:    pandn %xmm3, %xmm5
+; SSE42-NEXT:    movdqa {{.*#+}} xmm2 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
 ; SSE42-NEXT:    movdqa %xmm0, %xmm3
-; SSE42-NEXT:    pmaddubsw %xmm5, %xmm3
+; SSE42-NEXT:    pand %xmm4, %xmm3
+; SSE42-NEXT:    pand %xmm1, %xmm4
+; SSE42-NEXT:    pand %xmm2, %xmm1
+; SSE42-NEXT:    movdqa %xmm3, %xmm7
+; SSE42-NEXT:    pmullw %xmm1, %xmm7
+; SSE42-NEXT:    pmovzxbw {{.*#+}} xmm5 = [255,255,255,255,255,255,255,255]
+; SSE42-NEXT:    pand %xmm5, %xmm7
+; SSE42-NEXT:    movdqa %xmm5, %xmm6
+; SSE42-NEXT:    pandn %xmm1, %xmm6
+; SSE42-NEXT:    movdqa %xmm3, %xmm8
+; SSE42-NEXT:    pmaddubsw %xmm6, %xmm8
+; SSE42-NEXT:    psllw $8, %xmm8
+; SSE42-NEXT:    por %xmm7, %xmm8
+; SSE42-NEXT:    pand %xmm2, %xmm0
+; SSE42-NEXT:    movdqa %xmm0, %xmm9
+; SSE42-NEXT:    pmullw %xmm4, %xmm9
+; SSE42-NEXT:    pand %xmm5, %xmm9
+; SSE42-NEXT:    movdqa %xmm5, %xmm10
+; SSE42-NEXT:    pandn %xmm4, %xmm10
+; SSE42-NEXT:    movdqa %xmm0, %xmm7
+; SSE42-NEXT:    pmaddubsw %xmm10, %xmm7
+; SSE42-NEXT:    psllw $8, %xmm7
+; SSE42-NEXT:    por %xmm9, %xmm7
+; SSE42-NEXT:    pxor %xmm8, %xmm7
+; SSE42-NEXT:    pmullw %xmm3, %xmm4
+; SSE42-NEXT:    pand %xmm5, %xmm4
+; SSE42-NEXT:    pmaddubsw %xmm10, %xmm3
 ; SSE42-NEXT:    psllw $8, %xmm3
 ; SSE42-NEXT:    por %xmm4, %xmm3
-; SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-; SSE42-NEXT:    pand %xmm1, %xmm4
-; SSE42-NEXT:    movdqa %xmm0, %xmm5
-; SSE42-NEXT:    pmullw %xmm4, %xmm5
-; SSE42-NEXT:    pand %xmm2, %xmm5
-; SSE42-NEXT:    movdqa %xmm2, %xmm6
-; SSE42-NEXT:    pandn %xmm4, %xmm6
-; SSE42-NEXT:    movdqa %xmm0, %xmm4
-; SSE42-NEXT:    pmaddubsw %xmm6, %xmm4
-; SSE42-NEXT:    psllw $8, %xmm4
-; SSE42-NEXT:    por %xmm5, %xmm4
-; SSE42-NEXT:    pxor %xmm3, %xmm4
-; SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; SSE42-NEXT:    pand %xmm1, %xmm3
-; SSE42-NEXT:    movdqa %xmm0, %xmm5
-; SSE42-NEXT:    pmullw %xmm3, %xmm5
-; SSE42-NEXT:    pand %xmm2, %xmm5
-; SSE42-NEXT:    movdqa %xmm2, %xmm6
-; SSE42-NEXT:    pandn %xmm3, %xmm6
-; SSE42-NEXT:    movdqa %xmm0, %xmm7
-; SSE42-NEXT:    pmaddubsw %xmm6, %xmm7
-; SSE42-NEXT:    psllw $8, %xmm7
-; SSE42-NEXT:    por %xmm5, %xmm7
-; SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8]
-; SSE42-NEXT:    pand %xmm1, %xmm3
-; SSE42-NEXT:    movdqa %xmm0, %xmm5
-; SSE42-NEXT:    pmullw %xmm3, %xmm5
-; SSE42-NEXT:    pand %xmm2, %xmm5
-; SSE42-NEXT:    movdqa %xmm2, %xmm6
-; SSE42-NEXT:    pandn %xmm3, %xmm6
-; SSE42-NEXT:    movdqa %xmm0, %xmm3
-; SSE42-NEXT:    pmaddubsw %xmm6, %xmm3
-; SSE42-NEXT:    psllw $8, %xmm3
-; SSE42-NEXT:    por %xmm5, %xmm3
-; SSE42-NEXT:    pxor %xmm7, %xmm3
-; SSE42-NEXT:    pxor %xmm4, %xmm3
-; SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; SSE42-NEXT:    pand %xmm1, %xmm4
-; SSE42-NEXT:    movdqa %xmm0, %xmm5
-; SSE42-NEXT:    pmullw %xmm4, %xmm5
-; SSE42-NEXT:    pand %xmm2, %xmm5
-; SSE42-NEXT:    movdqa %xmm2, %xmm6
-; SSE42-NEXT:    pandn %xmm4, %xmm6
-; SSE42-NEXT:    movdqa %xmm0, %xmm4
-; SSE42-NEXT:    pmaddubsw %xmm6, %xmm4
-; SSE42-NEXT:    psllw $8, %xmm4
-; SSE42-NEXT:    por %xmm5, %xmm4
-; SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; SSE42-NEXT:    pand %xmm1, %xmm5
-; SSE42-NEXT:    movdqa %xmm0, %xmm6
-; SSE42-NEXT:    pmullw %xmm5, %xmm6
-; SSE42-NEXT:    pand %xmm2, %xmm6
-; SSE42-NEXT:    movdqa %xmm2, %xmm7
-; SSE42-NEXT:    pandn %xmm5, %xmm7
-; SSE42-NEXT:    movdqa %xmm0, %xmm5
-; SSE42-NEXT:    pmaddubsw %xmm7, %xmm5
-; SSE42-NEXT:    psllw $8, %xmm5
-; SSE42-NEXT:    por %xmm6, %xmm5
-; SSE42-NEXT:    pxor %xmm4, %xmm5
-; SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; SSE42-NEXT:    pand %xmm1, %xmm4
-; SSE42-NEXT:    movdqa %xmm0, %xmm6
-; SSE42-NEXT:    pmullw %xmm4, %xmm6
-; SSE42-NEXT:    pand %xmm2, %xmm6
-; SSE42-NEXT:    movdqa %xmm2, %xmm7
-; SSE42-NEXT:    pandn %xmm4, %xmm7
-; SSE42-NEXT:    movdqa %xmm0, %xmm4
-; SSE42-NEXT:    pmaddubsw %xmm7, %xmm4
-; SSE42-NEXT:    psllw $8, %xmm4
-; SSE42-NEXT:    por %xmm6, %xmm4
-; SSE42-NEXT:    pxor %xmm5, %xmm4
-; SSE42-NEXT:    pxor %xmm3, %xmm4
-; SSE42-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
-; SSE42-NEXT:    movdqa %xmm0, %xmm3
-; SSE42-NEXT:    pmullw %xmm1, %xmm3
-; SSE42-NEXT:    pand %xmm2, %xmm3
-; SSE42-NEXT:    pandn %xmm1, %xmm2
-; SSE42-NEXT:    pmaddubsw %xmm2, %xmm0
+; SSE42-NEXT:    pmullw %xmm0, %xmm1
+; SSE42-NEXT:    pand %xmm5, %xmm1
+; SSE42-NEXT:    pmaddubsw %xmm6, %xmm0
 ; SSE42-NEXT:    psllw $8, %xmm0
-; SSE42-NEXT:    por %xmm3, %xmm0
-; SSE42-NEXT:    pxor %xmm4, %xmm0
+; SSE42-NEXT:    por %xmm1, %xmm0
+; SSE42-NEXT:    pxor %xmm3, %xmm0
+; SSE42-NEXT:    pand %xmm2, %xmm0
+; SSE42-NEXT:    pandn %xmm7, %xmm2
+; SSE42-NEXT:    por %xmm2, %xmm0
 ; SSE42-NEXT:    retq
 ;
 ; AVX2-LABEL: clmul_v16i8:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm2
-; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero,xmm2[8],zero,xmm2[9],zero,xmm2[10],zero,xmm2[11],zero,xmm2[12],zero,xmm2[13],zero,xmm2[14],zero,xmm2[15],zero
-; AVX2-NEXT:    vpmullw %ymm2, %ymm0, %ymm3
-; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm2 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
-; AVX2-NEXT:    vpand %ymm2, %ymm3, %ymm3
-; AVX2-NEXT:    vextracti128 $1, %ymm3, %xmm4
-; AVX2-NEXT:    vpackuswb %xmm4, %xmm3, %xmm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm4
-; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero,xmm4[4],zero,xmm4[5],zero,xmm4[6],zero,xmm4[7],zero,xmm4[8],zero,xmm4[9],zero,xmm4[10],zero,xmm4[11],zero,xmm4[12],zero,xmm4[13],zero,xmm4[14],zero,xmm4[15],zero
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpand %ymm2, %ymm4, %ymm4
-; AVX2-NEXT:    vextracti128 $1, %ymm4, %xmm5
-; AVX2-NEXT:    vpackuswb %xmm5, %xmm4, %xmm4
-; AVX2-NEXT:    vpxor %xmm3, %xmm4, %xmm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm4
-; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero,xmm4[4],zero,xmm4[5],zero,xmm4[6],zero,xmm4[7],zero,xmm4[8],zero,xmm4[9],zero,xmm4[10],zero,xmm4[11],zero,xmm4[12],zero,xmm4[13],zero,xmm4[14],zero,xmm4[15],zero
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpand %ymm2, %ymm4, %ymm4
-; AVX2-NEXT:    vextracti128 $1, %ymm4, %xmm5
-; AVX2-NEXT:    vpackuswb %xmm5, %xmm4, %xmm4
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm5
+; AVX2-NEXT:    vpbroadcastb {{.*#+}} xmm2 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; AVX2-NEXT:    vpand %xmm2, %xmm1, %xmm3
+; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero,xmm3[4],zero,xmm3[5],zero,xmm3[6],zero,xmm3[7],zero,xmm3[8],zero,xmm3[9],zero,xmm3[10],zero,xmm3[11],zero,xmm3[12],zero,xmm3[13],zero,xmm3[14],zero,xmm3[15],zero
+; AVX2-NEXT:    vpbroadcastb {{.*#+}} xmm4 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX2-NEXT:    vpand %xmm4, %xmm0, %xmm5
 ; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero,xmm5[4],zero,xmm5[5],zero,xmm5[6],zero,xmm5[7],zero,xmm5[8],zero,xmm5[9],zero,xmm5[10],zero,xmm5[11],zero,xmm5[12],zero,xmm5[13],zero,xmm5[14],zero,xmm5[15],zero
-; AVX2-NEXT:    vpmullw %ymm5, %ymm0, %ymm5
-; AVX2-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX2-NEXT:    vextracti128 $1, %ymm5, %xmm6
-; AVX2-NEXT:    vpackuswb %xmm6, %xmm5, %xmm5
-; AVX2-NEXT:    vpxor %xmm5, %xmm4, %xmm4
-; AVX2-NEXT:    vpxor %xmm4, %xmm3, %xmm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm4
-; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero,xmm4[4],zero,xmm4[5],zero,xmm4[6],zero,xmm4[7],zero,xmm4[8],zero,xmm4[9],zero,xmm4[10],zero,xmm4[11],zero,xmm4[12],zero,xmm4[13],zero,xmm4[14],zero,xmm4[15],zero
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpand %ymm2, %ymm4, %ymm4
-; AVX2-NEXT:    vextracti128 $1, %ymm4, %xmm5
-; AVX2-NEXT:    vpackuswb %xmm5, %xmm4, %xmm4
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm5
-; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero,xmm5[4],zero,xmm5[5],zero,xmm5[6],zero,xmm5[7],zero,xmm5[8],zero,xmm5[9],zero,xmm5[10],zero,xmm5[11],zero,xmm5[12],zero,xmm5[13],zero,xmm5[14],zero,xmm5[15],zero
-; AVX2-NEXT:    vpmullw %ymm5, %ymm0, %ymm5
-; AVX2-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX2-NEXT:    vextracti128 $1, %ymm5, %xmm6
-; AVX2-NEXT:    vpackuswb %xmm6, %xmm5, %xmm5
-; AVX2-NEXT:    vpxor %xmm5, %xmm4, %xmm4
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm5
-; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero,xmm5[4],zero,xmm5[5],zero,xmm5[6],zero,xmm5[7],zero,xmm5[8],zero,xmm5[9],zero,xmm5[10],zero,xmm5[11],zero,xmm5[12],zero,xmm5[13],zero,xmm5[14],zero,xmm5[15],zero
-; AVX2-NEXT:    vpmullw %ymm5, %ymm0, %ymm5
-; AVX2-NEXT:    vpand %ymm2, %ymm5, %ymm5
-; AVX2-NEXT:    vextracti128 $1, %ymm5, %xmm6
-; AVX2-NEXT:    vpackuswb %xmm6, %xmm5, %xmm5
-; AVX2-NEXT:    vpxor %xmm5, %xmm4, %xmm4
-; AVX2-NEXT:    vpxor %xmm4, %xmm3, %xmm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1, %xmm1
+; AVX2-NEXT:    vpmullw %ymm3, %ymm5, %ymm6
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm7 = [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255]
+; AVX2-NEXT:    vpand %ymm7, %ymm6, %ymm6
+; AVX2-NEXT:    vextracti128 $1, %ymm6, %xmm8
+; AVX2-NEXT:    vpackuswb %xmm8, %xmm6, %xmm6
+; AVX2-NEXT:    vpand %xmm4, %xmm1, %xmm1
 ; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero,xmm1[8],zero,xmm1[9],zero,xmm1[10],zero,xmm1[11],zero,xmm1[12],zero,xmm1[13],zero,xmm1[14],zero,xmm1[15],zero
-; AVX2-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm0
-; AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
-; AVX2-NEXT:    vpackuswb %xmm1, %xmm0, %xmm0
-; AVX2-NEXT:    vpxor %xmm0, %xmm3, %xmm0
+; AVX2-NEXT:    vpand %xmm2, %xmm0, %xmm0
+; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
+; AVX2-NEXT:    vpmullw %ymm1, %ymm0, %ymm4
+; AVX2-NEXT:    vpand %ymm7, %ymm4, %ymm4
+; AVX2-NEXT:    vextracti128 $1, %ymm4, %xmm8
+; AVX2-NEXT:    vpackuswb %xmm8, %xmm4, %xmm4
+; AVX2-NEXT:    vpxor %xmm6, %xmm4, %xmm4
+; AVX2-NEXT:    vpandn %xmm4, %xmm2, %xmm4
+; AVX2-NEXT:    vpmullw %ymm1, %ymm5, %ymm1
+; AVX2-NEXT:    vpand %ymm7, %ymm1, %ymm1
+; AVX2-NEXT:    vextracti128 $1, %ymm1, %xmm5
+; AVX2-NEXT:    vpackuswb %xmm5, %xmm1, %xmm1
+; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm0
+; AVX2-NEXT:    vpand %ymm7, %ymm0, %ymm0
+; AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm3
+; AVX2-NEXT:    vpackuswb %xmm3, %xmm0, %xmm0
+; AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm0
+; AVX2-NEXT:    vpand %xmm2, %xmm0, %xmm0
+; AVX2-NEXT:    vpor %xmm4, %xmm0, %xmm0
 ; AVX2-NEXT:    vzeroupper
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: clmul_v16i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm1, %xmm2
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero,xmm2[8],zero,xmm2[9],zero,xmm2[10],zero,xmm2[11],zero,xmm2[12],zero,xmm2[13],zero,xmm2[14],zero,xmm2[15],zero
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm1, %xmm3
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; AVX512-NEXT:    vpand %xmm2, %xmm1, %xmm3
 ; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero,xmm3[4],zero,xmm3[5],zero,xmm3[6],zero,xmm3[7],zero,xmm3[8],zero,xmm3[9],zero,xmm3[10],zero,xmm3[11],zero,xmm3[12],zero,xmm3[13],zero,xmm3[14],zero,xmm3[15],zero
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpxor %ymm2, %ymm3, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm1, %xmm3
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero,xmm3[4],zero,xmm3[5],zero,xmm3[6],zero,xmm3[7],zero,xmm3[8],zero,xmm3[9],zero,xmm3[10],zero,xmm3[11],zero,xmm3[12],zero,xmm3[13],zero,xmm3[14],zero,xmm3[15],zero
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm1, %xmm4
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero,xmm4[4],zero,xmm4[5],zero,xmm4[6],zero,xmm4[7],zero,xmm4[8],zero,xmm4[9],zero,xmm4[10],zero,xmm4[11],zero,xmm4[12],zero,xmm4[13],zero,xmm4[14],zero,xmm4[15],zero
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm4 = ymm4 ^ ymm2 ^ ymm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm1, %xmm2
+; AVX512-NEXT:    vpand %xmm2, %xmm0, %xmm2
 ; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero,xmm2[8],zero,xmm2[9],zero,xmm2[10],zero,xmm2[11],zero,xmm2[12],zero,xmm2[13],zero,xmm2[14],zero,xmm2[15],zero
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm1, %xmm3
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero,xmm3[4],zero,xmm3[5],zero,xmm3[6],zero,xmm3[7],zero,xmm3[8],zero,xmm3[9],zero,xmm3[10],zero,xmm3[11],zero,xmm3[12],zero,xmm3[13],zero,xmm3[14],zero,xmm3[15],zero
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm3 = ymm3 ^ ymm4 ^ ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm1, %xmm2
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero,xmm2[4],zero,xmm2[5],zero,xmm2[6],zero,xmm2[7],zero,xmm2[8],zero,xmm2[9],zero,xmm2[10],zero,xmm2[11],zero,xmm2[12],zero,xmm2[13],zero,xmm2[14],zero,xmm2[15],zero
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to4}, %xmm1, %xmm1
+; AVX512-NEXT:    vpmullw %ymm3, %ymm2, %ymm4
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm5 = [1431655765,1431655765,1431655765,1431655765]
+; AVX512-NEXT:    vpand %xmm5, %xmm1, %xmm1
 ; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero,xmm1[8],zero,xmm1[9],zero,xmm1[10],zero,xmm1[11],zero,xmm1[12],zero,xmm1[13],zero,xmm1[14],zero,xmm1[15],zero
-; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 ^ ymm3 ^ ymm2
+; AVX512-NEXT:    vpand %xmm5, %xmm0, %xmm0
+; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
+; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm5
+; AVX512-NEXT:    vpxor %ymm4, %ymm5, %ymm4
+; AVX512-NEXT:    vpmovzxwd {{.*#+}} zmm4 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero,ymm4[8],zero,ymm4[9],zero,ymm4[10],zero,ymm4[11],zero,ymm4[12],zero,ymm4[13],zero,ymm4[14],zero,ymm4[15],zero
+; AVX512-NEXT:    vpmovdb %zmm4, %xmm4
+; AVX512-NEXT:    vpmullw %ymm1, %ymm2, %ymm1
+; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm0
+; AVX512-NEXT:    vpxor %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero,ymm0[8],zero,ymm0[9],zero,ymm0[10],zero,ymm0[11],zero,ymm0[12],zero,ymm0[13],zero,ymm0[14],zero,ymm0[15],zero
 ; AVX512-NEXT:    vpmovdb %zmm0, %xmm0
+; AVX512-NEXT:    vpternlogd {{.*#+}} xmm0 = xmm0 ^ (m32bcst & (xmm0 ^ xmm4))
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %res = call <16 x i8> @llvm.clmul.v16i8(<16 x i8> %a, <16 x i8> %b)
@@ -301,137 +172,47 @@ define <16 x i8> @clmul_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 }
 
 define <8 x i16> @clmul_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
-; SSE2-LABEL: clmul_v8i16:
-; SSE2:       # %bb.0:
-; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2,2,2,2,2,2,2,2]
-; SSE2-NEXT:    pand %xmm1, %xmm2
-; SSE2-NEXT:    pmullw %xmm0, %xmm2
-; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [1,1,1,1,1,1,1,1]
-; SSE2-NEXT:    pand %xmm1, %xmm3
-; SSE2-NEXT:    pmullw %xmm0, %xmm3
-; SSE2-NEXT:    pxor %xmm2, %xmm3
-; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [4,4,4,4,4,4,4,4]
-; SSE2-NEXT:    pand %xmm1, %xmm2
-; SSE2-NEXT:    pmullw %xmm0, %xmm2
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [8,8,8,8,8,8,8,8]
-; SSE2-NEXT:    pand %xmm1, %xmm4
-; SSE2-NEXT:    pmullw %xmm0, %xmm4
-; SSE2-NEXT:    pxor %xmm2, %xmm4
-; SSE2-NEXT:    pxor %xmm3, %xmm4
-; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [16,16,16,16,16,16,16,16]
-; SSE2-NEXT:    pand %xmm1, %xmm2
-; SSE2-NEXT:    pmullw %xmm0, %xmm2
-; SSE2-NEXT:    movdqa {{.*#+}} xmm5 = [32,32,32,32,32,32,32,32]
-; SSE2-NEXT:    pand %xmm1, %xmm5
-; SSE2-NEXT:    pmullw %xmm0, %xmm5
-; SSE2-NEXT:    pxor %xmm2, %xmm5
-; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [64,64,64,64,64,64,64,64]
-; SSE2-NEXT:    pand %xmm1, %xmm3
-; SSE2-NEXT:    pmullw %xmm0, %xmm3
-; SSE2-NEXT:    pxor %xmm5, %xmm3
-; SSE2-NEXT:    pxor %xmm4, %xmm3
-; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [128,128,128,128,128,128,128,128]
-; SSE2-NEXT:    pand %xmm1, %xmm2
-; SSE2-NEXT:    pmullw %xmm0, %xmm2
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [256,256,256,256,256,256,256,256]
-; SSE2-NEXT:    pand %xmm1, %xmm4
-; SSE2-NEXT:    pmullw %xmm0, %xmm4
-; SSE2-NEXT:    pxor %xmm2, %xmm4
-; SSE2-NEXT:    movdqa {{.*#+}} xmm5 = [512,512,512,512,512,512,512,512]
-; SSE2-NEXT:    pand %xmm1, %xmm5
-; SSE2-NEXT:    pmullw %xmm0, %xmm5
-; SSE2-NEXT:    pxor %xmm4, %xmm5
-; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [1024,1024,1024,1024,1024,1024,1024,1024]
-; SSE2-NEXT:    pand %xmm1, %xmm2
-; SSE2-NEXT:    pmullw %xmm0, %xmm2
-; SSE2-NEXT:    pxor %xmm5, %xmm2
-; SSE2-NEXT:    pxor %xmm3, %xmm2
-; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2048,2048,2048,2048,2048,2048,2048,2048]
-; SSE2-NEXT:    pand %xmm1, %xmm3
-; SSE2-NEXT:    pmullw %xmm0, %xmm3
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [4096,4096,4096,4096,4096,4096,4096,4096]
-; SSE2-NEXT:    pand %xmm1, %xmm4
-; SSE2-NEXT:    pmullw %xmm0, %xmm4
-; SSE2-NEXT:    pxor %xmm3, %xmm4
-; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [8192,8192,8192,8192,8192,8192,8192,8192]
-; SSE2-NEXT:    pand %xmm1, %xmm3
-; SSE2-NEXT:    pmullw %xmm0, %xmm3
-; SSE2-NEXT:    pxor %xmm4, %xmm3
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [16384,16384,16384,16384,16384,16384,16384,16384]
-; SSE2-NEXT:    pand %xmm1, %xmm4
-; SSE2-NEXT:    pmullw %xmm0, %xmm4
-; SSE2-NEXT:    pxor %xmm3, %xmm4
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
-; SSE2-NEXT:    pmullw %xmm1, %xmm0
-; SSE2-NEXT:    pxor %xmm4, %xmm0
-; SSE2-NEXT:    pxor %xmm2, %xmm0
-; SSE2-NEXT:    retq
-;
-; SSE42-LABEL: clmul_v8i16:
-; SSE42:       # %bb.0:
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm2 = [2,2,2,2,2,2,2,2]
-; SSE42-NEXT:    pand %xmm1, %xmm2
-; SSE42-NEXT:    pmullw %xmm0, %xmm2
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm3 = [1,1,1,1,1,1,1,1]
-; SSE42-NEXT:    pand %xmm1, %xmm3
-; SSE42-NEXT:    pmullw %xmm0, %xmm3
-; SSE42-NEXT:    pxor %xmm2, %xmm3
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm2 = [4,4,4,4,4,4,4,4]
-; SSE42-NEXT:    pand %xmm1, %xmm2
-; SSE42-NEXT:    pmullw %xmm0, %xmm2
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm4 = [8,8,8,8,8,8,8,8]
-; SSE42-NEXT:    pand %xmm1, %xmm4
-; SSE42-NEXT:    pmullw %xmm0, %xmm4
-; SSE42-NEXT:    pxor %xmm2, %xmm4
-; SSE42-NEXT:    pxor %xmm3, %xmm4
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm2 = [16,16,16,16,16,16,16,16]
-; SSE42-NEXT:    pand %xmm1, %xmm2
-; SSE42-NEXT:    pmullw %xmm0, %xmm2
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm5 = [32,32,32,32,32,32,32,32]
-; SSE42-NEXT:    pand %xmm1, %xmm5
-; SSE42-NEXT:    pmullw %xmm0, %xmm5
-; SSE42-NEXT:    pxor %xmm2, %xmm5
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm3 = [64,64,64,64,64,64,64,64]
-; SSE42-NEXT:    pand %xmm1, %xmm3
-; SSE42-NEXT:    pmullw %xmm0, %xmm3
-; SSE42-NEXT:    pxor %xmm5, %xmm3
-; SSE42-NEXT:    pxor %xmm4, %xmm3
-; SSE42-NEXT:    pmovzxbw {{.*#+}} xmm2 = [128,128,128,128,128,128,128,128]
-; SSE42-NEXT:    pand %xmm1, %xmm2
-; SSE42-NEXT:    pmullw %xmm0, %xmm2
-; SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [256,256,256,256,256,256,256,256]
-; SSE42-NEXT:    pand %xmm1, %xmm4
-; SSE42-NEXT:    pmullw %xmm0, %xmm4
-; SSE42-NEXT:    pxor %xmm2, %xmm4
-; SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [512,512,512,512,512,512,512,512]
-; SSE42-NEXT:    pand %xmm1, %xmm5
-; SSE42-NEXT:    pmullw %xmm0, %xmm5
-; SSE42-NEXT:    pxor %xmm4, %xmm5
-; SSE42-NEXT:    movdqa {{.*#+}} xmm2 = [1024,1024,1024,1024,1024,1024,1024,1024]
-; SSE42-NEXT:    pand %xmm1, %xmm2
-; SSE42-NEXT:    pmullw %xmm0, %xmm2
-; SSE42-NEXT:    pxor %xmm5, %xmm2
-; SSE42-NEXT:    pxor %xmm3, %xmm2
-; SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [2048,2048,2048,2048,2048,2048,2048,2048]
-; SSE42-NEXT:    pand %xmm1, %xmm3
-; SSE42-NEXT:    pmullw %xmm0, %xmm3
-; SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [4096,4096,4096,4096,4096,4096,4096,4096]
-; SSE42-NEXT:    pand %xmm1, %xmm4
-; SSE42-NEXT:    pmullw %xmm0, %xmm4
-; SSE42-NEXT:    pxor %xmm3, %xmm4
-; SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [8192,8192,8192,8192,8192,8192,8192,8192]
-; SSE42-NEXT:    pand %xmm1, %xmm3
-; SSE42-NEXT:    pmullw %xmm0, %xmm3
-; SSE42-NEXT:    pxor %xmm4, %xmm3
-; SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [16384,16384,16384,16384,16384,16384,16384,16384]
-; SSE42-NEXT:    pand %xmm1, %xmm4
-; SSE42-NEXT:    pmullw %xmm0, %xmm4
-; SSE42-NEXT:    pxor %xmm3, %xmm4
-; SSE42-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
-; SSE42-NEXT:    pmullw %xmm1, %xmm0
-; SSE42-NEXT:    pxor %xmm4, %xmm0
-; SSE42-NEXT:    pxor %xmm2, %xmm0
-; SSE42-NEXT:    retq
+; SSE-LABEL: clmul_v8i16:
+; SSE:       # %bb.0:
+; SSE-NEXT:    movdqa {{.*#+}} xmm3 = [37449,37449,37449,37449,37449,37449,37449,37449]
+; SSE-NEXT:    movdqa %xmm1, %xmm2
+; SSE-NEXT:    pand %xmm3, %xmm2
+; SSE-NEXT:    movdqa {{.*#+}} xmm7 = [9362,9362,9362,9362,9362,9362,9362,9362]
+; SSE-NEXT:    movdqa %xmm0, %xmm8
+; SSE-NEXT:    pand %xmm7, %xmm8
+; SSE-NEXT:    movdqa %xmm1, %xmm5
+; SSE-NEXT:    pand %xmm7, %xmm5
+; SSE-NEXT:    movdqa %xmm0, %xmm4
+; SSE-NEXT:    pand %xmm3, %xmm4
+; SSE-NEXT:    movdqa %xmm4, %xmm9
+; SSE-NEXT:    pmullw %xmm5, %xmm9
+; SSE-NEXT:    movdqa {{.*#+}} xmm6 = [18724,18724,18724,18724,18724,18724,18724,18724]
+; SSE-NEXT:    pand %xmm6, %xmm0
+; SSE-NEXT:    movdqa %xmm8, %xmm11
+; SSE-NEXT:    movdqa %xmm0, %xmm10
+; SSE-NEXT:    pmullw %xmm5, %xmm10
+; SSE-NEXT:    pmullw %xmm8, %xmm5
+; SSE-NEXT:    pmullw %xmm2, %xmm8
+; SSE-NEXT:    pxor %xmm8, %xmm9
+; SSE-NEXT:    pand %xmm6, %xmm1
+; SSE-NEXT:    movdqa %xmm0, %xmm8
+; SSE-NEXT:    pmullw %xmm1, %xmm8
+; SSE-NEXT:    pxor %xmm9, %xmm8
+; SSE-NEXT:    pand %xmm7, %xmm8
+; SSE-NEXT:    pmullw %xmm1, %xmm11
+; SSE-NEXT:    movdqa %xmm4, %xmm7
+; SSE-NEXT:    pmullw %xmm2, %xmm7
+; SSE-NEXT:    pxor %xmm11, %xmm7
+; SSE-NEXT:    pxor %xmm7, %xmm10
+; SSE-NEXT:    pand %xmm3, %xmm10
+; SSE-NEXT:    por %xmm8, %xmm10
+; SSE-NEXT:    pmullw %xmm1, %xmm4
+; SSE-NEXT:    pxor %xmm5, %xmm4
+; SSE-NEXT:    pmullw %xmm2, %xmm0
+; SSE-NEXT:    pxor %xmm4, %xmm0
+; SSE-NEXT:    pand %xmm6, %xmm0
+; SSE-NEXT:    por %xmm10, %xmm0
+; SSE-NEXT:    retq
 ;
 ; AVX2-LABEL: clmul_v8i16:
 ; AVX2:       # %bb.0:
@@ -1076,150 +857,105 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 define <16 x i8> @clmulr_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; SSE2-LABEL: clmulr_v16i8:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    movdqa %xmm0, %xmm3
-; SSE2-NEXT:    psrlw $4, %xmm3
+; SSE2-NEXT:    movdqa %xmm1, %xmm4
+; SSE2-NEXT:    psrlw $4, %xmm4
 ; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; SSE2-NEXT:    pand %xmm2, %xmm3
-; SSE2-NEXT:    pand %xmm2, %xmm0
-; SSE2-NEXT:    psllw $4, %xmm0
-; SSE2-NEXT:    por %xmm3, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm4
-; SSE2-NEXT:    psrlw $2, %xmm4
-; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51]
-; SSE2-NEXT:    pand %xmm3, %xmm4
-; SSE2-NEXT:    pand %xmm3, %xmm0
-; SSE2-NEXT:    psllw $2, %xmm0
-; SSE2-NEXT:    por %xmm4, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm5
-; SSE2-NEXT:    psrlw $1, %xmm5
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    pand %xmm4, %xmm0
-; SSE2-NEXT:    paddb %xmm0, %xmm0
-; SSE2-NEXT:    por %xmm5, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm6
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm6 = xmm6[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    movdqa %xmm1, %xmm5
-; SSE2-NEXT:    psrlw $4, %xmm5
-; SSE2-NEXT:    pand %xmm2, %xmm5
+; SSE2-NEXT:    pand %xmm2, %xmm4
 ; SSE2-NEXT:    pand %xmm2, %xmm1
 ; SSE2-NEXT:    psllw $4, %xmm1
-; SSE2-NEXT:    por %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm1
-; SSE2-NEXT:    psrlw $2, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm1
+; SSE2-NEXT:    por %xmm1, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm3
+; SSE2-NEXT:    psrlw $2, %xmm3
+; SSE2-NEXT:    movdqa {{.*#+}} xmm1 = [51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51]
+; SSE2-NEXT:    pand %xmm1, %xmm3
+; SSE2-NEXT:    pand %xmm1, %xmm4
+; SSE2-NEXT:    psllw $2, %xmm4
+; SSE2-NEXT:    por %xmm3, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm5
+; SSE2-NEXT:    psrlw $1, %xmm5
+; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; SSE2-NEXT:    pand %xmm3, %xmm4
+; SSE2-NEXT:    paddb %xmm4, %xmm4
+; SSE2-NEXT:    por %xmm4, %xmm5
 ; SSE2-NEXT:    pand %xmm3, %xmm5
-; SSE2-NEXT:    psllw $2, %xmm5
-; SSE2-NEXT:    por %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm8
-; SSE2-NEXT:    psrlw $1, %xmm8
-; SSE2-NEXT:    movdqa %xmm8, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    paddb %xmm5, %xmm5
-; SSE2-NEXT:    por %xmm5, %xmm1
-; SSE2-NEXT:    movdqa {{.*#+}} xmm9 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; SSE2-NEXT:    pand %xmm1, %xmm9
-; SSE2-NEXT:    movdqa %xmm9, %xmm10
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm10 = xmm10[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm10
-; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [255,255,255,255,255,255,255,255]
-; SSE2-NEXT:    pand %xmm7, %xmm10
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm9 = xmm9[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm9
-; SSE2-NEXT:    pand %xmm7, %xmm9
-; SSE2-NEXT:    packuswb %xmm10, %xmm9
-; SSE2-NEXT:    movdqa {{.*#+}} xmm10 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; SSE2-NEXT:    pand %xmm5, %xmm10
-; SSE2-NEXT:    movdqa %xmm10, %xmm11
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm11 = xmm11[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm11
-; SSE2-NEXT:    pand %xmm7, %xmm11
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm10 = xmm10[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm10
-; SSE2-NEXT:    pand %xmm7, %xmm10
-; SSE2-NEXT:    packuswb %xmm11, %xmm10
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm8
-; SSE2-NEXT:    movdqa %xmm8, %xmm11
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm11 = xmm11[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm11
-; SSE2-NEXT:    pand %xmm7, %xmm11
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm8 = xmm8[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pand %xmm7, %xmm8
-; SSE2-NEXT:    packuswb %xmm11, %xmm8
-; SSE2-NEXT:    pxor %xmm10, %xmm8
-; SSE2-NEXT:    pxor %xmm9, %xmm8
-; SSE2-NEXT:    movdqa {{.*#+}} xmm10 = [8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8]
-; SSE2-NEXT:    pand %xmm5, %xmm10
-; SSE2-NEXT:    movdqa %xmm10, %xmm9
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm9 = xmm9[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm9
-; SSE2-NEXT:    pand %xmm7, %xmm9
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm10 = xmm10[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm10
-; SSE2-NEXT:    pand %xmm7, %xmm10
-; SSE2-NEXT:    packuswb %xmm9, %xmm10
-; SSE2-NEXT:    movdqa {{.*#+}} xmm9 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; SSE2-NEXT:    pand %xmm1, %xmm9
-; SSE2-NEXT:    movdqa %xmm9, %xmm11
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm11 = xmm11[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm11
-; SSE2-NEXT:    pand %xmm7, %xmm11
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm9 = xmm9[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm9
-; SSE2-NEXT:    pand %xmm7, %xmm9
-; SSE2-NEXT:    packuswb %xmm11, %xmm9
-; SSE2-NEXT:    pxor %xmm10, %xmm9
-; SSE2-NEXT:    pxor %xmm8, %xmm9
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; SSE2-NEXT:    pand %xmm5, %xmm8
-; SSE2-NEXT:    movdqa %xmm8, %xmm10
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm10 = xmm10[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm10
-; SSE2-NEXT:    pand %xmm7, %xmm10
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm8 = xmm8[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pand %xmm7, %xmm8
-; SSE2-NEXT:    packuswb %xmm10, %xmm8
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
-; SSE2-NEXT:    movdqa %xmm1, %xmm10
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm10 = xmm10[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm10
-; SSE2-NEXT:    pand %xmm7, %xmm10
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm1 = xmm1[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm1
-; SSE2-NEXT:    pand %xmm7, %xmm1
-; SSE2-NEXT:    packuswb %xmm10, %xmm1
-; SSE2-NEXT:    pxor %xmm8, %xmm1
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm8
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm8 = xmm8[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm8
-; SSE2-NEXT:    pand %xmm7, %xmm8
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm5 = xmm5[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm5, %xmm0
-; SSE2-NEXT:    pand %xmm7, %xmm0
-; SSE2-NEXT:    packuswb %xmm8, %xmm0
-; SSE2-NEXT:    pxor %xmm1, %xmm0
-; SSE2-NEXT:    pxor %xmm9, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-NEXT:    psrlw $4, %xmm1
-; SSE2-NEXT:    pand %xmm2, %xmm1
+; SSE2-NEXT:    movdqa %xmm5, %xmm6
+; SSE2-NEXT:    punpckhbw {{.*#+}} xmm6 = xmm6[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $4, %xmm7
+; SSE2-NEXT:    pand %xmm2, %xmm7
 ; SSE2-NEXT:    pand %xmm2, %xmm0
 ; SSE2-NEXT:    psllw $4, %xmm0
-; SSE2-NEXT:    por %xmm1, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-NEXT:    psrlw $2, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $2, %xmm7
+; SSE2-NEXT:    pand %xmm1, %xmm7
+; SSE2-NEXT:    pand %xmm1, %xmm0
 ; SSE2-NEXT:    psllw $2, %xmm0
-; SSE2-NEXT:    por %xmm1, %xmm0
+; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm9
+; SSE2-NEXT:    pand %xmm3, %xmm9
+; SSE2-NEXT:    paddb %xmm9, %xmm9
+; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; SSE2-NEXT:    psrlw $1, %xmm0
+; SSE2-NEXT:    por %xmm9, %xmm0
+; SSE2-NEXT:    pand %xmm7, %xmm9
+; SSE2-NEXT:    movdqa %xmm9, %xmm11
+; SSE2-NEXT:    punpckhbw {{.*#+}} xmm11 = xmm11[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
+; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm8
+; SSE2-NEXT:    punpckhbw {{.*#+}} xmm8 = xmm8[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
+; SSE2-NEXT:    pand %xmm7, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm7
+; SSE2-NEXT:    punpckhbw {{.*#+}} xmm7 = xmm7[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
+; SSE2-NEXT:    movdqa %xmm8, %xmm10
+; SSE2-NEXT:    pmullw %xmm7, %xmm10
+; SSE2-NEXT:    pmullw %xmm11, %xmm7
+; SSE2-NEXT:    pmullw %xmm6, %xmm11
+; SSE2-NEXT:    movdqa {{.*#+}} xmm12 = [255,255,255,255,255,255,255,255]
+; SSE2-NEXT:    pand %xmm12, %xmm11
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm5 = xmm5[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm9 = xmm9[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm4 = xmm4[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    movdqa %xmm0, %xmm13
+; SSE2-NEXT:    pmullw %xmm4, %xmm13
+; SSE2-NEXT:    pmullw %xmm9, %xmm4
+; SSE2-NEXT:    pmullw %xmm5, %xmm9
+; SSE2-NEXT:    pand %xmm12, %xmm9
+; SSE2-NEXT:    packuswb %xmm11, %xmm9
+; SSE2-NEXT:    pand %xmm12, %xmm10
+; SSE2-NEXT:    pand %xmm12, %xmm13
+; SSE2-NEXT:    packuswb %xmm10, %xmm13
+; SSE2-NEXT:    pxor %xmm9, %xmm13
+; SSE2-NEXT:    movdqa %xmm3, %xmm9
+; SSE2-NEXT:    pandn %xmm13, %xmm9
+; SSE2-NEXT:    pmullw %xmm6, %xmm8
+; SSE2-NEXT:    pand %xmm12, %xmm8
+; SSE2-NEXT:    pmullw %xmm5, %xmm0
+; SSE2-NEXT:    pand %xmm12, %xmm0
+; SSE2-NEXT:    packuswb %xmm8, %xmm0
+; SSE2-NEXT:    pand %xmm12, %xmm7
+; SSE2-NEXT:    pand %xmm12, %xmm4
+; SSE2-NEXT:    packuswb %xmm7, %xmm4
+; SSE2-NEXT:    pxor %xmm4, %xmm0
+; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    por %xmm9, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-NEXT:    psrlw $4, %xmm4
+; SSE2-NEXT:    pand %xmm2, %xmm4
+; SSE2-NEXT:    pand %xmm2, %xmm0
+; SSE2-NEXT:    psllw $4, %xmm0
+; SSE2-NEXT:    por %xmm4, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm2
+; SSE2-NEXT:    psrlw $2, %xmm2
+; SSE2-NEXT:    pand %xmm1, %xmm2
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    psllw $2, %xmm0
+; SSE2-NEXT:    por %xmm2, %xmm0
 ; SSE2-NEXT:    movdqa %xmm0, %xmm1
 ; SSE2-NEXT:    psrlw $1, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm0
+; SSE2-NEXT:    pand %xmm3, %xmm1
+; SSE2-NEXT:    pand %xmm3, %xmm0
 ; SSE2-NEXT:    paddb %xmm0, %xmm0
 ; SSE2-NEXT:    por %xmm1, %xmm0
 ; SSE2-NEXT:    retq
@@ -1228,152 +964,110 @@ define <16 x i8> @clmulr_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; SSE42:       # %bb.0:
 ; SSE42-NEXT:    movdqa %xmm0, %xmm2
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; SSE42-NEXT:    movdqa %xmm1, %xmm0
 ; SSE42-NEXT:    pand %xmm4, %xmm0
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
-; SSE42-NEXT:    movdqa %xmm3, %xmm6
-; SSE42-NEXT:    pshufb %xmm0, %xmm6
-; SSE42-NEXT:    psrlw $4, %xmm2
-; SSE42-NEXT:    pand %xmm4, %xmm2
-; SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
-; SSE42-NEXT:    movdqa %xmm0, %xmm5
-; SSE42-NEXT:    pshufb %xmm2, %xmm5
-; SSE42-NEXT:    por %xmm6, %xmm5
-; SSE42-NEXT:    movdqa %xmm1, %xmm2
-; SSE42-NEXT:    psrlw $4, %xmm2
-; SSE42-NEXT:    pand %xmm4, %xmm2
-; SSE42-NEXT:    movdqa %xmm0, %xmm6
-; SSE42-NEXT:    pshufb %xmm2, %xmm6
-; SSE42-NEXT:    movdqa {{.*#+}} xmm7 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; SSE42-NEXT:    pand %xmm6, %xmm7
-; SSE42-NEXT:    movdqa %xmm5, %xmm8
-; SSE42-NEXT:    pmullw %xmm7, %xmm8
-; SSE42-NEXT:    pmovzxbw {{.*#+}} xmm2 = [255,255,255,255,255,255,255,255]
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    movdqa %xmm2, %xmm9
-; SSE42-NEXT:    pandn %xmm7, %xmm9
-; SSE42-NEXT:    movdqa %xmm5, %xmm10
-; SSE42-NEXT:    pmaddubsw %xmm9, %xmm10
-; SSE42-NEXT:    psllw $8, %xmm10
-; SSE42-NEXT:    por %xmm8, %xmm10
-; SSE42-NEXT:    movdqa {{.*#+}} xmm7 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-; SSE42-NEXT:    pand %xmm6, %xmm7
-; SSE42-NEXT:    movdqa %xmm5, %xmm8
-; SSE42-NEXT:    pmullw %xmm7, %xmm8
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    movdqa %xmm2, %xmm9
-; SSE42-NEXT:    pandn %xmm7, %xmm9
-; SSE42-NEXT:    movdqa %xmm5, %xmm7
-; SSE42-NEXT:    pmaddubsw %xmm9, %xmm7
-; SSE42-NEXT:    psllw $8, %xmm7
-; SSE42-NEXT:    por %xmm8, %xmm7
-; SSE42-NEXT:    pxor %xmm10, %xmm7
-; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; SSE42-NEXT:    pand %xmm6, %xmm8
-; SSE42-NEXT:    movdqa %xmm5, %xmm9
-; SSE42-NEXT:    pmullw %xmm8, %xmm9
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    movdqa %xmm2, %xmm10
-; SSE42-NEXT:    pandn %xmm8, %xmm10
-; SSE42-NEXT:    movdqa %xmm5, %xmm8
-; SSE42-NEXT:    pmaddubsw %xmm10, %xmm8
-; SSE42-NEXT:    psllw $8, %xmm8
-; SSE42-NEXT:    por %xmm9, %xmm8
-; SSE42-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm6
-; SSE42-NEXT:    movdqa %xmm5, %xmm9
-; SSE42-NEXT:    pmullw %xmm6, %xmm9
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    movdqa %xmm2, %xmm10
-; SSE42-NEXT:    pandn %xmm6, %xmm10
-; SSE42-NEXT:    movdqa %xmm5, %xmm6
-; SSE42-NEXT:    pmaddubsw %xmm10, %xmm6
-; SSE42-NEXT:    psllw $8, %xmm6
-; SSE42-NEXT:    por %xmm9, %xmm6
-; SSE42-NEXT:    pxor %xmm8, %xmm6
-; SSE42-NEXT:    pxor %xmm7, %xmm6
+; SSE42-NEXT:    movdqa %xmm3, %xmm5
+; SSE42-NEXT:    pshufb %xmm0, %xmm5
+; SSE42-NEXT:    psrlw $4, %xmm1
 ; SSE42-NEXT:    pand %xmm4, %xmm1
-; SSE42-NEXT:    movdqa %xmm3, %xmm7
+; SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; SSE42-NEXT:    movdqa %xmm0, %xmm7
 ; SSE42-NEXT:    pshufb %xmm1, %xmm7
-; SSE42-NEXT:    movdqa {{.*#+}} xmm1 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    movdqa %xmm5, %xmm8
-; SSE42-NEXT:    pmullw %xmm1, %xmm8
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    movdqa %xmm2, %xmm9
-; SSE42-NEXT:    pandn %xmm1, %xmm9
-; SSE42-NEXT:    movdqa %xmm5, %xmm1
+; SSE42-NEXT:    por %xmm5, %xmm7
+; SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; SSE42-NEXT:    movdqa %xmm7, %xmm6
+; SSE42-NEXT:    pand %xmm5, %xmm6
+; SSE42-NEXT:    movdqa %xmm2, %xmm1
+; SSE42-NEXT:    pand %xmm4, %xmm1
+; SSE42-NEXT:    movdqa %xmm3, %xmm8
+; SSE42-NEXT:    pshufb %xmm1, %xmm8
+; SSE42-NEXT:    psrlw $4, %xmm2
+; SSE42-NEXT:    pand %xmm4, %xmm2
+; SSE42-NEXT:    movdqa %xmm0, %xmm1
+; SSE42-NEXT:    pshufb %xmm2, %xmm1
+; SSE42-NEXT:    por %xmm8, %xmm1
+; SSE42-NEXT:    movdqa {{.*#+}} xmm10 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; SSE42-NEXT:    movdqa %xmm1, %xmm2
+; SSE42-NEXT:    pand %xmm10, %xmm2
+; SSE42-NEXT:    movdqa %xmm2, %xmm11
+; SSE42-NEXT:    pmullw %xmm6, %xmm11
+; SSE42-NEXT:    pmovzxbw {{.*#+}} xmm8 = [255,255,255,255,255,255,255,255]
+; SSE42-NEXT:    pand %xmm8, %xmm11
+; SSE42-NEXT:    movdqa %xmm8, %xmm9
+; SSE42-NEXT:    pandn %xmm6, %xmm9
+; SSE42-NEXT:    movdqa %xmm2, %xmm12
+; SSE42-NEXT:    pmaddubsw %xmm9, %xmm12
+; SSE42-NEXT:    psllw $8, %xmm12
+; SSE42-NEXT:    por %xmm11, %xmm12
+; SSE42-NEXT:    pand %xmm10, %xmm7
+; SSE42-NEXT:    pand %xmm5, %xmm1
+; SSE42-NEXT:    movdqa %xmm1, %xmm11
+; SSE42-NEXT:    pmullw %xmm7, %xmm11
+; SSE42-NEXT:    pand %xmm8, %xmm11
+; SSE42-NEXT:    movdqa %xmm8, %xmm13
+; SSE42-NEXT:    pandn %xmm7, %xmm13
+; SSE42-NEXT:    movdqa %xmm1, %xmm10
+; SSE42-NEXT:    pmaddubsw %xmm13, %xmm10
+; SSE42-NEXT:    psllw $8, %xmm10
+; SSE42-NEXT:    por %xmm11, %xmm10
+; SSE42-NEXT:    pxor %xmm12, %xmm10
+; SSE42-NEXT:    pmullw %xmm2, %xmm7
+; SSE42-NEXT:    pand %xmm8, %xmm7
+; SSE42-NEXT:    pmaddubsw %xmm13, %xmm2
+; SSE42-NEXT:    psllw $8, %xmm2
+; SSE42-NEXT:    por %xmm7, %xmm2
+; SSE42-NEXT:    pmullw %xmm1, %xmm6
+; SSE42-NEXT:    pand %xmm8, %xmm6
 ; SSE42-NEXT:    pmaddubsw %xmm9, %xmm1
 ; SSE42-NEXT:    psllw $8, %xmm1
-; SSE42-NEXT:    por %xmm8, %xmm1
-; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; SSE42-NEXT:    pand %xmm7, %xmm8
-; SSE42-NEXT:    movdqa %xmm5, %xmm9
-; SSE42-NEXT:    pmullw %xmm8, %xmm9
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    movdqa %xmm2, %xmm10
-; SSE42-NEXT:    pandn %xmm8, %xmm10
-; SSE42-NEXT:    movdqa %xmm5, %xmm8
-; SSE42-NEXT:    pmaddubsw %xmm10, %xmm8
-; SSE42-NEXT:    psllw $8, %xmm8
-; SSE42-NEXT:    por %xmm9, %xmm8
-; SSE42-NEXT:    pxor %xmm1, %xmm8
-; SSE42-NEXT:    movdqa {{.*#+}} xmm1 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    movdqa %xmm5, %xmm9
-; SSE42-NEXT:    pmullw %xmm1, %xmm9
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    movdqa %xmm2, %xmm10
-; SSE42-NEXT:    pandn %xmm1, %xmm10
-; SSE42-NEXT:    movdqa %xmm5, %xmm1
-; SSE42-NEXT:    pmaddubsw %xmm10, %xmm1
-; SSE42-NEXT:    psllw $8, %xmm1
-; SSE42-NEXT:    por %xmm9, %xmm1
-; SSE42-NEXT:    pxor %xmm8, %xmm1
-; SSE42-NEXT:    pxor %xmm6, %xmm1
-; SSE42-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7
-; SSE42-NEXT:    movdqa %xmm5, %xmm6
-; SSE42-NEXT:    pmullw %xmm7, %xmm6
-; SSE42-NEXT:    pand %xmm2, %xmm6
-; SSE42-NEXT:    pandn %xmm7, %xmm2
-; SSE42-NEXT:    pmaddubsw %xmm2, %xmm5
-; SSE42-NEXT:    psllw $8, %xmm5
-; SSE42-NEXT:    por %xmm6, %xmm5
-; SSE42-NEXT:    pxor %xmm1, %xmm5
-; SSE42-NEXT:    movdqa %xmm5, %xmm1
+; SSE42-NEXT:    por %xmm6, %xmm1
+; SSE42-NEXT:    pxor %xmm2, %xmm1
+; SSE42-NEXT:    pand %xmm5, %xmm1
+; SSE42-NEXT:    pandn %xmm10, %xmm5
+; SSE42-NEXT:    por %xmm5, %xmm1
+; SSE42-NEXT:    movdqa %xmm1, %xmm2
+; SSE42-NEXT:    pand %xmm4, %xmm2
+; SSE42-NEXT:    pshufb %xmm2, %xmm3
+; SSE42-NEXT:    psrlw $4, %xmm1
 ; SSE42-NEXT:    pand %xmm4, %xmm1
-; SSE42-NEXT:    pshufb %xmm1, %xmm3
-; SSE42-NEXT:    psrlw $4, %xmm5
-; SSE42-NEXT:    pand %xmm4, %xmm5
-; SSE42-NEXT:    pshufb %xmm5, %xmm0
+; SSE42-NEXT:    pshufb %xmm1, %xmm0
 ; SSE42-NEXT:    por %xmm3, %xmm0
 ; SSE42-NEXT:    retq
 ;
 ; AVX2-LABEL: clmulr_v16i8:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
 ; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero,xmm1[8],zero,xmm1[9],zero,xmm1[10],zero,xmm1[11],zero,xmm1[12],zero,xmm1[13],zero,xmm1[14],zero,xmm1[15],zero
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm2
-; AVX2-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpxor %ymm2, %ymm3, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
-; AVX2-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpxor %ymm0, %ymm2, %ymm0
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm2 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm3
+; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm4 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm5
+; AVX2-NEXT:    vpmullw %ymm3, %ymm5, %ymm6
+; AVX2-NEXT:    vpand %ymm4, %ymm1, %ymm7
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm8
+; AVX2-NEXT:    vpmullw %ymm7, %ymm8, %ymm9
+; AVX2-NEXT:    vpxor %ymm6, %ymm9, %ymm6
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm9 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX2-NEXT:    vpand %ymm1, %ymm9, %ymm1
+; AVX2-NEXT:    vpand %ymm0, %ymm9, %ymm0
+; AVX2-NEXT:    vpmullw %ymm1, %ymm0, %ymm10
+; AVX2-NEXT:    vpxor %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpand %ymm4, %ymm6, %ymm4
+; AVX2-NEXT:    vpmullw %ymm1, %ymm5, %ymm6
+; AVX2-NEXT:    vpmullw %ymm3, %ymm8, %ymm10
+; AVX2-NEXT:    vpxor %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpmullw %ymm7, %ymm0, %ymm10
+; AVX2-NEXT:    vpxor %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpand %ymm2, %ymm6, %ymm2
+; AVX2-NEXT:    vpor %ymm4, %ymm2, %ymm2
+; AVX2-NEXT:    vpmullw %ymm7, %ymm5, %ymm4
+; AVX2-NEXT:    vpmullw %ymm1, %ymm8, %ymm1
+; AVX2-NEXT:    vpxor %ymm4, %ymm1, %ymm1
+; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm0
+; AVX2-NEXT:    vpxor %ymm0, %ymm1, %ymm0
+; AVX2-NEXT:    vpand %ymm0, %ymm9, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX2-NEXT:    vpsrlw $7, %ymm0, %ymm0
 ; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
 ; AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
@@ -1383,28 +1077,32 @@ define <16 x i8> @clmulr_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ;
 ; AVX512-LABEL: clmulr_v16i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
 ; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero,xmm1[8],zero,xmm1[9],zero,xmm1[10],zero,xmm1[11],zero,xmm1[12],zero,xmm1[13],zero,xmm1[14],zero,xmm1[15],zero
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpxor %ymm2, %ymm3, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm4
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm4 = ymm4 ^ ymm2 ^ ymm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm3 = ymm3 ^ ymm4 ^ ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm1
-; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 ^ ymm3 ^ ymm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm2 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX512-NEXT:    vpand %ymm2, %ymm1, %ymm3
+; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
+; AVX512-NEXT:    vpand %ymm2, %ymm0, %ymm4
+; AVX512-NEXT:    vpmullw %ymm3, %ymm4, %ymm5
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm6 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX512-NEXT:    vpand %ymm6, %ymm1, %ymm7
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm8 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX512-NEXT:    vpand %ymm0, %ymm8, %ymm9
+; AVX512-NEXT:    vpmullw %ymm7, %ymm9, %ymm10
+; AVX512-NEXT:    vpand %ymm1, %ymm8, %ymm1
+; AVX512-NEXT:    vpand %ymm6, %ymm0, %ymm0
+; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm11
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm11 = ymm11 ^ ymm10 ^ ymm5
+; AVX512-NEXT:    vpmullw %ymm1, %ymm4, %ymm5
+; AVX512-NEXT:    vpmullw %ymm3, %ymm9, %ymm10
+; AVX512-NEXT:    vpmullw %ymm7, %ymm0, %ymm12
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm12 = ymm12 ^ ymm10 ^ ymm5
+; AVX512-NEXT:    vpmullw %ymm7, %ymm4, %ymm4
+; AVX512-NEXT:    vpmullw %ymm1, %ymm9, %ymm1
+; AVX512-NEXT:    vpxor %ymm4, %ymm1, %ymm1
+; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm0
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm8 & (ymm0 ^ ymm1)
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 | (ymm12 & ymm2)
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 | (ymm11 & ymm6)
 ; AVX512-NEXT:    vpsrlw $7, %ymm0, %ymm0
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero,ymm0[8],zero,ymm0[9],zero,ymm0[10],zero,ymm0[11],zero,ymm0[12],zero,ymm0[13],zero,ymm0[14],zero,ymm0[15],zero
 ; AVX512-NEXT:    vpmovdb %zmm0, %xmm0
@@ -1421,133 +1119,110 @@ define <16 x i8> @clmulr_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 define <8 x i16> @clmulr_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; SSE2-LABEL: clmulr_v8i16:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    movdqa %xmm0, %xmm2
-; SSE2-NEXT:    psrlw $8, %xmm2
-; SSE2-NEXT:    psllw $8, %xmm0
-; SSE2-NEXT:    por %xmm2, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm3
-; SSE2-NEXT:    psrlw $4, %xmm3
-; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; SSE2-NEXT:    pand %xmm2, %xmm3
-; SSE2-NEXT:    pand %xmm2, %xmm0
-; SSE2-NEXT:    psllw $4, %xmm0
-; SSE2-NEXT:    por %xmm3, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm4
-; SSE2-NEXT:    psrlw $2, %xmm4
-; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51]
-; SSE2-NEXT:    pand %xmm3, %xmm4
-; SSE2-NEXT:    pand %xmm3, %xmm0
-; SSE2-NEXT:    psllw $2, %xmm0
-; SSE2-NEXT:    por %xmm4, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm5
-; SSE2-NEXT:    psrlw $1, %xmm5
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    pand %xmm4, %xmm0
-; SSE2-NEXT:    paddb %xmm0, %xmm0
-; SSE2-NEXT:    por %xmm5, %xmm0
-; SSE2-NEXT:    movdqa %xmm1, %xmm5
-; SSE2-NEXT:    psrlw $8, %xmm5
+; SSE2-NEXT:    movdqa %xmm1, %xmm4
+; SSE2-NEXT:    psrlw $8, %xmm4
 ; SSE2-NEXT:    psllw $8, %xmm1
-; SSE2-NEXT:    por %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm1
-; SSE2-NEXT:    psrlw $4, %xmm1
-; SSE2-NEXT:    pand %xmm2, %xmm1
-; SSE2-NEXT:    pand %xmm2, %xmm5
-; SSE2-NEXT:    psllw $4, %xmm5
-; SSE2-NEXT:    por %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm1
-; SSE2-NEXT:    psrlw $2, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm1
+; SSE2-NEXT:    por %xmm1, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm2
+; SSE2-NEXT:    psrlw $4, %xmm2
+; SSE2-NEXT:    movdqa {{.*#+}} xmm1 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; SSE2-NEXT:    pand %xmm1, %xmm2
+; SSE2-NEXT:    pand %xmm1, %xmm4
+; SSE2-NEXT:    psllw $4, %xmm4
+; SSE2-NEXT:    por %xmm2, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm3
+; SSE2-NEXT:    psrlw $2, %xmm3
+; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51]
+; SSE2-NEXT:    pand %xmm2, %xmm3
+; SSE2-NEXT:    pand %xmm2, %xmm4
+; SSE2-NEXT:    psllw $2, %xmm4
+; SSE2-NEXT:    por %xmm3, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm5
+; SSE2-NEXT:    psrlw $1, %xmm5
+; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
 ; SSE2-NEXT:    pand %xmm3, %xmm5
-; SSE2-NEXT:    psllw $2, %xmm5
-; SSE2-NEXT:    por %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm6
-; SSE2-NEXT:    psrlw $1, %xmm6
-; SSE2-NEXT:    movdqa %xmm6, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    paddb %xmm5, %xmm5
-; SSE2-NEXT:    por %xmm5, %xmm1
-; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [4,4,4,4,4,4,4,4]
-; SSE2-NEXT:    pand %xmm1, %xmm7
-; SSE2-NEXT:    pmullw %xmm0, %xmm7
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [2,2,2,2,2,2,2,2]
-; SSE2-NEXT:    pand %xmm5, %xmm8
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    movdqa {{.*#+}} xmm9 = [1,1,1,1,1,1,1,1]
-; SSE2-NEXT:    pand %xmm6, %xmm9
-; SSE2-NEXT:    pmullw %xmm0, %xmm9
-; SSE2-NEXT:    pxor %xmm8, %xmm9
-; SSE2-NEXT:    pxor %xmm7, %xmm9
-; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [8,8,8,8,8,8,8,8]
-; SSE2-NEXT:    pand %xmm5, %xmm7
-; SSE2-NEXT:    pmullw %xmm0, %xmm7
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [16,16,16,16,16,16,16,16]
-; SSE2-NEXT:    pand %xmm1, %xmm8
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pxor %xmm7, %xmm8
-; SSE2-NEXT:    pxor %xmm9, %xmm8
-; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [32,32,32,32,32,32,32,32]
-; SSE2-NEXT:    pand %xmm5, %xmm7
-; SSE2-NEXT:    pmullw %xmm0, %xmm7
-; SSE2-NEXT:    movdqa {{.*#+}} xmm9 = [64,64,64,64,64,64,64,64]
-; SSE2-NEXT:    pand %xmm1, %xmm9
-; SSE2-NEXT:    pmullw %xmm0, %xmm9
-; SSE2-NEXT:    pxor %xmm7, %xmm9
-; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [128,128,128,128,128,128,128,128]
-; SSE2-NEXT:    pand %xmm5, %xmm7
-; SSE2-NEXT:    pmullw %xmm0, %xmm7
-; SSE2-NEXT:    pxor %xmm9, %xmm7
-; SSE2-NEXT:    pxor %xmm8, %xmm7
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm6
-; SSE2-NEXT:    pmullw %xmm0, %xmm6
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [512,512,512,512,512,512,512,512]
-; SSE2-NEXT:    pand %xmm5, %xmm8
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pxor %xmm6, %xmm8
-; SSE2-NEXT:    movdqa {{.*#+}} xmm6 = [1024,1024,1024,1024,1024,1024,1024,1024]
-; SSE2-NEXT:    pand %xmm1, %xmm6
-; SSE2-NEXT:    pmullw %xmm0, %xmm6
-; SSE2-NEXT:    pxor %xmm8, %xmm6
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [2048,2048,2048,2048,2048,2048,2048,2048]
-; SSE2-NEXT:    pand %xmm5, %xmm8
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pxor %xmm6, %xmm8
-; SSE2-NEXT:    movdqa {{.*#+}} xmm6 = [4096,4096,4096,4096,4096,4096,4096,4096]
-; SSE2-NEXT:    pand %xmm1, %xmm6
-; SSE2-NEXT:    pmullw %xmm0, %xmm6
-; SSE2-NEXT:    pxor %xmm8, %xmm6
-; SSE2-NEXT:    pxor %xmm7, %xmm6
-; SSE2-NEXT:    psllw $8, %xmm7
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [8192,8192,8192,8192,8192,8192,8192,8192]
-; SSE2-NEXT:    pand %xmm5, %xmm8
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
-; SSE2-NEXT:    pmullw %xmm0, %xmm1
-; SSE2-NEXT:    pxor %xmm8, %xmm1
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm5
-; SSE2-NEXT:    pmullw %xmm5, %xmm0
-; SSE2-NEXT:    pxor %xmm1, %xmm0
-; SSE2-NEXT:    pxor %xmm6, %xmm0
-; SSE2-NEXT:    psrlw $8, %xmm0
+; SSE2-NEXT:    pand %xmm3, %xmm4
+; SSE2-NEXT:    paddb %xmm4, %xmm4
+; SSE2-NEXT:    por %xmm5, %xmm4
+; SSE2-NEXT:    movdqa {{.*#+}} xmm6 = [37449,37449,37449,37449,37449,37449,37449,37449]
+; SSE2-NEXT:    movdqa %xmm4, %xmm5
+; SSE2-NEXT:    pand %xmm6, %xmm5
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $8, %xmm7
+; SSE2-NEXT:    psllw $8, %xmm0
 ; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $4, %xmm7
+; SSE2-NEXT:    pand %xmm1, %xmm7
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    psllw $4, %xmm0
+; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $2, %xmm7
+; SSE2-NEXT:    pand %xmm2, %xmm7
+; SSE2-NEXT:    pand %xmm2, %xmm0
+; SSE2-NEXT:    psllw $2, %xmm0
+; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $1, %xmm7
+; SSE2-NEXT:    pand %xmm3, %xmm7
+; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    paddb %xmm0, %xmm0
+; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [9362,9362,9362,9362,9362,9362,9362,9362]
+; SSE2-NEXT:    movdqa %xmm0, %xmm10
+; SSE2-NEXT:    pand %xmm8, %xmm10
+; SSE2-NEXT:    movdqa %xmm4, %xmm7
+; SSE2-NEXT:    pand %xmm8, %xmm7
+; SSE2-NEXT:    movdqa %xmm0, %xmm12
+; SSE2-NEXT:    pand %xmm6, %xmm12
+; SSE2-NEXT:    movdqa {{.*#+}} xmm9 = [18724,18724,18724,18724,18724,18724,18724,18724]
+; SSE2-NEXT:    pand %xmm9, %xmm4
+; SSE2-NEXT:    pand %xmm9, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm11
+; SSE2-NEXT:    pmullw %xmm4, %xmm11
+; SSE2-NEXT:    movdqa %xmm10, %xmm13
+; SSE2-NEXT:    pmullw %xmm4, %xmm13
+; SSE2-NEXT:    movdqa %xmm12, %xmm14
+; SSE2-NEXT:    pmullw %xmm12, %xmm4
+; SSE2-NEXT:    pmullw %xmm7, %xmm12
+; SSE2-NEXT:    movdqa %xmm0, %xmm15
+; SSE2-NEXT:    pmullw %xmm7, %xmm15
+; SSE2-NEXT:    pmullw %xmm10, %xmm7
+; SSE2-NEXT:    pmullw %xmm5, %xmm10
+; SSE2-NEXT:    pxor %xmm10, %xmm12
+; SSE2-NEXT:    pxor %xmm12, %xmm11
+; SSE2-NEXT:    pand %xmm8, %xmm11
+; SSE2-NEXT:    pmullw %xmm5, %xmm14
+; SSE2-NEXT:    pxor %xmm13, %xmm14
+; SSE2-NEXT:    pxor %xmm14, %xmm15
+; SSE2-NEXT:    pand %xmm6, %xmm15
+; SSE2-NEXT:    por %xmm11, %xmm15
+; SSE2-NEXT:    pxor %xmm7, %xmm4
+; SSE2-NEXT:    pmullw %xmm5, %xmm0
+; SSE2-NEXT:    pxor %xmm4, %xmm0
+; SSE2-NEXT:    pand %xmm9, %xmm0
+; SSE2-NEXT:    por %xmm15, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-NEXT:    psrlw $8, %xmm4
+; SSE2-NEXT:    psllw $8, %xmm0
+; SSE2-NEXT:    por %xmm4, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-NEXT:    psrlw $4, %xmm4
+; SSE2-NEXT:    pand %xmm1, %xmm4
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    psllw $4, %xmm0
+; SSE2-NEXT:    por %xmm4, %xmm0
 ; SSE2-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-NEXT:    psrlw $4, %xmm1
+; SSE2-NEXT:    psrlw $2, %xmm1
 ; SSE2-NEXT:    pand %xmm2, %xmm1
 ; SSE2-NEXT:    pand %xmm2, %xmm0
-; SSE2-NEXT:    psllw $4, %xmm0
-; SSE2-NEXT:    por %xmm1, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-NEXT:    psrlw $2, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm0
 ; SSE2-NEXT:    psllw $2, %xmm0
 ; SSE2-NEXT:    por %xmm1, %xmm0
 ; SSE2-NEXT:    movdqa %xmm0, %xmm1
 ; SSE2-NEXT:    psrlw $1, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm0
+; SSE2-NEXT:    pand %xmm3, %xmm1
+; SSE2-NEXT:    pand %xmm3, %xmm0
 ; SSE2-NEXT:    paddb %xmm0, %xmm0
 ; SSE2-NEXT:    por %xmm1, %xmm0
 ; SSE2-NEXT:    retq
@@ -1556,96 +1231,73 @@ define <8 x i16> @clmulr_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; SSE42:       # %bb.0:
 ; SSE42-NEXT:    movdqa %xmm0, %xmm2
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
-; SSE42-NEXT:    pshufb %xmm5, %xmm2
+; SSE42-NEXT:    pshufb %xmm5, %xmm1
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; SSE42-NEXT:    movdqa %xmm2, %xmm0
+; SSE42-NEXT:    movdqa %xmm1, %xmm0
 ; SSE42-NEXT:    pand %xmm4, %xmm0
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
 ; SSE42-NEXT:    movdqa %xmm3, %xmm7
 ; SSE42-NEXT:    pshufb %xmm0, %xmm7
-; SSE42-NEXT:    psrlw $4, %xmm2
-; SSE42-NEXT:    pand %xmm4, %xmm2
+; SSE42-NEXT:    psrlw $4, %xmm1
+; SSE42-NEXT:    pand %xmm4, %xmm1
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
 ; SSE42-NEXT:    movdqa %xmm0, %xmm6
-; SSE42-NEXT:    pshufb %xmm2, %xmm6
+; SSE42-NEXT:    pshufb %xmm1, %xmm6
 ; SSE42-NEXT:    por %xmm7, %xmm6
+; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [37449,37449,37449,37449,37449,37449,37449,37449]
+; SSE42-NEXT:    movdqa %xmm6, %xmm7
+; SSE42-NEXT:    pand %xmm8, %xmm7
+; SSE42-NEXT:    pshufb %xmm5, %xmm2
+; SSE42-NEXT:    movdqa %xmm2, %xmm1
+; SSE42-NEXT:    pand %xmm4, %xmm1
+; SSE42-NEXT:    movdqa %xmm3, %xmm9
+; SSE42-NEXT:    pshufb %xmm1, %xmm9
+; SSE42-NEXT:    psrlw $4, %xmm2
+; SSE42-NEXT:    pand %xmm4, %xmm2
+; SSE42-NEXT:    movdqa %xmm0, %xmm1
+; SSE42-NEXT:    pshufb %xmm2, %xmm1
+; SSE42-NEXT:    por %xmm9, %xmm1
+; SSE42-NEXT:    movdqa {{.*#+}} xmm9 = [9362,9362,9362,9362,9362,9362,9362,9362]
+; SSE42-NEXT:    movdqa %xmm1, %xmm13
+; SSE42-NEXT:    pand %xmm9, %xmm13
+; SSE42-NEXT:    movdqa %xmm6, %xmm2
+; SSE42-NEXT:    pand %xmm9, %xmm2
+; SSE42-NEXT:    movdqa %xmm1, %xmm11
+; SSE42-NEXT:    pand %xmm8, %xmm11
+; SSE42-NEXT:    movdqa %xmm11, %xmm12
+; SSE42-NEXT:    pmullw %xmm2, %xmm12
+; SSE42-NEXT:    movdqa {{.*#+}} xmm10 = [18724,18724,18724,18724,18724,18724,18724,18724]
+; SSE42-NEXT:    pand %xmm10, %xmm1
+; SSE42-NEXT:    movdqa %xmm13, %xmm15
+; SSE42-NEXT:    movdqa %xmm1, %xmm14
+; SSE42-NEXT:    pmullw %xmm2, %xmm14
+; SSE42-NEXT:    pmullw %xmm13, %xmm2
+; SSE42-NEXT:    pmullw %xmm7, %xmm13
+; SSE42-NEXT:    pxor %xmm13, %xmm12
+; SSE42-NEXT:    pand %xmm10, %xmm6
+; SSE42-NEXT:    movdqa %xmm1, %xmm13
+; SSE42-NEXT:    pmullw %xmm6, %xmm13
+; SSE42-NEXT:    pmullw %xmm6, %xmm15
+; SSE42-NEXT:    pmullw %xmm11, %xmm6
+; SSE42-NEXT:    pxor %xmm12, %xmm13
+; SSE42-NEXT:    pand %xmm9, %xmm13
+; SSE42-NEXT:    pmullw %xmm7, %xmm11
+; SSE42-NEXT:    pxor %xmm15, %xmm11
+; SSE42-NEXT:    pxor %xmm11, %xmm14
+; SSE42-NEXT:    pand %xmm8, %xmm14
+; SSE42-NEXT:    por %xmm13, %xmm14
+; SSE42-NEXT:    pxor %xmm2, %xmm6
+; SSE42-NEXT:    pmullw %xmm7, %xmm1
+; SSE42-NEXT:    pxor %xmm6, %xmm1
+; SSE42-NEXT:    pand %xmm10, %xmm1
+; SSE42-NEXT:    por %xmm14, %xmm1
 ; SSE42-NEXT:    pshufb %xmm5, %xmm1
-; SSE42-NEXT:    movdqa %xmm1, %xmm7
-; SSE42-NEXT:    psrlw $4, %xmm7
-; SSE42-NEXT:    pand %xmm4, %xmm7
-; SSE42-NEXT:    movdqa %xmm0, %xmm2
-; SSE42-NEXT:    pshufb %xmm7, %xmm2
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm7 = [2,2,2,2,2,2,2,2]
-; SSE42-NEXT:    pand %xmm2, %xmm7
-; SSE42-NEXT:    pmullw %xmm6, %xmm7
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm9 = [1,1,1,1,1,1,1,1]
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    pmullw %xmm6, %xmm9
-; SSE42-NEXT:    pxor %xmm7, %xmm9
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm7 = [4,4,4,4,4,4,4,4]
-; SSE42-NEXT:    pand %xmm2, %xmm7
-; SSE42-NEXT:    pmullw %xmm6, %xmm7
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm8 = [8,8,8,8,8,8,8,8]
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    pmullw %xmm6, %xmm8
-; SSE42-NEXT:    pxor %xmm7, %xmm8
-; SSE42-NEXT:    pxor %xmm9, %xmm8
+; SSE42-NEXT:    movdqa %xmm1, %xmm2
+; SSE42-NEXT:    pand %xmm4, %xmm2
+; SSE42-NEXT:    pshufb %xmm2, %xmm3
+; SSE42-NEXT:    psrlw $4, %xmm1
 ; SSE42-NEXT:    pand %xmm4, %xmm1
-; SSE42-NEXT:    movdqa %xmm3, %xmm7
-; SSE42-NEXT:    pshufb %xmm1, %xmm7
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm1 = [16,16,16,16,16,16,16,16]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    pmullw %xmm6, %xmm1
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm9 = [32,32,32,32,32,32,32,32]
-; SSE42-NEXT:    pand %xmm7, %xmm9
-; SSE42-NEXT:    pmullw %xmm6, %xmm9
-; SSE42-NEXT:    pxor %xmm1, %xmm9
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm10 = [64,64,64,64,64,64,64,64]
-; SSE42-NEXT:    pand %xmm7, %xmm10
-; SSE42-NEXT:    pmullw %xmm6, %xmm10
-; SSE42-NEXT:    pxor %xmm9, %xmm10
-; SSE42-NEXT:    pmovzxbw {{.*#+}} xmm1 = [128,128,128,128,128,128,128,128]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    pmullw %xmm6, %xmm1
-; SSE42-NEXT:    pxor %xmm10, %xmm1
-; SSE42-NEXT:    pxor %xmm8, %xmm1
-; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [256,256,256,256,256,256,256,256]
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    pmullw %xmm6, %xmm8
-; SSE42-NEXT:    movdqa {{.*#+}} xmm9 = [512,512,512,512,512,512,512,512]
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    pmullw %xmm6, %xmm9
-; SSE42-NEXT:    pxor %xmm8, %xmm9
-; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [1024,1024,1024,1024,1024,1024,1024,1024]
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    pmullw %xmm6, %xmm8
-; SSE42-NEXT:    pxor %xmm9, %xmm8
-; SSE42-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm2
-; SSE42-NEXT:    pmullw %xmm6, %xmm2
-; SSE42-NEXT:    pxor %xmm8, %xmm2
-; SSE42-NEXT:    pxor %xmm1, %xmm2
-; SSE42-NEXT:    movdqa {{.*#+}} xmm1 = [4096,4096,4096,4096,4096,4096,4096,4096]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    pmullw %xmm6, %xmm1
-; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [8192,8192,8192,8192,8192,8192,8192,8192]
-; SSE42-NEXT:    pand %xmm7, %xmm8
-; SSE42-NEXT:    pmullw %xmm6, %xmm8
-; SSE42-NEXT:    pxor %xmm1, %xmm8
-; SSE42-NEXT:    movdqa {{.*#+}} xmm1 = [16384,16384,16384,16384,16384,16384,16384,16384]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    pmullw %xmm6, %xmm1
-; SSE42-NEXT:    pxor %xmm8, %xmm1
-; SSE42-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7
-; SSE42-NEXT:    pmullw %xmm6, %xmm7
-; SSE42-NEXT:    pxor %xmm1, %xmm7
-; SSE42-NEXT:    pxor %xmm2, %xmm7
-; SSE42-NEXT:    pshufb %xmm5, %xmm7
-; SSE42-NEXT:    movdqa %xmm7, %xmm1
-; SSE42-NEXT:    pand %xmm4, %xmm1
-; SSE42-NEXT:    pshufb %xmm1, %xmm3
-; SSE42-NEXT:    psrlw $4, %xmm7
-; SSE42-NEXT:    pand %xmm4, %xmm7
-; SSE42-NEXT:    pshufb %xmm7, %xmm0
+; SSE42-NEXT:    pshufb %xmm1, %xmm0
 ; SSE42-NEXT:    por %xmm3, %xmm0
 ; SSE42-NEXT:    retq
 ;
@@ -2913,150 +2565,105 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 define <16 x i8> @clmulh_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; SSE2-LABEL: clmulh_v16i8:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    movdqa %xmm0, %xmm3
-; SSE2-NEXT:    psrlw $4, %xmm3
+; SSE2-NEXT:    movdqa %xmm1, %xmm4
+; SSE2-NEXT:    psrlw $4, %xmm4
 ; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; SSE2-NEXT:    pand %xmm2, %xmm3
-; SSE2-NEXT:    pand %xmm2, %xmm0
-; SSE2-NEXT:    psllw $4, %xmm0
-; SSE2-NEXT:    por %xmm3, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm4
-; SSE2-NEXT:    psrlw $2, %xmm4
-; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51]
-; SSE2-NEXT:    pand %xmm3, %xmm4
-; SSE2-NEXT:    pand %xmm3, %xmm0
-; SSE2-NEXT:    psllw $2, %xmm0
-; SSE2-NEXT:    por %xmm4, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm5
-; SSE2-NEXT:    psrlw $1, %xmm5
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    pand %xmm4, %xmm0
-; SSE2-NEXT:    paddb %xmm0, %xmm0
-; SSE2-NEXT:    por %xmm5, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm6
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm6 = xmm6[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    movdqa %xmm1, %xmm5
-; SSE2-NEXT:    psrlw $4, %xmm5
-; SSE2-NEXT:    pand %xmm2, %xmm5
+; SSE2-NEXT:    pand %xmm2, %xmm4
 ; SSE2-NEXT:    pand %xmm2, %xmm1
 ; SSE2-NEXT:    psllw $4, %xmm1
-; SSE2-NEXT:    por %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm1
-; SSE2-NEXT:    psrlw $2, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm1
+; SSE2-NEXT:    por %xmm1, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm3
+; SSE2-NEXT:    psrlw $2, %xmm3
+; SSE2-NEXT:    movdqa {{.*#+}} xmm1 = [51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51]
+; SSE2-NEXT:    pand %xmm1, %xmm3
+; SSE2-NEXT:    pand %xmm1, %xmm4
+; SSE2-NEXT:    psllw $2, %xmm4
+; SSE2-NEXT:    por %xmm3, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm5
+; SSE2-NEXT:    psrlw $1, %xmm5
+; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; SSE2-NEXT:    pand %xmm3, %xmm4
+; SSE2-NEXT:    paddb %xmm4, %xmm4
+; SSE2-NEXT:    por %xmm4, %xmm5
 ; SSE2-NEXT:    pand %xmm3, %xmm5
-; SSE2-NEXT:    psllw $2, %xmm5
-; SSE2-NEXT:    por %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm8
-; SSE2-NEXT:    psrlw $1, %xmm8
-; SSE2-NEXT:    movdqa %xmm8, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    paddb %xmm5, %xmm5
-; SSE2-NEXT:    por %xmm5, %xmm1
-; SSE2-NEXT:    movdqa {{.*#+}} xmm9 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; SSE2-NEXT:    pand %xmm1, %xmm9
-; SSE2-NEXT:    movdqa %xmm9, %xmm10
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm10 = xmm10[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm10
-; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [255,255,255,255,255,255,255,255]
-; SSE2-NEXT:    pand %xmm7, %xmm10
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm9 = xmm9[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm9
-; SSE2-NEXT:    pand %xmm7, %xmm9
-; SSE2-NEXT:    packuswb %xmm10, %xmm9
-; SSE2-NEXT:    movdqa {{.*#+}} xmm10 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; SSE2-NEXT:    pand %xmm5, %xmm10
-; SSE2-NEXT:    movdqa %xmm10, %xmm11
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm11 = xmm11[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm11
-; SSE2-NEXT:    pand %xmm7, %xmm11
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm10 = xmm10[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm10
-; SSE2-NEXT:    pand %xmm7, %xmm10
-; SSE2-NEXT:    packuswb %xmm11, %xmm10
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm8
-; SSE2-NEXT:    movdqa %xmm8, %xmm11
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm11 = xmm11[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm11
-; SSE2-NEXT:    pand %xmm7, %xmm11
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm8 = xmm8[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pand %xmm7, %xmm8
-; SSE2-NEXT:    packuswb %xmm11, %xmm8
-; SSE2-NEXT:    pxor %xmm10, %xmm8
-; SSE2-NEXT:    pxor %xmm9, %xmm8
-; SSE2-NEXT:    movdqa {{.*#+}} xmm10 = [8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8]
-; SSE2-NEXT:    pand %xmm5, %xmm10
-; SSE2-NEXT:    movdqa %xmm10, %xmm9
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm9 = xmm9[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm9
-; SSE2-NEXT:    pand %xmm7, %xmm9
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm10 = xmm10[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm10
-; SSE2-NEXT:    pand %xmm7, %xmm10
-; SSE2-NEXT:    packuswb %xmm9, %xmm10
-; SSE2-NEXT:    movdqa {{.*#+}} xmm9 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; SSE2-NEXT:    pand %xmm1, %xmm9
-; SSE2-NEXT:    movdqa %xmm9, %xmm11
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm11 = xmm11[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm11
-; SSE2-NEXT:    pand %xmm7, %xmm11
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm9 = xmm9[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm9
-; SSE2-NEXT:    pand %xmm7, %xmm9
-; SSE2-NEXT:    packuswb %xmm11, %xmm9
-; SSE2-NEXT:    pxor %xmm10, %xmm9
-; SSE2-NEXT:    pxor %xmm8, %xmm9
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; SSE2-NEXT:    pand %xmm5, %xmm8
-; SSE2-NEXT:    movdqa %xmm8, %xmm10
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm10 = xmm10[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm10
-; SSE2-NEXT:    pand %xmm7, %xmm10
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm8 = xmm8[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pand %xmm7, %xmm8
-; SSE2-NEXT:    packuswb %xmm10, %xmm8
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
-; SSE2-NEXT:    movdqa %xmm1, %xmm10
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm10 = xmm10[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm10
-; SSE2-NEXT:    pand %xmm7, %xmm10
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm1 = xmm1[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm0, %xmm1
-; SSE2-NEXT:    pand %xmm7, %xmm1
-; SSE2-NEXT:    packuswb %xmm10, %xmm1
-; SSE2-NEXT:    pxor %xmm8, %xmm1
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm8
-; SSE2-NEXT:    punpckhbw {{.*#+}} xmm8 = xmm8[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
-; SSE2-NEXT:    pmullw %xmm6, %xmm8
-; SSE2-NEXT:    pand %xmm7, %xmm8
-; SSE2-NEXT:    punpcklbw {{.*#+}} xmm5 = xmm5[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
-; SSE2-NEXT:    pmullw %xmm5, %xmm0
-; SSE2-NEXT:    pand %xmm7, %xmm0
-; SSE2-NEXT:    packuswb %xmm8, %xmm0
-; SSE2-NEXT:    pxor %xmm1, %xmm0
-; SSE2-NEXT:    pxor %xmm9, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-NEXT:    psrlw $4, %xmm1
-; SSE2-NEXT:    pand %xmm2, %xmm1
+; SSE2-NEXT:    movdqa %xmm5, %xmm6
+; SSE2-NEXT:    punpckhbw {{.*#+}} xmm6 = xmm6[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $4, %xmm7
+; SSE2-NEXT:    pand %xmm2, %xmm7
 ; SSE2-NEXT:    pand %xmm2, %xmm0
 ; SSE2-NEXT:    psllw $4, %xmm0
-; SSE2-NEXT:    por %xmm1, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-NEXT:    psrlw $2, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $2, %xmm7
+; SSE2-NEXT:    pand %xmm1, %xmm7
+; SSE2-NEXT:    pand %xmm1, %xmm0
 ; SSE2-NEXT:    psllw $2, %xmm0
-; SSE2-NEXT:    por %xmm1, %xmm0
+; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm9
+; SSE2-NEXT:    pand %xmm3, %xmm9
+; SSE2-NEXT:    paddb %xmm9, %xmm9
+; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; SSE2-NEXT:    psrlw $1, %xmm0
+; SSE2-NEXT:    por %xmm9, %xmm0
+; SSE2-NEXT:    pand %xmm7, %xmm9
+; SSE2-NEXT:    movdqa %xmm9, %xmm11
+; SSE2-NEXT:    punpckhbw {{.*#+}} xmm11 = xmm11[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
+; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm8
+; SSE2-NEXT:    punpckhbw {{.*#+}} xmm8 = xmm8[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
+; SSE2-NEXT:    pand %xmm7, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm7
+; SSE2-NEXT:    punpckhbw {{.*#+}} xmm7 = xmm7[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15]
+; SSE2-NEXT:    movdqa %xmm8, %xmm10
+; SSE2-NEXT:    pmullw %xmm7, %xmm10
+; SSE2-NEXT:    pmullw %xmm11, %xmm7
+; SSE2-NEXT:    pmullw %xmm6, %xmm11
+; SSE2-NEXT:    movdqa {{.*#+}} xmm12 = [255,255,255,255,255,255,255,255]
+; SSE2-NEXT:    pand %xmm12, %xmm11
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm5 = xmm5[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm9 = xmm9[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    punpcklbw {{.*#+}} xmm4 = xmm4[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
+; SSE2-NEXT:    movdqa %xmm0, %xmm13
+; SSE2-NEXT:    pmullw %xmm4, %xmm13
+; SSE2-NEXT:    pmullw %xmm9, %xmm4
+; SSE2-NEXT:    pmullw %xmm5, %xmm9
+; SSE2-NEXT:    pand %xmm12, %xmm9
+; SSE2-NEXT:    packuswb %xmm11, %xmm9
+; SSE2-NEXT:    pand %xmm12, %xmm10
+; SSE2-NEXT:    pand %xmm12, %xmm13
+; SSE2-NEXT:    packuswb %xmm10, %xmm13
+; SSE2-NEXT:    pxor %xmm9, %xmm13
+; SSE2-NEXT:    movdqa %xmm3, %xmm9
+; SSE2-NEXT:    pandn %xmm13, %xmm9
+; SSE2-NEXT:    pmullw %xmm6, %xmm8
+; SSE2-NEXT:    pand %xmm12, %xmm8
+; SSE2-NEXT:    pmullw %xmm5, %xmm0
+; SSE2-NEXT:    pand %xmm12, %xmm0
+; SSE2-NEXT:    packuswb %xmm8, %xmm0
+; SSE2-NEXT:    pand %xmm12, %xmm7
+; SSE2-NEXT:    pand %xmm12, %xmm4
+; SSE2-NEXT:    packuswb %xmm7, %xmm4
+; SSE2-NEXT:    pxor %xmm4, %xmm0
+; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    por %xmm9, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-NEXT:    psrlw $4, %xmm4
+; SSE2-NEXT:    pand %xmm2, %xmm4
+; SSE2-NEXT:    pand %xmm2, %xmm0
+; SSE2-NEXT:    psllw $4, %xmm0
+; SSE2-NEXT:    por %xmm4, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm2
+; SSE2-NEXT:    psrlw $2, %xmm2
+; SSE2-NEXT:    pand %xmm1, %xmm2
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    psllw $2, %xmm0
+; SSE2-NEXT:    por %xmm2, %xmm0
 ; SSE2-NEXT:    movdqa %xmm0, %xmm1
 ; SSE2-NEXT:    psrlw $1, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm0
+; SSE2-NEXT:    pand %xmm3, %xmm1
+; SSE2-NEXT:    pand %xmm3, %xmm0
 ; SSE2-NEXT:    paddb %xmm0, %xmm0
 ; SSE2-NEXT:    por %xmm1, %xmm0
 ; SSE2-NEXT:    psrlw $1, %xmm0
@@ -3067,122 +2674,74 @@ define <16 x i8> @clmulh_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; SSE42:       # %bb.0:
 ; SSE42-NEXT:    movdqa %xmm0, %xmm2
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; SSE42-NEXT:    movdqa %xmm1, %xmm0
 ; SSE42-NEXT:    pand %xmm4, %xmm0
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
-; SSE42-NEXT:    movdqa %xmm3, %xmm6
-; SSE42-NEXT:    pshufb %xmm0, %xmm6
-; SSE42-NEXT:    psrlw $4, %xmm2
-; SSE42-NEXT:    pand %xmm4, %xmm2
-; SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
-; SSE42-NEXT:    movdqa %xmm0, %xmm5
-; SSE42-NEXT:    pshufb %xmm2, %xmm5
-; SSE42-NEXT:    por %xmm6, %xmm5
-; SSE42-NEXT:    movdqa %xmm1, %xmm2
-; SSE42-NEXT:    psrlw $4, %xmm2
-; SSE42-NEXT:    pand %xmm4, %xmm2
-; SSE42-NEXT:    movdqa %xmm0, %xmm6
-; SSE42-NEXT:    pshufb %xmm2, %xmm6
-; SSE42-NEXT:    movdqa {{.*#+}} xmm7 = [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]
-; SSE42-NEXT:    pand %xmm6, %xmm7
-; SSE42-NEXT:    movdqa %xmm5, %xmm8
-; SSE42-NEXT:    pmullw %xmm7, %xmm8
-; SSE42-NEXT:    pmovzxbw {{.*#+}} xmm2 = [255,255,255,255,255,255,255,255]
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    movdqa %xmm2, %xmm9
-; SSE42-NEXT:    pandn %xmm7, %xmm9
-; SSE42-NEXT:    movdqa %xmm5, %xmm10
-; SSE42-NEXT:    pmaddubsw %xmm9, %xmm10
-; SSE42-NEXT:    psllw $8, %xmm10
-; SSE42-NEXT:    por %xmm8, %xmm10
-; SSE42-NEXT:    movdqa {{.*#+}} xmm7 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-; SSE42-NEXT:    pand %xmm6, %xmm7
-; SSE42-NEXT:    movdqa %xmm5, %xmm8
-; SSE42-NEXT:    pmullw %xmm7, %xmm8
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    movdqa %xmm2, %xmm9
-; SSE42-NEXT:    pandn %xmm7, %xmm9
-; SSE42-NEXT:    movdqa %xmm5, %xmm7
-; SSE42-NEXT:    pmaddubsw %xmm9, %xmm7
-; SSE42-NEXT:    psllw $8, %xmm7
-; SSE42-NEXT:    por %xmm8, %xmm7
-; SSE42-NEXT:    pxor %xmm10, %xmm7
-; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]
-; SSE42-NEXT:    pand %xmm6, %xmm8
-; SSE42-NEXT:    movdqa %xmm5, %xmm9
-; SSE42-NEXT:    pmullw %xmm8, %xmm9
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    movdqa %xmm2, %xmm10
-; SSE42-NEXT:    pandn %xmm8, %xmm10
-; SSE42-NEXT:    movdqa %xmm5, %xmm8
-; SSE42-NEXT:    pmaddubsw %xmm10, %xmm8
-; SSE42-NEXT:    psllw $8, %xmm8
-; SSE42-NEXT:    por %xmm9, %xmm8
-; SSE42-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm6
-; SSE42-NEXT:    movdqa %xmm5, %xmm9
-; SSE42-NEXT:    pmullw %xmm6, %xmm9
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    movdqa %xmm2, %xmm10
-; SSE42-NEXT:    pandn %xmm6, %xmm10
-; SSE42-NEXT:    movdqa %xmm5, %xmm6
-; SSE42-NEXT:    pmaddubsw %xmm10, %xmm6
-; SSE42-NEXT:    psllw $8, %xmm6
-; SSE42-NEXT:    por %xmm9, %xmm6
-; SSE42-NEXT:    pxor %xmm8, %xmm6
-; SSE42-NEXT:    pxor %xmm7, %xmm6
+; SSE42-NEXT:    movdqa %xmm3, %xmm5
+; SSE42-NEXT:    pshufb %xmm0, %xmm5
+; SSE42-NEXT:    psrlw $4, %xmm1
 ; SSE42-NEXT:    pand %xmm4, %xmm1
-; SSE42-NEXT:    movdqa %xmm3, %xmm7
+; SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
+; SSE42-NEXT:    movdqa %xmm0, %xmm7
 ; SSE42-NEXT:    pshufb %xmm1, %xmm7
-; SSE42-NEXT:    movdqa {{.*#+}} xmm1 = [16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    movdqa %xmm5, %xmm8
-; SSE42-NEXT:    pmullw %xmm1, %xmm8
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    movdqa %xmm2, %xmm9
-; SSE42-NEXT:    pandn %xmm1, %xmm9
-; SSE42-NEXT:    movdqa %xmm5, %xmm1
+; SSE42-NEXT:    por %xmm5, %xmm7
+; SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
+; SSE42-NEXT:    movdqa %xmm7, %xmm6
+; SSE42-NEXT:    pand %xmm5, %xmm6
+; SSE42-NEXT:    movdqa %xmm2, %xmm1
+; SSE42-NEXT:    pand %xmm4, %xmm1
+; SSE42-NEXT:    movdqa %xmm3, %xmm8
+; SSE42-NEXT:    pshufb %xmm1, %xmm8
+; SSE42-NEXT:    psrlw $4, %xmm2
+; SSE42-NEXT:    pand %xmm4, %xmm2
+; SSE42-NEXT:    movdqa %xmm0, %xmm1
+; SSE42-NEXT:    pshufb %xmm2, %xmm1
+; SSE42-NEXT:    por %xmm8, %xmm1
+; SSE42-NEXT:    movdqa {{.*#+}} xmm10 = [170,170,170,170,170,170,170,170,170,170,170,170,170,170,170,170]
+; SSE42-NEXT:    movdqa %xmm1, %xmm2
+; SSE42-NEXT:    pand %xmm10, %xmm2
+; SSE42-NEXT:    movdqa %xmm2, %xmm11
+; SSE42-NEXT:    pmullw %xmm6, %xmm11
+; SSE42-NEXT:    pmovzxbw {{.*#+}} xmm8 = [255,255,255,255,255,255,255,255]
+; SSE42-NEXT:    pand %xmm8, %xmm11
+; SSE42-NEXT:    movdqa %xmm8, %xmm9
+; SSE42-NEXT:    pandn %xmm6, %xmm9
+; SSE42-NEXT:    movdqa %xmm2, %xmm12
+; SSE42-NEXT:    pmaddubsw %xmm9, %xmm12
+; SSE42-NEXT:    psllw $8, %xmm12
+; SSE42-NEXT:    por %xmm11, %xmm12
+; SSE42-NEXT:    pand %xmm10, %xmm7
+; SSE42-NEXT:    pand %xmm5, %xmm1
+; SSE42-NEXT:    movdqa %xmm1, %xmm11
+; SSE42-NEXT:    pmullw %xmm7, %xmm11
+; SSE42-NEXT:    pand %xmm8, %xmm11
+; SSE42-NEXT:    movdqa %xmm8, %xmm13
+; SSE42-NEXT:    pandn %xmm7, %xmm13
+; SSE42-NEXT:    movdqa %xmm1, %xmm10
+; SSE42-NEXT:    pmaddubsw %xmm13, %xmm10
+; SSE42-NEXT:    psllw $8, %xmm10
+; SSE42-NEXT:    por %xmm11, %xmm10
+; SSE42-NEXT:    pxor %xmm12, %xmm10
+; SSE42-NEXT:    pmullw %xmm2, %xmm7
+; SSE42-NEXT:    pand %xmm8, %xmm7
+; SSE42-NEXT:    pmaddubsw %xmm13, %xmm2
+; SSE42-NEXT:    psllw $8, %xmm2
+; SSE42-NEXT:    por %xmm7, %xmm2
+; SSE42-NEXT:    pmullw %xmm1, %xmm6
+; SSE42-NEXT:    pand %xmm8, %xmm6
 ; SSE42-NEXT:    pmaddubsw %xmm9, %xmm1
 ; SSE42-NEXT:    psllw $8, %xmm1
-; SSE42-NEXT:    por %xmm8, %xmm1
-; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32]
-; SSE42-NEXT:    pand %xmm7, %xmm8
-; SSE42-NEXT:    movdqa %xmm5, %xmm9
-; SSE42-NEXT:    pmullw %xmm8, %xmm9
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    movdqa %xmm2, %xmm10
-; SSE42-NEXT:    pandn %xmm8, %xmm10
-; SSE42-NEXT:    movdqa %xmm5, %xmm8
-; SSE42-NEXT:    pmaddubsw %xmm10, %xmm8
-; SSE42-NEXT:    psllw $8, %xmm8
-; SSE42-NEXT:    por %xmm9, %xmm8
-; SSE42-NEXT:    pxor %xmm1, %xmm8
-; SSE42-NEXT:    movdqa {{.*#+}} xmm1 = [64,64,64,64,64,64,64,64,64,64,64,64,64,64,64,64]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    movdqa %xmm5, %xmm9
-; SSE42-NEXT:    pmullw %xmm1, %xmm9
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    movdqa %xmm2, %xmm10
-; SSE42-NEXT:    pandn %xmm1, %xmm10
-; SSE42-NEXT:    movdqa %xmm5, %xmm1
-; SSE42-NEXT:    pmaddubsw %xmm10, %xmm1
-; SSE42-NEXT:    psllw $8, %xmm1
-; SSE42-NEXT:    por %xmm9, %xmm1
-; SSE42-NEXT:    pxor %xmm8, %xmm1
-; SSE42-NEXT:    pxor %xmm6, %xmm1
-; SSE42-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7
-; SSE42-NEXT:    movdqa %xmm5, %xmm6
-; SSE42-NEXT:    pmullw %xmm7, %xmm6
-; SSE42-NEXT:    pand %xmm2, %xmm6
-; SSE42-NEXT:    pandn %xmm7, %xmm2
-; SSE42-NEXT:    pmaddubsw %xmm2, %xmm5
-; SSE42-NEXT:    psllw $8, %xmm5
-; SSE42-NEXT:    por %xmm6, %xmm5
-; SSE42-NEXT:    pxor %xmm1, %xmm5
-; SSE42-NEXT:    movdqa %xmm5, %xmm1
+; SSE42-NEXT:    por %xmm6, %xmm1
+; SSE42-NEXT:    pxor %xmm2, %xmm1
+; SSE42-NEXT:    pand %xmm5, %xmm1
+; SSE42-NEXT:    pandn %xmm10, %xmm5
+; SSE42-NEXT:    por %xmm5, %xmm1
+; SSE42-NEXT:    movdqa %xmm1, %xmm2
+; SSE42-NEXT:    pand %xmm4, %xmm2
+; SSE42-NEXT:    pshufb %xmm2, %xmm3
+; SSE42-NEXT:    psrlw $4, %xmm1
 ; SSE42-NEXT:    pand %xmm4, %xmm1
-; SSE42-NEXT:    pshufb %xmm1, %xmm3
-; SSE42-NEXT:    psrlw $4, %xmm5
-; SSE42-NEXT:    pand %xmm4, %xmm5
-; SSE42-NEXT:    pshufb %xmm5, %xmm0
+; SSE42-NEXT:    pshufb %xmm1, %xmm0
 ; SSE42-NEXT:    por %xmm3, %xmm0
 ; SSE42-NEXT:    psrlw $1, %xmm0
 ; SSE42-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
@@ -3190,31 +2749,37 @@ define <16 x i8> @clmulh_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ;
 ; AVX2-LABEL: clmulh_v16i8:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
 ; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero,xmm1[8],zero,xmm1[9],zero,xmm1[10],zero,xmm1[11],zero,xmm1[12],zero,xmm1[13],zero,xmm1[14],zero,xmm1[15],zero
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm2
-; AVX2-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpxor %ymm2, %ymm3, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm3
-; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm4
-; AVX2-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX2-NEXT:    vpxor %ymm4, %ymm3, %ymm3
-; AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm2
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
-; AVX2-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX2-NEXT:    vpxor %ymm0, %ymm2, %ymm0
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm2 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX2-NEXT:    vpand %ymm2, %ymm1, %ymm3
+; AVX2-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm4 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX2-NEXT:    vpand %ymm4, %ymm0, %ymm5
+; AVX2-NEXT:    vpmullw %ymm3, %ymm5, %ymm6
+; AVX2-NEXT:    vpand %ymm4, %ymm1, %ymm7
+; AVX2-NEXT:    vpand %ymm2, %ymm0, %ymm8
+; AVX2-NEXT:    vpmullw %ymm7, %ymm8, %ymm9
+; AVX2-NEXT:    vpxor %ymm6, %ymm9, %ymm6
+; AVX2-NEXT:    vpbroadcastw {{.*#+}} ymm9 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX2-NEXT:    vpand %ymm1, %ymm9, %ymm1
+; AVX2-NEXT:    vpand %ymm0, %ymm9, %ymm0
+; AVX2-NEXT:    vpmullw %ymm1, %ymm0, %ymm10
+; AVX2-NEXT:    vpxor %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpand %ymm4, %ymm6, %ymm4
+; AVX2-NEXT:    vpmullw %ymm1, %ymm5, %ymm6
+; AVX2-NEXT:    vpmullw %ymm3, %ymm8, %ymm10
+; AVX2-NEXT:    vpxor %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpmullw %ymm7, %ymm0, %ymm10
+; AVX2-NEXT:    vpxor %ymm6, %ymm10, %ymm6
+; AVX2-NEXT:    vpand %ymm2, %ymm6, %ymm2
+; AVX2-NEXT:    vpor %ymm4, %ymm2, %ymm2
+; AVX2-NEXT:    vpmullw %ymm7, %ymm5, %ymm4
+; AVX2-NEXT:    vpmullw %ymm1, %ymm8, %ymm1
+; AVX2-NEXT:    vpxor %ymm4, %ymm1, %ymm1
+; AVX2-NEXT:    vpmullw %ymm3, %ymm0, %ymm0
+; AVX2-NEXT:    vpxor %ymm0, %ymm1, %ymm0
+; AVX2-NEXT:    vpand %ymm0, %ymm9, %ymm0
+; AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
 ; AVX2-NEXT:    vpsrlw $8, %ymm0, %ymm0
 ; AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; AVX2-NEXT:    vpackuswb %xmm1, %xmm0, %xmm0
@@ -3223,28 +2788,32 @@ define <16 x i8> @clmulh_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ;
 ; AVX512-LABEL: clmulh_v16i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
 ; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero,xmm1[4],zero,xmm1[5],zero,xmm1[6],zero,xmm1[7],zero,xmm1[8],zero,xmm1[9],zero,xmm1[10],zero,xmm1[11],zero,xmm1[12],zero,xmm1[13],zero,xmm1[14],zero,xmm1[15],zero
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpxor %ymm2, %ymm3, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm4
-; AVX512-NEXT:    vpmullw %ymm4, %ymm0, %ymm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm4 = ymm4 ^ ymm2 ^ ymm3
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm3
-; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm3
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm3 = ymm3 ^ ymm4 ^ ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm2
-; AVX512-NEXT:    vpmullw %ymm2, %ymm0, %ymm2
-; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm1
-; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
-; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 ^ ymm3 ^ ymm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm2 = [9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362,9362]
+; AVX512-NEXT:    vpand %ymm2, %ymm1, %ymm3
+; AVX512-NEXT:    vpmovzxbw {{.*#+}} ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero,xmm0[4],zero,xmm0[5],zero,xmm0[6],zero,xmm0[7],zero,xmm0[8],zero,xmm0[9],zero,xmm0[10],zero,xmm0[11],zero,xmm0[12],zero,xmm0[13],zero,xmm0[14],zero,xmm0[15],zero
+; AVX512-NEXT:    vpand %ymm2, %ymm0, %ymm4
+; AVX512-NEXT:    vpmullw %ymm3, %ymm4, %ymm5
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm6 = [18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724,18724]
+; AVX512-NEXT:    vpand %ymm6, %ymm1, %ymm7
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} ymm8 = [37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449,37449]
+; AVX512-NEXT:    vpand %ymm0, %ymm8, %ymm9
+; AVX512-NEXT:    vpmullw %ymm7, %ymm9, %ymm10
+; AVX512-NEXT:    vpand %ymm1, %ymm8, %ymm1
+; AVX512-NEXT:    vpand %ymm6, %ymm0, %ymm0
+; AVX512-NEXT:    vpmullw %ymm1, %ymm0, %ymm11
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm11 = ymm11 ^ ymm10 ^ ymm5
+; AVX512-NEXT:    vpmullw %ymm1, %ymm4, %ymm5
+; AVX512-NEXT:    vpmullw %ymm3, %ymm9, %ymm10
+; AVX512-NEXT:    vpmullw %ymm7, %ymm0, %ymm12
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm12 = ymm12 ^ ymm10 ^ ymm5
+; AVX512-NEXT:    vpmullw %ymm7, %ymm4, %ymm4
+; AVX512-NEXT:    vpmullw %ymm1, %ymm9, %ymm1
+; AVX512-NEXT:    vpxor %ymm4, %ymm1, %ymm1
+; AVX512-NEXT:    vpmullw %ymm3, %ymm0, %ymm0
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm8 & (ymm0 ^ ymm1)
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 | (ymm12 & ymm2)
+; AVX512-NEXT:    vpternlogq {{.*#+}} ymm0 = ymm0 | (ymm11 & ymm6)
 ; AVX512-NEXT:    vpsrlw $8, %ymm0, %ymm0
 ; AVX512-NEXT:    vpmovzxwd {{.*#+}} zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero,ymm0[8],zero,ymm0[9],zero,ymm0[10],zero,ymm0[11],zero,ymm0[12],zero,ymm0[13],zero,ymm0[14],zero,ymm0[15],zero
 ; AVX512-NEXT:    vpmovdb %zmm0, %xmm0
@@ -3261,133 +2830,110 @@ define <16 x i8> @clmulh_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 define <8 x i16> @clmulh_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; SSE2-LABEL: clmulh_v8i16:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    movdqa %xmm0, %xmm2
-; SSE2-NEXT:    psrlw $8, %xmm2
-; SSE2-NEXT:    psllw $8, %xmm0
-; SSE2-NEXT:    por %xmm2, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm3
-; SSE2-NEXT:    psrlw $4, %xmm3
-; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; SSE2-NEXT:    pand %xmm2, %xmm3
-; SSE2-NEXT:    pand %xmm2, %xmm0
-; SSE2-NEXT:    psllw $4, %xmm0
-; SSE2-NEXT:    por %xmm3, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm4
-; SSE2-NEXT:    psrlw $2, %xmm4
-; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51]
-; SSE2-NEXT:    pand %xmm3, %xmm4
-; SSE2-NEXT:    pand %xmm3, %xmm0
-; SSE2-NEXT:    psllw $2, %xmm0
-; SSE2-NEXT:    por %xmm4, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm5
-; SSE2-NEXT:    psrlw $1, %xmm5
-; SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    pand %xmm4, %xmm0
-; SSE2-NEXT:    paddb %xmm0, %xmm0
-; SSE2-NEXT:    por %xmm5, %xmm0
-; SSE2-NEXT:    movdqa %xmm1, %xmm5
-; SSE2-NEXT:    psrlw $8, %xmm5
+; SSE2-NEXT:    movdqa %xmm1, %xmm4
+; SSE2-NEXT:    psrlw $8, %xmm4
 ; SSE2-NEXT:    psllw $8, %xmm1
-; SSE2-NEXT:    por %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm1
-; SSE2-NEXT:    psrlw $4, %xmm1
-; SSE2-NEXT:    pand %xmm2, %xmm1
-; SSE2-NEXT:    pand %xmm2, %xmm5
-; SSE2-NEXT:    psllw $4, %xmm5
-; SSE2-NEXT:    por %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm1
-; SSE2-NEXT:    psrlw $2, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm1
+; SSE2-NEXT:    por %xmm1, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm2
+; SSE2-NEXT:    psrlw $4, %xmm2
+; SSE2-NEXT:    movdqa {{.*#+}} xmm1 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; SSE2-NEXT:    pand %xmm1, %xmm2
+; SSE2-NEXT:    pand %xmm1, %xmm4
+; SSE2-NEXT:    psllw $4, %xmm4
+; SSE2-NEXT:    por %xmm2, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm3
+; SSE2-NEXT:    psrlw $2, %xmm3
+; SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [51,51,51,51,51,51,51,51,51,51,51,51,51,51,51,51]
+; SSE2-NEXT:    pand %xmm2, %xmm3
+; SSE2-NEXT:    pand %xmm2, %xmm4
+; SSE2-NEXT:    psllw $2, %xmm4
+; SSE2-NEXT:    por %xmm3, %xmm4
+; SSE2-NEXT:    movdqa %xmm4, %xmm5
+; SSE2-NEXT:    psrlw $1, %xmm5
+; SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [85,85,85,85,85,85,85,85,85,85,85,85,85,85,85,85]
 ; SSE2-NEXT:    pand %xmm3, %xmm5
-; SSE2-NEXT:    psllw $2, %xmm5
-; SSE2-NEXT:    por %xmm1, %xmm5
-; SSE2-NEXT:    movdqa %xmm5, %xmm6
-; SSE2-NEXT:    psrlw $1, %xmm6
-; SSE2-NEXT:    movdqa %xmm6, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    paddb %xmm5, %xmm5
-; SSE2-NEXT:    por %xmm5, %xmm1
-; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [4,4,4,4,4,4,4,4]
-; SSE2-NEXT:    pand %xmm1, %xmm7
-; SSE2-NEXT:    pmullw %xmm0, %xmm7
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [2,2,2,2,2,2,2,2]
-; SSE2-NEXT:    pand %xmm5, %xmm8
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    movdqa {{.*#+}} xmm9 = [1,1,1,1,1,1,1,1]
-; SSE2-NEXT:    pand %xmm6, %xmm9
-; SSE2-NEXT:    pmullw %xmm0, %xmm9
-; SSE2-NEXT:    pxor %xmm8, %xmm9
-; SSE2-NEXT:    pxor %xmm7, %xmm9
-; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [8,8,8,8,8,8,8,8]
-; SSE2-NEXT:    pand %xmm5, %xmm7
-; SSE2-NEXT:    pmullw %xmm0, %xmm7
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [16,16,16,16,16,16,16,16]
-; SSE2-NEXT:    pand %xmm1, %xmm8
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pxor %xmm7, %xmm8
-; SSE2-NEXT:    pxor %xmm9, %xmm8
-; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [32,32,32,32,32,32,32,32]
-; SSE2-NEXT:    pand %xmm5, %xmm7
-; SSE2-NEXT:    pmullw %xmm0, %xmm7
-; SSE2-NEXT:    movdqa {{.*#+}} xmm9 = [64,64,64,64,64,64,64,64]
-; SSE2-NEXT:    pand %xmm1, %xmm9
-; SSE2-NEXT:    pmullw %xmm0, %xmm9
-; SSE2-NEXT:    pxor %xmm7, %xmm9
-; SSE2-NEXT:    movdqa {{.*#+}} xmm7 = [128,128,128,128,128,128,128,128]
-; SSE2-NEXT:    pand %xmm5, %xmm7
-; SSE2-NEXT:    pmullw %xmm0, %xmm7
-; SSE2-NEXT:    pxor %xmm9, %xmm7
-; SSE2-NEXT:    pxor %xmm8, %xmm7
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm6
-; SSE2-NEXT:    pmullw %xmm0, %xmm6
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [512,512,512,512,512,512,512,512]
-; SSE2-NEXT:    pand %xmm5, %xmm8
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pxor %xmm6, %xmm8
-; SSE2-NEXT:    movdqa {{.*#+}} xmm6 = [1024,1024,1024,1024,1024,1024,1024,1024]
-; SSE2-NEXT:    pand %xmm1, %xmm6
-; SSE2-NEXT:    pmullw %xmm0, %xmm6
-; SSE2-NEXT:    pxor %xmm8, %xmm6
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [2048,2048,2048,2048,2048,2048,2048,2048]
-; SSE2-NEXT:    pand %xmm5, %xmm8
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pxor %xmm6, %xmm8
-; SSE2-NEXT:    movdqa {{.*#+}} xmm6 = [4096,4096,4096,4096,4096,4096,4096,4096]
-; SSE2-NEXT:    pand %xmm1, %xmm6
-; SSE2-NEXT:    pmullw %xmm0, %xmm6
-; SSE2-NEXT:    pxor %xmm8, %xmm6
-; SSE2-NEXT:    pxor %xmm7, %xmm6
-; SSE2-NEXT:    psllw $8, %xmm7
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [8192,8192,8192,8192,8192,8192,8192,8192]
-; SSE2-NEXT:    pand %xmm5, %xmm8
-; SSE2-NEXT:    pmullw %xmm0, %xmm8
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm1
-; SSE2-NEXT:    pmullw %xmm0, %xmm1
-; SSE2-NEXT:    pxor %xmm8, %xmm1
-; SSE2-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm5
-; SSE2-NEXT:    pmullw %xmm5, %xmm0
-; SSE2-NEXT:    pxor %xmm1, %xmm0
-; SSE2-NEXT:    pxor %xmm6, %xmm0
-; SSE2-NEXT:    psrlw $8, %xmm0
+; SSE2-NEXT:    pand %xmm3, %xmm4
+; SSE2-NEXT:    paddb %xmm4, %xmm4
+; SSE2-NEXT:    por %xmm5, %xmm4
+; SSE2-NEXT:    movdqa {{.*#+}} xmm6 = [37449,37449,37449,37449,37449,37449,37449,37449]
+; SSE2-NEXT:    movdqa %xmm4, %xmm5
+; SSE2-NEXT:    pand %xmm6, %xmm5
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $8, %xmm7
+; SSE2-NEXT:    psllw $8, %xmm0
 ; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $4, %xmm7
+; SSE2-NEXT:    pand %xmm1, %xmm7
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    psllw $4, %xmm0
+; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $2, %xmm7
+; SSE2-NEXT:    pand %xmm2, %xmm7
+; SSE2-NEXT:    pand %xmm2, %xmm0
+; SSE2-NEXT:    psllw $2, %xmm0
+; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm7
+; SSE2-NEXT:    psrlw $1, %xmm7
+; SSE2-NEXT:    pand %xmm3, %xmm7
+; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    paddb %xmm0, %xmm0
+; SSE2-NEXT:    por %xmm7, %xmm0
+; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [9362,9362,9362,9362,9362,9362,9362,9362]
+; SSE2-NEXT:    movdqa %xmm0, %xmm10
+; SSE2-NEXT:    pand %xmm8, %xmm10
+; SSE2-NEXT:    movdqa %xmm4, %xmm7
+; SSE2-NEXT:    pand %xmm8, %xmm7
+; SSE2-NEXT:    movdqa %xmm0, %xmm12
+; SSE2-NEXT:    pand %xmm6, %xmm12
+; SSE2-NEXT:    movdqa {{.*#+}} xmm9 = [18724,18724,18724,18724,18724,18724,18724,18724]
+; SSE2-NEXT:    pand %xmm9, %xmm4
+; SSE2-NEXT:    pand %xmm9, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm11
+; SSE2-NEXT:    pmullw %xmm4, %xmm11
+; SSE2-NEXT:    movdqa %xmm10, %xmm13
+; SSE2-NEXT:    pmullw %xmm4, %xmm13
+; SSE2-NEXT:    movdqa %xmm12, %xmm14
+; SSE2-NEXT:    pmullw %xmm12, %xmm4
+; SSE2-NEXT:    pmullw %xmm7, %xmm12
+; SSE2-NEXT:    movdqa %xmm0, %xmm15
+; SSE2-NEXT:    pmullw %xmm7, %xmm15
+; SSE2-NEXT:    pmullw %xmm10, %xmm7
+; SSE2-NEXT:    pmullw %xmm5, %xmm10
+; SSE2-NEXT:    pxor %xmm10, %xmm12
+; SSE2-NEXT:    pxor %xmm12, %xmm11
+; SSE2-NEXT:    pand %xmm8, %xmm11
+; SSE2-NEXT:    pmullw %xmm5, %xmm14
+; SSE2-NEXT:    pxor %xmm13, %xmm14
+; SSE2-NEXT:    pxor %xmm14, %xmm15
+; SSE2-NEXT:    pand %xmm6, %xmm15
+; SSE2-NEXT:    por %xmm11, %xmm15
+; SSE2-NEXT:    pxor %xmm7, %xmm4
+; SSE2-NEXT:    pmullw %xmm5, %xmm0
+; SSE2-NEXT:    pxor %xmm4, %xmm0
+; SSE2-NEXT:    pand %xmm9, %xmm0
+; SSE2-NEXT:    por %xmm15, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-NEXT:    psrlw $8, %xmm4
+; SSE2-NEXT:    psllw $8, %xmm0
+; SSE2-NEXT:    por %xmm4, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-NEXT:    psrlw $4, %xmm4
+; SSE2-NEXT:    pand %xmm1, %xmm4
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    psllw $4, %xmm0
+; SSE2-NEXT:    por %xmm4, %xmm0
 ; SSE2-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-NEXT:    psrlw $4, %xmm1
+; SSE2-NEXT:    psrlw $2, %xmm1
 ; SSE2-NEXT:    pand %xmm2, %xmm1
 ; SSE2-NEXT:    pand %xmm2, %xmm0
-; SSE2-NEXT:    psllw $4, %xmm0
-; SSE2-NEXT:    por %xmm1, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-NEXT:    psrlw $2, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm1
-; SSE2-NEXT:    pand %xmm3, %xmm0
 ; SSE2-NEXT:    psllw $2, %xmm0
 ; SSE2-NEXT:    por %xmm1, %xmm0
 ; SSE2-NEXT:    movdqa %xmm0, %xmm1
 ; SSE2-NEXT:    psrlw $1, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm1
-; SSE2-NEXT:    pand %xmm4, %xmm0
+; SSE2-NEXT:    pand %xmm3, %xmm1
+; SSE2-NEXT:    pand %xmm3, %xmm0
 ; SSE2-NEXT:    paddb %xmm0, %xmm0
 ; SSE2-NEXT:    por %xmm1, %xmm0
 ; SSE2-NEXT:    psrlw $1, %xmm0
@@ -3397,96 +2943,73 @@ define <8 x i16> @clmulh_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; SSE42:       # %bb.0:
 ; SSE42-NEXT:    movdqa %xmm0, %xmm2
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
-; SSE42-NEXT:    pshufb %xmm5, %xmm2
+; SSE42-NEXT:    pshufb %xmm5, %xmm1
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
-; SSE42-NEXT:    movdqa %xmm2, %xmm0
+; SSE42-NEXT:    movdqa %xmm1, %xmm0
 ; SSE42-NEXT:    pand %xmm4, %xmm0
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [0,128,64,192,32,160,96,224,16,144,80,208,48,176,112,240]
 ; SSE42-NEXT:    movdqa %xmm3, %xmm7
 ; SSE42-NEXT:    pshufb %xmm0, %xmm7
-; SSE42-NEXT:    psrlw $4, %xmm2
-; SSE42-NEXT:    pand %xmm4, %xmm2
+; SSE42-NEXT:    psrlw $4, %xmm1
+; SSE42-NEXT:    pand %xmm4, %xmm1
 ; SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [0,8,4,12,2,10,6,14,1,9,5,13,3,11,7,15]
 ; SSE42-NEXT:    movdqa %xmm0, %xmm6
-; SSE42-NEXT:    pshufb %xmm2, %xmm6
+; SSE42-NEXT:    pshufb %xmm1, %xmm6
 ; SSE42-NEXT:    por %xmm7, %xmm6
+; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [37449,37449,37449,37449,37449,37449,37449,37449]
+; SSE42-NEXT:    movdqa %xmm6, %xmm7
+; SSE42-NEXT:    pand %xmm8, %xmm7
+; SSE42-NEXT:    pshufb %xmm5, %xmm2
+; SSE42-NEXT:    movdqa %xmm2, %xmm1
+; SSE42-NEXT:    pand %xmm4, %xmm1
+; SSE42-NEXT:    movdqa %xmm3, %xmm9
+; SSE42-NEXT:    pshufb %xmm1, %xmm9
+; SSE42-NEXT:    psrlw $4, %xmm2
+; SSE42-NEXT:    pand %xmm4, %xmm2
+; SSE42-NEXT:    movdqa %xmm0, %xmm1
+; SSE42-NEXT:    pshufb %xmm2, %xmm1
+; SSE42-NEXT:    por %xmm9, %xmm1
+; SSE42-NEXT:    movdqa {{.*#+}} xmm9 = [9362,9362,9362,9362,9362,9362,9362,9362]
+; SSE42-NEXT:    movdqa %xmm1, %xmm13
+; SSE42-NEXT:    pand %xmm9, %xmm13
+; SSE42-NEXT:    movdqa %xmm6, %xmm2
+; SSE42-NEXT:    pand %xmm9, %xmm2
+; SSE42-NEXT:    movdqa %xmm1, %xmm11
+; SSE42-NEXT:    pand %xmm8, %xmm11
+; SSE42-NEXT:    movdqa %xmm11, %xmm12
+; SSE42-NEXT:    pmullw %xmm2, %xmm12
+; SSE42-NEXT:    movdqa {{.*#+}} xmm10 = [18724,18724,18724,18724,18724,18724,18724,18724]
+; SSE42-NEXT:    pand %xmm10, %xmm1
+; SSE42-NEXT:    movdqa %xmm13, %xmm15
+; SSE42-NEXT:    movdqa %xmm1, %xmm14
+; SSE42-NEXT:    pmullw %xmm2, %xmm14
+; SSE42-NEXT:    pmullw %xmm13, %xmm2
+; SSE42-NEXT:    pmullw %xmm7, %xmm13
+; SSE42-NEXT:    pxor %xmm13, %xmm12
+; SSE42-NEXT:    pand %xmm10, %xmm6
+; SSE42-NEXT:    movdqa %xmm1, %xmm13
+; SSE42-NEXT:    pmullw %xmm6, %xmm13
+; SSE42-NEXT:    pmullw %xmm6, %xmm15
+; SSE42-NEXT:    pmullw %xmm11, %xmm6
+; SSE42-NEXT:    pxor %xmm12, %xmm13
+; SSE42-NEXT:    pand %xmm9, %xmm13
+; SSE42-NEXT:    pmullw %xmm7, %xmm11
+; SSE42-NEXT:    pxor %xmm15, %xmm11
+; SSE42-NEXT:    pxor %xmm11, %xmm14
+; SSE42-NEXT:    pand %xmm8, %xmm14
+; SSE42-NEXT:    por %xmm13, %xmm14
+; SSE42-NEXT:    pxor %xmm2, %xmm6
+; SSE42-NEXT:    pmullw %xmm7, %xmm1
+; SSE42-NEXT:    pxor %xmm6, %xmm1
+; SSE42-NEXT:    pand %xmm10, %xmm1
+; SSE42-NEXT:    por %xmm14, %xmm1
 ; SSE42-NEXT:    pshufb %xmm5, %xmm1
-; SSE42-NEXT:    movdqa %xmm1, %xmm7
-; SSE42-NEXT:    psrlw $4, %xmm7
-; SSE42-NEXT:    pand %xmm4, %xmm7
-; SSE42-NEXT:    movdqa %xmm0, %xmm2
-; SSE42-NEXT:    pshufb %xmm7, %xmm2
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm7 = [2,2,2,2,2,2,2,2]
-; SSE42-NEXT:    pand %xmm2, %xmm7
-; SSE42-NEXT:    pmullw %xmm6, %xmm7
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm9 = [1,1,1,1,1,1,1,1]
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    pmullw %xmm6, %xmm9
-; SSE42-NEXT:    pxor %xmm7, %xmm9
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm7 = [4,4,4,4,4,4,4,4]
-; SSE42-NEXT:    pand %xmm2, %xmm7
-; SSE42-NEXT:    pmullw %xmm6, %xmm7
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm8 = [8,8,8,8,8,8,8,8]
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    pmullw %xmm6, %xmm8
-; SSE42-NEXT:    pxor %xmm7, %xmm8
-; SSE42-NEXT:    pxor %xmm9, %xmm8
+; SSE42-NEXT:    movdqa %xmm1, %xmm2
+; SSE42-NEXT:    pand %xmm4, %xmm2
+; SSE42-NEXT:    pshufb %xmm2, %xmm3
+; SSE42-NEXT:    psrlw $4, %xmm1
 ; SSE42-NEXT:    pand %xmm4, %xmm1
-; SSE42-NEXT:    movdqa %xmm3, %xmm7
-; SSE42-NEXT:    pshufb %xmm1, %xmm7
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm1 = [16,16,16,16,16,16,16,16]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    pmullw %xmm6, %xmm1
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm9 = [32,32,32,32,32,32,32,32]
-; SSE42-NEXT:    pand %xmm7, %xmm9
-; SSE42-NEXT:    pmullw %xmm6, %xmm9
-; SSE42-NEXT:    pxor %xmm1, %xmm9
-; SSE42-NEXT:    pmovsxbw {{.*#+}} xmm10 = [64,64,64,64,64,64,64,64]
-; SSE42-NEXT:    pand %xmm7, %xmm10
-; SSE42-NEXT:    pmullw %xmm6, %xmm10
-; SSE42-NEXT:    pxor %xmm9, %xmm10
-; SSE42-NEXT:    pmovzxbw {{.*#+}} xmm1 = [128,128,128,128,128,128,128,128]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    pmullw %xmm6, %xmm1
-; SSE42-NEXT:    pxor %xmm10, %xmm1
-; SSE42-NEXT:    pxor %xmm8, %xmm1
-; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [256,256,256,256,256,256,256,256]
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    pmullw %xmm6, %xmm8
-; SSE42-NEXT:    movdqa {{.*#+}} xmm9 = [512,512,512,512,512,512,512,512]
-; SSE42-NEXT:    pand %xmm2, %xmm9
-; SSE42-NEXT:    pmullw %xmm6, %xmm9
-; SSE42-NEXT:    pxor %xmm8, %xmm9
-; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [1024,1024,1024,1024,1024,1024,1024,1024]
-; SSE42-NEXT:    pand %xmm2, %xmm8
-; SSE42-NEXT:    pmullw %xmm6, %xmm8
-; SSE42-NEXT:    pxor %xmm9, %xmm8
-; SSE42-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm2
-; SSE42-NEXT:    pmullw %xmm6, %xmm2
-; SSE42-NEXT:    pxor %xmm8, %xmm2
-; SSE42-NEXT:    pxor %xmm1, %xmm2
-; SSE42-NEXT:    movdqa {{.*#+}} xmm1 = [4096,4096,4096,4096,4096,4096,4096,4096]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    pmullw %xmm6, %xmm1
-; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [8192,8192,8192,8192,8192,8192,8192,8192]
-; SSE42-NEXT:    pand %xmm7, %xmm8
-; SSE42-NEXT:    pmullw %xmm6, %xmm8
-; SSE42-NEXT:    pxor %xmm1, %xmm8
-; SSE42-NEXT:    movdqa {{.*#+}} xmm1 = [16384,16384,16384,16384,16384,16384,16384,16384]
-; SSE42-NEXT:    pand %xmm7, %xmm1
-; SSE42-NEXT:    pmullw %xmm6, %xmm1
-; SSE42-NEXT:    pxor %xmm8, %xmm1
-; SSE42-NEXT:    pand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm7
-; SSE42-NEXT:    pmullw %xmm6, %xmm7
-; SSE42-NEXT:    pxor %xmm1, %xmm7
-; SSE42-NEXT:    pxor %xmm2, %xmm7
-; SSE42-NEXT:    pshufb %xmm5, %xmm7
-; SSE42-NEXT:    movdqa %xmm7, %xmm1
-; SSE42-NEXT:    pand %xmm4, %xmm1
-; SSE42-NEXT:    pshufb %xmm1, %xmm3
-; SSE42-NEXT:    psrlw $4, %xmm7
-; SSE42-NEXT:    pand %xmm4, %xmm7
-; SSE42-NEXT:    pshufb %xmm7, %xmm0
+; SSE42-NEXT:    pshufb %xmm1, %xmm0
 ; SSE42-NEXT:    por %xmm3, %xmm0
 ; SSE42-NEXT:    psrlw $1, %xmm0
 ; SSE42-NEXT:    retq

--- a/llvm/test/CodeGen/X86/clmul.ll
+++ b/llvm/test/CodeGen/X86/clmul.ll
@@ -9,50 +9,28 @@
 define i8 @clmul_i8(i8 %a, i8 %b) nounwind {
 ; SCALAR-LABEL: clmul_i8:
 ; SCALAR:       # %bb.0:
-; SCALAR-NEXT:    # kill: def $edi killed $edi def $rdi
-; SCALAR-NEXT:    xorl %ecx, %ecx
-; SCALAR-NEXT:    testb $1, %sil
+; SCALAR-NEXT:    movl %edi, %ecx
+; SCALAR-NEXT:    andb $85, %cl
+; SCALAR-NEXT:    movl %esi, %r9d
+; SCALAR-NEXT:    andb $-86, %r9b
+; SCALAR-NEXT:    andb $-86, %dil
+; SCALAR-NEXT:    andb $85, %sil
 ; SCALAR-NEXT:    movl %edi, %eax
-; SCALAR-NEXT:    cmovel %ecx, %eax
-; SCALAR-NEXT:    leal (%rdi,%rdi), %edx
-; SCALAR-NEXT:    movzbl %dl, %edx
-; SCALAR-NEXT:    testb $2, %sil
-; SCALAR-NEXT:    cmovel %ecx, %edx
-; SCALAR-NEXT:    xorl %eax, %edx
-; SCALAR-NEXT:    leal (,%rdi,4), %eax
-; SCALAR-NEXT:    movzbl %al, %r8d
-; SCALAR-NEXT:    testb $4, %sil
-; SCALAR-NEXT:    cmovel %ecx, %r8d
-; SCALAR-NEXT:    leal (,%rdi,8), %eax
-; SCALAR-NEXT:    movzbl %al, %eax
-; SCALAR-NEXT:    testb $8, %sil
-; SCALAR-NEXT:    cmovel %ecx, %eax
-; SCALAR-NEXT:    xorl %r8d, %eax
-; SCALAR-NEXT:    xorl %edx, %eax
-; SCALAR-NEXT:    movl %edi, %edx
-; SCALAR-NEXT:    shlb $4, %dl
-; SCALAR-NEXT:    movzbl %dl, %edx
-; SCALAR-NEXT:    testb $16, %sil
-; SCALAR-NEXT:    cmovel %ecx, %edx
-; SCALAR-NEXT:    movl %edi, %r8d
-; SCALAR-NEXT:    shlb $5, %r8b
-; SCALAR-NEXT:    movzbl %r8b, %r8d
-; SCALAR-NEXT:    testb $32, %sil
-; SCALAR-NEXT:    cmovel %ecx, %r8d
-; SCALAR-NEXT:    xorl %edx, %r8d
-; SCALAR-NEXT:    movl %edi, %edx
-; SCALAR-NEXT:    shlb $6, %dl
-; SCALAR-NEXT:    movzbl %dl, %edx
-; SCALAR-NEXT:    testb $64, %sil
-; SCALAR-NEXT:    cmovel %ecx, %edx
-; SCALAR-NEXT:    xorl %r8d, %edx
-; SCALAR-NEXT:    xorl %eax, %edx
-; SCALAR-NEXT:    shlb $7, %dil
-; SCALAR-NEXT:    movzbl %dil, %eax
-; SCALAR-NEXT:    testb $-128, %sil
-; SCALAR-NEXT:    cmovel %ecx, %eax
-; SCALAR-NEXT:    xorl %edx, %eax
-; SCALAR-NEXT:    # kill: def $al killed $al killed $eax
+; SCALAR-NEXT:    mulb %sil
+; SCALAR-NEXT:    movl %eax, %edx
+; SCALAR-NEXT:    movl %ecx, %eax
+; SCALAR-NEXT:    mulb %r9b
+; SCALAR-NEXT:    movl %eax, %r8d
+; SCALAR-NEXT:    xorb %dl, %r8b
+; SCALAR-NEXT:    andb $-86, %r8b
+; SCALAR-NEXT:    movl %edi, %eax
+; SCALAR-NEXT:    mulb %r9b
+; SCALAR-NEXT:    movl %eax, %edx
+; SCALAR-NEXT:    movl %ecx, %eax
+; SCALAR-NEXT:    mulb %sil
+; SCALAR-NEXT:    xorb %dl, %al
+; SCALAR-NEXT:    andb $85, %al
+; SCALAR-NEXT:    orb %r8b, %al
 ; SCALAR-NEXT:    retq
 ;
 ; SSE-PCLMUL-LABEL: clmul_i8:
@@ -79,96 +57,48 @@ define i8 @clmul_i8(i8 %a, i8 %b) nounwind {
 define i16 @clmul_i16(i16 %a, i16 %b) nounwind {
 ; SCALAR-LABEL: clmul_i16:
 ; SCALAR:       # %bb.0:
-; SCALAR-NEXT:    # kill: def $edi killed $edi def $rdi
-; SCALAR-NEXT:    leal (%rdi,%rdi), %eax
+; SCALAR-NEXT:    pushq %rbp
+; SCALAR-NEXT:    pushq %rbx
 ; SCALAR-NEXT:    movl %esi, %ecx
-; SCALAR-NEXT:    andl $2, %ecx
-; SCALAR-NEXT:    cmovnel %eax, %ecx
-; SCALAR-NEXT:    movl %esi, %eax
-; SCALAR-NEXT:    andl $1, %eax
-; SCALAR-NEXT:    cmovnel %edi, %eax
-; SCALAR-NEXT:    xorl %ecx, %eax
-; SCALAR-NEXT:    leal (,%rdi,4), %ecx
+; SCALAR-NEXT:    andl $4681, %ecx # imm = 0x1249
+; SCALAR-NEXT:    movl %edi, %r9d
+; SCALAR-NEXT:    andl $9362, %r9d # imm = 0x2492
 ; SCALAR-NEXT:    movl %esi, %edx
-; SCALAR-NEXT:    andl $4, %edx
-; SCALAR-NEXT:    cmovnel %ecx, %edx
-; SCALAR-NEXT:    leal (,%rdi,8), %r8d
-; SCALAR-NEXT:    movl %esi, %ecx
-; SCALAR-NEXT:    andl $8, %ecx
-; SCALAR-NEXT:    cmovnel %r8d, %ecx
-; SCALAR-NEXT:    xorl %edx, %ecx
-; SCALAR-NEXT:    xorl %eax, %ecx
-; SCALAR-NEXT:    movl %edi, %eax
-; SCALAR-NEXT:    shll $4, %eax
-; SCALAR-NEXT:    movl %esi, %edx
-; SCALAR-NEXT:    andl $16, %edx
-; SCALAR-NEXT:    cmovnel %eax, %edx
-; SCALAR-NEXT:    movl %edi, %eax
-; SCALAR-NEXT:    shll $5, %eax
+; SCALAR-NEXT:    andl $9362, %edx # imm = 0x2492
+; SCALAR-NEXT:    movl %edi, %r11d
+; SCALAR-NEXT:    andl $4681, %r11d # imm = 0x1249
 ; SCALAR-NEXT:    movl %esi, %r8d
-; SCALAR-NEXT:    andl $32, %r8d
-; SCALAR-NEXT:    cmovnel %eax, %r8d
+; SCALAR-NEXT:    andl $18724, %r8d # imm = 0x4924
+; SCALAR-NEXT:    movl %edi, %eax
+; SCALAR-NEXT:    andl $18724, %eax # imm = 0x4924
+; SCALAR-NEXT:    movl %eax, %r10d
+; SCALAR-NEXT:    imull %r8d, %r10d
+; SCALAR-NEXT:    movl %r9d, %ebx
+; SCALAR-NEXT:    imull %r8d, %ebx
+; SCALAR-NEXT:    imull %r11d, %r8d
+; SCALAR-NEXT:    imull %edx, %r11d
+; SCALAR-NEXT:    movl %eax, %ebp
+; SCALAR-NEXT:    imull %edx, %ebp
+; SCALAR-NEXT:    imull %r9d, %edx
+; SCALAR-NEXT:    imull %ecx, %r9d
+; SCALAR-NEXT:    xorl %r9d, %r11d
+; SCALAR-NEXT:    xorl %r11d, %r10d
+; SCALAR-NEXT:    andl $9362, %r10d # imm = 0x2492
+; SCALAR-NEXT:    andl $37449, %esi # imm = 0x9249
+; SCALAR-NEXT:    andl $37449, %edi # imm = 0x9249
+; SCALAR-NEXT:    imull %esi, %edi
+; SCALAR-NEXT:    xorl %edi, %ebx
+; SCALAR-NEXT:    xorl %ebx, %ebp
+; SCALAR-NEXT:    andl $-28087, %ebp # imm = 0x9249
+; SCALAR-NEXT:    orl %r10d, %ebp
 ; SCALAR-NEXT:    xorl %edx, %r8d
-; SCALAR-NEXT:    movl %edi, %edx
-; SCALAR-NEXT:    shll $6, %edx
-; SCALAR-NEXT:    movl %esi, %eax
-; SCALAR-NEXT:    andl $64, %eax
-; SCALAR-NEXT:    cmovnel %edx, %eax
+; SCALAR-NEXT:    imull %ecx, %eax
 ; SCALAR-NEXT:    xorl %r8d, %eax
-; SCALAR-NEXT:    xorl %ecx, %eax
-; SCALAR-NEXT:    movl %edi, %ecx
-; SCALAR-NEXT:    shll $7, %ecx
-; SCALAR-NEXT:    movl %esi, %edx
-; SCALAR-NEXT:    andl $128, %edx
-; SCALAR-NEXT:    cmovnel %ecx, %edx
-; SCALAR-NEXT:    movl %edi, %ecx
-; SCALAR-NEXT:    shll $8, %ecx
-; SCALAR-NEXT:    movl %esi, %r8d
-; SCALAR-NEXT:    andl $256, %r8d # imm = 0x100
-; SCALAR-NEXT:    cmovnel %ecx, %r8d
-; SCALAR-NEXT:    xorl %edx, %r8d
-; SCALAR-NEXT:    movl %edi, %ecx
-; SCALAR-NEXT:    shll $9, %ecx
-; SCALAR-NEXT:    movl %esi, %edx
-; SCALAR-NEXT:    andl $512, %edx # imm = 0x200
-; SCALAR-NEXT:    cmovnel %ecx, %edx
-; SCALAR-NEXT:    xorl %r8d, %edx
-; SCALAR-NEXT:    movl %edi, %r8d
-; SCALAR-NEXT:    shll $10, %r8d
-; SCALAR-NEXT:    movl %esi, %ecx
-; SCALAR-NEXT:    andl $1024, %ecx # imm = 0x400
-; SCALAR-NEXT:    cmovnel %r8d, %ecx
-; SCALAR-NEXT:    xorl %edx, %ecx
-; SCALAR-NEXT:    xorl %eax, %ecx
-; SCALAR-NEXT:    movl %edi, %eax
-; SCALAR-NEXT:    shll $11, %eax
-; SCALAR-NEXT:    movl %esi, %edx
-; SCALAR-NEXT:    andl $2048, %edx # imm = 0x800
-; SCALAR-NEXT:    cmovnel %eax, %edx
-; SCALAR-NEXT:    movl %edi, %eax
-; SCALAR-NEXT:    shll $12, %eax
-; SCALAR-NEXT:    movl %esi, %r8d
-; SCALAR-NEXT:    andl $4096, %r8d # imm = 0x1000
-; SCALAR-NEXT:    cmovnel %eax, %r8d
-; SCALAR-NEXT:    xorl %edx, %r8d
-; SCALAR-NEXT:    movl %edi, %eax
-; SCALAR-NEXT:    shll $13, %eax
-; SCALAR-NEXT:    movl %esi, %edx
-; SCALAR-NEXT:    andl $8192, %edx # imm = 0x2000
-; SCALAR-NEXT:    cmovnel %eax, %edx
-; SCALAR-NEXT:    xorl %r8d, %edx
-; SCALAR-NEXT:    movl %edi, %r8d
-; SCALAR-NEXT:    shll $14, %r8d
-; SCALAR-NEXT:    movl %esi, %eax
-; SCALAR-NEXT:    andl $16384, %eax # imm = 0x4000
-; SCALAR-NEXT:    cmovnel %r8d, %eax
-; SCALAR-NEXT:    xorl %edx, %eax
-; SCALAR-NEXT:    shll $15, %edi
-; SCALAR-NEXT:    andl $32768, %esi # imm = 0x8000
-; SCALAR-NEXT:    cmovnel %edi, %esi
-; SCALAR-NEXT:    xorl %esi, %eax
-; SCALAR-NEXT:    xorl %ecx, %eax
+; SCALAR-NEXT:    andl $18724, %eax # imm = 0x4924
+; SCALAR-NEXT:    orl %ebp, %eax
 ; SCALAR-NEXT:    # kill: def $ax killed $ax killed $eax
+; SCALAR-NEXT:    popq %rbx
+; SCALAR-NEXT:    popq %rbp
 ; SCALAR-NEXT:    retq
 ;
 ; SSE-PCLMUL-LABEL: clmul_i16:
@@ -391,87 +321,42 @@ define i64 @clmul_i64(i64 %a, i64 %b) nounwind {
 define i8 @clmulr_i8(i8 %a, i8 %b) nounwind {
 ; SCALAR-LABEL: clmulr_i8:
 ; SCALAR:       # %bb.0:
-; SCALAR-NEXT:    pushq %rbp
-; SCALAR-NEXT:    pushq %r15
-; SCALAR-NEXT:    pushq %r14
-; SCALAR-NEXT:    pushq %rbx
-; SCALAR-NEXT:    movzbl %dil, %ecx
-; SCALAR-NEXT:    movl %ecx, %r11d
-; SCALAR-NEXT:    shll $8, %r11d
-; SCALAR-NEXT:    movl %ecx, %r10d
-; SCALAR-NEXT:    shll $9, %r10d
-; SCALAR-NEXT:    movl %ecx, %r9d
-; SCALAR-NEXT:    shll $10, %r9d
-; SCALAR-NEXT:    movl %ecx, %eax
-; SCALAR-NEXT:    shll $11, %eax
-; SCALAR-NEXT:    movl %ecx, %r8d
-; SCALAR-NEXT:    shll $12, %r8d
+; SCALAR-NEXT:    movl %esi, %eax
+; SCALAR-NEXT:    andl $73, %eax
+; SCALAR-NEXT:    movl %edi, %r9d
+; SCALAR-NEXT:    andl $146, %r9d
+; SCALAR-NEXT:    movl %esi, %ecx
+; SCALAR-NEXT:    andl $146, %ecx
 ; SCALAR-NEXT:    movl %edi, %edx
-; SCALAR-NEXT:    shll $13, %edx
-; SCALAR-NEXT:    xorl %ebx, %ebx
-; SCALAR-NEXT:    testw %bx, %bx
-; SCALAR-NEXT:    cmovel %ebx, %edx
-; SCALAR-NEXT:    cmovel %ebx, %r8d
-; SCALAR-NEXT:    cmovel %ebx, %eax
-; SCALAR-NEXT:    cmovel %ebx, %r9d
-; SCALAR-NEXT:    cmovel %ebx, %r10d
-; SCALAR-NEXT:    cmovel %ebx, %r11d
-; SCALAR-NEXT:    shll $14, %edi
-; SCALAR-NEXT:    testw %bx, %bx
-; SCALAR-NEXT:    cmovnel %edi, %ebx
-; SCALAR-NEXT:    movl %esi, %edi
-; SCALAR-NEXT:    andl $1, %edi
-; SCALAR-NEXT:    cmovnel %ecx, %edi
-; SCALAR-NEXT:    leal (%rcx,%rcx), %ebp
-; SCALAR-NEXT:    movl %esi, %r14d
-; SCALAR-NEXT:    andl $2, %r14d
-; SCALAR-NEXT:    cmovnel %ebp, %r14d
-; SCALAR-NEXT:    xorl %edi, %r14d
-; SCALAR-NEXT:    leal (,%rcx,4), %edi
-; SCALAR-NEXT:    movl %esi, %ebp
-; SCALAR-NEXT:    andl $4, %ebp
-; SCALAR-NEXT:    cmovnel %edi, %ebp
-; SCALAR-NEXT:    leal (,%rcx,8), %r15d
-; SCALAR-NEXT:    movl %esi, %edi
-; SCALAR-NEXT:    andl $8, %edi
-; SCALAR-NEXT:    cmovnel %r15d, %edi
-; SCALAR-NEXT:    xorl %ebp, %edi
-; SCALAR-NEXT:    xorl %r14d, %edi
-; SCALAR-NEXT:    movl %ecx, %ebp
-; SCALAR-NEXT:    shll $4, %ebp
-; SCALAR-NEXT:    movl %esi, %r14d
-; SCALAR-NEXT:    andl $16, %r14d
-; SCALAR-NEXT:    cmovnel %ebp, %r14d
-; SCALAR-NEXT:    movl %ecx, %ebp
-; SCALAR-NEXT:    shll $5, %ebp
-; SCALAR-NEXT:    movl %esi, %r15d
-; SCALAR-NEXT:    andl $32, %r15d
-; SCALAR-NEXT:    cmovnel %ebp, %r15d
-; SCALAR-NEXT:    xorl %r14d, %r15d
-; SCALAR-NEXT:    movl %ecx, %ebp
-; SCALAR-NEXT:    shll $6, %ebp
-; SCALAR-NEXT:    movl %esi, %r14d
-; SCALAR-NEXT:    andl $64, %r14d
-; SCALAR-NEXT:    cmovnel %ebp, %r14d
-; SCALAR-NEXT:    xorl %r15d, %r14d
-; SCALAR-NEXT:    xorl %edi, %r14d
-; SCALAR-NEXT:    shll $7, %ecx
-; SCALAR-NEXT:    andl $128, %esi
-; SCALAR-NEXT:    cmovel %esi, %ecx
-; SCALAR-NEXT:    xorl %r11d, %ecx
-; SCALAR-NEXT:    xorl %r10d, %ecx
-; SCALAR-NEXT:    xorl %r9d, %ecx
-; SCALAR-NEXT:    xorl %r14d, %ecx
-; SCALAR-NEXT:    xorl %r8d, %eax
+; SCALAR-NEXT:    andl $73, %edx
+; SCALAR-NEXT:    movl %edx, %r8d
+; SCALAR-NEXT:    imull %ecx, %r8d
+; SCALAR-NEXT:    andl $36, %edi
+; SCALAR-NEXT:    movl %r9d, %r11d
+; SCALAR-NEXT:    movl %edi, %r10d
+; SCALAR-NEXT:    imull %ecx, %r10d
+; SCALAR-NEXT:    imull %r9d, %ecx
+; SCALAR-NEXT:    imull %eax, %r9d
+; SCALAR-NEXT:    xorl %r9d, %r8d
+; SCALAR-NEXT:    andl $36, %esi
+; SCALAR-NEXT:    movl %edx, %r9d
+; SCALAR-NEXT:    imull %eax, %r9d
+; SCALAR-NEXT:    imull %edi, %eax
+; SCALAR-NEXT:    imull %esi, %edi
+; SCALAR-NEXT:    xorl %r8d, %edi
+; SCALAR-NEXT:    andl $9344, %edi # imm = 0x2480
+; SCALAR-NEXT:    imull %esi, %r11d
+; SCALAR-NEXT:    xorl %r11d, %r9d
+; SCALAR-NEXT:    xorl %r9d, %r10d
+; SCALAR-NEXT:    andl $4608, %r10d # imm = 0x1200
+; SCALAR-NEXT:    orl %edi, %r10d
+; SCALAR-NEXT:    imull %esi, %edx
+; SCALAR-NEXT:    xorl %ecx, %edx
 ; SCALAR-NEXT:    xorl %edx, %eax
-; SCALAR-NEXT:    xorl %ebx, %eax
-; SCALAR-NEXT:    xorl %ecx, %eax
+; SCALAR-NEXT:    andl $18688, %eax # imm = 0x4900
+; SCALAR-NEXT:    orl %r10d, %eax
 ; SCALAR-NEXT:    shrl $7, %eax
 ; SCALAR-NEXT:    # kill: def $al killed $al killed $eax
-; SCALAR-NEXT:    popq %rbx
-; SCALAR-NEXT:    popq %r14
-; SCALAR-NEXT:    popq %r15
-; SCALAR-NEXT:    popq %rbp
 ; SCALAR-NEXT:    retq
 ;
 ; SSE-PCLMUL-LABEL: clmulr_i8:
@@ -899,93 +784,42 @@ define i64 @clmulr_i64(i64 %a, i64 %b) nounwind {
 define i8 @clmulh_i8(i8 %a, i8 %b) nounwind {
 ; SCALAR-LABEL: clmulh_i8:
 ; SCALAR:       # %bb.0:
-; SCALAR-NEXT:    pushq %rbp
-; SCALAR-NEXT:    pushq %r15
-; SCALAR-NEXT:    pushq %r14
-; SCALAR-NEXT:    pushq %r12
-; SCALAR-NEXT:    pushq %rbx
-; SCALAR-NEXT:    movzbl %dil, %ecx
-; SCALAR-NEXT:    movl %ecx, %ebx
-; SCALAR-NEXT:    shll $8, %ebx
-; SCALAR-NEXT:    movl %ecx, %r11d
-; SCALAR-NEXT:    shll $9, %r11d
-; SCALAR-NEXT:    movl %ecx, %r10d
-; SCALAR-NEXT:    shll $10, %r10d
-; SCALAR-NEXT:    movl %ecx, %eax
-; SCALAR-NEXT:    shll $11, %eax
-; SCALAR-NEXT:    movl %ecx, %r9d
-; SCALAR-NEXT:    shll $12, %r9d
-; SCALAR-NEXT:    movl %ecx, %r8d
-; SCALAR-NEXT:    shll $13, %r8d
+; SCALAR-NEXT:    movl %esi, %eax
+; SCALAR-NEXT:    andl $73, %eax
+; SCALAR-NEXT:    movl %edi, %r9d
+; SCALAR-NEXT:    andl $146, %r9d
+; SCALAR-NEXT:    movl %esi, %ecx
+; SCALAR-NEXT:    andl $146, %ecx
 ; SCALAR-NEXT:    movl %edi, %edx
-; SCALAR-NEXT:    shll $14, %edx
-; SCALAR-NEXT:    xorl %ebp, %ebp
-; SCALAR-NEXT:    testw %bp, %bp
-; SCALAR-NEXT:    cmovel %ebp, %edx
-; SCALAR-NEXT:    cmovel %ebp, %r8d
-; SCALAR-NEXT:    cmovel %ebp, %r9d
-; SCALAR-NEXT:    cmovel %ebp, %eax
-; SCALAR-NEXT:    cmovel %ebp, %r10d
-; SCALAR-NEXT:    cmovel %ebp, %r11d
-; SCALAR-NEXT:    cmovel %ebp, %ebx
-; SCALAR-NEXT:    shll $15, %edi
-; SCALAR-NEXT:    testw %bp, %bp
-; SCALAR-NEXT:    cmovnel %edi, %ebp
-; SCALAR-NEXT:    movl %esi, %edi
-; SCALAR-NEXT:    andl $1, %edi
-; SCALAR-NEXT:    cmovnel %ecx, %edi
-; SCALAR-NEXT:    leal (%rcx,%rcx), %r14d
-; SCALAR-NEXT:    movl %esi, %r15d
-; SCALAR-NEXT:    andl $2, %r15d
-; SCALAR-NEXT:    cmovnel %r14d, %r15d
-; SCALAR-NEXT:    xorl %edi, %r15d
-; SCALAR-NEXT:    leal (,%rcx,4), %edi
-; SCALAR-NEXT:    movl %esi, %r14d
-; SCALAR-NEXT:    andl $4, %r14d
-; SCALAR-NEXT:    cmovnel %edi, %r14d
-; SCALAR-NEXT:    leal (,%rcx,8), %r12d
-; SCALAR-NEXT:    movl %esi, %edi
-; SCALAR-NEXT:    andl $8, %edi
-; SCALAR-NEXT:    cmovnel %r12d, %edi
-; SCALAR-NEXT:    xorl %r14d, %edi
-; SCALAR-NEXT:    xorl %r15d, %edi
-; SCALAR-NEXT:    movl %ecx, %r14d
-; SCALAR-NEXT:    shll $4, %r14d
-; SCALAR-NEXT:    movl %esi, %r15d
-; SCALAR-NEXT:    andl $16, %r15d
-; SCALAR-NEXT:    cmovnel %r14d, %r15d
-; SCALAR-NEXT:    movl %ecx, %r14d
-; SCALAR-NEXT:    shll $5, %r14d
-; SCALAR-NEXT:    movl %esi, %r12d
-; SCALAR-NEXT:    andl $32, %r12d
-; SCALAR-NEXT:    cmovnel %r14d, %r12d
-; SCALAR-NEXT:    xorl %r15d, %r12d
-; SCALAR-NEXT:    movl %ecx, %r14d
-; SCALAR-NEXT:    shll $6, %r14d
-; SCALAR-NEXT:    movl %esi, %r15d
-; SCALAR-NEXT:    andl $64, %r15d
-; SCALAR-NEXT:    cmovnel %r14d, %r15d
-; SCALAR-NEXT:    xorl %r12d, %r15d
-; SCALAR-NEXT:    xorl %edi, %r15d
-; SCALAR-NEXT:    shll $7, %ecx
-; SCALAR-NEXT:    andl $128, %esi
-; SCALAR-NEXT:    cmovel %esi, %ecx
-; SCALAR-NEXT:    xorl %ebx, %ecx
-; SCALAR-NEXT:    xorl %r11d, %ecx
-; SCALAR-NEXT:    xorl %r10d, %ecx
-; SCALAR-NEXT:    xorl %r15d, %ecx
-; SCALAR-NEXT:    xorl %r9d, %eax
-; SCALAR-NEXT:    xorl %r8d, %eax
+; SCALAR-NEXT:    andl $73, %edx
+; SCALAR-NEXT:    movl %edx, %r8d
+; SCALAR-NEXT:    imull %ecx, %r8d
+; SCALAR-NEXT:    andl $36, %edi
+; SCALAR-NEXT:    movl %r9d, %r11d
+; SCALAR-NEXT:    movl %edi, %r10d
+; SCALAR-NEXT:    imull %ecx, %r10d
+; SCALAR-NEXT:    imull %r9d, %ecx
+; SCALAR-NEXT:    imull %eax, %r9d
+; SCALAR-NEXT:    xorl %r9d, %r8d
+; SCALAR-NEXT:    andl $36, %esi
+; SCALAR-NEXT:    movl %edx, %r9d
+; SCALAR-NEXT:    imull %eax, %r9d
+; SCALAR-NEXT:    imull %edi, %eax
+; SCALAR-NEXT:    imull %esi, %edi
+; SCALAR-NEXT:    xorl %r8d, %edi
+; SCALAR-NEXT:    andl $9216, %edi # imm = 0x2400
+; SCALAR-NEXT:    imull %esi, %r11d
+; SCALAR-NEXT:    xorl %r11d, %r9d
+; SCALAR-NEXT:    xorl %r9d, %r10d
+; SCALAR-NEXT:    andl $4608, %r10d # imm = 0x1200
+; SCALAR-NEXT:    orl %edi, %r10d
+; SCALAR-NEXT:    imull %esi, %edx
+; SCALAR-NEXT:    xorl %ecx, %edx
 ; SCALAR-NEXT:    xorl %edx, %eax
-; SCALAR-NEXT:    xorl %ebp, %eax
-; SCALAR-NEXT:    xorl %ecx, %eax
+; SCALAR-NEXT:    andl $18688, %eax # imm = 0x4900
+; SCALAR-NEXT:    orl %r10d, %eax
 ; SCALAR-NEXT:    shrl $8, %eax
 ; SCALAR-NEXT:    # kill: def $al killed $al killed $eax
-; SCALAR-NEXT:    popq %rbx
-; SCALAR-NEXT:    popq %r12
-; SCALAR-NEXT:    popq %r14
-; SCALAR-NEXT:    popq %r15
-; SCALAR-NEXT:    popq %rbp
 ; SCALAR-NEXT:    retq
 ;
 ; SSE-PCLMUL-LABEL: clmulh_i8:
@@ -1408,50 +1242,28 @@ define i64 @clmulh_i64(i64 %a, i64 %b) nounwind {
 define i8 @clmul_i8_noimplicitfloat(i8 %a, i8 %b) nounwind noimplicitfloat {
 ; CHECK-LABEL: clmul_i8_noimplicitfloat:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    # kill: def $edi killed $edi def $rdi
-; CHECK-NEXT:    xorl %ecx, %ecx
-; CHECK-NEXT:    testb $1, %sil
+; CHECK-NEXT:    movl %edi, %ecx
+; CHECK-NEXT:    andb $85, %cl
+; CHECK-NEXT:    movl %esi, %r9d
+; CHECK-NEXT:    andb $-86, %r9b
+; CHECK-NEXT:    andb $-86, %dil
+; CHECK-NEXT:    andb $85, %sil
 ; CHECK-NEXT:    movl %edi, %eax
-; CHECK-NEXT:    cmovel %ecx, %eax
-; CHECK-NEXT:    leal (%rdi,%rdi), %edx
-; CHECK-NEXT:    movzbl %dl, %edx
-; CHECK-NEXT:    testb $2, %sil
-; CHECK-NEXT:    cmovel %ecx, %edx
-; CHECK-NEXT:    xorl %eax, %edx
-; CHECK-NEXT:    leal (,%rdi,4), %eax
-; CHECK-NEXT:    movzbl %al, %r8d
-; CHECK-NEXT:    testb $4, %sil
-; CHECK-NEXT:    cmovel %ecx, %r8d
-; CHECK-NEXT:    leal (,%rdi,8), %eax
-; CHECK-NEXT:    movzbl %al, %eax
-; CHECK-NEXT:    testb $8, %sil
-; CHECK-NEXT:    cmovel %ecx, %eax
-; CHECK-NEXT:    xorl %r8d, %eax
-; CHECK-NEXT:    xorl %edx, %eax
-; CHECK-NEXT:    movl %edi, %edx
-; CHECK-NEXT:    shlb $4, %dl
-; CHECK-NEXT:    movzbl %dl, %edx
-; CHECK-NEXT:    testb $16, %sil
-; CHECK-NEXT:    cmovel %ecx, %edx
-; CHECK-NEXT:    movl %edi, %r8d
-; CHECK-NEXT:    shlb $5, %r8b
-; CHECK-NEXT:    movzbl %r8b, %r8d
-; CHECK-NEXT:    testb $32, %sil
-; CHECK-NEXT:    cmovel %ecx, %r8d
-; CHECK-NEXT:    xorl %edx, %r8d
-; CHECK-NEXT:    movl %edi, %edx
-; CHECK-NEXT:    shlb $6, %dl
-; CHECK-NEXT:    movzbl %dl, %edx
-; CHECK-NEXT:    testb $64, %sil
-; CHECK-NEXT:    cmovel %ecx, %edx
-; CHECK-NEXT:    xorl %r8d, %edx
-; CHECK-NEXT:    xorl %eax, %edx
-; CHECK-NEXT:    shlb $7, %dil
-; CHECK-NEXT:    movzbl %dil, %eax
-; CHECK-NEXT:    testb $-128, %sil
-; CHECK-NEXT:    cmovel %ecx, %eax
-; CHECK-NEXT:    xorl %edx, %eax
-; CHECK-NEXT:    # kill: def $al killed $al killed $eax
+; CHECK-NEXT:    mulb %sil
+; CHECK-NEXT:    movl %eax, %edx
+; CHECK-NEXT:    movl %ecx, %eax
+; CHECK-NEXT:    mulb %r9b
+; CHECK-NEXT:    movl %eax, %r8d
+; CHECK-NEXT:    xorb %dl, %r8b
+; CHECK-NEXT:    andb $-86, %r8b
+; CHECK-NEXT:    movl %edi, %eax
+; CHECK-NEXT:    mulb %r9b
+; CHECK-NEXT:    movl %eax, %edx
+; CHECK-NEXT:    movl %ecx, %eax
+; CHECK-NEXT:    mulb %sil
+; CHECK-NEXT:    xorb %dl, %al
+; CHECK-NEXT:    andb $85, %al
+; CHECK-NEXT:    orb %r8b, %al
 ; CHECK-NEXT:    retq
   %res = call i8 @llvm.clmul.i8(i8 %a, i8 %b)
   ret i8 %res
@@ -1462,51 +1274,30 @@ declare void @use(i8)
 define void @commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwind {
 ; SCALAR-LABEL: commutative_clmul_i8:
 ; SCALAR:       # %bb.0:
-; SCALAR-NEXT:    # kill: def $edi killed $edi def $rdi
-; SCALAR-NEXT:    xorl %eax, %eax
-; SCALAR-NEXT:    testb $1, %sil
 ; SCALAR-NEXT:    movl %edi, %r8d
-; SCALAR-NEXT:    cmovel %eax, %r8d
-; SCALAR-NEXT:    leal (%rdi,%rdi), %r9d
-; SCALAR-NEXT:    movzbl %r9b, %r9d
-; SCALAR-NEXT:    testb $2, %sil
-; SCALAR-NEXT:    cmovel %eax, %r9d
-; SCALAR-NEXT:    xorl %r8d, %r9d
-; SCALAR-NEXT:    leal (,%rdi,4), %r8d
-; SCALAR-NEXT:    movzbl %r8b, %r10d
-; SCALAR-NEXT:    testb $4, %sil
-; SCALAR-NEXT:    cmovel %eax, %r10d
-; SCALAR-NEXT:    leal (,%rdi,8), %r8d
-; SCALAR-NEXT:    movzbl %r8b, %r8d
-; SCALAR-NEXT:    testb $8, %sil
-; SCALAR-NEXT:    cmovel %eax, %r8d
-; SCALAR-NEXT:    xorl %r10d, %r8d
-; SCALAR-NEXT:    xorl %r9d, %r8d
-; SCALAR-NEXT:    movl %edi, %r9d
-; SCALAR-NEXT:    shlb $4, %r9b
-; SCALAR-NEXT:    movzbl %r9b, %r9d
-; SCALAR-NEXT:    testb $16, %sil
-; SCALAR-NEXT:    cmovel %eax, %r9d
-; SCALAR-NEXT:    movl %edi, %r10d
-; SCALAR-NEXT:    shlb $5, %r10b
-; SCALAR-NEXT:    movzbl %r10b, %r10d
-; SCALAR-NEXT:    testb $32, %sil
-; SCALAR-NEXT:    cmovel %eax, %r10d
-; SCALAR-NEXT:    xorl %r9d, %r10d
-; SCALAR-NEXT:    movl %edi, %r9d
-; SCALAR-NEXT:    shlb $6, %r9b
-; SCALAR-NEXT:    movzbl %r9b, %r9d
-; SCALAR-NEXT:    testb $64, %sil
-; SCALAR-NEXT:    cmovel %eax, %r9d
-; SCALAR-NEXT:    xorl %r10d, %r9d
-; SCALAR-NEXT:    xorl %r8d, %r9d
-; SCALAR-NEXT:    shlb $7, %dil
-; SCALAR-NEXT:    movzbl %dil, %edi
-; SCALAR-NEXT:    testb $-128, %sil
-; SCALAR-NEXT:    cmovel %eax, %edi
-; SCALAR-NEXT:    xorl %r9d, %edi
-; SCALAR-NEXT:    movb %dil, (%rdx)
-; SCALAR-NEXT:    movb %dil, (%rcx)
+; SCALAR-NEXT:    andb $85, %r8b
+; SCALAR-NEXT:    movl %esi, %r11d
+; SCALAR-NEXT:    andb $-86, %r11b
+; SCALAR-NEXT:    andb $-86, %dil
+; SCALAR-NEXT:    andb $85, %sil
+; SCALAR-NEXT:    movl %edi, %eax
+; SCALAR-NEXT:    mulb %sil
+; SCALAR-NEXT:    movl %eax, %r9d
+; SCALAR-NEXT:    movl %r8d, %eax
+; SCALAR-NEXT:    mulb %r11b
+; SCALAR-NEXT:    movl %eax, %r10d
+; SCALAR-NEXT:    xorb %r9b, %r10b
+; SCALAR-NEXT:    andb $-86, %r10b
+; SCALAR-NEXT:    movl %edi, %eax
+; SCALAR-NEXT:    mulb %r11b
+; SCALAR-NEXT:    movl %eax, %edi
+; SCALAR-NEXT:    movl %r8d, %eax
+; SCALAR-NEXT:    mulb %sil
+; SCALAR-NEXT:    xorb %dil, %al
+; SCALAR-NEXT:    andb $85, %al
+; SCALAR-NEXT:    orb %r10b, %al
+; SCALAR-NEXT:    movb %al, (%rdx)
+; SCALAR-NEXT:    movb %al, (%rcx)
 ; SCALAR-NEXT:    retq
 ;
 ; SSE-PCLMUL-LABEL: commutative_clmul_i8:
@@ -1539,96 +1330,47 @@ define void @commutative_clmulh_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwind {
 ; SCALAR-LABEL: commutative_clmulh_i8:
 ; SCALAR:       # %bb.0:
 ; SCALAR-NEXT:    pushq %rbp
-; SCALAR-NEXT:    pushq %r15
 ; SCALAR-NEXT:    pushq %r14
-; SCALAR-NEXT:    pushq %r13
-; SCALAR-NEXT:    pushq %r12
 ; SCALAR-NEXT:    pushq %rbx
-; SCALAR-NEXT:    movq %rcx, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; SCALAR-NEXT:    movzbl %sil, %r14d
-; SCALAR-NEXT:    movl %r14d, %ebp
-; SCALAR-NEXT:    shll $8, %ebp
-; SCALAR-NEXT:    movl %r14d, %ebx
-; SCALAR-NEXT:    shll $9, %ebx
-; SCALAR-NEXT:    movl %r14d, %r11d
-; SCALAR-NEXT:    shll $10, %r11d
-; SCALAR-NEXT:    movl %r14d, %eax
-; SCALAR-NEXT:    shll $11, %eax
-; SCALAR-NEXT:    movl %r14d, %r10d
-; SCALAR-NEXT:    shll $12, %r10d
-; SCALAR-NEXT:    movl %r14d, %ecx
-; SCALAR-NEXT:    shll $13, %ecx
-; SCALAR-NEXT:    movl %esi, %r8d
-; SCALAR-NEXT:    shll $14, %r8d
-; SCALAR-NEXT:    xorl %r15d, %r15d
-; SCALAR-NEXT:    testw %r15w, %r15w
-; SCALAR-NEXT:    cmovel %r15d, %r8d
-; SCALAR-NEXT:    cmovel %r15d, %ecx
-; SCALAR-NEXT:    cmovel %r15d, %r10d
-; SCALAR-NEXT:    cmovel %r15d, %eax
-; SCALAR-NEXT:    cmovel %r15d, %r11d
-; SCALAR-NEXT:    cmovel %r15d, %ebx
-; SCALAR-NEXT:    cmovel %r15d, %ebp
-; SCALAR-NEXT:    shll $15, %esi
-; SCALAR-NEXT:    testw %r15w, %r15w
-; SCALAR-NEXT:    cmovel %r15d, %esi
-; SCALAR-NEXT:    movl %edi, %r15d
-; SCALAR-NEXT:    andl $1, %r15d
-; SCALAR-NEXT:    cmovnel %r14d, %r15d
-; SCALAR-NEXT:    leal (%r14,%r14), %r12d
-; SCALAR-NEXT:    movl %edi, %r13d
-; SCALAR-NEXT:    andl $2, %r13d
-; SCALAR-NEXT:    cmovnel %r12d, %r13d
-; SCALAR-NEXT:    xorl %r15d, %r13d
-; SCALAR-NEXT:    leal (,%r14,4), %r15d
-; SCALAR-NEXT:    movl %edi, %r12d
-; SCALAR-NEXT:    andl $4, %r12d
-; SCALAR-NEXT:    cmovnel %r15d, %r12d
-; SCALAR-NEXT:    movl %edi, %r15d
-; SCALAR-NEXT:    andl $8, %r15d
-; SCALAR-NEXT:    leal (,%r14,8), %r9d
-; SCALAR-NEXT:    cmovnel %r9d, %r15d
-; SCALAR-NEXT:    xorl %r12d, %r15d
-; SCALAR-NEXT:    xorl %r13d, %r15d
-; SCALAR-NEXT:    movl %r14d, %r9d
-; SCALAR-NEXT:    shll $4, %r9d
-; SCALAR-NEXT:    movl %edi, %r12d
-; SCALAR-NEXT:    andl $16, %r12d
-; SCALAR-NEXT:    cmovnel %r9d, %r12d
-; SCALAR-NEXT:    movl %r14d, %r9d
-; SCALAR-NEXT:    shll $5, %r9d
-; SCALAR-NEXT:    movl %edi, %r13d
-; SCALAR-NEXT:    andl $32, %r13d
-; SCALAR-NEXT:    cmovnel %r9d, %r13d
-; SCALAR-NEXT:    xorl %r12d, %r13d
-; SCALAR-NEXT:    movl %r14d, %r9d
-; SCALAR-NEXT:    shll $6, %r9d
-; SCALAR-NEXT:    movl %edi, %r12d
-; SCALAR-NEXT:    andl $64, %r12d
-; SCALAR-NEXT:    cmovnel %r9d, %r12d
-; SCALAR-NEXT:    xorl %r13d, %r12d
-; SCALAR-NEXT:    xorl %r15d, %r12d
-; SCALAR-NEXT:    shll $7, %r14d
-; SCALAR-NEXT:    andl $128, %edi
-; SCALAR-NEXT:    cmovnel %r14d, %edi
-; SCALAR-NEXT:    xorl %ebp, %edi
-; SCALAR-NEXT:    xorl %ebx, %edi
-; SCALAR-NEXT:    xorl %r11d, %edi
-; SCALAR-NEXT:    xorl %r12d, %edi
-; SCALAR-NEXT:    xorl %r10d, %eax
-; SCALAR-NEXT:    xorl %ecx, %eax
-; SCALAR-NEXT:    xorl %r8d, %eax
-; SCALAR-NEXT:    xorl %esi, %eax
-; SCALAR-NEXT:    xorl %edi, %eax
-; SCALAR-NEXT:    shrl $8, %eax
-; SCALAR-NEXT:    movb %al, (%rdx)
-; SCALAR-NEXT:    movq {{[-0-9]+}}(%r{{[sb]}}p), %rcx # 8-byte Reload
-; SCALAR-NEXT:    movb %al, (%rcx)
+; SCALAR-NEXT:    movl %edi, %eax
+; SCALAR-NEXT:    andl $73, %eax
+; SCALAR-NEXT:    movl %esi, %r9d
+; SCALAR-NEXT:    andl $146, %r9d
+; SCALAR-NEXT:    movl %edi, %r8d
+; SCALAR-NEXT:    andl $146, %r8d
+; SCALAR-NEXT:    movl %esi, %r11d
+; SCALAR-NEXT:    andl $73, %r11d
+; SCALAR-NEXT:    andl $36, %edi
+; SCALAR-NEXT:    andl $36, %esi
+; SCALAR-NEXT:    movl %esi, %r10d
+; SCALAR-NEXT:    imull %edi, %r10d
+; SCALAR-NEXT:    movl %r9d, %ebx
+; SCALAR-NEXT:    imull %edi, %ebx
+; SCALAR-NEXT:    movl %r11d, %ebp
+; SCALAR-NEXT:    imull %r11d, %edi
+; SCALAR-NEXT:    imull %r8d, %r11d
+; SCALAR-NEXT:    movl %esi, %r14d
+; SCALAR-NEXT:    imull %r8d, %r14d
+; SCALAR-NEXT:    imull %r9d, %r8d
+; SCALAR-NEXT:    imull %eax, %r9d
+; SCALAR-NEXT:    xorl %r9d, %r11d
+; SCALAR-NEXT:    xorl %r11d, %r10d
+; SCALAR-NEXT:    andl $9216, %r10d # imm = 0x2400
+; SCALAR-NEXT:    imull %eax, %ebp
+; SCALAR-NEXT:    xorl %ebx, %ebp
+; SCALAR-NEXT:    xorl %ebp, %r14d
+; SCALAR-NEXT:    andl $4608, %r14d # imm = 0x1200
+; SCALAR-NEXT:    orl %r10d, %r14d
+; SCALAR-NEXT:    xorl %r8d, %edi
+; SCALAR-NEXT:    imull %eax, %esi
+; SCALAR-NEXT:    xorl %edi, %esi
+; SCALAR-NEXT:    andl $18688, %esi # imm = 0x4900
+; SCALAR-NEXT:    orl %r14d, %esi
+; SCALAR-NEXT:    shrl $8, %esi
+; SCALAR-NEXT:    movb %sil, (%rdx)
+; SCALAR-NEXT:    movb %sil, (%rcx)
 ; SCALAR-NEXT:    popq %rbx
-; SCALAR-NEXT:    popq %r12
-; SCALAR-NEXT:    popq %r13
 ; SCALAR-NEXT:    popq %r14
-; SCALAR-NEXT:    popq %r15
 ; SCALAR-NEXT:    popq %rbp
 ; SCALAR-NEXT:    retq
 ;
@@ -1674,90 +1416,47 @@ define void @commutative_clmulr_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwind {
 ; SCALAR-LABEL: commutative_clmulr_i8:
 ; SCALAR:       # %bb.0:
 ; SCALAR-NEXT:    pushq %rbp
-; SCALAR-NEXT:    pushq %r15
 ; SCALAR-NEXT:    pushq %r14
-; SCALAR-NEXT:    pushq %r13
-; SCALAR-NEXT:    pushq %r12
 ; SCALAR-NEXT:    pushq %rbx
-; SCALAR-NEXT:    movzbl %sil, %r14d
-; SCALAR-NEXT:    movl %r14d, %ebx
-; SCALAR-NEXT:    shll $8, %ebx
-; SCALAR-NEXT:    movl %r14d, %r11d
-; SCALAR-NEXT:    shll $9, %r11d
-; SCALAR-NEXT:    movl %r14d, %r10d
-; SCALAR-NEXT:    shll $10, %r10d
-; SCALAR-NEXT:    movl %r14d, %eax
-; SCALAR-NEXT:    shll $11, %eax
-; SCALAR-NEXT:    movl %r14d, %r9d
-; SCALAR-NEXT:    shll $12, %r9d
-; SCALAR-NEXT:    movl %esi, %r8d
-; SCALAR-NEXT:    shll $13, %r8d
-; SCALAR-NEXT:    xorl %ebp, %ebp
-; SCALAR-NEXT:    testw %bp, %bp
-; SCALAR-NEXT:    cmovel %ebp, %r8d
-; SCALAR-NEXT:    cmovel %ebp, %r9d
-; SCALAR-NEXT:    cmovel %ebp, %eax
-; SCALAR-NEXT:    cmovel %ebp, %r10d
-; SCALAR-NEXT:    cmovel %ebp, %r11d
-; SCALAR-NEXT:    cmovel %ebp, %ebx
-; SCALAR-NEXT:    shll $14, %esi
-; SCALAR-NEXT:    testw %bp, %bp
-; SCALAR-NEXT:    cmovel %ebp, %esi
-; SCALAR-NEXT:    movl %edi, %ebp
-; SCALAR-NEXT:    andl $1, %ebp
-; SCALAR-NEXT:    cmovnel %r14d, %ebp
-; SCALAR-NEXT:    leal (%r14,%r14), %r15d
-; SCALAR-NEXT:    movl %edi, %r12d
-; SCALAR-NEXT:    andl $2, %r12d
-; SCALAR-NEXT:    cmovnel %r15d, %r12d
-; SCALAR-NEXT:    xorl %ebp, %r12d
-; SCALAR-NEXT:    leal (,%r14,4), %ebp
-; SCALAR-NEXT:    movl %edi, %r15d
-; SCALAR-NEXT:    andl $4, %r15d
-; SCALAR-NEXT:    cmovnel %ebp, %r15d
-; SCALAR-NEXT:    leal (,%r14,8), %r13d
-; SCALAR-NEXT:    movl %edi, %ebp
-; SCALAR-NEXT:    andl $8, %ebp
-; SCALAR-NEXT:    cmovnel %r13d, %ebp
-; SCALAR-NEXT:    xorl %r15d, %ebp
-; SCALAR-NEXT:    xorl %r12d, %ebp
-; SCALAR-NEXT:    movl %r14d, %r15d
-; SCALAR-NEXT:    shll $4, %r15d
-; SCALAR-NEXT:    movl %edi, %r12d
-; SCALAR-NEXT:    andl $16, %r12d
-; SCALAR-NEXT:    cmovnel %r15d, %r12d
-; SCALAR-NEXT:    movl %r14d, %r15d
-; SCALAR-NEXT:    shll $5, %r15d
-; SCALAR-NEXT:    movl %edi, %r13d
-; SCALAR-NEXT:    andl $32, %r13d
-; SCALAR-NEXT:    cmovnel %r15d, %r13d
-; SCALAR-NEXT:    xorl %r12d, %r13d
-; SCALAR-NEXT:    movl %r14d, %r15d
-; SCALAR-NEXT:    shll $6, %r15d
-; SCALAR-NEXT:    movl %edi, %r12d
-; SCALAR-NEXT:    andl $64, %r12d
-; SCALAR-NEXT:    cmovnel %r15d, %r12d
-; SCALAR-NEXT:    xorl %r13d, %r12d
-; SCALAR-NEXT:    xorl %ebp, %r12d
-; SCALAR-NEXT:    shll $7, %r14d
-; SCALAR-NEXT:    andl $128, %edi
-; SCALAR-NEXT:    cmovnel %r14d, %edi
-; SCALAR-NEXT:    xorl %ebx, %edi
-; SCALAR-NEXT:    xorl %r11d, %edi
-; SCALAR-NEXT:    xorl %r10d, %edi
-; SCALAR-NEXT:    xorl %r12d, %edi
-; SCALAR-NEXT:    xorl %r9d, %eax
-; SCALAR-NEXT:    xorl %r8d, %eax
-; SCALAR-NEXT:    xorl %esi, %eax
-; SCALAR-NEXT:    xorl %edi, %eax
-; SCALAR-NEXT:    shrl $7, %eax
-; SCALAR-NEXT:    movb %al, (%rdx)
-; SCALAR-NEXT:    movb %al, (%rcx)
+; SCALAR-NEXT:    movl %edi, %eax
+; SCALAR-NEXT:    andl $73, %eax
+; SCALAR-NEXT:    movl %esi, %r9d
+; SCALAR-NEXT:    andl $146, %r9d
+; SCALAR-NEXT:    movl %edi, %r8d
+; SCALAR-NEXT:    andl $146, %r8d
+; SCALAR-NEXT:    movl %esi, %r11d
+; SCALAR-NEXT:    andl $73, %r11d
+; SCALAR-NEXT:    andl $36, %edi
+; SCALAR-NEXT:    andl $36, %esi
+; SCALAR-NEXT:    movl %esi, %r10d
+; SCALAR-NEXT:    imull %edi, %r10d
+; SCALAR-NEXT:    movl %r9d, %ebx
+; SCALAR-NEXT:    imull %edi, %ebx
+; SCALAR-NEXT:    movl %r11d, %ebp
+; SCALAR-NEXT:    imull %r11d, %edi
+; SCALAR-NEXT:    imull %r8d, %r11d
+; SCALAR-NEXT:    movl %esi, %r14d
+; SCALAR-NEXT:    imull %r8d, %r14d
+; SCALAR-NEXT:    imull %r9d, %r8d
+; SCALAR-NEXT:    imull %eax, %r9d
+; SCALAR-NEXT:    xorl %r9d, %r11d
+; SCALAR-NEXT:    xorl %r11d, %r10d
+; SCALAR-NEXT:    andl $9344, %r10d # imm = 0x2480
+; SCALAR-NEXT:    imull %eax, %ebp
+; SCALAR-NEXT:    xorl %ebx, %ebp
+; SCALAR-NEXT:    xorl %ebp, %r14d
+; SCALAR-NEXT:    andl $4608, %r14d # imm = 0x1200
+; SCALAR-NEXT:    orl %r10d, %r14d
+; SCALAR-NEXT:    xorl %r8d, %edi
+; SCALAR-NEXT:    imull %eax, %esi
+; SCALAR-NEXT:    xorl %edi, %esi
+; SCALAR-NEXT:    andl $18688, %esi # imm = 0x4900
+; SCALAR-NEXT:    orl %r14d, %esi
+; SCALAR-NEXT:    shrl $7, %esi
+; SCALAR-NEXT:    movb %sil, (%rdx)
+; SCALAR-NEXT:    movb %sil, (%rcx)
 ; SCALAR-NEXT:    popq %rbx
-; SCALAR-NEXT:    popq %r12
-; SCALAR-NEXT:    popq %r13
 ; SCALAR-NEXT:    popq %r14
-; SCALAR-NEXT:    popq %r15
 ; SCALAR-NEXT:    popq %rbp
 ; SCALAR-NEXT:    retq
 ;
@@ -1806,50 +1505,30 @@ define void @mul_use_commutative_clmul_i8(i8 %x, i8 %y, ptr %p0, ptr %p1) nounwi
 ; SCALAR-NEXT:    pushq %rbx
 ; SCALAR-NEXT:    pushq %rax
 ; SCALAR-NEXT:    movq %rcx, %rbx
-; SCALAR-NEXT:    # kill: def $edi killed $edi def $rdi
-; SCALAR-NEXT:    xorl %eax, %eax
-; SCALAR-NEXT:    testb $1, %sil
-; SCALAR-NEXT:    movl %edi, %ebp
-; SCALAR-NEXT:    cmovel %eax, %ebp
-; SCALAR-NEXT:    leal (%rdi,%rdi), %ecx
-; SCALAR-NEXT:    movzbl %cl, %ecx
-; SCALAR-NEXT:    testb $2, %sil
-; SCALAR-NEXT:    cmovel %eax, %ecx
-; SCALAR-NEXT:    xorl %ecx, %ebp
-; SCALAR-NEXT:    leal (,%rdi,4), %ecx
-; SCALAR-NEXT:    movzbl %cl, %ecx
-; SCALAR-NEXT:    testb $4, %sil
-; SCALAR-NEXT:    cmovel %eax, %ecx
-; SCALAR-NEXT:    leal (,%rdi,8), %r8d
-; SCALAR-NEXT:    movzbl %r8b, %r8d
-; SCALAR-NEXT:    testb $8, %sil
-; SCALAR-NEXT:    cmovel %eax, %r8d
-; SCALAR-NEXT:    xorl %ecx, %r8d
-; SCALAR-NEXT:    xorl %r8d, %ebp
 ; SCALAR-NEXT:    movl %edi, %ecx
-; SCALAR-NEXT:    shlb $4, %cl
-; SCALAR-NEXT:    movzbl %cl, %ecx
-; SCALAR-NEXT:    testb $16, %sil
-; SCALAR-NEXT:    cmovel %eax, %ecx
-; SCALAR-NEXT:    movl %edi, %r8d
-; SCALAR-NEXT:    shlb $5, %r8b
-; SCALAR-NEXT:    movzbl %r8b, %r8d
-; SCALAR-NEXT:    testb $32, %sil
-; SCALAR-NEXT:    cmovel %eax, %r8d
-; SCALAR-NEXT:    xorl %ecx, %r8d
-; SCALAR-NEXT:    movl %edi, %ecx
-; SCALAR-NEXT:    shlb $6, %cl
-; SCALAR-NEXT:    movzbl %cl, %ecx
-; SCALAR-NEXT:    testb $64, %sil
-; SCALAR-NEXT:    cmovel %eax, %ecx
-; SCALAR-NEXT:    xorl %r8d, %ecx
-; SCALAR-NEXT:    xorl %ecx, %ebp
-; SCALAR-NEXT:    shlb $7, %dil
-; SCALAR-NEXT:    movzbl %dil, %ecx
-; SCALAR-NEXT:    testb $-128, %sil
-; SCALAR-NEXT:    cmovel %eax, %ecx
-; SCALAR-NEXT:    xorl %ecx, %ebp
-; SCALAR-NEXT:    movb %bpl, (%rdx)
+; SCALAR-NEXT:    andb $85, %cl
+; SCALAR-NEXT:    movl %esi, %r10d
+; SCALAR-NEXT:    andb $-86, %r10b
+; SCALAR-NEXT:    andb $-86, %dil
+; SCALAR-NEXT:    andb $85, %sil
+; SCALAR-NEXT:    movl %edi, %eax
+; SCALAR-NEXT:    mulb %sil
+; SCALAR-NEXT:    movl %eax, %r8d
+; SCALAR-NEXT:    movl %ecx, %eax
+; SCALAR-NEXT:    mulb %r10b
+; SCALAR-NEXT:    movl %eax, %r9d
+; SCALAR-NEXT:    xorb %r8b, %r9b
+; SCALAR-NEXT:    andb $-86, %r9b
+; SCALAR-NEXT:    movl %edi, %eax
+; SCALAR-NEXT:    mulb %r10b
+; SCALAR-NEXT:    movl %eax, %edi
+; SCALAR-NEXT:    movl %ecx, %eax
+; SCALAR-NEXT:    mulb %sil
+; SCALAR-NEXT:    xorb %dil, %al
+; SCALAR-NEXT:    andb $85, %al
+; SCALAR-NEXT:    orb %r9b, %al
+; SCALAR-NEXT:    movb %al, (%rdx)
+; SCALAR-NEXT:    movzbl %al, %ebp
 ; SCALAR-NEXT:    movl %ebp, %edi
 ; SCALAR-NEXT:    callq use@PLT
 ; SCALAR-NEXT:    movb %bpl, (%rbx)


### PR DESCRIPTION
Generalize the approach from https://github.com/llvm/llvm-project/pull/203727 to narrower and wider integers.

We still need the fallback for when multiplication isn't available, and it turns out that for some widths the fallback emits fewer instructions, the naive fallback is still used for  `i1`, `i3`, `i4` and `i9`. I've also now enabled wider integers (`i128` and `i256` have uses in cryptography).

Based on my local experiments, the Karatsuba approach (e.g. as in https://github.com/rust-lang/rust/pull/152132#discussion_r2778609222) is not actually better than zero extending the input and using multiplication with holes on the wider type.

CC https://github.com/llvm/llvm-project/issues/203694
CC: @eisenwave