### PR TITLE
[llvm-exegesis] Fix alias restrictions in special handlers for deterministic alias removing

### DIFF
--- a/llvm/test/tools/llvm-exegesis/RISCV/rvv/reduction.test
+++ b/llvm/test/tools/llvm-exegesis/RISCV/rvv/reduction.test
@@ -4,4 +4,6 @@
 # Make sure reduction ops alias between vd and vs2
 # CHECK:      instructions:
 # CHECK-NEXT: PseudoVWREDSUMU_VS_M8_E32
-# CHECK-SAME:  V[[REG:[0-9]+]] V[[REG]] V{{[0-9]+}}M8
+# CHECK-SAME: V[[REG:[0-9]+]] V[[REG]]
+# CHECK-NOT:  {{[[:space:]]*}}V[[REG]]{{[[:space:]]+}}
+# CHECK:      i

--- a/llvm/tools/llvm-exegesis/lib/CodeTemplate.cpp
+++ b/llvm/tools/llvm-exegesis/lib/CodeTemplate.cpp
@@ -25,7 +25,13 @@ CodeTemplate CodeTemplate::clone() const {
 }
 
 InstructionTemplate::InstructionTemplate(const Instruction *Instr)
-    : Instr(Instr), VariableValues(Instr->Variables.size()) {}
+    : Instr(Instr), VariableValues(Instr->Variables.size()),
+      AliasConstraintForVariables(Instr->Variables.size()) {
+  for (unsigned VarIdx = 0; VarIdx < Instr->Variables.size(); ++VarIdx) {
+    AliasConstraintForVariables[VarIdx].resize(Instr->Variables.size());
+  }
+}
+
 
 InstructionTemplate::InstructionTemplate(InstructionTemplate &&) = default;
 

--- a/llvm/tools/llvm-exegesis/lib/CodeTemplate.h
+++ b/llvm/tools/llvm-exegesis/lib/CodeTemplate.h
@@ -44,6 +44,22 @@ struct InstructionTemplate {
     VariableValues.assign(NewVariableValues.begin(), NewVariableValues.end());
   }
 
+  void setAliasConstraintForVariable(unsigned CurrVarIdx,
+                                     unsigned ForbiddenVarIdx) {
+    assert(AliasConstraintForVariables.size() > CurrVarIdx &&
+           "Variable index out of bounds");
+    assert(AliasConstraintForVariables.size() > ForbiddenVarIdx &&
+           "Variable index out of bounds");
+    AliasConstraintForVariables[CurrVarIdx].set(ForbiddenVarIdx);
+    AliasConstraintForVariables[ForbiddenVarIdx].set(CurrVarIdx);
+  }
+  const BitVector &getAliasConstraintForVariable(unsigned VarIdx) const {
+    assert(AliasConstraintForVariables.size() > VarIdx &&
+           "Variable index out of bounds");
+    return AliasConstraintForVariables[VarIdx];
+  }
+
+
   // Builds an MCInst from this InstructionTemplate setting its operands
   // to the corresponding variable values. Precondition: All VariableValues must
   // be set.
@@ -52,6 +68,11 @@ struct InstructionTemplate {
 private:
   const Instruction *Instr;
   SmallVector<MCOperand, 4> VariableValues;
+  // For each variable index holds the BitVector, where set bit for some index
+  // indicate that aliasing between them is forbidden, and clear bit indicates
+  // allowed aliasing.
+  SmallVector<BitVector, 4> AliasConstraintForVariables;
+
 };
 
 enum class ExecutionMode : uint8_t {

--- a/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
@@ -296,6 +296,8 @@ void RISCVSnippetGenerator<BaseT>::annotateWithVType(
           if (isVectorReduction(BaseOpcode) &&
               // vs1's operand index is always 3.
               Op->getIndex() == 3) {
+            // First variable is shared between tied vd and vs2.
+            IT.setAliasConstraintForVariable(Op->getVariableIndex(), 0);
             ROA = Uses.erase(ROA);
             continue;
           }

--- a/llvm/tools/llvm-exegesis/lib/SnippetGenerator.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetGenerator.cpp
@@ -303,10 +303,26 @@ Error randomizeUnsetVariables(const LLVMState &State,
                               InstructionTemplate &IT) {
   for (const Variable &Var : IT.getInstr().Variables) {
     MCOperand &AssignedValue = IT.getValueFor(Var);
-    if (!AssignedValue.isValid())
-      if (auto Err = randomizeMCOperand(State, IT.getInstr(), Var,
-                                        AssignedValue, ForbiddenRegs))
+    if (!AssignedValue.isValid()) {
+      auto ExtraForbiddenRegs = ForbiddenRegs;
+      // Add alias restrictions
+      const auto &AliasConstraint =
+          IT.getAliasConstraintForVariable(Var.getIndex());
+      if (!AliasConstraint.empty()) {
+        // Iterate over VarIdxs for this variable to gather forbidden regs from
+        // them (if any).
+        for (const auto &AliasVarIdx : AliasConstraint.set_bits()) {
+          if (IT.getValueFor(IT.getInstr().Variables[AliasVarIdx]).isReg()) {
+            ExtraForbiddenRegs.set(
+                IT.getValueFor(IT.getInstr().Variables[AliasVarIdx]).getReg());
+          }
+        }
+      }
+      if (auto Err =
+              randomizeMCOperand(State, IT.getInstr(), Var, AssignedValue,
+                                 ExtraForbiddenRegs, ImmValue))
         return Err;
+    }
   }
   return Error::success();
 }


### PR DESCRIPTION
Prior to this patch, if we ended up with <INVALID> registers (for example if Uses ROA became empty) the randomizeMCOperand could fill the invalid register value (in randomizeUnsetVariables) with the same register we actually don't want and tried to restrict by clearing Uses.

This patch adds aliasing restrictions to make sure even if that happens we still retain the restriction in randomization of registers.