### PR TITLE
[InstrProf] Support atomic updates of branch coverage counters on 32-bit platforms

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
@@ -1418,8 +1418,38 @@ void InstrLowerer::lowerIncrement(InstrProfIncrementInst *Inc) {
   // after promotion is done.
   if ((!isCounterPromotionEnabled() && isAtomic()) ||
       (Inc->getIndex()->isNullValue() && AtomicFirstCounter)) {
-    Builder.CreateAtomicRMW(AtomicRMWInst::Add, Addr, Inc->getStep(),
-                            MaybeAlign(), AtomicOrdering::Monotonic);
+    if (M.getDataLayout().getTypeSizeInBits(Addr->getType()) == 32) {
+      // For 32-bit platforms, perform atomic updates of two counter's halves.
+      unsigned AS = M.getDataLayout().getDefaultGlobalsAddressSpace();
+      auto *Int32Ty = Type::getInt32Ty(M.getContext());
+      auto *CtrLowPtr =
+          Builder.CreateBitCast(Addr, PointerType::get(M.getContext(), AS));
+      auto *CtrHighPtr =
+          Builder.CreateConstInBoundsGEP1_32(Int32Ty, CtrLowPtr, 1);
+      if (M.getDataLayout().isBigEndian())
+        std::swap(CtrLowPtr, CtrHighPtr);
+      Value *IncStep = Inc->getStep();
+      Value *IncStepLow = Builder.CreateTrunc(IncStep, Int32Ty);
+      Value *IncStepHigh = Builder.CreateLShr(IncStep, Builder.getInt64(32));
+      IncStepHigh = Builder.CreateTrunc(IncStepHigh, Int32Ty);
+      Value *OldLowValue =
+          Builder.CreateAtomicRMW(AtomicRMWInst::Add, CtrLowPtr, IncStepLow,
+                                  MaybeAlign(), AtomicOrdering::Monotonic);
+      Value *OverflowAdd = Builder.CreateZExt(
+          Builder.CreateICmpULT(Builder.CreateAdd(OldLowValue, IncStepLow),
+                                OldLowValue),
+          Int32Ty);
+      Value *IncHigh = Builder.CreateAdd(IncStepHigh, OverflowAdd);
+      Value *Cmp = Builder.CreateIsNotNull(IncHigh, "pgocount.ifnonzero");
+      // if (Cmp) update high half.
+      Instruction *ThenBranch = SplitBlockAndInsertIfThen(Cmp, Inc, false);
+      Builder.SetInsertPoint(ThenBranch);
+      Builder.CreateAtomicRMW(AtomicRMWInst::Add, CtrHighPtr, IncHigh,
+                              MaybeAlign(), AtomicOrdering::Monotonic);
+    } else {
+      Builder.CreateAtomicRMW(AtomicRMWInst::Add, Addr, Inc->getStep(),
+                              MaybeAlign(), AtomicOrdering::Monotonic);
+    }
   } else {
     Value *IncStep = Inc->getStep();
     Value *Load = Builder.CreateLoad(IncStep->getType(), Addr, "pgocount");

--- a/llvm/test/Instrumentation/InstrProfiling/atomic-updates-32.ll
+++ b/llvm/test/Instrumentation/InstrProfiling/atomic-updates-32.ll
@@ -1,0 +1,32 @@
+; RUN: opt < %s -S -mtriple=powerpc--linux -passes=instrprof -instrprof-atomic-counter-update-all | FileCheck %s --check-prefix=CHECK,BE
+; RUN: opt < %s -S -mtriple=powerpcle--linux -passes=instrprof -instrprof-atomic-counter-update-all | FileCheck %s --check-prefix=CHECK,LE
+
+target triple = "powerpc--linux"
+
+@__profn_foo = private constant [3 x i8] c"foo"
+
+; CHECK-LABEL: define void @foo
+
+; BE-NEXT: %[[LOW:[0-9]+]] = atomicrmw add ptr getelementptr inbounds (i32, ptr @__profc_foo, i32 1), i32 1 monotonic, align 4
+; LE-NEXT: %[[LOW:[0-9]+]] = atomicrmw add ptr @__profc_foo, i32 1 monotonic, align 4
+; CHECK-NEXT: %[[LOW_UPD:[0-9]+]] = add i32 %[[LOW]], 1
+; CHECK-NEXT: %[[CMP:[0-9]+]] = icmp ult i32 %[[LOW_UPD]], %[[LOW]]
+; CHECK-NEXT: %[[ZEXT:[0-9]+]] = zext i1 %[[CMP]] to i32
+; CHECK-NEXT: %[[INC:[0-9]+]] = add i32 0, %[[ZEXT]]
+; CHECK-NEXT: %pgocount.ifnonzero = icmp ne i32 %[[INC]], 0
+; CHECK-NEXT: br i1 %pgocount.ifnonzero, label %[[BR1:[0-9]+]], label %[[BR2:[0-9]+]]
+
+; CHECK: [[BR1:[0-9]+]]:
+; BE-NEXT: %[[HIGH:[0-9]+]] = atomicrmw add ptr @__profc_foo, i32 %[[INC]] monotonic, align 4
+; LE-NEXT: %[[HIGH:[0-9]+]] = atomicrmw add ptr getelementptr inbounds (i32, ptr @__profc_foo, i32 1), i32 %[[INC]] monotonic, align 4
+; CHECK-NEXT: br label %[[BR2:[0-9]+]]
+
+; CHECK: [[BR2]]:
+; CHECK-NEXT: ret void
+
+define void @foo() {
+  call void @llvm.instrprof.increment(ptr @__profn_foo, i64 0, i32 1, i32 0)
+  ret void
+}
+
+declare void @llvm.instrprof.increment(ptr, i64, i32, i32)


### PR DESCRIPTION
To prevent data races while updating 8-byte branch coverage counters on 32-bit platforms, we atomically update each 4-byte half of each counter as is done in GCC for gcov counters. The value to add to the upper half is calculated as the sum of the upper half of a step value plus the overflow flag from the lower half of the counter. To reduce the performance impact of instrumented code, the upper 4-byte half is updated only if the addition is not zero.