### PR TITLE
[Clang][AMDGPU] Default AMDGPU targets to the minimal runtime

### DIFF
--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -435,9 +435,12 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
   SanitizerMask InvalidTrappingKinds = TrappingKinds & NotAllowedWithTrap;
   const llvm::Triple &Triple = TC.getTriple();
 
-  MinimalRuntime =
+  const bool ExplicitMinimalRuntime =
       Args.hasFlag(options::OPT_fsanitize_minimal_runtime,
-                   options::OPT_fno_sanitize_minimal_runtime, MinimalRuntime);
+                   options::OPT_fno_sanitize_minimal_runtime, false);
+  MinimalRuntime = Args.hasFlag(options::OPT_fsanitize_minimal_runtime,
+                                options::OPT_fno_sanitize_minimal_runtime,
+                                Triple.isGPU());
   HandlerPreserveAllRegs =
       Args.hasFlag(options::OPT_fsanitize_handler_preserve_all_regs,
                    options::OPT_fno_sanitize_handler_preserve_all_regs,
@@ -484,7 +487,7 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
       }
       Add &= ~InvalidTrappingKinds;
 
-      if (MinimalRuntime) {
+      if (ExplicitMinimalRuntime) {
         if (SanitizerMask KindsToDiagnose =
                 Add & NotAllowedWithMinimalRuntime & ~DiagnosedKinds) {
           if (DiagnoseErrors) {
@@ -653,7 +656,7 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
       // Silently discard any unsupported sanitizers implicitly enabled through
       // group expansion.
       Add &= ~InvalidTrappingKinds;
-      if (MinimalRuntime) {
+      if (ExplicitMinimalRuntime) {
         Add &= ~NotAllowedWithMinimalRuntime;
       }
       // NotAllowedWithExecuteOnly is silently discarded on an execute-only
@@ -966,7 +969,7 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
   Stats = Args.hasFlag(options::OPT_fsanitize_stats,
                        options::OPT_fno_sanitize_stats, false);
 
-  if (MinimalRuntime) {
+  if (ExplicitMinimalRuntime) {
     SanitizerMask IncompatibleMask =
         Kinds & ~setGroupBits(CompatibleWithMinimalRuntime);
     if (IncompatibleMask && DiagnoseErrors)

--- a/clang/test/Driver/fsanitize-minimal-runtime.c
+++ b/clang/test/Driver/fsanitize-minimal-runtime.c
@@ -91,3 +91,17 @@
 // RUN: %clang --target=x86_64-linux-gnu -fsanitize=safe-stack -fsanitize-minimal-runtime %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-SAFESTACK-MINIMAL
 // CHECK-SAFESTACK-MINIMAL: "-fsanitize=safe-stack"
 // CHECK-SAFESTACK-MINIMAL: "-fsanitize-minimal-runtime"
+
+// Check that AMDGPU defaults to the minimal runtime.
+// RUN: %clang --target=amdgcn-amd-amdhsa -fsanitize=undefined -nogpulib %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-AMDGPU-MINIMAL
+// CHECK-AMDGPU-MINIMAL: "-fsanitize-minimal-runtime"
+
+// RUN: %clang --target=amdgcn-amd-amdhsa -fsanitize=undefined -fno-sanitize-minimal-runtime -nogpulib %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-AMDGPU-NO-MINIMAL
+// CHECK-AMDGPU-NO-MINIMAL-NOT: "-fsanitize-minimal-runtime"
+
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx900:xnack+ -fsanitize=address -nogpulib %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-AMDGPU-ASAN --implicit-check-not=error:
+// CHECK-AMDGPU-ASAN: "-fsanitize=address"
+// CHECK-AMDGPU-ASAN: "-fsanitize-minimal-runtime"
+
+// RUN: not %clang --target=amdgcn-amd-amdhsa -fsanitize=undefined -fsanitize=vptr -fsanitize-minimal-runtime -nogpulib %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-AMDGPU-EXPLICIT-VPTR
+// CHECK-AMDGPU-EXPLICIT-VPTR: error: invalid argument '-fsanitize=vptr' not allowed with '-fsanitize-minimal-runtime'


### PR DESCRIPTION
Summary:
The GPU can only support this runtime and there is little value in
pretending like we don't. So just make this the default so users don't
need to specify the minimal runtime, especially when combined with using
this on the CPU/GPU at the same time.
