### PR TITLE
[lldb] Make FindDirectNestedType be able to access dynamic types

### DIFF
--- a/lldb/include/lldb/API/SBType.h
+++ b/lldb/include/lldb/API/SBType.h
@@ -256,6 +256,7 @@ public:
                       lldb::DescriptionLevel description_level);
 
   lldb::SBType FindDirectNestedType(const char *name);
+  lldb::SBType FindDirectNestedType(const char *name, bool prefer_dynamic);
 
   lldb::SBType &operator=(const lldb::SBType &rhs);
 

--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -681,7 +681,7 @@ public:
   bool GetDescription(lldb_private::Stream &strm,
                       lldb::DescriptionLevel description_level);
 
-  CompilerType FindDirectNestedType(llvm::StringRef name);
+  CompilerType FindDirectNestedType(llvm::StringRef name, bool prefer_dynamic);
 
 private:
   bool CheckModule(lldb::ModuleSP &module_sp) const;

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -725,9 +725,15 @@ lldb::SBValue SBType::GetTemplateArgumentValue(lldb::SBTarget target,
 SBType SBType::FindDirectNestedType(const char *name) {
   LLDB_INSTRUMENT_VA(this, name);
 
+  return FindDirectNestedType(name, /*prefer_dynamic=*/false);
+}
+
+SBType SBType::FindDirectNestedType(const char *name, bool prefer_dynamic) {
+  LLDB_INSTRUMENT_VA(this, name, prefer_dynamic);
+
   if (!IsValid())
     return SBType();
-  return SBType(m_opaque_sp->FindDirectNestedType(name));
+  return SBType(m_opaque_sp->FindDirectNestedType(name, prefer_dynamic));
 }
 
 SBTypeList::SBTypeList() : m_opaque_up(new TypeListImpl()) {

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1212,11 +1212,11 @@ bool TypeImpl::GetDescription(lldb_private::Stream &strm,
   return true;
 }
 
-CompilerType TypeImpl::FindDirectNestedType(llvm::StringRef name) {
+CompilerType TypeImpl::FindDirectNestedType(llvm::StringRef name,
+                                            bool prefer_dynamic) {
   if (name.empty())
     return CompilerType();
-  return GetCompilerType(/*prefer_dynamic=*/false)
-      .GetDirectNestedTypeWithName(name);
+  return GetCompilerType(prefer_dynamic).GetDirectNestedTypeWithName(name);
 }
 
 bool TypeMemberFunctionImpl::IsValid() {

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -232,6 +232,18 @@ class TypeAndTypeListTestCase(TestBase):
             frame0.EvaluateExpression("task_head").GetType()
         )
 
+        # Check FindDirectNestedType on dynamic values
+        polymorphic = frame0.FindVariable("polymorphic").GetDynamicValue(
+            lldb.eDynamicDontRunTarget
+        )
+        self.DebugSBValue(polymorphic)
+        polymorphic_type = polymorphic.GetType().GetPointeeType()
+        self.DebugSBType(polymorphic_type)
+        self.assertFalse(polymorphic_type.FindDirectNestedType("Nested", False))
+        nested = polymorphic_type.FindDirectNestedType("Nested", True)
+        self.DebugSBType(nested)
+        self.assertEqual(nested.GetName(), "PolymorphicDerived::Nested")
+
         # We'll now get the child member 'id' from 'task_head'.
         id = task_head.GetChildMemberWithName("id")
         self.DebugSBValue(id)

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -232,18 +232,6 @@ class TypeAndTypeListTestCase(TestBase):
             frame0.EvaluateExpression("task_head").GetType()
         )
 
-        # Check FindDirectNestedType on dynamic values
-        polymorphic = frame0.FindVariable("polymorphic").GetDynamicValue(
-            lldb.eDynamicDontRunTarget
-        )
-        self.DebugSBValue(polymorphic)
-        polymorphic_type = polymorphic.GetType().GetPointeeType()
-        self.DebugSBType(polymorphic_type)
-        self.assertFalse(polymorphic_type.FindDirectNestedType("Nested", False))
-        nested = polymorphic_type.FindDirectNestedType("Nested", True)
-        self.DebugSBType(nested)
-        self.assertEqual(nested.GetName(), "PolymorphicDerived::Nested")
-
         # We'll now get the child member 'id' from 'task_head'.
         id = task_head.GetChildMemberWithName("id")
         self.DebugSBValue(id)
@@ -311,6 +299,25 @@ class TypeAndTypeListTestCase(TestBase):
         the_typedef = with_nested_typedef.FindDirectNestedType("TheTypedef")
         self.assertTrue(the_typedef)
         self.assertEqual(the_typedef.GetTypedefedType().GetName(), "int")
+
+    @expectedFailureWindows  # Dynamic type resolution not implemented
+    def test_dynamic_values(self):
+        """Test FindDirectNestedType on dynamic values"""
+
+        self.build()
+        lldbutil.run_to_line_breakpoint(self, lldb.SBFileSpec(self.source), self.line)
+        polymorphic = (
+            self.frame()
+            .FindVariable("polymorphic")
+            .GetDynamicValue(lldb.eDynamicDontRunTarget)
+        )
+        self.DebugSBValue(polymorphic)
+        polymorphic_type = polymorphic.GetType().GetPointeeType()
+        self.DebugSBType(polymorphic_type)
+        self.assertFalse(polymorphic_type.FindDirectNestedType("Nested", False))
+        nested = polymorphic_type.FindDirectNestedType("Nested", True)
+        self.DebugSBType(nested)
+        self.assertEqual(nested.GetName(), "PolymorphicDerived::Nested")
 
     def test_GetByteAlign(self):
         """Exercise SBType::GetByteAlign"""

--- a/lldb/test/API/python_api/type/main.cpp
+++ b/lldb/test/API/python_api/type/main.cpp
@@ -63,6 +63,15 @@ struct WithNestedTypedef {
 };
 WithNestedTypedef::TheTypedef typedefed_value;
 
+struct PolymorphicBase {
+  virtual void foo() {}
+};
+
+struct PolymorphicDerived : PolymorphicBase {
+  struct Nested {};
+  Nested get() { return {}; }
+};
+
 int main (int argc, char const *argv[])
 {
     Task *task_head = new Task(-1, NULL);
@@ -99,6 +108,8 @@ int main (int argc, char const *argv[])
     Pointer<3> pointer;
     PointerInfo<3>::Masks1 mask1 = PointerInfo<3>::Masks1::pointer_mask;
     PointerInfo<3>::Masks2 mask2 = PointerInfo<3>::Masks2::pointer_mask;
+
+    PolymorphicBase *polymorphic = new PolymorphicDerived();
 
     return 0; // Break at this line
 }


### PR DESCRIPTION
Right now, there isn't a way to access the dynamic type of the value. This fixes that.

This is the lazy version of the patch, and I'm not convinced it's the right approach. It seems to me that it may be better/more consistent to make SBType behave similar to SBValue, in that it stores a flag that tells you whether you're looking at the static or dynamic version of the type. But before I set out on that path, I wanted to hear what you think first.