### PR TITLE
[LV] Commonise some of the VPReplicateRecipe cost cases

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -3820,9 +3820,6 @@ InstructionCost VPReplicateRecipe::computeCost(ElementCount VF,
   case Instruction::Xor:
   case Instruction::ICmp:
   case Instruction::FCmp:
-    return getCostForRecipeWithOpcode(getOpcode(), ElementCount::getFixed(1),
-                                      Ctx) *
-           (isSingleScalar() ? 1 : VF.getFixedValue());
   case Instruction::SDiv:
   case Instruction::UDiv:
   case Instruction::SRem:


### PR DESCRIPTION
In VPReplicateRecipe::computeCost we handled the add/sub/mul/etc cases differently to urem/udiv/srem/sdiv. However, in theory there shouldn't be any difference since adds, subs, etc can also end up in a predicated, replicated region and their operands may also need scalarising. In practice, this PR alone doesn't have much effect because most of these costs are still being skipped in favour of the legacy costs. This PR enables follow-on PRs to stop skipping the vplan cost model for more opcodes.

I ran all the tests in Transforms/LoopVectorize and the only test that currently triggers the predicated, replicated code path for the added opcodes is forced_scalar_instr in file Transforms/LoopVectorize/AArch64/force-target-instruction-cost.ll. In addition I ran the LLVM test suite, which didn't seem to expose any cases. However, once we stop skipping the vplan costs for all the extra opcodes we then hit this code path much more often.