### PR TITLE
[Inliner] Use distinct DILocations and cache inlineDebugLoc by OrigDL

### DIFF
--- a/clang/test/DebugInfo/Generic/debug-label-inline.c
+++ b/clang/test/DebugInfo/Generic/debug-label-inline.c
@@ -25,4 +25,4 @@ int f2(void) {
 // CHECK: [[ELEMENTS]] = !{{{.*}}, [[LABEL_METADATA]]}
 // CHECK: [[LABEL_METADATA]] = !DILabel({{.*}}, name: "top", {{.*}}, line: 8, column: 1)
 // CHECK: [[INLINEDAT:!.*]] = distinct !DILocation(line: 18,
-// CHECK: [[LABEL_LOCATION]] = !DILocation(line: 8, {{.*}}, inlinedAt: [[INLINEDAT]])
+// CHECK: [[LABEL_LOCATION]] = distinct !DILocation(line: 8, {{.*}}, inlinedAt: [[INLINEDAT]])

--- a/llvm/lib/IR/DebugLoc.cpp
+++ b/llvm/lib/IR/DebugLoc.cpp
@@ -136,8 +136,9 @@ DebugLoc DebugLoc::appendInlinedAt(const DebugLoc &DL, DILocation *InlinedAt,
   // Gather all the inlined-at nodes.
   while (DILocation *IA = CurInlinedAt->getInlinedAt()) {
     // Skip any we've already built nodes for.
-    if (auto *Found = Cache[IA]) {
-      Last = cast<DILocation>(Found);
+    auto It = Cache.find(IA);
+    if (It != Cache.end() && It->second) {
+      Last = cast<DILocation>(It->second);
       break;
     }
 

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -1938,7 +1938,10 @@ inlineDebugLoc(DebugLoc OrigDL, DILocation *InlinedAt, LLVMContext &Ctx,
                DenseMap<const MDNode *, MDNode *> &InlineLocCache) {
   if (MDNode *Cached = InlineLocCache.lookup(OrigDL.get()))
     return DebugLoc(cast<DILocation>(Cached));
-  auto IA = DebugLoc::appendInlinedAt(OrigDL, InlinedAt, Ctx, IANodes);
+  DILocation *IA =
+      OrigDL->getInlinedAt()
+          ? DebugLoc::appendInlinedAt(OrigDL, InlinedAt, Ctx, IANodes).get()
+          : InlinedAt;
   DILocation *Result = DILocation::getDistinct(
       Ctx, OrigDL.getLine(), OrigDL.getCol(), OrigDL.getScope(), IA,
       OrigDL.isImplicitCode(), OrigDL->getAtomGroup(), OrigDL->getAtomRank());

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -1932,12 +1932,12 @@ static bool allocaWouldBeStaticInEntry(const AllocaInst *AI ) {
 
 /// Returns a DebugLoc for a new DILocation which is a clone of \p OrigDL
 /// inlined at \p InlinedAt. \p IANodes is an inlined-at cache.
-static DebugLoc
-inlineDebugLoc(DebugLoc OrigDL, DILocation *InlinedAt, LLVMContext &Ctx,
-               DenseMap<const MDNode *, MDNode *> &IANodes,
-               DenseMap<const MDNode *, MDNode *> &InlineLocCache) {
-  if (MDNode *Cached = InlineLocCache.lookup(OrigDL.get()))
-    return DebugLoc(cast<DILocation>(Cached));
+static DebugLoc inlineDebugLoc(
+    DebugLoc OrigDL, DILocation *InlinedAt, LLVMContext &Ctx,
+    DenseMap<const MDNode *, MDNode *> &IANodes,
+    SmallDenseMap<const DILocation *, DILocation *, 16> &InlineLocs) {
+  if (DILocation *Cached = InlineLocs.lookup(OrigDL.get()))
+    return DebugLoc(Cached);
   DILocation *IA =
       OrigDL->getInlinedAt()
           ? DebugLoc::appendInlinedAt(OrigDL, InlinedAt, Ctx, IANodes).get()
@@ -1945,7 +1945,7 @@ inlineDebugLoc(DebugLoc OrigDL, DILocation *InlinedAt, LLVMContext &Ctx,
   DILocation *Result = DILocation::getDistinct(
       Ctx, OrigDL.getLine(), OrigDL.getCol(), OrigDL.getScope(), IA,
       OrigDL.isImplicitCode(), OrigDL->getAtomGroup(), OrigDL->getAtomRank());
-  InlineLocCache[OrigDL.get()] = Result;
+  InlineLocs[OrigDL.get()] = Result;
   return DebugLoc(Result);
 }
 
@@ -1976,7 +1976,7 @@ static void fixupLineNumbers(Function *Fn, Function::iterator FI,
   // this every instruction's inlined-at chain would become distinct from each
   // other.
   DenseMap<const MDNode *, MDNode *> IANodes;
-  DenseMap<const MDNode *, MDNode *> InlineLocCache;
+  SmallDenseMap<const DILocation *, DILocation *, 16> InlineLocs;
 
   // Check if we are not generating inline line tables and want to use
   // the call site location instead.
@@ -1987,9 +1987,9 @@ static void fixupLineNumbers(Function *Fn, Function::iterator FI,
     // Loop metadata needs to be updated so that the start and end locs
     // reference inlined-at locations.
     auto updateLoopInfoLoc = [&Ctx, &InlinedAtNode, &IANodes,
-                              &InlineLocCache](Metadata *MD) -> Metadata * {
+                              &InlineLocs](Metadata *MD) -> Metadata * {
       if (auto *Loc = dyn_cast_or_null<DILocation>(MD))
-        return inlineDebugLoc(Loc, InlinedAtNode, Ctx, IANodes, InlineLocCache)
+        return inlineDebugLoc(Loc, InlinedAtNode, Ctx, IANodes, InlineLocs)
             .get();
       return MD;
     };
@@ -1998,7 +1998,7 @@ static void fixupLineNumbers(Function *Fn, Function::iterator FI,
     if (!NoInlineLineTables)
       if (DebugLoc DL = I.getDebugLoc()) {
         DebugLoc IDL = inlineDebugLoc(DL, InlinedAtNode, I.getContext(),
-                                      IANodes, InlineLocCache);
+                                      IANodes, InlineLocs);
         I.setDebugLoc(IDL);
         return;
       }
@@ -2036,7 +2036,7 @@ static void fixupLineNumbers(Function *Fn, Function::iterator FI,
     DebugLoc DL = DVR->getDebugLoc();
     DebugLoc IDL = inlineDebugLoc(DL, InlinedAtNode,
                                   DVR->getMarker()->getParent()->getContext(),
-                                  IANodes, InlineLocCache);
+                                  IANodes, InlineLocs);
     DVR->setDebugLoc(IDL);
   };
 

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -1932,13 +1932,18 @@ static bool allocaWouldBeStaticInEntry(const AllocaInst *AI ) {
 
 /// Returns a DebugLoc for a new DILocation which is a clone of \p OrigDL
 /// inlined at \p InlinedAt. \p IANodes is an inlined-at cache.
-static DebugLoc inlineDebugLoc(DebugLoc OrigDL, DILocation *InlinedAt,
-                               LLVMContext &Ctx,
-                               DenseMap<const MDNode *, MDNode *> &IANodes) {
+static DebugLoc
+inlineDebugLoc(DebugLoc OrigDL, DILocation *InlinedAt, LLVMContext &Ctx,
+               DenseMap<const MDNode *, MDNode *> &IANodes,
+               DenseMap<const MDNode *, MDNode *> &InlineLocCache) {
+  if (MDNode *Cached = InlineLocCache.lookup(OrigDL.get()))
+    return DebugLoc(cast<DILocation>(Cached));
   auto IA = DebugLoc::appendInlinedAt(OrigDL, InlinedAt, Ctx, IANodes);
-  return DILocation::get(Ctx, OrigDL.getLine(), OrigDL.getCol(),
-                         OrigDL.getScope(), IA, OrigDL.isImplicitCode(),
-                         OrigDL->getAtomGroup(), OrigDL->getAtomRank());
+  DILocation *Result = DILocation::getDistinct(
+      Ctx, OrigDL.getLine(), OrigDL.getCol(), OrigDL.getScope(), IA,
+      OrigDL.isImplicitCode(), OrigDL->getAtomGroup(), OrigDL->getAtomRank());
+  InlineLocCache[OrigDL.get()] = Result;
+  return DebugLoc(Result);
 }
 
 /// Update inlined instructions' line numbers to
@@ -1968,6 +1973,7 @@ static void fixupLineNumbers(Function *Fn, Function::iterator FI,
   // this every instruction's inlined-at chain would become distinct from each
   // other.
   DenseMap<const MDNode *, MDNode *> IANodes;
+  DenseMap<const MDNode *, MDNode *> InlineLocCache;
 
   // Check if we are not generating inline line tables and want to use
   // the call site location instead.
@@ -1977,18 +1983,19 @@ static void fixupLineNumbers(Function *Fn, Function::iterator FI,
   auto UpdateInst = [&](Instruction &I) {
     // Loop metadata needs to be updated so that the start and end locs
     // reference inlined-at locations.
-    auto updateLoopInfoLoc = [&Ctx, &InlinedAtNode,
-                              &IANodes](Metadata *MD) -> Metadata * {
+    auto updateLoopInfoLoc = [&Ctx, &InlinedAtNode, &IANodes,
+                              &InlineLocCache](Metadata *MD) -> Metadata * {
       if (auto *Loc = dyn_cast_or_null<DILocation>(MD))
-        return inlineDebugLoc(Loc, InlinedAtNode, Ctx, IANodes).get();
+        return inlineDebugLoc(Loc, InlinedAtNode, Ctx, IANodes, InlineLocCache)
+            .get();
       return MD;
     };
     updateLoopMetadataDebugLocations(I, updateLoopInfoLoc);
 
     if (!NoInlineLineTables)
       if (DebugLoc DL = I.getDebugLoc()) {
-        DebugLoc IDL =
-            inlineDebugLoc(DL, InlinedAtNode, I.getContext(), IANodes);
+        DebugLoc IDL = inlineDebugLoc(DL, InlinedAtNode, I.getContext(),
+                                      IANodes, InlineLocCache);
         I.setDebugLoc(IDL);
         return;
       }
@@ -2024,9 +2031,9 @@ static void fixupLineNumbers(Function *Fn, Function::iterator FI,
       return;
     }
     DebugLoc DL = DVR->getDebugLoc();
-    DebugLoc IDL =
-        inlineDebugLoc(DL, InlinedAtNode,
-                       DVR->getMarker()->getParent()->getContext(), IANodes);
+    DebugLoc IDL = inlineDebugLoc(DL, InlinedAtNode,
+                                  DVR->getMarker()->getParent()->getContext(),
+                                  IANodes, InlineLocCache);
     DVR->setDebugLoc(IDL);
   };
 

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/inline/id.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/inline/id.ll
@@ -21,8 +21,8 @@
 ; CHECK-NEXT: #dbg_assign(i32 5, [[val]], !DIExpression(), [[ID_1]], ptr %val.i1, !DIExpression(), [[dl_inline_1:![0-9]+]]
 ;
 ; CHECK-DAG: [[val]] = !DILocalVariable(name: "val",
-; CHECK-DAG: [[dl_inline_0]] = !DILocation({{.*}}inlinedAt
-; CHECK-DAG: [[dl_inline_1]] = !DILocation({{.*}}inlinedAt
+; CHECK-DAG: [[dl_inline_0]] = distinct !DILocation({{.*}}inlinedAt
+; CHECK-DAG: [[dl_inline_1]] = distinct !DILocation({{.*}}inlinedAt
 ; CHECK-DAG: [[ID_0]] = distinct !DIAssignID()
 ; CHECK-DAG: [[ID_1]] = distinct !DIAssignID()
 

--- a/llvm/test/DebugInfo/Generic/inline-dbg-values.ll
+++ b/llvm/test/DebugInfo/Generic/inline-dbg-values.ll
@@ -53,9 +53,9 @@
 ; CHECK-DAG: ![[TESTSP:[0-9]+]] = distinct !DISubprogram(name: "test",
 ; CHECK-DAG: ![[KVAR]] = !DILocalVariable(name: "k",
 ; CHECK-DAG: ![[K2VAR]] = !DILocalVariable(name: "k2",
-; CHECK-DAG: ![[KLINE]] = !DILocation(line: 4, scope: ![[TESTSP]], inlinedAt: ![[INLINESITE:[0-9]+]])
+; CHECK-DAG: ![[KLINE]] = distinct !DILocation(line: 4, scope: ![[TESTSP]], inlinedAt: ![[INLINESITE:[0-9]+]])
 ; CHECK-DAG: ![[INLINESITE]] = distinct !DILocation(line: 14, scope: ![[INLINESITEBLOCK]])
-; CHECK-DAG: ![[GLINE]] = !DILocation(line: 5, scope: ![[TESTSP]], inlinedAt: ![[INLINESITE:[0-9]+]])
+; CHECK-DAG: ![[GLINE]] = distinct !DILocation(line: 5, scope: ![[TESTSP]], inlinedAt: ![[INLINESITE:[0-9]+]])
 
 target triple = "x86_64--"
 

--- a/llvm/test/DebugInfo/Generic/inline-debug-info-multiret.ll
+++ b/llvm/test/DebugInfo/Generic/inline-debug-info-multiret.ll
@@ -11,7 +11,7 @@
 ; The branch instruction has the source location of line 9 and its inlined location
 ; has the source location of line 14.
 ; CHECK: ![[INL:[0-9]+]] = distinct !DILocation(line: 14, scope: {{.*}})
-; CHECK: ![[MD]] = !DILocation(line: 9, scope: {{.*}}, inlinedAt: ![[INL]])
+; CHECK: ![[MD]] = distinct !DILocation(line: 9, scope: {{.*}}, inlinedAt: ![[INL]])
 
 ; ModuleID = 'test.cpp'
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"

--- a/llvm/test/DebugInfo/Generic/inline-debug-info.ll
+++ b/llvm/test/DebugInfo/Generic/inline-debug-info.ll
@@ -32,7 +32,7 @@
 ; The branch instruction has the source location of line 9 and its inlined location
 ; has the source location of line 14.
 ; CHECK: [[INL:![0-9]*]] = distinct !DILocation(line: 14, scope: {{.*}})
-; CHECK: [[MD]] = !DILocation(line: 9, scope: {{.*}}, inlinedAt: [[INL]])
+; CHECK: [[MD]] = distinct !DILocation(line: 9, scope: {{.*}}, inlinedAt: [[INL]])
 
 ; ModuleID = 'test.cpp'
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"

--- a/llvm/test/DebugInfo/Generic/inline-no-debug-info.ll
+++ b/llvm/test/DebugInfo/Generic/inline-no-debug-info.ll
@@ -24,7 +24,7 @@
 ; CHECK-DAG: [[A]] = !DILocation(line: 4, scope: !{{[0-9]+}})
 
 ; Debug location of the inlined code.
-; CHECK-DAG: [[B]] = !DILocation(line: 2, scope: !{{[0-9]+}}, inlinedAt: [[A_INL:![0-9]*]])
+; CHECK-DAG: [[B]] = distinct !DILocation(line: 2, scope: !{{[0-9]+}}, inlinedAt: [[A_INL:![0-9]*]])
 ; CHECK-DAG: [[A_INL]] = distinct !DILocation(line: 4, scope: !{{[0-9]+}})
 
 

--- a/llvm/test/DebugInfo/KeyInstructions/Generic/inline.ll
+++ b/llvm/test/DebugInfo/KeyInstructions/Generic/inline.ll
@@ -9,8 +9,8 @@
 ; CHECK-NEXT: store i32 %add.i, ptr %x.i, align 4, !dbg [[G1R1:!.*]]
 
 ; CHECK: distinct !DISubprogram(name: "g", {{.*}}keyInstructions: true)
-; CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
-; CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+; CHECK: [[G1R2]] = distinct !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+; CHECK: [[G1R1]] = distinct !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
 
 define hidden void @_Z1fi(i32 noundef %a) !dbg !11 {
 entry:

--- a/llvm/test/Transforms/CodeExtractor/PartialInlineDebug.ll
+++ b/llvm/test/Transforms/CodeExtractor/PartialInlineDebug.ll
@@ -69,9 +69,9 @@ entry:
 ; CHECK: br label %if.then, !dbg ![[DBG6:[0-9]+]]
 
 ; CHECK: ![[DBG1]] = !DILocation(line: 10, column: 7,
-; CHECK: ![[DBG2]] = !DILocation(line: 10, column: 7,
+; CHECK: ![[DBG2]] = distinct !DILocation(line: 10, column: 7,
 ; CHECK: ![[DBG3]] = !DILocation(line: 110, column: 17,
-; CHECK: ![[DBG4]] = !DILocation(line: 110, column: 17,
+; CHECK: ![[DBG4]] = distinct !DILocation(line: 110, column: 17,
 ; CHECK: ![[DBG5]] = !DILocation(line: 110, column: 17,
 ; CHECK: ![[DBG6]] = !DILocation(line: 10, column: 7,
 

--- a/llvm/test/Transforms/CodeExtractor/PartialInlineVarArgsDebug.ll
+++ b/llvm/test/Transforms/CodeExtractor/PartialInlineVarArgsDebug.ll
@@ -31,7 +31,7 @@ entry:
 ; CHECK: br label %if.then, !dbg ![[DBG3:[0-9]+]]
 
 ; CHECK: ![[DBG1]] = !DILocation(line: 10, column: 7,
-; CHECK: ![[DBG2]] = !DILocation(line: 10, column: 7,
+; CHECK: ![[DBG2]] = distinct !DILocation(line: 10, column: 7,
 ; CHECK: ![[DBG3]] = !DILocation(line: 10, column: 7,
 
 

--- a/llvm/test/Transforms/Inline/X86/inline-landing-pad.ll
+++ b/llvm/test/Transforms/Inline/X86/inline-landing-pad.ll
@@ -66,7 +66,7 @@ bb:
 ; CHECK: [[DBG4]] = distinct !DISubprogram(name: "widget", linkageName: "widget", scope: [[META1]], file: [[META1]], line: 87, type: [[META5:![0-9]+]], scopeLine: 88, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: [[META0]], retainedNodes: [[META2]])
 ; CHECK: [[META5]] = distinct !DISubroutineType(types: [[META6:![0-9]+]])
 ; CHECK: [[META6]] = !{null}
-; CHECK: [[DBG7]] = !DILocation(line: 9, column: 7, scope: [[DBG8]], inlinedAt: [[META9:![0-9]+]])
+; CHECK: [[DBG7]] = distinct !DILocation(line: 9, column: 7, scope: [[DBG8]], inlinedAt: [[META9:![0-9]+]])
 ; CHECK: [[DBG8]] = distinct !DISubprogram(name: "baz", linkageName: "baz", scope: [[META1]], file: [[META1]], line: 7, type: [[META5]], scopeLine: 8, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: [[META0]], retainedNodes: [[META2]])
 ; CHECK: [[META9]] = distinct !DILocation(line: 99, column: 17, scope: [[DBG4]])
 ; CHECK: [[DBG10]] = !DILocation(line: 9, column: 7, scope: [[DBG8]])

--- a/llvm/test/Transforms/Inline/debug-invoke.ll
+++ b/llvm/test/Transforms/Inline/debug-invoke.ll
@@ -5,7 +5,7 @@
 ; CHECK: invoke void @test()
 ; CHECK-NEXT: to label {{.*}} unwind label {{.*}}, !dbg [[INL_LOC:![0-9]+]]
 ; CHECK: [[SP:.*]] = distinct !DISubprogram(
-; CHECK: [[INL_LOC]] = !DILocation(line: 1, scope: [[SP]], inlinedAt: [[INL_AT:.*]])
+; CHECK: [[INL_LOC]] = distinct !DILocation(line: 1, scope: [[SP]], inlinedAt: [[INL_AT:.*]])
 ; CHECK: [[INL_AT]] = distinct !DILocation(line: 2, scope: [[SP]])
 
 declare void @test()

--- a/llvm/test/Transforms/Inline/dilocation-loop-metadata-update.ll
+++ b/llvm/test/Transforms/Inline/dilocation-loop-metadata-update.ll
@@ -75,9 +75,9 @@ entry:
 ; CHECK: [[META16]] = !{!"llvm.loop.unroll.count", i32 1}
 ; CHECK: [[DBG17]] = distinct !DISubprogram(name: "f", scope: [[META1]], file: [[META1]], line: 9, type: [[META4]], scopeLine: 9, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: [[META0]])
 ; CHECK: [[LOOP18]] = distinct !{[[LOOP18]], [[META19:![0-9]+]], [[META21:![0-9]+]], [[META9]], [[META10]], [[META22:![0-9]+]]}
-; CHECK: [[META19]] = !DILocation(line: 6, column: 3, scope: [[DBG3]], inlinedAt: [[META20:![0-9]+]])
+; CHECK: [[META19]] = distinct !DILocation(line: 6, column: 3, scope: [[DBG3]], inlinedAt: [[META20:![0-9]+]])
 ; CHECK: [[META20]] = distinct !DILocation(line: 9, column: 12, scope: [[DBG17]])
-; CHECK: [[META21]] = !DILocation(line: 7, column: 22, scope: [[DBG3]], inlinedAt: [[META20]])
+; CHECK: [[META21]] = distinct !DILocation(line: 7, column: 22, scope: [[DBG3]], inlinedAt: [[META20]])
 ; CHECK: [[META22]] = !{!"llvm.loop.distribute.followup_all", [[META19]], [[META21]], [[META9]], [[META12]], [[META13]], [[META23:![0-9]+]]}
 ; CHECK: [[META23]] = !{!"llvm.loop.vectorize.followup_all", [[META19]], [[META21]], [[META9]], [[META15]], [[META16]]}
 ;.

--- a/llvm/test/Transforms/Inline/inline_dbg_declare.ll
+++ b/llvm/test/Transforms/Inline/inline_dbg_declare.ll
@@ -93,5 +93,5 @@ attributes #1 = { nounwind readnone }
 ; CHECK: [[FOO:![0-9]+]] = distinct !DISubprogram(name: "foo",
 ; CHECK: [[m23]] = !DILocalVariable(name: "x", arg: 1, scope: [[FOO]]
 ; CHECK: [[BAR:![0-9]+]] = distinct !DISubprogram(name: "bar",
-; CHECK: [[m24]] = !DILocation(line: 1, column: 17, scope: [[FOO]], inlinedAt: [[CALL_SITE:![0-9]+]])
+; CHECK: [[m24]] = distinct !DILocation(line: 1, column: 17, scope: [[FOO]], inlinedAt: [[CALL_SITE:![0-9]+]])
 ; CHECK: [[CALL_SITE]] = distinct !DILocation(line: 8, column: 14, scope: [[BAR]])

--- a/llvm/test/Transforms/SafeStack/ARM/debug.ll
+++ b/llvm/test/Transforms/SafeStack/ARM/debug.ll
@@ -12,7 +12,7 @@ target triple = "armv7-pc-linux-android"
 ; void Capture(char*x);
 ; void f() { char c[16]; Capture(c); }
 
-; CHECK: !36 = !DILocation(line: 3, column: 11, scope: !17, inlinedAt: !37)
+; CHECK: !36 = distinct !DILocation(line: 3, column: 11, scope: !17, inlinedAt: !37)
 ; CHECK: !37 = distinct !DILocation(line: 6, scope: !27)
 
 @addr = common local_unnamed_addr global ptr null, align 4, !dbg !0

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-emit-inline.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-emit-inline.ll
@@ -50,16 +50,16 @@ define dso_local i32 @entry() !dbg !14 {
 
 ; CHECK-IL: ![[#SCOPE1:]] = distinct !DISubprogram(name: "foo2"
 ; CHECK-IL: ![[#SCOPE2:]] = distinct !DISubprogram(name: "foo"
-; CHECK-IL: ![[#DL1]] = !DILocation(line: 3, column: 1,  scope: ![[#SCOPE1]], inlinedAt: ![[#INL1:]])
+; CHECK-IL: ![[#DL1]] = distinct !DILocation(line: 3, column: 1,  scope: ![[#SCOPE1]], inlinedAt: ![[#INL1:]])
 ; CHECK-IL: ![[#INL1]] = distinct !DILocation(line: 7, column: 3, scope: ![[#BL1:]])
 ;; A discriminator of 455082007 which is 0x1b200017 in hexdecimal, stands for a direct call probe
 ;; with an index of 2 and a scale of 100%.
 ; CHECK-IL: ![[#BL1]] = !DILexicalBlockFile(scope: ![[#SCOPE2]], file: !1, discriminator: 455082007)
 ; CHECK-IL: ![[#SCOPE3:]] = distinct !DISubprogram(name: "entry"
-; CHECK-IL: ![[#DL2]] = !DILocation(line: 7, column: 3,  scope: ![[#SCOPE2]], inlinedAt: ![[#INL2:]])
+; CHECK-IL: ![[#DL2]] = distinct !DILocation(line: 7, column: 3,  scope: ![[#SCOPE2]], inlinedAt: ![[#INL2:]])
 ; CHECK-IL: ![[#INL2]] = distinct !DILocation(line: 11, column: 3, scope: ![[#BL2:]])
 ; CHECK-IL: ![[#BL2]] = !DILexicalBlockFile(scope: ![[#SCOPE3]], file: !1, discriminator: 455082007)
-; CHECK-IL: ![[#DL3]] = !DILocation(line: 3, column: 1,  scope: ![[#SCOPE1]], inlinedAt: ![[#INL3:]])
+; CHECK-IL: ![[#DL3]] = distinct !DILocation(line: 3, column: 1,  scope: ![[#SCOPE1]], inlinedAt: ![[#INL3:]])
 ; CHECK-IL: ![[#INL3]] = distinct !DILocation(line: 7, column: 3,  scope: ![[#BL1]], inlinedAt: ![[#INL2]])
 
 


### PR DESCRIPTION
Found while profiling clang compiling `SLPVectorizer.cpp`.
The call chain `DILocation::get` -> `DILocation::getImpl` -> `llvm::getUniqued` caused lots of expensive `DenseSet` `find_as` and `grow` operations due to the cache being really inefficient. Switch to `DILocation::getDistinct` and cache `inlineDebugLoc` by `OrigDL` for a more efficient cache.
This resulted in a ~55% reduction in `fixupLineNumbers` samples when compiling `SLPVectorizer.cpp` with `-O2 -g`.
```text
Benchmark 1 (10 runs): old compiling SLPVectorizer.cpp
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          30.1s  ± 47.8ms    30.1s  … 30.2s           0 ( 0%)        0%
  peak_rss           1.11GB ±  222KB    1.10GB … 1.11GB          0 ( 0%)        0%
  cpu_cycles          148G  ±  228M      148G  …  149G           0 ( 0%)        0%
  instructions        201G  ± 44.5M      201G  …  201G           0 ( 0%)        0%
  cache_references   3.53G  ± 6.33M     3.52G  … 3.54G           0 ( 0%)        0%
  cache_misses        596M  ± 2.23M      594M  …  602M           1 (10%)        0%
  branch_misses      1.42G  ±  482K     1.42G  … 1.42G           1 (10%)        0%
Benchmark 2 (11 runs): new compiling SLPVectorizer.cpp
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          29.9s  ± 54.8ms    29.8s  … 30.0s           0 ( 0%)          -  0.8% ±  0.2%
  peak_rss           1.09GB ±  210KB    1.09GB … 1.09GB          0 ( 0%)        ⚡-  1.6% ±  0.0%
  cpu_cycles          147G  ±  237M      147G  …  147G           0 ( 0%)          -  0.8% ±  0.1%
  instructions        200G  ± 28.8M      200G  …  200G           0 ( 0%)          -  0.2% ±  0.0%
  cache_references   3.47G  ± 3.84M     3.46G  … 3.47G           0 ( 0%)        ⚡-  1.8% ±  0.1%
  cache_misses        561M  ± 1.74M      559M  …  565M           0 ( 0%)        ⚡-  5.9% ±  0.3%
  branch_misses      1.42G  ±  738K     1.42G  … 1.42G           0 ( 0%)          -  0.3% ±  0.0%
```
https://llvm-compile-time-tracker.com/compare.php?from=f999ca3037dfb43fc9b14612f03708a6435fab5e&to=4206e4d89ae7424cc3e8f61911ebc29a03bd4bea&stat=instructions%3Au
For stage1-ReleaseLTO-g this seems to be an improvement up to -0.5% without any obvious regressions.