### PR TITLE
[LLVM][CodeGen][SVE] Add ElementSize information to fp compare, continuous/replicating load and store instructions

### DIFF
--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -6230,6 +6230,7 @@ class sve_fp_3op_p_pd<bits<2> sz, bits<3> opc, string asm, PPRRegOp pprty,
   let Inst{4}     = opc{0};
   let Inst{3-0}   = Pd;
 
+  let ElementSize = zprty.ElementSize;
   let hasSideEffects = 0;
   let mayRaiseFPException = 1;
 }
@@ -6289,6 +6290,7 @@ class sve_fp_2op_p_pd<bits<2> sz, bits<3> opc, string asm, PPRRegOp pprty,
   let Inst{4}     = opc{0};
   let Inst{3-0}   = Pd;
 
+  let ElementSize = zprty.ElementSize;
   let hasSideEffects = 0;
   let mayRaiseFPException = 1;
 }
@@ -6831,7 +6833,7 @@ multiclass sve_int_bin_cons_shift_imm_right<bits<2> opc, string asm,
 //===----------------------------------------------------------------------===//
 
 class sve_mem_cst_si<bits<2> msz, bits<2> esz, string asm,
-                     RegisterOperand VecList>
+                     RegisterOperand VecList, ZPRRegOp zprty>
 : I<(outs), (ins VecList:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, simm4s1:$imm4),
   asm, "\t$Zt, $Pg, [$Rn, $imm4, mul vl]",
   "",
@@ -6850,6 +6852,7 @@ class sve_mem_cst_si<bits<2> msz, bits<2> esz, string asm,
   let Inst{9-5}   = Rn;
   let Inst{4-0}   = Zt;
 
+  let ElementSize = zprty.ElementSize;
   let hasSideEffects = 0;
   let mayStore = 1;
 }
@@ -6857,7 +6860,7 @@ class sve_mem_cst_si<bits<2> msz, bits<2> esz, string asm,
 multiclass sve_mem_cst_si<bits<2> msz, bits<2> esz, string asm,
                           RegisterOperand listty, ZPRRegOp zprty>
 {
-  def NAME : sve_mem_cst_si<msz, esz, asm, listty>;
+  def NAME : sve_mem_cst_si<msz, esz, asm, listty, zprty>;
 
   def : InstAlias<asm # "\t$Zt, $Pg, [$Rn, $imm4, mul vl]",
                  (!cast<Instruction>(NAME) zprty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, simm4s1:$imm4), 0>;
@@ -6981,7 +6984,8 @@ class sve_mem_128b_est_ss<bits<2> nregs, RegisterOperand VecList,
 
 
 class sve_mem_cst_ss_base<bits<4> dtype, string asm,
-                          RegisterOperand listty, RegisterOperand gprty>
+                          RegisterOperand listty, ZPRRegOp zprty,
+                          RegisterOperand gprty>
 : I<(outs), (ins listty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, gprty:$Rm),
   asm, "\t$Zt, $Pg, [$Rn, $Rm]",
   "",
@@ -6998,6 +7002,7 @@ class sve_mem_cst_ss_base<bits<4> dtype, string asm,
   let Inst{9-5}   = Rn;
   let Inst{4-0}   = Zt;
 
+  let ElementSize = zprty.ElementSize;
   let hasSideEffects = 0;
   let mayStore = 1;
 }
@@ -7005,13 +7010,14 @@ class sve_mem_cst_ss_base<bits<4> dtype, string asm,
 multiclass sve_mem_cst_ss<bits<4> dtype, string asm,
                           RegisterOperand listty, ZPRRegOp zprty,
                           RegisterOperand gprty> {
-  def NAME : sve_mem_cst_ss_base<dtype, asm, listty, gprty>;
+  def NAME : sve_mem_cst_ss_base<dtype, asm, listty, zprty, gprty>;
 
   def : InstAlias<asm # "\t$Zt, $Pg, [$Rn, $Rm]",
                   (!cast<Instruction>(NAME) zprty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, gprty:$Rm), 0>;
 }
 
-class sve_mem_cstnt_si<bits<2> msz, string asm, RegisterOperand VecList>
+class sve_mem_cstnt_si<bits<2> msz, string asm, RegisterOperand VecList,
+                       ZPRRegOp zprty>
 : I<(outs), (ins VecList:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, simm4s1:$imm4),
   asm, "\t$Zt, $Pg, [$Rn, $imm4, mul vl]",
   "",
@@ -7029,13 +7035,14 @@ class sve_mem_cstnt_si<bits<2> msz, string asm, RegisterOperand VecList>
   let Inst{9-5}   = Rn;
   let Inst{4-0}   = Zt;
 
+  let ElementSize = zprty.ElementSize;
   let hasSideEffects = 0;
   let mayStore = 1;
 }
 
 multiclass sve_mem_cstnt_si<bits<2> msz, string asm, RegisterOperand listty,
                             ZPRRegOp zprty> {
-  def NAME : sve_mem_cstnt_si<msz, asm, listty>;
+  def NAME : sve_mem_cstnt_si<msz, asm, listty, zprty>;
 
   def : InstAlias<asm # "\t$Zt, $Pg, [$Rn]",
                   (!cast<Instruction>(NAME) zprty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, 0), 0>;
@@ -7046,7 +7053,7 @@ multiclass sve_mem_cstnt_si<bits<2> msz, string asm, RegisterOperand listty,
 }
 
 class sve_mem_cstnt_ss_base<bits<2> msz, string asm, RegisterOperand listty,
-                            RegisterOperand gprty>
+                            ZPRRegOp zprty, RegisterOperand gprty>
 : I<(outs), (ins listty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, gprty:$Rm),
   asm, "\t$Zt, $Pg, [$Rn, $Rm]",
   "",
@@ -7064,13 +7071,14 @@ class sve_mem_cstnt_ss_base<bits<2> msz, string asm, RegisterOperand listty,
   let Inst{9-5}   = Rn;
   let Inst{4-0}   = Zt;
 
+  let ElementSize = zprty.ElementSize;
   let hasSideEffects = 0;
   let mayStore = 1;
 }
 
 multiclass sve_mem_cstnt_ss<bits<2> msz, string asm, RegisterOperand listty,
                             ZPRRegOp zprty, RegisterOperand gprty> {
-  def NAME : sve_mem_cstnt_ss_base<msz, asm, listty, gprty>;
+  def NAME : sve_mem_cstnt_ss_base<msz, asm, listty, zprty, gprty>;
 
   def : InstAlias<asm # "\t$Zt, $Pg, [$Rn, $Rm]",
                  (!cast<Instruction>(NAME) zprty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, gprty:$Rm), 0>;
@@ -8124,7 +8132,7 @@ multiclass sve_int_perm_compact_bh<string asm, SDPatternOperator op> {
 //===----------------------------------------------------------------------===//
 
 class sve_mem_cld_si_base<bits<4> dtype, bit nf, string asm,
-                          RegisterOperand VecList>
+                          RegisterOperand VecList, ZPRRegOp zprty>
 : I<(outs VecList:$Zt), (ins PPR3bAny:$Pg, GPR64sp:$Rn, simm4s1:$imm4),
   asm, "\t$Zt, $Pg/z, [$Rn, $imm4, mul vl]",
   "",
@@ -8143,6 +8151,7 @@ class sve_mem_cld_si_base<bits<4> dtype, bit nf, string asm,
   let Inst{4-0}   = Zt;
 
   let Defs = !if(nf, [FFR], []);
+  let ElementSize = zprty.ElementSize;
   let Uses = !if(nf, [FFR], []);
   let hasSideEffects = nf;
   let mayLoad = 1;
@@ -8150,7 +8159,7 @@ class sve_mem_cld_si_base<bits<4> dtype, bit nf, string asm,
 
 multiclass sve_mem_cld_si_base<bits<4> dtype, bit nf, string asm,
                                RegisterOperand listty, ZPRRegOp zprty> {
-  def NAME : sve_mem_cld_si_base<dtype, nf, asm, listty>;
+  def NAME : sve_mem_cld_si_base<dtype, nf, asm, listty, zprty>;
 
   def : InstAlias<asm # "\t$Zt, $Pg/z, [$Rn]",
                   (!cast<Instruction>(NAME) zprty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, 0), 0>;
@@ -8168,7 +8177,8 @@ multiclass sve_mem_cldnf_si<bits<4> dtype, string asm, RegisterOperand listty,
                             ZPRRegOp zprty>
 : sve_mem_cld_si_base<dtype, 1, asm, listty, zprty>;
 
-class sve_mem_cldnt_si_base<bits<2> msz, string asm, RegisterOperand VecList>
+class sve_mem_cldnt_si_base<bits<2> msz, string asm, RegisterOperand VecList,
+                            ZPRRegOp zprty>
 : I<(outs VecList:$Zt), (ins PPR3bAny:$Pg, GPR64sp:$Rn, simm4s1:$imm4),
   asm, "\t$Zt, $Pg/z, [$Rn, $imm4, mul vl]",
   "",
@@ -8186,13 +8196,14 @@ class sve_mem_cldnt_si_base<bits<2> msz, string asm, RegisterOperand VecList>
   let Inst{9-5}   = Rn;
   let Inst{4-0}   = Zt;
 
+  let ElementSize = zprty.ElementSize;
   let hasSideEffects = 0;
   let mayLoad = 1;
 }
 
 multiclass sve_mem_cldnt_si<bits<2> msz, string asm, RegisterOperand listty,
                             ZPRRegOp zprty> {
-  def NAME : sve_mem_cldnt_si_base<msz, asm, listty>;
+  def NAME : sve_mem_cldnt_si_base<msz, asm, listty, zprty>;
 
   def : InstAlias<asm # "\t$Zt, $Pg/z, [$Rn]",
                   (!cast<Instruction>(NAME) zprty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, 0), 0>;
@@ -8203,7 +8214,7 @@ multiclass sve_mem_cldnt_si<bits<2> msz, string asm, RegisterOperand listty,
 }
 
 class sve_mem_cldnt_ss_base<bits<2> msz, string asm, RegisterOperand VecList,
-                            RegisterOperand gprty>
+                            ZPRRegOp zprty, RegisterOperand gprty>
 : I<(outs VecList:$Zt), (ins PPR3bAny:$Pg, GPR64sp:$Rn, gprty:$Rm),
   asm, "\t$Zt, $Pg/z, [$Rn, $Rm]",
   "",
@@ -8221,13 +8232,14 @@ class sve_mem_cldnt_ss_base<bits<2> msz, string asm, RegisterOperand VecList,
   let Inst{9-5}   = Rn;
   let Inst{4-0}   = Zt;
 
+  let ElementSize = zprty.ElementSize;
   let hasSideEffects = 0;
   let mayLoad = 1;
 }
 
 multiclass sve_mem_cldnt_ss<bits<2> msz, string asm, RegisterOperand listty,
                             ZPRRegOp zprty, RegisterOperand gprty> {
-  def NAME : sve_mem_cldnt_ss_base<msz, asm, listty, gprty>;
+  def NAME : sve_mem_cldnt_ss_base<msz, asm, listty, zprty, gprty>;
 
   def : InstAlias<asm # "\t$Zt, $Pg/z, [$Rn, $Rm]",
                  (!cast<Instruction>(NAME) zprty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, gprty:$Rm), 0>;
@@ -8294,7 +8306,7 @@ multiclass sve_mem_ldqr_ss<bits<2> sz, string asm, RegisterOperand listty,
 }
 
 class sve_mem_ld_dup<bits<2> dtypeh, bits<2> dtypel, string asm,
-                     RegisterOperand VecList, Operand immtype>
+                     RegisterOperand VecList, ZPRRegOp zprty, Operand immtype>
 : I<(outs VecList:$Zt), (ins PPR3bAny:$Pg, GPR64sp:$Rn, immtype:$imm6),
   asm, "\t$Zt, $Pg/z, [$Rn, $imm6]",
   "",
@@ -8313,13 +8325,14 @@ class sve_mem_ld_dup<bits<2> dtypeh, bits<2> dtypel, string asm,
   let Inst{9-5}   = Rn;
   let Inst{4-0}   = Zt;
 
+  let ElementSize = zprty.ElementSize;
   let hasSideEffects = 0;
   let mayLoad = 1;
 }
 
 multiclass sve_mem_ld_dup<bits<2> dtypeh, bits<2> dtypel, string asm,
                           RegisterOperand zlistty, ZPRRegOp zprty, Operand immtype> {
-  def NAME : sve_mem_ld_dup<dtypeh, dtypel, asm, zlistty, immtype>;
+  def NAME : sve_mem_ld_dup<dtypeh, dtypel, asm, zlistty, zprty, immtype>;
 
   def : InstAlias<asm # "\t$Zt, $Pg/z, [$Rn]",
                   (!cast<Instruction>(NAME) zprty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, 0), 0>;
@@ -8330,7 +8343,7 @@ multiclass sve_mem_ld_dup<bits<2> dtypeh, bits<2> dtypel, string asm,
 }
 
 class sve_mem_cld_ss_base<bits<4> dtype, bit ff, dag iops, string asm,
-                          RegisterOperand VecList>
+                          RegisterOperand VecList, ZPRRegOp zprty>
 : I<(outs VecList:$Zt), iops,
   asm, "\t$Zt, $Pg/z, [$Rn, $Rm]",
   "",
@@ -8349,6 +8362,7 @@ class sve_mem_cld_ss_base<bits<4> dtype, bit ff, dag iops, string asm,
   let Inst{4-0}   = Zt;
 
   let Defs = !if(ff, [FFR], []);
+  let ElementSize = zprty.ElementSize;
   let Uses = !if(ff, [FFR], []);
   let hasSideEffects = ff;
   let mayLoad = 1;
@@ -8357,7 +8371,7 @@ class sve_mem_cld_ss_base<bits<4> dtype, bit ff, dag iops, string asm,
 multiclass sve_mem_cld_ss<bits<4> dtype, string asm, RegisterOperand listty,
                           ZPRRegOp zprty, RegisterOperand gprty> {
   def NAME : sve_mem_cld_ss_base<dtype, 0, (ins PPR3bAny:$Pg, GPR64sp:$Rn, gprty:$Rm),
-                               asm, listty>;
+                               asm, listty, zprty>;
 
   def : InstAlias<asm # "\t$Zt, $Pg/z, [$Rn, $Rm]",
                  (!cast<Instruction>(NAME) zprty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, gprty:$Rm), 0>;
@@ -8365,7 +8379,7 @@ multiclass sve_mem_cld_ss<bits<4> dtype, string asm, RegisterOperand listty,
 
 multiclass sve_mem_cldff_ss<bits<4> dtype, string asm, RegisterOperand listty,
                             ZPRRegOp zprty, RegisterOperand gprty> {
-  def NAME : sve_mem_cld_ss_base<dtype, 1, (ins PPR3bAny:$Pg, GPR64sp:$Rn, gprty:$Rm), asm, listty>;
+  def NAME : sve_mem_cld_ss_base<dtype, 1, (ins PPR3bAny:$Pg, GPR64sp:$Rn, gprty:$Rm), asm, listty, zprty>;
 
   def : InstAlias<asm # "\t$Zt, $Pg/z, [$Rn, $Rm]",
                  (!cast<Instruction>(NAME) zprty:$Zt, PPR3bAny:$Pg, GPR64sp:$Rn, gprty:$Rm), 0>;

--- a/llvm/test/CodeGen/AArch64/sve-ptrue-coalesce.mir
+++ b/llvm/test/CodeGen/AArch64/sve-ptrue-coalesce.mir
@@ -205,7 +205,6 @@ body:             |
     RET_ReallyLR
 
 ...
-
 ---
 name:            keep_ptrue_h_when_b_user_would_observe_extra_lanes
 alignment:       2
@@ -588,6 +587,268 @@ body:             |
     %6:ppr = BRKN_PPzP %0, %0, %0
     %1:ppr_3b = PTRUE_H 31, implicit $vg
     %4:ppr = CMPEQ_PPzZZ_H %1, %2, %3, implicit-def dead $nzcv
+    RET_ReallyLR
+
+...
+---
+name:            ptrue_s_replaces_ptrue_d_for_d_user_fcmp
+alignment:       2
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: ppr_3b }
+  - { id: 1, class: ppr_3b }
+  - { id: 2, class: zpr }
+  - { id: 3, class: zpr }
+  - { id: 4, class: ppr }
+  - { id: 5, class: ppr }
+liveins:
+  - { reg: '$z0', virtual-reg: '%2' }
+  - { reg: '$z1', virtual-reg: '%3' }
+body:             |
+  bb.0:
+    liveins: $z0, $z1
+
+    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_fcmp
+    ; CHECK: liveins: $z0, $z1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:zpr = COPY $z0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z1
+    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; CHECK-NEXT: [[FCMNE_PPzZZ_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZZ_D [[PTRUE_D]], [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: [[FCMNE_PPzZZ_D1:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZZ_D [[PTRUE_S]], [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: RET_ReallyLR
+    %2:zpr = COPY $z0
+    %3:zpr = COPY $z1
+    %0:ppr_3b = PTRUE_S 31, implicit $vg
+    %1:ppr_3b = PTRUE_D 31, implicit $vg
+    %4:ppr = nofpexcept FCMNE_PPzZZ_D %1, %2, %3
+    %5:ppr = nofpexcept FCMNE_PPzZZ_D %0, %2, %3
+    RET_ReallyLR
+
+...
+---
+name:            ptrue_s_replaces_ptrue_d_for_d_user_fcmpz
+alignment:       2
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: ppr_3b }
+  - { id: 1, class: ppr_3b }
+  - { id: 2, class: zpr }
+  - { id: 3, class: zpr }
+  - { id: 4, class: ppr }
+  - { id: 5, class: ppr }
+liveins:
+  - { reg: '$z0', virtual-reg: '%2' }
+  - { reg: '$z1', virtual-reg: '%3' }
+body:             |
+  bb.0:
+    liveins: $z0, $z1
+
+    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_fcmpz
+    ; CHECK: liveins: $z0, $z1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:zpr = COPY $z0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z1
+    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; CHECK-NEXT: [[FCMNE_PPzZ0_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_D]], [[COPY]]
+    ; CHECK-NEXT: [[FCMNE_PPzZ0_D1:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_S]], [[COPY1]]
+    ; CHECK-NEXT: RET_ReallyLR
+    %2:zpr = COPY $z0
+    %3:zpr = COPY $z1
+    %0:ppr_3b = PTRUE_S 31, implicit $vg
+    %1:ppr_3b = PTRUE_D 31, implicit $vg
+    %4:ppr = nofpexcept FCMNE_PPzZ0_D %1, %2
+    %5:ppr = nofpexcept FCMNE_PPzZ0_D %0, %3
+    RET_ReallyLR
+
+...
+---
+name:            ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_imm
+alignment:       2
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: gpr64common }
+  - { id: 1, class: ppr_3b }
+  - { id: 2, class: ppr_3b }
+  - { id: 3, class: zpr }
+  - { id: 4, class: zpr }
+liveins:
+  - { reg: '$x0', virtual-reg: '%0' }
+  - { reg: '$z0', virtual-reg: '%3' }
+body:             |
+  bb.0:
+    liveins: $x0, $z0
+
+    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_imm
+    ; CHECK: liveins: $x0, $z0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
+    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; CHECK-NEXT: [[LD1W_D_IMM:%[0-9]+]]:zpr = LD1W_D_IMM [[PTRUE_S]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
+    ; CHECK-NEXT: ST1W_IMM [[COPY1]], [[PTRUE_D]], [[COPY]], 0 :: (store (<vscale x 4 x s32>))
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:gpr64common = COPY $x0
+    %3:zpr = COPY $z0
+    %1:ppr_3b = PTRUE_S 31, implicit $vg
+    %2:ppr_3b = PTRUE_D 31, implicit $vg
+    %4:zpr = LD1W_D_IMM %1, %0, 0 :: (load (<vscale x 1 x s64>))
+    ST1W_IMM %3, %2, %0, 0 :: (store (<vscale x 4 x s32>))
+    RET_ReallyLR
+
+...
+---
+name:            ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_reg
+alignment:       2
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: gpr64common }
+  - { id: 1, class: ppr_3b }
+  - { id: 2, class: ppr_3b }
+  - { id: 3, class: zpr }
+  - { id: 4, class: zpr }
+  - { id: 5, class: gpr64common }
+liveins:
+  - { reg: '$x0', virtual-reg: '%0' }
+  - { reg: '$x1', virtual-reg: '%5' }
+  - { reg: '$z0', virtual-reg: '%3' }
+body:             |
+  bb.0:
+    liveins: $x0, $x1, $z0
+
+    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_reg
+    ; CHECK: liveins: $x0, $x1, $z0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr64common = COPY $x1
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:zpr = COPY $z0
+    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; CHECK-NEXT: [[LD1W_D:%[0-9]+]]:zpr = LD1W_D [[PTRUE_S]], [[COPY]], [[COPY1]] :: (load (<vscale x 1 x s64>))
+    ; CHECK-NEXT: ST1W [[COPY2]], [[PTRUE_D]], [[COPY]], [[COPY1]] :: (store (<vscale x 4 x s32>))
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:gpr64common = COPY $x0
+    %5:gpr64common = COPY $x1
+    %3:zpr = COPY $z0
+    %1:ppr_3b = PTRUE_S 31, implicit $vg
+    %2:ppr_3b = PTRUE_D 31, implicit $vg
+    %4:zpr = LD1W_D %1, %0, %5 :: (load (<vscale x 1 x s64>))
+    ST1W %3, %2, %0, %5 :: (store (<vscale x 4 x s32>))
+    RET_ReallyLR
+
+...
+---
+name:            ptrue_s_replaces_ptrue_d_for_d_user_ld1r_reg_imm
+alignment:       2
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: gpr64common }
+  - { id: 1, class: ppr_3b }
+  - { id: 2, class: ppr_3b }
+  - { id: 3, class: zpr }
+  - { id: 4, class: zpr }
+liveins:
+  - { reg: '$x0', virtual-reg: '%0' }
+  - { reg: '$z0', virtual-reg: '%3' }
+body:             |
+  bb.0:
+    liveins: $x0, $z0
+
+    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1r_reg_imm
+    ; CHECK: liveins: $x0, $z0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
+    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; CHECK-NEXT: [[LD1RW_D_IMM:%[0-9]+]]:zpr = LD1RW_D_IMM [[PTRUE_S]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
+    ; CHECK-NEXT: [[FCMNE_PPzZ0_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_D]], [[COPY1]]
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:gpr64common = COPY $x0
+    %3:zpr = COPY $z0
+    %1:ppr_3b = PTRUE_S 31, implicit $vg
+    %2:ppr_3b = PTRUE_D 31, implicit $vg
+    %4:zpr = LD1RW_D_IMM %1, %0, 0 :: (load (<vscale x 1 x s64>))
+    %5:ppr = nofpexcept FCMNE_PPzZ0_D %2, %3
+    RET_ReallyLR
+
+...
+---
+name:            ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_imm
+alignment:       2
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: gpr64common }
+  - { id: 1, class: ppr_3b }
+  - { id: 2, class: ppr_3b }
+  - { id: 3, class: zpr }
+  - { id: 4, class: zpr }
+liveins:
+  - { reg: '$x0', virtual-reg: '%0' }
+  - { reg: '$z0', virtual-reg: '%3' }
+body:             |
+  bb.0:
+    liveins: $x0, $z0
+
+    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_imm
+    ; CHECK: liveins: $x0, $z0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
+    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; CHECK-NEXT: [[LDNT1D_ZRI:%[0-9]+]]:zpr = LDNT1D_ZRI [[PTRUE_S]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
+    ; CHECK-NEXT: STNT1W_ZRI [[COPY1]], [[PTRUE_D]], [[COPY]], 0 :: (store (<vscale x 4 x s32>))
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:gpr64common = COPY $x0
+    %3:zpr = COPY $z0
+    %1:ppr_3b = PTRUE_S 31, implicit $vg
+    %2:ppr_3b = PTRUE_D 31, implicit $vg
+    %4:zpr = LDNT1D_ZRI %1, %0, 0 :: (load (<vscale x 1 x s64>))
+    STNT1W_ZRI %3, %2, %0, 0 :: (store (<vscale x 4 x s32>))
+    RET_ReallyLR
+
+...
+---
+name:            ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_reg
+alignment:       2
+tracksRegLiveness: true
+registers:
+  - { id: 0, class: gpr64common }
+  - { id: 1, class: ppr_3b }
+  - { id: 2, class: ppr_3b }
+  - { id: 3, class: zpr }
+  - { id: 4, class: zpr }
+  - { id: 5, class: gpr64common }
+liveins:
+  - { reg: '$x0', virtual-reg: '%0' }
+  - { reg: '$x1', virtual-reg: '%5' }
+  - { reg: '$z0', virtual-reg: '%3' }
+body:             |
+  bb.0:
+    liveins: $x0, $x1, $z0
+
+    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_reg
+    ; CHECK: liveins: $x0, $x1, $z0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr64common = COPY $x1
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:zpr = COPY $z0
+    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; CHECK-NEXT: [[LDNT1D_ZRR:%[0-9]+]]:zpr = LDNT1D_ZRR [[PTRUE_S]], [[COPY]], [[COPY1]] :: (load (<vscale x 1 x s64>))
+    ; CHECK-NEXT: STNT1W_ZRR [[COPY2]], [[PTRUE_D]], [[COPY]], [[COPY1]] :: (store (<vscale x 4 x s32>))
+    ; CHECK-NEXT: RET_ReallyLR
+    %0:gpr64common = COPY $x0
+    %5:gpr64common = COPY $x1
+    %3:zpr = COPY $z0
+    %1:ppr_3b = PTRUE_S 31, implicit $vg
+    %2:ppr_3b = PTRUE_D 31, implicit $vg
+    %4:zpr = LDNT1D_ZRR %1, %0, %5 :: (load (<vscale x 1 x s64>))
+    STNT1W_ZRR %3, %2, %0, %5 :: (store (<vscale x 4 x s32>))
     RET_ReallyLR
 
 ...

--- a/llvm/test/CodeGen/AArch64/sve-ptrue-coalesce.mir
+++ b/llvm/test/CodeGen/AArch64/sve-ptrue-coalesce.mir
@@ -608,16 +608,26 @@ body:             |
   bb.0:
     liveins: $z0, $z1
 
-    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_fcmp
-    ; CHECK: liveins: $z0, $z1
-    ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:zpr = COPY $z0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z1
-    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
-    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
-    ; CHECK-NEXT: [[FCMNE_PPzZZ_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZZ_D [[PTRUE_D]], [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: [[FCMNE_PPzZZ_D1:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZZ_D [[PTRUE_S]], [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: RET_ReallyLR
+    ; ENABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_fcmp
+    ; ENABLED: liveins: $z0, $z1
+    ; ENABLED-NEXT: {{  $}}
+    ; ENABLED-NEXT: [[COPY:%[0-9]+]]:zpr = COPY $z0
+    ; ENABLED-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z1
+    ; ENABLED-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; ENABLED-NEXT: [[FCMNE_PPzZZ_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZZ_D [[PTRUE_S]], [[COPY]], [[COPY1]]
+    ; ENABLED-NEXT: [[FCMNE_PPzZZ_D1:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZZ_D [[PTRUE_S]], [[COPY]], [[COPY1]]
+    ; ENABLED-NEXT: RET_ReallyLR
+    ;
+    ; DISABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_fcmp
+    ; DISABLED: liveins: $z0, $z1
+    ; DISABLED-NEXT: {{  $}}
+    ; DISABLED-NEXT: [[COPY:%[0-9]+]]:zpr = COPY $z0
+    ; DISABLED-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z1
+    ; DISABLED-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; DISABLED-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; DISABLED-NEXT: [[FCMNE_PPzZZ_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZZ_D [[PTRUE_D]], [[COPY]], [[COPY1]]
+    ; DISABLED-NEXT: [[FCMNE_PPzZZ_D1:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZZ_D [[PTRUE_S]], [[COPY]], [[COPY1]]
+    ; DISABLED-NEXT: RET_ReallyLR
     %2:zpr = COPY $z0
     %3:zpr = COPY $z1
     %0:ppr_3b = PTRUE_S 31, implicit $vg
@@ -645,16 +655,26 @@ body:             |
   bb.0:
     liveins: $z0, $z1
 
-    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_fcmpz
-    ; CHECK: liveins: $z0, $z1
-    ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:zpr = COPY $z0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z1
-    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
-    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
-    ; CHECK-NEXT: [[FCMNE_PPzZ0_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_D]], [[COPY]]
-    ; CHECK-NEXT: [[FCMNE_PPzZ0_D1:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_S]], [[COPY1]]
-    ; CHECK-NEXT: RET_ReallyLR
+    ; ENABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_fcmpz
+    ; ENABLED: liveins: $z0, $z1
+    ; ENABLED-NEXT: {{  $}}
+    ; ENABLED-NEXT: [[COPY:%[0-9]+]]:zpr = COPY $z0
+    ; ENABLED-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z1
+    ; ENABLED-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; ENABLED-NEXT: [[FCMNE_PPzZ0_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_S]], [[COPY]]
+    ; ENABLED-NEXT: [[FCMNE_PPzZ0_D1:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_S]], [[COPY1]]
+    ; ENABLED-NEXT: RET_ReallyLR
+    ;
+    ; DISABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_fcmpz
+    ; DISABLED: liveins: $z0, $z1
+    ; DISABLED-NEXT: {{  $}}
+    ; DISABLED-NEXT: [[COPY:%[0-9]+]]:zpr = COPY $z0
+    ; DISABLED-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z1
+    ; DISABLED-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; DISABLED-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; DISABLED-NEXT: [[FCMNE_PPzZ0_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_D]], [[COPY]]
+    ; DISABLED-NEXT: [[FCMNE_PPzZ0_D1:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_S]], [[COPY1]]
+    ; DISABLED-NEXT: RET_ReallyLR
     %2:zpr = COPY $z0
     %3:zpr = COPY $z1
     %0:ppr_3b = PTRUE_S 31, implicit $vg
@@ -681,16 +701,26 @@ body:             |
   bb.0:
     liveins: $x0, $z0
 
-    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_imm
-    ; CHECK: liveins: $x0, $z0
-    ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
-    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
-    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
-    ; CHECK-NEXT: [[LD1W_D_IMM:%[0-9]+]]:zpr = LD1W_D_IMM [[PTRUE_S]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
-    ; CHECK-NEXT: ST1W_IMM [[COPY1]], [[PTRUE_D]], [[COPY]], 0 :: (store (<vscale x 4 x s32>))
-    ; CHECK-NEXT: RET_ReallyLR
+    ; ENABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_imm
+    ; ENABLED: liveins: $x0, $z0
+    ; ENABLED-NEXT: {{  $}}
+    ; ENABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; ENABLED-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
+    ; ENABLED-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; ENABLED-NEXT: [[LD1W_D_IMM:%[0-9]+]]:zpr = LD1W_D_IMM [[PTRUE_D]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
+    ; ENABLED-NEXT: ST1W_IMM [[COPY1]], [[PTRUE_D]], [[COPY]], 0 :: (store (<vscale x 4 x s32>))
+    ; ENABLED-NEXT: RET_ReallyLR
+    ;
+    ; DISABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_imm
+    ; DISABLED: liveins: $x0, $z0
+    ; DISABLED-NEXT: {{  $}}
+    ; DISABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; DISABLED-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
+    ; DISABLED-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; DISABLED-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; DISABLED-NEXT: [[LD1W_D_IMM:%[0-9]+]]:zpr = LD1W_D_IMM [[PTRUE_S]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
+    ; DISABLED-NEXT: ST1W_IMM [[COPY1]], [[PTRUE_D]], [[COPY]], 0 :: (store (<vscale x 4 x s32>))
+    ; DISABLED-NEXT: RET_ReallyLR
     %0:gpr64common = COPY $x0
     %3:zpr = COPY $z0
     %1:ppr_3b = PTRUE_S 31, implicit $vg
@@ -719,17 +749,28 @@ body:             |
   bb.0:
     liveins: $x0, $x1, $z0
 
-    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_reg
-    ; CHECK: liveins: $x0, $x1, $z0
-    ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr64common = COPY $x1
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:zpr = COPY $z0
-    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
-    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
-    ; CHECK-NEXT: [[LD1W_D:%[0-9]+]]:zpr = LD1W_D [[PTRUE_S]], [[COPY]], [[COPY1]] :: (load (<vscale x 1 x s64>))
-    ; CHECK-NEXT: ST1W [[COPY2]], [[PTRUE_D]], [[COPY]], [[COPY1]] :: (store (<vscale x 4 x s32>))
-    ; CHECK-NEXT: RET_ReallyLR
+    ; ENABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_reg
+    ; ENABLED: liveins: $x0, $x1, $z0
+    ; ENABLED-NEXT: {{  $}}
+    ; ENABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; ENABLED-NEXT: [[COPY1:%[0-9]+]]:gpr64common = COPY $x1
+    ; ENABLED-NEXT: [[COPY2:%[0-9]+]]:zpr = COPY $z0
+    ; ENABLED-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; ENABLED-NEXT: [[LD1W_D:%[0-9]+]]:zpr = LD1W_D [[PTRUE_D]], [[COPY]], [[COPY1]] :: (load (<vscale x 1 x s64>))
+    ; ENABLED-NEXT: ST1W [[COPY2]], [[PTRUE_D]], [[COPY]], [[COPY1]] :: (store (<vscale x 4 x s32>))
+    ; ENABLED-NEXT: RET_ReallyLR
+    ;
+    ; DISABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_reg
+    ; DISABLED: liveins: $x0, $x1, $z0
+    ; DISABLED-NEXT: {{  $}}
+    ; DISABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; DISABLED-NEXT: [[COPY1:%[0-9]+]]:gpr64common = COPY $x1
+    ; DISABLED-NEXT: [[COPY2:%[0-9]+]]:zpr = COPY $z0
+    ; DISABLED-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; DISABLED-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; DISABLED-NEXT: [[LD1W_D:%[0-9]+]]:zpr = LD1W_D [[PTRUE_S]], [[COPY]], [[COPY1]] :: (load (<vscale x 1 x s64>))
+    ; DISABLED-NEXT: ST1W [[COPY2]], [[PTRUE_D]], [[COPY]], [[COPY1]] :: (store (<vscale x 4 x s32>))
+    ; DISABLED-NEXT: RET_ReallyLR
     %0:gpr64common = COPY $x0
     %5:gpr64common = COPY $x1
     %3:zpr = COPY $z0
@@ -757,16 +798,26 @@ body:             |
   bb.0:
     liveins: $x0, $z0
 
-    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1r_reg_imm
-    ; CHECK: liveins: $x0, $z0
-    ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
-    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
-    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
-    ; CHECK-NEXT: [[LD1RW_D_IMM:%[0-9]+]]:zpr = LD1RW_D_IMM [[PTRUE_S]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
-    ; CHECK-NEXT: [[FCMNE_PPzZ0_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_D]], [[COPY1]]
-    ; CHECK-NEXT: RET_ReallyLR
+    ; ENABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1r_reg_imm
+    ; ENABLED: liveins: $x0, $z0
+    ; ENABLED-NEXT: {{  $}}
+    ; ENABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; ENABLED-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
+    ; ENABLED-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; ENABLED-NEXT: [[LD1RW_D_IMM:%[0-9]+]]:zpr = LD1RW_D_IMM [[PTRUE_S]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
+    ; ENABLED-NEXT: [[FCMNE_PPzZ0_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_S]], [[COPY1]]
+    ; ENABLED-NEXT: RET_ReallyLR
+    ;
+    ; DISABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1r_reg_imm
+    ; DISABLED: liveins: $x0, $z0
+    ; DISABLED-NEXT: {{  $}}
+    ; DISABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; DISABLED-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
+    ; DISABLED-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; DISABLED-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; DISABLED-NEXT: [[LD1RW_D_IMM:%[0-9]+]]:zpr = LD1RW_D_IMM [[PTRUE_S]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
+    ; DISABLED-NEXT: [[FCMNE_PPzZ0_D:%[0-9]+]]:ppr = nofpexcept FCMNE_PPzZ0_D [[PTRUE_D]], [[COPY1]]
+    ; DISABLED-NEXT: RET_ReallyLR
     %0:gpr64common = COPY $x0
     %3:zpr = COPY $z0
     %1:ppr_3b = PTRUE_S 31, implicit $vg
@@ -793,16 +844,26 @@ body:             |
   bb.0:
     liveins: $x0, $z0
 
-    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_imm
-    ; CHECK: liveins: $x0, $z0
-    ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
-    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
-    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
-    ; CHECK-NEXT: [[LDNT1D_ZRI:%[0-9]+]]:zpr = LDNT1D_ZRI [[PTRUE_S]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
-    ; CHECK-NEXT: STNT1W_ZRI [[COPY1]], [[PTRUE_D]], [[COPY]], 0 :: (store (<vscale x 4 x s32>))
-    ; CHECK-NEXT: RET_ReallyLR
+    ; ENABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_imm
+    ; ENABLED: liveins: $x0, $z0
+    ; ENABLED-NEXT: {{  $}}
+    ; ENABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; ENABLED-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
+    ; ENABLED-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; ENABLED-NEXT: [[LDNT1D_ZRI:%[0-9]+]]:zpr = LDNT1D_ZRI [[PTRUE_D]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
+    ; ENABLED-NEXT: STNT1W_ZRI [[COPY1]], [[PTRUE_D]], [[COPY]], 0 :: (store (<vscale x 4 x s32>))
+    ; ENABLED-NEXT: RET_ReallyLR
+    ;
+    ; DISABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_imm
+    ; DISABLED: liveins: $x0, $z0
+    ; DISABLED-NEXT: {{  $}}
+    ; DISABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; DISABLED-NEXT: [[COPY1:%[0-9]+]]:zpr = COPY $z0
+    ; DISABLED-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; DISABLED-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; DISABLED-NEXT: [[LDNT1D_ZRI:%[0-9]+]]:zpr = LDNT1D_ZRI [[PTRUE_S]], [[COPY]], 0 :: (load (<vscale x 1 x s64>))
+    ; DISABLED-NEXT: STNT1W_ZRI [[COPY1]], [[PTRUE_D]], [[COPY]], 0 :: (store (<vscale x 4 x s32>))
+    ; DISABLED-NEXT: RET_ReallyLR
     %0:gpr64common = COPY $x0
     %3:zpr = COPY $z0
     %1:ppr_3b = PTRUE_S 31, implicit $vg
@@ -831,17 +892,28 @@ body:             |
   bb.0:
     liveins: $x0, $x1, $z0
 
-    ; CHECK-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_reg
-    ; CHECK: liveins: $x0, $x1, $z0
-    ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr64common = COPY $x1
-    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:zpr = COPY $z0
-    ; CHECK-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
-    ; CHECK-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
-    ; CHECK-NEXT: [[LDNT1D_ZRR:%[0-9]+]]:zpr = LDNT1D_ZRR [[PTRUE_S]], [[COPY]], [[COPY1]] :: (load (<vscale x 1 x s64>))
-    ; CHECK-NEXT: STNT1W_ZRR [[COPY2]], [[PTRUE_D]], [[COPY]], [[COPY1]] :: (store (<vscale x 4 x s32>))
-    ; CHECK-NEXT: RET_ReallyLR
+    ; ENABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_reg
+    ; ENABLED: liveins: $x0, $x1, $z0
+    ; ENABLED-NEXT: {{  $}}
+    ; ENABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; ENABLED-NEXT: [[COPY1:%[0-9]+]]:gpr64common = COPY $x1
+    ; ENABLED-NEXT: [[COPY2:%[0-9]+]]:zpr = COPY $z0
+    ; ENABLED-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; ENABLED-NEXT: [[LDNT1D_ZRR:%[0-9]+]]:zpr = LDNT1D_ZRR [[PTRUE_D]], [[COPY]], [[COPY1]] :: (load (<vscale x 1 x s64>))
+    ; ENABLED-NEXT: STNT1W_ZRR [[COPY2]], [[PTRUE_D]], [[COPY]], [[COPY1]] :: (store (<vscale x 4 x s32>))
+    ; ENABLED-NEXT: RET_ReallyLR
+    ;
+    ; DISABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_reg
+    ; DISABLED: liveins: $x0, $x1, $z0
+    ; DISABLED-NEXT: {{  $}}
+    ; DISABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+    ; DISABLED-NEXT: [[COPY1:%[0-9]+]]:gpr64common = COPY $x1
+    ; DISABLED-NEXT: [[COPY2:%[0-9]+]]:zpr = COPY $z0
+    ; DISABLED-NEXT: [[PTRUE_S:%[0-9]+]]:ppr_3b = PTRUE_S 31, implicit $vg
+    ; DISABLED-NEXT: [[PTRUE_D:%[0-9]+]]:ppr_3b = PTRUE_D 31, implicit $vg
+    ; DISABLED-NEXT: [[LDNT1D_ZRR:%[0-9]+]]:zpr = LDNT1D_ZRR [[PTRUE_S]], [[COPY]], [[COPY1]] :: (load (<vscale x 1 x s64>))
+    ; DISABLED-NEXT: STNT1W_ZRR [[COPY2]], [[PTRUE_D]], [[COPY]], [[COPY1]] :: (store (<vscale x 4 x s32>))
+    ; DISABLED-NEXT: RET_ReallyLR
     %0:gpr64common = COPY $x0
     %5:gpr64common = COPY $x1
     %3:zpr = COPY $z0

--- a/llvm/test/CodeGen/AArch64/sve-ptrue-coalesce.mir
+++ b/llvm/test/CodeGen/AArch64/sve-ptrue-coalesce.mir
@@ -685,7 +685,7 @@ body:             |
 
 ...
 ---
-name:            ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_imm
+name:            ptrue_d_replaces_ptrue_s_for_d_user_ld1_st1_reg_imm
 alignment:       2
 tracksRegLiveness: true
 registers:
@@ -701,7 +701,7 @@ body:             |
   bb.0:
     liveins: $x0, $z0
 
-    ; ENABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_imm
+    ; ENABLED-LABEL: name: ptrue_d_replaces_ptrue_s_for_d_user_ld1_st1_reg_imm
     ; ENABLED: liveins: $x0, $z0
     ; ENABLED-NEXT: {{  $}}
     ; ENABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
@@ -711,7 +711,7 @@ body:             |
     ; ENABLED-NEXT: ST1W_IMM [[COPY1]], [[PTRUE_D]], [[COPY]], 0 :: (store (<vscale x 4 x s32>))
     ; ENABLED-NEXT: RET_ReallyLR
     ;
-    ; DISABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_imm
+    ; DISABLED-LABEL: name: ptrue_d_replaces_ptrue_s_for_d_user_ld1_st1_reg_imm
     ; DISABLED: liveins: $x0, $z0
     ; DISABLED-NEXT: {{  $}}
     ; DISABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
@@ -731,7 +731,7 @@ body:             |
 
 ...
 ---
-name:            ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_reg
+name:            ptrue_d_replaces_ptrue_s_for_d_user_ld1_st1_reg_reg
 alignment:       2
 tracksRegLiveness: true
 registers:
@@ -749,7 +749,7 @@ body:             |
   bb.0:
     liveins: $x0, $x1, $z0
 
-    ; ENABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_reg
+    ; ENABLED-LABEL: name: ptrue_d_replaces_ptrue_s_for_d_user_ld1_st1_reg_reg
     ; ENABLED: liveins: $x0, $x1, $z0
     ; ENABLED-NEXT: {{  $}}
     ; ENABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
@@ -760,7 +760,7 @@ body:             |
     ; ENABLED-NEXT: ST1W [[COPY2]], [[PTRUE_D]], [[COPY]], [[COPY1]] :: (store (<vscale x 4 x s32>))
     ; ENABLED-NEXT: RET_ReallyLR
     ;
-    ; DISABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ld1_st1_reg_reg
+    ; DISABLED-LABEL: name: ptrue_d_replaces_ptrue_s_for_d_user_ld1_st1_reg_reg
     ; DISABLED: liveins: $x0, $x1, $z0
     ; DISABLED-NEXT: {{  $}}
     ; DISABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
@@ -828,7 +828,7 @@ body:             |
 
 ...
 ---
-name:            ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_imm
+name:            ptrue_d_replaces_ptrue_s_for_d_user_ldnt1_stnt1_reg_imm
 alignment:       2
 tracksRegLiveness: true
 registers:
@@ -844,7 +844,7 @@ body:             |
   bb.0:
     liveins: $x0, $z0
 
-    ; ENABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_imm
+    ; ENABLED-LABEL: name: ptrue_d_replaces_ptrue_s_for_d_user_ldnt1_stnt1_reg_imm
     ; ENABLED: liveins: $x0, $z0
     ; ENABLED-NEXT: {{  $}}
     ; ENABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
@@ -854,7 +854,7 @@ body:             |
     ; ENABLED-NEXT: STNT1W_ZRI [[COPY1]], [[PTRUE_D]], [[COPY]], 0 :: (store (<vscale x 4 x s32>))
     ; ENABLED-NEXT: RET_ReallyLR
     ;
-    ; DISABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_imm
+    ; DISABLED-LABEL: name: ptrue_d_replaces_ptrue_s_for_d_user_ldnt1_stnt1_reg_imm
     ; DISABLED: liveins: $x0, $z0
     ; DISABLED-NEXT: {{  $}}
     ; DISABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
@@ -874,7 +874,7 @@ body:             |
 
 ...
 ---
-name:            ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_reg
+name:            ptrue_d_replaces_ptrue_s_for_d_user_ldnt1_stnt1_reg_reg
 alignment:       2
 tracksRegLiveness: true
 registers:
@@ -892,7 +892,7 @@ body:             |
   bb.0:
     liveins: $x0, $x1, $z0
 
-    ; ENABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_reg
+    ; ENABLED-LABEL: name: ptrue_d_replaces_ptrue_s_for_d_user_ldnt1_stnt1_reg_reg
     ; ENABLED: liveins: $x0, $x1, $z0
     ; ENABLED-NEXT: {{  $}}
     ; ENABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0
@@ -903,7 +903,7 @@ body:             |
     ; ENABLED-NEXT: STNT1W_ZRR [[COPY2]], [[PTRUE_D]], [[COPY]], [[COPY1]] :: (store (<vscale x 4 x s32>))
     ; ENABLED-NEXT: RET_ReallyLR
     ;
-    ; DISABLED-LABEL: name: ptrue_s_replaces_ptrue_d_for_d_user_ldnt1_stnt1_reg_reg
+    ; DISABLED-LABEL: name: ptrue_d_replaces_ptrue_s_for_d_user_ldnt1_stnt1_reg_reg
     ; DISABLED: liveins: $x0, $x1, $z0
     ; DISABLED-NEXT: {{  $}}
     ; DISABLED-NEXT: [[COPY:%[0-9]+]]:gpr64common = COPY $x0


### PR DESCRIPTION
This information was originally used to implement MOVPFRX support. However https://github.com/llvm/llvm-project/pull/204820 uses the same information to determine which bits of an instruction's predicate operand are used so that PTRUE instructions can be coalesced. MOVPRFXable instructions are a subset of all predicated instructions, so this patch extends some non-MOVPRFXable instructions with ElementSize information.

Rather than test all instructions I've limited the verification to one instruction per tablegen class.

NOTE: This is not completely coverage (main omissions being LD/ST{2,3,4}, gathers, scatters and prefetches) but should be enough to exercise the AArch64PTrueCoalescing pass on real workloads.