### PR TITLE
[llvm] Avoid premature Twine .str() materialization

### DIFF
--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -7485,7 +7485,7 @@ Error ModuleSummaryIndexBitcodeReader::parseModule() {
         /// MODULE_CODE_HASH: [5*i32]
         case bitc::MODULE_CODE_HASH: {
           if (Record.size() != 5)
-            return error("Invalid hash length " + Twine(Record.size()).str());
+            return error("Invalid hash length " + Twine(Record.size()));
           auto &Hash = getThisModule()->second;
           int Pos = 0;
           for (auto &Val : Record) {
@@ -8475,7 +8475,7 @@ Error ModuleSummaryIndexBitcodeReader::parseModuleStringTable() {
     /// MST_CODE_HASH: [5*i32]
     case bitc::MST_CODE_HASH: {
       if (Record.size() != 5)
-        return error("Invalid hash length " + Twine(Record.size()).str());
+        return error("Invalid hash length " + Twine(Record.size()));
       if (!LastSeenModule)
         return error("Invalid hash that does not follow a module path");
       int Pos = 0;

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -927,7 +927,7 @@ Error OnDiskGraphDB::validate(bool Deep, HashingFuncT Hasher) const {
           llvm::errc::illegal_byte_sequence,
           "bad record at 0x" +
               utohexstr((unsigned)Offset.get(), /*LowerCase=*/true) + ": " +
-              Msg.str());
+              Msg);
     };
 
     if (Record.Data.size() != sizeof(TrieRecord))
@@ -1003,7 +1003,7 @@ Error OnDiskGraphDB::validate(bool Deep, HashingFuncT Hasher) const {
     auto dataError = [&](Twine Msg) {
       return createStringError(llvm::errc::illegal_byte_sequence,
                                "bad data for digest \'" + toHex(I->Hash) +
-                                   "\': " + Msg.str());
+                                   "\': " + Msg);
     };
     SmallVector<ArrayRef<uint8_t>> Refs;
     ArrayRef<char> StoredData;
@@ -1073,7 +1073,7 @@ Error OnDiskGraphDB::validateObjectID(ObjectID ExternalRef) const {
         llvm::errc::illegal_byte_sequence,
         "bad ref=0x" +
             utohexstr(ExternalRef.getOpaqueData(), /*LowerCase=*/true) + ": " +
-            Msg.str());
+            Msg);
   };
 
   if (ExternalRef.getOpaqueData() == 0)

--- a/llvm/lib/CAS/OnDiskKeyValueDB.cpp
+++ b/llvm/lib/CAS/OnDiskKeyValueDB.cpp
@@ -110,7 +110,7 @@ static Error validateOnDiskKeyValueDB(const OnDiskTrieRawHashMap &Cache,
               llvm::errc::illegal_byte_sequence,
               "bad cache value at 0x" +
                   utohexstr((unsigned)Offset.get(), /*LowerCase=*/true) + ": " +
-                  Msg.str());
+                  Msg);
         };
 
         if (Record.Data.size() != ValueSize)

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -441,16 +441,16 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
   }
 
   MergeableConst4Section = Ctx->getELFSection(
-      (CstPrefix + ".cst4").str(), ELF::SHT_PROGBITS, MergeableCstFlags, 4);
+      CstPrefix + ".cst4", ELF::SHT_PROGBITS, MergeableCstFlags, 4);
 
   MergeableConst8Section = Ctx->getELFSection(
-      (CstPrefix + ".cst8").str(), ELF::SHT_PROGBITS, MergeableCstFlags, 8);
+      CstPrefix + ".cst8", ELF::SHT_PROGBITS, MergeableCstFlags, 8);
 
   MergeableConst16Section = Ctx->getELFSection(
-      (CstPrefix + ".cst16").str(), ELF::SHT_PROGBITS, MergeableCstFlags, 16);
+      CstPrefix + ".cst16", ELF::SHT_PROGBITS, MergeableCstFlags, 16);
 
   MergeableConst32Section = Ctx->getELFSection(
-      (CstPrefix + ".cst32").str(), ELF::SHT_PROGBITS, MergeableCstFlags, 32);
+      CstPrefix + ".cst32", ELF::SHT_PROGBITS, MergeableCstFlags, 32);
 
   // Exception Handling Sections.
 

--- a/llvm/lib/ObjCopy/COFF/COFFObjcopy.cpp
+++ b/llvm/lib/ObjCopy/COFF/COFFObjcopy.cpp
@@ -226,10 +226,10 @@ static Error handleArgs(const CommonConfig &Config,
     if (Config.SymbolsToRemove.matches(Sym.Name)) {
       // Explicitly removing a referenced symbol is an error.
       if (Sym.Referenced)
-        return createStringError(
-            llvm::errc::invalid_argument,
-            "'" + Config.OutputFilename + "': not stripping symbol '" +
-                Sym.Name.str() + "' because it is named in a relocation");
+        return createStringError(llvm::errc::invalid_argument,
+                                 "'" + Config.OutputFilename +
+                                     "': not stripping symbol '" + Sym.Name +
+                                     "' because it is named in a relocation");
       return true;
     }
 

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -2294,9 +2294,8 @@ const Init *TGParser::ParseOperation(Record *CurRec, const RecTy *ItemType) {
 
     const Init *A = StringInit::get(Records, Lex.getCurStrVal());
     if (CurRec && CurRec->getValue(A)) {
-      TokError((Twine("left !foldl variable '") + A->getAsString() +
-                "' already defined")
-                   .str());
+      TokError(Twine("left !foldl variable '") + A->getAsString() +
+               "' already defined");
       return nullptr;
     }
 
@@ -2312,9 +2311,8 @@ const Init *TGParser::ParseOperation(Record *CurRec, const RecTy *ItemType) {
 
     const Init *B = StringInit::get(Records, Lex.getCurStrVal());
     if (CurRec && CurRec->getValue(B)) {
-      TokError((Twine("right !foldl variable '") + B->getAsString() +
-                "' already defined")
-                   .str());
+      TokError(Twine("right !foldl variable '") + B->getAsString() +
+               "' already defined");
       return nullptr;
     }
 
@@ -2600,9 +2598,8 @@ const Init *TGParser::ParseOperationListComprehension(Record *CurRec,
   Lex.Lex(); // eat the ID.
 
   if (CurRec && CurRec->getValue(LHS)) {
-    TokError((Twine("iteration variable '") + LHS->getAsString() +
-              "' is already defined")
-                 .str());
+    TokError(Twine("iteration variable '") + LHS->getAsString() +
+             "' is already defined");
     return nullptr;
   }
 

--- a/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
+++ b/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
@@ -165,7 +165,7 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
               BO->setString(IConf.SS.save(*V));
             } else {
               Ctx.diagnose(DiagnosticInfoInstrumentation(
-                  Twine("configuration key '") + ObjIt.first.str() +
+                  Twine("configuration key '") + StringRef(ObjIt.first) +
                       Twine("' expects a string, value ignored"),
                   DS_Warning));
             }
@@ -175,7 +175,7 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
               BO->setBool(*V);
             else {
               Ctx.diagnose(DiagnosticInfoInstrumentation(
-                  Twine("configuration key '") + ObjIt.first.str() +
+                  Twine("configuration key '") + StringRef(ObjIt.first) +
                       Twine("' expects a boolean, value ignored"),
                   DS_Warning));
             }
@@ -183,7 +183,7 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
           }
         } else if (!StringRef(ObjIt.first).ends_with(".description")) {
           Ctx.diagnose(DiagnosticInfoInstrumentation(
-              Twine("configuration key '") + ObjIt.first.str() +
+              Twine("configuration key '") + StringRef(ObjIt.first) +
                   Twine("' not found and ignored"),
               DS_Warning));
         }
@@ -205,7 +205,7 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
         Ctx.diagnose(DiagnosticInfoInstrumentation(
             Twine("malformed JSON configuration, expected an object matching "
                   "an instrumentor choice, got ") +
-                ObjIt.first.str(),
+                StringRef(ObjIt.first),
             DS_Warning));
         continue;
       }

--- a/llvm/lib/Transforms/IPO/InstrumentorUtils.cpp
+++ b/llvm/lib/Transforms/IPO/InstrumentorUtils.cpp
@@ -54,8 +54,7 @@ public:
     if (Pos < Expr.size() && Result)
       return createStringError(
           "unexpected characters at position " + std::to_string(Pos) + ": '" +
-          Expr.substr(Pos, std::min<size_t>(10, Expr.size() - Pos)).str() +
-          "'");
+          Expr.substr(Pos, std::min<size_t>(10, Expr.size() - Pos)) + "'");
 
     return Result;
   }
@@ -211,8 +210,8 @@ private:
             "'");
       }
 
-      return createStringError("unknown method '" + MethodName.str() +
-                               "' on property '" + PropName.str() + "'");
+      return createStringError("unknown method '" + MethodName +
+                               "' on property '" + PropName + "'");
     }
 
     // Check if this is an integer property.
@@ -251,8 +250,7 @@ private:
         }
       } else {
         return createStringError(
-            "expected comparison operator after property '" + PropName.str() +
-            "'");
+            "expected comparison operator after property '" + PropName + "'");
       }
 
       skipWhitespace();
@@ -276,8 +274,7 @@ private:
       StringRef ValueStr = Expr.slice(Start, Pos);
       int64_t RHS = 0;
       if (ValueStr.getAsInteger(10, RHS))
-        return createStringError("invalid integer value '" + ValueStr.str() +
-                                 "'");
+        return createStringError("invalid integer value '" + ValueStr + "'");
 
       if (Negative)
         RHS = -RHS;
@@ -316,13 +313,13 @@ private:
           Op = NE;
           Pos += 2;
         } else {
-          return createStringError("string property '" + PropName.str() +
+          return createStringError("string property '" + PropName +
                                    "' only supports == and != operators");
         }
       } else {
         return createStringError(
-            "expected comparison operator after string property '" +
-            PropName.str() + "'");
+            "expected comparison operator after string property '" + PropName +
+            "'");
       }
 
       skipWhitespace();
@@ -358,13 +355,13 @@ private:
           Op = NE;
           Pos += 2;
         } else {
-          return createStringError("pointer property '" + PropName.str() +
+          return createStringError("pointer property '" + PropName +
                                    "' only supports == and != operators");
         }
       } else {
         return createStringError(
-            "expected comparison operator after pointer property '" +
-            PropName.str() + "'");
+            "expected comparison operator after pointer property '" + PropName +
+            "'");
       }
 
       skipWhitespace();
@@ -378,7 +375,7 @@ private:
       if (RHS != "null")
         return createStringError("pointer comparisons only support 'null' as "
                                  "right-hand side, got '" +
-                                 RHS.str() + "'");
+                                 RHS + "'");
 
       // Check if the pointer is a constant null.
       bool IsNull = false;
@@ -405,7 +402,7 @@ private:
 
     // Unknown property, record an error.
     return createStringError("expected enabled property name, got '" +
-                             PropName.str() + "'");
+                             PropName + "'");
   }
 };
 } // anonymous namespace

--- a/llvm/tools/llvm-debuginfod/llvm-debuginfod.cpp
+++ b/llvm/tools/llvm-debuginfod/llvm-debuginfod.cpp
@@ -138,7 +138,7 @@ int llvm_debuginfod_main(int argc, char **argv, const llvm::ToolContext &) {
   else
     ExitOnErr(Server.Server.bind(Port, HostInterface.c_str()));
 
-  Log.push("Listening on port " + Twine(Port).str());
+  Log.push("Listening on port " + Twine(Port));
 
   Pool.async([&]() { ExitOnErr(Server.Server.listen()); });
   Pool.async([&]() {

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -723,7 +723,7 @@ static bool dumpObjectFile(ObjectFile &Obj, DWARFContext &DICtx,
   if (!MCRegInfo)
     logAllUnhandledErrors(createStringError(inconvertibleErrorCode(),
                                             "Error in creating MCRegInfo"),
-                          errs(), Filename.str() + ": ");
+                          errs(), Filename + ": ");
 
   auto GetRegName = [&MCRegInfo](uint64_t DwarfRegNum, bool IsEH) -> StringRef {
     if (!MCRegInfo)

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -1379,7 +1379,7 @@ static void addPltEntries(const MCSubtargetInfo &STI, const ObjectFile &Obj,
       if (Expected<StringRef> NameOrErr = Symbol.getName()) {
         if (!NameOrErr->empty())
           AllSymbols[SectionNames[Plt.Section]].emplace_back(
-              Plt.Address, Saver.save((*NameOrErr + "@plt").str()), SymbolType);
+              Plt.Address, Saver.save(*NameOrErr + "@plt"), SymbolType);
         continue;
       } else {
         // The warning has been reported in disassembleObject().


### PR DESCRIPTION
Several call sites across Bitcode, MC, CAS, ObjCopy, TableGen, the IPO Instrumentor, and command-line tools pass `expr.str()` to parameters of type `const llvm::Twine &`, forcing a throwaway heap std::string that is immediately rewrapped into a Twine. Drop the `.str()` and let Twine accept the StringRef/concatenation directly.

Assisted-by: Claude Opus 4.8