### PR TITLE
[clang] Avoid premature Twine .str() materialization

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/FormulaSerialization.cpp
+++ b/clang/lib/Analysis/FlowSensitive/FormulaSerialization.cpp
@@ -203,9 +203,8 @@ parseFormula(llvm::StringRef Str, Arena &A,
     return F.takeError();
   if (!Str.empty())
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   ("unexpected suffix of length: " +
-                                    llvm::Twine(Str.size() - OriginalSize))
-                                       .str());
+                                   "unexpected suffix of length: " +
+                                       llvm::Twine(Str.size() - OriginalSize));
   return F;
 }
 

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -1522,10 +1522,10 @@ static void initializeBuffer(CodeGenModule &CGM, llvm::GlobalVariable *GV,
                              ArrayRef<llvm::Value *> Args) {
 
   LLVMContext &Ctx = CGM.getLLVMContext();
-  llvm::Function *InitResFunc = llvm::Function::Create(
-      llvm::FunctionType::get(CGM.VoidTy, false),
-      llvm::GlobalValue::InternalLinkage,
-      ("_init_buffer_" + GV->getName()).str(), CGM.getModule());
+  llvm::Function *InitResFunc =
+      llvm::Function::Create(llvm::FunctionType::get(CGM.VoidTy, false),
+                             llvm::GlobalValue::InternalLinkage,
+                             "_init_buffer_" + GV->getName(), CGM.getModule());
   InitResFunc->addFnAttr(llvm::Attribute::AlwaysInline);
 
   llvm::BasicBlock *EntryBB =

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6503,7 +6503,7 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
     StringRef FcValue = C.getArgs().getLastArgValue(options::OPT_dxc_Fc);
     // TODO: Should we use `MakeCLOutputFilename` here? If so, we can probably
     // handle this as part of the SLASH_Fa handling below.
-    return C.addResultFile(C.getArgs().MakeArgString(FcValue.str()), &JA);
+    return C.addResultFile(C.getArgs().MakeArgString(FcValue), &JA);
   }
 
   if ((JA.getType() == types::TY_Object &&
@@ -6519,7 +6519,7 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
     // that is using Fc or just printing disassembly.
     if (TC.isLastOutputProducingJob(C.getArgs(), JA.getKind()) &&
         !FoValue.empty())
-      return C.addResultFile(C.getArgs().MakeArgString(FoValue.str()), &JA);
+      return C.addResultFile(C.getArgs().MakeArgString(FoValue), &JA);
     StringRef Name = llvm::sys::path::filename(BaseInput);
     std::pair<StringRef, StringRef> Split = Name.split('.');
     const char *Suffix = types::getTypeTempSuffix(JA.getType(), true);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1943,7 +1943,7 @@ void Clang::AddPPCTargetArgs(const ArgList &Args,
   if (Arg *A = Args.getLastArg(options::OPT_mtune_EQ)) {
     CmdArgs.push_back("-tune-cpu");
     StringRef CPU = llvm::PPC::getNormalizedPPCTuneCPU(T, A->getValue());
-    CmdArgs.push_back(Args.MakeArgString(CPU.str()));
+    CmdArgs.push_back(Args.MakeArgString(CPU));
   }
 
   // Select the ABI to use.

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -4630,7 +4630,7 @@ loadAndParseConfigFile(StringRef ConfigFile, llvm::vfs::FileSystem *FS,
                        llvm::SourceMgr::DiagHandlerTy DiagHandler,
                        bool IsDotHFile) {
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> Text =
-      FS->getBufferForFile(ConfigFile.str());
+      FS->getBufferForFile(ConfigFile);
   if (auto EC = Text.getError())
     return EC;
   if (auto EC = parseConfiguration(*Text.get(), Style, AllowUnknownOptions,

--- a/clang/lib/Frontend/DependencyFile.cpp
+++ b/clang/lib/Frontend/DependencyFile.cpp
@@ -345,7 +345,7 @@ static void PrintFilename(raw_ostream &OS, StringRef Filename,
                           DependencyOutputFormat OutputFormat) {
   // Convert filename to platform native path
   llvm::SmallString<256> NativePath;
-  llvm::sys::path::native(Filename.str(), NativePath);
+  llvm::sys::path::native(Filename, NativePath);
 
   if (OutputFormat == DependencyOutputFormat::NMake) {
     // Add quotes if needed. These are the characters listed as "special" to

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -1283,8 +1283,7 @@ void Parser::parseOMPContextSelectorSet(
     Diag(Tok.getLocation(), diag::warn_omp_declare_variant_expected)
         << "="
         << ("context set name \"" + getOpenMPContextTraitSetName(TISet.Kind) +
-            "\"")
-               .str();
+            "\"");
 
   // Parse '{'.
   if (Tok.is(tok::l_brace)) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -11418,7 +11418,7 @@ static bool CheckMultiVersionValue(Sema &S, const FunctionDecl *FD) {
       auto BareFeat = StringRef{Feat}.substr(1);
       if (Feat[0] == '-') {
         S.Diag(FD->getLocation(), diag::err_bad_multiversion_option)
-            << Feature << ("no-" + BareFeat).str();
+            << Feature << ("no-" + BareFeat);
         return true;
       }
 

--- a/clang/lib/StaticAnalyzer/Checkers/Yaml.h
+++ b/clang/lib/StaticAnalyzer/Checkers/Yaml.h
@@ -37,7 +37,7 @@ std::optional<T> getConfiguration(CheckerManager &Mgr, Checker *Chk,
                   .getFileManager()
                   .getVirtualFileSystem();
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> Buffer =
-      VFS.getBufferForFile(ConfigFile.str());
+      VFS.getBufferForFile(ConfigFile);
 
   if (Buffer.getError()) {
     Mgr.reportInvalidCheckerOptionValue(Chk, Option,


### PR DESCRIPTION
Several call sites pass `expr.str()` to parameters of type `const llvm::Twine &`, forcing a throwaway heap std::string that is immediately rewrapped into a Twine. Drop the `.str()` and let Twine accept the StringRef/concatenation directly.

Assisted-by: Claude Opus 4.8