### PR TITLE
[lldb] Add missing dependency on lldbPluginObjectFilePlaceholder

### DIFF
--- a/lldb/source/Plugins/Process/elf-core/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/elf-core/CMakeLists.txt
@@ -20,6 +20,7 @@ add_lldb_library(lldbPluginProcessElfCore PLUGIN
     lldbCore
     lldbTarget
     lldbPluginDynamicLoaderPosixDYLD
+    lldbPluginObjectFilePlaceholder
     lldbPluginObjectFileELF
     lldbPluginProcessUtility
   )


### PR DESCRIPTION
Fixes shared library build after 882d0251.
