### PR TITLE
[NFC] Remove SVEShuffleOpts variable unused in release build

### DIFF
--- a/llvm/lib/Target/AArch64/SVEShuffleOpts.cpp
+++ b/llvm/lib/Target/AArch64/SVEShuffleOpts.cpp
@@ -101,8 +101,7 @@ using DeinterleaveMap = SmallDenseMap<CallInst *, std::array<CastInst *, 4>>;
 static void evaluateDeinterleave(IntrinsicInst *I, DeinterleaveMap &Candidates,
                                  Loop &L, const AArch64TargetLowering &TL,
                                  const DataLayout DL) {
-  unsigned IntId = I->getIntrinsicID();
-  assert(IntId == Intrinsic::vector_deinterleave4 &&
+  assert(I->getIntrinsicID() == Intrinsic::vector_deinterleave4 &&
          "Only deinterleave4 supported currently");
 
   ConstantRange VScaleRange = getVScaleRange(I->getFunction(), 64);


### PR DESCRIPTION
Fixes a warning-as-error build failure for #193951