### PR TITLE
[llvm][Target] Avoid premature Twine .str() materialization

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -5982,11 +5982,12 @@ bool AMDGPUAsmParser::ParseDirectiveAMDGCNTarget() {
 
   SMRange TargetRange = SMRange(TargetStart, getTok().getLoc());
   if (getTargetStreamer().getTargetID()->toString() != TargetIDDirective)
-    return getParser().Error(TargetRange.Start,
+    return getParser().Error(
+        TargetRange.Start,
         (Twine(".amdgcn_target directive's target id ") +
          Twine(TargetIDDirective) +
          Twine(" does not match the specified target id ") +
-         Twine(getTargetStreamer().getTargetID()->toString())).str());
+         Twine(getTargetStreamer().getTargetID()->toString())));
 
   return false;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
@@ -199,7 +199,7 @@ bool SPIRVExtensionsParser::parse(cl::Option &O, StringRef ArgName,
     auto NameValuePair = SPIRVExtensionMap.find(ExtensionName);
 
     if (NameValuePair == SPIRVExtensionMap.end())
-      return O.error("Unknown SPIR-V extension: " + Token.str());
+      return O.error("Unknown SPIR-V extension: " + Token);
 
     EnabledExtensions.insert(NameValuePair->second);
   }
@@ -221,7 +221,7 @@ bool SPIRVExtensionsParser::parse(cl::Option &O, StringRef ArgName,
     auto NameValuePair = SPIRVExtensionMap.find(Token.substr(1));
 
     if (NameValuePair == SPIRVExtensionMap.end())
-      return O.error("Unknown SPIR-V extension: " + Token.str());
+      return O.error("Unknown SPIR-V extension: " + Token);
     if (EnabledExtensions.count(NameValuePair->second))
       return O.error(
           "Extension cannot be allowed and disallowed at the same time: " +

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1627,9 +1627,9 @@ void SystemZAsmPrinter::emitPPA1(PPA1Info &Info) {
     assert(FPRSaveAreaOffset < 0x10000000 && "Offset out of range");
     FPRSaveAreaOffset &= 0x0FFFFFFF; // Lose top 4 bits.
     OutStreamer->AddComment(
-        Twine("  Bit 0-3: Register R").concat(utostr(Info.FrameReg)).str());
+        Twine("  Bit 0-3: Register R").concat(utostr(Info.FrameReg)));
     OutStreamer->AddComment(
-        Twine("  Bit 4-31: Offset ").concat(utostr(FPRSaveAreaOffset)).str());
+        Twine("  Bit 4-31: Offset ").concat(utostr(FPRSaveAreaOffset)));
     OutStreamer->emitInt32(FPRSaveAreaOffset |
                            (Info.FrameReg << 28)); // Offset to FPR save area
                                                    // with register to add
@@ -1647,9 +1647,9 @@ void SystemZAsmPrinter::emitPPA1(PPA1Info &Info) {
     VRSaveAreaOffset &= 0x0FFFFFFF; // Lose top 4 bits.
     OutStreamer->AddComment("VR Save Area Locator");
     OutStreamer->AddComment(
-        Twine("  Bit 0-3: Register R").concat(utostr(Info.FrameReg)).str());
+        Twine("  Bit 0-3: Register R").concat(utostr(Info.FrameReg)));
     OutStreamer->AddComment(
-        Twine("  Bit 4-31: Offset ").concat(utostr(VRSaveAreaOffset)).str());
+        Twine("  Bit 4-31: Offset ").concat(utostr(VRSaveAreaOffset)));
     OutStreamer->emitInt32(VRSaveAreaOffset | (Info.FrameReg << 28));
   }
 
@@ -1758,10 +1758,9 @@ void SystemZAsmPrinter::calculatePPA1() {
   // Save the calculated values.
   if (MF->getFunction().hasName())
     Info.Name = MF->getFunction().getName();
-  Info.PPA1 = OutContext.createTempSymbol(Twine("PPA1_").concat(N).str(), true);
-  Info.EPMarker =
-      OutContext.createTempSymbol(Twine("EPM_").concat(N).str(), true);
-  Info.FnEnd = OutContext.createTempSymbol(Twine(N).concat("end_").str());
+  Info.PPA1 = OutContext.createTempSymbol(Twine("PPA1_").concat(N), true);
+  Info.EPMarker = OutContext.createTempSymbol(Twine("EPM_").concat(N), true);
+  Info.FnEnd = OutContext.createTempSymbol(Twine(N).concat("end_"));
   Info.PersonalityRoutine = PersonalityRoutine;
   Info.GCCEH = GCCEH;
   Info.OffsetFPR = OffsetFPR;

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -1821,10 +1821,8 @@ void SystemZInstrInfo::expandStackGuardPseudo(MachineInstr &MI,
     // Emit a load of the global stack guard's address
     BuildMI(MBB, MI, DL, get(SystemZ::LOAD_GLOBAL_STACKGUARD_ADDR), AddrReg);
   } else {
-    report_fatal_error(
-        (Twine("unknown stack protector type \"") + GuardType + "\".")
-            .str()
-            .c_str());
+    report_fatal_error(Twine("unknown stack protector type \"") + GuardType +
+                       "\".");
   }
 
   // Construct the appropriate move or compare instruction using the


### PR DESCRIPTION
Call sites in the AMDGPU and SPIRV parsers and the SystemZ AsmPrinter / InstrInfo pass `expr.str()` (or `.str().c_str()`) to parameters of type `const llvm::Twine &`, forcing a throwaway heap std::string that is immediately rewrapped into a Twine. Drop the materialization and let Twine accept the concatenation directly.

Assisted-by: Claude Opus 4.8