### PR TITLE
[lldb] Fix format string

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3088,7 +3088,8 @@ Target::ReadInstructions(const Address &start_addr, uint32_t count,
 
   if (error.Fail())
     return llvm::createStringErrorV(
-        error.AsCString("Target::ReadInstructions failed to read memory at {}"),
+        error.AsCString(
+            "Target::ReadInstructions failed to read memory at {:x}"),
         start_addr.GetLoadAddress(this));
 
   const bool data_from_file = load_addr == LLDB_INVALID_ADDRESS;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3087,8 +3087,8 @@ Target::ReadInstructions(const Address &start_addr, uint32_t count,
                  force_live_memory, &load_addr);
 
   if (error.Fail())
-    return llvm::createStringError(
-        error.AsCString("Target::ReadInstructions failed to read memory at %s"),
+    return llvm::createStringErrorV(
+        error.AsCString("Target::ReadInstructions failed to read memory at {}"),
         start_addr.GetLoadAddress(this));
 
   const bool data_from_file = load_addr == LLDB_INVALID_ADDRESS;


### PR DESCRIPTION
GetLoadAddress() returns an integer value, not a null-terminated string.