### PR TITLE
[lld][bolt][flang][mlir] Avoid premature Twine .str() materialization

### DIFF
--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -1581,8 +1581,7 @@ void BinaryContext::foldFunction(BinaryFunction &ChildBF,
   // placeholder so that getSymbol() doesn't crash. In non-relocation mode,
   // this effectively renames the function.
   WriteCtxLock.lock();
-  ChildBF.getSymbols().push_back(
-      Ctx->getOrCreateSymbol("__ICF_" + ChildName.str()));
+  ChildBF.getSymbols().push_back(Ctx->getOrCreateSymbol("__ICF_" + ChildName));
   WriteCtxLock.unlock();
 
   ChildBF.setFolded(&ParentBF);

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -6553,7 +6553,7 @@ static mlir::ParseResult parseSpecifierList(
 
   if (regionArgs.size() != regionArgTypes.size())
     return parser.emitError(parser.getNameLoc(), "mismatch in number of " +
-                                                     specifierKeyword.str() +
+                                                     specifierKeyword +
                                                      " arg and types");
 
   if (failed(parser.parseRParen()))

--- a/flang/lib/Optimizer/OpenACC/Analysis/FIROpenACCSupportAnalysis.cpp
+++ b/flang/lib/Optimizer/OpenACC/Analysis/FIROpenACCSupportAnalysis.cpp
@@ -37,7 +37,7 @@ FIROpenACCSupportAnalysis::emitNYI(Location loc, const Twine &message) {
   TODO(loc, message);
   // Should be unreachable, but we return an actual diagnostic
   // to satisfy the interface.
-  return mlir::emitError(loc, "not yet implemented: " + message.str());
+  return mlir::emitError(loc, "not yet implemented: " + message);
 }
 
 bool FIROpenACCSupportAnalysis::isValidSymbolUse(Operation *user,

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -2622,7 +2622,7 @@ static void writeDependencyFile(Ctx &ctx) {
   // * $ is escapes as $$.
   auto printFilename = [](raw_fd_ostream &os, StringRef filename) {
     llvm::SmallString<256> nativePath;
-    llvm::sys::path::native(filename.str(), nativePath);
+    llvm::sys::path::native(filename, nativePath);
     llvm::sys::path::remove_dots(nativePath, /*remove_dot_dot=*/true);
     for (unsigned i = 0, e = nativePath.size(); i != e; ++i) {
       if (nativePath[i] == '#') {

--- a/lld/ELF/LTO.cpp
+++ b/lld/ELF/LTO.cpp
@@ -82,7 +82,7 @@ static lto::Config createConfig(Ctx &ctx) {
       c.Options.BBSections = BasicBlockSection::None;
     } else {
       ErrorOr<std::unique_ptr<MemoryBuffer>> MBOrErr =
-          MemoryBuffer::getFile(ctx.arg.ltoBasicBlockSections.str());
+          MemoryBuffer::getFile(ctx.arg.ltoBasicBlockSections);
       if (!MBOrErr) {
         ErrAlways(ctx) << "cannot open " << ctx.arg.ltoBasicBlockSections << ":"
                        << MBOrErr.getError().message();

--- a/lld/MachO/DriverUtils.cpp
+++ b/lld/MachO/DriverUtils.cpp
@@ -339,7 +339,7 @@ macho::findPathCombination(const Twine &name,
       bool exists = fs::exists(location);
       searchedDylib(location, exists);
       if (exists)
-        return saver().save(location.str());
+        return saver().save(location);
     }
   }
   return {};

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -1345,7 +1345,7 @@ void ObjcCategoryMerger::doMerge() {
     }
     if (!merged)
       warn("ObjC category merging skipped for class symbol' " +
-           baseClass->getName().str() + "'\n");
+           baseClass->getName() + "'\n");
   }
 
   // Erase all categories that were merged

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -470,7 +470,7 @@ std::unique_ptr<Pass> mlir::createViewOpGraphPass(raw_ostream &os) {
 /// Generate a CFG for a region and show it in a window.
 static void llvmViewGraph(Region &region, const Twine &name) {
   int fd;
-  std::string filename = llvm::createGraphFilename(name.str(), fd);
+  std::string filename = llvm::createGraphFilename(name, fd);
   {
     llvm::raw_fd_ostream os(fd, /*shouldClose=*/true);
     if (fd == -1) {


### PR DESCRIPTION
Call sites in lld (MachO/ELF), BOLT, Flang (FIR) and MLIR pass `expr.str()` to parameters of type `const llvm::Twine &`, forcing a throwaway heap std::string that is immediately rewrapped into a Twine. Drop the `.str()` and let Twine accept the StringRef/concatenation directly.

Assisted-by: Claude Opus 4.8