### PR TITLE
[Support] Remove unused parameter of DataExtractor constructor

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/LowLevel/DWARFDataExtractorSimple.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/LowLevel/DWARFDataExtractorSimple.h
@@ -31,15 +31,7 @@ public:
 
   DWARFDataExtractorBase(ArrayRef<uint8_t> Data, bool IsLittleEndian,
                          unsigned AddressSize)
-      : DataExtractor(
-            StringRef(reinterpret_cast<const char *>(Data.data()), Data.size()),
-            IsLittleEndian),
-        AddressSize(AddressSize) {}
-
-  /// Truncating constructor
-  DWARFDataExtractorBase(const DWARFDataExtractorBase &Other, size_t Length)
-      : DataExtractor(Other.getData().substr(0, Length), Other.isLittleEndian(),
-                      Other.getAddressSize()) {}
+      : DataExtractor(Data, IsLittleEndian), AddressSize(AddressSize) {}
 
   /// Get the address size for this extractor.
   unsigned getAddressSize() const { return AddressSize; }

--- a/llvm/include/llvm/Support/DataExtractor.h
+++ b/llvm/include/llvm/Support/DataExtractor.h
@@ -88,14 +88,6 @@ public:
                        Data.size())),
         IsLittleEndian(IsLittleEndian) {}
 
-  // TODO: Delete.
-  DataExtractor(StringRef Data, bool IsLittleEndian, uint8_t)
-      : DataExtractor(Data, IsLittleEndian) {}
-
-  // TODO: Delete.
-  DataExtractor(ArrayRef<uint8_t> Data, bool IsLittleEndian, uint8_t)
-      : DataExtractor(Data, IsLittleEndian) {}
-
   /// Get the data pointed to by this extractor.
   StringRef getData() const { return Data; }
   /// Get the endianness for this extractor.

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -41,7 +41,7 @@ static uint64_t debugStrOffsetsHeaderSize(DataExtractor StrOffsetsData,
 
 static uint64_t getCUAbbrev(StringRef Abbrev, uint64_t AbbrCode) {
   uint64_t Offset = 0;
-  DataExtractor AbbrevData(Abbrev, true, 0);
+  DataExtractor AbbrevData(Abbrev, true);
   while (AbbrevData.getULEB128(&Offset) != AbbrCode) {
     // Tag
     AbbrevData.getULEB128(&Offset);
@@ -83,19 +83,19 @@ getIndexedString(dwarf::Form Form, DataExtractor InfoData, uint64_t &InfoOffset,
         "DW_FORM_string, DW_FORM_strx, DW_FORM_strx1, DW_FORM_strx2, "
         "DW_FORM_strx3, DW_FORM_strx4, or DW_FORM_GNU_str_index.");
   }
-  DataExtractor StrOffsetsData(StrOffsets, true, 0);
+  DataExtractor StrOffsetsData(StrOffsets, true);
   uint64_t StrOffsetsOffset = 4 * StrIndex;
   StrOffsetsOffset += debugStrOffsetsHeaderSize(StrOffsetsData, Version);
 
   uint64_t StrOffset = StrOffsetsData.getU32(&StrOffsetsOffset);
-  DataExtractor StrData(Str, true, 0);
+  DataExtractor StrData(Str, true);
   return StrData.getCStr(&StrOffset);
 }
 
 static Expected<CompileUnitIdentifiers>
 getCUIdentifiers(InfoSectionUnitHeader &Header, StringRef Abbrev,
                  StringRef Info, StringRef StrOffsets, StringRef Str) {
-  DataExtractor InfoData(Info, true, 0);
+  DataExtractor InfoData(Info, true);
   uint64_t Offset = Header.HeaderSize;
   if (Header.Version >= 5 && Header.UnitType != dwarf::DW_UT_split_compile)
     return make_error<DWPError>(
@@ -106,7 +106,7 @@ getCUIdentifiers(InfoSectionUnitHeader &Header, StringRef Abbrev,
   CompileUnitIdentifiers ID;
 
   uint32_t AbbrCode = InfoData.getULEB128(&Offset);
-  DataExtractor AbbrevData(Abbrev, true, 0);
+  DataExtractor AbbrevData(Abbrev, true);
   uint64_t AbbrevOffset = getCUAbbrev(Abbrev, AbbrCode);
   auto Tag = static_cast<dwarf::Tag>(AbbrevData.getULEB128(&AbbrevOffset));
   if (Tag != dwarf::DW_TAG_compile_unit)
@@ -258,7 +258,7 @@ static Error addAllTypesFromTypesSection(
   for (StringRef Types : TypesSections) {
     Out.switchSection(OutputSection);
     uint64_t Offset = 0;
-    DataExtractor Data(Types, true, 0);
+    DataExtractor Data(Types, true);
     while (Data.isValidOffset(Offset)) {
       UnitIndexEntry Entry = CUEntry;
       // Zero out the debug_info contribution
@@ -465,7 +465,7 @@ writeStringsAndOffsets(DWPWriter &Out, DWPStringPool &Strings,
   // Pre-reserve based on estimated string count to avoid rehashing.
   OffsetRemapping.reserve(CurStrSection.size() / 20);
 
-  DataExtractor Data(CurStrSection, true, 0);
+  DataExtractor Data(CurStrSection, true);
   uint64_t LocalOffset = 0;
   uint64_t PrevOffset = 0;
 
@@ -488,7 +488,7 @@ writeStringsAndOffsets(DWPWriter &Out, DWPStringPool &Strings,
     PrevOffset = LocalOffset;
   }
 
-  Data = DataExtractor(CurStrOffsetSection, true, 0);
+  Data = DataExtractor(CurStrOffsetSection, true);
 
   Out.switchSection(DS_StrOffsets);
 
@@ -920,7 +920,7 @@ Error write(DWPWriter &Out, ArrayRef<std::string> Inputs,
     StringRef DwpSingleInfoSection = CurInfoSection.front();
 
     DWARFUnitIndex CUIndex(DW_SECT_INFO);
-    DataExtractor CUIndexData(CurCUIndexSection, Obj.isLittleEndian(), 0);
+    DataExtractor CUIndexData(CurCUIndexSection, Obj.isLittleEndian());
     if (!CUIndex.parse(CUIndexData))
       return make_error<DWPError>("failed to parse cu_index");
     if (CUIndex.getVersion() != IndexVersion)
@@ -993,7 +993,7 @@ Error write(DWPWriter &Out, ArrayRef<std::string> Inputs,
       }
 
       DWARFUnitIndex TUIndex(TUSectionKind);
-      DataExtractor TUIndexData(CurTUIndexSection, Obj.isLittleEndian(), 0);
+      DataExtractor TUIndexData(CurTUIndexSection, Obj.isLittleEndian());
       if (!TUIndex.parse(TUIndexData))
         return make_error<DWPError>("failed to parse tu_index");
       if (TUIndex.getVersion() != IndexVersion)

--- a/llvm/tools/llvm-dwarfdump/Statistics.cpp
+++ b/llvm/tools/llvm-dwarfdump/Statistics.cpp
@@ -341,8 +341,7 @@ static void collectStatsForDie(DWARFDie Die, const std::string &FnPrefix,
 
   auto IsEntryValue = [&](ArrayRef<uint8_t> D) -> bool {
     DWARFUnit *U = Die.getDwarfUnit();
-    DataExtractor Data(toStringRef(D),
-                       Die.getDwarfUnit()->getContext().isLittleEndian(), 0);
+    DataExtractor Data(D, Die.getDwarfUnit()->getContext().isLittleEndian());
     DWARFExpression Expression(Data, U->getAddressByteSize(),
                                U->getFormParams().Format);
     // Consider the expression containing the DW_OP_entry_value as

--- a/llvm/tools/llvm-objdump/SourcePrinter.cpp
+++ b/llvm/tools/llvm-objdump/SourcePrinter.cpp
@@ -92,8 +92,7 @@ bool LiveVariable::liveAtAddress(object::SectionedAddress Addr) const {
 }
 
 void LiveVariable::print(raw_ostream &OS, const MCRegisterInfo &MRI) const {
-  DataExtractor Data({LocExpr.Expr.data(), LocExpr.Expr.size()},
-                     Unit->getContext().isLittleEndian(), 0);
+  DataExtractor Data(LocExpr.Expr, Unit->getContext().isLittleEndian());
   DWARFExpression Expression(Data, Unit->getAddressByteSize());
 
   auto GetRegName = [&MRI, &OS](uint64_t DwarfRegNum, bool IsEH) -> StringRef {

--- a/llvm/tools/llvm-readobj/DwarfCFIEHPrinter.h
+++ b/llvm/tools/llvm-readobj/DwarfCFIEHPrinter.h
@@ -114,8 +114,7 @@ void PrinterContext<ELFT>::printEHFrameHdr(const Elf_Phdr *EHFramePHdr) const {
   if (!Content)
     reportError(Content.takeError(), ObjF.getFileName());
 
-  DataExtractor DE(*Content, ELFT::Endianness == llvm::endianness::little,
-                   ELFT::Is64Bits ? 8 : 4);
+  DataExtractor DE(*Content, ELFT::Endianness == llvm::endianness::little);
 
   DictScope D(W, "Header");
   uint64_t Offset = 0;

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -5274,7 +5274,7 @@ template <class ELFT> void GNUELFDumper<ELFT>::printCGProfile() {
 template <class ELFT>
 bool ELFDumper<ELFT>::processCallGraphSection(const Elf_Shdr *CGSection) {
   ArrayRef<uint8_t> Contents = cantFail(Obj.getSectionContents(*CGSection));
-  DataExtractor Data(Contents, Obj.isLE(), ObjF.getBytesInAddress());
+  DataExtractor Data(Contents, Obj.isLE());
   DataExtractor::Cursor C(0);
   uint64_t UnknownCount = 0;
   while (C && C.tell() < CGSection->sh_size) {

--- a/llvm/tools/obj2yaml/elf2yaml.cpp
+++ b/llvm/tools/obj2yaml/elf2yaml.cpp
@@ -1024,7 +1024,7 @@ ELFDumper<ELFT>::dumpAddrsigSection(const Elf_Shdr *Shdr) {
 
   ArrayRef<uint8_t> Content = *ContentOrErr;
   DataExtractor::Cursor Cur(0);
-  DataExtractor Data(Content, Obj.isLE(), /*AddressSize=*/0);
+  DataExtractor Data(Content, Obj.isLE());
   std::vector<ELFYAML::YAMLFlowString> Symbols;
   while (Cur && Cur.tell() < Content.size()) {
     uint64_t SymNdx = Data.getULEB128(Cur);
@@ -1134,7 +1134,7 @@ ELFDumper<ELFT>::dumpCallGraphProfileSection(const Elf_Shdr *Shdr) {
 
   std::vector<ELFYAML::CallGraphEntryWeight> Entries(Content.size() /
                                                      SizeOfEntry);
-  DataExtractor Data(Content, Obj.isLE(), /*AddressSize=*/0);
+  DataExtractor Data(Content, Obj.isLE());
   DataExtractor::Cursor Cur(0);
   auto ReadEntry = [&](ELFYAML::CallGraphEntryWeight &E) {
     E.Weight = Data.getU64(Cur);
@@ -1358,7 +1358,7 @@ ELFDumper<ELFT>::dumpHashSection(const Elf_Shdr *Shdr) {
   }
 
   DataExtractor::Cursor Cur(0);
-  DataExtractor Data(Content, Obj.isLE(), /*AddressSize=*/0);
+  DataExtractor Data(Content, Obj.isLE());
   uint64_t NBucket = Data.getU32(Cur);
   uint64_t NChain = Data.getU32(Cur);
   if (Content.size() != (2 + NBucket + NChain) * 4) {

--- a/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCompactPrinterTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCompactPrinterTest.cpp
@@ -164,7 +164,7 @@ TEST(NVPTXPackedRegister, Compact_DW_OP_regx_NoMRI) {
 
   std::string Result;
   raw_string_ostream OS(Result);
-  DataExtractor DE(Enc, true, 8);
+  DataExtractor DE(Enc, true);
   DWARFExpression Expr(DE, 8);
 
   printDwarfExpressionCompact(&Expr, OS, nullptr);
@@ -179,7 +179,7 @@ TEST(NVPTXPackedRegister, Full_DW_OP_regx_NoMRI) {
 
   std::string Result;
   raw_string_ostream OS(Result);
-  DataExtractor DE(Enc, true, 8);
+  DataExtractor DE(Enc, true);
   DWARFExpression Expr(DE, 8);
 
   DIDumpOptions DumpOpts;
@@ -195,7 +195,7 @@ TEST(NVPTXPackedRegister, Full_DW_OP_regx_CallbackMiss) {
 
   std::string Result;
   raw_string_ostream OS(Result);
-  DataExtractor DE(Enc, true, 8);
+  DataExtractor DE(Enc, true);
   DWARFExpression Expr(DE, 8);
 
   DIDumpOptions DumpOpts;

--- a/llvm/unittests/Support/DataExtractorTest.cpp
+++ b/llvm/unittests/Support/DataExtractorTest.cpp
@@ -20,7 +20,7 @@ const char leb128data[] = "\xA6\x49";
 const char bigleb128data[] = "\xAA\xA9\xFF\xAA\xFF\xAA\xFF\x4A";
 
 TEST(DataExtractorTest, OffsetOverflow) {
-  DataExtractor DE(StringRef(numberData, sizeof(numberData)-1), false, 8);
+  DataExtractor DE(StringRef(numberData, sizeof(numberData) - 1), false);
   EXPECT_FALSE(DE.isValidOffsetForDataOfSize(-2U, 5));
 }
 
@@ -75,7 +75,7 @@ TEST(DataExtractorTest, UnsignedNumbers) {
 static void TestGetUnsignedHelper(bool IsLittleEndian) {
   // Use data with distinct byte values so each size produces a unique result.
   const char data[] = "\x01\x02\x03\x04\x05\x06\x07\x08";
-  DataExtractor DE(StringRef(data, sizeof(data) - 1), IsLittleEndian, 8);
+  DataExtractor DE(StringRef(data, sizeof(data) - 1), IsLittleEndian);
 
   // Expected values for big-endian: bytes are read high-to-low.
   // Expected values for little-endian: bytes are read low-to-high.
@@ -110,7 +110,7 @@ TEST(DataExtractorTest, GetUnsigned) {
 }
 
 TEST(DataExtractorTest, SignedNumbers) {
-  DataExtractor DE(StringRef(numberData, sizeof(numberData)-1), false, 8);
+  DataExtractor DE(StringRef(numberData, sizeof(numberData) - 1), false);
   uint64_t offset = 0;
 
   EXPECT_EQ(-128, DE.getSigned(&offset, 1));
@@ -143,7 +143,7 @@ TEST(DataExtractorTest, SignedNumbers) {
 
 TEST(DataExtractorTest, Strings) {
   const char stringData[] = "hellohello\0hello";
-  DataExtractor DE(StringRef(stringData, sizeof(stringData)-1), false, 8);
+  DataExtractor DE(StringRef(stringData, sizeof(stringData) - 1), false);
   uint64_t offset = 0;
 
   EXPECT_EQ(stringData, DE.getCStr(&offset));
@@ -162,7 +162,7 @@ TEST(DataExtractorTest, Strings) {
 }
 
 TEST(DataExtractorTest, LEB128) {
-  DataExtractor DE(StringRef(leb128data, sizeof(leb128data)-1), false, 8);
+  DataExtractor DE(StringRef(leb128data, sizeof(leb128data) - 1), false);
   uint64_t offset = 0;
 
   EXPECT_EQ(9382ULL, DE.getULEB128(&offset));
@@ -171,7 +171,7 @@ TEST(DataExtractorTest, LEB128) {
   EXPECT_EQ(-7002LL, DE.getSLEB128(&offset));
   EXPECT_EQ(2U, offset);
 
-  DataExtractor BDE(StringRef(bigleb128data, sizeof(bigleb128data)-1), false,8);
+  DataExtractor BDE(StringRef(bigleb128data, sizeof(bigleb128data) - 1), false);
   offset = 0;
   EXPECT_EQ(42218325750568106ULL, BDE.getULEB128(&offset));
   EXPECT_EQ(8U, offset);
@@ -181,7 +181,7 @@ TEST(DataExtractorTest, LEB128) {
 }
 
 TEST(DataExtractorTest, LEB128_error) {
-  DataExtractor DE(StringRef("\x81"), false, 8);
+  DataExtractor DE(StringRef("\x81"), false);
   uint64_t Offset = 0;
   EXPECT_EQ(0U, DE.getULEB128(&Offset));
   EXPECT_EQ(0U, Offset);
@@ -214,7 +214,7 @@ TEST(DataExtractorTest, LEB128_error) {
 }
 
 TEST(DataExtractorTest, Cursor_tell) {
-  DataExtractor DE(StringRef("AB"), false, 8);
+  DataExtractor DE(StringRef("AB"), false);
   DataExtractor::Cursor C(0);
   // A successful read operation advances the cursor
   EXPECT_EQ('A', DE.getU8(C));
@@ -244,7 +244,7 @@ TEST(DataExtractorTest, Cursor_seek) {
 }
 
 TEST(DataExtractorTest, Cursor_takeError) {
-  DataExtractor DE(StringRef("AB"), false, 8);
+  DataExtractor DE(StringRef("AB"), false);
   DataExtractor::Cursor C(0);
   // Initially, the cursor is in the "success" state.
   EXPECT_THAT_ERROR(C.takeError(), Succeeded());
@@ -268,7 +268,7 @@ TEST(DataExtractorTest, Cursor_takeError) {
 }
 
 TEST(DataExtractorTest, Cursor_chaining) {
-  DataExtractor DE(StringRef("ABCD"), false, 8);
+  DataExtractor DE(StringRef("ABCD"), false);
   DataExtractor::Cursor C(0);
 
   // Multiple reads can be chained without trigerring any assertions.
@@ -283,7 +283,7 @@ TEST(DataExtractorTest, Cursor_chaining) {
 #if defined(GTEST_HAS_DEATH_TEST) && defined(_DEBUG) &&                        \
     LLVM_ENABLE_ABI_BREAKING_CHECKS
 TEST(DataExtractorDeathTest, Cursor) {
-  DataExtractor DE(StringRef("AB"), false, 8);
+  DataExtractor DE(StringRef("AB"), false);
 
   // Even an unused cursor must be checked for errors:
   EXPECT_DEATH(DataExtractor::Cursor(0),
@@ -327,7 +327,7 @@ TEST(DataExtractorDeathTest, Cursor) {
 #endif
 
 TEST(DataExtractorTest, getU8_vector) {
-  DataExtractor DE(StringRef("AB"), false, 8);
+  DataExtractor DE(StringRef("AB"), false);
   DataExtractor::Cursor C(0);
   SmallVector<uint8_t, 2> S;
 
@@ -347,7 +347,7 @@ TEST(DataExtractorTest, getU8_vector) {
 }
 
 TEST(DataExtractorTest, getU24) {
-  DataExtractor DE(StringRef("ABCD"), false, 8);
+  DataExtractor DE(StringRef("ABCD"), false);
   DataExtractor::Cursor C(0);
 
   EXPECT_EQ(0x414243u, DE.getU24(C));
@@ -357,7 +357,7 @@ TEST(DataExtractorTest, getU24) {
 }
 
 TEST(DataExtractorTest, skip) {
-  DataExtractor DE(StringRef("AB"), false, 8);
+  DataExtractor DE(StringRef("AB"), false);
   DataExtractor::Cursor C(0);
 
   DE.skip(C, 4);
@@ -370,7 +370,7 @@ TEST(DataExtractorTest, skip) {
 }
 
 TEST(DataExtractorTest, eof) {
-  DataExtractor DE(StringRef("A"), false, 8);
+  DataExtractor DE(StringRef("A"), false);
   DataExtractor::Cursor C(0);
 
   EXPECT_FALSE(DE.eof(C));
@@ -386,16 +386,15 @@ TEST(DataExtractorTest, eof) {
 
 TEST(DataExtractorTest, size) {
   uint8_t Data[] = {'A', 'B', 'C', 'D'};
-  DataExtractor DE1(StringRef(reinterpret_cast<char *>(Data), sizeof(Data)),
-                    false, 8);
+  DataExtractor DE1(Data, false);
   EXPECT_EQ(DE1.size(), sizeof(Data));
-  DataExtractor DE2(ArrayRef<uint8_t>(Data), false, 8);
+  DataExtractor DE2(ArrayRef<uint8_t>(Data), false);
   EXPECT_EQ(DE2.size(), sizeof(Data));
 }
 
 TEST(DataExtractorTest, FixedLengthString) {
   const char Data[] = "hello\x00\x00\x00world  \thola\x00";
-  DataExtractor DE(StringRef(Data, sizeof(Data)-1), false, 8);
+  DataExtractor DE(StringRef(Data, sizeof(Data) - 1), false);
   uint64_t Offset = 0;
   StringRef Str;
   // Test extracting too many bytes doesn't modify Offset and returns
@@ -426,7 +425,7 @@ TEST(DataExtractorTest, GetBytes) {
   // Use data with an embedded NULL character for good measure.
   const char Data[] = "\x01\x02\x00\x04";
   StringRef Bytes(Data, sizeof(Data)-1);
-  DataExtractor DE(Bytes, false, 8);
+  DataExtractor DE(Bytes, false);
   uint64_t Offset = 0;
   StringRef Str;
   // Test extracting too many bytes doesn't modify Offset and returns


### PR DESCRIPTION
#190519 removed the uses of the parameter, and several follow-up patches cleaned up call sites. This is the last patch in the series that finally removes the parameter.
While here, also remove the unused "truncating constructor".
