### PR TITLE
[mlir][ptr] Add constantop convertion

### DIFF
--- a/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
+++ b/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
@@ -396,16 +396,19 @@ LogicalResult ConstantOpConversion::matchAndRewrite(
 
   if (isa<ptr::NullAttr>(value)) {
     rewriter.replaceOpWithNewOp<LLVM::ZeroOp>(op, resultType);
-  } else if (auto addrAttr = dyn_cast<ptr::AddressAttr>(value)) {
-    Type intType = rewriter.getIntegerType(addrAttr.getValue().getBitWidth());
-    Value intConst = LLVM::ConstantOp::create(rewriter, op.getLoc(), intType,
-                                              addrAttr.getValue());
-    rewriter.replaceOpWithNewOp<LLVM::IntToPtrOp>(op, resultType, intConst);
-  } else {
+    return success();
+  } 
+  auto addrAttr = dyn_cast<ptr::AddressAttr>(value);
+  // Early-exit if unknown attribute.
+  if (!addrAttr) {
     return rewriter.notifyMatchFailure(
         op, "unsupported value attribute kind: " +
                 value.getAbstractAttribute().getName());
   }
+  Type intType = rewriter.getIntegerType(addrAttr.getValue().getBitWidth());
+   Value intConst = LLVM::ConstantOp::create(rewriter, op.getLoc(), intType,
+                                            addrAttr.getValue());
+  rewriter.replaceOpWithNewOp<LLVM::IntToPtrOp>(op, resultType, intConst);
   return success();
 }
 

--- a/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
+++ b/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
@@ -73,6 +73,16 @@ struct TypeOffsetOpConversion
   matchAndRewrite(ptr::TypeOffsetOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;
 };
+
+//===----------------------------------------------------------------------===//
+// ConstantOpConversion
+//===----------------------------------------------------------------------===//
+struct ConstantOpConversion : public ConvertOpToLLVMPattern<ptr::ConstantOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  LogicalResult
+  matchAndRewrite(ptr::ConstantOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -371,6 +381,35 @@ LogicalResult TypeOffsetOpConversion::matchAndRewrite(
 }
 
 //===----------------------------------------------------------------------===//
+// ConstantOpConversion
+//===----------------------------------------------------------------------===//
+
+LogicalResult ConstantOpConversion::matchAndRewrite(
+    ptr::ConstantOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  mlir::TypedAttr value = op.getValue();
+  Type resultType = getTypeConverter()->convertType(op.getType());
+  if (!resultType)
+    return rewriter.notifyMatchFailure(op, "Couldn't convert the result type");
+
+  if (llvm::dyn_cast<ptr::NullAttr>(value)) {
+    rewriter.replaceOpWithNewOp<LLVM::ZeroOp>(op, resultType);
+    return llvm::success();
+  }
+
+  auto llvmPtrType = cast<LLVM::LLVMPointerType>(resultType);
+  auto addrAttr = cast<ptr::AddressAttr>(value);
+  unsigned addressSpace = llvmPtrType.getAddressSpace();
+  unsigned bitwidth = getTypeConverter()->getPointerBitwidth(addressSpace);
+  Type intType = rewriter.getIntegerType(bitwidth);
+  APInt addr = addrAttr.getValue().zextOrTrunc(bitwidth);
+  Value intConst =
+      LLVM::ConstantOp::create(rewriter, op.getLoc(), intType, addr);
+  rewriter.replaceOpWithNewOp<LLVM::IntToPtrOp>(op, resultType, intConst);
+  return llvm::success();
+}
+
+//===----------------------------------------------------------------------===//
 // ConvertToLLVMPatternInterface implementation
 //===----------------------------------------------------------------------===//
 
@@ -433,7 +472,8 @@ void mlir::ptr::populatePtrToLLVMConversionPatterns(
 
   // Add conversion patterns.
   patterns.add<FromPtrOpConversion, GetMetadataOpConversion, PtrAddOpConversion,
-               ToPtrOpConversion, TypeOffsetOpConversion>(converter);
+               ToPtrOpConversion, TypeOffsetOpConversion, ConstantOpConversion>(
+      converter);
 }
 
 void mlir::ptr::registerConvertPtrToLLVMInterface(DialectRegistry &registry) {

--- a/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
+++ b/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
@@ -15,8 +15,10 @@
 #include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/Ptr/IR/PtrAttrs.h"
 #include "mlir/Dialect/Ptr/IR/PtrOps.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "llvm/Support/LogicalResult.h"
 #include <type_traits>
 
 using namespace mlir;
@@ -387,25 +389,23 @@ LogicalResult TypeOffsetOpConversion::matchAndRewrite(
 LogicalResult ConstantOpConversion::matchAndRewrite(
     ptr::ConstantOp op, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
-  mlir::TypedAttr value = op.getValue();
+  TypedAttr value = op.getValue();
   Type resultType = getTypeConverter()->convertType(op.getType());
   if (!resultType)
     return rewriter.notifyMatchFailure(op, "Couldn't convert the result type");
 
-  if (llvm::dyn_cast<ptr::NullAttr>(value)) {
+  if (isa<ptr::NullAttr>(value)) {
     rewriter.replaceOpWithNewOp<LLVM::ZeroOp>(op, resultType);
-    return llvm::success();
+  } else if (auto addrAttr = dyn_cast<ptr::AddressAttr>(value)) {
+    Type intType = rewriter.getIntegerType(addrAttr.getValue().getBitWidth());
+    Value intConst = LLVM::ConstantOp::create(rewriter, op.getLoc(), intType,
+                                              addrAttr.getValue());
+    rewriter.replaceOpWithNewOp<LLVM::IntToPtrOp>(op, resultType, intConst);
+  } else {
+    return rewriter.notifyMatchFailure(
+        op, "unsupported value attribute kind: " +
+                value.getAbstractAttribute().getName());
   }
-
-  auto llvmPtrType = cast<LLVM::LLVMPointerType>(resultType);
-  auto addrAttr = cast<ptr::AddressAttr>(value);
-  unsigned addressSpace = llvmPtrType.getAddressSpace();
-  unsigned bitwidth = getTypeConverter()->getPointerBitwidth(addressSpace);
-  Type intType = rewriter.getIntegerType(bitwidth);
-  APInt addr = addrAttr.getValue().zextOrTrunc(bitwidth);
-  Value intConst =
-      LLVM::ConstantOp::create(rewriter, op.getLoc(), intType, addr);
-  rewriter.replaceOpWithNewOp<LLVM::IntToPtrOp>(op, resultType, intConst);
   return success();
 }
 

--- a/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
+++ b/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
@@ -397,7 +397,7 @@ LogicalResult ConstantOpConversion::matchAndRewrite(
   if (isa<ptr::NullAttr>(value)) {
     rewriter.replaceOpWithNewOp<LLVM::ZeroOp>(op, resultType);
     return success();
-  } 
+  }
   auto addrAttr = dyn_cast<ptr::AddressAttr>(value);
   // Early-exit if unknown attribute.
   if (!addrAttr) {
@@ -406,7 +406,7 @@ LogicalResult ConstantOpConversion::matchAndRewrite(
                 value.getAbstractAttribute().getName());
   }
   Type intType = rewriter.getIntegerType(addrAttr.getValue().getBitWidth());
-   Value intConst = LLVM::ConstantOp::create(rewriter, op.getLoc(), intType,
+  Value intConst = LLVM::ConstantOp::create(rewriter, op.getLoc(), intType,
                                             addrAttr.getValue());
   rewriter.replaceOpWithNewOp<LLVM::IntToPtrOp>(op, resultType, intConst);
   return success();

--- a/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
+++ b/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
@@ -406,7 +406,7 @@ LogicalResult ConstantOpConversion::matchAndRewrite(
   Value intConst =
       LLVM::ConstantOp::create(rewriter, op.getLoc(), intType, addr);
   rewriter.replaceOpWithNewOp<LLVM::IntToPtrOp>(op, resultType, intConst);
-  return llvm::success();
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Conversion/PtrToLLVM/ptr-to-llvm.mlir
+++ b/mlir/test/Conversion/PtrToLLVM/ptr-to-llvm.mlir
@@ -316,3 +316,17 @@ func.func @test_memref_ptradd_indexing(%arg0: memref<10x?x30xf32, #ptr.generic_s
   %3 = ptr.ptr_add %0, %2 : !ptr.ptr<#ptr.generic_space>, index
   return %3 : !ptr.ptr<#ptr.generic_space>
 }
+
+// CHECK-LABEL: func @test_constant_address_ops
+//       CHECK:   %[[C_0:.*]] = llvm.mlir.constant(0 : i64) : i64
+//       CHECK:   %[[PTR_0:.*]] = llvm.inttoptr %[[C_0]] : i64 to !llvm.ptr
+//       CHECK:   %[[PTR_ZERO:.*]] = llvm.mlir.zero : !llvm.ptr
+//       CHECK:   %[[RET_0:.*]] = llvm.mlir.poison : !llvm.struct<(ptr, ptr)>
+//       CHECK:   %[[RET_1:.*]] = llvm.insertvalue %[[PTR_0]], %[[RET_0]][0] : !llvm.struct<(ptr, ptr)>
+//       CHECK:   %[[RET_2:.*]] = llvm.insertvalue %[[PTR_ZERO]], %[[RET_1]][1] : !llvm.struct<(ptr, ptr)>
+//       CHECK:   llvm.return %[[RET_2]] : !llvm.struct<(ptr, ptr)>
+func.func @test_constant_address_ops() -> (!ptr.ptr<#ptr.generic_space>, !ptr.ptr<#ptr.generic_space>) {
+  %addr_0 = ptr.constant #ptr.address<0> : !ptr.ptr<#ptr.generic_space>
+  %null = ptr.constant #ptr.null : !ptr.ptr<#ptr.generic_space> 
+  return %addr_0, %null : !ptr.ptr<#ptr.generic_space>, !ptr.ptr<#ptr.generic_space>
+}


### PR DESCRIPTION
Previously, Ptr.ConstantOp was missing the lowering pattern to LLVM IR. This PR adds the missing conversion logic. See https://github.com/llvm/llvm-project/pull/190527#issuecomment-4751141164.