### PR TITLE
clang/AMDGPU: Remove driver restriction on --gpu-max-threads-per-block

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -881,15 +881,9 @@ void AMDGPUToolChain::addClangTargetOptions(
       if (DriverArgs.hasArgNoClaim(options::OPT_hipstdpar))
         CC1Args.append({"-mllvm", "-amdgpu-enable-hipstdpar"});
     }
-
-    // FIXME: This should not depend on HIP
-    StringRef MaxThreadsPerBlock =
-        DriverArgs.getLastArgValue(options::OPT_gpu_max_threads_per_block_EQ);
-    if (!MaxThreadsPerBlock.empty()) {
-      CC1Args.push_back(DriverArgs.MakeArgString(
-          Twine("--gpu-max-threads-per-block=") + MaxThreadsPerBlock));
-    }
   }
+
+  DriverArgs.AddLastArg(CC1Args, options::OPT_gpu_max_threads_per_block_EQ);
 
   // Default to "hidden" visibility, as object level linking will not be
   // supported for the foreseeable future.

--- a/clang/test/Driver/amdgpu-openmp-gpu-max-threads-per-block.c
+++ b/clang/test/Driver/amdgpu-openmp-gpu-max-threads-per-block.c
@@ -1,0 +1,6 @@
+// Test that --gpu-max-threads-per-block is not ignored by openmp.
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+// RUN:   --offload-arch=gfx906 -nogpulib --gpu-max-threads-per-block=256 %s 2>&1 | FileCheck %s
+
+// CHECK: "-cc1" "-triple" "amdgcn-amd-amdhsa"
+// CHECK-SAME: "--gpu-max-threads-per-block=256"

--- a/clang/test/Frontend/openmp-warn-gpu-max-threads-per-block.c
+++ b/clang/test/Frontend/openmp-warn-gpu-max-threads-per-block.c
@@ -1,0 +1,14 @@
+// REQUIRES: amdgpu-registered-target
+
+// Test that --gpu-max-threads-per-block warns when used outside of HIP.
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa --gpu-max-threads-per-block=1024 \
+// RUN:     -fsyntax-only -verify=warn %s
+
+// Test that no warning is emitted for HIP.
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -x hip -fcuda-is-device \
+// RUN:     --gpu-max-threads-per-block=1024 -fsyntax-only -verify=hip %s
+
+// warn-warning@*{{'--gpu-max-threads-per-block=1024' is ignored since it is only supported for HIP}}
+// hip-no-diagnostics
+
+void f(void) {}


### PR DESCRIPTION
Previously this flag was only handled for HIP, and would produce an unused
argument warning. There is a custom warning produced by cc1 that the
argument isn't supported, but practically speaking that was unreachable
due to not forwarding the argument. Also add a test for the untested warning.
Also use a simpler method for forwarding the flag to cc1.