### PR TITLE
clang/AMDGPU: Fix double linking opencl libs with --libclc-lib

### DIFF
--- a/clang/include/clang/Driver/CommonArgs.h
+++ b/clang/include/clang/Driver/CommonArgs.h
@@ -252,7 +252,11 @@ void addOpenMPDeviceRTL(const Driver &D, const llvm::opt::ArgList &DriverArgs,
                         StringRef BitcodeSuffix, const llvm::Triple &Triple,
                         const ToolChain &HostTC);
 
-void addOpenCLBuiltinsLib(const Driver &D, const llvm::Triple &TT,
+/// Try to link libclc, depending on the target ABI and command line
+/// arguments.
+///
+/// \return true if libclc should be linked for the compile.
+bool addOpenCLBuiltinsLib(const Driver &D, const llvm::Triple &TT,
                           const llvm::opt::ArgList &DriverArgs,
                           llvm::opt::ArgStringList &CC1Args);
 

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -931,7 +931,8 @@ void AMDGPUToolChain::addClangTargetOptions(
     if (DriverArgs.hasArg(options::OPT_nostdlib))
       return;
 
-    addOpenCLBuiltinsLib(getDriver(), getTriple(), DriverArgs, CC1Args);
+    if (addOpenCLBuiltinsLib(getDriver(), getTriple(), DriverArgs, CC1Args))
+      return;
   }
 
   if (!DriverArgs.hasFlag(options::OPT_offloadlib, options::OPT_no_offloadlib,

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -3131,7 +3131,7 @@ void tools::addOpenMPDeviceRTL(const Driver &D,
   }
 }
 
-void tools::addOpenCLBuiltinsLib(const Driver &D, const llvm::Triple &TT,
+bool tools::addOpenCLBuiltinsLib(const Driver &D, const llvm::Triple &TT,
                                  const llvm::opt::ArgList &DriverArgs,
                                  llvm::opt::ArgStringList &CC1Args) {
 
@@ -3142,12 +3142,12 @@ void tools::addOpenCLBuiltinsLib(const Driver &D, const llvm::Triple &TT,
     LibclcNamespec = A->getValue();
   } else {
     if (!TT.isAMDGPU() || TT.getEnvironment() != llvm::Triple::LLVM)
-      return;
+      return false;
 
     // TODO: Should this accept following -stdlib to override?
     if (DriverArgs.hasArg(options::OPT_no_offloadlib,
                           options::OPT_nodefaultlibs, options::OPT_nostdlib))
-      return;
+      return false;
   }
 
   bool FilenameSearch = LibclcNamespec.consume_front(":");
@@ -3156,10 +3156,10 @@ void tools::addOpenCLBuiltinsLib(const Driver &D, const llvm::Triple &TT,
     if (D.getVFS().exists(LibclcFile)) {
       CC1Args.push_back("-mlink-builtin-bitcode");
       CC1Args.push_back(DriverArgs.MakeArgString(LibclcFile));
-      return;
+      return true;
     }
     D.Diag(diag::err_drv_libclc_not_found) << LibclcFile;
-    return;
+    return false;
   }
 
   // The OpenCL libraries are stored in <ResourceDir>/lib/<triple>.
@@ -3177,7 +3177,7 @@ void tools::addOpenCLBuiltinsLib(const Driver &D, const llvm::Triple &TT,
       if (D.getVFS().exists(CPUPath)) {
         CC1Args.push_back("-mlink-builtin-bitcode");
         CC1Args.push_back(DriverArgs.MakeArgString(CPUPath));
-        return;
+        return true;
       }
     }
   }
@@ -3188,10 +3188,11 @@ void tools::addOpenCLBuiltinsLib(const Driver &D, const llvm::Triple &TT,
   if (D.getVFS().exists(GenericPath)) {
     CC1Args.push_back("-mlink-builtin-bitcode");
     CC1Args.push_back(DriverArgs.MakeArgString(GenericPath));
-    return;
+    return true;
   }
 
   D.Diag(diag::err_drv_libclc_not_found) << "libclc.bc";
+  return false;
 }
 
 void tools::addOutlineAtomicsArgs(const Driver &D, const ToolChain &TC,

--- a/clang/test/Driver/opencl-libclc.cl
+++ b/clang/test/Driver/opencl-libclc.cl
@@ -42,3 +42,12 @@
 // RUN:   -resource-dir %S/Inputs/resource_dir_with_per_target_subdir \
 // RUN:   %s 2>&1 | FileCheck %s --check-prefix=AMDGPU-LLVM-ENV-NO-OFFLOAD-LIB
 // AMDGPU-LLVM-ENV-NO-OFFLOAD-LIB-NOT: libclc.bc
+
+// With amdgcn-amd-amdhsa and --libclc-lib, should use libclc and NOT link ROCm device libs
+// RUN: %clang -### -target amdgcn-amd-amdhsa --libclc-lib=:%S/Inputs/libclc/libclc.bc \
+// RUN:   -resource-dir %S/Inputs/resource_dir_with_per_target_subdir \
+// RUN:   %s 2>&1 | FileCheck %s --check-prefix=AMDHSA-LIBCLC
+// AMDHSA-LIBCLC: -mlink-builtin-bitcode{{.*}}Inputs{{/|\\\\}}libclc{{/|\\\\}}libclc.bc
+// AMDHSA-LIBCLC-NOT: ocml
+// AMDHSA-LIBCLC-NOT: ockl
+// AMDHSA-LIBCLC-NOT: oclc


### PR DESCRIPTION
Noticed by inspection. If using an explicit --libclc-lib flag,
do not attempt to also link the rocm device libs which will contain
different implementations of the same opencl symbols.

Co-Authored-By: Claude <noreply@anthropic.com>