### PR TITLE
[Object][Wasm] Guard relocation diagnostics against out-of-range indexes

### DIFF
--- a/llvm/lib/Object/WasmObjectFile.cpp
+++ b/llvm/lib/Object/WasmObjectFile.cpp
@@ -1058,6 +1058,10 @@ Error WasmObjectFile::parseRelocSection(StringRef Name, ReadContext &Ctx) {
                                             object_error::parse_failed);
 
     auto badReloc = [&](StringRef msg) {
+      if (Reloc.Index >= Symbols.size())
+        return make_error<GenericBinaryError>(
+            msg + ": index " + Twine(Reloc.Index) + " out of range",
+            object_error::parse_failed);
       return make_error<GenericBinaryError>(
           msg + ": " + Twine(Symbols[Reloc.Index].Info.Name),
           object_error::parse_failed);

--- a/llvm/test/Object/Wasm/bad-relocation.yaml
+++ b/llvm/test/Object/Wasm/bad-relocation.yaml
@@ -33,3 +33,33 @@ Sections:
         Segment:         0
         Offset:          0
         Size:            1
+# RUN: yaml2obj %s --docnum=2 | not llvm-objdump -s - 2>&1 | FileCheck %s --check-prefix=OOB
+# OOB: invalid function relocation: index 13 out of range
+# OOB-NOT: dot-cfg-quiet
+--- !WASM
+FileHeader:
+  Version:         0x00000001
+Sections:
+  - Type:            DATA
+    Segments:
+      - SectionOffset:   0
+        InitFlags:       0
+        Offset:
+          Opcode:          I32_CONST
+          Value:           0
+        Content:         '6401020304'
+    Relocations:
+      - Type:            R_WASM_FUNCTION_INDEX_LEB
+        Index:           13
+        Offset:          0x00000000
+  - Type:            CUSTOM
+    Name:            linking
+    Version:         2
+    SymbolTable:
+      - Index:           0
+        Kind:            DATA
+        Name:            foo
+        Flags:           [ ]
+        Segment:         0
+        Offset:          0
+        Size:            1


### PR DESCRIPTION
The badReloc lambda in parseRelocSection() accesses Symbols[Reloc.Index]
when building diagnostic messages, even after validation has determined
that Reloc.Index is out of range. This causes a heap out-of-bounds read
that can crash LLVM tools or produce unexpected diagnostic output.

Fix by checking Reloc.Index against Symbols.size() before dereferencing,
and emit the numeric index in the error message when out of range.

The vulnerable diagnostic path is shared across multiple relocation type
validation failures, including R_WASM_FUNCTION_INDEX_LEB,
R_WASM_TAG_INDEX_LEB, R_WASM_TABLE_NUMBER_LEB, and R_WASM_MEMORY_ADDR_LEB.

Note: this is a minimal fix addressing the out-of-bounds access. The
R_WASM_TYPE_INDEX_LEB path validates against Signatures.size() but
badReloc() still references Symbols[Reloc.Index], which may warrant
a broader diagnostic refactoring separately.