### PR TITLE
[ARM] Optimize (a << 1) + (b < c) to branchless CMP, SBC, RSB sequence

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -5250,6 +5250,39 @@ SDValue ARMTargetLowering::LowerSELECT_CC(SDValue Op, SelectionDAG &DAG) const {
   ConstantSDNode *RHSC = dyn_cast<ConstantSDNode>(RHS);
   if (Op.getValueType().isInteger()) {
 
+    // Match select_cc(b, c, shl(a, 1) | 1, shl(a, 1), ULT/UGT) -> rsb a,
+    // sbc(cmp(b,c)), a<<1
+    if (VT == MVT::i32 && !Subtarget->isThumb1Only()) {
+      if (CC == ISD::SETULT || CC == ISD::SETUGT) {
+        SDValue Shl;
+        bool Match = false;
+        if (TrueVal.getOpcode() == ISD::OR &&
+            TrueVal.getOperand(0) == FalseVal &&
+            isa<ConstantSDNode>(TrueVal.getOperand(1)) &&
+            TrueVal.getConstantOperandVal(1) == 1) {
+          Shl = FalseVal;
+          Match = true;
+        }
+
+        if (Match && Shl.getOpcode() == ISD::SHL &&
+            isa<ConstantSDNode>(Shl.getOperand(1)) &&
+            Shl.getConstantOperandVal(1) >= 1 &&
+            Shl.getConstantOperandVal(1) <= 31) {
+
+          SDValue CmpLHS = LHS;
+          SDValue CmpRHS = RHS;
+          if (CC == ISD::SETUGT)
+            std::swap(CmpLHS, CmpRHS);
+
+          SDValue Cmp = DAG.getNode(ARMISD::CMP, dl, MVT::i32, CmpLHS, CmpRHS);
+          SDVTList VTs = DAG.getVTList(MVT::i32, MVT::i32);
+          SDValue SubE =
+              DAG.getNode(ARMISD::SUBE, dl, VTs, CmpLHS, CmpLHS, Cmp);
+          return DAG.getNode(ISD::SUB, dl, MVT::i32, Shl, SubE);
+        }
+      }
+    }
+
     // Check for SMAX(lhs, 0) and SMIN(lhs, 0) patterns.
     // (SELECT_CC setgt, lhs, 0, lhs, 0) -> (BIC lhs, (SRA lhs, typesize-1))
     // (SELECT_CC setlt, lhs, 0, lhs, 0) -> (AND lhs, (SRA lhs, typesize-1))

--- a/llvm/test/CodeGen/ARM/branchless-cmp-sbc-rsb.ll
+++ b/llvm/test/CodeGen/ARM/branchless-cmp-sbc-rsb.ll
@@ -1,0 +1,40 @@
+; RUN: llc -mtriple=armv7-linux-gnueabihf %s -o - | FileCheck %s
+
+define i32 @test_shl_add_ult(i32 %a, i32 %b, i32 %c) {
+; CHECK-LABEL: test_shl_add_ult:
+; CHECK: cmp r1, r2
+; CHECK-NEXT: sbc r1, r1, r1
+; CHECK-NEXT: rsb r0, r1, r0, lsl #1
+; CHECK-NEXT: bx lr
+  %cmp = icmp ult i32 %b, %c
+  %zext = zext i1 %cmp to i32
+  %shl = shl i32 %a, 1
+  %add = add i32 %shl, %zext
+  ret i32 %add
+}
+
+define i32 @test_shl_add_ugt(i32 %a, i32 %b, i32 %c) {
+; CHECK-LABEL: test_shl_add_ugt:
+; CHECK: cmp r2, r1
+; CHECK-NEXT: sbc r1, r2, r2
+; CHECK-NEXT: rsb r0, r1, r0, lsl #1
+; CHECK-NEXT: bx lr
+  %cmp = icmp ugt i32 %b, %c
+  %zext = zext i1 %cmp to i32
+  %shl = shl i32 %a, 1
+  %add = add i32 %shl, %zext
+  ret i32 %add
+}
+
+define i32 @test_shl2_add_ult(i32 %a, i32 %b, i32 %c) {
+; CHECK-LABEL: test_shl2_add_ult:
+; CHECK: cmp r1, r2
+; CHECK-NEXT: sbc r1, r1, r1
+; CHECK-NEXT: rsb r0, r1, r0, lsl #2
+; CHECK-NEXT: bx lr
+  %cmp = icmp ult i32 %b, %c
+  %zext = zext i1 %cmp to i32
+  %shl = shl i32 %a, 2
+  %add = add i32 %shl, %zext
+  ret i32 %add
+}


### PR DESCRIPTION
Motivation: Currently, code patterns resembling (a << 1) + (b < c) evaluate poorly on ARM32. Since ARM32 lacks a dedicated boolean materialization instruction like AArch64's cset, LLVM falls back to a 5-instruction conditional execution sequence to pad out the boolean logic, so we should address that.