### PR TITLE
[Verifier] Verify AMX tile-register index operands are in range

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -99,6 +99,7 @@
 #include "llvm/IR/IntrinsicsARM.h"
 #include "llvm/IR/IntrinsicsNVPTX.h"
 #include "llvm/IR/IntrinsicsWebAssembly.h"
+#include "llvm/IR/IntrinsicsX86.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/MemoryModelRelaxationAnnotations.h"
 #include "llvm/IR/Metadata.h"
@@ -7093,6 +7094,29 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     Check(cast<ConstantInt>(Call.getArgOperand(2))->getZExtValue() < 2,
           "stream argument to llvm.aarch64.range.prefetch must be 0 or 1",
           Call);
+    break;
+  }
+  case Intrinsic::x86_tilezero:
+  case Intrinsic::x86_tileloadd64:
+  case Intrinsic::x86_tileloaddt164:
+  case Intrinsic::x86_tilestored64: {
+    // AMX provides 8 physical tile registers, TMM0-TMM7; the leading immediate
+    // operand is a tile-register index and so must name one of them.
+    Check(cast<ConstantInt>(Call.getArgOperand(0))->getZExtValue() < 8,
+          "AMX tile register index must be in the range [0, 8)", Call);
+    break;
+  }
+  case Intrinsic::x86_tdpbssd:
+  case Intrinsic::x86_tdpbsud:
+  case Intrinsic::x86_tdpbusd:
+  case Intrinsic::x86_tdpbuud:
+  case Intrinsic::x86_tdpbf16ps:
+  case Intrinsic::x86_tdpfp16ps: {
+    // The destination and two source operands are each a tile-register index
+    // (TMM0-TMM7).
+    for (unsigned I : {0, 1, 2})
+      Check(cast<ConstantInt>(Call.getArgOperand(I))->getZExtValue() < 8,
+            "AMX tile register index must be in the range [0, 8)", Call);
     break;
   }
   case Intrinsic::callbr_landingpad: {

--- a/llvm/test/Verifier/x86-amx-tile-register-index.ll
+++ b/llvm/test/Verifier/x86-amx-tile-register-index.ll
@@ -1,0 +1,30 @@
+; RUN: not opt -passes=verify -S < %s 2>&1 | FileCheck %s
+
+; AMX exposes 8 physical tile registers (TMM0-TMM7), so a tile-register index
+; operand must be in the range [0, 8). This is a structural constraint on the
+; immediate operand and needs no subtarget information.
+
+declare void @llvm.x86.tilezero(i8 immarg)
+declare void @llvm.x86.tileloadd64(i8 immarg, ptr, i64)
+declare void @llvm.x86.tdpbssd(i8 immarg, i8 immarg, i8 immarg)
+
+define void @bad_tilezero() {
+; CHECK: AMX tile register index must be in the range [0, 8)
+  call void @llvm.x86.tilezero(i8 8)
+  ret void
+}
+
+; Only one of the three tile operands is out of range.
+define void @bad_tdpbssd() {
+; CHECK: AMX tile register index must be in the range [0, 8)
+  call void @llvm.x86.tdpbssd(i8 0, i8 1, i8 9)
+  ret void
+}
+
+; A valid tile index (0) with a large *constant* stride. The stride is operand 2,
+; not a tile-register index, so it must not be diagnosed.
+; CHECK-NOT: AMX tile register index
+define void @good_tileloadd64(ptr %p) {
+  call void @llvm.x86.tileloadd64(i8 0, ptr %p, i64 64)
+  ret void
+}


### PR DESCRIPTION
AMX has 8 physical tile registers (TMM0-TMM7), so the tile-index operands
of the AMX intrinsics must be in [0, 8): operand 0 for the tile
load/store/zero intrinsics, operands 0-2 for the tdp* family.