### PR TITLE
[LifetimeSafety] Add `LifetimeSafetyDanglingGlobalMoved` to strict diagnostic group

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -663,6 +663,7 @@ def LifetimeSafetyStrict : DiagGroup<"lifetime-safety-strict",
                                     LifetimeSafetyUseAfterScopeMoved,
                                     LifetimeSafetyReturnStackAddrMoved,
                                     LifetimeSafetyDanglingFieldMoved,
+                                    LifetimeSafetyDanglingGlobalMoved,
                                     LifetimeSafetyInvalidation]>;
 
 def LifetimeSafety : DiagGroup<"lifetime-safety",

--- a/clang/test/Sema/LifetimeSafety/dangling-global.cpp
+++ b/clang/test/Sema/LifetimeSafety/dangling-global.cpp
@@ -1,7 +1,11 @@
 // RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety -Wno-dangling -verify %s
+#include "Inputs/lifetime-analysis.h"
 
 int *global; // expected-note 10 {{this global dangles}}
 int *global_backup; // expected-note {{this global dangles}}
+
+std::string_view global_view; // expected-note {{this global dangles}}
+void takeString(std::string&& s);
 
 struct ObjWithStaticField {
   static int *static_field; // expected-note {{this static storage dangles}}
@@ -116,4 +120,9 @@ void ok_global_storage() {
   p += 1;
   ++p;
   global = (p -= 1); // no-warning
+}
+// When a local string is stored in a global view and then moved, the analyzer warns it "may" dangle since the storage may have been moved
+void store_local_in_global_but_moved(std::string s){
+  global_view = s; // expected-warning-re {{stack memory associated with parameter 's' may escape to the global variable 'global_view' which will dangle{{.*}} may have been moved}}
+  takeString(std::move(s)); //expected-note {{potentially moved here}}
 }


### PR DESCRIPTION
Fixes #204213

`-Wlifetime-safety-dangling-global-moved` was defined but not included
in any parent diagnostic group, meaning `-Wlifetime-safety-all` and
`-Wno-lifetime-safety-all` had no effect on it.

`LifetimeSafetyDanglingGlobal` (the non-moved variant) was already
correctly placed under `LifetimeSafetyPermissive`. Following the same
pattern as the other `-moved` sibling warnings
(`DanglingFieldMoved`, `ReturnStackAddrMoved`, `UseAfterScopeMoved`),
this patch adds `LifetimeSafetyDanglingGlobalMoved` to
`LifetimeSafetyStrict`, which is part of the `lifetime-safety-all`
hierarchy.

Assisted-by: Claude (Anthropic) — used for learning and understanding 
the codebase, not for generating code directly.