### PR TITLE
[lldb][DWARF] Fix implicit widening bug in DW_OP_plus_uconst

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -1534,8 +1534,11 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
 
     case DW_OP_plus_uconst: {
       const uint64_t uconst_value = op->getRawOperand(0);
+      const int byte_size = stack.back().GetScalar().GetByteSize();
       // Implicit conversion from a UINT to a Scalar...
       stack.back().GetScalar() += uconst_value;
+      if (byte_size > 0 && byte_size < 8)
+        stack.back().GetScalar().TruncOrExtendTo(byte_size * 8, false);
       if (!stack.back().GetScalar().IsValid())
         return llvm::createStringError("DW_OP_plus_uconst failed");
     } break;

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -722,6 +722,58 @@ TEST(DWARFExpression, DW_OP_plus_uconst) {
   EXPECT_THAT_EXPECTED(Evaluate({DW_OP_const1s, static_cast<uint8_t>(-10),
                                  DW_OP_plus_uconst, 5}),
                        ExpectScalar(static_cast<int32_t>(-5)));
+  const char *yamldata = R"(
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_EXEC
+  Machine: EM_386
+DWARF:
+  debug_abbrev:
+    - Table:
+        - Code:            0x00000001
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_language
+              Form:            DW_FORM_data2
+        - Code:            0x00000002
+          Tag:             DW_TAG_base_type
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_encoding
+              Form:            DW_FORM_data1
+            - Attribute:       DW_AT_byte_size
+              Form:            DW_FORM_data1
+  debug_info:
+    - Version:         4
+      AddrSize:        8
+      AbbrevTableID:   0
+      AbbrOffset:      0x0
+      Entries:
+        - AbbrCode:        0x00000001
+          Values:
+            - Value:           0x000000000000000C
+        # 0x0000000e:
+        - AbbrCode:        0x00000002
+          Values:
+            - Value:           0x0000000000000008 # DW_ATE_unsigned_char
+            - Value:           0x0000000000000001
+        - AbbrCode:        0x00000000
+  )";
+
+  DWARFExpressionTester t(yamldata, 0);
+  ASSERT_TRUE(t.GetDwarfUnit());
+
+  uint8_t offs_uchar = 0x0000000e;
+  bool not_signed = false;
+
+  EXPECT_THAT_EXPECTED(
+      t.Eval({DW_OP_const8u, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+              DW_OP_convert, offs_uchar, DW_OP_plus_uconst, 1, DW_OP_const1u, 7,
+              DW_OP_convert, offs_uchar, DW_OP_shr, DW_OP_stack_value}),
+      ExpectScalar(8, 0, not_signed));
 }
 
 TEST(DWARFExpression, DW_OP_and) {


### PR DESCRIPTION
Fixes an implicit widening bug in DW_OP_plus_uconst when handling DWARF 5 typed values. LLDB was incorrectly forwarding typed operations to uint64_t scalar arithmetic, which destroys the wrapping semantics required by the DWARF specification.

Updated the DW_OP_plus_uconst logic to explicitly truncate results to the operand's original bit-width, preventing illegal integer widening and maintaining correct DWARF wrap-around behavior

Fixes #204520 