### PR TITLE
[BOLT] Route alignment options through BinaryContext (NFC)

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -816,6 +816,22 @@ public:
   std::atomic<uint16_t> MaxMainCodeAlignment{1};
   std::atomic<uint16_t> MaxColdCodeAlignment{1};
 
+  /// Alignment-related options sourced from CommandLineOpts. Populated by
+  /// RewriteInstance::adjustCommandLineOptions() so passes and the emitter
+  /// can read them via BinaryContext instead of touching opts::* directly.
+  /// Defaults must stay in sync with the cl::init values in
+  /// bolt/lib/Utils/CommandLineOpts.cpp.
+  unsigned AlignText{0};
+  unsigned AlignFunctions{64};
+  unsigned AlignBlocksMinSize{0};
+  unsigned AlignBlocksThreshold{800};
+  unsigned AlignFunctionsMaxBytes{32};
+  unsigned BlockAlignment{16};
+  bool AlignBlocks{false};
+  bool PreserveBlocksAlignment{false};
+  bool UseCompactAligner{true};
+  bool X86AlignBranchBoundaryHotOnly{true};
+
   /// Fold \p Alignment into the running max for the main code section (when
   /// \p InMainSection) and/or the cold code section (when \p InColdSection),
   /// reflecting which output section(s) the object is emitted into. Safe to

--- a/bolt/include/bolt/Utils/CommandLineOpts.h
+++ b/bolt/include/bolt/Utils/CommandLineOpts.h
@@ -72,6 +72,14 @@ extern llvm::cl::OptionCategory BinaryAnalysisCategory;
 
 extern llvm::cl::opt<unsigned> AlignText;
 extern llvm::cl::opt<unsigned> AlignFunctions;
+extern llvm::cl::opt<bool> AlignBlocks;
+extern llvm::cl::opt<unsigned> AlignBlocksMinSize;
+extern llvm::cl::opt<unsigned> AlignBlocksThreshold;
+extern llvm::cl::opt<unsigned> AlignFunctionsMaxBytes;
+extern llvm::cl::opt<unsigned> BlockAlignment;
+extern llvm::cl::opt<bool> PreserveBlocksAlignment;
+extern llvm::cl::opt<bool> UseCompactAligner;
+extern llvm::cl::opt<bool> X86AlignBranchBoundaryHotOnly;
 extern llvm::cl::opt<bool> AggregateOnly;
 extern llvm::cl::opt<bool> ArmSPE;
 extern llvm::cl::opt<unsigned> BucketsPerLine;

--- a/bolt/lib/Core/BinaryEmitter.cpp
+++ b/bolt/lib/Core/BinaryEmitter.cpp
@@ -33,10 +33,6 @@ using namespace bolt;
 namespace opts {
 
 extern cl::opt<JumpTableSupportLevel> JumpTables;
-extern cl::opt<bool> PreserveBlocksAlignment;
-
-cl::opt<bool> AlignBlocks("align-blocks", cl::desc("align basic blocks"),
-                          cl::cat(BoltOptCategory));
 
 static cl::list<std::string>
 BreakFunctionNames("break-funcs",
@@ -67,12 +63,6 @@ static cl::opt<bool> MarkFuncs(
 static cl::opt<bool> PrintJumpTables("print-jump-tables",
                                      cl::desc("print jump tables"), cl::Hidden,
                                      cl::cat(BoltCategory));
-
-static cl::opt<bool>
-X86AlignBranchBoundaryHotOnly("x86-align-branch-boundary-hot-only",
-  cl::desc("only apply branch boundary alignment in hot code"),
-  cl::init(true),
-  cl::cat(BoltOptCategory));
 
 size_t padFunction(std::map<std::string, size_t> &FunctionPadding,
                    const cl::list<std::string> &Spec,
@@ -214,7 +204,7 @@ void BinaryEmitter::emitAll(StringRef OrgSecPrefix) {
   if (RuntimeLibrary *RtLibrary = BC.getRuntimeLibrary())
     RtLibrary->emitBinary(BC, Streamer);
 
-  BC.getTextSection()->setAlignment(Align(opts::AlignText));
+  BC.getTextSection()->setAlignment(Align(BC.AlignText));
 
   emitFunctions();
 
@@ -246,7 +236,7 @@ void BinaryEmitter::emitFunctions() {
       bool Emitted = false;
 
       // Turn off Intel JCC Erratum mitigation for cold code if requested
-      if (HasProfile && opts::X86AlignBranchBoundaryHotOnly &&
+      if (HasProfile && BC.X86AlignBranchBoundaryHotOnly &&
           !Function->hasValidProfile())
         Streamer.setAllowAutoPadding(false);
 
@@ -254,7 +244,7 @@ void BinaryEmitter::emitFunctions() {
       Emitted |= emitFunction(*Function, Layout.getMainFragment());
 
       if (Function->isSplit()) {
-        if (opts::X86AlignBranchBoundaryHotOnly)
+        if (BC.X86AlignBranchBoundaryHotOnly)
           Streamer.setAllowAutoPadding(false);
 
         assert((Layout.fragment_size() == 1 || Function->isSimple()) &&
@@ -317,7 +307,7 @@ bool BinaryEmitter::emitFunction(BinaryFunction &Function,
     // Set section alignment to at least maximum possible object alignment.
     // We need this to support LongJmp and other passes that calculates
     // tentative layout.
-    Section->ensureMinAlignment(Align(opts::AlignFunctions));
+    Section->ensureMinAlignment(Align(BC.AlignFunctions));
 
     Streamer.emitCodeAlignment(Function.getMinAlign(), &*BC.STI);
     uint16_t MaxAlignBytes = FF.isSplitFragment()
@@ -457,7 +447,7 @@ void BinaryEmitter::emitFunctionBody(BinaryFunction &BF, FunctionFragment &FF,
   // Track the first emitted instruction with debug info.
   bool FirstInstr = true;
   for (BinaryBasicBlock *const BB : FF) {
-    if ((opts::AlignBlocks || opts::PreserveBlocksAlignment) &&
+    if ((BC.AlignBlocks || BC.PreserveBlocksAlignment) &&
         BB->getAlignment() > 1)
       Streamer.emitCodeAlignment(BB->getAlign(), &*BC.STI,
                                  BB->getAlignmentMaxBytes());

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -111,11 +111,6 @@ static cl::opt<bool> NoScan(
         "slower binary)"),
     cl::Hidden, cl::cat(BoltOptCategory));
 
-cl::opt<bool>
-    PreserveBlocksAlignment("preserve-blocks-alignment",
-                            cl::desc("try to preserve basic block alignment"),
-                            cl::cat(BoltOptCategory));
-
 static cl::opt<bool> PrintOutputAddressRange(
     "print-output-address-range",
     cl::desc(
@@ -2351,7 +2346,7 @@ Error BinaryFunction::buildCFG(MCPlusBuilder::AllocatorIdTy AllocatorId) {
       // Always create new BB at branch destination.
       PrevBB = InsertBB ? InsertBB : PrevBB;
       InsertBB = addBasicBlockAt(LI->first, LI->second);
-      if (opts::PreserveBlocksAlignment && IsLastInstrNop)
+      if (BC.PreserveBlocksAlignment && IsLastInstrNop)
         InsertBB->setDerivedAlignment();
 
       if (PrevBB)
@@ -2388,7 +2383,7 @@ Error BinaryFunction::buildCFG(MCPlusBuilder::AllocatorIdTy AllocatorId) {
           Label = BC.Ctx->createNamedTempSymbol("FT");
         }
         InsertBB = addBasicBlockAt(Offset, Label);
-        if (opts::PreserveBlocksAlignment && IsLastInstrNop)
+        if (BC.PreserveBlocksAlignment && IsLastInstrNop)
           InsertBB->setDerivedAlignment();
         updateOffset(LastInstrOffset);
       }

--- a/bolt/lib/Passes/Aligner.cpp
+++ b/bolt/lib/Passes/Aligner.cpp
@@ -17,54 +17,16 @@
 
 using namespace llvm;
 
-namespace opts {
-
-extern cl::OptionCategory BoltOptCategory;
-
-extern cl::opt<bool> AlignBlocks;
-extern cl::opt<bool> PreserveBlocksAlignment;
-extern cl::opt<unsigned> AlignFunctions;
-
-static cl::opt<unsigned> AlignBlocksMinSize(
-    "align-blocks-min-size",
-    cl::desc("minimal size of the basic block that should be aligned"),
-    cl::init(0), cl::ZeroOrMore, cl::Hidden, cl::cat(BoltOptCategory));
-
-static cl::opt<unsigned> AlignBlocksThreshold(
-    "align-blocks-threshold",
-    cl::desc(
-        "align only blocks with frequency larger than containing function "
-        "execution frequency specified in percent. E.g. 1000 means aligning "
-        "blocks that are 10 times more frequently executed than the "
-        "containing function."),
-    cl::init(800), cl::Hidden, cl::cat(BoltOptCategory));
-
-static cl::opt<unsigned> AlignFunctionsMaxBytes(
-    "align-functions-max-bytes",
-    cl::desc("maximum number of bytes to use to align functions"), cl::init(32),
-    cl::cat(BoltOptCategory));
-
-static cl::opt<unsigned>
-    BlockAlignment("block-alignment",
-                   cl::desc("boundary to use for alignment of basic blocks"),
-                   cl::init(16), cl::ZeroOrMore, cl::cat(BoltOptCategory));
-
-static cl::opt<bool>
-    UseCompactAligner("use-compact-aligner",
-                      cl::desc("Use compact approach for aligning functions"),
-                      cl::init(true), cl::cat(BoltOptCategory));
-
-} // end namespace opts
-
 namespace llvm {
 namespace bolt {
 
 // Align function to the specified byte-boundary (typically, 64) offsetting
 // the function by not more than the corresponding value
 static void alignMaxBytes(BinaryFunction &Function) {
-  Function.setAlignment(opts::AlignFunctions);
-  Function.setMaxAlignmentBytes(opts::AlignFunctionsMaxBytes);
-  Function.setMaxColdAlignmentBytes(opts::AlignFunctionsMaxBytes);
+  const BinaryContext &BC = Function.getBinaryContext();
+  Function.setAlignment(BC.AlignFunctions);
+  Function.setMaxAlignmentBytes(BC.AlignFunctionsMaxBytes);
+  Function.setMaxColdAlignmentBytes(BC.AlignFunctionsMaxBytes);
 }
 
 // Align function to the specified byte-boundary (typically, 64) offsetting
@@ -90,16 +52,16 @@ static void alignCompact(BinaryFunction &Function,
     else
       HotSize += BC.computeCodeSize(BB.begin(), BB.end(), Emitter);
 
-  Function.setAlignment(opts::AlignFunctions);
+  Function.setAlignment(BC.AlignFunctions);
   if (HotSize > 0)
     Function.setMaxAlignmentBytes(
-      std::min(size_t(opts::AlignFunctionsMaxBytes), HotSize));
+        std::min(size_t(BC.AlignFunctionsMaxBytes), HotSize));
 
   // using the same option, max-align-bytes, both for cold and hot parts of the
   // functions, as aligning cold functions typically does not affect performance
   if (ColdSize > 0)
     Function.setMaxColdAlignmentBytes(
-      std::min(size_t(opts::AlignFunctionsMaxBytes), ColdSize));
+        std::min(size_t(BC.AlignFunctionsMaxBytes), ColdSize));
 }
 
 void AlignerPass::alignBlocks(BinaryFunction &Function,
@@ -115,7 +77,7 @@ void AlignerPass::alignBlocks(BinaryFunction &Function,
   for (BinaryBasicBlock *BB : Function.getLayout().blocks()) {
     uint64_t Count = BB->getKnownExecutionCount();
 
-    if (Count <= FuncCount * opts::AlignBlocksThreshold / 100) {
+    if (Count <= FuncCount * BC.AlignBlocksThreshold / 100) {
       PrevBB = BB;
       continue;
     }
@@ -132,12 +94,12 @@ void AlignerPass::alignBlocks(BinaryFunction &Function,
     const uint64_t BlockSize =
         BC.computeCodeSize(BB->begin(), BB->end(), Emitter);
     const uint64_t BytesToUse =
-        std::min<uint64_t>(opts::BlockAlignment - 1, BlockSize);
+        std::min<uint64_t>(BC.BlockAlignment - 1, BlockSize);
 
-    if (opts::AlignBlocksMinSize && BlockSize < opts::AlignBlocksMinSize)
+    if (BC.AlignBlocksMinSize && BlockSize < BC.AlignBlocksMinSize)
       continue;
 
-    BB->setAlignment(opts::BlockAlignment);
+    BB->setAlignment(BC.BlockAlignment);
     BB->setAlignmentMaxBytes(BytesToUse);
 
     // Update stats.
@@ -153,14 +115,14 @@ Error AlignerPass::runOnFunctions(BinaryContext &BC) {
   if (!BC.HasRelocations)
     return Error::success();
 
-  AlignHistogram.resize(opts::BlockAlignment);
+  AlignHistogram.resize(BC.BlockAlignment);
 
   ParallelUtilities::WorkFuncTy WorkFun = [&](BinaryFunction &BF) {
     // Create a separate MCCodeEmitter to allow lock free execution
     BinaryContext::IndependentCodeEmitter Emitter =
         BC.createIndependentMCCodeEmitter();
 
-    if (opts::UseCompactAligner)
+    if (BC.UseCompactAligner)
       alignCompact(BF, Emitter.MCE.get());
     else
       alignMaxBytes(BF);
@@ -185,7 +147,7 @@ Error AlignerPass::runOnFunctions(BinaryContext &BC) {
                       BC.getColdCodeSectionName();
     BC.updateMaxCodeAlignment(Align, InMainSection, InColdSection);
 
-    if (opts::AlignBlocks && !opts::PreserveBlocksAlignment)
+    if (BC.AlignBlocks && !BC.PreserveBlocksAlignment)
       alignBlocks(BF, Emitter.MCE.get());
   };
 

--- a/bolt/lib/Passes/LongJmp.cpp
+++ b/bolt/lib/Passes/LongJmp.cpp
@@ -22,8 +22,6 @@ using namespace llvm;
 namespace opts {
 extern cl::OptionCategory BoltCategory;
 extern cl::OptionCategory BoltOptCategory;
-extern llvm::cl::opt<unsigned> AlignText;
-extern cl::opt<unsigned> AlignFunctions;
 extern cl::opt<bool> UseOldText;
 extern cl::opt<bool> HotFunctionsAtEnd;
 
@@ -318,7 +316,7 @@ uint64_t LongJmpPass::tentativeLayoutRelocColdPart(
     const BinaryContext &BC, BinaryFunctionListType &SortedFunctions,
     uint64_t DotAddress) {
   DotAddress =
-      alignTo(DotAddress, std::max<uint64_t>(opts::AlignFunctions,
+      alignTo(DotAddress, std::max<uint64_t>(BC.AlignFunctions,
                                              BC.MaxColdCodeAlignment.load()));
   for (BinaryFunction *Func : SortedFunctions) {
     if (!Func->isSplit())
@@ -375,11 +373,11 @@ LongJmpPass::tentativeLayoutRelocMode(const BinaryContext &BC,
     // after the last non-cold section. Account for it before assigning cold
     // fragment addresses so range checks see the hot-to-cold gap.
     if (opts::Hugify && !BC.HasFixedLoadAddress && !opts::HotFunctionsAtEnd)
-      DotAddress = alignTo(DotAddress, opts::AlignText);
+      DotAddress = alignTo(DotAddress, BC.AlignText);
     DotAddress = tentativeLayoutRelocColdPart(BC, SortedFunctions, DotAddress);
     ColdLayoutDone = true;
     if (opts::HotFunctionsAtEnd)
-      DotAddress = alignTo(DotAddress, opts::AlignText);
+      DotAddress = alignTo(DotAddress, BC.AlignText);
   };
   for (BinaryFunction *Func : SortedFunctions) {
     if (!BC.shouldEmit(*Func)) {
@@ -446,8 +444,7 @@ void LongJmpPass::tentativeLayout(const BinaryContext &BC,
     // Initial padding
     if (EstimatedTextSize <= BC.OldTextSectionSize) {
       DotAddress = BC.OldTextSectionAddress;
-      uint64_t Pad =
-          offsetToAlignment(DotAddress, llvm::Align(opts::AlignText));
+      uint64_t Pad = offsetToAlignment(DotAddress, llvm::Align(BC.AlignText));
       if (Pad + EstimatedTextSize <= BC.OldTextSectionSize) {
         DotAddress += Pad;
       }
@@ -456,7 +453,7 @@ void LongJmpPass::tentativeLayout(const BinaryContext &BC,
 
   if (!EstimatedTextSize || EstimatedTextSize > BC.OldTextSectionSize) {
     uint64_t TextAlign =
-        std::max<uint64_t>(opts::AlignText, BC.MaxMainCodeAlignment.load());
+        std::max<uint64_t>(BC.AlignText, BC.MaxMainCodeAlignment.load());
     DotAddress = alignTo(BC.LayoutStartAddress, TextAlign);
   }
 

--- a/bolt/lib/Rewrite/MachORewriteInstance.cpp
+++ b/bolt/lib/Rewrite/MachORewriteInstance.cpp
@@ -32,7 +32,6 @@
 namespace opts {
 
 using namespace llvm;
-extern cl::opt<unsigned> AlignText;
 // FIXME! Upstream change
 // extern cl::opt<bool> CheckOverlappingElements;
 extern cl::opt<bool> Instrument;
@@ -557,6 +556,19 @@ void MachORewriteInstance::adjustCommandLineOptions() {
   opts::JumpTables = JTS_MOVE;
   opts::InstrumentCalls = false;
   opts::RuntimeInstrumentationLib = "libbolt_rt_instr_osx.a";
+
+  // Mirror alignment-related command line options onto BinaryContext so passes
+  // and the emitter can read them via BC instead of touching opts::*.
+  BC->AlignText = opts::AlignText;
+  BC->AlignFunctions = opts::AlignFunctions;
+  BC->AlignBlocks = opts::AlignBlocks;
+  BC->AlignBlocksMinSize = opts::AlignBlocksMinSize;
+  BC->AlignBlocksThreshold = opts::AlignBlocksThreshold;
+  BC->AlignFunctionsMaxBytes = opts::AlignFunctionsMaxBytes;
+  BC->BlockAlignment = opts::BlockAlignment;
+  BC->PreserveBlocksAlignment = opts::PreserveBlocksAlignment;
+  BC->UseCompactAligner = opts::UseCompactAligner;
+  BC->X86AlignBranchBoundaryHotOnly = opts::X86AlignBranchBoundaryHotOnly;
 }
 
 void MachORewriteInstance::run() {

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2447,6 +2447,19 @@ void RewriteInstance::adjustCommandLineOptions() {
   if (opts::AlignText < opts::AlignFunctions)
     opts::AlignText = (unsigned)opts::AlignFunctions;
 
+  // Mirror alignment-related command line options onto BinaryContext so passes
+  // and the emitter can read them via BC instead of touching opts::*.
+  BC->AlignText = opts::AlignText;
+  BC->AlignFunctions = opts::AlignFunctions;
+  BC->AlignBlocks = opts::AlignBlocks;
+  BC->AlignBlocksMinSize = opts::AlignBlocksMinSize;
+  BC->AlignBlocksThreshold = opts::AlignBlocksThreshold;
+  BC->AlignFunctionsMaxBytes = opts::AlignFunctionsMaxBytes;
+  BC->BlockAlignment = opts::BlockAlignment;
+  BC->PreserveBlocksAlignment = opts::PreserveBlocksAlignment;
+  BC->UseCompactAligner = opts::UseCompactAligner;
+  BC->X86AlignBranchBoundaryHotOnly = opts::X86AlignBranchBoundaryHotOnly;
+
   if (BC->isX86() && opts::Lite.getNumOccurrences() == 0 && !opts::StrictMode &&
       !opts::UseOldText)
     opts::Lite = true;
@@ -4323,7 +4336,7 @@ void RewriteInstance::mapCodeSections(BOLTLinker::SectionMapper MapSection) {
     const uint64_t CodeSize = EndAddress - StartAddress;
     if (CodeSize <= BC->OldTextSectionSize) {
       BC->outs() << "BOLT-INFO: using original .text for new code with 0x"
-                 << Twine::utohexstr(opts::AlignText) << " alignment";
+                 << Twine::utohexstr(BC->AlignText) << " alignment";
       if (StartAddress != BC->OldTextSectionAddress)
         BC->outs() << " at 0x" << Twine::utohexstr(StartAddress);
       BC->outs() << '\n';
@@ -4331,7 +4344,7 @@ void RewriteInstance::mapCodeSections(BOLTLinker::SectionMapper MapSection) {
     } else {
       BC->errs() << "BOLT-WARNING: --use-old-text failed. The original .text "
                     "too small to fit the new code using 0x"
-                 << Twine::utohexstr(opts::AlignText) << " alignment. "
+                 << Twine::utohexstr(BC->AlignText) << " alignment. "
                  << CodeSize << " bytes needed, have " << BC->OldTextSectionSize
                  << " bytes available. Rebuilding without --use-old-text may "
                     "produce a smaller binary\n";

--- a/bolt/lib/Utils/CommandLineOpts.cpp
+++ b/bolt/lib/Utils/CommandLineOpts.cpp
@@ -51,6 +51,48 @@ cl::opt<unsigned> AlignFunctions(
     cl::desc("align functions at a given value (relocation mode)"),
     cl::init(64), cl::cat(BoltOptCategory));
 
+cl::opt<bool> AlignBlocks("align-blocks", cl::desc("align basic blocks"),
+                          cl::cat(BoltOptCategory));
+
+cl::opt<unsigned> AlignBlocksMinSize(
+    "align-blocks-min-size",
+    cl::desc("minimal size of the basic block that should be aligned"),
+    cl::init(0), cl::ZeroOrMore, cl::Hidden, cl::cat(BoltOptCategory));
+
+cl::opt<unsigned> AlignBlocksThreshold(
+    "align-blocks-threshold",
+    cl::desc(
+        "align only blocks with frequency larger than containing function "
+        "execution frequency specified in percent. E.g. 1000 means aligning "
+        "blocks that are 10 times more frequently executed than the "
+        "containing function."),
+    cl::init(800), cl::Hidden, cl::cat(BoltOptCategory));
+
+cl::opt<unsigned> AlignFunctionsMaxBytes(
+    "align-functions-max-bytes",
+    cl::desc("maximum number of bytes to use to align functions"), cl::init(32),
+    cl::cat(BoltOptCategory));
+
+cl::opt<unsigned>
+    BlockAlignment("block-alignment",
+                   cl::desc("boundary to use for alignment of basic blocks"),
+                   cl::init(16), cl::ZeroOrMore, cl::cat(BoltOptCategory));
+
+cl::opt<bool>
+    PreserveBlocksAlignment("preserve-blocks-alignment",
+                            cl::desc("try to preserve basic block alignment"),
+                            cl::cat(BoltOptCategory));
+
+cl::opt<bool>
+    UseCompactAligner("use-compact-aligner",
+                      cl::desc("Use compact approach for aligning functions"),
+                      cl::init(true), cl::cat(BoltOptCategory));
+
+cl::opt<bool> X86AlignBranchBoundaryHotOnly(
+    "x86-align-branch-boundary-hot-only",
+    cl::desc("only apply branch boundary alignment in hot code"),
+    cl::init(true), cl::cat(BoltOptCategory));
+
 cl::opt<bool>
 AggregateOnly("aggregate-only",
   cl::desc("exit after writing aggregated data file"),


### PR DESCRIPTION
Consolidate all alignment-related `cl::opt` definitions into
`CommandLineOpts.cpp`, expose matching public members on `BinaryContext`,
and populate them from `RewriteInstance::adjustCommandLineOptions`
(mirrored in `MachORewriteInstance`). Switch all readers in Aligner,
BinaryEmitter, LongJmp, BinaryFunction and the use-old-text logs to
BC.* instead of opts::*.