### PR TITLE
Support for -fsplit-lto-unit option in flang driver

### DIFF
--- a/flang/test/Integration/split-lto-unit-2.f90
+++ b/flang/test/Integration/split-lto-unit-2.f90
@@ -1,19 +1,19 @@
 ! Check that -flto=thin without -fsplit-lto-unit has EnableSplitLTOUnit = 0
 ! RUN: %flang -flto=thin  -S -o - %s |  FileCheck %s --check-prefix=SPLIT0
-! RUN: %flang -flto=thin --target=x86_64-linux-gnu -S -o - %s |  FileCheck %s --check-prefix=SPLIT0
-! RUN: %flang -flto=thin --target=x86_64-apple-macosx -S -o - %s | FileCheck %s --check-prefix=SPLIT0
+! RUN: %if x86-registered-target %{ %flang -flto=thin --target=x86_64-linux-gnu -S -o - %s |  FileCheck %s --check-prefix=SPLIT0 %}
+! RUN: %if x86-registered-target %{ %flang -flto=thin --target=x86_64-apple-macosx -S -o - %s | FileCheck %s --check-prefix=SPLIT0 %}
 
 ! Check that -flto=thin with -fsplit-lto-unit has EnableSplitLTOUnit = 1
 ! RUN: %flang -flto=thin -fsplit-lto-unit -S -o - %s | FileCheck %s --check-prefix=SPLIT1
-! RUN: %flang -flto=thin --target=x86_64-linux-gnu -fsplit-lto-unit -S -o - %s | FileCheck %s --check-prefix=SPLIT1
-! RUN: %flang -flto=thin --target=x86_64-apple-macosx -fsplit-lto-unit -S -o - %s | FileCheck %s --check-prefix=SPLIT1
+! RUN: %if x86-registered-target %{ %flang -flto=thin --target=x86_64-linux-gnu -fsplit-lto-unit -S -o - %s | FileCheck %s --check-prefix=SPLIT1 %}
+! RUN: %if x86-registered-target %{ %flang -flto=thin --target=x86_64-apple-macosx -fsplit-lto-unit -S -o - %s | FileCheck %s --check-prefix=SPLIT1 %}
 
 ! Check that regular LTO has EnableSplitLTOUnit = 1 
 ! RUN: %flang -flto -S -o - %s | FileCheck %s --implicit-check-not="EnableSplitLTOUnit" --check-prefix=SPLIT1
-! RUN: %flang -flto --target=x86_64-linux-gnu -S -o - %s |  FileCheck %s --check-prefix=SPLIT1
+! RUN: %if x86-registered-target %{ %flang -flto --target=x86_64-linux-gnu -S -o - %s |  FileCheck %s --check-prefix=SPLIT1 %}
 
 ! Check that regular LTO has no EnableSplitLTOUnit for apple targets
-! RUN: %flang -flto --target=x86_64-apple-macosx -S -o - %s | FileCheck %s --check-prefix=NOSPLIT
+! RUN: %if x86-registered-target %{ %flang -flto --target=x86_64-apple-macosx -S -o - %s | FileCheck %s --check-prefix=NOSPLIT %}
 
 ! SPLIT0: !{i32 1, !"EnableSplitLTOUnit", i32 0}
 ! SPLIT1: !{i32 1, !"EnableSplitLTOUnit", i32 1}


### PR DESCRIPTION
Fix for buildbot failures in #202858

This commit fixes a regression introduced in commit 12aefe26cedd9a8f94546cc1f2be285cfddcc861 (Support for -fsplit-lto-unit option in flang driver). When the compiler is built only for aarch64 one of the testcase failed.

Added explicit check  %if x86-registered-target for this testcase to resolve the issue.