### PR TITLE
[clang] Add clang-format-check-format instead to CLANG_TEST_DEPS

### DIFF
--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -93,7 +93,7 @@ list(APPEND CLANG_TEST_DEPS
   clang
   clang-fuzzer-dictionary
   clang-resource-headers
-  clang-format
+  clang-format-check-format
   clang-tblgen
   clang-offload-bundler
   clang-import-test
@@ -255,7 +255,3 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/debuginfo-tests)
 endif()
 
 add_subdirectory(Analysis/LifetimeSafety)
-
-if(TARGET check-clang-format)
-  add_dependencies(check-clang-format clang-format-check-format)
-endif()


### PR DESCRIPTION
Ensure that clang-format doesn't break the existing format of its own source.

Reverts #199169 and #199638.