### PR TITLE
[clang][bytecode][NFC] Remove dead code

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -6962,9 +6962,6 @@ bool Compiler<Emitter>::compileConstructor(const CXXConstructorDecl *Ctor) {
           return false;
       }
 
-      if (IsUnion && !this->emitActivate(InitExpr))
-        return false;
-
       if (!this->visitInitializerPop(InitExpr))
         return false;
     } else if (const IndirectFieldDecl *IFD = Init->getIndirectMember()) {


### PR DESCRIPTION
Unions can't have base classes so this is never used.