### PR TITLE
[MC][llvm-ml] Fix MASM cross-assembly parser issues

### DIFF
--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -436,7 +436,7 @@ public:
     return MCSectionSubPair();
   }
   MCSection *getCurrentSectionOnly() const {
-    return CurFrag->getParent();
+    return CurFrag ? CurFrag->getParent() : nullptr;
   }
 
   /// Return the previous section that the streamer is emitting code to.

--- a/llvm/lib/MC/MCParser/MasmParser.cpp
+++ b/llvm/lib/MC/MCParser/MasmParser.cpp
@@ -3704,8 +3704,12 @@ bool MasmParser::parseStructInitializer(const StructInfo &Structure,
   if (parseOptionalToken(AsmToken::LCurly)) {
     EndToken = AsmToken::RCurly;
   } else if (parseOptionalAngleBracketOpen()) {
+    // Note: parseOptionalAngleBracketOpen() has already incremented
+    // AngleBracketDepth; the matching parseAngleBracketClose() below decrements
+    // it once, so it must not be incremented again here (otherwise the depth
+    // leaks and a later '>' is misparsed as a closing bracket instead of the
+    // GT operator).
     EndToken = AsmToken::Greater;
-    AngleBracketDepth++;
   } else if (FirstToken.is(AsmToken::Identifier) &&
              FirstToken.getString() == "?") {
     // ? initializer; leave EndToken uninitialized to treat as empty.

--- a/llvm/lib/MC/MCParser/MasmParser.cpp
+++ b/llvm/lib/MC/MCParser/MasmParser.cpp
@@ -1940,6 +1940,15 @@ bool MasmParser::parseStatement(ParseStatementInfo &Info,
     // identifier ':'   -> Label.
     Lex();
 
+    // MASM 'identifier ::' declares a global (public) label, equivalent to a
+    // plain label followed by a PUBLIC directive. Consume the second colon and
+    // remember to give the symbol global binding once it is created.
+    bool IsGlobalLabel = false;
+    if (getLexer().is(AsmToken::Colon)) {
+      Lex();
+      IsGlobalLabel = true;
+    }
+
     // Diagnose attempt to use '.' as a label.
     if (IDVal == ".")
       return Error(IDLoc, "invalid use of pseudo-symbol '.' as a label");
@@ -1983,8 +1992,12 @@ bool MasmParser::parseStatement(ParseStatementInfo &Info,
     }
 
     // Emit the label.
-    if (!getTargetParser().isParsingMSInlineAsm())
+    if (!getTargetParser().isParsingMSInlineAsm()) {
       Out.emitLabel(Sym, IDLoc);
+      // 'identifier ::' gives the label global (public) binding.
+      if (IsGlobalLabel)
+        Out.emitSymbolAttribute(Sym, MCSA_Global);
+    }
     return false;
   }
 

--- a/llvm/test/tools/llvm-ml/global_label.asm
+++ b/llvm/test/tools/llvm-ml/global_label.asm
@@ -1,0 +1,11 @@
+; 'identifier ::' defines a label and gives it global (public) binding, which is
+; equivalent to a plain label plus a PUBLIC directive.
+; RUN: llvm-ml -filetype=s %s /Fo - | FileCheck %s
+
+.code
+
+foo::
+  ret
+
+; CHECK: foo:
+; CHECK: .globl foo

--- a/llvm/test/tools/llvm-ml/section_required_obj.asm
+++ b/llvm/test/tools/llvm-ml/section_required_obj.asm
@@ -1,0 +1,8 @@
+; The object-file streamer (unlike the assembly streamer) starts with no current
+; section, so getCurrentSectionOnly() returns a null current fragment. Emitting a
+; directive before any section directive must report the "expected section
+; directive" diagnostic instead of dereferencing the null fragment and crashing.
+; RUN: not llvm-ml -filetype=obj %s /Fo /dev/null 2>&1 | FileCheck %s
+
+; CHECK: :[[# @LINE + 1]]:6: error: expected section directive before assembly directive in 'BYTE' directive
+BYTE 2, 3, 4

--- a/llvm/test/tools/llvm-ml/struct_initializer_angle_brackets.asm
+++ b/llvm/test/tools/llvm-ml/struct_initializer_angle_brackets.asm
@@ -1,0 +1,27 @@
+; A struct value initialized with '<...>' must not leak the angle-bracket nesting
+; depth. parseStructInitializer used to increment AngleBracketDepth twice (once in
+; parseOptionalAngleBracketOpen() and once directly) while parseAngleBracketClose()
+; decrements it only once. A leaked depth makes a later 'GT' operator -- which the
+; expression lexer treats as '>' -- be misparsed as a closing angle bracket, so an
+; 'IF <expr> GT <n>' after a '<...>' initializer failed with "expected newline".
+; RUN: llvm-ml -filetype=s %s /Fo - | FileCheck %s
+
+.data
+POINT STRUCT
+  x DWORD ?
+POINT ENDS
+
+p POINT <>
+
+.code
+foo:
+IF 1 GT 2
+  xor eax, eax
+ELSE
+  mov eax, 17
+ENDIF
+  ret
+
+; CHECK-LABEL: foo:
+; CHECK: mov eax, 17
+; CHECK-NOT: xor eax, eax


### PR DESCRIPTION
These three independent fixes to LLVM's MASM assembler (`llvm-ml` / `MasmParser` /
`MCStreamer`) were found while cross-assembling MSVC-syntax `.asm` sources with
`llvm-ml` (it is the only x64 MASM assembler available in a `clang-cl` cross
toolchain that ships no real `ml64`). All three are genuine `llvm-ml` ⇄ `ml64`
conformance issues — two crashes/parse bugs and one missing syntax — not specific
to any particular source base.

The commits are independent and ordered most-impactful first (the crash fix); I'm
happy to split them into three separate PRs if that's preferred.

### 1. `[MC]` Make `MCStreamer::getCurrentSectionOnly()` null-safe
`getCurrentSectionOnly()` dereferenced `CurFrag` unconditionally, but `CurFrag`
is null in the object streamer before the first section. Result: a **SIGSEGV** on
any label/data directive emitted before a section with `-filetype=obj`. (The
`-filetype=asm` streamer has a non-null `CurFrag`, so only the object path
crashed.)

### 2. `[MC]` Fix `AngleBracketDepth` double-increment in `parseStructInitializer()`
`parseStructInitializer()` incremented `AngleBracketDepth` twice — once inside
`parseOptionalAngleBracketOpen()` and once directly — while
`parseAngleBracketClose()` decrements it once, leaking one level per `<…>` struct
initializer. The leaked depth makes a later `>` parse as a closing bracket, so
e.g. `IF <expr> GT <n>` after a `<…>`-initialized struct fails with
`expected newline`.

### 3. `[llvm-ml]` Support the MASM `label ::` global-label syntax
`MasmParser` consumed only one colon after a label, so MASM's `name ::` form
(define a label **and** make it public) was unsupported and produced
`unexpected token at start of statement` on the second colon.

### Testing
Each commit adds a focused lit test under `llvm/test/tools/llvm-ml/`
(`section_required_obj.asm`, `struct_initializer_angle_brackets.asm`,
`global_label.asm`). All three new tests pass; there are **0 regressions** across
the `tools/llvm-ml` suite (the baseline-failure set is identical with and without
the patches), and `git clang-format main` is clean.
