### PR TITLE
[InstCombine] Remove fold with OneUse as there is fold without the check (NFC)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1665,7 +1665,6 @@ Instruction *InstCombinerImpl::visitZExt(ZExtInst &Zext) {
   if (auto *Cmp = dyn_cast<ICmpInst>(Src))
     return transformZExtICmp(Cmp, Zext);
 
-  // zext(trunc(X) & C) -> (X & zext(C)).
   Constant *C;
   Value *X;
   // zext((trunc(X) & C) ^ C) -> ((X & zext(C)) ^ zext(C)).

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1668,10 +1668,6 @@ Instruction *InstCombinerImpl::visitZExt(ZExtInst &Zext) {
   // zext(trunc(X) & C) -> (X & zext(C)).
   Constant *C;
   Value *X;
-  if (match(Src, m_OneUse(m_And(m_Trunc(m_Value(X)), m_Constant(C)))) &&
-      X->getType() == DestTy)
-    return BinaryOperator::CreateAnd(X, Builder.CreateZExt(C, DestTy));
-
   // zext((trunc(X) & C) ^ C) -> ((X & zext(C)) ^ zext(C)).
   Value *And;
   if (match(Src, m_OneUse(m_Xor(m_Value(And), m_Constant(C)))) &&


### PR DESCRIPTION
same fold some lined below without the OneUse check:
https://github.com/llvm/llvm-project/blob/f21080724d2067b5acf01893bf2d544b49239161/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp#L1689-L1693