### PR TITLE
[Clang][Sema] Warn on a function reference compared/converted to null

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -684,6 +684,11 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
   by the kernel, so setting them is almost always a typo (matching the
   bionic libc `diagnose_if` check).
 
+- `-Wtautological-pointer-compare` and `-Wpointer-bool-conversion` now
+  diagnose a reference to a function (e.g. of type `void (&)()`) compared
+  against or converted to a null pointer, the same as a bare function name.
+  (#GH46362)
+
 ### Improvements to Clang's time-trace
 
 ### Improvements to Coverage Mapping

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -14398,6 +14398,11 @@ void Sema::DiagnoseAlwaysNonNullPointer(Expr *E,
   }
 
   QualType T = D->getType();
+  // A reference to a function is never null either; look through it.
+  const bool IsFunctionReference =
+      T->isReferenceType() && T->getPointeeType()->isFunctionType();
+  if (IsFunctionReference)
+    T = T->getPointeeType();
   const bool IsArray = T->isArrayType();
   const bool IsFunction = T->isFunctionType();
 
@@ -14434,6 +14439,10 @@ void Sema::DiagnoseAlwaysNonNullPointer(Expr *E,
                                 << Range << IsEqual;
 
   if (!IsFunction)
+    return;
+
+  // The fix-it notes below only apply to a bare function name, not a reference.
+  if (IsFunctionReference)
     return;
 
   // Suggest '&' to silence the function warning.

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -14438,11 +14438,8 @@ void Sema::DiagnoseAlwaysNonNullPointer(Expr *E,
   Diag(E->getExprLoc(), DiagID) << DiagType << S.str() << E->getSourceRange()
                                 << Range << IsEqual;
 
-  if (!IsFunction)
-    return;
-
   // The fix-it notes below only apply to a bare function name, not a reference.
-  if (IsFunctionReference)
+  if (!IsFunction || IsFunctionReference)
     return;
 
   // Suggest '&' to silence the function warning.

--- a/clang/test/CXX/expr/expr.unary/expr.unary.general/p1.cpp
+++ b/clang/test/CXX/expr/expr.unary/expr.unary.general/p1.cpp
@@ -45,7 +45,7 @@ void dependent(T t, T* pt, T U::* mpt, T(&ft)(), T(&at)[4]) {
   *ft;
   +ft;
   -ft; // expected-error {{invalid argument type 'T (*)()' to unary expression}}
-  !ft;
+  !ft; // expected-warning {{address of function 'ft' will always evaluate to 'true'}}
   ~ft; // expected-error {{invalid argument type 'T (*)()' to unary expression}}
   &ft;
   ++ft; // expected-error {{cannot increment value of type 'T ()'}}
@@ -62,4 +62,4 @@ void dependent(T t, T* pt, T U::* mpt, T(&ft)(), T(&at)[4]) {
 }
 
 // Make sure we only emit diagnostics once.
-template void dependent(A t, A* pt, A B::* mpt, A(&ft)(), A(&at)[4]);
+template void dependent(A t, A* pt, A B::* mpt, A(&ft)(), A(&at)[4]); // expected-note {{in instantiation of function template specialization 'dependent<A, B>' requested here}}

--- a/clang/test/SemaCXX/condition.cpp
+++ b/clang/test/SemaCXX/condition.cpp
@@ -56,7 +56,7 @@ void test3() {
 }
 
 void test4(bool (&x)(void)) {
-  while (x);
+  while (x); // expected-warning {{address of function 'x' will always evaluate to 'true'}}
 }
 
 template <class>

--- a/clang/test/SemaCXX/warn-bool-conversion.cpp
+++ b/clang/test/SemaCXX/warn-bool-conversion.cpp
@@ -132,6 +132,15 @@ void bar() {
   b = S2::f4;
   if (S2::f4) {}
 }
+
+// GH46362: a reference to a function is never null, like a bare function name.
+void func_ref(void (&f)(), int *&ptr) {
+  bool b;
+  b = f; // expected-warning {{address of function 'f' will always evaluate to 'true'}}
+  if (f) {} // expected-warning {{address of function 'f' will always evaluate to 'true'}}
+  b = ptr;
+  if (ptr) {}
+}
 }
 
 namespace Array {

--- a/clang/test/SemaCXX/warn-tautological-compare.cpp
+++ b/clang/test/SemaCXX/warn-tautological-compare.cpp
@@ -110,6 +110,25 @@ namespace FunctionCompare {
   }
 }
 
+namespace FunctionReferenceCompare {
+  // GH46362: a reference to a function is never null, like a bare function name.
+  // No fix-it note is emitted, since prefixing '&' would not silence it.
+  void test(void (&f)(), int *&ptr) {
+    if (f == 0) {}
+    // expected-warning@-1{{comparison of function 'f' equal to a null pointer is always false}}
+    if (f != 0) {}
+    // expected-warning@-1{{comparison of function 'f' not equal to a null pointer is always true}}
+    if (f == nullptr) {}
+    // expected-warning@-1{{comparison of function 'f' equal to a null pointer is always false}}
+    if (nullptr != f) {}
+    // expected-warning@-1{{comparison of function 'f' not equal to a null pointer is always true}}
+
+    // A reference to a pointer can be null: no warning.
+    if (ptr == nullptr) {}
+    if (ptr != nullptr) {}
+  }
+}
+
 namespace PointerCompare {
   extern int a __attribute__((weak));
   int b;


### PR DESCRIPTION
Look through a reference-to-function in `DiagnoseAlwaysNonNullPointer` so `-Wtautological-pointer-compare` and              `-Wpointer-bool-conversion` fire for it, as they already do for a bare function name.

Fixes #46362

cc @Endilll @shafik 