### PR TITLE
workflows/new-prs: Remove obsolete code

### DIFF
--- a/.github/workflows/new-prs.yml
+++ b/.github/workflows/new-prs.yml
@@ -36,7 +36,6 @@ jobs:
       (github.event.pull_request.author_association != 'OWNER')
     steps:
       - name: Greet Author
-        working-directory: ./llvm/utils/git/
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This was left over after 57e4352de0d2617bae1656dc2e2b3ca430e83c4c and causing the jobs to fail.