### PR TITLE
[orc-rt] Sink Session::sendWrapperResult into Session.cpp. NFC.

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -469,12 +469,7 @@ private:
     }));
   }
 
-  void sendWrapperResult(uint64_t CallId, WrapperFunctionBuffer ResultBytes) {
-    if (auto TmpCA = std::atomic_load(&CA))
-      TmpCA->sendWrapperResult(CallId, std::move(ResultBytes));
-    ManagedCodeTaskGroup->releaseToken();
-  }
-
+  void sendWrapperResult(uint64_t CallId, WrapperFunctionBuffer ResultBytes);
   static void wrapperReturn(orc_rt_SessionRef S, uint64_t CallId,
                             orc_rt_WrapperFunctionBuffer ResultBytes);
 

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -361,6 +361,13 @@ void Session::completeShutdown() {
   CV.notify_all();
 }
 
+void Session::sendWrapperResult(uint64_t CallId,
+                                WrapperFunctionBuffer ResultBytes) {
+  if (auto TmpCA = std::atomic_load(&CA))
+    TmpCA->sendWrapperResult(CallId, std::move(ResultBytes));
+  ManagedCodeTaskGroup->releaseToken();
+}
+
 void Session::wrapperReturn(orc_rt_SessionRef S, uint64_t CallId,
                             orc_rt_WrapperFunctionBuffer ResultBytes) {
   unwrap(S)->sendWrapperResult(CallId, WrapperFunctionBuffer(ResultBytes));


### PR DESCRIPTION
This function is never called inline (except by Session::wrapperReturn, which is also in Session.cpp), so there's no need for it to be in the header.