### PR TITLE
[mlir][ptr] Add ptr.load op convert pattern to ptr-to-llvm pass

### DIFF
--- a/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
+++ b/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
@@ -85,6 +85,16 @@ struct ConstantOpConversion : public ConvertOpToLLVMPattern<ptr::ConstantOp> {
   matchAndRewrite(ptr::ConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;
 };
+
+//===----------------------------------------------------------------------===//
+// LoadOpConversion
+//===----------------------------------------------------------------------===//
+struct LoadOpConversion : public ConvertOpToLLVMPattern<ptr::LoadOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  LogicalResult
+  matchAndRewrite(ptr::LoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -413,6 +423,54 @@ LogicalResult ConstantOpConversion::matchAndRewrite(
 }
 
 //===----------------------------------------------------------------------===//
+// LoadOpConversion
+//===----------------------------------------------------------------------===//
+
+static LLVM::AtomicOrdering convertOrdering(ptr::AtomicOrdering ordering) {
+  switch (ordering) {
+  case ptr::AtomicOrdering::not_atomic:
+    return LLVM::AtomicOrdering::not_atomic;
+  case ptr::AtomicOrdering::unordered:
+    return LLVM::AtomicOrdering::unordered;
+  case ptr::AtomicOrdering::monotonic:
+    return LLVM::AtomicOrdering::monotonic;
+  case ptr::AtomicOrdering::acquire:
+    return LLVM::AtomicOrdering::acquire;
+  case ptr::AtomicOrdering::release:
+    return LLVM::AtomicOrdering::release;
+  case ptr::AtomicOrdering::acq_rel:
+    return LLVM::AtomicOrdering::acq_rel;
+  case ptr::AtomicOrdering::seq_cst:
+    return LLVM::AtomicOrdering::seq_cst;
+  }
+  llvm_unreachable("unhandled ptr::AtomicOrdering");
+}
+
+LogicalResult
+LoadOpConversion::matchAndRewrite(ptr::LoadOp op, OpAdaptor adaptor,
+                                  ConversionPatternRewriter &rewriter) const {
+  Type ptrType = getTypeConverter()->convertType(op.getPtr().getType());
+  if (!ptrType)
+    return rewriter.notifyMatchFailure(op, "Couldn't convert the ptr type");
+  unsigned alignment = 0;
+  if (std::optional<int64_t> align = op.getAlignment())
+    alignment = *align;
+  StringRef syncscope;
+  if (std::optional<StringRef> scope = op.getSyncscope())
+    syncscope = *scope;
+  rewriter.replaceOpWithNewOp<LLVM::LoadOp>(
+      op, op.getType(), adaptor.getPtr(),
+      /*alignment=*/alignment,
+      /*isVolatile=*/op.getVolatile_(),
+      /*isNonTemporal=*/op.getNontemporal(),
+      /*isInvariant=*/op.getInvariant(),
+      /*isInvariantGroup=*/op.getInvariantGroup(),
+      /*ordering=*/convertOrdering(op.getOrdering()),
+      /*syncscope=*/syncscope);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ConvertToLLVMPatternInterface implementation
 //===----------------------------------------------------------------------===//
 
@@ -475,8 +533,8 @@ void mlir::ptr::populatePtrToLLVMConversionPatterns(
 
   // Add conversion patterns.
   patterns.add<FromPtrOpConversion, GetMetadataOpConversion, PtrAddOpConversion,
-               ToPtrOpConversion, TypeOffsetOpConversion, ConstantOpConversion>(
-      converter);
+               ToPtrOpConversion, TypeOffsetOpConversion, ConstantOpConversion,
+               LoadOpConversion>(converter);
 }
 
 void mlir::ptr::registerConvertPtrToLLVMInterface(DialectRegistry &registry) {

--- a/mlir/test/Conversion/PtrToLLVM/ptr-to-llvm.mlir
+++ b/mlir/test/Conversion/PtrToLLVM/ptr-to-llvm.mlir
@@ -330,3 +330,23 @@ func.func @test_constant_address_ops() -> (!ptr.ptr<#ptr.generic_space>, !ptr.pt
   %null = ptr.constant #ptr.null : !ptr.ptr<#ptr.generic_space> 
   return %addr_0, %null : !ptr.ptr<#ptr.generic_space>, !ptr.ptr<#ptr.generic_space>
 }
+
+// CHECK-LABEL:  func @test_load_ops
+// CHECK-SAME:     %[[ARG0:.*]]: !llvm.ptr
+//       CHECK:    %[[LOAD_0:.*]] = llvm.load %[[ARG0]] : !llvm.ptr -> f32
+//       CHECK:    %[[LOAD_1:.*]] = llvm.load volatile %[[ARG0]] : !llvm.ptr -> f32
+//       CHECK:    %[[LOAD_2:.*]] = llvm.load %[[ARG0]] {nontemporal} : !llvm.ptr -> f32
+//       CHECK:    %[[LOAD_3:.*]] = llvm.load %[[ARG0]] invariant : !llvm.ptr -> f32
+//       CHECK:    %[[LOAD_4:.*]] = llvm.load %[[ARG0]] invariant_group : !llvm.ptr -> f32
+//       CHECK:    %[[LOAD_5:.*]] = llvm.load %[[ARG0]] atomic monotonic {alignment = 8 : i64} : !llvm.ptr -> i64
+//       CHECK:    %[[LOAD_6:.*]] = llvm.load volatile %[[ARG0]] atomic syncscope("workgroup") acquire {alignment = 4 : i64, nontemporal} : !llvm.ptr -> i32
+func.func @test_load_ops(%arg0: !ptr.ptr<#ptr.generic_space>) -> (f32, f32, f32, f32, f32, i64, i32) {
+  %0 = ptr.load %arg0 : !ptr.ptr<#ptr.generic_space> -> f32
+  %1 = ptr.load volatile %arg0 : !ptr.ptr<#ptr.generic_space> -> f32
+  %2 = ptr.load %arg0 nontemporal : !ptr.ptr<#ptr.generic_space> -> f32
+  %3 = ptr.load %arg0 invariant : !ptr.ptr<#ptr.generic_space> -> f32
+  %4 = ptr.load %arg0 invariant_group : !ptr.ptr<#ptr.generic_space> -> f32
+  %5 = ptr.load %arg0 atomic monotonic alignment = 8 : !ptr.ptr<#ptr.generic_space> -> i64
+  %6 = ptr.load volatile %arg0 atomic syncscope("workgroup") acquire nontemporal alignment = 4 : !ptr.ptr<#ptr.generic_space> -> i32
+  func.return %0, %1, %2, %3, %4, %5, %6 : f32, f32, f32, f32, f32, i64, i32
+}


### PR DESCRIPTION
Ptr.LoadOp was missing the lowering pattern to LLVM IR. This PR adds the missing conversion logic.