### PR TITLE
[InstCombine] Try folding align assumes with unkown offset

### DIFF
--- a/llvm/include/llvm/IR/BundleAttributes.h
+++ b/llvm/include/llvm/IR/BundleAttributes.h
@@ -30,6 +30,7 @@ inline BundleAttr getBundleAttrFromOBU(OperandBundleUse OBU) {
 struct AssumeAlignInfo {
   const Use &Ptr;
   const Use &Alignment;
+  const Use *Offset;
   std::optional<uint64_t> AlignmentVal;
   std::optional<uint64_t> OffsetVal;
 };

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -1075,7 +1075,7 @@ void llvm::computeKnownBitsFromContext(const Value *V, KnownBits &Known,
     if (Elem.Index != AssumptionCache::ExprResultIdx) {
       if (auto OBU = I->getOperandBundleAt(Elem.Index);
           getBundleAttrFromOBU(OBU) == BundleAttr::Align) {
-        auto [Ptr, _, Alignment, Offset] = getAssumeAlignInfo(OBU);
+        auto [Ptr, _, _2, Alignment, Offset] = getAssumeAlignInfo(OBU);
         if (Ptr == V && Alignment && Offset && isPowerOf2_64(*Alignment) &&
             isValidAssumeForContext(I, Q)) {
           Known.Zero |= (*Alignment - 1) & ~*Offset;

--- a/llvm/lib/IR/BundleAttributes.cpp
+++ b/llvm/lib/IR/BundleAttributes.cpp
@@ -39,10 +39,12 @@ BundleAttr llvm::getBundleAttrFromID(uint32_t ID) {
 AssumeAlignInfo llvm::getAssumeAlignInfo(OperandBundleUse OBU) {
   assert(OBU.getTagID() == LLVMContext::OB_Align && OBU.Inputs.size() >= 2 &&
          OBU.Inputs.size() <= 3);
-  AssumeAlignInfo Ret{OBU.Inputs[0], OBU.Inputs[1], std::nullopt, std::nullopt};
+  AssumeAlignInfo Ret{OBU.Inputs[0], OBU.Inputs[1], nullptr, std::nullopt,
+                      std::nullopt};
   if (auto *Align = dyn_cast<ConstantInt>(OBU.Inputs[1]))
     Ret.AlignmentVal = Align->getZExtValue();
   if (OBU.Inputs.size() == 3) {
+    Ret.Offset = &OBU.Inputs[2];
     if (auto *Offset = dyn_cast<ConstantInt>(OBU.Inputs[2]))
       Ret.OffsetVal = Offset->getZExtValue();
   } else {
@@ -83,7 +85,7 @@ bool llvm::assumeBundleImpliesNonNull(const Value *Val, const Function *Context,
                                       OperandBundleUse OBU) {
   switch (getBundleAttrFromOBU(OBU)) {
   case BundleAttr::Align: {
-    auto [Ptr, _, Alignment, Offset] = getAssumeAlignInfo(OBU);
+    auto [Ptr, _, _2, Alignment, Offset] = getAssumeAlignInfo(OBU);
     return Ptr == Val && Alignment && Offset && isPowerOf2_64(*Alignment) &&
            *Offset % *Alignment != 0;
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3701,9 +3701,9 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         llvm_unreachable("Unexpected Attribute");
       case BundleAttr::Align: {
         // Try to remove redundant alignment assumptions.
-        auto [Ptr, _, Alignment, Offset] = getAssumeAlignInfo(OBU);
+        auto [Ptr, _, OffsetPtr, Alignment, Offset] = getAssumeAlignInfo(OBU);
 
-        if (!Alignment || !Offset)
+        if (!Alignment)
           break;
 
         // Remove align 1 and non-power-of-two bundles; they don't add any
@@ -3716,9 +3716,12 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
             GEP->getMaxPreservedAlignment(getDataLayout()) >= *Alignment) {
           Builder.CreateAlignmentAssumption(
               getDataLayout(), GEP->getPointerOperand(), *Alignment,
-              *Offset == 0 ? nullptr : Builder.getInt64(*Offset));
+              OffsetPtr ? const_cast<Value *>(OffsetPtr->get()) : nullptr);
           return RemoveBundle();
         }
+
+        if (!Offset)
+          break;
 
         Value *BasePtr;
         const APInt *PtrOffset;

--- a/llvm/test/Transforms/InstCombine/assume.ll
+++ b/llvm/test/Transforms/InstCombine/assume.ll
@@ -199,6 +199,16 @@ define void @align_on_gep_keeping_alignment(ptr %ptr, i64 %offset) {
   ret void
 }
 
+define void @align_on_gep_keeping_alignment_variable_offset(ptr %ptr, i64 %offset, i64 %offset2) {
+; CHECK-LABEL: @align_on_gep_keeping_alignment_variable_offset(
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[PTR:%.*]], i64 8, i64 [[OFFSET2:%.*]]) ]
+; CHECK-NEXT:    ret void
+;
+  %ptr2 = getelementptr [8 x i8], ptr %ptr, i64 %offset
+  call void @llvm.assume(i1 true) [ "align"(ptr %ptr2, i64 8, i64 %offset2) ]
+  ret void
+}
+
 define void @align_on_gep_not_keeping_alignment(ptr %ptr, i64 %offset) {
 ; CHECK-LABEL: @align_on_gep_not_keeping_alignment(
 ; CHECK-NEXT:    [[PTR2:%.*]] = getelementptr [4 x i8], ptr [[PTR:%.*]], i64 [[OFFSET:%.*]]
@@ -239,6 +249,22 @@ define void @non_power_of_two_align(ptr %ptr) {
 ; CHECK-NEXT:    ret void
 ;
   call void @llvm.assume(i1 true) [ "align"(ptr %ptr, i64 3) ]
+  ret void
+}
+
+define void @non_power_of_two_align_variable_offset(ptr %ptr, i64 %i) {
+; CHECK-LABEL: @non_power_of_two_align_variable_offset(
+; CHECK-NEXT:    ret void
+;
+  call void @llvm.assume(i1 true) [ "align"(ptr %ptr, i64 3, i64 %i) ]
+  ret void
+}
+
+define void @align_1_variable_offset(ptr %ptr, i64 %i) {
+; CHECK-LABEL: @align_1_variable_offset(
+; CHECK-NEXT:    ret void
+;
+  call void @llvm.assume(i1 true) [ "align"(ptr %ptr, i64 1, i64 %i) ]
   ret void
 }
 


### PR DESCRIPTION
There are a few folds which don't depend on the offset of the alignment, but are nevertheless guarded on whether the offset is known. Run these folds unconditionally instead.
