### PR TITLE
[mlir][arith] Add ValueBoundsOpInterface external models for the arith integer CeilDiv, RemSI, RemUI, MaxUI, MinUI.

### DIFF
--- a/mlir/include/mlir/Interfaces/ValueBoundsOpInterface.h
+++ b/mlir/include/mlir/Interfaces/ValueBoundsOpInterface.h
@@ -313,6 +313,22 @@ public:
   static FailureOr<bool>
   areEquivalentSlices(MLIRContext *ctx, const HyperrectangularSlice &slice1,
                       const HyperrectangularSlice &slice2);
+  
+  /// Return "true" if the given value is provably non-negative. If it's provably positive,
+  /// or nothing can be proven, return "false".
+  static bool isProvablyNonNegative(Value value, ValueBoundsConstraintSet &cstr);
+
+  /// Return "true" if the given value is provably non-positive. If it's provably negative,
+  /// or nothing can be proven, return "false".
+  static bool isProvablyNonPositive(Value value, ValueBoundsConstraintSet &cstr);
+
+  /// Return "true" if the given value is provably positive. If it's provably non-negative,
+  /// or nothing can be proven, return "false".
+  static bool isProvablyPositive(Value value, ValueBoundsConstraintSet &cstr);
+  
+  /// Return "true" if the given value is provably negative. If it's provably non-positive,
+  /// or nothing can be proven, return "false".
+  static bool isProvablyNegative(Value value, ValueBoundsConstraintSet &cstr);
 
   /// Add a bound for the given index-typed value or shaped value. This function
   /// returns a builder that adds the bound.

--- a/mlir/include/mlir/Interfaces/ValueBoundsOpInterface.h
+++ b/mlir/include/mlir/Interfaces/ValueBoundsOpInterface.h
@@ -313,21 +313,23 @@ public:
   static FailureOr<bool>
   areEquivalentSlices(MLIRContext *ctx, const HyperrectangularSlice &slice1,
                       const HyperrectangularSlice &slice2);
-  
-  /// Return "true" if the given value is provably non-negative. If it's provably positive,
-  /// or nothing can be proven, return "false".
-  static bool isProvablyNonNegative(Value value, ValueBoundsConstraintSet &cstr);
 
-  /// Return "true" if the given value is provably non-positive. If it's provably negative,
-  /// or nothing can be proven, return "false".
-  static bool isProvablyNonPositive(Value value, ValueBoundsConstraintSet &cstr);
+  /// Return "true" if the given value is provably non-negative. If it's
+  /// provably positive, or nothing can be proven, return "false".
+  static bool isProvablyNonNegative(Value value,
+                                    ValueBoundsConstraintSet &cstr);
 
-  /// Return "true" if the given value is provably positive. If it's provably non-negative,
-  /// or nothing can be proven, return "false".
+  /// Return "true" if the given value is provably non-positive. If it's
+  /// provably negative, or nothing can be proven, return "false".
+  static bool isProvablyNonPositive(Value value,
+                                    ValueBoundsConstraintSet &cstr);
+
+  /// Return "true" if the given value is provably positive. If it's provably
+  /// non-negative, or nothing can be proven, return "false".
   static bool isProvablyPositive(Value value, ValueBoundsConstraintSet &cstr);
-  
-  /// Return "true" if the given value is provably negative. If it's provably non-positive,
-  /// or nothing can be proven, return "false".
+
+  /// Return "true" if the given value is provably negative. If it's provably
+  /// non-positive, or nothing can be proven, return "false".
   static bool isProvablyNegative(Value value, ValueBoundsConstraintSet &cstr);
 
   /// Add a bound for the given index-typed value or shaped value. This function

--- a/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
@@ -56,8 +56,9 @@ void arith::ArithDialect::initialize() {
   declarePromisedInterfaces<bufferization::BufferizableOpInterface, ConstantOp,
                             IndexCastOp, SelectOp>();
   declarePromisedInterfaces<ValueBoundsOpInterface, AddIOp, ConstantOp, SubIOp,
-                            MulIOp, SelectOp, FloorDivSIOp, CeilDivSIOp, MinSIOp,
-                            MaxSIOp, MinUIOp, MaxUIOp, RemSIOp, RemUIOp>();
+                            MulIOp, SelectOp, FloorDivSIOp, CeilDivSIOp,
+                            MinSIOp, MaxSIOp, MinUIOp, MaxUIOp, RemSIOp,
+                            RemUIOp>();
 }
 
 /// Materialize an integer or floating point constant.

--- a/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
@@ -56,7 +56,8 @@ void arith::ArithDialect::initialize() {
   declarePromisedInterfaces<bufferization::BufferizableOpInterface, ConstantOp,
                             IndexCastOp, SelectOp>();
   declarePromisedInterfaces<ValueBoundsOpInterface, AddIOp, ConstantOp, SubIOp,
-                            MulIOp, SelectOp, FloorDivSIOp, MinSIOp, MaxSIOp>();
+                            MulIOp, SelectOp, FloorDivSIOp, CeilDivSIOp, MinSIOp,
+                            MaxSIOp, MinUIOp, MaxUIOp, RemSIOp, RemUIOp>();
 }
 
 /// Materialize an integer or floating point constant.

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -172,7 +172,7 @@ struct RemUIOpInterface
     AffineExpr rhs = cstr.getExpr(rhsValue);
 
     // remui computes an unsigned remainder, so for a provably positive divisor
-    // the result is always in [0, rhs - 1]
+    // the result is always in [0, rhs - 1].
     if (isProvablyPositive(rhsValue, cstr)) {
       cstr.bound(value) >= 0;
       cstr.bound(value) <= rhs - 1;
@@ -293,17 +293,21 @@ struct MinUIOpInterface
     // ValueBoundsConstraintSet models values as signed integers (e.g. an i8
     // 0xff is treated as -1, not 255). For an unsigned minimum it is enough
     // that a single operand is provably non-negative: minui(x, y) is in
-    // [0, y] whenever y >= 0 (and symmetrically for x)
+    // [0, y] whenever y >= 0 (and symmetrically for x).
     bool lhsNonNegative = isProvablyNonNegative(minOp.getLhs(), cstr);
     bool rhsNonNegative = isProvablyNonNegative(minOp.getRhs(), cstr);
     if (!lhsNonNegative && !rhsNonNegative)
       return;
 
     cstr.bound(value) >= 0;
-    if (lhsNonNegative)
-      cstr.bound(value) <= cstr.getExpr(minOp.getLhs());
-    if (rhsNonNegative)
-      cstr.bound(value) <= cstr.getExpr(minOp.getRhs());
+    if (lhsNonNegative) {
+      AffineExpr lhs = cstr.getExpr(minOp.getLhs());
+      cstr.bound(value) <= lhs;
+    }
+    if (rhsNonNegative) {
+      AffineExpr rhs = cstr.getExpr(minOp.getRhs());
+      cstr.bound(value) <= rhs;
+    }
   }
 };
 

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -276,7 +276,7 @@ struct MaxSIOpInterface
                                    ValueBoundsConstraintSet &cstr) const {
     auto maxOp = cast<arith::MaxSIOp>(op);
     assert(value == maxOp.getResult() && "invalid value");
-
+    
     AffineExpr lhs = cstr.getExpr(maxOp.getLhs());
     AffineExpr rhs = cstr.getExpr(maxOp.getRhs());
     cstr.bound(value) >= lhs;

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -278,7 +278,7 @@ struct MinUIOpInterface
     assert(value == minOp.getResult() && "invalid value");
 
     // ValueBoundsConstraintSet models values as signed integers (e.g. an i8
-    // 0xff is treated as -1, not 255).So, we can only derive bounds for minui 
+    // 0xff is treated as -1, not 255).So, we can only derive bounds for minui
     // if both operands are provably non-negative.
     bool lhsNonNegative =
         ValueBoundsConstraintSet::isProvablyNonNegative(minOp.getLhs(), cstr);

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -278,25 +278,20 @@ struct MinUIOpInterface
     assert(value == minOp.getResult() && "invalid value");
 
     // ValueBoundsConstraintSet models values as signed integers (e.g. an i8
-    // 0xff is treated as -1, not 255). For an unsigned minimum it is enough
-    // that a single operand is provably non-negative: minui(x, y) is in
-    // [0, y] whenever y >= 0 (and symmetrically for x).
+    // 0xff is treated as -1, not 255).So, we can only derive bounds for minui 
+    // if both operands are provably non-negative.
     bool lhsNonNegative =
         ValueBoundsConstraintSet::isProvablyNonNegative(minOp.getLhs(), cstr);
     bool rhsNonNegative =
         ValueBoundsConstraintSet::isProvablyNonNegative(minOp.getRhs(), cstr);
-    if (!lhsNonNegative && !rhsNonNegative)
+    if (!lhsNonNegative || !rhsNonNegative)
       return;
 
     cstr.bound(value) >= 0;
-    if (lhsNonNegative) {
-      AffineExpr lhs = cstr.getExpr(minOp.getLhs());
-      cstr.bound(value) <= lhs;
-    }
-    if (rhsNonNegative) {
-      AffineExpr rhs = cstr.getExpr(minOp.getRhs());
-      cstr.bound(value) <= rhs;
-    }
+    AffineExpr lhs = cstr.getExpr(minOp.getLhs());
+    AffineExpr rhs = cstr.getExpr(minOp.getRhs());
+    cstr.bound(value) <= lhs;
+    cstr.bound(value) <= rhs;
   }
 };
 
@@ -309,9 +304,11 @@ struct MaxUIOpInterface
     assert(value == maxOp.getResult() && "invalid value");
 
     // See MinUIOpInterface comment
-    if (!ValueBoundsConstraintSet::isProvablyNonNegative(maxOp.getLhs(),
-                                                         cstr) ||
-        !ValueBoundsConstraintSet::isProvablyNonNegative(maxOp.getRhs(), cstr))
+    bool lhsNonNegative =
+        ValueBoundsConstraintSet::isProvablyNonNegative(maxOp.getLhs(), cstr);
+    bool rhsNonNegative =
+        ValueBoundsConstraintSet::isProvablyNonNegative(maxOp.getRhs(), cstr);
+    if (!lhsNonNegative || !rhsNonNegative)
       return;
 
     AffineExpr lhs = cstr.getExpr(maxOp.getLhs());

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -17,7 +17,6 @@ namespace mlir {
 namespace arith {
 namespace {
 
-
 struct AddIOpInterface
     : public ValueBoundsOpInterface::ExternalModel<AddIOpInterface, AddIOp> {
   void populateBoundsForIndexValue(Operation *op, Value value,
@@ -114,20 +113,24 @@ struct RemSIOpInterface
     Value lhsValue = remSIOp.getLhs();
     Value rhsValue = remSIOp.getRhs();
     AffineExpr rhs = cstr.getExpr(rhsValue);
-    bool rhsPositive = ValueBoundsConstraintSet::isProvablyPositive(rhsValue, cstr);
-    bool rhsNegative = ValueBoundsConstraintSet::isProvablyNegative(rhsValue, cstr);
+    bool rhsPositive =
+        ValueBoundsConstraintSet::isProvablyPositive(rhsValue, cstr);
+    bool rhsNegative =
+        ValueBoundsConstraintSet::isProvablyNegative(rhsValue, cstr);
 
-    // The result of remsi has the same sign as the dividend (lhs) and also fulfills |result| < |rhs|.
-    // The sign of lhs does not need to be a compile-time constant: it is sufficient if
-    // the constraint set can prove it. For lhs == 0 both branches may fire,
-    // which is consistent since the result is then 0. f.e:
+    // The result of remsi has the same sign as the dividend (lhs) and also
+    // fulfills |result| < |rhs|. The sign of lhs does not need to be a
+    // compile-time constant: it is sufficient if the constraint set can prove
+    // it. For lhs == 0 both branches may fire, which is consistent since the
+    // result is then 0. f.e:
     //   lhs   rhs   result   bounds
     //   ----  ----  ------   --------------------------------------------------
     //    7     3      1      0 <= val && val <= rhs-1 = 2      -> [0, 2]
     //    7    -3      1      0 <= val && val <= -rhs-1 = 2     -> [0, 2]
     //   -7     3     -1      val <= 0 && val >= 1-rhs = -2     -> [-2, 0]
     //   -7    -3     -1      val <= 0 && val >= rhs+1 = -2     -> [-2, 0]
-    //    0     3      0      both lhs branches fire (0<=val and val<=0) -> val == 0
+    //    0     3      0      both lhs branches fire (0<=val and val<=0) -> val
+    //    == 0
     if (ValueBoundsConstraintSet::isProvablyNonPositive(lhsValue, cstr)) {
       cstr.bound(value) <= 0;
       if (rhsPositive)
@@ -278,8 +281,10 @@ struct MinUIOpInterface
     // 0xff is treated as -1, not 255). For an unsigned minimum it is enough
     // that a single operand is provably non-negative: minui(x, y) is in
     // [0, y] whenever y >= 0 (and symmetrically for x).
-    bool lhsNonNegative = ValueBoundsConstraintSet::isProvablyNonNegative(minOp.getLhs(), cstr);
-    bool rhsNonNegative = ValueBoundsConstraintSet::isProvablyNonNegative(minOp.getRhs(), cstr);
+    bool lhsNonNegative =
+        ValueBoundsConstraintSet::isProvablyNonNegative(minOp.getLhs(), cstr);
+    bool rhsNonNegative =
+        ValueBoundsConstraintSet::isProvablyNonNegative(minOp.getRhs(), cstr);
     if (!lhsNonNegative && !rhsNonNegative)
       return;
 
@@ -304,7 +309,8 @@ struct MaxUIOpInterface
     assert(value == maxOp.getResult() && "invalid value");
 
     // See MinUIOpInterface comment
-    if (!ValueBoundsConstraintSet::isProvablyNonNegative(maxOp.getLhs(), cstr) ||
+    if (!ValueBoundsConstraintSet::isProvablyNonNegative(maxOp.getLhs(),
+                                                         cstr) ||
         !ValueBoundsConstraintSet::isProvablyNonNegative(maxOp.getRhs(), cstr))
       return;
 

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -17,16 +17,14 @@ namespace mlir {
 namespace arith {
 namespace {
 
-static bool isProvablyNonNegative(Value value,
-                                  ValueBoundsConstraintSet &cstr) {
+static bool isProvablyNonNegative(Value value, ValueBoundsConstraintSet &cstr) {
   return cstr.populateAndCompare(
       /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::GE,
       /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
 }
 
-static bool isProvablyNonPositive(Value value,
-                                  ValueBoundsConstraintSet &cstr) {
- return cstr.populateAndCompare(
+static bool isProvablyNonPositive(Value value, ValueBoundsConstraintSet &cstr) {
+  return cstr.populateAndCompare(
       /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::LE,
       /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
 }

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -17,6 +17,32 @@ namespace mlir {
 namespace arith {
 namespace {
 
+static bool isProvablyNonNegative(Value value,
+                                  ValueBoundsConstraintSet &cstr) {
+  return cstr.populateAndCompare(
+      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::GE,
+      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
+}
+
+static bool isProvablyNonPositive(Value value,
+                                  ValueBoundsConstraintSet &cstr) {
+ return cstr.populateAndCompare(
+      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::LE,
+      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
+}
+
+static bool isProvablyPositive(Value value, ValueBoundsConstraintSet &cstr) {
+  return cstr.populateAndCompare(
+      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::GT,
+      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
+}
+
+static bool isProvablyNegative(Value value, ValueBoundsConstraintSet &cstr) {
+  return cstr.populateAndCompare(
+      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::LT,
+      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
+}
+
 struct AddIOpInterface
     : public ValueBoundsOpInterface::ExternalModel<AddIOpInterface, AddIOp> {
   void populateBoundsForIndexValue(Operation *op, Value value,
@@ -86,6 +112,73 @@ struct FloorDivSIOpInterface
     AffineExpr lhs = cstr.getExpr(divSIOp.getLhs());
     AffineExpr rhs = cstr.getExpr(divSIOp.getRhs());
     cstr.bound(value) == lhs.floorDiv(rhs);
+  }
+};
+
+struct CeilDivSIOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<CeilDivSIOpInterface,
+                                                   CeilDivSIOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto divSIOp = cast<CeilDivSIOp>(op);
+    assert(value == divSIOp.getResult() && "invalid value");
+
+    AffineExpr lhs = cstr.getExpr(divSIOp.getLhs());
+    AffineExpr rhs = cstr.getExpr(divSIOp.getRhs());
+    cstr.bound(value) == lhs.ceilDiv(rhs);
+  }
+};
+
+struct RemSIOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<RemSIOpInterface, RemSIOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto remSIOp = cast<RemSIOp>(op);
+    assert(value == remSIOp.getResult() && "invalid value");
+
+    Value lhsValue = remSIOp.getLhs();
+    Value rhsValue = remSIOp.getRhs();
+    AffineExpr rhs = cstr.getExpr(rhsValue);
+    bool rhsPositive = isProvablyPositive(rhsValue, cstr);
+    bool rhsNegative = isProvablyNegative(rhsValue, cstr);
+
+    // The result of remsi has the same sign as the dividend (lhs). The sign
+    // of lhs does not need to be a compile-time constant: it is sufficient if
+    // the constraint set can prove it. For lhs == 0 both branches may fire,
+    // which is consistent since the result is then 0.
+    if (isProvablyNonPositive(lhsValue, cstr)) {
+      cstr.bound(value) <= 0;
+      if (rhsPositive)
+        cstr.bound(value) >= 1 - rhs;
+      if (rhsNegative)
+        cstr.bound(value) >= rhs + 1;
+    }
+    if (isProvablyNonNegative(lhsValue, cstr)) {
+      cstr.bound(value) >= 0;
+      if (rhsPositive)
+        cstr.bound(value) <= rhs - 1;
+      if (rhsNegative)
+        cstr.bound(value) <= -rhs - 1;
+    }
+  }
+};
+
+struct RemUIOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<RemUIOpInterface, RemUIOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto remUIOp = cast<RemUIOp>(op);
+    assert(value == remUIOp.getResult() && "invalid value");
+
+    Value rhsValue = remUIOp.getRhs();
+    AffineExpr rhs = cstr.getExpr(rhsValue);
+
+    // remui computes an unsigned remainder, so for a provably positive divisor
+    // the result is always in [0, rhs - 1]
+    if (isProvablyPositive(rhsValue, cstr)) {
+      cstr.bound(value) >= 0;
+      cstr.bound(value) <= rhs - 1;
+    }
   }
 };
 
@@ -183,7 +276,52 @@ struct MaxSIOpInterface
                                    ValueBoundsConstraintSet &cstr) const {
     auto maxOp = cast<arith::MaxSIOp>(op);
     assert(value == maxOp.getResult() && "invalid value");
-    
+
+    AffineExpr lhs = cstr.getExpr(maxOp.getLhs());
+    AffineExpr rhs = cstr.getExpr(maxOp.getRhs());
+    cstr.bound(value) >= lhs;
+    cstr.bound(value) >= rhs;
+  }
+};
+
+struct MinUIOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<MinUIOpInterface,
+                                                   arith::MinUIOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto minOp = cast<arith::MinUIOp>(op);
+    assert(value == minOp.getResult() && "invalid value");
+
+    // ValueBoundsConstraintSet models values as signed integers (e.g. an i8
+    // 0xff is treated as -1, not 255). For an unsigned minimum it is enough
+    // that a single operand is provably non-negative: minui(x, y) is in
+    // [0, y] whenever y >= 0 (and symmetrically for x)
+    bool lhsNonNegative = isProvablyNonNegative(minOp.getLhs(), cstr);
+    bool rhsNonNegative = isProvablyNonNegative(minOp.getRhs(), cstr);
+    if (!lhsNonNegative && !rhsNonNegative)
+      return;
+
+    cstr.bound(value) >= 0;
+    if (lhsNonNegative)
+      cstr.bound(value) <= cstr.getExpr(minOp.getLhs());
+    if (rhsNonNegative)
+      cstr.bound(value) <= cstr.getExpr(minOp.getRhs());
+  }
+};
+
+struct MaxUIOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<MaxUIOpInterface,
+                                                   arith::MaxUIOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto maxOp = cast<arith::MaxUIOp>(op);
+    assert(value == maxOp.getResult() && "invalid value");
+
+    // See MinUIOpInterface comment
+    if (!isProvablyNonNegative(maxOp.getLhs(), cstr) ||
+        !isProvablyNonNegative(maxOp.getRhs(), cstr))
+      return;
+
     AffineExpr lhs = cstr.getExpr(maxOp.getLhs());
     AffineExpr rhs = cstr.getExpr(maxOp.getRhs());
     cstr.bound(value) >= lhs;
@@ -202,8 +340,13 @@ void mlir::arith::registerValueBoundsOpInterfaceExternalModels(
     arith::SubIOp::attachInterface<arith::SubIOpInterface>(*ctx);
     arith::MulIOp::attachInterface<arith::MulIOpInterface>(*ctx);
     arith::FloorDivSIOp::attachInterface<arith::FloorDivSIOpInterface>(*ctx);
+    arith::CeilDivSIOp::attachInterface<arith::CeilDivSIOpInterface>(*ctx);
+    arith::RemSIOp::attachInterface<arith::RemSIOpInterface>(*ctx);
+    arith::RemUIOp::attachInterface<arith::RemUIOpInterface>(*ctx);
     arith::SelectOp::attachInterface<arith::SelectOpInterface>(*ctx);
     arith::MinSIOp::attachInterface<arith::MinSIOpInterface>(*ctx);
     arith::MaxSIOp::attachInterface<arith::MaxSIOpInterface>(*ctx);
+    arith::MinUIOp::attachInterface<arith::MinUIOpInterface>(*ctx);
+    arith::MaxUIOp::attachInterface<arith::MaxUIOpInterface>(*ctx);
   });
 }

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -17,29 +17,6 @@ namespace mlir {
 namespace arith {
 namespace {
 
-static bool isProvablyNonNegative(Value value, ValueBoundsConstraintSet &cstr) {
-  return cstr.populateAndCompare(
-      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::GE,
-      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
-}
-
-static bool isProvablyNonPositive(Value value, ValueBoundsConstraintSet &cstr) {
-  return cstr.populateAndCompare(
-      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::LE,
-      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
-}
-
-static bool isProvablyPositive(Value value, ValueBoundsConstraintSet &cstr) {
-  return cstr.populateAndCompare(
-      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::GT,
-      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
-}
-
-static bool isProvablyNegative(Value value, ValueBoundsConstraintSet &cstr) {
-  return cstr.populateAndCompare(
-      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::LT,
-      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
-}
 
 struct AddIOpInterface
     : public ValueBoundsOpInterface::ExternalModel<AddIOpInterface, AddIOp> {
@@ -137,21 +114,21 @@ struct RemSIOpInterface
     Value lhsValue = remSIOp.getLhs();
     Value rhsValue = remSIOp.getRhs();
     AffineExpr rhs = cstr.getExpr(rhsValue);
-    bool rhsPositive = isProvablyPositive(rhsValue, cstr);
-    bool rhsNegative = isProvablyNegative(rhsValue, cstr);
+    bool rhsPositive = ValueBoundsConstraintSet::isProvablyPositive(rhsValue, cstr);
+    bool rhsNegative = ValueBoundsConstraintSet::isProvablyNegative(rhsValue, cstr);
 
     // The result of remsi has the same sign as the dividend (lhs). The sign
     // of lhs does not need to be a compile-time constant: it is sufficient if
     // the constraint set can prove it. For lhs == 0 both branches may fire,
     // which is consistent since the result is then 0.
-    if (isProvablyNonPositive(lhsValue, cstr)) {
+    if (ValueBoundsConstraintSet::isProvablyNonPositive(lhsValue, cstr)) {
       cstr.bound(value) <= 0;
       if (rhsPositive)
         cstr.bound(value) >= 1 - rhs;
       if (rhsNegative)
         cstr.bound(value) >= rhs + 1;
     }
-    if (isProvablyNonNegative(lhsValue, cstr)) {
+    if (ValueBoundsConstraintSet::isProvablyNonNegative(lhsValue, cstr)) {
       cstr.bound(value) >= 0;
       if (rhsPositive)
         cstr.bound(value) <= rhs - 1;
@@ -173,7 +150,7 @@ struct RemUIOpInterface
 
     // remui computes an unsigned remainder, so for a provably positive divisor
     // the result is always in [0, rhs - 1].
-    if (isProvablyPositive(rhsValue, cstr)) {
+    if (ValueBoundsConstraintSet::isProvablyPositive(rhsValue, cstr)) {
       cstr.bound(value) >= 0;
       cstr.bound(value) <= rhs - 1;
     }
@@ -294,8 +271,8 @@ struct MinUIOpInterface
     // 0xff is treated as -1, not 255). For an unsigned minimum it is enough
     // that a single operand is provably non-negative: minui(x, y) is in
     // [0, y] whenever y >= 0 (and symmetrically for x).
-    bool lhsNonNegative = isProvablyNonNegative(minOp.getLhs(), cstr);
-    bool rhsNonNegative = isProvablyNonNegative(minOp.getRhs(), cstr);
+    bool lhsNonNegative = ValueBoundsConstraintSet::isProvablyNonNegative(minOp.getLhs(), cstr);
+    bool rhsNonNegative = ValueBoundsConstraintSet::isProvablyNonNegative(minOp.getRhs(), cstr);
     if (!lhsNonNegative && !rhsNonNegative)
       return;
 
@@ -320,8 +297,8 @@ struct MaxUIOpInterface
     assert(value == maxOp.getResult() && "invalid value");
 
     // See MinUIOpInterface comment
-    if (!isProvablyNonNegative(maxOp.getLhs(), cstr) ||
-        !isProvablyNonNegative(maxOp.getRhs(), cstr))
+    if (!ValueBoundsConstraintSet::isProvablyNonNegative(maxOp.getLhs(), cstr) ||
+        !ValueBoundsConstraintSet::isProvablyNonNegative(maxOp.getRhs(), cstr))
       return;
 
     AffineExpr lhs = cstr.getExpr(maxOp.getLhs());

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -117,10 +117,17 @@ struct RemSIOpInterface
     bool rhsPositive = ValueBoundsConstraintSet::isProvablyPositive(rhsValue, cstr);
     bool rhsNegative = ValueBoundsConstraintSet::isProvablyNegative(rhsValue, cstr);
 
-    // The result of remsi has the same sign as the dividend (lhs). The sign
-    // of lhs does not need to be a compile-time constant: it is sufficient if
+    // The result of remsi has the same sign as the dividend (lhs) and also fulfills |result| < |rhs|.
+    // The sign of lhs does not need to be a compile-time constant: it is sufficient if
     // the constraint set can prove it. For lhs == 0 both branches may fire,
-    // which is consistent since the result is then 0.
+    // which is consistent since the result is then 0. f.e:
+    //   lhs   rhs   result   bounds
+    //   ----  ----  ------   --------------------------------------------------
+    //    7     3      1      0 <= val && val <= rhs-1 = 2      -> [0, 2]
+    //    7    -3      1      0 <= val && val <= -rhs-1 = 2     -> [0, 2]
+    //   -7     3     -1      val <= 0 && val >= 1-rhs = -2     -> [-2, 0]
+    //   -7    -3     -1      val <= 0 && val >= rhs+1 = -2     -> [-2, 0]
+    //    0     3      0      both lhs branches fire (0<=val and val<=0) -> val == 0
     if (ValueBoundsConstraintSet::isProvablyNonPositive(lhsValue, cstr)) {
       cstr.bound(value) <= 0;
       if (rhsPositive)

--- a/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
+++ b/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
@@ -29,25 +29,29 @@ namespace mlir {
 #include "mlir/Interfaces/ValueBoundsOpInterface.cpp.inc"
 } // namespace mlir
 
-bool ValueBoundsConstraintSet::isProvablyNonNegative(Value value, ValueBoundsConstraintSet &cstr) {
+bool ValueBoundsConstraintSet::isProvablyNonNegative(
+    Value value, ValueBoundsConstraintSet &cstr) {
   return cstr.populateAndCompare(
       /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::GE,
       /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
 }
 
-bool ValueBoundsConstraintSet::isProvablyNonPositive(Value value, ValueBoundsConstraintSet &cstr) {
+bool ValueBoundsConstraintSet::isProvablyNonPositive(
+    Value value, ValueBoundsConstraintSet &cstr) {
   return cstr.populateAndCompare(
       /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::LE,
       /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
 }
 
-bool ValueBoundsConstraintSet::isProvablyPositive(Value value, ValueBoundsConstraintSet &cstr) {
+bool ValueBoundsConstraintSet::isProvablyPositive(
+    Value value, ValueBoundsConstraintSet &cstr) {
   return cstr.populateAndCompare(
       /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::GT,
       /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
 }
 
-bool ValueBoundsConstraintSet::isProvablyNegative(Value value, ValueBoundsConstraintSet &cstr) {
+bool ValueBoundsConstraintSet::isProvablyNegative(
+    Value value, ValueBoundsConstraintSet &cstr) {
   return cstr.populateAndCompare(
       /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::LT,
       /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});

--- a/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
+++ b/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
@@ -29,6 +29,30 @@ namespace mlir {
 #include "mlir/Interfaces/ValueBoundsOpInterface.cpp.inc"
 } // namespace mlir
 
+bool ValueBoundsConstraintSet::isProvablyNonNegative(Value value, ValueBoundsConstraintSet &cstr) {
+  return cstr.populateAndCompare(
+      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::GE,
+      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
+}
+
+bool ValueBoundsConstraintSet::isProvablyNonPositive(Value value, ValueBoundsConstraintSet &cstr) {
+  return cstr.populateAndCompare(
+      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::LE,
+      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
+}
+
+bool ValueBoundsConstraintSet::isProvablyPositive(Value value, ValueBoundsConstraintSet &cstr) {
+  return cstr.populateAndCompare(
+      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::GT,
+      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
+}
+
+bool ValueBoundsConstraintSet::isProvablyNegative(Value value, ValueBoundsConstraintSet &cstr) {
+  return cstr.populateAndCompare(
+      /*lhs=*/{value}, ValueBoundsConstraintSet::ComparisonOperator::LT,
+      /*rhs=*/{OpFoldResult(Builder(value.getContext()).getIndexAttr(0))});
+}
+
 static Operation *getOwnerOfValue(Value value) {
   if (auto bbArg = dyn_cast<BlockArgument>(value))
     return bbArg.getOwner()->getParentOp();

--- a/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
+++ b/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
@@ -211,7 +211,6 @@ func.func @arith_remsi_positive_lhs_symbolic_positive_rhs(%a: index) -> index {
 
 // -----
 
-// not sure this is correct
 // CHECK-LABEL: func @arith_remsi_negative_lhs_symbolic_positive_rhs(
 //  CHECK-SAME:     %[[a:.*]]: index
 //       CHECK:   %[[ub:.*]] = arith.constant 1 : index

--- a/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
+++ b/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
@@ -458,10 +458,6 @@ func.func @arith_maxui_addi() -> index {
 
 // -----
 
-// `minui` with a symbolic operand whose non-negativity is established through
-// the constraint set (`%nn = maxsi(%a, 0)` proves `%nn >= 0`). The guard then
-// passes and the (exclusive) upper bound reifies to `5`, exactly like `minsi`.
-
 // CHECK-LABEL: func @arith_minui_nonneg_symbolic(
 //  CHECK-SAME:     %[[a:.*]]: index
 //       CHECK:   %[[ub:.*]] = arith.constant 5 : index
@@ -476,11 +472,6 @@ func.func @arith_minui_nonneg_symbolic(%a: index) -> index {
 }
 
 // -----
-
-// `minui` with a symbolic operand that is provably *negative*
-// (`%neg = minsi(%a, -1)` proves `%neg <= -1`). That operand contributes no
-// bound, but the other operand `4` is non-negative and still bounds the
-// unsigned min, so the (exclusive) upper bound reifies to `5`.
 
 // CHECK-LABEL: func @arith_minui_negative_symbolic(
 //  CHECK-SAME:     %[[a:.*]]: index
@@ -497,10 +488,6 @@ func.func @arith_minui_negative_symbolic(%a: index) -> index {
 
 // -----
 
-// `maxui` with a symbolic operand whose non-negativity is established through
-// the constraint set. The guard passes and the lower bound reifies to `4`,
-// exactly like `maxsi`.
-
 // CHECK-LABEL: func @arith_maxui_nonneg_symbolic(
 //  CHECK-SAME:     %[[a:.*]]: index
 //       CHECK:   %[[lb:.*]] = arith.constant 4 : index
@@ -515,9 +502,6 @@ func.func @arith_maxui_nonneg_symbolic(%a: index) -> index {
 }
 
 // -----
-
-// `maxui` with a symbolic operand that is provably *negative*. As above, the
-// guard suppresses all bounds and reification fails.
 
 func.func @arith_maxui_negative_symbolic(%a: index) -> index {
   %cm1 = arith.constant -1 : index

--- a/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
+++ b/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
@@ -112,6 +112,158 @@ func.func @arith_floordivsi_non_pure(%a: index, %b: index) -> index {
 
 // -----
 
+// CHECK: #[[$map:.*]] = affine_map<()[s0] -> ((s0 + 4) floordiv 5)>
+// CHECK-LABEL: func @arith_ceildivsi(
+//  CHECK-SAME:     %[[a:.*]]: index
+//       CHECK:   %[[apply:.*]] = affine.apply #[[$map]]()[%[[a]]]
+//       CHECK:   return %[[apply]]
+func.func @arith_ceildivsi(%a: index) -> index {
+  %0 = arith.constant 5 : index
+  %1 = arith.ceildivsi %a, %0 : index
+  %2 = "test.reify_bound"(%1) : (index) -> (index)
+  return %2 : index
+}
+
+// -----
+
+func.func @arith_ceildivsi_non_pure(%a: index, %b: index) -> index {
+  %0 = arith.ceildivsi %a, %b : index
+  // Semi-affine expressions (such as "symbol * symbol") are not supported.
+  // expected-error @below{{could not reify bound}}
+  %1 = "test.reify_bound"(%0) : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_remsi_positive_positive()
+//       CHECK:   %[[c0:.*]] = arith.constant 0 : index
+//       CHECK:   %[[c5:.*]] = arith.constant 5 : index
+//       CHECK:   return %[[c0]], %[[c5]]
+func.func @arith_remsi_positive_positive() -> (index, index) {
+  %c7 = arith.constant 7 : index
+  %c5 = arith.constant 5 : index
+  %0 = arith.remsi %c7, %c5 : index
+  %1 = "test.reify_bound"(%0) {type = "LB"} : (index) -> (index)
+  %2 = "test.reify_bound"(%0) {type = "UB"} : (index) -> (index)
+  return %1, %2 : index, index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_remsi_negative_positive()
+//       CHECK:   %[[cm4:.*]] = arith.constant -4 : index
+//       CHECK:   %[[c1:.*]] = arith.constant 1 : index
+//       CHECK:   return %[[cm4]], %[[c1]]
+func.func @arith_remsi_negative_positive() -> (index, index) {
+  %cm7 = arith.constant -7 : index
+  %c5 = arith.constant 5 : index
+  %0 = arith.remsi %cm7, %c5 : index
+  %1 = "test.reify_bound"(%0) {type = "LB"} : (index) -> (index)
+  %2 = "test.reify_bound"(%0) {type = "UB"} : (index) -> (index)
+  return %1, %2 : index, index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_remsi_positive_negative()
+//       CHECK:   %[[c0:.*]] = arith.constant 0 : index
+//       CHECK:   %[[c5:.*]] = arith.constant 5 : index
+//       CHECK:   return %[[c0]], %[[c5]]
+func.func @arith_remsi_positive_negative() -> (index, index) {
+  %c7 = arith.constant 7 : index
+  %cm5 = arith.constant -5 : index
+  %0 = arith.remsi %c7, %cm5 : index
+  %1 = "test.reify_bound"(%0) {type = "LB"} : (index) -> (index)
+  %2 = "test.reify_bound"(%0) {type = "UB"} : (index) -> (index)
+  return %1, %2 : index, index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_remsi_negative_negative()
+//       CHECK:   %[[cm4:.*]] = arith.constant -4 : index
+//       CHECK:   %[[c1:.*]] = arith.constant 1 : index
+//       CHECK:   return %[[cm4]], %[[c1]]
+func.func @arith_remsi_negative_negative() -> (index, index) {
+  %cm7 = arith.constant -7 : index
+  %cm5 = arith.constant -5 : index
+  %0 = arith.remsi %cm7, %cm5 : index
+  %1 = "test.reify_bound"(%0) {type = "LB"} : (index) -> (index)
+  %2 = "test.reify_bound"(%0) {type = "UB"} : (index) -> (index)
+  return %1, %2 : index, index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_remsi_positive_lhs_symbolic_positive_rhs(
+//  CHECK-SAME:     %[[a:.*]]: index
+//       CHECK:   %[[lb:.*]] = arith.constant 0 : index
+//       CHECK:   return %[[lb]]
+func.func @arith_remsi_positive_lhs_symbolic_positive_rhs(%a: index) -> index {
+  %c1 = arith.constant 1 : index
+  %c7 = arith.constant 7 : index
+  %rhs = arith.maxsi %a, %c1 : index
+  %0 = arith.remsi %c7, %rhs : index
+  %1 = "test.reify_bound"(%0) {type = "LB", constant} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// not sure this is correct
+// CHECK-LABEL: func @arith_remsi_negative_lhs_symbolic_positive_rhs(
+//  CHECK-SAME:     %[[a:.*]]: index
+//       CHECK:   %[[ub:.*]] = arith.constant 1 : index
+//       CHECK:   return %[[ub]]
+func.func @arith_remsi_negative_lhs_symbolic_positive_rhs(%a: index) -> index {
+  %c1 = arith.constant 1 : index
+  %cm7 = arith.constant -7 : index
+  %rhs = arith.maxsi %a, %c1 : index
+  %0 = arith.remsi %cm7, %rhs : index
+  %1 = "test.reify_bound"(%0) {type = "UB", constant} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_remui_constant()
+//       CHECK:   %[[c0:.*]] = arith.constant 0 : index
+//       CHECK:   %[[c5:.*]] = arith.constant 5 : index
+//       CHECK:   return %[[c0]], %[[c5]]
+func.func @arith_remui_constant() -> (index, index) {
+  %c7 = arith.constant 7 : index
+  %c5 = arith.constant 5 : index
+  %0 = arith.remui %c7, %c5 : index
+  %1 = "test.reify_bound"(%0) {type = "LB"} : (index) -> (index)
+  %2 = "test.reify_bound"(%0) {type = "UB"} : (index) -> (index)
+  return %1, %2 : index, index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_remui_symbolic_dividend(
+//  CHECK-SAME:     %[[a:.*]]: index
+//       CHECK:   %[[ub:.*]] = arith.constant 5 : index
+//       CHECK:   return %[[ub]]
+func.func @arith_remui_symbolic_dividend(%a: index) -> index {
+  %c5 = arith.constant 5 : index
+  %0 = arith.remui %a, %c5 : index
+  %1 = "test.reify_bound"(%0) {type = "UB", constant} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+func.func @arith_remui_unknown_divisor(%a: index, %b: index) -> index {
+  %0 = arith.remui %a, %b : index
+  // expected-error @below{{could not reify bound}}
+  %1 = "test.reify_bound"(%0) {type = "UB", constant} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
 // CHECK-LABEL: func @arith_const()
 //       CHECK:   %[[c5:.*]] = arith.constant 5 : index
 //       CHECK:   %[[c5:.*]] = arith.constant 5 : index
@@ -215,5 +367,165 @@ func.func @arith_maxsi_ub(%a: index) -> index {
   // Signed max has no upper bound.
   // expected-error @below{{could not reify bound}}
   %1 = "test.reify_bound"(%0) {type = "UB"} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_minui(
+//       CHECK:   %[[ub:.*]] = arith.constant 5 : index
+//       CHECK:   return %[[ub]]
+func.func @arith_minui() -> index {
+  %c4 = arith.constant 4 : index
+  %c10 = arith.constant 10 : index
+  %0 = arith.minui %c10, %c4 : index
+  %1 = "test.reify_bound"(%0) {type = "UB"} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_minui_unknown_sign(
+//  CHECK-SAME:     %[[a:.*]]: index
+//       CHECK:   %[[ub:.*]] = arith.constant 5 : index
+//       CHECK:   return %[[ub]]
+func.func @arith_minui_unknown_sign(%a: index) -> index {
+  %c4 = arith.constant 4 : index
+  %0 = arith.minui %a, %c4 : index
+  %1 = "test.reify_bound"(%0) {type = "UB"} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_maxui(
+//       CHECK:   %[[lb:.*]] = arith.constant 10 : index
+//       CHECK:   return %[[lb]]
+func.func @arith_maxui() -> index {
+  %c4 = arith.constant 4 : index
+  %c10 = arith.constant 10 : index
+  %0 = arith.maxui %c10, %c4 : index
+  %1 = "test.reify_bound"(%0) {type = "LB"} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+func.func @arith_maxui_unknown_sign(%a: index) -> index {
+  %c4 = arith.constant 4 : index
+  %0 = arith.maxui %a, %c4 : index
+  // expected-error @below{{could not reify bound}}
+  %1 = "test.reify_bound"(%0) {type = "LB"} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_minui_wraparound(
+//       CHECK:   %[[ub:.*]] = arith.constant 11 : index
+//       CHECK:   return %[[ub]]
+func.func @arith_minui_wraparound() -> index {
+  %c255 = arith.constant 0xFF : i8
+  %c10 = arith.constant 10 : i8
+  %0 = arith.minui %c255, %c10 : i8
+  %1 = "test.reify_bound"(%0) {type = "UB", allow_integer_type} : (i8) -> (index)
+  return %1 : index
+}
+
+// -----
+
+func.func @arith_maxui_wraparound() -> index {
+  %c255 = arith.constant 0xFF : i8
+  %c10 = arith.constant 10 : i8
+  %0 = arith.maxui %c255, %c10 : i8
+  // expected-error @below{{could not reify bound}}
+  %1 = "test.reify_bound"(%0) {type = "LB", allow_integer_type} : (i8) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_maxui_addi(
+//       CHECK:   %[[lb:.*]] = arith.constant 14 : index
+//       CHECK:   return %[[lb]]
+func.func @arith_maxui_addi() -> index {
+  %c4 = arith.constant 4 : index
+  %c10 = arith.constant 10 : index
+  %sum = arith.addi %c4, %c10 : index
+  %0 = arith.maxui %sum, %c4 : index
+  %1 = "test.reify_bound"(%0) {type = "LB", constant} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// `minui` with a symbolic operand whose non-negativity is established through
+// the constraint set (`%nn = maxsi(%a, 0)` proves `%nn >= 0`). The guard then
+// passes and the (exclusive) upper bound reifies to `5`, exactly like `minsi`.
+
+// CHECK-LABEL: func @arith_minui_nonneg_symbolic(
+//  CHECK-SAME:     %[[a:.*]]: index
+//       CHECK:   %[[ub:.*]] = arith.constant 5 : index
+//       CHECK:   return %[[ub]]
+func.func @arith_minui_nonneg_symbolic(%a: index) -> index {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  %nn = arith.maxsi %a, %c0 : index
+  %0 = arith.minui %nn, %c4 : index
+  %1 = "test.reify_bound"(%0) {type = "UB", constant} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// `minui` with a symbolic operand that is provably *negative*
+// (`%neg = minsi(%a, -1)` proves `%neg <= -1`). That operand contributes no
+// bound, but the other operand `4` is non-negative and still bounds the
+// unsigned min, so the (exclusive) upper bound reifies to `5`.
+
+// CHECK-LABEL: func @arith_minui_negative_symbolic(
+//  CHECK-SAME:     %[[a:.*]]: index
+//       CHECK:   %[[ub:.*]] = arith.constant 5 : index
+//       CHECK:   return %[[ub]]
+func.func @arith_minui_negative_symbolic(%a: index) -> index {
+  %cm1 = arith.constant -1 : index
+  %c4 = arith.constant 4 : index
+  %neg = arith.minsi %a, %cm1 : index
+  %0 = arith.minui %neg, %c4 : index
+  %1 = "test.reify_bound"(%0) {type = "UB", constant} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// `maxui` with a symbolic operand whose non-negativity is established through
+// the constraint set. The guard passes and the lower bound reifies to `4`,
+// exactly like `maxsi`.
+
+// CHECK-LABEL: func @arith_maxui_nonneg_symbolic(
+//  CHECK-SAME:     %[[a:.*]]: index
+//       CHECK:   %[[lb:.*]] = arith.constant 4 : index
+//       CHECK:   return %[[lb]]
+func.func @arith_maxui_nonneg_symbolic(%a: index) -> index {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  %nn = arith.maxsi %a, %c0 : index
+  %0 = arith.maxui %nn, %c4 : index
+  %1 = "test.reify_bound"(%0) {type = "LB", constant} : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// `maxui` with a symbolic operand that is provably *negative*. As above, the
+// guard suppresses all bounds and reification fails.
+
+func.func @arith_maxui_negative_symbolic(%a: index) -> index {
+  %cm1 = arith.constant -1 : index
+  %c4 = arith.constant 4 : index
+  %neg = arith.minsi %a, %cm1 : index
+  %0 = arith.maxui %neg, %c4 : index
+  // expected-error @below{{could not reify bound}}
+  %1 = "test.reify_bound"(%0) {type = "LB", constant} : (index) -> (index)
   return %1 : index
 }

--- a/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
+++ b/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
@@ -384,19 +384,6 @@ func.func @arith_minui() -> index {
 
 // -----
 
-// CHECK-LABEL: func @arith_minui_unknown_sign(
-//  CHECK-SAME:     %[[a:.*]]: index
-//       CHECK:   %[[ub:.*]] = arith.constant 5 : index
-//       CHECK:   return %[[ub]]
-func.func @arith_minui_unknown_sign(%a: index) -> index {
-  %c4 = arith.constant 4 : index
-  %0 = arith.minui %a, %c4 : index
-  %1 = "test.reify_bound"(%0) {type = "UB"} : (index) -> (index)
-  return %1 : index
-}
-
-// -----
-
 // CHECK-LABEL: func @arith_maxui(
 //       CHECK:   %[[lb:.*]] = arith.constant 10 : index
 //       CHECK:   return %[[lb]]
@@ -420,13 +407,11 @@ func.func @arith_maxui_unknown_sign(%a: index) -> index {
 
 // -----
 
-// CHECK-LABEL: func @arith_minui_wraparound(
-//       CHECK:   %[[ub:.*]] = arith.constant 11 : index
-//       CHECK:   return %[[ub]]
 func.func @arith_minui_wraparound() -> index {
   %c255 = arith.constant 0xFF : i8
   %c10 = arith.constant 10 : i8
   %0 = arith.minui %c255, %c10 : i8
+  // expected-error @below{{could not reify bound}}
   %1 = "test.reify_bound"(%0) {type = "UB", allow_integer_type} : (i8) -> (index)
   return %1 : index
 }
@@ -473,15 +458,12 @@ func.func @arith_minui_nonneg_symbolic(%a: index) -> index {
 
 // -----
 
-// CHECK-LABEL: func @arith_minui_negative_symbolic(
-//  CHECK-SAME:     %[[a:.*]]: index
-//       CHECK:   %[[ub:.*]] = arith.constant 5 : index
-//       CHECK:   return %[[ub]]
 func.func @arith_minui_negative_symbolic(%a: index) -> index {
   %cm1 = arith.constant -1 : index
   %c4 = arith.constant 4 : index
   %neg = arith.minsi %a, %cm1 : index
   %0 = arith.minui %neg, %c4 : index
+  // expected-error @below{{could not reify bound}}
   %1 = "test.reify_bound"(%0) {type = "UB", constant} : (index) -> (index)
   return %1 : index
 }


### PR DESCRIPTION
Add ValueBoundsOpInterface external models for the arith integer
CeilDiv, RemSI, RemUI, MaxUI, MinUI.

Since the ValueBoundsConstraintSet infrastructure interprets unsigned integers as signed, unsigned ops needed special handling.
In the unsigned ops we first verify that the integers can be proven as positive, and if yes we add the appropriate constraints to the set.

The only exception for that is the RemUI, since the bound is only dependent on the divider we don't care what's the sign of the lhs.