### PR TITLE
[IRBuilder] (Target|InstSimplify)-fold intrinsics

### DIFF
--- a/llvm/include/llvm/Analysis/ConstantFolding.h
+++ b/llvm/include/llvm/Analysis/ConstantFolding.h
@@ -175,6 +175,9 @@ LLVM_ABI Constant *ConstantFoldUnaryIntrinsic(Intrinsic::ID ID, Constant *Op,
 LLVM_ABI Constant *ConstantFoldBinaryIntrinsic(Intrinsic::ID ID, Constant *LHS,
                                                Constant *RHS, Type *Ty);
 
+LLVM_ABI Constant *ConstantFoldIntrinsic(Intrinsic::ID ID,
+                                         ArrayRef<Constant *> Ops, Type *Ty);
+
 /// ConstantFoldLoadThroughBitcast - try to cast constant to destination type
 /// returning null if unsuccessful. Can cast pointer to pointer or pointer to
 /// integer and vice versa if their sizes are equal.

--- a/llvm/include/llvm/Analysis/ConstantFolding.h
+++ b/llvm/include/llvm/Analysis/ConstantFolding.h
@@ -169,12 +169,6 @@ LLVM_ABI Constant *ConstantFoldCall(const CallBase *Call, Function *F,
                                     const TargetLibraryInfo *TLI = nullptr,
                                     bool AllowNonDeterministic = true);
 
-LLVM_ABI Constant *ConstantFoldUnaryIntrinsic(Intrinsic::ID ID, Constant *Op,
-                                              Type *Ty);
-
-LLVM_ABI Constant *ConstantFoldBinaryIntrinsic(Intrinsic::ID ID, Constant *LHS,
-                                               Constant *RHS, Type *Ty);
-
 LLVM_ABI Constant *ConstantFoldIntrinsic(Intrinsic::ID ID,
                                          ArrayRef<Constant *> Ops, Type *Ty);
 

--- a/llvm/include/llvm/Analysis/InstSimplifyFolder.h
+++ b/llvm/include/llvm/Analysis/InstSimplifyFolder.h
@@ -120,21 +120,10 @@ public:
     return simplifyCastInst(Op, V, DestTy, SQ);
   }
 
-  Value *
-  FoldUnaryIntrinsic(Intrinsic::ID ID, Value *Op, Type *Ty,
-                     FastMathFlags FMF = FastMathFlags()) const override {
-    return simplifyUnaryIntrinsic(ID, Op, FMF, SQ);
-  }
-
-  Value *
-  FoldBinaryIntrinsic(Intrinsic::ID ID, Value *LHS, Value *RHS, Type *Ty,
-                      FastMathFlags FMF = FastMathFlags()) const override {
-    return simplifyBinaryIntrinsic(ID, Ty, LHS, RHS, FMF, SQ);
-  }
-
   Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
-                       FastMathFlags FMF) const override {
-    return simplifyIntrinsic(ID, Ty, Ops, FMF, SQ);
+                       FastMathFlags FMF = {},
+                       Function *CtxF = nullptr) const override {
+    return simplifyIntrinsic(ID, Ty, Ops, FMF, SQ, CtxF);
   }
 
   //===--------------------------------------------------------------------===//

--- a/llvm/include/llvm/Analysis/InstSimplifyFolder.h
+++ b/llvm/include/llvm/Analysis/InstSimplifyFolder.h
@@ -132,6 +132,11 @@ public:
     return simplifyBinaryIntrinsic(ID, Ty, LHS, RHS, FMF, SQ);
   }
 
+  Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
+                       FastMathFlags FMF) const override {
+    return simplifyIntrinsic(ID, Ty, Ops, FMF, SQ);
+  }
+
   //===--------------------------------------------------------------------===//
   // Cast/Conversion Operators
   //===--------------------------------------------------------------------===//

--- a/llvm/include/llvm/Analysis/InstructionSimplify.h
+++ b/llvm/include/llvm/Analysis/InstructionSimplify.h
@@ -194,17 +194,6 @@ LLVM_ABI Value *simplifyExtractElementInst(Value *Vec, Value *Idx,
 LLVM_ABI Value *simplifyCastInst(unsigned CastOpc, Value *Op, Type *Ty,
                                  const SimplifyQuery &Q);
 
-/// Given operands for a unary intrinsic, fold the result or return null.
-LLVM_ABI Value *simplifyUnaryIntrinsic(Intrinsic::ID IID, Value *Op0,
-                                       FastMathFlags FMF,
-                                       const SimplifyQuery &Q);
-
-/// Given operands for a binary intrinsic, fold the result or return null.
-LLVM_ABI Value *simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
-                                        Value *Op0, Value *Op1,
-                                        FastMathFlags FMF,
-                                        const SimplifyQuery &Q);
-
 /// Given operands for an intrinsic, fold the result or return null. Context
 /// Function is passed as \p CxtF. \p ExBehavior and \p Rounding only apply to
 /// constrained FP intrinsics.

--- a/llvm/include/llvm/Analysis/TargetFolder.h
+++ b/llvm/include/llvm/Analysis/TargetFolder.h
@@ -19,7 +19,6 @@
 #define LLVM_ANALYSIS_TARGETFOLDER_H
 
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/IR/ConstantFold.h"
 #include "llvm/IR/Constants.h"
@@ -195,11 +194,9 @@ public:
   Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
                        FastMathFlags FMF = {},
                        Function *CtxF = nullptr) const override {
-    if (all_of(Ops, IsaPred<Constant>)) {
-      auto COps =
-          map_to_vector(Ops, [](Value *Op) { return cast<Constant>(Op); });
-      return ConstantFoldIntrinsic(ID, COps, Ty);
-    }
+    if (all_of(Ops, IsaPred<Constant>))
+      return ConstantFoldIntrinsic(
+          ID, ArrayRef((Constant *const *)Ops.data(), Ops.size()), Ty);
     return nullptr;
   }
 

--- a/llvm/include/llvm/Analysis/TargetFolder.h
+++ b/llvm/include/llvm/Analysis/TargetFolder.h
@@ -19,6 +19,7 @@
 #define LLVM_ANALYSIS_TARGETFOLDER_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/IR/ConstantFold.h"
 #include "llvm/IR/Constants.h"
@@ -204,6 +205,15 @@ public:
     auto *C2 = dyn_cast<Constant>(RHS);
     if (C1 && C2)
       return ConstantFoldBinaryIntrinsic(ID, C1, C2, Ty);
+    return nullptr;
+  }
+
+  Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
+                       FastMathFlags FMF) const override {
+    auto COps =
+        map_to_vector(Ops, [](Value *Op) { return dyn_cast<Constant>(Op); });
+    if (none_of(COps, equal_to(nullptr)))
+      return ConstantFoldIntrinsic(ID, COps, Ty);
     return nullptr;
   }
 

--- a/llvm/include/llvm/Analysis/TargetFolder.h
+++ b/llvm/include/llvm/Analysis/TargetFolder.h
@@ -192,28 +192,14 @@ public:
     return nullptr;
   }
 
-  Value *FoldUnaryIntrinsic(Intrinsic::ID ID, Value *Op, Type *Ty,
-                            FastMathFlags FMF) const override {
-    if (auto *OpC = dyn_cast<Constant>(Op))
-      return ConstantFoldUnaryIntrinsic(ID, OpC, Ty);
-    return nullptr;
-  }
-
-  Value *FoldBinaryIntrinsic(Intrinsic::ID ID, Value *LHS, Value *RHS, Type *Ty,
-                             FastMathFlags FMF) const override {
-    auto *C1 = dyn_cast<Constant>(LHS);
-    auto *C2 = dyn_cast<Constant>(RHS);
-    if (C1 && C2)
-      return ConstantFoldBinaryIntrinsic(ID, C1, C2, Ty);
-    return nullptr;
-  }
-
   Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
-                       FastMathFlags FMF) const override {
-    auto COps =
-        map_to_vector(Ops, [](Value *Op) { return dyn_cast<Constant>(Op); });
-    if (none_of(COps, equal_to(nullptr)))
+                       FastMathFlags FMF = {},
+                       Function *CtxF = nullptr) const override {
+    if (all_of(Ops, IsaPred<Constant>)) {
+      auto COps =
+          map_to_vector(Ops, [](Value *Op) { return cast<Constant>(Op); });
       return ConstantFoldIntrinsic(ID, COps, Ty);
+    }
     return nullptr;
   }
 

--- a/llvm/include/llvm/IR/ConstantFolder.h
+++ b/llvm/include/llvm/IR/ConstantFolder.h
@@ -182,20 +182,8 @@ public:
     return nullptr;
   }
 
-  Value *FoldUnaryIntrinsic(Intrinsic::ID ID, Value *Op, Type *Ty,
-                            FastMathFlags FMF) const override {
-    // Use TargetFolder or InstSimplifyFolder instead.
-    return nullptr;
-  }
-
-  Value *FoldBinaryIntrinsic(Intrinsic::ID ID, Value *LHS, Value *RHS, Type *Ty,
-                             FastMathFlags FMF) const override {
-    // Use TargetFolder or InstSimplifyFolder instead.
-    return nullptr;
-  }
-
   Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
-                       FastMathFlags FMF) const override {
+                       FastMathFlags FMF, Function *CtxF) const override {
     // Use TargetFolder or InstSimplifyFolder instead.
     return nullptr;
   }

--- a/llvm/include/llvm/IR/ConstantFolder.h
+++ b/llvm/include/llvm/IR/ConstantFolder.h
@@ -194,6 +194,12 @@ public:
     return nullptr;
   }
 
+  Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
+                       FastMathFlags FMF) const override {
+    // Use TargetFolder or InstSimplifyFolder instead.
+    return nullptr;
+  }
+
   //===--------------------------------------------------------------------===//
   // Cast/Conversion Operators
   //===--------------------------------------------------------------------===//

--- a/llvm/include/llvm/IR/IRBuilderFolder.h
+++ b/llvm/include/llvm/IR/IRBuilderFolder.h
@@ -76,13 +76,15 @@ public:
   virtual Value *FoldCast(Instruction::CastOps Op, Value *V,
                           Type *DestTy) const = 0;
 
-  virtual Value *
-  FoldUnaryIntrinsic(Intrinsic::ID ID, Value *Op, Type *Ty,
-                     FastMathFlags FMF = FastMathFlags()) const = 0;
+  virtual Value *FoldUnaryIntrinsic(Intrinsic::ID ID, Value *Op, Type *Ty,
+                                    FastMathFlags FMF = {}) const = 0;
 
-  virtual Value *
-  FoldBinaryIntrinsic(Intrinsic::ID ID, Value *LHS, Value *RHS, Type *Ty,
-                      FastMathFlags FMF = FastMathFlags()) const = 0;
+  virtual Value *FoldBinaryIntrinsic(Intrinsic::ID ID, Value *LHS, Value *RHS,
+                                     Type *Ty,
+                                     FastMathFlags FMF = {}) const = 0;
+
+  virtual Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops,
+                               Type *Ty, FastMathFlags FMF = {}) const = 0;
 
   //===--------------------------------------------------------------------===//
   // Cast/Conversion Operators

--- a/llvm/include/llvm/IR/IRBuilderFolder.h
+++ b/llvm/include/llvm/IR/IRBuilderFolder.h
@@ -76,15 +76,9 @@ public:
   virtual Value *FoldCast(Instruction::CastOps Op, Value *V,
                           Type *DestTy) const = 0;
 
-  virtual Value *FoldUnaryIntrinsic(Intrinsic::ID ID, Value *Op, Type *Ty,
-                                    FastMathFlags FMF = {}) const = 0;
-
-  virtual Value *FoldBinaryIntrinsic(Intrinsic::ID ID, Value *LHS, Value *RHS,
-                                     Type *Ty,
-                                     FastMathFlags FMF = {}) const = 0;
-
   virtual Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops,
-                               Type *Ty, FastMathFlags FMF = {}) const = 0;
+                               Type *Ty, FastMathFlags FMF = {},
+                               Function *CtxF = nullptr) const = 0;
 
   //===--------------------------------------------------------------------===//
   // Cast/Conversion Operators

--- a/llvm/include/llvm/IR/NoFolder.h
+++ b/llvm/include/llvm/IR/NoFolder.h
@@ -124,6 +124,11 @@ public:
     return nullptr;
   }
 
+  Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
+                       FastMathFlags FMF) const override {
+    return nullptr;
+  }
+
   //===--------------------------------------------------------------------===//
   // Cast/Conversion Operators
   //===--------------------------------------------------------------------===//

--- a/llvm/include/llvm/IR/NoFolder.h
+++ b/llvm/include/llvm/IR/NoFolder.h
@@ -114,18 +114,8 @@ public:
     return nullptr;
   }
 
-  Value *FoldUnaryIntrinsic(Intrinsic::ID ID, Value *Op, Type *Ty,
-                            FastMathFlags FMF) const override {
-    return nullptr;
-  }
-
-  Value *FoldBinaryIntrinsic(Intrinsic::ID ID, Value *LHS, Value *RHS, Type *Ty,
-                             FastMathFlags FMF) const override {
-    return nullptr;
-  }
-
   Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
-                       FastMathFlags FMF) const override {
+                       FastMathFlags FMF, Function *CtxF) const override {
     return nullptr;
   }
 

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -4707,16 +4707,6 @@ ConstantFoldStructCall(StringRef Name, Intrinsic::ID IntrinsicID,
 
 } // end anonymous namespace
 
-Constant *llvm::ConstantFoldUnaryIntrinsic(Intrinsic::ID ID, Constant *Op,
-                                           Type *Ty) {
-  return ConstantFoldScalarCall1("", ID, Ty, Op);
-}
-
-Constant *llvm::ConstantFoldBinaryIntrinsic(Intrinsic::ID ID, Constant *LHS,
-                                            Constant *RHS, Type *Ty) {
-  return ConstantFoldIntrinsicCall2(ID, Ty, {LHS, RHS});
-}
-
 Constant *llvm::ConstantFoldIntrinsic(Intrinsic::ID ID,
                                       ArrayRef<Constant *> Ops, Type *Ty) {
   return ConstantFoldScalarCall("", ID, Ty, Ops);

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -2489,13 +2489,13 @@ getEvaluationRoundingMode(const ConstrainedFPIntrinsic *CI) {
 }
 
 /// Try to constant fold llvm.canonicalize for the given caller and value.
-static Constant *constantFoldCanonicalize(const Type *Ty, const CallBase *CI,
-                                          const APFloat &Src) {
+static Constant *constantFoldCanonicalize(const Type *Ty, const APFloat &Src,
+                                          const Function *CtxF = nullptr) {
   // Zero, positive and negative, is always OK to fold.
   if (Src.isZero()) {
     // Get a fresh 0, since ppc_fp128 does have non-canonical zeros.
     return ConstantFP::get(
-        CI->getContext(),
+        Ty->getContext(),
         APFloat::getZero(Src.getSemantics(), Src.isNegative()));
   }
 
@@ -2507,14 +2507,13 @@ static Constant *constantFoldCanonicalize(const Type *Ty, const CallBase *CI,
   // Denorms and nans may have special encodings, but it should be OK to fold a
   // totally average number.
   if (Src.isNormal() || Src.isInfinity())
-    return ConstantFP::get(CI->getContext(), Src);
+    return ConstantFP::get(Ty->getContext(), Src);
 
-  if (Src.isDenormal() && CI->getParent() && CI->getFunction()) {
-    DenormalMode DenormMode =
-        CI->getFunction()->getDenormalMode(Src.getSemantics());
+  if (Src.isDenormal() && CtxF) {
+    DenormalMode DenormMode = CtxF->getDenormalMode(Src.getSemantics());
 
     if (DenormMode == DenormalMode::getIEEE())
-      return ConstantFP::get(CI->getContext(), Src);
+      return ConstantFP::get(Ty->getContext(), Src);
 
     if (DenormMode.Input == DenormalMode::Dynamic)
       return nullptr;
@@ -2531,7 +2530,7 @@ static Constant *constantFoldCanonicalize(const Type *Ty, const CallBase *CI,
          (DenormMode.Output == DenormalMode::PositiveZero &&
           DenormMode.Input == DenormalMode::IEEE));
 
-    return ConstantFP::get(CI->getContext(),
+    return ConstantFP::get(Ty->getContext(),
                            APFloat::getZero(Src.getSemantics(), !IsPositive));
   }
 
@@ -2539,11 +2538,10 @@ static Constant *constantFoldCanonicalize(const Type *Ty, const CallBase *CI,
 }
 
 static Constant *ConstantFoldScalarCall1(StringRef Name,
-                                         Intrinsic::ID IntrinsicID,
-                                         Type *Ty,
+                                         Intrinsic::ID IntrinsicID, Type *Ty,
                                          ArrayRef<Constant *> Operands,
-                                         const TargetLibraryInfo *TLI,
-                                         const CallBase *Call) {
+                                         const TargetLibraryInfo *TLI = nullptr,
+                                         const CallBase *Call = nullptr) {
   assert(Operands.size() == 1 && "Wrong number of operands.");
 
   if (IntrinsicID == Intrinsic::is_constant) {
@@ -2580,7 +2578,7 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
       // a function during inlining), Call's caller may not be available.
       // So check Call's BB first before querying Call->getCaller.
       const Function *Caller =
-          Call->getParent() ? Call->getCaller() : nullptr;
+          Call && Call->getParent() ? Call->getCaller() : nullptr;
       if (Caller &&
           !NullPointerIsDefined(
               Caller, Operands[0]->getType()->getPointerAddressSpace())) {
@@ -2622,8 +2620,11 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
       return ConstantInt::get(Ty, Int);
     }
 
-    if (IntrinsicID == Intrinsic::canonicalize)
-      return constantFoldCanonicalize(Ty, Call, U);
+    if (IntrinsicID == Intrinsic::canonicalize) {
+      const Function *CtxF =
+          Call && Call->getParent() ? Call->getFunction() : nullptr;
+      return constantFoldCanonicalize(Ty, U, CtxF);
+    }
 
 #if defined(HAS_IEE754_FLOAT128) && defined(HAS_LOGF128)
     if (Ty->isFP128Ty()) {
@@ -2697,48 +2698,49 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
     // Rounding operations (floor, trunc, ceil, round and nearbyint) do not
     // raise FP exceptions, unless the argument is signaling NaN.
 
-    std::optional<APFloat::roundingMode> RM;
-    switch (IntrinsicID) {
-    default:
-      break;
-    case Intrinsic::experimental_constrained_nearbyint:
-    case Intrinsic::experimental_constrained_rint: {
-      auto CI = cast<ConstrainedFPIntrinsic>(Call);
-      RM = CI->getRoundingMode();
-      if (!RM || *RM == RoundingMode::Dynamic)
-        return nullptr;
-      break;
-    }
-    case Intrinsic::experimental_constrained_round:
-      RM = APFloat::rmNearestTiesToAway;
-      break;
-    case Intrinsic::experimental_constrained_ceil:
-      RM = APFloat::rmTowardPositive;
-      break;
-    case Intrinsic::experimental_constrained_floor:
-      RM = APFloat::rmTowardNegative;
-      break;
-    case Intrinsic::experimental_constrained_trunc:
-      RM = APFloat::rmTowardZero;
-      break;
-    }
-    if (RM) {
-      auto CI = cast<ConstrainedFPIntrinsic>(Call);
-      if (U.isFinite()) {
-        APFloat::opStatus St = U.roundToIntegral(*RM);
-        if (IntrinsicID == Intrinsic::experimental_constrained_rint &&
-            St == APFloat::opInexact) {
-          std::optional<fp::ExceptionBehavior> EB = CI->getExceptionBehavior();
-          if (EB == fp::ebStrict)
-            return nullptr;
-        }
-      } else if (U.isSignaling()) {
-        std::optional<fp::ExceptionBehavior> EB = CI->getExceptionBehavior();
-        if (EB && *EB != fp::ebIgnore)
+    if (auto *CI = dyn_cast_or_null<ConstrainedFPIntrinsic>(Call)) {
+      std::optional<APFloat::roundingMode> RM;
+      switch (IntrinsicID) {
+      default:
+        break;
+      case Intrinsic::experimental_constrained_nearbyint:
+      case Intrinsic::experimental_constrained_rint: {
+        RM = CI->getRoundingMode();
+        if (!RM || *RM == RoundingMode::Dynamic)
           return nullptr;
-        U = APFloat::getQNaN(U.getSemantics());
+        break;
       }
-      return ConstantFP::get(Ty, U);
+      case Intrinsic::experimental_constrained_round:
+        RM = APFloat::rmNearestTiesToAway;
+        break;
+      case Intrinsic::experimental_constrained_ceil:
+        RM = APFloat::rmTowardPositive;
+        break;
+      case Intrinsic::experimental_constrained_floor:
+        RM = APFloat::rmTowardNegative;
+        break;
+      case Intrinsic::experimental_constrained_trunc:
+        RM = APFloat::rmTowardZero;
+        break;
+      }
+      if (RM) {
+        if (U.isFinite()) {
+          APFloat::opStatus St = U.roundToIntegral(*RM);
+          if (IntrinsicID == Intrinsic::experimental_constrained_rint &&
+              St == APFloat::opInexact) {
+            std::optional<fp::ExceptionBehavior> EB =
+                CI->getExceptionBehavior();
+            if (EB == fp::ebStrict)
+              return nullptr;
+          }
+        } else if (U.isSignaling()) {
+          std::optional<fp::ExceptionBehavior> EB = CI->getExceptionBehavior();
+          if (EB && *EB != fp::ebIgnore)
+            return nullptr;
+          U = APFloat::getQNaN(U.getSemantics());
+        }
+        return ConstantFP::get(Ty, U);
+      }
     }
 
     // NVVM float/double to signed/unsigned int32/int64 conversions:
@@ -3350,7 +3352,7 @@ static Constant *ConstantFoldNextToward(const APFloat &Op0, const APFloat &Op1,
 
 static Constant *ConstantFoldLibCall2(StringRef Name, Type *Ty,
                                       ArrayRef<Constant *> Operands,
-                                      const TargetLibraryInfo *TLI) {
+                                      const TargetLibraryInfo *TLI = nullptr) {
   if (!TLI)
     return nullptr;
 
@@ -3421,7 +3423,7 @@ static Constant *ConstantFoldLibCall2(StringRef Name, Type *Ty,
 
 static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
                                             ArrayRef<Constant *> Operands,
-                                            const CallBase *Call) {
+                                            const CallBase *Call = nullptr) {
   assert(Operands.size() == 2 && "Wrong number of operands.");
 
   if (Ty->isFloatingPointTy()) {
@@ -4098,11 +4100,10 @@ static Constant *ConstantFoldAMDGCNPermIntrinsic(ArrayRef<Constant *> Operands,
 }
 
 static Constant *ConstantFoldScalarCall3(StringRef Name,
-                                         Intrinsic::ID IntrinsicID,
-                                         Type *Ty,
+                                         Intrinsic::ID IntrinsicID, Type *Ty,
                                          ArrayRef<Constant *> Operands,
-                                         const TargetLibraryInfo *TLI,
-                                         const CallBase *Call) {
+                                         const TargetLibraryInfo *TLI = nullptr,
+                                         const CallBase *Call = nullptr) {
   assert(Operands.size() == 3 && "Wrong number of operands.");
 
   if (const auto *Op1 = dyn_cast<ConstantFP>(Operands[0])) {
@@ -4112,7 +4113,8 @@ static Constant *ConstantFoldScalarCall3(StringRef Name,
         const APFloat &C2 = Op2->getValueAPF();
         const APFloat &C3 = Op3->getValueAPF();
 
-        if (const auto *ConstrIntr = dyn_cast<ConstrainedFPIntrinsic>(Call)) {
+        if (const auto *ConstrIntr =
+                dyn_cast_or_null<ConstrainedFPIntrinsic>(Call)) {
           RoundingMode RM = getEvaluationRoundingMode(ConstrIntr);
           APFloat Res = C1;
           APFloat::opStatus St;
@@ -4262,11 +4264,10 @@ static Constant *ConstantFoldScalarCall3(StringRef Name,
 }
 
 static Constant *ConstantFoldScalarCall(StringRef Name,
-                                        Intrinsic::ID IntrinsicID,
-                                        Type *Ty,
+                                        Intrinsic::ID IntrinsicID, Type *Ty,
                                         ArrayRef<Constant *> Operands,
-                                        const TargetLibraryInfo *TLI,
-                                        const CallBase *Call) {
+                                        const TargetLibraryInfo *TLI = nullptr,
+                                        const CallBase *Call = nullptr) {
   if (IntrinsicID != Intrinsic::not_intrinsic &&
       any_of(Operands, IsaPred<PoisonValue>) &&
       intrinsicPropagatesPoison(IntrinsicID))
@@ -4708,12 +4709,17 @@ ConstantFoldStructCall(StringRef Name, Intrinsic::ID IntrinsicID,
 
 Constant *llvm::ConstantFoldUnaryIntrinsic(Intrinsic::ID ID, Constant *Op,
                                            Type *Ty) {
-  return ConstantFoldScalarCall1("", ID, Ty, Op, nullptr, nullptr);
+  return ConstantFoldScalarCall1("", ID, Ty, Op);
 }
 
 Constant *llvm::ConstantFoldBinaryIntrinsic(Intrinsic::ID ID, Constant *LHS,
                                             Constant *RHS, Type *Ty) {
-  return ConstantFoldIntrinsicCall2(ID, Ty, {LHS, RHS}, nullptr);
+  return ConstantFoldIntrinsicCall2(ID, Ty, {LHS, RHS});
+}
+
+Constant *llvm::ConstantFoldIntrinsic(Intrinsic::ID ID,
+                                      ArrayRef<Constant *> Ops, Type *Ty) {
+  return ConstantFoldScalarCall("", ID, Ty, Ops);
 }
 
 Constant *llvm::ConstantFoldCall(const CallBase *Call, Function *F,

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -6553,8 +6553,9 @@ static Value *simplifyLdexp(Value *Op0, Value *Op1, const SimplifyQuery &Q,
   return nullptr;
 }
 
-Value *llvm::simplifyUnaryIntrinsic(Intrinsic::ID IID, Value *Op0,
-                                    FastMathFlags FMF, const SimplifyQuery &Q) {
+static Value *simplifyUnaryIntrinsic(Intrinsic::ID IID, Value *Op0,
+                                     FastMathFlags FMF,
+                                     const SimplifyQuery &Q) {
   // Idempotent functions return the same result when called repeatedly.
   if (isIdempotent(IID))
     if (auto *II = dyn_cast<IntrinsicInst>(Op0))
@@ -6879,9 +6880,9 @@ static Value *simplifySVEIntReduction(Intrinsic::ID IID, Type *ReturnType,
   return nullptr;
 }
 
-Value *llvm::simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
-                                     Value *Op0, Value *Op1, FastMathFlags FMF,
-                                     const SimplifyQuery &Q) {
+static Value *simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
+                                      Value *Op0, Value *Op1, FastMathFlags FMF,
+                                      const SimplifyQuery &Q) {
   unsigned BitWidth = ReturnType->getScalarSizeInBits();
   switch (IID) {
   case Intrinsic::get_active_lane_mask: {

--- a/llvm/lib/IR/IRBuilder.cpp
+++ b/llvm/lib/IR/IRBuilder.cpp
@@ -923,8 +923,9 @@ Value *IRBuilderBase::CreateUnaryIntrinsic(Intrinsic::ID ID, Value *Op,
                                            const Twine &Name) {
   Module *M = BB->getModule();
   Function *Fn = Intrinsic::getOrInsertDeclaration(M, ID, Op->getType());
-  if (Value *V = Folder.FoldUnaryIntrinsic(ID, Op, Fn->getReturnType(),
-                                           FMFSource.get(FMF)))
+  if (Value *V =
+          Folder.FoldIntrinsic(ID, Op, Fn->getReturnType(), FMFSource.get(FMF),
+                               GetInsertBlock()->getParent()))
     return V;
   return createCallHelper(Fn, Op, Name, FMFSource);
 }
@@ -934,8 +935,9 @@ Value *IRBuilderBase::CreateBinaryIntrinsic(Intrinsic::ID ID, Value *LHS,
                                             const Twine &Name) {
   Module *M = BB->getModule();
   Function *Fn = Intrinsic::getOrInsertDeclaration(M, ID, {LHS->getType()});
-  if (Value *V = Folder.FoldBinaryIntrinsic(ID, LHS, RHS, Fn->getReturnType(),
-                                            FMFSource.get(FMF)))
+  if (Value *V = Folder.FoldIntrinsic(ID, {LHS, RHS}, Fn->getReturnType(),
+                                      FMFSource.get(FMF),
+                                      GetInsertBlock()->getParent()))
     return V;
   return createCallHelper(Fn, {LHS, RHS}, Name, FMFSource);
 }
@@ -967,7 +969,8 @@ Value *IRBuilderBase::CreateIntrinsic(Intrinsic::ID ID,
                                       ArrayRef<OperandBundleDef> OpBundles,
                                       function_ref<void(CallInst *)> SetFn) {
   Type *RetTy = Intrinsic::getType(Context, ID, OverloadTypes)->getReturnType();
-  if (Value *V = Folder.FoldIntrinsic(ID, Args, RetTy, FMFSource.get(FMF)))
+  if (Value *V = Folder.FoldIntrinsic(ID, Args, RetTy, FMFSource.get(FMF),
+                                      GetInsertBlock()->getParent()))
     return V;
   CallInst *CI = CreateIntrinsicWithoutFolding(ID, OverloadTypes, Args,
                                                FMFSource, Name, OpBundles);
@@ -979,7 +982,8 @@ Value *IRBuilderBase::CreateIntrinsic(Type *RetTy, Intrinsic::ID ID,
                                       ArrayRef<Value *> Args,
                                       FMFSource FMFSource, const Twine &Name,
                                       function_ref<void(CallInst *)> SetFn) {
-  if (Value *V = Folder.FoldIntrinsic(ID, Args, RetTy, FMFSource.get(FMF)))
+  if (Value *V = Folder.FoldIntrinsic(ID, Args, RetTy, FMFSource.get(FMF),
+                                      GetInsertBlock()->getParent()))
     return V;
   CallInst *CI =
       CreateIntrinsicWithoutFolding(RetTy, ID, Args, FMFSource, Name);

--- a/llvm/lib/IR/IRBuilder.cpp
+++ b/llvm/lib/IR/IRBuilder.cpp
@@ -966,7 +966,9 @@ Value *IRBuilderBase::CreateIntrinsic(Intrinsic::ID ID,
                                       FMFSource FMFSource, const Twine &Name,
                                       ArrayRef<OperandBundleDef> OpBundles,
                                       function_ref<void(CallInst *)> SetFn) {
-  // TODO: Try to constant-fold.
+  Type *RetTy = Intrinsic::getType(Context, ID, OverloadTypes)->getReturnType();
+  if (Value *V = Folder.FoldIntrinsic(ID, Args, RetTy, FMFSource.get(FMF)))
+    return V;
   CallInst *CI = CreateIntrinsicWithoutFolding(ID, OverloadTypes, Args,
                                                FMFSource, Name, OpBundles);
   SetFn(CI);
@@ -977,7 +979,8 @@ Value *IRBuilderBase::CreateIntrinsic(Type *RetTy, Intrinsic::ID ID,
                                       ArrayRef<Value *> Args,
                                       FMFSource FMFSource, const Twine &Name,
                                       function_ref<void(CallInst *)> SetFn) {
-  // TODO: Try to constant-fold.
+  if (Value *V = Folder.FoldIntrinsic(ID, Args, RetTy, FMFSource.get(FMF)))
+    return V;
   CallInst *CI =
       CreateIntrinsicWithoutFolding(RetTy, ID, Args, FMFSource, Name);
   SetFn(CI);

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -2307,7 +2307,7 @@ Value *InstCombinerImpl::foldSelectWithConstOpToBinOp(ICmpInst *Cmp,
 
   auto FoldBinaryOpOrIntrinsic = [&](Constant *LHS, Constant *RHS) {
     return IsIntrinsic
-               ? ConstantFoldBinaryIntrinsic(Opcode, LHS, RHS, LHS->getType())
+               ? ConstantFoldIntrinsic(Opcode, {LHS, RHS}, LHS->getType())
                : ConstantFoldBinaryOpOperands(Opcode, LHS, RHS, DL);
   };
 

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1291,10 +1291,10 @@ static VPIRValue *tryToFoldLiveIns(VPSingleDefRecipe &R,
   auto FoldToIRValue = [&]() -> Value * {
     InstSimplifyFolder Folder(DL);
     if (OpcodeOrIID->first) {
-      if (R.getNumOperands() != 2)
-        return nullptr;
-      unsigned ID = OpcodeOrIID->second;
-      return Folder.FoldBinaryIntrinsic(ID, Ops[0], Ops[1], R.getScalarType());
+      auto *RFlags = dyn_cast<VPRecipeWithIRFlags>(&R);
+      return Folder.FoldIntrinsic(OpcodeOrIID->second, Ops, R.getScalarType(),
+                                  RFlags ? RFlags->getFastMathFlagsOrNone()
+                                         : FastMathFlags());
     }
     unsigned Opcode = OpcodeOrIID->second;
     if (Instruction::isBinaryOp(Opcode))

--- a/llvm/test/CodeGen/VE/Scalar/atomic.ll
+++ b/llvm/test/CodeGen/VE/Scalar/atomic.ll
@@ -16,7 +16,6 @@ define signext i8 @test_atomic_fetch_add_1() {
 ; CHECK-NEXT:    lea %s0, c@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s0, c@hi(, %s0)
-; CHECK-NEXT:    and %s0, -4, %s0
 ; CHECK-NEXT:    ldl.zx %s2, (, %s0)
 ; CHECK-NEXT:    lea %s1, -256
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -47,7 +46,6 @@ define signext i16 @test_atomic_fetch_sub_2() {
 ; CHECK-NEXT:    lea %s0, s@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s0, s@hi(, %s0)
-; CHECK-NEXT:    and %s0, -4, %s0
 ; CHECK-NEXT:    ldl.zx %s2, (, %s0)
 ; CHECK-NEXT:    lea %s1, -65536
 ; CHECK-NEXT:    and %s1, %s1, (32)0
@@ -123,8 +121,7 @@ define signext i8 @test_atomic_fetch_xor_1() {
 ; CHECK-NEXT:    fencem 3
 ; CHECK-NEXT:    lea %s0, c@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
-; CHECK-NEXT:    lea.sl %s0, c@hi(, %s0)
-; CHECK-NEXT:    and %s1, -4, %s0
+; CHECK-NEXT:    lea.sl %s1, c@hi(, %s0)
 ; CHECK-NEXT:    ldl.zx %s0, (, %s1)
 ; CHECK-NEXT:  .LBB4_1: # %atomicrmw.start
 ; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -150,7 +147,6 @@ define signext i16 @test_atomic_fetch_nand_2() {
 ; CHECK-NEXT:    lea %s0, s@lo
 ; CHECK-NEXT:    and %s0, %s0, (32)0
 ; CHECK-NEXT:    lea.sl %s0, s@hi(, %s0)
-; CHECK-NEXT:    and %s0, -4, %s0
 ; CHECK-NEXT:    ldl.zx %s2, (, %s0)
 ; CHECK-NEXT:    lea %s1, 65534
 ; CHECK-NEXT:    lea %s3, -65536

--- a/llvm/test/CodeGen/VE/Scalar/atomic_cmp_swap.ll
+++ b/llvm/test/CodeGen/VE/Scalar/atomic_cmp_swap.ll
@@ -1440,18 +1440,17 @@ define zeroext i1 @_Z30atomic_cmp_swap_relaxed_stk_i1Rbb(ptr nocapture nonnull a
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
 ; CHECK-NEXT:  .LBB33_4: # %bb
+; CHECK-NEXT:    ld1b.zx %s2, (, %s0)
+; CHECK-NEXT:    ldl.zx %s3, 8(, %s11)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
-; CHECK-NEXT:    ld1b.zx %s3, (, %s0)
-; CHECK-NEXT:    ldl.zx %s4, 8(, %s11)
-; CHECK-NEXT:    lea %s2, 8(, %s11)
-; CHECK-NEXT:    lea %s5, -256
-; CHECK-NEXT:    and %s5, %s5, (32)0
-; CHECK-NEXT:    and %s4, %s4, %s5
+; CHECK-NEXT:    lea %s4, -256
 ; CHECK-NEXT:    and %s4, %s4, (32)0
-; CHECK-NEXT:    or %s1, %s4, %s1
-; CHECK-NEXT:    or %s3, %s4, %s3
-; CHECK-NEXT:    cas.w %s1, (%s2), %s3
-; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s3
+; CHECK-NEXT:    and %s3, %s3, %s4
+; CHECK-NEXT:    and %s3, %s3, (32)0
+; CHECK-NEXT:    or %s1, %s3, %s1
+; CHECK-NEXT:    or %s2, %s3, %s2
+; CHECK-NEXT:    cas.w %s1, 8(%s11), %s2
+; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s2
 ; CHECK-NEXT:    or %s2, 0, (0)1
 ; CHECK-NEXT:    cmov.w.eq %s2, (63)0, %s3
 ; CHECK-NEXT:    brne.w 0, %s2, .LBB33_2
@@ -1502,19 +1501,18 @@ define signext i8 @_Z30atomic_cmp_swap_relaxed_stk_i8Rcc(ptr nocapture nonnull a
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
 ; CHECK-NEXT:  .LBB34_4: # %bb
-; CHECK-NEXT:    ld1b.zx %s3, (, %s0)
-; CHECK-NEXT:    lea %s2, 8(, %s11)
+; CHECK-NEXT:    ld1b.zx %s2, (, %s0)
 ; CHECK-NEXT:    and %s1, %s1, (56)0
-; CHECK-NEXT:    ldl.zx %s4, 8(, %s11)
+; CHECK-NEXT:    ldl.zx %s3, 8(, %s11)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
-; CHECK-NEXT:    lea %s5, -256
-; CHECK-NEXT:    and %s5, %s5, (32)0
-; CHECK-NEXT:    and %s4, %s4, %s5
+; CHECK-NEXT:    lea %s4, -256
 ; CHECK-NEXT:    and %s4, %s4, (32)0
-; CHECK-NEXT:    or %s1, %s4, %s1
-; CHECK-NEXT:    or %s3, %s4, %s3
-; CHECK-NEXT:    cas.w %s1, (%s2), %s3
-; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s3
+; CHECK-NEXT:    and %s3, %s3, %s4
+; CHECK-NEXT:    and %s3, %s3, (32)0
+; CHECK-NEXT:    or %s1, %s3, %s1
+; CHECK-NEXT:    or %s2, %s3, %s2
+; CHECK-NEXT:    cas.w %s1, 8(%s11), %s2
+; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s2
 ; CHECK-NEXT:    or %s2, 0, (0)1
 ; CHECK-NEXT:    cmov.w.eq %s2, (63)0, %s3
 ; CHECK-NEXT:    brne.w 0, %s2, .LBB34_2
@@ -1559,18 +1557,17 @@ define zeroext i8 @_Z30atomic_cmp_swap_relaxed_stk_u8Rhh(ptr nocapture nonnull a
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
 ; CHECK-NEXT:  .LBB35_4: # %bb
+; CHECK-NEXT:    ld1b.zx %s2, (, %s0)
+; CHECK-NEXT:    ldl.zx %s3, 8(, %s11)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
-; CHECK-NEXT:    ld1b.zx %s3, (, %s0)
-; CHECK-NEXT:    ldl.zx %s4, 8(, %s11)
-; CHECK-NEXT:    lea %s2, 8(, %s11)
-; CHECK-NEXT:    lea %s5, -256
-; CHECK-NEXT:    and %s5, %s5, (32)0
-; CHECK-NEXT:    and %s4, %s4, %s5
+; CHECK-NEXT:    lea %s4, -256
 ; CHECK-NEXT:    and %s4, %s4, (32)0
-; CHECK-NEXT:    or %s1, %s4, %s1
-; CHECK-NEXT:    or %s3, %s4, %s3
-; CHECK-NEXT:    cas.w %s1, (%s2), %s3
-; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s3
+; CHECK-NEXT:    and %s3, %s3, %s4
+; CHECK-NEXT:    and %s3, %s3, (32)0
+; CHECK-NEXT:    or %s1, %s3, %s1
+; CHECK-NEXT:    or %s2, %s3, %s2
+; CHECK-NEXT:    cas.w %s1, 8(%s11), %s2
+; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s2
 ; CHECK-NEXT:    or %s2, 0, (0)1
 ; CHECK-NEXT:    cmov.w.eq %s2, (63)0, %s3
 ; CHECK-NEXT:    brne.w 0, %s2, .LBB35_2
@@ -1615,19 +1612,18 @@ define signext i16 @_Z31atomic_cmp_swap_relaxed_stk_i16Rss(ptr nocapture nonnull
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
 ; CHECK-NEXT:  .LBB36_4: # %bb
-; CHECK-NEXT:    ld2b.zx %s3, (, %s0)
-; CHECK-NEXT:    lea %s2, 8(, %s11)
+; CHECK-NEXT:    ld2b.zx %s2, (, %s0)
 ; CHECK-NEXT:    and %s1, %s1, (48)0
-; CHECK-NEXT:    ldl.zx %s4, 8(, %s11)
+; CHECK-NEXT:    ldl.zx %s3, 8(, %s11)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
-; CHECK-NEXT:    lea %s5, -65536
-; CHECK-NEXT:    and %s5, %s5, (32)0
-; CHECK-NEXT:    and %s4, %s4, %s5
+; CHECK-NEXT:    lea %s4, -65536
 ; CHECK-NEXT:    and %s4, %s4, (32)0
-; CHECK-NEXT:    or %s1, %s4, %s1
-; CHECK-NEXT:    or %s3, %s4, %s3
-; CHECK-NEXT:    cas.w %s1, (%s2), %s3
-; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s3
+; CHECK-NEXT:    and %s3, %s3, %s4
+; CHECK-NEXT:    and %s3, %s3, (32)0
+; CHECK-NEXT:    or %s1, %s3, %s1
+; CHECK-NEXT:    or %s2, %s3, %s2
+; CHECK-NEXT:    cas.w %s1, 8(%s11), %s2
+; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s2
 ; CHECK-NEXT:    or %s2, 0, (0)1
 ; CHECK-NEXT:    cmov.w.eq %s2, (63)0, %s3
 ; CHECK-NEXT:    brne.w 0, %s2, .LBB36_2
@@ -1672,18 +1668,17 @@ define zeroext i16 @_Z31atomic_cmp_swap_relaxed_stk_u16Rtt(ptr nocapture nonnull
 ; CHECK-NEXT:    monc
 ; CHECK-NEXT:    or %s0, 0, %s62
 ; CHECK-NEXT:  .LBB37_4: # %bb
+; CHECK-NEXT:    ld2b.zx %s2, (, %s0)
+; CHECK-NEXT:    ldl.zx %s3, 8(, %s11)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
-; CHECK-NEXT:    ld2b.zx %s3, (, %s0)
-; CHECK-NEXT:    ldl.zx %s4, 8(, %s11)
-; CHECK-NEXT:    lea %s2, 8(, %s11)
-; CHECK-NEXT:    lea %s5, -65536
-; CHECK-NEXT:    and %s5, %s5, (32)0
-; CHECK-NEXT:    and %s4, %s4, %s5
+; CHECK-NEXT:    lea %s4, -65536
 ; CHECK-NEXT:    and %s4, %s4, (32)0
-; CHECK-NEXT:    or %s1, %s4, %s1
-; CHECK-NEXT:    or %s3, %s4, %s3
-; CHECK-NEXT:    cas.w %s1, (%s2), %s3
-; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s3
+; CHECK-NEXT:    and %s3, %s3, %s4
+; CHECK-NEXT:    and %s3, %s3, (32)0
+; CHECK-NEXT:    or %s1, %s3, %s1
+; CHECK-NEXT:    or %s2, %s3, %s2
+; CHECK-NEXT:    cas.w %s1, 8(%s11), %s2
+; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s2
 ; CHECK-NEXT:    or %s2, 0, (0)1
 ; CHECK-NEXT:    cmov.w.eq %s2, (63)0, %s3
 ; CHECK-NEXT:    brne.w 0, %s2, .LBB37_2
@@ -2004,21 +1999,20 @@ bb:
 define zeroext i1 @_Z29atomic_cmp_swap_relaxed_gv_i1Rbb(ptr nocapture nonnull align 1 dereferenceable(1) %arg, i1 zeroext %arg1) {
 ; CHECK-LABEL: _Z29atomic_cmp_swap_relaxed_gv_i1Rbb:
 ; CHECK:       # %bb.0: # %bb
-; CHECK-NEXT:    ld1b.zx %s2, (, %s0)
-; CHECK-NEXT:    lea %s3, gv_i1@lo
-; CHECK-NEXT:    and %s3, %s3, (32)0
-; CHECK-NEXT:    lea.sl %s3, gv_i1@hi(, %s3)
-; CHECK-NEXT:    and %s3, -4, %s3
-; CHECK-NEXT:    ldl.zx %s4, (, %s3)
+; CHECK-NEXT:    ld1b.zx %s3, (, %s0)
+; CHECK-NEXT:    lea %s2, gv_i1@lo
+; CHECK-NEXT:    and %s2, %s2, (32)0
+; CHECK-NEXT:    lea.sl %s2, gv_i1@hi(, %s2)
+; CHECK-NEXT:    ldl.zx %s4, (, %s2)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea %s5, -256
 ; CHECK-NEXT:    and %s5, %s5, (32)0
 ; CHECK-NEXT:    and %s4, %s4, %s5
 ; CHECK-NEXT:    and %s4, %s4, (32)0
 ; CHECK-NEXT:    or %s1, %s4, %s1
-; CHECK-NEXT:    or %s2, %s4, %s2
-; CHECK-NEXT:    cas.w %s1, (%s3), %s2
-; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s2
+; CHECK-NEXT:    or %s3, %s4, %s3
+; CHECK-NEXT:    cas.w %s1, (%s2), %s3
+; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s3
 ; CHECK-NEXT:    or %s2, 0, (0)1
 ; CHECK-NEXT:    cmov.w.eq %s2, (63)0, %s3
 ; CHECK-NEXT:    brne.w 0, %s2, .LBB44_2
@@ -2048,28 +2042,27 @@ define signext i8 @_Z29atomic_cmp_swap_relaxed_gv_i8Rcc(ptr nocapture nonnull al
 ; CHECK-LABEL: _Z29atomic_cmp_swap_relaxed_gv_i8Rcc:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    ld1b.zx %s2, (, %s0)
-; CHECK-NEXT:    lea %s3, gv_i8@lo
-; CHECK-NEXT:    and %s3, %s3, (32)0
-; CHECK-NEXT:    lea.sl %s3, gv_i8@hi(, %s3)
-; CHECK-NEXT:    and %s3, -4, %s3
-; CHECK-NEXT:    and %s1, %s1, (56)0
-; CHECK-NEXT:    ldl.zx %s4, (, %s3)
+; CHECK-NEXT:    and %s3, %s1, (56)0
+; CHECK-NEXT:    lea %s1, gv_i8@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
+; CHECK-NEXT:    lea.sl %s1, gv_i8@hi(, %s1)
+; CHECK-NEXT:    ldl.zx %s4, (, %s1)
+; CHECK-NEXT:    and %s3, %s3, (32)0
 ; CHECK-NEXT:    lea %s5, -256
 ; CHECK-NEXT:    and %s5, %s5, (32)0
 ; CHECK-NEXT:    and %s4, %s4, %s5
 ; CHECK-NEXT:    and %s4, %s4, (32)0
-; CHECK-NEXT:    or %s1, %s4, %s1
+; CHECK-NEXT:    or %s3, %s4, %s3
 ; CHECK-NEXT:    or %s2, %s4, %s2
-; CHECK-NEXT:    cas.w %s1, (%s3), %s2
-; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s2
-; CHECK-NEXT:    or %s2, 0, (0)1
-; CHECK-NEXT:    cmov.w.eq %s2, (63)0, %s3
-; CHECK-NEXT:    brne.w 0, %s2, .LBB45_2
+; CHECK-NEXT:    cas.w %s3, (%s1), %s2
+; CHECK-NEXT:    cmps.w.sx %s2, %s3, %s2
+; CHECK-NEXT:    or %s1, 0, (0)1
+; CHECK-NEXT:    cmov.w.eq %s1, (63)0, %s2
+; CHECK-NEXT:    brne.w 0, %s1, .LBB45_2
 ; CHECK-NEXT:  # %bb.1: # %bb4
-; CHECK-NEXT:    st1b %s1, (, %s0)
+; CHECK-NEXT:    st1b %s3, (, %s0)
 ; CHECK-NEXT:  .LBB45_2: # %bb6
-; CHECK-NEXT:    adds.w.zx %s0, %s2, (0)1
+; CHECK-NEXT:    adds.w.zx %s0, %s1, (0)1
 ; CHECK-NEXT:    b.l.t (, %s10)
 bb:
   %i = load i8, ptr %arg, align 1
@@ -2091,21 +2084,20 @@ bb6:                                              ; preds = %bb4, %bb
 define zeroext i8 @_Z29atomic_cmp_swap_relaxed_gv_u8Rhh(ptr nocapture nonnull align 1 dereferenceable(1) %arg, i8 zeroext %arg1) {
 ; CHECK-LABEL: _Z29atomic_cmp_swap_relaxed_gv_u8Rhh:
 ; CHECK:       # %bb.0: # %bb
-; CHECK-NEXT:    ld1b.zx %s2, (, %s0)
-; CHECK-NEXT:    lea %s3, gv_u8@lo
-; CHECK-NEXT:    and %s3, %s3, (32)0
-; CHECK-NEXT:    lea.sl %s3, gv_u8@hi(, %s3)
-; CHECK-NEXT:    and %s3, -4, %s3
-; CHECK-NEXT:    ldl.zx %s4, (, %s3)
+; CHECK-NEXT:    ld1b.zx %s3, (, %s0)
+; CHECK-NEXT:    lea %s2, gv_u8@lo
+; CHECK-NEXT:    and %s2, %s2, (32)0
+; CHECK-NEXT:    lea.sl %s2, gv_u8@hi(, %s2)
+; CHECK-NEXT:    ldl.zx %s4, (, %s2)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea %s5, -256
 ; CHECK-NEXT:    and %s5, %s5, (32)0
 ; CHECK-NEXT:    and %s4, %s4, %s5
 ; CHECK-NEXT:    and %s4, %s4, (32)0
 ; CHECK-NEXT:    or %s1, %s4, %s1
-; CHECK-NEXT:    or %s2, %s4, %s2
-; CHECK-NEXT:    cas.w %s1, (%s3), %s2
-; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s2
+; CHECK-NEXT:    or %s3, %s4, %s3
+; CHECK-NEXT:    cas.w %s1, (%s2), %s3
+; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s3
 ; CHECK-NEXT:    or %s2, 0, (0)1
 ; CHECK-NEXT:    cmov.w.eq %s2, (63)0, %s3
 ; CHECK-NEXT:    brne.w 0, %s2, .LBB46_2
@@ -2135,28 +2127,27 @@ define signext i16 @_Z30atomic_cmp_swap_relaxed_gv_i16Rss(ptr nocapture nonnull 
 ; CHECK-LABEL: _Z30atomic_cmp_swap_relaxed_gv_i16Rss:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    ld2b.zx %s2, (, %s0)
-; CHECK-NEXT:    lea %s3, gv_i16@lo
-; CHECK-NEXT:    and %s3, %s3, (32)0
-; CHECK-NEXT:    lea.sl %s3, gv_i16@hi(, %s3)
-; CHECK-NEXT:    and %s3, -4, %s3
-; CHECK-NEXT:    and %s1, %s1, (48)0
-; CHECK-NEXT:    ldl.zx %s4, (, %s3)
+; CHECK-NEXT:    and %s3, %s1, (48)0
+; CHECK-NEXT:    lea %s1, gv_i16@lo
 ; CHECK-NEXT:    and %s1, %s1, (32)0
+; CHECK-NEXT:    lea.sl %s1, gv_i16@hi(, %s1)
+; CHECK-NEXT:    ldl.zx %s4, (, %s1)
+; CHECK-NEXT:    and %s3, %s3, (32)0
 ; CHECK-NEXT:    lea %s5, -65536
 ; CHECK-NEXT:    and %s5, %s5, (32)0
 ; CHECK-NEXT:    and %s4, %s4, %s5
 ; CHECK-NEXT:    and %s4, %s4, (32)0
-; CHECK-NEXT:    or %s1, %s4, %s1
+; CHECK-NEXT:    or %s3, %s4, %s3
 ; CHECK-NEXT:    or %s2, %s4, %s2
-; CHECK-NEXT:    cas.w %s1, (%s3), %s2
-; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s2
-; CHECK-NEXT:    or %s2, 0, (0)1
-; CHECK-NEXT:    cmov.w.eq %s2, (63)0, %s3
-; CHECK-NEXT:    brne.w 0, %s2, .LBB47_2
+; CHECK-NEXT:    cas.w %s3, (%s1), %s2
+; CHECK-NEXT:    cmps.w.sx %s2, %s3, %s2
+; CHECK-NEXT:    or %s1, 0, (0)1
+; CHECK-NEXT:    cmov.w.eq %s1, (63)0, %s2
+; CHECK-NEXT:    brne.w 0, %s1, .LBB47_2
 ; CHECK-NEXT:  # %bb.1: # %bb4
-; CHECK-NEXT:    st2b %s1, (, %s0)
+; CHECK-NEXT:    st2b %s3, (, %s0)
 ; CHECK-NEXT:  .LBB47_2: # %bb6
-; CHECK-NEXT:    adds.w.zx %s0, %s2, (0)1
+; CHECK-NEXT:    adds.w.zx %s0, %s1, (0)1
 ; CHECK-NEXT:    b.l.t (, %s10)
 bb:
   %i = load i16, ptr %arg, align 2
@@ -2178,21 +2169,20 @@ bb6:                                              ; preds = %bb4, %bb
 define zeroext i16 @_Z30atomic_cmp_swap_relaxed_gv_u16Rtt(ptr nocapture nonnull align 2 dereferenceable(2) %arg, i16 zeroext %arg1) {
 ; CHECK-LABEL: _Z30atomic_cmp_swap_relaxed_gv_u16Rtt:
 ; CHECK:       # %bb.0: # %bb
-; CHECK-NEXT:    ld2b.zx %s2, (, %s0)
-; CHECK-NEXT:    lea %s3, gv_u16@lo
-; CHECK-NEXT:    and %s3, %s3, (32)0
-; CHECK-NEXT:    lea.sl %s3, gv_u16@hi(, %s3)
-; CHECK-NEXT:    and %s3, -4, %s3
-; CHECK-NEXT:    ldl.zx %s4, (, %s3)
+; CHECK-NEXT:    ld2b.zx %s3, (, %s0)
+; CHECK-NEXT:    lea %s2, gv_u16@lo
+; CHECK-NEXT:    and %s2, %s2, (32)0
+; CHECK-NEXT:    lea.sl %s2, gv_u16@hi(, %s2)
+; CHECK-NEXT:    ldl.zx %s4, (, %s2)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    lea %s5, -65536
 ; CHECK-NEXT:    and %s5, %s5, (32)0
 ; CHECK-NEXT:    and %s4, %s4, %s5
 ; CHECK-NEXT:    and %s4, %s4, (32)0
 ; CHECK-NEXT:    or %s1, %s4, %s1
-; CHECK-NEXT:    or %s2, %s4, %s2
-; CHECK-NEXT:    cas.w %s1, (%s3), %s2
-; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s2
+; CHECK-NEXT:    or %s3, %s4, %s3
+; CHECK-NEXT:    cas.w %s1, (%s2), %s3
+; CHECK-NEXT:    cmps.w.sx %s3, %s1, %s3
 ; CHECK-NEXT:    or %s2, 0, (0)1
 ; CHECK-NEXT:    cmov.w.eq %s2, (63)0, %s3
 ; CHECK-NEXT:    brne.w 0, %s2, .LBB48_2

--- a/llvm/test/Transforms/IRCE/correct-loop-info.ll
+++ b/llvm/test/Transforms/IRCE/correct-loop-info.ll
@@ -13,33 +13,30 @@ source_filename = "correct-loop-info.ll"
 define void @baz() personality ptr @ham {
 ; CHECK-LABEL: @baz(
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    [[EXIT_PRELOOP_AT:%.*]] = call i32 @llvm.smax.i32(i32 undef, i32 -1)
-; CHECK-NEXT:    [[EXIT_MAINLOOP_AT:%.*]] = call i32 @llvm.smax.i32(i32 undef, i32 0)
 ; CHECK-NEXT:    br label [[OUTERHEADER:%.*]]
 ; CHECK:       outerheader:
 ; CHECK-NEXT:    [[TMP:%.*]] = icmp slt i32 undef, 84
 ; CHECK-NEXT:    br i1 [[TMP]], label [[BB2:%.*]], label [[BB16:%.*]]
 ; CHECK:       bb2:
-; CHECK-NEXT:    [[TMP0:%.*]] = icmp slt i32 undef, [[EXIT_PRELOOP_AT]]
-; CHECK-NEXT:    br i1 [[TMP0]], label [[INNERHEADER_PRELOOP_PREHEADER:%.*]], label [[PRELOOP_PSEUDO_EXIT:%.*]]
+; CHECK-NEXT:    br i1 false, label [[INNERHEADER_PRELOOP_PREHEADER:%.*]], label [[PRELOOP_PSEUDO_EXIT:%.*]]
 ; CHECK:       innerheader.preloop.preheader:
 ; CHECK-NEXT:    br label [[INNERHEADER_PRELOOP:%.*]]
 ; CHECK:       mainloop:
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp slt i32 [[INDVAR_END:%.*]], [[EXIT_MAINLOOP_AT]]
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp slt i32 [[INDVAR_END:%.*]], 2147483647
 ; CHECK-NEXT:    br i1 [[TMP1]], label [[INNERHEADER_PREHEADER:%.*]], label [[MAIN_PSEUDO_EXIT:%.*]]
 ; CHECK:       innerheader.preheader:
 ; CHECK-NEXT:    br label [[INNERHEADER:%.*]]
 ; CHECK:       innerheader:
 ; CHECK-NEXT:    [[TMP4:%.*]] = phi i32 [ [[TMP6:%.*]], [[BB8:%.*]] ], [ [[TMP4_PRELOOP_COPY:%.*]], [[INNERHEADER_PREHEADER]] ]
 ; CHECK-NEXT:    invoke void @pluto()
-; CHECK-NEXT:    to label [[BB5:%.*]] unwind label [[OUTER_EXITING_LOOPEXIT_SPLIT_LP_LOOPEXIT_SPLIT_LP:%.*]]
+; CHECK-NEXT:            to label [[BB5:%.*]] unwind label [[OUTER_EXITING_LOOPEXIT_SPLIT_LP_LOOPEXIT_SPLIT_LP:%.*]]
 ; CHECK:       bb5:
 ; CHECK-NEXT:    [[TMP6]] = add nsw i32 [[TMP4]], 1
 ; CHECK-NEXT:    [[TMP7:%.*]] = icmp slt i32 [[TMP6]], 1
 ; CHECK-NEXT:    br i1 true, label [[BB8]], label [[EXIT3_LOOPEXIT5:%.*]]
 ; CHECK:       bb8:
 ; CHECK-NEXT:    [[TMP9:%.*]] = icmp slt i32 [[TMP6]], 84
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp slt i32 [[TMP6]], [[EXIT_MAINLOOP_AT]]
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp slt i32 [[TMP6]], 2147483647
 ; CHECK-NEXT:    br i1 [[TMP2]], label [[INNERHEADER]], label [[MAIN_EXIT_SELECTOR:%.*]]
 ; CHECK:       main.exit.selector:
 ; CHECK-NEXT:    [[TMP6_LCSSA:%.*]] = phi i32 [ [[TMP6]], [[BB8]] ]
@@ -51,22 +48,22 @@ define void @baz() personality ptr @ham {
 ; CHECK-NEXT:    br label [[POSTLOOP:%.*]]
 ; CHECK:       outer_exiting.loopexit:
 ; CHECK-NEXT:    [[LPAD_LOOPEXIT:%.*]] = landingpad { ptr, i32 }
-; CHECK-NEXT:    cleanup
+; CHECK-NEXT:            cleanup
 ; CHECK-NEXT:    br label [[OUTER_EXITING:%.*]]
 ; CHECK:       outer_exiting.loopexit.split-lp.loopexit:
 ; CHECK-NEXT:    [[LPAD_LOOPEXIT2:%.*]] = landingpad { ptr, i32 }
-; CHECK-NEXT:    cleanup
+; CHECK-NEXT:            cleanup
 ; CHECK-NEXT:    br label [[OUTER_EXITING_LOOPEXIT_SPLIT_LP:%.*]]
 ; CHECK:       outer_exiting.loopexit.split-lp.loopexit.split-lp:
 ; CHECK-NEXT:    [[LPAD_LOOPEXIT_SPLIT_LP3:%.*]] = landingpad { ptr, i32 }
-; CHECK-NEXT:    cleanup
+; CHECK-NEXT:            cleanup
 ; CHECK-NEXT:    br label [[OUTER_EXITING_LOOPEXIT_SPLIT_LP]]
 ; CHECK:       outer_exiting.loopexit.split-lp:
 ; CHECK-NEXT:    br label [[OUTER_EXITING]]
 ; CHECK:       outer_exiting:
 ; CHECK-NEXT:    switch i32 undef, label [[EXIT2:%.*]] [
-; CHECK-NEXT:    i32 142, label [[BB14:%.*]]
-; CHECK-NEXT:    i32 448, label [[EXIT:%.*]]
+; CHECK-NEXT:      i32 142, label [[BB14:%.*]]
+; CHECK-NEXT:      i32 448, label [[EXIT:%.*]]
 ; CHECK-NEXT:    ]
 ; CHECK:       exit3.loopexit:
 ; CHECK-NEXT:    br label [[EXIT3:%.*]]
@@ -91,19 +88,19 @@ define void @baz() personality ptr @ham {
 ; CHECK:       innerheader.preloop:
 ; CHECK-NEXT:    [[TMP4_PRELOOP:%.*]] = phi i32 [ [[TMP6_PRELOOP:%.*]], [[BB8_PRELOOP:%.*]] ], [ undef, [[INNERHEADER_PRELOOP_PREHEADER]] ]
 ; CHECK-NEXT:    invoke void @pluto()
-; CHECK-NEXT:    to label [[BB5_PRELOOP:%.*]] unwind label [[OUTER_EXITING_LOOPEXIT:%.*]]
+; CHECK-NEXT:            to label [[BB5_PRELOOP:%.*]] unwind label [[OUTER_EXITING_LOOPEXIT:%.*]]
 ; CHECK:       bb5.preloop:
 ; CHECK-NEXT:    [[TMP6_PRELOOP]] = add i32 [[TMP4_PRELOOP]], 1
 ; CHECK-NEXT:    [[TMP7_PRELOOP:%.*]] = icmp slt i32 [[TMP6_PRELOOP]], 1
 ; CHECK-NEXT:    br i1 [[TMP7_PRELOOP]], label [[BB8_PRELOOP]], label [[EXIT3_LOOPEXIT:%.*]]
 ; CHECK:       bb8.preloop:
 ; CHECK-NEXT:    [[TMP9_PRELOOP:%.*]] = icmp slt i32 [[TMP6_PRELOOP]], 84
-; CHECK-NEXT:    [[TMP4:%.*]] = icmp slt i32 [[TMP6_PRELOOP]], [[EXIT_PRELOOP_AT]]
-; CHECK-NEXT:    br i1 [[TMP4]], label [[INNERHEADER_PRELOOP]], label [[PRELOOP_EXIT_SELECTOR:%.*]], !llvm.loop [[LOOP0:![0-9]+]], !loop_constrainer.loop.clone [[META5:![0-9]+]]
+; CHECK-NEXT:    [[TMP5:%.*]] = icmp slt i32 [[TMP6_PRELOOP]], 2147483647
+; CHECK-NEXT:    br i1 [[TMP5]], label [[INNERHEADER_PRELOOP]], label [[PRELOOP_EXIT_SELECTOR:%.*]], !llvm.loop [[LOOP0:![0-9]+]], !loop_constrainer.loop.clone [[META5:![0-9]+]]
 ; CHECK:       preloop.exit.selector:
 ; CHECK-NEXT:    [[TMP6_PRELOOP_LCSSA:%.*]] = phi i32 [ [[TMP6_PRELOOP]], [[BB8_PRELOOP]] ]
-; CHECK-NEXT:    [[TMP5:%.*]] = icmp slt i32 [[TMP6_PRELOOP_LCSSA]], 84
-; CHECK-NEXT:    br i1 [[TMP5]], label [[PRELOOP_PSEUDO_EXIT]], label [[BB13]]
+; CHECK-NEXT:    [[TMP4:%.*]] = icmp slt i32 [[TMP6_PRELOOP_LCSSA]], 84
+; CHECK-NEXT:    br i1 [[TMP4]], label [[PRELOOP_PSEUDO_EXIT]], label [[BB13]]
 ; CHECK:       preloop.pseudo.exit:
 ; CHECK-NEXT:    [[TMP4_PRELOOP_COPY]] = phi i32 [ undef, [[BB2]] ], [ [[TMP6_PRELOOP_LCSSA]], [[PRELOOP_EXIT_SELECTOR]] ]
 ; CHECK-NEXT:    [[INDVAR_END]] = phi i32 [ undef, [[BB2]] ], [ [[TMP6_PRELOOP_LCSSA]], [[PRELOOP_EXIT_SELECTOR]] ]
@@ -113,7 +110,7 @@ define void @baz() personality ptr @ham {
 ; CHECK:       innerheader.postloop:
 ; CHECK-NEXT:    [[TMP4_POSTLOOP:%.*]] = phi i32 [ [[TMP6_POSTLOOP:%.*]], [[BB8_POSTLOOP:%.*]] ], [ [[TMP4_COPY]], [[POSTLOOP]] ]
 ; CHECK-NEXT:    invoke void @pluto()
-; CHECK-NEXT:    to label [[BB5_POSTLOOP:%.*]] unwind label [[OUTER_EXITING_LOOPEXIT_SPLIT_LP_LOOPEXIT:%.*]]
+; CHECK-NEXT:            to label [[BB5_POSTLOOP:%.*]] unwind label [[OUTER_EXITING_LOOPEXIT_SPLIT_LP_LOOPEXIT:%.*]]
 ; CHECK:       bb5.postloop:
 ; CHECK-NEXT:    [[TMP6_POSTLOOP]] = add i32 [[TMP4_POSTLOOP]], 1
 ; CHECK-NEXT:    [[TMP7_POSTLOOP:%.*]] = icmp slt i32 [[TMP6_POSTLOOP]], 1

--- a/llvm/test/Transforms/IndVarSimplify/lcssa-preservation.ll
+++ b/llvm/test/Transforms/IndVarSimplify/lcssa-preservation.ll
@@ -17,12 +17,11 @@ define void @PR18642(i32 %x) {
 ; CHECK:       outer.latch:
 ; CHECK-NEXT:    br i1 false, label [[OUTER_HEADER]], label [[EXIT_LOOPEXIT1:%.*]]
 ; CHECK:       exit.loopexit:
-; CHECK-NEXT:    [[INC_LCSSA:%.*]] = phi i32 [ -2147483648, [[INNER_LATCH]] ]
 ; CHECK-NEXT:    br label [[EXIT:%.*]]
 ; CHECK:       exit.loopexit1:
 ; CHECK-NEXT:    br label [[EXIT]]
 ; CHECK:       exit:
-; CHECK-NEXT:    [[EXIT_PHI:%.*]] = phi i32 [ [[INC_LCSSA]], [[EXIT_LOOPEXIT]] ], [ undef, [[EXIT_LOOPEXIT1]] ]
+; CHECK-NEXT:    [[EXIT_PHI:%.*]] = phi i32 [ -2147483648, [[EXIT_LOOPEXIT]] ], [ undef, [[EXIT_LOOPEXIT1]] ]
 ; CHECK-NEXT:    ret void
 ;
 entry:

--- a/llvm/test/Transforms/LoopUnroll/runtime-loop-multiexit-dom-verify.ll
+++ b/llvm/test/Transforms/LoopUnroll/runtime-loop-multiexit-dom-verify.ll
@@ -251,8 +251,7 @@ define void @test4(i16 %c3) {
 ; CHECK-LABEL: @test4(
 ; CHECK-NEXT:  preheader:
 ; CHECK-NEXT:    [[C1:%.*]] = zext i32 undef to i64
-; CHECK-NEXT:    [[UMAX:%.*]] = call i64 @llvm.umax.i64(i64 [[C1]], i64 1)
-; CHECK-NEXT:    [[TMP0:%.*]] = freeze i64 [[UMAX]]
+; CHECK-NEXT:    [[TMP0:%.*]] = freeze i64 [[C1]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = add i64 [[TMP0]], -1
 ; CHECK-NEXT:    [[XTRAITER:%.*]] = and i64 [[TMP0]], 3
 ; CHECK-NEXT:    [[LCMP_MOD:%.*]] = icmp ne i64 [[XTRAITER]], 0

--- a/llvm/test/Transforms/LoopVectorize/X86/replicating-load-store-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/replicating-load-store-costs.ll
@@ -1008,12 +1008,6 @@ define void @replicated_load_wide_store_derived_iv_zext_and(ptr noalias %src, pt
 ; I64-NEXT:    br label %[[VECTOR_SCEVCHECK:.*]]
 ; I64:       [[VECTOR_SCEVCHECK]]:
 ; I64-NEXT:    [[TMP0:%.*]] = trunc i32 [[STEP]] to i1
-; I64-NEXT:    [[MUL:%.*]] = call { i1, i1 } @llvm.umul.with.overflow.i1(i1 [[TMP0]], i1 false)
-; I64-NEXT:    [[MUL_RESULT:%.*]] = extractvalue { i1, i1 } [[MUL]], 0
-; I64-NEXT:    [[MUL_OVERFLOW:%.*]] = extractvalue { i1, i1 } [[MUL]], 1
-; I64-NEXT:    [[TMP1:%.*]] = select i1 [[TMP0]], i1 [[MUL_RESULT]], i1 false
-; I64-NEXT:    [[TMP2:%.*]] = or i1 [[TMP1]], [[MUL_OVERFLOW]]
-; I64-NEXT:    [[TMP3:%.*]] = or i1 [[TMP2]], [[TMP0]]
 ; I64-NEXT:    [[TMP4:%.*]] = sext i1 [[TMP0]] to i32
 ; I64-NEXT:    [[IDENT_CHECK:%.*]] = icmp ne i32 [[STEP]], [[TMP4]]
 ; I64-NEXT:    [[TMP5:%.*]] = sub i32 0, [[STEP]]
@@ -1026,7 +1020,7 @@ define void @replicated_load_wide_store_derived_iv_zext_and(ptr noalias %src, pt
 ; I64-NEXT:    [[TMP9:%.*]] = icmp ugt i32 [[TMP8]], 0
 ; I64-NEXT:    [[TMP10:%.*]] = select i1 [[TMP6]], i1 [[TMP9]], i1 false
 ; I64-NEXT:    [[TMP11:%.*]] = or i1 [[TMP10]], [[MUL_OVERFLOW3]]
-; I64-NEXT:    [[TMP12:%.*]] = or i1 [[TMP3]], [[IDENT_CHECK]]
+; I64-NEXT:    [[TMP12:%.*]] = or i1 [[TMP0]], [[IDENT_CHECK]]
 ; I64-NEXT:    [[TMP13:%.*]] = or i1 [[TMP12]], [[TMP11]]
 ; I64-NEXT:    br i1 [[TMP13]], label %[[SCALAR_PH:.*]], label %[[VECTOR_PH:.*]]
 ; I64:       [[VECTOR_PH]]:
@@ -1141,15 +1135,9 @@ define void @replicated_load_wide_store_derived_iv_zext_and2(ptr noalias %dst, p
 ; I64-NEXT:    br label %[[VECTOR_SCEVCHECK:.*]]
 ; I64:       [[VECTOR_SCEVCHECK]]:
 ; I64-NEXT:    [[TMP0:%.*]] = trunc i32 [[STEP]] to i1
-; I64-NEXT:    [[MUL:%.*]] = call { i1, i1 } @llvm.umul.with.overflow.i1(i1 [[TMP0]], i1 false)
-; I64-NEXT:    [[MUL_RESULT:%.*]] = extractvalue { i1, i1 } [[MUL]], 0
-; I64-NEXT:    [[MUL_OVERFLOW:%.*]] = extractvalue { i1, i1 } [[MUL]], 1
-; I64-NEXT:    [[TMP1:%.*]] = select i1 [[TMP0]], i1 [[MUL_RESULT]], i1 false
-; I64-NEXT:    [[TMP2:%.*]] = or i1 [[TMP1]], [[MUL_OVERFLOW]]
-; I64-NEXT:    [[TMP3:%.*]] = or i1 [[TMP2]], [[TMP0]]
 ; I64-NEXT:    [[TMP4:%.*]] = sext i1 [[TMP0]] to i32
 ; I64-NEXT:    [[IDENT_CHECK:%.*]] = icmp ne i32 [[STEP]], [[TMP4]]
-; I64-NEXT:    [[TMP5:%.*]] = or i1 [[TMP3]], [[IDENT_CHECK]]
+; I64-NEXT:    [[TMP5:%.*]] = or i1 [[TMP0]], [[IDENT_CHECK]]
 ; I64-NEXT:    br i1 [[TMP5]], label %[[SCALAR_PH:.*]], label %[[VECTOR_PH:.*]]
 ; I64:       [[VECTOR_PH]]:
 ; I64-NEXT:    [[TMP6:%.*]] = shl i32 [[STEP]], 7

--- a/llvm/test/Transforms/LoopVectorize/trip-count-expansion-may-introduce-ub.ll
+++ b/llvm/test/Transforms/LoopVectorize/trip-count-expansion-may-introduce-ub.ll
@@ -985,8 +985,7 @@ define i64 @multi_exit_4_exit_count_with_urem_by_constant_in_latch(ptr %dst, i64
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[SMAX:%.*]] = call i64 @llvm.smax.i64(i64 [[N]], i64 0)
 ; CHECK-NEXT:    [[TMP0:%.*]] = urem i64 [[N]], 42
-; CHECK-NEXT:    [[SMAX1:%.*]] = call i64 @llvm.smax.i64(i64 [[TMP0]], i64 0)
-; CHECK-NEXT:    [[UMIN:%.*]] = call i64 @llvm.umin.i64(i64 [[SMAX]], i64 [[SMAX1]])
+; CHECK-NEXT:    [[UMIN:%.*]] = call i64 @llvm.umin.i64(i64 [[SMAX]], i64 [[TMP0]])
 ; CHECK-NEXT:    [[TMP1:%.*]] = add nuw i64 [[UMIN]], 1
 ; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ule i64 [[TMP1]], 4
 ; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK]], label [[SCALAR_PH:%.*]], label [[VECTOR_PH:%.*]]

--- a/llvm/test/Transforms/LoopVectorize/version-mem-access.ll
+++ b/llvm/test/Transforms/LoopVectorize/version-mem-access.ll
@@ -129,14 +129,8 @@ define void @stride_poison(ptr %dst) mustprogress {
 ; CHECK-LABEL: define void @stride_poison(
 ; CHECK-SAME: ptr [[DST:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[UMAX:%.*]] = call i64 @llvm.umax.i64(i64 poison, i64 1)
-; CHECK-NEXT:    [[TMP0:%.*]] = udiv i64 99, [[UMAX]]
-; CHECK-NEXT:    [[TMP1:%.*]] = add nuw nsw i64 [[TMP0]], 2
 ; CHECK-NEXT:    br label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
-; CHECK-NEXT:    [[N_MOD_VF:%.*]] = urem i64 [[TMP1]], 2
-; CHECK-NEXT:    [[N_VEC:%.*]] = sub i64 [[TMP1]], [[N_MOD_VF]]
-; CHECK-NEXT:    [[TMP2:%.*]] = mul i64 [[N_VEC]], poison
 ; CHECK-NEXT:    br label %[[VECTOR_BODY:.*]]
 ; CHECK:       [[VECTOR_BODY]]:
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
@@ -147,11 +141,10 @@ define void @stride_poison(ptr %dst) mustprogress {
 ; CHECK-NEXT:    store i8 0, ptr [[TMP5]], align 1
 ; CHECK-NEXT:    store i8 0, ptr [[TMP6]], align 1
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 2
-; CHECK-NEXT:    [[TMP7:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
+; CHECK-NEXT:    [[TMP7:%.*]] = icmp eq i64 [[INDEX_NEXT]], poison
 ; CHECK-NEXT:    br i1 [[TMP7]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
-; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[TMP1]], [[N_VEC]]
-; CHECK-NEXT:    br i1 [[CMP_N]], [[EXIT:label %.*]], label %[[SCALAR_PH:.*]]
+; CHECK-NEXT:    br i1 poison, [[EXIT:label %.*]], label %[[SCALAR_PH:.*]]
 ; CHECK:       [[SCALAR_PH]]:
 ;
 entry:

--- a/llvm/test/Transforms/VectorCombine/AArch64/shuffle-of-intrinsics.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/shuffle-of-intrinsics.ll
@@ -48,11 +48,13 @@ entry:
 define <8 x i1> @test4(<4 x float> %0, <4 x float> %1) {
 ; CHECK-LABEL: @test4(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    ret <8 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP0:%.*]], <4 x float> [[TMP1:%.*]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    [[TMP3:%.*]] = call <8 x i1> @llvm.is.fpclass.v8f32(<8 x float> [[TMP2]], i32 3)
+; CHECK-NEXT:    ret <8 x i1> [[TMP3]]
 ;
 entry:
-  %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 0)
-  %3 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %1, i32 0)
+  %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 3)
+  %3 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %1, i32 3)
   %4 = shufflevector <4 x i1> %2, <4 x i1> %3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x i1> %4
 }
@@ -60,11 +62,13 @@ entry:
 define <2 x i1> @test4b(<4 x float> %0, <4 x float> %1) {
 ; CHECK-LABEL: @test4b(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    ret <2 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP0:%.*]], <4 x float> [[TMP1:%.*]], <2 x i32> <i32 0, i32 4>
+; CHECK-NEXT:    [[TMP3:%.*]] = call <2 x i1> @llvm.is.fpclass.v2f32(<2 x float> [[TMP2]], i32 3)
+; CHECK-NEXT:    ret <2 x i1> [[TMP3]]
 ;
 entry:
-  %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 0)
-  %3 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %1, i32 0)
+  %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 3)
+  %3 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %1, i32 3)
   %4 = shufflevector <4 x i1> %2, <4 x i1> %3, <2 x i32> <i32 0, i32 4>
   ret <2 x i1> %4
 }

--- a/llvm/test/Transforms/VectorCombine/AArch64/shuffle-of-intrinsics.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/shuffle-of-intrinsics.ll
@@ -48,9 +48,7 @@ entry:
 define <8 x i1> @test4(<4 x float> %0, <4 x float> %1) {
 ; CHECK-LABEL: @test4(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP0:%.*]], <4 x float> [[TMP1:%.*]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:    [[TMP3:%.*]] = call <8 x i1> @llvm.is.fpclass.v8f32(<8 x float> [[TMP2]], i32 0)
-; CHECK-NEXT:    ret <8 x i1> [[TMP3]]
+; CHECK-NEXT:    ret <8 x i1> zeroinitializer
 ;
 entry:
   %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 0)
@@ -62,9 +60,7 @@ entry:
 define <2 x i1> @test4b(<4 x float> %0, <4 x float> %1) {
 ; CHECK-LABEL: @test4b(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP0:%.*]], <4 x float> [[TMP1:%.*]], <2 x i32> <i32 0, i32 4>
-; CHECK-NEXT:    [[TMP3:%.*]] = call <2 x i1> @llvm.is.fpclass.v2f32(<2 x float> [[TMP2]], i32 0)
-; CHECK-NEXT:    ret <2 x i1> [[TMP3]]
+; CHECK-NEXT:    ret <2 x i1> zeroinitializer
 ;
 entry:
   %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 0)

--- a/llvm/test/Transforms/VectorCombine/AArch64/shuffletoidentity.ll
+++ b/llvm/test/Transforms/VectorCombine/AArch64/shuffletoidentity.ll
@@ -534,8 +534,8 @@ define <4 x i64> @single_zext(<4 x i32> %x) {
 
 define <4 x i64> @not_zext(<4 x i32> %x) {
 ; CHECK-LABEL: @not_zext(
-; CHECK-NEXT:    [[REVSHUF:%.*]] = shufflevector <4 x i32> [[X]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
-; CHECK-NEXT:    [[ZEXT:%.*]] = zext <4 x i32> [[REVSHUF:%.*]] to <4 x i64>
+; CHECK-NEXT:    [[REVSHUF:%.*]] = shufflevector <4 x i32> [[X:%.*]], <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext <4 x i32> [[REVSHUF]] to <4 x i64>
 ; CHECK-NEXT:    ret <4 x i64> [[ZEXT]]
 ;
   %zext = zext <4 x i32> %x to <4 x i64>
@@ -745,10 +745,7 @@ define <4 x i64> @zext_add_chain(<4 x i32> %x) {
 define <8 x i8> @intrinsics_minmax(<8 x i8> %a, <8 x i8> %b) {
 ; CHECK-LABEL: @intrinsics_minmax(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call <8 x i8> @llvm.smin.v8i8(<8 x i8> [[A:%.*]], <8 x i8> [[B:%.*]])
-; CHECK-NEXT:    [[TMP2:%.*]] = call <8 x i8> @llvm.smax.v8i8(<8 x i8> [[TMP1]], <8 x i8> [[B]])
-; CHECK-NEXT:    [[TMP3:%.*]] = call <8 x i8> @llvm.umin.v8i8(<8 x i8> [[TMP2]], <8 x i8> [[B]])
-; CHECK-NEXT:    [[R:%.*]] = call <8 x i8> @llvm.umax.v8i8(<8 x i8> [[TMP3]], <8 x i8> [[B]])
-; CHECK-NEXT:    ret <8 x i8> [[R]]
+; CHECK-NEXT:    ret <8 x i8> [[B]]
 ;
   %ab = shufflevector <8 x i8> %a, <8 x i8> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
   %at = shufflevector <8 x i8> %a, <8 x i8> poison, <4 x i32> <i32 7, i32 6, i32 5, i32 4>
@@ -922,8 +919,7 @@ define <4 x i8> @singleop(<4 x i8> %a, <4 x i8> %b) {
 
 define <4 x i64> @cast_mismatched_types(<4 x i32> %x) {
 ; CHECK-LABEL: @cast_mismatched_types(
-; CHECK-SAME: <4 x i32> [[X:%.*]]) {
-; CHECK-NEXT:    [[ZEXT:%.*]] = zext <4 x i32> [[X]] to <4 x i64>
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext <4 x i32> [[X:%.*]] to <4 x i64>
 ; CHECK-NEXT:    ret <4 x i64> [[ZEXT]]
 ;
   %shuf = shufflevector <4 x i32> %x, <4 x i32> poison, <2 x i32> <i32 0, i32 2>

--- a/llvm/test/Transforms/VectorCombine/RISCV/shuffle-of-intrinsics.ll
+++ b/llvm/test/Transforms/VectorCombine/RISCV/shuffle-of-intrinsics.ll
@@ -48,9 +48,7 @@ entry:
 define <8 x i1> @test4(<4 x float> %0, <4 x float> %1) {
 ; CHECK-LABEL: @test4(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP0:%.*]], <4 x float> [[TMP1:%.*]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:    [[TMP3:%.*]] = call <8 x i1> @llvm.is.fpclass.v8f32(<8 x float> [[TMP2]], i32 0)
-; CHECK-NEXT:    ret <8 x i1> [[TMP3]]
+; CHECK-NEXT:    ret <8 x i1> zeroinitializer
 ;
 entry:
   %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 0)

--- a/llvm/test/Transforms/VectorCombine/RISCV/shuffle-of-intrinsics.ll
+++ b/llvm/test/Transforms/VectorCombine/RISCV/shuffle-of-intrinsics.ll
@@ -48,11 +48,13 @@ entry:
 define <8 x i1> @test4(<4 x float> %0, <4 x float> %1) {
 ; CHECK-LABEL: @test4(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    ret <8 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP0:%.*]], <4 x float> [[TMP1:%.*]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    [[TMP4:%.*]] = call <8 x i1> @llvm.is.fpclass.v8f32(<8 x float> [[TMP2]], i32 2)
+; CHECK-NEXT:    ret <8 x i1> [[TMP4]]
 ;
 entry:
-  %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 0)
-  %3 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %1, i32 0)
+  %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 2)
+  %3 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %1, i32 2)
   %4 = shufflevector <4 x i1> %2, <4 x i1> %3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x i1> %4
 }

--- a/llvm/test/Transforms/VectorCombine/X86/shuffle-of-intrinsics.ll
+++ b/llvm/test/Transforms/VectorCombine/X86/shuffle-of-intrinsics.ll
@@ -51,9 +51,7 @@ entry:
 define <8 x i1> @test4(<4 x float> %0, <4 x float> %1) {
 ; SSE-LABEL: @test4(
 ; SSE-NEXT:  entry:
-; SSE-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP0:%.*]], <4 x float> [[TMP1:%.*]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-; SSE-NEXT:    [[TMP3:%.*]] = call <8 x i1> @llvm.is.fpclass.v8f32(<8 x float> [[TMP2]], i32 0)
-; SSE-NEXT:    ret <8 x i1> [[TMP3]]
+; SSE-NEXT:    ret <8 x i1> zeroinitializer
 ;
 ; AVX-LABEL: @test4(
 ; AVX-NEXT:  entry:
@@ -72,9 +70,7 @@ entry:
 define <2 x i1> @test4b(<4 x float> %0, <4 x float> %1) {
 ; CHECK-LABEL: @test4b(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP0:%.*]], <4 x float> [[TMP1:%.*]], <2 x i32> <i32 0, i32 4>
-; CHECK-NEXT:    [[TMP3:%.*]] = call <2 x i1> @llvm.is.fpclass.v2f32(<2 x float> [[TMP2]], i32 0)
-; CHECK-NEXT:    ret <2 x i1> [[TMP3]]
+; CHECK-NEXT:    ret <2 x i1> zeroinitializer
 ;
 entry:
   %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 0)
@@ -224,8 +220,7 @@ define <8 x i32> @test_shared_operands(<4 x i32> %0, <4 x i32> %1) {
 ; CHECK-LABEL: @test_shared_operands(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x i32> [[TMP0:%.*]], <4 x i32> [[TMP1:%.*]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:    [[R:%.*]] = call <8 x i32> @llvm.smax.v8i32(<8 x i32> [[TMP2]], <8 x i32> [[TMP2]])
-; CHECK-NEXT:    ret <8 x i32> [[R]]
+; CHECK-NEXT:    ret <8 x i32> [[TMP2]]
 ;
 entry:
   %a = call <4 x i32> @llvm.smax.v4i32(<4 x i32> %0, <4 x i32> %0)

--- a/llvm/test/Transforms/VectorCombine/X86/shuffle-of-intrinsics.ll
+++ b/llvm/test/Transforms/VectorCombine/X86/shuffle-of-intrinsics.ll
@@ -51,18 +51,20 @@ entry:
 define <8 x i1> @test4(<4 x float> %0, <4 x float> %1) {
 ; SSE-LABEL: @test4(
 ; SSE-NEXT:  entry:
-; SSE-NEXT:    ret <8 x i1> zeroinitializer
+; SSE-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP0:%.*]], <4 x float> [[TMP1:%.*]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+; SSE-NEXT:    [[TMP3:%.*]] = call <8 x i1> @llvm.is.fpclass.v8f32(<8 x float> [[TMP2]], i32 4)
+; SSE-NEXT:    ret <8 x i1> [[TMP3]]
 ;
 ; AVX-LABEL: @test4(
 ; AVX-NEXT:  entry:
-; AVX-NEXT:    [[TMP2:%.*]] = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> [[TMP0:%.*]], i32 0)
-; AVX-NEXT:    [[TMP3:%.*]] = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> [[TMP1:%.*]], i32 0)
+; AVX-NEXT:    [[TMP2:%.*]] = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> [[TMP0:%.*]], i32 4)
+; AVX-NEXT:    [[TMP3:%.*]] = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> [[TMP1:%.*]], i32 4)
 ; AVX-NEXT:    [[TMP4:%.*]] = shufflevector <4 x i1> [[TMP2]], <4 x i1> [[TMP3]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
 ; AVX-NEXT:    ret <8 x i1> [[TMP4]]
 ;
 entry:
-  %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 0)
-  %3 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %1, i32 0)
+  %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 4)
+  %3 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %1, i32 4)
   %4 = shufflevector <4 x i1> %2, <4 x i1> %3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x i1> %4
 }
@@ -70,11 +72,13 @@ entry:
 define <2 x i1> @test4b(<4 x float> %0, <4 x float> %1) {
 ; CHECK-LABEL: @test4b(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    ret <2 x i1> zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP0:%.*]], <4 x float> [[TMP1:%.*]], <2 x i32> <i32 0, i32 4>
+; CHECK-NEXT:    [[TMP3:%.*]] = call <2 x i1> @llvm.is.fpclass.v2f32(<2 x float> [[TMP2]], i32 4)
+; CHECK-NEXT:    ret <2 x i1> [[TMP3]]
 ;
 entry:
-  %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 0)
-  %3 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %1, i32 0)
+  %2 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %0, i32 4)
+  %3 = call <4 x i1> @llvm.is.fpclass.v4f32(<4 x float> %1, i32 4)
   %4 = shufflevector <4 x i1> %2, <4 x i1> %3, <2 x i32> <i32 0, i32 4>
   ret <2 x i1> %4
 }

--- a/polly/test/CodeGen/scop_expander_insert_point.ll
+++ b/polly/test/CodeGen/scop_expander_insert_point.ll
@@ -3,8 +3,7 @@
 ; CHECK:      entry:
 ; CHECK-NEXT:   %outvalue.141.phiops = alloca i64
 ; CHECK-NEXT:   %.preload.s2a = alloca i8
-; CHECK-NEXT:   %umax = call i32 @llvm.umax.i32(i32 undef, i32 1)
-; CHECK-NEXT:   %divpolly = sdiv i32 undef, %umax
+; CHECK-NEXT:   %divpolly = sdiv i32 undef, -1
 ; CHECK-NEXT:   %div = sdiv i32 undef, undef
 ;
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"


### PR DESCRIPTION
Includes changes to guard against a nullptr TLI and Call. TargetFold or InstSimplify fold in IRBuilderBase::CreateIntrinsic, in the same way we fold in Create(Unary|Binary)Intrinsic.