### PR TITLE
[Driver][SYCL] Treat stdin as C++ when -fsycl is active

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3134,6 +3134,8 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
       Diag(clang::diag::warn_drv_unused_x) << LastXArg->getValue();
   }
 
+  bool IsSYCL = Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false);
+
   for (Arg *A : Args) {
     if (A->getOption().getKind() == Option::InputClass) {
       const char *Value = A->getValue();
@@ -3151,6 +3153,8 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
             Ty = types::TY_Fortran;
           } else if (IsDXCMode()) {
             Ty = types::TY_HLSL;
+          } else if (IsSYCL) {
+            Ty = types::TY_CXX;
           } else {
             // If running with -E, treat as a C input (this changes the
             // builtin macros, for example). This may be overridden by -ObjC

--- a/clang/test/Driver/sycl-print-internal-defines.cpp
+++ b/clang/test/Driver/sycl-print-internal-defines.cpp
@@ -1,0 +1,12 @@
+// UNSUPPORTED: system-windows
+// Test that clang can print defines in SYCL mode.
+// REQUIRES: x86-registered-target
+
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -dM -E %s 2>&1 \
+// RUN: | FileCheck --check-prefix CHECK-PRINT-INTERNAL-DEFINES %s
+// CHECK-PRINT-INTERNAL-DEFINES: #define
+
+// Printing defines also works when input is stdin.
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -dM -E - < /dev/null 2>&1 \
+// RUN: | FileCheck --check-prefixes=CHECK-PRINT-INTERNAL-DEFINES,CHECK-NO-ERROR %s
+// CHECK-NO-ERROR-NOT: error:

--- a/clang/test/Driver/sycl-print-internal-defines.cpp
+++ b/clang/test/Driver/sycl-print-internal-defines.cpp
@@ -1,12 +1,8 @@
-// UNSUPPORTED: system-windows
 // Test that clang can print defines in SYCL mode.
-// REQUIRES: x86-registered-target
 
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -dM -E %s 2>&1 \
-// RUN: | FileCheck --check-prefix CHECK-PRINT-INTERNAL-DEFINES %s
+// RUN: %clangxx -fsycl -dM -E %s 2>&1 | FileCheck --check-prefix CHECK-PRINT-INTERNAL-DEFINES %s
 // CHECK-PRINT-INTERNAL-DEFINES: #define
 
 // Printing defines also works when input is stdin.
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -dM -E - < /dev/null 2>&1 \
-// RUN: | FileCheck --check-prefixes=CHECK-PRINT-INTERNAL-DEFINES,CHECK-NO-ERROR %s
+// RUN: %clangxx -fsycl -dM -E - < /dev/null 2>&1 | FileCheck --check-prefixes=CHECK-PRINT-INTERNAL-DEFINES,CHECK-NO-ERROR %s
 // CHECK-NO-ERROR-NOT: error:


### PR DESCRIPTION
1723b7a30145 added a frontend check that rejects C inputs when SYCL mode is active (since SYCL requires C++). The stdin path in BuildInputs hardcoded TY_C regardless of driver mode, so `-fsycl -dM -E -` would pass -x c to cc1 and trigger the new diagnostic.

Fix: use TY_CXX for stdin when IsSYCL.

Also, upstream a downstream test that fails due to 1723b7a30145.