### PR TITLE
[X86] Use the Divider resource consistently for scalar integer division

### DIFF
--- a/llvm/lib/Target/X86/X86SchedBroadwell.td
+++ b/llvm/lib/Target/X86/X86SchedBroadwell.td
@@ -212,24 +212,15 @@ defm : BWWriteResPair<WriteBEXTR, [BWPort06,BWPort15], 2, [1,1], 2>;
 defm : BWWriteResPair<WriteBLS,   [BWPort15], 1>;
 defm : BWWriteResPair<WriteBZHI,  [BWPort15], 1>;
 
-// TODO: Why isn't the BWDivider used consistently?
-defm : X86WriteRes<WriteDiv8,     [BWPort0, BWDivider], 25, [1, 10], 1>;
-defm : X86WriteRes<WriteDiv16,    [BWPort0,BWPort1,BWPort5,BWPort6,BWPort01,BWPort0156], 80, [7,7,3,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv32,    [BWPort0,BWPort1,BWPort5,BWPort6,BWPort01,BWPort0156], 80, [7,7,3,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv64,    [BWPort0,BWPort1,BWPort5,BWPort6,BWPort01,BWPort0156], 80, [7,7,3,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv8Ld,   [BWPort0,BWPort1,BWPort5,BWPort23,BWPort0156], 34, [2,2,2,1,1], 8>;
-defm : X86WriteRes<WriteDiv16Ld,  [BWPort0,BWPort1,BWPort5,BWPort23,BWPort0156], 34, [2,2,2,1,1], 8>;
-defm : X86WriteRes<WriteDiv32Ld,  [BWPort0,BWPort1,BWPort5,BWPort23,BWPort0156], 34, [2,2,2,1,1], 8>;
-defm : X86WriteRes<WriteDiv64Ld,  [BWPort0,BWPort1,BWPort5,BWPort23,BWPort0156], 34, [2,2,2,1,1], 8>;
+defm : BWWriteResPair<WriteDiv8,  [BWPort0, BWDivider], 24, [1,9],   9>;
+defm : BWWriteResPair<WriteDiv16, [BWPort0, BWDivider], 25, [1,9],  11>;
+defm : BWWriteResPair<WriteDiv32, [BWPort0, BWDivider], 28, [1,9],  10>;
+defm : BWWriteResPair<WriteDiv64, [BWPort0, BWDivider], 92, [1,21], 36>;
 
-defm : X86WriteRes<WriteIDiv8,    [BWPort0, BWDivider], 25, [1,10], 1>;
-defm : X86WriteRes<WriteIDiv16,   [BWPort0, BWDivider], 25, [1,10], 1>;
-defm : X86WriteRes<WriteIDiv32,   [BWPort0, BWDivider], 25, [1,10], 1>;
-defm : X86WriteRes<WriteIDiv64,   [BWPort0, BWDivider], 25, [1,10], 1>;
-defm : X86WriteRes<WriteIDiv8Ld,  [BWPort0,BWPort1,BWPort5,BWPort23,BWPort0156], 35, [2,2,2,1,1], 8>;
-defm : X86WriteRes<WriteIDiv16Ld, [BWPort0,BWPort1,BWPort5,BWPort23,BWPort0156], 35, [2,2,2,1,1], 8>;
-defm : X86WriteRes<WriteIDiv32Ld, [BWPort0,BWPort1,BWPort5,BWPort23,BWPort0156], 35, [2,2,2,1,1], 8>;
-defm : X86WriteRes<WriteIDiv64Ld, [BWPort0,BWPort1,BWPort5,BWPort23,BWPort0156], 35, [2,2,2,1,1], 8>;
+defm : BWWriteResPair<WriteIDiv8,  [BWPort0, BWDivider], 24, [1,6],  9>;
+defm : BWWriteResPair<WriteIDiv16, [BWPort0, BWDivider], 26, [1,6], 10>;
+defm : BWWriteResPair<WriteIDiv32, [BWPort0, BWDivider], 28, [1,6],  9>;
+defm : BWWriteResPair<WriteIDiv64, [BWPort0, BWDivider], 100, [1,24], 59>;
 
 // Floating point. This covers both scalar and vector operations.
 defm : X86WriteRes<WriteFLD0,          [BWPort01], 1, [1], 1>;

--- a/llvm/lib/Target/X86/X86SchedBroadwell.td
+++ b/llvm/lib/Target/X86/X86SchedBroadwell.td
@@ -212,15 +212,15 @@ defm : BWWriteResPair<WriteBEXTR, [BWPort06,BWPort15], 2, [1,1], 2>;
 defm : BWWriteResPair<WriteBLS,   [BWPort15], 1>;
 defm : BWWriteResPair<WriteBZHI,  [BWPort15], 1>;
 
-defm : BWWriteResPair<WriteDiv8,  [BWPort0, BWDivider], 24, [1,9],   9>;
-defm : BWWriteResPair<WriteDiv16, [BWPort0, BWDivider], 25, [1,9],  11>;
-defm : BWWriteResPair<WriteDiv32, [BWPort0, BWDivider], 28, [1,9],  10>;
-defm : BWWriteResPair<WriteDiv64, [BWPort0, BWDivider], 92, [1,21], 36>;
+defm : BWWriteResPair<WriteDiv8,  [BWPort0, BWPort1, BWPort5, BWPort06, BWPort0156, BWDivider], 24, [2, 2, 2, 1, 2, 9],   9>;
+defm : BWWriteResPair<WriteDiv16, [BWPort0, BWPort1, BWPort5, BWPort06, BWPort15, BWPort0156, BWDivider], 25, [2, 2, 2, 2, 1, 2, 9],  11>;
+defm : BWWriteResPair<WriteDiv32, [BWPort0, BWPort1, BWPort5, BWPort06, BWPort15, BWPort0156, BWDivider], 28, [2, 2, 2, 2, 1, 1, 9],  10>;
+defm : BWWriteResPair<WriteDiv64, [BWPort0, BWPort1, BWPort5, BWPort06, BWPort015, BWPort0156, BWDivider], 92, [2, 3, 3, 12, 7, 5, 21], 36>;
 
-defm : BWWriteResPair<WriteIDiv8,  [BWPort0, BWDivider], 24, [1,6],  9>;
-defm : BWWriteResPair<WriteIDiv16, [BWPort0, BWDivider], 26, [1,6], 10>;
-defm : BWWriteResPair<WriteIDiv32, [BWPort0, BWDivider], 28, [1,6],  9>;
-defm : BWWriteResPair<WriteIDiv64, [BWPort0, BWDivider], 100, [1,24], 59>;
+defm : BWWriteResPair<WriteIDiv8,  [BWPort0, BWPort1, BWPort5, BWPort0156, BWDivider], 24, [2, 2, 2, 3, 6],  9>;
+defm : BWWriteResPair<WriteIDiv16, [BWPort0, BWPort1, BWPort5, BWPort06, BWPort15, BWPort0156, BWDivider], 26, [2, 2, 2, 1, 1, 2, 6], 10>;
+defm : BWWriteResPair<WriteIDiv32, [BWPort0, BWPort1, BWPort5, BWPort06, BWPort15, BWPort0156, BWDivider], 28, [2, 2, 2, 1, 1, 1, 6],  9>;
+defm : BWWriteResPair<WriteIDiv64, [BWPort0, BWPort1, BWPort5, BWPort01, BWPort06, BWPort15, BWPort015, BWPort0156, BWDivider], 100, [2, 3, 5, 7, 26, 2, 11, 1, 24], 59>;
 
 // Floating point. This covers both scalar and vector operations.
 defm : X86WriteRes<WriteFLD0,          [BWPort01], 1, [1], 1>;

--- a/llvm/lib/Target/X86/X86SchedHaswell.td
+++ b/llvm/lib/Target/X86/X86SchedHaswell.td
@@ -214,15 +214,15 @@ defm : HWWriteResPair<WriteBEXTR, [HWPort06,HWPort15], 2, [1,1], 2>;
 defm : HWWriteResPair<WriteBLS,   [HWPort15], 1>;
 defm : HWWriteResPair<WriteBZHI,  [HWPort15], 1>;
 
-defm : HWWriteResPair<WriteDiv8,  [HWPort0, HWDivider], 24, [1,9],   9>;
-defm : HWWriteResPair<WriteDiv16, [HWPort0, HWDivider], 25, [1,9],  11>;
-defm : HWWriteResPair<WriteDiv32, [HWPort0, HWDivider], 28, [1,9],  10>;
-defm : HWWriteResPair<WriteDiv64, [HWPort0, HWDivider], 94, [1,21], 36>;
+defm : HWWriteResPair<WriteDiv8,  [HWPort0, HWPort1, HWPort5, HWPort06, HWPort0156, HWDivider], 24, [2, 2, 2, 1, 2, 9],   9>;
+defm : HWWriteResPair<WriteDiv16, [HWPort0, HWPort1, HWPort5, HWPort06, HWPort15, HWPort0156, HWDivider], 25, [2, 2, 2, 2, 1, 2, 9],  11>;
+defm : HWWriteResPair<WriteDiv32, [HWPort0, HWPort1, HWPort5, HWPort06, HWPort15, HWPort0156, HWDivider], 28, [2, 2, 2, 2, 1, 1, 9],  10>;
+defm : HWWriteResPair<WriteDiv64, [HWPort0, HWPort1, HWPort5, HWPort06, HWPort015, HWPort0156, HWDivider], 94, [2, 3, 3, 12, 8, 4, 21], 36>;
 
-defm : HWWriteResPair<WriteIDiv8,  [HWPort0, HWDivider], 24, [1,8],  9>;
-defm : HWWriteResPair<WriteIDiv16, [HWPort0, HWDivider], 25, [1,8], 10>;
-defm : HWWriteResPair<WriteIDiv32, [HWPort0, HWDivider], 28, [1,8],  9>;
-defm : HWWriteResPair<WriteIDiv64, [HWPort0, HWDivider], 101, [1,24], 59>;
+defm : HWWriteResPair<WriteIDiv8,  [HWPort0, HWPort1, HWPort5, HWPort0156, HWDivider], 24, [2, 2, 2, 3, 8],  9>;
+defm : HWWriteResPair<WriteIDiv16, [HWPort0, HWPort1, HWPort5, HWPort06, HWPort15, HWPort0156, HWDivider], 25, [2, 2, 2, 1, 1, 2, 8], 10>;
+defm : HWWriteResPair<WriteIDiv32, [HWPort0, HWPort1, HWPort5, HWPort06, HWPort15, HWPort0156, HWDivider], 28, [2, 2, 2, 1, 1, 1, 8],  9>;
+defm : HWWriteResPair<WriteIDiv64, [HWPort0, HWPort1, HWPort5, HWPort01, HWPort06, HWPort15, HWPort015, HWPort0156, HWDivider], 101, [2, 3, 5, 7, 26, 1, 12, 1, 24], 59>;
 
 // Floating point. This covers both scalar and vector operations.
 defm : X86WriteRes<WriteFLD0,          [HWPort01], 1, [1], 1>;

--- a/llvm/lib/Target/X86/X86SchedHaswell.td
+++ b/llvm/lib/Target/X86/X86SchedHaswell.td
@@ -214,24 +214,15 @@ defm : HWWriteResPair<WriteBEXTR, [HWPort06,HWPort15], 2, [1,1], 2>;
 defm : HWWriteResPair<WriteBLS,   [HWPort15], 1>;
 defm : HWWriteResPair<WriteBZHI,  [HWPort15], 1>;
 
-// TODO: Why isn't the HWDivider used?
-defm : X86WriteRes<WriteDiv8,     [HWPort0,HWPort1,HWPort5,HWPort6], 22, [], 9>;
-defm : X86WriteRes<WriteDiv16,    [HWPort0,HWPort1,HWPort5,HWPort6,HWPort01,HWPort0156], 98, [7,7,3,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv32,    [HWPort0,HWPort1,HWPort5,HWPort6,HWPort01,HWPort0156], 98, [7,7,3,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv64,    [HWPort0,HWPort1,HWPort5,HWPort6,HWPort01,HWPort0156], 98, [7,7,3,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv8Ld,   [HWPort0,HWPort23,HWDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteDiv16Ld,  [HWPort0,HWPort23,HWDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteDiv32Ld,  [HWPort0,HWPort23,HWDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteDiv64Ld,  [HWPort0,HWPort23,HWDivider], 29, [1,1,10], 2>;
+defm : HWWriteResPair<WriteDiv8,  [HWPort0, HWDivider], 24, [1,9],   9>;
+defm : HWWriteResPair<WriteDiv16, [HWPort0, HWDivider], 25, [1,9],  11>;
+defm : HWWriteResPair<WriteDiv32, [HWPort0, HWDivider], 28, [1,9],  10>;
+defm : HWWriteResPair<WriteDiv64, [HWPort0, HWDivider], 94, [1,21], 36>;
 
-defm : X86WriteRes<WriteIDiv8,    [HWPort0,HWPort1,HWPort5,HWPort6], 23, [], 9>;
-defm : X86WriteRes<WriteIDiv16,   [HWPort0,HWPort1,HWPort5,HWPort6,HWPort06,HWPort0156], 112, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv32,   [HWPort0,HWPort1,HWPort5,HWPort6,HWPort06,HWPort0156], 112, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv64,   [HWPort0,HWPort1,HWPort5,HWPort6,HWPort06,HWPort0156], 112, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv8Ld,  [HWPort0,HWPort23,HWDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteIDiv16Ld, [HWPort0,HWPort23,HWDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteIDiv32Ld, [HWPort0,HWPort23,HWDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteIDiv64Ld, [HWPort0,HWPort23,HWDivider], 29, [1,1,10], 2>;
+defm : HWWriteResPair<WriteIDiv8,  [HWPort0, HWDivider], 24, [1,8],  9>;
+defm : HWWriteResPair<WriteIDiv16, [HWPort0, HWDivider], 25, [1,8], 10>;
+defm : HWWriteResPair<WriteIDiv32, [HWPort0, HWDivider], 28, [1,8],  9>;
+defm : HWWriteResPair<WriteIDiv64, [HWPort0, HWDivider], 101, [1,24], 59>;
 
 // Floating point. This covers both scalar and vector operations.
 defm : X86WriteRes<WriteFLD0,          [HWPort01], 1, [1], 1>;

--- a/llvm/lib/Target/X86/X86SchedIceLake.td
+++ b/llvm/lib/Target/X86/X86SchedIceLake.td
@@ -148,15 +148,15 @@ defm : X86WriteRes<WriteCMPXCHG,[ICXPort06, ICXPort0156], 5, [2,3], 5>;
 defm : X86WriteRes<WriteCMPXCHGRMW,[ICXPort23,ICXPort06,ICXPort0156,ICXPort78,ICXPort49], 8, [1,2,1,1,1], 6>;
 defm : X86WriteRes<WriteXCHG,       [ICXPort0156], 2, [3], 3>;
 
-defm : ICXWriteResPair<WriteDiv8,  [ICXPort0, ICXDivider], 15, [1,6],  4>;
-defm : ICXWriteResPair<WriteDiv16, [ICXPort0, ICXDivider], 16, [1,6],  6>;
-defm : ICXWriteResPair<WriteDiv32, [ICXPort0, ICXDivider], 15, [1,6],  4>;
-defm : ICXWriteResPair<WriteDiv64, [ICXPort0, ICXDivider], 18, [1,10], 4>;
+defm : ICXWriteResPair<WriteDiv8,  [ICXPort1, ICXPort0156, ICXDivider], 15, [2, 2, 6],  4>;
+defm : ICXWriteResPair<WriteDiv16, [ICXPort1, ICXPort15, ICXPort0156, ICXDivider], 16, [2, 1, 3, 6],  6>;
+defm : ICXWriteResPair<WriteDiv32, [ICXPort1, ICXPort15, ICXPort0156, ICXDivider], 15, [2, 1, 1, 6],  4>;
+defm : ICXWriteResPair<WriteDiv64, [ICXPort1, ICXPort0156, ICXDivider], 18, [3, 1, 10], 4>;
 
-defm : ICXWriteResPair<WriteIDiv8,  [ICXPort0, ICXDivider], 15, [1,6],  4>;
-defm : ICXWriteResPair<WriteIDiv16, [ICXPort0, ICXDivider], 16, [1,6],  6>;
-defm : ICXWriteResPair<WriteIDiv32, [ICXPort0, ICXDivider], 15, [1,6],  4>;
-defm : ICXWriteResPair<WriteIDiv64, [ICXPort0, ICXDivider], 18, [1,10], 4>;
+defm : ICXWriteResPair<WriteIDiv8,  [ICXPort1, ICXPort0156, ICXDivider], 15, [2, 2, 6],  4>;
+defm : ICXWriteResPair<WriteIDiv16, [ICXPort1, ICXPort15, ICXPort0156, ICXDivider], 16, [2, 1, 3, 6],  6>;
+defm : ICXWriteResPair<WriteIDiv32, [ICXPort1, ICXPort15, ICXPort0156, ICXDivider], 15, [2, 1, 1, 6],  4>;
+defm : ICXWriteResPair<WriteIDiv64, [ICXPort1, ICXPort0156, ICXDivider], 18, [3, 1, 10], 4>;
 
 defm : ICXWriteResPair<WriteCRC32, [ICXPort1], 3>;
 

--- a/llvm/lib/Target/X86/X86SchedIceLake.td
+++ b/llvm/lib/Target/X86/X86SchedIceLake.td
@@ -148,23 +148,15 @@ defm : X86WriteRes<WriteCMPXCHG,[ICXPort06, ICXPort0156], 5, [2,3], 5>;
 defm : X86WriteRes<WriteCMPXCHGRMW,[ICXPort23,ICXPort06,ICXPort0156,ICXPort78,ICXPort49], 8, [1,2,1,1,1], 6>;
 defm : X86WriteRes<WriteXCHG,       [ICXPort0156], 2, [3], 3>;
 
-// TODO: Why isn't the ICXDivider used?
-defm : ICXWriteResPair<WriteDiv8,  [ICXPort0, ICXDivider], 25, [1,10], 1, 4>;
-defm : X86WriteRes<WriteDiv16,     [ICXPort0,ICXPort1,ICXPort5,ICXPort6,ICXPort05,ICXPort0156], 76, [7,2,8,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv32,     [ICXPort0,ICXPort1,ICXPort5,ICXPort6,ICXPort05,ICXPort0156], 76, [7,2,8,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv64,     [ICXPort0,ICXPort1,ICXPort5,ICXPort6,ICXPort05,ICXPort0156], 76, [7,2,8,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv16Ld,   [ICXPort0,ICXPort23,ICXDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteDiv32Ld,   [ICXPort0,ICXPort23,ICXDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteDiv64Ld,   [ICXPort0,ICXPort23,ICXDivider], 29, [1,1,10], 2>;
+defm : ICXWriteResPair<WriteDiv8,  [ICXPort0, ICXDivider], 15, [1,6],  4>;
+defm : ICXWriteResPair<WriteDiv16, [ICXPort0, ICXDivider], 16, [1,6],  6>;
+defm : ICXWriteResPair<WriteDiv32, [ICXPort0, ICXDivider], 15, [1,6],  4>;
+defm : ICXWriteResPair<WriteDiv64, [ICXPort0, ICXDivider], 18, [1,10], 4>;
 
-defm : X86WriteRes<WriteIDiv8,     [ICXPort0, ICXDivider], 25, [1,10], 1>;
-defm : X86WriteRes<WriteIDiv16,    [ICXPort0,ICXPort1,ICXPort5,ICXPort6,ICXPort06,ICXPort0156], 102, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv32,    [ICXPort0,ICXPort1,ICXPort5,ICXPort6,ICXPort06,ICXPort0156], 102, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv64,    [ICXPort0,ICXPort1,ICXPort5,ICXPort6,ICXPort06,ICXPort0156], 102, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv8Ld,   [ICXPort0,ICXPort5,ICXPort23,ICXPort0156], 28, [2,4,1,1], 8>;
-defm : X86WriteRes<WriteIDiv16Ld,  [ICXPort0,ICXPort5,ICXPort23,ICXPort0156], 28, [2,4,1,1], 8>;
-defm : X86WriteRes<WriteIDiv32Ld,  [ICXPort0,ICXPort5,ICXPort23,ICXPort0156], 28, [2,4,1,1], 8>;
-defm : X86WriteRes<WriteIDiv64Ld,  [ICXPort0,ICXPort5,ICXPort23,ICXPort0156], 28, [2,4,1,1], 8>;
+defm : ICXWriteResPair<WriteIDiv8,  [ICXPort0, ICXDivider], 15, [1,6],  4>;
+defm : ICXWriteResPair<WriteIDiv16, [ICXPort0, ICXDivider], 16, [1,6],  6>;
+defm : ICXWriteResPair<WriteIDiv32, [ICXPort0, ICXDivider], 15, [1,6],  4>;
+defm : ICXWriteResPair<WriteIDiv64, [ICXPort0, ICXDivider], 18, [1,10], 4>;
 
 defm : ICXWriteResPair<WriteCRC32, [ICXPort1], 3>;
 

--- a/llvm/lib/Target/X86/X86SchedSkylakeClient.td
+++ b/llvm/lib/Target/X86/X86SchedSkylakeClient.td
@@ -146,23 +146,15 @@ defm : X86WriteRes<WriteCMPXCHG,[SKLPort06, SKLPort0156], 5, [2,3], 5>;
 defm : X86WriteRes<WriteCMPXCHGRMW,[SKLPort23,SKLPort06,SKLPort0156,SKLPort237,SKLPort4], 8, [1,2,1,1,1], 6>;
 defm : X86WriteRes<WriteXCHG, [SKLPort0156], 2, [3], 3>;
 
-// TODO: Why isn't the SKLDivider used?
-defm : SKLWriteResPair<WriteDiv8,   [SKLPort0,SKLDivider], 25, [1,10], 1, 4>;
-defm : X86WriteRes<WriteDiv16,      [SKLPort0,SKLPort1,SKLPort5,SKLPort6,SKLPort05,SKLPort0156], 76, [7,2,8,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv32,      [SKLPort0,SKLPort1,SKLPort5,SKLPort6,SKLPort05,SKLPort0156], 76, [7,2,8,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv64,      [SKLPort0,SKLPort1,SKLPort5,SKLPort6,SKLPort05,SKLPort0156], 76, [7,2,8,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv16Ld,    [SKLPort0,SKLPort23,SKLDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteDiv32Ld,    [SKLPort0,SKLPort23,SKLDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteDiv64Ld,    [SKLPort0,SKLPort23,SKLDivider], 29, [1,1,10], 2>;
+defm : SKLWriteResPair<WriteDiv8,  [SKLPort0, SKLDivider], 25, [1,6],  10>;
+defm : SKLWriteResPair<WriteDiv16, [SKLPort0, SKLDivider], 24, [1,6],  10>;
+defm : SKLWriteResPair<WriteDiv32, [SKLPort0, SKLDivider], 28, [1,6],  10>;
+defm : SKLWriteResPair<WriteDiv64, [SKLPort0, SKLDivider], 90, [1,21], 36>;
 
-defm : X86WriteRes<WriteIDiv8,    [SKLPort0,SKLDivider], 25, [1,10], 1>;
-defm : X86WriteRes<WriteIDiv16,   [SKLPort0,SKLPort1,SKLPort5,SKLPort6,SKLPort06,SKLPort0156], 102, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv32,   [SKLPort0,SKLPort1,SKLPort5,SKLPort6,SKLPort06,SKLPort0156], 102, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv64,   [SKLPort0,SKLPort1,SKLPort5,SKLPort6,SKLPort06,SKLPort0156], 102, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv8Ld,  [SKLPort0,SKLPort5,SKLPort23,SKLPort0156], 28, [2,4,1,1], 8>;
-defm : X86WriteRes<WriteIDiv16Ld, [SKLPort0,SKLPort5,SKLPort23,SKLPort0156], 28, [2,4,1,1], 8>;
-defm : X86WriteRes<WriteIDiv32Ld, [SKLPort0,SKLPort5,SKLPort23,SKLPort0156], 28, [2,4,1,1], 8>;
-defm : X86WriteRes<WriteIDiv64Ld, [SKLPort0,SKLPort5,SKLPort23,SKLPort0156], 28, [2,4,1,1], 8>;
+defm : SKLWriteResPair<WriteIDiv8,  [SKLPort0, SKLDivider], 25, [1,6],  11>;
+defm : SKLWriteResPair<WriteIDiv16, [SKLPort0, SKLDivider], 24, [1,6],  10>;
+defm : SKLWriteResPair<WriteIDiv32, [SKLPort0, SKLDivider], 28, [1,6],  10>;
+defm : SKLWriteResPair<WriteIDiv64, [SKLPort0, SKLDivider], 96, [1,24], 57>;
 
 defm : SKLWriteResPair<WriteCRC32, [SKLPort1], 3>;
 

--- a/llvm/lib/Target/X86/X86SchedSkylakeClient.td
+++ b/llvm/lib/Target/X86/X86SchedSkylakeClient.td
@@ -146,15 +146,15 @@ defm : X86WriteRes<WriteCMPXCHG,[SKLPort06, SKLPort0156], 5, [2,3], 5>;
 defm : X86WriteRes<WriteCMPXCHGRMW,[SKLPort23,SKLPort06,SKLPort0156,SKLPort237,SKLPort4], 8, [1,2,1,1,1], 6>;
 defm : X86WriteRes<WriteXCHG, [SKLPort0156], 2, [3], 3>;
 
-defm : SKLWriteResPair<WriteDiv8,  [SKLPort0, SKLDivider], 25, [1,6],  10>;
-defm : SKLWriteResPair<WriteDiv16, [SKLPort0, SKLDivider], 24, [1,6],  10>;
-defm : SKLWriteResPair<WriteDiv32, [SKLPort0, SKLDivider], 28, [1,6],  10>;
-defm : SKLWriteResPair<WriteDiv64, [SKLPort0, SKLDivider], 90, [1,21], 36>;
+defm : SKLWriteResPair<WriteDiv8,  [SKLPort0, SKLPort5, SKLPort06, SKLPort15, SKLPort0156, SKLDivider], 25, [2, 4, 1, 1, 2, 6],  10>;
+defm : SKLWriteResPair<WriteDiv16, [SKLPort0, SKLPort5, SKLPort06, SKLPort15, SKLPort0156, SKLDivider], 24, [2, 4, 1, 1, 2, 6],  10>;
+defm : SKLWriteResPair<WriteDiv32, [SKLPort0, SKLPort5, SKLPort06, SKLPort15, SKLPort0156, SKLDivider], 28, [2, 4, 1, 1, 2, 6],  10>;
+defm : SKLWriteResPair<WriteDiv64, [SKLPort0, SKLPort1, SKLPort5, SKLPort05, SKLPort06, SKLPort015, SKLPort0156, SKLDivider], 90, [2, 1, 3, 1, 13, 8, 5, 21], 36>;
 
-defm : SKLWriteResPair<WriteIDiv8,  [SKLPort0, SKLDivider], 25, [1,6],  11>;
-defm : SKLWriteResPair<WriteIDiv16, [SKLPort0, SKLDivider], 24, [1,6],  10>;
-defm : SKLWriteResPair<WriteIDiv32, [SKLPort0, SKLDivider], 28, [1,6],  10>;
-defm : SKLWriteResPair<WriteIDiv64, [SKLPort0, SKLDivider], 96, [1,24], 57>;
+defm : SKLWriteResPair<WriteIDiv8,  [SKLPort0, SKLPort5, SKLPort06, SKLPort15, SKLPort0156, SKLDivider], 25, [2, 4, 1, 1, 3, 6],  11>;
+defm : SKLWriteResPair<WriteIDiv16, [SKLPort0, SKLPort5, SKLPort06, SKLPort15, SKLPort0156, SKLDivider], 24, [2, 4, 1, 1, 2, 6],  10>;
+defm : SKLWriteResPair<WriteIDiv32, [SKLPort0, SKLPort5, SKLPort06, SKLPort15, SKLPort0156, SKLDivider], 28, [2, 4, 1, 1, 2, 6],  10>;
+defm : SKLWriteResPair<WriteIDiv64, [SKLPort0, SKLPort1, SKLPort5, SKLPort01, SKLPort05, SKLPort06, SKLPort15, SKLPort015, SKLDivider], 96, [2, 1, 3, 5, 6, 27, 4, 10, 24], 57>;
 
 defm : SKLWriteResPair<WriteCRC32, [SKLPort1], 3>;
 

--- a/llvm/lib/Target/X86/X86SchedSkylakeServer.td
+++ b/llvm/lib/Target/X86/X86SchedSkylakeServer.td
@@ -147,23 +147,15 @@ defm : X86WriteRes<WriteCMPXCHG,[SKXPort06, SKXPort0156], 5, [2,3], 5>;
 defm : X86WriteRes<WriteCMPXCHGRMW,[SKXPort23,SKXPort06,SKXPort0156,SKXPort237,SKXPort4], 8, [1,2,1,1,1], 6>;
 defm : X86WriteRes<WriteXCHG,       [SKXPort0156], 2, [3], 3>;
 
-// TODO: Why isn't the SKXDivider used?
-defm : SKXWriteResPair<WriteDiv8,  [SKXPort0, SKXDivider], 25, [1,10], 1, 4>;
-defm : X86WriteRes<WriteDiv16,     [SKXPort0,SKXPort1,SKXPort5,SKXPort6,SKXPort05,SKXPort0156], 76, [7,2,8,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv32,     [SKXPort0,SKXPort1,SKXPort5,SKXPort6,SKXPort05,SKXPort0156], 76, [7,2,8,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv64,     [SKXPort0,SKXPort1,SKXPort5,SKXPort6,SKXPort05,SKXPort0156], 76, [7,2,8,3,1,11], 32>;
-defm : X86WriteRes<WriteDiv16Ld,   [SKXPort0,SKXPort23,SKXDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteDiv32Ld,   [SKXPort0,SKXPort23,SKXDivider], 29, [1,1,10], 2>;
-defm : X86WriteRes<WriteDiv64Ld,   [SKXPort0,SKXPort23,SKXDivider], 29, [1,1,10], 2>;
+defm : SKXWriteResPair<WriteDiv8,  [SKXPort0, SKXDivider], 25, [1,6],  10>;
+defm : SKXWriteResPair<WriteDiv16, [SKXPort0, SKXDivider], 24, [1,6],  10>;
+defm : SKXWriteResPair<WriteDiv32, [SKXPort0, SKXDivider], 28, [1,6],  10>;
+defm : SKXWriteResPair<WriteDiv64, [SKXPort0, SKXDivider], 89, [1,21], 36>;
 
-defm : X86WriteRes<WriteIDiv8,     [SKXPort0, SKXDivider], 25, [1,10], 1>;
-defm : X86WriteRes<WriteIDiv16,    [SKXPort0,SKXPort1,SKXPort5,SKXPort6,SKXPort06,SKXPort0156], 102, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv32,    [SKXPort0,SKXPort1,SKXPort5,SKXPort6,SKXPort06,SKXPort0156], 102, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv64,    [SKXPort0,SKXPort1,SKXPort5,SKXPort6,SKXPort06,SKXPort0156], 102, [4,2,4,8,14,34], 66>;
-defm : X86WriteRes<WriteIDiv8Ld,   [SKXPort0,SKXPort5,SKXPort23,SKXPort0156], 28, [2,4,1,1], 8>;
-defm : X86WriteRes<WriteIDiv16Ld,  [SKXPort0,SKXPort5,SKXPort23,SKXPort0156], 28, [2,4,1,1], 8>;
-defm : X86WriteRes<WriteIDiv32Ld,  [SKXPort0,SKXPort5,SKXPort23,SKXPort0156], 28, [2,4,1,1], 8>;
-defm : X86WriteRes<WriteIDiv64Ld,  [SKXPort0,SKXPort5,SKXPort23,SKXPort0156], 28, [2,4,1,1], 8>;
+defm : SKXWriteResPair<WriteIDiv8,  [SKXPort0, SKXDivider], 25, [1,6],  11>;
+defm : SKXWriteResPair<WriteIDiv16, [SKXPort0, SKXDivider], 24, [1,6],  10>;
+defm : SKXWriteResPair<WriteIDiv32, [SKXPort0, SKXDivider], 28, [1,6],  10>;
+defm : SKXWriteResPair<WriteIDiv64, [SKXPort0, SKXDivider], 96, [1,24], 57>;
 
 defm : SKXWriteResPair<WriteCRC32, [SKXPort1], 3>;
 

--- a/llvm/lib/Target/X86/X86SchedSkylakeServer.td
+++ b/llvm/lib/Target/X86/X86SchedSkylakeServer.td
@@ -147,15 +147,15 @@ defm : X86WriteRes<WriteCMPXCHG,[SKXPort06, SKXPort0156], 5, [2,3], 5>;
 defm : X86WriteRes<WriteCMPXCHGRMW,[SKXPort23,SKXPort06,SKXPort0156,SKXPort237,SKXPort4], 8, [1,2,1,1,1], 6>;
 defm : X86WriteRes<WriteXCHG,       [SKXPort0156], 2, [3], 3>;
 
-defm : SKXWriteResPair<WriteDiv8,  [SKXPort0, SKXDivider], 25, [1,6],  10>;
-defm : SKXWriteResPair<WriteDiv16, [SKXPort0, SKXDivider], 24, [1,6],  10>;
-defm : SKXWriteResPair<WriteDiv32, [SKXPort0, SKXDivider], 28, [1,6],  10>;
-defm : SKXWriteResPair<WriteDiv64, [SKXPort0, SKXDivider], 89, [1,21], 36>;
+defm : SKXWriteResPair<WriteDiv8,  [SKXPort0, SKXPort5, SKXPort06, SKXPort15, SKXPort0156, SKXDivider], 25, [2, 4, 1, 1, 2, 6],  10>;
+defm : SKXWriteResPair<WriteDiv16, [SKXPort0, SKXPort5, SKXPort06, SKXPort15, SKXPort0156, SKXDivider], 24, [2, 4, 1, 1, 2, 6],  10>;
+defm : SKXWriteResPair<WriteDiv32, [SKXPort0, SKXPort5, SKXPort06, SKXPort15, SKXPort0156, SKXDivider], 28, [2, 4, 1, 1, 2, 6],  10>;
+defm : SKXWriteResPair<WriteDiv64, [SKXPort0, SKXPort1, SKXPort5, SKXPort05, SKXPort06, SKXPort015, SKXPort0156, SKXDivider], 89, [2, 1, 3, 1, 13, 8, 5, 21], 36>;
 
-defm : SKXWriteResPair<WriteIDiv8,  [SKXPort0, SKXDivider], 25, [1,6],  11>;
-defm : SKXWriteResPair<WriteIDiv16, [SKXPort0, SKXDivider], 24, [1,6],  10>;
-defm : SKXWriteResPair<WriteIDiv32, [SKXPort0, SKXDivider], 28, [1,6],  10>;
-defm : SKXWriteResPair<WriteIDiv64, [SKXPort0, SKXDivider], 96, [1,24], 57>;
+defm : SKXWriteResPair<WriteIDiv8,  [SKXPort0, SKXPort5, SKXPort06, SKXPort15, SKXPort0156, SKXDivider], 25, [2, 4, 1, 1, 3, 6],  11>;
+defm : SKXWriteResPair<WriteIDiv16, [SKXPort0, SKXPort5, SKXPort06, SKXPort15, SKXPort0156, SKXDivider], 24, [2, 4, 1, 1, 2, 6],  10>;
+defm : SKXWriteResPair<WriteIDiv32, [SKXPort0, SKXPort5, SKXPort06, SKXPort15, SKXPort0156, SKXDivider], 28, [2, 4, 1, 1, 2, 6],  10>;
+defm : SKXWriteResPair<WriteIDiv64, [SKXPort0, SKXPort1, SKXPort5, SKXPort01, SKXPort05, SKXPort06, SKXPort15, SKXPort015, SKXDivider], 96, [2, 1, 3, 5, 7, 27, 5, 7, 24], 57>;
 
 defm : SKXWriteResPair<WriteCRC32, [SKXPort1], 3>;
 

--- a/llvm/test/CodeGen/X86/masked-sdiv.ll
+++ b/llvm/test/CodeGen/X86/masked-sdiv.ll
@@ -91,47 +91,47 @@ define <4 x i32> @sdiv_v4i32(<4 x i32> %x, <4 x i32> %y, <4 x i1> %m) {
 ; AVX2-NEXT:    cltd
 ; AVX2-NEXT:    idivl %esi
 ; AVX2-NEXT:    vmovd %eax, %xmm2
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrd $2, %xmm1, %ecx
+; AVX2-NEXT:    vpextrd $2, %xmm1, %esi
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX2-NEXT:    cltd
-; AVX2-NEXT:    idivl %ecx
-; AVX2-NEXT:    movl %eax, %ecx
-; AVX2-NEXT:    vpextrd $3, %xmm1, %esi
+; AVX2-NEXT:    idivl %esi
+; AVX2-NEXT:    movl %eax, %esi
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrd $3, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrd $3, %xmm0, %eax
 ; AVX2-NEXT:    cltd
-; AVX2-NEXT:    idivl %esi
-; AVX2-NEXT:    vpinsrd $2, %ecx, %xmm2, %xmm0
+; AVX2-NEXT:    idivl %ecx
+; AVX2-NEXT:    vpinsrd $2, %esi, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrd $3, %eax, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: sdiv_v4i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpslld $31, %xmm2, %xmm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm3 = [1,1,1,1]
 ; AVX512-NEXT:    vpmovd2m %xmm2, %k1
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1]
-; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm2 {%k1}
-; AVX512-NEXT:    vpextrd $1, %xmm2, %ecx
+; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm3 {%k1}
+; AVX512-NEXT:    vpextrd $1, %xmm3, %ecx
 ; AVX512-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %ecx
 ; AVX512-NEXT:    movl %eax, %ecx
-; AVX512-NEXT:    vmovd %xmm2, %esi
+; AVX512-NEXT:    vmovd %xmm3, %esi
 ; AVX512-NEXT:    vmovd %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %esi
 ; AVX512-NEXT:    movl %eax, %esi
-; AVX512-NEXT:    vpextrd $2, %xmm2, %edi
+; AVX512-NEXT:    vpextrd $2, %xmm3, %edi
 ; AVX512-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %edi
 ; AVX512-NEXT:    movl %eax, %edi
-; AVX512-NEXT:    vmovd %esi, %xmm1
-; AVX512-NEXT:    vpextrd $3, %xmm2, %esi
+; AVX512-NEXT:    vpextrd $3, %xmm3, %r8d
 ; AVX512-NEXT:    vpextrd $3, %xmm0, %eax
+; AVX512-NEXT:    vmovd %esi, %xmm0
 ; AVX512-NEXT:    cltd
-; AVX512-NEXT:    idivl %esi
-; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm1, %xmm0
+; AVX512-NEXT:    idivl %r8d
+; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $2, %edi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $3, %eax, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
@@ -323,25 +323,24 @@ define <4 x i64> @sdiv_v4i64(<4 x i64> %x, <4 x i64> %y, <4 x i1> %m) {
 ; AVX2-NEXT:    vpextrq $1, %xmm3, %rax
 ; AVX2-NEXT:    cqto
 ; AVX2-NEXT:    idivq %rcx
-; AVX2-NEXT:    movq %rax, %rcx
-; AVX2-NEXT:    vmovq %xmm2, %rsi
+; AVX2-NEXT:    vmovq %rax, %xmm4
+; AVX2-NEXT:    vmovq %xmm2, %rcx
 ; AVX2-NEXT:    vmovq %xmm3, %rax
+; AVX2-NEXT:    cqto
+; AVX2-NEXT:    idivq %rcx
+; AVX2-NEXT:    movq %rax, %rcx
+; AVX2-NEXT:    vpextrq $1, %xmm1, %rsi
+; AVX2-NEXT:    vpextrq $1, %xmm0, %rax
 ; AVX2-NEXT:    cqto
 ; AVX2-NEXT:    idivq %rsi
 ; AVX2-NEXT:    movq %rax, %rsi
-; AVX2-NEXT:    vpextrq $1, %xmm1, %rdi
-; AVX2-NEXT:    vpextrq $1, %xmm0, %rax
-; AVX2-NEXT:    cqto
-; AVX2-NEXT:    idivq %rdi
-; AVX2-NEXT:    movq %rax, %rdi
 ; AVX2-NEXT:    vmovq %rcx, %xmm2
-; AVX2-NEXT:    vmovq %rsi, %xmm3
-; AVX2-NEXT:    vpunpcklqdq {{.*#+}} xmm2 = xmm3[0],xmm2[0]
+; AVX2-NEXT:    vpunpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm4[0]
 ; AVX2-NEXT:    vmovq %xmm1, %rcx
 ; AVX2-NEXT:    vmovq %xmm0, %rax
 ; AVX2-NEXT:    cqto
 ; AVX2-NEXT:    idivq %rcx
-; AVX2-NEXT:    vmovq %rdi, %xmm0
+; AVX2-NEXT:    vmovq %rsi, %xmm0
 ; AVX2-NEXT:    vmovq %rax, %xmm1
 ; AVX2-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm1[0],xmm0[0]
 ; AVX2-NEXT:    vinserti128 $1, %xmm2, %ymm0, %ymm0
@@ -350,34 +349,34 @@ define <4 x i64> @sdiv_v4i64(<4 x i64> %x, <4 x i64> %y, <4 x i1> %m) {
 ; AVX512-LABEL: sdiv_v4i64:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpslld $31, %xmm2, %xmm2
+; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm3 = [1,1,1,1]
 ; AVX512-NEXT:    vpmovd2m %xmm2, %k1
-; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm2 = [1,1,1,1]
-; AVX512-NEXT:    vmovdqa64 %ymm1, %ymm2 {%k1}
-; AVX512-NEXT:    vextracti128 $1, %ymm2, %xmm1
+; AVX512-NEXT:    vmovdqa64 %ymm1, %ymm3 {%k1}
+; AVX512-NEXT:    vextracti128 $1, %ymm3, %xmm1
 ; AVX512-NEXT:    vpextrq $1, %xmm1, %rcx
-; AVX512-NEXT:    vextracti128 $1, %ymm0, %xmm3
-; AVX512-NEXT:    vpextrq $1, %xmm3, %rax
+; AVX512-NEXT:    vextracti128 $1, %ymm0, %xmm2
+; AVX512-NEXT:    vpextrq $1, %xmm2, %rax
 ; AVX512-NEXT:    cqto
 ; AVX512-NEXT:    idivq %rcx
 ; AVX512-NEXT:    movq %rax, %rcx
 ; AVX512-NEXT:    vmovq %xmm1, %rsi
-; AVX512-NEXT:    vmovq %xmm3, %rax
+; AVX512-NEXT:    vmovq %xmm2, %rax
 ; AVX512-NEXT:    cqto
 ; AVX512-NEXT:    idivq %rsi
 ; AVX512-NEXT:    movq %rax, %rsi
-; AVX512-NEXT:    vpextrq $1, %xmm2, %rdi
+; AVX512-NEXT:    vmovq %rcx, %xmm1
+; AVX512-NEXT:    vpextrq $1, %xmm3, %rcx
 ; AVX512-NEXT:    vpextrq $1, %xmm0, %rax
 ; AVX512-NEXT:    cqto
-; AVX512-NEXT:    idivq %rdi
-; AVX512-NEXT:    movq %rax, %rdi
-; AVX512-NEXT:    vmovq %rcx, %xmm1
-; AVX512-NEXT:    vmovq %xmm2, %rcx
+; AVX512-NEXT:    idivq %rcx
+; AVX512-NEXT:    movq %rax, %rcx
+; AVX512-NEXT:    vmovq %xmm3, %rdi
 ; AVX512-NEXT:    vmovq %xmm0, %rax
 ; AVX512-NEXT:    cqto
-; AVX512-NEXT:    idivq %rcx
+; AVX512-NEXT:    idivq %rdi
 ; AVX512-NEXT:    vmovq %rsi, %xmm0
 ; AVX512-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm0[0],xmm1[0]
-; AVX512-NEXT:    vmovq %rdi, %xmm1
+; AVX512-NEXT:    vmovq %rcx, %xmm1
 ; AVX512-NEXT:    vmovq %rax, %xmm2
 ; AVX512-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm2[0],xmm1[0]
 ; AVX512-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
@@ -477,47 +476,47 @@ define <2 x i32> @sdiv_v2i32(<2 x i32> %x, <2 x i32> %y, <2 x i1> %m) {
 ; AVX2-NEXT:    cltd
 ; AVX2-NEXT:    idivl %esi
 ; AVX2-NEXT:    vmovd %eax, %xmm2
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrd $2, %xmm1, %ecx
+; AVX2-NEXT:    vpextrd $2, %xmm1, %esi
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX2-NEXT:    cltd
-; AVX2-NEXT:    idivl %ecx
-; AVX2-NEXT:    movl %eax, %ecx
-; AVX2-NEXT:    vpextrd $3, %xmm1, %esi
+; AVX2-NEXT:    idivl %esi
+; AVX2-NEXT:    movl %eax, %esi
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrd $3, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrd $3, %xmm0, %eax
 ; AVX2-NEXT:    cltd
-; AVX2-NEXT:    idivl %esi
-; AVX2-NEXT:    vpinsrd $2, %ecx, %xmm2, %xmm0
+; AVX2-NEXT:    idivl %ecx
+; AVX2-NEXT:    vpinsrd $2, %esi, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrd $3, %eax, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: sdiv_v2i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpsllq $63, %xmm2, %xmm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm3 = [1,1,1,1]
 ; AVX512-NEXT:    vpmovq2m %xmm2, %k1
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1]
-; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm2 {%k1}
-; AVX512-NEXT:    vpextrd $1, %xmm2, %ecx
+; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm3 {%k1}
+; AVX512-NEXT:    vpextrd $1, %xmm3, %ecx
 ; AVX512-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %ecx
 ; AVX512-NEXT:    movl %eax, %ecx
-; AVX512-NEXT:    vmovd %xmm2, %esi
+; AVX512-NEXT:    vmovd %xmm3, %esi
 ; AVX512-NEXT:    vmovd %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %esi
 ; AVX512-NEXT:    movl %eax, %esi
-; AVX512-NEXT:    vpextrd $2, %xmm2, %edi
+; AVX512-NEXT:    vpextrd $2, %xmm3, %edi
 ; AVX512-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %edi
 ; AVX512-NEXT:    movl %eax, %edi
-; AVX512-NEXT:    vmovd %esi, %xmm1
-; AVX512-NEXT:    vpextrd $3, %xmm2, %esi
+; AVX512-NEXT:    vpextrd $3, %xmm3, %r8d
 ; AVX512-NEXT:    vpextrd $3, %xmm0, %eax
+; AVX512-NEXT:    vmovd %esi, %xmm0
 ; AVX512-NEXT:    cltd
-; AVX512-NEXT:    idivl %esi
-; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm1, %xmm0
+; AVX512-NEXT:    idivl %r8d
+; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $2, %edi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $3, %eax, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
@@ -738,9 +737,9 @@ define <4 x i16> @sdiv_v4i16(<4 x i16> %x, <4 x i16> %y, <4 x i1> %m) {
 ;
 ; AVX512-LABEL: sdiv_v4i16:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpslld $31, %xmm2, %xmm2
-; AVX512-NEXT:    vpmovd2m %xmm2, %k1
+; AVX512-NEXT:    vpslld $31, %xmm2, %xmm3
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1,1,1,1,1]
+; AVX512-NEXT:    vpmovd2m %xmm3, %k1
 ; AVX512-NEXT:    vmovdqu16 %xmm1, %xmm2 {%k1}
 ; AVX512-NEXT:    vpextrw $1, %xmm2, %ecx
 ; AVX512-NEXT:    vpextrw $1, %xmm0, %eax
@@ -753,49 +752,49 @@ define <4 x i16> @sdiv_v4i16(<4 x i16> %x, <4 x i16> %y, <4 x i1> %m) {
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
 ; AVX512-NEXT:    idivw %si
-; AVX512-NEXT:    # kill: def $ax killed $ax def $eax
-; AVX512-NEXT:    vmovd %eax, %xmm1
-; AVX512-NEXT:    vpinsrw $1, %ecx, %xmm1, %xmm1
-; AVX512-NEXT:    vpextrw $2, %xmm2, %ecx
+; AVX512-NEXT:    movl %eax, %esi
+; AVX512-NEXT:    vpextrw $2, %xmm2, %edi
 ; AVX512-NEXT:    vpextrw $2, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
-; AVX512-NEXT:    idivw %cx
-; AVX512-NEXT:    movl %eax, %ecx
+; AVX512-NEXT:    idivw %di
+; AVX512-NEXT:    movl %eax, %edi
+; AVX512-NEXT:    vmovd %esi, %xmm1
 ; AVX512-NEXT:    vpextrw $3, %xmm2, %esi
 ; AVX512-NEXT:    vpextrw $3, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
 ; AVX512-NEXT:    idivw %si
 ; AVX512-NEXT:    movl %eax, %esi
-; AVX512-NEXT:    vpextrw $4, %xmm2, %edi
+; AVX512-NEXT:    vpinsrw $1, %ecx, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $4, %xmm2, %ecx
 ; AVX512-NEXT:    vpextrw $4, %xmm0, %eax
-; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
-; AVX512-NEXT:    cwtd
-; AVX512-NEXT:    idivw %di
-; AVX512-NEXT:    # kill: def $ax killed $ax def $eax
-; AVX512-NEXT:    vpinsrw $2, %ecx, %xmm1, %xmm1
-; AVX512-NEXT:    vpinsrw $3, %esi, %xmm1, %xmm1
-; AVX512-NEXT:    vpinsrw $4, %eax, %xmm1, %xmm1
-; AVX512-NEXT:    vpextrw $5, %xmm2, %ecx
-; AVX512-NEXT:    vpextrw $5, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
 ; AVX512-NEXT:    idivw %cx
 ; AVX512-NEXT:    movl %eax, %ecx
+; AVX512-NEXT:    vpinsrw $2, %edi, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $5, %xmm2, %edi
+; AVX512-NEXT:    vpextrw $5, %xmm0, %eax
+; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
+; AVX512-NEXT:    cwtd
+; AVX512-NEXT:    idivw %di
+; AVX512-NEXT:    movl %eax, %edi
+; AVX512-NEXT:    vpinsrw $3, %esi, %xmm1, %xmm1
 ; AVX512-NEXT:    vpextrw $6, %xmm2, %esi
 ; AVX512-NEXT:    vpextrw $6, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
 ; AVX512-NEXT:    idivw %si
 ; AVX512-NEXT:    movl %eax, %esi
-; AVX512-NEXT:    vpextrw $7, %xmm2, %edi
+; AVX512-NEXT:    vpinsrw $4, %ecx, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $7, %xmm2, %ecx
 ; AVX512-NEXT:    vpextrw $7, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
-; AVX512-NEXT:    idivw %di
+; AVX512-NEXT:    idivw %cx
 ; AVX512-NEXT:    # kill: def $ax killed $ax def $eax
-; AVX512-NEXT:    vpinsrw $5, %ecx, %xmm1, %xmm0
+; AVX512-NEXT:    vpinsrw $5, %edi, %xmm1, %xmm0
 ; AVX512-NEXT:    vpinsrw $6, %esi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrw $7, %eax, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
@@ -815,25 +814,15 @@ define <1 x i64> @sdiv_v1i164(<1 x i64> %x, <1 x i64> %y, <1 x i1> %m) {
 ; SSE-NEXT:    idivq %rcx
 ; SSE-NEXT:    retq
 ;
-; AVX2-LABEL: sdiv_v1i164:
-; AVX2:       # %bb.0:
-; AVX2-NEXT:    testb $1, %dl
-; AVX2-NEXT:    movl $1, %ecx
-; AVX2-NEXT:    cmovneq %rsi, %rcx
-; AVX2-NEXT:    movq %rdi, %rax
-; AVX2-NEXT:    cqto
-; AVX2-NEXT:    idivq %rcx
-; AVX2-NEXT:    retq
-;
-; AVX512-LABEL: sdiv_v1i164:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    movq %rdi, %rax
-; AVX512-NEXT:    testb $1, %dl
-; AVX512-NEXT:    movl $1, %ecx
-; AVX512-NEXT:    cmovneq %rsi, %rcx
-; AVX512-NEXT:    cqto
-; AVX512-NEXT:    idivq %rcx
-; AVX512-NEXT:    retq
+; AVX-LABEL: sdiv_v1i164:
+; AVX:       # %bb.0:
+; AVX-NEXT:    movq %rdi, %rax
+; AVX-NEXT:    testb $1, %dl
+; AVX-NEXT:    movl $1, %ecx
+; AVX-NEXT:    cmovneq %rsi, %rcx
+; AVX-NEXT:    cqto
+; AVX-NEXT:    idivq %rcx
+; AVX-NEXT:    retq
   %res = call <1 x i64> @llvm.masked.sdiv(<1 x i64> %x, <1 x i64> %y, <1 x i1> %m)
   ret <1 x i64> %res
 }
@@ -1168,8 +1157,8 @@ define <3 x i10> @sdiv_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX2-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm2[0]
 ; AVX2-NEXT:    vmovd %ecx, %xmm2
 ; AVX2-NEXT:    vpinsrd $1, %r8d, %xmm2, %xmm2
-; AVX2-NEXT:    vpslld $31, %xmm1, %xmm1
 ; AVX2-NEXT:    vpinsrd $2, %r9d, %xmm2, %xmm2
+; AVX2-NEXT:    vpslld $31, %xmm1, %xmm1
 ; AVX2-NEXT:    vpslld $22, %xmm2, %xmm2
 ; AVX2-NEXT:    vpsrad $22, %xmm2, %xmm2
 ; AVX2-NEXT:    vbroadcastss {{.*#+}} xmm3 = [1,1,1,1]
@@ -1184,12 +1173,12 @@ define <3 x i10> @sdiv_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX2-NEXT:    cltd
 ; AVX2-NEXT:    idivl %esi
 ; AVX2-NEXT:    movl %eax, %esi
+; AVX2-NEXT:    vmovd %eax, %xmm2
 ; AVX2-NEXT:    vpextrd $2, %xmm1, %edi
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
-; AVX2-NEXT:    vmovd %esi, %xmm0
 ; AVX2-NEXT:    cltd
 ; AVX2-NEXT:    idivl %edi
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrd $2, %eax, %xmm0, %xmm1
 ; AVX2-NEXT:    vpextrw $2, %xmm0, %edx
 ; AVX2-NEXT:    vpextrw $4, %xmm1, %ecx
@@ -1205,10 +1194,10 @@ define <3 x i10> @sdiv_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX512-NEXT:    vpinsrd $2, %edx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpslld $22, %xmm0, %xmm0
 ; AVX512-NEXT:    vpsrad $22, %xmm0, %xmm0
-; AVX512-NEXT:    movb $7, %al
-; AVX512-NEXT:    kmovd %eax, %k1
 ; AVX512-NEXT:    vmovd {{.*#+}} xmm1 = mem[0],zero,zero,zero
 ; AVX512-NEXT:    vpinsrb $1, {{[0-9]+}}(%rsp), %xmm1, %xmm1
+; AVX512-NEXT:    movb $7, %al
+; AVX512-NEXT:    kmovd %eax, %k1
 ; AVX512-NEXT:    vpinsrb $2, {{[0-9]+}}(%rsp), %xmm1, %xmm1
 ; AVX512-NEXT:    vpmovzxbd {{.*#+}} xmm1 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1]
@@ -1244,5 +1233,3 @@ define <3 x i10> @sdiv_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
   %res = call <3 x i10> @llvm.masked.sdiv(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m)
   ret <3 x i10> %res
 }
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; AVX: {{.*}}

--- a/llvm/test/CodeGen/X86/masked-srem.ll
+++ b/llvm/test/CodeGen/X86/masked-srem.ll
@@ -91,47 +91,47 @@ define <4 x i32> @srem_v4i32(<4 x i32> %x, <4 x i32> %y, <4 x i1> %m) {
 ; AVX2-NEXT:    cltd
 ; AVX2-NEXT:    idivl %esi
 ; AVX2-NEXT:    vmovd %edx, %xmm2
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrd $2, %xmm1, %ecx
+; AVX2-NEXT:    vpextrd $2, %xmm1, %esi
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX2-NEXT:    cltd
-; AVX2-NEXT:    idivl %ecx
-; AVX2-NEXT:    movl %edx, %ecx
-; AVX2-NEXT:    vpextrd $3, %xmm1, %esi
+; AVX2-NEXT:    idivl %esi
+; AVX2-NEXT:    movl %edx, %esi
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrd $3, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrd $3, %xmm0, %eax
 ; AVX2-NEXT:    cltd
-; AVX2-NEXT:    idivl %esi
-; AVX2-NEXT:    vpinsrd $2, %ecx, %xmm2, %xmm0
+; AVX2-NEXT:    idivl %ecx
+; AVX2-NEXT:    vpinsrd $2, %esi, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrd $3, %edx, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: srem_v4i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpslld $31, %xmm2, %xmm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm3 = [1,1,1,1]
 ; AVX512-NEXT:    vpmovd2m %xmm2, %k1
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1]
-; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm2 {%k1}
-; AVX512-NEXT:    vpextrd $1, %xmm2, %ecx
+; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm3 {%k1}
+; AVX512-NEXT:    vpextrd $1, %xmm3, %ecx
 ; AVX512-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %ecx
 ; AVX512-NEXT:    movl %edx, %ecx
-; AVX512-NEXT:    vmovd %xmm2, %esi
+; AVX512-NEXT:    vmovd %xmm3, %esi
 ; AVX512-NEXT:    vmovd %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %esi
 ; AVX512-NEXT:    movl %edx, %esi
-; AVX512-NEXT:    vpextrd $2, %xmm2, %edi
+; AVX512-NEXT:    vpextrd $2, %xmm3, %edi
 ; AVX512-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %edi
 ; AVX512-NEXT:    movl %edx, %edi
-; AVX512-NEXT:    vmovd %esi, %xmm1
-; AVX512-NEXT:    vpextrd $3, %xmm2, %esi
+; AVX512-NEXT:    vpextrd $3, %xmm3, %r8d
 ; AVX512-NEXT:    vpextrd $3, %xmm0, %eax
+; AVX512-NEXT:    vmovd %esi, %xmm0
 ; AVX512-NEXT:    cltd
-; AVX512-NEXT:    idivl %esi
-; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm1, %xmm0
+; AVX512-NEXT:    idivl %r8d
+; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $2, %edi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $3, %edx, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
@@ -323,25 +323,24 @@ define <4 x i64> @srem_v4i64(<4 x i64> %x, <4 x i64> %y, <4 x i1> %m) {
 ; AVX2-NEXT:    vpextrq $1, %xmm3, %rax
 ; AVX2-NEXT:    cqto
 ; AVX2-NEXT:    idivq %rcx
-; AVX2-NEXT:    movq %rdx, %rcx
-; AVX2-NEXT:    vmovq %xmm2, %rsi
+; AVX2-NEXT:    vmovq %rdx, %xmm4
+; AVX2-NEXT:    vmovq %xmm2, %rcx
 ; AVX2-NEXT:    vmovq %xmm3, %rax
+; AVX2-NEXT:    cqto
+; AVX2-NEXT:    idivq %rcx
+; AVX2-NEXT:    movq %rdx, %rcx
+; AVX2-NEXT:    vpextrq $1, %xmm1, %rsi
+; AVX2-NEXT:    vpextrq $1, %xmm0, %rax
 ; AVX2-NEXT:    cqto
 ; AVX2-NEXT:    idivq %rsi
 ; AVX2-NEXT:    movq %rdx, %rsi
-; AVX2-NEXT:    vpextrq $1, %xmm1, %rdi
-; AVX2-NEXT:    vpextrq $1, %xmm0, %rax
-; AVX2-NEXT:    cqto
-; AVX2-NEXT:    idivq %rdi
-; AVX2-NEXT:    movq %rdx, %rdi
 ; AVX2-NEXT:    vmovq %rcx, %xmm2
-; AVX2-NEXT:    vmovq %rsi, %xmm3
-; AVX2-NEXT:    vpunpcklqdq {{.*#+}} xmm2 = xmm3[0],xmm2[0]
+; AVX2-NEXT:    vpunpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm4[0]
 ; AVX2-NEXT:    vmovq %xmm1, %rcx
 ; AVX2-NEXT:    vmovq %xmm0, %rax
 ; AVX2-NEXT:    cqto
 ; AVX2-NEXT:    idivq %rcx
-; AVX2-NEXT:    vmovq %rdi, %xmm0
+; AVX2-NEXT:    vmovq %rsi, %xmm0
 ; AVX2-NEXT:    vmovq %rdx, %xmm1
 ; AVX2-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm1[0],xmm0[0]
 ; AVX2-NEXT:    vinserti128 $1, %xmm2, %ymm0, %ymm0
@@ -350,34 +349,34 @@ define <4 x i64> @srem_v4i64(<4 x i64> %x, <4 x i64> %y, <4 x i1> %m) {
 ; AVX512-LABEL: srem_v4i64:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpslld $31, %xmm2, %xmm2
+; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm3 = [1,1,1,1]
 ; AVX512-NEXT:    vpmovd2m %xmm2, %k1
-; AVX512-NEXT:    vpbroadcastq {{.*#+}} ymm2 = [1,1,1,1]
-; AVX512-NEXT:    vmovdqa64 %ymm1, %ymm2 {%k1}
-; AVX512-NEXT:    vextracti128 $1, %ymm2, %xmm1
+; AVX512-NEXT:    vmovdqa64 %ymm1, %ymm3 {%k1}
+; AVX512-NEXT:    vextracti128 $1, %ymm3, %xmm1
 ; AVX512-NEXT:    vpextrq $1, %xmm1, %rcx
-; AVX512-NEXT:    vextracti128 $1, %ymm0, %xmm3
-; AVX512-NEXT:    vpextrq $1, %xmm3, %rax
+; AVX512-NEXT:    vextracti128 $1, %ymm0, %xmm2
+; AVX512-NEXT:    vpextrq $1, %xmm2, %rax
 ; AVX512-NEXT:    cqto
 ; AVX512-NEXT:    idivq %rcx
 ; AVX512-NEXT:    movq %rdx, %rcx
 ; AVX512-NEXT:    vmovq %xmm1, %rsi
-; AVX512-NEXT:    vmovq %xmm3, %rax
+; AVX512-NEXT:    vmovq %xmm2, %rax
 ; AVX512-NEXT:    cqto
 ; AVX512-NEXT:    idivq %rsi
 ; AVX512-NEXT:    movq %rdx, %rsi
-; AVX512-NEXT:    vpextrq $1, %xmm2, %rdi
+; AVX512-NEXT:    vmovq %rcx, %xmm1
+; AVX512-NEXT:    vpextrq $1, %xmm3, %rcx
 ; AVX512-NEXT:    vpextrq $1, %xmm0, %rax
 ; AVX512-NEXT:    cqto
-; AVX512-NEXT:    idivq %rdi
-; AVX512-NEXT:    movq %rdx, %rdi
-; AVX512-NEXT:    vmovq %rcx, %xmm1
-; AVX512-NEXT:    vmovq %xmm2, %rcx
+; AVX512-NEXT:    idivq %rcx
+; AVX512-NEXT:    movq %rdx, %rcx
+; AVX512-NEXT:    vmovq %xmm3, %rdi
 ; AVX512-NEXT:    vmovq %xmm0, %rax
 ; AVX512-NEXT:    cqto
-; AVX512-NEXT:    idivq %rcx
+; AVX512-NEXT:    idivq %rdi
 ; AVX512-NEXT:    vmovq %rsi, %xmm0
 ; AVX512-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm0[0],xmm1[0]
-; AVX512-NEXT:    vmovq %rdi, %xmm1
+; AVX512-NEXT:    vmovq %rcx, %xmm1
 ; AVX512-NEXT:    vmovq %rdx, %xmm2
 ; AVX512-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm2[0],xmm1[0]
 ; AVX512-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
@@ -477,47 +476,47 @@ define <2 x i32> @srem_v2i32(<2 x i32> %x, <2 x i32> %y, <2 x i1> %m) {
 ; AVX2-NEXT:    cltd
 ; AVX2-NEXT:    idivl %esi
 ; AVX2-NEXT:    vmovd %edx, %xmm2
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrd $2, %xmm1, %ecx
+; AVX2-NEXT:    vpextrd $2, %xmm1, %esi
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX2-NEXT:    cltd
-; AVX2-NEXT:    idivl %ecx
-; AVX2-NEXT:    movl %edx, %ecx
-; AVX2-NEXT:    vpextrd $3, %xmm1, %esi
+; AVX2-NEXT:    idivl %esi
+; AVX2-NEXT:    movl %edx, %esi
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrd $3, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrd $3, %xmm0, %eax
 ; AVX2-NEXT:    cltd
-; AVX2-NEXT:    idivl %esi
-; AVX2-NEXT:    vpinsrd $2, %ecx, %xmm2, %xmm0
+; AVX2-NEXT:    idivl %ecx
+; AVX2-NEXT:    vpinsrd $2, %esi, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrd $3, %edx, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: srem_v2i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpsllq $63, %xmm2, %xmm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm3 = [1,1,1,1]
 ; AVX512-NEXT:    vpmovq2m %xmm2, %k1
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1]
-; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm2 {%k1}
-; AVX512-NEXT:    vpextrd $1, %xmm2, %ecx
+; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm3 {%k1}
+; AVX512-NEXT:    vpextrd $1, %xmm3, %ecx
 ; AVX512-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %ecx
 ; AVX512-NEXT:    movl %edx, %ecx
-; AVX512-NEXT:    vmovd %xmm2, %esi
+; AVX512-NEXT:    vmovd %xmm3, %esi
 ; AVX512-NEXT:    vmovd %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %esi
 ; AVX512-NEXT:    movl %edx, %esi
-; AVX512-NEXT:    vpextrd $2, %xmm2, %edi
+; AVX512-NEXT:    vpextrd $2, %xmm3, %edi
 ; AVX512-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX512-NEXT:    cltd
 ; AVX512-NEXT:    idivl %edi
 ; AVX512-NEXT:    movl %edx, %edi
-; AVX512-NEXT:    vmovd %esi, %xmm1
-; AVX512-NEXT:    vpextrd $3, %xmm2, %esi
+; AVX512-NEXT:    vpextrd $3, %xmm3, %r8d
 ; AVX512-NEXT:    vpextrd $3, %xmm0, %eax
+; AVX512-NEXT:    vmovd %esi, %xmm0
 ; AVX512-NEXT:    cltd
-; AVX512-NEXT:    idivl %esi
-; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm1, %xmm0
+; AVX512-NEXT:    idivl %r8d
+; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $2, %edi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $3, %edx, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
@@ -738,9 +737,9 @@ define <4 x i16> @srem_v4i16(<4 x i16> %x, <4 x i16> %y, <4 x i1> %m) {
 ;
 ; AVX512-LABEL: srem_v4i16:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpslld $31, %xmm2, %xmm2
-; AVX512-NEXT:    vpmovd2m %xmm2, %k1
+; AVX512-NEXT:    vpslld $31, %xmm2, %xmm3
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1,1,1,1,1]
+; AVX512-NEXT:    vpmovd2m %xmm3, %k1
 ; AVX512-NEXT:    vmovdqu16 %xmm1, %xmm2 {%k1}
 ; AVX512-NEXT:    vpextrw $1, %xmm2, %ecx
 ; AVX512-NEXT:    vpextrw $1, %xmm0, %eax
@@ -753,49 +752,49 @@ define <4 x i16> @srem_v4i16(<4 x i16> %x, <4 x i16> %y, <4 x i1> %m) {
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
 ; AVX512-NEXT:    idivw %si
-; AVX512-NEXT:    # kill: def $dx killed $dx def $edx
-; AVX512-NEXT:    vmovd %edx, %xmm1
-; AVX512-NEXT:    vpinsrw $1, %ecx, %xmm1, %xmm1
-; AVX512-NEXT:    vpextrw $2, %xmm2, %ecx
+; AVX512-NEXT:    movl %edx, %esi
+; AVX512-NEXT:    vpextrw $2, %xmm2, %edi
 ; AVX512-NEXT:    vpextrw $2, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
-; AVX512-NEXT:    idivw %cx
-; AVX512-NEXT:    movl %edx, %ecx
+; AVX512-NEXT:    idivw %di
+; AVX512-NEXT:    movl %edx, %edi
+; AVX512-NEXT:    vmovd %esi, %xmm1
 ; AVX512-NEXT:    vpextrw $3, %xmm2, %esi
 ; AVX512-NEXT:    vpextrw $3, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
 ; AVX512-NEXT:    idivw %si
 ; AVX512-NEXT:    movl %edx, %esi
-; AVX512-NEXT:    vpextrw $4, %xmm2, %edi
+; AVX512-NEXT:    vpinsrw $1, %ecx, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $4, %xmm2, %ecx
 ; AVX512-NEXT:    vpextrw $4, %xmm0, %eax
-; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
-; AVX512-NEXT:    cwtd
-; AVX512-NEXT:    idivw %di
-; AVX512-NEXT:    # kill: def $dx killed $dx def $edx
-; AVX512-NEXT:    vpinsrw $2, %ecx, %xmm1, %xmm1
-; AVX512-NEXT:    vpinsrw $3, %esi, %xmm1, %xmm1
-; AVX512-NEXT:    vpinsrw $4, %edx, %xmm1, %xmm1
-; AVX512-NEXT:    vpextrw $5, %xmm2, %ecx
-; AVX512-NEXT:    vpextrw $5, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
 ; AVX512-NEXT:    idivw %cx
 ; AVX512-NEXT:    movl %edx, %ecx
+; AVX512-NEXT:    vpinsrw $2, %edi, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $5, %xmm2, %edi
+; AVX512-NEXT:    vpextrw $5, %xmm0, %eax
+; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
+; AVX512-NEXT:    cwtd
+; AVX512-NEXT:    idivw %di
+; AVX512-NEXT:    movl %edx, %edi
+; AVX512-NEXT:    vpinsrw $3, %esi, %xmm1, %xmm1
 ; AVX512-NEXT:    vpextrw $6, %xmm2, %esi
 ; AVX512-NEXT:    vpextrw $6, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
 ; AVX512-NEXT:    idivw %si
 ; AVX512-NEXT:    movl %edx, %esi
-; AVX512-NEXT:    vpextrw $7, %xmm2, %edi
+; AVX512-NEXT:    vpinsrw $4, %ecx, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $7, %xmm2, %ecx
 ; AVX512-NEXT:    vpextrw $7, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    cwtd
-; AVX512-NEXT:    idivw %di
+; AVX512-NEXT:    idivw %cx
 ; AVX512-NEXT:    # kill: def $dx killed $dx def $edx
-; AVX512-NEXT:    vpinsrw $5, %ecx, %xmm1, %xmm0
+; AVX512-NEXT:    vpinsrw $5, %edi, %xmm1, %xmm0
 ; AVX512-NEXT:    vpinsrw $6, %esi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrw $7, %edx, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
@@ -816,27 +815,16 @@ define <1 x i64> @srem_v1i164(<1 x i64> %x, <1 x i64> %y, <1 x i1> %m) {
 ; SSE-NEXT:    movq %rdx, %rax
 ; SSE-NEXT:    retq
 ;
-; AVX2-LABEL: srem_v1i164:
-; AVX2:       # %bb.0:
-; AVX2-NEXT:    testb $1, %dl
-; AVX2-NEXT:    movl $1, %ecx
-; AVX2-NEXT:    cmovneq %rsi, %rcx
-; AVX2-NEXT:    movq %rdi, %rax
-; AVX2-NEXT:    cqto
-; AVX2-NEXT:    idivq %rcx
-; AVX2-NEXT:    movq %rdx, %rax
-; AVX2-NEXT:    retq
-;
-; AVX512-LABEL: srem_v1i164:
-; AVX512:       # %bb.0:
-; AVX512-NEXT:    movq %rdi, %rax
-; AVX512-NEXT:    testb $1, %dl
-; AVX512-NEXT:    movl $1, %ecx
-; AVX512-NEXT:    cmovneq %rsi, %rcx
-; AVX512-NEXT:    cqto
-; AVX512-NEXT:    idivq %rcx
-; AVX512-NEXT:    movq %rdx, %rax
-; AVX512-NEXT:    retq
+; AVX-LABEL: srem_v1i164:
+; AVX:       # %bb.0:
+; AVX-NEXT:    movq %rdi, %rax
+; AVX-NEXT:    testb $1, %dl
+; AVX-NEXT:    movl $1, %ecx
+; AVX-NEXT:    cmovneq %rsi, %rcx
+; AVX-NEXT:    cqto
+; AVX-NEXT:    idivq %rcx
+; AVX-NEXT:    movq %rdx, %rax
+; AVX-NEXT:    retq
   %res = call <1 x i64> @llvm.masked.srem(<1 x i64> %x, <1 x i64> %y, <1 x i1> %m)
   ret <1 x i64> %res
 }
@@ -1172,8 +1160,8 @@ define <3 x i10> @srem_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX2-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm2[0]
 ; AVX2-NEXT:    vmovd %ecx, %xmm2
 ; AVX2-NEXT:    vpinsrd $1, %r8d, %xmm2, %xmm2
-; AVX2-NEXT:    vpslld $31, %xmm1, %xmm1
 ; AVX2-NEXT:    vpinsrd $2, %r9d, %xmm2, %xmm2
+; AVX2-NEXT:    vpslld $31, %xmm1, %xmm1
 ; AVX2-NEXT:    vpslld $22, %xmm2, %xmm2
 ; AVX2-NEXT:    vpsrad $22, %xmm2, %xmm2
 ; AVX2-NEXT:    vbroadcastss {{.*#+}} xmm3 = [1,1,1,1]
@@ -1188,12 +1176,12 @@ define <3 x i10> @srem_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX2-NEXT:    cltd
 ; AVX2-NEXT:    idivl %esi
 ; AVX2-NEXT:    movl %edx, %esi
+; AVX2-NEXT:    vmovd %edx, %xmm2
 ; AVX2-NEXT:    vpextrd $2, %xmm1, %edi
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
-; AVX2-NEXT:    vmovd %edx, %xmm0
 ; AVX2-NEXT:    cltd
 ; AVX2-NEXT:    idivl %edi
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrd $2, %edx, %xmm0, %xmm1
 ; AVX2-NEXT:    vpextrw $2, %xmm0, %edx
 ; AVX2-NEXT:    vpextrw $4, %xmm1, %ecx
@@ -1209,10 +1197,10 @@ define <3 x i10> @srem_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX512-NEXT:    vpinsrd $2, %edx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpslld $22, %xmm0, %xmm0
 ; AVX512-NEXT:    vpsrad $22, %xmm0, %xmm0
-; AVX512-NEXT:    movb $7, %al
-; AVX512-NEXT:    kmovd %eax, %k1
 ; AVX512-NEXT:    vmovd {{.*#+}} xmm1 = mem[0],zero,zero,zero
 ; AVX512-NEXT:    vpinsrb $1, {{[0-9]+}}(%rsp), %xmm1, %xmm1
+; AVX512-NEXT:    movb $7, %al
+; AVX512-NEXT:    kmovd %eax, %k1
 ; AVX512-NEXT:    vpinsrb $2, {{[0-9]+}}(%rsp), %xmm1, %xmm1
 ; AVX512-NEXT:    vpmovzxbd {{.*#+}} xmm1 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1]
@@ -1248,5 +1236,3 @@ define <3 x i10> @srem_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
   %res = call <3 x i10> @llvm.masked.srem(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m)
   ret <3 x i10> %res
 }
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; AVX: {{.*}}

--- a/llvm/test/CodeGen/X86/masked-udiv.ll
+++ b/llvm/test/CodeGen/X86/masked-udiv.ll
@@ -90,48 +90,48 @@ define <4 x i32> @udiv_v4i32(<4 x i32> %x, <4 x i32> %y, <4 x i1> %m) {
 ; AVX2-NEXT:    vmovd %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divl %esi
-; AVX2-NEXT:    vpextrd $2, %xmm1, %esi
 ; AVX2-NEXT:    vmovd %eax, %xmm2
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrd $2, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divl %esi
-; AVX2-NEXT:    movl %eax, %esi
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrd $3, %xmm1, %ecx
+; AVX2-NEXT:    divl %ecx
+; AVX2-NEXT:    movl %eax, %ecx
+; AVX2-NEXT:    vpextrd $3, %xmm1, %esi
 ; AVX2-NEXT:    vpextrd $3, %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divl %ecx
-; AVX2-NEXT:    vpinsrd $2, %esi, %xmm2, %xmm0
+; AVX2-NEXT:    divl %esi
+; AVX2-NEXT:    vpinsrd $2, %ecx, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrd $3, %eax, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: udiv_v4i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpslld $31, %xmm2, %xmm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm3 = [1,1,1,1]
 ; AVX512-NEXT:    vpmovd2m %xmm2, %k1
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1]
-; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm2 {%k1}
-; AVX512-NEXT:    vpextrd $1, %xmm2, %ecx
+; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm3 {%k1}
+; AVX512-NEXT:    vpextrd $1, %xmm3, %ecx
 ; AVX512-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %ecx
 ; AVX512-NEXT:    movl %eax, %ecx
-; AVX512-NEXT:    vmovd %xmm2, %esi
+; AVX512-NEXT:    vmovd %xmm3, %esi
 ; AVX512-NEXT:    vmovd %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %esi
 ; AVX512-NEXT:    movl %eax, %esi
-; AVX512-NEXT:    vpextrd $2, %xmm2, %edi
+; AVX512-NEXT:    vpextrd $2, %xmm3, %edi
 ; AVX512-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %edi
 ; AVX512-NEXT:    movl %eax, %edi
-; AVX512-NEXT:    vpextrd $3, %xmm2, %r8d
-; AVX512-NEXT:    vmovd %esi, %xmm1
+; AVX512-NEXT:    vpextrd $3, %xmm3, %r8d
 ; AVX512-NEXT:    vpextrd $3, %xmm0, %eax
+; AVX512-NEXT:    vmovd %esi, %xmm0
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %r8d
-; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm1, %xmm0
+; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $2, %edi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $3, %eax, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
@@ -475,48 +475,48 @@ define <2 x i32> @udiv_v2i32(<2 x i32> %x, <2 x i32> %y, <2 x i1> %m) {
 ; AVX2-NEXT:    vmovd %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divl %esi
-; AVX2-NEXT:    vpextrd $2, %xmm1, %esi
 ; AVX2-NEXT:    vmovd %eax, %xmm2
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrd $2, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divl %esi
-; AVX2-NEXT:    movl %eax, %esi
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrd $3, %xmm1, %ecx
+; AVX2-NEXT:    divl %ecx
+; AVX2-NEXT:    movl %eax, %ecx
+; AVX2-NEXT:    vpextrd $3, %xmm1, %esi
 ; AVX2-NEXT:    vpextrd $3, %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divl %ecx
-; AVX2-NEXT:    vpinsrd $2, %esi, %xmm2, %xmm0
+; AVX2-NEXT:    divl %esi
+; AVX2-NEXT:    vpinsrd $2, %ecx, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrd $3, %eax, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: udiv_v2i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpsllq $63, %xmm2, %xmm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm3 = [1,1,1,1]
 ; AVX512-NEXT:    vpmovq2m %xmm2, %k1
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1]
-; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm2 {%k1}
-; AVX512-NEXT:    vpextrd $1, %xmm2, %ecx
+; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm3 {%k1}
+; AVX512-NEXT:    vpextrd $1, %xmm3, %ecx
 ; AVX512-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %ecx
 ; AVX512-NEXT:    movl %eax, %ecx
-; AVX512-NEXT:    vmovd %xmm2, %esi
+; AVX512-NEXT:    vmovd %xmm3, %esi
 ; AVX512-NEXT:    vmovd %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %esi
 ; AVX512-NEXT:    movl %eax, %esi
-; AVX512-NEXT:    vpextrd $2, %xmm2, %edi
+; AVX512-NEXT:    vpextrd $2, %xmm3, %edi
 ; AVX512-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %edi
 ; AVX512-NEXT:    movl %eax, %edi
-; AVX512-NEXT:    vpextrd $3, %xmm2, %r8d
-; AVX512-NEXT:    vmovd %esi, %xmm1
+; AVX512-NEXT:    vpextrd $3, %xmm3, %r8d
 ; AVX512-NEXT:    vpextrd $3, %xmm0, %eax
+; AVX512-NEXT:    vmovd %esi, %xmm0
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %r8d
-; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm1, %xmm0
+; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $2, %edi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $3, %eax, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
@@ -689,57 +689,57 @@ define <4 x i16> @udiv_v4i16(<4 x i16> %x, <4 x i16> %y, <4 x i1> %m) {
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divw %si
 ; AVX2-NEXT:    # kill: def $ax killed $ax def $eax
-; AVX2-NEXT:    vpextrw $2, %xmm1, %esi
 ; AVX2-NEXT:    vmovd %eax, %xmm2
+; AVX2-NEXT:    vpinsrw $1, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrw $2, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrw $2, %xmm0, %eax
 ; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divw %si
-; AVX2-NEXT:    movl %eax, %esi
-; AVX2-NEXT:    vpinsrw $1, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrw $3, %xmm1, %ecx
+; AVX2-NEXT:    divw %cx
+; AVX2-NEXT:    movl %eax, %ecx
+; AVX2-NEXT:    vpextrw $3, %xmm1, %esi
 ; AVX2-NEXT:    vpextrw $3, %xmm0, %eax
 ; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divw %cx
-; AVX2-NEXT:    movl %eax, %ecx
-; AVX2-NEXT:    vpinsrw $2, %esi, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrw $4, %xmm1, %esi
+; AVX2-NEXT:    divw %si
+; AVX2-NEXT:    # kill: def $ax killed $ax def $eax
+; AVX2-NEXT:    vpinsrw $2, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpinsrw $3, %eax, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrw $4, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrw $4, %xmm0, %eax
 ; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divw %si
-; AVX2-NEXT:    movl %eax, %esi
-; AVX2-NEXT:    vpinsrw $3, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrw $5, %xmm1, %ecx
+; AVX2-NEXT:    divw %cx
+; AVX2-NEXT:    movl %eax, %ecx
+; AVX2-NEXT:    vpextrw $5, %xmm1, %esi
 ; AVX2-NEXT:    vpextrw $5, %xmm0, %eax
+; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
+; AVX2-NEXT:    xorl %edx, %edx
+; AVX2-NEXT:    divw %si
+; AVX2-NEXT:    # kill: def $ax killed $ax def $eax
+; AVX2-NEXT:    vpinsrw $4, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpinsrw $5, %eax, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrw $6, %xmm1, %ecx
+; AVX2-NEXT:    vpextrw $6, %xmm0, %eax
 ; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divw %cx
 ; AVX2-NEXT:    movl %eax, %ecx
-; AVX2-NEXT:    vpinsrw $4, %esi, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrw $6, %xmm1, %esi
-; AVX2-NEXT:    vpextrw $6, %xmm0, %eax
-; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
-; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divw %si
-; AVX2-NEXT:    movl %eax, %esi
-; AVX2-NEXT:    vpinsrw $5, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrw $7, %xmm1, %ecx
+; AVX2-NEXT:    vpextrw $7, %xmm1, %esi
 ; AVX2-NEXT:    vpextrw $7, %xmm0, %eax
 ; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divw %cx
+; AVX2-NEXT:    divw %si
 ; AVX2-NEXT:    # kill: def $ax killed $ax def $eax
-; AVX2-NEXT:    vpinsrw $6, %esi, %xmm2, %xmm0
+; AVX2-NEXT:    vpinsrw $6, %ecx, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrw $7, %eax, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: udiv_v4i16:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpslld $31, %xmm2, %xmm2
-; AVX512-NEXT:    vpmovd2m %xmm2, %k1
+; AVX512-NEXT:    vpslld $31, %xmm2, %xmm3
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1,1,1,1,1]
+; AVX512-NEXT:    vpmovd2m %xmm3, %k1
 ; AVX512-NEXT:    vmovdqu16 %xmm1, %xmm2 {%k1}
 ; AVX512-NEXT:    vpextrw $1, %xmm2, %ecx
 ; AVX512-NEXT:    vpextrw $1, %xmm0, %eax
@@ -758,44 +758,44 @@ define <4 x i16> @udiv_v4i16(<4 x i16> %x, <4 x i16> %y, <4 x i1> %m) {
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divw %di
-; AVX512-NEXT:    movl %eax, %r8d
-; AVX512-NEXT:    vpextrw $3, %xmm2, %edi
-; AVX512-NEXT:    vpextrw $3, %xmm0, %eax
-; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
-; AVX512-NEXT:    xorl %edx, %edx
-; AVX512-NEXT:    divw %di
 ; AVX512-NEXT:    movl %eax, %edi
-; AVX512-NEXT:    vpextrw $4, %xmm2, %r9d
-; AVX512-NEXT:    vpextrw $4, %xmm0, %eax
-; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
-; AVX512-NEXT:    xorl %edx, %edx
-; AVX512-NEXT:    divw %r9w
-; AVX512-NEXT:    movl %eax, %r9d
-; AVX512-NEXT:    vpextrw $5, %xmm2, %r10d
+; AVX512-NEXT:    vpextrw $3, %xmm2, %r8d
+; AVX512-NEXT:    vpextrw $3, %xmm0, %eax
 ; AVX512-NEXT:    vmovd %esi, %xmm1
-; AVX512-NEXT:    vpextrw $5, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    xorl %edx, %edx
-; AVX512-NEXT:    divw %r10w
+; AVX512-NEXT:    divw %r8w
 ; AVX512-NEXT:    movl %eax, %esi
 ; AVX512-NEXT:    vpinsrw $1, %ecx, %xmm1, %xmm1
-; AVX512-NEXT:    vpinsrw $2, %r8d, %xmm1, %xmm1
-; AVX512-NEXT:    vpextrw $6, %xmm2, %ecx
-; AVX512-NEXT:    vpextrw $6, %xmm0, %eax
+; AVX512-NEXT:    vpextrw $4, %xmm2, %ecx
+; AVX512-NEXT:    vpextrw $4, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divw %cx
 ; AVX512-NEXT:    movl %eax, %ecx
-; AVX512-NEXT:    vpinsrw $3, %edi, %xmm1, %xmm1
-; AVX512-NEXT:    vpinsrw $4, %r9d, %xmm1, %xmm1
-; AVX512-NEXT:    vpextrw $7, %xmm2, %edi
-; AVX512-NEXT:    vpextrw $7, %xmm0, %eax
+; AVX512-NEXT:    vpinsrw $2, %edi, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $5, %xmm2, %edi
+; AVX512-NEXT:    vpextrw $5, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divw %di
+; AVX512-NEXT:    movl %eax, %edi
+; AVX512-NEXT:    vpinsrw $3, %esi, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $6, %xmm2, %esi
+; AVX512-NEXT:    vpextrw $6, %xmm0, %eax
+; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
+; AVX512-NEXT:    xorl %edx, %edx
+; AVX512-NEXT:    divw %si
+; AVX512-NEXT:    movl %eax, %esi
+; AVX512-NEXT:    vpinsrw $4, %ecx, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $7, %xmm2, %ecx
+; AVX512-NEXT:    vpextrw $7, %xmm0, %eax
+; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
+; AVX512-NEXT:    xorl %edx, %edx
+; AVX512-NEXT:    divw %cx
 ; AVX512-NEXT:    # kill: def $ax killed $ax def $eax
-; AVX512-NEXT:    vpinsrw $5, %esi, %xmm1, %xmm0
-; AVX512-NEXT:    vpinsrw $6, %ecx, %xmm0, %xmm0
+; AVX512-NEXT:    vpinsrw $5, %edi, %xmm1, %xmm0
+; AVX512-NEXT:    vpinsrw $6, %esi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrw $7, %eax, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
   %res = call <4 x i16> @llvm.masked.udiv(<4 x i16> %x, <4 x i16> %y, <4 x i1> %m)
@@ -1143,11 +1143,15 @@ define <3 x i10> @udiv_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ;
 ; AVX2-LABEL: udiv_v3i10:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpbroadcastd {{.*#+}} xmm0 = [1023,1023,1023,1023]
-; AVX2-NEXT:    vmovd %ecx, %xmm1
-; AVX2-NEXT:    vpinsrd $1, %r8d, %xmm1, %xmm1
-; AVX2-NEXT:    vpinsrd $2, %r9d, %xmm1, %xmm1
-; AVX2-NEXT:    vpand %xmm0, %xmm1, %xmm1
+; AVX2-NEXT:    vmovd %edi, %xmm0
+; AVX2-NEXT:    vpinsrd $1, %esi, %xmm0, %xmm0
+; AVX2-NEXT:    vpinsrd $2, %edx, %xmm0, %xmm0
+; AVX2-NEXT:    vpbroadcastd {{.*#+}} xmm1 = [1023,1023,1023,1023]
+; AVX2-NEXT:    vpand %xmm1, %xmm0, %xmm0
+; AVX2-NEXT:    vmovd %ecx, %xmm2
+; AVX2-NEXT:    vpinsrd $1, %r8d, %xmm2, %xmm2
+; AVX2-NEXT:    vpinsrd $2, %r9d, %xmm2, %xmm2
+; AVX2-NEXT:    vpand %xmm1, %xmm2, %xmm1
 ; AVX2-NEXT:    vmovd {{.*#+}} xmm2 = mem[0],zero,zero,zero
 ; AVX2-NEXT:    vmovd {{.*#+}} xmm3 = mem[0],zero,zero,zero
 ; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm3[0],xmm2[0],xmm3[1],xmm2[1]
@@ -1156,11 +1160,7 @@ define <3 x i10> @udiv_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX2-NEXT:    vpslld $31, %xmm2, %xmm2
 ; AVX2-NEXT:    vbroadcastss {{.*#+}} xmm3 = [1,1,1,1]
 ; AVX2-NEXT:    vblendvps %xmm2, %xmm1, %xmm3, %xmm1
-; AVX2-NEXT:    vmovd %edi, %xmm2
-; AVX2-NEXT:    vpinsrd $1, %esi, %xmm2, %xmm2
-; AVX2-NEXT:    vpinsrd $2, %edx, %xmm2, %xmm2
 ; AVX2-NEXT:    vextractps $1, %xmm1, %ecx
-; AVX2-NEXT:    vpand %xmm0, %xmm2, %xmm0
 ; AVX2-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divl %ecx
@@ -1171,11 +1171,11 @@ define <3 x i10> @udiv_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX2-NEXT:    divl %esi
 ; AVX2-NEXT:    movl %eax, %esi
 ; AVX2-NEXT:    vpextrd $2, %xmm1, %edi
-; AVX2-NEXT:    vmovd %eax, %xmm1
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
+; AVX2-NEXT:    vmovd %esi, %xmm0
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divl %edi
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm1, %xmm0
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
 ; AVX2-NEXT:    vpinsrd $2, %eax, %xmm0, %xmm1
 ; AVX2-NEXT:    vpextrw $2, %xmm0, %edx
 ; AVX2-NEXT:    vpextrw $4, %xmm1, %ecx
@@ -1190,20 +1190,20 @@ define <3 x i10> @udiv_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX512-NEXT:    vpinsrd $1, %esi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $2, %edx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm1 = [1023,1023,1023,1023]
-; AVX512-NEXT:    movb $7, %al
-; AVX512-NEXT:    kmovd %eax, %k1
 ; AVX512-NEXT:    vmovd {{.*#+}} xmm2 = mem[0],zero,zero,zero
 ; AVX512-NEXT:    vpinsrb $1, {{[0-9]+}}(%rsp), %xmm2, %xmm2
+; AVX512-NEXT:    movb $7, %al
+; AVX512-NEXT:    kmovd %eax, %k1
 ; AVX512-NEXT:    vpinsrb $2, {{[0-9]+}}(%rsp), %xmm2, %xmm2
 ; AVX512-NEXT:    vpmovzxbd {{.*#+}} xmm2 = xmm2[0],zero,zero,zero,xmm2[1],zero,zero,zero,xmm2[2],zero,zero,zero,xmm2[3],zero,zero,zero
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm3 = [1,1,1,1]
-; AVX512-NEXT:    vmovd %ecx, %xmm4
-; AVX512-NEXT:    vpinsrd $1, %r8d, %xmm4, %xmm4
 ; AVX512-NEXT:    vptestmd %xmm3, %xmm2, %k1 {%k1}
-; AVX512-NEXT:    vpinsrd $2, %r9d, %xmm4, %xmm2
+; AVX512-NEXT:    vmovd %ecx, %xmm2
+; AVX512-NEXT:    vpinsrd $1, %r8d, %xmm2, %xmm2
+; AVX512-NEXT:    vpinsrd $2, %r9d, %xmm2, %xmm2
+; AVX512-NEXT:    vpand %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vpandd %xmm1, %xmm2, %xmm3 {%k1}
 ; AVX512-NEXT:    vpextrd $1, %xmm3, %ecx
-; AVX512-NEXT:    vpand %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %ecx

--- a/llvm/test/CodeGen/X86/masked-urem.ll
+++ b/llvm/test/CodeGen/X86/masked-urem.ll
@@ -90,48 +90,48 @@ define <4 x i32> @urem_v4i32(<4 x i32> %x, <4 x i32> %y, <4 x i1> %m) {
 ; AVX2-NEXT:    vmovd %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divl %esi
-; AVX2-NEXT:    vpextrd $2, %xmm1, %esi
 ; AVX2-NEXT:    vmovd %edx, %xmm2
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrd $2, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divl %esi
-; AVX2-NEXT:    movl %edx, %esi
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrd $3, %xmm1, %ecx
+; AVX2-NEXT:    divl %ecx
+; AVX2-NEXT:    movl %edx, %ecx
+; AVX2-NEXT:    vpextrd $3, %xmm1, %esi
 ; AVX2-NEXT:    vpextrd $3, %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divl %ecx
-; AVX2-NEXT:    vpinsrd $2, %esi, %xmm2, %xmm0
+; AVX2-NEXT:    divl %esi
+; AVX2-NEXT:    vpinsrd $2, %ecx, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrd $3, %edx, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: urem_v4i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpslld $31, %xmm2, %xmm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm3 = [1,1,1,1]
 ; AVX512-NEXT:    vpmovd2m %xmm2, %k1
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1]
-; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm2 {%k1}
-; AVX512-NEXT:    vpextrd $1, %xmm2, %ecx
+; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm3 {%k1}
+; AVX512-NEXT:    vpextrd $1, %xmm3, %ecx
 ; AVX512-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %ecx
 ; AVX512-NEXT:    movl %edx, %ecx
-; AVX512-NEXT:    vmovd %xmm2, %esi
+; AVX512-NEXT:    vmovd %xmm3, %esi
 ; AVX512-NEXT:    vmovd %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %esi
 ; AVX512-NEXT:    movl %edx, %esi
-; AVX512-NEXT:    vpextrd $2, %xmm2, %edi
+; AVX512-NEXT:    vpextrd $2, %xmm3, %edi
 ; AVX512-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %edi
 ; AVX512-NEXT:    movl %edx, %edi
-; AVX512-NEXT:    vpextrd $3, %xmm2, %r8d
-; AVX512-NEXT:    vmovd %esi, %xmm1
+; AVX512-NEXT:    vpextrd $3, %xmm3, %r8d
 ; AVX512-NEXT:    vpextrd $3, %xmm0, %eax
+; AVX512-NEXT:    vmovd %esi, %xmm0
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %r8d
-; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm1, %xmm0
+; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $2, %edi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $3, %edx, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
@@ -475,48 +475,48 @@ define <2 x i32> @urem_v2i32(<2 x i32> %x, <2 x i32> %y, <2 x i1> %m) {
 ; AVX2-NEXT:    vmovd %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divl %esi
-; AVX2-NEXT:    vpextrd $2, %xmm1, %esi
 ; AVX2-NEXT:    vmovd %edx, %xmm2
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrd $2, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divl %esi
-; AVX2-NEXT:    movl %edx, %esi
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrd $3, %xmm1, %ecx
+; AVX2-NEXT:    divl %ecx
+; AVX2-NEXT:    movl %edx, %ecx
+; AVX2-NEXT:    vpextrd $3, %xmm1, %esi
 ; AVX2-NEXT:    vpextrd $3, %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divl %ecx
-; AVX2-NEXT:    vpinsrd $2, %esi, %xmm2, %xmm0
+; AVX2-NEXT:    divl %esi
+; AVX2-NEXT:    vpinsrd $2, %ecx, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrd $3, %edx, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: urem_v2i32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpsllq $63, %xmm2, %xmm2
+; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm3 = [1,1,1,1]
 ; AVX512-NEXT:    vpmovq2m %xmm2, %k1
-; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1]
-; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm2 {%k1}
-; AVX512-NEXT:    vpextrd $1, %xmm2, %ecx
+; AVX512-NEXT:    vmovdqa32 %xmm1, %xmm3 {%k1}
+; AVX512-NEXT:    vpextrd $1, %xmm3, %ecx
 ; AVX512-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %ecx
 ; AVX512-NEXT:    movl %edx, %ecx
-; AVX512-NEXT:    vmovd %xmm2, %esi
+; AVX512-NEXT:    vmovd %xmm3, %esi
 ; AVX512-NEXT:    vmovd %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %esi
 ; AVX512-NEXT:    movl %edx, %esi
-; AVX512-NEXT:    vpextrd $2, %xmm2, %edi
+; AVX512-NEXT:    vpextrd $2, %xmm3, %edi
 ; AVX512-NEXT:    vpextrd $2, %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %edi
 ; AVX512-NEXT:    movl %edx, %edi
-; AVX512-NEXT:    vpextrd $3, %xmm2, %r8d
-; AVX512-NEXT:    vmovd %esi, %xmm1
+; AVX512-NEXT:    vpextrd $3, %xmm3, %r8d
 ; AVX512-NEXT:    vpextrd $3, %xmm0, %eax
+; AVX512-NEXT:    vmovd %esi, %xmm0
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %r8d
-; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm1, %xmm0
+; AVX512-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $2, %edi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $3, %edx, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
@@ -689,57 +689,57 @@ define <4 x i16> @urem_v4i16(<4 x i16> %x, <4 x i16> %y, <4 x i1> %m) {
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divw %si
 ; AVX2-NEXT:    # kill: def $dx killed $dx def $edx
-; AVX2-NEXT:    vpextrw $2, %xmm1, %esi
 ; AVX2-NEXT:    vmovd %edx, %xmm2
+; AVX2-NEXT:    vpinsrw $1, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrw $2, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrw $2, %xmm0, %eax
 ; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divw %si
-; AVX2-NEXT:    movl %edx, %esi
-; AVX2-NEXT:    vpinsrw $1, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrw $3, %xmm1, %ecx
+; AVX2-NEXT:    divw %cx
+; AVX2-NEXT:    movl %edx, %ecx
+; AVX2-NEXT:    vpextrw $3, %xmm1, %esi
 ; AVX2-NEXT:    vpextrw $3, %xmm0, %eax
 ; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divw %cx
-; AVX2-NEXT:    movl %edx, %ecx
-; AVX2-NEXT:    vpinsrw $2, %esi, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrw $4, %xmm1, %esi
+; AVX2-NEXT:    divw %si
+; AVX2-NEXT:    # kill: def $dx killed $dx def $edx
+; AVX2-NEXT:    vpinsrw $2, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpinsrw $3, %edx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrw $4, %xmm1, %ecx
 ; AVX2-NEXT:    vpextrw $4, %xmm0, %eax
 ; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divw %si
-; AVX2-NEXT:    movl %edx, %esi
-; AVX2-NEXT:    vpinsrw $3, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrw $5, %xmm1, %ecx
+; AVX2-NEXT:    divw %cx
+; AVX2-NEXT:    movl %edx, %ecx
+; AVX2-NEXT:    vpextrw $5, %xmm1, %esi
 ; AVX2-NEXT:    vpextrw $5, %xmm0, %eax
+; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
+; AVX2-NEXT:    xorl %edx, %edx
+; AVX2-NEXT:    divw %si
+; AVX2-NEXT:    # kill: def $dx killed $dx def $edx
+; AVX2-NEXT:    vpinsrw $4, %ecx, %xmm2, %xmm2
+; AVX2-NEXT:    vpinsrw $5, %edx, %xmm2, %xmm2
+; AVX2-NEXT:    vpextrw $6, %xmm1, %ecx
+; AVX2-NEXT:    vpextrw $6, %xmm0, %eax
 ; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divw %cx
 ; AVX2-NEXT:    movl %edx, %ecx
-; AVX2-NEXT:    vpinsrw $4, %esi, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrw $6, %xmm1, %esi
-; AVX2-NEXT:    vpextrw $6, %xmm0, %eax
-; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
-; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divw %si
-; AVX2-NEXT:    movl %edx, %esi
-; AVX2-NEXT:    vpinsrw $5, %ecx, %xmm2, %xmm2
-; AVX2-NEXT:    vpextrw $7, %xmm1, %ecx
+; AVX2-NEXT:    vpextrw $7, %xmm1, %esi
 ; AVX2-NEXT:    vpextrw $7, %xmm0, %eax
 ; AVX2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX2-NEXT:    xorl %edx, %edx
-; AVX2-NEXT:    divw %cx
+; AVX2-NEXT:    divw %si
 ; AVX2-NEXT:    # kill: def $dx killed $dx def $edx
-; AVX2-NEXT:    vpinsrw $6, %esi, %xmm2, %xmm0
+; AVX2-NEXT:    vpinsrw $6, %ecx, %xmm2, %xmm0
 ; AVX2-NEXT:    vpinsrw $7, %edx, %xmm0, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: urem_v4i16:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpslld $31, %xmm2, %xmm2
-; AVX512-NEXT:    vpmovd2m %xmm2, %k1
+; AVX512-NEXT:    vpslld $31, %xmm2, %xmm3
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [1,1,1,1,1,1,1,1]
+; AVX512-NEXT:    vpmovd2m %xmm3, %k1
 ; AVX512-NEXT:    vmovdqu16 %xmm1, %xmm2 {%k1}
 ; AVX512-NEXT:    vpextrw $1, %xmm2, %ecx
 ; AVX512-NEXT:    vpextrw $1, %xmm0, %eax
@@ -758,44 +758,44 @@ define <4 x i16> @urem_v4i16(<4 x i16> %x, <4 x i16> %y, <4 x i1> %m) {
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divw %di
-; AVX512-NEXT:    movl %edx, %r8d
-; AVX512-NEXT:    vpextrw $3, %xmm2, %edi
-; AVX512-NEXT:    vpextrw $3, %xmm0, %eax
-; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
-; AVX512-NEXT:    xorl %edx, %edx
-; AVX512-NEXT:    divw %di
 ; AVX512-NEXT:    movl %edx, %edi
-; AVX512-NEXT:    vpextrw $4, %xmm2, %r9d
-; AVX512-NEXT:    vpextrw $4, %xmm0, %eax
-; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
-; AVX512-NEXT:    xorl %edx, %edx
-; AVX512-NEXT:    divw %r9w
-; AVX512-NEXT:    movl %edx, %r9d
-; AVX512-NEXT:    vpextrw $5, %xmm2, %r10d
+; AVX512-NEXT:    vpextrw $3, %xmm2, %r8d
+; AVX512-NEXT:    vpextrw $3, %xmm0, %eax
 ; AVX512-NEXT:    vmovd %esi, %xmm1
-; AVX512-NEXT:    vpextrw $5, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    xorl %edx, %edx
-; AVX512-NEXT:    divw %r10w
+; AVX512-NEXT:    divw %r8w
 ; AVX512-NEXT:    movl %edx, %esi
 ; AVX512-NEXT:    vpinsrw $1, %ecx, %xmm1, %xmm1
-; AVX512-NEXT:    vpinsrw $2, %r8d, %xmm1, %xmm1
-; AVX512-NEXT:    vpextrw $6, %xmm2, %ecx
-; AVX512-NEXT:    vpextrw $6, %xmm0, %eax
+; AVX512-NEXT:    vpextrw $4, %xmm2, %ecx
+; AVX512-NEXT:    vpextrw $4, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divw %cx
 ; AVX512-NEXT:    movl %edx, %ecx
-; AVX512-NEXT:    vpinsrw $3, %edi, %xmm1, %xmm1
-; AVX512-NEXT:    vpinsrw $4, %r9d, %xmm1, %xmm1
-; AVX512-NEXT:    vpextrw $7, %xmm2, %edi
-; AVX512-NEXT:    vpextrw $7, %xmm0, %eax
+; AVX512-NEXT:    vpinsrw $2, %edi, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $5, %xmm2, %edi
+; AVX512-NEXT:    vpextrw $5, %xmm0, %eax
 ; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divw %di
+; AVX512-NEXT:    movl %edx, %edi
+; AVX512-NEXT:    vpinsrw $3, %esi, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $6, %xmm2, %esi
+; AVX512-NEXT:    vpextrw $6, %xmm0, %eax
+; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
+; AVX512-NEXT:    xorl %edx, %edx
+; AVX512-NEXT:    divw %si
+; AVX512-NEXT:    movl %edx, %esi
+; AVX512-NEXT:    vpinsrw $4, %ecx, %xmm1, %xmm1
+; AVX512-NEXT:    vpextrw $7, %xmm2, %ecx
+; AVX512-NEXT:    vpextrw $7, %xmm0, %eax
+; AVX512-NEXT:    # kill: def $ax killed $ax killed $eax
+; AVX512-NEXT:    xorl %edx, %edx
+; AVX512-NEXT:    divw %cx
 ; AVX512-NEXT:    # kill: def $dx killed $dx def $edx
-; AVX512-NEXT:    vpinsrw $5, %esi, %xmm1, %xmm0
-; AVX512-NEXT:    vpinsrw $6, %ecx, %xmm0, %xmm0
+; AVX512-NEXT:    vpinsrw $5, %edi, %xmm1, %xmm0
+; AVX512-NEXT:    vpinsrw $6, %esi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrw $7, %edx, %xmm0, %xmm0
 ; AVX512-NEXT:    retq
   %res = call <4 x i16> @llvm.masked.urem(<4 x i16> %x, <4 x i16> %y, <4 x i1> %m)
@@ -1146,11 +1146,15 @@ define <3 x i10> @urem_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ;
 ; AVX2-LABEL: urem_v3i10:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpbroadcastd {{.*#+}} xmm0 = [1023,1023,1023,1023]
-; AVX2-NEXT:    vmovd %ecx, %xmm1
-; AVX2-NEXT:    vpinsrd $1, %r8d, %xmm1, %xmm1
-; AVX2-NEXT:    vpinsrd $2, %r9d, %xmm1, %xmm1
-; AVX2-NEXT:    vpand %xmm0, %xmm1, %xmm1
+; AVX2-NEXT:    vmovd %edi, %xmm0
+; AVX2-NEXT:    vpinsrd $1, %esi, %xmm0, %xmm0
+; AVX2-NEXT:    vpinsrd $2, %edx, %xmm0, %xmm0
+; AVX2-NEXT:    vpbroadcastd {{.*#+}} xmm1 = [1023,1023,1023,1023]
+; AVX2-NEXT:    vpand %xmm1, %xmm0, %xmm0
+; AVX2-NEXT:    vmovd %ecx, %xmm2
+; AVX2-NEXT:    vpinsrd $1, %r8d, %xmm2, %xmm2
+; AVX2-NEXT:    vpinsrd $2, %r9d, %xmm2, %xmm2
+; AVX2-NEXT:    vpand %xmm1, %xmm2, %xmm1
 ; AVX2-NEXT:    vmovd {{.*#+}} xmm2 = mem[0],zero,zero,zero
 ; AVX2-NEXT:    vmovd {{.*#+}} xmm3 = mem[0],zero,zero,zero
 ; AVX2-NEXT:    vpunpckldq {{.*#+}} xmm2 = xmm3[0],xmm2[0],xmm3[1],xmm2[1]
@@ -1159,11 +1163,7 @@ define <3 x i10> @urem_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX2-NEXT:    vpslld $31, %xmm2, %xmm2
 ; AVX2-NEXT:    vbroadcastss {{.*#+}} xmm3 = [1,1,1,1]
 ; AVX2-NEXT:    vblendvps %xmm2, %xmm1, %xmm3, %xmm1
-; AVX2-NEXT:    vmovd %edi, %xmm2
-; AVX2-NEXT:    vpinsrd $1, %esi, %xmm2, %xmm2
-; AVX2-NEXT:    vpinsrd $2, %edx, %xmm2, %xmm2
 ; AVX2-NEXT:    vextractps $1, %xmm1, %ecx
-; AVX2-NEXT:    vpand %xmm0, %xmm2, %xmm0
 ; AVX2-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divl %ecx
@@ -1174,11 +1174,11 @@ define <3 x i10> @urem_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX2-NEXT:    divl %esi
 ; AVX2-NEXT:    movl %edx, %esi
 ; AVX2-NEXT:    vpextrd $2, %xmm1, %edi
-; AVX2-NEXT:    vmovd %edx, %xmm1
 ; AVX2-NEXT:    vpextrd $2, %xmm0, %eax
+; AVX2-NEXT:    vmovd %edx, %xmm0
 ; AVX2-NEXT:    xorl %edx, %edx
 ; AVX2-NEXT:    divl %edi
-; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm1, %xmm0
+; AVX2-NEXT:    vpinsrd $1, %ecx, %xmm0, %xmm0
 ; AVX2-NEXT:    vpinsrd $2, %edx, %xmm0, %xmm1
 ; AVX2-NEXT:    vpextrw $2, %xmm0, %edx
 ; AVX2-NEXT:    vpextrw $4, %xmm1, %ecx
@@ -1193,20 +1193,20 @@ define <3 x i10> @urem_v3i10(<3 x i10> %x, <3 x i10> %y, <3 x i1> %m) {
 ; AVX512-NEXT:    vpinsrd $1, %esi, %xmm0, %xmm0
 ; AVX512-NEXT:    vpinsrd $2, %edx, %xmm0, %xmm0
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm1 = [1023,1023,1023,1023]
-; AVX512-NEXT:    movb $7, %al
-; AVX512-NEXT:    kmovd %eax, %k1
 ; AVX512-NEXT:    vmovd {{.*#+}} xmm2 = mem[0],zero,zero,zero
 ; AVX512-NEXT:    vpinsrb $1, {{[0-9]+}}(%rsp), %xmm2, %xmm2
+; AVX512-NEXT:    movb $7, %al
+; AVX512-NEXT:    kmovd %eax, %k1
 ; AVX512-NEXT:    vpinsrb $2, {{[0-9]+}}(%rsp), %xmm2, %xmm2
 ; AVX512-NEXT:    vpmovzxbd {{.*#+}} xmm2 = xmm2[0],zero,zero,zero,xmm2[1],zero,zero,zero,xmm2[2],zero,zero,zero,xmm2[3],zero,zero,zero
 ; AVX512-NEXT:    vpbroadcastd {{.*#+}} xmm3 = [1,1,1,1]
-; AVX512-NEXT:    vmovd %ecx, %xmm4
-; AVX512-NEXT:    vpinsrd $1, %r8d, %xmm4, %xmm4
 ; AVX512-NEXT:    vptestmd %xmm3, %xmm2, %k1 {%k1}
-; AVX512-NEXT:    vpinsrd $2, %r9d, %xmm4, %xmm2
+; AVX512-NEXT:    vmovd %ecx, %xmm2
+; AVX512-NEXT:    vpinsrd $1, %r8d, %xmm2, %xmm2
+; AVX512-NEXT:    vpinsrd $2, %r9d, %xmm2, %xmm2
+; AVX512-NEXT:    vpand %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vpandd %xmm1, %xmm2, %xmm3 {%k1}
 ; AVX512-NEXT:    vpextrd $1, %xmm3, %ecx
-; AVX512-NEXT:    vpand %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vpextrd $1, %xmm0, %eax
 ; AVX512-NEXT:    xorl %edx, %edx
 ; AVX512-NEXT:    divl %ecx

--- a/llvm/test/tools/llvm-mca/X86/Broadwell/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Broadwell/resources-x86_64.s
@@ -1321,23 +1321,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  1      1     0.25                        decq	%rdi
 # CHECK-NEXT:  3      7     1.00    *      *            decq	(%rax)
 # CHECK-NEXT:  3      7     1.00    *      *            lock		decq	(%rax)
-# CHECK-NEXT:  1      25    10.00                 U     divb	%dil
-# CHECK-NEXT:  8      34    2.00    *             U     divb	(%rax)
-# CHECK-NEXT:  32     80    8.00                  U     divw	%si
-# CHECK-NEXT:  8      34    2.00    *             U     divw	(%rax)
-# CHECK-NEXT:  32     80    8.00                  U     divl	%edx
-# CHECK-NEXT:  8      34    2.00    *             U     divl	(%rax)
-# CHECK-NEXT:  32     80    8.00                  U     divq	%rcx
-# CHECK-NEXT:  8      34    2.00    *             U     divq	(%rax)
+# CHECK-NEXT:  9      24    9.00                  U     divb	%dil
+# CHECK-NEXT:  10     29    9.00    *             U     divb	(%rax)
+# CHECK-NEXT:  11     25    9.00                  U     divw	%si
+# CHECK-NEXT:  12     30    9.00    *             U     divw	(%rax)
+# CHECK-NEXT:  10     28    9.00                  U     divl	%edx
+# CHECK-NEXT:  11     33    9.00    *             U     divl	(%rax)
+# CHECK-NEXT:  36     92    21.00                 U     divq	%rcx
+# CHECK-NEXT:  37     97    21.00   *             U     divq	(%rax)
 # CHECK-NEXT:  1      100   0.25                  U     enter	$7, $4095
-# CHECK-NEXT:  1      25    10.00                 U     idivb	%dil
-# CHECK-NEXT:  8      35    2.00    *             U     idivb	(%rax)
-# CHECK-NEXT:  1      25    10.00                 U     idivw	%si
-# CHECK-NEXT:  8      35    2.00    *             U     idivw	(%rax)
-# CHECK-NEXT:  1      25    10.00                 U     idivl	%edx
-# CHECK-NEXT:  8      35    2.00    *             U     idivl	(%rax)
-# CHECK-NEXT:  1      25    10.00                 U     idivq	%rcx
-# CHECK-NEXT:  8      35    2.00    *             U     idivq	(%rax)
+# CHECK-NEXT:  9      24    6.00                  U     idivb	%dil
+# CHECK-NEXT:  10     29    6.00    *             U     idivb	(%rax)
+# CHECK-NEXT:  10     26    6.00                  U     idivw	%si
+# CHECK-NEXT:  11     31    6.00    *             U     idivw	(%rax)
+# CHECK-NEXT:  9      28    6.00                  U     idivl	%edx
+# CHECK-NEXT:  10     33    6.00    *             U     idivl	(%rax)
+# CHECK-NEXT:  59     100   24.00                 U     idivq	%rcx
+# CHECK-NEXT:  60     105   24.00   *             U     idivq	(%rax)
 # CHECK-NEXT:  1      3     1.00                        imulb	%dil
 # CHECK-NEXT:  2      8     1.00    *                   imulb	(%rax)
 # CHECK-NEXT:  4      4     1.00                        imulw	%di
@@ -1962,7 +1962,7 @@ xorq (%rax), %rdi
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]
-# CHECK-NEXT: 50.00   -     615.50 396.50 378.50 378.50 345.00 293.00 651.00 129.00
+# CHECK-NEXT: 180.00  -     577.75 347.75 378.50 378.50 345.00 257.75 631.75 129.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    Instructions:
@@ -2253,23 +2253,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     decq	%rdi
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   decq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   lock		decq	(%rax)
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -     divb	%dil
-# CHECK-NEXT:  -      -     2.25   2.25   0.50   0.50    -     2.25   0.25    -     divb	(%rax)
-# CHECK-NEXT:  -      -     10.25  10.25   -      -      -     5.75   5.75    -     divw	%si
-# CHECK-NEXT:  -      -     2.25   2.25   0.50   0.50    -     2.25   0.25    -     divw	(%rax)
-# CHECK-NEXT:  -      -     10.25  10.25   -      -      -     5.75   5.75    -     divl	%edx
-# CHECK-NEXT:  -      -     2.25   2.25   0.50   0.50    -     2.25   0.25    -     divl	(%rax)
-# CHECK-NEXT:  -      -     10.25  10.25   -      -      -     5.75   5.75    -     divq	%rcx
-# CHECK-NEXT:  -      -     2.25   2.25   0.50   0.50    -     2.25   0.25    -     divq	(%rax)
+# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divb	%dil
+# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divb	(%rax)
+# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divw	%si
+# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divw	(%rax)
+# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divl	%edx
+# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divl	(%rax)
+# CHECK-NEXT: 21.00   -     1.00    -      -      -      -      -      -      -     divq	%rcx
+# CHECK-NEXT: 21.00   -     1.00    -     0.50   0.50    -      -      -      -     divq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     enter	$7, $4095
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -     idivb	%dil
-# CHECK-NEXT:  -      -     2.25   2.25   0.50   0.50    -     2.25   0.25    -     idivb	(%rax)
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -     idivw	%si
-# CHECK-NEXT:  -      -     2.25   2.25   0.50   0.50    -     2.25   0.25    -     idivw	(%rax)
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -     idivl	%edx
-# CHECK-NEXT:  -      -     2.25   2.25   0.50   0.50    -     2.25   0.25    -     idivl	(%rax)
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -     idivq	%rcx
-# CHECK-NEXT:  -      -     2.25   2.25   0.50   0.50    -     2.25   0.25    -     idivq	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivb	%dil
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivb	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivw	%si
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivw	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivl	%edx
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivl	(%rax)
+# CHECK-NEXT: 24.00   -     1.00    -      -      -      -      -      -      -     idivq	%rcx
+# CHECK-NEXT: 24.00   -     1.00    -     0.50   0.50    -      -      -      -     idivq	(%rax)
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -      -      -     imulb	%dil
 # CHECK-NEXT:  -      -      -     1.00   0.50   0.50    -      -      -      -     imulb	(%rax)
 # CHECK-NEXT:  -      -     1.00   1.50    -      -      -     0.50   1.00    -     imulw	%di

--- a/llvm/test/tools/llvm-mca/X86/Broadwell/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Broadwell/resources-x86_64.s
@@ -1962,7 +1962,7 @@ xorq (%rax), %rdi
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]
-# CHECK-NEXT: 180.00  -     577.75 347.75 378.50 378.50 345.00 257.75 631.75 129.00
+# CHECK-NEXT: 180.00  -     666.25 417.25 378.50 378.50 345.00 324.25 685.25 129.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    Instructions:
@@ -2253,23 +2253,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     decq	%rdi
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   decq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   lock		decq	(%rax)
-# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divb	%dil
-# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divb	(%rax)
-# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divw	%si
-# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divw	(%rax)
-# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divl	%edx
-# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divl	(%rax)
-# CHECK-NEXT: 21.00   -     1.00    -      -      -      -      -      -      -     divq	%rcx
-# CHECK-NEXT: 21.00   -     1.00    -     0.50   0.50    -      -      -      -     divq	(%rax)
+# CHECK-NEXT: 9.00    -     3.00   2.50    -      -      -     2.50   1.00    -     divb	%dil
+# CHECK-NEXT: 9.00    -     3.00   2.50   0.50   0.50    -     2.50   1.00    -     divb	(%rax)
+# CHECK-NEXT: 9.00    -     3.50   3.00    -      -      -     3.00   1.50    -     divw	%si
+# CHECK-NEXT: 9.00    -     3.50   3.00   0.50   0.50    -     3.00   1.50    -     divw	(%rax)
+# CHECK-NEXT: 9.00    -     3.25   2.75    -      -      -     2.75   1.25    -     divl	%edx
+# CHECK-NEXT: 9.00    -     3.25   2.75   0.50   0.50    -     2.75   1.25    -     divl	(%rax)
+# CHECK-NEXT: 21.00   -     11.58  6.58    -      -      -     6.58   7.25    -     divq	%rcx
+# CHECK-NEXT: 21.00   -     11.58  6.58   0.50   0.50    -     6.58   7.25    -     divq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     enter	$7, $4095
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivb	%dil
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivb	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivw	%si
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivw	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivl	%edx
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivl	(%rax)
-# CHECK-NEXT: 24.00   -     1.00    -      -      -      -      -      -      -     idivq	%rcx
-# CHECK-NEXT: 24.00   -     1.00    -     0.50   0.50    -      -      -      -     idivq	(%rax)
+# CHECK-NEXT: 6.00    -     2.75   2.75    -      -      -     2.75   0.75    -     idivb	%dil
+# CHECK-NEXT: 6.00    -     2.75   2.75   0.50   0.50    -     2.75   0.75    -     idivb	(%rax)
+# CHECK-NEXT: 6.00    -     3.00   3.00    -      -      -     3.00   1.00    -     idivw	%si
+# CHECK-NEXT: 6.00    -     3.00   3.00   0.50   0.50    -     3.00   1.00    -     idivw	(%rax)
+# CHECK-NEXT: 6.00    -     2.75   2.75    -      -      -     2.75   0.75    -     idivl	%edx
+# CHECK-NEXT: 6.00    -     2.75   2.75   0.50   0.50    -     2.75   0.75    -     idivl	(%rax)
+# CHECK-NEXT: 24.00   -     22.42  11.42   -      -      -     9.92   13.25   -     idivq	%rcx
+# CHECK-NEXT: 24.00   -     22.42  11.42  0.50   0.50    -     9.92   13.25   -     idivq	(%rax)
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -      -      -     imulb	%dil
 # CHECK-NEXT:  -      -      -     1.00   0.50   0.50    -      -      -      -     imulb	(%rax)
 # CHECK-NEXT:  -      -     1.00   1.50    -      -      -     0.50   1.00    -     imulw	%di

--- a/llvm/test/tools/llvm-mca/X86/Haswell/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Haswell/resources-x86_64.s
@@ -1321,23 +1321,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  1      1     0.25                        decq	%rdi
 # CHECK-NEXT:  3      7     1.00    *      *            decq	(%rax)
 # CHECK-NEXT:  3      7     1.00    *      *            lock		decq	(%rax)
-# CHECK-NEXT:  9      22    1.00                  U     divb	%dil
-# CHECK-NEXT:  2      29    10.00   *             U     divb	(%rax)
-# CHECK-NEXT:  32     98    8.00                  U     divw	%si
-# CHECK-NEXT:  2      29    10.00   *             U     divw	(%rax)
-# CHECK-NEXT:  32     98    8.00                  U     divl	%edx
-# CHECK-NEXT:  2      29    10.00   *             U     divl	(%rax)
-# CHECK-NEXT:  32     98    8.00                  U     divq	%rcx
-# CHECK-NEXT:  2      29    10.00   *             U     divq	(%rax)
+# CHECK-NEXT:  9      24    9.00                  U     divb	%dil
+# CHECK-NEXT:  10     29    9.00    *             U     divb	(%rax)
+# CHECK-NEXT:  11     25    9.00                  U     divw	%si
+# CHECK-NEXT:  12     30    9.00    *             U     divw	(%rax)
+# CHECK-NEXT:  10     28    9.00                  U     divl	%edx
+# CHECK-NEXT:  11     33    9.00    *             U     divl	(%rax)
+# CHECK-NEXT:  36     94    21.00                 U     divq	%rcx
+# CHECK-NEXT:  37     99    21.00   *             U     divq	(%rax)
 # CHECK-NEXT:  1      100   0.25                  U     enter	$7, $4095
-# CHECK-NEXT:  9      23    1.00                  U     idivb	%dil
-# CHECK-NEXT:  2      29    10.00   *             U     idivb	(%rax)
-# CHECK-NEXT:  66     112   16.50                 U     idivw	%si
-# CHECK-NEXT:  2      29    10.00   *             U     idivw	(%rax)
-# CHECK-NEXT:  66     112   16.50                 U     idivl	%edx
-# CHECK-NEXT:  2      29    10.00   *             U     idivl	(%rax)
-# CHECK-NEXT:  66     112   16.50                 U     idivq	%rcx
-# CHECK-NEXT:  2      29    10.00   *             U     idivq	(%rax)
+# CHECK-NEXT:  9      24    8.00                  U     idivb	%dil
+# CHECK-NEXT:  10     29    8.00    *             U     idivb	(%rax)
+# CHECK-NEXT:  10     25    8.00                  U     idivw	%si
+# CHECK-NEXT:  11     30    8.00    *             U     idivw	(%rax)
+# CHECK-NEXT:  9      28    8.00                  U     idivl	%edx
+# CHECK-NEXT:  10     33    8.00    *             U     idivl	(%rax)
+# CHECK-NEXT:  59     101   24.00                 U     idivq	%rcx
+# CHECK-NEXT:  60     106   24.00   *             U     idivq	(%rax)
 # CHECK-NEXT:  1      3     1.00                        imulb	%dil
 # CHECK-NEXT:  2      8     1.00    *                   imulb	(%rax)
 # CHECK-NEXT:  4      4     1.00                        imulw	%di
@@ -1962,7 +1962,7 @@ xorq (%rax), %rdi
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]
-# CHECK-NEXT: 80.00   -     668.50 419.50 371.50 371.50 331.00 318.00 733.00 123.00
+# CHECK-NEXT: 192.00  -     585.25 355.25 371.50 371.50 331.00 261.25 643.25 123.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    Instructions:
@@ -2253,23 +2253,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     decq	%rdi
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   decq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   lock		decq	(%rax)
-# CHECK-NEXT:  -      -     1.00   1.00    -      -      -     1.00   1.00    -     divb	%dil
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divb	(%rax)
-# CHECK-NEXT:  -      -     10.25  10.25   -      -      -     5.75   5.75    -     divw	%si
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divw	(%rax)
-# CHECK-NEXT:  -      -     10.25  10.25   -      -      -     5.75   5.75    -     divl	%edx
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divl	(%rax)
-# CHECK-NEXT:  -      -     10.25  10.25   -      -      -     5.75   5.75    -     divq	%rcx
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divq	(%rax)
+# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divb	%dil
+# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divb	(%rax)
+# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divw	%si
+# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divw	(%rax)
+# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divl	%edx
+# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divl	(%rax)
+# CHECK-NEXT: 21.00   -     1.00    -      -      -      -      -      -      -     divq	%rcx
+# CHECK-NEXT: 21.00   -     1.00    -     0.50   0.50    -      -      -      -     divq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     enter	$7, $4095
-# CHECK-NEXT:  -      -     1.00   1.00    -      -      -     1.00   1.00    -     idivb	%dil
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     idivb	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -     idivw	%si
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     idivw	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -     idivl	%edx
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     idivl	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -     idivq	%rcx
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     idivq	(%rax)
+# CHECK-NEXT: 8.00    -     1.00    -      -      -      -      -      -      -     idivb	%dil
+# CHECK-NEXT: 8.00    -     1.00    -     0.50   0.50    -      -      -      -     idivb	(%rax)
+# CHECK-NEXT: 8.00    -     1.00    -      -      -      -      -      -      -     idivw	%si
+# CHECK-NEXT: 8.00    -     1.00    -     0.50   0.50    -      -      -      -     idivw	(%rax)
+# CHECK-NEXT: 8.00    -     1.00    -      -      -      -      -      -      -     idivl	%edx
+# CHECK-NEXT: 8.00    -     1.00    -     0.50   0.50    -      -      -      -     idivl	(%rax)
+# CHECK-NEXT: 24.00   -     1.00    -      -      -      -      -      -      -     idivq	%rcx
+# CHECK-NEXT: 24.00   -     1.00    -     0.50   0.50    -      -      -      -     idivq	(%rax)
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -      -      -     imulb	%dil
 # CHECK-NEXT:  -      -      -     1.00   0.50   0.50    -      -      -      -     imulb	(%rax)
 # CHECK-NEXT:  -      -     1.00   1.50    -      -      -     0.50   1.00    -     imulw	%di

--- a/llvm/test/tools/llvm-mca/X86/Haswell/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/Haswell/resources-x86_64.s
@@ -1962,7 +1962,7 @@ xorq (%rax), %rdi
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]
-# CHECK-NEXT: 192.00  -     585.25 355.25 371.50 371.50 331.00 261.25 643.25 123.00
+# CHECK-NEXT: 192.00  -     674.58 424.58 371.50 371.50 331.00 327.58 696.25 123.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    Instructions:
@@ -2253,23 +2253,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     decq	%rdi
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   decq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   lock		decq	(%rax)
-# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divb	%dil
-# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divb	(%rax)
-# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divw	%si
-# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divw	(%rax)
-# CHECK-NEXT: 9.00    -     1.00    -      -      -      -      -      -      -     divl	%edx
-# CHECK-NEXT: 9.00    -     1.00    -     0.50   0.50    -      -      -      -     divl	(%rax)
-# CHECK-NEXT: 21.00   -     1.00    -      -      -      -      -      -      -     divq	%rcx
-# CHECK-NEXT: 21.00   -     1.00    -     0.50   0.50    -      -      -      -     divq	(%rax)
+# CHECK-NEXT: 9.00    -     3.00   2.50    -      -      -     2.50   1.00    -     divb	%dil
+# CHECK-NEXT: 9.00    -     3.00   2.50   0.50   0.50    -     2.50   1.00    -     divb	(%rax)
+# CHECK-NEXT: 9.00    -     3.50   3.00    -      -      -     3.00   1.50    -     divw	%si
+# CHECK-NEXT: 9.00    -     3.50   3.00   0.50   0.50    -     3.00   1.50    -     divw	(%rax)
+# CHECK-NEXT: 9.00    -     3.25   2.75    -      -      -     2.75   1.25    -     divl	%edx
+# CHECK-NEXT: 9.00    -     3.25   2.75   0.50   0.50    -     2.75   1.25    -     divl	(%rax)
+# CHECK-NEXT: 21.00   -     11.67  6.67    -      -      -     6.67   7.00    -     divq	%rcx
+# CHECK-NEXT: 21.00   -     11.67  6.67   0.50   0.50    -     6.67   7.00    -     divq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     enter	$7, $4095
-# CHECK-NEXT: 8.00    -     1.00    -      -      -      -      -      -      -     idivb	%dil
-# CHECK-NEXT: 8.00    -     1.00    -     0.50   0.50    -      -      -      -     idivb	(%rax)
-# CHECK-NEXT: 8.00    -     1.00    -      -      -      -      -      -      -     idivw	%si
-# CHECK-NEXT: 8.00    -     1.00    -     0.50   0.50    -      -      -      -     idivw	(%rax)
-# CHECK-NEXT: 8.00    -     1.00    -      -      -      -      -      -      -     idivl	%edx
-# CHECK-NEXT: 8.00    -     1.00    -     0.50   0.50    -      -      -      -     idivl	(%rax)
-# CHECK-NEXT: 24.00   -     1.00    -      -      -      -      -      -      -     idivq	%rcx
-# CHECK-NEXT: 24.00   -     1.00    -     0.50   0.50    -      -      -      -     idivq	(%rax)
+# CHECK-NEXT: 8.00    -     2.75   2.75    -      -      -     2.75   0.75    -     idivb	%dil
+# CHECK-NEXT: 8.00    -     2.75   2.75   0.50   0.50    -     2.75   0.75    -     idivb	(%rax)
+# CHECK-NEXT: 8.00    -     3.00   3.00    -      -      -     3.00   1.00    -     idivw	%si
+# CHECK-NEXT: 8.00    -     3.00   3.00   0.50   0.50    -     3.00   1.00    -     idivw	(%rax)
+# CHECK-NEXT: 8.00    -     2.75   2.75    -      -      -     2.75   0.75    -     idivl	%edx
+# CHECK-NEXT: 8.00    -     2.75   2.75   0.50   0.50    -     2.75   0.75    -     idivl	(%rax)
+# CHECK-NEXT: 24.00   -     22.75  11.25   -      -      -     9.75   13.25   -     idivq	%rcx
+# CHECK-NEXT: 24.00   -     22.75  11.25  0.50   0.50    -     9.75   13.25   -     idivq	(%rax)
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -      -      -     imulb	%dil
 # CHECK-NEXT:  -      -      -     1.00   0.50   0.50    -      -      -      -     imulb	(%rax)
 # CHECK-NEXT:  -      -     1.00   1.50    -      -      -     0.50   1.00    -     imulw	%di

--- a/llvm/test/tools/llvm-mca/X86/IceLakeServer/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/IceLakeServer/resources-x86_64.s
@@ -1964,7 +1964,7 @@ xorq (%rax), %rdi
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]
-# CHECK-NEXT: 112.00  -     591.25 334.75 249.50 249.50 172.50 244.75 652.25 193.50 193.50 172.50
+# CHECK-NEXT: 112.00  -     582.25 381.75 249.50 249.50 172.50 255.75 659.25 193.50 193.50 172.50
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   Instructions:
@@ -2255,23 +2255,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -      -      -     decq	%rdi
 # CHECK-NEXT:  -      -     0.25   0.25   0.50   0.50   0.50   0.25   0.25   0.50   0.50   0.50   decq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25   0.50   0.50   0.50   0.25   0.25   0.50   0.50   0.50   lock		decq	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     divb	%dil
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     divb	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     divw	%si
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     divw	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     divl	%edx
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     divl	(%rax)
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -      -      -     divq	%rcx
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -      -      -     divq	(%rax)
+# CHECK-NEXT: 6.00    -     0.50   2.50    -      -      -     0.50   0.50    -      -      -     divb	%dil
+# CHECK-NEXT: 6.00    -     0.50   2.50   0.50   0.50    -     0.50   0.50    -      -      -     divb	(%rax)
+# CHECK-NEXT: 6.00    -     0.75   3.25    -      -      -     1.25   0.75    -      -      -     divw	%si
+# CHECK-NEXT: 6.00    -     0.75   3.25   0.50   0.50    -     1.25   0.75    -      -      -     divw	(%rax)
+# CHECK-NEXT: 6.00    -     0.25   2.75    -      -      -     0.75   0.25    -      -      -     divl	%edx
+# CHECK-NEXT: 6.00    -     0.25   2.75   0.50   0.50    -     0.75   0.25    -      -      -     divl	(%rax)
+# CHECK-NEXT: 10.00   -     0.25   3.25    -      -      -     0.25   0.25    -      -      -     divq	%rcx
+# CHECK-NEXT: 10.00   -     0.25   3.25   0.50   0.50    -     0.25   0.25    -      -      -     divq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -      -      -     enter	$7, $4095
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     idivb	%dil
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     idivb	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     idivw	%si
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     idivw	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     idivl	%edx
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     idivl	(%rax)
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -      -      -     idivq	%rcx
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -      -      -     idivq	(%rax)
+# CHECK-NEXT: 6.00    -     0.50   2.50    -      -      -     0.50   0.50    -      -      -     idivb	%dil
+# CHECK-NEXT: 6.00    -     0.50   2.50   0.50   0.50    -     0.50   0.50    -      -      -     idivb	(%rax)
+# CHECK-NEXT: 6.00    -     0.75   3.25    -      -      -     1.25   0.75    -      -      -     idivw	%si
+# CHECK-NEXT: 6.00    -     0.75   3.25   0.50   0.50    -     1.25   0.75    -      -      -     idivw	(%rax)
+# CHECK-NEXT: 6.00    -     0.25   2.75    -      -      -     0.75   0.25    -      -      -     idivl	%edx
+# CHECK-NEXT: 6.00    -     0.25   2.75   0.50   0.50    -     0.75   0.25    -      -      -     idivl	(%rax)
+# CHECK-NEXT: 10.00   -     0.25   3.25    -      -      -     0.25   0.25    -      -      -     idivq	%rcx
+# CHECK-NEXT: 10.00   -     0.25   3.25   0.50   0.50    -     0.25   0.25    -      -      -     idivq	(%rax)
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -      -      -      -      -     imulb	%dil
 # CHECK-NEXT:  -      -      -     1.00   0.50   0.50    -      -      -      -      -      -     imulb	(%rax)
 # CHECK-NEXT:  -      -     1.00   1.50    -      -      -     0.50   1.00    -      -      -     imulw	%di

--- a/llvm/test/tools/llvm-mca/X86/IceLakeServer/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/IceLakeServer/resources-x86_64.s
@@ -1321,23 +1321,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  1      1     0.25                        decq	%rdi
 # CHECK-NEXT:  3      7     0.50    *      *            decq	(%rax)
 # CHECK-NEXT:  3      7     0.50    *      *            lock		decq	(%rax)
-# CHECK-NEXT:  1      25    10.00                 U     divb	%dil
-# CHECK-NEXT:  2      29    10.00   *             U     divb	(%rax)
-# CHECK-NEXT:  32     76    8.00                  U     divw	%si
-# CHECK-NEXT:  2      29    10.00   *             U     divw	(%rax)
-# CHECK-NEXT:  32     76    8.00                  U     divl	%edx
-# CHECK-NEXT:  2      29    10.00   *             U     divl	(%rax)
-# CHECK-NEXT:  32     76    8.00                  U     divq	%rcx
-# CHECK-NEXT:  2      29    10.00   *             U     divq	(%rax)
+# CHECK-NEXT:  4      15    6.00                  U     divb	%dil
+# CHECK-NEXT:  5      20    6.00    *             U     divb	(%rax)
+# CHECK-NEXT:  6      16    6.00                  U     divw	%si
+# CHECK-NEXT:  7      21    6.00    *             U     divw	(%rax)
+# CHECK-NEXT:  4      15    6.00                  U     divl	%edx
+# CHECK-NEXT:  5      20    6.00    *             U     divl	(%rax)
+# CHECK-NEXT:  4      18    10.00                 U     divq	%rcx
+# CHECK-NEXT:  5      23    10.00   *             U     divq	(%rax)
 # CHECK-NEXT:  1      100   0.25                  U     enter	$7, $4095
-# CHECK-NEXT:  1      25    10.00                 U     idivb	%dil
-# CHECK-NEXT:  8      28    4.00    *             U     idivb	(%rax)
-# CHECK-NEXT:  66     102   16.50                 U     idivw	%si
-# CHECK-NEXT:  8      28    4.00    *             U     idivw	(%rax)
-# CHECK-NEXT:  66     102   16.50                 U     idivl	%edx
-# CHECK-NEXT:  8      28    4.00    *             U     idivl	(%rax)
-# CHECK-NEXT:  66     102   16.50                 U     idivq	%rcx
-# CHECK-NEXT:  8      28    4.00    *             U     idivq	(%rax)
+# CHECK-NEXT:  4      15    6.00                  U     idivb	%dil
+# CHECK-NEXT:  5      20    6.00    *             U     idivb	(%rax)
+# CHECK-NEXT:  6      16    6.00                  U     idivw	%si
+# CHECK-NEXT:  7      21    6.00    *             U     idivw	(%rax)
+# CHECK-NEXT:  4      15    6.00                  U     idivl	%edx
+# CHECK-NEXT:  5      20    6.00    *             U     idivl	(%rax)
+# CHECK-NEXT:  4      18    10.00                 U     idivq	%rcx
+# CHECK-NEXT:  5      23    10.00   *             U     idivq	(%rax)
 # CHECK-NEXT:  1      3     1.00                        imulb	%dil
 # CHECK-NEXT:  2      8     1.00    *                   imulb	(%rax)
 # CHECK-NEXT:  4      4     1.00                        imulw	%di
@@ -1964,7 +1964,7 @@ xorq (%rax), %rdi
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]
-# CHECK-NEXT: 60.00   -     679.50 381.50 249.50 249.50 172.50 333.00 741.00 193.50 193.50 172.50
+# CHECK-NEXT: 112.00  -     591.25 334.75 249.50 249.50 172.50 244.75 652.25 193.50 193.50 172.50
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   Instructions:
@@ -2255,23 +2255,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -      -      -     decq	%rdi
 # CHECK-NEXT:  -      -     0.25   0.25   0.50   0.50   0.50   0.25   0.25   0.50   0.50   0.50   decq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25   0.50   0.50   0.50   0.25   0.25   0.50   0.50   0.50   lock		decq	(%rax)
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -      -      -     divb	%dil
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -      -      -     divb	(%rax)
-# CHECK-NEXT:  -      -     10.25  4.75    -      -      -     11.25  5.75    -      -      -     divw	%si
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -      -      -     divw	(%rax)
-# CHECK-NEXT:  -      -     10.25  4.75    -      -      -     11.25  5.75    -      -      -     divl	%edx
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -      -      -     divl	(%rax)
-# CHECK-NEXT:  -      -     10.25  4.75    -      -      -     11.25  5.75    -      -      -     divq	%rcx
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     divb	%dil
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     divb	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     divw	%si
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     divw	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     divl	%edx
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     divl	(%rax)
+# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -      -      -     divq	%rcx
 # CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -      -      -     divq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -      -      -     enter	$7, $4095
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -      -      -     idivb	%dil
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -      -      -     idivb	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -      -      -     idivw	%si
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -      -      -     idivw	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -      -      -     idivl	%edx
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -      -      -     idivl	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -      -      -     idivq	%rcx
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -      -      -     idivq	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     idivb	%dil
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     idivb	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     idivw	%si
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     idivw	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -      -      -     idivl	%edx
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -      -      -     idivl	(%rax)
+# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -      -      -     idivq	%rcx
+# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -      -      -     idivq	(%rax)
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -      -      -      -      -     imulb	%dil
 # CHECK-NEXT:  -      -      -     1.00   0.50   0.50    -      -      -      -      -      -     imulb	(%rax)
 # CHECK-NEXT:  -      -     1.00   1.50    -      -      -     0.50   1.00    -      -      -     imulw	%di

--- a/llvm/test/tools/llvm-mca/X86/SkylakeClient/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/SkylakeClient/resources-x86_64.s
@@ -1962,7 +1962,7 @@ xorq (%rax), %rdi
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]
-# CHECK-NEXT: 162.00  -     595.00 334.50 378.50 378.50 345.00 244.50 656.00 129.00
+# CHECK-NEXT: 162.00  -     690.00 374.50 378.50 378.50 345.00 342.50 711.00 129.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    Instructions:
@@ -2253,23 +2253,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     decq	%rdi
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   decq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   lock		decq	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divb	%dil
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divb	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divw	%si
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divw	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divl	%edx
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divl	(%rax)
-# CHECK-NEXT: 21.00   -     1.00    -      -      -      -      -      -      -     divq	%rcx
-# CHECK-NEXT: 21.00   -     1.00    -     0.50   0.50    -      -      -      -     divq	(%rax)
+# CHECK-NEXT: 6.00    -     3.00   1.00    -      -      -     5.00   1.00    -     divb	%dil
+# CHECK-NEXT: 6.00    -     3.00   1.00   0.50   0.50    -     5.00   1.00    -     divb	(%rax)
+# CHECK-NEXT: 6.00    -     3.00   1.00    -      -      -     5.00   1.00    -     divw	%si
+# CHECK-NEXT: 6.00    -     3.00   1.00   0.50   0.50    -     5.00   1.00    -     divw	(%rax)
+# CHECK-NEXT: 6.00    -     3.00   1.00    -      -      -     5.00   1.00    -     divl	%edx
+# CHECK-NEXT: 6.00    -     3.00   1.00   0.50   0.50    -     5.00   1.00    -     divl	(%rax)
+# CHECK-NEXT: 21.00   -     12.92  4.92    -      -      -     7.42   7.75    -     divq	%rcx
+# CHECK-NEXT: 21.00   -     12.92  4.92   0.50   0.50    -     7.42   7.75    -     divq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     enter	$7, $4095
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivb	%dil
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivb	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivw	%si
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivw	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivl	%edx
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivl	(%rax)
-# CHECK-NEXT: 24.00   -     1.00    -      -      -      -      -      -      -     idivq	%rcx
-# CHECK-NEXT: 24.00   -     1.00    -     0.50   0.50    -      -      -      -     idivq	(%rax)
+# CHECK-NEXT: 6.00    -     3.25   1.25    -      -      -     5.25   1.25    -     idivb	%dil
+# CHECK-NEXT: 6.00    -     3.25   1.25   0.50   0.50    -     5.25   1.25    -     idivb	(%rax)
+# CHECK-NEXT: 6.00    -     3.00   1.00    -      -      -     5.00   1.00    -     idivw	%si
+# CHECK-NEXT: 6.00    -     3.00   1.00   0.50   0.50    -     5.00   1.00    -     idivw	(%rax)
+# CHECK-NEXT: 6.00    -     3.00   1.00    -      -      -     5.00   1.00    -     idivl	%edx
+# CHECK-NEXT: 6.00    -     3.00   1.00   0.50   0.50    -     5.00   1.00    -     idivl	(%rax)
+# CHECK-NEXT: 24.00   -     24.33  8.83    -      -      -     11.33  13.50   -     idivq	%rcx
+# CHECK-NEXT: 24.00   -     24.33  8.83   0.50   0.50    -     11.33  13.50   -     idivq	(%rax)
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -      -      -     imulb	%dil
 # CHECK-NEXT:  -      -      -     1.00   0.50   0.50    -      -      -      -     imulb	(%rax)
 # CHECK-NEXT:  -      -     1.00   1.50    -      -      -     0.50   1.00    -     imulw	%di

--- a/llvm/test/tools/llvm-mca/X86/SkylakeClient/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/SkylakeClient/resources-x86_64.s
@@ -1321,23 +1321,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  1      1     0.25                        decq	%rdi
 # CHECK-NEXT:  3      7     1.00    *      *            decq	(%rax)
 # CHECK-NEXT:  3      7     1.00    *      *            lock		decq	(%rax)
-# CHECK-NEXT:  1      25    10.00                 U     divb	%dil
-# CHECK-NEXT:  2      29    10.00   *             U     divb	(%rax)
-# CHECK-NEXT:  32     76    8.00                  U     divw	%si
-# CHECK-NEXT:  2      29    10.00   *             U     divw	(%rax)
-# CHECK-NEXT:  32     76    8.00                  U     divl	%edx
-# CHECK-NEXT:  2      29    10.00   *             U     divl	(%rax)
-# CHECK-NEXT:  32     76    8.00                  U     divq	%rcx
-# CHECK-NEXT:  2      29    10.00   *             U     divq	(%rax)
+# CHECK-NEXT:  10     25    6.00                  U     divb	%dil
+# CHECK-NEXT:  11     30    6.00    *             U     divb	(%rax)
+# CHECK-NEXT:  10     24    6.00                  U     divw	%si
+# CHECK-NEXT:  11     29    6.00    *             U     divw	(%rax)
+# CHECK-NEXT:  10     28    6.00                  U     divl	%edx
+# CHECK-NEXT:  11     33    6.00    *             U     divl	(%rax)
+# CHECK-NEXT:  36     90    21.00                 U     divq	%rcx
+# CHECK-NEXT:  37     95    21.00   *             U     divq	(%rax)
 # CHECK-NEXT:  1      100   0.25                  U     enter	$7, $4095
-# CHECK-NEXT:  1      25    10.00                 U     idivb	%dil
-# CHECK-NEXT:  8      28    4.00    *             U     idivb	(%rax)
-# CHECK-NEXT:  66     102   16.50                 U     idivw	%si
-# CHECK-NEXT:  8      28    4.00    *             U     idivw	(%rax)
-# CHECK-NEXT:  66     102   16.50                 U     idivl	%edx
-# CHECK-NEXT:  8      28    4.00    *             U     idivl	(%rax)
-# CHECK-NEXT:  66     102   16.50                 U     idivq	%rcx
-# CHECK-NEXT:  8      28    4.00    *             U     idivq	(%rax)
+# CHECK-NEXT:  11     25    6.00                  U     idivb	%dil
+# CHECK-NEXT:  12     30    6.00    *             U     idivb	(%rax)
+# CHECK-NEXT:  10     24    6.00                  U     idivw	%si
+# CHECK-NEXT:  11     29    6.00    *             U     idivw	(%rax)
+# CHECK-NEXT:  10     28    6.00                  U     idivl	%edx
+# CHECK-NEXT:  11     33    6.00    *             U     idivl	(%rax)
+# CHECK-NEXT:  57     96    24.00                 U     idivq	%rcx
+# CHECK-NEXT:  58     101   24.00   *             U     idivq	(%rax)
 # CHECK-NEXT:  1      3     1.00                        imulb	%dil
 # CHECK-NEXT:  2      8     1.00    *                   imulb	(%rax)
 # CHECK-NEXT:  4      4     1.00                        imulw	%di
@@ -1962,7 +1962,7 @@ xorq (%rax), %rdi
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]
-# CHECK-NEXT: 60.00   -     683.25 381.25 378.50 378.50 345.00 332.75 744.75 129.00
+# CHECK-NEXT: 162.00  -     595.00 334.50 378.50 378.50 345.00 244.50 656.00 129.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    Instructions:
@@ -2253,23 +2253,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     decq	%rdi
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   decq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   lock		decq	(%rax)
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -     divb	%dil
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divb	(%rax)
-# CHECK-NEXT:  -      -     10.25  4.75    -      -      -     11.25  5.75    -     divw	%si
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divw	(%rax)
-# CHECK-NEXT:  -      -     10.25  4.75    -      -      -     11.25  5.75    -     divl	%edx
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divl	(%rax)
-# CHECK-NEXT:  -      -     10.25  4.75    -      -      -     11.25  5.75    -     divq	%rcx
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divq	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divb	%dil
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divb	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divw	%si
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divw	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divl	%edx
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divl	(%rax)
+# CHECK-NEXT: 21.00   -     1.00    -      -      -      -      -      -      -     divq	%rcx
+# CHECK-NEXT: 21.00   -     1.00    -     0.50   0.50    -      -      -      -     divq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     enter	$7, $4095
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -     idivb	%dil
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -     idivb	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -     idivw	%si
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -     idivw	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -     idivl	%edx
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -     idivl	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -     idivq	%rcx
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -     idivq	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivb	%dil
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivb	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivw	%si
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivw	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivl	%edx
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivl	(%rax)
+# CHECK-NEXT: 24.00   -     1.00    -      -      -      -      -      -      -     idivq	%rcx
+# CHECK-NEXT: 24.00   -     1.00    -     0.50   0.50    -      -      -      -     idivq	(%rax)
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -      -      -     imulb	%dil
 # CHECK-NEXT:  -      -      -     1.00   0.50   0.50    -      -      -      -     imulb	(%rax)
 # CHECK-NEXT:  -      -     1.00   1.50    -      -      -     0.50   1.00    -     imulw	%di

--- a/llvm/test/tools/llvm-mca/X86/SkylakeServer/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/SkylakeServer/resources-x86_64.s
@@ -1962,7 +1962,7 @@ xorq (%rax), %rdi
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]
-# CHECK-NEXT: 162.00  -     595.25 334.75 378.50 378.50 345.00 244.75 656.25 129.00
+# CHECK-NEXT: 162.00  -     689.25 373.75 378.50 378.50 345.00 342.75 711.25 129.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    Instructions:
@@ -2253,23 +2253,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     decq	%rdi
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   decq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   lock		decq	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divb	%dil
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divb	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divw	%si
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divw	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divl	%edx
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divl	(%rax)
-# CHECK-NEXT: 21.00   -     1.00    -      -      -      -      -      -      -     divq	%rcx
-# CHECK-NEXT: 21.00   -     1.00    -     0.50   0.50    -      -      -      -     divq	(%rax)
+# CHECK-NEXT: 6.00    -     3.00   1.00    -      -      -     5.00   1.00    -     divb	%dil
+# CHECK-NEXT: 6.00    -     3.00   1.00   0.50   0.50    -     5.00   1.00    -     divb	(%rax)
+# CHECK-NEXT: 6.00    -     3.00   1.00    -      -      -     5.00   1.00    -     divw	%si
+# CHECK-NEXT: 6.00    -     3.00   1.00   0.50   0.50    -     5.00   1.00    -     divw	(%rax)
+# CHECK-NEXT: 6.00    -     3.00   1.00    -      -      -     5.00   1.00    -     divl	%edx
+# CHECK-NEXT: 6.00    -     3.00   1.00   0.50   0.50    -     5.00   1.00    -     divl	(%rax)
+# CHECK-NEXT: 21.00   -     12.92  4.92    -      -      -     7.42   7.75    -     divq	%rcx
+# CHECK-NEXT: 21.00   -     12.92  4.92   0.50   0.50    -     7.42   7.75    -     divq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     enter	$7, $4095
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivb	%dil
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivb	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivw	%si
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivw	(%rax)
-# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivl	%edx
-# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivl	(%rax)
-# CHECK-NEXT: 24.00   -     1.00    -      -      -      -      -      -      -     idivq	%rcx
-# CHECK-NEXT: 24.00   -     1.00    -     0.50   0.50    -      -      -      -     idivq	(%rax)
+# CHECK-NEXT: 6.00    -     3.25   1.25    -      -      -     5.25   1.25    -     idivb	%dil
+# CHECK-NEXT: 6.00    -     3.25   1.25   0.50   0.50    -     5.25   1.25    -     idivb	(%rax)
+# CHECK-NEXT: 6.00    -     3.00   1.00    -      -      -     5.00   1.00    -     idivw	%si
+# CHECK-NEXT: 6.00    -     3.00   1.00   0.50   0.50    -     5.00   1.00    -     idivw	(%rax)
+# CHECK-NEXT: 6.00    -     3.00   1.00    -      -      -     5.00   1.00    -     idivl	%edx
+# CHECK-NEXT: 6.00    -     3.00   1.00   0.50   0.50    -     5.00   1.00    -     idivl	(%rax)
+# CHECK-NEXT: 24.00   -     23.83  8.33    -      -      -     11.33  13.50   -     idivq	%rcx
+# CHECK-NEXT: 24.00   -     23.83  8.33   0.50   0.50    -     11.33  13.50   -     idivq	(%rax)
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -      -      -     imulb	%dil
 # CHECK-NEXT:  -      -      -     1.00   0.50   0.50    -      -      -      -     imulb	(%rax)
 # CHECK-NEXT:  -      -     1.00   1.50    -      -      -     0.50   1.00    -     imulw	%di

--- a/llvm/test/tools/llvm-mca/X86/SkylakeServer/resources-x86_64.s
+++ b/llvm/test/tools/llvm-mca/X86/SkylakeServer/resources-x86_64.s
@@ -1321,23 +1321,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  1      1     0.25                        decq	%rdi
 # CHECK-NEXT:  3      7     1.00    *      *            decq	(%rax)
 # CHECK-NEXT:  3      7     1.00    *      *            lock		decq	(%rax)
-# CHECK-NEXT:  1      25    10.00                 U     divb	%dil
-# CHECK-NEXT:  2      29    10.00   *             U     divb	(%rax)
-# CHECK-NEXT:  32     76    8.00                  U     divw	%si
-# CHECK-NEXT:  2      29    10.00   *             U     divw	(%rax)
-# CHECK-NEXT:  32     76    8.00                  U     divl	%edx
-# CHECK-NEXT:  2      29    10.00   *             U     divl	(%rax)
-# CHECK-NEXT:  32     76    8.00                  U     divq	%rcx
-# CHECK-NEXT:  2      29    10.00   *             U     divq	(%rax)
+# CHECK-NEXT:  10     25    6.00                  U     divb	%dil
+# CHECK-NEXT:  11     30    6.00    *             U     divb	(%rax)
+# CHECK-NEXT:  10     24    6.00                  U     divw	%si
+# CHECK-NEXT:  11     29    6.00    *             U     divw	(%rax)
+# CHECK-NEXT:  10     28    6.00                  U     divl	%edx
+# CHECK-NEXT:  11     33    6.00    *             U     divl	(%rax)
+# CHECK-NEXT:  36     89    21.00                 U     divq	%rcx
+# CHECK-NEXT:  37     94    21.00   *             U     divq	(%rax)
 # CHECK-NEXT:  1      100   0.25                  U     enter	$7, $4095
-# CHECK-NEXT:  1      25    10.00                 U     idivb	%dil
-# CHECK-NEXT:  8      28    4.00    *             U     idivb	(%rax)
-# CHECK-NEXT:  66     102   16.50                 U     idivw	%si
-# CHECK-NEXT:  8      28    4.00    *             U     idivw	(%rax)
-# CHECK-NEXT:  66     102   16.50                 U     idivl	%edx
-# CHECK-NEXT:  8      28    4.00    *             U     idivl	(%rax)
-# CHECK-NEXT:  66     102   16.50                 U     idivq	%rcx
-# CHECK-NEXT:  8      28    4.00    *             U     idivq	(%rax)
+# CHECK-NEXT:  11     25    6.00                  U     idivb	%dil
+# CHECK-NEXT:  12     30    6.00    *             U     idivb	(%rax)
+# CHECK-NEXT:  10     24    6.00                  U     idivw	%si
+# CHECK-NEXT:  11     29    6.00    *             U     idivw	(%rax)
+# CHECK-NEXT:  10     28    6.00                  U     idivl	%edx
+# CHECK-NEXT:  11     33    6.00    *             U     idivl	(%rax)
+# CHECK-NEXT:  57     96    24.00                 U     idivq	%rcx
+# CHECK-NEXT:  58     101   24.00   *             U     idivq	(%rax)
 # CHECK-NEXT:  1      3     1.00                        imulb	%dil
 # CHECK-NEXT:  2      8     1.00    *                   imulb	(%rax)
 # CHECK-NEXT:  4      4     1.00                        imulw	%di
@@ -1962,7 +1962,7 @@ xorq (%rax), %rdi
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]
-# CHECK-NEXT: 60.00   -     683.50 381.50 378.50 378.50 345.00 333.00 745.00 129.00
+# CHECK-NEXT: 162.00  -     595.25 334.75 378.50 378.50 345.00 244.75 656.25 129.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    Instructions:
@@ -2253,23 +2253,23 @@ xorq (%rax), %rdi
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     decq	%rdi
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   decq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25   0.83   0.83   1.00   0.25   0.25   0.33   lock		decq	(%rax)
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -     divb	%dil
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divb	(%rax)
-# CHECK-NEXT:  -      -     10.25  4.75    -      -      -     11.25  5.75    -     divw	%si
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divw	(%rax)
-# CHECK-NEXT:  -      -     10.25  4.75    -      -      -     11.25  5.75    -     divl	%edx
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divl	(%rax)
-# CHECK-NEXT:  -      -     10.25  4.75    -      -      -     11.25  5.75    -     divq	%rcx
-# CHECK-NEXT: 10.00   -     1.00    -     0.50   0.50    -      -      -      -     divq	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divb	%dil
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divb	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divw	%si
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divw	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     divl	%edx
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     divl	(%rax)
+# CHECK-NEXT: 21.00   -     1.00    -      -      -      -      -      -      -     divq	%rcx
+# CHECK-NEXT: 21.00   -     1.00    -     0.50   0.50    -      -      -      -     divq	(%rax)
 # CHECK-NEXT:  -      -     0.25   0.25    -      -      -     0.25   0.25    -     enter	$7, $4095
-# CHECK-NEXT: 10.00   -     1.00    -      -      -      -      -      -      -     idivb	%dil
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -     idivb	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -     idivw	%si
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -     idivw	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -     idivl	%edx
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -     idivl	(%rax)
-# CHECK-NEXT:  -      -     19.50  10.50   -      -      -     12.50  23.50   -     idivq	%rcx
-# CHECK-NEXT:  -      -     2.25   0.25   0.50   0.50    -     4.25   0.25    -     idivq	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivb	%dil
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivb	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivw	%si
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivw	(%rax)
+# CHECK-NEXT: 6.00    -     1.00    -      -      -      -      -      -      -     idivl	%edx
+# CHECK-NEXT: 6.00    -     1.00    -     0.50   0.50    -      -      -      -     idivl	(%rax)
+# CHECK-NEXT: 24.00   -     1.00    -      -      -      -      -      -      -     idivq	%rcx
+# CHECK-NEXT: 24.00   -     1.00    -     0.50   0.50    -      -      -      -     idivq	(%rax)
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -      -      -     imulb	%dil
 # CHECK-NEXT:  -      -      -     1.00   0.50   0.50    -      -      -      -     imulb	(%rax)
 # CHECK-NEXT:  -      -     1.00   1.50    -      -      -     0.50   1.00    -     imulw	%di


### PR DESCRIPTION
The Intel scheduler models from Haswell through Ice Lake model scalar integer division inconsistently. The Divider resource is used by some forms but not others with no consistent rule and on most of these models the 16/32/64-bit register forms just put one flat latency across the issue ports with no divider at all.

On Skylake, for example, the register form of DIV32 is given a latency of 76 with 32 uops, and IDIV32 a latency of 102 with 66 uops, when the real numbers are closer to 28 cycles and 10 uops. The same flat latency is used for every width so DIV stays 76 whether it is 16, 32 or 64 bit and IDIV stays 102, even though a 64-bit divide is slower than a 16-bit one.

Every WriteDiv and WriteIDiv form now goes through the Divider. The latency, throughput and uop counts come from uops.info.

## Data sources:

- DIV: 
  https://uops.info/html-instr/DIV_R8l.html
  https://uops.info/html-instr/DIV_R16.html
  https://uops.info/html-instr/DIV_R32.html
  https://uops.info/html-instr/DIV_R64.html
- IDIV: 
  https://uops.info/html-instr/IDIV_R8l.html
  https://uops.info/html-instr/IDIV_R16.html 
  https://uops.info/html-instr/IDIV_R32.html 
  https://uops.info/html-instr/IDIV_R64.html

## Changes: 

Format below is latency / divider / uops, where divider is the number of cycles the Divider resource is held or ports if that form didn't use the Divider and latency is worst-case max across all operand paths.

### Haswell

| Class  | Before           | After         |
|--------|------------------|---------------|
| DIV8   | 22 / ports / 9   | 24 / 9 / 9    |
| DIV16  | 98 / ports / 32  | 25 / 9 / 11   |
| DIV32  | 98 / ports / 32  | 28 / 9 / 10   |
| DIV64  | 98 / ports / 32  | 94 / 21 / 36  |
| IDIV8  | 23 / ports / 9   | 24 / 8 / 9    |
| IDIV16 | 112 / ports / 66 | 25 / 8 / 10   |
| IDIV32 | 112 / ports / 66 | 28 / 8 / 9    |
| IDIV64 | 112 / ports / 66 | 101 / 24 / 59 |

### Broadwell

| Class  | Before          | After         |
|--------|-----------------|---------------|
| DIV8   | 25 / 10 / 1     | 24 / 9 / 9    |
| DIV16  | 80 / ports / 32 | 25 / 9 / 11   |
| DIV32  | 80 / ports / 32 | 28 / 9 / 10   |
| DIV64  | 80 / ports / 32 | 92 / 21 / 36  |
| IDIV8  | 25 / 10 / 1     | 24 / 6 / 9    |
| IDIV16 | 25 / 10 / 1     | 26 / 6 / 10   |
| IDIV32 | 25 / 10 / 1     | 28 / 6 / 9    |
| IDIV64 | 25 / 10 / 1     | 100 / 24 / 59 |

### Skylake

| Class  | Before           | After        |
|--------|------------------|--------------|
| DIV8   | 25 / 10 / 1      | 25 / 6 / 10  |
| DIV16  | 76 / ports / 32  | 24 / 6 / 10  |
| DIV32  | 76 / ports / 32  | 28 / 6 / 10  |
| DIV64  | 76 / ports / 32  | 90 / 21 / 36 |
| IDIV8  | 25 / 10 / 1      | 25 / 6 / 11  |
| IDIV16 | 102 / ports / 66 | 24 / 6 / 10  |
| IDIV32 | 102 / ports / 66 | 28 / 6 / 10  |
| IDIV64 | 102 / ports / 66 | 96 / 24 / 57 |

### Ice Lake

| Class  | Before           | After       |
|--------|------------------|-------------|
| DIV8   | 25 / 10 / 1      | 15 / 6 / 4  |
| DIV16  | 76 / ports / 32  | 16 / 6 / 6  |
| DIV32  | 76 / ports / 32  | 15 / 6 / 4  |
| DIV64  | 76 / ports / 32  | 18 / 10 / 4 |
| IDIV8  | 25 / 10 / 1      | 15 / 6 / 4  |
| IDIV16 | 102 / ports / 66 | 16 / 6 / 6  |
| IDIV32 | 102 / ports / 66 | 15 / 6 / 4  |
| IDIV64 | 102 / ports / 66 | 18 / 10 / 4 |

Fixes #201568.
