### PR TITLE
[orc-rt] Add InProcessControllerAccess class.

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -11,6 +11,7 @@ set(ORC_RT_HEADERS
     orc-rt/SimpleSymbolTable.h
     orc-rt/Error.h
     orc-rt/ExecutorAddress.h
+    orc-rt/InProcessControllerAccess.h
     orc-rt/IntervalMap.h
     orc-rt/IntervalSet.h
     orc-rt/LockedAccess.h

--- a/orc-rt/include/orc-rt/InProcessControllerAccess.h
+++ b/orc-rt/include/orc-rt/InProcessControllerAccess.h
@@ -1,0 +1,142 @@
+//===---------------- InProcessControllerAccess.h ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Makes direct calls from / to the controller, which must exist in the same
+// process.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_INPROCESSCONTROLLERACCESS_H
+#define ORC_RT_INPROCESSCONTROLLERACCESS_H
+
+#include "orc-rt-c/WrapperFunction.h"
+#include "orc-rt/Error.h"
+#include "orc-rt/Session.h"
+#include "orc-rt/move_only_function.h"
+
+#include <mutex>
+#include <unordered_map>
+
+namespace orc_rt {
+
+/// Provides direct access from/to an ExecutorProcessControl object in the same
+/// process.
+class InProcessControllerAccess : public Session::ControllerAccess {
+public:
+  /// Pseudo-connection C struct. Used to facilitate calls between InProcessEPC
+  /// and InProcessControllerAccess without relying on anything but C ABI.
+  /// Must be kept in-sync with the corresponding struct in InProcessEPC.
+  struct Connection {
+    void (*Retain)(Connection *C) = nullptr;
+    void (*Release)(Connection *C) = nullptr;
+    void (*Disconnect)(Connection *C) = nullptr;
+    int (*EnterMessageScope)(Connection *C) = nullptr;
+    void (*LeaveMessageScope)(Connection *C) = nullptr;
+
+    /// Accessors to be set by the InProcessEPC instance.
+    void *IPEPC = nullptr;
+    void (*CallJITDispatch)(void *IPEPC, uint64_t CallId, void *HandlerTag,
+                            orc_rt_WrapperFunctionBuffer ArgBytes) = nullptr;
+    void (*ReturnWrapperResult)(void *IPEPC, uint64_t CallId,
+                                orc_rt_WrapperFunctionBuffer ResultBytes) =
+        nullptr;
+
+    /// Accessors to be set by the InProcessControllerAccess instance.
+    void *IPCA = nullptr;
+    void (*CallWrapper)(void *IPCA, uint64_t CallId, void *Fn,
+                        orc_rt_WrapperFunctionBuffer ArgBytes) = nullptr;
+    void (*ReturnJITDispatchResult)(void *IPCA, uint64_t CallId,
+                                    orc_rt_WrapperFunctionBuffer ResultBytes) =
+        nullptr;
+  };
+
+  struct ConnectionImpl;
+
+  /// Provides access to bootstrap info.
+  /// Must be kept in-sync with the corresponding struct in InProcessEPC.
+  struct BootstrapInfoAccess {
+    uint64_t (*GetPageSize)(void *BIA) = nullptr;
+    const char *(*GetTargetTriple)(void *BIA) = nullptr;
+
+    int (*GetNextValue)(void *BIA, const char **Name, const char **ValueBytes,
+                        uint64_t *ValueSize) = nullptr;
+    int (*GetNextSymbol)(void *BIA, const char **Name,
+                         uint64_t *Addr) = nullptr;
+  };
+
+  struct BootstrapInfoAccessImpl;
+
+  /// OnConnect callback type.
+  ///
+  /// An instance of this type will be stored in the InProcessControllerAccess
+  /// object and called from InProcessControllerAccess::connect. The IPCA&
+  /// reference argument remains valid for the lifetime of the calling IPCA
+  /// instance. The Connection *C argument is ref-counted; the IPCA holds the
+  /// initial reference, keeping C alive for at least the duration of the call.
+  /// Implementations that need to use C after OnConnect returns must call
+  /// C->Retain(C) (paired with C->Release(C) when finished) to take their own
+  /// reference. The BI and BCA arguments are valid only for the duration of
+  /// the call and must not be captured by the callback.
+  ///
+  /// It is expected that clients will use these arguments to construct an
+  /// llvm::orc::InProcessEPC object via that class's Create method, in which
+  /// case llvm::orc::InProcessEPC::Create will manage the retain and release of
+  /// Connection *C.
+  using OnConnectFn = move_only_function<Error(InProcessControllerAccess &IPCA,
+                                               BootstrapInfo &BI, Connection *C,
+                                               BootstrapInfoAccess *BCA)>;
+
+  /// Create an InProcessControllerAccess instance.
+  InProcessControllerAccess(Session &S, OnConnectFn OnConnect)
+      : Session::ControllerAccess(S), OnConnect(std::move(OnConnect)) {}
+
+  InProcessControllerAccess(const InProcessControllerAccess &) = delete;
+  InProcessControllerAccess &
+  operator=(const InProcessControllerAccess &) = delete;
+  InProcessControllerAccess(InProcessControllerAccess &&) = delete;
+  InProcessControllerAccess &operator=(InProcessControllerAccess &&) = delete;
+
+  ~InProcessControllerAccess();
+
+  void connect(BootstrapInfo BI) override;
+
+  void disconnect() override;
+
+  void callController(OnCallHandlerCompleteFn OnComplete, HandlerTag T,
+                      WrapperFunctionBuffer ArgBytes) override;
+  void sendWrapperResult(uint64_t CallId,
+                         WrapperFunctionBuffer ResultBytes) override;
+
+private:
+  uint64_t registerPendingHandler(OnCallHandlerCompleteFn OnComplete);
+  void doDisconnect();
+
+  void callWrapper(uint64_t CallId, void *Fn,
+                   orc_rt_WrapperFunctionBuffer ArgBytes);
+  static void callWrapperEntry(void *IPCA, uint64_t CallId, void *Fn,
+                               orc_rt_WrapperFunctionBuffer ArgBytes);
+
+  void returnJITDispatchResult(uint64_t CallId,
+                               orc_rt_WrapperFunctionBuffer ResultBytes);
+  static void
+  returnJITDispatchResultEntry(void *IPCA, uint64_t CallId,
+                               orc_rt_WrapperFunctionBuffer ResultBytes);
+
+  OnConnectFn OnConnect;
+  ConnectionImpl *C = nullptr;
+
+  std::mutex M;
+  uint64_t NextPendingCall = 0;
+
+  using PendingCallsMap = std::unordered_map<uint64_t, OnCallHandlerCompleteFn>;
+  PendingCallsMap PendingCalls;
+};
+
+} // namespace orc_rt
+
+#endif // ORC_RT_INPROCESSCONTROLLERACCESS_H

--- a/orc-rt/lib/executor/CMakeLists.txt
+++ b/orc-rt/lib/executor/CMakeLists.txt
@@ -4,6 +4,7 @@ set(files
   SimpleSymbolTable.cpp
   Error.cpp
   ExecutorProcessInfo.cpp
+  InProcessControllerAccess.cpp
   NativeDylibManager.cpp
   RTTI.cpp
   Service.cpp

--- a/orc-rt/lib/executor/InProcessControllerAccess.cpp
+++ b/orc-rt/lib/executor/InProcessControllerAccess.cpp
@@ -1,0 +1,285 @@
+//===- InProcessControllerAccess.cpp --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the implementation of APIs in the
+// orc-rt/InProcessControllerAccess.h header.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/InProcessControllerAccess.h"
+
+#include <cassert>
+
+namespace orc_rt {
+
+struct InProcessControllerAccess::ConnectionImpl : public Connection {
+public:
+  ConnectionImpl(InProcessControllerAccess &Instance) {
+    Retain = &retainEntry;
+    Release = &releaseEntry;
+    Disconnect = &disconnectEntry;
+    EnterMessageScope = &enterMessageScopeEntry;
+    LeaveMessageScope = &leaveMessageScopeEntry;
+    IPCA = &Instance;
+    CallWrapper = InProcessControllerAccess::callWrapperEntry;
+    ReturnJITDispatchResult =
+        InProcessControllerAccess::returnJITDispatchResultEntry;
+  }
+
+private:
+  void retain() {
+    std::scoped_lock<std::mutex> Lock(M);
+    ++RefCount;
+  }
+
+  static void retainEntry(Connection *C) {
+    static_cast<ConnectionImpl *>(C)->retain();
+  }
+
+  int release() {
+    std::scoped_lock<std::mutex> Lock(M);
+    --RefCount;
+    return RefCount == 0;
+  }
+
+  static void releaseEntry(Connection *C) {
+    if (static_cast<ConnectionImpl *>(C)->release())
+      delete static_cast<ConnectionImpl *>(C);
+  }
+
+  void disconnect() {
+    {
+      std::unique_lock<std::mutex> Lock(M);
+      if (!Connected)
+        return;
+      Connected = false;
+      CV.wait(Lock, [this]() { return InFlightCalls == 0; });
+    }
+    static_cast<InProcessControllerAccess *>(IPCA)->doDisconnect();
+  }
+
+  static void disconnectEntry(Connection *C) {
+    static_cast<ConnectionImpl *>(C)->disconnect();
+  }
+
+  int enterMessageScope() {
+    std::scoped_lock<std::mutex> Lock(M);
+    if (!Connected)
+      return 0;
+    ++InFlightCalls;
+    return 1;
+  }
+
+  static int enterMessageScopeEntry(Connection *C) {
+    return static_cast<ConnectionImpl *>(C)->enterMessageScope();
+  }
+
+  void leaveMessageScope() {
+    bool NotifyCV = false;
+    {
+      std::scoped_lock<std::mutex> Lock(M);
+      --InFlightCalls;
+      if (InFlightCalls == 0 && !Connected)
+        NotifyCV = true;
+    }
+    if (NotifyCV)
+      CV.notify_one();
+  }
+
+  static void leaveMessageScopeEntry(Connection *C) {
+    static_cast<ConnectionImpl *>(C)->leaveMessageScope();
+  }
+
+  std::mutex M;
+  std::condition_variable CV;
+  bool Connected = true;
+  size_t InFlightCalls = 0;
+  size_t RefCount = 1;
+};
+
+struct InProcessControllerAccess::BootstrapInfoAccessImpl
+    : public BootstrapInfoAccess {
+public:
+  BootstrapInfoAccessImpl(BootstrapInfo &BI)
+      : BI(BI), BVI(BI.values().begin()), BSI(BI.symbols().begin()) {
+    GetPageSize = getPageSizeEntry;
+    GetTargetTriple = getTargetTripleEntry;
+    GetNextValue = getNextValueEntry;
+    GetNextSymbol = getNextSymbolEntry;
+  }
+
+private:
+  uint64_t getPageSize() const noexcept { return BI.processInfo().pageSize(); }
+
+  static uint64_t getPageSizeEntry(void *BIA) noexcept {
+    return static_cast<BootstrapInfoAccessImpl *>(BIA)->getPageSize();
+  }
+
+  const char *getTargetTriple() const noexcept {
+    return BI.processInfo().targetTriple().c_str();
+  }
+
+  static const char *getTargetTripleEntry(void *BIA) {
+    return static_cast<BootstrapInfoAccessImpl *>(BIA)->getTargetTriple();
+  }
+
+  int getNextValue(const char **Name, const char **Value, uint64_t *ValueSize) {
+    if (BVI == BI.values().end())
+      return 0;
+    *Name = BVI->first.c_str();
+    *Value = BVI->second.data();
+    *ValueSize = BVI->second.size();
+    ++BVI;
+    return 1;
+  }
+
+  static int getNextValueEntry(void *BIA, const char **Name, const char **Value,
+                               uint64_t *ValueSize) {
+    return static_cast<BootstrapInfoAccessImpl *>(BIA)->getNextValue(
+        Name, Value, ValueSize);
+  }
+
+  int getNextSymbol(const char **Name, uint64_t *Addr) {
+    if (BSI == BI.symbols().end())
+      return 0;
+    *Name = BSI->first.c_str();
+    *Addr = ExecutorAddr::fromPtr(BSI->second).getValue();
+    ++BSI;
+    return 1;
+  }
+
+  static int getNextSymbolEntry(void *BIA, const char **Name, uint64_t *Addr) {
+    return static_cast<BootstrapInfoAccessImpl *>(BIA)->getNextSymbol(Name,
+                                                                      Addr);
+  }
+
+  BootstrapInfo &BI;
+  BootstrapInfo::ValueMap::iterator BVI;
+  SimpleSymbolTable::iterator BSI;
+};
+
+InProcessControllerAccess::~InProcessControllerAccess() {
+  // 'if (C)' to handle the case where the instance is destroyed without
+  // connect ever being run. (TODO: should calling 'connect' be required?)
+  if (C)
+    C->Release(C);
+}
+
+void InProcessControllerAccess::connect(BootstrapInfo BI) {
+  assert(!C && "connect called twice?");
+  C = new ConnectionImpl(*this);
+  BootstrapInfoAccessImpl BIA(BI);
+
+  if (auto Err = OnConnect(*this, BI, C, &BIA)) {
+    reportError(std::move(Err));
+    // Call disconnect. There's a benign race here: if IPEPC also called
+    // C->Disconnect(C) then it might have acquired responsibility for calling
+    // InProcessControllerAccess::onDisconnect. In this case control may return
+    // from disconnect below early, potentially causing us to return from
+    // 'connect' before notifyDisconnect is called. This may lead to confusing
+    // logs (since reportError will log error but connect will appear to
+    // succeed), however onDisconnect will still be called eventually, and the
+    // Session will detach as if the remote had initiated the action after a
+    // successful connect.
+    disconnect();
+    return;
+  }
+
+  assert(C->IPEPC && "IPEPC not set by OnConnect");
+  assert(C->CallJITDispatch && "CallJITDispatch not set by OnConnect");
+  assert(C->ReturnWrapperResult && "ReturnWrapperResult not set by OnConnect");
+}
+
+void InProcessControllerAccess::disconnect() {
+  assert(C && "disconnect called before connect");
+  C->Disconnect(C);
+}
+
+void InProcessControllerAccess::callController(
+    OnCallHandlerCompleteFn OnComplete, HandlerTag T,
+    WrapperFunctionBuffer ArgBytes) {
+  assert(C && "callController called before connect");
+  if (C->EnterMessageScope(C)) {
+    C->CallJITDispatch(C->IPEPC, registerPendingHandler(std::move(OnComplete)),
+                       T, ArgBytes.release());
+    C->LeaveMessageScope(C);
+  } else
+    OnComplete(
+        WrapperFunctionBuffer::createOutOfBandError("connection closed"));
+}
+
+void InProcessControllerAccess::sendWrapperResult(
+    uint64_t CallId, WrapperFunctionBuffer ResultBytes) {
+  assert(C && "sendWrapperResult called before connect");
+  if (C->EnterMessageScope(C)) {
+    C->ReturnWrapperResult(C->IPEPC, CallId, ResultBytes.release());
+    C->LeaveMessageScope(C);
+  }
+}
+
+uint64_t InProcessControllerAccess::registerPendingHandler(
+    OnCallHandlerCompleteFn OnComplete) {
+  std::scoped_lock<std::mutex> Lock(M);
+  PendingCalls[NextPendingCall] = std::move(OnComplete);
+  return NextPendingCall++;
+}
+
+void InProcessControllerAccess::doDisconnect() {
+  // Drain pending calls.
+  PendingCallsMap ToDrain;
+  {
+    std::scoped_lock<std::mutex> Lock(M);
+    ToDrain = std::move(PendingCalls);
+  }
+  for (auto &[_, H] : ToDrain)
+    H(WrapperFunctionBuffer::createOutOfBandError("disconnected"));
+
+  notifyDisconnected();
+}
+
+void InProcessControllerAccess::callWrapper(
+    uint64_t CallId, void *Fn, orc_rt_WrapperFunctionBuffer ArgBytes) {
+  handleWrapperCall(CallId, reinterpret_cast<orc_rt_WrapperFunction>(Fn),
+                    WrapperFunctionBuffer(ArgBytes));
+}
+
+void InProcessControllerAccess::callWrapperEntry(
+    void *IPCA, uint64_t CallId, void *Fn,
+    orc_rt_WrapperFunctionBuffer ArgBytes) {
+  assert(IPCA);
+  static_cast<InProcessControllerAccess *>(IPCA)->callWrapper(CallId, Fn,
+                                                              ArgBytes);
+}
+
+void InProcessControllerAccess::returnJITDispatchResult(
+    uint64_t CallId, orc_rt_WrapperFunctionBuffer ResultBytes) {
+
+  OnCallHandlerCompleteFn OnComplete;
+  {
+    std::scoped_lock<std::mutex> Lock(M);
+    auto I = PendingCalls.find(CallId);
+    if (I != PendingCalls.end()) {
+      OnComplete = std::move(I->second);
+      PendingCalls.erase(I);
+    }
+  }
+
+  if (!OnComplete)
+    return reportError(make_error<StringError>("Invalid call id"));
+
+  OnComplete(WrapperFunctionBuffer(ResultBytes));
+}
+
+void InProcessControllerAccess::returnJITDispatchResultEntry(
+    void *IPCA, uint64_t CallId, orc_rt_WrapperFunctionBuffer ResultBytes) {
+  assert(IPCA);
+  static_cast<InProcessControllerAccess *>(IPCA)->returnJITDispatchResult(
+      CallId, ResultBytes);
+}
+
+} // namespace orc_rt

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_orc_rt_unittest(CoreTests
   ErrorExceptionInteropTest.cpp
   ExecutorAddressTest.cpp
   ExecutorProcessInfoTest.cpp
+  InProcessControllerAccessTest.cpp
   IntervalMapTest.cpp
   IntervalSetTest.cpp
   LockedAccessTest.cpp

--- a/orc-rt/unittests/InProcessControllerAccessTest.cpp
+++ b/orc-rt/unittests/InProcessControllerAccessTest.cpp
@@ -1,0 +1,320 @@
+//===- InProcessControllerAccessTest.cpp ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for orc-rt's InProcessControllerAccess.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/InProcessControllerAccess.h"
+#include "orc-rt/QueueingRunner.h"
+
+#include "gtest/gtest.h"
+
+#include "CommonTestUtils.h"
+
+#include <deque>
+#include <optional>
+#include <string>
+
+using namespace orc_rt;
+
+using TaskQueue = std::deque<move_only_function<void()>>;
+
+namespace {
+
+// A minimal stand-in for llvm::orc::InProcessEPC. Registers itself on the
+// Connection during OnConnect, exposes hooks for tests to drive cross-calls
+// in either direction, and tears the connection down on destruction.
+class MockIPEPC {
+public:
+  using Connection = InProcessControllerAccess::Connection;
+
+  using OnCallJITDispatchFn = move_only_function<void(
+      uint64_t CallId, void *HandlerTag, WrapperFunctionBuffer ArgBytes)>;
+  using OnReturnWrapperResultFn = move_only_function<void(
+      uint64_t CallId, WrapperFunctionBuffer ResultBytes)>;
+
+  MockIPEPC(Connection *C) : C(C) {
+    C->Retain(C);
+    C->IPEPC = this;
+    C->CallJITDispatch = &callJITDispatchEntry;
+    C->ReturnWrapperResult = &returnWrapperResultEntry;
+  }
+
+  MockIPEPC(const MockIPEPC &) = delete;
+  MockIPEPC &operator=(const MockIPEPC &) = delete;
+
+  ~MockIPEPC() {
+    C->Disconnect(C);
+    C->Release(C);
+  }
+
+  void setOnCallJITDispatch(OnCallJITDispatchFn H) {
+    OnCallJITDispatch = std::move(H);
+  }
+  void setOnReturnWrapperResult(OnReturnWrapperResultFn H) {
+    OnReturnWrapperResult = std::move(H);
+  }
+
+  // Send a result back to a CallJITDispatch invocation.
+  void respondToCall(uint64_t CallId, WrapperFunctionBuffer Result) {
+    if (C->EnterMessageScope(C)) {
+      C->ReturnJITDispatchResult(C->IPCA, CallId, Result.release());
+      C->LeaveMessageScope(C);
+    }
+  }
+
+  // Initiate a wrapper call into the executor, simulating a controller-side
+  // wrapper invocation. Returns the CallId that ReturnWrapperResult will
+  // refer back to.
+  uint64_t callIntoExecutor(orc_rt_WrapperFunction Fn,
+                            WrapperFunctionBuffer ArgBytes) {
+    uint64_t CallId = NextCallId++;
+    if (C->EnterMessageScope(C)) {
+      C->CallWrapper(C->IPCA, CallId, reinterpret_cast<void *>(Fn),
+                     ArgBytes.release());
+      C->LeaveMessageScope(C);
+    }
+    return CallId;
+  }
+
+private:
+  static void callJITDispatchEntry(void *IPEPC, uint64_t CallId,
+                                   void *HandlerTag,
+                                   orc_rt_WrapperFunctionBuffer ArgBytes) {
+    auto *Self = static_cast<MockIPEPC *>(IPEPC);
+    WrapperFunctionBuffer Buf(ArgBytes);
+    if (Self->OnCallJITDispatch)
+      Self->OnCallJITDispatch(CallId, HandlerTag, std::move(Buf));
+  }
+
+  static void
+  returnWrapperResultEntry(void *IPEPC, uint64_t CallId,
+                           orc_rt_WrapperFunctionBuffer ResultBytes) {
+    auto *Self = static_cast<MockIPEPC *>(IPEPC);
+    WrapperFunctionBuffer Buf(ResultBytes);
+    if (Self->OnReturnWrapperResult)
+      Self->OnReturnWrapperResult(CallId, std::move(Buf));
+  }
+
+  Connection *C;
+  uint64_t NextCallId = 0;
+  OnCallJITDispatchFn OnCallJITDispatch;
+  OnReturnWrapperResultFn OnReturnWrapperResult;
+};
+
+// Convenience: attach an InProcessControllerAccess to S, constructing a
+// MockIPEPC into MockOut from inside OnConnect.
+void attachWithMock(Session &S, std::unique_ptr<MockIPEPC> &MockOut) {
+  S.attach<InProcessControllerAccess>(
+      BootstrapInfo(S), S,
+      [&MockOut](InProcessControllerAccess &, BootstrapInfo &,
+                 InProcessControllerAccess::Connection *C,
+                 InProcessControllerAccess::BootstrapInfoAccess *) -> Error {
+        MockOut = std::make_unique<MockIPEPC>(C);
+        return Error::success();
+      });
+}
+
+} // namespace
+
+TEST(InProcessControllerAccessTest, ConstructAndDestroyWithoutConnect) {
+  // An InProcessControllerAccess that is never attached to a Session (so its
+  // connect method is never called) must still destroy cleanly. The
+  // destructor's `if (C)` guard is what makes this safe.
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+
+  InProcessControllerAccess IPCA(
+      S,
+      [](InProcessControllerAccess &, BootstrapInfo &,
+         InProcessControllerAccess::Connection *,
+         InProcessControllerAccess::BootstrapInfoAccess *) -> Error {
+        ADD_FAILURE() << "OnConnect should not be called";
+        return Error::success();
+      });
+
+  // IPCA is destroyed at scope exit; test passes if there's no crash.
+}
+
+TEST(InProcessControllerAccessTest, AttachAndShutdownViaSession) {
+  // Smoke test: attach with a successful OnConnect, verify the mock was
+  // constructed, then let scope exit drive shutdown.
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+
+  std::unique_ptr<MockIPEPC> Mock;
+  attachWithMock(S, Mock);
+  EXPECT_TRUE(Mock) << "Expected OnConnect to construct MockIPEPC";
+}
+
+TEST(InProcessControllerAccessTest, OnConnectFailureIsReportedAndDetaches) {
+  // If OnConnect returns an Error, IPCA::connect should:
+  //   (1) Forward the error through Session::reportError.
+  //   (2) Trigger disconnect (so the Session ends up detached and no further
+  //       calls into the controller succeed).
+  Error Reported = Error::success();
+  cantFail(std::move(Reported)); // force checked state
+
+  Session S(mockExecutorProcessInfo(), noDispatch,
+            [&](Error E) { Reported = std::move(E); });
+
+  S.attach<InProcessControllerAccess>(
+      BootstrapInfo(S), S,
+      [](InProcessControllerAccess &, BootstrapInfo &,
+         InProcessControllerAccess::Connection *,
+         InProcessControllerAccess::BootstrapInfoAccess *) -> Error {
+        return make_error<StringError>("fake connect failure");
+      });
+
+  if (Reported)
+    EXPECT_EQ(toString(std::move(Reported)), "fake connect failure");
+  else
+    ADD_FAILURE() << "Expected OnConnect error to be reported";
+
+  // A subsequent call to the controller should now fail with "no controller
+  // attached" (i.e. the Session detached on the OnConnect error).
+  std::optional<std::string> CallErr;
+  S.callController(
+      [&](WrapperFunctionBuffer R) {
+        if (const char *Msg = R.getOutOfBandError())
+          CallErr = Msg;
+      },
+      reinterpret_cast<Session::HandlerTag>(0xdeadbeef),
+      WrapperFunctionBuffer::copyFrom("x", 1));
+
+  ASSERT_TRUE(CallErr);
+  EXPECT_EQ(*CallErr, "no controller attached");
+}
+
+TEST(InProcessControllerAccessTest, CallControllerSuccess) {
+  // A callController call routed through MockIPEPC, which echoes the args
+  // back as the result. Verify OnComplete fires with the payload.
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+
+  std::unique_ptr<MockIPEPC> Mock;
+  attachWithMock(S, Mock);
+  ASSERT_TRUE(Mock);
+
+  Mock->setOnCallJITDispatch(
+      [&](uint64_t CallId, void *, WrapperFunctionBuffer ArgBytes) {
+        Mock->respondToCall(CallId, std::move(ArgBytes));
+      });
+
+  std::optional<std::string> Result;
+  S.callController(
+      [&](WrapperFunctionBuffer R) {
+        ASSERT_FALSE(R.getOutOfBandError())
+            << "Unexpected out-of-band error: " << R.getOutOfBandError();
+        Result = std::string(R.data(), R.size());
+      },
+      reinterpret_cast<Session::HandlerTag>(0xdeadbeef),
+      WrapperFunctionBuffer::copyFrom("hello", 5));
+
+  ASSERT_TRUE(Result);
+  EXPECT_EQ(*Result, "hello");
+}
+
+TEST(InProcessControllerAccessTest, CallControllerOutOfBandError) {
+  // A callController call where the mock responds with an out-of-band error.
+  // OnComplete should observe the error message intact.
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+
+  std::unique_ptr<MockIPEPC> Mock;
+  attachWithMock(S, Mock);
+  ASSERT_TRUE(Mock);
+
+  Mock->setOnCallJITDispatch(
+      [&](uint64_t CallId, void *, WrapperFunctionBuffer) {
+        Mock->respondToCall(CallId, WrapperFunctionBuffer::createOutOfBandError(
+                                        "simulated failure"));
+      });
+
+  std::optional<std::string> ErrMsg;
+  S.callController(
+      [&](WrapperFunctionBuffer R) {
+        if (const char *Msg = R.getOutOfBandError())
+          ErrMsg = Msg;
+      },
+      reinterpret_cast<Session::HandlerTag>(0xdeadbeef),
+      WrapperFunctionBuffer::copyFrom("payload", 7));
+
+  ASSERT_TRUE(ErrMsg);
+  EXPECT_EQ(*ErrMsg, "simulated failure");
+}
+
+TEST(InProcessControllerAccessTest, DisconnectDrainsPendingCalls) {
+  // A callController call is in-flight when the connection drops (the mock
+  // never responds). Verify that doDisconnect drains the pending handler with
+  // a "disconnected" out-of-band error rather than leaving it stranded.
+  Session S(mockExecutorProcessInfo(), noDispatch, noErrors);
+
+  std::unique_ptr<MockIPEPC> Mock;
+  attachWithMock(S, Mock);
+  ASSERT_TRUE(Mock);
+
+  // Mock receives the call but never sends a result.
+  Mock->setOnCallJITDispatch([](uint64_t, void *, WrapperFunctionBuffer) {});
+
+  std::optional<std::string> ErrMsg;
+  S.callController(
+      [&](WrapperFunctionBuffer R) {
+        if (const char *Msg = R.getOutOfBandError())
+          ErrMsg = Msg;
+      },
+      reinterpret_cast<Session::HandlerTag>(0xdeadbeef),
+      WrapperFunctionBuffer::copyFrom("payload", 7));
+
+  ASSERT_FALSE(ErrMsg) << "OnComplete fired prematurely";
+
+  // Tearing down the mock triggers C->Disconnect, which routes through
+  // ConnectionImpl::disconnect → IPCA::doDisconnect and drains the pending
+  // OnComplete with a "disconnected" error.
+  Mock.reset();
+
+  ASSERT_TRUE(ErrMsg);
+  EXPECT_EQ(*ErrMsg, "disconnected");
+}
+
+// Wrapper function that echoes ArgBytes back as the result. Used to exercise
+// the controller-initiated wrapper-call path without pulling in SPS.
+static void echoWrapper(orc_rt_SessionRef S, uint64_t CallId,
+                        orc_rt_WrapperFunctionReturn Return,
+                        orc_rt_WrapperFunctionBuffer ArgBytes) {
+  Return(S, CallId, ArgBytes);
+}
+
+TEST(InProcessControllerAccessTest, CallFromControllerSuccess) {
+  // The mock IPEPC initiates a wrapper call into IPCA. The Session's
+  // RunWrapperCall hook (a QueueingRunner over `Tasks`) enqueues the
+  // invocation; draining the queue runs the wrapper, which echoes its
+  // arguments back. Verify the mock receives the echoed bytes via
+  // ReturnWrapperResult.
+  TaskQueue Tasks;
+  Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
+
+  std::unique_ptr<MockIPEPC> Mock;
+  attachWithMock(S, Mock);
+  ASSERT_TRUE(Mock);
+
+  std::optional<std::string> Result;
+  Mock->setOnReturnWrapperResult(
+      [&](uint64_t, WrapperFunctionBuffer ResultBytes) {
+        Result = std::string(ResultBytes.data(), ResultBytes.size());
+      });
+
+  Mock->callIntoExecutor(echoWrapper,
+                         WrapperFunctionBuffer::copyFrom("world", 5));
+
+  // Nothing has run yet -- the wrapper is sitting in `Tasks` waiting to be
+  // dispatched.
+  ASSERT_FALSE(Result);
+
+  QueueingRunner<TaskQueue>::runFIFOUntilEmpty(Tasks);
+
+  ASSERT_TRUE(Result);
+  EXPECT_EQ(*Result, "world");
+}


### PR DESCRIPTION
Adds a Session::ControllerAccess implementation for in-process JIT setups, where the controller (LLVM-side) and the executor (orc-rt) live in the same address space.

The two sides communicate through a refcounted C-ABI struct (Connection) of function pointers. The C-only interface avoids assuming a common C++ ABI between the two sides and supports symmetric, graceful disconnect: when either side calls Connection::Disconnect, in-flight cross-calls are drained and pending continuations are surfaced as out-of-band errors, after which further cross-calls fail cleanly.

This is intended to be paired with a new ExecutorProcessControl implementation (llvm::orc::InProcessEPC) on the LLVM side, landing in a follow-up commit. Unit tests are included covering construction without connect, attach via Session, OnConnect-failure detach, successful and out-of-band-error call cases, and the disconnect-drains-pending behavior.