### PR TITLE
Revert "[Legalizer] Add support for promoting integers for s/ucmp (#198554)

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
@@ -5659,21 +5659,6 @@ void SelectionDAGLegalize::PromoteNode(SDNode *Node) {
     ReplacedNode(Node);
     break;
   }
-  case ISD::SCMP:
-  case ISD::UCMP: {
-    unsigned ExtOp =
-        Node->getOpcode() == ISD::UCMP ? ISD::ZERO_EXTEND : ISD::SIGN_EXTEND;
-    MVT OpVT = Node->getOperand(0).getSimpleValueType();
-    // Compare at least at operand width; NVT is the legal type for the op
-    // result.
-    MVT ResVT = OpVT.bitsGT(NVT) ? OpVT : NVT;
-    Tmp1 = DAG.getNode(ExtOp, dl, ResVT, Node->getOperand(0));
-    Tmp2 = DAG.getNode(ExtOp, dl, ResVT, Node->getOperand(1));
-    Tmp1 = DAG.getNode(Node->getOpcode(), dl, ResVT, Tmp1, Tmp2);
-    // Result is -1/0/1; truncate to the original result type.
-    Results.push_back(DAG.getNode(ISD::TRUNCATE, dl, OVT, Tmp1));
-    break;
-  }
   case ISD::MUL:
   case ISD::SDIV:
   case ISD::SREM:

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -604,14 +604,8 @@ PPCTargetLowering::PPCTargetLowering(const PPCTargetMachine &TM,
   setOperationAction(ISD::SIGN_EXTEND_INREG, MVT::i1, Expand);
 
   // Custom handling for PowerPC ucmp instruction
-  if (isPPC64) {
-    // UCMP involves using carries, which only works in 64-bit
-    setOperationAction(ISD::UCMP, MVT::i32, Promote);
-    setOperationAction(ISD::UCMP, MVT::i64, Custom);
-  } else {
-    setOperationAction(ISD::UCMP, MVT::i32, Custom);
-    setOperationAction(ISD::UCMP, MVT::i64, Expand);
-  }
+  setOperationAction(ISD::UCMP, MVT::i32, Custom);
+  setOperationAction(ISD::UCMP, MVT::i64, isPPC64 ? Custom : Expand);
 
   // NOTE: EH_SJLJ_SETJMP/_LONGJMP supported here is NOT intended to support
   // SjLj exception handling but a light-weight setjmp/longjmp replacement to
@@ -12801,6 +12795,15 @@ SDValue PPCTargetLowering::LowerUCMP(SDValue Op, SelectionDAG &DAG) const {
   SDValue B = DAG.getFreeze(Op.getOperand(1));
   EVT OpVT = A.getValueType();
   EVT ResVT = Op.getValueType();
+
+  // On PPC64, i32 carries are affected by the upper 32 bits of the registers.
+  // We must zero-extend to i64 to ensure the carry reflects the 32-bit unsigned
+  // comparison.
+  if (Subtarget.isPPC64() && OpVT != MVT::i64) {
+    A = DAG.getNode(ISD::ZERO_EXTEND, DL, MVT::i64, A);
+    B = DAG.getNode(ISD::ZERO_EXTEND, DL, MVT::i64, B);
+    OpVT = MVT::i64;
+  }
 
   // First compute diff = A - B.
   SDValue Diff = DAG.getNode(ISD::SUB, DL, OpVT, A, B);

--- a/llvm/test/CodeGen/PowerPC/ucmp.ll
+++ b/llvm/test/CodeGen/PowerPC/ucmp.ll
@@ -4,8 +4,10 @@
 define i8 @ucmp_8_8(i8 zeroext %x, i8 zeroext %y) nounwind {
 ; CHECK-LABEL: ucmp_8_8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    subc 6, 4, 3
+; CHECK-NEXT:    clrldi 3, 3, 32
+; CHECK-NEXT:    clrldi 4, 4, 32
 ; CHECK-NEXT:    sub 5, 3, 4
+; CHECK-NEXT:    subc 6, 4, 3
 ; CHECK-NEXT:    subfe 3, 4, 3
 ; CHECK-NEXT:    subfe 3, 3, 5
 ; CHECK-NEXT:    blr
@@ -16,8 +18,10 @@ define i8 @ucmp_8_8(i8 zeroext %x, i8 zeroext %y) nounwind {
 define i8 @ucmp_8_16(i16 zeroext %x, i16 zeroext %y) nounwind {
 ; CHECK-LABEL: ucmp_8_16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    subc 6, 4, 3
+; CHECK-NEXT:    clrldi 3, 3, 32
+; CHECK-NEXT:    clrldi 4, 4, 32
 ; CHECK-NEXT:    sub 5, 3, 4
+; CHECK-NEXT:    subc 6, 4, 3
 ; CHECK-NEXT:    subfe 3, 4, 3
 ; CHECK-NEXT:    subfe 3, 3, 5
 ; CHECK-NEXT:    blr
@@ -106,5 +110,32 @@ define i64 @ucmp_64_64(i64 %x, i64 %y) nounwind {
 ; CHECK-NEXT:    subfe 3, 3, 5
 ; CHECK-NEXT:    blr
   %1 = call i64 @llvm.ucmp(i64 %x, i64 %y)
+  ret i64 %1
+}
+
+define i64 @ucmp_64_8_zero(i8 %x) nounwind {
+; CHECK-LABEL: ucmp_64_8_zero:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    clrldi 3, 3, 56
+; CHECK-NEXT:    subfic 4, 3, 0
+; CHECK-NEXT:    li 4, 0
+; CHECK-NEXT:    subfe 4, 4, 3
+; CHECK-NEXT:    subfe 3, 4, 3
+; CHECK-NEXT:    blr
+  %1 = call i64 @llvm.ucmp(i8 %x, i8 0)
+  ret i64 %1
+}
+
+define i64 @ucmp_64_8(i8 %x, i8 %y) nounwind {
+; CHECK-LABEL: ucmp_64_8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    clrldi 3, 3, 56
+; CHECK-NEXT:    clrldi 4, 4, 56
+; CHECK-NEXT:    sub 5, 3, 4
+; CHECK-NEXT:    subc 6, 4, 3
+; CHECK-NEXT:    subfe 3, 4, 3
+; CHECK-NEXT:    subfe 3, 3, 5
+; CHECK-NEXT:    blr
+  %1 = call i64 @llvm.ucmp(i8 %x, i8 %y)
   ret i64 %1
 }


### PR DESCRIPTION
This reverts commit 91edd87a801fc5c9d12c7f5c6863edd50327cef8.

It was causing CI failures for Linux.