### PR TITLE
[MIPS] Move dead register hack to MIPSSEISelDAGtoDAG

### DIFF
--- a/llvm/lib/CodeGen/LiveVariables.cpp
+++ b/llvm/lib/CodeGen/LiveVariables.cpp
@@ -506,10 +506,6 @@ void LiveVariables::runOnInstr(MachineInstr &MI,
         UseRegs.push_back(MOReg);
     } else {
       assert(MO.isDef());
-      // FIXME: We should not remove any dead flags. However the MIPS RDDSP
-      // instruction needs it at the moment: http://llvm.org/PR27116.
-      if (MOReg.isPhysical() && !MRI->isReserved(MOReg))
-        MO.setIsDead(false);
       DefRegs.push_back(MOReg);
     }
   }

--- a/llvm/lib/Target/Mips/MipsSEISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Mips/MipsSEISelDAGToDAG.cpp
@@ -48,8 +48,7 @@ void MipsSEDAGToDAGISel::addDSPCtrlRegOperands(bool IsDef, MachineInstr &MI,
                                                MachineFunction &MF) {
   MachineInstrBuilder MIB(MF, &MI);
   unsigned Mask = MI.getOperand(1).getImm();
-  RegState Flag =
-      IsDef ? RegState::ImplicitDefine : RegState::Implicit | RegState::Undef;
+  RegState Flag = IsDef ? RegState::ImplicitDefine : RegState::Implicit;
 
   if (Mask & 1)
     MIB.addReg(Mips::DSPPos, Flag);
@@ -147,6 +146,25 @@ void MipsSEDAGToDAGISel::emitMCountABI(MachineInstr &MI, MachineBasicBlock &MBB,
   }
 }
 
+static bool isDSPControlReg(Register Reg) {
+  switch (Reg) {
+  case Mips::DSPPos:
+  case Mips::DSPSCount:
+  case Mips::DSPCarry:
+  case Mips::DSPOutFlag:
+  case Mips::DSPCCond:
+  case Mips::DSPEFI:
+  case Mips::DSPOutFlag16_19:
+  case Mips::DSPOutFlag20:
+  case Mips::DSPOutFlag21:
+  case Mips::DSPOutFlag22:
+  case Mips::DSPOutFlag23:
+    return true;
+  default:
+    return false;
+  }
+}
+
 void MipsSEDAGToDAGISel::processFunctionAfterISel(MachineFunction &MF) {
   MF.getInfo<MipsFunctionInfo>()->initGlobalBaseReg(MF);
 
@@ -194,6 +212,18 @@ void MipsSEDAGToDAGISel::processFunctionAfterISel(MachineFunction &MF) {
         break;
       default:
         replaceUsesWithZeroReg(MRI, MI);
+      }
+
+      // MIPS DSP intrinsics don't explicitly model their dependencies
+      // in the SelectionDAG, which causes InstrEmitter to mistakenly mark them
+      // as dead. We clear the dead flags here so that LiveVariables will
+      // compute liveness correctly, avoiding MachineDeadInstrElim from deleting
+      // the definitions.
+      for (MachineOperand &MO : MI.operands()) {
+        if (MO.isReg() && MO.isDef() && MO.getReg().isPhysical() &&
+            isDSPControlReg(MO.getReg())) {
+          MO.setIsDead(false);
+        }
       }
     }
   }

--- a/llvm/lib/Target/Mips/MipsSEISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Mips/MipsSEISelDAGToDAG.cpp
@@ -219,12 +219,9 @@ void MipsSEDAGToDAGISel::processFunctionAfterISel(MachineFunction &MF) {
       // as dead. We clear the dead flags here so that LiveVariables will
       // compute liveness correctly, avoiding MachineDeadInstrElim from deleting
       // the definitions.
-      for (MachineOperand &MO : MI.operands()) {
-        if (MO.isReg() && MO.isDef() && MO.getReg().isPhysical() &&
-            isDSPControlReg(MO.getReg())) {
+      for (MachineOperand &MO : MI.operands())
+        if (MO.isReg() && MO.isDef() && isDSPControlReg(MO.getReg()))
           MO.setIsDead(false);
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
The old Implicit | Undef hack explicitly told the compiler to ignore the use dependency, which disabled proper liveness tracking and could have caused the definition to be incorrectly deleted by later passes. By using genuine Implicit uses and manually stripping the dead flags after ISel, we allow LiveVariables and LiveIntervals to construct a correct, unbroken live range.

Fixes: https://github.com/llvm/llvm-project/issues/27490