### PR TITLE
[mlir][ptr] Add nontemporal field to ptr.masked_load

### DIFF
--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
@@ -299,10 +299,15 @@ def Ptr_MaskedLoadOp : Pointer_Op<"masked_load", [
   let arguments = (ins Ptr_PtrType:$ptr,
                        Ptr_Mask1DType:$mask,
                        Ptr_Any1DType:$passthrough,
-                       AlignmentProp:$alignment);
+                       AlignmentProp:$alignment,
+                       UnitProp:$nontemporal);
   let results = (outs Ptr_Any1DType:$result);
   let assemblyFormat = [{
-    $ptr `,` $mask `,` $passthrough (`alignment` `=` $alignment^)?
+    $ptr `,` $mask `,` $passthrough
+    oilist(
+      `alignment` `=` $alignment |
+      `nontemporal` $nontemporal
+    )
     attr-dict `:` qualified(type($ptr)) `->` type($result)
   }];
   let builders = [

--- a/mlir/lib/Target/LLVMIR/Dialect/Ptr/PtrToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/Ptr/PtrToLLVMIRTranslation.cpp
@@ -259,6 +259,13 @@ translateMaskedLoadOp(MaskedLoadOp maskedLoadOp, llvm::IRBuilderBase &builder,
   llvm::Value *result = builder.CreateMaskedLoad(
       resultType, ptr, alignment.valueOrOne(), mask, passthrough);
 
+  if (maskedLoadOp.getNontemporal()) {
+    llvm::MDNode *metadata =
+        llvm::MDNode::get(result->getContext(),
+                          llvm::ConstantAsMetadata::get(builder.getInt32(1)));
+    llvm::cast<llvm::Instruction>(result)->setMetadata(
+        llvm::LLVMContext::MD_nontemporal, metadata);
+  }
   moduleTranslation.mapValue(maskedLoadOp.getResult(), result);
   return success();
 }

--- a/mlir/test/Dialect/Ptr/ops.mlir
+++ b/mlir/test/Dialect/Ptr/ops.mlir
@@ -89,6 +89,7 @@ func.func @scatter_ops_tensor(%value: tensor<8xi64>, %ptrs: tensor<8x!ptr.ptr<#p
 func.func @masked_load_ops(%ptr: !ptr.ptr<#ptr.generic_space>, %mask: vector<4xi1>, %passthrough: vector<4xf32>) -> vector<4xf32> {
   %0 = ptr.masked_load %ptr, %mask, %passthrough : !ptr.ptr<#ptr.generic_space> -> vector<4xf32>
   %1 = ptr.masked_load %ptr, %mask, %passthrough alignment = 16 : !ptr.ptr<#ptr.generic_space> -> vector<4xf32>
+  %2 = ptr.masked_load %ptr, %mask, %passthrough alignment = 16 nontemporal : !ptr.ptr<#ptr.generic_space> -> vector<4xf32> 
   return %0 : vector<4xf32>
 }
 
@@ -96,6 +97,7 @@ func.func @masked_load_ops(%ptr: !ptr.ptr<#ptr.generic_space>, %mask: vector<4xi
 func.func @masked_load_ops_tensor(%ptr: !ptr.ptr<#ptr.generic_space>, %mask: tensor<8xi1>, %passthrough: tensor<8xi32>) -> tensor<8xi32> {
   %0 = ptr.masked_load %ptr, %mask, %passthrough : !ptr.ptr<#ptr.generic_space> -> tensor<8xi32>
   %1 = ptr.masked_load %ptr, %mask, %passthrough alignment = 4 : !ptr.ptr<#ptr.generic_space> -> tensor<8xi32>
+  %2 = ptr.masked_load %ptr, %mask, %passthrough alignment = 4 nontemporal : !ptr.ptr<#ptr.generic_space> -> tensor<8xi32>
   return %0 : tensor<8xi32>
 }
 

--- a/mlir/test/Target/LLVMIR/ptr.mlir
+++ b/mlir/test/Target/LLVMIR/ptr.mlir
@@ -118,6 +118,7 @@ llvm.func @gather_ops_i32(%ptrs: vector<8x!ptr.ptr<#llvm.address_space<0>>>, %ma
 // CHECK-SAME: (ptr %[[PTR:.*]], <4 x i1> %[[MASK:.*]], <4 x float> %[[PASSTHROUGH:.*]]) {
 // CHECK-NEXT:   %[[V0:.*]] = call <4 x float> @llvm.masked.load.v4f32.p0(ptr align 1 %[[PTR]], <4 x i1> %[[MASK]], <4 x float> %[[PASSTHROUGH]])
 // CHECK-NEXT:   %[[V1:.*]] = call <4 x float> @llvm.masked.load.v4f32.p0(ptr align 16 %[[PTR]], <4 x i1> %[[MASK]], <4 x float> %[[PASSTHROUGH]])
+// CHECK-NEXT:   %[[V2:.*]] = call <4 x float> @llvm.masked.load.v4f32.p0(ptr align 16 %[[PTR]], <4 x i1> %[[MASK]], <4 x float> %[[PASSTHROUGH]]), !nontemporal
 // CHECK-NEXT:   ret <4 x float> %[[V0]]
 // CHECK-NEXT: }
 llvm.func @masked_load_ops(%ptr: !ptr.ptr<#llvm.address_space<0>>, %mask: vector<4xi1>, %passthrough: vector<4xf32>) -> vector<4xf32> {
@@ -125,6 +126,8 @@ llvm.func @masked_load_ops(%ptr: !ptr.ptr<#llvm.address_space<0>>, %mask: vector
   %0 = ptr.masked_load %ptr, %mask, %passthrough : !ptr.ptr<#llvm.address_space<0>> -> vector<4xf32>
   // Masked load with alignment
   %1 = ptr.masked_load %ptr, %mask, %passthrough alignment = 16 : !ptr.ptr<#llvm.address_space<0>> -> vector<4xf32>
+  // Masked load with nontemporal
+  %2 = ptr.masked_load %ptr, %mask, %passthrough alignment = 16 nontemporal : !ptr.ptr<#llvm.address_space<0>> -> vector<4xf32>
   llvm.return %0 : vector<4xf32>
 }
 


### PR DESCRIPTION
`llvm.intr.masked.load` supports a `nontemporal` flag, but `ptr.masked_load` was missing this field, limiting its expressiveness relative to the underlying LLVM intrinsic. This patch adds a `nontemporal` UnitProp to `ptr.masked_load`, mirroring the existing `nontemporal` support on `ptr.load`, and updates the assembly format accordingly using `oilist` to allow `alignment` and `nontemporal` to appear independently. Part of https://github.com/llvm/llvm-project/pull/205022.