### PR TITLE
[clangd] Log environment variables that influence compilation at startup

### DIFF
--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -912,6 +912,18 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
     log("argv[{0}]: {1}", I, argv[I]);
   if (auto EnvFlags = llvm::sys::Process::GetEnv(FlagsEnvVar))
     log("{0}: {1}", FlagsEnvVar, *EnvFlags);
+  // Log environment variables that influence how clangd finds system headers.
+  // This helps diagnose missing-include issues, especially on Windows.
+  for (const char *EnvVar : {
+           // MSVC environment variables (set by vcvarsall.bat)
+           "INCLUDE", "LIB", "LIBPATH", "CL", "_CL_",
+           // GCC/Clang environment variables
+           "CPATH", "C_INCLUDE_PATH", "CPLUS_INCLUDE_PATH",
+           "OBJC_INCLUDE_PATH", "LIBRARY_PATH", "GCC_EXEC_PREFIX",
+       }) {
+    if (auto Val = llvm::sys::Process::GetEnv(EnvVar))
+      log("Env {0}: {1}", EnvVar, *Val);
+  }
 
   ClangdLSPServer::Options Opts;
   Opts.UseDirBasedCDB = (CompileArgsFrom == FilesystemCompileArgs);

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -916,10 +916,18 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
   // This helps diagnose missing-include issues, especially on Windows.
   for (const char *EnvVar : {
            // MSVC environment variables (set by vcvarsall.bat)
-           "INCLUDE", "LIB", "LIBPATH", "CL", "_CL_",
+           "INCLUDE",
+           "LIB",
+           "LIBPATH",
+           "CL",
+           "_CL_",
            // GCC/Clang environment variables
-           "CPATH", "C_INCLUDE_PATH", "CPLUS_INCLUDE_PATH",
-           "OBJC_INCLUDE_PATH", "LIBRARY_PATH", "GCC_EXEC_PREFIX",
+           "CPATH",
+           "C_INCLUDE_PATH",
+           "CPLUS_INCLUDE_PATH",
+           "OBJC_INCLUDE_PATH",
+           "LIBRARY_PATH",
+           "GCC_EXEC_PREFIX",
        }) {
     if (auto Val = llvm::sys::Process::GetEnv(EnvVar))
       log("Env {0}: {1}", EnvVar, *Val);


### PR DESCRIPTION
  When users face missing system include issues (especially on Windows), it's
  difficult to diagnose whether the problem is caused by missing environment
  variables like `INCLUDE`, `CPATH`, etc.

  This patch logs the values of environment variables that influence how the
  compiler finds headers and libraries, at startup alongside the existing
  version/PID/argv logs. Only variables that are actually set are printed.

  Variables logged:
  - MSVC (set by vcvarsall.bat): `INCLUDE`, `LIB`, `LIBPATH`, `CL`, `_CL_`
  - GCC/Clang: `CPATH`, `C_INCLUDE_PATH`, `CPLUS_INCLUDE_PATH`, `OBJC_INCLUDE_PATH`, `LIBRARY_PATH`, `GCC_EXEC_PREFIX`

  Fixes https://github.com/clangd/clangd/issues/2657