### PR TITLE
[llvm-cov] Init `ViewOpts.Colors` before `error()`

### DIFF
--- a/llvm/test/tools/llvm-cov/show-colors-uninit.test
+++ b/llvm/test/tools/llvm-cov/show-colors-uninit.test
@@ -1,0 +1,7 @@
+; Regression test: calling `llvm-cov show` without `-instr-profile` or
+; `-empty-profile` triggered a UBSan error because `error()` reads `Colors` via
+; `colored_ostream()` before `Colors` was initialized.
+
+; RUN: not llvm-cov show 2>&1 | FileCheck %s
+
+; CHECK: error: exactly one of -instr-profile and -empty-profile must be specified

--- a/llvm/tools/llvm-cov/CodeCoverage.cpp
+++ b/llvm/tools/llvm-cov/CodeCoverage.cpp
@@ -814,6 +814,29 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
   auto commandLineParser = [&, this](int argc, const char **argv) -> int {
     cl::ParseCommandLineOptions(argc, argv, "LLVM code coverage tool\n");
     ViewOpts.Debug = DebugDump;
+
+    // Initialize `Format` and `Colors` before any call to `error()` or
+    // `warning()`, which use `ViewOpts.colored_ostream()` and would read
+    // uninitialized `Colors`.
+    ViewOpts.Format = Format;
+    switch (ViewOpts.Format) {
+    case CoverageViewOptions::OutputFormat::Text:
+      ViewOpts.Colors = UseColor == cl::boolOrDefault::BOU_UNSET
+                            ? sys::Process::StandardOutHasColors()
+                            : UseColor == cl::boolOrDefault::BOU_TRUE;
+      break;
+    case CoverageViewOptions::OutputFormat::HTML:
+      if (UseColor == cl::boolOrDefault::BOU_FALSE)
+        errs() << "Color output cannot be disabled when generating html.\n";
+      ViewOpts.Colors = true;
+      break;
+    case CoverageViewOptions::OutputFormat::Lcov:
+      if (UseColor == cl::boolOrDefault::BOU_TRUE)
+        errs() << "Color output cannot be enabled when generating lcov.\n";
+      ViewOpts.Colors = false;
+      break;
+    }
+
     if (Debuginfod) {
       HTTPClient::initialize();
       BIDFetcher = std::make_unique<DebuginfodFetcher>(DebugFileDirectory);
@@ -844,25 +867,6 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
       for (StringRef OF : ObjectFilenames)
         outs() << OF << '\n';
       ::exit(0);
-    }
-
-    ViewOpts.Format = Format;
-    switch (ViewOpts.Format) {
-    case CoverageViewOptions::OutputFormat::Text:
-      ViewOpts.Colors = UseColor == cl::boolOrDefault::BOU_UNSET
-                            ? sys::Process::StandardOutHasColors()
-                            : UseColor == cl::boolOrDefault::BOU_TRUE;
-      break;
-    case CoverageViewOptions::OutputFormat::HTML:
-      if (UseColor == cl::boolOrDefault::BOU_FALSE)
-        errs() << "Color output cannot be disabled when generating html.\n";
-      ViewOpts.Colors = true;
-      break;
-    case CoverageViewOptions::OutputFormat::Lcov:
-      if (UseColor == cl::boolOrDefault::BOU_TRUE)
-        errs() << "Color output cannot be enabled when generating lcov.\n";
-      ViewOpts.Colors = false;
-      break;
     }
 
     if (!PathRemaps.empty()) {


### PR DESCRIPTION
The `commandLineParser` lambda calls `error()` at several points before `ViewOpts.Colors` is set. `error()` uses `ViewOpts.colored_ostream()` which reads `Colors`, triggering undefined behavior (load of uninitialized `bool`).

Fix by moving the `Colors` initialization block to just after `ParseCommandLineOptions`, before any `error()` call in the lambda. This ensures error messages are always rendered with properly initialized color settings.