### PR TITLE
[libc] Prefix sanitizer macros with LIBC_

### DIFF
--- a/libc/src/__support/FPUtil/x86_64/fenv_x87_utils.h
+++ b/libc/src/__support/FPUtil/x86_64/fenv_x87_utils.h
@@ -34,7 +34,7 @@ LIBC_INLINE static uint16_t get_x87_control_word() {
   __asm fstcw w;
 #else  // !LIBC_COMPILER_IS_MSVC
   asm volatile("fnstcw %0" : "=m"(w)::);
-  MSAN_UNPOISON(&w, sizeof(w));
+  LIBC_MSAN_UNPOISON(&w, sizeof(w));
 #endif // LIBC_COMPILER_IS_MSVC
 
   return w;
@@ -55,7 +55,7 @@ LIBC_INLINE static uint16_t get_x87_status_word() {
   __asm fnstsw w;
 #else  // !LIBC_COMPILER_IS_MSVC
   asm volatile("fnstsw %0" : "=m"(w)::);
-  MSAN_UNPOISON(&w, sizeof(w));
+  LIBC_MSAN_UNPOISON(&w, sizeof(w));
 #endif // LIBC_COMPILER_IS_MSVC
 
   return w;
@@ -74,7 +74,7 @@ LIBC_INLINE static void get_x87_state_descriptor(X87StateDescriptor &s) {
   __asm fnstenv s;
 #else  // !LIBC_COMPILER_IS_MSVC
   asm volatile("fnstenv %0" : "=m"(s));
-  MSAN_UNPOISON(&s, sizeof(s));
+  LIBC_MSAN_UNPOISON(&s, sizeof(s));
 #endif // LIBC_COMPILER_IS_MSVC
 }
 

--- a/libc/src/__support/macros/sanitizer.h
+++ b/libc/src/__support/macros/sanitizer.h
@@ -26,7 +26,7 @@
 #ifdef LIBC_HAS_MEMORY_SANITIZER
 // Only perform MSAN unpoison in non-constexpr context.
 #include <sanitizer/msan_interface.h>
-#define LIBC_MSAN_UNPOISON(addr, size)                                              \
+#define LIBC_MSAN_UNPOISON(addr, size)                                         \
   do {                                                                         \
     if (!__builtin_is_constant_evaluated())                                    \
       __msan_unpoison(addr, size);                                             \
@@ -37,13 +37,14 @@
 
 #ifdef LIBC_HAS_ADDRESS_SANITIZER
 #include <sanitizer/asan_interface.h>
-#define LIBC_ASAN_POISON_MEMORY_REGION(addr, size)                                  \
+#define LIBC_ASAN_POISON_MEMORY_REGION(addr, size)                             \
   __asan_poison_memory_region((addr), (size))
-#define LIBC_ASAN_UNPOISON_MEMORY_REGION(addr, size)                                \
+#define LIBC_ASAN_UNPOISON_MEMORY_REGION(addr, size)                           \
   __asan_unpoison_memory_region((addr), (size))
 #else
 #define LIBC_ASAN_POISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
-#define LIBC_ASAN_UNPOISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
+#define LIBC_ASAN_UNPOISON_MEMORY_REGION(addr, size)                           \
+  ((void)(addr), (void)(size))
 #endif
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MACROS_SANITIZER_H

--- a/libc/src/__support/macros/sanitizer.h
+++ b/libc/src/__support/macros/sanitizer.h
@@ -26,24 +26,24 @@
 #ifdef LIBC_HAS_MEMORY_SANITIZER
 // Only perform MSAN unpoison in non-constexpr context.
 #include <sanitizer/msan_interface.h>
-#define MSAN_UNPOISON(addr, size)                                              \
+#define LIBC_MSAN_UNPOISON(addr, size)                                              \
   do {                                                                         \
     if (!__builtin_is_constant_evaluated())                                    \
       __msan_unpoison(addr, size);                                             \
   } while (0)
 #else
-#define MSAN_UNPOISON(ptr, size)
+#define LIBC_MSAN_UNPOISON(ptr, size)
 #endif
 
 #ifdef LIBC_HAS_ADDRESS_SANITIZER
 #include <sanitizer/asan_interface.h>
-#define ASAN_POISON_MEMORY_REGION(addr, size)                                  \
+#define LIBC_ASAN_POISON_MEMORY_REGION(addr, size)                                  \
   __asan_poison_memory_region((addr), (size))
-#define ASAN_UNPOISON_MEMORY_REGION(addr, size)                                \
+#define LIBC_ASAN_UNPOISON_MEMORY_REGION(addr, size)                                \
   __asan_unpoison_memory_region((addr), (size))
 #else
-#define ASAN_POISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
-#define ASAN_UNPOISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
+#define LIBC_ASAN_POISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
+#define LIBC_ASAN_UNPOISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
 #endif
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MACROS_SANITIZER_H

--- a/libc/src/sys/epoll/linux/epoll_pwait.cpp
+++ b/libc/src/sys/epoll/linux/epoll_pwait.cpp
@@ -35,7 +35,7 @@ LLVM_LIBC_FUNCTION(int, epoll_pwait,
     return -1;
   }
 
-  MSAN_UNPOISON(events, ret * sizeof(struct epoll_event));
+  LIBC_MSAN_UNPOISON(events, ret * sizeof(struct epoll_event));
 
   return ret;
 }

--- a/libc/src/sys/epoll/linux/epoll_pwait2.cpp
+++ b/libc/src/sys/epoll/linux/epoll_pwait2.cpp
@@ -37,7 +37,7 @@ LLVM_LIBC_FUNCTION(int, epoll_pwait2,
     return -1;
   }
 
-  MSAN_UNPOISON(events, ret * sizeof(struct epoll_event));
+  LIBC_MSAN_UNPOISON(events, ret * sizeof(struct epoll_event));
 
   return ret;
 }

--- a/libc/src/sys/epoll/linux/epoll_wait.cpp
+++ b/libc/src/sys/epoll/linux/epoll_wait.cpp
@@ -41,7 +41,7 @@ LLVM_LIBC_FUNCTION(int, epoll_wait,
     return -1;
   }
 
-  MSAN_UNPOISON(events, ret * sizeof(struct epoll_event));
+  LIBC_MSAN_UNPOISON(events, ret * sizeof(struct epoll_event));
 
   return ret;
 }

--- a/libc/src/sys/socket/linux/recv.cpp
+++ b/libc/src/sys/socket/linux/recv.cpp
@@ -28,7 +28,7 @@ LLVM_LIBC_FUNCTION(ssize_t, recv,
     return -1;
   }
 
-  MSAN_UNPOISON(buf, result.value());
+  LIBC_MSAN_UNPOISON(buf, result.value());
 
   return result.value();
 }

--- a/libc/src/sys/socket/linux/recvfrom.cpp
+++ b/libc/src/sys/socket/linux/recvfrom.cpp
@@ -42,13 +42,13 @@ LLVM_LIBC_FUNCTION(ssize_t, recvfrom,
   }
 
   ssize_t ret = result.value();
-  MSAN_UNPOISON(buf, ret);
+  LIBC_MSAN_UNPOISON(buf, ret);
 
   if (src_addr) {
     size_t min_src_addr_size = (*addrlen < srcaddr_sz) ? *addrlen : srcaddr_sz;
     (void)min_src_addr_size; // prevent "set but not used" warning
 
-    MSAN_UNPOISON(src_addr, min_src_addr_size);
+    LIBC_MSAN_UNPOISON(src_addr, min_src_addr_size);
   }
   return ret;
 }

--- a/libc/src/sys/socket/linux/recvmsg.cpp
+++ b/libc/src/sys/socket/linux/recvmsg.cpp
@@ -28,13 +28,13 @@ LLVM_LIBC_FUNCTION(ssize_t, recvmsg, (int sockfd, msghdr *msg, int flags)) {
   }
 
   // Unpoison the msghdr, as well as all its components.
-  MSAN_UNPOISON(msg, sizeof(msghdr));
-  MSAN_UNPOISON(msg->msg_name, msg->msg_namelen);
+  LIBC_MSAN_UNPOISON(msg, sizeof(msghdr));
+  LIBC_MSAN_UNPOISON(msg->msg_name, msg->msg_namelen);
 
   for (size_t i = 0; i < msg->msg_iovlen; ++i) {
-    MSAN_UNPOISON(msg->msg_iov[i].iov_base, msg->msg_iov[i].iov_len);
+    LIBC_MSAN_UNPOISON(msg->msg_iov[i].iov_base, msg->msg_iov[i].iov_len);
   }
-  MSAN_UNPOISON(msg->msg_control, msg->msg_controllen);
+  LIBC_MSAN_UNPOISON(msg->msg_control, msg->msg_controllen);
 
   return result.value();
 }

--- a/libc/src/sys/socket/linux/socketpair.cpp
+++ b/libc/src/sys/socket/linux/socketpair.cpp
@@ -26,7 +26,7 @@ LLVM_LIBC_FUNCTION(int, socketpair,
     return -1;
   }
 
-  MSAN_UNPOISON(sv, sizeof(int) * 2);
+  LIBC_MSAN_UNPOISON(sv, sizeof(int) * 2);
 
   return result.value();
 }

--- a/libc/src/unistd/linux/pipe.cpp
+++ b/libc/src/unistd/linux/pipe.cpp
@@ -12,7 +12,7 @@
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include "src/__support/macros/sanitizer.h" // for MSAN_UNPOISON
+#include "src/__support/macros/sanitizer.h" // for LIBC_MSAN_UNPOISON
 #include <sys/syscall.h>                    // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
@@ -25,7 +25,7 @@ LLVM_LIBC_FUNCTION(int, pipe, (int pipefd[2])) {
   int ret = LIBC_NAMESPACE::syscall_impl<int>(
       SYS_pipe2, reinterpret_cast<long>(pipefd), 0);
 #endif
-  MSAN_UNPOISON(pipefd, sizeof(int) * 2);
+  LIBC_MSAN_UNPOISON(pipefd, sizeof(int) * 2);
   if (ret < 0) {
     libc_errno = -ret;
     return -1;

--- a/libc/src/unistd/linux/pipe2.cpp
+++ b/libc/src/unistd/linux/pipe2.cpp
@@ -23,7 +23,7 @@ LLVM_LIBC_FUNCTION(int, pipe2, (int pipefd[2], int flags)) {
     libc_errno = -ret;
     return -1;
   }
-  MSAN_UNPOISON(pipefd, sizeof(int) * 2);
+  LIBC_MSAN_UNPOISON(pipefd, sizeof(int) * 2);
   return ret;
 }
 

--- a/libc/src/unistd/linux/pread.cpp
+++ b/libc/src/unistd/linux/pread.cpp
@@ -13,7 +13,7 @@
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include "src/__support/macros/sanitizer.h" // for MSAN_UNPOISON
+#include "src/__support/macros/sanitizer.h" // for LIBC_MSAN_UNPOISON
 #include <sys/syscall.h>                    // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
@@ -37,7 +37,7 @@ LLVM_LIBC_FUNCTION(ssize_t, pread,
   }
   // The cast is important since there is a check that dereferences the pointer
   // which fails on void*.
-  MSAN_UNPOISON(reinterpret_cast<char *>(buf), count);
+  LIBC_MSAN_UNPOISON(reinterpret_cast<char *>(buf), count);
   if (ret < 0) {
     libc_errno = static_cast<int>(-ret);
     return -1;

--- a/libc/src/unistd/linux/read.cpp
+++ b/libc/src/unistd/linux/read.cpp
@@ -12,7 +12,7 @@
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include "src/__support/macros/sanitizer.h" // for MSAN_UNPOISON
+#include "src/__support/macros/sanitizer.h" // for LIBC_MSAN_UNPOISON
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -24,7 +24,7 @@ LLVM_LIBC_FUNCTION(ssize_t, read, (int fd, void *buf, size_t count)) {
   }
   // The cast is important since there is a check that dereferences the pointer
   // which fails on void*.
-  MSAN_UNPOISON(reinterpret_cast<char *>(buf), count);
+  LIBC_MSAN_UNPOISON(reinterpret_cast<char *>(buf), count);
   return result.value();
 }
 

--- a/libc/test/src/string/memory_utils/memory_check_utils.h
+++ b/libc/test/src/string/memory_utils/memory_check_utils.h
@@ -25,7 +25,7 @@ namespace LIBC_NAMESPACE_DECL {
 // This is a utility class to be used by Buffer below, do not use directly.
 struct PoisonedBuffer {
   PoisonedBuffer(size_t size) : ptr((char *)malloc(size)) {
-    ASAN_POISON_MEMORY_REGION(ptr, size);
+    LIBC_ASAN_POISON_MEMORY_REGION(ptr, size);
   }
   ~PoisonedBuffer() { free(ptr); }
 
@@ -47,7 +47,7 @@ struct Buffer : private PoisonedBuffer {
     offset_ptr += distance_to_next_aligned<kAlign>(ptr);
     if (aligned == Aligned::NO)
       ++offset_ptr;
-    ASAN_UNPOISON_MEMORY_REGION(offset_ptr, size);
+    LIBC_ASAN_UNPOISON_MEMORY_REGION(offset_ptr, size);
   }
   cpp::span<char> span() { return cpp::span<char>(offset_ptr, size); }
 


### PR DESCRIPTION
Since these macros leak into user code via libc/shared/math.h,
prefix them with LIBC_ to not cause collisions.

Change created with:

    rg -l MSAN_UNPOISON libc | xargs sed -i '' \
        -e 's/MSAN_UNPOISON/LIBC_MSAN_UNPOISON/g'
    rg -l ASAN_POISON_MEMORY_REGION libc | xargs sed -i '' -e \
        's/ASAN_POISON_MEMORY_REGION/LIBC_ASAN_POISON_MEMORY_REGION/g'
    rg -l ASAN_POISON_MEMORY_REGION libc | xargs sed -i '' -e \
        's/ASAN_POISON_MEMORY_REGION/LIBC_ASAN_POISON_MEMORY_REGION/g'

No behavior change.