### PR TITLE
[VPlan] Add VPReplicateRecipe::getNumOperandsWithoutMask (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -3482,6 +3482,12 @@ public:
     return isPredicated() ? drop_end(operands()) : operands();
   }
 
+  /// Returns the number of operands, excluding the mask if the recipe is
+  /// predicated.
+  unsigned getNumOperandsWithoutMask() const {
+    return getNumOperands() - isPredicated();
+  }
+
   unsigned getOpcode() const { return getUnderlyingInstr()->getOpcode(); }
 
 protected:

--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -252,7 +252,7 @@ struct Recipe_match {
       assert(((isa<VPInstruction>(R) &&
                cast<VPInstruction>(R)->getNumOperandsForOpcode() == -1u) ||
               (RepR && std::tuple_size_v<Ops_t> ==
-                           RepR->getNumOperands() - RepR->isPredicated())) &&
+                           RepR->getNumOperandsWithoutMask())) &&
              "non-variadic recipe with matched opcode does not have the "
              "expected number of operands");
       return false;

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.h
@@ -92,9 +92,9 @@ template <typename Ty> Intrinsic::ID getIntrinsicID(const Ty *R) {
   };
   if (const auto *Rep = dyn_cast<VPReplicateRecipe>(R))
     if (Rep->getOpcode() == Instruction::Call)
-      // The mask is always the last operand if predicated.
+      // The callee is the last operand, excluding the mask if predicated.
       return GetCalleeIntrinsic(
-          Rep->getOperand(Rep->getNumOperands() - 1 - Rep->isPredicated()));
+          Rep->getOperand(Rep->getNumOperandsWithoutMask() - 1));
   if (const auto *VPI = dyn_cast<VPInstruction>(R))
     if (VPI->getOpcode() == Instruction::Call)
       return GetCalleeIntrinsic(VPI->getOperand(VPI->getNumOperands() - 1));


### PR DESCRIPTION
Add a getNumOperandsWithoutMask helper to VPReplicateRecipe, mirroring the existing VPInstruction::getNumOperandsWithoutMask, and use it to replace some hand-rolled code.