### PR TITLE
[VPlan] Use pattern matching in isUsedByLoadStoreAddress (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -259,13 +259,21 @@ struct Recipe_match {
     }
 
     // If the recipe has more operands than expected, we only support matching
-    // masked VPInstructions where the number of operands of the matcher is the
-    // same as the number of operands excluding mask.
+    // masked VPInstructions or predicated VPReplicateRecipes, where the number
+    // of operands of the matcher matches the number of operands excluding the
+    // mask.
     if (R->getNumOperands() > std::tuple_size<Ops_t>::value) {
-      auto *VPI = dyn_cast<VPInstruction>(R);
-      if (!VPI || !VPI->isMasked() ||
-          VPI->getNumOperandsWithoutMask() != std::tuple_size<Ops_t>::value)
+      if (auto *VPI = dyn_cast<VPInstruction>(R)) {
+        if (!VPI->isMasked() ||
+            VPI->getNumOperandsWithoutMask() != std::tuple_size<Ops_t>::value)
+          return false;
+      } else if (auto *RepR = dyn_cast<VPReplicateRecipe>(R)) {
+        if (!RepR->isPredicated() ||
+            RepR->getNumOperandsWithoutMask() != std::tuple_size<Ops_t>::value)
+          return false;
+      } else {
         return false;
+      }
     }
 
     auto IdxSeq = std::make_index_sequence<std::tuple_size<Ops_t>::value>();

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -771,14 +771,12 @@ bool vputils::isUsedByLoadStoreAddress(const VPValue *V) {
       if (auto *InterleaveR = dyn_cast<VPInterleaveBase>(U))
         if (InterleaveR->getAddr() == Cur)
           return true;
-      if (auto *RepR = dyn_cast<VPReplicateRecipe>(U)) {
-        if (RepR->getOpcode() == Instruction::Load &&
-            RepR->getOperand(0) == Cur)
-          return true;
-        if (RepR->getOpcode() == Instruction::Store &&
-            RepR->getOperand(1) == Cur)
-          return true;
-      }
+      // Cur is used as the pointer of a (possibly masked) load (operand 0) or
+      // store (operand 1).
+      if (match(U, m_CombineOr(m_Unary<Instruction::Load>(m_Specific(Cur)),
+                               m_Binary<Instruction::Store>(m_VPValue(),
+                                                            m_Specific(Cur)))))
+        return true;
       if (auto *MemR = dyn_cast<VPWidenMemoryRecipe>(cast<VPRecipeBase>(U))) {
         if (MemR->getAddr() == Cur && MemR->isConsecutive())
           return true;


### PR DESCRIPTION
Replace the hand-written check for a VPReplicateRecipe load/store using the value as its address with VPlan pattern matching via m_Unary/m_Binary, which also handle masked recipes uniformly.