### PR TITLE
[libc][math] Add missing freebsd entrypoint for cbrtf16

### DIFF
--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -610,7 +610,7 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.asinhf16
     libc.src.math.atan2f16
     libc.src.math.canonicalizef16
-    libc.src.math.cbrtf
+    libc.src.math.cbrtf16
     libc.src.math.ceilf16
     libc.src.math.copysignf16
     libc.src.math.cosf16

--- a/libc/config/freebsd/x86_64/entrypoints.txt
+++ b/libc/config/freebsd/x86_64/entrypoints.txt
@@ -375,6 +375,7 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.atanhf16
     libc.src.math.atanpif16
     libc.src.math.canonicalizef16
+    libc.src.math.cbrtf16
     libc.src.math.ceilf16
     libc.src.math.copysignf16
     libc.src.math.cosf16


### PR DESCRIPTION
Adds missing freebsd entrypoint in [5429667](https://github.com/llvm/llvm-project/pull/205011/commits/5429667e053398d39e180f084e0dd5c4c416aa27)
and fixes the wrong entry point for `crbtf1` in  [cdc394f](https://github.com/llvm/llvm-project/pull/205011/commits/cdc394f8ba7dffb9f49563d601def7cf31561d6f), which was `cbrtf` in `baremetal/riscv`