### PR TITLE
[libc][math] Fix aarch64 Darwin fenv implementation for full builds

### DIFF
--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -167,6 +167,7 @@ add_macro_header(
     math-function-macros.h
   DEPENDS
     .math_macros
+    .float16_macros
 )
 
 add_macro_header(

--- a/libc/include/llvm-libc-macros/math-function-macros.h
+++ b/libc/include/llvm-libc-macros/math-function-macros.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_MACROS_MATH_FUNCTION_MACROS_H
 #define LLVM_LIBC_MACROS_MATH_FUNCTION_MACROS_H
 
+#include "float16-macros.h" // LIBC_TYPES_HAS_FLOAT16, LIBC_TYPES_HAS_FLOAT128
 #include "math-macros.h"
 
 #ifndef __cplusplus
@@ -17,11 +18,34 @@
       float: issignalingf,                                                     \
       double: issignaling,                                                     \
       long double: issignalingl)(x)
+
+// 'iscanonical' is a C23 type-generic macro (7.12.3.1).  The '_Float16' and
+// 'float128' associations are only added when those types exist, and 'float128'
+// only when it is distinct from 'long double' (otherwise _Generic would have
+// two associations with compatible types).  The 'float128' guard mirrors
+// LIBC_TYPES_FLOAT128_IS_NOT_LONG_DOUBLE in
+// src/__support/macros/properties/types.h, which public headers cannot include.
+#ifdef LIBC_TYPES_HAS_FLOAT16
+#define __LIBC_MATH_ISCANONICAL_F16 _Float16 : iscanonicalf16,
+#else
+#define __LIBC_MATH_ISCANONICAL_F16
+#endif
+#if defined(LIBC_TYPES_HAS_FLOAT128) && (LDBL_MANT_DIG != 113)
+#define __LIBC_MATH_ISCANONICAL_F128                                           \
+  float128:                                                                    \
+  iscanonicalf128,
+#else
+#define __LIBC_MATH_ISCANONICAL_F128
+#endif
+// clang-format off
 #define iscanonical(x)                                                         \
   _Generic((x),                                                                \
+      __LIBC_MATH_ISCANONICAL_F16                                              \
+      __LIBC_MATH_ISCANONICAL_F128                                             \
       float: iscanonicalf,                                                     \
       double: iscanonical,                                                     \
       long double: iscanonicall)(x)
+// clang-format on
 #endif
 
 #define isfinite(x) __builtin_isfinite(x)

--- a/libc/src/__support/FPUtil/aarch64/fenv_darwin_impl.h
+++ b/libc/src/__support/FPUtil/aarch64/fenv_darwin_impl.h
@@ -24,13 +24,28 @@
 #include "hdr/types/fenv_t.h"
 #include "src/__support/FPUtil/FPBits.h"
 
+// libc's <fenv.h> spells the denormal/flush-to-zero exception FE_DENORM, while
+// the system (Apple) <fenv.h> used in an overlay build spells it FE_FLUSHTOZERO.
+// Provide the latter as an alias in a full build so the code below uses a single
+// name.
+#ifndef FE_FLUSHTOZERO
+#define FE_FLUSHTOZERO FE_DENORM
+#endif
+
 namespace LIBC_NAMESPACE_DECL {
 namespace fputil {
 
 struct FEnv {
   struct FPState {
+#ifdef LIBC_FULL_BUILD
+    // libc's own fenv_t: a 4-byte status word and a 4-byte control word.
+    uint32_t StatusWord;
+    uint32_t ControlWord;
+#else
+    // The system (Apple) fenv_t in an overlay build: two 64-bit words.
     uint64_t StatusWord;
     uint64_t ControlWord;
+#endif
   };
 
   static_assert(
@@ -54,6 +69,18 @@ struct FEnv {
   // __APPLE__ ARM64 has an extra flag that is raised when a denormal is flushed
   // to zero.
   static constexpr uint32_t EX_FLUSHTOZERO = 0x20;
+
+  // FPCR trap-enable bit masks.  These come from Apple's <fenv.h> (not the ACLE
+  // <arm_acle.h>), which a full build replaces with libc's own fenv headers, so
+  // define them here with the same values Apple uses.
+#ifdef LIBC_FULL_BUILD
+  static constexpr uint32_t __fpcr_trap_invalid = 0x00000100;
+  static constexpr uint32_t __fpcr_trap_divbyzero = 0x00000200;
+  static constexpr uint32_t __fpcr_trap_overflow = 0x00000400;
+  static constexpr uint32_t __fpcr_trap_underflow = 0x00000800;
+  static constexpr uint32_t __fpcr_trap_inexact = 0x00001000;
+  static constexpr uint32_t __fpcr_flush_to_zero = 0x01000000;
+#endif
 
   // Zero-th bit is the first bit.
   static constexpr uint32_t ROUNDING_CONTROL_BIT_POSITION = 22;

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -437,6 +437,8 @@ add_libc_test(
 #     libc.src.math.iscanonical
 #     libc.src.math.iscanonicalf
 #     libc.src.math.iscanonicall
+#     libc.src.math.iscanonicalf16
+#     libc.src.math.iscanonicalf128
 # )
 
 add_libc_test(

--- a/libc/test/include/iscanonical_test.c
+++ b/libc/test/include/iscanonical_test.c
@@ -5,9 +5,17 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "include/llvm-libc-macros/float16-macros.h"
+
 int iscanonical(double);
 int iscanonicalf(float);
 int iscanonicall(long double);
+#ifdef LIBC_TYPES_HAS_FLOAT16
+int iscanonicalf16(_Float16);
+#endif
+#if defined(LIBC_TYPES_HAS_FLOAT128) && (LDBL_MANT_DIG != 113)
+int iscanonicalf128(float128);
+#endif
 
 #include "include/llvm-libc-macros/math-function-macros.h"
 
@@ -24,6 +32,14 @@ int main(void) {
   assert(iscanonical(1.819f) == 1);
   assert(iscanonical(-1.726) == 1);
   assert(iscanonical(1.426L) == 1);
+#ifdef LIBC_TYPES_HAS_FLOAT16
+  assert(iscanonical(__builtin_nansf16("")) == 0);
+  assert(iscanonical((_Float16)1.0) == 1);
+#endif
+#if defined(LIBC_TYPES_HAS_FLOAT128) && (LDBL_MANT_DIG != 113)
+  assert(iscanonical(__builtin_nansf128("")) == 0);
+  assert(iscanonical((float128)1.0) == 1);
+#endif
   return 0;
 }
 #endif


### PR DESCRIPTION
A full build replaces the system (Apple) <fenv.h> with libc's headers, so fenv_darwin_impl.h no longer found an 8-byte fenv_t, FE_FLUSHTOZERO, or the __fpcr_* masks it relied on. Size FPState to the fenv_t in scope, alias FE_FLUSHTOZERO to FE_DENORM, and define the FPCR trap masks locally.

Stacked on https://github.com/llvm/llvm-project/pull/204981; and below https://github.com/llvm/llvm-project/pull/205237.