### PR TITLE
[orc-rt]R Align scope-exit with LLVM (rename to scope_exit, use CTAD)

### DIFF
--- a/orc-rt/include/orc-rt/ScopeExit.h
+++ b/orc-rt/include/orc-rt/ScopeExit.h
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// make_scope_exit and related APIs.
+// scope_exit and related APIs.
 //
 //===----------------------------------------------------------------------===//
 
@@ -17,17 +17,16 @@
 #include <utility>
 
 namespace orc_rt {
-namespace detail {
 
-template <typename Fn> class ScopeExitRunner {
+template <typename Fn> class scope_exit {
 public:
   template <typename FnInit>
-  ScopeExitRunner(FnInit &&F) : F(std::forward<FnInit>(F)) {}
-  ScopeExitRunner(const ScopeExitRunner &) = delete;
-  ScopeExitRunner &operator=(const ScopeExitRunner &) = delete;
-  ScopeExitRunner(ScopeExitRunner &&) = delete;
-  ScopeExitRunner &operator=(ScopeExitRunner &&) = delete;
-  ~ScopeExitRunner() {
+  scope_exit(FnInit &&F) : F(std::forward<FnInit>(F)) {}
+  scope_exit(const scope_exit &) = delete;
+  scope_exit &operator=(const scope_exit &) = delete;
+  scope_exit(scope_exit &&) = delete;
+  scope_exit &operator=(scope_exit &&) = delete;
+  ~scope_exit() {
     if (Engaged)
       F();
   }
@@ -38,16 +37,7 @@ private:
   bool Engaged = true;
 };
 
-} // namespace detail
-
-/// Creates an object that runs the given function object upon destruction.
-/// Calling the object's release method prior to destruction will prevent the
-/// function object from running.
-template <typename Fn>
-[[nodiscard]] detail::ScopeExitRunner<std::decay_t<Fn>>
-make_scope_exit(Fn &&F) {
-  return detail::ScopeExitRunner<std::decay_t<Fn>>(std::forward<Fn>(F));
-}
+template <typename Fn> scope_exit(Fn) -> scope_exit<Fn>;
 
 } // namespace orc_rt
 

--- a/orc-rt/lib/executor/AllocAction.cpp
+++ b/orc-rt/lib/executor/AllocAction.cpp
@@ -18,7 +18,7 @@ namespace orc_rt {
 Expected<std::vector<AllocAction>>
 runFinalizeActions(std::vector<AllocActionPair> AAPs) {
   std::vector<AllocAction> DeallocActions;
-  auto RunDeallocActions = make_scope_exit([&]() {
+  auto RunDeallocActions = scope_exit([&]() {
     while (!DeallocActions.empty()) {
       // TODO: Log errors from cleanup dealloc actions.
       {

--- a/orc-rt/unittests/ScopeExitTest.cpp
+++ b/orc-rt/unittests/ScopeExitTest.cpp
@@ -16,13 +16,13 @@
 using namespace orc_rt;
 
 TEST(ScopeExitTest, Noop) {
-  auto _ = make_scope_exit([]() {});
+  auto _ = scope_exit([]() {});
 }
 
 TEST(ScopeExitTest, OnScopeExit) {
   bool ScopeExitRun = false;
   {
-    auto _ = make_scope_exit([&]() { ScopeExitRun = true; });
+    auto _ = scope_exit([&]() { ScopeExitRun = true; });
     EXPECT_FALSE(ScopeExitRun);
   }
   EXPECT_TRUE(ScopeExitRun);
@@ -31,7 +31,7 @@ TEST(ScopeExitTest, OnScopeExit) {
 TEST(ScopeExitTest, Release) {
   bool ScopeExitRun = false;
   {
-    auto OnExit = make_scope_exit([&]() { ScopeExitRun = true; });
+    auto OnExit = scope_exit([&]() { ScopeExitRun = true; });
     EXPECT_FALSE(ScopeExitRun);
     OnExit.release();
   }
@@ -46,6 +46,6 @@ TEST(ScopeExitTest, MoveOnlyFunctionObject) {
   };
 
   {
-    auto OnExit = make_scope_exit(MoveOnly());
+    auto OnExit = scope_exit(MoveOnly());
   }
 }


### PR DESCRIPTION
This renames the orc_rt::detail::ScopeExitRunner class to orc_rt::scope_exit and adds a class template argument deduction guide.