### PR TITLE
[LegalizeTypes] Fix incorrect EVL1 clip in SplitVecRes_VP_SPLICE.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -3650,7 +3650,16 @@ void DAGTypeLegalizer::SplitVecRes_VP_SPLICE(SDNode *N, SDValue &Lo,
       PtrInfo, MachineMemOperand::MOLoad, LocationSize::beforeOrAfterPointer(),
       Alignment);
 
-  SDValue StackPtr2 = TLI.getVectorElementPointer(DAG, StackPtr, VT, EVL1);
+  // EVL1 may equal NElts (V2 starts just past V1), so clamp to NElts.
+  unsigned EltSize = VT.getScalarSizeInBits() / 8;
+  SDValue EVL1Ptr = DAG.getZExtOrTrunc(EVL1, DL, PtrVT);
+  SDValue MaxElts = DAG.getElementCount(DL, PtrVT, VT.getVectorElementCount());
+  EVL1Ptr = DAG.getNode(ISD::UMIN, DL, PtrVT, EVL1Ptr, MaxElts);
+  SDValue StackPtr2 =
+      DAG.getMemBasePlusOffset(StackPtr,
+                               DAG.getNode(ISD::MUL, DL, PtrVT, EVL1Ptr,
+                                           DAG.getConstant(EltSize, DL, PtrVT)),
+                               DL);
   SDValue PoisonPtr = DAG.getPOISON(PtrVT);
 
   SDValue TrueMask = DAG.getBoolConstant(true, DL, Mask.getValueType(), VT);

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -3650,16 +3650,14 @@ void DAGTypeLegalizer::SplitVecRes_VP_SPLICE(SDNode *N, SDValue &Lo,
       PtrInfo, MachineMemOperand::MOLoad, LocationSize::beforeOrAfterPointer(),
       Alignment);
 
-  // EVL1 may equal NElts (V2 starts just past V1), so clamp to NElts.
-  unsigned EltSize = VT.getScalarSizeInBits() / 8;
+  SDValue EltByteSize =
+      DAG.getTypeSize(DL, PtrVT, VT.getVectorElementType().getStoreSize());
   SDValue EVL1Ptr = DAG.getZExtOrTrunc(EVL1, DL, PtrVT);
-  SDValue MaxElts = DAG.getElementCount(DL, PtrVT, VT.getVectorElementCount());
-  EVL1Ptr = DAG.getNode(ISD::UMIN, DL, PtrVT, EVL1Ptr, MaxElts);
-  SDValue StackPtr2 =
-      DAG.getMemBasePlusOffset(StackPtr,
-                               DAG.getNode(ISD::MUL, DL, PtrVT, EVL1Ptr,
-                                           DAG.getConstant(EltSize, DL, PtrVT)),
-                               DL);
+  SDValue EVL1Bytes = DAG.getNode(ISD::MUL, DL, PtrVT, EVL1Ptr, EltByteSize);
+  // Clip EVL1Bytes to make sure we stay within the stack object.
+  SDValue VTBytes = DAG.getTypeSize(DL, PtrVT, VT.getStoreSize());
+  EVL1Bytes = DAG.getNode(ISD::UMIN, DL, PtrVT, EVL1Bytes, VTBytes);
+  SDValue StackPtr2 = DAG.getMemBasePlusOffset(StackPtr, EVL1Bytes, DL);
   SDValue PoisonPtr = DAG.getPOISON(PtrVT);
 
   SDValue TrueMask = DAG.getBoolConstant(true, DL, Mask.getValueType(), VT);

--- a/llvm/test/CodeGen/RISCV/rvv/vp-splice-mask-vectors.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vp-splice-mask-vectors.ll
@@ -924,17 +924,18 @@ define <vscale x 64 x i1> @test_vp_splice_nxv64i1_masked(<vscale x 64 x i1> %va,
 define <vscale x 128 x i1> @test_vp_splice_nxv128i1(<vscale x 128 x i1> %va, <vscale x 128 x i1> %vb, i32 zeroext %evla, i32 zeroext %evlb) #0 {
 ; NOVLDEP-LABEL: test_vp_splice_nxv128i1:
 ; NOVLDEP:       # %bb.0:
-; NOVLDEP-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
+; NOVLDEP-NEXT:    vsetvli a2, zero, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vmv1r.v v6, v10
 ; NOVLDEP-NEXT:    vmv1r.v v7, v9
-; NOVLDEP-NEXT:    csrr a2, vlenb
-; NOVLDEP-NEXT:    slli a5, a2, 4
+; NOVLDEP-NEXT:    vmv.v.i v16, 0
+; NOVLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
+; NOVLDEP-NEXT:    vmv1r.v v0, v8
+; NOVLDEP-NEXT:    csrr a3, vlenb
+; NOVLDEP-NEXT:    slli a2, a3, 3
 ; NOVLDEP-NEXT:    mv a4, a0
-; NOVLDEP-NEXT:    addi a5, a5, -1
-; NOVLDEP-NEXT:    mv a3, a0
-; NOVLDEP-NEXT:    bltu a0, a5, .LBB21_2
+; NOVLDEP-NEXT:    bltu a0, a2, .LBB21_2
 ; NOVLDEP-NEXT:  # %bb.1:
-; NOVLDEP-NEXT:    mv a3, a5
+; NOVLDEP-NEXT:    mv a4, a2
 ; NOVLDEP-NEXT:  .LBB21_2:
 ; NOVLDEP-NEXT:    addi sp, sp, -80
 ; NOVLDEP-NEXT:    .cfi_def_cfa_offset 80
@@ -948,56 +949,52 @@ define <vscale x 128 x i1> @test_vp_splice_nxv128i1(<vscale x 128 x i1> %va, <vs
 ; NOVLDEP-NEXT:    slli a5, a5, 5
 ; NOVLDEP-NEXT:    sub sp, sp, a5
 ; NOVLDEP-NEXT:    andi sp, sp, -64
-; NOVLDEP-NEXT:    vsetvli a5, zero, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vmv.v.i v16, 0
-; NOVLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
-; NOVLDEP-NEXT:    addi a5, sp, 64
-; NOVLDEP-NEXT:    slli a2, a2, 3
-; NOVLDEP-NEXT:    add a3, a5, a3
-; NOVLDEP-NEXT:    bltu a4, a2, .LBB21_4
-; NOVLDEP-NEXT:  # %bb.3:
-; NOVLDEP-NEXT:    mv a4, a2
-; NOVLDEP-NEXT:  .LBB21_4:
-; NOVLDEP-NEXT:    sub a6, a0, a2
-; NOVLDEP-NEXT:    vmv1r.v v0, v8
-; NOVLDEP-NEXT:    sltu a0, a0, a6
-; NOVLDEP-NEXT:    addi a0, a0, -1
-; NOVLDEP-NEXT:    and a6, a0, a6
+; NOVLDEP-NEXT:    sub a5, a0, a2
+; NOVLDEP-NEXT:    sltu a6, a0, a5
+; NOVLDEP-NEXT:    addi a6, a6, -1
+; NOVLDEP-NEXT:    and a6, a6, a5
 ; NOVLDEP-NEXT:    vsetvli zero, a6, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vmerge.vim v8, v16, 1, v0
+; NOVLDEP-NEXT:    addi a5, sp, 64
 ; NOVLDEP-NEXT:    vsetvli zero, a4, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vse8.v v24, (a5)
-; NOVLDEP-NEXT:    sub a0, a1, a2
+; NOVLDEP-NEXT:    sub a4, a1, a2
 ; NOVLDEP-NEXT:    vmv1r.v v0, v6
-; NOVLDEP-NEXT:    sltu a4, a1, a0
-; NOVLDEP-NEXT:    addi a4, a4, -1
-; NOVLDEP-NEXT:    and a0, a4, a0
-; NOVLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
+; NOVLDEP-NEXT:    sltu a7, a1, a4
+; NOVLDEP-NEXT:    addi a7, a7, -1
+; NOVLDEP-NEXT:    and a4, a7, a4
+; NOVLDEP-NEXT:    vsetvli zero, a4, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
-; NOVLDEP-NEXT:    add a5, a5, a2
+; NOVLDEP-NEXT:    add a7, a5, a2
+; NOVLDEP-NEXT:    slli a3, a3, 4
 ; NOVLDEP-NEXT:    vsetvli zero, a6, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vse8.v v8, (a5)
+; NOVLDEP-NEXT:    vse8.v v8, (a7)
+; NOVLDEP-NEXT:    bltu a0, a3, .LBB21_4
+; NOVLDEP-NEXT:  # %bb.3:
+; NOVLDEP-NEXT:    mv a0, a3
+; NOVLDEP-NEXT:  .LBB21_4:
 ; NOVLDEP-NEXT:    vmv1r.v v0, v7
-; NOVLDEP-NEXT:    vsetvli a4, zero, e8, m8, ta, ma
+; NOVLDEP-NEXT:    vsetvli a3, zero, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vmerge.vim v8, v16, 1, v0
-; NOVLDEP-NEXT:    add a4, a3, a2
-; NOVLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vse8.v v24, (a4)
+; NOVLDEP-NEXT:    add a0, a5, a0
+; NOVLDEP-NEXT:    add a3, a0, a2
+; NOVLDEP-NEXT:    vsetvli zero, a4, e8, m8, ta, ma
+; NOVLDEP-NEXT:    vse8.v v24, (a3)
 ; NOVLDEP-NEXT:    bltu a1, a2, .LBB21_6
 ; NOVLDEP-NEXT:  # %bb.5:
 ; NOVLDEP-NEXT:    mv a1, a2
 ; NOVLDEP-NEXT:  .LBB21_6:
 ; NOVLDEP-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vse8.v v8, (a3)
-; NOVLDEP-NEXT:    addi a3, sp, 69
-; NOVLDEP-NEXT:    add a2, a3, a2
-; NOVLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
+; NOVLDEP-NEXT:    vse8.v v8, (a0)
+; NOVLDEP-NEXT:    addi a0, sp, 69
+; NOVLDEP-NEXT:    add a2, a0, a2
+; NOVLDEP-NEXT:    vsetvli zero, a4, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vle8.v v8, (a2)
-; NOVLDEP-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
+; NOVLDEP-NEXT:    vsetvli a2, zero, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vand.vi v16, v8, 1
 ; NOVLDEP-NEXT:    vmsne.vi v8, v16, 0
 ; NOVLDEP-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vle8.v v16, (a3)
+; NOVLDEP-NEXT:    vle8.v v16, (a0)
 ; NOVLDEP-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vand.vi v16, v16, 1
 ; NOVLDEP-NEXT:    vmsne.vi v0, v16, 0
@@ -1013,17 +1010,18 @@ define <vscale x 128 x i1> @test_vp_splice_nxv128i1(<vscale x 128 x i1> %va, <vs
 ;
 ; VLDEP-LABEL: test_vp_splice_nxv128i1:
 ; VLDEP:       # %bb.0:
-; VLDEP-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
+; VLDEP-NEXT:    vsetvli a2, zero, e8, m8, ta, ma
 ; VLDEP-NEXT:    vmv1r.v v6, v10
 ; VLDEP-NEXT:    vmv1r.v v7, v9
-; VLDEP-NEXT:    csrr a2, vlenb
-; VLDEP-NEXT:    slli a5, a2, 4
+; VLDEP-NEXT:    vmv.v.i v16, 0
+; VLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
+; VLDEP-NEXT:    vmv1r.v v0, v8
+; VLDEP-NEXT:    csrr a3, vlenb
+; VLDEP-NEXT:    slli a2, a3, 3
 ; VLDEP-NEXT:    mv a4, a0
-; VLDEP-NEXT:    addi a5, a5, -1
-; VLDEP-NEXT:    mv a3, a0
-; VLDEP-NEXT:    bltu a0, a5, .LBB21_2
+; VLDEP-NEXT:    bltu a0, a2, .LBB21_2
 ; VLDEP-NEXT:  # %bb.1:
-; VLDEP-NEXT:    mv a3, a5
+; VLDEP-NEXT:    mv a4, a2
 ; VLDEP-NEXT:  .LBB21_2:
 ; VLDEP-NEXT:    addi sp, sp, -80
 ; VLDEP-NEXT:    .cfi_def_cfa_offset 80
@@ -1037,56 +1035,52 @@ define <vscale x 128 x i1> @test_vp_splice_nxv128i1(<vscale x 128 x i1> %va, <vs
 ; VLDEP-NEXT:    slli a5, a5, 5
 ; VLDEP-NEXT:    sub sp, sp, a5
 ; VLDEP-NEXT:    andi sp, sp, -64
-; VLDEP-NEXT:    vsetvli a5, zero, e8, m8, ta, ma
-; VLDEP-NEXT:    vmv.v.i v16, 0
-; VLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
-; VLDEP-NEXT:    addi a5, sp, 64
-; VLDEP-NEXT:    slli a2, a2, 3
-; VLDEP-NEXT:    add a3, a5, a3
-; VLDEP-NEXT:    bltu a4, a2, .LBB21_4
-; VLDEP-NEXT:  # %bb.3:
-; VLDEP-NEXT:    mv a4, a2
-; VLDEP-NEXT:  .LBB21_4:
-; VLDEP-NEXT:    sub a6, a0, a2
-; VLDEP-NEXT:    vmv1r.v v0, v8
-; VLDEP-NEXT:    sltu a0, a0, a6
-; VLDEP-NEXT:    addi a0, a0, -1
-; VLDEP-NEXT:    and a6, a0, a6
+; VLDEP-NEXT:    sub a5, a0, a2
+; VLDEP-NEXT:    sltu a6, a0, a5
+; VLDEP-NEXT:    addi a6, a6, -1
+; VLDEP-NEXT:    and a6, a6, a5
 ; VLDEP-NEXT:    vsetvli zero, a6, e8, m8, ta, ma
 ; VLDEP-NEXT:    vmerge.vim v8, v16, 1, v0
+; VLDEP-NEXT:    addi a5, sp, 64
 ; VLDEP-NEXT:    vsetvli zero, a4, e8, m8, ta, ma
 ; VLDEP-NEXT:    vse8.v v24, (a5)
-; VLDEP-NEXT:    sub a0, a1, a2
+; VLDEP-NEXT:    sub a4, a1, a2
 ; VLDEP-NEXT:    vmv1r.v v0, v6
-; VLDEP-NEXT:    sltu a4, a1, a0
-; VLDEP-NEXT:    addi a4, a4, -1
-; VLDEP-NEXT:    and a0, a4, a0
-; VLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
+; VLDEP-NEXT:    sltu a7, a1, a4
+; VLDEP-NEXT:    addi a7, a7, -1
+; VLDEP-NEXT:    and a4, a7, a4
+; VLDEP-NEXT:    vsetvli zero, a4, e8, m8, ta, ma
 ; VLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
-; VLDEP-NEXT:    add a5, a5, a2
+; VLDEP-NEXT:    add a7, a5, a2
+; VLDEP-NEXT:    slli a3, a3, 4
 ; VLDEP-NEXT:    vsetvli zero, a6, e8, m8, ta, ma
-; VLDEP-NEXT:    vse8.v v8, (a5)
+; VLDEP-NEXT:    vse8.v v8, (a7)
+; VLDEP-NEXT:    bltu a0, a3, .LBB21_4
+; VLDEP-NEXT:  # %bb.3:
+; VLDEP-NEXT:    mv a0, a3
+; VLDEP-NEXT:  .LBB21_4:
 ; VLDEP-NEXT:    vmv1r.v v0, v7
-; VLDEP-NEXT:    vsetvli a4, zero, e8, m8, ta, ma
+; VLDEP-NEXT:    vsetvli a3, zero, e8, m8, ta, ma
 ; VLDEP-NEXT:    vmerge.vim v8, v16, 1, v0
-; VLDEP-NEXT:    add a4, a3, a2
-; VLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
-; VLDEP-NEXT:    vse8.v v24, (a4)
+; VLDEP-NEXT:    add a0, a5, a0
+; VLDEP-NEXT:    add a3, a0, a2
+; VLDEP-NEXT:    vsetvli zero, a4, e8, m8, ta, ma
+; VLDEP-NEXT:    vse8.v v24, (a3)
 ; VLDEP-NEXT:    bltu a1, a2, .LBB21_6
 ; VLDEP-NEXT:  # %bb.5:
 ; VLDEP-NEXT:    mv a1, a2
 ; VLDEP-NEXT:  .LBB21_6:
 ; VLDEP-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; VLDEP-NEXT:    vse8.v v8, (a3)
-; VLDEP-NEXT:    addi a3, sp, 69
-; VLDEP-NEXT:    add a2, a3, a2
-; VLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
+; VLDEP-NEXT:    vse8.v v8, (a0)
+; VLDEP-NEXT:    addi a0, sp, 69
+; VLDEP-NEXT:    add a2, a0, a2
+; VLDEP-NEXT:    vsetvli zero, a4, e8, m8, ta, ma
 ; VLDEP-NEXT:    vle8.v v8, (a2)
-; VLDEP-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
+; VLDEP-NEXT:    vsetvli a2, zero, e8, m8, ta, ma
 ; VLDEP-NEXT:    vand.vi v16, v8, 1
 ; VLDEP-NEXT:    vmsne.vi v8, v16, 0
 ; VLDEP-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; VLDEP-NEXT:    vle8.v v16, (a3)
+; VLDEP-NEXT:    vle8.v v16, (a0)
 ; VLDEP-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
 ; VLDEP-NEXT:    vand.vi v16, v16, 1
 ; VLDEP-NEXT:    vmsne.vi v0, v16, 0
@@ -1106,17 +1100,18 @@ define <vscale x 128 x i1> @test_vp_splice_nxv128i1(<vscale x 128 x i1> %va, <vs
 define <vscale x 128 x i1> @test_vp_splice_nxv128i1_negative_offset(<vscale x 128 x i1> %va, <vscale x 128 x i1> %vb, i32 zeroext %evla, i32 zeroext %evlb) #0 {
 ; NOVLDEP-LABEL: test_vp_splice_nxv128i1_negative_offset:
 ; NOVLDEP:       # %bb.0:
-; NOVLDEP-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
+; NOVLDEP-NEXT:    vsetvli a2, zero, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vmv1r.v v6, v10
 ; NOVLDEP-NEXT:    vmv1r.v v7, v9
-; NOVLDEP-NEXT:    csrr a3, vlenb
-; NOVLDEP-NEXT:    slli a4, a3, 4
-; NOVLDEP-NEXT:    mv a5, a0
-; NOVLDEP-NEXT:    addi a4, a4, -1
-; NOVLDEP-NEXT:    mv a2, a0
-; NOVLDEP-NEXT:    bltu a0, a4, .LBB22_2
+; NOVLDEP-NEXT:    vmv.v.i v16, 0
+; NOVLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
+; NOVLDEP-NEXT:    vmv1r.v v0, v8
+; NOVLDEP-NEXT:    csrr a4, vlenb
+; NOVLDEP-NEXT:    slli a2, a4, 3
+; NOVLDEP-NEXT:    mv a3, a0
+; NOVLDEP-NEXT:    bltu a0, a2, .LBB22_2
 ; NOVLDEP-NEXT:  # %bb.1:
-; NOVLDEP-NEXT:    mv a2, a4
+; NOVLDEP-NEXT:    mv a3, a2
 ; NOVLDEP-NEXT:  .LBB22_2:
 ; NOVLDEP-NEXT:    addi sp, sp, -80
 ; NOVLDEP-NEXT:    .cfi_def_cfa_offset 80
@@ -1126,65 +1121,61 @@ define <vscale x 128 x i1> @test_vp_splice_nxv128i1_negative_offset(<vscale x 12
 ; NOVLDEP-NEXT:    .cfi_offset s0, -16
 ; NOVLDEP-NEXT:    addi s0, sp, 80
 ; NOVLDEP-NEXT:    .cfi_def_cfa s0, 0
-; NOVLDEP-NEXT:    csrr a4, vlenb
-; NOVLDEP-NEXT:    slli a4, a4, 5
-; NOVLDEP-NEXT:    sub sp, sp, a4
+; NOVLDEP-NEXT:    csrr a5, vlenb
+; NOVLDEP-NEXT:    slli a5, a5, 5
+; NOVLDEP-NEXT:    sub sp, sp, a5
 ; NOVLDEP-NEXT:    andi sp, sp, -64
-; NOVLDEP-NEXT:    vsetvli a4, zero, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vmv.v.i v16, 0
-; NOVLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
-; NOVLDEP-NEXT:    addi a6, sp, 64
-; NOVLDEP-NEXT:    slli a3, a3, 3
-; NOVLDEP-NEXT:    add a4, a6, a2
-; NOVLDEP-NEXT:    bltu a5, a3, .LBB22_4
-; NOVLDEP-NEXT:  # %bb.3:
-; NOVLDEP-NEXT:    mv a5, a3
-; NOVLDEP-NEXT:  .LBB22_4:
-; NOVLDEP-NEXT:    sub a7, a0, a3
-; NOVLDEP-NEXT:    vmv1r.v v0, v8
-; NOVLDEP-NEXT:    sltu a0, a0, a7
-; NOVLDEP-NEXT:    addi a0, a0, -1
-; NOVLDEP-NEXT:    and a7, a0, a7
-; NOVLDEP-NEXT:    vsetvli zero, a7, e8, m8, ta, ma
+; NOVLDEP-NEXT:    sub a5, a0, a2
+; NOVLDEP-NEXT:    sltu a6, a0, a5
+; NOVLDEP-NEXT:    addi a6, a6, -1
+; NOVLDEP-NEXT:    and a6, a6, a5
+; NOVLDEP-NEXT:    vsetvli zero, a6, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vmerge.vim v8, v16, 1, v0
-; NOVLDEP-NEXT:    vsetvli zero, a5, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vse8.v v24, (a6)
-; NOVLDEP-NEXT:    sub a0, a1, a3
-; NOVLDEP-NEXT:    vmv1r.v v0, v6
-; NOVLDEP-NEXT:    sltu a5, a1, a0
-; NOVLDEP-NEXT:    addi a5, a5, -1
-; NOVLDEP-NEXT:    and a0, a5, a0
-; NOVLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
-; NOVLDEP-NEXT:    add a6, a6, a3
-; NOVLDEP-NEXT:    vsetvli zero, a7, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vse8.v v8, (a6)
-; NOVLDEP-NEXT:    vmv1r.v v0, v7
-; NOVLDEP-NEXT:    vsetvli a5, zero, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vmerge.vim v8, v16, 1, v0
-; NOVLDEP-NEXT:    add a5, a4, a3
-; NOVLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
+; NOVLDEP-NEXT:    addi a5, sp, 64
+; NOVLDEP-NEXT:    vsetvli zero, a3, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vse8.v v24, (a5)
-; NOVLDEP-NEXT:    bltu a1, a3, .LBB22_6
+; NOVLDEP-NEXT:    sub a3, a1, a2
+; NOVLDEP-NEXT:    vmv1r.v v0, v6
+; NOVLDEP-NEXT:    sltu a7, a1, a3
+; NOVLDEP-NEXT:    addi a7, a7, -1
+; NOVLDEP-NEXT:    and a3, a7, a3
+; NOVLDEP-NEXT:    vsetvli zero, a3, e8, m8, ta, ma
+; NOVLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
+; NOVLDEP-NEXT:    add a7, a5, a2
+; NOVLDEP-NEXT:    slli a4, a4, 4
+; NOVLDEP-NEXT:    vsetvli zero, a6, e8, m8, ta, ma
+; NOVLDEP-NEXT:    vse8.v v8, (a7)
+; NOVLDEP-NEXT:    bltu a0, a4, .LBB22_4
+; NOVLDEP-NEXT:  # %bb.3:
+; NOVLDEP-NEXT:    mv a0, a4
+; NOVLDEP-NEXT:  .LBB22_4:
+; NOVLDEP-NEXT:    vmv1r.v v0, v7
+; NOVLDEP-NEXT:    vsetvli a4, zero, e8, m8, ta, ma
+; NOVLDEP-NEXT:    vmerge.vim v8, v16, 1, v0
+; NOVLDEP-NEXT:    add a5, a5, a0
+; NOVLDEP-NEXT:    add a4, a5, a2
+; NOVLDEP-NEXT:    vsetvli zero, a3, e8, m8, ta, ma
+; NOVLDEP-NEXT:    vse8.v v24, (a4)
+; NOVLDEP-NEXT:    bltu a1, a2, .LBB22_6
 ; NOVLDEP-NEXT:  # %bb.5:
-; NOVLDEP-NEXT:    mv a1, a3
+; NOVLDEP-NEXT:    mv a1, a2
 ; NOVLDEP-NEXT:  .LBB22_6:
-; NOVLDEP-NEXT:    li a5, 5
+; NOVLDEP-NEXT:    li a4, 5
 ; NOVLDEP-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vse8.v v8, (a4)
-; NOVLDEP-NEXT:    bltu a2, a5, .LBB22_8
+; NOVLDEP-NEXT:    vse8.v v8, (a5)
+; NOVLDEP-NEXT:    bltu a0, a4, .LBB22_8
 ; NOVLDEP-NEXT:  # %bb.7:
-; NOVLDEP-NEXT:    li a2, 5
+; NOVLDEP-NEXT:    li a0, 5
 ; NOVLDEP-NEXT:  .LBB22_8:
-; NOVLDEP-NEXT:    sub a4, a4, a2
-; NOVLDEP-NEXT:    add a3, a4, a3
-; NOVLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vle8.v v8, (a3)
+; NOVLDEP-NEXT:    sub a5, a5, a0
+; NOVLDEP-NEXT:    add a2, a5, a2
+; NOVLDEP-NEXT:    vsetvli zero, a3, e8, m8, ta, ma
+; NOVLDEP-NEXT:    vle8.v v8, (a2)
 ; NOVLDEP-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vand.vi v16, v8, 1
 ; NOVLDEP-NEXT:    vmsne.vi v8, v16, 0
 ; NOVLDEP-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; NOVLDEP-NEXT:    vle8.v v16, (a4)
+; NOVLDEP-NEXT:    vle8.v v16, (a5)
 ; NOVLDEP-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
 ; NOVLDEP-NEXT:    vand.vi v16, v16, 1
 ; NOVLDEP-NEXT:    vmsne.vi v0, v16, 0
@@ -1200,17 +1191,18 @@ define <vscale x 128 x i1> @test_vp_splice_nxv128i1_negative_offset(<vscale x 12
 ;
 ; VLDEP-LABEL: test_vp_splice_nxv128i1_negative_offset:
 ; VLDEP:       # %bb.0:
-; VLDEP-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
+; VLDEP-NEXT:    vsetvli a2, zero, e8, m8, ta, ma
 ; VLDEP-NEXT:    vmv1r.v v6, v10
 ; VLDEP-NEXT:    vmv1r.v v7, v9
-; VLDEP-NEXT:    csrr a3, vlenb
-; VLDEP-NEXT:    slli a4, a3, 4
-; VLDEP-NEXT:    mv a5, a0
-; VLDEP-NEXT:    addi a4, a4, -1
-; VLDEP-NEXT:    mv a2, a0
-; VLDEP-NEXT:    bltu a0, a4, .LBB22_2
+; VLDEP-NEXT:    vmv.v.i v16, 0
+; VLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
+; VLDEP-NEXT:    vmv1r.v v0, v8
+; VLDEP-NEXT:    csrr a4, vlenb
+; VLDEP-NEXT:    slli a2, a4, 3
+; VLDEP-NEXT:    mv a3, a0
+; VLDEP-NEXT:    bltu a0, a2, .LBB22_2
 ; VLDEP-NEXT:  # %bb.1:
-; VLDEP-NEXT:    mv a2, a4
+; VLDEP-NEXT:    mv a3, a2
 ; VLDEP-NEXT:  .LBB22_2:
 ; VLDEP-NEXT:    addi sp, sp, -80
 ; VLDEP-NEXT:    .cfi_def_cfa_offset 80
@@ -1220,65 +1212,61 @@ define <vscale x 128 x i1> @test_vp_splice_nxv128i1_negative_offset(<vscale x 12
 ; VLDEP-NEXT:    .cfi_offset s0, -16
 ; VLDEP-NEXT:    addi s0, sp, 80
 ; VLDEP-NEXT:    .cfi_def_cfa s0, 0
-; VLDEP-NEXT:    csrr a4, vlenb
-; VLDEP-NEXT:    slli a4, a4, 5
-; VLDEP-NEXT:    sub sp, sp, a4
+; VLDEP-NEXT:    csrr a5, vlenb
+; VLDEP-NEXT:    slli a5, a5, 5
+; VLDEP-NEXT:    sub sp, sp, a5
 ; VLDEP-NEXT:    andi sp, sp, -64
-; VLDEP-NEXT:    vsetvli a4, zero, e8, m8, ta, ma
-; VLDEP-NEXT:    vmv.v.i v16, 0
-; VLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
-; VLDEP-NEXT:    addi a6, sp, 64
-; VLDEP-NEXT:    slli a3, a3, 3
-; VLDEP-NEXT:    add a4, a6, a2
-; VLDEP-NEXT:    bltu a5, a3, .LBB22_4
-; VLDEP-NEXT:  # %bb.3:
-; VLDEP-NEXT:    mv a5, a3
-; VLDEP-NEXT:  .LBB22_4:
-; VLDEP-NEXT:    sub a7, a0, a3
-; VLDEP-NEXT:    vmv1r.v v0, v8
-; VLDEP-NEXT:    sltu a0, a0, a7
-; VLDEP-NEXT:    addi a0, a0, -1
-; VLDEP-NEXT:    and a7, a0, a7
-; VLDEP-NEXT:    vsetvli zero, a7, e8, m8, ta, ma
+; VLDEP-NEXT:    sub a5, a0, a2
+; VLDEP-NEXT:    sltu a6, a0, a5
+; VLDEP-NEXT:    addi a6, a6, -1
+; VLDEP-NEXT:    and a6, a6, a5
+; VLDEP-NEXT:    vsetvli zero, a6, e8, m8, ta, ma
 ; VLDEP-NEXT:    vmerge.vim v8, v16, 1, v0
-; VLDEP-NEXT:    vsetvli zero, a5, e8, m8, ta, ma
-; VLDEP-NEXT:    vse8.v v24, (a6)
-; VLDEP-NEXT:    sub a0, a1, a3
-; VLDEP-NEXT:    vmv1r.v v0, v6
-; VLDEP-NEXT:    sltu a5, a1, a0
-; VLDEP-NEXT:    addi a5, a5, -1
-; VLDEP-NEXT:    and a0, a5, a0
-; VLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
-; VLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
-; VLDEP-NEXT:    add a6, a6, a3
-; VLDEP-NEXT:    vsetvli zero, a7, e8, m8, ta, ma
-; VLDEP-NEXT:    vse8.v v8, (a6)
-; VLDEP-NEXT:    vmv1r.v v0, v7
-; VLDEP-NEXT:    vsetvli a5, zero, e8, m8, ta, ma
-; VLDEP-NEXT:    vmerge.vim v8, v16, 1, v0
-; VLDEP-NEXT:    add a5, a4, a3
-; VLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
+; VLDEP-NEXT:    addi a5, sp, 64
+; VLDEP-NEXT:    vsetvli zero, a3, e8, m8, ta, ma
 ; VLDEP-NEXT:    vse8.v v24, (a5)
-; VLDEP-NEXT:    bltu a1, a3, .LBB22_6
+; VLDEP-NEXT:    sub a3, a1, a2
+; VLDEP-NEXT:    vmv1r.v v0, v6
+; VLDEP-NEXT:    sltu a7, a1, a3
+; VLDEP-NEXT:    addi a7, a7, -1
+; VLDEP-NEXT:    and a3, a7, a3
+; VLDEP-NEXT:    vsetvli zero, a3, e8, m8, ta, ma
+; VLDEP-NEXT:    vmerge.vim v24, v16, 1, v0
+; VLDEP-NEXT:    add a7, a5, a2
+; VLDEP-NEXT:    slli a4, a4, 4
+; VLDEP-NEXT:    vsetvli zero, a6, e8, m8, ta, ma
+; VLDEP-NEXT:    vse8.v v8, (a7)
+; VLDEP-NEXT:    bltu a0, a4, .LBB22_4
+; VLDEP-NEXT:  # %bb.3:
+; VLDEP-NEXT:    mv a0, a4
+; VLDEP-NEXT:  .LBB22_4:
+; VLDEP-NEXT:    vmv1r.v v0, v7
+; VLDEP-NEXT:    vsetvli a4, zero, e8, m8, ta, ma
+; VLDEP-NEXT:    vmerge.vim v8, v16, 1, v0
+; VLDEP-NEXT:    add a5, a5, a0
+; VLDEP-NEXT:    add a4, a5, a2
+; VLDEP-NEXT:    vsetvli zero, a3, e8, m8, ta, ma
+; VLDEP-NEXT:    vse8.v v24, (a4)
+; VLDEP-NEXT:    bltu a1, a2, .LBB22_6
 ; VLDEP-NEXT:  # %bb.5:
-; VLDEP-NEXT:    mv a1, a3
+; VLDEP-NEXT:    mv a1, a2
 ; VLDEP-NEXT:  .LBB22_6:
-; VLDEP-NEXT:    li a5, 5
+; VLDEP-NEXT:    li a4, 5
 ; VLDEP-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; VLDEP-NEXT:    vse8.v v8, (a4)
-; VLDEP-NEXT:    bltu a2, a5, .LBB22_8
+; VLDEP-NEXT:    vse8.v v8, (a5)
+; VLDEP-NEXT:    bltu a0, a4, .LBB22_8
 ; VLDEP-NEXT:  # %bb.7:
-; VLDEP-NEXT:    li a2, 5
+; VLDEP-NEXT:    li a0, 5
 ; VLDEP-NEXT:  .LBB22_8:
-; VLDEP-NEXT:    sub a4, a4, a2
-; VLDEP-NEXT:    add a3, a4, a3
-; VLDEP-NEXT:    vsetvli zero, a0, e8, m8, ta, ma
-; VLDEP-NEXT:    vle8.v v8, (a3)
+; VLDEP-NEXT:    sub a5, a5, a0
+; VLDEP-NEXT:    add a2, a5, a2
+; VLDEP-NEXT:    vsetvli zero, a3, e8, m8, ta, ma
+; VLDEP-NEXT:    vle8.v v8, (a2)
 ; VLDEP-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
 ; VLDEP-NEXT:    vand.vi v16, v8, 1
 ; VLDEP-NEXT:    vmsne.vi v8, v16, 0
 ; VLDEP-NEXT:    vsetvli zero, a1, e8, m8, ta, ma
-; VLDEP-NEXT:    vle8.v v16, (a4)
+; VLDEP-NEXT:    vle8.v v16, (a5)
 ; VLDEP-NEXT:    vsetvli a0, zero, e8, m8, ta, ma
 ; VLDEP-NEXT:    vand.vi v16, v16, 1
 ; VLDEP-NEXT:    vmsne.vi v0, v16, 0

--- a/llvm/test/CodeGen/RISCV/rvv/vp-splice.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vp-splice.ll
@@ -493,24 +493,24 @@ define <vscale x 16 x i64> @test_vp_splice_nxv16i64(<vscale x 16 x i64> %va, <vs
 ; CHECK-NEXT:    sub a5, a2, a4
 ; CHECK-NEXT:    sltu a6, a2, a5
 ; CHECK-NEXT:    addi a6, a6, -1
-; CHECK-NEXT:    and a5, a6, a5
 ; CHECK-NEXT:    sub a7, a3, a4
-; CHECK-NEXT:    add t0, a0, a1
-; CHECK-NEXT:    sltu a6, a3, a7
-; CHECK-NEXT:    addi t1, a6, -1
-; CHECK-NEXT:    slli a6, a4, 1
-; CHECK-NEXT:    vsetvli zero, a5, e64, m8, ta, ma
-; CHECK-NEXT:    vse64.v v16, (t0)
-; CHECK-NEXT:    and a5, t1, a7
-; CHECK-NEXT:    bltu a2, a6, .LBB22_4
+; CHECK-NEXT:    and t0, a6, a5
+; CHECK-NEXT:    sltu a5, a3, a7
+; CHECK-NEXT:    add t1, a0, a1
+; CHECK-NEXT:    addi t2, a5, -1
+; CHECK-NEXT:    slli a6, a4, 4
+; CHECK-NEXT:    slli a5, a2, 3
+; CHECK-NEXT:    vsetvli zero, t0, e64, m8, ta, ma
+; CHECK-NEXT:    vse64.v v16, (t1)
+; CHECK-NEXT:    and a2, t2, a7
+; CHECK-NEXT:    bltu a5, a6, .LBB22_4
 ; CHECK-NEXT:  # %bb.3:
-; CHECK-NEXT:    mv a2, a6
+; CHECK-NEXT:    mv a5, a6
 ; CHECK-NEXT:  .LBB22_4:
-; CHECK-NEXT:    slli a2, a2, 3
-; CHECK-NEXT:    add a0, a0, a2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vsetvli zero, a5, e64, m8, ta, ma
-; CHECK-NEXT:    vse64.v v0, (a2)
+; CHECK-NEXT:    add a0, a0, a5
+; CHECK-NEXT:    add a5, a0, a1
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, ta, ma
+; CHECK-NEXT:    vse64.v v0, (a5)
 ; CHECK-NEXT:    bltu a3, a4, .LBB22_6
 ; CHECK-NEXT:  # %bb.5:
 ; CHECK-NEXT:    mv a3, a4
@@ -519,7 +519,7 @@ define <vscale x 16 x i64> @test_vp_splice_nxv16i64(<vscale x 16 x i64> %va, <vs
 ; CHECK-NEXT:    vse64.v v24, (a0)
 ; CHECK-NEXT:    addi a0, sp, 104
 ; CHECK-NEXT:    add a1, a0, a1
-; CHECK-NEXT:    vsetvli zero, a5, e64, m8, ta, ma
+; CHECK-NEXT:    vsetvli zero, a2, e64, m8, ta, ma
 ; CHECK-NEXT:    vle64.v v16, (a1)
 ; CHECK-NEXT:    vsetvli zero, a3, e64, m8, ta, ma
 ; CHECK-NEXT:    vle64.v v8, (a0)
@@ -559,12 +559,13 @@ define <vscale x 16 x i64> @test_vp_splice_nxv16i64_negative_offset(<vscale x 16
 ; CHECK-NEXT:    sub a0, a2, a4
 ; CHECK-NEXT:    sltu a6, a2, a0
 ; CHECK-NEXT:    addi a6, a6, -1
-; CHECK-NEXT:    and a0, a6, a0
 ; CHECK-NEXT:    sub a7, a3, a4
-; CHECK-NEXT:    add t0, a5, a1
+; CHECK-NEXT:    and a0, a6, a0
 ; CHECK-NEXT:    sltu a6, a3, a7
+; CHECK-NEXT:    add t0, a5, a1
 ; CHECK-NEXT:    addi t1, a6, -1
-; CHECK-NEXT:    slli a6, a4, 1
+; CHECK-NEXT:    slli a6, a4, 4
+; CHECK-NEXT:    slli a2, a2, 3
 ; CHECK-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-NEXT:    vse64.v v16, (t0)
 ; CHECK-NEXT:    and a0, t1, a7
@@ -572,7 +573,6 @@ define <vscale x 16 x i64> @test_vp_splice_nxv16i64_negative_offset(<vscale x 16
 ; CHECK-NEXT:  # %bb.3:
 ; CHECK-NEXT:    mv a2, a6
 ; CHECK-NEXT:  .LBB23_4:
-; CHECK-NEXT:    slli a2, a2, 3
 ; CHECK-NEXT:    add a5, a5, a2
 ; CHECK-NEXT:    add a6, a5, a1
 ; CHECK-NEXT:    vsetvli zero, a0, e64, m8, ta, ma

--- a/llvm/test/CodeGen/RISCV/rvv/vp-splice.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vp-splice.ll
@@ -469,62 +469,60 @@ define <vscale x 2 x float> @test_vp_splice_nxv2f32_masked(<vscale x 2 x float> 
 define <vscale x 16 x i64> @test_vp_splice_nxv16i64(<vscale x 16 x i64> %va, <vscale x 16 x i64> %vb, i32 zeroext %evla, i32 zeroext %evlb) #0 {
 ; CHECK-LABEL: test_vp_splice_nxv16i64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    mv a6, a2
+; CHECK-NEXT:    mv a5, a2
 ; CHECK-NEXT:    csrr a4, vlenb
-; CHECK-NEXT:    slli t0, a4, 1
 ; CHECK-NEXT:    slli a1, a4, 3
-; CHECK-NEXT:    addi t0, t0, -1
-; CHECK-NEXT:    add a5, a0, a1
-; CHECK-NEXT:    mv a7, a2
-; CHECK-NEXT:    bltu a2, t0, .LBB22_2
+; CHECK-NEXT:    add a6, a0, a1
+; CHECK-NEXT:    bltu a2, a4, .LBB22_2
 ; CHECK-NEXT:  # %bb.1:
-; CHECK-NEXT:    mv a7, t0
+; CHECK-NEXT:    mv a5, a4
 ; CHECK-NEXT:  .LBB22_2:
 ; CHECK-NEXT:    addi sp, sp, -80
 ; CHECK-NEXT:    sd ra, 72(sp) # 8-byte Folded Spill
 ; CHECK-NEXT:    sd s0, 64(sp) # 8-byte Folded Spill
 ; CHECK-NEXT:    addi s0, sp, 80
-; CHECK-NEXT:    csrr t0, vlenb
-; CHECK-NEXT:    slli t0, t0, 5
-; CHECK-NEXT:    sub sp, sp, t0
+; CHECK-NEXT:    csrr a7, vlenb
+; CHECK-NEXT:    slli a7, a7, 5
+; CHECK-NEXT:    sub sp, sp, a7
 ; CHECK-NEXT:    andi sp, sp, -64
-; CHECK-NEXT:    vl8re64.v v24, (a5)
-; CHECK-NEXT:    slli a5, a7, 3
-; CHECK-NEXT:    addi a7, sp, 64
-; CHECK-NEXT:    add a5, a7, a5
-; CHECK-NEXT:    bltu a6, a4, .LBB22_4
+; CHECK-NEXT:    vl8re64.v v0, (a6)
+; CHECK-NEXT:    vl8re64.v v24, (a0)
+; CHECK-NEXT:    addi a0, sp, 64
+; CHECK-NEXT:    vsetvli zero, a5, e64, m8, ta, ma
+; CHECK-NEXT:    vse64.v v8, (a0)
+; CHECK-NEXT:    sub a5, a2, a4
+; CHECK-NEXT:    sltu a6, a2, a5
+; CHECK-NEXT:    addi a6, a6, -1
+; CHECK-NEXT:    and a5, a6, a5
+; CHECK-NEXT:    sub a7, a3, a4
+; CHECK-NEXT:    add t0, a0, a1
+; CHECK-NEXT:    sltu a6, a3, a7
+; CHECK-NEXT:    addi t1, a6, -1
+; CHECK-NEXT:    slli a6, a4, 1
+; CHECK-NEXT:    vsetvli zero, a5, e64, m8, ta, ma
+; CHECK-NEXT:    vse64.v v16, (t0)
+; CHECK-NEXT:    and a5, t1, a7
+; CHECK-NEXT:    bltu a2, a6, .LBB22_4
 ; CHECK-NEXT:  # %bb.3:
-; CHECK-NEXT:    mv a6, a4
+; CHECK-NEXT:    mv a2, a6
 ; CHECK-NEXT:  .LBB22_4:
-; CHECK-NEXT:    vl8re64.v v0, (a0)
-; CHECK-NEXT:    vsetvli zero, a6, e64, m8, ta, ma
-; CHECK-NEXT:    vse64.v v8, (a7)
-; CHECK-NEXT:    sub a0, a2, a4
-; CHECK-NEXT:    sltu a2, a2, a0
-; CHECK-NEXT:    addi a2, a2, -1
-; CHECK-NEXT:    and a0, a2, a0
-; CHECK-NEXT:    add a7, a7, a1
-; CHECK-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
-; CHECK-NEXT:    vse64.v v16, (a7)
-; CHECK-NEXT:    sub a0, a3, a4
-; CHECK-NEXT:    sltu a2, a3, a0
-; CHECK-NEXT:    addi a2, a2, -1
-; CHECK-NEXT:    and a0, a2, a0
-; CHECK-NEXT:    add a2, a5, a1
-; CHECK-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
-; CHECK-NEXT:    vse64.v v24, (a2)
+; CHECK-NEXT:    slli a2, a2, 3
+; CHECK-NEXT:    add a0, a0, a2
+; CHECK-NEXT:    add a2, a0, a1
+; CHECK-NEXT:    vsetvli zero, a5, e64, m8, ta, ma
+; CHECK-NEXT:    vse64.v v0, (a2)
 ; CHECK-NEXT:    bltu a3, a4, .LBB22_6
 ; CHECK-NEXT:  # %bb.5:
 ; CHECK-NEXT:    mv a3, a4
 ; CHECK-NEXT:  .LBB22_6:
 ; CHECK-NEXT:    vsetvli zero, a3, e64, m8, ta, ma
-; CHECK-NEXT:    vse64.v v0, (a5)
-; CHECK-NEXT:    addi a2, sp, 104
-; CHECK-NEXT:    add a1, a2, a1
-; CHECK-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
+; CHECK-NEXT:    vse64.v v24, (a0)
+; CHECK-NEXT:    addi a0, sp, 104
+; CHECK-NEXT:    add a1, a0, a1
+; CHECK-NEXT:    vsetvli zero, a5, e64, m8, ta, ma
 ; CHECK-NEXT:    vle64.v v16, (a1)
 ; CHECK-NEXT:    vsetvli zero, a3, e64, m8, ta, ma
-; CHECK-NEXT:    vle64.v v8, (a2)
+; CHECK-NEXT:    vle64.v v8, (a0)
 ; CHECK-NEXT:    addi sp, s0, -80
 ; CHECK-NEXT:    ld ra, 72(sp) # 8-byte Folded Reload
 ; CHECK-NEXT:    ld s0, 64(sp) # 8-byte Folded Reload
@@ -537,67 +535,65 @@ define <vscale x 16 x i64> @test_vp_splice_nxv16i64(<vscale x 16 x i64> %va, <vs
 define <vscale x 16 x i64> @test_vp_splice_nxv16i64_negative_offset(<vscale x 16 x i64> %va, <vscale x 16 x i64> %vb, i32 zeroext %evla, i32 zeroext %evlb) #0 {
 ; CHECK-LABEL: test_vp_splice_nxv16i64_negative_offset:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    mv a7, a2
-; CHECK-NEXT:    csrr a4, vlenb
-; CHECK-NEXT:    slli t0, a4, 1
-; CHECK-NEXT:    slli a1, a4, 3
-; CHECK-NEXT:    addi t0, t0, -1
-; CHECK-NEXT:    add a5, a0, a1
 ; CHECK-NEXT:    mv a6, a2
-; CHECK-NEXT:    bltu a2, t0, .LBB23_2
+; CHECK-NEXT:    csrr a4, vlenb
+; CHECK-NEXT:    slli a1, a4, 3
+; CHECK-NEXT:    add a5, a0, a1
+; CHECK-NEXT:    bltu a2, a4, .LBB23_2
 ; CHECK-NEXT:  # %bb.1:
-; CHECK-NEXT:    mv a6, t0
+; CHECK-NEXT:    mv a6, a4
 ; CHECK-NEXT:  .LBB23_2:
 ; CHECK-NEXT:    addi sp, sp, -80
 ; CHECK-NEXT:    sd ra, 72(sp) # 8-byte Folded Spill
 ; CHECK-NEXT:    sd s0, 64(sp) # 8-byte Folded Spill
 ; CHECK-NEXT:    addi s0, sp, 80
-; CHECK-NEXT:    csrr t0, vlenb
-; CHECK-NEXT:    slli t0, t0, 5
-; CHECK-NEXT:    sub sp, sp, t0
+; CHECK-NEXT:    csrr a7, vlenb
+; CHECK-NEXT:    slli a7, a7, 5
+; CHECK-NEXT:    sub sp, sp, a7
 ; CHECK-NEXT:    andi sp, sp, -64
-; CHECK-NEXT:    vl8re64.v v24, (a5)
-; CHECK-NEXT:    slli a5, a6, 3
-; CHECK-NEXT:    addi t0, sp, 64
-; CHECK-NEXT:    add a6, t0, a5
-; CHECK-NEXT:    bltu a7, a4, .LBB23_4
-; CHECK-NEXT:  # %bb.3:
-; CHECK-NEXT:    mv a7, a4
-; CHECK-NEXT:  .LBB23_4:
-; CHECK-NEXT:    vl8re64.v v0, (a0)
-; CHECK-NEXT:    vsetvli zero, a7, e64, m8, ta, ma
-; CHECK-NEXT:    vse64.v v8, (t0)
+; CHECK-NEXT:    vl8re64.v v0, (a5)
+; CHECK-NEXT:    vl8re64.v v24, (a0)
+; CHECK-NEXT:    addi a5, sp, 64
+; CHECK-NEXT:    vsetvli zero, a6, e64, m8, ta, ma
+; CHECK-NEXT:    vse64.v v8, (a5)
 ; CHECK-NEXT:    sub a0, a2, a4
-; CHECK-NEXT:    sltu a2, a2, a0
-; CHECK-NEXT:    addi a2, a2, -1
-; CHECK-NEXT:    and a0, a2, a0
-; CHECK-NEXT:    add t0, t0, a1
+; CHECK-NEXT:    sltu a6, a2, a0
+; CHECK-NEXT:    addi a6, a6, -1
+; CHECK-NEXT:    and a0, a6, a0
+; CHECK-NEXT:    sub a7, a3, a4
+; CHECK-NEXT:    add t0, a5, a1
+; CHECK-NEXT:    sltu a6, a3, a7
+; CHECK-NEXT:    addi t1, a6, -1
+; CHECK-NEXT:    slli a6, a4, 1
 ; CHECK-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-NEXT:    vse64.v v16, (t0)
-; CHECK-NEXT:    sub a0, a3, a4
-; CHECK-NEXT:    sltu a2, a3, a0
-; CHECK-NEXT:    addi a2, a2, -1
-; CHECK-NEXT:    and a0, a2, a0
-; CHECK-NEXT:    add a2, a6, a1
+; CHECK-NEXT:    and a0, t1, a7
+; CHECK-NEXT:    bltu a2, a6, .LBB23_4
+; CHECK-NEXT:  # %bb.3:
+; CHECK-NEXT:    mv a2, a6
+; CHECK-NEXT:  .LBB23_4:
+; CHECK-NEXT:    slli a2, a2, 3
+; CHECK-NEXT:    add a5, a5, a2
+; CHECK-NEXT:    add a6, a5, a1
 ; CHECK-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
-; CHECK-NEXT:    vse64.v v24, (a2)
+; CHECK-NEXT:    vse64.v v0, (a6)
 ; CHECK-NEXT:    bltu a3, a4, .LBB23_6
 ; CHECK-NEXT:  # %bb.5:
 ; CHECK-NEXT:    mv a3, a4
 ; CHECK-NEXT:  .LBB23_6:
-; CHECK-NEXT:    li a2, 8
+; CHECK-NEXT:    li a4, 8
 ; CHECK-NEXT:    vsetvli zero, a3, e64, m8, ta, ma
-; CHECK-NEXT:    vse64.v v0, (a6)
-; CHECK-NEXT:    bltu a5, a2, .LBB23_8
+; CHECK-NEXT:    vse64.v v24, (a5)
+; CHECK-NEXT:    bltu a2, a4, .LBB23_8
 ; CHECK-NEXT:  # %bb.7:
-; CHECK-NEXT:    li a5, 8
+; CHECK-NEXT:    li a2, 8
 ; CHECK-NEXT:  .LBB23_8:
-; CHECK-NEXT:    sub a2, a6, a5
-; CHECK-NEXT:    add a1, a2, a1
+; CHECK-NEXT:    sub a5, a5, a2
+; CHECK-NEXT:    add a1, a5, a1
 ; CHECK-NEXT:    vsetvli zero, a0, e64, m8, ta, ma
 ; CHECK-NEXT:    vle64.v v16, (a1)
 ; CHECK-NEXT:    vsetvli zero, a3, e64, m8, ta, ma
-; CHECK-NEXT:    vle64.v v8, (a2)
+; CHECK-NEXT:    vle64.v v8, (a5)
 ; CHECK-NEXT:    addi sp, s0, -80
 ; CHECK-NEXT:    ld ra, 72(sp) # 8-byte Folded Reload
 ; CHECK-NEXT:    ld s0, 64(sp) # 8-byte Folded Reload


### PR DESCRIPTION
We were incorrectly clipping EVL1 to be a valid index for the VT, in the range [0, VT.getNumVectorElements() - 1]. It is legal for EVL1 to be equal to VT.getNumVectorElements() here so that was incorrect.

In case it isn't clear, the clip is necessary to prevent turning poison into UB by accessing outside the temporary stack object.

Assisted-by: Claude