### PR TITLE
[mlir][ptr] Add ptr.masked_load op convert pattern to ptr-to-llvm pass

### DIFF
--- a/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
+++ b/mlir/include/mlir/Dialect/Ptr/IR/PtrOps.td
@@ -299,10 +299,15 @@ def Ptr_MaskedLoadOp : Pointer_Op<"masked_load", [
   let arguments = (ins Ptr_PtrType:$ptr,
                        Ptr_Mask1DType:$mask,
                        Ptr_Any1DType:$passthrough,
-                       AlignmentProp:$alignment);
+                       AlignmentProp:$alignment,
+                       UnitProp:$nontemporal);
   let results = (outs Ptr_Any1DType:$result);
   let assemblyFormat = [{
-    $ptr `,` $mask `,` $passthrough (`alignment` `=` $alignment^)?
+    $ptr `,` $mask `,` $passthrough
+    oilist(
+      `alignment` `=` $alignment |
+      `nontemporal` $nontemporal
+    )
     attr-dict `:` qualified(type($ptr)) `->` type($result)
   }];
   let builders = [

--- a/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
+++ b/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
@@ -440,7 +440,7 @@ LogicalResult MaskLoadOpConversion::matchAndRewrite(
     alignment = *align;
   rewriter.replaceOpWithNewOp<LLVM::MaskedLoadOp>(
       op, resultType, adaptor.getPtr(), adaptor.getMask(),
-      adaptor.getPassthrough(), alignment);
+      adaptor.getPassthrough(), alignment, op.getNontemporal());
   return success();
 }
 

--- a/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
+++ b/mlir/lib/Conversion/PtrToLLVM/PtrToLLVM.cpp
@@ -85,6 +85,16 @@ struct ConstantOpConversion : public ConvertOpToLLVMPattern<ptr::ConstantOp> {
   matchAndRewrite(ptr::ConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override;
 };
+
+//===----------------------------------------------------------------------===//
+// MaskLoadOpConversion
+//===----------------------------------------------------------------------===//
+struct MaskLoadOpConversion : public ConvertOpToLLVMPattern<ptr::MaskedLoadOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+  LogicalResult
+  matchAndRewrite(ptr::MaskedLoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -413,6 +423,28 @@ LogicalResult ConstantOpConversion::matchAndRewrite(
 }
 
 //===----------------------------------------------------------------------===//
+// MaskLoadOpConversion
+//===----------------------------------------------------------------------===//
+
+LogicalResult MaskLoadOpConversion::matchAndRewrite(
+    ptr::MaskedLoadOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  Type ptrType = getTypeConverter()->convertType(op.getPtr().getType());
+  if (!ptrType)
+    return rewriter.notifyMatchFailure(op, "Couldn't convert the ptr type");
+  Type resultType = getTypeConverter()->convertType(op.getType());
+  if (!resultType)
+    return rewriter.notifyMatchFailure(op, "Couldn't convert the result type");
+  unsigned alignment = 0;
+  if (std::optional<int64_t> align = op.getAlignment())
+    alignment = *align;
+  rewriter.replaceOpWithNewOp<LLVM::MaskedLoadOp>(
+      op, resultType, adaptor.getPtr(), adaptor.getMask(),
+      adaptor.getPassthrough(), alignment);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ConvertToLLVMPatternInterface implementation
 //===----------------------------------------------------------------------===//
 
@@ -475,8 +507,8 @@ void mlir::ptr::populatePtrToLLVMConversionPatterns(
 
   // Add conversion patterns.
   patterns.add<FromPtrOpConversion, GetMetadataOpConversion, PtrAddOpConversion,
-               ToPtrOpConversion, TypeOffsetOpConversion, ConstantOpConversion>(
-      converter);
+               ToPtrOpConversion, TypeOffsetOpConversion, ConstantOpConversion,
+               MaskLoadOpConversion>(converter);
 }
 
 void mlir::ptr::registerConvertPtrToLLVMInterface(DialectRegistry &registry) {

--- a/mlir/test/Conversion/PtrToLLVM/ptr-to-llvm.mlir
+++ b/mlir/test/Conversion/PtrToLLVM/ptr-to-llvm.mlir
@@ -330,3 +330,22 @@ func.func @test_constant_address_ops() -> (!ptr.ptr<#ptr.generic_space>, !ptr.pt
   %null = ptr.constant #ptr.null : !ptr.ptr<#ptr.generic_space> 
   return %addr_0, %null : !ptr.ptr<#ptr.generic_space>, !ptr.ptr<#ptr.generic_space>
 }
+
+// CHECK-LABEL:  func @test_masked_load_ops(
+//  CHECK-SAME:    %[[ARG0:.*]]: !llvm.ptr,
+//  CHECK-SAME:    %[[ARG1:.*]]: vector<4xi1>,
+//  CHECK-SAME:    %[[ARG2:.*]]: vector<4xf32>
+//       CHECK:    %[[LOAD_0:.*]] = llvm.intr.masked.load %[[ARG0]], %[[ARG1]], %[[ARG2]] {alignment = 0 : i32} : (!llvm.ptr, vector<4xi1>, vector<4xf32>) -> vector<4xf32>
+//       CHECK:    %[[LOAD_1:.*]] = llvm.intr.masked.load %[[ARG0]], %[[ARG1]], %[[ARG2]] {alignment = 16 : i32} : (!llvm.ptr, vector<4xi1>, vector<4xf32>) -> vector<4xf32>
+//       CHECK:    %[[LOAD_2:.*]] = llvm.intr.masked.load %[[ARG0]], %[[ARG1]], %[[ARG2]] {alignment = 16 : i32, nontemporal} : (!llvm.ptr, vector<4xi1>, vector<4xf32>) -> vector<4xf32>
+//       CHECK:    %[[RET_0:.*]] = llvm.mlir.poison : !llvm.struct<(vector<4xf32>, vector<4xf32>, vector<4xf32>)>
+//       CHECK:    %[[RET_1:.*]] = llvm.insertvalue %[[LOAD_0]], %[[RET_0]][0] : !llvm.struct<(vector<4xf32>, vector<4xf32>, vector<4xf32>)>
+//       CHECK:    %[[RET_2:.*]] = llvm.insertvalue %[[LOAD_1]], %[[RET_1]][1] : !llvm.struct<(vector<4xf32>, vector<4xf32>, vector<4xf32>)>
+//       CHECK:    %[[RET_3:.*]] = llvm.insertvalue %[[LOAD_2]], %[[RET_2]][2] : !llvm.struct<(vector<4xf32>, vector<4xf32>, vector<4xf32>)>
+//       CHECK:    llvm.return %[[RET_3]] : !llvm.struct<(vector<4xf32>, vector<4xf32>, vector<4xf32>)>
+func.func @test_masked_load_ops(%ptr: !ptr.ptr<#ptr.generic_space>, %mask: vector<4xi1>, %passthrough: vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>) {
+  %0 = ptr.masked_load %ptr, %mask, %passthrough : !ptr.ptr<#ptr.generic_space> -> vector<4xf32>
+  %1 = ptr.masked_load %ptr, %mask, %passthrough alignment = 16 : !ptr.ptr<#ptr.generic_space> -> vector<4xf32>
+  %2 = ptr.masked_load %ptr, %mask, %passthrough alignment = 16 nontemporal : !ptr.ptr<#ptr.generic_space> -> vector<4xf32> 
+  return %0, %1, %2 : vector<4xf32>, vector<4xf32>, vector<4xf32>
+}

--- a/mlir/test/Dialect/Ptr/ops.mlir
+++ b/mlir/test/Dialect/Ptr/ops.mlir
@@ -89,6 +89,7 @@ func.func @scatter_ops_tensor(%value: tensor<8xi64>, %ptrs: tensor<8x!ptr.ptr<#p
 func.func @masked_load_ops(%ptr: !ptr.ptr<#ptr.generic_space>, %mask: vector<4xi1>, %passthrough: vector<4xf32>) -> vector<4xf32> {
   %0 = ptr.masked_load %ptr, %mask, %passthrough : !ptr.ptr<#ptr.generic_space> -> vector<4xf32>
   %1 = ptr.masked_load %ptr, %mask, %passthrough alignment = 16 : !ptr.ptr<#ptr.generic_space> -> vector<4xf32>
+  %2 = ptr.masked_load %ptr, %mask, %passthrough alignment = 16 nontemporal : !ptr.ptr<#ptr.generic_space> -> vector<4xf32> 
   return %0 : vector<4xf32>
 }
 
@@ -96,6 +97,7 @@ func.func @masked_load_ops(%ptr: !ptr.ptr<#ptr.generic_space>, %mask: vector<4xi
 func.func @masked_load_ops_tensor(%ptr: !ptr.ptr<#ptr.generic_space>, %mask: tensor<8xi1>, %passthrough: tensor<8xi32>) -> tensor<8xi32> {
   %0 = ptr.masked_load %ptr, %mask, %passthrough : !ptr.ptr<#ptr.generic_space> -> tensor<8xi32>
   %1 = ptr.masked_load %ptr, %mask, %passthrough alignment = 4 : !ptr.ptr<#ptr.generic_space> -> tensor<8xi32>
+  %2 = ptr.masked_load %ptr, %mask, %passthrough alignment = 4 nontemporal : !ptr.ptr<#ptr.generic_space> -> tensor<8xi32>
   return %0 : tensor<8xi32>
 }
 


### PR DESCRIPTION
`ptr.masked_load `was missing the lowering pattern to LLVM IR. This PR adds the missing conversion logic.