### PR TITLE
[orc-rt] Rename scope_exit header, add nodiscard attribute.

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -20,7 +20,6 @@ set(ORC_RT_HEADERS
     orc-rt/NativeDylibManager.h
     orc-rt/QueueingRunner.h
     orc-rt/RTTI.h
-    orc-rt/ScopeExit.h
     orc-rt/Service.h
     orc-rt/Session.h
     orc-rt/SimpleNativeMemoryMap.h
@@ -40,6 +39,7 @@ set(ORC_RT_HEADERS
     orc-rt/bind.h
     orc-rt/bit.h
     orc-rt/move_only_function.h
+    orc-rt/scope_exit.h
     orc-rt/span.h
 )
 

--- a/orc-rt/include/orc-rt/scope_exit.h
+++ b/orc-rt/include/orc-rt/scope_exit.h
@@ -1,4 +1,4 @@
-//===---------- ScopeExit.h - Execute code at scope exit --------*- C++ -*-===//
+//===---------- scope_exit.h - Execute code at scope exit -------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,15 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_SCOPEEXIT_H
-#define ORC_RT_SCOPEEXIT_H
+#ifndef ORC_RT_SCOPE_EXIT_H
+#define ORC_RT_SCOPE_EXIT_H
 
-#include <type_traits>
 #include <utility>
 
 namespace orc_rt {
 
-template <typename Fn> class scope_exit {
+template <typename Fn> class [[nodiscard]] scope_exit {
 public:
   template <typename FnInit>
   scope_exit(FnInit &&F) : F(std::forward<FnInit>(F)) {}
@@ -41,4 +40,4 @@ template <typename Fn> scope_exit(Fn) -> scope_exit<Fn>;
 
 } // namespace orc_rt
 
-#endif // ORC_RT_SCOPEEXIT_H
+#endif // ORC_RT_SCOPE_EXIT_H

--- a/orc-rt/lib/executor/AllocAction.cpp
+++ b/orc-rt/lib/executor/AllocAction.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/AllocAction.h"
-#include "orc-rt/ScopeExit.h"
+#include "orc-rt/scope_exit.h"
 
 namespace orc_rt {
 

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -35,7 +35,6 @@ add_orc_rt_unittest(CoreTests
   NativeDylibManagerSPSCITest.cpp
   QueueingRunnerTest.cpp
   RTTITest.cpp
-  ScopeExitTest.cpp
   SessionTest.cpp
   SimpleNativeMemoryMapTest.cpp
   SimpleNativeMemoryMapSPSCITest.cpp
@@ -51,6 +50,7 @@ add_orc_rt_unittest(CoreTests
   bit-test.cpp
   iterator_range-test.cpp
   move_only_function-test.cpp
+  scope_exit-test.cpp
   span-test.cpp
 
   DISABLE_LLVM_LINK_LLVM_DYLIB

--- a/orc-rt/unittests/scope_exit-test.cpp
+++ b/orc-rt/unittests/scope_exit-test.cpp
@@ -1,4 +1,4 @@
-//===- ScopeExitTest.cpp --------------------------------------------------===//
+//===- scope_exit-test.cpp ------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Tests for orc-rt's ScopeExit.h APIs.
+// Tests for orc-rt's scope_exit.h APIs.
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/ScopeExit.h"
+#include "orc-rt/scope_exit.h"
 #include "gtest/gtest.h"
 
 using namespace orc_rt;


### PR DESCRIPTION
The rename brings the scope_exit type's header name into alignment with other ORC runtime snake_case types.

The [[nodiscard]] attribute should help to prevent accidental misuse of the type.