### PR TITLE
[clang] Exclude EmptyRecord when calculating larger CXX records

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -113,6 +113,8 @@ ABI Changes in This Version
   compilers. On most targets this is not a breaking change because ``fastcc``
   and the platform C calling convention agree for ``void(ptr)``. It is an ABI
   break on i686, MIPS O32, PowerPC64 ELFv1, and Lanai.
+- Fixed incorrect struct return when single large vector (256/512-bit) used on
+  x86-64 targets. (#GH203760) The bug was introduced since Clang 21. (#GH120670)
 
 AST Dumping Potentially Breaking Changes
 ----------------------------------------

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -2085,6 +2085,7 @@ void X86_64ABIInfo::classify(QualType Ty, uint64_t OffsetBase, Class &Lo,
         Lo = merge(Lo, FieldLo);
         Hi = merge(Hi, FieldHi);
         if (returnCXXRecordGreaterThan128InMem() &&
+            !isEmptyRecord(getContext(), I.getType(), true) &&
             (Size > 128 && (Size != getContext().getTypeSize(I.getType()) ||
                             Size > getNativeVectorSizeForAVXABI(AVXLevel)))) {
           // The only case a 256(or 512)-bit wide vector could be used to return

--- a/clang/test/CodeGen/X86/avx-cxx-record.cpp
+++ b/clang/test/CodeGen/X86/avx-cxx-record.cpp
@@ -46,3 +46,21 @@ YMM2 bar() {
   ((YMM1<1>*)&result)->x = UInt64x4{5, 6, 7, 8};
   return result;
 }
+
+// Test that empty base classes do not prevent structs with a single wide
+// vector member from being passed/returned in registers (issue #203760).
+struct EmptyBase {};
+
+struct YMMWithEmptyBase : EmptyBase {
+    UInt64x4 x;
+};
+
+// A struct with a single 256-bit vector and an empty base should use registers,
+// matching the behavior with no base class.
+// CHECK: define{{.*}} <4 x i64> @_Z18ymm_empty_base_retv()
+// CLANG-20: define{{.*}} <4 x i64> @_Z18ymm_empty_base_retv()
+YMMWithEmptyBase ymm_empty_base_ret() { return {}; }
+
+// CHECK: define{{.*}} i64 @_Z19ymm_empty_base_pass16YMMWithEmptyBase(<4 x i64>
+// CLANG-20: define{{.*}} i64 @_Z19ymm_empty_base_pass16YMMWithEmptyBase(<4 x i64>
+unsigned long long ymm_empty_base_pass(YMMWithEmptyBase x) { return x.x[0]; }


### PR DESCRIPTION
To match with GCC: https://godbolt.org/z/KPKGhhenK

Fixes: #203760

Assisted-by: Claude Sonnet 4.6