### PR TITLE
[orc-rt] Add SPS serialization for ExecutorAddrRange.

### DIFF
--- a/orc-rt/include/orc-rt/SimplePackedSerialization.h
+++ b/orc-rt/include/orc-rt/SimplePackedSerialization.h
@@ -573,6 +573,26 @@ public:
   }
 };
 
+class SPSExecutorAddrRange;
+
+template <>
+class SPSSerializationTraits<SPSExecutorAddrRange, ExecutorAddrRange> {
+public:
+  static size_t size(const ExecutorAddrRange &R) {
+    return SPSArgList<SPSExecutorAddr, SPSExecutorAddr>::size(R.Start, R.End);
+  }
+
+  static bool serialize(SPSOutputBuffer &OB, const ExecutorAddrRange &R) {
+    return SPSArgList<SPSExecutorAddr, SPSExecutorAddr>::serialize(OB, R.Start,
+                                                                   R.End);
+  }
+
+  static bool deserialize(SPSInputBuffer &IB, ExecutorAddrRange &R) {
+    return SPSArgList<SPSExecutorAddr, SPSExecutorAddr>::deserialize(
+        IB, R.Start, R.End);
+  }
+};
+
 /// SPS tag type for errors.
 class SPSError;
 

--- a/orc-rt/unittests/SimplePackedSerializationTest.cpp
+++ b/orc-rt/unittests/SimplePackedSerializationTest.cpp
@@ -119,6 +119,12 @@ TEST(SimplePackedSerializationTest, ExecutorAddr) {
   blobSerializationRoundTrip<SPSExecutorAddr>(A);
 }
 
+TEST(SimplePackedSerializationTest, ExecutorAddrRange) {
+  int X = 42;
+  ExecutorAddrRange R(ExecutorAddr::fromPtr(&X), ExecutorAddr::fromPtr(&X + 1));
+  blobSerializationRoundTrip<SPSExecutorAddrRange>(R);
+}
+
 TEST(SimplePackedSerializationTest, StringViewCharSequenceSerialization) {
   const char *HW = "Hello, world!";
   blobSerializationRoundTrip<SPSString, std::string_view>(std::string_view(HW));


### PR DESCRIPTION
Allows SPS serialization to/from ExecutorAddrRange. This will be used in upcoming patches for compact-unwind registration support.