### PR TITLE
[clang][bytecode] Check for block pointers in Free()

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1380,6 +1380,9 @@ bool Free(InterpState &S, CodePtr OpPC, bool DeleteIsArrayForm,
     if (Ptr.isZero())
       return true;
 
+    if (!Ptr.isBlockPointer())
+      return false;
+
     // Remove base casts.
     QualType InitialType = Ptr.getType();
     Ptr = Ptr.expand().stripBaseCasts();

--- a/clang/test/AST/ByteCode/new-delete.cpp
+++ b/clang/test/AST/ByteCode/new-delete.cpp
@@ -1254,6 +1254,19 @@ namespace AllocInBase {
                    // both-note {{pointer to heap-allocated object is not a constant expression}}
 }
 
+namespace FreeNonBlockPointer {
+  extern int f();
+
+#define fold(x) (__builtin_constant_p(x) ? (x) : (x))
+  constexpr int foo() {
+    int *p;
+    p = fold((int*)(void*)f);
+    delete p;
+    return 10;
+  }
+  static_assert(foo() == 10); // both-error {{not an integral constant expression}}
+}
+
 #else
 /// Make sure we reject this prior to C++20
 constexpr int a() { // both-error {{never produces a constant expression}}


### PR DESCRIPTION
We need a block pointer here for the following operations, and non-block pointers aren't valid anyway.