### PR TITLE
[Flang][Driver]Add support for option '-fpseudo-probe-for-profiling' in flang

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -1944,7 +1944,7 @@ defm pseudo_probe_for_profiling
                   CodeGenOpts<"PseudoProbeForProfiling">, DefaultFalse,
                   PosFlag<SetTrue, [], [ClangOption], "Emit">,
                   NegFlag<SetFalse, [], [ClangOption], "Do not emit">,
-                  BothFlags<[], [ClangOption, CC1Option, CLOption],
+                  BothFlags<[], [ClangOption, CC1Option, CLOption, FlangOption, FC1Option],
                             " pseudo probes for sample profiling">>;
 def fprofile_list_EQ : Joined<["-"], "fprofile-list=">,
     Group<f_Group>, Visibility<[ClangOption, CC1Option, CLOption]>,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -1022,6 +1022,11 @@ static void addPGOAndCoverageFlags(const ToolChain &TC, const JobAction &JA,
         A->render(Args, CmdArgs);
     }
   }
+
+  //-fpseudo-probe-for-profiling
+  if (Args.hasFlag(options::OPT_fpseudo_probe_for_profiling,
+                   options::OPT_fno_pseudo_probe_for_profiling, false))
+    CmdArgs.push_back("-fpseudo-probe-for-profiling");
 }
 
 void Flang::ConstructJob(Compilation &C, const JobAction &JA,

--- a/flang/include/flang/Frontend/CodeGenOptions.def
+++ b/flang/include/flang/Frontend/CodeGenOptions.def
@@ -58,6 +58,7 @@ CODEGENOPT(UnrollLoops, 1, 0) ///< Enable loop unrolling
 CODEGENOPT(AliasAnalysis, 1, 0) ///< Enable alias analysis pass
 CODEGENOPT(DwarfVersion, 3, 0) ///< Dwarf version
 CODEGENOPT(DebugInfoForProfiling, 1, 0)  ///< Emit extra debug info to make sample profile more accurate.
+CODEGENOPT(PseudoProbeForProfiling, 1, 0) ///< Emit pseudo probes for sample profiling.
 
 CODEGENOPT(Underscoring, 1, 1)
 ENUM_CODEGENOPT(FPMaxminBehavior, Fortran::common::FPMaxminBehavior, 2, Fortran::common::FPMaxminBehavior::Legacy)

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -488,6 +488,10 @@ static void parseCodeGenArgs(Fortran::frontend::CodeGenOptions &opts,
   opts.SampleProfileFile =
       args.getLastArgValue(clang::options::OPT_fprofile_sample_use_EQ);
 
+  if (args.hasFlag(clang::options::OPT_fpseudo_probe_for_profiling,
+                   clang::options::OPT_fno_pseudo_probe_for_profiling, false))
+    opts.PseudoProbeForProfiling = 1;
+
   // -mcmodel option.
   if (const llvm::opt::Arg *a =
           args.getLastArg(clang::options::OPT_mcmodel_EQ)) {

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -489,8 +489,9 @@ static void parseCodeGenArgs(Fortran::frontend::CodeGenOptions &opts,
       args.getLastArgValue(clang::options::OPT_fprofile_sample_use_EQ);
 
   if (args.hasFlag(clang::options::OPT_fpseudo_probe_for_profiling,
-                   clang::options::OPT_fno_pseudo_probe_for_profiling, false))
+                   clang::options::OPT_fno_pseudo_probe_for_profiling, false)) {
     opts.PseudoProbeForProfiling = 1;
+  }
 
   // -mcmodel option.
   if (const llvm::opt::Arg *a =

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -1003,7 +1003,7 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
                               llvm::PGOOptions::NoAction,
                               llvm::PGOOptions::NoCSAction,
                               llvm::PGOOptions::ColdFuncOpt::Default,
-                              /*PseudoProbeForProfiling=*/true);
+                              /*DebugInfoForProfiling=*/true);
   }
 
   llvm::StandardInstrumentations si(llvmModule->getContext(),

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -984,12 +984,6 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
         opts.ProfileInstrumentUsePath, "", opts.ProfileRemappingFile,
         opts.MemoryProfileUsePath, llvm::PGOOptions::IRUse, CSAction,
         llvm::PGOOptions::ColdFuncOpt::Default, opts.DebugInfoForProfiling);
-  } else if (opts.DebugInfoForProfiling) {
-    // -fdebug-info-for-profiling
-    pgoOpt = llvm::PGOOptions("", "", "", /*MemoryProfile=*/"",
-                              llvm::PGOOptions::NoAction,
-                              llvm::PGOOptions::NoCSAction,
-                              llvm::PGOOptions::ColdFuncOpt::Default, true);
   } else if (!opts.SampleProfileFile.empty()) {
     pgoOpt = llvm::PGOOptions(
         opts.SampleProfileFile, "", opts.ProfileRemappingFile,
@@ -997,11 +991,19 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
         llvm::PGOOptions::NoCSAction, llvm::PGOOptions::ColdFuncOpt::Default,
         opts.DebugInfoForProfiling, opts.PseudoProbeForProfiling);
   } else if (opts.PseudoProbeForProfiling) {
-    // -fpseudo-probe-for-profiling
     pgoOpt = llvm::PGOOptions(
-        "", "", "", /*MemoryProfile=*/"", llvm::PGOOptions::NoAction,
+        /*ProfileFile=*/"", /*CSProfileGenFile=*/"",
+        /*ProfileRemappingFile=*/"",
+        /*MemoryProfile=*/"", llvm::PGOOptions::NoAction,
         llvm::PGOOptions::NoCSAction, llvm::PGOOptions::ColdFuncOpt::Default,
-        opts.DebugInfoForProfiling, true);
+        opts.DebugInfoForProfiling, /*PseudoProbeForProfiling=*/true);
+  } else if (opts.DebugInfoForProfiling) {
+    pgoOpt = llvm::PGOOptions(/*ProfileFile=*/"", /*CSProfileGenFile=*/"",
+                              /*ProfileRemappingFile=*/"", /*MemoryProfile=*/"",
+                              llvm::PGOOptions::NoAction,
+                              llvm::PGOOptions::NoCSAction,
+                              llvm::PGOOptions::ColdFuncOpt::Default,
+                              /*PseudoProbeForProfiling=*/true);
   }
 
   llvm::StandardInstrumentations si(llvmModule->getContext(),

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -995,7 +995,13 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
         opts.SampleProfileFile, "", opts.ProfileRemappingFile,
         opts.MemoryProfileUsePath, llvm::PGOOptions::SampleUse,
         llvm::PGOOptions::NoCSAction, llvm::PGOOptions::ColdFuncOpt::Default,
-        opts.DebugInfoForProfiling, /*PseudoProbeForProfiling=*/false);
+        opts.DebugInfoForProfiling, opts.PseudoProbeForProfiling);
+  } else if (opts.PseudoProbeForProfiling) {
+    // -fpseudo-probe-for-profiling
+    pgoOpt = llvm::PGOOptions(
+        "", "", "", /*MemoryProfile=*/"", llvm::PGOOptions::NoAction,
+        llvm::PGOOptions::NoCSAction, llvm::PGOOptions::ColdFuncOpt::Default,
+        opts.DebugInfoForProfiling, true);
   }
 
   llvm::StandardInstrumentations si(llvmModule->getContext(),

--- a/flang/test/Driver/fpseudo-probe-for-profiling.f90
+++ b/flang/test/Driver/fpseudo-probe-for-profiling.f90
@@ -1,0 +1,15 @@
+! Test to check the option "-fpseudo-probe-for-profiling".
+
+! RUN: %flang -### %s 2>&1 | FileCheck %s --check-prefix=NO-PROBE
+! RUN: %flang -### -fpseudo-probe-for-profiling %s 2>&1 | FileCheck %s --check-prefix=PROBE
+! RUN: %flang -### -fno-pseudo-probe-for-profiling %s 2>&1 | FileCheck %s --check-prefix=NO-PROBE
+! RUN: %flang -### -fpseudo-probe-for-profiling -fno-pseudo-probe-for-profiling %s 2>&1 | FileCheck %s --check-prefix=NO-PROBE
+! RUN: %flang -### -fpseudo-probe-for-profiling -fno-pseudo-probe-for-profiling -fpseudo-probe-for-profiling %s 2>&1 | FileCheck %s --check-prefix=PROBE
+
+! PROBE: "-fpseudo-probe-for-profiling"
+! NO-PROBE-NOT: "-fpseudo-probe-for-profiling"
+
+subroutine test
+    implicit none
+    print *, 1
+end subroutine test

--- a/flang/test/Integration/pseudo-probe-for-profiling.f90
+++ b/flang/test/Integration/pseudo-probe-for-profiling.f90
@@ -4,6 +4,10 @@
 ! RUN: %flang_fc1 -emit-llvm -O0 -fpseudo-probe-for-profiling -o - %s | FileCheck %s --check-prefix=PROBE
 ! RUN: %flang_fc1 -emit-llvm -O2 -fpseudo-probe-for-profiling -o - %s | FileCheck %s --check-prefix=PROBE
 
+! Test that -fdebug-info-for-profiling combined with -fpseudo-probe-for-profiling still emits pseudo-probes and debug info.
+! RUN: %flang_fc1 -emit-llvm -O2 -debug-info-kind=standalone \
+! RUN:   -fdebug-info-for-profiling -fpseudo-probe-for-profiling -o - %s | FileCheck %s --check-prefix=PROBE-AND-DEBUG
+
 ! PROBE-PASS: Running pass: SampleProfileProbePass on {{.*}}
 
 ! PROBE-LABEL: define void @foo
@@ -12,6 +16,11 @@
 ! PROBE: call void @llvm.pseudoprobe(i64 [[#GUID]], i64 4, i32 0, i64 -1)
 ! PROBE: call void @llvm.pseudoprobe(i64 [[#GUID]], i64 6, i32 0, i64 -1)
 ! PROBE: !llvm.pseudo_probe_desc = !{
+
+! PROBE-AND-DEBUG: call void @llvm.pseudoprobe
+! PROBE-AND-DEBUG: !llvm.pseudo_probe_desc = !{
+! PROBE-AND-DEBUG: !DICompileUnit({{.*}}debugInfoForProfiling: true{{.*}})
+! PROBE-AND-DEBUG: !DILexicalBlockFile({{.*}}discriminator:
 
 subroutine foo(x)
    implicit none

--- a/flang/test/Integration/pseudo-probe-for-profiling.f90
+++ b/flang/test/Integration/pseudo-probe-for-profiling.f90
@@ -1,0 +1,24 @@
+! Test -fpseudo-probe-for-profiling option runs SampleProfileProbePass and emits llvm.pseudoprobe intrinsic calls.
+!
+! RUN: %flang_fc1 -emit-llvm -fdebug-pass-manager -fpseudo-probe-for-profiling -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=PROBE-PASS
+! RUN: %flang_fc1 -emit-llvm -O0 -fpseudo-probe-for-profiling -o - %s | FileCheck %s --check-prefix=PROBE
+! RUN: %flang_fc1 -emit-llvm -O2 -fpseudo-probe-for-profiling -o - %s | FileCheck %s --check-prefix=PROBE
+
+! PROBE-PASS: Running pass: SampleProfileProbePass on {{.*}}
+
+! PROBE-LABEL: define void @foo
+! PROBE: call void @llvm.pseudoprobe(i64 [[#GUID:]], i64 1, i32 0, i64 -1)
+! PROBE: call void @llvm.pseudoprobe(i64 [[#GUID]], i64 2, i32 0, i64 -1)
+! PROBE: call void @llvm.pseudoprobe(i64 [[#GUID]], i64 4, i32 0, i64 -1)
+! PROBE: call void @llvm.pseudoprobe(i64 [[#GUID]], i64 6, i32 0, i64 -1)
+! PROBE: !llvm.pseudo_probe_desc = !{
+
+subroutine foo(x)
+   implicit none
+   integer, intent(in) :: x
+   if (x == 0) then
+      call bar
+   else
+      call go
+   end if
+end subroutine foo


### PR DESCRIPTION
Added support for option `-fpseudo-probe-for-profiling` in flang.

- When the option `-fpseudo-probe-for-profiling` is passed, the compiler sets the` PseudoProbeForProfiling` flag and triggers the `SampleProfileProbePass`. This pass inserts `llvm.pseudoprobe(..)` intrinsic calls and `!llvm.pseudo_probe_desc` metadata into the IR.