### PR TITLE
[InstCombine] Simplify redundant pext masks

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -2678,6 +2678,9 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     break;
   }
   case Intrinsic::pext: {
+    if (SimplifyDemandedInstructionBits(*II))
+      return II;
+
     const APInt *MaskC;
     if (match(II->getArgOperand(1), m_APInt(MaskC))) {
       unsigned MaskIdx, MaskLen;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -1104,6 +1104,15 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
         break;
       }
 
+      case Intrinsic::pext: {
+        Value *X;
+        if (match(II->getArgOperand(0),
+                  m_c_And(m_Value(X), m_Specific(II->getArgOperand(1)))))
+          return replaceOperand(*I, 0, X);
+
+        break;
+      }
+
       case Intrinsic::fshr:
       case Intrinsic::fshl: {
         const APInt *SA;

--- a/llvm/test/Transforms/InstCombine/pext.ll
+++ b/llvm/test/Transforms/InstCombine/pext.ll
@@ -102,3 +102,45 @@ define i64 @test_pext_64_constant_fold_2() nounwind readnone {
   ret i64 %1
 }
 
+define i32 @test_pext_and_mask_32(i32 %x, i32 %m) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_mask_32(
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 [[M:%.*]])
+; CHECK-NEXT:    ret i32 [[TMP1]]
+;
+  %and = and i32 %x, %m
+  %1 = tail call i32 @llvm.pext.i32(i32 %and, i32 %m)
+  ret i32 %1
+}
+
+define i64 @test_pext_and_mask_64(i64 %x, i64 %m) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_mask_64(
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i64 @llvm.pext.i64(i64 [[X:%.*]], i64 [[M:%.*]])
+; CHECK-NEXT:    ret i64 [[TMP1]]
+;
+  %and = and i64 %x, %m
+  %1 = tail call i64 @llvm.pext.i64(i64 %and, i64 %m)
+  ret i64 %1
+}
+
+define i32 @test_pext_and_mask_commuted_32(i32 %x, i32 %m) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_mask_commuted_32(
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 [[M:%.*]])
+; CHECK-NEXT:    ret i32 [[TMP1]]
+;
+  %and = and i32 %m, %x
+  %1 = tail call i32 @llvm.pext.i32(i32 %and, i32 %m)
+  ret i32 %1
+}
+
+define i64 @test_pext_and_mask_multi_use(i64 %x, i64 %m) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_mask_multi_use(
+; CHECK-NEXT:    [[AND:%.*]] = and i64 [[X:%.*]], [[M:%.*]]
+; CHECK-NEXT:    [[PEXT:%.*]] = tail call i64 @llvm.pext.i64(i64 [[X]], i64 [[M]])
+; CHECK-NEXT:    [[USE:%.*]] = add i64 [[AND]], [[PEXT]]
+; CHECK-NEXT:    ret i64 [[USE]]
+;
+  %and = and i64 %x, %m
+  %pext = tail call i64 @llvm.pext.i64(i64 %and, i64 %m)
+  %use = add i64 %and, %pext
+  ret i64 %use
+}


### PR DESCRIPTION
I simplified a redundant mask pattern around pext so InstCombine can drop the extra operation when the mask is already provided to the intrinsic.
Also added regression coverage for the scalar cases.
Fixes #204945