### PR TITLE
[MLIR] Install missing standalone helper tools

### DIFF
--- a/mlir/tools/mlir-irdl-to-cpp/CMakeLists.txt
+++ b/mlir/tools/mlir-irdl-to-cpp/CMakeLists.txt
@@ -7,3 +7,14 @@ mlir_target_link_libraries(mlir-irdl-to-cpp
   )
 
 setup_host_tool(mlir-irdl-to-cpp MLIR_IRDL_TO_CPP MLIR_IRDL_TO_CPP_EXE MLIR_IRDL_TO_CPP_TARGET)
+
+if(NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+  install(TARGETS mlir-irdl-to-cpp
+          RUNTIME DESTINATION "${MLIR_TOOLS_INSTALL_DIR}"
+          COMPONENT mlir-irdl-to-cpp)
+  if(NOT LLVM_ENABLE_IDE)
+    add_llvm_install_targets(install-mlir-irdl-to-cpp
+                             DEPENDS mlir-irdl-to-cpp
+                             COMPONENT mlir-irdl-to-cpp)
+  endif()
+endif()

--- a/mlir/tools/mlir-src-sharder/CMakeLists.txt
+++ b/mlir/tools/mlir-src-sharder/CMakeLists.txt
@@ -2,6 +2,8 @@ set(LLVM_LINK_COMPONENTS Support)
 set(LIBS MLIRSupport)
 
 add_tablegen(mlir-src-sharder MLIR_SRC_SHARDER
+  DESTINATION "${MLIR_TOOLS_INSTALL_DIR}"
+  EXPORT MLIR
   mlir-src-sharder.cpp)
 
 set_target_properties(mlir-src-sharder PROPERTIES FOLDER "MLIR/Tablegenning")


### PR DESCRIPTION
Standalone MLIR installs CMake package files that can reference helper executables needed by downstream builds. Most helper tools already have install paths available through existing LLVM tool and utility install options, but `mlir-src-sharder` does not pass an install destination to `add_tablegen` and `mlir-irdl-to-cpp` does not define an install rule.

Install those two missing helpers.

Co-authored-by: Luca Fancellu <luca.fancellu@arm.com>