### PR TITLE
[clang][bytecode] Add more sanity checks for pointers used in `dynamic_cast`

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -2019,9 +2019,11 @@ bool DynamicCast(InterpState &S, CodePtr OpPC, const Type *DestTypePtr,
     return false;
   }
 
-  // TODO: Other checks?
-  if (!Ptr.isBlockPointer())
+  if (!Ptr.isBlockPointer() || !Ptr.getRecord())
     return false;
+
+  if (!Ptr.isInitialized())
+    return DiagnoseUninitialized(S, OpPC, Ptr, AK_Read);
 
   // Our given pointer, limited by the base that's currently being initialized,
   // if any.

--- a/clang/test/AST/ByteCode/dynamic-cast.cpp
+++ b/clang/test/AST/ByteCode/dynamic-cast.cpp
@@ -294,3 +294,19 @@ namespace UnrelatedAndRootPtr{
   }
   static_assert(f());
 }
+
+namespace Invalid {
+  struct S { virtual void s(); };
+  struct A : S {};
+  struct B : A {};
+  constexpr __UINTPTR_TYPE__ g = 0;
+  static_assert(&dynamic_cast<A&>((S&)(B&)g) == &(A&)(B&)g); // both-error {{not an integral constant expression}} \
+                                                             // both-note {{cast that performs the conversions of a reinterpret_cast is not allowed in a constant expression}}
+
+  struct X : S { : ; }; // both-error {{expected expression}} \
+                        // both-error {{a type specifier is required for all declarations}}
+  constexpr X x; // both-error {{must be initialized by a constant expression}} \
+                 // both-note {{declared here}}
+  static_assert(&dynamic_cast<S&>((X&)x), ""); // both-error {{not an integral constant expression}} \
+                                               // both-note {{initializer of 'x' is not a constant expression}}
+}


### PR DESCRIPTION
Make sure it's initialized and that it points to a record.