### PR TITLE
[CGData] Serialize the outlined hash tree as offset-linked node block…

### DIFF
--- a/llvm/include/llvm/CGData/CodeGenData.h
+++ b/llvm/include/llvm/CGData/CodeGenData.h
@@ -288,6 +288,9 @@ enum CGDataVersion {
   // Version 4 adjusts the structure of stable function merging map for
   // efficient lazy loading support.
   Version4 = 4,
+  // Version 5 serializes the outlined hash tree as a region of per-node blocks
+  // linked by byte offset, so it can be read in place without materializing it.
+  Version5 = 5,
   CurrentVersion = CG_DATA_INDEX_VERSION
 };
 const uint64_t Version = CGDataVersion::CurrentVersion;

--- a/llvm/include/llvm/CGData/CodeGenData.inc
+++ b/llvm/include/llvm/CGData/CodeGenData.inc
@@ -49,4 +49,4 @@ CG_DATA_SECT_ENTRY(CG_merge, CG_DATA_QUOTE(CG_DATA_MERGE_COMMON),
 #endif
 
 /* Indexed codegen data format version (start from 1). */
-#define CG_DATA_INDEX_VERSION 4
+#define CG_DATA_INDEX_VERSION 5

--- a/llvm/include/llvm/CGData/CodeGenDataReader.h
+++ b/llvm/include/llvm/CGData/CodeGenDataReader.h
@@ -43,7 +43,7 @@ public:
   virtual bool hasStableFunctionMap() const = 0;
   /// Return the outlined hash tree that is released from the reader.
   std::unique_ptr<OutlinedHashTree> releaseOutlinedHashTree() {
-    return std::move(HashTreeRecord.HashTree);
+    return HashTreeRecord.releaseTree();
   }
   std::unique_ptr<StableFunctionMap> releaseStableFunctionMap() {
     return std::move(FunctionMapRecord.FunctionMap);

--- a/llvm/include/llvm/CGData/OutlinedHashTree.h
+++ b/llvm/include/llvm/CGData/OutlinedHashTree.h
@@ -19,7 +19,12 @@
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/ObjectYAML/YAML.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
 
 namespace llvm {
 
@@ -36,16 +41,118 @@ struct HashNode {
   DenseMap<stable_hash, std::unique_ptr<HashNode>> Successors;
 };
 
+/// A read-only outlined hash tree: an in-memory HashNode trie, or a tree read
+/// in place from a mapped blob. Either way it supports only the consume path.
+/// Building, mutating, or traversing the whole tree is done through
+/// MutableOutlinedHashTree, which takes over a tree's storage.
 class OutlinedHashTree {
+protected:
+  using HashSequence = SmallVector<stable_hash>;
+  using HashSequencePair = std::pair<HashSequence, unsigned>;
 
+  // Serializes the tree, and constructs it when (de)serializing / converting a
+  // read-in-place tree to a mutable one.
+  friend struct OutlinedHashTreeRecord;
+
+public:
+  /// A lightweight, copyable, read-only cursor over a single node in the tree.
+  /// It works for both the eager in-memory representation and the read-in-place
+  /// representation, so a consumer can walk the tree without knowing which is
+  /// in use.
+  class HashNodeCursor {
+  public:
+    /// \returns a cursor over the successor reached by following \p H from this
+    /// node in \p Tree, or std::nullopt if there is none.
+    LLVM_ABI std::optional<HashNodeCursor>
+    getSuccessor(const OutlinedHashTree &Tree, stable_hash H) const;
+
+    /// \returns the terminal count at this node in \p Tree, or std::nullopt if
+    /// the node is not the end of any sequence.
+    LLVM_ABI std::optional<unsigned>
+    getTerminals(const OutlinedHashTree &Tree) const;
+
+  private:
+    friend class OutlinedHashTree;
+    HashNodeCursor(const HashNode *N) : Node(N) {}
+    HashNodeCursor(uint64_t BlockOffset) : BlockOffset(BlockOffset) {}
+
+    // A single node handle: an in-memory HashNode pointer or a byte offset
+    // into the buffer region; which is live is selected by the tree's
+    // representation.
+    union {
+      const HashNode *Node;
+      uint64_t BlockOffset;
+    };
+  };
+
+  /// Construct a tree read in place from a mapped blob: its block region begins
+  /// at \p BlockBase (the root block at its offset 0) inside \p Buffer, which
+  /// is kept alive for the tree's lifetime.
+  OutlinedHashTree(std::shared_ptr<MemoryBuffer> Buffer,
+                   const unsigned char *BlockBase, uint32_t NumNodes)
+      : Buffer(std::move(Buffer)), BlockBase(BlockBase), NumNodes(NumNodes) {}
+
+  virtual ~OutlinedHashTree() = default;
+
+  /// \returns a read cursor positioned at the root, valid for both the
+  /// in-memory and read-in-place representations. This is the entry point for
+  /// the in-place consume path and never materializes the tree.
+  LLVM_ABI HashNodeCursor getRootCursor() const;
+
+  /// \returns the matching count if \p Sequence exists in the OutlinedHashTree.
+  LLVM_ABI std::optional<unsigned> find(const HashSequence &Sequence) const;
+
+  /// \returns true if the hash tree has only the root node.
+  bool empty() const {
+    return isReadInPlace() ? NumNodes <= 1 : Root.Successors.empty();
+  }
+
+  /// \returns true if this tree is read in place from a mapped blob instead of
+  /// being materialized into HashNode objects.
+  bool isReadInPlace() const { return (bool)Buffer; }
+
+protected:
+  /// An empty in-memory tree, to be populated by MutableOutlinedHashTree.
+  OutlinedHashTree() = default;
+
+  HashNode Root;
+
+private:
+  std::shared_ptr<MemoryBuffer> Buffer;
+  const unsigned char *BlockBase = nullptr;
+  uint32_t NumNodes = 0;
+};
+
+/// A mutable, always-in-memory OutlinedHashTree, adding building, mutation, and
+/// whole-tree traversal on top of the read-only base. Turn a read-only tree
+/// mutable by handing its storage to the move constructor: an in-memory tree's
+/// trie is moved; a read-in-place tree is materialized from its blob.
+class MutableOutlinedHashTree : public OutlinedHashTree {
+private:
   using EdgeCallbackFn =
       std::function<void(const HashNode *, const HashNode *)>;
   using NodeCallbackFn = std::function<void(const HashNode *)>;
 
-  using HashSequence = SmallVector<stable_hash>;
-  using HashSequencePair = std::pair<HashSequence, unsigned>;
-
 public:
+  MutableOutlinedHashTree() = default;
+
+  /// \returns the root hash node of the OutlinedHashTree.
+  const HashNode *getRoot() const { return &Root; }
+  HashNode *getRoot() { return &Root; }
+
+  /// Inserts a \p Sequence into this tree. The last node in the sequence
+  /// increments its Terminals.
+  LLVM_ABI void insert(const HashSequencePair &SequencePair);
+
+  /// Merge \p OtherTree into this tree.
+  LLVM_ABI void merge(const MutableOutlinedHashTree *OtherTree);
+
+  /// Release all hash nodes except the root hash node.
+  void clear() {
+    assert(Root.Hash == 0 && !Root.Terminals);
+    Root.Successors.clear();
+  }
+
   /// Walks every edge and node in the OutlinedHashTree and calls CallbackEdge
   /// for the edges and CallbackNode for the nodes with the stable_hash for
   /// the source and the stable_hash of the sink for an edge. These generic
@@ -55,15 +162,6 @@ public:
                           EdgeCallbackFn CallbackEdge = nullptr,
                           bool SortedWalk = false) const;
 
-  /// Release all hash nodes except the root hash node.
-  void clear() {
-    assert(getRoot()->Hash == 0 && !getRoot()->Terminals);
-    getRoot()->Successors.clear();
-  }
-
-  /// \returns true if the hash tree has only the root node.
-  bool empty() { return size() == 1; }
-
   /// \returns the size of a OutlinedHashTree by traversing it. If
   /// \p GetTerminalCountOnly is true, it only counts the terminal nodes
   /// (meaning it returns the the number of hash sequences in the
@@ -72,23 +170,6 @@ public:
 
   /// \returns the depth of a OutlinedHashTree by traversing it.
   LLVM_ABI size_t depth() const;
-
-  /// \returns the root hash node of a OutlinedHashTree.
-  const HashNode *getRoot() const { return &Root; }
-  HashNode *getRoot() { return &Root; }
-
-  /// Inserts a \p Sequence into the this tree. The last node in the sequence
-  /// will increase Terminals.
-  LLVM_ABI void insert(const HashSequencePair &SequencePair);
-
-  /// Merge a \p OtherTree into this Tree.
-  LLVM_ABI void merge(const OutlinedHashTree *OtherTree);
-
-  /// \returns the matching count if \p Sequence exists in the OutlinedHashTree.
-  LLVM_ABI std::optional<unsigned> find(const HashSequence &Sequence) const;
-
-private:
-  HashNode Root;
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/CGData/OutlinedHashTreeRecord.h
+++ b/llvm/include/llvm/CGData/OutlinedHashTreeRecord.h
@@ -34,16 +34,44 @@ using IdHashNodeMapTy = DenseMap<unsigned, HashNode *>;
 using HashNodeIdMapTy = DenseMap<const HashNode *, unsigned>;
 
 struct OutlinedHashTreeRecord {
-  std::unique_ptr<OutlinedHashTree> HashTree;
+  std::unique_ptr<MutableOutlinedHashTree> HashTree;
 
-  OutlinedHashTreeRecord() { HashTree = std::make_unique<OutlinedHashTree>(); }
-  OutlinedHashTreeRecord(std::unique_ptr<OutlinedHashTree> HashTree)
-      : HashTree(std::move(HashTree)) {};
+  OutlinedHashTreeRecord()
+      : HashTree(std::make_unique<MutableOutlinedHashTree>()) {}
+  /// Take ownership of the already-in-memory \p Tree.
+  OutlinedHashTreeRecord(std::unique_ptr<MutableOutlinedHashTree> Tree)
+      : HashTree(std::move(Tree)) {}
 
   /// Serialize the outlined hash tree to a raw_ostream.
   LLVM_ABI void serialize(raw_ostream &OS) const;
   /// Deserialize the outlined hash tree from a raw_ostream.
   LLVM_ABI void deserialize(const unsigned char *&Ptr);
+  /// Lazily set up this record's tree to read in place from \p Buffer at
+  /// \p Offset instead of deserializing it in memory.
+  LLVM_ABI void lazyDeserialize(std::shared_ptr<MemoryBuffer> Buffer,
+                                uint64_t Offset);
+
+  /// \returns a read-only tree that reads its nodes in place from \p Buffer
+  /// starting at \p BlobOffset, keeping \p Buffer alive for the tree's
+  /// lifetime.
+  LLVM_ABI static std::unique_ptr<OutlinedHashTree>
+  createReadInPlace(std::shared_ptr<MemoryBuffer> Buffer, uint64_t BlobOffset);
+
+  /// \returns a mutable, fully in-memory version of \p Tree: a read-in-place
+  /// tree is materialized from its blob; a tree already in memory is taken
+  /// over as-is.
+  LLVM_ABI static std::unique_ptr<MutableOutlinedHashTree>
+  createInMemory(std::unique_ptr<OutlinedHashTree> Tree);
+
+  /// \returns the block offset of the successor reached by following \p H, or
+  /// std::nullopt if there is none. In-place readers over a single serialized
+  /// node block at \p Block (the block region base + the node's block offset).
+  LLVM_ABI static std::optional<uint64_t>
+  readSuccessor(const unsigned char *Block, stable_hash H);
+
+  /// \returns the terminal count stored at \p Block (0 if not a terminal).
+  LLVM_ABI static unsigned readTerminals(const unsigned char *Block);
+
   /// Serialize the outlined hash tree to a YAML stream.
   LLVM_ABI void serializeYAML(yaml::Output &YOS) const;
   /// Deserialize the outlined hash tree from a YAML stream.
@@ -54,8 +82,15 @@ struct OutlinedHashTreeRecord {
     HashTree->merge(Other.HashTree.get());
   }
 
+  /// Release the held outlined hash tree as a read-only tree.
+  std::unique_ptr<OutlinedHashTree> releaseTree() {
+    if (ReadInPlaceHashTree)
+      return std::move(ReadInPlaceHashTree);
+    return std::move(HashTree);
+  }
+
   /// \returns true if the outlined hash tree is empty.
-  bool empty() const { return HashTree->empty(); }
+  bool empty() const { return tree().empty(); }
 
   /// Print the outlined hash tree in a YAML format.
   void print(raw_ostream &OS = llvm::errs()) const {
@@ -64,11 +99,38 @@ struct OutlinedHashTreeRecord {
   }
 
 private:
-  /// Convert the outlined hash tree to stable data.
-  void convertToStableData(IdHashNodeStableMapTy &IdNodeStableMap) const;
+  /// \returns a mutable, in-memory tree built from the block region beginning
+  /// at \p BlockBase (the root block at its offset 0).
+  static std::unique_ptr<MutableOutlinedHashTree>
+  createInMemory(const unsigned char *BlockBase);
+
+  /// \returns the held tree, whichever representation is in use.
+  const OutlinedHashTree &tree() const {
+    return ReadInPlaceHashTree ? *ReadInPlaceHashTree : *HashTree;
+  }
+
+  /// Controls how a node's successors are ordered when converting to stable
+  /// data.
+  enum class SuccessorOrder {
+    /// Sort by successor id, for stable, deterministic textual output.
+    ById,
+    /// Sort by child hash, as required by the binary format so the in-place
+    /// reader can binary-search a node's successors.
+    ByHash,
+  };
+
+  /// Convert the outlined hash tree to stable data, ordering each node's
+  /// successors per \p Order.
+  void convertToStableData(IdHashNodeStableMapTy &IdNodeStableMap,
+                           SuccessorOrder Order = SuccessorOrder::ById) const;
 
   /// Convert the stable data back to the outlined hash tree.
   void convertFromStableData(const IdHashNodeStableMapTy &IdNodeStableMap);
+
+  /// A read-only tree that reads its nodes in place from a mapped buffer, set
+  /// by lazyDeserialize(). Mutually exclusive with the in-memory HashTree;
+  /// releaseTree() hands out whichever of the two is set.
+  std::unique_ptr<OutlinedHashTree> ReadInPlaceHashTree;
 };
 
 } // end namespace llvm

--- a/llvm/lib/CGData/CodeGenData.cpp
+++ b/llvm/lib/CGData/CodeGenData.cpp
@@ -189,7 +189,7 @@ Expected<Header> Header::readFromBuffer(const unsigned char *Curr) {
     return make_error<CGDataError>(cgdata_error::unsupported_version);
   H.DataKind = endian::readNext<uint32_t, endianness::little, unaligned>(Curr);
 
-  static_assert(IndexedCGData::CGDataVersion::CurrentVersion == Version4,
+  static_assert(IndexedCGData::CGDataVersion::CurrentVersion == Version5,
                 "Please update the offset computation below if a new field has "
                 "been added to the header.");
   H.OutlinedHashTreeOffset =

--- a/llvm/lib/CGData/CodeGenDataReader.cpp
+++ b/llvm/lib/CGData/CodeGenDataReader.cpp
@@ -109,15 +109,21 @@ Error IndexedCodeGenDataReader::read() {
   if (auto E = IndexedCGData::Header::readFromBuffer(Start).moveInto(Header))
     return E;
 
+  // Keep the buffer alive via a shared_ptr so records can be read from it on
+  // demand and outlive this reader.
+  std::shared_ptr<MemoryBuffer> SharedDataBuffer = std::move(DataBuffer);
+
   if (hasOutlinedHashTree()) {
     const unsigned char *Ptr = Start + Header.OutlinedHashTreeOffset;
     if (Ptr >= End)
       return error(cgdata_error::eof);
-    HashTreeRecord.deserialize(Ptr);
+    if (IndexedCodeGenDataLazyLoading)
+      HashTreeRecord.lazyDeserialize(SharedDataBuffer,
+                                     Header.OutlinedHashTreeOffset);
+    else
+      HashTreeRecord.deserialize(Ptr);
   }
 
-  // TODO: lazy loading support for outlined hash tree.
-  std::shared_ptr<MemoryBuffer> SharedDataBuffer = std::move(DataBuffer);
   if (hasStableFunctionMap()) {
     const unsigned char *Ptr = Start + Header.StableFunctionMapOffset;
     if (Ptr >= End)

--- a/llvm/lib/CGData/OutlinedHashTree.cpp
+++ b/llvm/lib/CGData/OutlinedHashTree.cpp
@@ -13,14 +13,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CGData/OutlinedHashTree.h"
+#include "llvm/CGData/OutlinedHashTreeRecord.h"
 
 #define DEBUG_TYPE "outlined-hash-tree"
 
 using namespace llvm;
 
-void OutlinedHashTree::walkGraph(NodeCallbackFn CallbackNode,
-                                 EdgeCallbackFn CallbackEdge,
-                                 bool SortedWalk) const {
+void MutableOutlinedHashTree::walkGraph(NodeCallbackFn CallbackNode,
+                                        EdgeCallbackFn CallbackEdge,
+                                        bool SortedWalk) const {
   SmallVector<const HashNode *> Stack;
   Stack.emplace_back(getRoot());
 
@@ -48,7 +49,7 @@ void OutlinedHashTree::walkGraph(NodeCallbackFn CallbackNode,
   }
 }
 
-size_t OutlinedHashTree::size(bool GetTerminalCountOnly) const {
+size_t MutableOutlinedHashTree::size(bool GetTerminalCountOnly) const {
   size_t Size = 0;
   walkGraph([&Size, GetTerminalCountOnly](const HashNode *N) {
     Size += (N && (!GetTerminalCountOnly || N->Terminals));
@@ -56,7 +57,7 @@ size_t OutlinedHashTree::size(bool GetTerminalCountOnly) const {
   return Size;
 }
 
-size_t OutlinedHashTree::depth() const {
+size_t MutableOutlinedHashTree::depth() const {
   size_t Size = 0;
   DenseMap<const HashNode *, size_t> DepthMap;
   walkGraph([&Size, &DepthMap](
@@ -68,7 +69,7 @@ size_t OutlinedHashTree::depth() const {
   return Size;
 }
 
-void OutlinedHashTree::insert(const HashSequencePair &SequencePair) {
+void MutableOutlinedHashTree::insert(const HashSequencePair &SequencePair) {
   auto &[Sequence, Count] = SequencePair;
   HashNode *Current = getRoot();
 
@@ -87,7 +88,7 @@ void OutlinedHashTree::insert(const HashSequencePair &SequencePair) {
     Current->Terminals = Current->Terminals.value_or(0) + Count;
 }
 
-void OutlinedHashTree::merge(const OutlinedHashTree *Tree) {
+void MutableOutlinedHashTree::merge(const MutableOutlinedHashTree *Tree) {
   HashNode *Dst = getRoot();
   const HashNode *Src = Tree->getRoot();
   SmallVector<std::pair<HashNode *, const HashNode *>> Stack;
@@ -117,12 +118,46 @@ void OutlinedHashTree::merge(const OutlinedHashTree *Tree) {
 
 std::optional<unsigned>
 OutlinedHashTree::find(const HashSequence &Sequence) const {
-  const HashNode *Current = getRoot();
+  HashNodeCursor Cursor = getRootCursor();
   for (stable_hash StableHash : Sequence) {
-    const auto I = Current->Successors.find(StableHash);
-    if (I == Current->Successors.end())
+    auto Next = Cursor.getSuccessor(*this, StableHash);
+    if (!Next)
       return 0;
-    Current = I->second.get();
+    Cursor = *Next;
   }
-  return Current->Terminals;
+  return Cursor.getTerminals(*this);
+}
+
+OutlinedHashTree::HashNodeCursor OutlinedHashTree::getRootCursor() const {
+  if (isReadInPlace())
+    // root block at region offset 0
+    return HashNodeCursor(uint64_t(0));
+  return HashNodeCursor(&Root);
+}
+
+std::optional<OutlinedHashTree::HashNodeCursor>
+OutlinedHashTree::HashNodeCursor::getSuccessor(const OutlinedHashTree &Tree,
+                                               stable_hash H) const {
+  if (Tree.isReadInPlace()) {
+    if (auto SuccessorOffset = OutlinedHashTreeRecord::readSuccessor(
+            Tree.BlockBase + BlockOffset, H))
+      return HashNodeCursor(*SuccessorOffset);
+    return std::nullopt;
+  }
+  auto It = Node->Successors.find(H);
+  if (It == Node->Successors.end())
+    return std::nullopt;
+  return HashNodeCursor(It->second.get());
+}
+
+std::optional<unsigned> OutlinedHashTree::HashNodeCursor::getTerminals(
+    const OutlinedHashTree &Tree) const {
+  if (Tree.isReadInPlace()) {
+    unsigned T =
+        OutlinedHashTreeRecord::readTerminals(Tree.BlockBase + BlockOffset);
+    if (!T)
+      return std::nullopt;
+    return T;
+  }
+  return Node->Terminals;
 }

--- a/llvm/lib/CGData/OutlinedHashTreeRecord.cpp
+++ b/llvm/lib/CGData/OutlinedHashTreeRecord.cpp
@@ -14,14 +14,48 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CGData/OutlinedHashTreeRecord.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ObjectYAML/YAML.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/EndianStream.h"
+#include "llvm/Support/MathExtras.h"
 
 #define DEBUG_TYPE "outlined-hash-tree"
 
 using namespace llvm;
 using namespace llvm::support;
+
+namespace {
+/// On-disk binary layout of the serialized outlined hash tree. The structure is
+/// as follows:
+/// - Number of nodes
+/// - Padding to keep the block region that follows 8-byte aligned
+/// - Total size of the block region, for advancing past the blob when merging
+/// - Block region: one self-describing block per node, the root node first,
+///   each node identified by its block's byte offset within the region (the
+///   root is at offset 0):
+///   - Number of successors
+///   - Terminal count
+///   - Successor entries, sorted by child hash so readSuccessor() can
+///     binary-search them:
+///     - Child hash (a node's hash is stored only here, in its parent's
+///       entry; the root's is implicitly 0)
+///     - Byte offset of the child's block within the block region
+/// - Padding to align the blob to 8 bytes, so concatenated blobs stay aligned
+struct OutlinedHashTreeFormat {
+  static constexpr unsigned BlobHeaderSize = 16;
+  static constexpr unsigned BlockRegionSizeFieldOffset = 8;
+  static constexpr unsigned NumSuccFieldOffset = 0;
+  static constexpr unsigned TerminalsFieldOffset = 4;
+  static constexpr unsigned BlockHeaderSize = 8;
+  static constexpr unsigned EntryHashFieldOffset = 0;
+  static constexpr unsigned EntryChildOffsetFieldOffset = 8;
+  static constexpr unsigned EntrySize = 16;
+  static constexpr unsigned BlobAlign = 8;
+};
+} // namespace
+
+using Fmt = OutlinedHashTreeFormat;
 
 namespace llvm {
 namespace yaml {
@@ -57,42 +91,142 @@ template <> struct CustomMappingTraits<IdHashNodeStableMapTy> {
 
 void OutlinedHashTreeRecord::serialize(raw_ostream &OS) const {
   IdHashNodeStableMapTy IdNodeStableMap;
-  convertToStableData(IdNodeStableMap);
+  convertToStableData(IdNodeStableMap, SuccessorOrder::ByHash);
   support::endian::Writer Writer(OS, endianness::little);
-  Writer.write<uint32_t>(IdNodeStableMap.size());
 
+  // Compute the offsets for each node to avoid writeback.
+  uint32_t NumNodes = static_cast<uint32_t>(IdNodeStableMap.size());
+  std::vector<uint64_t> BlockOffset(NumNodes);
+  uint64_t Offset = 0;
   for (const auto &[Id, NodeStable] : IdNodeStableMap) {
-    Writer.write<uint32_t>(Id);
-    Writer.write<uint64_t>(NodeStable.Hash);
-    Writer.write<uint32_t>(NodeStable.Terminals);
-    Writer.write<uint32_t>(NodeStable.SuccessorIds.size());
-    for (auto SuccessorId : NodeStable.SuccessorIds)
-      Writer.write<uint32_t>(SuccessorId);
+    BlockOffset[Id] = Offset;
+    Offset += Fmt::BlockHeaderSize +
+              uint64_t(Fmt::EntrySize) * NodeStable.SuccessorIds.size();
   }
+  uint64_t BlockRegionSize = Offset;
+
+  Writer.write<uint32_t>(NumNodes);
+  Writer.write<uint32_t>(0);
+  Writer.write<uint64_t>(BlockRegionSize);
+  for (const auto &[Id, NodeStable] : IdNodeStableMap) {
+    Writer.write<uint32_t>(
+        static_cast<uint32_t>(NodeStable.SuccessorIds.size()));
+    Writer.write<uint32_t>(NodeStable.Terminals);
+    for (unsigned SuccId : NodeStable.SuccessorIds) {
+      Writer.write<uint64_t>(IdNodeStableMap.at(SuccId).Hash);
+      Writer.write<uint64_t>(BlockOffset[SuccId]);
+    }
+  }
+
+  // Pad the blob to OutlinedHashTreeFormat::BlobAlign so that concatenated
+  // blobs stay aligned and deserialize() can advance from one to the next.
+  uint64_t BlobSize = Fmt::BlobHeaderSize + BlockRegionSize;
+  for (uint64_t I = BlobSize, E = alignTo(BlobSize, Fmt::BlobAlign); I < E; ++I)
+    Writer.write<uint8_t>(0);
 }
 
 void OutlinedHashTreeRecord::deserialize(const unsigned char *&Ptr) {
-  IdHashNodeStableMapTy IdNodeStableMap;
-  auto NumIdNodeStableMap =
-      endian::readNext<uint32_t, endianness::little, unaligned>(Ptr);
+  const unsigned char *BlobStart = Ptr;
+  uint64_t BlockRegionSize = endian::read<uint64_t, unaligned>(
+      BlobStart + Fmt::BlockRegionSizeFieldOffset, endianness::little);
+  const unsigned char *BlockBase = BlobStart + Fmt::BlobHeaderSize;
+  HashTree = createInMemory(BlockBase);
 
-  for (unsigned I = 0; I < NumIdNodeStableMap; ++I) {
-    auto Id = endian::readNext<uint32_t, endianness::little, unaligned>(Ptr);
-    HashNodeStable NodeStable;
-    NodeStable.Hash =
-        endian::readNext<uint64_t, endianness::little, unaligned>(Ptr);
-    NodeStable.Terminals =
-        endian::readNext<uint32_t, endianness::little, unaligned>(Ptr);
-    auto NumSuccessorIds =
-        endian::readNext<uint32_t, endianness::little, unaligned>(Ptr);
-    for (unsigned J = 0; J < NumSuccessorIds; ++J)
-      NodeStable.SuccessorIds.push_back(
-          endian::readNext<uint32_t, endianness::little, unaligned>(Ptr));
+  // Advance Ptr past the blob, including the alignment padding serialize()
+  // appended, so a concatenated merge loop lands on the next blob / the end.
+  size_t ContentSize = (BlockBase + BlockRegionSize) - BlobStart;
+  Ptr = BlobStart + alignTo(ContentSize, Fmt::BlobAlign);
+}
 
-    IdNodeStableMap[Id] = std::move(NodeStable);
+std::unique_ptr<OutlinedHashTree>
+OutlinedHashTreeRecord::createReadInPlace(std::shared_ptr<MemoryBuffer> Buffer,
+                                          uint64_t BlobOffset) {
+  const auto *BlobStart =
+      reinterpret_cast<const unsigned char *>(Buffer->getBufferStart()) +
+      BlobOffset;
+  uint32_t NumNodes =
+      endian::read<uint32_t, unaligned>(BlobStart, endianness::little);
+  const unsigned char *BlockBase = BlobStart + Fmt::BlobHeaderSize;
+  return std::make_unique<OutlinedHashTree>(std::move(Buffer), BlockBase,
+                                            NumNodes);
+}
+
+void OutlinedHashTreeRecord::lazyDeserialize(
+    std::shared_ptr<MemoryBuffer> Buffer, uint64_t Offset) {
+  // The read-in-place tree becomes the record's only tree; drop the empty
+  // in-memory tree the constructor created.
+  HashTree.reset();
+  ReadInPlaceHashTree = createReadInPlace(std::move(Buffer), Offset);
+}
+
+static uint32_t readU32(const unsigned char *P) {
+  return endian::read<uint32_t, unaligned>(P, endianness::little);
+}
+static uint64_t readU64(const unsigned char *P) {
+  return endian::read<uint64_t, unaligned>(P, endianness::little);
+}
+
+std::optional<uint64_t>
+OutlinedHashTreeRecord::readSuccessor(const unsigned char *Block,
+                                      stable_hash H) {
+  const unsigned char *Entries = Block + Fmt::BlockHeaderSize;
+  uint32_t Lo = 0, Hi = readU32(Block + Fmt::NumSuccFieldOffset);
+  while (Lo < Hi) {
+    uint32_t Mid = Lo + (Hi - Lo) / 2;
+    const unsigned char *E = Entries + Fmt::EntrySize * Mid;
+    stable_hash ChildHash = readU64(E + Fmt::EntryHashFieldOffset);
+    if (ChildHash < H)
+      Lo = Mid + 1;
+    else if (ChildHash > H)
+      Hi = Mid;
+    else
+      return readU64(E + Fmt::EntryChildOffsetFieldOffset);
   }
+  return std::nullopt;
+}
 
-  convertFromStableData(IdNodeStableMap);
+unsigned OutlinedHashTreeRecord::readTerminals(const unsigned char *Block) {
+  return readU32(Block + Fmt::TerminalsFieldOffset);
+}
+
+std::unique_ptr<MutableOutlinedHashTree>
+OutlinedHashTreeRecord::createInMemory(const unsigned char *BlockBase) {
+  auto Tree = std::make_unique<MutableOutlinedHashTree>();
+  HashNode &Root = *Tree->getRoot();
+  // Iterative to avoid deep-chain stack overflow, in production the tree could
+  // have very long single-child chains.
+  SmallVector<std::pair<HashNode *, uint64_t>> Stack;
+  Stack.emplace_back(&Root, uint64_t(0));
+  while (!Stack.empty()) {
+    auto [Node, Off] = Stack.pop_back_val();
+    const unsigned char *Block = BlockBase + Off;
+    uint32_t NumSucc = readU32(Block + Fmt::NumSuccFieldOffset);
+    if (unsigned T = readTerminals(Block))
+      Node->Terminals = T;
+    const unsigned char *Entries = Block + Fmt::BlockHeaderSize;
+    for (uint32_t K = 0; K < NumSucc; ++K) {
+      const unsigned char *E = Entries + Fmt::EntrySize * K;
+      stable_hash ChildHash = readU64(E + Fmt::EntryHashFieldOffset);
+      uint64_t ChildOff = readU64(E + Fmt::EntryChildOffsetFieldOffset);
+      auto Child = std::make_unique<HashNode>();
+      Child->Hash = ChildHash;
+      HashNode *ChildPtr = Child.get();
+      Node->Successors.try_emplace(ChildHash, std::move(Child));
+      Stack.emplace_back(ChildPtr, ChildOff);
+    }
+  }
+  return Tree;
+}
+
+std::unique_ptr<MutableOutlinedHashTree>
+OutlinedHashTreeRecord::createInMemory(std::unique_ptr<OutlinedHashTree> Tree) {
+  if (Tree->isReadInPlace())
+    return createInMemory(Tree->BlockBase);
+  // An in-memory tree is already a MutableOutlinedHashTree; move its nodes into
+  // a fresh one so the caller gets the concrete mutable type back.
+  auto InMemory = std::make_unique<MutableOutlinedHashTree>();
+  *InMemory->getRoot() = std::move(Tree->Root);
+  return InMemory;
 }
 
 void OutlinedHashTreeRecord::serializeYAML(yaml::Output &YOS) const {
@@ -112,7 +246,7 @@ void OutlinedHashTreeRecord::deserializeYAML(yaml::Input &YIS) {
 }
 
 void OutlinedHashTreeRecord::convertToStableData(
-    IdHashNodeStableMapTy &IdNodeStableMap) const {
+    IdHashNodeStableMapTy &IdNodeStableMap, SuccessorOrder Order) const {
   // Build NodeIdMap
   HashNodeIdMapTy NodeIdMap;
   HashTree->walkGraph(
@@ -136,9 +270,22 @@ void OutlinedHashTreeRecord::convertToStableData(
     IdNodeStableMap[Id] = NodeStable;
   }
 
-  // Sort the Successors so that they come out in the same order as in the map.
-  for (auto &P : IdNodeStableMap)
-    llvm::sort(P.second.SuccessorIds);
+  // Sort each node's successors per the requested order. ById gives stable
+  // textual output; ByHash lets the in-place reader binary-search a
+  // node's successors by child hash.
+  for (auto &P : IdNodeStableMap) {
+    switch (Order) {
+    case SuccessorOrder::ById:
+      llvm::sort(P.second.SuccessorIds);
+      break;
+    case SuccessorOrder::ByHash:
+      llvm::sort(P.second.SuccessorIds, [&](unsigned A, unsigned B) {
+        return static_cast<uint64_t>(IdNodeStableMap.at(A).Hash) <
+               static_cast<uint64_t>(IdNodeStableMap.at(B).Hash);
+      });
+      break;
+    }
+  }
 }
 
 void OutlinedHashTreeRecord::convertFromStableData(

--- a/llvm/lib/CodeGen/MachineOutliner.cpp
+++ b/llvm/lib/CodeGen/MachineOutliner.cpp
@@ -444,7 +444,7 @@ struct MachineOutliner : public ModulePass {
   /// which will be dead-stripped not going to the final binary.
   /// A post-process using llvm-cgdata, lld, or ThinLTO can merge them into
   /// a global oulined hash tree for the subsequent codegen.
-  std::unique_ptr<OutlinedHashTree> LocalHashTree;
+  std::unique_ptr<MutableOutlinedHashTree> LocalHashTree;
 
   /// The mode of the outliner.
   /// When is's CGDataMode::None, candidates are populated with the suffix tree
@@ -663,7 +663,8 @@ static SmallVector<MatchedEntry> getMatchedEntries(InstructionMapper &Mapper) {
 
   // Get the global outlined hash tree built from the previous run.
   assert(cgdata::hasOutlinedHashTree());
-  const auto *RootNode = cgdata::getOutlinedHashTree()->getRoot();
+  auto *Tree = cgdata::getOutlinedHashTree();
+  auto RootCursor = Tree->getRootCursor();
 
   auto getValidInstr = [&](unsigned Index) -> const MachineInstr * {
     if (UnsignedVec[Index] >= Mapper.LegalInstrNumber)
@@ -672,19 +673,20 @@ static SmallVector<MatchedEntry> getMatchedEntries(InstructionMapper &Mapper) {
   };
 
   auto getStableHashAndFollow =
-      [](const MachineInstr &MI, const HashNode *CurrNode) -> const HashNode * {
+      [Tree](const MachineInstr &MI,
+             const OutlinedHashTree::HashNodeCursor &CurrNode)
+      -> std::optional<OutlinedHashTree::HashNodeCursor> {
     stable_hash StableHash = stableHashValue(MI);
     if (!StableHash)
-      return nullptr;
-    auto It = CurrNode->Successors.find(StableHash);
-    return (It == CurrNode->Successors.end()) ? nullptr : It->second.get();
+      return std::nullopt;
+    return CurrNode.getSuccessor(*Tree, StableHash);
   };
 
   for (unsigned I = 0; I < Size; ++I) {
     const MachineInstr *MI = getValidInstr(I);
     if (!MI || MI->isDebugInstr())
       continue;
-    const HashNode *CurrNode = getStableHashAndFollow(*MI, RootNode);
+    auto CurrNode = getStableHashAndFollow(*MI, RootCursor);
     if (!CurrNode)
       continue;
 
@@ -695,12 +697,12 @@ static SmallVector<MatchedEntry> getMatchedEntries(InstructionMapper &Mapper) {
       // Skip debug instructions as we did for the outlined function.
       if (MJ->isDebugInstr())
         continue;
-      CurrNode = getStableHashAndFollow(*MJ, CurrNode);
+      CurrNode = getStableHashAndFollow(*MJ, *CurrNode);
       if (!CurrNode)
         break;
       // Even with a match ending with a terminal, we continue finding
       // matches to populate all candidates.
-      if (auto Count = CurrNode->Terminals)
+      if (auto Count = CurrNode->getTerminals(*Tree))
         MatchedEntries.emplace_back(I, J, *Count);
     }
   }
@@ -1406,7 +1408,7 @@ void MachineOutliner::initializeOutlinerMode(const Module &M) {
   if (cgdata::emitCGData()) {
     OutlinerMode = CGDataMode::Write;
     // Create a local outlined hash tree to be published.
-    LocalHashTree = std::make_unique<OutlinedHashTree>();
+    LocalHashTree = std::make_unique<MutableOutlinedHashTree>();
     // We don't need to read the outlined hash tree from the previous codegen
   } else if (cgdata::hasOutlinedHashTree())
     OutlinerMode = CGDataMode::Read;

--- a/llvm/test/CodeGen/AArch64/cgdata-read-double-outline.ll
+++ b/llvm/test/CodeGen/AArch64/cgdata-read-double-outline.ll
@@ -24,6 +24,11 @@
 ; RUN: llc -mtriple=arm64-apple-darwin -enable-machine-outliner -codegen-data-use-path=%t_cgdata -filetype=obj %t/local-two-another.ll -o %t_read
 ; RUN: llvm-objdump -d %t_read | FileCheck %s
 
+; Re-run with the outlined hash tree read in place instead of
+; fully materialized, and confirm the same outlining is produced.
+; RUN: llc -mtriple=arm64-apple-darwin -enable-machine-outliner -codegen-data-use-path=%t_cgdata -indexed-codegen-data-lazy-loading -filetype=obj %t/local-two-another.ll -o %t_read_lazy
+; RUN: llvm-objdump -d %t_read_lazy | FileCheck %s
+
 ; CHECK: _OUTLINED_FUNCTION_{{.*}}:
 ; CHECK-NEXT:  mov
 ; CHECK-NEXT:  mov

--- a/llvm/test/CodeGen/AArch64/cgdata-read-single-outline.ll
+++ b/llvm/test/CodeGen/AArch64/cgdata-read-single-outline.ll
@@ -18,6 +18,11 @@
 ; RUN: llc -mtriple=arm64-apple-darwin -enable-machine-outliner -codegen-data-use-path=%t_cgdata -filetype=obj %t/local-one.ll -o %t_read
 ; RUN: llvm-objdump -d %t_read | FileCheck %s
 
+; Re-run with the outlined hash tree read in place instead of
+; fully materialized, and confirm the same outlining is produced.
+; RUN: llc -mtriple=arm64-apple-darwin -enable-machine-outliner -codegen-data-use-path=%t_cgdata -indexed-codegen-data-lazy-loading -filetype=obj %t/local-one.ll -o %t_read_lazy
+; RUN: llvm-objdump -d %t_read_lazy | FileCheck %s
+
 ; CHECK: _OUTLINED_FUNCTION
 ; CHECK-NEXT:  mov
 ; CHECK-NEXT:  mov

--- a/llvm/test/tools/llvm-cgdata/empty.test
+++ b/llvm/test/tools/llvm-cgdata/empty.test
@@ -16,7 +16,7 @@ RUN: llvm-cgdata --show %t_emptyheader.cgdata | count 0
 
 # The version number appears when asked, as it's in the header
 RUN: llvm-cgdata --show --cgdata-version %t_emptyheader.cgdata | FileCheck %s --check-prefix=VERSION
-VERSION: Version: 4
+VERSION: Version: 5
 
 # When converting a binary file (w/ the header only) to a text file, it's an empty file as the text format does not have an explicit header.
 RUN: llvm-cgdata --convert %t_emptyheader.cgdata --format text | count 0
@@ -30,7 +30,7 @@ RUN: llvm-cgdata --convert %t_emptyheader.cgdata --format text | count 0
 #   uint64_t StableFunctionMapOffset;
 # }
 RUN: printf '\377cgdata\201' > %t_header.cgdata
-RUN: printf '\004\000\000\000' >> %t_header.cgdata
+RUN: printf '\005\000\000\000' >> %t_header.cgdata
 RUN: printf '\000\000\000\000' >> %t_header.cgdata
 RUN: printf '\040\000\000\000\000\000\000\000' >> %t_header.cgdata
 RUN: printf '\040\000\000\000\000\000\000\000' >> %t_header.cgdata

--- a/llvm/test/tools/llvm-cgdata/error.test
+++ b/llvm/test/tools/llvm-cgdata/error.test
@@ -27,9 +27,9 @@ RUN: printf '\377cgdata\201' > %t_corrupt.cgdata
 RUN: not llvm-cgdata --show %t_corrupt.cgdata 2>&1 | FileCheck %s  --check-prefix=CORRUPT
 CORRUPT: {{.}}cgdata: invalid codegen data (file header is corrupt)
 
-# The current version 4 while the header says 5.
+# The current version 5 while the header says 6.
 RUN: printf '\377cgdata\201' > %t_version.cgdata
-RUN: printf '\005\000\000\000' >> %t_version.cgdata
+RUN: printf '\006\000\000\000' >> %t_version.cgdata
 RUN: printf '\000\000\000\000' >> %t_version.cgdata
 RUN: printf '\040\000\000\000\000\000\000\000' >> %t_version.cgdata
 RUN: printf '\040\000\000\000\000\000\000\000' >> %t_version.cgdata

--- a/llvm/test/tools/llvm-cgdata/merge-hashtree-concat.test
+++ b/llvm/test/tools/llvm-cgdata/merge-hashtree-concat.test
@@ -83,5 +83,5 @@ TREE-NEXT: ...
 ;--- merge-concat-template.ll
 
 ; In an linked executable (as opposed to an object file), cgdata in __llvm_outline might be concatenated. Although this is not a typical workflow, we simply support this case to parse cgdata that is concatenated. In other words, the following two trees are encoded back-to-back in a binary format.
-@.data1 = private unnamed_addr constant [72 x i8] c"<RAW_1_BYTES>", section "__DATA,__llvm_outline"
-@.data2 = private unnamed_addr constant [72 x i8] c"<RAW_2_BYTES>", section "__DATA,__llvm_outline"
+@.data1 = private unnamed_addr constant [72 x i8] c"<RAW_1_BYTES>", section "__DATA,__llvm_outline", align 1
+@.data2 = private unnamed_addr constant [72 x i8] c"<RAW_2_BYTES>", section "__DATA,__llvm_outline", align 1

--- a/llvm/tools/llvm-cgdata/llvm-cgdata.cpp
+++ b/llvm/tools/llvm-cgdata/llvm-cgdata.cpp
@@ -126,7 +126,9 @@ static int convert_main(int argc, const char *argv[]) {
   CodeGenDataWriter Writer;
   auto Reader = ReaderOrErr->get();
   if (Reader->hasOutlinedHashTree()) {
-    OutlinedHashTreeRecord Record(Reader->releaseOutlinedHashTree());
+    auto Tree = OutlinedHashTreeRecord::createInMemory(
+        Reader->releaseOutlinedHashTree());
+    OutlinedHashTreeRecord Record(std::move(Tree));
     Writer.addRecord(Record);
   }
   if (Reader->hasStableFunctionMap()) {
@@ -260,7 +262,9 @@ static int show_main(int argc, const char *argv[]) {
     OS << "Version: " << Reader->getVersion() << "\n";
 
   if (Reader->hasOutlinedHashTree()) {
-    auto Tree = Reader->releaseOutlinedHashTree();
+    // Whole-tree stats need the in-memory form.
+    auto Tree = OutlinedHashTreeRecord::createInMemory(
+        Reader->releaseOutlinedHashTree());
     OS << "Outlined hash tree:\n";
     OS << "  Total Node Count: " << Tree->size() << "\n";
     OS << "  Terminal Node Count: " << Tree->size(/*GetTerminalCountOnly=*/true)

--- a/llvm/unittests/CGData/OutlinedHashTreeRecordTest.cpp
+++ b/llvm/unittests/CGData/OutlinedHashTreeRecordTest.cpp
@@ -115,4 +115,48 @@ TEST(OutlinedHashTreeRecordTest, SerializeYAML) {
   EXPECT_EQ(TreeDump1, TreeDump2);
 }
 
+TEST(OutlinedHashTreeRecordTest, InPlaceRead) {
+  // A tree with a branch, so a node has two successors and the in-place
+  // binary search is exercised.
+  OutlinedHashTreeRecord Eager;
+  Eager.HashTree->insert({{1, 2}, 4});
+  Eager.HashTree->insert({{1, 3}, 5});
+
+  // Serialize, then read the same bytes in place.
+  SmallVector<char> Out;
+  raw_svector_ostream OS(Out);
+  Eager.serialize(OS);
+  std::shared_ptr<MemoryBuffer> Buffer =
+      MemoryBuffer::getMemBufferCopy(StringRef(Out.data(), Out.size()));
+
+  std::unique_ptr<OutlinedHashTree> LazyTree =
+      OutlinedHashTreeRecord::createReadInPlace(Buffer, /*BlobOffset=*/0);
+  ASSERT_TRUE(LazyTree->isReadInPlace());
+
+  // empty() and find() read the buffer in place and agree with the eagerly
+  // loaded tree. A read-only tree exposes only this consume path.
+  EXPECT_FALSE(LazyTree->empty());
+  EXPECT_EQ(LazyTree->find({1, 2}), Eager.HashTree->find({1, 2}));
+  EXPECT_EQ(LazyTree->find({1, 3}), Eager.HashTree->find({1, 3}));
+  EXPECT_EQ(*LazyTree->find({1, 2}), 4u);
+  EXPECT_EQ(*LazyTree->find({1, 3}), 5u);
+  // A missing successor and a missing first instruction both miss.
+  EXPECT_EQ(LazyTree->find({1, 9}), 0u);
+  EXPECT_EQ(LazyTree->find({9}), 0u);
+  // A non-terminal prefix has no terminal count.
+  EXPECT_FALSE(LazyTree->find({1}).has_value());
+  EXPECT_TRUE(LazyTree->isReadInPlace());
+
+  // Converting the read-in-place tree materializes it once; its whole-tree
+  // counts match the eager tree.
+  auto InMem = OutlinedHashTreeRecord::createInMemory(std::move(LazyTree));
+  EXPECT_FALSE(InMem->isReadInPlace());
+  EXPECT_EQ(InMem->size(), Eager.HashTree->size());
+  EXPECT_EQ(InMem->size(/*GetTerminalCountOnly=*/true),
+            Eager.HashTree->size(/*GetTerminalCountOnly=*/true));
+  EXPECT_EQ(InMem->depth(), Eager.HashTree->depth());
+  // find() still works on the materialized tree.
+  EXPECT_EQ(*InMem->find({1, 3}), 5u);
+}
+
 } // end namespace

--- a/llvm/unittests/CGData/OutlinedHashTreeTest.cpp
+++ b/llvm/unittests/CGData/OutlinedHashTreeTest.cpp
@@ -15,7 +15,7 @@ using namespace llvm;
 namespace {
 
 TEST(OutlinedHashTreeTest, Empty) {
-  OutlinedHashTree HashTree;
+  MutableOutlinedHashTree HashTree;
   EXPECT_TRUE(HashTree.empty());
   // The header node is always present.
   EXPECT_EQ(HashTree.size(), 1u);
@@ -23,7 +23,7 @@ TEST(OutlinedHashTreeTest, Empty) {
 }
 
 TEST(OutlinedHashTreeTest, Insert) {
-  OutlinedHashTree HashTree;
+  MutableOutlinedHashTree HashTree;
   HashTree.insert({{1, 2, 3}, 1});
   // The node count is 4 (including the root node).
   EXPECT_EQ(HashTree.size(), 4u);
@@ -43,7 +43,7 @@ TEST(OutlinedHashTreeTest, Insert) {
 }
 
 TEST(OutlinedHashTreeTest, Find) {
-  OutlinedHashTree HashTree;
+  MutableOutlinedHashTree HashTree;
   HashTree.insert({{1, 2, 3}, 1});
   HashTree.insert({{1, 2, 3}, 2});
 
@@ -57,15 +57,15 @@ TEST(OutlinedHashTreeTest, Find) {
 
 TEST(OutlinedHashTreeTest, Merge) {
   // Build HashTree1 inserting 2 sequences.
-  OutlinedHashTree HashTree1;
+  MutableOutlinedHashTree HashTree1;
 
   HashTree1.insert({{1, 2}, 20});
   HashTree1.insert({{1, 4}, 30});
 
   // Build HashTree2 and HashTree3 for each
-  OutlinedHashTree HashTree2;
+  MutableOutlinedHashTree HashTree2;
   HashTree2.insert({{1, 2}, 20});
-  OutlinedHashTree HashTree3;
+  MutableOutlinedHashTree HashTree3;
   HashTree3.insert({{1, 4}, 30});
 
   // Merge HashTree3 into HashTree2.


### PR DESCRIPTION
…s for in-place reads

Consuming codegen data in the MachineOutliner fully materializes the whole outlined hash tree as HashNode objects, which is slow and memory-hungry. This hurts traditional non-LTO builds most: every short-lived compiler process materializes the entire tree just to compile a single TU.

Bump the indexed format to v5 and serialize the outlined hash tree as a region of per-node blocks linked by byte offset. Each block is a small header followed by its successor entries, sorted by child hash, each carrying the child hash and the byte offset of the child block. A node is reached through its parent's entry, so a node's hash is stored once in its parent.

The existing -indexed-codegen-data-lazy-loading flag now also covers the outlined hash tree: under it, consuming the data no longer reads the blob into memory or builds any HashNode objects. The reader memory-maps the blob and a read-only HashNodeCursor reads node fields in place; each successor lookup is a binary search over the node's on-disk successor array, which is sorted by child hash and carries each child hash inline, so it touches only that one contiguous block with no scattered per-child reads.

OutlinedHashTree is now read-only, exposing only this consume path, backed by either representation. Building, mutating, and whole-tree traversal live on a MutableOutlinedHashTree subclass that is always in memory.