### PR TITLE
[clang-tidy][NFC] Update CERT wiki link across all clang-tidy docs

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/assignment-in-selection-statement.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/assignment-in-selection-statement.rst
@@ -17,7 +17,7 @@ condition (of ``if`` or a loop statement).
 
 This check corresponds to the CERT rule
 `EXP45-C. Do not perform assignments in selection statements
-<https://wiki.sei.cmu.edu/confluence/spaces/c/pages/87152228/EXP45-C.+Do+not+perform+assignments+in+selection+statements>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/expressions-exp/exp45-c/>`_.
 
 Examples
 ========

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/bad-signal-to-kill-thread.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/bad-signal-to-kill-thread.rst
@@ -13,6 +13,6 @@ just the individual thread. Use any signal except ``SIGTERM``.
 
 This check corresponds to the CERT C Coding Standard rule
 `POS44-C. Do not use signals to terminate threads
-<https://wiki.sei.cmu.edu/confluence/display/c/POS44-C.+Do+not+use+signals+to+terminate+threads>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/posix-pos/pos44-c/>`_.
 
 `cert-pos44-c` redirects here as an alias of this check.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/copy-constructor-mutates-argument.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/copy-constructor-mutates-argument.rst
@@ -8,4 +8,4 @@ in copy constructors and copy assignment operators.
 
 This check corresponds to the CERT C Coding Standard rule
 `OOP58-CPP. Copy operations must not mutate the source object
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP58-CPP.+Copy+operations+must+not+mutate+the+source+object>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop58-cpp/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/default-operator-new-on-overaligned-type.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/default-operator-new-on-overaligned-type.rst
@@ -17,4 +17,4 @@ References
 
 This check corresponds to the CERT C++ Coding Standard rule
 `MEM57-CPP. Avoid using default operator new for over-aligned types
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/MEM57-CPP.+Avoid+using+default+operator+new+for+over-aligned+types>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem57-cpp/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/exception-copy-constructor-throws.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/exception-copy-constructor-throws.rst
@@ -28,4 +28,4 @@ References
 
 This check corresponds to the CERT C++ Coding Standard rule
 `ERR60-CPP. Exception objects must be nothrow copy constructible
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/ERR60-CPP.+Exception+objects+must+be+nothrow+copy+constructible>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err60-cpp/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-parentheses.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-parentheses.rst
@@ -20,4 +20,4 @@ properly.
 
 This check corresponds to the CERT C Coding Standard rule
 `PRE02-C. Macro replacement lists should be parenthesized.
-<https://wiki.sei.cmu.edu/confluence/display/c/PRE02-C.+Macro+replacement+lists+should+be+parenthesized>`_
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/recommendations/preprocessor-pre/pre02-c/>`_

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object.rst
@@ -65,4 +65,4 @@ References
 
 This check corresponds to the SEI Cert rule
 `CTR56-CPP. Do not use pointer arithmetic on polymorphic objects
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/CTR56-CPP.+Do+not+use+pointer+arithmetic+on+polymorphic+objects>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/containers-ctr/ctr56-cpp/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/random-generator-seed.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/random-generator-seed.rst
@@ -39,6 +39,6 @@ References
 
 This check corresponds to the CERT C++ Coding Standard rules
 `MSC51-CPP. Ensure your random number generator is properly seeded
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/MSC51-CPP.+Ensure+your+random+number+generator+is+properly+seeded>`_ and
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc51-cpp/>`_ and
 `MSC32-C. Properly seed pseudorandom number generators
-<https://wiki.sei.cmu.edu/confluence/display/c/MSC32-C.+Properly+seed+pseudorandom+number+generators>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc32-c/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/raw-memory-call-on-non-trivial-type.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/raw-memory-call-on-non-trivial-type.rst
@@ -32,4 +32,4 @@ Options
 This check corresponds to the CERT C++ Coding Standard rule
 `OOP57-CPP. Prefer special member functions and overloaded operators to C
 Standard Library functions
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP57-CPP.+Prefer+special+member+functions+and+overloaded+operators+to+C+Standard+Library+functions>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop57-cpp/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/reserved-identifier.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/reserved-identifier.rst
@@ -38,10 +38,10 @@ standards, e.g. C++ 'zombie names' and C future library directions.
 
 This check corresponds to CERT C Coding Standard rule `DCL37-C. Do not declare
 or define a reserved identifier
-<https://wiki.sei.cmu.edu/confluence/display/c/DCL37-C.+Do+not+declare+or+define+a+reserved+identifier>`_
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/declarations-and-initialization-dcl/dcl37-c/>`_
 as well as its C++ counterpart, `DCL51-CPP. Do not declare or define a reserved
 identifier
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL51-CPP.+Do+not+declare+or+define+a+reserved+identifier>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl51-cpp/>`_.
 
 Options
 -------

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/shared-ptr-array-mismatch.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/shared-ptr-array-mismatch.rst
@@ -32,5 +32,5 @@ Example:
 
 This check partially covers the CERT C++ Coding Standard rule
 `MEM51-CPP. Properly deallocate dynamically allocated resources
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/MEM51-CPP.+Properly+deallocate+dynamically+allocated+resources>`_
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem51-cpp/>`_
 However, only the ``std::shared_ptr`` case is detected by this check.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/signal-handler.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/signal-handler.rst
@@ -31,10 +31,10 @@ recursively.
 
 This check implements the CERT C Coding Standard rule
 `SIG30-C. Call only asynchronous-safe functions within signal handlers
-<https://www.securecoding.cert.org/confluence/display/c/SIG30-C.+Call+only+asynchronous-safe+functions+within+signal+handlers>`_
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/signals-sig/sig30-c/>`_
 and the rule
 `MSC54-CPP. A signal handler must be a plain old function
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/MSC54-CPP.+A+signal+handler+must+be+a+plain+old+function>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc54-cpp/>`_.
 It has the alias names ``cert-sig30-c`` and ``cert-msc54-cpp``.
 
 Options

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-char-misuse.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-char-misuse.rst
@@ -45,7 +45,7 @@ Currently, this check warns in the following cases:
 See also:
 `STR34-C. Cast characters to unsigned char before converting to larger
 integer sizes
-<https://wiki.sei.cmu.edu/confluence/display/c/STR34-C.+Cast+characters+to+unsigned+char+before+converting+to+larger+integer+sizes>`_
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/characters-and-strings-str/str34-c/>`_
 
 A good example from the CERT description when a ``char`` variable is used to
 read from a file that might contain non-ASCII characters. The problem comes

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
@@ -264,7 +264,7 @@ this check.
 
 This check corresponds to the CERT C Coding Standard rule
 `ARR39-C. Do not add or subtract a scaled integer to a pointer
-<http://wiki.sei.cmu.edu/confluence/display/c/ARR39-C.+Do+not+add+or+subtract+a+scaled+integer+to+a+pointer>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/arrays-arr/arr39-c/>`_.
 
 
 Limitations

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/spuriously-wake-up-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/spuriously-wake-up-functions.rst
@@ -23,7 +23,7 @@ condition parameter.
 
 This check corresponds to the CERT C++ Coding Standard rule
 `CON54-CPP. Wrap functions that can spuriously wake up in a loop
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/CON54-CPP.+Wrap+functions+that+can+spuriously+wake+up+in+a+loop>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/concurrency-con/con54-cpp/>`_.
 and CERT C Coding Standard rule
 `CON36-C. Wrap functions that can spuriously wake up in a loop
-<https://wiki.sei.cmu.edu/confluence/display/c/CON36-C.+Wrap+functions+that+can+spuriously+wake+up+in+a+loop>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/concurrency-con/con36-c/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-memory-comparison.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-memory-comparison.rst
@@ -18,18 +18,18 @@ This may be caused by padding or floating-point types.
 
 See also:
 `EXP42-C. Do not compare padding data
-<https://wiki.sei.cmu.edu/confluence/display/c/EXP42-C.+Do+not+compare+padding+data>`_
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/expressions-exp/exp42-c/>`_
 and
 `FLP37-C. Do not use object representations to compare floating-point values
-<https://wiki.sei.cmu.edu/confluence/display/c/FLP37-C.+Do+not+use+object+representations+to+compare+floating-point+values>`_
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/floating-point-flp/flp37-c/>`_
 
 This check is also related to and partially overlaps the CERT C++ Coding Standard rules
 `OOP57-CPP. Prefer special member functions and overloaded operators to
 C Standard Library functions
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP57-CPP.+Prefer+special+member+functions+and+overloaded+operators+to+C+Standard+Library+functions>`_
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop57-cpp/>`_
 and
 `EXP62-CPP. Do not access the bits of an object representation that are not
 part of the object's value representation
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/EXP62-CPP.+Do+not+access+the+bits+of+an+object+representation+that+are+not+part+of+the+object%27s+value+representation>`_
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/expressions-exp/exp62-cpp/>`_
 
 `cert-exp42-c` redirects here as an alias of this check.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unhandled-self-assignment.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unhandled-self-assignment.rst
@@ -17,7 +17,7 @@ operator was not written with care.
 
 See also:
 `OOP54-CPP. Gracefully handle self-copy assignment
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP54-CPP.+Gracefully+handle+self-copy+assignment>`_
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop54-cpp/>`_
 
 A copy assignment operator must prevent that self-copy assignment ruins the
 object state. A typical use case is when the class has a pointer field

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unique-ptr-array-mismatch.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unique-ptr-array-mismatch.rst
@@ -35,5 +35,5 @@ Example:
 
 This check partially covers the CERT C++ Coding Standard rule
 `MEM51-CPP. Properly deallocate dynamically allocated resources
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/MEM51-CPP.+Properly+deallocate+dynamically+allocated+resources>`_
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem51-cpp/>`_
 However, only the ``std::unique_ptr`` case is detected by this check.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unsafe-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unsafe-functions.rst
@@ -10,9 +10,9 @@ The check heavily relies on the functions from the
 
 The check implements the following rules from the CERT C Coding Standard:
   - Recommendation `MSC24-C. Do not use deprecated or obsolescent functions
-    <https://wiki.sei.cmu.edu/confluence/display/c/MSC24-C.+Do+not+use+deprecated+or+obsolescent+functions>`_.
+    <https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/recommendations/miscellaneous-msc/msc24-c/>`_.
   - Rule `MSC33-C. Do not pass invalid data to the asctime() function
-    <https://wiki.sei.cmu.edu/confluence/display/c/MSC33-C.+Do+not+pass+invalid+data+to+the+asctime%28%29+function>`_.
+    <https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc33-c/>`_.
 
 `cert-msc24-c` and `cert-msc33-c` redirect here as aliases of this check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err33-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err33-c.rst
@@ -194,7 +194,7 @@ disabled by setting `AllowCastToVoid` option to `false`.
 
 The check corresponds to a part of CERT C Coding Standard rule `ERR33-C.
 Detect and handle standard library errors
-<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/error-handling-err/err33-c>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/error-handling-err/err33-c/>`_.
 The list of checked functions is taken from the rule, with following exception:
 
 * The check can not differentiate if a function is called with ``NULL``

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err33-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err33-c.rst
@@ -194,7 +194,7 @@ disabled by setting `AllowCastToVoid` option to `false`.
 
 The check corresponds to a part of CERT C Coding Standard rule `ERR33-C.
 Detect and handle standard library errors
-<https://wiki.sei.cmu.edu/confluence/display/c/ERR33-C.+Detect+and+handle+standard+library+errors>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/error-handling-err/err33-c>`_.
 The list of checked functions is taken from the rule, with following exception:
 
 * The check can not differentiate if a function is called with ``NULL``

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err60-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err60-cpp.rst
@@ -10,4 +10,4 @@ for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
 `ERR60-CPP. Exception objects must be nothrow copy constructible
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/ERR60-CPP.+Exception+objects+must+be+nothrow+copy+constructible>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err60-cpp/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/mem57-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/mem57-cpp.rst
@@ -10,4 +10,4 @@ for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
 `MEM57-CPP. Avoid using default operator new for over-aligned types
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/MEM57-CPP.+Avoid+using+default+operator+new+for+over-aligned+types>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/memory-management-mem/mem57-cpp/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc30-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc30-c.rst
@@ -8,4 +8,4 @@ The `cert-msc30-c` check is an alias, please see
 
 This check corresponds to the CERT C Coding Standard rule
 `MSC30-C. Do not use the rand() function for generating pseudorandom numbers
-<https://wiki.sei.cmu.edu/confluence/display/c/MSC30-C.+Do+not+use+the+rand%28%29+function+for+generating+pseudorandom+numbers>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc30-c/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc32-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc32-c.rst
@@ -9,4 +9,4 @@ for more information.
 
 This check corresponds to the CERT C Coding Standard rule
 `MSC32-C. Properly seed pseudorandom number generators
-<https://wiki.sei.cmu.edu/confluence/display/c/MSC32-C.+Properly+seed+pseudorandom+number+generators>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc32-c/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc50-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc50-cpp.rst
@@ -8,4 +8,4 @@ The `cert-msc50-cpp` check is an alias, please see
 
 This check corresponds to the CERT C Coding Standard rule
 `MSC50-CPP. Do not use std::rand() for generating pseudorandom numbers
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/MSC50-CPP.+Do+not+use+std%3A%3Arand%28%29+for+generating+pseudorandom+numbers>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc50-cpp>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.rst
@@ -10,4 +10,4 @@ for more information.
 
 This check corresponds to the CERT C++ Coding Standard rule
 `MSC51-CPP. Ensure your random number generator is properly seeded
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/MSC51-CPP.+Ensure+your+random+number+generator+is+properly+seeded>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc51-cpp/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/oop57-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/oop57-cpp.rst
@@ -11,4 +11,4 @@ for more information.
 This check corresponds to the CERT C++ Coding Standard rule
 `OOP57-CPP. Prefer special member functions and overloaded operators to C
 Standard Library functions
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP57-CPP.+Prefer+special+member+functions+and+overloaded+operators+to+C+Standard+Library+functions>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop57-cpp/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/concurrency/thread-canceltype-asynchronous.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/concurrency/thread-canceltype-asynchronous.rst
@@ -16,6 +16,6 @@ be acted upon and the effect is as if it was an asynchronous cancellation.
 
 This check corresponds to the CERT C Coding Standard rule
 `POS47-C. Do not use threads that can be canceled asynchronously
-<https://wiki.sei.cmu.edu/confluence/display/c/POS47-C.+Do+not+use+threads+that+can+be+canceled+asynchronously>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/posix-pos/pos47-c/>`_.
 
 `cert-pos47-c` redirects here as an alias of this check.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/anonymous-namespace-in-header.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/anonymous-namespace-in-header.rst
@@ -15,6 +15,6 @@ References
 
 This check corresponds to the CERT C++ Coding Standard rule
 `DCL59-CPP. Do not define an unnamed namespace in a header file
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL59-CPP.+Do+not+define+an+unnamed+namespace+in+a+header+file>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl59-cpp/>`_.
 
 Corresponding cpplint.py check name: `build/namespaces`.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/no-recursion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/no-recursion.rst
@@ -10,7 +10,7 @@ and displays one example of a possible call graph loop (recursion).
 
 References:
 
-* CERT C++ Coding Standard rule `DCL56-CPP. Avoid cycles during initialization of static objects <https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL56-CPP.+Avoid+cycles+during+initialization+of+static+objects>`_.
+* CERT C++ Coding Standard rule `DCL56-CPP. Avoid cycles during initialization of static objects <https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl56-cpp/>`_.
 * JPL Institutional Coding Standard for the C Programming Language
   (JPL DOCID D-60411) rule `2.4 Do not use direct or indirect recursion`.
 * OpenCL Specification, Version 1.2 rule `6.9 Restrictions: i. Recursion is not supported. <https://www.khronos.org/registry/OpenCL/specs/opencl-1.2.pdf>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/predictable-rand.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/predictable-rand.rst
@@ -15,6 +15,6 @@ References
 
 This check corresponds to the CERT C Coding Standard rules
 `MSC30-C. Do not use the rand() function for generating pseudorandom numbers
-<https://wiki.sei.cmu.edu/confluence/display/c/MSC30-C.+Do+not+use+the+rand%28%29+function+for+generating+pseudorandom+numbers>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/miscellaneous-msc/msc30-c/>`_.
 `MSC50-CPP. Do not use std::rand() for generating pseudorandom numbers
-<https://wiki.sei.cmu.edu/confluence/display/cplusplus/MSC50-CPP.+Do+not+use+std%3A%3Arand%28%29+for+generating+pseudorandom+numbers>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/miscellaneous-msc/msc50-cpp/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/static-initialization-cycle.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/static-initialization-cycle.rst
@@ -60,4 +60,4 @@ References
 ----------
 
 * CERT C++ Coding Standard rule `DCL56-CPP. Avoid cycles during initialization
-  of static objects <https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL56-CPP.+Avoid+cycles+during+initialization+of+static+objects>`_.
+  of static objects <https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/declarations-and-initialization-dcl/dcl56-cpp/>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/throw-by-value-catch-by-reference.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/throw-by-value-catch-by-reference.rst
@@ -8,7 +8,7 @@ misc-throw-by-value-catch-by-reference
 Finds violations of the rule "Throw by value, catch by reference" presented for
 example in "C++ Coding Standards" by H. Sutter and A. Alexandrescu, as well as
 the CERT C++ Coding Standard rule `ERR61-CPP. Catch exceptions by lvalue
-reference <https://wiki.sei.cmu.edu/confluence/display/cplusplus/ERR61-CPP.+Catch+exceptions+by+lvalue+reference>`_.
+reference <https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/exceptions-and-error-handling-err/err61-cpp/>`_.
 
 
 Exceptions:

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/enum-initial-value.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/enum-initial-value.rst
@@ -58,7 +58,7 @@ The following three cases are accepted:
   };
 
 This check corresponds to the CERT C Coding Standard recommendation `INT09-C. Ensure enumeration constants map to unique values
-<https://wiki.sei.cmu.edu/confluence/display/c/INT09-C.+Ensure+enumeration+constants+map+to+unique+values>`_.
+<https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/recommendations/integers-int/int09-c/>`_.
 
 `cert-int09-c` redirects here as an alias of this check.
 


### PR DESCRIPTION
This patch updates the outdated CMU wiki link in the CERT ERR33-C documentation. 

The old link currently returns a `301 Moved Permanently` redirecting to the new GitHub Pages location. This patch updates the source file to point directly to the new destination to prevent future link rot.

FIXES #200277 
<details>
<summary><b>Diagnosis & Curl Output</b></summary>

```http
$ curl -IL [https://wiki.sei.cmu.edu/confluence/display/c/ERR33-C.+Detect+and+handle+standard+library+errors](https://wiki.sei.cmu.edu/confluence/display/c/ERR33-C.+Detect+and+handle+standard+library+errors)

HTTP/1.0 301 Moved Permanently
Location: [https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/error-handling-err/err33-c](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/error-handling-err/err33-c)
Server: BigIP
Connection: close
Content-Length: 0

HTTP/2 301 
server: GitHub.com
location: [https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/error-handling-err/err33-c/](https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/rules/error-handling-err/err33-c/)

HTTP/2 200 
server: GitHub.com
content-type: text/html; charset=utf-8