### PR TITLE
[orc-rt] Default QueueingRunner to a synchronized queue.

### DIFF
--- a/orc-rt/include/orc-rt/QueueingRunner.h
+++ b/orc-rt/include/orc-rt/QueueingRunner.h
@@ -19,9 +19,45 @@
 #include "orc-rt-c/WrapperFunction.h"
 
 #include <cstdint>
+#include <deque>
+#include <mutex>
+#include <optional>
 #include <utility>
 
 namespace orc_rt {
+namespace detail {
+
+template <typename T> class SynchronizedDeque {
+public:
+  void push_back(T V) {
+    std::scoped_lock<std::mutex> Lock(M);
+    Q.push_back(std::move(V));
+  }
+
+  std::optional<T> pop_back() {
+    std::scoped_lock<std::mutex> Lock(M);
+    if (Q.empty())
+      return std::nullopt;
+    auto V = std::move(Q.back());
+    Q.pop_back();
+    return V;
+  }
+
+  std::optional<T> pop_front() {
+    std::scoped_lock<std::mutex> Lock(M);
+    if (Q.empty())
+      return std::nullopt;
+    auto V = std::move(Q.front());
+    Q.pop_front();
+    return V;
+  }
+
+private:
+  std::mutex M;
+  std::deque<T> Q;
+};
+
+} // namespace detail
 
 /// A wrapper-call runner that pushes incoming calls onto a caller-owned work
 /// queue, leaving the caller free to drain the queue however and whenever
@@ -32,14 +68,19 @@ namespace orc_rt {
 /// alternatives like ThreadPoolRunner are preferred.
 ///
 /// WorkQueue may be any container that stores `void()`-callable values and
-/// supports `push_back`, `pop_back`, `pop_front`, `back()`, `front()`, and
-/// `empty()` (e.g. `std::deque<move_only_function<void()>>`). In
+/// supports `push_back(T)`, `std::optional<T> pop_back()`, and
+/// `std::optional<T> pop_front()`, where the pop operations return
+/// `std::nullopt` on an empty queue (e.g. detail::SynchronizedDeque). In
 /// multi-threaded setups the WorkQueue type itself is responsible for
 /// providing whatever synchronization is needed for concurrent push and
 /// drain operations.
-template <typename WorkQueue> class QueueingRunner {
+template <typename WorkQueueT =
+              detail::SynchronizedDeque<move_only_function<void()>>>
+class QueueingRunner {
 public:
-  QueueingRunner(WorkQueue &Pending) : Pending(Pending) {}
+  using WorkQueue = WorkQueueT;
+
+  QueueingRunner(WorkQueueT &Pending) : Pending(Pending) {}
 
   /// Enqueue a wrapper-function call to be run later.
   void operator()(orc_rt_SessionRef S, uint64_t CallId,
@@ -52,30 +93,24 @@ public:
 
   /// Run all currently-queued calls in last-in-first-out order, returning when
   /// the queue is empty. Calls enqueued during draining are run too.
-  static void runLIFOUntilEmpty(WorkQueue &Q) {
-    while (!Q.empty()) {
-      auto Call = std::move(Q.back());
-      Q.pop_back();
-      Call();
-    }
+  static void runLIFOUntilEmpty(WorkQueueT &Q) {
+    while (auto Call = Q.pop_back())
+      (*Call)();
   }
 
   /// Run all currently-queued calls in first-in-first-out order, returning
   /// when the queue is empty. Calls enqueued during draining are run too.
-  static void runFIFOUntilEmpty(WorkQueue &Q) {
-    while (!Q.empty()) {
-      auto Call = std::move(Q.front());
-      Q.pop_front();
-      Call();
-    }
+  static void runFIFOUntilEmpty(WorkQueueT &Q) {
+    while (auto Call = Q.pop_front())
+      (*Call)();
   }
 
 private:
-  WorkQueue &Pending;
+  WorkQueueT &Pending;
 };
 
-template <typename WorkQueue>
-QueueingRunner(WorkQueue &) -> QueueingRunner<WorkQueue>;
+template <typename WorkQueueT>
+QueueingRunner(WorkQueueT &) -> QueueingRunner<WorkQueueT>;
 
 } // namespace orc_rt
 

--- a/orc-rt/unittests/InProcessControllerAccessTest.cpp
+++ b/orc-rt/unittests/InProcessControllerAccessTest.cpp
@@ -23,8 +23,6 @@
 
 using namespace orc_rt;
 
-using TaskQueue = std::deque<move_only_function<void()>>;
-
 namespace {
 
 // A minimal stand-in for llvm::orc::InProcessEPC. Registers itself on the
@@ -293,7 +291,7 @@ TEST(InProcessControllerAccessTest, CallFromControllerSuccess) {
   // invocation; draining the queue runs the wrapper, which echoes its
   // arguments back. Verify the mock receives the echoed bytes via
   // ReturnWrapperResult.
-  TaskQueue Tasks;
+  QueueingRunner<>::WorkQueue Tasks;
   Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
 
   std::unique_ptr<MockIPEPC> Mock;
@@ -313,7 +311,7 @@ TEST(InProcessControllerAccessTest, CallFromControllerSuccess) {
   // dispatched.
   ASSERT_FALSE(Result);
 
-  QueueingRunner<TaskQueue>::runFIFOUntilEmpty(Tasks);
+  QueueingRunner<>::runFIFOUntilEmpty(Tasks);
 
   ASSERT_TRUE(Result);
   EXPECT_EQ(*Result, "world");

--- a/orc-rt/unittests/QueueingRunnerTest.cpp
+++ b/orc-rt/unittests/QueueingRunnerTest.cpp
@@ -12,13 +12,12 @@
 
 #include <cstdint>
 #include <deque>
+#include <thread>
 #include <vector>
 
 using namespace orc_rt;
 
 namespace {
-
-using TaskQueue = std::deque<move_only_function<void()>>;
 
 // A dummy SessionRef value used purely to thread an opaque pointer through
 // the runner's enqueue path.
@@ -52,15 +51,19 @@ protected:
   void TearDown() override { RecordingLog = nullptr; }
 
   std::vector<CallRecord> Log;
-  TaskQueue Q;
+  QueueingRunner<>::WorkQueue Q;
 };
 
 TEST_F(QueueingRunnerTest, EnqueueDoesNotRunImmediately) {
-  QueueingRunner R(Q);
+  QueueingRunner<> R(Q);
   R(dummySession(), /*CallId=*/0, dummyReturn(), recordingFn,
     WrapperFunctionBuffer());
   EXPECT_EQ(Log.size(), 0u) << "Enqueue should not run the call";
-  EXPECT_EQ(Q.size(), 1u) << "Call should be sitting in the queue";
+  // Pop initial call.
+  EXPECT_TRUE(Q.pop_back())
+      << "At least one call should be sitting in the queue";
+  EXPECT_FALSE(Q.pop_back())
+      << "Exactly one call should have been sitting in the queue";
 }
 
 TEST_F(QueueingRunnerTest, RunFIFOUntilEmpty) {
@@ -68,13 +71,13 @@ TEST_F(QueueingRunnerTest, RunFIFOUntilEmpty) {
   for (uint64_t I = 0; I < 3; ++I)
     R(dummySession(), I, dummyReturn(), recordingFn, WrapperFunctionBuffer());
 
-  QueueingRunner<TaskQueue>::runFIFOUntilEmpty(Q);
+  QueueingRunner<>::runFIFOUntilEmpty(Q);
 
   ASSERT_EQ(Log.size(), 3u);
   EXPECT_EQ(Log[0].CallId, 0u);
   EXPECT_EQ(Log[1].CallId, 1u);
   EXPECT_EQ(Log[2].CallId, 2u);
-  EXPECT_TRUE(Q.empty());
+  EXPECT_FALSE(Q.pop_back()); // Expect queue to be empty.
 }
 
 TEST_F(QueueingRunnerTest, RunLIFOUntilEmpty) {
@@ -82,20 +85,20 @@ TEST_F(QueueingRunnerTest, RunLIFOUntilEmpty) {
   for (uint64_t I = 0; I < 3; ++I)
     R(dummySession(), I, dummyReturn(), recordingFn, WrapperFunctionBuffer());
 
-  QueueingRunner<TaskQueue>::runLIFOUntilEmpty(Q);
+  QueueingRunner<>::runLIFOUntilEmpty(Q);
 
   ASSERT_EQ(Log.size(), 3u);
   EXPECT_EQ(Log[0].CallId, 2u);
   EXPECT_EQ(Log[1].CallId, 1u);
   EXPECT_EQ(Log[2].CallId, 0u);
-  EXPECT_TRUE(Q.empty());
+  EXPECT_FALSE(Q.pop_back()); // Expect queue to be empty.
 }
 
 TEST_F(QueueingRunnerTest, DrainOnEmptyQueueIsNoOp) {
   // Both drain helpers should return immediately on an empty queue rather
   // than blocking.
-  QueueingRunner<TaskQueue>::runFIFOUntilEmpty(Q);
-  QueueingRunner<TaskQueue>::runLIFOUntilEmpty(Q);
+  QueueingRunner<>::runFIFOUntilEmpty(Q);
+  QueueingRunner<>::runLIFOUntilEmpty(Q);
   EXPECT_EQ(Log.size(), 0u);
 }
 
@@ -107,7 +110,7 @@ TEST_F(QueueingRunnerTest, DrainPicksUpCallsEnqueuedDuringDrain) {
   // First call enqueues a second call from inside its body. We use a custom
   // wrapper-function (not recordingFn) to do that, since recordingFn doesn't
   // know about the queue.
-  static QueueingRunner<TaskQueue> *PendingR = nullptr;
+  static QueueingRunner<> *PendingR = nullptr;
   PendingR = &R;
   static auto reentrantFn = [](orc_rt_SessionRef S, uint64_t CallId,
                                orc_rt_WrapperFunctionReturn,
@@ -122,12 +125,50 @@ TEST_F(QueueingRunnerTest, DrainPicksUpCallsEnqueuedDuringDrain) {
   R(dummySession(), /*CallId=*/0, dummyReturn(), reentrantFn,
     WrapperFunctionBuffer());
 
-  QueueingRunner<TaskQueue>::runFIFOUntilEmpty(Q);
+  QueueingRunner<>::runFIFOUntilEmpty(Q);
 
   ASSERT_EQ(Log.size(), 2u);
   EXPECT_EQ(Log[0].CallId, 0u);
   EXPECT_EQ(Log[1].CallId, 1u);
   PendingR = nullptr;
+}
+
+TEST_F(QueueingRunnerTest, ConcurrentProducerAndDrainer) {
+  // Verify that QueueingRunner's default WorkQueue (SynchronizedDeque)
+  // tolerates concurrent push from one thread and drain from another.
+  //
+  // A producer thread enqueues NumCalls wrapper-function invocations while
+  // the main thread spins draining the queue. Once the producer has finished
+  // enqueueing, the main thread joins it and then performs a final drain to
+  // pick up any tail of calls enqueued after its last loop iteration.
+  constexpr uint64_t NumCalls = 1024;
+
+  QueueingRunner<> R(Q);
+
+  std::thread Producer([&]() {
+    for (uint64_t I = 0; I < NumCalls; ++I)
+      R(dummySession(), I, dummyReturn(), recordingFn, WrapperFunctionBuffer());
+  });
+
+  // Drain concurrently with the producer. The drainer doesn't know when the
+  // producer is done, so we just spin until the producer thread has joined
+  // (after which a final drain will be definitive).
+  while (Log.size() < NumCalls) {
+    QueueingRunner<>::runFIFOUntilEmpty(Q);
+    std::this_thread::yield();
+  }
+
+  Producer.join();
+  QueueingRunner<>::runFIFOUntilEmpty(Q); // pick up any tail.
+
+  ASSERT_EQ(Log.size(), NumCalls);
+  // Producer enqueues in order 0..NumCalls; FIFO drain must observe the same
+  // order. (Concurrent draining doesn't reorder per-producer enqueues for a
+  // single producer.)
+  for (uint64_t I = 0; I < NumCalls; ++I)
+    EXPECT_EQ(Log[I].CallId, I);
+
+  EXPECT_FALSE(Q.pop_back()) << "Queue should be empty after final drain";
 }
 
 } // end anonymous namespace

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -28,8 +28,6 @@ using namespace orc_rt;
 using ::testing::Eq;
 using ::testing::Optional;
 
-using TaskQueue = std::deque<move_only_function<void()>>;
-
 class MockService : public Service {
 public:
   enum class Op { Detach, Shutdown };
@@ -269,10 +267,9 @@ private:
 };
 
 /// Build a PostFn for MockControllerAccess that pushes its work onto the
-/// supplied queue. With this, a single
-/// QueueingRunner<TaskQueue>::runFIFOUntilEmpty(Q) call advances both
-/// Session-side and controller-side work.
-inline MockControllerAccess::PostFn postOnto(TaskQueue &Q) {
+/// supplied queue. With this, a single QueueingRunner::runFIFOUntilEmpty(Q)
+/// call advances both Session-side and controller-side work.
+inline MockControllerAccess::PostFn postOnto(QueueingRunner<>::WorkQueue &Q) {
   return
       [&Q](move_only_function<void()> Work) { Q.push_back(std::move(Work)); };
 }
@@ -363,7 +360,7 @@ TEST(SessionTest, ScheduleShutdownFromOnDetachHandler) {
 
 TEST(SessionTest, RedundantAsyncShutdown) {
   // Check that redundant calls to shutdown have their callbacks run.
-  TaskQueue Tasks;
+  QueueingRunner<>::WorkQueue Tasks;
   Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
 
   // Initiate shutdown here, and wait for the on-shutdown callbacks to start
@@ -387,7 +384,7 @@ TEST(SessionTest, ExpectedShutdownSequenceWithNoActiveManagedCodeCalls) {
   bool SessionShutdownComplete = false;
 
   {
-    TaskQueue Tasks;
+    QueueingRunner<>::WorkQueue Tasks;
     Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
     S.addService(
         std::make_unique<MockService>(DetachOpIdx, ShutdownOpIdx, OpIdx));
@@ -403,7 +400,7 @@ TEST(SessionTest, ExpectedShutdownSequenceWithNoActiveManagedCodeCalls) {
 }
 
 TEST(SessionTest, ActiveManagedCallsDelayShutdown) {
-  TaskQueue Tasks;
+  QueueingRunner<>::WorkQueue Tasks;
   Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
 
   size_t OpIdx = 0;
@@ -646,12 +643,12 @@ TEST(SessionTest, TryCreateServiceFailure) {
 TEST(ControllerAccessTest, Basics) {
   // Test that we can set the ControllerAccess implementation and still shut
   // down as expected.
-  TaskQueue Tasks;
+  QueueingRunner<>::WorkQueue Tasks;
   Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
   S.attach(std::make_shared<MockControllerAccess>(S, postOnto(Tasks)),
            BootstrapInfo(S));
 
-  QueueingRunner<TaskQueue>::runFIFOUntilEmpty(Tasks);
+  QueueingRunner<>::runFIFOUntilEmpty(Tasks);
 }
 
 static void add_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
@@ -666,7 +663,7 @@ static void add_sps_wrapper(orc_rt_SessionRef S, uint64_t CallId,
 
 TEST(ControllerAccessTest, ValidCallToController) {
   // Simulate a call to a controller handler.
-  TaskQueue Tasks;
+  QueueingRunner<>::WorkQueue Tasks;
   Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
   S.attach(std::make_shared<MockControllerAccess>(S, postOnto(Tasks)),
            BootstrapInfo(S));
@@ -676,14 +673,14 @@ TEST(ControllerAccessTest, ValidCallToController) {
       S.callViaSession(reinterpret_cast<Session::HandlerTag>(add_sps_wrapper)),
       [&](Expected<int32_t> R) { Result = cantFail(std::move(R)); }, 41, 1);
 
-  QueueingRunner<TaskQueue>::runFIFOUntilEmpty(Tasks);
+  QueueingRunner<>::runFIFOUntilEmpty(Tasks);
 
   EXPECT_EQ(Result, 42);
 }
 
 TEST(ControllerAccessTest, CallToControllerBeforeAttach) {
   // Expect calls to the controller prior to attaching to fail.
-  TaskQueue Tasks;
+  QueueingRunner<>::WorkQueue Tasks;
   Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
 
   Error Err = Error::success();
@@ -700,7 +697,7 @@ TEST(ControllerAccessTest, CallToControllerBeforeAttach) {
 
 TEST(ControllerAccessTest, CallToControllerAfterDetach) {
   // Expect calls to the controller prior to attaching to fail.
-  TaskQueue Tasks;
+  QueueingRunner<>::WorkQueue Tasks;
   Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
   S.attach(std::make_shared<MockControllerAccess>(S, postOnto(Tasks)),
            BootstrapInfo(S));
@@ -721,7 +718,7 @@ TEST(ControllerAccessTest, CallToControllerAfterDetach) {
 
 TEST(ControllerAccessTest, CallFromController) {
   // Simulate a call from the controller.
-  TaskQueue Tasks;
+  QueueingRunner<>::WorkQueue Tasks;
   Session S(mockExecutorProcessInfo(), QueueingRunner(Tasks), noErrors);
   auto CA = std::make_shared<MockControllerAccess>(S, postOnto(Tasks));
   S.attach(CA, BootstrapInfo(S));
@@ -731,7 +728,7 @@ TEST(ControllerAccessTest, CallFromController) {
       CallViaMockControllerAccess(*CA, add_sps_wrapper),
       [&](Expected<int32_t> R) { Result = cantFail(std::move(R)); }, 41, 1);
 
-  QueueingRunner<TaskQueue>::runFIFOUntilEmpty(Tasks);
+  QueueingRunner<>::runFIFOUntilEmpty(Tasks);
 
   EXPECT_EQ(Result, 42);
 }


### PR DESCRIPTION
Adds orc_rt::detail::SynchronizedDeque<T>, a mutex-protected deque whose pop_front / pop_back return std::optional<T> (std::nullopt indicates the queue is empty), and makes it QueueingRunner's default WorkQueue type.

Using a synchronized queue type allows QueueingRunner to be used in multi-threaded contexts.

Updates SessionTest and InProcessControllerAccessTest to use the new default, and extends QueueingRunnerTest to cover the new contract.