### PR TITLE
[InstCombine] Add demanded-bits pext handling

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -2678,6 +2678,9 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     break;
   }
   case Intrinsic::pext: {
+    if (SimplifyDemandedInstructionBits(*II))
+      return II;
+
     const APInt *MaskC;
     if (match(II->getArgOperand(1), m_APInt(MaskC))) {
       unsigned MaskIdx, MaskLen;

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -2681,6 +2681,11 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     if (SimplifyDemandedInstructionBits(*II))
       return II;
 
+    Value *X;
+    if (match(II->getArgOperand(0),
+              m_c_And(m_Value(X), m_Specific(II->getArgOperand(1)))))
+      return replaceOperand(*II, 0, X);
+
     const APInt *MaskC;
     if (match(II->getArgOperand(1), m_APInt(MaskC))) {
       unsigned MaskIdx, MaskLen;

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -2681,11 +2681,6 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     if (SimplifyDemandedInstructionBits(*II))
       return II;
 
-    Value *X;
-    if (match(II->getArgOperand(0),
-              m_c_And(m_Value(X), m_Specific(II->getArgOperand(1)))))
-      return replaceOperand(*II, 0, X);
-
     const APInt *MaskC;
     if (match(II->getArgOperand(1), m_APInt(MaskC))) {
       unsigned MaskIdx, MaskLen;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -1104,6 +1104,35 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
         break;
       }
 
+      case Intrinsic::pext: {
+        APInt DemandedMaskRHS(APInt::getAllOnes(BitWidth));
+        if (SimplifyDemandedBits(I, 1, DemandedMaskRHS, RHSKnown, Q, Depth + 1))
+          return I;
+
+        APInt DemandedMaskLHS(BitWidth, 0);
+        unsigned M0 = 0, M1 = 0;
+        for (unsigned I = 0; I != BitWidth; ++I) {
+          if (!RHSKnown.Zero[I]) {
+            APInt Range = APInt::getBitsSet(BitWidth, M0, M1 + 1);
+            if (DemandedMask.intersects(Range))
+              DemandedMaskLHS.setBit(I);
+          }
+
+          if (RHSKnown.One[I])
+            ++M0, ++M1;
+          else if (!RHSKnown.Zero[I])
+            ++M1;
+        }
+
+        if (SimplifyDemandedBits(I, 0, DemandedMaskLHS, LHSKnown, Q, Depth + 1))
+          return I;
+
+        Known = KnownBits::pext(LHSKnown, RHSKnown);
+        KnownBitsComputed = true;
+
+        break;
+      }
+
       case Intrinsic::fshr:
       case Intrinsic::fshl: {
         const APInt *SA;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -1105,8 +1105,18 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
       }
 
       case Intrinsic::pext: {
-        APInt DemandedMaskRHS(APInt::getAllOnes(BitWidth));
-        if (SimplifyDemandedBits(I, 1, DemandedMaskRHS, RHSKnown, Q, Depth + 1))
+        RHSKnown = computeKnownBits(I->getOperand(1), I, Depth + 1);
+        unsigned N = DemandedMask.getActiveBits();
+        APInt DemandedMaskRHS(BitWidth, 0);
+        // pext result bits depend on the mask prefix through their rank.
+        for (unsigned Bit = 0; Bit != BitWidth && N != 0; ++Bit) {
+          DemandedMaskRHS.setBit(Bit);
+          if (RHSKnown.One[Bit])
+            --N;
+        }
+        if (ShrinkDemandedConstant(I, 1, DemandedMaskRHS) ||
+            SimplifyDemandedBits(I, 1, DemandedMaskRHS, RHSKnown, Q,
+                                 Depth + 1))
           return I;
 
         Value *X;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -1115,8 +1115,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
             --N;
         }
         if (ShrinkDemandedConstant(I, 1, DemandedMaskRHS) ||
-            SimplifyDemandedBits(I, 1, DemandedMaskRHS, RHSKnown, Q,
-                                 Depth + 1))
+            SimplifyDemandedBits(I, 1, DemandedMaskRHS, RHSKnown, Q, Depth + 1))
           return I;
 
         Value *X;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -1109,6 +1109,13 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
         if (SimplifyDemandedBits(I, 1, DemandedMaskRHS, RHSKnown, Q, Depth + 1))
           return I;
 
+        Value *X;
+        if (match(I->getOperand(0),
+                  m_c_And(m_Value(X), m_Specific(I->getOperand(1))))) {
+          replaceOperand(*I, 0, X);
+          return I;
+        }
+
         APInt DemandedMaskLHS(BitWidth, 0);
         unsigned M0 = 0, M1 = 0;
         for (unsigned I = 0; I != BitWidth; ++I) {

--- a/llvm/test/Analysis/ValueTracking/knownbits-pext.ll
+++ b/llvm/test/Analysis/ValueTracking/knownbits-pext.ll
@@ -66,8 +66,7 @@ define <2 x i1> @pext_zero_mask_known_zero_vector(<2 x i8> %x) nounwind {
 ; Negative: pext(x, 0b11001100) can have bits 0-3 set; can't prove bit 0 is zero.
 define i1 @pext_low_bits_not_known(i8 %x) nounwind {
 ; CHECK-LABEL: @pext_low_bits_not_known(
-; CHECK-NEXT:    [[PEXT:%.*]] = call i8 @llvm.pext.i8(i8 [[X:%.*]], i8 -52)
-; CHECK-NEXT:    [[AND:%.*]] = and i8 [[PEXT]], 1
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[X:%.*]], 4
 ; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[AND]], 0
 ; CHECK-NEXT:    ret i1 [[R]]
 ;
@@ -79,8 +78,7 @@ define i1 @pext_low_bits_not_known(i8 %x) nounwind {
 
 define <2 x i1> @pext_low_bits_not_known_vector(<2 x i8> %x) nounwind {
 ; CHECK-LABEL: @pext_low_bits_not_known_vector(
-; CHECK-NEXT:    [[PEXT:%.*]] = call <2 x i8> @llvm.pext.v2i8(<2 x i8> [[X:%.*]], <2 x i8> splat (i8 -52))
-; CHECK-NEXT:    [[AND:%.*]] = and <2 x i8> [[PEXT]], splat (i8 1)
+; CHECK-NEXT:    [[AND:%.*]] = and <2 x i8> [[X:%.*]], splat (i8 4)
 ; CHECK-NEXT:    [[R:%.*]] = icmp eq <2 x i8> [[AND]], zeroinitializer
 ; CHECK-NEXT:    ret <2 x i1> [[R]]
 ;

--- a/llvm/test/Transforms/InstCombine/pext.ll
+++ b/llvm/test/Transforms/InstCombine/pext.ll
@@ -102,3 +102,82 @@ define i64 @test_pext_64_constant_fold_2() nounwind readnone {
   ret i64 %1
 }
 
+define i32 @test_pext_and_constant_supermask_32(i32 %x) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_constant_supermask_32(
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 42)
+; CHECK-NEXT:    ret i32 [[TMP1]]
+;
+  %and = and i32 %x, 255
+  %1 = tail call i32 @llvm.pext.i32(i32 %and, i32 42)
+  ret i32 %1
+}
+
+define i64 @test_pext_and_constant_supermask_64(i64 %x) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_constant_supermask_64(
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i64 @llvm.pext.i64(i64 [[X:%.*]], i64 42)
+; CHECK-NEXT:    ret i64 [[TMP1]]
+;
+  %and = and i64 %x, 255
+  %1 = tail call i64 @llvm.pext.i64(i64 %and, i64 42)
+  ret i64 %1
+}
+
+define i32 @test_pext_and_known_zero_mask_32(i32 %x, i32 %y) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_known_zero_mask_32(
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], 42
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 [[M]])
+; CHECK-NEXT:    ret i32 [[TMP1]]
+;
+  %m = and i32 %y, 42
+  %and = and i32 %x, 63
+  %1 = tail call i32 @llvm.pext.i32(i32 %and, i32 %m)
+  ret i32 %1
+}
+
+define i32 @test_pext_and_known_zero_mask_multi_use_32(i32 %x, i32 %y) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_known_zero_mask_multi_use_32(
+; CHECK-NEXT:    [[M:%.*]] = and i32 [[Y:%.*]], 42
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], 63
+; CHECK-NEXT:    [[PEXT:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X]], i32 [[M]])
+; CHECK-NEXT:    [[USE:%.*]] = add nuw nsw i32 [[AND]], [[PEXT]]
+; CHECK-NEXT:    ret i32 [[USE]]
+;
+  %m = and i32 %y, 42
+  %and = and i32 %x, 63
+  %pext = tail call i32 @llvm.pext.i32(i32 %and, i32 %m)
+  %use = add i32 %and, %pext
+  ret i32 %use
+}
+
+define i32 @test_pext_and_constant_mask_32(i32 %x) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_constant_mask_32(
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 42)
+; CHECK-NEXT:    ret i32 [[TMP1]]
+;
+  %and = and i32 %x, 42
+  %1 = tail call i32 @llvm.pext.i32(i32 %and, i32 42)
+  ret i32 %1
+}
+
+define i32 @test_pext_and_unknown_mask_32(i32 %x, i32 %m) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_unknown_mask_32(
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], 63
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.pext.i32(i32 [[AND]], i32 [[M:%.*]])
+; CHECK-NEXT:    ret i32 [[TMP1]]
+;
+  %and = and i32 %x, 63
+  %1 = tail call i32 @llvm.pext.i32(i32 %and, i32 %m)
+  ret i32 %1
+}
+
+define i32 @test_pext_and_partial_demand_32(i32 %x) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_partial_demand_32(
+; CHECK-NEXT:    [[PEXT:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 42)
+; CHECK-NEXT:    [[USE:%.*]] = and i32 [[PEXT]], 1
+; CHECK-NEXT:    ret i32 [[USE]]
+;
+  %and = and i32 %x, 2
+  %pext = tail call i32 @llvm.pext.i32(i32 %and, i32 42)
+  %use = and i32 %pext, 1
+  ret i32 %use
+}

--- a/llvm/test/Transforms/InstCombine/pext.ll
+++ b/llvm/test/Transforms/InstCombine/pext.ll
@@ -192,12 +192,85 @@ define i32 @test_pext_and_unknown_mask_32(i32 %x, i32 %m) nounwind readnone {
 
 define i32 @test_pext_and_partial_demand_32(i32 %x) nounwind readnone {
 ; CHECK-LABEL: @test_pext_and_partial_demand_32(
-; CHECK-NEXT:    [[PEXT:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 42)
-; CHECK-NEXT:    [[USE:%.*]] = and i32 [[PEXT]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = lshr i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[USE:%.*]] = and i32 [[TMP1]], 1
 ; CHECK-NEXT:    ret i32 [[USE]]
 ;
   %and = and i32 %x, 2
   %pext = tail call i32 @llvm.pext.i32(i32 %and, i32 42)
   %use = and i32 %pext, 1
   ret i32 %use
+}
+
+define i32 @test_pext_rhs_lowest_known_one_32(i32 %x, i32 %y) nounwind readnone {
+; CHECK-LABEL: @test_pext_rhs_lowest_known_one_32(
+; CHECK-NEXT:    [[USE:%.*]] = and i32 [[X:%.*]], 1
+; CHECK-NEXT:    ret i32 [[USE]]
+;
+  %mask = or i32 %y, 1
+  %pext = tail call i32 @llvm.pext.i32(i32 %x, i32 %mask)
+  %use = and i32 %pext, 1
+  ret i32 %use
+}
+
+define i32 @test_pext_rhs_sparse_demand_32(i32 %x, i32 %y) nounwind readnone {
+; CHECK-LABEL: @test_pext_rhs_sparse_demand_32(
+; CHECK-NEXT:    [[MASK:%.*]] = or i32 [[Y:%.*]], 170
+; CHECK-NEXT:    [[PEXT:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 [[MASK]])
+; CHECK-NEXT:    [[USE:%.*]] = and i32 [[PEXT]], 8
+; CHECK-NEXT:    ret i32 [[USE]]
+;
+  %masked = and i32 %y, 341
+  %mask = or i32 %masked, 170
+  %pext = tail call i32 @llvm.pext.i32(i32 %x, i32 %mask)
+  %use = and i32 %pext, 8
+  ret i32 %use
+}
+
+define i32 @test_pext_rhs_insufficient_known_ones_32(i32 %x, i32 %y) nounwind readnone {
+; CHECK-LABEL: @test_pext_rhs_insufficient_known_ones_32(
+; CHECK-NEXT:    [[MASKED:%.*]] = and i32 [[Y:%.*]], 21
+; CHECK-NEXT:    [[MASK:%.*]] = or disjoint i32 [[MASKED]], 2
+; CHECK-NEXT:    [[PEXT:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 [[MASK]])
+; CHECK-NEXT:    [[USE:%.*]] = and i32 [[PEXT]], 3
+; CHECK-NEXT:    ret i32 [[USE]]
+;
+  %masked = and i32 %y, 21
+  %mask = or i32 %masked, 2
+  %pext = tail call i32 @llvm.pext.i32(i32 %x, i32 %mask)
+  %use = and i32 %pext, 3
+  ret i32 %use
+}
+
+define i32 @test_pext_rhs_low_four_known_ones_32(i32 %x, i32 %y) nounwind readnone {
+; CHECK-LABEL: @test_pext_rhs_low_four_known_ones_32(
+; CHECK-NEXT:    [[USE:%.*]] = and i32 [[X:%.*]], 15
+; CHECK-NEXT:    ret i32 [[USE]]
+;
+  %mask = or i32 %y, 15
+  %pext = tail call i32 @llvm.pext.i32(i32 %x, i32 %mask)
+  %use = and i32 %pext, 15
+  ret i32 %use
+}
+
+define i64 @test_pext_rhs_lowest_known_one_64(i64 %x, i64 %y) nounwind readnone {
+; CHECK-LABEL: @test_pext_rhs_lowest_known_one_64(
+; CHECK-NEXT:    [[USE:%.*]] = and i64 [[X:%.*]], 1
+; CHECK-NEXT:    ret i64 [[USE]]
+;
+  %mask = or i64 %y, 1
+  %pext = tail call i64 @llvm.pext.i64(i64 %x, i64 %mask)
+  %use = and i64 %pext, 1
+  ret i64 %use
+}
+
+define <2 x i32> @test_pext_rhs_lowest_known_one_v2i32(<2 x i32> %x, <2 x i32> %y) nounwind readnone {
+; CHECK-LABEL: @test_pext_rhs_lowest_known_one_v2i32(
+; CHECK-NEXT:    [[USE:%.*]] = and <2 x i32> [[X:%.*]], splat (i32 1)
+; CHECK-NEXT:    ret <2 x i32> [[USE]]
+;
+  %mask = or <2 x i32> %y, <i32 1, i32 1>
+  %pext = tail call <2 x i32> @llvm.pext.v2i32(<2 x i32> %x, <2 x i32> %mask)
+  %use = and <2 x i32> %pext, <i32 1, i32 1>
+  ret <2 x i32> %use
 }

--- a/llvm/test/Transforms/InstCombine/pext.ll
+++ b/llvm/test/Transforms/InstCombine/pext.ll
@@ -159,26 +159,6 @@ define i32 @test_pext_and_constant_mask_32(i32 %x) nounwind readnone {
   ret i32 %1
 }
 
-define i32 @test_pext_and_same_variable_mask_32(i32 %x, i32 %m) nounwind readnone {
-; CHECK-LABEL: @test_pext_and_same_variable_mask_32(
-; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 [[M:%.*]])
-; CHECK-NEXT:    ret i32 [[TMP1]]
-;
-  %and = and i32 %x, %m
-  %1 = tail call i32 @llvm.pext.i32(i32 %and, i32 %m)
-  ret i32 %1
-}
-
-define i32 @test_pext_and_same_variable_mask_commuted_32(i32 %x, i32 %m) nounwind readnone {
-; CHECK-LABEL: @test_pext_and_same_variable_mask_commuted_32(
-; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 [[M:%.*]])
-; CHECK-NEXT:    ret i32 [[TMP1]]
-;
-  %and = and i32 %m, %x
-  %1 = tail call i32 @llvm.pext.i32(i32 %and, i32 %m)
-  ret i32 %1
-}
-
 define i32 @test_pext_and_unknown_mask_32(i32 %x, i32 %m) nounwind readnone {
 ; CHECK-LABEL: @test_pext_and_unknown_mask_32(
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], 63

--- a/llvm/test/Transforms/InstCombine/pext.ll
+++ b/llvm/test/Transforms/InstCombine/pext.ll
@@ -159,6 +159,26 @@ define i32 @test_pext_and_constant_mask_32(i32 %x) nounwind readnone {
   ret i32 %1
 }
 
+define i32 @test_pext_and_same_variable_mask_32(i32 %x, i32 %m) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_same_variable_mask_32(
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 [[M:%.*]])
+; CHECK-NEXT:    ret i32 [[TMP1]]
+;
+  %and = and i32 %x, %m
+  %1 = tail call i32 @llvm.pext.i32(i32 %and, i32 %m)
+  ret i32 %1
+}
+
+define i32 @test_pext_and_same_variable_mask_commuted_32(i32 %x, i32 %m) nounwind readnone {
+; CHECK-LABEL: @test_pext_and_same_variable_mask_commuted_32(
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.pext.i32(i32 [[X:%.*]], i32 [[M:%.*]])
+; CHECK-NEXT:    ret i32 [[TMP1]]
+;
+  %and = and i32 %m, %x
+  %1 = tail call i32 @llvm.pext.i32(i32 %and, i32 %m)
+  ret i32 %1
+}
+
 define i32 @test_pext_and_unknown_mask_32(i32 %x, i32 %m) nounwind readnone {
 ; CHECK-LABEL: @test_pext_and_unknown_mask_32(
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], 63


### PR DESCRIPTION
I implemented this through SimplifyDemandedBits rather than adding a dedicated fold. For pext, compute which source bits can actually contribute to the demanded result bits from the mask, and then let the existing demanded-bits machinery simplify the source operand.
I added coverage for constant masks, masks with known-zero bits, partial-demanded results, an i64 case, and a multi-use case.
Fixes #204945