### PR TITLE
[RISCV][XCV] Add missing IsRV32 predicate to the XCVmac block

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -828,7 +828,7 @@ class PatCoreVMacGprGprUimm5 <string intr, string asm>
   : Pat<(!cast<Intrinsic>("int_riscv_cv_mac_" # intr) GPR:$rs1, GPR:$rs2, cv_tuimm5:$imm5),
         (!cast<RVInst>("CV_" # asm) GPR:$rs1, GPR:$rs2, cv_tuimm5:$imm5)>;
 
-let Predicates = [HasVendorXCVmac] in {
+let Predicates = [HasVendorXCVmac, IsRV32] in {
   def : PatCoreVMacGprGprGpr<"mac", "MAC">;
   def : PatCoreVMacGprGprGpr<"msu", "MSU">;
 


### PR DESCRIPTION
The XCVmac instruction block was missing the `IsRV32` predicate that every other XCV block already carries. `HasVendorXCVmac` on its own does not require RV32, so `-mtriple=riscv64 -mattr=+xcvmac` could select these RV32-only vendor instructions on RV64. Add `IsRV32` to the XCVmac block to match the other XCV extensions and prevent selecting invalid instructions on RV64.

Split out of #204879 at review request (one fix per PR).

Part of a CORE-V (XCV) series; see RFC: https://discourse.llvm.org/t/rfc-core-v-xcv-support-for-cv32e40p-clang-builtins-xcvsimd-intrinsics-and-generic-auto-selection/91111
