### PR TITLE
[RISCV][XCV] Relax long `cv.beqimm`/`cv.bneimm` branches

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
@@ -235,6 +235,10 @@ static unsigned getRelaxedOpcode(unsigned Opcode, ArrayRef<MCOperand> Operands,
     return RISCV::PseudoLongQC_E_BLTUI;
   case RISCV::QC_E_BGEUI:
     return RISCV::PseudoLongQC_E_BGEUI;
+  case RISCV::CV_BEQIMM:
+    return RISCV::PseudoLongCV_BEQIMM;
+  case RISCV::CV_BNEIMM:
+    return RISCV::PseudoLongCV_BNEIMM;
   }
 
   // Returning the original opcode means we cannot relax the instruction.
@@ -310,6 +314,8 @@ void RISCVAsmBackend::relaxInstruction(MCInst &Inst,
   case RISCV::QC_E_BGEI:
   case RISCV::QC_E_BLTUI:
   case RISCV::QC_E_BGEUI:
+  case RISCV::CV_BEQIMM:
+  case RISCV::CV_BNEIMM:
     Res.setOpcode(getRelaxedOpcode(Inst.getOpcode(), Inst.getOperands(), STI));
     Res.addOperand(Inst.getOperand(0));
     Res.addOperand(Inst.getOperand(1));

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
@@ -365,6 +365,10 @@ static unsigned getInvertedBranchOp(unsigned BrOp) {
     return RISCV::QC_E_BGEUI;
   case RISCV::PseudoLongQC_E_BGEUI:
     return RISCV::QC_E_BLTUI;
+  case RISCV::PseudoLongCV_BEQIMM:
+    return RISCV::CV_BNEIMM;
+  case RISCV::PseudoLongCV_BNEIMM:
+    return RISCV::CV_BEQIMM;
   }
 }
 
@@ -602,6 +606,8 @@ void RISCVMCCodeEmitter::encodeInstruction(const MCInst &MI,
   case RISCV::PseudoLongQC_BGEI:
   case RISCV::PseudoLongQC_BLTUI:
   case RISCV::PseudoLongQC_BGEUI:
+  case RISCV::PseudoLongCV_BEQIMM:
+  case RISCV::PseudoLongCV_BNEIMM:
     expandQCLongCondBrImm(MI, CB, Fixups, STI, 4);
     MCNumEmitted += 2;
     return;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -594,6 +594,13 @@ let Predicates = [HasVendorXCVbi, IsRV32] in {
   def CV_BNEIMM : CVInstImmBranch<0b111, (outs),
         (ins GPR:$rs1, simm5:$imm5, bare_simm13_lsb0:$imm12),
         "cv.bneimm", "$rs1, $imm5, $imm12">, Sched<[]>;
+  // Long-branch relaxation pseudos for cv.beqimm / cv.bneimm. These are emitted
+  // by the RISCVAsmBackend when the target of a CV_BEQIMM / CV_BNEIMM is
+  // further than +/-4 KiB away. Each expands to an inverted short cv.b{ne,eq}imm
+  // (4 bytes) plus an unconditional JAL trampoline (4 bytes). Reuses the
+  // LongBcciPseudo class from RISCVInstrInfo.td (size = 8 bytes, simm5 imm).
+  def PseudoLongCV_BEQIMM : LongBcciPseudo<simm5, 8>;
+  def PseudoLongCV_BNEIMM : LongBcciPseudo<simm5, 8>;
 }
 
 let Predicates = [HasVendorXCVmem, IsRV32] in {

--- a/llvm/test/MC/RISCV/corev/XCVbi-long-branch.s
+++ b/llvm/test/MC/RISCV/corev/XCVbi-long-branch.s
@@ -1,0 +1,37 @@
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+xcvbi %s \
+# RUN:   | llvm-objdump -dr -M no-aliases - \
+# RUN:   | FileCheck %s
+
+# cv.beqimm / cv.bneimm encode a 13-bit signed PC-relative offset
+# (+/-4094 bytes). A branch whose target is out of that range must be
+# relaxed by the assembler into an inverted short branch over a JAL
+# trampoline. An in-range branch stays a single instruction.
+
+.text
+
+# CHECK-LABEL: <far_beqimm>:
+# CHECK:        cv.bneimm a0, 0x3, 0x{{[0-9a-f]+}}
+# CHECK-NEXT:   jal zero, 0x{{[0-9a-f]+}} <target1>
+far_beqimm:
+  cv.beqimm a0, 3, target1
+  .space 8192
+target1:
+  ret
+
+# CHECK-LABEL: <far_bneimm>:
+# CHECK:        cv.beqimm a1, -0x5, 0x{{[0-9a-f]+}}
+# CHECK-NEXT:   jal zero, 0x{{[0-9a-f]+}} <target2>
+far_bneimm:
+  cv.bneimm a1, -5, target2
+  .space 8192
+target2:
+  ret
+
+# An in-range branch is not relaxed: a single cv.beqimm to the target.
+# CHECK-LABEL: <near_beqimm>:
+# CHECK:        cv.beqimm a0, 0x1, 0x{{[0-9a-f]+}} <target3>
+# CHECK-NOT:    jal zero
+near_beqimm:
+  cv.beqimm a0, 1, target3
+target3:
+  ret


### PR DESCRIPTION
`cv.beqimm` and `cv.bneimm` encode their target as a 13-bit signed PC-relative offset (+/-4094 bytes). Branches beyond that range were silently truncated by MC fixup application, producing wrong code with no diagnostic. Add `PseudoLongCV_BEQIMM`/`PseudoLongCV_BNEIMM` and the MC-layer relaxation flow (inverted short branch + JAL trampoline), mirroring the standard B-type and Qualcomm Xqcibi vendor branches.

**Tests:** `xcvbi-branch-relax.ll` (uses `-filetype=obj | llvm-objdump`, since MC-layer relaxation is only observable on object emission, not on textual asm).

Split out of #204879 at review request (one fix per PR).

Part of a CORE-V (XCV) series; see RFC: https://discourse.llvm.org/t/rfc-core-v-xcv-support-for-cv32e40p-clang-builtins-xcvsimd-intrinsics-and-generic-auto-selection/91111
