### PR TITLE
[AArch64] Correct latency calculation in runSVEPseudoTestForCPU test. NFC

### DIFF
--- a/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
@@ -87,6 +87,13 @@ void runSVEPseudoTestForCPU(const std::string &CPU) {
     int Latency = 0;
     int LatencyOrig = 0;
 
+    ASSERT_TRUE(SCDesc->isValid());
+    ASSERT_TRUE(SCDescOrig->isValid());
+    // We need to handle the variant if this becomes true
+    ASSERT_FALSE(SCDesc->isVariant());
+    ASSERT_FALSE(SCDescOrig->isVariant());
+    ASSERT_EQ(SCDesc->NumWriteLatencyEntries,
+              SCDescOrig->NumWriteLatencyEntries);
     for (unsigned DefIdx = 0, DefEnd = SCDesc->NumWriteLatencyEntries;
          DefIdx != DefEnd; ++DefIdx) {
       const MCWriteLatencyEntry *WLEntry =
@@ -94,11 +101,11 @@ void runSVEPseudoTestForCPU(const std::string &CPU) {
       const MCWriteLatencyEntry *WLEntryOrig =
           STI.getWriteLatencyEntry(SCDescOrig, DefIdx);
       Latency = std::max(Latency, static_cast<int>(WLEntry->Cycles));
-      LatencyOrig = std::max(Latency, static_cast<int>(WLEntryOrig->Cycles));
+      LatencyOrig =
+          std::max(LatencyOrig, static_cast<int>(WLEntryOrig->Cycles));
     }
 
     ASSERT_EQ(Latency, LatencyOrig);
-    ASSERT_TRUE(SCDesc->isValid());
   }
 }
 


### PR DESCRIPTION
It does not look like this caused problems in the pseudo scheduling tests, but is accumulating the wrong latency. I added extra checks that the NumWriteLatencyEntries were the same in both cases whilst I was here too.