### PR TITLE
[X86][Inline] Make ABI compatibility check more precise

### DIFF
--- a/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
+++ b/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
@@ -6765,23 +6765,19 @@ bool X86TTIImpl::areInlineCompatible(const Function *Caller,
 bool X86TTIImpl::areTypesABICompatible(const Function *Caller,
                                        const Function *Callee,
                                        ArrayRef<Type *> Types) const {
-  if (!BaseT::areTypesABICompatible(Caller, Callee, Types))
-    return false;
-
-  // If we get here, we know the target features match. If one function
-  // considers 512-bit vectors legal and the other does not, consider them
-  // incompatible.
   const TargetMachine &TM = getTLI()->getTargetMachine();
+  const TargetLowering *CallerTLI =
+      TM.getSubtargetImpl(*Caller)->getTargetLowering();
+  const TargetLowering *CalleeTLI =
+      TM.getSubtargetImpl(*Callee)->getTargetLowering();
 
-  if (TM.getSubtarget<X86Subtarget>(*Caller).useAVX512Regs() ==
-      TM.getSubtarget<X86Subtarget>(*Callee).useAVX512Regs())
-    return true;
-
-  // Consider the arguments compatible if they aren't vectors or aggregates.
-  // FIXME: Look at the size of vectors.
-  // FIXME: Look at the element types of aggregates to see if there are vectors.
-  return llvm::none_of(Types,
-      [](Type *T) { return T->isVectorTy() || T->isAggregateType(); });
+  LLVMContext &Ctx = Caller->getContext();
+  CallingConv::ID CC = Callee->getCallingConv();
+  return all_of(Types, [&](Type *Ty) {
+    EVT VT = CallerTLI->getValueType(DL, Ty);
+    return CallerTLI->getRegisterTypeForCallingConv(Ctx, CC, VT) ==
+           CalleeTLI->getRegisterTypeForCallingConv(Ctx, CC, VT);
+  });
 }
 
 X86TTIImpl::TTI::MemCmpExpansionOptions

--- a/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
+++ b/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
@@ -6719,21 +6719,24 @@ bool X86TTIImpl::areInlineCompatible(const Function *Caller,
   const TargetMachine &TM = getTLI()->getTargetMachine();
 
   // Work this as a subsetting of subtarget features.
-  const FeatureBitset &CallerBits =
-      TM.getSubtargetImpl(*Caller)->getFeatureBits();
-  const FeatureBitset &CalleeBits =
-      TM.getSubtargetImpl(*Callee)->getFeatureBits();
+  const X86Subtarget &CallerSubtarget = TM.getSubtarget<X86Subtarget>(*Caller);
+  const X86Subtarget &CalleeSubtarget = TM.getSubtarget<X86Subtarget>(*Callee);
+  const FeatureBitset &CallerBits = CallerSubtarget.getFeatureBits();
+  const FeatureBitset &CalleeBits = CalleeSubtarget.getFeatureBits();
 
-  // Check whether features are the same (apart from the ignore list).
+  // Check whether callee features are a subset of caller features
+  // (apart from the ignore list).
   FeatureBitset RealCallerBits = CallerBits & ~InlineFeatureIgnoreList;
   FeatureBitset RealCalleeBits = CalleeBits & ~InlineFeatureIgnoreList;
-  if (RealCallerBits == RealCalleeBits)
-    return true;
-
-  // If the features are a subset, we need to additionally check for calls
-  // that may become ABI-incompatible as a result of inlining.
   if ((RealCallerBits & RealCalleeBits) != RealCalleeBits)
     return false;
+
+  // If the features are not exactly the same (or there is a difference in
+  // AVX512 register usage), we need to additionally check for calls
+  // that may become ABI-incompatible as a result of inlining.
+  if (RealCallerBits == RealCalleeBits &&
+      CallerSubtarget.useAVX512Regs() == CalleeSubtarget.useAVX512Regs())
+    return true;
 
   for (const Instruction &I : instructions(Callee)) {
     if (const auto *CB = dyn_cast<CallBase>(&I)) {

--- a/llvm/test/Transforms/Inline/X86/call-abi-compatibility.ll
+++ b/llvm/test/Transforms/Inline/X86/call-abi-compatibility.ll
@@ -143,5 +143,138 @@ define internal <8 x i64> @callee_inline_asm(ptr %p0, i64 %k, ptr %p1, ptr %p2) 
   ret <8 x i64> %3
 }
 
+declare void @callee_128bit(<4 x float>)
+declare void @callee_256bit(<8 x float>)
+declare void @callee_512bit(<16 x float>)
+
+define void @callee_calls_128bit_baseline() {
+; CHECK-LABEL: define {{[^@]+}}@callee_calls_128bit_baseline() {
+; CHECK-NEXT:    call void @callee_128bit(<4 x float> zeroinitializer)
+; CHECK-NEXT:    ret void
+;
+  call void @callee_128bit(<4 x float> zeroinitializer)
+  ret void
+}
+
+; Okay to inline as +sse3 does not change the ABI of 128 bit vectors relative
+; to x86-64 baseline.
+define void @caller_calls_128bit_sse3() "target-features"="+sse3" {
+; CHECK-LABEL: define {{[^@]+}}@caller_calls_128bit_sse3
+; CHECK-SAME: () #[[ATTR3:[0-9]+]] {
+; CHECK-NEXT:    call void @callee_calls_128bit_baseline()
+; CHECK-NEXT:    ret void
+;
+  call void @callee_calls_128bit_baseline()
+  ret void
+}
+
+define void @callee_calls_256bit_baseline() {
+; CHECK-LABEL: define {{[^@]+}}@callee_calls_256bit_baseline() {
+; CHECK-NEXT:    call void @callee_256bit(<8 x float> zeroinitializer)
+; CHECK-NEXT:    ret void
+;
+  call void @callee_256bit(<8 x float> zeroinitializer)
+  ret void
+}
+
+; Okay to inline as +sse3 does not change the ABI of 256 bit vectors relative
+; to x86-64 baseline.
+define void @caller_calls_256bit_sse3() "target-features"="+sse3" {
+; CHECK-LABEL: define {{[^@]+}}@caller_calls_256bit_sse3
+; CHECK-SAME: () #[[ATTR3]] {
+; CHECK-NEXT:    call void @callee_calls_256bit_baseline()
+; CHECK-NEXT:    ret void
+;
+  call void @callee_calls_256bit_baseline()
+  ret void
+}
+
+; Can NOT inline as +avx changes the ABI of 256 bit vectors.
+define void @caller_calls_256bit_avx() "target-features"="+avx" {
+; CHECK-LABEL: define {{[^@]+}}@caller_calls_256bit_avx
+; CHECK-SAME: () #[[ATTR0]] {
+; CHECK-NEXT:    call void @callee_calls_256bit_baseline()
+; CHECK-NEXT:    ret void
+;
+  call void @callee_calls_256bit_baseline()
+  ret void
+}
+
+define void @callee_calls_256bit_avx() "target-features"="+avx" {
+; CHECK-LABEL: define {{[^@]+}}@callee_calls_256bit_avx
+; CHECK-SAME: () #[[ATTR0]] {
+; CHECK-NEXT:    call void @callee_256bit(<8 x float> zeroinitializer)
+; CHECK-NEXT:    ret void
+;
+  call void @callee_256bit(<8 x float> zeroinitializer)
+  ret void
+}
+
+; Okay to inline as +avx2 does not change the ABI of 256 bit vectors relative
+; to +avx.
+define void @caller_calls_256bit_avx2() "target-features"="+avx2" {
+; CHECK-LABEL: define {{[^@]+}}@caller_calls_256bit_avx2
+; CHECK-SAME: () #[[ATTR4:[0-9]+]] {
+; CHECK-NEXT:    call void @callee_calls_256bit_avx()
+; CHECK-NEXT:    ret void
+;
+  call void @callee_calls_256bit_avx()
+  ret void
+}
+
+define void @callee_calls_512bit_baseline() {
+; CHECK-LABEL: define {{[^@]+}}@callee_calls_512bit_baseline() {
+; CHECK-NEXT:    call void @callee_512bit(<16 x float> zeroinitializer)
+; CHECK-NEXT:    ret void
+;
+  call void @callee_512bit(<16 x float> zeroinitializer)
+  ret void
+}
+
+; Okay to inline as +sse3 does not change the ABI of 512 bit vectors relative
+; to x86-64 baseline.
+define void @caller_calls_512bit_sse3() "target-features"="+sse3" {
+; CHECK-LABEL: define {{[^@]+}}@caller_calls_512bit_sse3
+; CHECK-SAME: () #[[ATTR3]] {
+; CHECK-NEXT:    call void @callee_calls_512bit_baseline()
+; CHECK-NEXT:    ret void
+;
+  call void @callee_calls_512bit_baseline()
+  ret void
+}
+
+; Can NOT inline as +avx changes the ABI of 512 bit vectors.
+define void @caller_calls_512bit_avx() "target-features"="+avx" {
+; CHECK-LABEL: define {{[^@]+}}@caller_calls_512bit_avx
+; CHECK-SAME: () #[[ATTR0]] {
+; CHECK-NEXT:    call void @callee_calls_512bit_baseline()
+; CHECK-NEXT:    ret void
+;
+  call void @callee_calls_512bit_baseline()
+  ret void
+}
+
+define void @callee_calls_512bit_avx512f() "target-features"="+avx512f" {
+; CHECK-LABEL: define {{[^@]+}}@callee_calls_512bit_avx512f
+; CHECK-SAME: () #[[ATTR5:[0-9]+]] {
+; CHECK-NEXT:    call void @callee_512bit(<16 x float> zeroinitializer)
+; CHECK-NEXT:    ret void
+;
+  call void @callee_512bit(<16 x float> zeroinitializer)
+  ret void
+}
+
+; Okay to inline as +avx512bw does not change the ABI of 512 bit vectors
+;relative to +avx512f.
+define void @caller_calls_512bit_avx512bw() "target-features"="+avx512bw" {
+; CHECK-LABEL: define {{[^@]+}}@caller_calls_512bit_avx512bw
+; CHECK-SAME: () #[[ATTR6:[0-9]+]] {
+; CHECK-NEXT:    call void @callee_calls_512bit_avx512f()
+; CHECK-NEXT:    ret void
+;
+  call void @callee_calls_512bit_avx512f()
+  ret void
+}
+
 attributes #0 = { "min-legal-vector-width"="512" "target-features"="+avx,+avx2,+avx512bw,+avx512dq,+avx512f,+cmov,+crc32,+cx8,+evex512,+f16c,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave" "tune-cpu"="generic" }
 attributes #1 = { "min-legal-vector-width"="512" "target-features"="+avx,+avx2,+avx512bw,+avx512f,+cmov,+crc32,+cx8,+evex512,+f16c,+fma,+fxsr,+mmx,+popcnt,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave" "tune-cpu"="generic" }

--- a/llvm/test/Transforms/Inline/X86/call-abi-compatibility.ll
+++ b/llvm/test/Transforms/Inline/X86/call-abi-compatibility.ll
@@ -161,7 +161,7 @@ define void @callee_calls_128bit_baseline() {
 define void @caller_calls_128bit_sse3() "target-features"="+sse3" {
 ; CHECK-LABEL: define {{[^@]+}}@caller_calls_128bit_sse3
 ; CHECK-SAME: () #[[ATTR3:[0-9]+]] {
-; CHECK-NEXT:    call void @callee_calls_128bit_baseline()
+; CHECK-NEXT:    call void @callee_128bit(<4 x float> zeroinitializer)
 ; CHECK-NEXT:    ret void
 ;
   call void @callee_calls_128bit_baseline()
@@ -182,7 +182,7 @@ define void @callee_calls_256bit_baseline() {
 define void @caller_calls_256bit_sse3() "target-features"="+sse3" {
 ; CHECK-LABEL: define {{[^@]+}}@caller_calls_256bit_sse3
 ; CHECK-SAME: () #[[ATTR3]] {
-; CHECK-NEXT:    call void @callee_calls_256bit_baseline()
+; CHECK-NEXT:    call void @callee_256bit(<8 x float> zeroinitializer)
 ; CHECK-NEXT:    ret void
 ;
   call void @callee_calls_256bit_baseline()
@@ -215,7 +215,7 @@ define void @callee_calls_256bit_avx() "target-features"="+avx" {
 define void @caller_calls_256bit_avx2() "target-features"="+avx2" {
 ; CHECK-LABEL: define {{[^@]+}}@caller_calls_256bit_avx2
 ; CHECK-SAME: () #[[ATTR4:[0-9]+]] {
-; CHECK-NEXT:    call void @callee_calls_256bit_avx()
+; CHECK-NEXT:    call void @callee_256bit(<8 x float> zeroinitializer)
 ; CHECK-NEXT:    ret void
 ;
   call void @callee_calls_256bit_avx()
@@ -236,7 +236,7 @@ define void @callee_calls_512bit_baseline() {
 define void @caller_calls_512bit_sse3() "target-features"="+sse3" {
 ; CHECK-LABEL: define {{[^@]+}}@caller_calls_512bit_sse3
 ; CHECK-SAME: () #[[ATTR3]] {
-; CHECK-NEXT:    call void @callee_calls_512bit_baseline()
+; CHECK-NEXT:    call void @callee_512bit(<16 x float> zeroinitializer)
 ; CHECK-NEXT:    ret void
 ;
   call void @callee_calls_512bit_baseline()
@@ -269,7 +269,7 @@ define void @callee_calls_512bit_avx512f() "target-features"="+avx512f" {
 define void @caller_calls_512bit_avx512bw() "target-features"="+avx512bw" {
 ; CHECK-LABEL: define {{[^@]+}}@caller_calls_512bit_avx512bw
 ; CHECK-SAME: () #[[ATTR6:[0-9]+]] {
-; CHECK-NEXT:    call void @callee_calls_512bit_avx512f()
+; CHECK-NEXT:    call void @callee_512bit(<16 x float> zeroinitializer)
 ; CHECK-NEXT:    ret void
 ;
   call void @callee_calls_512bit_avx512f()

--- a/llvm/test/Transforms/Inline/X86/call-abi-compatibility.ll
+++ b/llvm/test/Transforms/Inline/X86/call-abi-compatibility.ll
@@ -265,7 +265,7 @@ define void @callee_calls_512bit_avx512f() "target-features"="+avx512f" {
 }
 
 ; Okay to inline as +avx512bw does not change the ABI of 512 bit vectors
-;relative to +avx512f.
+; relative to +avx512f.
 define void @caller_calls_512bit_avx512bw() "target-features"="+avx512bw" {
 ; CHECK-LABEL: define {{[^@]+}}@caller_calls_512bit_avx512bw
 ; CHECK-SAME: () #[[ATTR6:[0-9]+]] {
@@ -273,6 +273,26 @@ define void @caller_calls_512bit_avx512bw() "target-features"="+avx512bw" {
 ; CHECK-NEXT:    ret void
 ;
   call void @callee_calls_512bit_avx512f()
+  ret void
+}
+
+define void @callee_calls_512bit_vector_width_256() "target-features"="+avx512vl" "min-legal-vector-width"="256" "prefer-vector-width"="256" {
+; CHECK-LABEL: define {{[^@]+}}@callee_calls_512bit_vector_width_256
+; CHECK-SAME: () #[[ATTR7:[0-9]+]] {
+; CHECK-NEXT:    call void @callee_512bit(<16 x float> zeroinitializer)
+; CHECK-NEXT:    ret void
+;
+  call void @callee_512bit(<16 x float> zeroinitializer)
+  ret void
+}
+
+define void @caller_calls_512bit_vector_width_512() "target-features"="+avx512vl" "min-legal-vector-width"="512" "prefer-vector-width"="512" {
+; CHECK-LABEL: define {{[^@]+}}@caller_calls_512bit_vector_width_512
+; CHECK-SAME: () #[[ATTR8:[0-9]+]] {
+; CHECK-NEXT:    call void @callee_calls_512bit_vector_width_256()
+; CHECK-NEXT:    ret void
+;
+  call void @callee_calls_512bit_vector_width_256()
   ret void
 }
 

--- a/llvm/test/Transforms/PhaseOrdering/X86/loop-vectorizer-noalias.ll
+++ b/llvm/test/Transforms/PhaseOrdering/X86/loop-vectorizer-noalias.ll
@@ -27,9 +27,9 @@ define void @accsum(ptr noundef %vals, i64 noundef %num) #0 {
 ; CHECK-NEXT:    [[STORE_FORWARDED:%.*]] = phi i8 [ [[LOAD_INITIAL]], [[FOR_BODY_PREHEADER]] ], [ [[ADD_I:%.*]], [[FOR_BODY]] ]
 ; CHECK-NEXT:    [[I_02:%.*]] = phi i64 [ 1, [[FOR_BODY_PREHEADER]] ], [ [[INC:%.*]], [[FOR_BODY]] ]
 ; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds i8, ptr [[VALS]], i64 [[I_02]]
-; CHECK-NEXT:    [[TMP0:%.*]] = load i8, ptr [[ARRAYIDX]], align 1, !alias.scope [[META0:![0-9]+]], !noalias [[META3:![0-9]+]]
+; CHECK-NEXT:    [[TMP0:%.*]] = load i8, ptr [[ARRAYIDX]], align 1, !alias.scope [[META0:![0-9]+]]
 ; CHECK-NEXT:    [[ADD_I]] = add i8 [[TMP0]], [[STORE_FORWARDED]]
-; CHECK-NEXT:    store i8 [[ADD_I]], ptr [[ARRAYIDX]], align 1, !alias.scope [[META0]], !noalias [[META3]]
+; CHECK-NEXT:    store i8 [[ADD_I]], ptr [[ARRAYIDX]], align 1, !alias.scope [[META0]]
 ; CHECK-NEXT:    [[INC]] = add nuw i64 [[I_02]], 1
 ; CHECK-NEXT:    [[EXITCOND_NOT:%.*]] = icmp eq i64 [[INC]], [[NUM]]
 ; CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[FOR_END]], label [[FOR_BODY]]
@@ -73,6 +73,4 @@ attributes #0 = { "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87"}
 ; CHECK: [[META0]] = !{[[META1:![0-9]+]]}
 ; CHECK: [[META1]] = distinct !{[[META1]], [[META2:![0-9]+]], !"acc: %val"}
 ; CHECK: [[META2]] = distinct !{[[META2]], !"acc"}
-; CHECK: [[META3]] = !{[[META4:![0-9]+]]}
-; CHECK: [[META4]] = distinct !{[[META4]], [[META2]], !"acc: %prev"}
 ;.


### PR DESCRIPTION
When inlining a function that contains calls with vector arguments, we have to be careful that inlining does not change the ABI of the call. E.g. we generally can't inline a function without `+avx` into a function with `+avx` if there are calls using vectors of size 256 or larger, because they'd switch from passing in two xmm registers to passing in a ymm register.

However, the current check is very crude and only allows inlining with interior calls if the target features match *exactly* (via the base areTypesABICompatible implementation). This is unnecessarily conservative, as many target features do not affect the call ABI at all.

Make this check more precise by checking the result of getRegisterTypeForCallingConv for the type between the TLI instances for the caller and callee.