### PR TITLE
Fix test on read-only file systems

### DIFF
--- a/clang/test/AST/ByteCode/command-line-options.cpp
+++ b/clang/test/AST/ByteCode/command-line-options.cpp
@@ -6,11 +6,11 @@
 /// All this should be true if the driver is used or -cc1.
 
 
-// RUN: %clang -c   -fexperimental-new-constant-interpreter %s -Xclang -verify=bc
-// RUN: %clang -cc1 -fexperimental-new-constant-interpreter %s         -verify=bc
+// RUN: %clang -fsyntax-only -fexperimental-new-constant-interpreter %s -Xclang -verify=bc
+// RUN: %clang -cc1          -fexperimental-new-constant-interpreter %s         -verify=bc
 
-// RUN: %clang -c   -fno-experimental-new-constant-interpreter %s -Xclang -verify=nobc
-// RUN: %clang -cc1 -fno-experimental-new-constant-interpreter %s         -verify=nobc
+// RUN: %clang -fsyntax-only -fno-experimental-new-constant-interpreter %s -Xclang -verify=nobc
+// RUN: %clang -cc1          -fno-experimental-new-constant-interpreter %s         -verify=nobc
 
 
 /// Note that we're not testing the behavior without those command line options since that


### PR DESCRIPTION
Fixes 25e4057d49055a645dc6a51ae1f40ac647aaed5b.

Use the -fsyntax-only flag instead of -c.  This performs the necessary parsing and diagnostics verification (the actual intent of this test) without attempting to emit an object file.