### PR TITLE
Be more permissive on spaces in command line argument parsing

### DIFF
--- a/clang-tools-extra/clangd/test/did-change-configuration-params.test
+++ b/clang-tools-extra/clangd/test/did-change-configuration-params.test
@@ -48,7 +48,7 @@
 #
 # ERR: ASTWorker building file {{.*}}foo.c version 0 with command
 # ERR: [{{.*}}clangd-test2]
-# ERR: clang -c -Wall -Werror {{.*}} -- {{.*}}foo.c
+# ERR: clang -c -Wall -Werror{{.*}} -- {{.*}}foo.c
 ---
 {"jsonrpc":"2.0","id":5,"method":"shutdown"}
 ---


### PR DESCRIPTION
Fixes c888371ff0a3e10f8472676dc992f4347fca58d9.

This change properly accommodates both presence and absence of extra trailing arguments like -resource-dir.