### PR TITLE
[lldb][test] Fix TestHiddenIvars rebuild failures in hidden-ivars Makefile

### DIFF
--- a/lldb/test/API/lang/objc/hidden-ivars/Makefile
+++ b/lldb/test/API/lang/objc/hidden-ivars/Makefile
@@ -13,7 +13,7 @@ stripped: a.out.dSYM
 endif
 
 stripped: a.out libInternalDefiner.dylib
-	mkdir stripped
+	mkdir -p stripped
 	$(STRIP) -Sx a.out -o stripped/a.out
 	$(STRIP) -Sx libInternalDefiner.dylib -o stripped/libInternalDefiner.dylib
 ifneq "$(CODESIGN)" ""
@@ -23,5 +23,6 @@ ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -fs - stripped/libInternalDefiner.dylib
 endif
 ifeq "$(MAKE_DSYM)" "YES"
+	rm -rf stripped/a.out.dSYM
 	cp -r a.out.dSYM stripped/a.out.dSYM
 endif


### PR DESCRIPTION
Two rebuild-state bugs surfaced when running `./bin/lldb-dotest -p
TestHiddenIvars.py`:

```
FAILED (errors=6, skipped=7, expected failures=2)
```

1. `mkdir: stripped: File exists`, mkdir failed on the second build
   because the directory already existed.  Switch to `mkdir -p`.

2. `cp -r a.out.dSYM stripped/a.out.dSYM` recurses *into* the existing
   destination on rebuild, producing a nested `stripped/a.out.dSYM/
   a.out.dSYM/`.  The outer dSYM keeps its stale UUID, so lldb cannot
   match it to the freshly relinked stripped binary (which gets a new
   UUID per link via -Wl,-random_uuid), causing source breakpoints to
   fail to resolve.  Remove the destination before copying.
