### PR TITLE
[lldb][tests] Fix FS timing issue in `TestRerunAndExprDylib`.

### DIFF
--- a/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
+++ b/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
@@ -4,6 +4,9 @@ after rebuilding the a dynamic library flushes the scratch
 TypeSystems tied to that process.
 """
 
+import os
+import time
+
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
@@ -61,6 +64,12 @@ class TestRerunExprDylib(TestBase):
             }
         )
 
+        # Age the library file to 10 seconds in the past so that it is rebuilt
+        # and reloaded even on filesystems with 1s resolution.
+        fpath = self.getBuildArtifact(FULL_DYLIB_NAME)
+        old_mtime = time.time() - 10
+        os.utime(fpath, (old_mtime, old_mtime))
+
         # Build a.out
         self.build(
             dictionary={
@@ -83,9 +92,6 @@ class TestRerunExprDylib(TestBase):
             result_type="Foo",
             result_children=[ValueCheck(name="m_val", value="42")],
         )
-
-        # Delete the dylib to force make to rebuild it.
-        remove_file(self.getBuildArtifact(FULL_DYLIB_NAME))
 
         # Re-build libfoo.dylib
         self.build(


### PR DESCRIPTION
This PR fixes a timing issue that made `TestRerunAndExprDylib` fail with a small probability. The test rebuilds a library; however, the build and the re-build may fall into the same timestamp if the underlying filesystem only has second granularity such that LLDB doesn't reload the rebuilt library for the second execution.

The fix consists in artifically aging the library file from the first build, i.e., setting its timestamp 10 seconds into the past. This not only guarantees that LLDB reloads the file but also also that it is rebuilt, so the explicit removing is now unnecessary and removed.

This issue exists for at least six months, possible since the tests exists; I was not able to test older versions. However, we have recently seen frequent failures, probably due to some change in our underlying testing infrastructure.