### PR TITLE
[ARM] Selection should prefer immediates on the right hand side instead of shifted regs

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelDAGToDAG.cpp
+++ b/llvm/lib/Target/ARM/ARMISelDAGToDAG.cpp
@@ -188,6 +188,10 @@ public:
 private:
   void transferMemOperands(SDNode *Src, SDNode *Dst);
 
+  // Preference helper: for SUB with encodable immediate LHS, select RSBri
+  // and materialize any RHS shift first when needed. Returns true if handled.
+  bool tryPreferRSBForSUB(SDNode *N);
+
   /// Indexed (pre/post inc/dec) load matching code for ARM.
   bool tryARMIndexedLoad(SDNode *N);
   bool tryT1IndexedLoad(SDNode *N);
@@ -3588,6 +3592,81 @@ getContiguousRangeOfSetBits(const APInt &A) {
   return std::make_pair(FirstOne, LastOne);
 }
 
+bool ARMDAGToDAGISel::tryPreferRSBForSUB(SDNode *N) {
+  if (Subtarget->isThumb1Only())
+    return false;
+
+  SDValue LHS = N->getOperand(0);
+  SDValue RHS = N->getOperand(1);
+  const auto *CI = dyn_cast<ConstantSDNode>(LHS);
+  if (!CI)
+    return false;
+
+  unsigned Imm = (unsigned)CI->getZExtValue();
+  bool Encodable = Subtarget->isThumb() ? is_t2_so_imm(Imm) : is_so_imm(Imm);
+  if (!Encodable)
+    return false;
+
+  SDLoc dl(N);
+  SDValue Reg0 = CurDAG->getRegister(0, MVT::i32);
+  SDValue ImmOp = CurDAG->getTargetConstant(Imm, dl, MVT::i32);
+
+  // Materialize shift if RHS is shifted
+  ARM_AM::ShiftOpc ShOpcVal = ARM_AM::getShiftOpcForNode(RHS.getOpcode());
+  SDValue Rn = RHS;
+  if (ShOpcVal != ARM_AM::no_shift) {
+    const ConstantSDNode *ShC = dyn_cast<ConstantSDNode>(RHS.getOperand(1));
+    if (!ShC)
+      return false; // can't safely materialize variable shift here
+    unsigned ShAmt = ShC->getZExtValue();
+    if (Subtarget->isThumb()) {
+      unsigned ShOpc = 0;
+      switch (ShOpcVal) {
+      default:
+        ShOpc = 0;
+        break;
+      case ARM_AM::lsl:
+        ShOpc = ARM::t2LSLri;
+        break;
+      case ARM_AM::lsr:
+        ShOpc = ARM::t2LSRri;
+        break;
+      case ARM_AM::asr:
+        ShOpc = ARM::t2ASRri;
+        break;
+      case ARM_AM::ror:
+        ShOpc = ARM::t2RORri;
+        break;
+      }
+      if (!ShOpc)
+        return false;
+      SDValue ShAmtOp = CurDAG->getTargetConstant(ShAmt, dl, MVT::i32);
+      SDValue OpsShift[] = {RHS.getOperand(0), ShAmtOp, getAL(CurDAG, dl), Reg0,
+                            Reg0};
+      MachineSDNode *ShN =
+          CurDAG->getMachineNode(ShOpc, dl, MVT::i32, OpsShift);
+      Rn = SDValue(ShN, 0);
+    } else {
+      unsigned SOpc = ARM_AM::getSORegOpc(ShOpcVal, ShAmt);
+      SDValue ShImmOp = CurDAG->getTargetConstant(SOpc, dl, MVT::i32);
+      SDValue OpsShift[] = {RHS.getOperand(0), ShImmOp, getAL(CurDAG, dl), Reg0,
+                            Reg0};
+      MachineSDNode *ShN =
+          CurDAG->getMachineNode(ARM::MOVsi, dl, MVT::i32, OpsShift);
+      Rn = SDValue(ShN, 0);
+    }
+  }
+
+  if (Subtarget->isThumb()) {
+    SDValue Ops[] = {Rn, ImmOp, getAL(CurDAG, dl), Reg0, Reg0};
+    CurDAG->SelectNodeTo(N, ARM::t2RSBri, MVT::i32, Ops);
+  } else {
+    SDValue Ops[] = {Rn, ImmOp, getAL(CurDAG, dl), Reg0, Reg0};
+    CurDAG->SelectNodeTo(N, ARM::RSBri, MVT::i32, Ops);
+  }
+  return true;
+}
+
 void ARMDAGToDAGISel::SelectCMPZ(SDNode *N, bool &SwitchEQNEToPLMI) {
   assert(N->getOpcode() == ARMISD::CMPZ);
   SwitchEQNEToPLMI = false;
@@ -3737,6 +3816,10 @@ void ARMDAGToDAGISel::Select(SDNode *N) {
   case ISD::INLINEASM:
   case ISD::INLINEASM_BR:
     if (tryInlineAsm(N))
+      return;
+    break;
+  case ISD::SUB:
+    if (tryPreferRSBForSUB(N))
       return;
     break;
   case ISD::Constant: {

--- a/llvm/test/CodeGen/ARM/cmse-harden-entry-arguments.ll
+++ b/llvm/test/CodeGen/ARM/cmse-harden-entry-arguments.ll
@@ -297,8 +297,8 @@ define i32 @access_i65(ptr byval(i65) %0) "cmse_nonsecure_entry" {
 ; V8M-LE-NEXT:        ldrb.w r0, [sp, #8]
 ; V8M-LE-NEXT:        and r0, r0, #1
 ; V8M-LE-NEXT:        rsbs r0, r0, #0
-; V8M-BE-NEXT:        movs r1, #0
-; V8M-BE-NEXT:        sub.w r0, r1, r0, lsr #24
+; V8M-BE-NEXT:        lsrs r0, r0, #24
+; V8M-BE-NEXT:        rsbs r0, r0, #0
 ; V8M-COMMON-NEXT:    add sp, #16
 ; V8M-COMMON-NEXT:    mov r1, lr
 ; V8M-COMMON-NEXT:    mov r2, lr
@@ -316,8 +316,8 @@ define i32 @access_i65(ptr byval(i65) %0) "cmse_nonsecure_entry" {
 ; V81M-LE-NEXT:        ldrb.w r0, [sp, #8]
 ; V81M-LE-NEXT:        and r0, r0, #1
 ; V81M-LE-NEXT:        rsbs r0, r0, #0
-; V81M-BE-NEXT:        movs r1, #0
-; V81M-BE-NEXT:        sub.w r0, r1, r0, lsr #24
+; V81M-BE-NEXT:        lsrs r0, r0, #24
+; V81M-BE-NEXT:        rsbs r0, r0, #0
 ; V81M-COMMON-NEXT:    sub sp, #4
 ; V81M-COMMON-NEXT:    add sp, #16
 ; V81M-COMMON-NEXT:    vscclrm {s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, vpr}

--- a/llvm/test/Transforms/LoopStrengthReduce/ARM/ivchain-ARM.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/ARM/ivchain-ARM.ll
@@ -299,10 +299,10 @@ define hidden void @testNeon(ptr %ref_data, i32 %ref_stride, i32 %limit, ptr noc
 ; A9-NEXT:    cmp r2, #1
 ; A9-NEXT:    blt .LBB4_4
 ; A9-NEXT:  @ %bb.1: @ %.lr.ph
-; A9-NEXT:    movs r5, #0
 ; A9-NEXT:    movw r4, #64464
-; A9-NEXT:    sub.w r12, r5, r2, lsl #6
-; A9-NEXT:    sub.w lr, r1, r1, lsl #4
+; A9-NEXT:    lsls r5, r2, #6
+; A9-NEXT:    sub.w r12, r1, r1, lsl #4
+; A9-NEXT:    rsb.w lr, r5, #0
 ; A9-NEXT:    movt r4, #65535
 ; A9-NEXT:    mov r5, r3
 ; A9-NEXT:  .LBB4_2: @ =>This Inner Loop Header: Depth=1
@@ -319,13 +319,13 @@ define hidden void @testNeon(ptr %ref_data, i32 %ref_stride, i32 %limit, ptr noc
 ; A9-NEXT:    vst1.8 {d22, d23}, [r5]!
 ; A9-NEXT:    vld1.64 {d20}, [r0], r1
 ; A9-NEXT:    vadd.i8 q9, q9, q11
-; A9-NEXT:    vld1.64 {d21}, [r0], lr
+; A9-NEXT:    vld1.64 {d21}, [r0], r12
 ; A9-NEXT:    vadd.i8 q9, q9, q10
 ; A9-NEXT:    vadd.i8 q8, q8, q9
 ; A9-NEXT:    vst1.8 {d20, d21}, [r5], r4
 ; A9-NEXT:    bne .LBB4_2
 ; A9-NEXT:  @ %bb.3: @ %._crit_edge
-; A9-NEXT:    add.w r3, r3, r12, lsl #4
+; A9-NEXT:    add.w r3, r3, lr, lsl #4
 ; A9-NEXT:  .LBB4_4:
 ; A9-NEXT:    vst1.32 {d16, d17}, [r3]
 ; A9-NEXT:    pop {r4, r5, r7, pc}


### PR DESCRIPTION
On thumb2, this leads to more compression opportunities.

On ARM, This still leads to not having to move an immediate into a reg.