### PR TITLE
[SPIR-V] Add SPV_INTEL_bfloat16_arithmetic for Opencl.std instructions with bfloat16 type

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -14,10 +14,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// TODO: uses or report_fatal_error (which is also deprecated) /
-//       ReportFatalUsageError in this file should be refactored, as per LLVM
-//       best practices, to rely on the Diagnostic infrastructure (such as the
-//       reportUnsupported function below).
+// TODO: Per LLVM best practices, the report_fatal_error (deprecated) /
+//       ReportFatalUsageError calls in this file should be replaced with the
+//       Diagnostic infrastructure (e.g. the reportUnsupported function below).
 
 #include "SPIRVModuleAnalysis.h"
 #include "MCTargetDesc/SPIRVBaseInfo.h"
@@ -1691,10 +1690,12 @@ void addInstrRequirements(const MachineInstr &MI,
 
       if (UsesBFloat16) {
         if (!ST.canUseExtension(
-                SPIRV::Extension::SPV_INTEL_bfloat16_arithmetic))
+                SPIRV::Extension::SPV_INTEL_bfloat16_arithmetic)) {
           reportUnsupported(
               MI, "OpenCL Extended instructions with bfloat16 require the "
                   "following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic");
+          break;
+        }
         Reqs.addExtension(SPIRV::Extension::SPV_INTEL_bfloat16_arithmetic);
         Reqs.addCapability(SPIRV::Capability::BFloat16ArithmeticINTEL);
       }

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -16,7 +16,8 @@
 
 // TODO: uses or report_fatal_error (which is also deprecated) /
 //       ReportFatalUsageError in this file should be refactored, as per LLVM
-//       best practices, to rely on the Diagnostic infrastructure.
+//       best practices, to rely on the Diagnostic infrastructure (such as the
+//       reportUnsupported function below).
 
 #include "SPIRVModuleAnalysis.h"
 #include "MCTargetDesc/SPIRVBaseInfo.h"
@@ -55,6 +56,12 @@ char llvm::SPIRVModuleAnalysis::ID = 0;
 
 INITIALIZE_PASS(SPIRVModuleAnalysis, DEBUG_TYPE, "SPIRV module analysis", true,
                 true)
+
+static void reportUnsupported(const MachineInstr &MI, const char *Msg) {
+  const Function &Func = MI.getMF()->getFunction();
+  Func.getContext().diagnose(
+      DiagnosticInfoUnsupported(Func, Msg, MI.getDebugLoc()));
+}
 
 // Retrieve an unsigned from an MDNode with a list of them as operands.
 static unsigned getMetadataUInt(MDNode *MdNode, unsigned OpIndex,
@@ -1662,7 +1669,7 @@ void addInstrRequirements(const MachineInstr &MI,
     }
     if (MI.getOperand(2).getImm() ==
         static_cast<int64_t>(SPIRV::InstructionSet::OpenCL_std)) {
-      MachineFunction *MF = const_cast<MachineFunction *>(MI.getMF());
+      const MachineFunction *MF = MI.getMF();
       const MachineRegisterInfo &MRI = MF->getRegInfo();
       SPIRVGlobalRegistry *GR = ST.getSPIRVGlobalRegistry();
 
@@ -1678,16 +1685,16 @@ void addInstrRequirements(const MachineInstr &MI,
            ++I) {
         const MachineOperand &MO = MI.getOperand(I);
         if (MO.isReg())
-          UsesBFloat16 = IsBFloat16(GR->getResultType(MO.getReg(), MF));
+          UsesBFloat16 = IsBFloat16(GR->getResultType(
+              MO.getReg(), const_cast<MachineFunction *>(MF)));
       }
 
       if (UsesBFloat16) {
         if (!ST.canUseExtension(
                 SPIRV::Extension::SPV_INTEL_bfloat16_arithmetic))
-          report_fatal_error(
-              "Extended instructions with bfloat16 arguments require the "
-              "following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic",
-              false);
+          reportUnsupported(
+              MI, "OpenCL Extended instructions with bfloat16 require the "
+                  "following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic");
         Reqs.addExtension(SPIRV::Extension::SPV_INTEL_bfloat16_arithmetic);
       }
     }

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1696,6 +1696,7 @@ void addInstrRequirements(const MachineInstr &MI,
               MI, "OpenCL Extended instructions with bfloat16 require the "
                   "following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic");
         Reqs.addExtension(SPIRV::Extension::SPV_INTEL_bfloat16_arithmetic);
+        Reqs.addCapability(SPIRV::Capability::BFloat16ArithmeticINTEL);
       }
     }
     break;

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1660,8 +1660,38 @@ void addInstrRequirements(const MachineInstr &MI,
       addPrintfRequirements(MI, Reqs, ST);
       break;
     }
-    // TODO: handle bfloat16 extended instructions when
-    // SPV_INTEL_bfloat16_arithmetic is enabled.
+    if (MI.getOperand(2).getImm() ==
+        static_cast<int64_t>(SPIRV::InstructionSet::OpenCL_std)) {
+      MachineFunction *MF = const_cast<MachineFunction *>(MI.getMF());
+      const MachineRegisterInfo &MRI = MF->getRegInfo();
+      SPIRVGlobalRegistry *GR = ST.getSPIRVGlobalRegistry();
+
+      auto IsBFloat16 = [&](SPIRVTypeInst TypeDef) {
+        if (TypeDef && TypeDef->getOpcode() == SPIRV::OpTypeVector)
+          TypeDef = MRI.getVRegDef(TypeDef->getOperand(1).getReg());
+        return isBFloat16Type(TypeDef);
+      };
+
+      // Result type is operand 1; arguments start at operand 4.
+      bool UsesBFloat16 = IsBFloat16(MRI.getVRegDef(MI.getOperand(1).getReg()));
+      for (unsigned I = 4, E = MI.getNumOperands(); I < E && !UsesBFloat16;
+           ++I) {
+        const MachineOperand &MO = MI.getOperand(I);
+        if (MO.isReg())
+          UsesBFloat16 = IsBFloat16(GR->getResultType(MO.getReg(), MF));
+      }
+
+      // The OpenCL extended instruction set can operates on IEEE-754 encoding only
+      if (UsesBFloat16) {
+        if (!ST.canUseExtension(
+                SPIRV::Extension::SPV_INTEL_bfloat16_arithmetic))
+          report_fatal_error(
+              "Extended instructions with bfloat16 arguments require the "
+              "following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic",
+              false);
+        Reqs.addExtension(SPIRV::Extension::SPV_INTEL_bfloat16_arithmetic);
+      }
+    }
     break;
   }
   case SPIRV::OpAliasDomainDeclINTEL:

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1681,7 +1681,6 @@ void addInstrRequirements(const MachineInstr &MI,
           UsesBFloat16 = IsBFloat16(GR->getResultType(MO.getReg(), MF));
       }
 
-      // The OpenCL extended instruction set can operates on IEEE-754 encoding only
       if (UsesBFloat16) {
         if (!ST.canUseExtension(
                 SPIRV::Extension::SPV_INTEL_bfloat16_arithmetic))

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
@@ -1,17 +1,23 @@
 ; RUN: split-file %s %t
 
-; RUN: not --crash llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %t/bf16_result.ll -o /dev/null 2>&1 | FileCheck %s --check-prefix=RESULT-ERROR
-; RESULT-ERROR:      error: <unknown>:0:0: in function test_fabs bfloat (bfloat): OpenCL Extended instructions with bfloat16 require the
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %t/bf16_result_operand.ll -o /dev/null 2>&1 | FileCheck %s --check-prefix=RESULT-OPERAND-ERROR
+; RESULT-OPERAND-ERROR:      error: <unknown>:0:0: in function test_fabs bfloat (bfloat): OpenCL Extended instructions with bfloat16 require the
+; RESULT-OPERAND-ERROR-SAME:   following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic
+
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %t/bf16_result.ll -o /dev/null 2>&1 | FileCheck %s --check-prefix=RESULT-ERROR
+; RESULT-ERROR:      error: <unknown>:0:0: in function test_nan bfloat (i16): OpenCL Extended instructions with bfloat16 require the
 ; RESULT-ERROR-SAME:   following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic
 
-; RUN: not --crash llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %t/bf16_operand.ll -o /dev/null 2>&1 | FileCheck %s --check-prefix=OPERAND-ERROR
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %t/bf16_operand.ll -o /dev/null 2>&1 | FileCheck %s --check-prefix=OPERAND-ERROR
 ; OPERAND-ERROR:      error: <unknown>:0:0: in function test_ilogb i32 (bfloat): OpenCL Extended instructions with bfloat16 require the
 ; OPERAND-ERROR-SAME:   following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic
 
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_result_operand.ll -o - | FileCheck %s --check-prefixes=COMMON,BF16_RESULT_OPERAND
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_result.ll -o - | FileCheck %s --check-prefixes=COMMON,BF16_RESULT
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_operand.ll -o - | FileCheck %s --check-prefixes=COMMON,BF16_OPERAND
 
 ; TODO: re-enable spirv-val once it can verify SPV_INTEL_bfloat16_arithmetic with bfloat16 type on ExtInst
+; RUNx: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_result_operand.ll -o - -filetype=obj | spirv-val %}
 ; RUNx: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_result.ll -o - -filetype=obj | spirv-val %}
 ; RUNx: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_operand.ll -o - -filetype=obj | spirv-val %}
 
@@ -22,9 +28,17 @@
 ; COMMON-DAG: [[EXTSET:%.*]] = OpExtInstImport "OpenCL.std"
 ; COMMON-DAG: [[BFLOAT:%.*]] = OpTypeFloat 16 0
 
+; BF16_RESULT_OPERAND-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
+; BF16_RESULT_OPERAND: OpExtInst [[BFLOAT]] [[EXTSET]] fabs
+; BF16_RESULT_OPERAND: OpExtInst [[BFLOATV]] [[EXTSET]] fabs
+
+; BF16_RESULT-DAG: [[INT:%.*]] = OpTypeInt 16 0
+; BF16_RESULT-DAG: [[INTV:%.*]] = OpTypeVector [[INT]] 4
 ; BF16_RESULT-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
-; BF16_RESULT: OpExtInst [[BFLOAT]] [[EXTSET]] fabs
-; BF16_RESULT: OpExtInst [[BFLOATV]] [[EXTSET]] fabs
+; BF16_RESULT: [[OP:%.*]] = OpFunctionParameter [[INT]]
+; BF16_RESULT: OpExtInst [[BFLOAT]] [[EXTSET]] nan [[OP]]
+; BF16_RESULT: [[OPV:%.*]] = OpFunctionParameter [[INTV]]
+; BF16_RESULT: OpExtInst [[BFLOATV]] [[EXTSET]] nan [[OPV]]
 
 ; BF16_OPERAND-DAG: [[INT:%.*]] = OpTypeInt 32 0
 ; BF16_OPERAND-DAG: [[INTV:%.*]] = OpTypeVector [[INT]] 4
@@ -34,7 +48,7 @@
 ; BF16_OPERAND: [[OPV:%.*]] = OpFunctionParameter [[BFLOATV]]
 ; BF16_OPERAND: OpExtInst [[INTV]] [[EXTSET]] ilogb [[OPV]]
 
-;--- bf16_result.ll
+;--- bf16_result_operand.ll
 define spir_func bfloat @test_fabs(bfloat %x) {
   %r = call bfloat @llvm.fabs.bf16(bfloat %x)
   ret bfloat %r
@@ -47,6 +61,20 @@ define spir_func <4 x bfloat> @test_fabsv(<4 x bfloat> %x) {
 
 declare bfloat @llvm.fabs.bf16(bfloat)
 declare <4 x bfloat> @llvm.fabs.v4bf16(<4 x bfloat>)
+
+;--- bf16_result.ll
+define spir_func bfloat @test_nan(i16 %x) {
+  %r = call bfloat @_Z3nant(i16 %x)
+  ret bfloat %r
+}
+
+define spir_func <4 x bfloat> @test_nanv(<4 x i16> %x) {
+  %r = call <4 x bfloat> @_Z3nanDv4_t(<4 x i16> %x)
+  ret <4 x bfloat> %r
+}
+
+declare bfloat @_Z3nant(i16)
+declare <4 x bfloat> @_Z3nanDv4_t(<4 x i16>)
 
 ;--- bf16_operand.ll
 define spir_func i32 @test_ilogb(bfloat %x) {

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
@@ -15,7 +15,7 @@
 ; RUNx: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_result.ll -o - -filetype=obj | spirv-val %}
 ; RUNx: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_operand.ll -o - -filetype=obj | spirv-val %}
 
-; COMMON-NOT: OpCapability BFloat16ArithmeticINTEL
+; COMMON-DAG: OpCapability BFloat16ArithmeticINTEL
 ; COMMON-DAG: OpCapability BFloat16TypeKHR
 ; COMMON-DAG: OpExtension "SPV_KHR_bfloat16"
 ; COMMON-DAG: OpExtension "SPV_INTEL_bfloat16_arithmetic"

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
@@ -1,15 +1,21 @@
-; Without SPV_INTEL_bfloat16_arithmetic: report error.
-; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %s -o %t.spvt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
-; CHECK-ERROR: LLVM ERROR: Extended instructions with bfloat16 arguments require the following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic
+; RUN: split-file %s %t
 
-; With the extension: emit OpExtInst with OpExtension
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - | FileCheck %s --check-prefixes=COMMON,CHECK-FABS
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - | FileCheck %s --check-prefixes=COMMON,CHECK-FABSV
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - | FileCheck %s --check-prefixes=COMMON,CHECK-ILOGB
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - | FileCheck %s --check-prefixes=COMMON,CHECK-ILOGBV
+; RUN: not --crash llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %t/bf16_result.ll -o /dev/null 2>&1 | FileCheck %s --check-prefix=RESULT-ERROR
+; RESULT-ERROR:      error: <unknown>:0:0: in function test_fabs bfloat (bfloat): OpenCL Extended instructions with bfloat16 require the
+; RESULT-ERROR-SAME:   following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic
+
+; RUN: not --crash llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %t/bf16_operand.ll -o /dev/null 2>&1 | FileCheck %s --check-prefix=OPERAND-ERROR
+; OPERAND-ERROR:      error: <unknown>:0:0: in function test_ilogb i32 (bfloat): OpenCL Extended instructions with bfloat16 require the
+; OPERAND-ERROR-SAME:   following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_result.ll -o - | FileCheck %s \
+; RUN:   --check-prefixes=COMMON,BF16_RESULT
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_operand.ll -o - | FileCheck %s \
+; RUN:   --check-prefixes=COMMON,BF16_OPERAND
 
 ; TODO: re-enable spirv-val once it can verify SPV_INTEL_bfloat16_arithmetic with bfloat16 type on ExtInst
-; RUNx: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - -filetype=obj | spirv-val %}
+; RUNx: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_result.ll -o - -filetype=obj | spirv-val %}
+; RUNx: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_operand.ll -o - -filetype=obj | spirv-val %}
 
 ; COMMON-NOT: OpCapability BFloat16ArithmeticINTEL
 ; COMMON-DAG: OpCapability BFloat16TypeKHR
@@ -18,55 +24,39 @@
 ; COMMON-DAG: [[EXTSET:%.*]] = OpExtInstImport "OpenCL.std"
 ; COMMON-DAG: [[BFLOAT:%.*]] = OpTypeFloat 16 0
 
-; Scalar bfloat16 result and argument.
-; CHECK-FABS: OpFunction [[BFLOAT]]
-; CHECK-FABS: [[X:%.*]] = OpFunctionParameter [[BFLOAT]]
-; CHECK-FABS: OpExtInst [[BFLOAT]] [[EXTSET]] fabs [[X]]
+; BF16_RESULT-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
+; BF16_RESULT: OpExtInst [[BFLOAT]] [[EXTSET]] fabs
+; BF16_RESULT: OpExtInst [[BFLOATV]] [[EXTSET]] fabs
+
+; BF16_OPERAND-DAG: [[INT:%.*]] = OpTypeInt 32 0
+; BF16_OPERAND-DAG: [[INTV:%.*]] = OpTypeVector [[INT]] 4
+; BF16_OPERAND: OpExtInst [[INT]] [[EXTSET]] ilogb
+; BF16_OPERAND: OpExtInst [[INTV]] [[EXTSET]] ilogb
+
+;--- bf16_result.ll
 define spir_func bfloat @test_fabs(bfloat %x) {
-entry:
   %r = call bfloat @llvm.fabs.bf16(bfloat %x)
   ret bfloat %r
 }
 
-declare bfloat @llvm.fabs.bf16(bfloat)
-
-; Vector bfloat16 result and argument.
-; CHECK-FABSV-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
-; CHECK-FABSV: OpFunction [[BFLOATV]]
-; CHECK-FABSV: [[XV:%.*]] = OpFunctionParameter [[BFLOATV]]
-; CHECK-FABSV: OpExtInst [[BFLOATV]] [[EXTSET]] fabs [[XV]]
 define spir_func <4 x bfloat> @test_fabsv(<4 x bfloat> %x) {
-entry:
   %r = call <4 x bfloat> @llvm.fabs.v4bf16(<4 x bfloat> %x)
   ret <4 x bfloat> %r
 }
 
+declare bfloat @llvm.fabs.bf16(bfloat)
 declare <4 x bfloat> @llvm.fabs.v4bf16(<4 x bfloat>)
 
-; A non-bfloat16 (i32) result with a bfloat16 argument.
-; CHECK-ILOGB-DAG: [[INT:%.*]] = OpTypeInt 32 0
-; CHECK-ILOGB: OpFunction [[INT]]
-; CHECK-ILOGB: [[XI:%.*]] = OpFunctionParameter [[BFLOAT]]
-; CHECK-ILOGB: OpExtInst [[INT]] [[EXTSET]] ilogb [[XI]]
+;--- bf16_operand.ll
 define spir_func i32 @test_ilogb(bfloat %x) {
-entry:
-  %r = call i32 @_Z5ilogbDh(bfloat %x)
+  %r = call i32 @_Z5ilogbDF16_(bfloat %x)
   ret i32 %r
 }
 
-declare i32 @_Z5ilogbDh(bfloat)
-
-; Vector version of ilogb test.
-; CHECK-ILOGBV-DAG: [[INT:%.*]] = OpTypeInt 32 0
-; CHECK-ILOGBV-DAG: [[INTV:%.*]] = OpTypeVector [[INT]] 4
-; CHECK-ILOGBV-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
-; CHECK-ILOGBV: OpFunction [[INTV]]
-; CHECK-ILOGBV: [[XIV:%.*]] = OpFunctionParameter [[BFLOATV]]
-; CHECK-ILOGBV: OpExtInst [[INTV]] [[EXTSET]] ilogb [[XIV]]
 define spir_func <4 x i32> @test_ilogbv(<4 x bfloat> %x) {
-entry:
-  %r = call <4 x i32> @_Z5ilogbDv4_Dh(<4 x bfloat> %x)
+  %r = call <4 x i32> @_Z5ilogbDv4_DF16_(<4 x bfloat> %x)
   ret <4 x i32> %r
 }
 
-declare <4 x i32> @_Z5ilogbDv4_Dh(<4 x bfloat>)
+declare i32 @_Z5ilogbDF16_(bfloat)
+declare <4 x i32> @_Z5ilogbDv4_DF16_(<4 x bfloat>)

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
@@ -28,8 +28,11 @@
 
 ; BF16_OPERAND-DAG: [[INT:%.*]] = OpTypeInt 32 0
 ; BF16_OPERAND-DAG: [[INTV:%.*]] = OpTypeVector [[INT]] 4
-; BF16_OPERAND: OpExtInst [[INT]] [[EXTSET]] ilogb
-; BF16_OPERAND: OpExtInst [[INTV]] [[EXTSET]] ilogb
+; BF16_OPERAND-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
+; BF16_OPERAND: [[OP:%.*]] = OpFunctionParameter [[BFLOAT]]
+; BF16_OPERAND: OpExtInst [[INT]] [[EXTSET]] ilogb [[OP]]
+; BF16_OPERAND: [[OPV:%.*]] = OpFunctionParameter [[BFLOATV]]
+; BF16_OPERAND: OpExtInst [[INTV]] [[EXTSET]] ilogb [[OPV]]
 
 ;--- bf16_result.ll
 define spir_func bfloat @test_fabs(bfloat %x) {

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
@@ -1,0 +1,72 @@
+; Without SPV_INTEL_bfloat16_arithmetic: report error.
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %s -o %t.spvt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; CHECK-ERROR: LLVM ERROR: Extended instructions with bfloat16 arguments require the following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic
+
+; With the extension: emit OpExtInst with OpExtension
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - | FileCheck %s --check-prefixes=COMMON,CHECK-FABS
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - | FileCheck %s --check-prefixes=COMMON,CHECK-FABSV
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - | FileCheck %s --check-prefixes=COMMON,CHECK-ILOGB
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - | FileCheck %s --check-prefixes=COMMON,CHECK-ILOGBV
+
+; TODO: re-enable spirv-val once it can verify SPV_INTEL_bfloat16_arithmetic with bfloat16 type on ExtInst
+; RUNx: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - -filetype=obj | spirv-val %}
+
+; COMMON-NOT: OpCapability BFloat16ArithmeticINTEL
+; COMMON-DAG: OpCapability BFloat16TypeKHR
+; COMMON-DAG: OpExtension "SPV_KHR_bfloat16"
+; COMMON-DAG: OpExtension "SPV_INTEL_bfloat16_arithmetic"
+; COMMON-DAG: [[EXTSET:%.*]] = OpExtInstImport "OpenCL.std"
+; COMMON-DAG: [[BFLOAT:%.*]] = OpTypeFloat 16 0
+
+; Scalar bfloat16 result and argument.
+; CHECK-FABS: OpFunction [[BFLOAT]]
+; CHECK-FABS: [[X:%.*]] = OpFunctionParameter [[BFLOAT]]
+; CHECK-FABS: OpExtInst [[BFLOAT]] [[EXTSET]] fabs [[X]]
+define spir_func bfloat @test_fabs(bfloat %x) {
+entry:
+  %r = call bfloat @llvm.fabs.bf16(bfloat %x)
+  ret bfloat %r
+}
+
+declare bfloat @llvm.fabs.bf16(bfloat)
+
+; Vector bfloat16 result and argument.
+; CHECK-FABSV-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
+; CHECK-FABSV: OpFunction [[BFLOATV]]
+; CHECK-FABSV: [[XV:%.*]] = OpFunctionParameter [[BFLOATV]]
+; CHECK-FABSV: OpExtInst [[BFLOATV]] [[EXTSET]] fabs [[XV]]
+define spir_func <4 x bfloat> @test_fabsv(<4 x bfloat> %x) {
+entry:
+  %r = call <4 x bfloat> @llvm.fabs.v4bf16(<4 x bfloat> %x)
+  ret <4 x bfloat> %r
+}
+
+declare <4 x bfloat> @llvm.fabs.v4bf16(<4 x bfloat>)
+
+; A non-bfloat16 (i32) result with a bfloat16 argument.
+; CHECK-ILOGB-DAG: [[INT:%.*]] = OpTypeInt 32 0
+; CHECK-ILOGB: OpFunction [[INT]]
+; CHECK-ILOGB: [[XI:%.*]] = OpFunctionParameter [[BFLOAT]]
+; CHECK-ILOGB: OpExtInst [[INT]] [[EXTSET]] ilogb [[XI]]
+define spir_func i32 @test_ilogb(bfloat %x) {
+entry:
+  %r = call i32 @_Z5ilogbDh(bfloat %x)
+  ret i32 %r
+}
+
+declare i32 @_Z5ilogbDh(bfloat)
+
+; Vector version of ilogb test.
+; CHECK-ILOGBV-DAG: [[INT:%.*]] = OpTypeInt 32 0
+; CHECK-ILOGBV-DAG: [[INTV:%.*]] = OpTypeVector [[INT]] 4
+; CHECK-ILOGBV-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
+; CHECK-ILOGBV: OpFunction [[INTV]]
+; CHECK-ILOGBV: [[XIV:%.*]] = OpFunctionParameter [[BFLOATV]]
+; CHECK-ILOGBV: OpExtInst [[INTV]] [[EXTSET]] ilogb [[XIV]]
+define spir_func <4 x i32> @test_ilogbv(<4 x bfloat> %x) {
+entry:
+  %r = call <4 x i32> @_Z5ilogbDv4_Dh(<4 x bfloat> %x)
+  ret <4 x i32> %r
+}
+
+declare <4 x i32> @_Z5ilogbDv4_Dh(<4 x bfloat>)

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
@@ -8,10 +8,8 @@
 ; OPERAND-ERROR:      error: <unknown>:0:0: in function test_ilogb i32 (bfloat): OpenCL Extended instructions with bfloat16 require the
 ; OPERAND-ERROR-SAME:   following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic
 
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_result.ll -o - | FileCheck %s \
-; RUN:   --check-prefixes=COMMON,BF16_RESULT
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_operand.ll -o - | FileCheck %s \
-; RUN:   --check-prefixes=COMMON,BF16_OPERAND
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_result.ll -o - | FileCheck %s --check-prefixes=COMMON,BF16_RESULT
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_operand.ll -o - | FileCheck %s --check-prefixes=COMMON,BF16_OPERAND
 
 ; TODO: re-enable spirv-val once it can verify SPV_INTEL_bfloat16_arithmetic with bfloat16 type on ExtInst
 ; RUNx: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %t/bf16_result.ll -o - -filetype=obj | spirv-val %}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
@@ -27,14 +27,15 @@
 ; COMMON-DAG: OpExtension "SPV_INTEL_bfloat16_arithmetic"
 ; COMMON-DAG: [[EXTSET:%.*]] = OpExtInstImport "OpenCL.std"
 ; COMMON-DAG: [[BFLOAT:%.*]] = OpTypeFloat 16 0
+; COMMON-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
 
-; BF16_RESULT_OPERAND-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
-; BF16_RESULT_OPERAND: OpExtInst [[BFLOAT]] [[EXTSET]] fabs
-; BF16_RESULT_OPERAND: OpExtInst [[BFLOATV]] [[EXTSET]] fabs
+; BF16_RESULT_OPERAND: [[OP:%.*]] = OpFunctionParameter [[BFLOAT]]
+; BF16_RESULT_OPERAND: OpExtInst [[BFLOAT]] [[EXTSET]] fabs [[OP]]
+; BF16_RESULT_OPERAND: [[OPV:%.*]] = OpFunctionParameter [[BFLOATV]]
+; BF16_RESULT_OPERAND: OpExtInst [[BFLOATV]] [[EXTSET]] fabs [[OPV]]
 
 ; BF16_RESULT-DAG: [[INT:%.*]] = OpTypeInt 16 0
 ; BF16_RESULT-DAG: [[INTV:%.*]] = OpTypeVector [[INT]] 4
-; BF16_RESULT-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
 ; BF16_RESULT: [[OP:%.*]] = OpFunctionParameter [[INT]]
 ; BF16_RESULT: OpExtInst [[BFLOAT]] [[EXTSET]] nan [[OP]]
 ; BF16_RESULT: [[OPV:%.*]] = OpFunctionParameter [[INTV]]
@@ -42,7 +43,6 @@
 
 ; BF16_OPERAND-DAG: [[INT:%.*]] = OpTypeInt 32 0
 ; BF16_OPERAND-DAG: [[INTV:%.*]] = OpTypeVector [[INT]] 4
-; BF16_OPERAND-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
 ; BF16_OPERAND: [[OP:%.*]] = OpFunctionParameter [[BFLOAT]]
 ; BF16_OPERAND: OpExtInst [[INT]] [[EXTSET]] ilogb [[OP]]
 ; BF16_OPERAND: [[OPV:%.*]] = OpFunctionParameter [[BFLOATV]]


### PR DESCRIPTION
For `OpExtInst`, add check for bfloat16 type when it's an OpenCL.std extended instruction, and add requirements for SPV_INTEL_bfloat16_arithmetic if so.

Add such check and extension requirement since OpenCL.std extended instruction set can operate on IEEE-754 FP types only, as per the revision from [OpenCL.std spec](https://registry.khronos.org/SPIR-V/specs/unified1/OpenCL.ExtendedInstructionSet.100.html#_changes_from_version_1_0_revision_8)