### PR TITLE
[runtimes] Avoid duplicate static archive when shared libs are unsupported

### DIFF
--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -445,7 +445,21 @@ set(LIBCXX_INSTALL_RUNTIME_DIR "${CMAKE_INSTALL_BINDIR}" CACHE STRING
 set(LIBCXX_INSTALL_MODULES_DIR "share/libc++/v1" CACHE STRING
     "Path where target-agnostic libc++ module source files should be installed.")
 
-set(LIBCXX_SHARED_OUTPUT_NAME "c++" CACHE STRING "Output name for the shared libc++ runtime library.")
+# On platforms that don't support shared library targets (e.g. CMAKE_SYSTEM_NAME
+# of "Generic", used for GPU and other baremetal targets), CMake implicitly
+# changes shared library targets into static library targets. The shared target
+# is always defined even when LIBCXX_ENABLE_SHARED is off, so this would result
+# in two targets producing the same "libc++.a" output and break the build. Give
+# the shared library a different default output name in that case so it can't
+# collide with the static library.
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/25759.
+get_property(LIBCXX_TARGET_SUPPORTS_SHARED_LIBS GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS)
+if(DEFINED LIBCXX_TARGET_SUPPORTS_SHARED_LIBS AND NOT LIBCXX_TARGET_SUPPORTS_SHARED_LIBS)
+  set(LIBCXX_DEFAULT_SHARED_OUTPUT_NAME "c++-shared")
+else()
+  set(LIBCXX_DEFAULT_SHARED_OUTPUT_NAME "c++")
+endif()
+set(LIBCXX_SHARED_OUTPUT_NAME "${LIBCXX_DEFAULT_SHARED_OUTPUT_NAME}" CACHE STRING "Output name for the shared libc++ runtime library.")
 set(LIBCXX_STATIC_OUTPUT_NAME "c++" CACHE STRING "Output name for the static libc++ runtime library.")
 
 # TODO: Use common runtimes infrastructure for output and install paths

--- a/libcxxabi/CMakeLists.txt
+++ b/libcxxabi/CMakeLists.txt
@@ -89,7 +89,21 @@ set(LIBCXXABI_LIBDIR_SUFFIX "${LLVM_LIBDIR_SUFFIX}" CACHE STRING
 option(LIBCXXABI_INSTALL_HEADERS "Install the libc++abi headers." ON)
 option(LIBCXXABI_INSTALL_LIBRARY "Install the libc++abi library." ON)
 
-set(LIBCXXABI_SHARED_OUTPUT_NAME "c++abi" CACHE STRING "Output name for the shared libc++abi runtime library.")
+# On platforms that don't support shared library targets (e.g. CMAKE_SYSTEM_NAME
+# of "Generic", used for GPU and other baremetal targets), CMake implicitly
+# changes shared library targets into static library targets. The shared target
+# is always defined even when LIBCXXABI_ENABLE_SHARED is off, so this would
+# result in two targets producing the same "libc++abi.a" output and break the
+# build. Give the shared library a different default output name in that case so
+# it can't collide with the static library.
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/25759.
+get_property(LIBCXXABI_TARGET_SUPPORTS_SHARED_LIBS GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS)
+if(DEFINED LIBCXXABI_TARGET_SUPPORTS_SHARED_LIBS AND NOT LIBCXXABI_TARGET_SUPPORTS_SHARED_LIBS)
+  set(LIBCXXABI_DEFAULT_SHARED_OUTPUT_NAME "c++abi-shared")
+else()
+  set(LIBCXXABI_DEFAULT_SHARED_OUTPUT_NAME "c++abi")
+endif()
+set(LIBCXXABI_SHARED_OUTPUT_NAME "${LIBCXXABI_DEFAULT_SHARED_OUTPUT_NAME}" CACHE STRING "Output name for the shared libc++abi runtime library.")
 set(LIBCXXABI_STATIC_OUTPUT_NAME "c++abi" CACHE STRING "Output name for the static libc++abi runtime library.")
 
 set(LIBCXXABI_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}/c++/v1" CACHE STRING "Path to install the libc++abi headers at.")

--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -137,7 +137,21 @@ set(LIBUNWIND_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}" CACHE STRING
 set(LIBUNWIND_INSTALL_RUNTIME_DIR "${CMAKE_INSTALL_BINDIR}" CACHE STRING
     "Path where built libunwind runtime libraries should be installed.")
 
-set(LIBUNWIND_SHARED_OUTPUT_NAME "unwind" CACHE STRING "Output name for the shared libunwind runtime library.")
+# On platforms that don't support shared library targets (e.g. CMAKE_SYSTEM_NAME
+# of "Generic", used for GPU and other baremetal targets), CMake implicitly
+# changes shared library targets into static library targets. The shared target
+# is always defined even when LIBUNWIND_ENABLE_SHARED is off, so this would
+# result in two targets producing the same "libunwind.a" output and break the
+# build. Give the shared library a different default output name in that case so
+# it can't collide with the static library.
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/25759.
+get_property(LIBUNWIND_TARGET_SUPPORTS_SHARED_LIBS GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS)
+if(DEFINED LIBUNWIND_TARGET_SUPPORTS_SHARED_LIBS AND NOT LIBUNWIND_TARGET_SUPPORTS_SHARED_LIBS)
+  set(LIBUNWIND_DEFAULT_SHARED_OUTPUT_NAME "unwind-shared")
+else()
+  set(LIBUNWIND_DEFAULT_SHARED_OUTPUT_NAME "unwind")
+endif()
+set(LIBUNWIND_SHARED_OUTPUT_NAME "${LIBUNWIND_DEFAULT_SHARED_OUTPUT_NAME}" CACHE STRING "Output name for the shared libunwind runtime library.")
 set(LIBUNWIND_STATIC_OUTPUT_NAME "unwind" CACHE STRING "Output name for the static libunwind runtime library.")
 
 # TODO: Use common runtimes infrastructure for output and install paths


### PR DESCRIPTION
After #203504, runtime sub-builds for GPU/baremetal targets are configured
with CMAKE_SYSTEM_NAME=Generic rather than inheriting the host's system
name. CMake's Platform/Generic.cmake sets the global
TARGET_SUPPORTS_SHARED_LIBS property to FALSE, which causes CMake to
silently turn SHARED library targets into STATIC ones.

libcxx, libcxxabi and libunwind always define their shared library target
(gated by EXCLUDE_FROM_ALL) even when *_ENABLE_SHARED is off, and the shared
and static targets share the same OUTPUT_NAME. With the shared target demoted
to a static archive, both targets generate e.g. "libc++abi.a", which Ninja
rejects:

  ninja: error: build.ninja:147837: multiple rules generate
  lib/amdgcn-amd-amdhsa/libc++abi.a [-w dupbuild=err]

Default the shared library output name to a distinct "-shared" name when the
platform does not support shared libraries, mirroring the existing workaround
in libcxx/cmake/caches/Armv7M-picolibc.cmake. This makes the GPU and other
Generic-targeted runtimes builds configure again.

See https://gitlab.kitware.com/cmake/cmake/-/issues/25759.

This was generated by AI. This is the quick fix, I have a more
comprehensive patch pending.

Co-Authored-By: Claude <noreply@anthropic.com>