### PR TITLE
Class for checking floating-point properties

### DIFF
--- a/llvm/include/llvm/Analysis/InstSimplifyFolder.h
+++ b/llvm/include/llvm/Analysis/InstSimplifyFolder.h
@@ -66,12 +66,12 @@ public:
 
   Value *FoldBinOpFMF(Instruction::BinaryOps Opc, Value *LHS, Value *RHS,
                       FastMathFlags FMF) const override {
-    return simplifyBinOp(Opc, LHS, RHS, FMF, SQ);
+    return simplifyBinOp(Opc, LHS, RHS, FPTransformChecker(FMF), SQ);
   }
 
   Value *FoldUnOpFMF(Instruction::UnaryOps Opc, Value *V,
                       FastMathFlags FMF) const override {
-    return simplifyUnOp(Opc, V, FMF, SQ);
+    return simplifyUnOp(Opc, V, FPTransformChecker(FMF), SQ);
   }
 
   Value *FoldCmp(CmpInst::Predicate P, Value *LHS, Value *RHS) const override {
@@ -121,9 +121,9 @@ public:
   }
 
   Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
-                       FastMathFlags FMF = {},
+                       FPTransformChecker Checker = {},
                        Function *CtxF = nullptr) const override {
-    return simplifyIntrinsic(ID, Ty, Ops, FMF, SQ, CtxF);
+    return simplifyIntrinsic(ID, Ty, Ops, Checker, SQ, CtxF);
   }
 
   //===--------------------------------------------------------------------===//

--- a/llvm/include/llvm/Analysis/InstructionSimplify.h
+++ b/llvm/include/llvm/Analysis/InstructionSimplify.h
@@ -33,6 +33,7 @@
 
 #include "llvm/Analysis/SimplifyQuery.h"
 #include "llvm/IR/FPEnv.h"
+#include "llvm/IR/FPTransformChecker.h"
 #include "llvm/Support/Compiler.h"
 
 namespace llvm {
@@ -87,53 +88,40 @@ LLVM_ABI Value *simplifyURemInst(Value *LHS, Value *RHS,
                                  const SimplifyQuery &Q);
 
 /// Given operand for an FNeg, fold the result or return null.
-LLVM_ABI Value *simplifyFNegInst(Value *Op, FastMathFlags FMF,
-                                 const SimplifyQuery &Q);
+LLVM_ABI Value *simplifyFNegInst(Value *Op, const SimplifyQuery &Q);
 
 /// Given operands for an FAdd, fold the result or return null.
-LLVM_ABI Value *
-simplifyFAddInst(Value *LHS, Value *RHS, FastMathFlags FMF,
-                 const SimplifyQuery &Q,
-                 fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                 RoundingMode Rounding = RoundingMode::NearestTiesToEven);
+LLVM_ABI Value *simplifyFAddInst(Value *LHS, Value *RHS,
+                                 FPTransformChecker Checker,
+                                 const SimplifyQuery &Q);
 
 /// Given operands for an FSub, fold the result or return null.
-LLVM_ABI Value *
-simplifyFSubInst(Value *LHS, Value *RHS, FastMathFlags FMF,
-                 const SimplifyQuery &Q,
-                 fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                 RoundingMode Rounding = RoundingMode::NearestTiesToEven);
+LLVM_ABI Value *simplifyFSubInst(Value *LHS, Value *RHS,
+                                 FPTransformChecker Checker,
+                                 const SimplifyQuery &Q);
 
 /// Given operands for an FMul, fold the result or return null.
-LLVM_ABI Value *
-simplifyFMulInst(Value *LHS, Value *RHS, FastMathFlags FMF,
-                 const SimplifyQuery &Q,
-                 fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                 RoundingMode Rounding = RoundingMode::NearestTiesToEven);
+LLVM_ABI Value *simplifyFMulInst(Value *LHS, Value *RHS,
+                                 FPTransformChecker Checker,
+                                 const SimplifyQuery &Q);
 
 /// Given operands for the multiplication of a FMA, fold the result or return
 /// null. In contrast to simplifyFMulInst, this function will not perform
 /// simplifications whose unrounded results differ when rounded to the argument
 /// type.
-LLVM_ABI Value *
-simplifyFMAFMul(Value *LHS, Value *RHS, FastMathFlags FMF,
-                const SimplifyQuery &Q,
-                fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                RoundingMode Rounding = RoundingMode::NearestTiesToEven);
+LLVM_ABI Value *simplifyFMAFMul(Value *LHS, Value *RHS,
+                                FPTransformChecker Checker,
+                                const SimplifyQuery &Q);
 
 /// Given operands for an FDiv, fold the result or return null.
-LLVM_ABI Value *
-simplifyFDivInst(Value *LHS, Value *RHS, FastMathFlags FMF,
-                 const SimplifyQuery &Q,
-                 fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                 RoundingMode Rounding = RoundingMode::NearestTiesToEven);
+LLVM_ABI Value *simplifyFDivInst(Value *LHS, Value *RHS,
+                                 FPTransformChecker Checker,
+                                 const SimplifyQuery &Q);
 
 /// Given operands for an FRem, fold the result or return null.
-LLVM_ABI Value *
-simplifyFRemInst(Value *LHS, Value *RHS, FastMathFlags FMF,
-                 const SimplifyQuery &Q,
-                 fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                 RoundingMode Rounding = RoundingMode::NearestTiesToEven);
+LLVM_ABI Value *simplifyFRemInst(Value *LHS, Value *RHS,
+                                 FPTransformChecker Checker,
+                                 const SimplifyQuery &Q);
 
 /// Given operands for a Shl, fold the result or return null.
 LLVM_ABI Value *simplifyShlInst(Value *Op0, Value *Op1, bool IsNSW, bool IsNUW,
@@ -197,12 +185,11 @@ LLVM_ABI Value *simplifyCastInst(unsigned CastOpc, Value *Op, Type *Ty,
 /// Given operands for an intrinsic, fold the result or return null. Context
 /// Function is passed as \p CxtF. \p ExBehavior and \p Rounding only apply to
 /// constrained FP intrinsics.
-LLVM_ABI Value *
-simplifyIntrinsic(Intrinsic::ID IID, Type *ReturnType, ArrayRef<Value *> Args,
-                  FastMathFlags FMF, const SimplifyQuery &Q,
-                  Function *CxtF = nullptr,
-                  fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                  RoundingMode Rounding = RoundingMode::NearestTiesToEven);
+LLVM_ABI Value *simplifyIntrinsic(Intrinsic::ID IID, Type *ReturnType,
+                                  ArrayRef<Value *> Args,
+                                  FPTransformChecker Checker,
+                                  const SimplifyQuery &Q,
+                                  Function *CxtF = nullptr);
 
 /// Given operands for a ShuffleVectorInst, fold the result or return null.
 /// See class ShuffleVectorInst for a description of the mask representation.
@@ -222,7 +209,8 @@ LLVM_ABI Value *simplifyUnOp(unsigned Opcode, Value *Op,
 
 /// Given operand for a UnaryOperator, fold the result or return null.
 /// Try to use FastMathFlags when folding the result.
-LLVM_ABI Value *simplifyUnOp(unsigned Opcode, Value *Op, FastMathFlags FMF,
+LLVM_ABI Value *simplifyUnOp(unsigned Opcode, Value *Op,
+                             FPTransformChecker Checker,
                              const SimplifyQuery &Q);
 
 /// Given operands for a BinaryOperator, fold the result or return null.
@@ -232,7 +220,8 @@ LLVM_ABI Value *simplifyBinOp(unsigned Opcode, Value *LHS, Value *RHS,
 /// Given operands for a BinaryOperator, fold the result or return null.
 /// Try to use FastMathFlags when folding the result.
 LLVM_ABI Value *simplifyBinOp(unsigned Opcode, Value *LHS, Value *RHS,
-                              FastMathFlags FMF, const SimplifyQuery &Q);
+                              FPTransformChecker Checker,
+                              const SimplifyQuery &Q);
 
 /// Given a callsite, callee, and arguments, fold the result or return null.
 LLVM_ABI Value *simplifyCall(CallBase *Call, Value *Callee,

--- a/llvm/include/llvm/Analysis/TargetFolder.h
+++ b/llvm/include/llvm/Analysis/TargetFolder.h
@@ -192,7 +192,7 @@ public:
   }
 
   Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
-                       FastMathFlags FMF = {},
+                       FPTransformChecker Checker = {},
                        Function *CtxF = nullptr) const override {
     if (all_of(Ops, IsaPred<Constant>))
       return ConstantFoldIntrinsic(

--- a/llvm/include/llvm/IR/ConstantFolder.h
+++ b/llvm/include/llvm/IR/ConstantFolder.h
@@ -183,7 +183,8 @@ public:
   }
 
   Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
-                       FastMathFlags FMF, Function *CtxF) const override {
+                       FPTransformChecker Checker,
+                       Function *CtxF) const override {
     // Use TargetFolder or InstSimplifyFolder instead.
     return nullptr;
   }

--- a/llvm/include/llvm/IR/FMF.h
+++ b/llvm/include/llvm/IR/FMF.h
@@ -60,6 +60,8 @@ public:
   void clear() { Flags = 0; }
   void set() { Flags = AllFlagsMask; }
 
+  unsigned getAsOpaqueInt() const { return Flags; }
+
   /// Flag queries
   bool allowReassoc() const    { return 0 != (Flags & AllowReassoc); }
   bool noNaNs() const          { return 0 != (Flags & NoNaNs); }

--- a/llvm/include/llvm/IR/FPEnv.h
+++ b/llvm/include/llvm/IR/FPEnv.h
@@ -74,17 +74,5 @@ inline bool isDefaultFPEnvironment(fp::ExceptionBehavior EB, RoundingMode RM) {
 /// does not have a constrained intrinsic counterpart, the function returns
 /// zero.
 LLVM_ABI Intrinsic::ID getConstrainedIntrinsicID(const Instruction &Instr);
-
-/// Returns true if the rounding mode RM may be QRM at compile time or
-/// at run time.
-inline bool canRoundingModeBe(RoundingMode RM, RoundingMode QRM) {
-  return RM == QRM || RM == RoundingMode::Dynamic;
-}
-
-/// Returns true if the possibility of a signaling NaN can be safely
-/// ignored.
-inline bool canIgnoreSNaN(fp::ExceptionBehavior EB, FastMathFlags FMF) {
-  return (EB == fp::ebIgnore || FMF.noNaNs());
-}
 }
 #endif

--- a/llvm/include/llvm/IR/FPTransformChecker.h
+++ b/llvm/include/llvm/IR/FPTransformChecker.h
@@ -75,8 +75,8 @@ public:
     U.Flags = 0;
     init(F);
   }
-  FPTransformChecker(const Instruction *I);
-  FPTransformChecker(const SimplifyQuery &Q);
+  LLVM_ABI FPTransformChecker(const Instruction *I);
+  LLVM_ABI FPTransformChecker(const SimplifyQuery &Q);
   FPTransformChecker(FastMathFlags FMF) {
     U.Flags = 0;
     U.F.FastMath = FMF.getAsOpaqueInt();
@@ -119,7 +119,7 @@ public:
 
 private:
   FPTransformChecker(unsigned Flags) { U.Flags = 0; }
-  void init(const Function *F);
+  LLVM_ABI void init(const Function *F);
   void with(const Instruction *I);
 };
 

--- a/llvm/include/llvm/IR/FPTransformChecker.h
+++ b/llvm/include/llvm/IR/FPTransformChecker.h
@@ -1,0 +1,128 @@
+//===-- llvm/FPTransformChecker.h -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// This file defines a class that helps checking conditions for floating-point
+/// related IR transformations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_IR_FPTRANSFORMCHECKER_H
+#define LLVM_IR_FPTRANSFORMCHECKER_H
+
+#include "llvm/IR/FMF.h"
+#include "llvm/IR/FPEnv.h"
+#include "llvm/IR/Operator.h"
+
+namespace llvm {
+
+struct SimplifyQuery;
+
+/// The class keeps properties that can affect applicability of a floating-point
+/// related transformation to the selected instruction(s).
+class FPTransformChecker {
+  static constexpr unsigned FastMathMask = FastMathFlags::AllFlagsMask;
+  static constexpr unsigned FastMathBits = 8;
+  static_assert((1U << FastMathBits) > FastMathMask, "Too few fast math bits");
+
+  union {
+    unsigned Flags;
+    struct Fields {
+      unsigned FastMath : FastMathBits;
+      unsigned StrictFP : 1;
+      unsigned Rounding : 3;
+      unsigned Exceptions : 2;
+    } F;
+  } U;
+
+public:
+  static constexpr unsigned AllowReassoc = FastMathFlags::AllowReassoc;
+  static constexpr unsigned NoNaNs = FastMathFlags::NoNaNs;
+  static constexpr unsigned NoInfs = FastMathFlags::NoInfs;
+  static constexpr unsigned NoSignedZeros = FastMathFlags::NoSignedZeros;
+  static constexpr unsigned AllowReciprocal = FastMathFlags::AllowReciprocal;
+  static constexpr unsigned AllowContract = FastMathFlags::AllowContract;
+  static constexpr unsigned ApproxFunc = FastMathFlags::ApproxFunc;
+
+  bool allowReassoc() const { return 0 != (U.F.FastMath & AllowReassoc); }
+  bool noNaNs() const { return 0 != (U.F.FastMath & NoNaNs); }
+  bool noInfs() const { return 0 != (U.F.FastMath & NoInfs); }
+  bool noSignedZeros() const { return 0 != (U.F.FastMath & NoSignedZeros); }
+  bool allowReciprocal() const { return 0 != (U.F.FastMath & AllowReciprocal); }
+  bool allowContract() const { return 0 != (U.F.FastMath & AllowContract); }
+  bool approxFunc() const { return 0 != (U.F.FastMath & ApproxFunc); }
+
+  FastMathFlags getFMF() const { return FastMathFlags(U.F.FastMath); };
+
+  /// Return true if the enclosing function has attribute StrictFP.
+  bool isStrictFP() const { return U.F.StrictFP; }
+
+  RoundingMode getRoundingMode() const {
+    return static_cast<RoundingMode>(U.F.Rounding);
+  }
+
+  fp::ExceptionBehavior getExceptionBehavior() const {
+    return static_cast<fp::ExceptionBehavior>(U.F.Exceptions);
+  }
+
+  FPTransformChecker() { U.Flags = 0; }
+  FPTransformChecker(const Function *F) {
+    U.Flags = 0;
+    init(F);
+  }
+  FPTransformChecker(const Instruction *I);
+  FPTransformChecker(const SimplifyQuery &Q);
+  FPTransformChecker(FastMathFlags FMF) {
+    U.Flags = 0;
+    U.F.FastMath = FMF.getAsOpaqueInt();
+  }
+
+  FPTransformChecker withFastMath(FastMathFlags FMF) const {
+    unsigned NewFlags =
+        (U.Flags & ~FastMathMask) | (FMF.getAsOpaqueInt() & FastMathMask);
+    return FPTransformChecker(NewFlags);
+  }
+
+  /// Check if the FP properties allow combining the function call with other
+  /// call, like `exp(log(x))`.
+  bool mayCombineCalls() const { return allowReassoc() && !isStrictFP(); }
+
+  /// Returns true if the possibility of a signaling NaN can be safely
+  /// ignored.
+  bool canIgnoreSNaN() const {
+    return (U.F.Exceptions == fp::ebIgnore || noNaNs());
+  }
+
+  /// Returns true if the rounding mode can be QRM at compile time or at
+  /// run time.
+  inline bool canRoundingModeBe(RoundingMode QRM) const {
+    auto RM = getRoundingMode();
+    return RM == QRM || RM == RoundingMode::Dynamic;
+  }
+
+  /// Returns true if the exception handling behavior and rounding mode
+  /// match what is used in the default floating point environment.
+  inline bool isDefaultFPEnvironment() {
+    return U.F.Exceptions == fp::ebIgnore &&
+           getRoundingMode() == RoundingMode::NearestTiesToEven;
+  }
+
+  /// Returns true, if the expression (x - x) can be a negative zero.
+  bool canDiffWithItselfBeNegative() const {
+    return canRoundingModeBe(RoundingMode::TowardNegative) && !noSignedZeros();
+  }
+
+private:
+  FPTransformChecker(unsigned Flags) { U.Flags = 0; }
+  void init(const Function *F);
+  void with(const Instruction *I);
+};
+
+} // namespace llvm
+
+#endif

--- a/llvm/include/llvm/IR/IRBuilderFolder.h
+++ b/llvm/include/llvm/IR/IRBuilderFolder.h
@@ -15,6 +15,7 @@
 #define LLVM_IR_IRBUILDERFOLDER_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/IR/FPTransformChecker.h"
 #include "llvm/IR/GEPNoWrapFlags.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instruction.h"
@@ -77,7 +78,7 @@ public:
                           Type *DestTy) const = 0;
 
   virtual Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops,
-                               Type *Ty, FastMathFlags FMF = {},
+                               Type *Ty, FPTransformChecker Checker = {},
                                Function *CtxF = nullptr) const = 0;
 
   //===--------------------------------------------------------------------===//

--- a/llvm/include/llvm/IR/NoFolder.h
+++ b/llvm/include/llvm/IR/NoFolder.h
@@ -115,7 +115,8 @@ public:
   }
 
   Value *FoldIntrinsic(Intrinsic::ID ID, ArrayRef<Value *> Ops, Type *Ty,
-                       FastMathFlags FMF, Function *CtxF) const override {
+                       FPTransformChecker Checker,
+                       Function *CtxF) const override {
     return nullptr;
   }
 

--- a/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
+++ b/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
@@ -23,6 +23,7 @@
 #include "llvm/Analysis/InstructionSimplify.h"
 #include "llvm/Analysis/TargetFolder.h"
 #include "llvm/Analysis/ValueTracking.h"
+#include "llvm/IR/FPTransformChecker.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/Support/Compiler.h"
@@ -117,6 +118,9 @@ protected:
   /// Source for annotation metadata, used by the IRBuilder inserter.
   Instruction *AnnotationMetadataSource = nullptr;
 
+  /// Helper for checking FP properties required for a transformation.
+  FPTransformChecker FPChecker;
+
 public:
   InstCombiner(InstructionWorklist &Worklist, Function &F, AAResults *AA,
                AssumptionCache &AC, TargetLibraryInfo &TLI,
@@ -132,7 +136,7 @@ public:
         TLI(TLI), DT(DT), DL(DL),
         SQ(DL, &TLI, &DT, &AC, nullptr, /*UseInstrInfo*/ true,
            /*CanUseUndef*/ true, &DC),
-        ORE(ORE), BFI(BFI), BPI(BPI), PSI(PSI), RPOT(RPOT) {}
+        ORE(ORE), BFI(BFI), BPI(BPI), PSI(PSI), RPOT(RPOT), FPChecker(&F) {}
 
   virtual ~InstCombiner() = default;
 
@@ -375,6 +379,7 @@ public:
   }
   BlockFrequencyInfo *getBlockFrequencyInfo() const { return BFI; }
   ProfileSummaryInfo *getProfileSummaryInfo() const { return PSI; }
+  FPTransformChecker getFPChecker() const { return FPChecker; }
 
   // Call target specific combiners
   LLVM_ABI std::optional<Instruction *>

--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -2288,13 +2288,8 @@ bool CallAnalyzer::visitBinaryOperator(BinaryOperator &I) {
   Constant *CLHS = getDirectOrSimplifiedValue<Constant>(LHS);
   Constant *CRHS = getDirectOrSimplifiedValue<Constant>(RHS);
 
-  Value *SimpleV = nullptr;
-  if (auto FI = dyn_cast<FPMathOperator>(&I))
-    SimpleV = simplifyBinOp(I.getOpcode(), CLHS ? CLHS : LHS, CRHS ? CRHS : RHS,
-                            FI->getFastMathFlags(), DL);
-  else
-    SimpleV =
-        simplifyBinOp(I.getOpcode(), CLHS ? CLHS : LHS, CRHS ? CRHS : RHS, DL);
+  Value *SimpleV = simplifyBinOp(I.getOpcode(), CLHS ? CLHS : LHS,
+                                 CRHS ? CRHS : RHS, FPTransformChecker(&I), DL);
 
   if (Constant *C = dyn_cast_or_null<Constant>(SimpleV))
     SimplifiedValues[&I] = C;
@@ -2322,8 +2317,7 @@ bool CallAnalyzer::visitFNeg(UnaryOperator &I) {
   Value *Op = I.getOperand(0);
   Constant *COp = getDirectOrSimplifiedValue<Constant>(Op);
 
-  Value *SimpleV = simplifyFNegInst(
-      COp ? COp : Op, cast<FPMathOperator>(I).getFastMathFlags(), DL);
+  Value *SimpleV = simplifyFNegInst(COp ? COp : Op, DL);
 
   if (Constant *C = dyn_cast_or_null<Constant>(SimpleV))
     SimplifiedValues[&I] = C;

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -39,6 +39,7 @@
 #include "llvm/IR/ConstantRange.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Dominators.h"
+#include "llvm/IR/FPTransformChecker.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicsAArch64.h"
@@ -62,11 +63,11 @@ STATISTIC(NumReassoc, "Number of reassociations");
 static Value *simplifyAndInst(Value *, Value *, const SimplifyQuery &,
                               unsigned);
 static Value *simplifyUnOp(unsigned, Value *, const SimplifyQuery &, unsigned);
-static Value *simplifyFPUnOp(unsigned, Value *, const FastMathFlags &,
+static Value *simplifyFPUnOp(unsigned, Value *, FPTransformChecker,
                              const SimplifyQuery &, unsigned);
 static Value *simplifyBinOp(unsigned, Value *, Value *, const SimplifyQuery &,
                             unsigned);
-static Value *simplifyBinOp(unsigned, Value *, Value *, const FastMathFlags &,
+static Value *simplifyBinOp(unsigned, Value *, Value *, FPTransformChecker,
                             const SimplifyQuery &, unsigned);
 static Value *simplifyCmpInst(CmpPredicate, Value *, Value *,
                               const SimplifyQuery &, unsigned);
@@ -5855,8 +5856,8 @@ static Constant *foldConstant(Instruction::UnaryOps Opcode, Value *&Op,
 
 /// Given the operand for an FNeg, see if we can fold the result.  If not, this
 /// returns null.
-static Value *simplifyFNegInst(Value *Op, FastMathFlags FMF,
-                               const SimplifyQuery &Q, unsigned MaxRecurse) {
+static Value *simplifyFNegInst(Value *Op, const SimplifyQuery &Q,
+                               unsigned MaxRecurse) {
   if (Constant *C = foldConstant(Instruction::FNeg, Op, Q))
     return C;
 
@@ -5868,9 +5869,8 @@ static Value *simplifyFNegInst(Value *Op, FastMathFlags FMF,
   return nullptr;
 }
 
-Value *llvm::simplifyFNegInst(Value *Op, FastMathFlags FMF,
-                              const SimplifyQuery &Q) {
-  return ::simplifyFNegInst(Op, FMF, Q, RecursionLimit);
+Value *llvm::simplifyFNegInst(Value *Op, const SimplifyQuery &Q) {
+  return ::simplifyFNegInst(Op, Q, RecursionLimit);
 }
 
 /// Try to propagate existing NaN values when possible. If not, replace the
@@ -5917,10 +5917,8 @@ static Constant *propagateNaN(Constant *In) {
 /// Perform folds that are common to any floating-point operation. This implies
 /// transforms based on poison/undef/NaN because the operation itself makes no
 /// difference to the result.
-static Constant *simplifyFPOp(ArrayRef<Value *> Ops, FastMathFlags FMF,
-                              const SimplifyQuery &Q,
-                              fp::ExceptionBehavior ExBehavior,
-                              RoundingMode Rounding) {
+static Constant *simplifyFPOp(ArrayRef<Value *> Ops, FPTransformChecker Checker,
+                              const SimplifyQuery &Q) {
   // Poison is independent of anything else. It always propagates from an
   // operand to a math result.
   if (any_of(Ops, IsaPred<PoisonValue>))
@@ -5934,12 +5932,12 @@ static Constant *simplifyFPOp(ArrayRef<Value *> Ops, FastMathFlags FMF,
     // If this operation has 'nnan' or 'ninf' and at least 1 disallowed operand
     // (an undef operand can be chosen to be Nan/Inf), then the result of
     // this operation is poison.
-    if (FMF.noNaNs() && (IsNan || IsUndef))
+    if (Checker.noNaNs() && (IsNan || IsUndef))
       return PoisonValue::get(V->getType());
-    if (FMF.noInfs() && (IsInf || IsUndef))
+    if (Checker.noInfs() && (IsInf || IsUndef))
       return PoisonValue::get(V->getType());
 
-    if (isDefaultFPEnvironment(ExBehavior, Rounding)) {
+    if (Checker.isDefaultFPEnvironment()) {
       // Undef does not propagate because undef means that all bits can take on
       // any value. If this is undef * NaN for example, then the result values
       // (at least the exponent bits) are limited. Assume the undef is a
@@ -5948,7 +5946,7 @@ static Constant *simplifyFPOp(ArrayRef<Value *> Ops, FastMathFlags FMF,
         return ConstantFP::getNaN(V->getType());
       if (IsNan)
         return propagateNaN(cast<Constant>(V));
-    } else if (ExBehavior != fp::ebStrict) {
+    } else if (Checker.getExceptionBehavior() != fp::ebStrict) {
       if (IsNan)
         return propagateNaN(cast<Constant>(V));
     }
@@ -5958,16 +5956,14 @@ static Constant *simplifyFPOp(ArrayRef<Value *> Ops, FastMathFlags FMF,
 
 /// Given operands for an FAdd, see if we can fold the result.  If not, this
 /// returns null.
-static Value *
-simplifyFAddInst(Value *Op0, Value *Op1, FastMathFlags FMF,
-                 const SimplifyQuery &Q, unsigned MaxRecurse,
-                 fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                 RoundingMode Rounding = RoundingMode::NearestTiesToEven) {
-  if (isDefaultFPEnvironment(ExBehavior, Rounding))
+static Value *simplifyFAddInst(Value *Op0, Value *Op1,
+                               FPTransformChecker Checker,
+                               const SimplifyQuery &Q, unsigned MaxRecurse) {
+  if (Checker.isDefaultFPEnvironment())
     if (Constant *C = foldOrCommuteConstant(Instruction::FAdd, Op0, Op1, Q))
       return C;
 
-  if (Constant *C = simplifyFPOp({Op0, Op1}, FMF, Q, ExBehavior, Rounding))
+  if (Constant *C = simplifyFPOp({Op0, Op1}, Checker, Q))
     return C;
 
   // fadd X, -0 ==> X
@@ -5975,22 +5971,20 @@ simplifyFAddInst(Value *Op0, Value *Op1, FastMathFlags FMF,
   // not simplify to Op0:
   // fadd SNaN, -0.0 --> QNaN
   // fadd +0.0, -0.0 --> -0.0 (but only with round toward negative)
-  if (canIgnoreSNaN(ExBehavior, FMF) &&
-      (!canRoundingModeBe(Rounding, RoundingMode::TowardNegative) ||
-       FMF.noSignedZeros()))
+  if (Checker.canIgnoreSNaN() && !Checker.canDiffWithItselfBeNegative())
     if (match(Op1, m_NegZeroFP()))
       return Op0;
 
   // fadd X, 0 ==> X, when we know X is not -0
-  if (canIgnoreSNaN(ExBehavior, FMF))
+  if (Checker.canIgnoreSNaN())
     if (match(Op1, m_PosZeroFP()) &&
-        (FMF.noSignedZeros() || cannotBeNegativeZero(Op0, Q)))
+        (Checker.noSignedZeros() || cannotBeNegativeZero(Op0, Q)))
       return Op0;
 
-  if (!isDefaultFPEnvironment(ExBehavior, Rounding))
+  if (!Checker.isDefaultFPEnvironment())
     return nullptr;
 
-  if (FMF.noNaNs()) {
+  if (Checker.noNaNs()) {
     // With nnan: X + {+/-}Inf --> {+/-}Inf
     if (match(Op1, m_Inf()))
       return Op1;
@@ -6014,7 +6008,7 @@ simplifyFAddInst(Value *Op0, Value *Op1, FastMathFlags FMF,
   // (X - Y) + Y --> X
   // Y + (X - Y) --> X
   Value *X;
-  if (FMF.noSignedZeros() && FMF.allowReassoc() &&
+  if (Checker.noSignedZeros() && Checker.allowReassoc() &&
       (match(Op0, m_FSub(m_Value(X), m_Specific(Op1))) ||
        match(Op1, m_FSub(m_Value(X), m_Specific(Op0)))))
     return X;
@@ -6024,50 +6018,46 @@ simplifyFAddInst(Value *Op0, Value *Op1, FastMathFlags FMF,
 
 /// Given operands for an FSub, see if we can fold the result.  If not, this
 /// returns null.
-static Value *
-simplifyFSubInst(Value *Op0, Value *Op1, FastMathFlags FMF,
-                 const SimplifyQuery &Q, unsigned MaxRecurse,
-                 fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                 RoundingMode Rounding = RoundingMode::NearestTiesToEven) {
-  if (isDefaultFPEnvironment(ExBehavior, Rounding))
+static Value *simplifyFSubInst(Value *Op0, Value *Op1,
+                               FPTransformChecker Checker,
+                               const SimplifyQuery &Q, unsigned MaxRecurse) {
+  if (Checker.isDefaultFPEnvironment())
     if (Constant *C = foldOrCommuteConstant(Instruction::FSub, Op0, Op1, Q))
       return C;
 
-  if (Constant *C = simplifyFPOp({Op0, Op1}, FMF, Q, ExBehavior, Rounding))
+  if (Constant *C = simplifyFPOp({Op0, Op1}, Checker, Q))
     return C;
 
   // fsub X, +0 ==> X
-  if (canIgnoreSNaN(ExBehavior, FMF) &&
-      (!canRoundingModeBe(Rounding, RoundingMode::TowardNegative) ||
-       FMF.noSignedZeros()))
+  if (Checker.canIgnoreSNaN() && !Checker.canDiffWithItselfBeNegative())
     if (match(Op1, m_PosZeroFP()))
       return Op0;
 
   // fsub X, -0 ==> X, when we know X is not -0
-  if (canIgnoreSNaN(ExBehavior, FMF))
+  if (Checker.canIgnoreSNaN())
     if (match(Op1, m_NegZeroFP()) &&
-        (FMF.noSignedZeros() || cannotBeNegativeZero(Op0, Q)))
+        (Checker.noSignedZeros() || cannotBeNegativeZero(Op0, Q)))
       return Op0;
 
   // fsub -0.0, (fsub -0.0, X) ==> X
   // fsub -0.0, (fneg X) ==> X
   Value *X;
-  if (canIgnoreSNaN(ExBehavior, FMF))
+  if (Checker.canIgnoreSNaN())
     if (match(Op0, m_NegZeroFP()) && match(Op1, m_FNeg(m_Value(X))))
       return X;
 
   // fsub 0.0, (fsub 0.0, X) ==> X if signed zeros are ignored.
   // fsub 0.0, (fneg X) ==> X if signed zeros are ignored.
-  if (canIgnoreSNaN(ExBehavior, FMF))
-    if (FMF.noSignedZeros() && match(Op0, m_AnyZeroFP()) &&
+  if (Checker.canIgnoreSNaN())
+    if (Checker.noSignedZeros() && match(Op0, m_AnyZeroFP()) &&
         (match(Op1, m_FSub(m_AnyZeroFP(), m_Value(X))) ||
          match(Op1, m_FNeg(m_Value(X)))))
       return X;
 
-  if (!isDefaultFPEnvironment(ExBehavior, Rounding))
+  if (!Checker.isDefaultFPEnvironment())
     return nullptr;
 
-  if (FMF.noNaNs()) {
+  if (Checker.noNaNs()) {
     // fsub nnan x, x ==> 0.0
     if (Op0 == Op1)
       return Constant::getNullValue(Op0->getType());
@@ -6083,7 +6073,7 @@ simplifyFSubInst(Value *Op0, Value *Op1, FastMathFlags FMF,
 
   // Y - (Y - X) --> X
   // (X + Y) - Y --> X
-  if (FMF.noSignedZeros() && FMF.allowReassoc() &&
+  if (Checker.noSignedZeros() && Checker.allowReassoc() &&
       (match(Op1, m_FSub(m_Specific(Op0), m_Value(X))) ||
        match(Op0, m_c_FAdd(m_Specific(Op1), m_Value(X)))))
     return X;
@@ -6091,14 +6081,13 @@ simplifyFSubInst(Value *Op0, Value *Op1, FastMathFlags FMF,
   return nullptr;
 }
 
-static Value *simplifyFMAFMul(Value *Op0, Value *Op1, FastMathFlags FMF,
-                              const SimplifyQuery &Q, unsigned MaxRecurse,
-                              fp::ExceptionBehavior ExBehavior,
-                              RoundingMode Rounding) {
-  if (Constant *C = simplifyFPOp({Op0, Op1}, FMF, Q, ExBehavior, Rounding))
+static Value *simplifyFMAFMul(Value *Op0, Value *Op1,
+                              FPTransformChecker Checker,
+                              const SimplifyQuery &Q, unsigned MaxRecurse) {
+  if (Constant *C = simplifyFPOp({Op0, Op1}, Checker, Q))
     return C;
 
-  if (!isDefaultFPEnvironment(ExBehavior, Rounding))
+  if (!Checker.isDefaultFPEnvironment())
     return nullptr;
 
   // Canonicalize special constants as operand 1.
@@ -6111,13 +6100,14 @@ static Value *simplifyFMAFMul(Value *Op0, Value *Op1, FastMathFlags FMF,
 
   if (match(Op1, m_AnyZeroFP())) {
     // X * 0.0 --> 0.0 (with nnan and nsz)
-    if (FMF.noNaNs() && FMF.noSignedZeros())
+    if (Checker.noNaNs() && Checker.noSignedZeros())
       return ConstantFP::getZero(Op0->getType());
 
-    KnownFPClass Known = computeKnownFPClass(Op0, FMF, fcInf | fcNan, Q);
+    KnownFPClass Known =
+        computeKnownFPClass(Op0, Checker.getFMF(), fcInf | fcNan, Q);
     if (Known.isKnownNever(fcInf | fcNan)) {
       // if nsz is set, return 0.0
-      if (FMF.noSignedZeros())
+      if (Checker.noSignedZeros())
         return ConstantFP::getZero(Op0->getType());
       // +normal number * (-)0.0 --> (-)0.0
       if (Known.SignBit == false)
@@ -6133,72 +6123,59 @@ static Value *simplifyFMAFMul(Value *Op0, Value *Op1, FastMathFlags FMF,
   // 2. Ignore non-zero negative numbers because sqrt would produce NAN.
   // 3. Ignore -0.0 because sqrt(-0.0) == -0.0, but -0.0 * -0.0 == 0.0.
   Value *X;
-  if (Op0 == Op1 && match(Op0, m_Sqrt(m_Value(X))) && FMF.allowReassoc() &&
-      FMF.noNaNs() && FMF.noSignedZeros())
+  if (Op0 == Op1 && match(Op0, m_Sqrt(m_Value(X))) && Checker.allowReassoc() &&
+      Checker.noNaNs() && Checker.noSignedZeros())
     return X;
 
   return nullptr;
 }
 
 /// Given the operands for an FMul, see if we can fold the result
-static Value *
-simplifyFMulInst(Value *Op0, Value *Op1, FastMathFlags FMF,
-                 const SimplifyQuery &Q, unsigned MaxRecurse,
-                 fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                 RoundingMode Rounding = RoundingMode::NearestTiesToEven) {
-  if (isDefaultFPEnvironment(ExBehavior, Rounding))
+static Value *simplifyFMulInst(Value *Op0, Value *Op1,
+                               FPTransformChecker Checker,
+                               const SimplifyQuery &Q, unsigned MaxRecurse) {
+  if (Checker.isDefaultFPEnvironment())
     if (Constant *C = foldOrCommuteConstant(Instruction::FMul, Op0, Op1, Q))
       return C;
 
   // Now apply simplifications that do not require rounding.
-  return simplifyFMAFMul(Op0, Op1, FMF, Q, MaxRecurse, ExBehavior, Rounding);
+  return simplifyFMAFMul(Op0, Op1, Checker, Q, MaxRecurse);
 }
 
-Value *llvm::simplifyFAddInst(Value *Op0, Value *Op1, FastMathFlags FMF,
-                              const SimplifyQuery &Q,
-                              fp::ExceptionBehavior ExBehavior,
-                              RoundingMode Rounding) {
-  return ::simplifyFAddInst(Op0, Op1, FMF, Q, RecursionLimit, ExBehavior,
-                            Rounding);
+Value *llvm::simplifyFAddInst(Value *Op0, Value *Op1,
+                              FPTransformChecker Checker,
+                              const SimplifyQuery &Q) {
+  return ::simplifyFAddInst(Op0, Op1, Checker, Q, RecursionLimit);
 }
 
-Value *llvm::simplifyFSubInst(Value *Op0, Value *Op1, FastMathFlags FMF,
-                              const SimplifyQuery &Q,
-                              fp::ExceptionBehavior ExBehavior,
-                              RoundingMode Rounding) {
-  return ::simplifyFSubInst(Op0, Op1, FMF, Q, RecursionLimit, ExBehavior,
-                            Rounding);
+Value *llvm::simplifyFSubInst(Value *Op0, Value *Op1,
+                              FPTransformChecker Checker,
+                              const SimplifyQuery &Q) {
+  return ::simplifyFSubInst(Op0, Op1, Checker, Q, RecursionLimit);
 }
 
-Value *llvm::simplifyFMulInst(Value *Op0, Value *Op1, FastMathFlags FMF,
-                              const SimplifyQuery &Q,
-                              fp::ExceptionBehavior ExBehavior,
-                              RoundingMode Rounding) {
-  return ::simplifyFMulInst(Op0, Op1, FMF, Q, RecursionLimit, ExBehavior,
-                            Rounding);
+Value *llvm::simplifyFMulInst(Value *Op0, Value *Op1,
+                              FPTransformChecker Checker,
+                              const SimplifyQuery &Q) {
+  return ::simplifyFMulInst(Op0, Op1, Checker, Q, RecursionLimit);
 }
 
-Value *llvm::simplifyFMAFMul(Value *Op0, Value *Op1, FastMathFlags FMF,
-                             const SimplifyQuery &Q,
-                             fp::ExceptionBehavior ExBehavior,
-                             RoundingMode Rounding) {
-  return ::simplifyFMAFMul(Op0, Op1, FMF, Q, RecursionLimit, ExBehavior,
-                           Rounding);
+Value *llvm::simplifyFMAFMul(Value *Op0, Value *Op1, FPTransformChecker Checker,
+                             const SimplifyQuery &Q) {
+  return ::simplifyFMAFMul(Op0, Op1, Checker, Q, RecursionLimit);
 }
 
-static Value *
-simplifyFDivInst(Value *Op0, Value *Op1, FastMathFlags FMF,
-                 const SimplifyQuery &Q, unsigned,
-                 fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                 RoundingMode Rounding = RoundingMode::NearestTiesToEven) {
-  if (isDefaultFPEnvironment(ExBehavior, Rounding))
+static Value *simplifyFDivInst(Value *Op0, Value *Op1,
+                               FPTransformChecker Checker,
+                               const SimplifyQuery &Q, unsigned) {
+  if (Checker.isDefaultFPEnvironment())
     if (Constant *C = foldOrCommuteConstant(Instruction::FDiv, Op0, Op1, Q))
       return C;
 
-  if (Constant *C = simplifyFPOp({Op0, Op1}, FMF, Q, ExBehavior, Rounding))
+  if (Constant *C = simplifyFPOp({Op0, Op1}, Checker, Q))
     return C;
 
-  if (!isDefaultFPEnvironment(ExBehavior, Rounding))
+  if (!Checker.isDefaultFPEnvironment())
     return nullptr;
 
   // X / 1.0 -> X
@@ -6208,10 +6185,10 @@ simplifyFDivInst(Value *Op0, Value *Op1, FastMathFlags FMF,
   // 0 / X -> 0
   // Requires that NaNs are off (X could be zero) and signed zeroes are
   // ignored (X could be positive or negative, so the output sign is unknown).
-  if (FMF.noNaNs() && FMF.noSignedZeros() && match(Op0, m_AnyZeroFP()))
+  if (Checker.noNaNs() && Checker.noSignedZeros() && match(Op0, m_AnyZeroFP()))
     return ConstantFP::getZero(Op0->getType());
 
-  if (FMF.noNaNs()) {
+  if (Checker.noNaNs()) {
     // X / X -> 1.0 is legal when NaNs are ignored.
     // We can ignore infinities because INF/INF is NaN.
     if (Op0 == Op1)
@@ -6219,7 +6196,8 @@ simplifyFDivInst(Value *Op0, Value *Op1, FastMathFlags FMF,
 
     // (X * Y) / Y --> X if we can reassociate to the above form.
     Value *X;
-    if (FMF.allowReassoc() && match(Op0, m_c_FMul(m_Value(X), m_Specific(Op1))))
+    if (Checker.allowReassoc() &&
+        match(Op0, m_c_FMul(m_Value(X), m_Specific(Op1))))
       return X;
 
     // -X /  X -> -1.0 and
@@ -6230,40 +6208,36 @@ simplifyFDivInst(Value *Op0, Value *Op1, FastMathFlags FMF,
       return ConstantFP::get(Op0->getType(), -1.0);
 
     // nnan ninf X / [-]0.0 -> poison
-    if (FMF.noInfs() && match(Op1, m_AnyZeroFP()))
+    if (Checker.noInfs() && match(Op1, m_AnyZeroFP()))
       return PoisonValue::get(Op1->getType());
   }
 
   return nullptr;
 }
 
-Value *llvm::simplifyFDivInst(Value *Op0, Value *Op1, FastMathFlags FMF,
-                              const SimplifyQuery &Q,
-                              fp::ExceptionBehavior ExBehavior,
-                              RoundingMode Rounding) {
-  return ::simplifyFDivInst(Op0, Op1, FMF, Q, RecursionLimit, ExBehavior,
-                            Rounding);
+Value *llvm::simplifyFDivInst(Value *Op0, Value *Op1,
+                              FPTransformChecker Checker,
+                              const SimplifyQuery &Q) {
+  return ::simplifyFDivInst(Op0, Op1, Checker, Q, RecursionLimit);
 }
 
-static Value *
-simplifyFRemInst(Value *Op0, Value *Op1, FastMathFlags FMF,
-                 const SimplifyQuery &Q, unsigned,
-                 fp::ExceptionBehavior ExBehavior = fp::ebIgnore,
-                 RoundingMode Rounding = RoundingMode::NearestTiesToEven) {
-  if (isDefaultFPEnvironment(ExBehavior, Rounding))
+static Value *simplifyFRemInst(Value *Op0, Value *Op1,
+                               FPTransformChecker Checker,
+                               const SimplifyQuery &Q, unsigned) {
+  if (Checker.isDefaultFPEnvironment())
     if (Constant *C = foldOrCommuteConstant(Instruction::FRem, Op0, Op1, Q))
       return C;
 
-  if (Constant *C = simplifyFPOp({Op0, Op1}, FMF, Q, ExBehavior, Rounding))
+  if (Constant *C = simplifyFPOp({Op0, Op1}, Checker, Q))
     return C;
 
-  if (!isDefaultFPEnvironment(ExBehavior, Rounding))
+  if (!Checker.isDefaultFPEnvironment())
     return nullptr;
 
   // Unlike fdiv, the result of frem always matches the sign of the dividend.
   // The constant match may include undef elements in a vector, so return a full
   // zero constant as the result.
-  if (FMF.noNaNs()) {
+  if (Checker.noNaNs()) {
     // +0 % X -> 0
     if (match(Op0, m_PosZeroFP()))
       return ConstantFP::getZero(Op0->getType());
@@ -6275,12 +6249,10 @@ simplifyFRemInst(Value *Op0, Value *Op1, FastMathFlags FMF,
   return nullptr;
 }
 
-Value *llvm::simplifyFRemInst(Value *Op0, Value *Op1, FastMathFlags FMF,
-                              const SimplifyQuery &Q,
-                              fp::ExceptionBehavior ExBehavior,
-                              RoundingMode Rounding) {
-  return ::simplifyFRemInst(Op0, Op1, FMF, Q, RecursionLimit, ExBehavior,
-                            Rounding);
+Value *llvm::simplifyFRemInst(Value *Op0, Value *Op1,
+                              FPTransformChecker Checker,
+                              const SimplifyQuery &Q) {
+  return ::simplifyFRemInst(Op0, Op1, Checker, Q, RecursionLimit);
 }
 
 //=== Helper functions for higher up the class hierarchy.
@@ -6291,7 +6263,7 @@ static Value *simplifyUnOp(unsigned Opcode, Value *Op, const SimplifyQuery &Q,
                            unsigned MaxRecurse) {
   switch (Opcode) {
   case Instruction::FNeg:
-    return simplifyFNegInst(Op, FastMathFlags(), Q, MaxRecurse);
+    return simplifyFNegInst(Op, Q, MaxRecurse);
   default:
     llvm_unreachable("Unexpected opcode");
   }
@@ -6301,11 +6273,11 @@ static Value *simplifyUnOp(unsigned Opcode, Value *Op, const SimplifyQuery &Q,
 /// If not, this returns null.
 /// Try to use FastMathFlags when folding the result.
 static Value *simplifyFPUnOp(unsigned Opcode, Value *Op,
-                             const FastMathFlags &FMF, const SimplifyQuery &Q,
+                             FPTransformChecker Checker, const SimplifyQuery &Q,
                              unsigned MaxRecurse) {
   switch (Opcode) {
   case Instruction::FNeg:
-    return simplifyFNegInst(Op, FMF, Q, MaxRecurse);
+    return simplifyFNegInst(Op, Q, MaxRecurse);
   default:
     return simplifyUnOp(Opcode, Op, Q, MaxRecurse);
   }
@@ -6315,9 +6287,9 @@ Value *llvm::simplifyUnOp(unsigned Opcode, Value *Op, const SimplifyQuery &Q) {
   return ::simplifyUnOp(Opcode, Op, Q, RecursionLimit);
 }
 
-Value *llvm::simplifyUnOp(unsigned Opcode, Value *Op, FastMathFlags FMF,
-                          const SimplifyQuery &Q) {
-  return ::simplifyFPUnOp(Opcode, Op, FMF, Q, RecursionLimit);
+Value *llvm::simplifyUnOp(unsigned Opcode, Value *Op,
+                          FPTransformChecker Checker, const SimplifyQuery &Q) {
+  return ::simplifyFPUnOp(Opcode, Op, Checker, Q, RecursionLimit);
 }
 
 /// Given operands for a BinaryOperator, see if we can fold the result.
@@ -6356,15 +6328,15 @@ static Value *simplifyBinOp(unsigned Opcode, Value *LHS, Value *RHS,
   case Instruction::Xor:
     return simplifyXorInst(LHS, RHS, Q, MaxRecurse);
   case Instruction::FAdd:
-    return simplifyFAddInst(LHS, RHS, FastMathFlags(), Q, MaxRecurse);
+    return simplifyFAddInst(LHS, RHS, FPTransformChecker(Q), Q, MaxRecurse);
   case Instruction::FSub:
-    return simplifyFSubInst(LHS, RHS, FastMathFlags(), Q, MaxRecurse);
+    return simplifyFSubInst(LHS, RHS, FPTransformChecker(Q), Q, MaxRecurse);
   case Instruction::FMul:
-    return simplifyFMulInst(LHS, RHS, FastMathFlags(), Q, MaxRecurse);
+    return simplifyFMulInst(LHS, RHS, FPTransformChecker(Q), Q, MaxRecurse);
   case Instruction::FDiv:
-    return simplifyFDivInst(LHS, RHS, FastMathFlags(), Q, MaxRecurse);
+    return simplifyFDivInst(LHS, RHS, FPTransformChecker(Q), Q, MaxRecurse);
   case Instruction::FRem:
-    return simplifyFRemInst(LHS, RHS, FastMathFlags(), Q, MaxRecurse);
+    return simplifyFRemInst(LHS, RHS, FPTransformChecker(Q), Q, MaxRecurse);
   default:
     llvm_unreachable("Unexpected opcode");
   }
@@ -6374,17 +6346,19 @@ static Value *simplifyBinOp(unsigned Opcode, Value *LHS, Value *RHS,
 /// If not, this returns null.
 /// Try to use FastMathFlags when folding the result.
 static Value *simplifyBinOp(unsigned Opcode, Value *LHS, Value *RHS,
-                            const FastMathFlags &FMF, const SimplifyQuery &Q,
+                            FPTransformChecker Checker, const SimplifyQuery &Q,
                             unsigned MaxRecurse) {
   switch (Opcode) {
   case Instruction::FAdd:
-    return simplifyFAddInst(LHS, RHS, FMF, Q, MaxRecurse);
+    return simplifyFAddInst(LHS, RHS, Checker, Q, MaxRecurse);
   case Instruction::FSub:
-    return simplifyFSubInst(LHS, RHS, FMF, Q, MaxRecurse);
+    return simplifyFSubInst(LHS, RHS, Checker, Q, MaxRecurse);
   case Instruction::FMul:
-    return simplifyFMulInst(LHS, RHS, FMF, Q, MaxRecurse);
+    return simplifyFMulInst(LHS, RHS, Checker, Q, MaxRecurse);
   case Instruction::FDiv:
-    return simplifyFDivInst(LHS, RHS, FMF, Q, MaxRecurse);
+    return simplifyFDivInst(LHS, RHS, Checker, Q, MaxRecurse);
+  case Instruction::FRem:
+    return simplifyFRemInst(LHS, RHS, Checker, Q, MaxRecurse);
   default:
     return simplifyBinOp(Opcode, LHS, RHS, Q, MaxRecurse);
   }
@@ -6396,8 +6370,8 @@ Value *llvm::simplifyBinOp(unsigned Opcode, Value *LHS, Value *RHS,
 }
 
 Value *llvm::simplifyBinOp(unsigned Opcode, Value *LHS, Value *RHS,
-                           FastMathFlags FMF, const SimplifyQuery &Q) {
-  return ::simplifyBinOp(Opcode, LHS, RHS, FMF, Q, RecursionLimit);
+                           FPTransformChecker Checker, const SimplifyQuery &Q) {
+  return ::simplifyBinOp(Opcode, LHS, RHS, Checker, Q, RecursionLimit);
 }
 
 /// Given operands for a CmpInst, see if we can fold the result.
@@ -6554,7 +6528,7 @@ static Value *simplifyLdexp(Value *Op0, Value *Op1, const SimplifyQuery &Q,
 }
 
 static Value *simplifyUnaryIntrinsic(Intrinsic::ID IID, Value *Op0,
-                                     FastMathFlags FMF,
+                                     FPTransformChecker Checker,
                                      const SimplifyQuery &Q) {
   // Idempotent functions return the same result when called repeatedly.
   if (isIdempotent(IID))
@@ -6582,7 +6556,7 @@ static Value *simplifyUnaryIntrinsic(Intrinsic::ID IID, Value *Op0,
       return Op0;
 
     if (KnownClass.cannotBeOrderedLessThanZero() &&
-        KnownClass.isKnownNeverNaN() && FMF.noSignedZeros())
+        KnownClass.isKnownNeverNaN() && Checker.noSignedZeros())
       return Op0;
 
     break;
@@ -6611,31 +6585,31 @@ static Value *simplifyUnaryIntrinsic(Intrinsic::ID IID, Value *Op0,
   }
   case Intrinsic::exp:
     // exp(log(x)) -> x
-    if (FMF.allowReassoc() &&
+    if (Checker.mayCombineCalls() &&
         match(Op0, m_Intrinsic<Intrinsic::log>(m_Value(X))))
       return X;
     break;
   case Intrinsic::exp2:
     // exp2(log2(x)) -> x
-    if (FMF.allowReassoc() &&
+    if (Checker.mayCombineCalls() &&
         match(Op0, m_Intrinsic<Intrinsic::log2>(m_Value(X))))
       return X;
     break;
   case Intrinsic::exp10:
     // exp10(log10(x)) -> x
-    if (FMF.allowReassoc() &&
+    if (Checker.mayCombineCalls() &&
         match(Op0, m_Intrinsic<Intrinsic::log10>(m_Value(X))))
       return X;
     break;
   case Intrinsic::log:
     // log(exp(x)) -> x
-    if (FMF.allowReassoc() &&
+    if (Checker.mayCombineCalls() &&
         match(Op0, m_Intrinsic<Intrinsic::exp>(m_Value(X))))
       return X;
     break;
   case Intrinsic::log2:
     // log2(exp2(x)) -> x
-    if (FMF.allowReassoc() &&
+    if (Checker.mayCombineCalls() &&
         (match(Op0, m_Intrinsic<Intrinsic::exp2>(m_Value(X))) ||
          match(Op0,
                m_Intrinsic<Intrinsic::pow>(m_SpecificFP(2.0), m_Value(X)))))
@@ -6644,7 +6618,7 @@ static Value *simplifyUnaryIntrinsic(Intrinsic::ID IID, Value *Op0,
   case Intrinsic::log10:
     // log10(pow(10.0, x)) -> x
     // log10(exp10(x)) -> x
-    if (FMF.allowReassoc() &&
+    if (Checker.mayCombineCalls() &&
         (match(Op0, m_Intrinsic<Intrinsic::exp10>(m_Value(X))) ||
          match(Op0,
                m_Intrinsic<Intrinsic::pow>(m_SpecificFP(10.0), m_Value(X)))))
@@ -6881,7 +6855,8 @@ static Value *simplifySVEIntReduction(Intrinsic::ID IID, Type *ReturnType,
 }
 
 static Value *simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
-                                      Value *Op0, Value *Op1, FastMathFlags FMF,
+                                      Value *Op0, Value *Op1,
+                                      FPTransformChecker Checker,
                                       const SimplifyQuery &Q) {
   unsigned BitWidth = ReturnType->getScalarSizeInBits();
   switch (IID) {
@@ -7195,7 +7170,8 @@ static Value *simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
 
         if (Constant *SplatVal = C->getSplatValue()) {
           // Handle splat vectors (including scalable vectors)
-          OptResult = OptimizeConstMinMax(SplatVal, IID, FMF, &NewConst);
+          OptResult =
+              OptimizeConstMinMax(SplatVal, IID, Checker.getFMF(), &NewConst);
           if (OptResult == MinMaxOptResult::UseNewConstVal)
             NewConst = ConstantVector::getSplat(ElemCount, NewConst);
 
@@ -7214,7 +7190,8 @@ static Value *simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
               OptResult = MinMaxOptResult::CannotOptimize;
               break;
             }
-            auto ElemResult = OptimizeConstMinMax(Elt, IID, FMF, &NewConst);
+            auto ElemResult =
+                OptimizeConstMinMax(Elt, IID, Checker.getFMF(), &NewConst);
             if (ElemResult == MinMaxOptResult::CannotOptimize ||
                 (ElemResult != OptResult &&
                  OptResult != MinMaxOptResult::UseEither &&
@@ -7231,7 +7208,7 @@ static Value *simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
         }
       } else {
         // Handle scalar inputs
-        OptResult = OptimizeConstMinMax(C, IID, FMF, &NewConst);
+        OptResult = OptimizeConstMinMax(C, IID, Checker.getFMF(), &NewConst);
       }
 
       if (OptResult == MinMaxOptResult::UseOtherVal ||
@@ -7280,10 +7257,9 @@ static Value *simplifyBinaryIntrinsic(Intrinsic::ID IID, Type *ReturnType,
 }
 
 Value *llvm::simplifyIntrinsic(Intrinsic::ID IID, Type *ReturnType,
-                               ArrayRef<Value *> Args, FastMathFlags FMF,
-                               const SimplifyQuery &Q, Function *CxtF,
-                               fp::ExceptionBehavior ExBehavior,
-                               RoundingMode Rounding) {
+                               ArrayRef<Value *> Args,
+                               FPTransformChecker Checker,
+                               const SimplifyQuery &Q, Function *CxtF) {
   unsigned NumOperands = Args.size();
   if (IID != Intrinsic::not_intrinsic && intrinsicPropagatesPoison(IID) &&
       any_of(Args, IsaPred<PoisonValue>))
@@ -7307,10 +7283,11 @@ Value *llvm::simplifyIntrinsic(Intrinsic::ID IID, Type *ReturnType,
   }
 
   if (NumOperands == 1)
-    return simplifyUnaryIntrinsic(IID, Args[0], FMF, Q);
+    return simplifyUnaryIntrinsic(IID, Args[0], Checker, Q);
 
   if (NumOperands == 2)
-    return simplifyBinaryIntrinsic(IID, ReturnType, Args[0], Args[1], FMF, Q);
+    return simplifyBinaryIntrinsic(IID, ReturnType, Args[0], Args[1], Checker,
+                                   Q);
 
   // Handle intrinsics with 3 or more arguments.
   switch (IID) {
@@ -7365,11 +7342,10 @@ Value *llvm::simplifyIntrinsic(Intrinsic::ID IID, Type *ReturnType,
     return nullptr;
   }
   case Intrinsic::experimental_constrained_fma:
-    return simplifyFPOp(Args, {}, Q, ExBehavior, Rounding);
+    return simplifyFPOp(Args, Checker, Q);
   case Intrinsic::fma:
   case Intrinsic::fmuladd:
-    return simplifyFPOp(Args, {}, Q, fp::ebIgnore,
-                        RoundingMode::NearestTiesToEven);
+    return simplifyFPOp(Args, Checker, Q);
   case Intrinsic::smul_fix:
   case Intrinsic::smul_fix_sat: {
     Value *Op0 = Args[0];
@@ -7442,15 +7418,15 @@ Value *llvm::simplifyIntrinsic(Intrinsic::ID IID, Type *ReturnType,
     return nullptr;
   }
   case Intrinsic::experimental_constrained_fadd:
-    return simplifyFAddInst(Args[0], Args[1], FMF, Q, ExBehavior, Rounding);
+    return simplifyFAddInst(Args[0], Args[1], Checker, Q);
   case Intrinsic::experimental_constrained_fsub:
-    return simplifyFSubInst(Args[0], Args[1], FMF, Q, ExBehavior, Rounding);
+    return simplifyFSubInst(Args[0], Args[1], Checker, Q);
   case Intrinsic::experimental_constrained_fmul:
-    return simplifyFMulInst(Args[0], Args[1], FMF, Q, ExBehavior, Rounding);
+    return simplifyFMulInst(Args[0], Args[1], Checker, Q);
   case Intrinsic::experimental_constrained_fdiv:
-    return simplifyFDivInst(Args[0], Args[1], FMF, Q, ExBehavior, Rounding);
+    return simplifyFDivInst(Args[0], Args[1], Checker, Q);
   case Intrinsic::experimental_constrained_frem:
-    return simplifyFRemInst(Args[0], Args[1], FMF, Q, ExBehavior, Rounding);
+    return simplifyFRemInst(Args[0], Args[1], Checker, Q);
   case Intrinsic::experimental_constrained_ldexp:
     return simplifyLdexp(Args[0], Args[1], Q, true);
   case Intrinsic::experimental_vp_reverse: {
@@ -7502,18 +7478,9 @@ static Value *simplifyIntrinsic(CallBase *Call, ArrayRef<Value *> Args,
     }
     return nullptr;
   }
-  default: {
-    // Use the default FP environment if none is found.
-    fp::ExceptionBehavior ExBehavior = fp::ebIgnore;
-    RoundingMode Rounding = RoundingMode::NearestTiesToEven;
-    if (auto *Constrained = dyn_cast<ConstrainedFPIntrinsic>(Call)) {
-      ExBehavior = Constrained->getExceptionBehavior().value_or(ExBehavior);
-      Rounding = Constrained->getRoundingMode().value_or(Rounding);
-    }
-    return simplifyIntrinsic(IID, ReturnType, Args,
-                             Call->getFastMathFlagsOrNone(), Q,
-                             Call->getFunction(), ExBehavior, Rounding);
-  }
+  default:
+    return simplifyIntrinsic(IID, ReturnType, Args, FPTransformChecker(Call), Q,
+                             Call->getFunction());
   }
 }
 
@@ -7646,23 +7613,23 @@ static Value *simplifyInstructionWithOperands(Instruction *I,
     }
     return nullptr;
   case Instruction::FNeg:
-    return simplifyFNegInst(NewOps[0], I->getFastMathFlags(), Q, MaxRecurse);
+    return simplifyFNegInst(NewOps[0], Q, MaxRecurse);
   case Instruction::FAdd:
-    return simplifyFAddInst(NewOps[0], NewOps[1], I->getFastMathFlags(), Q,
+    return simplifyFAddInst(NewOps[0], NewOps[1], FPTransformChecker(I), Q,
                             MaxRecurse);
   case Instruction::Add:
     return simplifyAddInst(
         NewOps[0], NewOps[1], Q.IIQ.hasNoSignedWrap(cast<BinaryOperator>(I)),
         Q.IIQ.hasNoUnsignedWrap(cast<BinaryOperator>(I)), Q, MaxRecurse);
   case Instruction::FSub:
-    return simplifyFSubInst(NewOps[0], NewOps[1], I->getFastMathFlags(), Q,
+    return simplifyFSubInst(NewOps[0], NewOps[1], FPTransformChecker(I), Q,
                             MaxRecurse);
   case Instruction::Sub:
     return simplifySubInst(
         NewOps[0], NewOps[1], Q.IIQ.hasNoSignedWrap(cast<BinaryOperator>(I)),
         Q.IIQ.hasNoUnsignedWrap(cast<BinaryOperator>(I)), Q, MaxRecurse);
   case Instruction::FMul:
-    return simplifyFMulInst(NewOps[0], NewOps[1], I->getFastMathFlags(), Q,
+    return simplifyFMulInst(NewOps[0], NewOps[1], FPTransformChecker(I), Q,
                             MaxRecurse);
   case Instruction::Mul:
     return simplifyMulInst(
@@ -7677,14 +7644,14 @@ static Value *simplifyInstructionWithOperands(Instruction *I,
                             Q.IIQ.isExact(cast<BinaryOperator>(I)), Q,
                             MaxRecurse);
   case Instruction::FDiv:
-    return simplifyFDivInst(NewOps[0], NewOps[1], I->getFastMathFlags(), Q,
+    return simplifyFDivInst(NewOps[0], NewOps[1], FPTransformChecker(I), Q,
                             MaxRecurse);
   case Instruction::SRem:
     return simplifySRemInst(NewOps[0], NewOps[1], Q, MaxRecurse);
   case Instruction::URem:
     return simplifyURemInst(NewOps[0], NewOps[1], Q, MaxRecurse);
   case Instruction::FRem:
-    return simplifyFRemInst(NewOps[0], NewOps[1], I->getFastMathFlags(), Q,
+    return simplifyFRemInst(NewOps[0], NewOps[1], FPTransformChecker(I), Q,
                             MaxRecurse);
   case Instruction::Shl:
     return simplifyShlInst(

--- a/llvm/lib/IR/CMakeLists.txt
+++ b/llvm/lib/IR/CMakeLists.txt
@@ -31,6 +31,7 @@ add_llvm_component_library(LLVMCore
   DroppedVariableStatsIR.cpp
   EHPersonalities.cpp
   FPEnv.cpp
+  FPTransformChecker.cpp
   Function.cpp
   GCStrategy.cpp
   GVMaterializer.cpp

--- a/llvm/lib/IR/FPTransformChecker.cpp
+++ b/llvm/lib/IR/FPTransformChecker.cpp
@@ -1,0 +1,66 @@
+//===------ FPTransformChecker.cpp ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// This file implements a service that helps checking conditions for
+/// floating-point related IR transformations.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/IR/FPTransformChecker.h"
+#include "llvm/Analysis/SimplifyQuery.h"
+#include "llvm/IR/IntrinsicInst.h"
+
+using namespace llvm;
+
+FPTransformChecker::FPTransformChecker(const SimplifyQuery &Q)
+    : FPTransformChecker(Q.CxtI) {}
+
+void FPTransformChecker::init(const Function *Func) {
+  if (Func) {
+    if (Func->getAttributes().hasFnAttr(Attribute::StrictFP)) {
+      U.F.StrictFP = true;
+      U.F.Rounding = static_cast<unsigned>(RoundingMode::Dynamic);
+      U.F.Exceptions = fp::ebStrict;
+    } else {
+      U.F.StrictFP = false;
+      U.F.Rounding = static_cast<unsigned>(RoundingMode::NearestTiesToEven);
+      U.F.Exceptions = fp::ebIgnore;
+    }
+  } else {
+    // Conservatively assume the most restrictive case.
+    U.F.StrictFP = true;
+    U.F.Rounding = static_cast<unsigned>(RoundingMode::Dynamic);
+    U.F.Exceptions = fp::ebStrict;
+  }
+}
+
+void FPTransformChecker::with(const Instruction *I) {
+  if (I) {
+    if (auto *MathOp = dyn_cast<FPMathOperator>(I))
+      U.F.FastMath = MathOp->getFastMathFlags().getAsOpaqueInt();
+    if (const auto *CI = dyn_cast<ConstrainedFPIntrinsic>(I)) {
+      U.F.StrictFP = true;
+      U.F.Rounding = static_cast<unsigned>(
+          CI->getRoundingMode().value_or(RoundingMode::Dynamic));
+      U.F.Exceptions = CI->getExceptionBehavior().value_or(fp::ebStrict);
+    }
+  }
+}
+
+FPTransformChecker::FPTransformChecker(const Instruction *I) {
+  U.Flags = 0;
+  const Function *Func = nullptr;
+  if (I) {
+    if (const BasicBlock *BB = I->getParent())
+      if (const Function *F = BB->getParent())
+        Func = F;
+  }
+  init(Func);
+  with(I);
+}

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -1924,11 +1924,7 @@ simplifySVEIntrinsicBinOp(InstCombiner &IC, IntrinsicInst &II,
   Op1 = stripInactiveLanes(Op1, Pg);
   Op2 = stripInactiveLanes(Op2, Pg);
 
-  Value *SimpleII;
-  if (auto FII = dyn_cast<FPMathOperator>(&II))
-    SimpleII = simplifyBinOp(Opc, Op1, Op2, FII->getFastMathFlags(), DL);
-  else
-    SimpleII = simplifyBinOp(Opc, Op1, Op2, DL);
+  Value *SimpleII = simplifyBinOp(Opc, Op1, Op2, FPTransformChecker(&II), DL);
 
   // An SVE intrinsic's result is always defined. However, this is not the case
   // for its equivalent IR instruction (e.g. when shifting by an amount more

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -2072,9 +2072,9 @@ static Instruction *factorizeFAddFSub(BinaryOperator &I,
 }
 
 Instruction *InstCombinerImpl::visitFAdd(BinaryOperator &I) {
-  if (Value *V = simplifyFAddInst(I.getOperand(0), I.getOperand(1),
-                                  I.getFastMathFlags(),
-                                  SQ.getWithInstruction(&I)))
+  if (Value *V =
+          simplifyFAddInst(I.getOperand(0), I.getOperand(1),
+                           FPTransformChecker(&I), SQ.getWithInstruction(&I)))
     return replaceInstUsesWith(I, V);
 
   if (SimplifyAssociativeOrCommutative(I))
@@ -3144,8 +3144,8 @@ Instruction *InstCombinerImpl::hoistFNegAboveFMulFDiv(Value *FNegOp,
 Instruction *InstCombinerImpl::visitFNeg(UnaryOperator &I) {
   Value *Op = I.getOperand(0);
 
-  if (Value *V = simplifyFNegInst(Op, I.getFastMathFlags(),
-                                  getSimplifyQuery().getWithInstruction(&I)))
+  if (Value *V =
+          simplifyFNegInst(Op, getSimplifyQuery().getWithInstruction(&I)))
     return replaceInstUsesWith(I, V);
 
   if (Instruction *X = foldFNegIntoConstant(I, DL))
@@ -3235,7 +3235,7 @@ Instruction *InstCombinerImpl::visitFNeg(UnaryOperator &I) {
 
 Instruction *InstCombinerImpl::visitFSub(BinaryOperator &I) {
   if (Value *V = simplifyFSubInst(I.getOperand(0), I.getOperand(1),
-                                  I.getFastMathFlags(),
+                                  FPTransformChecker(&I),
                                   getSimplifyQuery().getWithInstruction(&I)))
     return replaceInstUsesWith(I, V);
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3079,7 +3079,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     // Try to simplify the underlying FMul.
     if (Value *V =
             simplifyFMulInst(II->getArgOperand(0), II->getArgOperand(1),
-                             II->getFastMathFlags(), SQ.getWithInstruction(II)))
+                             FPTransformChecker(II), SQ.getWithInstruction(II)))
       return BinaryOperator::CreateFAddFMF(V, II->getArgOperand(2),
                                            II->getFastMathFlags());
 
@@ -3107,7 +3107,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
 
     // Try to simplify the underlying FMul. We can only apply simplifications
     // that do not require rounding.
-    if (Value *V = simplifyFMAFMul(Src0, Src1, II->getFastMathFlags(),
+    if (Value *V = simplifyFMAFMul(Src0, Src1, FPTransformChecker(II),
                                    SQ.getWithInstruction(II)))
       return BinaryOperator::CreateFAddFMF(V, Src2, II->getFastMathFlags());
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -20,6 +20,7 @@
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/FPTransformChecker.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
@@ -1003,9 +1004,9 @@ Instruction *InstCombinerImpl::foldFMulReassoc(BinaryOperator &I) {
 }
 
 Instruction *InstCombinerImpl::visitFMul(BinaryOperator &I) {
-  if (Value *V = simplifyFMulInst(I.getOperand(0), I.getOperand(1),
-                                  I.getFastMathFlags(),
-                                  SQ.getWithInstruction(&I)))
+  if (Value *V =
+          simplifyFMulInst(I.getOperand(0), I.getOperand(1),
+                           FPTransformChecker(&I), SQ.getWithInstruction(&I)))
     return replaceInstUsesWith(I, V);
 
   if (SimplifyAssociativeOrCommutative(I))
@@ -2196,9 +2197,9 @@ convertFSqrtDivIntoFMul(CallInst *CI, Instruction *X,
 Instruction *InstCombinerImpl::visitFDiv(BinaryOperator &I) {
   Module *M = I.getModule();
 
-  if (Value *V = simplifyFDivInst(I.getOperand(0), I.getOperand(1),
-                                  I.getFastMathFlags(),
-                                  SQ.getWithInstruction(&I)))
+  if (Value *V =
+          simplifyFDivInst(I.getOperand(0), I.getOperand(1),
+                           FPTransformChecker(&I), SQ.getWithInstruction(&I)))
     return replaceInstUsesWith(I, V);
 
   if (Instruction *X = foldVectorBinop(I))
@@ -2634,9 +2635,9 @@ Instruction *InstCombinerImpl::visitSRem(BinaryOperator &I) {
 }
 
 Instruction *InstCombinerImpl::visitFRem(BinaryOperator &I) {
-  if (Value *V = simplifyFRemInst(I.getOperand(0), I.getOperand(1),
-                                  I.getFastMathFlags(),
-                                  SQ.getWithInstruction(&I)))
+  if (Value *V =
+          simplifyFRemInst(I.getOperand(0), I.getOperand(1),
+                           FPTransformChecker(&I), SQ.getWithInstruction(&I)))
     return replaceInstUsesWith(I, V);
 
   if (Instruction *X = foldVectorBinop(I))

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1403,11 +1403,12 @@ Value *InstCombinerImpl::SimplifySelectsFeedingBinaryOp(BinaryOperator &I,
     return nullptr;
   };
 
+  FPTransformChecker Checker(&I);
   if (LHSIsSelect && RHSIsSelect && A == D) {
     // (A ? B : C) op (A ? E : F) -> A ? (B op E) : (C op F)
     Cond = A;
-    True = simplifyBinOp(Opcode, B, E, FMF, Q);
-    False = simplifyBinOp(Opcode, C, F, FMF, Q);
+    True = simplifyBinOp(Opcode, B, E, Checker, Q);
+    False = simplifyBinOp(Opcode, C, F, Checker, Q);
 
     if (LHS->hasOneUse() && RHS->hasOneUse()) {
       if (False && !True)
@@ -1418,15 +1419,15 @@ Value *InstCombinerImpl::SimplifySelectsFeedingBinaryOp(BinaryOperator &I,
   } else if (LHSIsSelect && LHS->hasOneUse()) {
     // (A ? B : C) op Y -> A ? (B op Y) : (C op Y)
     Cond = A;
-    True = simplifyBinOp(Opcode, B, RHS, FMF, Q);
-    False = simplifyBinOp(Opcode, C, RHS, FMF, Q);
+    True = simplifyBinOp(Opcode, B, RHS, Checker, Q);
+    False = simplifyBinOp(Opcode, C, RHS, Checker, Q);
     if (Value *NewSel = foldAddNegate(B, C, RHS))
       return NewSel;
   } else if (RHSIsSelect && RHS->hasOneUse()) {
     // X op (D ? E : F) -> D ? (X op E) : (X op F)
     Cond = D;
-    True = simplifyBinOp(Opcode, LHS, E, FMF, Q);
-    False = simplifyBinOp(Opcode, LHS, F, FMF, Q);
+    True = simplifyBinOp(Opcode, LHS, E, Checker, Q);
+    False = simplifyBinOp(Opcode, LHS, F, Checker, Q);
     if (Value *NewSel = foldAddNegate(E, F, LHS))
       return NewSel;
   }

--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/AttributeMask.h"
 #include "llvm/IR/DataLayout.h"
+#include "llvm/IR/FPTransformChecker.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/IntrinsicInst.h"
@@ -4028,7 +4029,7 @@ Value *LibCallSimplifier::optimizeFloatingPointLibCall(CallInst *CI,
   const Module *M = CI->getModule();
 
   // Don't optimize calls that require strict floating point semantics.
-  if (CI->isStrictFP())
+  if (FPTransformChecker(CI).isStrictFP())
     return nullptr;
 
   if (Value *V = optimizeSymmetric(CI, Func, Builder))

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -1395,13 +1395,13 @@ bool VectorCombine::scalarizeOpOrCmp(Instruction &I) {
   // Fold the vector constants in the original vectors into a new base vector to
   // get more accurate cost modelling.
   Value *NewVecC = nullptr;
+  FPTransformChecker Checker(&I);
   if (CI)
     NewVecC = simplifyCmpInst(CI->getPredicate(), VecCs[0], VecCs[1], SQ);
   else if (UO)
-    NewVecC =
-        simplifyUnOp(UO->getOpcode(), VecCs[0], UO->getFastMathFlags(), SQ);
+    NewVecC = simplifyUnOp(UO->getOpcode(), VecCs[0], Checker, SQ);
   else if (BO)
-    NewVecC = simplifyBinOp(BO->getOpcode(), VecCs[0], VecCs[1], SQ);
+    NewVecC = simplifyBinOp(BO->getOpcode(), VecCs[0], VecCs[1], Checker, SQ);
   else if (II)
     NewVecC = simplifyCall(II, II->getCalledOperand(), VecCs, SQ);
 

--- a/llvm/test/Transforms/InstCombine/fdim.ll
+++ b/llvm/test/Transforms/InstCombine/fdim.ll
@@ -101,8 +101,7 @@ define double @fdim_nzero() {
 
 define double @fdim_strictfp() {
 ; CHECK-LABEL: define double @fdim_strictfp() {
-; CHECK-NEXT:    [[DIM:%.*]] = call double @fdim(double 1.000000e+01, double 8.000000e+00) #[[ATTR1:[0-9]+]]
-; CHECK-NEXT:    ret double [[DIM]]
+; CHECK-NEXT:    ret double 2.000000e+00
 ;
   %dim = call double @fdim(double 10.0, double 8.0) strictfp
   ret double %dim

--- a/llvm/test/Transforms/InstCombine/fma.ll
+++ b/llvm/test/Transforms/InstCombine/fma.ll
@@ -587,7 +587,7 @@ define <2 x double> @fma_const_fmul_one2(<2 x double> %b) {
 
 define <2 x double> @fma_nan_and_const_0(<2 x double> %b) {
 ; CHECK-LABEL: @fma_nan_and_const_0(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fma.v2f64(<2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>, <2 x double> <double 0.0000000129182, double 0.000009123>, <2 x double> %b)
   ret <2 x double> %res
@@ -595,7 +595,7 @@ define <2 x double> @fma_nan_and_const_0(<2 x double> %b) {
 
 define <2 x double> @fma_nan_and_const_1(<2 x double> %b) {
 ; CHECK-LABEL: @fma_nan_and_const_1(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fma.v2f64(<2 x double> <double 0.0000000129182, double 0.000009123>, <2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>, <2 x double> %b)
   ret <2 x double> %res
@@ -603,7 +603,7 @@ define <2 x double> @fma_nan_and_const_1(<2 x double> %b) {
 
 define <2 x double> @fma_nan_and_const_2(<2 x double> %b) {
 ; CHECK-LABEL: @fma_nan_and_const_2(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fma.v2f64(<2 x double> <double 0.0000000129182, double 0.000009123>, <2 x double> %b, <2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>)
   ret <2 x double> %res
@@ -611,7 +611,7 @@ define <2 x double> @fma_nan_and_const_2(<2 x double> %b) {
 
 define <2 x double> @fma_undef_0(<2 x double> %b, <2 x double> %c) {
 ; CHECK-LABEL: @fma_undef_0(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fma.v2f64(<2 x double> <double undef, double undef>, <2 x double> %b, <2 x double> %c)
   ret <2 x double> %res
@@ -619,7 +619,7 @@ define <2 x double> @fma_undef_0(<2 x double> %b, <2 x double> %c) {
 
 define <2 x double> @fma_undef_1(<2 x double> %b, <2 x double> %c) {
 ; CHECK-LABEL: @fma_undef_1(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fma.v2f64(<2 x double> %b, <2 x double> <double undef, double undef>, <2 x double> %c)
   ret <2 x double> %res
@@ -627,7 +627,7 @@ define <2 x double> @fma_undef_1(<2 x double> %b, <2 x double> %c) {
 
 define <2 x double> @fma_undef_2(<2 x double> %b, <2 x double> %c) {
 ; CHECK-LABEL: @fma_undef_2(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fma.v2f64(<2 x double> %b, <2 x double> %c, <2 x double> <double undef, double undef>)
   ret <2 x double> %res
@@ -663,14 +663,14 @@ define <2 x double> @fma_partial_undef_2(<2 x double> %b, <2 x double> %c) {
 
 define <2 x double> @fma_nan_0(<2 x double> %b, <2 x double> %c) {
 ; CHECK-LABEL: @fma_nan_0(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fma.v2f64(<2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>, <2 x double> %b, <2 x double> %c)
   ret <2 x double> %res
 }
 define <2 x double> @fma_nan_1(<2 x double> %b, <2 x double> %c) {
 ; CHECK-LABEL: @fma_nan_1(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fma.v2f64(<2 x double> %b, <2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>, <2 x double> %c)
   ret <2 x double> %res
@@ -678,7 +678,7 @@ define <2 x double> @fma_nan_1(<2 x double> %b, <2 x double> %c) {
 
 define <2 x double> @fma_nan_2(<2 x double> %b, <2 x double> %c) {
 ; CHECK-LABEL: @fma_nan_2(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fma.v2f64(<2 x double> %b, <2 x double> %c, <2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>)
   ret <2 x double> %res
@@ -695,7 +695,7 @@ define <2 x double> @fmuladd_const_fmul(<2 x double> %b) {
 
 define <2 x double> @fmuladd_nan_and_const_0(<2 x double> %b) {
 ; CHECK-LABEL: @fmuladd_nan_and_const_0(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fmuladd.v2f64(<2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>, <2 x double> <double 0.0000000129182, double 0.000009123>, <2 x double> %b)
   ret <2 x double> %res
@@ -703,7 +703,7 @@ define <2 x double> @fmuladd_nan_and_const_0(<2 x double> %b) {
 
 define <2 x double> @fmuladd_nan_and_const_1(<2 x double> %b) {
 ; CHECK-LABEL: @fmuladd_nan_and_const_1(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fmuladd.v2f64(<2 x double> <double 0.0000000129182, double 0.000009123>, <2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>, <2 x double> %b)
   ret <2 x double> %res
@@ -711,7 +711,7 @@ define <2 x double> @fmuladd_nan_and_const_1(<2 x double> %b) {
 
 define <2 x double> @fmuladd_nan_and_const_2(<2 x double> %b) {
 ; CHECK-LABEL: @fmuladd_nan_and_const_2(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fmuladd.v2f64(<2 x double> <double 0.0000000129182, double 0.000009123>, <2 x double> %b, <2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>)
   ret <2 x double> %res
@@ -719,7 +719,7 @@ define <2 x double> @fmuladd_nan_and_const_2(<2 x double> %b) {
 
 define <2 x double> @fmuladd_nan_0(<2 x double> %b, <2 x double> %c) {
 ; CHECK-LABEL: @fmuladd_nan_0(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fmuladd.v2f64(<2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>, <2 x double> %b, <2 x double> %c)
   ret <2 x double> %res
@@ -727,7 +727,7 @@ define <2 x double> @fmuladd_nan_0(<2 x double> %b, <2 x double> %c) {
 
 define <2 x double> @fmuladd_nan_1(<2 x double> %b, <2 x double> %c) {
 ; CHECK-LABEL: @fmuladd_nan_1(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fmuladd.v2f64(<2 x double> %b, <2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>, <2 x double> %c)
   ret <2 x double> %res
@@ -735,7 +735,7 @@ define <2 x double> @fmuladd_nan_1(<2 x double> %b, <2 x double> %c) {
 
 define <2 x double> @fmuladd_undef_0(<2 x double> %b, <2 x double> %c) {
 ; CHECK-LABEL: @fmuladd_undef_0(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fmuladd.v2f64(<2 x double> <double undef, double undef>, <2 x double> %b, <2 x double> %c)
   ret <2 x double> %res
@@ -743,7 +743,7 @@ define <2 x double> @fmuladd_undef_0(<2 x double> %b, <2 x double> %c) {
 
 define <2 x double> @fmuladd_undef_1(<2 x double> %b, <2 x double> %c) {
 ; CHECK-LABEL: @fmuladd_undef_1(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fmuladd.v2f64(<2 x double> %b, <2 x double> <double undef, double undef>, <2 x double> %c)
   ret <2 x double> %res
@@ -751,7 +751,7 @@ define <2 x double> @fmuladd_undef_1(<2 x double> %b, <2 x double> %c) {
 
 define <2 x double> @fmuladd_undef_2(<2 x double> %b, <2 x double> %c) {
 ; CHECK-LABEL: @fmuladd_undef_2(
-; CHECK-NEXT:    ret <2 x double> splat (double +qnan)
+; CHECK-NEXT:    ret <2 x double> poison
 ;
   %res = call nnan nsz <2 x double> @llvm.fmuladd.v2f64(<2 x double> %b, <2 x double> %c, <2 x double> <double 0x7FF8000000000000, double 0x7FF8000000000000>)
   ret <2 x double> %res

--- a/llvm/test/Transforms/NewGVN/commute.ll
+++ b/llvm/test/Transforms/NewGVN/commute.ll
@@ -73,9 +73,7 @@ declare float @llvm.fma.f32(float, float, float)
 
 define float @fma(float %x, float %y) {
 ; CHECK-LABEL: @fma(
-; CHECK-NEXT:    [[M1:%.*]] = call float @llvm.fma.f32(float [[X:%.*]], float [[Y:%.*]], float 1.000000e+00)
-; CHECK-NEXT:    [[R:%.*]] = fdiv nnan float [[M1]], [[M1]]
-; CHECK-NEXT:    ret float [[R]]
+; CHECK-NEXT:    ret float 1.000000e+00
 ;
   %m1 = call float @llvm.fma.f32(float %x, float %y, float 1.0)
   %m2 = call float @llvm.fma.f32(float %y, float %x, float 1.0)


### PR DESCRIPTION
Applicability of a particular transformation to floating-point expressions may depend on many parameters. Previously these parameters were mainly represented by fast-math flags, and in some cases they were supplemented by rounding mode and exception behavior, and all were passed as separate arguments to the relevant functions. Implementing more elaborated support of floating-point requires access to other properties, including function attributes (such as denormal mode or sNaN support). Passing these parameters as separate arguments is inconvenient. To address this problem a special class that collects all the necessary information is introduced in this commit.

The class is a wrapper over an integer value, where various bit fields represent properties, that transformations may depend on. This allows instances of the class to be passed by value. It incorporates fast-math flags and borrows part of the FastMathFlags interface.

This change was intended to be NFC, but in some cases, the behavior differs, because the floating-point operation information could previously be lost when traveling throughout function call stack.