### PR TITLE
[libc++] Optimize std::is_permutation

### DIFF
--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -59,6 +59,9 @@ Improvements and New Features
 - The ``std::ranges::fold_left_with_iter`` algorithm has been optimized for
   segmented iterators, resulting in a performance improvement of up to 1.38x
   for ``std::deque<int>`` iterators.
+- ``std::is_permutation`` and its ``std::ranges`` counterpart have been optimized
+  by using ``std::mismatch`` to skip a common prefix, resulting in a performance
+  improvement of up to 4x for ``std::vector<int>``.
 - ``std::copy(CharT*, CharT*, ostreambuf_iterator<CharT>)`` has been optimized, resulting in performance improvements
   of up to 25x.
 - A lot of transitive includes have been removed, resulting in significant compile time improvements.

--- a/libcxx/include/__algorithm/is_permutation.h
+++ b/libcxx/include/__algorithm/is_permutation.h
@@ -11,7 +11,11 @@
 #define _LIBCPP___ALGORITHM_IS_PERMUTATION_H
 
 #include <__algorithm/comp.h>
+#include <__algorithm/count_if.h>
+#include <__algorithm/find_if.h>
 #include <__algorithm/iterator_operations.h>
+#include <__algorithm/mismatch.h>
+#include <__algorithm/unwrap_iter.h>
 #include <__config>
 #include <__functional/identity.h>
 #include <__iterator/concepts.h>
@@ -78,32 +82,32 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation_impl(
     _Pred&& __pred,
     _Proj1&& __proj1,
     _Proj2&& __proj2) {
-  using _D1 = __iterator_difference_type<_Iter1>;
+  using _D1   = __iterator_difference_type<_Iter1>;
+  using _Ref1 = typename iterator_traits<_Iter1>::reference;
+  using _Ref2 = typename iterator_traits<_Iter2>::reference;
+  __identity __ident;
 
   for (auto __i = __first1; __i != __last1; ++__i) {
-    //  Have we already counted the number of *__i in [f1, l1)?
-    auto __match = __first1;
-    for (; __match != __i; ++__match) {
-      if (std::__invoke(__pred, std::__invoke(__proj1, *__match), std::__invoke(__proj1, *__i)))
-        break;
-    }
+    _Ref1 __va = *__i;
 
-    if (__match == __i) {
+    //  Have we already counted the number of *__i in [f1, l1)?
+    auto __match_pred = [&](_Ref1 __x) -> bool {
+      return std::__invoke(__pred, std::__invoke(__proj1, __x), std::__invoke(__proj1, __va));
+    };
+    if (std::__find_if(__first1, __i, __match_pred, __ident) == __i) {
       // Count number of *__i in [f2, l2)
-      _D1 __c2 = 0;
-      for (auto __j = __first2; __j != __last2; ++__j) {
-        if (std::__invoke(__pred, std::__invoke(__proj1, *__i), std::__invoke(__proj2, *__j)))
-          ++__c2;
-      }
+      auto __predicate2 = [&](_Ref2 __x) -> bool {
+        return std::__invoke(__pred, std::__invoke(__proj1, __va), std::__invoke(__proj2, __x));
+      };
+      _D1 __c2 = std::__count_if<_AlgPolicy>(__first2, __last2, __predicate2, __ident);
       if (__c2 == 0)
         return false;
 
       // Count number of *__i in [__i, l1) (we can start with 1)
-      _D1 __c1 = 1;
-      for (auto __j = _IterOps<_AlgPolicy>::next(__i); __j != __last1; ++__j) {
-        if (std::__invoke(__pred, std::__invoke(__proj1, *__i), std::__invoke(__proj1, *__j)))
-          ++__c1;
-      }
+      auto __predicate1 = [&](_Ref1 __x) -> bool {
+        return std::__invoke(__pred, std::__invoke(__proj1, __va), std::__invoke(__proj1, __x));
+      };
+      _D1 __c1 = 1 + std::__count_if<_AlgPolicy>(_IterOps<_AlgPolicy>::next(__i), __last1, __predicate1, __ident);
       if (__c1 != __c2)
         return false;
     }
@@ -116,11 +120,12 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation_impl(
 template <class _AlgPolicy, class _ForwardIterator1, class _Sentinel1, class _ForwardIterator2, class _BinaryPredicate>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
     _ForwardIterator1 __first1, _Sentinel1 __last1, _ForwardIterator2 __first2, _BinaryPredicate&& __pred) {
-  // Shorten sequences as much as possible by lopping of any equal prefix.
-  for (; __first1 != __last1; ++__first1, (void)++__first2) {
-    if (!__pred(*__first1, *__first2))
-      break;
-  }
+  // Shorten sequences as much as possible by lopping off any equal prefix (vectorized through std::__mismatch).
+  __identity __proj;
+  auto __result = std::__mismatch(
+      std::__unwrap_iter(__first1), std::__unwrap_iter(__last1), std::__unwrap_iter(__first2), __pred, __proj, __proj);
+  __first1 = std::__rewrap_iter(__first1, __result.first);
+  __first2 = std::__rewrap_iter(__first2, __result.second);
 
   if (__first1 == __last1)
     return true;
@@ -160,13 +165,10 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
     _Proj1&& __proj1,
     _Proj2&& __proj2,
     /*_ConstTimeDistance=*/false_type) {
-  // Shorten sequences as much as possible by lopping of any equal prefix.
-  while (__first1 != __last1 && __first2 != __last2) {
-    if (!std::__invoke(__pred, std::__invoke(__proj1, *__first1), std::__invoke(__proj2, *__first2)))
-      break;
-    ++__first1;
-    ++__first2;
-  }
+  // Shorten sequences as much as possible by lopping off any equal prefix.
+  auto __result = std::__mismatch(__first1, __last1, __first2, __last2, __pred, __proj1, __proj2);
+  __first1      = std::move(__result.first);
+  __first2      = std::move(__result.second);
 
   if (__first1 == __last1)
     return __first2 == __last2;


### PR DESCRIPTION
This replaces the hand-written loops in `std::is_permutation` (and the `std::ranges` version) with the library's own algorithms. The common prefix is now skipped with `std::mismatch` instead of a manual loop and since the iterators get unwrapped to pointers it lowers to the vectorized `std::__mismatch` for contiguous integral types.  the check that skips elements already counted earlier in the range uses std::__find_if and counting how many times an element appears in each range uses std::__count_if

This is basically the approach from #129565 (closed) but the main difference is I pass the predicate to `mismatch` by value instead of through `std::ref`. In that PR the `std::ref` wrapped it in a `reference_wrapper` which isn't `__equal_to` so the vectorized path got silently skipped and the speedup never showed up there

`--param optimization=speed`, QEMU virtual CPU (SSE4.2), clang 22:

```
Benchmark                                                             Baseline    Candidate    Difference    % Difference
------------------------------------------------------------------  ----------  -----------  ------------  --------------
std::is_permutation(deque<int>)_(3leg)_(common_prefix)/1024             482.14       493.18         11.05           2.29%
std::is_permutation(deque<int>)_(3leg)_(common_prefix)/8                  6.90         5.99         -0.91         -13.18%
std::is_permutation(deque<int>)_(3leg)_(common_prefix)/8192            4089.13      3929.77       -159.36          -3.90%
std::is_permutation(deque<int>)_(3leg)_(shuffled)/1024               855558.44    854969.47       -588.97          -0.07%
std::is_permutation(deque<int>)_(3leg)_(shuffled)/8                      67.23        74.15          6.91          10.28%
std::is_permutation(deque<int>)_(3leg,_pred)_(common_prefix)/1024       634.78       601.81        -32.97          -5.19%
std::is_permutation(deque<int>)_(3leg,_pred)_(common_prefix)/8            8.70         7.92         -0.78          -8.95%
std::is_permutation(deque<int>)_(3leg,_pred)_(common_prefix)/8192      5140.20      5076.78        -63.42          -1.23%
std::is_permutation(deque<int>)_(3leg,_pred)_(shuffled)/1024        1201781.18   1203871.87       2090.69           0.17%
std::is_permutation(deque<int>)_(3leg,_pred)_(shuffled)/8                96.83        81.82        -15.01         -15.50%
std::is_permutation(deque<int>)_(4leg)_(common_prefix)/1024             611.94       630.99         19.05           3.11%
std::is_permutation(deque<int>)_(4leg)_(common_prefix)/8                  9.70        11.47          1.76          18.17%
std::is_permutation(deque<int>)_(4leg)_(common_prefix)/8192            4920.25      4982.39         62.13           1.26%
std::is_permutation(deque<int>)_(4leg)_(shuffled)/1024               873246.32    888318.88      15072.56           1.73%
std::is_permutation(deque<int>)_(4leg)_(shuffled)/8                      93.24        76.83        -16.41         -17.60%
std::is_permutation(deque<int>)_(4leg,_pred)_(common_prefix)/1024       646.25       677.51         31.26           4.84%
std::is_permutation(deque<int>)_(4leg,_pred)_(common_prefix)/8           13.97        14.70          0.73           5.23%
std::is_permutation(deque<int>)_(4leg,_pred)_(common_prefix)/8192      5093.40      5244.57        151.17           2.97%
std::is_permutation(deque<int>)_(4leg,_pred)_(shuffled)/1024        1212565.09   1218821.85       6256.75           0.52%
std::is_permutation(deque<int>)_(4leg,_pred)_(shuffled)/8                83.82        97.07         13.25          15.81%
std::is_permutation(list<int>)_(3leg)_(common_prefix)/1024             2168.78      2169.51          0.74           0.03%
std::is_permutation(list<int>)_(3leg)_(common_prefix)/8                   4.02         3.90         -0.12          -3.04%
std::is_permutation(list<int>)_(3leg)_(common_prefix)/8192            18713.26     18742.31         29.05           0.16%
std::is_permutation(list<int>)_(3leg)_(shuffled)/1024               2458574.04   2454432.13      -4141.91          -0.17%
std::is_permutation(list<int>)_(3leg)_(shuffled)/8                       66.32        55.94        -10.38         -15.65%
std::is_permutation(list<int>)_(3leg,_pred)_(common_prefix)/1024       2163.24      2066.30        -96.94          -4.48%
std::is_permutation(list<int>)_(3leg,_pred)_(common_prefix)/8             5.71         5.84          0.13           2.24%
std::is_permutation(list<int>)_(3leg,_pred)_(common_prefix)/8192      15223.56     14952.75       -270.81          -1.78%
std::is_permutation(list<int>)_(3leg,_pred)_(shuffled)/1024         2990308.09   2800720.24    -189587.85          -6.34%
std::is_permutation(list<int>)_(3leg,_pred)_(shuffled)/8                 68.54        67.81         -0.73          -1.06%
std::is_permutation(list<int>)_(4leg)_(common_prefix)/1024             2196.28      2142.74        -53.54          -2.44%
std::is_permutation(list<int>)_(4leg)_(common_prefix)/8                   5.20         5.32          0.12           2.31%
std::is_permutation(list<int>)_(4leg)_(common_prefix)/8192            15798.00     15529.93       -268.08          -1.70%
std::is_permutation(list<int>)_(4leg)_(shuffled)/1024               2462148.70   2480549.40      18400.70           0.75%
std::is_permutation(list<int>)_(4leg)_(shuffled)/8                       62.43        60.00         -2.44          -3.90%
std::is_permutation(list<int>)_(4leg,_pred)_(common_prefix)/1024       2369.96      2266.50       -103.46          -4.37%
std::is_permutation(list<int>)_(4leg,_pred)_(common_prefix)/8             6.81         7.03          0.21           3.14%
std::is_permutation(list<int>)_(4leg,_pred)_(common_prefix)/8192      19068.40     18765.54       -302.86          -1.59%
std::is_permutation(list<int>)_(4leg,_pred)_(shuffled)/1024         3055011.29   2932093.91    -122917.38          -4.02%
std::is_permutation(list<int>)_(4leg,_pred)_(shuffled)/8                 70.83        71.28          0.45           0.63%
std::is_permutation(vector<int>)_(3leg)_(common_prefix)/1024            370.60        82.74       -287.86         -77.67%
std::is_permutation(vector<int>)_(3leg)_(common_prefix)/8                 3.23         1.86         -1.38         -42.59%
std::is_permutation(vector<int>)_(3leg)_(common_prefix)/8192           2630.31       606.64      -2023.67         -76.94%
std::is_permutation(vector<int>)_(3leg)_(shuffled)/1024              405630.79    385069.49     -20561.30          -5.07%
std::is_permutation(vector<int>)_(3leg)_(shuffled)/8                     45.34        41.93         -3.41          -7.52%
std::is_permutation(vector<int>)_(3leg,_pred)_(common_prefix)/1024      409.76       410.31          0.56           0.14%
std::is_permutation(vector<int>)_(3leg,_pred)_(common_prefix)/8           3.44         3.54          0.10           2.95%
std::is_permutation(vector<int>)_(3leg,_pred)_(common_prefix)/8192     3410.68      3328.96        -81.72          -2.40%
std::is_permutation(vector<int>)_(3leg,_pred)_(shuffled)/1024        962182.45    982189.38      20006.93           2.08%
std::is_permutation(vector<int>)_(3leg,_pred)_(shuffled)/8               60.76        60.44         -0.32          -0.52%
std::is_permutation(vector<int>)_(4leg)_(common_prefix)/1024            383.95       385.06          1.11           0.29%
std::is_permutation(vector<int>)_(4leg)_(common_prefix)/8                 5.44         4.90         -0.54          -9.96%
std::is_permutation(vector<int>)_(4leg)_(common_prefix)/8192           3006.75      2888.34       -118.41          -3.94%
std::is_permutation(vector<int>)_(4leg)_(shuffled)/1024              389124.31    397689.86       8565.55           2.20%
std::is_permutation(vector<int>)_(4leg)_(shuffled)/8                     42.65        41.34         -1.31          -3.07%
std::is_permutation(vector<int>)_(4leg,_pred)_(common_prefix)/1024      507.38       468.01        -39.37          -7.76%
std::is_permutation(vector<int>)_(4leg,_pred)_(common_prefix)/8           5.12         5.18          0.07           1.30%
std::is_permutation(vector<int>)_(4leg,_pred)_(common_prefix)/8192     4156.89      3651.07       -505.82         -12.17%
std::is_permutation(vector<int>)_(4leg,_pred)_(shuffled)/1024       1003161.43   1020680.19      17518.75           1.75%
std::is_permutation(vector<int>)_(4leg,_pred)_(shuffled)/8               60.79        64.07          3.28           5.39%
Geomean                                                                1201.53      1116.24        -85.30          -7.10%
```

So roughly -7% geomean, up to ~4x faster on `vector<int>` with a common prefix. The only regressions are the size-8 cases (sub-100ns) where the find_if/count_if abstraction doesn't amortize for std::deque's segmented iterator at tiny N. there's no regression at real sizes and the `std::list` regression that showed up in #129565 is gone.

No new tests since the behavior is identical and the existing `is_permutation` tests already cover the predicate/projection/ranges/constexpr cases.

Fixes #129324

(Used AI for some parts of this but went over everything myself and ran all benchmarks etc myself)