### PR TITLE
[libunwind] Fix an uninitialized read of __ra_sign_state

### DIFF
--- a/libunwind/src/UnwindRegistersSave.S
+++ b/libunwind/src/UnwindRegistersSave.S
@@ -807,6 +807,7 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
   mov    x1,sp
   str    x1,      [x0, #0x0F8]
   str    x30,     [x0, #0x100]    // store return address as pc
+  str    xzr,     [x0, #0x108]    // zero __ra_sign_state
   // skip cpsr
 #if defined(__ARM_FP) && __ARM_FP != 0
   stp    d0, d1,  [x0, #0x110]


### PR DESCRIPTION
The Arm DWARF spec defines UNW_AARCH64_RA_SIGN_STATE as being zeroed until the first .cfi_negate_ra_state / .cfi_set_ra_state [1]. The GPRs struct containing __ra_sign_state is memcpy'd directly from the unw_context_t, which in turn is initialized by __unw_getcontext. Since it is a pseudo register, there is no corresponding state to restore in __unw_resume.

https://github.com/ARM-software/abi-aa/blob/main/aadwarf64/aadwarf64.rst#44call-frame-instructions