### PR TITLE
[mlir][llvmir] Add new support for strict fp handling

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -1790,4 +1790,183 @@ def LLVM_AnyMDAttr : AnyAttrOf<[
     LLVM_MDStringAttr, LLVM_MDConstantAttr, LLVM_MDFuncAttr, LLVM_MDNodeAttr],
     "LLVM metadata attribute (md_string, md_const, md_func, or md_node)">;
 
+//===----------------------------------------------------------------------===//
+// FenvAttr
+//===----------------------------------------------------------------------===//
+
+def LLVM_FenvAttr : LLVM_Attr<"Fenv", "fenv"> {
+  let summary = "Describes floating-point environment constraints";
+  let description = [{
+    The `#llvm.fenv` attribute describes constraints on the floating-point
+    handling of a floating-point operation. It can be attached to
+    floating-point operations to capture rounding and exception behavior. All
+    of its parameters are optional.
+
+    - `rounding_mode`: the rounding mode to use. Every value other than
+      `dynamic` specifies a static rounding mode.
+    - `dynamic_rounding_mode`: the known dynamic rounding mode at the point the
+      instruction is executed. Otherwise the behavior is undefined.
+    - `except_mode`: the known exception mode at the point the instruction is
+      executed. Otherwise the behavior is undefined.
+    - `strict_snan`: whether to handle sNaN according to IEEE rules (`true`) or
+      LLVM's relaxed NaN propagation rules (`false`). This flag is only
+      meaningful when `except_mode` is `unmasked` or `unknown`, where it
+      defaults to `true`; when `except_mode` is `masked` the flag is ignored.
+    - `strict_except`: if `false`, any case that would produce an FP exception
+      produces it non-deterministically instead (i.e. it may or may not occur).
+      This means the FP status is written non-deterministically, and, if
+      exceptions are unmasked, the instruction traps non-deterministically.
+      This flag is only meaningful when `except_mode` is `unmasked` or
+      `unknown`, where it defaults to `true`; when `except_mode` is `masked`
+      the flag is ignored.
+
+    When this attribute is present on an operation, the operation is lowered to
+    the corresponding `llvm.experimental.constrained.*` intrinsic during
+    translation to LLVM IR.
+
+    The default setting for each parameter (`dynamic` rounding mode, `unknown`
+    dynamic rounding mode, `masked` exception mode, and, when exceptions are not
+    masked, `true` for both `strict_snan` and `strict_except`) is canonically
+    represented as an unset parameter. Constructing an attribute whose
+    parameters are all set to their defaults therefore yields the same
+    canonical, empty attribute as `#llvm.fenv<>`.
+
+    Carrying the (possibly empty) attribute is *not* the same as having no
+    attribute at all. An operation that carries the attribute is lowered to the
+    corresponding constrained intrinsic, even when every parameter is at its
+    default value (the constrained intrinsic then uses the default rounding mode
+    and exception behavior). An operation with no `#llvm.fenv` attribute is
+    lowered to the regular, unconstrained operation.
+
+    Example:
+    ```mlir
+    #llvm.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown,
+               strict_snan = true, strict_except = true>
+    ```
+  }];
+
+  let parameters = (ins
+    OptionalParameter<"std::optional<::mlir::LLVM::FPRoundingMode>">:$rounding_mode,
+    OptionalParameter<
+        "std::optional<::mlir::LLVM::FPDynamicRoundingMode>">:$dynamic_rounding_mode,
+    OptionalParameter<"std::optional<::mlir::LLVM::FPExceptionMode>">:$except_mode,
+    OptionalParameter<"mlir::BoolAttr">:$strict_snan,
+    OptionalParameter<"mlir::BoolAttr">:$strict_except);
+
+  let assemblyFormat = [{
+    `<` struct($rounding_mode, $dynamic_rounding_mode, $except_mode,
+               $strict_snan, $strict_except) `>`
+  }];
+
+  // Replace the default builder so that constructing the attribute normalizes
+  // any parameter that is set to its default value to "unset". This keeps a
+  // single canonical representation for the default floating-point environment.
+  // Because `skipDefaultBuilders` suppresses the auto-synthesized const builder
+  // call, provide it explicitly. The `DefaultValuedAttr` form below uses a null
+  // attribute as its default, so this simply forwards its argument (a null
+  // attribute when the operation does not carry a `#llvm.fenv` attribute).
+  let skipDefaultBuilders = 1;
+  let constBuilderCall = "$0";
+  let builders = [
+    AttrBuilder<(ins
+        CArg<"std::optional<::mlir::LLVM::FPRoundingMode>",
+             "std::nullopt">:$roundingMode,
+        CArg<"std::optional<::mlir::LLVM::FPDynamicRoundingMode>",
+             "std::nullopt">:$dynamicRoundingMode,
+        CArg<"std::optional<::mlir::LLVM::FPExceptionMode>",
+             "std::nullopt">:$exceptMode,
+        CArg<"mlir::BoolAttr", "{}">:$strictSNaN,
+        CArg<"mlir::BoolAttr", "{}">:$strictExcept), [{
+      if (roundingMode == ::mlir::LLVM::FPRoundingMode::Dynamic)
+        roundingMode = std::nullopt;
+      if (dynamicRoundingMode == ::mlir::LLVM::FPDynamicRoundingMode::Unknown)
+        dynamicRoundingMode = std::nullopt;
+      if (exceptMode == ::mlir::LLVM::FPExceptionMode::Masked)
+        exceptMode = std::nullopt;
+      // `strict_snan` and `strict_except` are only meaningful when exceptions
+      // are not masked, where they default to `true`. When exceptions are
+      // masked (the default) they are ignored, so drop them; otherwise elide a
+      // flag only when it matches the `true` default. After the normalization
+      // above, masked == unset.
+      if (!exceptMode || (strictSNaN && strictSNaN.getValue()))
+        strictSNaN = {};
+      if (!exceptMode || (strictExcept && strictExcept.getValue()))
+        strictExcept = {};
+      return Base::get($_ctxt, roundingMode, dynamicRoundingMode, exceptMode,
+                       strictSNaN, strictExcept);
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+    /// The default rounding mode used when `rounding_mode` is unset.
+    static constexpr ::mlir::LLVM::FPRoundingMode getDefaultRoundingMode() {
+      return ::mlir::LLVM::FPRoundingMode::Dynamic;
+    }
+    /// The default dynamic rounding mode used when `dynamic_rounding_mode` is
+    /// unset.
+    static constexpr ::mlir::LLVM::FPDynamicRoundingMode
+    getDefaultDynamicRoundingMode() {
+      return ::mlir::LLVM::FPDynamicRoundingMode::Unknown;
+    }
+    /// The default exception mode used when `except_mode` is unset.
+    static constexpr ::mlir::LLVM::FPExceptionMode getDefaultExceptionMode() {
+      return ::mlir::LLVM::FPExceptionMode::Masked;
+    }
+
+    /// Returns the effective rounding mode, substituting the default when unset.
+    ::mlir::LLVM::FPRoundingMode getRoundingModeOrDefault() const {
+      return getRoundingMode().value_or(getDefaultRoundingMode());
+    }
+    /// Returns the effective dynamic rounding mode, substituting the default
+    /// when unset.
+    ::mlir::LLVM::FPDynamicRoundingMode getDynamicRoundingModeOrDefault() const {
+      return getDynamicRoundingMode().value_or(getDefaultDynamicRoundingMode());
+    }
+    /// Returns the effective exception mode, substituting the default when
+    /// unset.
+    ::mlir::LLVM::FPExceptionMode getExceptionModeOrDefault() const {
+      return getExceptMode().value_or(getDefaultExceptionMode());
+    }
+    /// Returns the effective `strict_snan` flag. This flag is only meaningful
+    /// when exceptions are not masked, where it defaults to `true`. When
+    /// exceptions are masked it is ignored and reported as `false`.
+    bool getStrictSNaNOrDefault() const {
+      if (getExceptionModeOrDefault() == ::mlir::LLVM::FPExceptionMode::Masked)
+        return false;
+      ::mlir::BoolAttr attr = getStrictSnan();
+      return attr ? attr.getValue() : true;
+    }
+    /// Returns the effective `strict_except` flag. This flag is only meaningful
+    /// when exceptions are not masked, where it defaults to `true`. When
+    /// exceptions are masked it is ignored and reported as `false`.
+    bool getStrictExceptOrDefault() const {
+      if (getExceptionModeOrDefault() == ::mlir::LLVM::FPExceptionMode::Masked)
+        return false;
+      ::mlir::BoolAttr attr = getStrictExcept();
+      return attr ? attr.getValue() : true;
+    }
+
+    /// Returns true if every parameter is at its default value, i.e. the
+    /// attribute describes the default floating-point environment and imposes
+    /// no constraints. Because the builder normalizes defaults to "unset", this
+    /// is equivalent to all parameters being unset.
+    bool isDefault() const {
+      return !getRoundingMode() && !getDynamicRoundingMode() &&
+             !getExceptMode() && !getStrictSnan() && !getStrictExcept();
+    }
+  }];
+}
+
+// Default-valued form of the fenv attribute. Using a `DefaultValuedAttr`
+// (instead of `OptionalAttr`) keeps the attribute optional in generated
+// builders without dropping the default values of any preceding optional
+// builder arguments (e.g. `fastmathFlags`), so existing call sites are not
+// broken. The default is a *null* attribute (rather than a materialized empty
+// `#llvm.fenv<>`): an operation that does not carry the attribute stores a null
+// attribute and `getFenvAttr()` returns null, which lets the lowering
+// distinguish "no `fenv` attribute" (regular operation) from "an explicit
+// `fenv` attribute, possibly empty" (constrained intrinsic with default
+// settings).
+def LLVM_DefaultFenvAttr : DefaultValuedAttr<LLVM_FenvAttr, "nullptr">;
+
 #endif // LLVMIR_ATTRDEFS

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
@@ -546,6 +546,60 @@ def LLVM_FastmathFlagsAttr :
 }
 
 //===----------------------------------------------------------------------===//
+// Floating-point environment enums (used by the `#llvm.fenv` attribute)
+//===----------------------------------------------------------------------===//
+
+def FPRoundingMode : I32EnumAttr<
+    "FPRoundingMode", "floating-point rounding mode", [
+  I32EnumAttrCase<"Dynamic", 0, "dynamic">,
+  I32EnumAttrCase<"ToNearest", 1, "tonearest">,
+  I32EnumAttrCase<"Downward", 2, "downward">,
+  I32EnumAttrCase<"Upward", 3, "upward">,
+  I32EnumAttrCase<"UpwardZero", 4, "upwardzero">,
+  I32EnumAttrCase<"ToNearestAway", 5, "tonearestaway">
+]> {
+  let description = [{
+    The rounding mode to use for a floating-point operation. Every value other
+    than `dynamic` specifies a static rounding mode.
+  }];
+  let cppNamespace = "::mlir::LLVM";
+  let genSpecializedAttr = 0;
+}
+
+def FPDynamicRoundingMode : I32EnumAttr<
+    "FPDynamicRoundingMode", "floating-point dynamic rounding mode", [
+  I32EnumAttrCase<"Unknown", 0, "unknown">,
+  I32EnumAttrCase<"ToNearest", 1, "tonearest">,
+  I32EnumAttrCase<"Downward", 2, "downward">,
+  I32EnumAttrCase<"Upward", 3, "upward">,
+  I32EnumAttrCase<"UpwardZero", 4, "upwardzero">,
+  I32EnumAttrCase<"ToNearestAway", 5, "tonearestaway">
+]> {
+  let description = [{
+    The known dynamic rounding mode at the point the instruction is executed.
+    If the actual dynamic rounding mode differs from this value, the behavior
+    is undefined.
+  }];
+  let cppNamespace = "::mlir::LLVM";
+  let genSpecializedAttr = 0;
+}
+
+def FPExceptionMode : I32EnumAttr<
+    "FPExceptionMode", "floating-point exception mode", [
+  I32EnumAttrCase<"Unknown", 0, "unknown">,
+  I32EnumAttrCase<"Masked", 1, "masked">,
+  I32EnumAttrCase<"Unmasked", 2, "unmasked">
+]> {
+  let description = [{
+    The known floating-point exception mode at the point the instruction is
+    executed. If the actual exception mode differs from this value, the
+    behavior is undefined.
+  }];
+  let cppNamespace = "::mlir::LLVM";
+  let genSpecializedAttr = 0;
+}
+
+//===----------------------------------------------------------------------===//
 // FCmp and ICmp Predicates
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
@@ -49,6 +49,111 @@ def FastmathFlagsInterface : OpInterface<"FastmathFlagsInterface"> {
   ];
 }
 
+def FPEnvConstrainedOpInterface : OpInterface<"FPEnvConstrainedOpInterface"> {
+  let description = [{
+    This interface is implemented by floating-point operations that can carry an
+    optional `#llvm.fenv` attribute describing constraints on their
+    floating-point environment. It provides a uniform API for querying the
+    attribute and its individual fields.
+
+    When the attribute is present, the operation is lowered to the corresponding
+    `llvm.experimental.constrained.*` intrinsic during translation to LLVM IR.
+  }];
+
+  let cppNamespace = "::mlir::LLVM";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/        [{Returns the `#llvm.fenv` attribute attached to the
+                         operation, or a null attribute if none is present.}],
+      /*returnType=*/  "::mlir::LLVM::FenvAttr",
+      /*methodName=*/  "getFenvAttr",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        auto op = cast<ConcreteOp>(this->getOperation());
+        return op.getFenvAttr();
+      }]
+      >,
+    InterfaceMethod<
+      /*desc=*/        [{Returns the effective rounding mode requested by the
+                         attribute, substituting the default (`dynamic`) when the
+                         attribute is absent or does not request a static
+                         rounding mode.}],
+      /*returnType=*/  "::mlir::LLVM::FPRoundingMode",
+      /*methodName=*/  "getFenvRoundingMode",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        ::mlir::LLVM::FenvAttr attr = $_op.getFenvAttr();
+        return attr ? attr.getRoundingModeOrDefault()
+                    : ::mlir::LLVM::FenvAttr::getDefaultRoundingMode();
+      }]
+      >,
+    InterfaceMethod<
+      /*desc=*/        [{Returns the effective known dynamic rounding mode
+                         requested by the attribute, substituting the default
+                         (`unknown`) when the attribute is absent or does not set
+                         the field.}],
+      /*returnType=*/  "::mlir::LLVM::FPDynamicRoundingMode",
+      /*methodName=*/  "getFenvDynamicRoundingMode",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        ::mlir::LLVM::FenvAttr attr = $_op.getFenvAttr();
+        return attr ? attr.getDynamicRoundingModeOrDefault()
+                    : ::mlir::LLVM::FenvAttr::getDefaultDynamicRoundingMode();
+      }]
+      >,
+    InterfaceMethod<
+      /*desc=*/        [{Returns the effective known exception mode requested by
+                         the attribute, substituting the default (`masked`) when
+                         the attribute is absent or does not set the field.}],
+      /*returnType=*/  "::mlir::LLVM::FPExceptionMode",
+      /*methodName=*/  "getFenvExceptionMode",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        ::mlir::LLVM::FenvAttr attr = $_op.getFenvAttr();
+        return attr ? attr.getExceptionModeOrDefault()
+                    : ::mlir::LLVM::FenvAttr::getDefaultExceptionMode();
+      }]
+      >,
+    InterfaceMethod<
+      /*desc=*/        [{Returns the effective strict-sNaN flag requested by the
+                         attribute. The flag is only meaningful when
+                         `except_mode` is `unmasked` or `unknown`, where it
+                         defaults to `true`; when `except_mode` is `masked` (or
+                         the attribute is absent) it is ignored and reported as
+                         `false`.}],
+      /*returnType=*/  "bool",
+      /*methodName=*/  "getFenvStrictSNaN",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        ::mlir::LLVM::FenvAttr attr = $_op.getFenvAttr();
+        return attr ? attr.getStrictSNaNOrDefault() : false;
+      }]
+      >,
+    InterfaceMethod<
+      /*desc=*/        [{Returns the effective strict-exception flag requested by
+                         the attribute. The flag is only meaningful when
+                         `except_mode` is `unmasked` or `unknown`, where it
+                         defaults to `true`; when `except_mode` is `masked` (or
+                         the attribute is absent) it is ignored and reported as
+                         `false`.}],
+      /*returnType=*/  "bool",
+      /*methodName=*/  "getFenvStrictExcept",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        ::mlir::LLVM::FenvAttr attr = $_op.getFenvAttr();
+        return attr ? attr.getStrictExceptOrDefault() : false;
+      }]
+      >
+  ];
+}
+
 def IntegerOverflowFlagsInterface : OpInterface<"IntegerOverflowFlagsInterface"> {
   let description = [{
     This interface defines an LLVM operation with integer overflow flags and

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -16,11 +16,15 @@ include "mlir/Interfaces/MemorySlotInterfaces.td"
 class LLVM_UnaryIntrOpBase<string func, Type element,
                            list<Trait> traits = [], bit requiresFastmath = 0> :
     LLVM_OneResultIntrOp<func, [], [0],
-           !listconcat([Pure, SameOperandsAndResultType], traits),
+           !listconcat(
+             !if(!gt(requiresFastmath, 0), LLVM_FPEnvConstrainedTraits, [Pure]),
+             [SameOperandsAndResultType], traits),
            requiresFastmath> {
   dag commonArgs = (ins LLVM_ScalarOrVectorOf<element>:$in);
   let assemblyFormat = "`(` operands `)` attr-dict `:` "
       "functional-type(operands, results)";
+  let extraClassDefinition = !if(!gt(requiresFastmath, 0),
+                                 LLVM_FPEnvConstrainedDefs, [{}]);
 }
 
 class LLVM_UnaryIntrOpI<string func, list<Trait> traits = []> :
@@ -29,21 +33,33 @@ class LLVM_UnaryIntrOpI<string func, list<Trait> traits = []> :
 }
 
 class LLVM_UnaryIntrOpF<string func, list<Trait> traits = []> :
-    LLVM_UnaryIntrOpBase<func, LLVM_AnyFloat, traits, /*requiresFastmath=*/1> {
-  dag fmfArg = (
-    ins DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags);
-  let arguments = !con(commonArgs, fmfArg);
+    LLVM_UnaryIntrOpBase<func, LLVM_AnyFloat, traits,
+        /*requiresFastmath=*/1> {
+  dag fpArgs = (
+    ins DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags,
+        LLVM_DefaultFenvAttr:$fenv);
+  let arguments = !con(commonArgs, fpArgs);
+  let llvmBuilder = [{
+    if (op.getFenvAttr()) {
+      return emitConstrainedFPIntrinsic(op, llvm::Intrinsic::}]
+      # llvmEnumName # [{, builder, moduleTranslation);
+    }
+  }] # baseLlvmBuilder # baseLlvmBuilderCoda;
 }
 
 class LLVM_BinarySameArgsIntrOpBase<string func, Type element,
               list<Trait> traits = [], bit requiresFastmath = 0> :
     LLVM_OneResultIntrOp<func, [], [0],
-           !listconcat([Pure, SameOperandsAndResultType], traits),
+           !listconcat(
+             !if(!gt(requiresFastmath, 0), LLVM_FPEnvConstrainedTraits, [Pure]),
+             [SameOperandsAndResultType], traits),
            requiresFastmath> {
   dag commonArgs = (ins LLVM_ScalarOrVectorOf<element>:$a,
                         LLVM_ScalarOrVectorOf<element>:$b);
   let assemblyFormat = "`(` operands `)` attr-dict `:` "
       "functional-type(operands, results)";
+  let extraClassDefinition = !if(!gt(requiresFastmath, 0),
+                                 LLVM_FPEnvConstrainedDefs, [{}]);
 }
 
 class LLVM_BinarySameArgsIntrOpI<string func, list<Trait> traits = []> :
@@ -54,21 +70,32 @@ class LLVM_BinarySameArgsIntrOpI<string func, list<Trait> traits = []> :
 class LLVM_BinarySameArgsIntrOpF<string func, list<Trait> traits = []> :
     LLVM_BinarySameArgsIntrOpBase<func, LLVM_AnyFloat, traits,
                                   /*requiresFastmath=*/1> {
-  dag fmfArg = (
-    ins DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags);
-  let arguments = !con(commonArgs, fmfArg);
+  dag fpArgs = (
+    ins DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags,
+        LLVM_DefaultFenvAttr:$fenv);
+  let arguments = !con(commonArgs, fpArgs);
+  let llvmBuilder = [{
+    if (op.getFenvAttr()) {
+      return emitConstrainedFPIntrinsic(op, llvm::Intrinsic::}]
+      # llvmEnumName # [{, builder, moduleTranslation);
+    }
+  }] # baseLlvmBuilder # baseLlvmBuilderCoda;
 }
 
 class LLVM_TernarySameArgsIntrOpBase<string func, Type element,
               list<Trait> traits = [], bit requiresFastmath = 0> :
     LLVM_OneResultIntrOp<func, [], [0],
-           !listconcat([Pure, SameOperandsAndResultType], traits),
+           !listconcat(
+             !if(!gt(requiresFastmath, 0), LLVM_FPEnvConstrainedTraits, [Pure]),
+             [SameOperandsAndResultType], traits),
            requiresFastmath> {
   dag commonArgs = (ins LLVM_ScalarOrVectorOf<element>:$a,
                        LLVM_ScalarOrVectorOf<element>:$b,
                        LLVM_ScalarOrVectorOf<element>:$c);
   let assemblyFormat = "`(` operands `)` attr-dict `:` "
       "functional-type(operands, results)";
+  let extraClassDefinition = !if(!gt(requiresFastmath, 0),
+                                 LLVM_FPEnvConstrainedDefs, [{}]);
 }
 
 class LLVM_TernarySameArgsIntrOpI<string func, list<Trait> traits = []> :
@@ -79,9 +106,16 @@ class LLVM_TernarySameArgsIntrOpI<string func, list<Trait> traits = []> :
 class LLVM_TernarySameArgsIntrOpF<string func, list<Trait> traits = []> :
     LLVM_TernarySameArgsIntrOpBase<func, LLVM_AnyFloat, traits,
                                   /*requiresFastmath=*/1> {
-  dag fmfArg = (
-    ins DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags);
-  let arguments = !con(commonArgs, fmfArg);
+  dag fpArgs = (
+    ins DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags,
+        LLVM_DefaultFenvAttr:$fenv);
+  let arguments = !con(commonArgs, fpArgs);
+  let llvmBuilder = [{
+    if (op.getFenvAttr()) {
+      return emitConstrainedFPIntrinsic(op, llvm::Intrinsic::}]
+      # llvmEnumName # [{, builder, moduleTranslation);
+    }
+  }] # baseLlvmBuilder # baseLlvmBuilderCoda;
 }
 
 class LLVM_CountZerosIntrOp<string func, list<Trait> traits = []> :

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOpBase.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOpBase.td
@@ -21,6 +21,53 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
 
 //===----------------------------------------------------------------------===//
+// Floating-point environment (`#llvm.fenv`) traits.
+//===----------------------------------------------------------------------===//
+
+// Traits modeling the conditional purity of an operation that may carry a
+// `#llvm.fenv` attribute. Such operations are not unconditionally `Pure`:
+//   - They are speculatable only when floating-point exceptions are masked.
+//   - They carry an observable (write) side effect only when an exception may
+//      be raised (the exception mode is not `masked`) and it must be preserved
+//     (`strict_except` is set); otherwise the effect can be ignored, which
+//     keeps them eligible for dead-code elimination even when not speculatable.
+// The accompanying method definitions are provided by
+// `LLVM_FPEnvConstrainedDefs` and delegate to helpers in LLVMDialect.cpp.
+defvar LLVM_FPEnvConstrainedTraits = [
+    FPEnvConstrainedOpInterface,
+    DeclareOpInterfaceMethods<ConditionallySpeculatable>,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>];
+
+// Out-of-line definitions of the ConditionallySpeculatable and
+// MemoryEffectOpInterface methods for operations carrying a `#llvm.fenv`
+// attribute. Intended for use as (part of) an op's `extraClassDefinition`.
+defvar LLVM_FPEnvConstrainedDefs = [{
+  ::mlir::Speculation::Speculatability $cppClass::getSpeculatability() {
+    return ::getFPEnvSpeculatability(*this);
+  }
+  void $cppClass::getEffects(
+      ::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<
+          ::mlir::MemoryEffects::Effect>> &effects) {
+    ::getFPEnvEffects(*this, effects);
+  }
+}];
+
+// `llvmBuilder` prefix for math intrinsic operations that can carry a
+// `#llvm.fenv` attribute. When the attribute is present it routes to the
+// matching `llvm.experimental.constrained.*` intrinsic instead of the plain
+// intrinsic emitted by the default builder. The operation's base intrinsic ID
+// must be spliced in via the operation's `llvmEnumName` field, so this is
+// inlined directly into the relevant `LLVM_*IntrOpF` classes:
+//   let llvmBuilder = [{
+//       if (op.getFenvAttr()) {
+//         return emitConstrainedFPIntrinsic(op, llvm::Intrinsic::}]
+//       # llvmEnumName # [{, builder, moduleTranslation);
+//       }
+//     }] # baseLlvmBuilder # baseLlvmBuilderCoda;
+// `emitConstrainedFPIntrinsic` (LLVMToLLVMIRTranslation.cpp) maps the base ID
+//  to its constrained counterpart via `ConstrainedOps.def`.
+
+//===----------------------------------------------------------------------===//
 // LLVM dialect type constraints.
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -38,8 +38,7 @@ class LLVM_TerminatorOp<string mnemonic, list<Trait> traits = []> :
 // Class for arithmetic binary operations.
 class LLVM_ArithmeticOpBase<Type type, string mnemonic,
                             string instName, list<Trait> traits = []> :
-    LLVM_Op<mnemonic,
-           !listconcat([SameOperandsAndResultType, NoMemoryEffect], traits)>,
+    LLVM_Op<mnemonic, !listconcat([SameOperandsAndResultType], traits)>,
     LLVM_Builder<"$res = builder.Create" # instName # "($lhs, $rhs);"> {
   dag commonArgs = (ins LLVM_ScalarOrVectorOf<type>:$lhs,
                     LLVM_ScalarOrVectorOf<type>:$rhs);
@@ -50,7 +49,8 @@ class LLVM_ArithmeticOpBase<Type type, string mnemonic,
 }
 class LLVM_IntArithmeticOp<string mnemonic, string instName,
                            list<Trait> traits = []> :
-    LLVM_ArithmeticOpBase<AnySignlessInteger, mnemonic, instName, traits> {
+    LLVM_ArithmeticOpBase<AnySignlessInteger, mnemonic, instName,
+    !listconcat([NoMemoryEffect], traits)> {
   let arguments = commonArgs;
   string mlirBuilder = [{
     $res = $_qualCppClassName::create($_builder, $_location, $lhs, $rhs);
@@ -59,7 +59,9 @@ class LLVM_IntArithmeticOp<string mnemonic, string instName,
 class LLVM_IntArithmeticOpWithOverflowFlag<string mnemonic, string instName,
                                    list<Trait> traits = []> :
     LLVM_ArithmeticOpBase<AnySignlessInteger, mnemonic, instName,
-    !listconcat([DeclareOpInterfaceMethods<IntegerOverflowFlagsInterface>], traits)> {
+    !listconcat([NoMemoryEffect,
+                 DeclareOpInterfaceMethods<IntegerOverflowFlagsInterface>],
+                traits)> {
   dag iofArg = (ins LLVM_IntegerOverflowFlagsProp:$overflowFlags);
   let arguments = !con(commonArgs, iofArg);
 
@@ -78,7 +80,8 @@ class LLVM_IntArithmeticOpWithOverflowFlag<string mnemonic, string instName,
 class LLVM_IntArithmeticOpWithExactFlag<string mnemonic, string instName,
                                    list<Trait> traits = []> :
     LLVM_ArithmeticOpBase<AnySignlessInteger, mnemonic, instName,
-    !listconcat([DeclareOpInterfaceMethods<ExactFlagInterface>], traits)> {
+    !listconcat([NoMemoryEffect, DeclareOpInterfaceMethods<ExactFlagInterface>],
+                traits)> {
   let arguments = !con(commonArgs, (ins UnitAttr:$isExact));
 
   string mlirBuilder = [{
@@ -96,7 +99,9 @@ class LLVM_IntArithmeticOpWithExactFlag<string mnemonic, string instName,
 class LLVM_IntArithmeticOpWithDisjointFlag<string mnemonic, string instName,
                                    list<Trait> traits = []> :
     LLVM_ArithmeticOpBase<AnySignlessInteger, mnemonic, instName,
-    !listconcat([DeclareOpInterfaceMethods<DisjointFlagInterface>], traits)> {
+    !listconcat([NoMemoryEffect,
+                 DeclareOpInterfaceMethods<DisjointFlagInterface>],
+                traits)> {
   let arguments = !con(commonArgs, (ins UnitAttr:$isDisjoint));
 
   string mlirBuilder = [{
@@ -116,11 +121,14 @@ class LLVM_IntArithmeticOpWithDisjointFlag<string mnemonic, string instName,
 class LLVM_FloatArithmeticOp<string mnemonic, string instName,
                              list<Trait> traits = []> :
     LLVM_ArithmeticOpBase<LLVM_AnyFloat, mnemonic, instName,
-    !listconcat([DeclareOpInterfaceMethods<FastmathFlagsInterface>, Pure],
+    !listconcat([DeclareOpInterfaceMethods<FastmathFlagsInterface>],
+                 LLVM_FPEnvConstrainedTraits,
                  traits)> {
-  dag fmfArg = (
-    ins DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags);
-  let arguments = !con(commonArgs, fmfArg);
+  dag fpArgs = (
+    ins DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags,
+        LLVM_DefaultFenvAttr:$fenv);
+  let arguments = !con(commonArgs, fpArgs);
+  let extraClassDefinition = LLVM_FPEnvConstrainedDefs;
   string mlirBuilder = [{
     auto op = $_qualCppClassName::create($_builder, $_location, $lhs, $rhs);
     moduleImport.setFastmathFlagsAttr(inst, op);
@@ -132,15 +140,25 @@ class LLVM_FloatArithmeticOp<string mnemonic, string instName,
 class LLVM_UnaryFloatArithmeticOp<Type type, string mnemonic,
                                   string instName, list<Trait> traits = []> :
     LLVM_Op<mnemonic,
-           !listconcat([Pure, SameOperandsAndResultType, DeclareOpInterfaceMethods<FastmathFlagsInterface>], traits)>,
+           !listconcat([SameOperandsAndResultType, DeclareOpInterfaceMethods<FastmathFlagsInterface>], LLVM_FPEnvConstrainedTraits, traits)>,
     LLVM_Builder<"$res = builder.Create" # instName # "($operand);"> {
   let arguments = (
     ins type:$operand,
-    DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags);
+    DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags,
+    LLVM_DefaultFenvAttr:$fenv);
   let results = (outs type:$res);
   let builders = [LLVM_OneResultOpBuilder];
   let assemblyFormat = "$operand attr-dict `:` type($res)";
+  let extraClassDefinition = LLVM_FPEnvConstrainedDefs;
   string llvmInstName = instName;
+  // Unary floating-point arithmetic (`llvm.fneg`) has no constrained intrinsic
+  // counterpart, so reject a `fenv` attribute during translation.
+  let llvmBuilder = [{
+    if (op.getFenvAttr())
+      return op.emitError("no constrained intrinsic is available for '")
+             << op->getName().getStringRef() << "' carrying a 'fenv' attribute";
+    $res = builder.Create}] # instName # [{($operand);
+  }];
   string mlirBuilder = [{
     auto op = $_qualCppClassName::create($_builder, $_location, $operand);
     moduleImport.setFastmathFlagsAttr(inst, op);
@@ -206,17 +224,23 @@ def LLVM_ICmpOp : LLVM_ArithmeticCmpOp<"icmp", [Pure]> {
 }
 
 // Other floating-point operations.
-def LLVM_FCmpOp : LLVM_ArithmeticCmpOp<"fcmp", [
-    Pure, DeclareOpInterfaceMethods<FastmathFlagsInterface>]> {
+def LLVM_FCmpOp : LLVM_ArithmeticCmpOp<"fcmp", !listconcat(
+    [DeclareOpInterfaceMethods<FastmathFlagsInterface>],
+    LLVM_FPEnvConstrainedTraits)> {
   let arguments = (ins FCmpPredicate:$predicate,
                    LLVM_ScalarOrVectorOf<LLVM_AnyFloat>:$lhs,
                    LLVM_ScalarOrVectorOf<LLVM_AnyFloat>:$rhs,
                    DefaultValuedAttr<LLVM_FastmathFlagsAttr,
-                                     "{}">:$fastmathFlags);
+                                     "{}">:$fastmathFlags,
+                   LLVM_DefaultFenvAttr:$fenv);
   let hasCustomAssemblyFormat = 1;
+  let extraClassDefinition = LLVM_FPEnvConstrainedDefs;
   string llvmInstName = "FCmp";
+  // `emitConstrainedFCmp` chooses a plain `fcmp` or a quiet/signaling
+  // `experimental.constrained.fcmp(s)` based on the `fenv` attribute (it falls
+  // back to a plain `fcmp` when no `fenv` attribute is present).
   string llvmBuilder = [{
-    $res = builder.CreateFCmp(convertFCmpPredicateToLLVM($predicate), $lhs, $rhs);
+    return emitConstrainedFCmp(op, builder, moduleTranslation);
   }];
   string mlirBuilder = [{
     auto *fCmpInst = cast<llvm::FCmpInst>(inst);
@@ -226,8 +250,9 @@ def LLVM_FCmpOp : LLVM_ArithmeticCmpOp<"fcmp", [
     $res = op;
   }];
   // Set the $predicate index to -1 to indicate there is no matching operand
-  // and decrement the following indices.
-  list<int> llvmArgIndices = [-1, 0, 1, 2];
+  // and decrement the following indices. The trailing -1 corresponds to the
+  // optional `fenv` attribute, which has no matching LLVM IR operand.
+  list<int> llvmArgIndices = [-1, 0, 1, 2, -1];
 }
 
 // Floating point binary operations.
@@ -590,15 +615,17 @@ class LLVM_CastOpWithOverflowFlag<string mnemonic, string instName, Type type,
 
 class LLVM_CastOpWithFastMathFlag<string mnemonic, string instName, Type type,
                   Type resultType, list<Trait> traits = []> :
-    LLVM_Op<mnemonic, !listconcat([Pure], [DeclareOpInterfaceMethods<FastmathFlagsInterface>], traits)>,
+    LLVM_Op<mnemonic, !listconcat([DeclareOpInterfaceMethods<FastmathFlagsInterface>], LLVM_FPEnvConstrainedTraits, traits)>,
     LLVM_Builder<"$res = builder.Create" # instName # "($arg, $_resultType);"> {
   let arguments = (
     ins type:$arg,
-    DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags);
+    DefaultValuedAttr<LLVM_FastmathFlagsAttr, "{}">:$fastmathFlags,
+    LLVM_DefaultFenvAttr:$fenv);
   let results = (outs resultType:$res);
   let builders = [LLVM_OneResultOpBuilder];
   let assemblyFormat = "$arg (`fastmath` `` $fastmathFlags^)? "
                        "attr-dict `:` type($arg) `to` type($res)";
+  let extraClassDefinition = LLVM_FPEnvConstrainedDefs;
   string llvmInstName = instName;
   string mlirBuilder = [{
     auto op = $_qualCppClassName::create($_builder,
@@ -2574,7 +2601,8 @@ def LLVM_CallIntrinsicOp
     : LLVM_Op<"call_intrinsic",
               [ArgAndResultAttrsOpInterface,
                AttrSizedOperandSegments,
-               DeclareOpInterfaceMethods<FastmathFlagsInterface>]> {
+               DeclareOpInterfaceMethods<FastmathFlagsInterface>,
+               FPEnvConstrainedOpInterface]> {
   let summary = "Call to an LLVM intrinsic function.";
   let description = [{
     Call the specified llvm intrinsic. If the intrinsic is overloaded, use
@@ -2588,7 +2616,8 @@ def LLVM_CallIntrinsicOp
                        DenseI32ArrayAttr:$op_bundle_sizes,
                        OptionalAttr<ArrayAttr>:$op_bundle_tags,
                        OptionalAttr<DictArrayAttr>:$arg_attrs,
-                       OptionalAttr<DictArrayAttr>:$res_attrs);
+                       OptionalAttr<DictArrayAttr>:$res_attrs,
+                       LLVM_DefaultFenvAttr:$fenv);
   let results = (outs Optional<LLVM_Type>:$results);
   let llvmBuilder = [{
     return convertCallLLVMIntrinsicOp(op, builder, moduleTranslation);

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -75,10 +75,10 @@ getFPEnvSpeculatability(LLVM::FPEnvConstrainedOpInterface op) {
 /// exception is required to be preserved (`strict_except` is set). Otherwise
 /// the effect can be ignored, leaving the operation eligible for dead-code
 /// elimination even when it is not speculatable.
-static void
-getFPEnvEffects(LLVM::FPEnvConstrainedOpInterface op,
-                SmallVectorImpl<SideEffects::EffectInstance<
-                    MemoryEffects::Effect>> &effects) {
+static void getFPEnvEffects(
+    LLVM::FPEnvConstrainedOpInterface op,
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
   if (op.getFenvExceptionMode() != LLVM::FPExceptionMode::Masked &&
       op.getFenvStrictExcept())
     effects.emplace_back(MemoryEffects::Write::get(),

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -22,6 +22,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/Interfaces/FunctionImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Transforms/InliningUtils.h"
 
 #include "llvm/ADT/APFloat.h"
@@ -42,6 +43,47 @@ using mlir::LLVM::linkage::getMaxEnumValForLinkage;
 using mlir::LLVM::tailcallkind::getMaxEnumValForTailCallKind;
 
 #include "mlir/Dialect/LLVMIR/LLVMOpsDialect.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// Floating-point environment (`#llvm.fenv`) side effects and speculation.
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Side-effect resource modeling the floating-point exception state. An
+/// operation that may raise a floating-point exception that must be preserved
+/// carries a write effect on this resource.
+struct FPExceptionStateResource
+    : public SideEffects::Resource::Base<FPExceptionStateResource> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FPExceptionStateResource)
+  StringRef getName() const final { return "<FPExceptionState>"; }
+};
+} // namespace
+
+/// Computes the speculatability of an operation carrying a `#llvm.fenv`
+/// attribute. The operation can be speculatively executed exactly when
+/// floating-point exceptions are masked.
+static ::mlir::Speculation::Speculatability
+getFPEnvSpeculatability(LLVM::FPEnvConstrainedOpInterface op) {
+  return op.getFenvExceptionMode() == LLVM::FPExceptionMode::Masked
+             ? ::mlir::Speculation::Speculatability::Speculatable
+             : ::mlir::Speculation::Speculatability::NotSpeculatable;
+}
+
+/// Computes the memory effects of an operation carrying a `#llvm.fenv`
+/// attribute. The operation has an observable effect only when it may raise a
+/// floating-point exception (the exception mode is not `masked`) and that
+/// exception is required to be preserved (`strict_except` is set). Otherwise
+/// the effect can be ignored, leaving the operation eligible for dead-code
+/// elimination even when it is not speculatable.
+static void
+getFPEnvEffects(LLVM::FPEnvConstrainedOpInterface op,
+                SmallVectorImpl<SideEffects::EffectInstance<
+                    MemoryEffects::Effect>> &effects) {
+  if (op.getFenvExceptionMode() != LLVM::FPExceptionMode::Masked &&
+      op.getFenvStrictExcept())
+    effects.emplace_back(MemoryEffects::Write::get(),
+                         FPExceptionStateResource::get());
+}
 
 //===----------------------------------------------------------------------===//
 // Attribute Helpers
@@ -4037,7 +4079,7 @@ void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
   build(builder, state, /*resultTypes=*/TypeRange{}, intrin, args,
         FastmathFlagsAttr{},
         /*op_bundle_operands=*/{}, /*op_bundle_tags=*/{}, /*arg_attrs=*/{},
-        /*res_attrs=*/{});
+        /*res_attrs=*/{}, /*fenv=*/{});
 }
 
 void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
@@ -4046,7 +4088,7 @@ void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
   build(builder, state, /*resultTypes=*/TypeRange{}, intrin, args,
         fastMathFlags,
         /*op_bundle_operands=*/{}, /*op_bundle_tags=*/{}, /*arg_attrs=*/{},
-        /*res_attrs=*/{});
+        /*res_attrs=*/{}, /*fenv=*/{});
 }
 
 void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
@@ -4054,7 +4096,7 @@ void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
                             mlir::ValueRange args) {
   build(builder, state, {resultType}, intrin, args, FastmathFlagsAttr{},
         /*op_bundle_operands=*/{}, /*op_bundle_tags=*/{}, /*arg_attrs=*/{},
-        /*res_attrs=*/{});
+        /*res_attrs=*/{}, /*fenv=*/{});
 }
 
 void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
@@ -4063,7 +4105,7 @@ void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
                             mlir::LLVM::FastmathFlagsAttr fastMathFlags) {
   build(builder, state, resultTypes, intrin, args, fastMathFlags,
         /*op_bundle_operands=*/{}, /*op_bundle_tags=*/{}, /*arg_attrs=*/{},
-        /*res_attrs=*/{});
+        /*res_attrs=*/{}, /*fenv=*/{});
 }
 
 ParseResult CallIntrinsicOp::parse(OpAsmParser &parser,

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -20,9 +20,11 @@
 
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/FPEnv.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/MatrixBuilder.h"
 #include "llvm/IR/MemoryModelRelaxationAnnotations.h"
@@ -54,6 +56,230 @@ static llvm::FastMathFlags getFastmathFlags(FastmathFlagsInterface &op) {
     if (bitEnumContainsAll(fmfMlir, it.first))
       (ret.*(it.second))(true);
   return ret;
+}
+
+//===----------------------------------------------------------------------===//
+// Constrained floating-point lowering (the `#llvm.fenv` attribute).
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Scoped guard that configures the IRBuilder's constrained floating-point
+/// state, mirroring clang's `CodeGenFunction::CGFPOptionsRAII`. While the state
+/// is enabled, the IRBuilder automatically lowers ordinary floating-point
+/// operations (`CreateFAdd`, `CreateFCmp`, `CreateFPExt`, ...) to the matching
+/// `llvm.experimental.constrained.*` intrinsics. The previous state is restored
+/// on destruction.
+class ConstrainedFPStateRAII {
+public:
+  explicit ConstrainedFPStateRAII(llvm::IRBuilderBase &builder)
+      : builder(builder), oldIsConstrained(builder.getIsFPConstrained()),
+        oldExcept(builder.getDefaultConstrainedExcept()),
+        oldRounding(builder.getDefaultConstrainedRounding()) {}
+
+  ~ConstrainedFPStateRAII() {
+    builder.setIsFPConstrained(oldIsConstrained);
+    builder.setDefaultConstrainedExcept(oldExcept);
+    builder.setDefaultConstrainedRounding(oldRounding);
+  }
+
+  void enable(llvm::RoundingMode rounding,
+              llvm::fp::ExceptionBehavior except) {
+    builder.setIsFPConstrained(true);
+    builder.setDefaultConstrainedRounding(rounding);
+    builder.setDefaultConstrainedExcept(except);
+  }
+
+private:
+  llvm::IRBuilderBase &builder;
+  bool oldIsConstrained;
+  llvm::fp::ExceptionBehavior oldExcept;
+  llvm::RoundingMode oldRounding;
+};
+} // namespace
+
+static llvm::RoundingMode
+getConstrainedRoundingMode(LLVM::FPEnvConstrainedOpInterface fenvOp) {
+  switch (fenvOp.getFenvRoundingMode()) {
+  case LLVM::FPRoundingMode::Dynamic:
+    return llvm::RoundingMode::Dynamic;
+  case LLVM::FPRoundingMode::ToNearest:
+    return llvm::RoundingMode::NearestTiesToEven;
+  case LLVM::FPRoundingMode::Downward:
+    return llvm::RoundingMode::TowardNegative;
+  case LLVM::FPRoundingMode::Upward:
+    return llvm::RoundingMode::TowardPositive;
+  case LLVM::FPRoundingMode::UpwardZero:
+    return llvm::RoundingMode::TowardZero;
+  case LLVM::FPRoundingMode::ToNearestAway:
+    return llvm::RoundingMode::NearestTiesToAway;
+  }
+  llvm_unreachable("unknown LLVM::FPRoundingMode");
+}
+
+static llvm::fp::ExceptionBehavior
+getConstrainedExceptionBehavior(LLVM::FPEnvConstrainedOpInterface fenvOp) {
+  switch (fenvOp.getFenvExceptionMode()) {
+  case LLVM::FPExceptionMode::Masked:
+    return llvm::fp::ebIgnore;
+  case LLVM::FPExceptionMode::Unmasked:
+  case LLVM::FPExceptionMode::Unknown:
+    return fenvOp.getFenvStrictExcept() ? llvm::fp::ebStrict
+                                        : llvm::fp::ebMayTrap;
+  }
+  llvm_unreachable("unknown LLVM::FPExceptionMode");
+}
+
+/// Maps a non-constrained LLVM intrinsic to its constrained counterpart, or
+/// `not_intrinsic` if none exists. Used both for the math intrinsic dialect
+/// operations and for `llvm.call_intrinsic`. `ConstrainedOps.def` is the single
+/// source of truth for this mapping.
+static constexpr llvm::Intrinsic::ID
+getConstrainedIntrinsicFor(llvm::Intrinsic::ID base) {
+  switch (base) {
+#define DAG_FUNCTION(NAME, NARG, ROUND, INTRINSIC, DAGN)                       \
+  case llvm::Intrinsic::NAME:                                                  \
+    return llvm::Intrinsic::INTRINSIC;
+#define FUNCTION(NAME, NARG, ROUND, INTRINSIC)                                 \
+  case llvm::Intrinsic::NAME:                                                  \
+    return llvm::Intrinsic::INTRINSIC;
+#include "llvm/IR/ConstrainedOps.def"
+  default:
+    return llvm::Intrinsic::not_intrinsic;
+  }
+}
+
+/// Emits a constrained floating-point call for a function-style operation: the
+/// math intrinsic dialect operations and `llvm.call_intrinsic`. The original
+/// floating-point operands are taken from \p fpOperands and the result is mapped
+/// to \p result.
+static LogicalResult emitConstrainedFPCall(
+    Operation *op, llvm::Intrinsic::ID constrainedID, ValueRange fpOperands,
+    Value result, llvm::IRBuilderBase &builder,
+    LLVM::ModuleTranslation &moduleTranslation) {
+  llvm::Module *mod = builder.GetInsertBlock()->getModule();
+  llvm::LLVMContext &ctx = mod->getContext();
+
+  SmallVector<llvm::Value *> args = moduleTranslation.lookupValues(fpOperands);
+  llvm::Type *resultType = moduleTranslation.convertType(result.getType());
+
+  // Reconstruct the constrained intrinsic signature so the correct overloaded
+  // declaration can be resolved. Constrained intrinsics take one (exception
+  // behavior) or two (rounding mode and exception behavior) trailing metadata
+  // arguments in addition to the original floating-point arguments.
+  SmallVector<llvm::Type *> signatureArgTypes;
+  signatureArgTypes.reserve(args.size() + 2);
+  for (llvm::Value *arg : args)
+    signatureArgTypes.push_back(arg->getType());
+  unsigned numMetadataArgs =
+      llvm::Intrinsic::hasConstrainedFPRoundingModeOperand(constrainedID) ? 2
+                                                                          : 1;
+  llvm::Type *metadataType = llvm::Type::getMetadataTy(ctx);
+  for (unsigned i = 0; i < numMetadataArgs; ++i)
+    signatureArgTypes.push_back(metadataType);
+
+  llvm::FunctionType *signature =
+      llvm::FunctionType::get(resultType, signatureArgTypes, /*isVarArg=*/false);
+
+  std::string errorMsg;
+  llvm::raw_string_ostream errorOS(errorMsg);
+  SmallVector<llvm::Type *> overloadedTypes;
+  if (!llvm::Intrinsic::isSignatureValid(constrainedID, signature,
+                                         overloadedTypes, errorOS)) {
+    return op->emitError("could not resolve constrained intrinsic for the "
+                         "'fenv' attribute: ")
+           << errorMsg;
+  }
+
+  llvm::Function *callee =
+      llvm::Intrinsic::getOrInsertDeclaration(mod, constrainedID,
+                                              overloadedTypes);
+  // The rounding mode and exception behavior come from the IRBuilder's
+  // constrained floating-point state, configured by ConstrainedFPStateRAII.
+  llvm::Value *call = builder.CreateConstrainedFPCall(callee, args, "");
+  moduleTranslation.mapValue(result, call);
+  return success();
+}
+
+static bool isSignalingPredicate(LLVM::FCmpPredicate predicate) {
+  switch (predicate) {
+  case LLVM::FCmpPredicate::oeq:
+  case LLVM::FCmpPredicate::one:
+  case LLVM::FCmpPredicate::ueq:
+  case LLVM::FCmpPredicate::une:
+  case LLVM::FCmpPredicate::ugt:
+  case LLVM::FCmpPredicate::uge:
+  case LLVM::FCmpPredicate::ult:
+  case LLVM::FCmpPredicate::ule:
+  case LLVM::FCmpPredicate::uno:
+    return false;
+  default:
+    return true;
+  }
+}
+
+/// Emits the comparison for an `llvm.fcmp` carrying a `#llvm.fenv` attribute.
+///
+/// - `masked` exceptions: a plain `fcmp` instruction is emitted, even if other
+///   `fenv` fields (such as rounding) are set, since comparisons are unaffected
+///   by rounding and raise no exception.
+/// - `unmasked`/`unknown` exceptions with `strict_snan` and a non-equality
+///   predicate: a signaling comparison (`experimental.constrained.fcmps`).
+/// - `unmasked`/`unknown` exceptions otherwise: a quiet comparison
+///   (`experimental.constrained.fcmp`).
+static LogicalResult
+emitConstrainedFCmp(LLVM::FCmpOp fcmpOp, llvm::IRBuilderBase &builder,
+                    LLVM::ModuleTranslation &moduleTranslation) {
+  llvm::Value *lhs = moduleTranslation.lookupValue(fcmpOp.getLhs());
+  llvm::Value *rhs = moduleTranslation.lookupValue(fcmpOp.getRhs());
+  llvm::CmpInst::Predicate predicate =
+      convertFCmpPredicateToLLVM(fcmpOp.getPredicate());
+
+  llvm::Value *result;
+  if (fcmpOp.getFenvExceptionMode() == LLVM::FPExceptionMode::Masked) {
+    // Exceptions are masked: emit an ordinary comparison. The IRBuilder's
+    // constrained state may be enabled because of unrelated `fenv` fields, so
+    // temporarily disable it to force an unconstrained `fcmp`.
+    bool wasConstrained = builder.getIsFPConstrained();
+    builder.setIsFPConstrained(false);
+    result = builder.CreateFCmp(predicate, lhs, rhs);
+    builder.setIsFPConstrained(wasConstrained);
+  } else if (fcmpOp.getFenvStrictSNaN() &&
+             isSignalingPredicate(fcmpOp.getPredicate())) {
+    result = builder.CreateFCmpS(predicate, lhs, rhs);
+  } else {
+    result = builder.CreateFCmp(predicate, lhs, rhs);
+  }
+  moduleTranslation.mapValue(fcmpOp.getRes(), result);
+  return success();
+}
+
+/// Emits the constrained floating-point form of a math intrinsic dialect
+/// operation (sqrt, sin, fma, ...) carrying a `#llvm.fenv` attribute. These are
+/// declared with `LLVM_{Unary,BinarySameArgs,TernarySameArgs}IntrOpF<"func">`.
+/// \p base is the operation's unconstrained LLVM intrinsic. It is known
+/// statically in the generated translation code (the same ID the default
+/// builder passes to `createIntrinsicCall`) and is mapped to its constrained
+/// counterpart via `ConstrainedOps.def`. Because `getConstrainedIntrinsicFor`
+/// is `constexpr` and \p base is a compile-time constant at each call site,
+/// that mapping folds to the exact `experimental_constrained_*` intrinsic. The
+/// rounding mode and exception behavior are taken from the IRBuilder's
+/// constrained state (see ConstrainedFPStateRAII).
+///
+/// This is invoked from the generated translation code
+/// (LLVMIntrinsicConversions .inc) for the math intrinsic operations. See the
+/// `llvmBuilder` overrides on the `LLVM_*SameArgsIntrOpF`/`LLVM_UnaryIntrOpF`
+/// base classes.
+static LogicalResult
+emitConstrainedFPIntrinsic(Operation *op, llvm::Intrinsic::ID base,
+                           llvm::IRBuilderBase &builder,
+                           LLVM::ModuleTranslation &moduleTranslation) {
+  llvm::Intrinsic::ID constrainedID = getConstrainedIntrinsicFor(base);
+  if (!constrainedID)
+    return op->emitError("no constrained intrinsic is available for '")
+           << op->getName().getStringRef() << "' carrying a 'fenv' attribute";
+
+  return emitConstrainedFPCall(op, constrainedID, op->getOperands(),
+                               op->getResult(0), builder, moduleTranslation);
 }
 
 /// Convert the value of a DenseI64ArrayAttr to a vector of unsigned indices.
@@ -139,6 +365,25 @@ convertOperandBundles(OperandRangeRange bundleOperands,
 static LogicalResult
 convertCallLLVMIntrinsicOp(CallIntrinsicOp op, llvm::IRBuilderBase &builder,
                            LLVM::ModuleTranslation &moduleTranslation) {
+  // A non-default `#llvm.fenv` attribute selects the constrained variant of the
+  // named intrinsic. The IRBuilder's constrained floating-point state
+  // (configured by ConstrainedFPStateRAII) supplies the rounding mode and
+  // exception behavior.
+  if (op.getFenvAttr()) {
+    llvm::Intrinsic::ID base = llvm::Intrinsic::lookupIntrinsicID(op.getIntrin());
+    if (!base)
+      return op.emitError("could not find LLVM intrinsic: ") << op.getIntrin();
+    llvm::Intrinsic::ID constrainedID = getConstrainedIntrinsicFor(base);
+    if (!constrainedID)
+      return op.emitError("no constrained intrinsic is available for '")
+             << op.getIntrin() << "' carrying a 'fenv' attribute";
+    if (op.getNumResults() != 1)
+      return op.emitError("constrained lowering of 'llvm.call_intrinsic' "
+                          "requires exactly one result");
+    return emitConstrainedFPCall(op, constrainedID, op.getArgs(),
+                                 op.getResult(0), builder, moduleTranslation);
+  }
+
   llvm::Module *module = builder.GetInsertBlock()->getModule();
   llvm::Intrinsic::ID id =
       llvm::Intrinsic::lookupIntrinsicID(op.getIntrinAttr());
@@ -457,6 +702,22 @@ convertOperationImpl(Operation &opInst, llvm::IRBuilderBase &builder,
   llvm::IRBuilder<>::FastMathFlagGuard fmfGuard(builder);
   if (auto fmf = dyn_cast<FastmathFlagsInterface>(opInst))
     builder.setFastMathFlags(getFastmathFlags(fmf));
+
+  // Operations carrying an `#llvm.fenv` attribute are lowered to the matching
+  // constrained floating-point intrinsic. Configure the IRBuilder's constrained
+  // floating-point state (as clang's CGFPOptionsRAII does) so that ordinary
+  // floating-point operations are emitted as the corresponding
+  // `llvm.experimental.constrained.*` intrinsics automatically. The state is
+  // restored when this guard goes out of scope. Operations the IRBuilder cannot
+  // constrain automatically (`llvm.fcmp`, the math intrinsics, and
+  // `llvm.call_intrinsic`) handle the constrained lowering themselves from
+  // their generated `llvmBuilder` code (see emitConstrainedFCmp,
+  // emitConstrainedFPIntrinsic, and convertCallLLVMIntrinsicOp).
+  ConstrainedFPStateRAII constrainedFPState(builder);
+  if (auto fenvOp = dyn_cast<LLVM::FPEnvConstrainedOpInterface>(opInst);
+      fenvOp && fenvOp.getFenvAttr())
+    constrainedFPState.enable(getConstrainedRoundingMode(fenvOp),
+                              getConstrainedExceptionBehavior(fenvOp));
 
 #include "mlir/Dialect/LLVMIR/LLVMConversions.inc"
 #include "mlir/Dialect/LLVMIR/LLVMIntrinsicConversions.inc"

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -82,8 +82,7 @@ public:
     builder.setDefaultConstrainedRounding(oldRounding);
   }
 
-  void enable(llvm::RoundingMode rounding,
-              llvm::fp::ExceptionBehavior except) {
+  void enable(llvm::RoundingMode rounding, llvm::fp::ExceptionBehavior except) {
     builder.setIsFPConstrained(true);
     builder.setDefaultConstrainedRounding(rounding);
     builder.setDefaultConstrainedExcept(except);
@@ -150,12 +149,13 @@ getConstrainedIntrinsicFor(llvm::Intrinsic::ID base) {
 
 /// Emits a constrained floating-point call for a function-style operation: the
 /// math intrinsic dialect operations and `llvm.call_intrinsic`. The original
-/// floating-point operands are taken from \p fpOperands and the result is mapped
-/// to \p result.
-static LogicalResult emitConstrainedFPCall(
-    Operation *op, llvm::Intrinsic::ID constrainedID, ValueRange fpOperands,
-    Value result, llvm::IRBuilderBase &builder,
-    LLVM::ModuleTranslation &moduleTranslation) {
+/// floating-point operands are taken from \p fpOperands and the result is
+/// mapped to \p result.
+static LogicalResult
+emitConstrainedFPCall(Operation *op, llvm::Intrinsic::ID constrainedID,
+                      ValueRange fpOperands, Value result,
+                      llvm::IRBuilderBase &builder,
+                      LLVM::ModuleTranslation &moduleTranslation) {
   llvm::Module *mod = builder.GetInsertBlock()->getModule();
   llvm::LLVMContext &ctx = mod->getContext();
 
@@ -177,8 +177,8 @@ static LogicalResult emitConstrainedFPCall(
   for (unsigned i = 0; i < numMetadataArgs; ++i)
     signatureArgTypes.push_back(metadataType);
 
-  llvm::FunctionType *signature =
-      llvm::FunctionType::get(resultType, signatureArgTypes, /*isVarArg=*/false);
+  llvm::FunctionType *signature = llvm::FunctionType::get(
+      resultType, signatureArgTypes, /*isVarArg=*/false);
 
   std::string errorMsg;
   llvm::raw_string_ostream errorOS(errorMsg);
@@ -190,9 +190,8 @@ static LogicalResult emitConstrainedFPCall(
            << errorMsg;
   }
 
-  llvm::Function *callee =
-      llvm::Intrinsic::getOrInsertDeclaration(mod, constrainedID,
-                                              overloadedTypes);
+  llvm::Function *callee = llvm::Intrinsic::getOrInsertDeclaration(
+      mod, constrainedID, overloadedTypes);
   // The rounding mode and exception behavior come from the IRBuilder's
   // constrained floating-point state, configured by ConstrainedFPStateRAII.
   llvm::Value *call = builder.CreateConstrainedFPCall(callee, args, "");
@@ -370,7 +369,8 @@ convertCallLLVMIntrinsicOp(CallIntrinsicOp op, llvm::IRBuilderBase &builder,
   // (configured by ConstrainedFPStateRAII) supplies the rounding mode and
   // exception behavior.
   if (op.getFenvAttr()) {
-    llvm::Intrinsic::ID base = llvm::Intrinsic::lookupIntrinsicID(op.getIntrin());
+    llvm::Intrinsic::ID base =
+        llvm::Intrinsic::lookupIntrinsicID(op.getIntrin());
     if (!base)
       return op.emitError("could not find LLVM intrinsic: ") << op.getIntrin();
     llvm::Intrinsic::ID constrainedID = getConstrainedIntrinsicFor(base);

--- a/mlir/test/Dialect/LLVMIR/fenv-side-effects.mlir
+++ b/mlir/test/Dialect/LLVMIR/fenv-side-effects.mlir
@@ -1,0 +1,53 @@
+// RUN: mlir-opt %s -canonicalize | FileCheck %s
+
+// Operations carrying a `#llvm.fenv` attribute are no longer unconditionally
+// `Pure`. They only have an observable side effect when an exception may be
+// raised (the exception mode is not `masked`) and that exception must be
+// preserved (`strict_except` is set). Otherwise the (dead) operation can be
+// eliminated, even when it is not speculatable.
+
+// CHECK-LABEL: @dce_dead_ops
+llvm.func @dce_dead_ops(%a: f32, %b: f32) {
+  // A default (absent) floating-point environment behaves like a pure op and is
+  // removed when its result is unused.
+  // CHECK-NOT: llvm.fadd
+  %0 = llvm.fadd %a, %b : f32
+
+  // Masked exceptions: no side effect, removed.
+  // CHECK-NOT: llvm.fmul
+  %1 = llvm.fmul %a, %b {fenv = #llvm.fenv<except_mode = masked>} : f32
+
+  // Non-masked exceptions explicitly not required to be preserved
+  // (`strict_except = false`): the effect is ignorable, so the dead op is
+  // removed even though it is not speculatable.
+  // CHECK-NOT: llvm.fsub
+  %2 = llvm.fsub %a, %b {fenv = #llvm.fenv<except_mode = unmasked, strict_except = false>} : f32
+
+  // CHECK-NOT: llvm.fdiv
+  %3 = llvm.fdiv %a, %b {fenv = #llvm.fenv<except_mode = unknown, strict_except = false>} : f32
+
+  llvm.return
+}
+
+// -----
+
+// Operations whose exceptions must be preserved carry a write effect and are
+// not eliminated. With a non-masked exception mode, `strict_except` defaults to
+// `true`, so it need not be requested explicitly.
+
+// CHECK-LABEL: @keep_strict_except
+llvm.func @keep_strict_except(%a: f32, %b: f32) {
+  // Unmasked exceptions default to strict, so the dead op is preserved.
+  // CHECK: llvm.fadd
+  %0 = llvm.fadd %a, %b {fenv = #llvm.fenv<except_mode = unmasked>} : f32
+
+  // `unknown` is treated like `unmasked` and likewise defaults to strict.
+  // CHECK: llvm.fmul
+  %1 = llvm.fmul %a, %b {fenv = #llvm.fenv<except_mode = unknown>} : f32
+
+  // An explicit `strict_except = true` matches the default.
+  // CHECK: llvm.fdiv
+  %2 = llvm.fdiv %a, %b {fenv = #llvm.fenv<except_mode = unmasked, strict_except = true>} : f32
+
+  llvm.return
+}

--- a/mlir/test/Dialect/LLVMIR/fenv.mlir
+++ b/mlir/test/Dialect/LLVMIR/fenv.mlir
@@ -1,0 +1,36 @@
+// RUN: mlir-opt %s | mlir-opt | FileCheck %s
+
+// CHECK-LABEL: @roundtrip
+llvm.func @roundtrip(%a: f32, %b: f32) {
+  // CHECK: llvm.fadd %{{.*}}, %{{.*}} {fenv = #llvm.fenv<rounding_mode = upward>} : f32
+  %0 = llvm.fadd %a, %b {fenv = #llvm.fenv<rounding_mode = upward>} : f32
+  // `strict_snan`, like `strict_except`, is only meaningful (and thus retained)
+  // when exceptions are not masked, where it defaults to `true`; an explicit
+  // `false` round-trips.
+  // CHECK: llvm.fmul %{{.*}}, %{{.*}} {fenv = #llvm.fenv<except_mode = unmasked, strict_snan = false>} : f32
+  %1 = llvm.fmul %a, %b {fenv = #llvm.fenv<except_mode = unmasked, strict_snan = false>} : f32
+  // `strict_except` is only meaningful (and thus retained) when exceptions are
+  // not masked, where it defaults to `true`; an explicit `false` round-trips.
+  // CHECK: llvm.fcmp "olt" %{{.*}}, %{{.*}} {fenv = #llvm.fenv<dynamic_rounding_mode = tonearest, except_mode = unmasked, strict_except = false>} : f32
+  %2 = llvm.fcmp "olt" %a, %b {fenv = #llvm.fenv<dynamic_rounding_mode = tonearest, except_mode = unmasked, strict_except = false>} : f32
+  llvm.return
+}
+
+// -----
+
+// An attribute whose fields are all at their defaults normalizes to the
+// canonical, empty `#llvm.fenv<>`. The attribute is still present (and so is
+// preserved when printing): carrying it is not the same as having no attribute.
+
+// CHECK-LABEL: @normalized
+llvm.func @normalized(%a: f32, %b: f32) {
+  // CHECK: llvm.fadd %{{.*}}, %{{.*}} {fenv = #llvm.fenv<>} : f32
+  %0 = llvm.fadd %a, %b {fenv = #llvm.fenv<>} : f32
+  // CHECK: llvm.fsub %{{.*}}, %{{.*}} {fenv = #llvm.fenv<>} : f32
+  %1 = llvm.fsub %a, %b {fenv = #llvm.fenv<rounding_mode = dynamic,
+                                           dynamic_rounding_mode = unknown,
+                                           except_mode = masked,
+                                           strict_snan = false,
+                                           strict_except = false>} : f32
+  llvm.return
+}

--- a/mlir/test/Target/LLVMIR/fenv-invalid.mlir
+++ b/mlir/test/Target/LLVMIR/fenv-invalid.mlir
@@ -1,0 +1,19 @@
+// RUN: mlir-translate -verify-diagnostics -split-input-file -mlir-to-llvmir %s
+
+// `llvm.fneg` has no constrained floating-point intrinsic.
+llvm.func @fneg(%a: f32) -> f32 {
+  // expected-error @below {{no constrained intrinsic is available for 'llvm.fneg' carrying a 'fenv' attribute}}
+  // expected-error @below {{LLVM Translation failed for operation: llvm.fneg}}
+  %0 = llvm.fneg %a {fenv = #llvm.fenv<rounding_mode = upward>} : f32
+  llvm.return %0 : f32
+}
+
+// -----
+
+// A named intrinsic without a constrained counterpart is rejected.
+llvm.func @call_intrinsic(%a: f32) -> f32 {
+  // expected-error @below {{no constrained intrinsic is available for 'llvm.fabs.f32' carrying a 'fenv' attribute}}
+  // expected-error @below {{LLVM Translation failed for operation: llvm.call_intrinsic}}
+  %0 = llvm.call_intrinsic "llvm.fabs.f32"(%a) {fenv = #llvm.fenv<rounding_mode = upward>} : (f32) -> f32
+  llvm.return %0 : f32
+}

--- a/mlir/test/Target/LLVMIR/fenv.mlir
+++ b/mlir/test/Target/LLVMIR/fenv.mlir
@@ -1,0 +1,135 @@
+// RUN: mlir-translate -mlir-to-llvmir -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: define void @binops
+llvm.func @binops(%a: f32, %b: f32) {
+  // CHECK: call float @llvm.experimental.constrained.fadd.f32(float %{{.*}}, float %{{.*}}, metadata !"round.upward", metadata !"fpexcept.ignore")
+  %0 = llvm.fadd %a, %b {fenv = #llvm.fenv<rounding_mode = upward>} : f32
+  // CHECK: call float @llvm.experimental.constrained.fsub.f32(float %{{.*}}, float %{{.*}}, metadata !"round.downward", metadata !"fpexcept.ignore")
+  %1 = llvm.fsub %a, %b {fenv = #llvm.fenv<rounding_mode = downward>} : f32
+  // CHECK: call float @llvm.experimental.constrained.fmul.f32(float %{{.*}}, float %{{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+  %2 = llvm.fmul %a, %b {fenv = #llvm.fenv<rounding_mode = tonearest>} : f32
+  // CHECK: call float @llvm.experimental.constrained.fdiv.f32(float %{{.*}}, float %{{.*}}, metadata !"round.towardzero", metadata !"fpexcept.ignore")
+  %3 = llvm.fdiv %a, %b {fenv = #llvm.fenv<rounding_mode = upwardzero>} : f32
+  // CHECK: call float @llvm.experimental.constrained.frem.f32(float %{{.*}}, float %{{.*}}, metadata !"round.upward", metadata !"fpexcept.ignore")
+  %4 = llvm.frem %a, %b {fenv = #llvm.fenv<rounding_mode = upward>} : f32
+  llvm.return
+}
+
+// -----
+
+// `fcmp` lowering chooses between the signaling and quiet constrained
+// comparisons (or a plain `fcmp`) based on the exception mode, the
+// `strict_snan` flag, and the predicate.
+// CHECK-LABEL: define void @cmp
+llvm.func @cmp(%a: f32, %b: f32) {
+  // Unmasked exceptions default `strict_snan` to true, so a relational predicate
+  // becomes a signaling comparison.
+  // CHECK: call i1 @llvm.experimental.constrained.fcmps.f32(float %{{.*}}, float %{{.*}}, metadata !"olt", metadata !"fpexcept.strict")
+  %0 = llvm.fcmp "olt" %a, %b {fenv = #llvm.fenv<except_mode = unmasked>} : f32
+
+  // Equality predicates are non-signaling even with strict sNaN handling.
+  // CHECK: call i1 @llvm.experimental.constrained.fcmp.f32(float %{{.*}}, float %{{.*}}, metadata !"oeq", metadata !"fpexcept.strict")
+  %1 = llvm.fcmp "oeq" %a, %b {fenv = #llvm.fenv<except_mode = unmasked>} : f32
+
+  // With `strict_snan = false`, even a relational predicate stays quiet.
+  // CHECK: call i1 @llvm.experimental.constrained.fcmp.f32(float %{{.*}}, float %{{.*}}, metadata !"olt", metadata !"fpexcept.maytrap")
+  %2 = llvm.fcmp "olt" %a, %b {fenv = #llvm.fenv<except_mode = unmasked, strict_snan = false, strict_except = false>} : f32
+  llvm.return
+}
+
+// -----
+
+// Masked exceptions emit a plain `fcmp`, even when another field (here a
+// rounding mode, which is irrelevant to comparisons) makes the attribute
+// non-default.
+// CHECK-LABEL: define i1 @cmp_masked
+llvm.func @cmp_masked(%a: f32, %b: f32) -> i1 {
+  // CHECK: fcmp olt float %{{.*}}, %{{.*}}
+  // CHECK-NOT: experimental.constrained
+  %0 = llvm.fcmp "olt" %a, %b {fenv = #llvm.fenv<rounding_mode = upward>} : f32
+  llvm.return %0 : i1
+}
+
+// -----
+
+// `strict_except` controls whether unmasked/unknown exceptions map to
+// `fpexcept.strict` (true, the default) or `fpexcept.maytrap` (false).
+// CHECK-LABEL: define void @except_modes
+llvm.func @except_modes(%a: f32, %b: f32) {
+  // Explicit `strict_except = false` with an unmasked mode maps to maytrap.
+  // CHECK: call float @llvm.experimental.constrained.fadd.f32(float %{{.*}}, float %{{.*}}, metadata !"round.dynamic", metadata !"fpexcept.maytrap")
+  %0 = llvm.fadd %a, %b {fenv = #llvm.fenv<except_mode = unmasked, strict_except = false>} : f32
+  // `unknown` is treated like `unmasked`, so it defaults to strict.
+  // CHECK: call float @llvm.experimental.constrained.fsub.f32(float %{{.*}}, float %{{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+  %1 = llvm.fsub %a, %b {fenv = #llvm.fenv<except_mode = unknown>} : f32
+  llvm.return
+}
+
+// -----
+
+// CHECK-LABEL: define void @casts
+llvm.func @casts(%a: f32, %b: f64) {
+  // CHECK: call double @llvm.experimental.constrained.fpext.f64.f32(float %{{.*}}, metadata !"fpexcept.ignore")
+  %0 = llvm.fpext %a {fenv = #llvm.fenv<rounding_mode = upward>} : f32 to f64
+  // CHECK: call float @llvm.experimental.constrained.fptrunc.f32.f64(double %{{.*}}, metadata !"round.downward", metadata !"fpexcept.ignore")
+  %1 = llvm.fptrunc %b {fenv = #llvm.fenv<rounding_mode = downward>} : f64 to f32
+  llvm.return
+}
+
+// -----
+
+// CHECK-LABEL: define float @math_intrinsic
+llvm.func @math_intrinsic(%a: f32) -> f32 {
+  // CHECK: call float @llvm.experimental.constrained.sqrt.f32(float %{{.*}}, metadata !"round.upward", metadata !"fpexcept.ignore")
+  %0 = llvm.intr.sqrt(%a) {fenv = #llvm.fenv<rounding_mode = upward>} : (f32) -> f32
+  llvm.return %0 : f32
+}
+
+// -----
+
+// A named intrinsic call is mapped to its constrained counterpart.
+// CHECK-LABEL: define float @call_intrinsic
+llvm.func @call_intrinsic(%a: f32, %b: f32) -> f32 {
+  // CHECK: call float @llvm.experimental.constrained.maxnum.f32(float %{{.*}}, float %{{.*}}, metadata !"fpexcept.ignore")
+  %0 = llvm.call_intrinsic "llvm.maxnum.f32"(%a, %b) {fenv = #llvm.fenv<rounding_mode = upward>} : (f32, f32) -> f32
+  llvm.return %0 : f32
+}
+
+// -----
+
+// An absent attribute lowers to the regular, unconstrained operation.
+// CHECK-LABEL: define float @no_fenv
+llvm.func @no_fenv(%a: f32, %b: f32) -> f32 {
+  // CHECK: fadd float %{{.*}}, %{{.*}}
+  // CHECK-NOT: experimental.constrained
+  %0 = llvm.fadd %a, %b : f32
+  llvm.return %0 : f32
+}
+
+// -----
+
+// An empty attribute describes the default environment, but carrying the
+// attribute still selects the constrained intrinsic (with the default rounding
+// mode and exception behavior).
+// CHECK-LABEL: define float @empty_fenv
+llvm.func @empty_fenv(%a: f32, %b: f32) -> f32 {
+  // CHECK: call float @llvm.experimental.constrained.fadd.f32(float %{{.*}}, float %{{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+  %0 = llvm.fadd %a, %b {fenv = #llvm.fenv<>} : f32
+  llvm.return %0 : f32
+}
+
+// -----
+
+// An attribute whose fields are all set to their defaults is normalized to the
+// canonical (empty) environment, which is still present and therefore selects
+// the constrained intrinsic with the default settings.
+// CHECK-LABEL: define float @all_default_fenv
+llvm.func @all_default_fenv(%a: f32, %b: f32) -> f32 {
+  // CHECK: call float @llvm.experimental.constrained.fadd.f32(float %{{.*}}, float %{{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+  %0 = llvm.fadd %a, %b {fenv = #llvm.fenv<rounding_mode = dynamic,
+                                           dynamic_rounding_mode = unknown,
+                                           except_mode = masked,
+                                           strict_snan = false,
+                                           strict_except = false>} : f32
+  llvm.return %0 : f32
+}


### PR DESCRIPTION
This change adds a new attribute, llvm.fenv, to describe constrained floating-point behavior, adds this attribute to applicable floating-point operations, and adds support for automatically generating calls to the appropriate constrained intrinsic rather than the bare operation or intrinsic call when operations with this attribute are lowered to LLVM IR.

Assisted-by: Cursor / claude-opus-4.8