### PR TITLE
[WIP][X86] Deduplicate simple repeated constant chunks for vector loads

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -514,7 +514,6 @@ void X86AsmPrinter::emitBasicBlockEnd(const MachineBasicBlock &MBB) {
   SMShadowTracker.emitShadowPadding(*OutStreamer, getSubtargetInfo());
 }
 
-
 static bool shouldSkipX86OrigGlobal(const GlobalVariable *GV) {
   if (!GV->hasPrivateLinkage() || !GV->isConstant() || !GV->hasInitializer())
     return false;
@@ -523,18 +522,10 @@ static bool shouldSkipX86OrigGlobal(const GlobalVariable *GV) {
   if (!Name.ends_with(".x86.orig"))
     return false;
 
-  StringRef BaseName =
-      Name.drop_back(StringRef(".x86.orig").size());
-
+  StringRef BaseName = Name.drop_back(StringRef(".x86.orig").size());
   const Module *M = GV->getParent();
   const GlobalVariable *NewGV = M->getGlobalVariable(BaseName, true);
-  if (!NewGV)
-    return false;
-
-  if (!NewGV->hasInitializer() || !NewGV->isConstant())
-    return false;
-
-  return true;
+  return NewGV && NewGV->hasInitializer() && NewGV->isConstant();
 }
 
 void X86AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -523,12 +523,12 @@ static bool shouldSkipX86OrigGlobal(const GlobalVariable *GV) {
   if (!Name.ends_with(".x86.orig"))
     return false;
 
-  std::string BaseName =
-      Name.drop_back(StringRef(".x86.orig").size()).str();
+  StringRef BaseName =
+      Name.drop_back(StringRef(".x86.orig").size());
 
   const Module *M = GV->getParent();
   const GlobalVariable *NewGV = M->getGlobalVariable(BaseName, true);
-  if (!NewGV || NewGV == GV)
+  if (!NewGV)
     return false;
 
   if (!NewGV->hasInitializer() || !NewGV->isConstant())

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -514,29 +514,31 @@ void X86AsmPrinter::emitBasicBlockEnd(const MachineBasicBlock &MBB) {
   SMShadowTracker.emitShadowPadding(*OutStreamer, getSubtargetInfo());
 }
 
-static bool isX86RepeatedConstReplacedGlobal(const GlobalVariable *GV) {
-  const Module *M = GV->getParent();
-  const NamedMDNode *NMD = M->getNamedMetadata("x86.repeated_const_replaced");
-  if (!NMD)
+
+static bool shouldSkipX86OrigGlobal(const GlobalVariable *GV) {
+  if (!GV->hasPrivateLinkage() || !GV->isConstant() || !GV->hasInitializer())
     return false;
 
-  for (const MDNode *Node : NMD->operands()) {
-    if (Node->getNumOperands() != 1)
-      continue;
+  auto Name = GV->getName();
+  if (!Name.ends_with(".x86.orig"))
+    return false;
 
-    auto *VAM = dyn_cast<ValueAsMetadata>(Node->getOperand(0).get());
-    if (!VAM)
-      continue;
+  std::string BaseName =
+      Name.drop_back(StringRef(".x86.orig").size()).str();
 
-    if (VAM->getValue() == GV)
-      return true;
-  }
+  const Module *M = GV->getParent();
+  const GlobalVariable *NewGV = M->getGlobalVariable(BaseName, true);
+  if (!NewGV || NewGV == GV)
+    return false;
 
-  return false;
+  if (!NewGV->hasInitializer() || !NewGV->isConstant())
+    return false;
+
+  return true;
 }
 
 void X86AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
-  if (isX86RepeatedConstReplacedGlobal(GV))
+  if (shouldSkipX86OrigGlobal(GV))
     return;
 
   AsmPrinter::emitGlobalVariable(GV);

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -30,6 +30,7 @@
 #include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
 #include "llvm/CodeGenTypes/MachineValueType.h"
 #include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Mangler.h"
@@ -511,6 +512,34 @@ void X86AsmPrinter::emitBasicBlockEnd(const MachineBasicBlock &MBB) {
   }
   AsmPrinter::emitBasicBlockEnd(MBB);
   SMShadowTracker.emitShadowPadding(*OutStreamer, getSubtargetInfo());
+}
+
+static bool isX86RepeatedConstReplacedGlobal(const GlobalVariable *GV) {
+  const Module *M = GV->getParent();
+  const NamedMDNode *NMD = M->getNamedMetadata("x86.repeated_const_replaced");
+  if (!NMD)
+    return false;
+
+  for (const MDNode *Node : NMD->operands()) {
+    if (Node->getNumOperands() != 1)
+      continue;
+
+    auto *VAM = dyn_cast<ValueAsMetadata>(Node->getOperand(0).get());
+    if (!VAM)
+      continue;
+
+    if (VAM->getValue() == GV)
+      return true;
+  }
+
+  return false;
+}
+
+void X86AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
+  if (isX86RepeatedConstReplacedGlobal(GV))
+    return;
+
+  AsmPrinter::emitGlobalVariable(GV);
 }
 
 void X86AsmPrinter::PrintMemReference(const MachineInstr *MI, unsigned OpNo,

--- a/llvm/lib/Target/X86/X86AsmPrinter.h
+++ b/llvm/lib/Target/X86/X86AsmPrinter.h
@@ -180,6 +180,8 @@ public:
 
   void emitBasicBlockEnd(const MachineBasicBlock &MBB) override;
 
+  void emitGlobalVariable(const GlobalVariable *GV) override;
+
   bool PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
                        const char *ExtraCode, raw_ostream &O) override;
   bool PrintAsmMemoryOperand(const MachineInstr *MI, unsigned OpNo,

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -54445,8 +54445,12 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
     if (!GVar)
       return SDValue();
 
+    if (!GVar->hasInitializer())
+      return SDValue();
+
     if (GVar->getName().ends_with(".x86.opt"))
       return SDValue();
+
 
     OptimizedConstantArrayInfo Info = optimizeGlobalConstantArray(GVar);
     if (!Info.Success)

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -20096,14 +20096,12 @@ struct OptimizedConstantArrayInfo {
 };
 
 static OptimizedConstantArrayInfo
-optimizeGlobalConstantArray(GlobalVariable *GV) {
+optimizeGlobalConstantArray(GlobalVariable *GV, Module *M) {
   auto *OldInit = GV->getInitializer();
-
   auto *CDA = dyn_cast<ConstantDataArray>(OldInit);
-  if (!CDA)
-    return OptimizedConstantArrayInfo{OldInit->getType(), OldInit, 0};
-
-  constexpr unsigned PeriodElems = 4;
+  auto DL = M->getDataLayout();
+  auto Sz = DL.getTypeAllocSize(CDA->getElementType());
+  unsigned PeriodElems = 16 / Sz; // 128 bit load
 
   unsigned NumElems = CDA->getNumElements();
   Type *EltTy = CDA->getElementType();
@@ -20114,12 +20112,11 @@ optimizeGlobalConstantArray(GlobalVariable *GV) {
   for (unsigned I = PeriodElems; I < NumElems; ++I) {
     Constant *A = CDA->getElementAsConstant(I);
     Constant *B = CDA->getElementAsConstant(I % PeriodElems);
-
     if (A != B)
       return OptimizedConstantArrayInfo{OldInit->getType(), OldInit, 0};
   }
 
-  SmallVector<Constant *, PeriodElems> NewElems;
+  SmallVector<Constant *, 4> NewElems;
   for (unsigned I = 0; I < PeriodElems; ++I)
     NewElems.push_back(CDA->getElementAsConstant(I));
 
@@ -54344,17 +54341,17 @@ static SDValue combineConstantArrayVariable(EVT RegVT, LoadSDNode *Ld,
   if (!GVar->hasInitializer())
     return SDValue();
 
+  Module *M = GVar->getParent();
   auto *CDA = dyn_cast<ConstantDataArray>(GVar->getInitializer());
   if (!CDA)
     return SDValue();
-  if (CDA->getNumElements() <= 4)
+  if (CDA->getNumElements() <=
+      16 / M->getDataLayout().getTypeAllocSize(CDA->getElementType()))
     return SDValue();
 
-  OptimizedConstantArrayInfo Info = optimizeGlobalConstantArray(GVar);
+  OptimizedConstantArrayInfo Info = optimizeGlobalConstantArray(GVar, M);
   if (!Info.Success)
     return SDValue();
-
-  Module *M = GVar->getParent();
 
   // we set the old variable to XX.x86.orig
   // XX.x86.orig variable should be filtered in asm printer

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -54521,8 +54521,6 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
     SDLoc DLN(Ld);
     EVT PtrVT = Ptr.getValueType();
 
-    markX86RepeatedConstReplaced(GVar);
-
     SDValue NewPtr = DAG.getGlobalAddress(NewGV, DLN, PtrVT, NewByteOffset);
 
     MachinePointerInfo MPI(NewGV, NewByteOffset);

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -54489,6 +54489,7 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
 
     SDLoc DLN(Ld);
     EVT PtrVT = Ptr.getValueType();
+    markX86RepeatedConstReplaced(GVar);
 
     SDValue NewPtr = DAG.getGlobalAddress(NewGV, DLN, PtrVT, NewByteOffset);
 

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -54384,6 +54384,9 @@ static SDValue combineConstantArrayVariable(EVT RegVT, LoadSDNode *Ld,
     Module *M = GVar->getParent();
 
     // we set the old variable to XX.x86.orig
+    // XX.x86.orig variable should be filtered in asm printer
+    // TODO: I'm really really not sure it's a good design but don't find a
+    // better way...
     constexpr StringRef OrigSuffix = ".x86.orig";
 
     StringRef CurName = GVar->getName();
@@ -54425,6 +54428,7 @@ static SDValue combineConstantArrayVariable(EVT RegVT, LoadSDNode *Ld,
     return DAG.getLoad(Ld->getMemoryVT(), DLN, Ld->getChain(), NewPtr, MPI,
                        Ld->getAlign(), Ld->getMemOperand()->getFlags());
   }
+  return SDValue();
 }
 
 static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -54315,107 +54315,8 @@ static SDValue combineAtomicLoad(SDNode *N, SelectionDAG &DAG,
   return DAG.getMergeValues({Cast, IntLoad.getValue(1)}, DL);
 }
 
-static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
-                           TargetLowering::DAGCombinerInfo &DCI,
-                           const X86Subtarget &Subtarget) {
-  auto *Ld = cast<LoadSDNode>(N);
-  EVT RegVT = Ld->getValueType(0);
-  EVT MemVT = Ld->getMemoryVT();
-  SDLoc dl(Ld);
-  const TargetLowering &TLI = DAG.getTargetLoweringInfo();
-
-  // For chips with slow 32-byte unaligned loads, break the 32-byte operation
-  // into two 16-byte operations. Also split non-temporal aligned loads on
-  // pre-AVX2 targets as 32-byte loads will lower to regular temporal loads.
-  ISD::LoadExtType Ext = Ld->getExtensionType();
-  unsigned Fast;
-  if (RegVT.is256BitVector() && !DCI.isBeforeLegalizeOps() &&
-      Ext == ISD::NON_EXTLOAD &&
-      ((Ld->isNonTemporal() && !Subtarget.hasInt256() &&
-        Ld->getAlign() >= Align(16)) ||
-       (TLI.allowsMemoryAccess(*DAG.getContext(), DAG.getDataLayout(), RegVT,
-                               *Ld->getMemOperand(), &Fast) &&
-        !Fast))) {
-    unsigned NumElems = RegVT.getVectorNumElements();
-    if (NumElems < 2)
-      return SDValue();
-
-    unsigned HalfOffset = 16;
-    SDValue Ptr1 = Ld->getBasePtr();
-    SDValue Ptr2 =
-        DAG.getMemBasePlusOffset(Ptr1, TypeSize::getFixed(HalfOffset), dl);
-    EVT HalfVT = EVT::getVectorVT(*DAG.getContext(), MemVT.getScalarType(),
-                                  NumElems / 2);
-    SDValue Load1 =
-        DAG.getLoad(HalfVT, dl, Ld->getChain(), Ptr1, Ld->getPointerInfo(),
-                    Ld->getBaseAlign(), Ld->getMemOperand()->getFlags());
-    SDValue Load2 =
-        DAG.getLoad(HalfVT, dl, Ld->getChain(), Ptr2,
-                    Ld->getPointerInfo().getWithOffset(HalfOffset),
-                    Ld->getBaseAlign(), Ld->getMemOperand()->getFlags());
-    SDValue TF = DAG.getNode(ISD::TokenFactor, dl, MVT::Other,
-                             Load1.getValue(1), Load2.getValue(1));
-
-    SDValue NewVec = DAG.getNode(ISD::CONCAT_VECTORS, dl, RegVT, Load1, Load2);
-    return DCI.CombineTo(N, NewVec, TF, true);
-  }
-
-  // Bool vector load - attempt to cast to an integer, as we have good
-  // (vXiY *ext(vXi1 bitcast(iX))) handling.
-  if (Ext == ISD::NON_EXTLOAD && !Subtarget.hasAVX512() && RegVT.isVector() &&
-      RegVT.getScalarType() == MVT::i1 && DCI.isBeforeLegalize()) {
-    unsigned NumElts = RegVT.getVectorNumElements();
-    EVT IntVT = EVT::getIntegerVT(*DAG.getContext(), NumElts);
-    if (TLI.isTypeLegal(IntVT)) {
-      SDValue IntLoad = DAG.getLoad(IntVT, dl, Ld->getChain(), Ld->getBasePtr(),
-                                    Ld->getPointerInfo(), Ld->getBaseAlign(),
-                                    Ld->getMemOperand()->getFlags());
-      SDValue BoolVec = DAG.getBitcast(RegVT, IntLoad);
-      return DCI.CombineTo(N, BoolVec, IntLoad.getValue(1), true);
-    }
-  }
-
-  // If we also broadcast this vector to a wider type, then just extract the
-  // lowest subvector.
-  if (Ext == ISD::NON_EXTLOAD && Subtarget.hasAVX() && Ld->isSimple() &&
-      (RegVT.is128BitVector() || RegVT.is256BitVector())) {
-    SDValue Ptr = Ld->getBasePtr();
-    SDValue Chain = Ld->getChain();
-    for (SDNode *User : Chain->users()) {
-      auto *UserLd = dyn_cast<MemSDNode>(User);
-      if (User != N && UserLd &&
-          User->getOpcode() == X86ISD::SUBV_BROADCAST_LOAD &&
-          UserLd->getChain() == Chain && UserLd->getBasePtr() == Ptr &&
-          UserLd->getMemoryVT().getSizeInBits() == MemVT.getSizeInBits() &&
-          User->hasAnyUseOfValue(0) &&
-          User->getValueSizeInBits(0).getFixedValue() >
-              RegVT.getFixedSizeInBits()) {
-        DAG.makeEquivalentMemoryOrdering(SDValue(N, 1), SDValue(User, 1));
-        SDValue Extract = extractSubVector(SDValue(User, 0), 0, DAG, dl,
-                                           RegVT.getSizeInBits());
-        Extract = DAG.getBitcast(RegVT, Extract);
-        return DCI.CombineTo(N, Extract, SDValue(User, 1));
-      }
-    }
-  }
-
-  if (SDValue V = combineConstantPoolLoads(Ld, dl, DAG, DCI, Subtarget))
-    return V;
-
-  // Cast ptr32 and ptr64 pointers to the default address space before a load.
-  unsigned AddrSpace = Ld->getAddressSpace();
-  if (AddrSpace == X86AS::PTR64 || AddrSpace == X86AS::PTR32_SPTR ||
-      AddrSpace == X86AS::PTR32_UPTR) {
-    MVT PtrVT = TLI.getPointerTy(DAG.getDataLayout());
-    if (PtrVT != Ld->getBasePtr().getSimpleValueType()) {
-      SDValue Cast =
-          DAG.getAddrSpaceCast(dl, PtrVT, Ld->getBasePtr(), AddrSpace, 0);
-      return DAG.getExtLoad(Ext, dl, RegVT, Ld->getChain(), Cast,
-                            Ld->getPointerInfo(), MemVT, Ld->getBaseAlign(),
-                            Ld->getMemOperand()->getFlags());
-    }
-  }
-
+static SDValue combineConstantArrayVariable(EVT RegVT, LoadSDNode *Ld,
+                                            SelectionDAG &DAG) {
   if (RegVT.is128BitVector()) {
     SDValue Ptr = Ld->getBasePtr();
 
@@ -54524,6 +54425,113 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
     return DAG.getLoad(Ld->getMemoryVT(), DLN, Ld->getChain(), NewPtr, MPI,
                        Ld->getAlign(), Ld->getMemOperand()->getFlags());
   }
+}
+
+static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
+                           TargetLowering::DAGCombinerInfo &DCI,
+                           const X86Subtarget &Subtarget) {
+  auto *Ld = cast<LoadSDNode>(N);
+  EVT RegVT = Ld->getValueType(0);
+  EVT MemVT = Ld->getMemoryVT();
+  SDLoc dl(Ld);
+  const TargetLowering &TLI = DAG.getTargetLoweringInfo();
+
+  // For chips with slow 32-byte unaligned loads, break the 32-byte operation
+  // into two 16-byte operations. Also split non-temporal aligned loads on
+  // pre-AVX2 targets as 32-byte loads will lower to regular temporal loads.
+  ISD::LoadExtType Ext = Ld->getExtensionType();
+  unsigned Fast;
+  if (RegVT.is256BitVector() && !DCI.isBeforeLegalizeOps() &&
+      Ext == ISD::NON_EXTLOAD &&
+      ((Ld->isNonTemporal() && !Subtarget.hasInt256() &&
+        Ld->getAlign() >= Align(16)) ||
+       (TLI.allowsMemoryAccess(*DAG.getContext(), DAG.getDataLayout(), RegVT,
+                               *Ld->getMemOperand(), &Fast) &&
+        !Fast))) {
+    unsigned NumElems = RegVT.getVectorNumElements();
+    if (NumElems < 2)
+      return SDValue();
+
+    unsigned HalfOffset = 16;
+    SDValue Ptr1 = Ld->getBasePtr();
+    SDValue Ptr2 =
+        DAG.getMemBasePlusOffset(Ptr1, TypeSize::getFixed(HalfOffset), dl);
+    EVT HalfVT = EVT::getVectorVT(*DAG.getContext(), MemVT.getScalarType(),
+                                  NumElems / 2);
+    SDValue Load1 =
+        DAG.getLoad(HalfVT, dl, Ld->getChain(), Ptr1, Ld->getPointerInfo(),
+                    Ld->getBaseAlign(), Ld->getMemOperand()->getFlags());
+    SDValue Load2 =
+        DAG.getLoad(HalfVT, dl, Ld->getChain(), Ptr2,
+                    Ld->getPointerInfo().getWithOffset(HalfOffset),
+                    Ld->getBaseAlign(), Ld->getMemOperand()->getFlags());
+    SDValue TF = DAG.getNode(ISD::TokenFactor, dl, MVT::Other,
+                             Load1.getValue(1), Load2.getValue(1));
+
+    SDValue NewVec = DAG.getNode(ISD::CONCAT_VECTORS, dl, RegVT, Load1, Load2);
+    return DCI.CombineTo(N, NewVec, TF, true);
+  }
+
+  // Bool vector load - attempt to cast to an integer, as we have good
+  // (vXiY *ext(vXi1 bitcast(iX))) handling.
+  if (Ext == ISD::NON_EXTLOAD && !Subtarget.hasAVX512() && RegVT.isVector() &&
+      RegVT.getScalarType() == MVT::i1 && DCI.isBeforeLegalize()) {
+    unsigned NumElts = RegVT.getVectorNumElements();
+    EVT IntVT = EVT::getIntegerVT(*DAG.getContext(), NumElts);
+    if (TLI.isTypeLegal(IntVT)) {
+      SDValue IntLoad = DAG.getLoad(IntVT, dl, Ld->getChain(), Ld->getBasePtr(),
+                                    Ld->getPointerInfo(), Ld->getBaseAlign(),
+                                    Ld->getMemOperand()->getFlags());
+      SDValue BoolVec = DAG.getBitcast(RegVT, IntLoad);
+      return DCI.CombineTo(N, BoolVec, IntLoad.getValue(1), true);
+    }
+  }
+
+  // If we also broadcast this vector to a wider type, then just extract the
+  // lowest subvector.
+  if (Ext == ISD::NON_EXTLOAD && Subtarget.hasAVX() && Ld->isSimple() &&
+      (RegVT.is128BitVector() || RegVT.is256BitVector())) {
+    SDValue Ptr = Ld->getBasePtr();
+    SDValue Chain = Ld->getChain();
+    for (SDNode *User : Chain->users()) {
+      auto *UserLd = dyn_cast<MemSDNode>(User);
+      if (User != N && UserLd &&
+          User->getOpcode() == X86ISD::SUBV_BROADCAST_LOAD &&
+          UserLd->getChain() == Chain && UserLd->getBasePtr() == Ptr &&
+          UserLd->getMemoryVT().getSizeInBits() == MemVT.getSizeInBits() &&
+          User->hasAnyUseOfValue(0) &&
+          User->getValueSizeInBits(0).getFixedValue() >
+              RegVT.getFixedSizeInBits()) {
+        DAG.makeEquivalentMemoryOrdering(SDValue(N, 1), SDValue(User, 1));
+        SDValue Extract = extractSubVector(SDValue(User, 0), 0, DAG, dl,
+                                           RegVT.getSizeInBits());
+        Extract = DAG.getBitcast(RegVT, Extract);
+        return DCI.CombineTo(N, Extract, SDValue(User, 1));
+      }
+    }
+  }
+
+  if (SDValue V = combineConstantPoolLoads(Ld, dl, DAG, DCI, Subtarget))
+    return V;
+
+  // Cast ptr32 and ptr64 pointers to the default address space before a load.
+  unsigned AddrSpace = Ld->getAddressSpace();
+  if (AddrSpace == X86AS::PTR64 || AddrSpace == X86AS::PTR32_SPTR ||
+      AddrSpace == X86AS::PTR32_UPTR) {
+    MVT PtrVT = TLI.getPointerTy(DAG.getDataLayout());
+    if (PtrVT != Ld->getBasePtr().getSimpleValueType()) {
+      SDValue Cast =
+          DAG.getAddrSpaceCast(dl, PtrVT, Ld->getBasePtr(), AddrSpace, 0);
+      return DAG.getExtLoad(Ext, dl, RegVT, Ld->getChain(), Cast,
+                            Ld->getPointerInfo(), MemVT, Ld->getBaseAlign(),
+                            Ld->getMemOperand()->getFlags());
+    }
+  }
+
+  if (RegVT.is128BitVector()) {
+    return combineConstantArrayVariable(RegVT, Ld, DAG);
+  }
+
   return SDValue();
 }
 

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -20092,7 +20092,6 @@ X86TargetLowering::LowerBlockAddress(SDValue Op, SelectionDAG &DAG) const {
 struct OptimizedConstantArrayInfo {
   Type *Ty;
   Constant *Init;
-  uint64_t PeriodElems = 0;
   bool Success = false;
 };
 
@@ -20130,7 +20129,6 @@ optimizeGlobalConstantArray(GlobalVariable *GV) {
   return OptimizedConstantArrayInfo{
       NewInit->getType(),
       NewInit,
-      PeriodElems,
       true,
   };
 }
@@ -54318,13 +54316,11 @@ static SDValue combineAtomicLoad(SDNode *N, SelectionDAG &DAG,
 static SDValue combineConstantArrayVariable(EVT RegVT, LoadSDNode *Ld,
                                             SelectionDAG &DAG) {
   SDValue Ptr = Ld->getBasePtr();
-
   GlobalAddressSDNode *GA = nullptr;
 
   if (Ptr.getOpcode() == ISD::ADD) {
     SDValue LHS = Ptr.getOperand(0);
     SDValue RHS = Ptr.getOperand(1);
-
     if (isa<ConstantSDNode>(RHS)) {
       if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(LHS)) {
         GA = MatchedGA;
@@ -54345,17 +54341,12 @@ static SDValue combineConstantArrayVariable(EVT RegVT, LoadSDNode *Ld,
       const_cast<GlobalVariable *>(dyn_cast<GlobalVariable>(GA->getGlobal()));
   if (!GVar)
     return SDValue();
-
   if (!GVar->hasInitializer())
     return SDValue();
 
   auto *CDA = dyn_cast<ConstantDataArray>(GVar->getInitializer());
   if (!CDA)
     return SDValue();
-
-  // This prevents re-optimizing the new 4-element replacement global.
-  // Do not bail on ".x86.orig": remaining old-GV references must still be
-  // redirected to the replacement GV.
   if (CDA->getNumElements() <= 4)
     return SDValue();
 
@@ -54363,36 +54354,19 @@ static SDValue combineConstantArrayVariable(EVT RegVT, LoadSDNode *Ld,
   if (!Info.Success)
     return SDValue();
 
-  const DataLayout &DL = DAG.getDataLayout();
-  auto *ArrTy = dyn_cast<ArrayType>(Info.Ty);
-  if (!ArrTy)
-    return SDValue();
-
-  uint64_t ElemBytes = DL.getTypeAllocSize(ArrTy->getElementType());
-  uint64_t PeriodBytes = ElemBytes * Info.PeriodElems;
-  if (PeriodBytes == 0)
-    return SDValue();
-
-  // TODO: only match the simple case like [1, 2, 3, 4, 1, 2, 3, 4], so the new
-  // offset is always 0
-  int64_t NewByteOffset = 0;
-
-  uint64_t LoadBytes = Ld->getMemoryVT().getStoreSize();
-  if (static_cast<uint64_t>(NewByteOffset) + LoadBytes > PeriodBytes)
-    return SDValue();
-
   Module *M = GVar->getParent();
 
   // we set the old variable to XX.x86.orig
   // XX.x86.orig variable should be filtered in asm printer
-  // TODO: I'm really really not sure it's a good design but don't find a
-  // better way...
+  // TODO: I'm really really not sure whether it's a good design but didn't find
+  // a better way...
   constexpr StringRef OrigSuffix = ".x86.orig";
 
   StringRef CurName = GVar->getName();
   StringRef BaseNameRef(CurName);
-  if (BaseNameRef.ends_with(OrigSuffix))
-    BaseNameRef = BaseNameRef.drop_back(OrigSuffix.size());
+  BaseNameRef = BaseNameRef.ends_with(OrigSuffix)
+                    ? BaseNameRef.drop_back(OrigSuffix.size())
+                    : BaseNameRef;
 
   std::string OldName = BaseNameRef.str();
   std::string OrigName = OldName + OrigSuffix.str();
@@ -54402,16 +54376,18 @@ static SDValue combineConstantArrayVariable(EVT RegVT, LoadSDNode *Ld,
   if (NewGV == GVar) {
     // The global variable node is not optimized yet
     GVar->setName(OrigName);
+    assert(GVar->getName() == OrigName && "unexpected name collision");
     NewGV = nullptr;
   }
 
   if (!NewGV) {
     NewGV = new GlobalVariable(
         *M, Info.Ty,
-        /*isConstant=*/true, GlobalValue::PrivateLinkage, Info.Init, OldName,
+        /*isConstant=*/GVar->isConstant(), GlobalValue::PrivateLinkage,
+        Info.Init, OldName,
         /*InsertBefore=*/nullptr, GVar->getThreadLocalMode(),
         GVar->getAddressSpace(),
-        /*isExternallyInitialized=*/false);
+        /*isExternallyInitialized=*/GVar->isExternallyInitialized());
 
     NewGV->setAlignment(GVar->getAlign());
     NewGV->setUnnamedAddr(GVar->getUnnamedAddr());
@@ -54419,11 +54395,11 @@ static SDValue combineConstantArrayVariable(EVT RegVT, LoadSDNode *Ld,
   }
 
   SDLoc DLN(Ld);
-  EVT PtrVT = Ptr.getValueType();
+  // TODO: only match the simple case like [1, 2, 3, 4, 1, 2, 3, 4], so the new
+  SDValue NewPtr =
+      DAG.getGlobalAddress(NewGV, DLN, Ptr.getValueType(), /* offset */ 0);
 
-  SDValue NewPtr = DAG.getGlobalAddress(NewGV, DLN, PtrVT, NewByteOffset);
-
-  MachinePointerInfo MPI(NewGV, NewByteOffset);
+  MachinePointerInfo MPI(NewGV, /* offset */ 0);
 
   return DAG.getLoad(Ld->getMemoryVT(), DLN, Ld->getChain(), NewPtr, MPI,
                      Ld->getAlign(), Ld->getMemOperand()->getFlags());

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -20089,6 +20089,52 @@ X86TargetLowering::LowerBlockAddress(SDValue Op, SelectionDAG &DAG) const {
   return Result;
 }
 
+struct OptimizedConstantArrayInfo {
+  Type *Ty;
+  Constant *Init;
+  uint64_t PeriodElems = 0;
+  bool Success = false;
+};
+
+static OptimizedConstantArrayInfo
+optimizeGlobalConstantArray(GlobalVariable *GV) {
+  auto *OldInit = GV->getInitializer();
+
+  auto *CDA = dyn_cast<ConstantDataArray>(OldInit);
+  if (!CDA)
+    return OptimizedConstantArrayInfo{OldInit->getType(), OldInit, 0};
+
+  constexpr unsigned PeriodElems = 4;
+
+  unsigned NumElems = CDA->getNumElements();
+  Type *EltTy = CDA->getElementType();
+
+  if (NumElems < PeriodElems || NumElems % PeriodElems != 0)
+    return OptimizedConstantArrayInfo{OldInit->getType(), OldInit, 0};
+
+  for (unsigned I = PeriodElems; I < NumElems; ++I) {
+    Constant *A = CDA->getElementAsConstant(I);
+    Constant *B = CDA->getElementAsConstant(I % PeriodElems);
+
+    if (A != B)
+      return OptimizedConstantArrayInfo{OldInit->getType(), OldInit, 0};
+  }
+
+  SmallVector<Constant *, PeriodElems> NewElems;
+  for (unsigned I = 0; I < PeriodElems; ++I)
+    NewElems.push_back(CDA->getElementAsConstant(I));
+
+  auto *NewArrTy = ArrayType::get(EltTy, PeriodElems);
+  Constant *NewInit = ConstantArray::get(NewArrTy, NewElems);
+
+  return OptimizedConstantArrayInfo{
+      NewInit->getType(),
+      NewInit,
+      PeriodElems,
+      true,
+  };
+}
+
 /// Creates target global address or external symbol nodes for calls or
 /// other uses.
 SDValue X86TargetLowering::LowerGlobalOrExternal(SDValue Op, SelectionDAG &DAG,
@@ -54370,6 +54416,87 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
     }
   }
 
+  if (RegVT.is128BitVector()) {
+    SDValue Ptr = Ld->getBasePtr();
+
+    GlobalAddressSDNode *GA = nullptr;
+    int64_t OldByteOffset = 0;
+
+    if (Ptr.getOpcode() == ISD::ADD) {
+      SDValue LHS = Ptr.getOperand(0);
+      SDValue RHS = Ptr.getOperand(1);
+
+      if (auto *C = dyn_cast<ConstantSDNode>(RHS)) {
+        if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(LHS)) {
+          GA = MatchedGA;
+          OldByteOffset = GA->getOffset() + C->getSExtValue();
+        }
+      }
+    } else if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(Ptr)) {
+      GA = MatchedGA;
+      OldByteOffset = GA->getOffset();
+    }
+
+    if (!GA)
+      return SDValue();
+
+    auto *GVar =
+        const_cast<GlobalVariable *>(dyn_cast<GlobalVariable>(GA->getGlobal()));
+    if (!GVar)
+      return SDValue();
+
+    if (GVar->getName().ends_with(".x86.opt"))
+      return SDValue();
+
+    OptimizedConstantArrayInfo Info = optimizeGlobalConstantArray(GVar);
+    if (!Info.Success)
+      return SDValue();
+
+    const DataLayout &DL = DAG.getDataLayout();
+    auto *ArrTy = dyn_cast<ArrayType>(Info.Ty);
+    if (!ArrTy)
+      return SDValue();
+
+    uint64_t ElemBytes = DL.getTypeAllocSize(ArrTy->getElementType());
+    uint64_t PeriodBytes = ElemBytes * Info.PeriodElems;
+    if (PeriodBytes == 0)
+      return SDValue();
+
+    int64_t NewByteOffset = OldByteOffset % static_cast<int64_t>(PeriodBytes);
+    if (NewByteOffset < 0)
+      NewByteOffset += PeriodBytes;
+
+    uint64_t LoadBytes = Ld->getMemoryVT().getStoreSize();
+    if (static_cast<uint64_t>(NewByteOffset) + LoadBytes > PeriodBytes)
+      return SDValue();
+
+    Module *M = GVar->getParent();
+    std::string NewName = (GVar->getName() + ".x86.opt").str();
+
+    GlobalVariable *NewGV = M->getGlobalVariable(NewName, true);
+    if (!NewGV) {
+      NewGV = new GlobalVariable(
+          *M, Info.Ty,
+          /*isConstant=*/true, GlobalValue::PrivateLinkage, Info.Init, NewName,
+          /*InsertBefore=*/nullptr, GVar->getThreadLocalMode(),
+          GVar->getAddressSpace(),
+          /*isExternallyInitialized=*/false);
+
+      NewGV->setAlignment(GVar->getAlign());
+      NewGV->setUnnamedAddr(GVar->getUnnamedAddr());
+      NewGV->setDSOLocal(true);
+    }
+
+    SDLoc DLN(Ld);
+    EVT PtrVT = Ptr.getValueType();
+
+    SDValue NewPtr = DAG.getGlobalAddress(NewGV, DLN, PtrVT, NewByteOffset);
+
+    MachinePointerInfo MPI(NewGV, NewByteOffset);
+
+    return DAG.getLoad(Ld->getMemoryVT(), DLN, Ld->getChain(), NewPtr, MPI,
+                       Ld->getAlign(), Ld->getMemOperand()->getFlags());
+  }
   return SDValue();
 }
 

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -54420,26 +54420,22 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
     SDValue Ptr = Ld->getBasePtr();
 
     GlobalAddressSDNode *GA = nullptr;
-    int64_t OldByteOffset = 0;
 
     if (Ptr.getOpcode() == ISD::ADD) {
       SDValue LHS = Ptr.getOperand(0);
       SDValue RHS = Ptr.getOperand(1);
 
-      if (auto *C = dyn_cast<ConstantSDNode>(RHS)) {
+      if (isa<ConstantSDNode>(RHS)) {
         if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(LHS)) {
           GA = MatchedGA;
-          OldByteOffset = GA->getOffset() + C->getSExtValue();
         }
-      } else if (auto *C = dyn_cast<ConstantSDNode>(LHS)) {
+      } else if (isa<ConstantSDNode>(LHS)) {
         if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(RHS)) {
           GA = MatchedGA;
-          OldByteOffset = GA->getOffset() + C->getSExtValue();
         }
       }
     } else if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(Ptr)) {
       GA = MatchedGA;
-      OldByteOffset = GA->getOffset();
     }
 
     if (!GA)
@@ -54477,9 +54473,8 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
     if (PeriodBytes == 0)
       return SDValue();
 
-    int64_t NewByteOffset = OldByteOffset % static_cast<int64_t>(PeriodBytes);
-    if (NewByteOffset < 0)
-      NewByteOffset += PeriodBytes;
+    // TODO: only match the simple case like [1, 2, 3, 4, 1, 2, 3, 4], so the new offset is always 0
+    int64_t NewByteOffset = 0;
 
     uint64_t LoadBytes = Ld->getMemoryVT().getStoreSize();
     if (static_cast<uint64_t>(NewByteOffset) + LoadBytes > PeriodBytes)
@@ -54487,12 +54482,12 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
 
     Module *M = GVar->getParent();
 
+    // we set the old variable to XX.x86.orig
     constexpr StringRef OrigSuffix = ".x86.orig";
 
-    std::string CurName = GVar->getName().str();
+    StringRef CurName = GVar->getName();
     StringRef BaseNameRef(CurName);
-
-    while (BaseNameRef.ends_with(OrigSuffix))
+    if (BaseNameRef.ends_with(OrigSuffix))
       BaseNameRef = BaseNameRef.drop_back(OrigSuffix.size());
 
     std::string OldName = BaseNameRef.str();
@@ -54501,6 +54496,7 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
     GlobalVariable *NewGV = M->getGlobalVariable(OldName, true);
 
     if (NewGV == GVar) {
+      // The global variable node is not optimized yet
       GVar->setName(OrigName);
       NewGV = nullptr;
     }

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -54317,118 +54317,116 @@ static SDValue combineAtomicLoad(SDNode *N, SelectionDAG &DAG,
 
 static SDValue combineConstantArrayVariable(EVT RegVT, LoadSDNode *Ld,
                                             SelectionDAG &DAG) {
-  if (RegVT.is128BitVector()) {
-    SDValue Ptr = Ld->getBasePtr();
+  SDValue Ptr = Ld->getBasePtr();
 
-    GlobalAddressSDNode *GA = nullptr;
+  GlobalAddressSDNode *GA = nullptr;
 
-    if (Ptr.getOpcode() == ISD::ADD) {
-      SDValue LHS = Ptr.getOperand(0);
-      SDValue RHS = Ptr.getOperand(1);
+  if (Ptr.getOpcode() == ISD::ADD) {
+    SDValue LHS = Ptr.getOperand(0);
+    SDValue RHS = Ptr.getOperand(1);
 
-      if (isa<ConstantSDNode>(RHS)) {
-        if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(LHS)) {
-          GA = MatchedGA;
-        }
-      } else if (isa<ConstantSDNode>(LHS)) {
-        if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(RHS)) {
-          GA = MatchedGA;
-        }
+    if (isa<ConstantSDNode>(RHS)) {
+      if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(LHS)) {
+        GA = MatchedGA;
       }
-    } else if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(Ptr)) {
-      GA = MatchedGA;
+    } else if (isa<ConstantSDNode>(LHS)) {
+      if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(RHS)) {
+        GA = MatchedGA;
+      }
     }
-
-    if (!GA)
-      return SDValue();
-
-    auto *GVar =
-        const_cast<GlobalVariable *>(dyn_cast<GlobalVariable>(GA->getGlobal()));
-    if (!GVar)
-      return SDValue();
-
-    if (!GVar->hasInitializer())
-      return SDValue();
-
-    auto *CDA = dyn_cast<ConstantDataArray>(GVar->getInitializer());
-    if (!CDA)
-      return SDValue();
-
-    // This prevents re-optimizing the new 4-element replacement global.
-    // Do not bail on ".x86.orig": remaining old-GV references must still be
-    // redirected to the replacement GV.
-    if (CDA->getNumElements() <= 4)
-      return SDValue();
-
-    OptimizedConstantArrayInfo Info = optimizeGlobalConstantArray(GVar);
-    if (!Info.Success)
-      return SDValue();
-
-    const DataLayout &DL = DAG.getDataLayout();
-    auto *ArrTy = dyn_cast<ArrayType>(Info.Ty);
-    if (!ArrTy)
-      return SDValue();
-
-    uint64_t ElemBytes = DL.getTypeAllocSize(ArrTy->getElementType());
-    uint64_t PeriodBytes = ElemBytes * Info.PeriodElems;
-    if (PeriodBytes == 0)
-      return SDValue();
-
-    // TODO: only match the simple case like [1, 2, 3, 4, 1, 2, 3, 4], so the new offset is always 0
-    int64_t NewByteOffset = 0;
-
-    uint64_t LoadBytes = Ld->getMemoryVT().getStoreSize();
-    if (static_cast<uint64_t>(NewByteOffset) + LoadBytes > PeriodBytes)
-      return SDValue();
-
-    Module *M = GVar->getParent();
-
-    // we set the old variable to XX.x86.orig
-    // XX.x86.orig variable should be filtered in asm printer
-    // TODO: I'm really really not sure it's a good design but don't find a
-    // better way...
-    constexpr StringRef OrigSuffix = ".x86.orig";
-
-    StringRef CurName = GVar->getName();
-    StringRef BaseNameRef(CurName);
-    if (BaseNameRef.ends_with(OrigSuffix))
-      BaseNameRef = BaseNameRef.drop_back(OrigSuffix.size());
-
-    std::string OldName = BaseNameRef.str();
-    std::string OrigName = OldName + OrigSuffix.str();
-
-    GlobalVariable *NewGV = M->getGlobalVariable(OldName, true);
-
-    if (NewGV == GVar) {
-      // The global variable node is not optimized yet
-      GVar->setName(OrigName);
-      NewGV = nullptr;
-    }
-
-    if (!NewGV) {
-      NewGV = new GlobalVariable(
-          *M, Info.Ty,
-          /*isConstant=*/true, GlobalValue::PrivateLinkage, Info.Init, OldName,
-          /*InsertBefore=*/nullptr, GVar->getThreadLocalMode(),
-          GVar->getAddressSpace(),
-          /*isExternallyInitialized=*/false);
-
-      NewGV->setAlignment(GVar->getAlign());
-      NewGV->setUnnamedAddr(GVar->getUnnamedAddr());
-      NewGV->setDSOLocal(true);
-    }
-
-    SDLoc DLN(Ld);
-    EVT PtrVT = Ptr.getValueType();
-
-    SDValue NewPtr = DAG.getGlobalAddress(NewGV, DLN, PtrVT, NewByteOffset);
-
-    MachinePointerInfo MPI(NewGV, NewByteOffset);
-
-    return DAG.getLoad(Ld->getMemoryVT(), DLN, Ld->getChain(), NewPtr, MPI,
-                       Ld->getAlign(), Ld->getMemOperand()->getFlags());
+  } else if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(Ptr)) {
+    GA = MatchedGA;
   }
-  return SDValue();
+
+  if (!GA)
+    return SDValue();
+
+  auto *GVar =
+      const_cast<GlobalVariable *>(dyn_cast<GlobalVariable>(GA->getGlobal()));
+  if (!GVar)
+    return SDValue();
+
+  if (!GVar->hasInitializer())
+    return SDValue();
+
+  auto *CDA = dyn_cast<ConstantDataArray>(GVar->getInitializer());
+  if (!CDA)
+    return SDValue();
+
+  // This prevents re-optimizing the new 4-element replacement global.
+  // Do not bail on ".x86.orig": remaining old-GV references must still be
+  // redirected to the replacement GV.
+  if (CDA->getNumElements() <= 4)
+    return SDValue();
+
+  OptimizedConstantArrayInfo Info = optimizeGlobalConstantArray(GVar);
+  if (!Info.Success)
+    return SDValue();
+
+  const DataLayout &DL = DAG.getDataLayout();
+  auto *ArrTy = dyn_cast<ArrayType>(Info.Ty);
+  if (!ArrTy)
+    return SDValue();
+
+  uint64_t ElemBytes = DL.getTypeAllocSize(ArrTy->getElementType());
+  uint64_t PeriodBytes = ElemBytes * Info.PeriodElems;
+  if (PeriodBytes == 0)
+    return SDValue();
+
+  // TODO: only match the simple case like [1, 2, 3, 4, 1, 2, 3, 4], so the new
+  // offset is always 0
+  int64_t NewByteOffset = 0;
+
+  uint64_t LoadBytes = Ld->getMemoryVT().getStoreSize();
+  if (static_cast<uint64_t>(NewByteOffset) + LoadBytes > PeriodBytes)
+    return SDValue();
+
+  Module *M = GVar->getParent();
+
+  // we set the old variable to XX.x86.orig
+  // XX.x86.orig variable should be filtered in asm printer
+  // TODO: I'm really really not sure it's a good design but don't find a
+  // better way...
+  constexpr StringRef OrigSuffix = ".x86.orig";
+
+  StringRef CurName = GVar->getName();
+  StringRef BaseNameRef(CurName);
+  if (BaseNameRef.ends_with(OrigSuffix))
+    BaseNameRef = BaseNameRef.drop_back(OrigSuffix.size());
+
+  std::string OldName = BaseNameRef.str();
+  std::string OrigName = OldName + OrigSuffix.str();
+
+  GlobalVariable *NewGV = M->getGlobalVariable(OldName, true);
+
+  if (NewGV == GVar) {
+    // The global variable node is not optimized yet
+    GVar->setName(OrigName);
+    NewGV = nullptr;
+  }
+
+  if (!NewGV) {
+    NewGV = new GlobalVariable(
+        *M, Info.Ty,
+        /*isConstant=*/true, GlobalValue::PrivateLinkage, Info.Init, OldName,
+        /*InsertBefore=*/nullptr, GVar->getThreadLocalMode(),
+        GVar->getAddressSpace(),
+        /*isExternallyInitialized=*/false);
+
+    NewGV->setAlignment(GVar->getAlign());
+    NewGV->setUnnamedAddr(GVar->getUnnamedAddr());
+    NewGV->setDSOLocal(true);
+  }
+
+  SDLoc DLN(Ld);
+  EVT PtrVT = Ptr.getValueType();
+
+  SDValue NewPtr = DAG.getGlobalAddress(NewGV, DLN, PtrVT, NewByteOffset);
+
+  MachinePointerInfo MPI(NewGV, NewByteOffset);
+
+  return DAG.getLoad(Ld->getMemoryVT(), DLN, Ld->getChain(), NewPtr, MPI,
+                     Ld->getAlign(), Ld->getMemOperand()->getFlags());
 }
 
 static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -54431,6 +54431,11 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
           GA = MatchedGA;
           OldByteOffset = GA->getOffset() + C->getSExtValue();
         }
+      } else if (auto *C = dyn_cast<ConstantSDNode>(LHS)) {
+        if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(RHS)) {
+          GA = MatchedGA;
+          OldByteOffset = GA->getOffset() + C->getSExtValue();
+        }
       }
     } else if (auto *MatchedGA = dyn_cast<GlobalAddressSDNode>(Ptr)) {
       GA = MatchedGA;
@@ -54448,9 +54453,15 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
     if (!GVar->hasInitializer())
       return SDValue();
 
-    if (GVar->getName().ends_with(".x86.opt"))
+    auto *CDA = dyn_cast<ConstantDataArray>(GVar->getInitializer());
+    if (!CDA)
       return SDValue();
 
+    // This prevents re-optimizing the new 4-element replacement global.
+    // Do not bail on ".x86.orig": remaining old-GV references must still be
+    // redirected to the replacement GV.
+    if (CDA->getNumElements() <= 4)
+      return SDValue();
 
     OptimizedConstantArrayInfo Info = optimizeGlobalConstantArray(GVar);
     if (!Info.Success)
@@ -54475,13 +54486,29 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
       return SDValue();
 
     Module *M = GVar->getParent();
-    std::string NewName = (GVar->getName() + ".x86.opt").str();
 
-    GlobalVariable *NewGV = M->getGlobalVariable(NewName, true);
+    constexpr StringRef OrigSuffix = ".x86.orig";
+
+    std::string CurName = GVar->getName().str();
+    StringRef BaseNameRef(CurName);
+
+    while (BaseNameRef.ends_with(OrigSuffix))
+      BaseNameRef = BaseNameRef.drop_back(OrigSuffix.size());
+
+    std::string OldName = BaseNameRef.str();
+    std::string OrigName = OldName + OrigSuffix.str();
+
+    GlobalVariable *NewGV = M->getGlobalVariable(OldName, true);
+
+    if (NewGV == GVar) {
+      GVar->setName(OrigName);
+      NewGV = nullptr;
+    }
+
     if (!NewGV) {
       NewGV = new GlobalVariable(
           *M, Info.Ty,
-          /*isConstant=*/true, GlobalValue::PrivateLinkage, Info.Init, NewName,
+          /*isConstant=*/true, GlobalValue::PrivateLinkage, Info.Init, OldName,
           /*InsertBefore=*/nullptr, GVar->getThreadLocalMode(),
           GVar->getAddressSpace(),
           /*isExternallyInitialized=*/false);
@@ -54493,6 +54520,7 @@ static SDValue combineLoad(SDNode *N, SelectionDAG &DAG,
 
     SDLoc DLN(Ld);
     EVT PtrVT = Ptr.getValueType();
+
     markX86RepeatedConstReplaced(GVar);
 
     SDValue NewPtr = DAG.getGlobalAddress(NewGV, DLN, PtrVT, NewByteOffset);


### PR DESCRIPTION
This is a WIP attempt to address #201704.

The issue is that, when initializing stack data from a constant global, LLVM may emit multiple vector loads from different offsets of the same global even when the loaded chunks are identical/repeating. For example, for a pattern like:

```c++
int nums[8] = {1, 2, 3, 4, 1, 2, 3, 4};
```

we can load the second 16-byte chunk from the same 16-byte constant as the first one, instead of keeping both repeated chunks in the constant data.

The current implementation takes the following approach:

1. Detect a simple repeated constant pattern during DAG combine.
2. Rename the original global variable and create a new smaller global variable containing only the repeated period.
3. Rewrite the load in `combineLoad` so that it loads from the new global variable.
4. In `AsmPrinter`, recognize the replaced original global variable and avoid emitting it.

This patch intentionally only handles the simplest fully-periodic case for now, such as:

```c++
[1, 2, 3, 4, 1, 2, 3, 4]
```

It does not try to handle more complex cases yet, such as:

```c++
[1, 1, 2, 3, 4, 1, 2, 3, 4]
```

I am not sure whether creating a replacement global and suppressing the original one in `AsmPrinter` is the right direction for this optimization. This is therefore marked as WIP, and I would appreciate guidance on whether this approach is acceptable or whether there is a better place/design for implementing this transformation.
