### PR TITLE
[llvm-offload-binary] Add `member` key to single out archive members

### DIFF
--- a/llvm/docs/CommandGuide/llvm-offload-binary.rst
+++ b/llvm/docs/CommandGuide/llvm-offload-binary.rst
@@ -78,6 +78,11 @@ OPTIONS
   during extraction, all images are automatically extracted with descriptive
   filenames.
 
+  When extracting from a static archive, the ``member`` key restricts the output
+  to a single archive member for cases when `--archive` is insufficient.
+  , e.g.
+  ``--image=member=foo.o,triple=nvptx64,arch=sm_70,file=out.o``.
+
 .. option:: -o <file>
 
   Write output to <file>. When bundling, this specifies the fat binary filename.

--- a/llvm/test/tools/llvm-offload-binary/member-extract.test
+++ b/llvm/test/tools/llvm-offload-binary/member-extract.test
@@ -1,0 +1,22 @@
+# RUN: split-file %s %t
+
+# Two members with the same triple, arch, and kind but distinct contents.
+# RUN: llvm-offload-binary -o %t/a.o --image=file=%t/contentA,triple=x-y-z,arch=gfx90a,kind=openmp
+# RUN: llvm-offload-binary -o %t/b.o --image=file=%t/contentB,triple=x-y-z,arch=gfx90a,kind=openmp
+# RUN: llvm-ar rcs %t/lib.a %t/a.o %t/b.o
+
+# Each member can be extracted to a known file by its archive member name.
+# RUN: llvm-offload-binary %t/lib.a --image=member=a.o,triple=x-y-z,arch=gfx90a,kind=openmp,file=%t/outA
+# RUN: llvm-offload-binary %t/lib.a --image=member=b.o,triple=x-y-z,arch=gfx90a,kind=openmp,file=%t/outB
+# RUN: diff %t/contentA %t/outA
+# RUN: diff %t/contentB %t/outB
+
+# Without the 'member' selector the same filter matches both members.
+# RUN: llvm-offload-binary %t/lib.a --image=triple=x-y-z,arch=gfx90a,kind=openmp,file=%t/both 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=WARN
+# WARN: Multiple inputs match to a single file
+
+#--- contentA
+aaaa
+#--- contentB
+bbbb

--- a/llvm/tools/llvm-offload-binary/llvm-offload-binary.cpp
+++ b/llvm/tools/llvm-offload-binary/llvm-offload-binary.cpp
@@ -212,13 +212,17 @@ static Error unbundleImages() {
     SmallVector<const OffloadBinary *> Extracted;
     for (const OffloadFile &File : Binaries) {
       const auto *Binary = File.getBinary();
-      // We handle the 'file' and 'kind' identifiers differently.
+      // We handle the 'file', 'kind', and 'member' identifiers differently.
       bool Match = llvm::all_of(Args, [&](auto &Arg) {
         const auto [Key, Value] = Arg;
         if (Key == "file")
           return true;
         if (Key == "kind")
           return Binary->getOffloadKind() == getOffloadKind(Value);
+        if (Key == "member")
+          return sys::path::filename(
+                     Binary->getMemoryBufferRef().getBufferIdentifier()) ==
+                 Value;
         return Binary->getString(Key) == Value;
       });
       if (Match)


### PR DESCRIPTION
Summary:
Currently, archives offer three approaches.
1. `--archive` which takes an archive and puts all the output in a new
   archive
2. No filename, which outputs based on the member names
3. Filename, which just matches everything.
This has a gap for when people wnat a single file without relying on
implicit naming that dumps all the contents to the CWD.

This PR adds `member` which lets you specify the member names as you
would get from `ar t libfoo.a` for this.
