### PR TITLE
AMDGPU: Temporarily restore disassembler's dependency on TargetParser

### DIFF
--- a/llvm/lib/Target/AMDGPU/Disassembler/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/Disassembler/CMakeLists.txt
@@ -10,6 +10,7 @@ add_llvm_component_library(LLVMAMDGPUDisassembler
   CodeGenTypes
   MC
   MCDisassembler
+  TargetParser
   Support
 
   ADD_TO_COMPONENT


### PR DESCRIPTION
Reverts part of #204315