### PR TITLE
[lldb][NFC] FileSpec::GetFileNameStrippingExtension should return a StringRef

### DIFF
--- a/lldb/include/lldb/Utility/FileSpec.h
+++ b/lldb/include/lldb/Utility/FileSpec.h
@@ -336,12 +336,12 @@ public:
 
   /// Return the filename without the extension part
   ///
-  /// Returns a ConstString that represents the filename of this object
+  /// Returns a StringRef that represents the filename of this object
   /// without the extension part (e.g. for a file named "foo.bar", "foo" is
   /// returned)
   ///
-  /// \return Returns the filename without extension as a ConstString object.
-  ConstString GetFileNameStrippingExtension() const;
+  /// \return Returns the filename without extension as a StringRef object.
+  llvm::StringRef GetFileNameStrippingExtension() const;
 
   /// Get the memory cost of this object.
   ///

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -1442,12 +1442,10 @@ bool ModuleList::LoadScriptingResourcesInTarget(Target *target,
       Status error;
       if (!LoadScriptingResourceInTargetForModule(*module, *target, error)) {
         if (error.Fail() && error.AsCString()) {
-          error = Status::FromErrorStringWithFormat(
+          error = Status::FromErrorStringWithFormatv(
               "unable to load scripting data for "
-              "module %s - error reported was %s",
-              module->GetFileSpec()
-                  .GetFileNameStrippingExtension()
-                  .GetCString(),
+              "module {0} - error reported was {1}",
+              module->GetFileSpec().GetFileNameStrippingExtension(),
               error.AsCString());
           errors.push_back(std::move(error));
           if (!continue_on_error)

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -171,8 +171,7 @@ llvm::Expected<PluginInfo> PluginInfo::Create(const FileSpec &path) {
   // Look for files that follow the convention <g_plugin_prefix><name>.<ext>, in
   // which case we need to call lldb_initialize_<name> and
   // lldb_terminate_<name>.
-  llvm::StringRef file_name =
-      path.GetFileNameStrippingExtension().GetStringRef();
+  llvm::StringRef file_name = path.GetFileNameStrippingExtension();
   if (file_name.starts_with(g_plugin_prefix)) {
     llvm::StringRef plugin_name = file_name.substr(g_plugin_prefix.size());
     std::string init_symbol =

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -621,11 +621,11 @@ bool PlatformDarwinKernel::KextHasdSYMSibling(
   // CFBundleCopyExecutableURL
 
   // Look for a deep bundle foramt
-  ConstString executable_name =
+  llvm::StringRef executable_name =
       kext_bundle_filepath.GetFileNameStrippingExtension();
   std::string deep_bundle_str =
       kext_bundle_filepath.GetPath() + "/Contents/MacOS/";
-  deep_bundle_str += executable_name.GetStringRef();
+  deep_bundle_str += executable_name;
   deep_bundle_str += ".dSYM";
   dsym_fspec.SetFile(deep_bundle_str, FileSpec::Style::native);
   FileSystem::Instance().Resolve(dsym_fspec);
@@ -636,7 +636,7 @@ bool PlatformDarwinKernel::KextHasdSYMSibling(
   // look for a shallow bundle format
   //
   std::string shallow_bundle_str = kext_bundle_filepath.GetPath() + "/";
-  shallow_bundle_str += executable_name.GetStringRef();
+  shallow_bundle_str += executable_name;
   shallow_bundle_str += ".dSYM";
   dsym_fspec.SetFile(shallow_bundle_str, FileSpec::Style::native);
   FileSystem::Instance().Resolve(dsym_fspec);
@@ -696,8 +696,7 @@ PlatformDarwinKernel::GetDWARFBinaryInDSYMBundle(const FileSpec &dsym_bundle) {
     return results;
   }
   // Drop the '.dSYM' from the filename
-  std::string filename =
-      dsym_bundle.GetFileNameStrippingExtension().GetCString();
+  llvm::StringRef filename = dsym_bundle.GetFileNameStrippingExtension();
   std::string dirname = dsym_bundle.GetDirectory().GetCString();
 
   std::string binary_filepath = dsym_bundle.GetPath();

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -4512,7 +4512,7 @@ const std::shared_ptr<SymbolFileDWARFDwo> &SymbolFileDWARF::GetDwpSymbolFile() {
       // If we don't have a separate debug info file, then try stripping the
       // extension. The main module could be "a.debug" and the .dwp file could
       // be "a.dwp" instead of "a.debug.dwp".
-      ConstString filename_no_ext =
+      llvm::StringRef filename_no_ext =
           module_fspec.GetFileNameStrippingExtension();
       if (filename_no_ext != module_fspec.GetFilename()) {
         FileSpec module_spec_no_ext(module_fspec);

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -189,7 +189,7 @@ Platform::LocateExecutableScriptingResourcesFromSafePaths(
       target.GetDebugger()
           .GetScriptInterpreter()
           ->GetSanitizedScriptingModuleName(
-              module_spec.GetFileNameStrippingExtension().GetStringRef());
+              module_spec.GetFileNameStrippingExtension());
 
   FileSpecList paths = target.GetSafeAutoLoadPaths();
 

--- a/lldb/source/Utility/FileSpec.cpp
+++ b/lldb/source/Utility/FileSpec.cpp
@@ -407,8 +407,8 @@ llvm::StringRef FileSpec::GetFileNameExtension() const {
   return llvm::sys::path::extension(m_filename.GetStringRef(), m_style);
 }
 
-ConstString FileSpec::GetFileNameStrippingExtension() const {
-  return ConstString(llvm::sys::path::stem(m_filename.GetStringRef(), m_style));
+llvm::StringRef FileSpec::GetFileNameStrippingExtension() const {
+  return llvm::sys::path::stem(m_filename.GetStringRef(), m_style);
 }
 
 // Return the size in bytes that this object takes in memory. This returns the


### PR DESCRIPTION
No need to create a ConstString of a filename without its file extension.