### PR TITLE
[BOLT][Bazel] Configure Rewrite target backends

### DIFF
--- a/utils/bazel/llvm-project-overlay/bolt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/bolt/BUILD.bazel
@@ -6,6 +6,15 @@ load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load(":targets.bzl", "bolt_targets")
 
+_BOLT_REWRITE_TARGETS = [
+    target
+    for target in bolt_targets
+    if target in [
+        "AArch64",
+        "X86",
+    ]
+]
+
 package(
     default_visibility = ["//visibility:public"],
 )
@@ -71,9 +80,11 @@ cc_binary(
         ":Profile",
         ":Rewrite",
         ":RuntimeLibs",
-        ":TargetAArch64",
         ":TargetConfig",
-        ":TargetX86",
+    ] + [
+        ":Target" + target
+        for target in _BOLT_REWRITE_TARGETS
+    ] + [
         ":Utils",
         "//llvm:AllTargetsAsmParsers",
         "//llvm:AllTargetsCodeGens",
@@ -94,12 +105,19 @@ cc_library(
         "include/bolt/Rewrite/*.h",
     ]),
     includes = ["include"],
+    local_defines = [
+        target.upper() + "_AVAILABLE"
+        for target in _BOLT_REWRITE_TARGETS
+    ],
     deps = [
         ":Core",
         ":Passes",
         ":Profile",
         ":RuntimeLibs",
-        ":TargetX86",
+    ] + [
+        ":Target" + target
+        for target in _BOLT_REWRITE_TARGETS
+    ] + [
         ":Utils",
         "//llvm:Analysis",
         "//llvm:BinaryFormat",


### PR DESCRIPTION
`RewriteInstance.cpp` only creates target-specific `MCPlusBuilder` instances when `X86_AVAILABLE` or `AARCH64_AVAILABLE` is defined. The Bazel `Rewrite` target defines neither macro and hard-codes `TargetX86`, so `createMCPlusBuilder()` returns null for both target backends defined by the Bazel overlay. Derive the definitions and dependencies from the generated `bolt_targets` list, restricted to the `TargetAArch64` and `TargetX86` rules defined in this BUILD file, and use the same target dependencies for `llvm-bolt`.

Validation: `buildifier -mode=check -lint=warn utils/bazel/llvm-project-overlay/bolt/BUILD.bazel`; an equivalent LLVM 22 overlay change built and executed BOLT for Linux x86_64 and Linux AArch64 in [hermetic-llvm's remote build](https://app.buildbuddy.io/invocation/6071ef1c-8640-4dfd-9af8-340e7b32f84c).

AI tool disclosure: Co-authored with OpenAI Codex.
