### PR TITLE
[driver][AIX] Accept '32_64' and 'any' as valid value for OBJECT_MODE

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -960,6 +960,8 @@ AIX Support
 - Added support for ``#pragma comment(copyright, "token_sequence")`` on AIX.
   This directive embeds a copyright or identifying string into the compiled object file. 
   The string is included in the final executable and loaded into memory at program runtime.
+- The driver relaxes the restrictions on the ``OBJECT_MODE`` environment
+  variable and now silently accepts ``32_64`` and ``any``.
 
 NetBSD Support
 ^^^^^^^^^^^^^^

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -676,7 +676,8 @@ static llvm::Triple computeTargetTriple(const Driver &D,
 
       if (ObjectMode == "64") {
         AT = Target.get64BitArchVariant().getArch();
-      } else if (ObjectMode == "32") {
+      } else if (ObjectMode == "32" || ObjectMode == "32_64" ||
+                 ObjectMode == "any") {
         AT = Target.get32BitArchVariant().getArch();
       } else {
         D.Diag(diag::err_drv_invalid_object_mode) << ObjectMode;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -674,12 +674,12 @@ static llvm::Triple computeTargetTriple(const Driver &D,
       StringRef ObjectMode = *ObjectModeValue;
       llvm::Triple::ArchType AT = llvm::Triple::UnknownArch;
 
+      // Silently accept '32_64' and 'any'
       if (ObjectMode == "64") {
         AT = Target.get64BitArchVariant().getArch();
-      } else if (ObjectMode == "32" || ObjectMode == "32_64" ||
-                 ObjectMode == "any") {
+      } else if (ObjectMode == "32") {
         AT = Target.get32BitArchVariant().getArch();
-      } else {
+      } else if (ObjectMode != "32_64" && ObjectMode != "any") {
         D.Diag(diag::err_drv_invalid_object_mode) << ObjectMode;
       }
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -675,7 +675,8 @@ static llvm::Triple computeTargetTriple(const Driver &D,
       llvm::Triple::ArchType AT = llvm::Triple::UnknownArch;
 
       // Silently accept '32_64' and 'any'
-      const bool OtherAllowedMode = ObjectMode == "32_64" || ObjectMode == "any";
+      const bool OtherAllowedMode =
+          ObjectMode == "32_64" || ObjectMode == "any";
       if (ObjectMode == "64") {
         AT = Target.get64BitArchVariant().getArch();
       } else if (ObjectMode == "32") {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -675,11 +675,12 @@ static llvm::Triple computeTargetTriple(const Driver &D,
       llvm::Triple::ArchType AT = llvm::Triple::UnknownArch;
 
       // Silently accept '32_64' and 'any'
+      const bool OtherAllowedMode = ObjectMode == "32_64" || ObjectMode == "any";
       if (ObjectMode == "64") {
         AT = Target.get64BitArchVariant().getArch();
       } else if (ObjectMode == "32") {
         AT = Target.get32BitArchVariant().getArch();
-      } else if (ObjectMode != "32_64" && ObjectMode != "any") {
+      } else if (!OtherAllowedMode) {
         D.Diag(diag::err_drv_invalid_object_mode) << ObjectMode;
       }
 

--- a/clang/test/Driver/aix-object-mode.c
+++ b/clang/test/Driver/aix-object-mode.c
@@ -16,11 +16,17 @@
 // RUN: %clang --target=powerpc-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK32 %s
 
 // RUN: env OBJECT_MODE=32_64 \
+// RUN: %clang --target=powerpc64-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK64 %s
+
+// RUN: env OBJECT_MODE=32_64                   \
 // RUN: %clang -print-target-triple | FileCheck \
 // RUN:     -check-prefix=%if target={{powerpc64-.*}} %{CHECK64%} %else %{CHECK32%} %s
 
 // RUN: env OBJECT_MODE=any \
 // RUN: %clang --target=powerpc-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK32 %s
+
+// RUN: env OBJECT_MODE=any \
+// RUN: %clang --target=powerpc64-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK64 %s
 
 // RUN: env OBJECT_MODE=any \
 // RUN: %clang -print-target-triple | FileCheck \
@@ -36,8 +42,14 @@
 // RUN: env OBJECT_MODE=32_64 \
 // RUN: %clang --target=powerpc-ibm-aix -print-target-triple -m64 | FileCheck -check-prefix=CHECK64 %s
 
+// RUN: env OBJECT_MODE=32_64 \
+// RUN: %clang --target=powerpc64-ibm-aix -print-target-triple -m32 | FileCheck -check-prefix=CHECK32 %s
+
 // RUN: env OBJECT_MODE=any \
 // RUN: %clang --target=powerpc-ibm-aix -print-target-triple -m64 | FileCheck -check-prefix=CHECK64 %s
+
+// RUN: env OBJECT_MODE=any \
+// RUN: %clang --target=powerpc64-ibm-aix -print-target-triple -m32 | FileCheck -check-prefix=CHECK32 %s
 
 // CHECK32: powerpc-ibm-aix
 // CHECK64: powerpc64-ibm-aix

--- a/clang/test/Driver/aix-object-mode.c
+++ b/clang/test/Driver/aix-object-mode.c
@@ -16,13 +16,15 @@
 // RUN: %clang --target=powerpc-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK32 %s
 
 // RUN: env OBJECT_MODE=32_64 \
-// RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK64 %s
+// RUN: %clang -print-target-triple | FileCheck \
+// RUN:     -check-prefix=%if target={{powerpc64-.*}} %{CHECK64%} %else %{CHECK32%} %s
 
 // RUN: env OBJECT_MODE=any \
 // RUN: %clang --target=powerpc-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK32 %s
 
 // RUN: env OBJECT_MODE=any \
-// RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK64 %s
+// RUN: %clang -print-target-triple | FileCheck \
+// RUN:     -check-prefix=%if target={{powerpc64-.*}} %{CHECK64%} %else %{CHECK32%} %s
 
 // Command-line options win.
 // RUN: env OBJECT_MODE=64 \

--- a/clang/test/Driver/aix-object-mode.c
+++ b/clang/test/Driver/aix-object-mode.c
@@ -12,11 +12,26 @@
 // RUN: env OBJECT_MODE=32 \
 // RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK32 %s
 
+// RUN: env OBJECT_MODE=32_64 \
+// RUN: %clang --target=powerpc64-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK64 %s
+
+// RUN: env OBJECT_MODE=32_64 \
+// RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK32 %s
+
+// RUN: env OBJECT_MODE=any \
+// RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK32 %s
+
 // Command-line options win.
 // RUN: env OBJECT_MODE=64 \
 // RUN: %clang --target=powerpc64-ibm-aix -print-target-triple -m32 | FileCheck -check-prefix=CHECK32 %s
 
 // RUN: env OBJECT_MODE=32 \
+// RUN: %clang --target=powerpc-ibm-aix -print-target-triple -m64 | FileCheck -check-prefix=CHECK64 %s
+
+// RUN: env OBJECT_MODE=32_64 \
+// RUN: %clang --target=powerpc-ibm-aix -print-target-triple -m64 | FileCheck -check-prefix=CHECK64 %s
+
+// RUN: env OBJECT_MODE=any \
 // RUN: %clang --target=powerpc-ibm-aix -print-target-triple -m64 | FileCheck -check-prefix=CHECK64 %s
 
 // CHECK32: powerpc-ibm-aix

--- a/clang/test/Driver/aix-object-mode.c
+++ b/clang/test/Driver/aix-object-mode.c
@@ -19,6 +19,9 @@
 // RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK32 %s
 
 // RUN: env OBJECT_MODE=any \
+// RUN: %clang --target=powerpc64-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK64 %s
+
+// RUN: env OBJECT_MODE=any \
 // RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK32 %s
 
 // Command-line options win.

--- a/clang/test/Driver/aix-object-mode.c
+++ b/clang/test/Driver/aix-object-mode.c
@@ -13,16 +13,16 @@
 // RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK32 %s
 
 // RUN: env OBJECT_MODE=32_64 \
-// RUN: %clang --target=powerpc64-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK64 %s
+// RUN: %clang --target=powerpc-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK32 %s
 
 // RUN: env OBJECT_MODE=32_64 \
-// RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK32 %s
+// RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK64 %s
 
 // RUN: env OBJECT_MODE=any \
-// RUN: %clang --target=powerpc64-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK64 %s
+// RUN: %clang --target=powerpc-ibm-aix -print-target-triple | FileCheck -check-prefix=CHECK32 %s
 
 // RUN: env OBJECT_MODE=any \
-// RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK32 %s
+// RUN: %clang -print-target-triple | FileCheck -check-prefix=CHECK64 %s
 
 // Command-line options win.
 // RUN: env OBJECT_MODE=64 \


### PR DESCRIPTION
If OBJECT_MODE is set to '32_64' or 'any', the driver accepts the setting silently.