### PR TITLE
[WebAssembly] Fix nondeterminism by using MapVector for pointer-keyed maps [NFC]

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
@@ -29,6 +29,7 @@
 #include "WebAssemblySubtarget.h"
 #include "WebAssemblyTargetMachine.h"
 #include "WebAssemblyUtilities.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/BinaryFormat/Wasm.h"
 #include "llvm/CodeGen/MachineDominators.h"
@@ -1837,7 +1838,7 @@ bool WebAssemblyCFGStackify::fixCallUnwindMismatches(MachineFunction &MF) {
   // multiple BBs.
   using TryRange = std::pair<MachineInstr *, MachineInstr *>;
   // In original CFG, <unwind destination BB, a vector of try/try_table ranges>
-  DenseMap<MachineBasicBlock *, SmallVector<TryRange, 4>> UnwindDestToTryRanges;
+  MapVector<MachineBasicBlock *, SmallVector<TryRange, 4>> UnwindDestToTryRanges;
 
   // Gather possibly throwing calls (i.e., previously invokes) whose current
   // unwind destination is not the same as the original CFG. (Case 1)
@@ -2203,7 +2204,7 @@ bool WebAssemblyCFGStackify::fixCatchUnwindMismatches(MachineFunction &MF) {
   SmallVector<const MachineBasicBlock *, 8> EHPadStack;
   // For EH pads that have catch unwind mismatches, a map of <EH pad, its
   // correct unwind destination>.
-  DenseMap<MachineBasicBlock *, MachineBasicBlock *> EHPadToUnwindDest;
+  MapVector<MachineBasicBlock *, MachineBasicBlock *> EHPadToUnwindDest;
 
   for (auto &MBB : reverse(MF)) {
     for (auto &MI : reverse(MBB)) {

--- a/llvm/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyCFGStackify.cpp
@@ -1838,7 +1838,8 @@ bool WebAssemblyCFGStackify::fixCallUnwindMismatches(MachineFunction &MF) {
   // multiple BBs.
   using TryRange = std::pair<MachineInstr *, MachineInstr *>;
   // In original CFG, <unwind destination BB, a vector of try/try_table ranges>
-  MapVector<MachineBasicBlock *, SmallVector<TryRange, 4>> UnwindDestToTryRanges;
+  MapVector<MachineBasicBlock *, SmallVector<TryRange, 4>>
+      UnwindDestToTryRanges;
 
   // Gather possibly throwing calls (i.e., previously invokes) whose current
   // unwind destination is not the same as the original CFG. (Case 1)

--- a/llvm/lib/Target/WebAssembly/WebAssemblyLateEHPrepare.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLateEHPrepare.cpp
@@ -15,6 +15,7 @@
 #include "WebAssemblySubtarget.h"
 #include "WebAssemblyTargetMachine.h"
 #include "WebAssemblyUtilities.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
@@ -297,7 +298,7 @@ bool WebAssemblyLateEHPrepare::replaceFuncletReturns(MachineFunction &MF) {
 bool WebAssemblyLateEHPrepare::addCatchRefsAndThrowRefs(MachineFunction &MF) {
   const auto &TII = *MF.getSubtarget<WebAssemblySubtarget>().getInstrInfo();
   auto &MRI = MF.getRegInfo();
-  DenseMap<MachineBasicBlock *, SmallVector<MachineInstr *, 2>> EHPadToRethrows;
+  MapVector<MachineBasicBlock *, SmallVector<MachineInstr *, 2>> EHPadToRethrows;
 
   // Create a map of <EH pad, a vector of RETHROWs rethrowing its exception>
   for (auto &MBB : MF)

--- a/llvm/lib/Target/WebAssembly/WebAssemblyLateEHPrepare.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLateEHPrepare.cpp
@@ -298,7 +298,8 @@ bool WebAssemblyLateEHPrepare::replaceFuncletReturns(MachineFunction &MF) {
 bool WebAssemblyLateEHPrepare::addCatchRefsAndThrowRefs(MachineFunction &MF) {
   const auto &TII = *MF.getSubtarget<WebAssemblySubtarget>().getInstrInfo();
   auto &MRI = MF.getRegInfo();
-  MapVector<MachineBasicBlock *, SmallVector<MachineInstr *, 2>> EHPadToRethrows;
+  MapVector<MachineBasicBlock *, SmallVector<MachineInstr *, 2>>
+      EHPadToRethrows;
 
   // Create a map of <EH pad, a vector of RETHROWs rethrowing its exception>
   for (auto &MBB : MF)

--- a/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
@@ -1746,8 +1746,7 @@ void WebAssemblyLowerEmscriptenEHSjLj::handleLongjmpableCallsForWasmSjLj(
     }
   }
 
-  MapVector<BasicBlock *, SmallSetVector<BasicBlock *, 4>>
-      UnwindDestToNewPreds;
+  MapVector<BasicBlock *, SmallSetVector<BasicBlock *, 4>> UnwindDestToNewPreds;
   for (auto *CI : LongjmpableCalls) {
     // Even if the callee function has attribute 'nounwind', which is true for
     // all C functions, it can longjmp, which means it can throw a Wasm

--- a/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
@@ -1746,7 +1746,7 @@ void WebAssemblyLowerEmscriptenEHSjLj::handleLongjmpableCallsForWasmSjLj(
     }
   }
 
-  MapVector<BasicBlock *, SmallSetVector<BasicBlock *, 4>> UnwindDestToNewPreds;
+  SmallMapVector<BasicBlock *, SmallSetVector<BasicBlock *, 4>, 4> UnwindDestToNewPreds;
   for (auto *CI : LongjmpableCalls) {
     // Even if the callee function has attribute 'nounwind', which is true for
     // all C functions, it can longjmp, which means it can throw a Wasm

--- a/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
@@ -1746,7 +1746,8 @@ void WebAssemblyLowerEmscriptenEHSjLj::handleLongjmpableCallsForWasmSjLj(
     }
   }
 
-  SmallMapVector<BasicBlock *, SmallSetVector<BasicBlock *, 4>, 4> UnwindDestToNewPreds;
+  SmallMapVector<BasicBlock *, SmallSetVector<BasicBlock *, 4>, 4>
+      UnwindDestToNewPreds;
   for (auto *CI : LongjmpableCalls) {
     // Even if the callee function has attribute 'nounwind', which is true for
     // all C functions, it can longjmp, which means it can throw a Wasm

--- a/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
@@ -263,6 +263,7 @@
 
 #include "WebAssembly.h"
 #include "WebAssemblyTargetMachine.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
 #include "llvm/CodeGen/WasmEHInfo.h"
@@ -1745,7 +1746,7 @@ void WebAssemblyLowerEmscriptenEHSjLj::handleLongjmpableCallsForWasmSjLj(
     }
   }
 
-  SmallDenseMap<BasicBlock *, SmallSetVector<BasicBlock *, 4>, 4>
+  MapVector<BasicBlock *, SmallSetVector<BasicBlock *, 4>>
       UnwindDestToNewPreds;
   for (auto *CI : LongjmpableCalls) {
     // Even if the callee function has attribute 'nounwind', which is true for

--- a/llvm/test/CodeGen/WebAssembly/cfg-stackify-eh.ll
+++ b/llvm/test/CodeGen/WebAssembly/cfg-stackify-eh.ll
@@ -1561,13 +1561,68 @@ bb21:                                             ; preds = %bb10
           to label %common.ret unwind label %bb16
 }
 
+; NOSORT-LABEL: nested_cleanup_unwind_to_caller:
+; NOSORT:      block     exnref
+; NOSORT:        try_table    (catch_all_ref 0)             # 0: down to label[[L0:[0-9]+]]
+; NOSORT:          block     exnref
+; NOSORT:            block     exnref
+; NOSORT:              try_table    (catch_all_ref 0)       # 0: down to label[[L1:[0-9]+]]
+; NOSORT:                call  throwing_func
+; NOSORT:                try_table    (catch_all_ref 2)     # 2: down to label[[L2:[0-9]+]]
+; NOSORT:                  call  throwing_func
+; NOSORT:                end_try_table
+; NOSORT:                try_table    (catch_all_ref 5)     # 5: down to label[[L4:[0-9]+]]
+; NOSORT:                  call  cleanup_dtor
+; NOSORT:                end_try_table
+; NOSORT:                return
+; NOSORT:              end_try_table
+; NOSORT:              unreachable
+; NOSORT:            end_block                              # label[[L1]]:
+; NOSORT:            try_table    (catch_all_ref 3)         # 3: down to label[[L4]]
+; NOSORT:              call  cleanup_dtor
+; NOSORT:              throw_ref
+; NOSORT:      .LBB{{[0-9]+}}_{{[0-9]+}}:
+; NOSORT-NEXT:       end_try_table
+; NOSORT-NEXT: .LBB{{[0-9]+}}_{{[0-9]+}}:
+; NOSORT-NEXT:       unreachable
+; NOSORT-NEXT: .LBB{{[0-9]+}}_{{[0-9]+}}:
+; NOSORT-NEXT:     end_block                           # label[[L2]]:
+define hidden void @nested_cleanup_unwind_to_caller() personality ptr @__gxx_wasm_personality_v0 {
+entry:
+  %c = alloca i8, align 1
+  %dummy1 = alloca i32, align 4
+  %dummy2 = alloca i32, align 4
+  invoke void @throwing_func()
+          to label %invoke.cont unwind label %ehcleanup
+
+invoke.cont:                                      ; preds = %entry
+  invoke void @throwing_func()
+          to label %invoke.cont2 unwind label %ehcleanup2
+
+invoke.cont2:                                     ; preds = %invoke.cont
+  %ignore1 = call ptr @cleanup_dtor(ptr %c)
+  ret void
+
+ehcleanup:                                        ; preds = %entry
+  %pad = cleanuppad within none []
+  %ignore2 = call ptr @cleanup_dtor(ptr %c) [ "funclet"(token %pad) ]
+  cleanupret from %pad unwind to caller
+
+ehcleanup2:                                       ; preds = %invoke.cont
+  %pad2 = cleanuppad within none []
+  %ignore3 = call ptr @cleanup_dtor(ptr %c) [ "funclet"(token %pad2) ]
+  cleanupret from %pad2 unwind to caller
+}
+
 ; Check if the unwind destination mismatch stats are correct
-; NOSORT: 25 wasm-cfg-stackify    - Number of call unwind mismatches found
+; NOSORT: 28 wasm-cfg-stackify    - Number of call unwind mismatches found
 ; NOSORT:  5 wasm-cfg-stackify    - Number of catch unwind mismatches found
 
 declare void @foo()
 declare void @bar()
 declare i32 @baz()
+declare void @throwing_func()
+declare ptr @cleanup_dtor(ptr)
 declare i32 @qux(i32)
 declare void @quux(i32)
 declare void @fun(i32)


### PR DESCRIPTION
Several DenseMaps in the WebAssembly backend keyed by pointers were being
iterated over, potentially leading to nondeterministic codegen (differing
try/delegate nesting, virtual register allocation, or PHI node insertion)
due to nondeterministsic pointer values.

This patch replaces these DenseMaps with MapVectors to guarantee
deterministic iteration order:
  - UnwindDestToTryRanges in WebAssemblyCFGStackify.cpp
  - EHPadToUnwindDest in WebAssemblyCFGStackify.cpp
  - EHPadToRethrows in WebAssemblyLateEHPrepare.cpp
  - UnwindDestToNewPreds in WebAssemblyLowerEmscriptenEHSjLj.cpp

Fixes: #204883

Co-authored-by: Ammar Askar <aaskar@google.com>
Assisted-by: Antigravity
