### PR TITLE
[BOLT][Bazel] Add bolt_rt_instr

### DIFF
--- a/utils/bazel/llvm-project-overlay/bolt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/bolt/BUILD.bazel
@@ -70,6 +70,45 @@ cc_binary(
     ],
 )
 
+expand_template(
+    name = "runtime_config",
+    out = "runtime/config.h",
+    substitutions = {
+        "#cmakedefine HAVE_ELF_H": "#define HAVE_ELF_H",
+    },
+    template = "runtime/config.h.in",
+)
+
+cc_library(
+    name = "bolt_rt_instr",
+    srcs = ["runtime/instr.cpp"],
+    hdrs = glob([
+        "runtime/*.h",
+    ]) + [":runtime_config"],
+    copts = [
+        "-ffreestanding",
+        "-fno-exceptions",
+        "-fno-rtti",
+        "-fno-stack-protector",
+        "-fPIC",
+        "-fomit-frame-pointer",
+    ] + select({
+        "@platforms//cpu:aarch64": [
+            "-mgeneral-regs-only",
+            "-mno-outline-atomics",
+        ],
+        "@platforms//cpu:x86_64": [
+            "-mgeneral-regs-only",
+            "-mno-sse",
+        ],
+        "//conditions:default": [],
+    }),
+    features = ["-thin_lto"],
+    includes = ["runtime"],
+    linkstatic = True,
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
 cc_binary(
     name = "llvm-bolt",
     srcs = glob([


### PR DESCRIPTION
Add `bolt_rt_instr` with the generated `runtime/config.h` and the compile options from `bolt/runtime/CMakeLists.txt`. Bazel consumers can pass the resulting archive to `llvm-bolt` without exporting and recompiling LLVM runtime sources. This follows the `Rewrite` target configuration merged in #205179.

Validation: `buildifier -mode=check -lint=warn utils/bazel/llvm-project-overlay/bolt/BUILD.bazel`; the equivalent LLVM 22 overlay patch built `bolt_rt_instr` and executed BOLT for Linux x86_64 and Linux AArch64 in [hermetic-llvm's remote build](https://app.buildbuddy.io/invocation/6071ef1c-8640-4dfd-9af8-340e7b32f84c).

AI tool disclosure: Co-authored with OpenAI Codex.
