### PR TITLE
[mlir][emitc]: use converted result types when func.call has one result

### DIFF
--- a/mlir/lib/Conversion/FuncToEmitC/FuncToEmitC.cpp
+++ b/mlir/lib/Conversion/FuncToEmitC/FuncToEmitC.cpp
@@ -188,9 +188,9 @@ public:
     }
 
     if (callOp.getNumResults() <= 1) {
-      rewriter.replaceOpWithNewOp<emitc::CallOp>(
-          callOp, callOp.getResultTypes(), adaptor.getOperands(),
-          callOp->getAttrs());
+      rewriter.replaceOpWithNewOp<emitc::CallOp>(callOp, convertedResultTypes,
+                                                 adaptor.getOperands(),
+                                                 callOp->getAttrs());
       return success();
     }
 

--- a/mlir/test/Conversion/ConvertToEmitC/func.mlir
+++ b/mlir/test/Conversion/ConvertToEmitC/func.mlir
@@ -11,3 +11,11 @@ func.func @index(%arg0: index) -> index {
     // CHECK: return
     return %arg0 : index
 }
+
+// CHECK-LABEL: emitc.func @call_with_one_result
+func.func @call_with_one_result(%arg0: index) -> index {
+    // CHECK: call @index
+    // CHECK-SAME: (!emitc.size_t) -> !emitc.size_t
+    %0 = func.call @index(%arg0) : (index) -> index
+    return %0 : index
+}


### PR DESCRIPTION
The lowering for `func.call` to emitc properly uses converted result types when there are multiple return values from the called func, but not when there is a single one.