### PR TITLE
[SandboxVec][Scheduler] Implement direction

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -216,6 +216,24 @@ class Scheduler {
   Scheduler &operator=(const Scheduler &) = delete;
 
 public:
+  enum class Direction {
+    BottomUp,
+    TopDown,
+  };
+  static StringLiteral directionToStr(Direction Dir) {
+    switch (Dir) {
+    case Direction::BottomUp:
+      return "BottomUp";
+    case Direction::TopDown:
+      return "TopDown";
+    }
+    llvm_unreachable("Unhandled Dir!");
+  }
+
+private:
+  Direction Dir = Direction::BottomUp;
+
+public:
   Scheduler(AAResults &AA, Context &Ctx) : DAG(AA, Ctx), Ctx(Ctx) {
     // NOTE: The scheduler's callback depends on the DAG's callback running
     // before it and updating the DAG accordingly.
@@ -225,6 +243,12 @@ public:
   ~Scheduler() {
     if (CreateInstrCB)
       Ctx.unregisterCreateInstrCallback(*CreateInstrCB);
+  }
+  void setDirection(Direction NewDir) {
+    assert(Bndls.empty() && DAG.empty() && ReadyList.empty() &&
+           !ScheduleTopItOpt && ScheduledBB == nullptr &&
+           "We can't change the direction during scheduling!");
+    Dir = NewDir;
   }
   /// Tries to build a schedule that includes all of \p Instrs scheduled at the
   /// same scheduling cycle. This essentially checks that there are no

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -103,6 +103,14 @@ public:
 #endif // NDEBUG
 };
 
+enum class SchedDirection {
+  BottomUp,
+  TopDown,
+};
+#ifndef NDEBUG
+StringLiteral schedDirectionToStr(SchedDirection Dir);
+#endif
+
 /// The nodes that need to be scheduled back-to-back in a single scheduling
 /// cycle form a SchedBundle.
 class SchedBundle {
@@ -150,8 +158,11 @@ public:
   /// Move all bundle instructions to \p Where back-to-back.
   LLVM_ABI void cluster(BasicBlock::iterator Where);
   /// \Returns true if all nodes in the bundle are ready.
-  bool ready() const {
-    return all_of(Nodes, [](const auto *N) { return N->readyBottomUp(); });
+  bool ready(SchedDirection Dir) const {
+    return all_of(Nodes, [Dir](const auto *N) {
+      return Dir == SchedDirection::BottomUp ? N->readyBottomUp()
+                                             : N->readyTopDown();
+    });
   }
 #ifndef NDEBUG
   void dump(raw_ostream &OS) const;
@@ -215,23 +226,8 @@ class Scheduler {
   Scheduler(const Scheduler &) = delete;
   Scheduler &operator=(const Scheduler &) = delete;
 
-public:
-  enum class Direction {
-    BottomUp,
-    TopDown,
-  };
-  static StringLiteral directionToStr(Direction Dir) {
-    switch (Dir) {
-    case Direction::BottomUp:
-      return "BottomUp";
-    case Direction::TopDown:
-      return "TopDown";
-    }
-    llvm_unreachable("Unhandled Dir!");
-  }
-
 private:
-  Direction Dir = Direction::BottomUp;
+  SchedDirection Dir = SchedDirection::BottomUp;
 
 public:
   Scheduler(AAResults &AA, Context &Ctx) : DAG(AA, Ctx), Ctx(Ctx) {
@@ -244,7 +240,7 @@ public:
     if (CreateInstrCB)
       Ctx.unregisterCreateInstrCallback(*CreateInstrCB);
   }
-  void setDirection(Direction NewDir) {
+  void setDirection(SchedDirection NewDir) {
     assert(Bndls.empty() && DAG.empty() && ReadyList.empty() &&
            !ScheduleTopItOpt && ScheduledBB == nullptr &&
            "We can't change the direction during scheduling!");

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
@@ -146,6 +146,16 @@ public:
     }
     return LowestI;
   }
+  /// \Returns the instruction in \p Instrs that is highest in the BB. Expects
+  /// that all instructions are in the same BB.
+  static Instruction *getHighest(ArrayRef<Instruction *> Instrs) {
+    Instruction *HighestI = Instrs.front();
+    for (auto *I : drop_begin(Instrs)) {
+      if (I->comesBefore(HighestI))
+        HighestI = I;
+    }
+    return HighestI;
+  }
   /// \Returns the lowest instruction in \p Vals, or nullptr if no instructions
   /// are found. Skips instructions not in \p BB.
   static Instruction *getLowest(ArrayRef<Value *> Vals, BasicBlock *BB) {

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
@@ -355,9 +355,10 @@ void DependencyGraph::setDefUseUnscheduledSuccs(
         continue;
       if (!TopInterval.contains(OpI))
         continue;
-      OpN->incrUnscheduledSuccs();
-      if (!OpN->scheduled())
+      if (!OpN->scheduled()) {
+        OpN->incrUnscheduledSuccs();
         ++CntUnscheduledPreds;
+      }
     }
     *BotN->UnscheduledPreds += CntUnscheduledPreds;
   }

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -69,18 +69,34 @@ void ReadyListContainer::dump() const {
 void Scheduler::scheduleAndUpdateReadyList(SchedBundle &Bndl) {
   // Find where we should schedule the instructions.
   assert(ScheduleTopItOpt && "Should have been set by now!");
-  auto Where = *ScheduleTopItOpt;
+  auto Where = Dir == Direction::BottomUp ? *ScheduleTopItOpt
+                                          : std::next(*ScheduleTopItOpt);
   // Move all instructions in `Bndl` to `Where`.
   Bndl.cluster(Where);
   // Update the last scheduled bundle.
-  ScheduleTopItOpt = Bndl.getTop()->getInstruction()->getIterator();
-  // Set nodes as "scheduled" and decrement the UnsceduledSuccs counter of all
-  // dependency predecessors.
+  ScheduleTopItOpt = Dir == Direction::BottomUp
+                         ? Bndl.getTop()->getInstruction()->getIterator()
+                         : Bndl.getBot()->getInstruction()->getIterator();
+  // Set nodes as "scheduled" and decrement the UnscheduledSuccs/Preds counter
+  // of all dependency predecessors/successors.
   for (DGNode *N : Bndl) {
-    for (auto *DepN : N->preds(DAG)) {
-      DepN->decrUnscheduledSuccs();
-      if (DepN->readyBottomUp() && !DepN->scheduled())
-        ReadyList.insert(DepN);
+    switch (Dir) {
+    case Direction::BottomUp: {
+      for (auto *DepN : N->preds(DAG)) {
+        DepN->decrUnscheduledSuccs();
+        if (DepN->readyBottomUp() && !DepN->scheduled())
+          ReadyList.insert(DepN);
+      }
+      break;
+    }
+    case Direction::TopDown: {
+      for (auto *DepN : N->succs(DAG)) {
+        DepN->decrUnscheduledPreds();
+        if (DepN->readyTopDown() && !DepN->scheduled())
+          ReadyList.insert(DepN);
+      }
+      break;
+    }
     }
     N->setScheduled();
   }
@@ -97,16 +113,26 @@ void Scheduler::notifyCreateInstr(Instruction *I) {
   // "scheduled".
   bool IsScheduled = ScheduleTopItOpt &&
                      *ScheduleTopItOpt != I->getParent()->end() &&
-                     (*ScheduleTopItOpt.value()).comesBefore(I);
+                     ((Dir == Direction::BottomUp &&
+                       (*ScheduleTopItOpt.value()).comesBefore(I)) ||
+                      (Dir == Direction::TopDown &&
+                       I->comesBefore(&*ScheduleTopItOpt.value())));
   if (IsScheduled)
     N->setScheduled();
   // If the new instruction is above the top of schedule we need to remove its
   // dependency predecessors from the ready list and increment their
   // `UnscheduledSuccs` counters.
   if (!IsScheduled) {
-    for (auto *PredN : N->preds(DAG)) {
-      ReadyList.remove(PredN);
-      PredN->incrUnscheduledSuccs();
+    if (Dir == Direction::BottomUp) {
+      for (auto *PredN : N->preds(DAG)) {
+        ReadyList.remove(PredN);
+        PredN->incrUnscheduledSuccs();
+      }
+    } else {
+      for (auto *SuccN : N->succs(DAG)) {
+        ReadyList.remove(SuccN);
+        SuccN->incrUnscheduledPreds();
+      }
     }
   }
 }
@@ -251,8 +277,14 @@ void Scheduler::trimSchedule(ArrayRef<Instruction *> Instrs) {
   //  N
   //  N <- DAGInterval.bottom()
   //
-  Instruction *TopI = &*ScheduleTopItOpt.value();
-  Instruction *LowestI = VecUtils::getLowest(Instrs);
+  // Note: this figure assumes bottom-up scheduling. In top-down we have the
+  // top-down mirror image.
+  Instruction *TopI = Dir == Direction::BottomUp ? &*ScheduleTopItOpt.value()
+                                                 : VecUtils::getHighest(Instrs);
+  Instruction *LowestI = Dir == Direction::BottomUp
+                             ? VecUtils::getLowest(Instrs)
+                             : &*ScheduleTopItOpt.value();
+
   // Destroy the singleton schedule bundles from LowestI all the way to the top.
   for (auto *I = LowestI, *E = TopI->getPrevNode(); I != E;
        I = I->getPrevNode()) {
@@ -272,11 +304,20 @@ void Scheduler::trimSchedule(ArrayRef<Instruction *> Instrs) {
   for (Instruction &I : ResetIntvl) {
     auto *N = DAG.getNode(&I);
     N->resetScheduleState();
-    // Recompute UnscheduledSuccs for nodes not only in ResetIntvl but even for
-    // nodes above the top of schedule.
-    for (auto *PredN : N->preds(DAG))
-      PredN->incrUnscheduledSuccs();
+    if (Dir == Direction::BottomUp) {
+      // Recompute UnscheduledSuccs for nodes not only in ResetIntvl but even
+      // for nodes above the top of schedule.
+      for (auto *PredN : N->preds(DAG))
+        PredN->incrUnscheduledSuccs();
+    } else {
+      assert(Dir == Direction::TopDown);
+      // Recompute UnscheduledPreds for nodes not only in ResetIntvl but even
+      // for nodes below the bottom of schedule.
+      for (auto *SuccN : N->succs(DAG))
+        SuccN->incrUnscheduledPreds();
+    }
   }
+
   // Refill the ready list by visiting all nodes from the top of DAG to LowestI.
   ReadyList.clear();
   Interval<Instruction> RefillIntvl(DAG.getInterval().top(), LowestI);
@@ -305,6 +346,16 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
   if (any_of(Instrs,
              [this](Instruction *I) { return I->getParent() != ScheduledBB; }))
     return false;
+
+  auto GetSchedPoint = [](Direction Dir, const auto &Instrs) {
+    switch (Dir) {
+    case Direction::BottomUp:
+      return std::next(VecUtils::getLowest(Instrs)->getIterator());
+    case Direction::TopDown:
+      return VecUtils::getHighest(Instrs)->getIterator();
+    }
+    llvm_unreachable("Unhandled Dir!");
+  };
   auto SchedState = getBndlSchedState(Instrs);
   switch (SchedState) {
   case BndlSchedState::FullyScheduled:
@@ -321,19 +372,19 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
     // re-schedule.
     DAG.extend(Instrs);
     trimSchedule(Instrs);
-    ScheduleTopItOpt = std::next(VecUtils::getLowest(Instrs)->getIterator());
+    ScheduleTopItOpt = GetSchedPoint(Dir, Instrs);
     return tryScheduleUntil(Instrs);
   case BndlSchedState::NoneScheduled: {
     // TODO: Set the window of the DAG that we are interested in.
     if (!ScheduleTopItOpt)
-      // We start scheduling at the bottom instr of Instrs.
-      ScheduleTopItOpt = std::next(VecUtils::getLowest(Instrs)->getIterator());
+      // We start scheduling at the bottom instr of Instrs (top in TopDown).
+      ScheduleTopItOpt = GetSchedPoint(Dir, Instrs);
     // Extend the DAG to include Instrs.
     Interval<Instruction> Extension = DAG.extend(Instrs);
-    // Add nodes to ready list.
+    // Add nodes from the new interval to ready list if they are ready.
     for (auto &I : Extension) {
       auto *N = DAG.getNode(&I);
-      if (N->readyBottomUp())
+      if (Dir == Direction::BottomUp ? N->readyBottomUp() : N->readyTopDown())
         ReadyList.insert(N);
     }
     // Try schedule all nodes until we can schedule Instrs back-to-back.
@@ -347,7 +398,8 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
 void Scheduler::dump(raw_ostream &OS) const {
   OS << "ReadyList:\n";
   ReadyList.dump(OS);
-  OS << "Top of schedule: ";
+  OS << "Dir=" << directionToStr(Dir) << " "
+     << (Dir == Direction::BottomUp ? "Top" : "Bottom") << " of schedule: ";
   if (ScheduleTopItOpt)
     OS << **ScheduleTopItOpt;
   else

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -11,6 +11,18 @@
 
 namespace llvm::sandboxir {
 
+#ifndef NDEBUG
+StringLiteral schedDirectionToStr(SchedDirection Dir) {
+  switch (Dir) {
+  case SchedDirection::BottomUp:
+    return "BottomUp";
+  case SchedDirection::TopDown:
+    return "TopDown";
+  }
+  llvm_unreachable("Unhandled Dir!");
+}
+#endif // NDEBUG
+
 // TODO: Check if we can cache top/bottom to reduce compile-time.
 DGNode *SchedBundle::getTop() const {
   DGNode *TopN = Nodes.front();
@@ -69,19 +81,19 @@ void ReadyListContainer::dump() const {
 void Scheduler::scheduleAndUpdateReadyList(SchedBundle &Bndl) {
   // Find where we should schedule the instructions.
   assert(ScheduleTopItOpt && "Should have been set by now!");
-  auto Where = Dir == Direction::BottomUp ? *ScheduleTopItOpt
-                                          : std::next(*ScheduleTopItOpt);
+  auto Where = Dir == SchedDirection::BottomUp ? *ScheduleTopItOpt
+                                               : std::next(*ScheduleTopItOpt);
   // Move all instructions in `Bndl` to `Where`.
   Bndl.cluster(Where);
   // Update the last scheduled bundle.
-  ScheduleTopItOpt = Dir == Direction::BottomUp
+  ScheduleTopItOpt = Dir == SchedDirection::BottomUp
                          ? Bndl.getTop()->getInstruction()->getIterator()
                          : Bndl.getBot()->getInstruction()->getIterator();
   // Set nodes as "scheduled" and decrement the UnscheduledSuccs/Preds counter
   // of all dependency predecessors/successors.
   for (DGNode *N : Bndl) {
     switch (Dir) {
-    case Direction::BottomUp: {
+    case SchedDirection::BottomUp: {
       for (auto *DepN : N->preds(DAG)) {
         DepN->decrUnscheduledSuccs();
         if (DepN->readyBottomUp() && !DepN->scheduled())
@@ -89,7 +101,7 @@ void Scheduler::scheduleAndUpdateReadyList(SchedBundle &Bndl) {
       }
       break;
     }
-    case Direction::TopDown: {
+    case SchedDirection::TopDown: {
       for (auto *DepN : N->succs(DAG)) {
         DepN->decrUnscheduledPreds();
         if (DepN->readyTopDown() && !DepN->scheduled())
@@ -113,9 +125,9 @@ void Scheduler::notifyCreateInstr(Instruction *I) {
   // "scheduled".
   bool IsScheduled = ScheduleTopItOpt &&
                      *ScheduleTopItOpt != I->getParent()->end() &&
-                     ((Dir == Direction::BottomUp &&
+                     ((Dir == SchedDirection::BottomUp &&
                        (*ScheduleTopItOpt.value()).comesBefore(I)) ||
-                      (Dir == Direction::TopDown &&
+                      (Dir == SchedDirection::TopDown &&
                        I->comesBefore(&*ScheduleTopItOpt.value())));
   if (IsScheduled)
     N->setScheduled();
@@ -123,7 +135,7 @@ void Scheduler::notifyCreateInstr(Instruction *I) {
   // dependency predecessors from the ready list and increment their
   // `UnscheduledSuccs` counters.
   if (!IsScheduled) {
-    if (Dir == Direction::BottomUp) {
+    if (Dir == SchedDirection::BottomUp) {
       for (auto *PredN : N->preds(DAG)) {
         ReadyList.remove(PredN);
         PredN->incrUnscheduledSuccs();
@@ -178,7 +190,7 @@ bool Scheduler::tryScheduleUntil(ArrayRef<Instruction *> Instrs) {
         scheduleAndUpdateReadyList(*SingletonSB);
         return TryScheduleRes::Success;
       }
-      if (SB->ready()) {
+      if (SB->ready(Dir)) {
         // Remove the rest of the bundle from the ready list.
         // TODO: Perhaps change the Scheduler + ReadyList to operate on
         // SchedBundles instead of DGNodes.
@@ -279,9 +291,10 @@ void Scheduler::trimSchedule(ArrayRef<Instruction *> Instrs) {
   //
   // Note: this figure assumes bottom-up scheduling. In top-down we have the
   // top-down mirror image.
-  Instruction *TopI = Dir == Direction::BottomUp ? &*ScheduleTopItOpt.value()
-                                                 : VecUtils::getHighest(Instrs);
-  Instruction *LowestI = Dir == Direction::BottomUp
+  Instruction *TopI = Dir == SchedDirection::BottomUp
+                          ? &*ScheduleTopItOpt.value()
+                          : VecUtils::getHighest(Instrs);
+  Instruction *LowestI = Dir == SchedDirection::BottomUp
                              ? VecUtils::getLowest(Instrs)
                              : &*ScheduleTopItOpt.value();
 
@@ -304,13 +317,13 @@ void Scheduler::trimSchedule(ArrayRef<Instruction *> Instrs) {
   for (Instruction &I : ResetIntvl) {
     auto *N = DAG.getNode(&I);
     N->resetScheduleState();
-    if (Dir == Direction::BottomUp) {
+    if (Dir == SchedDirection::BottomUp) {
       // Recompute UnscheduledSuccs for nodes not only in ResetIntvl but even
       // for nodes above the top of schedule.
       for (auto *PredN : N->preds(DAG))
         PredN->incrUnscheduledSuccs();
     } else {
-      assert(Dir == Direction::TopDown);
+      assert(Dir == SchedDirection::TopDown);
       // Recompute UnscheduledPreds for nodes not only in ResetIntvl but even
       // for nodes below the bottom of schedule.
       for (auto *SuccN : N->succs(DAG))
@@ -347,11 +360,11 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
              [this](Instruction *I) { return I->getParent() != ScheduledBB; }))
     return false;
 
-  auto GetSchedPoint = [](Direction Dir, const auto &Instrs) {
+  auto GetSchedPoint = [](SchedDirection Dir, const auto &Instrs) {
     switch (Dir) {
-    case Direction::BottomUp:
+    case SchedDirection::BottomUp:
       return std::next(VecUtils::getLowest(Instrs)->getIterator());
-    case Direction::TopDown:
+    case SchedDirection::TopDown:
       return VecUtils::getHighest(Instrs)->getIterator();
     }
     llvm_unreachable("Unhandled Dir!");
@@ -384,7 +397,8 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
     // Add nodes from the new interval to ready list if they are ready.
     for (auto &I : Extension) {
       auto *N = DAG.getNode(&I);
-      if (Dir == Direction::BottomUp ? N->readyBottomUp() : N->readyTopDown())
+      if (Dir == SchedDirection::BottomUp ? N->readyBottomUp()
+                                          : N->readyTopDown())
         ReadyList.insert(N);
     }
     // Try schedule all nodes until we can schedule Instrs back-to-back.
@@ -398,8 +412,9 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
 void Scheduler::dump(raw_ostream &OS) const {
   OS << "ReadyList:\n";
   ReadyList.dump(OS);
-  OS << "Dir=" << directionToStr(Dir) << " "
-     << (Dir == Direction::BottomUp ? "Top" : "Bottom") << " of schedule: ";
+  OS << "Dir=" << schedDirectionToStr(Dir) << " "
+     << (Dir == SchedDirection::BottomUp ? "Top" : "Bottom")
+     << " of schedule: ";
   if (ScheduleTopItOpt)
     OS << **ScheduleTopItOpt;
   else

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -260,6 +260,104 @@ define void @foo(ptr %ptr, i8 %v0, i8 %v1) {
   }
 }
 
+TEST_F(SchedulerTest, Basic_TopDown) {
+  parseIR(C, R"IR(
+define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
+  %ld0 = load i8, ptr %ptr0
+  %ld1 = load i8, ptr %ptr1
+  store i8 %ld0, ptr %ptr0
+  store i8 %ld1, ptr %ptr1
+  store i8 %ld0, ptr %ptr0
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *L0 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L1 = cast<sandboxir::LoadInst>(&*It++);
+  auto *S0 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S1 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S2 = cast<sandboxir::StoreInst>(&*It++);
+  auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
+
+  {
+    Ctx.save();
+    sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
+    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    EXPECT_TRUE(Sched.trySchedule({L0, L1}));
+    EXPECT_TRUE(Sched.trySchedule({S0, S1}));
+    EXPECT_TRUE(Sched.trySchedule({Ret}));
+    Ctx.revert();
+  }
+  {
+    Ctx.save();
+    sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
+    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    EXPECT_TRUE(Sched.trySchedule({L0, L1}));
+    EXPECT_TRUE(Sched.trySchedule({S1}));
+    EXPECT_TRUE(Sched.trySchedule({S0}));
+    EXPECT_TRUE(Sched.trySchedule({Ret}));
+    Ctx.revert();
+  }
+  {
+    Ctx.save();
+    sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
+    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    EXPECT_TRUE(Sched.trySchedule({L0, L1}));
+    EXPECT_TRUE(Sched.trySchedule({S0}));
+    EXPECT_TRUE(Sched.trySchedule({S1}));
+    EXPECT_TRUE(Sched.trySchedule({S2}));
+    EXPECT_TRUE(Sched.trySchedule({Ret}));
+    Ctx.revert();
+  }
+  {
+    Ctx.save();
+    sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
+    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    EXPECT_TRUE(Sched.trySchedule({L0}));
+    EXPECT_TRUE(Sched.trySchedule({L1}));
+    EXPECT_FALSE(Sched.trySchedule({S0, S2}));
+    Sched.clear(); // TODO: Remove
+    EXPECT_TRUE(Sched.trySchedule({S0, S1}));
+    EXPECT_TRUE(Sched.trySchedule({Ret}));
+    Ctx.revert();
+  }
+  {
+    Ctx.save();
+    sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
+    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    EXPECT_TRUE(Sched.trySchedule({L1}));
+    EXPECT_TRUE(Sched.trySchedule({L0}));
+    EXPECT_TRUE(Sched.trySchedule({S0, S1}));
+    EXPECT_TRUE(Sched.trySchedule({Ret}));
+    Ctx.revert();
+  }
+  {
+    Ctx.save();
+    sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
+    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    // Dependent instrs.
+    EXPECT_FALSE(Sched.trySchedule({L0, L1, S0, S1}));
+    Sched.clear(); // TODO: Remove
+    EXPECT_FALSE(Sched.trySchedule({L0, L1, S0}));
+    Sched.clear(); // TODO: Remove
+    EXPECT_FALSE(Sched.trySchedule({L0, S0}));
+    Sched.clear(); // TODO: Remove
+    EXPECT_FALSE(Sched.trySchedule({L1, S1}));
+    Sched.clear(); // TODO: Remove
+    EXPECT_FALSE(Sched.trySchedule({L1, S1, Ret}));
+    Sched.clear(); // TODO: Remove
+    // This should succeed.
+    EXPECT_TRUE(Sched.trySchedule({L0, L1}));
+    // Dependent instrs.
+    EXPECT_FALSE(Sched.trySchedule({S0, S2}));
+    Ctx.revert();
+  }
+}
+
 TEST_F(SchedulerTest, Bundles) {
   parseIR(C, R"IR(
 define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -286,7 +286,7 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
   {
     Ctx.save();
     sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
-    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    Sched.setDirection(sandboxir::SchedDirection::TopDown);
     EXPECT_TRUE(Sched.trySchedule({L0, L1}));
     EXPECT_TRUE(Sched.trySchedule({S0, S1}));
     EXPECT_TRUE(Sched.trySchedule({Ret}));
@@ -295,7 +295,7 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
   {
     Ctx.save();
     sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
-    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    Sched.setDirection(sandboxir::SchedDirection::TopDown);
     EXPECT_TRUE(Sched.trySchedule({L0, L1}));
     EXPECT_TRUE(Sched.trySchedule({S1}));
     EXPECT_TRUE(Sched.trySchedule({S0}));
@@ -305,7 +305,7 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
   {
     Ctx.save();
     sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
-    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    Sched.setDirection(sandboxir::SchedDirection::TopDown);
     EXPECT_TRUE(Sched.trySchedule({L0, L1}));
     EXPECT_TRUE(Sched.trySchedule({S0}));
     EXPECT_TRUE(Sched.trySchedule({S1}));
@@ -316,11 +316,10 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
   {
     Ctx.save();
     sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
-    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    Sched.setDirection(sandboxir::SchedDirection::TopDown);
     EXPECT_TRUE(Sched.trySchedule({L0}));
     EXPECT_TRUE(Sched.trySchedule({L1}));
     EXPECT_FALSE(Sched.trySchedule({S0, S2}));
-    Sched.clear(); // TODO: Remove
     EXPECT_TRUE(Sched.trySchedule({S0, S1}));
     EXPECT_TRUE(Sched.trySchedule({Ret}));
     Ctx.revert();
@@ -328,7 +327,7 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
   {
     Ctx.save();
     sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
-    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    Sched.setDirection(sandboxir::SchedDirection::TopDown);
     EXPECT_TRUE(Sched.trySchedule({L1}));
     EXPECT_TRUE(Sched.trySchedule({L0}));
     EXPECT_TRUE(Sched.trySchedule({S0, S1}));
@@ -338,16 +337,12 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
   {
     Ctx.save();
     sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
-    Sched.setDirection(sandboxir::Scheduler::Direction::TopDown);
+    Sched.setDirection(sandboxir::SchedDirection::TopDown);
     // Dependent instrs.
     EXPECT_FALSE(Sched.trySchedule({L0, L1, S0, S1}));
-    Sched.clear(); // TODO: Remove
     EXPECT_FALSE(Sched.trySchedule({L0, L1, S0}));
-    Sched.clear(); // TODO: Remove
     EXPECT_FALSE(Sched.trySchedule({L0, S0}));
-    Sched.clear(); // TODO: Remove
     EXPECT_FALSE(Sched.trySchedule({L1, S1}));
-    Sched.clear(); // TODO: Remove
     EXPECT_FALSE(Sched.trySchedule({L1, S1, Ret}));
     Sched.clear(); // TODO: Remove
     // This should succeed.

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/VecUtilsTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/VecUtilsTest.cpp
@@ -545,6 +545,20 @@ bb1:
   SmallVector<sandboxir::Instruction *> CBA({IC, IB, IA});
   EXPECT_EQ(sandboxir::VecUtils::getLowest(CBA), IC);
 
+  {
+    // Check getHighest(ArrayRef<Instruction *>)
+    SmallVector<sandboxir::Instruction *> A({IA});
+    EXPECT_EQ(sandboxir::VecUtils::getHighest(A), IA);
+    SmallVector<sandboxir::Instruction *> ABC({IA, IB, IC});
+    EXPECT_EQ(sandboxir::VecUtils::getHighest(ABC), IA);
+    SmallVector<sandboxir::Instruction *> ACB({IA, IC, IB});
+    EXPECT_EQ(sandboxir::VecUtils::getHighest(ACB), IA);
+    SmallVector<sandboxir::Instruction *> CAB({IC, IA, IB});
+    EXPECT_EQ(sandboxir::VecUtils::getHighest(CAB), IA);
+    SmallVector<sandboxir::Instruction *> CBA({IC, IB, IA});
+    EXPECT_EQ(sandboxir::VecUtils::getHighest(CBA), IA);
+  }
+
   // Check getLowest(ArrayRef<Value *>)
   SmallVector<sandboxir::Value *> C1Only({C1});
   EXPECT_EQ(sandboxir::VecUtils::getLowest(C1Only, &BB), nullptr);


### PR DESCRIPTION
DGNode::UnscheduledPreds was added in a previous patch, so this patch makes use of it in the scheduler. Depending on Dir we can now schedule BottomUp or TopDown.