### PR TITLE
[llvm-cas] Fix validation test on Ubuntu / uutils v0.2.2, NFC

### DIFF
--- a/llvm/test/tools/llvm-cas/validation.test
+++ b/llvm/test/tools/llvm-cas/validation.test
@@ -42,5 +42,5 @@ RUN: llvm-cas --cas %t/ac --validate
 
 # Note: records are 40 bytes (32 hash bytes + 8 byte value), so trim the last
 # allocated record, leaving it invalid.
-RUN: truncate -s -40 %t/ac/v1.1/actions.v1
+RUN: truncate -s=-40 %t/ac/v1.1/actions.v1
 RUN: not llvm-cas --cas %t/ac --validate

--- a/llvm/test/tools/llvm-cas/validation.test
+++ b/llvm/test/tools/llvm-cas/validation.test
@@ -42,5 +42,7 @@ RUN: llvm-cas --cas %t/ac --validate
 
 # Note: records are 40 bytes (32 hash bytes + 8 byte value), so trim the last
 # allocated record, leaving it invalid.
-RUN: truncate -s=-40 %t/ac/v1.1/actions.v1
+# FIXME: Use `truncate -s -40` once Ubuntu 26.04 is the LTS support baseline,
+# see https://github.com/uutils/coreutils/issues/9128
+RUN: %python -c "with open(r'%t/ac/v1.1/actions.v1', 'r+b') as f: f.truncate(f.seek(0, 2) - 40)"
 RUN: not llvm-cas --cas %t/ac --validate


### PR DESCRIPTION
Work around uutils/coreutils#9128 by implementing the 40 byte truncation in Python. Otherwise, this test fails out of the box on Ubuntu 25.10. GNU coreutils supports -s=arg, but Mac truncate does not. Resorting to Python seemed like the cleanest solution. The next best idea was to use subshells or other techniques to calculate the file size and subtract 40, but that seemed excessive.

Test-only, so self-approving.