### PR TITLE
[Clang][Test] Fix warn-memset-bad-sizeof.cpp after #183004

### DIFF
--- a/clang/test/SemaCXX/warn-memset-bad-sizeof.cpp
+++ b/clang/test/SemaCXX/warn-memset-bad-sizeof.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -Wno-sizeof-array-argument %s
+// RUN: %clang_cc1 -fsyntax-only -verify -Wno-sizeof-array-argument -Wno-stringop-overread %s
 //
 extern "C" void *bzero(void *, unsigned);
 extern "C" void *memset(void *, int, unsigned);


### PR DESCRIPTION
The new `-Wstringop-overread` warning (added in #183004) fires on the SemaCXX test warn-memset-bad-sizeof.cpp. This happens on targets where unsigned matches size_t, such as 32-bit ARM, because clang will match the declaration with the builtin prototype (specifically, argument `unsigned n`).

Suppress the warning since this test is exercising `-Wsizeof-pointer-memaccess`, not source buffer overreads.

Fixes:
- https://lab.llvm.org/buildbot/#/builders/154/builds/32985
- https://lab.llvm.org/buildbot/#/builders/135/builds/3888
- https://lab.llvm.org/buildbot/#/builders/38/builds/9363