### PR TITLE
[RISCV][clang] Use fcf-protection flag in Multilib Selection

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -445,6 +445,18 @@ static void getRISCVMultilibFlags(const Driver &D, const llvm::Triple &Triple,
     Result.push_back("-fsanitize=shadow-call-stack");
   else
     Result.push_back("-fno-sanitize=shadow-call-stack");
+
+  const Arg *CFProtectionArg =
+      Args.getLastArgNoClaim(options::OPT_fcf_protection_EQ);
+  StringRef CFProtectionVal =
+      CFProtectionArg ? CFProtectionArg->getValue() : "none";
+  Result.push_back(("-fcf-protection=" + CFProtectionVal).str());
+
+  if (CFProtectionVal == "branch" || CFProtectionVal == "full") {
+    if (const Arg *SchemeArg =
+            Args.getLastArgNoClaim(options::OPT_mcf_branch_label_scheme_EQ))
+      Result.push_back(SchemeArg->getAsString(Args));
+  }
 }
 
 Multilib::flags_list

--- a/clang/test/Driver/print-multi-selection-flags.c
+++ b/clang/test/Driver/print-multi-selection-flags.c
@@ -154,3 +154,16 @@
 // CHECK-OPT-OS: -Os
 // CHECK-OPT-NOT: -Oz
 // CHECK-OPT-NOT: -Os
+
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf                                                         | FileCheck --check-prefix=CHECK-CF-PROTECTION-NONE --implicit-check-not="mcf-branch-label-scheme" %s
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf -fcf-protection=none                                   | FileCheck --check-prefix=CHECK-CF-PROTECTION-NONE --implicit-check-not="mcf-branch-label-scheme" %s
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf -fcf-protection=return                                 | FileCheck --check-prefix=CHECK-CF-PROTECTION-RETURN --implicit-check-not="mcf-branch-label-scheme" %s
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf -fcf-protection=branch -mcf-branch-label-scheme=unlabeled | FileCheck --check-prefix=CHECK-CF-PROTECTION-BRANCH %s
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf -fcf-protection=full   -mcf-branch-label-scheme=unlabeled | FileCheck --check-prefix=CHECK-CF-PROTECTION-FULL   %s
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf -fcf-protection        -mcf-branch-label-scheme=unlabeled | FileCheck --check-prefix=CHECK-CF-PROTECTION-FULL   %s
+// CHECK-CF-PROTECTION-NONE: -fcf-protection=none
+// CHECK-CF-PROTECTION-RETURN: -fcf-protection=return
+// CHECK-CF-PROTECTION-BRANCH: -fcf-protection=branch
+// CHECK-CF-PROTECTION-BRANCH: -mcf-branch-label-scheme=unlabeled
+// CHECK-CF-PROTECTION-FULL: -fcf-protection=full
+// CHECK-CF-PROTECTION-FULL: -mcf-branch-label-scheme=unlabeled


### PR DESCRIPTION
This ensures that we can separate out multilibs that are or are not built with control flow protection enabled.

The initial version of the patch claims all values of these flags are incompatible. It might be the case that we could make this logic more complex if some versions do become compatible.