### PR TITLE
[SCCP] Fix overdefined worklist regression

### DIFF
--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -588,6 +588,10 @@ class SCCPInstVisitor : public InstVisitor<SCCPInstVisitor> {
   /// constants.
   SmallPtrSet<Function *, 16> TrackingIncomingArguments;
 
+  /// The reason for two worklists is that overdefined is the lowest state
+  /// on the lattice, and moving things to overdefined as fast as possible
+  /// makes SCCP converge much faster.
+  SmallSetVector<Value *, 16> OverdefinedWorkList;
   /// Worklist of instructions to re-visit. This only includes instructions
   /// in blocks that have already been visited at least once.
   SmallSetVector<Instruction *, 16> InstWorkList;
@@ -627,6 +631,9 @@ private:
   /// Like pushUsersToWorkList(), but also prints a debug message with the
   /// updated value.
   void pushUsersToWorkListMsg(ValueLatticeElement &IV, Value *V);
+
+  /// Helper to push users of a value \p V while checking if overdefined.
+  void pushChangedValue(ValueLatticeElement &IV, Value *V);
 
   // markConstant - Make a value be marked as "constant".  If the value
   // is not already a constant, add it to the instruction work list so that
@@ -777,8 +784,46 @@ private:
   // successors are reachable from a given terminator instruction.
   void getFeasibleSuccessors(Instruction &TI, SmallVectorImpl<bool> &Succs);
 
+  // OperandChangedState - This method is invoked on all of the users of an
+  // instruction that was just changed state somehow.  Based on this
+  // information, we need to update the specified user of this instruction.
+  void operandChangedState(Instruction *I) {
+    if (BBExecutable.count(I->getParent())) // Inst is executable?
+      visit(*I);
+  }
+
   // Add U as additional user of V.
   void addAdditionalUser(Value *V, User *U) { AdditionalUsers[V].insert(U); }
+
+  // Mark V's users as changed, including AdditionalUsers.
+  void markUsersAsChanged(Value *V) {
+    // Functions include their arguments in the use-list. Changed function
+    // values mean that the result of the function changed. We only need to
+    // update the call sites with the new function result and do not have to
+    // propagate the call arguments.
+    if (isa<Function>(V)) {
+      for (User *U : V->users()) {
+        if (auto *CB = dyn_cast<CallBase>(U))
+          handleCallResult(*CB);
+      }
+    } else {
+      for (User *U : V->users())
+        if (auto *UI = dyn_cast<Instruction>(U))
+          operandChangedState(UI);
+    }
+
+    auto Iter = AdditionalUsers.find(V);
+    if (Iter != AdditionalUsers.end()) {
+      // Copy additional users before notifying them of changes, because new
+      // users may be added, potentially invalidating the iterator.
+      SmallVector<Instruction *, 2> ToNotify;
+      for (User *U : Iter->second)
+        if (auto *UI = dyn_cast<Instruction>(U))
+          ToNotify.push_back(UI);
+      for (Instruction *UI : ToNotify)
+        operandChangedState(UI);
+    }
+  }
 
   void handlePredicate(Instruction *I, Value *CopyOf, const PredicateBase *PI);
   void handleCallOverdefined(CallBase &CB);
@@ -1096,6 +1141,15 @@ void SCCPInstVisitor::pushUsersToWorkList(Value *V) {
   }
 }
 
+void SCCPInstVisitor::pushChangedValue(ValueLatticeElement &IV, Value *V) {
+  if (IV.isOverdefined()) {
+    OverdefinedWorkList.insert(V);
+    return;
+  }
+
+  pushUsersToWorkList(V);
+}
+
 void SCCPInstVisitor::pushUsersToWorkListMsg(ValueLatticeElement &IV,
                                              Value *V) {
   LLVM_DEBUG(dbgs() << "updated " << IV << ": " << *V << '\n');
@@ -1107,7 +1161,7 @@ bool SCCPInstVisitor::markConstant(ValueLatticeElement &IV, Value *V,
   if (!IV.markConstant(C, MayIncludeUndef))
     return false;
   LLVM_DEBUG(dbgs() << "markConstant: " << *C << ": " << *V << '\n');
-  pushUsersToWorkList(V);
+  pushChangedValue(IV, V);
   return true;
 }
 
@@ -1116,7 +1170,7 @@ bool SCCPInstVisitor::markNotConstant(ValueLatticeElement &IV, Value *V,
   if (!IV.markNotConstant(C))
     return false;
   LLVM_DEBUG(dbgs() << "markNotConstant: " << *C << ": " << *V << '\n');
-  pushUsersToWorkList(V);
+  pushChangedValue(IV, V);
   return true;
 }
 
@@ -1125,7 +1179,7 @@ bool SCCPInstVisitor::markConstantRange(ValueLatticeElement &IV, Value *V,
   if (!IV.markConstantRange(CR))
     return false;
   LLVM_DEBUG(dbgs() << "markConstantRange: " << CR << ": " << *V << '\n');
-  pushUsersToWorkList(V);
+  pushChangedValue(IV, V);
   return true;
 }
 
@@ -1137,8 +1191,7 @@ bool SCCPInstVisitor::markOverdefined(ValueLatticeElement &IV, Value *V) {
              if (auto *F = dyn_cast<Function>(V)) dbgs()
              << "Function '" << F->getName() << "'\n";
              else dbgs() << *V << '\n');
-  // Only instructions go on the work list
-  pushUsersToWorkList(V);
+  pushChangedValue(IV, V);
   return true;
 }
 
@@ -1245,7 +1298,7 @@ bool SCCPInstVisitor::mergeInValue(ValueLatticeElement &IV, Value *V,
                                    const ValueLatticeElement &MergeWithV,
                                    ValueLatticeElement::MergeOptions Opts) {
   if (IV.mergeIn(MergeWithV, Opts)) {
-    pushUsersToWorkList(V);
+    pushChangedValue(IV, V);
     LLVM_DEBUG(dbgs() << "Merged " << MergeWithV << " into " << *V << " : "
                       << IV << "\n");
     return true;
@@ -1265,7 +1318,7 @@ bool SCCPInstVisitor::markEdgeExecutable(BasicBlock *Source, BasicBlock *Dest) {
                       << " -> " << Dest->getName() << '\n');
 
     for (PHINode &PN : Dest->phis())
-      pushToWorkList(&PN);
+      visitPHINode(PN);
   }
   return true;
 }
@@ -2222,9 +2275,22 @@ bool SCCPInstVisitor::isInstFullyOverDefined(Instruction &Inst) {
 }
 
 void SCCPInstVisitor::solve() {
-  // Process the work lists until they are empty!
-  while (!BBWorkList.empty() || !InstWorkList.empty()) {
-    // Process the instruction work list.
+  // Process the worklists until they are empty!
+  while (!BBWorkList.empty() || !InstWorkList.empty() ||
+         !OverdefinedWorkList.empty()) {
+
+    // Process the overdefined worklist!
+    while (!OverdefinedWorkList.empty()) {
+      Value *V = OverdefinedWorkList.pop_back_val();
+      Invalidated.erase(V);
+
+      LLVM_DEBUG(dbgs() << "\nPopped off O-WL: " << *V << '\n');
+
+      // Chase users of this overdefined value.
+      markUsersAsChanged(V);
+    }
+
+    // Process the instruction worklist!
     while (!InstWorkList.empty()) {
       Instruction *I = InstWorkList.pop_back_val();
       Invalidated.erase(I);
@@ -2234,7 +2300,7 @@ void SCCPInstVisitor::solve() {
       visit(I);
     }
 
-    // Process the basic block work list.
+    // Process the basic block worklist!
     while (!BBWorkList.empty()) {
       BasicBlock *BB = BBWorkList.pop_back_val();
       BBVisited.insert(BB);

--- a/llvm/test/Transforms/SCCP/sccp-overdefined-chasing.ll
+++ b/llvm/test/Transforms/SCCP/sccp-overdefined-chasing.ll
@@ -1,0 +1,20 @@
+; RUN: opt -passes='sccp,instcombine' -S %s | FileCheck %s
+
+define i32 @src(i32 %v0_u8, i32 %v1_u8) {
+; CHECK-LABEL: define {{.*}}i32 @src(
+; CHECK-NOT: lshr
+; CHECK-NOT: xor
+; CHECK: ret i32 %v1_u8
+entry:
+  %v0.lo = icmp sge i32 %v0_u8, 0
+  %v0.hi = icmp sle i32 %v0_u8, 1
+  %v0.ok = and i1 %v0.lo, %v0.hi
+  call void @llvm.assume(i1 %v0.ok)
+  %v1.lo = icmp sge i32 %v1_u8, 1
+  %v1.hi = icmp sle i32 %v1_u8, 2
+  %v1.ok = and i1 %v1.lo, %v1.hi
+  call void @llvm.assume(i1 %v1.ok)
+  %shr = lshr i32 %v0_u8, %v1_u8
+  %xor = xor i32 %v1_u8, %shr
+  ret i32 %xor
+}


### PR DESCRIPTION
Restore some of the usage of the overdefined worklist. Use similar logic pre-regression-commit to allow arg values to be added to the overdefined worklist and be pursued in solved(). Issue report says O3, but this was also a regression on O1/O2/Os/Oz.

This gets a different output on the test below, though there was a discussion on what the right testcase was supposed to be.

- Breaks Test: [FuncSpec] Skip SCCP on blocks of dead functions and poison their callsites (#154668)
     - Commit: 6bd844812385dd5cb65e08fe9561be9f91ace876

- Fixes Issue: [Regression] Missed Optimization at O3 (#204049)

- Original PR: [SCCP] Improve worklist management (#146321)
     - Commit: 545cdca4883552b147a0f1adfac713f76fc22305