### PR TITLE
[NFC][CodeGen] Don't allow copying SUnit

### DIFF
--- a/llvm/include/llvm/CodeGen/ScheduleDAG.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAG.h
@@ -357,6 +357,7 @@ class TargetRegisterInfo;
           isHeightCurrent(false), isNode(false), isInst(false),
           SchedulingPref(Sched::None) {}
 
+    // Don't allow copying, SUnit can be very large.
     SUnit(const SUnit &) = delete;
     SUnit &operator=(const SUnit &) = delete;
     SUnit(SUnit &&) = default;

--- a/llvm/include/llvm/CodeGen/ScheduleDAG.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAG.h
@@ -357,6 +357,11 @@ class TargetRegisterInfo;
           isHeightCurrent(false), isNode(false), isInst(false),
           SchedulingPref(Sched::None) {}
 
+    SUnit(const SUnit &) = delete;
+    SUnit &operator=(const SUnit &) = delete;
+    SUnit(SUnit &&) = default;
+    SUnit &operator=(SUnit &&) = default;
+
     /// Boundary nodes are placeholders for the boundary of the
     /// scheduling region.
     ///

--- a/llvm/lib/Target/AMDGPU/GCNILPSched.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNILPSched.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/BitVector.h"
 #include "llvm/CodeGen/ScheduleDAG.h"
 
 using namespace llvm;
@@ -290,11 +291,12 @@ GCNILPScheduler::schedule(ArrayRef<const SUnit*> BotRoots,
   auto &SUnits = const_cast<ScheduleDAG&>(DAG).SUnits;
 
   std::vector<unsigned> SavedNumSuccsLeft(SUnits.size());
-  std::vector<char> SavedIsScheduled(SUnits.size());
+  BitVector SavedIsScheduled(SUnits.size());
 
   for (const SUnit &SU : SUnits) {
     SavedNumSuccsLeft[SU.NodeNum] = SU.NumSuccsLeft;
-    SavedIsScheduled[SU.NodeNum] = SU.isScheduled;
+    if (SU.isScheduled)
+      SavedIsScheduled.set(SU.NodeNum);
   }
 
   SUNumbers.assign(SUnits.size(), 0);
@@ -346,7 +348,7 @@ GCNILPScheduler::schedule(ArrayRef<const SUnit*> BotRoots,
 
   // restore units
   for (auto &SU : SUnits) {
-    SU.isScheduled = SavedIsScheduled[SU.NodeNum];
+    SU.isScheduled = SavedIsScheduled.test(SU.NodeNum);
     SU.NumSuccsLeft = SavedNumSuccsLeft[SU.NodeNum];
     SU.setHeightDirty();
   }

--- a/llvm/lib/Target/AMDGPU/GCNILPSched.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNILPSched.cpp
@@ -289,13 +289,13 @@ GCNILPScheduler::schedule(ArrayRef<const SUnit*> BotRoots,
                           const ScheduleDAG &DAG) {
   auto &SUnits = const_cast<ScheduleDAG&>(DAG).SUnits;
 
-  std::vector<SUnit> SUSavedCopy;
-  SUSavedCopy.resize(SUnits.size());
+  std::vector<unsigned> SavedNumSuccsLeft(SUnits.size());
+  std::vector<char> SavedIsScheduled(SUnits.size());
 
-  // we cannot save only those fields we touch: some of them are private
-  // so save units verbatim: this assumes SUnit should have value semantics
-  for (const SUnit &SU : SUnits)
-    SUSavedCopy[SU.NodeNum] = SU;
+  for (const SUnit &SU : SUnits) {
+    SavedNumSuccsLeft[SU.NodeNum] = SU.NumSuccsLeft;
+    SavedIsScheduled[SU.NodeNum] = SU.isScheduled;
+  }
 
   SUNumbers.assign(SUnits.size(), 0);
   for (const SUnit &SU : SUnits)
@@ -345,8 +345,11 @@ GCNILPScheduler::schedule(ArrayRef<const SUnit*> BotRoots,
   std::reverse(Schedule.begin(), Schedule.end());
 
   // restore units
-  for (auto &SU : SUnits)
-    SU = SUSavedCopy[SU.NodeNum];
+  for (auto &SU : SUnits) {
+    SU.isScheduled = SavedIsScheduled[SU.NodeNum];
+    SU.NumSuccsLeft = SavedNumSuccsLeft[SU.NodeNum];
+    SU.setHeightDirty();
+  }
 
   return Schedule;
 }

--- a/llvm/lib/Target/AMDGPU/SIMachineScheduler.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineScheduler.cpp
@@ -1833,10 +1833,10 @@ void SIScheduleDAGMI::moveLowLatencies() {
 void SIScheduleDAGMI::restoreSULinksLeft() {
   for (unsigned i = 0, e = SUnits.size(); i != e; ++i) {
     SUnits[i].isScheduled = false;
-    SUnits[i].WeakPredsLeft = SUnitsLinksBackup[i].WeakPredsLeft;
-    SUnits[i].NumPredsLeft = SUnitsLinksBackup[i].NumPredsLeft;
-    SUnits[i].WeakSuccsLeft = SUnitsLinksBackup[i].WeakSuccsLeft;
-    SUnits[i].NumSuccsLeft = SUnitsLinksBackup[i].NumSuccsLeft;
+    SUnits[i].WeakPredsLeft = SUnitsWeakPredsLeftBackup[i];
+    SUnits[i].NumPredsLeft = SUnitsNumPredsLeftBackup[i];
+    SUnits[i].WeakSuccsLeft = SUnitsWeakSuccsLeftBackup[i];
+    SUnits[i].NumSuccsLeft = SUnitsNumSuccsLeftBackup[i];
   }
 }
 
@@ -1887,7 +1887,20 @@ void SIScheduleDAGMI::schedule()
 
   // Fill some stats to help scheduling.
 
-  SUnitsLinksBackup = SUnits;
+  SUnitsWeakPredsLeftBackup.clear();
+  SUnitsNumPredsLeftBackup.clear();
+  SUnitsWeakSuccsLeftBackup.clear();
+  SUnitsNumSuccsLeftBackup.clear();
+  SUnitsWeakPredsLeftBackup.reserve(SUnits.size());
+  SUnitsNumPredsLeftBackup.reserve(SUnits.size());
+  SUnitsWeakSuccsLeftBackup.reserve(SUnits.size());
+  SUnitsNumSuccsLeftBackup.reserve(SUnits.size());
+  for (const auto &SU : SUnits) {
+    SUnitsWeakPredsLeftBackup.push_back(SU.WeakPredsLeft);
+    SUnitsNumPredsLeftBackup.push_back(SU.NumPredsLeft);
+    SUnitsWeakSuccsLeftBackup.push_back(SU.WeakSuccsLeft);
+    SUnitsNumSuccsLeftBackup.push_back(SU.NumSuccsLeft);
+  }
   IsLowLatencySU.clear();
   LowLatencyOffset.clear();
   IsHighLatencySU.clear();

--- a/llvm/lib/Target/AMDGPU/SIMachineScheduler.h
+++ b/llvm/lib/Target/AMDGPU/SIMachineScheduler.h
@@ -426,7 +426,10 @@ class SIScheduleDAGMI final : public ScheduleDAGMILive {
   const SIInstrInfo *SITII;
   const SIRegisterInfo *SITRI;
 
-  std::vector<SUnit> SUnitsLinksBackup;
+  std::vector<unsigned> SUnitsWeakPredsLeftBackup;
+  std::vector<unsigned> SUnitsNumPredsLeftBackup;
+  std::vector<unsigned> SUnitsWeakSuccsLeftBackup;
+  std::vector<unsigned> SUnitsNumSuccsLeftBackup;
 
   // For moveLowLatencies. After all Scheduling variants are tested.
   std::vector<unsigned> ScheduledSUnits;


### PR DESCRIPTION
In preparation for #205171.

We shouldn't be copying around SUnits anyway, they may have large SmallVectors.

Assisted-by: Gemini