### PR TITLE
[clang][Dependency Scanning] Fix the Input File for By-Name Lookup's Input CC1 Command Line

### DIFF
--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -378,10 +378,11 @@ CompilerInstanceWithContext::initializeFromCommandline(
       std::make_unique<DiagnosticsEngineWithDiagOpts>(ModifiedCommandLine, FS,
                                                       DC);
 
-  if (CommandLine.size() >= 2 && CommandLine[1] == "-cc1") {
+  if (ModifiedCommandLine.size() >= 2 && ModifiedCommandLine[1] == "-cc1") {
     // The input command line is already a -cc1 invocation; initialize the
     // compiler instance directly from it.
-    CompilerInstanceWithContext CIWithContext(Tool.Worker, CWD, CommandLine);
+    CompilerInstanceWithContext CIWithContext(Tool.Worker, CWD,
+                                              ModifiedCommandLine);
     if (!CIWithContext.initialize(Controller,
                                   std::move(DiagEngineWithCmdAndOpts),
                                   std::move(OverlayFS)))

--- a/clang/test/ClangScanDeps/modules-full-by-mult-mod-names-diagnostics.c
+++ b/clang/test/ClangScanDeps/modules-full-by-mult-mod-names-diagnostics.c
@@ -26,6 +26,20 @@ module root2 { header "root2.h" }
 // RUN: cat %t/error.txt | FileCheck %s --check-prefixes=ERROR
 // RUN: cat %t/result.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
+//--- cdb.cc1.json.template
+[{
+  "file": "",
+  "directory": "DIR",
+  "command": "clang -cc1 -nostdsysteminc -nobuiltininc -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache -I DIR -x c"
+}]
+
+// RUN: sed "s|DIR|%/t|g" %t/cdb.cc1.json.template > %t/cdb.cc1.json
+// RUN: not clang-scan-deps -compilation-database %t/cdb.cc1.json -format \
+// RUN:   experimental-full -module-names=modA,root,modB,modC,root2 2> \
+// RUN:   %t/error.cc1.txt > %t/result.cc1.json
+// RUN: cat %t/error.cc1.txt | FileCheck %s --check-prefixes=ERROR
+// RUN: cat %t/result.cc1.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
+
 // ERROR: Error while scanning dependencies for modA:
 // ERROR-NEXT: module-include.input:1:1: fatal error: module 'modA' not found
 // ERROR-NEXT: Error while scanning dependencies for modB:


### PR DESCRIPTION
When the command line is a CC1 command, the scanner does not append the fake input file to the command line when initializing the compiler instance. This PR fixes that by passing the compiler instance initialization the correct modified command line. Without specifying the fake input file, clang picks up `-` as its input. 

An observable behavior is that the diagnostics are pointing to incorrect files for cc1 commands, hence a test is added to check the diagnostics messages contain the correct file name. 