### PR TITLE
[AMDGPU] Fold constant offsets into named barrier addresses

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -1553,7 +1553,10 @@ SDValue AMDGPUTargetLowering::LowerGlobalAddress(AMDGPUMachineFunctionInfo *MFI,
         unsigned BarCnt = cast<GlobalVariable>(GV)->getGlobalSize(DL) / 16;
         MFI->recordNumNamedBarriers(Address.value(), BarCnt);
       }
-      return DAG.getConstant(*Address, SDLoc(Op), Op.getValueType());
+      // A constant byte offset (e.g. from a GEP into an array of named
+      // barriers) folds directly into the fixed LDS address.
+      return DAG.getConstant(*Address + G->getOffset(), SDLoc(Op),
+                             Op.getValueType());
     } else if (IsNamedBarrier) {
       llvm_unreachable("named barrier should have an assigned address");
     }
@@ -1582,15 +1585,14 @@ SDValue AMDGPUTargetLowering::LowerGlobalAddress(AMDGPUMachineFunctionInfo *MFI,
       return DAG.getPOISON(Op.getValueType());
     }
 
-    // XXX: What does the value of G->getOffset() mean?
-    assert(G->getOffset() == 0 &&
-         "Do not know what to do with an non-zero offset");
-
     // TODO: We could emit code to handle the initialization somewhere.
     // We ignore the initializer for now and legalize it to allow selection.
     // The initializer will anyway get errored out during assembly emission.
     unsigned Offset = MFI->allocateLDSGlobal(DL, *cast<GlobalVariable>(GV));
-    return DAG.getConstant(Offset, SDLoc(Op), Op.getValueType());
+    // A constant byte offset (e.g. from a GEP into an array of named barriers)
+    // folds directly into the allocated LDS address.
+    return DAG.getConstant(Offset + G->getOffset(), SDLoc(Op),
+                           Op.getValueType());
   }
   return SDValue();
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -1546,9 +1546,12 @@ SDValue AMDGPUTargetLowering::LowerGlobalAddress(AMDGPUMachineFunctionInfo *MFI,
   const GlobalValue *GV = G->getGlobal();
 
   if (!MFI->isModuleEntryFunction()) {
-    auto IsNamedBarrier = AMDGPU::isNamedBarrier(*cast<GlobalVariable>(GV));
-    if (std::optional<uint32_t> Address =
-            AMDGPUMachineFunctionInfo::getLDSAbsoluteAddress(*GV)) {
+    bool IsNamedBarrier = AMDGPU::isNamedBarrier(*cast<GlobalVariable>(GV));
+    std::optional<uint32_t> Address =
+        AMDGPUMachineFunctionInfo::getLDSAbsoluteAddress(*GV);
+    if (!Address && IsNamedBarrier)
+      llvm_unreachable("named barrier should have an assigned address");
+    if (Address) {
       if (IsNamedBarrier) {
         unsigned BarCnt = cast<GlobalVariable>(GV)->getGlobalSize(DL) / 16;
         MFI->recordNumNamedBarriers(Address.value(), BarCnt);
@@ -1557,8 +1560,6 @@ SDValue AMDGPUTargetLowering::LowerGlobalAddress(AMDGPUMachineFunctionInfo *MFI,
       // barriers) folds directly into the fixed LDS address.
       return DAG.getConstant(*Address + G->getOffset(), SDLoc(Op),
                              Op.getValueType());
-    } else if (IsNamedBarrier) {
-      llvm_unreachable("named barrier should have an assigned address");
     }
   }
 

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -15,6 +15,7 @@
 #include "AMDGPU.h"
 #include "AMDGPUInstrInfo.h"
 #include "AMDGPULaneMaskUtils.h"
+#include "AMDGPUMemoryUtils.h"
 #include "AMDGPUSelectionDAGInfo.h"
 #include "AMDGPUTargetMachine.h"
 #include "GCNSubtarget.h"
@@ -9862,6 +9863,13 @@ SDValue SITargetLowering::lowerBUILD_VECTOR(SDValue Op,
 
 bool SITargetLowering::isOffsetFoldingLegal(
     const GlobalAddressSDNode *GA) const {
+  // Named barriers have fixed, non-relocated LDS addresses, so a constant
+  // offset into an array of them can be folded into the address.
+  if (GA->getAddressSpace() == AMDGPUAS::LOCAL_ADDRESS) {
+    const auto *GV = dyn_cast<GlobalVariable>(GA->getGlobal());
+    return GV && AMDGPU::isNamedBarrier(*GV);
+  }
+
   // OSes that use ELF REL relocations (instead of RELA) can only store a
   // 32-bit addend in the instruction, so it is not safe to allow offset folding
   // which can create arbitrary 64-bit addends. (This is only a problem for

--- a/llvm/test/CodeGen/AMDGPU/s-barrier-signal-var-gep.ll
+++ b/llvm/test/CodeGen/AMDGPU/s-barrier-signal-var-gep.ll
@@ -68,8 +68,7 @@ define amdgpu_kernel void @signal_var_bar1() {
 ; SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; SDAG-NEXT:    s_mov_b32 m0, 0x100002
 ; SDAG-NEXT:    s_barrier_init m0
-; SDAG-NEXT:    s_mov_b32 m0, 2
-; SDAG-NEXT:    s_barrier_signal m0
+; SDAG-NEXT:    s_barrier_signal 2
 ; SDAG-NEXT:    s_barrier_wait 1
 ; SDAG-NEXT:    s_endpgm
 ;
@@ -85,11 +84,9 @@ define amdgpu_kernel void @signal_var_bar1() {
 ; OBJ-SDAG-LABEL: signal_var_bar1:
 ; OBJ-SDAG:       ; %bb.0:
 ; OBJ-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; OBJ-SDAG-NEXT:    s_add_co_i32 s0, __amdgpu_named_barrier.bars.5a19a560517f8a3a4347b4502da34a70@abs32@lo, 16
+; OBJ-SDAG-NEXT:    s_lshr_b32 s0, __amdgpu_named_barrier.bars.5a19a560517f8a3a4347b4502da34a70@abs32@lo+16, 4
 ; OBJ-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; OBJ-SDAG-NEXT:    s_lshr_b32 s0, s0, 4
 ; OBJ-SDAG-NEXT:    s_and_b32 s0, s0, 63
-; OBJ-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; OBJ-SDAG-NEXT:    s_or_b32 m0, 0x100000, s0
 ; OBJ-SDAG-NEXT:    s_barrier_init m0
 ; OBJ-SDAG-NEXT:    s_mov_b32 m0, s0
@@ -128,8 +125,7 @@ define amdgpu_kernel void @signal_var_misaligned() {
 ; SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
 ; SDAG-NEXT:    s_mov_b32 m0, 0x100001
 ; SDAG-NEXT:    s_barrier_init m0
-; SDAG-NEXT:    s_mov_b32 m0, 1
-; SDAG-NEXT:    s_barrier_signal m0
+; SDAG-NEXT:    s_barrier_signal 1
 ; SDAG-NEXT:    s_barrier_wait 1
 ; SDAG-NEXT:    s_endpgm
 ;
@@ -145,7 +141,7 @@ define amdgpu_kernel void @signal_var_misaligned() {
 ; OBJ-SDAG-LABEL: signal_var_misaligned:
 ; OBJ-SDAG:       ; %bb.0:
 ; OBJ-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; OBJ-SDAG-NEXT:    s_lshr_b32 s0, __amdgpu_named_barrier.bars.5a19a560517f8a3a4347b4502da34a70@abs32@lo, 4
+; OBJ-SDAG-NEXT:    s_lshr_b32 s0, __amdgpu_named_barrier.bars.5a19a560517f8a3a4347b4502da34a70@abs32@lo+1, 4
 ; OBJ-SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; OBJ-SDAG-NEXT:    s_and_b32 s0, s0, 63
 ; OBJ-SDAG-NEXT:    s_or_b32 m0, 0x100000, s0


### PR DESCRIPTION
Allow isOffsetFoldingLegal to fold a constant offset into an LDS named-barrier global, and include the node offset when materializing the LDS address in LowerGlobalAddress. `s_barrier_signal_var` on a GEP'd named barrier now selects the immediate form, matching a bare global and GlobalISel.

Refer to ROCM-26246

[2/2] <- this one

---

This PR was assisted by AI, but I have reviewed the changes.