### PR TITLE
[BPF] Increase BPFMaxStoresPerMemFunc from 128 to 192

### DIFF
--- a/llvm/lib/Target/BPF/BPFSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/BPF/BPFSelectionDAGInfo.cpp
@@ -22,7 +22,7 @@ using namespace llvm;
 #define DEBUG_TYPE "bpf-selectiondag-info"
 
 static cl::opt<unsigned> BPFMaxStoresPerMemFunc(
-    "bpf-max-stores-per-memfunc", cl::Hidden, cl::init(128),
+    "bpf-max-stores-per-memfunc", cl::Hidden, cl::init(192),
     cl::desc("Set the maximum number of stores for inlined BPF memory "
              "intrinsics"));
 


### PR DESCRIPTION
With commits [1] and [2], memory operations like memcpy/memmove lower to a sequence of loads/stores whose width is the minimum of the source and destination alignment, and the store count is bounded by BPFMaxStoresPerMemFunc. For 1-byte alignment, the maximum copy length that can be inlined is therefore 128 bytes.

This may regress cases that previously inlined. Consider a memcpy with src alignment 8, dst alignment 1 and size 136. After [1]/[2], the store width is the minimum alignment (1 byte), so the store count is 136, which exceeds the 128 limit and the copy falls back. Before [1]/[2], the store count was computed with a fixed 8-byte unit regardless of the actual alignment (each unit expands to 8 one-byte stores when the minimum alignment is 1), so the total count was only 17 (136/8 < 128) and the copy was inlined.

Raise the limit from 128 to 192 to mitigate. Alternatively, users can increase alignment to avoid the regression.

  [1] https://github.com/llvm/llvm-project/pull/201119
  [2] https://github.com/llvm/llvm-project/pull/204042