### PR TITLE
[clang-format] Use fc and echo on Windows if diff is not found.

### DIFF
--- a/clang/lib/Format/CMakeLists.txt
+++ b/clang/lib/Format/CMakeLists.txt
@@ -41,17 +41,31 @@ file(GLOB_RECURSE files
   ${CLANG_SOURCE_DIR}/unittests/Format/*.h
   )
 
+find_program(DIFF_EXE diff)
 set(check_format_depends)
 set(i 0)
 foreach(file IN LISTS files)
-  add_custom_command(OUTPUT check_format_depend_${i}
-    COMMAND clang-format ${file} | diff -u ${file} - &&
-            touch check_format_depend_${i}
-    VERBATIM
-    COMMENT "Checking format of ${file}"
-    DEPENDS clang-format
-            ${file}
-    )
+  if(NOT DIFF_EXE AND WIN32)
+    file(TO_NATIVE_PATH ${file} src_path)
+    file(TO_NATIVE_PATH ${file}.tmp tmp_path)
+    add_custom_command(OUTPUT check_format_depend_${i}
+      COMMAND clang-format ${src_path} > ${tmp_path} && fc ${src_path} ${tmp_path} && del ${tmp_path} &&
+              echo. > check_format_depend_${i}
+      VERBATIM
+      COMMENT "Checking format of ${file}"
+      DEPENDS clang-format
+              ${file}
+      )
+  else()
+    add_custom_command(OUTPUT check_format_depend_${i}
+      COMMAND clang-format ${file} | diff -u ${file} - &&
+              touch check_format_depend_${i}
+      VERBATIM
+      COMMENT "Checking format of ${file}"
+      DEPENDS clang-format
+              ${file}
+      )
+  endif()
   list(APPEND check_format_depends check_format_depend_${i})
   math(EXPR i ${i}+1)
 endforeach()


### PR DESCRIPTION
Fixing the issue introduced by #204908, and attempted to be fixed by #205036.

There were several issues that I identified:
- diff is not available by default on Windows (replace with fc.exe)
- touch is not available by default on Windows (replace with echo.)
- fc command cannot read from stdin for one of the comparison files, both files must be specified on the command line explicitly
- fc command does not accept paths with forward slashes instead of backslashes
- The generated cmd.exe command contained some double quotes which needed to be escaped (or removed, I did the latter)

I ran the changes here on my bot that was failing and it was able to successfully complete all testing.