### PR TITLE
[RISCV][P-ext] Rename pwcvt/pncvt pseudoinstructions for RV64.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1635,16 +1635,15 @@ let append Predicates = [IsRV64] in {
   def : InstAlias<"pmsgt.w $rd, $rs, $rt", (PMSLT_W GPR:$rd, GPR:$rt, GPR:$rs), 0>;
   def : InstAlias<"pmsgtu.w $rd, $rs, $rt", (PMSLTU_W GPR:$rd, GPR:$rt, GPR:$rs), 0>;
 
-  // No pwcvt.b/h for RV64.
-  def : InstAlias<"pwcvtu.b $rd, $rs", (ZIP8P GPR:$rd, GPR:$rs, X0)>;
-  def : InstAlias<"pwcvtu.h $rd, $rs", (ZIP16P GPR:$rd, GPR:$rs, X0)>;
-  def : InstAlias<"pwcvth.b $rd, $rs", (ZIP8P GPR:$rd, X0, GPR:$rs)>;
-  def : InstAlias<"pwcvth.h $rd, $rs", (ZIP16P GPR:$rd, X0, GPR:$rs)>;
+  def : InstAlias<"pwcvtu.wb $rd, $rs", (ZIP8P GPR:$rd, GPR:$rs, X0)>;
+  def : InstAlias<"pwcvtu.wh $rd, $rs", (ZIP16P GPR:$rd, GPR:$rs, X0)>;
+  def : InstAlias<"pwcvth.wb $rd, $rs", (ZIP8P GPR:$rd, X0, GPR:$rs)>;
+  def : InstAlias<"pwcvth.wh $rd, $rs", (ZIP16P GPR:$rd, X0, GPR:$rs)>;
 
-  def : InstAlias<"pncvt.b $rd, $rs", (UNZIP8P GPR:$rd, GPR:$rs, X0)>;
-  def : InstAlias<"pncvt.h $rd, $rs", (UNZIP16P GPR:$rd, GPR:$rs, X0)>;
-  def : InstAlias<"pncvth.b $rd, $rs", (UNZIP8HP GPR:$rd, GPR:$rs, X0)>;
-  def : InstAlias<"pncvth.h $rd, $rs", (UNZIP16HP GPR:$rd, GPR:$rs, X0)>;
+  def : InstAlias<"pncvt.wb $rd, $rs", (UNZIP8P GPR:$rd, GPR:$rs, X0)>;
+  def : InstAlias<"pncvt.wh $rd, $rs", (UNZIP16P GPR:$rd, GPR:$rs, X0)>;
+  def : InstAlias<"pncvth.wb $rd, $rs", (UNZIP8HP GPR:$rd, GPR:$rs, X0)>;
+  def : InstAlias<"pncvth.wh $rd, $rs", (UNZIP16HP GPR:$rd, GPR:$rs, X0)>;
 } // append Predicates = [IsRV64]
 
 let append Predicates = [IsRV32] in {

--- a/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
@@ -1310,8 +1310,8 @@ define <4 x i8> @test_pmulhsu_b(<4 x i8> %a, <4 x i8> %b) {
 ;
 ; RV64-LABEL: test_pmulhsu_b:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    pwcvtu.b a0, a0
-; RV64-NEXT:    pwcvtu.b a1, a1
+; RV64-NEXT:    pwcvtu.wb a0, a0
+; RV64-NEXT:    pwcvtu.wb a1, a1
 ; RV64-NEXT:    psext.h.b a0, a0
 ; RV64-NEXT:    pmul.w.h11 a2, a0, a1
 ; RV64-NEXT:    pmul.w.h00 a0, a0, a1
@@ -1346,8 +1346,8 @@ define <4 x i8> @test_pmulhsu_b_commuted(<4 x i8> %a, <4 x i8> %b) {
 ;
 ; RV64-LABEL: test_pmulhsu_b_commuted:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    pwcvtu.b a1, a1
-; RV64-NEXT:    pwcvtu.b a0, a0
+; RV64-NEXT:    pwcvtu.wb a1, a1
+; RV64-NEXT:    pwcvtu.wb a0, a0
 ; RV64-NEXT:    psext.h.b a1, a1
 ; RV64-NEXT:    pmul.w.h11 a2, a0, a1
 ; RV64-NEXT:    pmul.w.h00 a0, a0, a1

--- a/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
@@ -2448,19 +2448,19 @@ define <8 x i8> @test_pmulhsu_b(<8 x i8> %a, <8 x i8> %b) {
 ; RV64-NEXT:    ppaire.b a2, a3, a2
 ; RV64-NEXT:    ppaire.b a3, a5, a4
 ; RV64-NEXT:    ppaire.h a2, a3, a2
-; RV64-NEXT:    pwcvtu.b a2, a2
+; RV64-NEXT:    pwcvtu.wb a2, a2
 ; RV64-NEXT:    srli a3, a1, 56
 ; RV64-NEXT:    srli a4, a1, 48
 ; RV64-NEXT:    psext.h.b a2, a2
 ; RV64-NEXT:    ppaire.b a3, a4, a3
 ; RV64-NEXT:    srli a4, a1, 40
 ; RV64-NEXT:    srli a5, a1, 32
-; RV64-NEXT:    pwcvtu.b a0, a0
+; RV64-NEXT:    pwcvtu.wb a0, a0
 ; RV64-NEXT:    ppaire.b a4, a5, a4
 ; RV64-NEXT:    psext.h.b a0, a0
 ; RV64-NEXT:    ppaire.h a3, a4, a3
-; RV64-NEXT:    pwcvtu.b a3, a3
-; RV64-NEXT:    pwcvtu.b a1, a1
+; RV64-NEXT:    pwcvtu.wb a3, a3
+; RV64-NEXT:    pwcvtu.wb a1, a1
 ; RV64-NEXT:    pmul.w.h11 a4, a2, a3
 ; RV64-NEXT:    pmul.w.h00 a2, a2, a3
 ; RV64-NEXT:    pmul.w.h11 a3, a0, a1
@@ -2524,12 +2524,12 @@ define <8 x i8> @test_pmulhsu_b_commuted(<8 x i8> %a, <8 x i8> %b) {
 ; RV64-NEXT:    ppaire.b a3, a5, a4
 ; RV64-NEXT:    srli a4, a1, 40
 ; RV64-NEXT:    srli a5, a1, 32
-; RV64-NEXT:    pwcvtu.b a2, a2
+; RV64-NEXT:    pwcvtu.wb a2, a2
 ; RV64-NEXT:    ppaire.b a4, a5, a4
-; RV64-NEXT:    pwcvtu.b a0, a0
+; RV64-NEXT:    pwcvtu.wb a0, a0
 ; RV64-NEXT:    ppaire.h a3, a4, a3
-; RV64-NEXT:    pwcvtu.b a3, a3
-; RV64-NEXT:    pwcvtu.b a1, a1
+; RV64-NEXT:    pwcvtu.wb a3, a3
+; RV64-NEXT:    pwcvtu.wb a1, a1
 ; RV64-NEXT:    psext.h.b a3, a3
 ; RV64-NEXT:    psext.h.b a1, a1
 ; RV64-NEXT:    pmul.w.h11 a4, a2, a3
@@ -4668,19 +4668,29 @@ define <2 x i32> @test_bitreverse_v2i32(<2 x i32> %a) {
 }
 
 define <4 x i16> @test_zext_v4i8_to_v4i16(<4 x i8> %a) {
-; CHECK-LABEL: test_zext_v4i8_to_v4i16:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    pwcvtu.b a0, a0
-; CHECK-NEXT:    ret
+; RV32-LABEL: test_zext_v4i8_to_v4i16:
+; RV32:       # %bb.0:
+; RV32-NEXT:    pwcvtu.b a0, a0
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_zext_v4i8_to_v4i16:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pwcvtu.wb a0, a0
+; RV64-NEXT:    ret
   %res = zext <4 x i8> %a to <4 x i16>
   ret <4 x i16> %res
 }
 
 define <2 x i32> @test_zext_v2i16_to_v2i32(<2 x i16> %a) {
-; CHECK-LABEL: test_zext_v2i16_to_v2i32:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    pwcvtu.h a0, a0
-; CHECK-NEXT:    ret
+; RV32-LABEL: test_zext_v2i16_to_v2i32:
+; RV32:       # %bb.0:
+; RV32-NEXT:    pwcvtu.h a0, a0
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: test_zext_v2i16_to_v2i32:
+; RV64:       # %bb.0:
+; RV64-NEXT:    pwcvtu.wh a0, a0
+; RV64-NEXT:    ret
   %res = zext <2 x i16> %a to <2 x i32>
   ret <2 x i32> %res
 }
@@ -4693,7 +4703,7 @@ define <4 x i16> @test_sext_v4i8_to_v4i16(<4 x i8> %a) {
 ;
 ; RV64-LABEL: test_sext_v4i8_to_v4i16:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    pwcvtu.b a0, a0
+; RV64-NEXT:    pwcvtu.wb a0, a0
 ; RV64-NEXT:    psext.h.b a0, a0
 ; RV64-NEXT:    ret
   %res = sext <4 x i8> %a to <4 x i16>
@@ -4708,7 +4718,7 @@ define <2 x i32> @test_sext_v2i16_to_v2i32(<2 x i16> %a) {
 ;
 ; RV64-LABEL: test_sext_v2i16_to_v2i32:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    pwcvtu.h a0, a0
+; RV64-NEXT:    pwcvtu.wh a0, a0
 ; RV64-NEXT:    psext.w.h a0, a0
 ; RV64-NEXT:    ret
   %res = sext <2 x i16> %a to <2 x i32>

--- a/llvm/test/MC/RISCV/rv64p-aliases-valid.s
+++ b/llvm/test/MC/RISCV/rv64p-aliases-valid.s
@@ -126,36 +126,36 @@ pmsgt.w a0, a1, a2
 pmsgtu.w a3, a4, a5
 
 # CHECK-S-OBJ-NOALIAS: zip8p a4, a5, zero
-# CHECK-S-OBJ: pwcvtu.b a4, a5
-pwcvtu.b a4, a5
+# CHECK-S-OBJ: pwcvtu.wb a4, a5
+pwcvtu.wb a4, a5
 
 # CHECK-S-OBJ-NOALIAS: zip16p a6, a7, zero
-# CHECK-S-OBJ: pwcvtu.h a6, a7
-pwcvtu.h a6, a7
+# CHECK-S-OBJ: pwcvtu.wh a6, a7
+pwcvtu.wh a6, a7
 
 # CHECK-S-OBJ-NOALIAS: zip8p s0, zero, s1
-# CHECK-S-OBJ: pwcvth.b s0, s1
-pwcvth.b s0, s1
+# CHECK-S-OBJ: pwcvth.wb s0, s1
+pwcvth.wb s0, s1
 
 # CHECK-S-OBJ-NOALIAS: zip16p s2, zero, s3
-# CHECK-S-OBJ: pwcvth.h s2, s3
-pwcvth.h s2, s3
+# CHECK-S-OBJ: pwcvth.wh s2, s3
+pwcvth.wh s2, s3
 
 # CHECK-S-OBJ-NOALIAS: unzip8p s3, s4, zero
-# CHECK-S-OBJ: pncvt.b s3, s4
-pncvt.b s3, s4
+# CHECK-S-OBJ: pncvt.wb s3, s4
+pncvt.wb s3, s4
 
 # CHECK-S-OBJ-NOALIAS: unzip16p s5, s6, zero
-# CHECK-S-OBJ: pncvt.h s5, s6
-pncvt.h s5, s6
+# CHECK-S-OBJ: pncvt.wh s5, s6
+pncvt.wh s5, s6
 
 # CHECK-S-OBJ-NOALIAS: unzip8hp s7, s8, zero
-# CHECK-S-OBJ: pncvth.b s7, s8
-pncvth.b s7, s8
+# CHECK-S-OBJ: pncvth.wb s7, s8
+pncvth.wb s7, s8
 
 # CHECK-S-OBJ-NOALIAS: unzip16hp s9, s10, zero
-# CHECK-S-OBJ: pncvth.h s9, s10
-pncvth.h s9, s10
+# CHECK-S-OBJ: pncvth.wh s9, s10
+pncvth.wh s9, s10
 
 # CHECK-S-OBJ-NOALIAS: pli.b s10, 17
 # CHECK-S-OBJ: pli.b s10, 17


### PR DESCRIPTION
See https://github.com/riscv/riscv-p-spec/pull/303

We need to add a 'w' to the suffix to indicate it operates on a word and not a register pair like on RV32.