### PR TITLE
[HLSL] Diagnose initialization of static local resource variables

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13806,6 +13806,9 @@ def warn_hlsl_assigning_local_resource_is_not_unique
               "unique global resource">,
       InGroup<HLSLExplicitBinding>;
 
+def err_hlsl_static_local_resource : Error<
+  "static local resource variable is not allowed">;
+  
 def err_hlsl_push_constant_unique
     : Error<"cannot have more than one push constant block">;
 def err_hlsl_samplecmp_requires_float

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -6513,6 +6513,13 @@ QualType SemaHLSL::checkMatrixComponent(Sema &S, QualType baseType,
 }
 
 bool SemaHLSL::handleInitialization(VarDecl *VDecl, Expr *&Init) {
+  // Static local resource variables cannot be copy-initialized.
+  if (VDecl->isStaticLocal() && VDecl->getType()->isHLSLResourceRecord()) {
+    SemaRef.Diag(VDecl->getLocation(), diag::err_hlsl_static_local_resource);
+    VDecl->setInvalidDecl();
+    return false;
+  }
+
   // If initializing a local resource, track the resource binding it is using
   if (VDecl->getType()->isHLSLResourceRecord() && !VDecl->hasGlobalStorage())
     trackLocalResource(VDecl, Init);

--- a/clang/test/SemaHLSL/Resources/static_local_resource_init.hlsl
+++ b/clang/test/SemaHLSL/Resources/static_local_resource_init.hlsl
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.6-compute -x hlsl -fsyntax-only %s -verify
+// This test validates that initializing a static local variable with a resource
+// type produces a diagnostic error instead of crashing during optimization.
+
+RWByteAddressBuffer gBuf0 : register(u0);
+
+void fn() {
+    // expected-error@+1 {{static local resource variable is not allowed}}
+    static RWByteAddressBuffer buf = gBuf0; 
+}
+
+[numthreads(1,1,1)]
+void main() {
+}


### PR DESCRIPTION
Initializing a static local variable with a resource type
(`static RWByteAddressBuffer buf = gBuf0;`) is not valid in HLSL,
but the compiler had no guard for it. The code reached globalopt,
which attempted to constant-fold a zeroinitializer on a target
extension type that does not support zero initialization, causing
an assertion failure.

This patch adds an early check in `SemaHLSL::handleInitialization`
that rejects static local resource variables with an initializer,
emitting a clean diagnostic instead of crashing. Default-initialized
static local resources (`static RWBuffer<float> buf;`) remain valid
and are unaffected.

Fixes #205169.