### PR TITLE
Reland [Allocator] Keep bump pointer at a minimum alignment

### DIFF
--- a/llvm/include/llvm/Support/Allocator.h
+++ b/llvm/include/llvm/Support/Allocator.h
@@ -59,11 +59,16 @@ LLVM_ABI void printBumpPtrAllocatorStats(unsigned NumSlabs,
 ///
 /// The GrowthDelay specifies after how many allocated slabs the allocator
 /// increases the size of the slabs.
+///
+/// MinAlign keeps the bump pointer aligned between allocations: each size is
+/// rounded up to a multiple of MinAlign so the fast path can skip realigning
+/// CurPtr when the requested alignment is no greater than MinAlign.
 template <typename AllocatorT = MallocAllocator, size_t SlabSize = 4096,
-          size_t SizeThreshold = SlabSize, size_t GrowthDelay = 128>
+          size_t SizeThreshold = SlabSize, size_t GrowthDelay = 128,
+          size_t MinAlign = 8>
 class BumpPtrAllocatorImpl
-    : public AllocatorBase<BumpPtrAllocatorImpl<AllocatorT, SlabSize,
-                                                SizeThreshold, GrowthDelay>>,
+    : public AllocatorBase<BumpPtrAllocatorImpl<
+          AllocatorT, SlabSize, SizeThreshold, GrowthDelay, MinAlign>>,
       private detail::AllocatorHolder<AllocatorT> {
   using AllocTy = detail::AllocatorHolder<AllocatorT>;
 
@@ -75,6 +80,10 @@ public:
   static_assert(GrowthDelay > 0,
                 "GrowthDelay must be at least 1 which already increases the"
                 "slab size after each allocated slab.");
+  static_assert(MinAlign > 0 && (MinAlign & (MinAlign - 1)) == 0,
+                "MinAlign must be a power of two");
+  static_assert(MinAlign <= alignof(std::max_align_t),
+                "MinAlign must not exceed the alignment of fresh slabs");
 
   BumpPtrAllocatorImpl() = default;
 
@@ -150,14 +159,17 @@ public:
     // Keep track of how many bytes we've allocated.
     BytesAllocated += Size;
 
-    uintptr_t AlignedPtr = alignAddr(CurPtr, Alignment);
-
     size_t SizeToAllocate = Size;
 #if LLVM_ADDRESS_SANITIZER_BUILD
     // Add trailing bytes as a "red zone" under ASan.
     SizeToAllocate += RedZoneSize;
 #endif
+    SizeToAllocate = alignToPowerOf2(SizeToAllocate, MinAlign);
 
+    // CurPtr is already MinAlign-aligned, so only a stricter request realigns.
+    uintptr_t AlignedPtr = uintptr_t(CurPtr);
+    if (Alignment.value() > MinAlign)
+      AlignedPtr = alignAddr(CurPtr, Alignment);
     uintptr_t AllocEndPtr = AlignedPtr + SizeToAllocate;
     assert(AllocEndPtr >= uintptr_t(CurPtr) &&
            "Alignment + Size must not overflow");
@@ -388,7 +400,13 @@ using BumpPtrAllocator = BumpPtrAllocatorImpl<>;
 /// This allows calling the destructor in DestroyAll() and when the allocator is
 /// destroyed.
 template <typename T> class SpecificBumpPtrAllocator {
-  BumpPtrAllocator Allocator;
+  // DestroyAll() walks objects at a fixed sizeof(T) stride, so it needs tight
+  // packing: MinAlign=1 disables the size rounding. (alignof(T) would pack just
+  // as tightly and reuse the default instantiation, but T may be incomplete
+  // here, e.g. SpecificBumpPtrAllocator<MCSectionELF>.)
+  using BumpPtrAllocatorTy =
+      BumpPtrAllocatorImpl<MallocAllocator, 4096, 4096, 128, /*MinAlign=*/1>;
+  BumpPtrAllocatorTy Allocator;
 
 public:
   SpecificBumpPtrAllocator() {
@@ -417,7 +435,7 @@ public:
 
     for (auto I = Allocator.Slabs.begin(), E = Allocator.Slabs.end(); I != E;
          ++I) {
-      size_t AllocatedSlabSize = BumpPtrAllocator::computeSlabSize(
+      size_t AllocatedSlabSize = BumpPtrAllocatorTy::computeSlabSize(
           std::distance(Allocator.Slabs.begin(), I));
       char *Begin = (char *)alignAddr(*I, Align::Of<T>());
       char *End = *I == Allocator.Slabs.back() ? Allocator.CurPtr
@@ -437,7 +455,14 @@ public:
   }
 
   /// Allocate space for an array of objects without constructing them.
-  T *Allocate(size_t num = 1) { return Allocator.Allocate<T>(num); }
+  T *Allocate(size_t num = 1) {
+    // Slabs are max_align_t-aligned and every size is a multiple of alignof(T),
+    // so the bump pointer is already alignof(T)-aligned. Request alignment 1 so
+    // the fast path skips realigning CurPtr; over-aligned T still needs it.
+    if constexpr (alignof(T) <= alignof(std::max_align_t))
+      return static_cast<T *>(Allocator.Allocate(num * sizeof(T), Align()));
+    return Allocator.Allocate<T>(num);
+  }
 
   /// \return An index uniquely and reproducibly identifying
   /// an input pointer \p Ptr in the given allocator.
@@ -450,20 +475,19 @@ public:
 } // end namespace llvm
 
 template <typename AllocatorT, size_t SlabSize, size_t SizeThreshold,
-          size_t GrowthDelay>
+          size_t GrowthDelay, size_t MinAlign>
 void *
 operator new(size_t Size,
              llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold,
-                                        GrowthDelay> &Allocator) {
-  return Allocator.Allocate(Size, std::min((size_t)llvm::NextPowerOf2(Size),
-                                           alignof(std::max_align_t)));
+                                        GrowthDelay, MinAlign> &Allocator) {
+  return Allocator.Allocate(
+      Size, std::min(llvm::bit_ceil(Size), alignof(std::max_align_t)));
 }
 
 template <typename AllocatorT, size_t SlabSize, size_t SizeThreshold,
-          size_t GrowthDelay>
-void operator delete(void *,
-                     llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize,
-                                                SizeThreshold, GrowthDelay> &) {
-}
+          size_t GrowthDelay, size_t MinAlign>
+void operator delete(
+    void *, llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold,
+                                       GrowthDelay, MinAlign> &) {}
 
 #endif // LLVM_SUPPORT_ALLOCATOR_H

--- a/llvm/unittests/Support/AllocatorTest.cpp
+++ b/llvm/unittests/Support/AllocatorTest.cpp
@@ -279,4 +279,23 @@ TEST(AllocatorTest, TestBigAlignment) {
   EXPECT_GT(MockSlabAllocator::GetLastSlabSize(), 4096u);
 }
 
+// Over-aligned element type: Allocate() honors alignof(T) > MinAlign and
+// DestroyAll() runs every destructor.
+TEST(AllocatorTest, TestOverAlignedSpecific) {
+  unsigned NumDtorCalls = 0;
+  struct alignas(32) S {
+    unsigned *Calls;
+    ~S() { ++*Calls; }
+  };
+  {
+    SpecificBumpPtrAllocator<S> Alloc;
+    for (int I = 0; I != 4; ++I) {
+      S *P = Alloc.Allocate();
+      EXPECT_EQ(0u, reinterpret_cast<uintptr_t>(P) & 31u);
+      P->Calls = &NumDtorCalls;
+    }
+  }
+  EXPECT_EQ(4u, NumDtorCalls);
+}
+
 }  // anonymous namespace


### PR DESCRIPTION
Reland #203718 (reverted in #205091) by making computation in integer
domain to avoid UB (nullptr + non-zero offset).

Add a `MinAlign` template parameter (default 8, sizeof(size_t) on 64-bit
platforms) so that the common case `Alignment <= MinAlign` can skip
realigning `CurPtr`.

This is achieved by rounding each allocation's size up to MinAlign, so
the bump pointer stays MinAlign-aligned between allocations.

SpecificBumpPtrAllocator::DestroyAll() walks objects at a fixed
sizeof(T) stride and needs tight packing, so it uses MinAlign=1. (alignof(T) would
pack just as tightly and reuse the default instantiation, but T may be
incomplete here, e.g. `SpecificBumpPtrAllocator<MCSectionELF>`.)

Its `Allocate` still skips the realign: the slab is max_align_t-aligned
and every size is a multiple of alignof(T), so the bump pointer stays
alignof(T)-aligned and we can just request alignment 1. Over-aligned
types (alignof(T) > alignof(max_align_t)) keep requesting alignof(T).

Also use `bit_ceil` instead of `NextPowerOf2` in the placement operator
new alignment heuristic. NextPowerOf2 is strictly greater, so an 8-byte
pointer-sized object asked for alignment 16 and missed the fast path;
bit_ceil(8) == 8 keeps it on the fast path.

Aided by Claude Opus 4.8