### PR TITLE
[CIR][NFC] Rename zero result flag variable

### DIFF
--- a/clang/utils/TableGen/CIRLoweringEmitter.cpp
+++ b/clang/utils/TableGen/CIRLoweringEmitter.cpp
@@ -138,7 +138,7 @@ void GenerateLLVMLoweringPattern(llvm::StringRef OpName,
                                  llvm::StringRef PatternName, bool IsRecursive,
                                  llvm::StringRef ExtraDecl,
                                  const Record *CustomCtorRec,
-                                 llvm::StringRef LLVMOp, bool IsZeroResult) {
+                                 llvm::StringRef LLVMOp, bool HasZeroResult) {
   std::optional<CustomLoweringCtor> CustomCtor =
       parseCustomLoweringCtor(CustomCtorRec);
   std::string CodeBuffer;
@@ -188,7 +188,7 @@ void GenerateLLVMLoweringPattern(llvm::StringRef OpName,
         << "  mlir::LogicalResult matchAndRewrite(cir::" << OpName
         << " op, OpAdaptor adaptor, mlir::ConversionPatternRewriter &rewriter) "
            "const override {\n";
-    if (IsZeroResult) {
+    if (HasZeroResult) {
       Code << "    rewriter.replaceOpWithNewOp<mlir::LLVM::" << LLVMOp
            << ">(op, mlir::TypeRange{}, adaptor.getOperands());\n";
     } else {


### PR DESCRIPTION
###summary

This is a follow up of https://github.com/llvm/llvm-project/pull/202273

Just a light patch for renaming the zero result flag variable.