### PR TITLE
[FixIrreducible] Use reportFatalUsageError for unsupported terminators

### DIFF
--- a/llvm/lib/Transforms/Utils/FixIrreducible.cpp
+++ b/llvm/lib/Transforms/Utils/FixIrreducible.cpp
@@ -134,6 +134,7 @@
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Transforms/Utils.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/ControlFlowUtils.h"
@@ -320,7 +321,8 @@ static bool fixIrreducible(Cycle &C, CycleInfo &CI, DominatorTree &DT,
                           << printBasicBlock(Succ) << '\n');
       }
     } else {
-      llvm_unreachable("unsupported block terminator");
+      reportFatalUsageError("unsupported block terminator: fix-irreducible "
+                            "only supports br and callbr instructions");
     }
   }
 
@@ -364,7 +366,8 @@ static bool fixIrreducible(Cycle &C, CycleInfo &CI, DominatorTree &DT,
                           << printBasicBlock(Succ) << '\n');
       }
     } else {
-      llvm_unreachable("unsupported block terminator");
+      reportFatalUsageError("unsupported block terminator: fix-irreducible "
+                            "only supports br and callbr instructions");
     }
   }
 

--- a/llvm/test/Transforms/FixIrreducible/unsupported-terminator.ll
+++ b/llvm/test/Transforms/FixIrreducible/unsupported-terminator.ll
@@ -1,0 +1,19 @@
+; RUN: not opt < %s -passes=fix-irreducible -S 2>&1 | FileCheck %s
+; CHECK: LLVM ERROR: unsupported block terminator: fix-irreducible only supports br and callbr instructions
+
+define void @loop_1(i32 %Value, i1 %PredEntry) {
+entry:
+  br i1 %PredEntry, label %A, label %B
+
+A:
+  br label %B
+
+B:
+  switch i32 %Value, label %exit [
+    i32 0, label %A
+    i32 1, label %B
+  ]
+
+exit:
+  ret void
+}


### PR DESCRIPTION
`opt -passes=fix-irreducible` crashed via `llvm_unreachable` on a
`switch` terminator incident to an irreducible cycle header. Such
terminators must be lowered first (`lower-switch`); replace the
`llvm_unreachable` at both sites with `reportFatalUsageError` so the
pass fails gracefully instead of crashing.

Fixes #191978
