### PR TITLE
[Clang] Accept 'noconvergent' attributes outside of CUDA

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2391,7 +2391,6 @@ def NoConvergent : InheritableAttr {
   let Spellings = [Clang<"noconvergent">, Declspec<"noconvergent">];
   let Subjects = SubjectList<[Function, Stmt], WarnDiag,
                              "functions and statements">;
-  let LangOpts = [CUDA];
   let Documentation = [NoConvergentDocs];
   let SimpleHandler = 1;
 }

--- a/clang/test/CodeGen/convergent-functions.cpp
+++ b/clang/test/CodeGen/convergent-functions.cpp
@@ -3,8 +3,17 @@
 
 // Test that the -fconvergent-functions flag works
 
-// CHECK: attributes #0 = {
+// CHECK: define {{.*}} @func() #[[ATTR:[0-9]+]]
+void func(void) { }
+
+// CONVFUNC: define {{.*}} @nofunc() #[[NOATTR:[0-9]+]]
+__attribute__((noconvergent)) void nofunc(void) { }
+
+// CHECK: attributes #[[ATTR]] = {
 // NOCONVFUNC-NOT: convergent
 // CONVFUNC-SAME: convergent
 // CHECK-SAME: }
-void func(void) { }
+
+// CONVFUNC: attributes #[[NOATTR]] = {
+// CONVFUNC-NOT: convergent
+// CONVFUNC-SAME: }


### PR DESCRIPTION
Summary:
There is no reason that `convergent` should be a generic attributes but
not `noconvergent`.
