### PR TITLE
[MLIR][ADT] Improve matcher compatability with C++20 STL

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1220,6 +1220,7 @@ public:
   class iterator : public indexed_accessor_iterator<iterator, BaseT, T,
                                                     PointerT, ReferenceT> {
   public:
+    iterator() : iterator::indexed_accessor_iterator(nullptr, 0) {}
     // Index into this iterator, invoking a static method on the derived type.
     ReferenceT operator*() const {
       return DerivedT::dereference_iterator(this->getBase(), this->getIndex());

--- a/mlir/include/mlir/Query/Matcher/MatchersInternal.h
+++ b/mlir/include/mlir/Query/Matcher/MatchersInternal.h
@@ -102,13 +102,11 @@ using VariadicOperatorFunction = bool (*)(Operation *op,
 template <VariadicOperatorFunction Func>
 class VariadicMatcher : public MatcherInterface {
 public:
-  VariadicMatcher(std::vector<DynMatcher> matchers)
-      : matchers(std::move(matchers)) {}
+  VariadicMatcher(std::vector<DynMatcher> matchers);
+  ~VariadicMatcher() override;
 
-  bool match(Operation *op) override { return Func(op, nullptr, matchers); }
-  bool match(Operation *op, SetVector<Operation *> &matchedOps) override {
-    return Func(op, &matchedOps, matchers);
-  }
+  bool match(Operation *op) override;
+  bool match(Operation *op, SetVector<Operation *> &matchedOps) override;
 
 private:
   std::vector<DynMatcher> matchers;
@@ -167,6 +165,25 @@ private:
   llvm::IntrusiveRefCntPtr<MatcherInterface> implementation;
   std::string functionName;
 };
+
+// Implementation of VariadicMatcher functions after DynMatcher is defined
+template <VariadicOperatorFunction Func>
+VariadicMatcher<Func>::VariadicMatcher(std::vector<DynMatcher> matchers)
+    : matchers(std::move(matchers)) {}
+
+template <VariadicOperatorFunction Func>
+VariadicMatcher<Func>::~VariadicMatcher() = default;
+
+template <VariadicOperatorFunction Func>
+bool VariadicMatcher<Func>::match(Operation *op) {
+  return Func(op, nullptr, matchers);
+}
+
+template <VariadicOperatorFunction Func>
+bool VariadicMatcher<Func>::match(Operation *op,
+                                  SetVector<Operation *> &matchedOps) {
+  return Func(op, &matchedOps, matchers);
+}
 
 // VariadicOperatorMatcher related types.
 template <typename... Ps>


### PR DESCRIPTION
When building MLIR on C++20 in Visual Studio with clang-cl, there are several related compiler errors, grouped by project:

MLIRQueryMatcher
```C
type '_Mybase' (aka 'typename conditional<conjunction_v<is_trivially_destructible<DynMatcher>, is_trivially_move_constructible<DynMatcher>, is_trivially_move_assignable<DynMatcher>>, typename conditional<conjunction_v<is_trivially_destructible<DynMatcher>, is_trivially_copy_constructible<DynMatcher>, is_trivially_copy_assignable<DynMatcher>>, _Non_trivial_move<_Optional_construct_base<DynMatcher>, DynMatcher>, _Non_trivial_copy_assign<_Optional_construct_base<DynMatcher>, DynMatcher>>::type, _Non_trivial_move_assign<_Optional_construct_base<DynMatcher>, DynMatcher>>::type') is not a direct or virtual base of 'std::optional<mlir::query::matcher::DynMatcher>'
no member named '_Value' in 'std::optional<mlir::query::matcher::DynMatcher>'
no member named '_Has_value' in 'std::optional<mlir::query::matcher::DynMatcher>'
no matching function for call to '_Destroy_range'
invalid application of 'sizeof' to an incomplete type 'mlir::query::matcher::DynMatcher'
invalid application of 'alignof' to an incomplete type 'mlir::query::matcher::DynMatcher'
```

MLIRQueryMatcher, MLIRQuery, MLIRQueryLib, and mlir-query
```C
no viable conversion from 'std::vector<DynMatcher>' to 'ArrayRef<DynMatcher>'
incomplete type 'mlir::query::matcher::DynMatcher' used in type trait expression
```

MLIRIR
```C
no matching constructor for initialization of 'llvm::detail::indexed_accessor_range_base<mlir::SuccessorRange, mlir::BlockOperand *, mlir::Block *, mlir::Block *, mlir::Block *>::iterator'
invalid operands to binary expression ('const std::reverse_iterator<llvm::detail::indexed_accessor_range_base<mlir::SuccessorRange, mlir::BlockOperand *, mlir::Block *, mlir::Block *, mlir::Block *>::iterator>' and 'const std::reverse_iterator<llvm::detail::indexed_accessor_range_base<mlir::SuccessorRange, mlir::BlockOperand *, mlir::Block *, mlir::Block *, mlir::Block *>::iterator>')
```

std::vector<T> operations require complete type T for pointer arithmetic, std::optional<T> has a similar problem. std::reverse_iterator requires a default constructor for iterator.

Adding a default constructor for iterator, and defining VariadicMatcher functions after DynMatcher is defined, resolves the errors.