### PR TITLE
AMDGPU: Move AMDGPUTargetID to AMDGPUTargetParser

### DIFF
--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -17,10 +17,13 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compiler.h"
 #include <cstdint>
+#include <optional>
+#include <string>
 #include <utility>
 
 namespace llvm {
 
+class raw_ostream;
 template <typename T> class SmallVectorImpl;
 class Triple;
 
@@ -102,6 +105,110 @@ LLVM_ABI IsaVersion getIsaVersion(StringRef GPU);
 /// default target features with entries overridden by \p Features.
 LLVM_ABI std::pair<FeatureError, StringRef>
 fillAMDGPUFeatureMap(StringRef GPU, const Triple &T, StringMap<bool> &Features);
+
+enum class TargetIDSetting { Unsupported, Any, Off, On };
+
+class LLVM_ABI AMDGPUTargetID {
+private:
+  GPUKind Arch;
+  std::string TargetTripleString;
+  TargetIDSetting XnackSetting;
+  TargetIDSetting SramEccSetting;
+  bool IsAMDHSA;
+
+public:
+  AMDGPUTargetID(GPUKind Arch, const Triple &TT, TargetIDSetting XnackSetting,
+                 TargetIDSetting SramEccSetting);
+
+  ~AMDGPUTargetID() = default;
+
+  /// \return True if the current xnack setting is not "Unsupported".
+  bool isXnackSupported() const {
+    return XnackSetting != TargetIDSetting::Unsupported;
+  }
+
+  /// \returns True if the current xnack setting is "On" or "Any".
+  bool isXnackOnOrAny() const {
+    return XnackSetting == TargetIDSetting::On ||
+           XnackSetting == TargetIDSetting::Any;
+  }
+
+  /// \returns True if current xnack setting is "On" or "Off",
+  /// false otherwise.
+  bool isXnackOnOrOff() const {
+    return getXnackSetting() == TargetIDSetting::On ||
+           getXnackSetting() == TargetIDSetting::Off;
+  }
+
+  /// \returns The current xnack TargetIDSetting, possible options are
+  /// "Unsupported", "Any", "Off", and "On".
+  TargetIDSetting getXnackSetting() const { return XnackSetting; }
+
+  /// Sets xnack setting to \p NewXnackSetting.
+  void setXnackSetting(TargetIDSetting NewXnackSetting) {
+    XnackSetting = NewXnackSetting;
+  }
+
+  /// \return True if the current sramecc setting is not "Unsupported".
+  bool isSramEccSupported() const {
+    return SramEccSetting != TargetIDSetting::Unsupported;
+  }
+
+  /// \returns True if the current sramecc setting is "On" or "Any".
+  bool isSramEccOnOrAny() const {
+    return SramEccSetting == TargetIDSetting::On ||
+           SramEccSetting == TargetIDSetting::Any;
+  }
+
+  /// \returns True if current sramecc setting is "On" or "Off",
+  /// false otherwise.
+  bool isSramEccOnOrOff() const {
+    return getSramEccSetting() == TargetIDSetting::On ||
+           getSramEccSetting() == TargetIDSetting::Off;
+  }
+
+  /// \returns The current sramecc TargetIDSetting, possible options are
+  /// "Unsupported", "Any", "Off", and "On".
+  TargetIDSetting getSramEccSetting() const { return SramEccSetting; }
+
+  /// Sets sramecc setting to \p NewSramEccSetting.
+  void setSramEccSetting(TargetIDSetting NewSramEccSetting) {
+    SramEccSetting = NewSramEccSetting;
+  }
+
+  void setTargetIDFromTargetIDStream(StringRef TargetID);
+
+  GPUKind getGPUKind() const { return Arch; }
+
+  StringRef getTargetTripleString() const { return TargetTripleString; }
+
+  /// \returns True if this is an AMDHSA target.
+  bool isAMDHSA() const { return IsAMDHSA; }
+
+  /// Parse a target ID directive string (e.g.,
+  /// "amdgcn-amd-amdhsa--gfx1010:xnack-") and return an AMDGPUTargetID.
+  /// \returns AMDGPUTargetID or std::nullopt if malformed.
+  static std::optional<AMDGPUTargetID>
+  parseTargetIDString(StringRef TargetIDDirective);
+
+  /// Write string representation to \p OS
+  void print(raw_ostream &OS) const;
+
+  /// \returns String representation of an object.
+  std::string toString() const;
+
+  bool operator==(const AMDGPUTargetID &Other) const;
+  bool operator!=(const AMDGPUTargetID &Other) const {
+    return !(*this == Other);
+  }
+};
+
+inline raw_ostream &operator<<(raw_ostream &OS,
+                               const AMDGPUTargetID &TargetID) {
+  TargetID.print(OS);
+  return OS;
+}
+
 } // namespace AMDGPU
 
 } // namespace llvm

--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -198,7 +198,7 @@ void AMDGPUAsmPrinter::emitFunctionBodyStart() {
   // Make sure function's xnack settings are compatible with module's
   // xnack settings.
   if (FunctionTargetID.isXnackSupported() &&
-      FunctionTargetID.getXnackSetting() != IsaInfo::TargetIDSetting::Any &&
+      FunctionTargetID.getXnackSetting() != AMDGPU::TargetIDSetting::Any &&
       FunctionTargetID.getXnackSetting() !=
           getTargetStreamer()->getTargetID()->getXnackSetting()) {
     OutContext.reportError(
@@ -209,7 +209,7 @@ void AMDGPUAsmPrinter::emitFunctionBodyStart() {
   // Make sure function's sramecc settings are compatible with module's
   // sramecc settings.
   if (FunctionTargetID.isSramEccSupported() &&
-      FunctionTargetID.getSramEccSetting() != IsaInfo::TargetIDSetting::Any &&
+      FunctionTargetID.getSramEccSetting() != AMDGPU::TargetIDSetting::Any &&
       FunctionTargetID.getSramEccSetting() !=
           getTargetStreamer()->getTargetID()->getSramEccSetting()) {
     OutContext.reportError(
@@ -1212,12 +1212,12 @@ void AMDGPUAsmPrinter::initializeTargetID(const Module &M) {
       break;
 
     const GCNSubtarget &STM = TM.getSubtarget<GCNSubtarget>(F);
-    const IsaInfo::AMDGPUTargetID &STMTargetID = STM.getTargetID();
+    const AMDGPUTargetID &STMTargetID = STM.getTargetID();
     if (TSTargetID->isXnackSupported())
-      if (TSTargetID->getXnackSetting() == IsaInfo::TargetIDSetting::Any)
+      if (TSTargetID->getXnackSetting() == AMDGPU::TargetIDSetting::Any)
         TSTargetID->setXnackSetting(STMTargetID.getXnackSetting());
     if (TSTargetID->isSramEccSupported())
-      if (TSTargetID->getSramEccSetting() == IsaInfo::TargetIDSetting::Any)
+      if (TSTargetID->getSramEccSetting() == AMDGPU::TargetIDSetting::Any)
         TSTargetID->setSramEccSetting(STMTargetID.getSramEccSetting());
   }
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
@@ -215,8 +215,7 @@ void MetadataStreamerMsgPackV4::emitVersion() {
   getRootMetadata("amdhsa.version") = Version;
 }
 
-void MetadataStreamerMsgPackV4::emitTargetID(
-    const IsaInfo::AMDGPUTargetID &TargetID) {
+void MetadataStreamerMsgPackV4::emitTargetID(const AMDGPUTargetID &TargetID) {
   getRootMetadata("amdhsa.target") =
       HSAMetadataDoc->getNode(TargetID.toString(), /*Copy=*/true);
 }
@@ -559,7 +558,7 @@ bool MetadataStreamerMsgPackV4::emitTo(AMDGPUTargetStreamer &TargetStreamer) {
 }
 
 void MetadataStreamerMsgPackV4::begin(const Module &Mod,
-                                      const IsaInfo::AMDGPUTargetID &TargetID) {
+                                      const AMDGPUTargetID &TargetID) {
   emitVersion();
   emitTargetID(TargetID);
   emitPrintf(Mod);

--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.h
@@ -36,9 +36,7 @@ class Type;
 
 namespace AMDGPU {
 
-namespace IsaInfo {
 class AMDGPUTargetID;
-}
 
 namespace HSAMD {
 
@@ -48,8 +46,7 @@ public:
 
   virtual bool emitTo(AMDGPUTargetStreamer &TargetStreamer) = 0;
 
-  virtual void begin(const Module &Mod,
-                     const IsaInfo::AMDGPUTargetID &TargetID) = 0;
+  virtual void begin(const Module &Mod, const AMDGPUTargetID &TargetID) = 0;
 
   virtual void end() = 0;
 
@@ -96,7 +93,7 @@ protected:
 
   void emitVersion() override;
 
-  void emitTargetID(const IsaInfo::AMDGPUTargetID &TargetID);
+  void emitTargetID(const AMDGPUTargetID &TargetID);
 
   void emitPrintf(const Module &Mod);
 
@@ -135,8 +132,7 @@ public:
 
   bool emitTo(AMDGPUTargetStreamer &TargetStreamer) override;
 
-  void begin(const Module &Mod,
-             const IsaInfo::AMDGPUTargetID &TargetID) override;
+  void begin(const Module &Mod, const AMDGPUTargetID &TargetID) override;
 
   void end() override;
 

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -5980,13 +5980,13 @@ bool AMDGPUAsmParser::ParseDirectiveAMDGCNTarget() {
   if (getParser().parseEscapedString(TargetIDDirective))
     return true;
 
-  std::optional<AMDGPU::IsaInfo::AMDGPUTargetID> MaybeParsed =
-      AMDGPU::IsaInfo::AMDGPUTargetID::parseTargetIDString(TargetIDDirective);
+  std::optional<AMDGPU::AMDGPUTargetID> MaybeParsed =
+      AMDGPU::AMDGPUTargetID::parseTargetIDString(TargetIDDirective);
   if (!MaybeParsed)
     return getParser().Error(TargetStart, "malformed target ID");
 
-  const AMDGPU::IsaInfo::AMDGPUTargetID &ParsedTargetID = *MaybeParsed;
-  const std::optional<AMDGPU::IsaInfo::AMDGPUTargetID> &CurrentTargetID =
+  const AMDGPU::AMDGPUTargetID &ParsedTargetID = *MaybeParsed;
+  const std::optional<AMDGPU::AMDGPUTargetID> &CurrentTargetID =
       getTargetStreamer().getTargetID();
 
   if (*CurrentTargetID != ParsedTargetID) {
@@ -6692,13 +6692,13 @@ bool AMDGPUAsmParser::ParseDirectiveISAVersion() {
 
   StringRef TargetIDDirective = getLexer().getTok().getStringContents();
 
-  std::optional<AMDGPU::IsaInfo::AMDGPUTargetID> MaybeParsed =
-      AMDGPU::IsaInfo::AMDGPUTargetID::parseTargetIDString(TargetIDDirective);
+  std::optional<AMDGPU::AMDGPUTargetID> MaybeParsed =
+      AMDGPU::AMDGPUTargetID::parseTargetIDString(TargetIDDirective);
   if (!MaybeParsed)
     return Error(getParser().getTok().getLoc(), "malformed target id");
 
-  const AMDGPU::IsaInfo::AMDGPUTargetID &ParsedTargetID = *MaybeParsed;
-  const std::optional<AMDGPU::IsaInfo::AMDGPUTargetID> &CurrentTargetID =
+  const AMDGPU::AMDGPUTargetID &ParsedTargetID = *MaybeParsed;
+  const std::optional<AMDGPU::AMDGPUTargetID> &CurrentTargetID =
       getTargetStreamer().getTargetID();
 
   if (*CurrentTargetID != ParsedTargetID) {

--- a/llvm/lib/Target/AMDGPU/Disassembler/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/Disassembler/CMakeLists.txt
@@ -10,7 +10,6 @@ add_llvm_component_library(LLVMAMDGPUDisassembler
   CodeGenTypes
   MC
   MCDisassembler
-  TargetParser
   Support
 
   ADD_TO_COMPONENT

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.cpp
@@ -180,7 +180,7 @@ GCNSubtarget::GCNSubtarget(const Triple &TT, StringRef GPU, StringRef FS,
     : // clang-format off
     AMDGPUGenSubtargetInfo(TT, GPU, /*TuneCPU*/ GPU, FS),
     AMDGPUSubtarget(TT),
-    TargetID(*this, FS),
+    TargetID(AMDGPU::createAMDGPUTargetID(*this, FS)),
     InstrItins(getInstrItineraryForCPU(GPU)),
     BufferOOBRelaxed(BufferOOBRelaxed),
     TBufferOOBRelaxed(TBufferOOBRelaxed),

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -71,7 +71,7 @@ private:
 
 protected:
   // Basic subtarget description.
-  AMDGPU::IsaInfo::AMDGPUTargetID TargetID;
+  AMDGPU::AMDGPUTargetID TargetID;
   unsigned Gen = INVALID;
   InstrItineraryData InstrItins;
   int LDSBankCount = 0;
@@ -157,9 +157,7 @@ public:
     return RegBankInfo.get();
   }
 
-  const AMDGPU::IsaInfo::AMDGPUTargetID &getTargetID() const {
-    return TargetID;
-  }
+  const AMDGPU::AMDGPUTargetID &getTargetID() const { return TargetID; }
 
   const InstrItineraryData *getInstrItineraryData() const override {
     return &InstrItins;

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -914,31 +914,31 @@ unsigned AMDGPUTargetELFStreamer::getEFlagsV4() {
 
   // xnack.
   switch (getTargetID()->getXnackSetting()) {
-  case AMDGPU::IsaInfo::TargetIDSetting::Unsupported:
+  case AMDGPU::TargetIDSetting::Unsupported:
     EFlagsV4 |= ELF::EF_AMDGPU_FEATURE_XNACK_UNSUPPORTED_V4;
     break;
-  case AMDGPU::IsaInfo::TargetIDSetting::Any:
+  case AMDGPU::TargetIDSetting::Any:
     EFlagsV4 |= ELF::EF_AMDGPU_FEATURE_XNACK_ANY_V4;
     break;
-  case AMDGPU::IsaInfo::TargetIDSetting::Off:
+  case AMDGPU::TargetIDSetting::Off:
     EFlagsV4 |= ELF::EF_AMDGPU_FEATURE_XNACK_OFF_V4;
     break;
-  case AMDGPU::IsaInfo::TargetIDSetting::On:
+  case AMDGPU::TargetIDSetting::On:
     EFlagsV4 |= ELF::EF_AMDGPU_FEATURE_XNACK_ON_V4;
     break;
   }
   // sramecc.
   switch (getTargetID()->getSramEccSetting()) {
-  case AMDGPU::IsaInfo::TargetIDSetting::Unsupported:
+  case AMDGPU::TargetIDSetting::Unsupported:
     EFlagsV4 |= ELF::EF_AMDGPU_FEATURE_SRAMECC_UNSUPPORTED_V4;
     break;
-  case AMDGPU::IsaInfo::TargetIDSetting::Any:
+  case AMDGPU::TargetIDSetting::Any:
     EFlagsV4 |= ELF::EF_AMDGPU_FEATURE_SRAMECC_ANY_V4;
     break;
-  case AMDGPU::IsaInfo::TargetIDSetting::Off:
+  case AMDGPU::TargetIDSetting::Off:
     EFlagsV4 |= ELF::EF_AMDGPU_FEATURE_SRAMECC_OFF_V4;
     break;
-  case AMDGPU::IsaInfo::TargetIDSetting::On:
+  case AMDGPU::TargetIDSetting::On:
     EFlagsV4 |= ELF::EF_AMDGPU_FEATURE_SRAMECC_ON_V4;
     break;
   }

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.h
@@ -57,7 +57,7 @@ class AMDGPUTargetStreamer : public MCTargetStreamer {
 
 protected:
   // TODO: Move HSAMetadataStream to AMDGPUTargetStreamer.
-  std::optional<AMDGPU::IsaInfo::AMDGPUTargetID> TargetID;
+  std::optional<AMDGPU::AMDGPUTargetID> TargetID;
   unsigned CodeObjectVersion;
 
   MCContext &getContext() const { return Streamer.getContext(); }
@@ -133,15 +133,13 @@ public:
   static StringRef getArchNameFromElfMach(unsigned ElfMach);
   static unsigned getElfMach(StringRef GPU);
 
-  const std::optional<AMDGPU::IsaInfo::AMDGPUTargetID> &getTargetID() const {
+  const std::optional<AMDGPU::AMDGPUTargetID> &getTargetID() const {
     return TargetID;
   }
-  std::optional<AMDGPU::IsaInfo::AMDGPUTargetID> &getTargetID() {
-    return TargetID;
-  }
+  std::optional<AMDGPU::AMDGPUTargetID> &getTargetID() { return TargetID; }
   void initializeTargetID(const MCSubtargetInfo &STI, StringRef FeatureString) {
     assert(TargetID == std::nullopt && "TargetID can only be initialized once");
-    TargetID.emplace(STI, FeatureString);
+    TargetID = AMDGPU::createAMDGPUTargetID(STI, FeatureString);
   }
 };
 

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1097,20 +1097,15 @@ VOPD::InstInfo getVOPDInstInfo(unsigned VOPDOpcode,
   return VOPD::InstInfo(OpXInfo, OpYInfo);
 }
 
-namespace IsaInfo {
-
-AMDGPUTargetID::AMDGPUTargetID(const MCSubtargetInfo &STI,
-                               StringRef FeatureString)
-    : Arch(parseArchAMDGCN(STI.getCPU())),
-      TargetTripleString(
-          STI.getTargetTriple().normalize(Triple::CanonicalForm::FOUR_IDENT)),
-      XnackSetting(STI.getFeatureBits().test(FeatureSupportsXNACK)
-                       ? TargetIDSetting::Any
-                       : TargetIDSetting::Unsupported),
-      SramEccSetting(STI.getFeatureBits().test(FeatureSupportsSRAMECC)
-                         ? TargetIDSetting::Any
-                         : TargetIDSetting::Unsupported),
-      IsAMDHSA(STI.getTargetTriple().getOS() == Triple::AMDHSA) {
+AMDGPUTargetID createAMDGPUTargetID(const MCSubtargetInfo &STI,
+                                    StringRef FeatureString) {
+  AMDGPUTargetID TargetID(parseArchAMDGCN(STI.getCPU()), STI.getTargetTriple(),
+                          STI.getFeatureBits().test(FeatureSupportsXNACK)
+                              ? TargetIDSetting::Any
+                              : TargetIDSetting::Unsupported,
+                          STI.getFeatureBits().test(FeatureSupportsSRAMECC)
+                              ? TargetIDSetting::Any
+                              : TargetIDSetting::Unsupported);
 
   // Check if xnack or sramecc is explicitly enabled or disabled.  In the
   // absence of the target features we assume we must generate code that can run
@@ -1134,12 +1129,12 @@ AMDGPUTargetID::AMDGPUTargetID(const MCSubtargetInfo &STI,
   // Targets without on/off mode support keep their initial setting (Any).
 
   bool XnackSupported = STI.getFeatureBits().test(FeatureXNACKOnOffModes);
-  bool SramEccSupported = isSramEccSupported();
+  bool SramEccSupported = TargetID.isSramEccSupported();
 
   if (XnackRequested) {
     if (XnackSupported) {
-      XnackSetting =
-          *XnackRequested ? TargetIDSetting::On : TargetIDSetting::Off;
+      TargetID.setXnackSetting(*XnackRequested ? TargetIDSetting::On
+                                               : TargetIDSetting::Off);
     } else {
       // If a specific xnack setting was requested and this GPU does not support
       // xnack emit a warning. Setting will remain set to "Unsupported".
@@ -1155,8 +1150,8 @@ AMDGPUTargetID::AMDGPUTargetID(const MCSubtargetInfo &STI,
 
   if (SramEccRequested) {
     if (SramEccSupported) {
-      SramEccSetting =
-          *SramEccRequested ? TargetIDSetting::On : TargetIDSetting::Off;
+      TargetID.setSramEccSetting(*SramEccRequested ? TargetIDSetting::On
+                                                   : TargetIDSetting::Off);
     } else {
       // If a specific sramecc setting was requested and this GPU does not
       // support sramecc emit a warning. Setting will remain set to
@@ -1170,111 +1165,11 @@ AMDGPUTargetID::AMDGPUTargetID(const MCSubtargetInfo &STI,
       }
     }
   }
+
+  return TargetID;
 }
 
-AMDGPUTargetID::AMDGPUTargetID(GPUKind Arch, StringRef TargetTripleString,
-                               TargetIDSetting XnackSetting,
-                               TargetIDSetting SramEccSetting, bool IsAMDHSA)
-    : Arch(Arch), TargetTripleString(TargetTripleString),
-      XnackSetting(XnackSetting), SramEccSetting(SramEccSetting),
-      IsAMDHSA(IsAMDHSA) {}
-
-static TargetIDSetting
-getTargetIDSettingFromFeatureString(StringRef FeatureString) {
-  if (FeatureString.ends_with("-"))
-    return TargetIDSetting::Off;
-  if (FeatureString.ends_with("+"))
-    return TargetIDSetting::On;
-
-  llvm_unreachable("Malformed feature string");
-}
-
-void AMDGPUTargetID::setTargetIDFromTargetIDStream(StringRef TargetID) {
-  SmallVector<StringRef, 3> TargetIDSplit;
-  TargetID.split(TargetIDSplit, ':');
-
-  for (const auto &FeatureString : TargetIDSplit) {
-    if (FeatureString.starts_with("xnack"))
-      XnackSetting = getTargetIDSettingFromFeatureString(FeatureString);
-    if (FeatureString.starts_with("sramecc"))
-      SramEccSetting = getTargetIDSettingFromFeatureString(FeatureString);
-  }
-}
-
-std::optional<AMDGPUTargetID>
-AMDGPUTargetID::parseTargetIDString(StringRef TargetIDDirective) {
-  // Split on '-' to get arch-vendor-os-environment-processor:features
-  // There is a single dash separator after the 4-component triple
-  SmallVector<StringRef, 5> Parts;
-  TargetIDDirective.split(Parts, '-', /*MaxSplit=*/4);
-  if (Parts.size() < 4)
-    return std::nullopt;
-
-  Triple TT(Parts[0], Parts[1], Parts[2], Parts[3]);
-  if (!TT.isAMDGCN())
-    return std::nullopt;
-
-  SmallVector<StringRef, 3> FeatureSplit;
-  Parts[4].split(FeatureSplit, ':');
-  if (FeatureSplit.empty())
-    return std::nullopt;
-
-  StringRef CPUName = FeatureSplit[0];
-
-  // Determine xnack/sramecc support based on the architecture attributes
-  GPUKind Arch = parseArchAMDGCN(CPUName);
-  unsigned ArchAttr = getArchAttrAMDGCN(Arch);
-
-  TargetIDSetting XnackSetting = (ArchAttr & FEATURE_XNACK)
-                                     ? TargetIDSetting::Any
-                                     : TargetIDSetting::Unsupported;
-  TargetIDSetting SramEccSetting = (ArchAttr & FEATURE_SRAMECC)
-                                       ? TargetIDSetting::Any
-                                       : TargetIDSetting::Unsupported;
-
-  for (StringRef FeatureString :
-       ArrayRef<StringRef>(FeatureSplit).drop_front(1)) {
-    if (FeatureString.starts_with("xnack"))
-      XnackSetting = getTargetIDSettingFromFeatureString(FeatureString);
-    else if (FeatureString.starts_with("sramecc"))
-      SramEccSetting = getTargetIDSettingFromFeatureString(FeatureString);
-  }
-
-  return AMDGPUTargetID(Arch, TT.normalize(Triple::CanonicalForm::FOUR_IDENT),
-                        XnackSetting, SramEccSetting,
-                        TT.getOS() == Triple::AMDHSA);
-}
-
-void AMDGPUTargetID::print(raw_ostream &StreamRep) const {
-  StreamRep << TargetTripleString << '-' << getArchNameAMDGCN(Arch);
-
-  if (IsAMDHSA) {
-    // sramecc.
-    if (getSramEccSetting() == TargetIDSetting::Off)
-      StreamRep << ":sramecc-";
-    else if (getSramEccSetting() == TargetIDSetting::On)
-      StreamRep << ":sramecc+";
-
-    // xnack.
-    if (getXnackSetting() == TargetIDSetting::Off)
-      StreamRep << ":xnack-";
-    else if (getXnackSetting() == TargetIDSetting::On)
-      StreamRep << ":xnack+";
-  }
-}
-
-std::string AMDGPUTargetID::toString() const {
-  std::string Str;
-  raw_string_ostream OS(Str);
-  OS << *this;
-  return Str;
-}
-
-bool AMDGPUTargetID::operator==(const AMDGPUTargetID &Other) const {
-  return Arch == Other.Arch && XnackSetting == Other.XnackSetting &&
-         SramEccSetting == Other.SramEccSetting && IsAMDHSA == Other.IsAMDHSA &&
-         TargetTripleString == Other.TargetTripleString;
-}
+namespace IsaInfo {
 
 unsigned getInstCacheLineSize(const MCSubtargetInfo &STI) {
   if (STI.getFeatureBits().test(FeatureInstCacheLineSize128))
@@ -3963,19 +3858,18 @@ ClusterDimsAttr ClusterDimsAttr::get(const Function &F) {
 
 } // namespace AMDGPU
 
-raw_ostream &operator<<(raw_ostream &OS,
-                        const AMDGPU::IsaInfo::TargetIDSetting S) {
+raw_ostream &operator<<(raw_ostream &OS, const AMDGPU::TargetIDSetting S) {
   switch (S) {
-  case (AMDGPU::IsaInfo::TargetIDSetting::Unsupported):
+  case (AMDGPU::TargetIDSetting::Unsupported):
     OS << "Unsupported";
     break;
-  case (AMDGPU::IsaInfo::TargetIDSetting::Any):
+  case (AMDGPU::TargetIDSetting::Any):
     OS << "Any";
     break;
-  case (AMDGPU::IsaInfo::TargetIDSetting::Off):
+  case (AMDGPU::TargetIDSetting::Off):
     OS << "Off";
     break;
-  case (AMDGPU::IsaInfo::TargetIDSetting::On):
+  case (AMDGPU::TargetIDSetting::On):
     OS << "On";
     break;
   }

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -143,6 +143,14 @@ struct WMMAInstInfo {
 #define GET_WMMAInstInfoTable_DECL
 #include "AMDGPUGenSearchableTables.inc"
 
+using TargetIDSetting = AMDGPU::TargetIDSetting;
+using AMDGPUTargetID = AMDGPU::AMDGPUTargetID;
+
+/// Construct AMDGPUTargetID from MCSubtargetInfo. \p FeatureString is used to
+/// determine explicitly requested xnack/sramecc settings.
+AMDGPUTargetID createAMDGPUTargetID(const MCSubtargetInfo &STI,
+                                    StringRef FeatureString);
+
 namespace IsaInfo {
 
 enum {
@@ -151,112 +159,6 @@ enum {
   FIXED_NUM_SGPRS_FOR_INIT_BUG = 96,
   TRAP_NUM_SGPRS = 16
 };
-
-enum class TargetIDSetting { Unsupported, Any, Off, On };
-
-class AMDGPUTargetID {
-private:
-  GPUKind Arch;
-  std::string TargetTripleString;
-  TargetIDSetting XnackSetting;
-  TargetIDSetting SramEccSetting;
-  bool IsAMDHSA;
-
-public:
-  explicit AMDGPUTargetID(const MCSubtargetInfo &STI, StringRef FeatureString);
-
-  AMDGPUTargetID(GPUKind Arch, StringRef TargetTripleString,
-                 TargetIDSetting XnackSetting, TargetIDSetting SramEccSetting,
-                 bool IsAMDHSA);
-
-  ~AMDGPUTargetID() = default;
-
-  /// \return True if the current xnack setting is not "Unsupported".
-  bool isXnackSupported() const {
-    return XnackSetting != TargetIDSetting::Unsupported;
-  }
-
-  /// \returns True if the current xnack setting is "On" or "Any".
-  bool isXnackOnOrAny() const {
-    return XnackSetting == TargetIDSetting::On ||
-           XnackSetting == TargetIDSetting::Any;
-  }
-
-  /// \returns True if current xnack setting is "On" or "Off",
-  /// false otherwise.
-  bool isXnackOnOrOff() const {
-    return getXnackSetting() == TargetIDSetting::On ||
-           getXnackSetting() == TargetIDSetting::Off;
-  }
-
-  /// \returns The current xnack TargetIDSetting, possible options are
-  /// "Unsupported", "Any", "Off", and "On".
-  TargetIDSetting getXnackSetting() const { return XnackSetting; }
-
-  /// Sets xnack setting to \p NewXnackSetting.
-  void setXnackSetting(TargetIDSetting NewXnackSetting) {
-    XnackSetting = NewXnackSetting;
-  }
-
-  /// \return True if the current sramecc setting is not "Unsupported".
-  bool isSramEccSupported() const {
-    return SramEccSetting != TargetIDSetting::Unsupported;
-  }
-
-  /// \returns True if the current sramecc setting is "On" or "Any".
-  bool isSramEccOnOrAny() const {
-    return SramEccSetting == TargetIDSetting::On ||
-           SramEccSetting == TargetIDSetting::Any;
-  }
-
-  /// \returns True if current sramecc setting is "On" or "Off",
-  /// false otherwise.
-  bool isSramEccOnOrOff() const {
-    return getSramEccSetting() == TargetIDSetting::On ||
-           getSramEccSetting() == TargetIDSetting::Off;
-  }
-
-  /// \returns The current sramecc TargetIDSetting, possible options are
-  /// "Unsupported", "Any", "Off", and "On".
-  TargetIDSetting getSramEccSetting() const { return SramEccSetting; }
-
-  /// Sets sramecc setting to \p NewSramEccSetting.
-  void setSramEccSetting(TargetIDSetting NewSramEccSetting) {
-    SramEccSetting = NewSramEccSetting;
-  }
-
-  void setTargetIDFromTargetIDStream(StringRef TargetID);
-
-  GPUKind getGPUKind() const { return Arch; }
-
-  StringRef getTargetTripleString() const { return TargetTripleString; }
-
-  /// \returns True if this is an AMDHSA target.
-  bool isAMDHSA() const { return IsAMDHSA; }
-
-  /// Parse a target ID directive string (e.g.,
-  /// "amdgcn-amd-amdhsa--gfx1010:xnack-") and return an AMDGPUTargetID.
-  /// \returns AMDGPUTargetID or std::nullopt if malformed.
-  static std::optional<AMDGPUTargetID>
-  parseTargetIDString(StringRef TargetIDDirective);
-
-  /// Write string representation to \p OS
-  void print(raw_ostream &OS) const;
-
-  /// \returns String representation of an object.
-  std::string toString() const;
-
-  bool operator==(const AMDGPUTargetID &Other) const;
-  bool operator!=(const AMDGPUTargetID &Other) const {
-    return !(*this == Other);
-  }
-};
-
-inline raw_ostream &operator<<(raw_ostream &OS,
-                               const AMDGPUTargetID &TargetID) {
-  TargetID.print(OS);
-  return OS;
-}
 
 /// \returns Instruction cache line size in bytes for given subtarget \p STI.
 unsigned getInstCacheLineSize(const MCSubtargetInfo &STI);
@@ -1930,8 +1832,7 @@ private:
 
 } // namespace AMDGPU
 
-raw_ostream &operator<<(raw_ostream &OS,
-                        const AMDGPU::IsaInfo::TargetIDSetting S);
+raw_ostream &operator<<(raw_ostream &OS, const AMDGPU::TargetIDSetting S);
 
 } // end namespace llvm
 

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -11,9 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/TargetParser/AMDGPUTargetParser.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
 
 using namespace llvm;
@@ -668,4 +671,107 @@ AMDGPU::fillAMDGPUFeatureMap(StringRef GPU, const Triple &T,
     }
   }
   return {NO_ERROR, StringRef()};
+}
+
+AMDGPUTargetID::AMDGPUTargetID(GPUKind Arch, const Triple &TT,
+                               TargetIDSetting XnackSetting,
+                               TargetIDSetting SramEccSetting)
+    : Arch(Arch),
+      TargetTripleString(TT.normalize(Triple::CanonicalForm::FOUR_IDENT)),
+      XnackSetting(XnackSetting), SramEccSetting(SramEccSetting),
+      IsAMDHSA(TT.getOS() == Triple::AMDHSA) {}
+
+static TargetIDSetting
+getTargetIDSettingFromFeatureString(StringRef FeatureString) {
+  if (FeatureString.ends_with("-"))
+    return TargetIDSetting::Off;
+  if (FeatureString.ends_with("+"))
+    return TargetIDSetting::On;
+
+  llvm_unreachable("Malformed feature string");
+}
+
+void AMDGPUTargetID::setTargetIDFromTargetIDStream(StringRef TargetID) {
+  SmallVector<StringRef, 3> TargetIDSplit;
+  TargetID.split(TargetIDSplit, ':');
+
+  for (const auto &FeatureString : TargetIDSplit) {
+    if (FeatureString.starts_with("xnack"))
+      XnackSetting = getTargetIDSettingFromFeatureString(FeatureString);
+    if (FeatureString.starts_with("sramecc"))
+      SramEccSetting = getTargetIDSettingFromFeatureString(FeatureString);
+  }
+}
+
+std::optional<AMDGPUTargetID>
+AMDGPUTargetID::parseTargetIDString(StringRef TargetIDDirective) {
+  // Split on '-' to get arch-vendor-os-environment-processor:features
+  // There is a single dash separator after the 4-component triple
+  SmallVector<StringRef, 5> Parts;
+  TargetIDDirective.split(Parts, '-', /*MaxSplit=*/4);
+  if (Parts.size() < 4)
+    return std::nullopt;
+
+  Triple TT(Parts[0], Parts[1], Parts[2], Parts[3]);
+  if (!TT.isAMDGCN())
+    return std::nullopt;
+
+  SmallVector<StringRef, 3> FeatureSplit;
+  Parts[4].split(FeatureSplit, ':');
+  if (FeatureSplit.empty())
+    return std::nullopt;
+
+  StringRef CPUName = FeatureSplit[0];
+
+  // Determine xnack/sramecc support based on the architecture attributes
+  GPUKind Arch = parseArchAMDGCN(CPUName);
+  unsigned ArchAttr = getArchAttrAMDGCN(Arch);
+
+  TargetIDSetting XnackSetting = (ArchAttr & FEATURE_XNACK)
+                                     ? TargetIDSetting::Any
+                                     : TargetIDSetting::Unsupported;
+  TargetIDSetting SramEccSetting = (ArchAttr & FEATURE_SRAMECC)
+                                       ? TargetIDSetting::Any
+                                       : TargetIDSetting::Unsupported;
+
+  for (StringRef FeatureString :
+       ArrayRef<StringRef>(FeatureSplit).drop_front(1)) {
+    if (FeatureString.starts_with("xnack"))
+      XnackSetting = getTargetIDSettingFromFeatureString(FeatureString);
+    else if (FeatureString.starts_with("sramecc"))
+      SramEccSetting = getTargetIDSettingFromFeatureString(FeatureString);
+  }
+
+  return AMDGPUTargetID(Arch, TT, XnackSetting, SramEccSetting);
+}
+
+void AMDGPUTargetID::print(raw_ostream &StreamRep) const {
+  StreamRep << TargetTripleString << '-' << getArchNameAMDGCN(Arch);
+
+  if (IsAMDHSA) {
+    // sramecc.
+    if (getSramEccSetting() == TargetIDSetting::Off)
+      StreamRep << ":sramecc-";
+    else if (getSramEccSetting() == TargetIDSetting::On)
+      StreamRep << ":sramecc+";
+
+    // xnack.
+    if (getXnackSetting() == TargetIDSetting::Off)
+      StreamRep << ":xnack-";
+    else if (getXnackSetting() == TargetIDSetting::On)
+      StreamRep << ":xnack+";
+  }
+}
+
+std::string AMDGPUTargetID::toString() const {
+  std::string Str;
+  raw_string_ostream OS(Str);
+  OS << *this;
+  return Str;
+}
+
+bool AMDGPUTargetID::operator==(const AMDGPUTargetID &Other) const {
+  return Arch == Other.Arch && XnackSetting == Other.XnackSetting &&
+         SramEccSetting == Other.SramEccSetting && IsAMDHSA == Other.IsAMDHSA &&
+         TargetTripleString == Other.TargetTripleString;
 }


### PR DESCRIPTION
Move the AMDGPUTargetID class and TargetIDSetting enum from
AMDGPUBaseInfo to AMDGPUTargetParser, making them available in the
MC-independent TargetParser library.

Currently there is this backend implementation, and a second one in
clang. Move this here so in the future the clang copy can be deleted.

Co-Authored-By: Claude <noreply@anthropic.com>