### PR TITLE
AMDGPU: Rename AMDGPUTargetID to TargetID

### DIFF
--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -108,7 +108,7 @@ fillAMDGPUFeatureMap(StringRef GPU, const Triple &T, StringMap<bool> &Features);
 
 enum class TargetIDSetting { Unsupported, Any, Off, On };
 
-class LLVM_ABI AMDGPUTargetID {
+class LLVM_ABI TargetID {
 private:
   GPUKind Arch;
   std::string TargetTripleString;
@@ -117,10 +117,10 @@ private:
   bool IsAMDHSA;
 
 public:
-  AMDGPUTargetID(GPUKind Arch, const Triple &TT, TargetIDSetting XnackSetting,
-                 TargetIDSetting SramEccSetting);
+  TargetID(GPUKind Arch, const Triple &TT, TargetIDSetting XnackSetting,
+           TargetIDSetting SramEccSetting);
 
-  ~AMDGPUTargetID() = default;
+  ~TargetID() = default;
 
   /// \return True if the current xnack setting is not "Unsupported".
   bool isXnackSupported() const {
@@ -185,26 +185,18 @@ public:
   /// \returns True if this is an AMDHSA target.
   bool isAMDHSA() const { return IsAMDHSA; }
 
-  /// Parse a target ID directive string (e.g.,
-  /// "amdgcn-amd-amdhsa--gfx1010:xnack-") and return an AMDGPUTargetID.
-  /// \returns AMDGPUTargetID or std::nullopt if malformed.
-  static std::optional<AMDGPUTargetID>
+  static std::optional<TargetID>
   parseTargetIDString(StringRef TargetIDDirective);
 
-  /// Write string representation to \p OS
   void print(raw_ostream &OS) const;
 
-  /// \returns String representation of an object.
   std::string toString() const;
 
-  bool operator==(const AMDGPUTargetID &Other) const;
-  bool operator!=(const AMDGPUTargetID &Other) const {
-    return !(*this == Other);
-  }
+  bool operator==(const TargetID &Other) const;
+  bool operator!=(const TargetID &Other) const { return !(*this == Other); }
 };
 
-inline raw_ostream &operator<<(raw_ostream &OS,
-                               const AMDGPUTargetID &TargetID) {
+inline raw_ostream &operator<<(raw_ostream &OS, const TargetID &TargetID) {
   TargetID.print(OS);
   return OS;
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -1212,7 +1212,7 @@ void AMDGPUAsmPrinter::initializeTargetID(const Module &M) {
       break;
 
     const GCNSubtarget &STM = TM.getSubtarget<GCNSubtarget>(F);
-    const AMDGPUTargetID &STMTargetID = STM.getTargetID();
+    const AMDGPU::TargetID &STMTargetID = STM.getTargetID();
     if (TSTargetID->isXnackSupported())
       if (TSTargetID->getXnackSetting() == AMDGPU::TargetIDSetting::Any)
         TSTargetID->setXnackSetting(STMTargetID.getXnackSetting());

--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
@@ -215,7 +215,7 @@ void MetadataStreamerMsgPackV4::emitVersion() {
   getRootMetadata("amdhsa.version") = Version;
 }
 
-void MetadataStreamerMsgPackV4::emitTargetID(const AMDGPUTargetID &TargetID) {
+void MetadataStreamerMsgPackV4::emitTargetID(const TargetID &TargetID) {
   getRootMetadata("amdhsa.target") =
       HSAMetadataDoc->getNode(TargetID.toString(), /*Copy=*/true);
 }
@@ -558,7 +558,7 @@ bool MetadataStreamerMsgPackV4::emitTo(AMDGPUTargetStreamer &TargetStreamer) {
 }
 
 void MetadataStreamerMsgPackV4::begin(const Module &Mod,
-                                      const AMDGPUTargetID &TargetID) {
+                                      const TargetID &TargetID) {
   emitVersion();
   emitTargetID(TargetID);
   emitPrintf(Mod);

--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.h
@@ -36,7 +36,7 @@ class Type;
 
 namespace AMDGPU {
 
-class AMDGPUTargetID;
+class TargetID;
 
 namespace HSAMD {
 
@@ -46,7 +46,7 @@ public:
 
   virtual bool emitTo(AMDGPUTargetStreamer &TargetStreamer) = 0;
 
-  virtual void begin(const Module &Mod, const AMDGPUTargetID &TargetID) = 0;
+  virtual void begin(const Module &Mod, const TargetID &TargetID) = 0;
 
   virtual void end() = 0;
 
@@ -93,7 +93,7 @@ protected:
 
   void emitVersion() override;
 
-  void emitTargetID(const AMDGPUTargetID &TargetID);
+  void emitTargetID(const TargetID &TargetID);
 
   void emitPrintf(const Module &Mod);
 
@@ -132,7 +132,7 @@ public:
 
   bool emitTo(AMDGPUTargetStreamer &TargetStreamer) override;
 
-  void begin(const Module &Mod, const AMDGPUTargetID &TargetID) override;
+  void begin(const Module &Mod, const TargetID &TargetID) override;
 
   void end() override;
 

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -5980,13 +5980,13 @@ bool AMDGPUAsmParser::ParseDirectiveAMDGCNTarget() {
   if (getParser().parseEscapedString(TargetIDDirective))
     return true;
 
-  std::optional<AMDGPU::AMDGPUTargetID> MaybeParsed =
-      AMDGPU::AMDGPUTargetID::parseTargetIDString(TargetIDDirective);
+  std::optional<AMDGPU::TargetID> MaybeParsed =
+      AMDGPU::TargetID::parseTargetIDString(TargetIDDirective);
   if (!MaybeParsed)
     return getParser().Error(TargetStart, "malformed target ID");
 
-  const AMDGPU::AMDGPUTargetID &ParsedTargetID = *MaybeParsed;
-  const std::optional<AMDGPU::AMDGPUTargetID> &CurrentTargetID =
+  const AMDGPU::TargetID &ParsedTargetID = *MaybeParsed;
+  const std::optional<AMDGPU::TargetID> &CurrentTargetID =
       getTargetStreamer().getTargetID();
 
   if (*CurrentTargetID != ParsedTargetID) {
@@ -6692,13 +6692,13 @@ bool AMDGPUAsmParser::ParseDirectiveISAVersion() {
 
   StringRef TargetIDDirective = getLexer().getTok().getStringContents();
 
-  std::optional<AMDGPU::AMDGPUTargetID> MaybeParsed =
-      AMDGPU::AMDGPUTargetID::parseTargetIDString(TargetIDDirective);
+  std::optional<AMDGPU::TargetID> MaybeParsed =
+      AMDGPU::TargetID::parseTargetIDString(TargetIDDirective);
   if (!MaybeParsed)
     return Error(getParser().getTok().getLoc(), "malformed target id");
 
-  const AMDGPU::AMDGPUTargetID &ParsedTargetID = *MaybeParsed;
-  const std::optional<AMDGPU::AMDGPUTargetID> &CurrentTargetID =
+  const AMDGPU::TargetID &ParsedTargetID = *MaybeParsed;
+  const std::optional<AMDGPU::TargetID> &CurrentTargetID =
       getTargetStreamer().getTargetID();
 
   if (*CurrentTargetID != ParsedTargetID) {

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -71,7 +71,7 @@ private:
 
 protected:
   // Basic subtarget description.
-  AMDGPU::AMDGPUTargetID TargetID;
+  AMDGPU::TargetID TargetID;
   unsigned Gen = INVALID;
   InstrItineraryData InstrItins;
   int LDSBankCount = 0;
@@ -157,7 +157,7 @@ public:
     return RegBankInfo.get();
   }
 
-  const AMDGPU::AMDGPUTargetID &getTargetID() const { return TargetID; }
+  const AMDGPU::TargetID &getTargetID() const { return TargetID; }
 
   const InstrItineraryData *getInstrItineraryData() const override {
     return &InstrItins;

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.h
@@ -57,7 +57,7 @@ class AMDGPUTargetStreamer : public MCTargetStreamer {
 
 protected:
   // TODO: Move HSAMetadataStream to AMDGPUTargetStreamer.
-  std::optional<AMDGPU::AMDGPUTargetID> TargetID;
+  std::optional<AMDGPU::TargetID> TargetID;
   unsigned CodeObjectVersion;
 
   MCContext &getContext() const { return Streamer.getContext(); }
@@ -133,10 +133,10 @@ public:
   static StringRef getArchNameFromElfMach(unsigned ElfMach);
   static unsigned getElfMach(StringRef GPU);
 
-  const std::optional<AMDGPU::AMDGPUTargetID> &getTargetID() const {
+  const std::optional<AMDGPU::TargetID> &getTargetID() const {
     return TargetID;
   }
-  std::optional<AMDGPU::AMDGPUTargetID> &getTargetID() { return TargetID; }
+  std::optional<AMDGPU::TargetID> &getTargetID() { return TargetID; }
   void initializeTargetID(const MCSubtargetInfo &STI, StringRef FeatureString) {
     assert(TargetID == std::nullopt && "TargetID can only be initialized once");
     TargetID = AMDGPU::createAMDGPUTargetID(STI, FeatureString);

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1097,15 +1097,15 @@ VOPD::InstInfo getVOPDInstInfo(unsigned VOPDOpcode,
   return VOPD::InstInfo(OpXInfo, OpYInfo);
 }
 
-AMDGPUTargetID createAMDGPUTargetID(const MCSubtargetInfo &STI,
-                                    StringRef FeatureString) {
-  AMDGPUTargetID TargetID(parseArchAMDGCN(STI.getCPU()), STI.getTargetTriple(),
-                          STI.getFeatureBits().test(FeatureSupportsXNACK)
-                              ? TargetIDSetting::Any
-                              : TargetIDSetting::Unsupported,
-                          STI.getFeatureBits().test(FeatureSupportsSRAMECC)
-                              ? TargetIDSetting::Any
-                              : TargetIDSetting::Unsupported);
+TargetID createAMDGPUTargetID(const MCSubtargetInfo &STI,
+                              StringRef FeatureString) {
+  TargetID TargetID(parseArchAMDGCN(STI.getCPU()), STI.getTargetTriple(),
+                    STI.getFeatureBits().test(FeatureSupportsXNACK)
+                        ? TargetIDSetting::Any
+                        : TargetIDSetting::Unsupported,
+                    STI.getFeatureBits().test(FeatureSupportsSRAMECC)
+                        ? TargetIDSetting::Any
+                        : TargetIDSetting::Unsupported);
 
   // Check if xnack or sramecc is explicitly enabled or disabled.  In the
   // absence of the target features we assume we must generate code that can run

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -144,12 +144,12 @@ struct WMMAInstInfo {
 #include "AMDGPUGenSearchableTables.inc"
 
 using TargetIDSetting = AMDGPU::TargetIDSetting;
-using AMDGPUTargetID = AMDGPU::AMDGPUTargetID;
+using TargetID = AMDGPU::TargetID;
 
-/// Construct AMDGPUTargetID from MCSubtargetInfo. \p FeatureString is used to
+/// Construct TargetID from MCSubtargetInfo. \p FeatureString is used to
 /// determine explicitly requested xnack/sramecc settings.
-AMDGPUTargetID createAMDGPUTargetID(const MCSubtargetInfo &STI,
-                                    StringRef FeatureString);
+TargetID createAMDGPUTargetID(const MCSubtargetInfo &STI,
+                              StringRef FeatureString);
 
 namespace IsaInfo {
 

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -673,9 +673,8 @@ AMDGPU::fillAMDGPUFeatureMap(StringRef GPU, const Triple &T,
   return {NO_ERROR, StringRef()};
 }
 
-AMDGPUTargetID::AMDGPUTargetID(GPUKind Arch, const Triple &TT,
-                               TargetIDSetting XnackSetting,
-                               TargetIDSetting SramEccSetting)
+TargetID::TargetID(GPUKind Arch, const Triple &TT, TargetIDSetting XnackSetting,
+                   TargetIDSetting SramEccSetting)
     : Arch(Arch),
       TargetTripleString(TT.normalize(Triple::CanonicalForm::FOUR_IDENT)),
       XnackSetting(XnackSetting), SramEccSetting(SramEccSetting),
@@ -691,7 +690,7 @@ getTargetIDSettingFromFeatureString(StringRef FeatureString) {
   llvm_unreachable("Malformed feature string");
 }
 
-void AMDGPUTargetID::setTargetIDFromTargetIDStream(StringRef TargetID) {
+void TargetID::setTargetIDFromTargetIDStream(StringRef TargetID) {
   SmallVector<StringRef, 3> TargetIDSplit;
   TargetID.split(TargetIDSplit, ':');
 
@@ -703,8 +702,8 @@ void AMDGPUTargetID::setTargetIDFromTargetIDStream(StringRef TargetID) {
   }
 }
 
-std::optional<AMDGPUTargetID>
-AMDGPUTargetID::parseTargetIDString(StringRef TargetIDDirective) {
+std::optional<TargetID>
+TargetID::parseTargetIDString(StringRef TargetIDDirective) {
   // Split on '-' to get arch-vendor-os-environment-processor:features
   // There is a single dash separator after the 4-component triple
   SmallVector<StringRef, 5> Parts;
@@ -742,10 +741,10 @@ AMDGPUTargetID::parseTargetIDString(StringRef TargetIDDirective) {
       SramEccSetting = getTargetIDSettingFromFeatureString(FeatureString);
   }
 
-  return AMDGPUTargetID(Arch, TT, XnackSetting, SramEccSetting);
+  return TargetID(Arch, TT, XnackSetting, SramEccSetting);
 }
 
-void AMDGPUTargetID::print(raw_ostream &StreamRep) const {
+void TargetID::print(raw_ostream &StreamRep) const {
   StreamRep << TargetTripleString << '-' << getArchNameAMDGCN(Arch);
 
   if (IsAMDHSA) {
@@ -763,14 +762,14 @@ void AMDGPUTargetID::print(raw_ostream &StreamRep) const {
   }
 }
 
-std::string AMDGPUTargetID::toString() const {
+std::string TargetID::toString() const {
   std::string Str;
   raw_string_ostream OS(Str);
   OS << *this;
   return Str;
 }
 
-bool AMDGPUTargetID::operator==(const AMDGPUTargetID &Other) const {
+bool TargetID::operator==(const TargetID &Other) const {
   return Arch == Other.Arch && XnackSetting == Other.XnackSetting &&
          SramEccSetting == Other.SramEccSetting && IsAMDHSA == Other.IsAMDHSA &&
          TargetTripleString == Other.TargetTripleString;


### PR DESCRIPTION
The AMDGPU prefix is redundant with the namespace.

Co-Authored-By: Claude <noreply@anthropic.com>