### PR TITLE
[flang] Fix for runtime crash for huge local array

### DIFF
--- a/flang/lib/Lower/PFTBuilder.cpp
+++ b/flang/lib/Lower/PFTBuilder.cpp
@@ -1615,10 +1615,18 @@ bool Fortran::lower::definedInCommonBlock(const semantics::Symbol &sym) {
   return semantics::FindCommonBlockContaining(sym);
 }
 
+static constexpr std::size_t largeLocalArrayBytes = std::size_t{1} << 31;
+
 /// Is the symbol `sym` a global?
 bool Fortran::lower::symbolIsGlobal(const semantics::Symbol &sym) {
+  const semantics::Scope &scope = sym.owner();
+  const semantics::Symbol *proc = scope.symbol();
   return (semantics::IsSaved(sym) && semantics::CanCUDASymbolBeGlobal(sym)) ||
-         lower::definedInCommonBlock(sym) || semantics::IsNamedConstant(sym);
+         lower::definedInCommonBlock(sym) || semantics::IsNamedConstant(sym) ||
+         (sym.Rank() > 0 && sym.size() > largeLocalArrayBytes &&
+          !semantics::IsDummy(sym) && !semantics::IsAllocatableOrPointer(sym) &&
+          scope.kind() == semantics::Scope::Kind::Subprogram && proc &&
+          !proc->attrs().test(semantics::Attr::RECURSIVE));
 }
 
 namespace {

--- a/flang/test/Lower/local-array-static.f90
+++ b/flang/test/Lower/local-array-static.f90
@@ -1,0 +1,21 @@
+! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s
+
+subroutine small_local
+  integer :: arr(8)
+! CHECK-LABEL: func @_QPsmall_local
+! CHECK: fir.alloca {{.*}}uniq_name = "_QFsmall_localEarr"
+end subroutine
+
+recursive subroutine recursive_local
+  integer :: arr(8)
+! CHECK-LABEL: func @_QPrecursive_local
+! CHECK: fir.alloca {{.*}}uniq_name = "_QFrecursive_localEarr"
+end subroutine
+
+subroutine huge_local
+  ! One byte over the 2 GiB threshold (2**31, x86-64 small code model limit).
+  integer(8), parameter :: big = ishft(1_8, 31) + 1
+  integer(1) :: x(big)
+! CHECK-LABEL: fir.global internal @_QFhuge_localEx
+! CHECK-NOT: fir.alloca {{.*}}uniq_name = "_QFhuge_localEx"
+end subroutine


### PR DESCRIPTION
Fixes #192932

Root cause
llvm-flang treats only SAVEd variables, COMMON symbols, and named constants as global in symbolIsGlobal(). All other locals, including huge subroutine arrays, are lowered via instantiateLocal() to fir.alloca on the stack. Multi‑gigabyte arrays cannot live on the stack and crash at runtime.

Fix
Extend symbolIsGlobal() to also treat local arrays over 2 GiB (1 << 31 bytes) in non-recursive subprograms as global, excluding dummies and allocatable/pointer symbols. Those arrays are lowered with instantiateGlobal() as fir.global internal instead of fir.alloca. The 2 GiB threshold limits the change to objects too large for the stack and beyond the x86-64 small code model range. Recursive procedures are excluded because static storage would be shared across calls; local-array-static.f90 checks small, huge, and recursive cases.