### PR TITLE
[orc-rt] Add return serialization to AllocActionFunction::handle.

### DIFF
--- a/orc-rt/include/orc-rt/AllocAction.h
+++ b/orc-rt/include/orc-rt/AllocAction.h
@@ -28,15 +28,16 @@ typedef orc_rt_WrapperFunctionBuffer (*AllocActionFn)(const char *ArgData,
 
 struct AllocActionFunction {
 
-  template <typename Deserializer, typename Handler>
+  template <typename Deserializer, typename Serializer, typename Handler>
   static WrapperFunctionBuffer handle(const char *ArgData, size_t ArgSize,
-                                      Deserializer &&D, Handler &&H) {
+                                      Deserializer &&D, Serializer &&S,
+                                      Handler &&H) {
     typename CallableArgInfo<Handler>::args_tuple_type Args;
     if (!D.deserialize(ArgData, ArgSize, Args))
       return WrapperFunctionBuffer::createOutOfBandError(
           "Could not deserialize allocation action argument buffer");
 
-    return std::apply(std::forward<Handler>(H), std::move(Args));
+    return S.serialize(std::apply(std::forward<Handler>(H), std::move(Args)));
   }
 };
 

--- a/orc-rt/include/orc-rt/SPSAllocAction.h
+++ b/orc-rt/include/orc-rt/SPSAllocAction.h
@@ -66,6 +66,22 @@ public:
   }
 };
 
+struct AllocActionSPSSerializer {
+
+  /// Pass-through for handlers returning WrapperFunctionBuffer.
+  static WrapperFunctionBuffer serialize(WrapperFunctionBuffer B) { return B; }
+
+  /// Error serialization:
+  ///   - success values converted to empty WrapperFunctionBuffers
+  ///   - failure values converted to out-of-band errors.
+  static WrapperFunctionBuffer serialize(Error Err) {
+    if (!Err)
+      return WrapperFunctionBuffer();
+    return WrapperFunctionBuffer::createOutOfBandError(
+        toString(std::move(Err)).c_str());
+  }
+};
+
 template <typename... SPSArgTs> struct AllocActionSPSDeserializer {
   template <typename... ArgTs>
   bool deserialize(const char *ArgData, size_t ArgSize, ArgTs &...Args) {
@@ -84,7 +100,7 @@ template <typename... SPSArgTs> struct SPSAllocActionFunction {
                                       Handler &&H) {
     return AllocActionFunction::handle(
         ArgData, ArgSize, AllocActionSPSDeserializer<SPSTuple<SPSArgTs...>>(),
-        std::forward<Handler>(H));
+        AllocActionSPSSerializer(), std::forward<Handler>(H));
   }
 };
 

--- a/orc-rt/unittests/AllocActionTest.cpp
+++ b/orc-rt/unittests/AllocActionTest.cpp
@@ -175,3 +175,39 @@ TEST(AllocActionTest, RunFinalizeActionsNullDealloc) {
 
   EXPECT_EQ(Val, 1);
 }
+
+// Handler that returns Error::success(). Exercises the
+// AllocActionSPSSerializer::serialize(Error) overload's success path.
+static orc_rt_WrapperFunctionBuffer
+errorSuccess_sps_allocaction(const char *ArgData, size_t ArgSize) {
+  return SPSAllocActionFunction<>::handle(
+             ArgData, ArgSize, []() -> Error { return Error::success(); })
+      .release();
+}
+
+// Handler that returns a StringError. Exercises the
+// AllocActionSPSSerializer::serialize(Error) overload's failure path.
+static orc_rt_WrapperFunctionBuffer
+errorFailure_sps_allocaction(const char *ArgData, size_t ArgSize) {
+  return SPSAllocActionFunction<>::handle(
+             ArgData, ArgSize,
+             []() -> Error { return make_error<StringError>("test failure"); })
+      .release();
+}
+
+TEST(AllocActionTest, RunActionWithErrorSuccessReturn) {
+  // A handler returning Error::success() should produce a non-out-of-band
+  // result buffer.
+  AllocAction AA(errorSuccess_sps_allocaction, WrapperFunctionBuffer());
+  auto B = AA();
+  EXPECT_EQ(B.getOutOfBandError(), nullptr);
+}
+
+TEST(AllocActionTest, RunActionWithErrorFailureReturn) {
+  // A handler returning a real Error should produce an out-of-band error
+  // result buffer carrying the Error's string form.
+  AllocAction AA(errorFailure_sps_allocaction, WrapperFunctionBuffer());
+  auto B = AA();
+  ASSERT_NE(B.getOutOfBandError(), nullptr);
+  EXPECT_STREQ(B.getOutOfBandError(), "test failure");
+}


### PR DESCRIPTION
Add a Serializer template parameter to AllocActionFunction::handle and apply it to the handler's return value before forwarding as the action result. This lets handler authors return types other than WrapperFunctionBuffer.

For SPS, AllocActionSPSSerializer is the default Serializer used by SPSAllocActionFunction::handle. It accepts either:
  - WrapperFunctionBuffer (identity pass-through, the existing behavior), or
  - Error (success → empty WFB; failure → out-of-band-error WFB carrying toString(Err)).

Adds AllocActionTest coverage for both Error-return paths.