### PR TITLE
clang: Change TargetInfo::setCPU to take StringRef

### DIFF
--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -1404,9 +1404,7 @@ public:
   /// Target the specified CPU.
   ///
   /// \return  False on error (invalid CPU name).
-  virtual bool setCPU(const std::string &Name) {
-    return false;
-  }
+  virtual bool setCPU(StringRef Name) { return false; }
 
   /// Fill a SmallVectorImpl with the valid values to setCPU.
   virtual void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const {}

--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -285,9 +285,7 @@ bool AArch64TargetInfo::isValidCPUName(StringRef Name) const {
   return llvm::AArch64::parseCpu(Name).has_value();
 }
 
-bool AArch64TargetInfo::setCPU(const std::string &Name) {
-  return isValidCPUName(Name);
-}
+bool AArch64TargetInfo::setCPU(StringRef Name) { return isValidCPUName(Name); }
 
 void AArch64TargetInfo::fillValidCPUList(
     SmallVectorImpl<StringRef> &Values) const {

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -167,7 +167,7 @@ public:
 
   bool isValidCPUName(StringRef Name) const override;
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
-  bool setCPU(const std::string &Name) override;
+  bool setCPU(StringRef Name) override;
 
   llvm::APInt getFMVPriority(ArrayRef<StringRef> Features) const override;
 

--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -280,7 +280,7 @@ public:
 
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     if (getTriple().isAMDGCN()) {
       GPUKind = llvm::AMDGPU::parseArchAMDGCN(Name);
       GPUFeatures = llvm::AMDGPU::getArchAttrAMDGCN(GPUKind);

--- a/clang/lib/Basic/Targets/ARM.cpp
+++ b/clang/lib/Basic/Targets/ARM.cpp
@@ -647,7 +647,7 @@ void ARMTargetInfo::fillValidCPUList(SmallVectorImpl<StringRef> &Values) const {
   llvm::ARM::fillValidCPUArchList(Values);
 }
 
-bool ARMTargetInfo::setCPU(const std::string &Name) {
+bool ARMTargetInfo::setCPU(StringRef Name) {
   if (Name != "generic")
     setArchInfo(llvm::ARM::parseCPUArch(Name));
 

--- a/clang/lib/Basic/Targets/ARM.h
+++ b/clang/lib/Basic/Targets/ARM.h
@@ -173,7 +173,7 @@ public:
   bool isValidCPUName(StringRef Name) const override;
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
 
-  bool setCPU(const std::string &Name) override;
+  bool setCPU(StringRef Name) override;
 
   bool setFPMath(StringRef Name) override;
 

--- a/clang/lib/Basic/Targets/AVR.cpp
+++ b/clang/lib/Basic/Targets/AVR.cpp
@@ -501,7 +501,7 @@ void AVRTargetInfo::fillValidCPUList(SmallVectorImpl<StringRef> &Values) const {
     Values.push_back(Info.Name);
 }
 
-bool AVRTargetInfo::setCPU(const std::string &Name) {
+bool AVRTargetInfo::setCPU(StringRef Name) {
   // Set the ABI field based on the device or family name.
   auto It = llvm::find_if(
       AVRMcus, [&](const MCUInfo &Info) { return Info.Name == Name; });

--- a/clang/lib/Basic/Targets/AVR.h
+++ b/clang/lib/Basic/Targets/AVR.h
@@ -173,7 +173,7 @@ public:
 
   bool isValidCPUName(StringRef Name) const override;
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
-  bool setCPU(const std::string &Name) override;
+  bool setCPU(StringRef Name) override;
   std::optional<std::string> handleAsmEscapedChar(char EscChar) const override;
   StringRef getABI() const override { return ABI; }
 

--- a/clang/lib/Basic/Targets/BPF.h
+++ b/clang/lib/Basic/Targets/BPF.h
@@ -99,7 +99,7 @@ public:
 
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     if (Name == "v3" || Name == "v4") {
       HasAlu32 = true;
     }

--- a/clang/lib/Basic/Targets/CSKY.cpp
+++ b/clang/lib/Basic/Targets/CSKY.cpp
@@ -19,7 +19,7 @@ bool CSKYTargetInfo::isValidCPUName(StringRef Name) const {
   return llvm::CSKY::parseCPUArch(Name) != llvm::CSKY::ArchKind::INVALID;
 }
 
-bool CSKYTargetInfo::setCPU(const std::string &Name) {
+bool CSKYTargetInfo::setCPU(StringRef Name) {
   llvm::CSKY::ArchKind archKind = llvm::CSKY::parseCPUArch(Name);
   bool isValid = (archKind != llvm::CSKY::ArchKind::INVALID);
 

--- a/clang/lib/Basic/Targets/CSKY.h
+++ b/clang/lib/Basic/Targets/CSKY.h
@@ -65,7 +65,7 @@ public:
     return false;
   }
 
-  bool setCPU(const std::string &Name) override;
+  bool setCPU(StringRef Name) override;
 
   bool isValidCPUName(StringRef Name) const override;
 

--- a/clang/lib/Basic/Targets/Hexagon.h
+++ b/clang/lib/Basic/Targets/Hexagon.h
@@ -123,7 +123,7 @@ public:
 
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     if (!isValidCPUName(Name))
       return false;
     CPU = Name;

--- a/clang/lib/Basic/Targets/Lanai.cpp
+++ b/clang/lib/Basic/Targets/Lanai.cpp
@@ -44,7 +44,7 @@ void LanaiTargetInfo::fillValidCPUList(
   Values.emplace_back("v11");
 }
 
-bool LanaiTargetInfo::setCPU(const std::string &Name) {
+bool LanaiTargetInfo::setCPU(StringRef Name) {
   CPU = llvm::StringSwitch<CPUKind>(Name).Case("v11", CK_V11).Default(CK_NONE);
 
   return CPU != CK_NONE;

--- a/clang/lib/Basic/Targets/Lanai.h
+++ b/clang/lib/Basic/Targets/Lanai.h
@@ -58,7 +58,7 @@ public:
 
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
 
-  bool setCPU(const std::string &Name) override;
+  bool setCPU(StringRef Name) override;
 
   bool hasFeature(StringRef Feature) const override;
 

--- a/clang/lib/Basic/Targets/LoongArch.h
+++ b/clang/lib/Basic/Targets/LoongArch.h
@@ -65,7 +65,7 @@ public:
     BitIntMaxAlign = 128;
   }
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     if (!isValidCPUName(Name))
       return false;
     CPU = Name;

--- a/clang/lib/Basic/Targets/M68k.cpp
+++ b/clang/lib/Basic/Targets/M68k.cpp
@@ -35,9 +35,8 @@ M68kTargetInfo::M68kTargetInfo(const llvm::Triple &Triple,
   IntAlign = LongAlign = PointerAlign = 16;
 }
 
-bool M68kTargetInfo::setCPU(const std::string &Name) {
-  StringRef N = Name;
-  CPU = llvm::StringSwitch<CPUKind>(N)
+bool M68kTargetInfo::setCPU(StringRef Name) {
+  CPU = llvm::StringSwitch<CPUKind>(Name)
             .Case("generic", CK_68000)
             .Case("M68000", CK_68000)
             .Case("M68010", CK_68010)

--- a/clang/lib/Basic/Targets/M68k.h
+++ b/clang/lib/Basic/Targets/M68k.h
@@ -54,7 +54,7 @@ public:
   std::optional<std::string> handleAsmEscapedChar(char EscChar) const override;
   std::string_view getClobbers() const override;
   BuiltinVaListKind getBuiltinVaListKind() const override;
-  bool setCPU(const std::string &Name) override;
+  bool setCPU(StringRef Name) override;
   CallingConvCheckResult checkCallingConvention(CallingConv CC) const override;
 
   std::pair<unsigned, unsigned> hardwareInterferenceSizes() const override {

--- a/clang/lib/Basic/Targets/Mips.h
+++ b/clang/lib/Basic/Targets/Mips.h
@@ -155,7 +155,7 @@ public:
   bool isValidCPUName(StringRef Name) const override;
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     CPU = Name;
     return isValidCPUName(Name);
   }

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -158,7 +158,7 @@ public:
       Values.emplace_back(OffloadArchToString(static_cast<OffloadArch>(i)));
   }
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     GPU = StringToOffloadArch(Name);
     return GPU != OffloadArch::Unknown;
   }

--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -98,7 +98,7 @@ public:
   bool isValidCPUName(StringRef Name) const override;
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     bool CPUKnown = isValidCPUName(Name);
     if (CPUKnown) {
       CPU = Name;

--- a/clang/lib/Basic/Targets/RISCV.h
+++ b/clang/lib/Basic/Targets/RISCV.h
@@ -51,7 +51,7 @@ public:
     HasStrictFP = true;
   }
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     if (!isValidCPUName(Name))
       return false;
     CPU = Name;

--- a/clang/lib/Basic/Targets/Sparc.h
+++ b/clang/lib/Basic/Targets/Sparc.h
@@ -136,7 +136,7 @@ public:
 
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     CPU = getCPUKind(Name);
     return CPU != CK_GENERIC;
   }
@@ -234,7 +234,7 @@ public:
 
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     if (!SparcTargetInfo::setCPU(Name))
       return false;
     return getCPUGeneration(CPU) == CG_V9;

--- a/clang/lib/Basic/Targets/SystemZ.h
+++ b/clang/lib/Basic/Targets/SystemZ.h
@@ -185,7 +185,7 @@ public:
     fillValidCPUList(Values);
   }
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     ISARevision = getISARevision(Name);
     return ISARevision != -1;
   }

--- a/clang/lib/Basic/Targets/WebAssembly.h
+++ b/clang/lib/Basic/Targets/WebAssembly.h
@@ -142,7 +142,7 @@ private:
   bool isValidCPUName(StringRef Name) const final;
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const final;
 
-  bool setCPU(const std::string &Name) final { return isValidCPUName(Name); }
+  bool setCPU(StringRef Name) final { return isValidCPUName(Name); }
 
   llvm::SmallVector<Builtin::InfosShard> getTargetBuiltins() const final;
 

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -391,7 +391,7 @@ public:
   void fillValidCPUList(SmallVectorImpl<StringRef> &Values) const override;
   void fillValidTuneCPUList(SmallVectorImpl<StringRef> &Values) const override;
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     bool Only64Bit = getTriple().getArch() != llvm::Triple::x86;
     CPU = llvm::X86::parseArchX86(Name, Only64Bit);
     return CPU != llvm::X86::CK_None;

--- a/clang/lib/Basic/Targets/Xtensa.h
+++ b/clang/lib/Basic/Targets/Xtensa.h
@@ -100,7 +100,7 @@ public:
     return llvm::StringSwitch<bool>(Name).Case("generic", true).Default(false);
   }
 
-  bool setCPU(const std::string &Name) override {
+  bool setCPU(StringRef Name) override {
     CPU = Name;
     return isValidCPUName(Name);
   }


### PR DESCRIPTION
The related APIs all use StringRef, so use StringRef for
consistency.

Co-Authored-By: Claude (Opus 4.8) <noreply@anthropic.com>