### PR TITLE
[flang] Fix value separators for CHARACTER array output

### DIFF
--- a/flang-rt/lib/runtime/descriptor-io.cpp
+++ b/flang-rt/lib/runtime/descriptor-io.cpp
@@ -381,6 +381,11 @@ inline RT_API_ATTRS bool FormattedCharacterIO(
   for (std::size_t j{0}; j < numElements; ++j) {
     A *x{&ExtractElement<A>(io, descriptor, subscripts)};
     if (listOutput) {
+      // NAMELIST only: undelimited character array elements must not inherit
+      // lastWasUndelimitedCharacter across elements
+      if (io.mutableModes().inNamelist) {
+        listOutput->set_lastWasUndelimitedCharacter(false);
+      }
       if (!ListDirectedCharacterOutput(io, *listOutput, x, length)) {
         return false;
       }

--- a/flang-rt/unittests/Runtime/Namelist.cpp
+++ b/flang-rt/unittests/Runtime/Namelist.cpp
@@ -415,4 +415,22 @@ TEST(NamelistTests, BangAsValueSeparator) {
   EXPECT_EQ(gotC, "a!b     ");
 }
 
+// NAMELIST: undelimited CHARACTER array elements must be value-separated.
+TEST(NamelistTests, UndelimitedCharacterArray) {
+  OwningPtr<Descriptor> xDesc{MakeArray<TypeCategory::Character, 1>(
+      std::vector<int>{3}, std::vector<std::string>{"0", "1", "2"}, 1)};
+  const NamelistGroup::Item items[]{{"x", *xDesc}};
+  const NamelistGroup group{"nml", 1, items};
+  char buffer[32]{};
+  StaticDescriptor<1, true> statDesc;
+  Descriptor &internalDesc{statDesc.descriptor()};
+  internalDesc.Establish(TypeCode{CFI_type_char}, sizeof buffer, buffer, 0,
+      nullptr, CFI_attribute_pointer);
+  auto outCookie{IONAME(BeginInternalArrayListOutput)(
+      internalDesc, nullptr, 0, __FILE__, __LINE__)};
+  ASSERT_TRUE(IONAME(OutputNamelist)(outCookie, group));
+  ASSERT_EQ(IONAME(EndIoStatement)(outCookie), IostatOk);
+  EXPECT_EQ(std::string(buffer, sizeof buffer).find("012"), std::string::npos);
+}
+
 // TODO: Internal NAMELIST error tests


### PR DESCRIPTION
Fixes #192936

Root cause:
ListDirectedCharacterOutput sets lastWasUndelimitedCharacter after each element, and EmitLeadingSpaceOrAdvance skips separators when that flag is set. The flag was not cleared between descriptor elements, so later elements were treated as continuations of the previous value.

Fix:
Reset lastWasUndelimitedCharacter before each element in FormattedCharacterIO NameList output. Update NumericalFormatTest and added a minimal Namelist unit test.