### PR TITLE
[mlir][LLVMIR] Guard ShlOp/OrOp folds against APInt bitwidth mismatch

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -4004,6 +4004,12 @@ OpFoldResult LLVM::ShlOp::fold(FoldAdaptor adaptor) {
   if (!lhs)
     return {};
 
+  // Bail out if APInt bitwidths don't match the result type.
+  unsigned width = getType().getIntOrFloatBitWidth();
+  if (lhs.getValue().getBitWidth() != width ||
+      rhs.getValue().getBitWidth() != width)
+    return {};
+
   return IntegerAttr::get(getType(), lhs.getValue().shl(rhs.getValue()));
 }
 
@@ -4018,6 +4024,12 @@ OpFoldResult LLVM::OrOp::fold(FoldAdaptor adaptor) {
 
   auto rhs = dyn_cast_or_null<IntegerAttr>(adaptor.getRhs());
   if (!rhs)
+    return {};
+
+  // Same bitwidth guard as ShlOp::fold.
+  unsigned width = getType().getIntOrFloatBitWidth();
+  if (lhs.getValue().getBitWidth() != width ||
+      rhs.getValue().getBitWidth() != width)
     return {};
 
   return IntegerAttr::get(getType(), lhs.getValue() | rhs.getValue());

--- a/mlir/test/Dialect/LLVMIR/constant-folding.mlir
+++ b/mlir/test/Dialect/LLVMIR/constant-folding.mlir
@@ -211,3 +211,23 @@ llvm.func @blockaddress_select(%arg: i1) -> !llvm.ptr {
   llvm.blocktag <id = 1>
   llvm.return %1 : !llvm.ptr
 }
+
+// -----
+
+// CHECK-LABEL: llvm.func @shl_bitwidth_mismatch
+llvm.func @shl_bitwidth_mismatch() -> i64 {
+  %0 = llvm.mlir.constant(1 : i8) : i64
+  // CHECK: llvm.shl
+  %1 = llvm.shl %0, %0 : i64
+  llvm.return %1 : i64
+}
+
+// -----
+
+// CHECK-LABEL: llvm.func @or_bitwidth_mismatch
+llvm.func @or_bitwidth_mismatch() -> i64 {
+  %0 = llvm.mlir.constant(1 : i8) : i64
+  // CHECK: llvm.or
+  %1 = llvm.or %0, %0 : i64
+  llvm.return %1 : i64
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/205286

When a constant op carries an attribute whose integer type differs in bitwidth from the op result type (e.g. llvm.mlir.constant(1 : i8) : i64), `ShlOp::fold` and `OrOp::fold` would crash in `IntegerAttr::get` because the
APInt bitwidth does not match the integer type width.

Added a bitwidth guard in both fold methods to return early in this case, consistent with how the arith `int-range-optimizations` pass handles the same class of mismatch (as #205110)