### PR TITLE
Reland "[clang][ssaf][NFC] Move SSAF flags from FrontendOptions to a dedicated SSAFOptions"

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -317,6 +317,11 @@ public:
     return Invocation->getFrontendOpts();
   }
 
+  ssaf::SSAFOptions &getSSAFOpts() { return Invocation->getSSAFOpts(); }
+  const ssaf::SSAFOptions &getSSAFOpts() const {
+    return Invocation->getSSAFOpts();
+  }
+
   HeaderSearchOptions &getHeaderSearchOpts() {
     return Invocation->getHeaderSearchOpts();
   }

--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -51,6 +51,10 @@ class HeaderSearchOptions;
 class PreprocessorOptions;
 class TargetOptions;
 
+namespace ssaf {
+class SSAFOptions;
+} // namespace ssaf
+
 // This lets us create the DiagnosticsEngine with a properly-filled-out
 // DiagnosticOptions instance.
 std::unique_ptr<DiagnosticOptions>
@@ -116,6 +120,9 @@ protected:
   /// Options controlling preprocessed output.
   std::shared_ptr<PreprocessorOutputOptions> PreprocessorOutputOpts;
 
+  /// Options controlling the Scalable Static Analysis Framework (SSAF).
+  std::shared_ptr<ssaf::SSAFOptions> SSAFOpts;
+
   /// Dummy tag type whose instance can be passed into the constructor to
   /// prevent creation of the reference-counted option objects.
   struct EmptyConstructor {};
@@ -150,6 +157,7 @@ public:
   const PreprocessorOutputOptions &getPreprocessorOutputOpts() const {
     return *PreprocessorOutputOpts;
   }
+  const ssaf::SSAFOptions &getSSAFOpts() const { return *SSAFOpts; }
   /// @}
 
   /// Visitation.
@@ -247,19 +255,20 @@ public:
   /// @{
   // Note: These need to be pulled in manually. Otherwise, they get hidden by
   // the mutable getters with the same names.
-  using CompilerInvocationBase::getLangOpts;
-  using CompilerInvocationBase::getTargetOpts;
-  using CompilerInvocationBase::getDiagnosticOpts;
-  using CompilerInvocationBase::getHeaderSearchOpts;
-  using CompilerInvocationBase::getPreprocessorOpts;
   using CompilerInvocationBase::getAnalyzerOpts;
-  using CompilerInvocationBase::getMigratorOpts;
   using CompilerInvocationBase::getAPINotesOpts;
   using CompilerInvocationBase::getCodeGenOpts;
+  using CompilerInvocationBase::getDependencyOutputOpts;
+  using CompilerInvocationBase::getDiagnosticOpts;
   using CompilerInvocationBase::getFileSystemOpts;
   using CompilerInvocationBase::getFrontendOpts;
-  using CompilerInvocationBase::getDependencyOutputOpts;
+  using CompilerInvocationBase::getHeaderSearchOpts;
+  using CompilerInvocationBase::getLangOpts;
+  using CompilerInvocationBase::getMigratorOpts;
+  using CompilerInvocationBase::getPreprocessorOpts;
   using CompilerInvocationBase::getPreprocessorOutputOpts;
+  using CompilerInvocationBase::getSSAFOpts;
+  using CompilerInvocationBase::getTargetOpts;
   /// @}
 
   /// Mutable getters.
@@ -281,6 +290,7 @@ public:
   PreprocessorOutputOptions &getPreprocessorOutputOpts() {
     return *PreprocessorOutputOpts;
   }
+  ssaf::SSAFOptions &getSSAFOpts() { return *SSAFOpts; }
   /// @}
 
   /// Create a compiler invocation from a list of input options.
@@ -392,6 +402,7 @@ public:
   FrontendOptions &getMutFrontendOpts();
   DependencyOutputOptions &getMutDependencyOutputOpts();
   PreprocessorOutputOptions &getMutPreprocessorOutputOpts();
+  ssaf::SSAFOptions &getMutSSAFOpts();
   /// @}
 };
 

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -543,27 +543,6 @@ public:
   /// minimization hints.
   std::string DumpMinimizationHintsPath;
 
-  /// List of SSAF extractors to enable.
-  std::vector<std::string> SSAFExtractSummaries;
-
-  /// The TU summary output file with the file extension representing the file
-  /// format.
-  std::string SSAFTUSummaryFile;
-
-  /// Stable identifier for this translation unit, used as the name of the
-  /// `CompilationUnit` `BuildNamespace` of every produced TU summary. The
-  /// caller (typically the build system) supplies a value that is constant
-  /// across stages of the SSAF pipeline.
-  std::string SSAFCompilationUnitId;
-
-  /// Show available SSAF summary extractors.
-  LLVM_PREFERRED_TYPE(bool)
-  unsigned SSAFShowExtractors : 1;
-
-  /// Show available SSAF serialization formats.
-  LLVM_PREFERRED_TYPE(bool)
-  unsigned SSAFShowFormats : 1;
-
 public:
   FrontendOptions()
       : DisableFree(false), RelocatablePCH(false), ShowHelp(false),
@@ -581,8 +560,7 @@ public:
         EmitPrettySymbolGraphs(false), GenReducedBMI(false),
         UseClangIRPipeline(false), ClangIRDisablePasses(false),
         ClangIRDisableCIRVerifier(false), ClangIREnableIdiomRecognizer(false),
-        TimeTraceGranularity(500), TimeTraceVerbose(false),
-        SSAFShowExtractors(false), SSAFShowFormats(false) {}
+        TimeTraceGranularity(500), TimeTraceVerbose(false) {}
 
   /// getInputKindForExtension - Return the appropriate input kind for a file
   /// extension. For example, "c" would return Language::C.

--- a/clang/include/clang/Frontend/SSAFOptions.h
+++ b/clang/include/clang/Frontend/SSAFOptions.h
@@ -1,0 +1,52 @@
+//===- SSAFOptions.h --------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_FRONTEND_SSAFOPTIONS_H
+#define LLVM_CLANG_FRONTEND_SSAFOPTIONS_H
+
+#include "llvm/Support/Compiler.h"
+#include <string>
+#include <vector>
+
+namespace clang::ssaf {
+
+class SSAFOptions {
+public:
+  /// List of SSAF extractors to enable.
+  /// Controlled by: --ssaf-extract-summaries
+  std::vector<std::string> ExtractSummaries;
+
+  /// The TU summary output file with the file extension representing the
+  /// serialization format.
+  /// Controlled by: --ssaf-tu-summary-file
+  std::string TUSummaryFile;
+
+  /// Stable identifier used as the name of the `CompilationUnit`
+  /// `BuildNamespace` of every produced TU summary.
+  /// Controlled by: --ssaf-compilation-unit-id
+  std::string CompilationUnitId;
+
+  /// Show the list of available SSAF summary extractors and exit.
+  /// Controlled by: --ssaf-list-extractors
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned ShowExtractors : 1;
+
+  /// Show the list of available SSAF serialization formats and exit.
+  /// Controlled by: --ssaf-list-formats
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned ShowFormats : 1;
+
+  SSAFOptions() {
+    ShowExtractors = false;
+    ShowFormats = false;
+  };
+};
+
+} // namespace clang::ssaf
+
+#endif // LLVM_CLANG_FRONTEND_SSAFOPTIONS_H

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -346,7 +346,7 @@ class FileSystemOpts<string base>
 class AnalyzerOpts<string base>
   : KeyPathAndMacro<"AnalyzerOpts->", base, "ANALYZER_"> {}
 class SSAFOpts<string base>
-  : KeyPathAndMacro<"SSAFOpts.", base, "SSAF_"> {}
+  : KeyPathAndMacro<"SSAFOpts->", base, "SSAF_"> {}
 class MigratorOpts<string base>
   : KeyPathAndMacro<"MigratorOpts.", base, "MIGRATOR_"> {}
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -345,6 +345,8 @@ class FileSystemOpts<string base>
   : KeyPathAndMacro<"FileSystemOpts.", base, "FILE_SYSTEM_"> {}
 class AnalyzerOpts<string base>
   : KeyPathAndMacro<"AnalyzerOpts->", base, "ANALYZER_"> {}
+class SSAFOpts<string base>
+  : KeyPathAndMacro<"SSAFOpts.", base, "SSAF_"> {}
 class MigratorOpts<string base>
   : KeyPathAndMacro<"MigratorOpts.", base, "MIGRATOR_"> {}
 
@@ -947,7 +949,7 @@ def _ssaf_extract_summaries :
   Group<SSAF_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Comma-separated list of summary names to extract">,
-  MarshallingInfoStringVector<FrontendOpts<"SSAFExtractSummaries">>;
+  MarshallingInfoStringVector<SSAFOpts<"ExtractSummaries">>;
 def _ssaf_tu_summary_file :
   Joined<["--"], "ssaf-tu-summary-file=">,
   MetaVarName<"<path>.<format>">,
@@ -956,19 +958,19 @@ def _ssaf_tu_summary_file :
   HelpText<
     "The output file for the extracted summaries. "
     "The extension selects which file format to use.">,
-  MarshallingInfoString<FrontendOpts<"SSAFTUSummaryFile">>;
+  MarshallingInfoString<SSAFOpts<"TUSummaryFile">>;
 def _ssaf_list_extractors :
   Flag<["--"], "ssaf-list-extractors">,
   Group<SSAF_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Display the list of available SSAF summary extractors">,
-  MarshallingInfoFlag<FrontendOpts<"SSAFShowExtractors">>;
+  MarshallingInfoFlag<SSAFOpts<"ShowExtractors">>;
 def _ssaf_list_formats :
   Flag<["--"], "ssaf-list-formats">,
   Group<SSAF_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Display the list of available SSAF serialization formats">,
-  MarshallingInfoFlag<FrontendOpts<"SSAFShowFormats">>;
+  MarshallingInfoFlag<SSAFOpts<"ShowFormats">>;
 def _ssaf_compilation_unit_id :
   Joined<["--"], "ssaf-compilation-unit-id=">,
   MetaVarName<"<id>">,
@@ -978,7 +980,7 @@ def _ssaf_compilation_unit_id :
     "Stable identifier used as the CompilationUnit namespace name of every "
     "produced SSAF TU summary. Required when '--ssaf-tu-summary-file=' is "
     "set.">,
-  MarshallingInfoString<FrontendOpts<"SSAFCompilationUnitId">>;
+  MarshallingInfoString<SSAFOpts<"CompilationUnitId">>;
 def Xarch__
     : JoinedAndSeparate<["-"], "Xarch_">,
       Flags<[NoXarchOption]>,

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1042,17 +1042,21 @@ static void GenerateAnalyzerArgs(const AnalyzerOptions &Opts,
   // Nothing to generate for FullCompilerInvocation.
 }
 
-static void GenerateSSAFArgs(const ssaf::SSAFOptions &SSAFOpts,
+static void GenerateSSAFArgs(const ssaf::SSAFOptions &Opts,
                              ArgumentConsumer Consumer) {
+  const ssaf::SSAFOptions *SSAFOpts = &Opts;
+
 #define SSAF_OPTION_WITH_MARSHALLING(...)                                      \
   GENERATE_OPTION_WITH_MARSHALLING(Consumer, __VA_ARGS__)
 #include "clang/Options/Options.inc"
 #undef SSAF_OPTION_WITH_MARSHALLING
 }
 
-static bool ParseSSAFArgs(ssaf::SSAFOptions &SSAFOpts, ArgList &Args,
+static bool ParseSSAFArgs(ssaf::SSAFOptions &Opts, ArgList &Args,
                           DiagnosticsEngine &Diags) {
   unsigned NumErrorsBefore = Diags.getNumErrors();
+
+  ssaf::SSAFOptions *SSAFOpts = &Opts;
 
 #define SSAF_OPTION_WITH_MARSHALLING(...)                                      \
   PARSE_OPTION_WITH_MARSHALLING(Args, Diags, __VA_ARGS__)

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -32,6 +32,7 @@
 #include "clang/Frontend/FrontendOptions.h"
 #include "clang/Frontend/MigratorOptions.h"
 #include "clang/Frontend/PreprocessorOutputOptions.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/Frontend/TextDiagnosticBuffer.h"
 #include "clang/Frontend/Utils.h"
 #include "clang/Lex/HeaderSearchOptions.h"
@@ -133,7 +134,8 @@ CompilerInvocationBase::CompilerInvocationBase()
       FSOpts(std::make_shared<FileSystemOptions>()),
       FrontendOpts(std::make_shared<FrontendOptions>()),
       DependencyOutputOpts(std::make_shared<DependencyOutputOptions>()),
-      PreprocessorOutputOpts(std::make_shared<PreprocessorOutputOptions>()) {}
+      PreprocessorOutputOpts(std::make_shared<PreprocessorOutputOptions>()),
+      SSAFOpts(std::make_shared<ssaf::SSAFOptions>()) {}
 
 CompilerInvocationBase &
 CompilerInvocationBase::deep_copy_assign(const CompilerInvocationBase &X) {
@@ -151,6 +153,7 @@ CompilerInvocationBase::deep_copy_assign(const CompilerInvocationBase &X) {
     FrontendOpts = make_shared_copy(X.getFrontendOpts());
     DependencyOutputOpts = make_shared_copy(X.getDependencyOutputOpts());
     PreprocessorOutputOpts = make_shared_copy(X.getPreprocessorOutputOpts());
+    SSAFOpts = make_shared_copy(X.getSSAFOpts());
   }
   return *this;
 }
@@ -171,6 +174,7 @@ CompilerInvocationBase::shallow_copy_assign(const CompilerInvocationBase &X) {
     FrontendOpts = X.FrontendOpts;
     DependencyOutputOpts = X.DependencyOutputOpts;
     PreprocessorOutputOpts = X.PreprocessorOutputOpts;
+    SSAFOpts = X.SSAFOpts;
   }
   return *this;
 }
@@ -235,6 +239,10 @@ FileSystemOptions &CowCompilerInvocation::getMutFileSystemOpts() {
 
 FrontendOptions &CowCompilerInvocation::getMutFrontendOpts() {
   return ensureOwned(FrontendOpts);
+}
+
+ssaf::SSAFOptions &CowCompilerInvocation::getMutSSAFOpts() {
+  return ensureOwned(SSAFOpts);
 }
 
 DependencyOutputOptions &CowCompilerInvocation::getMutDependencyOutputOpts() {
@@ -1032,6 +1040,26 @@ static void GenerateAnalyzerArgs(const AnalyzerOptions &Opts,
   }
 
   // Nothing to generate for FullCompilerInvocation.
+}
+
+static void GenerateSSAFArgs(const ssaf::SSAFOptions &SSAFOpts,
+                             ArgumentConsumer Consumer) {
+#define SSAF_OPTION_WITH_MARSHALLING(...)                                      \
+  GENERATE_OPTION_WITH_MARSHALLING(Consumer, __VA_ARGS__)
+#include "clang/Options/Options.inc"
+#undef SSAF_OPTION_WITH_MARSHALLING
+}
+
+static bool ParseSSAFArgs(ssaf::SSAFOptions &SSAFOpts, ArgList &Args,
+                          DiagnosticsEngine &Diags) {
+  unsigned NumErrorsBefore = Diags.getNumErrors();
+
+#define SSAF_OPTION_WITH_MARSHALLING(...)                                      \
+  PARSE_OPTION_WITH_MARSHALLING(Args, Diags, __VA_ARGS__)
+#include "clang/Options/Options.inc"
+#undef SSAF_OPTION_WITH_MARSHALLING
+
+  return Diags.getNumErrors() == NumErrorsBefore;
 }
 
 static bool ParseAnalyzerArgs(AnalyzerOptions &Opts, ArgList &Args,
@@ -5083,6 +5111,7 @@ bool CompilerInvocation::CreateFromArgsImpl(
   ParseFileSystemArgs(Res.getFileSystemOpts(), Args, Diags);
   ParseMigratorArgs(Res.getMigratorOpts(), Args, Diags);
   ParseAnalyzerArgs(Res.getAnalyzerOpts(), Args, Diags);
+  ParseSSAFArgs(Res.getSSAFOpts(), Args, Diags);
   ParseDiagnosticArgs(Res.getDiagnosticOpts(), Args, &Diags,
                       /*DefaultDiagColor=*/false);
   ParseFrontendArgs(Res.getFrontendOpts(), Args, Diags, LangOpts.IsHeaderFile);
@@ -5435,6 +5464,7 @@ void CompilerInvocationBase::generateCC1CommandLine(
   GenerateFileSystemArgs(getFileSystemOpts(), Consumer);
   GenerateMigratorArgs(getMigratorOpts(), Consumer);
   GenerateAnalyzerArgs(getAnalyzerOpts(), Consumer);
+  GenerateSSAFArgs(getSSAFOpts(), Consumer);
   GenerateDiagnosticArgs(getDiagnosticOpts(), Consumer,
                          /*DefaultDiagColor=*/false);
   GenerateFrontendArgs(getFrontendOpts(), Consumer, getLangOpts().IsHeaderFile);

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -19,6 +19,7 @@
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/Frontend/Utils.h"
 #include "clang/FrontendTool/Utils.h"
 #include "clang/Options/Options.h"
@@ -209,7 +210,7 @@ CreateFrontendAction(CompilerInstance &CI) {
     Act = std::make_unique<ASTMergeAction>(std::move(Act),
                                             FEOpts.ASTMergeFiles);
 
-  if (!FEOpts.SSAFTUSummaryFile.empty()) {
+  if (!CI.getSSAFOpts().TUSummaryFile.empty()) {
     Act = std::make_unique<ssaf::TUSummaryExtractorFrontendAction>(
         std::move(Act));
   }

--- a/clang/lib/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendAction.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendAction.cpp
@@ -11,6 +11,7 @@
 #include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Frontend/MultiplexConsumer.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Serialization/SerializationFormatRegistry.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/ExtractorRegistry.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummary.h"
@@ -100,33 +101,33 @@ public:
 private:
   TUSummaryRunner(llvm::Triple TargetTriple,
                   std::unique_ptr<SerializationFormat> Format,
-                  const FrontendOptions &Opts);
+                  const SSAFOptions &Opts);
 
   void HandleTranslationUnit(ASTContext &Ctx) override;
 
   TUSummary Summary;
   TUSummaryBuilder Builder = TUSummaryBuilder(Summary);
   std::unique_ptr<SerializationFormat> Format;
-  const FrontendOptions &Opts;
+  const SSAFOptions &Opts;
 };
 } // namespace
 
 std::unique_ptr<TUSummaryRunner> TUSummaryRunner::create(CompilerInstance &CI) {
-  const FrontendOptions &Opts = CI.getFrontendOpts();
+  const SSAFOptions &Opts = CI.getSSAFOpts();
   DiagnosticsEngine &Diags = CI.getDiagnostics();
 
-  if (Opts.SSAFCompilationUnitId.empty()) {
+  if (Opts.CompilationUnitId.empty()) {
     Diags.Report(diag::warn_ssaf_tu_summary_requires_compilation_unit_id);
     return nullptr;
   }
 
   auto MaybePair =
-      parseOutputFileFormatAndPathOrReportError(Diags, Opts.SSAFTUSummaryFile);
+      parseOutputFileFormatAndPathOrReportError(Diags, Opts.TUSummaryFile);
   if (!MaybePair.has_value())
     return nullptr;
   auto [FormatName, OutputPath] = MaybePair.value();
 
-  if (reportUnrecognizedExtractorNames(Diags, Opts.SSAFExtractSummaries))
+  if (reportUnrecognizedExtractorNames(Diags, Opts.ExtractSummaries))
     return nullptr;
 
   return std::unique_ptr<TUSummaryRunner>{new TUSummaryRunner{
@@ -135,18 +136,18 @@ std::unique_ptr<TUSummaryRunner> TUSummaryRunner::create(CompilerInstance &CI) {
 
 TUSummaryRunner::TUSummaryRunner(llvm::Triple TargetTriple,
                                  std::unique_ptr<SerializationFormat> Format,
-                                 const FrontendOptions &Opts)
+                                 const SSAFOptions &Opts)
     : MultiplexConsumer(std::vector<std::unique_ptr<ASTConsumer>>{}),
       Summary(std::move(TargetTriple),
               BuildNamespace(BuildNamespaceKind::CompilationUnit,
-                             Opts.SSAFCompilationUnitId)),
+                             Opts.CompilationUnitId)),
       Format(std::move(Format)), Opts(Opts) {
   assert(this->Format);
-  assert(!Opts.SSAFCompilationUnitId.empty());
+  assert(!Opts.CompilationUnitId.empty());
 
   // Now the Summary and the builders are constructed, we can also construct the
   // extractors.
-  auto Extractors = makeTUSummaryExtractors(Builder, Opts.SSAFExtractSummaries);
+  auto Extractors = makeTUSummaryExtractors(Builder, Opts.ExtractSummaries);
   assert(!Extractors.empty());
 
   // We must initialize the Consumers here because our extractors need a
@@ -164,9 +165,9 @@ void TUSummaryRunner::HandleTranslationUnit(ASTContext &Ctx) {
   llvm::sys::sandbox::ScopedSetting Guard = llvm::sys::sandbox::scopedDisable();
 
   // Then serialize the result.
-  if (auto Err = Format->writeTUSummary(Summary, Opts.SSAFTUSummaryFile)) {
+  if (auto Err = Format->writeTUSummary(Summary, Opts.TUSummaryFile)) {
     Ctx.getDiagnostics().Report(diag::warn_ssaf_write_tu_summary_failed)
-        << Opts.SSAFTUSummaryFile << llvm::toString(std::move(Err));
+        << Opts.TUSummaryFile << llvm::toString(std::move(Err));
   }
 }
 

--- a/clang/unittests/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendActionTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendActionTest.cpp
@@ -11,6 +11,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendOptions.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/Frontend/TextDiagnosticBuffer.h"
 #include "clang/Lex/PreprocessorOptions.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Serialization/SerializationFormat.h"
@@ -299,9 +300,9 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
   // Configure valid SSAF options so the failure is purely from the wrapped
   // action, not from runner creation.
   std::string Output = makePath("output.MockSerializationFormat");
-  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
-  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
-  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
+  Compiler->getSSAFOpts().TUSummaryFile = Output;
+  Compiler->getSSAFOpts().ExtractSummaries = {"NoOpExtractor"};
+  Compiler->getSSAFOpts().CompilationUnitId = "test-cu";
 
   TUSummaryExtractorFrontendAction ExtractorAction(
       std::make_unique<FailingAction>());
@@ -315,9 +316,9 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
        RunnerFailsWithInvalidFormat_WrappedConsumerStillRuns) {
   // Use an unregistered format extension so TUSummaryRunner::create fails.
   std::string Output = makePath("output.xyz");
-  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
-  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
-  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
+  Compiler->getSSAFOpts().TUSummaryFile = Output;
+  Compiler->getSSAFOpts().ExtractSummaries = {"NoOpExtractor"};
+  Compiler->getSSAFOpts().CompilationUnitId = "test-cu";
 
   auto Wrapped = std::make_unique<RecordingAction>();
   const EventLog &Log = Wrapped->getLog();
@@ -345,9 +346,9 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
 TEST_F(TUSummaryExtractorFrontendActionTest,
        RunnerFailsWithUnknownExtractor_WrappedConsumerStillRuns) {
   std::string Output = makePath("output.MockSerializationFormat");
-  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
-  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NonExistentExtractor"};
-  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
+  Compiler->getSSAFOpts().TUSummaryFile = Output;
+  Compiler->getSSAFOpts().ExtractSummaries = {"NonExistentExtractor"};
+  Compiler->getSSAFOpts().CompilationUnitId = "test-cu";
 
   auto Wrapped = std::make_unique<RecordingAction>();
   const EventLog &Log = Wrapped->getLog();
@@ -370,9 +371,9 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
 TEST_F(TUSummaryExtractorFrontendActionTest,
        RunnerSucceeds_ASTConsumerCallbacksPropagate) {
   std::string Output = makePath("output.MockSerializationFormat");
-  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
-  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
-  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
+  Compiler->getSSAFOpts().TUSummaryFile = Output;
+  Compiler->getSSAFOpts().ExtractSummaries = {"NoOpExtractor"};
+  Compiler->getSSAFOpts().CompilationUnitId = "test-cu";
 
   auto Wrapped = std::make_unique<RecordingAction>();
   const EventLog &Log = Wrapped->getLog();
@@ -425,9 +426,9 @@ struct OrderCheckingAction : public ASTFrontendAction {
 TEST_F(TUSummaryExtractorFrontendActionTest,
        RunnerSucceeds_WrappedRunsBeforeRunner) {
   std::string Output = makePath("output.MockSerializationFormat");
-  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
-  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
-  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
+  Compiler->getSSAFOpts().TUSummaryFile = Output;
+  Compiler->getSSAFOpts().ExtractSummaries = {"NoOpExtractor"};
+  Compiler->getSSAFOpts().CompilationUnitId = "test-cu";
 
   auto Wrapped = std::make_unique<OrderCheckingAction>();
   Wrapped->OutputPath = Output;
@@ -447,9 +448,9 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
 
 TEST_F(TUSummaryExtractorFrontendActionTest, RunnerFailsToWrite) {
   std::string Output = makePath("output.FailingSerializationFormat");
-  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
-  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
-  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
+  Compiler->getSSAFOpts().TUSummaryFile = Output;
+  Compiler->getSSAFOpts().ExtractSummaries = {"NoOpExtractor"};
+  Compiler->getSSAFOpts().CompilationUnitId = "test-cu";
 
   TUSummaryExtractorFrontendAction Action(std::make_unique<RecordingAction>());
 
@@ -469,8 +470,8 @@ TEST_F(TUSummaryExtractorFrontendActionTest, RunnerFailsToWrite) {
 TEST_F(TUSummaryExtractorFrontendActionTest,
        MissingCompilationUnitIdDiagnoses) {
   std::string Output = makePath("output.MockSerializationFormat");
-  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
-  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
+  Compiler->getSSAFOpts().TUSummaryFile = Output;
+  Compiler->getSSAFOpts().ExtractSummaries = {"NoOpExtractor"};
   // SSAFCompilationUnitId left empty.
 
   auto Wrapped = std::make_unique<RecordingAction>();
@@ -493,9 +494,9 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
 TEST_F(TUSummaryExtractorFrontendActionTest,
        EmptyCompilationUnitIdDiagnoses) {
   std::string Output = makePath("output.MockSerializationFormat");
-  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
-  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
-  Compiler->getFrontendOpts().SSAFCompilationUnitId = "";
+  Compiler->getSSAFOpts().TUSummaryFile = Output;
+  Compiler->getSSAFOpts().ExtractSummaries = {"NoOpExtractor"};
+  Compiler->getSSAFOpts().CompilationUnitId = "";
 
   auto Wrapped = std::make_unique<RecordingAction>();
   const EventLog &Log = Wrapped->getLog();
@@ -520,9 +521,9 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
 
   const std::string CUId = "cu-X-test";
   std::string Output = makePath("output.CapturingSerializationFormat");
-  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
-  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
-  Compiler->getFrontendOpts().SSAFCompilationUnitId = CUId;
+  Compiler->getSSAFOpts().TUSummaryFile = Output;
+  Compiler->getSSAFOpts().ExtractSummaries = {"NoOpExtractor"};
+  Compiler->getSSAFOpts().CompilationUnitId = CUId;
 
   TUSummaryExtractorFrontendAction Action(std::make_unique<RecordingAction>());
   EXPECT_TRUE(Compiler->ExecuteAction(Action));


### PR DESCRIPTION
Third attempt of #204686
Previous attempt was: #204798
This was last reverted in #205279

This class will help keeping SSAF options apart from generic
FrontendOptions. It is inspired by AnalyzerOptions.

This way all of these SSAF (and future) options will be at a
centralized place.

In preparation of rdar://179151023

---

The previous attempt had issues on Windows with `/permissive` configs.
The issue was that `GENERATE_OPTION_WITH_MARSHALLING` had a generic lambda capture and that does not constitute as an ODR-use of the captured name - because that name was only used in an unevaluated context.
This meant that MSVC refused to find the function parameter.

My speculative solution is to follow the established pattern of passing a pointer to the Opts structure instead of passing it directly as a reference - similar to how `AnalyzerOptions` are passed around that macro.