### PR TITLE
[InstCombine] Sink instructions across assumes

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5629,7 +5629,7 @@ bool InstCombinerImpl::tryToSinkInstruction(Instruction *I,
     for (BasicBlock::iterator Scan = std::next(I->getIterator()),
                               E = I->getParent()->end();
          Scan != E; ++Scan)
-      if (Scan->mayWriteToMemory())
+      if (Scan->mayWriteToMemory() && !isa<AssumeInst>(Scan))
         return false;
   }
 

--- a/llvm/test/Transforms/InstCombine/assume.ll
+++ b/llvm/test/Transforms/InstCombine/assume.ll
@@ -851,6 +851,24 @@ define void @nonnull_gep_not_inbounds(ptr %p, i64 %i) {
   ret void
 }
 
+define void @nonnull_move_fixpoint(ptr %ptr) {
+; CHECK-LABEL: @nonnull_move_fixpoint(
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "nonnull"(ptr [[PTR:%.*]]) ]
+; CHECK-NEXT:    br label [[BB:%.*]]
+; CHECK:       bb:
+; CHECK-NEXT:    [[PTR2:%.*]] = load ptr, ptr [[PTR]], align 8
+; CHECK-NEXT:    store i32 0, ptr [[PTR2]], align 4
+; CHECK-NEXT:    ret void
+;
+  %ptr2 = load ptr, ptr %ptr, align 8
+  call void @llvm.assume(i1 true) [ "nonnull"(ptr %ptr) ]
+  br label %bb
+
+bb:
+  store i32 0, ptr %ptr2, align 4
+  ret void
+}
+
 define void @always_true_assumption() {
 ; CHECK-LABEL: @always_true_assumption(
 ; CHECK-NEXT:    ret void


### PR DESCRIPTION
Not sinking across assumes causes InstCombine to not reach a fixpoint when assumes can be dropped due to the load (usually nonnull assumes). Sinking the instructions causes the assume to not be dropped anymore, but I don't think that's a big problem.
