### PR TITLE
[SDAG] Bad codegen for swapping two bits 

### DIFF
--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3805,6 +3805,21 @@ bool llvm::recognizeBSwapOrBitReverseIdiom(
   assert(all_of(BitProvenance,
                 [](int8_t I) { return I == BitPart::Unset || 0 <= I; }) &&
          "Illegal bit provenance index");
+  // Guard against misclassifying a degenerate bit-pair swap
+  //  as a genuine bitreverse
+  unsigned MovedBits = 0;
+  unsigned TotalLiveBits = 0;
+  for (unsigned i = 0; i < BitProvenance.size(); ++i) {
+    int8_t Src = BitProvenance[i];
+    if (Src == BitPart::Unset)
+      continue;
+    TotalLiveBits++;
+    if (Src != (int8_t)i)
+      MovedBits++;
+  }
+  // Block if fewer than 4 bits moved (catches single bit-pair swaps)
+  if (TotalLiveBits > 0 && MovedBits <= 2)
+    return false;
 
   // If the upper bits are zero, then attempt to perform as a truncated op.
   Type *DemandedTy = ITy;

--- a/llvm/test/Transforms/InstCombine/bitreverse.ll
+++ b/llvm/test/Transforms/InstCombine/bitreverse.ll
@@ -538,8 +538,9 @@ declare i32 @llvm.bswap.i32(i32 %or11.i)
 
 define i16 @bit_swap(i16 %v3) {
 ; CHECK-LABEL: @bit_swap(
-; CHECK-NEXT:    [[TMP1:%.*]] = and i16 [[V3:%.*]], -32767
-; CHECK-NEXT:    [[OR:%.*]] = call i16 @llvm.bitreverse.i16(i16 [[TMP1]])
+; CHECK-NEXT:    [[SHL:%.*]] = shl i16 [[V3:%.*]], 15
+; CHECK-NEXT:    [[SHR:%.*]] = lshr i16 [[V3]], 15
+; CHECK-NEXT:    [[OR:%.*]] = or disjoint i16 [[SHL]], [[SHR]]
 ; CHECK-NEXT:    ret i16 [[OR]]
 ;
   %conv = zext i16 %v3 to i32

--- a/llvm/test/Transforms/InstCombine/bitreverse.ll
+++ b/llvm/test/Transforms/InstCombine/bitreverse.ll
@@ -534,3 +534,18 @@ define i64 @rev_all_operand64_multiuse_both(i64 %a, i64 %b) #0 {
 }
 
 declare i32 @llvm.bswap.i32(i32 %or11.i)
+
+
+define i16 @bit_swap(i16 %v3) {
+; CHECK-LABEL: @bit_swap(
+; CHECK-NEXT:    [[TMP1:%.*]] = and i16 [[V3:%.*]], -32767
+; CHECK-NEXT:    [[OR:%.*]] = call i16 @llvm.bitreverse.i16(i16 [[TMP1]])
+; CHECK-NEXT:    ret i16 [[OR]]
+;
+  %conv = zext i16 %v3 to i32
+  %shl = shl i32 %conv, 15
+  %shr = ashr i32 %conv, 15
+  %or = or i32 %shl, %shr
+  %conv2 = trunc i32 %or to i16
+  ret i16 %conv2
+}


### PR DESCRIPTION
Fixes  #110402 
Fix by counting how many live bits actually changed position. A pattern where 2 or fewer bits moved is treated as a degenerate swap rather than a true bitreverse, and is left in its original form. Verified via BitProvenance traces that genuine bitreverse idioms move  far more than 2 bits, so existing recognition is unaffected.

Alive2 : https://alive2.llvm.org/ce/z/IEZhbq