### PR TITLE
[NFC] UnicodeNameMappingGenerator: restore #include <unordered_map>

### DIFF
--- a/llvm/utils/UnicodeData/UnicodeNameMappingGenerator.cpp
+++ b/llvm/utils/UnicodeData/UnicodeNameMappingGenerator.cpp
@@ -23,6 +23,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
#204303 removed this include while converting `unordered_map` uses to `DenseMap`, but `loadDataFiles` still uses `unordered_multimap`.

See https://ci.swift.org/job/llvm.org/job/clang-stage2-Rthinlto/job/main/360/

```
[2026-06-23T05:46:26.519Z] /Users/ec2-user/jenkins/workspace/m.org_clang-stage2-Rthinlto_main/llvm-project/llvm/utils/UnicodeData/UnicodeNameMappingGenerator.cpp:34:13: error: missing '#include <unordered_map>'; 'unordered_multimap' must be declared before it is used
[2026-06-23T05:46:26.519Z]    34 | static std::unordered_multimap<char32_t, std::string>
[2026-06-23T05:46:26.519Z]       |             ^
```