### PR TITLE
[orc-rt] Split AllocAction tests by SPS dependency.

### DIFF
--- a/orc-rt/unittests/AllocActionTest.cpp
+++ b/orc-rt/unittests/AllocActionTest.cpp
@@ -8,25 +8,85 @@
 //
 // Tests for orc-rt's AllocAction.h APIs.
 //
+// These tests exercise the AllocAction layer directly, using a small bespoke
+// (de)serializer that exchanges raw int* values via memcpy. SPS-layer tests
+// live in SPSAllocActionTest.cpp.
+//
 //===----------------------------------------------------------------------===//
 
 #include "orc-rt/AllocAction.h"
-#include "orc-rt/ExecutorAddress.h"
-#include "orc-rt/SPSAllocAction.h"
 
-#include "AllocActionTestUtils.h"
 #include "gtest/gtest.h"
+
+#include <cstring>
 
 using namespace orc_rt;
 
-TEST(AllocActionTest, DefaultConstruct) {
-  AllocAction AA;
-  EXPECT_FALSE(AA);
+namespace {
+
+// A minimal AllocActionFunction (de)serializer pair that exchanges a single
+// int* via memcpy. Used to drive AllocActionFunction::handle without pulling
+// in SPS.
+struct IntPtrDeserializer {
+  bool deserialize(const char *ArgData, size_t ArgSize,
+                   std::tuple<int *> &Args) {
+    if (ArgSize != sizeof(int *))
+      return false;
+    memcpy(&std::get<0>(Args), ArgData, sizeof(int *));
+    return true;
+  }
+};
+
+struct IdentitySerializer {
+  static WrapperFunctionBuffer serialize(WrapperFunctionBuffer B) { return B; }
+};
+
+WrapperFunctionBuffer makeIntPtrArgBuffer(int *P) {
+  auto B = WrapperFunctionBuffer::allocate(sizeof(int *));
+  memcpy(B.data(), &P, sizeof(int *));
+  return B;
 }
+
+} // anonymous namespace
 
 static orc_rt_WrapperFunctionBuffer noopAction(const char *ArgData,
                                                size_t ArgSize) {
   return WrapperFunctionBuffer().release();
+}
+
+// Increments an int via pointer.
+static orc_rt_WrapperFunctionBuffer
+increment_int_ptr_action(const char *ArgData, size_t ArgSize) {
+  return AllocActionFunction::handle(ArgData, ArgSize, IntPtrDeserializer(),
+                                     IdentitySerializer(),
+                                     [](int *P) {
+                                       ++*P;
+                                       return WrapperFunctionBuffer();
+                                     })
+      .release();
+}
+
+// Decrements an int via pointer.
+static orc_rt_WrapperFunctionBuffer
+decrement_int_ptr_action(const char *ArgData, size_t ArgSize) {
+  return AllocActionFunction::handle(ArgData, ArgSize, IntPtrDeserializer(),
+                                     IdentitySerializer(),
+                                     [](int *P) {
+                                       --*P;
+                                       return WrapperFunctionBuffer();
+                                     })
+      .release();
+}
+
+// Always returns an out-of-band error.
+static orc_rt_WrapperFunctionBuffer fail_action(const char *ArgData,
+                                                size_t ArgSize) {
+  return WrapperFunctionBuffer::createOutOfBandError("failed").release();
+}
+
+TEST(AllocActionTest, DefaultConstruct) {
+  AllocAction AA;
+  EXPECT_FALSE(AA);
 }
 
 TEST(AllocActionTest, ConstructWithAction) {
@@ -34,38 +94,9 @@ TEST(AllocActionTest, ConstructWithAction) {
   EXPECT_TRUE(AA);
 }
 
-// Increments int via pointer.
-static orc_rt_WrapperFunctionBuffer
-increment_sps_allocaction(const char *ArgData, size_t ArgSize) {
-  return SPSAllocActionFunction<SPSExecutorAddr>::handle(
-             ArgData, ArgSize,
-             [](ExecutorAddr IntPtr) {
-               *IntPtr.toPtr<int *>() += 1;
-               return WrapperFunctionBuffer();
-             })
-      .release();
-}
-
-// Increments int via pointer.
-static orc_rt_WrapperFunctionBuffer
-decrement_sps_allocaction(const char *ArgData, size_t ArgSize) {
-  return SPSAllocActionFunction<SPSExecutorAddr>::handle(
-             ArgData, ArgSize,
-             [](ExecutorAddr IntPtr) {
-               *IntPtr.toPtr<int *>() -= 1;
-               return WrapperFunctionBuffer();
-             })
-      .release();
-}
-
-template <typename T>
-static WrapperFunctionBuffer makeExecutorAddrBuffer(T *P) {
-  return *spsSerialize<SPSArgList<SPSExecutorAddr>>(ExecutorAddr::fromPtr(P));
-}
-
 TEST(AllocActionTest, RunBasicAction) {
   int Val = 0;
-  AllocAction IncVal(increment_sps_allocaction, makeExecutorAddrBuffer(&Val));
+  AllocAction IncVal(increment_int_ptr_action, makeIntPtrArgBuffer(&Val));
   EXPECT_TRUE(IncVal);
   auto B = IncVal();
   EXPECT_TRUE(B.empty());
@@ -78,13 +109,12 @@ TEST(AllocActionTest, RunFinalizationActionsComplete) {
   std::vector<AllocActionPair> InitialActions;
 
   auto MakeAAOnVal = [&](AllocActionFn Fn) {
-    return *MakeAllocAction<SPSExecutorAddr>::from(Fn,
-                                                   ExecutorAddr::fromPtr(&Val));
+    return AllocAction(Fn, makeIntPtrArgBuffer(&Val));
   };
-  InitialActions.push_back({MakeAAOnVal(increment_sps_allocaction),
-                            MakeAAOnVal(decrement_sps_allocaction)});
-  InitialActions.push_back({MakeAAOnVal(increment_sps_allocaction),
-                            MakeAAOnVal(decrement_sps_allocaction)});
+  InitialActions.push_back({MakeAAOnVal(increment_int_ptr_action),
+                            MakeAAOnVal(decrement_int_ptr_action)});
+  InitialActions.push_back({MakeAAOnVal(increment_int_ptr_action),
+                            MakeAAOnVal(decrement_int_ptr_action)});
 
   auto DeallocActions = cantFail(runFinalizeActions(std::move(InitialActions)));
 
@@ -95,24 +125,18 @@ TEST(AllocActionTest, RunFinalizationActionsComplete) {
   EXPECT_EQ(Val, 0);
 }
 
-static orc_rt_WrapperFunctionBuffer fail_sps_allocaction(const char *ArgData,
-                                                         size_t ArgSize) {
-  return WrapperFunctionBuffer::createOutOfBandError("failed").release();
-}
-
 TEST(AllocActionTest, RunFinalizeActionsFail) {
   int Val = 0;
 
   std::vector<AllocActionPair> InitialActions;
 
   auto MakeAAOnVal = [&](AllocActionFn Fn) {
-    return *MakeAllocAction<SPSExecutorAddr>::from(Fn,
-                                                   ExecutorAddr::fromPtr(&Val));
+    return AllocAction(Fn, makeIntPtrArgBuffer(&Val));
   };
-  InitialActions.push_back({MakeAAOnVal(increment_sps_allocaction),
-                            MakeAAOnVal(decrement_sps_allocaction)});
-  InitialActions.push_back({*MakeAllocAction<>::from(fail_sps_allocaction),
-                            MakeAAOnVal(decrement_sps_allocaction)});
+  InitialActions.push_back({MakeAAOnVal(increment_int_ptr_action),
+                            MakeAAOnVal(decrement_int_ptr_action)});
+  InitialActions.push_back({AllocAction(fail_action, WrapperFunctionBuffer()),
+                            MakeAAOnVal(decrement_int_ptr_action)});
 
   auto DeallocActions = runFinalizeActions(std::move(InitialActions));
 
@@ -133,13 +157,12 @@ TEST(AllocActionTest, RunFinalizeActionsNullFinalize) {
   std::vector<AllocActionPair> InitialActions;
 
   auto MakeAAOnVal = [&](AllocActionFn Fn) {
-    return *MakeAllocAction<SPSExecutorAddr>::from(Fn,
-                                                   ExecutorAddr::fromPtr(&Val));
+    return AllocAction(Fn, makeIntPtrArgBuffer(&Val));
   };
-  InitialActions.push_back({MakeAAOnVal(increment_sps_allocaction),
-                            MakeAAOnVal(decrement_sps_allocaction)});
-  InitialActions.push_back({*MakeAllocAction<>::from(nullptr),
-                            MakeAAOnVal(decrement_sps_allocaction)});
+  InitialActions.push_back({MakeAAOnVal(increment_int_ptr_action),
+                            MakeAAOnVal(decrement_int_ptr_action)});
+  InitialActions.push_back({AllocAction(nullptr, WrapperFunctionBuffer()),
+                            MakeAAOnVal(decrement_int_ptr_action)});
 
   auto DeallocActions = cantFail(runFinalizeActions(std::move(InitialActions)));
 
@@ -158,13 +181,12 @@ TEST(AllocActionTest, RunFinalizeActionsNullDealloc) {
   std::vector<AllocActionPair> InitialActions;
 
   auto MakeAAOnVal = [&](AllocActionFn Fn) {
-    return *MakeAllocAction<SPSExecutorAddr>::from(Fn,
-                                                   ExecutorAddr::fromPtr(&Val));
+    return AllocAction(Fn, makeIntPtrArgBuffer(&Val));
   };
-  InitialActions.push_back({MakeAAOnVal(increment_sps_allocaction),
-                            MakeAAOnVal(decrement_sps_allocaction)});
-  InitialActions.push_back({MakeAAOnVal(increment_sps_allocaction),
-                            *MakeAllocAction<>::from(nullptr)});
+  InitialActions.push_back({MakeAAOnVal(increment_int_ptr_action),
+                            MakeAAOnVal(decrement_int_ptr_action)});
+  InitialActions.push_back({MakeAAOnVal(increment_int_ptr_action),
+                            AllocAction(nullptr, WrapperFunctionBuffer())});
 
   auto DeallocActions = cantFail(runFinalizeActions(std::move(InitialActions)));
 
@@ -174,40 +196,4 @@ TEST(AllocActionTest, RunFinalizeActionsNullDealloc) {
   runDeallocActions(std::move(DeallocActions));
 
   EXPECT_EQ(Val, 1);
-}
-
-// Handler that returns Error::success(). Exercises the
-// AllocActionSPSSerializer::serialize(Error) overload's success path.
-static orc_rt_WrapperFunctionBuffer
-errorSuccess_sps_allocaction(const char *ArgData, size_t ArgSize) {
-  return SPSAllocActionFunction<>::handle(
-             ArgData, ArgSize, []() -> Error { return Error::success(); })
-      .release();
-}
-
-// Handler that returns a StringError. Exercises the
-// AllocActionSPSSerializer::serialize(Error) overload's failure path.
-static orc_rt_WrapperFunctionBuffer
-errorFailure_sps_allocaction(const char *ArgData, size_t ArgSize) {
-  return SPSAllocActionFunction<>::handle(
-             ArgData, ArgSize,
-             []() -> Error { return make_error<StringError>("test failure"); })
-      .release();
-}
-
-TEST(AllocActionTest, RunActionWithErrorSuccessReturn) {
-  // A handler returning Error::success() should produce a non-out-of-band
-  // result buffer.
-  AllocAction AA(errorSuccess_sps_allocaction, WrapperFunctionBuffer());
-  auto B = AA();
-  EXPECT_EQ(B.getOutOfBandError(), nullptr);
-}
-
-TEST(AllocActionTest, RunActionWithErrorFailureReturn) {
-  // A handler returning a real Error should produce an out-of-band error
-  // result buffer carrying the Error's string form.
-  AllocAction AA(errorFailure_sps_allocaction, WrapperFunctionBuffer());
-  auto B = AA();
-  ASSERT_NE(B.getOutOfBandError(), nullptr);
-  EXPECT_STREQ(B.getOutOfBandError(), "test failure");
 }

--- a/orc-rt/unittests/SPSAllocActionTest.cpp
+++ b/orc-rt/unittests/SPSAllocActionTest.cpp
@@ -12,6 +12,9 @@
 
 #include "orc-rt/SPSAllocAction.h"
 
+#include "orc-rt/ExecutorAddress.h"
+
+#include "AllocActionTestUtils.h"
 #include "SimplePackedSerializationTestUtils.h"
 #include "gtest/gtest.h"
 
@@ -46,4 +49,80 @@ TEST(SPSAllocActionTest, AllocActionPairSerialization) {
   AAP.Dealloc = {noopAction, WrapperFunctionBuffer::copyFrom("foo")};
 
   blobSerializationRoundTrip<SPSAllocActionPair>(AAP, AAPEQ);
+}
+
+// Handler that returns Error::success(). Exercises the
+// AllocActionSPSSerializer::serialize(Error) overload's success path.
+static orc_rt_WrapperFunctionBuffer
+errorSuccess_sps_allocaction(const char *ArgData, size_t ArgSize) {
+  return SPSAllocActionFunction<>::handle(
+             ArgData, ArgSize, []() -> Error { return Error::success(); })
+      .release();
+}
+
+// Handler that returns a StringError. Exercises the
+// AllocActionSPSSerializer::serialize(Error) overload's failure path.
+static orc_rt_WrapperFunctionBuffer
+errorFailure_sps_allocaction(const char *ArgData, size_t ArgSize) {
+  return SPSAllocActionFunction<>::handle(
+             ArgData, ArgSize,
+             []() -> Error { return make_error<StringError>("test failure"); })
+      .release();
+}
+
+TEST(SPSAllocActionTest, RunActionWithErrorSuccessReturn) {
+  // A handler returning Error::success() should produce a non-out-of-band
+  // result buffer.
+  AllocAction AA(errorSuccess_sps_allocaction, WrapperFunctionBuffer());
+  auto B = AA();
+  EXPECT_EQ(B.getOutOfBandError(), nullptr);
+}
+
+TEST(SPSAllocActionTest, RunActionWithErrorFailureReturn) {
+  // A handler returning a real Error should produce an out-of-band error
+  // result buffer carrying the Error's string form.
+  AllocAction AA(errorFailure_sps_allocaction, WrapperFunctionBuffer());
+  auto B = AA();
+  ASSERT_NE(B.getOutOfBandError(), nullptr);
+  EXPECT_STREQ(B.getOutOfBandError(), "test failure");
+}
+
+// Handler that takes an SPS-encoded int* argument and increments the int.
+// Exercises both the SPS argument-deserialization path and the identity
+// (WrapperFunctionBuffer) overload of AllocActionSPSSerializer.
+static orc_rt_WrapperFunctionBuffer
+increment_sps_allocaction(const char *ArgData, size_t ArgSize) {
+  return SPSAllocActionFunction<SPSExecutorAddr>::handle(
+             ArgData, ArgSize,
+             [](ExecutorAddr IntPtr) {
+               *IntPtr.toPtr<int *>() += 1;
+               return WrapperFunctionBuffer();
+             })
+      .release();
+}
+
+TEST(SPSAllocActionTest, RunActionWithSPSArgsAndWFBReturn) {
+  // Verifies that handlers with SPS-encoded arguments work end-to-end: SPS
+  // deserializes the int*, the handler runs, and its empty WFB return is
+  // passed through by AllocActionSPSSerializer's identity overload.
+  int Val = 0;
+  auto IncVal = *MakeAllocAction<SPSExecutorAddr>::from(
+      increment_sps_allocaction, ExecutorAddr::fromPtr(&Val));
+  EXPECT_TRUE(IncVal);
+  auto B = IncVal();
+  EXPECT_EQ(B.getOutOfBandError(), nullptr);
+  EXPECT_EQ(Val, 1);
+}
+
+TEST(SPSAllocActionTest, RunActionWithUndecodableArgs) {
+  // An arg buffer that's too small for the wrapper's declared SPS signature
+  // (SPSExecutorAddr expects 8 bytes here) should cause
+  // AllocActionFunction::handle to return its out-of-band deserialization
+  // error without invoking the handler.
+  AllocAction AA(increment_sps_allocaction,
+                 WrapperFunctionBuffer::allocate(/*Size=*/1));
+  auto B = AA();
+  ASSERT_NE(B.getOutOfBandError(), nullptr);
+  EXPECT_STREQ(B.getOutOfBandError(),
+               "Could not deserialize allocation action argument buffer");
 }


### PR DESCRIPTION
Rewrites AllocActionTest.cpp's integration tests (RunBasicAction, RunFinalize*) to drive AllocActionFunction::handle with a small local IntPtrDeserializer / IdentitySerializer pair instead of going through SPS, and moves the existing SPS-using AllocAction tests into SPSAllocActionTest.cpp.

Also adds two new SPS tests covering previously-uncovered paths:
  - RunActionWithSPSArgsAndWFBReturn — SPS argument deserialization plus AllocActionSPSSerializer's identity (WrapperFunctionBuffer) overload.
  - RunActionWithUndecodableArgs — the deserialization-failure path in AllocActionFunction::handle.

After the split, an AllocActionTest failure indicates problems with the AllocAction machinery, and an SPSAllocActionTest failure without a corresponding AllocActionTest failure indicates an SPS encoding / decoding issue for AllocAction.