### PR TITLE
[orc-rt] Add MacroUtils.h header for general purpose macros.

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -15,6 +15,7 @@ set(ORC_RT_HEADERS
     orc-rt/IntervalMap.h
     orc-rt/IntervalSet.h
     orc-rt/LockedAccess.h
+    orc-rt/MacroUtils.h
     orc-rt/Math.h
     orc-rt/MemoryFlags.h
     orc-rt/NativeDylibManager.h

--- a/orc-rt/include/orc-rt/MacroUtils.h
+++ b/orc-rt/include/orc-rt/MacroUtils.h
@@ -1,0 +1,32 @@
+//===- MacroUtils.h - General-purpose preprocessor helpers ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Small preprocessor-utility macros not specific to any particular orc-rt
+// subsystem.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_MACROUTILS_H
+#define ORC_RT_MACROUTILS_H
+
+
+#define ORC_RT_DETAIL_DEPAREN_HELPER(...) __VA_ARGS__
+
+/// Strip a single layer of outer parentheses from a token sequence.
+///
+/// Useful for passing a parenthesized comma-separated list (e.g. a list of
+/// types) as a single argument to a function-like macro, then unwrapping it
+/// at the use site:
+///
+///     #define MY_MACRO(Types) some_template<ORC_RT_DEPAREN(Types)>
+///     MY_MACRO((int, double, char))
+///         -> some_template<int, double, char>
+///
+#define ORC_RT_DEPAREN(X) ORC_RT_DETAIL_DEPAREN_HELPER X
+
+#endif // ORC_RT_MACROUTILS_H

--- a/orc-rt/include/orc-rt/MacroUtils.h
+++ b/orc-rt/include/orc-rt/MacroUtils.h
@@ -14,7 +14,6 @@
 #ifndef ORC_RT_MACROUTILS_H
 #define ORC_RT_MACROUTILS_H
 
-
 #define ORC_RT_DETAIL_DEPAREN_HELPER(...) __VA_ARGS__
 
 /// Strip a single layer of outer parentheses from a token sequence.

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_orc_rt_unittest(CoreTests
   IntervalMapTest.cpp
   IntervalSetTest.cpp
   LockedAccessTest.cpp
+  MacroUtilsTest.cpp
   MathTest.cpp
   MemoryAccessSPSCITest.cpp
   MemoryFlagsTest.cpp

--- a/orc-rt/unittests/MacroUtilsTest.cpp
+++ b/orc-rt/unittests/MacroUtilsTest.cpp
@@ -1,0 +1,42 @@
+//===- MacroUtilsTest.cpp -------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for orc-rt's MacroUtils.h APIs.
+//
+// These are compile-time invariants — the static_asserts pin the contract
+// of ORC_RT_DEPAREN. The trivial TEST exists so the file produces a gtest
+// case to run.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/MacroUtils.h"
+
+#include "gtest/gtest.h"
+
+#include <tuple>
+#include <type_traits>
+
+// Multi-element list.
+static_assert(
+    std::is_same_v<std::tuple<ORC_RT_DEPAREN((int, double, char))>,
+                   std::tuple<int, double, char>>,
+    "ORC_RT_DEPAREN should strip outer parens from a multi-element list");
+
+// Single-element list.
+static_assert(
+    std::is_same_v<std::tuple<ORC_RT_DEPAREN((int))>, std::tuple<int>>,
+    "ORC_RT_DEPAREN should strip outer parens from a single-element list");
+
+// Empty list.
+static_assert(std::is_same_v<std::tuple<ORC_RT_DEPAREN(())>, std::tuple<>>,
+              "ORC_RT_DEPAREN should produce nothing from an empty list");
+
+TEST(MacroUtilsTest, DeParenCompiles) {
+  // The real coverage is in the static_asserts above; this case exists so
+  // the file contributes a runnable gtest entry.
+}


### PR DESCRIPTION
For now just contains ORC_RT_DEPAREN, a macro for stripping parentheses from its argument. This will be used in an upcoming commit.