### PR TITLE
[orc-rt] Add ORC_RT_SPS_ALLOC_ACTION helper macro.

### DIFF
--- a/orc-rt/include/orc-rt/SPSAllocAction.h
+++ b/orc-rt/include/orc-rt/SPSAllocAction.h
@@ -15,8 +15,27 @@
 #define ORC_RT_SPSALLOCACTION_H
 
 #include "orc-rt/AllocAction.h"
+#include "orc-rt/MacroUtils.h"
 #include "orc-rt/SPSWrapperFunctionBuffer.h"
 #include "orc-rt/SimplePackedSerialization.h"
+
+/// Define an allocation-action wrapper function with the given Name that
+/// uses SPS to deserialize its arguments and dispatches to Handle.
+///
+/// SPSArgs is a parenthesized comma-separated list of SPS argument types
+/// (the parens are stripped by ORC_RT_DEPAREN before being expanded into
+/// the SPSAllocActionFunction template instantiation):
+///
+///     static Error checkEq(int32_t X, int32_t Y);
+///     ORC_RT_SPS_ALLOC_ACTION(check_eq_action, (int32_t, int32_t), checkEq)
+///
+#define ORC_RT_SPS_ALLOC_ACTION(Name, SPSArgs, Handle)                         \
+  static orc_rt_WrapperFunctionBuffer Name(const char *ArgData,                \
+                                           size_t ArgSize) {                   \
+    return orc_rt::SPSAllocActionFunction<ORC_RT_DEPAREN(SPSArgs)>::handle(    \
+               ArgData, ArgSize, Handle)                                       \
+        .release();                                                            \
+  }
 
 namespace orc_rt {
 

--- a/orc-rt/unittests/SPSAllocActionTest.cpp
+++ b/orc-rt/unittests/SPSAllocActionTest.cpp
@@ -126,3 +126,27 @@ TEST(SPSAllocActionTest, RunActionWithUndecodableArgs) {
   EXPECT_STREQ(B.getOutOfBandError(),
                "Could not deserialize allocation action argument buffer");
 }
+
+// Test the ORC_RT_SPS_ALLOC_ACTION macro.
+static Error check_values_equal(int32_t X, int32_t Y) {
+  if (X == Y)
+    return Error::success();
+  return make_error<StringError>("X and Y differ");
+}
+ORC_RT_SPS_ALLOC_ACTION(macro_defined_allocaction, (int32_t, int32_t),
+                        check_values_equal)
+
+TEST(SPSAllocActionTest, RunMacroDefinedAllocActionWithErrorSuccessReturn) {
+  AllocAction AA(macro_defined_allocaction,
+                 *spsSerialize<SPSArgList<int32_t, int32_t>>(42, 42));
+  auto B = AA();
+  EXPECT_EQ(B.getOutOfBandError(), nullptr);
+}
+
+TEST(SPSAllocActionTest, RunMacroDefinedAllocActionWithErrorFailureReturn) {
+  AllocAction AA(macro_defined_allocaction,
+                 *spsSerialize<SPSArgList<int32_t, int32_t>>(42, 7));
+  auto B = AA();
+  ASSERT_NE(B.getOutOfBandError(), nullptr);
+  EXPECT_STREQ(B.getOutOfBandError(), "X and Y differ");
+}


### PR DESCRIPTION
ORC_RT_SPS_ALLOC_ACTION(Name, SPSArgs, Handle) is shorthand for defining an allocation-action wrapper function whose arguments are SPS-encoded. It expands to:

    static orc_rt_WrapperFunctionBuffer Name(const char *ArgData,
                                             size_t ArgSize);

with a body that deserializes ArgData via SPSAllocActionFunction<SPSArgs...> and forwards the decoded arguments to Handle.

SPSArgs is given as a parenthesized comma-separated list of SPS argument types — e.g. (int32_t, int32_t) — stripped at expansion time via ORC_RT_DEPAREN.