### PR TITLE
[clang] Update C++ DR status page

### DIFF
--- a/clang/test/CXX/drs/cwg5xx.cpp
+++ b/clang/test/CXX/drs/cwg5xx.cpp
@@ -84,9 +84,6 @@ namespace cwg506 { // cwg506: 2.7
   // since-cxx11-error@-2 {{cannot pass object of non-trivial type 'NonPod' through variadic function; call will abort at runtime}}
 } // namespace cwg506
 
-// FIXME: Add tests here once CWG260 is resolved.
-// cwg507: dup 260
-
 // cwg508: na
 // cwg509: na
 // cwg510: na

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -58,7 +58,7 @@
   <tr class="open" id="2">
     <td><a href="https://cplusplus.github.io/CWG/issues/2.html">2</a></td>
     <td>[<a href="https://wg21.link/temp.dep.res">temp.dep.res</a>]</td>
-    <td>drafting</td>
+    <td>open</td>
     <td>How can dependent names be used in member declarations that appear outside of the class template definition?</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -1864,7 +1864,7 @@
   <tr class="open" id="260">
     <td><a href="https://cplusplus.github.io/CWG/issues/260.html">260</a></td>
     <td>[<a href="https://wg21.link/over.built">over.built</a>]</td>
-    <td>open</td>
+    <td>review</td>
     <td>User-defined conversions and built-in <TT>operator=</TT></td>
     <td align="center">Not resolved</td>
   </tr>
@@ -3594,12 +3594,12 @@
     <td>Conditionally-supported behavior for non-POD objects passed to ellipsis</td>
     <td class="full" align="center">Clang 2.7</td>
   </tr>
-  <tr id="507">
+  <tr class="open" id="507">
     <td><a href="https://cplusplus.github.io/CWG/issues/507.html">507</a></td>
     <td>[<a href="https://wg21.link/over.built">over.built</a>]</td>
-    <td>dup</td>
-    <td>Ambiguity assigning class object to built-in type</td>
-    <td class="unknown" align="center">Duplicate of <a href="#260">260</a></td>
+    <td>open</td>
+    <td>Ambiguity with built-in binary operator candidates for class object convertible to built-in type</td>
+    <td align="center">Not resolved</td>
   </tr>
   <tr id="508">
     <td><a href="https://cplusplus.github.io/CWG/issues/508.html">508</a></td>
@@ -15383,7 +15383,7 @@
   <tr class="open" id="2228">
     <td><a href="https://cplusplus.github.io/CWG/issues/2228.html">2228</a></td>
     <td>[<a href="https://wg21.link/dcl.ambig.res">dcl.ambig.res</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Ambiguity resolution for cast to function type</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -18591,7 +18591,7 @@
   <tr class="open" id="2684">
     <td><a href="https://cplusplus.github.io/CWG/issues/2684.html">2684</a></td>
     <td>[<a href="https://wg21.link/basic.start.dynamic">basic.start.dynamic</a>]</td>
-    <td>open</td>
+    <td>ready</td>
     <td>thread_local dynamic initialization</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -19095,7 +19095,7 @@
   <tr class="open" id="2756">
     <td><a href="https://cplusplus.github.io/CWG/issues/2756.html">2756</a></td>
     <td>[<a href="https://wg21.link/class.init">class.init</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Completion of initialization by delegating constructor</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -20626,14 +20626,14 @@
   <tr class="open" id="2973">
     <td><a href="https://cplusplus.github.io/CWG/issues/2973.html">2973</a></td>
     <td>[<a href="https://wg21.link/dcl.typedef">dcl.typedef</a>]</td>
-    <td>open</td>
+    <td>review</td>
     <td>Does an <I>alias-declaration</I> introduce a name for linkage purposes?</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2974">
     <td><a href="https://cplusplus.github.io/CWG/issues/2974.html">2974</a></td>
     <td>[<a href="https://wg21.link/temp.deduct.type">temp.deduct.type</a>]</td>
-    <td>open</td>
+    <td>ready</td>
     <td>Non-deduced context for <I>qualified-id</I> naming a template</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -20976,7 +20976,7 @@
   <tr class="open" id="3023">
     <td><a href="https://cplusplus.github.io/CWG/issues/3023.html">3023</a></td>
     <td>[<a href="https://wg21.link/dcl.init.list">dcl.init.list</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Default arguments in list-initialization</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21004,7 +21004,7 @@
   <tr class="open" id="3027">
     <td><a href="https://cplusplus.github.io/CWG/issues/3027.html">3027</a></td>
     <td>[<a href="https://wg21.link/temp.type">temp.type</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Equivalence of <I>pack-index-specifier</I>s</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21137,7 +21137,7 @@
   <tr class="open" id="3046">
     <td><a href="https://cplusplus.github.io/CWG/issues/3046.html">3046</a></td>
     <td>[<a href="https://wg21.link/dcl.enum">dcl.enum</a>]</td>
-    <td>open</td>
+    <td>ready</td>
     <td>Enumerations as part of the common initial sequence</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21837,7 +21837,7 @@
   <tr class="open" id="3146">
     <td><a href="https://cplusplus.github.io/CWG/issues/3146.html">3146</a></td>
     <td>[<a href="https://wg21.link/diff.expr">diff.expr</a>]</td>
-    <td>open</td>
+    <td>ready</td>
     <td>Usual arithmetic conversions for enumerations are different in C</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21928,7 +21928,7 @@
   <tr class="open" id="3159">
     <td><a href="https://cplusplus.github.io/CWG/issues/3159.html">3159</a></td>
     <td>[<a href="https://wg21.link/temp.inst">temp.inst</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Instantiation of variables with incomplete array types</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -21963,35 +21963,35 @@
   <tr class="open" id="3164">
     <td><a href="https://cplusplus.github.io/CWG/issues/3164.html">3164</a></td>
     <td>[<a href="https://wg21.link/cpp.predefined">cpp.predefined</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Location of specification of <TT>__STDCPP_FLOAT16_T__</TT> macro</td>
     <td align="center">Not resolved</td>
   </tr>
-  <tr class="open" id="3165">
+  <tr id="3165">
     <td><a href="https://cplusplus.github.io/CWG/issues/3165.html">3165</a></td>
     <td>[<a href="https://wg21.link/basic.link">basic.link</a>]</td>
-    <td>tentatively ready</td>
+    <td>dup</td>
     <td>Use "equivalent type" to support templated entities</td>
-    <td align="center">Not resolved</td>
+    <td class="unknown" align="center">Unknown</td>
   </tr>
   <tr class="open" id="3166">
     <td><a href="https://cplusplus.github.io/CWG/issues/3166.html">3166</a></td>
     <td>[<a href="https://wg21.link/expr.reflect">expr.reflect</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Protected access rule for a pointer-to-member from a <I>reflect-expression</I></td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3167">
     <td><a href="https://cplusplus.github.io/CWG/issues/3167.html">3167</a></td>
     <td>[<a href="https://wg21.link/dcl.init">dcl.init</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Initializing typedefs</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3168">
     <td><a href="https://cplusplus.github.io/CWG/issues/3168.html">3168</a></td>
     <td>[<a href="https://wg21.link/conv.rank">conv.rank</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Issues with integer conversion ranks</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -22033,7 +22033,7 @@
   <tr class="open" id="3174">
     <td><a href="https://cplusplus.github.io/CWG/issues/3174.html">3174</a></td>
     <td>[<a href="https://wg21.link/basic.lookup.argdep">basic.lookup.argdep</a>]</td>
-    <td>tentatively ready</td>
+    <td>review</td>
     <td>Handling of friends in argument-dependent lookup</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -22047,14 +22047,14 @@
   <tr class="open" id="3176">
     <td><a href="https://cplusplus.github.io/CWG/issues/3176.html">3176</a></td>
     <td>[<a href="https://wg21.link/intro.execution">intro.execution</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Sequencing default arguments during constant evaluation</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3177">
     <td><a href="https://cplusplus.github.io/CWG/issues/3177.html">3177</a></td>
     <td>[<a href="https://wg21.link/lex.pptoken">lex.pptoken</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Formation of a <I>header-name</I> preprocessing token</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -22068,7 +22068,7 @@
   <tr class="open" id="3179">
     <td><a href="https://cplusplus.github.io/CWG/issues/3179.html">3179</a></td>
     <td>[<a href="https://wg21.link/dcl.fct">dcl.fct</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>More edge cases for a <TT>void</TT> function parameter</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -22089,21 +22089,21 @@
   <tr class="open" id="3182">
     <td><a href="https://cplusplus.github.io/CWG/issues/3182.html">3182</a></td>
     <td>[<a href="https://wg21.link/temp.deduct.call">temp.deduct.call</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Notional template parameters introduced for an array parameter</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3183">
     <td><a href="https://cplusplus.github.io/CWG/issues/3183.html">3183</a></td>
     <td>[<a href="https://wg21.link/expr.call">expr.call</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>No <I>expression</I>s in an <I>expression-list</I></td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="3184">
     <td><a href="https://cplusplus.github.io/CWG/issues/3184.html">3184</a></td>
     <td>[<a href="https://wg21.link/expr.add">expr.add</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Pointer arithmetic with similar types</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -22117,7 +22117,7 @@
   <tr class="open" id="3186">
     <td><a href="https://cplusplus.github.io/CWG/issues/3186.html">3186</a></td>
     <td>[<a href="https://wg21.link/basic.lookup.argdep">basic.lookup.argdep</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Argument-dependent lookup is for a name</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -22131,7 +22131,7 @@
   <tr class="open" id="3188">
     <td><a href="https://cplusplus.github.io/CWG/issues/3188.html">3188</a></td>
     <td>[<a href="https://wg21.link/diff.cpp20">diff.cpp20</a>]</td>
-    <td>tentatively ready</td>
+    <td>ready</td>
     <td>Behavior change for class template argument deduction</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -22145,7 +22145,7 @@
   <tr class="open" id="3190">
     <td><a href="https://cplusplus.github.io/CWG/issues/3190.html">3190</a></td>
     <td>[<a href="https://wg21.link/expr.reflect">expr.reflect</a>]</td>
-    <td>review</td>
+    <td>ready</td>
     <td>Ambiguous lookup for type aliases in reflection</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -22168,6 +22168,48 @@
     <td>[<a href="https://wg21.link/dcl.friend">dcl.friend</a>]</td>
     <td>open</td>
     <td>Missing restrictions and effects for friend declarations</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3194">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3194.html">3194</a></td>
+    <td>[<a href="https://wg21.link/lex.pptoken">lex.pptoken</a>]</td>
+    <td>open</td>
+    <td>Lexing of <TT>&lt;=&gt;</TT></td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3195">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3195.html">3195</a></td>
+    <td>[<a href="https://wg21.link/expr.const.core">expr.const.core</a>]</td>
+    <td>open</td>
+    <td>Starting the lifetime of a runtime object during constant evaluation</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3196">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3196.html">3196</a></td>
+    <td>[<a href="https://wg21.link/basic.start.term">basic.start.term</a>]</td>
+    <td>open</td>
+    <td>Move restriction on standard library functions in signal handlers</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3197">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3197.html">3197</a></td>
+    <td>[<a href="https://wg21.link/diff.basic">diff.basic</a>]</td>
+    <td>open</td>
+    <td>Relaxed requirements for integer representations</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3198">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3198.html">3198</a></td>
+    <td>[<a href="https://wg21.link/except.handle">except.handle</a>]</td>
+    <td>open</td>
+    <td>Stack unwinding when no matching handler is found</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3199">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3199.html">3199</a></td>
+    <td>[<a href="https://wg21.link/cpp.predefined">cpp.predefined</a>]</td>
+    <td>open</td>
+    <td>Missing predefined macros for <TT>chart16_t</TT> and <TT>char32_t</TT></td>
     <td align="center">Not resolved</td>
   </tr></table>
 


### PR DESCRIPTION
The post-Brno draft will not be out for three more weeks, but Brno updates for Core issues statuses are already trickling in.

Notably, [CWG507](https://cplusplus.github.io/CWG/issues/507.html) "Ambiguity with built-in binary operator candidates for class object convertible to built-in type", which used to be marked as a duplicate of [CWG260](https://cplusplus.github.io/CWG/issues/260.html) "User-defined conversions and built-in `operator=`", is open again, presumably because it contains an example that goes beyond the scope of CWG260. Relatively recent CWG thread that might be related (WG21 access required): [link](https://lists.isocpp.org/core/2025/08/18478.php).