### PR TITLE
[lit] Extract pluggable ExecutionBackend in run.py

### DIFF
--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -1,3 +1,4 @@
+import abc
 import multiprocessing
 import os
 import platform
@@ -21,6 +22,20 @@ WINDOWS_MAX_WORKERS_PER_POOL = 60
 def _ceilDiv(a, b):
     return (a + b - 1) // b
 
+
+def _distribute_workers(workers, max_per_pool):
+    """Split workers across as few pools as possible, each no longer than
+    max_per_pool, balancing the counts as evenly as we can. POSIX always
+    returns a single pool; the split only matters on Windows (60-worker cap) or
+    when LIT_WINDOWS_MAX_WORKERS_PER_POOL forces it. Returns the list of
+    per-pool worker counts."""
+    num_pools = max(1, _ceilDiv(workers, max_per_pool))
+    sizes = [workers // num_pools] * num_pools
+    for i in range(workers % num_pools):
+        sizes[i] += 1
+    return sizes
+
+
 class MaxFailuresError(Exception):
     pass
 
@@ -32,6 +47,170 @@ class TimeoutError(Exception):
 class WorkerCrashError(Exception):
     """A worker process died abrupty (segfault, OOM-kill, abort) instead of returning a result."""
     pass
+
+
+class ExecutionBackend(abc.ABC):
+    """Manages the worker lifecycle and runs the entire test suite for a single Run.
+
+    It operates at a higher level than a standard Executor. Instead of just running tasks
+    and returning futures, a backend manages its own workers and handles its own abort
+    logic (like instantly killing processes vs cleanly stopping threads). Heavy lifting
+    like timeouts, failure limits, and saving results lives in Run._wait_for so all backends
+    share it.
+
+    Because of this, backends wrap an executor rather than subclassing it. Forcing
+    concurrent.futures.Executor wouldn't work for an async engine (which uses an event loop,
+    not futures) and lacks the abort() method that standard executors don't support.
+    """
+
+    __slots__ = ()
+
+    @abc.abstractmethod
+    def submit(self, tests):
+        """Dispatch every test; return a {future: test} map for _wait_for."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def abort(self):
+        """Force stop all in-flight work (ctrl-C, --max-failures,
+        --max-time, or a worker crash)."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def shutdown(self):
+        """Clean shutdown after every result has been collected."""
+        raise NotImplementedError
+
+
+class ProcessPoolBackend(ExecutionBackend):
+    """Run each test in a standalone process using ProcessPoolExecutor.
+
+    This is the default backend, moving the existing behavior here cleanly. It isolates
+    everything process-specific away from Run. This includes handling process-limit
+    bumps (RLIMIT_NPROC), using shared-memory semaphores for parallelism groups,
+    splitting pools on Windows to respect the 60-worker limit, initializing each child
+    process with lit_config, and handling hard SIGKILL teardowns.
+    """
+
+    def __init__(self, lit_config, workers):
+        self.lit_config = lit_config
+        self.workers = workers
+        self.future_to_test = {}
+        self._increase_process_limit()
+
+        semaphores = {
+            k: multiprocessing.BoundedSemaphore(v)
+            for k, v in lit_config.parallelism_groups.items()
+            if v is not None
+        }
+        # Windows has a limit of 60 workers per pool, so we need to use multiple pools
+        # if we have more workers requested than the limit.
+        # Also, allow to override the limit with the LIT_WINDOWS_MAX_WORKERS_PER_POOL environment variable.
+        max_workers_per_pool = (
+            WINDOWS_MAX_WORKERS_PER_POOL if os.name == "nt" else self.workers
+        )
+        max_workers_per_pool = int(
+            os.getenv("LIT_WINDOWS_MAX_WORKERS_PER_POOL", max_workers_per_pool)
+        )
+        pool_sizes = _distribute_workers(workers, max_workers_per_pool)
+
+        if len(pool_sizes) > 1:
+            self.lit_config.note(
+                "Using %d pools balancing %d workers total distributed as %s (Windows worker limit workaround)"
+                % (len(pool_sizes), self.workers, pool_sizes)
+            )
+
+        self.executors = [
+            ProcessPoolExecutor(
+                max_workers=pool_size,
+                initializer=lit.worker.initialize,
+                initargs=(lit_config, semaphores),
+            )
+            for pool_size in pool_sizes
+        ]
+
+    def submit(self, tests):
+        self.future_to_test = {}
+        for i, test in enumerate(tests):
+            ex = self.executors[i % len(self.executors)]
+            self.future_to_test[ex.submit(lit.worker.execute, test)] = test
+        return self.future_to_test
+
+    def shutdown(self):
+        for ex in self.executors:
+            ex.shutdown(wait=True)
+
+    def abort(self):
+        """SIGKILL all workers on abort (ctrl-C, --max-failures, --max-time,
+        worker crash). Pre-3.14 ProcessPoolExecutor has no force-stop."""
+        try:
+            # We don't call ex.shutdown() here: it joins the management thread,
+            # which is blocked reading the queue we just corrupted.
+            # On 3.8 / 3.9, cancel() races with the call-queue feeder thread and can
+            # deadlock or corrupt the queue (https://github.com/python/cpython/issues/94440).
+            # Skipping it is safe because we SIGKILL workers below, so no pending future
+            # will ever be dispatched. cancel() on 3.10+ is a clean hint.
+            if sys.version_info >= (3, 10):
+                for future in self.future_to_test:
+                    future.cancel()
+            # Killing worker processes can corrupt the executor's queues, which makes it
+            # unsafe for its atexit hooks to join their threads. Disable those hooks
+            # before terminating workers (a second ctrl-C should not bypass this cleanup).
+            # This applies to call-queue feeder threads and management threads.
+            # Otherwise, a thread blocked on a partially written pipe may require multiple
+            # ctrl-C to unblock.
+            # See: https://github.com/python/cpython/issues/125886
+            # These threads are daemonic on Python 3.8, so disabling them is harmless.
+            for ex in self.executors:
+                if hasattr(ex, "_call_queue") and ex._call_queue is not None:
+                    ex._call_queue.cancel_join_thread()
+            if hasattr(concurrent.futures.process, "_threads_wakeups"):
+                concurrent.futures.process._threads_wakeups.clear()
+            tree_kill_ok, _ = lit.util.killProcessAndChildrenIsSupported()
+            for ex in self.executors:
+                for pid, proc in list((ex._processes or {}).items()):
+                    if tree_kill_ok:
+                        lit.util.killProcessAndChildren(pid)
+                    else:
+                        proc.kill()
+            # TODO: Python>=3.14 adds ex.kill_workers(), which stops the workers cleanly
+            # without corrupting the queues. However kill_workers() won't reap the
+            # llc / FileCheck grandchildren the workers spawned.
+            # https://github.com/python/cpython/issues/128041
+        except Exception:
+            pass
+
+    # TODO(yln): interferes with progress bar
+    # Some tests use threads internally, and at least on Linux each of these
+    # threads counts toward the current process limit. Try to raise the (soft)
+    # process limit so that tests don't fail due to resource exhaustion.
+    def _increase_process_limit(self):
+        ncpus = lit.util.usable_core_count()
+        desired_limit = self.workers * ncpus * 2  # the 2 is a safety factor
+
+        # Importing the resource module will likely fail on Windows.
+        try:
+            import resource
+
+            NPROC = resource.RLIMIT_NPROC
+
+            soft_limit, hard_limit = resource.getrlimit(NPROC)
+            desired_limit = min(desired_limit, hard_limit)
+
+            if soft_limit < desired_limit:
+                resource.setrlimit(NPROC, (desired_limit, hard_limit))
+                self.lit_config.note(
+                    "Raised process limit from %d to %d" % (soft_limit, desired_limit)
+                )
+        except Exception as ex:
+            # Warn, unless this is Windows, z/OS, Solaris or Cygwin in which case this is expected.
+            if (
+                os.name != "nt"
+                and platform.system() != "OS/390"
+                and platform.system() != "SunOS"
+                and platform.sys.platform != "cygwin"
+            ):
+                self.lit_config.warning("Failed to raise process limit: %s" % ex)
 
 
 class Run:
@@ -81,100 +260,25 @@ class Run:
                 if test.result is None:
                     test.setResult(skipped)
 
-    def _abort_executors(self, executors, future_to_test):
-        """SIGKILL all workers on abort (ctrl-C, --max-failures, --max-time,
-        worker crash). Pre-3.14 ProcessPoolExecutor has no force-stop."""
-        try:
-            # We don't call ex.shutdown() here: it joins the management thread,
-            # which is blocked reading the queue we just corrupted.
-            # On 3.8 / 3.9, cancel() races with the call-queue feeder thread and can
-            # deadlock or corrupt the queue (https://github.com/python/cpython/issues/94440).
-            # Skipping it is safe because we SIGKILL workers below, so no pending future
-            # will ever be dispatched. cancel() on 3.10+ is a clean hint.
-            if sys.version_info >= (3, 10):
-                for future in future_to_test:
-                    future.cancel()
-            # Killing worker processes can corrupt the executor's queues, which makes it
-            # unsafe for its atexit hooks to join their threads. Disable those hooks
-            # before terminating workers (a second ctrl-C should not bypass this cleanup).
-            # This applies to call-queue feeder threads and management threads.
-            # Otherwise, a thread blocked on a partially written pipe may require multiple
-            # ctrl-C to unblock.
-            # See: https://github.com/python/cpython/issues/125886
-            # These threads are daemonic on Python 3.8, so disabling them is harmless.
-            for ex in executors:
-                if hasattr(ex, "_call_queue") and ex._call_queue is not None:
-                    ex._call_queue.cancel_join_thread()
-            if hasattr(concurrent.futures.process, "_threads_wakeups"):
-                concurrent.futures.process._threads_wakeups.clear()
-            tree_kill_ok, _ = lit.util.killProcessAndChildrenIsSupported()
-            for ex in executors:
-                for pid, proc in list((ex._processes or {}).items()):
-                    if tree_kill_ok:
-                        lit.util.killProcessAndChildren(pid)
-                    else:
-                        proc.kill()
-            # TODO: Python>=3.14 adds ex.kill_workers(), which stops the workers cleanly
-            # without corrupting the queues. However kill_workers() won't reap the
-            # llc / FileCheck grandchildren the workers spawned.
-            # https://github.com/python/cpython/issues/128041
-        except Exception:
-            pass
+    def _make_backend(self):
+        """The single entry point for backend selection. Right now, it only supports
+        the process pool. Future updates will add a ThreadPoolBackend behind
+        --experimental-thread-workers, followed by an async engine.
+
+        Without flags, it defaults to the process pool (current behavior).
+        """
+        return ProcessPoolBackend(self.lit_config, self.workers)
 
     def _execute(self, deadline):
-        self._increase_process_limit()
-
-        semaphores = {
-            k: multiprocessing.BoundedSemaphore(v)
-            for k, v in self.lit_config.parallelism_groups.items()
-            if v is not None
-        }
-
-        # Windows has a limit of 60 workers per pool, so we need to use multiple pools
-        # if we have more workers requested than the limit.
-        # Also, allow to override the limit with the LIT_WINDOWS_MAX_WORKERS_PER_POOL environment variable.
-        max_workers_per_pool = (
-            WINDOWS_MAX_WORKERS_PER_POOL if os.name == "nt" else self.workers
-        )
-        max_workers_per_pool = int(
-            os.getenv("LIT_WINDOWS_MAX_WORKERS_PER_POOL", max_workers_per_pool)
-        )
-
-        num_pools = max(1, _ceilDiv(self.workers, max_workers_per_pool))
-
-        # Distribute self.workers across num_pools as evenly as possible
-        workers_per_pool_list = [self.workers // num_pools] * num_pools
-        for pool_idx in range(self.workers % num_pools):
-            workers_per_pool_list[pool_idx] += 1
-
-        if num_pools > 1:
-            self.lit_config.note(
-                "Using %d pools balancing %d workers total distributed as %s (Windows worker limit workaround)"
-                % (num_pools, self.workers, workers_per_pool_list)
-            )
-
-        executors = [
-            ProcessPoolExecutor(
-                max_workers=pool_size,
-                initializer=lit.worker.initialize,
-                initargs=(self.lit_config, semaphores),
-            )
-            for pool_size in workers_per_pool_list
-        ]
-
-        future_to_test = {}
-        for i, test in enumerate(self.tests):
-            ex = executors[i % len(executors)]
-            future_to_test[ex.submit(lit.worker.execute, test)] = test
-
+        backend = self._make_backend()
+        future_to_test = backend.submit(self.tests)
         try:
             self._wait_for(future_to_test, deadline)
         except BaseException:
-            self._abort_executors(executors, future_to_test)
+            backend.abort()
             raise
         else:
-            for ex in executors:
-                ex.shutdown(wait=True)
+            backend.shutdown()
 
     def _wait_for(self, future_to_test, deadline):
         try:
@@ -200,34 +304,3 @@ class Run:
         local_test.requires = remote_test.requires
         local_test.result = remote_test.result
 
-    # TODO(yln): interferes with progress bar
-    # Some tests use threads internally, and at least on Linux each of these
-    # threads counts toward the current process limit. Try to raise the (soft)
-    # process limit so that tests don't fail due to resource exhaustion.
-    def _increase_process_limit(self):
-        ncpus = lit.util.usable_core_count()
-        desired_limit = self.workers * ncpus * 2  # the 2 is a safety factor
-
-        # Importing the resource module will likely fail on Windows.
-        try:
-            import resource
-
-            NPROC = resource.RLIMIT_NPROC
-
-            soft_limit, hard_limit = resource.getrlimit(NPROC)
-            desired_limit = min(desired_limit, hard_limit)
-
-            if soft_limit < desired_limit:
-                resource.setrlimit(NPROC, (desired_limit, hard_limit))
-                self.lit_config.note(
-                    "Raised process limit from %d to %d" % (soft_limit, desired_limit)
-                )
-        except Exception as ex:
-            # Warn, unless this is Windows, z/OS, Solaris or Cygwin in which case this is expected.
-            if (
-                os.name != "nt"
-                and platform.system() != "OS/390"
-                and platform.system() != "SunOS"
-                and platform.sys.platform != "cygwin"
-            ):
-                self.lit_config.warning("Failed to raise process limit: %s" % ex)


### PR DESCRIPTION
Run._execute currently mixes two unrelated jobs: process-specific pool management (limits, semaphores, Windows splits, and SIGKILL teardowns) and backend-agnostic bookkeeping (result collection, timeouts, and --max-failures). Adding a thread backend would require messy 'if threads' conditionals across the codebase, which is especially dangerous for abort logic since threads can't be safely killed with SIGKILL.

To solve this, extract an ExecutionBackend abstract class and move all process-specific logic into ProcessPoolBackend. Run now handles the shared collection loop (_wait_for) and selects the backend in a single factory method (_make_backend). This allows thread and async backends to be plugged in seamlessly later.

This is a pure refactor with no behavior changes.