### PR TITLE
[mlir][IntRangeAnalysis] Fix floordiv/ceildiv-by-zero crash in inferAffineExpr

### DIFF
--- a/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
+++ b/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
@@ -877,7 +877,11 @@ mlir::intrange::inferAffineExpr(AffineExpr expr,
         inferAffineExpr(binExpr.getLHS(), dimRanges, symbolRanges);
     ConstantIntRanges rhs =
         inferAffineExpr(binExpr.getRHS(), dimRanges, symbolRanges);
-    // Affine floordiv requires strictly positive divisor (> 0).
+    // Affine floordiv requires a strictly positive divisor. Bail out when the
+    // divisor's maximum is zero (e.g. a literal zero): clamping it would build
+    // an inverted range and divide by zero below; return the full range.
+    if (rhs.smax().isZero())
+      return ConstantIntRanges::maxRange(rhs.smin().getBitWidth());
     // Clamp divisor lower bound to 1 for tighter range inference.
     ConstantIntRanges clampedRhs = clampToPositive(rhs);
     return inferFloorDivS({lhs, clampedRhs});
@@ -888,7 +892,11 @@ mlir::intrange::inferAffineExpr(AffineExpr expr,
         inferAffineExpr(binExpr.getLHS(), dimRanges, symbolRanges);
     ConstantIntRanges rhs =
         inferAffineExpr(binExpr.getRHS(), dimRanges, symbolRanges);
-    // Affine ceildiv requires strictly positive divisor (> 0).
+    // Affine ceildiv requires a strictly positive divisor. Bail out when the
+    // divisor's maximum is zero (e.g. a literal zero): clamping it would build
+    // an inverted range and divide by zero below; return the full range.
+    if (rhs.smax().isZero())
+      return ConstantIntRanges::maxRange(rhs.smin().getBitWidth());
     // Clamp divisor lower bound to 1 for tighter range inference.
     ConstantIntRanges clampedRhs = clampToPositive(rhs);
     return inferCeilDivS({lhs, clampedRhs});

--- a/mlir/test/Dialect/Affine/int-range-interface.mlir
+++ b/mlir/test/Dialect/Affine/int-range-interface.mlir
@@ -171,3 +171,26 @@ func.func @affine_apply_mod_negative_dividend() -> index {
   %1 = test.reflect_bounds %0 : index
   func.return %1 : index
 }
+
+// A literal zero divisor is degenerate (affine floordiv/ceildiv require a
+// strictly positive divisor). Range inference must not divide by zero; it
+// returns the full range instead of crashing.
+// CHECK-LABEL: func @affine_apply_floordiv_zero
+// CHECK: test.reflect_bounds {smax = 9223372036854775807 : index, smin = -9223372036854775808 : index, umax = -1 : index, umin = 0 : index}
+func.func @affine_apply_floordiv_zero() -> index {
+  %d0 = test.with_bounds { umin = 5 : index, umax = 10 : index,
+                           smin = 5 : index, smax = 10 : index } : index
+  %0 = affine.apply affine_map<(d0) -> (d0 floordiv 0)>(%d0)
+  %1 = test.reflect_bounds %0 : index
+  func.return %1 : index
+}
+
+// CHECK-LABEL: func @affine_apply_ceildiv_zero
+// CHECK: test.reflect_bounds {smax = 9223372036854775807 : index, smin = -9223372036854775808 : index, umax = -1 : index, umin = 0 : index}
+func.func @affine_apply_ceildiv_zero() -> index {
+  %d0 = test.with_bounds { umin = 5 : index, umax = 10 : index,
+                           smin = 5 : index, smax = 10 : index } : index
+  %0 = affine.apply affine_map<(d0) -> (d0 ceildiv 0)>(%d0)
+  %1 = test.reflect_bounds %0 : index
+  func.return %1 : index
+}


### PR DESCRIPTION
intrange::inferAffineExpr previously passed the divisor of an affine floordiv/ceildiv through clampToPositive before computing the resulting range. When the divisor’s maximum value is zero (e.g. floordiv 0), this produces an inverted range (smin = 1, smax = 0). Although inferDivSRange later checks smin > 0 and therefore passes its zero-divisor guard, it still ends up using smax = 0 as the divisor in sdiv, resulting in a runtime crash with “Divide by zero?”.

Unlike the Mod case, which explicitly checks isZero() and bails out early, FloorDiv and CeilDiv lacked this safeguard.

This patch fixes the issue by adding an early bailout to return the full range when the divisor’s maximum is zero, before any clamping occurs. This ensures malformed or degenerate divisor ranges are never propagated into division operations, aligning FloorDiv and CeilDiv behavior with the existing Mod handling.

Fixes #205072