### PR TITLE
[clang][ssaf] Add --ssaf-include-local-entities flag

### DIFF
--- a/clang/include/clang/Frontend/SSAFOptions.h
+++ b/clang/include/clang/Frontend/SSAFOptions.h
@@ -41,9 +41,16 @@ public:
   LLVM_PREFERRED_TYPE(bool)
   unsigned ShowFormats : 1;
 
+  /// Include block-scope (function-local) declarations in extracted SSAF
+  /// summaries. Defaults to false to preserve the original behavior.
+  /// Controlled by: --ssaf-include-local-entities
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned IncludeLocalEntities : 1;
+
   SSAFOptions() {
     ShowExtractors = false;
     ShowFormats = false;
+    IncludeLocalEntities = false;
   };
 };
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -982,6 +982,14 @@ def _ssaf_compilation_unit_id :
     "produced SSAF TU summary. Required when '--ssaf-tu-summary-file=' is "
     "set.">,
   MarshallingInfoString<SSAFOpts<"CompilationUnitId">>;
+def _ssaf_include_local_entities :
+  Flag<["--"], "ssaf-include-local-entities">,
+  Group<SSAF_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<
+    "Include block-scope (function-local) declarations in extracted SSAF "
+    "summaries. By default they are omitted.">,
+  MarshallingInfoFlag<SSAFOpts<"IncludeLocalEntities">>;
 def Xarch__
     : JoinedAndSeparate<["-"], "Xarch_">,
       Flags<[NoXarchOption]>,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8077,6 +8077,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_extract_summaries);
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_tu_summary_file);
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_compilation_unit_id);
+  Args.AddLastArg(CmdArgs, options::OPT__ssaf_include_local_entities);
 
   // Handle serialized diagnostics.
   if (Arg *A = Args.getLastArg(options::OPT__serialize_diags)) {

--- a/clang/lib/ScalableStaticAnalysis/Analyses/CallGraph/CallGraphExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/CallGraph/CallGraphExtractor.cpp
@@ -35,6 +35,12 @@ private:
 } // namespace
 
 void CallGraphExtractor::HandleTranslationUnit(ASTContext &Ctx) {
+  // FIXME: Depending on the IncludeLocalEntities option, the extractor should
+  // include or exclude calls to function-local defined:
+  //   - lambda functions
+  //   - methods of local classes
+  // Currently, the extractor always includes these callees, even if
+  // IncludeLocalEntities is false.
   CallGraph CG;
   CG.addToCallGraph(
       const_cast<TranslationUnitDecl *>(Ctx.getTranslationUnitDecl()));

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
@@ -12,9 +12,11 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/ExprCXX.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "llvm/ADT/SetVector.h"
 
 using namespace clang;
+using namespace ssaf;
 
 std::string ssaf::describeJSONValue(const llvm::json::Value &V) {
   return llvm::formatv("{0:2}", V).str();
@@ -33,8 +35,9 @@ namespace {
 class ContributorFinder : public DynamicRecursiveASTVisitor {
 public:
   llvm::SetVector<const NamedDecl *> Contributors;
+  const SSAFOptions &Opts;
 
-  ContributorFinder() {
+  ContributorFinder(const SSAFOptions &Opts) : Opts(Opts) {
     ShouldVisitTemplateInstantiations = true;
     ShouldVisitImplicitCode = false;
   }
@@ -53,7 +56,23 @@ public:
     DeclContext *DC = D->getDeclContext();
 
     // Collects Decl for global variables or static data members:
-    if (DC->isFileContext() || D->isStaticDataMember())
+    if (DC->isFileContext() || D->isStaticDataMember()) {
+      Contributors.insert(D);
+      return true;
+    }
+
+    // Optionally include block-scope (function-local) variables. Parameters
+    // are intentionally skipped: they are exposed via their parent function's
+    // USR + a parameter-index suffix in getEntityName, so registering them as
+    // independent contributors would be redundant.
+    //
+    // FIXME: clang::index::generateUSRForDecl can produce non-unique or empty
+    // USRs for some local declaration shapes (e.g., locals of certain template
+    // instantiations). The current addEntity path returns std::nullopt when
+    // that happens and downstream extractors skip gracefully, so this is
+    // tolerated for now.
+    if (Opts.IncludeLocalEntities && !D->isImplicit() && !isa<ParmVarDecl>(D) &&
+        DC->isFunctionOrMethod())
       Contributors.insert(D);
     return true;
   }
@@ -125,10 +144,10 @@ public:
 } // namespace
 
 void ssaf::findContributors(
-    ASTContext &Ctx,
+    ASTContext &Ctx, const SSAFOptions &Options,
     llvm::DenseMap<const NamedDecl *, std::vector<const NamedDecl *>>
         &Contributors) {
-  ContributorFinder Finder;
+  ContributorFinder Finder{Options};
   Finder.TraverseAST(Ctx);
   for (const NamedDecl *C : Finder.Contributors)
     Contributors[cast<NamedDecl>(C->getCanonicalDecl())].push_back(C);

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.h
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.h
@@ -27,6 +27,8 @@
 #include <memory>
 
 namespace clang::ssaf {
+class SSAFOptions;
+
 ///\return a short descriptions of a json::Value
 std::string describeJSONValue(const llvm::json::Value &V);
 ///\return a short descriptions of a json::Array
@@ -75,8 +77,15 @@ inline void logWarningFromError(llvm::Error Err) {
 /// Find all contributors in an AST. The found contributors are organized as a
 /// map from the canonical declaration of each entity to all of its
 /// declarations.
+///
+/// \p Options controls which declarations qualify as contributors. By default
+/// the visitor preserves the original SSAF behavior of skipping block-scope
+/// (function-local) variable declarations; setting
+/// \c Options.IncludeLocalEntities to \c true also collects local variables
+/// (excluding function parameters, which are addressed via their parent
+/// function's USR).
 void findContributors(
-    ASTContext &Ctx,
+    ASTContext &Ctx, const SSAFOptions &Options,
     llvm::DenseMap<const NamedDecl *, std::vector<const NamedDecl *>>
         &Contributors);
 
@@ -107,7 +116,7 @@ void extractAndAddSummaries(TUSummaryExtractor &Extractor,
                             llvm::StringRef ExtractorName = "") {
   llvm::DenseMap<const NamedDecl *, std::vector<const NamedDecl *>>
       Contributors;
-  findContributors(Ctx, Contributors);
+  findContributors(Ctx, Extractor.getOptions(), Contributors);
   for (const auto &[Cano, Decls] : Contributors) {
     assert(!Decls.empty() &&
            "'findContributors' guarantees that 'Decls' are non-empty");

--- a/clang/test/Analysis/Scalable/call-graph-local-entities.cpp
+++ b/clang/test/Analysis/Scalable/call-graph-local-entities.cpp
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// RUN: %clang_cc1 -fsyntax-only %s \
+// RUN:   --ssaf-extract-summaries=CallGraph \
+// RUN:   --ssaf-compilation-unit-id=test-cu \
+// RUN:   --ssaf-tu-summary-file=%t/cg.default.json
+// RUN: %clang_cc1 -fsyntax-only %s \
+// RUN:   --ssaf-extract-summaries=CallGraph \
+// RUN:   --ssaf-include-local-entities \
+// RUN:   --ssaf-compilation-unit-id=test-cu \
+// RUN:   --ssaf-tu-summary-file=%t/cg.with_locals.json
+
+// FIXME: The next line should assert 1 count because the lambda call operator
+//        should be included only if requested.
+// RUN: cat %t/cg.default.json     | grep '"entity_id":' | count 2
+// RUN: cat %t/cg.with_locals.json | grep '"entity_id":' | count 2
+
+void caller() {
+  auto local = []{};
+  local();
+}

--- a/clang/test/Analysis/Scalable/command-line-interface.cpp
+++ b/clang/test/Analysis/Scalable/command-line-interface.cpp
@@ -13,6 +13,19 @@
 // RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=extractor1,extractor2 2>&1 | %{filecheck}=NO-EXTRACTORS-WITH-NAME
 // RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=extractor1,extractor2 2>&1 | %{filecheck}=NO-EXTRACTORS-WITH-NAME
 
+// Verify --ssaf-include-local-entities is accepted alongside summary extraction
+// in both the driver and CC1, and that without --ssaf-tu-summary-file= the
+// flag is silently ignored (same shape as --ssaf-list-extractors).
+// RUN: rm -rf %t.localents && mkdir %t.localents
+// RUN: %clang     -fsyntax-only %s --ssaf-include-local-entities
+// RUN: %clang_cc1 -fsyntax-only %s --ssaf-include-local-entities
+// RUN: %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.localents/a.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=CallGraph --ssaf-include-local-entities
+// RUN: %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.localents/b.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=CallGraph --ssaf-include-local-entities
+
+// Verify the driver forwards the flag to CC1.
+// RUN: %clang -### -fsyntax-only %s --ssaf-include-local-entities --ssaf-tu-summary-file=%t.localents/c.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=CallGraph 2>&1 | FileCheck %s --check-prefix=DRIVER-FORWARDS-FLAG
+// DRIVER-FORWARDS-FLAG: "-cc1"{{.+}}"--ssaf-include-local-entities"
+
 void empty() {}
 
 // NOT-MATCHING-THE-PATTERN: error: failed to parse the value of '--ssaf-tu-summary-file=foobar' the value must follow the '<path>.<format>' pattern [-Wscalable-static-analysis-framework]

--- a/clang/test/Analysis/Scalable/help.cpp
+++ b/clang/test/Analysis/Scalable/help.cpp
@@ -7,6 +7,8 @@
 // HELP-NEXT:    Stable identifier used as the CompilationUnit namespace name of every produced SSAF TU summary. Required when '--ssaf-tu-summary-file=' is set.
 // HELP-NEXT:  --ssaf-extract-summaries=<summary-names>
 // HELP-NEXT:    Comma-separated list of summary names to extract
+// HELP-NEXT:  --ssaf-include-local-entities
+// HELP-NEXT:    Include block-scope (function-local) declarations in extracted SSAF summaries. By default they are omitted.
 // HELP-NEXT:  --ssaf-list-extractors  Display the list of available SSAF summary extractors
 // HELP-NEXT:  --ssaf-list-formats     Display the list of available SSAF serialization formats
 // HELP-NEXT:  --ssaf-tu-summary-file=<path>.<format>

--- a/clang/test/Analysis/Scalable/local-entities.cpp
+++ b/clang/test/Analysis/Scalable/local-entities.cpp
@@ -1,0 +1,56 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// PointerFlow:
+//  RUN: %clang_cc1 -fsyntax-only %t/local.cpp \
+//  RUN:   --ssaf-extract-summaries=PointerFlow \
+//  RUN:   --ssaf-compilation-unit-id=test-cu \
+//  RUN:   --ssaf-tu-summary-file=%t/pf.default.json
+//  RUN: %clang_cc1 -fsyntax-only %t/local.cpp \
+//  RUN:   --ssaf-extract-summaries=PointerFlow \
+//  RUN:   --ssaf-include-local-entities \
+//  RUN:   --ssaf-compilation-unit-id=test-cu \
+//  RUN:   --ssaf-tu-summary-file=%t/pf.with_locals.json
+
+// With the flag, summary_data must gain one additional entity_id entry for
+// the local pointer.
+// RUN: cat %t/pf.default.json     | grep '"entity_id":' | count 2
+// RUN: cat %t/pf.with_locals.json | grep '"entity_id":' | count 3
+
+// UnsafeBufferUsage:
+//  RUN: %clang_cc1 -fsyntax-only %t/local.cpp \
+//  RUN:   --ssaf-extract-summaries=UnsafeBufferUsage \
+//  RUN:   --ssaf-compilation-unit-id=test-cu \
+//  RUN:   --ssaf-tu-summary-file=%t/ubu.default.json
+//  RUN: %clang_cc1 -fsyntax-only %t/local.cpp \
+//  RUN:   --ssaf-extract-summaries=UnsafeBufferUsage \
+//  RUN:   --ssaf-include-local-entities \
+//  RUN:   --ssaf-compilation-unit-id=test-cu \
+//  RUN:   --ssaf-tu-summary-file=%t/ubu.with_locals.json
+
+// The unsafe subscript happens inside the local var's initializer scope so its
+// own summary is emitted under the flag.
+// RUN: cat %t/ubu.default.json     | grep '"entity_id":' | count 1
+// RUN: cat %t/ubu.with_locals.json | grep '"entity_id":' | count 2
+
+//--- local.cpp
+// Two externally visible entities: 'g_in', 'g_arr'.
+// One local pointer that aliases 'g_in' and is then unsafely subscripted
+// in the initializer of 'unsafe_local'.
+
+// Default run: summary_data has exactly 2 entries:
+// 'use' and the global pointer's initializer
+//
+// With-locals run: a third entity_id entry covers the local pointer's
+// own contributor scope.
+
+int g_arr[10];
+int *g_in = g_arr;
+
+void use(int *param) {
+  int *local_ptr = param;
+  int unsafe_local = local_ptr[3];
+  (void)unsafe_local;
+  (void)g_in;
+}

--- a/clang/unittests/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowTest.cpp
@@ -161,7 +161,8 @@ protected:
   template <typename ContributorDecl = NamedDecl,
             typename =
                 std::enable_if_t<std::is_base_of_v<NamedDecl, ContributorDecl>>>
-  bool setUpTest(StringRef Code) {
+  bool setUpTest(StringRef Code, const SSAFOptions &Opts = {}) {
+    this->Opts = Opts; // Override the options.
     AST = tooling::buildASTFromCodeWithArgs(
         Code, {"-Wno-unused-value", "-Wno-int-to-pointer-cast"});
 
@@ -1573,4 +1574,48 @@ TEST_F(PointerFlowTest, RefBindFunctionCallInitializer) {
   EXPECT_EQ(*Sum, makeEdges(__LINE__, {{{"r", 1U}, {"g", 1U, true}}}));
 }
 
+//////////////////////////////////////////////////////////////
+//          Local-entity inclusion option tests             //
+//////////////////////////////////////////////////////////////
+
+TEST_F(PointerFlowTest, LocalPointerSkippedByDefault) {
+  StringRef Code = R"cpp(
+    void foo(int *param) {
+      int *local_ptr = param;
+      local_ptr = param;
+    }
+  )cpp";
+
+  ASSERT_TRUE(setUpTest(Code));
+
+  // Without IncludeLocalEntities, the local pointer is not registered as a
+  // contributor and therefore has no entity summary of its own.
+  EXPECT_FALSE(getEntitySummary<VarDecl>("local_ptr"));
+  // The enclosing function still has its summary describing the assignment
+  // edge from `local_ptr` to `param` (via the initializer).
+  EXPECT_TRUE(getEntitySummary("foo"));
+}
+
+TEST_F(PointerFlowTest, LocalPointerReportedWhenIncluded) {
+  SSAFOptions Opts;
+  Opts.IncludeLocalEntities = true;
+  StringRef Code = R"cpp(
+    void foo(int *param) {
+      int *local_ptr = param;
+      local_ptr = param;
+    }
+  )cpp";
+
+  ASSERT_TRUE(setUpTest(Code, Opts));
+
+  // With the option enabled, the local pointer becomes a contributor and gets
+  // its own entity summary describing the same edge that was previously only
+  // observable through `foo`.
+  const auto *LocalSum = getEntitySummary<VarDecl>("local_ptr");
+  ASSERT_TRUE(LocalSum);
+  EXPECT_EQ(*LocalSum,
+            makeEdges(__LINE__, {{{"local_ptr", 1U}, {"param", 1U}}}));
+
+  EXPECT_TRUE(getEntitySummary("foo"));
+}
 } // namespace

--- a/clang/unittests/ScalableStaticAnalysis/Analyses/UnsafeBufferUsage/UnsafeBufferUsageTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysis/Analyses/UnsafeBufferUsage/UnsafeBufferUsageTest.cpp
@@ -47,7 +47,8 @@ protected:
               BuildNamespace(BuildNamespaceKind::CompilationUnit, "Mock.cpp")),
         Builder(TUSum, Opts) {}
 
-  bool setUpTest(StringRef Code) {
+  bool setUpTest(StringRef Code, const SSAFOptions &Opts = {}) {
+    this->Opts = Opts; // Override the options.
     AST = tooling::buildASTFromCodeWithArgs(
         Code, {"-Wno-unused-value", "-Wno-int-to-pointer-cast"});
 
@@ -779,5 +780,49 @@ TEST_F(UnsafeBufferUsageTest, StmtExprArrayAccess) {
           .contains("attempt to translate StmtExpr to EntityPointerLevels"));
 }
 #endif
+//////////////////////////////////////////////////////////////
+//          Local-entity inclusion option tests             //
+//////////////////////////////////////////////////////////////
+
+TEST_F(UnsafeBufferUsageTest, LocalVarSkippedByDefault) {
+  // The unsafe subscript p[5] sits inside a local-variable initializer.
+  // Without IncludeLocalEntities, only `use` (the enclosing function) is a
+  // contributor. The initializer is still walked as part of `use`'s body, so
+  // `use` gets a summary attributing the unsafe usage to its parameter.
+  ASSERT_TRUE(setUpTest(R"cpp(
+    int use(int *param) {
+      int x = param[5];
+      return x;
+    }
+  )cpp"));
+
+  EXPECT_TRUE(getEntitySummary("use"));
+  // `x` is not a contributor and therefore has no entity summary of its own.
+  EXPECT_FALSE(getEntitySummary<VarDecl>("x"));
+}
+
+TEST_F(UnsafeBufferUsageTest, LocalVarReportedWhenIncluded) {
+  // With IncludeLocalEntities, the local var `x` becomes its own contributor.
+  // The matcher then walks `x`'s scope (the initializer) and reports the
+  // unsafe subscript on `param` against `x` as well.
+  SSAFOptions Opts;
+  Opts.IncludeLocalEntities = true;
+  ASSERT_TRUE(setUpTest(R"cpp(
+    int use(int *param) {
+      int x = param[5];
+      return x;
+    }
+  )cpp",
+                        Opts));
+
+  // Pre-existing per-function summary is still produced.
+  EXPECT_TRUE(getEntitySummary("use"));
+
+  // The new local-entity summary describes the same unsafe-pointer usage,
+  // but is attributed to the local variable's own scope.
+  const auto *LocalSum = getEntitySummary<VarDecl>("x");
+  ASSERT_TRUE(LocalSum);
+  EXPECT_EQ(*LocalSum, makeSet(__LINE__, {{"param", 1U}}));
+}
 
 } // namespace


### PR DESCRIPTION
This option allows including local entities in summaries. This means that ContributorFinder can optionally include block-scope (function-local) variables.
Parameters are intentionally skipped: they are exposed via their parent function's USR + a parameter-index suffix in getEntityName, so registering them as independent contributors would be redundant.

rdar://179151023