### PR TITLE
[AArch64] Don't call fma/fmaf for @llvm.fmuladd.f64/f32 in softfp

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -19719,7 +19719,7 @@ bool AArch64TargetLowering::isFMAFasterThanFMulAndFAdd(
     return Subtarget->hasFullFP16();
   case MVT::f32:
   case MVT::f64:
-    return true;
+    return Subtarget->hasFPARMv8();
   case MVT::bf16:
     return VT.isScalableVector() && Subtarget->hasBF16() &&
            Subtarget->isNonStreamingSVEorSME2Available();
@@ -19735,7 +19735,7 @@ bool AArch64TargetLowering::isFMAFasterThanFMulAndFAdd(const Function &F,
   switch (Ty->getScalarType()->getTypeID()) {
   case Type::FloatTyID:
   case Type::DoubleTyID:
-    return true;
+    return Subtarget->hasFPARMv8();
   default:
     return false;
   }

--- a/llvm/test/CodeGen/AArch64/aarch64-fmuladd.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-fmuladd.ll
@@ -1,0 +1,47 @@
+; RUN: llc -mtriple=aarch64                      -global-isel=0 %s -o - | FileCheck %s --check-prefix=CHECK,FP
+; RUN: llc -mtriple=aarch64                  -O0 -global-isel=1 %s -o - | FileCheck %s --check-prefix=CHECK,FP
+; RUN: llc -mtriple=aarch64 -mattr=-fp-armv8     -global-isel=0 %s -o - | FileCheck %s --check-prefix=CHECK,NOFP
+; RUN: llc -mtriple=aarch64 -mattr=-fp-armv8 -O0 -global-isel=1 %s -o - | FileCheck %s --check-prefix=CHECK,NOFP
+
+; Test that @llvm.fmuladd, with the semantics "multiply and add can be
+; fused or separate at the compiler's option", fuses them in the
+; normal case of hardware FP, but doesn't fuse them in AArch64 softfp,
+; on the theory that the libc fma function is likely slower than the
+; combination.
+;
+; However, @llvm.fma must fuse them regardless, so that _should_ emit
+; a call to fma in softfp modes.
+
+define float @whichever_float(float %0, float %1, float %2) {
+  %result = call float @llvm.fmuladd.f32(float %0, float %1, float %2)
+  ret float %result
+; CHECK: {{^}}whichever_float:
+; FP: fmadd s0, s0, s1, s2
+; NOFP: bl __mulsf3
+; NOFP: bl __addsf3
+}
+
+define double @whichever_double(double %0, double %1, double %2) {
+  %result = call double @llvm.fmuladd.f64(double %0, double %1, double %2)
+  ret double %result
+; CHECK: {{^}}whichever_double:
+; FP: fmadd d0, d0, d1, d2
+; NOFP: bl __muldf3
+; NOFP: bl __adddf3
+}
+
+define float @force_fma_float(float %0, float %1, float %2) {
+  %result = call float @llvm.fma.f32(float %0, float %1, float %2)
+  ret float %result
+; CHECK: {{^}}force_fma_float:
+; FP: fmadd s0, s0, s1, s2
+; NOFP: bl fmaf
+}
+
+define double @force_fma_double(double %0, double %1, double %2) {
+  %result = call double @llvm.fma.f64(double %0, double %1, double %2)
+  ret double %result
+; CHECK: {{^}}force_fma_double:
+; FP: fmadd d0, d0, d1, d2
+; NOFP: bl fma
+}

--- a/llvm/test/CodeGen/AArch64/aarch64-fmuladd.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-fmuladd.ll
@@ -15,7 +15,7 @@
 define float @whichever_float(float %0, float %1, float %2) {
   %result = call float @llvm.fmuladd.f32(float %0, float %1, float %2)
   ret float %result
-; CHECK: {{^}}whichever_float:
+; CHECK-LABEL: {{^}}whichever_float:
 ; FP: fmadd s0, s0, s1, s2
 ; NOFP: bl __mulsf3
 ; NOFP: bl __addsf3
@@ -24,7 +24,7 @@ define float @whichever_float(float %0, float %1, float %2) {
 define double @whichever_double(double %0, double %1, double %2) {
   %result = call double @llvm.fmuladd.f64(double %0, double %1, double %2)
   ret double %result
-; CHECK: {{^}}whichever_double:
+; CHECK-LABEL: {{^}}whichever_double:
 ; FP: fmadd d0, d0, d1, d2
 ; NOFP: bl __muldf3
 ; NOFP: bl __adddf3
@@ -33,7 +33,7 @@ define double @whichever_double(double %0, double %1, double %2) {
 define float @force_fma_float(float %0, float %1, float %2) {
   %result = call float @llvm.fma.f32(float %0, float %1, float %2)
   ret float %result
-; CHECK: {{^}}force_fma_float:
+; CHECK-LABEL: {{^}}force_fma_float:
 ; FP: fmadd s0, s0, s1, s2
 ; NOFP: bl fmaf
 }
@@ -41,7 +41,7 @@ define float @force_fma_float(float %0, float %1, float %2) {
 define double @force_fma_double(double %0, double %1, double %2) {
   %result = call double @llvm.fma.f64(double %0, double %1, double %2)
   ret double %result
-; CHECK: {{^}}force_fma_double:
+; CHECK-LABEL: {{^}}force_fma_double:
 ; FP: fmadd d0, d0, d1, d2
 ; NOFP: bl fma
 }


### PR DESCRIPTION
@llvm.fmuladd is the IR intrinsic that leaves it up to code generation whether to fuse an FP multiply+add pair or leave them separate. Generally you only fuse them if fused mul+add has good performance.

On AArch64, for the float and double instances of this intrinsic, isel was unconditionally fusing the operations. This is sensible with hardware FP, but a bad idea for the rare case of AArch64 without hardware FP, because that leads to a call to the libm `fma()` or `fmaf()` function. That function generally (in multiple libcs) seems to be much slower than separate mul+add operations. So this patch checks for the presence of FP before reporting that fusing the operations is a performance win.