### PR TITLE
Preserve the result number of a statepoint call target

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
@@ -811,8 +811,11 @@ SDValue SelectionDAGBuilder::LowerAsSTATEPOINT(
       CallNode->getNumOperands() - (CallHasIncomingGlue ? 4 : 3);
   Ops.push_back(DAG.getTargetConstant(NumCallRegArgs, getCurSDLoc(), MVT::i32));
 
-  // Add call target
-  SDValue CallTarget = SDValue(CallNode->getOperand(1).getNode(), 0);
+  // Add call target. Preserve the result index: the callee may be a non-zero
+  // result of a multi-result node (e.g. a field of a by-value struct argument,
+  // which is lowered to a merge_values node). Forcing result 0 here would
+  // silently substitute the struct's first field for the real callee.
+  SDValue CallTarget = CallNode->getOperand(1);
   Ops.push_back(CallTarget);
 
   // Add call arguments

--- a/llvm/test/CodeGen/X86/statepoint-call-target-struct-field.ll
+++ b/llvm/test/CodeGen/X86/statepoint-call-target-struct-field.ll
@@ -1,0 +1,29 @@
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -verify-machineinstrs < %s | FileCheck %s
+
+; The call target of a gc.statepoint may be a field of a by-value aggregate
+; argument, which SelectionDAG lowers to a (possibly non-zero) result of a
+; merge_values node.  LowerAsSTATEPOINT must record that exact SDValue as the
+; call target; it previously rebuilt the operand with result number forced to
+; 0, which silently calls the aggregate's *first* field instead of the intended
+; one.  Here the two statepoints must call through %rsi (field 1) and %rdi
+; (field 0) respectively.
+
+declare token @llvm.experimental.gc.statepoint.p0(i64, i32, ptr, i32, i32, ...)
+
+define void @statepoint_call_target_struct_field({ ptr, ptr } %fns, i1 %cond) gc "statepoint-example" {
+; CHECK-LABEL: statepoint_call_target_struct_field:
+; CHECK:       callq *%rsi
+; CHECK:       callq *%rdi
+entry:
+  br i1 %cond, label %call_field1, label %call_field0
+
+call_field1:
+  %f1 = extractvalue { ptr, ptr } %fns, 1
+  call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 0, i32 0, ptr elementtype(void ()) %f1, i32 0, i32 0, i32 0, i32 0) [ "deopt"() ]
+  ret void
+
+call_field0:
+  %f0 = extractvalue { ptr, ptr } %fns, 0
+  call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 1, i32 0, ptr elementtype(void ()) %f0, i32 0, i32 0, i32 0, i32 0) [ "deopt"() ]
+  ret void
+}


### PR DESCRIPTION
LowerAsSTATEPOINT built the statepoint's call-target operand as

 `SDValue CallTarget = SDValue(CallNode->getOperand(1).getNode(), 0);`

which drops the result number of the call target and forces it to 0. That is fine when the call target is the first (or only) result of its node, as in the common cases (a TargetGlobalAddress, or a pointer loaded from memory). But when the call target is a non-zero result of a multi-result node, it is silently replaced by result 0 of that same node.

This happens, for instance, when the callee is a field of a by-value aggregate argument: such an argument is lowered to a single merge_values node, and field N is SDValue(merge, N). An indirect gc.statepoint through field 2 of the struct was then lowered to call field 0 instead. Two statepoints in different blocks whose callees are different fields of the same struct both collapse to field 0.

Use the call node operand directly so its result number is preserved.