### PR TITLE
[RISCV] Remove isCodeGenOnly=0 from PseudoLA_TLSDESC.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1955,7 +1955,7 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 8,
 def PseudoLA_TLS_GD : Pseudo<(outs GPR:$dst), (ins bare_symbol:$src), [],
                              "la.tls.gd", "$dst, $src">;
 
-let hasSideEffects = 0, mayLoad = 1, mayStore = 0, Size = 32, isCodeGenOnly = 0 in
+let hasSideEffects = 0, mayLoad = 1, mayStore = 0, Size = 32 in
 def PseudoLA_TLSDESC : Pseudo<(outs GPR:$dst), (ins bare_symbol:$src), [],
                              "la.tlsdesc", "$dst, $src">;
 


### PR DESCRIPTION
The default for a Pseudo is isCodeGenOnly=1. With isCodeGenOnly=0 the 'la.tlsdesc' is a valid mnemonic for the assembly parser, but crashes in the encoder.

I don't think this was meant to be a valid assembly mnemonic so remove it.