### PR TITLE
[analyzer] Rename z3 constraint manager backend to unsupported-z3

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -1057,6 +1057,10 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 
 ### Static Analyzer
 
+- The `-analyzer-constraints` option `z3` was renamed to `unsupported-z3`
+  because the Z3-based (constraint) solver was known for crashing for years now.
+  Didn't receive support, so it was marked unsupported.
+
 #### Crash and bug fixes
 
 - Fixed `security.VAList` checker producing false positives when analyzing

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -597,8 +597,8 @@ def err_analyzer_checker_option_invalid_input : Error<
 def err_analyzer_checker_incompatible_analyzer_option : Error<
   "checker cannot be enabled with analyzer option '%0' == %1">;
 def err_analyzer_not_built_with_z3 : Error<
-  "analyzer constraint manager 'z3' is only available if LLVM was built with "
-  "-DLLVM_ENABLE_Z3_SOLVER=ON">;
+  "analyzer constraint manager 'unsupported-z3' is only available if LLVM was "
+  "built with -DLLVM_ENABLE_Z3_SOLVER=ON">;
 
 def warn_drv_needs_hvx : Warning<
   "%0 requires HVX, use -mhvx/-mhvx= to enable it">,

--- a/clang/include/clang/StaticAnalyzer/Core/Analyses.def
+++ b/clang/include/clang/StaticAnalyzer/Core/Analyses.def
@@ -18,7 +18,9 @@ ANALYSIS_CONSTRAINTS(RangeConstraints, "range",
                      "Use constraint tracking of concrete value ranges",
                      CreateRangeConstraintManager)
 
-ANALYSIS_CONSTRAINTS(Z3Constraints, "z3", "Use Z3 contraint solver",
+ANALYSIS_CONSTRAINTS(Z3Constraints, "unsupported-z3",
+                     "[UNSUPPORTED] Z3 SMT solver. Known to crash; patches "
+                     "welcome, crash reports are not.",
                      CreateZ3ConstraintManager)
 
 #ifndef ANALYSIS_DIAGNOSTICS

--- a/clang/test/Analysis/missing-z3-nocrash.c
+++ b/clang/test/Analysis/missing-z3-nocrash.c
@@ -1,5 +1,5 @@
-// RUN: not %clang_analyze_cc1 -analyzer-constraints=z3 %s 2>&1 | FileCheck %s
+// RUN: not %clang_analyze_cc1 -analyzer-constraints=unsupported-z3 %s 2>&1 | FileCheck %s
 // UNSUPPORTED: z3
 
-// CHECK: error: analyzer constraint manager 'z3' is only available if LLVM
-// CHECK: was built with -DLLVM_ENABLE_Z3_SOLVER=ON
+// CHECK: error: analyzer constraint manager 'unsupported-z3' is only available
+// CHECK-SAME: if LLVM was built with -DLLVM_ENABLE_Z3_SOLVER=ON

--- a/clang/test/Analysis/z3/D83660.c
+++ b/clang/test/Analysis/z3/D83660.c
@@ -1,6 +1,6 @@
 // RUN: env Z3_SOLVER_RESULTS="SAT,SAT,SAT,SAT,UNDEF" \
 // RUN: LD_PRELOAD="%llvmshlibdir/MockZ3SolverCheck%pluginext" \
-// RUN: %clang_analyze_cc1 -analyzer-constraints=z3 \
+// RUN: %clang_analyze_cc1 -analyzer-constraints=unsupported-z3 \
 // RUN:   -analyzer-checker=core %s -verify
 //
 // REQUIRES: z3, z3-mock, asserts, system-linux

--- a/clang/test/Analysis/z3/pretty-dump.c
+++ b/clang/test/Analysis/z3/pretty-dump.c
@@ -1,4 +1,4 @@
-// RUN: %clang_analyze_cc1 -analyzer-constraints=z3 \
+// RUN: %clang_analyze_cc1 -analyzer-constraints=unsupported-z3 \
 // RUN:   -analyzer-checker=core,debug.ExprInspection %s 2>&1 | FileCheck %s
 //
 // REQUIRES: z3

--- a/clang/test/Analysis/z3/z3-unarysymexpr.c
+++ b/clang/test/Analysis/z3/z3-unarysymexpr.c
@@ -1,5 +1,5 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection -verify %s \
-// RUN:  -analyzer-constraints=z3
+// RUN:  -analyzer-constraints=unsupported-z3
 // RUN: %clang_analyze_cc1 -verify %s \
 // RUN:  -analyzer-checker=core,debug.ExprInspection \
 // RUN:  -analyzer-config crosscheck-with-z3=true


### PR DESCRIPTION
The Z3 constraint manager backend (selected via -analyzer-constraints=z3) is unmaintained and known to crash on real-world input. Rename the user-facing flag to unsupported-z3 and reword its description so users see up front that the backend is unsupported and crash-prone -- patches welcome, crash reports are not.

Assisted-By: claude