### PR TITLE
[TableGen] Use llvm_unreachable in switch guard for all except gcc 8-

### DIFF
--- a/llvm/test/TableGen/directive1.td
+++ b/llvm/test/TableGen/directive1.td
@@ -143,9 +143,11 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:    case TDLD_dira:
 // CHECK-NEXT:      return Association::None;
 // CHECK-NEXT:    } // switch (Dir)
-// CHECK-NEXT:    assert(llvm::to_underlying(Dir) >= llvm::to_underlying(Directive::First_) &&
-// CHECK-NEXT:           llvm::to_underlying(Dir) <= llvm::to_underlying(Directive::Last_) &&
-// CHECK-NEXT:           "Unexpected directive");
+// CHECK-NEXT:  #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 9
+// CHECK-NEXT:    abort();
+// CHECK-NEXT:  #else
+// CHECK-NEXT:    llvm_unreachable("Unexpected directive");
+// CHECK-NEXT:  #endif
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
 // CHECK-NEXT:  constexpr Category getDirectiveCategory(Directive Dir) {
@@ -153,9 +155,11 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:    case TDLD_dira:
 // CHECK-NEXT:      return Category::Executable;
 // CHECK-NEXT:    } // switch (Dir)
-// CHECK-NEXT:    assert(llvm::to_underlying(Dir) >= llvm::to_underlying(Directive::First_) &&
-// CHECK-NEXT:           llvm::to_underlying(Dir) <= llvm::to_underlying(Directive::Last_) &&
-// CHECK-NEXT:           "Unexpected directive");
+// CHECK-NEXT:  #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 9
+// CHECK-NEXT:    abort();
+// CHECK-NEXT:  #else
+// CHECK-NEXT:    llvm_unreachable("Unexpected directive");
+// CHECK-NEXT:  #endif
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
 // CHECK-NEXT:  constexpr SourceLanguage getDirectiveLanguages(Directive D) {
@@ -163,9 +167,11 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:    case TDLD_dira:
 // CHECK-NEXT:      return SourceLanguage::C | SourceLanguage::Fortran;
 // CHECK-NEXT:    } // switch(D)
-// CHECK-NEXT:    assert(llvm::to_underlying(D) >= llvm::to_underlying(Directive::First_) &&
-// CHECK-NEXT:           llvm::to_underlying(D) <= llvm::to_underlying(Directive::Last_) &&
-// CHECK-NEXT:           "Unexpected directive");
+// CHECK-NEXT:  #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 9
+// CHECK-NEXT:    abort();
+// CHECK-NEXT:  #else
+// CHECK-NEXT:    llvm_unreachable("Unexpected directive");
+// CHECK-NEXT:  #endif
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
 // CHECK-NEXT:  // Enumeration helper functions

--- a/llvm/test/TableGen/directive2.td
+++ b/llvm/test/TableGen/directive2.td
@@ -119,9 +119,11 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:    case TDLD_dira:
 // CHECK-NEXT:      return Association::Block;
 // CHECK-NEXT:    } // switch (Dir)
-// CHECK-NEXT:    assert(llvm::to_underlying(Dir) >= llvm::to_underlying(Directive::First_) &&
-// CHECK-NEXT:           llvm::to_underlying(Dir) <= llvm::to_underlying(Directive::Last_) &&
-// CHECK-NEXT:           "Unexpected directive");
+// CHECK-NEXT:  #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 9
+// CHECK-NEXT:    abort();
+// CHECK-NEXT:  #else
+// CHECK-NEXT:    llvm_unreachable("Unexpected directive");
+// CHECK-NEXT:  #endif
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
 // CHECK-NEXT:  constexpr Category getDirectiveCategory(Directive Dir) {
@@ -129,9 +131,11 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:    case TDLD_dira:
 // CHECK-NEXT:      return Category::Declarative;
 // CHECK-NEXT:    } // switch (Dir)
-// CHECK-NEXT:    assert(llvm::to_underlying(Dir) >= llvm::to_underlying(Directive::First_) &&
-// CHECK-NEXT:           llvm::to_underlying(Dir) <= llvm::to_underlying(Directive::Last_) &&
-// CHECK-NEXT:           "Unexpected directive");
+// CHECK-NEXT:  #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 9
+// CHECK-NEXT:    abort();
+// CHECK-NEXT:  #else
+// CHECK-NEXT:    llvm_unreachable("Unexpected directive");
+// CHECK-NEXT:  #endif
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
 // CHECK-NEXT:  constexpr SourceLanguage getDirectiveLanguages(Directive D) {
@@ -139,9 +143,11 @@ def TDL_DirA : Directive<[Spelling<"dira">]> {
 // CHECK-NEXT:    case TDLD_dira:
 // CHECK-NEXT:      return SourceLanguage::C | SourceLanguage::Fortran;
 // CHECK-NEXT:    } // switch(D)
-// CHECK-NEXT:    assert(llvm::to_underlying(D) >= llvm::to_underlying(Directive::First_) &&
-// CHECK-NEXT:           llvm::to_underlying(D) <= llvm::to_underlying(Directive::Last_) &&
-// CHECK-NEXT:           "Unexpected directive");
+// CHECK-NEXT:  #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 9
+// CHECK-NEXT:    abort();
+// CHECK-NEXT:  #else
+// CHECK-NEXT:    llvm_unreachable("Unexpected directive");
+// CHECK-NEXT:  #endif
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
 // CHECK-NEXT:  // Enumeration helper functions

--- a/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
@@ -850,11 +850,11 @@ static void generateGetDirectiveAssociation(const DirectiveLanguage &DirLang,
     }
   }
   OS << "  } // switch (Dir)\n";
-  OS << "  assert(llvm::to_underlying(Dir) >= "
-        "llvm::to_underlying(Directive::First_) &&\n";
-  OS << "         llvm::to_underlying(Dir) <= "
-        "llvm::to_underlying(Directive::Last_) &&\n";
-  OS << "         \"Unexpected directive\");\n";
+  OS << "#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 9\n";
+  OS << "  abort();\n";
+  OS << "#else\n";
+  OS << "  llvm_unreachable(\"Unexpected directive\");\n";
+  OS << "#endif\n";
   OS << "}\n";
 }
 
@@ -872,11 +872,11 @@ static void generateGetDirectiveCategory(const DirectiveLanguage &DirLang,
        << ";\n";
   }
   OS << "  } // switch (Dir)\n";
-  OS << "  assert(llvm::to_underlying(Dir) >= "
-        "llvm::to_underlying(Directive::First_) &&\n";
-  OS << "         llvm::to_underlying(Dir) <= "
-        "llvm::to_underlying(Directive::Last_) &&\n";
-  OS << "         \"Unexpected directive\");\n";
+  OS << "#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 9\n";
+  OS << "  abort();\n";
+  OS << "#else\n";
+  OS << "  llvm_unreachable(\"Unexpected directive\");\n";
+  OS << "#endif\n";
   OS << "}\n";
 }
 
@@ -901,11 +901,11 @@ static void generateGetDirectiveLanguages(const DirectiveLanguage &DirLang,
     OS << ";\n";
   }
   OS << "  } // switch(D)\n";
-  OS << "  assert(llvm::to_underlying(D) >= "
-        "llvm::to_underlying(Directive::First_) &&\n";
-  OS << "         llvm::to_underlying(D) <= "
-        "llvm::to_underlying(Directive::Last_) &&\n";
-  OS << "         \"Unexpected directive\");\n";
+  OS << "#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 9\n";
+  OS << "  abort();\n";
+  OS << "#else\n";
+  OS << "  llvm_unreachable(\"Unexpected directive\");\n";
+  OS << "#endif\n";
   OS << "}\n";
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/llvm/llvm-project/pull/194728.

For gccs older than v9 use abort. That seems to make everybody happy.