### PR TITLE
[AMDGPU] Fix SimplifyDemandedBitsForTargetNode for set.inactive intrinsic.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -5851,11 +5851,22 @@ bool AMDGPUTargetLowering::SimplifyDemandedBitsForTargetNode(
     switch (Op.getConstantOperandVal(0)) {
     case Intrinsic::amdgcn_readfirstlane:
     case Intrinsic::amdgcn_readlane:
-    case Intrinsic::amdgcn_set_inactive:
     case Intrinsic::amdgcn_wwm: {
       if (SimplifyDemandedBits(Op.getOperand(1), OriginalDemandedBits,
                                OriginalDemandedElts, Known, TLO, Depth + 1))
         return true;
+      break;
+    }
+    case Intrinsic::amdgcn_set_inactive: {
+      KnownBits KnownInactive;
+      if (SimplifyDemandedBits(Op.getOperand(1), OriginalDemandedBits,
+                               OriginalDemandedElts, Known, TLO, Depth + 1))
+        return true;
+      if (SimplifyDemandedBits(Op.getOperand(2), OriginalDemandedBits,
+                               OriginalDemandedElts, KnownInactive, TLO,
+                               Depth + 1))
+        return true;
+      Known = Known.intersectWith(KnownInactive);
       break;
     }
     default:

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-demanded-bits-for-target-node.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-demanded-bits-for-target-node.ll
@@ -263,4 +263,52 @@ define i16 @set.inactive_demanded_i16_sext(i16 %src) nounwind {
   ret i16 %trunc
 }
 
+define i16 @set.inactive_demanded_i16_i16_sext(i16 %src1, i16 %src2) nounwind {
+; GCN-LABEL: set.inactive_demanded_i16_i16_sext:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    ; kill: def $vgpr0 killed $vgpr0 killed $exec
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+  %sext1 = sext i16 %src1 to i32
+  %sext2 = sext i16 %src2 to i32
+  %set.inactive = call i32 @llvm.amdgcn.set.inactive.i32(i32 %sext1, i32 %sext2)
+  %trunc = trunc i32 %set.inactive to i16
+  ret i16 %trunc
+}
 
+define i16 @set.inactive_demanded_i16_i16_zext(i16 %src1, i16 %src2) nounwind {
+; GCN-LABEL: set.inactive_demanded_i16_i16_zext:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    ; kill: def $vgpr0 killed $vgpr0 killed $exec
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+  %zext1 = zext i16 %src1 to i32
+  %zext2 = zext i16 %src2 to i32
+  %set.inactive = call i32 @llvm.amdgcn.set.inactive.i32(i32 %zext1, i32 %zext2)
+  %trunc = trunc i32 %set.inactive to i16
+  ret i16 %trunc
+}
+
+define i16 @set.inactive_demanded_i32_i16_sext(i32 %src1, i16 %src2) nounwind {
+; GCN-LABEL: set.inactive_demanded_i32_i16_sext:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    ; kill: def $vgpr0 killed $vgpr0 killed $exec
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+  %sext = sext i16 %src2 to i32
+  %set.inactive = call i32 @llvm.amdgcn.set.inactive.i32(i32 %src1, i32 %sext)
+  %trunc = trunc i32 %set.inactive to i16
+  ret i16 %trunc
+}
+
+define i16 @set.inactive_demanded_i16_i32_sext(i16 %src1, i32 %src2) nounwind {
+; GCN-LABEL: set.inactive_demanded_i16_i32_sext:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    ; kill: def $vgpr0 killed $vgpr0 killed $exec
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+  %sext = sext i16 %src1 to i32
+  %set.inactive = call i32 @llvm.amdgcn.set.inactive.i32(i32 %sext, i32 %src2)
+  %trunc = trunc i32 %set.inactive to i16
+  ret i16 %trunc
+}

--- a/llvm/test/CodeGen/AMDGPU/fix-wwm-vgpr-copy.ll
+++ b/llvm/test/CodeGen/AMDGPU/fix-wwm-vgpr-copy.ll
@@ -6,24 +6,27 @@
 define amdgpu_hs void @wwm(i32 inreg %arg, ptr addrspace(8) inreg %buffer) {
 ; GCN-LABEL: wwm:
 ; GCN:       ; %bb.0: ; %entry
-; GCN-NEXT:    s_mov_b32 s7, s4
-; GCN-NEXT:    s_mov_b32 s4, s1
-; GCN-NEXT:    s_mov_b32 s1, 16
 ; GCN-NEXT:    s_mov_b32 s6, s3
 ; GCN-NEXT:    s_mov_b32 s5, s2
-; GCN-NEXT:    v_mov_b32_e32 v0, s1
+; GCN-NEXT:    s_or_saveexec_b64 s[2:3], -1
+; GCN-NEXT:    s_mov_b32 s7, s4
+; GCN-NEXT:    s_mov_b32 s4, s1
+; GCN-NEXT:    s_mov_b32 s1, 1
+; GCN-NEXT:    v_cndmask_b32_e64 v0, 1, 4, s[2:3]
+; GCN-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GCN-NEXT:    s_mov_b64 exec, s[2:3]
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 0
-; GCN-NEXT:    s_mov_b32 s0, 0
-; GCN-NEXT:    s_cbranch_scc1 .LBB0_2
-; GCN-NEXT:  ; %bb.1:
-; GCN-NEXT:    s_mov_b32 s0, 1
+; GCN-NEXT:    v_mov_b32_e32 v1, v0
+; GCN-NEXT:    s_cbranch_scc0 .LBB0_2
+; GCN-NEXT:  ; %bb.1: ; %bb42
+; GCN-NEXT:    s_mov_b32 s1, 0
 ; GCN-NEXT:  .LBB0_2: ; %bb602
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, s0, v0
+; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, s1, v1
 ; GCN-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GCN-NEXT:    s_cbranch_execz .LBB0_4
 ; GCN-NEXT:  ; %bb.3: ; %bb49
-; GCN-NEXT:    v_mov_b32_e32 v0, 1.0
-; GCN-NEXT:    tbuffer_store_format_x v0, off, s[4:7], 1 format:[BUF_DATA_FORMAT_32,BUF_NUM_FORMAT_FLOAT] offset:4 glc
+; GCN-NEXT:    v_mov_b32_e32 v1, 1.0
+; GCN-NEXT:    tbuffer_store_format_x v1, off, s[4:7], 1 format:[BUF_DATA_FORMAT_32,BUF_NUM_FORMAT_FLOAT] offset:4 glc
 ; GCN-NEXT:  .LBB0_4: ; %UnifiedReturnBlock
 ; GCN-NEXT:    s_endpgm
 entry:
@@ -58,24 +61,27 @@ work:
 define amdgpu_hs void @strict_wwm(i32 inreg %arg, ptr addrspace(8) inreg %buffer) {
 ; GCN-LABEL: strict_wwm:
 ; GCN:       ; %bb.0: ; %entry
-; GCN-NEXT:    s_mov_b32 s7, s4
-; GCN-NEXT:    s_mov_b32 s4, s1
-; GCN-NEXT:    s_mov_b32 s1, 16
 ; GCN-NEXT:    s_mov_b32 s6, s3
 ; GCN-NEXT:    s_mov_b32 s5, s2
-; GCN-NEXT:    v_mov_b32_e32 v0, s1
+; GCN-NEXT:    s_or_saveexec_b64 s[2:3], -1
+; GCN-NEXT:    s_mov_b32 s7, s4
+; GCN-NEXT:    s_mov_b32 s4, s1
+; GCN-NEXT:    s_mov_b32 s1, 1
+; GCN-NEXT:    v_cndmask_b32_e64 v0, 1, 4, s[2:3]
+; GCN-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GCN-NEXT:    s_mov_b64 exec, s[2:3]
 ; GCN-NEXT:    s_cmp_lg_u32 s0, 0
-; GCN-NEXT:    s_mov_b32 s0, 0
-; GCN-NEXT:    s_cbranch_scc1 .LBB1_2
-; GCN-NEXT:  ; %bb.1:
-; GCN-NEXT:    s_mov_b32 s0, 1
+; GCN-NEXT:    v_mov_b32_e32 v1, v0
+; GCN-NEXT:    s_cbranch_scc0 .LBB1_2
+; GCN-NEXT:  ; %bb.1: ; %bb42
+; GCN-NEXT:    s_mov_b32 s1, 0
 ; GCN-NEXT:  .LBB1_2: ; %bb602
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, s0, v0
+; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, s1, v1
 ; GCN-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GCN-NEXT:    s_cbranch_execz .LBB1_4
 ; GCN-NEXT:  ; %bb.3: ; %bb49
-; GCN-NEXT:    v_mov_b32_e32 v0, 1.0
-; GCN-NEXT:    tbuffer_store_format_x v0, off, s[4:7], 1 format:[BUF_DATA_FORMAT_32,BUF_NUM_FORMAT_FLOAT] offset:4 glc
+; GCN-NEXT:    v_mov_b32_e32 v1, 1.0
+; GCN-NEXT:    tbuffer_store_format_x v1, off, s[4:7], 1 format:[BUF_DATA_FORMAT_32,BUF_NUM_FORMAT_FLOAT] offset:4 glc
 ; GCN-NEXT:  .LBB1_4: ; %UnifiedReturnBlock
 ; GCN-NEXT:    s_endpgm
 entry:


### PR DESCRIPTION
Fixes a soundness issue introduced in #190830.

The previous patch handled set.inactive together with the single-operand lane intrinsics, deriving known bits only from operand 1 (the active value).
But set.inactive(%active, %inactive) returns %active in active lanes and %inactive in inactive lanes, so the result's known bits must be the intersection of both operands — using operand 1 alone over-claims known bits.
This patch handles set.inactive like a select: it calls SimplifyDemandedBits on both value operands and intersects the resulting known bits. The CHECK lines in fix-wwm-vgpr-copy.ll are updated to the corrected (longer) codegen.
Also adds new test cases for set.inactive.