### PR TITLE
[MetaRenamer] Change basic block naming from 'bb' to 'bbl'

### DIFF
--- a/llvm/lib/Transforms/Utils/MetaRenamer.cpp
+++ b/llvm/lib/Transforms/Utils/MetaRenamer.cpp
@@ -120,7 +120,7 @@ void MetaRename(Function &F) {
       Arg.setName("arg");
 
   for (auto &BB : F) {
-    BB.setName("bb");
+    BB.setName("bbl");
 
     for (auto &I : BB)
       if (!I.getType()->isVoidTy())

--- a/llvm/test/Transforms/MetaRenamer/metarenamer.ll
+++ b/llvm/test/Transforms/MetaRenamer/metarenamer.ll
@@ -98,7 +98,7 @@ declare void @free(ptr nocapture)
 
 define void @dont_rename_lib_funcs() {
 ; CHECK-LABEL: @foo(
-; CHECK-NEXT:  bb:
+; CHECK-NEXT:  bbl:
 ; CHECK-NEXT:    [[TMP:%.*]] = call ptr @malloc(i64 23)
 ; CHECK-NEXT:    call void @free(ptr [[TMP]])
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/MetaRenamer/opcodes.ll
+++ b/llvm/test/Transforms/MetaRenamer/opcodes.ll
@@ -1,22 +1,22 @@
 ; RUN: opt -passes=metarenamer -S < %s | FileCheck %s
 
 define void @opcodes(ptr %p, ptr %arr) {
-; CHECK-LABEL: bb:
+; CHECK-LABEL: bbl:
 ; CHECK:         %load = load i32, ptr %arg, align 4
-; CHECK:         br label %bb2
-; CHECK-LABEL: bb2:                                              ; preds = %bb5, %bb
-; CHECK:         %phi = phi i32 [ %load, %bb ], [ %sub, %bb5 ]
+; CHECK:         br label %bbl2
+; CHECK-LABEL: bbl2:                                              ; preds = %bbl5, %bbl
+; CHECK:         %phi = phi i32 [ %load, %bbl ], [ %sub, %bbl5 ]
 ; CHECK:         %icmp = icmp eq i32 %phi, 0
-; CHECK:         br i1 %icmp, label %bb8, label %bb3
-; CHECK-LABEL: bb3:                                              ; preds = %bb2
+; CHECK:         br i1 %icmp, label %bbl8, label %bbl3
+; CHECK-LABEL: bbl3:                                              ; preds = %bbl2
 ; CHECK:         %sub = sub i32 %phi, 1
 ; CHECK:         %icmp4 = icmp ult i32 %sub, %load
-; CHECK:         br i1 %icmp4, label %bb5, label %bb9
-; CHECK-LABEL: bb5:                                              ; preds = %bb3
+; CHECK:         br i1 %icmp4, label %bbl5, label %bbl9
+; CHECK-LABEL: bbl5:                                              ; preds = %bbl3
 ; CHECK:         %getelementptr = getelementptr i32, ptr %arg, i32 %phi
 ; CHECK:         %load6 = load i32, ptr %getelementptr, align 4
 ; CHECK:         %icmp7 = icmp eq i32 %load6, 0
-; CHECK:         br i1 %icmp7, label %bb2, label %bb8
+; CHECK:         br i1 %icmp7, label %bbl2, label %bbl8
 preheader:
   %len = load i32, ptr %p
   br label %loop


### PR DESCRIPTION
Currently, `update_test_checks.py` warns when run on MetaRenamer output e.g., `WARNING: Change IR value name 'bb3' or use --prefix-filecheck-ir-name to prevent possible conflict with scripted FileCheck name.`

Avoid this conflict by changing MetaRenamer to use 'bbl' for basic blocks.

This is similar in spirit to
https://github.com/llvm/llvm-project/commit/86a63b2ae147e5a3edc39643783acfd39b059c92, which renamed instructions from 'tmp' to 'inst' to avoid a conflict with automatically-generated checks.