### PR TITLE
[Clang] Disable C++ exceptions by default for GPU targets

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -136,6 +136,7 @@ shouldUseExceptionTablesForObjCExceptions(const ObjCRuntime &runtime,
 /// disable C++ exceptions but enable Objective-C exceptions.
 static bool addExceptionArgs(const ArgList &Args, types::ID InputType,
                              const ToolChain &TC, bool KernelOrKext,
+                             bool IsDeviceOffloadAction,
                              const ObjCRuntime &objcRuntime,
                              ArgStringList &CmdArgs) {
   const llvm::Triple &Triple = TC.getTriple();
@@ -179,9 +180,10 @@ static bool addExceptionArgs(const ArgList &Args, types::ID InputType,
   }
 
   if (types::isCXX(InputType)) {
-    // Disable C++ EH by default on XCore and PS4/PS5.
+    // Disable C++ EH by default on XCore, PS4/PS5 and GPU targets.
     bool CXXExceptionsEnabled = Triple.getArch() != llvm::Triple::xcore &&
-                                !Triple.isPS() && !Triple.isDriverKit();
+                                !Triple.isPS() && !Triple.isDriverKit() &&
+                                !(Triple.isGPU() && !IsDeviceOffloadAction);
     Arg *ExceptionArg = Args.getLastArg(
         options::OPT_fcxx_exceptions, options::OPT_fno_cxx_exceptions,
         options::OPT_fexceptions, options::OPT_fno_exceptions);
@@ -7712,7 +7714,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   // Handle GCC-style exception args.
   bool EH = false;
   if (!C.getDriver().IsCLMode())
-    EH = addExceptionArgs(Args, InputType, TC, KernelOrKext, Runtime, CmdArgs);
+    EH = addExceptionArgs(Args, InputType, TC, KernelOrKext,
+                          IsDeviceOffloadAction, Runtime, CmdArgs);
 
   // Handle exception personalities
   Arg *A = Args.getLastArg(

--- a/clang/test/Driver/gpu-exceptions.cpp
+++ b/clang/test/Driver/gpu-exceptions.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a -nogpulib %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=NOEXC
+// RUN: %clang -### --target=nvptx64-nvidia-cuda -march=sm_80 -nogpulib %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=NOEXC
+
+// Check that the default can still be overridden.
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a -nogpulib -fexceptions %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=EXC
+
+// Check that offloading languages still use their own handling.
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp \
+// RUN:   --offload-arch=gfx90a -nogpulib -nogpuinc %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=OPENMP
+
+// NOEXC-NOT: "-fcxx-exceptions"
+// NOEXC-NOT: "-fexceptions"
+
+// EXC: "-fcxx-exceptions"
+// EXC: "-fexceptions"
+
+// OPENMP: "-cc1"{{.*}}"-triple" "amdgcn-amd-amdhsa"
+// OPENMP-SAME: "-fcxx-exceptions"
+
+int main() { return 0; }

--- a/clang/test/Driver/gpu-exceptions.cpp
+++ b/clang/test/Driver/gpu-exceptions.cpp
@@ -2,6 +2,8 @@
 // RUN:   | FileCheck %s --check-prefix=NOEXC
 // RUN: %clang -### --target=nvptx64-nvidia-cuda -march=sm_80 -nogpulib %s 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=NOEXC
+// RUN: %clang -### --target=spirv64-- -nogpulib %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=NOEXC
 
 // Check that the default can still be overridden.
 // RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a -nogpulib -fexceptions %s 2>&1 \


### PR DESCRIPTION
Summary:
Exceptions are not supporter, and likely will never be supported, on
GPUs. The SIMT model makes context switching nearly impossible, and
building an unwinder would require stashing a register file that is
over 8 KiB these days. There's precedent to disable this for the target,
so we should just do this.

Offloading languages have their own weird handling, some chimera that
just accepts exceptions but turns them into traps on the device side, so
we leave that unaffected.
