### PR TITLE
[SystemZ] Add missing asserts requirement for pre-RA sched mir tests

### DIFF
--- a/llvm/test/CodeGen/SystemZ/misched-prera-loads.mir
+++ b/llvm/test/CodeGen/SystemZ/misched-prera-loads.mir
@@ -1,6 +1,7 @@
 # RUN: llc -o - %s -mtriple=s390x-linux-gnu -mcpu=z17 -verify-machineinstrs \
 # RUN:   -run-pass=machine-scheduler -debug-only=machine-scheduler \
 # RUN:   2>&1 | FileCheck %s
+# REQUIRES: asserts
 
 --- |
 

--- a/llvm/test/CodeGen/SystemZ/misched-prera-pdiffs.mir
+++ b/llvm/test/CodeGen/SystemZ/misched-prera-pdiffs.mir
@@ -1,6 +1,7 @@
 # RUN: llc -o - %s -mtriple=s390x-linux-gnu -mcpu=z16 -verify-machineinstrs \
 # RUN:   -run-pass=machine-scheduler -debug-only=machine-scheduler 2>&1\
 # RUN:   | FileCheck %s
+# REQUIRES: asserts
 
 # Some tests for Pressure Diffs of scheduling units. Each interesting register
 # class is used in a def-use sequence and the initial Pressure Diff of each SU


### PR DESCRIPTION
This is based off https://github.com/llvm/llvm-project/pull/188823 and is needed because tests are failing in release (non-asserts) builds