### PR TITLE
[infra] Exclude libc config files from RISC-V label

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -1082,12 +1082,16 @@ backend:MIPS:
       - '**/*Mips*/**'
 
 backend:RISC-V:
+- all:
   - changed-files:
     - any-glob-to-any-file:
       - '**/*riscv*'
       - '**/*RISCV*'
       - '**/*riscv*/**'
       - '**/*RISCV*/**'
+    # Exclude tagging libc config changes
+    - all-globs-to-all-files:
+      - '!libc/config/**'
 
 backend:Xtensa:
   - changed-files:

--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -1082,15 +1082,9 @@ backend:MIPS:
       - '**/*Mips*/**'
 
 backend:RISC-V:
-- all:
   - changed-files:
-    - any-glob-to-any-file:
-      - '**/*riscv*'
-      - '**/*RISCV*'
-      - '**/*riscv*/**'
-      - '**/*RISCV*/**'
-    # Exclude tagging libc config changes
-    - all-globs-to-all-files:
+    - all-globs-to-any-file:
+      - '{**/*riscv**,**/*RISCV**,**/*riscv*/**,**/*RISCV*/**}'
       - '!libc/config/**'
 
 backend:Xtensa:


### PR DESCRIPTION
Currently, almost every single new function in libc is tagged with `backend:RISC-V` because the configurations in `libc/config/**/riscv` are changed when adding a function.

The intention of this PR is to exclude only changes to `libc/config` which touch `riscv` paths from being tagged. There are other files/directories in libc which contain risc-v specific code, which should continue to be tagged with `backend:RISC-V`.

I'm not 100% sure of the syntax here, but I based this PR on this example in the labeller readme:
https://github.com/actions/labeler/blob/f612d9ad188e81643862c2de70f57fbb1d17abd1/README.md?plain=1#L141-L145