### PR TITLE
Revert "[NFC][Support] Implement slash-agnostic path matching in GlobPattern"

### DIFF
--- a/llvm/include/llvm/Support/GlobPattern.h
+++ b/llvm/include/llvm/Support/GlobPattern.h
@@ -56,8 +56,7 @@ public:
   ///                       created from expanding braces otherwise disable
   ///                       brace expansion
   LLVM_ABI static Expected<GlobPattern>
-  create(StringRef Pat, std::optional<size_t> MaxSubPatterns = {},
-         bool SlashAgnostic = false);
+  create(StringRef Pat, std::optional<size_t> MaxSubPatterns = {});
   /// \returns \p true if \p S matches this glob pattern
   LLVM_ABI bool match(StringRef S) const;
 
@@ -88,14 +87,12 @@ private:
   StringRef Pattern;
   size_t PrefixSize = 0;
   size_t SuffixSize = 0;
-  bool SlashAgnostic = false;
 
   struct SubGlobPattern {
     /// \param Pat the pattern to match against
-    LLVM_ABI static Expected<SubGlobPattern> create(StringRef Pat,
-                                                    bool SlashAgnostic);
+    LLVM_ABI static Expected<SubGlobPattern> create(StringRef Pat);
     /// \returns \p true if \p S matches this glob pattern
-    LLVM_ABI bool match(StringRef S, bool SlashAgnostic) const;
+    LLVM_ABI bool match(StringRef S) const;
     StringRef getPat() const { return StringRef(Pat.data(), Pat.size()); }
 
     // Brackets with their end position and matched bytes.

--- a/llvm/lib/Support/GlobPattern.cpp
+++ b/llvm/lib/Support/GlobPattern.cpp
@@ -18,8 +18,6 @@ using namespace llvm;
 
 static constexpr char PrefixMetacharacters[] = "?*[{\\";
 static constexpr char SuffixMetacharacters[] = "?*[]{}\\";
-static constexpr char PrefixMetacharactersWithSlash[] = "?*[{\\/";
-static constexpr char SuffixMetacharactersWithSlash[] = "?*[]{}\\/";
 
 // Expands character ranges and returns a bitmap.
 // For example, "a-cf-hz" is expanded to "abcfghz".
@@ -137,12 +135,10 @@ parseBraceExpansions(StringRef S, std::optional<size_t> MaxSubPatterns) {
   return std::move(SubPatterns);
 }
 
-static StringRef maxPlainSubstring(StringRef S, bool SlashAgnostic) {
-  const char *Metas =
-      SlashAgnostic ? PrefixMetacharactersWithSlash : PrefixMetacharacters;
+static StringRef maxPlainSubstring(StringRef S) {
   StringRef Best;
   while (!S.empty()) {
-    size_t PrefixSize = S.find_first_of(Metas);
+    size_t PrefixSize = S.find_first_of(PrefixMetacharacters);
     if (PrefixSize == std::string::npos)
       PrefixSize = S.size();
 
@@ -182,20 +178,13 @@ static StringRef maxPlainSubstring(StringRef S, bool SlashAgnostic) {
   return Best;
 }
 
-Expected<GlobPattern> GlobPattern::create(StringRef S,
-                                          std::optional<size_t> MaxSubPatterns,
-                                          bool SlashAgnostic) {
+Expected<GlobPattern>
+GlobPattern::create(StringRef S, std::optional<size_t> MaxSubPatterns) {
   GlobPattern Pat;
-  Pat.SlashAgnostic = SlashAgnostic;
   Pat.Pattern = S;
 
-  const char *PrefixMetas =
-      SlashAgnostic ? PrefixMetacharactersWithSlash : PrefixMetacharacters;
-  const char *SuffixMetas =
-      SlashAgnostic ? SuffixMetacharactersWithSlash : SuffixMetacharacters;
-
   // Store the prefix that does not contain any metacharacter.
-  Pat.PrefixSize = S.find_first_of(PrefixMetas);
+  Pat.PrefixSize = S.find_first_of(PrefixMetacharacters);
   if (Pat.PrefixSize == std::string::npos) {
     Pat.PrefixSize = S.size();
     return Pat;
@@ -203,7 +192,7 @@ Expected<GlobPattern> GlobPattern::create(StringRef S,
   S = S.substr(Pat.PrefixSize);
 
   // Just in case we stop on unmatched opening brackets.
-  size_t SuffixStart = S.find_last_of(SuffixMetas);
+  size_t SuffixStart = S.find_last_of(SuffixMetacharacters);
   assert(SuffixStart != std::string::npos);
   if (S[SuffixStart] == '\\')
     ++SuffixStart;
@@ -216,7 +205,7 @@ Expected<GlobPattern> GlobPattern::create(StringRef S,
   if (auto Err = parseBraceExpansions(S, MaxSubPatterns).moveInto(SubPats))
     return std::move(Err);
   for (StringRef SubPat : SubPats) {
-    auto SubGlobOrErr = SubGlobPattern::create(SubPat, SlashAgnostic);
+    auto SubGlobOrErr = SubGlobPattern::create(SubPat);
     if (!SubGlobOrErr)
       return SubGlobOrErr.takeError();
     Pat.SubGlobs.push_back(*SubGlobOrErr);
@@ -226,7 +215,7 @@ Expected<GlobPattern> GlobPattern::create(StringRef S,
 }
 
 Expected<GlobPattern::SubGlobPattern>
-GlobPattern::SubGlobPattern::create(StringRef S, bool SlashAgnostic) {
+GlobPattern::SubGlobPattern::create(StringRef S) {
   SubGlobPattern Pat;
 
   // Parse brackets.
@@ -248,10 +237,6 @@ GlobPattern::SubGlobPattern::create(StringRef S, bool SlashAgnostic) {
       if (!BVOrErr)
         return BVOrErr.takeError();
       BitVector &BV = *BVOrErr;
-      if (SlashAgnostic && (BV['\\'] || BV['/'])) {
-        BV.set('\\');
-        BV.set('/');
-      }
       if (Invert)
         BV.flip();
       Pat.Brackets.push_back(Bracket{J + 1, std::move(BV)});
@@ -266,8 +251,8 @@ GlobPattern::SubGlobPattern::create(StringRef S, bool SlashAgnostic) {
 }
 
 StringRef GlobPattern::longest_substr() const {
-  return maxPlainSubstring(Pattern.drop_front(PrefixSize).drop_back(SuffixSize),
-                           SlashAgnostic);
+  return maxPlainSubstring(
+      Pattern.drop_front(PrefixSize).drop_back(SuffixSize));
 }
 
 bool GlobPattern::match(StringRef S) const {
@@ -278,23 +263,15 @@ bool GlobPattern::match(StringRef S) const {
   if (SubGlobs.empty() && S.empty())
     return true;
   for (auto &Glob : SubGlobs)
-    if (Glob.match(S, SlashAgnostic))
+    if (Glob.match(S))
       return true;
   return false;
-}
-
-static bool matchChar(char PatC, char QueryC, bool SlashAgnostic) {
-  if (PatC == QueryC)
-    return true;
-  return SlashAgnostic && (PatC == '\\' || PatC == '/') &&
-         (QueryC == '\\' || QueryC == '/');
 }
 
 // Factor the pattern into segments split by '*'. The segment is matched
 // sequentianlly by finding the first occurrence past the end of the previous
 // match.
-bool GlobPattern::SubGlobPattern::match(StringRef Str,
-                                        bool SlashAgnostic) const {
+bool GlobPattern::SubGlobPattern::match(StringRef Str) const {
   const char *P = Pat.data(), *SegmentBegin = nullptr, *S = Str.data(),
              *SavedS = S;
   const char *const PEnd = P + Pat.size(), *const End = S + Str.size();
@@ -316,12 +293,12 @@ bool GlobPattern::SubGlobPattern::match(StringRef Str,
         continue;
       }
     } else if (*P == '\\') {
-      if (matchChar(*++P, *S, SlashAgnostic)) {
+      if (*++P == *S) {
         ++P;
         ++S;
         continue;
       }
-    } else if (matchChar(*P, *S, SlashAgnostic) || *P == '?') {
+    } else if (*P == *S || *P == '?') {
       ++P;
       ++S;
       continue;

--- a/llvm/unittests/Support/GlobPatternTest.cpp
+++ b/llvm/unittests/Support/GlobPatternTest.cpp
@@ -327,30 +327,6 @@ TEST_F(GlobPatternTest, PrefixSuffix) {
   ASSERT_TRUE((bool)Pat);
   EXPECT_EQ("", Pat->prefix());
   EXPECT_EQ("cd", Pat->suffix());
-
-  Pat = GlobPattern::create("ab/cd", /*MaxSubPatterns=*/{},
-                            /*SlashAgnostic=*/true);
-  ASSERT_TRUE((bool)Pat);
-  EXPECT_EQ("ab", Pat->prefix());
-  EXPECT_EQ("cd", Pat->suffix());
-
-  Pat = GlobPattern::create("ab\\cd", /*MaxSubPatterns=*/{},
-                            /*SlashAgnostic=*/true);
-  ASSERT_TRUE((bool)Pat);
-  EXPECT_EQ("ab", Pat->prefix());
-  EXPECT_EQ("d", Pat->suffix());
-
-  Pat = GlobPattern::create("ab/cd", /*MaxSubPatterns=*/{},
-                            /*SlashAgnostic=*/false);
-  ASSERT_TRUE((bool)Pat);
-  EXPECT_EQ("ab/cd", Pat->prefix());
-  EXPECT_EQ("", Pat->suffix());
-
-  Pat = GlobPattern::create("ab\\cd", /*MaxSubPatterns=*/{},
-                            /*SlashAgnostic=*/false);
-  ASSERT_TRUE((bool)Pat);
-  EXPECT_EQ("ab", Pat->prefix());
-  EXPECT_EQ("d", Pat->suffix());
 }
 
 TEST_F(GlobPatternTest, Substr) {
@@ -417,26 +393,6 @@ TEST_F(GlobPatternTest, Substr) {
   Pat = GlobPattern::create("a*bcdef{g}*h");
   ASSERT_TRUE((bool)Pat);
   EXPECT_EQ("bcdef", Pat->longest_substr());
-
-  Pat = GlobPattern::create("a*bc/de*f", /*MaxSubPatterns=*/{},
-                            /*SlashAgnostic=*/true);
-  ASSERT_TRUE((bool)Pat);
-  EXPECT_EQ("bc", Pat->longest_substr());
-
-  Pat = GlobPattern::create("a*bc\\de*f", /*MaxSubPatterns=*/{},
-                            /*SlashAgnostic=*/true);
-  ASSERT_TRUE((bool)Pat);
-  EXPECT_EQ("bc", Pat->longest_substr());
-
-  Pat = GlobPattern::create("a*bc/de*f", /*MaxSubPatterns=*/{},
-                            /*SlashAgnostic=*/false);
-  ASSERT_TRUE((bool)Pat);
-  EXPECT_EQ("bc/de", Pat->longest_substr());
-
-  Pat = GlobPattern::create("a*bc\\de*f", /*MaxSubPatterns=*/{},
-                            /*SlashAgnostic=*/false);
-  ASSERT_TRUE((bool)Pat);
-  EXPECT_EQ("bc", Pat->longest_substr());
 }
 
 TEST_F(GlobPatternTest, Pathological) {
@@ -452,23 +408,5 @@ TEST_F(GlobPatternTest, Pathological) {
   ASSERT_TRUE((bool)Pat);
   EXPECT_FALSE(Pat->match(S));
   EXPECT_TRUE(Pat->match(S + 'b'));
-}
-
-TEST_F(GlobPatternTest, SlashAgnosticMatch) {
-  auto Pat1 = GlobPattern::create("foo\\\\bar[a\\\\-z]", 1024,
-                                  /*SlashAgnostic=*/true);
-  ASSERT_TRUE((bool)Pat1);
-  EXPECT_TRUE(Pat1->match("foo/bar\\"));
-  EXPECT_TRUE(Pat1->match("foo/barb"));
-  EXPECT_TRUE(Pat1->match("foo/bar/"));
-}
-
-TEST_F(GlobPatternTest, SlashAgnosticMatchInverted) {
-  auto Pat = GlobPattern::create("foo\\\\bar[^a\\\\-z]", 1024,
-                                 /*SlashAgnostic=*/true);
-  ASSERT_TRUE((bool)Pat);
-  EXPECT_FALSE(Pat->match("foo/bar/"));
-  EXPECT_FALSE(Pat->match("foo/barb"));
-  EXPECT_TRUE(Pat->match("foo/bar1"));
 }
 }


### PR DESCRIPTION
Reverts llvm/llvm-project#202854 due to downstream breakage (see discussion in https://github.com/llvm/llvm-project/pull/202854#issuecomment-4746579478)