### PR TITLE
[libc] Implement CPU_{AND,OR,XOR,EQUAL}(_S)? macros

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1105,13 +1105,17 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_setspecific
 
     # sched.h entrypoints
+    libc.src.sched.__sched_andcpuset
     libc.src.sched.__sched_clrcpuset
     libc.src.sched.__sched_cpualloc
+    libc.src.sched.__sched_cpuequal
     libc.src.sched.__sched_cpufree
     libc.src.sched.__sched_getcpucount
-    libc.src.sched.__sched_setcpuzero
-    libc.src.sched.__sched_setcpuset
     libc.src.sched.__sched_getcpuisset
+    libc.src.sched.__sched_orcpuset
+    libc.src.sched.__sched_setcpuset
+    libc.src.sched.__sched_setcpuzero
+    libc.src.sched.__sched_xorcpuset
 
     # strings.h entrypoints
     libc.src.strings.strcasecmp_l

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1238,13 +1238,17 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_setspecific
 
     # sched.h entrypoints
+    libc.src.sched.__sched_andcpuset
     libc.src.sched.__sched_clrcpuset
     libc.src.sched.__sched_cpualloc
+    libc.src.sched.__sched_cpuequal
     libc.src.sched.__sched_cpufree
     libc.src.sched.__sched_getcpucount
-    libc.src.sched.__sched_setcpuzero
-    libc.src.sched.__sched_setcpuset
     libc.src.sched.__sched_getcpuisset
+    libc.src.sched.__sched_orcpuset
+    libc.src.sched.__sched_setcpuset
+    libc.src.sched.__sched_setcpuzero
+    libc.src.sched.__sched_xorcpuset
 
     # setjmp.h entrypoints
     libc.src.setjmp.longjmp

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1300,13 +1300,17 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_setspecific
 
     # sched.h entrypoints
+    libc.src.sched.__sched_andcpuset
     libc.src.sched.__sched_clrcpuset
     libc.src.sched.__sched_cpualloc
+    libc.src.sched.__sched_cpuequal
     libc.src.sched.__sched_cpufree
     libc.src.sched.__sched_getcpucount
-    libc.src.sched.__sched_setcpuzero
-    libc.src.sched.__sched_setcpuset
     libc.src.sched.__sched_getcpuisset
+    libc.src.sched.__sched_orcpuset
+    libc.src.sched.__sched_setcpuset
+    libc.src.sched.__sched_setcpuzero
+    libc.src.sched.__sched_xorcpuset
 
     # setjmp.h entrypoints
     libc.src.setjmp.longjmp

--- a/libc/include/llvm-libc-macros/linux/sched-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sched-macros.h
@@ -25,16 +25,30 @@
 
 #define CPU_SETSIZE __CPU_SETSIZE
 #define NCPUBITS __NCPUBITS
+#define CPU_AND_S(setsize, destset, srcset1, srcset2)                          \
+  __sched_andcpuset(setsize, destset, srcset1, srcset2)
+#define CPU_AND(destset, srcset1, srcset2)                                     \
+  CPU_AND_S(sizeof(cpu_set_t), destset, srcset1, srcset2)
 #define CPU_CLR_S(cpu, setsize, set) __sched_clrcpuset(cpu, setsize, set)
 #define CPU_CLR(cpu, set) CPU_CLR_S(cpu, sizeof(cpu_set_t), set)
 #define CPU_COUNT_S(setsize, set) __sched_getcpucount(setsize, set)
 #define CPU_COUNT(set) CPU_COUNT_S(sizeof(cpu_set_t), set)
+#define CPU_EQUAL_S(setsize, set1, set2) __sched_cpuequal(setsize, set1, set2)
+#define CPU_EQUAL(set1, set2) CPU_EQUAL_S(sizeof(cpu_set_t), set1, set2)
 #define CPU_ZERO_S(setsize, set) __sched_setcpuzero(setsize, set)
 #define CPU_ZERO(set) CPU_ZERO_S(sizeof(cpu_set_t), set)
 #define CPU_SET_S(cpu, setsize, set) __sched_setcpuset(cpu, setsize, set)
 #define CPU_SET(cpu, set) CPU_SET_S(cpu, sizeof(cpu_set_t), set)
 #define CPU_ISSET_S(cpu, setsize, set) __sched_getcpuisset(cpu, setsize, set)
 #define CPU_ISSET(cpu, set) CPU_ISSET_S(cpu, sizeof(cpu_set_t), set)
+#define CPU_OR_S(setsize, destset, srcset1, srcset2)                           \
+  __sched_orcpuset(setsize, destset, srcset1, srcset2)
+#define CPU_OR(destset, srcset1, srcset2)                                      \
+  CPU_OR_S(sizeof(cpu_set_t), destset, srcset1, srcset2)
+#define CPU_XOR_S(setsize, destset, srcset1, srcset2)                          \
+  __sched_xorcpuset(setsize, destset, srcset1, srcset2)
+#define CPU_XOR(destset, srcset1, srcset2)                                     \
+  CPU_XOR_S(sizeof(cpu_set_t), destset, srcset1, srcset2)
 
 #define CPU_ALLOC_SIZE(count)                                                  \
   ((((count) + NCPUBITS - 1) / NCPUBITS) * sizeof(__cpu_set_mask_t))

--- a/libc/include/sched.yaml
+++ b/libc/include/sched.yaml
@@ -18,6 +18,15 @@ types:
 enums: []
 objects: []
 functions:
+  - name: __sched_andcpuset
+    standards:
+      - llvm_libc_ext
+    return_type: void
+    arguments:
+      - type: size_t
+      - type: cpu_set_t *
+      - type: const cpu_set_t *
+      - type: const cpu_set_t *
   - name: __sched_clrcpuset
     standards:
       - llvm_libc_ext
@@ -32,6 +41,14 @@ functions:
     return_type: cpu_set_t *
     arguments:
       - type: size_t
+  - name: __sched_cpuequal
+    standards:
+      - llvm_libc_ext
+    return_type: int
+    arguments:
+      - type: size_t
+      - type: const cpu_set_t *
+      - type: const cpu_set_t *
   - name: __sched_cpufree
     standards:
       - llvm_libc_ext
@@ -53,6 +70,15 @@ functions:
       - type: int
       - type: size_t
       - type: const cpu_set_t *
+  - name: __sched_orcpuset
+    standards:
+      - llvm_libc_ext
+    return_type: void
+    arguments:
+      - type: size_t
+      - type: cpu_set_t *
+      - type: const cpu_set_t *
+      - type: const cpu_set_t *
   - name: __sched_setcpuset
     standards:
       - llvm_libc_ext
@@ -68,6 +94,15 @@ functions:
     arguments:
       - type: size_t
       - type: cpu_set_t *
+  - name: __sched_xorcpuset
+    standards:
+      - llvm_libc_ext
+    return_type: void
+    arguments:
+      - type: size_t
+      - type: cpu_set_t *
+      - type: const cpu_set_t *
+      - type: const cpu_set_t *
   - name: getcpu
     standards:
       - linux

--- a/libc/src/sched/CMakeLists.txt
+++ b/libc/src/sched/CMakeLists.txt
@@ -87,6 +87,13 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  __sched_andcpuset
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.__sched_andcpuset
+)
+
+add_entrypoint_object(
   __sched_clrcpuset
   ALIAS
   DEPENDS
@@ -98,6 +105,13 @@ add_entrypoint_object(
   ALIAS
   DEPENDS
     .${LIBC_TARGET_OS}.__sched_cpualloc
+)
+
+add_entrypoint_object(
+  __sched_cpuequal
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.__sched_cpuequal
 )
 
 add_entrypoint_object(
@@ -133,4 +147,18 @@ add_entrypoint_object(
   ALIAS
   DEPENDS
     .${LIBC_TARGET_OS}.__sched_getcpuisset
+)
+
+add_entrypoint_object(
+  __sched_orcpuset
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.__sched_orcpuset
+)
+
+add_entrypoint_object(
+  __sched_xorcpuset
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.__sched_xorcpuset
 )

--- a/libc/src/sched/linux/CMakeLists.txt
+++ b/libc/src/sched/linux/CMakeLists.txt
@@ -169,6 +169,20 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  __sched_andcpuset
+  SRCS
+    sched_andcpuset.cpp
+  HDRS
+    ../sched_andcpuset.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.size_t
+)
+
+add_entrypoint_object(
   __sched_clrcpuset
   SRCS
     sched_clrcpuset.cpp
@@ -202,6 +216,21 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  __sched_cpuequal
+  SRCS
+    sched_cpuequal.cpp
+  HDRS
+    ../sched_cpuequal.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
+    libc.src.string.memory_utils.inline_memcmp
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.size_t
+)
+
+add_entrypoint_object(
   __sched_cpufree
   SRCS
     sched_cpufree.cpp
@@ -213,6 +242,20 @@ add_entrypoint_object(
     libc.src.__support.common
     libc.src.__support.CPP.new
     libc.src.__support.macros.config
+)
+
+add_entrypoint_object(
+  __sched_orcpuset
+  SRCS
+    sched_orcpuset.cpp
+  HDRS
+    ../sched_orcpuset.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.size_t
 )
 
 add_entrypoint_object(
@@ -255,6 +298,20 @@ add_entrypoint_object(
     libc.src.__support.macros.config
     libc.src.__support.macros.null_check
     libc.hdr.sched_macros
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.size_t
+)
+
+add_entrypoint_object(
+  __sched_xorcpuset
+  SRCS
+    sched_xorcpuset.cpp
+  HDRS
+    ../sched_xorcpuset.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
     libc.hdr.types.cpu_set_t
     libc.hdr.types.size_t
 )

--- a/libc/src/sched/linux/sched_andcpuset.cpp
+++ b/libc/src/sched/linux/sched_andcpuset.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of __sched_andcpuset.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/sched/sched_andcpuset.h"
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+#include "src/__support/common.h"            // LLVM_LIBC_FUNCTION
+#include "src/__support/macros/config.h"     // LIBC_NAMESPACE_DECL
+#include "src/__support/macros/null_check.h" // LIBC_CRASH_ON_NULLPTR
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void, __sched_andcpuset,
+                   (size_t cpuset_size, cpu_set_t *destset,
+                    const cpu_set_t *srcset1, const cpu_set_t *srcset2)) {
+  LIBC_CRASH_ON_NULLPTR(destset);
+  LIBC_CRASH_ON_NULLPTR(srcset1);
+  LIBC_CRASH_ON_NULLPTR(srcset2);
+  size_t limit = cpuset_size / sizeof(__cpu_set_mask_t);
+  for (size_t i = 0; i < limit; ++i)
+    destset->__mask[i] = srcset1->__mask[i] & srcset2->__mask[i];
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sched/linux/sched_cpuequal.cpp
+++ b/libc/src/sched/linux/sched_cpuequal.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of __sched_cpuequal.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/sched/sched_cpuequal.h"
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+#include "src/__support/common.h"            // LLVM_LIBC_FUNCTION
+#include "src/__support/macros/config.h"     // LIBC_NAMESPACE_DECL
+#include "src/__support/macros/null_check.h" // LIBC_CRASH_ON_NULLPTR
+#include "src/string/memory_utils/inline_memcmp.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, __sched_cpuequal,
+                   (size_t cpuset_size, const cpu_set_t *set1,
+                    const cpu_set_t *set2)) {
+  LIBC_CRASH_ON_NULLPTR(set1);
+  LIBC_CRASH_ON_NULLPTR(set2);
+  return inline_memcmp(set1, set2, cpuset_size) == 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sched/linux/sched_orcpuset.cpp
+++ b/libc/src/sched/linux/sched_orcpuset.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of __sched_orcpuset.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/sched/sched_orcpuset.h"
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+#include "src/__support/common.h"            // LLVM_LIBC_FUNCTION
+#include "src/__support/macros/config.h"     // LIBC_NAMESPACE_DECL
+#include "src/__support/macros/null_check.h" // LIBC_CRASH_ON_NULLPTR
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void, __sched_orcpuset,
+                   (size_t cpuset_size, cpu_set_t *destset,
+                    const cpu_set_t *srcset1, const cpu_set_t *srcset2)) {
+  LIBC_CRASH_ON_NULLPTR(destset);
+  LIBC_CRASH_ON_NULLPTR(srcset1);
+  LIBC_CRASH_ON_NULLPTR(srcset2);
+  size_t limit = cpuset_size / sizeof(__cpu_set_mask_t);
+  for (size_t i = 0; i < limit; ++i)
+    destset->__mask[i] = srcset1->__mask[i] | srcset2->__mask[i];
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sched/linux/sched_xorcpuset.cpp
+++ b/libc/src/sched/linux/sched_xorcpuset.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of __sched_xorcpuset.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/sched/sched_xorcpuset.h"
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+#include "src/__support/common.h"            // LLVM_LIBC_FUNCTION
+#include "src/__support/macros/config.h"     // LIBC_NAMESPACE_DECL
+#include "src/__support/macros/null_check.h" // LIBC_CRASH_ON_NULLPTR
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void, __sched_xorcpuset,
+                   (size_t cpuset_size, cpu_set_t *destset,
+                    const cpu_set_t *srcset1, const cpu_set_t *srcset2)) {
+  LIBC_CRASH_ON_NULLPTR(destset);
+  LIBC_CRASH_ON_NULLPTR(srcset1);
+  LIBC_CRASH_ON_NULLPTR(srcset2);
+  size_t limit = cpuset_size / sizeof(__cpu_set_mask_t);
+  for (size_t i = 0; i < limit; ++i)
+    destset->__mask[i] = srcset1->__mask[i] ^ srcset2->__mask[i];
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sched/sched_andcpuset.h
+++ b/libc/src/sched/sched_andcpuset.h
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for __sched_andcpuset.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SCHED_SCHED_ANDCPUSET_H
+#define LLVM_LIBC_SRC_SCHED_SCHED_ANDCPUSET_H
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// for internal use in the CPU_AND macro
+void __sched_andcpuset(size_t cpuset_size, cpu_set_t *destset,
+                       const cpu_set_t *srcset1, const cpu_set_t *srcset2);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SCHED_SCHED_ANDCPUSET_H

--- a/libc/src/sched/sched_cpuequal.h
+++ b/libc/src/sched/sched_cpuequal.h
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for __sched_cpuequal.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SCHED_SCHED_CPUEQUAL_H
+#define LLVM_LIBC_SRC_SCHED_SCHED_CPUEQUAL_H
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// for internal use in the CPU_EQUAL macro
+int __sched_cpuequal(size_t cpuset_size, const cpu_set_t *set1,
+                     const cpu_set_t *set2);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SCHED_SCHED_CPUEQUAL_H

--- a/libc/src/sched/sched_orcpuset.h
+++ b/libc/src/sched/sched_orcpuset.h
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for __sched_orcpuset.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SCHED_SCHED_ORCPUSET_H
+#define LLVM_LIBC_SRC_SCHED_SCHED_ORCPUSET_H
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// for internal use in the CPU_OR macro
+void __sched_orcpuset(size_t cpuset_size, cpu_set_t *destset,
+                      const cpu_set_t *srcset1, const cpu_set_t *srcset2);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SCHED_SCHED_ORCPUSET_H

--- a/libc/src/sched/sched_xorcpuset.h
+++ b/libc/src/sched/sched_xorcpuset.h
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for __sched_xorcpuset.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SCHED_SCHED_XORCPUSET_H
+#define LLVM_LIBC_SRC_SCHED_SCHED_XORCPUSET_H
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// for internal use in the CPU_XOR macro
+void __sched_xorcpuset(size_t cpuset_size, cpu_set_t *destset,
+                       const cpu_set_t *srcset1, const cpu_set_t *srcset2);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SCHED_SCHED_XORCPUSET_H

--- a/libc/test/src/sched/CMakeLists.txt
+++ b/libc/test/src/sched/CMakeLists.txt
@@ -145,3 +145,61 @@ add_libc_unittest(
     libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
+
+add_libc_unittest(
+  sched_andcpuset_test
+  SUITE
+    libc_sched_unittests
+  SRCS
+    sched_andcpuset_test.cpp
+  DEPENDS
+    libc.hdr.types.cpu_set_t
+    libc.src.sched.__sched_andcpuset
+    libc.src.sched.__sched_cpuequal
+    libc.src.sched.__sched_getcpucount
+    libc.src.sched.__sched_setcpuset
+    libc.src.sched.__sched_setcpuzero
+)
+
+add_libc_unittest(
+  sched_cpuequal_test
+  SUITE
+    libc_sched_unittests
+  SRCS
+    sched_cpuequal_test.cpp
+  DEPENDS
+    libc.hdr.types.cpu_set_t
+    libc.src.sched.__sched_cpuequal
+    libc.src.sched.__sched_setcpuset
+    libc.src.sched.__sched_setcpuzero
+)
+
+add_libc_unittest(
+  sched_orcpuset_test
+  SUITE
+    libc_sched_unittests
+  SRCS
+    sched_orcpuset_test.cpp
+  DEPENDS
+    libc.hdr.types.cpu_set_t
+    libc.src.sched.__sched_getcpucount
+    libc.src.sched.__sched_getcpuisset
+    libc.src.sched.__sched_orcpuset
+    libc.src.sched.__sched_setcpuset
+    libc.src.sched.__sched_setcpuzero
+)
+
+add_libc_unittest(
+  sched_xorcpuset_test
+  SUITE
+    libc_sched_unittests
+  SRCS
+    sched_xorcpuset_test.cpp
+  DEPENDS
+    libc.hdr.types.cpu_set_t
+    libc.src.sched.__sched_getcpucount
+    libc.src.sched.__sched_getcpuisset
+    libc.src.sched.__sched_setcpuset
+    libc.src.sched.__sched_setcpuzero
+    libc.src.sched.__sched_xorcpuset
+)

--- a/libc/test/src/sched/sched_andcpuset_test.cpp
+++ b/libc/test/src/sched/sched_andcpuset_test.cpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for __sched_andcpuset.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/types/cpu_set_t.h"
+#include "src/sched/sched_andcpuset.h"
+#include "src/sched/sched_cpuequal.h"
+#include "src/sched/sched_getcpucount.h"
+#include "src/sched/sched_setcpuset.h"
+#include "src/sched/sched_setcpuzero.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcSchedAndCpuSetTest = LIBC_NAMESPACE::testing::Test;
+
+TEST_F(LlvmLibcSchedAndCpuSetTest, AndCpuSet) {
+  cpu_set_t mask1, mask2, result;
+  const size_t alloc_size = sizeof(cpu_set_t);
+
+  LIBC_NAMESPACE::__sched_setcpuzero(alloc_size, &mask1);
+  LIBC_NAMESPACE::__sched_setcpuzero(alloc_size, &mask2);
+  LIBC_NAMESPACE::__sched_setcpuset(1, alloc_size, &mask1);
+  LIBC_NAMESPACE::__sched_setcpuset(2, alloc_size, &mask2);
+
+  LIBC_NAMESPACE::__sched_andcpuset(alloc_size, &result, &mask1, &mask2);
+  ASSERT_EQ(LIBC_NAMESPACE::__sched_getcpucount(alloc_size, &result), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::__sched_cpuequal(alloc_size, &result, &mask1), 0);
+}

--- a/libc/test/src/sched/sched_cpuequal_test.cpp
+++ b/libc/test/src/sched/sched_cpuequal_test.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for __sched_cpuequal.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/types/cpu_set_t.h"
+#include "src/sched/sched_cpuequal.h"
+#include "src/sched/sched_setcpuset.h"
+#include "src/sched/sched_setcpuzero.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcSchedCpuEqualTest = LIBC_NAMESPACE::testing::Test;
+
+TEST_F(LlvmLibcSchedCpuEqualTest, CpuEqual) {
+  cpu_set_t mask1, mask2;
+  const size_t alloc_size = sizeof(cpu_set_t);
+
+  LIBC_NAMESPACE::__sched_setcpuzero(alloc_size, &mask1);
+  LIBC_NAMESPACE::__sched_setcpuzero(alloc_size, &mask2);
+  ASSERT_EQ(LIBC_NAMESPACE::__sched_cpuequal(alloc_size, &mask1, &mask2), 1);
+
+  LIBC_NAMESPACE::__sched_setcpuset(1, alloc_size, &mask1);
+  ASSERT_EQ(LIBC_NAMESPACE::__sched_cpuequal(alloc_size, &mask1, &mask2), 0);
+}

--- a/libc/test/src/sched/sched_orcpuset_test.cpp
+++ b/libc/test/src/sched/sched_orcpuset_test.cpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for __sched_orcpuset.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/types/cpu_set_t.h"
+#include "src/sched/sched_getcpucount.h"
+#include "src/sched/sched_getcpuisset.h"
+#include "src/sched/sched_orcpuset.h"
+#include "src/sched/sched_setcpuset.h"
+#include "src/sched/sched_setcpuzero.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcSchedOrCpuSetTest = LIBC_NAMESPACE::testing::Test;
+
+TEST_F(LlvmLibcSchedOrCpuSetTest, OrCpuSet) {
+  cpu_set_t mask1, mask2, result;
+  const size_t alloc_size = sizeof(cpu_set_t);
+
+  LIBC_NAMESPACE::__sched_setcpuzero(alloc_size, &mask1);
+  LIBC_NAMESPACE::__sched_setcpuzero(alloc_size, &mask2);
+  LIBC_NAMESPACE::__sched_setcpuset(1, alloc_size, &mask1);
+  LIBC_NAMESPACE::__sched_setcpuset(2, alloc_size, &mask2);
+
+  LIBC_NAMESPACE::__sched_orcpuset(alloc_size, &result, &mask1, &mask2);
+  ASSERT_EQ(LIBC_NAMESPACE::__sched_getcpuisset(1, alloc_size, &result), 1);
+  ASSERT_EQ(LIBC_NAMESPACE::__sched_getcpuisset(2, alloc_size, &result), 1);
+  ASSERT_EQ(LIBC_NAMESPACE::__sched_getcpucount(alloc_size, &result), 2);
+}

--- a/libc/test/src/sched/sched_xorcpuset_test.cpp
+++ b/libc/test/src/sched/sched_xorcpuset_test.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for __sched_xorcpuset.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/types/cpu_set_t.h"
+#include "src/sched/sched_getcpucount.h"
+#include "src/sched/sched_getcpuisset.h"
+#include "src/sched/sched_setcpuset.h"
+#include "src/sched/sched_setcpuzero.h"
+#include "src/sched/sched_xorcpuset.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcSchedXorCpuSetTest = LIBC_NAMESPACE::testing::Test;
+
+TEST_F(LlvmLibcSchedXorCpuSetTest, XorCpuSet) {
+  cpu_set_t mask1, mask2, result;
+  const size_t alloc_size = sizeof(cpu_set_t);
+
+  LIBC_NAMESPACE::__sched_setcpuzero(alloc_size, &mask1);
+  LIBC_NAMESPACE::__sched_setcpuzero(alloc_size, &mask2);
+  LIBC_NAMESPACE::__sched_setcpuset(1, alloc_size, &mask1);
+  LIBC_NAMESPACE::__sched_setcpuset(1, alloc_size, &mask2);
+  LIBC_NAMESPACE::__sched_setcpuset(2, alloc_size, &mask2);
+
+  LIBC_NAMESPACE::__sched_xorcpuset(alloc_size, &result, &mask1, &mask2);
+  ASSERT_EQ(LIBC_NAMESPACE::__sched_getcpuisset(1, alloc_size, &result), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::__sched_getcpuisset(2, alloc_size, &result), 1);
+  ASSERT_EQ(LIBC_NAMESPACE::__sched_getcpucount(alloc_size, &result), 1);
+}


### PR DESCRIPTION
This patch implements CPU_AND, CPU_OR, CPU_XOR, and CPU_EQUAL macros (along with their _S variants) from sched.h.

The implementation follows existing patterns by adding internal entry points (__sched_andcpuset, __sched_orcpuset, __sched_xorcpuset, and __sched_cpuequal) that perform bitwise operations on cpu_set_t. For __sched_cpuequal, I use inline_memcmp instead of a manual loop.