### PR TITLE
[Instrumentor] Add spellcheck for instrumentor properties

### DIFF
--- a/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
+++ b/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -116,7 +117,7 @@ template <typename Map>
 static StringRef closestOption(const Map &Options, StringRef Missing) {
   uint32_t MaxEdit = 5;
   StringRef Closest;
-  for (auto Key : Options.keys()) {
+  for (const auto &Key : Options.keys()) {
     auto EditDist = Missing.edit_distance_insensitive(Key, true, MaxEdit);
     if (EditDist < MaxEdit) {
       Closest = Key;
@@ -239,9 +240,8 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
       StringSet<> IOOpts;
       IOOpts.insert("enabled");
       IOOpts.insert("filter");
-      for (auto &IRArg : IO->IRTArgs) {
+      for (auto &IRArg : IO->IRTArgs)
         IOOpts.insert(IRArg.Name);
-      }
       for (auto &InnerObjIt : *InnerObj) {
         auto Name = StringRef(InnerObjIt.first);
         if (Name == "filter") {

--- a/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
+++ b/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
@@ -197,14 +197,11 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
             break;
           }
         } else if (!StringRef(ObjIt.first).ends_with(".description")) {
-          Twine NoMatchingMsg = Twine("configuration key '") +
-                                StringRef(ObjIt.first) +
-                                Twine("' not found and ignored");
+          std::string Diag = "configuration key '" + ObjIt.first.str() +
+                             "' not found and ignored";
           StringRef Closest = closestOption(BCOMap, ObjIt.first);
-          Twine Diag =
-              NoMatchingMsg + (Closest.empty() ? Twine()
-                                               : Twine("; did you mean '") +
-                                                     Closest + Twine("'?"));
+          if (!Closest.empty())
+            Diag += "; did you mean '" + Closest.str() + "'?";
           Ctx.diagnose(DiagnosticInfoInstrumentation(Diag, DS_Warning));
         }
       }
@@ -222,15 +219,13 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
       }
       auto *IO = IChoiceMap.lookup(ObjIt.first);
       if (!IO) {
-        Twine NoMatchingMsg =
-            Twine("malformed JSON configuration, expected an object matching "
-                  "an instrumentor choice, got '") +
-            StringRef(ObjIt.first) + Twine("'");
+        std::string Diag =
+            "malformed JSON configuration, expected an object matching "
+            "an instrumentor choice, got '" +
+            ObjIt.first.str() + "'";
         StringRef Closest = closestOption(IChoiceMap, ObjIt.first);
-        Twine Diag = NoMatchingMsg +
-                     (Closest.empty()
-                          ? Twine()
-                          : Twine("; did you mean '") + Closest + Twine("'?"));
+        if (!Closest.empty())
+          Diag += "; did you mean '" + Closest.str() + "'?";
         Ctx.diagnose(DiagnosticInfoInstrumentation(Diag, DS_Warning));
         continue;
       }
@@ -253,14 +248,12 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
           ValueMap[Name] = InnerObjIt.second.getAsBoolean().value_or(false);
         }
         if (!IOOpts.contains(Name)) {
-          Twine NoMatchingMsg = Twine("unrecognized JSON property '") +
-                                StringRef(Name) + ("' in configuration for '") +
-                                IO->getName() + Twine("'");
+          std::string Diag = "unrecognized JSON property '" + Name.str() +
+                             "' in configuration for '" + IO->getName().str() +
+                             "'";
           StringRef Closest = closestOption(IOOpts, Name);
-          Twine Diag =
-              NoMatchingMsg + (Closest.empty() ? Twine()
-                                               : Twine("; did you mean '") +
-                                                     Closest + Twine("'?"));
+          if (!Closest.empty())
+            Diag += "; did you mean '" + Closest.str() + "'?";
           Ctx.diagnose(DiagnosticInfoInstrumentation(Diag, DS_Warning));
         }
       }

--- a/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
+++ b/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
@@ -112,6 +112,20 @@ void writeConfigToJSON(InstrumentationConfig &IConf, StringRef OutputFile,
   J.objectEnd();
 }
 
+template <typename Map>
+static StringRef closestOption(const Map &Options, StringRef Missing) {
+  uint32_t MaxEdit = 5;
+  StringRef Closest;
+  for (auto Key : Options.keys()) {
+    auto EditDist = Missing.edit_distance_insensitive(Key, true, MaxEdit);
+    if (EditDist < MaxEdit) {
+      Closest = Key;
+      MaxEdit = EditDist;
+    }
+  }
+  return Closest;
+}
+
 bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
                         LLVMContext &Ctx, vfs::FileSystem &FS) {
   if (InputFile.empty())
@@ -182,10 +196,15 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
             break;
           }
         } else if (!StringRef(ObjIt.first).ends_with(".description")) {
-          Ctx.diagnose(DiagnosticInfoInstrumentation(
-              Twine("configuration key '") + StringRef(ObjIt.first) +
-                  Twine("' not found and ignored"),
-              DS_Warning));
+          Twine NoMatchingMsg = Twine("configuration key '") +
+                                StringRef(ObjIt.first) +
+                                Twine("' not found and ignored");
+          StringRef Closest = closestOption(BCOMap, ObjIt.first);
+          Twine Diag =
+              NoMatchingMsg + (Closest.empty() ? Twine()
+                                               : Twine("; did you mean '") +
+                                                     Closest + Twine("'?"));
+          Ctx.diagnose(DiagnosticInfoInstrumentation(Diag, DS_Warning));
         }
       }
       continue;
@@ -202,16 +221,27 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
       }
       auto *IO = IChoiceMap.lookup(ObjIt.first);
       if (!IO) {
-        Ctx.diagnose(DiagnosticInfoInstrumentation(
+        Twine NoMatchingMsg =
             Twine("malformed JSON configuration, expected an object matching "
-                  "an instrumentor choice, got ") +
-                StringRef(ObjIt.first),
-            DS_Warning));
+                  "an instrumentor choice, got '") +
+            StringRef(ObjIt.first) + Twine("'");
+        StringRef Closest = closestOption(IChoiceMap, ObjIt.first);
+        Twine Diag = NoMatchingMsg +
+                     (Closest.empty()
+                          ? Twine()
+                          : Twine("; did you mean '") + Closest + Twine("'?"));
+        Ctx.diagnose(DiagnosticInfoInstrumentation(Diag, DS_Warning));
         continue;
       }
       SeenIOs.insert(IO);
       StringMap<bool> ValueMap, ReplaceMap;
       StringRef FilterStr;
+      StringSet<> IOOpts;
+      IOOpts.insert("enabled");
+      IOOpts.insert("filter");
+      for (auto &IRArg : IO->IRTArgs) {
+        IOOpts.insert(IRArg.Name);
+      }
       for (auto &InnerObjIt : *InnerObj) {
         auto Name = StringRef(InnerObjIt.first);
         if (Name == "filter") {
@@ -221,6 +251,17 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
           ReplaceMap[Name] = InnerObjIt.second.getAsBoolean().value_or(false);
         } else {
           ValueMap[Name] = InnerObjIt.second.getAsBoolean().value_or(false);
+        }
+        if (!IOOpts.contains(Name)) {
+          Twine NoMatchingMsg = Twine("unrecognized JSON property '") +
+                                StringRef(Name) + ("' in configuration for '") +
+                                IO->getName() + Twine("'");
+          StringRef Closest = closestOption(IOOpts, Name);
+          Twine Diag =
+              NoMatchingMsg + (Closest.empty() ? Twine()
+                                               : Twine("; did you mean '") +
+                                                     Closest + Twine("'?"));
+          Ctx.diagnose(DiagnosticInfoInstrumentation(Diag, DS_Warning));
         }
       }
       IO->Enabled = ValueMap["enabled"];

--- a/llvm/test/Instrumentation/Instrumentor/bad_spelling.ll
+++ b/llvm/test/Instrumentation/Instrumentor/bad_spelling.ll
@@ -1,0 +1,7 @@
+; RUN: opt < %s -passes=instrumentor -instrumentor-read-config-files=%S/bad_spelling_config.json -S 2>&1 | FileCheck %s
+
+; CHECK: warning: configuration key 'gpu_enabeld' not found and ignored; did you mean 'gpu_enabled'?
+; CHECK: warning: malformed JSON configuration, expected an object matching an instrumentor choice, got 'numerci'; did you mean 'numeric'?
+; CHECK: warning: unrecognized JSON property 'zzzzzz' in configuration for 'numeric'
+; CHECK: warning: unrecognized JSON property 'opocde' in configuration for 'numeric'; did you mean 'opcode'?
+; CHECK: warning: unrecognized JSON property 'enabld' in configuration for 'numeric'; did you mean 'enabled'?

--- a/llvm/test/Instrumentation/Instrumentor/bad_spelling.ll
+++ b/llvm/test/Instrumentation/Instrumentor/bad_spelling.ll
@@ -1,7 +1,7 @@
 ; RUN: opt < %s -passes=instrumentor -instrumentor-read-config-files=%S/bad_spelling_config.json -S 2>&1 | FileCheck %s
 
-; CHECK: warning: configuration key 'gpu_enabeld' not found and ignored; did you mean 'gpu_enabled'?
 ; CHECK: warning: malformed JSON configuration, expected an object matching an instrumentor choice, got 'numerci'; did you mean 'numeric'?
-; CHECK: warning: unrecognized JSON property 'zzzzzz' in configuration for 'numeric'
-; CHECK: warning: unrecognized JSON property 'opocde' in configuration for 'numeric'; did you mean 'opcode'?
-; CHECK: warning: unrecognized JSON property 'enabld' in configuration for 'numeric'; did you mean 'enabled'?
+; CHECK-NEXT: warning: configuration key 'gpu_enabeld' not found and ignored; did you mean 'gpu_enabled'?
+; CHECK-NEXT: warning: unrecognized JSON property 'opocde' in configuration for 'numeric'; did you mean 'opcode'?
+; CHECK-NEXT: warning: unrecognized JSON property 'zzzzzz' in configuration for 'numeric'
+; CHECK-NEXT: warning: unrecognized JSON property 'enabld' in configuration for 'numeric'; did you mean 'enabled'?

--- a/llvm/test/Instrumentation/Instrumentor/bad_spelling.ll
+++ b/llvm/test/Instrumentation/Instrumentor/bad_spelling.ll
@@ -1,7 +1,7 @@
 ; RUN: opt < %s -passes=instrumentor -instrumentor-read-config-files=%S/bad_spelling_config.json -S 2>&1 | FileCheck %s
 
-; CHECK: warning: malformed JSON configuration, expected an object matching an instrumentor choice, got 'numerci'; did you mean 'numeric'?
-; CHECK-NEXT: warning: configuration key 'gpu_enabeld' not found and ignored; did you mean 'gpu_enabled'?
-; CHECK-NEXT: warning: unrecognized JSON property 'opocde' in configuration for 'numeric'; did you mean 'opcode'?
-; CHECK-NEXT: warning: unrecognized JSON property 'zzzzzz' in configuration for 'numeric'
-; CHECK-NEXT: warning: unrecognized JSON property 'enabld' in configuration for 'numeric'; did you mean 'enabled'?
+; CHECK-DAG: warning: malformed JSON configuration, expected an object matching an instrumentor choice, got 'numerci'; did you mean 'numeric'?
+; CHECK-DAG: warning: configuration key 'gpu_enabeld' not found and ignored; did you mean 'gpu_enabled'?
+; CHECK-DAG: warning: unrecognized JSON property 'opocde' in configuration for 'numeric'; did you mean 'opcode'?
+; CHECK-DAG: warning: unrecognized JSON property 'zzzzzz' in configuration for 'numeric'
+; CHECK-DAG: warning: unrecognized JSON property 'enabld' in configuration for 'numeric'; did you mean 'enabled'?

--- a/llvm/test/Instrumentation/Instrumentor/bad_spelling_config.json
+++ b/llvm/test/Instrumentation/Instrumentor/bad_spelling_config.json
@@ -1,0 +1,30 @@
+{
+  "configuration": {
+    "runtime_prefix": "__instrumentor_",
+    "gpu_enabeld": false
+  },
+  "instruction_pre": {
+    "numeric": {
+      "enabld": true,
+      "type_id": true,
+      "size": true,
+      "opocde": true,
+      "left": true,
+      "right": true,
+      "zzzzzz": false,
+      "id": true
+    }
+  },
+  "instruction_post": {
+    "numerci": {
+      "enabled": true,
+      "type_id": true,
+      "size": true,
+      "opcode": true,
+      "left": true,
+      "right": true,
+      "result": true,
+      "id": true
+    }
+  }
+}


### PR DESCRIPTION
This patch adds spellcheck hints for unrecognized properties in the instrumentor's JSON configuration.