### PR TITLE
[lldb][NFC] Change how Target stores BreakpointNames

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -2087,9 +2087,8 @@ protected:
   SectionLoadHistory m_section_load_history;
   BreakpointList m_breakpoint_list;
   BreakpointList m_internal_breakpoint_list;
-  using BreakpointNameList =
-      std::map<ConstString, std::unique_ptr<BreakpointName>>;
-  BreakpointNameList m_breakpoint_names;
+  using BreakpointNameMap = llvm::StringMap<std::unique_ptr<BreakpointName>>;
+  BreakpointNameMap m_breakpoint_names;
 
   std::map<lldb::user_id_t, BreakpointResolverOverrideUP>
       m_breakpoint_overrides;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -888,7 +888,7 @@ BreakpointName *Target::FindBreakpointName(ConstString name, bool can_create,
   if (!error.Success())
     return nullptr;
 
-  BreakpointNameList::iterator iter = m_breakpoint_names.find(name);
+  BreakpointNameMap::iterator iter = m_breakpoint_names.find(name);
   if (iter != m_breakpoint_names.end()) {
     return iter->second.get();
   }
@@ -905,7 +905,7 @@ BreakpointName *Target::FindBreakpointName(ConstString name, bool can_create,
 }
 
 void Target::DeleteBreakpointName(ConstString name) {
-  BreakpointNameList::iterator iter = m_breakpoint_names.find(name);
+  BreakpointNameMap::iterator iter = m_breakpoint_names.find(name);
 
   if (iter != m_breakpoint_names.end()) {
     const char *name_cstr = name.AsCString(nullptr);
@@ -945,8 +945,8 @@ void Target::ApplyNameToBreakpoints(BreakpointName &bp_name) {
 
 void Target::GetBreakpointNames(std::vector<std::string> &names) {
   names.clear();
-  for (const auto& bp_name_entry : m_breakpoint_names) {
-    names.push_back(bp_name_entry.first.GetString());
+  for (const auto &bp_name_entry : m_breakpoint_names) {
+    names.push_back(bp_name_entry.first().str());
   }
   llvm::sort(names);
 }


### PR DESCRIPTION
This changes 2 things:
1) BreakpointNameList is now called BreakpointNameMap to reflect the
   actual underlying data structure.
2) BreakpointNameMap goes from a `std::map` to a `llvm::StringMap` to
   eliminate the use of ConstString.