### PR TITLE
[flang][cuda] Materialize trivial computation to avoid data transfer error

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -5447,7 +5447,8 @@ private:
         fir::StoreOp::create(builder, loc, rhsVal, lhsVal);
       } else {
         cuf::DataTransferOp::create(builder, loc, rhsVal, lhsVal, shape,
-                                    transferKindAttr, hasManagedOrUnifedSymbols);
+                                    transferKindAttr,
+                                    hasManagedOrUnifedSymbols);
       }
       return;
     }

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -5443,8 +5443,12 @@ private:
       }
       auto transferKindAttr = cuf::DataTransferKindAttr::get(
           builder.getContext(), cuf::DataTransferKind::DeviceHost);
-      cuf::DataTransferOp::create(builder, loc, rhsVal, lhsVal, shape,
-                                  transferKindAttr, hasManagedOrUnifedSymbols);
+      if (fir::isa_trivial(rhsVal.getType())) {
+        fir::StoreOp::create(builder, loc, rhsVal, lhsVal);
+      } else {
+        cuf::DataTransferOp::create(builder, loc, rhsVal, lhsVal, shape,
+                                    transferKindAttr, hasManagedOrUnifedSymbols);
+      }
       return;
     }
 

--- a/flang/test/Lower/CUDA/cuda-data-transfer.cuf
+++ b/flang/test/Lower/CUDA/cuda-data-transfer.cuf
@@ -23,6 +23,8 @@ module mod1
 
   real(kind=8), device, allocatable, dimension(:) :: p
 
+  real, constant :: c1 = 1.0
+
   interface
     function __sum(a_d) result(res_h)
       integer(4), managed, intent(in) :: a_d(:,:,:,:)
@@ -495,7 +497,7 @@ subroutine sub25()
 end
 
 ! CHECK-LABEL: func.func @_QPsub25()
-! CHECK: fir.allocmem !fir.array<?xf64>, %15#1 {bindc_name = ".tmp", uniq_name = ""}
+! CHECK: fir.allocmem !fir.array<?xf64>, %{{.*}} {bindc_name = ".tmp", uniq_name = ""}
 ! CHECK: cuf.data_transfer %{{.*}} to %{{.*}} {transfer_kind = #cuf.cuda_transfer<device_host>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf64>>>>, !fir.box<!fir.array<?xf64>>
 ! CHECK: hlfir.assign %{{.*}} to %{{.*}} : f64, !fir.ref<f64>
 ! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.array<?xf64>>
@@ -724,3 +726,14 @@ subroutine sub41()
   
   lm(1:5) = a%m(1:5)
 end subroutine
+
+subroutine sub42()
+  use mod1
+  real :: a
+  a = c1 * c1
+end subroutine
+
+! CHECK-LABEL: func.func @_QPsub42()
+! CHECK: %[[RES:.*]] = arith.mulf
+! CHECK: fir.store %[[RES]] to %{{.*}} : !fir.ref<f32>
+! CHECK-NOT: cuf.data_transfer

--- a/flang/test/Lower/CUDA/cuda-data-transfer.cuf
+++ b/flang/test/Lower/CUDA/cuda-data-transfer.cuf
@@ -24,6 +24,7 @@ module mod1
   real(kind=8), device, allocatable, dimension(:) :: p
 
   real, constant :: c1 = 1.0
+  real, device :: d1 = 1.0
 
   interface
     function __sum(a_d) result(res_h)
@@ -736,4 +737,25 @@ end subroutine
 ! CHECK-LABEL: func.func @_QPsub42()
 ! CHECK: %[[RES:.*]] = arith.mulf
 ! CHECK: fir.store %[[RES]] to %{{.*}} : !fir.ref<f32>
+! CHECK-NOT: cuf.data_transfer
+
+subroutine sub43()
+  use mod1
+  real :: a
+  a = d1 * d1
+end subroutine
+
+! CHECK-LABEL: func.func @_QPsub43()
+! CHECK: %[[RES:.*]] = arith.mulf
+! CHECK: fir.store %[[RES]] to %{{.*}} : !fir.ref<f32>
+! CHECK-NOT: cuf.data_transfer
+
+subroutine sub44()
+  use mod1
+  real :: a
+  a = -d1
+end subroutine
+
+! CHECK-LABEL: func.func @_QPsub44()
+! CHECK: arith.negf
 ! CHECK-NOT: cuf.data_transfer


### PR DESCRIPTION
Avoid this error: `error: 'cuf.data_transfer' op expect src and dst to be references or descriptors or src to be a constant: 'f32' - '!fir.ref<f32>'`