### PR TITLE
[lldb] Disable dynamic script interpreters by default under Xcode

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -190,7 +190,7 @@ else()
   set(LLDB_ENABLE_MTE OFF)
 endif()
 
-if (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD")
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD" AND NOT CMAKE_GENERATOR MATCHES "Xcode")
   set(default_enable_dynamic_scriptinterpreters ON)
 else()
   set(default_enable_dynamic_scriptinterpreters OFF)


### PR DESCRIPTION
When LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS is set, liblldb's export list is built by merging the undefined LLDB symbols extracted from each script interpreter plugin's objects (119e57630281). Because the plugins link liblldb, the generated file is wired into liblldb's link via LINK_DEPENDS, a file-level dependency with no target-level edge.

The Xcode generator only has coarse target-level dependencies, so that generated liblldb-script-interpreter.exports ends up attached to two targets with no common dependency, which its "new build system" rejects at generation time:

```
  CMake Error in source/API/CMakeLists.txt:
    .../source/API/liblldb-script-interpreter.exports
    is attached to multiple targets ... but none of these is a common
    dependency of the other(s). This is not allowed by the Xcode "new
    build system".
```

Default the option to OFF under the Xcode generator. The script interpreter plugins are then linked statically into liblldb and the per-plugin export path is never taken.

rdar://180422686