### PR TITLE
[DRAFT][Runtimes] Make runtimes configure wait for flang in shared-library builds

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -367,6 +367,16 @@ function(runtime_default_target)
                            ${EXTRA_ARGS} ${ARG_EXTRA_ARGS})
 
   add_flang_mod_deps(runtimes-build ${extra_targets} ${test_targets})
+
+  # The runtimes configure step runs `flang` for CMake's Fortran ABI detection
+  # (enable_language(Fortran)). The mock `flang-lazy` driver only guarantees
+  # that bin/flang *exists*, not that its shared libraries are fully linked, so
+  # in a shared-library build the configure step can race with the linking of
+  # e.g. libFortranLower.so. Force the real flang (and its shared libraries) to
+  # be built first in that configuration; static builds keep the mock fast path.
+  if(LLVM_LINK_LLVM_DYLIB OR BUILD_SHARED_LIBS)
+    add_flang_mod_deps(runtimes-configure)
+  endif()
 endfunction()
 
 # runtime_register_target(name)
@@ -523,6 +533,13 @@ function(runtime_register_target name)
   endforeach()
 
   add_flang_mod_deps(runtimes-${name}-build ${${name}_extra_targets})
+
+  # See the comment in runtime_default_target: the configure step executes the
+  # real flang, so in shared-library builds it must wait for flang's shared
+  # libraries to be linked rather than racing against them.
+  if(LLVM_LINK_LLVM_DYLIB OR BUILD_SHARED_LIBS)
+    add_flang_mod_deps(runtimes-${name}-configure)
+  endif()
 endfunction()
 
 # Check if we have any runtimes to build.


### PR DESCRIPTION
(This was an experiment to try something out. It dramatically increased buildbot times, so not good.)

The `runtimes` external-project configure step runs `flang` for CMake's Fortran ABI detection (`enable_language(Fortran)` in `runtimes/cmake/config-Fortran.cmake`). Since #198205 dropped `flang` from the configure dependency, the only Fortran-related dependency of the configure step is the mock `flang-lazy`/`fakeflang` driver, which merely guarantees that `bin/flang` exists -- not that flang's shared libraries are fully linked.

In a shared-library build (`BUILD_SHARED_LIBS`/`LLVM_LINK_LLVM_DYLIB`), the real `flang` executable and each `lib*.so` are independent ninja edges, so the configure step can be scheduled while e.g. `libFortranLower.so` is still being linked. Running flang then fails with "error while loading shared libraries: libFortranLower.so: file too short", aborting the runtimes configure (llvm/llvm-project#205360).

Restore an ordering dependency from the configure step to the full `flang` target (and therefore its shared libraries) in shared-library builds only. Static and standalone builds keep the mock fast path, where `bin/flang` existing implies it is runnable, preserving the #198205 distribution optimization where it is safe.

Assisted-by: AI