### PR TITLE
[lldb][NFC] Change type of Breakpoint's name list

### DIFF
--- a/lldb/include/lldb/Breakpoint/Breakpoint.h
+++ b/lldb/include/lldb/Breakpoint/Breakpoint.h
@@ -689,10 +689,9 @@ private:
   bool
       m_hardware; // If this breakpoint is required to use a hardware breakpoint
   Target &m_target; // The target that holds this breakpoint.
-  llvm::StringSet<> m_name_list; // If not empty, this is the name
-                                 // of this breakpoint (many
-                                 // breakpoints can share the same
-                                 // name.)
+  /// If not empty, this is the name of this breakpoint (many breakpoints can
+  /// share the same name.)
+  llvm::StringSet<> m_name_list; 
   lldb::SearchFilterSP
       m_filter_sp; // The filter that constrains the breakpoint's domain.
   lldb::BreakpointResolverSP

--- a/lldb/include/lldb/Breakpoint/Breakpoint.h
+++ b/lldb/include/lldb/Breakpoint/Breakpoint.h
@@ -691,7 +691,7 @@ private:
   Target &m_target; // The target that holds this breakpoint.
   /// If not empty, this is the name of this breakpoint (many breakpoints can
   /// share the same name.)
-  llvm::StringSet<> m_name_list; 
+  llvm::StringSet<> m_name_list;
   lldb::SearchFilterSP
       m_filter_sp; // The filter that constrains the breakpoint's domain.
   lldb::BreakpointResolverSP

--- a/lldb/include/lldb/Breakpoint/Breakpoint.h
+++ b/lldb/include/lldb/Breakpoint/Breakpoint.h
@@ -27,6 +27,8 @@
 #include "lldb/Utility/StringList.h"
 #include "lldb/Utility/StructuredData.h"
 
+#include "llvm/ADT/StringSet.h"
+
 namespace lldb_private {
 
 /// \class Breakpoint Breakpoint.h "lldb/Breakpoint/Breakpoint.h" Class that
@@ -583,8 +585,8 @@ public:
 
   void GetNames(std::vector<std::string> &names) {
     names.clear();
-    for (auto name : m_name_list) {
-      names.push_back(name);
+    for (auto name : m_name_list.keys()) {
+      names.push_back(name.str());
     }
   }
 
@@ -687,10 +689,10 @@ private:
   bool
       m_hardware; // If this breakpoint is required to use a hardware breakpoint
   Target &m_target; // The target that holds this breakpoint.
-  std::unordered_set<std::string> m_name_list; // If not empty, this is the name
-                                               // of this breakpoint (many
-                                               // breakpoints can share the same
-                                               // name.)
+  llvm::StringSet<> m_name_list; // If not empty, this is the name
+                                 // of this breakpoint (many
+                                 // breakpoints can share the same
+                                 // name.)
   lldb::SearchFilterSP
       m_filter_sp; // The filter that constrains the breakpoint's domain.
   lldb::BreakpointResolverSP

--- a/lldb/source/Breakpoint/Breakpoint.cpp
+++ b/lldb/source/Breakpoint/Breakpoint.cpp
@@ -88,7 +88,7 @@ StructuredData::ObjectSP Breakpoint::SerializeToStructuredData() {
 
   if (!m_name_list.empty()) {
     StructuredData::ArraySP names_array_sp(new StructuredData::Array());
-    for (auto name : m_name_list) {
+    for (auto name : m_name_list.keys()) {
       names_array_sp->AddItem(std::make_shared<StructuredData::String>(name));
     }
     breakpoint_contents_sp->AddItem(Breakpoint::GetKey(OptionNames::Names),
@@ -1003,9 +1003,9 @@ void Breakpoint::GetDescriptionForType(Stream *s, lldb::DescriptionLevel level,
         s->Printf("Names:");
         s->EOL();
         s->IndentMore();
-        for (const std::string &name : m_name_list) {
+        for (llvm::StringRef name : m_name_list.keys()) {
           s->Indent();
-          s->Printf("%s\n", name.c_str());
+          s->Format("{0}\n", name);
         }
         s->IndentLess();
       }


### PR DESCRIPTION
This is currently a `std::unordered_set<std::string>`. The downside of this is that you need to have a `std::string` to perform a lookup of any kind. This may require an allocation whenever we want to query the name list. Even using `std::string_view` is not sufficient to perform a lookup.

I propose that this instead be a `llvm::StringSet` which uses StringRefs as its primary currency for insertions, lookups, and more.