### PR TITLE
[AMDGPU][True16][GlobalISel] Update True16 handling for FMA_MIX instructions in GlobalISel

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -7186,6 +7186,27 @@ AMDGPUInstructionSelector::selectSMRDBufferSgprImm(MachineOperand &Root) const {
            [=](MachineInstrBuilder &MIB) { MIB.addImm(*EncodedOffset); }}};
 }
 
+static Register createVOP3PSrc32FromLo16(Register Src, MachineInstr *MI,
+                                         MachineRegisterInfo &MRI,
+                                         const SIInstrInfo &TII,
+                                         const AMDGPUSubtarget &ST) {
+  MachineIRBuilder B(*MI);
+
+  // Create an vgpr_16 for the hi16 part using IMPLICIT_DEF
+  Register ImpdefReg = MRI.createVirtualRegister(&AMDGPU::VGPR_16RegClass);
+  B.buildInstr(TargetOpcode::IMPLICIT_DEF).addDef(ImpdefReg);
+
+  Register DstReg = MRI.createVirtualRegister(&AMDGPU::VGPR_32RegClass);
+  B.buildInstr(AMDGPU::REG_SEQUENCE)
+      .addDef(DstReg)
+      .addReg(Src)
+      .addImm(AMDGPU::lo16)
+      .addReg(ImpdefReg)
+      .addImm(AMDGPU::hi16);
+
+  return DstReg;
+}
+
 std::pair<Register, unsigned>
 AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
                                                      bool &Matched) const {
@@ -7231,13 +7252,10 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
       Mods |= SISrcMods::OP_SEL_0;
       CheckAbsNeg();
     }
-    // Since we looked through FPEXT and removed it, we must also remove
-    // G_TRUNC. G_TRUNC to 16-bits would have a destination in RC VGPR_16, which
-    // is not compatible with MadMix instructions
-    Register PeekSrc = Src;
-    if (Subtarget->useRealTrue16Insts() &&
-        mi_match(PeekSrc, *MRI, m_GTrunc(m_Reg(PeekSrc))))
-      Src = PeekSrc;
+
+    if (Subtarget->useRealTrue16Insts())
+      Src = createVOP3PSrc32FromLo16(Src, Root.getParent(), *MRI, TII,
+                                     *Subtarget);
 
     Matched = true;
   }

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -2960,6 +2960,34 @@ static bool isExtractHiElt(MachineRegisterInfo &MRI, Register In,
   return false;
 }
 
+// Counterpart of isExtractHiElt for the lower 16 bits. Instructions that read a
+// 32-bit source and use op_sel to pick the half to operate on do not need the
+// extraction at all, so find the 32-bit register that `In` is the low half of.
+static bool isExtractLoElt(MachineRegisterInfo &MRI, Register In,
+                           Register &Out) {
+  // There could be a bitcast between the extraction and its use.
+  In = stripBitCast(In, MRI);
+
+  // The first def of a 2 x 16-bit unmerge is the low half of its source.
+  if (auto *Unmerge = dyn_cast<GUnmerge>(MRI.getVRegDef(In))) {
+    if (Unmerge->getNumDefs() == 2 && Unmerge->getOperand(0).getReg() == In &&
+        MRI.getType(In).getSizeInBits() == 16) {
+      Out = Unmerge->getSourceReg();
+      return true;
+    }
+  }
+
+  // A truncation from 32 to 16 bits keeps the low half in place
+  Register Trunc;
+  if (mi_match(In, MRI, m_GTrunc(m_Reg(Trunc))) &&
+      MRI.getType(Trunc).getSizeInBits() == 32) {
+    Out = stripBitCast(Trunc, MRI);
+    return true;
+  }
+
+  return false;
+}
+
 bool AMDGPUInstructionSelector::selectG_FPEXT(MachineInstr &I) const {
   if (!Subtarget->hasSALUFloatInsts())
     return false;
@@ -4579,6 +4607,13 @@ bool AMDGPUInstructionSelector::select(MachineInstr &I) {
     if (selectImpl(I, *CoverageInfo))
       return true;
     return selectG_ADD_SUB(I);
+  case TargetOpcode::G_FMA:
+  case TargetOpcode::G_FADD:
+  case TargetOpcode::G_FMUL:
+  case TargetOpcode::G_FSUB:
+    if (selectVOP3PMadMixF32(I))
+      return true;
+    return selectImpl(I, *CoverageInfo);
   case TargetOpcode::G_UADDO:
   case TargetOpcode::G_USUBO:
   case TargetOpcode::G_UADDE:
@@ -7186,32 +7221,22 @@ AMDGPUInstructionSelector::selectSMRDBufferSgprImm(MachineOperand &Root) const {
            [=](MachineInstrBuilder &MIB) { MIB.addImm(*EncodedOffset); }}};
 }
 
-// Place a 16-bit source into the low half of a new 32-bit VGPR
-static Register createVOP3PSrc32FromLo16(Register Src, MachineInstr *InsertPt,
-                                         MachineRegisterInfo &MRI) {
-  MachineIRBuilder B(*InsertPt);
+// In True16 instructions 16-bit VALU values live in VGPR_16 and must be
+// widened before a mix instruction can read them. 16-bit SALU values are
+// already in an SGPR_32.
+bool AMDGPUInstructionSelector::madMixSrcNeedsWiden(Register Src) const {
+  if (!Subtarget->useRealTrue16Insts() ||
+      MRI->getType(Src).getSizeInBits() != 16)
+    return false;
 
-  // Create an vgpr_16 for the hi16 part using IMPLICIT_DEF
-  Register ImpdefReg = MRI.createVirtualRegister(&AMDGPU::VGPR_16RegClass);
-  B.buildInstr(TargetOpcode::IMPLICIT_DEF).addDef(ImpdefReg);
-
-  Register DstReg = MRI.createVirtualRegister(&AMDGPU::VGPR_32RegClass);
-  B.buildInstr(AMDGPU::REG_SEQUENCE)
-      .addDef(DstReg)
-      .addReg(Src)
-      .addImm(AMDGPU::lo16)
-      .addReg(ImpdefReg)
-      .addImm(AMDGPU::hi16);
-
-  return DstReg;
+  const RegisterBank *SrcRB = RBI.getRegBank(Src, *MRI, TRI);
+  return SrcRB && SrcRB->getID() == AMDGPU::VGPRRegBankID;
 }
 
 std::pair<Register, unsigned>
 AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
-                                                     bool &Matched,
-                                                     bool &NeedsWiden) const {
+                                                     bool &Matched) const {
   Matched = false;
-  NeedsWiden = false;
 
   Register Src;
   unsigned Mods;
@@ -7249,20 +7274,13 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
 
     Mods |= SISrcMods::OP_SEL_1;
 
-    // The instruction reads a 32-bit source and selects a half of it
-    // so we search for that 32-bit source
-    Register Src32;
+    // When a 32-bit register already holds the value, use it. Otherwise Src
+    // stays 16-bit, which madMixSrcNeedsWiden keys off in the manual matcher
     if (isExtractHiElt(*MRI, Src, Src)) {
-      // Src is now the 32-bit source and op_sel picks its high half.
       Mods |= SISrcMods::OP_SEL_0;
       CheckAbsNeg();
-    } else if (mi_match(Src, *MRI, m_GTrunc(m_Reg(Src32))) &&
-               MRI->getType(Src32) == LLT::scalar(32)) {
-      // Technically a 16-bit source, but the trunc is redundant
-      Src = Src32;
     } else {
-      // In True16, the source is genuinely 16 bits wide so we widen it
-      NeedsWiden = Subtarget->useRealTrue16Insts();
+      isExtractLoElt(*MRI, Src, Src);
     }
 
     Matched = true;
@@ -7277,19 +7295,13 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsExt(
   Register Src;
   unsigned Mods;
   bool Matched;
-  bool NeedsWiden;
-  std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched, NeedsWiden);
-  if (!Matched)
+  std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched);
+
+  if (!Matched || madMixSrcNeedsWiden(Src))
     return {};
 
-  MachineRegisterInfo *RegInfo = MRI;
   return {{
-      [=](MachineInstrBuilder &MIB) {
-        Register Reg = Src;
-        if (NeedsWiden)
-          Reg = createVOP3PSrc32FromLo16(Src, MIB.getInstr(), *RegInfo);
-        MIB.addReg(Reg);
-      },
+      [=](MachineInstrBuilder &MIB) { MIB.addReg(Src); },
       [=](MachineInstrBuilder &MIB) { MIB.addImm(Mods); } // src_mods
   }};
 }
@@ -7299,19 +7311,132 @@ AMDGPUInstructionSelector::selectVOP3PMadMixMods(MachineOperand &Root) const {
   Register Src;
   unsigned Mods;
   bool Matched;
-  bool NeedsWiden;
-  std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched, NeedsWiden);
+  std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched);
 
-  MachineRegisterInfo *RegInfo = MRI;
+  if (madMixSrcNeedsWiden(Src))
+    std::tie(Src, Mods) = selectVOP3ModsImpl(Root.getReg());
+
   return {{
-      [=](MachineInstrBuilder &MIB) {
-        Register Reg = Src;
-        if (NeedsWiden)
-          Reg = createVOP3PSrc32FromLo16(Src, MIB.getInstr(), *RegInfo);
-        MIB.addReg(Reg);
-      },
+      [=](MachineInstrBuilder &MIB) { MIB.addReg(Src); },
       [=](MachineInstrBuilder &MIB) { MIB.addImm(Mods); } // src_mods
   }};
+}
+
+// With real true16 instructions a 16-bit value lives in a VGPR_16, which cannot
+// be used as a source of the 32-bit mix instructions. Widening it needs a
+// REG_SEQUENCE
+bool AMDGPUInstructionSelector::selectVOP3PMadMixF32(MachineInstr &I) const {
+  if (!Subtarget->useRealTrue16Insts() || !Subtarget->hasFmaMixInsts())
+    return false;
+
+  Register Dst = I.getOperand(0).getReg();
+  if (MRI->getType(Dst) != LLT::scalar(32) ||
+      RBI.getRegBank(Dst, *MRI, TRI)->getID() != AMDGPU::VGPRRegBankID)
+    return false;
+
+  struct MixSrc {
+    Register Reg;
+    int64_t Imm = 0;
+    unsigned Mods = SISrcMods::NONE;
+    bool IsImm = false;
+    bool NeedsWiden = false;
+  } Srcs[3];
+
+  const auto MatchReg = [&](MixSrc &S, MachineOperand &Op) {
+    bool Matched;
+    std::tie(S.Reg, S.Mods) = selectVOP3PMadMixModsImpl(Op, Matched);
+    S.NeedsWiden = madMixSrcNeedsWiden(S.Reg);
+  };
+  const auto SetImm = [](MixSrc &S, int64_t Imm, unsigned Mods) {
+    S.IsImm = true;
+    S.Imm = Imm;
+    S.Mods = Mods;
+  };
+
+  switch (I.getOpcode()) {
+  case TargetOpcode::G_FMA:
+    MatchReg(Srcs[0], I.getOperand(1));
+    MatchReg(Srcs[1], I.getOperand(2));
+    MatchReg(Srcs[2], I.getOperand(3));
+    break;
+  case TargetOpcode::G_FADD:
+    // (fadd x, y) -> (fma x, 1.0, y)
+    MatchReg(Srcs[0], I.getOperand(1));
+    SetImm(Srcs[1], 0x3C00 /*half 1.0*/, SISrcMods::OP_SEL_1);
+    MatchReg(Srcs[2], I.getOperand(2));
+    break;
+  case TargetOpcode::G_FMUL:
+    // (fmul x, y) -> (fma x, y, -0.0)
+    MatchReg(Srcs[0], I.getOperand(1));
+    MatchReg(Srcs[1], I.getOperand(2));
+    SetImm(Srcs[2], 0, SISrcMods::NEG);
+    break;
+  case TargetOpcode::G_FSUB:
+    // (fsub x, y) -> (fma y, -1.0, x)
+    MatchReg(Srcs[0], I.getOperand(2));
+    SetImm(Srcs[1], 0xBC00 /*half -1.0*/, SISrcMods::OP_SEL_1);
+    MatchReg(Srcs[2], I.getOperand(1));
+    break;
+  default:
+    return false;
+  }
+
+  if (none_of(Srcs, [](const MixSrc &S) { return S.NeedsWiden; }))
+    return false;
+
+  // Constrain the sources that are about to be widened before creating
+  // anything, so that a failure here leaves the function untouched.
+  for (const MixSrc &S : Srcs) {
+    if (S.NeedsWiden &&
+        !RBI.constrainGenericRegister(S.Reg, AMDGPU::VGPR_16RegClass, *MRI))
+      return false;
+  }
+
+  MachineBasicBlock *BB = I.getParent();
+  const DebugLoc &DL = I.getDebugLoc();
+
+  for (MixSrc &S : Srcs) {
+    if (!S.NeedsWiden)
+      continue;
+
+    // Place the 16-bit value in the low half of a fresh 32-bit register
+    Register Undef = MRI->createVirtualRegister(&AMDGPU::VGPR_16RegClass);
+    BuildMI(*BB, &I, DL, TII.get(TargetOpcode::IMPLICIT_DEF), Undef);
+
+    Register Wide = MRI->createVirtualRegister(&AMDGPU::VGPR_32RegClass);
+    BuildMI(*BB, &I, DL, TII.get(TargetOpcode::REG_SEQUENCE), Wide)
+        .addReg(S.Reg)
+        .addImm(AMDGPU::lo16)
+        .addReg(Undef)
+        .addImm(AMDGPU::hi16);
+    S.Reg = Wide;
+  }
+
+  // Mirror the flag handling of the TableGen selector: the generic instruction
+  // cannot raise an FP exception but the mix instruction can, so the result has
+  // to be marked as not raising one.
+  const MCInstrDesc &MixDesc = TII.get(AMDGPU::V_FMA_MIX_F32);
+  uint32_t Flags = I.getFlags();
+  if (!I.getDesc().mayRaiseFPException() && MixDesc.mayRaiseFPException())
+    Flags |= MachineInstr::NoFPExcept;
+
+  auto MIB = BuildMI(*BB, &I, DL, MixDesc, Dst).setMIFlags(Flags);
+  for (const MixSrc &S : Srcs) {
+    MIB.addImm(S.Mods);
+    if (S.IsImm)
+      MIB.addImm(S.Imm);
+    else
+      MIB.addReg(S.Reg);
+  }
+  // The per-source op_sel and op_sel_hi bits are carried by the modifiers, so
+  // the dedicated operands stay at their default of 0, as in the patterns.
+  MIB.addImm(0); // clamp
+  MIB.addImm(0); // op_sel
+  MIB.addImm(0); // op_sel_hi
+
+  I.eraseFromParent();
+  constrainSelectedInstRegOperands(*MIB, TII, TRI, RBI);
+  return true;
 }
 
 bool AMDGPUInstructionSelector::selectSBarrierSignalIsfirst(

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -7231,6 +7231,13 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
       Mods |= SISrcMods::OP_SEL_0;
       CheckAbsNeg();
     }
+    // Since we looked through FPEXT and removed it, we must also remove
+    // G_TRUNC. G_TRUNC to 16-bits would have a destination in RC VGPR_16, which
+    // is not compatible with MadMix instructions
+    Register PeekSrc = Src;
+    if (Subtarget->useRealTrue16Insts() &&
+        mi_match(PeekSrc, *MRI, m_GTrunc(m_Reg(PeekSrc))))
+      Src = PeekSrc;
 
     Matched = true;
   }

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -7186,11 +7186,10 @@ AMDGPUInstructionSelector::selectSMRDBufferSgprImm(MachineOperand &Root) const {
            [=](MachineInstrBuilder &MIB) { MIB.addImm(*EncodedOffset); }}};
 }
 
-static Register createVOP3PSrc32FromLo16(Register Src, MachineInstr *MI,
-                                         MachineRegisterInfo &MRI,
-                                         const SIInstrInfo &TII,
-                                         const AMDGPUSubtarget &ST) {
-  MachineIRBuilder B(*MI);
+// Place a 16-bit source into the low half of a new 32-bit VGPR
+static Register createVOP3PSrc32FromLo16(Register Src, MachineInstr *InsertPt,
+                                         MachineRegisterInfo &MRI) {
+  MachineIRBuilder B(*InsertPt);
 
   // Create an vgpr_16 for the hi16 part using IMPLICIT_DEF
   Register ImpdefReg = MRI.createVirtualRegister(&AMDGPU::VGPR_16RegClass);
@@ -7209,8 +7208,10 @@ static Register createVOP3PSrc32FromLo16(Register Src, MachineInstr *MI,
 
 std::pair<Register, unsigned>
 AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
-                                                     bool &Matched) const {
+                                                     bool &Matched,
+                                                     bool &NeedsWiden) const {
   Matched = false;
+  NeedsWiden = false;
 
   Register Src;
   unsigned Mods;
@@ -7248,14 +7249,21 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
 
     Mods |= SISrcMods::OP_SEL_1;
 
+    // The instruction reads a 32-bit source and selects a half of it
+    // so we search for that 32-bit source
+    Register Src32;
     if (isExtractHiElt(*MRI, Src, Src)) {
+      // Src is now the 32-bit source and op_sel picks its high half.
       Mods |= SISrcMods::OP_SEL_0;
       CheckAbsNeg();
+    } else if (mi_match(Src, *MRI, m_GTrunc(m_Reg(Src32))) &&
+               MRI->getType(Src32) == LLT::scalar(32)) {
+      // Technically a 16-bit source, but the trunc is redundant
+      Src = Src32;
+    } else {
+      // In True16, the source is genuinely 16 bits wide so we widen it
+      NeedsWiden = Subtarget->useRealTrue16Insts();
     }
-
-    if (Subtarget->useRealTrue16Insts())
-      Src = createVOP3PSrc32FromLo16(Src, Root.getParent(), *MRI, TII,
-                                     *Subtarget);
 
     Matched = true;
   }
@@ -7269,12 +7277,19 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsExt(
   Register Src;
   unsigned Mods;
   bool Matched;
-  std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched);
+  bool NeedsWiden;
+  std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched, NeedsWiden);
   if (!Matched)
     return {};
 
+  MachineRegisterInfo *RegInfo = MRI;
   return {{
-      [=](MachineInstrBuilder &MIB) { MIB.addReg(Src); },
+      [=](MachineInstrBuilder &MIB) {
+        Register Reg = Src;
+        if (NeedsWiden)
+          Reg = createVOP3PSrc32FromLo16(Src, MIB.getInstr(), *RegInfo);
+        MIB.addReg(Reg);
+      },
       [=](MachineInstrBuilder &MIB) { MIB.addImm(Mods); } // src_mods
   }};
 }
@@ -7284,10 +7299,17 @@ AMDGPUInstructionSelector::selectVOP3PMadMixMods(MachineOperand &Root) const {
   Register Src;
   unsigned Mods;
   bool Matched;
-  std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched);
+  bool NeedsWiden;
+  std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched, NeedsWiden);
 
+  MachineRegisterInfo *RegInfo = MRI;
   return {{
-      [=](MachineInstrBuilder &MIB) { MIB.addReg(Src); },
+      [=](MachineInstrBuilder &MIB) {
+        Register Reg = Src;
+        if (NeedsWiden)
+          Reg = createVOP3PSrc32FromLo16(Src, MIB.getInstr(), *RegInfo);
+        MIB.addReg(Reg);
+      },
       [=](MachineInstrBuilder &MIB) { MIB.addImm(Mods); } // src_mods
   }};
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -7183,7 +7183,7 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
   unsigned Mods;
   std::tie(Src, Mods) = selectVOP3ModsImpl(Root.getReg());
 
-  if (!STI.useRealTrue16Insts() && mi_match(Src, *MRI, m_GFPExt(m_Reg(Src)))) {
+  if (mi_match(Src, *MRI, m_GFPExt(m_Reg(Src)))) {
     assert(MRI->getType(Src) == LLT::scalar(16));
 
     // Only change Src if src modifier could be gained. In such cases new Src

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -2895,6 +2895,31 @@ static bool isExtractHiElt(MachineRegisterInfo &MRI, Register In,
   return false;
 }
 
+static bool isExtractLoElt(MachineRegisterInfo &MRI, Register In,
+                           Register &Out) {
+  // There could be a bitcast between the extraction and its use.
+  In = stripBitCast(In, MRI);
+
+  // The first def of a 2 x 16-bit unmerge is the low half of its source.
+  if (auto *Unmerge = dyn_cast<GUnmerge>(MRI.getVRegDef(In))) {
+    if (Unmerge->getNumDefs() == 2 && Unmerge->getOperand(0).getReg() == In &&
+        MRI.getType(In).getSizeInBits() == 16) {
+      Out = Unmerge->getSourceReg();
+      return true;
+    }
+  }
+
+  // A truncation from 32 to 16 bits keeps the low half in place.
+  Register Trunc;
+  if (mi_match(In, MRI, m_GTrunc(m_Reg(Trunc))) &&
+      MRI.getType(Trunc).getSizeInBits() == 32) {
+    Out = stripBitCast(Trunc, MRI);
+    return true;
+  }
+
+  return false;
+}
+
 bool AMDGPUInstructionSelector::selectG_FPEXT(MachineInstr &I) const {
   if (!Subtarget->hasSALUFloatInsts())
     return false;
@@ -7120,6 +7145,26 @@ AMDGPUInstructionSelector::selectSMRDBufferSgprImm(MachineOperand &Root) const {
            [=](MachineInstrBuilder &MIB) { MIB.addImm(*EncodedOffset); }}};
 }
 
+// Place a 16-bit source into the low half of a new 32-bit VGPR.
+static Register createVOP3PSrc32FromLo16(Register Src, MachineInstr *InsertPt,
+                                         MachineRegisterInfo &MRI) {
+  MachineIRBuilder B(*InsertPt);
+
+  // Create an vgpr_16 for the hi16 part using IMPLICIT_DEF
+  Register ImpdefReg = MRI.createVirtualRegister(&AMDGPU::VGPR_16RegClass);
+  B.buildInstr(TargetOpcode::IMPLICIT_DEF).addDef(ImpdefReg);
+
+  Register DstReg = MRI.createVirtualRegister(&AMDGPU::VGPR_32RegClass);
+  B.buildInstr(AMDGPU::REG_SEQUENCE)
+      .addDef(DstReg)
+      .addReg(Src)
+      .addImm(AMDGPU::lo16)
+      .addReg(ImpdefReg)
+      .addImm(AMDGPU::hi16);
+
+  return DstReg;
+}
+
 std::pair<Register, unsigned>
 AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
                                                      bool &Matched) const {
@@ -7161,9 +7206,20 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
 
     Mods |= SISrcMods::OP_SEL_1;
 
+    // The instruction reads a 32-bit source and selects a half of it, so look
+    // for the 32-bit register the 16-bit value is a half of.
     if (isExtractHiElt(*MRI, Src, Src)) {
+      // Src is now the 32-bit source and op_sel picks its high half.
       Mods |= SISrcMods::OP_SEL_0;
       CheckAbsNeg();
+    } else if (!isExtractLoElt(*MRI, Src, Src)) {
+      // Src is genuinely 16 bits wide. With real true16 instructions a 16-bit
+      // VALU value lives in a VGPR_16, which the mix instructions cannot read,
+      // so widen it. 16-bit SALU values already occupy a full SGPR_32.
+      const RegisterBank *SrcRB = RBI.getRegBank(Src, *MRI, TRI);
+      if (Subtarget->useRealTrue16Insts() && SrcRB &&
+          SrcRB->getID() == AMDGPU::VGPRRegBankID)
+        Src = createVOP3PSrc32FromLo16(Src, Root.getParent(), *MRI);
     }
 
     Matched = true;

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -4752,6 +4752,34 @@ Register AMDGPUInstructionSelector::copyToVGPRIfSrcFolded(
   return Src;
 }
 
+/// The mix instructions read 32-bit sources. With real true16 instructions a
+/// 16-bit VALU value lives in a VGPR_16, which they cannot read, so place it in
+/// the low half of a new 32-bit VGPR.
+Register AMDGPUInstructionSelector::widenMadMixSrcIfVGPR16(
+    Register Src, MachineInstr *InsertPt) const {
+  if (!Subtarget->useRealTrue16Insts() || MRI->getType(Src) != LLT::scalar(16))
+    return Src;
+
+  const RegisterBank *SrcRB = RBI.getRegBank(Src, *MRI, TRI);
+  if (!SrcRB || SrcRB->getID() != AMDGPU::VGPRRegBankID)
+    return Src;
+
+  MachineIRBuilder B(*InsertPt);
+
+  Register ImpDefReg = MRI->createVirtualRegister(&AMDGPU::VGPR_16RegClass);
+  B.buildInstr(TargetOpcode::IMPLICIT_DEF).addDef(ImpDefReg);
+
+  Register DstReg = MRI->createVirtualRegister(&AMDGPU::VGPR_32RegClass);
+  B.buildInstr(AMDGPU::REG_SEQUENCE)
+      .addDef(DstReg)
+      .addReg(Src)
+      .addImm(AMDGPU::lo16)
+      .addReg(ImpDefReg)
+      .addImm(AMDGPU::hi16);
+
+  return DstReg;
+}
+
 ///
 /// This will select either an SGPR or VGPR operand and will save us from
 /// having to write an extra tablegen pattern.
@@ -7145,26 +7173,6 @@ AMDGPUInstructionSelector::selectSMRDBufferSgprImm(MachineOperand &Root) const {
            [=](MachineInstrBuilder &MIB) { MIB.addImm(*EncodedOffset); }}};
 }
 
-// Place a 16-bit source into the low half of a new 32-bit VGPR.
-static Register createVOP3PSrc32FromLo16(Register Src, MachineInstr *InsertPt,
-                                         MachineRegisterInfo &MRI) {
-  MachineIRBuilder B(*InsertPt);
-
-  // Create an vgpr_16 for the hi16 part using IMPLICIT_DEF
-  Register ImpdefReg = MRI.createVirtualRegister(&AMDGPU::VGPR_16RegClass);
-  B.buildInstr(TargetOpcode::IMPLICIT_DEF).addDef(ImpdefReg);
-
-  Register DstReg = MRI.createVirtualRegister(&AMDGPU::VGPR_32RegClass);
-  B.buildInstr(AMDGPU::REG_SEQUENCE)
-      .addDef(DstReg)
-      .addReg(Src)
-      .addImm(AMDGPU::lo16)
-      .addReg(ImpdefReg)
-      .addImm(AMDGPU::hi16);
-
-  return DstReg;
-}
-
 std::pair<Register, unsigned>
 AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
                                                      bool &Matched) const {
@@ -7212,14 +7220,12 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
       // Src is now the 32-bit source and op_sel picks its high half.
       Mods |= SISrcMods::OP_SEL_0;
       CheckAbsNeg();
-    } else if (!isExtractLoElt(*MRI, Src, Src)) {
-      // Src is genuinely 16 bits wide. With real true16 instructions a 16-bit
-      // VALU value lives in a VGPR_16, which the mix instructions cannot read,
-      // so widen it. 16-bit SALU values already occupy a full SGPR_32.
-      const RegisterBank *SrcRB = RBI.getRegBank(Src, *MRI, TRI);
-      if (Subtarget->useRealTrue16Insts() && SrcRB &&
-          SrcRB->getID() == AMDGPU::VGPRRegBankID)
-        Src = createVOP3PSrc32FromLo16(Src, Root.getParent(), *MRI);
+    } else {
+      // op_sel already picks the low half, so use the 32-bit source directly if
+      // the 16-bit value is the low half of one. Otherwise Src is genuinely 16
+      // bits wide and widenMadMixSrcIfVGPR16 widens it when the operand is
+      // rendered.
+      isExtractLoElt(*MRI, Src, Src);
     }
 
     Matched = true;
@@ -7239,7 +7245,9 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsExt(
     return {};
 
   return {{
-      [=](MachineInstrBuilder &MIB) { MIB.addReg(Src); },
+      [=](MachineInstrBuilder &MIB) {
+        MIB.addReg(widenMadMixSrcIfVGPR16(Src, MIB));
+      },
       [=](MachineInstrBuilder &MIB) { MIB.addImm(Mods); } // src_mods
   }};
 }
@@ -7252,7 +7260,9 @@ AMDGPUInstructionSelector::selectVOP3PMadMixMods(MachineOperand &Root) const {
   std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched);
 
   return {{
-      [=](MachineInstrBuilder &MIB) { MIB.addReg(Src); },
+      [=](MachineInstrBuilder &MIB) {
+        MIB.addReg(widenMadMixSrcIfVGPR16(Src, MIB));
+      },
       [=](MachineInstrBuilder &MIB) { MIB.addImm(Mods); } // src_mods
   }};
 }
@@ -7268,7 +7278,9 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsExtNeg(
     return {};
 
   return {{
-      [=](MachineInstrBuilder &MIB) { MIB.addReg(Src); },
+      [=](MachineInstrBuilder &MIB) {
+        MIB.addReg(widenMadMixSrcIfVGPR16(Src, MIB));
+      },
       [=](MachineInstrBuilder &MIB) {
         MIB.addImm(Mods ^ SISrcMods::NEG);
       } // src_mods
@@ -7284,7 +7296,9 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsNeg(
   std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched);
 
   return {{
-      [=](MachineInstrBuilder &MIB) { MIB.addReg(Src); },
+      [=](MachineInstrBuilder &MIB) {
+        MIB.addReg(widenMadMixSrcIfVGPR16(Src, MIB));
+      },
       [=](MachineInstrBuilder &MIB) {
         MIB.addImm(Mods ^ SISrcMods::NEG);
       } // src_mods

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -4752,11 +4752,12 @@ Register AMDGPUInstructionSelector::copyToVGPRIfSrcFolded(
   return Src;
 }
 
-/// The mix instructions read 32-bit sources. With real true16 instructions a
+/// Some instructions must have 32-bit sources. With real true16 instructions a
 /// 16-bit VALU value lives in a VGPR_16, which they cannot read, so place it in
 /// the low half of a new 32-bit VGPR.
-Register AMDGPUInstructionSelector::widenMadMixSrcIfVGPR16(
-    Register Src, MachineInstr *InsertPt) const {
+Register
+AMDGPUInstructionSelector::widenSrcIfVGPR16(Register Src,
+                                            MachineInstr *InsertPt) const {
   if (!Subtarget->useRealTrue16Insts() || MRI->getType(Src) != LLT::scalar(16))
     return Src;
 
@@ -7223,7 +7224,7 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsImpl(MachineOperand &Root,
     } else {
       // op_sel already picks the low half, so use the 32-bit source directly if
       // the 16-bit value is the low half of one. Otherwise Src is genuinely 16
-      // bits wide and widenMadMixSrcIfVGPR16 widens it when the operand is
+      // bits wide and widenSrcIfVGPR16 widens it when the operand is
       // rendered.
       isExtractLoElt(*MRI, Src, Src);
     }
@@ -7245,9 +7246,7 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsExt(
     return {};
 
   return {{
-      [=](MachineInstrBuilder &MIB) {
-        MIB.addReg(widenMadMixSrcIfVGPR16(Src, MIB));
-      },
+      [=](MachineInstrBuilder &MIB) { MIB.addReg(widenSrcIfVGPR16(Src, MIB)); },
       [=](MachineInstrBuilder &MIB) { MIB.addImm(Mods); } // src_mods
   }};
 }
@@ -7260,9 +7259,7 @@ AMDGPUInstructionSelector::selectVOP3PMadMixMods(MachineOperand &Root) const {
   std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched);
 
   return {{
-      [=](MachineInstrBuilder &MIB) {
-        MIB.addReg(widenMadMixSrcIfVGPR16(Src, MIB));
-      },
+      [=](MachineInstrBuilder &MIB) { MIB.addReg(widenSrcIfVGPR16(Src, MIB)); },
       [=](MachineInstrBuilder &MIB) { MIB.addImm(Mods); } // src_mods
   }};
 }
@@ -7278,9 +7275,7 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsExtNeg(
     return {};
 
   return {{
-      [=](MachineInstrBuilder &MIB) {
-        MIB.addReg(widenMadMixSrcIfVGPR16(Src, MIB));
-      },
+      [=](MachineInstrBuilder &MIB) { MIB.addReg(widenSrcIfVGPR16(Src, MIB)); },
       [=](MachineInstrBuilder &MIB) {
         MIB.addImm(Mods ^ SISrcMods::NEG);
       } // src_mods
@@ -7296,9 +7291,7 @@ AMDGPUInstructionSelector::selectVOP3PMadMixModsNeg(
   std::tie(Src, Mods) = selectVOP3PMadMixModsImpl(Root, Matched);
 
   return {{
-      [=](MachineInstrBuilder &MIB) {
-        MIB.addReg(widenMadMixSrcIfVGPR16(Src, MIB));
-      },
+      [=](MachineInstrBuilder &MIB) { MIB.addReg(widenSrcIfVGPR16(Src, MIB)); },
       [=](MachineInstrBuilder &MIB) {
         MIB.addImm(Mods ^ SISrcMods::NEG);
       } // src_mods

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
@@ -348,8 +348,9 @@ private:
   ComplexRendererFns selectSMRDBufferImm32(MachineOperand &Root) const;
   ComplexRendererFns selectSMRDBufferSgprImm(MachineOperand &Root) const;
 
-  std::pair<Register, unsigned> selectVOP3PMadMixModsImpl(MachineOperand &Root,
-                                                          bool &Matched) const;
+  std::pair<Register, unsigned>
+  selectVOP3PMadMixModsImpl(MachineOperand &Root, bool &Matched,
+                            bool &NeedsWiden) const;
   ComplexRendererFns selectVOP3PMadMixModsExt(MachineOperand &Root) const;
   ComplexRendererFns selectVOP3PMadMixMods(MachineOperand &Root) const;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
@@ -348,11 +348,12 @@ private:
   ComplexRendererFns selectSMRDBufferImm32(MachineOperand &Root) const;
   ComplexRendererFns selectSMRDBufferSgprImm(MachineOperand &Root) const;
 
-  std::pair<Register, unsigned>
-  selectVOP3PMadMixModsImpl(MachineOperand &Root, bool &Matched,
-                            bool &NeedsWiden) const;
+  bool madMixSrcNeedsWiden(Register Src) const;
+  std::pair<Register, unsigned> selectVOP3PMadMixModsImpl(MachineOperand &Root,
+                                                          bool &Matched) const;
   ComplexRendererFns selectVOP3PMadMixModsExt(MachineOperand &Root) const;
   ComplexRendererFns selectVOP3PMadMixMods(MachineOperand &Root) const;
+  bool selectVOP3PMadMixF32(MachineInstr &I) const;
 
   void renderTruncImm32(MachineInstrBuilder &MIB, const MachineInstr &MI,
                         int OpIdx = -1) const;

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
@@ -168,7 +168,7 @@ private:
                                  MachineOperand Root, MachineInstr *InsertPt,
                                  bool ForceVGPR = false) const;
 
-  Register widenMadMixSrcIfVGPR16(Register Src, MachineInstr *InsertPt) const;
+  Register widenSrcIfVGPR16(Register Src, MachineInstr *InsertPt) const;
 
   InstructionSelector::ComplexRendererFns
   selectVCSRC(MachineOperand &Root) const;

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.h
@@ -168,6 +168,8 @@ private:
                                  MachineOperand Root, MachineInstr *InsertPt,
                                  bool ForceVGPR = false) const;
 
+  Register widenMadMixSrcIfVGPR16(Register Src, MachineInstr *InsertPt) const;
+
   InstructionSelector::ComplexRendererFns
   selectVCSRC(MachineOperand &Root) const;
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fma-mix-true16.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fma-mix-true16.ll
@@ -3,18 +3,15 @@
 ; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=-real-true16 < %s | FileCheck -check-prefixes=GFX11-FAKE16 %s
 
 ; With real true16 instructions s16 values live in 16-bit register classes,
-; and folding an fpext into a mix instruction's 32-bit source operand leaves
-; an unselectable 16-bit def. Check that the fold is skipped instead of
-; crashing the selector.
+; which the mix instructions cannot read. Check that folding an fpext into a
+; mix instruction's 32-bit source operand widens such a source instead of
+; leaving an unselectable 16-bit def, so that true16 matches fake16 here.
 
 define float @v_mul_f32_fpext_f16(half %x, half %y) {
 ; GFX11-TRUE16-LABEL: v_mul_f32_fpext_f16:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v0, v0, v1
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, neg(0) op_sel_hi:[1,1,0]
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: v_mul_f32_fpext_f16:
@@ -32,10 +29,7 @@ define float @v_fma_f32_fpext_f16(half %x, half %y, float %z) {
 ; GFX11-TRUE16-LABEL: v_fma_f32_fpext_f16:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fma_f32 v0, v0, v1, v2
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,0]
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: v_fma_f32_fpext_f16:
@@ -53,10 +47,7 @@ define float @v_fma_f32_fpext_fneg_f16(half %x, half %y, float %z) {
 ; GFX11-TRUE16-LABEL: v_fma_f32_fpext_fneg_f16:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e64 v0, -v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_fma_f32 v0, v0, v1, v2
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, -v0, v1, v2 op_sel_hi:[1,1,0]
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: v_fma_f32_fpext_fneg_f16:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/fpow.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/fpow.ll
@@ -699,10 +699,10 @@ define half @v_pow_f16(half %x, half %y) {
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v4, v1.l
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0x800000, |v0|
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v5, v1
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v5, v4
 ; GFX11-TRUE16-NEXT:    v_cmp_class_f32_e64 s2, v0, 24
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v2, 0, 1, s0
@@ -714,23 +714,25 @@ define half @v_pow_f16(half %x, half %y) {
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
 ; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v2, v2, v3
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_mul_dx9_zero_f32_e32 v2, v1, v2
+; GFX11-TRUE16-NEXT:    v_mul_dx9_zero_f32_e32 v2, v4, v2
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0xc2fc0000, v2
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v3, 0, 0x42800000, vcc_lo
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v4, 0, 0xffffffc0, vcc_lo
-; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v5, v1
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_dual_add_f32 v2, v2, v3 :: v_dual_mul_f32 v3, 0.5, v1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_dual_add_f32 v2, v2, v3 :: v_dual_mov_b32 v3, 0.5
 ; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v2, v2
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v6, v3
-; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s0, v6, v3
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v1, v1, v3, neg(0) op_sel_hi:[1,0,0]
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v3, 0, 0xffffffc0, vcc_lo
+; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v5, v4
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v6, v1
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v2, v4
-; GFX11-TRUE16-NEXT:    v_and_b32_e32 v4, 0x80000000, v0
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v2, v3
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v3, 0x80000000, v0
+; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s0, v6, v1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v1, 0x7fffffff, v2, v3
 ; GFX11-TRUE16-NEXT:    s_and_b32 s0, vcc_lo, s0
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v1, 0x7fffffff, v2, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v0, v2, v1, s0
 ; GFX11-TRUE16-NEXT:    s_xor_b32 s0, vcc_lo, exec_lo
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
@@ -1094,76 +1096,76 @@ define <2 x half> @v_pow_v2f16(<2 x half> %x, <2 x half> %y) {
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v7, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0x800000, |v2|
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s1, 0x800000, |v0|
 ; GFX11-TRUE16-NEXT:    v_cmp_class_f32_e64 s4, v2, 24
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v8, v7
-; GFX11-TRUE16-NEXT:    v_dual_mul_f32 v9, 0.5, v1 :: v_dual_and_b32 v10, 0x80000000, v0
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s1
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v14, 0x80000000, v0
+; GFX11-TRUE16-NEXT:    v_cmp_class_f32_e64 s5, v0, 24
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v5, 0, 0x42000000, s0
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s1
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s0
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v6, 0, 0x42000000, s1
-; GFX11-TRUE16-NEXT:    v_cmp_class_f32_e64 s5, v0, 24
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 5, v4
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, |v0|, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_log_f32_e32 v4, v4
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
 ; GFX11-TRUE16-NEXT:    v_dual_sub_f32 v4, v4, v6 :: v_dual_lshlrev_b32 v3, 5, v3
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_ldexp_f32 v3, |v2|, v3
-; GFX11-TRUE16-NEXT:    v_mul_dx9_zero_f32_e32 v4, v1, v4
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_log_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0xc2fc0000, v4
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v6, 0, 0x42800000, s0
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
 ; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v3, v3, v5
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v0, 0, 0xffffffc0, s0
-; GFX11-TRUE16-NEXT:    v_dual_add_f32 v4, v4, v6 :: v_dual_mul_dx9_zero_f32 v3, v7, v3
-; GFX11-TRUE16-NEXT:    v_and_b32_e32 v6, 0x80000000, v2
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v4, v4
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v5, v1.h
+; GFX11-TRUE16-NEXT:    v_dual_mul_dx9_zero_f32 v3, v7, v3 :: v_dual_mul_dx9_zero_f32 v4, v5, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0xc2fc0000, v3
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v5, 0, 0x42800000, vcc_lo
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0xc2fc0000, v4
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v8, 0, 0x42800000, vcc_lo
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v9, 0, 0x42800000, s0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v6, 0.5
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v11, 0, 0xffffffc0, vcc_lo
-; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v8, v7
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v8, v9
-; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v0, v4, v0
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v3, v3, v5
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v5, 0.5, v7
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v13, 0, 0xffffffc0, s0
+; GFX11-TRUE16-NEXT:    v_dual_add_f32 v3, v3, v8 :: v_dual_add_f32 v4, v4, v9
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v9, 0x80000000, v2
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v10, v1, v6, neg(0) op_sel_hi:[1,0,0]
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v1, v1, v6, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v3, v3
+; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v4, v4
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v6, v7
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v8, v10
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v2, v5
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v12, v1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v6, v7
+; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s0, v8, v10
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(TRANS32_DEP_2)
+; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e64 s1, v2, v5
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v0, v3, v11
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v3, v4, v13
+; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s2, v12, v1
 ; GFX11-TRUE16-NEXT:    s_xor_b32 s6, vcc_lo, exec_lo
-; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s2, v8, v9
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v2, v3
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v7, v5
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v3, v1
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s1, v7, v5
-; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e64 s0, v3, v1
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v3, 0x7fffffff, v0, v10
-; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v2, v11
-; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, vcc_lo, s1
-; GFX11-TRUE16-NEXT:    s_and_b32 s1, s4, s6
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v1, 0x7fffffff, v2, v6
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc_lo
-; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, s0, s2
-; GFX11-TRUE16-NEXT:    s_xor_b32 s0, s0, exec_lo
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc_lo
+; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, vcc_lo, s0
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v2, 0x7fffffff, v0, v9
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v1, 0x7fffffff, v3, v14
+; GFX11-TRUE16-NEXT:    s_xor_b32 s0, s1, exec_lo
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    s_and_b32 s0, s5, s0
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fc00000, s1
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
+; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, s1, s2
+; GFX11-TRUE16-NEXT:    s_and_b32 s1, s4, s6
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc_lo
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v2, v0, 0x7fc00000, s0
-; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v1
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v2
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v0, v0, 0x7fc00000, s1
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fc00000, s0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v0
+; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v1
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: v_pow_v2f16:
@@ -1564,14 +1566,10 @@ define <2 x half> @v_pow_v2f16_fneg_lhs(<2 x half> %x, <2 x half> %y) {
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v7, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v8, v7
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v9, 0.5, v1
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0x800000, |v2|
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s1, 0x800000, |v0|
 ; GFX11-TRUE16-NEXT:    v_cmp_class_f32_e64 s4, v2, 24
@@ -1581,65 +1579,67 @@ define <2 x half> @v_pow_v2f16_fneg_lhs(<2 x half> %x, <2 x half> %y) {
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s1
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s0
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v6, 0, 0x42000000, s1
-; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e64 s1, v8, v7
-; GFX11-TRUE16-NEXT:    v_and_b32_e32 v8, 0x80000000, v2
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 5, v4
-; GFX11-TRUE16-NEXT:    s_xor_b32 s6, s1, exec_lo
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, |v0|, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_log_f32_e32 v4, v4
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
 ; GFX11-TRUE16-NEXT:    v_dual_sub_f32 v4, v4, v6 :: v_dual_lshlrev_b32 v3, 5, v3
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_ldexp_f32 v3, |v2|, v3
-; GFX11-TRUE16-NEXT:    v_mul_dx9_zero_f32_e32 v4, v1, v4
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_log_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0xc2fc0000, v4
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v6, 0, 0x42800000, s0
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
 ; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v3, v3, v5
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v2, 0, 0xffffffc0, s0
-; GFX11-TRUE16-NEXT:    v_dual_add_f32 v4, v4, v6 :: v_dual_mul_dx9_zero_f32 v3, v7, v3
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v6, v1
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v4, v4
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v5, v1.h
+; GFX11-TRUE16-NEXT:    v_dual_mul_dx9_zero_f32 v3, v7, v3 :: v_dual_mul_dx9_zero_f32 v4, v5, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0xc2fc0000, v3
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v5, 0, 0x42800000, vcc_lo
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v10, 0, 0xffffffc0, vcc_lo
-; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v6, v1
-; GFX11-TRUE16-NEXT:    v_and_b32_e32 v6, 0x80000000, v0
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v1, v9
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v3, v3, v5
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v5, 0.5, v7
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v4, v2
-; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s2, v1, v9
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0xc2fc0000, v4
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v8, 0, 0x42800000, vcc_lo
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v6, 0.5
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v9, 0, 0x42800000, s0
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v3, v3, v8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v10, v1, v6, neg(0) op_sel_hi:[1,0,0]
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v1, v1, v6, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v6, v7
+; GFX11-TRUE16-NEXT:    v_add_f32_e32 v4, v4, v9
 ; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v7, v5
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v1, 0x7fffffff, v2, v6
-; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s0, v7, v5
-; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v3, v3, v10
-; GFX11-TRUE16-NEXT:    s_and_b32 s0, s1, s0
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v8, v10
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v9, v5
+; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e64 s1, v6, v7
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v6, 0, 0xffffffc0, vcc_lo
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v7, 0, 0xffffffc0, s0
+; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e32 vcc_lo, v8, v10
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v11, v1
+; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e64 s0, v9, v5
+; GFX11-TRUE16-NEXT:    s_xor_b32 s6, s1, exec_lo
+; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, s1, vcc_lo
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v8, 0x80000000, v2
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v3, v6
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v3, 0x80000000, v0
+; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v4, v4
+; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s2, v11, v1
 ; GFX11-TRUE16-NEXT:    s_and_b32 s1, s4, s6
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v0, 0x7fffffff, v3, v8
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v0, v3, v0, s0
-; GFX11-TRUE16-NEXT:    s_and_b32 s0, vcc_lo, s2
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v1, v2, v1, s0
-; GFX11-TRUE16-NEXT:    s_xor_b32 s0, vcc_lo, exec_lo
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v0, v0, 0x7fc00000, s1
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v1, 0x7fffffff, v2, v8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc_lo
+; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, s0, s2
+; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, v4, v7
+; GFX11-TRUE16-NEXT:    s_xor_b32 s0, s0, exec_lo
 ; GFX11-TRUE16-NEXT:    s_and_b32 s0, s5, s0
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instid1(SALU_CYCLE_1)
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fc00000, s0
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v0
-; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v1
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fc00000, s1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v0, 0x7fffffff, v4, v3
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v2, v0, 0x7fc00000, s0
+; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v2
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-FAKE16-LABEL: v_pow_v2f16_fneg_lhs:
@@ -2042,73 +2042,74 @@ define <2 x half> @v_pow_v2f16_fneg_rhs(<2 x half> %x, <2 x half> %y) {
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX11-TRUE16-NEXT:    v_xor_b32_e32 v1, 0x80008000, v1
+; GFX11-TRUE16-NEXT:    v_xor_b32_e32 v5, 0x80008000, v1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0x800000, |v2|
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s1, 0x800000, |v0|
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v7, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v8, v5.l
 ; GFX11-TRUE16-NEXT:    v_cmp_class_f32_e64 s4, v2, 24
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v5, 0, 0x42000000, s0
+; GFX11-TRUE16-NEXT:    v_cmp_class_f32_e64 s5, v0, 24
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v6, 0, 0x42000000, s0
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s1
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s0
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v6, 0, 0x42000000, s1
-; GFX11-TRUE16-NEXT:    v_cmp_class_f32_e64 s5, v0, 24
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v10, 0.5, v1
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v7, 0, 0x42000000, s1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 5, v4
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, |v0|, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_log_f32_e32 v4, v4
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_dual_sub_f32 v4, v4, v6 :: v_dual_lshlrev_b32 v3, 5, v3
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v3, |v2|, v3
-; GFX11-TRUE16-NEXT:    v_mul_dx9_zero_f32_e32 v4, v1, v4
+; GFX11-TRUE16-NEXT:    v_dual_sub_f32 v4, v4, v7 :: v_dual_mov_b32 v7, 0.5
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 5, v3
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v1, -v1, v7, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v3, |v2|, v3
 ; GFX11-TRUE16-NEXT:    v_log_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0xc2fc0000, v4
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v6, 0, 0x42800000, s0
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v3, v3, v5
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v11, 0, 0xffffffc0, s0
-; GFX11-TRUE16-NEXT:    v_mul_dx9_zero_f32_e32 v3, v7, v3
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v3, v3, v6
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v5.h
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v5, v5, v7, neg(0) op_sel_hi:[1,0,0]
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v7, 0x80000000, v2
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    v_dual_mul_dx9_zero_f32 v3, v8, v3 :: v_dual_mul_dx9_zero_f32 v4, v6, v4
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v12, v5
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v13, v6
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0xc2fc0000, v3
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v5, 0, 0x42800000, vcc_lo
-; GFX11-TRUE16-NEXT:    v_and_b32_e32 v8, 0x80000000, v2
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v9, 0, 0xffffffc0, vcc_lo
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v2, v4, v6
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v6, v1
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v3, v3, v5
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v5, 0.5, v7
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v2, v2
-; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e64 s0, v6, v1
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0xc2fc0000, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s1, v12, v5
+; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e64 s2, v13, v6
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v9, 0, 0x42800000, vcc_lo
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v10, 0, 0x42800000, s0
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v11, 0, 0xffffffc0, s0
+; GFX11-TRUE16-NEXT:    v_dual_add_f32 v3, v3, v9 :: v_dual_add_f32 v4, v4, v10
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v9, 0x80000000, v0
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v0, 0, 0xffffffc0, vcc_lo
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v10, v8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v2, v3
+; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v4, v4
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v3, v1
+; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e64 s0, v10, v8
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e32 vcc_lo, v3, v1
+; GFX11-TRUE16-NEXT:    s_xor_b32 s6, s0, exec_lo
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v2, v11
-; GFX11-TRUE16-NEXT:    v_and_b32_e32 v4, 0x80000000, v0
-; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v0, v3
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v3, v7
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v3, v7
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v3, v5
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v7, v10
-; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v0, v0, v9
-; GFX11-TRUE16-NEXT:    s_xor_b32 s6, vcc_lo, exec_lo
-; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s1, v3, v5
-; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s2, v7, v10
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v3, 0x7fffffff, v2, v4
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v1, 0x7fffffff, v0, v8
-; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, vcc_lo, s1
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v0, v2, v0
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v1, v4, v11
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, s1
+; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, s2, vcc_lo
 ; GFX11-TRUE16-NEXT:    s_and_b32 s1, s4, s6
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, s0, s2
-; GFX11-TRUE16-NEXT:    s_xor_b32 s0, s0, exec_lo
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v2, v3, vcc_lo
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v2, 0x7fffffff, v0, v7
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v3, 0x7fffffff, v1, v9
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s0
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
+; GFX11-TRUE16-NEXT:    s_xor_b32 s0, s2, exec_lo
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    s_and_b32 s0, s5, s0
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v0, v0, 0x7fc00000, s1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
@@ -2515,78 +2516,78 @@ define <2 x half> @v_pow_v2f16_fneg_lhs_rhs(<2 x half> %x, <2 x half> %y) {
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
-; GFX11-TRUE16-NEXT:    v_xor_b32_e32 v1, 0x80008000, v1
+; GFX11-TRUE16-NEXT:    v_xor_b32_e32 v5, 0x80008000, v1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v0.l
 ; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, v0.h
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v7, v1.l
-; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, v1.h
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v8, v5.l
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0x800000, |v2|
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s1, 0x800000, |v0|
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v11, 0x80000000, v2
 ; GFX11-TRUE16-NEXT:    v_cmp_class_f32_e64 s4, v2, 24
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v8, v7
-; GFX11-TRUE16-NEXT:    v_dual_mul_f32 v9, 0.5, v1 :: v_dual_and_b32 v10, 0x80000000, v0
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s1
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v5, 0, 0x42000000, s0
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s0
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v6, 0, 0x42000000, s1
 ; GFX11-TRUE16-NEXT:    v_cmp_class_f32_e64 s5, v0, 24
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v6, 0, 0x42000000, s0
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s1
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v3, 0, 1, s0
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v7, 0, 0x42000000, s1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v4, 5, v4
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_ldexp_f32 v4, |v0|, v4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_log_f32_e32 v4, v4
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_dual_sub_f32 v4, v4, v6 :: v_dual_lshlrev_b32 v3, 5, v3
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v3, |v2|, v3
-; GFX11-TRUE16-NEXT:    v_mul_dx9_zero_f32_e32 v4, v1, v4
+; GFX11-TRUE16-NEXT:    v_dual_sub_f32 v4, v4, v7 :: v_dual_mov_b32 v7, 0.5
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 5, v3
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v1, -v1, v7, neg(0) op_sel:[1,0,0] op_sel_hi:[1,0,0]
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v3, |v2|, v3
 ; GFX11-TRUE16-NEXT:    v_log_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0xc2fc0000, v4
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v6, 0, 0x42800000, s0
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v3, v3, v5
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v0, 0, 0xffffffc0, s0
-; GFX11-TRUE16-NEXT:    v_dual_add_f32 v4, v4, v6 :: v_dual_mul_dx9_zero_f32 v3, v7, v3
-; GFX11-TRUE16-NEXT:    v_and_b32_e32 v6, 0x80000000, v2
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v4, v4
+; GFX11-TRUE16-NEXT:    v_sub_f32_e32 v3, v3, v6
+; GFX11-TRUE16-NEXT:    v_cvt_f32_f16_e32 v6, v5.h
+; GFX11-TRUE16-NEXT:    v_fma_mix_f32 v5, v5, v7, neg(0) op_sel_hi:[1,0,0]
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v7, v1
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_dual_mul_dx9_zero_f32 v3, v8, v3 :: v_dual_mul_dx9_zero_f32 v4, v6, v4
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v12, v6
 ; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e32 vcc_lo, 0xc2fc0000, v3
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v5, 0, 0x42800000, vcc_lo
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v11, 0, 0xffffffc0, vcc_lo
-; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e32 vcc_lo, v8, v7
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v8, v9
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    v_cmp_gt_f32_e64 s0, 0xc2fc0000, v4
+; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e64 s2, v12, v6
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v9, 0, 0x42800000, vcc_lo
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v10, 0, 0x42800000, s0
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v13, 0, 0xffffffc0, s0
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v2, 0, 0xffffffc0, vcc_lo
+; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e32 vcc_lo, v7, v1
+; GFX11-TRUE16-NEXT:    v_dual_add_f32 v3, v3, v9 :: v_dual_add_f32 v4, v4, v10
+; GFX11-TRUE16-NEXT:    v_and_b32_e32 v1, 0x80000000, v0
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v9, v8
+; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v10, v5
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v3, v3
+; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v4, v4
+; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, s2, vcc_lo
+; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e64 s0, v9, v8
+; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s1, v10, v5
+; GFX11-TRUE16-NEXT:    s_xor_b32 s6, s0, exec_lo
+; GFX11-TRUE16-NEXT:    s_and_b32 s0, s0, s1
 ; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v0, v4, v0
-; GFX11-TRUE16-NEXT:    v_add_f32_e32 v3, v3, v5
-; GFX11-TRUE16-NEXT:    v_mul_f32_e32 v5, 0.5, v7
-; GFX11-TRUE16-NEXT:    s_xor_b32 s6, vcc_lo, exec_lo
-; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s2, v8, v9
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_exp_f32_e32 v2, v3
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v7, v5
-; GFX11-TRUE16-NEXT:    v_trunc_f32_e32 v3, v1
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-TRUE16-NEXT:    v_cmp_lg_f32_e64 s1, v7, v5
-; GFX11-TRUE16-NEXT:    v_cmp_eq_f32_e64 s0, v3, v1
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v3, 0x7fffffff, v0, v10
-; GFX11-TRUE16-NEXT:    s_waitcnt_depctr depctr_va_vdst(0)
-; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v2, v11
-; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, vcc_lo, s1
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v2, v3, v2
+; GFX11-TRUE16-NEXT:    v_ldexp_f32 v0, v4, v13
 ; GFX11-TRUE16-NEXT:    s_and_b32 s1, s4, s6
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-TRUE16-NEXT:    v_and_or_b32 v1, 0x7fffffff, v2, v6
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc_lo
-; GFX11-TRUE16-NEXT:    s_and_b32 vcc_lo, s0, s2
-; GFX11-TRUE16-NEXT:    s_xor_b32 s0, s0, exec_lo
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc_lo
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v1, 0x7fffffff, v0, v1
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
+; GFX11-TRUE16-NEXT:    v_and_or_b32 v3, 0x7fffffff, v2, v11
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v2, v2, v3, s0
+; GFX11-TRUE16-NEXT:    s_xor_b32 s0, s2, exec_lo
 ; GFX11-TRUE16-NEXT:    s_and_b32 s0, s5, s0
-; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7fc00000, s1
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v1, v2, 0x7fc00000, s1
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e64 v2, v0, 0x7fc00000, s0
 ; GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-hi.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-hi.ll
@@ -5,8 +5,7 @@
 ; RUN: llc -mtriple=amdgpu8.03 < %s | FileCheck -check-prefixes=VI,SDAG-VI %s
 ; RUN: llc -mtriple=amdgpu7.01 < %s | FileCheck -check-prefixes=SDAG-CI %s
 
-; FIXME-TRUE16. fix gisel
-; XUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX11,GISEL-GFX11,GISEL-GFX11-TRUE16 %s
+; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX11,GISEL-GFX11,GISEL-GFX11-TRUE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=-real-true16 < %s | FileCheck -check-prefixes=GFX11,GISEL-GFX11,GISEL-GFX11-FAKE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu9.00 < %s | FileCheck -check-prefixes=GFX9,GISEL-GFX9 %s
 ; RUN: llc -global-isel -mtriple=amdgpu8.03 < %s | FileCheck -check-prefixes=VI,GISEL-VI %s
@@ -126,14 +125,21 @@ define <2 x half> @v_mad_mixhi_f16_f16lo_f16lo_f16lo_constlo(half %src0, half %s
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, 0x3c00, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX11-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_constlo:
-; GISEL-GFX11:       ; %bb.0:
-; GISEL-GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX11-NEXT:    v_mov_b32_e32 v3, 0x3c00
-; GISEL-GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX11-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX11-NEXT:    v_mov_b32_e32 v0, v3
-; GISEL-GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX11-TRUE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_constlo:
+; GISEL-GFX11-TRUE16:       ; %bb.0:
+; GISEL-GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 0x3c00
+; GISEL-GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX11-FAKE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_constlo:
+; GISEL-GFX11-FAKE16:       ; %bb.0:
+; GISEL-GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-FAKE16-NEXT:    v_mov_b32_e32 v3, 0x3c00
+; GISEL-GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX11-FAKE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-VI-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_constlo:
 ; GISEL-VI:       ; %bb.0:
@@ -301,14 +307,23 @@ define i32 @v_mad_mixhi_f16_f16lo_f16lo_f16lo_intpack(half %src0, half %src1, ha
 ; SDAG-CI-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX11-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_intpack:
-; GISEL-GFX11:       ; %bb.0:
-; GISEL-GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX11-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX11-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GISEL-GFX11-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
-; GISEL-GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX11-TRUE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_intpack:
+; GISEL-GFX11-TRUE16:       ; %bb.0:
+; GISEL-GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX11-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GISEL-GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GISEL-GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX11-FAKE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_intpack:
+; GISEL-GFX11-FAKE16:       ; %bb.0:
+; GISEL-GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-FAKE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GISEL-GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GISEL-GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_intpack:
 ; GISEL-GFX9:       ; %bb.0:
@@ -486,15 +501,23 @@ define <2 x half> @v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_precvt(half %
 ; SDAG-CI-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX11-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_precvt:
-; GISEL-GFX11:       ; %bb.0:
-; GISEL-GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX11-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX11-NEXT:    v_and_b32_e64 v1, 0xffff, s0
-; GISEL-GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX11-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GISEL-GFX11-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
-; GISEL-GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX11-TRUE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_precvt:
+; GISEL-GFX11-TRUE16:       ; %bb.0:
+; GISEL-GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v0
+; GISEL-GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX11-FAKE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_precvt:
+; GISEL-GFX11-FAKE16:       ; %bb.0:
+; GISEL-GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX11-FAKE16-NEXT:    v_and_b32_e64 v1, 0xffff, s0
+; GISEL-GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX11-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-GFX11-FAKE16-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
+; GISEL-GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_precvt:
 ; GISEL-GFX9:       ; %bb.0:
@@ -751,5 +774,4 @@ declare <2 x float> @llvm.fmuladd.v2f32(<2 x float>, <2 x float>, <2 x float>) #
 attributes #0 = { nounwind denormal_fpenv(float: preservesign) }
 attributes #1 = { nounwind readnone speculatable }
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GISEL-GFX11-FAKE16: {{.*}}
 ; VI: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-hi.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-hi.ll
@@ -707,24 +707,14 @@ define <2 x half> @v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_postcvt_multi
 ; SDAG-CI-NEXT:    v_lshlrev_b32_e32 v0, 16, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX11-TRUE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_postcvt_multi_use:
-; GISEL-GFX11-TRUE16:       ; %bb.0:
-; GISEL-GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX11-TRUE16-NEXT:    v_fma_mixhi_f16 v1, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX11-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX11-TRUE16-NEXT:    global_store_d16_hi_b16 v[0:1], v1, off dlc
-; GISEL-GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
-; GISEL-GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX11-FAKE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_postcvt_multi_use:
-; GISEL-GFX11-FAKE16:       ; %bb.0:
-; GISEL-GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX11-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX11-FAKE16-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v3, off dlc
-; GISEL-GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
-; GISEL-GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX11-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_postcvt_multi_use:
+; GISEL-GFX11:       ; %bb.0:
+; GISEL-GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX11-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX11-NEXT:    global_store_b16 v[0:1], v3, off dlc
+; GISEL-GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
+; GISEL-GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-VI-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_postcvt_multi_use:
 ; GISEL-VI:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-hi.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-hi.ll
@@ -707,14 +707,24 @@ define <2 x half> @v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_postcvt_multi
 ; SDAG-CI-NEXT:    v_lshlrev_b32_e32 v0, 16, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX11-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_postcvt_multi_use:
-; GISEL-GFX11:       ; %bb.0:
-; GISEL-GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX11-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX11-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX11-NEXT:    global_store_b16 v[0:1], v3, off dlc
-; GISEL-GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
-; GISEL-GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX11-TRUE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_postcvt_multi_use:
+; GISEL-GFX11-TRUE16:       ; %bb.0:
+; GISEL-GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-TRUE16-NEXT:    v_fma_mixhi_f16 v1, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX11-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX11-TRUE16-NEXT:    global_store_d16_hi_b16 v[0:1], v1, off dlc
+; GISEL-GFX11-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GISEL-GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX11-FAKE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_postcvt_multi_use:
+; GISEL-GFX11-FAKE16:       ; %bb.0:
+; GISEL-GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX11-FAKE16-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v3, off dlc
+; GISEL-GFX11-FAKE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GISEL-GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-VI-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_postcvt_multi_use:
 ; GISEL-VI:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-hi.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-hi.ll
@@ -5,8 +5,7 @@
 ; RUN: llc -mtriple=amdgpu8.03 < %s | FileCheck -check-prefixes=VI,SDAG-VI %s
 ; RUN: llc -mtriple=amdgpu7.01 < %s | FileCheck -check-prefixes=SDAG-CI %s
 
-; FIXME-TRUE16. fix gisel
-; XUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX11,GISEL-GFX11,GISEL-GFX11-TRUE16 %s
+; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX11,GISEL-GFX11,GISEL-GFX11-TRUE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=-real-true16 < %s | FileCheck -check-prefixes=GFX11,GISEL-GFX11,GISEL-GFX11-FAKE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu9.00 < %s | FileCheck -check-prefixes=GFX9,GISEL-GFX9 %s
 ; RUN: llc -global-isel -mtriple=amdgpu8.03 < %s | FileCheck -check-prefixes=VI,GISEL-VI %s
@@ -126,14 +125,21 @@ define <2 x half> @v_mad_mixhi_f16_f16lo_f16lo_f16lo_constlo(half %src0, half %s
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, 0x3c00, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX11-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_constlo:
-; GISEL-GFX11:       ; %bb.0:
-; GISEL-GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX11-NEXT:    v_mov_b32_e32 v3, 0x3c00
-; GISEL-GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX11-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX11-NEXT:    v_mov_b32_e32 v0, v3
-; GISEL-GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX11-TRUE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_constlo:
+; GISEL-GFX11-TRUE16:       ; %bb.0:
+; GISEL-GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 0x3c00
+; GISEL-GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX11-FAKE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_constlo:
+; GISEL-GFX11-FAKE16:       ; %bb.0:
+; GISEL-GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-FAKE16-NEXT:    v_mov_b32_e32 v3, 0x3c00
+; GISEL-GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX11-FAKE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-VI-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_constlo:
 ; GISEL-VI:       ; %bb.0:
@@ -301,14 +307,23 @@ define i32 @v_mad_mixhi_f16_f16lo_f16lo_f16lo_intpack(half %src0, half %src1, ha
 ; SDAG-CI-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX11-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_intpack:
-; GISEL-GFX11:       ; %bb.0:
-; GISEL-GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX11-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX11-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GISEL-GFX11-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
-; GISEL-GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX11-TRUE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_intpack:
+; GISEL-GFX11-TRUE16:       ; %bb.0:
+; GISEL-GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX11-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GISEL-GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GISEL-GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX11-FAKE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_intpack:
+; GISEL-GFX11-FAKE16:       ; %bb.0:
+; GISEL-GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-FAKE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GISEL-GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
+; GISEL-GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_intpack:
 ; GISEL-GFX9:       ; %bb.0:
@@ -473,15 +488,23 @@ define <2 x half> @v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_precvt(half %
 ; SDAG-CI-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX11-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_precvt:
-; GISEL-GFX11:       ; %bb.0:
-; GISEL-GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX11-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX11-NEXT:    v_and_b32_e64 v1, 0xffff, s0
-; GISEL-GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX11-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GISEL-GFX11-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
-; GISEL-GFX11-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX11-TRUE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_precvt:
+; GISEL-GFX11-TRUE16:       ; %bb.0:
+; GISEL-GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX11-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v0
+; GISEL-GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX11-FAKE16-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_precvt:
+; GISEL-GFX11-FAKE16:       ; %bb.0:
+; GISEL-GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX11-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX11-FAKE16-NEXT:    v_and_b32_e64 v1, 0xffff, s0
+; GISEL-GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX11-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-GFX11-FAKE16-NEXT:    v_lshl_or_b32 v0, v0, 16, v1
+; GISEL-GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9-LABEL: v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_precvt:
 ; GISEL-GFX9:       ; %bb.0:
@@ -737,5 +760,3 @@ declare <2 x float> @llvm.fmuladd.v2f32(<2 x float>, <2 x float>, <2 x float>) #
 
 attributes #0 = { nounwind denormal_fpenv(float: preservesign) }
 attributes #1 = { nounwind readnone speculatable }
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GISEL-GFX11-FAKE16: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-lo.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-lo.ll
@@ -6,8 +6,7 @@
 ; RUN: llc -mtriple=amdgpu8.03 < %s | FileCheck -check-prefixes=VI,SDAG-VI %s
 ; RUN: llc -mtriple=amdgpu7.01 < %s | FileCheck -check-prefixes=SDAG-CI %s
 
-; FIXME-TRUE16. enable gisel
-; XUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-TRUE16 %s
+; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-TRUE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=-real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-FAKE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu9.00 < %s | FileCheck -check-prefixes=GFX900,GISEL-GFX900 %s
 ; RUN: llc -global-isel -mtriple=amdgpu9.06 < %s | FileCheck -check-prefixes=GFX906,GISEL-GFX906 %s
@@ -388,13 +387,21 @@ define half @v_mad_mixlo_f16_f16lo_f16lo_f32_clamp_pre_cvt(half %src0, half %src
 ; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mixlo_f16_f16lo_f16lo_f32_clamp_pre_cvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,0] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mixlo_f16_f16lo_f16lo_f32_clamp_pre_cvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,0] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mixlo_f16_f16lo_f16lo_f32_clamp_pre_cvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,0] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mixlo_f16_f16lo_f16lo_f32_clamp_pre_cvt:
 ; GISEL-CI:       ; %bb.0:
@@ -487,14 +494,26 @@ define <2 x half> @v_mad_mix_v2f32(<2 x half> %src0, <2 x half> %src1, <2 x half
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v1, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v0, v3
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v3, v4, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-VI-LABEL: v_mad_mix_v2f32:
 ; GISEL-VI:       ; %bb.0:
@@ -628,17 +647,32 @@ define <3 x half> @v_mad_mix_v3f32(<3 x half> %src0, <3 x half> %src1, <3 x half
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v2, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v3f32:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v2, v4 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_dual_mov_b32 v0, v3 :: v_dual_and_b32 v1, 0xffff, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v3f32:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v3.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v6, v7, v8 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v9, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v3f32:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v2, v4 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_dual_mov_b32 v0, v3 :: v_dual_and_b32 v1, 0xffff, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v3f32:
 ; GISEL-GFX900:       ; %bb.0:
@@ -829,17 +863,36 @@ define <4 x half> @v_mad_mix_v4f32(<4 x half> %src0, <4 x half> %src1, <4 x half
 ; SDAG-CI-NEXT:    v_or_b32_e32 v1, v3, v4
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v4f32:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v7, v1, v3, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v7, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_dual_mov_b32 v0, v6 :: v_dual_mov_b32 v1, v7
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v4f32:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v10.l, v3.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v11.l, v5.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v6, v6, v8, v9 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v2, v7, v10, v11 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v2, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v6
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v1, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v4f32:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v7, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v7, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_dual_mov_b32 v0, v6 :: v_dual_mov_b32 v1, v7
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v4f32:
 ; GISEL-GFX900:       ; %bb.0:
@@ -1024,14 +1077,25 @@ define <2 x half> @v_mad_mix_v2f32_clamp_postcvt(<2 x half> %src0, <2 x half> %s
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_clamp_postcvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v0, v3
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_postcvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v3, v4, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_clamp_postcvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-VI-LABEL: v_mad_mix_v2f32_clamp_postcvt:
 ; GISEL-VI:       ; %bb.0:
@@ -1212,18 +1276,31 @@ define <3 x half> @v_mad_mix_v3f32_clamp_postcvt(<3 x half> %src0, <3 x half> %s
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v0, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v3f32_clamp_postcvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v2, v4 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_dual_mov_b32 v0, v3 :: v_dual_and_b32 v1, 0xffff, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
-; GISEL-GFX1100-NEXT:    v_pk_max_f16 v1, v1, v1 clamp
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v3f32_clamp_postcvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v6, v7, v8 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_pk_max_f16 v1, v1, v1 clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v3f32_clamp_postcvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_dual_mov_b32 v0, v3 :: v_dual_and_b32 v1, 0xffff, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
+; GISEL-GFX1100-FAKE16-NEXT:    v_pk_max_f16 v1, v1, v1 clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v3f32_clamp_postcvt:
 ; GISEL-GFX900:       ; %bb.0:
@@ -1470,17 +1547,33 @@ define <4 x half> @v_mad_mix_v4f32_clamp_postcvt(<4 x half> %src0, <4 x half> %s
 ; SDAG-CI-NEXT:    v_or_b32_e32 v1, v3, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v4f32_clamp_postcvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v7, v1, v3, v5 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v7, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_dual_mov_b32 v0, v6 :: v_dual_mov_b32 v1, v7
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v4f32_clamp_postcvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v10.l, v3.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v11.l, v5.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v1, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v6, v8, v9 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v7, v10, v11 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v4f32_clamp_postcvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v7, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v7, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_dual_mov_b32 v0, v6 :: v_dual_mov_b32 v1, v7
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-VI-LABEL: v_mad_mix_v4f32_clamp_postcvt:
 ; GISEL-VI:       ; %bb.0:
@@ -1664,18 +1757,33 @@ define <2 x half> @v_mad_mix_v2f32_clamp_postcvt_lo(<2 x half> %src0, <2 x half>
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v1, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_clamp_postcvt_lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v4, v3
-; GISEL-GFX1100-NEXT:    v_max_f16_e64 v3, v3, v3 clamp
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_bfe_u32 v0, v3, 0, 16
-; GISEL-GFX1100-NEXT:    v_and_or_b32 v0, 0xffff0000, v4, v0
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_postcvt_lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_3)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v4, v5, v6 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v4, v4, v5, v6 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_bfe_u32 v0, v3, 0, 16
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_and_or_b32 v0, 0xffff0000, v4, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_clamp_postcvt_lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v4, v3
+; GISEL-GFX1100-FAKE16-NEXT:    v_max_f16_e64 v3, v3, v3 clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_bfe_u32 v0, v3, 0, 16
+; GISEL-GFX1100-FAKE16-NEXT:    v_and_or_b32 v0, 0xffff0000, v4, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_clamp_postcvt_lo:
 ; GISEL-GFX900:       ; %bb.0:
@@ -1839,18 +1947,34 @@ define <2 x half> @v_mad_mix_v2f32_clamp_postcvt_hi(<2 x half> %src0, <2 x half>
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v1, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_clamp_postcvt_hi:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v4, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_bfe_u32 v3, v3, 0, 16
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_lshlrev_b32_e32 v0, 16, v3
-; GISEL-GFX1100-NEXT:    v_and_or_b32 v0, 0xffff, v4, v0
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_postcvt_hi:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_bfe_u32 v3, v3, 0, 16
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v4, v4, v5, v6 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v3
+; GISEL-GFX1100-TRUE16-NEXT:    v_and_or_b32 v0, 0xffff, v4, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_clamp_postcvt_hi:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v4, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_bfe_u32 v3, v3, 0, 16
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v3
+; GISEL-GFX1100-FAKE16-NEXT:    v_and_or_b32 v0, 0xffff, v4, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_clamp_postcvt_hi:
 ; GISEL-GFX900:       ; %bb.0:
@@ -2022,17 +2146,31 @@ define <2 x half> @v_mad_mix_v2f32_clamp_precvt(<2 x half> %src0, <2 x half> %sr
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_clamp_precvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v1, v3
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_pack_b32_f16 v0, v1, v0
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_precvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v3, v4, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v1
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v3
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_clamp_precvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, v3
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_pack_b32_f16 v0, v1, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_clamp_precvt:
 ; GISEL-GFX900:       ; %bb.0:
@@ -2203,22 +2341,38 @@ define <3 x half> @v_mad_mix_v3f32_clamp_precvt(<3 x half> %src0, <3 x half> %sr
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v0, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v3f32_clamp_precvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v2, v4 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v2, v3
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GISEL-GFX1100-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_pack_b32_f16 v0, v2, v0
-; GISEL-GFX1100-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v3f32_clamp_precvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v6, v6, v7, v8 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v1
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v6
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v3f32_clamp_precvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v3, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, v3
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_pack_b32_f16 v0, v2, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v3f32_clamp_precvt:
 ; GISEL-GFX900:       ; %bb.0:
@@ -2433,23 +2587,45 @@ define <4 x half> @v_mad_mix_v4f32_clamp_precvt(<4 x half> %src0, <4 x half> %sr
 ; SDAG-CI-NEXT:    v_or_b32_e32 v1, v1, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v4f32_clamp_precvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v2, v1, v3, v5 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v3, v6
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_pack_b32_f16 v0, v3, v0
-; GISEL-GFX1100-NEXT:    v_pack_b32_f16 v1, v2, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v4f32_clamp_precvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v10.l, v3.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v11.l, v5.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v6, v6, v7, v8 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v9, v10, v11 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v6
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.h, v1
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v3
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v4f32_clamp_precvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v3, v6
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_pack_b32_f16 v0, v3, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_pack_b32_f16 v1, v2, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v4f32_clamp_precvt:
 ; GISEL-GFX900:       ; %bb.0:
@@ -2604,13 +2780,21 @@ define i32 @mixlo_zext(float %src0, float %src1, float %src2) #0 {
 ; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v0, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: mixlo_zext:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: mixlo_zext:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: mixlo_zext:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-VI-LABEL: mixlo_zext:
 ; GISEL-VI:       ; %bb.0:
@@ -2847,4 +3031,4 @@ declare <4 x float> @llvm.fmuladd.v4f32(<4 x float>, <4 x float>, <4 x float>) #
 attributes #0 = { nounwind denormal_fpenv(float: preservesign) }
 attributes #1 = { nounwind readnone speculatable }
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GISEL-GFX1100-FAKE16: {{.*}}
+; GISEL-GFX1100: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-lo.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-lo.ll
@@ -497,12 +497,10 @@ define <2 x half> @v_mad_mix_v2f32(<2 x half> %src0, <2 x half> %src1, <2 x half
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v3, v4, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32:
@@ -649,13 +647,11 @@ define <3 x half> @v_mad_mix_v3f32(<3 x half> %src0, <3 x half> %src1, <3 x half
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v3f32:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v2, v4 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v6, v7, v8 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v6
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v3f32:
@@ -862,17 +858,13 @@ define <4 x half> @v_mad_mix_v4f32(<4 x half> %src0, <4 x half> %src1, <4 x half
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v4f32:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v10.l, v3.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v11.l, v5.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v2, v4 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v6, v7, v8 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v1, v9, v10, v11 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v2, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v2, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v6
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v1, v2
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v4f32:
@@ -1073,11 +1065,8 @@ define <2 x half> @v_mad_mix_v2f32_clamp_postcvt(<2 x half> %src0, <2 x half> %s
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_postcvt:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v3, v4, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1272,14 +1261,10 @@ define <3 x half> @v_mad_mix_v3f32_clamp_postcvt(<3 x half> %src0, <3 x half> %s
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v3f32_clamp_postcvt:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v4.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v6, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_pk_max_f16 v1, v1, v1 clamp
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v2, v4 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1544,15 +1529,8 @@ define <4 x half> @v_mad_mix_v4f32_clamp_postcvt(<4 x half> %src0, <4 x half> %s
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v4f32_clamp_postcvt:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v10.l, v3.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v11.l, v5.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v6, v7, v8 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v1, v9, v10, v11 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v1, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v2, v4 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1] clamp
@@ -1755,15 +1733,11 @@ define <2 x half> @v_mad_mix_v2f32_clamp_postcvt_lo(<2 x half> %src0, <2 x half>
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_postcvt_lo:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v4, v5, v6 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v4, v4, v5, v6 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v4, v0, v1, v2 op_sel_hi:[1,1,1]
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_bfe_u32 v0, v3, 0, 16
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_and_or_b32 v0, 0xffff0000, v4, v0
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1946,15 +1920,12 @@ define <2 x half> @v_mad_mix_v2f32_clamp_postcvt_hi(<2 x half> %src0, <2 x half>
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_bfe_u32 v3, v3, 0, 16
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v4, v4, v5, v6 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v4, v0, v1, v2 op_sel_hi:[1,1,1]
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
 ; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_bfe_u32 v3, v3, 0, 16
 ; GISEL-GFX1100-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v3
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_and_or_b32 v0, 0xffff, v4, v0
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2581,13 +2552,11 @@ define <4 x half> @v_mad_mix_v4f32_clamp_precvt(<4 x half> %src0, <4 x half> %sr
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v4, v1, v3, v5 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v3.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v5.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_4)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v0, v1, v3 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v6
 ; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v4
 ; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.h, v3
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-lo.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-lo.ll
@@ -1065,9 +1065,10 @@ define <2 x half> @v_mad_mix_v2f32_clamp_postcvt(<2 x half> %src0, <2 x half> %s
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_postcvt:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_clamp_postcvt:
@@ -1262,10 +1263,11 @@ define <3 x half> @v_mad_mix_v3f32_clamp_postcvt(<3 x half> %src0, <3 x half> %s
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_pk_max_f16 v1, v1, v1 clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v3f32_clamp_postcvt:
@@ -1529,11 +1531,13 @@ define <4 x half> @v_mad_mix_v4f32_clamp_postcvt(<4 x half> %src0, <4 x half> %s
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v4f32_clamp_postcvt:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v1, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v2, v4 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v2, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v2, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v6
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v1, v2
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v4f32_clamp_postcvt:

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-lo.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-lo.ll
@@ -500,10 +500,9 @@ define <2 x half> @v_mad_mix_v2f32(<2 x half> %src0, <2 x half> %src1, <2 x half
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v3, v4, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v3, v4, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1]
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32:
@@ -653,13 +652,10 @@ define <3 x half> @v_mad_mix_v3f32(<3 x half> %src0, <3 x half> %src1, <3 x half
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v3.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v6, v7, v8 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v9, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v2, v4 op_sel_hi:[1,1,1]
 ; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v6, v7, v8 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v3f32:
@@ -867,19 +863,16 @@ define <4 x half> @v_mad_mix_v4f32(<4 x half> %src0, <4 x half> %src1, <4 x half
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v1.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v10.l, v3.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v11.l, v5.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v6, v6, v8, v9 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v2, v7, v10, v11 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v2, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v6
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v1, v2
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v2, v4 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v6, v7, v8 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v1, v9, v10, v11 op_sel:[1,1,1] op_sel_hi:[1,1,1]
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v4f32:
@@ -1083,9 +1076,9 @@ define <2 x half> @v_mad_mix_v2f32_clamp_postcvt(<2 x half> %src0, <2 x half> %s
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v3, v4, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v3, v4, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_clamp_postcvt:
@@ -1280,13 +1273,14 @@ define <3 x half> @v_mad_mix_v3f32_clamp_postcvt(<3 x half> %src0, <3 x half> %s
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v6, v7, v8 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v6, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    v_pk_max_f16 v1, v1, v1 clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v2, v4 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v3f32_clamp_postcvt:
@@ -1551,16 +1545,17 @@ define <4 x half> @v_mad_mix_v4f32_clamp_postcvt(<4 x half> %src0, <4 x half> %s
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v1.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v10.l, v3.l
 ; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v11.l, v5.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v1, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v6, v8, v9 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v7, v10, v11 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v0, v6, v7, v8 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v1, v9, v10, v11 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v4f32_clamp_postcvt:
@@ -2149,15 +2144,11 @@ define <2 x half> @v_mad_mix_v2f32_clamp_precvt(<2 x half> %src0, <2 x half> %sr
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_precvt:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v3, v4, v5 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v1
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v3
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v1
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_clamp_precvt:
@@ -2344,17 +2335,14 @@ define <3 x half> @v_mad_mix_v3f32_clamp_precvt(<3 x half> %src0, <3 x half> %sr
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v3f32_clamp_precvt:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v6, v6, v7, v8 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v2
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v1
 ; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v6
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v1
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v3f32_clamp_precvt:
@@ -2590,23 +2578,18 @@ define <4 x half> @v_mad_mix_v4f32_clamp_precvt(<4 x half> %src0, <4 x half> %sr
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v4f32_clamp_precvt:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v6.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v7.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v8.l, v4.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v9.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v10.l, v3.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v11.l, v5.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v6, v6, v7, v8 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v9, v10, v11 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v2
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v4, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v3.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v5.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v0, v1, v3 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
 ; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v6
-; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.h, v1
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v3
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v2
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v4
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.h, v3
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v4f32_clamp_precvt:

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-lo.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-lo.ll
@@ -6,8 +6,7 @@
 ; RUN: llc -mtriple=amdgpu8.03 < %s | FileCheck -check-prefixes=VI,SDAG-VI %s
 ; RUN: llc -mtriple=amdgpu7.01 < %s | FileCheck -check-prefixes=SDAG-CI %s
 
-; FIXME-TRUE16. enable gisel
-; XUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-TRUE16 %s
+; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-TRUE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=-real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-FAKE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu9.00 < %s | FileCheck -check-prefixes=GFX900,GISEL-GFX900 %s
 ; RUN: llc -global-isel -mtriple=amdgpu9.06 < %s | FileCheck -check-prefixes=GFX906,GISEL-GFX906 %s
@@ -388,13 +387,21 @@ define half @v_mad_mixlo_f16_f16lo_f16lo_f32_clamp_pre_cvt(half %src0, half %src
 ; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mixlo_f16_f16lo_f16lo_f32_clamp_pre_cvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,0] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mixlo_f16_f16lo_f16lo_f32_clamp_pre_cvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,0] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mixlo_f16_f16lo_f16lo_f32_clamp_pre_cvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,0] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mixlo_f16_f16lo_f16lo_f32_clamp_pre_cvt:
 ; GISEL-CI:       ; %bb.0:
@@ -487,14 +494,23 @@ define <2 x half> @v_mad_mix_v2f32(<2 x half> %src0, <2 x half> %src1, <2 x half
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v1, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v0, v3
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-VI-LABEL: v_mad_mix_v2f32:
 ; GISEL-VI:       ; %bb.0:
@@ -628,17 +644,27 @@ define <3 x half> @v_mad_mix_v3f32(<3 x half> %src0, <3 x half> %src1, <3 x half
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v2, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v3f32:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v2, v4 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_dual_mov_b32 v0, v3 :: v_dual_and_b32 v1, 0xffff, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v3f32:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v6
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v3f32:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v2, v4 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_dual_mov_b32 v0, v3 :: v_dual_and_b32 v1, 0xffff, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v3f32:
 ; GISEL-GFX900:       ; %bb.0:
@@ -829,17 +855,29 @@ define <4 x half> @v_mad_mix_v4f32(<4 x half> %src0, <4 x half> %src1, <4 x half
 ; SDAG-CI-NEXT:    v_or_b32_e32 v1, v3, v4
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v4f32:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v7, v1, v3, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v7, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_dual_mov_b32 v0, v6 :: v_dual_mov_b32 v1, v7
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v4f32:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v2, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v2, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v6
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v1, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v4f32:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v7, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v7, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_dual_mov_b32 v0, v6 :: v_dual_mov_b32 v1, v7
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v4f32:
 ; GISEL-GFX900:       ; %bb.0:
@@ -1024,14 +1062,23 @@ define <2 x half> @v_mad_mix_v2f32_clamp_postcvt(<2 x half> %src0, <2 x half> %s
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_clamp_postcvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v0, v3
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_postcvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_clamp_postcvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-VI-LABEL: v_mad_mix_v2f32_clamp_postcvt:
 ; GISEL-VI:       ; %bb.0:
@@ -1212,18 +1259,29 @@ define <3 x half> @v_mad_mix_v3f32_clamp_postcvt(<3 x half> %src0, <3 x half> %s
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v0, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v3f32_clamp_postcvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v2, v4 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_dual_mov_b32 v0, v3 :: v_dual_and_b32 v1, 0xffff, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
-; GISEL-GFX1100-NEXT:    v_pk_max_f16 v1, v1, v1 clamp
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v3f32_clamp_postcvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_pk_max_f16 v1, v1, v1 clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v3f32_clamp_postcvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v1, v1, v3, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v3, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_dual_mov_b32 v0, v3 :: v_dual_and_b32 v1, 0xffff, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
+; GISEL-GFX1100-FAKE16-NEXT:    v_pk_max_f16 v1, v1, v1 clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v3f32_clamp_postcvt:
 ; GISEL-GFX900:       ; %bb.0:
@@ -1470,17 +1528,29 @@ define <4 x half> @v_mad_mix_v4f32_clamp_postcvt(<4 x half> %src0, <4 x half> %s
 ; SDAG-CI-NEXT:    v_or_b32_e32 v1, v3, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v4f32_clamp_postcvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v7, v1, v3, v5 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v7, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_dual_mov_b32 v0, v6 :: v_dual_mov_b32 v1, v7
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v4f32_clamp_postcvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v2, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v2, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v6
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v1, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v4f32_clamp_postcvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v7, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v6, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v7, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_dual_mov_b32 v0, v6 :: v_dual_mov_b32 v1, v7
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-VI-LABEL: v_mad_mix_v4f32_clamp_postcvt:
 ; GISEL-VI:       ; %bb.0:
@@ -1664,18 +1734,29 @@ define <2 x half> @v_mad_mix_v2f32_clamp_postcvt_lo(<2 x half> %src0, <2 x half>
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v1, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_clamp_postcvt_lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v4, v3
-; GISEL-GFX1100-NEXT:    v_max_f16_e64 v3, v3, v3 clamp
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_bfe_u32 v0, v3, 0, 16
-; GISEL-GFX1100-NEXT:    v_and_or_b32 v0, 0xffff0000, v4, v0
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_postcvt_lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v4, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_bfe_u32 v0, v3, 0, 16
+; GISEL-GFX1100-TRUE16-NEXT:    v_and_or_b32 v0, 0xffff0000, v4, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_clamp_postcvt_lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v4, v3
+; GISEL-GFX1100-FAKE16-NEXT:    v_max_f16_e64 v3, v3, v3 clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_bfe_u32 v0, v3, 0, 16
+; GISEL-GFX1100-FAKE16-NEXT:    v_and_or_b32 v0, 0xffff0000, v4, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_clamp_postcvt_lo:
 ; GISEL-GFX900:       ; %bb.0:
@@ -1839,18 +1920,31 @@ define <2 x half> @v_mad_mix_v2f32_clamp_postcvt_hi(<2 x half> %src0, <2 x half>
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v1, v0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_clamp_postcvt_hi:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v4, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_bfe_u32 v3, v3, 0, 16
-; GISEL-GFX1100-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_lshlrev_b32_e32 v0, 16, v3
-; GISEL-GFX1100-NEXT:    v_and_or_b32 v0, 0xffff, v4, v0
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_postcvt_hi:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v4, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_bfe_u32 v3, v3, 0, 16
+; GISEL-GFX1100-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v3
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_and_or_b32 v0, 0xffff, v4, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_clamp_postcvt_hi:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v3, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v4, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_bfe_u32 v3, v3, 0, 16
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixhi_f16 v4, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v3
+; GISEL-GFX1100-FAKE16-NEXT:    v_and_or_b32 v0, 0xffff, v4, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_clamp_postcvt_hi:
 ; GISEL-GFX900:       ; %bb.0:
@@ -2022,17 +2116,27 @@ define <2 x half> @v_mad_mix_v2f32_clamp_precvt(<2 x half> %src0, <2 x half> %sr
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_clamp_precvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v1, v3
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_pack_b32_f16 v0, v1, v0
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_clamp_precvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v3
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v1
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_clamp_precvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, v3
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_pack_b32_f16 v0, v1, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_clamp_precvt:
 ; GISEL-GFX900:       ; %bb.0:
@@ -2203,22 +2307,35 @@ define <3 x half> @v_mad_mix_v3f32_clamp_precvt(<3 x half> %src0, <3 x half> %sr
 ; SDAG-CI-NEXT:    v_or_b32_e32 v0, v0, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v3f32_clamp_precvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v2, v4 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v2, v3
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GISEL-GFX1100-NEXT:    v_and_b32_e32 v1, 0xffff, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_pack_b32_f16 v0, v2, v0
-; GISEL-GFX1100-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v3f32_clamp_precvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v6
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v1
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v3f32_clamp_precvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v3, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, v3
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_pack_b32_f16 v0, v2, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshl_or_b32 v1, s0, 16, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v3f32_clamp_precvt:
 ; GISEL-GFX900:       ; %bb.0:
@@ -2433,23 +2550,38 @@ define <4 x half> @v_mad_mix_v4f32_clamp_precvt(<4 x half> %src0, <4 x half> %sr
 ; SDAG-CI-NEXT:    v_or_b32_e32 v1, v1, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v4f32_clamp_precvt:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v2, v1, v3, v5 op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v3, v6
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GISEL-GFX1100-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_pack_b32_f16 v0, v3, v0
-; GISEL-GFX1100-NEXT:    v_pack_b32_f16 v1, v2, v1
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v4f32_clamp_precvt:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v4, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, v6
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.h, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, v4
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.h, v3
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v4f32_clamp_precvt:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v6, v0, v2, v4 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v2, v4 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v1, v3, v5 op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v1, v3, v5 op_sel:[1,1,1] op_sel_hi:[1,1,1] clamp
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v3, v6
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GISEL-GFX1100-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_pack_b32_f16 v0, v3, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_pack_b32_f16 v1, v2, v1
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v4f32_clamp_precvt:
 ; GISEL-GFX900:       ; %bb.0:
@@ -2604,13 +2736,21 @@ define i32 @mixlo_zext(float %src0, float %src1, float %src2) #0 {
 ; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v0, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: mixlo_zext:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: mixlo_zext:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_cvt_u32_u16_e32 v0, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: mixlo_zext:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mixlo_f16 v0, v0, v1, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: mixlo_zext:
 ; GISEL-CI:       ; %bb.0:
@@ -2838,4 +2978,4 @@ declare <4 x float> @llvm.fmuladd.v4f32(<4 x float>, <4 x float>, <4 x float>) #
 attributes #0 = { nounwind denormal_fpenv(float: preservesign) }
 attributes #1 = { nounwind readnone speculatable }
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GISEL-GFX1100-FAKE16: {{.*}}
+; GISEL-GFX1100: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/mad-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix.ll
@@ -202,14 +202,14 @@ define float @v_mad_mix_f32_f16hi_f16hi_f16hi_elt(<2 x half> %src0, <2 x half> %
 }
 
 define <2 x float> @v_mad_mix_v2f32(<2 x half> %src0, <2 x half> %src1, <2 x half> %src2) #0 {
-; SDAG-GFX1100-LABEL: v_mad_mix_v2f32:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v3
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_v2f32:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1100-NEXT:    v_mov_b32_e32 v0, v3
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_v2f32:
 ; GFX900:       ; %bb.0:
@@ -268,27 +268,6 @@ define <2 x float> @v_mad_mix_v2f32(<2 x half> %src0, <2 x half> %src1, <2 x hal
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v1, v5, v4
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v0, v6, v7
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32:
-; GISEL-GFX1100-TRUE16:       ; %bb.0:
-; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v3, v4, v5 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
-; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32:
-; GISEL-GFX1100-FAKE16:       ; %bb.0:
-; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v3
-; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9GEN-LABEL: v_mad_mix_v2f32:
 ; GISEL-GFX9GEN:       ; %bb.0:
@@ -408,11 +387,12 @@ define <2 x float> @v_mad_mix_v2f32_shuffle(<2 x half> %src0, <2 x half> %src1, 
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_shuffle:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v3, v2 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v4, v1, v2 op_sel:[0,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v3, v1, v4 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[0,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_shuffle:
@@ -1286,28 +1266,15 @@ define <2 x float> @v_mad_mix_v2f32_f32imm1(<2 x half> %src0, <2 x half> %src1) 
 ; SDAG-CI-NEXT:    v_mad_f32 v1, v3, v2, 1.0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_f32imm1:
-; GISEL-GFX1100-TRUE16:       ; %bb.0:
-; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v3, 1.0
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, v4, v3 op_sel_hi:[1,1,0]
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_f32imm1:
-; GISEL-GFX1100-FAKE16:       ; %bb.0:
-; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v3, 1.0
-; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_f32imm1:
+; GISEL-GFX1100:       ; %bb.0:
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v3, 1.0
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
+; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_f32imm1:
 ; GISEL-GFX900:       ; %bb.0:
@@ -1434,28 +1401,15 @@ define <2 x float> @v_mad_mix_v2f32_cvtf16imminv2pi(<2 x half> %src0, <2 x half>
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v1, v3, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_cvtf16imminv2pi:
-; GISEL-GFX1100-TRUE16:       ; %bb.0:
-; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v3, 0x3e230000
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, v4, v3 op_sel_hi:[1,1,0]
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_cvtf16imminv2pi:
-; GISEL-GFX1100-FAKE16:       ; %bb.0:
-; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v3, 0x3e230000
-; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_cvtf16imminv2pi:
+; GISEL-GFX1100:       ; %bb.0:
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v3, 0x3e230000
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
+; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_cvtf16imminv2pi:
 ; GISEL-GFX900:       ; %bb.0:
@@ -1584,28 +1538,15 @@ define <2 x float> @v_mad_mix_v2f32_f32imminv2pi(<2 x half> %src0, <2 x half> %s
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v1, v3, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_f32imminv2pi:
-; GISEL-GFX1100-TRUE16:       ; %bb.0:
-; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v3, 0.15915494
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, v4, v3 op_sel_hi:[1,1,0]
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_f32imminv2pi:
-; GISEL-GFX1100-FAKE16:       ; %bb.0:
-; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v3, 0.15915494
-; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_f32imminv2pi:
+; GISEL-GFX1100:       ; %bb.0:
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v3, 0.15915494
+; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
+; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_f32imminv2pi:
 ; GISEL-GFX900:       ; %bb.0:
@@ -2831,14 +2772,14 @@ define float @v_mad_mix_f32_f16hi_add_f16hi_elt(<2 x half> %src0, <2 x half> %sr
 }
 
 define <2 x float> @v_mad_mix_v2f32_cvt_add(<2 x half> %src0, <2 x half> %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_v2f32_cvt_add:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_v2f32_cvt_add:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1100-NEXT:    v_mov_b32_e32 v0, v2
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_v2f32_cvt_add:
 ; SDAG-GFX900:       ; %bb.0:
@@ -2893,26 +2834,6 @@ define <2 x float> @v_mad_mix_v2f32_cvt_add(<2 x half> %src0, <2 x half> %src1) 
 ; SDAG-CI-NEXT:    v_add_f32_e32 v1, v3, v2
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v4
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_cvt_add:
-; GISEL-GFX1100-TRUE16:       ; %bb.0:
-; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, 1.0, v3 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_cvt_add:
-; GISEL-GFX1100-FAKE16:       ; %bb.0:
-; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_cvt_add:
 ; GISEL-GFX900:       ; %bb.0:
@@ -3032,11 +2953,11 @@ define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_add(<2 x half> %src0, <2 x half>
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, 1.0, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v3, 1.0, v1 op_sel:[0,0,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[0,0,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
@@ -4482,14 +4403,14 @@ define float @v_mad_mix_f32_f16hi_mul_f16hi_elt(<2 x half> %src0, <2 x half> %sr
 }
 
 define <2 x float> @v_mad_mix_v2f32_cvt_mul(<2 x half> %src0, <2 x half> %src1) {
-; SDAG-GFX1100-LABEL: v_mad_mix_v2f32_cvt_mul:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel_hi:[1,1,0]
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_v2f32_cvt_mul:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel_hi:[1,1,0]
+; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1100-NEXT:    v_mov_b32_e32 v0, v2
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_v2f32_cvt_mul:
 ; SDAG-GFX900:       ; %bb.0:
@@ -4544,26 +4465,6 @@ define <2 x float> @v_mad_mix_v2f32_cvt_mul(<2 x half> %src0, <2 x half> %src1) 
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v1, v3, v2
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v0, v0, v4
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_cvt_mul:
-; GISEL-GFX1100-TRUE16:       ; %bb.0:
-; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, v3, neg(0) op_sel_hi:[1,1,0]
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_cvt_mul:
-; GISEL-GFX1100-FAKE16:       ; %bb.0:
-; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel_hi:[1,1,0]
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_cvt_mul:
 ; GISEL-GFX900:       ; %bb.0:
@@ -4683,11 +4584,11 @@ define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_mul(<2 x half> %src0, <2 x half>
 ; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v1.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v2, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v3, v1, neg(0) op_sel:[0,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[0,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:

--- a/llvm/test/CodeGen/AMDGPU/mad-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix.ll
@@ -7,8 +7,7 @@
 ; RUN: llc -mtriple=amdgpu8.03 < %s | FileCheck -check-prefixes=VI,SDAG-VI %s
 ; RUN: llc -mtriple=amdgpu7.01 < %s | FileCheck -check-prefixes=CI,SDAG-CI %s
 
-; FIXME-TRUE16. enable gisel
-; XUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-TRUE16 %s
+; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-TRUE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=-real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-FAKE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu9.00 < %s | FileCheck -check-prefixes=GFX900,GISEL-GFX900 %s
 ; RUN: llc -global-isel -mtriple=amdgpu9.06 < %s | FileCheck -check-prefixes=GFX906,GISEL-GFX906 %s
@@ -203,14 +202,14 @@ define float @v_mad_mix_f32_f16hi_f16hi_f16hi_elt(<2 x half> %src0, <2 x half> %
 }
 
 define <2 x float> @v_mad_mix_v2f32(<2 x half> %src0, <2 x half> %src1, <2 x half> %src2) #0 {
-; GFX1100-LABEL: v_mad_mix_v2f32:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1100-NEXT:    v_mov_b32_e32 v0, v3
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_v2f32:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v3
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_v2f32:
 ; GFX900:       ; %bb.0:
@@ -270,6 +269,27 @@ define <2 x float> @v_mad_mix_v2f32(<2 x half> %src0, <2 x half> %src1, <2 x hal
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v0, v6, v7
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v5.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v3, v4, v5 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[1,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GISEL-GFX9GEN-LABEL: v_mad_mix_v2f32:
 ; GISEL-GFX9GEN:       ; %bb.0:
 ; GISEL-GFX9GEN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -319,14 +339,14 @@ define <2 x float> @v_mad_mix_v2f32(<2 x half> %src0, <2 x half> %src1, <2 x hal
 }
 
 define <2 x float> @v_mad_mix_v2f32_shuffle(<2 x half> %src0, <2 x half> %src1, <2 x half> %src2) #0 {
-; GFX1100-LABEL: v_mad_mix_v2f32_shuffle:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[0,1,1] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1100-NEXT:    v_mov_b32_e32 v0, v3
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_v2f32_shuffle:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[0,1,1] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v3
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_v2f32_shuffle:
 ; GFX900:       ; %bb.0:
@@ -384,6 +404,25 @@ define <2 x float> @v_mad_mix_v2f32_shuffle(<2 x half> %src0, <2 x half> %src1, 
 ; SDAG-CI-NEXT:    v_mad_f32 v0, v4, v0, v1
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v1, v5, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_shuffle:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v3, v2 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v4, v1, v2 op_sel:[0,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_shuffle:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[0,1,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v3
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_v2f32_shuffle:
 ; GISEL-CI:       ; %bb.0:
@@ -1247,15 +1286,28 @@ define <2 x float> @v_mad_mix_v2f32_f32imm1(<2 x half> %src0, <2 x half> %src1) 
 ; SDAG-CI-NEXT:    v_mad_f32 v1, v3, v2, 1.0
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_f32imm1:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v3, 1.0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_f32imm1:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v3, 1.0
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, v4, v3 op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_f32imm1:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v3, 1.0
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_f32imm1:
 ; GISEL-GFX900:       ; %bb.0:
@@ -1382,15 +1434,28 @@ define <2 x float> @v_mad_mix_v2f32_cvtf16imminv2pi(<2 x half> %src0, <2 x half>
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v1, v3, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_cvtf16imminv2pi:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v3, 0x3e230000
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_cvtf16imminv2pi:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v3, 0x3e230000
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, v4, v3 op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_cvtf16imminv2pi:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v3, 0x3e230000
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_cvtf16imminv2pi:
 ; GISEL-GFX900:       ; %bb.0:
@@ -1519,15 +1584,28 @@ define <2 x float> @v_mad_mix_v2f32_f32imminv2pi(<2 x half> %src0, <2 x half> %s
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v1, v3, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_v2f32_f32imminv2pi:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v3, 0.15915494
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_f32imminv2pi:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v3, 0.15915494
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, v4, v3 op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_f32imminv2pi:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v3, 0.15915494
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, v1, v3 op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v3 op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_f32imminv2pi:
 ; GISEL-GFX900:       ; %bb.0:
@@ -2224,14 +2302,23 @@ define float @v_mad_mix_f32_precvtnegf16hi_abs_f16lo_f16lo(i32 %src0.arg, half %
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v0, v3, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_f16lo_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_f16lo_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_xor_b16 v0.l, 0x8000, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_f16lo_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_f16lo_f16lo:
 ; GISEL-CI:       ; %bb.0:
@@ -2744,14 +2831,14 @@ define float @v_mad_mix_f32_f16hi_add_f16hi_elt(<2 x half> %src0, <2 x half> %sr
 }
 
 define <2 x float> @v_mad_mix_v2f32_cvt_add(<2 x half> %src0, <2 x half> %src1)  {
-; GFX1100-LABEL: v_mad_mix_v2f32_cvt_add:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1100-NEXT:    v_mov_b32_e32 v0, v2
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_v2f32_cvt_add:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_v2f32_cvt_add:
 ; SDAG-GFX900:       ; %bb.0:
@@ -2807,6 +2894,26 @@ define <2 x float> @v_mad_mix_v2f32_cvt_add(<2 x half> %src0, <2 x half> %src1) 
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v4
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_cvt_add:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, 1.0, v3 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_cvt_add:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_cvt_add:
 ; GISEL-GFX900:       ; %bb.0:
 ; GISEL-GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -2859,14 +2966,14 @@ define <2 x float> @v_mad_mix_v2f32_cvt_add(<2 x half> %src0, <2 x half> %src1) 
 }
 
 define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_add(<2 x half> %src0, <2 x half> %src1)  {
-; GFX1100-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[0,0,1] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1100-NEXT:    v_mov_b32_e32 v0, v2
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[0,0,1] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
 ; GFX900:       ; %bb.0:
@@ -2921,6 +3028,25 @@ define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_add(<2 x half> %src0, <2 x half>
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v3, v0
 ; SDAG-CI-NEXT:    v_add_f32_e32 v1, v4, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, 1.0, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v3, 1.0, v1 op_sel:[0,0,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[0,0,1] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
 ; GISEL-CI:       ; %bb.0:
@@ -3795,14 +3921,23 @@ define float @v_mad_mix_f32_precvtnegf16hi_abs_add_f16lo(i32 %src0.arg, half %sr
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_add_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_add_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_xor_b16 v0.l, 0x8000, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_add_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_add_f16lo:
 ; GISEL-CI:       ; %bb.0:
@@ -4347,14 +4482,14 @@ define float @v_mad_mix_f32_f16hi_mul_f16hi_elt(<2 x half> %src0, <2 x half> %sr
 }
 
 define <2 x float> @v_mad_mix_v2f32_cvt_mul(<2 x half> %src0, <2 x half> %src1) {
-; GFX1100-LABEL: v_mad_mix_v2f32_cvt_mul:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel_hi:[1,1,0]
-; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[1,1,0] op_sel_hi:[1,1,0]
-; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1100-NEXT:    v_mov_b32_e32 v0, v2
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_v2f32_cvt_mul:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel_hi:[1,1,0]
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_v2f32_cvt_mul:
 ; SDAG-GFX900:       ; %bb.0:
@@ -4410,6 +4545,26 @@ define <2 x float> @v_mad_mix_v2f32_cvt_mul(<2 x half> %src0, <2 x half> %src1) 
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v0, v0, v4
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_cvt_mul:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, v3, neg(0) op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_cvt_mul:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[1,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
 ; GISEL-GFX900-LABEL: v_mad_mix_v2f32_cvt_mul:
 ; GISEL-GFX900:       ; %bb.0:
 ; GISEL-GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
@@ -4462,14 +4617,14 @@ define <2 x float> @v_mad_mix_v2f32_cvt_mul(<2 x half> %src0, <2 x half> %src1) 
 }
 
 define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_mul(<2 x half> %src0, <2 x half> %src1) {
-; GFX1100-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[0,1,0] op_sel_hi:[1,1,0]
-; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX1100-NEXT:    v_mov_b32_e32 v0, v2
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[0,1,0] op_sel_hi:[1,1,0]
+; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
 ; GFX900:       ; %bb.0:
@@ -4524,6 +4679,25 @@ define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_mul(<2 x half> %src0, <2 x half>
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v0, v3, v0
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v1, v4, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v1.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v2, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v3, v1, neg(0) op_sel:[0,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[0,1,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
 ; GISEL-CI:       ; %bb.0:
@@ -5299,14 +5473,23 @@ define float @v_mad_mix_f32_precvtnegf16hi_abs_mul_f16lo(i32 %src0.arg, half %sr
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_mul_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel_hi:[1,1,0]
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_mul_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_xor_b16 v0.l, 0x8000, v0.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_mul_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_mul_f16lo:
 ; GISEL-CI:       ; %bb.0:
@@ -5901,5 +6084,3 @@ declare <2 x float> @llvm.fmuladd.v2f32(<2 x float>, <2 x float>, <2 x float>) #
 attributes #0 = { nounwind denormal_fpenv(float: preservesign) }
 attributes #1 = { nounwind denormal_fpenv(float: ieee|ieee) }
 attributes #2 = { nounwind readnone speculatable }
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GISEL-GFX1100-FAKE16: {{.*}}

--- a/llvm/test/CodeGen/AMDGPU/mad-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix.ll
@@ -5916,74 +5916,74 @@ define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
   ret float %result
 }
 
-; The fpext sources are defined by 16-bit instructions rather than by truncates,
-; so with real-true16 they live in VGPR_16 and have to be placed in the low half
-; of a 32-bit register before mad-mix can read them. This is the only shape that
-; needs those copies; they should coalesce away here.
-define float @v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src(half %src0, half %src1, half %src2, half %add) #0 {
-; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; The mix instructions read a 32-bit source and use op_sel to pick the half to
+; convert. Check the sources that are the result of a real 16-bit instruction
+; rather than a truncate, which with real true16 instructions live in a VGPR_16
+; and have to be placed into a 32-bit register first.
+define float @v_mad_mix_f32_f16lo_f16lo_f16lo_16bit_srcs(half %src0, half %src1, half %src2, half %scale) #0 {
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_16bit_srcs:
 ; SDAG-GFX1100-TRUE16:       ; %bb.0:
 ; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SDAG-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v0.l, v0.l, v3.l
-; SDAG-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v1.l, v1.l, v3.l
-; SDAG-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v2.l, v2.l, v3.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_mul_f16_e32 v1.l, v1.l, v3.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_sub_f16_e32 v2.l, v2.l, v3.l
 ; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; SDAG-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
 ; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_16bit_srcs:
 ; SDAG-GFX1100-FAKE16:       ; %bb.0:
 ; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SDAG-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v0, v0, v3
-; SDAG-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v1, v1, v3
-; SDAG-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v2, v2, v3
+; SDAG-GFX1100-FAKE16-NEXT:    v_mul_f16_e32 v1, v1, v3
+; SDAG-GFX1100-FAKE16-NEXT:    v_sub_f16_e32 v2, v2, v3
 ; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; SDAG-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
 ; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX900-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GFX900-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_16bit_srcs:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX900-NEXT:    v_add_f16_e32 v0, v0, v3
-; GFX900-NEXT:    v_add_f16_e32 v1, v1, v3
-; GFX900-NEXT:    v_add_f16_e32 v2, v2, v3
+; GFX900-NEXT:    v_mul_f16_e32 v1, v1, v3
+; GFX900-NEXT:    v_sub_f16_e32 v2, v2, v3
 ; GFX900-NEXT:    v_mad_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX906-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GFX906-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_16bit_srcs:
 ; GFX906:       ; %bb.0:
 ; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX906-NEXT:    v_add_f16_e32 v0, v0, v3
-; GFX906-NEXT:    v_add_f16_e32 v1, v1, v3
-; GFX906-NEXT:    v_add_f16_e32 v2, v2, v3
+; GFX906-NEXT:    v_mul_f16_e32 v1, v1, v3
+; GFX906-NEXT:    v_sub_f16_e32 v2, v2, v3
 ; GFX906-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
 ; GFX906-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_16bit_srcs:
 ; GFX9GEN:       ; %bb.0:
 ; GFX9GEN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9GEN-NEXT:    v_add_f16_e32 v0, v0, v3
-; GFX9GEN-NEXT:    v_add_f16_e32 v1, v1, v3
-; GFX9GEN-NEXT:    v_add_f16_e32 v2, v2, v3
+; GFX9GEN-NEXT:    v_mul_f16_e32 v1, v1, v3
+; GFX9GEN-NEXT:    v_sub_f16_e32 v2, v2, v3
 ; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v3, v0
 ; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v0, v2
 ; GFX9GEN-NEXT:    v_mac_f32_e32 v0, v3, v1
 ; GFX9GEN-NEXT:    s_setpc_b64 s[30:31]
 ;
-; VI-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; VI-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_16bit_srcs:
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_add_f16_e32 v0, v0, v3
-; VI-NEXT:    v_add_f16_e32 v1, v1, v3
-; VI-NEXT:    v_add_f16_e32 v2, v2, v3
+; VI-NEXT:    v_mul_f16_e32 v1, v1, v3
+; VI-NEXT:    v_sub_f16_e32 v2, v2, v3
 ; VI-NEXT:    v_cvt_f32_f16_e32 v3, v0
 ; VI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; VI-NEXT:    v_cvt_f32_f16_e32 v0, v2
 ; VI-NEXT:    v_mac_f32_e32 v0, v3, v1
 ; VI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; SDAG-CI-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; SDAG-CI-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_16bit_srcs:
 ; SDAG-CI:       ; %bb.0:
 ; SDAG-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v3, v3
@@ -5991,8 +5991,8 @@ define float @v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src(half %src0, half %src1,
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v3
-; SDAG-CI-NEXT:    v_add_f32_e32 v1, v1, v3
-; SDAG-CI-NEXT:    v_add_f32_e32 v2, v2, v3
+; SDAG-CI-NEXT:    v_mul_f32_e32 v1, v1, v3
+; SDAG-CI-NEXT:    v_sub_f32_e32 v2, v2, v3
 ; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v1, v1
 ; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v2, v2
@@ -6002,37 +6002,38 @@ define float @v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src(half %src0, half %src1,
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v0, v3, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_16bit_srcs:
 ; GISEL-GFX1100-TRUE16:       ; %bb.0:
 ; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v0.l, v0.l, v3.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v1.l, v1.l, v3.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v2.l, v2.l, v3.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_mul_f16_e32 v1.l, v1.l, v3.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_sub_f16_e32 v2.l, v2.l, v3.l
 ; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
 ; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_16bit_srcs:
 ; GISEL-GFX1100-FAKE16:       ; %bb.0:
 ; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v0, v0, v3
-; GISEL-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v1, v1, v3
-; GISEL-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v2, v2, v3
+; GISEL-GFX1100-FAKE16-NEXT:    v_mul_f16_e32 v1, v1, v3
+; GISEL-GFX1100-FAKE16-NEXT:    v_sub_f16_e32 v2, v2, v3
 ; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
 ; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-CI-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GISEL-CI-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_16bit_srcs:
 ; GISEL-CI:       ; %bb.0:
 ; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v4, v3
 ; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GISEL-CI-NEXT:    v_add_f32_e32 v0, v0, v3
-; GISEL-CI-NEXT:    v_add_f32_e32 v1, v1, v3
-; GISEL-CI-NEXT:    v_add_f32_e32 v2, v2, v3
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e64 v3, -v3
+; GISEL-CI-NEXT:    v_add_f32_e32 v0, v0, v4
+; GISEL-CI-NEXT:    v_mul_f32_e32 v1, v1, v4
 ; GISEL-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-CI-NEXT:    v_add_f32_e32 v2, v2, v3
 ; GISEL-CI-NEXT:    v_cvt_f16_f32_e32 v1, v1
 ; GISEL-CI-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v3, v0
@@ -6040,13 +6041,393 @@ define float @v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src(half %src0, half %src1,
 ; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v0, v2
 ; GISEL-CI-NEXT:    v_mac_f32_e32 v0, v3, v1
 ; GISEL-CI-NEXT:    s_setpc_b64 s[30:31]
-  %src0.add = fadd half %src0, %add
-  %src1.add = fadd half %src1, %add
-  %src2.add = fadd half %src2, %add
-  %src0.ext = fpext half %src0.add to float
-  %src1.ext = fpext half %src1.add to float
-  %src2.ext = fpext half %src2.add to float
-  %result = tail call float @llvm.fmuladd.f32(float %src0.ext, float %src1.ext, float %src2.ext)
+  %src0.op = fadd half %src0, %scale
+  %src1.op = fmul half %src1, %scale
+  %src2.op = fsub half %src2, %scale
+  %src0.ext = fpext half %src0.op to float
+  %src1.ext = fpext half %src1.op to float
+  %src2.ext = fpext half %src2.op to float
+  %result = call float @llvm.fmuladd.f32(float %src0.ext, float %src1.ext, float %src2.ext)
+  ret float %result
+}
+
+define float @v_mad_mix_f32_16bit_src_add_f16lo(half %src0, half %src1, half %scale) #0 {
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_16bit_src_add_f16lo:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v0.l, v0.l, v2.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, 1.0, v1 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_16bit_src_add_f16lo:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v0, v0, v2
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, 1.0, v1 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX900-LABEL: v_mad_mix_f32_16bit_src_add_f16lo:
+; GFX900:       ; %bb.0:
+; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX900-NEXT:    v_add_f16_e32 v0, v0, v2
+; GFX900-NEXT:    v_mad_mix_f32 v0, v0, 1.0, v1 op_sel_hi:[1,1,1]
+; GFX900-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX906-LABEL: v_mad_mix_f32_16bit_src_add_f16lo:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_add_f16_e32 v0, v0, v2
+; GFX906-NEXT:    v_fma_mix_f32 v0, v0, 1.0, v1 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GEN-LABEL: v_mad_mix_f32_16bit_src_add_f16lo:
+; GFX9GEN:       ; %bb.0:
+; GFX9GEN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GEN-NEXT:    v_add_f16_e32 v0, v0, v2
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX9GEN-NEXT:    v_add_f32_e32 v0, v0, v1
+; GFX9GEN-NEXT:    s_setpc_b64 s[30:31]
+;
+; VI-LABEL: v_mad_mix_f32_16bit_src_add_f16lo:
+; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_add_f16_e32 v0, v0, v2
+; VI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; VI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; VI-NEXT:    v_add_f32_e32 v0, v0, v1
+; VI-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-CI-LABEL: v_mad_mix_f32_16bit_src_add_f16lo:
+; SDAG-CI:       ; %bb.0:
+; SDAG-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v2
+; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v1
+; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_16bit_src_add_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v0.l, v0.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, 1.0, v1 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_16bit_src_add_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v0, v0, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, 1.0, v1 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-CI-LABEL: v_mad_mix_f32_16bit_src_add_f16lo:
+; GISEL-CI:       ; %bb.0:
+; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-CI-NEXT:    v_add_f32_e32 v0, v0, v2
+; GISEL-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-CI-NEXT:    v_add_f32_e32 v0, v0, v1
+; GISEL-CI-NEXT:    s_setpc_b64 s[30:31]
+  %src0.op = fadd half %src0, %scale
+  %src0.ext = fpext half %src0.op to float
+  %src1.ext = fpext half %src1 to float
+  %result = fadd float %src0.ext, %src1.ext
+  ret float %result
+}
+
+define float @v_mad_mix_f32_16bit_src_mul_f16lo(half %src0, half %src1, half %scale) #0 {
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_16bit_src_mul_f16lo:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v0.l, v0.l, v2.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, neg(0) op_sel_hi:[1,1,0]
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_16bit_src_mul_f16lo:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v0, v0, v2
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, neg(0) op_sel_hi:[1,1,0]
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX900-LABEL: v_mad_mix_f32_16bit_src_mul_f16lo:
+; GFX900:       ; %bb.0:
+; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX900-NEXT:    v_add_f16_e32 v0, v0, v2
+; GFX900-NEXT:    v_mad_mix_f32 v0, v0, v1, neg(0) op_sel_hi:[1,1,0]
+; GFX900-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX906-LABEL: v_mad_mix_f32_16bit_src_mul_f16lo:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_add_f16_e32 v0, v0, v2
+; GFX906-NEXT:    v_fma_mix_f32 v0, v0, v1, neg(0) op_sel_hi:[1,1,0]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GEN-LABEL: v_mad_mix_f32_16bit_src_mul_f16lo:
+; GFX9GEN:       ; %bb.0:
+; GFX9GEN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GEN-NEXT:    v_add_f16_e32 v0, v0, v2
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX9GEN-NEXT:    v_mul_f32_e32 v0, v0, v1
+; GFX9GEN-NEXT:    s_setpc_b64 s[30:31]
+;
+; VI-LABEL: v_mad_mix_f32_16bit_src_mul_f16lo:
+; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_add_f16_e32 v0, v0, v2
+; VI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; VI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; VI-NEXT:    v_mul_f32_e32 v0, v0, v1
+; VI-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-CI-LABEL: v_mad_mix_f32_16bit_src_mul_f16lo:
+; SDAG-CI:       ; %bb.0:
+; SDAG-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v2
+; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-CI-NEXT:    v_mul_f32_e32 v0, v0, v1
+; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_16bit_src_mul_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v0.l, v0.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, neg(0) op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_16bit_src_mul_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v0, v0, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, neg(0) op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-CI-LABEL: v_mad_mix_f32_16bit_src_mul_f16lo:
+; GISEL-CI:       ; %bb.0:
+; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-CI-NEXT:    v_add_f32_e32 v0, v0, v2
+; GISEL-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-CI-NEXT:    v_mul_f32_e32 v0, v0, v1
+; GISEL-CI-NEXT:    s_setpc_b64 s[30:31]
+  %src0.op = fadd half %src0, %scale
+  %src0.ext = fpext half %src0.op to float
+  %src1.ext = fpext half %src1 to float
+  %result = fmul float %src0.ext, %src1.ext
+  ret float %result
+}
+
+define float @v_mad_mix_f32_16bit_src_sub_f16lo(half %src0, half %src1, half %scale) #0 {
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_16bit_src_sub_f16lo:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v0.l, v0.l, v2.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_16bit_src_sub_f16lo:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v0, v0, v2
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX900-LABEL: v_mad_mix_f32_16bit_src_sub_f16lo:
+; GFX900:       ; %bb.0:
+; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX900-NEXT:    v_add_f16_e32 v0, v0, v2
+; GFX900-NEXT:    v_mad_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; GFX900-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX906-LABEL: v_mad_mix_f32_16bit_src_sub_f16lo:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_add_f16_e32 v0, v0, v2
+; GFX906-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GEN-LABEL: v_mad_mix_f32_16bit_src_sub_f16lo:
+; GFX9GEN:       ; %bb.0:
+; GFX9GEN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GEN-NEXT:    v_add_f16_e32 v0, v0, v2
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX9GEN-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX9GEN-NEXT:    s_setpc_b64 s[30:31]
+;
+; VI-LABEL: v_mad_mix_f32_16bit_src_sub_f16lo:
+; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_add_f16_e32 v0, v0, v2
+; VI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; VI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; VI-NEXT:    v_sub_f32_e32 v0, v0, v1
+; VI-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-CI-LABEL: v_mad_mix_f32_16bit_src_sub_f16lo:
+; SDAG-CI:       ; %bb.0:
+; SDAG-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v2
+; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-CI-NEXT:    v_sub_f32_e32 v0, v0, v1
+; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_16bit_src_sub_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v0.l, v0.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_16bit_src_sub_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v0, v0, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-CI-LABEL: v_mad_mix_f32_16bit_src_sub_f16lo:
+; GISEL-CI:       ; %bb.0:
+; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-CI-NEXT:    v_add_f32_e32 v0, v0, v2
+; GISEL-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-CI-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GISEL-CI-NEXT:    s_setpc_b64 s[30:31]
+  %src0.op = fadd half %src0, %scale
+  %src0.ext = fpext half %src0.op to float
+  %src1.ext = fpext half %src1 to float
+  %result = fsub float %src0.ext, %src1.ext
+  ret float %result
+}
+
+define float @v_mad_mix_f32_f16lo_sub_16bit_src(half %src0, half %src1, half %scale) #0 {
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_sub_16bit_src:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v1.l, v1.l, v2.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_sub_16bit_src:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v1, v1, v2
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX900-LABEL: v_mad_mix_f32_f16lo_sub_16bit_src:
+; GFX900:       ; %bb.0:
+; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX900-NEXT:    v_add_f16_e32 v1, v1, v2
+; GFX900-NEXT:    v_mad_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; GFX900-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX906-LABEL: v_mad_mix_f32_f16lo_sub_16bit_src:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_add_f16_e32 v1, v1, v2
+; GFX906-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_sub_16bit_src:
+; GFX9GEN:       ; %bb.0:
+; GFX9GEN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GEN-NEXT:    v_add_f16_e32 v1, v1, v2
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX9GEN-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GFX9GEN-NEXT:    s_setpc_b64 s[30:31]
+;
+; VI-LABEL: v_mad_mix_f32_f16lo_sub_16bit_src:
+; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_add_f16_e32 v1, v1, v2
+; VI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; VI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; VI-NEXT:    v_sub_f32_e32 v0, v0, v1
+; VI-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-CI-LABEL: v_mad_mix_f32_f16lo_sub_16bit_src:
+; SDAG-CI:       ; %bb.0:
+; SDAG-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-CI-NEXT:    v_add_f32_e32 v1, v1, v2
+; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-CI-NEXT:    v_sub_f32_e32 v0, v0, v1
+; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_sub_16bit_src:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v1.l, v1.l, v2.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_sub_16bit_src:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v1, v1, v2
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v1, -1.0, v0 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-CI-LABEL: v_mad_mix_f32_f16lo_sub_16bit_src:
+; GISEL-CI:       ; %bb.0:
+; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-CI-NEXT:    v_add_f32_e32 v1, v1, v2
+; GISEL-CI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-CI-NEXT:    v_sub_f32_e32 v0, v0, v1
+; GISEL-CI-NEXT:    s_setpc_b64 s[30:31]
+  %src1.op = fadd half %src1, %scale
+  %src0.ext = fpext half %src0 to float
+  %src1.ext = fpext half %src1.op to float
+  %result = fsub float %src0.ext, %src1.ext
   ret float %result
 }
 

--- a/llvm/test/CodeGen/AMDGPU/mad-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix.ll
@@ -318,14 +318,14 @@ define <2 x float> @v_mad_mix_v2f32(<2 x half> %src0, <2 x half> %src1, <2 x hal
 }
 
 define <2 x float> @v_mad_mix_v2f32_shuffle(<2 x half> %src0, <2 x half> %src1, <2 x half> %src2) #0 {
-; SDAG-GFX1100-LABEL: v_mad_mix_v2f32_shuffle:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[0,1,1] op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v3
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_v2f32_shuffle:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel:[1,0,1] op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[0,1,1] op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1100-NEXT:    v_mov_b32_e32 v0, v3
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_v2f32_shuffle:
 ; GFX900:       ; %bb.0:
@@ -383,26 +383,6 @@ define <2 x float> @v_mad_mix_v2f32_shuffle(<2 x half> %src0, <2 x half> %src1, 
 ; SDAG-CI-NEXT:    v_mad_f32 v0, v4, v0, v1
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v1, v5, v2
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_shuffle:
-; GISEL-GFX1100-TRUE16:       ; %bb.0:
-; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v4.l, v2.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v3, v3, v1, v4 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[0,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v3
-; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_shuffle:
-; GISEL-GFX1100-FAKE16:       ; %bb.0:
-; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v3, v0, v1, v2 op_sel:[1,0,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, v2 op_sel:[0,1,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v3
-; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_v2f32_shuffle:
 ; GISEL-CI:       ; %bb.0:
@@ -2887,14 +2867,14 @@ define <2 x float> @v_mad_mix_v2f32_cvt_add(<2 x half> %src0, <2 x half> %src1) 
 }
 
 define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_add(<2 x half> %src0, <2 x half> %src1)  {
-; SDAG-GFX1100-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[0,0,1] op_sel_hi:[1,1,1]
-; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[0,0,1] op_sel_hi:[1,1,1]
+; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1100-NEXT:    v_mov_b32_e32 v0, v2
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
 ; GFX900:       ; %bb.0:
@@ -2949,25 +2929,6 @@ define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_add(<2 x half> %src0, <2 x half>
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v3, v0
 ; SDAG-CI-NEXT:    v_add_f32_e32 v1, v4, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
-; GISEL-GFX1100-TRUE16:       ; %bb.0:
-; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[0,0,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
-; GISEL-GFX1100-FAKE16:       ; %bb.0:
-; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, 1.0, v1 op_sel:[0,0,1] op_sel_hi:[1,1,1]
-; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_v2f32_shuffle_cvt_add:
 ; GISEL-CI:       ; %bb.0:
@@ -4518,14 +4479,14 @@ define <2 x float> @v_mad_mix_v2f32_cvt_mul(<2 x half> %src0, <2 x half> %src1) 
 }
 
 define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_mul(<2 x half> %src0, <2 x half> %src1) {
-; SDAG-GFX1100-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
-; SDAG-GFX1100:       ; %bb.0:
-; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[0,1,0] op_sel_hi:[1,1,0]
-; SDAG-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; SDAG-GFX1100-NEXT:    v_mov_b32_e32 v0, v2
-; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GFX1100-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
+; GFX1100:       ; %bb.0:
+; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1100-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GFX1100-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[0,1,0] op_sel_hi:[1,1,0]
+; GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX1100-NEXT:    v_mov_b32_e32 v0, v2
+; GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
 ; GFX900:       ; %bb.0:
@@ -4580,25 +4541,6 @@ define <2 x float> @v_mad_mix_v2f32_shuffle_cvt_mul(<2 x half> %src0, <2 x half>
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v0, v3, v0
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v1, v4, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
-; GISEL-GFX1100-TRUE16:       ; %bb.0:
-; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
-; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v2, v2, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[0,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
-;
-; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
-; GISEL-GFX1100-FAKE16:       ; %bb.0:
-; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v2, v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v1, v0, v1, neg(0) op_sel:[0,1,0] op_sel_hi:[1,1,0]
-; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GISEL-GFX1100-FAKE16-NEXT:    v_mov_b32_e32 v0, v2
-; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_v2f32_shuffle_cvt_mul:
 ; GISEL-CI:       ; %bb.0:
@@ -5971,6 +5913,140 @@ define float @v_mad_mix_f32_absf16hi_fsub_f16hi(i32 %src0, i32 %src1)  {
   %src0.ext.abs = call float @llvm.fabs.f32(float %src0.ext)
   %src1.ext = fpext half %src1.fp16 to float
   %result = fsub float %src0.ext.abs, %src1.ext
+  ret float %result
+}
+
+; The fpext sources are defined by 16-bit instructions rather than by truncates,
+; so with real-true16 they live in VGPR_16 and have to be placed in the low half
+; of a 32-bit register before mad-mix can read them. This is the only shape that
+; needs those copies; they should coalesce away here.
+define float @v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src(half %src0, half %src1, half %src2, half %add) #0 {
+; SDAG-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; SDAG-GFX1100-TRUE16:       ; %bb.0:
+; SDAG-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v0.l, v0.l, v3.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v1.l, v1.l, v3.l
+; SDAG-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v2.l, v2.l, v3.l
+; SDAG-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; SDAG-GFX1100-FAKE16:       ; %bb.0:
+; SDAG-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v0, v0, v3
+; SDAG-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v1, v1, v3
+; SDAG-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v2, v2, v3
+; SDAG-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; SDAG-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; SDAG-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX900-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GFX900:       ; %bb.0:
+; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX900-NEXT:    v_add_f16_e32 v0, v0, v3
+; GFX900-NEXT:    v_add_f16_e32 v1, v1, v3
+; GFX900-NEXT:    v_add_f16_e32 v2, v2, v3
+; GFX900-NEXT:    v_mad_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; GFX900-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX906-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GFX906:       ; %bb.0:
+; GFX906-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX906-NEXT:    v_add_f16_e32 v0, v0, v3
+; GFX906-NEXT:    v_add_f16_e32 v1, v1, v3
+; GFX906-NEXT:    v_add_f16_e32 v2, v2, v3
+; GFX906-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; GFX906-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GEN-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GFX9GEN:       ; %bb.0:
+; GFX9GEN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GEN-NEXT:    v_add_f16_e32 v0, v0, v3
+; GFX9GEN-NEXT:    v_add_f16_e32 v1, v1, v3
+; GFX9GEN-NEXT:    v_add_f16_e32 v2, v2, v3
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v3, v0
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX9GEN-NEXT:    v_cvt_f32_f16_e32 v0, v2
+; GFX9GEN-NEXT:    v_mac_f32_e32 v0, v3, v1
+; GFX9GEN-NEXT:    s_setpc_b64 s[30:31]
+;
+; VI-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; VI:       ; %bb.0:
+; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; VI-NEXT:    v_add_f16_e32 v0, v0, v3
+; VI-NEXT:    v_add_f16_e32 v1, v1, v3
+; VI-NEXT:    v_add_f16_e32 v2, v2, v3
+; VI-NEXT:    v_cvt_f32_f16_e32 v3, v0
+; VI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; VI-NEXT:    v_cvt_f32_f16_e32 v0, v2
+; VI-NEXT:    v_mac_f32_e32 v0, v3, v1
+; VI-NEXT:    s_setpc_b64 s[30:31]
+;
+; SDAG-CI-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; SDAG-CI:       ; %bb.0:
+; SDAG-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v3
+; SDAG-CI-NEXT:    v_add_f32_e32 v1, v1, v3
+; SDAG-CI-NEXT:    v_add_f32_e32 v2, v2, v3
+; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; SDAG-CI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v3, v0
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v2
+; SDAG-CI-NEXT:    v_mac_f32_e32 v0, v3, v1
+; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v0.l, v0.l, v3.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v1.l, v1.l, v3.l
+; GISEL-GFX1100-TRUE16-NEXT:    v_add_f16_e32 v2.l, v2.l, v3.l
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v0, v0, v3
+; GISEL-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v1, v1, v3
+; GISEL-GFX1100-FAKE16-NEXT:    v_add_f16_e32 v2, v2, v3
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-CI-LABEL: v_mad_mix_f32_f16lo_f16lo_f16lo_realf16src:
+; GISEL-CI:       ; %bb.0:
+; GISEL-CI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GISEL-CI-NEXT:    v_add_f32_e32 v0, v0, v3
+; GISEL-CI-NEXT:    v_add_f32_e32 v1, v1, v3
+; GISEL-CI-NEXT:    v_add_f32_e32 v2, v2, v3
+; GISEL-CI-NEXT:    v_cvt_f16_f32_e32 v0, v0
+; GISEL-CI-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; GISEL-CI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v3, v0
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GISEL-CI-NEXT:    v_cvt_f32_f16_e32 v0, v2
+; GISEL-CI-NEXT:    v_mac_f32_e32 v0, v3, v1
+; GISEL-CI-NEXT:    s_setpc_b64 s[30:31]
+  %src0.add = fadd half %src0, %add
+  %src1.add = fadd half %src1, %add
+  %src2.add = fadd half %src2, %add
+  %src0.ext = fpext half %src0.add to float
+  %src1.ext = fpext half %src1.add to float
+  %src2.ext = fpext half %src2.add to float
+  %result = tail call float @llvm.fmuladd.f32(float %src0.ext, float %src1.ext, float %src2.ext)
   ret float %result
 }
 

--- a/llvm/test/CodeGen/AMDGPU/mad-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix.ll
@@ -7,8 +7,7 @@
 ; RUN: llc -mtriple=amdgpu8.03 < %s | FileCheck -check-prefixes=VI,SDAG-VI %s
 ; RUN: llc -mtriple=amdgpu7.01 < %s | FileCheck -check-prefixes=CI,SDAG-CI %s
 
-; FIXME-TRUE16. enable gisel
-; XUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-TRUE16 %s
+; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=+real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-TRUE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu11.00 -mattr=-real-true16 < %s | FileCheck -check-prefixes=GFX1100,GISEL-GFX1100,GISEL-GFX1100-FAKE16 %s
 ; RUN: llc -global-isel -mtriple=amdgpu9.00 < %s | FileCheck -check-prefixes=GFX900,GISEL-GFX900 %s
 ; RUN: llc -global-isel -mtriple=amdgpu9.06 < %s | FileCheck -check-prefixes=GFX906,GISEL-GFX906 %s
@@ -2224,14 +2223,22 @@ define float @v_mad_mix_f32_precvtnegf16hi_abs_f16lo_f16lo(i32 %src0.arg, half %
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v0, v3, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_f16lo_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_f16lo_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_xor_b16 v0.l, 0x8000, v0.h
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_f16lo_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_f16lo_f16lo:
 ; GISEL-CI:       ; %bb.0:
@@ -2254,11 +2261,11 @@ define float @v_mad_mix_f32_precvtnegf16hi_abs_f16lo_f16lo(i32 %src0.arg, half %
 }
 
 define float @v_mad_mix_f32_precvtabsf16hi_f16lo_f16lo(i32 %src0.arg, half %src1, half %src2) #0 {
-; GFX1100-LABEL: v_mad_mix_f32_precvtabsf16hi_f16lo_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_precvtabsf16hi_f16lo_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_precvtabsf16hi_f16lo_f16lo:
 ; GFX900:       ; %bb.0:
@@ -2299,6 +2306,20 @@ define float @v_mad_mix_f32_precvtabsf16hi_f16lo_f16lo(i32 %src0.arg, half %src1
 ; CI-NEXT:    v_cvt_f32_f16_e32 v0, v2
 ; CI-NEXT:    v_mac_f32_e32 v0, v3, v1
 ; CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_precvtabsf16hi_f16lo_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v0.h
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_precvtabsf16hi_f16lo_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   %src0.arg.bc = bitcast i32 %src0.arg to <2 x half>
   %src0 = extractelement <2 x half> %src0.arg.bc, i32 1
   %src0.abs = call half @llvm.fabs.f16(half %src0)
@@ -2310,11 +2331,11 @@ define float @v_mad_mix_f32_precvtabsf16hi_f16lo_f16lo(i32 %src0.arg, half %src1
 }
 
 define float @v_mad_mix_f32_preextractfneg_f16hi_f16lo_f16lo(i32 %src0.arg, half %src1, half %src2) #0 {
-; GFX1100-LABEL: v_mad_mix_f32_preextractfneg_f16hi_f16lo_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_preextractfneg_f16hi_f16lo_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_preextractfneg_f16hi_f16lo_f16lo:
 ; GFX900:       ; %bb.0:
@@ -2355,6 +2376,20 @@ define float @v_mad_mix_f32_preextractfneg_f16hi_f16lo_f16lo(i32 %src0.arg, half
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v2
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v0, v3, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfneg_f16hi_f16lo_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfneg_f16hi_f16lo_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, -v0, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9GEN-LABEL: v_mad_mix_f32_preextractfneg_f16hi_f16lo_f16lo:
 ; GISEL-GFX9GEN:       ; %bb.0:
@@ -2397,11 +2432,11 @@ define float @v_mad_mix_f32_preextractfneg_f16hi_f16lo_f16lo(i32 %src0.arg, half
 }
 
 define float @v_mad_mix_f32_preextractfabs_f16hi_f16lo_f16lo(i32 %src0.arg, half %src1, half %src2) #0 {
-; GFX1100-LABEL: v_mad_mix_f32_preextractfabs_f16hi_f16lo_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_preextractfabs_f16hi_f16lo_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_preextractfabs_f16hi_f16lo_f16lo:
 ; GFX900:       ; %bb.0:
@@ -2442,6 +2477,20 @@ define float @v_mad_mix_f32_preextractfabs_f16hi_f16lo_f16lo(i32 %src0.arg, half
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v2
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v0, v3, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfabs_f16hi_f16lo_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_and_b32_e32 v0, 0x7fff7fff, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfabs_f16hi_f16lo_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9GEN-LABEL: v_mad_mix_f32_preextractfabs_f16hi_f16lo_f16lo:
 ; GISEL-GFX9GEN:       ; %bb.0:
@@ -2484,11 +2533,11 @@ define float @v_mad_mix_f32_preextractfabs_f16hi_f16lo_f16lo(i32 %src0.arg, half
 }
 
 define float @v_mad_mix_f32_preextractfabsfneg_f16hi_f16lo_f16lo(i32 %src0.arg, half %src1, half %src2) #0 {
-; GFX1100-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_f16lo_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_f16lo_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_f16lo_f16lo:
 ; GFX900:       ; %bb.0:
@@ -2529,6 +2578,20 @@ define float @v_mad_mix_f32_preextractfabsfneg_f16hi_f16lo_f16lo(i32 %src0.arg, 
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v0, v2
 ; SDAG-CI-NEXT:    v_mac_f32_e32 v0, v3, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_f16lo_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_or_b32_e32 v0, 0x80008000, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_f16lo_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, -|v0|, v1, v2 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX9GEN-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_f16lo_f16lo:
 ; GISEL-GFX9GEN:       ; %bb.0:
@@ -3759,14 +3822,22 @@ define float @v_mad_mix_f32_precvtnegf16hi_abs_add_f16lo(i32 %src0.arg, half %sr
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_add_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel_hi:[1,1,1]
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_add_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_xor_b16 v0.l, 0x8000, v0.h
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_add_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_add_f16lo:
 ; GISEL-CI:       ; %bb.0:
@@ -3787,11 +3858,11 @@ define float @v_mad_mix_f32_precvtnegf16hi_abs_add_f16lo(i32 %src0.arg, half %sr
 }
 
 define float @v_mad_mix_f32_precvtabsf16hi_add_f16lo(i32 %src0.arg, half %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_precvtabsf16hi_add_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_precvtabsf16hi_add_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_precvtabsf16hi_add_f16lo:
 ; GFX900:       ; %bb.0:
@@ -3831,6 +3902,20 @@ define float @v_mad_mix_f32_precvtabsf16hi_add_f16lo(i32 %src0.arg, half %src1) 
 ; CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; CI-NEXT:    v_add_f32_e32 v0, v0, v1
 ; CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_precvtabsf16hi_add_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v0.h
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_precvtabsf16hi_add_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   %src0.arg.bc = bitcast i32 %src0.arg to <2 x half>
   %src0 = extractelement <2 x half> %src0.arg.bc, i32 1
   %src0.abs = call half @llvm.fabs.f16(half %src0)
@@ -3841,11 +3926,11 @@ define float @v_mad_mix_f32_precvtabsf16hi_add_f16lo(i32 %src0.arg, half %src1) 
 }
 
 define float @v_mad_mix_f32_preextractfneg_f16hi_add_f16lo(i32 %src0.arg, half %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -3885,6 +3970,20 @@ define float @v_mad_mix_f32_preextractfneg_f16hi_add_f16lo(i32 %src0.arg, half %
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, -v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_f32_preextractfneg_f16hi_add_f16lo:
 ; GISEL-GFX900:       ; %bb.0:
@@ -3932,11 +4031,11 @@ define float @v_mad_mix_f32_preextractfneg_f16hi_add_f16lo(i32 %src0.arg, half %
 }
 
 define float @v_mad_mix_f32_preextractfabs_f16hi_add_f16lo(i32 %src0.arg, half %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_preextractfabs_f16hi_add_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_preextractfabs_f16hi_add_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_preextractfabs_f16hi_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -3976,6 +4075,20 @@ define float @v_mad_mix_f32_preextractfabs_f16hi_add_f16lo(i32 %src0.arg, half %
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfabs_f16hi_add_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_and_b32_e32 v0, 0x7fff7fff, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfabs_f16hi_add_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_f32_preextractfabs_f16hi_add_f16lo:
 ; GISEL-GFX900:       ; %bb.0:
@@ -4023,11 +4136,11 @@ define float @v_mad_mix_f32_preextractfabs_f16hi_add_f16lo(i32 %src0.arg, half %
 }
 
 define float @v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo(i32 %src0.arg, half %src1)  {
-; GFX1100-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -4067,6 +4180,20 @@ define float @v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo(i32 %src0.arg, ha
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; SDAG-CI-NEXT:    v_add_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_or_b32_e32 v0, 0x80008000, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, -|v0|, 1.0, v1 op_sel:[1,0,0] op_sel_hi:[1,1,1]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_add_f16lo:
 ; GISEL-GFX900:       ; %bb.0:
@@ -5239,14 +5366,22 @@ define float @v_mad_mix_f32_precvtnegf16hi_abs_mul_f16lo(i32 %src0.arg, half %sr
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GISEL-GFX1100-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_mul_f16lo:
-; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GISEL-GFX1100-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GISEL-GFX1100-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
-; GISEL-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel_hi:[1,1,0]
-; GISEL-GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_mul_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_xor_b16 v0.l, 0x8000, v0.h
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_mul_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
+; GISEL-GFX1100-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GISEL-GFX1100-FAKE16-NEXT:    v_xor_b32_e32 v0, 0x8000, v0
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-CI-LABEL: v_mad_mix_f32_precvtnegf16hi_abs_mul_f16lo:
 ; GISEL-CI:       ; %bb.0:
@@ -5267,11 +5402,11 @@ define float @v_mad_mix_f32_precvtnegf16hi_abs_mul_f16lo(i32 %src0.arg, half %sr
 }
 
 define float @v_mad_mix_f32_precvtabsf16hi_mul_f16lo(i32 %src0.arg, half %src1) {
-; GFX1100-LABEL: v_mad_mix_f32_precvtabsf16hi_mul_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_precvtabsf16hi_mul_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_mad_mix_f32_precvtabsf16hi_mul_f16lo:
 ; GFX900:       ; %bb.0:
@@ -5311,6 +5446,20 @@ define float @v_mad_mix_f32_precvtabsf16hi_mul_f16lo(i32 %src0.arg, half %src1) 
 ; CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; CI-NEXT:    v_mul_f32_e32 v0, v0, v1
 ; CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_precvtabsf16hi_mul_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v0.h
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_precvtabsf16hi_mul_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
   %src0.arg.bc = bitcast i32 %src0.arg to <2 x half>
   %src0 = extractelement <2 x half> %src0.arg.bc, i32 1
   %src0.abs = call half @llvm.fabs.f16(half %src0)
@@ -5321,11 +5470,11 @@ define float @v_mad_mix_f32_precvtabsf16hi_mul_f16lo(i32 %src0.arg, half %src1) 
 }
 
 define float @v_mad_mix_f32_preextractfneg_f16hi_mul_f16lo(i32 %src0.arg, half %src1) {
-; GFX1100-LABEL: v_mad_mix_f32_preextractfneg_f16hi_mul_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_preextractfneg_f16hi_mul_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_preextractfneg_f16hi_mul_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -5365,6 +5514,20 @@ define float @v_mad_mix_f32_preextractfneg_f16hi_mul_f16lo(i32 %src0.arg, half %
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfneg_f16hi_mul_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_xor_b32_e32 v0, 0x80008000, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfneg_f16hi_mul_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, -v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_f32_preextractfneg_f16hi_mul_f16lo:
 ; GISEL-GFX900:       ; %bb.0:
@@ -5412,11 +5575,11 @@ define float @v_mad_mix_f32_preextractfneg_f16hi_mul_f16lo(i32 %src0.arg, half %
 }
 
 define float @v_mad_mix_f32_preextractfabs_f16hi_mul_f16lo(i32 %src0.arg, half %src1) {
-; GFX1100-LABEL: v_mad_mix_f32_preextractfabs_f16hi_mul_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_preextractfabs_f16hi_mul_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_preextractfabs_f16hi_mul_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -5456,6 +5619,20 @@ define float @v_mad_mix_f32_preextractfabs_f16hi_mul_f16lo(i32 %src0.arg, half %
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfabs_f16hi_mul_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_and_b32_e32 v0, 0x7fff7fff, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfabs_f16hi_mul_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, |v0|, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_f32_preextractfabs_f16hi_mul_f16lo:
 ; GISEL-GFX900:       ; %bb.0:
@@ -5503,11 +5680,11 @@ define float @v_mad_mix_f32_preextractfabs_f16hi_mul_f16lo(i32 %src0.arg, half %
 }
 
 define float @v_mad_mix_f32_preextractfabsfneg_f16hi_mul_f16lo(i32 %src0.arg, half %src1) {
-; GFX1100-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_mul_f16lo:
-; GFX1100:       ; %bb.0:
-; GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
-; GFX1100-NEXT:    s_setpc_b64 s[30:31]
+; SDAG-GFX1100-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_mul_f16lo:
+; SDAG-GFX1100:       ; %bb.0:
+; SDAG-GFX1100-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; SDAG-GFX1100-NEXT:    v_fma_mix_f32 v0, -|v0|, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; SDAG-GFX1100-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; SDAG-GFX900-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_mul_f16lo:
 ; SDAG-GFX900:       ; %bb.0:
@@ -5547,6 +5724,20 @@ define float @v_mad_mix_f32_preextractfabsfneg_f16hi_mul_f16lo(i32 %src0.arg, ha
 ; SDAG-CI-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; SDAG-CI-NEXT:    v_mul_f32_e32 v0, v0, v1
 ; SDAG-CI-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-TRUE16-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_mul_f16lo:
+; GISEL-GFX1100-TRUE16:       ; %bb.0:
+; GISEL-GFX1100-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-TRUE16-NEXT:    v_or_b32_e32 v0, 0x80008000, v0
+; GISEL-GFX1100-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GISEL-GFX1100-TRUE16-NEXT:    v_fma_mix_f32 v0, v0, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GISEL-GFX1100-FAKE16-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_mul_f16lo:
+; GISEL-GFX1100-FAKE16:       ; %bb.0:
+; GISEL-GFX1100-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-FAKE16-NEXT:    v_fma_mix_f32 v0, -|v0|, v1, neg(0) op_sel:[1,0,0] op_sel_hi:[1,1,0]
+; GISEL-GFX1100-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GISEL-GFX900-LABEL: v_mad_mix_f32_preextractfabsfneg_f16hi_mul_f16lo:
 ; GISEL-GFX900:       ; %bb.0:
@@ -5894,5 +6085,3 @@ declare <2 x float> @llvm.fmuladd.v2f32(<2 x float>, <2 x float>, <2 x float>) #
 attributes #0 = { nounwind denormal_fpenv(float: preservesign) }
 attributes #1 = { nounwind denormal_fpenv(float: ieee|ieee) }
 attributes #2 = { nounwind readnone speculatable }
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; GISEL-GFX1100-FAKE16: {{.*}}


### PR DESCRIPTION
The mad-mix instruction selection combines fpext on src operands into the mad-mix itself. This makes the truncate flowing into fpext useless and result in incorrect register classes.

This also resolves some diff with downstream