### PR TITLE
[DirectX] Widen i1 indexable temps to i32 in DXILDataScalarization

### DIFF
--- a/llvm/lib/Target/DirectX/DXILDataScalarization.cpp
+++ b/llvm/lib/Target/DirectX/DXILDataScalarization.cpp
@@ -194,6 +194,14 @@ DataScalarizerVisitor::createArrayFromVector(IRBuilder<> &Builder, Value *Vec,
   // Allocate the array to hold the vector elements
   Builder.SetInsertPointPastAllocas(Builder.GetInsertBlock()->getParent());
   Type *ArrTy = equivalentArrayTypeFromVector(Vec->getType());
+  // DXIL indexable temps cannot hold i1 elements; booleans occupy 32 bits in
+  // memory. Widen i1 element arrays to i32.
+  Type *ArrElemTy = ArrTy->getArrayElementType();
+  bool WidenBool = ArrElemTy->isIntegerTy(1);
+  if (WidenBool) {
+    ArrElemTy = Builder.getInt32Ty();
+    ArrTy = ArrayType::get(ArrElemTy, ArrTy->getArrayNumElements());
+  }
   AllocaInst *ArrAlloca =
       Builder.CreateAlloca(ArrTy, nullptr, Name + ".alloca");
   const uint64_t ArrNumElems = ArrTy->getArrayNumElements();
@@ -206,6 +214,8 @@ DataScalarizerVisitor::createArrayFromVector(IRBuilder<> &Builder, Value *Vec,
   SmallVector<Value *, 4> GEPs(ArrNumElems);
   for (unsigned I = 0; I < ArrNumElems; ++I) {
     Value *EE = Builder.CreateExtractElement(Vec, I, Name + ".extract");
+    if (WidenBool)
+      EE = Builder.CreateZExt(EE, ArrElemTy, Name + ".zext");
     GEPs[I] = Builder.CreateInBoundsGEP(
         ArrTy, ArrAlloca, {Builder.getInt32(0), Builder.getInt32(I)},
         Name + ".index");
@@ -243,17 +253,30 @@ bool DataScalarizerVisitor::replaceDynamicInsertElementInst(
   Type *ArrTy = std::get<1>(ArrAllocaAndGEPs);
   SmallVector<Value *, 4> &ArrGEPs = std::get<2>(ArrAllocaAndGEPs);
 
+  // The array element type may have been widened (e.g. i1 -> i32) so that the
+  // indexable temp uses a legal DXIL memory type. Convert between the vector
+  // element type and the (possibly wider) array element type as needed.
+  Type *ArrElemTy = ArrTy->getArrayElementType();
+  Type *VecElemTy = cast<VectorType>(Vec->getType())->getElementType();
+  bool WidenBool = ArrElemTy != VecElemTy && VecElemTy->isIntegerTy(1);
+
   auto GEPAndLoad =
       dynamicallyLoadArray(Builder, ArrAlloca, ArrTy, Index, IEI.getName());
   Value *GEP = GEPAndLoad.first;
   Value *Load = GEPAndLoad.second;
 
-  Builder.CreateStore(Val, GEP);
+  Value *StoreVal = Val;
+  if (WidenBool)
+    StoreVal = Builder.CreateZExt(Val, ArrElemTy, IEI.getName() + ".zext");
+  Builder.CreateStore(StoreVal, GEP);
   Value *NewIEI = PoisonValue::get(Vec->getType());
   for (unsigned I = 0; I < ArrTy->getArrayNumElements(); ++I) {
-    Value *Load = Builder.CreateLoad(ArrTy->getArrayElementType(), ArrGEPs[I],
-                                     IEI.getName() + ".load");
-    NewIEI = Builder.CreateInsertElement(NewIEI, Load, Builder.getInt32(I),
+    Value *EltLoad = Builder.CreateLoad(ArrElemTy, ArrGEPs[I],
+                                        IEI.getName() + ".load");
+    if (WidenBool)
+      EltLoad =
+          Builder.CreateTrunc(EltLoad, VecElemTy, IEI.getName() + ".trunc");
+    NewIEI = Builder.CreateInsertElement(NewIEI, EltLoad, Builder.getInt32(I),
                                          IEI.getName() + ".insert");
   }
 
@@ -286,6 +309,12 @@ bool DataScalarizerVisitor::replaceDynamicExtractElementInst(
   auto GEPAndLoad = dynamicallyLoadArray(Builder, ArrAlloca, ArrTy,
                                          EEI.getIndexOperand(), EEI.getName());
   Value *Load = GEPAndLoad.second;
+
+  // The array element type may have been widened (e.g. i1 -> i32) so that the
+  // indexable temp uses a legal DXIL memory type. Truncate back to the original
+  // element type of the extractelement if necessary.
+  if (Load->getType() != EEI.getType())
+    Load = Builder.CreateTrunc(Load, EEI.getType(), EEI.getName() + ".trunc");
 
   EEI.replaceAllUsesWith(Load);
   EEI.eraseFromParent();

--- a/llvm/lib/Target/DirectX/DXILDataScalarization.cpp
+++ b/llvm/lib/Target/DirectX/DXILDataScalarization.cpp
@@ -271,8 +271,8 @@ bool DataScalarizerVisitor::replaceDynamicInsertElementInst(
   Builder.CreateStore(StoreVal, GEP);
   Value *NewIEI = PoisonValue::get(Vec->getType());
   for (unsigned I = 0; I < ArrTy->getArrayNumElements(); ++I) {
-    Value *EltLoad = Builder.CreateLoad(ArrElemTy, ArrGEPs[I],
-                                        IEI.getName() + ".load");
+    Value *EltLoad =
+        Builder.CreateLoad(ArrElemTy, ArrGEPs[I], IEI.getName() + ".load");
     if (WidenBool)
       EltLoad =
           Builder.CreateTrunc(EltLoad, VecElemTy, IEI.getName() + ".trunc");
@@ -313,8 +313,11 @@ bool DataScalarizerVisitor::replaceDynamicExtractElementInst(
   // The array element type may have been widened (e.g. i1 -> i32) so that the
   // indexable temp uses a legal DXIL memory type. Truncate back to the original
   // element type of the extractelement if necessary.
-  if (Load->getType() != EEI.getType())
+  if (Load->getType() != EEI.getType()) {
+    assert(Load->getType()->isIntegerTy(32) && EEI.getType()->isIntegerTy(1) &&
+           "Unexpected type mismatch: only i32 -> i1 widening is supported");
     Load = Builder.CreateTrunc(Load, EEI.getType(), EEI.getName() + ".trunc");
+  }
 
   EEI.replaceAllUsesWith(Load);
   EEI.eraseFromParent();

--- a/llvm/test/CodeGen/DirectX/scalarize-dynamic-vector-index.ll
+++ b/llvm/test/CodeGen/DirectX/scalarize-dynamic-vector-index.ll
@@ -180,3 +180,82 @@ define <2 x half> @insert_half_vec_constant(<2 x half> %v, half %a) {
   ret <2 x half> %ie
 }
 
+; DXIL indexable temps cannot hold i1 elements (booleans are 32 bits in memory).
+; A dynamically indexed extractelement of a <N x i1> vector must spill to an
+; [N x i32] array, zero-extending each element on store and truncating the
+; dynamically loaded value back to i1.
+define i1 @extract_i1_vec_dynamic(<4 x i1> %v, i32 %i) {
+; CHECK-LABEL: define i1 @extract_i1_vec_dynamic(
+; CHECK-SAME: <4 x i1> [[V:%.*]], i32 [[I:%.*]]) {
+; CHECK-NEXT:    [[EE_ALLOCA:%.*]] = alloca [4 x i32], align 4
+; CHECK-NEXT:    [[EE_EXTRACT:%.*]] = extractelement <4 x i1> [[V]], i64 0
+; CHECK-NEXT:    [[EE_ZEXT:%.*]] = zext i1 [[EE_EXTRACT]] to i32
+; CHECK-NEXT:    [[EE_INDEX:%.*]] = getelementptr inbounds [4 x i32], ptr [[EE_ALLOCA]], i32 0, i32 0
+; CHECK-NEXT:    store i32 [[EE_ZEXT]], ptr [[EE_INDEX]], align 4
+; CHECK-NEXT:    [[EE_EXTRACT1:%.*]] = extractelement <4 x i1> [[V]], i64 1
+; CHECK-NEXT:    [[EE_ZEXT2:%.*]] = zext i1 [[EE_EXTRACT1]] to i32
+; CHECK-NEXT:    [[EE_INDEX3:%.*]] = getelementptr inbounds [4 x i32], ptr [[EE_ALLOCA]], i32 0, i32 1
+; CHECK-NEXT:    store i32 [[EE_ZEXT2]], ptr [[EE_INDEX3]], align 4
+; CHECK-NEXT:    [[EE_EXTRACT4:%.*]] = extractelement <4 x i1> [[V]], i64 2
+; CHECK-NEXT:    [[EE_ZEXT5:%.*]] = zext i1 [[EE_EXTRACT4]] to i32
+; CHECK-NEXT:    [[EE_INDEX6:%.*]] = getelementptr inbounds [4 x i32], ptr [[EE_ALLOCA]], i32 0, i32 2
+; CHECK-NEXT:    store i32 [[EE_ZEXT5]], ptr [[EE_INDEX6]], align 4
+; CHECK-NEXT:    [[EE_EXTRACT7:%.*]] = extractelement <4 x i1> [[V]], i64 3
+; CHECK-NEXT:    [[EE_ZEXT8:%.*]] = zext i1 [[EE_EXTRACT7]] to i32
+; CHECK-NEXT:    [[EE_INDEX9:%.*]] = getelementptr inbounds [4 x i32], ptr [[EE_ALLOCA]], i32 0, i32 3
+; CHECK-NEXT:    store i32 [[EE_ZEXT8]], ptr [[EE_INDEX9]], align 4
+; CHECK-NEXT:    [[EE_INDEX10:%.*]] = getelementptr inbounds [4 x i32], ptr [[EE_ALLOCA]], i32 0, i32 [[I]]
+; CHECK-NEXT:    [[EE_LOAD:%.*]] = load i32, ptr [[EE_INDEX10]], align 4
+; CHECK-NEXT:    [[EE_TRUNC:%.*]] = trunc i32 [[EE_LOAD]] to i1
+; CHECK-NEXT:    ret i1 [[EE_TRUNC]]
+;
+  %ee = extractelement <4 x i1> %v, i32 %i
+  ret i1 %ee
+}
+
+; A dynamically indexed insertelement of a <N x i1> vector must likewise spill
+; to an [N x i32] array, zero-extending the stored value and truncating each
+; reloaded element back to i1 when reconstructing the vector.
+define <4 x i1> @insert_i1_vec_dynamic(<4 x i1> %v, i1 %a, i32 %i) {
+; CHECK-LABEL: define <4 x i1> @insert_i1_vec_dynamic(
+; CHECK-SAME: <4 x i1> [[V:%.*]], i1 [[A:%.*]], i32 [[I:%.*]]) {
+; CHECK-NEXT:    [[IE_ALLOCA:%.*]] = alloca [4 x i32], align 4
+; CHECK-NEXT:    [[IE_EXTRACT:%.*]] = extractelement <4 x i1> [[V]], i64 0
+; CHECK-NEXT:    [[IE_ZEXT:%.*]] = zext i1 [[IE_EXTRACT]] to i32
+; CHECK-NEXT:    [[IE_INDEX:%.*]] = getelementptr inbounds [4 x i32], ptr [[IE_ALLOCA]], i32 0, i32 0
+; CHECK-NEXT:    store i32 [[IE_ZEXT]], ptr [[IE_INDEX]], align 4
+; CHECK-NEXT:    [[IE_EXTRACT1:%.*]] = extractelement <4 x i1> [[V]], i64 1
+; CHECK-NEXT:    [[IE_ZEXT2:%.*]] = zext i1 [[IE_EXTRACT1]] to i32
+; CHECK-NEXT:    [[IE_INDEX3:%.*]] = getelementptr inbounds [4 x i32], ptr [[IE_ALLOCA]], i32 0, i32 1
+; CHECK-NEXT:    store i32 [[IE_ZEXT2]], ptr [[IE_INDEX3]], align 4
+; CHECK-NEXT:    [[IE_EXTRACT4:%.*]] = extractelement <4 x i1> [[V]], i64 2
+; CHECK-NEXT:    [[IE_ZEXT5:%.*]] = zext i1 [[IE_EXTRACT4]] to i32
+; CHECK-NEXT:    [[IE_INDEX6:%.*]] = getelementptr inbounds [4 x i32], ptr [[IE_ALLOCA]], i32 0, i32 2
+; CHECK-NEXT:    store i32 [[IE_ZEXT5]], ptr [[IE_INDEX6]], align 4
+; CHECK-NEXT:    [[IE_EXTRACT7:%.*]] = extractelement <4 x i1> [[V]], i64 3
+; CHECK-NEXT:    [[IE_ZEXT8:%.*]] = zext i1 [[IE_EXTRACT7]] to i32
+; CHECK-NEXT:    [[IE_INDEX9:%.*]] = getelementptr inbounds [4 x i32], ptr [[IE_ALLOCA]], i32 0, i32 3
+; CHECK-NEXT:    store i32 [[IE_ZEXT8]], ptr [[IE_INDEX9]], align 4
+; CHECK-NEXT:    [[IE_INDEX10:%.*]] = getelementptr inbounds [4 x i32], ptr [[IE_ALLOCA]], i32 0, i32 [[I]]
+; CHECK-NEXT:    [[IE_LOAD:%.*]] = load i32, ptr [[IE_INDEX10]], align 4
+; CHECK-NEXT:    [[IE_ZEXT11:%.*]] = zext i1 [[A]] to i32
+; CHECK-NEXT:    store i32 [[IE_ZEXT11]], ptr [[IE_INDEX10]], align 4
+; CHECK-NEXT:    [[IE_LOAD12:%.*]] = load i32, ptr [[IE_INDEX]], align 4
+; CHECK-NEXT:    [[IE_TRUNC:%.*]] = trunc i32 [[IE_LOAD12]] to i1
+; CHECK-NEXT:    [[IE_INSERT:%.*]] = insertelement <4 x i1> poison, i1 [[IE_TRUNC]], i32 0
+; CHECK-NEXT:    [[IE_LOAD13:%.*]] = load i32, ptr [[IE_INDEX3]], align 4
+; CHECK-NEXT:    [[IE_TRUNC14:%.*]] = trunc i32 [[IE_LOAD13]] to i1
+; CHECK-NEXT:    [[IE_INSERT15:%.*]] = insertelement <4 x i1> [[IE_INSERT]], i1 [[IE_TRUNC14]], i32 1
+; CHECK-NEXT:    [[IE_LOAD16:%.*]] = load i32, ptr [[IE_INDEX6]], align 4
+; CHECK-NEXT:    [[IE_TRUNC17:%.*]] = trunc i32 [[IE_LOAD16]] to i1
+; CHECK-NEXT:    [[IE_INSERT18:%.*]] = insertelement <4 x i1> [[IE_INSERT15]], i1 [[IE_TRUNC17]], i32 2
+; CHECK-NEXT:    [[IE_LOAD19:%.*]] = load i32, ptr [[IE_INDEX9]], align 4
+; CHECK-NEXT:    [[IE_TRUNC20:%.*]] = trunc i32 [[IE_LOAD19]] to i1
+; CHECK-NEXT:    [[IE_INSERT21:%.*]] = insertelement <4 x i1> [[IE_INSERT18]], i1 [[IE_TRUNC20]], i32 3
+; CHECK-NEXT:    store i32 [[IE_LOAD]], ptr [[IE_INDEX10]], align 4
+; CHECK-NEXT:    ret <4 x i1> [[IE_INSERT21]]
+;
+  %ie = insertelement <4 x i1> %v, i1 %a, i32 %i
+  ret <4 x i1> %ie
+}
+


### PR DESCRIPTION
fixes #205443

Dynamically-indexed <N x i1> vectors were lowered to alloca [N x i1] indexable temps. DXIL booleans are 32-bit in memory, and i1 stack arrays are mishandled downstream (e.g. WARP returns 1 for every
    dynamically-indexed element), producing wrong results for dynamic
bool vector/matrix accesses.

Widen i1 indexable-temp arrays to [N x i32], zero-extending on store and truncating back to i1 on load, matching DXC. Fixes the dynamic bool extract/insert miscompile.

We make this change in DXILDataScalarization because this is the pass that adds the i1 allocas which was the cause of our miscompile.

Assisted by Claude Opus 4.7