### PR TITLE
[clang][SSAF] Optionally skip system-header contributors

### DIFF
--- a/clang/include/clang/Frontend/SSAFOptions.h
+++ b/clang/include/clang/Frontend/SSAFOptions.h
@@ -49,9 +49,7 @@ public:
 
   /// Extract from system-header declarations during SSAF contributor
   /// enumeration. Defaults to true to preserve the original behavior.
-  /// Cleared by `--ssaf-no-extract-from-system-headers` (negative-marshalled
-  /// flag) when the caller wants to scope contributor enumeration to
-  /// user-source decls.
+  /// Controlled by: --ssaf-no-extract-from-system-headers
   LLVM_PREFERRED_TYPE(bool)
   unsigned ExtractFromSystemHeaders : 1;
 

--- a/clang/include/clang/Frontend/SSAFOptions.h
+++ b/clang/include/clang/Frontend/SSAFOptions.h
@@ -47,10 +47,19 @@ public:
   LLVM_PREFERRED_TYPE(bool)
   unsigned IncludeLocalEntities : 1;
 
+  /// Extract from system-header declarations during SSAF contributor
+  /// enumeration. Defaults to true to preserve the original behavior.
+  /// Cleared by `--ssaf-no-extract-from-system-headers` (negative-marshalled
+  /// flag) when the caller wants to scope contributor enumeration to
+  /// user-source decls.
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned ExtractFromSystemHeaders : 1;
+
   SSAFOptions() {
     ShowExtractors = false;
     ShowFormats = false;
     IncludeLocalEntities = false;
+    ExtractFromSystemHeaders = true;
   };
 };
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -995,10 +995,7 @@ def _ssaf_no_extract_from_system_headers :
   Group<SSAF_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<
-    "Skip declarations in system headers during SSAF contributor "
-    "enumeration. By default the SSAF TU summary extractors enumerate "
-    "system-header declarations alongside user-source declarations; "
-    "this flag opts out of that enumeration.">,
+    "Skip declarations in system headers during SSAF summary extraction">,
   MarshallingInfoNegativeFlag<SSAFOpts<"ExtractFromSystemHeaders">>;
 def Xarch__
     : JoinedAndSeparate<["-"], "Xarch_">,

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -990,6 +990,16 @@ def _ssaf_include_local_entities :
     "Include block-scope (function-local) declarations in extracted SSAF "
     "summaries. By default they are omitted.">,
   MarshallingInfoFlag<SSAFOpts<"IncludeLocalEntities">>;
+def _ssaf_no_extract_from_system_headers :
+  Flag<["--"], "ssaf-no-extract-from-system-headers">,
+  Group<SSAF_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<
+    "Skip declarations in system headers during SSAF contributor "
+    "enumeration. By default the SSAF TU summary extractors enumerate "
+    "system-header declarations alongside user-source declarations; "
+    "this flag opts out of that enumeration.">,
+  MarshallingInfoNegativeFlag<SSAFOpts<"ExtractFromSystemHeaders">>;
 def Xarch__
     : JoinedAndSeparate<["-"], "Xarch_">,
       Flags<[NoXarchOption]>,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8082,6 +8082,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_tu_summary_file);
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_compilation_unit_id);
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_include_local_entities);
+  Args.AddLastArg(CmdArgs, options::OPT__ssaf_no_extract_from_system_headers);
 
   // Handle serialized diagnostics.
   if (Arg *A = Args.getLastArg(options::OPT__serialize_diags)) {

--- a/clang/lib/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowExtractor.cpp
@@ -13,9 +13,9 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
-#include "clang/Frontend/SSAFOptions.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/TypeBase.h"
+<<<<<<< HEAD:clang/lib/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowExtractor.cpp
 #include "clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h"
 #include "clang/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlow.h"
 #include "clang/ScalableStaticAnalysis/Core/Model/EntityId.h"
@@ -23,6 +23,16 @@
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/ExtractorRegistry.h"
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/TUSummaryBuilder.h"
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/TUSummaryExtractor.h"
+=======
+#include "clang/Frontend/SSAFOptions.h"
+#include "clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevel.h"
+#include "clang/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlow.h"
+#include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h"
+#include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityName.h"
+#include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/ExtractorRegistry.h"
+#include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryBuilder.h"
+#include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.h"
+>>>>>>> b1cd54411a3a (Fix code formatting):clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowExtractor.cpp
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/Sequence.h"

--- a/clang/lib/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowExtractor.cpp
@@ -13,6 +13,7 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/TypeBase.h"
 #include "clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h"

--- a/clang/lib/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowExtractor.cpp
@@ -15,7 +15,7 @@
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/TypeBase.h"
-<<<<<<< HEAD:clang/lib/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowExtractor.cpp
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h"
 #include "clang/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlow.h"
 #include "clang/ScalableStaticAnalysis/Core/Model/EntityId.h"
@@ -23,16 +23,6 @@
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/ExtractorRegistry.h"
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/TUSummaryBuilder.h"
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/TUSummaryExtractor.h"
-=======
-#include "clang/Frontend/SSAFOptions.h"
-#include "clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevel.h"
-#include "clang/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlow.h"
-#include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h"
-#include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityName.h"
-#include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/ExtractorRegistry.h"
-#include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryBuilder.h"
-#include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.h"
->>>>>>> b1cd54411a3a (Fix code formatting):clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowExtractor.cpp
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/Sequence.h"

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
@@ -46,9 +46,8 @@ public:
   }
 
   bool VisitFunctionDecl(FunctionDecl *D) override {
-    if (skipForSystemHeader(D))
-      return true;
-    Contributors.insert(D);
+    if (!skipForSystemHeader(D))
+      Contributors.insert(D);
     return true;
   }
 

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
@@ -39,8 +39,9 @@ public:
   const SSAFOptions &Opts;
 
   ContributorFinder(ASTContext &Ctx, const SSAFOptions &Opts,
-                     bool ExtractFromSystemHeaders)
-      : Opts(Opts), Ctx(Ctx), ExtractFromSystemHeaders(ExtractFromSystemHeaders) {
+                    bool ExtractFromSystemHeaders)
+      : Opts(Opts), Ctx(Ctx),
+        ExtractFromSystemHeaders(ExtractFromSystemHeaders) {
     ShouldVisitTemplateInstantiations = true;
     ShouldVisitImplicitCode = false;
   }

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
@@ -86,13 +86,7 @@ public:
   }
 
   bool VisitLambdaExpr(LambdaExpr *L) override {
-    // TraverseLambdaExpr directly visits the body stmt, skipping the
-    // CXXMethodDecl, which is a contributor that needs to be collected.
-    // The system-header gate fires via the delegated VisitFunctionDecl
-    // (the call operator's spelling location is the lambda's source
-    // location), so no separate gate here.
-    VisitFunctionDecl(L->getCallOperator());
-    return true;
+    return VisitFunctionDecl(L->getCallOperator());
   }
 
 private:

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
@@ -12,6 +12,7 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/ExprCXX.h"
+#include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/SSAFOptions.h"
 #include "llvm/ADT/SetVector.h"
 
@@ -37,22 +38,30 @@ public:
   llvm::SetVector<const NamedDecl *> Contributors;
   const SSAFOptions &Opts;
 
-  ContributorFinder(const SSAFOptions &Opts) : Opts(Opts) {
+  ContributorFinder(ASTContext &Ctx, const SSAFOptions &Opts,
+                     bool ExtractFromSystemHeaders)
+      : Opts(Opts), Ctx(Ctx), ExtractFromSystemHeaders(ExtractFromSystemHeaders) {
     ShouldVisitTemplateInstantiations = true;
     ShouldVisitImplicitCode = false;
   }
 
   bool VisitFunctionDecl(FunctionDecl *D) override {
+    if (skipForSystemHeader(D))
+      return true;
     Contributors.insert(D);
     return true;
   }
 
   bool VisitRecordDecl(RecordDecl *D) override {
+    if (skipForSystemHeader(D))
+      return true;
     Contributors.insert(D);
     return true;
   }
 
   bool VisitVarDecl(VarDecl *D) override {
+    if (skipForSystemHeader(D))
+      return true;
     DeclContext *DC = D->getDeclContext();
 
     // Collects Decl for global variables or static data members:
@@ -80,9 +89,28 @@ public:
   bool VisitLambdaExpr(LambdaExpr *L) override {
     // TraverseLambdaExpr directly visits the body stmt, skipping the
     // CXXMethodDecl, which is a contributor that needs to be collected.
+    // The system-header gate fires via the delegated VisitFunctionDecl
+    // (the call operator's spelling location is the lambda's source
+    // location), so no separate gate here.
     VisitFunctionDecl(L->getCallOperator());
     return true;
   }
+
+private:
+  // Returns true when the contributor shall be skipped because its location
+  // is in a system header. The `Loc.isValid()` guard matches the in-tree
+  // precedent at `ReferenceBindingEntityExtractor.cpp` — compiler-generated
+  // decls (builtin FunctionDecls, implicit template instantiations) can reach
+  // the visitor with invalid locations and shall NOT be inadvertently skipped.
+  bool skipForSystemHeader(const Decl *D) const {
+    if (ExtractFromSystemHeaders)
+      return false;
+    SourceLocation Loc = D->getLocation();
+    return Loc.isValid() && Ctx.getSourceManager().isInSystemHeader(Loc);
+  }
+
+  ASTContext &Ctx;
+  bool ExtractFromSystemHeaders;
 };
 
 /// An AST visitor that skips the root node's strict-descendants that are
@@ -146,8 +174,9 @@ public:
 void ssaf::findContributors(
     ASTContext &Ctx, const SSAFOptions &Options,
     llvm::DenseMap<const NamedDecl *, std::vector<const NamedDecl *>>
-        &Contributors) {
-  ContributorFinder Finder{Options};
+        &Contributors,
+    bool ExtractFromSystemHeaders) {
+  ContributorFinder Finder{Ctx, Options, ExtractFromSystemHeaders};
   Finder.TraverseAST(Ctx);
   for (const NamedDecl *C : Finder.Contributors)
     Contributors[cast<NamedDecl>(C->getCanonicalDecl())].push_back(C);

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
@@ -96,11 +96,6 @@ public:
   }
 
 private:
-  // Returns true when the contributor shall be skipped because its location
-  // is in a system header. The `Loc.isValid()` guard matches the in-tree
-  // precedent at `ReferenceBindingEntityExtractor.cpp` — compiler-generated
-  // decls (builtin FunctionDecls, implicit template instantiations) can reach
-  // the visitor with invalid locations and shall NOT be inadvertently skipped.
   bool skipForSystemHeader(const Decl *D) const {
     if (ExtractFromSystemHeaders)
       return false;

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.h
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.h
@@ -119,7 +119,7 @@ void extractAndAddSummaries(TUSummaryExtractor &Extractor,
   llvm::DenseMap<const NamedDecl *, std::vector<const NamedDecl *>>
       Contributors;
   findContributors(Ctx, Extractor.getOptions(), Contributors,
-                    Extractor.getOptions().ExtractFromSystemHeaders);
+                   Extractor.getOptions().ExtractFromSystemHeaders);
   for (const auto &[Cano, Decls] : Contributors) {
     assert(!Decls.empty() &&
            "'findContributors' guarantees that 'Decls' are non-empty");

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.h
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.h
@@ -15,6 +15,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTTypeTraits.h"
 #include "clang/AST/Decl.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/ScalableStaticAnalysis/Core/Model/EntityId.h"
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/TUSummaryBuilder.h"
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/TUSummaryExtractor.h"
@@ -87,7 +88,8 @@ inline void logWarningFromError(llvm::Error Err) {
 void findContributors(
     ASTContext &Ctx, const SSAFOptions &Options,
     llvm::DenseMap<const NamedDecl *, std::vector<const NamedDecl *>>
-        &Contributors);
+        &Contributors,
+    bool ExtractFromSystemHeaders = true);
 
 /// Perform "MatchAction" on each Stmt and Decl belonging to the `Contributor`.
 /// \param Contributor
@@ -116,7 +118,8 @@ void extractAndAddSummaries(TUSummaryExtractor &Extractor,
                             llvm::StringRef ExtractorName = "") {
   llvm::DenseMap<const NamedDecl *, std::vector<const NamedDecl *>>
       Contributors;
-  findContributors(Ctx, Extractor.getOptions(), Contributors);
+  findContributors(Ctx, Extractor.getOptions(), Contributors,
+                    Extractor.getOptions().ExtractFromSystemHeaders);
   for (const auto &[Cano, Decls] : Contributors) {
     assert(!Decls.empty() &&
            "'findContributors' guarantees that 'Decls' are non-empty");

--- a/clang/lib/ScalableStaticAnalysis/Analyses/UnsafeBufferUsage/UnsafeBufferUsageExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/UnsafeBufferUsage/UnsafeBufferUsageExtractor.cpp
@@ -11,6 +11,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/Analysis/Analyses/UnsafeBufferUsage.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/ScalableStaticAnalysis/Analyses/EntityPointerLevel/EntityPointerLevel.h"
 #include "clang/ScalableStaticAnalysis/Analyses/UnsafeBufferUsage/UnsafeBufferUsage.h"
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/ExtractorRegistry.h"

--- a/clang/test/Analysis/Scalable/PointerFlow/system-header-opt-out.cpp
+++ b/clang/test/Analysis/Scalable/PointerFlow/system-header-opt-out.cpp
@@ -1,0 +1,43 @@
+// Regression for clang-reforge-7y4 / iter-03: end-to-end verification
+// of the --ssaf-no-extract-from-system-headers opt-out. Spec:
+// tu-summary-extraction's "System-header contributor opt-out flag"
+// requirement.
+
+// REQUIRES: system-darwin || system-linux
+
+// Setup: synthesise an -isystem header containing a benign user-named
+// symbol (no USR collision — that case is exercised end-to-end by the
+// parity-finale verification step against libJP2).
+// RUN: rm -rf %t.dir
+// RUN: mkdir -p %t.dir/sysinc
+// RUN: printf '#pragma clang system_header\nint *sys_gp; void sys_fn(int *p) { sys_gp = p; }\n' > %t.dir/sysinc/sys.h
+
+// === Case A: flag absent (default extracts from system headers). ===
+// The extractor enumerates both sys_fn and user_fn; the TU summary's
+// IdTable contains both names.
+// RUN: rm -f %t-default.json
+// RUN: %clang -c %s -o %t-default.o -isystem %t.dir/sysinc \
+// RUN:   --ssaf-extract-summaries=PointerFlow \
+// RUN:   --ssaf-tu-summary-file=%t-default.json \
+// RUN:   --ssaf-compilation-unit-id=sys-default
+// RUN: FileCheck --check-prefix=DEFAULT %s < %t-default.json
+// DEFAULT-DAG: sys_fn
+// DEFAULT-DAG: user_fn
+
+// === Case B: flag present (opt-out skips system-header decls). ===
+// The extractor skips sys_fn (system header) but keeps user_fn.
+// The TU summary's IdTable contains user_fn but NOT sys_fn.
+// RUN: rm -f %t-optout.json
+// RUN: %clang -c %s -o %t-optout.o -isystem %t.dir/sysinc \
+// RUN:   --ssaf-extract-summaries=PointerFlow \
+// RUN:   --ssaf-tu-summary-file=%t-optout.json \
+// RUN:   --ssaf-no-extract-from-system-headers \
+// RUN:   --ssaf-compilation-unit-id=sys-optout
+// RUN: FileCheck --check-prefix=OPTOUT %s < %t-optout.json
+// OPTOUT-NOT: sys_fn
+// OPTOUT: user_fn
+
+#include <sys.h>
+
+int *user_gp;
+void user_fn(int *p) { user_gp = p; }

--- a/clang/test/Analysis/Scalable/PointerFlow/system-header-opt-out.cpp
+++ b/clang/test/Analysis/Scalable/PointerFlow/system-header-opt-out.cpp
@@ -1,42 +1,41 @@
-// Regression for clang-reforge-7y4 / iter-03: end-to-end verification
-// of the --ssaf-no-extract-from-system-headers opt-out. Spec:
-// tu-summary-extraction's "System-header contributor opt-out flag"
-// requirement.
+// Synthesise an -isystem header containing a benign user-named
+// symbol.
 
 // REQUIRES: system-darwin || system-linux
 
-// Setup: synthesise an -isystem header containing a benign user-named
-// symbol (no USR collision — that case is exercised end-to-end by the
-// parity-finale verification step against libJP2).
-// RUN: rm -rf %t.dir
-// RUN: mkdir -p %t.dir/sysinc
-// RUN: printf '#pragma clang system_header\nint *sys_gp; void sys_fn(int *p) { sys_gp = p; }\n' > %t.dir/sysinc/sys.h
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
 
 // === Case A: flag absent (default extracts from system headers). ===
 // The extractor enumerates both sys_fn and user_fn; the TU summary's
 // IdTable contains both names.
-// RUN: rm -f %t-default.json
-// RUN: %clang -c %s -o %t-default.o -isystem %t.dir/sysinc \
+// RUN: %clang -c %t/test.cpp -o %t/default.o -isystem %t/sysinc \
 // RUN:   --ssaf-extract-summaries=PointerFlow \
-// RUN:   --ssaf-tu-summary-file=%t-default.json \
+// RUN:   --ssaf-tu-summary-file=%t/default.json \
 // RUN:   --ssaf-compilation-unit-id=sys-default
-// RUN: FileCheck --check-prefix=DEFAULT %s < %t-default.json
+// RUN: FileCheck --check-prefix=DEFAULT %s < %t/default.json
 // DEFAULT-DAG: sys_fn
 // DEFAULT-DAG: user_fn
 
 // === Case B: flag present (opt-out skips system-header decls). ===
 // The extractor skips sys_fn (system header) but keeps user_fn.
 // The TU summary's IdTable contains user_fn but NOT sys_fn.
-// RUN: rm -f %t-optout.json
-// RUN: %clang -c %s -o %t-optout.o -isystem %t.dir/sysinc \
+// RUN: %clang -c %t/test.cpp -o %t/optout.o -isystem %t/sysinc \
 // RUN:   --ssaf-extract-summaries=PointerFlow \
-// RUN:   --ssaf-tu-summary-file=%t-optout.json \
+// RUN:   --ssaf-tu-summary-file=%t/optout.json \
 // RUN:   --ssaf-no-extract-from-system-headers \
 // RUN:   --ssaf-compilation-unit-id=sys-optout
-// RUN: FileCheck --check-prefix=OPTOUT %s < %t-optout.json
+// RUN: FileCheck --check-prefix=OPTOUT %s < %t/optout.json
 // OPTOUT-NOT: sys_fn
 // OPTOUT: user_fn
 
+//--- sysinc/sys.h
+#pragma clang system_header
+int *sys_gp;
+void sys_fn(int *p) { sys_gp = p; }
+
+//--- test.cpp
 #include <sys.h>
 
 int *user_gp;

--- a/clang/test/Analysis/Scalable/help.cpp
+++ b/clang/test/Analysis/Scalable/help.cpp
@@ -12,7 +12,7 @@
 // HELP-NEXT:  --ssaf-list-extractors  Display the list of available SSAF summary extractors
 // HELP-NEXT:  --ssaf-list-formats     Display the list of available SSAF serialization formats
 // HELP-NEXT:  --ssaf-no-extract-from-system-headers
-// HELP-NEXT:    Skip declarations in system headers during SSAF contributor enumeration. By default the SSAF TU summary extractors enumerate system-header declarations alongside user-source declarations; this flag opts out of that enumeration.
+// HELP-NEXT:    Skip declarations in system headers during SSAF summary extraction
 // HELP-NEXT:  --ssaf-tu-summary-file=<path>.<format>
 // HELP-NEXT:    The output file for the extracted summaries. The extension selects which file format to use.
 

--- a/clang/test/Analysis/Scalable/help.cpp
+++ b/clang/test/Analysis/Scalable/help.cpp
@@ -11,6 +11,8 @@
 // HELP-NEXT:    Include block-scope (function-local) declarations in extracted SSAF summaries. By default they are omitted.
 // HELP-NEXT:  --ssaf-list-extractors  Display the list of available SSAF summary extractors
 // HELP-NEXT:  --ssaf-list-formats     Display the list of available SSAF serialization formats
+// HELP-NEXT:  --ssaf-no-extract-from-system-headers
+// HELP-NEXT:    Skip declarations in system headers during SSAF contributor enumeration. By default the SSAF TU summary extractors enumerate system-header declarations alongside user-source declarations; this flag opts out of that enumeration.
 // HELP-NEXT:  --ssaf-tu-summary-file=<path>.<format>
 // HELP-NEXT:    The output file for the extracted summaries. The extension selects which file format to use.
 

--- a/clang/unittests/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowTest.cpp
@@ -1659,7 +1659,7 @@ TEST_F(PointerFlowTest, LocalPointerReportedWhenIncluded) {
 // Default: ExtractFromSystemHeaders == true. A function decl in a
 // `#pragma clang system_header`-marked included header IS enumerated
 // as a contributor and produces an EntitySummary.
-TEST_F(PointerFlowTest, SystemHeader_ExtractDefault) {
+TEST_F(PointerFlowTest, ExtractFromSystemHeadersByDefault) {
   const char *SysHeader = "int *sys_gp; void sys_fn(int *p) { sys_gp = p; }\n";
   const char *Main = R"cpp(
     #include <sys.h>
@@ -1672,10 +1672,7 @@ TEST_F(PointerFlowTest, SystemHeader_ExtractDefault) {
   EXPECT_TRUE(getEntitySummary("user_fn"));
 }
 
-// Opt-out: ExtractFromSystemHeaders == false. The system-header decl
-// is NOT enumerated; getEntitySummary returns nullptr for it. The
-// user-source decl is still enumerated (gate is per-decl, not TU-wide).
-TEST_F(PointerFlowTest, SystemHeader_SkipOptOut) {
+TEST_F(PointerFlowTest, DontExtractFromSystemHeadersWhenOverridden) {
   const char *SysHeader = "int *sys_gp; void sys_fn(int *p) { sys_gp = p; }\n";
   const char *Main = R"cpp(
     #include <sys.h>
@@ -1684,11 +1681,7 @@ TEST_F(PointerFlowTest, SystemHeader_SkipOptOut) {
   )cpp";
   ASSERT_TRUE(setUpTestWithSystemHeader(Main, SysHeader,
                                         /*ExtractFromSystemHeaders=*/false));
-  // sys_fn lives in a system header and is skipped at the
-  // ContributorFinder layer when ExtractFromSystemHeaders == false.
-  // getEntitySummary returns nullptr (no summary was built for it).
-  EXPECT_EQ(getEntitySummary("sys_fn"), nullptr);
-  // user_fn is in non-system code so the gate does not fire for it.
-  EXPECT_NE(getEntitySummary("user_fn"), nullptr);
+  EXPECT_FALSE(getEntitySummary("sys_fn")); // 'sys_fn' is skipped.
+  EXPECT_TRUE(getEntitySummary("user_fn")); // 'user_fn' is still present.
 }
 } // namespace

--- a/clang/unittests/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowTest.cpp
@@ -1668,11 +1668,8 @@ TEST_F(PointerFlowTest, SystemHeader_ExtractDefault) {
   )cpp";
   ASSERT_TRUE(setUpTestWithSystemHeader(Main, SysHeader,
                                         /*ExtractFromSystemHeaders=*/true));
-  // sys_fn is in a system header but the default (extract-true) enumerates
-  // it as a contributor — summary is non-null.
-  EXPECT_NE(getEntitySummary("sys_fn"), nullptr);
-  // user_fn is enumerated either way (positive control).
-  EXPECT_NE(getEntitySummary("user_fn"), nullptr);
+  EXPECT_TRUE(getEntitySummary("sys_fn"));
+  EXPECT_TRUE(getEntitySummary("user_fn"));
 }
 
 // Opt-out: ExtractFromSystemHeaders == false. The system-header decl

--- a/clang/unittests/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowTest.cpp
@@ -191,13 +191,11 @@ protected:
     Opts.ExtractFromSystemHeaders = ExtractFromSystemHeaders;
     std::string SysWithPragma =
         ("#pragma clang system_header\n" + SysHeaderCode).str();
-    tooling::FileContentMappings VirtFiles = {
-        {"/sysinc/sys.h", SysWithPragma}};
+    tooling::FileContentMappings VirtFiles = {{"/sysinc/sys.h", SysWithPragma}};
     AST = tooling::buildASTFromCodeWithArgs(
         Code,
         {"-Wno-unused-value", "-Wno-int-to-pointer-cast", "-isystem/sysinc"},
-        "input.cc", "clang-tool",
-        std::make_shared<PCHContainerOperations>(),
+        "input.cc", "clang-tool", std::make_shared<PCHContainerOperations>(),
         tooling::getClangStripDependencyFileAdjuster(), VirtFiles);
 
     for (auto &E : clang::ssaf::TUSummaryExtractorRegistry::entries()) {

--- a/clang/unittests/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowTest.cpp
@@ -13,6 +13,7 @@
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/Frontend/ASTUnit.h"
+#include "clang/Frontend/PCHContainerOperations.h"
 #include "clang/Frontend/SSAFOptions.h"
 #include "clang/ScalableStaticAnalysis/Core/Model/EntityId.h"
 #include "clang/ScalableStaticAnalysis/Core/TUSummary/ExtractorRegistry.h"
@@ -173,6 +174,38 @@ protected:
       }
     }
 
+    if (!Extractor) {
+      ADD_FAILURE() << "failed to find PointerFlowTUSummaryExtractor";
+      return false;
+    }
+    Extractor->HandleTranslationUnit(AST->getASTContext());
+    return true;
+  }
+
+  // Variant that mounts a virtual `<sys.h>` header (with
+  // `#pragma clang system_header` prepended) on an `-isystem` path,
+  // letting tests exercise the system-header contributor gate.
+  // Returns true on AST build + extractor instantiation success.
+  bool setUpTestWithSystemHeader(StringRef Code, StringRef SysHeaderCode,
+                                 bool ExtractFromSystemHeaders) {
+    Opts.ExtractFromSystemHeaders = ExtractFromSystemHeaders;
+    std::string SysWithPragma =
+        ("#pragma clang system_header\n" + SysHeaderCode).str();
+    tooling::FileContentMappings VirtFiles = {
+        {"/sysinc/sys.h", SysWithPragma}};
+    AST = tooling::buildASTFromCodeWithArgs(
+        Code,
+        {"-Wno-unused-value", "-Wno-int-to-pointer-cast", "-isystem/sysinc"},
+        "input.cc", "clang-tool",
+        std::make_shared<PCHContainerOperations>(),
+        tooling::getClangStripDependencyFileAdjuster(), VirtFiles);
+
+    for (auto &E : clang::ssaf::TUSummaryExtractorRegistry::entries()) {
+      if (E.getName() == PointerFlowEntitySummary::Name) {
+        Extractor = E.instantiate(Builder);
+        break;
+      }
+    }
     if (!Extractor) {
       ADD_FAILURE() << "failed to find PointerFlowTUSummaryExtractor";
       return false;
@@ -1617,5 +1650,50 @@ TEST_F(PointerFlowTest, LocalPointerReportedWhenIncluded) {
             makeEdges(__LINE__, {{{"local_ptr", 1U}, {"param", 1U}}}));
 
   EXPECT_TRUE(getEntitySummary("foo"));
+}
+
+//////////////////////////////////////////////////////////////
+//          System-header contributor opt-out gate.         //
+//          Spec: tu-summary-extraction,                    //
+//          "System-header contributor opt-out flag".       //
+//////////////////////////////////////////////////////////////
+
+// Default: ExtractFromSystemHeaders == true. A function decl in a
+// `#pragma clang system_header`-marked included header IS enumerated
+// as a contributor and produces an EntitySummary.
+TEST_F(PointerFlowTest, SystemHeader_ExtractDefault) {
+  const char *SysHeader = "int *sys_gp; void sys_fn(int *p) { sys_gp = p; }\n";
+  const char *Main = R"cpp(
+    #include <sys.h>
+    int *user_gp;
+    void user_fn(int *p) { user_gp = p; }
+  )cpp";
+  ASSERT_TRUE(setUpTestWithSystemHeader(Main, SysHeader,
+                                        /*ExtractFromSystemHeaders=*/true));
+  // sys_fn is in a system header but the default (extract-true) enumerates
+  // it as a contributor — summary is non-null.
+  EXPECT_NE(getEntitySummary("sys_fn"), nullptr);
+  // user_fn is enumerated either way (positive control).
+  EXPECT_NE(getEntitySummary("user_fn"), nullptr);
+}
+
+// Opt-out: ExtractFromSystemHeaders == false. The system-header decl
+// is NOT enumerated; getEntitySummary returns nullptr for it. The
+// user-source decl is still enumerated (gate is per-decl, not TU-wide).
+TEST_F(PointerFlowTest, SystemHeader_SkipOptOut) {
+  const char *SysHeader = "int *sys_gp; void sys_fn(int *p) { sys_gp = p; }\n";
+  const char *Main = R"cpp(
+    #include <sys.h>
+    int *user_gp;
+    void user_fn(int *p) { user_gp = p; }
+  )cpp";
+  ASSERT_TRUE(setUpTestWithSystemHeader(Main, SysHeader,
+                                        /*ExtractFromSystemHeaders=*/false));
+  // sys_fn lives in a system header and is skipped at the
+  // ContributorFinder layer when ExtractFromSystemHeaders == false.
+  // getEntitySummary returns nullptr (no summary was built for it).
+  EXPECT_EQ(getEntitySummary("sys_fn"), nullptr);
+  // user_fn is in non-system code so the gate does not fire for it.
+  EXPECT_NE(getEntitySummary("user_fn"), nullptr);
 }
 } // namespace


### PR DESCRIPTION
A new —ssaf-no-extract-from-system-headers switch that gates the contributor finder so contributors located inside system headers are dropped from the per-TU summary.
rdar://179151040