### PR TITLE
[Clang-tools-extra] Add missing values to CharacteristicKindStrings

### DIFF
--- a/clang-tools-extra/pp-trace/PPCallbacksTracker.cpp
+++ b/clang-tools-extra/pp-trace/PPCallbacksTracker.cpp
@@ -60,8 +60,9 @@ static const char *const FileChangeReasonStrings[] = {
 };
 
 // CharacteristicKind strings.
-static const char *const CharacteristicKindStrings[] = { "C_User", "C_System",
-                                                         "C_ExternCSystem" };
+static const char *const CharacteristicKindStrings[] = {
+    "C_User", "C_System", "C_ExternCSystem", "C_User_ModuleMap",
+    "C_System_ModuleMap"};
 
 // MacroDirective::Kind strings.
 static const char *const MacroDirectiveKindStrings[] = {


### PR DESCRIPTION
Static analysis flagged that we were indexing CharacteristicKindStrings in PPCallbacksTracker::FileChanged based on the values of SrcMgr::CharacteristicKind which would access outside array bounds for some values of the enum. As far I can see all value of the enum are possible when calling FileChanged and so the array should indeed cover all values. So I added the missing values to the array.