### PR TITLE
[clang] Support the Swift calling convention on 32-bit PowerPC

### DIFF
--- a/clang/lib/CodeGen/Targets/PPC.cpp
+++ b/clang/lib/CodeGen/Targets/PPC.cpp
@@ -387,7 +387,10 @@ public:
   PPC32TargetCodeGenInfo(CodeGenTypes &CGT, bool SoftFloatABI,
                          bool RetSmallStructInRegABI)
       : TargetCodeGenInfo(std::make_unique<PPC32_SVR4_ABIInfo>(
-            CGT, SoftFloatABI, RetSmallStructInRegABI)) {}
+            CGT, SoftFloatABI, RetSmallStructInRegABI)) {
+    SwiftInfo =
+        std::make_unique<SwiftABIInfo>(CGT, /*SwiftErrorInRegister=*/false);
+  }
 
   static bool isStructReturnInRegABI(const llvm::Triple &Triple,
                                      const CodeGenOptions &Opts);

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -5978,9 +5978,10 @@ SDValue PPCTargetLowering::LowerCall_32SVR4(
   const bool IsVarArg = CFlags.IsVarArg;
   const bool IsTailCall = CFlags.IsTailCall;
 
-  assert((CallConv == CallingConv::C ||
-          CallConv == CallingConv::Cold ||
-          CallConv == CallingConv::Fast) && "Unknown calling convention!");
+  assert((CallConv == CallingConv::C || CallConv == CallingConv::Cold ||
+          CallConv == CallingConv::Fast || CallConv == CallingConv::Swift ||
+          CallConv == CallingConv::SwiftTail) &&
+         "Unknown calling convention!");
 
   const Align PtrAlign(4);
 


### PR DESCRIPTION
Adds Swift calling-convention (swiftcc/swifttailcc) support to the 32-bit PowerPC SVR4/EABI target. Without it, clang aborts with "Swift ABI info has not been initialized" because the 32-bit PowerPC target registered no SwiftABIInfo, which prevents Swift (e.g. Embedded Swift) from targeting 32-bit PowerPC platforms such as the Nintendo Wii/GameCube (PPC750) and Linux PPC32.

Mirrors the existing X86-32, ARM, AArch64 and 64-bit PowerPC handling.

Will help close https://github.com/swiftlang/swift/issues/58206