### PR TITLE
[CIR][NFC] Re-enable invalid linkage test

### DIFF
--- a/clang/test/CIR/IR/invalid-linkage.cir
+++ b/clang/test/CIR/IR/invalid-linkage.cir
@@ -1,11 +1,8 @@
 // Test that cir.global requires a valid linkage attribute
 // RUN: cir-opt %s -verify-diagnostics
 
-// XFAIL: *
-
 !u32i = !cir.int<u, 32>
 module {
-  // expected-error@+1 {{this is here to prevent the test from being reported as an unexpected pass if the problem is fixed outside of CIR}}
   // expected-error@+1 {{expected string or keyword containing one of the following enum values for attribute 'linkage' [external, available_externally, linkonce, linkonce_odr, weak, weak_odr, appending, internal, cir_private, extern_weak, common]}}
   cir.global @a = #cir.const_array<[0 : !u8i, -23 : !u8i, 33 : !u8i] : !cir.array<!u32i x 3>>
 }


### PR DESCRIPTION
The CIR verification test for a cir.global op with a missing linkage attribute was broken by a change to the MLIR asm parser back in April. At that time, I marked the test as XFAIL and added a check that would prevent it from randomly passing. In the meantime, another MLIR parser changed (https://github.com/llvm/llvm-project/pull/188008) fixed the original problem.

This change reverts the test to its previous state since it now passes.