### PR TITLE
[Instrumentor] Move common instruction IO functions into a class

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Instrumentor.h
+++ b/llvm/include/llvm/Transforms/IPO/Instrumentor.h
@@ -583,18 +583,42 @@ struct InstrumentationOpportunity {
   }
 };
 
-/// The base instrumentation opportunity class for instruction opportunities.
+/// The base class that implements basic logic for any instruction
+/// instrumentation opportunity that inherits from InstructionIO.
+struct BaseInstructionIO : public InstrumentationOpportunity {
+  virtual ~BaseInstructionIO() {}
+
+  BaseInstructionIO(InstrumentationLocation::KindTy Kind)
+      : InstrumentationOpportunity(InstrumentationLocation(Kind)) {}
+
+  LLVM_ABI static Value *getOpcode(Value &V, Type &Ty,
+                                   InstrumentationConfig &IConf,
+                                   InstrumentorIRBuilderTy &IIRB);
+  LLVM_ABI static Value *getTypeSize(Value &V, Type &Ty,
+                                     InstrumentationConfig &IConf,
+                                     InstrumentorIRBuilderTy &IIRB);
+  LLVM_ABI static Value *getLeftOperand(Value &V, Type &Ty,
+                                        InstrumentationConfig &IConf,
+                                        InstrumentorIRBuilderTy &IIRB);
+  LLVM_ABI static Value *getRightOperand(Value &V, Type &Ty,
+                                         InstrumentationConfig &IConf,
+                                         InstrumentorIRBuilderTy &IIRB);
+  LLVM_ABI static Value *getTypeId(Value &V, Type &Ty,
+                                   InstrumentationConfig &IConf,
+                                   InstrumentorIRBuilderTy &IIRB);
+};
+
+/// The common instrumentation opportunity class for instruction opportunities.
 /// Each instruction opportunity should inherit from this class and implement
 /// the virtual class members. If multiple opcodes are provided, all of them
 /// are instrumented using the same logic, and a name must be explicitly
 /// provided by overriding getName().
-template <unsigned... Opcodes>
-struct InstructionIO : public InstrumentationOpportunity {
+template <unsigned... Opcodes> struct InstructionIO : public BaseInstructionIO {
   virtual ~InstructionIO() {}
 
   /// Construct an instruction opportunity.
   InstructionIO(InstrumentationLocation::KindTy Kind)
-      : InstrumentationOpportunity(InstrumentationLocation(Kind)) {
+      : BaseInstructionIO(Kind) {
     static_assert(sizeof...(Opcodes) >= 1,
                   "InstructionIO must have at least one opcode");
   }
@@ -621,20 +645,6 @@ struct InstructionIO : public InstrumentationOpportunity {
     return Instruction::getOpcodeName(OpcodesArray[0]);
   }
 };
-
-/// Common getters use across different instrumentation opportunities.
-///{
-LLVM_ABI Value *getOpcode(Value &V, Type &Ty, InstrumentationConfig &IConf,
-                          InstrumentorIRBuilderTy &IIRB);
-LLVM_ABI Value *getTypeSize(Value &V, Type &Ty, InstrumentationConfig &IConf,
-                            InstrumentorIRBuilderTy &IIRB);
-LLVM_ABI Value *getLeft(Value &V, Type &Ty, InstrumentationConfig &IConf,
-                        InstrumentorIRBuilderTy &IIRB);
-LLVM_ABI Value *getRight(Value &V, Type &Ty, InstrumentationConfig &IConf,
-                         InstrumentorIRBuilderTy &IIRB);
-LLVM_ABI Value *getTypeId(Value &V, Type &Ty, InstrumentationConfig &IConf,
-                          InstrumentorIRBuilderTy &IIRB);
-///}
 
 /// The instrumentation opportunity for functions.
 struct FunctionIO final : public InstrumentationOpportunity {

--- a/llvm/lib/Transforms/IPO/Instrumentor.cpp
+++ b/llvm/lib/Transforms/IPO/Instrumentor.cpp
@@ -905,31 +905,31 @@ static void readValuePack(const Range &R, Value &Pack,
   }
 }
 
-Value *llvm::instrumentor::getOpcode(Value &V, Type &Ty,
-                                     InstrumentationConfig &IConf,
-                                     InstrumentorIRBuilderTy &IIRB) {
+Value *BaseInstructionIO::getOpcode(Value &V, Type &Ty,
+                                    InstrumentationConfig &IConf,
+                                    InstrumentorIRBuilderTy &IIRB) {
   auto &I = cast<Instruction>(V);
   return getCI(&Ty, I.getOpcode());
 }
 
-Value *llvm::instrumentor::getTypeSize(Value &V, Type &Ty,
-                                       InstrumentationConfig &IConf,
-                                       InstrumentorIRBuilderTy &IIRB) {
+Value *BaseInstructionIO::getTypeSize(Value &V, Type &Ty,
+                                      InstrumentationConfig &IConf,
+                                      InstrumentorIRBuilderTy &IIRB) {
   auto &I = cast<Instruction>(V);
   auto &DL = I.getDataLayout();
   return getCI(&Ty, DL.getTypeStoreSize(V.getType()));
 }
 
-Value *llvm::instrumentor::getLeft(Value &V, Type &Ty,
-                                   InstrumentationConfig &IConf,
-                                   InstrumentorIRBuilderTy &IIRB) {
+Value *BaseInstructionIO::getLeftOperand(Value &V, Type &Ty,
+                                         InstrumentationConfig &IConf,
+                                         InstrumentorIRBuilderTy &IIRB) {
   auto &I = cast<Instruction>(V);
   return I.getOperand(0);
 }
 
-Value *llvm::instrumentor::getRight(Value &V, Type &Ty,
-                                    InstrumentationConfig &IConf,
-                                    InstrumentorIRBuilderTy &IIRB) {
+Value *BaseInstructionIO::getRightOperand(Value &V, Type &Ty,
+                                          InstrumentationConfig &IConf,
+                                          InstrumentorIRBuilderTy &IIRB) {
   auto &I = cast<Instruction>(V);
   if (I.getNumOperands() > 1)
     return I.getOperand(1);
@@ -937,9 +937,9 @@ Value *llvm::instrumentor::getRight(Value &V, Type &Ty,
     return PoisonValue::get(&Ty);
 }
 
-Value *llvm::instrumentor::getTypeId(Value &V, Type &Ty,
-                                     InstrumentationConfig &IConf,
-                                     InstrumentorIRBuilderTy &IIRB) {
+Value *BaseInstructionIO::getTypeId(Value &V, Type &Ty,
+                                    InstrumentationConfig &IConf,
+                                    InstrumentorIRBuilderTy &IIRB) {
   return getCI(&Ty, V.getType()->getTypeID());
 }
 
@@ -1777,12 +1777,12 @@ void NumericIO::init(InstrumentationConfig &IConf,
   if (Config.has(PassLeft))
     IRTArgs.push_back(IRTArg(IIRB.Int64Ty, "left",
                              "The operation's left operand.", ValArgOpts,
-                             getLeft));
+                             getLeftOperand));
   if (Config.has(PassRight))
     IRTArgs.push_back(IRTArg(IIRB.Int64Ty, "right",
                              "The operation's right operand. This value is "
                              "poison for unary operations.",
-                             ValArgOpts, getRight));
+                             ValArgOpts, getRightOperand));
   if (!IsPRE && Config.has(PassResult))
     IRTArgs.push_back(
         IRTArg(IIRB.Int64Ty, "result", "Result of the operation.",
@@ -1867,11 +1867,11 @@ void CompareIO::init(InstrumentationConfig &IConf,
   if (Config.has(PassLeft))
     IRTArgs.push_back(IRTArg(IIRB.Int64Ty, "left",
                              "The comparison's left operand.", OperandArgOpts,
-                             getLeft));
+                             getLeftOperand));
   if (Config.has(PassRight))
     IRTArgs.push_back(IRTArg(IIRB.Int64Ty, "right",
                              "The comparison's right operand.", OperandArgOpts,
-                             getRight));
+                             getRightOperand));
   if (!IsPRE && Config.has(PassResultSize))
     IRTArgs.push_back(IRTArg(IIRB.Int32Ty, "result_type_id",
                              "The result value's type ID.", IRTArg::NONE,


### PR DESCRIPTION
This commit moves several instruction-related IO functions into a class instead of having them defined in the instrumentor namespace. We add the BaseInstructionIO non-templated class because InstructionIO is a templated class. Adding the common functions into InstructionIO would force us to define them in the header.