### PR TITLE
[clang] Add Swift support for MIPS

### DIFF
--- a/clang/lib/CodeGen/Targets/Mips.cpp
+++ b/clang/lib/CodeGen/Targets/Mips.cpp
@@ -44,7 +44,10 @@ class MIPSTargetCodeGenInfo : public TargetCodeGenInfo {
 public:
   MIPSTargetCodeGenInfo(CodeGenTypes &CGT, bool IsO32)
       : TargetCodeGenInfo(std::make_unique<MipsABIInfo>(CGT, IsO32)),
-        SizeOfUnwindException(IsO32 ? 24 : 32) {}
+        SizeOfUnwindException(IsO32 ? 24 : 32) {
+    SwiftInfo =
+        std::make_unique<SwiftABIInfo>(CGT, /*SwiftErrorInRegister=*/false);
+  }
 
   int getDwarfEHStackPointer(CodeGen::CodeGenModule &CGM) const override {
     return 29;


### PR DESCRIPTION
Adds support for compiling Swift targeting the MIPS ABI.

Related to https://github.com/swiftlang/swift/issues/58204

Upstream rework of https://github.com/swiftlang/llvm-project/pull/4021