### PR TITLE
[lldb] Remove unused MemorySize methods (NFC)

### DIFF
--- a/lldb/include/lldb/Core/Address.h
+++ b/lldb/include/lldb/Core/Address.h
@@ -354,12 +354,6 @@ public:
   ///     otherwise.
   bool IsValid() const { return m_offset != LLDB_INVALID_ADDRESS; }
 
-  /// Get the memory cost of this object.
-  ///
-  /// \return
-  ///     The number of bytes that this object occupies in memory.
-  size_t MemorySize() const;
-
   /// Resolve a file virtual address using a section list.
   ///
   /// Given a list of sections, attempt to resolve \a addr as an offset into

--- a/lldb/include/lldb/Core/AddressRange.h
+++ b/lldb/include/lldb/Core/AddressRange.h
@@ -222,16 +222,6 @@ public:
   ///     The size in bytes of this address range.
   lldb::addr_t GetByteSize() const { return m_byte_size; }
 
-  /// Get the memory cost of this object.
-  ///
-  /// \return
-  ///     The number of bytes that this object occupies in memory.
-  size_t MemorySize() const {
-    // Noting special for the memory size of a single AddressRange object, it
-    // is just the size of itself.
-    return sizeof(AddressRange);
-  }
-
   /// Set accessor for the byte size of this range.
   ///
   /// \param[in] byte_size

--- a/lldb/include/lldb/Core/Declaration.h
+++ b/lldb/include/lldb/Core/Declaration.h
@@ -150,14 +150,6 @@ public:
     return m_file && m_line != 0 && m_line != LLDB_INVALID_LINE_NUMBER;
   }
 
-  /// Get the memory cost of this object.
-  ///
-  /// \return
-  ///     The number of bytes that this object occupies in memory.
-  ///     The returned value does not include the bytes for any
-  ///     shared string values.
-  size_t MemorySize() const;
-
   /// Set accessor for the declaration file specification.
   ///
   /// \param[in] file_spec

--- a/lldb/include/lldb/Core/Mangled.h
+++ b/lldb/include/lldb/Core/Mangled.h
@@ -198,16 +198,6 @@ public:
   }
   bool NameMatches(const RegularExpression &regex) const;
 
-  /// Get the memory cost of this object.
-  ///
-  /// Return the size in bytes that this object takes in memory. This returns
-  /// the size in bytes of this object, not any shared string values it may
-  /// refer to.
-  ///
-  /// \return
-  ///     The number of bytes that this object occupies in memory.
-  size_t MemorySize() const;
-
   /// Set the string value in this object.
   ///
   /// This version auto detects if the string is mangled by inspecting the

--- a/lldb/include/lldb/Symbol/Block.h
+++ b/lldb/include/lldb/Symbol/Block.h
@@ -277,15 +277,6 @@ public:
 
   CompilerDeclContext GetDeclContext();
 
-  /// Get the memory cost of this object.
-  ///
-  /// Returns the cost of this object plus any owned objects from the ranges,
-  /// variables, and inline function information.
-  ///
-  /// \return
-  ///     The number of bytes that this object occupies in memory.
-  size_t MemorySize() const;
-
   /// Set accessor for any inlined function information.
   ///
   /// \param[in] name

--- a/lldb/include/lldb/Symbol/Function.h
+++ b/lldb/include/lldb/Symbol/Function.h
@@ -105,14 +105,6 @@ public:
   ///     A const reference to the method name object.
   ConstString GetName() const;
 
-  /// Get the memory cost of this object.
-  ///
-  /// \return
-  ///     The number of bytes that this object occupies in memory.
-  ///     The returned value does not include the bytes for any
-  ///     shared string values.
-  virtual size_t MemorySize() const;
-
 protected:
   /// Function method name (not a mangled name).
   ConstString m_name;
@@ -230,14 +222,6 @@ public:
   /// \return
   ///     A const reference to the mangled name object.
   const Mangled &GetMangled() const;
-
-  /// Get the memory cost of this object.
-  ///
-  /// \return
-  ///     The number of bytes that this object occupies in memory.
-  ///     The returned value does not include the bytes for any
-  ///     shared string values.
-  size_t MemorySize() const override;
 
 private:
   /// Mangled inlined function name (can be empty if there is no mangled
@@ -578,14 +562,6 @@ public:
   ///
   /// \see SymbolContextScope
   void DumpSymbolContext(Stream *s) override;
-
-  /// Get the memory cost of this object.
-  ///
-  /// \return
-  ///     The number of bytes that this object occupies in memory.
-  ///     The returned value does not include the bytes for any
-  ///     shared string values.
-  size_t MemorySize() const;
 
   /// Get whether compiler optimizations were enabled for this function
   ///

--- a/lldb/include/lldb/Symbol/Variable.h
+++ b/lldb/include/lldb/Symbol/Variable.h
@@ -88,8 +88,6 @@ public:
   // the location that contains this address.
   bool DumpLocations(Stream *s, const Address &address);
 
-  size_t MemorySize() const;
-
   void CalculateSymbolContext(SymbolContext *sc);
 
   bool IsInScope(StackFrame *frame);

--- a/lldb/include/lldb/Symbol/VariableList.h
+++ b/lldb/include/lldb/Symbol/VariableList.h
@@ -64,8 +64,6 @@ public:
 
   uint32_t FindIndexForVariable(Variable *variable);
 
-  size_t MemorySize() const;
-
   size_t GetSize() const;
   bool Empty() const { return m_variables.empty(); }
 

--- a/lldb/include/lldb/Utility/FileSpecList.h
+++ b/lldb/include/lldb/Utility/FileSpecList.h
@@ -202,16 +202,6 @@ public:
   ///     returned.
   const FileSpec &GetFileSpecAtIndex(size_t idx) const;
 
-  /// Get the memory cost of this object.
-  ///
-  /// Return the size in bytes that this object takes in memory. This returns
-  /// the size in bytes of this object, not any shared string values it may
-  /// refer to.
-  ///
-  /// \return
-  ///     The number of bytes that this object occupies in memory.
-  size_t MemorySize() const;
-
   bool IsEmpty() const { return m_files.empty(); }
 
   /// Get the number of files in the file list.

--- a/lldb/source/Core/Address.cpp
+++ b/lldb/source/Core/Address.cpp
@@ -958,12 +958,6 @@ int Address::CompareModulePointerAndOffset(const Address &a, const Address &b) {
   return 0;
 }
 
-size_t Address::MemorySize() const {
-  // Noting special for the memory size of a single Address object, it is just
-  // the size of itself.
-  return sizeof(Address);
-}
-
 // NOTE: Be careful using this operator. It can correctly compare two
 // addresses from the same Module correctly. It can't compare two addresses
 // from different modules in any meaningful way, but it will compare the module

--- a/lldb/source/Core/Declaration.cpp
+++ b/lldb/source/Core/Declaration.cpp
@@ -53,8 +53,6 @@ bool Declaration::DumpStopContext(Stream *s, bool show_fullpaths) const {
   return false;
 }
 
-size_t Declaration::MemorySize() const { return sizeof(Declaration); }
-
 int Declaration::Compare(const Declaration &a, const Declaration &b) {
   int result = FileSpec::Compare(a.m_file, b.m_file, true);
   if (result)

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -407,13 +407,6 @@ void Mangled::DumpDebug(Stream *s) const {
   m_demangled.DumpDebug(s);
 }
 
-// Return the size in byte that this object takes in memory. The size includes
-// the size of the objects it owns, and not the strings that it references
-// because they are shared strings.
-size_t Mangled::MemorySize() const {
-  return m_mangled.MemorySize() + m_demangled.MemorySize();
-}
-
 // We "guess" the language because we can't determine a symbol's language from
 // it's name.  For example, a Pascal symbol can be mangled using the C++
 // Itanium scheme, and defined in a compilation unit within the same module as

--- a/lldb/source/Symbol/Block.cpp
+++ b/lldb/source/Symbol/Block.cpp
@@ -367,16 +367,6 @@ void Block::AddRange(const Range &range) {
   m_ranges.Append(range);
 }
 
-// Return the current number of bytes that this object occupies in memory
-size_t Block::MemorySize() const {
-  size_t mem_size = sizeof(Block) + m_ranges.GetSize() * sizeof(Range);
-  if (m_inlineInfoSP.get())
-    mem_size += m_inlineInfoSP->MemorySize();
-  if (m_variable_list_sp.get())
-    mem_size += m_variable_list_sp->MemorySize();
-  return mem_size;
-}
-
 BlockSP Block::CreateChild(user_id_t uid) {
   m_children.push_back(std::shared_ptr<Block>(new Block(uid, *this)));
   return m_children.back();

--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -59,10 +59,6 @@ const Declaration &FunctionInfo::GetDeclaration() const {
 
 ConstString FunctionInfo::GetName() const { return m_name; }
 
-size_t FunctionInfo::MemorySize() const {
-  return m_name.MemorySize() + m_declaration.MemorySize();
-}
-
 InlineFunctionInfo::InlineFunctionInfo(const char *name,
                                        llvm::StringRef mangled,
                                        const Declaration *decl_ptr,
@@ -115,10 +111,6 @@ const Declaration &InlineFunctionInfo::GetCallSite() const {
 Mangled &InlineFunctionInfo::GetMangled() { return m_mangled; }
 
 const Mangled &InlineFunctionInfo::GetMangled() const { return m_mangled; }
-
-size_t InlineFunctionInfo::MemorySize() const {
-  return FunctionInfo::MemorySize() + m_mangled.MemorySize();
-}
 
 /// @name Call site related structures
 /// @{
@@ -507,11 +499,6 @@ bool Function::GetDisassembly(const ExecutionContext &exe_ctx,
 void Function::DumpSymbolContext(Stream *s) {
   m_comp_unit->DumpSymbolContext(s);
   s->Printf(", Function{0x%8.8" PRIx64 "}", GetID());
-}
-
-size_t Function::MemorySize() const {
-  size_t mem_size = sizeof(Function) + m_block.MemorySize();
-  return mem_size;
 }
 
 bool Function::GetIsOptimized() {

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -200,8 +200,6 @@ bool Variable::DumpDeclaration(Stream *s, bool show_fullpaths,
   return dumped_declaration_info;
 }
 
-size_t Variable::MemorySize() const { return sizeof(Variable); }
-
 CompilerDeclContext Variable::GetDeclContext() {
   Type *type = GetType();
   if (type)

--- a/lldb/source/Symbol/VariableList.cpp
+++ b/lldb/source/Symbol/VariableList.cpp
@@ -142,14 +142,6 @@ uint32_t VariableList::FindIndexForVariable(Variable *variable) {
   return UINT32_MAX;
 }
 
-size_t VariableList::MemorySize() const {
-  size_t mem_size = sizeof(VariableList);
-  const_iterator pos, end = m_variables.end();
-  for (pos = m_variables.begin(); pos != end; ++pos)
-    mem_size += (*pos)->MemorySize();
-  return mem_size;
-}
-
 size_t VariableList::GetSize() const { return m_variables.size(); }
 
 void VariableList::Dump(Stream *s, bool show_context) const {

--- a/lldb/source/Utility/FileSpecList.cpp
+++ b/lldb/source/Utility/FileSpecList.cpp
@@ -217,19 +217,5 @@ SupportFileNSP SupportFileList::GetSupportFileAtIndex(size_t idx) const {
   return std::make_shared<SupportFile>();
 }
 
-// Return the size in bytes that this object takes in memory. This returns the
-// size in bytes of this object's member variables and any FileSpec objects its
-// member variables contain, the result doesn't not include the string values
-// for the directories any filenames as those are in shared string pools.
-size_t FileSpecList::MemorySize() const {
-  size_t mem_size = sizeof(FileSpecList);
-  collection::const_iterator pos, end = m_files.end();
-  for (pos = m_files.begin(); pos != end; ++pos) {
-    mem_size += pos->MemorySize();
-  }
-
-  return mem_size;
-}
-
 // Return the number of files in the file spec list.
 size_t FileSpecList::GetSize() const { return m_files.size(); }


### PR DESCRIPTION
These `MemorySize` methods are unused. There are two remaining which are used: `FileSpec::MemorySize` and `ConstString::MemorySize`.