### PR TITLE
[RISCV] Emit .option arch extensions without the "experimental-" prefix

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -540,7 +540,9 @@ bool RISCVAsmPrinter::emitDirectiveOptionArch() {
 
     auto Delta = STI->hasFeature(Feature.Value) ? RISCVOptionArchArgType::Plus
                                                 : RISCVOptionArchArgType::Minus;
-    NeedEmitStdOptionArgs.emplace_back(Delta, Feature.Key);
+    StringRef ExtName = Feature.Key;
+    ExtName.consume_front("experimental-");
+    NeedEmitStdOptionArgs.emplace_back(Delta, ExtName.str());
   }
   if (!NeedEmitStdOptionArgs.empty()) {
     RTS.emitDirectiveOptionPush();

--- a/llvm/test/CodeGen/RISCV/option-arch-experimental.ll
+++ b/llvm/test/CodeGen/RISCV/option-arch-experimental.ll
@@ -1,0 +1,13 @@
+; RUN: llc -mtriple=riscv64 < %s | FileCheck %s
+; RUN: llc -mtriple=riscv64 < %s \
+; RUN:   | llvm-mc -triple=riscv64 -mattr=+experimental -filetype=obj -o /dev/null
+
+; CHECK: .option push
+; CHECK-NEXT: .option arch, +zicfiss, +zicsr, +zimop
+; CHECK-NOT: experimental-
+define void @f() "target-features"="+experimental-zicfiss" {
+; CHECK-LABEL: f:
+; CHECK: .option pop
+entry:
+  ret void
+}


### PR DESCRIPTION
We currently emit the "experimental-" prefix in .option arch, e.g. `.option arch, +experimental-zicfiss`, but the assembler can't parse that back.

There are two ways to fix this:

1. Teach the assembler to accept `.option arch, +experimental-zicfiss`.
2. Emit `.option arch, +zicfiss` instead of `.option arch, +experimental-zicfiss`.

This patch takes the second approach, which better fits the .option arch syntax we defined. Experimental extensions are still guarded by `-menable-experimental-extensions`.