### PR TITLE
[clang][ExprConst] Add early exit in `evaluateDestruction()`

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -21707,8 +21707,15 @@ bool Expr::EvaluateAsInitializer(const ASTContext &Ctx, const VarDecl *VD,
 
 bool VarDecl::evaluateDestruction(
     SmallVectorImpl<PartialDiagnosticAt> &Notes) const {
-
-  if (getType()->isPointerOrReferenceType()) {
+  // This function is only meaningful for records and arrays of records.
+  QualType VarTy = getType();
+  if (VarTy->isArrayType()) {
+    QualType ElemTy = getASTContext().getBaseElementType(VarTy);
+    if (!ElemTy->isRecordType()) {
+      ensureEvaluatedStmt()->HasConstantDestruction = true;
+      return true;
+    }
+  } else if (!VarTy->isRecordType()) {
     ensureEvaluatedStmt()->HasConstantDestruction = true;
     return true;
   }
@@ -21727,7 +21734,7 @@ bool VarDecl::evaluateDestruction(
   APValue DestroyedValue;
   if (getEvaluatedValue())
     DestroyedValue = *getEvaluatedValue();
-  else if (!handleDefaultInitValue(getType(), DestroyedValue))
+  else if (!handleDefaultInitValue(VarTy, DestroyedValue))
     return false;
 
   if (Ctx.getLangOpts().EnableNewConstInterp) {
@@ -21744,7 +21751,7 @@ bool VarDecl::evaluateDestruction(
     return true;
   }
 
-  if (!EvaluateDestruction(Ctx, this, std::move(DestroyedValue), getType(),
+  if (!EvaluateDestruction(Ctx, this, std::move(DestroyedValue), VarTy,
                            getLocation(), EStatus, IsConstantDestruction) ||
       EStatus.HasSideEffects)
     return false;

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -21707,6 +21707,12 @@ bool Expr::EvaluateAsInitializer(const ASTContext &Ctx, const VarDecl *VD,
 
 bool VarDecl::evaluateDestruction(
     SmallVectorImpl<PartialDiagnosticAt> &Notes) const {
+
+  if (getType()->isPointerOrReferenceType()) {
+    ensureEvaluatedStmt()->HasConstantDestruction = true;
+    return true;
+  }
+
   Expr::EvalStatus EStatus;
   EStatus.Diag = &Notes;
 


### PR DESCRIPTION
There's nothing to do here for them. It's a little sad that we still crated the vector holding the notes int he caller but setting `HasConstantDestruction` is a side-effect of `evaluateDestruction()` that some callers rely on.