### PR TITLE
[clang-tidy][NFC] Remove a wrong comment in ProTypeMemberInitCheck

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProTypeMemberInitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProTypeMemberInitCheck.cpp
@@ -572,8 +572,6 @@ void ProTypeMemberInitCheck::checkMissingBaseClassInitializer(
 
     for (const CXXCtorInitializer *Init : Ctor->inits())
       if (Init->isBaseInitializer() && Init->isWritten()) {
-        // In template AST BaseInitializer could be generated too even if it's
-        // not target to base class.
         if (const CXXRecordDecl *CRD =
                 Init->getBaseClass()->getAsCXXRecordDecl())
           BasesToInit.erase(CRD->getCanonicalDecl());


### PR DESCRIPTION
`getAsCXXRecordDecl` will return nullptr for any dependent types.

It's introduced by #192786,  see https://github.com/llvm/llvm-project/pull/192786#issuecomment-4785223372 in original PR.