### PR TITLE
[mlir][sparse_tensor] Handle block argument for sparse_tensor.expand codegen

### DIFF
--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorCodegen.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseTensorCodegen.cpp
@@ -912,7 +912,11 @@ public:
     Type boolType = rewriter.getIntegerType(1);
     Type idxType = rewriter.getIndexType();
     // All initialization should be done on entry of the loop nest.
-    rewriter.setInsertionPointAfter(op.getTensor().getDefiningOp());
+    if (isa<BlockArgument>(op.getTensor())) {
+      rewriter.setInsertionPointToStart(op->getBlock());
+    } else {
+      rewriter.setInsertionPointAfter(op.getTensor().getDefiningOp());
+    }
 
     // Determine the size for access expansion (always the innermost stored
     // level size).

--- a/mlir/test/Dialect/SparseTensor/sparse_tensor_codegen_expand.mlir
+++ b/mlir/test/Dialect/SparseTensor/sparse_tensor_codegen_expand.mlir
@@ -1,0 +1,17 @@
+// RUN: mlir-opt %s -sparse-tensor-codegen | FileCheck %s
+
+#sparse = #sparse_tensor.encoding<{ map = (d0, d1) -> (d0 : compressed, d1 : compressed) }>
+
+// This test verifies that sparse_tensor.expand codegen handles the case where
+// the input sparse tensor is a function block argument.
+// CHECK-LABEL: func.func @sparse_expansion(
+// CHECK-SAME: %[[A0:.*]]: memref<?xindex>, %[[A1:.*]]: memref<?xindex>, %[[A2:.*]]: memref<?xindex>, %[[A3:.*]]: memref<?xindex>, %[[A4:.*]]: memref<?xf64>, %[[A5:.*]]: !sparse_tensor.storage_specifier<#sparse>) -> index
+// CHECK-NOT: sparse_tensor.expand
+
+module {
+  func.func @sparse_expansion(%arg0: tensor<8x8xf64, #sparse>) -> index {
+    %values, %filled, %added, %count = sparse_tensor.expand %arg0
+      : tensor<8x8xf64, #sparse> to memref<?xf64>, memref<?xi1>, memref<?xindex>
+    return %count : index
+  }
+}


### PR DESCRIPTION
Handle the case where the source tensor of `sparse_tensor.expand` is a block argument in SparseExpandConverter. Previously it unconditionally uses `getDefiningOp()`, which is `null` for block arguments and causes a crash.

A regression test is added to cover `sparse_tensor.expand` on a function argument.

Fixes #204712 