### PR TITLE
[Hexagon] Fix 32-bit funnel shift miscompilation with register shift amounts

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonPatterns.td
+++ b/llvm/lib/Target/Hexagon/HexagonPatterns.td
@@ -1274,7 +1274,7 @@ def Divu8: SDNodeXForm<imm, [{
 def FShl32i: OutPatFrag<(ops node:$Rs, node:$Rt, node:$S),
   (HiReg (S2_asl_i_p (Combinew $Rs, $Rt), $S))>;
 def FShl32r: OutPatFrag<(ops node:$Rs, node:$Rt, node:$Ru),
-  (HiReg (S2_asl_r_p (Combinew $Rs, $Rt), $Ru))>;
+  (HiReg (S2_asl_r_p (Combinew $Rs, $Rt), (A2_andir $Ru, 31)))>;
 
 def FShl64i: OutPatFrag<(ops node:$Rs, node:$Rt, node:$S),
   (S2_lsr_i_p_or (S2_asl_i_p $Rs, $S),  $Rt, (Subi<64> $S))>;
@@ -1316,7 +1316,7 @@ def: Pat<(fshl I64:$Rs, I64:$Rt, I32:$Ru),  (FShl64r $Rs, $Rt, $Ru)>;
 def FShr32i: OutPatFrag<(ops node:$Rs, node:$Rt, node:$S),
   (LoReg (S2_lsr_i_p (Combinew $Rs, $Rt), $S))>;
 def FShr32r: OutPatFrag<(ops node:$Rs, node:$Rt, node:$Ru),
-  (LoReg (S2_lsr_r_p (Combinew $Rs, $Rt), $Ru))>;
+  (LoReg (S2_lsr_r_p (Combinew $Rs, $Rt), (A2_andir $Ru, 31)))>;
 
 def FShr64i: OutPatFrag<(ops node:$Rs, node:$Rt, node:$S),
   (S2_asl_i_p_or (S2_lsr_i_p $Rt, $S),  $Rs, (Subi<64> $S))>;

--- a/llvm/test/CodeGen/Hexagon/fshl-fshr-i32-mask.ll
+++ b/llvm/test/CodeGen/Hexagon/fshl-fshr-i32-mask.ll
@@ -1,0 +1,45 @@
+; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+
+; Variable-amount 32-bit funnel shifts (and the rotates that lower to them)
+; are realized as a 64-bit asl/lsr of the {hi,lo} combine, taking one word of
+; the result. That identity only holds for a shift amount in [0,31], and
+; llvm.fshl/fshr define the amount to be taken modulo 32. Hexagon's register
+; variable shifts do NOT reduce the amount modulo the operand width -- they
+; treat the low 7 bits as a signed amount in [-64,63] -- so the amount must be
+; explicitly masked with #31 before the 64-bit shift. Without the mask, counts
+; >= 32 or "negative" counts (e.g. -1 == 0xffffffff) are miscompiled.
+
+; CHECK-LABEL: rotl_var:
+; CHECK: r[[A0:[0-9]+]] = and(r1,#31)
+; CHECK: = asl(r{{[0-9]+}}:{{[0-9]+}},r[[A0]])
+define i32 @rotl_var(i32 %n, i32 %c) {
+  %r = tail call i32 @llvm.fshl.i32(i32 %n, i32 %n, i32 %c)
+  ret i32 %r
+}
+
+; CHECK-LABEL: rotr_var:
+; CHECK: r[[A1:[0-9]+]] = and(r1,#31)
+; CHECK: = lsr(r{{[0-9]+}}:{{[0-9]+}},r[[A1]])
+define i32 @rotr_var(i32 %n, i32 %c) {
+  %r = tail call i32 @llvm.fshr.i32(i32 %n, i32 %n, i32 %c)
+  ret i32 %r
+}
+
+; CHECK-LABEL: fshl_var:
+; CHECK: r[[A2:[0-9]+]] = and(r2,#31)
+; CHECK: = asl(r{{[0-9]+}}:{{[0-9]+}},r[[A2]])
+define i32 @fshl_var(i32 %a, i32 %b, i32 %c) {
+  %r = tail call i32 @llvm.fshl.i32(i32 %a, i32 %b, i32 %c)
+  ret i32 %r
+}
+
+; CHECK-LABEL: fshr_var:
+; CHECK: r[[A3:[0-9]+]] = and(r2,#31)
+; CHECK: = lsr(r{{[0-9]+}}:{{[0-9]+}},r[[A3]])
+define i32 @fshr_var(i32 %a, i32 %b, i32 %c) {
+  %r = tail call i32 @llvm.fshr.i32(i32 %a, i32 %b, i32 %c)
+  ret i32 %r
+}
+
+declare i32 @llvm.fshl.i32(i32, i32, i32)
+declare i32 @llvm.fshr.i32(i32, i32, i32)

--- a/llvm/test/CodeGen/Hexagon/funnel-shift.ll
+++ b/llvm/test/CodeGen/Hexagon/funnel-shift.ll
@@ -11,7 +11,8 @@ b0:
 
 ; CHECK-LABEL: f1:
 ; CHECK: r[[R10:[0-9]+]]:[[R11:[0-9]+]] = combine(r0,r1)
-; CHECK: r[[R12:[0-9]+]]:[[R13:[0-9]+]] = asl(r[[R10]]:[[R11]],r2)
+; CHECK: r[[R1A:[0-9]+]] = and(r2,#31)
+; CHECK: r[[R12:[0-9]+]]:[[R13:[0-9]+]] = asl(r[[R10]]:[[R11]],r[[R1A]])
 define i32 @f1(i32 %a0, i32 %a1, i32 %a2) #1 {
 b0:
   %v0 = tail call i32 @llvm.fshl.i32(i32 %a0, i32 %a1, i32 %a2)
@@ -49,7 +50,8 @@ b0:
 
 ; CHECK-LABEL: f5:
 ; CHECK: r[[R50:[0-9]+]]:[[R51:[0-9]+]] = combine(r0,r1)
-; CHECK: r[[R52:[0-9]+]]:[[R53:[0-9]+]] = lsr(r[[R50]]:[[R51]],r2)
+; CHECK: r[[R5A:[0-9]+]] = and(r2,#31)
+; CHECK: r[[R52:[0-9]+]]:[[R53:[0-9]+]] = lsr(r[[R50]]:[[R51]],r[[R5A]])
 define i32 @f5(i32 %a0, i32 %a1, i32 %a2) #1 {
 b0:
   %v0 = tail call i32 @llvm.fshr.i32(i32 %a0, i32 %a1, i32 %a2)
@@ -85,8 +87,8 @@ b0:
 }
 
 ; CHECK-LABEL: f9:
-; CHECK: r[[R90:[0-9]+]]:[[R91:[0-9]+]] = combine(r0,r0)
-; CHECK: r[[R92:[0-9]+]]:[[R93:[0-9]+]] = asl(r[[R90]]:[[R91]],r1)
+; CHECK: r[[R9A:[0-9]+]] = and(r1,#31)
+; CHECK: = asl(r{{[0-9]+}}:{{[0-9]+}},r[[R9A]])
 define i32 @f9(i32 %a0, i32 %a1) #1 {
 b0:
   %v0 = tail call i32 @llvm.fshl.i32(i32 %a0, i32 %a0, i32 %a1)
@@ -121,8 +123,8 @@ b0:
 }
 
 ; CHECK-LABEL: f13:
-; CHECK: r[[RD0:[0-9]+]]:[[RD1:[0-9]+]] = combine(r0,r0)
-; CHECK: r[[RD2:[0-9]+]]:[[RD3:[0-9]+]] = lsr(r[[RD0]]:[[RD1]],r1)
+; CHECK: r[[RDA:[0-9]+]] = and(r1,#31)
+; CHECK: = lsr(r{{[0-9]+}}:{{[0-9]+}},r[[RDA]])
 define i32 @f13(i32 %a0, i32 %a1) #1 {
 b0:
   %v0 = tail call i32 @llvm.fshr.i32(i32 %a0, i32 %a0, i32 %a1)

--- a/llvm/test/CodeGen/Hexagon/rotate.ll
+++ b/llvm/test/CodeGen/Hexagon/rotate.ll
@@ -14,8 +14,10 @@ b0:
 
 ; CHECK-LABEL: f1
 ; This is a rotate left by %a1(r1). Use register-pair shift to implement it.
-; CHECK: r[[R10:[0-9]+]]:[[R11:[0-9]+]] = combine(r0,r0)
-; CHECK: r[[R12:[0-9]+]]:[[R13:[0-9]+]] = asl(r[[R10]]:[[R11]],r1)
+; The amount must be masked modulo 32 because Hexagon's variable shift does not
+; reduce it and treats it as signed.
+; CHECK: r[[R1A:[0-9]+]] = and(r1,#31)
+; CHECK: r[[R12:[0-9]+]]:[[R13:[0-9]+]] = asl(r{{[0-9]+}}:{{[0-9]+}},r[[R1A]])
 ; CHECK: r0 = r[[R12]]
 define i32 @f1(i32 %a0, i32 %a1) #0 {
 b0:
@@ -38,8 +40,10 @@ b0:
 
 ; CHECK-LABEL: f3
 ; This is a rotate right by %a1(r1). Use register-pair shift to implement it.
-; CHECK: r[[R30:[0-9]+]]:[[R31:[0-9]+]] = combine(r0,r0)
-; CHECK: r[[R32:[0-9]+]]:[[R33:[0-9]+]] = lsr(r[[R30]]:[[R31]],r1)
+; The amount must be masked modulo 32 because Hexagon's variable shift does not
+; reduce it and treats it as signed.
+; CHECK: r[[R3A:[0-9]+]] = and(r1,#31)
+; CHECK: r[[R32:[0-9]+]]:[[R33:[0-9]+]] = lsr(r{{[0-9]+}}:{{[0-9]+}},r[[R3A]])
 define i32 @f3(i32 %a0, i32 %a1) #0 {
 b0:
   %v0 = lshr i32 %a0, %a1


### PR DESCRIPTION
The register-variable 32-bit funnel shifts and the i32 rotates that lower through them, realize the shift as a 64-bit asl/lsr of the {hi,lo} combine and take one word of the result. That identity only holds for a shift amount in [0, 31], and llvm.fshl/fshr define the amount to be taken modulo 32. The register-form variable shift does not reduce the amount modulo the operand width, it treats the low 7 bits as a signed amount in [-64, 63].  So the raw, unreduced amount must be masked with #31 before the 64-bit shift.

Without the mask, counts >= 32 or "negative" counts are miscompiled: a count of 63 shifts left by 63, 64 becomes -64 and shifts the value out entirely, and -1 becomes an arithmetic right shift by 1. In-range counts 0..31 come out correct, which is why a test that only sweeps 0..31 does not catch it. This is exactly the i32.rotl/i32.rotr miscompile that caused the WAMR Wasm spec-test suites (which invoke rotates with counts of 32, 33, and -1) to be skipped on Hexagon.

Fix by masking the amount with (A2_andir $Ru, 31), mirroring the masking the 64-bit patterns already use. This completes the 32-bit case left unaddressed by 4fffee037520 ("[Hexagon] Fix 64-bit funnel shift miscompilation with register shift amounts", #183669), which fixed only the FShl64r/FShr64r width.