### PR TITLE
[Hexagon] Fix unused variable in non-assert builds (KCFI)

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonAsmPrinter.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonAsmPrinter.cpp
@@ -979,7 +979,8 @@ void HexagonAsmPrinter::LowerPATCHABLE_EVENT_CALL(const MachineInstr &MI,
 void HexagonAsmPrinter::LowerKCFI_CHECK(const MachineInstr &MI) {
   Register AddrReg = MI.getOperand(0).getReg();
   const int64_t Type = MI.getOperand(1).getImm();
-  MachineBasicBlock::const_instr_iterator NextI = std::next(MI.getIterator());
+  [[maybe_unused]] MachineBasicBlock::const_instr_iterator NextI =
+      std::next(MI.getIterator());
   assert(NextI != MI.getParent()->instr_end() && NextI->isCall() &&
          "KCFI_CHECK not followed by a call instruction");
   assert(NextI->getOperand(0).getReg() == AddrReg &&


### PR DESCRIPTION
Without asserts, we see failures like so:

    /repo/llvm/llvm/lib/Target/Hexagon/HexagonAsmPrinter.cpp:982:43: error: unused variable 'NextI' [-Werror,-Wunused-variable]
      982 |   MachineBasicBlock::const_instr_iterator NextI = std::next(MI.getIterator());
          |                                           ^~~~~
    1 error generated.

Mark NextI `maybe_unused` to address the issue.

Fixes a regression introduced by f8aa5f66209d.