### PR TITLE
[mlir][gpu] Fix verifier crash on unterminated warp_execute_on_lane_0 body

### DIFF
--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -2597,7 +2597,11 @@ LogicalResult WarpExecuteOnLane0Op::verify() {
   if (getArgs().size() != getWarpRegion().getNumArguments())
     return emitOpError(
         "expected same number op arguments and block arguments.");
-  auto yield = dyn_cast<gpu::YieldOp>(getBody()->getTerminator());
+  Block *body = getBody();
+  // Malformed parsed IR may leave the body unterminated; guard getTerminator().
+  auto yield = body->mightHaveTerminator()
+                   ? dyn_cast<gpu::YieldOp>(body->getTerminator())
+                   : nullptr;
   if (!yield)
     return emitOpError("expected body to be terminated with 'gpu.yield'");
   if (yield.getNumOperands() != getNumResults())

--- a/mlir/test/Dialect/GPU/invalid.mlir
+++ b/mlir/test/Dialect/GPU/invalid.mlir
@@ -1061,6 +1061,18 @@ func.func @warp_wrong_num_outputs(%laneid: index) {
 
 // -----
 
+// A body left unterminated by malformed (generic-form) IR must be diagnosed,
+// not crash getTerminator().
+func.func @warp_unterminated_body(%laneid: index) {
+  // expected-error@+1 {{'gpu.warp_execute_on_lane_0' op expected body to be terminated with 'gpu.yield'}}
+  "gpu.warp_execute_on_lane_0"(%laneid) <{warp_size = 32 : i64}> ({
+    %0 = "arith.constant"() <{value = 1 : index}> : () -> index
+  }) : (index) -> ()
+  return
+}
+
+// -----
+
 func.func @warp_wrong_num_inputs(%laneid: index) {
   // expected-error@+1 {{'gpu.warp_execute_on_lane_0' op expected same number op arguments and block arguments.}}
   gpu.warp_execute_on_lane_0(%laneid)[64] {


### PR DESCRIPTION
WarpExecuteOnLane0Op::verify() called getBody()->getTerminator() directly. For malformed IR parsed in generic form, the region's block can have no terminator, and getTerminator() asserts mightHaveTerminator(). Guard the call so the verifier emits "expected body to be terminated with 'gpu.yield'" instead of crashing.

Fixes #205239