### PR TITLE
[Support] Sort RealFSDirIter directory entries Windows-style

### DIFF
--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -436,26 +436,34 @@ std::unique_ptr<FileSystem> vfs::createPhysicalFileSystem() {
 namespace {
 
 class RealFSDirIter : public llvm::vfs::detail::DirIterImpl {
-  llvm::sys::fs::directory_iterator Iter;
+  std::vector<directory_entry> Entries;
+  size_t Index = 0;
 
 public:
   RealFSDirIter(const Twine &Path, std::error_code &EC) {
     auto BypassSandbox = sys::sandbox::scopedDisable();
 
-    Iter = sys::fs::directory_iterator(Path, EC);
-    if (Iter != sys::fs::directory_iterator())
-      CurrentEntry = directory_entry(Iter->path(), Iter->type());
+    for (sys::fs::directory_iterator Iter(Path, EC), End; Iter != End && !EC;
+         Iter.increment(EC)) {
+      Entries.push_back(directory_entry(Iter->path(), Iter->type()));
+    }
+    if (EC)
+      return;
+
+    // Sort entries in case-insensitive lexicographical order to replicate
+    // Windows (NTFS) directory iteration behavior on Linux.
+    llvm::sort(Entries, [](const directory_entry &A, const directory_entry &B) {
+      return StringRef(A.path()).compare_insensitive(StringRef(B.path())) < 0;
+    });
+
+    if (!Entries.empty())
+      CurrentEntry = Entries[0];
   }
 
   std::error_code increment() override {
-    auto BypassSandbox = sys::sandbox::scopedDisable();
-
-    std::error_code EC;
-    Iter.increment(EC);
-    CurrentEntry = (Iter == llvm::sys::fs::directory_iterator())
-                       ? directory_entry()
-                       : directory_entry(Iter->path(), Iter->type());
-    return EC;
+    Index++;
+    CurrentEntry = (Index < Entries.size()) ? Entries[Index] : directory_entry();
+    return std::error_code();
   }
 };
 


### PR DESCRIPTION
On Linux (ext4/xfs), directory iteration order returned by readdir depends on inode/hash order. On Windows (NTFS), FindNextFile returns directory entries in case-insensitive lexicographical order.

When building Clang Modules (PCM), this filesystem difference causes non-deterministic ordering of top-level declarations and submodules. Specifically, when compiling code calling hypot(float, float), lazy deserialization of corecrt_math.h's hypotf declaration depends on iteration order, causing missing dllimport attributes and link errors (missing DLL import thunks for __imp__hypotf) on Windows.

This patch modifies RealFSDirIter to sort directory entries in case-insensitive lexicographical order, allowing Linux hosts to replicate Windows directory iteration behavior and reproduce Windows-specific Clang Modules link errors deterministically.