### PR TITLE
[BOLT] hugify: fix conflict with --no-huge-pages

### DIFF
--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -158,7 +158,16 @@ BinaryContext::BinaryContext(std::unique_ptr<MCContext> Ctx,
       MIA(std::move(MIA)), MIB(std::move(MIB)), MRI(std::move(MRI)),
       DisAsm(std::move(DisAsm)), Logger(Logger), InitialDynoStats(isAArch64()) {
   RegularPageSize = isAArch64() ? RegularPageSizeAArch64 : RegularPageSizeX86;
-  PageAlign = opts::NoHugePages ? RegularPageSize : HugePageSize;
+  if (opts::Hugify) {
+    if (opts::NoHugePages) {
+      this->errs() << "BOLT-ERROR: a conflict between --hugify and "
+                      "--no-huge-pages options, choose one of them\n";
+      exit(1);
+    }
+    PageAlign = HugePageSize;
+  } else {
+    PageAlign = opts::NoHugePages ? RegularPageSize : HugePageSize;
+  }
 }
 
 BinaryContext::~BinaryContext() {

--- a/bolt/test/runtime/hugify.c
+++ b/bolt/test/runtime/hugify.c
@@ -14,15 +14,21 @@ RUN: %clang %cflags -no-pie %s -o %t.nopie.exe -Wl,-q
 RUN: %clang %cflags -fpic %s -o %t.pie.exe -Wl,-q
 
 RUN: llvm-bolt %t.nopie.exe --lite=0 -o %t.nopie --hugify
+RUN: not llvm-bolt %t.nopie.exe --lite=0 -o /dev/null --hugify \
+RUN:   --no-huge-pages=true 2>&1 | FileCheck %s -check-prefix=CHECK-ERROR
 RUN: llvm-bolt %t.pie.exe --lite=0 -o %t.pie --hugify
+RUN: not llvm-bolt %t.pie.exe --lite=0 -o /dev/null -hugify \
+RUN:   -no-huge-pages=true 2>&1 | FileCheck %s -check-prefix=CHECK-ERROR
 
 RUN: llvm-nm --numeric-sort --print-armap %t.nopie | \
 RUN:   FileCheck %s -check-prefix=CHECK-NM
-RUN: %t.nopie | FileCheck %s -check-prefix=CHECK-NOPIE
+RUN: %t.nopie | FileCheck %s -check-prefix=CHECK
+RUN: llvm-readelf -lS %t.nopie | FileCheck %s -check-prefix=CHECK-ALIGNMENT
 
 RUN: llvm-nm --numeric-sort --print-armap %t.pie | \
 RUN:   FileCheck %s -check-prefix=CHECK-NM
-RUN: %t.pie | FileCheck %s -check-prefix=CHECK-PIE
+RUN: %t.pie | FileCheck %s -check-prefix=CHECK
+RUN: llvm-readelf -lS %t.pie | FileCheck %s -check-prefix=CHECK-ALIGNMENT
 
 CHECK-NM:       W  __hot_start
 CHECK-NM-NEXT:  T _start
@@ -31,8 +37,13 @@ CHECK-NM:       W __hot_end
 CHECK-NM:       t __bolt_hugify_start_program
 CHECK-NM-NEXT:  W __bolt_runtime_start
 
-CHECK-NOPIE: Hello world
+COM: .text section must have a hugepage alignment
+COM: at least one R-E segment must have a hugepage alignment
+CHECK-ALIGNMENT: {{.*}} .text PROGBITS {{[0-9a-f]+}}00000 {{.*}} 2097152
+CHECK-ALIGNMENT: LOAD 0x{{.*}} R E 0x200000
 
-CHECK-PIE: Hello world
+CHECK: Hello world
+
+CHECK-ERROR: BOLT-ERROR: a conflict between --hugify and --no-huge-pages options
 
 */


### PR DESCRIPTION
There is a conflict between --hugify and --no-huge-pages options.
Both of these options change page alignment in different ways.
In the case of using both options simultaneously the llvm-bolt fails with an error.