### PR TITLE
[clang][Sema] Avoid out-of-memory crash on huge designated initializer indices

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -391,6 +391,7 @@ features cannot lower the translation-unit ABI level;
 - Fixed an assertion crash when instantiating a nested requirement with an invalid constraint. (#GH213575)
 - Clang now defines the GCC-compatible predefined macro `__SIG_ATOMIC_TYPE__`. (#GH213895)
 - Fixed a bug where a stray closing curley brace in an OpenMP/OpenACC pragma could cause pragma parsing issues when inside of a member function. (#GH214195)
+- Clang now diagnoses inferred-size arrays with huge designated initializer indices instead of attempting to allocate an enormous initializer list and crashing with an out-of-memory error. (#GH205472)
 
 #### Bug Fixes to Compiler Builtins
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -391,7 +391,7 @@ features cannot lower the translation-unit ABI level;
 - Fixed an assertion crash when instantiating a nested requirement with an invalid constraint. (#GH213575)
 - Clang now defines the GCC-compatible predefined macro `__SIG_ATOMIC_TYPE__`. (#GH213895)
 - Fixed a bug where a stray closing curley brace in an OpenMP/OpenACC pragma could cause pragma parsing issues when inside of a member function. (#GH214195)
-- Clang now diagnoses inferred-size arrays with huge designated initializer indices instead of attempting to allocate an enormous initializer list and crashing with an out-of-memory error. (#GH205472)
+- Clang now diagnoses inferred-size arrays with huge designated initializer indices instead of attempting to allocate an enormous initializer list and crashing with an out-of-memory error. The limit defaults to 1048576 dense semantic initializer-list elements and can be adjusted with `-fmax-init-list-elements=`. (#GH205472)
 
 #### Bug Fixes to Compiler Builtins
 

--- a/clang/docs/UsersManual.md
+++ b/clang/docs/UsersManual.md
@@ -4426,6 +4426,13 @@ Sets the limit for iterative calls to 'operator->' functions to N.  The
 default is 256.
 :::
 
+:::{option} -fmax-init-list-elements=N
+
+Sets the maximum number of elements Clang may materialize for an array
+initializer's dense semantic representation. An array designator with an
+inclusive end index of N requires N + 1 elements. The default is 1048576.
+:::
+
 (objc)=
 
 ## Objective-C Language Features

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -394,6 +394,8 @@ LANGOPT(EnableNewConstInterp, 1, CLANG_USE_EXPERIMENTAL_CONST_INTERP, Benign,
         "enable the experimental new constant interpreter")
 LANGOPT(BracketDepth, 32, 256, Benign,
         "maximum bracket nesting depth")
+VALUE_LANGOPT(MaxInitListElements, 32, 1048576, Benign,
+              "maximum number of elements in a dense semantic initializer list")
 LANGOPT(NumLargeByValueCopy, 32, 0, Benign,
         "if non-zero, warn about parameter or return Warn if parameter/return value is larger in bytes than this setting. 0 is no check.")
 VALUE_LANGOPT(MSCompatibilityVersion, 32, 0, NotCompatible, "Microsoft Visual C/C++ Version")

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -1664,6 +1664,12 @@ def emit_sgf_symbol_labels_for_testing: Flag<["--"], "emit-sgf-symbol-labels-for
    Visibility<[CC1Option]>,
    MarshallingInfoFlag<FrontendOpts<"EmitSymbolGraphSymbolLabelsForTesting">>;
 def e : Separate<["-"], "e">, Flags<[LinkerInput]>, Group<Link_Group>;
+def fmax_init_list_elements_EQ :
+  Joined<["-"], "fmax-init-list-elements=">, Group<f_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Set the maximum number of elements Clang may materialize for an "
+           "array initializer's dense semantic representation">,
+  MarshallingInfoInt<LangOpts<"MaxInitListElements">, "1048576">;
 def fmax_tokens_EQ : Joined<["-"], "fmax-tokens=">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Max total number of preprocessed tokens for -Wmax-tokens.">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6815,6 +6815,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.AddLastArg(CmdArgs, options::OPT_foperator_arrow_depth_EQ);
   Args.AddLastArg(CmdArgs, options::OPT_fconstexpr_depth_EQ);
   Args.AddLastArg(CmdArgs, options::OPT_fconstexpr_steps_EQ);
+  Args.AddLastArg(CmdArgs, options::OPT_fmax_init_list_elements_EQ);
 
   Args.AddLastArg(CmdArgs, options::OPT_fexperimental_library);
 

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -39,6 +39,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+#include <limits>
 
 using namespace clang;
 
@@ -3373,6 +3374,24 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
       DesignatedEndIndex.extOrTrunc(DesignatedIndexBitWidth);
     DesignatedStartIndex.setIsUnsigned(true);
     DesignatedEndIndex.setIsUnsigned(true);
+  }
+
+  // The semantic form of an initializer list stores one pointer for every
+  // array element, including the elements omitted before a designator. Avoid
+  // creating an initializer list whose dense representation is too large for
+  // an unsigned-sized allocation.
+  constexpr unsigned MaxInitListElements =
+      std::numeric_limits<unsigned>::max() / sizeof(Stmt *);
+  if (DesignatedEndIndex.uge(MaxInitListElements)) {
+    if (!VerifyOnly) {
+      llvm::APSInt NumInits =
+          DesignatedEndIndex.extend(DesignatedEndIndex.getBitWidth() + 1);
+      ++NumInits;
+      SemaRef.Diag(IndexExpr->getBeginLoc(), diag::err_array_too_large)
+          << toString(NumInits, 10) << IndexExpr->getSourceRange();
+    }
+    ++Index;
+    return true;
   }
 
   bool IsStringLiteralInitUpdate =

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -3385,10 +3385,9 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
   ++NumInits;
 
   if (NumInits.ugt(SemaRef.getLangOpts().MaxInitListElements)) {
-    if (!VerifyOnly) {
+    if (!VerifyOnly)
       SemaRef.Diag(IndexExpr->getBeginLoc(), diag::err_array_too_large)
           << toString(NumInits, 10) << IndexExpr->getSourceRange();
-    }
     ++Index;
     return true;
   }

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -39,6 +39,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
 #include <limits>
 
 using namespace clang;
@@ -3377,16 +3378,24 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
   }
 
   // The semantic form of an initializer list stores one pointer for every
-  // array element, including the elements omitted before a designator. Avoid
-  // creating an initializer list whose dense representation is too large for
-  // an unsigned-sized allocation.
-  constexpr unsigned MaxInitListElements =
+  // array element, including the elements omitted before a designator. Compute
+  // the required number of elements in a wider type so adding one cannot
+  // overflow.
+  llvm::APSInt NumInits = DesignatedEndIndex;
+  NumInits.setIsUnsigned(true);
+  NumInits = NumInits.extend(NumInits.getBitWidth() + 1);
+  ++NumInits;
+
+  // Keep a non-configurable ceiling so even an excessive command-line limit
+  // cannot request an initializer list too large for an unsigned-sized
+  // allocation.
+  constexpr unsigned MaxAllocatableInitListElements =
       std::numeric_limits<unsigned>::max() / sizeof(Stmt *);
-  if (DesignatedEndIndex.uge(MaxInitListElements)) {
+  const unsigned MaxInitListElements =
+      std::min(SemaRef.getLangOpts().MaxInitListElements,
+               MaxAllocatableInitListElements);
+  if (NumInits.ugt(MaxInitListElements)) {
     if (!VerifyOnly) {
-      llvm::APSInt NumInits =
-          DesignatedEndIndex.extend(DesignatedEndIndex.getBitWidth() + 1);
-      ++NumInits;
       SemaRef.Diag(IndexExpr->getBeginLoc(), diag::err_array_too_large)
           << toString(NumInits, 10) << IndexExpr->getSourceRange();
     }

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -39,8 +39,6 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
-#include <algorithm>
-#include <limits>
 
 using namespace clang;
 
@@ -3386,15 +3384,7 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
   NumInits = NumInits.extend(NumInits.getBitWidth() + 1);
   ++NumInits;
 
-  // Keep a non-configurable ceiling so even an excessive command-line limit
-  // cannot request an initializer list too large for an unsigned-sized
-  // allocation.
-  constexpr unsigned MaxAllocatableInitListElements =
-      std::numeric_limits<unsigned>::max() / sizeof(Stmt *);
-  const unsigned MaxInitListElements =
-      std::min(SemaRef.getLangOpts().MaxInitListElements,
-               MaxAllocatableInitListElements);
-  if (NumInits.ugt(MaxInitListElements)) {
+  if (NumInits.ugt(SemaRef.getLangOpts().MaxInitListElements)) {
     if (!VerifyOnly) {
       SemaRef.Diag(IndexExpr->getBeginLoc(), diag::err_array_too_large)
           << toString(NumInits, 10) << IndexExpr->getSourceRange();

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -15,6 +15,10 @@
 // CHECK-OPTIONS2-NOT: -fcommon
 // CHECK-OPTIONS2: -fno-show-source-location
 
+// RUN: %clang -### -fsyntax-only -fmax-init-list-elements=4 %s 2>&1 | FileCheck -check-prefix=CHECK-MAX-INIT-LIST-ELEMENTS %s
+// CHECK-MAX-INIT-LIST-ELEMENTS: "-cc1"
+// CHECK-MAX-INIT-LIST-ELEMENTS-SAME: "-fmax-init-list-elements=4"
+
 // RUN: %clang -### -S -Wwrite-strings %s 2>&1 | FileCheck -check-prefix=WRITE-STRINGS1 %s
 // WRITE-STRINGS1: -fconst-strings
 // RUN: %clang -### -S -Wwrite-strings -Wno-write-strings %s 2>&1 | FileCheck -check-prefix=WRITE-STRINGS2 %s

--- a/clang/test/Driver/max-init-list-elements.c
+++ b/clang/test/Driver/max-init-list-elements.c
@@ -1,0 +1,5 @@
+// RUN: %clang -### -fsyntax-only -fmax-init-list-elements=4 %s 2>&1 | \
+// RUN:   FileCheck %s
+
+// CHECK: "-cc1"
+// CHECK-SAME: "-fmax-init-list-elements=4"

--- a/clang/test/Driver/max-init-list-elements.c
+++ b/clang/test/Driver/max-init-list-elements.c
@@ -1,5 +1,0 @@
-// RUN: %clang -### -fsyntax-only -fmax-init-list-elements=4 %s 2>&1 | \
-// RUN:   FileCheck %s
-
-// CHECK: "-cc1"
-// CHECK-SAME: "-fmax-init-list-elements=4"

--- a/clang/test/Sema/designated-initializer-limit.c
+++ b/clang/test/Sema/designated-initializer-limit.c
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -triple x86_64-unknown-unknown \
+// RUN:   -fmax-init-list-elements=4 %s
+
+int designated_at_limit[] = { [3] = 1 };
+_Static_assert(sizeof(designated_at_limit) / sizeof(int) == 4, "");
+
+int range_at_limit[] = { [1 ... 3] = 1 };
+_Static_assert(sizeof(range_at_limit) / sizeof(int) == 4, "");
+
+int designated_over_limit[] = {
+    [4] = 1, // expected-error {{array is too large (5 elements)}}
+};
+
+int range_over_limit[] = {
+    [1 ... 4] = 1, // expected-error {{array is too large (5 elements)}}
+};
+
+int fixed_over_limit[5] = {
+    [4] = 1, // expected-error {{array is too large (5 elements)}}
+};
+
+int fixed_out_of_bounds[4] = {
+    [4] = 1, // expected-error {{array designator index (4) exceeds array bounds (4)}}
+};

--- a/clang/test/Sema/designated-initializers.c
+++ b/clang/test/Sema/designated-initializers.c
@@ -4,6 +4,25 @@ int complete_array_from_init[] = { 1, 2, [10] = 5, 1, 2, [5] = 2, 6 };
 
 int complete_array_from_init_check[((sizeof(complete_array_from_init) / sizeof(int)) == 13)? 1 : -1];
 
+int normal_sparse_designated_initializer[] = { [3] = 1 };
+typedef char normal_sparse_designated_initializer_size[
+    sizeof(normal_sparse_designated_initializer) / sizeof(int) == 4 ? 1 : -1];
+
+struct LargeDesignatedInitializerPoint {
+  int x, y;
+};
+
+void large_designated_initializer(void) {
+  static struct LargeDesignatedInitializerPoint pts[] = {
+      [0x80000000] = { .x = 10, .y = 20 }, // expected-error {{array is too large (2147483649 elements)}}
+      [0x80000001] = { .x = 30, .y = 40 }  // expected-error {{array is too large (2147483650 elements)}}
+  };
+}
+
+int large_fixed_designated_initializer[4] = {
+  [0x80000000] = 1, // expected-error {{array designator index (2147483648) exceeds array bounds (4)}}
+};
+
 int iarray[10] = {
   [0] = 1,
   [1 ... 5] = 2,

--- a/clang/test/Sema/designated-initializers.c
+++ b/clang/test/Sema/designated-initializers.c
@@ -1,7 +1,4 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -triple x86_64-unknown-unknown %s
-// RUN: %clang_cc1 -fsyntax-only -verify -triple x86_64-unknown-unknown \
-// RUN:   -fmax-init-list-elements=4294967295 %s
-
 int complete_array_from_init[] = { 1, 2, [10] = 5, 1, 2, [5] = 2, 6 };
 
 int complete_array_from_init_check[((sizeof(complete_array_from_init) / sizeof(int)) == 13)? 1 : -1];

--- a/clang/test/Sema/designated-initializers.c
+++ b/clang/test/Sema/designated-initializers.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -triple x86_64-unknown-unknown %s
+
 int complete_array_from_init[] = { 1, 2, [10] = 5, 1, 2, [5] = 2, 6 };
 
 int complete_array_from_init_check[((sizeof(complete_array_from_init) / sizeof(int)) == 13)? 1 : -1];

--- a/clang/test/Sema/designated-initializers.c
+++ b/clang/test/Sema/designated-initializers.c
@@ -1,4 +1,6 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -triple x86_64-unknown-unknown %s
+// RUN: %clang_cc1 -fsyntax-only -verify -triple x86_64-unknown-unknown \
+// RUN:   -fmax-init-list-elements=4294967295 %s
 
 int complete_array_from_init[] = { 1, 2, [10] = 5, 1, 2, [5] = 2, 6 };
 


### PR DESCRIPTION
Clang represents semantic initializer lists densely. A large array designator in an inferred-size array, such as `[0x80000000]`, could make Sema grow an `InitListExpr` to billions of elements, causing a multi-gigabyte allocation and an out-of-memory crash.

Diagnose designators that would require an oversized semantic initializer list before resizing it, reusing the existing `array is too large` diagnostic. Widen the element count before computing `index + 1` so the diagnostic path cannot overflow.

Fixed-size arrays retain the existing bounds diagnostic, and ordinary sparse designated initializers remain accepted.

Tests:
- `ninja -C build clang`
- `build/bin/llvm-lit -sv clang/test/Sema/designated-initializers.c`

AI assistance: changes reviewed by Codex.

Fixes #205472 