### PR TITLE
[ARM] Replace Neon concat patterns with insert_subregs.

### DIFF
--- a/llvm/lib/Target/ARM/ARMInstrNEON.td
+++ b/llvm/lib/Target/ARM/ARMInstrNEON.td
@@ -8130,19 +8130,19 @@ let Predicates = [HasNEON,IsBE] in {
 
 let Predicates = [HasNEON] in {
 def : Pat<(v2i64 (concat_vectors DPR:$Dn, DPR:$Dm)),
-          (REG_SEQUENCE QPR, DPR:$Dn, dsub_0, DPR:$Dm, dsub_1)>;
+          (INSERT_SUBREG (INSERT_SUBREG (IMPLICIT_DEF), DPR:$Dn, dsub_0), DPR:$Dm, dsub_1)>;
 def : Pat<(v4i32 (concat_vectors DPR:$Dn, DPR:$Dm)),
-          (REG_SEQUENCE QPR, DPR:$Dn, dsub_0, DPR:$Dm, dsub_1)>;
+          (INSERT_SUBREG (INSERT_SUBREG (IMPLICIT_DEF), DPR:$Dn, dsub_0), DPR:$Dm, dsub_1)>;
 def : Pat<(v8i16 (concat_vectors DPR:$Dn, DPR:$Dm)),
-          (REG_SEQUENCE QPR, DPR:$Dn, dsub_0, DPR:$Dm, dsub_1)>;
+          (INSERT_SUBREG (INSERT_SUBREG (IMPLICIT_DEF), DPR:$Dn, dsub_0), DPR:$Dm, dsub_1)>;
 def : Pat<(v16i8 (concat_vectors DPR:$Dn, DPR:$Dm)),
-          (REG_SEQUENCE QPR, DPR:$Dn, dsub_0, DPR:$Dm, dsub_1)>;
+          (INSERT_SUBREG (INSERT_SUBREG (IMPLICIT_DEF), DPR:$Dn, dsub_0), DPR:$Dm, dsub_1)>;
 def : Pat<(v4f32 (concat_vectors DPR:$Dn, DPR:$Dm)),
-          (REG_SEQUENCE QPR, DPR:$Dn, dsub_0, DPR:$Dm, dsub_1)>;
+          (INSERT_SUBREG (INSERT_SUBREG (IMPLICIT_DEF), DPR:$Dn, dsub_0), DPR:$Dm, dsub_1)>;
 def : Pat<(v8f16 (concat_vectors DPR:$Dn, DPR:$Dm)),
-          (REG_SEQUENCE QPR, DPR:$Dn, dsub_0, DPR:$Dm, dsub_1)>;
+          (INSERT_SUBREG (INSERT_SUBREG (IMPLICIT_DEF), DPR:$Dn, dsub_0), DPR:$Dm, dsub_1)>;
 def : Pat<(v8bf16 (concat_vectors DPR:$Dn, DPR:$Dm)),
-          (REG_SEQUENCE QPR, DPR:$Dn, dsub_0, DPR:$Dm, dsub_1)>;
+          (INSERT_SUBREG (INSERT_SUBREG (IMPLICIT_DEF), DPR:$Dn, dsub_0), DPR:$Dm, dsub_1)>;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/ARM/aes-erratum-fix.ll
+++ b/llvm/test/CodeGen/ARM/aes-erratum-fix.ll
@@ -1387,20 +1387,20 @@ define arm_aapcs_vfpcc void @aese_setf16_cond_via_ptr(i1 zeroext %0, ptr %1, <16
 ; CHECK-FIX-NOSCHED-NEXT:  .LBB36_3:
 ; CHECK-FIX-NOSCHED-NEXT:    add r3, r2, #8
 ; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d16[0]}, [r2:32]
-; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d17[0]}, [r3:32]
+; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d18[0]}, [r3:32]
 ; CHECK-FIX-NOSCHED-NEXT:    add r3, r2, #4
 ; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d16[1]}, [r3:32]
 ; CHECK-FIX-NOSCHED-NEXT:    add r3, r2, #12
-; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d17[1]}, [r3:32]
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d17[3]
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r9, d17[0]
+; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d18[1]}, [r3:32]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d18[3]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r9, d18[0]
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r10, d16[3]
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r11, d16[2]
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r7, d16[0]
 ; CHECK-FIX-NOSCHED-NEXT:    str r3, [sp, #8] @ 4-byte Spill
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d17[2]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d18[2]
 ; CHECK-FIX-NOSCHED-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d17[1]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d18[1]
 ; CHECK-FIX-NOSCHED-NEXT:    str r3, [sp] @ 4-byte Spill
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d16[1]
 ; CHECK-FIX-NOSCHED-NEXT:    cmp r0, #0
@@ -1444,91 +1444,85 @@ define arm_aapcs_vfpcc void @aese_setf16_cond_via_ptr(i1 zeroext %0, ptr %1, <16
 ; CHECK-CORTEX-FIX:       @ %bb.0:
 ; CHECK-CORTEX-FIX-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 ; CHECK-CORTEX-FIX-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-CORTEX-FIX-NEXT:    .pad #24
-; CHECK-CORTEX-FIX-NEXT:    sub sp, sp, #24
+; CHECK-CORTEX-FIX-NEXT:    .pad #16
+; CHECK-CORTEX-FIX-NEXT:    sub sp, sp, #16
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    beq .LBB36_3
 ; CHECK-CORTEX-FIX-NEXT:  @ %bb.1:
 ; CHECK-CORTEX-FIX-NEXT:    vld1.64 {d16, d17}, [r2]
+; CHECK-CORTEX-FIX-NEXT:    ldrh r11, [r1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[1]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d17[0]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d17[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r4, d17[3]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #20] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d17[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d17[3]
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[2]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #8] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[3]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d17[1]
+; CHECK-CORTEX-FIX-NEXT:    str r7, [sp, #4] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #12] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    ldrh r3, [r1]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #16] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    mov r3, r6
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[3]
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #8] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d17[1]
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    bne .LBB36_4
 ; CHECK-CORTEX-FIX-NEXT:  .LBB36_2:
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r0, d0[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r4, d0[0]
 ; CHECK-CORTEX-FIX-NEXT:    b .LBB36_5
 ; CHECK-CORTEX-FIX-NEXT:  .LBB36_3:
 ; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d16[0]}, [r2:32]
 ; CHECK-CORTEX-FIX-NEXT:    add r3, r2, #8
 ; CHECK-CORTEX-FIX-NEXT:    add r7, r2, #4
-; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d17[0]}, [r3:32]
+; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d18[0]}, [r3:32]
 ; CHECK-CORTEX-FIX-NEXT:    add r3, r2, #12
 ; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d16[1]}, [r7:32]
-; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d17[1]}, [r3:32]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[0]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d17[1]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r4, d17[3]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #16] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d18[1]}, [r3:32]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[1]
-; CHECK-CORTEX-FIX-NEXT:    str r7, [sp, #12] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d17[2]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #20] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d16[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d18[2]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d18[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d18[3]
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[2]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #8] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    str r7, [sp, #4] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #12] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[3]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d17[0]
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #8] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d18[1]
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    beq .LBB36_2
 ; CHECK-CORTEX-FIX-NEXT:  .LBB36_4:
-; CHECK-CORTEX-FIX-NEXT:    ldrh r0, [r1]
+; CHECK-CORTEX-FIX-NEXT:    ldrh r4, [r1]
 ; CHECK-CORTEX-FIX-NEXT:  .LBB36_5:
-; CHECK-CORTEX-FIX-NEXT:    str r0, [sp] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    ldr r0, [sp, #8] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    ldr r1, [sp, #4] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r9, r7, r4, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    ldr r4, [sp, #20] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d0[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r5, d0[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d0[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r12, d0[3]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d1[0]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r5, d1[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r9, d1[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r1, d1[1]
+; CHECK-CORTEX-FIX-NEXT:    ldr r0, [sp] @ 4-byte Reload
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 lr, d1[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d1[3]
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r7, r0, r1, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    ldr r1, [sp, #12] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, lr, r8, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d1[3]
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r3, r8, r3, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, r11, r0, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r5, r4, r5, lsl #16
 ; CHECK-CORTEX-FIX-NEXT:    pkhbt r6, r6, r12, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r5, r11, r5, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r1, r3, r1, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    ldr r3, [sp, #16] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r4, r3, r4, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    ldr r3, [sp] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[0], r4
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[0], r1
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[1], r7
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[1], r9
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r3, r3, r10, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[0], r3
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[0], r5
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r1, r9, r1, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[0], r0
+; CHECK-CORTEX-FIX-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[0], r3
+; CHECK-CORTEX-FIX-NEXT:    ldr r3, [sp, #12] @ 4-byte Reload
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r7, lr, r7, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[0], r5
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, r0, r10, lsl #16
 ; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[1], r6
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[1], r0
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[0], r1
+; CHECK-CORTEX-FIX-NEXT:    ldr r6, [sp, #8] @ 4-byte Reload
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r3, r3, r6, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[1], r3
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[1], r0
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[1], r7
 ; CHECK-CORTEX-FIX-NEXT:    aese.8 q9, q8
 ; CHECK-CORTEX-FIX-NEXT:    aesmc.8 q8, q9
 ; CHECK-CORTEX-FIX-NEXT:    vst1.64 {d16, d17}, [r2]
-; CHECK-CORTEX-FIX-NEXT:    add sp, sp, #24
+; CHECK-CORTEX-FIX-NEXT:    add sp, sp, #16
 ; CHECK-CORTEX-FIX-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
   br i1 %0, label %5, label %12
 
@@ -1598,18 +1592,18 @@ define arm_aapcs_vfpcc void @aese_setf16_cond_via_val(i1 zeroext %0, half %1, <1
 ; CHECK-FIX-NOSCHED-NEXT:  .LBB37_2:
 ; CHECK-FIX-NOSCHED-NEXT:    add r2, r1, #8
 ; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d16[0]}, [r1:32]
-; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d17[0]}, [r2:32]
+; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d18[0]}, [r2:32]
 ; CHECK-FIX-NOSCHED-NEXT:    add r2, r1, #4
 ; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d16[1]}, [r2:32]
 ; CHECK-FIX-NOSCHED-NEXT:    add r2, r1, #12
-; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d17[1]}, [r2:32]
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r2, d17[1]
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r7, d17[3]
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 lr, d17[2]
+; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d18[1]}, [r2:32]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r2, d18[1]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r7, d18[3]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 lr, d18[2]
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r11, d16[2]
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r8, d16[1]
 ; CHECK-FIX-NOSCHED-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r2, d17[0]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r2, d18[0]
 ; CHECK-FIX-NOSCHED-NEXT:    str r2, [sp, #4] @ 4-byte Spill
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r2, d16[3]
 ; CHECK-FIX-NOSCHED-NEXT:    str r2, [sp] @ 4-byte Spill
@@ -1665,8 +1659,8 @@ define arm_aapcs_vfpcc void @aese_setf16_cond_via_val(i1 zeroext %0, half %1, <1
 ; CHECK-CORTEX-FIX:       @ %bb.0:
 ; CHECK-CORTEX-FIX-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 ; CHECK-CORTEX-FIX-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-CORTEX-FIX-NEXT:    .pad #12
-; CHECK-CORTEX-FIX-NEXT:    sub sp, sp, #12
+; CHECK-CORTEX-FIX-NEXT:    .pad #8
+; CHECK-CORTEX-FIX-NEXT:    sub sp, sp, #8
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    beq .LBB37_3
 ; CHECK-CORTEX-FIX-NEXT:  @ %bb.1:
@@ -1674,82 +1668,82 @@ define arm_aapcs_vfpcc void @aese_setf16_cond_via_val(i1 zeroext %0, half %1, <1
 ; CHECK-CORTEX-FIX-NEXT:    vmov.f32 s2, s0
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d16[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d16[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d16[3]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d17[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d17[3]
-; CHECK-CORTEX-FIX-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d17[0]
-; CHECK-CORTEX-FIX-NEXT:    str r2, [sp, #4] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d17[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 lr, d16[3]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d17[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d17[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d17[3]
 ; CHECK-CORTEX-FIX-NEXT:    str r2, [sp] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d17[2]
+; CHECK-CORTEX-FIX-NEXT:    str r2, [sp, #4] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    bne .LBB37_4
 ; CHECK-CORTEX-FIX-NEXT:  .LBB37_2:
+; CHECK-CORTEX-FIX-NEXT:    mov r0, lr
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 lr, d2[0]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d2[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d2[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d2[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r4, d2[3]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r9, d3[0]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d3[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d3[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r9, d3[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r5, d3[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r12, d3[3]
 ; CHECK-CORTEX-FIX-NEXT:    vmov s0, lr
+; CHECK-CORTEX-FIX-NEXT:    mov lr, r0
 ; CHECK-CORTEX-FIX-NEXT:    b .LBB37_5
 ; CHECK-CORTEX-FIX-NEXT:  .LBB37_3:
 ; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d16[0]}, [r1:32]
 ; CHECK-CORTEX-FIX-NEXT:    add r2, r1, #8
 ; CHECK-CORTEX-FIX-NEXT:    add r3, r1, #4
-; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d17[0]}, [r2:32]
+; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d18[0]}, [r2:32]
 ; CHECK-CORTEX-FIX-NEXT:    add r2, r1, #12
 ; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d16[1]}, [r3:32]
-; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d17[1]}, [r2:32]
+; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d18[1]}, [r2:32]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d16[0]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d16[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d16[3]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d17[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d17[3]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #8] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d17[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 lr, d16[3]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d18[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d18[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d18[3]
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d18[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov s2, r2
 ; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d17[1]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    beq .LBB37_2
 ; CHECK-CORTEX-FIX-NEXT:  .LBB37_4:
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d2[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d2[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d2[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r4, d2[3]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r9, d3[0]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d3[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d3[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r9, d3[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r5, d3[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r12, d3[3]
 ; CHECK-CORTEX-FIX-NEXT:  .LBB37_5:
-; CHECK-CORTEX-FIX-NEXT:    pkhbt lr, r11, r6, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, r7, r10, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    ldm sp, {r6, r7} @ 8-byte Folded Reload
 ; CHECK-CORTEX-FIX-NEXT:    pkhbt r3, r3, r4, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov r4, s2
+; CHECK-CORTEX-FIX-NEXT:    ldr r0, [sp] @ 4-byte Reload
 ; CHECK-CORTEX-FIX-NEXT:    pkhbt r5, r5, r12, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r2, r9, r2, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r4, r7, r6, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    vmov r7, s2
-; CHECK-CORTEX-FIX-NEXT:    ldr r6, [sp, #8] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r7, r7, r6, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    vmov r6, s0
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[0], r7
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[0], r4
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[1], r0
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[1], lr
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r6, r6, r8, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[0], r6
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[0], r2
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r6, r11, r6, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r4, r4, r0, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov r0, s0
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[0], r4
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[0], r6
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, r0, r2, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r2, r7, lr, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[0], r0
+; CHECK-CORTEX-FIX-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[1], r2
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, r0, r10, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[1], r0
 ; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[1], r3
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r3, r8, r9, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[0], r3
 ; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[1], r5
 ; CHECK-CORTEX-FIX-NEXT:    aese.8 q9, q8
 ; CHECK-CORTEX-FIX-NEXT:    aesmc.8 q8, q9
 ; CHECK-CORTEX-FIX-NEXT:    vst1.64 {d16, d17}, [r1]
-; CHECK-CORTEX-FIX-NEXT:    add sp, sp, #12
+; CHECK-CORTEX-FIX-NEXT:    add sp, sp, #8
 ; CHECK-CORTEX-FIX-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
   br i1 %0, label %5, label %11
 
@@ -3541,20 +3535,20 @@ define arm_aapcs_vfpcc void @aesd_setf16_cond_via_ptr(i1 zeroext %0, ptr %1, <16
 ; CHECK-FIX-NOSCHED-NEXT:  .LBB82_3:
 ; CHECK-FIX-NOSCHED-NEXT:    add r3, r2, #8
 ; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d16[0]}, [r2:32]
-; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d17[0]}, [r3:32]
+; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d18[0]}, [r3:32]
 ; CHECK-FIX-NOSCHED-NEXT:    add r3, r2, #4
 ; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d16[1]}, [r3:32]
 ; CHECK-FIX-NOSCHED-NEXT:    add r3, r2, #12
-; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d17[1]}, [r3:32]
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d17[3]
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r9, d17[0]
+; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d18[1]}, [r3:32]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d18[3]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r9, d18[0]
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r10, d16[3]
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r11, d16[2]
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r7, d16[0]
 ; CHECK-FIX-NOSCHED-NEXT:    str r3, [sp, #8] @ 4-byte Spill
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d17[2]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d18[2]
 ; CHECK-FIX-NOSCHED-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d17[1]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d18[1]
 ; CHECK-FIX-NOSCHED-NEXT:    str r3, [sp] @ 4-byte Spill
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r3, d16[1]
 ; CHECK-FIX-NOSCHED-NEXT:    cmp r0, #0
@@ -3598,91 +3592,85 @@ define arm_aapcs_vfpcc void @aesd_setf16_cond_via_ptr(i1 zeroext %0, ptr %1, <16
 ; CHECK-CORTEX-FIX:       @ %bb.0:
 ; CHECK-CORTEX-FIX-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 ; CHECK-CORTEX-FIX-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-CORTEX-FIX-NEXT:    .pad #24
-; CHECK-CORTEX-FIX-NEXT:    sub sp, sp, #24
+; CHECK-CORTEX-FIX-NEXT:    .pad #16
+; CHECK-CORTEX-FIX-NEXT:    sub sp, sp, #16
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    beq .LBB82_3
 ; CHECK-CORTEX-FIX-NEXT:  @ %bb.1:
 ; CHECK-CORTEX-FIX-NEXT:    vld1.64 {d16, d17}, [r2]
+; CHECK-CORTEX-FIX-NEXT:    ldrh r11, [r1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[1]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d17[0]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d17[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r4, d17[3]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #20] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d17[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d17[3]
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[2]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #8] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[3]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d17[1]
+; CHECK-CORTEX-FIX-NEXT:    str r7, [sp, #4] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #12] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    ldrh r3, [r1]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #16] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    mov r3, r6
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[3]
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #8] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d17[1]
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    bne .LBB82_4
 ; CHECK-CORTEX-FIX-NEXT:  .LBB82_2:
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r0, d0[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r4, d0[0]
 ; CHECK-CORTEX-FIX-NEXT:    b .LBB82_5
 ; CHECK-CORTEX-FIX-NEXT:  .LBB82_3:
 ; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d16[0]}, [r2:32]
 ; CHECK-CORTEX-FIX-NEXT:    add r3, r2, #8
 ; CHECK-CORTEX-FIX-NEXT:    add r7, r2, #4
-; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d17[0]}, [r3:32]
+; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d18[0]}, [r3:32]
 ; CHECK-CORTEX-FIX-NEXT:    add r3, r2, #12
 ; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d16[1]}, [r7:32]
-; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d17[1]}, [r3:32]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[0]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d17[1]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r4, d17[3]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #16] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d18[1]}, [r3:32]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[1]
-; CHECK-CORTEX-FIX-NEXT:    str r7, [sp, #12] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d17[2]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #20] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d16[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d18[2]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d18[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d18[3]
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[2]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #8] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    str r7, [sp, #4] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #12] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[3]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d17[0]
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #8] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d18[1]
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    beq .LBB82_2
 ; CHECK-CORTEX-FIX-NEXT:  .LBB82_4:
-; CHECK-CORTEX-FIX-NEXT:    ldrh r0, [r1]
+; CHECK-CORTEX-FIX-NEXT:    ldrh r4, [r1]
 ; CHECK-CORTEX-FIX-NEXT:  .LBB82_5:
-; CHECK-CORTEX-FIX-NEXT:    str r0, [sp] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    ldr r0, [sp, #8] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    ldr r1, [sp, #4] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r9, r7, r4, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    ldr r4, [sp, #20] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d0[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r5, d0[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d0[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r12, d0[3]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d1[0]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r5, d1[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r9, d1[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r1, d1[1]
+; CHECK-CORTEX-FIX-NEXT:    ldr r0, [sp] @ 4-byte Reload
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 lr, d1[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d1[3]
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r7, r0, r1, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    ldr r1, [sp, #12] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, lr, r8, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d1[3]
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r3, r8, r3, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, r11, r0, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r5, r4, r5, lsl #16
 ; CHECK-CORTEX-FIX-NEXT:    pkhbt r6, r6, r12, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r5, r11, r5, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r1, r3, r1, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    ldr r3, [sp, #16] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r4, r3, r4, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    ldr r3, [sp] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[0], r4
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[0], r1
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[1], r7
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[1], r9
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r3, r3, r10, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[0], r3
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[0], r5
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r1, r9, r1, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[0], r0
+; CHECK-CORTEX-FIX-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[0], r3
+; CHECK-CORTEX-FIX-NEXT:    ldr r3, [sp, #12] @ 4-byte Reload
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r7, lr, r7, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[0], r5
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, r0, r10, lsl #16
 ; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[1], r6
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[1], r0
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[0], r1
+; CHECK-CORTEX-FIX-NEXT:    ldr r6, [sp, #8] @ 4-byte Reload
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r3, r3, r6, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[1], r3
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[1], r0
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[1], r7
 ; CHECK-CORTEX-FIX-NEXT:    aesd.8 q9, q8
 ; CHECK-CORTEX-FIX-NEXT:    aesimc.8 q8, q9
 ; CHECK-CORTEX-FIX-NEXT:    vst1.64 {d16, d17}, [r2]
-; CHECK-CORTEX-FIX-NEXT:    add sp, sp, #24
+; CHECK-CORTEX-FIX-NEXT:    add sp, sp, #16
 ; CHECK-CORTEX-FIX-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
   br i1 %0, label %5, label %12
 
@@ -3752,18 +3740,18 @@ define arm_aapcs_vfpcc void @aesd_setf16_cond_via_val(i1 zeroext %0, half %1, <1
 ; CHECK-FIX-NOSCHED-NEXT:  .LBB83_2:
 ; CHECK-FIX-NOSCHED-NEXT:    add r2, r1, #8
 ; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d16[0]}, [r1:32]
-; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d17[0]}, [r2:32]
+; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d18[0]}, [r2:32]
 ; CHECK-FIX-NOSCHED-NEXT:    add r2, r1, #4
 ; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d16[1]}, [r2:32]
 ; CHECK-FIX-NOSCHED-NEXT:    add r2, r1, #12
-; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d17[1]}, [r2:32]
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r2, d17[1]
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r7, d17[3]
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 lr, d17[2]
+; CHECK-FIX-NOSCHED-NEXT:    vld1.32 {d18[1]}, [r2:32]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r2, d18[1]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r7, d18[3]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 lr, d18[2]
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r11, d16[2]
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r8, d16[1]
 ; CHECK-FIX-NOSCHED-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r2, d17[0]
+; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r2, d18[0]
 ; CHECK-FIX-NOSCHED-NEXT:    str r2, [sp, #4] @ 4-byte Spill
 ; CHECK-FIX-NOSCHED-NEXT:    vmov.u16 r2, d16[3]
 ; CHECK-FIX-NOSCHED-NEXT:    str r2, [sp] @ 4-byte Spill
@@ -3819,8 +3807,8 @@ define arm_aapcs_vfpcc void @aesd_setf16_cond_via_val(i1 zeroext %0, half %1, <1
 ; CHECK-CORTEX-FIX:       @ %bb.0:
 ; CHECK-CORTEX-FIX-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 ; CHECK-CORTEX-FIX-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-CORTEX-FIX-NEXT:    .pad #12
-; CHECK-CORTEX-FIX-NEXT:    sub sp, sp, #12
+; CHECK-CORTEX-FIX-NEXT:    .pad #8
+; CHECK-CORTEX-FIX-NEXT:    sub sp, sp, #8
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    beq .LBB83_3
 ; CHECK-CORTEX-FIX-NEXT:  @ %bb.1:
@@ -3828,82 +3816,82 @@ define arm_aapcs_vfpcc void @aesd_setf16_cond_via_val(i1 zeroext %0, half %1, <1
 ; CHECK-CORTEX-FIX-NEXT:    vmov.f32 s2, s0
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d16[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d16[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d16[3]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d17[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d17[3]
-; CHECK-CORTEX-FIX-NEXT:    str r2, [sp, #8] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d17[0]
-; CHECK-CORTEX-FIX-NEXT:    str r2, [sp, #4] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d17[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 lr, d16[3]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d17[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d17[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d17[3]
 ; CHECK-CORTEX-FIX-NEXT:    str r2, [sp] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d17[2]
+; CHECK-CORTEX-FIX-NEXT:    str r2, [sp, #4] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    bne .LBB83_4
 ; CHECK-CORTEX-FIX-NEXT:  .LBB83_2:
+; CHECK-CORTEX-FIX-NEXT:    mov r0, lr
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 lr, d2[0]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d2[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d2[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d2[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r4, d2[3]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r9, d3[0]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d3[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d3[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r9, d3[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r5, d3[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r12, d3[3]
 ; CHECK-CORTEX-FIX-NEXT:    vmov s0, lr
+; CHECK-CORTEX-FIX-NEXT:    mov lr, r0
 ; CHECK-CORTEX-FIX-NEXT:    b .LBB83_5
 ; CHECK-CORTEX-FIX-NEXT:  .LBB83_3:
 ; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d16[0]}, [r1:32]
 ; CHECK-CORTEX-FIX-NEXT:    add r2, r1, #8
 ; CHECK-CORTEX-FIX-NEXT:    add r3, r1, #4
-; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d17[0]}, [r2:32]
+; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d18[0]}, [r2:32]
 ; CHECK-CORTEX-FIX-NEXT:    add r2, r1, #12
 ; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d16[1]}, [r3:32]
-; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d17[1]}, [r2:32]
+; CHECK-CORTEX-FIX-NEXT:    vld1.32 {d18[1]}, [r2:32]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d16[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d16[0]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r7, d16[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d16[3]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d17[2]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d17[3]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #8] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d17[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 lr, d16[3]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r11, d18[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r6, d18[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r10, d18[3]
+; CHECK-CORTEX-FIX-NEXT:    str r3, [sp] @ 4-byte Spill
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d18[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov s2, r2
 ; CHECK-CORTEX-FIX-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d17[1]
-; CHECK-CORTEX-FIX-NEXT:    str r3, [sp] @ 4-byte Spill
 ; CHECK-CORTEX-FIX-NEXT:    cmp r0, #0
 ; CHECK-CORTEX-FIX-NEXT:    beq .LBB83_2
 ; CHECK-CORTEX-FIX-NEXT:  .LBB83_4:
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d2[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d2[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r3, d2[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r4, d2[3]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r9, d3[0]
-; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r2, d3[1]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r8, d3[0]
+; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r9, d3[1]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r5, d3[2]
 ; CHECK-CORTEX-FIX-NEXT:    vmov.u16 r12, d3[3]
 ; CHECK-CORTEX-FIX-NEXT:  .LBB83_5:
-; CHECK-CORTEX-FIX-NEXT:    pkhbt lr, r11, r6, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, r7, r10, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    ldm sp, {r6, r7} @ 8-byte Folded Reload
 ; CHECK-CORTEX-FIX-NEXT:    pkhbt r3, r3, r4, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov r4, s2
+; CHECK-CORTEX-FIX-NEXT:    ldr r0, [sp] @ 4-byte Reload
 ; CHECK-CORTEX-FIX-NEXT:    pkhbt r5, r5, r12, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r2, r9, r2, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r4, r7, r6, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    vmov r7, s2
-; CHECK-CORTEX-FIX-NEXT:    ldr r6, [sp, #8] @ 4-byte Reload
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r7, r7, r6, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    vmov r6, s0
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[0], r7
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[0], r4
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[1], r0
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[1], lr
-; CHECK-CORTEX-FIX-NEXT:    pkhbt r6, r6, r8, lsl #16
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[0], r6
-; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[0], r2
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r6, r11, r6, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r4, r4, r0, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov r0, s0
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[0], r4
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[0], r6
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, r0, r2, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r2, r7, lr, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[0], r0
+; CHECK-CORTEX-FIX-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d18[1], r2
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r0, r0, r10, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d19[1], r0
 ; CHECK-CORTEX-FIX-NEXT:    vmov.32 d16[1], r3
+; CHECK-CORTEX-FIX-NEXT:    pkhbt r3, r8, r9, lsl #16
+; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[0], r3
 ; CHECK-CORTEX-FIX-NEXT:    vmov.32 d17[1], r5
 ; CHECK-CORTEX-FIX-NEXT:    aesd.8 q9, q8
 ; CHECK-CORTEX-FIX-NEXT:    aesimc.8 q8, q9
 ; CHECK-CORTEX-FIX-NEXT:    vst1.64 {d16, d17}, [r1]
-; CHECK-CORTEX-FIX-NEXT:    add sp, sp, #12
+; CHECK-CORTEX-FIX-NEXT:    add sp, sp, #8
 ; CHECK-CORTEX-FIX-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
   br i1 %0, label %5, label %11
 

--- a/llvm/test/CodeGen/ARM/bf16-create-get-set-dup.ll
+++ b/llvm/test/CodeGen/ARM/bf16-create-get-set-dup.ll
@@ -83,9 +83,10 @@ entry:
 define arm_aapcs_vfpcc <8 x bfloat> @test_vcombine_bf16(<4 x bfloat> %low, <4 x bfloat> %high) {
 ; CHECK-LABEL: test_vcombine_bf16:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vmov.f64 d16, d1
-; CHECK-NEXT:    vorr d17, d0, d0
-; CHECK-NEXT:    vorr q0, q8, q8
+; CHECK-NEXT:    @ kill: def $d1 killed $d1 def $d1_d2
+; CHECK-NEXT:    vmov.f64 d2, d0
+; CHECK-NEXT:    vmov.f64 d0, d1
+; CHECK-NEXT:    vmov.f64 d1, d2
 ; CHECK-NEXT:    bx lr
 entry:
   %shuffle.i = shufflevector <4 x bfloat> %high, <4 x bfloat> %low, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>

--- a/llvm/test/CodeGen/ARM/bf16-shuffle.ll
+++ b/llvm/test/CodeGen/ARM/bf16-shuffle.ll
@@ -324,49 +324,49 @@ entry:
 define arm_aapcs_vfpcc <8 x bfloat> @shuffle3step1_bf16(<32 x bfloat> %src) {
 ; CHECK-NOFP16-LABEL: shuffle3step1_bf16:
 ; CHECK-NOFP16:       @ %bb.0: @ %entry
-; CHECK-NOFP16-NEXT:    vorr q3, q0, q0
-; CHECK-NOFP16-NEXT:    vmov.u16 r1, d6[1]
-; CHECK-NOFP16-NEXT:    vmov r0, s14
-; CHECK-NOFP16-NEXT:    vmov.16 d0[0], r1
-; CHECK-NOFP16-NEXT:    vmov.16 d0[1], r0
-; CHECK-NOFP16-NEXT:    vmov.u16 r0, d7[3]
-; CHECK-NOFP16-NEXT:    vmov.16 d0[2], r0
+; CHECK-NOFP16-NEXT:    vmov.u16 r1, d0[1]
+; CHECK-NOFP16-NEXT:    vmov r0, s2
+; CHECK-NOFP16-NEXT:    vmov.16 d16[0], r1
+; CHECK-NOFP16-NEXT:    vmov.16 d16[1], r0
+; CHECK-NOFP16-NEXT:    vmov.u16 r0, d1[3]
+; CHECK-NOFP16-NEXT:    vdup.16 q0, d3[1]
+; CHECK-NOFP16-NEXT:    vmov r1, s0
+; CHECK-NOFP16-NEXT:    vmov.16 d16[2], r0
 ; CHECK-NOFP16-NEXT:    vmov r0, s5
-; CHECK-NOFP16-NEXT:    vdup.16 q1, d3[1]
-; CHECK-NOFP16-NEXT:    vmov r1, s4
-; CHECK-NOFP16-NEXT:    vmov.16 d0[3], r0
+; CHECK-NOFP16-NEXT:    vmov.16 d16[3], r0
 ; CHECK-NOFP16-NEXT:    vmov r0, s8
-; CHECK-NOFP16-NEXT:    vmov.16 d1[0], r1
-; CHECK-NOFP16-NEXT:    vmov.16 d1[1], r0
+; CHECK-NOFP16-NEXT:    vmov.16 d17[0], r1
+; CHECK-NOFP16-NEXT:    vmov.16 d17[1], r0
 ; CHECK-NOFP16-NEXT:    vmov.u16 r0, d4[3]
-; CHECK-NOFP16-NEXT:    vmov.16 d1[2], r0
+; CHECK-NOFP16-NEXT:    vmov.16 d17[2], r0
 ; CHECK-NOFP16-NEXT:    vmov r0, s11
-; CHECK-NOFP16-NEXT:    vmov.16 d1[3], r0
+; CHECK-NOFP16-NEXT:    vmov.16 d17[3], r0
+; CHECK-NOFP16-NEXT:    vorr q0, q8, q8
 ; CHECK-NOFP16-NEXT:    bx lr
 ;
 ; CHECK-FP16-LABEL: shuffle3step1_bf16:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    vorr q3, q0, q0
-; CHECK-FP16-NEXT:    vmovx.f16 s0, s12
-; CHECK-FP16-NEXT:    vmovx.f16 s12, s15
+; CHECK-FP16-NEXT:    vmovx.f16 s12, s0
+; CHECK-FP16-NEXT:    vmov r0, s2
+; CHECK-FP16-NEXT:    vmov r1, s12
+; CHECK-FP16-NEXT:    vmovx.f16 s0, s3
+; CHECK-FP16-NEXT:    vmov.16 d16[0], r1
+; CHECK-FP16-NEXT:    vmov.16 d16[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s0
+; CHECK-FP16-NEXT:    vdup.16 q0, d3[1]
 ; CHECK-FP16-NEXT:    vmov r1, s0
-; CHECK-FP16-NEXT:    vmov r0, s14
-; CHECK-FP16-NEXT:    vmov.16 d0[0], r1
-; CHECK-FP16-NEXT:    vmov.16 d0[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s12
-; CHECK-FP16-NEXT:    vmov.16 d0[2], r0
+; CHECK-FP16-NEXT:    vmovx.f16 s0, s9
+; CHECK-FP16-NEXT:    vmov.16 d16[2], r0
 ; CHECK-FP16-NEXT:    vmov r0, s5
-; CHECK-FP16-NEXT:    vdup.16 q1, d3[1]
-; CHECK-FP16-NEXT:    vmov r1, s4
-; CHECK-FP16-NEXT:    vmovx.f16 s4, s9
-; CHECK-FP16-NEXT:    vmov.16 d0[3], r0
+; CHECK-FP16-NEXT:    vmov.16 d16[3], r0
 ; CHECK-FP16-NEXT:    vmov r0, s8
-; CHECK-FP16-NEXT:    vmov.16 d1[0], r1
-; CHECK-FP16-NEXT:    vmov.16 d1[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s4
-; CHECK-FP16-NEXT:    vmov.16 d1[2], r0
+; CHECK-FP16-NEXT:    vmov.16 d17[0], r1
+; CHECK-FP16-NEXT:    vmov.16 d17[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s0
+; CHECK-FP16-NEXT:    vmov.16 d17[2], r0
 ; CHECK-FP16-NEXT:    vmov r0, s11
-; CHECK-FP16-NEXT:    vmov.16 d1[3], r0
+; CHECK-FP16-NEXT:    vmov.16 d17[3], r0
+; CHECK-FP16-NEXT:    vorr q0, q8, q8
 ; CHECK-FP16-NEXT:    bx lr
 entry:
   %s1 = shufflevector <32 x bfloat> %src, <32 x bfloat> undef, <8 x i32> <i32 1, i32 4, i32 7, i32 10, i32 13, i32 16, i32 19, i32 22>

--- a/llvm/test/CodeGen/ARM/big-endian-vector-callee.ll
+++ b/llvm/test/CodeGen/ARM/big-endian-vector-callee.ll
@@ -1285,10 +1285,10 @@ define <2 x double> @test_v2f64_f128(fp128 %p) {
 ; SOFT-NEXT:    sub sp, sp, #16
 ; SOFT-NEXT:    stm sp, {r0, r1, r2, r3}
 ; SOFT-NEXT:    bl __addtf3
-; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[0], r0
-; SOFT-NEXT:    vmov.32 d17[1], r3
+; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[1], r1
+; SOFT-NEXT:    vmov.32 d17[1], r3
 ; SOFT-NEXT:    vrev64.32 q8, q8
 ; SOFT-NEXT:    vadd.f64 d18, d16, d16
 ; SOFT-NEXT:    vadd.f64 d16, d17, d17
@@ -1305,10 +1305,10 @@ define <2 x double> @test_v2f64_f128(fp128 %p) {
 ; HARD-NEXT:    sub sp, sp, #16
 ; HARD-NEXT:    stm sp, {r0, r1, r2, r3}
 ; HARD-NEXT:    bl __addtf3
-; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[0], r0
-; HARD-NEXT:    vmov.32 d17[1], r3
+; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[1], r1
+; HARD-NEXT:    vmov.32 d17[1], r3
 ; HARD-NEXT:    vrev64.32 q8, q8
 ; HARD-NEXT:    vadd.f64 d1, d17, d17
 ; HARD-NEXT:    vadd.f64 d0, d16, d16
@@ -1465,10 +1465,10 @@ define <2 x i64> @test_v2i64_f128(fp128 %p) {
 ; SOFT-NEXT:    sub sp, sp, #16
 ; SOFT-NEXT:    stm sp, {r0, r1, r2, r3}
 ; SOFT-NEXT:    bl __addtf3
-; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[0], r0
-; SOFT-NEXT:    vmov.32 d17[1], r3
+; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[1], r1
+; SOFT-NEXT:    vmov.32 d17[1], r3
 ; SOFT-NEXT:    vrev64.32 q8, q8
 ; SOFT-NEXT:    vadd.i64 q8, q8, q8
 ; SOFT-NEXT:    vmov r1, r0, d16
@@ -1484,10 +1484,10 @@ define <2 x i64> @test_v2i64_f128(fp128 %p) {
 ; HARD-NEXT:    sub sp, sp, #16
 ; HARD-NEXT:    stm sp, {r0, r1, r2, r3}
 ; HARD-NEXT:    bl __addtf3
-; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[0], r0
-; HARD-NEXT:    vmov.32 d17[1], r3
+; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[1], r1
+; HARD-NEXT:    vmov.32 d17[1], r3
 ; HARD-NEXT:    vrev64.32 q8, q8
 ; HARD-NEXT:    vadd.i64 q0, q8, q8
 ; HARD-NEXT:    add sp, sp, #16
@@ -1635,10 +1635,10 @@ define <4 x float> @test_v4f32_f128(fp128 %p) {
 ; SOFT-NEXT:    sub sp, sp, #16
 ; SOFT-NEXT:    stm sp, {r0, r1, r2, r3}
 ; SOFT-NEXT:    bl __addtf3
-; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[0], r0
-; SOFT-NEXT:    vmov.32 d17[1], r3
+; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[1], r1
+; SOFT-NEXT:    vmov.32 d17[1], r3
 ; SOFT-NEXT:    vadd.f32 q8, q8, q8
 ; SOFT-NEXT:    vrev64.32 q8, q8
 ; SOFT-NEXT:    vmov r1, r0, d16
@@ -1654,10 +1654,10 @@ define <4 x float> @test_v4f32_f128(fp128 %p) {
 ; HARD-NEXT:    sub sp, sp, #16
 ; HARD-NEXT:    stm sp, {r0, r1, r2, r3}
 ; HARD-NEXT:    bl __addtf3
-; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[0], r0
-; HARD-NEXT:    vmov.32 d17[1], r3
+; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[1], r1
+; HARD-NEXT:    vmov.32 d17[1], r3
 ; HARD-NEXT:    vadd.f32 q8, q8, q8
 ; HARD-NEXT:    vrev64.32 q0, q8
 ; HARD-NEXT:    add sp, sp, #16
@@ -1813,10 +1813,10 @@ define <4 x i32> @test_v4i32_f128(fp128 %p) {
 ; SOFT-NEXT:    sub sp, sp, #16
 ; SOFT-NEXT:    stm sp, {r0, r1, r2, r3}
 ; SOFT-NEXT:    bl __addtf3
-; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[0], r0
-; SOFT-NEXT:    vmov.32 d17[1], r3
+; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[1], r1
+; SOFT-NEXT:    vmov.32 d17[1], r3
 ; SOFT-NEXT:    vadd.i32 q8, q8, q8
 ; SOFT-NEXT:    vrev64.32 q8, q8
 ; SOFT-NEXT:    vmov r1, r0, d16
@@ -1832,10 +1832,10 @@ define <4 x i32> @test_v4i32_f128(fp128 %p) {
 ; HARD-NEXT:    sub sp, sp, #16
 ; HARD-NEXT:    stm sp, {r0, r1, r2, r3}
 ; HARD-NEXT:    bl __addtf3
-; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[0], r0
-; HARD-NEXT:    vmov.32 d17[1], r3
+; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[1], r1
+; HARD-NEXT:    vmov.32 d17[1], r3
 ; HARD-NEXT:    vadd.i32 q8, q8, q8
 ; HARD-NEXT:    vrev64.32 q0, q8
 ; HARD-NEXT:    add sp, sp, #16
@@ -1991,10 +1991,10 @@ define <8 x i16> @test_v8i16_f128(fp128 %p) {
 ; SOFT-NEXT:    sub sp, sp, #16
 ; SOFT-NEXT:    stm sp, {r0, r1, r2, r3}
 ; SOFT-NEXT:    bl __addtf3
-; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[0], r0
-; SOFT-NEXT:    vmov.32 d17[1], r3
+; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[1], r1
+; SOFT-NEXT:    vmov.32 d17[1], r3
 ; SOFT-NEXT:    vrev32.16 q8, q8
 ; SOFT-NEXT:    vadd.i16 q8, q8, q8
 ; SOFT-NEXT:    vrev64.16 q8, q8
@@ -2011,10 +2011,10 @@ define <8 x i16> @test_v8i16_f128(fp128 %p) {
 ; HARD-NEXT:    sub sp, sp, #16
 ; HARD-NEXT:    stm sp, {r0, r1, r2, r3}
 ; HARD-NEXT:    bl __addtf3
-; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[0], r0
-; HARD-NEXT:    vmov.32 d17[1], r3
+; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[1], r1
+; HARD-NEXT:    vmov.32 d17[1], r3
 ; HARD-NEXT:    vrev32.16 q8, q8
 ; HARD-NEXT:    vadd.i16 q8, q8, q8
 ; HARD-NEXT:    vrev64.16 q0, q8
@@ -2173,10 +2173,10 @@ define <16 x i8> @test_v16i8_f128(fp128 %p) {
 ; SOFT-NEXT:    sub sp, sp, #16
 ; SOFT-NEXT:    stm sp, {r0, r1, r2, r3}
 ; SOFT-NEXT:    bl __addtf3
-; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[0], r0
-; SOFT-NEXT:    vmov.32 d17[1], r3
+; SOFT-NEXT:    vmov.32 d17[0], r2
 ; SOFT-NEXT:    vmov.32 d16[1], r1
+; SOFT-NEXT:    vmov.32 d17[1], r3
 ; SOFT-NEXT:    vrev32.8 q8, q8
 ; SOFT-NEXT:    vadd.i8 q8, q8, q8
 ; SOFT-NEXT:    vrev64.8 q8, q8
@@ -2193,10 +2193,10 @@ define <16 x i8> @test_v16i8_f128(fp128 %p) {
 ; HARD-NEXT:    sub sp, sp, #16
 ; HARD-NEXT:    stm sp, {r0, r1, r2, r3}
 ; HARD-NEXT:    bl __addtf3
-; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[0], r0
-; HARD-NEXT:    vmov.32 d17[1], r3
+; HARD-NEXT:    vmov.32 d17[0], r2
 ; HARD-NEXT:    vmov.32 d16[1], r1
+; HARD-NEXT:    vmov.32 d17[1], r3
 ; HARD-NEXT:    vrev32.8 q8, q8
 ; HARD-NEXT:    vadd.i8 q8, q8, q8
 ; HARD-NEXT:    vrev64.8 q0, q8

--- a/llvm/test/CodeGen/ARM/div-by-constant-to-mul-crash.ll
+++ b/llvm/test/CodeGen/ARM/div-by-constant-to-mul-crash.ll
@@ -8,44 +8,44 @@ define <8 x i32> @f1(<8 x i32> %arg) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, r7, r11, lr}
-; CHECK-NEXT:    vmov r0, r2, d2
+; CHECK-NEXT:    vmov r0, r2, d3
 ; CHECK-NEXT:    movw r4, #60681
-; CHECK-NEXT:    vmov lr, r1, d0
+; CHECK-NEXT:    vmov lr, r1, d1
 ; CHECK-NEXT:    movt r4, #46117
-; CHECK-NEXT:    vmov r12, r3, d3
+; CHECK-NEXT:    vmov r12, r3, d2
 ; CHECK-NEXT:    smmul r5, r0, r4
 ; CHECK-NEXT:    smmul r7, r2, r4
 ; CHECK-NEXT:    smmul r6, r1, r4
 ; CHECK-NEXT:    asr r2, r5, #4
 ; CHECK-NEXT:    smmul r1, r3, r4
 ; CHECK-NEXT:    add r2, r2, r5, lsr #31
-; CHECK-NEXT:    vmov r3, r5, d1
+; CHECK-NEXT:    vmov r3, r5, d0
 ; CHECK-NEXT:    smmul r0, lr, r4
-; CHECK-NEXT:    vmov.32 d2[0], r2
+; CHECK-NEXT:    vmov.32 d3[0], r2
 ; CHECK-NEXT:    smmul r5, r5, r4
 ; CHECK-NEXT:    smmul r3, r3, r4
 ; CHECK-NEXT:    smmul r4, r12, r4
 ; CHECK-NEXT:    asr r2, r4, #4
 ; CHECK-NEXT:    add r2, r2, r4, lsr #31
 ; CHECK-NEXT:    asr r4, r3, #4
-; CHECK-NEXT:    vmov.32 d3[0], r2
+; CHECK-NEXT:    vmov.32 d2[0], r2
 ; CHECK-NEXT:    add r2, r4, r3, lsr #31
 ; CHECK-NEXT:    asr r3, r0, #4
 ; CHECK-NEXT:    add r0, r3, r0, lsr #31
-; CHECK-NEXT:    vmov.32 d1[0], r2
+; CHECK-NEXT:    vmov.32 d0[0], r2
 ; CHECK-NEXT:    asr r2, r5, #4
-; CHECK-NEXT:    vmov.32 d0[0], r0
+; CHECK-NEXT:    vmov.32 d1[0], r0
 ; CHECK-NEXT:    add r0, r2, r5, lsr #31
 ; CHECK-NEXT:    asr r2, r6, #4
-; CHECK-NEXT:    vmov.32 d1[1], r0
+; CHECK-NEXT:    vmov.32 d0[1], r0
 ; CHECK-NEXT:    add r0, r2, r6, lsr #31
 ; CHECK-NEXT:    asr r2, r1, #4
-; CHECK-NEXT:    vmov.32 d0[1], r0
+; CHECK-NEXT:    vmov.32 d1[1], r0
 ; CHECK-NEXT:    add r0, r2, r1, lsr #31
 ; CHECK-NEXT:    asr r1, r7, #4
-; CHECK-NEXT:    vmov.32 d3[1], r0
-; CHECK-NEXT:    add r0, r1, r7, lsr #31
 ; CHECK-NEXT:    vmov.32 d2[1], r0
+; CHECK-NEXT:    add r0, r1, r7, lsr #31
+; CHECK-NEXT:    vmov.32 d3[1], r0
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r11, pc}
   %v = sdiv <8 x i32> %arg, <i32 -54, i32 -54, i32 -54, i32 -54, i32 -54, i32 -54, i32 -54, i32 -54>
   ret <8 x i32> %v

--- a/llvm/test/CodeGen/ARM/fp-intrinsics-vector-v8.ll
+++ b/llvm/test/CodeGen/ARM/fp-intrinsics-vector-v8.ll
@@ -130,8 +130,24 @@ define <4 x half> @ceil_v4f16(<4 x half> %x) #0 {
 define <8 x half> @nearbyint_v8f16(<8 x half> %x) #0 {
 ; CHECK-LABEL: nearbyint_v8f16:
 ; CHECK:       @ %bb.0:
+; CHECK-NEXT:    vmovx.f16 s4, s0
+; CHECK-NEXT:    vrintr.f16 s4, s4
+; CHECK-NEXT:    vmov r0, s4
+; CHECK-NEXT:    vrintr.f16 s4, s0
+; CHECK-NEXT:    vmov r1, s4
+; CHECK-NEXT:    vrintr.f16 s4, s1
+; CHECK-NEXT:    vmovx.f16 s0, s3
+; CHECK-NEXT:    vrintr.f16 s0, s0
+; CHECK-NEXT:    vmov.16 d16[0], r1
+; CHECK-NEXT:    vmov.16 d16[1], r0
+; CHECK-NEXT:    vmov r0, s4
+; CHECK-NEXT:    vmovx.f16 s4, s1
+; CHECK-NEXT:    vrintr.f16 s4, s4
+; CHECK-NEXT:    vmov.16 d16[2], r0
+; CHECK-NEXT:    vmov r0, s4
 ; CHECK-NEXT:    vmovx.f16 s4, s2
 ; CHECK-NEXT:    vrintr.f16 s4, s4
+; CHECK-NEXT:    vmov.16 d16[3], r0
 ; CHECK-NEXT:    vmov r0, s4
 ; CHECK-NEXT:    vrintr.f16 s4, s2
 ; CHECK-NEXT:    vmov r1, s4
@@ -139,25 +155,9 @@ define <8 x half> @nearbyint_v8f16(<8 x half> %x) #0 {
 ; CHECK-NEXT:    vmov.16 d17[0], r1
 ; CHECK-NEXT:    vmov.16 d17[1], r0
 ; CHECK-NEXT:    vmov r0, s4
-; CHECK-NEXT:    vmovx.f16 s4, s3
-; CHECK-NEXT:    vrintr.f16 s4, s4
 ; CHECK-NEXT:    vmov.16 d17[2], r0
-; CHECK-NEXT:    vmov r0, s4
-; CHECK-NEXT:    vmovx.f16 s4, s0
-; CHECK-NEXT:    vrintr.f16 s4, s4
-; CHECK-NEXT:    vmov.16 d17[3], r0
-; CHECK-NEXT:    vmov r0, s4
-; CHECK-NEXT:    vrintr.f16 s4, s0
-; CHECK-NEXT:    vmovx.f16 s0, s1
-; CHECK-NEXT:    vmov r1, s4
-; CHECK-NEXT:    vrintr.f16 s4, s1
-; CHECK-NEXT:    vrintr.f16 s0, s0
-; CHECK-NEXT:    vmov.16 d16[0], r1
-; CHECK-NEXT:    vmov.16 d16[1], r0
-; CHECK-NEXT:    vmov r0, s4
-; CHECK-NEXT:    vmov.16 d16[2], r0
 ; CHECK-NEXT:    vmov r0, s0
-; CHECK-NEXT:    vmov.16 d16[3], r0
+; CHECK-NEXT:    vmov.16 d17[3], r0
 ; CHECK-NEXT:    vorr q0, q8, q8
 ; CHECK-NEXT:    bx lr
   %val = call <8 x half> @llvm.experimental.constrained.nearbyint.v8f16(<8 x half> %x, metadata !"round.dynamic", metadata !"fpexcept.strict")

--- a/llvm/test/CodeGen/ARM/fp-intrinsics-vector.ll
+++ b/llvm/test/CodeGen/ARM/fp-intrinsics-vector.ll
@@ -69,18 +69,18 @@ define <4 x float> @fma_v4f32(<4 x float> %x, <4 x float> %y, <4 x float> %z) #0
 define <4 x i32> @fptosi_v4i32_v4f32(<4 x float> %x) #0 {
 ; CHECK-LABEL: fptosi_v4i32_v4f32:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vcvt.s32.f32 s4, s2
-; CHECK-NEXT:    vcvt.s32.f32 s6, s0
-; CHECK-NEXT:    vcvt.s32.f32 s0, s1
+; CHECK-NEXT:    vcvt.s32.f32 s4, s0
+; CHECK-NEXT:    vcvt.s32.f32 s6, s2
+; CHECK-NEXT:    vcvt.s32.f32 s0, s3
 ; CHECK-NEXT:    vmov r0, s4
-; CHECK-NEXT:    vcvt.s32.f32 s4, s3
-; CHECK-NEXT:    vmov.32 d17[0], r0
-; CHECK-NEXT:    vmov r0, s6
+; CHECK-NEXT:    vcvt.s32.f32 s4, s1
 ; CHECK-NEXT:    vmov.32 d16[0], r0
+; CHECK-NEXT:    vmov r0, s6
+; CHECK-NEXT:    vmov.32 d17[0], r0
 ; CHECK-NEXT:    vmov r0, s4
-; CHECK-NEXT:    vmov.32 d17[1], r0
-; CHECK-NEXT:    vmov r0, s0
 ; CHECK-NEXT:    vmov.32 d16[1], r0
+; CHECK-NEXT:    vmov r0, s0
+; CHECK-NEXT:    vmov.32 d17[1], r0
 ; CHECK-NEXT:    vorr q0, q8, q8
 ; CHECK-NEXT:    bx lr
   %val = call <4 x i32> @llvm.experimental.constrained.fptosi.v4i32.v4f32(<4 x float> %x, metadata !"fpexcept.strict") #0
@@ -90,18 +90,18 @@ define <4 x i32> @fptosi_v4i32_v4f32(<4 x float> %x) #0 {
 define <4 x i32> @fptoui_v4i32_v4f32(<4 x float> %x) #0 {
 ; CHECK-LABEL: fptoui_v4i32_v4f32:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    vcvt.u32.f32 s4, s2
-; CHECK-NEXT:    vcvt.u32.f32 s6, s0
-; CHECK-NEXT:    vcvt.u32.f32 s0, s1
+; CHECK-NEXT:    vcvt.u32.f32 s4, s0
+; CHECK-NEXT:    vcvt.u32.f32 s6, s2
+; CHECK-NEXT:    vcvt.u32.f32 s0, s3
 ; CHECK-NEXT:    vmov r0, s4
-; CHECK-NEXT:    vcvt.u32.f32 s4, s3
-; CHECK-NEXT:    vmov.32 d17[0], r0
-; CHECK-NEXT:    vmov r0, s6
+; CHECK-NEXT:    vcvt.u32.f32 s4, s1
 ; CHECK-NEXT:    vmov.32 d16[0], r0
+; CHECK-NEXT:    vmov r0, s6
+; CHECK-NEXT:    vmov.32 d17[0], r0
 ; CHECK-NEXT:    vmov r0, s4
-; CHECK-NEXT:    vmov.32 d17[1], r0
-; CHECK-NEXT:    vmov r0, s0
 ; CHECK-NEXT:    vmov.32 d16[1], r0
+; CHECK-NEXT:    vmov r0, s0
+; CHECK-NEXT:    vmov.32 d17[1], r0
 ; CHECK-NEXT:    vorr q0, q8, q8
 ; CHECK-NEXT:    bx lr
   %val = call <4 x i32> @llvm.experimental.constrained.fptoui.v4i32.v4f32(<4 x float> %x, metadata !"fpexcept.strict") #0
@@ -116,28 +116,28 @@ define <4 x i64> @fptosi_v4i64_v4f32(<4 x float> %x) #0 {
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, s19
+; CHECK-NEXT:    vmov r0, s18
 ; CHECK-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    vmov r1, s16
-; CHECK-NEXT:    vmov r5, s17
-; CHECK-NEXT:    vmov r6, s18
-; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    vmov r1, s17
+; CHECK-NEXT:    vmov r5, s16
+; CHECK-NEXT:    vmov r6, s19
+; CHECK-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEXT:    mov r0, r1
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov.32 d10[0], r0
+; CHECK-NEXT:    vmov.32 d11[0], r0
 ; CHECK-NEXT:    mov r0, r5
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEXT:    vmov.32 d10[0], r0
 ; CHECK-NEXT:    mov r0, r6
 ; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov.32 d8[0], r0
-; CHECK-NEXT:    vmov.32 d11[1], r5
-; CHECK-NEXT:    vmov.32 d9[1], r4
-; CHECK-NEXT:    vmov.32 d10[1], r7
-; CHECK-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    vmov.32 d10[1], r5
+; CHECK-NEXT:    vmov.32 d8[1], r4
+; CHECK-NEXT:    vmov.32 d11[1], r7
+; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    vorr q0, q5, q5
 ; CHECK-NEXT:    vorr q1, q4, q4
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11}
@@ -154,28 +154,28 @@ define <4 x i64> @fptoui_v4i64_v4f32(<4 x float> %x) #0 {
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, s19
+; CHECK-NEXT:    vmov r0, s18
 ; CHECK-NEXT:    bl __aeabi_f2ulz
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    vmov r1, s16
-; CHECK-NEXT:    vmov r5, s17
-; CHECK-NEXT:    vmov r6, s18
-; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    vmov r1, s17
+; CHECK-NEXT:    vmov r5, s16
+; CHECK-NEXT:    vmov r6, s19
+; CHECK-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEXT:    mov r0, r1
 ; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    vmov.32 d10[0], r0
+; CHECK-NEXT:    vmov.32 d11[0], r0
 ; CHECK-NEXT:    mov r0, r5
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEXT:    vmov.32 d10[0], r0
 ; CHECK-NEXT:    mov r0, r6
 ; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    vmov.32 d8[0], r0
-; CHECK-NEXT:    vmov.32 d11[1], r5
-; CHECK-NEXT:    vmov.32 d9[1], r4
-; CHECK-NEXT:    vmov.32 d10[1], r7
-; CHECK-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    vmov.32 d10[1], r5
+; CHECK-NEXT:    vmov.32 d8[1], r4
+; CHECK-NEXT:    vmov.32 d11[1], r7
+; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    vorr q0, q5, q5
 ; CHECK-NEXT:    vorr q1, q4, q4
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11}
@@ -601,10 +601,10 @@ define <4 x float> @trunc_v4f32(<4 x float> %x) #0 {
 define <4 x i1> @fcmp_v4f32(<4 x float> %x, <4 x float> %y) #0 {
 ; CHECK-LABEL: fcmp_v4f32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vcmp.f32 s3, s7
+; CHECK-NEXT:    vcmp.f32 s1, s5
 ; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vcmp.f32 s2, s6
+; CHECK-NEXT:    vcmp.f32 s0, s4
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    mov r3, #0
 ; CHECK-NEXT:    mov r0, #0
@@ -612,23 +612,23 @@ define <4 x i1> @fcmp_v4f32(<4 x float> %x, <4 x float> %y) #0 {
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    mvnne r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vcmp.f32 s0, s4
+; CHECK-NEXT:    vcmp.f32 s2, s6
 ; CHECK-NEXT:    movweq r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vcmp.f32 s1, s5
-; CHECK-NEXT:    vmov.32 d17[0], r2
+; CHECK-NEXT:    vcmp.f32 s3, s7
+; CHECK-NEXT:    vmov.32 d16[0], r2
 ; CHECK-NEXT:    movweq r3, #1
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    mvnne r3, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vmov.32 d16[0], r3
-; CHECK-NEXT:    vmov.32 d17[1], r1
+; CHECK-NEXT:    vmov.32 d17[0], r3
+; CHECK-NEXT:    vmov.32 d16[1], r1
 ; CHECK-NEXT:    movweq r0, #1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vmov.32 d16[1], r0
+; CHECK-NEXT:    vmov.32 d17[1], r0
 ; CHECK-NEXT:    vmovn.i32 d0, q8
 ; CHECK-NEXT:    bx lr
 entry:
@@ -639,10 +639,10 @@ entry:
 define <4 x i1> @fcmps_v4f32(<4 x float> %x, <4 x float> %y) #0 {
 ; CHECK-LABEL: fcmps_v4f32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vcmpe.f32 s3, s7
+; CHECK-NEXT:    vcmpe.f32 s1, s5
 ; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vcmpe.f32 s2, s6
+; CHECK-NEXT:    vcmpe.f32 s0, s4
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    mov r3, #0
 ; CHECK-NEXT:    mov r0, #0
@@ -650,23 +650,23 @@ define <4 x i1> @fcmps_v4f32(<4 x float> %x, <4 x float> %y) #0 {
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    mvnne r1, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vcmpe.f32 s0, s4
+; CHECK-NEXT:    vcmpe.f32 s2, s6
 ; CHECK-NEXT:    movweq r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vcmpe.f32 s1, s5
-; CHECK-NEXT:    vmov.32 d17[0], r2
+; CHECK-NEXT:    vcmpe.f32 s3, s7
+; CHECK-NEXT:    vmov.32 d16[0], r2
 ; CHECK-NEXT:    movweq r3, #1
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    mvnne r3, #0
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
-; CHECK-NEXT:    vmov.32 d16[0], r3
-; CHECK-NEXT:    vmov.32 d17[1], r1
+; CHECK-NEXT:    vmov.32 d17[0], r3
+; CHECK-NEXT:    vmov.32 d16[1], r1
 ; CHECK-NEXT:    movweq r0, #1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vmov.32 d16[1], r0
+; CHECK-NEXT:    vmov.32 d17[1], r0
 ; CHECK-NEXT:    vmovn.i32 d0, q8
 ; CHECK-NEXT:    bx lr
 entry:
@@ -767,16 +767,16 @@ define <2 x i64> @fptosi_v2i64_v2f64(<2 x double> %x) #0 {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, r1, d9
+; CHECK-NEXT:    vmov r0, r1, d8
 ; CHECK-NEXT:    bl __aeabi_d2lz
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    vmov r2, r1, d8
-; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    vmov r2, r1, d9
+; CHECK-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEXT:    mov r0, r2
 ; CHECK-NEXT:    bl __aeabi_d2lz
-; CHECK-NEXT:    vmov.32 d8[0], r0
-; CHECK-NEXT:    vmov.32 d9[1], r4
-; CHECK-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    vmov.32 d8[1], r4
+; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    vorr q0, q4, q4
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, pc}
@@ -792,16 +792,16 @@ define <2 x i64> @fptoui_v2i64_v2f64(<2 x double> %x) #0 {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, r1, d9
+; CHECK-NEXT:    vmov r0, r1, d8
 ; CHECK-NEXT:    bl __aeabi_d2ulz
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    vmov r2, r1, d8
-; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    vmov r2, r1, d9
+; CHECK-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEXT:    mov r0, r2
 ; CHECK-NEXT:    bl __aeabi_d2ulz
-; CHECK-NEXT:    vmov.32 d8[0], r0
-; CHECK-NEXT:    vmov.32 d9[1], r4
-; CHECK-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    vmov.32 d8[1], r4
+; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    vorr q0, q4, q4
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, pc}

--- a/llvm/test/CodeGen/ARM/fpclamptosat_vec.ll
+++ b/llvm/test/CodeGen/ARM/fpclamptosat_vec.ll
@@ -12,18 +12,18 @@ define <2 x i32> @stest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, r1, d9
+; CHECK-NEXT:    vmov r0, r1, d8
 ; CHECK-NEXT:    bl __aeabi_d2lz
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    mov r5, r1
-; CHECK-NEXT:    vmov r0, r1, d8
-; CHECK-NEXT:    vmov.32 d9[0], r4
+; CHECK-NEXT:    vmov r0, r1, d9
+; CHECK-NEXT:    vmov.32 d8[0], r4
 ; CHECK-NEXT:    bl __aeabi_d2lz
-; CHECK-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEXT:    mvn r3, #-2147483648
 ; CHECK-NEXT:    subs r4, r4, r3
 ; CHECK-NEXT:    adr r2, .LCPI0_0
-; CHECK-NEXT:    vmov.32 d9[1], r5
+; CHECK-NEXT:    vmov.32 d8[1], r5
 ; CHECK-NEXT:    sbcs r5, r5, #0
 ; CHECK-NEXT:    mov r5, #0
 ; CHECK-NEXT:    mvn r12, #0
@@ -32,20 +32,20 @@ define <2 x i32> @stest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    mvnne r5, #0
 ; CHECK-NEXT:    subs r0, r0, r3
 ; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    adr r4, .LCPI0_1
 ; CHECK-NEXT:    movwlt r0, #1
 ; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    vdup.32 d19, r5
+; CHECK-NEXT:    vdup.32 d18, r5
 ; CHECK-NEXT:    mvnne r0, #0
 ; CHECK-NEXT:    vld1.64 {d16, d17}, [r2:128]
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    vdup.32 d18, r0
+; CHECK-NEXT:    vdup.32 d19, r0
 ; CHECK-NEXT:    vbit q8, q4, q9
 ; CHECK-NEXT:    vld1.64 {d18, d19}, [r4:128]
-; CHECK-NEXT:    vmov r0, r1, d17
-; CHECK-NEXT:    vmov r3, r5, d16
+; CHECK-NEXT:    vmov r0, r1, d16
+; CHECK-NEXT:    vmov r3, r5, d17
 ; CHECK-NEXT:    rsbs r0, r0, #-2147483648
 ; CHECK-NEXT:    sbcs r0, r12, r1
 ; CHECK-NEXT:    mov r0, #0
@@ -54,11 +54,11 @@ define <2 x i32> @stest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    mvnne r0, #0
 ; CHECK-NEXT:    rsbs r1, r3, #-2147483648
 ; CHECK-NEXT:    sbcs r1, r12, r5
-; CHECK-NEXT:    vdup.32 d21, r0
+; CHECK-NEXT:    vdup.32 d20, r0
 ; CHECK-NEXT:    movwlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d20, r2
+; CHECK-NEXT:    vdup.32 d21, r2
 ; CHECK-NEXT:    vbif q8, q9, q10
 ; CHECK-NEXT:    vmovn.i64 d0, q8
 ; CHECK-NEXT:    vpop {d8, d9}
@@ -93,18 +93,18 @@ define <2 x i32> @utest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, r1, d9
+; CHECK-NEXT:    vmov r0, r1, d8
 ; CHECK-NEXT:    bl __aeabi_d2ulz
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    mov r5, r1
-; CHECK-NEXT:    vmov r0, r1, d8
-; CHECK-NEXT:    vmov.32 d9[0], r4
+; CHECK-NEXT:    vmov r0, r1, d9
+; CHECK-NEXT:    vmov.32 d8[0], r4
 ; CHECK-NEXT:    bl __aeabi_d2ulz
-; CHECK-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEXT:    mvn r3, #0
 ; CHECK-NEXT:    subs r4, r4, r3
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    vmov.32 d9[1], r5
+; CHECK-NEXT:    vmov.32 d8[1], r5
 ; CHECK-NEXT:    sbcs r5, r5, #0
 ; CHECK-NEXT:    mov r5, #0
 ; CHECK-NEXT:    movwlo r5, #1
@@ -112,12 +112,12 @@ define <2 x i32> @utest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    mvnne r5, #0
 ; CHECK-NEXT:    subs r0, r0, r3
 ; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    movwlo r2, #1
 ; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    vdup.32 d17, r5
+; CHECK-NEXT:    vdup.32 d16, r5
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d16, r2
+; CHECK-NEXT:    vdup.32 d17, r2
 ; CHECK-NEXT:    vand q9, q4, q8
 ; CHECK-NEXT:    vorn q8, q9, q8
 ; CHECK-NEXT:    vmovn.i64 d0, q8
@@ -139,18 +139,18 @@ define <2 x i32> @ustest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, r1, d9
+; CHECK-NEXT:    vmov r0, r1, d8
 ; CHECK-NEXT:    bl __aeabi_d2lz
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    mov r5, r1
-; CHECK-NEXT:    vmov r0, r1, d8
-; CHECK-NEXT:    vmov.32 d9[0], r4
+; CHECK-NEXT:    vmov r0, r1, d9
+; CHECK-NEXT:    vmov.32 d8[0], r4
 ; CHECK-NEXT:    bl __aeabi_d2lz
-; CHECK-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEXT:    mvn r3, #0
 ; CHECK-NEXT:    subs r4, r4, r3
-; CHECK-NEXT:    vmov.i64 q9, #0xffffffff
-; CHECK-NEXT:    vmov.32 d9[1], r5
+; CHECK-NEXT:    vmov.i64 q8, #0xffffffff
+; CHECK-NEXT:    vmov.32 d8[1], r5
 ; CHECK-NEXT:    sbcs r5, r5, #0
 ; CHECK-NEXT:    mov r5, #0
 ; CHECK-NEXT:    mov r2, #0
@@ -159,16 +159,16 @@ define <2 x i32> @ustest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    mvnne r5, #0
 ; CHECK-NEXT:    subs r0, r0, r3
 ; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    movwlt r0, #1
 ; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    vdup.32 d17, r5
+; CHECK-NEXT:    vdup.32 d18, r5
 ; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d16, r0
-; CHECK-NEXT:    vbsl q8, q4, q9
-; CHECK-NEXT:    vmov r0, r1, d17
-; CHECK-NEXT:    vmov r3, r5, d16
+; CHECK-NEXT:    vdup.32 d19, r0
+; CHECK-NEXT:    vbit q8, q4, q9
+; CHECK-NEXT:    vmov r0, r1, d16
+; CHECK-NEXT:    vmov r3, r5, d17
 ; CHECK-NEXT:    rsbs r0, r0, #0
 ; CHECK-NEXT:    rscs r0, r1, #0
 ; CHECK-NEXT:    mov r0, #0
@@ -177,11 +177,11 @@ define <2 x i32> @ustest_f64i32(<2 x double> %x) {
 ; CHECK-NEXT:    mvnne r0, #0
 ; CHECK-NEXT:    rsbs r1, r3, #0
 ; CHECK-NEXT:    rscs r1, r5, #0
-; CHECK-NEXT:    vdup.32 d19, r0
+; CHECK-NEXT:    vdup.32 d18, r0
 ; CHECK-NEXT:    movwlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d18, r2
+; CHECK-NEXT:    vdup.32 d19, r2
 ; CHECK-NEXT:    vand q8, q9, q8
 ; CHECK-NEXT:    vmovn.i64 d0, q8
 ; CHECK-NEXT:    vpop {d8, d9}
@@ -199,109 +199,109 @@ entry:
 define <4 x i32> @stest_f32i32(<4 x float> %x) {
 ; CHECK-LABEL: stest_f32i32:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEXT:    .pad #4
-; CHECK-NEXT:    sub sp, sp, #4
-; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
+; CHECK-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
+; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, s19
-; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    vmov r0, s18
-; CHECK-NEXT:    mov r7, r1
-; CHECK-NEXT:    adr r1, .LCPI3_0
-; CHECK-NEXT:    vld1.64 {d10, d11}, [r1:128]
-; CHECK-NEXT:    vmov r5, s17
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    mvn r9, #-2147483648
-; CHECK-NEXT:    vmov.32 d13[0], r6
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r6, r9
-; CHECK-NEXT:    vmov.32 d12[0], r0
-; CHECK-NEXT:    sbcs r2, r7, #0
-; CHECK-NEXT:    vmov r8, s16
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    vmov.32 d13[1], r7
-; CHECK-NEXT:    movwlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    subs r0, r0, r9
-; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    vdup.32 d17, r2
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    vmov.32 d12[1], r1
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d16, r0
+; CHECK-NEXT:    mov r8, r0
+; CHECK-NEXT:    vmov r0, s17
+; CHECK-NEXT:    mov r9, r1
+; CHECK-NEXT:    vmov r4, s16
+; CHECK-NEXT:    vmov r5, s19
+; CHECK-NEXT:    vmov.32 d10[0], r8
+; CHECK-NEXT:    bl __aeabi_f2lz
+; CHECK-NEXT:    mov r7, r0
+; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    mov r0, r4
+; CHECK-NEXT:    mov r10, r1
+; CHECK-NEXT:    bl __aeabi_f2lz
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEXT:    mov r0, r5
-; CHECK-NEXT:    vorr q4, q8, q8
-; CHECK-NEXT:    vbsl q4, q6, q5
+; CHECK-NEXT:    mov r6, r1
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEXT:    subs r0, r0, r9
-; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mov r0, r8
-; CHECK-NEXT:    vmov r11, r10, d8
-; CHECK-NEXT:    vmov.32 d13[1], r1
-; CHECK-NEXT:    mvnne r6, #0
-; CHECK-NEXT:    vmov r5, r7, d9
-; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov.32 d12[0], r0
-; CHECK-NEXT:    subs r0, r0, r9
-; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    vdup.32 d17, r6
-; CHECK-NEXT:    movwlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vmov.32 d12[1], r1
-; CHECK-NEXT:    adr r1, .LCPI3_1
-; CHECK-NEXT:    rsbs r3, r11, #-2147483648
-; CHECK-NEXT:    vdup.32 d16, r0
-; CHECK-NEXT:    mvn r0, #0
-; CHECK-NEXT:    vbsl q8, q6, q5
-; CHECK-NEXT:    vld1.64 {d18, d19}, [r1:128]
-; CHECK-NEXT:    sbcs r3, r0, r10
+; CHECK-NEXT:    mvn r5, #-2147483648
+; CHECK-NEXT:    subs r3, r4, r5
+; CHECK-NEXT:    sbcs r3, r6, #0
+; CHECK-NEXT:    vmov.32 d11[0], r0
 ; CHECK-NEXT:    mov r3, #0
-; CHECK-NEXT:    vmov r1, r2, d17
+; CHECK-NEXT:    adr r2, .LCPI3_0
 ; CHECK-NEXT:    movwlt r3, #1
 ; CHECK-NEXT:    cmp r3, #0
 ; CHECK-NEXT:    mvnne r3, #0
-; CHECK-NEXT:    rsbs r6, r5, #-2147483648
-; CHECK-NEXT:    vmov r6, r5, d16
-; CHECK-NEXT:    sbcs r7, r0, r7
+; CHECK-NEXT:    subs r0, r0, r5
+; CHECK-NEXT:    sbcs r0, r1, #0
+; CHECK-NEXT:    vmov.32 d10[1], r9
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    movwlt r0, #1
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    vmov.32 d11[1], r1
+; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    subs r1, r8, r5
+; CHECK-NEXT:    sbcs r1, r9, #0
+; CHECK-NEXT:    vld1.64 {d18, d19}, [r2:128]
+; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    movwlt r1, #1
+; CHECK-NEXT:    cmp r1, #0
+; CHECK-NEXT:    mvnne r1, #0
+; CHECK-NEXT:    subs r7, r7, r5
+; CHECK-NEXT:    vdup.32 d16, r1
+; CHECK-NEXT:    sbcs r1, r10, #0
+; CHECK-NEXT:    vdup.32 d17, r0
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    vbsl q8, q5, q9
+; CHECK-NEXT:    vmov.32 d8[1], r6
+; CHECK-NEXT:    movwlt r0, #1
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    vdup.32 d20, r3
+; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    vmov.32 d9[1], r10
+; CHECK-NEXT:    vmov r3, r12, d17
+; CHECK-NEXT:    mvn r1, #0
+; CHECK-NEXT:    vmov r4, r7, d16
+; CHECK-NEXT:    vdup.32 d21, r0
+; CHECK-NEXT:    adr r0, .LCPI3_1
+; CHECK-NEXT:    vbit q9, q4, q10
+; CHECK-NEXT:    vld1.64 {d20, d21}, [r0:128]
+; CHECK-NEXT:    vmov r6, r5, d18
+; CHECK-NEXT:    rsbs r0, r3, #-2147483648
+; CHECK-NEXT:    sbcs r0, r1, r12
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    movwlt r0, #1
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    rsbs r3, r6, #-2147483648
+; CHECK-NEXT:    sbcs r3, r1, r5
+; CHECK-NEXT:    vmov r6, r5, d19
+; CHECK-NEXT:    mov r3, #0
+; CHECK-NEXT:    movwlt r3, #1
+; CHECK-NEXT:    cmp r3, #0
+; CHECK-NEXT:    mvnne r3, #0
+; CHECK-NEXT:    rsbs r4, r4, #-2147483648
+; CHECK-NEXT:    sbcs r7, r1, r7
+; CHECK-NEXT:    vdup.32 d24, r3
 ; CHECK-NEXT:    mov r7, #0
 ; CHECK-NEXT:    movwlt r7, #1
 ; CHECK-NEXT:    cmp r7, #0
 ; CHECK-NEXT:    mvnne r7, #0
-; CHECK-NEXT:    vdup.32 d23, r7
-; CHECK-NEXT:    vdup.32 d22, r3
-; CHECK-NEXT:    vbsl q11, q4, q9
-; CHECK-NEXT:    vmovn.i64 d1, q11
-; CHECK-NEXT:    rsbs r1, r1, #-2147483648
-; CHECK-NEXT:    sbcs r1, r0, r2
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    rsbs r2, r6, #-2147483648
-; CHECK-NEXT:    sbcs r0, r0, r5
-; CHECK-NEXT:    vdup.32 d21, r1
-; CHECK-NEXT:    movwlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    vdup.32 d20, r4
-; CHECK-NEXT:    vbif q8, q9, q10
-; CHECK-NEXT:    vmovn.i64 d0, q8
-; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
-; CHECK-NEXT:    add sp, sp, #4
-; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+; CHECK-NEXT:    vdup.32 d22, r7
+; CHECK-NEXT:    vdup.32 d23, r0
+; CHECK-NEXT:    vbif q8, q10, q11
+; CHECK-NEXT:    rsbs r6, r6, #-2147483648
+; CHECK-NEXT:    sbcs r1, r1, r5
+; CHECK-NEXT:    movwlt r2, #1
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    vdup.32 d25, r2
+; CHECK-NEXT:    vbif q9, q10, q12
+; CHECK-NEXT:    vmovn.i64 d0, q9
+; CHECK-NEXT:    vmovn.i64 d1, q8
+; CHECK-NEXT:    vpop {d8, d9, d10, d11}
+; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.1:
 ; CHECK-NEXT:  .LCPI3_0:
@@ -332,65 +332,65 @@ define <4 x i32> @utest_f32i32(<4 x float> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, s19
+; CHECK-NEXT:    vmov r0, s16
 ; CHECK-NEXT:    bl __aeabi_f2ulz
 ; CHECK-NEXT:    mov r8, r0
-; CHECK-NEXT:    vmov r0, s16
+; CHECK-NEXT:    vmov r0, s19
 ; CHECK-NEXT:    mov r9, r1
-; CHECK-NEXT:    vmov r4, s17
 ; CHECK-NEXT:    vmov r6, s18
-; CHECK-NEXT:    vmov.32 d9[0], r8
+; CHECK-NEXT:    vmov r10, s17
+; CHECK-NEXT:    vmov.32 d8[0], r8
 ; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    mov r10, r0
-; CHECK-NEXT:    vmov.32 d10[0], r0
-; CHECK-NEXT:    mov r0, r4
-; CHECK-NEXT:    mov r7, r1
-; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    mov r5, r0
 ; CHECK-NEXT:    vmov.32 d11[0], r0
 ; CHECK-NEXT:    mov r0, r6
-; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    vmov.32 d8[0], r0
-; CHECK-NEXT:    mvn r3, #0
-; CHECK-NEXT:    subs r0, r0, r3
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    vmov.32 d9[1], r9
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movwlo r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    vmov.32 d8[1], r1
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    subs r1, r8, r3
-; CHECK-NEXT:    sbcs r1, r9, #0
-; CHECK-NEXT:    vmov.32 d11[1], r5
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movwlo r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    subs r6, r4, r3
-; CHECK-NEXT:    sbcs r6, r5, #0
-; CHECK-NEXT:    vdup.32 d19, r1
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    vdup.32 d18, r0
-; CHECK-NEXT:    movwlo r6, #1
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mvnne r6, #0
-; CHECK-NEXT:    subs r3, r10, r3
-; CHECK-NEXT:    sbcs r3, r7, #0
+; CHECK-NEXT:    mov r6, r0
+; CHECK-NEXT:    vmov.32 d10[0], r0
+; CHECK-NEXT:    mov r0, r10
+; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    bl __aeabi_f2ulz
+; CHECK-NEXT:    mvn r12, #0
+; CHECK-NEXT:    subs r3, r5, r12
+; CHECK-NEXT:    sbcs r3, r4, #0
 ; CHECK-NEXT:    vmov.32 d10[1], r7
+; CHECK-NEXT:    mov r3, #0
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    movwlo r3, #1
+; CHECK-NEXT:    cmp r3, #0
+; CHECK-NEXT:    mvnne r3, #0
+; CHECK-NEXT:    subs r5, r8, r12
+; CHECK-NEXT:    sbcs r5, r9, #0
+; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    mov r5, #0
+; CHECK-NEXT:    movwlo r5, #1
+; CHECK-NEXT:    cmp r5, #0
+; CHECK-NEXT:    mvnne r5, #0
+; CHECK-NEXT:    subs r6, r6, r12
+; CHECK-NEXT:    sbcs r7, r7, #0
+; CHECK-NEXT:    vmov.32 d8[1], r9
+; CHECK-NEXT:    mov r7, #0
+; CHECK-NEXT:    movwlo r7, #1
+; CHECK-NEXT:    cmp r7, #0
+; CHECK-NEXT:    mvnne r7, #0
+; CHECK-NEXT:    subs r0, r0, r12
+; CHECK-NEXT:    sbcs r0, r1, #0
+; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    movwlo r2, #1
 ; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    vdup.32 d17, r6
+; CHECK-NEXT:    vdup.32 d18, r5
 ; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    vdup.32 d16, r7
+; CHECK-NEXT:    vdup.32 d19, r2
+; CHECK-NEXT:    vmov.32 d11[1], r4
 ; CHECK-NEXT:    vand q10, q4, q9
-; CHECK-NEXT:    vdup.32 d16, r2
-; CHECK-NEXT:    vand q11, q5, q8
+; CHECK-NEXT:    vdup.32 d17, r3
 ; CHECK-NEXT:    vorn q9, q10, q9
+; CHECK-NEXT:    vand q11, q5, q8
 ; CHECK-NEXT:    vorn q8, q11, q8
-; CHECK-NEXT:    vmovn.i64 d1, q9
-; CHECK-NEXT:    vmovn.i64 d0, q8
+; CHECK-NEXT:    vmovn.i64 d0, q9
+; CHECK-NEXT:    vmovn.i64 d1, q8
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -411,95 +411,94 @@ define <4 x i32> @ustest_f32i32(<4 x float> %x) {
 ; CHECK-NEXT:    vorr q4, q0, q0
 ; CHECK-NEXT:    vmov r0, s18
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    mov r5, r0
+; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    vmov r0, s19
-; CHECK-NEXT:    mov r6, r1
+; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    vmov r5, s16
+; CHECK-NEXT:    vmov r8, s17
+; CHECK-NEXT:    vmov.32 d8[0], r6
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    mov r2, r0
-; CHECK-NEXT:    vmov r0, s17
-; CHECK-NEXT:    vmov.32 d17[0], r2
-; CHECK-NEXT:    mvn r4, #0
-; CHECK-NEXT:    subs r2, r2, r4
-; CHECK-NEXT:    vmov r8, s16
-; CHECK-NEXT:    vmov.32 d16[0], r5
-; CHECK-NEXT:    vmov.i64 q5, #0xffffffff
-; CHECK-NEXT:    mov r7, #0
-; CHECK-NEXT:    vmov.32 d17[1], r1
-; CHECK-NEXT:    sbcs r1, r1, #0
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movwlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    subs r2, r5, r4
-; CHECK-NEXT:    sbcs r2, r6, #0
-; CHECK-NEXT:    vdup.32 d19, r1
+; CHECK-NEXT:    mvn r9, #0
+; CHECK-NEXT:    subs r2, r6, r9
+; CHECK-NEXT:    sbcs r2, r7, #0
+; CHECK-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    vmov.32 d16[1], r6
+; CHECK-NEXT:    vmov.i64 q5, #0xffffffff
 ; CHECK-NEXT:    movwlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d18, r2
-; CHECK-NEXT:    vorr q4, q9, q9
-; CHECK-NEXT:    vbsl q4, q8, q5
-; CHECK-NEXT:    vmov r10, r9, d8
+; CHECK-NEXT:    subs r0, r0, r9
+; CHECK-NEXT:    sbcs r0, r1, #0
+; CHECK-NEXT:    vmov.32 d8[1], r7
+; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    mov r4, #0
+; CHECK-NEXT:    movwlt r0, #1
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    vmov.32 d9[1], r1
+; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    vdup.32 d16, r2
+; CHECK-NEXT:    vdup.32 d17, r0
+; CHECK-NEXT:    mov r0, r5
+; CHECK-NEXT:    vbif q4, q5, q8
+; CHECK-NEXT:    vmov r7, r10, d9
 ; CHECK-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEXT:    mov r5, r0
-; CHECK-NEXT:    vmov.32 d13[0], r0
+; CHECK-NEXT:    vmov.32 d12[0], r0
 ; CHECK-NEXT:    mov r0, r8
 ; CHECK-NEXT:    mov r6, r1
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    subs r2, r5, r4
-; CHECK-NEXT:    vmov.32 d12[0], r0
+; CHECK-NEXT:    subs r2, r5, r9
+; CHECK-NEXT:    vmov.32 d13[0], r0
 ; CHECK-NEXT:    sbcs r2, r6, #0
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    vmov.32 d13[1], r6
+; CHECK-NEXT:    vmov.32 d12[1], r6
 ; CHECK-NEXT:    movwlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    subs r0, r0, r4
+; CHECK-NEXT:    subs r0, r0, r9
 ; CHECK-NEXT:    sbcs r0, r1, #0
-; CHECK-NEXT:    vmov.32 d12[1], r1
+; CHECK-NEXT:    vmov.32 d13[1], r1
 ; CHECK-NEXT:    mov r0, #0
+; CHECK-NEXT:    vmov r3, r6, d8
 ; CHECK-NEXT:    movwlt r0, #1
 ; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    vdup.32 d16, r2
 ; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d17, r2
-; CHECK-NEXT:    vdup.32 d16, r0
-; CHECK-NEXT:    vmov r0, r1, d9
+; CHECK-NEXT:    vdup.32 d17, r0
+; CHECK-NEXT:    rsbs r0, r7, #0
 ; CHECK-NEXT:    vbsl q8, q6, q5
-; CHECK-NEXT:    rsbs r6, r10, #0
-; CHECK-NEXT:    rscs r6, r9, #0
-; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    vmov r2, r3, d17
-; CHECK-NEXT:    movwlt r6, #1
-; CHECK-NEXT:    vmov r5, r4, d16
-; CHECK-NEXT:    cmp r6, #0
-; CHECK-NEXT:    mvnne r6, #0
-; CHECK-NEXT:    rsbs r0, r0, #0
-; CHECK-NEXT:    rscs r0, r1, #0
+; CHECK-NEXT:    rscs r0, r10, #0
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    movwlt r0, #1
 ; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    vmov r1, r2, d16
 ; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    rsbs r1, r2, #0
-; CHECK-NEXT:    rscs r1, r3, #0
-; CHECK-NEXT:    vdup.32 d21, r0
+; CHECK-NEXT:    vmov r7, r5, d17
+; CHECK-NEXT:    rsbs r1, r1, #0
+; CHECK-NEXT:    rscs r1, r2, #0
 ; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    vdup.32 d20, r6
 ; CHECK-NEXT:    movwlt r1, #1
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    rsbs r2, r5, #0
-; CHECK-NEXT:    rscs r2, r4, #0
-; CHECK-NEXT:    vdup.32 d19, r1
-; CHECK-NEXT:    movwlt r7, #1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    mvnne r7, #0
-; CHECK-NEXT:    vand q10, q10, q4
-; CHECK-NEXT:    vdup.32 d18, r7
-; CHECK-NEXT:    vand q8, q9, q8
-; CHECK-NEXT:    vmovn.i64 d1, q10
+; CHECK-NEXT:    rsbs r2, r3, #0
+; CHECK-NEXT:    rscs r2, r6, #0
+; CHECK-NEXT:    vdup.32 d20, r1
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    movwlt r2, #1
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    rsbs r3, r7, #0
+; CHECK-NEXT:    rscs r3, r5, #0
+; CHECK-NEXT:    vdup.32 d18, r2
+; CHECK-NEXT:    movwlt r4, #1
+; CHECK-NEXT:    cmp r4, #0
+; CHECK-NEXT:    mvnne r4, #0
+; CHECK-NEXT:    vdup.32 d19, r0
+; CHECK-NEXT:    vdup.32 d21, r4
+; CHECK-NEXT:    vand q9, q9, q4
+; CHECK-NEXT:    vand q8, q10, q8
 ; CHECK-NEXT:    vmovn.i64 d0, q8
+; CHECK-NEXT:    vmovn.i64 d1, q9
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -515,114 +514,115 @@ entry:
 define <4 x i32> @stest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-LABEL: stest_f16i32:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; CHECK-NEON-NEXT:    .pad #4
-; CHECK-NEON-NEXT:    sub sp, sp, #4
-; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11}
+; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEON-NEXT:    vmov r0, s2
 ; CHECK-NEON-NEXT:    vmov.f32 s16, s3
 ; CHECK-NEON-NEXT:    vmov.f32 s18, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    mov r6, r0
-; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    mov r5, r1
+; CHECK-NEON-NEXT:    mov r8, r0
+; CHECK-NEON-NEXT:    vmov r0, s18
+; CHECK-NEON-NEXT:    vmov r4, s20
+; CHECK-NEON-NEXT:    mov r9, r1
+; CHECK-NEON-NEXT:    vmov r5, s16
+; CHECK-NEON-NEXT:    vmov.32 d10[0], r8
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov r2, s18
-; CHECK-NEON-NEXT:    adr r3, .LCPI6_0
-; CHECK-NEON-NEXT:    vld1.64 {d8, d9}, [r3:128]
-; CHECK-NEON-NEXT:    mvn r9, #-2147483648
-; CHECK-NEON-NEXT:    subs r3, r6, r9
-; CHECK-NEON-NEXT:    mov r4, #0
-; CHECK-NEON-NEXT:    sbcs r3, r5, #0
-; CHECK-NEON-NEXT:    vmov.32 d15[0], r0
-; CHECK-NEON-NEXT:    movwlt r4, #1
-; CHECK-NEON-NEXT:    cmp r4, #0
-; CHECK-NEON-NEXT:    mvnne r4, #0
-; CHECK-NEON-NEXT:    subs r0, r0, r9
-; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    vmov.32 d14[0], r6
-; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    vmov r8, s20
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    vmov.32 d15[1], r1
-; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    vdup.32 d11, r0
-; CHECK-NEON-NEXT:    vmov.32 d14[1], r5
-; CHECK-NEON-NEXT:    mov r0, r2
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vdup.32 d10, r4
-; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEON-NEXT:    subs r0, r0, r9
-; CHECK-NEON-NEXT:    vbsl q5, q7, q4
-; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    mov r6, #0
-; CHECK-NEON-NEXT:    mov r0, r8
-; CHECK-NEON-NEXT:    movwlt r6, #1
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    vmov r11, r10, d10
-; CHECK-NEON-NEXT:    vmov.32 d13[1], r1
-; CHECK-NEON-NEXT:    mvnne r6, #0
-; CHECK-NEON-NEXT:    vmov r5, r4, d11
+; CHECK-NEON-NEXT:    mov r7, r0
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEON-NEXT:    mov r0, r4
+; CHECK-NEON-NEXT:    mov r10, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
-; CHECK-NEON-NEXT:    subs r0, r0, r9
-; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    vdup.32 d17, r6
-; CHECK-NEON-NEXT:    movwlt r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    vmov.32 d12[1], r1
-; CHECK-NEON-NEXT:    adr r1, .LCPI6_1
-; CHECK-NEON-NEXT:    rsbs r3, r11, #-2147483648
-; CHECK-NEON-NEXT:    vdup.32 d16, r0
-; CHECK-NEON-NEXT:    mvn r0, #0
-; CHECK-NEON-NEXT:    vbsl q8, q6, q4
-; CHECK-NEON-NEXT:    vld1.64 {d18, d19}, [r1:128]
-; CHECK-NEON-NEXT:    sbcs r3, r0, r10
+; CHECK-NEON-NEXT:    mov r4, r0
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEON-NEXT:    mov r0, r5
+; CHECK-NEON-NEXT:    mov r6, r1
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    bl __aeabi_f2lz
+; CHECK-NEON-NEXT:    mvn r5, #-2147483648
+; CHECK-NEON-NEXT:    subs r3, r4, r5
+; CHECK-NEON-NEXT:    sbcs r3, r6, #0
+; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
 ; CHECK-NEON-NEXT:    mov r3, #0
-; CHECK-NEON-NEXT:    vmov r1, r2, d17
+; CHECK-NEON-NEXT:    adr r2, .LCPI6_0
 ; CHECK-NEON-NEXT:    movwlt r3, #1
 ; CHECK-NEON-NEXT:    cmp r3, #0
 ; CHECK-NEON-NEXT:    mvnne r3, #0
-; CHECK-NEON-NEXT:    rsbs r6, r5, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r6, r0, r4
-; CHECK-NEON-NEXT:    vmov r5, r4, d16
-; CHECK-NEON-NEXT:    mov r6, #0
-; CHECK-NEON-NEXT:    movwlt r6, #1
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    mvnne r6, #0
-; CHECK-NEON-NEXT:    vdup.32 d23, r6
-; CHECK-NEON-NEXT:    vdup.32 d22, r3
-; CHECK-NEON-NEXT:    vbsl q11, q5, q9
-; CHECK-NEON-NEXT:    vmovn.i64 d1, q11
-; CHECK-NEON-NEXT:    rsbs r1, r1, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r1, r0, r2
+; CHECK-NEON-NEXT:    subs r0, r0, r5
+; CHECK-NEON-NEXT:    sbcs r0, r1, #0
+; CHECK-NEON-NEXT:    vmov.32 d10[1], r9
+; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    movwlt r0, #1
+; CHECK-NEON-NEXT:    cmp r0, #0
+; CHECK-NEON-NEXT:    vmov.32 d11[1], r1
+; CHECK-NEON-NEXT:    mvnne r0, #0
+; CHECK-NEON-NEXT:    subs r1, r8, r5
+; CHECK-NEON-NEXT:    sbcs r1, r9, #0
+; CHECK-NEON-NEXT:    vld1.64 {d18, d19}, [r2:128]
 ; CHECK-NEON-NEXT:    mov r1, #0
+; CHECK-NEON-NEXT:    mov r2, #0
 ; CHECK-NEON-NEXT:    movwlt r1, #1
 ; CHECK-NEON-NEXT:    cmp r1, #0
 ; CHECK-NEON-NEXT:    mvnne r1, #0
-; CHECK-NEON-NEXT:    rsbs r2, r5, #-2147483648
-; CHECK-NEON-NEXT:    sbcs r0, r0, r4
-; CHECK-NEON-NEXT:    vdup.32 d21, r1
+; CHECK-NEON-NEXT:    subs r7, r7, r5
+; CHECK-NEON-NEXT:    vdup.32 d16, r1
+; CHECK-NEON-NEXT:    sbcs r1, r10, #0
+; CHECK-NEON-NEXT:    vdup.32 d17, r0
+; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    vbsl q8, q5, q9
+; CHECK-NEON-NEXT:    vmov.32 d8[1], r6
+; CHECK-NEON-NEXT:    movwlt r0, #1
+; CHECK-NEON-NEXT:    cmp r0, #0
+; CHECK-NEON-NEXT:    vdup.32 d20, r3
+; CHECK-NEON-NEXT:    mvnne r0, #0
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r10
+; CHECK-NEON-NEXT:    vmov r3, r12, d17
+; CHECK-NEON-NEXT:    mvn r1, #0
+; CHECK-NEON-NEXT:    vmov r4, r7, d16
+; CHECK-NEON-NEXT:    vdup.32 d21, r0
+; CHECK-NEON-NEXT:    adr r0, .LCPI6_1
+; CHECK-NEON-NEXT:    vbit q9, q4, q10
+; CHECK-NEON-NEXT:    vld1.64 {d20, d21}, [r0:128]
+; CHECK-NEON-NEXT:    vmov r6, r5, d18
+; CHECK-NEON-NEXT:    rsbs r0, r3, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r0, r1, r12
+; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    movwlt r0, #1
+; CHECK-NEON-NEXT:    cmp r0, #0
+; CHECK-NEON-NEXT:    mvnne r0, #0
+; CHECK-NEON-NEXT:    rsbs r3, r6, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r3, r1, r5
+; CHECK-NEON-NEXT:    vmov r6, r5, d19
+; CHECK-NEON-NEXT:    mov r3, #0
+; CHECK-NEON-NEXT:    movwlt r3, #1
+; CHECK-NEON-NEXT:    cmp r3, #0
+; CHECK-NEON-NEXT:    mvnne r3, #0
+; CHECK-NEON-NEXT:    rsbs r4, r4, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r7, r1, r7
+; CHECK-NEON-NEXT:    vdup.32 d24, r3
+; CHECK-NEON-NEXT:    mov r7, #0
 ; CHECK-NEON-NEXT:    movwlt r7, #1
 ; CHECK-NEON-NEXT:    cmp r7, #0
 ; CHECK-NEON-NEXT:    mvnne r7, #0
-; CHECK-NEON-NEXT:    vdup.32 d20, r7
-; CHECK-NEON-NEXT:    vbif q8, q9, q10
-; CHECK-NEON-NEXT:    vmovn.i64 d0, q8
-; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEON-NEXT:    add sp, sp, #4
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+; CHECK-NEON-NEXT:    vdup.32 d22, r7
+; CHECK-NEON-NEXT:    vdup.32 d23, r0
+; CHECK-NEON-NEXT:    vbif q8, q10, q11
+; CHECK-NEON-NEXT:    rsbs r6, r6, #-2147483648
+; CHECK-NEON-NEXT:    sbcs r1, r1, r5
+; CHECK-NEON-NEXT:    movwlt r2, #1
+; CHECK-NEON-NEXT:    cmp r2, #0
+; CHECK-NEON-NEXT:    mvnne r2, #0
+; CHECK-NEON-NEXT:    vdup.32 d25, r2
+; CHECK-NEON-NEXT:    vbif q9, q10, q12
+; CHECK-NEON-NEXT:    vmovn.i64 d0, q9
+; CHECK-NEON-NEXT:    vmovn.i64 d1, q8
+; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11}
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ; CHECK-NEON-NEXT:    .p2align 4
 ; CHECK-NEON-NEXT:  @ %bb.1:
 ; CHECK-NEON-NEXT:  .LCPI6_0:
@@ -640,104 +640,111 @@ define <4 x i32> @stest_f16i32(<4 x half> %x) {
 ; CHECK-FP16:       @ %bb.0: @ %entry
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-FP16-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
-; CHECK-FP16-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[3]
+; CHECK-FP16-NEXT:    .vsave {d10, d11, d12, d13}
+; CHECK-FP16-NEXT:    vpush {d10, d11, d12, d13}
+; CHECK-FP16-NEXT:    .vsave {d8}
+; CHECK-FP16-NEXT:    vpush {d8}
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[2]
 ; CHECK-FP16-NEXT:    vorr d8, d0, d0
-; CHECK-FP16-NEXT:    vmov.u16 r8, d0[0]
-; CHECK-FP16-NEXT:    vmov.u16 r9, d0[1]
+; CHECK-FP16-NEXT:    vmov.u16 r4, d0[0]
 ; CHECK-FP16-NEXT:    vmov s0, r0
+; CHECK-FP16-NEXT:    bl __fixhfdi
+; CHECK-FP16-NEXT:    mov r8, r0
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[1]
+; CHECK-FP16-NEXT:    mov r9, r1
+; CHECK-FP16-NEXT:    vmov.32 d12[0], r8
+; CHECK-FP16-NEXT:    vmov s0, r0
+; CHECK-FP16-NEXT:    bl __fixhfdi
+; CHECK-FP16-NEXT:    vmov s0, r4
+; CHECK-FP16-NEXT:    mov r7, r0
+; CHECK-FP16-NEXT:    mov r10, r1
+; CHECK-FP16-NEXT:    vmov.32 d11[0], r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    mov r4, r0
-; CHECK-FP16-NEXT:    vmov.u16 r0, d8[2]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[3]
 ; CHECK-FP16-NEXT:    mov r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d9[0], r4
+; CHECK-FP16-NEXT:    vmov.32 d10[0], r4
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    adr r2, .LCPI6_0
-; CHECK-FP16-NEXT:    mvn r10, #-2147483648
-; CHECK-FP16-NEXT:    vld1.64 {d10, d11}, [r2:128]
-; CHECK-FP16-NEXT:    subs r2, r4, r10
-; CHECK-FP16-NEXT:    sbcs r2, r5, #0
-; CHECK-FP16-NEXT:    vmov s0, r9
-; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    vmov.32 d8[0], r0
-; CHECK-FP16-NEXT:    movwlt r2, #1
-; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    mvnne r2, #0
-; CHECK-FP16-NEXT:    subs r0, r0, r10
-; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    vmov.32 d9[1], r5
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    mov r6, #0
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d8[1], r1
-; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    vdup.32 d17, r2
-; CHECK-FP16-NEXT:    vdup.32 d16, r0
-; CHECK-FP16-NEXT:    vbif q4, q5, q8
-; CHECK-FP16-NEXT:    bl __fixhfdi
+; CHECK-FP16-NEXT:    mvn r6, #-2147483648
+; CHECK-FP16-NEXT:    subs r3, r4, r6
+; CHECK-FP16-NEXT:    sbcs r3, r5, #0
 ; CHECK-FP16-NEXT:    vmov.32 d13[0], r0
-; CHECK-FP16-NEXT:    subs r0, r0, r10
-; CHECK-FP16-NEXT:    vmov s0, r8
-; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    vmov r9, r8, d8
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    vmov.32 d13[1], r1
-; CHECK-FP16-NEXT:    vmov r5, r4, d9
-; CHECK-FP16-NEXT:    mvnne r7, #0
-; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    vmov.32 d12[0], r0
-; CHECK-FP16-NEXT:    subs r0, r0, r10
-; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    vdup.32 d17, r7
-; CHECK-FP16-NEXT:    movwlt r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d12[1], r1
-; CHECK-FP16-NEXT:    adr r1, .LCPI6_1
-; CHECK-FP16-NEXT:    rsbs r3, r9, #-2147483648
-; CHECK-FP16-NEXT:    vdup.32 d16, r0
-; CHECK-FP16-NEXT:    mvn r0, #0
-; CHECK-FP16-NEXT:    vbsl q8, q6, q5
-; CHECK-FP16-NEXT:    vld1.64 {d18, d19}, [r1:128]
-; CHECK-FP16-NEXT:    sbcs r3, r0, r8
 ; CHECK-FP16-NEXT:    mov r3, #0
-; CHECK-FP16-NEXT:    vmov r1, r2, d17
+; CHECK-FP16-NEXT:    adr r2, .LCPI6_0
 ; CHECK-FP16-NEXT:    movwlt r3, #1
 ; CHECK-FP16-NEXT:    cmp r3, #0
 ; CHECK-FP16-NEXT:    mvnne r3, #0
-; CHECK-FP16-NEXT:    rsbs r7, r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r7, r0, r4
-; CHECK-FP16-NEXT:    vmov r5, r4, d16
+; CHECK-FP16-NEXT:    subs r0, r0, r6
+; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    vmov.32 d12[1], r9
+; CHECK-FP16-NEXT:    mov r0, #0
+; CHECK-FP16-NEXT:    movwlt r0, #1
+; CHECK-FP16-NEXT:    cmp r0, #0
+; CHECK-FP16-NEXT:    vmov.32 d13[1], r1
+; CHECK-FP16-NEXT:    mvnne r0, #0
+; CHECK-FP16-NEXT:    subs r1, r8, r6
+; CHECK-FP16-NEXT:    sbcs r1, r9, #0
+; CHECK-FP16-NEXT:    vld1.64 {d18, d19}, [r2:128]
+; CHECK-FP16-NEXT:    mov r1, #0
+; CHECK-FP16-NEXT:    mov r2, #0
+; CHECK-FP16-NEXT:    movwlt r1, #1
+; CHECK-FP16-NEXT:    cmp r1, #0
+; CHECK-FP16-NEXT:    mvnne r1, #0
+; CHECK-FP16-NEXT:    subs r7, r7, r6
+; CHECK-FP16-NEXT:    vdup.32 d16, r1
+; CHECK-FP16-NEXT:    sbcs r1, r10, #0
+; CHECK-FP16-NEXT:    vdup.32 d17, r0
+; CHECK-FP16-NEXT:    mov r0, #0
+; CHECK-FP16-NEXT:    vbsl q8, q6, q9
+; CHECK-FP16-NEXT:    vmov.32 d10[1], r5
+; CHECK-FP16-NEXT:    movwlt r0, #1
+; CHECK-FP16-NEXT:    cmp r0, #0
+; CHECK-FP16-NEXT:    vdup.32 d20, r3
+; CHECK-FP16-NEXT:    mvnne r0, #0
+; CHECK-FP16-NEXT:    vmov.32 d11[1], r10
+; CHECK-FP16-NEXT:    vmov r3, r12, d17
+; CHECK-FP16-NEXT:    mvn r1, #0
+; CHECK-FP16-NEXT:    vmov r4, r7, d16
+; CHECK-FP16-NEXT:    vdup.32 d21, r0
+; CHECK-FP16-NEXT:    adr r0, .LCPI6_1
+; CHECK-FP16-NEXT:    vbit q9, q5, q10
+; CHECK-FP16-NEXT:    vld1.64 {d20, d21}, [r0:128]
+; CHECK-FP16-NEXT:    vmov r6, r5, d18
+; CHECK-FP16-NEXT:    rsbs r0, r3, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r0, r1, r12
+; CHECK-FP16-NEXT:    mov r0, #0
+; CHECK-FP16-NEXT:    movwlt r0, #1
+; CHECK-FP16-NEXT:    cmp r0, #0
+; CHECK-FP16-NEXT:    mvnne r0, #0
+; CHECK-FP16-NEXT:    rsbs r3, r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r3, r1, r5
+; CHECK-FP16-NEXT:    vmov r6, r5, d19
+; CHECK-FP16-NEXT:    mov r3, #0
+; CHECK-FP16-NEXT:    movwlt r3, #1
+; CHECK-FP16-NEXT:    cmp r3, #0
+; CHECK-FP16-NEXT:    mvnne r3, #0
+; CHECK-FP16-NEXT:    rsbs r4, r4, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r7, r1, r7
+; CHECK-FP16-NEXT:    vdup.32 d24, r3
 ; CHECK-FP16-NEXT:    mov r7, #0
 ; CHECK-FP16-NEXT:    movwlt r7, #1
 ; CHECK-FP16-NEXT:    cmp r7, #0
 ; CHECK-FP16-NEXT:    mvnne r7, #0
-; CHECK-FP16-NEXT:    vdup.32 d23, r7
-; CHECK-FP16-NEXT:    vdup.32 d22, r3
-; CHECK-FP16-NEXT:    vbsl q11, q4, q9
-; CHECK-FP16-NEXT:    vmovn.i64 d1, q11
-; CHECK-FP16-NEXT:    rsbs r1, r1, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r1, r0, r2
-; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    movwlt r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    mvnne r1, #0
-; CHECK-FP16-NEXT:    rsbs r2, r5, #-2147483648
-; CHECK-FP16-NEXT:    sbcs r0, r0, r4
-; CHECK-FP16-NEXT:    vdup.32 d21, r1
-; CHECK-FP16-NEXT:    movwlt r6, #1
-; CHECK-FP16-NEXT:    cmp r6, #0
-; CHECK-FP16-NEXT:    mvnne r6, #0
-; CHECK-FP16-NEXT:    vdup.32 d20, r6
-; CHECK-FP16-NEXT:    vbif q8, q9, q10
-; CHECK-FP16-NEXT:    vmovn.i64 d0, q8
-; CHECK-FP16-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
+; CHECK-FP16-NEXT:    vdup.32 d22, r7
+; CHECK-FP16-NEXT:    vdup.32 d23, r0
+; CHECK-FP16-NEXT:    vbif q8, q10, q11
+; CHECK-FP16-NEXT:    rsbs r6, r6, #-2147483648
+; CHECK-FP16-NEXT:    sbcs r1, r1, r5
+; CHECK-FP16-NEXT:    movwlt r2, #1
+; CHECK-FP16-NEXT:    cmp r2, #0
+; CHECK-FP16-NEXT:    mvnne r2, #0
+; CHECK-FP16-NEXT:    vdup.32 d25, r2
+; CHECK-FP16-NEXT:    vbif q9, q10, q12
+; CHECK-FP16-NEXT:    vmovn.i64 d0, q9
+; CHECK-FP16-NEXT:    vmovn.i64 d1, q8
+; CHECK-FP16-NEXT:    vpop {d8}
+; CHECK-FP16-NEXT:    vpop {d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ; CHECK-FP16-NEXT:    .p2align 4
 ; CHECK-FP16-NEXT:  @ %bb.1:
@@ -764,78 +771,81 @@ entry:
 define <4 x i32> @utest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-LABEL: utest_f16i32:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
+; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+; CHECK-NEON-NEXT:    .pad #4
+; CHECK-NEON-NEXT:    sub sp, sp, #4
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11}
-; CHECK-NEON-NEXT:    vmov r0, s3
-; CHECK-NEON-NEXT:    vmov.f32 s16, s2
-; CHECK-NEON-NEXT:    vmov.f32 s18, s1
-; CHECK-NEON-NEXT:    vmov.f32 s20, s0
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.f32 s16, s3
+; CHECK-NEON-NEXT:    vmov.f32 s18, s2
+; CHECK-NEON-NEXT:    vmov.f32 s20, s1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
 ; CHECK-NEON-NEXT:    mov r8, r0
-; CHECK-NEON-NEXT:    vmov r0, s20
+; CHECK-NEON-NEXT:    vmov r0, s16
+; CHECK-NEON-NEXT:    vmov r6, s18
 ; CHECK-NEON-NEXT:    mov r9, r1
-; CHECK-NEON-NEXT:    vmov r4, s18
-; CHECK-NEON-NEXT:    vmov r6, s16
-; CHECK-NEON-NEXT:    vmov.32 d9[0], r8
+; CHECK-NEON-NEXT:    vmov r10, s20
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r8
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    mov r10, r0
+; CHECK-NEON-NEXT:    mov r5, r0
+; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEON-NEXT:    mov r0, r6
+; CHECK-NEON-NEXT:    mov r4, r1
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
+; CHECK-NEON-NEXT:    mov r11, r0
 ; CHECK-NEON-NEXT:    vmov.32 d10[0], r0
-; CHECK-NEON-NEXT:    mov r0, r4
+; CHECK-NEON-NEXT:    mov r0, r10
 ; CHECK-NEON-NEXT:    mov r7, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    mov r4, r0
-; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
-; CHECK-NEON-NEXT:    mov r0, r6
-; CHECK-NEON-NEXT:    mov r5, r1
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
-; CHECK-NEON-NEXT:    mvn r3, #0
-; CHECK-NEON-NEXT:    subs r0, r0, r3
-; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    vmov.32 d9[1], r9
-; CHECK-NEON-NEXT:    mov r0, #0
-; CHECK-NEON-NEXT:    movwlo r0, #1
-; CHECK-NEON-NEXT:    cmp r0, #0
-; CHECK-NEON-NEXT:    vmov.32 d8[1], r1
-; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    subs r1, r8, r3
-; CHECK-NEON-NEXT:    sbcs r1, r9, #0
-; CHECK-NEON-NEXT:    vmov.32 d11[1], r5
-; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    movwlo r1, #1
-; CHECK-NEON-NEXT:    cmp r1, #0
-; CHECK-NEON-NEXT:    mvnne r1, #0
-; CHECK-NEON-NEXT:    subs r6, r4, r3
-; CHECK-NEON-NEXT:    sbcs r6, r5, #0
-; CHECK-NEON-NEXT:    vdup.32 d19, r1
-; CHECK-NEON-NEXT:    mov r6, #0
-; CHECK-NEON-NEXT:    vdup.32 d18, r0
-; CHECK-NEON-NEXT:    movwlo r6, #1
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    mvnne r6, #0
-; CHECK-NEON-NEXT:    subs r3, r10, r3
-; CHECK-NEON-NEXT:    sbcs r3, r7, #0
+; CHECK-NEON-NEXT:    mvn r6, #0
+; CHECK-NEON-NEXT:    subs r3, r5, r6
+; CHECK-NEON-NEXT:    sbcs r3, r4, #0
 ; CHECK-NEON-NEXT:    vmov.32 d10[1], r7
+; CHECK-NEON-NEXT:    mov r3, #0
+; CHECK-NEON-NEXT:    mov r2, #0
+; CHECK-NEON-NEXT:    movwlo r3, #1
+; CHECK-NEON-NEXT:    cmp r3, #0
+; CHECK-NEON-NEXT:    mvnne r3, #0
+; CHECK-NEON-NEXT:    subs r5, r8, r6
+; CHECK-NEON-NEXT:    sbcs r5, r9, #0
+; CHECK-NEON-NEXT:    vmov.32 d11[1], r4
+; CHECK-NEON-NEXT:    mov r5, #0
+; CHECK-NEON-NEXT:    movwlo r5, #1
+; CHECK-NEON-NEXT:    cmp r5, #0
+; CHECK-NEON-NEXT:    mvnne r5, #0
+; CHECK-NEON-NEXT:    subs r4, r11, r6
+; CHECK-NEON-NEXT:    sbcs r7, r7, #0
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEON-NEXT:    mov r7, #0
+; CHECK-NEON-NEXT:    movwlo r7, #1
+; CHECK-NEON-NEXT:    cmp r7, #0
+; CHECK-NEON-NEXT:    mvnne r7, #0
+; CHECK-NEON-NEXT:    subs r0, r0, r6
+; CHECK-NEON-NEXT:    sbcs r0, r1, #0
+; CHECK-NEON-NEXT:    vmov.32 d8[1], r9
 ; CHECK-NEON-NEXT:    movwlo r2, #1
 ; CHECK-NEON-NEXT:    cmp r2, #0
-; CHECK-NEON-NEXT:    vdup.32 d17, r6
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEON-NEXT:    mvnne r2, #0
+; CHECK-NEON-NEXT:    vdup.32 d18, r5
+; CHECK-NEON-NEXT:    vdup.32 d16, r7
+; CHECK-NEON-NEXT:    vdup.32 d19, r2
 ; CHECK-NEON-NEXT:    vand q10, q4, q9
-; CHECK-NEON-NEXT:    vdup.32 d16, r2
+; CHECK-NEON-NEXT:    vdup.32 d17, r3
 ; CHECK-NEON-NEXT:    vand q11, q5, q8
 ; CHECK-NEON-NEXT:    vorn q9, q10, q9
 ; CHECK-NEON-NEXT:    vorn q8, q11, q8
-; CHECK-NEON-NEXT:    vmovn.i64 d1, q9
-; CHECK-NEON-NEXT:    vmovn.i64 d0, q8
+; CHECK-NEON-NEXT:    vmovn.i64 d0, q9
+; CHECK-NEON-NEXT:    vmovn.i64 d1, q8
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11}
-; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
+; CHECK-NEON-NEXT:    add sp, sp, #4
+; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 ;
 ; CHECK-FP16-LABEL: utest_f16i32:
 ; CHECK-FP16:       @ %bb.0: @ %entry
@@ -845,68 +855,68 @@ define <4 x i32> @utest_f16i32(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    vpush {d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    .vsave {d8}
 ; CHECK-FP16-NEXT:    vpush {d8}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[3]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
 ; CHECK-FP16-NEXT:    vorr d8, d0, d0
-; CHECK-FP16-NEXT:    vmov.u16 r4, d0[1]
+; CHECK-FP16-NEXT:    vmov.u16 r6, d0[2]
 ; CHECK-FP16-NEXT:    vmov s0, r0
+; CHECK-FP16-NEXT:    bl __fixunshfdi
+; CHECK-FP16-NEXT:    mov r8, r0
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-FP16-NEXT:    mov r9, r1
+; CHECK-FP16-NEXT:    vmov.32 d10[0], r8
+; CHECK-FP16-NEXT:    vmov s0, r0
+; CHECK-FP16-NEXT:    bl __fixunshfdi
+; CHECK-FP16-NEXT:    vmov s0, r6
+; CHECK-FP16-NEXT:    mov r4, r0
+; CHECK-FP16-NEXT:    mov r5, r1
+; CHECK-FP16-NEXT:    vmov.32 d13[0], r0
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
 ; CHECK-FP16-NEXT:    mov r6, r0
-; CHECK-FP16-NEXT:    vmov.u16 r0, d8[0]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[1]
 ; CHECK-FP16-NEXT:    mov r7, r1
-; CHECK-FP16-NEXT:    vmov.32 d11[0], r6
+; CHECK-FP16-NEXT:    vmov.32 d12[0], r6
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
-; CHECK-FP16-NEXT:    vmov s0, r4
-; CHECK-FP16-NEXT:    mov r8, r0
-; CHECK-FP16-NEXT:    mov r9, r1
-; CHECK-FP16-NEXT:    vmov.32 d12[0], r0
-; CHECK-FP16-NEXT:    bl __fixunshfdi
-; CHECK-FP16-NEXT:    mov r4, r0
-; CHECK-FP16-NEXT:    vmov.u16 r0, d8[2]
-; CHECK-FP16-NEXT:    mov r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d13[0], r4
-; CHECK-FP16-NEXT:    vmov s0, r0
-; CHECK-FP16-NEXT:    bl __fixunshfdi
-; CHECK-FP16-NEXT:    vmov.32 d10[0], r0
-; CHECK-FP16-NEXT:    mvn r3, #0
-; CHECK-FP16-NEXT:    subs r0, r0, r3
+; CHECK-FP16-NEXT:    mvn r12, #0
+; CHECK-FP16-NEXT:    subs r3, r4, r12
+; CHECK-FP16-NEXT:    sbcs r3, r5, #0
+; CHECK-FP16-NEXT:    vmov.32 d12[1], r7
+; CHECK-FP16-NEXT:    mov r3, #0
 ; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    vmov.32 d11[1], r7
-; CHECK-FP16-NEXT:    mov r0, #0
-; CHECK-FP16-NEXT:    movwlo r0, #1
-; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d10[1], r1
-; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    subs r1, r6, r3
-; CHECK-FP16-NEXT:    sbcs r1, r7, #0
+; CHECK-FP16-NEXT:    movwlo r3, #1
+; CHECK-FP16-NEXT:    cmp r3, #0
 ; CHECK-FP16-NEXT:    vmov.32 d13[1], r5
-; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    movwlo r1, #1
-; CHECK-FP16-NEXT:    cmp r1, #0
-; CHECK-FP16-NEXT:    mvnne r1, #0
-; CHECK-FP16-NEXT:    subs r7, r4, r3
-; CHECK-FP16-NEXT:    sbcs r7, r5, #0
-; CHECK-FP16-NEXT:    vdup.32 d19, r1
+; CHECK-FP16-NEXT:    mvnne r3, #0
+; CHECK-FP16-NEXT:    subs r5, r8, r12
+; CHECK-FP16-NEXT:    sbcs r5, r9, #0
+; CHECK-FP16-NEXT:    vmov.32 d11[0], r0
+; CHECK-FP16-NEXT:    mov r5, #0
+; CHECK-FP16-NEXT:    movwlo r5, #1
+; CHECK-FP16-NEXT:    cmp r5, #0
+; CHECK-FP16-NEXT:    mvnne r5, #0
+; CHECK-FP16-NEXT:    subs r6, r6, r12
+; CHECK-FP16-NEXT:    sbcs r7, r7, #0
+; CHECK-FP16-NEXT:    vmov.32 d10[1], r9
 ; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    vdup.32 d18, r0
 ; CHECK-FP16-NEXT:    movwlo r7, #1
 ; CHECK-FP16-NEXT:    cmp r7, #0
 ; CHECK-FP16-NEXT:    mvnne r7, #0
-; CHECK-FP16-NEXT:    subs r3, r8, r3
-; CHECK-FP16-NEXT:    sbcs r3, r9, #0
-; CHECK-FP16-NEXT:    vmov.32 d12[1], r9
+; CHECK-FP16-NEXT:    subs r0, r0, r12
+; CHECK-FP16-NEXT:    sbcs r0, r1, #0
+; CHECK-FP16-NEXT:    vmov.32 d11[1], r1
 ; CHECK-FP16-NEXT:    movwlo r2, #1
 ; CHECK-FP16-NEXT:    cmp r2, #0
-; CHECK-FP16-NEXT:    vdup.32 d17, r7
+; CHECK-FP16-NEXT:    vdup.32 d18, r5
 ; CHECK-FP16-NEXT:    mvnne r2, #0
+; CHECK-FP16-NEXT:    vdup.32 d16, r7
+; CHECK-FP16-NEXT:    vdup.32 d19, r2
 ; CHECK-FP16-NEXT:    vand q10, q5, q9
-; CHECK-FP16-NEXT:    vdup.32 d16, r2
+; CHECK-FP16-NEXT:    vdup.32 d17, r3
 ; CHECK-FP16-NEXT:    vand q11, q6, q8
 ; CHECK-FP16-NEXT:    vorn q9, q10, q9
 ; CHECK-FP16-NEXT:    vorn q8, q11, q8
-; CHECK-FP16-NEXT:    vmovn.i64 d1, q9
-; CHECK-FP16-NEXT:    vmovn.i64 d0, q8
+; CHECK-FP16-NEXT:    vmovn.i64 d0, q9
+; CHECK-FP16-NEXT:    vmovn.i64 d1, q8
 ; CHECK-FP16-NEXT:    vpop {d8}
 ; CHECK-FP16-NEXT:    vpop {d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r11, pc}
@@ -925,8 +935,8 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
-; CHECK-NEON-NEXT:    vmov r0, s2
-; CHECK-NEON-NEXT:    vmov.f32 s16, s3
+; CHECK-NEON-NEXT:    vmov r0, s3
+; CHECK-NEON-NEXT:    vmov.f32 s16, s2
 ; CHECK-NEON-NEXT:    vmov.f32 s18, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
@@ -937,92 +947,92 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEON-NEXT:    mov r2, r0
-; CHECK-NEON-NEXT:    vmov r0, s18
-; CHECK-NEON-NEXT:    vmov.32 d17[0], r2
-; CHECK-NEON-NEXT:    mvn r8, #0
-; CHECK-NEON-NEXT:    subs r2, r2, r8
-; CHECK-NEON-NEXT:    vmov r4, s20
-; CHECK-NEON-NEXT:    vmov.32 d16[0], r5
+; CHECK-NEON-NEXT:    vmov r0, s20
+; CHECK-NEON-NEXT:    vmov.32 d16[0], r2
+; CHECK-NEON-NEXT:    mvn r4, #0
+; CHECK-NEON-NEXT:    subs r2, r2, r4
+; CHECK-NEON-NEXT:    vmov r8, s18
+; CHECK-NEON-NEXT:    vmov.32 d17[0], r5
 ; CHECK-NEON-NEXT:    vmov.i64 q5, #0xffffffff
 ; CHECK-NEON-NEXT:    mov r7, #0
-; CHECK-NEON-NEXT:    vmov.32 d17[1], r1
+; CHECK-NEON-NEXT:    vmov.32 d16[1], r1
 ; CHECK-NEON-NEXT:    sbcs r1, r1, #0
 ; CHECK-NEON-NEXT:    mov r1, #0
 ; CHECK-NEON-NEXT:    movwlt r1, #1
 ; CHECK-NEON-NEXT:    cmp r1, #0
 ; CHECK-NEON-NEXT:    mvnne r1, #0
-; CHECK-NEON-NEXT:    subs r2, r5, r8
+; CHECK-NEON-NEXT:    subs r2, r5, r4
 ; CHECK-NEON-NEXT:    sbcs r2, r6, #0
-; CHECK-NEON-NEXT:    vdup.32 d19, r1
+; CHECK-NEON-NEXT:    vdup.32 d18, r1
 ; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    vmov.32 d16[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d17[1], r6
 ; CHECK-NEON-NEXT:    movwlt r2, #1
 ; CHECK-NEON-NEXT:    cmp r2, #0
 ; CHECK-NEON-NEXT:    mvnne r2, #0
-; CHECK-NEON-NEXT:    vdup.32 d18, r2
+; CHECK-NEON-NEXT:    vdup.32 d19, r2
 ; CHECK-NEON-NEXT:    vorr q4, q9, q9
 ; CHECK-NEON-NEXT:    vbsl q4, q8, q5
-; CHECK-NEON-NEXT:    vmov r10, r9, d8
+; CHECK-NEON-NEXT:    vmov r10, r9, d9
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEON-NEXT:    mov r5, r0
-; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEON-NEXT:    mov r0, r4
+; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
+; CHECK-NEON-NEXT:    mov r0, r8
 ; CHECK-NEON-NEXT:    mov r6, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    subs r2, r5, r8
-; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
+; CHECK-NEON-NEXT:    subs r2, r5, r4
+; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
 ; CHECK-NEON-NEXT:    sbcs r2, r6, #0
 ; CHECK-NEON-NEXT:    mov r2, #0
-; CHECK-NEON-NEXT:    vmov.32 d13[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d12[1], r6
 ; CHECK-NEON-NEXT:    movwlt r2, #1
 ; CHECK-NEON-NEXT:    cmp r2, #0
 ; CHECK-NEON-NEXT:    mvnne r2, #0
-; CHECK-NEON-NEXT:    subs r0, r0, r8
+; CHECK-NEON-NEXT:    subs r0, r0, r4
 ; CHECK-NEON-NEXT:    sbcs r0, r1, #0
-; CHECK-NEON-NEXT:    vmov.32 d12[1], r1
+; CHECK-NEON-NEXT:    vmov.32 d13[1], r1
 ; CHECK-NEON-NEXT:    mov r0, #0
+; CHECK-NEON-NEXT:    vmov r3, r6, d8
 ; CHECK-NEON-NEXT:    movwlt r0, #1
 ; CHECK-NEON-NEXT:    cmp r0, #0
+; CHECK-NEON-NEXT:    vdup.32 d16, r2
 ; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    vdup.32 d17, r2
-; CHECK-NEON-NEXT:    vdup.32 d16, r0
-; CHECK-NEON-NEXT:    vmov r0, r1, d9
+; CHECK-NEON-NEXT:    vdup.32 d17, r0
+; CHECK-NEON-NEXT:    rsbs r0, r10, #0
 ; CHECK-NEON-NEXT:    vbsl q8, q6, q5
-; CHECK-NEON-NEXT:    rsbs r6, r10, #0
-; CHECK-NEON-NEXT:    rscs r6, r9, #0
-; CHECK-NEON-NEXT:    mov r6, #0
-; CHECK-NEON-NEXT:    vmov r2, r3, d17
-; CHECK-NEON-NEXT:    movwlt r6, #1
-; CHECK-NEON-NEXT:    vmov r5, r4, d16
-; CHECK-NEON-NEXT:    cmp r6, #0
-; CHECK-NEON-NEXT:    mvnne r6, #0
-; CHECK-NEON-NEXT:    rsbs r0, r0, #0
-; CHECK-NEON-NEXT:    rscs r0, r1, #0
+; CHECK-NEON-NEXT:    rscs r0, r9, #0
 ; CHECK-NEON-NEXT:    mov r0, #0
 ; CHECK-NEON-NEXT:    movwlt r0, #1
 ; CHECK-NEON-NEXT:    cmp r0, #0
+; CHECK-NEON-NEXT:    vmov r1, r2, d16
 ; CHECK-NEON-NEXT:    mvnne r0, #0
-; CHECK-NEON-NEXT:    rsbs r1, r2, #0
-; CHECK-NEON-NEXT:    rscs r1, r3, #0
-; CHECK-NEON-NEXT:    vdup.32 d21, r0
+; CHECK-NEON-NEXT:    vmov r5, r4, d17
+; CHECK-NEON-NEXT:    rsbs r1, r1, #0
+; CHECK-NEON-NEXT:    rscs r1, r2, #0
 ; CHECK-NEON-NEXT:    mov r1, #0
-; CHECK-NEON-NEXT:    vdup.32 d20, r6
 ; CHECK-NEON-NEXT:    movwlt r1, #1
 ; CHECK-NEON-NEXT:    cmp r1, #0
 ; CHECK-NEON-NEXT:    mvnne r1, #0
-; CHECK-NEON-NEXT:    rsbs r2, r5, #0
-; CHECK-NEON-NEXT:    rscs r2, r4, #0
-; CHECK-NEON-NEXT:    vdup.32 d19, r1
+; CHECK-NEON-NEXT:    rsbs r2, r3, #0
+; CHECK-NEON-NEXT:    rscs r2, r6, #0
+; CHECK-NEON-NEXT:    vdup.32 d20, r1
+; CHECK-NEON-NEXT:    mov r2, #0
+; CHECK-NEON-NEXT:    movwlt r2, #1
+; CHECK-NEON-NEXT:    cmp r2, #0
+; CHECK-NEON-NEXT:    mvnne r2, #0
+; CHECK-NEON-NEXT:    rsbs r3, r5, #0
+; CHECK-NEON-NEXT:    rscs r3, r4, #0
+; CHECK-NEON-NEXT:    vdup.32 d18, r2
 ; CHECK-NEON-NEXT:    movwlt r7, #1
 ; CHECK-NEON-NEXT:    cmp r7, #0
 ; CHECK-NEON-NEXT:    mvnne r7, #0
-; CHECK-NEON-NEXT:    vand q10, q10, q4
-; CHECK-NEON-NEXT:    vdup.32 d18, r7
-; CHECK-NEON-NEXT:    vand q8, q9, q8
-; CHECK-NEON-NEXT:    vmovn.i64 d1, q10
+; CHECK-NEON-NEXT:    vdup.32 d19, r0
+; CHECK-NEON-NEXT:    vdup.32 d21, r7
+; CHECK-NEON-NEXT:    vand q9, q9, q4
+; CHECK-NEON-NEXT:    vand q8, q10, q8
 ; CHECK-NEON-NEXT:    vmovn.i64 d0, q8
+; CHECK-NEON-NEXT:    vmovn.i64 d1, q9
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
@@ -1032,21 +1042,21 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r11, lr}
 ; CHECK-FP16-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[3]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[2]
 ; CHECK-FP16-NEXT:    vorr d8, d0, d0
-; CHECK-FP16-NEXT:    vmov.u16 r8, d0[1]
+; CHECK-FP16-NEXT:    vmov.u16 r8, d0[0]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    mov r4, r0
-; CHECK-FP16-NEXT:    vmov.u16 r0, d8[2]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[3]
 ; CHECK-FP16-NEXT:    mov r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d11[0], r4
+; CHECK-FP16-NEXT:    vmov.32 d10[0], r4
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    mvn r7, #0
 ; CHECK-FP16-NEXT:    subs r2, r4, r7
 ; CHECK-FP16-NEXT:    sbcs r2, r5, #0
-; CHECK-FP16-NEXT:    vmov.32 d10[0], r0
+; CHECK-FP16-NEXT:    vmov.32 d11[0], r0
 ; CHECK-FP16-NEXT:    mov r2, #0
 ; CHECK-FP16-NEXT:    vmov.i64 q6, #0xffffffff
 ; CHECK-FP16-NEXT:    movwlt r2, #1
@@ -1054,77 +1064,77 @@ define <4 x i32> @ustest_f16i32(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    mvnne r2, #0
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    vmov.32 d11[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d10[1], r5
 ; CHECK-FP16-NEXT:    mov r0, #0
 ; CHECK-FP16-NEXT:    vmov s0, r8
 ; CHECK-FP16-NEXT:    movwlt r0, #1
 ; CHECK-FP16-NEXT:    cmp r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d10[1], r1
+; CHECK-FP16-NEXT:    vmov.32 d11[1], r1
 ; CHECK-FP16-NEXT:    mvnne r0, #0
 ; CHECK-FP16-NEXT:    mov r6, #0
-; CHECK-FP16-NEXT:    vdup.32 d17, r2
-; CHECK-FP16-NEXT:    vdup.32 d16, r0
+; CHECK-FP16-NEXT:    vdup.32 d16, r2
+; CHECK-FP16-NEXT:    vdup.32 d17, r0
 ; CHECK-FP16-NEXT:    vbif q5, q6, q8
-; CHECK-FP16-NEXT:    vmov r9, r8, d10
+; CHECK-FP16-NEXT:    vmov r9, r8, d11
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    mov r4, r0
-; CHECK-FP16-NEXT:    vmov.u16 r0, d8[0]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d8[1]
 ; CHECK-FP16-NEXT:    mov r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d9[0], r4
+; CHECK-FP16-NEXT:    vmov.32 d8[0], r4
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    subs r2, r4, r7
-; CHECK-FP16-NEXT:    vmov.32 d8[0], r0
+; CHECK-FP16-NEXT:    vmov.32 d9[0], r0
 ; CHECK-FP16-NEXT:    sbcs r2, r5, #0
 ; CHECK-FP16-NEXT:    mov r2, #0
-; CHECK-FP16-NEXT:    vmov.32 d9[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d8[1], r5
 ; CHECK-FP16-NEXT:    movwlt r2, #1
 ; CHECK-FP16-NEXT:    cmp r2, #0
 ; CHECK-FP16-NEXT:    mvnne r2, #0
 ; CHECK-FP16-NEXT:    subs r0, r0, r7
 ; CHECK-FP16-NEXT:    sbcs r0, r1, #0
-; CHECK-FP16-NEXT:    vmov.32 d8[1], r1
+; CHECK-FP16-NEXT:    vmov.32 d9[1], r1
 ; CHECK-FP16-NEXT:    mov r0, #0
+; CHECK-FP16-NEXT:    vmov r3, r7, d10
 ; CHECK-FP16-NEXT:    movwlt r0, #1
 ; CHECK-FP16-NEXT:    cmp r0, #0
+; CHECK-FP16-NEXT:    vdup.32 d16, r2
 ; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    vdup.32 d17, r2
-; CHECK-FP16-NEXT:    vdup.32 d16, r0
-; CHECK-FP16-NEXT:    vmov r0, r1, d11
+; CHECK-FP16-NEXT:    vdup.32 d17, r0
+; CHECK-FP16-NEXT:    rsbs r0, r9, #0
 ; CHECK-FP16-NEXT:    vbsl q8, q4, q6
-; CHECK-FP16-NEXT:    rsbs r7, r9, #0
-; CHECK-FP16-NEXT:    rscs r7, r8, #0
-; CHECK-FP16-NEXT:    mov r7, #0
-; CHECK-FP16-NEXT:    vmov r2, r3, d17
-; CHECK-FP16-NEXT:    movwlt r7, #1
-; CHECK-FP16-NEXT:    vmov r5, r4, d16
-; CHECK-FP16-NEXT:    cmp r7, #0
-; CHECK-FP16-NEXT:    mvnne r7, #0
-; CHECK-FP16-NEXT:    rsbs r0, r0, #0
-; CHECK-FP16-NEXT:    rscs r0, r1, #0
+; CHECK-FP16-NEXT:    rscs r0, r8, #0
 ; CHECK-FP16-NEXT:    mov r0, #0
 ; CHECK-FP16-NEXT:    movwlt r0, #1
 ; CHECK-FP16-NEXT:    cmp r0, #0
+; CHECK-FP16-NEXT:    vmov r1, r2, d16
 ; CHECK-FP16-NEXT:    mvnne r0, #0
-; CHECK-FP16-NEXT:    rsbs r1, r2, #0
-; CHECK-FP16-NEXT:    rscs r1, r3, #0
-; CHECK-FP16-NEXT:    vdup.32 d21, r0
+; CHECK-FP16-NEXT:    vmov r5, r4, d17
+; CHECK-FP16-NEXT:    rsbs r1, r1, #0
+; CHECK-FP16-NEXT:    rscs r1, r2, #0
 ; CHECK-FP16-NEXT:    mov r1, #0
-; CHECK-FP16-NEXT:    vdup.32 d20, r7
 ; CHECK-FP16-NEXT:    movwlt r1, #1
 ; CHECK-FP16-NEXT:    cmp r1, #0
 ; CHECK-FP16-NEXT:    mvnne r1, #0
-; CHECK-FP16-NEXT:    rsbs r2, r5, #0
-; CHECK-FP16-NEXT:    rscs r2, r4, #0
-; CHECK-FP16-NEXT:    vdup.32 d19, r1
+; CHECK-FP16-NEXT:    rsbs r2, r3, #0
+; CHECK-FP16-NEXT:    rscs r2, r7, #0
+; CHECK-FP16-NEXT:    vdup.32 d20, r1
+; CHECK-FP16-NEXT:    mov r2, #0
+; CHECK-FP16-NEXT:    movwlt r2, #1
+; CHECK-FP16-NEXT:    cmp r2, #0
+; CHECK-FP16-NEXT:    mvnne r2, #0
+; CHECK-FP16-NEXT:    rsbs r3, r5, #0
+; CHECK-FP16-NEXT:    rscs r3, r4, #0
+; CHECK-FP16-NEXT:    vdup.32 d18, r2
 ; CHECK-FP16-NEXT:    movwlt r6, #1
 ; CHECK-FP16-NEXT:    cmp r6, #0
 ; CHECK-FP16-NEXT:    mvnne r6, #0
-; CHECK-FP16-NEXT:    vand q10, q10, q5
-; CHECK-FP16-NEXT:    vdup.32 d18, r6
-; CHECK-FP16-NEXT:    vand q8, q9, q8
-; CHECK-FP16-NEXT:    vmovn.i64 d1, q10
+; CHECK-FP16-NEXT:    vdup.32 d19, r0
+; CHECK-FP16-NEXT:    vdup.32 d21, r6
+; CHECK-FP16-NEXT:    vand q9, q9, q5
+; CHECK-FP16-NEXT:    vand q8, q10, q8
 ; CHECK-FP16-NEXT:    vmovn.i64 d0, q8
+; CHECK-FP16-NEXT:    vmovn.i64 d1, q9
 ; CHECK-FP16-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r11, pc}
 entry:
@@ -1270,115 +1280,115 @@ define <8 x i16> @stest_f16i16(<8 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEON-NEXT:    vmov r0, s1
-; CHECK-NEON-NEXT:    vmov.f32 s16, s7
-; CHECK-NEON-NEXT:    vmov.f32 s18, s6
-; CHECK-NEON-NEXT:    vmov.f32 s20, s5
-; CHECK-NEON-NEXT:    vmov.f32 s22, s4
-; CHECK-NEON-NEXT:    vmov.f32 s24, s3
-; CHECK-NEON-NEXT:    vmov.f32 s26, s2
+; CHECK-NEON-NEXT:    vmov r0, s7
+; CHECK-NEON-NEXT:    vmov.f32 s16, s6
+; CHECK-NEON-NEXT:    vmov.f32 s18, s5
+; CHECK-NEON-NEXT:    vmov.f32 s20, s4
+; CHECK-NEON-NEXT:    vmov.f32 s22, s3
+; CHECK-NEON-NEXT:    vmov.f32 s24, s2
+; CHECK-NEON-NEXT:    vmov.f32 s26, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s28, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r4, r0
-; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    vmov r0, s20
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r5, r0
-; CHECK-NEON-NEXT:    vmov r0, s22
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s24
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r7, r0
+; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s18
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov s22, r7
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov s30, r6
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[1], r0
+; CHECK-NEON-NEXT:    mov r7, r0
 ; CHECK-NEON-NEXT:    vmov r0, s28
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r1, s20
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[0], r0
+; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov s20, r7
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov s24, r6
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[1], r0
+; CHECK-NEON-NEXT:    vmov r0, s16
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov r1, s22
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r5
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s20, s2
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s22, s2
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s30
-; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s24
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d15[0], r0
 ; CHECK-NEON-NEXT:    mov r0, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r0, s20
+; CHECK-NEON-NEXT:    vmov r0, s22
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r4
 ; CHECK-NEON-NEXT:    vmov.i32 q8, #0x7fff
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s2, s2
 ; CHECK-NEON-NEXT:    vmvn.i32 q9, #0x7fff
-; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s22
-; CHECK-NEON-NEXT:    vmov.32 d12[1], r0
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s20
+; CHECK-NEON-NEXT:    vmov.32 d15[1], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmin.s32 q10, q6, q8
+; CHECK-NEON-NEXT:    vmin.s32 q10, q7, q8
 ; CHECK-NEON-NEXT:    vmax.s32 q10, q10, q9
-; CHECK-NEON-NEXT:    vmov.32 d9[1], r0
-; CHECK-NEON-NEXT:    vmov r0, s2
-; CHECK-NEON-NEXT:    vmovn.i32 d1, q10
 ; CHECK-NEON-NEXT:    vmov.32 d8[1], r0
+; CHECK-NEON-NEXT:    vmov r0, s2
+; CHECK-NEON-NEXT:    vmovn.i32 d0, q10
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r0
 ; CHECK-NEON-NEXT:    vmin.s32 q8, q4, q8
 ; CHECK-NEON-NEXT:    vmax.s32 q8, q8, q9
-; CHECK-NEON-NEXT:    vmovn.i32 d0, q8
+; CHECK-NEON-NEXT:    vmovn.i32 d1, q8
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; CHECK-FP16-LABEL: stest_f16i16:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    vmovx.f16 s4, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s12, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s0, s3
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s5, s2
+; CHECK-FP16-NEXT:    vmovx.f16 s10, s0
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s0, s0
 ; CHECK-FP16-NEXT:    vmov r0, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s14, s1
-; CHECK-FP16-NEXT:    vmovx.f16 s10, s3
-; CHECK-FP16-NEXT:    vmovx.f16 s8, s2
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s5, s1
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s14, s2
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s12, s3
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s10, s10
+; CHECK-FP16-NEXT:    vmovx.f16 s8, s1
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s8, s8
-; CHECK-FP16-NEXT:    vmovx.f16 s6, s1
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s4, s4
+; CHECK-FP16-NEXT:    vmovx.f16 s6, s2
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s6, s6
+; CHECK-FP16-NEXT:    vmovx.f16 s4, s3
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s4, s4
 ; CHECK-FP16-NEXT:    vmov.i32 q10, #0x7fff
 ; CHECK-FP16-NEXT:    vmvn.i32 q11, #0x7fff
-; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s5
 ; CHECK-FP16-NEXT:    vmov.32 d16[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s5
+; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s14
-; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s12
 ; CHECK-FP16-NEXT:    vmov.32 d18[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s12
+; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s10
-; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s8
 ; CHECK-FP16-NEXT:    vmov.32 d16[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s8
+; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
 ; CHECK-FP16-NEXT:    vmov r0, s6
 ; CHECK-FP16-NEXT:    vmin.s32 q8, q8, q10
 ; CHECK-FP16-NEXT:    vmax.s32 q8, q8, q11
-; CHECK-FP16-NEXT:    vmovn.i32 d1, q8
-; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmovn.i32 d0, q8
 ; CHECK-FP16-NEXT:    vmov.32 d18[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
 ; CHECK-FP16-NEXT:    vmin.s32 q9, q9, q10
 ; CHECK-FP16-NEXT:    vmax.s32 q9, q9, q11
-; CHECK-FP16-NEXT:    vmovn.i32 d0, q9
+; CHECK-FP16-NEXT:    vmovn.i32 d1, q9
 ; CHECK-FP16-NEXT:    bx lr
 entry:
   %conv = fptosi <8 x half> %x to <8 x i32>
@@ -1395,111 +1405,111 @@ define <8 x i16> @utest_f16i16(<8 x half> %x) {
 ; CHECK-NEON:       @ %bb.0: @ %entry
 ; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
-; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
-; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
-; CHECK-NEON-NEXT:    vmov r0, s1
-; CHECK-NEON-NEXT:    vmov.f32 s16, s7
-; CHECK-NEON-NEXT:    vmov.f32 s18, s6
-; CHECK-NEON-NEXT:    vmov.f32 s20, s5
-; CHECK-NEON-NEXT:    vmov.f32 s22, s4
-; CHECK-NEON-NEXT:    vmov.f32 s24, s3
-; CHECK-NEON-NEXT:    vmov.f32 s26, s2
+; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEON-NEXT:    vmov r0, s7
+; CHECK-NEON-NEXT:    vmov.f32 s16, s6
+; CHECK-NEON-NEXT:    vmov.f32 s18, s5
+; CHECK-NEON-NEXT:    vmov.f32 s20, s4
+; CHECK-NEON-NEXT:    vmov.f32 s22, s3
+; CHECK-NEON-NEXT:    vmov.f32 s24, s2
+; CHECK-NEON-NEXT:    vmov.f32 s26, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s28, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r4, r0
-; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    vmov r0, s20
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r5, r0
-; CHECK-NEON-NEXT:    vmov r0, s22
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s24
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r7, r0
+; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s18
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov s16, r7
-; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov s18, r6
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[1], r0
+; CHECK-NEON-NEXT:    mov r7, r0
 ; CHECK-NEON-NEXT:    vmov r0, s28
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r1, s20
+; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[0], r0
+; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov s20, r7
+; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov s24, r6
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[1], r0
+; CHECK-NEON-NEXT:    vmov r0, s16
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov r1, s22
 ; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r5
+; CHECK-NEON-NEXT:    vcvt.u32.f32 s22, s2
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s18
-; CHECK-NEON-NEXT:    vcvt.u32.f32 s18, s2
-; CHECK-NEON-NEXT:    vmov.32 d10[0], r0
+; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s24
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d15[0], r0
 ; CHECK-NEON-NEXT:    mov r0, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r0, s18
+; CHECK-NEON-NEXT:    vmov r0, s22
 ; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r4
 ; CHECK-NEON-NEXT:    vmov.i32 q8, #0xffff
 ; CHECK-NEON-NEXT:    vcvt.u32.f32 s2, s2
-; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s16
-; CHECK-NEON-NEXT:    vmov.32 d12[1], r0
+; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s20
+; CHECK-NEON-NEXT:    vmov.32 d15[1], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmin.u32 q9, q6, q8
-; CHECK-NEON-NEXT:    vmov.32 d11[1], r0
+; CHECK-NEON-NEXT:    vmin.u32 q9, q7, q8
+; CHECK-NEON-NEXT:    vmov.32 d8[1], r0
 ; CHECK-NEON-NEXT:    vmov r0, s2
-; CHECK-NEON-NEXT:    vmovn.i32 d1, q9
-; CHECK-NEON-NEXT:    vmov.32 d10[1], r0
-; CHECK-NEON-NEXT:    vmin.u32 q8, q5, q8
-; CHECK-NEON-NEXT:    vmovn.i32 d0, q8
-; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
+; CHECK-NEON-NEXT:    vmovn.i32 d0, q9
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r0
+; CHECK-NEON-NEXT:    vmin.u32 q8, q4, q8
+; CHECK-NEON-NEXT:    vmovn.i32 d1, q8
+; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; CHECK-FP16-LABEL: utest_f16i16:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    vmovx.f16 s4, s0
-; CHECK-FP16-NEXT:    vcvt.u32.f16 s12, s0
-; CHECK-FP16-NEXT:    vcvt.u32.f16 s0, s3
-; CHECK-FP16-NEXT:    vcvt.u32.f16 s5, s2
+; CHECK-FP16-NEXT:    vmovx.f16 s10, s0
+; CHECK-FP16-NEXT:    vcvt.u32.f16 s0, s0
 ; CHECK-FP16-NEXT:    vmov r0, s0
-; CHECK-FP16-NEXT:    vcvt.u32.f16 s14, s1
-; CHECK-FP16-NEXT:    vmovx.f16 s10, s3
-; CHECK-FP16-NEXT:    vmovx.f16 s8, s2
+; CHECK-FP16-NEXT:    vcvt.u32.f16 s5, s1
+; CHECK-FP16-NEXT:    vcvt.u32.f16 s14, s2
+; CHECK-FP16-NEXT:    vcvt.u32.f16 s12, s3
 ; CHECK-FP16-NEXT:    vcvt.u32.f16 s10, s10
+; CHECK-FP16-NEXT:    vmovx.f16 s8, s1
 ; CHECK-FP16-NEXT:    vcvt.u32.f16 s8, s8
-; CHECK-FP16-NEXT:    vmovx.f16 s6, s1
-; CHECK-FP16-NEXT:    vcvt.u32.f16 s4, s4
+; CHECK-FP16-NEXT:    vmovx.f16 s6, s2
 ; CHECK-FP16-NEXT:    vcvt.u32.f16 s6, s6
+; CHECK-FP16-NEXT:    vmovx.f16 s4, s3
+; CHECK-FP16-NEXT:    vcvt.u32.f16 s4, s4
 ; CHECK-FP16-NEXT:    vmov.i32 q10, #0xffff
-; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s5
 ; CHECK-FP16-NEXT:    vmov.32 d16[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s5
+; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s14
-; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s12
 ; CHECK-FP16-NEXT:    vmov.32 d18[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s12
+; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s10
-; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s8
 ; CHECK-FP16-NEXT:    vmov.32 d16[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s8
+; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
 ; CHECK-FP16-NEXT:    vmov r0, s6
 ; CHECK-FP16-NEXT:    vmin.u32 q8, q8, q10
-; CHECK-FP16-NEXT:    vmovn.i32 d1, q8
-; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmovn.i32 d0, q8
 ; CHECK-FP16-NEXT:    vmov.32 d18[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
 ; CHECK-FP16-NEXT:    vmin.u32 q9, q9, q10
-; CHECK-FP16-NEXT:    vmovn.i32 d0, q9
+; CHECK-FP16-NEXT:    vmovn.i32 d1, q9
 ; CHECK-FP16-NEXT:    bx lr
 entry:
   %conv = fptoui <8 x half> %x to <8 x i32>
@@ -1516,115 +1526,115 @@ define <8 x i16> @ustest_f16i16(<8 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEON-NEXT:    vmov r0, s1
-; CHECK-NEON-NEXT:    vmov.f32 s16, s7
-; CHECK-NEON-NEXT:    vmov.f32 s18, s6
-; CHECK-NEON-NEXT:    vmov.f32 s20, s5
-; CHECK-NEON-NEXT:    vmov.f32 s22, s4
-; CHECK-NEON-NEXT:    vmov.f32 s24, s3
-; CHECK-NEON-NEXT:    vmov.f32 s26, s2
+; CHECK-NEON-NEXT:    vmov r0, s7
+; CHECK-NEON-NEXT:    vmov.f32 s16, s6
+; CHECK-NEON-NEXT:    vmov.f32 s18, s5
+; CHECK-NEON-NEXT:    vmov.f32 s20, s4
+; CHECK-NEON-NEXT:    vmov.f32 s22, s3
+; CHECK-NEON-NEXT:    vmov.f32 s24, s2
+; CHECK-NEON-NEXT:    vmov.f32 s26, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s28, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r4, r0
-; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    vmov r0, s20
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r5, r0
-; CHECK-NEON-NEXT:    vmov r0, s22
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s24
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r7, r0
+; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s18
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov s22, r7
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov s30, r6
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[1], r0
+; CHECK-NEON-NEXT:    mov r7, r0
 ; CHECK-NEON-NEXT:    vmov r0, s28
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r1, s20
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[0], r0
+; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov s20, r7
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov s24, r6
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[1], r0
+; CHECK-NEON-NEXT:    vmov r0, s16
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov r1, s22
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r5
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s20, s2
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s22, s2
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s30
-; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s24
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d15[0], r0
 ; CHECK-NEON-NEXT:    mov r0, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r0, s20
+; CHECK-NEON-NEXT:    vmov r0, s22
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r4
 ; CHECK-NEON-NEXT:    vmov.i32 q8, #0xffff
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s2, s2
 ; CHECK-NEON-NEXT:    vmov.i32 q9, #0x0
-; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s22
-; CHECK-NEON-NEXT:    vmov.32 d12[1], r0
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s20
+; CHECK-NEON-NEXT:    vmov.32 d15[1], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmin.s32 q10, q6, q8
+; CHECK-NEON-NEXT:    vmin.s32 q10, q7, q8
 ; CHECK-NEON-NEXT:    vmax.s32 q10, q10, q9
-; CHECK-NEON-NEXT:    vmov.32 d9[1], r0
-; CHECK-NEON-NEXT:    vmov r0, s2
-; CHECK-NEON-NEXT:    vmovn.i32 d1, q10
 ; CHECK-NEON-NEXT:    vmov.32 d8[1], r0
+; CHECK-NEON-NEXT:    vmov r0, s2
+; CHECK-NEON-NEXT:    vmovn.i32 d0, q10
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r0
 ; CHECK-NEON-NEXT:    vmin.s32 q8, q4, q8
 ; CHECK-NEON-NEXT:    vmax.s32 q8, q8, q9
-; CHECK-NEON-NEXT:    vmovn.i32 d0, q8
+; CHECK-NEON-NEXT:    vmovn.i32 d1, q8
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; CHECK-FP16-LABEL: ustest_f16i16:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    vmovx.f16 s4, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s12, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s0, s3
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s5, s2
+; CHECK-FP16-NEXT:    vmovx.f16 s10, s0
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s0, s0
 ; CHECK-FP16-NEXT:    vmov r0, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s14, s1
-; CHECK-FP16-NEXT:    vmovx.f16 s10, s3
-; CHECK-FP16-NEXT:    vmovx.f16 s8, s2
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s5, s1
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s14, s2
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s12, s3
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s10, s10
+; CHECK-FP16-NEXT:    vmovx.f16 s8, s1
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s8, s8
-; CHECK-FP16-NEXT:    vmovx.f16 s6, s1
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s4, s4
+; CHECK-FP16-NEXT:    vmovx.f16 s6, s2
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s6, s6
+; CHECK-FP16-NEXT:    vmovx.f16 s4, s3
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s4, s4
 ; CHECK-FP16-NEXT:    vmov.i32 q10, #0xffff
 ; CHECK-FP16-NEXT:    vmov.i32 q11, #0x0
-; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s5
 ; CHECK-FP16-NEXT:    vmov.32 d16[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s5
+; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s14
-; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s12
 ; CHECK-FP16-NEXT:    vmov.32 d18[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s12
+; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s10
-; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s8
 ; CHECK-FP16-NEXT:    vmov.32 d16[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s8
+; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
 ; CHECK-FP16-NEXT:    vmov r0, s6
 ; CHECK-FP16-NEXT:    vmin.s32 q8, q8, q10
 ; CHECK-FP16-NEXT:    vmax.s32 q8, q8, q11
-; CHECK-FP16-NEXT:    vmovn.i32 d1, q8
-; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmovn.i32 d0, q8
 ; CHECK-FP16-NEXT:    vmov.32 d18[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
 ; CHECK-FP16-NEXT:    vmin.s32 q9, q9, q10
 ; CHECK-FP16-NEXT:    vmax.s32 q9, q9, q11
-; CHECK-FP16-NEXT:    vmovn.i32 d0, q9
+; CHECK-FP16-NEXT:    vmovn.i32 d1, q9
 ; CHECK-FP16-NEXT:    bx lr
 entry:
   %conv = fptosi <8 x half> %x to <8 x i32>
@@ -1646,14 +1656,13 @@ define <2 x i64> @stest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    mvn r9, #0
 ; CHECK-NEXT:    subs r1, r0, r9
 ; CHECK-NEXT:    mvn r5, #-2147483648
 ; CHECK-NEXT:    sbcs r1, r4, r5
-; CHECK-NEXT:    vorr d0, d8, d8
+; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    sbcs r1, r2, #0
 ; CHECK-NEXT:    mov r7, #0
 ; CHECK-NEXT:    sbcs r1, r3, #0
@@ -1676,7 +1685,7 @@ define <2 x i64> @stest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    moveq r4, r8
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d1[0], r7
+; CHECK-NEXT:    vmov.32 d0[0], r7
 ; CHECK-NEXT:    sbcs r6, r1, r5
 ; CHECK-NEXT:    sbcs r6, r2, #0
 ; CHECK-NEXT:    sbcs r6, r3, #0
@@ -1695,9 +1704,9 @@ define <2 x i64> @stest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    cmp r10, #0
 ; CHECK-NEXT:    movne r10, r0
 ; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d0[0], r10
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -1718,11 +1727,10 @@ define <2 x i64> @utest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    subs r1, r2, #1
-; CHECK-NEXT:    vorr d0, d8, d8
+; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    sbcs r1, r3, #0
 ; CHECK-NEXT:    mov r6, #0
 ; CHECK-NEXT:    mov r5, #0
@@ -1732,15 +1740,15 @@ define <2 x i64> @utest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    movne r6, r0
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEXT:    vmov.32 d0[0], r6
 ; CHECK-NEXT:    sbcs r2, r3, #0
 ; CHECK-NEXT:    movwlo r5, #1
 ; CHECK-NEXT:    cmp r5, #0
 ; CHECK-NEXT:    moveq r0, r5
 ; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[0], r0
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -1759,7 +1767,6 @@ define <2 x i64> @ustest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    subs r1, r2, #1
@@ -1774,7 +1781,7 @@ define <2 x i64> @ustest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    movne r1, r0
 ; CHECK-NEXT:    rsbs r0, r1, #0
 ; CHECK-NEXT:    rscs r0, r4, #0
-; CHECK-NEXT:    vorr d0, d8, d8
+; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    rscs r0, r2, #0
 ; CHECK-NEXT:    mov r7, #0
 ; CHECK-NEXT:    rscs r0, r3, #0
@@ -1785,7 +1792,7 @@ define <2 x i64> @ustest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    movne r7, r1
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs r6, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r7
+; CHECK-NEXT:    vmov.32 d0[0], r7
 ; CHECK-NEXT:    sbcs r6, r3, #0
 ; CHECK-NEXT:    movlt r8, r2
 ; CHECK-NEXT:    mov r2, #0
@@ -1802,9 +1809,9 @@ define <2 x i64> @ustest_f64i64(<2 x double> %x) {
 ; CHECK-NEXT:    cmp r5, #0
 ; CHECK-NEXT:    moveq r2, r5
 ; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    vmov.32 d0[0], r2
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[0], r2
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
@@ -1825,14 +1832,13 @@ define <2 x i64> @stest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    .vsave {d8}
 ; CHECK-NEXT:    vpush {d8}
 ; CHECK-NEXT:    vmov.f64 d8, d0
-; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    mvn r9, #0
 ; CHECK-NEXT:    subs r1, r0, r9
 ; CHECK-NEXT:    mvn r5, #-2147483648
 ; CHECK-NEXT:    sbcs r1, r4, r5
-; CHECK-NEXT:    vmov.f32 s0, s16
+; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    sbcs r1, r2, #0
 ; CHECK-NEXT:    mov r7, #0
 ; CHECK-NEXT:    sbcs r1, r3, #0
@@ -1855,7 +1861,7 @@ define <2 x i64> @stest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    moveq r4, r8
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d1[0], r7
+; CHECK-NEXT:    vmov.32 d0[0], r7
 ; CHECK-NEXT:    sbcs r6, r1, r5
 ; CHECK-NEXT:    sbcs r6, r2, #0
 ; CHECK-NEXT:    sbcs r6, r3, #0
@@ -1874,9 +1880,9 @@ define <2 x i64> @stest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    cmp r10, #0
 ; CHECK-NEXT:    movne r10, r0
 ; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d0[0], r10
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -1897,9 +1903,8 @@ define <2 x i64> @utest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    .vsave {d8}
 ; CHECK-NEXT:    vpush {d8}
 ; CHECK-NEXT:    vmov.f64 d8, d0
-; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    bl __fixunssfti
-; CHECK-NEXT:    vmov.f32 s0, s16
+; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    subs r1, r2, #1
 ; CHECK-NEXT:    mov r6, #0
@@ -1911,15 +1916,15 @@ define <2 x i64> @utest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    movne r6, r0
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEXT:    vmov.32 d0[0], r6
 ; CHECK-NEXT:    sbcs r2, r3, #0
 ; CHECK-NEXT:    movwlo r5, #1
 ; CHECK-NEXT:    cmp r5, #0
 ; CHECK-NEXT:    moveq r0, r5
 ; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[0], r0
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -1938,14 +1943,13 @@ define <2 x i64> @ustest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    .vsave {d8}
 ; CHECK-NEXT:    vpush {d8}
 ; CHECK-NEXT:    vmov.f64 d8, d0
-; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    subs r1, r2, #1
 ; CHECK-NEXT:    sbcs r1, r3, #0
 ; CHECK-NEXT:    mov r8, #1
 ; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    vmov.f32 s0, s16
+; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    movge r2, r8
 ; CHECK-NEXT:    movwlt r1, #1
 ; CHECK-NEXT:    cmp r1, #0
@@ -1964,7 +1968,7 @@ define <2 x i64> @ustest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    movne r7, r1
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs r6, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r7
+; CHECK-NEXT:    vmov.32 d0[0], r7
 ; CHECK-NEXT:    sbcs r6, r3, #0
 ; CHECK-NEXT:    movlt r8, r2
 ; CHECK-NEXT:    mov r2, #0
@@ -1981,9 +1985,9 @@ define <2 x i64> @ustest_f32i64(<2 x float> %x) {
 ; CHECK-NEXT:    cmp r5, #0
 ; CHECK-NEXT:    moveq r2, r5
 ; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    vmov.32 d0[0], r2
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[0], r2
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
@@ -2003,8 +2007,8 @@ define <2 x i64> @stest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8}
 ; CHECK-NEON-NEXT:    vpush {d8}
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.f32 s16, s1
+; CHECK-NEON-NEXT:    vmov r0, s1
+; CHECK-NEON-NEXT:    vmov.f32 s16, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r8, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
@@ -2039,7 +2043,7 @@ define <2 x i64> @stest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    moveq r4, r8
 ; CHECK-NEON-NEXT:    bl __fixsfti
 ; CHECK-NEON-NEXT:    subs r7, r0, r9
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEON-NEXT:    sbcs r7, r1, r6
 ; CHECK-NEON-NEXT:    sbcs r7, r2, #0
 ; CHECK-NEON-NEXT:    sbcs r7, r3, #0
@@ -2058,9 +2062,9 @@ define <2 x i64> @stest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    cmp r10, #0
 ; CHECK-NEON-NEXT:    movne r10, r0
 ; CHECK-NEON-NEXT:    moveq r6, r8
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r10
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r6
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
@@ -2068,8 +2072,8 @@ define <2 x i64> @stest_f16i64(<2 x half> %x) {
 ; CHECK-FP16:       @ %bb.0: @ %entry
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
-; CHECK-FP16-NEXT:    vmov.u16 r7, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r7, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    mov r4, r1
@@ -2100,7 +2104,7 @@ define <2 x i64> @stest_f16i64(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    moveq r4, r8
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    subs r6, r0, r9
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r7
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r7
 ; CHECK-FP16-NEXT:    sbcs r6, r1, r5
 ; CHECK-FP16-NEXT:    sbcs r6, r2, #0
 ; CHECK-FP16-NEXT:    sbcs r6, r3, #0
@@ -2119,9 +2123,9 @@ define <2 x i64> @stest_f16i64(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    cmp r10, #0
 ; CHECK-FP16-NEXT:    movne r10, r0
 ; CHECK-FP16-NEXT:    moveq r5, r8
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r10
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r10
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <2 x half> %x to <2 x i128>
@@ -2140,8 +2144,8 @@ define <2 x i64> @utest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8}
 ; CHECK-NEON-NEXT:    vpush {d8}
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.f32 s16, s1
+; CHECK-NEON-NEXT:    vmov r0, s1
+; CHECK-NEON-NEXT:    vmov.f32 s16, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r5, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
@@ -2160,15 +2164,15 @@ define <2 x i64> @utest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    movne r5, r0
 ; CHECK-NEON-NEXT:    bl __fixunssfti
 ; CHECK-NEON-NEXT:    subs r2, r2, #1
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEON-NEXT:    sbcs r2, r3, #0
 ; CHECK-NEON-NEXT:    movwlo r6, #1
 ; CHECK-NEON-NEXT:    cmp r6, #0
 ; CHECK-NEON-NEXT:    moveq r0, r6
 ; CHECK-NEON-NEXT:    movne r6, r1
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r6
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -2176,8 +2180,8 @@ define <2 x i64> @utest_f16i64(<2 x half> %x) {
 ; CHECK-FP16:       @ %bb.0: @ %entry
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, lr}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
-; CHECK-FP16-NEXT:    vmov.u16 r6, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r6, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfti
 ; CHECK-FP16-NEXT:    mov r4, r1
@@ -2192,15 +2196,15 @@ define <2 x i64> @utest_f16i64(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    movne r6, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfti
 ; CHECK-FP16-NEXT:    subs r2, r2, #1
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r6
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r6
 ; CHECK-FP16-NEXT:    sbcs r2, r3, #0
 ; CHECK-FP16-NEXT:    movwlo r5, #1
 ; CHECK-FP16-NEXT:    cmp r5, #0
 ; CHECK-FP16-NEXT:    moveq r0, r5
 ; CHECK-FP16-NEXT:    movne r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r0
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r0
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, pc}
 entry:
   %conv = fptoui <2 x half> %x to <2 x i128>
@@ -2217,8 +2221,8 @@ define <2 x i64> @ustest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8}
 ; CHECK-NEON-NEXT:    vpush {d8}
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.f32 s16, s1
+; CHECK-NEON-NEXT:    vmov r0, s1
+; CHECK-NEON-NEXT:    vmov.f32 s16, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r5, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
@@ -2249,7 +2253,7 @@ define <2 x i64> @ustest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    movne r7, r1
 ; CHECK-NEON-NEXT:    bl __fixsfti
 ; CHECK-NEON-NEXT:    subs r6, r2, #1
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r7
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r7
 ; CHECK-NEON-NEXT:    sbcs r6, r3, #0
 ; CHECK-NEON-NEXT:    movlt r8, r2
 ; CHECK-NEON-NEXT:    mov r2, #0
@@ -2266,9 +2270,9 @@ define <2 x i64> @ustest_f16i64(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    cmp r5, #0
 ; CHECK-NEON-NEXT:    moveq r2, r5
 ; CHECK-NEON-NEXT:    movne r5, r1
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r2
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r2
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 ;
@@ -2276,8 +2280,8 @@ define <2 x i64> @ustest_f16i64(<2 x half> %x) {
 ; CHECK-FP16:       @ %bb.0: @ %entry
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, lr}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
-; CHECK-FP16-NEXT:    vmov.u16 r5, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r5, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    mov r4, r1
@@ -2304,7 +2308,7 @@ define <2 x i64> @ustest_f16i64(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    movne r7, r1
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    subs r6, r2, #1
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r7
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r7
 ; CHECK-FP16-NEXT:    sbcs r6, r3, #0
 ; CHECK-FP16-NEXT:    movlt r8, r2
 ; CHECK-FP16-NEXT:    mov r2, #0
@@ -2321,9 +2325,9 @@ define <2 x i64> @ustest_f16i64(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    cmp r5, #0
 ; CHECK-FP16-NEXT:    moveq r2, r5
 ; CHECK-FP16-NEXT:    movne r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r2
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r2
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
   %conv = fptosi <2 x half> %x to <2 x i128>
@@ -2396,17 +2400,17 @@ define <2 x i32> @utest_f64i32_mm(<2 x double> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, r1, d9
+; CHECK-NEXT:    vmov r0, r1, d8
 ; CHECK-NEXT:    bl __aeabi_d2ulz
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    vmov r2, r1, d8
-; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    vmov r2, r1, d9
+; CHECK-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEXT:    mov r0, r2
 ; CHECK-NEXT:    bl __aeabi_d2ulz
-; CHECK-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEXT:    vmov.i64 q8, #0xffffffff
-; CHECK-NEXT:    vmov.32 d9[1], r4
-; CHECK-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEXT:    vmov.32 d8[1], r4
+; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    vqsub.u64 q8, q4, q8
 ; CHECK-NEXT:    vsub.i64 q8, q4, q8
 ; CHECK-NEXT:    vmovn.i64 d0, q8
@@ -2484,15 +2488,15 @@ define <4 x i32> @stest_f32i32_mm(<4 x float> %x) {
 ; CHECK-NEXT:    .pad #8
 ; CHECK-NEXT:    sub sp, sp, #8
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, s19
-; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov r2, s18
-; CHECK-NEXT:    mov r11, r0
 ; CHECK-NEXT:    vmov r0, s17
+; CHECK-NEXT:    bl __aeabi_f2lz
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    mov r11, r0
+; CHECK-NEXT:    vmov r0, s19
 ; CHECK-NEXT:    mvn r6, #-2147483648
 ; CHECK-NEXT:    mov r3, #-2147483648
 ; CHECK-NEXT:    mvn r10, #0
-; CHECK-NEXT:    vmov r7, s16
+; CHECK-NEXT:    vmov r7, s18
 ; CHECK-NEXT:    mov r4, #0
 ; CHECK-NEXT:    str r2, [sp, #4] @ 4-byte Spill
 ; CHECK-NEXT:    subs r2, r11, r6
@@ -2538,14 +2542,14 @@ define <4 x i32> @stest_f32i32_mm(<4 x float> %x) {
 ; CHECK-NEXT:    movge r6, r1
 ; CHECK-NEXT:    rsbs r0, r7, #-2147483648
 ; CHECK-NEXT:    sbcs r0, r10, r8
-; CHECK-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEXT:    vmov.32 d0[0], r6
 ; CHECK-NEXT:    movge r7, r1
 ; CHECK-NEXT:    rsbs r0, r5, #-2147483648
-; CHECK-NEXT:    vmov.32 d0[0], r7
+; CHECK-NEXT:    vmov.32 d1[0], r7
 ; CHECK-NEXT:    sbcs r0, r10, r9
 ; CHECK-NEXT:    movge r5, r1
-; CHECK-NEXT:    vmov.32 d1[1], r11
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d0[1], r11
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    add sp, sp, #8
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    add sp, sp, #4
@@ -2566,35 +2570,35 @@ define <4 x i32> @utest_f32i32_mm(<4 x float> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, s17
+; CHECK-NEXT:    vmov r0, s18
 ; CHECK-NEXT:    bl __aeabi_f2ulz
 ; CHECK-NEXT:    mov r4, r1
-; CHECK-NEXT:    vmov r1, s18
-; CHECK-NEXT:    vmov r5, s19
-; CHECK-NEXT:    vmov r6, s16
-; CHECK-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEXT:    vmov r1, s17
+; CHECK-NEXT:    vmov r5, s16
+; CHECK-NEXT:    vmov r6, s19
+; CHECK-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEXT:    mov r0, r1
 ; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    vmov.32 d10[0], r0
+; CHECK-NEXT:    vmov.32 d11[0], r0
 ; CHECK-NEXT:    mov r0, r5
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEXT:    vmov.32 d10[0], r0
 ; CHECK-NEXT:    mov r0, r6
 ; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEXT:    vmov.i64 q8, #0xffffffff
-; CHECK-NEXT:    vmov.32 d11[1], r5
-; CHECK-NEXT:    vmov.32 d9[1], r4
-; CHECK-NEXT:    vmov.32 d10[1], r7
-; CHECK-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEXT:    vmov.32 d10[1], r5
+; CHECK-NEXT:    vmov.32 d8[1], r4
+; CHECK-NEXT:    vmov.32 d11[1], r7
+; CHECK-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEXT:    vqsub.u64 q9, q5, q8
 ; CHECK-NEXT:    vqsub.u64 q8, q4, q8
 ; CHECK-NEXT:    vsub.i64 q9, q5, q9
 ; CHECK-NEXT:    vsub.i64 q8, q4, q8
-; CHECK-NEXT:    vmovn.i64 d1, q9
-; CHECK-NEXT:    vmovn.i64 d0, q8
+; CHECK-NEXT:    vmovn.i64 d0, q9
+; CHECK-NEXT:    vmovn.i64 d1, q8
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 entry:
@@ -2612,14 +2616,14 @@ define <4 x i32> @ustest_f32i32_mm(<4 x float> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vmov r0, s19
+; CHECK-NEXT:    vmov r0, s17
 ; CHECK-NEXT:    bl __aeabi_f2lz
-; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    mvn r6, #0
 ; CHECK-NEXT:    subs r3, r0, r6
 ; CHECK-NEXT:    mov r4, #0
 ; CHECK-NEXT:    sbcs r3, r1, #0
-; CHECK-NEXT:    vmov r8, s17
+; CHECK-NEXT:    vmov r8, s19
 ; CHECK-NEXT:    mov r3, #0
 ; CHECK-NEXT:    movge r0, r6
 ; CHECK-NEXT:    movwlt r3, #1
@@ -2627,7 +2631,7 @@ define <4 x i32> @ustest_f32i32_mm(<4 x float> %x) {
 ; CHECK-NEXT:    movne r3, r1
 ; CHECK-NEXT:    rsbs r1, r0, #0
 ; CHECK-NEXT:    rscs r1, r3, #0
-; CHECK-NEXT:    vmov r9, s18
+; CHECK-NEXT:    vmov r9, s16
 ; CHECK-NEXT:    movwlt r4, #1
 ; CHECK-NEXT:    cmp r4, #0
 ; CHECK-NEXT:    movne r4, r0
@@ -2665,7 +2669,7 @@ define <4 x i32> @ustest_f32i32_mm(<4 x float> %x) {
 ; CHECK-NEXT:    mov r0, r8
 ; CHECK-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEXT:    subs r2, r0, r6
-; CHECK-NEXT:    vmov.32 d1[0], r7
+; CHECK-NEXT:    vmov.32 d0[0], r7
 ; CHECK-NEXT:    sbcs r2, r1, #0
 ; CHECK-NEXT:    movlt r6, r0
 ; CHECK-NEXT:    mov r0, #0
@@ -2674,12 +2678,12 @@ define <4 x i32> @ustest_f32i32_mm(<4 x float> %x) {
 ; CHECK-NEXT:    movne r0, r1
 ; CHECK-NEXT:    rsbs r1, r6, #0
 ; CHECK-NEXT:    rscs r0, r0, #0
-; CHECK-NEXT:    vmov.32 d0[0], r5
+; CHECK-NEXT:    vmov.32 d1[0], r5
 ; CHECK-NEXT:    movwlt r10, #1
 ; CHECK-NEXT:    cmp r10, #0
-; CHECK-NEXT:    vmov.32 d1[1], r4
+; CHECK-NEXT:    vmov.32 d0[1], r4
 ; CHECK-NEXT:    movne r10, r6
-; CHECK-NEXT:    vmov.32 d0[1], r10
+; CHECK-NEXT:    vmov.32 d1[1], r10
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -2701,19 +2705,19 @@ define <4 x i32> @stest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10}
 ; CHECK-NEON-NEXT:    .pad #8
 ; CHECK-NEON-NEXT:    sub sp, sp, #8
-; CHECK-NEON-NEXT:    vmov r0, s3
-; CHECK-NEON-NEXT:    vmov.f32 s16, s2
-; CHECK-NEON-NEXT:    vmov.f32 s18, s1
+; CHECK-NEON-NEXT:    vmov r0, s1
+; CHECK-NEON-NEXT:    vmov.f32 s16, s3
+; CHECK-NEON-NEXT:    vmov.f32 s18, s2
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov r2, s16
+; CHECK-NEON-NEXT:    vmov r2, s20
 ; CHECK-NEON-NEXT:    mov r11, r0
-; CHECK-NEON-NEXT:    vmov r0, s18
+; CHECK-NEON-NEXT:    vmov r0, s16
 ; CHECK-NEON-NEXT:    mvn r6, #-2147483648
 ; CHECK-NEON-NEXT:    mov r3, #-2147483648
 ; CHECK-NEON-NEXT:    mvn r10, #0
-; CHECK-NEON-NEXT:    vmov r7, s20
+; CHECK-NEON-NEXT:    vmov r7, s18
 ; CHECK-NEON-NEXT:    mov r4, #0
 ; CHECK-NEON-NEXT:    str r2, [sp, #4] @ 4-byte Spill
 ; CHECK-NEON-NEXT:    subs r2, r11, r6
@@ -2762,14 +2766,14 @@ define <4 x i32> @stest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    movge r6, r1
 ; CHECK-NEON-NEXT:    rsbs r0, r7, #-2147483648
 ; CHECK-NEON-NEXT:    sbcs r0, r10, r9
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r6
 ; CHECK-NEON-NEXT:    movge r7, r1
 ; CHECK-NEON-NEXT:    rsbs r0, r5, #-2147483648
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r7
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r7
 ; CHECK-NEON-NEXT:    sbcs r0, r10, r8
 ; CHECK-NEON-NEXT:    movge r5, r1
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r11
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r11
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEON-NEXT:    add sp, sp, #8
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10}
 ; CHECK-NEON-NEXT:    add sp, sp, #4
@@ -2783,10 +2787,10 @@ define <4 x i32> @stest_f16i32_mm(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    sub sp, sp, #4
 ; CHECK-FP16-NEXT:    .vsave {d8, d9}
 ; CHECK-FP16-NEXT:    vpush {d8, d9}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[3]
-; CHECK-FP16-NEXT:    vmov.u16 r4, d0[2]
-; CHECK-FP16-NEXT:    vmov.u16 r5, d0[0]
-; CHECK-FP16-NEXT:    vmov.u16 r6, d0[1]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
+; CHECK-FP16-NEXT:    vmov.u16 r4, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r5, d0[2]
+; CHECK-FP16-NEXT:    vmov.u16 r6, d0[3]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    mov r10, r0
@@ -2840,14 +2844,14 @@ define <4 x i32> @stest_f16i32_mm(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    movge r7, r1
 ; CHECK-FP16-NEXT:    rsbs r0, r6, #-2147483648
 ; CHECK-FP16-NEXT:    sbcs r0, r9, r8
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r7
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r7
 ; CHECK-FP16-NEXT:    movge r6, r1
 ; CHECK-FP16-NEXT:    rsbs r0, r5, #-2147483648
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r6
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r6
 ; CHECK-FP16-NEXT:    sbcs r0, r9, r4
 ; CHECK-FP16-NEXT:    movge r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r10
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r10
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
 ; CHECK-FP16-NEXT:    vpop {d8, d9}
 ; CHECK-FP16-NEXT:    add sp, sp, #4
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
@@ -2866,42 +2870,42 @@ define <4 x i32> @utest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11}
-; CHECK-NEON-NEXT:    vmov r0, s1
+; CHECK-NEON-NEXT:    vmov r0, s2
 ; CHECK-NEON-NEXT:    vmov.f32 s16, s3
-; CHECK-NEON-NEXT:    vmov.f32 s18, s2
+; CHECK-NEON-NEXT:    vmov.f32 s18, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
 ; CHECK-NEON-NEXT:    mov r4, r1
 ; CHECK-NEON-NEXT:    vmov r1, s18
-; CHECK-NEON-NEXT:    vmov r6, s16
-; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
-; CHECK-NEON-NEXT:    vmov r7, s20
+; CHECK-NEON-NEXT:    vmov r7, s16
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEON-NEXT:    vmov r6, s20
 ; CHECK-NEON-NEXT:    mov r0, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    vmov.32 d10[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
 ; CHECK-NEON-NEXT:    mov r0, r6
 ; CHECK-NEON-NEXT:    mov r5, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d10[0], r0
 ; CHECK-NEON-NEXT:    mov r0, r7
 ; CHECK-NEON-NEXT:    mov r6, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2ulz
-; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEON-NEXT:    vmov.i64 q8, #0xffffffff
-; CHECK-NEON-NEXT:    vmov.32 d11[1], r6
-; CHECK-NEON-NEXT:    vmov.32 d9[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d10[1], r5
-; CHECK-NEON-NEXT:    vmov.32 d8[1], r1
+; CHECK-NEON-NEXT:    vmov.32 d10[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d8[1], r4
+; CHECK-NEON-NEXT:    vmov.32 d11[1], r5
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r1
 ; CHECK-NEON-NEXT:    vqsub.u64 q9, q5, q8
 ; CHECK-NEON-NEXT:    vqsub.u64 q8, q4, q8
 ; CHECK-NEON-NEXT:    vsub.i64 q9, q5, q9
 ; CHECK-NEON-NEXT:    vsub.i64 q8, q4, q8
-; CHECK-NEON-NEXT:    vmovn.i64 d1, q9
-; CHECK-NEON-NEXT:    vmovn.i64 d0, q8
+; CHECK-NEON-NEXT:    vmovn.i64 d0, q9
+; CHECK-NEON-NEXT:    vmovn.i64 d1, q8
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
@@ -2913,37 +2917,37 @@ define <4 x i32> @utest_f16i32_mm(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    vpush {d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    .vsave {d8}
 ; CHECK-FP16-NEXT:    vpush {d8}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[2]
 ; CHECK-FP16-NEXT:    vorr d8, d0, d0
-; CHECK-FP16-NEXT:    vmov.u16 r6, d0[3]
+; CHECK-FP16-NEXT:    vmov.u16 r6, d0[0]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
 ; CHECK-FP16-NEXT:    mov r4, r1
-; CHECK-FP16-NEXT:    vmov.u16 r1, d8[2]
-; CHECK-FP16-NEXT:    vmov.32 d11[0], r0
+; CHECK-FP16-NEXT:    vmov.u16 r1, d8[1]
+; CHECK-FP16-NEXT:    vmov.32 d10[0], r0
 ; CHECK-FP16-NEXT:    vmov s0, r1
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
 ; CHECK-FP16-NEXT:    vmov s0, r6
 ; CHECK-FP16-NEXT:    mov r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d12[0], r0
+; CHECK-FP16-NEXT:    vmov.32 d13[0], r0
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
 ; CHECK-FP16-NEXT:    mov r6, r1
-; CHECK-FP16-NEXT:    vmov.u16 r1, d8[0]
-; CHECK-FP16-NEXT:    vmov.32 d13[0], r0
+; CHECK-FP16-NEXT:    vmov.u16 r1, d8[3]
+; CHECK-FP16-NEXT:    vmov.32 d12[0], r0
 ; CHECK-FP16-NEXT:    vmov s0, r1
 ; CHECK-FP16-NEXT:    bl __fixunshfdi
-; CHECK-FP16-NEXT:    vmov.32 d10[0], r0
+; CHECK-FP16-NEXT:    vmov.32 d11[0], r0
 ; CHECK-FP16-NEXT:    vmov.i64 q8, #0xffffffff
-; CHECK-FP16-NEXT:    vmov.32 d13[1], r6
-; CHECK-FP16-NEXT:    vmov.32 d11[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d12[1], r5
-; CHECK-FP16-NEXT:    vmov.32 d10[1], r1
+; CHECK-FP16-NEXT:    vmov.32 d12[1], r6
+; CHECK-FP16-NEXT:    vmov.32 d10[1], r4
+; CHECK-FP16-NEXT:    vmov.32 d13[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d11[1], r1
 ; CHECK-FP16-NEXT:    vqsub.u64 q9, q6, q8
 ; CHECK-FP16-NEXT:    vqsub.u64 q8, q5, q8
 ; CHECK-FP16-NEXT:    vsub.i64 q9, q6, q9
 ; CHECK-FP16-NEXT:    vsub.i64 q8, q5, q8
-; CHECK-FP16-NEXT:    vmovn.i64 d1, q9
-; CHECK-FP16-NEXT:    vmovn.i64 d0, q8
+; CHECK-FP16-NEXT:    vmovn.i64 d0, q9
+; CHECK-FP16-NEXT:    vmovn.i64 d1, q8
 ; CHECK-FP16-NEXT:    vpop {d8}
 ; CHECK-FP16-NEXT:    vpop {d10, d11, d12, d13}
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, pc}
@@ -2961,18 +2965,18 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10}
-; CHECK-NEON-NEXT:    vmov r0, s3
-; CHECK-NEON-NEXT:    vmov.f32 s16, s2
-; CHECK-NEON-NEXT:    vmov.f32 s18, s1
+; CHECK-NEON-NEXT:    vmov r0, s1
+; CHECK-NEON-NEXT:    vmov.f32 s16, s3
+; CHECK-NEON-NEXT:    vmov.f32 s18, s2
 ; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
-; CHECK-NEON-NEXT:    vmov r2, s20
+; CHECK-NEON-NEXT:    vmov r2, s18
 ; CHECK-NEON-NEXT:    mvn r6, #0
 ; CHECK-NEON-NEXT:    subs r3, r0, r6
 ; CHECK-NEON-NEXT:    mov r4, #0
 ; CHECK-NEON-NEXT:    sbcs r3, r1, #0
-; CHECK-NEON-NEXT:    vmov r8, s18
+; CHECK-NEON-NEXT:    vmov r8, s16
 ; CHECK-NEON-NEXT:    mov r3, #0
 ; CHECK-NEON-NEXT:    movge r0, r6
 ; CHECK-NEON-NEXT:    movwlt r3, #1
@@ -2980,7 +2984,7 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    movne r3, r1
 ; CHECK-NEON-NEXT:    rsbs r1, r0, #0
 ; CHECK-NEON-NEXT:    rscs r1, r3, #0
-; CHECK-NEON-NEXT:    vmov r9, s16
+; CHECK-NEON-NEXT:    vmov r9, s20
 ; CHECK-NEON-NEXT:    movwlt r4, #1
 ; CHECK-NEON-NEXT:    cmp r4, #0
 ; CHECK-NEON-NEXT:    movne r4, r0
@@ -3021,7 +3025,7 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    bl __aeabi_f2lz
 ; CHECK-NEON-NEXT:    subs r2, r0, r6
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r7
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r7
 ; CHECK-NEON-NEXT:    sbcs r2, r1, #0
 ; CHECK-NEON-NEXT:    movlt r6, r0
 ; CHECK-NEON-NEXT:    mov r0, #0
@@ -3030,12 +3034,12 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-NEON-NEXT:    movne r0, r1
 ; CHECK-NEON-NEXT:    rsbs r1, r6, #0
 ; CHECK-NEON-NEXT:    rscs r0, r0, #0
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
 ; CHECK-NEON-NEXT:    movwlt r10, #1
 ; CHECK-NEON-NEXT:    cmp r10, #0
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
 ; CHECK-NEON-NEXT:    movne r10, r6
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r10
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r10
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
@@ -3045,14 +3049,14 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, lr}
 ; CHECK-FP16-NEXT:    .vsave {d8, d9}
 ; CHECK-FP16-NEXT:    vpush {d8, d9}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[3]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
 ; CHECK-FP16-NEXT:    vorr d8, d0, d0
-; CHECK-FP16-NEXT:    vmov.u16 r5, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r5, d0[2]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
-; CHECK-FP16-NEXT:    vmov.u16 r2, d8[1]
+; CHECK-FP16-NEXT:    vmov.u16 r2, d8[3]
 ; CHECK-FP16-NEXT:    mvn r4, #0
-; CHECK-FP16-NEXT:    vmov.u16 r3, d8[2]
+; CHECK-FP16-NEXT:    vmov.u16 r3, d8[0]
 ; CHECK-FP16-NEXT:    vmov s0, r5
 ; CHECK-FP16-NEXT:    mov r6, #0
 ; CHECK-FP16-NEXT:    mov r8, #0
@@ -3102,7 +3106,7 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    movne r5, r0
 ; CHECK-FP16-NEXT:    bl __fixhfdi
 ; CHECK-FP16-NEXT:    subs r2, r0, r4
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r5
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r5
 ; CHECK-FP16-NEXT:    sbcs r2, r1, #0
 ; CHECK-FP16-NEXT:    movlt r4, r0
 ; CHECK-FP16-NEXT:    mov r0, #0
@@ -3111,12 +3115,12 @@ define <4 x i32> @ustest_f16i32_mm(<4 x half> %x) {
 ; CHECK-FP16-NEXT:    movne r0, r1
 ; CHECK-FP16-NEXT:    rsbs r1, r4, #0
 ; CHECK-FP16-NEXT:    rscs r0, r0, #0
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r7
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r7
 ; CHECK-FP16-NEXT:    movwlt r8, #1
 ; CHECK-FP16-NEXT:    cmp r8, #0
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r6
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r6
 ; CHECK-FP16-NEXT:    movne r8, r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r8
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r8
 ; CHECK-FP16-NEXT:    vpop {d8, d9}
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 entry:
@@ -3250,115 +3254,115 @@ define <8 x i16> @stest_f16i16_mm(<8 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEON-NEXT:    vmov r0, s1
-; CHECK-NEON-NEXT:    vmov.f32 s16, s7
-; CHECK-NEON-NEXT:    vmov.f32 s18, s6
-; CHECK-NEON-NEXT:    vmov.f32 s20, s5
-; CHECK-NEON-NEXT:    vmov.f32 s22, s4
-; CHECK-NEON-NEXT:    vmov.f32 s24, s3
-; CHECK-NEON-NEXT:    vmov.f32 s26, s2
+; CHECK-NEON-NEXT:    vmov r0, s7
+; CHECK-NEON-NEXT:    vmov.f32 s16, s6
+; CHECK-NEON-NEXT:    vmov.f32 s18, s5
+; CHECK-NEON-NEXT:    vmov.f32 s20, s4
+; CHECK-NEON-NEXT:    vmov.f32 s22, s3
+; CHECK-NEON-NEXT:    vmov.f32 s24, s2
+; CHECK-NEON-NEXT:    vmov.f32 s26, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s28, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r4, r0
-; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    vmov r0, s20
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r5, r0
-; CHECK-NEON-NEXT:    vmov r0, s22
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s24
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r7, r0
+; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s18
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov s22, r7
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov s30, r6
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[1], r0
+; CHECK-NEON-NEXT:    mov r7, r0
 ; CHECK-NEON-NEXT:    vmov r0, s28
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r1, s20
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[0], r0
+; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov s20, r7
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov s24, r6
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[1], r0
+; CHECK-NEON-NEXT:    vmov r0, s16
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov r1, s22
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r5
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s20, s2
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s22, s2
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s30
-; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s24
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d15[0], r0
 ; CHECK-NEON-NEXT:    mov r0, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r0, s20
+; CHECK-NEON-NEXT:    vmov r0, s22
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r4
 ; CHECK-NEON-NEXT:    vmov.i32 q8, #0x7fff
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s2, s2
 ; CHECK-NEON-NEXT:    vmvn.i32 q9, #0x7fff
-; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s22
-; CHECK-NEON-NEXT:    vmov.32 d12[1], r0
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s20
+; CHECK-NEON-NEXT:    vmov.32 d15[1], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmin.s32 q10, q6, q8
+; CHECK-NEON-NEXT:    vmin.s32 q10, q7, q8
 ; CHECK-NEON-NEXT:    vmax.s32 q10, q10, q9
-; CHECK-NEON-NEXT:    vmov.32 d9[1], r0
-; CHECK-NEON-NEXT:    vmov r0, s2
-; CHECK-NEON-NEXT:    vmovn.i32 d1, q10
 ; CHECK-NEON-NEXT:    vmov.32 d8[1], r0
+; CHECK-NEON-NEXT:    vmov r0, s2
+; CHECK-NEON-NEXT:    vmovn.i32 d0, q10
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r0
 ; CHECK-NEON-NEXT:    vmin.s32 q8, q4, q8
 ; CHECK-NEON-NEXT:    vmax.s32 q8, q8, q9
-; CHECK-NEON-NEXT:    vmovn.i32 d0, q8
+; CHECK-NEON-NEXT:    vmovn.i32 d1, q8
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; CHECK-FP16-LABEL: stest_f16i16_mm:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    vmovx.f16 s4, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s12, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s0, s3
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s5, s2
+; CHECK-FP16-NEXT:    vmovx.f16 s10, s0
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s0, s0
 ; CHECK-FP16-NEXT:    vmov r0, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s14, s1
-; CHECK-FP16-NEXT:    vmovx.f16 s10, s3
-; CHECK-FP16-NEXT:    vmovx.f16 s8, s2
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s5, s1
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s14, s2
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s12, s3
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s10, s10
+; CHECK-FP16-NEXT:    vmovx.f16 s8, s1
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s8, s8
-; CHECK-FP16-NEXT:    vmovx.f16 s6, s1
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s4, s4
+; CHECK-FP16-NEXT:    vmovx.f16 s6, s2
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s6, s6
+; CHECK-FP16-NEXT:    vmovx.f16 s4, s3
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s4, s4
 ; CHECK-FP16-NEXT:    vmov.i32 q10, #0x7fff
 ; CHECK-FP16-NEXT:    vmvn.i32 q11, #0x7fff
-; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s5
 ; CHECK-FP16-NEXT:    vmov.32 d16[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s5
+; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s14
-; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s12
 ; CHECK-FP16-NEXT:    vmov.32 d18[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s12
+; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s10
-; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s8
 ; CHECK-FP16-NEXT:    vmov.32 d16[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s8
+; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
 ; CHECK-FP16-NEXT:    vmov r0, s6
 ; CHECK-FP16-NEXT:    vmin.s32 q8, q8, q10
 ; CHECK-FP16-NEXT:    vmax.s32 q8, q8, q11
-; CHECK-FP16-NEXT:    vmovn.i32 d1, q8
-; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmovn.i32 d0, q8
 ; CHECK-FP16-NEXT:    vmov.32 d18[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
 ; CHECK-FP16-NEXT:    vmin.s32 q9, q9, q10
 ; CHECK-FP16-NEXT:    vmax.s32 q9, q9, q11
-; CHECK-FP16-NEXT:    vmovn.i32 d0, q9
+; CHECK-FP16-NEXT:    vmovn.i32 d1, q9
 ; CHECK-FP16-NEXT:    bx lr
 entry:
   %conv = fptosi <8 x half> %x to <8 x i32>
@@ -3373,111 +3377,111 @@ define <8 x i16> @utest_f16i16_mm(<8 x half> %x) {
 ; CHECK-NEON:       @ %bb.0: @ %entry
 ; CHECK-NEON-NEXT:    .save {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
-; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
-; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
-; CHECK-NEON-NEXT:    vmov r0, s1
-; CHECK-NEON-NEXT:    vmov.f32 s16, s7
-; CHECK-NEON-NEXT:    vmov.f32 s18, s6
-; CHECK-NEON-NEXT:    vmov.f32 s20, s5
-; CHECK-NEON-NEXT:    vmov.f32 s22, s4
-; CHECK-NEON-NEXT:    vmov.f32 s24, s3
-; CHECK-NEON-NEXT:    vmov.f32 s26, s2
+; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
+; CHECK-NEON-NEXT:    vmov r0, s7
+; CHECK-NEON-NEXT:    vmov.f32 s16, s6
+; CHECK-NEON-NEXT:    vmov.f32 s18, s5
+; CHECK-NEON-NEXT:    vmov.f32 s20, s4
+; CHECK-NEON-NEXT:    vmov.f32 s22, s3
+; CHECK-NEON-NEXT:    vmov.f32 s24, s2
+; CHECK-NEON-NEXT:    vmov.f32 s26, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s28, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r4, r0
-; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    vmov r0, s20
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r5, r0
-; CHECK-NEON-NEXT:    vmov r0, s22
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s24
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r7, r0
+; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s18
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov s16, r7
-; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov s18, r6
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[1], r0
+; CHECK-NEON-NEXT:    mov r7, r0
 ; CHECK-NEON-NEXT:    vmov r0, s28
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r1, s20
+; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[0], r0
+; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov s20, r7
+; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov s24, r6
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[1], r0
+; CHECK-NEON-NEXT:    vmov r0, s16
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov r1, s22
 ; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r5
+; CHECK-NEON-NEXT:    vcvt.u32.f32 s22, s2
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s18
-; CHECK-NEON-NEXT:    vcvt.u32.f32 s18, s2
-; CHECK-NEON-NEXT:    vmov.32 d10[0], r0
+; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s24
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d15[0], r0
 ; CHECK-NEON-NEXT:    mov r0, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r0, s18
+; CHECK-NEON-NEXT:    vmov r0, s22
 ; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r4
 ; CHECK-NEON-NEXT:    vmov.i32 q8, #0xffff
 ; CHECK-NEON-NEXT:    vcvt.u32.f32 s2, s2
-; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s16
-; CHECK-NEON-NEXT:    vmov.32 d12[1], r0
+; CHECK-NEON-NEXT:    vcvt.u32.f32 s0, s20
+; CHECK-NEON-NEXT:    vmov.32 d15[1], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmin.u32 q9, q6, q8
-; CHECK-NEON-NEXT:    vmov.32 d11[1], r0
+; CHECK-NEON-NEXT:    vmin.u32 q9, q7, q8
+; CHECK-NEON-NEXT:    vmov.32 d8[1], r0
 ; CHECK-NEON-NEXT:    vmov r0, s2
-; CHECK-NEON-NEXT:    vmovn.i32 d1, q9
-; CHECK-NEON-NEXT:    vmov.32 d10[1], r0
-; CHECK-NEON-NEXT:    vmin.u32 q8, q5, q8
-; CHECK-NEON-NEXT:    vmovn.i32 d0, q8
-; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
+; CHECK-NEON-NEXT:    vmovn.i32 d0, q9
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r0
+; CHECK-NEON-NEXT:    vmin.u32 q8, q4, q8
+; CHECK-NEON-NEXT:    vmovn.i32 d1, q8
+; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; CHECK-FP16-LABEL: utest_f16i16_mm:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    vmovx.f16 s4, s0
-; CHECK-FP16-NEXT:    vcvt.u32.f16 s12, s0
-; CHECK-FP16-NEXT:    vcvt.u32.f16 s0, s3
-; CHECK-FP16-NEXT:    vcvt.u32.f16 s5, s2
+; CHECK-FP16-NEXT:    vmovx.f16 s10, s0
+; CHECK-FP16-NEXT:    vcvt.u32.f16 s0, s0
 ; CHECK-FP16-NEXT:    vmov r0, s0
-; CHECK-FP16-NEXT:    vcvt.u32.f16 s14, s1
-; CHECK-FP16-NEXT:    vmovx.f16 s10, s3
-; CHECK-FP16-NEXT:    vmovx.f16 s8, s2
+; CHECK-FP16-NEXT:    vcvt.u32.f16 s5, s1
+; CHECK-FP16-NEXT:    vcvt.u32.f16 s14, s2
+; CHECK-FP16-NEXT:    vcvt.u32.f16 s12, s3
 ; CHECK-FP16-NEXT:    vcvt.u32.f16 s10, s10
+; CHECK-FP16-NEXT:    vmovx.f16 s8, s1
 ; CHECK-FP16-NEXT:    vcvt.u32.f16 s8, s8
-; CHECK-FP16-NEXT:    vmovx.f16 s6, s1
-; CHECK-FP16-NEXT:    vcvt.u32.f16 s4, s4
+; CHECK-FP16-NEXT:    vmovx.f16 s6, s2
 ; CHECK-FP16-NEXT:    vcvt.u32.f16 s6, s6
+; CHECK-FP16-NEXT:    vmovx.f16 s4, s3
+; CHECK-FP16-NEXT:    vcvt.u32.f16 s4, s4
 ; CHECK-FP16-NEXT:    vmov.i32 q10, #0xffff
-; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s5
 ; CHECK-FP16-NEXT:    vmov.32 d16[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s5
+; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s14
-; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s12
 ; CHECK-FP16-NEXT:    vmov.32 d18[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s12
+; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s10
-; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s8
 ; CHECK-FP16-NEXT:    vmov.32 d16[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s8
+; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
 ; CHECK-FP16-NEXT:    vmov r0, s6
 ; CHECK-FP16-NEXT:    vmin.u32 q8, q8, q10
-; CHECK-FP16-NEXT:    vmovn.i32 d1, q8
-; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmovn.i32 d0, q8
 ; CHECK-FP16-NEXT:    vmov.32 d18[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
 ; CHECK-FP16-NEXT:    vmin.u32 q9, q9, q10
-; CHECK-FP16-NEXT:    vmovn.i32 d0, q9
+; CHECK-FP16-NEXT:    vmovn.i32 d1, q9
 ; CHECK-FP16-NEXT:    bx lr
 entry:
   %conv = fptoui <8 x half> %x to <8 x i32>
@@ -3493,115 +3497,115 @@ define <8 x i16> @ustest_f16i16_mm(<8 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEON-NEXT:    vmov r0, s1
-; CHECK-NEON-NEXT:    vmov.f32 s16, s7
-; CHECK-NEON-NEXT:    vmov.f32 s18, s6
-; CHECK-NEON-NEXT:    vmov.f32 s20, s5
-; CHECK-NEON-NEXT:    vmov.f32 s22, s4
-; CHECK-NEON-NEXT:    vmov.f32 s24, s3
-; CHECK-NEON-NEXT:    vmov.f32 s26, s2
+; CHECK-NEON-NEXT:    vmov r0, s7
+; CHECK-NEON-NEXT:    vmov.f32 s16, s6
+; CHECK-NEON-NEXT:    vmov.f32 s18, s5
+; CHECK-NEON-NEXT:    vmov.f32 s20, s4
+; CHECK-NEON-NEXT:    vmov.f32 s22, s3
+; CHECK-NEON-NEXT:    vmov.f32 s24, s2
+; CHECK-NEON-NEXT:    vmov.f32 s26, s1
 ; CHECK-NEON-NEXT:    vmov.f32 s28, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r4, r0
-; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    vmov r0, s20
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r5, r0
-; CHECK-NEON-NEXT:    vmov r0, s22
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s24
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r7, r0
+; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s18
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[0], r0
-; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov s22, r7
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov s30, r6
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d13[1], r0
+; CHECK-NEON-NEXT:    mov r7, r0
 ; CHECK-NEON-NEXT:    vmov r0, s28
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r1, s20
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[0], r0
+; CHECK-NEON-NEXT:    vmov r0, s26
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov s20, r7
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
+; CHECK-NEON-NEXT:    vmov s24, r6
+; CHECK-NEON-NEXT:    vmov r0, s0
+; CHECK-NEON-NEXT:    vmov.32 d14[1], r0
+; CHECK-NEON-NEXT:    vmov r0, s16
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov r1, s22
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r5
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s20, s2
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s22, s2
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s30
-; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s24
+; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d12[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d15[0], r0
 ; CHECK-NEON-NEXT:    mov r0, r1
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vmov r0, s20
+; CHECK-NEON-NEXT:    vmov r0, s22
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
 ; CHECK-NEON-NEXT:    vmov s2, r4
 ; CHECK-NEON-NEXT:    vmov.i32 q8, #0xffff
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s2, s2
 ; CHECK-NEON-NEXT:    vmov.i32 q9, #0x0
-; CHECK-NEON-NEXT:    vmov.32 d9[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d8[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s22
-; CHECK-NEON-NEXT:    vmov.32 d12[1], r0
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s20
+; CHECK-NEON-NEXT:    vmov.32 d15[1], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmin.s32 q10, q6, q8
+; CHECK-NEON-NEXT:    vmin.s32 q10, q7, q8
 ; CHECK-NEON-NEXT:    vmax.s32 q10, q10, q9
-; CHECK-NEON-NEXT:    vmov.32 d9[1], r0
-; CHECK-NEON-NEXT:    vmov r0, s2
-; CHECK-NEON-NEXT:    vmovn.i32 d1, q10
 ; CHECK-NEON-NEXT:    vmov.32 d8[1], r0
+; CHECK-NEON-NEXT:    vmov r0, s2
+; CHECK-NEON-NEXT:    vmovn.i32 d0, q10
+; CHECK-NEON-NEXT:    vmov.32 d9[1], r0
 ; CHECK-NEON-NEXT:    vmin.s32 q8, q4, q8
 ; CHECK-NEON-NEXT:    vmax.s32 q8, q8, q9
-; CHECK-NEON-NEXT:    vmovn.i32 d0, q8
+; CHECK-NEON-NEXT:    vmovn.i32 d1, q8
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; CHECK-FP16-LABEL: ustest_f16i16_mm:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    vmovx.f16 s4, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s12, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s0, s3
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s5, s2
+; CHECK-FP16-NEXT:    vmovx.f16 s10, s0
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s0, s0
 ; CHECK-FP16-NEXT:    vmov r0, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s14, s1
-; CHECK-FP16-NEXT:    vmovx.f16 s10, s3
-; CHECK-FP16-NEXT:    vmovx.f16 s8, s2
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s5, s1
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s14, s2
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s12, s3
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s10, s10
+; CHECK-FP16-NEXT:    vmovx.f16 s8, s1
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s8, s8
-; CHECK-FP16-NEXT:    vmovx.f16 s6, s1
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s4, s4
+; CHECK-FP16-NEXT:    vmovx.f16 s6, s2
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s6, s6
+; CHECK-FP16-NEXT:    vmovx.f16 s4, s3
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s4, s4
 ; CHECK-FP16-NEXT:    vmov.i32 q10, #0xffff
 ; CHECK-FP16-NEXT:    vmov.i32 q11, #0x0
-; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s5
 ; CHECK-FP16-NEXT:    vmov.32 d16[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s5
+; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s14
-; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s12
 ; CHECK-FP16-NEXT:    vmov.32 d18[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s12
+; CHECK-FP16-NEXT:    vmov.32 d19[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s10
-; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s8
 ; CHECK-FP16-NEXT:    vmov.32 d16[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s8
+; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
 ; CHECK-FP16-NEXT:    vmov r0, s6
 ; CHECK-FP16-NEXT:    vmin.s32 q8, q8, q10
 ; CHECK-FP16-NEXT:    vmax.s32 q8, q8, q11
-; CHECK-FP16-NEXT:    vmovn.i32 d1, q8
-; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmovn.i32 d0, q8
 ; CHECK-FP16-NEXT:    vmov.32 d18[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmov.32 d19[1], r0
 ; CHECK-FP16-NEXT:    vmin.s32 q9, q9, q10
 ; CHECK-FP16-NEXT:    vmax.s32 q9, q9, q11
-; CHECK-FP16-NEXT:    vmovn.i32 d0, q9
+; CHECK-FP16-NEXT:    vmovn.i32 d1, q9
 ; CHECK-FP16-NEXT:    bx lr
 entry:
   %conv = fptosi <8 x half> %x to <8 x i32>
@@ -3621,14 +3625,13 @@ define <2 x i64> @stest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    mvn r9, #0
 ; CHECK-NEXT:    subs r1, r0, r9
 ; CHECK-NEXT:    mvn r5, #-2147483648
 ; CHECK-NEXT:    sbcs r1, r4, r5
-; CHECK-NEXT:    vorr d0, d8, d8
+; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    sbcs r1, r2, #0
 ; CHECK-NEXT:    mov r7, #0
 ; CHECK-NEXT:    sbcs r1, r3, #0
@@ -3651,7 +3654,7 @@ define <2 x i64> @stest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    moveq r4, r8
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d1[0], r7
+; CHECK-NEXT:    vmov.32 d0[0], r7
 ; CHECK-NEXT:    sbcs r6, r1, r5
 ; CHECK-NEXT:    sbcs r6, r2, #0
 ; CHECK-NEXT:    sbcs r6, r3, #0
@@ -3670,9 +3673,9 @@ define <2 x i64> @stest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    cmp r10, #0
 ; CHECK-NEXT:    movne r10, r0
 ; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d0[0], r10
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -3691,11 +3694,10 @@ define <2 x i64> @utest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    subs r1, r2, #1
-; CHECK-NEXT:    vorr d0, d8, d8
+; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    sbcs r1, r3, #0
 ; CHECK-NEXT:    mov r6, #0
 ; CHECK-NEXT:    mov r5, #0
@@ -3705,15 +3707,15 @@ define <2 x i64> @utest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    movne r6, r0
 ; CHECK-NEXT:    bl __fixunsdfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEXT:    vmov.32 d0[0], r6
 ; CHECK-NEXT:    sbcs r2, r3, #0
 ; CHECK-NEXT:    movwlo r5, #1
 ; CHECK-NEXT:    cmp r5, #0
 ; CHECK-NEXT:    moveq r0, r5
 ; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[0], r0
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -3731,12 +3733,11 @@ define <2 x i64> @ustest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vorr q4, q0, q0
-; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    mov r5, r0
 ; CHECK-NEXT:    subs r0, r2, #1
 ; CHECK-NEXT:    sbcs r0, r3, #0
-; CHECK-NEXT:    vorr d0, d8, d8
+; CHECK-NEXT:    vorr d0, d9, d9
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    movwlt r0, #1
@@ -3750,7 +3751,7 @@ define <2 x i64> @ustest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    movwmi r5, #0
 ; CHECK-NEXT:    bl __fixdfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEXT:    sbcs r2, r3, #0
 ; CHECK-NEXT:    movwlt r6, #1
 ; CHECK-NEXT:    cmp r6, #0
@@ -3760,9 +3761,9 @@ define <2 x i64> @ustest_f64i64_mm(<2 x double> %x) {
 ; CHECK-NEXT:    cmp r6, #0
 ; CHECK-NEXT:    movwmi r0, #0
 ; CHECK-NEXT:    movwmi r1, #0
-; CHECK-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r1
+; CHECK-NEXT:    vmov.32 d1[0], r0
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -3781,14 +3782,13 @@ define <2 x i64> @stest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    .vsave {d8}
 ; CHECK-NEXT:    vpush {d8}
 ; CHECK-NEXT:    vmov.f64 d8, d0
-; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    mvn r9, #0
 ; CHECK-NEXT:    subs r1, r0, r9
 ; CHECK-NEXT:    mvn r5, #-2147483648
 ; CHECK-NEXT:    sbcs r1, r4, r5
-; CHECK-NEXT:    vmov.f32 s0, s16
+; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    sbcs r1, r2, #0
 ; CHECK-NEXT:    mov r7, #0
 ; CHECK-NEXT:    sbcs r1, r3, #0
@@ -3811,7 +3811,7 @@ define <2 x i64> @stest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    moveq r4, r8
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs r6, r0, r9
-; CHECK-NEXT:    vmov.32 d1[0], r7
+; CHECK-NEXT:    vmov.32 d0[0], r7
 ; CHECK-NEXT:    sbcs r6, r1, r5
 ; CHECK-NEXT:    sbcs r6, r2, #0
 ; CHECK-NEXT:    sbcs r6, r3, #0
@@ -3830,9 +3830,9 @@ define <2 x i64> @stest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    cmp r10, #0
 ; CHECK-NEXT:    movne r10, r0
 ; CHECK-NEXT:    moveq r5, r8
-; CHECK-NEXT:    vmov.32 d0[0], r10
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
@@ -3851,9 +3851,8 @@ define <2 x i64> @utest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    .vsave {d8}
 ; CHECK-NEXT:    vpush {d8}
 ; CHECK-NEXT:    vmov.f64 d8, d0
-; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    bl __fixunssfti
-; CHECK-NEXT:    vmov.f32 s0, s16
+; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    mov r4, r1
 ; CHECK-NEXT:    subs r1, r2, #1
 ; CHECK-NEXT:    mov r6, #0
@@ -3865,15 +3864,15 @@ define <2 x i64> @utest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    movne r6, r0
 ; CHECK-NEXT:    bl __fixunssfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r6
+; CHECK-NEXT:    vmov.32 d0[0], r6
 ; CHECK-NEXT:    sbcs r2, r3, #0
 ; CHECK-NEXT:    movwlo r5, #1
 ; CHECK-NEXT:    cmp r5, #0
 ; CHECK-NEXT:    moveq r0, r5
 ; CHECK-NEXT:    movne r5, r1
-; CHECK-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r5
+; CHECK-NEXT:    vmov.32 d1[0], r0
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r5
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -3891,9 +3890,8 @@ define <2 x i64> @ustest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    .vsave {d8}
 ; CHECK-NEXT:    vpush {d8}
 ; CHECK-NEXT:    vmov.f64 d8, d0
-; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    bl __fixsfti
-; CHECK-NEXT:    vmov.f32 s0, s16
+; CHECK-NEXT:    vmov.f32 s0, s17
 ; CHECK-NEXT:    mov r5, r0
 ; CHECK-NEXT:    subs r0, r2, #1
 ; CHECK-NEXT:    mov r4, r1
@@ -3910,7 +3908,7 @@ define <2 x i64> @ustest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    movwmi r5, #0
 ; CHECK-NEXT:    bl __fixsfti
 ; CHECK-NEXT:    subs r2, r2, #1
-; CHECK-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEXT:    sbcs r2, r3, #0
 ; CHECK-NEXT:    movwlt r6, #1
 ; CHECK-NEXT:    cmp r6, #0
@@ -3920,9 +3918,9 @@ define <2 x i64> @ustest_f32i64_mm(<2 x float> %x) {
 ; CHECK-NEXT:    cmp r6, #0
 ; CHECK-NEXT:    movwmi r0, #0
 ; CHECK-NEXT:    movwmi r1, #0
-; CHECK-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEXT:    vmov.32 d0[1], r1
+; CHECK-NEXT:    vmov.32 d1[0], r0
+; CHECK-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEXT:    vpop {d8}
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
 entry:
@@ -3940,8 +3938,8 @@ define <2 x i64> @stest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8}
 ; CHECK-NEON-NEXT:    vpush {d8}
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.f32 s16, s1
+; CHECK-NEON-NEXT:    vmov r0, s1
+; CHECK-NEON-NEXT:    vmov.f32 s16, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r8, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
@@ -3976,7 +3974,7 @@ define <2 x i64> @stest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    moveq r4, r8
 ; CHECK-NEON-NEXT:    bl __fixsfti
 ; CHECK-NEON-NEXT:    subs r7, r0, r9
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEON-NEXT:    sbcs r7, r1, r6
 ; CHECK-NEON-NEXT:    sbcs r7, r2, #0
 ; CHECK-NEON-NEXT:    sbcs r7, r3, #0
@@ -3995,9 +3993,9 @@ define <2 x i64> @stest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    cmp r10, #0
 ; CHECK-NEON-NEXT:    movne r10, r0
 ; CHECK-NEON-NEXT:    moveq r6, r8
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r10
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r10
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r6
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
@@ -4005,8 +4003,8 @@ define <2 x i64> @stest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16:       @ %bb.0: @ %entry
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
-; CHECK-FP16-NEXT:    vmov.u16 r7, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r7, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    mov r4, r1
@@ -4037,7 +4035,7 @@ define <2 x i64> @stest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    moveq r4, r8
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    subs r6, r0, r9
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r7
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r7
 ; CHECK-FP16-NEXT:    sbcs r6, r1, r5
 ; CHECK-FP16-NEXT:    sbcs r6, r2, #0
 ; CHECK-FP16-NEXT:    sbcs r6, r3, #0
@@ -4056,9 +4054,9 @@ define <2 x i64> @stest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    cmp r10, #0
 ; CHECK-FP16-NEXT:    movne r10, r0
 ; CHECK-FP16-NEXT:    moveq r5, r8
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r10
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r10
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 entry:
   %conv = fptosi <2 x half> %x to <2 x i128>
@@ -4075,8 +4073,8 @@ define <2 x i64> @utest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8}
 ; CHECK-NEON-NEXT:    vpush {d8}
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.f32 s16, s1
+; CHECK-NEON-NEXT:    vmov r0, s1
+; CHECK-NEON-NEXT:    vmov.f32 s16, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r5, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
@@ -4095,15 +4093,15 @@ define <2 x i64> @utest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    movne r5, r0
 ; CHECK-NEON-NEXT:    bl __fixunssfti
 ; CHECK-NEON-NEXT:    subs r2, r2, #1
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEON-NEXT:    sbcs r2, r3, #0
 ; CHECK-NEON-NEXT:    movwlo r6, #1
 ; CHECK-NEON-NEXT:    cmp r6, #0
 ; CHECK-NEON-NEXT:    moveq r0, r6
 ; CHECK-NEON-NEXT:    movne r6, r1
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r6
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r6
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -4111,8 +4109,8 @@ define <2 x i64> @utest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16:       @ %bb.0: @ %entry
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, lr}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
-; CHECK-FP16-NEXT:    vmov.u16 r6, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r6, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfti
 ; CHECK-FP16-NEXT:    mov r4, r1
@@ -4127,15 +4125,15 @@ define <2 x i64> @utest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    movne r6, r0
 ; CHECK-FP16-NEXT:    bl __fixunshfti
 ; CHECK-FP16-NEXT:    subs r2, r2, #1
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r6
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r6
 ; CHECK-FP16-NEXT:    sbcs r2, r3, #0
 ; CHECK-FP16-NEXT:    movwlo r5, #1
 ; CHECK-FP16-NEXT:    cmp r5, #0
 ; CHECK-FP16-NEXT:    moveq r0, r5
 ; CHECK-FP16-NEXT:    movne r5, r1
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r0
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r5
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r0
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r5
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, pc}
 entry:
   %conv = fptoui <2 x half> %x to <2 x i128>
@@ -4151,8 +4149,8 @@ define <2 x i64> @ustest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8}
 ; CHECK-NEON-NEXT:    vpush {d8}
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.f32 s16, s1
+; CHECK-NEON-NEXT:    vmov r0, s1
+; CHECK-NEON-NEXT:    vmov.f32 s16, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    mov r6, r0
 ; CHECK-NEON-NEXT:    vmov r0, s16
@@ -4176,7 +4174,7 @@ define <2 x i64> @ustest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    movwmi r5, #0
 ; CHECK-NEON-NEXT:    bl __fixsfti
 ; CHECK-NEON-NEXT:    subs r2, r2, #1
-; CHECK-NEON-NEXT:    vmov.32 d1[0], r5
+; CHECK-NEON-NEXT:    vmov.32 d0[0], r5
 ; CHECK-NEON-NEXT:    sbcs r2, r3, #0
 ; CHECK-NEON-NEXT:    movwlt r7, #1
 ; CHECK-NEON-NEXT:    cmp r7, #0
@@ -4186,9 +4184,9 @@ define <2 x i64> @ustest_f16i64_mm(<2 x half> %x) {
 ; CHECK-NEON-NEXT:    cmp r7, #0
 ; CHECK-NEON-NEXT:    movwmi r0, #0
 ; CHECK-NEON-NEXT:    movwmi r1, #0
-; CHECK-NEON-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEON-NEXT:    vmov.32 d1[1], r4
-; CHECK-NEON-NEXT:    vmov.32 d0[1], r1
+; CHECK-NEON-NEXT:    vmov.32 d1[0], r0
+; CHECK-NEON-NEXT:    vmov.32 d0[1], r4
+; CHECK-NEON-NEXT:    vmov.32 d1[1], r1
 ; CHECK-NEON-NEXT:    vpop {d8}
 ; CHECK-NEON-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
@@ -4196,8 +4194,8 @@ define <2 x i64> @ustest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16:       @ %bb.0: @ %entry
 ; CHECK-FP16-NEXT:    .save {r4, r5, r6, r7, r11, lr}
 ; CHECK-FP16-NEXT:    push {r4, r5, r6, r7, r11, lr}
-; CHECK-FP16-NEXT:    vmov.u16 r0, d0[1]
-; CHECK-FP16-NEXT:    vmov.u16 r7, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r0, d0[0]
+; CHECK-FP16-NEXT:    vmov.u16 r7, d0[1]
 ; CHECK-FP16-NEXT:    vmov s0, r0
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    mov r5, r0
@@ -4217,7 +4215,7 @@ define <2 x i64> @ustest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    movwmi r5, #0
 ; CHECK-FP16-NEXT:    bl __fixhfti
 ; CHECK-FP16-NEXT:    subs r2, r2, #1
-; CHECK-FP16-NEXT:    vmov.32 d1[0], r5
+; CHECK-FP16-NEXT:    vmov.32 d0[0], r5
 ; CHECK-FP16-NEXT:    sbcs r2, r3, #0
 ; CHECK-FP16-NEXT:    movwlt r6, #1
 ; CHECK-FP16-NEXT:    cmp r6, #0
@@ -4227,9 +4225,9 @@ define <2 x i64> @ustest_f16i64_mm(<2 x half> %x) {
 ; CHECK-FP16-NEXT:    cmp r6, #0
 ; CHECK-FP16-NEXT:    movwmi r0, #0
 ; CHECK-FP16-NEXT:    movwmi r1, #0
-; CHECK-FP16-NEXT:    vmov.32 d0[0], r0
-; CHECK-FP16-NEXT:    vmov.32 d1[1], r4
-; CHECK-FP16-NEXT:    vmov.32 d0[1], r1
+; CHECK-FP16-NEXT:    vmov.32 d1[0], r0
+; CHECK-FP16-NEXT:    vmov.32 d0[1], r4
+; CHECK-FP16-NEXT:    vmov.32 d1[1], r1
 ; CHECK-FP16-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 entry:
   %conv = fptosi <2 x half> %x to <2 x i128>
@@ -4244,62 +4242,63 @@ entry:
 define <4 x i32> @ustest_f16i32_nsat(<4 x half> %x) {
 ; CHECK-NEON-LABEL: ustest_f16i32_nsat:
 ; CHECK-NEON:       @ %bb.0: @ %entry
-; CHECK-NEON-NEXT:    .save {r4, lr}
-; CHECK-NEON-NEXT:    push {r4, lr}
+; CHECK-NEON-NEXT:    .save {r4, r5, r11, lr}
+; CHECK-NEON-NEXT:    push {r4, r5, r11, lr}
 ; CHECK-NEON-NEXT:    .vsave {d8, d9, d10, d11}
 ; CHECK-NEON-NEXT:    vpush {d8, d9, d10, d11}
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.f32 s16, s3
-; CHECK-NEON-NEXT:    vmov.f32 s18, s2
-; CHECK-NEON-NEXT:    vmov.f32 s20, s1
+; CHECK-NEON-NEXT:    vmov r0, s3
+; CHECK-NEON-NEXT:    vmov.f32 s16, s2
+; CHECK-NEON-NEXT:    vmov.f32 s18, s1
+; CHECK-NEON-NEXT:    vmov.f32 s20, s0
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    mov r4, r0
-; CHECK-NEON-NEXT:    vmov r0, s16
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s16, r0
-; CHECK-NEON-NEXT:    vmov r0, s18
-; CHECK-NEON-NEXT:    bl __aeabi_h2f
-; CHECK-NEON-NEXT:    vmov s0, r0
 ; CHECK-NEON-NEXT:    vmov r1, s20
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov s18, r4
-; CHECK-NEON-NEXT:    vmov r0, s0
-; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
+; CHECK-NEON-NEXT:    vmov r4, s16
+; CHECK-NEON-NEXT:    vmov s16, r0
+; CHECK-NEON-NEXT:    vmov r5, s18
 ; CHECK-NEON-NEXT:    mov r0, r1
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s18, r0
+; CHECK-NEON-NEXT:    mov r0, r4
 ; CHECK-NEON-NEXT:    bl __aeabi_h2f
 ; CHECK-NEON-NEXT:    vcvt.s32.f32 s2, s18
 ; CHECK-NEON-NEXT:    vmov s0, r0
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s4, s16
-; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
-; CHECK-NEON-NEXT:    vmov.i32 q8, #0x0
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s18, s0
 ; CHECK-NEON-NEXT:    vmov r0, s2
 ; CHECK-NEON-NEXT:    vmov.32 d10[0], r0
-; CHECK-NEON-NEXT:    vmov r0, s4
-; CHECK-NEON-NEXT:    vmov.32 d11[1], r0
+; CHECK-NEON-NEXT:    mov r0, r5
+; CHECK-NEON-NEXT:    bl __aeabi_h2f
+; CHECK-NEON-NEXT:    vmov s0, r0
+; CHECK-NEON-NEXT:    vmov r0, s18
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s0, s0
+; CHECK-NEON-NEXT:    vcvt.s32.f32 s2, s16
+; CHECK-NEON-NEXT:    vmov.i32 q8, #0x0
+; CHECK-NEON-NEXT:    vmov.32 d11[0], r0
 ; CHECK-NEON-NEXT:    vmov r0, s0
 ; CHECK-NEON-NEXT:    vmov.32 d10[1], r0
+; CHECK-NEON-NEXT:    vmov r0, s2
+; CHECK-NEON-NEXT:    vmov.32 d11[1], r0
 ; CHECK-NEON-NEXT:    vmin.s32 q9, q5, q8
 ; CHECK-NEON-NEXT:    vmax.s32 q0, q9, q8
 ; CHECK-NEON-NEXT:    vpop {d8, d9, d10, d11}
-; CHECK-NEON-NEXT:    pop {r4, pc}
+; CHECK-NEON-NEXT:    pop {r4, r5, r11, pc}
 ;
 ; CHECK-FP16-LABEL: ustest_f16i32_nsat:
 ; CHECK-FP16:       @ %bb.0: @ %entry
-; CHECK-FP16-NEXT:    vmovx.f16 s2, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s6, s0
-; CHECK-FP16-NEXT:    vcvt.s32.f16 s0, s1
-; CHECK-FP16-NEXT:    vmovx.f16 s4, s1
+; CHECK-FP16-NEXT:    vmovx.f16 s4, s0
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s0, s0
 ; CHECK-FP16-NEXT:    vmov r0, s0
+; CHECK-FP16-NEXT:    vcvt.s32.f16 s6, s1
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s4, s4
+; CHECK-FP16-NEXT:    vmovx.f16 s2, s1
 ; CHECK-FP16-NEXT:    vcvt.s32.f16 s2, s2
 ; CHECK-FP16-NEXT:    vmov.i32 q9, #0x0
-; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
-; CHECK-FP16-NEXT:    vmov r0, s6
 ; CHECK-FP16-NEXT:    vmov.32 d16[0], r0
+; CHECK-FP16-NEXT:    vmov r0, s6
+; CHECK-FP16-NEXT:    vmov.32 d17[0], r0
 ; CHECK-FP16-NEXT:    vmov r0, s4
-; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s2
 ; CHECK-FP16-NEXT:    vmov.32 d16[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s2
+; CHECK-FP16-NEXT:    vmov.32 d17[1], r0
 ; CHECK-FP16-NEXT:    vmin.s32 q8, q8, q9
 ; CHECK-FP16-NEXT:    vmax.s32 q0, q8, q9
 ; CHECK-FP16-NEXT:    bx lr

--- a/llvm/test/CodeGen/ARM/legalize-bitcast.ll
+++ b/llvm/test/CodeGen/ARM/legalize-bitcast.ll
@@ -11,12 +11,13 @@ define i32 @vec_to_int() {
 ; CHECK-NEXT:    movw r0, :lower16:vec6_p
 ; CHECK-NEXT:    movt r0, :upper16:vec6_p
 ; CHECK-NEXT:    vld1.8 {d16}, [r0]!
+; CHECK-NEXT:    vrev16.8 d18, d16
+; CHECK-NEXT:    @ implicit-def: $q8
+; CHECK-NEXT:    vmov.f64 d16, d18
 ; CHECK-NEXT:    ldr r0, [r0]
-; CHECK-NEXT:    @ implicit-def: $d17
-; CHECK-NEXT:    vmov.32 d17[0], r0
-; CHECK-NEXT:    vrev32.16 d18, d17
-; CHECK-NEXT:    vrev16.8 d16, d16
-; CHECK-NEXT:    @ kill: def $d16 killed $d16 def $q8
+; CHECK-NEXT:    @ implicit-def: $d18
+; CHECK-NEXT:    vmov.32 d18[0], r0
+; CHECK-NEXT:    vrev32.16 d18, d18
 ; CHECK-NEXT:    vmov.f64 d17, d18
 ; CHECK-NEXT:    vstmia sp, {d16, d17} @ 16-byte Spill
 ; CHECK-NEXT:    b .LBB0_1

--- a/llvm/test/CodeGen/ARM/llvm.frexp.ll
+++ b/llvm/test/CodeGen/ARM/llvm.frexp.ll
@@ -332,25 +332,25 @@ define { <4 x float>, <4 x i32> } @test_frexp_v4f32_v4i32(<4 x float> %a) {
 ; CHECK-NEXT:    bl frexpf
 ; CHECK-NEXT:    vldr d16, [sp, #80]
 ; CHECK-NEXT:    mov r5, r0
-; CHECK-NEXT:    vld1.32 {d8[0]}, [r8:32]
+; CHECK-NEXT:    vld1.32 {d10[0]}, [r8:32]
 ; CHECK-NEXT:    add.w r8, sp, #4
 ; CHECK-NEXT:    vmov r0, r7, d16
 ; CHECK-NEXT:    mov r1, r8
-; CHECK-NEXT:    vld1.32 {d8[1]}, [r6:32]
+; CHECK-NEXT:    vld1.32 {d10[1]}, [r6:32]
 ; CHECK-NEXT:    bl frexpf
-; CHECK-NEXT:    vld1.32 {d9[0]}, [r8:32]
-; CHECK-NEXT:    vmov s21, r5
+; CHECK-NEXT:    vld1.32 {d11[0]}, [r8:32]
+; CHECK-NEXT:    vmov s17, r5
 ; CHECK-NEXT:    mov r5, sp
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    mov r0, r7
 ; CHECK-NEXT:    mov r1, r5
-; CHECK-NEXT:    vmov s20, r9
+; CHECK-NEXT:    vmov s16, r9
 ; CHECK-NEXT:    bl frexpf
-; CHECK-NEXT:    vmov s23, r0
-; CHECK-NEXT:    vld1.32 {d9[1]}, [r5:32]
-; CHECK-NEXT:    vmov s22, r6
-; CHECK-NEXT:    vst1.32 {d10, d11}, [r4]!
-; CHECK-NEXT:    vst1.64 {d8, d9}, [r4]
+; CHECK-NEXT:    vmov s19, r0
+; CHECK-NEXT:    vld1.32 {d11[1]}, [r5:32]
+; CHECK-NEXT:    vmov s18, r6
+; CHECK-NEXT:    vst1.32 {d8, d9}, [r4]!
+; CHECK-NEXT:    vst1.64 {d10, d11}, [r4]
 ; CHECK-NEXT:    add sp, #16
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11}
 ; CHECK-NEXT:    add sp, #4

--- a/llvm/test/CodeGen/ARM/neon-vmovn.ll
+++ b/llvm/test/CodeGen/ARM/neon-vmovn.ll
@@ -11,9 +11,8 @@ define arm_aapcs_vfpcc <8 x i16> @vmovn32_trunc1(<4 x i32> %src1, <4 x i32> %src
 ; CHECK-LABEL: vmovn32_trunc1:
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    vzip.32 q0, q1
-; CHECK-NEXT:    vmovn.i32 d17, q1
-; CHECK-NEXT:    vmovn.i32 d16, q0
-; CHECK-NEXT:    vorr q0, q8, q8
+; CHECK-NEXT:    vmovn.i32 d0, q0
+; CHECK-NEXT:    vmovn.i32 d1, q1
 ; CHECK-NEXT:    bx lr
 ;
 ; CHECKBE-LABEL: vmovn32_trunc1:
@@ -21,9 +20,9 @@ define arm_aapcs_vfpcc <8 x i16> @vmovn32_trunc1(<4 x i32> %src1, <4 x i32> %src
 ; CHECKBE-NEXT:    vrev64.32 q8, q1
 ; CHECKBE-NEXT:    vrev64.32 q9, q0
 ; CHECKBE-NEXT:    vzip.32 q9, q8
-; CHECKBE-NEXT:    vmovn.i32 d17, q8
-; CHECKBE-NEXT:    vmovn.i32 d16, q9
-; CHECKBE-NEXT:    vrev64.16 q0, q8
+; CHECKBE-NEXT:    vmovn.i32 d18, q9
+; CHECKBE-NEXT:    vmovn.i32 d19, q8
+; CHECKBE-NEXT:    vrev64.16 q0, q9
 ; CHECKBE-NEXT:    bx lr
 entry:
   %strided.vec = shufflevector <4 x i32> %src1, <4 x i32> %src2, <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 2, i32 6, i32 3, i32 7>
@@ -35,8 +34,9 @@ define arm_aapcs_vfpcc <8 x i16> @vmovn32_trunc2(<4 x i32> %src1, <4 x i32> %src
 ; CHECK-LABEL: vmovn32_trunc2:
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    vzip.32 q1, q0
-; CHECK-NEXT:    vmovn.i32 d1, q0
-; CHECK-NEXT:    vmovn.i32 d0, q1
+; CHECK-NEXT:    vmovn.i32 d16, q1
+; CHECK-NEXT:    vmovn.i32 d17, q0
+; CHECK-NEXT:    vorr q0, q8, q8
 ; CHECK-NEXT:    bx lr
 ;
 ; CHECKBE-LABEL: vmovn32_trunc2:
@@ -44,9 +44,9 @@ define arm_aapcs_vfpcc <8 x i16> @vmovn32_trunc2(<4 x i32> %src1, <4 x i32> %src
 ; CHECKBE-NEXT:    vrev64.32 q8, q0
 ; CHECKBE-NEXT:    vrev64.32 q9, q1
 ; CHECKBE-NEXT:    vzip.32 q9, q8
-; CHECKBE-NEXT:    vmovn.i32 d17, q8
-; CHECKBE-NEXT:    vmovn.i32 d16, q9
-; CHECKBE-NEXT:    vrev64.16 q0, q8
+; CHECKBE-NEXT:    vmovn.i32 d18, q9
+; CHECKBE-NEXT:    vmovn.i32 d19, q8
+; CHECKBE-NEXT:    vrev64.16 q0, q9
 ; CHECKBE-NEXT:    bx lr
 entry:
   %strided.vec = shufflevector <4 x i32> %src1, <4 x i32> %src2, <8 x i32> <i32 4, i32 0, i32 5, i32 1, i32 6, i32 2, i32 7, i32 3>
@@ -58,9 +58,8 @@ define arm_aapcs_vfpcc <16 x i8> @vmovn16_trunc1(<8 x i16> %src1, <8 x i16> %src
 ; CHECK-LABEL: vmovn16_trunc1:
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    vzip.16 q0, q1
-; CHECK-NEXT:    vmovn.i16 d17, q1
-; CHECK-NEXT:    vmovn.i16 d16, q0
-; CHECK-NEXT:    vorr q0, q8, q8
+; CHECK-NEXT:    vmovn.i16 d0, q0
+; CHECK-NEXT:    vmovn.i16 d1, q1
 ; CHECK-NEXT:    bx lr
 ;
 ; CHECKBE-LABEL: vmovn16_trunc1:
@@ -68,9 +67,9 @@ define arm_aapcs_vfpcc <16 x i8> @vmovn16_trunc1(<8 x i16> %src1, <8 x i16> %src
 ; CHECKBE-NEXT:    vrev64.16 q8, q1
 ; CHECKBE-NEXT:    vrev64.16 q9, q0
 ; CHECKBE-NEXT:    vzip.16 q9, q8
-; CHECKBE-NEXT:    vmovn.i16 d17, q8
-; CHECKBE-NEXT:    vmovn.i16 d16, q9
-; CHECKBE-NEXT:    vrev64.8 q0, q8
+; CHECKBE-NEXT:    vmovn.i16 d18, q9
+; CHECKBE-NEXT:    vmovn.i16 d19, q8
+; CHECKBE-NEXT:    vrev64.8 q0, q9
 ; CHECKBE-NEXT:    bx lr
 entry:
   %strided.vec = shufflevector <8 x i16> %src1, <8 x i16> %src2, <16 x i32> <i32 0, i32 8, i32 1, i32 9, i32 2, i32 10, i32 3, i32 11, i32 4, i32 12, i32 5, i32 13, i32 6, i32 14, i32 7, i32 15>
@@ -82,8 +81,9 @@ define arm_aapcs_vfpcc <16 x i8> @vmovn16_trunc2(<8 x i16> %src1, <8 x i16> %src
 ; CHECK-LABEL: vmovn16_trunc2:
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    vzip.16 q1, q0
-; CHECK-NEXT:    vmovn.i16 d1, q0
-; CHECK-NEXT:    vmovn.i16 d0, q1
+; CHECK-NEXT:    vmovn.i16 d16, q1
+; CHECK-NEXT:    vmovn.i16 d17, q0
+; CHECK-NEXT:    vorr q0, q8, q8
 ; CHECK-NEXT:    bx lr
 ;
 ; CHECKBE-LABEL: vmovn16_trunc2:
@@ -91,9 +91,9 @@ define arm_aapcs_vfpcc <16 x i8> @vmovn16_trunc2(<8 x i16> %src1, <8 x i16> %src
 ; CHECKBE-NEXT:    vrev64.16 q8, q0
 ; CHECKBE-NEXT:    vrev64.16 q9, q1
 ; CHECKBE-NEXT:    vzip.16 q9, q8
-; CHECKBE-NEXT:    vmovn.i16 d17, q8
-; CHECKBE-NEXT:    vmovn.i16 d16, q9
-; CHECKBE-NEXT:    vrev64.8 q0, q8
+; CHECKBE-NEXT:    vmovn.i16 d18, q9
+; CHECKBE-NEXT:    vmovn.i16 d19, q8
+; CHECKBE-NEXT:    vrev64.8 q0, q9
 ; CHECKBE-NEXT:    bx lr
 entry:
   %strided.vec = shufflevector <8 x i16> %src1, <8 x i16> %src2, <16 x i32> <i32 8, i32 0, i32 9, i32 1, i32 10, i32 2, i32 11, i32 3, i32 12, i32 4, i32 13, i32 5, i32 14, i32 6, i32 15, i32 7>
@@ -372,23 +372,23 @@ entry:
 define arm_aapcs_vfpcc <8 x i16> @vmovn16_b1(<8 x i16> %src1, <8 x i16> %src2) {
 ; CHECK-LABEL: vmovn16_b1:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vrev32.16 d16, d1
-; CHECK-NEXT:    vrev32.16 d17, d0
-; CHECK-NEXT:    vtrn.16 d16, d3
-; CHECK-NEXT:    vtrn.16 d17, d2
+; CHECK-NEXT:    vrev32.16 d16, d0
+; CHECK-NEXT:    vrev32.16 d17, d1
+; CHECK-NEXT:    vtrn.16 d16, d2
+; CHECK-NEXT:    vtrn.16 d17, d3
 ; CHECK-NEXT:    vorr q0, q1, q1
 ; CHECK-NEXT:    bx lr
 ;
 ; CHECKBE-LABEL: vmovn16_b1:
 ; CHECKBE:       @ %bb.0: @ %entry
-; CHECKBE-NEXT:    vrev64.16 d16, d1
-; CHECKBE-NEXT:    vrev64.16 d17, d0
-; CHECKBE-NEXT:    vrev64.16 d19, d3
-; CHECKBE-NEXT:    vrev32.16 d16, d16
+; CHECKBE-NEXT:    vrev64.16 d16, d0
+; CHECKBE-NEXT:    vrev64.16 d17, d1
 ; CHECKBE-NEXT:    vrev64.16 d18, d2
+; CHECKBE-NEXT:    vrev32.16 d16, d16
+; CHECKBE-NEXT:    vrev64.16 d19, d3
 ; CHECKBE-NEXT:    vrev32.16 d17, d17
-; CHECKBE-NEXT:    vtrn.16 d16, d19
-; CHECKBE-NEXT:    vtrn.16 d17, d18
+; CHECKBE-NEXT:    vtrn.16 d16, d18
+; CHECKBE-NEXT:    vtrn.16 d17, d19
 ; CHECKBE-NEXT:    vrev64.16 q0, q9
 ; CHECKBE-NEXT:    bx lr
 entry:
@@ -399,27 +399,27 @@ entry:
 define arm_aapcs_vfpcc <8 x i16> @vmovn16_b2(<8 x i16> %src1, <8 x i16> %src2) {
 ; CHECK-LABEL: vmovn16_b2:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vorr d17, d3, d3
-; CHECK-NEXT:    vtrn.16 d17, d1
 ; CHECK-NEXT:    vorr d16, d2, d2
 ; CHECK-NEXT:    vtrn.16 d16, d0
-; CHECK-NEXT:    vtrn.16 d3, d17
+; CHECK-NEXT:    vorr d17, d3, d3
+; CHECK-NEXT:    vtrn.16 d17, d1
 ; CHECK-NEXT:    vtrn.16 d2, d16
+; CHECK-NEXT:    vtrn.16 d3, d17
 ; CHECK-NEXT:    vorr q0, q8, q8
 ; CHECK-NEXT:    bx lr
 ;
 ; CHECKBE-LABEL: vmovn16_b2:
 ; CHECKBE:       @ %bb.0: @ %entry
-; CHECKBE-NEXT:    vrev64.16 d17, d3
-; CHECKBE-NEXT:    vorr d21, d17, d17
-; CHECKBE-NEXT:    vrev64.16 d16, d1
-; CHECKBE-NEXT:    vrev64.16 d19, d2
-; CHECKBE-NEXT:    vrev64.16 d18, d0
-; CHECKBE-NEXT:    vtrn.16 d21, d16
-; CHECKBE-NEXT:    vorr d20, d19, d19
-; CHECKBE-NEXT:    vtrn.16 d20, d18
-; CHECKBE-NEXT:    vtrn.16 d17, d21
-; CHECKBE-NEXT:    vtrn.16 d19, d20
+; CHECKBE-NEXT:    vrev64.16 d17, d2
+; CHECKBE-NEXT:    vorr d20, d17, d17
+; CHECKBE-NEXT:    vrev64.16 d16, d0
+; CHECKBE-NEXT:    vrev64.16 d19, d3
+; CHECKBE-NEXT:    vrev64.16 d18, d1
+; CHECKBE-NEXT:    vtrn.16 d20, d16
+; CHECKBE-NEXT:    vorr d21, d19, d19
+; CHECKBE-NEXT:    vtrn.16 d21, d18
+; CHECKBE-NEXT:    vtrn.16 d17, d20
+; CHECKBE-NEXT:    vtrn.16 d19, d21
 ; CHECKBE-NEXT:    vrev64.16 q0, q10
 ; CHECKBE-NEXT:    bx lr
 entry:
@@ -430,27 +430,27 @@ entry:
 define arm_aapcs_vfpcc <8 x i16> @vmovn16_b3(<8 x i16> %src1, <8 x i16> %src2) {
 ; CHECK-LABEL: vmovn16_b3:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vorr d17, d1, d1
-; CHECK-NEXT:    vtrn.16 d17, d3
 ; CHECK-NEXT:    vorr d16, d0, d0
 ; CHECK-NEXT:    vtrn.16 d16, d2
-; CHECK-NEXT:    vtrn.16 d1, d17
+; CHECK-NEXT:    vorr d17, d1, d1
+; CHECK-NEXT:    vtrn.16 d17, d3
 ; CHECK-NEXT:    vtrn.16 d0, d16
+; CHECK-NEXT:    vtrn.16 d1, d17
 ; CHECK-NEXT:    vorr q0, q8, q8
 ; CHECK-NEXT:    bx lr
 ;
 ; CHECKBE-LABEL: vmovn16_b3:
 ; CHECKBE:       @ %bb.0: @ %entry
-; CHECKBE-NEXT:    vrev64.16 d17, d1
-; CHECKBE-NEXT:    vorr d21, d17, d17
-; CHECKBE-NEXT:    vrev64.16 d16, d3
-; CHECKBE-NEXT:    vrev64.16 d19, d0
-; CHECKBE-NEXT:    vrev64.16 d18, d2
-; CHECKBE-NEXT:    vtrn.16 d21, d16
-; CHECKBE-NEXT:    vorr d20, d19, d19
-; CHECKBE-NEXT:    vtrn.16 d20, d18
-; CHECKBE-NEXT:    vtrn.16 d17, d21
-; CHECKBE-NEXT:    vtrn.16 d19, d20
+; CHECKBE-NEXT:    vrev64.16 d17, d0
+; CHECKBE-NEXT:    vorr d20, d17, d17
+; CHECKBE-NEXT:    vrev64.16 d16, d2
+; CHECKBE-NEXT:    vrev64.16 d19, d1
+; CHECKBE-NEXT:    vrev64.16 d18, d3
+; CHECKBE-NEXT:    vtrn.16 d20, d16
+; CHECKBE-NEXT:    vorr d21, d19, d19
+; CHECKBE-NEXT:    vtrn.16 d21, d18
+; CHECKBE-NEXT:    vtrn.16 d17, d20
+; CHECKBE-NEXT:    vtrn.16 d19, d21
 ; CHECKBE-NEXT:    vrev64.16 q0, q10
 ; CHECKBE-NEXT:    bx lr
 entry:
@@ -461,22 +461,22 @@ entry:
 define arm_aapcs_vfpcc <8 x i16> @vmovn16_b4(<8 x i16> %src1, <8 x i16> %src2) {
 ; CHECK-LABEL: vmovn16_b4:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    vrev32.16 d16, d3
-; CHECK-NEXT:    vrev32.16 d17, d2
-; CHECK-NEXT:    vtrn.16 d16, d1
-; CHECK-NEXT:    vtrn.16 d17, d0
+; CHECK-NEXT:    vrev32.16 d16, d2
+; CHECK-NEXT:    vrev32.16 d17, d3
+; CHECK-NEXT:    vtrn.16 d16, d0
+; CHECK-NEXT:    vtrn.16 d17, d1
 ; CHECK-NEXT:    bx lr
 ;
 ; CHECKBE-LABEL: vmovn16_b4:
 ; CHECKBE:       @ %bb.0: @ %entry
-; CHECKBE-NEXT:    vrev64.16 d16, d3
-; CHECKBE-NEXT:    vrev64.16 d17, d2
-; CHECKBE-NEXT:    vrev64.16 d19, d1
-; CHECKBE-NEXT:    vrev32.16 d16, d16
+; CHECKBE-NEXT:    vrev64.16 d16, d2
+; CHECKBE-NEXT:    vrev64.16 d17, d3
 ; CHECKBE-NEXT:    vrev64.16 d18, d0
+; CHECKBE-NEXT:    vrev32.16 d16, d16
+; CHECKBE-NEXT:    vrev64.16 d19, d1
 ; CHECKBE-NEXT:    vrev32.16 d17, d17
-; CHECKBE-NEXT:    vtrn.16 d16, d19
-; CHECKBE-NEXT:    vtrn.16 d17, d18
+; CHECKBE-NEXT:    vtrn.16 d16, d18
+; CHECKBE-NEXT:    vtrn.16 d17, d19
 ; CHECKBE-NEXT:    vrev64.16 q0, q9
 ; CHECKBE-NEXT:    bx lr
 entry:
@@ -525,12 +525,14 @@ entry:
 define arm_aapcs_vfpcc <16 x i8> @vmovn8_t1(<16 x i8> %src1, <16 x i8> %src2) {
 ; CHECK-LABEL: vmovn8_t1:
 ; CHECK:       @ %bb.0: @ %entry
+; CHECK-NEXT:    @ kill: def $q1 killed $q1 killed $d1_d2_d3 def $d1_d2_d3
 ; CHECK-NEXT:    vorr q2, q0, q0
-; CHECK-NEXT:    vldr d16, .LCPI24_0
+; CHECK-NEXT:    vldr d18, .LCPI24_0
+; CHECK-NEXT:    vorr d1, d4, d4
 ; CHECK-NEXT:    vorr d6, d3, d3
-; CHECK-NEXT:    vtbl.8 d1, {d5, d6}, d16
-; CHECK-NEXT:    vorr d5, d2, d2
-; CHECK-NEXT:    vtbl.8 d0, {d4, d5}, d16
+; CHECK-NEXT:    vtbl.8 d16, {d1, d2}, d18
+; CHECK-NEXT:    vtbl.8 d17, {d5, d6}, d18
+; CHECK-NEXT:    vorr q0, q8, q8
 ; CHECK-NEXT:    bx lr
 ; CHECK-NEXT:    .p2align 3
 ; CHECK-NEXT:  @ %bb.1:
@@ -547,13 +549,13 @@ define arm_aapcs_vfpcc <16 x i8> @vmovn8_t1(<16 x i8> %src1, <16 x i8> %src2) {
 ; CHECKBE-LABEL: vmovn8_t1:
 ; CHECKBE:       @ %bb.0: @ %entry
 ; CHECKBE-NEXT:    vldr d16, .LCPI24_0
-; CHECKBE-NEXT:    vrev64.8 d19, d3
-; CHECKBE-NEXT:    vrev64.8 d21, d2
-; CHECKBE-NEXT:    vrev64.8 d18, d1
+; CHECKBE-NEXT:    vrev64.8 d19, d2
+; CHECKBE-NEXT:    vrev64.8 d21, d3
+; CHECKBE-NEXT:    vrev64.8 d18, d0
 ; CHECKBE-NEXT:    vrev64.8 d16, d16
-; CHECKBE-NEXT:    vrev64.8 d20, d0
-; CHECKBE-NEXT:    vtbl.8 d19, {d18, d19}, d16
-; CHECKBE-NEXT:    vtbl.8 d18, {d20, d21}, d16
+; CHECKBE-NEXT:    vrev64.8 d20, d1
+; CHECKBE-NEXT:    vtbl.8 d18, {d18, d19}, d16
+; CHECKBE-NEXT:    vtbl.8 d19, {d20, d21}, d16
 ; CHECKBE-NEXT:    vrev64.8 q0, q9
 ; CHECKBE-NEXT:    bx lr
 ; CHECKBE-NEXT:    .p2align 3
@@ -575,13 +577,13 @@ entry:
 define arm_aapcs_vfpcc <16 x i8> @vmovn8_t2(<16 x i8> %src1, <16 x i8> %src2) {
 ; CHECK-LABEL: vmovn8_t2:
 ; CHECK:       @ %bb.0: @ %entry
+; CHECK-NEXT:    vorr q3, q0, q0
 ; CHECK-NEXT:    @ kill: def $q1 killed $q1 def $d2_d3_d4
-; CHECK-NEXT:    vldr d18, .LCPI25_0
-; CHECK-NEXT:    vorr d4, d1, d1
-; CHECK-NEXT:    vtbl.8 d17, {d3, d4}, d18
-; CHECK-NEXT:    vorr d3, d0, d0
-; CHECK-NEXT:    vtbl.8 d16, {d2, d3}, d18
-; CHECK-NEXT:    vorr q0, q8, q8
+; CHECK-NEXT:    vldr d16, .LCPI25_0
+; CHECK-NEXT:    vorr d5, d2, d2
+; CHECK-NEXT:    vorr d4, d7, d7
+; CHECK-NEXT:    vtbl.8 d0, {d5, d6}, d16
+; CHECK-NEXT:    vtbl.8 d1, {d3, d4}, d16
 ; CHECK-NEXT:    bx lr
 ; CHECK-NEXT:    .p2align 3
 ; CHECK-NEXT:  @ %bb.1:
@@ -598,13 +600,13 @@ define arm_aapcs_vfpcc <16 x i8> @vmovn8_t2(<16 x i8> %src1, <16 x i8> %src2) {
 ; CHECKBE-LABEL: vmovn8_t2:
 ; CHECKBE:       @ %bb.0: @ %entry
 ; CHECKBE-NEXT:    vldr d16, .LCPI25_0
-; CHECKBE-NEXT:    vrev64.8 d19, d1
-; CHECKBE-NEXT:    vrev64.8 d21, d0
-; CHECKBE-NEXT:    vrev64.8 d18, d3
+; CHECKBE-NEXT:    vrev64.8 d19, d0
+; CHECKBE-NEXT:    vrev64.8 d21, d1
+; CHECKBE-NEXT:    vrev64.8 d18, d2
 ; CHECKBE-NEXT:    vrev64.8 d16, d16
-; CHECKBE-NEXT:    vrev64.8 d20, d2
-; CHECKBE-NEXT:    vtbl.8 d19, {d18, d19}, d16
-; CHECKBE-NEXT:    vtbl.8 d18, {d20, d21}, d16
+; CHECKBE-NEXT:    vrev64.8 d20, d3
+; CHECKBE-NEXT:    vtbl.8 d18, {d18, d19}, d16
+; CHECKBE-NEXT:    vtbl.8 d19, {d20, d21}, d16
 ; CHECKBE-NEXT:    vrev64.8 q0, q9
 ; CHECKBE-NEXT:    bx lr
 ; CHECKBE-NEXT:    .p2align 3
@@ -626,12 +628,14 @@ entry:
 define arm_aapcs_vfpcc <16 x i8> @vmovn8_t3(<16 x i8> %src1, <16 x i8> %src2) {
 ; CHECK-LABEL: vmovn8_t3:
 ; CHECK:       @ %bb.0: @ %entry
+; CHECK-NEXT:    @ kill: def $q1 killed $q1 killed $d1_d2_d3 def $d1_d2_d3
 ; CHECK-NEXT:    vorr q2, q0, q0
-; CHECK-NEXT:    vldr d16, .LCPI26_0
+; CHECK-NEXT:    vldr d18, .LCPI26_0
+; CHECK-NEXT:    vorr d1, d4, d4
 ; CHECK-NEXT:    vorr d6, d3, d3
-; CHECK-NEXT:    vtbl.8 d1, {d5, d6}, d16
-; CHECK-NEXT:    vorr d5, d2, d2
-; CHECK-NEXT:    vtbl.8 d0, {d4, d5}, d16
+; CHECK-NEXT:    vtbl.8 d16, {d1, d2}, d18
+; CHECK-NEXT:    vtbl.8 d17, {d5, d6}, d18
+; CHECK-NEXT:    vorr q0, q8, q8
 ; CHECK-NEXT:    bx lr
 ; CHECK-NEXT:    .p2align 3
 ; CHECK-NEXT:  @ %bb.1:
@@ -648,13 +652,13 @@ define arm_aapcs_vfpcc <16 x i8> @vmovn8_t3(<16 x i8> %src1, <16 x i8> %src2) {
 ; CHECKBE-LABEL: vmovn8_t3:
 ; CHECKBE:       @ %bb.0: @ %entry
 ; CHECKBE-NEXT:    vldr d16, .LCPI26_0
-; CHECKBE-NEXT:    vrev64.8 d19, d3
-; CHECKBE-NEXT:    vrev64.8 d21, d2
-; CHECKBE-NEXT:    vrev64.8 d18, d1
+; CHECKBE-NEXT:    vrev64.8 d19, d2
+; CHECKBE-NEXT:    vrev64.8 d21, d3
+; CHECKBE-NEXT:    vrev64.8 d18, d0
 ; CHECKBE-NEXT:    vrev64.8 d16, d16
-; CHECKBE-NEXT:    vrev64.8 d20, d0
-; CHECKBE-NEXT:    vtbl.8 d19, {d18, d19}, d16
-; CHECKBE-NEXT:    vtbl.8 d18, {d20, d21}, d16
+; CHECKBE-NEXT:    vrev64.8 d20, d1
+; CHECKBE-NEXT:    vtbl.8 d18, {d18, d19}, d16
+; CHECKBE-NEXT:    vtbl.8 d19, {d20, d21}, d16
 ; CHECKBE-NEXT:    vrev64.8 q0, q9
 ; CHECKBE-NEXT:    bx lr
 ; CHECKBE-NEXT:    .p2align 3
@@ -676,13 +680,13 @@ entry:
 define arm_aapcs_vfpcc <16 x i8> @vmovn8_t4(<16 x i8> %src1, <16 x i8> %src2) {
 ; CHECK-LABEL: vmovn8_t4:
 ; CHECK:       @ %bb.0: @ %entry
+; CHECK-NEXT:    vorr q3, q0, q0
 ; CHECK-NEXT:    @ kill: def $q1 killed $q1 def $d2_d3_d4
-; CHECK-NEXT:    vldr d18, .LCPI27_0
-; CHECK-NEXT:    vorr d4, d1, d1
-; CHECK-NEXT:    vtbl.8 d17, {d3, d4}, d18
-; CHECK-NEXT:    vorr d3, d0, d0
-; CHECK-NEXT:    vtbl.8 d16, {d2, d3}, d18
-; CHECK-NEXT:    vorr q0, q8, q8
+; CHECK-NEXT:    vldr d16, .LCPI27_0
+; CHECK-NEXT:    vorr d5, d2, d2
+; CHECK-NEXT:    vorr d4, d7, d7
+; CHECK-NEXT:    vtbl.8 d0, {d5, d6}, d16
+; CHECK-NEXT:    vtbl.8 d1, {d3, d4}, d16
 ; CHECK-NEXT:    bx lr
 ; CHECK-NEXT:    .p2align 3
 ; CHECK-NEXT:  @ %bb.1:
@@ -699,13 +703,13 @@ define arm_aapcs_vfpcc <16 x i8> @vmovn8_t4(<16 x i8> %src1, <16 x i8> %src2) {
 ; CHECKBE-LABEL: vmovn8_t4:
 ; CHECKBE:       @ %bb.0: @ %entry
 ; CHECKBE-NEXT:    vldr d16, .LCPI27_0
-; CHECKBE-NEXT:    vrev64.8 d19, d1
-; CHECKBE-NEXT:    vrev64.8 d21, d0
-; CHECKBE-NEXT:    vrev64.8 d18, d3
+; CHECKBE-NEXT:    vrev64.8 d19, d0
+; CHECKBE-NEXT:    vrev64.8 d21, d1
+; CHECKBE-NEXT:    vrev64.8 d18, d2
 ; CHECKBE-NEXT:    vrev64.8 d16, d16
-; CHECKBE-NEXT:    vrev64.8 d20, d2
-; CHECKBE-NEXT:    vtbl.8 d19, {d18, d19}, d16
-; CHECKBE-NEXT:    vtbl.8 d18, {d20, d21}, d16
+; CHECKBE-NEXT:    vrev64.8 d20, d3
+; CHECKBE-NEXT:    vtbl.8 d18, {d18, d19}, d16
+; CHECKBE-NEXT:    vtbl.8 d19, {d20, d21}, d16
 ; CHECKBE-NEXT:    vrev64.8 q0, q9
 ; CHECKBE-NEXT:    bx lr
 ; CHECKBE-NEXT:    .p2align 3

--- a/llvm/test/CodeGen/ARM/neon_vabd.ll
+++ b/llvm/test/CodeGen/ARM/neon_vabd.ll
@@ -144,11 +144,11 @@ define <2 x i64> @sabd_2d(<2 x i64> %a, <2 x i64> %b) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
-; CHECK-NEXT:    vmov r0, r1, d1
+; CHECK-NEXT:    vmov r0, r1, d0
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    vmov r2, r3, d3
-; CHECK-NEXT:    vmov r12, lr, d0
-; CHECK-NEXT:    vmov r4, r5, d2
+; CHECK-NEXT:    vmov r2, r3, d2
+; CHECK-NEXT:    vmov r12, lr, d1
+; CHECK-NEXT:    vmov r4, r5, d3
 ; CHECK-NEXT:    vsub.i64 q8, q0, q1
 ; CHECK-NEXT:    subs r0, r2, r0
 ; CHECK-NEXT:    sbcs r0, r3, r1
@@ -158,11 +158,11 @@ define <2 x i64> @sabd_2d(<2 x i64> %a, <2 x i64> %b) {
 ; CHECK-NEXT:    mvnne r0, #0
 ; CHECK-NEXT:    subs r1, r4, r12
 ; CHECK-NEXT:    sbcs r1, r5, lr
-; CHECK-NEXT:    vdup.32 d19, r0
+; CHECK-NEXT:    vdup.32 d18, r0
 ; CHECK-NEXT:    movwlt r6, #1
 ; CHECK-NEXT:    cmp r6, #0
 ; CHECK-NEXT:    mvnne r6, #0
-; CHECK-NEXT:    vdup.32 d18, r6
+; CHECK-NEXT:    vdup.32 d19, r6
 ; CHECK-NEXT:    veor q8, q8, q9
 ; CHECK-NEXT:    vsub.i64 q0, q9, q8
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}
@@ -475,11 +475,11 @@ define <2 x i64> @smaxmin_v2i64(<2 x i64> %0, <2 x i64> %1) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
-; CHECK-NEXT:    vmov r0, r1, d1
+; CHECK-NEXT:    vmov r0, r1, d0
 ; CHECK-NEXT:    mov r6, #0
-; CHECK-NEXT:    vmov r2, r3, d3
-; CHECK-NEXT:    vmov r12, lr, d0
-; CHECK-NEXT:    vmov r4, r5, d2
+; CHECK-NEXT:    vmov r2, r3, d2
+; CHECK-NEXT:    vmov r12, lr, d1
+; CHECK-NEXT:    vmov r4, r5, d3
 ; CHECK-NEXT:    vsub.i64 q8, q0, q1
 ; CHECK-NEXT:    subs r0, r2, r0
 ; CHECK-NEXT:    sbcs r0, r3, r1
@@ -489,11 +489,11 @@ define <2 x i64> @smaxmin_v2i64(<2 x i64> %0, <2 x i64> %1) {
 ; CHECK-NEXT:    mvnne r0, #0
 ; CHECK-NEXT:    subs r1, r4, r12
 ; CHECK-NEXT:    sbcs r1, r5, lr
-; CHECK-NEXT:    vdup.32 d19, r0
+; CHECK-NEXT:    vdup.32 d18, r0
 ; CHECK-NEXT:    movwlt r6, #1
 ; CHECK-NEXT:    cmp r6, #0
 ; CHECK-NEXT:    mvnne r6, #0
-; CHECK-NEXT:    vdup.32 d18, r6
+; CHECK-NEXT:    vdup.32 d19, r6
 ; CHECK-NEXT:    veor q8, q8, q9
 ; CHECK-NEXT:    vsub.i64 q0, q9, q8
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}

--- a/llvm/test/CodeGen/ARM/pr196779.ll
+++ b/llvm/test/CodeGen/ARM/pr196779.ll
@@ -11,40 +11,40 @@ define void @repro(ptr %out, ptr %base) {
 ; CHECK-NEXT:    bne .LBB0_3
 ; CHECK-NEXT:  @ %bb.1: @ %cond.load
 ; CHECK-NEXT:    vmov.i32 d16, #0x0
-; CHECK-NEXT:    vldr d17, [r0]
+; CHECK-NEXT:    vldr d18, [r0]
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    beq .LBB0_4
 ; CHECK-NEXT:  .LBB0_2:
-; CHECK-NEXT:    vorr d18, d16, d16
+; CHECK-NEXT:    vorr d20, d16, d16
 ; CHECK-NEXT:    b .LBB0_5
 ; CHECK-NEXT:  .LBB0_3:
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    vmov d17, r2, r2
-; CHECK-NEXT:    vorr d16, d17, d17
+; CHECK-NEXT:    vmov d18, r2, r2
+; CHECK-NEXT:    vorr d16, d18, d18
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    bne .LBB0_2
 ; CHECK-NEXT:  .LBB0_4: @ %cond.load1
 ; CHECK-NEXT:    ldm r0, {r0, r3}
-; CHECK-NEXT:    vmov d18, r0, r3
+; CHECK-NEXT:    vmov d20, r0, r3
 ; CHECK-NEXT:  .LBB0_5: @ %else2
 ; CHECK-NEXT:    mov r0, #1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    bne .LBB0_8
 ; CHECK-NEXT:  @ %bb.6: @ %cond.load4
 ; CHECK-NEXT:    ldrd r2, r3, [r1]
-; CHECK-NEXT:    vmov d19, r2, r3
+; CHECK-NEXT:    vmov d22, r2, r3
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    beq .LBB0_9
 ; CHECK-NEXT:  .LBB0_7:
-; CHECK-NEXT:    vorr d20, d16, d16
+; CHECK-NEXT:    vorr d21, d16, d16
 ; CHECK-NEXT:    b .LBB0_10
 ; CHECK-NEXT:  .LBB0_8:
-; CHECK-NEXT:    vorr d19, d16, d16
+; CHECK-NEXT:    vorr d22, d16, d16
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    bne .LBB0_7
 ; CHECK-NEXT:  .LBB0_9: @ %cond.load7
 ; CHECK-NEXT:    ldrd r0, r1, [r0]
-; CHECK-NEXT:    vmov d20, r0, r1
+; CHECK-NEXT:    vmov d21, r0, r1
 ; CHECK-NEXT:  .LBB0_10: @ %else8
 ; CHECK-NEXT:    mov r0, #1
 ; CHECK-NEXT:    cmp r0, #0
@@ -68,19 +68,19 @@ define void @repro(ptr %out, ptr %base) {
 ; CHECK-NEXT:    add sp, sp, #4
 ; CHECK-NEXT:    bx lr
 ; CHECK-NEXT:  .LBB0_16: @ %cond.store
-; CHECK-NEXT:    vst1.8 {d17}, [r0]
+; CHECK-NEXT:    vst1.8 {d18}, [r0]
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    bne .LBB0_12
 ; CHECK-NEXT:  .LBB0_17: @ %cond.store15
-; CHECK-NEXT:    vst1.8 {d18}, [r0]
+; CHECK-NEXT:    vst1.8 {d20}, [r0]
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    bne .LBB0_13
 ; CHECK-NEXT:  .LBB0_18: @ %cond.store17
-; CHECK-NEXT:    vst1.8 {d19}, [r0]
+; CHECK-NEXT:    vst1.8 {d22}, [r0]
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    bne .LBB0_14
 ; CHECK-NEXT:  .LBB0_19: @ %cond.store19
-; CHECK-NEXT:    vst1.8 {d20}, [r0]
+; CHECK-NEXT:    vst1.8 {d21}, [r0]
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    bne .LBB0_15
 ; CHECK-NEXT:  .LBB0_20: @ %cond.store21

--- a/llvm/test/CodeGen/ARM/srem-seteq-illegal-types.ll
+++ b/llvm/test/CodeGen/ARM/srem-seteq-illegal-types.ll
@@ -362,11 +362,10 @@ define <3 x i1> @test_srem_vec(<3 x i33> %X) nounwind {
 ; ARM7:       @ %bb.0:
 ; ARM7-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; ARM7-NEXT:    vpush {d8, d9}
-; ARM7-NEXT:    mov r6, r0
-; ARM7-NEXT:    and r0, r3, #1
-; ARM7-NEXT:    mov r5, r1
-; ARM7-NEXT:    rsb r1, r0, #0
-; ARM7-NEXT:    mov r0, r2
+; ARM7-NEXT:    and r1, r1, #1
+; ARM7-NEXT:    mov r5, r3
+; ARM7-NEXT:    rsb r1, r1, #0
+; ARM7-NEXT:    mov r6, r2
 ; ARM7-NEXT:    mov r2, #9
 ; ARM7-NEXT:    mov r3, #0
 ; ARM7-NEXT:    bl __moddi3
@@ -378,24 +377,24 @@ define <3 x i1> @test_srem_vec(<3 x i33> %X) nounwind {
 ; ARM7-NEXT:    mov r2, #9
 ; ARM7-NEXT:    mov r3, #0
 ; ARM7-NEXT:    bl __moddi3
-; ARM7-NEXT:    vmov.32 d8[0], r0
+; ARM7-NEXT:    vmov.32 d9[0], r0
 ; ARM7-NEXT:    ldr r0, [sp, #44]
 ; ARM7-NEXT:    ldr r2, [sp, #40]
 ; ARM7-NEXT:    mov r5, r1
 ; ARM7-NEXT:    and r0, r0, #1
 ; ARM7-NEXT:    mvn r3, #0
 ; ARM7-NEXT:    rsb r1, r0, #0
-; ARM7-NEXT:    vmov.32 d9[0], r7
+; ARM7-NEXT:    vmov.32 d8[0], r7
 ; ARM7-NEXT:    mov r0, r2
 ; ARM7-NEXT:    mvn r2, #8
 ; ARM7-NEXT:    bl __moddi3
 ; ARM7-NEXT:    vmov.32 d16[0], r0
 ; ARM7-NEXT:    adr r0, .LCPI3_0
-; ARM7-NEXT:    vmov.32 d9[1], r4
+; ARM7-NEXT:    vmov.32 d8[1], r4
 ; ARM7-NEXT:    vld1.64 {d18, d19}, [r0:128]
 ; ARM7-NEXT:    adr r0, .LCPI3_1
 ; ARM7-NEXT:    vmov.32 d16[1], r1
-; ARM7-NEXT:    vmov.32 d8[1], r5
+; ARM7-NEXT:    vmov.32 d9[1], r5
 ; ARM7-NEXT:    vand q8, q8, q9
 ; ARM7-NEXT:    vld1.64 {d20, d21}, [r0:128]
 ; ARM7-NEXT:    adr r0, .LCPI3_2
@@ -438,11 +437,10 @@ define <3 x i1> @test_srem_vec(<3 x i33> %X) nounwind {
 ; ARM8:       @ %bb.0:
 ; ARM8-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; ARM8-NEXT:    vpush {d8, d9}
-; ARM8-NEXT:    mov r6, r0
-; ARM8-NEXT:    and r0, r3, #1
-; ARM8-NEXT:    mov r5, r1
-; ARM8-NEXT:    rsb r1, r0, #0
-; ARM8-NEXT:    mov r0, r2
+; ARM8-NEXT:    and r1, r1, #1
+; ARM8-NEXT:    mov r5, r3
+; ARM8-NEXT:    rsb r1, r1, #0
+; ARM8-NEXT:    mov r6, r2
 ; ARM8-NEXT:    mov r2, #9
 ; ARM8-NEXT:    mov r3, #0
 ; ARM8-NEXT:    bl __moddi3
@@ -454,24 +452,24 @@ define <3 x i1> @test_srem_vec(<3 x i33> %X) nounwind {
 ; ARM8-NEXT:    mov r2, #9
 ; ARM8-NEXT:    mov r3, #0
 ; ARM8-NEXT:    bl __moddi3
-; ARM8-NEXT:    vmov.32 d8[0], r0
+; ARM8-NEXT:    vmov.32 d9[0], r0
 ; ARM8-NEXT:    ldr r0, [sp, #44]
 ; ARM8-NEXT:    ldr r2, [sp, #40]
 ; ARM8-NEXT:    mov r5, r1
 ; ARM8-NEXT:    and r0, r0, #1
 ; ARM8-NEXT:    mvn r3, #0
 ; ARM8-NEXT:    rsb r1, r0, #0
-; ARM8-NEXT:    vmov.32 d9[0], r7
+; ARM8-NEXT:    vmov.32 d8[0], r7
 ; ARM8-NEXT:    mov r0, r2
 ; ARM8-NEXT:    mvn r2, #8
 ; ARM8-NEXT:    bl __moddi3
 ; ARM8-NEXT:    vmov.32 d16[0], r0
 ; ARM8-NEXT:    adr r0, .LCPI3_0
-; ARM8-NEXT:    vmov.32 d9[1], r4
+; ARM8-NEXT:    vmov.32 d8[1], r4
 ; ARM8-NEXT:    vld1.64 {d18, d19}, [r0:128]
 ; ARM8-NEXT:    adr r0, .LCPI3_1
 ; ARM8-NEXT:    vmov.32 d16[1], r1
-; ARM8-NEXT:    vmov.32 d8[1], r5
+; ARM8-NEXT:    vmov.32 d9[1], r5
 ; ARM8-NEXT:    vand q8, q8, q9
 ; ARM8-NEXT:    vld1.64 {d20, d21}, [r0:128]
 ; ARM8-NEXT:    adr r0, .LCPI3_2
@@ -514,11 +512,10 @@ define <3 x i1> @test_srem_vec(<3 x i33> %X) nounwind {
 ; NEON7:       @ %bb.0:
 ; NEON7-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; NEON7-NEXT:    vpush {d8, d9}
-; NEON7-NEXT:    mov r6, r0
-; NEON7-NEXT:    and r0, r3, #1
-; NEON7-NEXT:    mov r5, r1
-; NEON7-NEXT:    rsb r1, r0, #0
-; NEON7-NEXT:    mov r0, r2
+; NEON7-NEXT:    and r1, r1, #1
+; NEON7-NEXT:    mov r5, r3
+; NEON7-NEXT:    rsb r1, r1, #0
+; NEON7-NEXT:    mov r6, r2
 ; NEON7-NEXT:    mov r2, #9
 ; NEON7-NEXT:    mov r3, #0
 ; NEON7-NEXT:    bl __moddi3
@@ -530,24 +527,24 @@ define <3 x i1> @test_srem_vec(<3 x i33> %X) nounwind {
 ; NEON7-NEXT:    mov r2, #9
 ; NEON7-NEXT:    mov r3, #0
 ; NEON7-NEXT:    bl __moddi3
-; NEON7-NEXT:    vmov.32 d8[0], r0
+; NEON7-NEXT:    vmov.32 d9[0], r0
 ; NEON7-NEXT:    ldr r0, [sp, #44]
 ; NEON7-NEXT:    ldr r2, [sp, #40]
 ; NEON7-NEXT:    mov r5, r1
 ; NEON7-NEXT:    and r0, r0, #1
 ; NEON7-NEXT:    mvn r3, #0
 ; NEON7-NEXT:    rsb r1, r0, #0
-; NEON7-NEXT:    vmov.32 d9[0], r7
+; NEON7-NEXT:    vmov.32 d8[0], r7
 ; NEON7-NEXT:    mov r0, r2
 ; NEON7-NEXT:    mvn r2, #8
 ; NEON7-NEXT:    bl __moddi3
 ; NEON7-NEXT:    vmov.32 d16[0], r0
 ; NEON7-NEXT:    adr r0, .LCPI3_0
-; NEON7-NEXT:    vmov.32 d9[1], r4
+; NEON7-NEXT:    vmov.32 d8[1], r4
 ; NEON7-NEXT:    vld1.64 {d18, d19}, [r0:128]
 ; NEON7-NEXT:    adr r0, .LCPI3_1
 ; NEON7-NEXT:    vmov.32 d16[1], r1
-; NEON7-NEXT:    vmov.32 d8[1], r5
+; NEON7-NEXT:    vmov.32 d9[1], r5
 ; NEON7-NEXT:    vand q8, q8, q9
 ; NEON7-NEXT:    vld1.64 {d20, d21}, [r0:128]
 ; NEON7-NEXT:    adr r0, .LCPI3_2
@@ -590,11 +587,10 @@ define <3 x i1> @test_srem_vec(<3 x i33> %X) nounwind {
 ; NEON8:       @ %bb.0:
 ; NEON8-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; NEON8-NEXT:    vpush {d8, d9}
-; NEON8-NEXT:    mov r6, r0
-; NEON8-NEXT:    and r0, r3, #1
-; NEON8-NEXT:    mov r5, r1
-; NEON8-NEXT:    rsb r1, r0, #0
-; NEON8-NEXT:    mov r0, r2
+; NEON8-NEXT:    and r1, r1, #1
+; NEON8-NEXT:    mov r5, r3
+; NEON8-NEXT:    rsb r1, r1, #0
+; NEON8-NEXT:    mov r6, r2
 ; NEON8-NEXT:    mov r2, #9
 ; NEON8-NEXT:    mov r3, #0
 ; NEON8-NEXT:    bl __moddi3
@@ -606,24 +602,24 @@ define <3 x i1> @test_srem_vec(<3 x i33> %X) nounwind {
 ; NEON8-NEXT:    mov r2, #9
 ; NEON8-NEXT:    mov r3, #0
 ; NEON8-NEXT:    bl __moddi3
-; NEON8-NEXT:    vmov.32 d8[0], r0
+; NEON8-NEXT:    vmov.32 d9[0], r0
 ; NEON8-NEXT:    ldr r0, [sp, #44]
 ; NEON8-NEXT:    ldr r2, [sp, #40]
 ; NEON8-NEXT:    mov r5, r1
 ; NEON8-NEXT:    and r0, r0, #1
 ; NEON8-NEXT:    mvn r3, #0
 ; NEON8-NEXT:    rsb r1, r0, #0
-; NEON8-NEXT:    vmov.32 d9[0], r7
+; NEON8-NEXT:    vmov.32 d8[0], r7
 ; NEON8-NEXT:    mov r0, r2
 ; NEON8-NEXT:    mvn r2, #8
 ; NEON8-NEXT:    bl __moddi3
 ; NEON8-NEXT:    vmov.32 d16[0], r0
 ; NEON8-NEXT:    adr r0, .LCPI3_0
-; NEON8-NEXT:    vmov.32 d9[1], r4
+; NEON8-NEXT:    vmov.32 d8[1], r4
 ; NEON8-NEXT:    vld1.64 {d18, d19}, [r0:128]
 ; NEON8-NEXT:    adr r0, .LCPI3_1
 ; NEON8-NEXT:    vmov.32 d16[1], r1
-; NEON8-NEXT:    vmov.32 d8[1], r5
+; NEON8-NEXT:    vmov.32 d9[1], r5
 ; NEON8-NEXT:    vand q8, q8, q9
 ; NEON8-NEXT:    vld1.64 {d20, d21}, [r0:128]
 ; NEON8-NEXT:    adr r0, .LCPI3_2

--- a/llvm/test/CodeGen/ARM/vcombine.ll
+++ b/llvm/test/CodeGen/ARM/vcombine.ll
@@ -5,18 +5,18 @@
 define <16 x i8> @vcombine8(ptr %A, ptr %B) nounwind {
 ; CHECK-LE-LABEL: vcombine8:
 ; CHECK-LE:       @ %bb.0:
-; CHECK-LE-NEXT:    vldr d16, [r1]
-; CHECK-LE-NEXT:    vldr d17, [r0]
-; CHECK-LE-NEXT:    vmov r2, r3, d16
-; CHECK-LE-NEXT:    vmov r0, r1, d17
+; CHECK-LE-NEXT:    vldr d18, [r1]
+; CHECK-LE-NEXT:    vldr d16, [r0]
+; CHECK-LE-NEXT:    vmov r2, r3, d18
+; CHECK-LE-NEXT:    vmov r0, r1, d16
 ; CHECK-LE-NEXT:    mov pc, lr
 ;
 ; CHECK-BE-LABEL: vcombine8:
 ; CHECK-BE:       @ %bb.0:
-; CHECK-BE-NEXT:    vldr d16, [r1]
-; CHECK-BE-NEXT:    vldr d17, [r0]
-; CHECK-BE-NEXT:    vrev64.8 d19, d16
-; CHECK-BE-NEXT:    vrev64.8 d18, d17
+; CHECK-BE-NEXT:    vldr d16, [r0]
+; CHECK-BE-NEXT:    vldr d17, [r1]
+; CHECK-BE-NEXT:    vrev64.8 d18, d16
+; CHECK-BE-NEXT:    vrev64.8 d19, d17
 ; CHECK-BE-NEXT:    vrev64.8 q8, q9
 ; CHECK-BE-NEXT:    vmov r1, r0, d16
 ; CHECK-BE-NEXT:    vmov r3, r2, d17
@@ -32,18 +32,18 @@ define <16 x i8> @vcombine8(ptr %A, ptr %B) nounwind {
 define <8 x i16> @vcombine16(ptr %A, ptr %B) nounwind {
 ; CHECK-LE-LABEL: vcombine16:
 ; CHECK-LE:       @ %bb.0:
-; CHECK-LE-NEXT:    vldr d16, [r1]
-; CHECK-LE-NEXT:    vldr d17, [r0]
-; CHECK-LE-NEXT:    vmov r2, r3, d16
-; CHECK-LE-NEXT:    vmov r0, r1, d17
+; CHECK-LE-NEXT:    vldr d18, [r1]
+; CHECK-LE-NEXT:    vldr d16, [r0]
+; CHECK-LE-NEXT:    vmov r2, r3, d18
+; CHECK-LE-NEXT:    vmov r0, r1, d16
 ; CHECK-LE-NEXT:    mov pc, lr
 ;
 ; CHECK-BE-LABEL: vcombine16:
 ; CHECK-BE:       @ %bb.0:
-; CHECK-BE-NEXT:    vldr d16, [r1]
-; CHECK-BE-NEXT:    vldr d17, [r0]
-; CHECK-BE-NEXT:    vrev64.16 d19, d16
-; CHECK-BE-NEXT:    vrev64.16 d18, d17
+; CHECK-BE-NEXT:    vldr d16, [r0]
+; CHECK-BE-NEXT:    vldr d17, [r1]
+; CHECK-BE-NEXT:    vrev64.16 d18, d16
+; CHECK-BE-NEXT:    vrev64.16 d19, d17
 ; CHECK-BE-NEXT:    vrev64.16 q8, q9
 ; CHECK-BE-NEXT:    vmov r1, r0, d16
 ; CHECK-BE-NEXT:    vmov r3, r2, d17
@@ -59,18 +59,18 @@ define <8 x i16> @vcombine16(ptr %A, ptr %B) nounwind {
 define <4 x i32> @vcombine32(ptr %A, ptr %B) nounwind {
 ; CHECK-LE-LABEL: vcombine32:
 ; CHECK-LE:       @ %bb.0:
-; CHECK-LE-NEXT:    vldr d16, [r1]
-; CHECK-LE-NEXT:    vldr d17, [r0]
-; CHECK-LE-NEXT:    vmov r2, r3, d16
-; CHECK-LE-NEXT:    vmov r0, r1, d17
+; CHECK-LE-NEXT:    vldr d18, [r1]
+; CHECK-LE-NEXT:    vldr d16, [r0]
+; CHECK-LE-NEXT:    vmov r2, r3, d18
+; CHECK-LE-NEXT:    vmov r0, r1, d16
 ; CHECK-LE-NEXT:    mov pc, lr
 ;
 ; CHECK-BE-LABEL: vcombine32:
 ; CHECK-BE:       @ %bb.0:
-; CHECK-BE-NEXT:    vldr d16, [r1]
-; CHECK-BE-NEXT:    vldr d17, [r0]
-; CHECK-BE-NEXT:    vrev64.32 d19, d16
-; CHECK-BE-NEXT:    vrev64.32 d18, d17
+; CHECK-BE-NEXT:    vldr d16, [r0]
+; CHECK-BE-NEXT:    vldr d17, [r1]
+; CHECK-BE-NEXT:    vrev64.32 d18, d16
+; CHECK-BE-NEXT:    vrev64.32 d19, d17
 ; CHECK-BE-NEXT:    vrev64.32 q8, q9
 ; CHECK-BE-NEXT:    vmov r1, r0, d16
 ; CHECK-BE-NEXT:    vmov r3, r2, d17
@@ -87,18 +87,18 @@ define <4 x i32> @vcombine32(ptr %A, ptr %B) nounwind {
 define <4 x float> @vcombinefloat(ptr %A, ptr %B) nounwind {
 ; CHECK-LE-LABEL: vcombinefloat:
 ; CHECK-LE:       @ %bb.0:
-; CHECK-LE-NEXT:    vldr d16, [r1]
-; CHECK-LE-NEXT:    vldr d17, [r0]
-; CHECK-LE-NEXT:    vmov r2, r3, d16
-; CHECK-LE-NEXT:    vmov r0, r1, d17
+; CHECK-LE-NEXT:    vldr d18, [r1]
+; CHECK-LE-NEXT:    vldr d16, [r0]
+; CHECK-LE-NEXT:    vmov r2, r3, d18
+; CHECK-LE-NEXT:    vmov r0, r1, d16
 ; CHECK-LE-NEXT:    mov pc, lr
 ;
 ; CHECK-BE-LABEL: vcombinefloat:
 ; CHECK-BE:       @ %bb.0:
-; CHECK-BE-NEXT:    vldr d16, [r1]
-; CHECK-BE-NEXT:    vldr d17, [r0]
-; CHECK-BE-NEXT:    vrev64.32 d19, d16
-; CHECK-BE-NEXT:    vrev64.32 d18, d17
+; CHECK-BE-NEXT:    vldr d16, [r0]
+; CHECK-BE-NEXT:    vldr d17, [r1]
+; CHECK-BE-NEXT:    vrev64.32 d18, d16
+; CHECK-BE-NEXT:    vrev64.32 d19, d17
 ; CHECK-BE-NEXT:    vrev64.32 q8, q9
 ; CHECK-BE-NEXT:    vmov r1, r0, d16
 ; CHECK-BE-NEXT:    vmov r3, r2, d17
@@ -115,18 +115,18 @@ define <4 x float> @vcombinefloat(ptr %A, ptr %B) nounwind {
 define <2 x i64> @vcombine64(ptr %A, ptr %B) nounwind {
 ; CHECK-LE-LABEL: vcombine64:
 ; CHECK-LE:       @ %bb.0:
-; CHECK-LE-NEXT:    vldr d16, [r1]
-; CHECK-LE-NEXT:    vldr d17, [r0]
-; CHECK-LE-NEXT:    vmov r2, r3, d16
-; CHECK-LE-NEXT:    vmov r0, r1, d17
+; CHECK-LE-NEXT:    vldr d18, [r1]
+; CHECK-LE-NEXT:    vldr d16, [r0]
+; CHECK-LE-NEXT:    vmov r2, r3, d18
+; CHECK-LE-NEXT:    vmov r0, r1, d16
 ; CHECK-LE-NEXT:    mov pc, lr
 ;
 ; CHECK-BE-LABEL: vcombine64:
 ; CHECK-BE:       @ %bb.0:
-; CHECK-BE-NEXT:    vldr d16, [r1]
-; CHECK-BE-NEXT:    vldr d17, [r0]
-; CHECK-BE-NEXT:    vmov r3, r2, d16
-; CHECK-BE-NEXT:    vmov r1, r0, d17
+; CHECK-BE-NEXT:    vldr d18, [r1]
+; CHECK-BE-NEXT:    vldr d16, [r0]
+; CHECK-BE-NEXT:    vmov r3, r2, d18
+; CHECK-BE-NEXT:    vmov r1, r0, d16
 ; CHECK-BE-NEXT:    mov pc, lr
 
 
@@ -179,9 +179,9 @@ define <8 x i16> @vcombine_vdup(<8 x i16> %src, ptr nocapture readonly %p) {
 ; CHECK-LE:       @ %bb.0:
 ; CHECK-LE-NEXT:    ldr r0, [sp]
 ; CHECK-LE-NEXT:    vld1.16 {d16[]}, [r0:16]!
-; CHECK-LE-NEXT:    vld1.16 {d17[]}, [r0:16]
+; CHECK-LE-NEXT:    vld1.16 {d18[]}, [r0:16]
 ; CHECK-LE-NEXT:    vmov r0, r1, d16
-; CHECK-LE-NEXT:    vmov r2, r3, d17
+; CHECK-LE-NEXT:    vmov r2, r3, d18
 ; CHECK-LE-NEXT:    mov pc, lr
 ;
 ; CHECK-BE-LABEL: vcombine_vdup:
@@ -202,6 +202,45 @@ define <8 x i16> @vcombine_vdup(<8 x i16> %src, ptr nocapture readonly %p) {
   %b3 = shufflevector <4 x i16> %b2, <4 x i16> undef, <4 x i32> zeroinitializer
   %shuffle = shufflevector <4 x i16> %a3, <4 x i16> %b3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x i16> %shuffle
+}
+
+define void @pr200378(i64 %conv2.i, ptr %call.i4) {
+; CHECK-LE-LABEL: pr200378:
+; CHECK-LE:       @ %bb.0: @ %entry
+; CHECK-LE-NEXT:    vmov.32 d17[0], r0
+; CHECK-LE-NEXT:    mov r0, #1
+; CHECK-LE-NEXT:    vmov.32 d17[1], r1
+; CHECK-LE-NEXT:    vmov.32 d16[0], r0
+; CHECK-LE-NEXT:    mov r0, #0
+; CHECK-LE-NEXT:    vmov.32 d16[1], r0
+; CHECK-LE-NEXT:  .LBB8_1: @ %for.body
+; CHECK-LE-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-LE-NEXT:    vst1.64 {d16, d17}, [r2]
+; CHECK-LE-NEXT:    b .LBB8_1
+;
+; CHECK-BE-LABEL: pr200378:
+; CHECK-BE:       @ %bb.0: @ %entry
+; CHECK-BE-NEXT:    vmov.32 d17[0], r0
+; CHECK-BE-NEXT:    mov r0, #0
+; CHECK-BE-NEXT:    vmov.32 d17[1], r1
+; CHECK-BE-NEXT:    vrev64.32 q8, q8
+; CHECK-BE-NEXT:    vrev64.32 q8, q8
+; CHECK-BE-NEXT:    vmov.32 d16[0], r0
+; CHECK-BE-NEXT:    mov r0, #1
+; CHECK-BE-NEXT:    vmov.32 d16[1], r0
+; CHECK-BE-NEXT:    vrev64.32 q8, q8
+; CHECK-BE-NEXT:  .LBB8_1: @ %for.body
+; CHECK-BE-NEXT:    @ =>This Inner Loop Header: Depth=1
+; CHECK-BE-NEXT:    vst1.64 {d16, d17}, [r2]
+; CHECK-BE-NEXT:    b .LBB8_1
+entry:
+  %0 = insertelement <2 x i64> poison, i64 %conv2.i, i64 1
+  br label %for.body
+
+for.body:                                         ; preds = %for.body, %entry
+  %1 = insertelement <2 x i64> %0, i64 1, i64 0
+  store <2 x i64> %1, ptr %call.i4, align 8
+  br label %for.body
 }
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
 ; CHECK: {{.*}}

--- a/llvm/test/CodeGen/ARM/vector-llrint.ll
+++ b/llvm/test/CodeGen/ARM/vector-llrint.ll
@@ -44,8 +44,8 @@ define <2 x i64> @llrint_v1i64_v2f16(<2 x half> %x) {
 ; LE-NEXT:    push {r4, r5, r11, lr}
 ; LE-NEXT:    .vsave {d8, d9}
 ; LE-NEXT:    vpush {d8, d9}
-; LE-NEXT:    vmov r0, s1
-; LE-NEXT:    vmov.f32 s16, s0
+; LE-NEXT:    vmov r0, s0
+; LE-NEXT:    vmov.f32 s16, s1
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
 ; LE-NEXT:    bl llrintf
@@ -54,11 +54,11 @@ define <2 x i64> @llrint_v1i64_v2f16(<2 x half> %x) {
 ; LE-NEXT:    mov r5, r1
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
-; LE-NEXT:    vmov.32 d9[0], r4
+; LE-NEXT:    vmov.32 d8[0], r4
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d8[0], r0
-; LE-NEXT:    vmov.32 d9[1], r5
-; LE-NEXT:    vmov.32 d8[1], r1
+; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    vmov.32 d8[1], r5
+; LE-NEXT:    vmov.32 d9[1], r1
 ; LE-NEXT:    vorr q0, q4, q4
 ; LE-NEXT:    vpop {d8, d9}
 ; LE-NEXT:    pop {r4, r5, r11, pc}
@@ -69,8 +69,8 @@ define <2 x i64> @llrint_v1i64_v2f16(<2 x half> %x) {
 ; BE-NEXT:    push {r4, r5, r11, lr}
 ; BE-NEXT:    .vsave {d8}
 ; BE-NEXT:    vpush {d8}
-; BE-NEXT:    vmov r0, s1
-; BE-NEXT:    vmov.f32 s16, s0
+; BE-NEXT:    vmov r0, s0
+; BE-NEXT:    vmov.f32 s16, s1
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    vmov s0, r0
 ; BE-NEXT:    bl llrintf
@@ -84,8 +84,8 @@ define <2 x i64> @llrint_v1i64_v2f16(<2 x half> %x) {
 ; BE-NEXT:    vmov.32 d16[0], r0
 ; BE-NEXT:    vmov.32 d8[1], r5
 ; BE-NEXT:    vmov.32 d16[1], r1
-; BE-NEXT:    vrev64.32 d1, d8
-; BE-NEXT:    vrev64.32 d0, d16
+; BE-NEXT:    vrev64.32 d0, d8
+; BE-NEXT:    vrev64.32 d1, d16
 ; BE-NEXT:    vpop {d8}
 ; BE-NEXT:    pop {r4, r5, r11, pc}
   %a = call <2 x i64> @llvm.llrint.v2i64.v2f16(<2 x half> %x)
@@ -98,46 +98,43 @@ define <4 x i64> @llrint_v4i64_v4f16(<4 x half> %x) {
 ; LE:       @ %bb.0:
 ; LE-NEXT:    .save {r4, r5, r6, r7, r11, lr}
 ; LE-NEXT:    push {r4, r5, r6, r7, r11, lr}
-; LE-NEXT:    .vsave {d12, d13}
-; LE-NEXT:    vpush {d12, d13}
-; LE-NEXT:    .vsave {d8, d9, d10}
-; LE-NEXT:    vpush {d8, d9, d10}
-; LE-NEXT:    vmov r0, s1
+; LE-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
+; LE-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
+; LE-NEXT:    vmov r0, s0
 ; LE-NEXT:    vmov.f32 s16, s3
-; LE-NEXT:    vmov.f32 s20, s2
-; LE-NEXT:    vmov.f32 s18, s0
+; LE-NEXT:    vmov.f32 s18, s2
+; LE-NEXT:    vmov.f32 s20, s1
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    mov r5, r0
-; LE-NEXT:    vmov r0, s18
+; LE-NEXT:    vmov r0, s20
 ; LE-NEXT:    mov r4, r1
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    mov r7, r0
-; LE-NEXT:    vmov r0, s16
+; LE-NEXT:    vmov r0, s18
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov s0, r7
 ; LE-NEXT:    mov r6, r1
-; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    vmov.32 d10[0], r0
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d12[0], r0
-; LE-NEXT:    vmov r0, s20
+; LE-NEXT:    vmov.32 d13[0], r0
+; LE-NEXT:    vmov r0, s16
 ; LE-NEXT:    mov r7, r1
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
-; LE-NEXT:    vmov.32 d13[0], r5
+; LE-NEXT:    vmov.32 d12[0], r5
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d8[0], r0
-; LE-NEXT:    vmov.32 d13[1], r4
-; LE-NEXT:    vmov.32 d9[1], r6
-; LE-NEXT:    vmov.32 d12[1], r7
-; LE-NEXT:    vmov.32 d8[1], r1
+; LE-NEXT:    vmov.32 d11[0], r0
+; LE-NEXT:    vmov.32 d12[1], r4
+; LE-NEXT:    vmov.32 d10[1], r6
+; LE-NEXT:    vmov.32 d13[1], r7
+; LE-NEXT:    vmov.32 d11[1], r1
 ; LE-NEXT:    vorr q0, q6, q6
-; LE-NEXT:    vorr q1, q4, q4
-; LE-NEXT:    vpop {d8, d9, d10}
-; LE-NEXT:    vpop {d12, d13}
+; LE-NEXT:    vorr q1, q5, q5
+; LE-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; LE-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; BE-LABEL: llrint_v4i64_v4f16:
@@ -146,10 +143,10 @@ define <4 x i64> @llrint_v4i64_v4f16(<4 x half> %x) {
 ; BE-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; BE-NEXT:    .vsave {d8, d9, d10}
 ; BE-NEXT:    vpush {d8, d9, d10}
-; BE-NEXT:    vmov r0, s1
+; BE-NEXT:    vmov r0, s0
 ; BE-NEXT:    vmov.f32 s16, s3
 ; BE-NEXT:    vmov.f32 s18, s2
-; BE-NEXT:    vmov.f32 s20, s0
+; BE-NEXT:    vmov.f32 s20, s1
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    vmov s0, r0
 ; BE-NEXT:    bl llrintf
@@ -158,30 +155,30 @@ define <4 x i64> @llrint_v4i64_v4f16(<4 x half> %x) {
 ; BE-NEXT:    mov r4, r1
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    mov r7, r0
-; BE-NEXT:    vmov r0, s16
+; BE-NEXT:    vmov r0, s18
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    vmov s0, r0
 ; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov s0, r7
 ; BE-NEXT:    mov r6, r1
-; BE-NEXT:    vmov.32 d8[0], r0
+; BE-NEXT:    vmov.32 d9[0], r0
 ; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.32 d10[0], r0
-; BE-NEXT:    vmov r0, s18
+; BE-NEXT:    vmov r0, s16
 ; BE-NEXT:    mov r7, r1
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    vmov s0, r0
-; BE-NEXT:    vmov.32 d9[0], r5
+; BE-NEXT:    vmov.32 d8[0], r5
 ; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.32 d16[0], r0
-; BE-NEXT:    vmov.32 d9[1], r4
-; BE-NEXT:    vmov.32 d8[1], r6
+; BE-NEXT:    vmov.32 d8[1], r4
+; BE-NEXT:    vmov.32 d9[1], r6
 ; BE-NEXT:    vmov.32 d10[1], r7
 ; BE-NEXT:    vmov.32 d16[1], r1
-; BE-NEXT:    vrev64.32 d1, d9
-; BE-NEXT:    vrev64.32 d3, d8
-; BE-NEXT:    vrev64.32 d0, d10
-; BE-NEXT:    vrev64.32 d2, d16
+; BE-NEXT:    vrev64.32 d0, d8
+; BE-NEXT:    vrev64.32 d2, d9
+; BE-NEXT:    vrev64.32 d1, d10
+; BE-NEXT:    vrev64.32 d3, d16
 ; BE-NEXT:    vpop {d8, d9, d10}
 ; BE-NEXT:    pop {r4, r5, r6, r7, r11, pc}
   %a = call <4 x i64> @llvm.llrint.v4i64.v4f16(<4 x half> %x)
@@ -200,78 +197,78 @@ define <8 x i64> @llrint_v8i64_v8f16(<8 x half> %x) {
 ; LE-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-NEXT:    .pad #8
 ; LE-NEXT:    sub sp, sp, #8
-; LE-NEXT:    vmov r0, s1
-; LE-NEXT:    vstr s6, [sp, #4] @ 4-byte Spill
-; LE-NEXT:    vmov.f32 s16, s7
-; LE-NEXT:    vmov.f32 s18, s5
-; LE-NEXT:    vmov.f32 s20, s4
-; LE-NEXT:    vmov.f32 s22, s3
-; LE-NEXT:    vmov.f32 s24, s2
-; LE-NEXT:    vmov.f32 s26, s0
+; LE-NEXT:    vmov r0, s0
+; LE-NEXT:    vstr s7, [sp, #4] @ 4-byte Spill
+; LE-NEXT:    vmov.f32 s18, s6
+; LE-NEXT:    vmov.f32 s20, s5
+; LE-NEXT:    vmov.f32 s22, s4
+; LE-NEXT:    vmov.f32 s24, s3
+; LE-NEXT:    vmov.f32 s26, s2
+; LE-NEXT:    vmov.f32 s28, s1
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    mov r9, r0
-; LE-NEXT:    vmov r0, s26
+; LE-NEXT:    vmov r0, s28
 ; LE-NEXT:    str r1, [sp] @ 4-byte Spill
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    mov r10, r0
-; LE-NEXT:    vmov r0, s22
+; LE-NEXT:    vmov r0, s26
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    mov r5, r0
 ; LE-NEXT:    vmov r0, s24
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    mov r7, r0
-; LE-NEXT:    vmov r0, s18
+; LE-NEXT:    vmov r0, s22
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    mov r6, r0
 ; LE-NEXT:    vmov r0, s20
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    mov r4, r0
-; LE-NEXT:    vmov r0, s16
+; LE-NEXT:    vmov r0, s18
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov s0, r4
 ; LE-NEXT:    mov r11, r1
-; LE-NEXT:    vmov.32 d11[0], r0
+; LE-NEXT:    vmov.32 d10[0], r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov s0, r6
 ; LE-NEXT:    mov r8, r1
-; LE-NEXT:    vmov.32 d12[0], r0
+; LE-NEXT:    vmov.32 d13[0], r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov s0, r7
 ; LE-NEXT:    mov r6, r1
-; LE-NEXT:    vmov.32 d13[0], r0
+; LE-NEXT:    vmov.32 d12[0], r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov s0, r5
 ; LE-NEXT:    mov r7, r1
-; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    vmov.32 d15[0], r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov s0, r10
 ; LE-NEXT:    mov r5, r1
-; LE-NEXT:    vmov.32 d15[0], r0
+; LE-NEXT:    vmov.32 d14[0], r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vldr s0, [sp, #4] @ 4-byte Reload
 ; LE-NEXT:    mov r4, r1
-; LE-NEXT:    vmov.32 d8[0], r0
+; LE-NEXT:    vmov.32 d9[0], r0
 ; LE-NEXT:    vmov r0, s0
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
-; LE-NEXT:    vmov.32 d9[0], r9
+; LE-NEXT:    vmov.32 d8[0], r9
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d10[0], r0
+; LE-NEXT:    vmov.32 d11[0], r0
 ; LE-NEXT:    ldr r0, [sp] @ 4-byte Reload
-; LE-NEXT:    vmov.32 d15[1], r5
-; LE-NEXT:    vmov.32 d9[1], r0
-; LE-NEXT:    vmov.32 d13[1], r6
-; LE-NEXT:    vmov.32 d11[1], r11
-; LE-NEXT:    vmov.32 d8[1], r4
-; LE-NEXT:    vmov.32 d14[1], r7
+; LE-NEXT:    vmov.32 d14[1], r5
+; LE-NEXT:    vmov.32 d8[1], r0
+; LE-NEXT:    vmov.32 d12[1], r6
+; LE-NEXT:    vmov.32 d10[1], r11
+; LE-NEXT:    vmov.32 d9[1], r4
+; LE-NEXT:    vmov.32 d15[1], r7
 ; LE-NEXT:    vorr q0, q4, q4
-; LE-NEXT:    vmov.32 d12[1], r8
+; LE-NEXT:    vmov.32 d13[1], r8
 ; LE-NEXT:    vorr q1, q7, q7
-; LE-NEXT:    vmov.32 d10[1], r1
+; LE-NEXT:    vmov.32 d11[1], r1
 ; LE-NEXT:    vorr q2, q6, q6
 ; LE-NEXT:    vorr q3, q5, q5
 ; LE-NEXT:    add sp, sp, #8
@@ -289,14 +286,14 @@ define <8 x i64> @llrint_v8i64_v8f16(<8 x half> %x) {
 ; BE-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
 ; BE-NEXT:    .pad #8
 ; BE-NEXT:    sub sp, sp, #8
-; BE-NEXT:    vmov r0, s1
-; BE-NEXT:    vmov.f32 s18, s7
-; BE-NEXT:    vmov.f32 s16, s6
+; BE-NEXT:    vmov r0, s0
+; BE-NEXT:    vmov.f32 s16, s7
+; BE-NEXT:    vmov.f32 s18, s6
 ; BE-NEXT:    vmov.f32 s20, s5
 ; BE-NEXT:    vmov.f32 s22, s4
 ; BE-NEXT:    vmov.f32 s24, s3
 ; BE-NEXT:    vmov.f32 s26, s2
-; BE-NEXT:    vmov.f32 s28, s0
+; BE-NEXT:    vmov.f32 s28, s1
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    vmov s0, r0
 ; BE-NEXT:    bl llrintf
@@ -305,16 +302,16 @@ define <8 x i64> @llrint_v8i64_v8f16(<8 x half> %x) {
 ; BE-NEXT:    str r1, [sp, #4] @ 4-byte Spill
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    mov r10, r0
-; BE-NEXT:    vmov r0, s24
-; BE-NEXT:    bl __aeabi_h2f
-; BE-NEXT:    mov r5, r0
 ; BE-NEXT:    vmov r0, s26
 ; BE-NEXT:    bl __aeabi_h2f
+; BE-NEXT:    mov r5, r0
+; BE-NEXT:    vmov r0, s24
+; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    mov r7, r0
-; BE-NEXT:    vmov r0, s20
+; BE-NEXT:    vmov r0, s22
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    mov r6, r0
-; BE-NEXT:    vmov r0, s22
+; BE-NEXT:    vmov r0, s20
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    mov r4, r0
 ; BE-NEXT:    vmov r0, s18
@@ -358,14 +355,14 @@ define <8 x i64> @llrint_v8i64_v8f16(<8 x half> %x) {
 ; BE-NEXT:    vmov.32 d12[1], r7
 ; BE-NEXT:    vmov.32 d10[1], r8
 ; BE-NEXT:    vmov.32 d16[1], r1
-; BE-NEXT:    vrev64.32 d1, d8
-; BE-NEXT:    vrev64.32 d3, d13
-; BE-NEXT:    vrev64.32 d5, d11
-; BE-NEXT:    vrev64.32 d7, d9
-; BE-NEXT:    vrev64.32 d0, d14
-; BE-NEXT:    vrev64.32 d2, d12
-; BE-NEXT:    vrev64.32 d4, d10
-; BE-NEXT:    vrev64.32 d6, d16
+; BE-NEXT:    vrev64.32 d0, d8
+; BE-NEXT:    vrev64.32 d2, d13
+; BE-NEXT:    vrev64.32 d4, d11
+; BE-NEXT:    vrev64.32 d6, d9
+; BE-NEXT:    vrev64.32 d1, d14
+; BE-NEXT:    vrev64.32 d3, d12
+; BE-NEXT:    vrev64.32 d5, d10
+; BE-NEXT:    vrev64.32 d7, d16
 ; BE-NEXT:    add sp, sp, #8
 ; BE-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
 ; BE-NEXT:    add sp, sp, #4
@@ -384,112 +381,115 @@ define <16 x i64> @llrint_v16i64_v16f16(<16 x half> %x) {
 ; LE-NEXT:    sub sp, sp, #4
 ; LE-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; LE-NEXT:    .pad #120
-; LE-NEXT:    sub sp, sp, #120
+; LE-NEXT:    .pad #136
+; LE-NEXT:    sub sp, sp, #136
 ; LE-NEXT:    mov r11, r0
-; LE-NEXT:    vmov r0, s7
-; LE-NEXT:    vstr s15, [sp, #24] @ 4-byte Spill
+; LE-NEXT:    vmov r0, s6
+; LE-NEXT:    vstr s15, [sp, #112] @ 4-byte Spill
 ; LE-NEXT:    vmov.f32 s23, s13
-; LE-NEXT:    vstr s14, [sp, #100] @ 4-byte Spill
-; LE-NEXT:    vmov.f32 s25, s12
-; LE-NEXT:    vmov.f32 s27, s11
-; LE-NEXT:    vstr s10, [sp, #104] @ 4-byte Spill
-; LE-NEXT:    vstr s9, [sp, #108] @ 4-byte Spill
-; LE-NEXT:    vmov.f32 s24, s8
-; LE-NEXT:    vmov.f32 s19, s6
-; LE-NEXT:    vmov.f32 s29, s5
-; LE-NEXT:    vmov.f32 s17, s4
-; LE-NEXT:    vmov.f32 s16, s3
-; LE-NEXT:    vmov.f32 s21, s2
-; LE-NEXT:    vmov.f32 s26, s1
-; LE-NEXT:    vmov.f32 s18, s0
+; LE-NEXT:    vstr s14, [sp, #40] @ 4-byte Spill
+; LE-NEXT:    vmov.f32 s25, s11
+; LE-NEXT:    vstr s12, [sp, #100] @ 4-byte Spill
+; LE-NEXT:    vmov.f32 s27, s10
+; LE-NEXT:    vstr s9, [sp, #104] @ 4-byte Spill
+; LE-NEXT:    vmov.f32 s19, s7
+; LE-NEXT:    vstr s8, [sp, #120] @ 4-byte Spill
+; LE-NEXT:    vmov.f32 s17, s5
+; LE-NEXT:    vmov.f32 s29, s4
+; LE-NEXT:    vmov.f32 s21, s3
+; LE-NEXT:    vmov.f32 s16, s2
+; LE-NEXT:    vmov.f32 s18, s1
+; LE-NEXT:    vmov.f32 s26, s0
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    mov r7, r0
-; LE-NEXT:    vmov r0, s25
-; LE-NEXT:    str r1, [sp, #56] @ 4-byte Spill
+; LE-NEXT:    vmov r0, s27
+; LE-NEXT:    str r1, [sp, #80] @ 4-byte Spill
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    mov r5, r0
-; LE-NEXT:    vmov r0, s27
+; LE-NEXT:    vmov r0, s25
 ; LE-NEXT:    str r1, [sp, #116] @ 4-byte Spill
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    mov r6, r0
 ; LE-NEXT:    vmov r0, s29
-; LE-NEXT:    str r1, [sp, #112] @ 4-byte Spill
+; LE-NEXT:    str r1, [sp, #108] @ 4-byte Spill
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d15[0], r0
+; LE-NEXT:    vmov.32 d14[0], r0
 ; LE-NEXT:    vmov r0, s23
 ; LE-NEXT:    mov r4, r1
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
-; LE-NEXT:    add lr, sp, #80
-; LE-NEXT:    vmov.32 d17[0], r6
-; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
+; LE-NEXT:    vmov.32 d12[0], r6
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    mov r6, r0
 ; LE-NEXT:    vmov r0, s17
-; LE-NEXT:    vmov r8, s21
+; LE-NEXT:    vmov.32 d11[0], r5
+; LE-NEXT:    add lr, sp, #56
 ; LE-NEXT:    str r1, [sp, #76] @ 4-byte Spill
+; LE-NEXT:    vmov r8, s21
 ; LE-NEXT:    vmov r10, s19
-; LE-NEXT:    vmov.32 d10[0], r5
+; LE-NEXT:    vstmia lr, {d11, d12} @ 16-byte Spill
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
-; LE-NEXT:    add lr, sp, #40
-; LE-NEXT:    vmov.32 d11[0], r6
-; LE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; LE-NEXT:    add lr, sp, #24
+; LE-NEXT:    vmov.32 d17[0], r6
+; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    vmov.32 d15[0], r0
 ; LE-NEXT:    mov r0, r10
 ; LE-NEXT:    mov r9, r1
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
-; LE-NEXT:    vmov.32 d11[0], r7
+; LE-NEXT:    vmov.32 d10[0], r7
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d10[0], r0
+; LE-NEXT:    vmov.32 d11[0], r0
 ; LE-NEXT:    mov r0, r8
 ; LE-NEXT:    mov r7, r1
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    mov r6, r0
-; LE-NEXT:    ldr r0, [sp, #56] @ 4-byte Reload
-; LE-NEXT:    vmov.32 d11[1], r0
+; LE-NEXT:    ldr r0, [sp, #80] @ 4-byte Reload
+; LE-NEXT:    vmov.32 d10[1], r0
 ; LE-NEXT:    vmov r0, s18
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    mov r5, r0
 ; LE-NEXT:    vmov r0, s16
-; LE-NEXT:    vmov.32 d10[1], r7
-; LE-NEXT:    add lr, sp, #56
+; LE-NEXT:    add lr, sp, #80
+; LE-NEXT:    vmov.32 d11[1], r7
 ; LE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov s0, r0
-; LE-NEXT:    vmov.32 d15[1], r4
+; LE-NEXT:    vmov.32 d14[1], r4
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    vmov.32 d16[0], r0
 ; LE-NEXT:    vmov r0, s26
-; LE-NEXT:    add lr, sp, #24
-; LE-NEXT:    vmov r8, s24
-; LE-NEXT:    vmov.32 d14[1], r9
+; LE-NEXT:    add lr, sp, #120
 ; LE-NEXT:    mov r10, r1
+; LE-NEXT:    vldr s0, [sp, #120] @ 4-byte Reload
 ; LE-NEXT:    vmov s24, r5
-; LE-NEXT:    vldr s0, [sp, #24] @ 4-byte Reload
-; LE-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
+; LE-NEXT:    add lr, sp, #40
+; LE-NEXT:    vmov r8, s0
+; LE-NEXT:    vldr s0, [sp, #40] @ 4-byte Reload
+; LE-NEXT:    vmov.32 d15[1], r9
 ; LE-NEXT:    vmov r7, s0
+; LE-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov.f32 s0, s24
 ; LE-NEXT:    vmov s22, r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov.f32 s0, s22
 ; LE-NEXT:    mov r5, r1
-; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    vmov.32 d9[0], r0
 ; LE-NEXT:    vmov s24, r6
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d15[0], r0
+; LE-NEXT:    vmov.32 d8[0], r0
 ; LE-NEXT:    mov r0, r7
 ; LE-NEXT:    mov r6, r1
 ; LE-NEXT:    bl __aeabi_h2f
@@ -497,37 +497,42 @@ define <16 x i64> @llrint_v16i64_v16f16(<16 x half> %x) {
 ; LE-NEXT:    vmov s22, r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov.f32 s0, s22
-; LE-NEXT:    vmov.32 d8[0], r0
-; LE-NEXT:    add lr, sp, #8
+; LE-NEXT:    add lr, sp, #120
 ; LE-NEXT:    mov r9, r1
-; LE-NEXT:    vmov.32 d15[1], r6
-; LE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; LE-NEXT:    vmov.32 d8[1], r6
+; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-NEXT:    vmov.32 d17[0], r0
+; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d13[0], r0
+; LE-NEXT:    vmov.32 d12[0], r0
 ; LE-NEXT:    mov r0, r8
 ; LE-NEXT:    mov r6, r1
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vldr s0, [sp, #100] @ 4-byte Reload
 ; LE-NEXT:    mov r7, r0
-; LE-NEXT:    vmov.32 d14[1], r5
+; LE-NEXT:    add lr, sp, #8
+; LE-NEXT:    vmov.32 d9[1], r5
 ; LE-NEXT:    vmov r0, s0
+; LE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vldr s0, [sp, #104] @ 4-byte Reload
 ; LE-NEXT:    vmov s20, r0
-; LE-NEXT:    vmov.32 d13[1], r6
+; LE-NEXT:    vmov.32 d12[1], r6
 ; LE-NEXT:    vmov r4, s0
-; LE-NEXT:    vldr s0, [sp, #108] @ 4-byte Reload
+; LE-NEXT:    vldr s0, [sp, #112] @ 4-byte Reload
 ; LE-NEXT:    vmov r0, s0
 ; LE-NEXT:    bl __aeabi_h2f
 ; LE-NEXT:    vmov.f32 s0, s20
 ; LE-NEXT:    vmov s16, r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov.f32 s0, s16
+; LE-NEXT:    add lr, sp, #24
 ; LE-NEXT:    mov r5, r1
-; LE-NEXT:    vmov.32 d12[0], r0
 ; LE-NEXT:    vmov s18, r7
+; LE-NEXT:    vldmia lr, {d14, d15} @ 16-byte Reload
+; LE-NEXT:    vmov.32 d14[0], r0
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d11[0], r0
+; LE-NEXT:    vmov.32 d13[0], r0
 ; LE-NEXT:    mov r0, r4
 ; LE-NEXT:    mov r6, r1
 ; LE-NEXT:    bl __aeabi_h2f
@@ -535,42 +540,42 @@ define <16 x i64> @llrint_v16i64_v16f16(<16 x half> %x) {
 ; LE-NEXT:    vmov s16, r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov.f32 s0, s16
-; LE-NEXT:    vmov.32 d10[0], r0
 ; LE-NEXT:    mov r4, r1
-; LE-NEXT:    vmov.32 d11[1], r6
+; LE-NEXT:    vmov.32 d10[0], r0
+; LE-NEXT:    vmov.32 d13[1], r6
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    add lr, sp, #80
-; LE-NEXT:    vmov.32 d10[1], r4
-; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-NEXT:    add lr, sp, #40
-; LE-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
-; LE-NEXT:    add lr, sp, #8
-; LE-NEXT:    vmov.32 d16[0], r0
+; LE-NEXT:    vmov.32 d11[0], r0
 ; LE-NEXT:    ldr r0, [sp, #76] @ 4-byte Reload
-; LE-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
-; LE-NEXT:    add lr, sp, #24
-; LE-NEXT:    vmov.32 d19[1], r0
+; LE-NEXT:    add lr, sp, #56
+; LE-NEXT:    vmov.32 d14[1], r5
+; LE-NEXT:    vmov.32 d15[1], r0
 ; LE-NEXT:    ldr r0, [sp, #116] @ 4-byte Reload
-; LE-NEXT:    vmov.32 d21[1], r10
-; LE-NEXT:    vmov.32 d18[1], r0
-; LE-NEXT:    ldr r0, [sp, #112] @ 4-byte Reload
-; LE-NEXT:    vmov.32 d12[1], r5
+; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-NEXT:    add lr, sp, #120
+; LE-NEXT:    vmov.32 d10[1], r4
+; LE-NEXT:    vmov.32 d16[1], r0
+; LE-NEXT:    ldr r0, [sp, #108] @ 4-byte Reload
+; LE-NEXT:    vmov.32 d11[1], r1
 ; LE-NEXT:    vmov.32 d17[1], r0
 ; LE-NEXT:    add r0, r11, #64
-; LE-NEXT:    vmov.32 d16[1], r1
+; LE-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
+; LE-NEXT:    add lr, sp, #8
 ; LE-NEXT:    vst1.64 {d10, d11}, [r0:128]!
 ; LE-NEXT:    vst1.64 {d16, d17}, [r0:128]!
-; LE-NEXT:    vst1.64 {d18, d19}, [r0:128]!
-; LE-NEXT:    vmov.32 d20[1], r9
+; LE-NEXT:    vst1.64 {d14, d15}, [r0:128]!
 ; LE-NEXT:    vst1.64 {d12, d13}, [r0:128]
-; LE-NEXT:    vst1.64 {d14, d15}, [r11:128]!
+; LE-NEXT:    vmov.32 d20[1], r10
+; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-NEXT:    add lr, sp, #40
+; LE-NEXT:    vmov.32 d21[1], r9
+; LE-NEXT:    vst1.64 {d16, d17}, [r11:128]!
 ; LE-NEXT:    vst1.64 {d20, d21}, [r11:128]!
 ; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-NEXT:    add lr, sp, #56
+; LE-NEXT:    add lr, sp, #80
 ; LE-NEXT:    vst1.64 {d16, d17}, [r11:128]!
 ; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-NEXT:    vst1.64 {d16, d17}, [r11:128]
-; LE-NEXT:    add sp, sp, #120
+; LE-NEXT:    add sp, sp, #136
 ; LE-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-NEXT:    add sp, sp, #4
 ; LE-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
@@ -586,31 +591,31 @@ define <16 x i64> @llrint_v16i64_v16f16(<16 x half> %x) {
 ; BE-NEXT:    .pad #112
 ; BE-NEXT:    sub sp, sp, #112
 ; BE-NEXT:    mov r11, r0
-; BE-NEXT:    vmov r0, s14
-; BE-NEXT:    vmov.f32 s17, s15
-; BE-NEXT:    vstr s13, [sp, #52] @ 4-byte Spill
-; BE-NEXT:    vmov.f32 s21, s12
-; BE-NEXT:    vstr s10, [sp, #68] @ 4-byte Spill
-; BE-NEXT:    vmov.f32 s23, s11
-; BE-NEXT:    vstr s7, [sp, #72] @ 4-byte Spill
-; BE-NEXT:    vmov.f32 s19, s9
-; BE-NEXT:    vstr s4, [sp, #28] @ 4-byte Spill
+; BE-NEXT:    vmov r0, s15
+; BE-NEXT:    vmov.f32 s19, s14
+; BE-NEXT:    vstr s12, [sp, #52] @ 4-byte Spill
+; BE-NEXT:    vmov.f32 s21, s13
+; BE-NEXT:    vstr s9, [sp, #68] @ 4-byte Spill
+; BE-NEXT:    vmov.f32 s17, s11
+; BE-NEXT:    vstr s6, [sp, #72] @ 4-byte Spill
+; BE-NEXT:    vmov.f32 s23, s10
+; BE-NEXT:    vstr s5, [sp, #28] @ 4-byte Spill
 ; BE-NEXT:    vmov.f32 s26, s8
-; BE-NEXT:    vmov.f32 s24, s6
-; BE-NEXT:    vmov.f32 s18, s5
-; BE-NEXT:    vmov.f32 s25, s3
-; BE-NEXT:    vmov.f32 s16, s2
+; BE-NEXT:    vmov.f32 s24, s7
+; BE-NEXT:    vmov.f32 s18, s4
+; BE-NEXT:    vmov.f32 s16, s3
+; BE-NEXT:    vmov.f32 s25, s2
 ; BE-NEXT:    vmov.f32 s27, s1
 ; BE-NEXT:    vmov.f32 s29, s0
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    vmov s0, r0
 ; BE-NEXT:    bl llrintf
 ; BE-NEXT:    mov r8, r0
-; BE-NEXT:    vmov r0, s29
+; BE-NEXT:    vmov r0, s27
 ; BE-NEXT:    mov r4, r1
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    mov r9, r0
-; BE-NEXT:    vmov r0, s27
+; BE-NEXT:    vmov r0, s29
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    mov r7, r0
 ; BE-NEXT:    vmov r0, s21
@@ -643,12 +648,12 @@ define <16 x i64> @llrint_v16i64_v16f16(<16 x half> %x) {
 ; BE-NEXT:    vmov.32 d14[0], r0
 ; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.32 d15[0], r0
-; BE-NEXT:    vmov r0, s17
+; BE-NEXT:    vmov r0, s19
 ; BE-NEXT:    mov r5, r1
 ; BE-NEXT:    bl __aeabi_h2f
 ; BE-NEXT:    vmov s0, r0
 ; BE-NEXT:    vmov.32 d10[0], r8
-; BE-NEXT:    vmov r6, s19
+; BE-NEXT:    vmov r6, s17
 ; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.32 d11[0], r0
 ; BE-NEXT:    mov r0, r6
@@ -735,51 +740,51 @@ define <16 x i64> @llrint_v16i64_v16f16(<16 x half> %x) {
 ; BE-NEXT:    vmov.32 d9[0], r0
 ; BE-NEXT:    vmov.32 d15[1], r4
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.32 d24[0], r0
+; BE-NEXT:    vmov.32 d16[0], r0
 ; BE-NEXT:    ldr r0, [sp, #76] @ 4-byte Reload
-; BE-NEXT:    vldr d23, [sp, #56] @ 8-byte Reload
-; BE-NEXT:    vldr d20, [sp, #8] @ 8-byte Reload
-; BE-NEXT:    vmov.32 d23[1], r0
+; BE-NEXT:    vldr d29, [sp, #56] @ 8-byte Reload
+; BE-NEXT:    vldr d22, [sp, #8] @ 8-byte Reload
+; BE-NEXT:    vmov.32 d29[1], r0
 ; BE-NEXT:    ldr r0, [sp, #92] @ 4-byte Reload
-; BE-NEXT:    vldr d22, [sp, #80] @ 8-byte Reload
-; BE-NEXT:    vldr d26, [sp, #16] @ 8-byte Reload
-; BE-NEXT:    vrev64.32 d21, d20
-; BE-NEXT:    vmov.32 d22[1], r0
+; BE-NEXT:    vldr d28, [sp, #80] @ 8-byte Reload
+; BE-NEXT:    vldr d24, [sp, #16] @ 8-byte Reload
+; BE-NEXT:    vrev64.32 d22, d22
+; BE-NEXT:    vmov.32 d28[1], r0
 ; BE-NEXT:    ldr r0, [sp, #108] @ 4-byte Reload
 ; BE-NEXT:    vldr d30, [sp] @ 8-byte Reload
-; BE-NEXT:    vldr d25, [sp, #96] @ 8-byte Reload
-; BE-NEXT:    vrev64.32 d20, d26
-; BE-NEXT:    vldr d26, [sp, #32] @ 8-byte Reload
+; BE-NEXT:    vldr d17, [sp, #96] @ 8-byte Reload
+; BE-NEXT:    vrev64.32 d23, d24
+; BE-NEXT:    vldr d24, [sp, #32] @ 8-byte Reload
 ; BE-NEXT:    vmov.32 d10[1], r5
-; BE-NEXT:    vmov.32 d12[1], r9
-; BE-NEXT:    vldr d28, [sp, #40] @ 8-byte Reload
-; BE-NEXT:    vrev64.32 d27, d26
-; BE-NEXT:    vmov.32 d25[1], r0
+; BE-NEXT:    vmov.32 d9[1], r6
+; BE-NEXT:    vldr d26, [sp, #40] @ 8-byte Reload
+; BE-NEXT:    vrev64.32 d24, d24
+; BE-NEXT:    vmov.32 d17[1], r0
 ; BE-NEXT:    add r0, r11, #64
 ; BE-NEXT:    vmov.32 d30[1], r8
-; BE-NEXT:    vmov.32 d9[1], r6
-; BE-NEXT:    vrev64.32 d26, d28
-; BE-NEXT:    vrev64.32 d29, d10
-; BE-NEXT:    vmov.32 d24[1], r1
-; BE-NEXT:    vrev64.32 d1, d12
-; BE-NEXT:    vrev64.32 d28, d23
-; BE-NEXT:    vrev64.32 d23, d22
-; BE-NEXT:    vrev64.32 d22, d30
-; BE-NEXT:    vrev64.32 d31, d25
+; BE-NEXT:    vmov.32 d16[1], r1
+; BE-NEXT:    vrev64.32 d25, d26
+; BE-NEXT:    vrev64.32 d26, d10
+; BE-NEXT:    vmov.32 d12[1], r9
 ; BE-NEXT:    vrev64.32 d0, d9
-; BE-NEXT:    vrev64.32 d30, d24
+; BE-NEXT:    vrev64.32 d27, d29
+; BE-NEXT:    vrev64.32 d28, d28
+; BE-NEXT:    vrev64.32 d29, d30
+; BE-NEXT:    vrev64.32 d30, d17
+; BE-NEXT:    vrev64.32 d1, d16
+; BE-NEXT:    vrev64.32 d31, d12
 ; BE-NEXT:    vst1.64 {d0, d1}, [r0:128]!
 ; BE-NEXT:    vst1.64 {d30, d31}, [r0:128]!
-; BE-NEXT:    vst1.64 {d28, d29}, [r0:128]!
-; BE-NEXT:    vrev64.32 d19, d13
-; BE-NEXT:    vst1.64 {d26, d27}, [r0:128]
-; BE-NEXT:    vst1.64 {d20, d21}, [r11:128]!
-; BE-NEXT:    vrev64.32 d18, d14
+; BE-NEXT:    vst1.64 {d26, d27}, [r0:128]!
+; BE-NEXT:    vrev64.32 d20, d13
+; BE-NEXT:    vst1.64 {d24, d25}, [r0:128]
 ; BE-NEXT:    vst1.64 {d22, d23}, [r11:128]!
-; BE-NEXT:    vrev64.32 d17, d15
-; BE-NEXT:    vrev64.32 d16, d11
-; BE-NEXT:    vst1.64 {d18, d19}, [r11:128]!
-; BE-NEXT:    vst1.64 {d16, d17}, [r11:128]
+; BE-NEXT:    vrev64.32 d21, d14
+; BE-NEXT:    vst1.64 {d28, d29}, [r11:128]!
+; BE-NEXT:    vrev64.32 d18, d15
+; BE-NEXT:    vrev64.32 d19, d11
+; BE-NEXT:    vst1.64 {d20, d21}, [r11:128]!
+; BE-NEXT:    vst1.64 {d18, d19}, [r11:128]
 ; BE-NEXT:    add sp, sp, #112
 ; BE-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-NEXT:    add sp, sp, #4
@@ -823,15 +828,14 @@ define <2 x i64> @llrint_v2i64_v2f32(<2 x float> %x) {
 ; LE-NEXT:    .vsave {d8}
 ; LE-NEXT:    vpush {d8}
 ; LE-NEXT:    vmov.f64 d8, d0
+; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov.f32 s0, s17
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s16
 ; LE-NEXT:    mov r4, r1
-; LE-NEXT:    vmov.32 d11[0], r0
-; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov.32 d10[0], r0
-; LE-NEXT:    vmov.32 d11[1], r4
-; LE-NEXT:    vmov.32 d10[1], r1
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.32 d11[0], r0
+; LE-NEXT:    vmov.32 d10[1], r4
+; LE-NEXT:    vmov.32 d11[1], r1
 ; LE-NEXT:    vorr q0, q5, q5
 ; LE-NEXT:    vpop {d8}
 ; LE-NEXT:    vpop {d10, d11}
@@ -846,15 +850,15 @@ define <2 x i64> @llrint_v2i64_v2f32(<2 x float> %x) {
 ; BE-NEXT:    .vsave {d8}
 ; BE-NEXT:    vpush {d8}
 ; BE-NEXT:    vrev64.32 d8, d0
-; BE-NEXT:    vmov.f32 s0, s17
-; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.f32 s0, s16
-; BE-NEXT:    mov r4, r1
-; BE-NEXT:    vmov.32 d11[0], r0
 ; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.f32 s0, s17
+; BE-NEXT:    mov r4, r1
 ; BE-NEXT:    vmov.32 d10[0], r0
-; BE-NEXT:    vmov.32 d11[1], r4
-; BE-NEXT:    vmov.32 d10[1], r1
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.32 d11[0], r0
+; BE-NEXT:    vmov.32 d10[1], r4
+; BE-NEXT:    vmov.32 d11[1], r1
 ; BE-NEXT:    vrev64.32 q0, q5
 ; BE-NEXT:    vpop {d8}
 ; BE-NEXT:    vpop {d10, d11}
@@ -871,28 +875,28 @@ define <4 x i64> @llrint_v4i64_v4f32(<4 x float> %x) {
 ; LE-NEXT:    push {r4, r5, r6, lr}
 ; LE-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
 ; LE-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
-; LE-NEXT:    vorr q5, q0, q0
-; LE-NEXT:    vmov.f32 s0, s23
+; LE-NEXT:    vorr q4, q0, q0
+; LE-NEXT:    vmov.f32 s0, s18
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s20
+; LE-NEXT:    vmov.f32 s0, s17
 ; LE-NEXT:    mov r4, r1
-; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    vmov.32 d10[0], r0
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s21
+; LE-NEXT:    vmov.f32 s0, s16
 ; LE-NEXT:    mov r5, r1
-; LE-NEXT:    vmov.32 d12[0], r0
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s22
-; LE-NEXT:    mov r6, r1
 ; LE-NEXT:    vmov.32 d13[0], r0
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d8[0], r0
-; LE-NEXT:    vmov.32 d13[1], r6
-; LE-NEXT:    vmov.32 d9[1], r4
-; LE-NEXT:    vmov.32 d12[1], r5
-; LE-NEXT:    vmov.32 d8[1], r1
+; LE-NEXT:    vmov.f32 s0, s19
+; LE-NEXT:    mov r6, r1
+; LE-NEXT:    vmov.32 d12[0], r0
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.32 d11[0], r0
+; LE-NEXT:    vmov.32 d12[1], r6
+; LE-NEXT:    vmov.32 d10[1], r4
+; LE-NEXT:    vmov.32 d13[1], r5
+; LE-NEXT:    vmov.32 d11[1], r1
 ; LE-NEXT:    vorr q0, q6, q6
-; LE-NEXT:    vorr q1, q4, q4
+; LE-NEXT:    vorr q1, q5, q5
 ; LE-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; LE-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -904,25 +908,25 @@ define <4 x i64> @llrint_v4i64_v4f32(<4 x float> %x) {
 ; BE-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
 ; BE-NEXT:    vrev64.32 d8, d1
 ; BE-NEXT:    vrev64.32 d9, d0
-; BE-NEXT:    vmov.f32 s0, s17
-; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.f32 s0, s18
-; BE-NEXT:    mov r4, r1
-; BE-NEXT:    vmov.32 d11[0], r0
+; BE-NEXT:    vmov.f32 s0, s16
 ; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.f32 s0, s19
-; BE-NEXT:    mov r5, r1
-; BE-NEXT:    vmov.32 d12[0], r0
+; BE-NEXT:    mov r4, r1
+; BE-NEXT:    vmov.32 d10[0], r0
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.f32 s0, s16
-; BE-NEXT:    mov r6, r1
+; BE-NEXT:    vmov.f32 s0, s18
+; BE-NEXT:    mov r5, r1
 ; BE-NEXT:    vmov.32 d13[0], r0
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.32 d10[0], r0
-; BE-NEXT:    vmov.32 d13[1], r6
-; BE-NEXT:    vmov.32 d11[1], r4
-; BE-NEXT:    vmov.32 d12[1], r5
-; BE-NEXT:    vmov.32 d10[1], r1
+; BE-NEXT:    vmov.f32 s0, s17
+; BE-NEXT:    mov r6, r1
+; BE-NEXT:    vmov.32 d12[0], r0
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.32 d11[0], r0
+; BE-NEXT:    vmov.32 d12[1], r6
+; BE-NEXT:    vmov.32 d10[1], r4
+; BE-NEXT:    vmov.32 d13[1], r5
+; BE-NEXT:    vmov.32 d11[1], r1
 ; BE-NEXT:    vrev64.32 q0, q6
 ; BE-NEXT:    vrev64.32 q1, q5
 ; BE-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
@@ -945,54 +949,54 @@ define <8 x i64> @llrint_v8i64_v8f32(<8 x float> %x) {
 ; LE-NEXT:    add lr, sp, #24
 ; LE-NEXT:    vorr q7, q0, q0
 ; LE-NEXT:    vstmia lr, {d2, d3} @ 16-byte Spill
-; LE-NEXT:    vmov.f32 s0, s27
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s24
-; LE-NEXT:    mov r8, r1
-; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    vmov.f32 s0, s26
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov.f32 s0, s25
+; LE-NEXT:    mov r8, r1
+; LE-NEXT:    vmov.32 d8[0], r0
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.f32 s0, s24
 ; LE-NEXT:    mov r9, r1
-; LE-NEXT:    vmov.32 d10[0], r0
+; LE-NEXT:    vmov.32 d11[0], r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vorr q6, q7, q7
 ; LE-NEXT:    add lr, sp, #8
 ; LE-NEXT:    mov r10, r1
-; LE-NEXT:    vmov.32 d11[0], r0
-; LE-NEXT:    vmov.f32 s0, s26
+; LE-NEXT:    vmov.32 d10[0], r0
+; LE-NEXT:    vmov.f32 s0, s27
 ; LE-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s27
+; LE-NEXT:    vmov.f32 s0, s26
 ; LE-NEXT:    mov r7, r1
-; LE-NEXT:    vmov.32 d14[0], r0
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s24
-; LE-NEXT:    mov r4, r1
 ; LE-NEXT:    vmov.32 d15[0], r0
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.f32 s0, s25
+; LE-NEXT:    mov r4, r1
+; LE-NEXT:    vmov.32 d14[0], r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    add lr, sp, #8
 ; LE-NEXT:    mov r5, r1
-; LE-NEXT:    vmov.32 d12[0], r0
+; LE-NEXT:    vmov.32 d13[0], r0
 ; LE-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; LE-NEXT:    vmov.f32 s0, s1
+; LE-NEXT:    @ kill: def $s0 killed $s0 killed $q0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    add lr, sp, #24
 ; LE-NEXT:    mov r6, r1
-; LE-NEXT:    vmov.32 d13[0], r0
+; LE-NEXT:    vmov.32 d12[0], r0
 ; LE-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; LE-NEXT:    vmov.f32 s0, s2
+; LE-NEXT:    vmov.f32 s0, s3
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.32 d8[0], r0
-; LE-NEXT:    vmov.32 d13[1], r6
-; LE-NEXT:    vmov.32 d15[1], r4
-; LE-NEXT:    vmov.32 d11[1], r10
-; LE-NEXT:    vmov.32 d9[1], r8
-; LE-NEXT:    vmov.32 d12[1], r5
-; LE-NEXT:    vmov.32 d14[1], r7
+; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    vmov.32 d12[1], r6
+; LE-NEXT:    vmov.32 d14[1], r4
+; LE-NEXT:    vmov.32 d10[1], r10
+; LE-NEXT:    vmov.32 d8[1], r8
+; LE-NEXT:    vmov.32 d13[1], r5
+; LE-NEXT:    vmov.32 d15[1], r7
 ; LE-NEXT:    vorr q0, q6, q6
-; LE-NEXT:    vmov.32 d10[1], r9
+; LE-NEXT:    vmov.32 d11[1], r9
 ; LE-NEXT:    vorr q1, q7, q7
-; LE-NEXT:    vmov.32 d8[1], r1
+; LE-NEXT:    vmov.32 d9[1], r1
 ; LE-NEXT:    vorr q2, q5, q5
 ; LE-NEXT:    vorr q3, q4, q4
 ; LE-NEXT:    add sp, sp, #40
@@ -1008,61 +1012,60 @@ define <8 x i64> @llrint_v8i64_v8f32(<8 x float> %x) {
 ; BE-NEXT:    .pad #32
 ; BE-NEXT:    sub sp, sp, #32
 ; BE-NEXT:    vorr q4, q1, q1
-; BE-NEXT:    add lr, sp, #8
-; BE-NEXT:    vorr q5, q0, q0
-; BE-NEXT:    vstmia lr, {d0, d1} @ 16-byte Spill
+; BE-NEXT:    vorr q7, q0, q0
 ; BE-NEXT:    vrev64.32 d12, d8
-; BE-NEXT:    vmov.f32 s0, s25
-; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.f32 s0, s24
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.f32 s0, s25
 ; BE-NEXT:    mov r8, r1
-; BE-NEXT:    vmov.32 d15[0], r0
-; BE-NEXT:    bl llrintf
-; BE-NEXT:    vrev64.32 d0, d11
-; BE-NEXT:    mov r9, r1
-; BE-NEXT:    vrev64.32 d8, d9
-; BE-NEXT:    vorr d9, d0, d0
-; BE-NEXT:    vmov.32 d14[0], r0
-; BE-NEXT:    vstr d8, [sp, #24] @ 8-byte Spill
-; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.f32 s0, s17
-; BE-NEXT:    mov r10, r1
 ; BE-NEXT:    vmov.32 d10[0], r0
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    add lr, sp, #8
-; BE-NEXT:    vmov.f32 s0, s19
-; BE-NEXT:    mov r7, r1
-; BE-NEXT:    vmov.32 d13[0], r0
-; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; BE-NEXT:    vrev64.32 d8, d16
-; BE-NEXT:    vstr d8, [sp, #8] @ 8-byte Spill
+; BE-NEXT:    vrev64.32 d1, d15
+; BE-NEXT:    add lr, sp, #16
+; BE-NEXT:    vrev64.32 d9, d9
+; BE-NEXT:    mov r9, r1
+; BE-NEXT:    vmov.f32 s0, s3
+; BE-NEXT:    vmov.32 d11[0], r0
+; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; BE-NEXT:    vstr d9, [sp, #8] @ 8-byte Spill
+; BE-NEXT:    vmov.f64 d8, d1
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.f32 s0, s16
-; BE-NEXT:    mov r4, r1
+; BE-NEXT:    vmov.f32 s0, s18
+; BE-NEXT:    mov r10, r1
 ; BE-NEXT:    vmov.32 d11[0], r0
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    vldr d0, [sp, #8] @ 8-byte Reload
+; BE-NEXT:    vmov.f32 s0, s16
+; BE-NEXT:    mov r7, r1
+; BE-NEXT:    vmov.32 d12[0], r0
+; BE-NEXT:    vrev64.32 d9, d14
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.f32 s0, s19
+; BE-NEXT:    mov r4, r1
+; BE-NEXT:    vmov.32 d10[0], r0
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.f32 s0, s18
 ; BE-NEXT:    mov r5, r1
-; BE-NEXT:    vmov.32 d8[0], r0
+; BE-NEXT:    vmov.32 d15[0], r0
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    vldr d0, [sp, #8] @ 8-byte Reload
+; BE-NEXT:    mov r6, r1
+; BE-NEXT:    vmov.32 d14[0], r0
 ; BE-NEXT:    vmov.f32 s0, s1
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    vldr d0, [sp, #24] @ 8-byte Reload
-; BE-NEXT:    mov r6, r1
-; BE-NEXT:    @ kill: def $s0 killed $s0 killed $d0
-; BE-NEXT:    vmov.32 d9[0], r0
-; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.32 d12[0], r0
-; BE-NEXT:    vmov.32 d9[1], r6
-; BE-NEXT:    vmov.32 d11[1], r4
-; BE-NEXT:    vmov.32 d15[1], r8
-; BE-NEXT:    vmov.32 d13[1], r7
-; BE-NEXT:    vmov.32 d8[1], r5
-; BE-NEXT:    vmov.32 d10[1], r10
-; BE-NEXT:    vmov.32 d14[1], r9
-; BE-NEXT:    vmov.32 d12[1], r1
-; BE-NEXT:    vrev64.32 q0, q4
+; BE-NEXT:    add lr, sp, #16
+; BE-NEXT:    vmov.32 d13[0], r0
+; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; BE-NEXT:    vmov.32 d14[1], r6
+; BE-NEXT:    vmov.32 d10[1], r4
+; BE-NEXT:    vmov.32 d16[1], r8
+; BE-NEXT:    vmov.32 d12[1], r7
+; BE-NEXT:    vmov.32 d15[1], r5
+; BE-NEXT:    vmov.32 d11[1], r10
+; BE-NEXT:    vmov.32 d17[1], r9
+; BE-NEXT:    vmov.32 d13[1], r1
+; BE-NEXT:    vrev64.32 q0, q7
 ; BE-NEXT:    vrev64.32 q1, q5
-; BE-NEXT:    vrev64.32 q2, q7
+; BE-NEXT:    vrev64.32 q2, q8
 ; BE-NEXT:    vrev64.32 q3, q6
 ; BE-NEXT:    add sp, sp, #32
 ; BE-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
@@ -1081,150 +1084,144 @@ define <16 x i64> @llrint_v16i64_v16f32(<16 x float> %x) {
 ; LE-NEXT:    sub sp, sp, #4
 ; LE-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; LE-NEXT:    .pad #160
-; LE-NEXT:    sub sp, sp, #160
-; LE-NEXT:    add lr, sp, #112
-; LE-NEXT:    vorr q5, q3, q3
-; LE-NEXT:    vorr q6, q0, q0
+; LE-NEXT:    .pad #152
+; LE-NEXT:    sub sp, sp, #152
+; LE-NEXT:    add lr, sp, #64
+; LE-NEXT:    vorr q6, q3, q3
+; LE-NEXT:    vorr q4, q0, q0
 ; LE-NEXT:    mov r4, r0
 ; LE-NEXT:    vstmia lr, {d4, d5} @ 16-byte Spill
 ; LE-NEXT:    add lr, sp, #48
 ; LE-NEXT:    vorr q7, q1, q1
 ; LE-NEXT:    vstmia lr, {d0, d1} @ 16-byte Spill
-; LE-NEXT:    vmov.f32 s0, s23
+; LE-NEXT:    vmov.f32 s0, s26
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s24
-; LE-NEXT:    add lr, sp, #144
-; LE-NEXT:    vmov.32 d17[0], r0
-; LE-NEXT:    str r1, [sp, #108] @ 4-byte Spill
+; LE-NEXT:    vmov.f32 s0, s17
+; LE-NEXT:    vmov.32 d16[0], r0
+; LE-NEXT:    add lr, sp, #136
+; LE-NEXT:    str r1, [sp, #100] @ 4-byte Spill
 ; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s25
-; LE-NEXT:    str r1, [sp, #84] @ 4-byte Spill
-; LE-NEXT:    vmov.32 d8[0], r0
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s28
-; LE-NEXT:    add lr, sp, #128
-; LE-NEXT:    vmov.32 d9[0], r0
-; LE-NEXT:    str r1, [sp, #44] @ 4-byte Spill
-; LE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; LE-NEXT:    vmov.f32 s0, s16
+; LE-NEXT:    str r1, [sp, #96] @ 4-byte Spill
+; LE-NEXT:    vmov.32 d11[0], r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov.f32 s0, s29
-; LE-NEXT:    mov r9, r1
+; LE-NEXT:    vmov.32 d10[0], r0
+; LE-NEXT:    add lr, sp, #120
+; LE-NEXT:    str r1, [sp, #44] @ 4-byte Spill
+; LE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.f32 s0, s28
+; LE-NEXT:    mov r11, r1
+; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.f32 s0, s31
+; LE-NEXT:    mov r6, r1
 ; LE-NEXT:    vmov.32 d8[0], r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    vmov.f32 s0, s30
-; LE-NEXT:    mov r6, r1
-; LE-NEXT:    vmov.32 d9[0], r0
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s31
 ; LE-NEXT:    mov r5, r1
-; LE-NEXT:    vmov.32 d12[0], r0
+; LE-NEXT:    vmov.32 d11[0], r0
 ; LE-NEXT:    bl llrintf
-; LE-NEXT:    add lr, sp, #112
-; LE-NEXT:    mov r7, r1
-; LE-NEXT:    vmov.32 d13[0], r0
-; LE-NEXT:    vldmia lr, {d14, d15} @ 16-byte Reload
-; LE-NEXT:    vmov.f32 s0, s29
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s22
-; LE-NEXT:    add lr, sp, #24
-; LE-NEXT:    vmov.32 d17[0], r0
-; LE-NEXT:    mov r11, r1
-; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; LE-NEXT:    vmov.32 d13[1], r7
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    add lr, sp, #144
-; LE-NEXT:    vmov.f32 s0, s21
-; LE-NEXT:    vmov.32 d12[1], r5
-; LE-NEXT:    str r1, [sp, #40] @ 4-byte Spill
-; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-NEXT:    vmov.32 d16[0], r0
-; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; LE-NEXT:    add lr, sp, #88
-; LE-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s20
-; LE-NEXT:    mov r10, r1
-; LE-NEXT:    vmov.32 d13[0], r0
-; LE-NEXT:    vmov.32 d9[1], r6
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s31
-; LE-NEXT:    vmov.32 d12[0], r0
-; LE-NEXT:    add lr, sp, #8
-; LE-NEXT:    mov r8, r1
-; LE-NEXT:    vmov.32 d8[1], r9
-; LE-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
-; LE-NEXT:    add lr, sp, #64
-; LE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    add lr, sp, #128
-; LE-NEXT:    vmov.32 d9[0], r0
-; LE-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
-; LE-NEXT:    mov r9, r1
-; LE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-NEXT:    add lr, sp, #48
-; LE-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
 ; LE-NEXT:    vmov.f32 s0, s27
-; LE-NEXT:    vmov.32 d11[1], r0
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    vmov.f32 s0, s26
-; LE-NEXT:    vmov.32 d15[0], r0
-; LE-NEXT:    ldr r0, [sp, #84] @ 4-byte Reload
-; LE-NEXT:    add lr, sp, #128
 ; LE-NEXT:    mov r7, r1
-; LE-NEXT:    vmov.32 d10[1], r0
+; LE-NEXT:    vmov.32 d10[0], r0
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.f32 s0, s24
+; LE-NEXT:    add lr, sp, #136
+; LE-NEXT:    str r1, [sp, #40] @ 4-byte Spill
+; LE-NEXT:    vmov.32 d10[1], r7
+; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-NEXT:    vmov.32 d17[0], r0
+; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.f32 s0, s25
+; LE-NEXT:    add lr, sp, #104
+; LE-NEXT:    vmov.32 d11[1], r5
+; LE-NEXT:    mov r9, r1
+; LE-NEXT:    vmov.32 d14[0], r0
 ; LE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; LE-NEXT:    bl llrintf
+; LE-NEXT:    add lr, sp, #24
+; LE-NEXT:    vmov.32 d15[0], r0
+; LE-NEXT:    mov r10, r1
+; LE-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-NEXT:    add lr, sp, #64
+; LE-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
+; LE-NEXT:    vmov.f32 s0, s26
+; LE-NEXT:    vmov.32 d8[1], r6
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.f32 s0, s27
+; LE-NEXT:    add lr, sp, #80
+; LE-NEXT:    vmov.32 d9[1], r11
+; LE-NEXT:    mov r8, r1
 ; LE-NEXT:    vmov.32 d14[0], r0
-; LE-NEXT:    add lr, sp, #144
-; LE-NEXT:    ldr r0, [sp, #108] @ 4-byte Reload
-; LE-NEXT:    mov r5, r1
-; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-NEXT:    vmov.32 d17[1], r0
-; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; LE-NEXT:    add lr, sp, #112
+; LE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    add lr, sp, #8
+; LE-NEXT:    vmov.32 d15[0], r0
+; LE-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
+; LE-NEXT:    mov r11, r1
+; LE-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-NEXT:    add lr, sp, #120
+; LE-NEXT:    vldmia lr, {d14, d15} @ 16-byte Reload
+; LE-NEXT:    add lr, sp, #48
 ; LE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-NEXT:    vmov.f32 s0, s20
+; LE-NEXT:    vmov.f32 s0, s22
+; LE-NEXT:    vmov.32 d14[1], r0
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.f32 s0, s23
+; LE-NEXT:    vmov.32 d8[0], r0
+; LE-NEXT:    ldr r0, [sp, #96] @ 4-byte Reload
+; LE-NEXT:    add lr, sp, #120
+; LE-NEXT:    mov r6, r1
+; LE-NEXT:    vmov.32 d15[1], r0
+; LE-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.f32 s0, s24
+; LE-NEXT:    add lr, sp, #136
+; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    ldr r0, [sp, #100] @ 4-byte Reload
+; LE-NEXT:    mov r5, r1
+; LE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
+; LE-NEXT:    vmov.32 d10[1], r0
+; LE-NEXT:    bl llrintf
+; LE-NEXT:    vmov.f32 s0, s25
+; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
+; LE-NEXT:    mov r7, r1
+; LE-NEXT:    vmov.32 d11[1], r0
 ; LE-NEXT:    bl llrintf
 ; LE-NEXT:    add lr, sp, #24
-; LE-NEXT:    vmov.f32 s0, s22
-; LE-NEXT:    mov r6, r1
-; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-NEXT:    vmov.32 d16[0], r0
-; LE-NEXT:    vmov.32 d17[1], r11
-; LE-NEXT:    vorr q6, q8, q8
-; LE-NEXT:    bl llrintf
-; LE-NEXT:    add lr, sp, #144
-; LE-NEXT:    vmov.32 d8[0], r0
-; LE-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
+; LE-NEXT:    vmov.32 d15[0], r0
+; LE-NEXT:    add r0, r4, #64
 ; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-NEXT:    add lr, sp, #8
 ; LE-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
-; LE-NEXT:    add lr, sp, #128
-; LE-NEXT:    vmov.32 d9[1], r9
-; LE-NEXT:    vmov.32 d12[1], r6
-; LE-NEXT:    vmov.32 d19[1], r10
-; LE-NEXT:    vmov.32 d8[1], r1
-; LE-NEXT:    vmov.32 d16[1], r0
-; LE-NEXT:    add r0, r4, #64
+; LE-NEXT:    add lr, sp, #120
+; LE-NEXT:    vmov.32 d14[1], r7
 ; LE-NEXT:    vmov.32 d18[1], r8
-; LE-NEXT:    vst1.64 {d12, d13}, [r0:128]!
-; LE-NEXT:    vst1.64 {d8, d9}, [r0:128]!
+; LE-NEXT:    vmov.32 d15[1], r1
+; LE-NEXT:    vmov.32 d16[1], r9
+; LE-NEXT:    vmov.32 d19[1], r11
+; LE-NEXT:    vmov.32 d17[1], r10
+; LE-NEXT:    vst1.64 {d14, d15}, [r0:128]!
 ; LE-NEXT:    vst1.64 {d18, d19}, [r0:128]!
-; LE-NEXT:    vst1.64 {d16, d17}, [r0:128]
-; LE-NEXT:    vmov.32 d15[1], r7
+; LE-NEXT:    vst1.64 {d16, d17}, [r0:128]!
+; LE-NEXT:    vst1.64 {d10, d11}, [r0:128]
+; LE-NEXT:    vmov.32 d8[1], r6
 ; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-NEXT:    add lr, sp, #64
-; LE-NEXT:    vmov.32 d14[1], r5
+; LE-NEXT:    add lr, sp, #80
+; LE-NEXT:    vmov.32 d9[1], r5
 ; LE-NEXT:    vst1.64 {d16, d17}, [r4:128]!
-; LE-NEXT:    vst1.64 {d14, d15}, [r4:128]!
+; LE-NEXT:    vst1.64 {d8, d9}, [r4:128]!
 ; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-NEXT:    add lr, sp, #88
+; LE-NEXT:    add lr, sp, #104
 ; LE-NEXT:    vst1.64 {d16, d17}, [r4:128]!
 ; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-NEXT:    vst1.64 {d16, d17}, [r4:128]
-; LE-NEXT:    add sp, sp, #160
+; LE-NEXT:    add sp, sp, #152
 ; LE-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-NEXT:    add sp, sp, #4
 ; LE-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
@@ -1247,79 +1244,79 @@ define <16 x i64> @llrint_v16i64_v16f32(<16 x float> %x) {
 ; BE-NEXT:    add lr, sp, #96
 ; BE-NEXT:    vrev64.32 d8, d13
 ; BE-NEXT:    vstmia lr, {d2, d3} @ 16-byte Spill
-; BE-NEXT:    vmov.f32 s0, s17
-; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.f32 s0, s16
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.f32 s0, s17
 ; BE-NEXT:    str r1, [sp, #88] @ 4-byte Spill
-; BE-NEXT:    vmov.32 d11[0], r0
+; BE-NEXT:    vmov.32 d10[0], r0
 ; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vrev64.32 d8, d14
 ; BE-NEXT:    add lr, sp, #128
-; BE-NEXT:    vmov.32 d10[0], r0
-; BE-NEXT:    str r1, [sp, #92] @ 4-byte Spill
-; BE-NEXT:    vmov.f32 s0, s16
 ; BE-NEXT:    vrev64.32 d9, d12
+; BE-NEXT:    str r1, [sp, #92] @ 4-byte Spill
+; BE-NEXT:    vmov.f32 s0, s17
+; BE-NEXT:    vmov.32 d11[0], r0
 ; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-NEXT:    vstr d9, [sp, #64] @ 8-byte Spill
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.f32 s0, s19
-; BE-NEXT:    mov r9, r1
-; BE-NEXT:    vmov.32 d12[0], r0
-; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.f32 s0, s17
-; BE-NEXT:    str r1, [sp, #84] @ 4-byte Spill
-; BE-NEXT:    vmov.32 d11[0], r0
-; BE-NEXT:    vrev64.32 d9, d15
-; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.f32 s0, s18
-; BE-NEXT:    mov r6, r1
+; BE-NEXT:    mov r9, r1
 ; BE-NEXT:    vmov.32 d13[0], r0
 ; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.f32 s0, s16
+; BE-NEXT:    str r1, [sp, #84] @ 4-byte Spill
+; BE-NEXT:    vmov.32 d10[0], r0
+; BE-NEXT:    vrev64.32 d9, d15
+; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.f32 s0, s19
+; BE-NEXT:    mov r6, r1
+; BE-NEXT:    vmov.32 d12[0], r0
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.f32 s0, s18
 ; BE-NEXT:    mov r5, r1
-; BE-NEXT:    vmov.32 d14[0], r0
+; BE-NEXT:    vmov.32 d15[0], r0
 ; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vldr d0, [sp, #64] @ 8-byte Reload
 ; BE-NEXT:    mov r7, r1
-; BE-NEXT:    @ kill: def $s0 killed $s0 killed $d0
-; BE-NEXT:    vmov.32 d15[0], r0
+; BE-NEXT:    vmov.32 d14[0], r0
+; BE-NEXT:    vmov.f32 s0, s1
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.32 d10[0], r0
 ; BE-NEXT:    add lr, sp, #40
+; BE-NEXT:    vmov.32 d11[0], r0
 ; BE-NEXT:    str r1, [sp, #60] @ 4-byte Spill
-; BE-NEXT:    vmov.32 d15[1], r7
 ; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-NEXT:    add lr, sp, #96
 ; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; BE-NEXT:    vmov.32 d14[1], r7
 ; BE-NEXT:    vrev64.32 d8, d16
-; BE-NEXT:    vmov.f32 s0, s17
-; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.f32 s0, s16
-; BE-NEXT:    vmov.32 d14[1], r5
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.f32 s0, s17
 ; BE-NEXT:    add lr, sp, #64
+; BE-NEXT:    vmov.32 d15[1], r5
 ; BE-NEXT:    mov r10, r1
-; BE-NEXT:    vmov.32 d11[0], r0
+; BE-NEXT:    vmov.32 d10[0], r0
 ; BE-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.32 d10[0], r0
 ; BE-NEXT:    add lr, sp, #24
+; BE-NEXT:    vmov.32 d11[0], r0
 ; BE-NEXT:    mov r11, r1
-; BE-NEXT:    vmov.32 d13[1], r6
 ; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-NEXT:    add lr, sp, #96
 ; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-NEXT:    vrev64.32 d8, d17
-; BE-NEXT:    vmov.f32 s0, s17
-; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.32 d12[1], r6
 ; BE-NEXT:    vmov.f32 s0, s16
-; BE-NEXT:    vmov.32 d12[1], r9
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.f32 s0, s17
 ; BE-NEXT:    add lr, sp, #96
+; BE-NEXT:    vmov.32 d13[1], r9
 ; BE-NEXT:    mov r8, r1
-; BE-NEXT:    vmov.32 d11[0], r0
+; BE-NEXT:    vmov.32 d10[0], r0
 ; BE-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    vmov.32 d10[0], r0
 ; BE-NEXT:    add lr, sp, #8
+; BE-NEXT:    vmov.32 d11[0], r0
 ; BE-NEXT:    ldr r0, [sp, #88] @ 4-byte Reload
 ; BE-NEXT:    mov r9, r1
 ; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
@@ -1328,54 +1325,54 @@ define <16 x i64> @llrint_v16i64_v16f32(<16 x float> %x) {
 ; BE-NEXT:    add lr, sp, #128
 ; BE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
 ; BE-NEXT:    vrev64.32 d8, d16
-; BE-NEXT:    vmov.32 d11[1], r0
-; BE-NEXT:    vmov.f32 s0, s17
-; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.32 d10[1], r0
 ; BE-NEXT:    vmov.f32 s0, s16
-; BE-NEXT:    vmov.32 d15[0], r0
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    vmov.f32 s0, s17
+; BE-NEXT:    vmov.32 d14[0], r0
 ; BE-NEXT:    ldr r0, [sp, #92] @ 4-byte Reload
 ; BE-NEXT:    add lr, sp, #128
 ; BE-NEXT:    mov r7, r1
-; BE-NEXT:    vmov.32 d10[1], r0
+; BE-NEXT:    vmov.32 d11[1], r0
 ; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-NEXT:    bl llrintf
 ; BE-NEXT:    add lr, sp, #112
-; BE-NEXT:    vmov.32 d14[0], r0
+; BE-NEXT:    vmov.32 d15[0], r0
 ; BE-NEXT:    ldr r0, [sp, #84] @ 4-byte Reload
 ; BE-NEXT:    mov r5, r1
 ; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-NEXT:    add lr, sp, #40
 ; BE-NEXT:    vrev64.32 d8, d17
 ; BE-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
-; BE-NEXT:    vmov.f32 s0, s17
-; BE-NEXT:    vmov.32 d13[1], r0
-; BE-NEXT:    bl llrintf
 ; BE-NEXT:    vmov.f32 s0, s16
-; BE-NEXT:    vmov.32 d11[0], r0
-; BE-NEXT:    ldr r0, [sp, #60] @ 4-byte Reload
-; BE-NEXT:    mov r6, r1
 ; BE-NEXT:    vmov.32 d12[1], r0
 ; BE-NEXT:    bl llrintf
-; BE-NEXT:    add lr, sp, #24
+; BE-NEXT:    vmov.f32 s0, s17
 ; BE-NEXT:    vmov.32 d10[0], r0
+; BE-NEXT:    ldr r0, [sp, #60] @ 4-byte Reload
+; BE-NEXT:    mov r6, r1
+; BE-NEXT:    vmov.32 d13[1], r0
+; BE-NEXT:    bl llrintf
+; BE-NEXT:    add lr, sp, #24
+; BE-NEXT:    vmov.32 d11[0], r0
 ; BE-NEXT:    add r0, r4, #64
 ; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-NEXT:    add lr, sp, #8
-; BE-NEXT:    vmov.32 d17[1], r10
-; BE-NEXT:    vmov.32 d16[1], r11
+; BE-NEXT:    vmov.32 d14[1], r7
+; BE-NEXT:    vmov.32 d16[1], r10
+; BE-NEXT:    vmov.32 d17[1], r11
 ; BE-NEXT:    vorr q12, q8, q8
 ; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-NEXT:    add lr, sp, #128
-; BE-NEXT:    vmov.32 d15[1], r7
-; BE-NEXT:    vmov.32 d11[1], r6
-; BE-NEXT:    vmov.32 d14[1], r5
+; BE-NEXT:    vmov.32 d10[1], r6
+; BE-NEXT:    vmov.32 d15[1], r5
 ; BE-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
 ; BE-NEXT:    add lr, sp, #96
-; BE-NEXT:    vmov.32 d10[1], r1
-; BE-NEXT:    vmov.32 d17[1], r8
+; BE-NEXT:    vmov.32 d11[1], r1
+; BE-NEXT:    vmov.32 d16[1], r8
 ; BE-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
 ; BE-NEXT:    add lr, sp, #64
-; BE-NEXT:    vmov.32 d16[1], r9
+; BE-NEXT:    vmov.32 d17[1], r9
 ; BE-NEXT:    vrev64.32 q14, q7
 ; BE-NEXT:    vorr q13, q8, q8
 ; BE-NEXT:    vrev64.32 q15, q5
@@ -1435,15 +1432,14 @@ define <2 x i64> @llrint_v2i64_v2f64(<2 x double> %x) {
 ; LE-NEXT:    .vsave {d8, d9, d10, d11}
 ; LE-NEXT:    vpush {d8, d9, d10, d11}
 ; LE-NEXT:    vorr q4, q0, q0
+; LE-NEXT:    bl llrint
 ; LE-NEXT:    vorr d0, d9, d9
-; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d8, d8
 ; LE-NEXT:    mov r4, r1
-; LE-NEXT:    vmov.32 d11[0], r0
-; LE-NEXT:    bl llrint
 ; LE-NEXT:    vmov.32 d10[0], r0
-; LE-NEXT:    vmov.32 d11[1], r4
-; LE-NEXT:    vmov.32 d10[1], r1
+; LE-NEXT:    bl llrint
+; LE-NEXT:    vmov.32 d11[0], r0
+; LE-NEXT:    vmov.32 d10[1], r4
+; LE-NEXT:    vmov.32 d11[1], r1
 ; LE-NEXT:    vorr q0, q5, q5
 ; LE-NEXT:    vpop {d8, d9, d10, d11}
 ; LE-NEXT:    pop {r4, pc}
@@ -1455,15 +1451,14 @@ define <2 x i64> @llrint_v2i64_v2f64(<2 x double> %x) {
 ; BE-NEXT:    .vsave {d8, d9, d10, d11}
 ; BE-NEXT:    vpush {d8, d9, d10, d11}
 ; BE-NEXT:    vorr q4, q0, q0
+; BE-NEXT:    bl llrint
 ; BE-NEXT:    vorr d0, d9, d9
-; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d8, d8
 ; BE-NEXT:    mov r4, r1
-; BE-NEXT:    vmov.32 d11[0], r0
-; BE-NEXT:    bl llrint
 ; BE-NEXT:    vmov.32 d10[0], r0
-; BE-NEXT:    vmov.32 d11[1], r4
-; BE-NEXT:    vmov.32 d10[1], r1
+; BE-NEXT:    bl llrint
+; BE-NEXT:    vmov.32 d11[0], r0
+; BE-NEXT:    vmov.32 d10[1], r4
+; BE-NEXT:    vmov.32 d11[1], r1
 ; BE-NEXT:    vrev64.32 q0, q5
 ; BE-NEXT:    vpop {d8, d9, d10, d11}
 ; BE-NEXT:    pop {r4, pc}
@@ -1479,29 +1474,29 @@ define <4 x i64> @llrint_v4i64_v4f64(<4 x double> %x) {
 ; LE-NEXT:    push {r4, r5, r6, lr}
 ; LE-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; LE-NEXT:    vorr q5, q1, q1
-; LE-NEXT:    vorr q6, q0, q0
+; LE-NEXT:    vorr q4, q1, q1
+; LE-NEXT:    vorr q5, q0, q0
+; LE-NEXT:    vorr d0, d8, d8
+; LE-NEXT:    bl llrint
 ; LE-NEXT:    vorr d0, d11, d11
-; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d12, d12
 ; LE-NEXT:    mov r4, r1
-; LE-NEXT:    vmov.32 d9[0], r0
-; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d13, d13
-; LE-NEXT:    mov r5, r1
-; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    vmov.32 d12[0], r0
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    vorr d0, d10, d10
-; LE-NEXT:    mov r6, r1
+; LE-NEXT:    mov r5, r1
 ; LE-NEXT:    vmov.32 d15[0], r0
 ; LE-NEXT:    bl llrint
-; LE-NEXT:    vmov.32 d8[0], r0
-; LE-NEXT:    vmov.32 d15[1], r6
-; LE-NEXT:    vmov.32 d9[1], r4
-; LE-NEXT:    vmov.32 d14[1], r5
-; LE-NEXT:    vmov.32 d8[1], r1
+; LE-NEXT:    vorr d0, d9, d9
+; LE-NEXT:    mov r6, r1
+; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    bl llrint
+; LE-NEXT:    vmov.32 d13[0], r0
+; LE-NEXT:    vmov.32 d14[1], r6
+; LE-NEXT:    vmov.32 d12[1], r4
+; LE-NEXT:    vmov.32 d15[1], r5
+; LE-NEXT:    vmov.32 d13[1], r1
 ; LE-NEXT:    vorr q0, q7, q7
-; LE-NEXT:    vorr q1, q4, q4
+; LE-NEXT:    vorr q1, q6, q6
 ; LE-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -1513,25 +1508,25 @@ define <4 x i64> @llrint_v4i64_v4f64(<4 x double> %x) {
 ; BE-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-NEXT:    vorr q4, q1, q1
 ; BE-NEXT:    vorr q5, q0, q0
-; BE-NEXT:    vorr d0, d9, d9
-; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d10, d10
-; BE-NEXT:    mov r4, r1
-; BE-NEXT:    vmov.32 d13[0], r0
+; BE-NEXT:    vorr d0, d8, d8
 ; BE-NEXT:    bl llrint
 ; BE-NEXT:    vorr d0, d11, d11
-; BE-NEXT:    mov r5, r1
-; BE-NEXT:    vmov.32 d14[0], r0
+; BE-NEXT:    mov r4, r1
+; BE-NEXT:    vmov.32 d12[0], r0
 ; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d8, d8
-; BE-NEXT:    mov r6, r1
+; BE-NEXT:    vorr d0, d10, d10
+; BE-NEXT:    mov r5, r1
 ; BE-NEXT:    vmov.32 d15[0], r0
 ; BE-NEXT:    bl llrint
-; BE-NEXT:    vmov.32 d12[0], r0
-; BE-NEXT:    vmov.32 d15[1], r6
-; BE-NEXT:    vmov.32 d13[1], r4
-; BE-NEXT:    vmov.32 d14[1], r5
-; BE-NEXT:    vmov.32 d12[1], r1
+; BE-NEXT:    vorr d0, d9, d9
+; BE-NEXT:    mov r6, r1
+; BE-NEXT:    vmov.32 d14[0], r0
+; BE-NEXT:    bl llrint
+; BE-NEXT:    vmov.32 d13[0], r0
+; BE-NEXT:    vmov.32 d14[1], r6
+; BE-NEXT:    vmov.32 d12[1], r4
+; BE-NEXT:    vmov.32 d15[1], r5
+; BE-NEXT:    vmov.32 d13[1], r1
 ; BE-NEXT:    vrev64.32 q0, q7
 ; BE-NEXT:    vrev64.32 q1, q6
 ; BE-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
@@ -1552,57 +1547,57 @@ define <8 x i64> @llrint_v8i64_v8f64(<8 x double> %x) {
 ; LE-NEXT:    sub sp, sp, #40
 ; LE-NEXT:    vorr q4, q0, q0
 ; LE-NEXT:    add lr, sp, #24
-; LE-NEXT:    vorr d0, d7, d7
+; LE-NEXT:    vorr d0, d6, d6
 ; LE-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; LE-NEXT:    vorr q7, q2, q2
 ; LE-NEXT:    vorr q6, q1, q1
 ; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d14, d14
+; LE-NEXT:    vorr d0, d15, d15
+; LE-NEXT:    vmov.32 d16[0], r0
 ; LE-NEXT:    add lr, sp, #8
-; LE-NEXT:    vmov.32 d17[0], r0
 ; LE-NEXT:    mov r8, r1
 ; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d15, d15
+; LE-NEXT:    vorr d0, d14, d14
 ; LE-NEXT:    mov r9, r1
-; LE-NEXT:    vmov.32 d10[0], r0
-; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d12, d12
-; LE-NEXT:    mov r10, r1
 ; LE-NEXT:    vmov.32 d11[0], r0
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    vorr d0, d13, d13
-; LE-NEXT:    mov r7, r1
-; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    mov r10, r1
+; LE-NEXT:    vmov.32 d10[0], r0
 ; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d8, d8
-; LE-NEXT:    mov r4, r1
+; LE-NEXT:    vorr d0, d12, d12
+; LE-NEXT:    mov r7, r1
 ; LE-NEXT:    vmov.32 d15[0], r0
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    vorr d0, d9, d9
+; LE-NEXT:    mov r4, r1
+; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    bl llrint
+; LE-NEXT:    vorr d0, d8, d8
 ; LE-NEXT:    mov r5, r1
-; LE-NEXT:    vmov.32 d12[0], r0
+; LE-NEXT:    vmov.32 d13[0], r0
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    add lr, sp, #24
 ; LE-NEXT:    mov r6, r1
-; LE-NEXT:    vmov.32 d13[0], r0
-; LE-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; LE-NEXT:    @ kill: def $d0 killed $d0 killed $q0
+; LE-NEXT:    vmov.32 d12[0], r0
+; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-NEXT:    vorr d0, d17, d17
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    add lr, sp, #8
-; LE-NEXT:    vmov.32 d13[1], r6
+; LE-NEXT:    vmov.32 d12[1], r6
 ; LE-NEXT:    vldmia lr, {d6, d7} @ 16-byte Reload
-; LE-NEXT:    vmov.32 d15[1], r4
-; LE-NEXT:    vmov.32 d11[1], r10
-; LE-NEXT:    vmov.32 d6[0], r0
-; LE-NEXT:    vmov.32 d12[1], r5
-; LE-NEXT:    vmov.32 d14[1], r7
+; LE-NEXT:    vmov.32 d14[1], r4
+; LE-NEXT:    vmov.32 d10[1], r10
+; LE-NEXT:    vmov.32 d7[0], r0
+; LE-NEXT:    vmov.32 d13[1], r5
+; LE-NEXT:    vmov.32 d15[1], r7
 ; LE-NEXT:    vorr q0, q6, q6
-; LE-NEXT:    vmov.32 d10[1], r9
+; LE-NEXT:    vmov.32 d11[1], r9
 ; LE-NEXT:    vorr q1, q7, q7
-; LE-NEXT:    vmov.32 d7[1], r8
+; LE-NEXT:    vmov.32 d6[1], r8
 ; LE-NEXT:    vorr q2, q5, q5
-; LE-NEXT:    vmov.32 d6[1], r1
+; LE-NEXT:    vmov.32 d7[1], r1
 ; LE-NEXT:    add sp, sp, #40
 ; LE-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
@@ -1617,54 +1612,54 @@ define <8 x i64> @llrint_v8i64_v8f64(<8 x double> %x) {
 ; BE-NEXT:    sub sp, sp, #40
 ; BE-NEXT:    vorr q4, q0, q0
 ; BE-NEXT:    add lr, sp, #24
-; BE-NEXT:    vorr d0, d7, d7
+; BE-NEXT:    vorr d0, d6, d6
 ; BE-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; BE-NEXT:    vorr q7, q2, q2
 ; BE-NEXT:    vorr q6, q1, q1
 ; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d14, d14
+; BE-NEXT:    vorr d0, d15, d15
+; BE-NEXT:    vmov.32 d16[0], r0
 ; BE-NEXT:    add lr, sp, #8
-; BE-NEXT:    vmov.32 d17[0], r0
 ; BE-NEXT:    mov r8, r1
 ; BE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d15, d15
+; BE-NEXT:    vorr d0, d14, d14
 ; BE-NEXT:    mov r9, r1
-; BE-NEXT:    vmov.32 d10[0], r0
-; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d12, d12
-; BE-NEXT:    mov r10, r1
 ; BE-NEXT:    vmov.32 d11[0], r0
 ; BE-NEXT:    bl llrint
 ; BE-NEXT:    vorr d0, d13, d13
-; BE-NEXT:    mov r7, r1
-; BE-NEXT:    vmov.32 d14[0], r0
+; BE-NEXT:    mov r10, r1
+; BE-NEXT:    vmov.32 d10[0], r0
 ; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d8, d8
-; BE-NEXT:    mov r4, r1
+; BE-NEXT:    vorr d0, d12, d12
+; BE-NEXT:    mov r7, r1
 ; BE-NEXT:    vmov.32 d15[0], r0
 ; BE-NEXT:    bl llrint
 ; BE-NEXT:    vorr d0, d9, d9
+; BE-NEXT:    mov r4, r1
+; BE-NEXT:    vmov.32 d14[0], r0
+; BE-NEXT:    bl llrint
+; BE-NEXT:    vorr d0, d8, d8
 ; BE-NEXT:    mov r5, r1
-; BE-NEXT:    vmov.32 d12[0], r0
+; BE-NEXT:    vmov.32 d13[0], r0
 ; BE-NEXT:    bl llrint
 ; BE-NEXT:    add lr, sp, #24
 ; BE-NEXT:    mov r6, r1
-; BE-NEXT:    vmov.32 d13[0], r0
-; BE-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; BE-NEXT:    @ kill: def $d0 killed $d0 killed $q0
+; BE-NEXT:    vmov.32 d12[0], r0
+; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; BE-NEXT:    vorr d0, d17, d17
 ; BE-NEXT:    bl llrint
 ; BE-NEXT:    add lr, sp, #8
-; BE-NEXT:    vmov.32 d13[1], r6
+; BE-NEXT:    vmov.32 d12[1], r6
 ; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; BE-NEXT:    vmov.32 d15[1], r4
-; BE-NEXT:    vmov.32 d16[0], r0
-; BE-NEXT:    vmov.32 d11[1], r10
-; BE-NEXT:    vmov.32 d17[1], r8
-; BE-NEXT:    vmov.32 d12[1], r5
-; BE-NEXT:    vmov.32 d14[1], r7
-; BE-NEXT:    vmov.32 d10[1], r9
-; BE-NEXT:    vmov.32 d16[1], r1
+; BE-NEXT:    vmov.32 d17[0], r0
+; BE-NEXT:    vmov.32 d14[1], r4
+; BE-NEXT:    vmov.32 d10[1], r10
+; BE-NEXT:    vmov.32 d16[1], r8
+; BE-NEXT:    vmov.32 d13[1], r5
+; BE-NEXT:    vmov.32 d15[1], r7
+; BE-NEXT:    vmov.32 d11[1], r9
+; BE-NEXT:    vmov.32 d17[1], r1
 ; BE-NEXT:    vrev64.32 q0, q6
 ; BE-NEXT:    vrev64.32 q1, q7
 ; BE-NEXT:    vrev64.32 q2, q5
@@ -1697,7 +1692,7 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; LE-NEXT:    vorr q7, q1, q1
 ; LE-NEXT:    vstmia lr, {d0, d1} @ 16-byte Spill
 ; LE-NEXT:    add lr, sp, #144
-; LE-NEXT:    vorr d0, d1, d1
+; LE-NEXT:    @ kill: def $d0 killed $d0 killed $q0
 ; LE-NEXT:    vld1.64 {d16, d17}, [r0]
 ; LE-NEXT:    add r0, sp, #280
 ; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
@@ -1713,137 +1708,138 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; LE-NEXT:    vld1.64 {d16, d17}, [r0]
 ; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d14, d14
-; LE-NEXT:    str r1, [sp, #116] @ 4-byte Spill
-; LE-NEXT:    vmov.32 d11[0], r0
-; LE-NEXT:    bl llrint
 ; LE-NEXT:    vorr d0, d15, d15
-; LE-NEXT:    str r1, [sp, #76] @ 4-byte Spill
-; LE-NEXT:    vmov.32 d8[0], r0
+; LE-NEXT:    str r1, [sp, #116] @ 4-byte Spill
+; LE-NEXT:    vmov.32 d10[0], r0
 ; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d12, d12
-; LE-NEXT:    add lr, sp, #160
+; LE-NEXT:    vorr d0, d14, d14
+; LE-NEXT:    str r1, [sp, #76] @ 4-byte Spill
 ; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    bl llrint
+; LE-NEXT:    vorr d0, d13, d13
+; LE-NEXT:    vmov.32 d8[0], r0
+; LE-NEXT:    add lr, sp, #160
 ; LE-NEXT:    str r1, [sp, #72] @ 4-byte Spill
 ; LE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
 ; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d13, d13
+; LE-NEXT:    vorr d0, d12, d12
 ; LE-NEXT:    mov r6, r1
-; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    vmov.32 d9[0], r0
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    add lr, sp, #40
 ; LE-NEXT:    mov r4, r1
-; LE-NEXT:    vmov.32 d15[0], r0
-; LE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; LE-NEXT:    vorr d0, d8, d8
+; LE-NEXT:    vmov.32 d8[0], r0
+; LE-NEXT:    vldmia lr, {d14, d15} @ 16-byte Reload
+; LE-NEXT:    vorr d0, d15, d15
 ; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d9, d9
+; LE-NEXT:    vorr d0, d14, d14
 ; LE-NEXT:    mov r7, r1
-; LE-NEXT:    vmov.32 d12[0], r0
+; LE-NEXT:    vmov.32 d13[0], r0
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    add lr, sp, #96
 ; LE-NEXT:    mov r5, r1
-; LE-NEXT:    vmov.32 d13[0], r0
-; LE-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; LE-NEXT:    @ kill: def $d0 killed $d0 killed $q0
-; LE-NEXT:    bl llrint
-; LE-NEXT:    vmov.32 d10[0], r0
-; LE-NEXT:    add lr, sp, #40
-; LE-NEXT:    mov r10, r1
-; LE-NEXT:    vmov.32 d13[1], r5
-; LE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
-; LE-NEXT:    add lr, sp, #56
-; LE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; LE-NEXT:    vorr d0, d9, d9
-; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d8, d8
-; LE-NEXT:    vmov.32 d12[1], r7
-; LE-NEXT:    add lr, sp, #96
-; LE-NEXT:    mov r9, r1
-; LE-NEXT:    vmov.32 d11[0], r0
-; LE-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
-; LE-NEXT:    bl llrint
-; LE-NEXT:    vmov.32 d10[0], r0
-; LE-NEXT:    add lr, sp, #24
-; LE-NEXT:    mov r11, r1
-; LE-NEXT:    vmov.32 d15[1], r4
-; LE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
-; LE-NEXT:    add lr, sp, #144
+; LE-NEXT:    vmov.32 d12[0], r0
 ; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-NEXT:    vorr d0, d17, d17
 ; LE-NEXT:    bl llrint
+; LE-NEXT:    add lr, sp, #40
+; LE-NEXT:    vmov.32 d11[0], r0
+; LE-NEXT:    mov r9, r1
+; LE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; LE-NEXT:    add lr, sp, #56
+; LE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
+; LE-NEXT:    vorr d0, d10, d10
+; LE-NEXT:    vmov.32 d12[1], r5
+; LE-NEXT:    bl llrint
+; LE-NEXT:    vorr d0, d11, d11
+; LE-NEXT:    add lr, sp, #96
+; LE-NEXT:    vmov.32 d13[1], r7
+; LE-NEXT:    mov r10, r1
+; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
+; LE-NEXT:    bl llrint
+; LE-NEXT:    add lr, sp, #24
+; LE-NEXT:    vmov.32 d15[0], r0
+; LE-NEXT:    mov r11, r1
+; LE-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-NEXT:    add lr, sp, #144
+; LE-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
+; LE-NEXT:    @ kill: def $d0 killed $d0 killed $q0
+; LE-NEXT:    vmov.32 d8[1], r4
+; LE-NEXT:    bl llrint
+; LE-NEXT:    vmov.32 d16[0], r0
 ; LE-NEXT:    add lr, sp, #8
-; LE-NEXT:    vmov.32 d14[1], r6
 ; LE-NEXT:    mov r8, r1
-; LE-NEXT:    vmov.32 d17[0], r0
+; LE-NEXT:    vmov.32 d9[1], r6
 ; LE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-NEXT:    add lr, sp, #56
-; LE-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
 ; LE-NEXT:    add lr, sp, #80
+; LE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
+; LE-NEXT:    vorr d0, d8, d8
+; LE-NEXT:    bl llrint
+; LE-NEXT:    add lr, sp, #160
+; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    vorr d0, d9, d9
+; LE-NEXT:    ldr r0, [sp, #72] @ 4-byte Reload
 ; LE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-NEXT:    vorr d0, d11, d11
+; LE-NEXT:    mov r6, r1
+; LE-NEXT:    vmov.32 d10[1], r0
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    vmov.32 d15[0], r0
-; LE-NEXT:    add lr, sp, #160
-; LE-NEXT:    vorr d0, d10, d10
-; LE-NEXT:    ldr r0, [sp, #72] @ 4-byte Reload
-; LE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; LE-NEXT:    mov r6, r1
-; LE-NEXT:    vmov.32 d9[1], r0
-; LE-NEXT:    bl llrint
-; LE-NEXT:    vmov.32 d14[0], r0
 ; LE-NEXT:    ldr r0, [sp, #76] @ 4-byte Reload
 ; LE-NEXT:    add lr, sp, #160
 ; LE-NEXT:    mov r4, r1
-; LE-NEXT:    vmov.32 d8[1], r0
-; LE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; LE-NEXT:    vmov.32 d11[1], r0
+; LE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; LE-NEXT:    add lr, sp, #120
 ; LE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-NEXT:    vorr d0, d11, d11
-; LE-NEXT:    bl llrint
-; LE-NEXT:    vmov.32 d13[0], r0
-; LE-NEXT:    add lr, sp, #40
 ; LE-NEXT:    vorr d0, d10, d10
+; LE-NEXT:    bl llrint
+; LE-NEXT:    add lr, sp, #40
+; LE-NEXT:    vmov.32 d12[0], r0
+; LE-NEXT:    vorr d0, d11, d11
 ; LE-NEXT:    ldr r0, [sp, #116] @ 4-byte Reload
 ; LE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
 ; LE-NEXT:    mov r5, r1
-; LE-NEXT:    vmov.32 d9[1], r0
+; LE-NEXT:    vmov.32 d8[1], r0
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    add lr, sp, #144
 ; LE-NEXT:    mov r7, r1
-; LE-NEXT:    vmov.32 d12[0], r0
-; LE-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; LE-NEXT:    @ kill: def $d0 killed $d0 killed $q0
-; LE-NEXT:    vmov.32 d8[1], r10
+; LE-NEXT:    vmov.32 d13[0], r0
+; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-NEXT:    vorr d0, d17, d17
+; LE-NEXT:    vmov.32 d9[1], r9
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    add lr, sp, #8
-; LE-NEXT:    vmov.32 d15[1], r6
-; LE-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
+; LE-NEXT:    vmov.32 d14[1], r6
+; LE-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
 ; LE-NEXT:    add lr, sp, #24
+; LE-NEXT:    vmov.32 d19[0], r0
+; LE-NEXT:    vmov.32 d18[1], r8
+; LE-NEXT:    vorr q10, q9, q9
 ; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-NEXT:    add lr, sp, #160
-; LE-NEXT:    vmov.32 d20[0], r0
-; LE-NEXT:    vmov.32 d21[1], r8
-; LE-NEXT:    vmov.32 d20[1], r1
+; LE-NEXT:    vmov.32 d12[1], r5
+; LE-NEXT:    vmov.32 d21[1], r1
 ; LE-NEXT:    ldr r1, [sp, #140] @ 4-byte Reload
-; LE-NEXT:    vmov.32 d13[1], r5
+; LE-NEXT:    vmov.32 d15[1], r4
 ; LE-NEXT:    mov r0, r1
 ; LE-NEXT:    vst1.64 {d8, d9}, [r0:128]!
 ; LE-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
 ; LE-NEXT:    add lr, sp, #56
-; LE-NEXT:    vmov.32 d14[1], r4
+; LE-NEXT:    vmov.32 d13[1], r7
 ; LE-NEXT:    vst1.64 {d18, d19}, [r0:128]!
 ; LE-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
 ; LE-NEXT:    add lr, sp, #96
-; LE-NEXT:    vmov.32 d12[1], r7
+; LE-NEXT:    vmov.32 d16[1], r10
 ; LE-NEXT:    vst1.64 {d18, d19}, [r0:128]!
 ; LE-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
-; LE-NEXT:    vmov.32 d17[1], r9
+; LE-NEXT:    vmov.32 d17[1], r11
 ; LE-NEXT:    vst1.64 {d18, d19}, [r0:128]
 ; LE-NEXT:    add r0, r1, #64
 ; LE-NEXT:    vst1.64 {d14, d15}, [r0:128]!
 ; LE-NEXT:    vst1.64 {d12, d13}, [r0:128]!
-; LE-NEXT:    vmov.32 d16[1], r11
 ; LE-NEXT:    vst1.64 {d20, d21}, [r0:128]!
 ; LE-NEXT:    vst1.64 {d16, d17}, [r0:128]
 ; LE-NEXT:    add sp, sp, #176
@@ -1861,164 +1857,163 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; BE-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-NEXT:    .pad #168
 ; BE-NEXT:    sub sp, sp, #168
-; BE-NEXT:    add lr, sp, #64
-; BE-NEXT:    str r0, [sp, #132] @ 4-byte Spill
+; BE-NEXT:    add lr, sp, #24
+; BE-NEXT:    str r0, [sp, #148] @ 4-byte Spill
 ; BE-NEXT:    add r0, sp, #304
-; BE-NEXT:    vorr q4, q3, q3
+; BE-NEXT:    vorr q6, q2, q2
+; BE-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
+; BE-NEXT:    add lr, sp, #80
+; BE-NEXT:    vorr q7, q1, q1
 ; BE-NEXT:    vstmia lr, {d0, d1} @ 16-byte Spill
-; BE-NEXT:    add lr, sp, #48
-; BE-NEXT:    vorr d0, d1, d1
+; BE-NEXT:    add lr, sp, #64
+; BE-NEXT:    @ kill: def $d0 killed $d0 killed $q0
 ; BE-NEXT:    vld1.64 {d16, d17}, [r0]
 ; BE-NEXT:    add r0, sp, #320
-; BE-NEXT:    vorr q6, q2, q2
 ; BE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; BE-NEXT:    add lr, sp, #88
-; BE-NEXT:    vorr q7, q1, q1
+; BE-NEXT:    add lr, sp, #104
 ; BE-NEXT:    vld1.64 {d16, d17}, [r0]
 ; BE-NEXT:    add r0, sp, #272
 ; BE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; BE-NEXT:    add lr, sp, #112
+; BE-NEXT:    add lr, sp, #128
 ; BE-NEXT:    vld1.64 {d16, d17}, [r0]
 ; BE-NEXT:    add r0, sp, #288
 ; BE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; BE-NEXT:    add lr, sp, #24
+; BE-NEXT:    add lr, sp, #40
 ; BE-NEXT:    vld1.64 {d16, d17}, [r0]
 ; BE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d14, d14
-; BE-NEXT:    add lr, sp, #136
-; BE-NEXT:    vmov.32 d17[0], r0
-; BE-NEXT:    str r1, [sp, #108] @ 4-byte Spill
-; BE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; BE-NEXT:    bl llrint
 ; BE-NEXT:    vorr d0, d15, d15
-; BE-NEXT:    str r1, [sp, #84] @ 4-byte Spill
+; BE-NEXT:    str r1, [sp, #124] @ 4-byte Spill
 ; BE-NEXT:    vmov.32 d10[0], r0
 ; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d12, d12
-; BE-NEXT:    add lr, sp, #152
-; BE-NEXT:    vmov.32 d11[0], r0
-; BE-NEXT:    str r1, [sp, #44] @ 4-byte Spill
-; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; BE-NEXT:    vorr d0, d14, d14
+; BE-NEXT:    str r1, [sp, #100] @ 4-byte Spill
+; BE-NEXT:    vmov.32 d9[0], r0
 ; BE-NEXT:    bl llrint
 ; BE-NEXT:    vorr d0, d13, d13
-; BE-NEXT:    mov r6, r1
-; BE-NEXT:    vmov.32 d10[0], r0
-; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d8, d8
-; BE-NEXT:    mov r4, r1
-; BE-NEXT:    vmov.32 d11[0], r0
-; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d9, d9
-; BE-NEXT:    mov r7, r1
-; BE-NEXT:    vmov.32 d12[0], r0
-; BE-NEXT:    bl llrint
-; BE-NEXT:    add lr, sp, #64
-; BE-NEXT:    mov r5, r1
-; BE-NEXT:    vmov.32 d13[0], r0
-; BE-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; BE-NEXT:    @ kill: def $d0 killed $d0 killed $q0
-; BE-NEXT:    bl llrint
-; BE-NEXT:    add lr, sp, #136
-; BE-NEXT:    mov r9, r1
-; BE-NEXT:    vmov.32 d13[1], r5
-; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; BE-NEXT:    vmov.32 d16[0], r0
-; BE-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; BE-NEXT:    add lr, sp, #24
-; BE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; BE-NEXT:    vorr d0, d9, d9
-; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d8, d8
-; BE-NEXT:    vmov.32 d12[1], r7
-; BE-NEXT:    add lr, sp, #64
-; BE-NEXT:    mov r10, r1
-; BE-NEXT:    vmov.32 d15[0], r0
-; BE-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
-; BE-NEXT:    bl llrint
-; BE-NEXT:    vmov.32 d14[0], r0
-; BE-NEXT:    add lr, sp, #8
-; BE-NEXT:    mov r11, r1
-; BE-NEXT:    vmov.32 d11[1], r4
-; BE-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
-; BE-NEXT:    add lr, sp, #48
-; BE-NEXT:    vorr q6, q5, q5
-; BE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; BE-NEXT:    vorr d0, d9, d9
-; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d8, d8
-; BE-NEXT:    vmov.32 d12[1], r6
-; BE-NEXT:    add lr, sp, #24
-; BE-NEXT:    mov r8, r1
-; BE-NEXT:    vmov.32 d11[0], r0
-; BE-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
-; BE-NEXT:    bl llrint
-; BE-NEXT:    vmov.32 d10[0], r0
-; BE-NEXT:    add lr, sp, #48
-; BE-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
-; BE-NEXT:    mov r6, r1
-; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; BE-NEXT:    vmov.32 d8[0], r0
 ; BE-NEXT:    add lr, sp, #152
-; BE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; BE-NEXT:    add lr, sp, #88
-; BE-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
-; BE-NEXT:    vorr d0, d13, d13
-; BE-NEXT:    vmov.32 d9[1], r0
-; BE-NEXT:    bl llrint
-; BE-NEXT:    vmov.32 d15[0], r0
-; BE-NEXT:    ldr r0, [sp, #84] @ 4-byte Reload
-; BE-NEXT:    vorr d0, d12, d12
-; BE-NEXT:    add lr, sp, #152
-; BE-NEXT:    mov r4, r1
-; BE-NEXT:    vmov.32 d8[1], r0
+; BE-NEXT:    str r1, [sp, #60] @ 4-byte Spill
 ; BE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
 ; BE-NEXT:    bl llrint
-; BE-NEXT:    add lr, sp, #136
+; BE-NEXT:    vorr d0, d12, d12
+; BE-NEXT:    mov r6, r1
+; BE-NEXT:    vmov.32 d15[0], r0
+; BE-NEXT:    bl llrint
+; BE-NEXT:    add lr, sp, #24
+; BE-NEXT:    mov r4, r1
 ; BE-NEXT:    vmov.32 d14[0], r0
-; BE-NEXT:    ldr r0, [sp, #108] @ 4-byte Reload
-; BE-NEXT:    mov r5, r1
-; BE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; BE-NEXT:    add lr, sp, #112
 ; BE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
 ; BE-NEXT:    vorr d0, d9, d9
-; BE-NEXT:    vmov.32 d11[1], r0
 ; BE-NEXT:    bl llrint
 ; BE-NEXT:    vorr d0, d8, d8
 ; BE-NEXT:    mov r7, r1
 ; BE-NEXT:    vmov.32 d13[0], r0
-; BE-NEXT:    vmov.32 d10[1], r9
 ; BE-NEXT:    bl llrint
-; BE-NEXT:    add lr, sp, #8
+; BE-NEXT:    add lr, sp, #80
+; BE-NEXT:    mov r5, r1
 ; BE-NEXT:    vmov.32 d12[0], r0
 ; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; BE-NEXT:    add lr, sp, #48
-; BE-NEXT:    vmov.32 d17[1], r10
-; BE-NEXT:    vmov.32 d16[1], r11
+; BE-NEXT:    vorr d0, d17, d17
+; BE-NEXT:    bl llrint
+; BE-NEXT:    add lr, sp, #24
+; BE-NEXT:    vmov.32 d11[0], r0
+; BE-NEXT:    mov r9, r1
+; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; BE-NEXT:    add lr, sp, #40
+; BE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
+; BE-NEXT:    vorr d0, d8, d8
+; BE-NEXT:    vmov.32 d12[1], r5
+; BE-NEXT:    bl llrint
+; BE-NEXT:    vorr d0, d9, d9
+; BE-NEXT:    add lr, sp, #80
+; BE-NEXT:    vmov.32 d13[1], r7
+; BE-NEXT:    mov r10, r1
+; BE-NEXT:    vmov.32 d10[0], r0
+; BE-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
+; BE-NEXT:    bl llrint
+; BE-NEXT:    add lr, sp, #8
+; BE-NEXT:    vmov.32 d11[0], r0
+; BE-NEXT:    mov r11, r1
+; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; BE-NEXT:    add lr, sp, #64
+; BE-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
+; BE-NEXT:    vorr d0, d12, d12
+; BE-NEXT:    vmov.32 d14[1], r4
+; BE-NEXT:    bl llrint
+; BE-NEXT:    vorr d0, d13, d13
+; BE-NEXT:    add lr, sp, #40
+; BE-NEXT:    vmov.32 d15[1], r6
+; BE-NEXT:    mov r8, r1
+; BE-NEXT:    vmov.32 d8[0], r0
+; BE-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; BE-NEXT:    bl llrint
+; BE-NEXT:    add lr, sp, #64
+; BE-NEXT:    vmov.32 d9[0], r0
+; BE-NEXT:    ldr r0, [sp, #60] @ 4-byte Reload
+; BE-NEXT:    mov r6, r1
+; BE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; BE-NEXT:    add lr, sp, #152
+; BE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
+; BE-NEXT:    add lr, sp, #104
+; BE-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
+; BE-NEXT:    vorr d0, d12, d12
+; BE-NEXT:    vmov.32 d8[1], r0
+; BE-NEXT:    bl llrint
+; BE-NEXT:    vmov.32 d14[0], r0
+; BE-NEXT:    ldr r0, [sp, #100] @ 4-byte Reload
+; BE-NEXT:    vorr d0, d13, d13
+; BE-NEXT:    add lr, sp, #152
+; BE-NEXT:    mov r4, r1
+; BE-NEXT:    vmov.32 d9[1], r0
+; BE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; BE-NEXT:    bl llrint
+; BE-NEXT:    add lr, sp, #24
+; BE-NEXT:    vmov.32 d15[0], r0
+; BE-NEXT:    ldr r0, [sp, #124] @ 4-byte Reload
+; BE-NEXT:    mov r5, r1
+; BE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
+; BE-NEXT:    add lr, sp, #128
+; BE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
+; BE-NEXT:    vorr d0, d10, d10
+; BE-NEXT:    vmov.32 d8[1], r0
+; BE-NEXT:    bl llrint
+; BE-NEXT:    vorr d0, d11, d11
+; BE-NEXT:    mov r7, r1
+; BE-NEXT:    vmov.32 d12[0], r0
+; BE-NEXT:    vmov.32 d9[1], r9
+; BE-NEXT:    bl llrint
+; BE-NEXT:    add lr, sp, #8
+; BE-NEXT:    vmov.32 d13[0], r0
+; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; BE-NEXT:    add lr, sp, #64
+; BE-NEXT:    vmov.32 d12[1], r7
+; BE-NEXT:    vmov.32 d16[1], r10
+; BE-NEXT:    vmov.32 d17[1], r11
 ; BE-NEXT:    vorr q12, q8, q8
 ; BE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-NEXT:    add lr, sp, #152
-; BE-NEXT:    vmov.32 d17[1], r8
-; BE-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
-; BE-NEXT:    add lr, sp, #24
-; BE-NEXT:    vmov.32 d13[1], r7
-; BE-NEXT:    vmov.32 d16[1], r6
-; BE-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
-; BE-NEXT:    add lr, sp, #64
-; BE-NEXT:    vorr q13, q8, q8
-; BE-NEXT:    vmov.32 d12[1], r1
-; BE-NEXT:    ldr r1, [sp, #132] @ 4-byte Reload
-; BE-NEXT:    vrev64.32 q8, q5
+; BE-NEXT:    vmov.32 d13[1], r1
+; BE-NEXT:    ldr r1, [sp, #148] @ 4-byte Reload
+; BE-NEXT:    vmov.32 d16[1], r8
 ; BE-NEXT:    mov r0, r1
+; BE-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
+; BE-NEXT:    add lr, sp, #40
+; BE-NEXT:    vmov.32 d17[1], r6
+; BE-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
+; BE-NEXT:    add lr, sp, #80
+; BE-NEXT:    vorr q13, q8, q8
+; BE-NEXT:    vrev64.32 q8, q4
 ; BE-NEXT:    vldmia lr, {d22, d23} @ 16-byte Reload
 ; BE-NEXT:    vrev64.32 q9, q9
 ; BE-NEXT:    vrev64.32 q10, q10
 ; BE-NEXT:    vst1.64 {d16, d17}, [r0:128]!
 ; BE-NEXT:    vst1.64 {d18, d19}, [r0:128]!
 ; BE-NEXT:    vrev64.32 q11, q11
-; BE-NEXT:    vmov.32 d15[1], r4
+; BE-NEXT:    vmov.32 d14[1], r4
 ; BE-NEXT:    vst1.64 {d20, d21}, [r0:128]!
 ; BE-NEXT:    vrev64.32 q15, q6
-; BE-NEXT:    vmov.32 d14[1], r5
+; BE-NEXT:    vmov.32 d15[1], r5
 ; BE-NEXT:    vrev64.32 q12, q12
 ; BE-NEXT:    vst1.64 {d22, d23}, [r0:128]
 ; BE-NEXT:    add r0, r1, #64
@@ -2064,58 +2059,46 @@ declare <1 x i64> @llvm.llrint.v1i64.v1f128(<1 x fp128>)
 define <2 x i64> @llrint_v2i64_v2f128(<2 x fp128> %x) {
 ; LE-LABEL: llrint_v2i64_v2f128:
 ; LE:       @ %bb.0:
-; LE-NEXT:    .save {r4, r5, r6, r7, r8, lr}
-; LE-NEXT:    push {r4, r5, r6, r7, r8, lr}
+; LE-NEXT:    .save {r4, lr}
+; LE-NEXT:    push {r4, lr}
 ; LE-NEXT:    .vsave {d8, d9}
 ; LE-NEXT:    vpush {d8, d9}
-; LE-NEXT:    mov r8, r3
-; LE-NEXT:    add r3, sp, #40
-; LE-NEXT:    mov r5, r2
-; LE-NEXT:    mov r6, r1
-; LE-NEXT:    mov r7, r0
-; LE-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-NEXT:    bl llrintl
+; LE-NEXT:    ldr r12, [sp, #24]
+; LE-NEXT:    add r3, sp, #28
 ; LE-NEXT:    mov r4, r1
-; LE-NEXT:    vmov.32 d9[0], r0
-; LE-NEXT:    mov r0, r7
-; LE-NEXT:    mov r1, r6
-; LE-NEXT:    mov r2, r5
-; LE-NEXT:    mov r3, r8
-; LE-NEXT:    bl llrintl
 ; LE-NEXT:    vmov.32 d8[0], r0
-; LE-NEXT:    vmov.32 d9[1], r4
-; LE-NEXT:    vmov.32 d8[1], r1
+; LE-NEXT:    ldm r3, {r1, r2, r3}
+; LE-NEXT:    mov r0, r12
+; LE-NEXT:    bl llrintl
+; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    vmov.32 d8[1], r4
+; LE-NEXT:    vmov.32 d9[1], r1
 ; LE-NEXT:    vorr q0, q4, q4
 ; LE-NEXT:    vpop {d8, d9}
-; LE-NEXT:    pop {r4, r5, r6, r7, r8, pc}
+; LE-NEXT:    pop {r4, pc}
 ;
 ; BE-LABEL: llrint_v2i64_v2f128:
 ; BE:       @ %bb.0:
-; BE-NEXT:    .save {r4, r5, r6, r7, r8, lr}
-; BE-NEXT:    push {r4, r5, r6, r7, r8, lr}
+; BE-NEXT:    .save {r4, lr}
+; BE-NEXT:    push {r4, lr}
 ; BE-NEXT:    .vsave {d8}
 ; BE-NEXT:    vpush {d8}
-; BE-NEXT:    mov r8, r3
-; BE-NEXT:    add r3, sp, #32
-; BE-NEXT:    mov r5, r2
-; BE-NEXT:    mov r6, r1
-; BE-NEXT:    mov r7, r0
-; BE-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-NEXT:    bl llrintl
+; BE-NEXT:    ldr r12, [sp, #16]
+; BE-NEXT:    add r3, sp, #20
 ; BE-NEXT:    mov r4, r1
 ; BE-NEXT:    vmov.32 d8[0], r0
-; BE-NEXT:    mov r0, r7
-; BE-NEXT:    mov r1, r6
-; BE-NEXT:    mov r2, r5
-; BE-NEXT:    mov r3, r8
+; BE-NEXT:    ldm r3, {r1, r2, r3}
+; BE-NEXT:    mov r0, r12
 ; BE-NEXT:    bl llrintl
 ; BE-NEXT:    vmov.32 d16[0], r0
 ; BE-NEXT:    vmov.32 d8[1], r4
 ; BE-NEXT:    vmov.32 d16[1], r1
-; BE-NEXT:    vrev64.32 d1, d8
-; BE-NEXT:    vrev64.32 d0, d16
+; BE-NEXT:    vrev64.32 d0, d8
+; BE-NEXT:    vrev64.32 d1, d16
 ; BE-NEXT:    vpop {d8}
-; BE-NEXT:    pop {r4, r5, r6, r7, r8, pc}
+; BE-NEXT:    pop {r4, pc}
   %a = call <2 x i64> @llvm.llrint.v2i64.v2f128(<2 x fp128> %x)
   ret <2 x i64> %a
 }
@@ -2128,39 +2111,39 @@ define <4 x i64> @llrint_v4i64_v4f128(<4 x fp128> %x) {
 ; LE-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; LE-NEXT:    .vsave {d8, d9, d10, d11}
 ; LE-NEXT:    vpush {d8, d9, d10, d11}
-; LE-NEXT:    mov r5, r3
-; LE-NEXT:    add r3, sp, #96
-; LE-NEXT:    mov r7, r2
-; LE-NEXT:    mov r6, r1
+; LE-NEXT:    mov r9, r3
+; LE-NEXT:    add r3, sp, #80
+; LE-NEXT:    mov r6, r2
+; LE-NEXT:    mov r7, r1
 ; LE-NEXT:    mov r4, r0
 ; LE-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-NEXT:    bl llrintl
-; LE-NEXT:    mov r9, r1
-; LE-NEXT:    vmov.32 d9[0], r0
-; LE-NEXT:    mov r0, r4
-; LE-NEXT:    mov r1, r6
-; LE-NEXT:    mov r2, r7
-; LE-NEXT:    mov r3, r5
-; LE-NEXT:    ldr r8, [sp, #80]
-; LE-NEXT:    ldr r10, [sp, #64]
-; LE-NEXT:    bl llrintl
+; LE-NEXT:    ldr r5, [sp, #64]
 ; LE-NEXT:    add r3, sp, #68
+; LE-NEXT:    mov r8, r1
+; LE-NEXT:    vmov.32 d8[0], r0
+; LE-NEXT:    ldm r3, {r1, r2, r3}
+; LE-NEXT:    mov r0, r5
+; LE-NEXT:    bl llrintl
 ; LE-NEXT:    mov r5, r1
+; LE-NEXT:    vmov.32 d11[0], r0
+; LE-NEXT:    mov r0, r4
+; LE-NEXT:    mov r1, r7
+; LE-NEXT:    mov r2, r6
+; LE-NEXT:    mov r3, r9
+; LE-NEXT:    ldr r10, [sp, #96]
+; LE-NEXT:    bl llrintl
+; LE-NEXT:    add r3, sp, #100
+; LE-NEXT:    mov r4, r1
 ; LE-NEXT:    vmov.32 d10[0], r0
 ; LE-NEXT:    mov r0, r10
 ; LE-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-NEXT:    bl llrintl
-; LE-NEXT:    add r3, sp, #84
-; LE-NEXT:    mov r4, r1
-; LE-NEXT:    vmov.32 d11[0], r0
-; LE-NEXT:    mov r0, r8
-; LE-NEXT:    ldm r3, {r1, r2, r3}
-; LE-NEXT:    bl llrintl
-; LE-NEXT:    vmov.32 d8[0], r0
-; LE-NEXT:    vmov.32 d11[1], r4
-; LE-NEXT:    vmov.32 d9[1], r9
-; LE-NEXT:    vmov.32 d10[1], r5
-; LE-NEXT:    vmov.32 d8[1], r1
+; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    vmov.32 d10[1], r4
+; LE-NEXT:    vmov.32 d8[1], r8
+; LE-NEXT:    vmov.32 d11[1], r5
+; LE-NEXT:    vmov.32 d9[1], r1
 ; LE-NEXT:    vorr q0, q5, q5
 ; LE-NEXT:    vorr q1, q4, q4
 ; LE-NEXT:    vpop {d8, d9, d10, d11}
@@ -2172,43 +2155,43 @@ define <4 x i64> @llrint_v4i64_v4f128(<4 x fp128> %x) {
 ; BE-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; BE-NEXT:    .vsave {d8, d9, d10}
 ; BE-NEXT:    vpush {d8, d9, d10}
-; BE-NEXT:    mov r5, r3
-; BE-NEXT:    add r3, sp, #88
-; BE-NEXT:    mov r7, r2
-; BE-NEXT:    mov r6, r1
+; BE-NEXT:    mov r9, r3
+; BE-NEXT:    add r3, sp, #72
+; BE-NEXT:    mov r6, r2
+; BE-NEXT:    mov r7, r1
 ; BE-NEXT:    mov r4, r0
 ; BE-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-NEXT:    bl llrintl
-; BE-NEXT:    mov r9, r1
-; BE-NEXT:    vmov.32 d8[0], r0
-; BE-NEXT:    mov r0, r4
-; BE-NEXT:    mov r1, r6
-; BE-NEXT:    mov r2, r7
-; BE-NEXT:    mov r3, r5
-; BE-NEXT:    ldr r8, [sp, #72]
-; BE-NEXT:    ldr r10, [sp, #56]
-; BE-NEXT:    bl llrintl
+; BE-NEXT:    ldr r5, [sp, #56]
 ; BE-NEXT:    add r3, sp, #60
+; BE-NEXT:    mov r8, r1
+; BE-NEXT:    vmov.32 d8[0], r0
+; BE-NEXT:    ldm r3, {r1, r2, r3}
+; BE-NEXT:    mov r0, r5
+; BE-NEXT:    bl llrintl
 ; BE-NEXT:    mov r5, r1
 ; BE-NEXT:    vmov.32 d9[0], r0
-; BE-NEXT:    mov r0, r10
-; BE-NEXT:    ldm r3, {r1, r2, r3}
+; BE-NEXT:    mov r0, r4
+; BE-NEXT:    mov r1, r7
+; BE-NEXT:    mov r2, r6
+; BE-NEXT:    mov r3, r9
+; BE-NEXT:    ldr r10, [sp, #88]
 ; BE-NEXT:    bl llrintl
-; BE-NEXT:    add r3, sp, #76
+; BE-NEXT:    add r3, sp, #92
 ; BE-NEXT:    mov r4, r1
 ; BE-NEXT:    vmov.32 d10[0], r0
-; BE-NEXT:    mov r0, r8
+; BE-NEXT:    mov r0, r10
 ; BE-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-NEXT:    bl llrintl
 ; BE-NEXT:    vmov.32 d16[0], r0
 ; BE-NEXT:    vmov.32 d10[1], r4
-; BE-NEXT:    vmov.32 d8[1], r9
+; BE-NEXT:    vmov.32 d8[1], r8
 ; BE-NEXT:    vmov.32 d9[1], r5
 ; BE-NEXT:    vmov.32 d16[1], r1
-; BE-NEXT:    vrev64.32 d1, d10
-; BE-NEXT:    vrev64.32 d3, d8
-; BE-NEXT:    vrev64.32 d0, d9
-; BE-NEXT:    vrev64.32 d2, d16
+; BE-NEXT:    vrev64.32 d0, d10
+; BE-NEXT:    vrev64.32 d2, d8
+; BE-NEXT:    vrev64.32 d1, d9
+; BE-NEXT:    vrev64.32 d3, d16
 ; BE-NEXT:    vpop {d8, d9, d10}
 ; BE-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
   %a = call <4 x i64> @llvm.llrint.v4i64.v4f128(<4 x fp128> %x)
@@ -2225,78 +2208,77 @@ define <8 x i64> @llrint_v8i64_v8f128(<8 x fp128> %x) {
 ; LE-NEXT:    sub sp, sp, #4
 ; LE-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; LE-NEXT:    .pad #8
-; LE-NEXT:    sub sp, sp, #8
-; LE-NEXT:    mov r11, r3
-; LE-NEXT:    add r3, sp, #208
-; LE-NEXT:    mov r10, r2
-; LE-NEXT:    mov r4, r1
+; LE-NEXT:    .pad #16
+; LE-NEXT:    sub sp, sp, #16
+; LE-NEXT:    stmib sp, {r2, r3} @ 8-byte Folded Spill
+; LE-NEXT:    add r3, sp, #200
+; LE-NEXT:    mov r7, r1
 ; LE-NEXT:    mov r5, r0
 ; LE-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-NEXT:    bl llrintl
-; LE-NEXT:    add r7, sp, #164
-; LE-NEXT:    ldr r6, [sp, #160]
-; LE-NEXT:    str r1, [sp, #4] @ 4-byte Spill
-; LE-NEXT:    vmov.32 d9[0], r0
-; LE-NEXT:    ldm r7, {r1, r2, r3, r7}
-; LE-NEXT:    mov r0, r6
-; LE-NEXT:    ldr r8, [sp, #128]
-; LE-NEXT:    ldr r9, [sp, #144]
+; LE-NEXT:    ldr r4, [sp, #184]
+; LE-NEXT:    add r3, sp, #188
+; LE-NEXT:    str r1, [sp, #12] @ 4-byte Spill
+; LE-NEXT:    vmov.32 d8[0], r0
+; LE-NEXT:    ldm r3, {r1, r2, r3}
+; LE-NEXT:    mov r0, r4
+; LE-NEXT:    ldr r6, [sp, #168]
+; LE-NEXT:    ldr r8, [sp, #152]
+; LE-NEXT:    ldr r10, [sp, #136]
+; LE-NEXT:    ldr r9, [sp, #120]
 ; LE-NEXT:    bl llrintl
-; LE-NEXT:    add r3, sp, #180
-; LE-NEXT:    str r1, [sp] @ 4-byte Spill
-; LE-NEXT:    vmov.32 d10[0], r0
-; LE-NEXT:    mov r0, r7
+; LE-NEXT:    add r3, sp, #172
+; LE-NEXT:    mov r11, r1
+; LE-NEXT:    vmov.32 d11[0], r0
+; LE-NEXT:    mov r0, r6
 ; LE-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-NEXT:    bl llrintl
-; LE-NEXT:    add r3, sp, #132
-; LE-NEXT:    mov r7, r1
-; LE-NEXT:    vmov.32 d11[0], r0
+; LE-NEXT:    add r3, sp, #156
+; LE-NEXT:    mov r6, r1
+; LE-NEXT:    vmov.32 d10[0], r0
 ; LE-NEXT:    mov r0, r8
 ; LE-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-NEXT:    bl llrintl
-; LE-NEXT:    add r3, sp, #148
+; LE-NEXT:    add r3, sp, #140
+; LE-NEXT:    mov r4, r1
+; LE-NEXT:    vmov.32 d13[0], r0
+; LE-NEXT:    mov r0, r10
+; LE-NEXT:    ldm r3, {r1, r2, r3}
+; LE-NEXT:    bl llrintl
+; LE-NEXT:    add r3, sp, #124
 ; LE-NEXT:    mov r8, r1
 ; LE-NEXT:    vmov.32 d12[0], r0
 ; LE-NEXT:    mov r0, r9
 ; LE-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-NEXT:    bl llrintl
 ; LE-NEXT:    mov r9, r1
-; LE-NEXT:    vmov.32 d13[0], r0
-; LE-NEXT:    mov r0, r5
-; LE-NEXT:    mov r1, r4
-; LE-NEXT:    mov r2, r10
-; LE-NEXT:    mov r3, r11
-; LE-NEXT:    ldr r6, [sp, #112]
-; LE-NEXT:    bl llrintl
-; LE-NEXT:    add r3, sp, #116
-; LE-NEXT:    mov r4, r1
-; LE-NEXT:    vmov.32 d14[0], r0
-; LE-NEXT:    mov r0, r6
-; LE-NEXT:    ldm r3, {r1, r2, r3}
-; LE-NEXT:    bl llrintl
-; LE-NEXT:    add r3, sp, #196
 ; LE-NEXT:    vmov.32 d15[0], r0
-; LE-NEXT:    ldr r0, [sp, #192]
+; LE-NEXT:    mov r0, r5
+; LE-NEXT:    mov r1, r7
+; LE-NEXT:    ldmib sp, {r2, r3} @ 8-byte Folded Reload
+; LE-NEXT:    ldr r10, [sp, #216]
+; LE-NEXT:    bl llrintl
+; LE-NEXT:    add r3, sp, #220
 ; LE-NEXT:    mov r5, r1
+; LE-NEXT:    vmov.32 d14[0], r0
+; LE-NEXT:    mov r0, r10
 ; LE-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-NEXT:    bl llrintl
-; LE-NEXT:    vmov.32 d8[0], r0
-; LE-NEXT:    ldr r0, [sp] @ 4-byte Reload
-; LE-NEXT:    vmov.32 d11[1], r7
-; LE-NEXT:    vmov.32 d10[1], r0
-; LE-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
-; LE-NEXT:    vmov.32 d15[1], r5
-; LE-NEXT:    vorr q2, q5, q5
-; LE-NEXT:    vmov.32 d13[1], r9
-; LE-NEXT:    vmov.32 d9[1], r0
-; LE-NEXT:    vmov.32 d14[1], r4
+; LE-NEXT:    vmov.32 d9[0], r0
+; LE-NEXT:    ldr r0, [sp, #12] @ 4-byte Reload
+; LE-NEXT:    vmov.32 d14[1], r5
 ; LE-NEXT:    vmov.32 d12[1], r8
+; LE-NEXT:    vmov.32 d10[1], r6
+; LE-NEXT:    vmov.32 d8[1], r0
+; LE-NEXT:    vmov.32 d15[1], r9
+; LE-NEXT:    vmov.32 d13[1], r4
 ; LE-NEXT:    vorr q0, q7, q7
-; LE-NEXT:    vmov.32 d8[1], r1
+; LE-NEXT:    vmov.32 d11[1], r11
 ; LE-NEXT:    vorr q1, q6, q6
+; LE-NEXT:    vmov.32 d9[1], r1
+; LE-NEXT:    vorr q2, q5, q5
 ; LE-NEXT:    vorr q3, q4, q4
-; LE-NEXT:    add sp, sp, #8
+; LE-NEXT:    add sp, sp, #16
 ; LE-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-NEXT:    add sp, sp, #4
 ; LE-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
@@ -2311,24 +2293,25 @@ define <8 x i64> @llrint_v8i64_v8f128(<8 x fp128> %x) {
 ; BE-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
 ; BE-NEXT:    .pad #16
 ; BE-NEXT:    sub sp, sp, #16
-; BE-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; BE-NEXT:    add r3, sp, #208
-; BE-NEXT:    mov r11, r2
-; BE-NEXT:    mov r4, r1
+; BE-NEXT:    stmib sp, {r2, r3} @ 8-byte Folded Spill
+; BE-NEXT:    add r3, sp, #192
+; BE-NEXT:    mov r7, r1
 ; BE-NEXT:    mov r5, r0
 ; BE-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-NEXT:    bl llrintl
-; BE-NEXT:    ldr r7, [sp, #176]
+; BE-NEXT:    ldr r4, [sp, #176]
 ; BE-NEXT:    add r3, sp, #180
 ; BE-NEXT:    str r1, [sp, #12] @ 4-byte Spill
 ; BE-NEXT:    vmov.32 d8[0], r0
 ; BE-NEXT:    ldm r3, {r1, r2, r3}
-; BE-NEXT:    mov r0, r7
-; BE-NEXT:    ldr r6, [sp, #128]
+; BE-NEXT:    mov r0, r4
+; BE-NEXT:    ldr r6, [sp, #160]
 ; BE-NEXT:    ldr r8, [sp, #144]
+; BE-NEXT:    ldr r10, [sp, #128]
+; BE-NEXT:    ldr r9, [sp, #112]
 ; BE-NEXT:    bl llrintl
-; BE-NEXT:    add r3, sp, #132
-; BE-NEXT:    str r1, [sp, #8] @ 4-byte Spill
+; BE-NEXT:    add r3, sp, #164
+; BE-NEXT:    mov r11, r1
 ; BE-NEXT:    vmov.32 d9[0], r0
 ; BE-NEXT:    mov r0, r6
 ; BE-NEXT:    ldm r3, {r1, r2, r3}
@@ -2339,51 +2322,49 @@ define <8 x i64> @llrint_v8i64_v8f128(<8 x fp128> %x) {
 ; BE-NEXT:    mov r0, r8
 ; BE-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-NEXT:    bl llrintl
-; BE-NEXT:    add r3, sp, #160
-; BE-NEXT:    mov r9, r0
-; BE-NEXT:    mov r7, r1
-; BE-NEXT:    ldm r3, {r0, r1, r2, r3}
-; BE-NEXT:    bl llrintl
-; BE-NEXT:    ldr r3, [sp, #4] @ 4-byte Reload
-; BE-NEXT:    mov r8, r1
-; BE-NEXT:    vmov.32 d11[0], r0
-; BE-NEXT:    mov r0, r5
-; BE-NEXT:    mov r1, r4
-; BE-NEXT:    mov r2, r11
-; BE-NEXT:    ldr r10, [sp, #112]
-; BE-NEXT:    vmov.32 d12[0], r9
-; BE-NEXT:    bl llrintl
-; BE-NEXT:    add r3, sp, #116
+; BE-NEXT:    add r3, sp, #132
 ; BE-NEXT:    mov r4, r1
-; BE-NEXT:    vmov.32 d13[0], r0
+; BE-NEXT:    vmov.32 d11[0], r0
 ; BE-NEXT:    mov r0, r10
 ; BE-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-NEXT:    bl llrintl
-; BE-NEXT:    add r3, sp, #196
-; BE-NEXT:    vmov.32 d14[0], r0
-; BE-NEXT:    ldr r0, [sp, #192]
+; BE-NEXT:    add r3, sp, #116
+; BE-NEXT:    mov r8, r1
+; BE-NEXT:    vmov.32 d12[0], r0
+; BE-NEXT:    mov r0, r9
+; BE-NEXT:    ldm r3, {r1, r2, r3}
+; BE-NEXT:    bl llrintl
+; BE-NEXT:    mov r9, r1
+; BE-NEXT:    vmov.32 d13[0], r0
+; BE-NEXT:    mov r0, r5
+; BE-NEXT:    mov r1, r7
+; BE-NEXT:    ldmib sp, {r2, r3} @ 8-byte Folded Reload
+; BE-NEXT:    ldr r10, [sp, #208]
+; BE-NEXT:    bl llrintl
+; BE-NEXT:    add r3, sp, #212
 ; BE-NEXT:    mov r5, r1
+; BE-NEXT:    vmov.32 d14[0], r0
+; BE-NEXT:    mov r0, r10
 ; BE-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-NEXT:    bl llrintl
 ; BE-NEXT:    vmov.32 d16[0], r0
-; BE-NEXT:    ldr r0, [sp, #8] @ 4-byte Reload
-; BE-NEXT:    vmov.32 d14[1], r5
-; BE-NEXT:    vmov.32 d9[1], r0
 ; BE-NEXT:    ldr r0, [sp, #12] @ 4-byte Reload
-; BE-NEXT:    vmov.32 d12[1], r7
-; BE-NEXT:    vmov.32 d8[1], r0
-; BE-NEXT:    vmov.32 d13[1], r4
+; BE-NEXT:    vmov.32 d14[1], r5
+; BE-NEXT:    vmov.32 d12[1], r8
 ; BE-NEXT:    vmov.32 d10[1], r6
-; BE-NEXT:    vmov.32 d11[1], r8
+; BE-NEXT:    vmov.32 d8[1], r0
+; BE-NEXT:    vmov.32 d13[1], r9
+; BE-NEXT:    vmov.32 d11[1], r4
+; BE-NEXT:    vmov.32 d9[1], r11
 ; BE-NEXT:    vmov.32 d16[1], r1
-; BE-NEXT:    vrev64.32 d1, d14
-; BE-NEXT:    vrev64.32 d3, d12
+; BE-NEXT:    vrev64.32 d0, d14
+; BE-NEXT:    vrev64.32 d2, d12
+; BE-NEXT:    vrev64.32 d4, d10
+; BE-NEXT:    vrev64.32 d6, d8
+; BE-NEXT:    vrev64.32 d1, d13
+; BE-NEXT:    vrev64.32 d3, d11
 ; BE-NEXT:    vrev64.32 d5, d9
-; BE-NEXT:    vrev64.32 d7, d8
-; BE-NEXT:    vrev64.32 d0, d13
-; BE-NEXT:    vrev64.32 d2, d10
-; BE-NEXT:    vrev64.32 d4, d11
-; BE-NEXT:    vrev64.32 d6, d16
+; BE-NEXT:    vrev64.32 d7, d16
 ; BE-NEXT:    add sp, sp, #16
 ; BE-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
 ; BE-NEXT:    add sp, sp, #4

--- a/llvm/test/CodeGen/ARM/vector-lrint.ll
+++ b/llvm/test/CodeGen/ARM/vector-lrint.ll
@@ -91,8 +91,8 @@ define <2 x iXLen> @lrint_v2f16(<2 x half> %x) {
 ; LE-I64-NEXT:    push {r4, r5, r11, lr}
 ; LE-I64-NEXT:    .vsave {d8, d9}
 ; LE-I64-NEXT:    vpush {d8, d9}
-; LE-I64-NEXT:    vmov r0, s1
-; LE-I64-NEXT:    vmov.f32 s16, s0
+; LE-I64-NEXT:    vmov r0, s0
+; LE-I64-NEXT:    vmov.f32 s16, s1
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
 ; LE-I64-NEXT:    bl lrintf
@@ -101,11 +101,11 @@ define <2 x iXLen> @lrint_v2f16(<2 x half> %x) {
 ; LE-I64-NEXT:    mov r5, r1
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
-; LE-I64-NEXT:    vmov.32 d9[0], r4
+; LE-I64-NEXT:    vmov.32 d8[0], r4
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    vmov.32 d9[1], r5
-; LE-I64-NEXT:    vmov.32 d8[1], r1
+; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    vmov.32 d8[1], r5
+; LE-I64-NEXT:    vmov.32 d9[1], r1
 ; LE-I64-NEXT:    vorr q0, q4, q4
 ; LE-I64-NEXT:    vpop {d8, d9}
 ; LE-I64-NEXT:    pop {r4, r5, r11, pc}
@@ -138,8 +138,8 @@ define <2 x iXLen> @lrint_v2f16(<2 x half> %x) {
 ; BE-I64-NEXT:    push {r4, r5, r11, lr}
 ; BE-I64-NEXT:    .vsave {d8}
 ; BE-I64-NEXT:    vpush {d8}
-; BE-I64-NEXT:    vmov r0, s1
-; BE-I64-NEXT:    vmov.f32 s16, s0
+; BE-I64-NEXT:    vmov r0, s0
+; BE-I64-NEXT:    vmov.f32 s16, s1
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    vmov s0, r0
 ; BE-I64-NEXT:    bl lrintf
@@ -153,8 +153,8 @@ define <2 x iXLen> @lrint_v2f16(<2 x half> %x) {
 ; BE-I64-NEXT:    vmov.32 d16[0], r0
 ; BE-I64-NEXT:    vmov.32 d8[1], r5
 ; BE-I64-NEXT:    vmov.32 d16[1], r1
-; BE-I64-NEXT:    vrev64.32 d1, d8
-; BE-I64-NEXT:    vrev64.32 d0, d16
+; BE-I64-NEXT:    vrev64.32 d0, d8
+; BE-I64-NEXT:    vrev64.32 d1, d16
 ; BE-I64-NEXT:    vpop {d8}
 ; BE-I64-NEXT:    pop {r4, r5, r11, pc}
   %a = call <2 x iXLen> @llvm.lrint.v2iXLen.v2f16(<2 x half> %x)
@@ -168,31 +168,31 @@ define <4 x iXLen> @lrint_v4f16(<4 x half> %x) {
 ; LE-I32-NEXT:    push {r4, r5, r11, lr}
 ; LE-I32-NEXT:    .vsave {d8, d9, d10, d11}
 ; LE-I32-NEXT:    vpush {d8, d9, d10, d11}
-; LE-I32-NEXT:    vmov r0, s3
-; LE-I32-NEXT:    vmov.f32 s16, s2
-; LE-I32-NEXT:    vmov.f32 s18, s1
+; LE-I32-NEXT:    vmov r0, s1
+; LE-I32-NEXT:    vmov.f32 s16, s3
+; LE-I32-NEXT:    vmov.f32 s18, s2
 ; LE-I32-NEXT:    vmov.f32 s20, s0
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    mov r4, r0
-; LE-I32-NEXT:    vmov r0, s16
+; LE-I32-NEXT:    vmov r0, s20
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    mov r5, r0
-; LE-I32-NEXT:    vmov r0, s20
+; LE-I32-NEXT:    vmov r0, s18
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov s0, r5
-; LE-I32-NEXT:    vmov.32 d10[0], r0
-; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov.32 d11[0], r0
-; LE-I32-NEXT:    vmov r0, s18
+; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov.32 d10[0], r0
+; LE-I32-NEXT:    vmov r0, s16
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
-; LE-I32-NEXT:    vmov.32 d11[1], r4
+; LE-I32-NEXT:    vmov.32 d10[1], r4
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.32 d10[1], r0
+; LE-I32-NEXT:    vmov.32 d11[1], r0
 ; LE-I32-NEXT:    vorr q0, q5, q5
 ; LE-I32-NEXT:    vpop {d8, d9, d10, d11}
 ; LE-I32-NEXT:    pop {r4, r5, r11, pc}
@@ -201,46 +201,43 @@ define <4 x iXLen> @lrint_v4f16(<4 x half> %x) {
 ; LE-I64:       @ %bb.0:
 ; LE-I64-NEXT:    .save {r4, r5, r6, r7, r11, lr}
 ; LE-I64-NEXT:    push {r4, r5, r6, r7, r11, lr}
-; LE-I64-NEXT:    .vsave {d12, d13}
-; LE-I64-NEXT:    vpush {d12, d13}
-; LE-I64-NEXT:    .vsave {d8, d9, d10}
-; LE-I64-NEXT:    vpush {d8, d9, d10}
-; LE-I64-NEXT:    vmov r0, s1
+; LE-I64-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
+; LE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
+; LE-I64-NEXT:    vmov r0, s0
 ; LE-I64-NEXT:    vmov.f32 s16, s3
-; LE-I64-NEXT:    vmov.f32 s20, s2
-; LE-I64-NEXT:    vmov.f32 s18, s0
+; LE-I64-NEXT:    vmov.f32 s18, s2
+; LE-I64-NEXT:    vmov.f32 s20, s1
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    mov r5, r0
-; LE-I64-NEXT:    vmov r0, s18
+; LE-I64-NEXT:    vmov r0, s20
 ; LE-I64-NEXT:    mov r4, r1
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    mov r7, r0
-; LE-I64-NEXT:    vmov r0, s16
+; LE-I64-NEXT:    vmov r0, s18
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov s0, r7
 ; LE-I64-NEXT:    mov r6, r1
-; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    vmov.32 d10[0], r0
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d12[0], r0
-; LE-I64-NEXT:    vmov r0, s20
+; LE-I64-NEXT:    vmov.32 d13[0], r0
+; LE-I64-NEXT:    vmov r0, s16
 ; LE-I64-NEXT:    mov r7, r1
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
-; LE-I64-NEXT:    vmov.32 d13[0], r5
+; LE-I64-NEXT:    vmov.32 d12[0], r5
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    vmov.32 d13[1], r4
-; LE-I64-NEXT:    vmov.32 d9[1], r6
-; LE-I64-NEXT:    vmov.32 d12[1], r7
-; LE-I64-NEXT:    vmov.32 d8[1], r1
+; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    vmov.32 d12[1], r4
+; LE-I64-NEXT:    vmov.32 d10[1], r6
+; LE-I64-NEXT:    vmov.32 d13[1], r7
+; LE-I64-NEXT:    vmov.32 d11[1], r1
 ; LE-I64-NEXT:    vorr q0, q6, q6
-; LE-I64-NEXT:    vorr q1, q4, q4
-; LE-I64-NEXT:    vpop {d8, d9, d10}
-; LE-I64-NEXT:    vpop {d12, d13}
+; LE-I64-NEXT:    vorr q1, q5, q5
+; LE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; LE-I64-NEXT:    pop {r4, r5, r6, r7, r11, pc}
 ;
 ; BE-I32-LABEL: lrint_v4f16:
@@ -249,31 +246,31 @@ define <4 x iXLen> @lrint_v4f16(<4 x half> %x) {
 ; BE-I32-NEXT:    push {r4, r5, r11, lr}
 ; BE-I32-NEXT:    .vsave {d8, d9, d10, d11}
 ; BE-I32-NEXT:    vpush {d8, d9, d10, d11}
-; BE-I32-NEXT:    vmov r0, s3
-; BE-I32-NEXT:    vmov.f32 s16, s2
-; BE-I32-NEXT:    vmov.f32 s18, s1
+; BE-I32-NEXT:    vmov r0, s1
+; BE-I32-NEXT:    vmov.f32 s16, s3
+; BE-I32-NEXT:    vmov.f32 s18, s2
 ; BE-I32-NEXT:    vmov.f32 s20, s0
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    mov r4, r0
-; BE-I32-NEXT:    vmov r0, s16
+; BE-I32-NEXT:    vmov r0, s20
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    mov r5, r0
-; BE-I32-NEXT:    vmov r0, s20
+; BE-I32-NEXT:    vmov r0, s18
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov s0, r5
-; BE-I32-NEXT:    vmov.32 d10[0], r0
-; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov.32 d11[0], r0
-; BE-I32-NEXT:    vmov r0, s18
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.32 d10[0], r0
+; BE-I32-NEXT:    vmov r0, s16
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
-; BE-I32-NEXT:    vmov.32 d11[1], r4
+; BE-I32-NEXT:    vmov.32 d10[1], r4
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.32 d10[1], r0
+; BE-I32-NEXT:    vmov.32 d11[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q5
 ; BE-I32-NEXT:    vpop {d8, d9, d10, d11}
 ; BE-I32-NEXT:    pop {r4, r5, r11, pc}
@@ -284,10 +281,10 @@ define <4 x iXLen> @lrint_v4f16(<4 x half> %x) {
 ; BE-I64-NEXT:    push {r4, r5, r6, r7, r11, lr}
 ; BE-I64-NEXT:    .vsave {d8, d9, d10}
 ; BE-I64-NEXT:    vpush {d8, d9, d10}
-; BE-I64-NEXT:    vmov r0, s1
+; BE-I64-NEXT:    vmov r0, s0
 ; BE-I64-NEXT:    vmov.f32 s16, s3
 ; BE-I64-NEXT:    vmov.f32 s18, s2
-; BE-I64-NEXT:    vmov.f32 s20, s0
+; BE-I64-NEXT:    vmov.f32 s20, s1
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    vmov s0, r0
 ; BE-I64-NEXT:    bl lrintf
@@ -296,30 +293,30 @@ define <4 x iXLen> @lrint_v4f16(<4 x half> %x) {
 ; BE-I64-NEXT:    mov r4, r1
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    mov r7, r0
-; BE-I64-NEXT:    vmov r0, s16
+; BE-I64-NEXT:    vmov r0, s18
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    vmov s0, r0
 ; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov s0, r7
 ; BE-I64-NEXT:    mov r6, r1
-; BE-I64-NEXT:    vmov.32 d8[0], r0
+; BE-I64-NEXT:    vmov.32 d9[0], r0
 ; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.32 d10[0], r0
-; BE-I64-NEXT:    vmov r0, s18
+; BE-I64-NEXT:    vmov r0, s16
 ; BE-I64-NEXT:    mov r7, r1
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    vmov s0, r0
-; BE-I64-NEXT:    vmov.32 d9[0], r5
+; BE-I64-NEXT:    vmov.32 d8[0], r5
 ; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.32 d16[0], r0
-; BE-I64-NEXT:    vmov.32 d9[1], r4
-; BE-I64-NEXT:    vmov.32 d8[1], r6
+; BE-I64-NEXT:    vmov.32 d8[1], r4
+; BE-I64-NEXT:    vmov.32 d9[1], r6
 ; BE-I64-NEXT:    vmov.32 d10[1], r7
 ; BE-I64-NEXT:    vmov.32 d16[1], r1
-; BE-I64-NEXT:    vrev64.32 d1, d9
-; BE-I64-NEXT:    vrev64.32 d3, d8
-; BE-I64-NEXT:    vrev64.32 d0, d10
-; BE-I64-NEXT:    vrev64.32 d2, d16
+; BE-I64-NEXT:    vrev64.32 d0, d8
+; BE-I64-NEXT:    vrev64.32 d2, d9
+; BE-I64-NEXT:    vrev64.32 d1, d10
+; BE-I64-NEXT:    vrev64.32 d3, d16
 ; BE-I64-NEXT:    vpop {d8, d9, d10}
 ; BE-I64-NEXT:    pop {r4, r5, r6, r7, r11, pc}
   %a = call <4 x iXLen> @llvm.lrint.v4iXLen.v4f16(<4 x half> %x)
@@ -333,9 +330,9 @@ define <8 x iXLen> @lrint_v8f16(<8 x half> %x) {
 ; LE-I32-NEXT:    push {r4, r5, r6, r7, r8, r9, r11, lr}
 ; LE-I32-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
 ; LE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
-; LE-I32-NEXT:    vmov r0, s7
+; LE-I32-NEXT:    vmov r0, s5
+; LE-I32-NEXT:    vmov.f32 s16, s7
 ; LE-I32-NEXT:    vmov.f32 s18, s6
-; LE-I32-NEXT:    vmov.f32 s16, s5
 ; LE-I32-NEXT:    vmov.f32 s20, s4
 ; LE-I32-NEXT:    vmov.f32 s22, s3
 ; LE-I32-NEXT:    vmov.f32 s24, s2
@@ -345,47 +342,47 @@ define <8 x iXLen> @lrint_v8f16(<8 x half> %x) {
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    mov r8, r0
-; LE-I32-NEXT:    vmov r0, s26
-; LE-I32-NEXT:    bl __aeabi_h2f
-; LE-I32-NEXT:    mov r9, r0
 ; LE-I32-NEXT:    vmov r0, s22
 ; LE-I32-NEXT:    bl __aeabi_h2f
-; LE-I32-NEXT:    mov r6, r0
-; LE-I32-NEXT:    vmov r0, s28
+; LE-I32-NEXT:    mov r9, r0
+; LE-I32-NEXT:    vmov r0, s26
 ; LE-I32-NEXT:    bl __aeabi_h2f
-; LE-I32-NEXT:    mov r7, r0
+; LE-I32-NEXT:    mov r6, r0
 ; LE-I32-NEXT:    vmov r0, s24
 ; LE-I32-NEXT:    bl __aeabi_h2f
+; LE-I32-NEXT:    mov r7, r0
+; LE-I32-NEXT:    vmov r0, s28
+; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    mov r4, r0
-; LE-I32-NEXT:    vmov r0, s18
+; LE-I32-NEXT:    vmov r0, s20
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    mov r5, r0
-; LE-I32-NEXT:    vmov r0, s20
+; LE-I32-NEXT:    vmov r0, s18
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov s0, r5
-; LE-I32-NEXT:    vmov.32 d10[0], r0
-; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov s0, r4
 ; LE-I32-NEXT:    vmov.32 d11[0], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov s0, r7
-; LE-I32-NEXT:    vmov.32 d13[0], r0
+; LE-I32-NEXT:    vmov s0, r4
+; LE-I32-NEXT:    vmov.32 d10[0], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov s0, r6
+; LE-I32-NEXT:    vmov s0, r7
 ; LE-I32-NEXT:    vmov.32 d12[0], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov s0, r9
-; LE-I32-NEXT:    vmov.32 d13[1], r0
+; LE-I32-NEXT:    vmov s0, r6
+; LE-I32-NEXT:    vmov.32 d13[0], r0
 ; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov s0, r9
 ; LE-I32-NEXT:    vmov.32 d12[1], r0
+; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov.32 d13[1], r0
 ; LE-I32-NEXT:    vmov r0, s16
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
-; LE-I32-NEXT:    vmov.32 d11[1], r8
+; LE-I32-NEXT:    vmov.32 d10[1], r8
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.32 d10[1], r0
+; LE-I32-NEXT:    vmov.32 d11[1], r0
 ; LE-I32-NEXT:    vorr q0, q6, q6
 ; LE-I32-NEXT:    vorr q1, q5, q5
 ; LE-I32-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
@@ -401,78 +398,78 @@ define <8 x iXLen> @lrint_v8f16(<8 x half> %x) {
 ; LE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    .pad #8
 ; LE-I64-NEXT:    sub sp, sp, #8
-; LE-I64-NEXT:    vmov r0, s1
-; LE-I64-NEXT:    vstr s6, [sp, #4] @ 4-byte Spill
-; LE-I64-NEXT:    vmov.f32 s16, s7
-; LE-I64-NEXT:    vmov.f32 s18, s5
-; LE-I64-NEXT:    vmov.f32 s20, s4
-; LE-I64-NEXT:    vmov.f32 s22, s3
-; LE-I64-NEXT:    vmov.f32 s24, s2
-; LE-I64-NEXT:    vmov.f32 s26, s0
+; LE-I64-NEXT:    vmov r0, s0
+; LE-I64-NEXT:    vstr s7, [sp, #4] @ 4-byte Spill
+; LE-I64-NEXT:    vmov.f32 s18, s6
+; LE-I64-NEXT:    vmov.f32 s20, s5
+; LE-I64-NEXT:    vmov.f32 s22, s4
+; LE-I64-NEXT:    vmov.f32 s24, s3
+; LE-I64-NEXT:    vmov.f32 s26, s2
+; LE-I64-NEXT:    vmov.f32 s28, s1
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    mov r9, r0
-; LE-I64-NEXT:    vmov r0, s26
+; LE-I64-NEXT:    vmov r0, s28
 ; LE-I64-NEXT:    str r1, [sp] @ 4-byte Spill
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    mov r10, r0
-; LE-I64-NEXT:    vmov r0, s22
+; LE-I64-NEXT:    vmov r0, s26
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    mov r5, r0
 ; LE-I64-NEXT:    vmov r0, s24
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    mov r7, r0
-; LE-I64-NEXT:    vmov r0, s18
+; LE-I64-NEXT:    vmov r0, s22
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    mov r6, r0
 ; LE-I64-NEXT:    vmov r0, s20
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    mov r4, r0
-; LE-I64-NEXT:    vmov r0, s16
+; LE-I64-NEXT:    vmov r0, s18
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov s0, r4
 ; LE-I64-NEXT:    mov r11, r1
-; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    vmov.32 d10[0], r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov s0, r6
 ; LE-I64-NEXT:    mov r8, r1
-; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    vmov.32 d13[0], r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov s0, r7
 ; LE-I64-NEXT:    mov r6, r1
-; LE-I64-NEXT:    vmov.32 d13[0], r0
+; LE-I64-NEXT:    vmov.32 d12[0], r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov s0, r5
 ; LE-I64-NEXT:    mov r7, r1
-; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    vmov.32 d15[0], r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov s0, r10
 ; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    vmov.32 d15[0], r0
+; LE-I64-NEXT:    vmov.32 d14[0], r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vldr s0, [sp, #4] @ 4-byte Reload
 ; LE-I64-NEXT:    mov r4, r1
-; LE-I64-NEXT:    vmov.32 d8[0], r0
+; LE-I64-NEXT:    vmov.32 d9[0], r0
 ; LE-I64-NEXT:    vmov r0, s0
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
-; LE-I64-NEXT:    vmov.32 d9[0], r9
+; LE-I64-NEXT:    vmov.32 d8[0], r9
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d10[0], r0
+; LE-I64-NEXT:    vmov.32 d11[0], r0
 ; LE-I64-NEXT:    ldr r0, [sp] @ 4-byte Reload
-; LE-I64-NEXT:    vmov.32 d15[1], r5
-; LE-I64-NEXT:    vmov.32 d9[1], r0
-; LE-I64-NEXT:    vmov.32 d13[1], r6
-; LE-I64-NEXT:    vmov.32 d11[1], r11
-; LE-I64-NEXT:    vmov.32 d8[1], r4
-; LE-I64-NEXT:    vmov.32 d14[1], r7
+; LE-I64-NEXT:    vmov.32 d14[1], r5
+; LE-I64-NEXT:    vmov.32 d8[1], r0
+; LE-I64-NEXT:    vmov.32 d12[1], r6
+; LE-I64-NEXT:    vmov.32 d10[1], r11
+; LE-I64-NEXT:    vmov.32 d9[1], r4
+; LE-I64-NEXT:    vmov.32 d15[1], r7
 ; LE-I64-NEXT:    vorr q0, q4, q4
-; LE-I64-NEXT:    vmov.32 d12[1], r8
+; LE-I64-NEXT:    vmov.32 d13[1], r8
 ; LE-I64-NEXT:    vorr q1, q7, q7
-; LE-I64-NEXT:    vmov.32 d10[1], r1
+; LE-I64-NEXT:    vmov.32 d11[1], r1
 ; LE-I64-NEXT:    vorr q2, q6, q6
 ; LE-I64-NEXT:    vorr q3, q5, q5
 ; LE-I64-NEXT:    add sp, sp, #8
@@ -486,59 +483,59 @@ define <8 x iXLen> @lrint_v8f16(<8 x half> %x) {
 ; BE-I32-NEXT:    push {r4, r5, r6, r7, r8, r9, r11, lr}
 ; BE-I32-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
 ; BE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
-; BE-I32-NEXT:    vmov r0, s1
-; BE-I32-NEXT:    vmov.f32 s18, s7
-; BE-I32-NEXT:    vmov.f32 s20, s6
-; BE-I32-NEXT:    vmov.f32 s16, s5
+; BE-I32-NEXT:    vmov r0, s3
+; BE-I32-NEXT:    vmov.f32 s16, s7
+; BE-I32-NEXT:    vmov.f32 s18, s6
+; BE-I32-NEXT:    vmov.f32 s20, s5
 ; BE-I32-NEXT:    vmov.f32 s22, s4
-; BE-I32-NEXT:    vmov.f32 s24, s3
-; BE-I32-NEXT:    vmov.f32 s26, s2
+; BE-I32-NEXT:    vmov.f32 s24, s2
+; BE-I32-NEXT:    vmov.f32 s26, s1
 ; BE-I32-NEXT:    vmov.f32 s28, s0
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    mov r8, r0
-; BE-I32-NEXT:    vmov r0, s24
-; BE-I32-NEXT:    bl __aeabi_h2f
-; BE-I32-NEXT:    mov r9, r0
-; BE-I32-NEXT:    vmov r0, s18
-; BE-I32-NEXT:    bl __aeabi_h2f
-; BE-I32-NEXT:    mov r6, r0
 ; BE-I32-NEXT:    vmov r0, s26
 ; BE-I32-NEXT:    bl __aeabi_h2f
-; BE-I32-NEXT:    mov r7, r0
+; BE-I32-NEXT:    mov r9, r0
 ; BE-I32-NEXT:    vmov r0, s20
 ; BE-I32-NEXT:    bl __aeabi_h2f
-; BE-I32-NEXT:    mov r4, r0
+; BE-I32-NEXT:    mov r6, r0
 ; BE-I32-NEXT:    vmov r0, s28
 ; BE-I32-NEXT:    bl __aeabi_h2f
-; BE-I32-NEXT:    mov r5, r0
+; BE-I32-NEXT:    mov r7, r0
 ; BE-I32-NEXT:    vmov r0, s22
+; BE-I32-NEXT:    bl __aeabi_h2f
+; BE-I32-NEXT:    mov r4, r0
+; BE-I32-NEXT:    vmov r0, s24
+; BE-I32-NEXT:    bl __aeabi_h2f
+; BE-I32-NEXT:    mov r5, r0
+; BE-I32-NEXT:    vmov r0, s18
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov s0, r5
-; BE-I32-NEXT:    vmov.32 d10[0], r0
-; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov s0, r4
-; BE-I32-NEXT:    vmov.32 d12[0], r0
-; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov s0, r7
 ; BE-I32-NEXT:    vmov.32 d11[0], r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov s0, r6
+; BE-I32-NEXT:    vmov s0, r4
 ; BE-I32-NEXT:    vmov.32 d13[0], r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov s0, r9
-; BE-I32-NEXT:    vmov.32 d11[1], r0
+; BE-I32-NEXT:    vmov s0, r7
+; BE-I32-NEXT:    vmov.32 d10[0], r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.32 d13[1], r0
+; BE-I32-NEXT:    vmov s0, r6
+; BE-I32-NEXT:    vmov.32 d12[0], r0
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov s0, r9
+; BE-I32-NEXT:    vmov.32 d10[1], r0
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.32 d12[1], r0
 ; BE-I32-NEXT:    vmov r0, s16
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
-; BE-I32-NEXT:    vmov.32 d12[1], r8
+; BE-I32-NEXT:    vmov.32 d13[1], r8
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.32 d10[1], r0
+; BE-I32-NEXT:    vmov.32 d11[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q6
 ; BE-I32-NEXT:    vrev64.32 q1, q5
 ; BE-I32-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
@@ -554,14 +551,14 @@ define <8 x iXLen> @lrint_v8f16(<8 x half> %x) {
 ; BE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
 ; BE-I64-NEXT:    .pad #8
 ; BE-I64-NEXT:    sub sp, sp, #8
-; BE-I64-NEXT:    vmov r0, s1
-; BE-I64-NEXT:    vmov.f32 s18, s7
-; BE-I64-NEXT:    vmov.f32 s16, s6
+; BE-I64-NEXT:    vmov r0, s0
+; BE-I64-NEXT:    vmov.f32 s16, s7
+; BE-I64-NEXT:    vmov.f32 s18, s6
 ; BE-I64-NEXT:    vmov.f32 s20, s5
 ; BE-I64-NEXT:    vmov.f32 s22, s4
 ; BE-I64-NEXT:    vmov.f32 s24, s3
 ; BE-I64-NEXT:    vmov.f32 s26, s2
-; BE-I64-NEXT:    vmov.f32 s28, s0
+; BE-I64-NEXT:    vmov.f32 s28, s1
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    vmov s0, r0
 ; BE-I64-NEXT:    bl lrintf
@@ -570,16 +567,16 @@ define <8 x iXLen> @lrint_v8f16(<8 x half> %x) {
 ; BE-I64-NEXT:    str r1, [sp, #4] @ 4-byte Spill
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    mov r10, r0
-; BE-I64-NEXT:    vmov r0, s24
-; BE-I64-NEXT:    bl __aeabi_h2f
-; BE-I64-NEXT:    mov r5, r0
 ; BE-I64-NEXT:    vmov r0, s26
 ; BE-I64-NEXT:    bl __aeabi_h2f
+; BE-I64-NEXT:    mov r5, r0
+; BE-I64-NEXT:    vmov r0, s24
+; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    mov r7, r0
-; BE-I64-NEXT:    vmov r0, s20
+; BE-I64-NEXT:    vmov r0, s22
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    mov r6, r0
-; BE-I64-NEXT:    vmov r0, s22
+; BE-I64-NEXT:    vmov r0, s20
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    mov r4, r0
 ; BE-I64-NEXT:    vmov r0, s18
@@ -623,14 +620,14 @@ define <8 x iXLen> @lrint_v8f16(<8 x half> %x) {
 ; BE-I64-NEXT:    vmov.32 d12[1], r7
 ; BE-I64-NEXT:    vmov.32 d10[1], r8
 ; BE-I64-NEXT:    vmov.32 d16[1], r1
-; BE-I64-NEXT:    vrev64.32 d1, d8
-; BE-I64-NEXT:    vrev64.32 d3, d13
-; BE-I64-NEXT:    vrev64.32 d5, d11
-; BE-I64-NEXT:    vrev64.32 d7, d9
-; BE-I64-NEXT:    vrev64.32 d0, d14
-; BE-I64-NEXT:    vrev64.32 d2, d12
-; BE-I64-NEXT:    vrev64.32 d4, d10
-; BE-I64-NEXT:    vrev64.32 d6, d16
+; BE-I64-NEXT:    vrev64.32 d0, d8
+; BE-I64-NEXT:    vrev64.32 d2, d13
+; BE-I64-NEXT:    vrev64.32 d4, d11
+; BE-I64-NEXT:    vrev64.32 d6, d9
+; BE-I64-NEXT:    vrev64.32 d1, d14
+; BE-I64-NEXT:    vrev64.32 d3, d12
+; BE-I64-NEXT:    vrev64.32 d5, d10
+; BE-I64-NEXT:    vrev64.32 d7, d16
 ; BE-I64-NEXT:    add sp, sp, #8
 ; BE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
 ; BE-I64-NEXT:    add sp, sp, #4
@@ -648,110 +645,110 @@ define <16 x iXLen> @lrint_v16f16(<16 x half> %x) {
 ; LE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I32-NEXT:    .pad #8
 ; LE-I32-NEXT:    sub sp, sp, #8
-; LE-I32-NEXT:    vmov r0, s15
-; LE-I32-NEXT:    vstr s13, [sp, #4] @ 4-byte Spill
-; LE-I32-NEXT:    vmov.f32 s26, s14
-; LE-I32-NEXT:    vstr s0, [sp] @ 4-byte Spill
-; LE-I32-NEXT:    vmov.f32 s20, s12
+; LE-I32-NEXT:    vmov r0, s13
+; LE-I32-NEXT:    vstr s15, [sp, #4] @ 4-byte Spill
+; LE-I32-NEXT:    vmov.f32 s20, s14
+; LE-I32-NEXT:    vstr s2, [sp] @ 4-byte Spill
+; LE-I32-NEXT:    vmov.f32 s26, s12
 ; LE-I32-NEXT:    vmov.f32 s22, s11
-; LE-I32-NEXT:    vmov.f32 s18, s10
+; LE-I32-NEXT:    vmov.f32 s24, s10
 ; LE-I32-NEXT:    vmov.f32 s17, s9
-; LE-I32-NEXT:    vmov.f32 s24, s8
+; LE-I32-NEXT:    vmov.f32 s18, s8
 ; LE-I32-NEXT:    vmov.f32 s19, s7
-; LE-I32-NEXT:    vmov.f32 s30, s6
+; LE-I32-NEXT:    vmov.f32 s16, s6
 ; LE-I32-NEXT:    vmov.f32 s21, s5
-; LE-I32-NEXT:    vmov.f32 s16, s4
+; LE-I32-NEXT:    vmov.f32 s30, s4
 ; LE-I32-NEXT:    vmov.f32 s23, s3
-; LE-I32-NEXT:    vmov.f32 s28, s2
 ; LE-I32-NEXT:    vmov.f32 s25, s1
+; LE-I32-NEXT:    vmov.f32 s28, s0
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    mov r8, r0
-; LE-I32-NEXT:    vmov r0, s17
-; LE-I32-NEXT:    bl __aeabi_h2f
-; LE-I32-NEXT:    mov r9, r0
 ; LE-I32-NEXT:    vmov r0, s22
 ; LE-I32-NEXT:    bl __aeabi_h2f
-; LE-I32-NEXT:    mov r10, r0
-; LE-I32-NEXT:    vmov r0, s21
+; LE-I32-NEXT:    mov r9, r0
+; LE-I32-NEXT:    vmov r0, s17
 ; LE-I32-NEXT:    bl __aeabi_h2f
-; LE-I32-NEXT:    mov r7, r0
+; LE-I32-NEXT:    mov r10, r0
 ; LE-I32-NEXT:    vmov r0, s19
 ; LE-I32-NEXT:    bl __aeabi_h2f
+; LE-I32-NEXT:    mov r7, r0
+; LE-I32-NEXT:    vmov r0, s21
+; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    mov r4, r0
-; LE-I32-NEXT:    vmov r0, s25
+; LE-I32-NEXT:    vmov r0, s23
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    mov r5, r0
-; LE-I32-NEXT:    vmov r0, s23
+; LE-I32-NEXT:    vmov r0, s25
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    mov r6, r0
 ; LE-I32-NEXT:    vmov r0, s20
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.32 d10[0], r0
+; LE-I32-NEXT:    vmov.32 d11[0], r0
 ; LE-I32-NEXT:    vmov r0, s26
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.32 d11[0], r0
+; LE-I32-NEXT:    vmov.32 d10[0], r0
 ; LE-I32-NEXT:    vmov r0, s24
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.32 d12[0], r0
+; LE-I32-NEXT:    vmov.32 d13[0], r0
 ; LE-I32-NEXT:    vmov r0, s18
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.32 d13[0], r0
+; LE-I32-NEXT:    vmov.32 d12[0], r0
 ; LE-I32-NEXT:    vmov r0, s16
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.32 d8[0], r0
+; LE-I32-NEXT:    vmov.32 d9[0], r0
 ; LE-I32-NEXT:    vmov r0, s30
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.32 d9[0], r0
+; LE-I32-NEXT:    vmov.32 d8[0], r0
 ; LE-I32-NEXT:    vmov r0, s28
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vldr s0, [sp] @ 4-byte Reload
-; LE-I32-NEXT:    vmov.32 d15[0], r0
+; LE-I32-NEXT:    vmov.32 d14[0], r0
 ; LE-I32-NEXT:    vmov r0, s0
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov s0, r6
-; LE-I32-NEXT:    vmov.32 d14[0], r0
+; LE-I32-NEXT:    vmov.32 d15[0], r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov s0, r5
-; LE-I32-NEXT:    vmov.32 d15[1], r0
-; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov s0, r4
 ; LE-I32-NEXT:    vmov.32 d14[1], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov s0, r7
-; LE-I32-NEXT:    vmov.32 d9[1], r0
+; LE-I32-NEXT:    vmov s0, r4
+; LE-I32-NEXT:    vmov.32 d15[1], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov s0, r10
+; LE-I32-NEXT:    vmov s0, r7
 ; LE-I32-NEXT:    vmov.32 d8[1], r0
 ; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov s0, r10
+; LE-I32-NEXT:    vmov.32 d9[1], r0
+; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov s0, r9
-; LE-I32-NEXT:    vmov.32 d13[1], r0
+; LE-I32-NEXT:    vmov.32 d12[1], r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vldr s0, [sp, #4] @ 4-byte Reload
-; LE-I32-NEXT:    vmov.32 d12[1], r0
+; LE-I32-NEXT:    vmov.32 d13[1], r0
 ; LE-I32-NEXT:    vmov r0, s0
 ; LE-I32-NEXT:    bl __aeabi_h2f
 ; LE-I32-NEXT:    vmov s0, r0
-; LE-I32-NEXT:    vmov.32 d11[1], r8
+; LE-I32-NEXT:    vmov.32 d10[1], r8
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.32 d10[1], r0
+; LE-I32-NEXT:    vmov.32 d11[1], r0
 ; LE-I32-NEXT:    vorr q0, q7, q7
 ; LE-I32-NEXT:    vorr q1, q4, q4
 ; LE-I32-NEXT:    vorr q2, q6, q6
@@ -768,112 +765,115 @@ define <16 x iXLen> @lrint_v16f16(<16 x half> %x) {
 ; LE-I64-NEXT:    sub sp, sp, #4
 ; LE-I64-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; LE-I64-NEXT:    .pad #120
-; LE-I64-NEXT:    sub sp, sp, #120
+; LE-I64-NEXT:    .pad #136
+; LE-I64-NEXT:    sub sp, sp, #136
 ; LE-I64-NEXT:    mov r11, r0
-; LE-I64-NEXT:    vmov r0, s7
-; LE-I64-NEXT:    vstr s15, [sp, #24] @ 4-byte Spill
+; LE-I64-NEXT:    vmov r0, s6
+; LE-I64-NEXT:    vstr s15, [sp, #112] @ 4-byte Spill
 ; LE-I64-NEXT:    vmov.f32 s23, s13
-; LE-I64-NEXT:    vstr s14, [sp, #100] @ 4-byte Spill
-; LE-I64-NEXT:    vmov.f32 s25, s12
-; LE-I64-NEXT:    vmov.f32 s27, s11
-; LE-I64-NEXT:    vstr s10, [sp, #104] @ 4-byte Spill
-; LE-I64-NEXT:    vstr s9, [sp, #108] @ 4-byte Spill
-; LE-I64-NEXT:    vmov.f32 s24, s8
-; LE-I64-NEXT:    vmov.f32 s19, s6
-; LE-I64-NEXT:    vmov.f32 s29, s5
-; LE-I64-NEXT:    vmov.f32 s17, s4
-; LE-I64-NEXT:    vmov.f32 s16, s3
-; LE-I64-NEXT:    vmov.f32 s21, s2
-; LE-I64-NEXT:    vmov.f32 s26, s1
-; LE-I64-NEXT:    vmov.f32 s18, s0
+; LE-I64-NEXT:    vstr s14, [sp, #40] @ 4-byte Spill
+; LE-I64-NEXT:    vmov.f32 s25, s11
+; LE-I64-NEXT:    vstr s12, [sp, #100] @ 4-byte Spill
+; LE-I64-NEXT:    vmov.f32 s27, s10
+; LE-I64-NEXT:    vstr s9, [sp, #104] @ 4-byte Spill
+; LE-I64-NEXT:    vmov.f32 s19, s7
+; LE-I64-NEXT:    vstr s8, [sp, #120] @ 4-byte Spill
+; LE-I64-NEXT:    vmov.f32 s17, s5
+; LE-I64-NEXT:    vmov.f32 s29, s4
+; LE-I64-NEXT:    vmov.f32 s21, s3
+; LE-I64-NEXT:    vmov.f32 s16, s2
+; LE-I64-NEXT:    vmov.f32 s18, s1
+; LE-I64-NEXT:    vmov.f32 s26, s0
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    mov r7, r0
-; LE-I64-NEXT:    vmov r0, s25
-; LE-I64-NEXT:    str r1, [sp, #56] @ 4-byte Spill
+; LE-I64-NEXT:    vmov r0, s27
+; LE-I64-NEXT:    str r1, [sp, #80] @ 4-byte Spill
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    mov r5, r0
-; LE-I64-NEXT:    vmov r0, s27
+; LE-I64-NEXT:    vmov r0, s25
 ; LE-I64-NEXT:    str r1, [sp, #116] @ 4-byte Spill
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    mov r6, r0
 ; LE-I64-NEXT:    vmov r0, s29
-; LE-I64-NEXT:    str r1, [sp, #112] @ 4-byte Spill
+; LE-I64-NEXT:    str r1, [sp, #108] @ 4-byte Spill
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d15[0], r0
+; LE-I64-NEXT:    vmov.32 d14[0], r0
 ; LE-I64-NEXT:    vmov r0, s23
 ; LE-I64-NEXT:    mov r4, r1
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
-; LE-I64-NEXT:    add lr, sp, #80
-; LE-I64-NEXT:    vmov.32 d17[0], r6
-; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
+; LE-I64-NEXT:    vmov.32 d12[0], r6
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    mov r6, r0
 ; LE-I64-NEXT:    vmov r0, s17
-; LE-I64-NEXT:    vmov r8, s21
+; LE-I64-NEXT:    vmov.32 d11[0], r5
+; LE-I64-NEXT:    add lr, sp, #56
 ; LE-I64-NEXT:    str r1, [sp, #76] @ 4-byte Spill
+; LE-I64-NEXT:    vmov r8, s21
 ; LE-I64-NEXT:    vmov r10, s19
-; LE-I64-NEXT:    vmov.32 d10[0], r5
+; LE-I64-NEXT:    vstmia lr, {d11, d12} @ 16-byte Spill
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
-; LE-I64-NEXT:    add lr, sp, #40
-; LE-I64-NEXT:    vmov.32 d11[0], r6
-; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; LE-I64-NEXT:    add lr, sp, #24
+; LE-I64-NEXT:    vmov.32 d17[0], r6
+; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    vmov.32 d15[0], r0
 ; LE-I64-NEXT:    mov r0, r10
 ; LE-I64-NEXT:    mov r9, r1
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
-; LE-I64-NEXT:    vmov.32 d11[0], r7
+; LE-I64-NEXT:    vmov.32 d10[0], r7
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d10[0], r0
+; LE-I64-NEXT:    vmov.32 d11[0], r0
 ; LE-I64-NEXT:    mov r0, r8
 ; LE-I64-NEXT:    mov r7, r1
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    mov r6, r0
-; LE-I64-NEXT:    ldr r0, [sp, #56] @ 4-byte Reload
-; LE-I64-NEXT:    vmov.32 d11[1], r0
+; LE-I64-NEXT:    ldr r0, [sp, #80] @ 4-byte Reload
+; LE-I64-NEXT:    vmov.32 d10[1], r0
 ; LE-I64-NEXT:    vmov r0, s18
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    mov r5, r0
 ; LE-I64-NEXT:    vmov r0, s16
-; LE-I64-NEXT:    vmov.32 d10[1], r7
-; LE-I64-NEXT:    add lr, sp, #56
+; LE-I64-NEXT:    add lr, sp, #80
+; LE-I64-NEXT:    vmov.32 d11[1], r7
 ; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov s0, r0
-; LE-I64-NEXT:    vmov.32 d15[1], r4
+; LE-I64-NEXT:    vmov.32 d14[1], r4
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    vmov.32 d16[0], r0
 ; LE-I64-NEXT:    vmov r0, s26
-; LE-I64-NEXT:    add lr, sp, #24
-; LE-I64-NEXT:    vmov r8, s24
-; LE-I64-NEXT:    vmov.32 d14[1], r9
+; LE-I64-NEXT:    add lr, sp, #120
 ; LE-I64-NEXT:    mov r10, r1
+; LE-I64-NEXT:    vldr s0, [sp, #120] @ 4-byte Reload
 ; LE-I64-NEXT:    vmov s24, r5
-; LE-I64-NEXT:    vldr s0, [sp, #24] @ 4-byte Reload
-; LE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
+; LE-I64-NEXT:    add lr, sp, #40
+; LE-I64-NEXT:    vmov r8, s0
+; LE-I64-NEXT:    vldr s0, [sp, #40] @ 4-byte Reload
+; LE-I64-NEXT:    vmov.32 d15[1], r9
 ; LE-I64-NEXT:    vmov r7, s0
+; LE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov.f32 s0, s24
 ; LE-I64-NEXT:    vmov s22, r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov.f32 s0, s22
 ; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    vmov.32 d9[0], r0
 ; LE-I64-NEXT:    vmov s24, r6
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d15[0], r0
+; LE-I64-NEXT:    vmov.32 d8[0], r0
 ; LE-I64-NEXT:    mov r0, r7
 ; LE-I64-NEXT:    mov r6, r1
 ; LE-I64-NEXT:    bl __aeabi_h2f
@@ -881,37 +881,42 @@ define <16 x iXLen> @lrint_v16f16(<16 x half> %x) {
 ; LE-I64-NEXT:    vmov s22, r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov.f32 s0, s22
-; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    add lr, sp, #8
+; LE-I64-NEXT:    add lr, sp, #120
 ; LE-I64-NEXT:    mov r9, r1
-; LE-I64-NEXT:    vmov.32 d15[1], r6
-; LE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; LE-I64-NEXT:    vmov.32 d8[1], r6
+; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-I64-NEXT:    vmov.32 d17[0], r0
+; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d13[0], r0
+; LE-I64-NEXT:    vmov.32 d12[0], r0
 ; LE-I64-NEXT:    mov r0, r8
 ; LE-I64-NEXT:    mov r6, r1
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vldr s0, [sp, #100] @ 4-byte Reload
 ; LE-I64-NEXT:    mov r7, r0
-; LE-I64-NEXT:    vmov.32 d14[1], r5
+; LE-I64-NEXT:    add lr, sp, #8
+; LE-I64-NEXT:    vmov.32 d9[1], r5
 ; LE-I64-NEXT:    vmov r0, s0
+; LE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vldr s0, [sp, #104] @ 4-byte Reload
 ; LE-I64-NEXT:    vmov s20, r0
-; LE-I64-NEXT:    vmov.32 d13[1], r6
+; LE-I64-NEXT:    vmov.32 d12[1], r6
 ; LE-I64-NEXT:    vmov r4, s0
-; LE-I64-NEXT:    vldr s0, [sp, #108] @ 4-byte Reload
+; LE-I64-NEXT:    vldr s0, [sp, #112] @ 4-byte Reload
 ; LE-I64-NEXT:    vmov r0, s0
 ; LE-I64-NEXT:    bl __aeabi_h2f
 ; LE-I64-NEXT:    vmov.f32 s0, s20
 ; LE-I64-NEXT:    vmov s16, r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov.f32 s0, s16
+; LE-I64-NEXT:    add lr, sp, #24
 ; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    vmov.32 d12[0], r0
 ; LE-I64-NEXT:    vmov s18, r7
+; LE-I64-NEXT:    vldmia lr, {d14, d15} @ 16-byte Reload
+; LE-I64-NEXT:    vmov.32 d14[0], r0
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    vmov.32 d13[0], r0
 ; LE-I64-NEXT:    mov r0, r4
 ; LE-I64-NEXT:    mov r6, r1
 ; LE-I64-NEXT:    bl __aeabi_h2f
@@ -919,42 +924,42 @@ define <16 x iXLen> @lrint_v16f16(<16 x half> %x) {
 ; LE-I64-NEXT:    vmov s16, r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov.f32 s0, s16
-; LE-I64-NEXT:    vmov.32 d10[0], r0
 ; LE-I64-NEXT:    mov r4, r1
-; LE-I64-NEXT:    vmov.32 d11[1], r6
+; LE-I64-NEXT:    vmov.32 d10[0], r0
+; LE-I64-NEXT:    vmov.32 d13[1], r6
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    add lr, sp, #80
-; LE-I64-NEXT:    vmov.32 d10[1], r4
-; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-I64-NEXT:    add lr, sp, #40
-; LE-I64-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
-; LE-I64-NEXT:    add lr, sp, #8
-; LE-I64-NEXT:    vmov.32 d16[0], r0
+; LE-I64-NEXT:    vmov.32 d11[0], r0
 ; LE-I64-NEXT:    ldr r0, [sp, #76] @ 4-byte Reload
-; LE-I64-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
-; LE-I64-NEXT:    add lr, sp, #24
-; LE-I64-NEXT:    vmov.32 d19[1], r0
+; LE-I64-NEXT:    add lr, sp, #56
+; LE-I64-NEXT:    vmov.32 d14[1], r5
+; LE-I64-NEXT:    vmov.32 d15[1], r0
 ; LE-I64-NEXT:    ldr r0, [sp, #116] @ 4-byte Reload
-; LE-I64-NEXT:    vmov.32 d21[1], r10
-; LE-I64-NEXT:    vmov.32 d18[1], r0
-; LE-I64-NEXT:    ldr r0, [sp, #112] @ 4-byte Reload
-; LE-I64-NEXT:    vmov.32 d12[1], r5
+; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-I64-NEXT:    add lr, sp, #120
+; LE-I64-NEXT:    vmov.32 d10[1], r4
+; LE-I64-NEXT:    vmov.32 d16[1], r0
+; LE-I64-NEXT:    ldr r0, [sp, #108] @ 4-byte Reload
+; LE-I64-NEXT:    vmov.32 d11[1], r1
 ; LE-I64-NEXT:    vmov.32 d17[1], r0
 ; LE-I64-NEXT:    add r0, r11, #64
-; LE-I64-NEXT:    vmov.32 d16[1], r1
+; LE-I64-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
+; LE-I64-NEXT:    add lr, sp, #8
 ; LE-I64-NEXT:    vst1.64 {d10, d11}, [r0:128]!
 ; LE-I64-NEXT:    vst1.64 {d16, d17}, [r0:128]!
-; LE-I64-NEXT:    vst1.64 {d18, d19}, [r0:128]!
-; LE-I64-NEXT:    vmov.32 d20[1], r9
+; LE-I64-NEXT:    vst1.64 {d14, d15}, [r0:128]!
 ; LE-I64-NEXT:    vst1.64 {d12, d13}, [r0:128]
-; LE-I64-NEXT:    vst1.64 {d14, d15}, [r11:128]!
+; LE-I64-NEXT:    vmov.32 d20[1], r10
+; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-I64-NEXT:    add lr, sp, #40
+; LE-I64-NEXT:    vmov.32 d21[1], r9
+; LE-I64-NEXT:    vst1.64 {d16, d17}, [r11:128]!
 ; LE-I64-NEXT:    vst1.64 {d20, d21}, [r11:128]!
 ; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-I64-NEXT:    add lr, sp, #56
+; LE-I64-NEXT:    add lr, sp, #80
 ; LE-I64-NEXT:    vst1.64 {d16, d17}, [r11:128]!
 ; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I64-NEXT:    vst1.64 {d16, d17}, [r11:128]
-; LE-I64-NEXT:    add sp, sp, #120
+; LE-I64-NEXT:    add sp, sp, #136
 ; LE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    add sp, sp, #4
 ; LE-I64-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
@@ -967,112 +972,112 @@ define <16 x iXLen> @lrint_v16f16(<16 x half> %x) {
 ; BE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-I32-NEXT:    .pad #16
 ; BE-I32-NEXT:    sub sp, sp, #16
-; BE-I32-NEXT:    vmov r0, s1
-; BE-I32-NEXT:    vstr s14, [sp, #4] @ 4-byte Spill
-; BE-I32-NEXT:    vmov.f32 s30, s15
-; BE-I32-NEXT:    vstr s13, [sp, #12] @ 4-byte Spill
-; BE-I32-NEXT:    vmov.f32 s17, s12
-; BE-I32-NEXT:    vstr s10, [sp, #8] @ 4-byte Spill
-; BE-I32-NEXT:    vmov.f32 s19, s11
-; BE-I32-NEXT:    vstr s8, [sp] @ 4-byte Spill
-; BE-I32-NEXT:    vmov.f32 s21, s9
-; BE-I32-NEXT:    vmov.f32 s23, s7
-; BE-I32-NEXT:    vmov.f32 s24, s6
-; BE-I32-NEXT:    vmov.f32 s25, s5
-; BE-I32-NEXT:    vmov.f32 s26, s4
-; BE-I32-NEXT:    vmov.f32 s27, s3
-; BE-I32-NEXT:    vmov.f32 s28, s2
-; BE-I32-NEXT:    vmov.f32 s29, s0
+; BE-I32-NEXT:    vmov r0, s3
+; BE-I32-NEXT:    vstr s15, [sp, #12] @ 4-byte Spill
+; BE-I32-NEXT:    vmov.f32 s17, s14
+; BE-I32-NEXT:    vstr s12, [sp, #4] @ 4-byte Spill
+; BE-I32-NEXT:    vmov.f32 s19, s13
+; BE-I32-NEXT:    vstr s10, [sp] @ 4-byte Spill
+; BE-I32-NEXT:    vmov.f32 s21, s11
+; BE-I32-NEXT:    vstr s8, [sp, #8] @ 4-byte Spill
+; BE-I32-NEXT:    vmov.f32 s23, s9
+; BE-I32-NEXT:    vmov.f32 s25, s7
+; BE-I32-NEXT:    vmov.f32 s26, s6
+; BE-I32-NEXT:    vmov.f32 s27, s5
+; BE-I32-NEXT:    vmov.f32 s24, s4
+; BE-I32-NEXT:    vmov.f32 s30, s2
+; BE-I32-NEXT:    vmov.f32 s29, s1
+; BE-I32-NEXT:    vmov.f32 s28, s0
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    mov r8, r0
-; BE-I32-NEXT:    vmov r0, s27
+; BE-I32-NEXT:    vmov r0, s29
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    mov r9, r0
 ; BE-I32-NEXT:    vmov r0, s25
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    mov r10, r0
-; BE-I32-NEXT:    vmov r0, s23
+; BE-I32-NEXT:    vmov r0, s27
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    mov r7, r0
 ; BE-I32-NEXT:    vmov r0, s21
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    mov r4, r0
-; BE-I32-NEXT:    vmov r0, s19
+; BE-I32-NEXT:    vmov r0, s23
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    mov r5, r0
-; BE-I32-NEXT:    vmov r0, s30
+; BE-I32-NEXT:    vmov r0, s19
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    mov r6, r0
 ; BE-I32-NEXT:    vmov r0, s17
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.32 d8[0], r0
-; BE-I32-NEXT:    vmov r0, s29
-; BE-I32-NEXT:    bl __aeabi_h2f
-; BE-I32-NEXT:    vmov s0, r0
-; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.32 d10[0], r0
-; BE-I32-NEXT:    vmov r0, s28
+; BE-I32-NEXT:    vmov.32 d9[0], r0
+; BE-I32-NEXT:    vmov r0, s30
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov.32 d11[0], r0
+; BE-I32-NEXT:    vmov r0, s28
+; BE-I32-NEXT:    bl __aeabi_h2f
+; BE-I32-NEXT:    vmov s0, r0
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.32 d10[0], r0
 ; BE-I32-NEXT:    vmov r0, s26
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.32 d14[0], r0
+; BE-I32-NEXT:    vmov.32 d15[0], r0
 ; BE-I32-NEXT:    vmov r0, s24
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vldr s0, [sp] @ 4-byte Reload
-; BE-I32-NEXT:    vmov.32 d15[0], r0
+; BE-I32-NEXT:    vmov.32 d14[0], r0
 ; BE-I32-NEXT:    vmov r0, s0
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vldr s0, [sp, #4] @ 4-byte Reload
-; BE-I32-NEXT:    vmov.32 d12[0], r0
+; BE-I32-NEXT:    vmov.32 d13[0], r0
 ; BE-I32-NEXT:    vmov r0, s0
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vldr s0, [sp, #8] @ 4-byte Reload
-; BE-I32-NEXT:    vmov.32 d9[0], r0
+; BE-I32-NEXT:    vmov.32 d8[0], r0
 ; BE-I32-NEXT:    vmov r0, s0
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov s0, r6
-; BE-I32-NEXT:    vmov.32 d13[0], r0
+; BE-I32-NEXT:    vmov.32 d12[0], r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov s0, r5
-; BE-I32-NEXT:    vmov.32 d9[1], r0
+; BE-I32-NEXT:    vmov.32 d8[1], r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov s0, r4
-; BE-I32-NEXT:    vmov.32 d13[1], r0
-; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov s0, r7
 ; BE-I32-NEXT:    vmov.32 d12[1], r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov s0, r10
-; BE-I32-NEXT:    vmov.32 d15[1], r0
+; BE-I32-NEXT:    vmov s0, r7
+; BE-I32-NEXT:    vmov.32 d13[1], r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov s0, r9
+; BE-I32-NEXT:    vmov s0, r10
 ; BE-I32-NEXT:    vmov.32 d14[1], r0
 ; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov s0, r9
+; BE-I32-NEXT:    vmov.32 d15[1], r0
+; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vldr s0, [sp, #12] @ 4-byte Reload
-; BE-I32-NEXT:    vmov.32 d11[1], r0
+; BE-I32-NEXT:    vmov.32 d10[1], r0
 ; BE-I32-NEXT:    vmov r0, s0
 ; BE-I32-NEXT:    bl __aeabi_h2f
 ; BE-I32-NEXT:    vmov s0, r0
-; BE-I32-NEXT:    vmov.32 d10[1], r8
+; BE-I32-NEXT:    vmov.32 d11[1], r8
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.32 d8[1], r0
+; BE-I32-NEXT:    vmov.32 d9[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q5
 ; BE-I32-NEXT:    vrev64.32 q1, q7
 ; BE-I32-NEXT:    vrev64.32 q2, q6
@@ -1092,31 +1097,31 @@ define <16 x iXLen> @lrint_v16f16(<16 x half> %x) {
 ; BE-I64-NEXT:    .pad #112
 ; BE-I64-NEXT:    sub sp, sp, #112
 ; BE-I64-NEXT:    mov r11, r0
-; BE-I64-NEXT:    vmov r0, s14
-; BE-I64-NEXT:    vmov.f32 s17, s15
-; BE-I64-NEXT:    vstr s13, [sp, #52] @ 4-byte Spill
-; BE-I64-NEXT:    vmov.f32 s21, s12
-; BE-I64-NEXT:    vstr s10, [sp, #68] @ 4-byte Spill
-; BE-I64-NEXT:    vmov.f32 s23, s11
-; BE-I64-NEXT:    vstr s7, [sp, #72] @ 4-byte Spill
-; BE-I64-NEXT:    vmov.f32 s19, s9
-; BE-I64-NEXT:    vstr s4, [sp, #28] @ 4-byte Spill
+; BE-I64-NEXT:    vmov r0, s15
+; BE-I64-NEXT:    vmov.f32 s19, s14
+; BE-I64-NEXT:    vstr s12, [sp, #52] @ 4-byte Spill
+; BE-I64-NEXT:    vmov.f32 s21, s13
+; BE-I64-NEXT:    vstr s9, [sp, #68] @ 4-byte Spill
+; BE-I64-NEXT:    vmov.f32 s17, s11
+; BE-I64-NEXT:    vstr s6, [sp, #72] @ 4-byte Spill
+; BE-I64-NEXT:    vmov.f32 s23, s10
+; BE-I64-NEXT:    vstr s5, [sp, #28] @ 4-byte Spill
 ; BE-I64-NEXT:    vmov.f32 s26, s8
-; BE-I64-NEXT:    vmov.f32 s24, s6
-; BE-I64-NEXT:    vmov.f32 s18, s5
-; BE-I64-NEXT:    vmov.f32 s25, s3
-; BE-I64-NEXT:    vmov.f32 s16, s2
+; BE-I64-NEXT:    vmov.f32 s24, s7
+; BE-I64-NEXT:    vmov.f32 s18, s4
+; BE-I64-NEXT:    vmov.f32 s16, s3
+; BE-I64-NEXT:    vmov.f32 s25, s2
 ; BE-I64-NEXT:    vmov.f32 s27, s1
 ; BE-I64-NEXT:    vmov.f32 s29, s0
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    vmov s0, r0
 ; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    mov r8, r0
-; BE-I64-NEXT:    vmov r0, s29
+; BE-I64-NEXT:    vmov r0, s27
 ; BE-I64-NEXT:    mov r4, r1
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    mov r9, r0
-; BE-I64-NEXT:    vmov r0, s27
+; BE-I64-NEXT:    vmov r0, s29
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    mov r7, r0
 ; BE-I64-NEXT:    vmov r0, s21
@@ -1149,12 +1154,12 @@ define <16 x iXLen> @lrint_v16f16(<16 x half> %x) {
 ; BE-I64-NEXT:    vmov.32 d14[0], r0
 ; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.32 d15[0], r0
-; BE-I64-NEXT:    vmov r0, s17
+; BE-I64-NEXT:    vmov r0, s19
 ; BE-I64-NEXT:    mov r5, r1
 ; BE-I64-NEXT:    bl __aeabi_h2f
 ; BE-I64-NEXT:    vmov s0, r0
 ; BE-I64-NEXT:    vmov.32 d10[0], r8
-; BE-I64-NEXT:    vmov r6, s19
+; BE-I64-NEXT:    vmov r6, s17
 ; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.32 d11[0], r0
 ; BE-I64-NEXT:    mov r0, r6
@@ -1241,51 +1246,51 @@ define <16 x iXLen> @lrint_v16f16(<16 x half> %x) {
 ; BE-I64-NEXT:    vmov.32 d9[0], r0
 ; BE-I64-NEXT:    vmov.32 d15[1], r4
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.32 d24[0], r0
+; BE-I64-NEXT:    vmov.32 d16[0], r0
 ; BE-I64-NEXT:    ldr r0, [sp, #76] @ 4-byte Reload
-; BE-I64-NEXT:    vldr d23, [sp, #56] @ 8-byte Reload
-; BE-I64-NEXT:    vldr d20, [sp, #8] @ 8-byte Reload
-; BE-I64-NEXT:    vmov.32 d23[1], r0
+; BE-I64-NEXT:    vldr d29, [sp, #56] @ 8-byte Reload
+; BE-I64-NEXT:    vldr d22, [sp, #8] @ 8-byte Reload
+; BE-I64-NEXT:    vmov.32 d29[1], r0
 ; BE-I64-NEXT:    ldr r0, [sp, #92] @ 4-byte Reload
-; BE-I64-NEXT:    vldr d22, [sp, #80] @ 8-byte Reload
-; BE-I64-NEXT:    vldr d26, [sp, #16] @ 8-byte Reload
-; BE-I64-NEXT:    vrev64.32 d21, d20
-; BE-I64-NEXT:    vmov.32 d22[1], r0
+; BE-I64-NEXT:    vldr d28, [sp, #80] @ 8-byte Reload
+; BE-I64-NEXT:    vldr d24, [sp, #16] @ 8-byte Reload
+; BE-I64-NEXT:    vrev64.32 d22, d22
+; BE-I64-NEXT:    vmov.32 d28[1], r0
 ; BE-I64-NEXT:    ldr r0, [sp, #108] @ 4-byte Reload
 ; BE-I64-NEXT:    vldr d30, [sp] @ 8-byte Reload
-; BE-I64-NEXT:    vldr d25, [sp, #96] @ 8-byte Reload
-; BE-I64-NEXT:    vrev64.32 d20, d26
-; BE-I64-NEXT:    vldr d26, [sp, #32] @ 8-byte Reload
+; BE-I64-NEXT:    vldr d17, [sp, #96] @ 8-byte Reload
+; BE-I64-NEXT:    vrev64.32 d23, d24
+; BE-I64-NEXT:    vldr d24, [sp, #32] @ 8-byte Reload
 ; BE-I64-NEXT:    vmov.32 d10[1], r5
-; BE-I64-NEXT:    vmov.32 d12[1], r9
-; BE-I64-NEXT:    vldr d28, [sp, #40] @ 8-byte Reload
-; BE-I64-NEXT:    vrev64.32 d27, d26
-; BE-I64-NEXT:    vmov.32 d25[1], r0
+; BE-I64-NEXT:    vmov.32 d9[1], r6
+; BE-I64-NEXT:    vldr d26, [sp, #40] @ 8-byte Reload
+; BE-I64-NEXT:    vrev64.32 d24, d24
+; BE-I64-NEXT:    vmov.32 d17[1], r0
 ; BE-I64-NEXT:    add r0, r11, #64
 ; BE-I64-NEXT:    vmov.32 d30[1], r8
-; BE-I64-NEXT:    vmov.32 d9[1], r6
-; BE-I64-NEXT:    vrev64.32 d26, d28
-; BE-I64-NEXT:    vrev64.32 d29, d10
-; BE-I64-NEXT:    vmov.32 d24[1], r1
-; BE-I64-NEXT:    vrev64.32 d1, d12
-; BE-I64-NEXT:    vrev64.32 d28, d23
-; BE-I64-NEXT:    vrev64.32 d23, d22
-; BE-I64-NEXT:    vrev64.32 d22, d30
-; BE-I64-NEXT:    vrev64.32 d31, d25
+; BE-I64-NEXT:    vmov.32 d16[1], r1
+; BE-I64-NEXT:    vrev64.32 d25, d26
+; BE-I64-NEXT:    vrev64.32 d26, d10
+; BE-I64-NEXT:    vmov.32 d12[1], r9
 ; BE-I64-NEXT:    vrev64.32 d0, d9
-; BE-I64-NEXT:    vrev64.32 d30, d24
+; BE-I64-NEXT:    vrev64.32 d27, d29
+; BE-I64-NEXT:    vrev64.32 d28, d28
+; BE-I64-NEXT:    vrev64.32 d29, d30
+; BE-I64-NEXT:    vrev64.32 d30, d17
+; BE-I64-NEXT:    vrev64.32 d1, d16
+; BE-I64-NEXT:    vrev64.32 d31, d12
 ; BE-I64-NEXT:    vst1.64 {d0, d1}, [r0:128]!
 ; BE-I64-NEXT:    vst1.64 {d30, d31}, [r0:128]!
-; BE-I64-NEXT:    vst1.64 {d28, d29}, [r0:128]!
-; BE-I64-NEXT:    vrev64.32 d19, d13
-; BE-I64-NEXT:    vst1.64 {d26, d27}, [r0:128]
-; BE-I64-NEXT:    vst1.64 {d20, d21}, [r11:128]!
-; BE-I64-NEXT:    vrev64.32 d18, d14
+; BE-I64-NEXT:    vst1.64 {d26, d27}, [r0:128]!
+; BE-I64-NEXT:    vrev64.32 d20, d13
+; BE-I64-NEXT:    vst1.64 {d24, d25}, [r0:128]
 ; BE-I64-NEXT:    vst1.64 {d22, d23}, [r11:128]!
-; BE-I64-NEXT:    vrev64.32 d17, d15
-; BE-I64-NEXT:    vrev64.32 d16, d11
-; BE-I64-NEXT:    vst1.64 {d18, d19}, [r11:128]!
-; BE-I64-NEXT:    vst1.64 {d16, d17}, [r11:128]
+; BE-I64-NEXT:    vrev64.32 d21, d14
+; BE-I64-NEXT:    vst1.64 {d28, d29}, [r11:128]!
+; BE-I64-NEXT:    vrev64.32 d18, d15
+; BE-I64-NEXT:    vrev64.32 d19, d11
+; BE-I64-NEXT:    vst1.64 {d20, d21}, [r11:128]!
+; BE-I64-NEXT:    vst1.64 {d18, d19}, [r11:128]
 ; BE-I64-NEXT:    add sp, sp, #112
 ; BE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-I64-NEXT:    add sp, sp, #4
@@ -1357,15 +1362,14 @@ define <2 x iXLen> @lrint_v2f32(<2 x float> %x) {
 ; LE-I64-NEXT:    .vsave {d8}
 ; LE-I64-NEXT:    vpush {d8}
 ; LE-I64-NEXT:    vmov.f64 d8, d0
+; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov.f32 s0, s17
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s16
 ; LE-I64-NEXT:    mov r4, r1
-; LE-I64-NEXT:    vmov.32 d11[0], r0
-; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov.32 d10[0], r0
-; LE-I64-NEXT:    vmov.32 d11[1], r4
-; LE-I64-NEXT:    vmov.32 d10[1], r1
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    vmov.32 d10[1], r4
+; LE-I64-NEXT:    vmov.32 d11[1], r1
 ; LE-I64-NEXT:    vorr q0, q5, q5
 ; LE-I64-NEXT:    vpop {d8}
 ; LE-I64-NEXT:    vpop {d10, d11}
@@ -1397,15 +1401,15 @@ define <2 x iXLen> @lrint_v2f32(<2 x float> %x) {
 ; BE-I64-NEXT:    .vsave {d8}
 ; BE-I64-NEXT:    vpush {d8}
 ; BE-I64-NEXT:    vrev64.32 d8, d0
-; BE-I64-NEXT:    vmov.f32 s0, s17
-; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.f32 s0, s16
-; BE-I64-NEXT:    mov r4, r1
-; BE-I64-NEXT:    vmov.32 d11[0], r0
 ; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.f32 s0, s17
+; BE-I64-NEXT:    mov r4, r1
 ; BE-I64-NEXT:    vmov.32 d10[0], r0
-; BE-I64-NEXT:    vmov.32 d11[1], r4
-; BE-I64-NEXT:    vmov.32 d10[1], r1
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    vmov.32 d10[1], r4
+; BE-I64-NEXT:    vmov.32 d11[1], r1
 ; BE-I64-NEXT:    vrev64.32 q0, q5
 ; BE-I64-NEXT:    vpop {d8}
 ; BE-I64-NEXT:    vpop {d10, d11}
@@ -1422,18 +1426,17 @@ define <4 x iXLen> @lrint_v4f32(<4 x float> %x) {
 ; LE-I32-NEXT:    .vsave {d8, d9, d10, d11}
 ; LE-I32-NEXT:    vpush {d8, d9, d10, d11}
 ; LE-I32-NEXT:    vorr q4, q0, q0
+; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov.f32 s0, s18
-; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s16
-; LE-I32-NEXT:    vmov.32 d11[0], r0
-; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s19
 ; LE-I32-NEXT:    vmov.32 d10[0], r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov.f32 s0, s17
-; LE-I32-NEXT:    vmov.32 d11[1], r0
+; LE-I32-NEXT:    vmov.32 d11[0], r0
 ; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov.f32 s0, s19
 ; LE-I32-NEXT:    vmov.32 d10[1], r0
+; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov.32 d11[1], r0
 ; LE-I32-NEXT:    vorr q0, q5, q5
 ; LE-I32-NEXT:    vpop {d8, d9, d10, d11}
 ; LE-I32-NEXT:    pop {r11, pc}
@@ -1444,28 +1447,28 @@ define <4 x iXLen> @lrint_v4f32(<4 x float> %x) {
 ; LE-I64-NEXT:    push {r4, r5, r6, lr}
 ; LE-I64-NEXT:    .vsave {d8, d9, d10, d11, d12, d13}
 ; LE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
-; LE-I64-NEXT:    vorr q5, q0, q0
-; LE-I64-NEXT:    vmov.f32 s0, s23
+; LE-I64-NEXT:    vorr q4, q0, q0
+; LE-I64-NEXT:    vmov.f32 s0, s18
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s20
+; LE-I64-NEXT:    vmov.f32 s0, s17
 ; LE-I64-NEXT:    mov r4, r1
-; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    vmov.32 d10[0], r0
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s21
+; LE-I64-NEXT:    vmov.f32 s0, s16
 ; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    vmov.32 d12[0], r0
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s22
-; LE-I64-NEXT:    mov r6, r1
 ; LE-I64-NEXT:    vmov.32 d13[0], r0
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    vmov.32 d13[1], r6
-; LE-I64-NEXT:    vmov.32 d9[1], r4
-; LE-I64-NEXT:    vmov.32 d12[1], r5
-; LE-I64-NEXT:    vmov.32 d8[1], r1
+; LE-I64-NEXT:    vmov.f32 s0, s19
+; LE-I64-NEXT:    mov r6, r1
+; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    vmov.32 d12[1], r6
+; LE-I64-NEXT:    vmov.32 d10[1], r4
+; LE-I64-NEXT:    vmov.32 d13[1], r5
+; LE-I64-NEXT:    vmov.32 d11[1], r1
 ; LE-I64-NEXT:    vorr q0, q6, q6
-; LE-I64-NEXT:    vorr q1, q4, q4
+; LE-I64-NEXT:    vorr q1, q5, q5
 ; LE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; LE-I64-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -1476,18 +1479,18 @@ define <4 x iXLen> @lrint_v4f32(<4 x float> %x) {
 ; BE-I32-NEXT:    .vsave {d8, d9, d10, d11}
 ; BE-I32-NEXT:    vpush {d8, d9, d10, d11}
 ; BE-I32-NEXT:    vrev64.32 q4, q0
-; BE-I32-NEXT:    vmov.f32 s0, s18
-; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov.f32 s0, s16
-; BE-I32-NEXT:    vmov.32 d11[0], r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s19
+; BE-I32-NEXT:    vmov.f32 s0, s18
 ; BE-I32-NEXT:    vmov.32 d10[0], r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov.f32 s0, s17
-; BE-I32-NEXT:    vmov.32 d11[1], r0
+; BE-I32-NEXT:    vmov.32 d11[0], r0
 ; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.f32 s0, s19
 ; BE-I32-NEXT:    vmov.32 d10[1], r0
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.32 d11[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q5
 ; BE-I32-NEXT:    vpop {d8, d9, d10, d11}
 ; BE-I32-NEXT:    pop {r11, pc}
@@ -1500,25 +1503,25 @@ define <4 x iXLen> @lrint_v4f32(<4 x float> %x) {
 ; BE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
 ; BE-I64-NEXT:    vrev64.32 d8, d1
 ; BE-I64-NEXT:    vrev64.32 d9, d0
-; BE-I64-NEXT:    vmov.f32 s0, s17
-; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.f32 s0, s18
-; BE-I64-NEXT:    mov r4, r1
-; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    vmov.f32 s0, s16
 ; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.f32 s0, s19
-; BE-I64-NEXT:    mov r5, r1
-; BE-I64-NEXT:    vmov.32 d12[0], r0
+; BE-I64-NEXT:    mov r4, r1
+; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.f32 s0, s16
-; BE-I64-NEXT:    mov r6, r1
+; BE-I64-NEXT:    vmov.f32 s0, s18
+; BE-I64-NEXT:    mov r5, r1
 ; BE-I64-NEXT:    vmov.32 d13[0], r0
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.32 d10[0], r0
-; BE-I64-NEXT:    vmov.32 d13[1], r6
-; BE-I64-NEXT:    vmov.32 d11[1], r4
-; BE-I64-NEXT:    vmov.32 d12[1], r5
-; BE-I64-NEXT:    vmov.32 d10[1], r1
+; BE-I64-NEXT:    vmov.f32 s0, s17
+; BE-I64-NEXT:    mov r6, r1
+; BE-I64-NEXT:    vmov.32 d12[0], r0
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    vmov.32 d12[1], r6
+; BE-I64-NEXT:    vmov.32 d10[1], r4
+; BE-I64-NEXT:    vmov.32 d13[1], r5
+; BE-I64-NEXT:    vmov.32 d11[1], r1
 ; BE-I64-NEXT:    vrev64.32 q0, q6
 ; BE-I64-NEXT:    vrev64.32 q1, q5
 ; BE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
@@ -1534,34 +1537,34 @@ define <8 x iXLen> @lrint_v8f32(<8 x float> %x) {
 ; LE-I32-NEXT:    push {r11, lr}
 ; LE-I32-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; LE-I32-NEXT:    vorr q5, q1, q1
-; LE-I32-NEXT:    vorr q7, q0, q0
-; LE-I32-NEXT:    vmov.f32 s0, s20
+; LE-I32-NEXT:    vorr q4, q1, q1
+; LE-I32-NEXT:    vorr q5, q0, q0
+; LE-I32-NEXT:    vmov.f32 s0, s18
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s22
-; LE-I32-NEXT:    vmov.32 d8[0], r0
-; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s30
-; LE-I32-NEXT:    vmov.32 d9[0], r0
-; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s28
+; LE-I32-NEXT:    vmov.f32 s0, s16
 ; LE-I32-NEXT:    vmov.32 d13[0], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s31
+; LE-I32-NEXT:    vmov.f32 s0, s20
 ; LE-I32-NEXT:    vmov.32 d12[0], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s29
-; LE-I32-NEXT:    vmov.32 d13[1], r0
-; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s23
-; LE-I32-NEXT:    vmov.32 d12[1], r0
+; LE-I32-NEXT:    vmov.f32 s0, s22
+; LE-I32-NEXT:    vmov.32 d14[0], r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov.f32 s0, s21
-; LE-I32-NEXT:    vmov.32 d9[1], r0
+; LE-I32-NEXT:    vmov.32 d15[0], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.32 d8[1], r0
-; LE-I32-NEXT:    vorr q0, q6, q6
-; LE-I32-NEXT:    vorr q1, q4, q4
+; LE-I32-NEXT:    vmov.f32 s0, s23
+; LE-I32-NEXT:    vmov.32 d14[1], r0
+; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov.f32 s0, s17
+; LE-I32-NEXT:    vmov.32 d15[1], r0
+; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov.f32 s0, s19
+; LE-I32-NEXT:    vmov.32 d12[1], r0
+; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov.32 d13[1], r0
+; LE-I32-NEXT:    vorr q0, q7, q7
+; LE-I32-NEXT:    vorr q1, q6, q6
 ; LE-I32-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I32-NEXT:    pop {r11, pc}
 ;
@@ -1577,54 +1580,54 @@ define <8 x iXLen> @lrint_v8f32(<8 x float> %x) {
 ; LE-I64-NEXT:    add lr, sp, #24
 ; LE-I64-NEXT:    vorr q7, q0, q0
 ; LE-I64-NEXT:    vstmia lr, {d2, d3} @ 16-byte Spill
-; LE-I64-NEXT:    vmov.f32 s0, s27
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s24
-; LE-I64-NEXT:    mov r8, r1
-; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    vmov.f32 s0, s26
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov.f32 s0, s25
+; LE-I64-NEXT:    mov r8, r1
+; LE-I64-NEXT:    vmov.32 d8[0], r0
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.f32 s0, s24
 ; LE-I64-NEXT:    mov r9, r1
-; LE-I64-NEXT:    vmov.32 d10[0], r0
+; LE-I64-NEXT:    vmov.32 d11[0], r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vorr q6, q7, q7
 ; LE-I64-NEXT:    add lr, sp, #8
 ; LE-I64-NEXT:    mov r10, r1
-; LE-I64-NEXT:    vmov.32 d11[0], r0
-; LE-I64-NEXT:    vmov.f32 s0, s26
+; LE-I64-NEXT:    vmov.32 d10[0], r0
+; LE-I64-NEXT:    vmov.f32 s0, s27
 ; LE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s27
+; LE-I64-NEXT:    vmov.f32 s0, s26
 ; LE-I64-NEXT:    mov r7, r1
-; LE-I64-NEXT:    vmov.32 d14[0], r0
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s24
-; LE-I64-NEXT:    mov r4, r1
 ; LE-I64-NEXT:    vmov.32 d15[0], r0
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.f32 s0, s25
+; LE-I64-NEXT:    mov r4, r1
+; LE-I64-NEXT:    vmov.32 d14[0], r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    add lr, sp, #8
 ; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    vmov.32 d13[0], r0
 ; LE-I64-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; LE-I64-NEXT:    vmov.f32 s0, s1
+; LE-I64-NEXT:    @ kill: def $s0 killed $s0 killed $q0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    add lr, sp, #24
 ; LE-I64-NEXT:    mov r6, r1
-; LE-I64-NEXT:    vmov.32 d13[0], r0
+; LE-I64-NEXT:    vmov.32 d12[0], r0
 ; LE-I64-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; LE-I64-NEXT:    vmov.f32 s0, s2
+; LE-I64-NEXT:    vmov.f32 s0, s3
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    vmov.32 d13[1], r6
-; LE-I64-NEXT:    vmov.32 d15[1], r4
-; LE-I64-NEXT:    vmov.32 d11[1], r10
-; LE-I64-NEXT:    vmov.32 d9[1], r8
-; LE-I64-NEXT:    vmov.32 d12[1], r5
-; LE-I64-NEXT:    vmov.32 d14[1], r7
+; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    vmov.32 d12[1], r6
+; LE-I64-NEXT:    vmov.32 d14[1], r4
+; LE-I64-NEXT:    vmov.32 d10[1], r10
+; LE-I64-NEXT:    vmov.32 d8[1], r8
+; LE-I64-NEXT:    vmov.32 d13[1], r5
+; LE-I64-NEXT:    vmov.32 d15[1], r7
 ; LE-I64-NEXT:    vorr q0, q6, q6
-; LE-I64-NEXT:    vmov.32 d10[1], r9
+; LE-I64-NEXT:    vmov.32 d11[1], r9
 ; LE-I64-NEXT:    vorr q1, q7, q7
-; LE-I64-NEXT:    vmov.32 d8[1], r1
+; LE-I64-NEXT:    vmov.32 d9[1], r1
 ; LE-I64-NEXT:    vorr q2, q5, q5
 ; LE-I64-NEXT:    vorr q3, q4, q4
 ; LE-I64-NEXT:    add sp, sp, #40
@@ -1639,30 +1642,30 @@ define <8 x iXLen> @lrint_v8f32(<8 x float> %x) {
 ; BE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-I32-NEXT:    vrev64.32 q4, q1
 ; BE-I32-NEXT:    vrev64.32 q5, q0
-; BE-I32-NEXT:    vmov.f32 s0, s16
-; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s20
-; BE-I32-NEXT:    vmov.32 d12[0], r0
-; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov.f32 s0, s18
-; BE-I32-NEXT:    vmov.32 d14[0], r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov.f32 s0, s22
 ; BE-I32-NEXT:    vmov.32 d13[0], r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s19
+; BE-I32-NEXT:    vmov.f32 s0, s16
 ; BE-I32-NEXT:    vmov.32 d15[0], r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s23
-; BE-I32-NEXT:    vmov.32 d13[1], r0
-; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s21
-; BE-I32-NEXT:    vmov.32 d15[1], r0
+; BE-I32-NEXT:    vmov.f32 s0, s20
+; BE-I32-NEXT:    vmov.32 d12[0], r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov.f32 s0, s17
+; BE-I32-NEXT:    vmov.32 d14[0], r0
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.f32 s0, s21
+; BE-I32-NEXT:    vmov.32 d12[1], r0
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.f32 s0, s23
 ; BE-I32-NEXT:    vmov.32 d14[1], r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.32 d12[1], r0
+; BE-I32-NEXT:    vmov.f32 s0, s19
+; BE-I32-NEXT:    vmov.32 d15[1], r0
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.32 d13[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q7
 ; BE-I32-NEXT:    vrev64.32 q1, q6
 ; BE-I32-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
@@ -1677,61 +1680,60 @@ define <8 x iXLen> @lrint_v8f32(<8 x float> %x) {
 ; BE-I64-NEXT:    .pad #32
 ; BE-I64-NEXT:    sub sp, sp, #32
 ; BE-I64-NEXT:    vorr q4, q1, q1
-; BE-I64-NEXT:    add lr, sp, #8
-; BE-I64-NEXT:    vorr q5, q0, q0
-; BE-I64-NEXT:    vstmia lr, {d0, d1} @ 16-byte Spill
+; BE-I64-NEXT:    vorr q7, q0, q0
 ; BE-I64-NEXT:    vrev64.32 d12, d8
-; BE-I64-NEXT:    vmov.f32 s0, s25
-; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.f32 s0, s24
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.f32 s0, s25
 ; BE-I64-NEXT:    mov r8, r1
-; BE-I64-NEXT:    vmov.32 d15[0], r0
-; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vrev64.32 d0, d11
-; BE-I64-NEXT:    mov r9, r1
-; BE-I64-NEXT:    vrev64.32 d8, d9
-; BE-I64-NEXT:    vorr d9, d0, d0
-; BE-I64-NEXT:    vmov.32 d14[0], r0
-; BE-I64-NEXT:    vstr d8, [sp, #24] @ 8-byte Spill
-; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.f32 s0, s17
-; BE-I64-NEXT:    mov r10, r1
 ; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    add lr, sp, #8
-; BE-I64-NEXT:    vmov.f32 s0, s19
-; BE-I64-NEXT:    mov r7, r1
-; BE-I64-NEXT:    vmov.32 d13[0], r0
-; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; BE-I64-NEXT:    vrev64.32 d8, d16
-; BE-I64-NEXT:    vstr d8, [sp, #8] @ 8-byte Spill
+; BE-I64-NEXT:    vrev64.32 d1, d15
+; BE-I64-NEXT:    add lr, sp, #16
+; BE-I64-NEXT:    vrev64.32 d9, d9
+; BE-I64-NEXT:    mov r9, r1
+; BE-I64-NEXT:    vmov.f32 s0, s3
+; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; BE-I64-NEXT:    vstr d9, [sp, #8] @ 8-byte Spill
+; BE-I64-NEXT:    vmov.f64 d8, d1
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.f32 s0, s16
-; BE-I64-NEXT:    mov r4, r1
+; BE-I64-NEXT:    vmov.f32 s0, s18
+; BE-I64-NEXT:    mov r10, r1
 ; BE-I64-NEXT:    vmov.32 d11[0], r0
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vldr d0, [sp, #8] @ 8-byte Reload
+; BE-I64-NEXT:    vmov.f32 s0, s16
+; BE-I64-NEXT:    mov r7, r1
+; BE-I64-NEXT:    vmov.32 d12[0], r0
+; BE-I64-NEXT:    vrev64.32 d9, d14
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.f32 s0, s19
+; BE-I64-NEXT:    mov r4, r1
+; BE-I64-NEXT:    vmov.32 d10[0], r0
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.f32 s0, s18
 ; BE-I64-NEXT:    mov r5, r1
-; BE-I64-NEXT:    vmov.32 d8[0], r0
+; BE-I64-NEXT:    vmov.32 d15[0], r0
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vldr d0, [sp, #8] @ 8-byte Reload
+; BE-I64-NEXT:    mov r6, r1
+; BE-I64-NEXT:    vmov.32 d14[0], r0
 ; BE-I64-NEXT:    vmov.f32 s0, s1
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vldr d0, [sp, #24] @ 8-byte Reload
-; BE-I64-NEXT:    mov r6, r1
-; BE-I64-NEXT:    @ kill: def $s0 killed $s0 killed $d0
-; BE-I64-NEXT:    vmov.32 d9[0], r0
-; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.32 d12[0], r0
-; BE-I64-NEXT:    vmov.32 d9[1], r6
-; BE-I64-NEXT:    vmov.32 d11[1], r4
-; BE-I64-NEXT:    vmov.32 d15[1], r8
-; BE-I64-NEXT:    vmov.32 d13[1], r7
-; BE-I64-NEXT:    vmov.32 d8[1], r5
-; BE-I64-NEXT:    vmov.32 d10[1], r10
-; BE-I64-NEXT:    vmov.32 d14[1], r9
-; BE-I64-NEXT:    vmov.32 d12[1], r1
-; BE-I64-NEXT:    vrev64.32 q0, q4
+; BE-I64-NEXT:    add lr, sp, #16
+; BE-I64-NEXT:    vmov.32 d13[0], r0
+; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; BE-I64-NEXT:    vmov.32 d14[1], r6
+; BE-I64-NEXT:    vmov.32 d10[1], r4
+; BE-I64-NEXT:    vmov.32 d16[1], r8
+; BE-I64-NEXT:    vmov.32 d12[1], r7
+; BE-I64-NEXT:    vmov.32 d15[1], r5
+; BE-I64-NEXT:    vmov.32 d11[1], r10
+; BE-I64-NEXT:    vmov.32 d17[1], r9
+; BE-I64-NEXT:    vmov.32 d13[1], r1
+; BE-I64-NEXT:    vrev64.32 q0, q7
 ; BE-I64-NEXT:    vrev64.32 q1, q5
-; BE-I64-NEXT:    vrev64.32 q2, q7
+; BE-I64-NEXT:    vrev64.32 q2, q8
 ; BE-I64-NEXT:    vrev64.32 q3, q6
 ; BE-I64-NEXT:    add sp, sp, #32
 ; BE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
@@ -1750,82 +1752,81 @@ define <16 x iXLen> @lrint_v16f32(<16 x float> %x) {
 ; LE-I32-NEXT:    .pad #80
 ; LE-I32-NEXT:    sub sp, sp, #80
 ; LE-I32-NEXT:    vorr q5, q3, q3
-; LE-I32-NEXT:    vstmia sp, {d0, d1} @ 16-byte Spill
 ; LE-I32-NEXT:    add lr, sp, #32
-; LE-I32-NEXT:    vorr q6, q2, q2
-; LE-I32-NEXT:    vorr q7, q1, q1
-; LE-I32-NEXT:    vmov.f32 s0, s20
+; LE-I32-NEXT:    vorr q4, q0, q0
+; LE-I32-NEXT:    vstmia sp, {d2, d3} @ 16-byte Spill
+; LE-I32-NEXT:    vorr q7, q2, q2
+; LE-I32-NEXT:    vmov.f32 s0, s22
 ; LE-I32-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s22
-; LE-I32-NEXT:    vmov.32 d8[0], r0
+; LE-I32-NEXT:    vmov.f32 s0, s20
+; LE-I32-NEXT:    vmov.32 d13[0], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s24
+; LE-I32-NEXT:    vmov.f32 s0, s30
+; LE-I32-NEXT:    vmov.32 d12[0], r0
 ; LE-I32-NEXT:    add lr, sp, #48
-; LE-I32-NEXT:    vmov.32 d9[0], r0
-; LE-I32-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
-; LE-I32-NEXT:    add lr, sp, #16
 ; LE-I32-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
+; LE-I32-NEXT:    add lr, sp, #16
+; LE-I32-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s26
-; LE-I32-NEXT:    vmov.32 d8[0], r0
-; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    add lr, sp, #64
-; LE-I32-NEXT:    vmov.32 d9[0], r0
-; LE-I32-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
-; LE-I32-NEXT:    vorr q4, q7, q7
-; LE-I32-NEXT:    vmov.f32 s0, s16
-; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s18
-; LE-I32-NEXT:    vmov.32 d10[0], r0
+; LE-I32-NEXT:    vmov.f32 s0, s28
+; LE-I32-NEXT:    vmov.32 d11[0], r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vldmia sp, {d12, d13} @ 16-byte Reload
 ; LE-I32-NEXT:    vmov.f32 s0, s26
-; LE-I32-NEXT:    vmov.32 d11[0], r0
+; LE-I32-NEXT:    add lr, sp, #64
+; LE-I32-NEXT:    vmov.32 d10[0], r0
+; LE-I32-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov.f32 s0, s24
-; LE-I32-NEXT:    vmov.32 d15[0], r0
+; LE-I32-NEXT:    vmov.32 d11[0], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s27
+; LE-I32-NEXT:    vmov.f32 s0, s16
+; LE-I32-NEXT:    vmov.32 d10[0], r0
+; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov.f32 s0, s18
 ; LE-I32-NEXT:    vmov.32 d14[0], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s25
-; LE-I32-NEXT:    vmov.32 d15[1], r0
+; LE-I32-NEXT:    vmov.f32 s0, s17
+; LE-I32-NEXT:    vmov.32 d15[0], r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov.f32 s0, s19
 ; LE-I32-NEXT:    vmov.32 d14[1], r0
 ; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s17
-; LE-I32-NEXT:    vmov.32 d11[1], r0
+; LE-I32-NEXT:    vmov.f32 s0, s25
+; LE-I32-NEXT:    vmov.32 d15[1], r0
+; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov.f32 s0, s27
+; LE-I32-NEXT:    vmov.32 d10[1], r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    add lr, sp, #16
-; LE-I32-NEXT:    vmov.32 d10[1], r0
-; LE-I32-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
-; LE-I32-NEXT:    vmov.f32 s0, s27
-; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.f32 s0, s25
-; LE-I32-NEXT:    add lr, sp, #64
+; LE-I32-NEXT:    vmov.32 d11[1], r0
 ; LE-I32-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; LE-I32-NEXT:    vmov.32 d9[1], r0
-; LE-I32-NEXT:    bl lrintf
-; LE-I32-NEXT:    vmov.32 d8[1], r0
-; LE-I32-NEXT:    add lr, sp, #64
-; LE-I32-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
-; LE-I32-NEXT:    add lr, sp, #32
-; LE-I32-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; LE-I32-NEXT:    vmov.f32 s0, s19
-; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    vmov.f32 s0, s17
-; LE-I32-NEXT:    add lr, sp, #48
+; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov.f32 s0, s19
+; LE-I32-NEXT:    add lr, sp, #64
 ; LE-I32-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
-; LE-I32-NEXT:    vmov.32 d13[1], r0
+; LE-I32-NEXT:    vmov.32 d12[1], r0
 ; LE-I32-NEXT:    bl lrintf
 ; LE-I32-NEXT:    add lr, sp, #64
-; LE-I32-NEXT:    vmov.32 d12[1], r0
+; LE-I32-NEXT:    vmov.32 d13[1], r0
+; LE-I32-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
+; LE-I32-NEXT:    add lr, sp, #32
+; LE-I32-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
+; LE-I32-NEXT:    vmov.f32 s0, s25
+; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    vmov.f32 s0, s27
+; LE-I32-NEXT:    add lr, sp, #48
+; LE-I32-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
+; LE-I32-NEXT:    vmov.32 d8[1], r0
+; LE-I32-NEXT:    bl lrintf
+; LE-I32-NEXT:    add lr, sp, #64
+; LE-I32-NEXT:    vmov.32 d9[1], r0
 ; LE-I32-NEXT:    vorr q0, q7, q7
 ; LE-I32-NEXT:    vldmia lr, {d4, d5} @ 16-byte Reload
+; LE-I32-NEXT:    vorr q3, q4, q4
 ; LE-I32-NEXT:    vorr q1, q5, q5
-; LE-I32-NEXT:    vorr q3, q6, q6
 ; LE-I32-NEXT:    add sp, sp, #80
 ; LE-I32-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I32-NEXT:    pop {r11, pc}
@@ -1838,150 +1839,144 @@ define <16 x iXLen> @lrint_v16f32(<16 x float> %x) {
 ; LE-I64-NEXT:    sub sp, sp, #4
 ; LE-I64-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; LE-I64-NEXT:    .pad #160
-; LE-I64-NEXT:    sub sp, sp, #160
-; LE-I64-NEXT:    add lr, sp, #112
-; LE-I64-NEXT:    vorr q5, q3, q3
-; LE-I64-NEXT:    vorr q6, q0, q0
+; LE-I64-NEXT:    .pad #152
+; LE-I64-NEXT:    sub sp, sp, #152
+; LE-I64-NEXT:    add lr, sp, #64
+; LE-I64-NEXT:    vorr q6, q3, q3
+; LE-I64-NEXT:    vorr q4, q0, q0
 ; LE-I64-NEXT:    mov r4, r0
 ; LE-I64-NEXT:    vstmia lr, {d4, d5} @ 16-byte Spill
 ; LE-I64-NEXT:    add lr, sp, #48
 ; LE-I64-NEXT:    vorr q7, q1, q1
 ; LE-I64-NEXT:    vstmia lr, {d0, d1} @ 16-byte Spill
-; LE-I64-NEXT:    vmov.f32 s0, s23
+; LE-I64-NEXT:    vmov.f32 s0, s26
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s24
-; LE-I64-NEXT:    add lr, sp, #144
-; LE-I64-NEXT:    vmov.32 d17[0], r0
-; LE-I64-NEXT:    str r1, [sp, #108] @ 4-byte Spill
+; LE-I64-NEXT:    vmov.f32 s0, s17
+; LE-I64-NEXT:    vmov.32 d16[0], r0
+; LE-I64-NEXT:    add lr, sp, #136
+; LE-I64-NEXT:    str r1, [sp, #100] @ 4-byte Spill
 ; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s25
-; LE-I64-NEXT:    str r1, [sp, #84] @ 4-byte Spill
-; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s28
-; LE-I64-NEXT:    add lr, sp, #128
-; LE-I64-NEXT:    vmov.32 d9[0], r0
-; LE-I64-NEXT:    str r1, [sp, #44] @ 4-byte Spill
-; LE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; LE-I64-NEXT:    vmov.f32 s0, s16
+; LE-I64-NEXT:    str r1, [sp, #96] @ 4-byte Spill
+; LE-I64-NEXT:    vmov.32 d11[0], r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov.f32 s0, s29
-; LE-I64-NEXT:    mov r9, r1
+; LE-I64-NEXT:    vmov.32 d10[0], r0
+; LE-I64-NEXT:    add lr, sp, #120
+; LE-I64-NEXT:    str r1, [sp, #44] @ 4-byte Spill
+; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.f32 s0, s28
+; LE-I64-NEXT:    mov r11, r1
+; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.f32 s0, s31
+; LE-I64-NEXT:    mov r6, r1
 ; LE-I64-NEXT:    vmov.32 d8[0], r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    vmov.f32 s0, s30
-; LE-I64-NEXT:    mov r6, r1
-; LE-I64-NEXT:    vmov.32 d9[0], r0
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s31
 ; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    vmov.32 d11[0], r0
 ; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    add lr, sp, #112
-; LE-I64-NEXT:    mov r7, r1
-; LE-I64-NEXT:    vmov.32 d13[0], r0
-; LE-I64-NEXT:    vldmia lr, {d14, d15} @ 16-byte Reload
-; LE-I64-NEXT:    vmov.f32 s0, s29
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s22
-; LE-I64-NEXT:    add lr, sp, #24
-; LE-I64-NEXT:    vmov.32 d17[0], r0
-; LE-I64-NEXT:    mov r11, r1
-; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; LE-I64-NEXT:    vmov.32 d13[1], r7
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    add lr, sp, #144
-; LE-I64-NEXT:    vmov.f32 s0, s21
-; LE-I64-NEXT:    vmov.32 d12[1], r5
-; LE-I64-NEXT:    str r1, [sp, #40] @ 4-byte Spill
-; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-I64-NEXT:    vmov.32 d16[0], r0
-; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; LE-I64-NEXT:    add lr, sp, #88
-; LE-I64-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s20
-; LE-I64-NEXT:    mov r10, r1
-; LE-I64-NEXT:    vmov.32 d13[0], r0
-; LE-I64-NEXT:    vmov.32 d9[1], r6
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s31
-; LE-I64-NEXT:    vmov.32 d12[0], r0
-; LE-I64-NEXT:    add lr, sp, #8
-; LE-I64-NEXT:    mov r8, r1
-; LE-I64-NEXT:    vmov.32 d8[1], r9
-; LE-I64-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
-; LE-I64-NEXT:    add lr, sp, #64
-; LE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    add lr, sp, #128
-; LE-I64-NEXT:    vmov.32 d9[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
-; LE-I64-NEXT:    mov r9, r1
-; LE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-I64-NEXT:    add lr, sp, #48
-; LE-I64-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
 ; LE-I64-NEXT:    vmov.f32 s0, s27
-; LE-I64-NEXT:    vmov.32 d11[1], r0
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    vmov.f32 s0, s26
-; LE-I64-NEXT:    vmov.32 d15[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #84] @ 4-byte Reload
-; LE-I64-NEXT:    add lr, sp, #128
 ; LE-I64-NEXT:    mov r7, r1
-; LE-I64-NEXT:    vmov.32 d10[1], r0
+; LE-I64-NEXT:    vmov.32 d10[0], r0
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.f32 s0, s24
+; LE-I64-NEXT:    add lr, sp, #136
+; LE-I64-NEXT:    str r1, [sp, #40] @ 4-byte Spill
+; LE-I64-NEXT:    vmov.32 d10[1], r7
+; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-I64-NEXT:    vmov.32 d17[0], r0
+; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.f32 s0, s25
+; LE-I64-NEXT:    add lr, sp, #104
+; LE-I64-NEXT:    vmov.32 d11[1], r5
+; LE-I64-NEXT:    mov r9, r1
+; LE-I64-NEXT:    vmov.32 d14[0], r0
 ; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    add lr, sp, #24
+; LE-I64-NEXT:    vmov.32 d15[0], r0
+; LE-I64-NEXT:    mov r10, r1
+; LE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-I64-NEXT:    add lr, sp, #64
+; LE-I64-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
+; LE-I64-NEXT:    vmov.f32 s0, s26
+; LE-I64-NEXT:    vmov.32 d8[1], r6
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.f32 s0, s27
+; LE-I64-NEXT:    add lr, sp, #80
+; LE-I64-NEXT:    vmov.32 d9[1], r11
+; LE-I64-NEXT:    mov r8, r1
 ; LE-I64-NEXT:    vmov.32 d14[0], r0
-; LE-I64-NEXT:    add lr, sp, #144
-; LE-I64-NEXT:    ldr r0, [sp, #108] @ 4-byte Reload
-; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-I64-NEXT:    vmov.32 d17[1], r0
-; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; LE-I64-NEXT:    add lr, sp, #112
+; LE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    add lr, sp, #8
+; LE-I64-NEXT:    vmov.32 d15[0], r0
+; LE-I64-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
+; LE-I64-NEXT:    mov r11, r1
+; LE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-I64-NEXT:    add lr, sp, #120
+; LE-I64-NEXT:    vldmia lr, {d14, d15} @ 16-byte Reload
+; LE-I64-NEXT:    add lr, sp, #48
 ; LE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-I64-NEXT:    vmov.f32 s0, s20
+; LE-I64-NEXT:    vmov.f32 s0, s22
+; LE-I64-NEXT:    vmov.32 d14[1], r0
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.f32 s0, s23
+; LE-I64-NEXT:    vmov.32 d8[0], r0
+; LE-I64-NEXT:    ldr r0, [sp, #96] @ 4-byte Reload
+; LE-I64-NEXT:    add lr, sp, #120
+; LE-I64-NEXT:    mov r6, r1
+; LE-I64-NEXT:    vmov.32 d15[1], r0
+; LE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.f32 s0, s24
+; LE-I64-NEXT:    add lr, sp, #136
+; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    ldr r0, [sp, #100] @ 4-byte Reload
+; LE-I64-NEXT:    mov r5, r1
+; LE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
+; LE-I64-NEXT:    vmov.32 d10[1], r0
+; LE-I64-NEXT:    bl lrintf
+; LE-I64-NEXT:    vmov.f32 s0, s25
+; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
+; LE-I64-NEXT:    mov r7, r1
+; LE-I64-NEXT:    vmov.32 d11[1], r0
 ; LE-I64-NEXT:    bl lrintf
 ; LE-I64-NEXT:    add lr, sp, #24
-; LE-I64-NEXT:    vmov.f32 s0, s22
-; LE-I64-NEXT:    mov r6, r1
-; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-I64-NEXT:    vmov.32 d16[0], r0
-; LE-I64-NEXT:    vmov.32 d17[1], r11
-; LE-I64-NEXT:    vorr q6, q8, q8
-; LE-I64-NEXT:    bl lrintf
-; LE-I64-NEXT:    add lr, sp, #144
-; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #40] @ 4-byte Reload
+; LE-I64-NEXT:    vmov.32 d15[0], r0
+; LE-I64-NEXT:    add r0, r4, #64
 ; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I64-NEXT:    add lr, sp, #8
 ; LE-I64-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
-; LE-I64-NEXT:    add lr, sp, #128
-; LE-I64-NEXT:    vmov.32 d9[1], r9
-; LE-I64-NEXT:    vmov.32 d12[1], r6
-; LE-I64-NEXT:    vmov.32 d19[1], r10
-; LE-I64-NEXT:    vmov.32 d8[1], r1
-; LE-I64-NEXT:    vmov.32 d16[1], r0
-; LE-I64-NEXT:    add r0, r4, #64
+; LE-I64-NEXT:    add lr, sp, #120
+; LE-I64-NEXT:    vmov.32 d14[1], r7
 ; LE-I64-NEXT:    vmov.32 d18[1], r8
-; LE-I64-NEXT:    vst1.64 {d12, d13}, [r0:128]!
-; LE-I64-NEXT:    vst1.64 {d8, d9}, [r0:128]!
+; LE-I64-NEXT:    vmov.32 d15[1], r1
+; LE-I64-NEXT:    vmov.32 d16[1], r9
+; LE-I64-NEXT:    vmov.32 d19[1], r11
+; LE-I64-NEXT:    vmov.32 d17[1], r10
+; LE-I64-NEXT:    vst1.64 {d14, d15}, [r0:128]!
 ; LE-I64-NEXT:    vst1.64 {d18, d19}, [r0:128]!
-; LE-I64-NEXT:    vst1.64 {d16, d17}, [r0:128]
-; LE-I64-NEXT:    vmov.32 d15[1], r7
+; LE-I64-NEXT:    vst1.64 {d16, d17}, [r0:128]!
+; LE-I64-NEXT:    vst1.64 {d10, d11}, [r0:128]
+; LE-I64-NEXT:    vmov.32 d8[1], r6
 ; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-I64-NEXT:    add lr, sp, #64
-; LE-I64-NEXT:    vmov.32 d14[1], r5
+; LE-I64-NEXT:    add lr, sp, #80
+; LE-I64-NEXT:    vmov.32 d9[1], r5
 ; LE-I64-NEXT:    vst1.64 {d16, d17}, [r4:128]!
-; LE-I64-NEXT:    vst1.64 {d14, d15}, [r4:128]!
+; LE-I64-NEXT:    vst1.64 {d8, d9}, [r4:128]!
 ; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-I64-NEXT:    add lr, sp, #88
+; LE-I64-NEXT:    add lr, sp, #104
 ; LE-I64-NEXT:    vst1.64 {d16, d17}, [r4:128]!
 ; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I64-NEXT:    vst1.64 {d16, d17}, [r4:128]
-; LE-I64-NEXT:    add sp, sp, #160
+; LE-I64-NEXT:    add sp, sp, #152
 ; LE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    add sp, sp, #4
 ; LE-I64-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
@@ -1997,86 +1992,86 @@ define <16 x iXLen> @lrint_v16f32(<16 x float> %x) {
 ; BE-I32-NEXT:    vrev64.32 q3, q3
 ; BE-I32-NEXT:    add lr, sp, #64
 ; BE-I32-NEXT:    vrev64.32 q4, q0
-; BE-I32-NEXT:    vmov.f32 s0, s12
+; BE-I32-NEXT:    vmov.f32 s0, s14
 ; BE-I32-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; BE-I32-NEXT:    add lr, sp, #32
 ; BE-I32-NEXT:    vrev64.32 q5, q1
 ; BE-I32-NEXT:    vrev64.32 q7, q2
 ; BE-I32-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s16
-; BE-I32-NEXT:    vmov.32 d16[0], r0
+; BE-I32-NEXT:    vmov.f32 s0, s18
 ; BE-I32-NEXT:    add lr, sp, #80
+; BE-I32-NEXT:    vmov.32 d17[0], r0
 ; BE-I32-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s18
-; BE-I32-NEXT:    vmov.32 d12[0], r0
-; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s20
-; BE-I32-NEXT:    add lr, sp, #48
+; BE-I32-NEXT:    vmov.f32 s0, s16
 ; BE-I32-NEXT:    vmov.32 d13[0], r0
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.f32 s0, s22
+; BE-I32-NEXT:    vmov.32 d12[0], r0
+; BE-I32-NEXT:    add lr, sp, #48
 ; BE-I32-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
 ; BE-I32-NEXT:    add lr, sp, #16
 ; BE-I32-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s22
-; BE-I32-NEXT:    vmov.32 d8[0], r0
-; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s28
+; BE-I32-NEXT:    vmov.f32 s0, s20
 ; BE-I32-NEXT:    vmov.32 d9[0], r0
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.f32 s0, s30
+; BE-I32-NEXT:    vmov.32 d8[0], r0
 ; BE-I32-NEXT:    vstmia sp, {d8, d9} @ 16-byte Spill
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    add lr, sp, #64
-; BE-I32-NEXT:    vmov.32 d12[0], r0
+; BE-I32-NEXT:    vmov.32 d13[0], r0
 ; BE-I32-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; BE-I32-NEXT:    vmov.f32 s0, s22
+; BE-I32-NEXT:    vmov.f32 s0, s20
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s30
+; BE-I32-NEXT:    vmov.f32 s0, s28
 ; BE-I32-NEXT:    add lr, sp, #80
 ; BE-I32-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; BE-I32-NEXT:    vmov.32 d9[0], r0
+; BE-I32-NEXT:    vmov.32 d8[0], r0
 ; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s23
-; BE-I32-NEXT:    vmov.32 d13[0], r0
-; BE-I32-NEXT:    bl lrintf
-; BE-I32-NEXT:    vmov.f32 s0, s31
-; BE-I32-NEXT:    add lr, sp, #80
-; BE-I32-NEXT:    vmov.32 d9[1], r0
-; BE-I32-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; BE-I32-NEXT:    vmov.f32 s0, s21
+; BE-I32-NEXT:    vmov.32 d12[0], r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov.f32 s0, s29
-; BE-I32-NEXT:    vmov.32 d13[1], r0
+; BE-I32-NEXT:    vmov.32 d8[1], r0
+; BE-I32-NEXT:    add lr, sp, #80
+; BE-I32-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.f32 s0, s31
+; BE-I32-NEXT:    vmov.32 d12[1], r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    add lr, sp, #16
-; BE-I32-NEXT:    vmov.32 d12[1], r0
+; BE-I32-NEXT:    vmov.32 d13[1], r0
 ; BE-I32-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; BE-I32-NEXT:    vmov.f32 s0, s19
-; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov.f32 s0, s17
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.f32 s0, s19
 ; BE-I32-NEXT:    vldmia sp, {d10, d11} @ 16-byte Reload
-; BE-I32-NEXT:    vmov.32 d11[1], r0
+; BE-I32-NEXT:    vmov.32 d10[1], r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    add lr, sp, #32
-; BE-I32-NEXT:    vmov.32 d10[1], r0
+; BE-I32-NEXT:    vmov.32 d11[1], r0
 ; BE-I32-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; BE-I32-NEXT:    vmov.f32 s0, s19
 ; BE-I32-NEXT:    vorr q7, q5, q5
-; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    vmov.f32 s0, s17
+; BE-I32-NEXT:    bl lrintf
+; BE-I32-NEXT:    vmov.f32 s0, s19
 ; BE-I32-NEXT:    add lr, sp, #48
 ; BE-I32-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; BE-I32-NEXT:    vmov.32 d11[1], r0
+; BE-I32-NEXT:    vmov.32 d10[1], r0
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    add lr, sp, #64
-; BE-I32-NEXT:    vmov.32 d10[1], r0
+; BE-I32-NEXT:    vmov.32 d11[1], r0
 ; BE-I32-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; BE-I32-NEXT:    vmov.f32 s0, s1
+; BE-I32-NEXT:    vmov.f32 s0, s3
 ; BE-I32-NEXT:    bl lrintf
 ; BE-I32-NEXT:    add lr, sp, #80
 ; BE-I32-NEXT:    vrev64.32 q0, q5
 ; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; BE-I32-NEXT:    vmov.32 d17[1], r0
 ; BE-I32-NEXT:    vrev64.32 q1, q7
-; BE-I32-NEXT:    vmov.32 d16[1], r0
 ; BE-I32-NEXT:    vrev64.32 q2, q6
 ; BE-I32-NEXT:    vrev64.32 q3, q8
 ; BE-I32-NEXT:    add sp, sp, #96
@@ -2101,79 +2096,79 @@ define <16 x iXLen> @lrint_v16f32(<16 x float> %x) {
 ; BE-I64-NEXT:    add lr, sp, #96
 ; BE-I64-NEXT:    vrev64.32 d8, d13
 ; BE-I64-NEXT:    vstmia lr, {d2, d3} @ 16-byte Spill
-; BE-I64-NEXT:    vmov.f32 s0, s17
-; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.f32 s0, s16
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.f32 s0, s17
 ; BE-I64-NEXT:    str r1, [sp, #88] @ 4-byte Spill
-; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vrev64.32 d8, d14
 ; BE-I64-NEXT:    add lr, sp, #128
-; BE-I64-NEXT:    vmov.32 d10[0], r0
-; BE-I64-NEXT:    str r1, [sp, #92] @ 4-byte Spill
-; BE-I64-NEXT:    vmov.f32 s0, s16
 ; BE-I64-NEXT:    vrev64.32 d9, d12
+; BE-I64-NEXT:    str r1, [sp, #92] @ 4-byte Spill
+; BE-I64-NEXT:    vmov.f32 s0, s17
+; BE-I64-NEXT:    vmov.32 d11[0], r0
 ; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-I64-NEXT:    vstr d9, [sp, #64] @ 8-byte Spill
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.f32 s0, s19
-; BE-I64-NEXT:    mov r9, r1
-; BE-I64-NEXT:    vmov.32 d12[0], r0
-; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.f32 s0, s17
-; BE-I64-NEXT:    str r1, [sp, #84] @ 4-byte Spill
-; BE-I64-NEXT:    vmov.32 d11[0], r0
-; BE-I64-NEXT:    vrev64.32 d9, d15
-; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.f32 s0, s18
-; BE-I64-NEXT:    mov r6, r1
+; BE-I64-NEXT:    mov r9, r1
 ; BE-I64-NEXT:    vmov.32 d13[0], r0
 ; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.f32 s0, s16
+; BE-I64-NEXT:    str r1, [sp, #84] @ 4-byte Spill
+; BE-I64-NEXT:    vmov.32 d10[0], r0
+; BE-I64-NEXT:    vrev64.32 d9, d15
+; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.f32 s0, s19
+; BE-I64-NEXT:    mov r6, r1
+; BE-I64-NEXT:    vmov.32 d12[0], r0
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.f32 s0, s18
 ; BE-I64-NEXT:    mov r5, r1
-; BE-I64-NEXT:    vmov.32 d14[0], r0
+; BE-I64-NEXT:    vmov.32 d15[0], r0
 ; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vldr d0, [sp, #64] @ 8-byte Reload
 ; BE-I64-NEXT:    mov r7, r1
-; BE-I64-NEXT:    @ kill: def $s0 killed $s0 killed $d0
-; BE-I64-NEXT:    vmov.32 d15[0], r0
+; BE-I64-NEXT:    vmov.32 d14[0], r0
+; BE-I64-NEXT:    vmov.f32 s0, s1
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    add lr, sp, #40
+; BE-I64-NEXT:    vmov.32 d11[0], r0
 ; BE-I64-NEXT:    str r1, [sp, #60] @ 4-byte Spill
-; BE-I64-NEXT:    vmov.32 d15[1], r7
 ; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-I64-NEXT:    add lr, sp, #96
 ; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; BE-I64-NEXT:    vmov.32 d14[1], r7
 ; BE-I64-NEXT:    vrev64.32 d8, d16
-; BE-I64-NEXT:    vmov.f32 s0, s17
-; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.f32 s0, s16
-; BE-I64-NEXT:    vmov.32 d14[1], r5
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.f32 s0, s17
 ; BE-I64-NEXT:    add lr, sp, #64
+; BE-I64-NEXT:    vmov.32 d15[1], r5
 ; BE-I64-NEXT:    mov r10, r1
-; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    add lr, sp, #24
+; BE-I64-NEXT:    vmov.32 d11[0], r0
 ; BE-I64-NEXT:    mov r11, r1
-; BE-I64-NEXT:    vmov.32 d13[1], r6
 ; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-I64-NEXT:    add lr, sp, #96
 ; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-I64-NEXT:    vrev64.32 d8, d17
-; BE-I64-NEXT:    vmov.f32 s0, s17
-; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.32 d12[1], r6
 ; BE-I64-NEXT:    vmov.f32 s0, s16
-; BE-I64-NEXT:    vmov.32 d12[1], r9
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.f32 s0, s17
 ; BE-I64-NEXT:    add lr, sp, #96
+; BE-I64-NEXT:    vmov.32 d13[1], r9
 ; BE-I64-NEXT:    mov r8, r1
-; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    add lr, sp, #8
+; BE-I64-NEXT:    vmov.32 d11[0], r0
 ; BE-I64-NEXT:    ldr r0, [sp, #88] @ 4-byte Reload
 ; BE-I64-NEXT:    mov r9, r1
 ; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
@@ -2182,54 +2177,54 @@ define <16 x iXLen> @lrint_v16f32(<16 x float> %x) {
 ; BE-I64-NEXT:    add lr, sp, #128
 ; BE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
 ; BE-I64-NEXT:    vrev64.32 d8, d16
-; BE-I64-NEXT:    vmov.32 d11[1], r0
-; BE-I64-NEXT:    vmov.f32 s0, s17
-; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.32 d10[1], r0
 ; BE-I64-NEXT:    vmov.f32 s0, s16
-; BE-I64-NEXT:    vmov.32 d15[0], r0
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    vmov.f32 s0, s17
+; BE-I64-NEXT:    vmov.32 d14[0], r0
 ; BE-I64-NEXT:    ldr r0, [sp, #92] @ 4-byte Reload
 ; BE-I64-NEXT:    add lr, sp, #128
 ; BE-I64-NEXT:    mov r7, r1
-; BE-I64-NEXT:    vmov.32 d10[1], r0
+; BE-I64-NEXT:    vmov.32 d11[1], r0
 ; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    add lr, sp, #112
-; BE-I64-NEXT:    vmov.32 d14[0], r0
+; BE-I64-NEXT:    vmov.32 d15[0], r0
 ; BE-I64-NEXT:    ldr r0, [sp, #84] @ 4-byte Reload
 ; BE-I64-NEXT:    mov r5, r1
 ; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-I64-NEXT:    add lr, sp, #40
 ; BE-I64-NEXT:    vrev64.32 d8, d17
 ; BE-I64-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
-; BE-I64-NEXT:    vmov.f32 s0, s17
-; BE-I64-NEXT:    vmov.32 d13[1], r0
-; BE-I64-NEXT:    bl lrintf
 ; BE-I64-NEXT:    vmov.f32 s0, s16
-; BE-I64-NEXT:    vmov.32 d11[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #60] @ 4-byte Reload
-; BE-I64-NEXT:    mov r6, r1
 ; BE-I64-NEXT:    vmov.32 d12[1], r0
 ; BE-I64-NEXT:    bl lrintf
-; BE-I64-NEXT:    add lr, sp, #24
+; BE-I64-NEXT:    vmov.f32 s0, s17
 ; BE-I64-NEXT:    vmov.32 d10[0], r0
+; BE-I64-NEXT:    ldr r0, [sp, #60] @ 4-byte Reload
+; BE-I64-NEXT:    mov r6, r1
+; BE-I64-NEXT:    vmov.32 d13[1], r0
+; BE-I64-NEXT:    bl lrintf
+; BE-I64-NEXT:    add lr, sp, #24
+; BE-I64-NEXT:    vmov.32 d11[0], r0
 ; BE-I64-NEXT:    add r0, r4, #64
 ; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-I64-NEXT:    add lr, sp, #8
-; BE-I64-NEXT:    vmov.32 d17[1], r10
-; BE-I64-NEXT:    vmov.32 d16[1], r11
+; BE-I64-NEXT:    vmov.32 d14[1], r7
+; BE-I64-NEXT:    vmov.32 d16[1], r10
+; BE-I64-NEXT:    vmov.32 d17[1], r11
 ; BE-I64-NEXT:    vorr q12, q8, q8
 ; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-I64-NEXT:    add lr, sp, #128
-; BE-I64-NEXT:    vmov.32 d15[1], r7
-; BE-I64-NEXT:    vmov.32 d11[1], r6
-; BE-I64-NEXT:    vmov.32 d14[1], r5
+; BE-I64-NEXT:    vmov.32 d10[1], r6
+; BE-I64-NEXT:    vmov.32 d15[1], r5
 ; BE-I64-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
 ; BE-I64-NEXT:    add lr, sp, #96
-; BE-I64-NEXT:    vmov.32 d10[1], r1
-; BE-I64-NEXT:    vmov.32 d17[1], r8
+; BE-I64-NEXT:    vmov.32 d11[1], r1
+; BE-I64-NEXT:    vmov.32 d16[1], r8
 ; BE-I64-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
 ; BE-I64-NEXT:    add lr, sp, #64
-; BE-I64-NEXT:    vmov.32 d16[1], r9
+; BE-I64-NEXT:    vmov.32 d17[1], r9
 ; BE-I64-NEXT:    vrev64.32 q14, q7
 ; BE-I64-NEXT:    vorr q13, q8, q8
 ; BE-I64-NEXT:    vrev64.32 q15, q5
@@ -2317,15 +2312,14 @@ define <2 x iXLen> @lrint_v2f64(<2 x double> %x) {
 ; LE-I64-NEXT:    .vsave {d8, d9, d10, d11}
 ; LE-I64-NEXT:    vpush {d8, d9, d10, d11}
 ; LE-I64-NEXT:    vorr q4, q0, q0
+; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    vorr d0, d9, d9
-; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d8, d8
 ; LE-I64-NEXT:    mov r4, r1
-; LE-I64-NEXT:    vmov.32 d11[0], r0
-; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    vmov.32 d10[0], r0
-; LE-I64-NEXT:    vmov.32 d11[1], r4
-; LE-I64-NEXT:    vmov.32 d10[1], r1
+; LE-I64-NEXT:    bl lrint
+; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    vmov.32 d10[1], r4
+; LE-I64-NEXT:    vmov.32 d11[1], r1
 ; LE-I64-NEXT:    vorr q0, q5, q5
 ; LE-I64-NEXT:    vpop {d8, d9, d10, d11}
 ; LE-I64-NEXT:    pop {r4, pc}
@@ -2353,15 +2347,14 @@ define <2 x iXLen> @lrint_v2f64(<2 x double> %x) {
 ; BE-I64-NEXT:    .vsave {d8, d9, d10, d11}
 ; BE-I64-NEXT:    vpush {d8, d9, d10, d11}
 ; BE-I64-NEXT:    vorr q4, q0, q0
+; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vorr d0, d9, d9
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d8, d8
 ; BE-I64-NEXT:    mov r4, r1
-; BE-I64-NEXT:    vmov.32 d11[0], r0
-; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vmov.32 d10[0], r0
-; BE-I64-NEXT:    vmov.32 d11[1], r4
-; BE-I64-NEXT:    vmov.32 d10[1], r1
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    vmov.32 d10[1], r4
+; BE-I64-NEXT:    vmov.32 d11[1], r1
 ; BE-I64-NEXT:    vrev64.32 q0, q5
 ; BE-I64-NEXT:    vpop {d8, d9, d10, d11}
 ; BE-I64-NEXT:    pop {r4, pc}
@@ -2378,18 +2371,17 @@ define <4 x iXLen> @lrint_v4f64(<4 x double> %x) {
 ; LE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
 ; LE-I32-NEXT:    vorr q4, q1, q1
 ; LE-I32-NEXT:    vorr q5, q0, q0
+; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vorr d0, d8, d8
-; LE-I32-NEXT:    bl lrint
-; LE-I32-NEXT:    vorr d0, d10, d10
-; LE-I32-NEXT:    vmov.32 d13[0], r0
-; LE-I32-NEXT:    bl lrint
-; LE-I32-NEXT:    vorr d0, d9, d9
 ; LE-I32-NEXT:    vmov.32 d12[0], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vorr d0, d11, d11
-; LE-I32-NEXT:    vmov.32 d13[1], r0
+; LE-I32-NEXT:    vmov.32 d13[0], r0
 ; LE-I32-NEXT:    bl lrint
+; LE-I32-NEXT:    vorr d0, d9, d9
 ; LE-I32-NEXT:    vmov.32 d12[1], r0
+; LE-I32-NEXT:    bl lrint
+; LE-I32-NEXT:    vmov.32 d13[1], r0
 ; LE-I32-NEXT:    vorr q0, q6, q6
 ; LE-I32-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; LE-I32-NEXT:    pop {r11, pc}
@@ -2400,29 +2392,29 @@ define <4 x iXLen> @lrint_v4f64(<4 x double> %x) {
 ; LE-I64-NEXT:    push {r4, r5, r6, lr}
 ; LE-I64-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; LE-I64-NEXT:    vorr q5, q1, q1
-; LE-I64-NEXT:    vorr q6, q0, q0
+; LE-I64-NEXT:    vorr q4, q1, q1
+; LE-I64-NEXT:    vorr q5, q0, q0
+; LE-I64-NEXT:    vorr d0, d8, d8
+; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    vorr d0, d11, d11
-; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d12, d12
 ; LE-I64-NEXT:    mov r4, r1
-; LE-I64-NEXT:    vmov.32 d9[0], r0
-; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d13, d13
-; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    vmov.32 d12[0], r0
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    vorr d0, d10, d10
-; LE-I64-NEXT:    mov r6, r1
+; LE-I64-NEXT:    mov r5, r1
 ; LE-I64-NEXT:    vmov.32 d15[0], r0
 ; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    vmov.32 d15[1], r6
-; LE-I64-NEXT:    vmov.32 d9[1], r4
-; LE-I64-NEXT:    vmov.32 d14[1], r5
-; LE-I64-NEXT:    vmov.32 d8[1], r1
+; LE-I64-NEXT:    vorr d0, d9, d9
+; LE-I64-NEXT:    mov r6, r1
+; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    bl lrint
+; LE-I64-NEXT:    vmov.32 d13[0], r0
+; LE-I64-NEXT:    vmov.32 d14[1], r6
+; LE-I64-NEXT:    vmov.32 d12[1], r4
+; LE-I64-NEXT:    vmov.32 d15[1], r5
+; LE-I64-NEXT:    vmov.32 d13[1], r1
 ; LE-I64-NEXT:    vorr q0, q7, q7
-; LE-I64-NEXT:    vorr q1, q4, q4
+; LE-I64-NEXT:    vorr q1, q6, q6
 ; LE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -2434,18 +2426,17 @@ define <4 x iXLen> @lrint_v4f64(<4 x double> %x) {
 ; BE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13}
 ; BE-I32-NEXT:    vorr q4, q1, q1
 ; BE-I32-NEXT:    vorr q5, q0, q0
+; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    vorr d0, d8, d8
-; BE-I32-NEXT:    bl lrint
-; BE-I32-NEXT:    vorr d0, d10, d10
-; BE-I32-NEXT:    vmov.32 d13[0], r0
-; BE-I32-NEXT:    bl lrint
-; BE-I32-NEXT:    vorr d0, d9, d9
 ; BE-I32-NEXT:    vmov.32 d12[0], r0
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    vorr d0, d11, d11
-; BE-I32-NEXT:    vmov.32 d13[1], r0
+; BE-I32-NEXT:    vmov.32 d13[0], r0
 ; BE-I32-NEXT:    bl lrint
+; BE-I32-NEXT:    vorr d0, d9, d9
 ; BE-I32-NEXT:    vmov.32 d12[1], r0
+; BE-I32-NEXT:    bl lrint
+; BE-I32-NEXT:    vmov.32 d13[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q6
 ; BE-I32-NEXT:    vpop {d8, d9, d10, d11, d12, d13}
 ; BE-I32-NEXT:    pop {r11, pc}
@@ -2458,25 +2449,25 @@ define <4 x iXLen> @lrint_v4f64(<4 x double> %x) {
 ; BE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-I64-NEXT:    vorr q4, q1, q1
 ; BE-I64-NEXT:    vorr q5, q0, q0
-; BE-I64-NEXT:    vorr d0, d9, d9
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d10, d10
-; BE-I64-NEXT:    mov r4, r1
-; BE-I64-NEXT:    vmov.32 d13[0], r0
+; BE-I64-NEXT:    vorr d0, d8, d8
 ; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vorr d0, d11, d11
-; BE-I64-NEXT:    mov r5, r1
-; BE-I64-NEXT:    vmov.32 d14[0], r0
+; BE-I64-NEXT:    mov r4, r1
+; BE-I64-NEXT:    vmov.32 d12[0], r0
 ; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d8, d8
-; BE-I64-NEXT:    mov r6, r1
+; BE-I64-NEXT:    vorr d0, d10, d10
+; BE-I64-NEXT:    mov r5, r1
 ; BE-I64-NEXT:    vmov.32 d15[0], r0
 ; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vmov.32 d12[0], r0
-; BE-I64-NEXT:    vmov.32 d15[1], r6
-; BE-I64-NEXT:    vmov.32 d13[1], r4
-; BE-I64-NEXT:    vmov.32 d14[1], r5
-; BE-I64-NEXT:    vmov.32 d12[1], r1
+; BE-I64-NEXT:    vorr d0, d9, d9
+; BE-I64-NEXT:    mov r6, r1
+; BE-I64-NEXT:    vmov.32 d14[0], r0
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    vmov.32 d13[0], r0
+; BE-I64-NEXT:    vmov.32 d14[1], r6
+; BE-I64-NEXT:    vmov.32 d12[1], r4
+; BE-I64-NEXT:    vmov.32 d15[1], r5
+; BE-I64-NEXT:    vmov.32 d13[1], r1
 ; BE-I64-NEXT:    vrev64.32 q0, q7
 ; BE-I64-NEXT:    vrev64.32 q1, q6
 ; BE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
@@ -2494,40 +2485,40 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) {
 ; LE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I32-NEXT:    .pad #32
 ; LE-I32-NEXT:    sub sp, sp, #32
-; LE-I32-NEXT:    vorr q5, q0, q0
+; LE-I32-NEXT:    vorr q7, q0, q0
 ; LE-I32-NEXT:    add lr, sp, #16
-; LE-I32-NEXT:    vorr d0, d4, d4
-; LE-I32-NEXT:    vstmia sp, {d6, d7} @ 16-byte Spill
-; LE-I32-NEXT:    vorr q7, q3, q3
-; LE-I32-NEXT:    vstmia lr, {d4, d5} @ 16-byte Spill
+; LE-I32-NEXT:    vorr d0, d6, d6
+; LE-I32-NEXT:    vstmia sp, {d4, d5} @ 16-byte Spill
+; LE-I32-NEXT:    vorr q5, q2, q2
+; LE-I32-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; LE-I32-NEXT:    vorr q6, q1, q1
+; LE-I32-NEXT:    bl lrint
+; LE-I32-NEXT:    vorr d0, d10, d10
+; LE-I32-NEXT:    vmov.32 d9[0], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vorr d0, d14, d14
 ; LE-I32-NEXT:    vmov.32 d8[0], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vorr d0, d12, d12
-; LE-I32-NEXT:    vmov.32 d9[0], r0
+; LE-I32-NEXT:    vmov.32 d10[0], r0
 ; LE-I32-NEXT:    bl lrint
-; LE-I32-NEXT:    vorr d0, d10, d10
-; LE-I32-NEXT:    vmov.32 d15[0], r0
+; LE-I32-NEXT:    vorr d0, d15, d15
+; LE-I32-NEXT:    vmov.32 d11[0], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vorr d0, d13, d13
-; LE-I32-NEXT:    vmov.32 d14[0], r0
-; LE-I32-NEXT:    bl lrint
-; LE-I32-NEXT:    vorr d0, d11, d11
-; LE-I32-NEXT:    vmov.32 d15[1], r0
+; LE-I32-NEXT:    vmov.32 d10[1], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vldmia sp, {d16, d17} @ 16-byte Reload
 ; LE-I32-NEXT:    vorr d0, d17, d17
-; LE-I32-NEXT:    vmov.32 d14[1], r0
+; LE-I32-NEXT:    vmov.32 d11[1], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    add lr, sp, #16
-; LE-I32-NEXT:    vmov.32 d9[1], r0
+; LE-I32-NEXT:    vmov.32 d8[1], r0
 ; LE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I32-NEXT:    vorr d0, d17, d17
 ; LE-I32-NEXT:    bl lrint
-; LE-I32-NEXT:    vmov.32 d8[1], r0
-; LE-I32-NEXT:    vorr q0, q7, q7
+; LE-I32-NEXT:    vmov.32 d9[1], r0
+; LE-I32-NEXT:    vorr q0, q5, q5
 ; LE-I32-NEXT:    vorr q1, q4, q4
 ; LE-I32-NEXT:    add sp, sp, #32
 ; LE-I32-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
@@ -2543,57 +2534,57 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) {
 ; LE-I64-NEXT:    sub sp, sp, #40
 ; LE-I64-NEXT:    vorr q4, q0, q0
 ; LE-I64-NEXT:    add lr, sp, #24
-; LE-I64-NEXT:    vorr d0, d7, d7
+; LE-I64-NEXT:    vorr d0, d6, d6
 ; LE-I64-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; LE-I64-NEXT:    vorr q7, q2, q2
 ; LE-I64-NEXT:    vorr q6, q1, q1
 ; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d14, d14
+; LE-I64-NEXT:    vorr d0, d15, d15
+; LE-I64-NEXT:    vmov.32 d16[0], r0
 ; LE-I64-NEXT:    add lr, sp, #8
-; LE-I64-NEXT:    vmov.32 d17[0], r0
 ; LE-I64-NEXT:    mov r8, r1
 ; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d15, d15
+; LE-I64-NEXT:    vorr d0, d14, d14
 ; LE-I64-NEXT:    mov r9, r1
-; LE-I64-NEXT:    vmov.32 d10[0], r0
-; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d12, d12
-; LE-I64-NEXT:    mov r10, r1
 ; LE-I64-NEXT:    vmov.32 d11[0], r0
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    vorr d0, d13, d13
-; LE-I64-NEXT:    mov r7, r1
-; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    mov r10, r1
+; LE-I64-NEXT:    vmov.32 d10[0], r0
 ; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d8, d8
-; LE-I64-NEXT:    mov r4, r1
+; LE-I64-NEXT:    vorr d0, d12, d12
+; LE-I64-NEXT:    mov r7, r1
 ; LE-I64-NEXT:    vmov.32 d15[0], r0
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    vorr d0, d9, d9
+; LE-I64-NEXT:    mov r4, r1
+; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    bl lrint
+; LE-I64-NEXT:    vorr d0, d8, d8
 ; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    vmov.32 d13[0], r0
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    add lr, sp, #24
 ; LE-I64-NEXT:    mov r6, r1
-; LE-I64-NEXT:    vmov.32 d13[0], r0
-; LE-I64-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; LE-I64-NEXT:    @ kill: def $d0 killed $d0 killed $q0
+; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-I64-NEXT:    vorr d0, d17, d17
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    add lr, sp, #8
-; LE-I64-NEXT:    vmov.32 d13[1], r6
+; LE-I64-NEXT:    vmov.32 d12[1], r6
 ; LE-I64-NEXT:    vldmia lr, {d6, d7} @ 16-byte Reload
-; LE-I64-NEXT:    vmov.32 d15[1], r4
-; LE-I64-NEXT:    vmov.32 d11[1], r10
-; LE-I64-NEXT:    vmov.32 d6[0], r0
-; LE-I64-NEXT:    vmov.32 d12[1], r5
-; LE-I64-NEXT:    vmov.32 d14[1], r7
+; LE-I64-NEXT:    vmov.32 d14[1], r4
+; LE-I64-NEXT:    vmov.32 d10[1], r10
+; LE-I64-NEXT:    vmov.32 d7[0], r0
+; LE-I64-NEXT:    vmov.32 d13[1], r5
+; LE-I64-NEXT:    vmov.32 d15[1], r7
 ; LE-I64-NEXT:    vorr q0, q6, q6
-; LE-I64-NEXT:    vmov.32 d10[1], r9
+; LE-I64-NEXT:    vmov.32 d11[1], r9
 ; LE-I64-NEXT:    vorr q1, q7, q7
-; LE-I64-NEXT:    vmov.32 d7[1], r8
+; LE-I64-NEXT:    vmov.32 d6[1], r8
 ; LE-I64-NEXT:    vorr q2, q5, q5
-; LE-I64-NEXT:    vmov.32 d6[1], r1
+; LE-I64-NEXT:    vmov.32 d7[1], r1
 ; LE-I64-NEXT:    add sp, sp, #40
 ; LE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
@@ -2606,39 +2597,39 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) {
 ; BE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-I32-NEXT:    .pad #32
 ; BE-I32-NEXT:    sub sp, sp, #32
-; BE-I32-NEXT:    vorr q5, q0, q0
-; BE-I32-NEXT:    vstmia sp, {d0, d1} @ 16-byte Spill
-; BE-I32-NEXT:    vorr d0, d4, d4
+; BE-I32-NEXT:    vorr q6, q0, q0
 ; BE-I32-NEXT:    add lr, sp, #16
-; BE-I32-NEXT:    vorr q7, q3, q3
-; BE-I32-NEXT:    vstmia lr, {d4, d5} @ 16-byte Spill
-; BE-I32-NEXT:    vorr q6, q1, q1
+; BE-I32-NEXT:    vorr d0, d6, d6
+; BE-I32-NEXT:    vstmia sp, {d2, d3} @ 16-byte Spill
+; BE-I32-NEXT:    vorr q7, q2, q2
+; BE-I32-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
+; BE-I32-NEXT:    vorr q5, q1, q1
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    vorr d0, d10, d10
-; BE-I32-NEXT:    vmov.32 d8[0], r0
-; BE-I32-NEXT:    bl lrint
-; BE-I32-NEXT:    vorr d0, d14, d14
-; BE-I32-NEXT:    vmov.32 d10[0], r0
-; BE-I32-NEXT:    bl lrint
-; BE-I32-NEXT:    vorr d0, d12, d12
 ; BE-I32-NEXT:    vmov.32 d9[0], r0
 ; BE-I32-NEXT:    bl lrint
-; BE-I32-NEXT:    vorr d0, d15, d15
+; BE-I32-NEXT:    vorr d0, d14, d14
 ; BE-I32-NEXT:    vmov.32 d11[0], r0
 ; BE-I32-NEXT:    bl lrint
+; BE-I32-NEXT:    vorr d0, d12, d12
+; BE-I32-NEXT:    vmov.32 d8[0], r0
+; BE-I32-NEXT:    bl lrint
+; BE-I32-NEXT:    vorr d0, d15, d15
+; BE-I32-NEXT:    vmov.32 d10[0], r0
+; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    vorr d0, d13, d13
-; BE-I32-NEXT:    vmov.32 d9[1], r0
+; BE-I32-NEXT:    vmov.32 d8[1], r0
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    vldmia sp, {d16, d17} @ 16-byte Reload
 ; BE-I32-NEXT:    vorr d0, d17, d17
-; BE-I32-NEXT:    vmov.32 d11[1], r0
+; BE-I32-NEXT:    vmov.32 d10[1], r0
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #16
-; BE-I32-NEXT:    vmov.32 d10[1], r0
+; BE-I32-NEXT:    vmov.32 d11[1], r0
 ; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-I32-NEXT:    vorr d0, d17, d17
 ; BE-I32-NEXT:    bl lrint
-; BE-I32-NEXT:    vmov.32 d8[1], r0
+; BE-I32-NEXT:    vmov.32 d9[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q5
 ; BE-I32-NEXT:    vrev64.32 q1, q4
 ; BE-I32-NEXT:    add sp, sp, #32
@@ -2655,54 +2646,54 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) {
 ; BE-I64-NEXT:    sub sp, sp, #40
 ; BE-I64-NEXT:    vorr q4, q0, q0
 ; BE-I64-NEXT:    add lr, sp, #24
-; BE-I64-NEXT:    vorr d0, d7, d7
+; BE-I64-NEXT:    vorr d0, d6, d6
 ; BE-I64-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; BE-I64-NEXT:    vorr q7, q2, q2
 ; BE-I64-NEXT:    vorr q6, q1, q1
 ; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d14, d14
+; BE-I64-NEXT:    vorr d0, d15, d15
+; BE-I64-NEXT:    vmov.32 d16[0], r0
 ; BE-I64-NEXT:    add lr, sp, #8
-; BE-I64-NEXT:    vmov.32 d17[0], r0
 ; BE-I64-NEXT:    mov r8, r1
 ; BE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d15, d15
+; BE-I64-NEXT:    vorr d0, d14, d14
 ; BE-I64-NEXT:    mov r9, r1
-; BE-I64-NEXT:    vmov.32 d10[0], r0
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d12, d12
-; BE-I64-NEXT:    mov r10, r1
 ; BE-I64-NEXT:    vmov.32 d11[0], r0
 ; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vorr d0, d13, d13
-; BE-I64-NEXT:    mov r7, r1
-; BE-I64-NEXT:    vmov.32 d14[0], r0
+; BE-I64-NEXT:    mov r10, r1
+; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d8, d8
-; BE-I64-NEXT:    mov r4, r1
+; BE-I64-NEXT:    vorr d0, d12, d12
+; BE-I64-NEXT:    mov r7, r1
 ; BE-I64-NEXT:    vmov.32 d15[0], r0
 ; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vorr d0, d9, d9
+; BE-I64-NEXT:    mov r4, r1
+; BE-I64-NEXT:    vmov.32 d14[0], r0
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    vorr d0, d8, d8
 ; BE-I64-NEXT:    mov r5, r1
-; BE-I64-NEXT:    vmov.32 d12[0], r0
+; BE-I64-NEXT:    vmov.32 d13[0], r0
 ; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    add lr, sp, #24
 ; BE-I64-NEXT:    mov r6, r1
-; BE-I64-NEXT:    vmov.32 d13[0], r0
-; BE-I64-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; BE-I64-NEXT:    @ kill: def $d0 killed $d0 killed $q0
+; BE-I64-NEXT:    vmov.32 d12[0], r0
+; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; BE-I64-NEXT:    vorr d0, d17, d17
 ; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    add lr, sp, #8
-; BE-I64-NEXT:    vmov.32 d13[1], r6
+; BE-I64-NEXT:    vmov.32 d12[1], r6
 ; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; BE-I64-NEXT:    vmov.32 d15[1], r4
-; BE-I64-NEXT:    vmov.32 d16[0], r0
-; BE-I64-NEXT:    vmov.32 d11[1], r10
-; BE-I64-NEXT:    vmov.32 d17[1], r8
-; BE-I64-NEXT:    vmov.32 d12[1], r5
-; BE-I64-NEXT:    vmov.32 d14[1], r7
-; BE-I64-NEXT:    vmov.32 d10[1], r9
-; BE-I64-NEXT:    vmov.32 d16[1], r1
+; BE-I64-NEXT:    vmov.32 d17[0], r0
+; BE-I64-NEXT:    vmov.32 d14[1], r4
+; BE-I64-NEXT:    vmov.32 d10[1], r10
+; BE-I64-NEXT:    vmov.32 d16[1], r8
+; BE-I64-NEXT:    vmov.32 d13[1], r5
+; BE-I64-NEXT:    vmov.32 d15[1], r7
+; BE-I64-NEXT:    vmov.32 d11[1], r9
+; BE-I64-NEXT:    vmov.32 d17[1], r1
 ; BE-I64-NEXT:    vrev64.32 q0, q6
 ; BE-I64-NEXT:    vrev64.32 q1, q7
 ; BE-I64-NEXT:    vrev64.32 q2, q5
@@ -2723,41 +2714,41 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; LE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I32-NEXT:    .pad #128
 ; LE-I32-NEXT:    sub sp, sp, #128
-; LE-I32-NEXT:    add lr, sp, #80
-; LE-I32-NEXT:    add r0, sp, #240
-; LE-I32-NEXT:    vld1.64 {d16, d17}, [r0]
-; LE-I32-NEXT:    add r0, sp, #208
-; LE-I32-NEXT:    vorr q6, q0, q0
-; LE-I32-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; LE-I32-NEXT:    add lr, sp, #32
-; LE-I32-NEXT:    vorr q5, q1, q1
+; LE-I32-NEXT:    add r0, sp, #256
+; LE-I32-NEXT:    vld1.64 {d16, d17}, [r0]
+; LE-I32-NEXT:    add r0, sp, #224
+; LE-I32-NEXT:    vorr q5, q0, q0
+; LE-I32-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
+; LE-I32-NEXT:    add lr, sp, #80
+; LE-I32-NEXT:    vorr q6, q1, q1
 ; LE-I32-NEXT:    vstmia lr, {d4, d5} @ 16-byte Spill
 ; LE-I32-NEXT:    add lr, sp, #16
-; LE-I32-NEXT:    vstmia lr, {d0, d1} @ 16-byte Spill
+; LE-I32-NEXT:    vstmia lr, {d2, d3} @ 16-byte Spill
 ; LE-I32-NEXT:    add lr, sp, #64
-; LE-I32-NEXT:    vorr d0, d4, d4
 ; LE-I32-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-I32-NEXT:    add lr, sp, #112
 ; LE-I32-NEXT:    vld1.64 {d16, d17}, [r0]
-; LE-I32-NEXT:    add r0, sp, #224
+; LE-I32-NEXT:    add r0, sp, #208
 ; LE-I32-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-I32-NEXT:    add lr, sp, #96
 ; LE-I32-NEXT:    vld1.64 {d16, d17}, [r0]
-; LE-I32-NEXT:    add r0, sp, #256
+; LE-I32-NEXT:    add r0, sp, #240
+; LE-I32-NEXT:    vstmia sp, {d0, d1} @ 16-byte Spill
+; LE-I32-NEXT:    vorr d0, d6, d6
 ; LE-I32-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-I32-NEXT:    add lr, sp, #48
 ; LE-I32-NEXT:    vld1.64 {d14, d15}, [r0]
-; LE-I32-NEXT:    vstmia sp, {d2, d3} @ 16-byte Spill
 ; LE-I32-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vorr d0, d12, d12
-; LE-I32-NEXT:    vmov.32 d8[0], r0
+; LE-I32-NEXT:    vmov.32 d9[0], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vorr d0, d10, d10
-; LE-I32-NEXT:    vmov.32 d12[0], r0
+; LE-I32-NEXT:    vmov.32 d13[0], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vorr d0, d14, d14
-; LE-I32-NEXT:    vmov.32 d13[0], r0
+; LE-I32-NEXT:    vmov.32 d12[0], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    add lr, sp, #64
 ; LE-I32-NEXT:    mov r4, r0
@@ -2765,61 +2756,61 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; LE-I32-NEXT:    @ kill: def $d0 killed $d0 killed $q0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    add lr, sp, #80
-; LE-I32-NEXT:    vmov.32 d14[0], r0
+; LE-I32-NEXT:    vmov.32 d15[0], r0
 ; LE-I32-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
 ; LE-I32-NEXT:    @ kill: def $d0 killed $d0 killed $q0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    add lr, sp, #112
-; LE-I32-NEXT:    vmov.32 d9[0], r0
+; LE-I32-NEXT:    vmov.32 d8[0], r0
 ; LE-I32-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
 ; LE-I32-NEXT:    @ kill: def $d0 killed $d0 killed $q0
-; LE-I32-NEXT:    vmov.32 d15[0], r4
+; LE-I32-NEXT:    vmov.32 d14[0], r4
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vldmia sp, {d16, d17} @ 16-byte Reload
 ; LE-I32-NEXT:    vorr d0, d17, d17
-; LE-I32-NEXT:    vmov.32 d10[0], r0
+; LE-I32-NEXT:    vmov.32 d11[0], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    add lr, sp, #96
-; LE-I32-NEXT:    vmov.32 d13[1], r0
+; LE-I32-NEXT:    vmov.32 d12[1], r0
 ; LE-I32-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
 ; LE-I32-NEXT:    @ kill: def $d0 killed $d0 killed $q0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    add lr, sp, #16
-; LE-I32-NEXT:    vmov.32 d11[0], r0
+; LE-I32-NEXT:    vmov.32 d10[0], r0
 ; LE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I32-NEXT:    vorr d0, d17, d17
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    add lr, sp, #80
-; LE-I32-NEXT:    vmov.32 d12[1], r0
+; LE-I32-NEXT:    vmov.32 d13[1], r0
 ; LE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I32-NEXT:    vorr d0, d17, d17
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    add lr, sp, #32
-; LE-I32-NEXT:    vmov.32 d9[1], r0
-; LE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-I32-NEXT:    vorr d0, d17, d17
-; LE-I32-NEXT:    bl lrint
-; LE-I32-NEXT:    add lr, sp, #96
 ; LE-I32-NEXT:    vmov.32 d8[1], r0
 ; LE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I32-NEXT:    vorr d0, d17, d17
 ; LE-I32-NEXT:    bl lrint
-; LE-I32-NEXT:    add lr, sp, #112
-; LE-I32-NEXT:    vmov.32 d11[1], r0
+; LE-I32-NEXT:    add lr, sp, #96
+; LE-I32-NEXT:    vmov.32 d9[1], r0
 ; LE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I32-NEXT:    vorr d0, d17, d17
 ; LE-I32-NEXT:    bl lrint
-; LE-I32-NEXT:    add lr, sp, #48
+; LE-I32-NEXT:    add lr, sp, #112
 ; LE-I32-NEXT:    vmov.32 d10[1], r0
 ; LE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I32-NEXT:    vorr d0, d17, d17
 ; LE-I32-NEXT:    bl lrint
-; LE-I32-NEXT:    add lr, sp, #64
-; LE-I32-NEXT:    vmov.32 d15[1], r0
+; LE-I32-NEXT:    add lr, sp, #48
+; LE-I32-NEXT:    vmov.32 d11[1], r0
 ; LE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I32-NEXT:    vorr d0, d17, d17
 ; LE-I32-NEXT:    bl lrint
+; LE-I32-NEXT:    add lr, sp, #64
 ; LE-I32-NEXT:    vmov.32 d14[1], r0
+; LE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-I32-NEXT:    vorr d0, d17, d17
+; LE-I32-NEXT:    bl lrint
+; LE-I32-NEXT:    vmov.32 d15[1], r0
 ; LE-I32-NEXT:    vorr q0, q6, q6
 ; LE-I32-NEXT:    vorr q1, q4, q4
 ; LE-I32-NEXT:    vorr q2, q5, q5
@@ -2847,7 +2838,7 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; LE-I64-NEXT:    vorr q7, q1, q1
 ; LE-I64-NEXT:    vstmia lr, {d0, d1} @ 16-byte Spill
 ; LE-I64-NEXT:    add lr, sp, #144
-; LE-I64-NEXT:    vorr d0, d1, d1
+; LE-I64-NEXT:    @ kill: def $d0 killed $d0 killed $q0
 ; LE-I64-NEXT:    vld1.64 {d16, d17}, [r0]
 ; LE-I64-NEXT:    add r0, sp, #280
 ; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
@@ -2863,137 +2854,138 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; LE-I64-NEXT:    vld1.64 {d16, d17}, [r0]
 ; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d14, d14
-; LE-I64-NEXT:    str r1, [sp, #116] @ 4-byte Spill
-; LE-I64-NEXT:    vmov.32 d11[0], r0
-; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    vorr d0, d15, d15
-; LE-I64-NEXT:    str r1, [sp, #76] @ 4-byte Spill
-; LE-I64-NEXT:    vmov.32 d8[0], r0
+; LE-I64-NEXT:    str r1, [sp, #116] @ 4-byte Spill
+; LE-I64-NEXT:    vmov.32 d10[0], r0
 ; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d12, d12
-; LE-I64-NEXT:    add lr, sp, #160
+; LE-I64-NEXT:    vorr d0, d14, d14
+; LE-I64-NEXT:    str r1, [sp, #76] @ 4-byte Spill
 ; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    bl lrint
+; LE-I64-NEXT:    vorr d0, d13, d13
+; LE-I64-NEXT:    vmov.32 d8[0], r0
+; LE-I64-NEXT:    add lr, sp, #160
 ; LE-I64-NEXT:    str r1, [sp, #72] @ 4-byte Spill
 ; LE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
 ; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d13, d13
+; LE-I64-NEXT:    vorr d0, d12, d12
 ; LE-I64-NEXT:    mov r6, r1
-; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    vmov.32 d9[0], r0
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    add lr, sp, #40
 ; LE-I64-NEXT:    mov r4, r1
-; LE-I64-NEXT:    vmov.32 d15[0], r0
-; LE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; LE-I64-NEXT:    vorr d0, d8, d8
+; LE-I64-NEXT:    vmov.32 d8[0], r0
+; LE-I64-NEXT:    vldmia lr, {d14, d15} @ 16-byte Reload
+; LE-I64-NEXT:    vorr d0, d15, d15
 ; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d9, d9
+; LE-I64-NEXT:    vorr d0, d14, d14
 ; LE-I64-NEXT:    mov r7, r1
-; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    vmov.32 d13[0], r0
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    add lr, sp, #96
 ; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    vmov.32 d13[0], r0
-; LE-I64-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; LE-I64-NEXT:    @ kill: def $d0 killed $d0 killed $q0
-; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vmov.32 d10[0], r0
-; LE-I64-NEXT:    add lr, sp, #40
-; LE-I64-NEXT:    mov r10, r1
-; LE-I64-NEXT:    vmov.32 d13[1], r5
-; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
-; LE-I64-NEXT:    add lr, sp, #56
-; LE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; LE-I64-NEXT:    vorr d0, d9, d9
-; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d8, d8
-; LE-I64-NEXT:    vmov.32 d12[1], r7
-; LE-I64-NEXT:    add lr, sp, #96
-; LE-I64-NEXT:    mov r9, r1
-; LE-I64-NEXT:    vmov.32 d11[0], r0
-; LE-I64-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
-; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vmov.32 d10[0], r0
-; LE-I64-NEXT:    add lr, sp, #24
-; LE-I64-NEXT:    mov r11, r1
-; LE-I64-NEXT:    vmov.32 d15[1], r4
-; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
-; LE-I64-NEXT:    add lr, sp, #144
+; LE-I64-NEXT:    vmov.32 d12[0], r0
 ; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I64-NEXT:    vorr d0, d17, d17
 ; LE-I64-NEXT:    bl lrint
+; LE-I64-NEXT:    add lr, sp, #40
+; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    mov r9, r1
+; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; LE-I64-NEXT:    add lr, sp, #56
+; LE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
+; LE-I64-NEXT:    vorr d0, d10, d10
+; LE-I64-NEXT:    vmov.32 d12[1], r5
+; LE-I64-NEXT:    bl lrint
+; LE-I64-NEXT:    vorr d0, d11, d11
+; LE-I64-NEXT:    add lr, sp, #96
+; LE-I64-NEXT:    vmov.32 d13[1], r7
+; LE-I64-NEXT:    mov r10, r1
+; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
+; LE-I64-NEXT:    bl lrint
+; LE-I64-NEXT:    add lr, sp, #24
+; LE-I64-NEXT:    vmov.32 d15[0], r0
+; LE-I64-NEXT:    mov r11, r1
+; LE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-I64-NEXT:    add lr, sp, #144
+; LE-I64-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
+; LE-I64-NEXT:    @ kill: def $d0 killed $d0 killed $q0
+; LE-I64-NEXT:    vmov.32 d8[1], r4
+; LE-I64-NEXT:    bl lrint
+; LE-I64-NEXT:    vmov.32 d16[0], r0
 ; LE-I64-NEXT:    add lr, sp, #8
-; LE-I64-NEXT:    vmov.32 d14[1], r6
 ; LE-I64-NEXT:    mov r8, r1
-; LE-I64-NEXT:    vmov.32 d17[0], r0
+; LE-I64-NEXT:    vmov.32 d9[1], r6
 ; LE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-I64-NEXT:    add lr, sp, #56
-; LE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; LE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
 ; LE-I64-NEXT:    add lr, sp, #80
+; LE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
+; LE-I64-NEXT:    vorr d0, d8, d8
+; LE-I64-NEXT:    bl lrint
+; LE-I64-NEXT:    add lr, sp, #160
+; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    vorr d0, d9, d9
+; LE-I64-NEXT:    ldr r0, [sp, #72] @ 4-byte Reload
 ; LE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-I64-NEXT:    vorr d0, d11, d11
+; LE-I64-NEXT:    mov r6, r1
+; LE-I64-NEXT:    vmov.32 d10[1], r0
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    vmov.32 d15[0], r0
-; LE-I64-NEXT:    add lr, sp, #160
-; LE-I64-NEXT:    vorr d0, d10, d10
-; LE-I64-NEXT:    ldr r0, [sp, #72] @ 4-byte Reload
-; LE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; LE-I64-NEXT:    mov r6, r1
-; LE-I64-NEXT:    vmov.32 d9[1], r0
-; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vmov.32 d14[0], r0
 ; LE-I64-NEXT:    ldr r0, [sp, #76] @ 4-byte Reload
 ; LE-I64-NEXT:    add lr, sp, #160
 ; LE-I64-NEXT:    mov r4, r1
-; LE-I64-NEXT:    vmov.32 d8[1], r0
-; LE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; LE-I64-NEXT:    vmov.32 d11[1], r0
+; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; LE-I64-NEXT:    add lr, sp, #120
 ; LE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-I64-NEXT:    vorr d0, d11, d11
-; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vmov.32 d13[0], r0
-; LE-I64-NEXT:    add lr, sp, #40
 ; LE-I64-NEXT:    vorr d0, d10, d10
+; LE-I64-NEXT:    bl lrint
+; LE-I64-NEXT:    add lr, sp, #40
+; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    vorr d0, d11, d11
 ; LE-I64-NEXT:    ldr r0, [sp, #116] @ 4-byte Reload
 ; LE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
 ; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    vmov.32 d9[1], r0
+; LE-I64-NEXT:    vmov.32 d8[1], r0
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    add lr, sp, #144
 ; LE-I64-NEXT:    mov r7, r1
-; LE-I64-NEXT:    vmov.32 d12[0], r0
-; LE-I64-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; LE-I64-NEXT:    @ kill: def $d0 killed $d0 killed $q0
-; LE-I64-NEXT:    vmov.32 d8[1], r10
+; LE-I64-NEXT:    vmov.32 d13[0], r0
+; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-I64-NEXT:    vorr d0, d17, d17
+; LE-I64-NEXT:    vmov.32 d9[1], r9
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    add lr, sp, #8
-; LE-I64-NEXT:    vmov.32 d15[1], r6
-; LE-I64-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
+; LE-I64-NEXT:    vmov.32 d14[1], r6
+; LE-I64-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
 ; LE-I64-NEXT:    add lr, sp, #24
+; LE-I64-NEXT:    vmov.32 d19[0], r0
+; LE-I64-NEXT:    vmov.32 d18[1], r8
+; LE-I64-NEXT:    vorr q10, q9, q9
 ; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I64-NEXT:    add lr, sp, #160
-; LE-I64-NEXT:    vmov.32 d20[0], r0
-; LE-I64-NEXT:    vmov.32 d21[1], r8
-; LE-I64-NEXT:    vmov.32 d20[1], r1
+; LE-I64-NEXT:    vmov.32 d12[1], r5
+; LE-I64-NEXT:    vmov.32 d21[1], r1
 ; LE-I64-NEXT:    ldr r1, [sp, #140] @ 4-byte Reload
-; LE-I64-NEXT:    vmov.32 d13[1], r5
+; LE-I64-NEXT:    vmov.32 d15[1], r4
 ; LE-I64-NEXT:    mov r0, r1
 ; LE-I64-NEXT:    vst1.64 {d8, d9}, [r0:128]!
 ; LE-I64-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
 ; LE-I64-NEXT:    add lr, sp, #56
-; LE-I64-NEXT:    vmov.32 d14[1], r4
+; LE-I64-NEXT:    vmov.32 d13[1], r7
 ; LE-I64-NEXT:    vst1.64 {d18, d19}, [r0:128]!
 ; LE-I64-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
 ; LE-I64-NEXT:    add lr, sp, #96
-; LE-I64-NEXT:    vmov.32 d12[1], r7
+; LE-I64-NEXT:    vmov.32 d16[1], r10
 ; LE-I64-NEXT:    vst1.64 {d18, d19}, [r0:128]!
 ; LE-I64-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
-; LE-I64-NEXT:    vmov.32 d17[1], r9
+; LE-I64-NEXT:    vmov.32 d17[1], r11
 ; LE-I64-NEXT:    vst1.64 {d18, d19}, [r0:128]
 ; LE-I64-NEXT:    add r0, r1, #64
 ; LE-I64-NEXT:    vst1.64 {d14, d15}, [r0:128]!
 ; LE-I64-NEXT:    vst1.64 {d12, d13}, [r0:128]!
-; LE-I64-NEXT:    vmov.32 d16[1], r11
 ; LE-I64-NEXT:    vst1.64 {d20, d21}, [r0:128]!
 ; LE-I64-NEXT:    vst1.64 {d16, d17}, [r0:128]
 ; LE-I64-NEXT:    add sp, sp, #176
@@ -3010,40 +3002,40 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; BE-I32-NEXT:    .pad #128
 ; BE-I32-NEXT:    sub sp, sp, #128
 ; BE-I32-NEXT:    add lr, sp, #64
-; BE-I32-NEXT:    add r0, sp, #240
+; BE-I32-NEXT:    add r0, sp, #256
 ; BE-I32-NEXT:    vld1.64 {d16, d17}, [r0]
-; BE-I32-NEXT:    add r0, sp, #224
-; BE-I32-NEXT:    vorr q6, q3, q3
-; BE-I32-NEXT:    vstmia lr, {d4, d5} @ 16-byte Spill
-; BE-I32-NEXT:    add lr, sp, #16
-; BE-I32-NEXT:    vorr q5, q1, q1
-; BE-I32-NEXT:    vstmia lr, {d2, d3} @ 16-byte Spill
+; BE-I32-NEXT:    add r0, sp, #208
+; BE-I32-NEXT:    vorr q5, q0, q0
+; BE-I32-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; BE-I32-NEXT:    add lr, sp, #32
+; BE-I32-NEXT:    vorr q6, q2, q2
+; BE-I32-NEXT:    vstmia lr, {d2, d3} @ 16-byte Spill
+; BE-I32-NEXT:    add lr, sp, #16
 ; BE-I32-NEXT:    vstmia lr, {d0, d1} @ 16-byte Spill
 ; BE-I32-NEXT:    add lr, sp, #80
-; BE-I32-NEXT:    @ kill: def $d0 killed $d0 killed $q0
+; BE-I32-NEXT:    vorr d0, d2, d2
 ; BE-I32-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; BE-I32-NEXT:    add lr, sp, #112
 ; BE-I32-NEXT:    vld1.64 {d16, d17}, [r0]
-; BE-I32-NEXT:    add r0, sp, #256
+; BE-I32-NEXT:    add r0, sp, #240
 ; BE-I32-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; BE-I32-NEXT:    add lr, sp, #96
 ; BE-I32-NEXT:    vld1.64 {d16, d17}, [r0]
-; BE-I32-NEXT:    add r0, sp, #208
+; BE-I32-NEXT:    add r0, sp, #224
 ; BE-I32-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; BE-I32-NEXT:    add lr, sp, #48
 ; BE-I32-NEXT:    vld1.64 {d14, d15}, [r0]
-; BE-I32-NEXT:    vstmia sp, {d6, d7} @ 16-byte Spill
+; BE-I32-NEXT:    vstmia sp, {d4, d5} @ 16-byte Spill
 ; BE-I32-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    vorr d0, d10, d10
-; BE-I32-NEXT:    vmov.32 d8[0], r0
-; BE-I32-NEXT:    bl lrint
-; BE-I32-NEXT:    vorr d0, d12, d12
 ; BE-I32-NEXT:    vmov.32 d9[0], r0
 ; BE-I32-NEXT:    bl lrint
+; BE-I32-NEXT:    vorr d0, d12, d12
+; BE-I32-NEXT:    vmov.32 d8[0], r0
+; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    vorr d0, d14, d14
-; BE-I32-NEXT:    vmov.32 d11[0], r0
+; BE-I32-NEXT:    vmov.32 d10[0], r0
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #80
 ; BE-I32-NEXT:    mov r4, r0
@@ -3051,61 +3043,61 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; BE-I32-NEXT:    @ kill: def $d0 killed $d0 killed $q0
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #64
-; BE-I32-NEXT:    vmov.32 d12[0], r0
+; BE-I32-NEXT:    vmov.32 d13[0], r0
 ; BE-I32-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
 ; BE-I32-NEXT:    @ kill: def $d0 killed $d0 killed $q0
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #112
-; BE-I32-NEXT:    vmov.32 d10[0], r0
+; BE-I32-NEXT:    vmov.32 d11[0], r0
 ; BE-I32-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
 ; BE-I32-NEXT:    @ kill: def $d0 killed $d0 killed $q0
-; BE-I32-NEXT:    vmov.32 d14[0], r4
+; BE-I32-NEXT:    vmov.32 d15[0], r4
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    vldmia sp, {d16, d17} @ 16-byte Reload
 ; BE-I32-NEXT:    vorr d0, d17, d17
-; BE-I32-NEXT:    vmov.32 d15[0], r0
+; BE-I32-NEXT:    vmov.32 d14[0], r0
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #96
-; BE-I32-NEXT:    vmov.32 d11[1], r0
+; BE-I32-NEXT:    vmov.32 d10[1], r0
 ; BE-I32-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
 ; BE-I32-NEXT:    @ kill: def $d0 killed $d0 killed $q0
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #64
-; BE-I32-NEXT:    vmov.32 d13[0], r0
+; BE-I32-NEXT:    vmov.32 d12[0], r0
 ; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-I32-NEXT:    vorr d0, d17, d17
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #16
-; BE-I32-NEXT:    vmov.32 d10[1], r0
+; BE-I32-NEXT:    vmov.32 d11[1], r0
 ; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-I32-NEXT:    vorr d0, d17, d17
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #32
-; BE-I32-NEXT:    vmov.32 d9[1], r0
-; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; BE-I32-NEXT:    vorr d0, d17, d17
-; BE-I32-NEXT:    bl lrint
-; BE-I32-NEXT:    add lr, sp, #96
 ; BE-I32-NEXT:    vmov.32 d8[1], r0
 ; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-I32-NEXT:    vorr d0, d17, d17
 ; BE-I32-NEXT:    bl lrint
+; BE-I32-NEXT:    add lr, sp, #96
+; BE-I32-NEXT:    vmov.32 d9[1], r0
+; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; BE-I32-NEXT:    vorr d0, d17, d17
+; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #112
-; BE-I32-NEXT:    vmov.32 d13[1], r0
+; BE-I32-NEXT:    vmov.32 d12[1], r0
 ; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-I32-NEXT:    vorr d0, d17, d17
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #48
-; BE-I32-NEXT:    vmov.32 d15[1], r0
-; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; BE-I32-NEXT:    vorr d0, d17, d17
-; BE-I32-NEXT:    bl lrint
-; BE-I32-NEXT:    add lr, sp, #80
 ; BE-I32-NEXT:    vmov.32 d14[1], r0
 ; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-I32-NEXT:    vorr d0, d17, d17
 ; BE-I32-NEXT:    bl lrint
-; BE-I32-NEXT:    vmov.32 d12[1], r0
+; BE-I32-NEXT:    add lr, sp, #80
+; BE-I32-NEXT:    vmov.32 d15[1], r0
+; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; BE-I32-NEXT:    vorr d0, d17, d17
+; BE-I32-NEXT:    bl lrint
+; BE-I32-NEXT:    vmov.32 d13[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q4
 ; BE-I32-NEXT:    vrev64.32 q1, q5
 ; BE-I32-NEXT:    vrev64.32 q2, q7
@@ -3124,164 +3116,163 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; BE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-I64-NEXT:    .pad #168
 ; BE-I64-NEXT:    sub sp, sp, #168
-; BE-I64-NEXT:    add lr, sp, #64
-; BE-I64-NEXT:    str r0, [sp, #132] @ 4-byte Spill
+; BE-I64-NEXT:    add lr, sp, #24
+; BE-I64-NEXT:    str r0, [sp, #148] @ 4-byte Spill
 ; BE-I64-NEXT:    add r0, sp, #304
-; BE-I64-NEXT:    vorr q4, q3, q3
+; BE-I64-NEXT:    vorr q6, q2, q2
+; BE-I64-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
+; BE-I64-NEXT:    add lr, sp, #80
+; BE-I64-NEXT:    vorr q7, q1, q1
 ; BE-I64-NEXT:    vstmia lr, {d0, d1} @ 16-byte Spill
-; BE-I64-NEXT:    add lr, sp, #48
-; BE-I64-NEXT:    vorr d0, d1, d1
+; BE-I64-NEXT:    add lr, sp, #64
+; BE-I64-NEXT:    @ kill: def $d0 killed $d0 killed $q0
 ; BE-I64-NEXT:    vld1.64 {d16, d17}, [r0]
 ; BE-I64-NEXT:    add r0, sp, #320
-; BE-I64-NEXT:    vorr q6, q2, q2
 ; BE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; BE-I64-NEXT:    add lr, sp, #88
-; BE-I64-NEXT:    vorr q7, q1, q1
+; BE-I64-NEXT:    add lr, sp, #104
 ; BE-I64-NEXT:    vld1.64 {d16, d17}, [r0]
 ; BE-I64-NEXT:    add r0, sp, #272
 ; BE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; BE-I64-NEXT:    add lr, sp, #112
+; BE-I64-NEXT:    add lr, sp, #128
 ; BE-I64-NEXT:    vld1.64 {d16, d17}, [r0]
 ; BE-I64-NEXT:    add r0, sp, #288
 ; BE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; BE-I64-NEXT:    add lr, sp, #24
+; BE-I64-NEXT:    add lr, sp, #40
 ; BE-I64-NEXT:    vld1.64 {d16, d17}, [r0]
 ; BE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d14, d14
-; BE-I64-NEXT:    add lr, sp, #136
-; BE-I64-NEXT:    vmov.32 d17[0], r0
-; BE-I64-NEXT:    str r1, [sp, #108] @ 4-byte Spill
-; BE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vorr d0, d15, d15
-; BE-I64-NEXT:    str r1, [sp, #84] @ 4-byte Spill
+; BE-I64-NEXT:    str r1, [sp, #124] @ 4-byte Spill
 ; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d12, d12
-; BE-I64-NEXT:    add lr, sp, #152
-; BE-I64-NEXT:    vmov.32 d11[0], r0
-; BE-I64-NEXT:    str r1, [sp, #44] @ 4-byte Spill
-; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; BE-I64-NEXT:    vorr d0, d14, d14
+; BE-I64-NEXT:    str r1, [sp, #100] @ 4-byte Spill
+; BE-I64-NEXT:    vmov.32 d9[0], r0
 ; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vorr d0, d13, d13
-; BE-I64-NEXT:    mov r6, r1
-; BE-I64-NEXT:    vmov.32 d10[0], r0
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d8, d8
-; BE-I64-NEXT:    mov r4, r1
-; BE-I64-NEXT:    vmov.32 d11[0], r0
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d9, d9
-; BE-I64-NEXT:    mov r7, r1
-; BE-I64-NEXT:    vmov.32 d12[0], r0
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    add lr, sp, #64
-; BE-I64-NEXT:    mov r5, r1
-; BE-I64-NEXT:    vmov.32 d13[0], r0
-; BE-I64-NEXT:    vldmia lr, {d0, d1} @ 16-byte Reload
-; BE-I64-NEXT:    @ kill: def $d0 killed $d0 killed $q0
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    add lr, sp, #136
-; BE-I64-NEXT:    mov r9, r1
-; BE-I64-NEXT:    vmov.32 d13[1], r5
-; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; BE-I64-NEXT:    vmov.32 d16[0], r0
-; BE-I64-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
-; BE-I64-NEXT:    add lr, sp, #24
-; BE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; BE-I64-NEXT:    vorr d0, d9, d9
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d8, d8
-; BE-I64-NEXT:    vmov.32 d12[1], r7
-; BE-I64-NEXT:    add lr, sp, #64
-; BE-I64-NEXT:    mov r10, r1
-; BE-I64-NEXT:    vmov.32 d15[0], r0
-; BE-I64-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vmov.32 d14[0], r0
-; BE-I64-NEXT:    add lr, sp, #8
-; BE-I64-NEXT:    mov r11, r1
-; BE-I64-NEXT:    vmov.32 d11[1], r4
-; BE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
-; BE-I64-NEXT:    add lr, sp, #48
-; BE-I64-NEXT:    vorr q6, q5, q5
-; BE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; BE-I64-NEXT:    vorr d0, d9, d9
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d8, d8
-; BE-I64-NEXT:    vmov.32 d12[1], r6
-; BE-I64-NEXT:    add lr, sp, #24
-; BE-I64-NEXT:    mov r8, r1
-; BE-I64-NEXT:    vmov.32 d11[0], r0
-; BE-I64-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vmov.32 d10[0], r0
-; BE-I64-NEXT:    add lr, sp, #48
-; BE-I64-NEXT:    ldr r0, [sp, #44] @ 4-byte Reload
-; BE-I64-NEXT:    mov r6, r1
-; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; BE-I64-NEXT:    vmov.32 d8[0], r0
 ; BE-I64-NEXT:    add lr, sp, #152
-; BE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; BE-I64-NEXT:    add lr, sp, #88
-; BE-I64-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
-; BE-I64-NEXT:    vorr d0, d13, d13
-; BE-I64-NEXT:    vmov.32 d9[1], r0
-; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vmov.32 d15[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #84] @ 4-byte Reload
-; BE-I64-NEXT:    vorr d0, d12, d12
-; BE-I64-NEXT:    add lr, sp, #152
-; BE-I64-NEXT:    mov r4, r1
-; BE-I64-NEXT:    vmov.32 d8[1], r0
+; BE-I64-NEXT:    str r1, [sp, #60] @ 4-byte Spill
 ; BE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
 ; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    add lr, sp, #136
+; BE-I64-NEXT:    vorr d0, d12, d12
+; BE-I64-NEXT:    mov r6, r1
+; BE-I64-NEXT:    vmov.32 d15[0], r0
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    add lr, sp, #24
+; BE-I64-NEXT:    mov r4, r1
 ; BE-I64-NEXT:    vmov.32 d14[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #108] @ 4-byte Reload
-; BE-I64-NEXT:    mov r5, r1
-; BE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; BE-I64-NEXT:    add lr, sp, #112
 ; BE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
 ; BE-I64-NEXT:    vorr d0, d9, d9
-; BE-I64-NEXT:    vmov.32 d11[1], r0
 ; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vorr d0, d8, d8
 ; BE-I64-NEXT:    mov r7, r1
 ; BE-I64-NEXT:    vmov.32 d13[0], r0
-; BE-I64-NEXT:    vmov.32 d10[1], r9
 ; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    add lr, sp, #8
+; BE-I64-NEXT:    add lr, sp, #80
+; BE-I64-NEXT:    mov r5, r1
 ; BE-I64-NEXT:    vmov.32 d12[0], r0
 ; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; BE-I64-NEXT:    add lr, sp, #48
-; BE-I64-NEXT:    vmov.32 d17[1], r10
-; BE-I64-NEXT:    vmov.32 d16[1], r11
+; BE-I64-NEXT:    vorr d0, d17, d17
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    add lr, sp, #24
+; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    mov r9, r1
+; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; BE-I64-NEXT:    add lr, sp, #40
+; BE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
+; BE-I64-NEXT:    vorr d0, d8, d8
+; BE-I64-NEXT:    vmov.32 d12[1], r5
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    vorr d0, d9, d9
+; BE-I64-NEXT:    add lr, sp, #80
+; BE-I64-NEXT:    vmov.32 d13[1], r7
+; BE-I64-NEXT:    mov r10, r1
+; BE-I64-NEXT:    vmov.32 d10[0], r0
+; BE-I64-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    add lr, sp, #8
+; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    mov r11, r1
+; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; BE-I64-NEXT:    add lr, sp, #64
+; BE-I64-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
+; BE-I64-NEXT:    vorr d0, d12, d12
+; BE-I64-NEXT:    vmov.32 d14[1], r4
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    vorr d0, d13, d13
+; BE-I64-NEXT:    add lr, sp, #40
+; BE-I64-NEXT:    vmov.32 d15[1], r6
+; BE-I64-NEXT:    mov r8, r1
+; BE-I64-NEXT:    vmov.32 d8[0], r0
+; BE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    add lr, sp, #64
+; BE-I64-NEXT:    vmov.32 d9[0], r0
+; BE-I64-NEXT:    ldr r0, [sp, #60] @ 4-byte Reload
+; BE-I64-NEXT:    mov r6, r1
+; BE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; BE-I64-NEXT:    add lr, sp, #152
+; BE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
+; BE-I64-NEXT:    add lr, sp, #104
+; BE-I64-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
+; BE-I64-NEXT:    vorr d0, d12, d12
+; BE-I64-NEXT:    vmov.32 d8[1], r0
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    vmov.32 d14[0], r0
+; BE-I64-NEXT:    ldr r0, [sp, #100] @ 4-byte Reload
+; BE-I64-NEXT:    vorr d0, d13, d13
+; BE-I64-NEXT:    add lr, sp, #152
+; BE-I64-NEXT:    mov r4, r1
+; BE-I64-NEXT:    vmov.32 d9[1], r0
+; BE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    add lr, sp, #24
+; BE-I64-NEXT:    vmov.32 d15[0], r0
+; BE-I64-NEXT:    ldr r0, [sp, #124] @ 4-byte Reload
+; BE-I64-NEXT:    mov r5, r1
+; BE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
+; BE-I64-NEXT:    add lr, sp, #128
+; BE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
+; BE-I64-NEXT:    vorr d0, d10, d10
+; BE-I64-NEXT:    vmov.32 d8[1], r0
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    vorr d0, d11, d11
+; BE-I64-NEXT:    mov r7, r1
+; BE-I64-NEXT:    vmov.32 d12[0], r0
+; BE-I64-NEXT:    vmov.32 d9[1], r9
+; BE-I64-NEXT:    bl lrint
+; BE-I64-NEXT:    add lr, sp, #8
+; BE-I64-NEXT:    vmov.32 d13[0], r0
+; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; BE-I64-NEXT:    add lr, sp, #64
+; BE-I64-NEXT:    vmov.32 d12[1], r7
+; BE-I64-NEXT:    vmov.32 d16[1], r10
+; BE-I64-NEXT:    vmov.32 d17[1], r11
 ; BE-I64-NEXT:    vorr q12, q8, q8
 ; BE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; BE-I64-NEXT:    add lr, sp, #152
-; BE-I64-NEXT:    vmov.32 d17[1], r8
-; BE-I64-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
-; BE-I64-NEXT:    add lr, sp, #24
-; BE-I64-NEXT:    vmov.32 d13[1], r7
-; BE-I64-NEXT:    vmov.32 d16[1], r6
-; BE-I64-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
-; BE-I64-NEXT:    add lr, sp, #64
-; BE-I64-NEXT:    vorr q13, q8, q8
-; BE-I64-NEXT:    vmov.32 d12[1], r1
-; BE-I64-NEXT:    ldr r1, [sp, #132] @ 4-byte Reload
-; BE-I64-NEXT:    vrev64.32 q8, q5
+; BE-I64-NEXT:    vmov.32 d13[1], r1
+; BE-I64-NEXT:    ldr r1, [sp, #148] @ 4-byte Reload
+; BE-I64-NEXT:    vmov.32 d16[1], r8
 ; BE-I64-NEXT:    mov r0, r1
+; BE-I64-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
+; BE-I64-NEXT:    add lr, sp, #40
+; BE-I64-NEXT:    vmov.32 d17[1], r6
+; BE-I64-NEXT:    vldmia lr, {d20, d21} @ 16-byte Reload
+; BE-I64-NEXT:    add lr, sp, #80
+; BE-I64-NEXT:    vorr q13, q8, q8
+; BE-I64-NEXT:    vrev64.32 q8, q4
 ; BE-I64-NEXT:    vldmia lr, {d22, d23} @ 16-byte Reload
 ; BE-I64-NEXT:    vrev64.32 q9, q9
 ; BE-I64-NEXT:    vrev64.32 q10, q10
 ; BE-I64-NEXT:    vst1.64 {d16, d17}, [r0:128]!
 ; BE-I64-NEXT:    vst1.64 {d18, d19}, [r0:128]!
 ; BE-I64-NEXT:    vrev64.32 q11, q11
-; BE-I64-NEXT:    vmov.32 d15[1], r4
+; BE-I64-NEXT:    vmov.32 d14[1], r4
 ; BE-I64-NEXT:    vst1.64 {d20, d21}, [r0:128]!
 ; BE-I64-NEXT:    vrev64.32 q15, q6
-; BE-I64-NEXT:    vmov.32 d14[1], r5
+; BE-I64-NEXT:    vmov.32 d15[1], r5
 ; BE-I64-NEXT:    vrev64.32 q12, q12
 ; BE-I64-NEXT:    vst1.64 {d22, d23}, [r0:128]
 ; BE-I64-NEXT:    add r0, r1, #64
@@ -3360,30 +3351,24 @@ define <2 x iXLen> @lrint_v2fp128(<2 x fp128> %x) {
 ;
 ; LE-I64-LABEL: lrint_v2fp128:
 ; LE-I64:       @ %bb.0:
-; LE-I64-NEXT:    .save {r4, r5, r6, r7, r8, lr}
-; LE-I64-NEXT:    push {r4, r5, r6, r7, r8, lr}
+; LE-I64-NEXT:    .save {r4, lr}
+; LE-I64-NEXT:    push {r4, lr}
 ; LE-I64-NEXT:    .vsave {d8, d9}
 ; LE-I64-NEXT:    vpush {d8, d9}
-; LE-I64-NEXT:    mov r8, r3
-; LE-I64-NEXT:    add r3, sp, #40
-; LE-I64-NEXT:    mov r5, r2
-; LE-I64-NEXT:    mov r6, r1
-; LE-I64-NEXT:    mov r7, r0
-; LE-I64-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    ldr r12, [sp, #24]
+; LE-I64-NEXT:    add r3, sp, #28
 ; LE-I64-NEXT:    mov r4, r1
-; LE-I64-NEXT:    vmov.32 d9[0], r0
-; LE-I64-NEXT:    mov r0, r7
-; LE-I64-NEXT:    mov r1, r6
-; LE-I64-NEXT:    mov r2, r5
-; LE-I64-NEXT:    mov r3, r8
-; LE-I64-NEXT:    bl lrintl
 ; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    vmov.32 d9[1], r4
-; LE-I64-NEXT:    vmov.32 d8[1], r1
+; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I64-NEXT:    mov r0, r12
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    vmov.32 d8[1], r4
+; LE-I64-NEXT:    vmov.32 d9[1], r1
 ; LE-I64-NEXT:    vorr q0, q4, q4
 ; LE-I64-NEXT:    vpop {d8, d9}
-; LE-I64-NEXT:    pop {r4, r5, r6, r7, r8, pc}
+; LE-I64-NEXT:    pop {r4, pc}
 ;
 ; BE-I32-LABEL: lrint_v2fp128:
 ; BE-I32:       @ %bb.0:
@@ -3409,31 +3394,25 @@ define <2 x iXLen> @lrint_v2fp128(<2 x fp128> %x) {
 ;
 ; BE-I64-LABEL: lrint_v2fp128:
 ; BE-I64:       @ %bb.0:
-; BE-I64-NEXT:    .save {r4, r5, r6, r7, r8, lr}
-; BE-I64-NEXT:    push {r4, r5, r6, r7, r8, lr}
+; BE-I64-NEXT:    .save {r4, lr}
+; BE-I64-NEXT:    push {r4, lr}
 ; BE-I64-NEXT:    .vsave {d8}
 ; BE-I64-NEXT:    vpush {d8}
-; BE-I64-NEXT:    mov r8, r3
-; BE-I64-NEXT:    add r3, sp, #32
-; BE-I64-NEXT:    mov r5, r2
-; BE-I64-NEXT:    mov r6, r1
-; BE-I64-NEXT:    mov r7, r0
-; BE-I64-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
+; BE-I64-NEXT:    ldr r12, [sp, #16]
+; BE-I64-NEXT:    add r3, sp, #20
 ; BE-I64-NEXT:    mov r4, r1
 ; BE-I64-NEXT:    vmov.32 d8[0], r0
-; BE-I64-NEXT:    mov r0, r7
-; BE-I64-NEXT:    mov r1, r6
-; BE-I64-NEXT:    mov r2, r5
-; BE-I64-NEXT:    mov r3, r8
+; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; BE-I64-NEXT:    mov r0, r12
 ; BE-I64-NEXT:    bl lrintl
 ; BE-I64-NEXT:    vmov.32 d16[0], r0
 ; BE-I64-NEXT:    vmov.32 d8[1], r4
 ; BE-I64-NEXT:    vmov.32 d16[1], r1
-; BE-I64-NEXT:    vrev64.32 d1, d8
-; BE-I64-NEXT:    vrev64.32 d0, d16
+; BE-I64-NEXT:    vrev64.32 d0, d8
+; BE-I64-NEXT:    vrev64.32 d1, d16
 ; BE-I64-NEXT:    vpop {d8}
-; BE-I64-NEXT:    pop {r4, r5, r6, r7, r8, pc}
+; BE-I64-NEXT:    pop {r4, pc}
   %a = call <2 x iXLen> @llvm.lrint.v2iXLen.v2fp128(<2 x fp128> %x)
   ret <2 x iXLen> %a
 }
@@ -3441,32 +3420,40 @@ define <2 x iXLen> @lrint_v2fp128(<2 x fp128> %x) {
 define <4 x iXLen> @lrint_v4fp128(<4 x fp128> %x) {
 ; LE-I32-LABEL: lrint_v4fp128:
 ; LE-I32:       @ %bb.0:
-; LE-I32-NEXT:    .save {r4, lr}
-; LE-I32-NEXT:    push {r4, lr}
+; LE-I32-NEXT:    .save {r4, r5, r6, r7, r8, lr}
+; LE-I32-NEXT:    push {r4, r5, r6, r7, r8, lr}
 ; LE-I32-NEXT:    .vsave {d8, d9}
 ; LE-I32-NEXT:    vpush {d8, d9}
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    add r3, sp, #60
-; LE-I32-NEXT:    ldr r12, [sp, #56]
-; LE-I32-NEXT:    vmov.32 d8[0], r0
-; LE-I32-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I32-NEXT:    mov r0, r12
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    add r3, sp, #40
-; LE-I32-NEXT:    mov r4, r0
+; LE-I32-NEXT:    mov r8, r3
+; LE-I32-NEXT:    add r3, sp, #56
+; LE-I32-NEXT:    mov r5, r2
+; LE-I32-NEXT:    mov r6, r1
+; LE-I32-NEXT:    mov r7, r0
 ; LE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    add r3, sp, #28
-; LE-I32-NEXT:    ldr r12, [sp, #24]
+; LE-I32-NEXT:    add r3, sp, #44
+; LE-I32-NEXT:    ldr r12, [sp, #40]
 ; LE-I32-NEXT:    vmov.32 d9[0], r0
 ; LE-I32-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I32-NEXT:    mov r0, r12
-; LE-I32-NEXT:    vmov.32 d9[1], r4
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    vmov.32 d8[1], r0
+; LE-I32-NEXT:    mov r4, r0
+; LE-I32-NEXT:    mov r0, r7
+; LE-I32-NEXT:    mov r1, r6
+; LE-I32-NEXT:    mov r2, r5
+; LE-I32-NEXT:    mov r3, r8
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    add r3, sp, #76
+; LE-I32-NEXT:    ldr r7, [sp, #72]
+; LE-I32-NEXT:    vmov.32 d8[0], r0
+; LE-I32-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I32-NEXT:    mov r0, r7
+; LE-I32-NEXT:    vmov.32 d8[1], r4
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    vmov.32 d9[1], r0
 ; LE-I32-NEXT:    vorr q0, q4, q4
 ; LE-I32-NEXT:    vpop {d8, d9}
-; LE-I32-NEXT:    pop {r4, pc}
+; LE-I32-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 ;
 ; LE-I64-LABEL: lrint_v4fp128:
 ; LE-I64:       @ %bb.0:
@@ -3474,39 +3461,39 @@ define <4 x iXLen> @lrint_v4fp128(<4 x fp128> %x) {
 ; LE-I64-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; LE-I64-NEXT:    .vsave {d8, d9, d10, d11}
 ; LE-I64-NEXT:    vpush {d8, d9, d10, d11}
-; LE-I64-NEXT:    mov r5, r3
-; LE-I64-NEXT:    add r3, sp, #96
-; LE-I64-NEXT:    mov r7, r2
-; LE-I64-NEXT:    mov r6, r1
+; LE-I64-NEXT:    mov r9, r3
+; LE-I64-NEXT:    add r3, sp, #80
+; LE-I64-NEXT:    mov r6, r2
+; LE-I64-NEXT:    mov r7, r1
 ; LE-I64-NEXT:    mov r4, r0
 ; LE-I64-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    mov r9, r1
-; LE-I64-NEXT:    vmov.32 d9[0], r0
-; LE-I64-NEXT:    mov r0, r4
-; LE-I64-NEXT:    mov r1, r6
-; LE-I64-NEXT:    mov r2, r7
-; LE-I64-NEXT:    mov r3, r5
-; LE-I64-NEXT:    ldr r8, [sp, #80]
-; LE-I64-NEXT:    ldr r10, [sp, #64]
-; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    ldr r5, [sp, #64]
 ; LE-I64-NEXT:    add r3, sp, #68
+; LE-I64-NEXT:    mov r8, r1
+; LE-I64-NEXT:    vmov.32 d8[0], r0
+; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I64-NEXT:    mov r0, r5
+; LE-I64-NEXT:    bl lrintl
 ; LE-I64-NEXT:    mov r5, r1
+; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    mov r0, r4
+; LE-I64-NEXT:    mov r1, r7
+; LE-I64-NEXT:    mov r2, r6
+; LE-I64-NEXT:    mov r3, r9
+; LE-I64-NEXT:    ldr r10, [sp, #96]
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add r3, sp, #100
+; LE-I64-NEXT:    mov r4, r1
 ; LE-I64-NEXT:    vmov.32 d10[0], r0
 ; LE-I64-NEXT:    mov r0, r10
 ; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #84
-; LE-I64-NEXT:    mov r4, r1
-; LE-I64-NEXT:    vmov.32 d11[0], r0
-; LE-I64-NEXT:    mov r0, r8
-; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    vmov.32 d11[1], r4
-; LE-I64-NEXT:    vmov.32 d9[1], r9
-; LE-I64-NEXT:    vmov.32 d10[1], r5
-; LE-I64-NEXT:    vmov.32 d8[1], r1
+; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    vmov.32 d10[1], r4
+; LE-I64-NEXT:    vmov.32 d8[1], r8
+; LE-I64-NEXT:    vmov.32 d11[1], r5
+; LE-I64-NEXT:    vmov.32 d9[1], r1
 ; LE-I64-NEXT:    vorr q0, q5, q5
 ; LE-I64-NEXT:    vorr q1, q4, q4
 ; LE-I64-NEXT:    vpop {d8, d9, d10, d11}
@@ -3514,32 +3501,40 @@ define <4 x iXLen> @lrint_v4fp128(<4 x fp128> %x) {
 ;
 ; BE-I32-LABEL: lrint_v4fp128:
 ; BE-I32:       @ %bb.0:
-; BE-I32-NEXT:    .save {r4, lr}
-; BE-I32-NEXT:    push {r4, lr}
+; BE-I32-NEXT:    .save {r4, r5, r6, r7, r8, lr}
+; BE-I32-NEXT:    push {r4, r5, r6, r7, r8, lr}
 ; BE-I32-NEXT:    .vsave {d8, d9}
 ; BE-I32-NEXT:    vpush {d8, d9}
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    add r3, sp, #60
-; BE-I32-NEXT:    ldr r12, [sp, #56]
-; BE-I32-NEXT:    vmov.32 d8[0], r0
-; BE-I32-NEXT:    ldm r3, {r1, r2, r3}
-; BE-I32-NEXT:    mov r0, r12
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    add r3, sp, #40
-; BE-I32-NEXT:    mov r4, r0
+; BE-I32-NEXT:    mov r8, r3
+; BE-I32-NEXT:    add r3, sp, #56
+; BE-I32-NEXT:    mov r5, r2
+; BE-I32-NEXT:    mov r6, r1
+; BE-I32-NEXT:    mov r7, r0
 ; BE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    add r3, sp, #28
-; BE-I32-NEXT:    ldr r12, [sp, #24]
+; BE-I32-NEXT:    add r3, sp, #44
+; BE-I32-NEXT:    ldr r12, [sp, #40]
 ; BE-I32-NEXT:    vmov.32 d9[0], r0
 ; BE-I32-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I32-NEXT:    mov r0, r12
-; BE-I32-NEXT:    vmov.32 d9[1], r4
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    vmov.32 d8[1], r0
+; BE-I32-NEXT:    mov r4, r0
+; BE-I32-NEXT:    mov r0, r7
+; BE-I32-NEXT:    mov r1, r6
+; BE-I32-NEXT:    mov r2, r5
+; BE-I32-NEXT:    mov r3, r8
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    add r3, sp, #76
+; BE-I32-NEXT:    ldr r7, [sp, #72]
+; BE-I32-NEXT:    vmov.32 d8[0], r0
+; BE-I32-NEXT:    ldm r3, {r1, r2, r3}
+; BE-I32-NEXT:    mov r0, r7
+; BE-I32-NEXT:    vmov.32 d8[1], r4
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    vmov.32 d9[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q4
 ; BE-I32-NEXT:    vpop {d8, d9}
-; BE-I32-NEXT:    pop {r4, pc}
+; BE-I32-NEXT:    pop {r4, r5, r6, r7, r8, pc}
 ;
 ; BE-I64-LABEL: lrint_v4fp128:
 ; BE-I64:       @ %bb.0:
@@ -3547,43 +3542,43 @@ define <4 x iXLen> @lrint_v4fp128(<4 x fp128> %x) {
 ; BE-I64-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; BE-I64-NEXT:    .vsave {d8, d9, d10}
 ; BE-I64-NEXT:    vpush {d8, d9, d10}
-; BE-I64-NEXT:    mov r5, r3
-; BE-I64-NEXT:    add r3, sp, #88
-; BE-I64-NEXT:    mov r7, r2
-; BE-I64-NEXT:    mov r6, r1
+; BE-I64-NEXT:    mov r9, r3
+; BE-I64-NEXT:    add r3, sp, #72
+; BE-I64-NEXT:    mov r6, r2
+; BE-I64-NEXT:    mov r7, r1
 ; BE-I64-NEXT:    mov r4, r0
 ; BE-I64-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    mov r9, r1
-; BE-I64-NEXT:    vmov.32 d8[0], r0
-; BE-I64-NEXT:    mov r0, r4
-; BE-I64-NEXT:    mov r1, r6
-; BE-I64-NEXT:    mov r2, r7
-; BE-I64-NEXT:    mov r3, r5
-; BE-I64-NEXT:    ldr r8, [sp, #72]
-; BE-I64-NEXT:    ldr r10, [sp, #56]
-; BE-I64-NEXT:    bl lrintl
+; BE-I64-NEXT:    ldr r5, [sp, #56]
 ; BE-I64-NEXT:    add r3, sp, #60
+; BE-I64-NEXT:    mov r8, r1
+; BE-I64-NEXT:    vmov.32 d8[0], r0
+; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; BE-I64-NEXT:    mov r0, r5
+; BE-I64-NEXT:    bl lrintl
 ; BE-I64-NEXT:    mov r5, r1
 ; BE-I64-NEXT:    vmov.32 d9[0], r0
-; BE-I64-NEXT:    mov r0, r10
-; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; BE-I64-NEXT:    mov r0, r4
+; BE-I64-NEXT:    mov r1, r7
+; BE-I64-NEXT:    mov r2, r6
+; BE-I64-NEXT:    mov r3, r9
+; BE-I64-NEXT:    ldr r10, [sp, #88]
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #76
+; BE-I64-NEXT:    add r3, sp, #92
 ; BE-I64-NEXT:    mov r4, r1
 ; BE-I64-NEXT:    vmov.32 d10[0], r0
-; BE-I64-NEXT:    mov r0, r8
+; BE-I64-NEXT:    mov r0, r10
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
 ; BE-I64-NEXT:    vmov.32 d16[0], r0
 ; BE-I64-NEXT:    vmov.32 d10[1], r4
-; BE-I64-NEXT:    vmov.32 d8[1], r9
+; BE-I64-NEXT:    vmov.32 d8[1], r8
 ; BE-I64-NEXT:    vmov.32 d9[1], r5
 ; BE-I64-NEXT:    vmov.32 d16[1], r1
-; BE-I64-NEXT:    vrev64.32 d1, d10
-; BE-I64-NEXT:    vrev64.32 d3, d8
-; BE-I64-NEXT:    vrev64.32 d0, d9
-; BE-I64-NEXT:    vrev64.32 d2, d16
+; BE-I64-NEXT:    vrev64.32 d0, d10
+; BE-I64-NEXT:    vrev64.32 d2, d8
+; BE-I64-NEXT:    vrev64.32 d1, d9
+; BE-I64-NEXT:    vrev64.32 d3, d16
 ; BE-I64-NEXT:    vpop {d8, d9, d10}
 ; BE-I64-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
   %a = call <4 x iXLen> @llvm.lrint.v4iXLen.v4fp128(<4 x fp128> %x)
@@ -3597,62 +3592,62 @@ define <8 x iXLen> @lrint_v8fp128(<8 x fp128> %x) {
 ; LE-I32-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; LE-I32-NEXT:    .vsave {d8, d9, d10, d11}
 ; LE-I32-NEXT:    vpush {d8, d9, d10, d11}
-; LE-I32-NEXT:    mov r6, r3
-; LE-I32-NEXT:    add r3, sp, #112
-; LE-I32-NEXT:    mov r7, r2
-; LE-I32-NEXT:    mov r4, r1
-; LE-I32-NEXT:    mov r5, r0
+; LE-I32-NEXT:    mov r5, r3
+; LE-I32-NEXT:    add r3, sp, #144
+; LE-I32-NEXT:    mov r6, r2
+; LE-I32-NEXT:    mov r7, r1
+; LE-I32-NEXT:    mov r4, r0
 ; LE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    vmov.32 d8[0], r0
-; LE-I32-NEXT:    mov r0, r5
-; LE-I32-NEXT:    mov r1, r4
-; LE-I32-NEXT:    mov r2, r7
-; LE-I32-NEXT:    mov r3, r6
-; LE-I32-NEXT:    ldr r8, [sp, #160]
-; LE-I32-NEXT:    ldr r9, [sp, #64]
-; LE-I32-NEXT:    ldr r10, [sp, #80]
-; LE-I32-NEXT:    bl lrintl
 ; LE-I32-NEXT:    add r3, sp, #84
-; LE-I32-NEXT:    vmov.32 d10[0], r0
-; LE-I32-NEXT:    mov r0, r10
+; LE-I32-NEXT:    ldr r12, [sp, #80]
+; LE-I32-NEXT:    vmov.32 d9[0], r0
 ; LE-I32-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I32-NEXT:    mov r0, r12
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    ldr r6, [sp, #96]
 ; LE-I32-NEXT:    vmov.32 d11[0], r0
-; LE-I32-NEXT:    ldr r1, [sp, #100]
-; LE-I32-NEXT:    ldr r2, [sp, #104]
-; LE-I32-NEXT:    ldr r3, [sp, #108]
-; LE-I32-NEXT:    mov r0, r6
-; LE-I32-NEXT:    ldr r4, [sp, #68]
-; LE-I32-NEXT:    ldr r5, [sp, #72]
-; LE-I32-NEXT:    ldr r10, [sp, #164]
-; LE-I32-NEXT:    ldr r7, [sp, #168]
+; LE-I32-NEXT:    mov r0, r4
+; LE-I32-NEXT:    mov r1, r7
+; LE-I32-NEXT:    mov r2, r6
+; LE-I32-NEXT:    mov r3, r5
+; LE-I32-NEXT:    ldr r8, [sp, #128]
+; LE-I32-NEXT:    ldr r9, [sp, #96]
 ; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    ldr r4, [sp, #64]
+; LE-I32-NEXT:    vmov.32 d10[0], r0
+; LE-I32-NEXT:    ldr r1, [sp, #68]
+; LE-I32-NEXT:    ldr r2, [sp, #72]
 ; LE-I32-NEXT:    ldr r3, [sp, #76]
-; LE-I32-NEXT:    vmov.32 d11[1], r0
-; LE-I32-NEXT:    mov r0, r9
-; LE-I32-NEXT:    mov r1, r4
-; LE-I32-NEXT:    mov r2, r5
+; LE-I32-NEXT:    mov r0, r4
+; LE-I32-NEXT:    ldr r5, [sp, #100]
+; LE-I32-NEXT:    ldr r6, [sp, #104]
+; LE-I32-NEXT:    ldr r10, [sp, #132]
+; LE-I32-NEXT:    ldr r7, [sp, #136]
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    ldr r3, [sp, #172]
+; LE-I32-NEXT:    ldr r3, [sp, #108]
 ; LE-I32-NEXT:    vmov.32 d10[1], r0
+; LE-I32-NEXT:    mov r0, r9
+; LE-I32-NEXT:    mov r1, r5
+; LE-I32-NEXT:    mov r2, r6
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    ldr r3, [sp, #140]
+; LE-I32-NEXT:    vmov.32 d11[1], r0
 ; LE-I32-NEXT:    mov r0, r8
 ; LE-I32-NEXT:    mov r1, r10
 ; LE-I32-NEXT:    mov r2, r7
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    add r3, sp, #144
+; LE-I32-NEXT:    add r3, sp, #112
 ; LE-I32-NEXT:    mov r4, r0
 ; LE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    add r3, sp, #132
-; LE-I32-NEXT:    ldr r7, [sp, #128]
-; LE-I32-NEXT:    vmov.32 d9[0], r0
+; LE-I32-NEXT:    add r3, sp, #164
+; LE-I32-NEXT:    ldr r7, [sp, #160]
+; LE-I32-NEXT:    vmov.32 d8[0], r0
 ; LE-I32-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I32-NEXT:    mov r0, r7
-; LE-I32-NEXT:    vmov.32 d9[1], r4
+; LE-I32-NEXT:    vmov.32 d8[1], r4
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    vmov.32 d8[1], r0
+; LE-I32-NEXT:    vmov.32 d9[1], r0
 ; LE-I32-NEXT:    vorr q0, q5, q5
 ; LE-I32-NEXT:    vorr q1, q4, q4
 ; LE-I32-NEXT:    vpop {d8, d9, d10, d11}
@@ -3666,154 +3661,147 @@ define <8 x iXLen> @lrint_v8fp128(<8 x fp128> %x) {
 ; LE-I64-NEXT:    sub sp, sp, #4
 ; LE-I64-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; LE-I64-NEXT:    .pad #8
-; LE-I64-NEXT:    sub sp, sp, #8
-; LE-I64-NEXT:    mov r11, r3
-; LE-I64-NEXT:    add r3, sp, #208
-; LE-I64-NEXT:    mov r10, r2
-; LE-I64-NEXT:    mov r4, r1
+; LE-I64-NEXT:    .pad #16
+; LE-I64-NEXT:    sub sp, sp, #16
+; LE-I64-NEXT:    stmib sp, {r2, r3} @ 8-byte Folded Spill
+; LE-I64-NEXT:    add r3, sp, #200
+; LE-I64-NEXT:    mov r7, r1
 ; LE-I64-NEXT:    mov r5, r0
 ; LE-I64-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r7, sp, #164
-; LE-I64-NEXT:    ldr r6, [sp, #160]
-; LE-I64-NEXT:    str r1, [sp, #4] @ 4-byte Spill
-; LE-I64-NEXT:    vmov.32 d9[0], r0
-; LE-I64-NEXT:    ldm r7, {r1, r2, r3, r7}
-; LE-I64-NEXT:    mov r0, r6
-; LE-I64-NEXT:    ldr r8, [sp, #128]
-; LE-I64-NEXT:    ldr r9, [sp, #144]
+; LE-I64-NEXT:    ldr r4, [sp, #184]
+; LE-I64-NEXT:    add r3, sp, #188
+; LE-I64-NEXT:    str r1, [sp, #12] @ 4-byte Spill
+; LE-I64-NEXT:    vmov.32 d8[0], r0
+; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I64-NEXT:    mov r0, r4
+; LE-I64-NEXT:    ldr r6, [sp, #168]
+; LE-I64-NEXT:    ldr r8, [sp, #152]
+; LE-I64-NEXT:    ldr r10, [sp, #136]
+; LE-I64-NEXT:    ldr r9, [sp, #120]
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #180
-; LE-I64-NEXT:    str r1, [sp] @ 4-byte Spill
-; LE-I64-NEXT:    vmov.32 d10[0], r0
-; LE-I64-NEXT:    mov r0, r7
+; LE-I64-NEXT:    add r3, sp, #172
+; LE-I64-NEXT:    mov r11, r1
+; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    mov r0, r6
 ; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #132
-; LE-I64-NEXT:    mov r7, r1
-; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    add r3, sp, #156
+; LE-I64-NEXT:    mov r6, r1
+; LE-I64-NEXT:    vmov.32 d10[0], r0
 ; LE-I64-NEXT:    mov r0, r8
 ; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #148
+; LE-I64-NEXT:    add r3, sp, #140
+; LE-I64-NEXT:    mov r4, r1
+; LE-I64-NEXT:    vmov.32 d13[0], r0
+; LE-I64-NEXT:    mov r0, r10
+; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add r3, sp, #124
 ; LE-I64-NEXT:    mov r8, r1
 ; LE-I64-NEXT:    vmov.32 d12[0], r0
 ; LE-I64-NEXT:    mov r0, r9
 ; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
 ; LE-I64-NEXT:    mov r9, r1
-; LE-I64-NEXT:    vmov.32 d13[0], r0
-; LE-I64-NEXT:    mov r0, r5
-; LE-I64-NEXT:    mov r1, r4
-; LE-I64-NEXT:    mov r2, r10
-; LE-I64-NEXT:    mov r3, r11
-; LE-I64-NEXT:    ldr r6, [sp, #112]
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #116
-; LE-I64-NEXT:    mov r4, r1
-; LE-I64-NEXT:    vmov.32 d14[0], r0
-; LE-I64-NEXT:    mov r0, r6
-; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #196
 ; LE-I64-NEXT:    vmov.32 d15[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #192]
+; LE-I64-NEXT:    mov r0, r5
+; LE-I64-NEXT:    mov r1, r7
+; LE-I64-NEXT:    ldmib sp, {r2, r3} @ 8-byte Folded Reload
+; LE-I64-NEXT:    ldr r10, [sp, #216]
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add r3, sp, #220
 ; LE-I64-NEXT:    mov r5, r1
+; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    mov r0, r10
 ; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    ldr r0, [sp] @ 4-byte Reload
-; LE-I64-NEXT:    vmov.32 d11[1], r7
-; LE-I64-NEXT:    vmov.32 d10[1], r0
-; LE-I64-NEXT:    ldr r0, [sp, #4] @ 4-byte Reload
-; LE-I64-NEXT:    vmov.32 d15[1], r5
-; LE-I64-NEXT:    vorr q2, q5, q5
-; LE-I64-NEXT:    vmov.32 d13[1], r9
-; LE-I64-NEXT:    vmov.32 d9[1], r0
-; LE-I64-NEXT:    vmov.32 d14[1], r4
+; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    ldr r0, [sp, #12] @ 4-byte Reload
+; LE-I64-NEXT:    vmov.32 d14[1], r5
 ; LE-I64-NEXT:    vmov.32 d12[1], r8
+; LE-I64-NEXT:    vmov.32 d10[1], r6
+; LE-I64-NEXT:    vmov.32 d8[1], r0
+; LE-I64-NEXT:    vmov.32 d15[1], r9
+; LE-I64-NEXT:    vmov.32 d13[1], r4
 ; LE-I64-NEXT:    vorr q0, q7, q7
-; LE-I64-NEXT:    vmov.32 d8[1], r1
+; LE-I64-NEXT:    vmov.32 d11[1], r11
 ; LE-I64-NEXT:    vorr q1, q6, q6
+; LE-I64-NEXT:    vmov.32 d9[1], r1
+; LE-I64-NEXT:    vorr q2, q5, q5
 ; LE-I64-NEXT:    vorr q3, q4, q4
-; LE-I64-NEXT:    add sp, sp, #8
+; LE-I64-NEXT:    add sp, sp, #16
 ; LE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    add sp, sp, #4
 ; LE-I64-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
 ;
 ; BE-I32-LABEL: lrint_v8fp128:
 ; BE-I32:       @ %bb.0:
-; BE-I32-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; BE-I32-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-; BE-I32-NEXT:    .pad #4
-; BE-I32-NEXT:    sub sp, sp, #4
+; BE-I32-NEXT:    .save {r4, r5, r6, r7, r8, r9, r10, lr}
+; BE-I32-NEXT:    push {r4, r5, r6, r7, r8, r9, r10, lr}
 ; BE-I32-NEXT:    .vsave {d8, d9, d10, d11}
 ; BE-I32-NEXT:    vpush {d8, d9, d10, d11}
-; BE-I32-NEXT:    .pad #8
-; BE-I32-NEXT:    sub sp, sp, #8
-; BE-I32-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; BE-I32-NEXT:    add r3, sp, #128
-; BE-I32-NEXT:    mov r11, r2
-; BE-I32-NEXT:    mov r6, r1
-; BE-I32-NEXT:    mov r7, r0
+; BE-I32-NEXT:    mov r6, r3
+; BE-I32-NEXT:    add r3, sp, #144
+; BE-I32-NEXT:    mov r7, r2
+; BE-I32-NEXT:    mov r4, r1
+; BE-I32-NEXT:    mov r5, r0
 ; BE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    add r3, sp, #100
-; BE-I32-NEXT:    ldr r5, [sp, #96]
-; BE-I32-NEXT:    vmov.32 d8[0], r0
-; BE-I32-NEXT:    ldr r4, [sp, #160]
-; BE-I32-NEXT:    ldm r3, {r1, r2, r3}
+; BE-I32-NEXT:    vmov.32 d9[0], r0
 ; BE-I32-NEXT:    mov r0, r5
+; BE-I32-NEXT:    mov r1, r4
+; BE-I32-NEXT:    mov r2, r7
+; BE-I32-NEXT:    mov r3, r6
+; BE-I32-NEXT:    ldr r8, [sp, #96]
+; BE-I32-NEXT:    ldr r9, [sp, #64]
+; BE-I32-NEXT:    ldr r10, [sp, #112]
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    add r3, sp, #116
+; BE-I32-NEXT:    vmov.32 d10[0], r0
+; BE-I32-NEXT:    mov r0, r10
+; BE-I32-NEXT:    ldm r3, {r1, r2, r3}
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    ldr r6, [sp, #128]
+; BE-I32-NEXT:    vmov.32 d8[0], r0
+; BE-I32-NEXT:    ldr r1, [sp, #132]
+; BE-I32-NEXT:    ldr r2, [sp, #136]
+; BE-I32-NEXT:    ldr r3, [sp, #140]
+; BE-I32-NEXT:    mov r0, r6
+; BE-I32-NEXT:    ldr r4, [sp, #68]
+; BE-I32-NEXT:    ldr r5, [sp, #72]
+; BE-I32-NEXT:    ldr r10, [sp, #100]
+; BE-I32-NEXT:    ldr r7, [sp, #104]
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    ldr r3, [sp, #76]
+; BE-I32-NEXT:    vmov.32 d8[1], r0
+; BE-I32-NEXT:    mov r0, r9
+; BE-I32-NEXT:    mov r1, r4
+; BE-I32-NEXT:    mov r2, r5
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    ldr r3, [sp, #108]
+; BE-I32-NEXT:    vmov.32 d10[1], r0
+; BE-I32-NEXT:    mov r0, r8
+; BE-I32-NEXT:    mov r1, r10
+; BE-I32-NEXT:    mov r2, r7
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    add r3, sp, #80
+; BE-I32-NEXT:    mov r4, r0
+; BE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-I32-NEXT:    bl lrintl
 ; BE-I32-NEXT:    add r3, sp, #164
+; BE-I32-NEXT:    ldr r7, [sp, #160]
 ; BE-I32-NEXT:    vmov.32 d11[0], r0
-; BE-I32-NEXT:    mov r0, r4
 ; BE-I32-NEXT:    ldm r3, {r1, r2, r3}
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    ldr r4, [sp, #176]
-; BE-I32-NEXT:    vmov.32 d9[0], r0
-; BE-I32-NEXT:    ldr r1, [sp, #180]
-; BE-I32-NEXT:    ldr r2, [sp, #184]
-; BE-I32-NEXT:    ldr r3, [sp, #188]
-; BE-I32-NEXT:    mov r0, r4
-; BE-I32-NEXT:    ldr r5, [sp, #116]
-; BE-I32-NEXT:    ldr r8, [sp, #120]
-; BE-I32-NEXT:    ldr r10, [sp, #84]
-; BE-I32-NEXT:    ldr r9, [sp, #88]
+; BE-I32-NEXT:    mov r0, r7
+; BE-I32-NEXT:    vmov.32 d11[1], r4
 ; BE-I32-NEXT:    bl lrintl
 ; BE-I32-NEXT:    vmov.32 d9[1], r0
-; BE-I32-NEXT:    ldr r3, [sp, #124]
-; BE-I32-NEXT:    ldr r0, [sp, #112]
-; BE-I32-NEXT:    mov r1, r5
-; BE-I32-NEXT:    mov r2, r8
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    vmov.32 d11[1], r0
-; BE-I32-NEXT:    ldr r3, [sp, #92]
-; BE-I32-NEXT:    ldr r0, [sp, #80]
-; BE-I32-NEXT:    mov r1, r10
-; BE-I32-NEXT:    mov r2, r9
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    ldr r3, [sp, #4] @ 4-byte Reload
-; BE-I32-NEXT:    mov r4, r0
-; BE-I32-NEXT:    mov r0, r7
-; BE-I32-NEXT:    mov r1, r6
-; BE-I32-NEXT:    mov r2, r11
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    add r3, sp, #148
-; BE-I32-NEXT:    ldr r7, [sp, #144]
-; BE-I32-NEXT:    vmov.32 d10[0], r0
-; BE-I32-NEXT:    ldm r3, {r1, r2, r3}
-; BE-I32-NEXT:    mov r0, r7
-; BE-I32-NEXT:    vmov.32 d10[1], r4
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    vmov.32 d8[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q5
 ; BE-I32-NEXT:    vrev64.32 q1, q4
-; BE-I32-NEXT:    add sp, sp, #8
 ; BE-I32-NEXT:    vpop {d8, d9, d10, d11}
-; BE-I32-NEXT:    add sp, sp, #4
-; BE-I32-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
+; BE-I32-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, pc}
 ;
 ; BE-I64-LABEL: lrint_v8fp128:
 ; BE-I64:       @ %bb.0:
@@ -3825,24 +3813,25 @@ define <8 x iXLen> @lrint_v8fp128(<8 x fp128> %x) {
 ; BE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
 ; BE-I64-NEXT:    .pad #16
 ; BE-I64-NEXT:    sub sp, sp, #16
-; BE-I64-NEXT:    str r3, [sp, #4] @ 4-byte Spill
-; BE-I64-NEXT:    add r3, sp, #208
-; BE-I64-NEXT:    mov r11, r2
-; BE-I64-NEXT:    mov r4, r1
+; BE-I64-NEXT:    stmib sp, {r2, r3} @ 8-byte Folded Spill
+; BE-I64-NEXT:    add r3, sp, #192
+; BE-I64-NEXT:    mov r7, r1
 ; BE-I64-NEXT:    mov r5, r0
 ; BE-I64-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    ldr r7, [sp, #176]
+; BE-I64-NEXT:    ldr r4, [sp, #176]
 ; BE-I64-NEXT:    add r3, sp, #180
 ; BE-I64-NEXT:    str r1, [sp, #12] @ 4-byte Spill
 ; BE-I64-NEXT:    vmov.32 d8[0], r0
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; BE-I64-NEXT:    mov r0, r7
-; BE-I64-NEXT:    ldr r6, [sp, #128]
+; BE-I64-NEXT:    mov r0, r4
+; BE-I64-NEXT:    ldr r6, [sp, #160]
 ; BE-I64-NEXT:    ldr r8, [sp, #144]
+; BE-I64-NEXT:    ldr r10, [sp, #128]
+; BE-I64-NEXT:    ldr r9, [sp, #112]
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #132
-; BE-I64-NEXT:    str r1, [sp, #8] @ 4-byte Spill
+; BE-I64-NEXT:    add r3, sp, #164
+; BE-I64-NEXT:    mov r11, r1
 ; BE-I64-NEXT:    vmov.32 d9[0], r0
 ; BE-I64-NEXT:    mov r0, r6
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
@@ -3853,51 +3842,49 @@ define <8 x iXLen> @lrint_v8fp128(<8 x fp128> %x) {
 ; BE-I64-NEXT:    mov r0, r8
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #160
-; BE-I64-NEXT:    mov r9, r0
-; BE-I64-NEXT:    mov r7, r1
-; BE-I64-NEXT:    ldm r3, {r0, r1, r2, r3}
-; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    ldr r3, [sp, #4] @ 4-byte Reload
-; BE-I64-NEXT:    mov r8, r1
-; BE-I64-NEXT:    vmov.32 d11[0], r0
-; BE-I64-NEXT:    mov r0, r5
-; BE-I64-NEXT:    mov r1, r4
-; BE-I64-NEXT:    mov r2, r11
-; BE-I64-NEXT:    ldr r10, [sp, #112]
-; BE-I64-NEXT:    vmov.32 d12[0], r9
-; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #116
+; BE-I64-NEXT:    add r3, sp, #132
 ; BE-I64-NEXT:    mov r4, r1
-; BE-I64-NEXT:    vmov.32 d13[0], r0
+; BE-I64-NEXT:    vmov.32 d11[0], r0
 ; BE-I64-NEXT:    mov r0, r10
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #196
-; BE-I64-NEXT:    vmov.32 d14[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #192]
+; BE-I64-NEXT:    add r3, sp, #116
+; BE-I64-NEXT:    mov r8, r1
+; BE-I64-NEXT:    vmov.32 d12[0], r0
+; BE-I64-NEXT:    mov r0, r9
+; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; BE-I64-NEXT:    bl lrintl
+; BE-I64-NEXT:    mov r9, r1
+; BE-I64-NEXT:    vmov.32 d13[0], r0
+; BE-I64-NEXT:    mov r0, r5
+; BE-I64-NEXT:    mov r1, r7
+; BE-I64-NEXT:    ldmib sp, {r2, r3} @ 8-byte Folded Reload
+; BE-I64-NEXT:    ldr r10, [sp, #208]
+; BE-I64-NEXT:    bl lrintl
+; BE-I64-NEXT:    add r3, sp, #212
 ; BE-I64-NEXT:    mov r5, r1
+; BE-I64-NEXT:    vmov.32 d14[0], r0
+; BE-I64-NEXT:    mov r0, r10
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
 ; BE-I64-NEXT:    vmov.32 d16[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #8] @ 4-byte Reload
-; BE-I64-NEXT:    vmov.32 d14[1], r5
-; BE-I64-NEXT:    vmov.32 d9[1], r0
 ; BE-I64-NEXT:    ldr r0, [sp, #12] @ 4-byte Reload
-; BE-I64-NEXT:    vmov.32 d12[1], r7
-; BE-I64-NEXT:    vmov.32 d8[1], r0
-; BE-I64-NEXT:    vmov.32 d13[1], r4
+; BE-I64-NEXT:    vmov.32 d14[1], r5
+; BE-I64-NEXT:    vmov.32 d12[1], r8
 ; BE-I64-NEXT:    vmov.32 d10[1], r6
-; BE-I64-NEXT:    vmov.32 d11[1], r8
+; BE-I64-NEXT:    vmov.32 d8[1], r0
+; BE-I64-NEXT:    vmov.32 d13[1], r9
+; BE-I64-NEXT:    vmov.32 d11[1], r4
+; BE-I64-NEXT:    vmov.32 d9[1], r11
 ; BE-I64-NEXT:    vmov.32 d16[1], r1
-; BE-I64-NEXT:    vrev64.32 d1, d14
-; BE-I64-NEXT:    vrev64.32 d3, d12
+; BE-I64-NEXT:    vrev64.32 d0, d14
+; BE-I64-NEXT:    vrev64.32 d2, d12
+; BE-I64-NEXT:    vrev64.32 d4, d10
+; BE-I64-NEXT:    vrev64.32 d6, d8
+; BE-I64-NEXT:    vrev64.32 d1, d13
+; BE-I64-NEXT:    vrev64.32 d3, d11
 ; BE-I64-NEXT:    vrev64.32 d5, d9
-; BE-I64-NEXT:    vrev64.32 d7, d8
-; BE-I64-NEXT:    vrev64.32 d0, d13
-; BE-I64-NEXT:    vrev64.32 d2, d10
-; BE-I64-NEXT:    vrev64.32 d4, d11
-; BE-I64-NEXT:    vrev64.32 d6, d16
+; BE-I64-NEXT:    vrev64.32 d7, d16
 ; BE-I64-NEXT:    add sp, sp, #16
 ; BE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
 ; BE-I64-NEXT:    add sp, sp, #4
@@ -3916,116 +3903,115 @@ define <16 x iXLen> @lrint_v16fp128(<16 x fp128> %x) {
 ; LE-I32-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I32-NEXT:    mov r8, r3
-; LE-I32-NEXT:    add r3, sp, #280
-; LE-I32-NEXT:    mov r9, r2
-; LE-I32-NEXT:    mov r10, r1
-; LE-I32-NEXT:    mov r6, r0
-; LE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    ldr r4, [sp, #216]
-; LE-I32-NEXT:    vmov.32 d8[0], r0
-; LE-I32-NEXT:    ldr r1, [sp, #220]
-; LE-I32-NEXT:    ldr r2, [sp, #224]
-; LE-I32-NEXT:    ldr r3, [sp, #228]
-; LE-I32-NEXT:    mov r0, r4
-; LE-I32-NEXT:    ldr r7, [sp, #152]
-; LE-I32-NEXT:    ldr r11, [sp, #104]
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    add r3, sp, #156
-; LE-I32-NEXT:    vmov.32 d10[0], r0
-; LE-I32-NEXT:    mov r0, r7
-; LE-I32-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    ldr r7, [sp, #184]
-; LE-I32-NEXT:    vmov.32 d12[0], r0
-; LE-I32-NEXT:    ldr r1, [sp, #188]
-; LE-I32-NEXT:    ldr r2, [sp, #192]
-; LE-I32-NEXT:    ldr r3, [sp, #196]
-; LE-I32-NEXT:    mov r0, r7
-; LE-I32-NEXT:    ldr r4, [sp, #120]
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    add r3, sp, #124
-; LE-I32-NEXT:    vmov.32 d13[0], r0
-; LE-I32-NEXT:    mov r0, r4
-; LE-I32-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    ldr r5, [sp, #136]
-; LE-I32-NEXT:    vmov.32 d15[0], r0
-; LE-I32-NEXT:    ldr r1, [sp, #140]
-; LE-I32-NEXT:    ldr r2, [sp, #144]
-; LE-I32-NEXT:    ldr r3, [sp, #148]
-; LE-I32-NEXT:    mov r0, r5
-; LE-I32-NEXT:    ldr r4, [sp, #108]
-; LE-I32-NEXT:    ldr r7, [sp, #112]
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    ldr r3, [sp, #116]
-; LE-I32-NEXT:    vmov.32 d15[1], r0
-; LE-I32-NEXT:    mov r0, r11
-; LE-I32-NEXT:    mov r1, r4
-; LE-I32-NEXT:    mov r2, r7
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    mov r4, r0
-; LE-I32-NEXT:    mov r0, r6
-; LE-I32-NEXT:    mov r1, r10
-; LE-I32-NEXT:    mov r2, r9
-; LE-I32-NEXT:    mov r3, r8
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    ldr r7, [sp, #200]
-; LE-I32-NEXT:    vmov.32 d14[0], r0
-; LE-I32-NEXT:    ldr r1, [sp, #204]
-; LE-I32-NEXT:    ldr r2, [sp, #208]
-; LE-I32-NEXT:    ldr r3, [sp, #212]
-; LE-I32-NEXT:    mov r0, r7
-; LE-I32-NEXT:    ldr r5, [sp, #172]
-; LE-I32-NEXT:    vmov.32 d14[1], r4
-; LE-I32-NEXT:    ldr r6, [sp, #176]
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    vmov.32 d13[1], r0
-; LE-I32-NEXT:    ldr r3, [sp, #180]
-; LE-I32-NEXT:    ldr r0, [sp, #168]
-; LE-I32-NEXT:    mov r1, r5
-; LE-I32-NEXT:    mov r2, r6
-; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    add r3, sp, #248
+; LE-I32-NEXT:    add r3, sp, #312
+; LE-I32-NEXT:    mov r7, r2
+; LE-I32-NEXT:    mov r4, r1
 ; LE-I32-NEXT:    mov r5, r0
 ; LE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    ldr r4, [sp, #264]
+; LE-I32-NEXT:    ldr r6, [sp, #248]
+; LE-I32-NEXT:    vmov.32 d9[0], r0
+; LE-I32-NEXT:    ldr r1, [sp, #252]
+; LE-I32-NEXT:    ldr r2, [sp, #256]
+; LE-I32-NEXT:    ldr r3, [sp, #260]
+; LE-I32-NEXT:    mov r0, r6
+; LE-I32-NEXT:    ldr r11, [sp, #184]
+; LE-I32-NEXT:    ldr r10, [sp, #152]
+; LE-I32-NEXT:    ldr r9, [sp, #200]
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    add r3, sp, #188
 ; LE-I32-NEXT:    vmov.32 d11[0], r0
-; LE-I32-NEXT:    ldr r1, [sp, #268]
-; LE-I32-NEXT:    ldr r2, [sp, #272]
-; LE-I32-NEXT:    vmov.32 d12[1], r5
-; LE-I32-NEXT:    ldr r3, [sp, #276]
-; LE-I32-NEXT:    mov r0, r4
-; LE-I32-NEXT:    ldr r6, [sp, #236]
-; LE-I32-NEXT:    ldr r7, [sp, #240]
-; LE-I32-NEXT:    ldr r8, [sp, #332]
-; LE-I32-NEXT:    ldr r5, [sp, #336]
+; LE-I32-NEXT:    mov r0, r11
+; LE-I32-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    vmov.32 d11[1], r0
-; LE-I32-NEXT:    ldr r3, [sp, #244]
-; LE-I32-NEXT:    ldr r0, [sp, #232]
-; LE-I32-NEXT:    mov r1, r6
+; LE-I32-NEXT:    add r3, sp, #156
+; LE-I32-NEXT:    vmov.32 d13[0], r0
+; LE-I32-NEXT:    mov r0, r10
+; LE-I32-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    vmov.32 d12[0], r0
+; LE-I32-NEXT:    mov r0, r5
+; LE-I32-NEXT:    mov r1, r4
 ; LE-I32-NEXT:    mov r2, r7
+; LE-I32-NEXT:    mov r3, r8
+; LE-I32-NEXT:    ldr r10, [sp, #136]
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    vmov.32 d10[1], r0
-; LE-I32-NEXT:    ldr r3, [sp, #340]
-; LE-I32-NEXT:    ldr r0, [sp, #328]
-; LE-I32-NEXT:    mov r1, r8
+; LE-I32-NEXT:    ldr r7, [sp, #104]
+; LE-I32-NEXT:    vmov.32 d14[0], r0
+; LE-I32-NEXT:    ldr r1, [sp, #108]
+; LE-I32-NEXT:    ldr r2, [sp, #112]
+; LE-I32-NEXT:    ldr r3, [sp, #116]
+; LE-I32-NEXT:    mov r0, r7
+; LE-I32-NEXT:    ldr r4, [sp, #140]
+; LE-I32-NEXT:    ldr r5, [sp, #144]
+; LE-I32-NEXT:    ldr r8, [sp, #296]
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    ldr r3, [sp, #148]
+; LE-I32-NEXT:    vmov.32 d14[1], r0
+; LE-I32-NEXT:    mov r0, r10
+; LE-I32-NEXT:    mov r1, r4
 ; LE-I32-NEXT:    mov r2, r5
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    add r3, sp, #312
+; LE-I32-NEXT:    add r3, sp, #120
 ; LE-I32-NEXT:    mov r4, r0
 ; LE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    add r3, sp, #300
-; LE-I32-NEXT:    ldr r7, [sp, #296]
-; LE-I32-NEXT:    vmov.32 d9[0], r0
+; LE-I32-NEXT:    ldr r6, [sp, #168]
+; LE-I32-NEXT:    vmov.32 d15[0], r0
+; LE-I32-NEXT:    ldr r1, [sp, #172]
+; LE-I32-NEXT:    ldr r2, [sp, #176]
+; LE-I32-NEXT:    ldr r3, [sp, #180]
+; LE-I32-NEXT:    mov r0, r6
+; LE-I32-NEXT:    ldr r5, [sp, #204]
+; LE-I32-NEXT:    vmov.32 d15[1], r4
+; LE-I32-NEXT:    ldr r7, [sp, #208]
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    ldr r3, [sp, #212]
+; LE-I32-NEXT:    vmov.32 d12[1], r0
+; LE-I32-NEXT:    mov r0, r9
+; LE-I32-NEXT:    mov r1, r5
+; LE-I32-NEXT:    mov r2, r7
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    add r3, sp, #216
+; LE-I32-NEXT:    mov r5, r0
+; LE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    ldr r4, [sp, #232]
+; LE-I32-NEXT:    vmov.32 d10[0], r0
+; LE-I32-NEXT:    ldr r1, [sp, #236]
+; LE-I32-NEXT:    ldr r2, [sp, #240]
+; LE-I32-NEXT:    vmov.32 d13[1], r5
+; LE-I32-NEXT:    ldr r3, [sp, #244]
+; LE-I32-NEXT:    mov r0, r4
+; LE-I32-NEXT:    ldr r6, [sp, #268]
+; LE-I32-NEXT:    ldr r7, [sp, #272]
+; LE-I32-NEXT:    ldr r9, [sp, #300]
+; LE-I32-NEXT:    ldr r5, [sp, #304]
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    vmov.32 d10[1], r0
+; LE-I32-NEXT:    ldr r3, [sp, #276]
+; LE-I32-NEXT:    ldr r0, [sp, #264]
+; LE-I32-NEXT:    mov r1, r6
+; LE-I32-NEXT:    mov r2, r7
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    ldr r3, [sp, #308]
+; LE-I32-NEXT:    vmov.32 d11[1], r0
+; LE-I32-NEXT:    mov r0, r8
+; LE-I32-NEXT:    mov r1, r9
+; LE-I32-NEXT:    mov r2, r5
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    add r3, sp, #280
+; LE-I32-NEXT:    mov r4, r0
+; LE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
+; LE-I32-NEXT:    bl lrintl
+; LE-I32-NEXT:    add r3, sp, #332
+; LE-I32-NEXT:    ldr r7, [sp, #328]
+; LE-I32-NEXT:    vmov.32 d8[0], r0
 ; LE-I32-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I32-NEXT:    mov r0, r7
-; LE-I32-NEXT:    vmov.32 d9[1], r4
+; LE-I32-NEXT:    vmov.32 d8[1], r4
 ; LE-I32-NEXT:    bl lrintl
-; LE-I32-NEXT:    vmov.32 d8[1], r0
+; LE-I32-NEXT:    vmov.32 d9[1], r0
 ; LE-I32-NEXT:    vorr q0, q7, q7
 ; LE-I32-NEXT:    vorr q1, q6, q6
 ; LE-I32-NEXT:    vorr q2, q5, q5
@@ -4042,157 +4028,158 @@ define <16 x iXLen> @lrint_v16fp128(<16 x fp128> %x) {
 ; LE-I64-NEXT:    sub sp, sp, #4
 ; LE-I64-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; LE-I64-NEXT:    .pad #72
-; LE-I64-NEXT:    sub sp, sp, #72
+; LE-I64-NEXT:    .pad #80
+; LE-I64-NEXT:    sub sp, sp, #80
 ; LE-I64-NEXT:    mov r6, r3
-; LE-I64-NEXT:    add r3, sp, #408
+; LE-I64-NEXT:    add r3, sp, #400
 ; LE-I64-NEXT:    mov r7, r2
 ; LE-I64-NEXT:    mov r4, r0
 ; LE-I64-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r5, sp, #176
+; LE-I64-NEXT:    add r8, sp, #184
 ; LE-I64-NEXT:    mov r10, r1
-; LE-I64-NEXT:    vmov.32 d13[0], r0
-; LE-I64-NEXT:    mov r0, r7
-; LE-I64-NEXT:    ldm r5, {r2, r3, r5}
-; LE-I64-NEXT:    mov r1, r6
-; LE-I64-NEXT:    ldr r8, [sp, #232]
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #188
-; LE-I64-NEXT:    mov r9, r1
 ; LE-I64-NEXT:    vmov.32 d8[0], r0
+; LE-I64-NEXT:    mov r0, r7
+; LE-I64-NEXT:    ldm r8, {r2, r3, r8}
+; LE-I64-NEXT:    mov r1, r6
+; LE-I64-NEXT:    ldr r5, [sp, #256]
+; LE-I64-NEXT:    ldr r9, [sp, #240]
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add r3, sp, #260
+; LE-I64-NEXT:    mov r7, r1
+; LE-I64-NEXT:    vmov.32 d10[0], r0
 ; LE-I64-NEXT:    mov r0, r5
 ; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #236
-; LE-I64-NEXT:    mov r11, r1
-; LE-I64-NEXT:    vmov.32 d9[0], r0
-; LE-I64-NEXT:    mov r0, r8
-; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #252
-; LE-I64-NEXT:    vmov.32 d10[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #248]
-; LE-I64-NEXT:    mov r8, r1
-; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #268
-; LE-I64-NEXT:    vmov.32 d11[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #264]
+; LE-I64-NEXT:    add r3, sp, #244
 ; LE-I64-NEXT:    mov r6, r1
-; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #284
-; LE-I64-NEXT:    vmov.32 d14[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #280]
-; LE-I64-NEXT:    mov r7, r1
-; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #316
-; LE-I64-NEXT:    vmov.32 d15[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #312]
-; LE-I64-NEXT:    mov r5, r1
-; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    vmov.32 d15[1], r5
-; LE-I64-NEXT:    add lr, sp, #56
-; LE-I64-NEXT:    ldr r5, [sp, #300]
-; LE-I64-NEXT:    vmov.32 d14[1], r7
-; LE-I64-NEXT:    ldr r2, [sp, #304]
-; LE-I64-NEXT:    ldr r3, [sp, #308]
-; LE-I64-NEXT:    vmov.32 d11[1], r6
-; LE-I64-NEXT:    ldr r6, [sp, #200]
-; LE-I64-NEXT:    ldr r7, [sp, #204]
-; LE-I64-NEXT:    vmov.32 d10[1], r8
-; LE-I64-NEXT:    ldr r8, [sp, #344]
-; LE-I64-NEXT:    vmov.32 d9[1], r11
-; LE-I64-NEXT:    ldr r11, [sp, #216]
-; LE-I64-NEXT:    vstmia lr, {d14, d15} @ 16-byte Spill
-; LE-I64-NEXT:    add lr, sp, #40
-; LE-I64-NEXT:    vmov.32 d17[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #296]
-; LE-I64-NEXT:    vmov.32 d8[1], r9
-; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
-; LE-I64-NEXT:    add lr, sp, #24
-; LE-I64-NEXT:    vorr q5, q8, q8
-; LE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
-; LE-I64-NEXT:    vorr q4, q6, q6
-; LE-I64-NEXT:    vmov.32 d11[1], r1
-; LE-I64-NEXT:    mov r1, r5
-; LE-I64-NEXT:    vmov.32 d9[1], r10
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    vmov.32 d10[0], r0
-; LE-I64-NEXT:    ldr r2, [sp, #208]
-; LE-I64-NEXT:    ldr r3, [sp, #212]
-; LE-I64-NEXT:    add lr, sp, #8
-; LE-I64-NEXT:    mov r9, r1
-; LE-I64-NEXT:    mov r0, r6
-; LE-I64-NEXT:    mov r1, r7
-; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #220
-; LE-I64-NEXT:    mov r10, r1
-; LE-I64-NEXT:    vmov.32 d10[0], r0
-; LE-I64-NEXT:    mov r0, r11
-; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #348
-; LE-I64-NEXT:    mov r11, r1
-; LE-I64-NEXT:    vmov.32 d11[0], r0
-; LE-I64-NEXT:    mov r0, r8
-; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #364
 ; LE-I64-NEXT:    vmov.32 d13[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #360]
-; LE-I64-NEXT:    mov r8, r1
+; LE-I64-NEXT:    mov r0, r9
 ; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #380
-; LE-I64-NEXT:    vmov.32 d14[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #376]
+; LE-I64-NEXT:    add r3, sp, #196
 ; LE-I64-NEXT:    mov r5, r1
+; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    mov r0, r8
 ; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #396
-; LE-I64-NEXT:    vmov.32 d15[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #392]
+; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    mov r9, r1
+; LE-I64-NEXT:    ldr r0, [sp, #304]
+; LE-I64-NEXT:    add lr, sp, #64
+; LE-I64-NEXT:    ldr r1, [sp, #308]
+; LE-I64-NEXT:    vmov.32 d12[1], r5
+; LE-I64-NEXT:    ldr r2, [sp, #312]
+; LE-I64-NEXT:    ldr r3, [sp, #316]
+; LE-I64-NEXT:    vmov.32 d13[1], r6
+; LE-I64-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
+; LE-I64-NEXT:    vmov.32 d10[1], r7
+; LE-I64-NEXT:    vmov.32 d8[1], r10
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add r3, sp, #288
+; LE-I64-NEXT:    mov r11, r0
+; LE-I64-NEXT:    str r1, [sp, #60] @ 4-byte Spill
+; LE-I64-NEXT:    ldm r3, {r0, r1, r2, r3}
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    ldr r7, [sp, #272]
+; LE-I64-NEXT:    add r3, sp, #276
+; LE-I64-NEXT:    mov r5, r1
+; LE-I64-NEXT:    vmov.32 d13[0], r0
+; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I64-NEXT:    mov r0, r7
+; LE-I64-NEXT:    ldr r6, [sp, #416]
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add r3, sp, #420
+; LE-I64-NEXT:    mov r7, r1
+; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    mov r0, r6
+; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add lr, sp, #40
+; LE-I64-NEXT:    vmov.32 d12[1], r7
+; LE-I64-NEXT:    ldr r7, [sp, #228]
+; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    ldr r0, [sp, #224]
+; LE-I64-NEXT:    ldr r2, [sp, #232]
+; LE-I64-NEXT:    vmov.32 d13[1], r5
+; LE-I64-NEXT:    ldr r3, [sp, #236]
+; LE-I64-NEXT:    ldr r8, [sp, #336]
+; LE-I64-NEXT:    vstmia lr, {d12, d13} @ 16-byte Spill
+; LE-I64-NEXT:    add lr, sp, #24
+; LE-I64-NEXT:    vmov.32 d11[1], r9
+; LE-I64-NEXT:    ldr r10, [sp, #352]
+; LE-I64-NEXT:    ldr r5, [sp, #208]
+; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
+; LE-I64-NEXT:    add lr, sp, #8
+; LE-I64-NEXT:    vmov.32 d9[1], r1
+; LE-I64-NEXT:    mov r1, r7
+; LE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
+; LE-I64-NEXT:    vmov.32 d10[0], r11
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add r3, sp, #212
+; LE-I64-NEXT:    mov r9, r1
+; LE-I64-NEXT:    vmov.32 d9[0], r0
+; LE-I64-NEXT:    mov r0, r5
+; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add r3, sp, #356
+; LE-I64-NEXT:    mov r11, r1
+; LE-I64-NEXT:    vmov.32 d8[0], r0
+; LE-I64-NEXT:    mov r0, r10
+; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add r3, sp, #340
+; LE-I64-NEXT:    mov r10, r1
+; LE-I64-NEXT:    vmov.32 d13[0], r0
+; LE-I64-NEXT:    mov r0, r8
+; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add r3, sp, #388
+; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    ldr r0, [sp, #384]
 ; LE-I64-NEXT:    mov r6, r1
 ; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
-; LE-I64-NEXT:    add r3, sp, #332
-; LE-I64-NEXT:    vmov.32 d8[0], r0
-; LE-I64-NEXT:    ldr r0, [sp, #328]
+; LE-I64-NEXT:    add r3, sp, #372
+; LE-I64-NEXT:    vmov.32 d15[0], r0
+; LE-I64-NEXT:    ldr r0, [sp, #368]
 ; LE-I64-NEXT:    mov r7, r1
 ; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    add r3, sp, #324
+; LE-I64-NEXT:    vmov.32 d14[0], r0
+; LE-I64-NEXT:    ldr r0, [sp, #320]
+; LE-I64-NEXT:    mov r5, r1
+; LE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; LE-I64-NEXT:    bl lrintl
+; LE-I64-NEXT:    vmov.32 d11[0], r0
+; LE-I64-NEXT:    ldr r0, [sp, #60] @ 4-byte Reload
 ; LE-I64-NEXT:    add lr, sp, #8
-; LE-I64-NEXT:    vmov.32 d12[0], r0
+; LE-I64-NEXT:    vmov.32 d12[1], r6
+; LE-I64-NEXT:    vmov.32 d10[1], r0
 ; LE-I64-NEXT:    add r0, r4, #64
-; LE-I64-NEXT:    vldmia lr, {d18, d19} @ 16-byte Reload
-; LE-I64-NEXT:    add lr, sp, #24
-; LE-I64-NEXT:    vmov.32 d13[1], r8
-; LE-I64-NEXT:    vmov.32 d18[1], r9
-; LE-I64-NEXT:    vmov.32 d15[1], r6
-; LE-I64-NEXT:    vmov.32 d12[1], r1
+; LE-I64-NEXT:    vmov.32 d11[1], r1
 ; LE-I64-NEXT:    vmov.32 d14[1], r5
-; LE-I64-NEXT:    vst1.64 {d18, d19}, [r0:128]!
+; LE-I64-NEXT:    vmov.32 d13[1], r10
+; LE-I64-NEXT:    vmov.32 d15[1], r7
+; LE-I64-NEXT:    vst1.64 {d10, d11}, [r0:128]!
 ; LE-I64-NEXT:    vst1.64 {d12, d13}, [r0:128]!
-; LE-I64-NEXT:    vmov.32 d8[1], r7
 ; LE-I64-NEXT:    vst1.64 {d14, d15}, [r0:128]!
-; LE-I64-NEXT:    vst1.64 {d8, d9}, [r0:128]
-; LE-I64-NEXT:    vmov.32 d11[1], r11
+; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-I64-NEXT:    add lr, sp, #24
+; LE-I64-NEXT:    vmov.32 d8[1], r11
+; LE-I64-NEXT:    vst1.64 {d16, d17}, [r0:128]
+; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
+; LE-I64-NEXT:    add lr, sp, #64
+; LE-I64-NEXT:    vmov.32 d9[1], r9
+; LE-I64-NEXT:    vst1.64 {d16, d17}, [r4:128]!
+; LE-I64-NEXT:    vst1.64 {d8, d9}, [r4:128]!
 ; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I64-NEXT:    add lr, sp, #40
-; LE-I64-NEXT:    vmov.32 d10[1], r10
-; LE-I64-NEXT:    vst1.64 {d16, d17}, [r4:128]!
-; LE-I64-NEXT:    vst1.64 {d10, d11}, [r4:128]!
-; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-I64-NEXT:    add lr, sp, #56
 ; LE-I64-NEXT:    vst1.64 {d16, d17}, [r4:128]!
 ; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
 ; LE-I64-NEXT:    vst1.64 {d16, d17}, [r4:128]
-; LE-I64-NEXT:    add sp, sp, #72
+; LE-I64-NEXT:    add sp, sp, #80
 ; LE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; LE-I64-NEXT:    add sp, sp, #4
 ; LE-I64-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
@@ -4205,121 +4192,125 @@ define <16 x iXLen> @lrint_v16fp128(<16 x fp128> %x) {
 ; BE-I32-NEXT:    sub sp, sp, #4
 ; BE-I32-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-I32-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; BE-I32-NEXT:    .pad #16
-; BE-I32-NEXT:    sub sp, sp, #16
-; BE-I32-NEXT:    stm sp, {r0, r1, r2, r3} @ 16-byte Folded Spill
-; BE-I32-NEXT:    add r3, sp, #264
+; BE-I32-NEXT:    .pad #8
+; BE-I32-NEXT:    sub sp, sp, #8
+; BE-I32-NEXT:    str r3, [sp, #4] @ 4-byte Spill
+; BE-I32-NEXT:    add r3, sp, #224
+; BE-I32-NEXT:    mov r11, r2
+; BE-I32-NEXT:    mov r6, r1
+; BE-I32-NEXT:    mov r7, r0
 ; BE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    add r3, sp, #332
-; BE-I32-NEXT:    ldr r7, [sp, #328]
-; BE-I32-NEXT:    vmov.32 d9[0], r0
-; BE-I32-NEXT:    ldr r10, [sp, #280]
+; BE-I32-NEXT:    add r3, sp, #292
+; BE-I32-NEXT:    ldr r5, [sp, #288]
+; BE-I32-NEXT:    vmov.32 d8[0], r0
 ; BE-I32-NEXT:    ldm r3, {r1, r2, r3}
-; BE-I32-NEXT:    mov r0, r7
-; BE-I32-NEXT:    ldr r8, [sp, #168]
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    ldr r5, [sp, #344]
-; BE-I32-NEXT:    vmov.32 d11[0], r0
-; BE-I32-NEXT:    ldr r1, [sp, #348]
-; BE-I32-NEXT:    ldr r2, [sp, #352]
-; BE-I32-NEXT:    ldr r3, [sp, #356]
 ; BE-I32-NEXT:    mov r0, r5
-; BE-I32-NEXT:    ldr r7, [sp, #284]
-; BE-I32-NEXT:    ldr r4, [sp, #288]
-; BE-I32-NEXT:    ldr r6, [sp, #172]
-; BE-I32-NEXT:    ldr r9, [sp, #176]
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    ldr r3, [sp, #292]
-; BE-I32-NEXT:    vmov.32 d11[1], r0
-; BE-I32-NEXT:    mov r0, r10
-; BE-I32-NEXT:    mov r1, r7
-; BE-I32-NEXT:    mov r2, r4
+; BE-I32-NEXT:    ldr r4, [sp, #304]
+; BE-I32-NEXT:    vmov.32 d10[0], r0
+; BE-I32-NEXT:    ldr r1, [sp, #308]
+; BE-I32-NEXT:    ldr r2, [sp, #312]
+; BE-I32-NEXT:    ldr r3, [sp, #316]
+; BE-I32-NEXT:    mov r0, r4
+; BE-I32-NEXT:    ldr r5, [sp, #244]
+; BE-I32-NEXT:    ldr r9, [sp, #248]
+; BE-I32-NEXT:    ldr r8, [sp, #196]
+; BE-I32-NEXT:    ldr r10, [sp, #200]
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    ldr r3, [sp, #180]
-; BE-I32-NEXT:    vmov.32 d9[1], r0
-; BE-I32-NEXT:    mov r0, r8
-; BE-I32-NEXT:    mov r1, r6
+; BE-I32-NEXT:    vmov.32 d10[1], r0
+; BE-I32-NEXT:    ldr r3, [sp, #252]
+; BE-I32-NEXT:    ldr r0, [sp, #240]
+; BE-I32-NEXT:    mov r1, r5
 ; BE-I32-NEXT:    mov r2, r9
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    add r3, sp, #232
+; BE-I32-NEXT:    vmov.32 d8[1], r0
+; BE-I32-NEXT:    ldr r3, [sp, #204]
+; BE-I32-NEXT:    ldr r0, [sp, #192]
+; BE-I32-NEXT:    mov r1, r8
+; BE-I32-NEXT:    mov r2, r10
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    add r3, sp, #256
 ; BE-I32-NEXT:    mov r4, r0
 ; BE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    add r3, sp, #136
+; BE-I32-NEXT:    ldr r3, [sp, #4] @ 4-byte Reload
+; BE-I32-NEXT:    mov r5, r0
+; BE-I32-NEXT:    mov r0, r7
+; BE-I32-NEXT:    mov r1, r6
+; BE-I32-NEXT:    mov r2, r11
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    ldr r6, [sp, #320]
+; BE-I32-NEXT:    vmov.32 d12[0], r0
+; BE-I32-NEXT:    ldr r1, [sp, #324]
+; BE-I32-NEXT:    ldr r2, [sp, #328]
+; BE-I32-NEXT:    ldr r3, [sp, #332]
+; BE-I32-NEXT:    mov r0, r6
+; BE-I32-NEXT:    ldr r10, [sp, #176]
+; BE-I32-NEXT:    ldr r9, [sp, #180]
+; BE-I32-NEXT:    ldr r8, [sp, #112]
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    ldr r7, [sp, #272]
+; BE-I32-NEXT:    vmov.32 d11[0], r0
+; BE-I32-NEXT:    ldr r1, [sp, #276]
+; BE-I32-NEXT:    ldr r2, [sp, #280]
+; BE-I32-NEXT:    vmov.32 d9[0], r5
+; BE-I32-NEXT:    ldr r3, [sp, #284]
+; BE-I32-NEXT:    mov r0, r7
+; BE-I32-NEXT:    ldr r6, [sp, #184]
+; BE-I32-NEXT:    ldr r11, [sp, #144]
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    ldr r3, [sp, #188]
+; BE-I32-NEXT:    vmov.32 d9[1], r0
+; BE-I32-NEXT:    mov r0, r10
+; BE-I32-NEXT:    mov r1, r9
+; BE-I32-NEXT:    mov r2, r6
+; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    add r3, sp, #160
 ; BE-I32-NEXT:    mov r6, r0
 ; BE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    ldr r5, [sp, #296]
-; BE-I32-NEXT:    vmov.32 d13[0], r0
-; BE-I32-NEXT:    ldr r1, [sp, #300]
-; BE-I32-NEXT:    ldr r2, [sp, #304]
-; BE-I32-NEXT:    ldr r3, [sp, #308]
-; BE-I32-NEXT:    mov r0, r5
-; BE-I32-NEXT:    ldr r10, [sp, #216]
-; BE-I32-NEXT:    ldr r8, [sp, #220]
-; BE-I32-NEXT:    ldr r9, [sp, #152]
+; BE-I32-NEXT:    vmov.32 d14[0], r0
+; BE-I32-NEXT:    ldr r0, [sp, #208]
+; BE-I32-NEXT:    ldr r1, [sp, #212]
+; BE-I32-NEXT:    ldr r2, [sp, #216]
+; BE-I32-NEXT:    vmov.32 d15[0], r4
+; BE-I32-NEXT:    ldr r3, [sp, #220]
+; BE-I32-NEXT:    vmov.32 d14[1], r6
+; BE-I32-NEXT:    ldr r7, [sp, #116]
+; BE-I32-NEXT:    ldr r5, [sp, #120]
+; BE-I32-NEXT:    ldr r4, [sp, #148]
+; BE-I32-NEXT:    ldr r6, [sp, #152]
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    ldr r7, [sp, #248]
-; BE-I32-NEXT:    vmov.32 d10[0], r0
-; BE-I32-NEXT:    ldr r1, [sp, #252]
-; BE-I32-NEXT:    ldr r2, [sp, #256]
-; BE-I32-NEXT:    vmov.32 d8[0], r6
-; BE-I32-NEXT:    ldr r3, [sp, #260]
-; BE-I32-NEXT:    mov r0, r7
-; BE-I32-NEXT:    ldr r5, [sp, #224]
-; BE-I32-NEXT:    ldr r11, [sp, #120]
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    ldr r3, [sp, #228]
-; BE-I32-NEXT:    vmov.32 d8[1], r0
-; BE-I32-NEXT:    mov r0, r10
-; BE-I32-NEXT:    mov r1, r8
+; BE-I32-NEXT:    ldr r3, [sp, #124]
+; BE-I32-NEXT:    vmov.32 d15[1], r0
+; BE-I32-NEXT:    mov r0, r8
+; BE-I32-NEXT:    mov r1, r7
 ; BE-I32-NEXT:    mov r2, r5
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    add r3, sp, #200
-; BE-I32-NEXT:    mov r5, r0
-; BE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    vmov.32 d15[0], r0
-; BE-I32-NEXT:    ldr r0, [sp, #184]
-; BE-I32-NEXT:    ldr r1, [sp, #188]
-; BE-I32-NEXT:    ldr r2, [sp, #192]
-; BE-I32-NEXT:    vmov.32 d14[0], r4
-; BE-I32-NEXT:    ldr r3, [sp, #196]
-; BE-I32-NEXT:    vmov.32 d15[1], r5
-; BE-I32-NEXT:    ldr r7, [sp, #156]
-; BE-I32-NEXT:    ldr r6, [sp, #160]
-; BE-I32-NEXT:    ldr r4, [sp, #124]
-; BE-I32-NEXT:    ldr r5, [sp, #128]
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    ldr r3, [sp, #164]
-; BE-I32-NEXT:    vmov.32 d14[1], r0
-; BE-I32-NEXT:    mov r0, r9
-; BE-I32-NEXT:    mov r1, r7
-; BE-I32-NEXT:    mov r2, r6
-; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    ldr r3, [sp, #132]
-; BE-I32-NEXT:    vmov.32 d13[1], r0
+; BE-I32-NEXT:    ldr r3, [sp, #156]
+; BE-I32-NEXT:    vmov.32 d12[1], r0
 ; BE-I32-NEXT:    mov r0, r11
 ; BE-I32-NEXT:    mov r1, r4
-; BE-I32-NEXT:    mov r2, r5
+; BE-I32-NEXT:    mov r2, r6
 ; BE-I32-NEXT:    bl lrintl
+; BE-I32-NEXT:    add r3, sp, #128
 ; BE-I32-NEXT:    mov r4, r0
-; BE-I32-NEXT:    ldm sp, {r0, r1, r2, r3} @ 16-byte Folded Reload
+; BE-I32-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    add r3, sp, #316
-; BE-I32-NEXT:    ldr r7, [sp, #312]
-; BE-I32-NEXT:    vmov.32 d12[0], r0
+; BE-I32-NEXT:    add r3, sp, #340
+; BE-I32-NEXT:    ldr r7, [sp, #336]
+; BE-I32-NEXT:    vmov.32 d13[0], r0
 ; BE-I32-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I32-NEXT:    mov r0, r7
-; BE-I32-NEXT:    vmov.32 d12[1], r4
+; BE-I32-NEXT:    vmov.32 d13[1], r4
 ; BE-I32-NEXT:    bl lrintl
-; BE-I32-NEXT:    vmov.32 d10[1], r0
+; BE-I32-NEXT:    vmov.32 d11[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q6
 ; BE-I32-NEXT:    vrev64.32 q1, q7
 ; BE-I32-NEXT:    vrev64.32 q2, q4
 ; BE-I32-NEXT:    vrev64.32 q3, q5
-; BE-I32-NEXT:    add sp, sp, #16
+; BE-I32-NEXT:    add sp, sp, #8
 ; BE-I32-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-I32-NEXT:    add sp, sp, #4
 ; BE-I32-NEXT:    pop {r4, r5, r6, r7, r8, r9, r10, r11, pc}
@@ -4335,73 +4326,75 @@ define <16 x iXLen> @lrint_v16fp128(<16 x fp128> %x) {
 ; BE-I64-NEXT:    .pad #56
 ; BE-I64-NEXT:    sub sp, sp, #56
 ; BE-I64-NEXT:    mov r5, r3
-; BE-I64-NEXT:    add r3, sp, #376
+; BE-I64-NEXT:    add r3, sp, #392
 ; BE-I64-NEXT:    mov r6, r2
 ; BE-I64-NEXT:    mov r4, r0
 ; BE-I64-NEXT:    ldm r3, {r0, r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    ldr r7, [sp, #392]
-; BE-I64-NEXT:    add r3, sp, #396
-; BE-I64-NEXT:    mov r9, r1
+; BE-I64-NEXT:    ldr r7, [sp, #376]
+; BE-I64-NEXT:    add r3, sp, #380
+; BE-I64-NEXT:    str r1, [sp] @ 4-byte Spill
 ; BE-I64-NEXT:    vmov.32 d8[0], r0
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    mov r0, r7
-; BE-I64-NEXT:    ldr r11, [sp, #168]
-; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    ldr r2, [sp, #160]
-; BE-I64-NEXT:    mov r10, r1
-; BE-I64-NEXT:    ldr r3, [sp, #164]
-; BE-I64-NEXT:    vmov.32 d9[0], r0
-; BE-I64-NEXT:    mov r0, r6
-; BE-I64-NEXT:    mov r1, r5
+; BE-I64-NEXT:    ldr r8, [sp, #168]
 ; BE-I64-NEXT:    bl lrintl
 ; BE-I64-NEXT:    add r3, sp, #172
+; BE-I64-NEXT:    mov r11, r1
+; BE-I64-NEXT:    vmov.32 d9[0], r0
+; BE-I64-NEXT:    mov r0, r8
+; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; BE-I64-NEXT:    bl lrintl
+; BE-I64-NEXT:    ldr r2, [sp, #160]
 ; BE-I64-NEXT:    mov r8, r1
+; BE-I64-NEXT:    ldr r3, [sp, #164]
 ; BE-I64-NEXT:    vmov.32 d10[0], r0
-; BE-I64-NEXT:    mov r0, r11
+; BE-I64-NEXT:    mov r0, r6
+; BE-I64-NEXT:    mov r1, r5
+; BE-I64-NEXT:    ldr r10, [sp, #264]
+; BE-I64-NEXT:    bl lrintl
+; BE-I64-NEXT:    add r3, sp, #236
+; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    ldr r0, [sp, #232]
+; BE-I64-NEXT:    mov r9, r1
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
 ; BE-I64-NEXT:    add r3, sp, #220
-; BE-I64-NEXT:    vmov.32 d11[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #216]
-; BE-I64-NEXT:    mov r11, r1
-; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #236
 ; BE-I64-NEXT:    vmov.32 d12[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #232]
+; BE-I64-NEXT:    ldr r0, [sp, #216]
 ; BE-I64-NEXT:    mov r6, r1
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #252
-; BE-I64-NEXT:    vmov.32 d13[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #248]
+; BE-I64-NEXT:    add r3, sp, #268
 ; BE-I64-NEXT:    mov r7, r1
+; BE-I64-NEXT:    vmov.32 d13[0], r0
+; BE-I64-NEXT:    mov r0, r10
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #268
+; BE-I64-NEXT:    add r3, sp, #252
 ; BE-I64-NEXT:    vmov.32 d14[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #264]
+; BE-I64-NEXT:    ldr r0, [sp, #248]
 ; BE-I64-NEXT:    mov r5, r1
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
+; BE-I64-NEXT:    ldr r2, [sp] @ 4-byte Reload
 ; BE-I64-NEXT:    vmov.32 d15[0], r0
 ; BE-I64-NEXT:    ldr r0, [sp, #280]
-; BE-I64-NEXT:    ldr r2, [sp, #288]
-; BE-I64-NEXT:    vmov.32 d13[1], r7
-; BE-I64-NEXT:    ldr r7, [sp, #284]
-; BE-I64-NEXT:    ldr r3, [sp, #292]
 ; BE-I64-NEXT:    vmov.32 d14[1], r5
-; BE-I64-NEXT:    ldr r5, [sp, #328]
+; BE-I64-NEXT:    ldr r5, [sp, #284]
+; BE-I64-NEXT:    ldr r3, [sp, #292]
+; BE-I64-NEXT:    vmov.32 d13[1], r7
+; BE-I64-NEXT:    ldr r7, [sp, #328]
 ; BE-I64-NEXT:    vmov.32 d12[1], r6
-; BE-I64-NEXT:    ldr r6, [sp, #300]
+; BE-I64-NEXT:    ldr r6, [sp, #332]
 ; BE-I64-NEXT:    vmov.32 d10[1], r8
-; BE-I64-NEXT:    ldr r8, [sp, #184]
-; BE-I64-NEXT:    vmov.32 d11[1], r11
-; BE-I64-NEXT:    vmov.32 d9[1], r10
-; BE-I64-NEXT:    vmov.32 d8[1], r9
+; BE-I64-NEXT:    ldr r8, [sp, #312]
+; BE-I64-NEXT:    vmov.32 d8[1], r2
+; BE-I64-NEXT:    ldr r2, [sp, #288]
+; BE-I64-NEXT:    vmov.32 d11[1], r9
+; BE-I64-NEXT:    vmov.32 d9[1], r11
 ; BE-I64-NEXT:    vmov.32 d15[1], r1
-; BE-I64-NEXT:    mov r1, r7
+; BE-I64-NEXT:    mov r1, r5
 ; BE-I64-NEXT:    vstr d14, [sp, #48] @ 8-byte Spill
 ; BE-I64-NEXT:    vstr d13, [sp, #40] @ 8-byte Spill
 ; BE-I64-NEXT:    vstr d12, [sp, #32] @ 8-byte Spill
@@ -4410,91 +4403,90 @@ define <16 x iXLen> @lrint_v16fp128(<16 x fp128> %x) {
 ; BE-I64-NEXT:    vstr d9, [sp, #8] @ 8-byte Spill
 ; BE-I64-NEXT:    vstr d8, [sp] @ 8-byte Spill
 ; BE-I64-NEXT:    bl lrintl
+; BE-I64-NEXT:    ldr r2, [sp, #336]
 ; BE-I64-NEXT:    mov r10, r1
-; BE-I64-NEXT:    ldr r1, [sp, #296]
-; BE-I64-NEXT:    ldr r2, [sp, #304]
+; BE-I64-NEXT:    ldr r3, [sp, #340]
 ; BE-I64-NEXT:    vmov.32 d8[0], r0
-; BE-I64-NEXT:    ldr r3, [sp, #308]
-; BE-I64-NEXT:    mov r0, r1
+; BE-I64-NEXT:    mov r0, r7
 ; BE-I64-NEXT:    mov r1, r6
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #332
+; BE-I64-NEXT:    add r3, sp, #316
 ; BE-I64-NEXT:    mov r11, r1
 ; BE-I64-NEXT:    vmov.32 d9[0], r0
-; BE-I64-NEXT:    mov r0, r5
-; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #188
-; BE-I64-NEXT:    mov r7, r1
-; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    mov r0, r8
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
 ; BE-I64-NEXT:    add r3, sp, #204
-; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    vmov.32 d10[0], r0
 ; BE-I64-NEXT:    ldr r0, [sp, #200]
-; BE-I64-NEXT:    mov r8, r1
-; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #348
-; BE-I64-NEXT:    vmov.32 d12[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #344]
-; BE-I64-NEXT:    mov r5, r1
-; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
-; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #364
-; BE-I64-NEXT:    vmov.32 d13[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #360]
 ; BE-I64-NEXT:    mov r9, r1
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    add r3, sp, #316
-; BE-I64-NEXT:    vmov.32 d14[0], r0
-; BE-I64-NEXT:    ldr r0, [sp, #312]
+; BE-I64-NEXT:    add r3, sp, #188
+; BE-I64-NEXT:    vmov.32 d11[0], r0
+; BE-I64-NEXT:    ldr r0, [sp, #184]
+; BE-I64-NEXT:    mov r8, r1
+; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; BE-I64-NEXT:    bl lrintl
+; BE-I64-NEXT:    add r3, sp, #364
+; BE-I64-NEXT:    vmov.32 d12[0], r0
+; BE-I64-NEXT:    ldr r0, [sp, #360]
+; BE-I64-NEXT:    mov r5, r1
+; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; BE-I64-NEXT:    bl lrintl
+; BE-I64-NEXT:    add r3, sp, #348
+; BE-I64-NEXT:    vmov.32 d13[0], r0
+; BE-I64-NEXT:    ldr r0, [sp, #344]
 ; BE-I64-NEXT:    mov r6, r1
 ; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
 ; BE-I64-NEXT:    bl lrintl
-; BE-I64-NEXT:    vldr d18, [sp, #48] @ 8-byte Reload
-; BE-I64-NEXT:    vrev64.32 d17, d15
-; BE-I64-NEXT:    vrev64.32 d16, d18
-; BE-I64-NEXT:    vldr d18, [sp, #40] @ 8-byte Reload
-; BE-I64-NEXT:    vmov.32 d24[0], r0
+; BE-I64-NEXT:    add r3, sp, #300
+; BE-I64-NEXT:    vmov.32 d14[0], r0
+; BE-I64-NEXT:    ldr r0, [sp, #296]
+; BE-I64-NEXT:    mov r7, r1
+; BE-I64-NEXT:    ldm r3, {r1, r2, r3}
+; BE-I64-NEXT:    bl lrintl
+; BE-I64-NEXT:    vldr d17, [sp, #48] @ 8-byte Reload
+; BE-I64-NEXT:    vrev64.32 d18, d15
+; BE-I64-NEXT:    vrev64.32 d19, d17
+; BE-I64-NEXT:    vldr d17, [sp, #40] @ 8-byte Reload
+; BE-I64-NEXT:    vmov.32 d16[0], r0
 ; BE-I64-NEXT:    add r0, r4, #64
-; BE-I64-NEXT:    vldr d20, [sp, #32] @ 8-byte Reload
-; BE-I64-NEXT:    vrev64.32 d19, d18
-; BE-I64-NEXT:    vmov.32 d9[1], r11
-; BE-I64-NEXT:    vmov.32 d10[1], r7
-; BE-I64-NEXT:    vrev64.32 d18, d20
-; BE-I64-NEXT:    vldr d20, [sp, #24] @ 8-byte Reload
+; BE-I64-NEXT:    vrev64.32 d20, d17
+; BE-I64-NEXT:    vldr d17, [sp, #32] @ 8-byte Reload
 ; BE-I64-NEXT:    vmov.32 d8[1], r10
-; BE-I64-NEXT:    vmov.32 d14[1], r6
-; BE-I64-NEXT:    vmov.32 d24[1], r1
-; BE-I64-NEXT:    vldr d22, [sp, #16] @ 8-byte Reload
-; BE-I64-NEXT:    vrev64.32 d21, d20
-; BE-I64-NEXT:    vrev64.32 d1, d9
-; BE-I64-NEXT:    vmov.32 d13[1], r9
-; BE-I64-NEXT:    vrev64.32 d31, d10
-; BE-I64-NEXT:    vrev64.32 d20, d22
-; BE-I64-NEXT:    vldr d22, [sp, #8] @ 8-byte Reload
+; BE-I64-NEXT:    vrev64.32 d21, d17
+; BE-I64-NEXT:    vldr d17, [sp, #24] @ 8-byte Reload
+; BE-I64-NEXT:    vmov.32 d10[1], r9
+; BE-I64-NEXT:    vmov.32 d16[1], r1
+; BE-I64-NEXT:    vmov.32 d14[1], r7
+; BE-I64-NEXT:    vrev64.32 d22, d17
+; BE-I64-NEXT:    vldr d17, [sp, #16] @ 8-byte Reload
+; BE-I64-NEXT:    vmov.32 d9[1], r11
 ; BE-I64-NEXT:    vrev64.32 d0, d8
-; BE-I64-NEXT:    vrev64.32 d29, d14
+; BE-I64-NEXT:    vmov.32 d13[1], r6
+; BE-I64-NEXT:    vrev64.32 d30, d10
+; BE-I64-NEXT:    vrev64.32 d23, d17
+; BE-I64-NEXT:    vldr d17, [sp, #8] @ 8-byte Reload
+; BE-I64-NEXT:    vrev64.32 d1, d16
+; BE-I64-NEXT:    vrev64.32 d26, d14
 ; BE-I64-NEXT:    vmov.32 d12[1], r5
-; BE-I64-NEXT:    vrev64.32 d30, d24
-; BE-I64-NEXT:    vrev64.32 d27, d22
-; BE-I64-NEXT:    vldr d22, [sp] @ 8-byte Reload
+; BE-I64-NEXT:    vrev64.32 d31, d9
+; BE-I64-NEXT:    vrev64.32 d24, d17
+; BE-I64-NEXT:    vldr d17, [sp] @ 8-byte Reload
 ; BE-I64-NEXT:    vst1.64 {d0, d1}, [r0:128]!
 ; BE-I64-NEXT:    vmov.32 d11[1], r8
-; BE-I64-NEXT:    vrev64.32 d28, d13
+; BE-I64-NEXT:    vrev64.32 d27, d13
 ; BE-I64-NEXT:    vst1.64 {d30, d31}, [r0:128]!
-; BE-I64-NEXT:    vrev64.32 d26, d22
-; BE-I64-NEXT:    vrev64.32 d23, d12
-; BE-I64-NEXT:    vst1.64 {d28, d29}, [r0:128]!
-; BE-I64-NEXT:    vrev64.32 d22, d11
-; BE-I64-NEXT:    vst1.64 {d26, d27}, [r0:128]
-; BE-I64-NEXT:    vst1.64 {d20, d21}, [r4:128]!
+; BE-I64-NEXT:    vrev64.32 d28, d12
+; BE-I64-NEXT:    vrev64.32 d25, d17
+; BE-I64-NEXT:    vst1.64 {d26, d27}, [r0:128]!
+; BE-I64-NEXT:    vrev64.32 d29, d11
+; BE-I64-NEXT:    vst1.64 {d24, d25}, [r0:128]
 ; BE-I64-NEXT:    vst1.64 {d22, d23}, [r4:128]!
-; BE-I64-NEXT:    vst1.64 {d18, d19}, [r4:128]!
-; BE-I64-NEXT:    vst1.64 {d16, d17}, [r4:128]
+; BE-I64-NEXT:    vst1.64 {d28, d29}, [r4:128]!
+; BE-I64-NEXT:    vst1.64 {d20, d21}, [r4:128]!
+; BE-I64-NEXT:    vst1.64 {d18, d19}, [r4:128]
 ; BE-I64-NEXT:    add sp, sp, #56
 ; BE-I64-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; BE-I64-NEXT:    add sp, sp, #4

--- a/llvm/test/CodeGen/ARM/vext.ll
+++ b/llvm/test/CodeGen/ARM/vext.ll
@@ -257,15 +257,15 @@ define <8 x i16> @test_illegal(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: test_illegal:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vld1.64 {d16, d17}, [r0]
-; CHECK-NEXT:    vorr d21, d16, d16
-; CHECK-NEXT:    vmov.u16 r0, d16[0]
 ; CHECK-NEXT:    vorr d22, d16, d16
+; CHECK-NEXT:    vmov.u16 r0, d16[0]
+; CHECK-NEXT:    vorr d23, d16, d16
 ; CHECK-NEXT:    vmov.u16 r2, d17[3]
 ; CHECK-NEXT:    vmov.u16 r3, d17[1]
 ; CHECK-NEXT:    vld1.64 {d18, d19}, [r1]
 ; CHECK-NEXT:    vmov.u16 r1, d19[1]
-; CHECK-NEXT:    vuzp.16 d21, d22
-; CHECK-NEXT:    vuzp.16 d21, d18
+; CHECK-NEXT:    vuzp.16 d22, d23
+; CHECK-NEXT:    vuzp.16 d22, d18
 ; CHECK-NEXT:    vext.16 d16, d16, d18, #3
 ; CHECK-NEXT:    vmov.16 d20[0], r0
 ; CHECK-NEXT:    vmov.16 d20[1], r2

--- a/llvm/test/CodeGen/ARM/vldlane.ll
+++ b/llvm/test/CodeGen/ARM/vldlane.ll
@@ -918,8 +918,8 @@ define <8 x i16> @test_qqqq_regsequence_subreg([6 x i64] %b) nounwind {
 ; DEFAULT-NEXT:    add r0, sp, #24
 ; DEFAULT-NEXT:    vld1.32 {d21[0]}, [r0:32]
 ; DEFAULT-NEXT:    add r0, sp, #28
-; DEFAULT-NEXT:    vmov.i32 d20, #0x0
 ; DEFAULT-NEXT:    vld1.32 {d21[1]}, [r0:32]
+; DEFAULT-NEXT:    vmov.i32 d20, #0x0
 ; DEFAULT-NEXT:    vld3.16 {d16[1], d18[1], d20[1]}, [r0]
 ; DEFAULT-NEXT:    vadd.i16 q12, q8, q9
 ; DEFAULT-NEXT:    vadd.i16 q8, q10, q12
@@ -932,8 +932,8 @@ define <8 x i16> @test_qqqq_regsequence_subreg([6 x i64] %b) nounwind {
 ; BASIC-NEXT:    add r0, sp, #24
 ; BASIC-NEXT:    vld1.32 {d23[0]}, [r0:32]
 ; BASIC-NEXT:    add r0, sp, #28
-; BASIC-NEXT:    vmov.i32 d22, #0x0
 ; BASIC-NEXT:    vld1.32 {d23[1]}, [r0:32]
+; BASIC-NEXT:    vmov.i32 d22, #0x0
 ; BASIC-NEXT:    vld3.16 {d18[1], d20[1], d22[1]}, [r0]
 ; BASIC-NEXT:    vadd.i16 q8, q9, q10
 ; BASIC-NEXT:    vadd.i16 q8, q11, q8

--- a/llvm/test/CodeGen/ARM/vrint.ll
+++ b/llvm/test/CodeGen/ARM/vrint.ll
@@ -93,75 +93,75 @@ define <8 x half> @frinta_8h(<8 x half> %A) nounwind {
 ; CHECK-ARMV7-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vmov.f32 s28, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s7
-; CHECK-ARMV7-NEXT:    vmov.f32 s16, s6
-; CHECK-ARMV7-NEXT:    vmov.f32 s18, s5
-; CHECK-ARMV7-NEXT:    vmov.f32 s20, s4
-; CHECK-ARMV7-NEXT:    vmov.f32 s22, s3
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s3
+; CHECK-ARMV7-NEXT:    vmov.f32 s16, s7
+; CHECK-ARMV7-NEXT:    vmov.f32 s18, s6
+; CHECK-ARMV7-NEXT:    vmov.f32 s20, s5
+; CHECK-ARMV7-NEXT:    vmov.f32 s22, s4
 ; CHECK-ARMV7-NEXT:    vmov.f32 s24, s2
 ; CHECK-ARMV7-NEXT:    vmov.f32 s26, s1
 ; CHECK-ARMV7-NEXT:    bl roundf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s16
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s24
 ; CHECK-ARMV7-NEXT:    vmov r4, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s24, s24
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s18, s18
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s16, s16
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s28, s28
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s26, s26
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    bl roundf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
 ; CHECK-ARMV7-NEXT:    pkhbt r4, r0, r4, lsl #16
 ; CHECK-ARMV7-NEXT:    bl roundf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r5, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    bl roundf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-ARMV7-NEXT:    vmov r0, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
+; CHECK-ARMV7-NEXT:    bl roundf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s20, s0
 ; CHECK-ARMV7-NEXT:    vmov.f32 s0, s28
 ; CHECK-ARMV7-NEXT:    bl roundf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
-; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
-; CHECK-ARMV7-NEXT:    bl roundf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s16, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
-; CHECK-ARMV7-NEXT:    bl roundf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s16
+; CHECK-ARMV7-NEXT:    vmov r0, s20
 ; CHECK-ARMV7-NEXT:    vmov r1, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s16
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r0
+; CHECK-ARMV7-NEXT:    vmov.32 d10[0], r0
 ; CHECK-ARMV7-NEXT:    bl roundf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d9[0], r5
+; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r5
 ; CHECK-ARMV7-NEXT:    vmov r6, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s24
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
 ; CHECK-ARMV7-NEXT:    bl roundf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r4
+; CHECK-ARMV7-NEXT:    vmov.32 d10[1], r4
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r12, d10[0]
+; CHECK-ARMV7-NEXT:    vmov.u16 r1, d10[1]
+; CHECK-ARMV7-NEXT:    vmov.u16 r2, d10[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r3, d10[3]
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r0, r6, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
-; CHECK-ARMV7-NEXT:    vmov.32 d9[1], r0
-; CHECK-ARMV7-NEXT:    vmov s5, r5
-; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
-; CHECK-ARMV7-NEXT:    vmov s6, r4
-; CHECK-ARMV7-NEXT:    vmov.u16 r12, d9[0]
-; CHECK-ARMV7-NEXT:    vmov.u16 r1, d9[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r2, d9[2]
-; CHECK-ARMV7-NEXT:    vmov.u16 r3, d9[3]
-; CHECK-ARMV7-NEXT:    vmov s4, r6
-; CHECK-ARMV7-NEXT:    vmov s7, r0
+; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r0
 ; CHECK-ARMV7-NEXT:    vmov s0, r12
 ; CHECK-ARMV7-NEXT:    vmov s1, r1
+; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
 ; CHECK-ARMV7-NEXT:    vmov s2, r2
+; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
 ; CHECK-ARMV7-NEXT:    vmov s3, r3
+; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-ARMV7-NEXT:    vmov s4, r6
+; CHECK-ARMV7-NEXT:    vmov s5, r5
+; CHECK-ARMV7-NEXT:    vmov s6, r4
+; CHECK-ARMV7-NEXT:    vmov s7, r0
 ; CHECK-ARMV7-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -169,62 +169,62 @@ define <8 x half> @frinta_8h(<8 x half> %A) nounwind {
 ; CHECK-NOFP16:       @ %bb.0:
 ; CHECK-NOFP16-NEXT:    .save {r4, r5, r11, lr}
 ; CHECK-NOFP16-NEXT:    push {r4, r5, r11, lr}
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s7
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s3
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s2
 ; CHECK-NOFP16-NEXT:    vrinta.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vrinta.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vrinta.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vmov r0, s8
 ; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r1, s6
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s1
-; CHECK-NOFP16-NEXT:    vrinta.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s5
+; CHECK-NOFP16-NEXT:    vrinta.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vrinta.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s5
+; CHECK-NOFP16-NEXT:    vmov r3, s0
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s7
 ; CHECK-NOFP16-NEXT:    vrinta.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s4, s4
-; CHECK-NOFP16-NEXT:    vrinta.f32 s4, s4
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s4, s4
-; CHECK-NOFP16-NEXT:    vmov r3, s4
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r1, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s4
+; CHECK-NOFP16-NEXT:    vrinta.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s1
+; CHECK-NOFP16-NEXT:    vrinta.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    pkhbt r1, r2, r1, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s3
-; CHECK-NOFP16-NEXT:    vrinta.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov.32 d17[0], r1
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vmov.32 d18[0], r1
 ; CHECK-NOFP16-NEXT:    pkhbt r2, r3, r2, lsl #16
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[0], r2
 ; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s6
 ; CHECK-NOFP16-NEXT:    vrinta.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[1], r0
 ; CHECK-NOFP16-NEXT:    vmov r1, s0
-; CHECK-NOFP16-NEXT:    vmov.u16 r4, d16[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r5, d16[3]
+; CHECK-NOFP16-NEXT:    vmov.u16 r12, d16[0]
+; CHECK-NOFP16-NEXT:    vmov.u16 lr, d16[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r3, d16[3]
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r2, lsl #16
-; CHECK-NOFP16-NEXT:    vmov.u16 r1, d16[1]
-; CHECK-NOFP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-NOFP16-NEXT:    vmov s6, r4
-; CHECK-NOFP16-NEXT:    vmov.u16 r0, d16[0]
-; CHECK-NOFP16-NEXT:    vmov s7, r5
-; CHECK-NOFP16-NEXT:    vmov.u16 r12, d17[0]
-; CHECK-NOFP16-NEXT:    vmov.u16 lr, d17[1]
-; CHECK-NOFP16-NEXT:    vmov.u16 r2, d17[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r3, d17[3]
-; CHECK-NOFP16-NEXT:    vmov s5, r1
-; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov.u16 r2, d16[2]
+; CHECK-NOFP16-NEXT:    vmov.32 d18[1], r0
 ; CHECK-NOFP16-NEXT:    vmov s0, r12
 ; CHECK-NOFP16-NEXT:    vmov s1, lr
-; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov.u16 r0, d18[0]
 ; CHECK-NOFP16-NEXT:    vmov s3, r3
+; CHECK-NOFP16-NEXT:    vmov.u16 r1, d18[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r4, d18[2]
+; CHECK-NOFP16-NEXT:    vmov.u16 r5, d18[3]
+; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov s5, r1
+; CHECK-NOFP16-NEXT:    vmov s6, r4
+; CHECK-NOFP16-NEXT:    vmov s7, r5
 ; CHECK-NOFP16-NEXT:    pop {r4, r5, r11, pc}
 ;
 ; CHECK-FP16-LABEL: frinta_8h:
@@ -426,75 +426,75 @@ define <8 x half> @frinti_8h(<8 x half> %A) nounwind {
 ; CHECK-ARMV7-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vmov.f32 s28, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s7
-; CHECK-ARMV7-NEXT:    vmov.f32 s16, s6
-; CHECK-ARMV7-NEXT:    vmov.f32 s18, s5
-; CHECK-ARMV7-NEXT:    vmov.f32 s20, s4
-; CHECK-ARMV7-NEXT:    vmov.f32 s22, s3
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s3
+; CHECK-ARMV7-NEXT:    vmov.f32 s16, s7
+; CHECK-ARMV7-NEXT:    vmov.f32 s18, s6
+; CHECK-ARMV7-NEXT:    vmov.f32 s20, s5
+; CHECK-ARMV7-NEXT:    vmov.f32 s22, s4
 ; CHECK-ARMV7-NEXT:    vmov.f32 s24, s2
 ; CHECK-ARMV7-NEXT:    vmov.f32 s26, s1
 ; CHECK-ARMV7-NEXT:    bl nearbyintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s16
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s24
 ; CHECK-ARMV7-NEXT:    vmov r4, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s24, s24
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s18, s18
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s16, s16
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s28, s28
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s26, s26
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    bl nearbyintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
 ; CHECK-ARMV7-NEXT:    pkhbt r4, r0, r4, lsl #16
 ; CHECK-ARMV7-NEXT:    bl nearbyintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r5, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    bl nearbyintf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-ARMV7-NEXT:    vmov r0, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
+; CHECK-ARMV7-NEXT:    bl nearbyintf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s20, s0
 ; CHECK-ARMV7-NEXT:    vmov.f32 s0, s28
 ; CHECK-ARMV7-NEXT:    bl nearbyintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
-; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
-; CHECK-ARMV7-NEXT:    bl nearbyintf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s16, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
-; CHECK-ARMV7-NEXT:    bl nearbyintf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s16
+; CHECK-ARMV7-NEXT:    vmov r0, s20
 ; CHECK-ARMV7-NEXT:    vmov r1, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s16
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r0
+; CHECK-ARMV7-NEXT:    vmov.32 d10[0], r0
 ; CHECK-ARMV7-NEXT:    bl nearbyintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d9[0], r5
+; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r5
 ; CHECK-ARMV7-NEXT:    vmov r6, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s24
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
 ; CHECK-ARMV7-NEXT:    bl nearbyintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r4
+; CHECK-ARMV7-NEXT:    vmov.32 d10[1], r4
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r12, d10[0]
+; CHECK-ARMV7-NEXT:    vmov.u16 r1, d10[1]
+; CHECK-ARMV7-NEXT:    vmov.u16 r2, d10[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r3, d10[3]
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r0, r6, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
-; CHECK-ARMV7-NEXT:    vmov.32 d9[1], r0
-; CHECK-ARMV7-NEXT:    vmov s5, r5
-; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
-; CHECK-ARMV7-NEXT:    vmov s6, r4
-; CHECK-ARMV7-NEXT:    vmov.u16 r12, d9[0]
-; CHECK-ARMV7-NEXT:    vmov.u16 r1, d9[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r2, d9[2]
-; CHECK-ARMV7-NEXT:    vmov.u16 r3, d9[3]
-; CHECK-ARMV7-NEXT:    vmov s4, r6
-; CHECK-ARMV7-NEXT:    vmov s7, r0
+; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r0
 ; CHECK-ARMV7-NEXT:    vmov s0, r12
 ; CHECK-ARMV7-NEXT:    vmov s1, r1
+; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
 ; CHECK-ARMV7-NEXT:    vmov s2, r2
+; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
 ; CHECK-ARMV7-NEXT:    vmov s3, r3
+; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-ARMV7-NEXT:    vmov s4, r6
+; CHECK-ARMV7-NEXT:    vmov s5, r5
+; CHECK-ARMV7-NEXT:    vmov s6, r4
+; CHECK-ARMV7-NEXT:    vmov s7, r0
 ; CHECK-ARMV7-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -502,68 +502,84 @@ define <8 x half> @frinti_8h(<8 x half> %A) nounwind {
 ; CHECK-NOFP16:       @ %bb.0:
 ; CHECK-NOFP16-NEXT:    .save {r4, r5, r11, lr}
 ; CHECK-NOFP16-NEXT:    push {r4, r5, r11, lr}
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s7
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s3
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintr.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vrintr.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vrintr.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vmov r0, s8
 ; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r1, s6
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s1
-; CHECK-NOFP16-NEXT:    vrintr.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s5
+; CHECK-NOFP16-NEXT:    vrintr.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintr.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s5
+; CHECK-NOFP16-NEXT:    vmov r3, s0
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s7
 ; CHECK-NOFP16-NEXT:    vrintr.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s4, s4
-; CHECK-NOFP16-NEXT:    vrintr.f32 s4, s4
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s4, s4
-; CHECK-NOFP16-NEXT:    vmov r3, s4
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r1, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s4
+; CHECK-NOFP16-NEXT:    vrintr.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s1
+; CHECK-NOFP16-NEXT:    vrintr.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    pkhbt r1, r2, r1, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s3
-; CHECK-NOFP16-NEXT:    vrintr.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov.32 d17[0], r1
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vmov.32 d18[0], r1
 ; CHECK-NOFP16-NEXT:    pkhbt r2, r3, r2, lsl #16
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[0], r2
 ; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s6
 ; CHECK-NOFP16-NEXT:    vrintr.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[1], r0
 ; CHECK-NOFP16-NEXT:    vmov r1, s0
-; CHECK-NOFP16-NEXT:    vmov.u16 r4, d16[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r5, d16[3]
+; CHECK-NOFP16-NEXT:    vmov.u16 r12, d16[0]
+; CHECK-NOFP16-NEXT:    vmov.u16 lr, d16[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r3, d16[3]
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r2, lsl #16
-; CHECK-NOFP16-NEXT:    vmov.u16 r1, d16[1]
-; CHECK-NOFP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-NOFP16-NEXT:    vmov s6, r4
-; CHECK-NOFP16-NEXT:    vmov.u16 r0, d16[0]
-; CHECK-NOFP16-NEXT:    vmov s7, r5
-; CHECK-NOFP16-NEXT:    vmov.u16 r12, d17[0]
-; CHECK-NOFP16-NEXT:    vmov.u16 lr, d17[1]
-; CHECK-NOFP16-NEXT:    vmov.u16 r2, d17[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r3, d17[3]
-; CHECK-NOFP16-NEXT:    vmov s5, r1
-; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov.u16 r2, d16[2]
+; CHECK-NOFP16-NEXT:    vmov.32 d18[1], r0
 ; CHECK-NOFP16-NEXT:    vmov s0, r12
 ; CHECK-NOFP16-NEXT:    vmov s1, lr
-; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov.u16 r0, d18[0]
 ; CHECK-NOFP16-NEXT:    vmov s3, r3
+; CHECK-NOFP16-NEXT:    vmov.u16 r1, d18[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r4, d18[2]
+; CHECK-NOFP16-NEXT:    vmov.u16 r5, d18[3]
+; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov s5, r1
+; CHECK-NOFP16-NEXT:    vmov s6, r4
+; CHECK-NOFP16-NEXT:    vmov s7, r5
 ; CHECK-NOFP16-NEXT:    pop {r4, r5, r11, pc}
 ;
 ; CHECK-FP16-LABEL: frinti_8h:
 ; CHECK-FP16:       @ %bb.0:
+; CHECK-FP16-NEXT:    vmovx.f16 s4, s0
+; CHECK-FP16-NEXT:    vrintr.f16 s4, s4
+; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vrintr.f16 s4, s0
+; CHECK-FP16-NEXT:    vmov r1, s4
+; CHECK-FP16-NEXT:    vrintr.f16 s4, s1
+; CHECK-FP16-NEXT:    vmovx.f16 s0, s3
+; CHECK-FP16-NEXT:    vrintr.f16 s0, s0
+; CHECK-FP16-NEXT:    vmov.16 d16[0], r1
+; CHECK-FP16-NEXT:    vmov.16 d16[1], r0
+; CHECK-FP16-NEXT:    vmov r0, s4
+; CHECK-FP16-NEXT:    vmovx.f16 s4, s1
+; CHECK-FP16-NEXT:    vrintr.f16 s4, s4
+; CHECK-FP16-NEXT:    vmov.16 d16[2], r0
+; CHECK-FP16-NEXT:    vmov r0, s4
 ; CHECK-FP16-NEXT:    vmovx.f16 s4, s2
 ; CHECK-FP16-NEXT:    vrintr.f16 s4, s4
+; CHECK-FP16-NEXT:    vmov.16 d16[3], r0
 ; CHECK-FP16-NEXT:    vmov r0, s4
 ; CHECK-FP16-NEXT:    vrintr.f16 s4, s2
 ; CHECK-FP16-NEXT:    vmov r1, s4
@@ -571,25 +587,9 @@ define <8 x half> @frinti_8h(<8 x half> %A) nounwind {
 ; CHECK-FP16-NEXT:    vmov.16 d17[0], r1
 ; CHECK-FP16-NEXT:    vmov.16 d17[1], r0
 ; CHECK-FP16-NEXT:    vmov r0, s4
-; CHECK-FP16-NEXT:    vmovx.f16 s4, s3
-; CHECK-FP16-NEXT:    vrintr.f16 s4, s4
 ; CHECK-FP16-NEXT:    vmov.16 d17[2], r0
-; CHECK-FP16-NEXT:    vmov r0, s4
-; CHECK-FP16-NEXT:    vmovx.f16 s4, s0
-; CHECK-FP16-NEXT:    vrintr.f16 s4, s4
-; CHECK-FP16-NEXT:    vmov.16 d17[3], r0
-; CHECK-FP16-NEXT:    vmov r0, s4
-; CHECK-FP16-NEXT:    vrintr.f16 s4, s0
-; CHECK-FP16-NEXT:    vmovx.f16 s0, s1
-; CHECK-FP16-NEXT:    vmov r1, s4
-; CHECK-FP16-NEXT:    vrintr.f16 s4, s1
-; CHECK-FP16-NEXT:    vrintr.f16 s0, s0
-; CHECK-FP16-NEXT:    vmov.16 d16[0], r1
-; CHECK-FP16-NEXT:    vmov.16 d16[1], r0
-; CHECK-FP16-NEXT:    vmov r0, s4
-; CHECK-FP16-NEXT:    vmov.16 d16[2], r0
 ; CHECK-FP16-NEXT:    vmov r0, s0
-; CHECK-FP16-NEXT:    vmov.16 d16[3], r0
+; CHECK-FP16-NEXT:    vmov.16 d17[3], r0
 ; CHECK-FP16-NEXT:    vorr q0, q8, q8
 ; CHECK-FP16-NEXT:    bx lr
   %tmp3 = call <8 x half> @llvm.nearbyint.v8f16(<8 x half> %A)
@@ -779,75 +779,75 @@ define <8 x half> @frintm_8h(<8 x half> %A) nounwind {
 ; CHECK-ARMV7-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vmov.f32 s28, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s7
-; CHECK-ARMV7-NEXT:    vmov.f32 s16, s6
-; CHECK-ARMV7-NEXT:    vmov.f32 s18, s5
-; CHECK-ARMV7-NEXT:    vmov.f32 s20, s4
-; CHECK-ARMV7-NEXT:    vmov.f32 s22, s3
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s3
+; CHECK-ARMV7-NEXT:    vmov.f32 s16, s7
+; CHECK-ARMV7-NEXT:    vmov.f32 s18, s6
+; CHECK-ARMV7-NEXT:    vmov.f32 s20, s5
+; CHECK-ARMV7-NEXT:    vmov.f32 s22, s4
 ; CHECK-ARMV7-NEXT:    vmov.f32 s24, s2
 ; CHECK-ARMV7-NEXT:    vmov.f32 s26, s1
 ; CHECK-ARMV7-NEXT:    bl floorf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s16
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s24
 ; CHECK-ARMV7-NEXT:    vmov r4, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s24, s24
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s18, s18
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s16, s16
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s28, s28
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s26, s26
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    bl floorf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
 ; CHECK-ARMV7-NEXT:    pkhbt r4, r0, r4, lsl #16
 ; CHECK-ARMV7-NEXT:    bl floorf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r5, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    bl floorf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-ARMV7-NEXT:    vmov r0, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
+; CHECK-ARMV7-NEXT:    bl floorf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s20, s0
 ; CHECK-ARMV7-NEXT:    vmov.f32 s0, s28
 ; CHECK-ARMV7-NEXT:    bl floorf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
-; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
-; CHECK-ARMV7-NEXT:    bl floorf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s16, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
-; CHECK-ARMV7-NEXT:    bl floorf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s16
+; CHECK-ARMV7-NEXT:    vmov r0, s20
 ; CHECK-ARMV7-NEXT:    vmov r1, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s16
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r0
+; CHECK-ARMV7-NEXT:    vmov.32 d10[0], r0
 ; CHECK-ARMV7-NEXT:    bl floorf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d9[0], r5
+; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r5
 ; CHECK-ARMV7-NEXT:    vmov r6, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s24
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
 ; CHECK-ARMV7-NEXT:    bl floorf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r4
+; CHECK-ARMV7-NEXT:    vmov.32 d10[1], r4
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r12, d10[0]
+; CHECK-ARMV7-NEXT:    vmov.u16 r1, d10[1]
+; CHECK-ARMV7-NEXT:    vmov.u16 r2, d10[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r3, d10[3]
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r0, r6, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
-; CHECK-ARMV7-NEXT:    vmov.32 d9[1], r0
-; CHECK-ARMV7-NEXT:    vmov s5, r5
-; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
-; CHECK-ARMV7-NEXT:    vmov s6, r4
-; CHECK-ARMV7-NEXT:    vmov.u16 r12, d9[0]
-; CHECK-ARMV7-NEXT:    vmov.u16 r1, d9[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r2, d9[2]
-; CHECK-ARMV7-NEXT:    vmov.u16 r3, d9[3]
-; CHECK-ARMV7-NEXT:    vmov s4, r6
-; CHECK-ARMV7-NEXT:    vmov s7, r0
+; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r0
 ; CHECK-ARMV7-NEXT:    vmov s0, r12
 ; CHECK-ARMV7-NEXT:    vmov s1, r1
+; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
 ; CHECK-ARMV7-NEXT:    vmov s2, r2
+; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
 ; CHECK-ARMV7-NEXT:    vmov s3, r3
+; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-ARMV7-NEXT:    vmov s4, r6
+; CHECK-ARMV7-NEXT:    vmov s5, r5
+; CHECK-ARMV7-NEXT:    vmov s6, r4
+; CHECK-ARMV7-NEXT:    vmov s7, r0
 ; CHECK-ARMV7-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -855,62 +855,62 @@ define <8 x half> @frintm_8h(<8 x half> %A) nounwind {
 ; CHECK-NOFP16:       @ %bb.0:
 ; CHECK-NOFP16-NEXT:    .save {r4, r5, r11, lr}
 ; CHECK-NOFP16-NEXT:    push {r4, r5, r11, lr}
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s7
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s3
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintm.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vrintm.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vrintm.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vmov r0, s8
 ; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r1, s6
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s1
-; CHECK-NOFP16-NEXT:    vrintm.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s5
+; CHECK-NOFP16-NEXT:    vrintm.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintm.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s5
+; CHECK-NOFP16-NEXT:    vmov r3, s0
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s7
 ; CHECK-NOFP16-NEXT:    vrintm.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s4, s4
-; CHECK-NOFP16-NEXT:    vrintm.f32 s4, s4
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s4, s4
-; CHECK-NOFP16-NEXT:    vmov r3, s4
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r1, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s4
+; CHECK-NOFP16-NEXT:    vrintm.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s1
+; CHECK-NOFP16-NEXT:    vrintm.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    pkhbt r1, r2, r1, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s3
-; CHECK-NOFP16-NEXT:    vrintm.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov.32 d17[0], r1
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vmov.32 d18[0], r1
 ; CHECK-NOFP16-NEXT:    pkhbt r2, r3, r2, lsl #16
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[0], r2
 ; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s6
 ; CHECK-NOFP16-NEXT:    vrintm.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[1], r0
 ; CHECK-NOFP16-NEXT:    vmov r1, s0
-; CHECK-NOFP16-NEXT:    vmov.u16 r4, d16[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r5, d16[3]
+; CHECK-NOFP16-NEXT:    vmov.u16 r12, d16[0]
+; CHECK-NOFP16-NEXT:    vmov.u16 lr, d16[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r3, d16[3]
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r2, lsl #16
-; CHECK-NOFP16-NEXT:    vmov.u16 r1, d16[1]
-; CHECK-NOFP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-NOFP16-NEXT:    vmov s6, r4
-; CHECK-NOFP16-NEXT:    vmov.u16 r0, d16[0]
-; CHECK-NOFP16-NEXT:    vmov s7, r5
-; CHECK-NOFP16-NEXT:    vmov.u16 r12, d17[0]
-; CHECK-NOFP16-NEXT:    vmov.u16 lr, d17[1]
-; CHECK-NOFP16-NEXT:    vmov.u16 r2, d17[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r3, d17[3]
-; CHECK-NOFP16-NEXT:    vmov s5, r1
-; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov.u16 r2, d16[2]
+; CHECK-NOFP16-NEXT:    vmov.32 d18[1], r0
 ; CHECK-NOFP16-NEXT:    vmov s0, r12
 ; CHECK-NOFP16-NEXT:    vmov s1, lr
-; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov.u16 r0, d18[0]
 ; CHECK-NOFP16-NEXT:    vmov s3, r3
+; CHECK-NOFP16-NEXT:    vmov.u16 r1, d18[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r4, d18[2]
+; CHECK-NOFP16-NEXT:    vmov.u16 r5, d18[3]
+; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov s5, r1
+; CHECK-NOFP16-NEXT:    vmov s6, r4
+; CHECK-NOFP16-NEXT:    vmov s7, r5
 ; CHECK-NOFP16-NEXT:    pop {r4, r5, r11, pc}
 ;
 ; CHECK-FP16-LABEL: frintm_8h:
@@ -1098,75 +1098,75 @@ define <8 x half> @frintn_8h(<8 x half> %A) nounwind {
 ; CHECK-ARMV7-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vmov.f32 s28, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s7
-; CHECK-ARMV7-NEXT:    vmov.f32 s16, s6
-; CHECK-ARMV7-NEXT:    vmov.f32 s18, s5
-; CHECK-ARMV7-NEXT:    vmov.f32 s20, s4
-; CHECK-ARMV7-NEXT:    vmov.f32 s22, s3
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s3
+; CHECK-ARMV7-NEXT:    vmov.f32 s16, s7
+; CHECK-ARMV7-NEXT:    vmov.f32 s18, s6
+; CHECK-ARMV7-NEXT:    vmov.f32 s20, s5
+; CHECK-ARMV7-NEXT:    vmov.f32 s22, s4
 ; CHECK-ARMV7-NEXT:    vmov.f32 s24, s2
 ; CHECK-ARMV7-NEXT:    vmov.f32 s26, s1
 ; CHECK-ARMV7-NEXT:    bl roundevenf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s16
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s24
 ; CHECK-ARMV7-NEXT:    vmov r4, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s24, s24
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s18, s18
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s16, s16
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s28, s28
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s26, s26
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    bl roundevenf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
 ; CHECK-ARMV7-NEXT:    pkhbt r4, r0, r4, lsl #16
 ; CHECK-ARMV7-NEXT:    bl roundevenf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r5, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    bl roundevenf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-ARMV7-NEXT:    vmov r0, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
+; CHECK-ARMV7-NEXT:    bl roundevenf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s20, s0
 ; CHECK-ARMV7-NEXT:    vmov.f32 s0, s28
 ; CHECK-ARMV7-NEXT:    bl roundevenf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
-; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
-; CHECK-ARMV7-NEXT:    bl roundevenf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s16, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
-; CHECK-ARMV7-NEXT:    bl roundevenf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s16
+; CHECK-ARMV7-NEXT:    vmov r0, s20
 ; CHECK-ARMV7-NEXT:    vmov r1, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s16
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r0
+; CHECK-ARMV7-NEXT:    vmov.32 d10[0], r0
 ; CHECK-ARMV7-NEXT:    bl roundevenf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d9[0], r5
+; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r5
 ; CHECK-ARMV7-NEXT:    vmov r6, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s24
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
 ; CHECK-ARMV7-NEXT:    bl roundevenf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r4
+; CHECK-ARMV7-NEXT:    vmov.32 d10[1], r4
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r12, d10[0]
+; CHECK-ARMV7-NEXT:    vmov.u16 r1, d10[1]
+; CHECK-ARMV7-NEXT:    vmov.u16 r2, d10[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r3, d10[3]
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r0, r6, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
-; CHECK-ARMV7-NEXT:    vmov.32 d9[1], r0
-; CHECK-ARMV7-NEXT:    vmov s5, r5
-; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
-; CHECK-ARMV7-NEXT:    vmov s6, r4
-; CHECK-ARMV7-NEXT:    vmov.u16 r12, d9[0]
-; CHECK-ARMV7-NEXT:    vmov.u16 r1, d9[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r2, d9[2]
-; CHECK-ARMV7-NEXT:    vmov.u16 r3, d9[3]
-; CHECK-ARMV7-NEXT:    vmov s4, r6
-; CHECK-ARMV7-NEXT:    vmov s7, r0
+; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r0
 ; CHECK-ARMV7-NEXT:    vmov s0, r12
 ; CHECK-ARMV7-NEXT:    vmov s1, r1
+; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
 ; CHECK-ARMV7-NEXT:    vmov s2, r2
+; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
 ; CHECK-ARMV7-NEXT:    vmov s3, r3
+; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-ARMV7-NEXT:    vmov s4, r6
+; CHECK-ARMV7-NEXT:    vmov s5, r5
+; CHECK-ARMV7-NEXT:    vmov s6, r4
+; CHECK-ARMV7-NEXT:    vmov s7, r0
 ; CHECK-ARMV7-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -1174,62 +1174,62 @@ define <8 x half> @frintn_8h(<8 x half> %A) nounwind {
 ; CHECK-NOFP16:       @ %bb.0:
 ; CHECK-NOFP16-NEXT:    .save {r4, r5, r11, lr}
 ; CHECK-NOFP16-NEXT:    push {r4, r5, r11, lr}
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s7
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s3
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintn.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vrintn.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vrintn.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vmov r0, s8
 ; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r1, s6
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s1
-; CHECK-NOFP16-NEXT:    vrintn.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s5
+; CHECK-NOFP16-NEXT:    vrintn.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintn.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s5
+; CHECK-NOFP16-NEXT:    vmov r3, s0
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s7
 ; CHECK-NOFP16-NEXT:    vrintn.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s4, s4
-; CHECK-NOFP16-NEXT:    vrintn.f32 s4, s4
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s4, s4
-; CHECK-NOFP16-NEXT:    vmov r3, s4
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r1, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s4
+; CHECK-NOFP16-NEXT:    vrintn.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s1
+; CHECK-NOFP16-NEXT:    vrintn.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    pkhbt r1, r2, r1, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s3
-; CHECK-NOFP16-NEXT:    vrintn.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov.32 d17[0], r1
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vmov.32 d18[0], r1
 ; CHECK-NOFP16-NEXT:    pkhbt r2, r3, r2, lsl #16
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[0], r2
 ; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s6
 ; CHECK-NOFP16-NEXT:    vrintn.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[1], r0
 ; CHECK-NOFP16-NEXT:    vmov r1, s0
-; CHECK-NOFP16-NEXT:    vmov.u16 r4, d16[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r5, d16[3]
+; CHECK-NOFP16-NEXT:    vmov.u16 r12, d16[0]
+; CHECK-NOFP16-NEXT:    vmov.u16 lr, d16[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r3, d16[3]
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r2, lsl #16
-; CHECK-NOFP16-NEXT:    vmov.u16 r1, d16[1]
-; CHECK-NOFP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-NOFP16-NEXT:    vmov s6, r4
-; CHECK-NOFP16-NEXT:    vmov.u16 r0, d16[0]
-; CHECK-NOFP16-NEXT:    vmov s7, r5
-; CHECK-NOFP16-NEXT:    vmov.u16 r12, d17[0]
-; CHECK-NOFP16-NEXT:    vmov.u16 lr, d17[1]
-; CHECK-NOFP16-NEXT:    vmov.u16 r2, d17[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r3, d17[3]
-; CHECK-NOFP16-NEXT:    vmov s5, r1
-; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov.u16 r2, d16[2]
+; CHECK-NOFP16-NEXT:    vmov.32 d18[1], r0
 ; CHECK-NOFP16-NEXT:    vmov s0, r12
 ; CHECK-NOFP16-NEXT:    vmov s1, lr
-; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov.u16 r0, d18[0]
 ; CHECK-NOFP16-NEXT:    vmov s3, r3
+; CHECK-NOFP16-NEXT:    vmov.u16 r1, d18[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r4, d18[2]
+; CHECK-NOFP16-NEXT:    vmov.u16 r5, d18[3]
+; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov s5, r1
+; CHECK-NOFP16-NEXT:    vmov s6, r4
+; CHECK-NOFP16-NEXT:    vmov s7, r5
 ; CHECK-NOFP16-NEXT:    pop {r4, r5, r11, pc}
 ;
 ; CHECK-FP16-LABEL: frintn_8h:
@@ -1417,75 +1417,75 @@ define <8 x half> @frintp_8h(<8 x half> %A) nounwind {
 ; CHECK-ARMV7-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vmov.f32 s28, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s7
-; CHECK-ARMV7-NEXT:    vmov.f32 s16, s6
-; CHECK-ARMV7-NEXT:    vmov.f32 s18, s5
-; CHECK-ARMV7-NEXT:    vmov.f32 s20, s4
-; CHECK-ARMV7-NEXT:    vmov.f32 s22, s3
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s3
+; CHECK-ARMV7-NEXT:    vmov.f32 s16, s7
+; CHECK-ARMV7-NEXT:    vmov.f32 s18, s6
+; CHECK-ARMV7-NEXT:    vmov.f32 s20, s5
+; CHECK-ARMV7-NEXT:    vmov.f32 s22, s4
 ; CHECK-ARMV7-NEXT:    vmov.f32 s24, s2
 ; CHECK-ARMV7-NEXT:    vmov.f32 s26, s1
 ; CHECK-ARMV7-NEXT:    bl ceilf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s16
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s24
 ; CHECK-ARMV7-NEXT:    vmov r4, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s24, s24
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s18, s18
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s16, s16
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s28, s28
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s26, s26
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    bl ceilf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
 ; CHECK-ARMV7-NEXT:    pkhbt r4, r0, r4, lsl #16
 ; CHECK-ARMV7-NEXT:    bl ceilf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r5, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    bl ceilf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-ARMV7-NEXT:    vmov r0, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
+; CHECK-ARMV7-NEXT:    bl ceilf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s20, s0
 ; CHECK-ARMV7-NEXT:    vmov.f32 s0, s28
 ; CHECK-ARMV7-NEXT:    bl ceilf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
-; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
-; CHECK-ARMV7-NEXT:    bl ceilf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s16, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
-; CHECK-ARMV7-NEXT:    bl ceilf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s16
+; CHECK-ARMV7-NEXT:    vmov r0, s20
 ; CHECK-ARMV7-NEXT:    vmov r1, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s16
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r0
+; CHECK-ARMV7-NEXT:    vmov.32 d10[0], r0
 ; CHECK-ARMV7-NEXT:    bl ceilf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d9[0], r5
+; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r5
 ; CHECK-ARMV7-NEXT:    vmov r6, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s24
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
 ; CHECK-ARMV7-NEXT:    bl ceilf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r4
+; CHECK-ARMV7-NEXT:    vmov.32 d10[1], r4
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r12, d10[0]
+; CHECK-ARMV7-NEXT:    vmov.u16 r1, d10[1]
+; CHECK-ARMV7-NEXT:    vmov.u16 r2, d10[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r3, d10[3]
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r0, r6, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
-; CHECK-ARMV7-NEXT:    vmov.32 d9[1], r0
-; CHECK-ARMV7-NEXT:    vmov s5, r5
-; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
-; CHECK-ARMV7-NEXT:    vmov s6, r4
-; CHECK-ARMV7-NEXT:    vmov.u16 r12, d9[0]
-; CHECK-ARMV7-NEXT:    vmov.u16 r1, d9[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r2, d9[2]
-; CHECK-ARMV7-NEXT:    vmov.u16 r3, d9[3]
-; CHECK-ARMV7-NEXT:    vmov s4, r6
-; CHECK-ARMV7-NEXT:    vmov s7, r0
+; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r0
 ; CHECK-ARMV7-NEXT:    vmov s0, r12
 ; CHECK-ARMV7-NEXT:    vmov s1, r1
+; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
 ; CHECK-ARMV7-NEXT:    vmov s2, r2
+; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
 ; CHECK-ARMV7-NEXT:    vmov s3, r3
+; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-ARMV7-NEXT:    vmov s4, r6
+; CHECK-ARMV7-NEXT:    vmov s5, r5
+; CHECK-ARMV7-NEXT:    vmov s6, r4
+; CHECK-ARMV7-NEXT:    vmov s7, r0
 ; CHECK-ARMV7-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -1493,62 +1493,62 @@ define <8 x half> @frintp_8h(<8 x half> %A) nounwind {
 ; CHECK-NOFP16:       @ %bb.0:
 ; CHECK-NOFP16-NEXT:    .save {r4, r5, r11, lr}
 ; CHECK-NOFP16-NEXT:    push {r4, r5, r11, lr}
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s7
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s3
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintp.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vrintp.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vrintp.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vmov r0, s8
 ; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r1, s6
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s1
-; CHECK-NOFP16-NEXT:    vrintp.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s5
+; CHECK-NOFP16-NEXT:    vrintp.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintp.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s5
+; CHECK-NOFP16-NEXT:    vmov r3, s0
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s7
 ; CHECK-NOFP16-NEXT:    vrintp.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s4, s4
-; CHECK-NOFP16-NEXT:    vrintp.f32 s4, s4
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s4, s4
-; CHECK-NOFP16-NEXT:    vmov r3, s4
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r1, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s4
+; CHECK-NOFP16-NEXT:    vrintp.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s1
+; CHECK-NOFP16-NEXT:    vrintp.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    pkhbt r1, r2, r1, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s3
-; CHECK-NOFP16-NEXT:    vrintp.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov.32 d17[0], r1
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vmov.32 d18[0], r1
 ; CHECK-NOFP16-NEXT:    pkhbt r2, r3, r2, lsl #16
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[0], r2
 ; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s6
 ; CHECK-NOFP16-NEXT:    vrintp.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[1], r0
 ; CHECK-NOFP16-NEXT:    vmov r1, s0
-; CHECK-NOFP16-NEXT:    vmov.u16 r4, d16[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r5, d16[3]
+; CHECK-NOFP16-NEXT:    vmov.u16 r12, d16[0]
+; CHECK-NOFP16-NEXT:    vmov.u16 lr, d16[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r3, d16[3]
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r2, lsl #16
-; CHECK-NOFP16-NEXT:    vmov.u16 r1, d16[1]
-; CHECK-NOFP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-NOFP16-NEXT:    vmov s6, r4
-; CHECK-NOFP16-NEXT:    vmov.u16 r0, d16[0]
-; CHECK-NOFP16-NEXT:    vmov s7, r5
-; CHECK-NOFP16-NEXT:    vmov.u16 r12, d17[0]
-; CHECK-NOFP16-NEXT:    vmov.u16 lr, d17[1]
-; CHECK-NOFP16-NEXT:    vmov.u16 r2, d17[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r3, d17[3]
-; CHECK-NOFP16-NEXT:    vmov s5, r1
-; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov.u16 r2, d16[2]
+; CHECK-NOFP16-NEXT:    vmov.32 d18[1], r0
 ; CHECK-NOFP16-NEXT:    vmov s0, r12
 ; CHECK-NOFP16-NEXT:    vmov s1, lr
-; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov.u16 r0, d18[0]
 ; CHECK-NOFP16-NEXT:    vmov s3, r3
+; CHECK-NOFP16-NEXT:    vmov.u16 r1, d18[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r4, d18[2]
+; CHECK-NOFP16-NEXT:    vmov.u16 r5, d18[3]
+; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov s5, r1
+; CHECK-NOFP16-NEXT:    vmov s6, r4
+; CHECK-NOFP16-NEXT:    vmov s7, r5
 ; CHECK-NOFP16-NEXT:    pop {r4, r5, r11, pc}
 ;
 ; CHECK-FP16-LABEL: frintp_8h:
@@ -1736,75 +1736,75 @@ define <8 x half> @frintx_8h(<8 x half> %A) nounwind {
 ; CHECK-ARMV7-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vmov.f32 s28, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s7
-; CHECK-ARMV7-NEXT:    vmov.f32 s16, s6
-; CHECK-ARMV7-NEXT:    vmov.f32 s18, s5
-; CHECK-ARMV7-NEXT:    vmov.f32 s20, s4
-; CHECK-ARMV7-NEXT:    vmov.f32 s22, s3
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s3
+; CHECK-ARMV7-NEXT:    vmov.f32 s16, s7
+; CHECK-ARMV7-NEXT:    vmov.f32 s18, s6
+; CHECK-ARMV7-NEXT:    vmov.f32 s20, s5
+; CHECK-ARMV7-NEXT:    vmov.f32 s22, s4
 ; CHECK-ARMV7-NEXT:    vmov.f32 s24, s2
 ; CHECK-ARMV7-NEXT:    vmov.f32 s26, s1
 ; CHECK-ARMV7-NEXT:    bl rintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s16
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s24
 ; CHECK-ARMV7-NEXT:    vmov r4, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s24, s24
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s18, s18
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s16, s16
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s28, s28
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s26, s26
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    bl rintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
 ; CHECK-ARMV7-NEXT:    pkhbt r4, r0, r4, lsl #16
 ; CHECK-ARMV7-NEXT:    bl rintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r5, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    bl rintf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-ARMV7-NEXT:    vmov r0, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
+; CHECK-ARMV7-NEXT:    bl rintf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s20, s0
 ; CHECK-ARMV7-NEXT:    vmov.f32 s0, s28
 ; CHECK-ARMV7-NEXT:    bl rintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
-; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
-; CHECK-ARMV7-NEXT:    bl rintf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s16, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
-; CHECK-ARMV7-NEXT:    bl rintf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s16
+; CHECK-ARMV7-NEXT:    vmov r0, s20
 ; CHECK-ARMV7-NEXT:    vmov r1, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s16
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r0
+; CHECK-ARMV7-NEXT:    vmov.32 d10[0], r0
 ; CHECK-ARMV7-NEXT:    bl rintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d9[0], r5
+; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r5
 ; CHECK-ARMV7-NEXT:    vmov r6, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s24
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
 ; CHECK-ARMV7-NEXT:    bl rintf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r4
+; CHECK-ARMV7-NEXT:    vmov.32 d10[1], r4
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r12, d10[0]
+; CHECK-ARMV7-NEXT:    vmov.u16 r1, d10[1]
+; CHECK-ARMV7-NEXT:    vmov.u16 r2, d10[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r3, d10[3]
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r0, r6, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
-; CHECK-ARMV7-NEXT:    vmov.32 d9[1], r0
-; CHECK-ARMV7-NEXT:    vmov s5, r5
-; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
-; CHECK-ARMV7-NEXT:    vmov s6, r4
-; CHECK-ARMV7-NEXT:    vmov.u16 r12, d9[0]
-; CHECK-ARMV7-NEXT:    vmov.u16 r1, d9[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r2, d9[2]
-; CHECK-ARMV7-NEXT:    vmov.u16 r3, d9[3]
-; CHECK-ARMV7-NEXT:    vmov s4, r6
-; CHECK-ARMV7-NEXT:    vmov s7, r0
+; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r0
 ; CHECK-ARMV7-NEXT:    vmov s0, r12
 ; CHECK-ARMV7-NEXT:    vmov s1, r1
+; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
 ; CHECK-ARMV7-NEXT:    vmov s2, r2
+; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
 ; CHECK-ARMV7-NEXT:    vmov s3, r3
+; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-ARMV7-NEXT:    vmov s4, r6
+; CHECK-ARMV7-NEXT:    vmov s5, r5
+; CHECK-ARMV7-NEXT:    vmov s6, r4
+; CHECK-ARMV7-NEXT:    vmov s7, r0
 ; CHECK-ARMV7-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -1812,62 +1812,62 @@ define <8 x half> @frintx_8h(<8 x half> %A) nounwind {
 ; CHECK-NOFP16:       @ %bb.0:
 ; CHECK-NOFP16-NEXT:    .save {r4, r5, r11, lr}
 ; CHECK-NOFP16-NEXT:    push {r4, r5, r11, lr}
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s7
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s3
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintx.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vrintx.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vrintx.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vmov r0, s8
 ; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r1, s6
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s1
-; CHECK-NOFP16-NEXT:    vrintx.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s5
+; CHECK-NOFP16-NEXT:    vrintx.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintx.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s5
+; CHECK-NOFP16-NEXT:    vmov r3, s0
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s7
 ; CHECK-NOFP16-NEXT:    vrintx.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s4, s4
-; CHECK-NOFP16-NEXT:    vrintx.f32 s4, s4
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s4, s4
-; CHECK-NOFP16-NEXT:    vmov r3, s4
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r1, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s4
+; CHECK-NOFP16-NEXT:    vrintx.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s1
+; CHECK-NOFP16-NEXT:    vrintx.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    pkhbt r1, r2, r1, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s3
-; CHECK-NOFP16-NEXT:    vrintx.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov.32 d17[0], r1
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vmov.32 d18[0], r1
 ; CHECK-NOFP16-NEXT:    pkhbt r2, r3, r2, lsl #16
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[0], r2
 ; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s6
 ; CHECK-NOFP16-NEXT:    vrintx.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[1], r0
 ; CHECK-NOFP16-NEXT:    vmov r1, s0
-; CHECK-NOFP16-NEXT:    vmov.u16 r4, d16[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r5, d16[3]
+; CHECK-NOFP16-NEXT:    vmov.u16 r12, d16[0]
+; CHECK-NOFP16-NEXT:    vmov.u16 lr, d16[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r3, d16[3]
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r2, lsl #16
-; CHECK-NOFP16-NEXT:    vmov.u16 r1, d16[1]
-; CHECK-NOFP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-NOFP16-NEXT:    vmov s6, r4
-; CHECK-NOFP16-NEXT:    vmov.u16 r0, d16[0]
-; CHECK-NOFP16-NEXT:    vmov s7, r5
-; CHECK-NOFP16-NEXT:    vmov.u16 r12, d17[0]
-; CHECK-NOFP16-NEXT:    vmov.u16 lr, d17[1]
-; CHECK-NOFP16-NEXT:    vmov.u16 r2, d17[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r3, d17[3]
-; CHECK-NOFP16-NEXT:    vmov s5, r1
-; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov.u16 r2, d16[2]
+; CHECK-NOFP16-NEXT:    vmov.32 d18[1], r0
 ; CHECK-NOFP16-NEXT:    vmov s0, r12
 ; CHECK-NOFP16-NEXT:    vmov s1, lr
-; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov.u16 r0, d18[0]
 ; CHECK-NOFP16-NEXT:    vmov s3, r3
+; CHECK-NOFP16-NEXT:    vmov.u16 r1, d18[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r4, d18[2]
+; CHECK-NOFP16-NEXT:    vmov.u16 r5, d18[3]
+; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov s5, r1
+; CHECK-NOFP16-NEXT:    vmov s6, r4
+; CHECK-NOFP16-NEXT:    vmov s7, r5
 ; CHECK-NOFP16-NEXT:    pop {r4, r5, r11, pc}
 ;
 ; CHECK-FP16-LABEL: frintx_8h:
@@ -2055,75 +2055,75 @@ define <8 x half> @frintz_8h(<8 x half> %A) nounwind {
 ; CHECK-ARMV7-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    vmov.f32 s28, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s7
-; CHECK-ARMV7-NEXT:    vmov.f32 s16, s6
-; CHECK-ARMV7-NEXT:    vmov.f32 s18, s5
-; CHECK-ARMV7-NEXT:    vmov.f32 s20, s4
-; CHECK-ARMV7-NEXT:    vmov.f32 s22, s3
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s0, s3
+; CHECK-ARMV7-NEXT:    vmov.f32 s16, s7
+; CHECK-ARMV7-NEXT:    vmov.f32 s18, s6
+; CHECK-ARMV7-NEXT:    vmov.f32 s20, s5
+; CHECK-ARMV7-NEXT:    vmov.f32 s22, s4
 ; CHECK-ARMV7-NEXT:    vmov.f32 s24, s2
 ; CHECK-ARMV7-NEXT:    vmov.f32 s26, s1
 ; CHECK-ARMV7-NEXT:    bl truncf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s16
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s2, s24
 ; CHECK-ARMV7-NEXT:    vmov r4, s0
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s24, s24
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
-; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s18, s18
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s2
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s16, s16
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s28, s28
 ; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s26, s26
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s22, s22
+; CHECK-ARMV7-NEXT:    vcvtb.f32.f16 s20, s20
 ; CHECK-ARMV7-NEXT:    bl truncf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
 ; CHECK-ARMV7-NEXT:    pkhbt r4, r0, r4, lsl #16
 ; CHECK-ARMV7-NEXT:    bl truncf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-ARMV7-NEXT:    vmov r5, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    bl truncf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-ARMV7-NEXT:    vmov r0, s0
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s26
+; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
+; CHECK-ARMV7-NEXT:    bl truncf
+; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s20, s0
 ; CHECK-ARMV7-NEXT:    vmov.f32 s0, s28
 ; CHECK-ARMV7-NEXT:    bl truncf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
-; CHECK-ARMV7-NEXT:    pkhbt r5, r0, r5, lsl #16
-; CHECK-ARMV7-NEXT:    bl truncf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s16, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s20
-; CHECK-ARMV7-NEXT:    bl truncf
-; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov r0, s16
+; CHECK-ARMV7-NEXT:    vmov r0, s20
 ; CHECK-ARMV7-NEXT:    vmov r1, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s22
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s16
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r0
+; CHECK-ARMV7-NEXT:    vmov.32 d10[0], r0
 ; CHECK-ARMV7-NEXT:    bl truncf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d9[0], r5
+; CHECK-ARMV7-NEXT:    vmov.32 d8[0], r5
 ; CHECK-ARMV7-NEXT:    vmov r6, s0
-; CHECK-ARMV7-NEXT:    vmov.f32 s0, s24
+; CHECK-ARMV7-NEXT:    vmov.f32 s0, s18
 ; CHECK-ARMV7-NEXT:    bl truncf
 ; CHECK-ARMV7-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r4
+; CHECK-ARMV7-NEXT:    vmov.32 d10[1], r4
 ; CHECK-ARMV7-NEXT:    vmov r0, s0
-; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r12, d10[0]
+; CHECK-ARMV7-NEXT:    vmov.u16 r1, d10[1]
+; CHECK-ARMV7-NEXT:    vmov.u16 r2, d10[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r3, d10[3]
 ; CHECK-ARMV7-NEXT:    pkhbt r0, r0, r6, lsl #16
-; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
-; CHECK-ARMV7-NEXT:    vmov.32 d9[1], r0
-; CHECK-ARMV7-NEXT:    vmov s5, r5
-; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
-; CHECK-ARMV7-NEXT:    vmov s6, r4
-; CHECK-ARMV7-NEXT:    vmov.u16 r12, d9[0]
-; CHECK-ARMV7-NEXT:    vmov.u16 r1, d9[1]
-; CHECK-ARMV7-NEXT:    vmov.u16 r2, d9[2]
-; CHECK-ARMV7-NEXT:    vmov.u16 r3, d9[3]
-; CHECK-ARMV7-NEXT:    vmov s4, r6
-; CHECK-ARMV7-NEXT:    vmov s7, r0
+; CHECK-ARMV7-NEXT:    vmov.32 d8[1], r0
 ; CHECK-ARMV7-NEXT:    vmov s0, r12
 ; CHECK-ARMV7-NEXT:    vmov s1, r1
+; CHECK-ARMV7-NEXT:    vmov.u16 r6, d8[0]
 ; CHECK-ARMV7-NEXT:    vmov s2, r2
+; CHECK-ARMV7-NEXT:    vmov.u16 r5, d8[1]
 ; CHECK-ARMV7-NEXT:    vmov s3, r3
+; CHECK-ARMV7-NEXT:    vmov.u16 r4, d8[2]
+; CHECK-ARMV7-NEXT:    vmov.u16 r0, d8[3]
+; CHECK-ARMV7-NEXT:    vmov s4, r6
+; CHECK-ARMV7-NEXT:    vmov s5, r5
+; CHECK-ARMV7-NEXT:    vmov s6, r4
+; CHECK-ARMV7-NEXT:    vmov s7, r0
 ; CHECK-ARMV7-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14}
 ; CHECK-ARMV7-NEXT:    pop {r4, r5, r6, pc}
 ;
@@ -2131,62 +2131,62 @@ define <8 x half> @frintz_8h(<8 x half> %A) nounwind {
 ; CHECK-NOFP16:       @ %bb.0:
 ; CHECK-NOFP16-NEXT:    .save {r4, r5, r11, lr}
 ; CHECK-NOFP16-NEXT:    push {r4, r5, r11, lr}
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s7
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s8, s3
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintz.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vrintz.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vrintz.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s8, s8
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vmov r0, s8
 ; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r1, s6
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s6, s1
-; CHECK-NOFP16-NEXT:    vrintz.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s5
+; CHECK-NOFP16-NEXT:    vrintz.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vrintz.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s6, s6
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s5
+; CHECK-NOFP16-NEXT:    vmov r3, s0
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s7
 ; CHECK-NOFP16-NEXT:    vrintz.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s4, s4
-; CHECK-NOFP16-NEXT:    vrintz.f32 s4, s4
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s4, s4
-; CHECK-NOFP16-NEXT:    vmov r3, s4
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r0, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r1, s6
+; CHECK-NOFP16-NEXT:    vmov r1, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s4
+; CHECK-NOFP16-NEXT:    vrintz.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s2, s1
+; CHECK-NOFP16-NEXT:    vrintz.f32 s2, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s2, s2
 ; CHECK-NOFP16-NEXT:    pkhbt r1, r2, r1, lsl #16
-; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s3
-; CHECK-NOFP16-NEXT:    vrintz.f32 s0, s0
-; CHECK-NOFP16-NEXT:    vmov.32 d17[0], r1
-; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
+; CHECK-NOFP16-NEXT:    vmov r2, s2
+; CHECK-NOFP16-NEXT:    vmov.32 d18[0], r1
 ; CHECK-NOFP16-NEXT:    pkhbt r2, r3, r2, lsl #16
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[0], r2
 ; CHECK-NOFP16-NEXT:    vmov r2, s0
-; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s2
+; CHECK-NOFP16-NEXT:    vcvtb.f32.f16 s0, s6
 ; CHECK-NOFP16-NEXT:    vrintz.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vcvtb.f16.f32 s0, s0
 ; CHECK-NOFP16-NEXT:    vmov.32 d16[1], r0
 ; CHECK-NOFP16-NEXT:    vmov r1, s0
-; CHECK-NOFP16-NEXT:    vmov.u16 r4, d16[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r5, d16[3]
+; CHECK-NOFP16-NEXT:    vmov.u16 r12, d16[0]
+; CHECK-NOFP16-NEXT:    vmov.u16 lr, d16[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r3, d16[3]
 ; CHECK-NOFP16-NEXT:    pkhbt r0, r1, r2, lsl #16
-; CHECK-NOFP16-NEXT:    vmov.u16 r1, d16[1]
-; CHECK-NOFP16-NEXT:    vmov.32 d17[1], r0
-; CHECK-NOFP16-NEXT:    vmov s6, r4
-; CHECK-NOFP16-NEXT:    vmov.u16 r0, d16[0]
-; CHECK-NOFP16-NEXT:    vmov s7, r5
-; CHECK-NOFP16-NEXT:    vmov.u16 r12, d17[0]
-; CHECK-NOFP16-NEXT:    vmov.u16 lr, d17[1]
-; CHECK-NOFP16-NEXT:    vmov.u16 r2, d17[2]
-; CHECK-NOFP16-NEXT:    vmov.u16 r3, d17[3]
-; CHECK-NOFP16-NEXT:    vmov s5, r1
-; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov.u16 r2, d16[2]
+; CHECK-NOFP16-NEXT:    vmov.32 d18[1], r0
 ; CHECK-NOFP16-NEXT:    vmov s0, r12
 ; CHECK-NOFP16-NEXT:    vmov s1, lr
-; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov.u16 r0, d18[0]
 ; CHECK-NOFP16-NEXT:    vmov s3, r3
+; CHECK-NOFP16-NEXT:    vmov.u16 r1, d18[1]
+; CHECK-NOFP16-NEXT:    vmov.u16 r4, d18[2]
+; CHECK-NOFP16-NEXT:    vmov.u16 r5, d18[3]
+; CHECK-NOFP16-NEXT:    vmov s2, r2
+; CHECK-NOFP16-NEXT:    vmov s4, r0
+; CHECK-NOFP16-NEXT:    vmov s5, r1
+; CHECK-NOFP16-NEXT:    vmov s6, r4
+; CHECK-NOFP16-NEXT:    vmov s7, r5
 ; CHECK-NOFP16-NEXT:    pop {r4, r5, r11, pc}
 ;
 ; CHECK-FP16-LABEL: frintz_8h:

--- a/llvm/test/CodeGen/ARM/vselect_imax.ll
+++ b/llvm/test/CodeGen/ARM/vselect_imax.ll
@@ -113,16 +113,16 @@ define void @func_blend18(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storea
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
-; CHECK-NEXT:    vld1.64 {d16, d17}, [r1:128]!
+; CHECK-NEXT:    vld1.64 {d20, d21}, [r1:128]!
 ; CHECK-NEXT:    vld1.64 {d22, d23}, [r0:128]!
-; CHECK-NEXT:    vmov r4, r6, d16
-; CHECK-NEXT:    vld1.64 {d18, d19}, [r1:128]
-; CHECK-NEXT:    vld1.64 {d20, d21}, [r0:128]
-; CHECK-NEXT:    vmov lr, r12, d18
+; CHECK-NEXT:    vmov r4, r6, d21
+; CHECK-NEXT:    vld1.64 {d16, d17}, [r1:128]
+; CHECK-NEXT:    vld1.64 {d18, d19}, [r0:128]
+; CHECK-NEXT:    vmov lr, r12, d16
 ; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    vmov r2, r1, d20
+; CHECK-NEXT:    vmov r2, r1, d18
 ; CHECK-NEXT:    subs r2, r2, lr
-; CHECK-NEXT:    vmov r2, r5, d22
+; CHECK-NEXT:    vmov r2, r5, d23
 ; CHECK-NEXT:    sbcs r1, r1, r12
 ; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    movlt r1, #1
@@ -130,33 +130,33 @@ define void @func_blend18(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storea
 ; CHECK-NEXT:    mvnne r1, #0
 ; CHECK-NEXT:    subs r2, r2, r4
 ; CHECK-NEXT:    sbcs r6, r5, r6
-; CHECK-NEXT:    vmov r2, r12, d17
-; CHECK-NEXT:    vmov r5, r4, d23
+; CHECK-NEXT:    vmov r2, r12, d20
+; CHECK-NEXT:    vmov r5, r4, d22
 ; CHECK-NEXT:    mov r6, #0
 ; CHECK-NEXT:    movlt r6, #1
 ; CHECK-NEXT:    cmp r6, #0
 ; CHECK-NEXT:    mvnne r6, #0
 ; CHECK-NEXT:    subs r2, r5, r2
 ; CHECK-NEXT:    sbcs r2, r4, r12
-; CHECK-NEXT:    vmov lr, r12, d19
-; CHECK-NEXT:    vmov r4, r5, d21
+; CHECK-NEXT:    vmov lr, r12, d17
+; CHECK-NEXT:    vmov r4, r5, d19
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    movlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d25, r2
-; CHECK-NEXT:    vdup.32 d24, r6
-; CHECK-NEXT:    vbit q8, q11, q12
-; CHECK-NEXT:    vst1.64 {d16, d17}, [r3:128]!
+; CHECK-NEXT:    vdup.32 d24, r2
+; CHECK-NEXT:    vdup.32 d25, r6
+; CHECK-NEXT:    vbit q10, q11, q12
+; CHECK-NEXT:    vdup.32 d22, r1
+; CHECK-NEXT:    vst1.64 {d20, d21}, [r3:128]!
 ; CHECK-NEXT:    subs r4, r4, lr
 ; CHECK-NEXT:    sbcs r5, r5, r12
 ; CHECK-NEXT:    movlt r0, #1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d27, r0
-; CHECK-NEXT:    vdup.32 d26, r1
-; CHECK-NEXT:    vbit q9, q10, q13
-; CHECK-NEXT:    vst1.64 {d18, d19}, [r3:128]
+; CHECK-NEXT:    vdup.32 d23, r0
+; CHECK-NEXT:    vbit q8, q9, q11
+; CHECK-NEXT:    vst1.64 {d16, d17}, [r3:128]
 ; CHECK-NEXT:    pop {r4, r5, r6, lr}
 ; CHECK-NEXT:    mov pc, lr
 ; COST: func_blend18
@@ -178,93 +178,95 @@ define void @func_blend19(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storea
 ; CHECK-NEXT:    .save {r4, r5, r6, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEXT:    vld1.64 {d28, d29}, [r1:128]!
-; CHECK-NEXT:    mov lr, #0
-; CHECK-NEXT:    vld1.64 {d30, d31}, [r0:128]!
-; CHECK-NEXT:    vld1.64 {d20, d21}, [r1:128]!
-; CHECK-NEXT:    vld1.64 {d24, d25}, [r0:128]!
-; CHECK-NEXT:    vld1.64 {d22, d23}, [r1:128]!
-; CHECK-NEXT:    vld1.64 {d26, d27}, [r0:128]!
-; CHECK-NEXT:    vld1.64 {d16, d17}, [r1:128]
-; CHECK-NEXT:    vld1.64 {d18, d19}, [r0:128]
-; CHECK-NEXT:    vmov r0, r12, d16
-; CHECK-NEXT:    vmov r1, r2, d18
-; CHECK-NEXT:    subs r0, r1, r0
-; CHECK-NEXT:    vmov r1, r4, d25
-; CHECK-NEXT:    sbcs r0, r2, r12
 ; CHECK-NEXT:    mov r12, #0
-; CHECK-NEXT:    vmov r2, r0, d21
-; CHECK-NEXT:    movlt r12, #1
-; CHECK-NEXT:    cmp r12, #0
-; CHECK-NEXT:    mvnne r12, #0
-; CHECK-NEXT:    subs r1, r1, r2
-; CHECK-NEXT:    sbcs r0, r4, r0
-; CHECK-NEXT:    vmov r2, r4, d24
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d1, r0
-; CHECK-NEXT:    vmov r0, r1, d20
-; CHECK-NEXT:    subs r0, r2, r0
-; CHECK-NEXT:    sbcs r0, r4, r1
-; CHECK-NEXT:    vmov r2, r4, d26
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d0, r0
-; CHECK-NEXT:    vmov r0, r1, d22
-; CHECK-NEXT:    vbit q10, q12, q0
-; CHECK-NEXT:    subs r0, r2, r0
+; CHECK-NEXT:    vld1.64 {d30, d31}, [r0:128]!
+; CHECK-NEXT:    vmov r2, lr, d28
+; CHECK-NEXT:    vmov r4, r5, d30
+; CHECK-NEXT:    vld1.64 {d16, d17}, [r0:128]!
+; CHECK-NEXT:    vld1.64 {d18, d19}, [r1:128]!
+; CHECK-NEXT:    vld1.64 {d20, d21}, [r1:128]!
+; CHECK-NEXT:    vld1.64 {d26, d27}, [r0:128]!
+; CHECK-NEXT:    vld1.64 {d22, d23}, [r1:128]
+; CHECK-NEXT:    vld1.64 {d24, d25}, [r0:128]
+; CHECK-NEXT:    vmov r0, r1, d23
+; CHECK-NEXT:    subs r2, r4, r2
+; CHECK-NEXT:    vmov r4, r6, d31
+; CHECK-NEXT:    sbcs r2, r5, lr
+; CHECK-NEXT:    vmov r5, lr, d29
 ; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    sbcs r0, r4, r1
-; CHECK-NEXT:    vmov r4, r5, d31
-; CHECK-NEXT:    vmov r0, r1, d29
 ; CHECK-NEXT:    movlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    subs r0, r4, r0
-; CHECK-NEXT:    sbcs r0, r5, r1
-; CHECK-NEXT:    vmov r4, r5, d30
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d3, r0
-; CHECK-NEXT:    vmov r0, r1, d28
-; CHECK-NEXT:    subs r0, r4, r0
-; CHECK-NEXT:    sbcs r0, r5, r1
-; CHECK-NEXT:    vmov r4, r5, d27
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    movlt r0, #1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d2, r0
-; CHECK-NEXT:    vmov r0, r1, d23
-; CHECK-NEXT:    vbit q14, q15, q1
+; CHECK-NEXT:    vdup.32 d0, r2
+; CHECK-NEXT:    subs r4, r4, r5
+; CHECK-NEXT:    vmov r2, r5, d25
+; CHECK-NEXT:    sbcs r6, r6, lr
+; CHECK-NEXT:    mov r6, #0
+; CHECK-NEXT:    movlt r6, #1
+; CHECK-NEXT:    cmp r6, #0
+; CHECK-NEXT:    mvnne r6, #0
+; CHECK-NEXT:    vdup.32 d1, r6
+; CHECK-NEXT:    vbit q14, q15, q0
 ; CHECK-NEXT:    vst1.64 {d28, d29}, [r3:128]!
-; CHECK-NEXT:    vst1.64 {d20, d21}, [r3:128]!
-; CHECK-NEXT:    subs r0, r4, r0
+; CHECK-NEXT:    subs r0, r2, r0
 ; CHECK-NEXT:    sbcs r0, r5, r1
-; CHECK-NEXT:    vmov r1, r4, d17
-; CHECK-NEXT:    vmov r5, r6, d19
+; CHECK-NEXT:    vmov r1, r2, d21
+; CHECK-NEXT:    vmov r6, r5, d27
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    movlt r0, #1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    mvnne r0, #0
-; CHECK-NEXT:    vdup.32 d31, r0
+; CHECK-NEXT:    subs r1, r6, r1
+; CHECK-NEXT:    sbcs r1, r5, r2
+; CHECK-NEXT:    vmov r2, r6, d18
+; CHECK-NEXT:    vmov r5, r4, d16
+; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    movlt r1, #1
+; CHECK-NEXT:    cmp r1, #0
+; CHECK-NEXT:    mvnne r1, #0
+; CHECK-NEXT:    subs r2, r5, r2
+; CHECK-NEXT:    sbcs r2, r4, r6
+; CHECK-NEXT:    vmov r6, lr, d19
+; CHECK-NEXT:    vmov r4, r5, d17
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    movlt r2, #1
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    mvnne r2, #0
 ; CHECK-NEXT:    vdup.32 d30, r2
-; CHECK-NEXT:    vbit q11, q13, q15
-; CHECK-NEXT:    vst1.64 {d22, d23}, [r3:128]!
-; CHECK-NEXT:    subs r1, r5, r1
-; CHECK-NEXT:    sbcs r1, r6, r4
-; CHECK-NEXT:    movlt lr, #1
-; CHECK-NEXT:    cmp lr, #0
-; CHECK-NEXT:    mvnne lr, #0
-; CHECK-NEXT:    vdup.32 d3, lr
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    subs r4, r4, r6
+; CHECK-NEXT:    sbcs r6, r5, lr
+; CHECK-NEXT:    vmov r4, r5, d26
+; CHECK-NEXT:    vmov r6, lr, d20
+; CHECK-NEXT:    movlt r2, #1
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    vdup.32 d31, r2
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    vbif q8, q9, q15
+; CHECK-NEXT:    vst1.64 {d16, d17}, [r3:128]!
+; CHECK-NEXT:    subs r4, r4, r6
+; CHECK-NEXT:    sbcs r6, r5, lr
+; CHECK-NEXT:    vmov r4, r5, d24
+; CHECK-NEXT:    vmov r6, lr, d22
+; CHECK-NEXT:    movlt r2, #1
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    vdup.32 d0, r2
+; CHECK-NEXT:    vdup.32 d1, r1
+; CHECK-NEXT:    vorr q9, q0, q0
+; CHECK-NEXT:    vbsl q9, q13, q10
+; CHECK-NEXT:    vst1.64 {d18, d19}, [r3:128]!
+; CHECK-NEXT:    subs r4, r4, r6
+; CHECK-NEXT:    sbcs r6, r5, lr
+; CHECK-NEXT:    movlt r12, #1
+; CHECK-NEXT:    cmp r12, #0
+; CHECK-NEXT:    mvnne r12, #0
 ; CHECK-NEXT:    vdup.32 d2, r12
-; CHECK-NEXT:    vbit q8, q9, q1
-; CHECK-NEXT:    vst1.64 {d16, d17}, [r3:128]
+; CHECK-NEXT:    vdup.32 d3, r0
+; CHECK-NEXT:    vorr q10, q1, q1
+; CHECK-NEXT:    vbsl q10, q12, q11
+; CHECK-NEXT:    vst1.64 {d20, d21}, [r3:128]
 ; CHECK-NEXT:    pop {r4, r5, r6, lr}
 ; CHECK-NEXT:    mov pc, lr
 ; COST: func_blend19
@@ -287,83 +289,71 @@ define void @func_blend20(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storea
 ; CHECK-NEXT:    push {r4, r5, r6, r7, r8, lr}
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
-; CHECK-NEXT:    add r8, r1, #64
-; CHECK-NEXT:    add lr, r0, #64
+; CHECK-NEXT:    add lr, r1, #64
 ; CHECK-NEXT:    vld1.64 {d16, d17}, [r1:128]!
+; CHECK-NEXT:    add r8, r0, #64
 ; CHECK-NEXT:    mov r12, #0
-; CHECK-NEXT:    vld1.64 {d24, d25}, [r0:128]!
-; CHECK-NEXT:    vmov r4, r5, d17
-; CHECK-NEXT:    vmov r6, r7, d25
-; CHECK-NEXT:    vld1.64 {d18, d19}, [lr:128]!
-; CHECK-NEXT:    vld1.64 {d20, d21}, [r8:128]!
-; CHECK-NEXT:    vld1.64 {d0, d1}, [lr:128]!
-; CHECK-NEXT:    vld1.64 {d22, d23}, [r8:128]!
-; CHECK-NEXT:    vld1.64 {d28, d29}, [lr:128]!
+; CHECK-NEXT:    vld1.64 {d26, d27}, [r0:128]!
+; CHECK-NEXT:    vmov r4, r5, d16
+; CHECK-NEXT:    vmov r6, r7, d26
+; CHECK-NEXT:    vld1.64 {d18, d19}, [r8:128]!
+; CHECK-NEXT:    vld1.64 {d20, d21}, [lr:128]!
+; CHECK-NEXT:    vld1.64 {d22, d23}, [lr:128]!
+; CHECK-NEXT:    vld1.64 {d24, d25}, [r8:128]!
+; CHECK-NEXT:    vld1.64 {d30, d31}, [r0:128]!
+; CHECK-NEXT:    vld1.64 {d4, d5}, [r1:128]!
+; CHECK-NEXT:    vld1.64 {d0, d1}, [r0:128]!
+; CHECK-NEXT:    vld1.64 {d2, d3}, [r1:128]!
 ; CHECK-NEXT:    subs r4, r6, r4
 ; CHECK-NEXT:    sbcs r4, r7, r5
-; CHECK-NEXT:    vmov r5, r6, d16
-; CHECK-NEXT:    vmov r7, r2, d24
+; CHECK-NEXT:    vmov r5, r6, d17
+; CHECK-NEXT:    vmov r7, r2, d27
 ; CHECK-NEXT:    mov r4, #0
 ; CHECK-NEXT:    movlt r4, #1
 ; CHECK-NEXT:    cmp r4, #0
 ; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    vdup.32 d27, r4
+; CHECK-NEXT:    vdup.32 d28, r4
 ; CHECK-NEXT:    subs r5, r7, r5
 ; CHECK-NEXT:    sbcs r2, r2, r6
-; CHECK-NEXT:    vmov r5, r6, d1
+; CHECK-NEXT:    vmov r5, r6, d24
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    movlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d26, r2
-; CHECK-NEXT:    vmov r2, r4, d23
-; CHECK-NEXT:    vbit q8, q12, q13
-; CHECK-NEXT:    vld1.64 {d24, d25}, [r0:128]!
-; CHECK-NEXT:    vld1.64 {d26, d27}, [r1:128]!
-; CHECK-NEXT:    vld1.64 {d6, d7}, [r0:128]!
+; CHECK-NEXT:    vdup.32 d29, r2
+; CHECK-NEXT:    vmov r2, r4, d22
+; CHECK-NEXT:    vbit q8, q13, q14
 ; CHECK-NEXT:    subs r2, r5, r2
 ; CHECK-NEXT:    sbcs r2, r6, r4
-; CHECK-NEXT:    vmov r4, r5, d22
-; CHECK-NEXT:    vmov r6, r7, d0
+; CHECK-NEXT:    vmov r4, r5, d23
+; CHECK-NEXT:    vmov r6, r7, d25
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    movlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d3, r2
+; CHECK-NEXT:    vdup.32 d28, r2
 ; CHECK-NEXT:    subs r4, r6, r4
 ; CHECK-NEXT:    sbcs r4, r7, r5
-; CHECK-NEXT:    vmov r2, r5, d27
-; CHECK-NEXT:    vmov r6, r7, d25
+; CHECK-NEXT:    vmov r2, r5, d4
+; CHECK-NEXT:    vmov r6, r7, d30
 ; CHECK-NEXT:    mov r4, #0
 ; CHECK-NEXT:    movlt r4, #1
 ; CHECK-NEXT:    cmp r4, #0
 ; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    vdup.32 d2, r4
-; CHECK-NEXT:    vbit q11, q0, q1
-; CHECK-NEXT:    vld1.64 {d2, d3}, [r0:128]
+; CHECK-NEXT:    vdup.32 d29, r4
+; CHECK-NEXT:    mov r4, #0
+; CHECK-NEXT:    vbit q11, q12, q14
+; CHECK-NEXT:    vld1.64 {d24, d25}, [r1:128]
+; CHECK-NEXT:    vld1.64 {d28, d29}, [r0:128]
 ; CHECK-NEXT:    subs r2, r6, r2
 ; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    vmov r6, r7, d24
+; CHECK-NEXT:    vmov r6, r7, d31
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    movlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d5, r2
-; CHECK-NEXT:    vmov r2, r5, d26
-; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    vmov r6, r7, d19
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movlt r2, #1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d4, r2
-; CHECK-NEXT:    vmov r2, r5, d21
-; CHECK-NEXT:    vbit q13, q12, q2
-; CHECK-NEXT:    vld1.64 {d24, d25}, [lr:128]
-; CHECK-NEXT:    mov lr, #0
-; CHECK-NEXT:    vld1.64 {d4, d5}, [r1:128]!
-; CHECK-NEXT:    vld1.64 {d0, d1}, [r1:128]
+; CHECK-NEXT:    vdup.32 d6, r2
+; CHECK-NEXT:    vmov r2, r5, d5
 ; CHECK-NEXT:    subs r2, r6, r2
 ; CHECK-NEXT:    sbcs r2, r7, r5
 ; CHECK-NEXT:    vmov r6, r7, d18
@@ -371,103 +361,116 @@ define void @func_blend20(ptr %loadaddr, ptr %loadaddr2, ptr %blend, ptr %storea
 ; CHECK-NEXT:    movlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d31, r2
+; CHECK-NEXT:    vdup.32 d7, r2
 ; CHECK-NEXT:    vmov r2, r5, d20
 ; CHECK-NEXT:    subs r2, r6, r2
 ; CHECK-NEXT:    sbcs r2, r7, r5
-; CHECK-NEXT:    vmov r6, r5, d25
+; CHECK-NEXT:    vmov r6, r7, d19
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    movlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    vdup.32 d30, r2
-; CHECK-NEXT:    vbif q9, q10, q15
-; CHECK-NEXT:    vld1.64 {d30, d31}, [r8:128]!
-; CHECK-NEXT:    vld1.64 {d20, d21}, [r8:128]
-; CHECK-NEXT:    vmov r2, r7, d21
-; CHECK-NEXT:    subs r1, r6, r2
-; CHECK-NEXT:    vmov r0, r6, d2
-; CHECK-NEXT:    sbcs r1, r5, r7
-; CHECK-NEXT:    vmov r2, r7, d0
-; CHECK-NEXT:    movlt lr, #1
-; CHECK-NEXT:    cmp lr, #0
-; CHECK-NEXT:    mvnne lr, #0
-; CHECK-NEXT:    subs r0, r0, r2
-; CHECK-NEXT:    sbcs r0, r6, r7
-; CHECK-NEXT:    vmov r2, r7, d30
-; CHECK-NEXT:    vmov r6, r5, d28
+; CHECK-NEXT:    vdup.32 d26, r2
+; CHECK-NEXT:    vmov r2, r5, d21
+; CHECK-NEXT:    subs r2, r6, r2
+; CHECK-NEXT:    sbcs r2, r7, r5
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    movlt r2, #1
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    vdup.32 d27, r2
+; CHECK-NEXT:    vbif q9, q10, q13
+; CHECK-NEXT:    vld1.64 {d26, d27}, [r8:128]!
+; CHECK-NEXT:    vorr q10, q3, q3
+; CHECK-NEXT:    vmov r6, r7, d27
+; CHECK-NEXT:    vbsl q10, q15, q2
+; CHECK-NEXT:    vld1.64 {d30, d31}, [lr:128]!
+; CHECK-NEXT:    vmov r2, r5, d31
+; CHECK-NEXT:    vld1.64 {d4, d5}, [r8:128]
+; CHECK-NEXT:    vld1.64 {d6, d7}, [lr:128]
+; CHECK-NEXT:    subs r2, r6, r2
+; CHECK-NEXT:    sbcs r2, r7, r5
+; CHECK-NEXT:    vmov r6, r7, d26
+; CHECK-NEXT:    vmov r2, r5, d30
+; CHECK-NEXT:    movlt r4, #1
+; CHECK-NEXT:    cmp r4, #0
+; CHECK-NEXT:    mvnne r4, #0
+; CHECK-NEXT:    subs r2, r6, r2
+; CHECK-NEXT:    sbcs r0, r7, r5
+; CHECK-NEXT:    vmov r1, r2, d24
+; CHECK-NEXT:    vmov r5, r6, d28
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    movlt r0, #1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    mvnne r0, #0
+; CHECK-NEXT:    subs r1, r5, r1
+; CHECK-NEXT:    sbcs r1, r6, r2
+; CHECK-NEXT:    vmov r2, r5, d2
+; CHECK-NEXT:    vmov r6, r7, d0
+; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    movlt r1, #1
+; CHECK-NEXT:    cmp r1, #0
+; CHECK-NEXT:    mvnne r1, #0
 ; CHECK-NEXT:    subs r2, r6, r2
-; CHECK-NEXT:    sbcs r2, r5, r7
-; CHECK-NEXT:    vmov r7, r6, d31
-; CHECK-NEXT:    vmov r5, r4, d29
+; CHECK-NEXT:    sbcs r2, r7, r5
+; CHECK-NEXT:    vmov r6, r7, d1
 ; CHECK-NEXT:    mov r2, #0
 ; CHECK-NEXT:    movlt r2, #1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    mvnne r2, #0
-; CHECK-NEXT:    subs r7, r5, r7
-; CHECK-NEXT:    vmov r5, r1, d7
-; CHECK-NEXT:    sbcs r7, r4, r6
-; CHECK-NEXT:    mov r4, #0
-; CHECK-NEXT:    vmov r7, r6, d5
-; CHECK-NEXT:    movlt r4, #1
-; CHECK-NEXT:    cmp r4, #0
-; CHECK-NEXT:    mvnne r4, #0
-; CHECK-NEXT:    subs r5, r5, r7
-; CHECK-NEXT:    sbcs r1, r1, r6
-; CHECK-NEXT:    vmov r6, r7, d6
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    vdup.32 d9, r1
-; CHECK-NEXT:    vmov r1, r5, d4
-; CHECK-NEXT:    subs r1, r6, r1
-; CHECK-NEXT:    sbcs r1, r7, r5
-; CHECK-NEXT:    vmov r6, r7, d3
-; CHECK-NEXT:    mov r1, #0
-; CHECK-NEXT:    movlt r1, #1
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    vdup.32 d8, r1
-; CHECK-NEXT:    vmov r1, r5, d1
-; CHECK-NEXT:    vbit q2, q3, q4
-; CHECK-NEXT:    vdup.32 d9, r4
 ; CHECK-NEXT:    vdup.32 d8, r2
-; CHECK-NEXT:    subs r1, r6, r1
-; CHECK-NEXT:    sbcs r1, r7, r5
-; CHECK-NEXT:    vmov r5, r6, d24
+; CHECK-NEXT:    vmov r2, r5, d3
+; CHECK-NEXT:    subs r2, r6, r2
+; CHECK-NEXT:    sbcs r2, r7, r5
+; CHECK-NEXT:    mov r2, #0
+; CHECK-NEXT:    movlt r2, #1
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    mvnne r2, #0
+; CHECK-NEXT:    vdup.32 d9, r2
+; CHECK-NEXT:    vmov r2, r7, d25
+; CHECK-NEXT:    vbif q0, q1, q4
+; CHECK-NEXT:    vdup.32 d2, r1
+; CHECK-NEXT:    vmov r1, r6, d29
+; CHECK-NEXT:    vdup.32 d8, r0
+; CHECK-NEXT:    vdup.32 d9, r4
+; CHECK-NEXT:    vmov r5, r4, d7
+; CHECK-NEXT:    mov r0, r3
+; CHECK-NEXT:    vst1.64 {d16, d17}, [r0:128]!
+; CHECK-NEXT:    vorr q8, q4, q4
+; CHECK-NEXT:    vst1.64 {d20, d21}, [r0:128]!
+; CHECK-NEXT:    vbsl q8, q13, q15
+; CHECK-NEXT:    vst1.64 {d0, d1}, [r0:128]!
+; CHECK-NEXT:    subs r1, r1, r2
+; CHECK-NEXT:    sbcs r1, r6, r7
+; CHECK-NEXT:    vmov r7, r6, d4
 ; CHECK-NEXT:    mov r1, #0
 ; CHECK-NEXT:    movlt r1, #1
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    mvnne r1, #0
-; CHECK-NEXT:    vdup.32 d7, r1
-; CHECK-NEXT:    vmov r1, r4, d20
-; CHECK-NEXT:    vdup.32 d6, r0
-; CHECK-NEXT:    subs r1, r5, r1
-; CHECK-NEXT:    mov r1, r3
-; CHECK-NEXT:    sbcs r0, r6, r4
-; CHECK-NEXT:    vst1.64 {d16, d17}, [r1:128]!
-; CHECK-NEXT:    vorr q8, q4, q4
+; CHECK-NEXT:    vdup.32 d3, r1
+; CHECK-NEXT:    vmov r1, r2, d6
+; CHECK-NEXT:    vbit q12, q14, q1
+; CHECK-NEXT:    vst1.64 {d24, d25}, [r0:128]
+; CHECK-NEXT:    add r0, r3, #64
+; CHECK-NEXT:    vst1.64 {d18, d19}, [r0:128]!
+; CHECK-NEXT:    vst1.64 {d22, d23}, [r0:128]!
+; CHECK-NEXT:    vst1.64 {d16, d17}, [r0:128]!
+; CHECK-NEXT:    subs r1, r7, r1
+; CHECK-NEXT:    sbcs r1, r6, r2
+; CHECK-NEXT:    vmov r2, r7, d5
+; CHECK-NEXT:    mov r1, #0
+; CHECK-NEXT:    movlt r1, #1
+; CHECK-NEXT:    cmp r1, #0
+; CHECK-NEXT:    mvnne r1, #0
+; CHECK-NEXT:    vdup.32 d26, r1
+; CHECK-NEXT:    subs r2, r2, r5
+; CHECK-NEXT:    sbcs r2, r7, r4
 ; CHECK-NEXT:    movlt r12, #1
 ; CHECK-NEXT:    cmp r12, #0
-; CHECK-NEXT:    vbsl q8, q14, q15
-; CHECK-NEXT:    add r0, r3, #64
-; CHECK-NEXT:    vorr q15, q3, q3
-; CHECK-NEXT:    vdup.32 d29, lr
 ; CHECK-NEXT:    mvnne r12, #0
-; CHECK-NEXT:    vst1.64 {d18, d19}, [r0:128]!
-; CHECK-NEXT:    vbsl q15, q1, q0
-; CHECK-NEXT:    vdup.32 d28, r12
-; CHECK-NEXT:    vst1.64 {d26, d27}, [r1:128]!
-; CHECK-NEXT:    vbit q10, q12, q14
-; CHECK-NEXT:    vst1.64 {d22, d23}, [r0:128]!
-; CHECK-NEXT:    vst1.64 {d4, d5}, [r1:128]!
-; CHECK-NEXT:    vst1.64 {d16, d17}, [r0:128]!
-; CHECK-NEXT:    vst1.64 {d30, d31}, [r1:128]
+; CHECK-NEXT:    vdup.32 d27, r12
+; CHECK-NEXT:    vorr q10, q13, q13
+; CHECK-NEXT:    vbsl q10, q2, q3
 ; CHECK-NEXT:    vst1.64 {d20, d21}, [r0:128]
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, r8, lr}

--- a/llvm/test/CodeGen/ARM/vtrn.ll
+++ b/llvm/test/CodeGen/ARM/vtrn.ll
@@ -22,9 +22,9 @@ define <16 x i8> @vtrni8_Qres(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: vtrni8_Qres:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vldr d17, [r0]
-; CHECK-NEXT:    vtrn.8 d17, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vldr d18, [r0]
+; CHECK-NEXT:    vtrn.8 d18, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    vmov r2, r3, d16
 ; CHECK-NEXT:    mov pc, lr
   %tmp1 = load <8 x i8>, ptr %A
@@ -54,9 +54,9 @@ define <8 x i16> @vtrni16_Qres(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: vtrni16_Qres:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vldr d17, [r0]
-; CHECK-NEXT:    vtrn.16 d17, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vldr d18, [r0]
+; CHECK-NEXT:    vtrn.16 d18, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    vmov r2, r3, d16
 ; CHECK-NEXT:    mov pc, lr
   %tmp1 = load <4 x i16>, ptr %A
@@ -86,9 +86,9 @@ define <4 x i32> @vtrni32_Qres(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: vtrni32_Qres:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vldr d17, [r0]
-; CHECK-NEXT:    vtrn.32 d17, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vldr d18, [r0]
+; CHECK-NEXT:    vtrn.32 d18, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    vmov r2, r3, d16
 ; CHECK-NEXT:    mov pc, lr
   %tmp1 = load <2 x i32>, ptr %A
@@ -118,9 +118,9 @@ define <4 x float> @vtrnf_Qres(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: vtrnf_Qres:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vldr d17, [r0]
-; CHECK-NEXT:    vtrn.32 d17, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vldr d18, [r0]
+; CHECK-NEXT:    vtrn.32 d18, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    vmov r2, r3, d16
 ; CHECK-NEXT:    mov pc, lr
   %tmp1 = load <2 x float>, ptr %A
@@ -283,9 +283,9 @@ define <16 x i8> @vtrni8_undef_Qres(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: vtrni8_undef_Qres:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vldr d17, [r0]
-; CHECK-NEXT:    vtrn.8 d17, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vldr d18, [r0]
+; CHECK-NEXT:    vtrn.8 d18, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    vmov r2, r3, d16
 ; CHECK-NEXT:    mov pc, lr
   %tmp1 = load <8 x i8>, ptr %A

--- a/llvm/test/CodeGen/ARM/vuzp.ll
+++ b/llvm/test/CodeGen/ARM/vuzp.ll
@@ -22,9 +22,9 @@ define <16 x i8> @vuzpi8_Qres(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: vuzpi8_Qres:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vldr d17, [r0]
-; CHECK-NEXT:    vuzp.8 d17, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vldr d18, [r0]
+; CHECK-NEXT:    vuzp.8 d18, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    vmov r2, r3, d16
 ; CHECK-NEXT:    mov pc, lr
 	%tmp1 = load <8 x i8>, ptr %A
@@ -54,9 +54,9 @@ define <8 x i16> @vuzpi16_Qres(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: vuzpi16_Qres:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vldr d17, [r0]
-; CHECK-NEXT:    vuzp.16 d17, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vldr d18, [r0]
+; CHECK-NEXT:    vuzp.16 d18, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    vmov r2, r3, d16
 ; CHECK-NEXT:    mov pc, lr
 	%tmp1 = load <4 x i16>, ptr %A
@@ -222,9 +222,9 @@ define <16 x i8> @vuzpi8_undef_Qres(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: vuzpi8_undef_Qres:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vldr d17, [r0]
-; CHECK-NEXT:    vuzp.8 d17, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vldr d18, [r0]
+; CHECK-NEXT:    vuzp.8 d18, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    vmov r2, r3, d16
 ; CHECK-NEXT:    mov pc, lr
 	%tmp1 = load <8 x i8>, ptr %A
@@ -288,10 +288,10 @@ define <4 x i32> @vuzp_lower_shufflemask_zeroed(ptr %A, ptr %B) {
 ; CHECK-NEXT:    vldr d17, [r0]
 ; CHECK-NEXT:    vorr d18, d17, d17
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vdup.32 d17, d17[0]
 ; CHECK-NEXT:    vtrn.32 d18, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vdup.32 d18, d17[0]
 ; CHECK-NEXT:    vmov r2, r3, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    mov pc, lr
 entry:
   %tmp1 = load <2 x i32>, ptr %A
@@ -322,19 +322,19 @@ define <8 x i8> @cmpsel_trunc(<8 x i8> %in0, <8 x i8> %in1, <8 x i32> %cmp0, <8 
 ; truncate from i32 to i16 and one vmovn.i16 to perform the final truncation for i8.
 ; CHECK-LABEL: cmpsel_trunc:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    add r12, sp, #16
-; CHECK-NEXT:    vld1.64 {d16, d17}, [r12]
 ; CHECK-NEXT:    mov r12, sp
+; CHECK-NEXT:    vld1.64 {d16, d17}, [r12]
+; CHECK-NEXT:    add r12, sp, #16
 ; CHECK-NEXT:    vld1.64 {d18, d19}, [r12]
-; CHECK-NEXT:    add r12, sp, #48
-; CHECK-NEXT:    vld1.64 {d20, d21}, [r12]
 ; CHECK-NEXT:    add r12, sp, #32
+; CHECK-NEXT:    vld1.64 {d20, d21}, [r12]
+; CHECK-NEXT:    add r12, sp, #48
 ; CHECK-NEXT:    vcgt.u32 q8, q10, q8
 ; CHECK-NEXT:    vld1.64 {d20, d21}, [r12]
 ; CHECK-NEXT:    vcgt.u32 q9, q10, q9
 ; CHECK-NEXT:    vmov d20, r2, r3
-; CHECK-NEXT:    vmovn.i32 d17, q8
-; CHECK-NEXT:    vmovn.i32 d16, q9
+; CHECK-NEXT:    vmovn.i32 d16, q8
+; CHECK-NEXT:    vmovn.i32 d17, q9
 ; CHECK-NEXT:    vmov d18, r0, r1
 ; CHECK-NEXT:    vmovn.i16 d16, q8
 ; CHECK-NEXT:    vbsl d16, d18, d20
@@ -453,45 +453,45 @@ define <10 x i8> @vuzp_wide_type(<10 x i8> %tr0, <10 x i8> %tr1,
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, lr}
 ; CHECK-NEXT:    push {r4, lr}
-; CHECK-NEXT:    add r12, sp, #32
-; CHECK-NEXT:    add lr, sp, #48
-; CHECK-NEXT:    vld1.32 {d17[0]}, [r12:32]
 ; CHECK-NEXT:    add r12, sp, #24
+; CHECK-NEXT:    add lr, sp, #48
 ; CHECK-NEXT:    vld1.32 {d16[0]}, [r12:32]
-; CHECK-NEXT:    add r12, sp, #56
-; CHECK-NEXT:    vld1.32 {d19[0]}, [r12:32]
+; CHECK-NEXT:    add r12, sp, #32
+; CHECK-NEXT:    vld1.32 {d17[0]}, [r12:32]
 ; CHECK-NEXT:    vld1.32 {d18[0]}, [lr:32]
-; CHECK-NEXT:    add lr, sp, #40
-; CHECK-NEXT:    vld1.32 {d20[0]}, [lr:32]
+; CHECK-NEXT:    add lr, sp, #56
+; CHECK-NEXT:    vld1.32 {d19[0]}, [lr:32]
 ; CHECK-NEXT:    ldr r12, [sp, #68]
 ; CHECK-NEXT:    ldr r4, [r12]
-; CHECK-NEXT:    vmov.32 d23[0], r4
+; CHECK-NEXT:    vmov.32 d21[0], r4
+; CHECK-NEXT:    add r4, sp, #40
+; CHECK-NEXT:    vld1.32 {d22[0]}, [r4:32]
 ; CHECK-NEXT:    add r4, sp, #64
 ; CHECK-NEXT:    vld1.32 {d24[0]}, [r4:32]
-; CHECK-NEXT:    add r4, sp, #36
-; CHECK-NEXT:    vcgt.u32 q10, q12, q10
-; CHECK-NEXT:    vld1.32 {d17[1]}, [r4:32]
 ; CHECK-NEXT:    add r4, sp, #28
+; CHECK-NEXT:    vcgt.u32 q11, q12, q11
 ; CHECK-NEXT:    vld1.32 {d16[1]}, [r4:32]
-; CHECK-NEXT:    add r4, sp, #60
-; CHECK-NEXT:    vld1.32 {d19[1]}, [r4:32]
+; CHECK-NEXT:    add r4, sp, #36
+; CHECK-NEXT:    vld1.32 {d17[1]}, [r4:32]
 ; CHECK-NEXT:    add r4, sp, #52
 ; CHECK-NEXT:    vld1.32 {d18[1]}, [r4:32]
+; CHECK-NEXT:    add r4, sp, #60
+; CHECK-NEXT:    vld1.32 {d19[1]}, [r4:32]
 ; CHECK-NEXT:    add r4, r12, #4
 ; CHECK-NEXT:    vcgt.u32 q8, q9, q8
-; CHECK-NEXT:    vmovn.i32 d19, q10
-; CHECK-NEXT:    vmov.u8 lr, d23[3]
+; CHECK-NEXT:    vmovn.i32 d19, q11
+; CHECK-NEXT:    vmov.u8 lr, d21[3]
 ; CHECK-NEXT:    vmovn.i32 d18, q8
-; CHECK-NEXT:    vmovn.i16 d22, q9
-; CHECK-NEXT:    vldr d18, .LCPI23_0
-; CHECK-NEXT:    vmov.8 d17[0], lr
-; CHECK-NEXT:    vtbl.8 d16, {d22, d23}, d18
+; CHECK-NEXT:    vldr d16, .LCPI23_0
+; CHECK-NEXT:    vmovn.i16 d20, q9
 ; CHECK-NEXT:    vmov d19, r2, r3
-; CHECK-NEXT:    vld1.8 {d17[1]}, [r4]
-; CHECK-NEXT:    add r4, sp, #8
 ; CHECK-NEXT:    vmov d18, r0, r1
-; CHECK-NEXT:    vshl.i8 q8, q8, #7
+; CHECK-NEXT:    vmov.8 d23[0], lr
+; CHECK-NEXT:    vld1.8 {d23[1]}, [r4]
+; CHECK-NEXT:    add r4, sp, #8
+; CHECK-NEXT:    vtbl.8 d22, {d20, d21}, d16
 ; CHECK-NEXT:    vld1.64 {d20, d21}, [r4]
+; CHECK-NEXT:    vshl.i8 q8, q11, #7
 ; CHECK-NEXT:    vshr.s8 q8, q8, #7
 ; CHECK-NEXT:    vbsl q8, q9, q10
 ; CHECK-NEXT:    vmov r0, r1, d16
@@ -543,44 +543,44 @@ define void @test_15xi16(ptr %next.gep, ptr %next.gep13) {
 ; CHECK-NEXT:    push {r4, r5, r6, lr}
 ; CHECK-NEXT:    add r2, r0, #2
 ; CHECK-NEXT:    add r3, r0, #6
-; CHECK-NEXT:    vld1.16 {d20, d21}, [r2]!
-; CHECK-NEXT:    vld1.16 {d16}, [r2]!
-; CHECK-NEXT:    vmov.u16 r12, d16[0]
+; CHECK-NEXT:    vld1.16 {d16, d17}, [r2]!
+; CHECK-NEXT:    vld1.16 {d18}, [r2]!
+; CHECK-NEXT:    vmov.u16 r12, d18[0]
 ; CHECK-NEXT:    ldr r2, [r2]
-; CHECK-NEXT:    vmov.u16 r4, d20[0]
-; CHECK-NEXT:    vld1.16 {d22, d23}, [r3]!
-; CHECK-NEXT:    vld1.16 {d24}, [r3]!
-; CHECK-NEXT:    vmov.u16 lr, d16[2]
-; CHECK-NEXT:    vmov.u16 r5, d22[0]
-; CHECK-NEXT:    vmov.u16 r6, d21[0]
-; CHECK-NEXT:    vmov.16 d17[0], r12
-; CHECK-NEXT:    vmov.16 d16[0], r4
-; CHECK-NEXT:    vmov.u16 r4, d24[0]
-; CHECK-NEXT:    vmov.u16 r12, d24[2]
-; CHECK-NEXT:    vmov.16 d17[1], lr
-; CHECK-NEXT:    vmov.16 d18[0], r5
-; CHECK-NEXT:    vmov.u16 r5, d20[2]
-; CHECK-NEXT:    vmov.u16 lr, d23[0]
-; CHECK-NEXT:    vmov.16 d19[0], r4
-; CHECK-NEXT:    vmov.u16 r4, d22[2]
-; CHECK-NEXT:    vmov.16 d16[1], r5
-; CHECK-NEXT:    vmov.u16 r5, d21[2]
-; CHECK-NEXT:    vmov.16 d17[2], r2
+; CHECK-NEXT:    vmov.u16 r4, d16[0]
+; CHECK-NEXT:    vld1.16 {d20, d21}, [r3]!
+; CHECK-NEXT:    vld1.16 {d19}, [r3]!
+; CHECK-NEXT:    vmov.u16 r5, d20[0]
+; CHECK-NEXT:    vmov.u16 lr, d18[2]
+; CHECK-NEXT:    vmov.u16 r6, d17[0]
+; CHECK-NEXT:    vmov.16 d23[0], r12
+; CHECK-NEXT:    vmov.16 d22[0], r4
+; CHECK-NEXT:    vmov.u16 r4, d19[0]
+; CHECK-NEXT:    vmov.u16 r12, d19[2]
+; CHECK-NEXT:    vmov.16 d24[0], r5
+; CHECK-NEXT:    vmov.u16 r5, d16[2]
+; CHECK-NEXT:    vmov.16 d23[1], lr
+; CHECK-NEXT:    vmov.u16 lr, d21[0]
+; CHECK-NEXT:    vmov.16 d25[0], r4
+; CHECK-NEXT:    vmov.u16 r4, d20[2]
+; CHECK-NEXT:    vmov.16 d22[1], r5
+; CHECK-NEXT:    vmov.u16 r5, d17[2]
+; CHECK-NEXT:    vmov.16 d23[2], r2
 ; CHECK-NEXT:    ldr r2, [r3]
-; CHECK-NEXT:    vmov.16 d16[2], r6
-; CHECK-NEXT:    vmov.16 d18[1], r4
-; CHECK-NEXT:    vmov.u16 r4, d23[2]
-; CHECK-NEXT:    vmov.16 d19[1], r12
-; CHECK-NEXT:    vmov.16 d18[2], lr
-; CHECK-NEXT:    vmov.16 d19[2], r2
+; CHECK-NEXT:    vmov.16 d22[2], r6
+; CHECK-NEXT:    vmov.16 d24[1], r4
+; CHECK-NEXT:    vmov.u16 r4, d21[2]
+; CHECK-NEXT:    vmov.16 d25[1], r12
+; CHECK-NEXT:    vmov.16 d24[2], lr
+; CHECK-NEXT:    vmov.16 d25[2], r2
 ; CHECK-NEXT:    add r2, r0, #30
 ; CHECK-NEXT:    add r0, r0, #34
-; CHECK-NEXT:    vld1.16 {d17[3]}, [r2:16]
-; CHECK-NEXT:    vmov.16 d16[3], r5
-; CHECK-NEXT:    vmov.16 d18[3], r4
-; CHECK-NEXT:    vld1.16 {d19[3]}, [r0:16]
-; CHECK-NEXT:    vst1.16 {d16, d17}, [r1]!
-; CHECK-NEXT:    vst1.16 {d18, d19}, [r1]
+; CHECK-NEXT:    vld1.16 {d23[3]}, [r2:16]
+; CHECK-NEXT:    vmov.16 d22[3], r5
+; CHECK-NEXT:    vmov.16 d24[3], r4
+; CHECK-NEXT:    vld1.16 {d25[3]}, [r0:16]
+; CHECK-NEXT:    vst1.16 {d22, d23}, [r1]!
+; CHECK-NEXT:    vst1.16 {d24, d25}, [r1]
 ; CHECK-NEXT:    pop {r4, r5, r6, lr}
 ; CHECK-NEXT:    mov pc, lr
   %a = getelementptr inbounds nuw i8, ptr %next.gep, i32 2

--- a/llvm/test/CodeGen/ARM/vzip.ll
+++ b/llvm/test/CodeGen/ARM/vzip.ll
@@ -22,9 +22,9 @@ define <16 x i8> @vzipi8_Qres(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: vzipi8_Qres:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vldr d17, [r0]
-; CHECK-NEXT:    vzip.8 d17, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vldr d18, [r0]
+; CHECK-NEXT:    vzip.8 d18, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    vmov r2, r3, d16
 ; CHECK-NEXT:    mov pc, lr
 	%tmp1 = load <8 x i8>, ptr %A
@@ -54,9 +54,9 @@ define <8 x i16> @vzipi16_Qres(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: vzipi16_Qres:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vldr d17, [r0]
-; CHECK-NEXT:    vzip.16 d17, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vldr d18, [r0]
+; CHECK-NEXT:    vzip.16 d18, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    vmov r2, r3, d16
 ; CHECK-NEXT:    mov pc, lr
 	%tmp1 = load <4 x i16>, ptr %A
@@ -222,9 +222,9 @@ define <16 x i8> @vzipi8_undef_Qres(ptr %A, ptr %B) nounwind {
 ; CHECK-LABEL: vzipi8_undef_Qres:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    vldr d16, [r1]
-; CHECK-NEXT:    vldr d17, [r0]
-; CHECK-NEXT:    vzip.8 d17, d16
-; CHECK-NEXT:    vmov r0, r1, d17
+; CHECK-NEXT:    vldr d18, [r0]
+; CHECK-NEXT:    vzip.8 d18, d16
+; CHECK-NEXT:    vmov r0, r1, d18
 ; CHECK-NEXT:    vmov r2, r3, d16
 ; CHECK-NEXT:    mov pc, lr
 	%tmp1 = load <8 x i8>, ptr %A

--- a/llvm/test/CodeGen/Thumb2/srem-seteq-illegal-types.ll
+++ b/llvm/test/CodeGen/Thumb2/srem-seteq-illegal-types.ll
@@ -68,11 +68,10 @@ define <3 x i1> @test_srem_vec(<3 x i33> %X) nounwind {
 ; CHECK-NEXT:    sub sp, #4
 ; CHECK-NEXT:    .vsave {d8, d9}
 ; CHECK-NEXT:    vpush {d8, d9}
-; CHECK-NEXT:    mov r6, r0
-; CHECK-NEXT:    and r0, r3, #1
-; CHECK-NEXT:    mov r5, r1
-; CHECK-NEXT:    rsbs r1, r0, #0
-; CHECK-NEXT:    mov r0, r2
+; CHECK-NEXT:    and r1, r1, #1
+; CHECK-NEXT:    mov r5, r3
+; CHECK-NEXT:    rsbs r1, r1, #0
+; CHECK-NEXT:    mov r6, r2
 ; CHECK-NEXT:    movs r2, #9
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    bl __aeabi_ldivmod
@@ -85,22 +84,22 @@ define <3 x i1> @test_srem_vec(<3 x i33> %X) nounwind {
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    bl __aeabi_ldivmod
 ; CHECK-NEXT:    ldr r1, [sp, #44]
-; CHECK-NEXT:    vmov.32 d8[0], r2
+; CHECK-NEXT:    vmov.32 d9[0], r2
 ; CHECK-NEXT:    ldr r0, [sp, #40]
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    and r1, r1, #1
 ; CHECK-NEXT:    mvn r2, #8
 ; CHECK-NEXT:    rsbs r1, r1, #0
 ; CHECK-NEXT:    mov.w r3, #-1
-; CHECK-NEXT:    vmov.32 d9[0], r7
+; CHECK-NEXT:    vmov.32 d8[0], r7
 ; CHECK-NEXT:    bl __aeabi_ldivmod
 ; CHECK-NEXT:    vmov.32 d16[0], r2
 ; CHECK-NEXT:    adr r0, .LCPI3_0
-; CHECK-NEXT:    vmov.32 d9[1], r4
+; CHECK-NEXT:    vmov.32 d8[1], r4
 ; CHECK-NEXT:    vld1.64 {d18, d19}, [r0:128]
 ; CHECK-NEXT:    adr r0, .LCPI3_1
 ; CHECK-NEXT:    vmov.32 d16[1], r3
-; CHECK-NEXT:    vmov.32 d8[1], r5
+; CHECK-NEXT:    vmov.32 d9[1], r5
 ; CHECK-NEXT:    vand q8, q8, q9
 ; CHECK-NEXT:    vld1.64 {d20, d21}, [r0:128]
 ; CHECK-NEXT:    adr r0, .LCPI3_2

--- a/llvm/test/Transforms/LoopStrengthReduce/ARM/ivchain-ARM.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/ARM/ivchain-ARM.ll
@@ -317,12 +317,12 @@ define hidden void @testNeon(ptr %ref_data, i32 %ref_stride, i32 %limit, ptr noc
 ; A9-NEXT:    vadd.i8 q9, q9, q10
 ; A9-NEXT:    vld1.64 {d23}, [r0], r1
 ; A9-NEXT:    vst1.8 {d22, d23}, [r5]!
-; A9-NEXT:    vld1.64 {d20}, [r0], r1
+; A9-NEXT:    vld1.64 {d24}, [r0], r1
 ; A9-NEXT:    vadd.i8 q9, q9, q11
-; A9-NEXT:    vld1.64 {d21}, [r0], lr
-; A9-NEXT:    vadd.i8 q9, q9, q10
+; A9-NEXT:    vld1.64 {d25}, [r0], lr
+; A9-NEXT:    vadd.i8 q9, q9, q12
 ; A9-NEXT:    vadd.i8 q8, q8, q9
-; A9-NEXT:    vst1.8 {d20, d21}, [r5], r4
+; A9-NEXT:    vst1.8 {d24, d25}, [r5], r4
 ; A9-NEXT:    bne .LBB4_2
 ; A9-NEXT:  @ %bb.3: @ %._crit_edge
 ; A9-NEXT:    add.w r3, r3, r12, lsl #4


### PR DESCRIPTION
This replaces the REG_SEQUENCE we use for concat_vector with INSERT_SUBREG, which whilst not perfect can produce slightly better code overall, and helps us avoid REG_SEQUENCE instructions.