### PR TITLE
[libc++] Don't make libc++ headers system headers in the modulemap

### DIFF
--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -334,6 +334,8 @@ public:
 #    endif // defined(__BIONIC__)
 #  elif defined(__GLIBC__)
   typedef unsigned short mask;
+  _LIBCPP_DIAGNOSTIC_PUSH
+  _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wmodules-ambiguous-internal-linkage")
   static const mask space  = _ISspace;
   static const mask print  = _ISprint;
   static const mask cntrl  = _IScntrl;
@@ -344,6 +346,7 @@ public:
   static const mask punct  = _ISpunct;
   static const mask xdigit = _ISxdigit;
   static const mask blank  = _ISblank;
+  _LIBCPP_DIAGNOSTIC_POP
 #    if defined(__mips__) || (BYTE_ORDER == BIG_ENDIAN)
   static const mask __regex_word = static_cast<mask>(_ISbit(15));
 #    else

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -1,6 +1,6 @@
 // This module contains headers related to the configuration of the library. These headers
 // are free of any dependency on the rest of libc++.
-module std_config [system] {
+module std_config {
   @LIBCXX_CONFIG_SITE_MODULE_ENTRY@ // generated via CMake
   textual header "__config"
   textual header "__configuration/abi.h"
@@ -18,7 +18,7 @@ module std_config [system] {
   textual header "version"
 }
 
-module std_core [system] {
+module std_core {
   module cstddef {
     module byte         { header "__cstddef/byte.h" }
     module max_align_t  {
@@ -380,7 +380,7 @@ module std_core [system] {
   }
 } // module std_core
 
-module std [system] {
+module std {
   module algorithm {
     module adjacent_find                          { header "__algorithm/adjacent_find.h" }
     module all_of                                 { header "__algorithm/all_of.h" }
@@ -1625,7 +1625,7 @@ module std [system] {
   }
 
   // TODO: Understand why this needs to live in its own module
-  module locale_base [system] {
+  module locale_base {
     header "__locale"
     export *
   }
@@ -2451,57 +2451,57 @@ module std [system] {
 // These modules need to be their own top-level modules because they depend on the system-provided
 // headers (via include_next), which are then free to include other C headers provided by libc++.
 // If we group these headers in a single module, we would end up with circular dependencies.
-module std_complex_h [system] {
+module std_complex_h {
   header "complex.h"
   export *
 }
-module std_errno_h [system] {
+module std_errno_h {
   header "errno.h"
   export *
 }
-module std_math_h [system] {
+module std_math_h {
   header "math.h"
   export *
 }
-module std_stdatomic_h [system] {
+module std_stdatomic_h {
   header "stdatomic.h"
   export *
 }
-module std_stddef_h [system] {
+module std_stddef_h {
   // <stddef.h> supports being included multiple times with different pre-defined macros
   textual header "stddef.h"
 }
-module std_stdio_h [system] {
+module std_stdio_h {
   // <stdio.h> supports being included multiple times with different pre-defined macros
   textual header "stdio.h"
 }
-module std_stdlib_h [system] {
+module std_stdlib_h {
   // <stdlib.h> supports being included multiple times with different pre-defined macros
   textual header "stdlib.h"
 }
-module std_string_h [system] {
+module std_string_h {
   header "string.h"
   export *
 }
-module std_tgmath_h [system] {
+module std_tgmath_h {
   header "tgmath.h"
   export *
 }
-module std_uchar_h [system] {
+module std_uchar_h {
   header "uchar.h"
   export *
 }
-module std_wchar_h [system] {
+module std_wchar_h {
   // <wchar.h> supports being included multiple times with different pre-defined macros
   textual header "wchar.h"
 }
-module std_wctype_h [system] {
+module std_wctype_h {
   header "wctype.h"
   export *
 }
 
 // This header is used by other C compatibility headers so it needs to be in its own module.
-module std_private_mbstate_t [system] {
+module std_private_mbstate_t {
   header "__mbstate_t.h"
   export *
 }

--- a/libcxx/include/syncstream
+++ b/libcxx/include/syncstream
@@ -196,7 +196,8 @@ public:
   // calling __inc_reference.
   //
   // pre: __ptr is in __lut_
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI lock_guard<mutex> __get_lock([[maybe_unused]] void* __ptr) noexcept {
+  _LIBCPP_NO_THREAD_SAFETY_ANALYSIS [[nodiscard]] _LIBCPP_HIDE_FROM_ABI lock_guard<mutex>
+  __get_lock([[maybe_unused]] void* __ptr) noexcept {
     shared_lock __lock{__mutex_};
     return lock_guard{__get_it(__ptr)->second.__mutex};
   }

--- a/libcxx/test/std/depr/depr.cpp.headers/ccomplex.verify.cpp
+++ b/libcxx/test/std/depr/depr.cpp.headers/ccomplex.verify.cpp
@@ -12,7 +12,6 @@
 // When built with modules, <ccomplex> should be omitted.
 
 // UNSUPPORTED: c++03, c++11, c++14
-// UNSUPPORTED: clang-modules-build
 
 // FIXME: using `#warning` causes diagnostics from system headers which include deprecated headers. This can only be
 // enabled again once https://github.com/llvm/llvm-project/pull/168041 (or a similar feature) has landed, since that

--- a/libcxx/test/std/depr/depr.cpp.headers/ciso646.verify.cpp
+++ b/libcxx/test/std/depr/depr.cpp.headers/ciso646.verify.cpp
@@ -12,7 +12,6 @@
 // When built with modules, <ciso646> should be omitted.
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// UNSUPPORTED: clang-modules-build
 
 // FIXME: using `#warning` causes diagnostics from system headers which include deprecated headers. This can only be
 // enabled again once https://github.com/llvm/llvm-project/pull/168041 (or a similar feature) has landed, since that

--- a/libcxx/test/std/depr/depr.cpp.headers/cstdalign.verify.cpp
+++ b/libcxx/test/std/depr/depr.cpp.headers/cstdalign.verify.cpp
@@ -12,7 +12,6 @@
 // When built with modules, <cstdalign> should be omitted.
 
 // UNSUPPORTED: c++03, c++11, c++14
-// UNSUPPORTED: clang-modules-build
 
 // FIXME: using `#warning` causes diagnostics from system headers which include deprecated headers. This can only be
 // enabled again once https://github.com/llvm/llvm-project/pull/168041 (or a similar feature) has landed, since that

--- a/libcxx/test/std/depr/depr.cpp.headers/cstdbool.verify.cpp
+++ b/libcxx/test/std/depr/depr.cpp.headers/cstdbool.verify.cpp
@@ -12,7 +12,6 @@
 // When built with modules, <cstdbool> should be omitted.
 
 // UNSUPPORTED: c++03, c++11, c++14
-// UNSUPPORTED: clang-modules-build
 
 // FIXME: using `#warning` causes diagnostics from system headers which include deprecated headers. This can only be
 // enabled again once https://github.com/llvm/llvm-project/pull/168041 (or a similar feature) has landed, since that

--- a/libcxx/test/std/depr/depr.cpp.headers/ctgmath.verify.cpp
+++ b/libcxx/test/std/depr/depr.cpp.headers/ctgmath.verify.cpp
@@ -12,7 +12,6 @@
 // When built with modules, <ctgmath> should be omitted.
 
 // UNSUPPORTED: c++03, c++11, c++14
-// UNSUPPORTED: clang-modules-build
 
 // FIXME: using `#warning` causes diagnostics from system headers which include deprecated headers. This can only be
 // enabled again once https://github.com/llvm/llvm-project/pull/168041 (or a similar feature) has landed, since that

--- a/libcxx/test/std/library/description/conventions/expos.only.func/synth_three_way.pass.cpp
+++ b/libcxx/test/std/library/description/conventions/expos.only.func/synth_three_way.pass.cpp
@@ -11,11 +11,8 @@
 // constexpr auto synth-three-way = ...;
 //   via std::tuple<T>(t) <=> std::tuple<U>(u), which exposes its behavior most directly
 
-#include "test_macros.h"
-
-TEST_CLANG_DIAGNOSTIC_IGNORED("-Wsign-compare")
-TEST_GCC_DIAGNOSTIC_IGNORED("-Wsign-compare")
-TEST_MSVC_DIAGNOSTIC_IGNORED(4242 4244) // Various truncation warnings
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-sign-compare
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4242 /wd4244
 
 #include <cassert>
 #include <compare>
@@ -23,6 +20,8 @@ TEST_MSVC_DIAGNOSTIC_IGNORED(4242 4244) // Various truncation warnings
 #include <tuple>
 #include <type_traits>
 #include <utility> // declval
+
+#include "test_macros.h"
 
 template <typename T, typename U = T>
 concept can_synth_three_way = requires(T t, U u) { std::tuple<T>(t) <=> std::tuple<U>(u); };

--- a/libcxx/test/std/ranges/range.factories/range.iota.view/ctor.value.bound.pass.cpp
+++ b/libcxx/test/std/ranges/range.factories/range.iota.view/ctor.value.bound.pass.cpp
@@ -8,11 +8,10 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-#include "test_macros.h"
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-sign-compare
 
-TEST_CLANG_DIAGNOSTIC_IGNORED("-Wsign-compare")
-TEST_GCC_DIAGNOSTIC_IGNORED("-Wsign-compare")
-TEST_MSVC_DIAGNOSTIC_IGNORED(4018 4389) // various "signed/unsigned mismatch"
+// various "signed/unsigned mismatch"
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4018 /wd4389
 
 // constexpr explicit iota_view(type_identity_t<W> value, type_identity_t<Bound> bound); // explicit since C++23
 

--- a/libcxx/test/std/ranges/range.factories/range.iota.view/end.pass.cpp
+++ b/libcxx/test/std/ranges/range.factories/range.iota.view/end.pass.cpp
@@ -8,11 +8,10 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-#include "test_macros.h"
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-sign-compare
 
-TEST_CLANG_DIAGNOSTIC_IGNORED("-Wsign-compare")
-TEST_GCC_DIAGNOSTIC_IGNORED("-Wsign-compare")
-TEST_MSVC_DIAGNOSTIC_IGNORED(4018 4389) // various "signed/unsigned mismatch"
+// various "signed/unsigned mismatch"
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4018 /wd4389
 
 // constexpr auto end() const;
 // constexpr iterator end() const requires same_as<W, Bound>;
@@ -21,6 +20,7 @@ TEST_MSVC_DIAGNOSTIC_IGNORED(4018 4389) // various "signed/unsigned mismatch"
 #include <ranges>
 #include <utility>
 
+#include "test_macros.h"
 #include "types.h"
 
 template<class T, class U>

--- a/libcxx/test/std/ranges/range.factories/range.iota.view/iterator/star.pass.cpp
+++ b/libcxx/test/std/ranges/range.factories/range.iota.view/iterator/star.pass.cpp
@@ -10,16 +10,16 @@
 
 // constexpr W operator*() const noexcept(is_nothrow_copy_constructible_v<W>);
 
-#include "test_macros.h"
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-sign-compare
 
-TEST_CLANG_DIAGNOSTIC_IGNORED("-Wsign-compare")
-TEST_GCC_DIAGNOSTIC_IGNORED("-Wsign-compare")
-TEST_MSVC_DIAGNOSTIC_IGNORED(4018) // various "signed/unsigned mismatch"
+// various "signed/unsigned mismatch"
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4018
 
 #include <ranges>
 #include <cassert>
 
 #include "../types.h"
+#include "test_macros.h"
 
 struct NotNoexceptCopy {
   using difference_type = int;

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.rel/three_way.pass.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.rel/three_way.pass.cpp
@@ -18,11 +18,8 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-#include "test_macros.h"
-
-TEST_CLANG_DIAGNOSTIC_IGNORED("-Wsign-compare")
-TEST_GCC_DIAGNOSTIC_IGNORED("-Wsign-compare")
-TEST_MSVC_DIAGNOSTIC_IGNORED(4242 4244)
+// ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-sign-compare
+// ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4242 /wd4244
 
 #include <array>
 #include <cassert>
@@ -33,6 +30,8 @@ TEST_MSVC_DIAGNOSTIC_IGNORED(4242 4244)
 #include <tuple>
 #include <type_traits> // std::is_constant_evaluated
 #include <utility>
+
+#include "test_macros.h"
 
 // A custom three-way result type
 struct CustomEquality {


### PR DESCRIPTION
We currently have `[system]` attributes in the modulemap, which automatically makes the headers inside the module system headers. This disables warnings when running the tests, which we generally don't want. We also already have `#pragma GCC system_header` everywhere and use `-isystem`, so there isn't much need for the tag in the modulemap as well.
