### PR TITLE
[runtimes] Don't create shared library targets when unsupported

### DIFF
--- a/clang/cmake/modules/ClangConfig.cmake.in
+++ b/clang/cmake/modules/ClangConfig.cmake.in
@@ -13,7 +13,10 @@ set(CLANG_LINK_CLANG_DYLIB "@CLANG_LINK_CLANG_DYLIB@")
 set(CLANG_DEFAULT_LINKER "@CLANG_DEFAULT_LINKER@")
 
 # Provide all our library targets to users.
-@CLANG_CONFIG_INCLUDE_EXPORTS@
+# Skip when cross-compiling, as host library targets are not usable.
+if(NOT CMAKE_CROSSCOMPILING)
+  @CLANG_CONFIG_INCLUDE_EXPORTS@
+endif()
 
 # By creating clang-tablegen-targets here, subprojects that depend on Clang's
 # tablegen-generated headers can always depend on this target whether building

--- a/cmake/Modules/CMakePolicy.cmake
+++ b/cmake/Modules/CMakePolicy.cmake
@@ -47,3 +47,9 @@ endif()
 if(POLICY CMP0182)
   cmake_policy(SET CMP0182 NEW)
 endif()
+
+# CMP0164: add_library(... SHARED ...) fails on platforms that do not support
+# shared libraries, instead of silently building a static library.
+if(POLICY CMP0164)
+  cmake_policy(SET CMP0164 NEW)
+endif()

--- a/cmake/Modules/GetTripleCMakeSystemName.cmake
+++ b/cmake/Modules/GetTripleCMakeSystemName.cmake
@@ -1,0 +1,89 @@
+#===--------------------------------------------------------------------===//
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for details.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===--------------------------------------------------------------------===//
+
+# Extract the OS component from a target triple and map it to the
+# corresponding CMake system name.
+#
+# Usage:
+#   get_triple_cmake_system_name(<triple> <out_var>)
+#
+# Parses the triple (arch-vendor-os[-env]) and sets <out_var> to the
+# CMake-style system name (e.g. "Darwin", "Linux", "Windows").
+# Unrecognized OS values are mapped to "Generic". This expects a
+# normalized triple.
+
+function(get_triple_cmake_system_name triple out_var)
+  string(REPLACE "-" ";" _components "${triple}")
+  list(LENGTH _components _len)
+  if(_len LESS 3)
+    set(${out_var} "${CMAKE_HOST_SYSTEM_NAME}" PARENT_SCOPE)
+    return()
+  endif()
+
+  list(GET _components 1 _vendor)
+  list(GET _components 2 _os)
+  set(_env "")
+  if(_len GREATER_EQUAL 4)
+    list(GET _components 3 _env)
+  endif()
+
+  # Check the special environment components first, since it can
+  # override the usual OS mapping.
+  if("${_env}" MATCHES "^android")
+    set(${out_var} "Android" PARENT_SCOPE)
+  elseif("${_env}" MATCHES "^cygnus")
+    set(${out_var} "CYGWIN" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^darwin|^macos")
+    set(${out_var} "Darwin" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^ios")
+    set(${out_var} "iOS" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^tvos")
+    set(${out_var} "tvOS" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^watchos")
+    set(${out_var} "watchOS" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^xros|^visionos")
+    set(${out_var} "visionOS" PARENT_SCOPE)
+  elseif("${_vendor}" STREQUAL "apple")
+    # Catch-all for other Apple triples (e.g. driverkit, bridgeos).
+    set(${out_var} "Darwin" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^linux")
+    set(${out_var} "Linux" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^windows")
+    set(${out_var} "Windows" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^freebsd|^kfreebsd")
+    set(${out_var} "FreeBSD" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^netbsd")
+    set(${out_var} "NetBSD" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^openbsd")
+    set(${out_var} "OpenBSD" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^dragonfly")
+    set(${out_var} "DragonFly" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^solaris")
+    set(${out_var} "SunOS" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^aix")
+    set(${out_var} "AIX" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^fuchsia")
+    set(${out_var} "Fuchsia" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^haiku")
+    set(${out_var} "Haiku" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^emscripten")
+    set(${out_var} "Emscripten" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^wasi")
+    set(${out_var} "WASI" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^rtems")
+    set(${out_var} "RTEMS" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^zos")
+    set(${out_var} "OS390" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^hurd")
+    set(${out_var} "GNU" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^serenity")
+    set(${out_var} "SerenityOS" PARENT_SCOPE)
+  else()
+    set(${out_var} "Generic" PARENT_SCOPE)
+  endif()
+endfunction()

--- a/cmake/Modules/NormalizeTriple.cmake
+++ b/cmake/Modules/NormalizeTriple.cmake
@@ -1,0 +1,36 @@
+#===--------------------------------------------------------------------===//
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for details.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===--------------------------------------------------------------------===//
+
+# Normalize a target triple using clang's -print-target-triple.
+#
+# Usage:
+#   normalize_triple(<compiler> <triple> <out_var>)
+#
+# Runs <compiler> --target=<triple> -print-target-triple to produce a
+# canonical triple. If the compiler invocation fails (e.g. the compiler
+# is not clang), <triple> is returned unchanged.
+
+function(normalize_triple compiler triple out_var)
+  set(_prefix "")
+  if(CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC")
+    set(_prefix "/clang:")
+  endif()
+  execute_process(
+    COMMAND "${compiler}" "${_prefix}--target=${triple}" "${_prefix}-print-target-triple"
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE _output
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+  if(_result EQUAL 0 AND _output)
+    set(${out_var} "${_output}" PARENT_SCOPE)
+  else()
+    # TODO(#97876): Report an error.
+    message(WARNING "Failed to execute `${compiler} ${_prefix}--target=${triple} ${_prefix}-print-target-triple` to normalize target triple.")
+    set(${out_var} "${triple}" PARENT_SCOPE)
+  endif()
+endfunction()

--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -445,6 +445,19 @@ set(LIBCXX_INSTALL_RUNTIME_DIR "${CMAKE_INSTALL_BINDIR}" CACHE STRING
 set(LIBCXX_INSTALL_MODULES_DIR "share/libc++/v1" CACHE STRING
     "Path where target-agnostic libc++ module source files should be installed.")
 
+# On platforms that don't support shared library targets
+# (e.g. CMAKE_SYSTEM_NAME of "Generic", used for GPU and other
+# baremetal targets), the shared library target is not built at
+# all. The global TARGET_SUPPORTS_SHARED_LIBS property is left
+# undefined on platforms that do support shared libraries, and only
+# set to FALSE on those that don't. See
+# https://gitlab.kitware.com/cmake/cmake/-/issues/25759.
+get_property(LIBCXX_TARGET_SUPPORTS_SHARED_LIBS GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS)
+if(NOT DEFINED LIBCXX_TARGET_SUPPORTS_SHARED_LIBS OR LIBCXX_TARGET_SUPPORTS_SHARED_LIBS)
+  set(LIBCXX_SUPPORTS_SHARED_LIBRARY ON)
+else()
+  set(LIBCXX_SUPPORTS_SHARED_LIBRARY OFF)
+endif()
 set(LIBCXX_SHARED_OUTPUT_NAME "c++" CACHE STRING "Output name for the shared libc++ runtime library.")
 set(LIBCXX_STATIC_OUTPUT_NAME "c++" CACHE STRING "Output name for the static libc++ runtime library.")
 

--- a/libcxx/src/CMakeLists.txt
+++ b/libcxx/src/CMakeLists.txt
@@ -172,6 +172,7 @@ split_list(LIBCXX_LINK_FLAGS)
 include(FindLibcCommonUtils)
 
 # Build the shared library.
+if (LIBCXX_SUPPORTS_SHARED_LIBRARY)
 add_library(cxx_shared SHARED ${LIBCXX_SOURCES} ${LIBCXX_HEADERS})
 target_include_directories(cxx_shared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(cxx_shared PUBLIC cxx-headers runtimes-libc-shared
@@ -255,6 +256,7 @@ if(WIN32 AND NOT MINGW AND NOT "${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
                           APPEND_STRING PROPERTY LINK_FLAGS " -Xlinker /MANIFEST:NO")
   endif()
 endif()
+endif(LIBCXX_SUPPORTS_SHARED_LIBRARY)
 
 set(CMAKE_STATIC_LIBRARY_PREFIX "lib")
 
@@ -324,7 +326,7 @@ endif()
 
 add_library(cxx_experimental STATIC ${LIBCXX_EXPERIMENTAL_SOURCES})
 target_link_libraries(cxx_experimental PUBLIC cxx-headers)
-if (LIBCXX_ENABLE_SHARED)
+if (LIBCXX_ENABLE_SHARED AND TARGET cxx_shared)
   target_link_libraries(cxx_experimental PRIVATE cxx_shared)
 else()
   target_link_libraries(cxx_experimental PRIVATE cxx_static)
@@ -346,14 +348,14 @@ target_compile_options(cxx_experimental PUBLIC -D_LIBCPP_ENABLE_EXPERIMENTAL)
 
 # Add a meta-target for both libraries and the experimental library.
 add_custom_target(cxx DEPENDS cxx_experimental)
-if (LIBCXX_ENABLE_SHARED)
+if (LIBCXX_ENABLE_SHARED AND TARGET cxx_shared)
   add_dependencies(cxx cxx_shared)
 endif()
 if (LIBCXX_ENABLE_STATIC)
   add_dependencies(cxx cxx_static)
 endif()
 
-if (LIBCXX_INSTALL_SHARED_LIBRARY)
+if (LIBCXX_INSTALL_SHARED_LIBRARY AND TARGET cxx_shared)
   install(TARGETS cxx_shared
     ARCHIVE DESTINATION ${LIBCXX_INSTALL_LIBRARY_DIR} COMPONENT cxx
     LIBRARY DESTINATION ${LIBCXX_INSTALL_LIBRARY_DIR} COMPONENT cxx
@@ -376,7 +378,7 @@ endif()
 
 # NOTE: This install command must go after the cxx install command otherwise
 # it will not be executed after the library symlinks are installed.
-if (LIBCXX_ENABLE_SHARED AND LIBCXX_ENABLE_ABI_LINKER_SCRIPT)
+if (LIBCXX_ENABLE_SHARED AND LIBCXX_ENABLE_ABI_LINKER_SCRIPT AND TARGET cxx_shared)
   install(FILES "$<TARGET_LINKER_FILE:cxx_shared>"
     DESTINATION ${LIBCXX_INSTALL_LIBRARY_DIR}
     COMPONENT cxx)

--- a/libcxxabi/CMakeLists.txt
+++ b/libcxxabi/CMakeLists.txt
@@ -89,6 +89,19 @@ set(LIBCXXABI_LIBDIR_SUFFIX "${LLVM_LIBDIR_SUFFIX}" CACHE STRING
 option(LIBCXXABI_INSTALL_HEADERS "Install the libc++abi headers." ON)
 option(LIBCXXABI_INSTALL_LIBRARY "Install the libc++abi library." ON)
 
+# On platforms that don't support shared library targets
+# (e.g. CMAKE_SYSTEM_NAME of "Generic", used for GPU and other
+# baremetal targets), the shared library target is not built at
+# all. The global TARGET_SUPPORTS_SHARED_LIBS property is left
+# undefined on platforms that do support shared libraries, and only
+# set to FALSE on those that don't.  See
+# https://gitlab.kitware.com/cmake/cmake/-/issues/25759.
+get_property(LIBCXXABI_TARGET_SUPPORTS_SHARED_LIBS GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS)
+if(NOT DEFINED LIBCXXABI_TARGET_SUPPORTS_SHARED_LIBS OR LIBCXXABI_TARGET_SUPPORTS_SHARED_LIBS)
+  set(LIBCXXABI_SUPPORTS_SHARED_LIBRARY ON)
+else()
+  set(LIBCXXABI_SUPPORTS_SHARED_LIBRARY OFF)
+endif()
 set(LIBCXXABI_SHARED_OUTPUT_NAME "c++abi" CACHE STRING "Output name for the shared libc++abi runtime library.")
 set(LIBCXXABI_STATIC_OUTPUT_NAME "c++abi" CACHE STRING "Output name for the static libc++abi runtime library.")
 

--- a/libcxxabi/src/CMakeLists.txt
+++ b/libcxxabi/src/CMakeLists.txt
@@ -161,6 +161,7 @@ endif()
 include(WarningFlags)
 
 # Build the shared library.
+if (LIBCXXABI_SUPPORTS_SHARED_LIBRARY)
 add_library(cxxabi_shared_objects OBJECT EXCLUDE_FROM_ALL ${LIBCXXABI_SOURCES} ${LIBCXXABI_HEADERS})
 cxx_add_warning_flags(cxxabi_shared_objects ${LIBCXXABI_ENABLE_WERROR} ${LIBCXXABI_ENABLE_PEDANTIC})
 if (LIBCXXABI_USE_LLVM_UNWINDER)
@@ -260,6 +261,7 @@ if (LIBCXXABI_ENABLE_EXCEPTIONS)
     reexport_symbols("${CMAKE_CURRENT_SOURCE_DIR}/../lib/personality-v0.exp")
   endif()
 endif()
+endif(LIBCXXABI_SUPPORTS_SHARED_LIBRARY)
 
 # Build the static library.
 add_library(cxxabi_static_objects OBJECT EXCLUDE_FROM_ALL ${LIBCXXABI_SOURCES} ${LIBCXXABI_HEADERS})
@@ -320,14 +322,14 @@ target_link_libraries(cxxabi_static
 
 # Add a meta-target for both libraries.
 add_custom_target(cxxabi)
-if (LIBCXXABI_ENABLE_SHARED)
+if (LIBCXXABI_ENABLE_SHARED AND TARGET cxxabi_shared)
   add_dependencies(cxxabi cxxabi_shared)
 endif()
 if (LIBCXXABI_ENABLE_STATIC)
   add_dependencies(cxxabi cxxabi_static)
 endif()
 
-if (LIBCXXABI_INSTALL_SHARED_LIBRARY)
+if (LIBCXXABI_INSTALL_SHARED_LIBRARY AND TARGET cxxabi_shared)
   install(TARGETS cxxabi_shared
     ARCHIVE DESTINATION ${LIBCXXABI_INSTALL_LIBRARY_DIR} COMPONENT cxxabi
     LIBRARY DESTINATION ${LIBCXXABI_INSTALL_LIBRARY_DIR} COMPONENT cxxabi

--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -137,6 +137,19 @@ set(LIBUNWIND_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}" CACHE STRING
 set(LIBUNWIND_INSTALL_RUNTIME_DIR "${CMAKE_INSTALL_BINDIR}" CACHE STRING
     "Path where built libunwind runtime libraries should be installed.")
 
+# On platforms that don't support shared library targets
+# (e.g. CMAKE_SYSTEM_NAME of "Generic", used for GPU and other
+# baremetal targets), the shared library target is not built at
+# all. The global TARGET_SUPPORTS_SHARED_LIBS property is left
+# undefined on platforms that do support shared libraries, and only
+# set to FALSE on those that don't.  See
+# https://gitlab.kitware.com/cmake/cmake/-/issues/25759.
+get_property(LIBUNWIND_TARGET_SUPPORTS_SHARED_LIBS GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS)
+if(NOT DEFINED LIBUNWIND_TARGET_SUPPORTS_SHARED_LIBS OR LIBUNWIND_TARGET_SUPPORTS_SHARED_LIBS)
+  set(LIBUNWIND_SUPPORTS_SHARED_LIBRARY ON)
+else()
+  set(LIBUNWIND_SUPPORTS_SHARED_LIBRARY OFF)
+endif()
 set(LIBUNWIND_SHARED_OUTPUT_NAME "unwind" CACHE STRING "Output name for the shared libunwind runtime library.")
 set(LIBUNWIND_STATIC_OUTPUT_NAME "unwind" CACHE STRING "Output name for the static libunwind runtime library.")
 

--- a/libunwind/src/CMakeLists.txt
+++ b/libunwind/src/CMakeLists.txt
@@ -89,7 +89,7 @@ add_link_flags_if(CXX_SUPPORTS_UNWINDLIB_EQ_NONE_FLAG --unwindlib=none)
 # MINGW_LIBRARIES is defined in config-ix.cmake
 add_library_flags_if(MINGW "${MINGW_LIBRARIES}")
 
-if (LIBUNWIND_ENABLE_SHARED AND
+if (LIBUNWIND_ENABLE_SHARED AND LIBUNWIND_SUPPORTS_SHARED_LIBRARY AND
     NOT (CXX_SUPPORTS_FNO_EXCEPTIONS_FLAG AND
          CXX_SUPPORTS_FUNWIND_TABLES_FLAG))
   message(FATAL_ERROR
@@ -125,6 +125,7 @@ set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "")
 include(WarningFlags)
 
 # Build the shared library.
+if (LIBUNWIND_SUPPORTS_SHARED_LIBRARY)
 add_library(unwind_shared_objects OBJECT EXCLUDE_FROM_ALL ${LIBUNWIND_SOURCES} ${LIBUNWIND_HEADERS})
 cxx_add_warning_flags(unwind_shared_objects ${LIBUNWIND_ENABLE_WERROR} ${LIBUNWIND_ENABLE_PEDANTIC})
 if(CMAKE_C_COMPILER_ID STREQUAL MSVC)
@@ -158,6 +159,7 @@ set_target_properties(unwind_shared
     VERSION     "${LIBUNWIND_LIBRARY_VERSION}"
     SOVERSION   "1"
 )
+endif(LIBUNWIND_SUPPORTS_SHARED_LIBRARY)
 
 # Build the static library.
 add_library(unwind_static_objects OBJECT EXCLUDE_FROM_ALL ${LIBUNWIND_SOURCES} ${LIBUNWIND_HEADERS})
@@ -200,14 +202,14 @@ set_target_properties(unwind_static
 
 # Add a meta-target for both libraries.
 add_custom_target(unwind)
-if (LIBUNWIND_ENABLE_SHARED)
+if (LIBUNWIND_ENABLE_SHARED AND TARGET unwind_shared)
   add_dependencies(unwind unwind_shared)
 endif()
 if (LIBUNWIND_ENABLE_STATIC)
   add_dependencies(unwind unwind_static)
 endif()
 
-if (LIBUNWIND_INSTALL_SHARED_LIBRARY)
+if (LIBUNWIND_INSTALL_SHARED_LIBRARY AND TARGET unwind_shared)
   install(TARGETS unwind_shared
     ARCHIVE DESTINATION ${LIBUNWIND_INSTALL_LIBRARY_DIR} COMPONENT unwind
     LIBRARY DESTINATION ${LIBUNWIND_INSTALL_LIBRARY_DIR} COMPONENT unwind

--- a/llvm/cmake/modules/Findzstd.cmake
+++ b/llvm/cmake/modules/Findzstd.cmake
@@ -32,7 +32,19 @@ if(zstd_FOUND)
   if(zstd_LIBRARY MATCHES "${zstd_STATIC_LIBRARY_SUFFIX}$" AND NOT zstd_LIBRARY MATCHES "\\.dll\\.a$")
     set(zstd_STATIC_LIBRARY "${zstd_LIBRARY}")
   elseif (NOT TARGET zstd::libzstd_shared)
-    add_library(zstd::libzstd_shared SHARED IMPORTED)
+    # An IMPORTED target only references an already-built library, but under
+    # CMP0164 NEW the SHARED keyword is rejected on platforms that do not
+    # support shared libraries (e.g. CMAKE_SYSTEM_NAME of "Generic"). Use
+    # UNKNOWN IMPORTED there since we just link against the found library file.
+    get_property(zstd_target_supports_shared_libs
+      GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS)
+    if(DEFINED zstd_target_supports_shared_libs AND
+       NOT zstd_target_supports_shared_libs)
+      add_library(zstd::libzstd_shared UNKNOWN IMPORTED)
+    else()
+      add_library(zstd::libzstd_shared SHARED IMPORTED)
+    endif()
+    unset(zstd_target_supports_shared_libs)
     if(WIN32 OR CYGWIN)
       include(GNUInstallDirs) # For CMAKE_INSTALL_LIBDIR and friends.
       # IMPORTED_LOCATION is the path to the DLL and IMPORTED_IMPLIB is the "library".

--- a/llvm/cmake/modules/Findzstd.cmake
+++ b/llvm/cmake/modules/Findzstd.cmake
@@ -32,19 +32,7 @@ if(zstd_FOUND)
   if(zstd_LIBRARY MATCHES "${zstd_STATIC_LIBRARY_SUFFIX}$" AND NOT zstd_LIBRARY MATCHES "\\.dll\\.a$")
     set(zstd_STATIC_LIBRARY "${zstd_LIBRARY}")
   elseif (NOT TARGET zstd::libzstd_shared)
-    # An IMPORTED target only references an already-built library, but under
-    # CMP0164 NEW the SHARED keyword is rejected on platforms that do not
-    # support shared libraries (e.g. CMAKE_SYSTEM_NAME of "Generic"). Use
-    # UNKNOWN IMPORTED there since we just link against the found library file.
-    get_property(zstd_target_supports_shared_libs
-      GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS)
-    if(DEFINED zstd_target_supports_shared_libs AND
-       NOT zstd_target_supports_shared_libs)
-      add_library(zstd::libzstd_shared UNKNOWN IMPORTED)
-    else()
-      add_library(zstd::libzstd_shared SHARED IMPORTED)
-    endif()
-    unset(zstd_target_supports_shared_libs)
+    add_library(zstd::libzstd_shared SHARED IMPORTED)
     if(WIN32 OR CYGWIN)
       include(GNUInstallDirs) # For CMAKE_INSTALL_LIBDIR and friends.
       # IMPORTED_LOCATION is the path to the DLL and IMPORTED_IMPLIB is the "library".

--- a/llvm/cmake/modules/LLVMConfig.cmake.in
+++ b/llvm/cmake/modules/LLVMConfig.cmake.in
@@ -56,52 +56,47 @@ set(LLVM_ENABLE_ASSERTIONS @LLVM_ENABLE_ASSERTIONS@)
 set(LLVM_ENABLE_EH @LLVM_ENABLE_EH@)
 
 set(LLVM_ENABLE_FFI @LLVM_ENABLE_FFI@)
-if(LLVM_ENABLE_FFI)
-  find_package(FFI)
-endif()
-
 set(LLVM_ENABLE_RTTI @LLVM_ENABLE_RTTI@)
-
-set(LLVM_ENABLE_LIBEDIT @HAVE_LIBEDIT@)
-if(LLVM_ENABLE_LIBEDIT)
-  find_package(LibEdit)
-endif()
-
 set(LLVM_ENABLE_THREADS @LLVM_ENABLE_THREADS@)
-
 set(LLVM_ENABLE_UNWIND_TABLES @LLVM_ENABLE_UNWIND_TABLES@)
-
 set(LLVM_ENABLE_ZLIB @LLVM_ENABLE_ZLIB@)
-if(LLVM_ENABLE_ZLIB)
-  set(ZLIB_ROOT @ZLIB_ROOT@)
-  find_package(ZLIB)
-endif()
-
 set(LLVM_ENABLE_ZSTD @LLVM_ENABLE_ZSTD@)
-if(LLVM_ENABLE_ZSTD)
-  find_package(zstd)
-endif()
-
 set(LLVM_ENABLE_LIBXML2 @LLVM_ENABLE_LIBXML2@)
-if(LLVM_ENABLE_LIBXML2)
-  find_package(LibXml2)
-endif()
-
 set(LLVM_ENABLE_CURL @LLVM_ENABLE_CURL@)
-if(LLVM_ENABLE_CURL)
-  find_package(CURL)
-endif()
-
 set(LLVM_ENABLE_HTTPLIB @LLVM_ENABLE_HTTPLIB@)
-if(LLVM_ENABLE_HTTPLIB)
-  find_package(httplib)
-endif()
-
 set(LLVM_WITH_Z3 @LLVM_WITH_Z3@)
-
 set(LLVM_ENABLE_DIA_SDK @LLVM_ENABLE_DIA_SDK@)
-if(LLVM_ENABLE_DIA_SDK)
-  find_package(DIASDK)
+set(LLVM_ENABLE_LIBEDIT @HAVE_LIBEDIT@)
+
+# These are host libraries that LLVM was built with. Only find them when the
+# consumer can actually use them (i.e. not when cross-compiling for an
+# incompatible target).
+if(NOT CMAKE_CROSSCOMPILING)
+  if(LLVM_ENABLE_FFI)
+    find_package(FFI)
+  endif()
+  if(LLVM_ENABLE_LIBEDIT)
+    find_package(LibEdit)
+  endif()
+  if(LLVM_ENABLE_ZLIB)
+    set(ZLIB_ROOT @ZLIB_ROOT@)
+    find_package(ZLIB)
+  endif()
+  if(LLVM_ENABLE_ZSTD)
+    find_package(zstd)
+  endif()
+  if(LLVM_ENABLE_LIBXML2)
+    find_package(LibXml2)
+  endif()
+  if(LLVM_ENABLE_CURL)
+    find_package(CURL)
+  endif()
+  if(LLVM_ENABLE_HTTPLIB)
+    find_package(httplib)
+  endif()
+  if(LLVM_ENABLE_DIA_SDK)
+    find_package(DIASDK)
+  endif()
 endif()
 
 set(LLVM_NATIVE_ARCH @LLVM_NATIVE_ARCH@)
@@ -152,7 +147,7 @@ set(LLVM_ENABLE_SHARED_LIBS @BUILD_SHARED_LIBS@)
 set(LLVM_DEFAULT_EXTERNAL_LIT "@LLVM_CONFIG_DEFAULT_EXTERNAL_LIT@")
 set(LLVM_LIT_ARGS "@LLVM_LIT_ARGS@")
 
-if(NOT TARGET LLVMSupport)
+if(NOT TARGET LLVMSupport AND NOT CMAKE_CROSSCOMPILING)
   @LLVM_CONFIG_INCLUDE_EXPORTS@
   @llvm_config_include_buildtree_only_exports@
 endif()

--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -84,12 +84,6 @@ function(llvm_ExternalProject_Add name source_dir)
     endif()
   endforeach()
 
-  # If CMAKE_SYSTEM_NAME is not set explicitly in the arguments passed to us,
-  # reflect CMake's own default.
-  if (NOT _cmake_system_name)
-    set(_cmake_system_name "${CMAKE_HOST_SYSTEM_NAME}")
-  endif()
-
   if(NOT ARG_TARGET_TRIPLE)
     set(target_triple ${LLVM_DEFAULT_TARGET_TRIPLE})
   else()
@@ -97,6 +91,36 @@ function(llvm_ExternalProject_Add name source_dir)
   endif()
 
   is_msvc_triple(is_msvc_target "${target_triple}")
+
+  if(ARG_USE_TOOLCHAIN AND NOT CMAKE_CROSSCOMPILING)
+    set(_cmake_c_compiler "${LLVM_RUNTIME_OUTPUT_INTDIR}/clang${CMAKE_EXECUTABLE_SUFFIX}")
+    set(_cmake_cxx_compiler "${LLVM_RUNTIME_OUTPUT_INTDIR}/clang++${CMAKE_EXECUTABLE_SUFFIX}")
+    set(_cmake_asm_compiler "${_cmake_c_compiler}")
+    if(is_msvc_target)
+      set(_cmake_c_compiler "${LLVM_RUNTIME_OUTPUT_INTDIR}/clang-cl${CMAKE_EXECUTABLE_SUFFIX}")
+      set(_cmake_cxx_compiler "${_cmake_c_compiler}")
+      set(_cmake_asm_compiler "${_cmake_c_compiler}")
+    endif()
+  else()
+    set(_cmake_c_compiler "${CMAKE_C_COMPILER}")
+    set(_cmake_cxx_compiler "${CMAKE_CXX_COMPILER}")
+    set(_cmake_asm_compiler "${CMAKE_C_COMPILER}")
+  endif()
+
+  # If CMAKE_SYSTEM_NAME is not set explicitly in the arguments passed to us,
+  # derive it from the target triple if available, otherwise reflect CMake's
+  # own default. This ensures that cross-compilation targets get the correct
+  # platform files (e.g. AMDGPU targets on a Darwin host won't get macOS flags).
+  if (NOT _cmake_system_name)
+    if(ARG_TARGET_TRIPLE)
+      include(NormalizeTriple)
+      normalize_triple("${_cmake_c_compiler}" "${ARG_TARGET_TRIPLE}" _normalized_triple)
+      include(GetTripleCMakeSystemName)
+      get_triple_cmake_system_name("${_normalized_triple}" _cmake_system_name)
+    else()
+      set(_cmake_system_name "${CMAKE_HOST_SYSTEM_NAME}")
+    endif()
+  endif()
 
   if(NOT ARG_TOOLCHAIN_TOOLS)
     set(ARG_TOOLCHAIN_TOOLS clang)
@@ -231,15 +255,9 @@ function(llvm_ExternalProject_Add name source_dir)
 
   if(ARG_USE_TOOLCHAIN AND NOT CMAKE_CROSSCOMPILING)
     if(CLANG_IN_TOOLCHAIN)
-      if(is_msvc_target)
-        set(compiler_args -DCMAKE_C_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang-cl${CMAKE_EXECUTABLE_SUFFIX}
-                          -DCMAKE_CXX_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang-cl${CMAKE_EXECUTABLE_SUFFIX}
-                          -DCMAKE_ASM_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang-cl${CMAKE_EXECUTABLE_SUFFIX})
-      else()
-        set(compiler_args -DCMAKE_C_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang${CMAKE_EXECUTABLE_SUFFIX}
-                          -DCMAKE_CXX_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang++${CMAKE_EXECUTABLE_SUFFIX}
-                          -DCMAKE_ASM_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang${CMAKE_EXECUTABLE_SUFFIX})
-      endif()
+      set(compiler_args -DCMAKE_C_COMPILER=${_cmake_c_compiler}
+                        -DCMAKE_CXX_COMPILER=${_cmake_cxx_compiler}
+                        -DCMAKE_ASM_COMPILER=${_cmake_asm_compiler})
     endif()
     if(FLANG_IN_TOOLCHAIN)
       list(APPEND compiler_args -DCMAKE_Fortran_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/flang${CMAKE_EXECUTABLE_SUFFIX})
@@ -379,6 +397,22 @@ function(llvm_ExternalProject_Add name source_dir)
     list(APPEND compiler_args -DCMAKE_CXX_COMPILER_TARGET=${ARG_TARGET_TRIPLE})
     list(APPEND compiler_args -DCMAKE_Fortran_COMPILER_TARGET=${ARG_TARGET_TRIPLE})
     list(APPEND compiler_args -DCMAKE_ASM_COMPILER_TARGET=${ARG_TARGET_TRIPLE})
+
+    # Pass CMAKE_SYSTEM_NAME derived from the target triple so the sub-build
+    # loads the correct platform files instead of the host's.
+    if(NOT "${_cmake_system_name}" STREQUAL "${CMAKE_HOST_SYSTEM_NAME}")
+      list(APPEND compiler_args -DCMAKE_SYSTEM_NAME=${_cmake_system_name})
+    endif()
+
+    # Forward Darwin-specific variables only when targeting Darwin.
+    if("${_cmake_system_name}" STREQUAL "Darwin")
+      if(CMAKE_OSX_SYSROOT)
+        list(APPEND compiler_args -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT})
+      endif()
+      if(CMAKE_OSX_DEPLOYMENT_TARGET)
+        list(APPEND compiler_args -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+      endif()
+    endif()
   endif()
 
   if(CMAKE_VERBOSE_MAKEFILE)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -4,10 +4,6 @@
 # the two files.
 
 set(COMMON_CMAKE_ARGS "-DHAVE_LLVM_LIT=ON;-DCLANG_RESOURCE_DIR=${CLANG_RESOURCE_DIR};-DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX}")
-if(APPLE AND CMAKE_OSX_SYSROOT AND (LLVM_TARGET_TRIPLE STREQUAL LLVM_HOST_TRIPLE))
-  # Only propagate the host sysroot for native runtimes builds.
-  list(APPEND RUNTIMES_CMAKE_ARGS "-DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}")
-endif()
 foreach(proj ${LLVM_ENABLE_RUNTIMES})
   string(TOUPPER "${proj}" canon_name)
   STRING(REGEX REPLACE "-" "_" canon_name ${canon_name})

--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -228,22 +228,8 @@ message(STATUS "LLVM default target triple: ${LLVM_DEFAULT_TARGET_TRIPLE}")
 set(LLVM_TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}")
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-  set(option_prefix "")
-  if (CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC")
-    set(option_prefix "/clang:")
-  endif()
-  set(print_target_triple ${CMAKE_C_COMPILER} ${option_prefix}--target=${LLVM_DEFAULT_TARGET_TRIPLE} ${option_prefix}-print-target-triple)
-  execute_process(COMMAND ${print_target_triple}
-    RESULT_VARIABLE result
-    OUTPUT_VARIABLE output
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if(result EQUAL 0)
-    set(LLVM_DEFAULT_TARGET_TRIPLE ${output})
-  else()
-    string(REPLACE ";" " " print_target_triple "${print_target_triple}")
-    # TODO(#97876): Report an error.
-    message(WARNING "Failed to execute `${print_target_triple}` to normalize target triple.")
-  endif()
+  include(NormalizeTriple)
+  normalize_triple("${CMAKE_C_COMPILER}" "${LLVM_DEFAULT_TARGET_TRIPLE}" LLVM_DEFAULT_TARGET_TRIPLE)
 endif()
 
 # Determine output and install paths based on LLVM_TARGET_TRIPLE


### PR DESCRIPTION
[runtimes] Don't create shared library targets when unsupported

On platforms that don't support shared libraries (e.g. CMAKE_SYSTEM_NAME of
"Generic", used for GPU and other baremetal targets), CMake's
Platform/Generic.cmake sets the global TARGET_SUPPORTS_SHARED_LIBS property to
FALSE. Under CMP0164's OLD behavior (the default, since the runtimes set
cmake_minimum_required(3.20)), CMake silently demotes SHARED library targets to
STATIC archives. libcxx, libcxxabi and libunwind always create their shared
target, so after demotion both the shared and static targets emit e.g.
"libc++abi.a" and Ninja fails with "multiple rules generate ...".

Rather than papering over the collision with a distinct output name, skip
creating the shared library targets entirely when the platform does not support
them, gating on the TARGET_SUPPORTS_SHARED_LIBS property (left undefined on
platforms that do support shared libraries). The few consumers of the shared
targets are guarded with TARGET checks so they fall back to the static library
or are skipped.

Also set policy CMP0164 to NEW so that any future unguarded
add_library(... SHARED ...) on an unsupported platform fails at configure time
instead of silently producing a colliding static archive.

See https://gitlab.kitware.com/cmake/cmake/-/issues/25759.

The bodies of the newly-conditional blocks are left at their original
indentation to keep this diff minimal. A follow-up commit will fix the
indentation. This was mostly AI generated with some comment fixups.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>

Reapply "runtimes: Pass CMAKE_SYSTEM_NAME based on target triple" (#205133)

This reverts commit 08c728e8528c9584bc1fe0f46bbdd657e368be91.

Reapply after runtimes build fixes on platforms without shared libraries.

XXX - Findzstd

Revert "XXX - Findzstd"

This reverts commit 2d88d3c09aa78676c9bc4c6ede6f83fb0af58522.