### PR TITLE
[PlaceSafepoints] Report usage error instead of asserting on invalid gc.safepoint_poll

### DIFF
--- a/llvm/lib/Transforms/Scalar/PlaceSafepoints.cpp
+++ b/llvm/lib/Transforms/Scalar/PlaceSafepoints.cpp
@@ -629,7 +629,8 @@ InsertSafepointPoll(BasicBlock::iterator InsertBefore,
   // path call - where we need to insert a safepoint (parsepoint).
 
   auto *F = M->getFunction(GCSafepointPollName);
-  assert(F && "gc.safepoint_poll function is missing");
+  if (!F)
+    reportFatalUsageError("gc.safepoint_poll function is missing");
   assert(F->getFunctionType() ==
              FunctionType::get(Type::getVoidTy(M->getContext()), false) &&
          "gc.safepoint_poll declared with wrong type");

--- a/llvm/test/Transforms/PlaceSafepoints/missing-safepoint-poll.ll
+++ b/llvm/test/Transforms/PlaceSafepoints/missing-safepoint-poll.ll
@@ -1,0 +1,7 @@
+; RUN: not opt < %s -S -passes=place-safepoints 2>&1 | FileCheck %s
+; CHECK: LLVM ERROR: gc.safepoint_poll function is missing
+
+define void @test_libcall() gc "statepoint-example" {
+entry:
+  ret void
+}

--- a/llvm/test/Transforms/PlaceSafepoints/safepoint-poll-empty.ll
+++ b/llvm/test/Transforms/PlaceSafepoints/safepoint-poll-empty.ll
@@ -1,0 +1,10 @@
+; REQUIRES: asserts
+; RUN: not --crash opt < %s -S -passes=place-safepoints 2>&1 | FileCheck %s
+; CHECK: gc.safepoint_poll must be a non-empty function
+
+define void @test_libcall() gc "statepoint-example" {
+entry:
+  ret void
+}
+
+declare void @gc.safepoint_poll()

--- a/llvm/test/Transforms/PlaceSafepoints/safepoint-poll-wrong-type.ll
+++ b/llvm/test/Transforms/PlaceSafepoints/safepoint-poll-wrong-type.ll
@@ -1,0 +1,13 @@
+; REQUIRES: asserts
+; RUN: not --crash opt < %s -S -passes=place-safepoints 2>&1 | FileCheck %s
+; CHECK: gc.safepoint_poll declared with wrong type
+
+define void @test_libcall() gc "statepoint-example" {
+entry:
+  ret void
+}
+
+define i32 @gc.safepoint_poll() {
+entry:
+  ret i32 0
+}


### PR DESCRIPTION
When opt runs place-safepoints on valid IR that needs a safepoint poll but does not define a valid gc.safepoint_poll, InsertSafepointPoll asserted and crashed. Since this is reachable from user input, replace the precondition asserts with reportFatalUsageError so the tool reports a clean error and exits instead of crashing. These now report in all builds, not only assertions-enabled builds.

The missing-function path has a regression test; the wrong-type and empty-function paths are handled the same way.

Fixes #191975