### PR TITLE
Reapply "runtimes: Pass CMAKE_SYSTEM_NAME based on target triple" (#205133)

### DIFF
--- a/clang/cmake/modules/ClangConfig.cmake.in
+++ b/clang/cmake/modules/ClangConfig.cmake.in
@@ -13,7 +13,10 @@ set(CLANG_LINK_CLANG_DYLIB "@CLANG_LINK_CLANG_DYLIB@")
 set(CLANG_DEFAULT_LINKER "@CLANG_DEFAULT_LINKER@")
 
 # Provide all our library targets to users.
-@CLANG_CONFIG_INCLUDE_EXPORTS@
+# Skip when cross-compiling, as host library targets are not usable.
+if(NOT CMAKE_CROSSCOMPILING)
+  @CLANG_CONFIG_INCLUDE_EXPORTS@
+endif()
 
 # By creating clang-tablegen-targets here, subprojects that depend on Clang's
 # tablegen-generated headers can always depend on this target whether building

--- a/cmake/Modules/GetTripleCMakeSystemName.cmake
+++ b/cmake/Modules/GetTripleCMakeSystemName.cmake
@@ -1,0 +1,89 @@
+#===--------------------------------------------------------------------===//
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for details.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===--------------------------------------------------------------------===//
+
+# Extract the OS component from a target triple and map it to the
+# corresponding CMake system name.
+#
+# Usage:
+#   get_triple_cmake_system_name(<triple> <out_var>)
+#
+# Parses the triple (arch-vendor-os[-env]) and sets <out_var> to the
+# CMake-style system name (e.g. "Darwin", "Linux", "Windows").
+# Unrecognized OS values are mapped to "Generic". This expects a
+# normalized triple.
+
+function(get_triple_cmake_system_name triple out_var)
+  string(REPLACE "-" ";" _components "${triple}")
+  list(LENGTH _components _len)
+  if(_len LESS 3)
+    set(${out_var} "${CMAKE_HOST_SYSTEM_NAME}" PARENT_SCOPE)
+    return()
+  endif()
+
+  list(GET _components 1 _vendor)
+  list(GET _components 2 _os)
+  set(_env "")
+  if(_len GREATER_EQUAL 4)
+    list(GET _components 3 _env)
+  endif()
+
+  # Check the special environment components first, since it can
+  # override the usual OS mapping.
+  if("${_env}" MATCHES "^android")
+    set(${out_var} "Android" PARENT_SCOPE)
+  elseif("${_env}" MATCHES "^cygnus")
+    set(${out_var} "CYGWIN" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^darwin|^macos")
+    set(${out_var} "Darwin" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^ios")
+    set(${out_var} "iOS" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^tvos")
+    set(${out_var} "tvOS" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^watchos")
+    set(${out_var} "watchOS" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^xros|^visionos")
+    set(${out_var} "visionOS" PARENT_SCOPE)
+  elseif("${_vendor}" STREQUAL "apple")
+    # Catch-all for other Apple triples (e.g. driverkit, bridgeos).
+    set(${out_var} "Darwin" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^linux")
+    set(${out_var} "Linux" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^windows")
+    set(${out_var} "Windows" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^freebsd|^kfreebsd")
+    set(${out_var} "FreeBSD" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^netbsd")
+    set(${out_var} "NetBSD" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^openbsd")
+    set(${out_var} "OpenBSD" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^dragonfly")
+    set(${out_var} "DragonFly" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^solaris")
+    set(${out_var} "SunOS" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^aix")
+    set(${out_var} "AIX" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^fuchsia")
+    set(${out_var} "Fuchsia" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^haiku")
+    set(${out_var} "Haiku" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^emscripten")
+    set(${out_var} "Emscripten" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^wasi")
+    set(${out_var} "WASI" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^rtems")
+    set(${out_var} "RTEMS" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^zos")
+    set(${out_var} "OS390" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^hurd")
+    set(${out_var} "GNU" PARENT_SCOPE)
+  elseif("${_os}" MATCHES "^serenity")
+    set(${out_var} "SerenityOS" PARENT_SCOPE)
+  else()
+    set(${out_var} "Generic" PARENT_SCOPE)
+  endif()
+endfunction()

--- a/cmake/Modules/NormalizeTriple.cmake
+++ b/cmake/Modules/NormalizeTriple.cmake
@@ -1,0 +1,36 @@
+#===--------------------------------------------------------------------===//
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for details.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===--------------------------------------------------------------------===//
+
+# Normalize a target triple using clang's -print-target-triple.
+#
+# Usage:
+#   normalize_triple(<compiler> <triple> <out_var>)
+#
+# Runs <compiler> --target=<triple> -print-target-triple to produce a
+# canonical triple. If the compiler invocation fails (e.g. the compiler
+# is not clang), <triple> is returned unchanged.
+
+function(normalize_triple compiler triple out_var)
+  set(_prefix "")
+  if(CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC")
+    set(_prefix "/clang:")
+  endif()
+  execute_process(
+    COMMAND "${compiler}" "${_prefix}--target=${triple}" "${_prefix}-print-target-triple"
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE _output
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+  if(_result EQUAL 0 AND _output)
+    set(${out_var} "${_output}" PARENT_SCOPE)
+  else()
+    # TODO(#97876): Report an error.
+    message(WARNING "Failed to execute `${compiler} ${_prefix}--target=${triple} ${_prefix}-print-target-triple` to normalize target triple.")
+    set(${out_var} "${triple}" PARENT_SCOPE)
+  endif()
+endfunction()

--- a/llvm/cmake/modules/LLVMConfig.cmake.in
+++ b/llvm/cmake/modules/LLVMConfig.cmake.in
@@ -56,52 +56,47 @@ set(LLVM_ENABLE_ASSERTIONS @LLVM_ENABLE_ASSERTIONS@)
 set(LLVM_ENABLE_EH @LLVM_ENABLE_EH@)
 
 set(LLVM_ENABLE_FFI @LLVM_ENABLE_FFI@)
-if(LLVM_ENABLE_FFI)
-  find_package(FFI)
-endif()
-
 set(LLVM_ENABLE_RTTI @LLVM_ENABLE_RTTI@)
-
-set(LLVM_ENABLE_LIBEDIT @HAVE_LIBEDIT@)
-if(LLVM_ENABLE_LIBEDIT)
-  find_package(LibEdit)
-endif()
-
 set(LLVM_ENABLE_THREADS @LLVM_ENABLE_THREADS@)
-
 set(LLVM_ENABLE_UNWIND_TABLES @LLVM_ENABLE_UNWIND_TABLES@)
-
 set(LLVM_ENABLE_ZLIB @LLVM_ENABLE_ZLIB@)
-if(LLVM_ENABLE_ZLIB)
-  set(ZLIB_ROOT @ZLIB_ROOT@)
-  find_package(ZLIB)
-endif()
-
 set(LLVM_ENABLE_ZSTD @LLVM_ENABLE_ZSTD@)
-if(LLVM_ENABLE_ZSTD)
-  find_package(zstd)
-endif()
-
 set(LLVM_ENABLE_LIBXML2 @LLVM_ENABLE_LIBXML2@)
-if(LLVM_ENABLE_LIBXML2)
-  find_package(LibXml2)
-endif()
-
 set(LLVM_ENABLE_CURL @LLVM_ENABLE_CURL@)
-if(LLVM_ENABLE_CURL)
-  find_package(CURL)
-endif()
-
 set(LLVM_ENABLE_HTTPLIB @LLVM_ENABLE_HTTPLIB@)
-if(LLVM_ENABLE_HTTPLIB)
-  find_package(httplib)
-endif()
-
 set(LLVM_WITH_Z3 @LLVM_WITH_Z3@)
-
 set(LLVM_ENABLE_DIA_SDK @LLVM_ENABLE_DIA_SDK@)
-if(LLVM_ENABLE_DIA_SDK)
-  find_package(DIASDK)
+set(LLVM_ENABLE_LIBEDIT @HAVE_LIBEDIT@)
+
+# These are host libraries that LLVM was built with. Only find them when the
+# consumer can actually use them (i.e. not when cross-compiling for an
+# incompatible target).
+if(NOT CMAKE_CROSSCOMPILING)
+  if(LLVM_ENABLE_FFI)
+    find_package(FFI)
+  endif()
+  if(LLVM_ENABLE_LIBEDIT)
+    find_package(LibEdit)
+  endif()
+  if(LLVM_ENABLE_ZLIB)
+    set(ZLIB_ROOT @ZLIB_ROOT@)
+    find_package(ZLIB)
+  endif()
+  if(LLVM_ENABLE_ZSTD)
+    find_package(zstd)
+  endif()
+  if(LLVM_ENABLE_LIBXML2)
+    find_package(LibXml2)
+  endif()
+  if(LLVM_ENABLE_CURL)
+    find_package(CURL)
+  endif()
+  if(LLVM_ENABLE_HTTPLIB)
+    find_package(httplib)
+  endif()
+  if(LLVM_ENABLE_DIA_SDK)
+    find_package(DIASDK)
+  endif()
 endif()
 
 set(LLVM_NATIVE_ARCH @LLVM_NATIVE_ARCH@)
@@ -152,7 +147,7 @@ set(LLVM_ENABLE_SHARED_LIBS @BUILD_SHARED_LIBS@)
 set(LLVM_DEFAULT_EXTERNAL_LIT "@LLVM_CONFIG_DEFAULT_EXTERNAL_LIT@")
 set(LLVM_LIT_ARGS "@LLVM_LIT_ARGS@")
 
-if(NOT TARGET LLVMSupport)
+if(NOT TARGET LLVMSupport AND NOT CMAKE_CROSSCOMPILING)
   @LLVM_CONFIG_INCLUDE_EXPORTS@
   @llvm_config_include_buildtree_only_exports@
 endif()

--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -84,12 +84,6 @@ function(llvm_ExternalProject_Add name source_dir)
     endif()
   endforeach()
 
-  # If CMAKE_SYSTEM_NAME is not set explicitly in the arguments passed to us,
-  # reflect CMake's own default.
-  if (NOT _cmake_system_name)
-    set(_cmake_system_name "${CMAKE_HOST_SYSTEM_NAME}")
-  endif()
-
   if(NOT ARG_TARGET_TRIPLE)
     set(target_triple ${LLVM_DEFAULT_TARGET_TRIPLE})
   else()
@@ -97,6 +91,36 @@ function(llvm_ExternalProject_Add name source_dir)
   endif()
 
   is_msvc_triple(is_msvc_target "${target_triple}")
+
+  if(ARG_USE_TOOLCHAIN AND NOT CMAKE_CROSSCOMPILING)
+    set(_cmake_c_compiler "${LLVM_RUNTIME_OUTPUT_INTDIR}/clang${CMAKE_EXECUTABLE_SUFFIX}")
+    set(_cmake_cxx_compiler "${LLVM_RUNTIME_OUTPUT_INTDIR}/clang++${CMAKE_EXECUTABLE_SUFFIX}")
+    set(_cmake_asm_compiler "${_cmake_c_compiler}")
+    if(is_msvc_target)
+      set(_cmake_c_compiler "${LLVM_RUNTIME_OUTPUT_INTDIR}/clang-cl${CMAKE_EXECUTABLE_SUFFIX}")
+      set(_cmake_cxx_compiler "${_cmake_c_compiler}")
+      set(_cmake_asm_compiler "${_cmake_c_compiler}")
+    endif()
+  else()
+    set(_cmake_c_compiler "${CMAKE_C_COMPILER}")
+    set(_cmake_cxx_compiler "${CMAKE_CXX_COMPILER}")
+    set(_cmake_asm_compiler "${CMAKE_C_COMPILER}")
+  endif()
+
+  # If CMAKE_SYSTEM_NAME is not set explicitly in the arguments passed to us,
+  # derive it from the target triple if available, otherwise reflect CMake's
+  # own default. This ensures that cross-compilation targets get the correct
+  # platform files (e.g. AMDGPU targets on a Darwin host won't get macOS flags).
+  if (NOT _cmake_system_name)
+    if(ARG_TARGET_TRIPLE)
+      include(NormalizeTriple)
+      normalize_triple("${_cmake_c_compiler}" "${ARG_TARGET_TRIPLE}" _normalized_triple)
+      include(GetTripleCMakeSystemName)
+      get_triple_cmake_system_name("${_normalized_triple}" _cmake_system_name)
+    else()
+      set(_cmake_system_name "${CMAKE_HOST_SYSTEM_NAME}")
+    endif()
+  endif()
 
   if(NOT ARG_TOOLCHAIN_TOOLS)
     set(ARG_TOOLCHAIN_TOOLS clang)
@@ -231,15 +255,9 @@ function(llvm_ExternalProject_Add name source_dir)
 
   if(ARG_USE_TOOLCHAIN AND NOT CMAKE_CROSSCOMPILING)
     if(CLANG_IN_TOOLCHAIN)
-      if(is_msvc_target)
-        set(compiler_args -DCMAKE_C_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang-cl${CMAKE_EXECUTABLE_SUFFIX}
-                          -DCMAKE_CXX_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang-cl${CMAKE_EXECUTABLE_SUFFIX}
-                          -DCMAKE_ASM_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang-cl${CMAKE_EXECUTABLE_SUFFIX})
-      else()
-        set(compiler_args -DCMAKE_C_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang${CMAKE_EXECUTABLE_SUFFIX}
-                          -DCMAKE_CXX_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang++${CMAKE_EXECUTABLE_SUFFIX}
-                          -DCMAKE_ASM_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/clang${CMAKE_EXECUTABLE_SUFFIX})
-      endif()
+      set(compiler_args -DCMAKE_C_COMPILER=${_cmake_c_compiler}
+                        -DCMAKE_CXX_COMPILER=${_cmake_cxx_compiler}
+                        -DCMAKE_ASM_COMPILER=${_cmake_asm_compiler})
     endif()
     if(FLANG_IN_TOOLCHAIN)
       list(APPEND compiler_args -DCMAKE_Fortran_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/flang${CMAKE_EXECUTABLE_SUFFIX})
@@ -379,6 +397,22 @@ function(llvm_ExternalProject_Add name source_dir)
     list(APPEND compiler_args -DCMAKE_CXX_COMPILER_TARGET=${ARG_TARGET_TRIPLE})
     list(APPEND compiler_args -DCMAKE_Fortran_COMPILER_TARGET=${ARG_TARGET_TRIPLE})
     list(APPEND compiler_args -DCMAKE_ASM_COMPILER_TARGET=${ARG_TARGET_TRIPLE})
+
+    # Pass CMAKE_SYSTEM_NAME derived from the target triple so the sub-build
+    # loads the correct platform files instead of the host's.
+    if(NOT "${_cmake_system_name}" STREQUAL "${CMAKE_HOST_SYSTEM_NAME}")
+      list(APPEND compiler_args -DCMAKE_SYSTEM_NAME=${_cmake_system_name})
+    endif()
+
+    # Forward Darwin-specific variables only when targeting Darwin.
+    if("${_cmake_system_name}" STREQUAL "Darwin")
+      if(CMAKE_OSX_SYSROOT)
+        list(APPEND compiler_args -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT})
+      endif()
+      if(CMAKE_OSX_DEPLOYMENT_TARGET)
+        list(APPEND compiler_args -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+      endif()
+    endif()
   endif()
 
   if(CMAKE_VERBOSE_MAKEFILE)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -4,10 +4,6 @@
 # the two files.
 
 set(COMMON_CMAKE_ARGS "-DHAVE_LLVM_LIT=ON;-DCLANG_RESOURCE_DIR=${CLANG_RESOURCE_DIR};-DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX}")
-if(APPLE AND CMAKE_OSX_SYSROOT AND (LLVM_TARGET_TRIPLE STREQUAL LLVM_HOST_TRIPLE))
-  # Only propagate the host sysroot for native runtimes builds.
-  list(APPEND RUNTIMES_CMAKE_ARGS "-DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}")
-endif()
 foreach(proj ${LLVM_ENABLE_RUNTIMES})
   string(TOUPPER "${proj}" canon_name)
   STRING(REGEX REPLACE "-" "_" canon_name ${canon_name})

--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -235,22 +235,8 @@ message(STATUS "LLVM default target triple: ${LLVM_DEFAULT_TARGET_TRIPLE}")
 set(LLVM_TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}")
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-  set(option_prefix "")
-  if (CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC")
-    set(option_prefix "/clang:")
-  endif()
-  set(print_target_triple ${CMAKE_C_COMPILER} ${option_prefix}--target=${LLVM_DEFAULT_TARGET_TRIPLE} ${option_prefix}-print-target-triple)
-  execute_process(COMMAND ${print_target_triple}
-    RESULT_VARIABLE result
-    OUTPUT_VARIABLE output
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if(result EQUAL 0)
-    set(LLVM_DEFAULT_TARGET_TRIPLE ${output})
-  else()
-    string(REPLACE ";" " " print_target_triple "${print_target_triple}")
-    # TODO(#97876): Report an error.
-    message(WARNING "Failed to execute `${print_target_triple}` to normalize target triple.")
-  endif()
+  include(NormalizeTriple)
+  normalize_triple("${CMAKE_C_COMPILER}" "${LLVM_DEFAULT_TARGET_TRIPLE}" LLVM_DEFAULT_TARGET_TRIPLE)
 endif()
 
 # Determine output and install paths based on LLVM_TARGET_TRIPLE


### PR DESCRIPTION
This reverts commit 08c728e8528c9584bc1fe0f46bbdd657e368be91.

Reapply after runtimes build fixes on platforms without shared libraries.