### PR TITLE
[AArch64][SVE] add missing MLA commute instcombine

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -1977,17 +1977,6 @@ let Predicates = [HasSVE] in {
     def : Pat<(Ty (AArch64mla_p (PredTy (SVEAnyPredicate)), Ty:$Acc, Ty:$Op,
                                 (Ty (splat_vector (ScalarTy 8))))),
               (Adr3 $Acc, $Op)>;
-
-    // MLA commuted. These can be removed if the commuted forms are canonicalized.
-    def : Pat<(Ty (AArch64mla_p (PredTy (SVEAnyPredicate)), Ty:$Acc,
-                                (Ty (splat_vector (ScalarTy 2))), Ty:$Op)),
-              (Adr1 $Acc, $Op)>;
-    def : Pat<(Ty (AArch64mla_p (PredTy (SVEAnyPredicate)), Ty:$Acc,
-                                (Ty (splat_vector (ScalarTy 4))), Ty:$Op)),
-              (Adr2 $Acc, $Op)>;
-    def : Pat<(Ty (AArch64mla_p (PredTy (SVEAnyPredicate)), Ty:$Acc,
-                                (Ty (splat_vector (ScalarTy 8))), Ty:$Op)),
-              (Adr3 $Acc, $Op)>;
   }
 
   let AddedComplexity = 10 in {

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -2601,6 +2601,12 @@ instCombineSVEVectorMlaU(InstCombiner &IC, IntrinsicInst &II) {
   if (match(MulOp1, m_AllOnes()))
     return IC.replaceInstUsesWith(II, IC.Builder.CreateSub(Acc, MulOp0));
 
+  if (isa<Constant>(MulOp0) && !isa<Constant>(MulOp1)) {
+    II.setArgOperand(2, MulOp1);
+    II.setArgOperand(3, MulOp0);
+    return &II;
+  }
+
   return std::nullopt;
 }
 

--- a/llvm/test/CodeGen/AArch64/sve-mul-imm-add-adr.ll
+++ b/llvm/test/CodeGen/AArch64/sve-mul-imm-add-adr.ll
@@ -284,35 +284,6 @@ define <vscale x 4 x i32> @svmla_u_i32_by_8(<vscale x 4 x i1> %pg, <vscale x 4 x
   ret <vscale x 4 x i32> %out
 }
 
-
-define <vscale x 4 x i32> @svmla_u_i32_by_2_commuted(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> %x) {
-; CHECK-LABEL: svmla_u_i32_by_2_commuted:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    adr z0.s, [z0.s, z1.s, lsl #1]
-; CHECK-NEXT:    ret
-  %out = call <vscale x 4 x i32> @llvm.aarch64.sve.mla.u.nxv4i32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> splat(i32 2), <vscale x 4 x i32> %x)
-  ret <vscale x 4 x i32> %out
-}
-
-define <vscale x 4 x i32> @svmla_u_i32_by_4_commuted(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> %x) {
-; CHECK-LABEL: svmla_u_i32_by_4_commuted:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    adr z0.s, [z0.s, z1.s, lsl #2]
-; CHECK-NEXT:    ret
-  %out = call <vscale x 4 x i32> @llvm.aarch64.sve.mla.u.nxv4i32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> splat(i32 4), <vscale x 4 x i32> %x)
-  ret <vscale x 4 x i32> %out
-}
-
-define <vscale x 4 x i32> @svmla_u_i32_by_8_commuted(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> %x) {
-; CHECK-LABEL: svmla_u_i32_by_8_commuted:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    adr z0.s, [z0.s, z1.s, lsl #3]
-; CHECK-NEXT:    ret
-  %out = call <vscale x 4 x i32> @llvm.aarch64.sve.mla.u.nxv4i32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> splat(i32 8), <vscale x 4 x i32> %x)
-  ret <vscale x 4 x i32> %out
-}
-
-
 define <vscale x 4 x i32> @svmla_m_partial_i32_by_2(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> %x) {
 ; CHECK-LABEL: svmla_m_partial_i32_by_2:
 ; CHECK:       // %bb.0:

--- a/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-fma-binops.ll
+++ b/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-fma-binops.ll
@@ -193,4 +193,28 @@ define <vscale x 2 x double> @no_replace_on_non_ptrue_all_u(<vscale x 2 x double
   ret <vscale x 2 x double> %2
 }
 
+define <vscale x 4 x i32> @canonicalize_mla_u_constant_lhs(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> %x) #0 {
+; CHECK-LABEL: @canonicalize_mla_u_constant_lhs
+; CHECK-NEXT:  %out = call <vscale x 4 x i32> @llvm.aarch64.sve.mla.u.nxv4i32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> %x, <vscale x 4 x i32> splat (i32 2))
+; CHECK-NEXT:  ret <vscale x 4 x i32> %out
+  %out = call <vscale x 4 x i32> @llvm.aarch64.sve.mla.u.nxv4i32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> splat (i32 2), <vscale x 4 x i32> %x)
+  ret <vscale x 4 x i32> %out
+}
+
+define <vscale x 4 x i32> @fold_mla_u_constant_lhs_one_with_constant_rhs(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a) #0 {
+; CHECK-LABEL: @fold_mla_u_constant_lhs_one_with_constant_rhs
+; CHECK-NEXT:  %out = add <vscale x 4 x i32> %a, splat (i32 5)
+; CHECK-NEXT:  ret <vscale x 4 x i32> %out
+  %out = call <vscale x 4 x i32> @llvm.aarch64.sve.mla.u.nxv4i32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> splat (i32 1), <vscale x 4 x i32> splat (i32 5))
+  ret <vscale x 4 x i32> %out
+}
+
+define <vscale x 4 x i32> @fold_mla_u_constant_lhs_allones_with_constant_rhs(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a) #0 {
+; CHECK-LABEL: @fold_mla_u_constant_lhs_allones_with_constant_rhs
+; CHECK-NEXT:  %out = add <vscale x 4 x i32> %a, splat (i32 -5)
+; CHECK-NEXT:  ret <vscale x 4 x i32> %out
+  %out = call <vscale x 4 x i32> @llvm.aarch64.sve.mla.u.nxv4i32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> splat (i32 -1), <vscale x 4 x i32> splat (i32 5))
+  ret <vscale x 4 x i32> %out
+}
+
 attributes #0 = { "target-features"="+sve" }


### PR DESCRIPTION
Remove the MLA commuted patterns added in https://github.com/llvm/llvm-project/pull/198566 and canonicalise those operations in instcombine instead.