### PR TITLE
[libc++] Split the PSTL configuration macros into a separate header

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -343,6 +343,7 @@ set(files
   __configuration/language.h
   __configuration/namespace.h
   __configuration/platform.h
+  __configuration/pstl.h
   __configuration/utility.h
   __coroutine/coroutine_handle.h
   __coroutine/coroutine_traits.h

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -28,6 +28,7 @@
 #  include <__configuration/language.h>
 #  include <__configuration/namespace.h>
 #  include <__configuration/platform.h>
+#  include <__configuration/pstl.h>
 #  include <__configuration/utility.h>
 
 // The attributes supported by clang are documented at https://clang.llvm.org/docs/AttributeReference.html
@@ -360,53 +361,6 @@ typedef __char32_t char32_t;
 #  else
 #    define _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(_ClassName) static_assert(true, "")
 #  endif
-
-#  define _PSTL_PRAGMA(x) _Pragma(#x)
-
-// Enable SIMD for compilers that support OpenMP 4.0
-#  if (defined(_OPENMP) && _OPENMP >= 201307)
-
-#    define _PSTL_UDR_PRESENT
-#    define _PSTL_PRAGMA_SIMD _PSTL_PRAGMA(omp simd)
-#    define _PSTL_PRAGMA_DECLARE_SIMD _PSTL_PRAGMA(omp declare simd)
-#    define _PSTL_PRAGMA_SIMD_REDUCTION(PRM) _PSTL_PRAGMA(omp simd reduction(PRM))
-#    define _PSTL_PRAGMA_SIMD_SCAN(PRM) _PSTL_PRAGMA(omp simd reduction(inscan, PRM))
-#    define _PSTL_PRAGMA_SIMD_INCLUSIVE_SCAN(PRM) _PSTL_PRAGMA(omp scan inclusive(PRM))
-#    define _PSTL_PRAGMA_SIMD_EXCLUSIVE_SCAN(PRM) _PSTL_PRAGMA(omp scan exclusive(PRM))
-
-// Declaration of reduction functor, where
-// NAME - the name of the functor
-// OP - type of the callable object with the reduction operation
-// omp_in - refers to the local partial result
-// omp_out - refers to the final value of the combiner operator
-// omp_priv - refers to the private copy of the initial value
-// omp_orig - refers to the original variable to be reduced
-#    define _PSTL_PRAGMA_DECLARE_REDUCTION(NAME, OP)                                                                   \
-      _PSTL_PRAGMA(omp declare reduction(NAME:OP : omp_out(omp_in)) initializer(omp_priv = omp_orig))
-
-#  elif defined(_LIBCPP_COMPILER_CLANG_BASED)
-
-#    define _PSTL_PRAGMA_SIMD _Pragma("clang loop vectorize(enable) interleave(enable)")
-#    define _PSTL_PRAGMA_DECLARE_SIMD
-#    define _PSTL_PRAGMA_SIMD_REDUCTION(PRM) _Pragma("clang loop vectorize(enable) interleave(enable)")
-#    define _PSTL_PRAGMA_SIMD_SCAN(PRM) _Pragma("clang loop vectorize(enable) interleave(enable)")
-#    define _PSTL_PRAGMA_SIMD_INCLUSIVE_SCAN(PRM)
-#    define _PSTL_PRAGMA_SIMD_EXCLUSIVE_SCAN(PRM)
-#    define _PSTL_PRAGMA_DECLARE_REDUCTION(NAME, OP)
-
-#  else // (defined(_OPENMP) && _OPENMP >= 201307)
-
-#    define _PSTL_PRAGMA_SIMD
-#    define _PSTL_PRAGMA_DECLARE_SIMD
-#    define _PSTL_PRAGMA_SIMD_REDUCTION(PRM)
-#    define _PSTL_PRAGMA_SIMD_SCAN(PRM)
-#    define _PSTL_PRAGMA_SIMD_INCLUSIVE_SCAN(PRM)
-#    define _PSTL_PRAGMA_SIMD_EXCLUSIVE_SCAN(PRM)
-#    define _PSTL_PRAGMA_DECLARE_REDUCTION(NAME, OP)
-
-#  endif // (defined(_OPENMP) && _OPENMP >= 201307)
-
-#  define _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
 
 #endif // __cplusplus
 

--- a/libcxx/include/__configuration/pstl.h
+++ b/libcxx/include/__configuration/pstl.h
@@ -1,0 +1,66 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___CONFIGURATION_PSTL_H
+#define _LIBCPP___CONFIGURATION_PSTL_H
+
+#include <__config_site>
+
+#ifndef _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER
+#  pragma GCC system_header
+#endif
+
+#define _PSTL_PRAGMA(x) _Pragma(#x)
+
+// Enable SIMD for compilers that support OpenMP 4.0
+#if (defined(_OPENMP) && _OPENMP >= 201307)
+
+#  define _PSTL_UDR_PRESENT
+#  define _PSTL_PRAGMA_SIMD _PSTL_PRAGMA(omp simd)
+#  define _PSTL_PRAGMA_DECLARE_SIMD _PSTL_PRAGMA(omp declare simd)
+#  define _PSTL_PRAGMA_SIMD_REDUCTION(PRM) _PSTL_PRAGMA(omp simd reduction(PRM))
+#  define _PSTL_PRAGMA_SIMD_SCAN(PRM) _PSTL_PRAGMA(omp simd reduction(inscan, PRM))
+#  define _PSTL_PRAGMA_SIMD_INCLUSIVE_SCAN(PRM) _PSTL_PRAGMA(omp scan inclusive(PRM))
+#  define _PSTL_PRAGMA_SIMD_EXCLUSIVE_SCAN(PRM) _PSTL_PRAGMA(omp scan exclusive(PRM))
+
+// Declaration of reduction functor, where
+// NAME - the name of the functor
+// OP - type of the callable object with the reduction operation
+// omp_in - refers to the local partial result
+// omp_out - refers to the final value of the combiner operator
+// omp_priv - refers to the private copy of the initial value
+// omp_orig - refers to the original variable to be reduced
+#  define _PSTL_PRAGMA_DECLARE_REDUCTION(NAME, OP)                                                                     \
+    _PSTL_PRAGMA(omp declare reduction(NAME:OP : omp_out(omp_in)) initializer(omp_priv = omp_orig))
+
+#elif defined(_LIBCPP_COMPILER_CLANG_BASED)
+
+#  define _PSTL_PRAGMA_SIMD _Pragma("clang loop vectorize(enable) interleave(enable)")
+#  define _PSTL_PRAGMA_DECLARE_SIMD
+#  define _PSTL_PRAGMA_SIMD_REDUCTION(PRM) _Pragma("clang loop vectorize(enable) interleave(enable)")
+#  define _PSTL_PRAGMA_SIMD_SCAN(PRM) _Pragma("clang loop vectorize(enable) interleave(enable)")
+#  define _PSTL_PRAGMA_SIMD_INCLUSIVE_SCAN(PRM)
+#  define _PSTL_PRAGMA_SIMD_EXCLUSIVE_SCAN(PRM)
+#  define _PSTL_PRAGMA_DECLARE_REDUCTION(NAME, OP)
+
+#else // (defined(_OPENMP) && _OPENMP >= 201307)
+
+#  define _PSTL_PRAGMA_SIMD
+#  define _PSTL_PRAGMA_DECLARE_SIMD
+#  define _PSTL_PRAGMA_SIMD_REDUCTION(PRM)
+#  define _PSTL_PRAGMA_SIMD_SCAN(PRM)
+#  define _PSTL_PRAGMA_SIMD_INCLUSIVE_SCAN(PRM)
+#  define _PSTL_PRAGMA_SIMD_EXCLUSIVE_SCAN(PRM)
+#  define _PSTL_PRAGMA_DECLARE_REDUCTION(NAME, OP)
+
+#endif // (defined(_OPENMP) && _OPENMP >= 201307)
+
+#define _PSTL_USE_NONTEMPORAL_STORES_IF_ALLOWED
+
+#endif // _LIBCPP___CONFIGURATION_PSTL_H

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -13,6 +13,7 @@ module std_config [system] {
   textual header "__configuration/language.h"
   textual header "__configuration/namespace.h"
   textual header "__configuration/platform.h"
+  textual header "__configuration/pstl.h"
   textual header "__configuration/utility.h"
   textual header "version"
 }


### PR DESCRIPTION
This continues the effort to split `<__config>` into self-contained detail headers.
