### PR TITLE
[libc++] Move constexpr/explicit macros to <__configuration/language.h>

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -238,42 +238,6 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_DIAGNOSE_DEPRECATED_HEADERS 0
 #  endif
 
-#  if _LIBCPP_STD_VER <= 11
-#    define _LIBCPP_EXPLICIT_SINCE_CXX14
-#  else
-#    define _LIBCPP_EXPLICIT_SINCE_CXX14 explicit
-#  endif
-
-#  if _LIBCPP_STD_VER >= 14
-#    define _LIBCPP_CONSTEXPR_SINCE_CXX14 constexpr
-#  else
-#    define _LIBCPP_CONSTEXPR_SINCE_CXX14
-#  endif
-
-#  if _LIBCPP_STD_VER >= 17
-#    define _LIBCPP_CONSTEXPR_SINCE_CXX17 constexpr
-#  else
-#    define _LIBCPP_CONSTEXPR_SINCE_CXX17
-#  endif
-
-#  if _LIBCPP_STD_VER >= 20
-#    define _LIBCPP_CONSTEXPR_SINCE_CXX20 constexpr
-#  else
-#    define _LIBCPP_CONSTEXPR_SINCE_CXX20
-#  endif
-
-#  if _LIBCPP_STD_VER >= 23
-#    define _LIBCPP_CONSTEXPR_SINCE_CXX23 constexpr
-#  else
-#    define _LIBCPP_CONSTEXPR_SINCE_CXX23
-#  endif
-
-#  if _LIBCPP_STD_VER >= 26
-#    define _LIBCPP_CONSTEXPR_SINCE_CXX26 constexpr
-#  else
-#    define _LIBCPP_CONSTEXPR_SINCE_CXX26
-#  endif
-
 // Thread API
 // clang-format off
 #  if _LIBCPP_HAS_THREADS &&                                                                                           \

--- a/libcxx/include/__configuration/language.h
+++ b/libcxx/include/__configuration/language.h
@@ -56,4 +56,40 @@
 #  define _LIBCPP_HAS_CHAR8_T 1
 #endif
 
+#if _LIBCPP_STD_VER <= 11
+#  define _LIBCPP_EXPLICIT_SINCE_CXX14
+#else
+#  define _LIBCPP_EXPLICIT_SINCE_CXX14 explicit
+#endif
+
+#if _LIBCPP_STD_VER >= 14
+#  define _LIBCPP_CONSTEXPR_SINCE_CXX14 constexpr
+#else
+#  define _LIBCPP_CONSTEXPR_SINCE_CXX14
+#endif
+
+#if _LIBCPP_STD_VER >= 17
+#  define _LIBCPP_CONSTEXPR_SINCE_CXX17 constexpr
+#else
+#  define _LIBCPP_CONSTEXPR_SINCE_CXX17
+#endif
+
+#if _LIBCPP_STD_VER >= 20
+#  define _LIBCPP_CONSTEXPR_SINCE_CXX20 constexpr
+#else
+#  define _LIBCPP_CONSTEXPR_SINCE_CXX20
+#endif
+
+#if _LIBCPP_STD_VER >= 23
+#  define _LIBCPP_CONSTEXPR_SINCE_CXX23 constexpr
+#else
+#  define _LIBCPP_CONSTEXPR_SINCE_CXX23
+#endif
+
+#if _LIBCPP_STD_VER >= 26
+#  define _LIBCPP_CONSTEXPR_SINCE_CXX26 constexpr
+#else
+#  define _LIBCPP_CONSTEXPR_SINCE_CXX26
+#endif
+
 #endif // _LIBCPP___CONFIGURATION_LANGUAGE_H


### PR DESCRIPTION
These macros are essentially a property of the language mode we're in, so move them to `<__configuration/language.h>`.
