### PR TITLE
[libc++] Move _LIBCPP_FOPEN_CLOEXEC_MODE to <fstream>

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -400,17 +400,6 @@ typedef __char32_t char32_t;
 #    endif // defined(_LIBCPP_ABI_MICROSOFT) && !defined(_LIBCPP_BUILDING_LIBRARY)
 #  endif   // _LIBCPP_NO_AUTO_LINK
 
-// Configures the fopen close-on-exec mode character, if any. This string will
-// be appended to any mode string used by fstream for fopen/fdopen.
-//
-// Not all platforms support this, but it helps avoid fd-leaks on platforms that
-// do.
-#  if defined(__BIONIC__)
-#    define _LIBCPP_FOPEN_CLOEXEC_MODE "e"
-#  else
-#    define _LIBCPP_FOPEN_CLOEXEC_MODE
-#  endif
-
 // c8rtomb() and mbrtoc8() were added in C++20 and C23. Support for these
 // functions is gradually being added to existing C libraries. The conditions
 // below check for known C library versions and conditions under which these

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -600,6 +600,17 @@ inline bool basic_filebuf<_CharT, _Traits>::is_open() const {
   return __file_ != nullptr;
 }
 
+// Configures the fopen close-on-exec mode character, if any. This string will
+// be appended to any mode string used by fstream for fopen/fdopen.
+//
+// Not all platforms support this, but it helps avoid fd-leaks on platforms that
+// do.
+#    if defined(__BIONIC__)
+#      define _LIBCPP_FOPEN_CLOEXEC_MODE "e"
+#    else
+#      define _LIBCPP_FOPEN_CLOEXEC_MODE
+#    endif
+
 template <class _CharT, class _Traits>
 const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode __mode) _NOEXCEPT {
   switch (__mode & ~ios_base::ate) {


### PR DESCRIPTION
The macro is only required inside `<fstream>`, so we can move it there instead of having it as a general configuration macro.
