### PR TITLE
[DirectX] Select PSV version from the module validator version

### DIFF
--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -341,6 +341,21 @@ void DXContainerGlobals::addResourcesForPSV(Module &M, PSVRuntimeInfo &PSV) {
   }
 }
 
+// Selects the PSV version to encode based on the module's validator version.
+// The DXIL validator computes the expected PSVRuntimeInfo size from the
+// validator version, so the emitted PSV version must agree with it; otherwise
+// the DXContainer is rejected with a PSVRuntimeInfoSize mismatch. This mirrors
+// the mapping used by DXC (hlsl::GetPSVVersion).
+static uint32_t getPSVVersion(VersionTuple ValVer) {
+  if (ValVer.empty() || ValVer < VersionTuple(1, 1))
+    return 0;
+  if (ValVer < VersionTuple(1, 6))
+    return 1;
+  if (ValVer < VersionTuple(1, 8))
+    return 2;
+  return 3;
+}
+
 void DXContainerGlobals::addPipelineStateValidationInfo(
     Module &M, SmallVector<GlobalValue *> &Globals) {
   SmallString<256> Data;
@@ -385,8 +400,13 @@ void DXContainerGlobals::addPipelineStateValidationInfo(
       MMI.ShaderProfile != Triple::RootSignature)
     PSV.EntryName = MMI.EntryPropertyVec[0].Entry->getName();
 
-  PSV.finalize(MMI.ShaderProfile);
-  PSV.write(OS);
+  // The PSV version determines the size of the PSVRuntimeInfo record written
+  // below. The DXIL validator computes the expected size from the module's
+  // validator version, so the emitted version must be selected the same way or
+  // the container is rejected with a PSVRuntimeInfoSize mismatch.
+  uint32_t PSVVersion = getPSVVersion(MMI.ValidatorVersion);
+  PSV.finalize(MMI.ShaderProfile, PSVVersion);
+  PSV.write(OS, PSVVersion);
   addSection(M, Globals, Data, "dx.psv0", "PSV0");
 }
 

--- a/llvm/test/CodeGen/DirectX/ContainerData/PSVVersionFromValidatorVersion.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/PSVVersionFromValidatorVersion.ll
@@ -1,0 +1,69 @@
+; The PSV0 RuntimeInfo version is selected from the module's validator version
+; so the encoded record size matches what the DXIL validator expects. A module
+; without dx.valver encodes version 0; declared validator versions select
+; higher PSV versions (mirroring DXC's hlsl::GetPSVVersion mapping).
+
+; RUN: split-file %s %t
+; RUN: llc %t/no_valver.ll --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=V0
+; RUN: llc %t/valver_1_7.ll --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=V2
+; RUN: llc %t/valver_1_8.ll --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=V3
+
+;--- no_valver.ll
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+define void @main() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+; No dx.valver -> PSV version 0 (24-byte RuntimeInfo).
+; V0:      - Name:            PSV0
+; V0-NEXT:     Size:            32
+; V0:          Version:         0
+; V0-NOT:      NumThreadsX:
+; V0-NOT:      RuntimeInfoSize:
+; V0-NOT:      EntryName:
+
+;--- valver_1_7.ll
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+define void @main() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!dx.valver = !{!0}
+!0 = !{i32 1, i32 7}
+
+; Validator version 1.7 -> PSV version 2 (48-byte RuntimeInfo, no EntryName).
+; V2:      - Name:            PSV0
+; V2-NEXT:     Size:            68
+; V2:          Version:         2
+; V2:          NumThreadsX:     1
+; V2:          RuntimeInfoSize: 48
+; V2-NOT:      EntryName:
+
+;--- valver_1_8.ll
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+define void @main() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!dx.valver = !{!0}
+!0 = !{i32 1, i32 8}
+
+; Validator version 1.8 -> PSV version 3 (52-byte RuntimeInfo, with EntryName).
+; V3:      - Name:            PSV0
+; V3-NEXT:     Size:            76
+; V3:          Version:         3
+; V3:          NumThreadsX:     1
+; V3:          EntryName:       main
+; V3:          RuntimeInfoSize: 52

--- a/llvm/test/CodeGen/DirectX/ContainerData/PipelineStateValidation.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/PipelineStateValidation.ll
@@ -13,7 +13,7 @@ attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 !dx.valver = !{!0}
 
-!0 = !{i32 1, i32 7}
+!0 = !{i32 1, i32 8}
 
 ; DXC: - Name:            PSV0
 ; DXC:     Size:            76

--- a/llvm/test/CodeGen/DirectX/ContainerData/RuntimeInfoCS.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RuntimeInfoCS.ll
@@ -13,7 +13,7 @@ attributes #0 = { "hlsl.numthreads"="8,8,1" "hlsl.shader"="compute" }
 
 !dx.valver = !{!0}
 
-!0 = !{i32 1, i32 7}
+!0 = !{i32 1, i32 8}
 
 ; DXC: - Name:            PSV0
 ; DXC-NEXT:   Size:            80


### PR DESCRIPTION
## Summary

`DXContainerGlobals` always emitted the `PSV0` `RuntimeInfo` record at the
highest supported version (v3, 52 bytes). `addPipelineStateValidationInfo`
calls `PSVRuntimeInfo::finalize()` / `write()` without a version argument, and
the default argument encodes the maximum version regardless of the module.

The DXIL validator derives the expected `PSVRuntimeInfo` size from the module's
validator version, using the same mapping DXC implements in
`hlsl::GetPSVVersion`. A module without a `dx.valver` entry is treated as
validator version 0.0, so the validator expects a v0 (24-byte) record while
`llc` wrote v3 (52 bytes). The mismatch makes the validator reject the
container:

```
error 0x80aa0013: PSVRuntimeInfoSize 'PSV0' part: ('52') vs DXIL module: ('24')
```

The same mismatch happens for any declared validator version below 1.8.

## Fix

Select the PSV version from `MMI.ValidatorVersion` using the DXC mapping
(`<1.1 -> 0`, `<1.6 -> 1`, `<1.8 -> 2`, otherwise `3`) and pass it to
`finalize()` / `write()`, so the encoded record size agrees with the size the
validator computes from the module.

## Tests

- New test `PSVVersionFromValidatorVersion.ll` covers the
  no-`dx.valver` -> v0, `1.7` -> v2 and `1.8` -> v3 mappings. It fails before
  this change (a no-`dx.valver` module emits v3) and passes after.
- `RuntimeInfoCS.ll` / `PipelineStateValidation.ll` declared validator version
  1.7 but asserted the v3 record; they now declare 1.8 so they keep exercising
  v3.
- `llvm-lit llvm/test/CodeGen/DirectX` passes (465/465) with the change.

As an additional cross-check, a container emitted for a compute module without
`dx.valver` is now accepted by the signed Microsoft DXIL validator
(`dxv.exe` / `IDxcValidator`, dxil.dll 1.9.2602.24), whereas before the change
it was rejected with `0x80aa0013`.