### PR TITLE
[libc++] Move <features.h> include to <__configuration/platform.h>

### DIFF
--- a/libcxx/include/__configuration/platform.h
+++ b/libcxx/include/__configuration/platform.h
@@ -30,6 +30,10 @@
 // ... add new file formats here ...
 #endif
 
+#if defined(__MVS__)
+#  include <features.h> // for __NATIVE_ASCII_F
+#endif
+
 // Need to detect which libc we're using if we're on Linux.
 #if (defined(__linux__) || defined(__AMDGPU__) || defined(__NVPTX__)) && __has_include(<features.h>)
 #  include <features.h>


### PR DESCRIPTION
Including `<features.h>` is platform-specific configuration and should therefore be in `<__configuration/platform.h>`.
