### PR TITLE
[libc++] Remove <features.h> include from <__config>

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -66,10 +66,6 @@
 #    define _LIBCPP_ABI_VCRUNTIME
 #  endif
 
-#  if defined(__MVS__)
-#    include <features.h> // for __NATIVE_ASCII_F
-#  endif
-
 #  if defined(_WIN32)
 #    define _LIBCPP_WIN32API
 #    define _LIBCPP_SHORT_WCHAR 1


### PR DESCRIPTION
The include was moved to `<__configuration/platform.h>` in #205548, which was also supposed to remove the include in `<__config>`.
