### PR TITLE
[clang][bytecode][NFC] Use SourceInfo for opcode emitter helpers

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4963,26 +4963,26 @@ bool Compiler<Emitter>::visitAssignment(const Expr *LHS, const Expr *RHS,
 
 template <class Emitter>
 template <typename T>
-bool Compiler<Emitter>::emitConst(T Value, PrimType Ty, const Expr *E) {
+bool Compiler<Emitter>::emitConst(T Value, PrimType Ty, SourceInfo Info) {
   switch (Ty) {
   case PT_Sint8:
-    return this->emitConstSint8(Value, E);
+    return this->emitConstSint8(Value, Info);
   case PT_Uint8:
-    return this->emitConstUint8(Value, E);
+    return this->emitConstUint8(Value, Info);
   case PT_Sint16:
-    return this->emitConstSint16(Value, E);
+    return this->emitConstSint16(Value, Info);
   case PT_Uint16:
-    return this->emitConstUint16(Value, E);
+    return this->emitConstUint16(Value, Info);
   case PT_Sint32:
-    return this->emitConstSint32(Value, E);
+    return this->emitConstSint32(Value, Info);
   case PT_Uint32:
-    return this->emitConstUint32(Value, E);
+    return this->emitConstUint32(Value, Info);
   case PT_Sint64:
-    return this->emitConstSint64(Value, E);
+    return this->emitConstSint64(Value, Info);
   case PT_Uint64:
-    return this->emitConstUint64(Value, E);
+    return this->emitConstUint64(Value, Info);
   case PT_Bool:
-    return this->emitConstBool(Value, E);
+    return this->emitConstBool(Value, Info);
   case PT_Ptr:
   case PT_MemberPtr:
   case PT_Float:
@@ -5003,28 +5003,28 @@ bool Compiler<Emitter>::emitConst(T Value, const Expr *E) {
 
 template <class Emitter>
 bool Compiler<Emitter>::emitConst(const APSInt &Value, PrimType Ty,
-                                  const Expr *E) {
+                                  SourceInfo Info) {
   if (Ty == PT_IntAPS)
-    return this->emitConstIntAPS(Value, E);
+    return this->emitConstIntAPS(Value, Info);
   if (Ty == PT_IntAP)
-    return this->emitConstIntAP(Value, E);
+    return this->emitConstIntAP(Value, Info);
 
   if (Value.isSigned())
-    return this->emitConst(Value.getSExtValue(), Ty, E);
-  return this->emitConst(Value.getZExtValue(), Ty, E);
+    return this->emitConst(Value.getSExtValue(), Ty, Info);
+  return this->emitConst(Value.getZExtValue(), Ty, Info);
 }
 
 template <class Emitter>
 bool Compiler<Emitter>::emitConst(const APInt &Value, PrimType Ty,
-                                  const Expr *E) {
+                                  SourceInfo Info) {
   if (Ty == PT_IntAPS)
-    return this->emitConstIntAPS(Value, E);
+    return this->emitConstIntAPS(Value, Info);
   if (Ty == PT_IntAP)
-    return this->emitConstIntAP(Value, E);
+    return this->emitConstIntAP(Value, Info);
 
   if (isSignedType(Ty))
-    return this->emitConst(Value.getSExtValue(), Ty, E);
-  return this->emitConst(Value.getZExtValue(), Ty, E);
+    return this->emitConst(Value.getSExtValue(), Ty, Info);
+  return this->emitConst(Value.getZExtValue(), Ty, Info);
 }
 
 template <class Emitter>
@@ -5411,42 +5411,44 @@ bool Compiler<Emitter>::visitDtorCall(const VarDecl *VD, const APValue &Value) {
 
   if (!this->emitGetPtrLocal(Local.Offset, VD))
     return false;
-  if (!this->visitAPValueInitializer(Value, nullptr, Ty))
+
+  if (!this->visitAPValueInitializer(Value, VD, Ty))
     return false;
+
   return this->emitDestructionPop(D, VD);
 }
 
 template <class Emitter>
 bool Compiler<Emitter>::visitAPValue(const APValue &Val, PrimType ValType,
-                                     const Expr *E) {
+                                     SourceInfo Info) {
   assert(!DiscardResult);
   if (Val.isInt())
-    return this->emitConst(Val.getInt(), ValType, E);
+    return this->emitConst(Val.getInt(), ValType, Info);
   if (Val.isFloat()) {
     APFloat F = Val.getFloat();
-    return this->emitFloat(F, E);
+    return this->emitFloat(F, Info);
   }
 
   if (Val.isMemberPointer()) {
     if (const ValueDecl *MemberDecl = Val.getMemberPointerDecl()) {
-      if (!this->emitGetMemberPtr(MemberDecl, E))
+      if (!this->emitGetMemberPtr(MemberDecl, Info))
         return false;
 
       bool IsDerived = Val.isMemberPointerToDerivedMember();
       // Apply the member pointer path.
       for (const CXXRecordDecl *PathEntry : Val.getMemberPointerPath()) {
-        if (!this->emitCopyMemberPtrPath(PathEntry, IsDerived, E))
+        if (!this->emitCopyMemberPtrPath(PathEntry, IsDerived, Info))
           return false;
       }
 
       return true;
     }
-    return this->emitNullMemberPtr(0, nullptr, E);
+    return this->emitNullMemberPtr(0, nullptr, Info);
   }
 
   if (Val.isLValue()) {
     if (Val.isNullPointer())
-      return this->emitNull(ValType, 0, nullptr, E);
+      return this->emitNull(ValType, 0, nullptr, Info);
 
     APValue::LValueBase Base = Val.getLValueBase();
     ArrayRef<APValue::LValuePathEntry> Path = Val.getLValuePath();
@@ -5454,7 +5456,7 @@ bool Compiler<Emitter>::visitAPValue(const APValue &Val, PrimType ValType,
     if (const Expr *BaseExpr = Base.dyn_cast<const Expr *>())
       return this->visit(BaseExpr);
     if (const auto *VD = Base.dyn_cast<const ValueDecl *>()) {
-      if (!this->visitDeclRef(VD, E))
+      if (!this->visitDeclRef(VD, Info.asExpr()))
         return false;
 
       QualType EntryType = VD->getType();
@@ -5463,9 +5465,9 @@ bool Compiler<Emitter>::visitAPValue(const APValue &Val, PrimType ValType,
           uint64_t Index = Entry.getAsArrayIndex();
           QualType ElemType =
               EntryType->getAsArrayTypeUnsafe()->getElementType();
-          if (!this->emitConst(Index, PT_Uint64, E))
+          if (!this->emitConst(Index, PT_Uint64, Info))
             return false;
-          if (!this->emitArrayElemPtrPop(PT_Uint64, E))
+          if (!this->emitArrayElemPtrPop(PT_Uint64, Info))
             return false;
           EntryType = ElemType;
         } else {
@@ -5480,13 +5482,13 @@ bool Compiler<Emitter>::visitAPValue(const APValue &Val, PrimType ValType,
           const Decl *BaseOrMember = Entry.getAsBaseOrMember().getPointer();
           if (const auto *FD = dyn_cast<FieldDecl>(BaseOrMember)) {
             unsigned EntryOffset = EntryRecord->getField(FD)->Offset;
-            if (!this->emitGetPtrFieldPop(EntryOffset, E))
+            if (!this->emitGetPtrFieldPop(EntryOffset, Info))
               return false;
             EntryType = FD->getType();
           } else {
             const auto *Base = cast<CXXRecordDecl>(BaseOrMember);
             unsigned BaseOffset = EntryRecord->getBase(Base)->Offset;
-            if (!this->emitGetPtrBasePop(BaseOffset, /*NullOK=*/false, E))
+            if (!this->emitGetPtrBasePop(BaseOffset, /*NullOK=*/false, Info))
               return false;
             EntryType = Ctx.getASTContext().getCanonicalTagType(Base);
           }
@@ -5502,7 +5504,7 @@ bool Compiler<Emitter>::visitAPValue(const APValue &Val, PrimType ValType,
 
 template <class Emitter>
 bool Compiler<Emitter>::visitAPValueInitializer(const APValue &Val,
-                                                const Expr *E, QualType T) {
+                                                SourceInfo Info, QualType T) {
   if (Val.isStruct()) {
     const Record *R = this->getRecord(T);
     assert(R);
@@ -5513,16 +5515,16 @@ bool Compiler<Emitter>::visitAPValueInitializer(const APValue &Val,
 
       // Fields.
       if (OptPrimType PT = classify(FieldType)) {
-        if (!this->visitAPValue(F, *PT, E))
+        if (!this->visitAPValue(F, *PT, Info))
           return false;
-        if (!this->emitInitField(*PT, RF->Offset, E))
+        if (!this->emitInitField(*PT, RF->Offset, Info))
           return false;
       } else {
-        if (!this->emitGetPtrField(RF->Offset, E))
+        if (!this->emitGetPtrField(RF->Offset, Info))
           return false;
-        if (!this->visitAPValueInitializer(F, E, FieldType))
+        if (!this->visitAPValueInitializer(F, Info, FieldType))
           return false;
-        if (!this->emitFinishInitPop(E))
+        if (!this->emitFinishInitPop(Info))
           return false;
       }
     }
@@ -5533,11 +5535,11 @@ bool Compiler<Emitter>::visitAPValueInitializer(const APValue &Val,
       const Record::Base *RB = R->getBase(I);
       QualType BaseType = Ctx.getASTContext().getCanonicalTagType(RB->Decl);
 
-      if (!this->emitGetPtrBase(RB->Offset, E))
+      if (!this->emitGetPtrBase(RB->Offset, Info))
         return false;
-      if (!this->visitAPValueInitializer(B, E, BaseType))
+      if (!this->visitAPValueInitializer(B, Info, BaseType))
         return false;
-      if (!this->emitFinishInitPop(E))
+      if (!this->emitFinishInitPop(Info))
         return false;
     }
 
@@ -5554,21 +5556,21 @@ bool Compiler<Emitter>::visitAPValueInitializer(const APValue &Val,
     QualType FieldType = RF->Decl->getType();
 
     if (OptPrimType PT = classify(FieldType)) {
-      if (!this->visitAPValue(F, *PT, E))
+      if (!this->visitAPValue(F, *PT, Info))
         return false;
       if (RF->isBitField())
         return this->emitInitBitFieldActivate(*PT, RF->Offset, RF->bitWidth(),
-                                              E);
-      return this->emitInitFieldActivate(*PT, RF->Offset, E);
+                                              Info);
+      return this->emitInitFieldActivate(*PT, RF->Offset, Info);
     }
 
-    if (!this->emitGetPtrField(RF->Offset, E))
+    if (!this->emitGetPtrField(RF->Offset, Info))
       return false;
-    if (!this->emitActivate(E))
+    if (!this->emitActivate(Info))
       return false;
-    if (!this->visitAPValueInitializer(F, E, FieldType))
+    if (!this->visitAPValueInitializer(F, Info, FieldType))
       return false;
-    return this->emitPopPtr(E);
+    return this->emitPopPtr(Info);
   }
   if (Val.isArray()) {
     unsigned InitializedElems = Val.getArrayInitializedElts();
@@ -5582,18 +5584,18 @@ bool Compiler<Emitter>::visitAPValueInitializer(const APValue &Val,
                                 : Val.getArrayInitializedElt(A);
 
       if (ElemT) {
-        if (!this->visitAPValue(Elem, *ElemT, E))
+        if (!this->visitAPValue(Elem, *ElemT, Info))
           return false;
-        if (!this->emitInitElem(*ElemT, A, E))
+        if (!this->emitInitElem(*ElemT, A, Info))
           return false;
       } else {
-        if (!this->emitConstUint32(A, E))
+        if (!this->emitConstUint32(A, Info))
           return false;
-        if (!this->emitArrayElemPtrUint32(E))
+        if (!this->emitArrayElemPtrUint32(Info))
           return false;
-        if (!this->visitAPValueInitializer(Elem, E, ElemType))
+        if (!this->visitAPValueInitializer(Elem, Info, ElemType))
           return false;
-        if (!this->emitPopPtr(E))
+        if (!this->emitPopPtr(Info))
           return false;
       }
     }
@@ -8163,15 +8165,15 @@ bool Compiler<Emitter>::emitDummyPtr(const DeclTy &D, const Expr *E, bool CU) {
 }
 
 template <class Emitter>
-bool Compiler<Emitter>::emitFloat(const APFloat &F, const Expr *E) {
+bool Compiler<Emitter>::emitFloat(const APFloat &F, SourceInfo Info) {
   if (Floating::singleWord(F.getSemantics()))
-    return this->emitConstFloat(Floating(F), E);
+    return this->emitConstFloat(Floating(F), Info);
 
   APInt I = F.bitcastToAPInt();
   return this->emitConstFloat(
       Floating(const_cast<uint64_t *>(I.getRawData()),
                llvm::APFloatBase::SemanticsToEnum(F.getSemantics())),
-      E);
+      Info);
 }
 
 //  This function is constexpr if and only if To, From, and the types of

--- a/clang/lib/AST/ByteCode/Compiler.h
+++ b/clang/lib/AST/ByteCode/Compiler.h
@@ -317,8 +317,8 @@ protected:
                                 bool Toplevel = false);
   VarCreationState visitDecl(const VarDecl *VD);
   /// Visit an APValue.
-  bool visitAPValue(const APValue &Val, PrimType ValType, const Expr *E);
-  bool visitAPValueInitializer(const APValue &Val, const Expr *E, QualType T);
+  bool visitAPValue(const APValue &Val, PrimType ValType, SourceInfo Info);
+  bool visitAPValueInitializer(const APValue &Val, SourceInfo Info, QualType T);
   /// Visit the given decl as if we have a reference to it.
   bool visitDeclRef(const ValueDecl *D, const Expr *E);
 
@@ -366,15 +366,15 @@ private:
   bool visitAssignment(const Expr *LHS, const Expr *RHS, const Expr *E);
 
   /// Emits an APSInt constant.
-  bool emitConst(const llvm::APSInt &Value, PrimType Ty, const Expr *E);
-  bool emitConst(const llvm::APInt &Value, PrimType Ty, const Expr *E);
+  bool emitConst(const llvm::APSInt &Value, PrimType Ty, SourceInfo Info);
+  bool emitConst(const llvm::APInt &Value, PrimType Ty, SourceInfo Info);
   bool emitConst(const llvm::APSInt &Value, const Expr *E);
   bool emitConst(const llvm::APInt &Value, const Expr *E) {
     return emitConst(Value, classifyPrim(E), E);
   }
 
   /// Emits an integer constant.
-  template <typename T> bool emitConst(T Value, PrimType Ty, const Expr *E);
+  template <typename T> bool emitConst(T Value, PrimType Ty, SourceInfo Info);
   template <typename T> bool emitConst(T Value, const Expr *E);
   bool emitBool(bool V, const Expr *E) override {
     return this->emitConst(V, E);
@@ -421,7 +421,7 @@ private:
   bool emitRecordDestructionPop(const Record *R, SourceInfo Loc);
   bool emitDestructionPop(const Descriptor *Desc, SourceInfo Loc);
   bool emitDummyPtr(const DeclTy &D, const Expr *E, bool CU = false);
-  bool emitFloat(const APFloat &F, const Expr *E);
+  bool emitFloat(const APFloat &F, SourceInfo Info);
   unsigned collectBaseOffset(const QualType BaseType,
                              const QualType DerivedType);
   bool emitLambdaStaticInvokerBody(const CXXMethodDecl *MD);


### PR DESCRIPTION
Instead of only using an `Expr*`. This makes more sense and we can later use a decl as a source as well.