### PR TITLE
[libc++] Remove _BitScanForward{,64}

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -76,15 +76,9 @@
 #    if defined(_MSC_VER) && !defined(__MINGW32__)
 #      define _LIBCPP_MSVCRT // Using Microsoft's C Runtime library
 #    endif
-#    if (defined(_M_AMD64) || defined(__x86_64__)) || (defined(_M_ARM) || defined(__arm__))
-#      define _LIBCPP_HAS_BITSCAN64 1
-#    else
-#      define _LIBCPP_HAS_BITSCAN64 0
-#    endif
 #    define _LIBCPP_HAS_OPEN_WITH_WCHAR 1
 #  else
 #    define _LIBCPP_HAS_OPEN_WITH_WCHAR 0
-#    define _LIBCPP_HAS_BITSCAN64 0
 #  endif // defined(_WIN32)
 
 #  if defined(_AIX) && !defined(__64BIT__)

--- a/libcxx/include/__cxx03/__config
+++ b/libcxx/include/__cxx03/__config
@@ -229,9 +229,6 @@ _LIBCPP_HARDENING_MODE_DEBUG
 #    if defined(_MSC_VER) && !defined(__MINGW32__)
 #      define _LIBCPP_MSVCRT // Using Microsoft's C Runtime library
 #    endif
-#    if (defined(_M_AMD64) || defined(__x86_64__)) || (defined(_M_ARM) || defined(__arm__))
-#      define _LIBCPP_HAS_BITSCAN64
-#    endif
 #    define _LIBCPP_HAS_OPEN_WITH_WCHAR
 #  endif // defined(_WIN32)
 

--- a/libcxx/src/include/ryu/ryu.h
+++ b/libcxx/src/include/ryu/ryu.h
@@ -67,24 +67,6 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // https://github.com/ulfjack/ryu/tree/59661c3/ryu
 
-#if !defined(_MSC_VER)
-_LIBCPP_HIDE_FROM_ABI inline unsigned char _BitScanForward64(unsigned long* __index, unsigned long long __mask) {
-  if (__mask == 0) {
-    return false;
-  }
-  *__index = __builtin_ctzll(__mask);
-  return true;
-}
-
-_LIBCPP_HIDE_FROM_ABI inline unsigned char _BitScanForward(unsigned long* __index, unsigned int __mask) {
-  if (__mask == 0) {
-    return false;
-  }
-  *__index = __builtin_ctz(__mask);
-  return true;
-}
-#endif  // !_MSC_VER
-
 template <class _Floating>
 [[nodiscard]] to_chars_result _Floating_to_chars_ryu(
     char* const _First, char* const _Last, const _Floating _Value, const chars_format _Fmt) noexcept {

--- a/libcxx/src/ryu/d2s.cpp
+++ b/libcxx/src/ryu/d2s.cpp
@@ -41,6 +41,7 @@
 
 #include <__assert>
 #include <__config>
+#include <bit>
 #include <charconv>
 #include <cstddef>
 
@@ -478,19 +479,7 @@ struct __floating_decimal_64 {
           2882303761517u, 576460752303u, 115292150460u, 23058430092u, 4611686018u, 922337203u, 184467440u,
           36893488u, 7378697u, 1475739u, 295147u, 59029u, 11805u, 2361u, 472u, 94u, 18u, 3u };
 
-        unsigned long _Trailing_zero_bits;
-#if _LIBCPP_HAS_BITSCAN64
-        (void) _BitScanForward64(&_Trailing_zero_bits, __v.__mantissa); // __v.__mantissa is guaranteed nonzero
-#else // ^^^ 64-bit ^^^ / vvv 32-bit vvv
-        const uint32_t _Low_mantissa = static_cast<uint32_t>(__v.__mantissa);
-        if (_Low_mantissa != 0) {
-          (void) _BitScanForward(&_Trailing_zero_bits, _Low_mantissa);
-        } else {
-          const uint32_t _High_mantissa = static_cast<uint32_t>(__v.__mantissa >> 32); // nonzero here
-          (void) _BitScanForward(&_Trailing_zero_bits, _High_mantissa);
-          _Trailing_zero_bits += 32;
-        }
-#endif // ^^^ 32-bit ^^^
+        unsigned long _Trailing_zero_bits = std::countr_zero(__v.__mantissa);
         const uint64_t _Shifted_mantissa = __v.__mantissa >> _Trailing_zero_bits;
         _Can_use_ryu = _Shifted_mantissa <= _Max_shifted_mantissa[_Ryu_exponent];
       }

--- a/libcxx/src/ryu/f2s.cpp
+++ b/libcxx/src/ryu/f2s.cpp
@@ -41,6 +41,7 @@
 
 #include <__assert>
 #include <__config>
+#include <bit>
 #include <charconv>
 #include <cstdint>
 #include <cstddef>
@@ -535,8 +536,7 @@ struct __floating_decimal_32 {
         static constexpr uint32_t _Max_shifted_mantissa[11] = {
           16777215, 3355443, 671088, 134217, 26843, 5368, 1073, 214, 42, 8, 1 };
 
-        unsigned long _Trailing_zero_bits;
-        (void) _BitScanForward(&_Trailing_zero_bits, __v.__mantissa); // __v.__mantissa is guaranteed nonzero
+        unsigned long _Trailing_zero_bits = std::countr_zero(__v.__mantissa); // __v.__mantissa is guaranteed nonzero
         const uint32_t _Shifted_mantissa = __v.__mantissa >> _Trailing_zero_bits;
         _Can_use_ryu = _Shifted_mantissa <= _Max_shifted_mantissa[_Ryu_exponent];
       }


### PR DESCRIPTION
`std::countr_zero` can be used instead, which is a standard API.
