### PR TITLE
[libc++] Remove __broadcast simd function

### DIFF
--- a/libcxx/include/__algorithm/simd_utils.h
+++ b/libcxx/include/__algorithm/simd_utils.h
@@ -124,15 +124,6 @@ template <class _VecT, size_t _Np, class _Iter>
     return _VecT{__iter[_LoadIndices]..., ((void)_ZeroIndices, 0)...};
   }(make_index_sequence<_Np>{}, make_index_sequence<__simd_vector_size_v<_VecT> - _Np>{});
 }
-
-// Create a vector where every elements is __val
-template <class _VecT>
-[[__nodiscard__]] _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _VecT
-__broadcast(__simd_vector_underlying_type_t<_VecT> __val) {
-  return [&]<std::size_t... _Indices>(index_sequence<_Indices...>) {
-    return _VecT{((void)_Indices, __val)...};
-  }(make_index_sequence<__simd_vector_size_v<_VecT>>());
-}
 _LIBCPP_DIAGNOSTIC_POP
 
 template <class _Tp, size_t _Np>

--- a/libcxx/include/__locale_dir/num.h
+++ b/libcxx/include/__locale_dir/num.h
@@ -96,9 +96,8 @@ struct __num_get : protected __num_get_base {
       _LIBCPP_DIAGNOSTIC_PUSH
       _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wpsabi")
       using __vec   = __simd_vector<char, 32>;
-      __vec __chars = std::__broadcast<__vec>(__val);
       __vec __cmp   = std::__partial_load<__vec, __int_chr_cnt>(__atoms);
-      auto __res    = __chars == __cmp;
+      auto __res    = __vec(__val) == __cmp;
       if (std::__none_of(__res))
         return __int_chr_cnt;
       return std::min(__int_chr_cnt, std::__find_first_set(__res));


### PR DESCRIPTION
The simd vector type in Clang already provides a conversion operator that acts as a broadcast constructor. We can use that instead.
