### PR TITLE
[ImplicitNullChecks] Preserve debug location on FAULTING_OP

### DIFF
--- a/llvm/lib/CodeGen/ImplicitNullChecks.cpp
+++ b/llvm/lib/CodeGen/ImplicitNullChecks.cpp
@@ -703,7 +703,6 @@ bool ImplicitNullChecks::analyzeBlockForNullChecks(
 /// faults.  The FAULTING instruction is inserted at the end of MBB.
 MachineInstr *ImplicitNullChecks::insertFaultingInstr(
     MachineInstr *MI, MachineBasicBlock *MBB, MachineBasicBlock *HandlerMBB) {
-  DebugLoc DL;
   unsigned NumDefs = MI->getDesc().getNumDefs();
   assert(NumDefs <= 1 && "other cases unhandled!");
 
@@ -720,7 +719,8 @@ MachineInstr *ImplicitNullChecks::insertFaultingInstr(
   else
     FK = FaultMaps::FaultingStore;
 
-  auto MIB = BuildMI(MBB, DL, TII->get(TargetOpcode::FAULTING_OP), DefReg)
+  auto MIB = BuildMI(MBB, MI->getDebugLoc(),
+                     TII->get(TargetOpcode::FAULTING_OP), DefReg)
                  .addImm(FK)
                  .addMBB(HandlerMBB)
                  .addImm(MI->getOpcode());

--- a/llvm/test/CodeGen/X86/implicit-null-check-debugloc.ll
+++ b/llvm/test/CodeGen/X86/implicit-null-check-debugloc.ll
@@ -1,0 +1,33 @@
+; RUN: llc -mtriple=x86_64-linux-gnu -enable-implicit-null-checks \
+; RUN:   -stop-after=implicit-null-checks -o - %s | FileCheck %s
+
+; ImplicitNullChecks must preserve the folded load's debug location on the
+; resulting FAULTING_OP, otherwise the faulting instruction loses its source
+; attribution in the DWARF line table.
+
+; CHECK: [[LOC:![0-9]+]] = !DILocation(line: 4
+; CHECK: FAULTING_OP {{.*}}debug-location [[LOC]] :: (load (s32) from %ir.p)
+
+define i32 @f(ptr %p) !dbg !4 {
+entry:
+  %nn = icmp eq ptr %p, null
+  br i1 %nn, label %null, label %notnull, !make.implicit !0
+
+notnull:
+  %v = load i32, ptr %p, !dbg !7
+  ret i32 %v
+
+null:
+  unreachable
+}
+
+!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!2}
+
+!0 = !{}
+!1 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, emissionKind: FullDebug)
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = !DIFile(filename: "repro.c", directory: "/")
+!4 = distinct !DISubprogram(name: "f", scope: !3, file: !3, line: 1, type: !5, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !1)
+!5 = !DISubroutineType(types: !{})
+!7 = !DILocation(line: 4, column: 10, scope: !4)


### PR DESCRIPTION
insertFaultingInstr() built the FAULTING_OP with an empty DebugLoc, dropping the folded memory op's source location. As a result the faulting load is mislabeled in the line table, giving wrong source attribution for the very instruction that traps on a null deref. Fix by using MI->getDebugLoc().

The original report also flagged dropped MIFlags and def renamable/ sub-register/early-clobber bits, but those are not observable: Unpredictable is never set on loads, the register bits are never read (FAULTING_OP is opaque until AsmPrinter), and the sub-register write is already modeled correctly. Only the debug location is fixed here.

Found via @jlebar's X86 LLVM bug hunt / FuzzX effort: https://github.com/SemiAnalysisAI/FuzzX/blob/master/x86/bugs/099-implicitnullchecks-insertFaultingInstr-loses-mi-flags

cc @jlebar