### PR TITLE
[lldb-dap][test] Re-enable test_by_name_waitFor on Windows

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -73,7 +73,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         self.attach(program=program)
         self.continue_and_verify_pid()
 
-    @expectedFailureWindows
+    @expectedFailureWindowsAndNoLLDBServer
     def test_by_name_waitFor(self):
         """
         Tests waiting for, and attaching to a process by process name that
@@ -98,6 +98,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
                 self.spawn_thread.join(timeout=10)
 
     @expectedFailureWindows
+    @skipIfWindowsAndLLDBServer
     def test_by_partial_name_waitFor(self):
         """
         Tests waiting for and attaching to a process by partial process name


### PR DESCRIPTION
`test_by_name_waitFor` passes with `LLDB_USE_LLDB_SERVER=1`. `test_by_partial_name_waitFor` hangs on exit. Skip if for now.

rdar://180515488