### PR TITLE
[lldb-server] Route info prints to the log channel

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -347,9 +347,9 @@ Status GDBRemoteCommunicationServerLLGS::LaunchProcess() {
              m_current_process->GetID());
   }
 
-  printf("Launched '%s' as process %" PRIu64 "...\n",
-         m_process_launch_info.GetArguments().GetArgumentAtIndex(0),
-         m_current_process->GetID());
+  LLDB_LOG(GetLog(LLDBLog::Host), "Launched '{0}' as process {1}",
+           m_process_launch_info.GetArguments().GetArgumentAtIndex(0),
+           m_current_process->GetID());
 
   return Status();
 }
@@ -398,7 +398,8 @@ Status GDBRemoteCommunicationServerLLGS::AttachToProcess(lldb::pid_t pid) {
               __FUNCTION__, terminal_fd);
   }
 
-  printf("Attached to process %" PRIu64 "...\n", pid);
+  // See LaunchProcess for why this is logged rather than printed.
+  LLDB_LOG(GetLog(LLDBLog::Host), "Attached to process {0}", pid);
   return Status();
 }
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
@@ -449,9 +449,9 @@ Status GDBRemoteCommunicationServerPlatform::LaunchProcess() {
     return error;
   }
 
-  printf("Launched '%s' as process %" PRIu64 "...\n",
-         m_process_launch_info.GetArguments().GetArgumentAtIndex(0),
-         m_process_launch_info.GetProcessID());
+  LLDB_LOG(GetLog(LLDBLog::Platform), "Launched '{0}' as process {1}",
+           m_process_launch_info.GetArguments().GetArgumentAtIndex(0),
+           m_process_launch_info.GetProcessID());
 
   // add to list of spawned processes.  On an lldb-gdbserver, we would expect
   // there to be only one.

--- a/lldb/tools/lldb-server/lldb-gdbserver.cpp
+++ b/lldb/tools/lldb-server/lldb-gdbserver.cpp
@@ -286,7 +286,7 @@ llvm::Error ConnectToRemote(MainLoop &mainloop,
   if (status.Fail())
     return llvm::createStringErrorV("failed to initialize connection: {0}",
                                     status);
-  llvm::outs() << "Connection established.\n";
+  LLDB_LOG(GetLog(LLDBLog::Host), "lldb-server connection established");
   return llvm::Error::success();
 }
 
@@ -485,8 +485,9 @@ int main_gdbserver(int argc, char *argv[]) {
     }
   }
 
-  // Print version info.
-  printf("%s-%s\n", LLGS_PROGRAM_NAME, LLGS_VERSION_STR);
+  // Print version info to the host log channel
+  LLDB_LOG(GetLog(LLDBLog::Host), "{0}-{1}", LLGS_PROGRAM_NAME,
+           LLGS_VERSION_STR);
 
   if (llvm::Error err = ConnectToRemote(
           mainloop, gdb_server, reverse_connect, host_and_port, progname,
@@ -506,7 +507,7 @@ int main_gdbserver(int argc, char *argv[]) {
             ret.AsCString());
     return EXIT_FAILURE;
   }
-  fprintf(stderr, "lldb-server exiting...\n");
+  LLDB_LOG(GetLog(LLDBLog::Host), "lldb-server exiting cleanly");
 
   return EXIT_SUCCESS;
 }

--- a/lldb/tools/lldb-server/lldb-platform.cpp
+++ b/lldb/tools/lldb-server/lldb-platform.cpp
@@ -302,7 +302,8 @@ static void client_handle(GDBRemoteCommunicationServerPlatform &platform,
       break;
   }
 
-  printf("Disconnected.\n");
+  LLDB_LOG(GetLog(LLDBLog::Platform),
+           "lldb-server platform connection disconnected");
 }
 
 static Status spawn_process(const char *progname, const FileSpec &prog,
@@ -625,7 +626,8 @@ int main_platform(int argc, char *argv[]) {
             main_loop, [progname, gdbserver_port, &inferior_arguments, log_file,
                         log_channels, &main_loop, multi_client,
                         &platform_handles](std::unique_ptr<Socket> sock_up) {
-              printf("Connection established.\n");
+              LLDB_LOG(GetLog(LLDBLog::Platform),
+                       "lldb-server platform connection established");
               Status status = spawn_process(
                   progname, HostInfo::GetProgramFileSpec(), sock_up.get(),
                   gdbserver_port, inferior_arguments, log_file, log_channels,
@@ -660,7 +662,7 @@ int main_platform(int argc, char *argv[]) {
     main_loop.Run();
   }
 
-  fprintf(stderr, "lldb-server exiting...\n");
+  LLDB_LOG(GetLog(LLDBLog::Platform), "lldb-server exiting cleanly");
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
When `lldb-server` is invoked as a child of the lldb client and stdout/stderr are piped together to FileCheck on Windows, asynchronous prints from lldb-server race against the client's output and break ordering-sensitive tests.

This patch converts prints to an `LLDB_LOG` entry on the Platform channel and Host channels.

This fixes `local-variables.cpp` on Windows with `LLDB_USE_LLDB_SERVER=1`.

The alternative is to remove the `-NEXT` from `CHECK-NEXT` in the test: https://github.com/llvm/llvm-project/pull/205574