### PR TITLE
[lldb][Windows] Relax Filecheck requirements in local-variables.cpp

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
@@ -19,145 +19,145 @@ int main(int argc, char **argv) {
 }
 
 // CHECK:      (lldb) target create "{{.*}}local-variables.cpp.tmp.exe"
-// CHECK-DAG: Current executable set to '{{.*}}local-variables.cpp.tmp.exe'
-// CHECK-DAG: (lldb) command source -s 0 '{{.*}}local-variables.lldbinit'
-// CHECK-DAG: Executing commands in '{{.*}}local-variables.lldbinit'.
-// CHECK-DAG: (lldb) break set -f local-variables.cpp -l 17
-// CHECK-DAG: Breakpoint 1: where = local-variables.cpp.tmp.exe`main + {{.*}} at local-variables.cpp:{{.*}}, address = {{.*}}
-// CHECK-DAG: (lldb) run a b c d e f g
-// CHECK-DAG: Process {{.*}} launched: '{{.*}}local-variables.cpp.tmp.exe'
-// CHECK-DAG: Process {{.*}} stopped
-// CHECK-DAG: * thread #1, stop reason = breakpoint 1.1
-// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`main(argc=8, argv={{.*}}) at local-variables.cpp:{{.*}}
-// CHECK-DAG:    14   }
-// CHECK-DAG:    15
-// CHECK-DAG:    16   int main(int argc, char **argv) {
-// CHECK-DAG: -> 17     int SomeLocal = argc * 2;
-// CHECK-DAG:    18     return Function(SomeLocal, 'a');
-// CHECK-DAG:    19   }
-// CHECK-DAG:    20
+// CHECK-NEXT: Current executable set to '{{.*}}local-variables.cpp.tmp.exe'
+// CHECK-NEXT: (lldb) command source -s 0 '{{.*}}local-variables.lldbinit'
+// CHECK-NEXT: Executing commands in '{{.*}}local-variables.lldbinit'.
+// CHECK-NEXT: (lldb) break set -f local-variables.cpp -l 17
+// CHECK-NEXT: Breakpoint 1: where = local-variables.cpp.tmp.exe`main + {{.*}} at local-variables.cpp:{{.*}}, address = {{.*}}
+// CHECK-NEXT: (lldb) run a b c d e f g
+// CHECK-NEXT: Process {{.*}} launched: '{{.*}}local-variables.cpp.tmp.exe'
+// CHECK-NEXT: Process {{.*}} stopped
+// CHECK-NEXT: * thread #1, stop reason = breakpoint 1.1
+// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`main(argc=8, argv={{.*}}) at local-variables.cpp:{{.*}}
+// CHECK-NEXT:    14   }
+// CHECK-NEXT:    15
+// CHECK-NEXT:    16   int main(int argc, char **argv) {
+// CHECK-NEXT: -> 17     int SomeLocal = argc * 2;
+// CHECK-NEXT:    18     return Function(SomeLocal, 'a');
+// CHECK-NEXT:    19   }
+// CHECK-NEXT:    20
 
 // CHECK:      (lldb) expression argc
-// CHECK-DAG: (int) $0 = 8
-// CHECK-DAG: (lldb) step
-// CHECK-DAG: Process {{.*}} stopped
-// CHECK-DAG: * thread #1, stop reason = step in
-// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`main(argc=8, argv={{.*}}) at local-variables.cpp:{{.*}}
-// CHECK-DAG:    15
-// CHECK-DAG:    16 int main(int argc, char **argv) {
-// CHECK-DAG:    17     int SomeLocal = argc * 2;
-// CHECK-DAG: -> 18     return Function(SomeLocal, 'a');
-// CHECK-DAG:    19 }
-// CHECK-DAG:    20
+// CHECK-NEXT: (int) $0 = 8
+// CHECK-NEXT: (lldb) step
+// CHECK-NEXT: Process {{.*}} stopped
+// CHECK-NEXT: * thread #1, stop reason = step in
+// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`main(argc=8, argv={{.*}}) at local-variables.cpp:{{.*}}
+// CHECK-NEXT:    15
+// CHECK-NEXT:    16 int main(int argc, char **argv) {
+// CHECK-NEXT:    17     int SomeLocal = argc * 2;
+// CHECK-NEXT: -> 18     return Function(SomeLocal, 'a');
+// CHECK-NEXT:    19 }
+// CHECK-NEXT:    20
 
 // CHECK:      (lldb) expression SomeLocal
-// CHECK-DAG: (int) $1 = 16
-// CHECK-DAG: (lldb) step
-// CHECK-DAG: Process {{.*}} stopped
-// CHECK-DAG: * thread #1, stop reason = step in
-// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
-// CHECK-DAG:    6
-// CHECK-DAG:    7
-// CHECK-DAG:    8 int Function(int Param1, char Param2) {
-// CHECK-DAG: -> 9      unsigned Local1 = Param1 + 1;
-// CHECK-DAG:    10     char Local2 = Param2 + 1;
-// CHECK-DAG:    11     ++Local1;
-// CHECK-DAG:    12     ++Local2;
+// CHECK-NEXT: (int) $1 = 16
+// CHECK-NEXT: (lldb) step
+// CHECK-NEXT: Process {{.*}} stopped
+// CHECK-NEXT: * thread #1, stop reason = step in
+// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
+// CHECK-NEXT:    6
+// CHECK-NEXT:    7
+// CHECK-NEXT:    8 int Function(int Param1, char Param2) {
+// CHECK-NEXT: -> 9      unsigned Local1 = Param1 + 1;
+// CHECK-NEXT:    10     char Local2 = Param2 + 1;
+// CHECK-NEXT:    11     ++Local1;
+// CHECK-NEXT:    12     ++Local2;
 
 // CHECK:      (lldb) expression Param1
-// CHECK-DAG: (int) $2 = 16
-// CHECK-DAG: (lldb) expression Param2
-// CHECK-DAG: (char) $3 = 'a'
-// CHECK-DAG: (lldb) step
-// CHECK-DAG: Process {{.*}} stopped
-// CHECK-DAG: * thread #1, stop reason = step in
-// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
-// CHECK-DAG:    7
-// CHECK-DAG:    8    int Function(int Param1, char Param2) {
-// CHECK-DAG:    9      unsigned Local1 = Param1 + 1;
-// CHECK-DAG: -> 10     char Local2 = Param2 + 1;
-// CHECK-DAG:    11     ++Local1;
-// CHECK-DAG:    12     ++Local2;
-// CHECK-DAG:    13     return Local1;
+// CHECK-NEXT: (int) $2 = 16
+// CHECK-NEXT: (lldb) expression Param2
+// CHECK-NEXT: (char) $3 = 'a'
+// CHECK-NEXT: (lldb) step
+// CHECK-NEXT: Process {{.*}} stopped
+// CHECK-NEXT: * thread #1, stop reason = step in
+// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
+// CHECK-NEXT:    7
+// CHECK-NEXT:    8    int Function(int Param1, char Param2) {
+// CHECK-NEXT:    9      unsigned Local1 = Param1 + 1;
+// CHECK-NEXT: -> 10     char Local2 = Param2 + 1;
+// CHECK-NEXT:    11     ++Local1;
+// CHECK-NEXT:    12     ++Local2;
+// CHECK-NEXT:    13     return Local1;
 
 // CHECK:      (lldb) expression Param1
-// CHECK-DAG: (int) $4 = 16
-// CHECK-DAG: (lldb) expression Param2
-// CHECK-DAG: (char) $5 = 'a'
-// CHECK-DAG: (lldb) expression Local1
-// CHECK-DAG: (unsigned int) $6 = 17
-// CHECK-DAG: (lldb) step
-// CHECK-DAG: Process {{.*}} stopped
-// CHECK-DAG: * thread #1, stop reason = step in
-// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
-// CHECK-DAG:    8    int Function(int Param1, char Param2) {
-// CHECK-DAG:    9      unsigned Local1 = Param1 + 1;
-// CHECK-DAG:    10     char Local2 = Param2 + 1;
-// CHECK-DAG: -> 11     ++Local1;
-// CHECK-DAG:    12     ++Local2;
-// CHECK-DAG:    13     return Local1;
-// CHECK-DAG:    14   }
+// CHECK-NEXT: (int) $4 = 16
+// CHECK-NEXT: (lldb) expression Param2
+// CHECK-NEXT: (char) $5 = 'a'
+// CHECK-NEXT: (lldb) expression Local1
+// CHECK-NEXT: (unsigned int) $6 = 17
+// CHECK-NEXT: (lldb) step
+// CHECK-NEXT: Process {{.*}} stopped
+// CHECK-NEXT: * thread #1, stop reason = step in
+// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
+// CHECK-NEXT:    8    int Function(int Param1, char Param2) {
+// CHECK-NEXT:    9      unsigned Local1 = Param1 + 1;
+// CHECK-NEXT:    10     char Local2 = Param2 + 1;
+// CHECK-NEXT: -> 11     ++Local1;
+// CHECK-NEXT:    12     ++Local2;
+// CHECK-NEXT:    13     return Local1;
+// CHECK-NEXT:    14   }
 
 // CHECK:      (lldb) expression Param1
-// CHECK-DAG: (int) $7 = 16
-// CHECK-DAG: (lldb) expression Param2
-// CHECK-DAG: (char) $8 = 'a'
-// CHECK-DAG: (lldb) expression Local1
-// CHECK-DAG: (unsigned int) $9 = 17
-// CHECK-DAG: (lldb) expression Local2
-// CHECK-DAG: (char) $10 = 'b'
-// CHECK-DAG: (lldb) step
-// CHECK-DAG: Process {{.*}} stopped
-// CHECK-DAG: * thread #1, stop reason = step in
-// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
-// CHECK-DAG:    9      unsigned Local1 = Param1 + 1;
-// CHECK-DAG:    10     char Local2 = Param2 + 1;
-// CHECK-DAG:    11     ++Local1;
-// CHECK-DAG: -> 12     ++Local2;
-// CHECK-DAG:    13     return Local1;
-// CHECK-DAG:    14   }
-// CHECK-DAG:    15
+// CHECK-NEXT: (int) $7 = 16
+// CHECK-NEXT: (lldb) expression Param2
+// CHECK-NEXT: (char) $8 = 'a'
+// CHECK-NEXT: (lldb) expression Local1
+// CHECK-NEXT: (unsigned int) $9 = 17
+// CHECK-NEXT: (lldb) expression Local2
+// CHECK-NEXT: (char) $10 = 'b'
+// CHECK-NEXT: (lldb) step
+// CHECK-NEXT: Process {{.*}} stopped
+// CHECK-NEXT: * thread #1, stop reason = step in
+// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
+// CHECK-NEXT:    9      unsigned Local1 = Param1 + 1;
+// CHECK-NEXT:    10     char Local2 = Param2 + 1;
+// CHECK-NEXT:    11     ++Local1;
+// CHECK-NEXT: -> 12     ++Local2;
+// CHECK-NEXT:    13     return Local1;
+// CHECK-NEXT:    14   }
+// CHECK-NEXT:    15
 
 // CHECK:      (lldb) expression Param1
-// CHECK-DAG: (int) $11 = 16
-// CHECK-DAG: (lldb) expression Param2
-// CHECK-DAG: (char) $12 = 'a'
-// CHECK-DAG: (lldb) expression Local1
-// CHECK-DAG: (unsigned int) $13 = 18
-// CHECK-DAG: (lldb) expression Local2
-// CHECK-DAG: (char) $14 = 'b'
-// CHECK-DAG: (lldb) step
-// CHECK-DAG: Process {{.*}} stopped
-// CHECK-DAG: * thread #1, stop reason = step in
-// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
-// CHECK-DAG:    10      char Local2 = Param2 + 1;
-// CHECK-DAG:    11     ++Local1;
-// CHECK-DAG:    12     ++Local2;
-// CHECK-DAG: -> 13     return Local1;
-// CHECK-DAG:    14   }
-// CHECK-DAG:    15
-// CHECK-DAG:    16   int main(int argc, char **argv) {
+// CHECK-NEXT: (int) $11 = 16
+// CHECK-NEXT: (lldb) expression Param2
+// CHECK-NEXT: (char) $12 = 'a'
+// CHECK-NEXT: (lldb) expression Local1
+// CHECK-NEXT: (unsigned int) $13 = 18
+// CHECK-NEXT: (lldb) expression Local2
+// CHECK-NEXT: (char) $14 = 'b'
+// CHECK-NEXT: (lldb) step
+// CHECK-NEXT: Process {{.*}} stopped
+// CHECK-NEXT: * thread #1, stop reason = step in
+// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
+// CHECK-NEXT:    10      char Local2 = Param2 + 1;
+// CHECK-NEXT:    11     ++Local1;
+// CHECK-NEXT:    12     ++Local2;
+// CHECK-NEXT: -> 13     return Local1;
+// CHECK-NEXT:    14   }
+// CHECK-NEXT:    15
+// CHECK-NEXT:    16   int main(int argc, char **argv) {
 
 // CHECK:      (lldb) expression Param1
-// CHECK-DAG: (int) $15 = 16
-// CHECK-DAG: (lldb) expression Param2
-// CHECK-DAG: (char) $16 = 'a'
-// CHECK-DAG: (lldb) expression Local1
-// CHECK-DAG: (unsigned int) $17 = 18
-// CHECK-DAG: (lldb) expression Local2
-// CHECK-DAG: (char) $18 = 'c'
-// CHECK-DAG: (lldb) continue
+// CHECK-NEXT: (int) $15 = 16
+// CHECK-NEXT: (lldb) expression Param2
+// CHECK-NEXT: (char) $16 = 'a'
+// CHECK-NEXT: (lldb) expression Local1
+// CHECK-NEXT: (unsigned int) $17 = 18
+// CHECK-NEXT: (lldb) expression Local2
+// CHECK-NEXT: (char) $18 = 'c'
+// CHECK-NEXT: (lldb) continue
 // CHECK-DAG: Process {{.*}} resuming
-// CHECK-DAG: Process {{.*}} exited with status = 18 (0x00000012)
+// CHECK-NEXT: Process {{.*}} exited with status = 18 (0x00000012)
 
 // CHECK:      (lldb) target modules dump ast
 // CHECK-DAG: Dumping clang ast for {{.*}} modules.
-// CHECK-DAG: TranslationUnitDecl
-// CHECK-DAG: |-FunctionDecl {{.*}} main 'int (int, char **)'
-// CHECK-DAG: | |-ParmVarDecl {{.*}} argc 'int'
-// CHECK-DAG: | `-ParmVarDecl {{.*}} argv 'char **'
-// CHECK-DAG: |-FunctionDecl {{.*}} __scrt_common_main_seh 'int ()' static 
-// CHECK-DAG: |-FunctionDecl {{.*}} invoke_main 'int ()' inline
+// CHECK-NEXT: TranslationUnitDecl
+// CHECK-NEXT: |-FunctionDecl {{.*}} main 'int (int, char **)'
+// CHECK-NEXT: | |-ParmVarDecl {{.*}} argc 'int'
+// CHECK-NEXT: | `-ParmVarDecl {{.*}} argv 'char **'
+// CHECK-NEXT: |-FunctionDecl {{.*}} __scrt_common_main_seh 'int ()' static 
+// CHECK-NEXT: |-FunctionDecl {{.*}} invoke_main 'int ()' inline
 // CHECK: `-FunctionDecl {{.*}} Function 'int (int, char)'
-// CHECK-DAG:   |-ParmVarDecl {{.*}} Param1 'int'
-// CHECK-DAG:   `-ParmVarDecl {{.*}} Param2 'char'
+// CHECK-NEXT:   |-ParmVarDecl {{.*}} Param1 'int'
+// CHECK-NEXT:   `-ParmVarDecl {{.*}} Param2 'char'

--- a/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
@@ -19,145 +19,145 @@ int main(int argc, char **argv) {
 }
 
 // CHECK:      (lldb) target create "{{.*}}local-variables.cpp.tmp.exe"
-// CHECK-NEXT: Current executable set to '{{.*}}local-variables.cpp.tmp.exe'
-// CHECK-NEXT: (lldb) command source -s 0 '{{.*}}local-variables.lldbinit'
-// CHECK-NEXT: Executing commands in '{{.*}}local-variables.lldbinit'.
-// CHECK-NEXT: (lldb) break set -f local-variables.cpp -l 17
-// CHECK-NEXT: Breakpoint 1: where = local-variables.cpp.tmp.exe`main + {{.*}} at local-variables.cpp:{{.*}}, address = {{.*}}
-// CHECK-NEXT: (lldb) run a b c d e f g
-// CHECK-NEXT: Process {{.*}} launched: '{{.*}}local-variables.cpp.tmp.exe'
-// CHECK-NEXT: Process {{.*}} stopped
-// CHECK-NEXT: * thread #1, stop reason = breakpoint 1.1
-// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`main(argc=8, argv={{.*}}) at local-variables.cpp:{{.*}}
-// CHECK-NEXT:    14   }
-// CHECK-NEXT:    15
-// CHECK-NEXT:    16   int main(int argc, char **argv) {
-// CHECK-NEXT: -> 17     int SomeLocal = argc * 2;
-// CHECK-NEXT:    18     return Function(SomeLocal, 'a');
-// CHECK-NEXT:    19   }
-// CHECK-NEXT:    20
+// CHECK-DAG: Current executable set to '{{.*}}local-variables.cpp.tmp.exe'
+// CHECK-DAG: (lldb) command source -s 0 '{{.*}}local-variables.lldbinit'
+// CHECK-DAG: Executing commands in '{{.*}}local-variables.lldbinit'.
+// CHECK-DAG: (lldb) break set -f local-variables.cpp -l 17
+// CHECK-DAG: Breakpoint 1: where = local-variables.cpp.tmp.exe`main + {{.*}} at local-variables.cpp:{{.*}}, address = {{.*}}
+// CHECK-DAG: (lldb) run a b c d e f g
+// CHECK-DAG: Process {{.*}} launched: '{{.*}}local-variables.cpp.tmp.exe'
+// CHECK-DAG: Process {{.*}} stopped
+// CHECK-DAG: * thread #1, stop reason = breakpoint 1.1
+// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`main(argc=8, argv={{.*}}) at local-variables.cpp:{{.*}}
+// CHECK-DAG:    14   }
+// CHECK-DAG:    15
+// CHECK-DAG:    16   int main(int argc, char **argv) {
+// CHECK-DAG: -> 17     int SomeLocal = argc * 2;
+// CHECK-DAG:    18     return Function(SomeLocal, 'a');
+// CHECK-DAG:    19   }
+// CHECK-DAG:    20
 
 // CHECK:      (lldb) expression argc
-// CHECK-NEXT: (int) $0 = 8
-// CHECK-NEXT: (lldb) step
-// CHECK-NEXT: Process {{.*}} stopped
-// CHECK-NEXT: * thread #1, stop reason = step in
-// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`main(argc=8, argv={{.*}}) at local-variables.cpp:{{.*}}
-// CHECK-NEXT:    15
-// CHECK-NEXT:    16 int main(int argc, char **argv) {
-// CHECK-NEXT:    17     int SomeLocal = argc * 2;
-// CHECK-NEXT: -> 18     return Function(SomeLocal, 'a');
-// CHECK-NEXT:    19 }
-// CHECK-NEXT:    20
+// CHECK-DAG: (int) $0 = 8
+// CHECK-DAG: (lldb) step
+// CHECK-DAG: Process {{.*}} stopped
+// CHECK-DAG: * thread #1, stop reason = step in
+// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`main(argc=8, argv={{.*}}) at local-variables.cpp:{{.*}}
+// CHECK-DAG:    15
+// CHECK-DAG:    16 int main(int argc, char **argv) {
+// CHECK-DAG:    17     int SomeLocal = argc * 2;
+// CHECK-DAG: -> 18     return Function(SomeLocal, 'a');
+// CHECK-DAG:    19 }
+// CHECK-DAG:    20
 
 // CHECK:      (lldb) expression SomeLocal
-// CHECK-NEXT: (int) $1 = 16
-// CHECK-NEXT: (lldb) step
-// CHECK-NEXT: Process {{.*}} stopped
-// CHECK-NEXT: * thread #1, stop reason = step in
-// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
-// CHECK-NEXT:    6
-// CHECK-NEXT:    7
-// CHECK-NEXT:    8 int Function(int Param1, char Param2) {
-// CHECK-NEXT: -> 9      unsigned Local1 = Param1 + 1;
-// CHECK-NEXT:    10     char Local2 = Param2 + 1;
-// CHECK-NEXT:    11     ++Local1;
-// CHECK-NEXT:    12     ++Local2;
+// CHECK-DAG: (int) $1 = 16
+// CHECK-DAG: (lldb) step
+// CHECK-DAG: Process {{.*}} stopped
+// CHECK-DAG: * thread #1, stop reason = step in
+// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
+// CHECK-DAG:    6
+// CHECK-DAG:    7
+// CHECK-DAG:    8 int Function(int Param1, char Param2) {
+// CHECK-DAG: -> 9      unsigned Local1 = Param1 + 1;
+// CHECK-DAG:    10     char Local2 = Param2 + 1;
+// CHECK-DAG:    11     ++Local1;
+// CHECK-DAG:    12     ++Local2;
 
 // CHECK:      (lldb) expression Param1
-// CHECK-NEXT: (int) $2 = 16
-// CHECK-NEXT: (lldb) expression Param2
-// CHECK-NEXT: (char) $3 = 'a'
-// CHECK-NEXT: (lldb) step
-// CHECK-NEXT: Process {{.*}} stopped
-// CHECK-NEXT: * thread #1, stop reason = step in
-// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
-// CHECK-NEXT:    7
-// CHECK-NEXT:    8    int Function(int Param1, char Param2) {
-// CHECK-NEXT:    9      unsigned Local1 = Param1 + 1;
-// CHECK-NEXT: -> 10     char Local2 = Param2 + 1;
-// CHECK-NEXT:    11     ++Local1;
-// CHECK-NEXT:    12     ++Local2;
-// CHECK-NEXT:    13     return Local1;
+// CHECK-DAG: (int) $2 = 16
+// CHECK-DAG: (lldb) expression Param2
+// CHECK-DAG: (char) $3 = 'a'
+// CHECK-DAG: (lldb) step
+// CHECK-DAG: Process {{.*}} stopped
+// CHECK-DAG: * thread #1, stop reason = step in
+// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
+// CHECK-DAG:    7
+// CHECK-DAG:    8    int Function(int Param1, char Param2) {
+// CHECK-DAG:    9      unsigned Local1 = Param1 + 1;
+// CHECK-DAG: -> 10     char Local2 = Param2 + 1;
+// CHECK-DAG:    11     ++Local1;
+// CHECK-DAG:    12     ++Local2;
+// CHECK-DAG:    13     return Local1;
 
 // CHECK:      (lldb) expression Param1
-// CHECK-NEXT: (int) $4 = 16
-// CHECK-NEXT: (lldb) expression Param2
-// CHECK-NEXT: (char) $5 = 'a'
-// CHECK-NEXT: (lldb) expression Local1
-// CHECK-NEXT: (unsigned int) $6 = 17
-// CHECK-NEXT: (lldb) step
-// CHECK-NEXT: Process {{.*}} stopped
-// CHECK-NEXT: * thread #1, stop reason = step in
-// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
-// CHECK-NEXT:    8    int Function(int Param1, char Param2) {
-// CHECK-NEXT:    9      unsigned Local1 = Param1 + 1;
-// CHECK-NEXT:    10     char Local2 = Param2 + 1;
-// CHECK-NEXT: -> 11     ++Local1;
-// CHECK-NEXT:    12     ++Local2;
-// CHECK-NEXT:    13     return Local1;
-// CHECK-NEXT:    14   }
+// CHECK-DAG: (int) $4 = 16
+// CHECK-DAG: (lldb) expression Param2
+// CHECK-DAG: (char) $5 = 'a'
+// CHECK-DAG: (lldb) expression Local1
+// CHECK-DAG: (unsigned int) $6 = 17
+// CHECK-DAG: (lldb) step
+// CHECK-DAG: Process {{.*}} stopped
+// CHECK-DAG: * thread #1, stop reason = step in
+// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
+// CHECK-DAG:    8    int Function(int Param1, char Param2) {
+// CHECK-DAG:    9      unsigned Local1 = Param1 + 1;
+// CHECK-DAG:    10     char Local2 = Param2 + 1;
+// CHECK-DAG: -> 11     ++Local1;
+// CHECK-DAG:    12     ++Local2;
+// CHECK-DAG:    13     return Local1;
+// CHECK-DAG:    14   }
 
 // CHECK:      (lldb) expression Param1
-// CHECK-NEXT: (int) $7 = 16
-// CHECK-NEXT: (lldb) expression Param2
-// CHECK-NEXT: (char) $8 = 'a'
-// CHECK-NEXT: (lldb) expression Local1
-// CHECK-NEXT: (unsigned int) $9 = 17
-// CHECK-NEXT: (lldb) expression Local2
-// CHECK-NEXT: (char) $10 = 'b'
-// CHECK-NEXT: (lldb) step
-// CHECK-NEXT: Process {{.*}} stopped
-// CHECK-NEXT: * thread #1, stop reason = step in
-// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
-// CHECK-NEXT:    9      unsigned Local1 = Param1 + 1;
-// CHECK-NEXT:    10     char Local2 = Param2 + 1;
-// CHECK-NEXT:    11     ++Local1;
-// CHECK-NEXT: -> 12     ++Local2;
-// CHECK-NEXT:    13     return Local1;
-// CHECK-NEXT:    14   }
-// CHECK-NEXT:    15
+// CHECK-DAG: (int) $7 = 16
+// CHECK-DAG: (lldb) expression Param2
+// CHECK-DAG: (char) $8 = 'a'
+// CHECK-DAG: (lldb) expression Local1
+// CHECK-DAG: (unsigned int) $9 = 17
+// CHECK-DAG: (lldb) expression Local2
+// CHECK-DAG: (char) $10 = 'b'
+// CHECK-DAG: (lldb) step
+// CHECK-DAG: Process {{.*}} stopped
+// CHECK-DAG: * thread #1, stop reason = step in
+// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
+// CHECK-DAG:    9      unsigned Local1 = Param1 + 1;
+// CHECK-DAG:    10     char Local2 = Param2 + 1;
+// CHECK-DAG:    11     ++Local1;
+// CHECK-DAG: -> 12     ++Local2;
+// CHECK-DAG:    13     return Local1;
+// CHECK-DAG:    14   }
+// CHECK-DAG:    15
 
 // CHECK:      (lldb) expression Param1
-// CHECK-NEXT: (int) $11 = 16
-// CHECK-NEXT: (lldb) expression Param2
-// CHECK-NEXT: (char) $12 = 'a'
-// CHECK-NEXT: (lldb) expression Local1
-// CHECK-NEXT: (unsigned int) $13 = 18
-// CHECK-NEXT: (lldb) expression Local2
-// CHECK-NEXT: (char) $14 = 'b'
-// CHECK-NEXT: (lldb) step
-// CHECK-NEXT: Process {{.*}} stopped
-// CHECK-NEXT: * thread #1, stop reason = step in
-// CHECK-NEXT:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
-// CHECK-NEXT:    10      char Local2 = Param2 + 1;
-// CHECK-NEXT:    11     ++Local1;
-// CHECK-NEXT:    12     ++Local2;
-// CHECK-NEXT: -> 13     return Local1;
-// CHECK-NEXT:    14   }
-// CHECK-NEXT:    15
-// CHECK-NEXT:    16   int main(int argc, char **argv) {
+// CHECK-DAG: (int) $11 = 16
+// CHECK-DAG: (lldb) expression Param2
+// CHECK-DAG: (char) $12 = 'a'
+// CHECK-DAG: (lldb) expression Local1
+// CHECK-DAG: (unsigned int) $13 = 18
+// CHECK-DAG: (lldb) expression Local2
+// CHECK-DAG: (char) $14 = 'b'
+// CHECK-DAG: (lldb) step
+// CHECK-DAG: Process {{.*}} stopped
+// CHECK-DAG: * thread #1, stop reason = step in
+// CHECK-DAG:     frame #0: {{.*}} local-variables.cpp.tmp.exe`int Function(Param1=16, Param2='a') at local-variables.cpp:{{.*}}
+// CHECK-DAG:    10      char Local2 = Param2 + 1;
+// CHECK-DAG:    11     ++Local1;
+// CHECK-DAG:    12     ++Local2;
+// CHECK-DAG: -> 13     return Local1;
+// CHECK-DAG:    14   }
+// CHECK-DAG:    15
+// CHECK-DAG:    16   int main(int argc, char **argv) {
 
 // CHECK:      (lldb) expression Param1
-// CHECK-NEXT: (int) $15 = 16
-// CHECK-NEXT: (lldb) expression Param2
-// CHECK-NEXT: (char) $16 = 'a'
-// CHECK-NEXT: (lldb) expression Local1
-// CHECK-NEXT: (unsigned int) $17 = 18
-// CHECK-NEXT: (lldb) expression Local2
-// CHECK-NEXT: (char) $18 = 'c'
-// CHECK-NEXT: (lldb) continue
-// CHECK-NEXT: Process {{.*}} resuming
-// CHECK-NEXT: Process {{.*}} exited with status = 18 (0x00000012)
+// CHECK-DAG: (int) $15 = 16
+// CHECK-DAG: (lldb) expression Param2
+// CHECK-DAG: (char) $16 = 'a'
+// CHECK-DAG: (lldb) expression Local1
+// CHECK-DAG: (unsigned int) $17 = 18
+// CHECK-DAG: (lldb) expression Local2
+// CHECK-DAG: (char) $18 = 'c'
+// CHECK-DAG: (lldb) continue
+// CHECK-DAG: Process {{.*}} resuming
+// CHECK-DAG: Process {{.*}} exited with status = 18 (0x00000012)
 
 // CHECK:      (lldb) target modules dump ast
-// CHECK-NEXT: Dumping clang ast for {{.*}} modules.
-// CHECK-NEXT: TranslationUnitDecl
-// CHECK-NEXT: |-FunctionDecl {{.*}} main 'int (int, char **)'
-// CHECK-NEXT: | |-ParmVarDecl {{.*}} argc 'int'
-// CHECK-NEXT: | `-ParmVarDecl {{.*}} argv 'char **'
-// CHECK-NEXT: |-FunctionDecl {{.*}} __scrt_common_main_seh 'int ()' static 
-// CHECK-NEXT: |-FunctionDecl {{.*}} invoke_main 'int ()' inline
+// CHECK-DAG: Dumping clang ast for {{.*}} modules.
+// CHECK-DAG: TranslationUnitDecl
+// CHECK-DAG: |-FunctionDecl {{.*}} main 'int (int, char **)'
+// CHECK-DAG: | |-ParmVarDecl {{.*}} argc 'int'
+// CHECK-DAG: | `-ParmVarDecl {{.*}} argv 'char **'
+// CHECK-DAG: |-FunctionDecl {{.*}} __scrt_common_main_seh 'int ()' static 
+// CHECK-DAG: |-FunctionDecl {{.*}} invoke_main 'int ()' inline
 // CHECK: `-FunctionDecl {{.*}} Function 'int (int, char)'
-// CHECK-NEXT:   |-ParmVarDecl {{.*}} Param1 'int'
-// CHECK-NEXT:   `-ParmVarDecl {{.*}} Param2 'char'
+// CHECK-DAG:   |-ParmVarDecl {{.*}} Param1 'int'
+// CHECK-DAG:   `-ParmVarDecl {{.*}} Param2 'char'

--- a/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
@@ -151,7 +151,7 @@ int main(int argc, char **argv) {
 // CHECK-NEXT: Process {{.*}} exited with status = 18 (0x00000012)
 
 // CHECK:      (lldb) target modules dump ast
-// CHECK-DAG: Dumping clang ast for {{.*}} modules.
+// CHECK: Dumping clang ast for {{.*}} modules.
 // CHECK-NEXT: TranslationUnitDecl
 // CHECK-NEXT: |-FunctionDecl {{.*}} main 'int (int, char **)'
 // CHECK-NEXT: | |-ParmVarDecl {{.*}} argc 'int'

--- a/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
@@ -147,7 +147,7 @@ int main(int argc, char **argv) {
 // CHECK-NEXT: (lldb) expression Local2
 // CHECK-NEXT: (char) $18 = 'c'
 // CHECK-NEXT: (lldb) continue
-// CHECK-DAG: Process {{.*}} resuming
+// CHECK: Process {{.*}} resuming
 // CHECK-NEXT: Process {{.*}} exited with status = 18 (0x00000012)
 
 // CHECK:      (lldb) target modules dump ast


### PR DESCRIPTION
When using `lldb-server` on Windows, lldb's output gets mangled with lldb-server's info prints. This causes the `local-variables.cpp` test to fail.

Relax that test by switching from `CHECK-NEXT` to `CHECK-DAG` where the prints are emitted.

This is an alternative to https://github.com/llvm/llvm-project/pull/205572.

rdar://181035363