### PR TITLE
[LangRef] Clarifying the copying behaviour of byval

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -1361,7 +1361,7 @@ Currently, only the following parameter attributes are defined:
     (if there is no explicit align attribute). That is, the hidden copy is
     interpreted as a call to memcpy with the allocation size of the specified type,
     instead of loading from the pointee and storing back into the copy in the type.
-    In this case, the padding between field types of a struct type is still copied.
+    In particular, the padding between field types of a struct type is still copied.
 
     The byval attribute also supports specifying an alignment with the
     ``align`` attribute. It indicates the alignment of the stack slot to

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -1357,7 +1357,11 @@ Currently, only the following parameter attributes are defined:
     ``byval`` parameters). This is not a valid attribute for return
     values.
 
-    The byval type argument indicates the in-memory value type.
+    The byval type argument indicates the in-memory value type. Note that
+    the hidden copy is interpreted as loading from the pointee and storing
+    back into the copy in the specified type instead of a call to memcpy.
+    In this case, the padding between field types of a struct type remains
+    uninitialized.
 
     The byval attribute also supports specifying an alignment with the
     ``align`` attribute. It indicates the alignment of the stack slot to

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -1357,12 +1357,11 @@ Currently, only the following parameter attributes are defined:
     ``byval`` parameters). This is not a valid attribute for return
     values.
 
-    The byval type argument indicates the in-memory value type. Note that
-    the hidden copy is interpreted as a call to memcpy with the allocation
-    size of the specified type, instead of loading from the pointee and
-    storing back into the copy in the type. In this case, the padding between
-    field types of a struct type is still copied, since it may be a part of
-    another active member of a union type.
+    The byval type argument is only used for its allocation size and alignment
+    (if there is no explicit align attribute). That is, the hidden copy is
+    interpreted as a call to memcpy with the allocation size of the specified type,
+    instead of loading from the pointee and storing back into the copy in the type.
+    In this case, the padding between field types of a struct type is still copied.
 
     The byval attribute also supports specifying an alignment with the
     ``align`` attribute. It indicates the alignment of the stack slot to

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -1358,10 +1358,11 @@ Currently, only the following parameter attributes are defined:
     values.
 
     The byval type argument indicates the in-memory value type. Note that
-    the hidden copy is interpreted as loading from the pointee and storing
-    back into the copy in the specified type instead of a call to memcpy.
-    In this case, the padding between field types of a struct type remains
-    uninitialized.
+    the hidden copy is interpreted as a call to memcpy with the allocation
+    size of the specified type, instead of loading from the pointee and
+    storing back into the copy in the type. In this case, the padding between
+    field types of a struct type is still copied, since it may be a part of
+    another active member of a union type.
 
     The byval attribute also supports specifying an alignment with the
     ``align`` attribute. It indicates the alignment of the stack slot to


### PR DESCRIPTION
The hidden copy of a byval argument can only be treated as a continuous memcpy with the allocation size. It is incorrect to interpret it as a load-store forwarding in the specified type, since a padding between struct fields may still be a part of an active member of a union type.

See also previous discussions in https://github.com/llvm/llvm-project/pull/201852.
