### PR TITLE
[Docs][TySan] Correct optimisation remarks

### DIFF
--- a/clang/docs/TypeSanitizer.rst
+++ b/clang/docs/TypeSanitizer.rst
@@ -75,8 +75,8 @@ Usage
 
 Compile and link your program with ``-fsanitize=type`` flag. The
 TypeSanitizer run-time library should be linked to the final executable, so
-make sure to use ``clang`` (not ``ld``) for the final link step. To
-get a reasonable performance add ``-O1`` or higher.
+make sure to use ``clang`` (not ``ld``) for the final link step. To increase performance, you can optimise with ``-O1``.
+Higher levels of optimization may result in false-negatives as incorrect code fragments may get optimized out incorrectly.
 TypeSanitizer by default doesn't print the full stack trace in error messages. Use ``TYSAN_OPTIONS=print_stacktrace=1`` 
 to print the full trace. To get nicer stack traces in error messages add ``-fno-omit-frame-pointer`` and 
 ``-g``.  To get perfect stack traces you may need to disable inlining (just use ``-O1``) and tail call elimination 


### PR DESCRIPTION
I think I got my wires crossed here between TySan and other sanitizers when I was using their docs for reference on how to structure this file. If a strict aliasing violation was going to cause problems, by the time higher level optimizations come through and restructure the code, say by removing a load/store, you no longer have the behaviour TySan would pick up on.