### PR TITLE
[clang-doc] Test more language constructs

### DIFF
--- a/clang-tools-extra/test/clang-doc/Inputs/array-type.cpp
+++ b/clang-tools-extra/test/clang-doc/Inputs/array-type.cpp
@@ -1,0 +1,1 @@
+void qux(int (&arr)[5]);

--- a/clang-tools-extra/test/clang-doc/Inputs/class-partial-specialization.cpp
+++ b/clang-tools-extra/test/clang-doc/Inputs/class-partial-specialization.cpp
@@ -1,0 +1,2 @@
+template<typename T> struct MyClass {};
+template<typename T> struct MyClass<T*> {};

--- a/clang-tools-extra/test/clang-doc/Inputs/function-pointer-type.cpp
+++ b/clang-tools-extra/test/clang-doc/Inputs/function-pointer-type.cpp
@@ -1,0 +1,1 @@
+void bar(void (*fn)(int));

--- a/clang-tools-extra/test/clang-doc/Inputs/member-function-pointer-type.cpp
+++ b/clang-tools-extra/test/clang-doc/Inputs/member-function-pointer-type.cpp
@@ -1,0 +1,2 @@
+struct Class {};
+void baz(void (Class::*fn)(int));

--- a/clang-tools-extra/test/clang-doc/Inputs/nested-pointer-qualifiers.cpp
+++ b/clang-tools-extra/test/clang-doc/Inputs/nested-pointer-qualifiers.cpp
@@ -1,0 +1,1 @@
+void foo(const int * const * ptr);

--- a/clang-tools-extra/test/clang-doc/array-type.cpp
+++ b/clang-tools-extra/test/clang-doc/array-type.cpp
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --output=%t --format=html --executor=standalone %S/Inputs/array-type.cpp
+// RUN: FileCheck %s --check-prefix=HTML < %t/html/GlobalNamespace/index.html
+// RUN: clang-doc --output=%t --format=md --executor=standalone %S/Inputs/array-type.cpp
+// RUN: FileCheck %s --check-prefix=MD < %t/GlobalNamespace/index.md
+// RUN: clang-doc --output=%t --format=md_mustache --executor=standalone %S/Inputs/array-type.cpp
+// RUN: FileCheck %s --check-prefix=MD-MUSTACHE < %t/md/GlobalNamespace/index.md
+
+// HTML: <pre><code class="language-cpp code-clang-doc">void qux (int (&amp;)[5] arr)</code></pre>
+
+// MD: *void qux(int (&)[5] arr)*
+// MD-MUSTACHE: *void qux(int (&)[5] arr)*

--- a/clang-tools-extra/test/clang-doc/class-partial-specialization.cpp
+++ b/clang-tools-extra/test/clang-doc/class-partial-specialization.cpp
@@ -1,0 +1,13 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --output=%t --format=html --executor=standalone %S/Inputs/class-partial-specialization.cpp
+// RUN: FileCheck %s --check-prefix=HTML < %t/html/GlobalNamespace/_ZTV7MyClassIPT_E.html
+// RUN: clang-doc --output=%t --format=md --executor=standalone %S/Inputs/class-partial-specialization.cpp
+// RUN: FileCheck %s --check-prefix=MD < %t/GlobalNamespace/MyClass.md
+// RUN: clang-doc --output=%t --format=md_mustache --executor=standalone %S/Inputs/class-partial-specialization.cpp
+// RUN: FileCheck %s --check-prefix=MD-MUSTACHE < %t/md/GlobalNamespace/_ZTV7MyClassIPT_E.md
+
+// HTML: <pre><code class="language-cpp code-clang-doc">template &lt;typename T&gt;</code></pre>
+// HTML: <h1 class="hero__title-large">struct MyClass</h1>
+
+// MD: # struct MyClass
+// MD-MUSTACHE: # struct MyClass

--- a/clang-tools-extra/test/clang-doc/function-pointer-type.cpp
+++ b/clang-tools-extra/test/clang-doc/function-pointer-type.cpp
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --output=%t --format=html --executor=standalone %S/Inputs/function-pointer-type.cpp
+// RUN: FileCheck %s --check-prefix=HTML < %t/html/GlobalNamespace/index.html
+// RUN: clang-doc --output=%t --format=md --executor=standalone %S/Inputs/function-pointer-type.cpp
+// RUN: FileCheck %s --check-prefix=MD < %t/GlobalNamespace/index.md
+// RUN: clang-doc --output=%t --format=md_mustache --executor=standalone %S/Inputs/function-pointer-type.cpp
+// RUN: FileCheck %s --check-prefix=MD-MUSTACHE < %t/md/GlobalNamespace/index.md
+
+// HTML: <pre><code class="language-cpp code-clang-doc">void bar (void (*)(int) fn)</code></pre>
+
+// MD: *void bar(void (*)(int) fn)*
+// MD-MUSTACHE: *void bar(void (*)(int) fn)*

--- a/clang-tools-extra/test/clang-doc/json/array-type.cpp
+++ b/clang-tools-extra/test/clang-doc/json/array-type.cpp
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %S/../Inputs/array-type.cpp
+// RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
+
+// CHECK:          "Functions": [
+// CHECK-NEXT:       {
+// CHECK:              "Name": "qux",
+// CHECK:              "Params": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "Name": "arr",
+// CHECK-NEXT:             "ParamEnd": true,
+// CHECK-NEXT:             "Type": {
+// CHECK-NEXT:               "Name": "int (&)[5]",
+// CHECK-NEXT:               "QualName": "int (&)[5]",
+// CHECK-NEXT:               "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]

--- a/clang-tools-extra/test/clang-doc/json/class-partial-specialization.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-partial-specialization.cpp
@@ -1,0 +1,25 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %S/../Inputs/class-partial-specialization.cpp
+// RUN: FileCheck %s < %t/json/GlobalNamespace/_ZTV7MyClassIPT_E.json
+
+// CHECK:      "MangledName": "_ZTV7MyClassIPT_E",
+// CHECK-NEXT: "Name": "MyClass",
+// CHECK:      "Template": {
+// CHECK-NEXT:   "Parameters": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "End": true,
+// CHECK-NEXT:       "Param": "typename T"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "Specialization": {
+// CHECK-NEXT:     "Parameters": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "Param": "T*",
+// CHECK-NEXT:         "SpecParamEnd": true
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "SpecializationOf": "{{[0-9A-F]*}}",
+// CHECK-NEXT:     "VerticalDisplay": false
+// CHECK-NEXT:   },
+// CHECK-NEXT:   "VerticalDisplay": false
+// CHECK-NEXT: }

--- a/clang-tools-extra/test/clang-doc/json/function-pointer-type.cpp
+++ b/clang-tools-extra/test/clang-doc/json/function-pointer-type.cpp
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %S/../Inputs/function-pointer-type.cpp
+// RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
+
+// CHECK:          "Functions": [
+// CHECK-NEXT:       {
+// CHECK:              "Name": "bar",
+// CHECK:              "Params": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "Name": "fn",
+// CHECK-NEXT:             "ParamEnd": true,
+// CHECK-NEXT:             "Type": {
+// CHECK-NEXT:               "Name": "void (*)(int)",
+// CHECK-NEXT:               "QualName": "void (*)(int)",
+// CHECK-NEXT:               "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]

--- a/clang-tools-extra/test/clang-doc/json/member-function-pointer-type.cpp
+++ b/clang-tools-extra/test/clang-doc/json/member-function-pointer-type.cpp
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %S/../Inputs/member-function-pointer-type.cpp
+// RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
+
+// CHECK:          "Functions": [
+// CHECK-NEXT:       {
+// CHECK:              "Name": "baz",
+// CHECK:              "Params": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "Name": "fn",
+// CHECK-NEXT:             "ParamEnd": true,
+// CHECK-NEXT:             "Type": {
+// CHECK-NEXT:               "Name": "void (Class::*)(int)",
+// CHECK-NEXT:               "QualName": "void (Class::*)(int)",
+// CHECK-NEXT:               "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]

--- a/clang-tools-extra/test/clang-doc/json/nested-pointer-qualifiers.cpp
+++ b/clang-tools-extra/test/clang-doc/json/nested-pointer-qualifiers.cpp
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --pretty-json --output=%t --format=json --executor=standalone %S/../Inputs/nested-pointer-qualifiers.cpp
+// RUN: FileCheck %s < %t/json/GlobalNamespace/index.json
+
+// CHECK:          "Functions": [
+// CHECK-NEXT:       {
+// CHECK:              "Name": "foo",
+// CHECK:              "Params": [
+// CHECK-NEXT:           {
+// CHECK-NEXT:             "Name": "ptr",
+// CHECK-NEXT:             "ParamEnd": true,
+// CHECK-NEXT:             "Type": {
+// CHECK-NEXT:               "Name": "const int *const *",
+// CHECK-NEXT:               "QualName": "const int *const *",
+// CHECK-NEXT:               "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         ]

--- a/clang-tools-extra/test/clang-doc/member-function-pointer-type.cpp
+++ b/clang-tools-extra/test/clang-doc/member-function-pointer-type.cpp
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --output=%t --format=html --executor=standalone %S/Inputs/member-function-pointer-type.cpp
+// RUN: FileCheck %s --check-prefix=HTML < %t/html/GlobalNamespace/index.html
+// RUN: clang-doc --output=%t --format=md --executor=standalone %S/Inputs/member-function-pointer-type.cpp
+// RUN: FileCheck %s --check-prefix=MD < %t/GlobalNamespace/index.md
+// RUN: clang-doc --output=%t --format=md_mustache --executor=standalone %S/Inputs/member-function-pointer-type.cpp
+// RUN: FileCheck %s --check-prefix=MD-MUSTACHE < %t/md/GlobalNamespace/index.md
+
+// HTML: <pre><code class="language-cpp code-clang-doc">void baz (void (Class::*)(int) fn)</code></pre>
+
+// MD: *void baz(void (Class::*)(int) fn)*
+// MD-MUSTACHE: *void baz(void (Class::*)(int) fn)*

--- a/clang-tools-extra/test/clang-doc/nested-pointer-qualifiers.cpp
+++ b/clang-tools-extra/test/clang-doc/nested-pointer-qualifiers.cpp
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --output=%t --format=html --executor=standalone %S/Inputs/nested-pointer-qualifiers.cpp
+// RUN: FileCheck %s --check-prefix=HTML < %t/html/GlobalNamespace/index.html
+// RUN: clang-doc --output=%t --format=md --executor=standalone %S/Inputs/nested-pointer-qualifiers.cpp
+// RUN: FileCheck %s --check-prefix=MD < %t/GlobalNamespace/index.md
+// RUN: clang-doc --output=%t --format=md_mustache --executor=standalone %S/Inputs/nested-pointer-qualifiers.cpp
+// RUN: FileCheck %s --check-prefix=MD-MUSTACHE < %t/md/GlobalNamespace/index.md
+
+// HTML: <pre><code class="language-cpp code-clang-doc">void foo (const int *const * ptr)</code></pre>
+
+// MD: *void foo(const int *const * ptr)*
+// MD-MUSTACHE: *void foo(const int *const * ptr)*


### PR DESCRIPTION
We're missing several different language constructs in our tests. This
patch simply adds the basic tests and captures the output without trying
to fix or adjust any behavior, and can be considered a sort of precommit
test for future fixes to the various documentation components.