### PR TITLE
[LV] Allow interleave analysis to emit runtime no-wrap predicates

### DIFF
--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -631,6 +631,14 @@ public:
   /// Return true if this group is full, i.e. it has no gaps.
   bool isFull() const { return getNumMembers() == getFactor(); }
 
+  void addRequiredPredicates(ArrayRef<const SCEVPredicate *> Preds) {
+    Predicates.append(Preds.begin(), Preds.end());
+  }
+
+  ArrayRef<const SCEVPredicate *> getRequiredPredicates() const {
+    return Predicates;
+  }
+
 private:
   uint32_t Factor; // Interleave Factor.
   bool Reverse;
@@ -651,6 +659,8 @@ private:
   //      %odd = add i32               // Def of %odd
   //      store i32 %odd               // Insert Position
   InstTy *InsertPos;
+
+  SmallVector<const SCEVPredicate *> Predicates;
 };
 
 /// Drive the analysis of interleaved memory accesses in the loop.

--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -1596,10 +1596,13 @@ void InterleavedAccessInfo::analyzeInterleaving(
     assert(Member && "Group member does not exist");
     Value *MemberPtr = getLoadStorePointerOperand(Member);
     Type *AccessTy = getLoadStoreType(Member);
+    SmallVector<const SCEVPredicate *, 2> Predicates;
     if (getPtrStride(PSE, AccessTy, MemberPtr, TheLoop, *DT, Strides,
-                     /*Assume=*/false, /*ShouldCheckWrap=*/true)
-            .value_or(0))
+                     /*ShouldCheckWrap=*/true, &Predicates)
+            .value_or(0)) {
+      Group->addRequiredPredicates(Predicates);
       return false;
+    }
     LLVM_DEBUG(dbgs() << "LV: Invalidate candidate interleaved group due to "
                       << FirstOrLast
                       << " group member potentially pointer-wrapping.\n");
@@ -1611,11 +1614,6 @@ void InterleavedAccessInfo::analyzeInterleaving(
   // accesses may wrap around. We have to revisit the getPtrStride analysis,
   // this time with ShouldCheckWrap=true, since collectConstStrideAccesses does
   // not check wrapping (see documentation there).
-  // FORNOW we use Assume=false;
-  // TODO: Change to Assume=true but making sure we don't exceed the threshold
-  // of runtime SCEV assumptions checks (thereby potentially failing to
-  // vectorize altogether).
-  // Additional optional optimizations:
   // TODO: If we are peeling the loop and we know that the first pointer doesn't
   // wrap then we can deduce that all pointers in the group don't wrap.
   // This means that we can forcefully peel the loop in order to only have to

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -1097,6 +1097,25 @@ public:
     return EpilogueLoweringStatus == CM_EpilogueAllowed;
   }
 
+  bool isForceVectorized() const {
+    return Hints->getForce() == LoopVectorizeHints::FK_Enabled;
+  }
+
+  /// Returns true if the loop should be optimized for size, which means SCEV
+  /// predicates (i.e. runtime checks) are not allowed.
+  bool isOptForSize() const {
+    return !isForceVectorized() &&
+           (EpilogueLoweringStatus == CM_EpilogueNotAllowedOptSize ||
+            EpilogueLoweringStatus == CM_EpilogueNotAllowedLowTripLoop);
+  }
+
+  /// Returns the SCEV check complexity threshold, accounting for force
+  /// vectorization pragma which raises the limit.
+  unsigned getSCEVCheckThreshold() const {
+    return isForceVectorized() ? PragmaVectorizeSCEVCheckThreshold
+                               : VectorizeSCEVCheckThreshold;
+  }
+
   /// Returns true if tail-folding is preferred over an epilogue.
   bool preferTailFoldedLoop() const {
     return EpilogueLoweringStatus == CM_EpilogueNotNeededFoldTail ||
@@ -4744,8 +4763,15 @@ void LoopVectorizationCostModel::setCostBasedWideningDecision(ElementCount VF) {
           continue;
 
         NumAccesses = Group->getNumMembers();
-        if (interleavedAccessCanBeWidened(&I, VF))
-          InterleaveCost = getInterleaveGroupCost(&I, VF);
+        if (interleavedAccessCanBeWidened(&I, VF)) {
+          unsigned PredComplexity = 0;
+          for (const auto *P : Group->getRequiredPredicates())
+            PredComplexity += P->getComplexity();
+          if (PredComplexity == 0 ||
+              (!isOptForSize() && (PSE.getPredicate().getComplexity() +
+                                   PredComplexity) < getSCEVCheckThreshold()))
+            InterleaveCost = getInterleaveGroupCost(&I, VF);
+        }
       }
 
       InstructionCost GatherScatterCost =
@@ -4782,6 +4808,9 @@ void LoopVectorizationCostModel::setCostBasedWideningDecision(ElementCount VF) {
         } else {
           setWideningDecision(Group, VF, Decision, Cost);
         }
+        if (Decision == CM_Interleave)
+          for (const auto *P : Group->getRequiredPredicates())
+            PSE.addPredicate(*P);
       } else
         setWideningDecision(&I, VF, Decision, Cost);
     }
@@ -6532,16 +6561,9 @@ VPlanPtr LoopVectorizationPlanner::tryToBuildVPlan1() {
                    LAI->getSymbolicStrides(), VPDT);
 
   // Add surviving induction predicates to PSE and check constraints.
-  bool ForceVectorization = Hints.getForce() == LoopVectorizeHints::FK_Enabled;
-  bool OptForSize =
-      !ForceVectorization &&
-      (CM.EpilogueLoweringStatus == CM_EpilogueNotAllowedOptSize ||
-       CM.EpilogueLoweringStatus == CM_EpilogueNotAllowedLowTripLoop);
-  unsigned SCEVCheckThreshold = ForceVectorization
-                                    ? PragmaVectorizeSCEVCheckThreshold
-                                    : VectorizeSCEVCheckThreshold;
   if (!RUN_VPLAN_PASS(VPlanTransforms::finalizeSCEVPredicates, *VPlan0, PSE,
-                      OptForSize, SCEVCheckThreshold, ORE, OrigLoop))
+                      CM.isOptForSize(), CM.getSCEVCheckThreshold(), ORE,
+                      OrigLoop))
     return nullptr;
 
   // If we're vectorizing a loop with an uncountable exit, make sure that the

--- a/llvm/test/Transforms/LoopVectorize/AArch64/induction-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/induction-costs.ll
@@ -752,13 +752,23 @@ define i64 @live_out_extract_from_ptr_iv_increment(i64 %count, ptr %start, ptr n
 ; CHECK-SAME: i64 [[COUNT:%.*]], ptr [[START:%.*]], ptr noalias [[DST:%.*]]) {
 ; CHECK-NEXT:  [[ITER_CHECK:.*]]:
 ; CHECK-NEXT:    [[TMP0:%.*]] = add i64 [[COUNT]], 1
-; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i64 [[TMP0]], 8
+; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ule i64 [[TMP0]], 8
 ; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK]], label %[[VEC_EPILOG_SCALAR_PH:.*]], label %[[VECTOR_MAIN_LOOP_ITER_CHECK:.*]]
 ; CHECK:       [[VECTOR_MAIN_LOOP_ITER_CHECK]]:
-; CHECK-NEXT:    [[MIN_ITERS_CHECK1:%.*]] = icmp ult i64 [[TMP0]], 16
+; CHECK-NEXT:    [[MUL:%.*]] = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 3, i64 [[COUNT]])
+; CHECK-NEXT:    [[MUL_RESULT:%.*]] = extractvalue { i64, i1 } [[MUL]], 0
+; CHECK-NEXT:    [[MUL_OVERFLOW:%.*]] = extractvalue { i64, i1 } [[MUL]], 1
+; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr i8, ptr [[START]], i64 [[MUL_RESULT]]
+; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult ptr [[TMP5]], [[START]]
+; CHECK-NEXT:    [[TMP7:%.*]] = or i1 [[TMP6]], [[MUL_OVERFLOW]]
+; CHECK-NEXT:    br i1 [[TMP7]], label %[[VEC_EPILOG_SCALAR_PH]], label %[[VECTOR_MAIN_LOOP_ITER_CHECK1:.*]]
+; CHECK:       [[VECTOR_MAIN_LOOP_ITER_CHECK1]]:
+; CHECK-NEXT:    [[MIN_ITERS_CHECK1:%.*]] = icmp ule i64 [[TMP0]], 32
 ; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK1]], label %[[VEC_EPILOG_PH:.*]], label %[[VECTOR_PH:.*]]
 ; CHECK:       [[VECTOR_PH]]:
-; CHECK-NEXT:    [[N_MOD_VF:%.*]] = urem i64 [[TMP0]], 16
+; CHECK-NEXT:    [[N_MOD_VF1:%.*]] = urem i64 [[TMP0]], 32
+; CHECK-NEXT:    [[TMP4:%.*]] = icmp eq i64 [[N_MOD_VF1]], 0
+; CHECK-NEXT:    [[N_MOD_VF:%.*]] = select i1 [[TMP4]], i64 32, i64 [[N_MOD_VF1]]
 ; CHECK-NEXT:    [[N_VEC:%.*]] = sub i64 [[TMP0]], [[N_MOD_VF]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = mul i64 [[N_VEC]], 3
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP1]]
@@ -766,190 +776,51 @@ define i64 @live_out_extract_from_ptr_iv_increment(i64 %count, ptr %start, ptr n
 ; CHECK:       [[VECTOR_BODY]]:
 ; CHECK-NEXT:    [[INDEX:%.*]] = phi i64 [ 0, %[[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], %[[VECTOR_BODY]] ]
 ; CHECK-NEXT:    [[TMP3:%.*]] = mul i64 [[INDEX]], 3
-; CHECK-NEXT:    [[TMP4:%.*]] = add i64 [[TMP3]], 3
-; CHECK-NEXT:    [[TMP5:%.*]] = add i64 [[TMP3]], 6
-; CHECK-NEXT:    [[TMP6:%.*]] = add i64 [[TMP3]], 9
-; CHECK-NEXT:    [[TMP7:%.*]] = add i64 [[TMP3]], 12
-; CHECK-NEXT:    [[TMP8:%.*]] = add i64 [[TMP3]], 15
-; CHECK-NEXT:    [[TMP9:%.*]] = add i64 [[TMP3]], 18
-; CHECK-NEXT:    [[TMP10:%.*]] = add i64 [[TMP3]], 21
-; CHECK-NEXT:    [[TMP11:%.*]] = add i64 [[TMP3]], 24
-; CHECK-NEXT:    [[TMP12:%.*]] = add i64 [[TMP3]], 27
-; CHECK-NEXT:    [[TMP13:%.*]] = add i64 [[TMP3]], 30
-; CHECK-NEXT:    [[TMP14:%.*]] = add i64 [[TMP3]], 33
-; CHECK-NEXT:    [[TMP15:%.*]] = add i64 [[TMP3]], 36
-; CHECK-NEXT:    [[TMP16:%.*]] = add i64 [[TMP3]], 39
-; CHECK-NEXT:    [[TMP17:%.*]] = add i64 [[TMP3]], 42
-; CHECK-NEXT:    [[TMP18:%.*]] = add i64 [[TMP3]], 45
-; CHECK-NEXT:    [[NEXT_GEP:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP3]]
-; CHECK-NEXT:    [[NEXT_GEP2:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP4]]
-; CHECK-NEXT:    [[NEXT_GEP3:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP5]]
-; CHECK-NEXT:    [[NEXT_GEP4:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP6]]
-; CHECK-NEXT:    [[NEXT_GEP5:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP7]]
-; CHECK-NEXT:    [[NEXT_GEP6:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP8]]
-; CHECK-NEXT:    [[NEXT_GEP7:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP9]]
-; CHECK-NEXT:    [[NEXT_GEP8:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP10]]
-; CHECK-NEXT:    [[NEXT_GEP9:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP11]]
-; CHECK-NEXT:    [[NEXT_GEP10:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP12]]
-; CHECK-NEXT:    [[NEXT_GEP11:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP13]]
-; CHECK-NEXT:    [[NEXT_GEP12:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP14]]
-; CHECK-NEXT:    [[NEXT_GEP13:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP15]]
-; CHECK-NEXT:    [[NEXT_GEP14:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP16]]
-; CHECK-NEXT:    [[NEXT_GEP15:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP17]]
+; CHECK-NEXT:    [[TMP18:%.*]] = add i64 [[TMP3]], 48
 ; CHECK-NEXT:    [[NEXT_GEP16:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP18]]
-; CHECK-NEXT:    [[TMP19:%.*]] = load i8, ptr [[NEXT_GEP]], align 1
-; CHECK-NEXT:    [[TMP20:%.*]] = load i8, ptr [[NEXT_GEP2]], align 1
-; CHECK-NEXT:    [[TMP21:%.*]] = load i8, ptr [[NEXT_GEP3]], align 1
-; CHECK-NEXT:    [[TMP22:%.*]] = load i8, ptr [[NEXT_GEP4]], align 1
-; CHECK-NEXT:    [[TMP23:%.*]] = load i8, ptr [[NEXT_GEP5]], align 1
-; CHECK-NEXT:    [[TMP24:%.*]] = load i8, ptr [[NEXT_GEP6]], align 1
-; CHECK-NEXT:    [[TMP25:%.*]] = load i8, ptr [[NEXT_GEP7]], align 1
-; CHECK-NEXT:    [[TMP26:%.*]] = load i8, ptr [[NEXT_GEP8]], align 1
-; CHECK-NEXT:    [[TMP27:%.*]] = load i8, ptr [[NEXT_GEP9]], align 1
-; CHECK-NEXT:    [[TMP28:%.*]] = load i8, ptr [[NEXT_GEP10]], align 1
-; CHECK-NEXT:    [[TMP29:%.*]] = load i8, ptr [[NEXT_GEP11]], align 1
-; CHECK-NEXT:    [[TMP30:%.*]] = load i8, ptr [[NEXT_GEP12]], align 1
-; CHECK-NEXT:    [[TMP31:%.*]] = load i8, ptr [[NEXT_GEP13]], align 1
-; CHECK-NEXT:    [[TMP32:%.*]] = load i8, ptr [[NEXT_GEP14]], align 1
-; CHECK-NEXT:    [[TMP33:%.*]] = load i8, ptr [[NEXT_GEP15]], align 1
-; CHECK-NEXT:    [[TMP34:%.*]] = load i8, ptr [[NEXT_GEP16]], align 1
-; CHECK-NEXT:    [[TMP35:%.*]] = insertelement <16 x i8> poison, i8 [[TMP19]], i32 0
-; CHECK-NEXT:    [[TMP36:%.*]] = insertelement <16 x i8> [[TMP35]], i8 [[TMP20]], i32 1
-; CHECK-NEXT:    [[TMP37:%.*]] = insertelement <16 x i8> [[TMP36]], i8 [[TMP21]], i32 2
-; CHECK-NEXT:    [[TMP38:%.*]] = insertelement <16 x i8> [[TMP37]], i8 [[TMP22]], i32 3
-; CHECK-NEXT:    [[TMP39:%.*]] = insertelement <16 x i8> [[TMP38]], i8 [[TMP23]], i32 4
-; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <16 x i8> [[TMP39]], i8 [[TMP24]], i32 5
-; CHECK-NEXT:    [[TMP41:%.*]] = insertelement <16 x i8> [[TMP40]], i8 [[TMP25]], i32 6
-; CHECK-NEXT:    [[TMP42:%.*]] = insertelement <16 x i8> [[TMP41]], i8 [[TMP26]], i32 7
-; CHECK-NEXT:    [[TMP43:%.*]] = insertelement <16 x i8> [[TMP42]], i8 [[TMP27]], i32 8
-; CHECK-NEXT:    [[TMP44:%.*]] = insertelement <16 x i8> [[TMP43]], i8 [[TMP28]], i32 9
-; CHECK-NEXT:    [[TMP45:%.*]] = insertelement <16 x i8> [[TMP44]], i8 [[TMP29]], i32 10
-; CHECK-NEXT:    [[TMP46:%.*]] = insertelement <16 x i8> [[TMP45]], i8 [[TMP30]], i32 11
-; CHECK-NEXT:    [[TMP47:%.*]] = insertelement <16 x i8> [[TMP46]], i8 [[TMP31]], i32 12
-; CHECK-NEXT:    [[TMP48:%.*]] = insertelement <16 x i8> [[TMP47]], i8 [[TMP32]], i32 13
-; CHECK-NEXT:    [[TMP49:%.*]] = insertelement <16 x i8> [[TMP48]], i8 [[TMP33]], i32 14
-; CHECK-NEXT:    [[TMP50:%.*]] = insertelement <16 x i8> [[TMP49]], i8 [[TMP34]], i32 15
+; CHECK-NEXT:    [[WIDE_VEC:%.*]] = load <48 x i8>, ptr [[NEXT_GEP16]], align 1
+; CHECK-NEXT:    [[TMP50:%.*]] = shufflevector <48 x i8> [[WIDE_VEC]], <48 x i8> poison, <16 x i32> <i32 0, i32 3, i32 6, i32 9, i32 12, i32 15, i32 18, i32 21, i32 24, i32 27, i32 30, i32 33, i32 36, i32 39, i32 42, i32 45>
 ; CHECK-NEXT:    [[TMP51:%.*]] = zext <16 x i8> [[TMP50]] to <16 x i32>
 ; CHECK-NEXT:    [[TMP52:%.*]] = extractelement <16 x i32> [[TMP51]], i64 15
 ; CHECK-NEXT:    store i32 [[TMP52]], ptr [[DST]], align 4
-; CHECK-NEXT:    [[TMP53:%.*]] = getelementptr i8, ptr [[NEXT_GEP]], i64 3
-; CHECK-NEXT:    [[TMP54:%.*]] = getelementptr i8, ptr [[NEXT_GEP2]], i64 3
-; CHECK-NEXT:    [[TMP55:%.*]] = getelementptr i8, ptr [[NEXT_GEP3]], i64 3
-; CHECK-NEXT:    [[TMP56:%.*]] = getelementptr i8, ptr [[NEXT_GEP4]], i64 3
-; CHECK-NEXT:    [[TMP57:%.*]] = getelementptr i8, ptr [[NEXT_GEP5]], i64 3
-; CHECK-NEXT:    [[TMP58:%.*]] = getelementptr i8, ptr [[NEXT_GEP6]], i64 3
-; CHECK-NEXT:    [[TMP59:%.*]] = getelementptr i8, ptr [[NEXT_GEP7]], i64 3
-; CHECK-NEXT:    [[TMP60:%.*]] = getelementptr i8, ptr [[NEXT_GEP8]], i64 3
-; CHECK-NEXT:    [[TMP61:%.*]] = getelementptr i8, ptr [[NEXT_GEP9]], i64 3
-; CHECK-NEXT:    [[TMP62:%.*]] = getelementptr i8, ptr [[NEXT_GEP10]], i64 3
-; CHECK-NEXT:    [[TMP63:%.*]] = getelementptr i8, ptr [[NEXT_GEP11]], i64 3
-; CHECK-NEXT:    [[TMP64:%.*]] = getelementptr i8, ptr [[NEXT_GEP12]], i64 3
-; CHECK-NEXT:    [[TMP65:%.*]] = getelementptr i8, ptr [[NEXT_GEP13]], i64 3
-; CHECK-NEXT:    [[TMP66:%.*]] = getelementptr i8, ptr [[NEXT_GEP14]], i64 3
-; CHECK-NEXT:    [[TMP67:%.*]] = getelementptr i8, ptr [[NEXT_GEP15]], i64 3
-; CHECK-NEXT:    [[TMP68:%.*]] = getelementptr i8, ptr [[NEXT_GEP16]], i64 3
-; CHECK-NEXT:    [[TMP69:%.*]] = insertelement <16 x ptr> poison, ptr [[TMP53]], i32 0
-; CHECK-NEXT:    [[TMP70:%.*]] = insertelement <16 x ptr> [[TMP69]], ptr [[TMP54]], i32 1
-; CHECK-NEXT:    [[TMP71:%.*]] = insertelement <16 x ptr> [[TMP70]], ptr [[TMP55]], i32 2
-; CHECK-NEXT:    [[TMP72:%.*]] = insertelement <16 x ptr> [[TMP71]], ptr [[TMP56]], i32 3
-; CHECK-NEXT:    [[TMP73:%.*]] = insertelement <16 x ptr> [[TMP72]], ptr [[TMP57]], i32 4
-; CHECK-NEXT:    [[TMP74:%.*]] = insertelement <16 x ptr> [[TMP73]], ptr [[TMP58]], i32 5
-; CHECK-NEXT:    [[TMP75:%.*]] = insertelement <16 x ptr> [[TMP74]], ptr [[TMP59]], i32 6
-; CHECK-NEXT:    [[TMP76:%.*]] = insertelement <16 x ptr> [[TMP75]], ptr [[TMP60]], i32 7
-; CHECK-NEXT:    [[TMP77:%.*]] = insertelement <16 x ptr> [[TMP76]], ptr [[TMP61]], i32 8
-; CHECK-NEXT:    [[TMP78:%.*]] = insertelement <16 x ptr> [[TMP77]], ptr [[TMP62]], i32 9
-; CHECK-NEXT:    [[TMP79:%.*]] = insertelement <16 x ptr> [[TMP78]], ptr [[TMP63]], i32 10
-; CHECK-NEXT:    [[TMP80:%.*]] = insertelement <16 x ptr> [[TMP79]], ptr [[TMP64]], i32 11
-; CHECK-NEXT:    [[TMP81:%.*]] = insertelement <16 x ptr> [[TMP80]], ptr [[TMP65]], i32 12
-; CHECK-NEXT:    [[TMP82:%.*]] = insertelement <16 x ptr> [[TMP81]], ptr [[TMP66]], i32 13
-; CHECK-NEXT:    [[TMP83:%.*]] = insertelement <16 x ptr> [[TMP82]], ptr [[TMP67]], i32 14
-; CHECK-NEXT:    [[TMP84:%.*]] = insertelement <16 x ptr> [[TMP83]], ptr [[TMP68]], i32 15
-; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 16
+; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[INDEX]], 32
 ; CHECK-NEXT:    [[TMP85:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP85]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP26:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
-; CHECK-NEXT:    [[TMP86:%.*]] = ptrtoint <16 x ptr> [[TMP84]] to <16 x i64>
-; CHECK-NEXT:    [[TMP87:%.*]] = extractelement <16 x i64> [[TMP86]], i64 15
-; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[TMP0]], [[N_VEC]]
-; CHECK-NEXT:    br i1 [[CMP_N]], label %[[EXIT:.*]], label %[[VEC_EPILOG_ITER_CHECK:.*]]
+; CHECK-NEXT:    br label %[[VEC_EPILOG_ITER_CHECK:.*]]
 ; CHECK:       [[VEC_EPILOG_ITER_CHECK]]:
-; CHECK-NEXT:    [[MIN_EPILOG_ITERS_CHECK:%.*]] = icmp ult i64 [[N_MOD_VF]], 8
-; CHECK-NEXT:    br i1 [[MIN_EPILOG_ITERS_CHECK]], label %[[VEC_EPILOG_SCALAR_PH]], label %[[VEC_EPILOG_PH]], !prof [[PROF8]]
+; CHECK-NEXT:    [[MIN_EPILOG_ITERS_CHECK:%.*]] = icmp ule i64 [[N_MOD_VF]], 8
+; CHECK-NEXT:    br i1 [[MIN_EPILOG_ITERS_CHECK]], label %[[VEC_EPILOG_SCALAR_PH]], label %[[VEC_EPILOG_PH]], !prof [[PROF27:![0-9]+]]
 ; CHECK:       [[VEC_EPILOG_PH]]:
-; CHECK-NEXT:    [[VEC_EPILOG_RESUME_VAL:%.*]] = phi i64 [ [[N_VEC]], %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[VECTOR_MAIN_LOOP_ITER_CHECK]] ]
+; CHECK-NEXT:    [[VEC_EPILOG_RESUME_VAL:%.*]] = phi i64 [ [[N_VEC]], %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[VECTOR_MAIN_LOOP_ITER_CHECK1]] ]
 ; CHECK-NEXT:    [[N_MOD_VF17:%.*]] = urem i64 [[TMP0]], 8
-; CHECK-NEXT:    [[N_VEC18:%.*]] = sub i64 [[TMP0]], [[N_MOD_VF17]]
+; CHECK-NEXT:    [[TMP10:%.*]] = icmp eq i64 [[N_MOD_VF17]], 0
+; CHECK-NEXT:    [[TMP11:%.*]] = select i1 [[TMP10]], i64 8, i64 [[N_MOD_VF17]]
+; CHECK-NEXT:    [[N_VEC18:%.*]] = sub i64 [[TMP0]], [[TMP11]]
 ; CHECK-NEXT:    [[TMP88:%.*]] = mul i64 [[N_VEC18]], 3
 ; CHECK-NEXT:    [[TMP89:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP88]]
 ; CHECK-NEXT:    br label %[[VEC_EPILOG_VECTOR_BODY:.*]]
 ; CHECK:       [[VEC_EPILOG_VECTOR_BODY]]:
 ; CHECK-NEXT:    [[INDEX19:%.*]] = phi i64 [ [[VEC_EPILOG_RESUME_VAL]], %[[VEC_EPILOG_PH]] ], [ [[INDEX_NEXT28:%.*]], %[[VEC_EPILOG_VECTOR_BODY]] ]
 ; CHECK-NEXT:    [[TMP90:%.*]] = mul i64 [[INDEX19]], 3
-; CHECK-NEXT:    [[TMP91:%.*]] = add i64 [[TMP90]], 3
-; CHECK-NEXT:    [[TMP92:%.*]] = add i64 [[TMP90]], 6
-; CHECK-NEXT:    [[TMP93:%.*]] = add i64 [[TMP90]], 9
-; CHECK-NEXT:    [[TMP94:%.*]] = add i64 [[TMP90]], 12
-; CHECK-NEXT:    [[TMP95:%.*]] = add i64 [[TMP90]], 15
-; CHECK-NEXT:    [[TMP96:%.*]] = add i64 [[TMP90]], 18
-; CHECK-NEXT:    [[TMP97:%.*]] = add i64 [[TMP90]], 21
 ; CHECK-NEXT:    [[NEXT_GEP20:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP90]]
-; CHECK-NEXT:    [[NEXT_GEP21:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP91]]
-; CHECK-NEXT:    [[NEXT_GEP22:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP92]]
-; CHECK-NEXT:    [[NEXT_GEP23:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP93]]
-; CHECK-NEXT:    [[NEXT_GEP24:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP94]]
-; CHECK-NEXT:    [[NEXT_GEP25:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP95]]
-; CHECK-NEXT:    [[NEXT_GEP26:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP96]]
-; CHECK-NEXT:    [[NEXT_GEP27:%.*]] = getelementptr i8, ptr [[START]], i64 [[TMP97]]
-; CHECK-NEXT:    [[TMP98:%.*]] = load i8, ptr [[NEXT_GEP20]], align 1
-; CHECK-NEXT:    [[TMP99:%.*]] = load i8, ptr [[NEXT_GEP21]], align 1
-; CHECK-NEXT:    [[TMP100:%.*]] = load i8, ptr [[NEXT_GEP22]], align 1
-; CHECK-NEXT:    [[TMP101:%.*]] = load i8, ptr [[NEXT_GEP23]], align 1
-; CHECK-NEXT:    [[TMP102:%.*]] = load i8, ptr [[NEXT_GEP24]], align 1
-; CHECK-NEXT:    [[TMP103:%.*]] = load i8, ptr [[NEXT_GEP25]], align 1
-; CHECK-NEXT:    [[TMP104:%.*]] = load i8, ptr [[NEXT_GEP26]], align 1
-; CHECK-NEXT:    [[TMP105:%.*]] = load i8, ptr [[NEXT_GEP27]], align 1
-; CHECK-NEXT:    [[TMP106:%.*]] = insertelement <8 x i8> poison, i8 [[TMP98]], i32 0
-; CHECK-NEXT:    [[TMP107:%.*]] = insertelement <8 x i8> [[TMP106]], i8 [[TMP99]], i32 1
-; CHECK-NEXT:    [[TMP108:%.*]] = insertelement <8 x i8> [[TMP107]], i8 [[TMP100]], i32 2
-; CHECK-NEXT:    [[TMP109:%.*]] = insertelement <8 x i8> [[TMP108]], i8 [[TMP101]], i32 3
-; CHECK-NEXT:    [[TMP110:%.*]] = insertelement <8 x i8> [[TMP109]], i8 [[TMP102]], i32 4
-; CHECK-NEXT:    [[TMP111:%.*]] = insertelement <8 x i8> [[TMP110]], i8 [[TMP103]], i32 5
-; CHECK-NEXT:    [[TMP112:%.*]] = insertelement <8 x i8> [[TMP111]], i8 [[TMP104]], i32 6
-; CHECK-NEXT:    [[TMP113:%.*]] = insertelement <8 x i8> [[TMP112]], i8 [[TMP105]], i32 7
+; CHECK-NEXT:    [[WIDE_VEC6:%.*]] = load <24 x i8>, ptr [[NEXT_GEP20]], align 1
+; CHECK-NEXT:    [[TMP113:%.*]] = shufflevector <24 x i8> [[WIDE_VEC6]], <24 x i8> poison, <8 x i32> <i32 0, i32 3, i32 6, i32 9, i32 12, i32 15, i32 18, i32 21>
 ; CHECK-NEXT:    [[TMP114:%.*]] = zext <8 x i8> [[TMP113]] to <8 x i32>
 ; CHECK-NEXT:    [[TMP115:%.*]] = extractelement <8 x i32> [[TMP114]], i64 7
 ; CHECK-NEXT:    store i32 [[TMP115]], ptr [[DST]], align 4
-; CHECK-NEXT:    [[TMP116:%.*]] = getelementptr i8, ptr [[NEXT_GEP20]], i64 3
-; CHECK-NEXT:    [[TMP117:%.*]] = getelementptr i8, ptr [[NEXT_GEP21]], i64 3
-; CHECK-NEXT:    [[TMP118:%.*]] = getelementptr i8, ptr [[NEXT_GEP22]], i64 3
-; CHECK-NEXT:    [[TMP119:%.*]] = getelementptr i8, ptr [[NEXT_GEP23]], i64 3
-; CHECK-NEXT:    [[TMP120:%.*]] = getelementptr i8, ptr [[NEXT_GEP24]], i64 3
-; CHECK-NEXT:    [[TMP121:%.*]] = getelementptr i8, ptr [[NEXT_GEP25]], i64 3
-; CHECK-NEXT:    [[TMP122:%.*]] = getelementptr i8, ptr [[NEXT_GEP26]], i64 3
-; CHECK-NEXT:    [[TMP123:%.*]] = getelementptr i8, ptr [[NEXT_GEP27]], i64 3
-; CHECK-NEXT:    [[TMP124:%.*]] = insertelement <8 x ptr> poison, ptr [[TMP116]], i32 0
-; CHECK-NEXT:    [[TMP125:%.*]] = insertelement <8 x ptr> [[TMP124]], ptr [[TMP117]], i32 1
-; CHECK-NEXT:    [[TMP126:%.*]] = insertelement <8 x ptr> [[TMP125]], ptr [[TMP118]], i32 2
-; CHECK-NEXT:    [[TMP127:%.*]] = insertelement <8 x ptr> [[TMP126]], ptr [[TMP119]], i32 3
-; CHECK-NEXT:    [[TMP128:%.*]] = insertelement <8 x ptr> [[TMP127]], ptr [[TMP120]], i32 4
-; CHECK-NEXT:    [[TMP129:%.*]] = insertelement <8 x ptr> [[TMP128]], ptr [[TMP121]], i32 5
-; CHECK-NEXT:    [[TMP130:%.*]] = insertelement <8 x ptr> [[TMP129]], ptr [[TMP122]], i32 6
-; CHECK-NEXT:    [[TMP131:%.*]] = insertelement <8 x ptr> [[TMP130]], ptr [[TMP123]], i32 7
 ; CHECK-NEXT:    [[INDEX_NEXT28]] = add nuw i64 [[INDEX19]], 8
 ; CHECK-NEXT:    [[TMP132:%.*]] = icmp eq i64 [[INDEX_NEXT28]], [[N_VEC18]]
-; CHECK-NEXT:    br i1 [[TMP132]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP27:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP132]], label %[[VEC_EPILOG_MIDDLE_BLOCK:.*]], label %[[VEC_EPILOG_VECTOR_BODY]], !llvm.loop [[LOOP28:![0-9]+]]
 ; CHECK:       [[VEC_EPILOG_MIDDLE_BLOCK]]:
-; CHECK-NEXT:    [[TMP133:%.*]] = ptrtoint <8 x ptr> [[TMP131]] to <8 x i64>
-; CHECK-NEXT:    [[TMP134:%.*]] = extractelement <8 x i64> [[TMP133]], i64 7
-; CHECK-NEXT:    [[CMP_N29:%.*]] = icmp eq i64 [[TMP0]], [[N_VEC18]]
-; CHECK-NEXT:    br i1 [[CMP_N29]], label %[[EXIT]], label %[[VEC_EPILOG_SCALAR_PH]]
+; CHECK-NEXT:    br label %[[VEC_EPILOG_SCALAR_PH]]
 ; CHECK:       [[VEC_EPILOG_SCALAR_PH]]:
-; CHECK-NEXT:    [[BC_RESUME_VAL30:%.*]] = phi i64 [ [[N_VEC18]], %[[VEC_EPILOG_MIDDLE_BLOCK]] ], [ [[N_VEC]], %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[ITER_CHECK]] ]
-; CHECK-NEXT:    [[BC_RESUME_VAL31:%.*]] = phi ptr [ [[TMP89]], %[[VEC_EPILOG_MIDDLE_BLOCK]] ], [ [[TMP2]], %[[VEC_EPILOG_ITER_CHECK]] ], [ [[START]], %[[ITER_CHECK]] ]
+; CHECK-NEXT:    [[BC_RESUME_VAL9:%.*]] = phi i64 [ [[N_VEC18]], %[[VEC_EPILOG_MIDDLE_BLOCK]] ], [ [[N_VEC]], %[[VEC_EPILOG_ITER_CHECK]] ], [ 0, %[[VECTOR_MAIN_LOOP_ITER_CHECK]] ], [ 0, %[[ITER_CHECK]] ]
+; CHECK-NEXT:    [[BC_RESUME_VAL10:%.*]] = phi ptr [ [[TMP89]], %[[VEC_EPILOG_MIDDLE_BLOCK]] ], [ [[TMP2]], %[[VEC_EPILOG_ITER_CHECK]] ], [ [[START]], %[[VECTOR_MAIN_LOOP_ITER_CHECK]] ], [ [[START]], %[[ITER_CHECK]] ]
 ; CHECK-NEXT:    br label %[[LOOP:.*]]
 ; CHECK:       [[LOOP]]:
-; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ [[BC_RESUME_VAL30]], %[[VEC_EPILOG_SCALAR_PH]] ], [ [[IV_NEXT:%.*]], %[[LOOP]] ]
-; CHECK-NEXT:    [[PTR_IV:%.*]] = phi ptr [ [[BC_RESUME_VAL31]], %[[VEC_EPILOG_SCALAR_PH]] ], [ [[PTR_IV_NEXT:%.*]], %[[LOOP]] ]
+; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ [[BC_RESUME_VAL9]], %[[VEC_EPILOG_SCALAR_PH]] ], [ [[IV_NEXT:%.*]], %[[LOOP]] ]
+; CHECK-NEXT:    [[PTR_IV:%.*]] = phi ptr [ [[BC_RESUME_VAL10]], %[[VEC_EPILOG_SCALAR_PH]] ], [ [[PTR_IV_NEXT:%.*]], %[[LOOP]] ]
 ; CHECK-NEXT:    [[VAL:%.*]] = load i8, ptr [[PTR_IV]], align 1
 ; CHECK-NEXT:    [[VAL_EXT:%.*]] = zext i8 [[VAL]] to i32
 ; CHECK-NEXT:    store i32 [[VAL_EXT]], ptr [[DST]], align 4
@@ -957,9 +828,9 @@ define i64 @live_out_extract_from_ptr_iv_increment(i64 %count, ptr %start, ptr n
 ; CHECK-NEXT:    [[IV_NEXT]] = add i64 [[IV]], 1
 ; CHECK-NEXT:    [[PTR_INT:%.*]] = ptrtoint ptr [[PTR_IV_NEXT]] to i64
 ; CHECK-NEXT:    [[EC:%.*]] = icmp ult i64 [[IV]], [[COUNT]]
-; CHECK-NEXT:    br i1 [[EC]], label %[[LOOP]], label %[[EXIT]], !llvm.loop [[LOOP28:![0-9]+]]
+; CHECK-NEXT:    br i1 [[EC]], label %[[LOOP]], label %[[EXIT:.*]], !llvm.loop [[LOOP29:![0-9]+]]
 ; CHECK:       [[EXIT]]:
-; CHECK-NEXT:    [[PTR_INT_LCSSA:%.*]] = phi i64 [ [[PTR_INT]], %[[LOOP]] ], [ [[TMP87]], %[[MIDDLE_BLOCK]] ], [ [[TMP134]], %[[VEC_EPILOG_MIDDLE_BLOCK]] ]
+; CHECK-NEXT:    [[PTR_INT_LCSSA:%.*]] = phi i64 [ [[PTR_INT]], %[[LOOP]] ]
 ; CHECK-NEXT:    ret i64 [[PTR_INT_LCSSA]]
 ;
 entry:


### PR DESCRIPTION
Allow interleaved access analysis to generate no-wrap predicates in runtime check for the first group member.