### PR TITLE
[libc++] Move compiler-specific configuration into <__configuration/compiler.h>

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -37,31 +37,6 @@
 // defined to XXYYZZ.
 #  define _LIBCPP_VERSION 230000
 
-#  ifndef __has_constexpr_builtin
-#    define __has_constexpr_builtin(x) 0
-#  endif
-
-// This checks wheter a Clang module is built
-#  ifndef __building_module
-#    define __building_module(...) 0
-#  endif
-
-// '__is_identifier' returns '0' if '__x' is a reserved identifier provided by
-// the compiler and '1' otherwise.
-#  ifndef __is_identifier
-#    define __is_identifier(__x) 1
-#  endif
-
-#  define __has_keyword(__x) !(__is_identifier(__x))
-
-#  ifndef __has_warning
-#    define __has_warning(...) 0
-#  endif
-
-#  if !defined(_LIBCPP_COMPILER_CLANG_BASED) && __cplusplus < 201103L
-#    error "libc++ only supports C++03 with Clang-based compilers. Please enable C++11"
-#  endif
-
 #  if defined(_LIBCPP_ABI_MICROSOFT) && !defined(_LIBCPP_NO_VCRUNTIME)
 #    define _LIBCPP_ABI_VCRUNTIME
 #  endif

--- a/libcxx/include/__configuration/compiler.h
+++ b/libcxx/include/__configuration/compiler.h
@@ -46,6 +46,31 @@
 #    endif
 #  endif
 
+#  ifndef __has_constexpr_builtin
+#    define __has_constexpr_builtin(x) 0
+#  endif
+
+// This checks wheter a Clang module is built
+#  ifndef __building_module
+#    define __building_module(...) 0
+#  endif
+
+// '__is_identifier' returns '0' if '__x' is a reserved identifier provided by
+// the compiler and '1' otherwise.
+#  ifndef __is_identifier
+#    define __is_identifier(__x) 1
+#  endif
+
+#  define __has_keyword(__x) !(__is_identifier(__x))
+
+#  ifndef __has_warning
+#    define __has_warning(...) 0
+#  endif
+
+#  if !defined(_LIBCPP_COMPILER_CLANG_BASED) && __cplusplus < 201103L
+#    error "libc++ only supports C++03 with Clang-based compilers. Please enable C++11"
+#  endif
+
 #endif
 
 #endif // _LIBCPP___CONFIGURATION_COMPILER_H


### PR DESCRIPTION
These macros are essentially there to query compiler features, so they should be moved into `<__configuration/compiler.h>`.
