### PR TITLE
AMDGPU/GlobalISel: Fix get.rounding s_getreg lowering

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
@@ -1353,8 +1353,10 @@ bool RegBankLegalizeHelper::lowerGetRounding(MachineInstr &MI) {
 
   uint32_t BothRoundHwReg =
       AMDGPU::Hwreg::HwregEncoding::encode(AMDGPU::Hwreg::ID_MODE, 0, 4);
-  auto GetReg = B.buildInstr(AMDGPU::S_GETREG_B32, {SgprRB_S32}, {})
-                    .addImm(BothRoundHwReg);
+  auto GetReg =
+      B.buildIntrinsic(Intrinsic::amdgcn_s_getreg, {SgprRB_S32},
+                       /*HasSideEffects=*/true, /*isConvergent=*/false)
+          .addImm(BothRoundHwReg);
 
   // There are two rounding modes, one for f32 and one for f64/f16. We only
   // report in the standard value range if both are the same.


### PR DESCRIPTION
Use llvm.amdgcn.s.getreg instead of emitting S_GETREG_B32 directly so instruction selection applies the required SReg_32 operand constraint.

This was done for setreg but missed for getreg.

Fixes https://github.com/llvm/llvm-project/pull/205265 when expensive checks are enabled.