### PR TITLE
[lldb] Support indexes of hidden children in SBValue.child accessor

### DIFF
--- a/lldb/bindings/interface/SBValueExtensions.i
+++ b/lldb/bindings/interface/SBValueExtensions.i
@@ -22,6 +22,7 @@ STRING_EXTENSION_OUTSIDE(SBValue)
                     count = len(self)
                     if -count <= key < count:
                         key %= count
+                    if key >= 0:
                         return self.sbvalue.GetChildAtIndex(key)
                 return None
 

--- a/lldb/bindings/interface/SBValueExtensions.i
+++ b/lldb/bindings/interface/SBValueExtensions.i
@@ -19,9 +19,9 @@ STRING_EXTENSION_OUTSIDE(SBValue)
 
             def __getitem__(self, key):
                 if isinstance(key, int):
-                    count = len(self)
-                    if -count <= key < count:
-                        key %= count
+                    if key < 0:
+                        # Support pythonic negative indexing.
+                        key += len(self)
                     if key >= 0:
                         return self.sbvalue.GetChildAtIndex(key)
                 return None

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-python-synth/TestDataFormatterPythonSynth.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-python-synth/TestDataFormatterPythonSynth.py
@@ -187,6 +187,7 @@ class PythonSynthDataFormatterTestCase(TestBase):
         # indexes beyond num_children. wrapfooSynthProvider has a hidden child
         # at index=num_children, access by the name "$$dereference$$".
         hidden_index = wrapper_var.GetIndexOfChildWithName("$$dereference$$")
+        self.assertNotEqual(hidden_index, lldb.LLDB_INVALID_INDEX32)
         self.assertGreaterEqual(hidden_index, wrapper_var.num_children)
         hidden_child = wrapper_var.child[hidden_index]
         self.assertIsNotNone(hidden_child)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-python-synth/TestDataFormatterPythonSynth.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-python-synth/TestDataFormatterPythonSynth.py
@@ -183,6 +183,15 @@ class PythonSynthDataFormatterTestCase(TestBase):
         self.assertEqual(foo_var.GetChildAtIndex(1).GetName(), "fake_a")
         self.assertEqual(foo_var.GetChildAtIndex(2).GetName(), "r")
 
+        # Test the `child` accessor with indexes of hidden children: those with
+        # indexes beyond num_children. wrapfooSynthProvider has a hidden child
+        # at index=num_children, access by the name "$$dereference$$".
+        hidden_index = wrapper_var.GetIndexOfChildWithName("$$dereference$$")
+        self.assertGreaterEqual(hidden_index, wrapper_var.num_children)
+        hidden_child = wrapper_var.child[hidden_index]
+        self.assertIsNotNone(hidden_child)
+        self.assertGreater(hidden_child.num_children, 0)
+
         # now delete the synth and add the filter
         self.runCmd("type synth delete foo")
         self.runCmd("type synth delete wrapfoo")


### PR DESCRIPTION
A value object can have "hidden" children, which are children which can be access by an index that is past the number of children reported by the value object. This is used for example with `$$dereference$$` children. It's also useful for designing a value object which shows only a subset of its children.

This change updates the `SBValue.child` accessor to allow indexes that are past the reported number children, to match the behavior or `GetChildAtIndex`.