### PR TITLE
[compiler-rt][test][builtins] Check linker support for --start-group

### DIFF
--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -43,9 +43,17 @@ if (MSVC AND NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
 endif()
 pythonize_bool(BUILTINS_IS_MSVC)
 
-# Check if the linker supports --start-group and --end-group options
-include(CheckLinkerFlag)
-check_linker_flag(C "-Wl,--start-group" COMPILER_RT_HAS_START_GROUP)
+# Check if the linker supports --start-group options
+# Standalone builtins builds set CMAKE_TRY_COMPILE_TARGET_TYPE to
+# STATIC_LIBRARY to avoid invoking the linker during compiler checks.
+# Such builds are typically intended for target environments (e.g.
+# bare-metal) where support for --start-group is assumed.
+if(CMAKE_TRY_COMPILE_TARGET_TYPE STREQUAL "STATIC_LIBRARY")
+  set(COMPILER_RT_HAS_START_GROUP ON)
+else()
+  include(CheckLinkerFlag)
+  check_linker_flag(C "-Wl,--start-group" COMPILER_RT_HAS_START_GROUP)
+endif()
 pythonize_bool(COMPILER_RT_HAS_START_GROUP)
 
 set(BUILTIN_TEST_ARCH ${BUILTIN_SUPPORTED_ARCH})

--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -43,6 +43,11 @@ if (MSVC AND NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
 endif()
 pythonize_bool(BUILTINS_IS_MSVC)
 
+# Check if the linker supports --start-group and --end-group options
+include(CheckLinkerFlag)
+check_linker_flag(C "-Wl,--start-group" COMPILER_RT_HAS_START_GROUP)
+pythonize_bool(COMPILER_RT_HAS_START_GROUP)
+
 set(BUILTIN_TEST_ARCH ${BUILTIN_SUPPORTED_ARCH})
 if(APPLE)
   darwin_filter_host_archs(BUILTIN_SUPPORTED_ARCH BUILTIN_TEST_ARCH)

--- a/compiler-rt/test/builtins/Unit/lit.cfg.py
+++ b/compiler-rt/test/builtins/Unit/lit.cfg.py
@@ -107,9 +107,16 @@ else:
     if config.target_os == "Haiku":
         config.substitutions.append(("%librt ", base_lib + " -lroot "))
     else:
-        config.substitutions.append(
-            ("%librt ", "-lm -Wl,--start-group " + base_lib + " -lc -Wl,--end-group ")
-        )
+        # Check if the linker supports --start-group and --end-group
+        linker_supports_start_group = get_required_attr(config, "linker_supports_start_group")
+        if linker_supports_start_group:
+            config.substitutions.append(
+                ("%librt ", "-lm -Wl,--start-group " + base_lib + " -lc -Wl,--end-group ")
+            )
+        else:
+            config.substitutions.append(
+                ("%librt ", "-lm " + base_lib + " -lc ")
+            )
 
 builtins_test_crt = get_required_attr(config, "builtins_test_crt")
 if builtins_test_crt:

--- a/compiler-rt/test/builtins/Unit/lit.cfg.py
+++ b/compiler-rt/test/builtins/Unit/lit.cfg.py
@@ -108,15 +108,18 @@ else:
         config.substitutions.append(("%librt ", base_lib + " -lroot "))
     else:
         # Check if the linker supports --start-group and --end-group
-        linker_supports_start_group = get_required_attr(config, "linker_supports_start_group")
+        linker_supports_start_group = get_required_attr(
+            config, "linker_supports_start_group"
+        )
         if linker_supports_start_group:
             config.substitutions.append(
-                ("%librt ", "-lm -Wl,--start-group " + base_lib + " -lc -Wl,--end-group ")
+                (
+                    "%librt ",
+                    "-lm -Wl,--start-group " + base_lib + " -lc -Wl,--end-group "
+                )
             )
         else:
-            config.substitutions.append(
-                ("%librt ", "-lm " + base_lib + " -lc ")
-            )
+            config.substitutions.append(("%librt ", "-lm " + base_lib + " -lc "))
 
 builtins_test_crt = get_required_attr(config, "builtins_test_crt")
 if builtins_test_crt:

--- a/compiler-rt/test/builtins/Unit/lit.cfg.py
+++ b/compiler-rt/test/builtins/Unit/lit.cfg.py
@@ -107,15 +107,16 @@ else:
     if config.target_os == "Haiku":
         config.substitutions.append(("%librt ", base_lib + " -lroot "))
     else:
-        # Check if the linker supports --start-group and --end-group
         linker_supports_start_group = get_required_attr(
             config, "linker_supports_start_group"
         )
-        if linker_supports_start_group:
+        # Check if the linker supports --start-group and --end-group
+        # For nvptx64 target, it falls back to the default.
+        if linker_supports_start_group and "nvptx" in target_arch:
             config.substitutions.append(
                 (
                     "%librt ",
-                    "-lm -Wl,--start-group " + base_lib + " -lc -Wl,--end-group "
+                    "-lm -Wl,--start-group " + base_lib + " -lc -Wl,--end-group ",
                 )
             )
         else:

--- a/compiler-rt/test/builtins/Unit/lit.cfg.py
+++ b/compiler-rt/test/builtins/Unit/lit.cfg.py
@@ -112,7 +112,7 @@ else:
         )
         # Check if the linker supports --start-group and --end-group
         # For nvptx64 target, it falls back to the default.
-        if linker_supports_start_group and "nvptx" in target_arch:
+        if linker_supports_start_group and "nvptx" not in config.target_arch:
             config.substitutions.append(
                 (
                     "%librt ",

--- a/compiler-rt/test/builtins/Unit/lit.site.cfg.py.in
+++ b/compiler-rt/test/builtins/Unit/lit.site.cfg.py.in
@@ -9,6 +9,7 @@ config.builtins_test_crt = @COMPILER_RT_TEST_CRT_PYBOOL@
 config.is_msvc = @MSVC_PYBOOL@
 config.builtins_is_msvc = @BUILTINS_IS_MSVC_PYBOOL@
 config.builtins_lit_source_features = "@BUILTINS_LIT_SOURCE_FEATURES@"
+config.linker_supports_start_group = @COMPILER_RT_HAS_START_GROUP_PYBOOL@
 config.test_suite_supports_overriding_runtime_lib_path = True
 
 # Load common config for all compiler-rt lit tests.


### PR DESCRIPTION
This patch is to add a check for the linker whether the --start-group option is supported before passing to the linker. This can accommodate different linker requirements.