### PR TITLE
[MachineScheduler] Put -dag-maps-huge-region back to 1000

### DIFF
--- a/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
+++ b/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
@@ -84,7 +84,7 @@ static cl::opt<bool>
 // When Stores and Loads maps (or NonAliasStores and NonAliasLoads)
 // together hold this many SUs, a reduction of maps will be done.
 static cl::opt<unsigned>
-    HugeRegion("dag-maps-huge-region", cl::Hidden, cl::init(500),
+    HugeRegion("dag-maps-huge-region", cl::Hidden, cl::init(1000),
                cl::desc("The limit to use while constructing the DAG "
                         "prior to scheduling, at which point a trade-off "
                         "is made to avoid excessive compile time."));


### PR DESCRIPTION
In #200945 we reworked -dag-maps-huge-region to help in some cases where compile times blew up. This had the effect of initially adding a barrier after 500 memory operations instead of 1000 memory operations. There are reports of performance regressions due to this.

Bring this back to 1000. This has the effect of adding a barrier every 1000 memory ops, rather than 1000/1500/2000/etc, which is actually leans more toward performance in the performance/compile time tradeoff compared to pre-#200945.

There are likely other ways to deal with the quadratic nature of DAG construction, like #204715, #205171, #205613. We can probably increase this threshold when those land.