### PR TITLE
[OpenACC] add acc::ReductionAccumulateArrayOp

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -178,7 +178,8 @@ def OpenACC_ReductionAccumulateArrayOp
     : OpenACC_Op<"reduction_accumulate_array", []> {
   let summary = "Accumulates elements of an array";
   let description = [{
-    Accumulates elements of an array across threads given an acc.bounds op.
+    Accumulates elements of an array across the specified parallel dimension 
+    given an acc.bounds op.
   }];
   let arguments = (ins Arg<OpenACC_PointerLikeTypeInterface,
                            "Reduction variable to update",

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -171,6 +171,28 @@ def OpenACC_ReductionAccumulateOp
 }
 
 //===----------------------------------------------------------------------===//
+// acc.reduction_accumulate_array
+//===----------------------------------------------------------------------===//
+
+def OpenACC_ReductionAccumulateArrayOp
+    : OpenACC_Op<"reduction_accumulate_array", []> {
+  let summary = "Accumulates elements of an array";
+  let description = [{
+    Accumulates elements of an array across threads given an acc.bounds op.
+  }];
+  let arguments = (ins Arg<OpenACC_PointerLikeTypeInterface,
+                           "Reduction variable to update",
+                           [MemRead, MemWrite]>:$memref,
+                       OpenACC_DataBoundsType:$bounds,
+                       OpenACC_ReductionOperatorAttr:$reductionOperator,
+                       OpenACC_GPUParallelDimsAttr:$par_dims);
+  let assemblyFormat = [{
+    $memref `bounds` `(` $bounds `)` $reductionOperator `:` type($memref) attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // acc.kernel_environment
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
@@ -486,6 +486,16 @@ LogicalResult ReductionAccumulateOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// ReductionAccumulateArrayOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ReductionAccumulateArrayOp::verify() {
+  if (getParDims().getArray().empty())
+    return emitOpError("par_dims must specify at least one parallel dimension");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ReductionCombineOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/Dialect/OpenACC/invalid-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/invalid-cg.mlir
@@ -75,6 +75,25 @@ func.func @reduction_accumulate_empty_par_dims() {
 
 // -----
 
+func.func @reduction_accumulate_array_invalid_operator(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
+  acc.reduction_accumulate_array %private bounds(%bounds) <addi>
+      : memref<4xi32> {par_dims = #acc<par_dims[thread_x]>}
+  // expected-error@-2 {{expected ::mlir::acc::ReductionOperator to be one of}}
+  // expected-error@-3 {{failed to parse OpenACC_ReductionOperatorAttr}}
+  return
+}
+
+// -----
+
+func.func @reduction_accumulate_array_empty_par_dims(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
+  // expected-error@+1 {{par_dims must specify at least one parallel dimension}}
+  acc.reduction_accumulate_array %private bounds(%bounds) <add>
+      : memref<4xi32> {par_dims = #acc<par_dims[]>}
+  return
+}
+
+// -----
+
 func.func @predicate_region_empty() {
   acc.compute_region {
     // expected-error@+1 {{region needs to have at least one block}}

--- a/mlir/test/Dialect/OpenACC/ops-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg.mlir
@@ -320,6 +320,15 @@ func.func @reduction_accumulate_block_thread(%partial: i32, %private: memref<i32
 
 // -----
 
+// CHECK-LABEL: func @reduction_accumulate_array
+func.func @reduction_accumulate_array(%private: memref<4xi32>, %bounds: !acc.data_bounds_ty) {
+  acc.reduction_accumulate_array %private bounds(%bounds) <add> : memref<4xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+  return
+}
+// CHECK: acc.reduction_accumulate_array  %{{.*}} bounds(%{{.*}}) <add> : memref<4xi32> {par_dims = #acc<par_dims[block_x, thread_x]>}
+
+// -----
+
 // CHECK-LABEL: func @compute_region_with_results
 func.func @compute_region_with_results() -> i32 {
   %w0 = acc.par_width {par_dim = #acc.par_dim<thread_x>}


### PR DESCRIPTION
Add an OpenACC Dialect operation to accumulate elements of a (private) array across threads. This operation only specifies the PointerLikeType and an acc::DataBoundsOp to represent the accumulation of the array at a high level. This will ultimately get lowered by "codegen".