### PR TITLE
[mlir][bazel]: only depend on needed LLVM translations in ExecutionEngine

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -9570,9 +9570,11 @@ cc_library(
     ],
     includes = ["include"],
     deps = [
-        ":AllToLLVMIRTranslations",
+        ":BuiltinToLLVMIRTranslation",
         ":IR",
         ":LLVMDialect",
+        ":LLVMToLLVMIRTranslation",
+        ":OpenMPToLLVMIRTranslation",
         ":Support",
         ":ToLLVMIRTranslation",
         "//llvm:AllTargetsAsmParsers",


### PR DESCRIPTION
ExecutionEngine currently pulls in `AllToLLVMIRTranslations` which includes heavy dependencies on GPU dialects (notably NVVMDialect.cpp which takes a whopping 2 minutes to compile!), despite the ExecutionEngine not doing anything GPU-specific.

This change reduces the dependencies to just the subset of LLVMIR translations that ExecutionEngine actually uses: Builtin, LLVM dialect, and OpenMP dialect.