### PR TITLE
[libc][math] Fix MPI_OVER_2 constant in atan2f_float

### DIFF
--- a/libc/src/__support/math/atan2f_float.h
+++ b/libc/src/__support/math/atan2f_float.h
@@ -134,7 +134,7 @@ LIBC_INLINE constexpr float atan2f(float y, float x) {
   constexpr FloatFloat MPI = {0x1.777a5cp-24f, -0x1.921fb6p1f};
   constexpr FloatFloat PI_OVER_4 = {-0x1.777a5cp-26f, 0x1.921fb6p-1f};
   constexpr FloatFloat PI_OVER_2 = {-0x1.777a5cp-25f, 0x1.921fb6p0f};
-  constexpr FloatFloat MPI_OVER_2 = {-0x1.777a5cp-25f, 0x1.921fb6p0f};
+  constexpr FloatFloat MPI_OVER_2 = {0x1.777a5cp-25f, -0x1.921fb6p0f};
   constexpr FloatFloat THREE_PI_OVER_4 = {-0x1.99bc5cp-28f, 0x1.2d97c8p1f};
   // Adjustment for constant term:
   //   CONST_ADJ[x_sign][y_sign][recip]


### PR DESCRIPTION
Fix a typo in the size-optimized float-float implementation of atan2f
where MPI_OVER_2 (-pi/2) was defined identically to PI_OVER_2 (pi/2).

This caused atan2f to return incorrect values (off by pi) on targets
where the float-float path is selected (e.g. baremetal ARM Cortex-M
with hardware FMA/floating-point support) for inputs requiring
reciprocal range reduction, such as atan2f(10.0f, 1.0f).
