### PR TITLE
[Support][CHERI] Refactor CHERICapabilityFormatBase to embrace CRTP

### DIFF
--- a/llvm/include/llvm/Support/CHERICapabilityFormat.h
+++ b/llvm/include/llvm/Support/CHERICapabilityFormat.h
@@ -23,21 +23,31 @@ struct CHERICapabilityFormatBase {
   /// Returns the "alignment mask" for an allocation of size \p Length. This
   /// mask is 0 where the capability format alignment requires the
   /// address to be 0, and 1 otherwise.
-  LLVM_ABI static AddressType getAlignmentMask(AddressType Length);
+  LLVM_ABI static AddressType getAlignmentMask(AddressType Length) {
+    return Derived::getAlignmentMaskImpl(Length);
+  }
 
   /// Returns the required alignment for an allocation of size \p Length.
-  LLVM_ABI static Align getRequiredAlignment(AddressType Length);
+  LLVM_ABI static Align getRequiredAlignment(AddressType Length) {
+    return Align((~getAlignmentMask(Length) + 1) & AddressMask);
+  }
 
   /// Returns \p Length rounded up to the nearest representable allocation
   /// length.
-  LLVM_ABI static AddressType getRepresentableLength(AddressType Length);
+  LLVM_ABI static AddressType getRepresentableLength(AddressType Length) {
+    AddressType Mask = getAlignmentMask(Length);
+    return (Length + ~Mask) & Mask;
+  }
 };
 
 template <typename AddressType, unsigned MW, unsigned MAX_E>
 struct RVYCapabilityFormat
     : public CHERICapabilityFormatBase<
           RVYCapabilityFormat<AddressType, MW, MAX_E>, AddressType> {
-  LLVM_ABI static AddressType getAlignmentMask(uint64_t Length);
+  friend struct CHERICapabilityFormatBase<
+      RVYCapabilityFormat<AddressType, MW, MAX_E>, AddressType>;
+
+  LLVM_ABI static AddressType getAlignmentMaskImpl(uint64_t Length);
 };
 
 using RV32YCapabilityFormat = RVYCapabilityFormat<uint32_t, 10, 24>;
@@ -45,7 +55,9 @@ using RV64YCapabilityFormat = RVYCapabilityFormat<uint64_t, 14, 52>;
 
 struct CHERIoTCapabilityFormat
     : public CHERICapabilityFormatBase<CHERIoTCapabilityFormat, uint32_t> {
-  LLVM_ABI static uint32_t getAlignmentMask(uint32_t Length);
+  friend struct CHERICapabilityFormatBase<CHERIoTCapabilityFormat, uint32_t>;
+
+  LLVM_ABI static uint32_t getAlignmentMaskImpl(uint32_t Length);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Support/CHERICapabilityFormat.h
+++ b/llvm/include/llvm/Support/CHERICapabilityFormat.h
@@ -47,6 +47,7 @@ struct RVYCapabilityFormat
   friend struct CHERICapabilityFormatBase<
       RVYCapabilityFormat<AddressType, MW, MAX_E>, AddressType>;
 
+private:
   LLVM_ABI static AddressType getAlignmentMaskImpl(uint64_t Length);
 };
 
@@ -57,6 +58,7 @@ struct CHERIoTCapabilityFormat
     : public CHERICapabilityFormatBase<CHERIoTCapabilityFormat, uint32_t> {
   friend struct CHERICapabilityFormatBase<CHERIoTCapabilityFormat, uint32_t>;
 
+private:
   LLVM_ABI static uint32_t getAlignmentMaskImpl(uint32_t Length);
 };
 

--- a/llvm/include/llvm/Support/CHERICapabilityFormat.h
+++ b/llvm/include/llvm/Support/CHERICapabilityFormat.h
@@ -23,18 +23,18 @@ struct CHERICapabilityFormatBase {
   /// Returns the "alignment mask" for an allocation of size \p Length. This
   /// mask is 0 where the capability format alignment requires the
   /// address to be 0, and 1 otherwise.
-  LLVM_ABI static AddressType getAlignmentMask(AddressType Length) {
+  static AddressType getAlignmentMask(AddressType Length) {
     return Derived::getAlignmentMaskImpl(Length);
   }
 
   /// Returns the required alignment for an allocation of size \p Length.
-  LLVM_ABI static Align getRequiredAlignment(AddressType Length) {
+  static Align getRequiredAlignment(AddressType Length) {
     return Align((~getAlignmentMask(Length) + 1) & AddressMask);
   }
 
   /// Returns \p Length rounded up to the nearest representable allocation
   /// length.
-  LLVM_ABI static AddressType getRepresentableLength(AddressType Length) {
+  static AddressType getRepresentableLength(AddressType Length) {
     AddressType Mask = getAlignmentMask(Length);
     return (Length + ~Mask) & Mask;
   }

--- a/llvm/lib/Support/CHERICapabilityFormat.cpp
+++ b/llvm/lib/Support/CHERICapabilityFormat.cpp
@@ -11,23 +11,9 @@
 
 namespace llvm {
 
-template <typename Derived, typename AddressType>
-Align CHERICapabilityFormatBase<Derived, AddressType>::getRequiredAlignment(
-    AddressType Length) {
-  return Align((~Derived::getAlignmentMask(Length) + 1) & AddressMask);
-}
-
-template <typename Derived, typename AddressType>
-AddressType
-CHERICapabilityFormatBase<Derived, AddressType>::getRepresentableLength(
-    AddressType Length) {
-  AddressType Mask = Derived::getAlignmentMask(Length);
-  return (Length + ~Mask) & Mask;
-}
-
 template <typename AddressType, unsigned MW, unsigned MAX_E>
-AddressType
-RVYCapabilityFormat<AddressType, MW, MAX_E>::getAlignmentMask(uint64_t Length) {
+AddressType RVYCapabilityFormat<AddressType, MW, MAX_E>::getAlignmentMaskImpl(
+    uint64_t Length) {
   static constexpr unsigned int IE_TAKE_BITS = 3;
 
   if (Length == 0)
@@ -57,7 +43,7 @@ template struct CHERICapabilityFormatBase<RVYCapabilityFormat<uint64_t, 14, 52>,
 template struct RVYCapabilityFormat<uint32_t, 10, 24>;
 template struct RVYCapabilityFormat<uint64_t, 14, 52>;
 
-uint32_t CHERIoTCapabilityFormat::getAlignmentMask(uint32_t Length) {
+uint32_t CHERIoTCapabilityFormat::getAlignmentMaskImpl(uint32_t Length) {
   // Per section 7.13.4 and table 7.4 in the v1.0 CHERIoT specification.
   constexpr uint32_t NINE_SET_BITS = 511;
   uint32_t E;


### PR DESCRIPTION
Currently CHERICapabilityFormatBase does not provide a definition for
getAlignmentMask, but does provide a declaration, which leads to
warnings when building with MSVC. We want to have an abstract base here
without any dynamic dispatch, which is what CRTP is for, so use it for
getAlignmentMask such that the base can provide a definition that uses
each derived type's implementation, just as the two base wrappers were
already doing when calling getAlignmentMask. Whilst doing this we might
as well move the wrappers to the header so they can be inlined (and now
that getAlignmentMask is defined we can use it in the helpers rather
than needing each of them to explicitly use the derived type).

Fixes: 7dc09d0d3cf1 ("[CHERI] Add a Support utility for determining alignment requirements of CHERI capabilities. (#197402)")
