### PR TITLE
[SandboxVec][PassBuilder] Add support for RegionPass aux args

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -98,7 +98,9 @@ class LLVM_ABI BottomUpVec final : public RegionPass {
   bool tryVectorize(ArrayRef<Value *> Seeds, LegalityAnalysis &Legality);
 
 public:
-  BottomUpVec() : RegionPass("bottom-up-vec") {}
+  BottomUpVec(StringRef AuxArg) : RegionPass("bottom-up-vec") {
+    assert(AuxArg.empty() && "This pass ignores aux arg!");
+  }
   bool runOnRegion(Region &Rgn, const Analyses &A) final;
 };
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.h
@@ -39,7 +39,9 @@ class LLVM_ABI LoadStoreVec final : public RegionPass {
                           ArrayRef<Value *> Operands);
 
 public:
-  LoadStoreVec() : RegionPass("load-store-vec") {}
+  LoadStoreVec(StringRef AuxArg) : RegionPass("load-store-vec") {
+    assert(AuxArg.empty() && "This pass ignores aux arg!");
+  }
   bool runOnRegion(Region &Rgn, const Analyses &A) final;
 };
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/NullPass.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/NullPass.h
@@ -19,10 +19,15 @@ namespace llvm::sandboxir {
 class Region;
 
 /// A Region pass that does nothing, for use as a placeholder in tests.
+/// It can also echo the AuxArg passed to it by the pass builder, which is used
+/// for AuxArg testing.
 class NullPass final : public RegionPass {
+  StringRef AuxArg;
+
 public:
-  NullPass() : RegionPass("null") {}
+  NullPass(StringRef AuxArg) : RegionPass("null"), AuxArg(AuxArg) {}
   bool runOnRegion(Region &R, const Analyses &A) final { return false; }
+  StringRef getAuxArg() const { return AuxArg; }
 };
 
 } // namespace llvm::sandboxir

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PackReuse.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PackReuse.h
@@ -27,7 +27,9 @@ class LLVM_ABI PackReuse final : public RegionPass {
   bool Change = false;
 
 public:
-  PackReuse() : RegionPass("pack-reuse") {}
+  PackReuse(StringRef AuxArg) : RegionPass("pack-reuse") {
+    assert(AuxArg.empty() && "This pass ignores aux arg!");
+  }
   bool runOnRegion(Region &Rgn, const Analyses &A) final;
 };
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintInstructionCount.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintInstructionCount.h
@@ -11,7 +11,9 @@ namespace llvm::sandboxir {
 /// passes.
 class PrintInstructionCount final : public RegionPass {
 public:
-  PrintInstructionCount() : RegionPass("null") {}
+  PrintInstructionCount(StringRef AuxArg) : RegionPass("null") {
+    assert(AuxArg.empty() && "This pass ignores aux arg!");
+  }
   bool runOnRegion(Region &R, const Analyses &A) final {
     outs() << "InstructionCount: " << llvm::size(R) << "\n";
     return false;

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintRegion.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintRegion.h
@@ -9,7 +9,9 @@ namespace llvm::sandboxir {
 /// A Region pass that does nothing, for use as a placeholder in tests.
 class PrintRegion final : public RegionPass {
 public:
-  PrintRegion() : RegionPass("print-region") {}
+  PrintRegion(StringRef AuxArg) : RegionPass("print-region") {
+    assert(AuxArg.empty() && "This pass ignores aux arg!");
+  }
   bool runOnRegion(Region &R, const Analyses &A) final {
     raw_ostream &OS = outs();
 #ifndef NDEBUG

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAcceptOrRevert.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAcceptOrRevert.h
@@ -21,7 +21,10 @@ namespace llvm::sandboxir {
 
 class LLVM_ABI TransactionAcceptOrRevert : public RegionPass {
 public:
-  TransactionAcceptOrRevert() : RegionPass("tr-accept-or-revert") {}
+  TransactionAcceptOrRevert(StringRef AuxArg)
+      : RegionPass("tr-accept-or-revert") {
+    assert(AuxArg.empty() && "This pass ignores aux arg!");
+  }
   bool runOnRegion(Region &Rgn, const Analyses &A) final;
 };
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAlwaysAccept.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAlwaysAccept.h
@@ -20,7 +20,9 @@ namespace llvm::sandboxir {
 
 class TransactionAlwaysAccept : public RegionPass {
 public:
-  TransactionAlwaysAccept() : RegionPass("tr-accept") {}
+  TransactionAlwaysAccept(StringRef AuxArg) : RegionPass("tr-accept") {
+    assert(AuxArg.empty() && "This pass ignores aux arg!");
+  }
   bool runOnRegion(Region &Rgn, const Analyses &A) final {
     auto &Tracker = Rgn.getContext().getTracker();
     bool HasChanges = !Tracker.empty();

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAlwaysRevert.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAlwaysRevert.h
@@ -20,7 +20,9 @@ namespace llvm::sandboxir {
 
 class TransactionAlwaysRevert : public RegionPass {
 public:
-  TransactionAlwaysRevert() : RegionPass("tr-revert") {}
+  TransactionAlwaysRevert(StringRef AuxArg) : RegionPass("tr-revert") {
+    assert(AuxArg.empty() && "This pass ignores aux arg!");
+  }
   bool runOnRegion(Region &Rgn, const Analyses &A) final {
     auto &Tracker = Rgn.getContext().getTracker();
     bool HasChanges = !Tracker.empty();

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionSave.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionSave.h
@@ -19,7 +19,9 @@ namespace llvm::sandboxir {
 
 class LLVM_ABI TransactionSave : public RegionPass {
 public:
-  TransactionSave() : RegionPass("tr-save") {}
+  TransactionSave(StringRef AuxArg) : RegionPass("tr-save") {
+    assert(AuxArg.empty() && "This pass ignores aux arg!");
+  }
   bool runOnRegion(Region &Rgn, const Analyses &A) final;
 };
 

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerPassBuilder.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerPassBuilder.cpp
@@ -22,8 +22,7 @@ SandboxVectorizerPassBuilder::createRegionPass(StringRef Name, StringRef Args,
 #define REGION_PASS(NAME, CLASS_NAME)                                          \
   if (Name == NAME) {                                                          \
     assert(Args.empty() && "Unexpected arguments for pass '" NAME "'.");       \
-    assert(AuxArg.empty() && "TODO: Add RegionPass support for AuxArge);");    \
-    return std::make_unique<CLASS_NAME>();                                     \
+    return std::make_unique<CLASS_NAME>(AuxArg);                               \
   }
 // TODO: Support region passes with params.
 #include "Passes/PassRegistry.def"

--- a/llvm/test/Transforms/SandboxVectorizer/region_pass_arg.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/region_pass_arg.ll
@@ -1,0 +1,10 @@
+; RUN: opt -passes=sandbox-vectorizer -sbvec-passes="regions-from-metadata<null(aux-arg-foo)>" %s -disable-output
+
+; Checks that the NullPass, which is a region pass can take an aux argument.
+; TODO: This test can be removed once real passes start using aux-args.
+
+define void @foo() {
+  ret void, !sandboxvec !0
+}
+!0 = distinct !{!"sandboxregion"}
+

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/CMakeLists.txt
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/CMakeLists.txt
@@ -12,6 +12,7 @@ add_llvm_unittest(SandboxVectorizerTests
   InstrMapsTest.cpp
   IntervalTest.cpp
   LegalityTest.cpp
+  PassBuilderTest.cpp
   RegionWithScoreTest.cpp
   SandboxVectorizerIRTest.cpp
   SandboxVectorizerTest.cpp

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/PassBuilderTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/PassBuilderTest.cpp
@@ -1,0 +1,25 @@
+//===- PassBuilderTest.cpp ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/NullPass.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerPassBuilder.h"
+#include "gtest/gtest.h"
+
+using namespace llvm::sandboxir;
+
+// Check that the PassBuilder passes the AuxArg to the RegionPass upon
+// construction.
+TEST(PassBuilderTest, RegionPassAuxArg) {
+  SandboxVectorizerPassBuilder Builder;
+  std::string AuxArgStr("aux-arg-test");
+  auto RgnPassPtr =
+      Builder.createRegionPass("null", /*Args=*/"", /*AuxArg=*/AuxArgStr);
+  NullPass *NPass = static_cast<NullPass *>(RgnPassPtr.get());
+  EXPECT_EQ(NPass->getAuxArg(), AuxArgStr);
+}


### PR DESCRIPTION
Pass auxiliary string arguments are used as a way to pass additional information to a pass upon construction, which can be particularly helpful with passes that support more than one mode/functionality.

You can specify an aux argument in the pass pipeline using the syntax: `<pass>(<aux arg>)`.

FunctionPass already supports aux arguments (and are used in the SeedCollection pass). This patch adds support for RegionPass too.
To help with testing this I modified the NullPass to add the ability to echo the aux arg.