### PR TITLE
[VPlan] Remove unused VPlan::getExitBlock(BasicBlock*) (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -899,14 +899,6 @@ VPlan::~VPlan() {
   delete BackedgeTakenCount;
 }
 
-VPIRBasicBlock *VPlan::getExitBlock(BasicBlock *IRBB) const {
-  auto Iter = find_if(getExitBlocks(), [IRBB](const VPIRBasicBlock *VPIRBB) {
-    return VPIRBB->getIRBasicBlock() == IRBB;
-  });
-  assert(Iter != getExitBlocks().end() && "no exit block found");
-  return *Iter;
-}
-
 bool VPlan::isExitBlock(VPBlockBase *VPBB) {
   return is_contained(ExitBlocks, VPBB);
 }

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -4913,10 +4913,6 @@ public:
   /// the original scalar loop.
   ArrayRef<VPIRBasicBlock *> getExitBlocks() const { return ExitBlocks; }
 
-  /// Return the VPIRBasicBlock corresponding to \p IRBB. \p IRBB must be an
-  /// exit block.
-  VPIRBasicBlock *getExitBlock(BasicBlock *IRBB) const;
-
   /// Returns true if \p VPBB is an exit block.
   bool isExitBlock(VPBlockBase *VPBB);
 


### PR DESCRIPTION
Remove unused function.