### PR TITLE
[IR] Fix invalid debug metadata diagnostic kind

### DIFF
--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -240,14 +240,14 @@ public:
 class LLVM_ABI DiagnosticInfoIgnoringInvalidDebugMetadata
     : public DiagnosticInfo {
 private:
-  /// The module that is concerned by this debug metadata version diagnostic.
+  /// The module that is concerned by this invalid debug metadata diagnostic.
   const Module &M;
 
 public:
-  /// \p The module that is concerned by this debug metadata version diagnostic.
+  /// \p The module that is concerned by this invalid debug metadata diagnostic.
   DiagnosticInfoIgnoringInvalidDebugMetadata(
       const Module &M, DiagnosticSeverity Severity = DS_Warning)
-      : DiagnosticInfo(DK_DebugMetadataVersion, Severity), M(M) {}
+      : DiagnosticInfo(DK_DebugMetadataInvalid, Severity), M(M) {}
 
   const Module &getModule() const { return M; }
 

--- a/llvm/unittests/IR/CMakeLists.txt
+++ b/llvm/unittests/IR/CMakeLists.txt
@@ -21,6 +21,7 @@ add_llvm_unittest(IRTests
   ConstantRangeListTest.cpp
   ConstantsTest.cpp
   DataLayoutTest.cpp
+  DiagnosticInfoTest.cpp
   DebugInfoTest.cpp
   DebugTypeODRUniquingTest.cpp
   DemandedBitsTest.cpp

--- a/llvm/unittests/IR/DiagnosticInfoTest.cpp
+++ b/llvm/unittests/IR/DiagnosticInfoTest.cpp
@@ -1,0 +1,36 @@
+//===- DiagnosticInfoTest.cpp - DiagnosticInfo unit tests -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/IR/DiagnosticInfo.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Casting.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+TEST(DiagnosticInfoTest, DebugMetadataKindsMatchClassof) {
+  LLVMContext C;
+  Module M("M", C);
+
+  DiagnosticInfoDebugMetadataVersion Version(M, 1);
+  const DiagnosticInfo *VersionInfo = &Version;
+  EXPECT_EQ(DK_DebugMetadataVersion, VersionInfo->getKind());
+  EXPECT_TRUE(isa<DiagnosticInfoDebugMetadataVersion>(VersionInfo));
+  EXPECT_FALSE(isa<DiagnosticInfoIgnoringInvalidDebugMetadata>(VersionInfo));
+
+  DiagnosticInfoIgnoringInvalidDebugMetadata Invalid(M);
+  const DiagnosticInfo *InvalidInfo = &Invalid;
+  EXPECT_EQ(DK_DebugMetadataInvalid, InvalidInfo->getKind());
+  EXPECT_TRUE(isa<DiagnosticInfoIgnoringInvalidDebugMetadata>(InvalidInfo));
+  EXPECT_FALSE(isa<DiagnosticInfoDebugMetadataVersion>(InvalidInfo));
+}
+
+} // end anonymous namespace


### PR DESCRIPTION
This type is only ever passed to LLVMContext::diagnose directly, and there are no downcasts to this type, so classof is effectively dead, but we should fix this oversight.

Fixes #205340