### PR TITLE
clang: Replace getTargetID API with isProcessorName

### DIFF
--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -1324,10 +1324,10 @@ public:
     return Triple;
   }
 
-  /// Returns the target ID if supported.
-  virtual std::optional<std::string> getTargetID() const {
-    return std::nullopt;
-  }
+  /// Returns true if the target's processor is compatible with the processor
+  /// named by \p Name, i.e. \p Name names this target's processor or a
+  /// compatible processor.
+  virtual bool isProcessorName(StringRef Name) const { return false; }
 
   const char *getDataLayoutString() const {
     assert(!DataLayoutString.empty() && "Uninitialized DataLayout!");

--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -295,8 +295,12 @@ void AMDGPUTargetInfo::getTargetDefines(const LangOptions &Opts,
                         Twine("__"));
     Builder.defineMacro("__amdgcn_processor__",
                         Twine("\"") + Twine(CanonName) + Twine("\""));
-    Builder.defineMacro("__amdgcn_target_id__",
-                        Twine("\"") + Twine(*getTargetID()) + Twine("\""));
+    Builder.defineMacro(
+        "__amdgcn_target_id__",
+        Twine("\"") +
+            Twine(getCanonicalTargetID(getArchNameAMDGCN(GPUKind),
+                                       OffloadArchFeatures)) +
+            Twine("\""));
     for (auto F : getAllPossibleTargetIDFeatures(getTriple(), CanonName)) {
       auto Loc = OffloadArchFeatures.find(F);
       if (Loc != OffloadArchFeatures.end()) {

--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -485,15 +485,11 @@ public:
     return true;
   }
 
-  std::optional<std::string> getTargetID() const override {
-    if (!getTriple().isAMDGCN())
-      return std::nullopt;
-    // When -target-cpu is not set, we assume generic code that it is valid
-    // for all GPU and use an empty string as target ID to represent that.
-    if (GPUKind == llvm::AMDGPU::GK_NONE)
-      return std::string("");
-    return getCanonicalTargetID(getArchNameAMDGCN(GPUKind),
-                                OffloadArchFeatures);
+  bool isProcessorName(StringRef Name) const override {
+    llvm::AMDGPU::GPUKind NameKind = getTriple().isAMDGCN()
+                                         ? llvm::AMDGPU::parseArchAMDGCN(Name)
+                                         : llvm::AMDGPU::parseArchR600(Name);
+    return NameKind == GPUKind;
   }
 
   bool hasHIPImageSupport() const override { return HasImage; }

--- a/clang/lib/Sema/SemaAMDGPU.cpp
+++ b/clang/lib/Sema/SemaAMDGPU.cpp
@@ -818,8 +818,7 @@ Expr *SemaAMDGPU::ExpandAMDGPUPredicateBuiltIn(Expr *E) {
       return *ExpandedPredicates.insert(CE).first;
     }
 
-    if (auto TID = Ctx.getTargetInfo().getTargetID())
-      P = TID->find(N) == 0;
+    P = TI.isProcessorName(N);
   } else {
     Expr *Arg = CE->getArg(0);
     if (!Arg || Arg->getType() != Ctx.BuiltinFnTy) {


### PR DESCRIPTION
The "target ID" naming is an AMDGPUism. Replace the getTargetID query
with an isProcessorName predicate so the target reports whether the
string should be considered a match. This makes alias handling more
natural than checking for exact match, and avoids an unnecessary
parse of the target ID.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>