### PR TITLE
[gn] Fix oversight from cf6527a49669c796b

### DIFF
--- a/llvm/utils/gn/secondary/compiler-rt/lib/profile/BUILD.gn
+++ b/llvm/utils/gn/secondary/compiler-rt/lib/profile/BUILD.gn
@@ -1,6 +1,9 @@
 import("//compiler-rt/target.gni")
 
 static_library("profile") {
+  configs -= [ "//llvm/utils/gn/build:llvm_code" ]
+  configs += [ "//llvm/utils/gn/build:crt_code" ]
+
   output_dir = crt_current_out_dir
   if (current_os == "mac") {
     output_name = "clang_rt.profile_osx"


### PR DESCRIPTION
Without this, the interception/interception.h include in
InstProfilingPlatformROCm.cpp isn't found.