### PR TITLE
[libc] add shared subdf3 builtin

### DIFF
--- a/libc/shared/builtins.h
+++ b/libc/shared/builtins.h
@@ -21,6 +21,7 @@
 #include "builtins/addtf3.h"
 #include "builtins/divtf3.h"
 #include "builtins/multf3.h"
+#include "builtins/subdf3.h"
 #include "builtins/subtf3.h"
 
 #endif // LLVM_LIBC_SHARED_BUILTINS_H

--- a/libc/shared/builtins/subdf3.h
+++ b/libc/shared/builtins/subdf3.h
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This header exposes LLVM-libc's __subdf3 implementation as shared::subdf3 so
+/// that it can be reused by compiler-rt's builtins.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_BUILTINS_SUBDF3_H
+#define LLVM_LIBC_SHARED_BUILTINS_SUBDF3_H
+
+#include "shared/libc_common.h"
+#include "src/__support/builtins/subdf3.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using builtins::subdf3;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_BUILTINS_SUBDF3_H

--- a/libc/src/__support/builtins/CMakeLists.txt
+++ b/libc/src/__support/builtins/CMakeLists.txt
@@ -46,3 +46,12 @@ add_header_library(
     libc.src.__support.FPUtil.generic.add_sub
     libc.src.__support.macros.config
 )
+
+add_header_library(
+  subdf3
+  HDRS
+    subdf3.h
+  DEPENDS
+    libc.src.__support.FPUtil.generic.add_sub
+    libc.src.__support.macros.config
+)

--- a/libc/src/__support/builtins/subdf3.h
+++ b/libc/src/__support/builtins/subdf3.h
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This header exposes LLVM-libc's __subdf3 implementation as builtins::subdf3
+/// so that it can be reused by compiler-rt's builtins.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_BUILTINS_SUBDF3_H
+#define LLVM_LIBC_SRC___SUPPORT_BUILTINS_SUBDF3_H
+
+#include "src/__support/FPUtil/generic/add_sub.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace builtins {
+
+// Subtraction at double precision; mirrors compiler-rt's __subdf3.
+LIBC_INLINE double subdf3(double x, double y) {
+  return fputil::generic::sub<double>(x, y);
+}
+
+} // namespace builtins
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_BUILTINS_SUBDF3_H

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -831,6 +831,7 @@ add_fp_unittest(
     libc.src.__support.builtins.addtf3
     libc.src.__support.builtins.divtf3
     libc.src.__support.builtins.multf3
+    libc.src.__support.builtins.subdf3
     libc.src.__support.builtins.subtf3
 )
 

--- a/libc/test/shared/shared_builtins_test.cpp
+++ b/libc/test/shared/shared_builtins_test.cpp
@@ -16,6 +16,7 @@ TEST(LlvmLibcSharedBuiltinsTest, AllFloat) {
 
 TEST(LlvmLibcSharedBuiltinsTest, AllDouble) {
   EXPECT_FP_EQ(3.0, LIBC_NAMESPACE::shared::adddf3(1.0, 2.0));
+  EXPECT_FP_EQ(2.0, LIBC_NAMESPACE::shared::subdf3(5.0, 3.0));
 }
 
 #ifdef LIBC_TYPES_HAS_FLOAT128


### PR DESCRIPTION
Re-exposes LLVM-libc's `__subdf3` as `shared::subdf3` for reuse by compiler-rt's builtins.

Stacked change - merge these first:
- #200094
- #205669
- #205670
- #205671
- #205672

Part of #197824