### PR TITLE
[flang][semantics][OpenACC] Warn for DEFAULT(NONE) scalars by default

### DIFF
--- a/clang/include/clang/Options/FlangOptions.td
+++ b/clang/include/clang/Options/FlangOptions.td
@@ -191,8 +191,8 @@ defm ppc_native_vec_elem_order: BoolOptionWithoutMarshalling<"f", "ppc-native-ve
   NegFlag<SetFalse, [], [ClangOption], "Specifies PowerPC non-native vector element order">>;
 defm unsigned : OptInFC1FFlag<"unsigned", "Enables UNSIGNED type">;
 defm openacc_default_none_scalars_strict : OptOutFC1FFlag<"openacc-default-none-scalars-strict",
-  "Require explicit data clauses for all variables (including scalars) under OpenACC DEFAULT(NONE) (default)",
-  "Allow scalars without explicit data clauses under OpenACC DEFAULT(NONE) (pre-OpenACC-3.2 behavior)">;
+  "Require explicit data clauses for all variables (including scalars) under OpenACC DEFAULT(NONE)",
+  "Allow scalars without explicit data clauses under OpenACC DEFAULT(NONE) (default, pre-OpenACC-3.2 behavior)">;
 defm openacc_multiple_names_in_routine : OptOutFC1FFlag<"openacc-multiple-names-in-routine",
   "Accept multiple names in OpenACC ROUTINE directive (extension)",
   "Do not accept multiple names in OpenACC ROUTINE directive">;

--- a/flang/docs/OpenACC-extensions.md
+++ b/flang/docs/OpenACC-extensions.md
@@ -63,28 +63,24 @@ with multiple names.  A warning is emitted for each such directive
 `-Wno-openacc-multiple-names-in-routine`).  This extension may be disabled with
 `-fno-openacc-multiple-names-in-routine`.
 
-## Extensions enabled by flag
-
-### `-fno-openacc-default-none-scalars-strict` — pre-OpenACC-3.2 scalar behavior under `DEFAULT(NONE)`
+### Pre-OpenACC-3.2 scalar behavior under `DEFAULT(NONE)`
 
 OpenACC version 3.2 (section 1.16, change 733) clarified that the
 `default(none)` clause applies to scalar variables.  Prior to version 3.2,
 `default(none)` did not impose a data-clause requirement on scalar variables.
 
-By default, Flang enforces the OpenACC 3.2 behavior: scalar variables
-referenced inside a `default(none)` compute region without an explicit data
-clause produce an error.
-
-When `-fno-openacc-default-none-scalars-strict` is specified, Flang reverts to
-the pre-3.2 behavior: scalar variables referenced inside a `default(none)`
-compute region without an explicit data clause do not produce an error.
-Instead, Flang infers implicit data attributes for those scalars via the same
-implicit-copy logic applied in regions without `default(none)`.
+By default, Flang uses the pre-3.2 behavior: scalar variables referenced inside
+a `default(none)` compute region without an explicit data clause do not produce
+an error. Instead, Flang infers implicit data attributes for those scalars via
+the same implicit-copy logic applied in regions without `default(none)`.
 
 Array variables always require an explicit data clause under `default(none)`
-regardless of this flag.
+regardless of this extension.
 
-When a scalar is implicitly attributed under this extension no warning is
-emitted by default; explicit opt-in to the non-standard behavior is treated as
-acknowledgement.  Use `-Wopenacc-default-none-scalars-strict` to enable
-per-use warnings for audit purposes.
+When a scalar is implicitly attributed under this extension, a warning is
+emitted by default (`-Wopenacc-default-none-scalars-strict`; suppress with
+`-Wno-openacc-default-none-scalars-strict`). Use
+`-fopenacc-default-none-scalars-strict` to enforce the OpenACC 3.2 behavior and
+produce an error for scalar variables that are not listed in an explicit data
+clause. `-fno-openacc-default-none-scalars-strict` preserves the default
+pre-3.2 behavior explicitly.

--- a/flang/include/flang/Semantics/semantics.h
+++ b/flang/include/flang/Semantics/semantics.h
@@ -80,6 +80,9 @@ public:
     return languageFeatures_;
   }
   const common::LangOptions &langOptions() const { return langOpts_; }
+  const std::string &openAccDefaultNoneScalarsStrictDisableOption() const {
+    return openAccDefaultNoneScalarsStrictDisableOption_;
+  }
   int GetDefaultKind(TypeCategory) const;
   int doublePrecisionKind() const {
     return defaultKinds_.doublePrecisionKind();
@@ -166,6 +169,11 @@ public:
   }
   SemanticsContext &set_debugModuleWriter(bool x) {
     debugModuleWriter_ = x;
+    return *this;
+  }
+  SemanticsContext &set_openAccDefaultNoneScalarsStrictDisableOption(
+      std::string x) {
+    openAccDefaultNoneScalarsStrictDisableOption_ = std::move(x);
     return *this;
   }
 
@@ -369,6 +377,7 @@ private:
   const common::LanguageFeatureControl &languageFeatures_;
   const common::LangOptions &langOpts_;
   parser::AllCookedSources &allCookedSources_;
+  std::string openAccDefaultNoneScalarsStrictDisableOption_;
   std::optional<parser::CharBlock> location_;
   std::vector<std::string> searchDirectories_;
   std::vector<std::string> intrinsicModuleDirectories_;

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -886,7 +886,7 @@ static bool parseFrontendArgs(FrontendOptions &opts, llvm::opt::ArgList &args,
       Fortran::common::LanguageFeature::OpenAccDefaultNoneScalarsStrict,
       args.hasFlag(clang::options::OPT_fopenacc_default_none_scalars_strict,
                    clang::options::OPT_fno_openacc_default_none_scalars_strict,
-                   true));
+                   false));
 
   // -f{no-}openacc-multiple-names-in-routine
   opts.features.Enable(
@@ -1961,7 +1961,12 @@ CompilerInvocation::getSemanticsCtx(
       .set_maxErrors(getMaxErrors())
       .set_warningsAreErrors(getWarnAsErr())
       .set_moduleFileSuffix(getModuleFileSuffix())
-      .set_underscoring(getCodeGenOpts().Underscoring);
+      .set_underscoring(getCodeGenOpts().Underscoring)
+      .set_openAccDefaultNoneScalarsStrictDisableOption(
+          clang::getDriverOptTable()
+              .getOptionPrefixedName(
+                  clang::options::OPT_fno_openacc_default_none_scalars_strict)
+              .str());
 
   std::string compilerVersion = Fortran::common::getFlangFullVersion();
   Fortran::tools::setUpTargetCharacteristics(

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1856,8 +1856,9 @@ void AccAttributeVisitor::Post(const parser::Name &name) {
             context_.Warn(
                 common::LanguageFeature::OpenAccDefaultNoneScalarsStrict,
                 name.source,
-                "Implicit attribute inferred for DEFAULT(NONE) scalar '%s'"_warn_en_US,
-                symbol.name());
+                "OpenACC DEFAULT(NONE) ignored for scalar '%s' (%s)"_warn_en_US,
+                symbol.name(),
+                context_.openAccDefaultNoneScalarsStrictDisableOption());
           } else {
             context_.Say(name.source,
                 "The DEFAULT(NONE) clause requires that '%s' must be listed in a data-mapping clause"_err_en_US,

--- a/flang/lib/Semantics/semantics.cpp
+++ b/flang/lib/Semantics/semantics.cpp
@@ -385,6 +385,9 @@ SemanticsContext::SemanticsContext(
     common::FPMaxminBehavior fpMaxminBehavior)
     : defaultKinds_{defaultKinds}, languageFeatures_{languageFeatures},
       langOpts_{langOpts}, allCookedSources_{allCookedSources},
+      openAccDefaultNoneScalarsStrictDisableOption_{"-fno-"s +
+          std::string{languageFeatures_.getDefaultCliSpelling(
+              common::LanguageFeature::OpenAccDefaultNoneScalarsStrict)}},
       intrinsics_{evaluate::IntrinsicProcTable::Configure(defaultKinds_)},
       globalScope_{*this}, intrinsicModulesScope_{globalScope_.MakeScope(
                                Scope::Kind::IntrinsicModules, nullptr)},

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -150,6 +150,7 @@ LanguageFeatureControl::LanguageFeatureControl() {
   // Possibly an accidental "feature" of nvfortran.
   disable_.set(LanguageFeature::AssumedRankPassedToNonAssumedRank);
   disable_.set(LanguageFeature::Coarray);
+  disable_.set(LanguageFeature::OpenAccDefaultNoneScalarsStrict);
   // These warnings are enabled by default, but only because they used
   // to be unconditional.  TODO: prune this list
   warnLanguage_.set(LanguageFeature::ExponentMatchingKindParam);
@@ -217,6 +218,7 @@ LanguageFeatureControl::LanguageFeatureControl() {
   warnUsage_.set(UsageWarning::IgnoredNoReallocateLHS);
   warnUsage_.set(UsageWarning::IoImpliedDoIndexConflict);
   warnLanguage_.set(LanguageFeature::OpenMPThreadprivateEquivalence);
+  warnLanguage_.set(LanguageFeature::OpenAccDefaultNoneScalarsStrict);
   warnLanguage_.set(LanguageFeature::OpenACCMultipleNamesInRoutine);
 }
 

--- a/flang/test/Semantics/OpenACC/acc-default-none-scalars-strict.f90
+++ b/flang/test/Semantics/OpenACC/acc-default-none-scalars-strict.f90
@@ -1,33 +1,36 @@
 ! RUN: %flang_fc1 -fsyntax-only -fopenacc-default-none-scalars-strict -Wopenacc-default-none-scalars-strict %s 2>&1 | FileCheck --allow-empty --check-prefix=NO-ACC %s
-! RUN: not %flang_fc1 -fsyntax-only -fopenacc %s 2>&1 | FileCheck --check-prefix=STRICT %s
+! RUN: not %flang_fc1 -fsyntax-only -fopenacc %s 2>&1 | FileCheck --check-prefix=LENIENT %s
+! RUN: not %flang_fc1 -fsyntax-only -fopenacc -Wopenacc-default-none-scalars-strict %s 2>&1 | FileCheck --check-prefix=LENIENT %s
+! RUN: not %flang_fc1 -fsyntax-only -fopenacc -Wno-openacc-default-none-scalars-strict %s 2>&1 | FileCheck --check-prefix=SILENT-LENIENT %s
 ! RUN: not %flang_fc1 -fsyntax-only -fopenacc -fopenacc-default-none-scalars-strict %s 2>&1 | FileCheck --check-prefix=STRICT %s
-! RUN: not %flang_fc1 -fsyntax-only -fopenacc -Wopenacc-default-none-scalars-strict %s 2>&1 | FileCheck --check-prefix=STRICT %s
 ! RUN: not %flang_fc1 -fsyntax-only -fopenacc -fopenacc-default-none-scalars-strict -Wopenacc-default-none-scalars-strict %s 2>&1 | FileCheck --check-prefix=STRICT %s
-! RUN: not %flang_fc1 -fsyntax-only -fopenacc -Wno-openacc-default-none-scalars-strict %s 2>&1 | FileCheck --check-prefix=STRICT %s
 ! RUN: not %flang_fc1 -fsyntax-only -fopenacc -fopenacc-default-none-scalars-strict -Wno-openacc-default-none-scalars-strict %s 2>&1 | FileCheck --check-prefix=STRICT %s
-! RUN: not %flang_fc1 -fsyntax-only -fopenacc -fno-openacc-default-none-scalars-strict %s 2>&1 | FileCheck --check-prefix=SILENT-LENIENT %s
+! RUN: not %flang_fc1 -fsyntax-only -fopenacc -fno-openacc-default-none-scalars-strict %s 2>&1 | FileCheck --check-prefix=LENIENT %s
 ! RUN: not %flang_fc1 -fsyntax-only -fopenacc -fno-openacc-default-none-scalars-strict -Wopenacc-default-none-scalars-strict %s 2>&1 | FileCheck --check-prefix=LENIENT %s
 ! RUN: not %flang_fc1 -fsyntax-only -fopenacc -fno-openacc-default-none-scalars-strict -Wno-openacc-default-none-scalars-strict %s 2>&1 | FileCheck --check-prefix=SILENT-LENIENT %s
 
 ! Without -fopenacc, no OpenACC directives are processed, so no diagnostics.
 ! NO-ACC-NOT: DEFAULT(NONE) clause requires
-! NO-ACC-NOT: Implicit attribute inferred
+! NO-ACC-NOT: OpenACC DEFAULT(NONE) ignored for scalar
 
-! With -fopenacc (strict mode, default), all unlisted variables error.
+! With explicit strict mode, all unlisted variables error.
 ! STRICT: error: The DEFAULT(NONE) clause requires that 's' must be listed in a data-mapping clause
 ! STRICT-NOT: DEFAULT(NONE) clause requires that 'se'
 ! STRICT: error: The DEFAULT(NONE) clause requires that 'a' must be listed in a data-mapping clause
 ! STRICT-NOT: DEFAULT(NONE) clause requires that 'ae'
 
-! With -fno-openacc-default-none-scalars-strict (lenient mode), implicit scalars are
-! silent by default; -Wopenacc-default-none-scalars-strict enables per-use warnings.
-! LENIENT: warning: Implicit attribute inferred for DEFAULT(NONE) scalar 's'
-! LENIENT-NOT: Implicit attribute inferred for DEFAULT(NONE) scalar 'se'
+! By default, and with -fno-openacc-default-none-scalars-strict, implicit scalars
+! warn instead of erroring.  Arrays still error.
+! LENIENT-NOT: error: The DEFAULT(NONE) clause requires that 's'
+! LENIENT: warning: OpenACC DEFAULT(NONE) ignored for scalar 's' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
+! LENIENT-NOT: OpenACC DEFAULT(NONE) ignored for scalar 'se'
 ! LENIENT: error: The DEFAULT(NONE) clause requires that 'a' must be listed in a data-mapping clause
 ! LENIENT-NOT: DEFAULT(NONE) clause requires that 'ae'
 
-! Lenient mode default (no explicit -W): scalar attribution is silent; array error is unaffected.
-! SILENT-LENIENT-NOT: Implicit attribute inferred for DEFAULT(NONE) scalar 's'
+! -Wno-openacc-default-none-scalars-strict suppresses the default scalar warning;
+! the array error is unaffected.
+! SILENT-LENIENT-NOT: error: The DEFAULT(NONE) clause requires that 's'
+! SILENT-LENIENT-NOT: OpenACC DEFAULT(NONE) ignored for scalar 's'
 ! SILENT-LENIENT: error: The DEFAULT(NONE) clause requires that 'a' must be listed in a data-mapping clause
 ! SILENT-LENIENT-NOT: DEFAULT(NONE) clause requires that 'ae'
 

--- a/flang/test/Semantics/OpenACC/acc-default-none-scalars.f90
+++ b/flang/test/Semantics/OpenACC/acc-default-none-scalars.f90
@@ -1,14 +1,14 @@
-! RUN: %python %S/../test_errors.py %s %flang -fopenacc -fno-openacc-default-none-scalars-strict -Wopenacc-default-none-scalars-strict
+! RUN: %python %S/../test_errors.py %s %flang -fopenacc
 
-! With -fno-openacc-default-none-scalars-strict, scalar variables without explicit
-! data clauses under DEFAULT(NONE) are allowed and get a warning
-! (-Wopenacc-default-none-scalars-strict) instead of an error.  Arrays continue to error.
+! By default, scalar variables without explicit data clauses under DEFAULT(NONE)
+! are allowed and get a warning (-Wopenacc-default-none-scalars-strict) instead
+! of an error.  Arrays continue to error.
 
 subroutine default_none_scalars()
   integer :: a
   integer :: b(10)
   !$acc parallel default(none)
-  !WARNING: Implicit attribute inferred for DEFAULT(NONE) scalar 'a' [-Wopenacc-default-none-scalars-strict]
+  !WARNING: OpenACC DEFAULT(NONE) ignored for scalar 'a' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
   a = 1
   !ERROR: The DEFAULT(NONE) clause requires that 'b' must be listed in a data-mapping clause
   b(1) = 2
@@ -22,9 +22,9 @@ subroutine default_none_scalar_precomputed(x, n, p, q)
   integer :: n, i
   factor = p / q
   !$acc parallel loop default(none) present(x)
-  !WARNING: Implicit attribute inferred for DEFAULT(NONE) scalar 'n' [-Wopenacc-default-none-scalars-strict]
+  !WARNING: OpenACC DEFAULT(NONE) ignored for scalar 'n' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
   do i = 1, n
-    !WARNING: Implicit attribute inferred for DEFAULT(NONE) scalar 'factor' [-Wopenacc-default-none-scalars-strict]
+    !WARNING: OpenACC DEFAULT(NONE) ignored for scalar 'factor' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
     x(i) = x(i) * factor
   end do
   !$acc end parallel loop
@@ -64,12 +64,12 @@ subroutine default_none_outer_loop_scalars(x, n, m)
     thresh = real(k) - real(k) / real(m)
     val    = real(k) * 4.0
     !$acc parallel loop default(none) present(x)
-    !WARNING: Implicit attribute inferred for DEFAULT(NONE) scalar 'n' [-Wopenacc-default-none-scalars-strict]
+    !WARNING: OpenACC DEFAULT(NONE) ignored for scalar 'n' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
     do i = 1, n
-      !WARNING: Implicit attribute inferred for DEFAULT(NONE) scalar 'thresh' [-Wopenacc-default-none-scalars-strict]
-      !WARNING: Implicit attribute inferred for DEFAULT(NONE) scalar 'coef' [-Wopenacc-default-none-scalars-strict]
-      !WARNING: Implicit attribute inferred for DEFAULT(NONE) scalar 'val' [-Wopenacc-default-none-scalars-strict]
-      !WARNING: Implicit attribute inferred for DEFAULT(NONE) scalar 'k' [-Wopenacc-default-none-scalars-strict]
+      !WARNING: OpenACC DEFAULT(NONE) ignored for scalar 'thresh' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
+      !WARNING: OpenACC DEFAULT(NONE) ignored for scalar 'coef' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
+      !WARNING: OpenACC DEFAULT(NONE) ignored for scalar 'val' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
+      !WARNING: OpenACC DEFAULT(NONE) ignored for scalar 'k' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
       if (x(i) < thresh) x(i) = x(i) + coef * val * real(k)
     end do
     !$acc end parallel loop

--- a/flang/test/Semantics/OpenACC/acc-kernels-loop.f90
+++ b/flang/test/Semantics/OpenACC/acc-kernels-loop.f90
@@ -249,7 +249,7 @@ program openacc_kernels_loop_validity
   end do
 
   !$acc kernels loop default(none)
-  !ERROR: The DEFAULT(NONE) clause requires that 'n' must be listed in a data-mapping clause
+  !WARNING: OpenACC DEFAULT(NONE) ignored for scalar 'n' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
   do i = 1, N
     !ERROR: The DEFAULT(NONE) clause requires that 'a' must be listed in a data-mapping clause
     a(i) = 3.14d0

--- a/flang/test/Semantics/OpenACC/acc-parallel.f90
+++ b/flang/test/Semantics/OpenACC/acc-parallel.f90
@@ -207,7 +207,7 @@ subroutine acc_parallel_default_none
   l = 10
   !$acc parallel default(none)
   !$acc loop
-  !ERROR: The DEFAULT(NONE) clause requires that 'l' must be listed in a data-mapping clause
+  !WARNING: OpenACC DEFAULT(NONE) ignored for scalar 'l' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
   do i = 1, l
     !ERROR: The DEFAULT(NONE) clause requires that 'a' must be listed in a data-mapping clause
     a(1,i) = 1

--- a/flang/test/Semantics/OpenACC/acc-resolve01.f90
+++ b/flang/test/Semantics/OpenACC/acc-resolve01.f90
@@ -11,7 +11,7 @@ subroutine default_none()
   !$acc parallel default(none) private(c)
   !ERROR: The DEFAULT(NONE) clause requires that 'a' must be listed in a data-mapping clause
   A(1:2) = 3
-  !ERROR: The DEFAULT(NONE) clause requires that 'b' must be listed in a data-mapping clause
+  !WARNING: OpenACC DEFAULT(NONE) ignored for scalar 'b' (-fno-openacc-default-none-scalars-strict) [-Wopenacc-default-none-scalars-strict]
   B = 4
   C = 5
   !$acc end parallel

--- a/flang/unittests/Frontend/CompilerInstanceTest.cpp
+++ b/flang/unittests/Frontend/CompilerInstanceTest.cpp
@@ -7,9 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Frontend/CompilerInstance.h"
+#include "flang/Frontend/CompilerInvocation.h"
 #include "flang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Basic/DiagnosticOptions.h"
+#include "clang/Options/Options.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/TargetParser/Host.h"
+#include "llvm/TargetParser/Triple.h"
 
 #include "gtest/gtest.h"
 
@@ -92,5 +97,28 @@ TEST(CompilerInstance, AllowDiagnosticLogWithUnownedDiagnosticConsumer) {
   // 6. Verify that the reported diagnostic wasn't lost and did end up in the
   // output stream
   ASSERT_EQ(diagnosticOutput, "error: expected no crash\n");
+}
+
+TEST(CompilerInstance,
+    OpenAccDefaultNoneScalarsStrictDisableOptionUsesDriverTable) {
+  CompilerInstance compInst;
+  compInst.createDiagnostics();
+
+  auto invocation = std::make_shared<CompilerInvocation>();
+  invocation->getTargetOpts().triple =
+      llvm::Triple::normalize(llvm::sys::getDefaultTargetTriple());
+
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllTargetMCs();
+
+  compInst.setInvocation(std::move(invocation));
+  ASSERT_TRUE(compInst.setUpTargetMachine());
+  auto &context = compInst.createNewSemanticsContext();
+
+  EXPECT_EQ(context.openAccDefaultNoneScalarsStrictDisableOption(),
+      clang::getDriverOptTable()
+          .getOptionPrefixedName(
+              clang::options::OPT_fno_openacc_default_none_scalars_strict)
+          .str());
 }
 } // namespace


### PR DESCRIPTION
  Change OpenACC `DEFAULT(NONE)` scalar handling to use the pre-OpenACC-3.2 scalar behavior by default while emitting a warning. Scalars referenced in a `default(none)` compute region without an explicit data clause now warn by default instead of erroring. Arrays and other non-scalars still error under `default(none)`.

  Users can opt into OpenACC 3.2 strict scalar behavior with: `-fopenacc-default-none-scalars-strict` and the default scalar warning can be suppressed with: `-Wno-openacc-default-none-scalars-strict`