### PR TITLE
[lldb][NFC] Remove ConstString from Language::MethodNameVariant

### DIFF
--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -200,22 +200,22 @@ public:
   virtual const char *GetLanguageSpecificTypeLookupHelp();
 
   class MethodNameVariant {
-    ConstString m_name;
+    std::string m_name;
     lldb::FunctionNameType m_type;
 
   public:
-    MethodNameVariant(ConstString name, lldb::FunctionNameType type)
-        : m_name(name), m_type(type) {}
-    ConstString GetName() const { return m_name; }
+    MethodNameVariant(std::string name, lldb::FunctionNameType type)
+        : m_name(std::move(name)), m_type(type) {}
+    llvm::StringRef GetName() const { return m_name; }
     lldb::FunctionNameType GetType() const { return m_type; }
   };
   // If a language can have more than one possible name for a method, this
   // function can be used to enumerate them. This is useful when doing name
   // lookups.
   virtual std::vector<Language::MethodNameVariant>
-  GetMethodNameVariants(ConstString method_name) const {
+  GetMethodNameVariants(llvm::StringRef method_name) const {
     return std::vector<Language::MethodNameVariant>();
-  };
+  }
 
   class MethodName {
   public:

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -228,7 +228,7 @@ void BreakpointResolverName::AddNameLookup(ConstString name,
         std::vector<Module::LookupInfo> variant_lookups =
             Module::LookupInfo::MakeLookupInfos(name, variant.GetType(),
                                                 lang->GetLanguageType(),
-                                                variant.GetName());
+                                                ConstString(variant.GetName()));
         llvm::append_range(m_lookups, variant_lookups);
       }
     }

--- a/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
+++ b/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
@@ -177,14 +177,14 @@ std::string ObjCLanguage::ObjCMethodName::GetFullNameWithoutCategory() const {
 }
 
 std::vector<Language::MethodNameVariant>
-ObjCLanguage::GetMethodNameVariants(ConstString method_name) const {
+ObjCLanguage::GetMethodNameVariants(llvm::StringRef method_name) const {
   std::vector<Language::MethodNameVariant> variant_names;
   std::optional<const ObjCLanguage::ObjCMethodName> objc_method =
-      ObjCLanguage::ObjCMethodName::Create(method_name.GetStringRef(), false);
+      ObjCLanguage::ObjCMethodName::Create(method_name, false);
   if (!objc_method)
     return variant_names;
 
-  variant_names.emplace_back(ConstString(objc_method->GetSelector()),
+  variant_names.emplace_back(objc_method->GetSelector().str(),
                              lldb::eFunctionNameTypeSelector);
 
   const std::string name_sans_category =
@@ -192,29 +192,29 @@ ObjCLanguage::GetMethodNameVariants(ConstString method_name) const {
 
   if (objc_method->IsClassMethod() || objc_method->IsInstanceMethod()) {
     if (!name_sans_category.empty())
-      variant_names.emplace_back(ConstString(name_sans_category),
+      variant_names.emplace_back(name_sans_category,
                                  lldb::eFunctionNameTypeFull);
   } else {
     StreamString strm;
 
     strm.Printf("+%s", objc_method->GetFullName().c_str());
-    variant_names.emplace_back(ConstString(strm.GetString()),
+    variant_names.emplace_back(strm.GetString().str(),
                                lldb::eFunctionNameTypeFull);
     strm.Clear();
 
     strm.Printf("-%s", objc_method->GetFullName().c_str());
-    variant_names.emplace_back(ConstString(strm.GetString()),
+    variant_names.emplace_back(strm.GetString().str(),
                                lldb::eFunctionNameTypeFull);
     strm.Clear();
 
     if (!name_sans_category.empty()) {
       strm.Printf("+%s", name_sans_category.c_str());
-      variant_names.emplace_back(ConstString(strm.GetString()),
+      variant_names.emplace_back(strm.GetString().str(),
                                  lldb::eFunctionNameTypeFull);
       strm.Clear();
 
       strm.Printf("-%s", name_sans_category.c_str());
-      variant_names.emplace_back(ConstString(strm.GetString()),
+      variant_names.emplace_back(strm.GetString().str(),
                                  lldb::eFunctionNameTypeFull);
     }
   }

--- a/lldb/source/Plugins/Language/ObjC/ObjCLanguage.h
+++ b/lldb/source/Plugins/Language/ObjC/ObjCLanguage.h
@@ -137,7 +137,7 @@ public:
   //  variant_names[3] => "-[NSString myStringWithCString:]"
   // Also returns the FunctionNameType of each possible name.
   std::vector<Language::MethodNameVariant>
-  GetMethodNameVariants(ConstString method_name) const override;
+  GetMethodNameVariants(llvm::StringRef method_name) const override;
 
   std::pair<lldb::FunctionNameType, std::optional<ConstString>>
   GetFunctionNameInfo(ConstString name) const override;

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -364,13 +364,13 @@ void Symtab::InitNameIndexes() {
       for (Language *lang : languages) {
         for (auto variant : lang->GetMethodNameVariants(name)) {
           if (variant.GetType() & lldb::eFunctionNameTypeSelector)
-            selector_to_index.Append(variant.GetName(), value);
+            selector_to_index.Append(ConstString(variant.GetName()), value);
           else if (variant.GetType() & lldb::eFunctionNameTypeFull)
-            name_to_index.Append(variant.GetName(), value);
+            name_to_index.Append(ConstString(variant.GetName()), value);
           else if (variant.GetType() & lldb::eFunctionNameTypeMethod)
-            method_to_index.Append(variant.GetName(), value);
+            method_to_index.Append(ConstString(variant.GetName()), value);
           else if (variant.GetType() & lldb::eFunctionNameTypeBase)
-            basename_to_index.Append(variant.GetName(), value);
+            basename_to_index.Append(ConstString(variant.GetName()), value);
         }
       }
     }


### PR DESCRIPTION
Language::MethodNameVariant is for when a given method name may have several language-defined variants. For example, we may see an objective-C method name with a category that should be searchable via the name without the category.

The ObjCLanguage plugin computes these names without checking that they are actually useful or even exist. Because these variant names are stored in ConstString, they will live forever even if they are never used.