### PR TITLE
[lldb] Don't fail scripted frame construction on WebAssembly

### DIFF
--- a/lldb/examples/python/templates/scripted_process.py
+++ b/lldb/examples/python/templates/scripted_process.py
@@ -532,6 +532,13 @@ class ScriptedFrame(metaclass=ABCMeta):
                 elif "hexagon" in self.arch:
                     self.register_info["sets"] = ["General Purpose Registers"]
                     self.register_info["registers"] = HEXAGON_GPR
+                elif "wasm" in self.arch:
+                    # WebAssembly is a stack machine with no general-purpose
+                    # register file, so there is no GPR layout to expose. Leave
+                    # the register info empty rather than raising, which would
+                    # otherwise prevent the scripted frame from constructing.
+                    self.register_info["sets"] = []
+                    self.register_info["registers"] = []
                 else:
                     raise ValueError("Unknown architecture", self.arch)
         return self.register_info


### PR DESCRIPTION
ScriptedFrame.get_register_info() dispatches on a hardcoded list of architectures (x86_64/arm64/arm/hexagon) to pick a general-purpose register layout and raised ValueError for anything else. Because ScriptedFrame.__init__ calls get_register_info() eagerly, this made every scripted frame fail to construct on wasm32: the Python exception surfaced as "invalid script object", the frame provider produced an empty stack, and that tripped the "a valid thread has no frames" assert in StackFrameList::GetFrameAtIndex.

WebAssembly is a stack machine with no general-purpose register file, so there's no GPR layout to expose. This adds an explicit wasm case that leaves the register info empty and lets the frame construct.

Per the discussion below, I've kept the else: raise ValueError(...) for genuinely unknown architectures rather than changing the default — those should still surface an error, and #198153 will make that diagnostic better.

Assisted-by: Claude