### PR TITLE
[lldb] Change BreakpointList::FindBreakpointsByName to use StringRef

### DIFF
--- a/lldb/include/lldb/Breakpoint/Breakpoint.h
+++ b/lldb/include/lldb/Breakpoint/Breakpoint.h
@@ -579,7 +579,7 @@ private:
   bool HasFacadeLocations() { return m_facade_locations.GetSize() != 0; }
 
 public:
-  bool MatchesName(const char *name) {
+  bool MatchesName(llvm::StringRef name) {
     return m_name_list.find(name) != m_name_list.end();
   }
 

--- a/lldb/include/lldb/Breakpoint/BreakpointList.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointList.h
@@ -70,7 +70,7 @@ public:
   ///   error if the input name was not a legal breakpoint name, vector
   ///   of breakpoints otherwise.
   llvm::Expected<std::vector<lldb::BreakpointSP>>
-  FindBreakpointsByName(const char *name);
+  FindBreakpointsByName(llvm::StringRef name);
 
   /// Returns the number of elements in this breakpoint list.
   ///

--- a/lldb/source/Breakpoint/BreakpointList.cpp
+++ b/lldb/source/Breakpoint/BreakpointList.cpp
@@ -125,13 +125,13 @@ BreakpointSP BreakpointList::FindBreakpointByID(break_id_t break_id) const {
 }
 
 llvm::Expected<std::vector<lldb::BreakpointSP>>
-BreakpointList::FindBreakpointsByName(const char *name) {
-  if (!name)
+BreakpointList::FindBreakpointsByName(llvm::StringRef name) {
+  if (name.empty())
     return llvm::createStringError(llvm::errc::invalid_argument,
                                    "FindBreakpointsByName requires a name");
 
   Status error;
-  if (!BreakpointID::StringIsBreakpointName(llvm::StringRef(name), error))
+  if (!BreakpointID::StringIsBreakpointName(name, error))
     return error.ToError();
 
   std::vector<lldb::BreakpointSP> matching_bps;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -930,8 +930,7 @@ void Target::ConfigureBreakpointName(
 
 void Target::ApplyNameToBreakpoints(BreakpointName &bp_name) {
   llvm::Expected<std::vector<BreakpointSP>> expected_vector =
-      m_breakpoint_list.FindBreakpointsByName(
-          bp_name.GetName().AsCString(nullptr));
+      m_breakpoint_list.FindBreakpointsByName(bp_name.GetName().GetStringRef());
 
   if (!expected_vector) {
     LLDB_LOG(GetLog(LLDBLog::Breakpoints), "invalid breakpoint name: {}",


### PR DESCRIPTION
It's not possible to turn a StringRef into a c-string safely without a potential allocation. I will use this in a follow-up to remove ConstString from BreakpointName.