### PR TITLE
[flang][cuda] Accept cuf kernel do without scalar

### DIFF
--- a/flang/lib/Parser/executable-parsers.cpp
+++ b/flang/lib/Parser/executable-parsers.cpp
@@ -583,7 +583,9 @@ TYPE_PARSER("<<<" >>
 
 TYPE_PARSER(sourced(beginDirective >> "$CUF KERNEL DO"_tok >>
     construct<CUFKernelDoConstruct::Directive>(
-        maybe(parenthesized(scalarIntConstantExpr)),
+        // Accept !$CUF KERNEL DO, !$CUF KERNEL DO(), and
+        // !$CUF KERNEL DO(<scalar-int-constant-expr>).
+        defaulted(parenthesized(maybe(scalarIntConstantExpr))),
         maybe(Parser<CUFKernelDoConstruct::LaunchConfiguration>{}),
         many(Parser<CUFReduction>{}) / endDirective)))
 TYPE_CONTEXT_PARSER("!$CUF KERNEL DO construct"_en_US,

--- a/flang/test/Semantics/cuf23.cuf
+++ b/flang/test/Semantics/cuf23.cuf
@@ -35,6 +35,11 @@ subroutine host()
   do i = 1, 10
     print*, a(i) ! ok
   end do
+
+  !$cuf kernel do()
+  do i = 1, 10
+    print*, a(i) ! ok
+  end do
 end subroutine
 
 attributes(global) subroutine global1()


### PR DESCRIPTION
The base compiler accept `!$cuf kernel do()` instead of raising an error. Update the parser to accept the same syntax. 
`!$cuf kernel do()` is equivalent to `!$cuf kernel do`