### PR TITLE
[clang][dataflow] Move expensive solver asserts under EXPENSIVE_CHECKS

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/WatchedLiteralsSolver.cpp
+++ b/clang/lib/Analysis/FlowSensitive/WatchedLiteralsSolver.cpp
@@ -162,9 +162,11 @@ public:
       // FIXME: Consider replacing these with test cases that fail if the any
       // of the invariants is broken. That might not be easy due to the
       // transformations performed by `buildCNF`.
+#ifdef EXPENSIVE_CHECKS
       assert(activeVarsAreUnassigned());
       assert(activeVarsFormWatchedLiterals());
       assert(unassignedVarsFormingWatchedLiteralsAreActive());
+#endif
 
       const Variable ActiveVar = ActiveVars[I];
 


### PR DESCRIPTION
The watched-literal solver has a few invariant checks that run on every solver iteration in assertion builds. Some of these checks rebuild and iterate over the watched-literal state. This overhead is usually hidden, but it becomes dominant for large flow-sensitive analyses.

While testing clang-tidy's `unchecked-optional-access` check on real world projects (in this case, LLVM itself), we found there are a few extreme slow analyses caused by this overhead.

| Time    | File                                                |
|---------|-----------------------------------------------------|
| 8235.7s | llvm-project/clang/utils/TableGen/RISCVVEmitter.cpp |
| 8197.2s | llvm-project/clang/lib/Driver/Multilib.cpp          |

(Ran on a machine with Icelake 32cores + 128gb memory)

After moving these asserts to `EXPENSIVE_CHECKS`, the same files complete in about 14.2 seconds and 12.2 seconds locally. That is roughly a 580x improvement for `RISCVVEmitter.cpp` and a 673x improvement for `Multilib.cpp`.

This can also affect clang-tidy pre-merge CI, because the pre-merge configuration uses an assertions build and enables `bugprone-unchecked-optional-access`.

Given this scale of improvement, I think these invariant checks are better suited for `EXPENSIVE_CHECKS`. They remain available in dedicated expensive-check builds, while avoiding a very large cost in regular release+assertions builds.

Closes https://github.com/llvm/llvm-project/issues/205713