### PR TITLE
[libc++] Add implementations of `__get_locale_encoding(...)` to Fuschia and LLVM-Libc

### DIFF
--- a/libcxx/include/__locale_dir/support/fuchsia.h
+++ b/libcxx/include/__locale_dir/support/fuchsia.h
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cwchar>
+#include <langinfo.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -67,6 +68,10 @@ inline _LIBCPP_HIDE_FROM_ABI char* __setlocale(int __category, char const* __loc
 inline _LIBCPP_HIDE_FROM_ABI __lconv_t* __localeconv(__locale_t& __loc) {
   __locale_guard __current(__loc);
   return std::localeconv();
+}
+
+inline _LIBCPP_HIDE_FROM_ABI const char* __get_locale_encoding([[maybe_unused]] __locale_t __loc) {
+  return ::nl_langinfo_l(CODESET, __loc);
 }
 
 //

--- a/libcxx/include/__locale_dir/support/fuchsia.h
+++ b/libcxx/include/__locale_dir/support/fuchsia.h
@@ -70,7 +70,7 @@ inline _LIBCPP_HIDE_FROM_ABI __lconv_t* __localeconv(__locale_t& __loc) {
   return std::localeconv();
 }
 
-inline _LIBCPP_HIDE_FROM_ABI const char* __get_locale_encoding([[maybe_unused]] __locale_t __loc) {
+inline _LIBCPP_HIDE_FROM_ABI const char* __get_locale_encoding(__locale_t __loc) {
   return ::nl_langinfo_l(CODESET, __loc);
 }
 

--- a/libcxx/include/__locale_dir/support/llvm_libc.h
+++ b/libcxx/include/__locale_dir/support/llvm_libc.h
@@ -47,6 +47,8 @@ inline _LIBCPP_HIDE_FROM_ABI char* __setlocale(int __category, char const* __loc
 }
 
 inline _LIBCPP_HIDE_FROM_ABI __lconv_t* __localeconv(__locale_t&) { return std::localeconv(); }
+
+inline _LIBCPP_HIDE_FROM_ABI const char* __get_locale_encoding([[maybe_unused]] __locale_t) { return nullptr; }
 #endif // _LIBCPP_BUILDING_LIBRARY
 
 } // namespace __locale

--- a/libcxx/include/__locale_dir/support/llvm_libc.h
+++ b/libcxx/include/__locale_dir/support/llvm_libc.h
@@ -48,7 +48,7 @@ inline _LIBCPP_HIDE_FROM_ABI char* __setlocale(int __category, char const* __loc
 
 inline _LIBCPP_HIDE_FROM_ABI __lconv_t* __localeconv(__locale_t&) { return std::localeconv(); }
 
-inline _LIBCPP_HIDE_FROM_ABI const char* __get_locale_encoding([[maybe_unused]] __locale_t) { return nullptr; }
+inline _LIBCPP_HIDE_FROM_ABI const char* __get_locale_encoding(__locale_t) { return nullptr; }
 #endif // _LIBCPP_BUILDING_LIBRARY
 
 } // namespace __locale

--- a/libcxx/test/libcxx/text/text_encoding/environment.pass.cpp
+++ b/libcxx/test/libcxx/text/text_encoding/environment.pass.cpp
@@ -14,6 +14,7 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: windows, android
 // UNSUPPORTED: availability-te-environment-missing
+// UNSUPPORTED: LLVM-LIBC-FIXME
 
 // std::text_encoding::environment()
 

--- a/libcxx/test/std/text/text_encoding/text_encoding.members/environment.pass.cpp
+++ b/libcxx/test/std/text/text_encoding/text_encoding.members/environment.pass.cpp
@@ -11,6 +11,7 @@
 
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: availability-te-environment-missing
+// UNSUPPORTED: LLVM-LIBC-FIXME
 
 // <text_encoding>
 


### PR DESCRIPTION
- These were missed in #141312 and consequently broke the Fuschia and AMDGPU llvm-libc build bots.
- Fuschia seems to have support for `nl_langinfo_l(...)`, so we can use that.
- However, LLVM-libc does not implement it, so for now we can do a dummy implementation and mark `environment()` and `encoding()` as unsupported on LLVM libc.