### PR TITLE
[Flang][OpenMP] Added diagnostic for ORDERED THREADS SIMD inside plain SIMD region

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1486,6 +1486,13 @@ void OmpStructureChecker::ChecksOnOrderedAsBlock() {
       context_.Say(GetContext().directiveSource,
           "An ORDERED directive with SIMD clause must be closely nested in a "
           "SIMD or worksharing-loop SIMD region"_err_en_US);
+    } else if (CurrentDirectiveIsNested() &&
+        FindClause(llvm::omp::Clause::OMPC_simd) &&
+        FindClause(llvm::omp::Clause::OMPC_threads) && isNestedInSIMD &&
+        !isNestedInDoSIMD) {
+      context_.Say(GetContext().directiveSource,
+          "An ORDERED directive with SIMD and THREADS clauses must be closely "
+          "nested in a worksharing-loop SIMD region"_err_en_US);
     }
     if (isNestedInDo && (noOrderedClause || isOrderedClauseWithPara)) {
       context_.Say(GetContext().directiveSource,

--- a/flang/test/Semantics/OpenMP/ordered02.f90
+++ b/flang/test/Semantics/OpenMP/ordered02.f90
@@ -143,4 +143,23 @@ subroutine sub1()
     !$omp end ordered
   end do
   !$omp end target parallel do
+
+  ! THREADS+SIMD inside a plain SIMD (not DO SIMD) region must be rejected
+  !$omp simd
+  do i = 1, N
+    !ERROR: An ORDERED directive with SIMD and THREADS clauses must be closely nested in a worksharing-loop SIMD region
+    !$omp ordered threads simd
+    arrayA(i) = foo(i)
+    !$omp end ordered
+  end do
+  !$omp end simd
+
+  ! THREADS+SIMD inside a DO SIMD region is valid
+  !$omp do simd ordered
+  do i = 1, N
+    !$omp ordered threads simd
+    arrayA(i) = foo(i)
+    !$omp end ordered
+  end do
+  !$omp end do simd
 end

--- a/flang/test/Semantics/OpenMP/ordered02.f90
+++ b/flang/test/Semantics/OpenMP/ordered02.f90
@@ -163,3 +163,20 @@ subroutine sub1()
   end do
   !$omp end do simd
 end
+
+! No diagnostic when ORDERED THREADS SIMD is in a called routine (enclosing
+! DO SIMD region is not visible to the static checker).
+subroutine contains_ordered_threads_simd()
+  !$omp ordered threads simd
+  !$omp end ordered
+end subroutine
+
+subroutine sub2()
+  integer :: i, N = 10
+  external :: contains_ordered_threads_simd
+  !$omp do simd ordered
+  do i = 1, N
+    call contains_ordered_threads_simd()
+  end do
+  !$omp end do simd
+end subroutine


### PR DESCRIPTION
Fixes [#205516 ](https://github.com/llvm/llvm-project/issues/205516)

#### Problem
Per OpenMP 4.5 Sec 2.13.8 Restrictions:

> An ordered region arising from an ordered construct with both the simd and 
> threads clauses must be closely nested inside a loop SIMD region.

Flang was missing this check. `!$OMP ORDERED THREADS SIMD` inside a standalone `!$OMP SIMD` region was accepted without diagnostic. 
#### Fix
`check-omp-structure.cpp`: Added a new check in `ChecksOnOrderedAsBlock()`. If an ORDERED directive has both SIMD and THREADS clauses and is nested inside a standalone SIMD region (but not a DO SIMD region), emit the following error:

`An ORDERED directive with SIMD and THREADS clauses must be closely nested in a worksharing-loop SIMD region.`

`ordered02.f90`: Added two test cases:
Negative test: ORDERED THREADS SIMD inside !$OMP SIMD → expected error.
Positive test: ORDERED THREADS SIMD inside !$OMP DO SIMD ordered → no error, as allowed by OpenMP 2.13.8.
