### PR TITLE
clang/AMDGPU: Simplify cpu name checks for __builtin_amdgcn_is_processor

### DIFF
--- a/clang/lib/Sema/SemaAMDGPU.cpp
+++ b/clang/lib/Sema/SemaAMDGPU.cpp
@@ -800,20 +800,16 @@ Expr *SemaAMDGPU::ExpandAMDGPUPredicateBuiltIn(Expr *E) {
 
     StringRef N = GFX->getString();
     const TargetInfo &TI = Ctx.getTargetInfo();
-    const TargetInfo *AuxTI = Ctx.getAuxTargetInfo();
-    if (!TI.isValidCPUName(N) && (!AuxTI || !AuxTI->isValidCPUName(N))) {
+    if (llvm::AMDGPU::parseArchAMDGCN(N) == llvm::AMDGPU::GK_NONE) {
       Diag(Loc, diag::err_amdgcn_processor_is_arg_invalid_value) << N;
-      SmallVector<StringRef, 32> ValidList;
-      if (TI.getTriple().getVendor() == llvm::Triple::VendorType::AMD)
-        TI.fillValidCPUList(ValidList);
-      else if (AuxTI) // Since the BI is present it must be an AMDGPU triple.
-        AuxTI->fillValidCPUList(ValidList);
+      SmallVector<StringRef, 64> ValidList;
+      llvm::AMDGPU::fillValidArchListAMDGCN(ValidList);
       if (!ValidList.empty())
         Diag(Loc, diag::note_amdgcn_processor_is_valid_options)
             << llvm::join(ValidList, ", ");
       return nullptr;
     }
-    if (Ctx.getTargetInfo().getTriple().isSPIRV()) {
+    if (TI.getTriple().isSPIRV()) {
       CE->setType(BoolTy);
       return *ExpandedPredicates.insert(CE).first;
     }


### PR DESCRIPTION
Instead of trying to figure out which TargetInfo to use, skip it and
directly use the source of truth from TargetParser. This avoids regressions
in future commits where isValidCPUName will be conditionally filtered.