### PR TITLE
[flang][acc] Avoid assert for assumed-size arrays without a descriptor

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
@@ -345,7 +345,9 @@ generateSeqTyAccBounds(fir::SequenceType seqType, mlir::Value var,
           firBuilder, loc, exv, info);
     }
 
-    assert(false && "array with unknown dimension expected to have descriptor");
+    // An assumed-size array (or other non-descriptor array with an unknown
+    // trailing extent) has no recoverable bounds here and is passed without a
+    // descriptor; map it without bounds rather than asserting.
     return {};
   }
 

--- a/flang/test/Fir/OpenACC/openacc-mappable.fir
+++ b/flang/test/Fir/OpenACC/openacc-mappable.fir
@@ -141,4 +141,19 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<f16 = dense<16> : vector<2xi64>,
   // CHECK: fir.result %[[ZERO]], %[[MINUSONE]], %[[ZERO]], %[[ZERO]], %[[ZERO]] : index, index, index, index, index
   // CHECK: }
   // CHECK: Upper bound: %[[IF]]:5 = fir.if %[[PRESENT]] -> (index, index, index, index, index) {
+
+  // An assumed-size array (unknown trailing extent) passed without a
+  // descriptor, whose acc clause operand is not produced by an [hl]fir.declare
+  // (so no shape is recoverable). It must produce no bounds.
+  func.func @_QPassumed_size_no_descriptor(%arg0: !fir.ref<!fir.array<?x?xf32>> {fir.bindc_name = "a"}) {
+    %0 = fir.convert %arg0 : (!fir.ref<!fir.array<?x?xf32>>) -> !fir.ref<!fir.array<?x?xf32>>
+    %1 = acc.copyin varPtr(%0 : !fir.ref<!fir.array<?x?xf32>>) -> !fir.ref<!fir.array<?x?xf32>> {name = "a", structured = false}
+    acc.enter_data dataOperands(%1 : !fir.ref<!fir.array<?x?xf32>>)
+    return
+  }
+  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<?x?xf32>>) -> !fir.ref<!fir.array<?x?xf32>> {name = "a", structured = false}
+  // CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<?x?xf32>>
+  // CHECK: Type category: array
+  // CHECK: Has unknown dimensions: true
+  // CHECK-NOT: Bound[
 }


### PR DESCRIPTION
Example:
```fortran
subroutine sub(a, n)
  real(8) :: a(n, *)
  integer :: n, i
  !$acc data no_create(a)
  !$acc parallel loop
  do i = 1, n
    a(1, i) = 0.0d0
  end do
  !$acc end data
end subroutine
```
An assumed-size dummy array (e.g. `real(8) :: a(n,*)`) has an unknown
trailing extent and is passed without a descriptor. When the OpenACC
implicit-data pass builds a data clause for such an array,
`generateSeqTyAccBounds` enters the unknown-shape branch but finds no
descriptor (`fir.box`) to recover bounds from, and hits:

    assert(false && "array with unknown dimension expected to have descriptor");

The premise is wrong: an assumed-size array legitimately has no
descriptor and no recoverable bounds.

Fix: return empty bounds instead of asserting. The caller only assigns
bounds when non-empty, so the array is mapped without bounds — the only
correct option when the extent is unknown, and sufficient for
presence-only clauses (`no_create`/`present`).