### PR TITLE
[DebugInfo][CodeView] Emit path prefix substitution for COFF object file name.

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.h
+++ b/clang/include/clang/Basic/CodeGenOptions.h
@@ -700,6 +700,10 @@ public:
     }
     llvm_unreachable("Unknown BoolFromMem enum");
   }
+
+  /// Remap specified path prefix using provided DebugPrefixMap map.
+  /// Returns updated path or unchanged if no substituion was found.
+  std::string remapDebugPathPrefix(StringRef Path) const;
 };
 
 }  // end namespace clang

--- a/clang/include/clang/Basic/CodeGenOptions.h
+++ b/clang/include/clang/Basic/CodeGenOptions.h
@@ -702,7 +702,7 @@ public:
   }
 
   /// Remap specified path prefix using provided DebugPrefixMap map.
-  /// Returns updated path or unchanged if no substituion was found.
+  /// Returns updated path or unchanged if no substitution was found.
   std::string remapDebugPathPrefix(StringRef Path) const;
 };
 

--- a/clang/lib/Basic/CodeGenOptions.cpp
+++ b/clang/lib/Basic/CodeGenOptions.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Basic/CodeGenOptions.h"
+#include "llvm/Support/Path.h"
 
 namespace clang {
 
@@ -48,6 +49,15 @@ void CodeGenOptions::resetNonModularOptions(StringRef ModuleFormat) {
   }
 
   RelocationModel = llvm::Reloc::PIC_;
+}
+
+std::string CodeGenOptions::remapDebugPathPrefix(StringRef Path) const {
+  SmallString<0> P = Path;
+
+  for (auto &[From, To] : llvm::reverse(DebugPrefixMap))
+    if (llvm::sys::path::replace_path_prefix(P, From, To))
+      break;
+  return P.str().str();
 }
 
 }  // end namespace clang

--- a/clang/lib/Basic/CodeGenOptions.cpp
+++ b/clang/lib/Basic/CodeGenOptions.cpp
@@ -52,7 +52,7 @@ void CodeGenOptions::resetNonModularOptions(StringRef ModuleFormat) {
 }
 
 std::string CodeGenOptions::remapDebugPathPrefix(StringRef Path) const {
-  SmallString<0> P = Path;
+  SmallString<256> P = Path;
 
   for (auto &[From, To] : llvm::reverse(DebugPrefixMap))
     if (llvm::sys::path::replace_path_prefix(P, From, To))

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -481,7 +481,8 @@ static bool initTargetOptions(const CompilerInstance &CI,
   Options.XRayFunctionIndex = CodeGenOpts.XRayFunctionIndex;
   Options.LoopAlignment = CodeGenOpts.LoopAlignment;
   Options.DebugStrictDwarf = CodeGenOpts.DebugStrictDwarf;
-  Options.ObjectFilenameForDebug = CodeGenOpts.remapDebugPathPrefix(CodeGenOpts.ObjectFilenameForDebug);
+  Options.ObjectFilenameForDebug =
+      CodeGenOpts.remapDebugPathPrefix(CodeGenOpts.ObjectFilenameForDebug);
   Options.Hotpatch = CodeGenOpts.HotPatch;
   Options.JMCInstrument = CodeGenOpts.JMCInstrument;
   Options.XCOFFReadOnlyPointers = CodeGenOpts.XCOFFReadOnlyPointers;

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -481,7 +481,7 @@ static bool initTargetOptions(const CompilerInstance &CI,
   Options.XRayFunctionIndex = CodeGenOpts.XRayFunctionIndex;
   Options.LoopAlignment = CodeGenOpts.LoopAlignment;
   Options.DebugStrictDwarf = CodeGenOpts.DebugStrictDwarf;
-  Options.ObjectFilenameForDebug = CodeGenOpts.ObjectFilenameForDebug;
+  Options.ObjectFilenameForDebug = CodeGenOpts.remapDebugPathPrefix(CodeGenOpts.ObjectFilenameForDebug);
   Options.Hotpatch = CodeGenOpts.HotPatch;
   Options.JMCInstrument = CodeGenOpts.JMCInstrument;
   Options.XCOFFReadOnlyPointers = CodeGenOpts.XCOFFReadOnlyPointers;

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -671,11 +671,7 @@ llvm::DIFile *CGDebugInfo::createFile(
 }
 
 std::string CGDebugInfo::remapDIPath(StringRef Path) const {
-  SmallString<256> P = Path;
-  for (auto &[From, To] : llvm::reverse(CGM.getCodeGenOpts().DebugPrefixMap))
-    if (llvm::sys::path::replace_path_prefix(P, From, To))
-      break;
-  return P.str().str();
+  return CGM.getCodeGenOpts().remapDebugPathPrefix(Path);
 }
 
 unsigned CGDebugInfo::getLineNumber(SourceLocation Loc) {

--- a/clang/test/DebugInfo/Generic/codeview-buildinfo.c
+++ b/clang/test/DebugInfo/Generic/codeview-buildinfo.c
@@ -24,6 +24,14 @@
 // RUN: cd %t.relpath && %clang_cl --target=i686-windows-msvc /c /Z7 /Fo:hello.obj -- hello.cpp
 // RUN: llvm-pdbutil dump --types %t.relpath/hello.obj | FileCheck %s --check-prefix RELPATH
 
+// The S_OBJNAME path must be get remapped if a proper prefix map was specified via `/pathmap`.
+// RUN: rm -rf %t.pathmap && mkdir -p %t.pathmap
+// RUN: cp %s %t.pathmap/%{s:basename}
+// RUN: cd %t.pathmap && %clang_cl --target=i686-windows-msvc /c /Z7 \
+// RUN:   /pathmap:%t.pathmap=x:/path-to /experimental:deterministic \
+// RUN:   /Fo:%{s:basename}.obj -- %{s:basename}
+// RUN: llvm-pdbutil dump --all %{s:basename}.obj | FileCheck %s --check-prefix OBJNAME-PATHMAP
+
 int main(void) { return 42; }
 
 // CHECK:                       Types (.debug$T)
@@ -78,3 +86,5 @@ int main(void) { return 42; }
 // RELPATH-NEXT:           0x{{.*}}: `
 // RELPATH-NOT:   {{hello\.cpp}}
 // RELPATH-SAME:  `
+
+// OBJNAME-PATHMAP: {{^.+}} | S_OBJNAME [size = {{.+}}] sig=0, `x:/path-to{{[\\/]}}codeview-buildinfo.c.obj`

--- a/clang/test/DebugInfo/Generic/codeview-buildinfo.c
+++ b/clang/test/DebugInfo/Generic/codeview-buildinfo.c
@@ -24,13 +24,12 @@
 // RUN: cd %t.relpath && %clang_cl --target=i686-windows-msvc /c /Z7 /Fo:hello.obj -- hello.cpp
 // RUN: llvm-pdbutil dump --types %t.relpath/hello.obj | FileCheck %s --check-prefix RELPATH
 
-// The S_OBJNAME path must be get remapped if a proper prefix map was specified via `/pathmap`.
+// The S_OBJNAME path must be remapped if a proper prefix map was specified via `/pathmap`.
 // RUN: rm -rf %t.pathmap && mkdir -p %t.pathmap
 // RUN: cp %s %t.pathmap/%{s:basename}
 // RUN: cd %t.pathmap && %clang_cl --target=i686-windows-msvc /c /Z7 \
-// RUN:   /pathmap:%t.pathmap=x:/path-to /experimental:deterministic \
-// RUN:   /Fo:%{s:basename}.obj -- %{s:basename}
-// RUN: llvm-pdbutil dump --all %{s:basename}.obj | FileCheck %s --check-prefix OBJNAME-PATHMAP
+// RUN:   /pathmap:%t.pathmap=x:/path-to /Fo:%{s:basename}.obj -- %{s:basename}
+// RUN: llvm-pdbutil dump --symbols %{s:basename}.obj | FileCheck %s --check-prefix OBJNAME-PATHMAP
 
 int main(void) { return 42; }
 


### PR DESCRIPTION
The `S_OBJNAME` field value gets by bypassing `CGDebugInfo` and its path prefix does not get remapped if requested `fdebug-prefix-map=` option as the other pathes in the debug info. This patch fixes it and does remapping for the object file path either.