### PR TITLE
[mlir][acc] Drop redundant `acc.terminator` erase that broke atomic capture under `if`

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/Transforms/ACCSpecializePatterns.h
+++ b/mlir/include/mlir/Dialect/OpenACC/Transforms/ACCSpecializePatterns.h
@@ -97,8 +97,10 @@ public:
                                 PatternRewriter &rewriter) const override {
     assert(op.getRegion().hasOneBlock() && "expected one block");
     Block *block = &op.getRegion().front();
-    // Erase the terminator (acc.yield or acc.terminator) before unwrapping
-    rewriter.eraseOp(block->getTerminator());
+    // The terminator may already be erased by the acc.terminator erase pattern
+    // during host fallback; only remove it if still present.
+    if (block->mightHaveTerminator())
+      rewriter.eraseOp(block->getTerminator());
     rewriter.inlineBlockBefore(block, op);
     rewriter.eraseOp(op);
     return success();

--- a/mlir/include/mlir/Dialect/OpenACC/Transforms/ACCSpecializePatterns.h
+++ b/mlir/include/mlir/Dialect/OpenACC/Transforms/ACCSpecializePatterns.h
@@ -97,10 +97,8 @@ public:
                                 PatternRewriter &rewriter) const override {
     assert(op.getRegion().hasOneBlock() && "expected one block");
     Block *block = &op.getRegion().front();
-    // The terminator may already be erased by the acc.terminator erase pattern
-    // during host fallback; only remove it if still present.
-    if (block->mightHaveTerminator())
-      rewriter.eraseOp(block->getTerminator());
+    // Erase the terminator (acc.yield or acc.terminator) before unwrapping
+    rewriter.eraseOp(block->getTerminator());
     rewriter.inlineBlockBefore(block, op);
     rewriter.eraseOp(op);
     return success();

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForHost.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForHost.cpp
@@ -256,12 +256,28 @@ class ACCOrphanAtomicCaptureOpConversion
 
     assert(captureOp.getRegion().hasOneBlock() && "expected one block");
     Block *block = &captureOp.getRegion().front();
-    // The implicit acc.terminator may already be erased by the acc.terminator
-    // erase pattern during host fallback; only remove it if still present.
-    if (block->mightHaveTerminator())
-      rewriter.eraseOp(block->getTerminator());
+    // Remove the terminator before inlining
+    rewriter.eraseOp(block->getTerminator());
     rewriter.inlineBlockBefore(block, captureOp);
     rewriter.eraseOp(captureOp);
+    return success();
+  }
+};
+
+// Erase a stray acc.terminator only once it is no longer owned by a live ACC
+// region op; owning ops erase their own terminator when unwrapped.
+class ACCOrphanTerminatorEraseConversion
+    : public OpRewritePattern<acc::TerminatorOp> {
+  using OpRewritePattern<acc::TerminatorOp>::OpRewritePattern;
+
+public:
+  LogicalResult matchAndRewrite(acc::TerminatorOp op,
+                                PatternRewriter &rewriter) const override {
+    if (Operation *parent = op->getParentOp())
+      if (parent->getDialect() ==
+          op->getContext()->getLoadedDialect<acc::OpenACCDialect>())
+        return failure();
+    rewriter.eraseOp(op);
     return success();
   }
 };
@@ -463,8 +479,12 @@ void mlir::acc::populateACCHostFallbackPatterns(RewritePatternSet &patterns,
   // Runtime operations - erase them
   patterns.insert<
       ACCOpEraseConversion<acc::InitOp>, ACCOpEraseConversion<acc::ShutdownOp>,
-      ACCOpEraseConversion<acc::SetOp>, ACCOpEraseConversion<acc::WaitOp>,
-      ACCOpEraseConversion<acc::TerminatorOp>>(context);
+      ACCOpEraseConversion<acc::SetOp>, ACCOpEraseConversion<acc::WaitOp>>(
+      context);
+
+  // acc.terminator - erase only stray terminators no longer owned by an ACC
+  // region op; region-bearing ops erase their own terminator when unwrapped.
+  patterns.insert<ACCOrphanTerminatorEraseConversion>(context);
 
   // Compute constructs - unwrap their regions
   patterns.insert<ACCRegionUnwrapConversion<acc::ParallelOp>,

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForHost.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForHost.cpp
@@ -256,8 +256,10 @@ class ACCOrphanAtomicCaptureOpConversion
 
     assert(captureOp.getRegion().hasOneBlock() && "expected one block");
     Block *block = &captureOp.getRegion().front();
-    // Remove the terminator before inlining
-    rewriter.eraseOp(block->getTerminator());
+    // The implicit acc.terminator may already be erased by the acc.terminator
+    // erase pattern during host fallback; only remove it if still present.
+    if (block->mightHaveTerminator())
+      rewriter.eraseOp(block->getTerminator());
     rewriter.inlineBlockBefore(block, captureOp);
     rewriter.eraseOp(captureOp);
     return success();

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForHost.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCSpecializeForHost.cpp
@@ -264,24 +264,6 @@ class ACCOrphanAtomicCaptureOpConversion
   }
 };
 
-// Erase a stray acc.terminator only once it is no longer owned by a live ACC
-// region op; owning ops erase their own terminator when unwrapped.
-class ACCOrphanTerminatorEraseConversion
-    : public OpRewritePattern<acc::TerminatorOp> {
-  using OpRewritePattern<acc::TerminatorOp>::OpRewritePattern;
-
-public:
-  LogicalResult matchAndRewrite(acc::TerminatorOp op,
-                                PatternRewriter &rewriter) const override {
-    if (Operation *parent = op->getParentOp())
-      if (parent->getDialect() ==
-          op->getContext()->getLoadedDialect<acc::OpenACCDialect>())
-        return failure();
-    rewriter.eraseOp(op);
-    return success();
-  }
-};
-
 // Convert orphan acc.loop to scf.for or scf.execute_region.
 // Only matches if NOT inside an ACC compute construct.
 class ACCOrphanLoopOpConversion : public OpRewritePattern<acc::LoopOp> {
@@ -481,10 +463,6 @@ void mlir::acc::populateACCHostFallbackPatterns(RewritePatternSet &patterns,
       ACCOpEraseConversion<acc::InitOp>, ACCOpEraseConversion<acc::ShutdownOp>,
       ACCOpEraseConversion<acc::SetOp>, ACCOpEraseConversion<acc::WaitOp>>(
       context);
-
-  // acc.terminator - erase only stray terminators no longer owned by an ACC
-  // region op; region-bearing ops erase their own terminator when unwrapped.
-  patterns.insert<ACCOrphanTerminatorEraseConversion>(context);
 
   // Compute constructs - unwrap their regions
   patterns.insert<ACCRegionUnwrapConversion<acc::ParallelOp>,

--- a/mlir/test/Dialect/OpenACC/acc-if-clause-lowering.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-if-clause-lowering.mlir
@@ -374,3 +374,35 @@ func.func @test_acc_private(%arg0: memref<i32>, %cond: i1) {
   }
   return
 }
+
+// -----
+
+// Regression: acc.parallel with an if clause whose body holds an
+// acc.atomic.capture. Host fallback inlines the capture; lowering must not
+// assert when the capture region terminator is erased before the capture op.
+// CHECK-LABEL: func.func @test_parallel_if_atomic_capture
+func.func @test_parallel_if_atomic_capture(%x: memref<i32>, %v: memref<i32>, %cond: i1) {
+  %c1_i32 = arith.constant 1 : i32
+  // CHECK-NOT: acc.parallel if
+  // CHECK: scf.if %{{.*}} {
+  // CHECK:   acc.parallel {
+  // CHECK:     acc.atomic.capture {
+  // CHECK:   } else {
+  // CHECK-NOT: acc.atomic.capture
+  // CHECK:     memref.load
+  // CHECK:     arith.addi
+  // CHECK:     memref.store
+  // CHECK:   }
+  acc.parallel if(%cond) {
+    acc.atomic.capture {
+      acc.atomic.update %x : memref<i32> {
+      ^bb0(%arg: i32):
+        %r = arith.addi %arg, %c1_i32 : i32
+        acc.yield %r : i32
+      }
+      acc.atomic.read %v = %x : memref<i32>, memref<i32>, i32
+    }
+    acc.yield
+  }
+  return
+}

--- a/mlir/test/Dialect/OpenACC/acc-if-clause-lowering.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-if-clause-lowering.mlir
@@ -377,9 +377,9 @@ func.func @test_acc_private(%arg0: memref<i32>, %cond: i1) {
 
 // -----
 
-// Regression: acc.parallel with an if clause whose body holds an
-// acc.atomic.capture. Host fallback inlines the capture; lowering must not
-// assert when the capture region terminator is erased before the capture op.
+// Test that an acc.parallel with an if clause whose body holds an
+// acc.atomic.capture lowers cleanly: the device path keeps the capture and the
+// host fallback inlines it.
 // CHECK-LABEL: func.func @test_parallel_if_atomic_capture
 func.func @test_parallel_if_atomic_capture(%x: memref<i32>, %v: memref<i32>, %cond: i1) {
   %c1_i32 = arith.constant 1 : i32


### PR DESCRIPTION
Example:
```fortran
!$acc parallel if(cond)
!$acc atomic capture
  a = a + 1
  b = a
!$acc end atomic
!$acc end parallel
```

In this code, the `if` clause triggers host-fallback specialization. A blanket `acc.terminator` erase pattern strips the implicit terminator of the still-present `acc.atomic.capture`, so the later `getTerminator()` trips `mightHaveTerminator()`.

Fix: remove that pattern — every ACC region op already erases its own terminator when it unwraps/inlines, so it was redundant (and only raced ahead to break this case). Adds a lit test.