### PR TITLE
[TableGen] Skip non-TypedInit values in resolveInitTypes instead of leaving VTy null

### DIFF
--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -2750,9 +2750,10 @@ TGParser::resolveInitTypes(ArrayRef<const Init *> Inits, const Twine &ErrCtx) {
     if (isa<UnsetInit>(V))
       continue;
 
-    const RecTy *VTy = nullptr;
-    if (const auto *Vt = dyn_cast<TypedInit>(V))
-      VTy = Vt->getType();
+    const auto *Vt = dyn_cast<TypedInit>(V);
+    if (!Vt)
+      continue;
+    const RecTy *VTy = Vt->getType();
 
     if (!Type) {
       Type = VTy;


### PR DESCRIPTION
Avoids a potential null dereference by skipping values that cannot be cast to TypedInit rather than proceeding with a null VTy.