### PR TITLE
[InstCombine] do not assume the operand position of reverse shuffle

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -3392,7 +3392,7 @@ Instruction *InstCombinerImpl::visitBitCast(BitCastInst &CI) {
     // bitcast <N x i8> (shuf X, undef, <N, N-1,...0>) -> bswap (bitcast X)
     // bitcast <N x i1> (shuf X, undef, <N, N-1,...0>) -> bitreverse (bitcast X)
     if (DestTy->isIntegerTy() && ShufElts.getKnownMinValue() % 2 == 0 &&
-        Shuf->hasOneUse() && Shuf->isReverse() && match(ShufOp1, m_Undef())) {
+        Shuf->hasOneUse() && Shuf->isReverse() && match(ShufOp1, m_Poison())) {
       unsigned IntrinsicNum = 0;
       if (DL.isLegalInteger(DestTy->getScalarSizeInBits()) &&
           SrcTy->getScalarSizeInBits() == 8) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -3392,7 +3392,7 @@ Instruction *InstCombinerImpl::visitBitCast(BitCastInst &CI) {
     // bitcast <N x i8> (shuf X, undef, <N, N-1,...0>) -> bswap (bitcast X)
     // bitcast <N x i1> (shuf X, undef, <N, N-1,...0>) -> bitreverse (bitcast X)
     if (DestTy->isIntegerTy() && ShufElts.getKnownMinValue() % 2 == 0 &&
-        Shuf->hasOneUse() && Shuf->isReverse()) {
+        Shuf->hasOneUse() && Shuf->isReverse() && match(ShufOp1, m_Undef())) {
       unsigned IntrinsicNum = 0;
       if (DL.isLegalInteger(DestTy->getScalarSizeInBits()) &&
           SrcTy->getScalarSizeInBits() == 8) {
@@ -3402,7 +3402,6 @@ Instruction *InstCombinerImpl::visitBitCast(BitCastInst &CI) {
       }
       if (IntrinsicNum != 0) {
         assert(ShufOp0->getType() == SrcTy && "Unexpected shuffle mask");
-        assert(match(ShufOp1, m_Undef()) && "Unexpected shuffle op");
         Function *BswapOrBitreverse = Intrinsic::getOrInsertDeclaration(
             CI.getModule(), IntrinsicNum, DestTy);
         Value *ScalarX = Builder.CreateBitCast(ShufOp0, DestTy);

--- a/llvm/test/Transforms/InstCombine/bswap.ll
+++ b/llvm/test/Transforms/InstCombine/bswap.ll
@@ -685,6 +685,32 @@ define i32 @shuf_bitcast_twice_4bytes(i32 %x) {
   ret i32 %cast2
 }
 
+define i64 @shuf_reverse_of_op1_crash(i16 %call, ptr %coerce, <2 x i8> %vec) {
+; CHECK-LABEL: @shuf_reverse_of_op1_crash(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    store i16 [[CALL:%.*]], ptr [[COERCE:%.*]], align 2
+; CHECK-NEXT:    br label [[LBL_CONT1:%.*]]
+; CHECK:       lbl_cont1:
+; CHECK-NEXT:    store i16 poison, ptr null, align 2
+; CHECK-NEXT:    br label [[IF_THEN:%.*]]
+; CHECK:       if.then:
+; CHECK-NEXT:    br label [[LBL_CONT1]]
+;
+entry:
+  store i16 %call, ptr %coerce, align 2
+  %load = load <2 x i8>, ptr %coerce, align 2
+  store <2 x i8> %load, ptr null, align 2
+  br label %lbl_cont1
+
+lbl_cont1:                                        ; preds = %if.then, %entry
+  br label %if.then
+
+if.then:                                          ; preds = %lbl_cont1
+  %shuffle = shufflevector <2 x i8> %vec, <2 x i8> zeroinitializer, <2 x i32> <i32 3, i32 2>
+  store <2 x i8> %shuffle, ptr null, align 2
+  br label %lbl_cont1
+}
+
 ; Negative test - extra use
 declare void @use(<4 x i8>)
 


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/204522
`Shuf->isReverse` only guarantees that the shuffle mask is reverse for one of the operands, instead of the first one, and we cannot assume that the second shuffle operand is undef. Otherwise, the assertion can be triggered by the bitcasts on non-canonical shuffles, e.g., bitcast on `%shuffle` generated by `InstCombinerImpl::mergeStoreIntoSuccessor` in the testcase.

In this patch, we remove the assertion and do the fold only if the second shuffle operand is undef. In this case, for whichever shuffle operand the mask is reverse for, we are performing the correct refinement.