### PR TITLE
[AArch64] Fix reversed values in big-endian 128-bit atomics

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -332,6 +332,13 @@ bool AArch64ExpandPseudoImpl::expandCMP_SWAP_128(
   Register NewLoReg = MI.getOperand(6).getReg();
   Register NewHiReg = MI.getOperand(7).getReg();
 
+  auto &STI = MBB.getParent()->getSubtarget<AArch64Subtarget>();
+  bool LittleEndian = STI.isLittleEndian();
+  MachineOperand &Dest0 = LittleEndian ? DestLo : DestHi;
+  MachineOperand &Dest1 = LittleEndian ? DestHi : DestLo;
+  Register New0Reg = LittleEndian ? NewLoReg : NewHiReg;
+  Register New1Reg = LittleEndian ? NewHiReg : NewLoReg;
+
   unsigned LdxpOp, StxpOp;
 
   switch (MI.getOpcode()) {
@@ -372,8 +379,8 @@ bool AArch64ExpandPseudoImpl::expandCMP_SWAP_128(
   //     sbcs xDestHi, xDesiredHi
   //     b.ne .Ldone
   BuildMI(LoadCmpBB, MIMD, TII->get(LdxpOp))
-      .addReg(DestLo.getReg(), RegState::Define)
-      .addReg(DestHi.getReg(), RegState::Define)
+      .addReg(Dest0.getReg(), RegState::Define)
+      .addReg(Dest1.getReg(), RegState::Define)
       .addReg(AddrReg);
   BuildMI(LoadCmpBB, MIMD, TII->get(AArch64::SUBSXrs), AArch64::XZR)
       .addReg(DestLo.getReg(), getKillRegState(DestLo.isDead()))
@@ -401,8 +408,8 @@ bool AArch64ExpandPseudoImpl::expandCMP_SWAP_128(
   //     stlxp wStatus, xNewLo, xNewHi, [xAddr]
   //     cbnz wStatus, .Lloadcmp
   BuildMI(StoreBB, MIMD, TII->get(StxpOp), StatusReg)
-      .addReg(NewLoReg)
-      .addReg(NewHiReg)
+      .addReg(New0Reg)
+      .addReg(New1Reg)
       .addReg(AddrReg);
   BuildMI(StoreBB, MIMD, TII->get(AArch64::CBNZW))
       .addReg(StatusReg, getKillRegState(StatusDead))
@@ -415,8 +422,8 @@ bool AArch64ExpandPseudoImpl::expandCMP_SWAP_128(
   //     stlxp wStatus, xDestLo, xDestHi, [xAddr]
   //     cbnz wStatus, .Lloadcmp
   BuildMI(FailBB, MIMD, TII->get(StxpOp), StatusReg)
-      .addReg(DestLo.getReg())
-      .addReg(DestHi.getReg())
+      .addReg(Dest0.getReg())
+      .addReg(Dest1.getReg())
       .addReg(AddrReg);
   BuildMI(FailBB, MIMD, TII->get(AArch64::CBNZW))
       .addReg(StatusReg, getKillRegState(StatusDead))

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -31742,7 +31742,7 @@ Value *AArch64TargetLowering::emitLoadLinked(IRBuilderBase &Builder,
 
     unsigned LoPos = Subtarget->isLittleEndian() ? 0 : 1;
     Value *Lo = Builder.CreateExtractValue(LoHi, LoPos, "lo");
-    Value *Hi = Builder.CreateExtractValue(LoHi, 1-LoPos, "hi");
+    Value *Hi = Builder.CreateExtractValue(LoHi, 1 - LoPos, "hi");
 
     auto *Int128Ty = Type::getInt128Ty(Builder.getContext());
     Lo = Builder.CreateZExt(Lo, Int128Ty, "lo64");

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -31740,8 +31740,9 @@ Value *AArch64TargetLowering::emitLoadLinked(IRBuilderBase &Builder,
     Value *LoHi =
         Builder.CreateIntrinsic(Int, Addr, /*FMFSource=*/nullptr, "lohi");
 
-    Value *Lo = Builder.CreateExtractValue(LoHi, 0, "lo");
-    Value *Hi = Builder.CreateExtractValue(LoHi, 1, "hi");
+    unsigned LoPos = Subtarget->isLittleEndian() ? 0 : 1;
+    Value *Lo = Builder.CreateExtractValue(LoHi, LoPos, "lo");
+    Value *Hi = Builder.CreateExtractValue(LoHi, 1-LoPos, "hi");
 
     auto *Int128Ty = Type::getInt128Ty(Builder.getContext());
     Lo = Builder.CreateZExt(Lo, Int128Ty, "lo64");
@@ -31792,7 +31793,10 @@ Value *AArch64TargetLowering::emitStoreConditional(IRBuilderBase &Builder,
     Value *Lo = Builder.CreateTrunc(CastVal, Int64Ty, "lo");
     Value *Hi =
         Builder.CreateTrunc(Builder.CreateLShr(CastVal, 64), Int64Ty, "hi");
-    return Builder.CreateCall(Stxr, {Lo, Hi, Addr});
+    if (Subtarget->isLittleEndian())
+      return Builder.CreateCall(Stxr, {Lo, Hi, Addr});
+    else
+      return Builder.CreateCall(Stxr, {Hi, Lo, Addr});
   }
 
   Intrinsic::ID Int =

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-load-outline_atomics.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-load-outline_atomics.ll
@@ -232,8 +232,8 @@ define dso_local i128 @load_atomic_i128_aligned_unordered(ptr %ptr) {
 ; -O0:    bl __aarch64_cas16_relax
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_unordered:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr unordered, align 16
     ret i128 %r
 }
@@ -243,8 +243,8 @@ define dso_local i128 @load_atomic_i128_aligned_unordered_const(ptr readonly %pt
 ; -O0:    bl __aarch64_cas16_relax
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_unordered_const:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr unordered, align 16
     ret i128 %r
 }
@@ -254,8 +254,8 @@ define dso_local i128 @load_atomic_i128_aligned_monotonic(ptr %ptr) {
 ; -O0:    bl __aarch64_cas16_relax
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr monotonic, align 16
     ret i128 %r
 }
@@ -265,8 +265,8 @@ define dso_local i128 @load_atomic_i128_aligned_monotonic_const(ptr readonly %pt
 ; -O0:    bl __aarch64_cas16_relax
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_monotonic_const:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr monotonic, align 16
     ret i128 %r
 }
@@ -276,8 +276,8 @@ define dso_local i128 @load_atomic_i128_aligned_acquire(ptr %ptr) {
 ; -O0:    bl __aarch64_cas16_acq
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr acquire, align 16
     ret i128 %r
 }
@@ -287,8 +287,8 @@ define dso_local i128 @load_atomic_i128_aligned_acquire_const(ptr readonly %ptr)
 ; -O0:    bl __aarch64_cas16_acq
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_acquire_const:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr acquire, align 16
     ret i128 %r
 }
@@ -298,8 +298,8 @@ define dso_local i128 @load_atomic_i128_aligned_seq_cst(ptr %ptr) {
 ; -O0:    bl __aarch64_cas16_acq_rel
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stlxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stlxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }
@@ -309,8 +309,8 @@ define dso_local i128 @load_atomic_i128_aligned_seq_cst_const(ptr readonly %ptr)
 ; -O0:    bl __aarch64_cas16_acq_rel
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst_const:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stlxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stlxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-load-rcpc.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-load-rcpc.ll
@@ -229,120 +229,120 @@ define dso_local i64 @load_atomic_i64_aligned_seq_cst_const(ptr readonly %ptr) {
 
 define dso_local i128 @load_atomic_i128_aligned_unordered(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_unordered:
-; -O0:    ldxp x1, x0, [x9]
+; -O0:    ldxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_unordered:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr unordered, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_unordered_const(ptr readonly %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_unordered_const:
-; -O0:    ldxp x1, x0, [x9]
+; -O0:    ldxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_unordered_const:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr unordered, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_monotonic(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_monotonic:
-; -O0:    ldxp x1, x0, [x9]
+; -O0:    ldxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr monotonic, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_monotonic_const(ptr readonly %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_monotonic_const:
-; -O0:    ldxp x1, x0, [x9]
+; -O0:    ldxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_monotonic_const:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr monotonic, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_acquire(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_acquire:
-; -O0:    ldaxp x1, x0, [x9]
+; -O0:    ldaxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr acquire, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_acquire_const(ptr readonly %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_acquire_const:
-; -O0:    ldaxp x1, x0, [x9]
+; -O0:    ldaxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_acquire_const:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr acquire, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_seq_cst(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst:
-; -O0:    ldaxp x1, x0, [x9]
+; -O0:    ldaxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stlxp w8, x10, x10, [x9]
-; -O0:    stlxp w8, x1, x0, [x9]
+; -O0:    stlxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stlxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stlxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_seq_cst_const(ptr readonly %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst_const:
-; -O0:    ldaxp x1, x0, [x9]
+; -O0:    ldaxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stlxp w8, x10, x10, [x9]
-; -O0:    stlxp w8, x1, x0, [x9]
+; -O0:    stlxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst_const:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stlxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stlxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-load-v8a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-load-v8a.ll
@@ -229,120 +229,120 @@ define dso_local i64 @load_atomic_i64_aligned_seq_cst_const(ptr readonly %ptr) {
 
 define dso_local i128 @load_atomic_i128_aligned_unordered(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_unordered:
-; -O0:    ldxp x1, x0, [x9]
+; -O0:    ldxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_unordered:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr unordered, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_unordered_const(ptr readonly %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_unordered_const:
-; -O0:    ldxp x1, x0, [x9]
+; -O0:    ldxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_unordered_const:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr unordered, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_monotonic(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_monotonic:
-; -O0:    ldxp x1, x0, [x9]
+; -O0:    ldxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr monotonic, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_monotonic_const(ptr readonly %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_monotonic_const:
-; -O0:    ldxp x1, x0, [x9]
+; -O0:    ldxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_monotonic_const:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr monotonic, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_acquire(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_acquire:
-; -O0:    ldaxp x1, x0, [x9]
+; -O0:    ldaxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr acquire, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_acquire_const(ptr readonly %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_acquire_const:
-; -O0:    ldaxp x1, x0, [x9]
+; -O0:    ldaxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stxp w8, x10, x10, [x9]
-; -O0:    stxp w8, x1, x0, [x9]
+; -O0:    stxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_acquire_const:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr acquire, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_seq_cst(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst:
-; -O0:    ldaxp x1, x0, [x9]
+; -O0:    ldaxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stlxp w8, x10, x10, [x9]
-; -O0:    stlxp w8, x1, x0, [x9]
+; -O0:    stlxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stlxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stlxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }
 
 define dso_local i128 @load_atomic_i128_aligned_seq_cst_const(ptr readonly %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst_const:
-; -O0:    ldaxp x1, x0, [x9]
+; -O0:    ldaxp x0, x1, [x9]
 ; -O0:    cmp x1, x10
 ; -O0:    cmp x0, x10
 ; -O0:    stlxp w8, x10, x10, [x9]
-; -O0:    stlxp w8, x1, x0, [x9]
+; -O0:    stlxp w8, x0, x1, [x9]
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst_const:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    stlxp w9, x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    stlxp w9, x0, x1, [x8]
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-store-outline_atomics.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-store-outline_atomics.ll
@@ -123,7 +123,7 @@ define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_unordered:
 ; -O1:    ldxp xzr, x8, [x2]
-; -O1:    stxp w8, x1, x0, [x2]
+; -O1:    stxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr unordered, align 16
     ret void
 }
@@ -136,7 +136,7 @@ define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O1:    ldxp xzr, x8, [x2]
-; -O1:    stxp w8, x1, x0, [x2]
+; -O1:    stxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr monotonic, align 16
     ret void
 }
@@ -149,7 +149,7 @@ define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) 
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_release:
 ; -O1:    ldxp xzr, x8, [x2]
-; -O1:    stlxp w8, x1, x0, [x2]
+; -O1:    stlxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr release, align 16
     ret void
 }
@@ -162,7 +162,7 @@ define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) 
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O1:    ldaxp xzr, x8, [x2]
-; -O1:    stlxp w8, x1, x0, [x2]
+; -O1:    stlxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr seq_cst, align 16
     ret void
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-store-rcpc.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-store-rcpc.ll
@@ -117,68 +117,68 @@ define dso_local void @store_atomic_i64_aligned_seq_cst(i64 %value, ptr %ptr) {
 
 define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_unordered:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_unordered:
 ; -O1:    ldxp xzr, x8, [x2]
-; -O1:    stxp w8, x1, x0, [x2]
+; -O1:    stxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr unordered, align 16
     ret void
 }
 
 define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_monotonic:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O1:    ldxp xzr, x8, [x2]
-; -O1:    stxp w8, x1, x0, [x2]
+; -O1:    stxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr monotonic, align 16
     ret void
 }
 
 define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_release:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_release:
 ; -O1:    ldxp xzr, x8, [x2]
-; -O1:    stlxp w8, x1, x0, [x2]
+; -O1:    stlxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr release, align 16
     ret void
 }
 
 define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O1:    ldaxp xzr, x8, [x2]
-; -O1:    stlxp w8, x1, x0, [x2]
+; -O1:    stlxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr seq_cst, align 16
     ret void
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-store-v8a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-store-v8a.ll
@@ -117,68 +117,68 @@ define dso_local void @store_atomic_i64_aligned_seq_cst(i64 %value, ptr %ptr) {
 
 define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_unordered:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_unordered:
 ; -O1:    ldxp xzr, x8, [x2]
-; -O1:    stxp w8, x1, x0, [x2]
+; -O1:    stxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr unordered, align 16
     ret void
 }
 
 define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_monotonic:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O1:    ldxp xzr, x8, [x2]
-; -O1:    stxp w8, x1, x0, [x2]
+; -O1:    stxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr monotonic, align 16
     ret void
 }
 
 define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_release:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_release:
 ; -O1:    ldxp xzr, x8, [x2]
-; -O1:    stlxp w8, x1, x0, [x2]
+; -O1:    stlxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr release, align 16
     ret void
 }
 
 define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O1:    ldaxp xzr, x8, [x2]
-; -O1:    stlxp w8, x1, x0, [x2]
+; -O1:    stlxp w8, x0, x1, [x2]
     store atomic i128 %value, ptr %ptr seq_cst, align 16
     ret void
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lse2.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lse2.ll
@@ -285,85 +285,85 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O1:    ldxp x1, x8, [x0]
-; -O1:    stxp w9, x3, x2, [x0]
+; -O1:    ldxp x8, x1, [x0]
+; -O1:    stxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O1:    ldxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -901,18 +901,18 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
@@ -920,18 +920,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
@@ -939,18 +939,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
@@ -958,18 +958,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
@@ -977,18 +977,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -1641,18 +1641,18 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
@@ -1660,18 +1660,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
@@ -1679,18 +1679,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
@@ -1698,18 +1698,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
@@ -1717,18 +1717,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -2382,18 +2382,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -2403,18 +2403,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -2424,18 +2424,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -2445,18 +2445,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -2466,18 +2466,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -3184,18 +3184,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stxp w11, x9, x10, [x8]
@@ -3209,18 +3209,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stxp w11, x9, x10, [x8]
@@ -3234,18 +3234,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -3259,18 +3259,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -3284,18 +3284,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -4022,18 +4022,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 ; -O0-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -4043,18 +4043,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -4064,18 +4064,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -4085,18 +4085,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -4106,18 +4106,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -4782,18 +4782,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -4803,18 +4803,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -4824,18 +4824,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -4845,18 +4845,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -4866,18 +4866,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -5603,19 +5603,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -5626,19 +5626,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -5649,19 +5649,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -5672,19 +5672,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -5695,19 +5695,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -6503,19 +6503,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -6526,19 +6526,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -6549,19 +6549,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -6572,19 +6572,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -6595,19 +6595,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -7403,19 +7403,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -7426,19 +7426,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -7449,19 +7449,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -7472,19 +7472,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -7495,19 +7495,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -8303,19 +8303,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -8326,19 +8326,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -8349,19 +8349,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -8372,19 +8372,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -8395,19 +8395,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-outline_atomics.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-outline_atomics.ll
@@ -150,8 +150,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O1:    ldxp x1, x8, [x0]
-; -O1:    stxp w9, x3, x2, [x0]
+; -O1:    ldxp x8, x1, [x0]
+; -O1:    stxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
@@ -163,8 +163,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
@@ -176,8 +176,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O1:    ldxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
@@ -189,8 +189,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
@@ -202,8 +202,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -531,9 +531,9 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
@@ -546,9 +546,9 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
@@ -561,9 +561,9 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
@@ -576,9 +576,9 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
@@ -591,9 +591,9 @@ define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -1106,9 +1106,9 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
@@ -1121,9 +1121,9 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
@@ -1136,9 +1136,9 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
@@ -1151,9 +1151,9 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
@@ -1166,9 +1166,9 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -1722,9 +1722,9 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -1739,9 +1739,9 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -1756,9 +1756,9 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -1773,9 +1773,9 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -1790,9 +1790,9 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -2444,9 +2444,9 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stxp w11, x9, x10, [x8]
@@ -2465,9 +2465,9 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stxp w11, x9, x10, [x8]
@@ -2486,9 +2486,9 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -2507,9 +2507,9 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -2528,9 +2528,9 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -3072,9 +3072,9 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -3089,9 +3089,9 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -3106,9 +3106,9 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -3123,9 +3123,9 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -3140,9 +3140,9 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -3587,9 +3587,9 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -3604,9 +3604,9 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -3621,9 +3621,9 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -3638,9 +3638,9 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -3655,9 +3655,9 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -4303,10 +4303,10 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -4322,10 +4322,10 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -4341,10 +4341,10 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -4360,10 +4360,10 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -4379,10 +4379,10 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -5133,10 +5133,10 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -5152,10 +5152,10 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -5171,10 +5171,10 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -5190,10 +5190,10 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -5209,10 +5209,10 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -5963,10 +5963,10 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -5982,10 +5982,10 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -6001,10 +6001,10 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -6020,10 +6020,10 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -6039,10 +6039,10 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -6793,10 +6793,10 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -6812,10 +6812,10 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -6831,10 +6831,10 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -6850,10 +6850,10 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -6869,10 +6869,10 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-rcpc.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-rcpc.ll
@@ -285,85 +285,85 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O1:    ldxp x1, x8, [x0]
-; -O1:    stxp w9, x3, x2, [x0]
+; -O1:    ldxp x8, x1, [x0]
+; -O1:    stxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O1:    ldxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -901,18 +901,18 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
@@ -920,18 +920,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
@@ -939,18 +939,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
@@ -958,18 +958,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
@@ -977,18 +977,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -1641,18 +1641,18 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
@@ -1660,18 +1660,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
@@ -1679,18 +1679,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
@@ -1698,18 +1698,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
@@ -1717,18 +1717,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -2382,18 +2382,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -2403,18 +2403,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -2424,18 +2424,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -2445,18 +2445,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -2466,18 +2466,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -3184,18 +3184,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stxp w11, x9, x10, [x8]
@@ -3209,18 +3209,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stxp w11, x9, x10, [x8]
@@ -3234,18 +3234,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -3259,18 +3259,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -3284,18 +3284,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -4022,18 +4022,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 ; -O0-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -4043,18 +4043,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -4064,18 +4064,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -4085,18 +4085,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -4106,18 +4106,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -4782,18 +4782,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -4803,18 +4803,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -4824,18 +4824,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -4845,18 +4845,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -4866,18 +4866,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -5603,19 +5603,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -5626,19 +5626,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -5649,19 +5649,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -5672,19 +5672,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -5695,19 +5695,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -6503,19 +6503,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -6526,19 +6526,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -6549,19 +6549,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -6572,19 +6572,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -6595,19 +6595,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -7403,19 +7403,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -7426,19 +7426,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -7449,19 +7449,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -7472,19 +7472,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -7495,19 +7495,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -8303,19 +8303,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -8326,19 +8326,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -8349,19 +8349,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -8372,19 +8372,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -8395,19 +8395,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-rcpc3.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-rcpc3.ll
@@ -285,85 +285,85 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O1:    ldxp x1, x8, [x0]
-; -O1:    stxp w9, x3, x2, [x0]
+; -O1:    ldxp x8, x1, [x0]
+; -O1:    stxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O1:    ldxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -901,18 +901,18 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
@@ -920,18 +920,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
@@ -939,18 +939,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
@@ -958,18 +958,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
@@ -977,18 +977,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -1641,18 +1641,18 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
@@ -1660,18 +1660,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
@@ -1679,18 +1679,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
@@ -1698,18 +1698,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
@@ -1717,18 +1717,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -2382,18 +2382,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -2403,18 +2403,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -2424,18 +2424,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -2445,18 +2445,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -2466,18 +2466,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -3184,18 +3184,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stxp w11, x9, x10, [x8]
@@ -3209,18 +3209,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stxp w11, x9, x10, [x8]
@@ -3234,18 +3234,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -3259,18 +3259,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -3284,18 +3284,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -4022,18 +4022,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 ; -O0-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -4043,18 +4043,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -4064,18 +4064,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -4085,18 +4085,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -4106,18 +4106,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -4782,18 +4782,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -4803,18 +4803,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -4824,18 +4824,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -4845,18 +4845,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -4866,18 +4866,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -5603,19 +5603,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -5626,19 +5626,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -5649,19 +5649,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -5672,19 +5672,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -5695,19 +5695,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -6503,19 +6503,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -6526,19 +6526,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -6549,19 +6549,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -6572,19 +6572,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -6595,19 +6595,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -7403,19 +7403,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -7426,19 +7426,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -7449,19 +7449,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -7472,19 +7472,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -7495,19 +7495,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -8303,19 +8303,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -8326,19 +8326,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -8349,19 +8349,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -8372,19 +8372,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -8395,19 +8395,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-v8a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-v8a.ll
@@ -285,85 +285,85 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O1:    ldxp x1, x8, [x0]
-; -O1:    stxp w9, x3, x2, [x0]
+; -O1:    ldxp x8, x1, [x0]
+; -O1:    stxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O1:    ldxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x8, [x0]
-; -O1:    stlxp w9, x3, x2, [x0]
+; -O1:    ldaxp x8, x1, [x0]
+; -O1:    stlxp w9, x2, x3, [x0]
     %r = atomicrmw xchg ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -901,18 +901,18 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
@@ -920,18 +920,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
@@ -939,18 +939,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
@@ -958,18 +958,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
@@ -977,18 +977,18 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O0:    adds x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    adds x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw add ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -1641,18 +1641,18 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
 }
@@ -1660,18 +1660,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stxp w11, x9, x10, [x8]
+; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
 }
@@ -1679,18 +1679,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value release, align 16
     ret i128 %r
 }
@@ -1698,18 +1698,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
 }
@@ -1717,18 +1717,18 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O0:    subs x14, x11, x10
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    subs x9, x1, x3
-; -O1:    stlxp w11, x9, x10, [x8]
+; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw sub ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
 }
@@ -2382,18 +2382,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -2403,18 +2403,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -2424,18 +2424,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -2445,18 +2445,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -2466,18 +2466,18 @@ define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O0:    and x15, x13, x10
 ; -O0:    and x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x0, x2
-; -O1:    and x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x1, x3
+; -O1:    and x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw and ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -3184,18 +3184,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stxp w11, x9, x10, [x8]
@@ -3209,18 +3209,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stxp w11, x9, x10, [x8]
@@ -3234,18 +3234,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -3259,18 +3259,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -3284,18 +3284,18 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    and x10, x13, x10
 ; -O0:    mvn x15, x10
 ; -O0:    mvn x14, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    and x9, x1, x3
-; -O1:    and x10, x0, x2
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    and x9, x0, x2
+; -O1:    and x10, x1, x3
 ; -O1:    mvn x10, x10
 ; -O1:    mvn x9, x9
 ; -O1:    stlxp w11, x9, x10, [x8]
@@ -4022,18 +4022,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 ; -O0-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -4043,18 +4043,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -4064,18 +4064,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -4085,18 +4085,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -4106,18 +4106,18 @@ define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) 
 ; -O0-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O0:    orr x15, x13, x10
 ; -O0:    orr x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    orr x9, x0, x2
-; -O1:    orr x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    orr x9, x1, x3
+; -O1:    orr x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw or ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -4782,18 +4782,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -4803,18 +4803,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -4824,18 +4824,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -4845,18 +4845,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -4866,18 +4866,18 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O0:    eor x15, x13, x10
 ; -O0:    eor x14, x11, x8
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
-; -O1:    eor x9, x0, x2
-; -O1:    eor x10, x1, x3
+; -O1:    ldaxp x0, x1, [x8]
+; -O1:    eor x9, x1, x3
+; -O1:    eor x10, x0, x2
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw xor ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -5603,19 +5603,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -5626,19 +5626,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -5649,19 +5649,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -5672,19 +5672,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -5695,19 +5695,19 @@ define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lt
 ; -O0:    csel x14, x11, x8, lt
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lt
-; -O1:    csel x10, x1, x3, lt
+; -O1:    csel x9, x1, x3, lt
+; -O1:    csel x10, x0, x2, lt
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw max ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -6503,19 +6503,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -6526,19 +6526,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -6549,19 +6549,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -6572,19 +6572,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -6595,19 +6595,19 @@ define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value)
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, ge
 ; -O0:    csel x14, x11, x8, ge
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, ge
-; -O1:    csel x10, x1, x3, ge
+; -O1:    csel x9, x1, x3, ge
+; -O1:    csel x10, x0, x2, ge
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw min ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -7403,19 +7403,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -7426,19 +7426,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -7449,19 +7449,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -7472,19 +7472,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -7495,19 +7495,19 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, lo
 ; -O0:    csel x14, x11, x8, lo
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, lo
-; -O1:    csel x10, x1, x3, lo
+; -O1:    csel x9, x1, x3, lo
+; -O1:    csel x10, x0, x2, lo
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umax ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r
@@ -8303,19 +8303,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value monotonic, align 16
     ret i128 %r
@@ -8326,19 +8326,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stxp w8, x14, x15, [x9]
-; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    stxp w8, x15, x14, [x9]
+; -O0:    stxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value acquire, align 16
     ret i128 %r
@@ -8349,19 +8349,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldxp x10, x12, [x9]
+; -O0:    ldxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O1:    ldxp x1, x0, [x8]
+; -O1:    ldxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value release, align 16
     ret i128 %r
@@ -8372,19 +8372,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value acq_rel, align 16
     ret i128 %r
@@ -8395,19 +8395,19 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value
 ; -O0:    subs x12, x8, x11
 ; -O0:    csel x15, x13, x10, hs
 ; -O0:    csel x14, x11, x8, hs
-; -O0:    ldaxp x10, x12, [x9]
+; -O0:    ldaxp x12, x10, [x9]
 ; -O0:    cmp x10, x11
 ; -O0:    cmp x12, x13
-; -O0:    stlxp w8, x14, x15, [x9]
-; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    stlxp w8, x15, x14, [x9]
+; -O0:    stlxp w8, x12, x10, [x9]
 ; -O0:    subs x12, x12, x13
 ; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O1:    ldaxp x1, x0, [x8]
+; -O1:    ldaxp x0, x1, [x8]
 ; -O1:    cmp x3, x1
-; -O1:    csel x9, x0, x2, hs
-; -O1:    csel x10, x1, x3, hs
+; -O1:    csel x9, x1, x3, hs
+; -O1:    csel x10, x0, x2, hs
 ; -O1:    stlxp w11, x10, x9, [x8]
     %r = atomicrmw umin ptr %ptr, i128 %value seq_cst, align 16
     ret i128 %r

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-cmpxchg-lse2.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-cmpxchg-lse2.ll
@@ -1835,18 +1835,18 @@ define dso_local i64 @cmpxchg_i64_aligned_seq_cst_seq_cst_weak(i64 %expected, i6
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_monotonic:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_monotonic:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1854,18 +1854,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic(i128 %expected, 
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_monotonic_weak:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_monotonic_weak:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1873,18 +1873,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic_weak(i128 %expec
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1892,18 +1892,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1911,18 +1911,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1930,18 +1930,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1949,18 +1949,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1968,18 +1968,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1987,18 +1987,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2006,18 +2006,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2025,18 +2025,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2044,18 +2044,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2063,18 +2063,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_release_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_monotonic:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_monotonic:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2082,18 +2082,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_release_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_monotonic_weak:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_monotonic_weak:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2101,18 +2101,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_release_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2120,18 +2120,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_release_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2139,18 +2139,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2158,18 +2158,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2177,18 +2177,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2196,18 +2196,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2215,18 +2215,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2234,18 +2234,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2253,18 +2253,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2272,18 +2272,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2291,18 +2291,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2310,18 +2310,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2329,18 +2329,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2348,18 +2348,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2367,18 +2367,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2386,18 +2386,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-cmpxchg-rcpc.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-cmpxchg-rcpc.ll
@@ -1835,18 +1835,18 @@ define dso_local i64 @cmpxchg_i64_aligned_seq_cst_seq_cst_weak(i64 %expected, i6
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_monotonic:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_monotonic:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1854,18 +1854,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic(i128 %expected, 
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_monotonic_weak:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_monotonic_weak:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1873,18 +1873,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic_weak(i128 %expec
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1892,18 +1892,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1911,18 +1911,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1930,18 +1930,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1949,18 +1949,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1968,18 +1968,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1987,18 +1987,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2006,18 +2006,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2025,18 +2025,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2044,18 +2044,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2063,18 +2063,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_release_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_monotonic:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_monotonic:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2082,18 +2082,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_release_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_monotonic_weak:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_monotonic_weak:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2101,18 +2101,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_release_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2120,18 +2120,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_release_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2139,18 +2139,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2158,18 +2158,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2177,18 +2177,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2196,18 +2196,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2215,18 +2215,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2234,18 +2234,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2253,18 +2253,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2272,18 +2272,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2291,18 +2291,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2310,18 +2310,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2329,18 +2329,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2348,18 +2348,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2367,18 +2367,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2386,18 +2386,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-cmpxchg-rcpc3.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-cmpxchg-rcpc3.ll
@@ -1835,18 +1835,18 @@ define dso_local i64 @cmpxchg_i64_aligned_seq_cst_seq_cst_weak(i64 %expected, i6
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_monotonic:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_monotonic:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1854,18 +1854,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic(i128 %expected, 
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_monotonic_weak:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_monotonic_weak:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1873,18 +1873,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic_weak(i128 %expec
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1892,18 +1892,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1911,18 +1911,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1930,18 +1930,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1949,18 +1949,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1968,18 +1968,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1987,18 +1987,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2006,18 +2006,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2025,18 +2025,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2044,18 +2044,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2063,18 +2063,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_release_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_monotonic:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_monotonic:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2082,18 +2082,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_release_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_monotonic_weak:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_monotonic_weak:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2101,18 +2101,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_release_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2120,18 +2120,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_release_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2139,18 +2139,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2158,18 +2158,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2177,18 +2177,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2196,18 +2196,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2215,18 +2215,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2234,18 +2234,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2253,18 +2253,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2272,18 +2272,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2291,18 +2291,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2310,18 +2310,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2329,18 +2329,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2348,18 +2348,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2367,18 +2367,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2386,18 +2386,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-cmpxchg-v8a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-cmpxchg-v8a.ll
@@ -1835,18 +1835,18 @@ define dso_local i64 @cmpxchg_i64_aligned_seq_cst_seq_cst_weak(i64 %expected, i6
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_monotonic:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_monotonic:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1854,18 +1854,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic(i128 %expected, 
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_monotonic_weak:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_monotonic_weak:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1873,18 +1873,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_monotonic_weak(i128 %expec
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1892,18 +1892,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1911,18 +1911,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_acquire_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new monotonic seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1930,18 +1930,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_monotonic_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new monotonic seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1949,18 +1949,18 @@ define dso_local i128 @cmpxchg_i128_aligned_monotonic_seq_cst_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1968,18 +1968,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -1987,18 +1987,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2006,18 +2006,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stxp w8, x3, x2, [x4]
-; -O0:    stxp w8, x1, x0, [x4]
+; -O0:    stxp w8, x2, x3, [x4]
+; -O0:    stxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stxp w10, x8, x9, [x4]
-; -O1:    stxp w10, x3, x2, [x4]
+; -O1:    stxp w10, x9, x8, [x4]
+; -O1:    stxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2025,18 +2025,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acquire seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2044,18 +2044,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acquire_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acquire_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acquire seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2063,18 +2063,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acquire_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_release_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_monotonic:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_monotonic:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2082,18 +2082,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_release_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_monotonic_weak:
-; -O0:    ldxp x1, x0, [x4]
+; -O0:    ldxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_monotonic_weak:
-; -O1:    ldxp x8, x9, [x4]
+; -O1:    ldxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2101,18 +2101,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_release_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2120,18 +2120,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_release_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2139,18 +2139,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new release seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2158,18 +2158,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_release_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_release_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new release seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2177,18 +2177,18 @@ define dso_local i128 @cmpxchg_i128_aligned_release_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2196,18 +2196,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2215,18 +2215,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2234,18 +2234,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2253,18 +2253,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new acq_rel seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2272,18 +2272,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_acq_rel_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new acq_rel seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2291,18 +2291,18 @@ define dso_local i128 @cmpxchg_i128_aligned_acq_rel_seq_cst_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2310,18 +2310,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic(i128 %expected, i1
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_monotonic_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst monotonic, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2329,18 +2329,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_monotonic_weak(i128 %expecte
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_acquire:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_acquire:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2348,18 +2348,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_acquire_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_acquire_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst acquire, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2367,18 +2367,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_acquire_weak(i128 %expected,
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg ptr %ptr, i128 %expected, i128 %new seq_cst seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r
@@ -2386,18 +2386,18 @@ define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst(i128 %expected, i128
 
 define dso_local i128 @cmpxchg_i128_aligned_seq_cst_seq_cst_weak(i128 %expected, i128 %new, ptr %ptr) {
 ; -O0-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst_weak:
-; -O0:    ldaxp x1, x0, [x4]
+; -O0:    ldaxp x0, x1, [x4]
 ; -O0:    cmp x1, x9
 ; -O0:    cmp x0, x10
-; -O0:    stlxp w8, x3, x2, [x4]
-; -O0:    stlxp w8, x1, x0, [x4]
+; -O0:    stlxp w8, x2, x3, [x4]
+; -O0:    stlxp w8, x0, x1, [x4]
 ;
 ; -O1-LABEL: cmpxchg_i128_aligned_seq_cst_seq_cst_weak:
-; -O1:    ldaxp x8, x9, [x4]
+; -O1:    ldaxp x9, x8, [x4]
 ; -O1:    cmp x8, x1
 ; -O1:    cmp x9, x0
-; -O1:    stlxp w10, x8, x9, [x4]
-; -O1:    stlxp w10, x3, x2, [x4]
+; -O1:    stlxp w10, x9, x8, [x4]
+; -O1:    stlxp w10, x2, x3, [x4]
     %pair = cmpxchg weak ptr %ptr, i128 %expected, i128 %new seq_cst seq_cst, align 16
     %r = extractvalue { i128, i1 } %pair, 0
     ret i128 %r

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_i128_endianness.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_i128_endianness.ll
@@ -1,0 +1,46 @@
+; RUN: llc %s -o - -verify-machineinstrs -mtriple=aarch64    -mattr=+v8a -O1 | FileCheck %s
+; RUN: llc %s -o - -verify-machineinstrs -mtriple=aarch64_be -mattr=+v8a -O1 | FileCheck %s
+
+; Each function in this test performs an i128 atomic memory operation
+; and also an ordinary load or store. The checks ensure that the two
+; registers used in the ldxp/stxp instructions that implement the
+; atomic operation appear in the same order as in the ldp/stp of the
+; ordinary store. This invariant should be true in both endiannesses
+; of AArch64.
+
+define void @load_atomic(ptr %normal, ptr %atomic) {
+  %value = load atomic i128, ptr %atomic monotonic, align 16
+  store i128 %value, ptr %normal, align 16
+  ret void
+; CHECK-LABEL: load_atomic:
+; CHECK: ldxp [[FIRST:x[0-9]+]], [[SECOND:x[0-9]+]], [x1]
+; CHECK: stxp {{w[0-9]+}}, [[FIRST]], [[SECOND]], [x1]
+; CHECK: stp [[FIRST]], [[SECOND]], [x0]
+}
+
+define void @store_atomic(ptr %normal, ptr %atomic) {
+  %value = load i128, ptr %normal, align 16
+  store atomic i128 %value, ptr %atomic monotonic, align 16
+  ret void
+; CHECK-LABEL: store_atomic:
+; CHECK: ldp [[FIRST:x[0-9]+]], [[SECOND:x[0-9]+]], [x0]
+; CHECK: stxp {{w[0-9]+}}, [[FIRST]], [[SECOND]], [x1]
+}
+
+define void @compare_exchange(ptr %origptr, ptr %expectedptr, ptr %newptr, ptr %atomic) {
+  %new = load i128, ptr %newptr, align 16
+  %expected = load i128, ptr %expectedptr, align 16
+  %pair = cmpxchg ptr %atomic, i128 %expected, i128 %new monotonic monotonic, align 16
+  %orig = extractvalue { i128, i1 } %pair, 0
+  store i128 %orig, ptr %origptr, align 16
+  ret void
+; CHECK-LABEL: compare_exchange:
+; CHECK-DAG: ldp [[NEWFIRST:x[0-9]+]], [[NEWSECOND:x[0-9]+]], [x2]
+; CHECK-DAG: ldp [[EXPFIRST:x[0-9]+]], [[EXPSECOND:x[0-9]+]], [x1]
+; CHECK: ldxp [[ATOMICFIRST:x[0-9]+]], [[ATOMICSECOND:x[0-9]+]], [x3]
+; CHECK-DAG: cmp [[ATOMICFIRST]], [[EXPFIRST]]
+; CHECK-DAG: cmp [[ATOMICSECOND]], [[EXPSECOND]]
+; CHECK: stxp {{w[0-9]+}}, [[ATOMICFIRST]], [[ATOMICSECOND]], [x3]
+; CHECK: stxp {{w[0-9]+}}, [[NEWFIRST]], [[NEWSECOND]], [x3]
+; CHECK: stp [[ATOMICFIRST]], [[ATOMICSECOND]], [x0]
+}


### PR DESCRIPTION
When AArch64TargetLowering expands a load-linked or a store-conditional during the atomic-expand pass, it made the fixed assumption that the 64-bit value stored first in memory was the low-order half of the 128-bit value, instead of checking the SubtargetInfo's endianness. The same was true of the code that expands CMP_SWAP_128 pseudoinstructions. So in each case, if you compiled 128-bit atomic code big-endian, you'd get back a 128-bit integer with the top and bottom half swapped.

This was found by compiler-rt's existing tests when we ran them for a big-endian AArch64 target in Arm Toolchain.

Most of the test changes here are `update_llc_test_checks` churn: there were already many tests of AArch64 atomics in big-endian mode, and apparently they all simply had the reversed registers in their expected output.

The one new test, `aarch64_i128_endianness.ll`, directly demonstrates the failure if run against llc without the patch, because it does both atomic and normal loads and stores in each test function, and you can see in the big-endian generated code that the same pair of registers is used in opposite orders by the ldxp/stxp and ldp/stp instructions. After this fix, the order of the registers matches.