### PR TITLE
[CMake] Suppress more MSVC warnings

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -786,6 +786,8 @@ if (MSVC)
       # We only putting dll export on classes with out of line members so this 
       # warning gets triggered a lot for bases we haven't exported'
       -wd4275 # non dll-interface class used as base for dll-interface class
+      -wd4661 # no suitable definition provided for explicit template instantiation request
+      -wd4910 # '__declspec(dllexport)' and 'extern' are incompatible on an explicit instantiation
 
       # Promoted warnings.
       -w14062 # Promote 'enumerator in switch of enum is not handled' to level 1 warning.


### PR DESCRIPTION
Disable the following warnings:
* C4661: no suitable definition provided for explicit template instantiation request. This is firing because some explicit template instantiations cause MSVC to instantiate every member, which may only be declared, but not defined, in a given TU, particularly with CRTP.
* C4910: '__declspec(dllexport)' and 'extern' are incompatible on an explicit instantiation. This is the intended way of exporting some symbols. The linker resolves these correctly.