### PR TITLE
[lldb] Always lock in StreamLogHandler::Write

### DIFF
--- a/lldb/source/Utility/Log.cpp
+++ b/lldb/source/Utility/Log.cpp
@@ -378,12 +378,8 @@ void StreamLogHandler::Flush() {
 }
 
 void StreamLogHandler::Emit(llvm::StringRef message) {
-  if (m_stream.GetBufferSize() > 0) {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    m_stream << message;
-  } else {
-    m_stream << message;
-  }
+  std::lock_guard<std::mutex> guard(m_mutex);
+  m_stream << message;
 }
 
 CallbackLogHandler::CallbackLogHandler(lldb::LogOutputCallback callback,


### PR DESCRIPTION
This code assumes that writing to an unbuffered raw_fd_ostream from multiple threads is somehow safe. raw_fd_ostream doesn't make any guarantees about this from what I can see.

The current raw_fd_ostream implementation also uses a looping write call to write the content in chunks, and doing this from multiple threads leads to interleaving log messages.

This patch unconditionally make us aquire the stream lock.