### PR TITLE
[lldb][gdb-remote] Send QSetSTDIOWindowSize for a 0x0 size

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -2039,6 +2039,7 @@ int GDBRemoteCommunicationClient::SetSTDERR(const FileSpec &file_spec) {
 
 int GDBRemoteCommunicationClient::SetSTDIOWindowSize(uint16_t cols,
                                                      uint16_t rows) {
+  // The size is only valid if both or none of the dimensions are zero.
   if ((cols == 0) != (rows == 0))
     return -1;
   StreamString packet;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -2039,7 +2039,7 @@ int GDBRemoteCommunicationClient::SetSTDERR(const FileSpec &file_spec) {
 
 int GDBRemoteCommunicationClient::SetSTDIOWindowSize(uint16_t cols,
                                                      uint16_t rows) {
-  if (cols == 0 || rows == 0)
+  if ((cols == 0) != (rows == 0))
     return -1;
   StreamString packet;
   packet.Printf("QSetSTDIOWindowSize:cols=%u;rows=%u",


### PR DESCRIPTION
The client uses a 0x0 STDIO window size as a deliberate signal to the server that there is no client terminal, so the server should redirect the inferior's stdio over anonymous pipes instead of a ConPTY (on Windows).

This is a follow up to https://github.com/llvm/llvm-project/pull/203562.

rdar://178725958