### PR TITLE
[OpenMP] target-fast implies teams/threads oversubscription

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6983,11 +6983,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // thread and team counts in the device.
       if (Args.hasFlag(options::OPT_fopenmp_assume_teams_oversubscription,
                        options::OPT_fno_openmp_assume_teams_oversubscription,
-                       /*Default=*/false))
+                       /*Default=*/TargetFastUsed))
         CmdArgs.push_back("-fopenmp-assume-teams-oversubscription");
       if (Args.hasFlag(options::OPT_fopenmp_assume_threads_oversubscription,
                        options::OPT_fno_openmp_assume_threads_oversubscription,
-                       /*Default=*/false))
+                       /*Default=*/TargetFastUsed))
         CmdArgs.push_back("-fopenmp-assume-threads-oversubscription");
 
       // Handle -fopenmp-assume-no-thread-state (implied by target-fast)

--- a/clang/test/Driver/openmp-target-fast-flag.c
+++ b/clang/test/Driver/openmp-target-fast-flag.c
@@ -1,25 +1,25 @@
 // REQUIRES: x86-registered-target, amdgpu-registered-target
 
 // RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib %s -O0 2>&1 \
-// RUN:   | FileCheck -check-prefixes=DefaultTFast,DefaultTState,DefaultNoNestParallel %s
+// RUN:   | FileCheck -check-prefixes=DefaultTFast,DefaultTState,DefaultNoNestParallel,DefaultTeamsOver,DefaultThreadsOver %s
 
 // RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O0 -fopenmp-target-fast %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=TState,NestParallel %s
+// RUN:   | FileCheck -check-prefixes=TState,NestParallel,TeamsOver,ThreadsOver %s
 
 // RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O3 %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=O3,DefaultTFast,DefaultTState,DefaultNoNestParallel %s
+// RUN:   | FileCheck -check-prefixes=O3,DefaultTFast,DefaultTState,DefaultNoNestParallel,DefaultTeamsOver,DefaultThreadsOver %s
 
 // RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O3 -fno-openmp-target-fast %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=O3,DefaultTState,DefaultNoNestParallel %s
+// RUN:   | FileCheck -check-prefixes=O3,DefaultTState,DefaultNoNestParallel,DefaultTeamsOver,DefaultThreadsOver %s
 
 // RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -Ofast %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=OFast,TState,NestParallel %s
+// RUN:   | FileCheck -check-prefixes=OFast,TState,NestParallel,TeamsOver,ThreadsOver %s
 
 // RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -Ofast -fno-openmp-target-fast %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=OFast,DefaultTState,DefaultNoNestParallel %s
+// RUN:   | FileCheck -check-prefixes=OFast,DefaultTState,DefaultNoNestParallel,DefaultTeamsOver,DefaultThreadsOver %s
 
 // RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O0 -fno-openmp-target-fast -fopenmp-target-fast %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=TState,NestParallel %s
+// RUN:   | FileCheck -check-prefixes=TState,NestParallel,TeamsOver,ThreadsOver %s
 
 // O3: -O3
 // OFast: -Ofast
@@ -33,3 +33,11 @@
 // NestParallel: "-fopenmp-assume-no-nested-parallelism"
 // NestParallel-NOT: "-fno-openmp-assume-no-nested-parallelism"
 // DefaultNoNestParallel-NOT: {{"-f(-no-)?openmp-assume-no-nested-parallelism"}}
+
+// TeamsOver: "-fopenmp-assume-teams-oversubscription"
+// TeamsOver-NOT: "-fno-openmp-assume-teams-oversubscription"
+// DefaultTeamsOver-NOT: {{"-f(no-)?openmp-assume-teams-oversubscription"}}
+
+// ThreadsOver: "-fopenmp-assume-threads-oversubscription"
+// ThreadsOver-NOT: "-fno-openmp-assume-threads-oversubscription"
+// DefaultThreadsOver-NOT: {{"-f(no-)?openmp-assume-threads-oversubscription"}}


### PR DESCRIPTION
Enable -fopenmp-assume-teams-oversubscription and
-fopenmp-assume-threads-oversubscription by default under
-fopenmp-target-fast. Adds driver test coverage for both.

Split out of #205325 as a standalone change.