### PR TITLE
[Sparc] Apply the GRLIB-TN-0011 errata workaround to ldstub

### DIFF
--- a/llvm/lib/Target/Sparc/SparcAsmPrinter.cpp
+++ b/llvm/lib/Target/Sparc/SparcAsmPrinter.cpp
@@ -347,7 +347,6 @@ void SparcAsmPrinter::emitInstruction(const MachineInstr *MI) {
   case SP::LDSTUBrr:
   case SP::LDSTUBri:
   case SP::LDSTUBArr:
-  case SP::LDSTUBAri:
     if (MF->getSubtarget<SparcSubtarget>().fixTN0011())
       OutStreamer->emitCodeAlignment(Align(16), getSubtargetInfo());
     break;

--- a/llvm/lib/Target/Sparc/SparcAsmPrinter.cpp
+++ b/llvm/lib/Target/Sparc/SparcAsmPrinter.cpp
@@ -344,6 +344,10 @@ void SparcAsmPrinter::emitInstruction(const MachineInstr *MI) {
   case SP::CASArr:
   case SP::SWAPrr:
   case SP::SWAPri:
+  case SP::LDSTUBrr:
+  case SP::LDSTUBri:
+  case SP::LDSTUBArr:
+  case SP::LDSTUBAri:
     if (MF->getSubtarget<SparcSubtarget>().fixTN0011())
       OutStreamer->emitCodeAlignment(Align(16), getSubtargetInfo());
     break;

--- a/llvm/test/CodeGen/SPARC/tn0011.ll
+++ b/llvm/test/CodeGen/SPARC/tn0011.ll
@@ -24,3 +24,11 @@ entry:
   %2 = atomicrmw xchg ptr %1, i32 %v seq_cst, align 4
   ret i32 %2
 }
+
+; CHECK: .p2align 4
+; CHECK-NEXT: ldstub
+define i32 @test_fence() {
+entry:
+  fence seq_cst
+  ret i32 0
+}


### PR DESCRIPTION
Add ldstub to the list of atomic instruction that needs to be aligned.