### PR TITLE
[RISCV] Add assembler support to lower `la/lla` to `qc.e.li`

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -3647,10 +3647,10 @@ void RISCVAsmParser::emitLoadLocalAddress(MCInst &Inst, SMLoc IDLoc,
   MCRegister DestReg = Inst.getOperand(0).getReg();
   const MCExpr *Symbol = Inst.getOperand(1).getExpr();
   if (STI->hasFeature(RISCV::Feature32Bit) &&
-      STI->hasFeature(RISCV::FeatureVendorXqcili)) {
+      STI->hasFeature(RISCV::FeatureVendorXqcili))
     emitToStreamer(
         Out, MCInstBuilder(RISCV::QC_E_LI).addReg(DestReg).addExpr(Symbol));
-  } else
+  else
     emitAuipcInstPair(DestReg, DestReg, Symbol, RISCV::S_PCREL_HI, RISCV::ADDI,
                       IDLoc, Out);
 }

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -3646,8 +3646,13 @@ void RISCVAsmParser::emitLoadLocalAddress(MCInst &Inst, SMLoc IDLoc,
   //             ADDI rdest, rdest, %pcrel_lo(TmpLabel)
   MCRegister DestReg = Inst.getOperand(0).getReg();
   const MCExpr *Symbol = Inst.getOperand(1).getExpr();
-  emitAuipcInstPair(DestReg, DestReg, Symbol, RISCV::S_PCREL_HI, RISCV::ADDI,
-                    IDLoc, Out);
+  if (STI->hasFeature(RISCV::Feature32Bit) &&
+      STI->hasFeature(RISCV::FeatureVendorXqcili)) {
+    emitToStreamer(
+        Out, MCInstBuilder(RISCV::QC_E_LI).addReg(DestReg).addExpr(Symbol));
+  } else
+    emitAuipcInstPair(DestReg, DestReg, Symbol, RISCV::S_PCREL_HI, RISCV::ADDI,
+                      IDLoc, Out);
 }
 
 void RISCVAsmParser::emitLoadGlobalAddress(MCInst &Inst, SMLoc IDLoc,

--- a/llvm/test/MC/RISCV/xqcili-load-address.s
+++ b/llvm/test/MC/RISCV/xqcili-load-address.s
@@ -1,0 +1,41 @@
+# RUN: llvm-mc -triple=riscv32 -mattr=+xqcili %s \
+# RUN:     | FileCheck -check-prefix=ASM %s
+# RUN: llvm-mc -triple=riscv32 -mattr=+xqcili %s \
+# RUN:     -filetype=obj -o - \
+# RUN:     | llvm-objdump --no-addresses -dr --mattr=+xqcili - \
+# RUN:     | FileCheck -check-prefix=OBJ %s
+
+## This test checks that we are lowering la/lla to qc.e.li correctly
+
+lla x6, abs_sym
+// ASM: qc.e.li	t1, abs_sym
+// OBJ: 031f 0000 0000        	qc.e.li	t1, 0x0
+// OBJ-NEXT: R_RISCV_VENDOR	QUALCOMM
+// OBJ-NEXT: R_RISCV_QC_E_32	abs_sym
+
+lla x6, same_section
+// ASM: qc.e.li	t1, same_section
+// OBJ: 031f 0000 0000        	qc.e.li	t1, 0x0
+// OBJ-NEXT: R_RISCV_VENDOR	QUALCOMM
+// OBJ-NEXT: R_RISCV_QC_E_32	same_section
+
+.option nopic
+// ASM: .option	nopic
+
+la x6, same_section
+// ASM: qc.e.li	t1, same_section
+// OBJ: 031f 0000 0000        	qc.e.li	t1, 0x0
+// OBJ-NEXT: R_RISCV_VENDOR	QUALCOMM
+// OBJ-NEXT: R_RISCV_QC_E_32	same_section
+
+la x6, abs_sym
+// ASM: qc.e.li	t1, abs_sym
+// OBJ: 031f 0000 0000        	qc.e.li	t1, 0x0
+// OBJ-NEXT: R_RISCV_VENDOR	QUALCOMM
+// OBJ-NEXT: R_RISCV_QC_E_32	abs_sym
+
+same_section:
+// ASM: same_section:
+nop
+// ASM: nop
+// OBJ: 0001                  	nop


### PR DESCRIPTION
This patch updates the `RISCVAsmParser::emitLoadLocalAddress` function to enable lowering of the `la/lla` pseudos to `qc.e.li` from the Qualcomm uC Xqcili extension.