### PR TITLE
[runtimes][cmake] Keep default PIC behavior consistent in standalone build

### DIFF
--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -205,6 +205,12 @@ endif()
 # Avoid checking whether the compiler is working.
 set(LLVM_COMPILER_CHECKED ON)
 
+# Match default PIC behavior between bootstrap and standalone runtime builds.
+# Required before including HandleLLVMOptions.
+if (NOT CMAKE_SYSTEM_NAME MATCHES "OS390")
+  option(LLVM_ENABLE_PIC "Build Position-Independent Code" ON)
+endif()
+
 # Handle common options used by all runtimes.
 include(AddLLVM)
 include(HandleLLVMOptions)

--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -207,9 +207,7 @@ set(LLVM_COMPILER_CHECKED ON)
 
 # Match default PIC behavior between bootstrap and standalone runtime builds.
 # Required before including HandleLLVMOptions.
-if (NOT CMAKE_SYSTEM_NAME MATCHES "OS390")
-  option(LLVM_ENABLE_PIC "Build Position-Independent Code" ON)
-endif()
+option(LLVM_ENABLE_PIC "Build Position-Independent Code" ON)
 
 # Handle common options used by all runtimes.
 include(AddLLVM)


### PR DESCRIPTION
Define LLVM_ENABLE_PIC in runtimes/CMakeLists.txt so standalone runtime build uses the same defaults as bootstrapping runtime build (as of LLVM_ENABLE_PIC is defined in llvm/CMakeLists.txt) and so the option is available to HandleLLVMOptions.