### PR TITLE
[flang][OpenMP] Decompose combined construct selectors in variant matching

### DIFF
--- a/flang/lib/Semantics/openmp-utils.cpp
+++ b/flang/lib/Semantics/openmp-utils.cpp
@@ -27,6 +27,7 @@
 #include "flang/Parser/openmp-utils.h"
 #include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/expression.h"
+#include "flang/Semantics/openmp-directive-sets.h"
 #include "flang/Semantics/scope.h"
 #include "flang/Semantics/semantics.h"
 #include "flang/Semantics/symbol.h"
@@ -2261,6 +2262,31 @@ UnsupportedSelectorFeature FindUnsupportedSelectorFeature(
   return UnsupportedSelectorFeature::None;
 }
 
+// Add the construct trait properties implied by an OpenMP directive (e.g.
+// `target` adds `construct_target_target`, `target teams` adds both
+// `construct_target_target` and `construct_teams_teams`) to \p vmi. This
+// decomposes combined/composite construct selectors into their leaf traits.
+static void AppendConstructTraitsForDirective(
+    llvm::omp::Directive dir, llvm::omp::VariantMatchInfo &vmi) {
+  auto add = [&](llvm::omp::TraitProperty prop) {
+    vmi.addTrait(prop, llvm::omp::getOpenMPContextTraitPropertyName(prop, ""));
+  };
+  if (llvm::omp::allTargetSet.test(dir))
+    add(llvm::omp::TraitProperty::construct_target_target);
+  if (llvm::omp::allTeamsSet.test(dir))
+    add(llvm::omp::TraitProperty::construct_teams_teams);
+  if (llvm::omp::allParallelSet.test(dir))
+    add(llvm::omp::TraitProperty::construct_parallel_parallel);
+  if (llvm::omp::allDoSet.test(dir))
+    add(llvm::omp::TraitProperty::construct_for_for);
+  if (llvm::omp::allSimdSet.test(dir))
+    add(llvm::omp::TraitProperty::construct_simd_simd);
+  // dispatch is a standalone construct trait (not part of any combined
+  // directive set), so it is matched explicitly.
+  if (dir == llvm::omp::Directive::OMPD_dispatch)
+    add(llvm::omp::TraitProperty::construct_dispatch_dispatch);
+}
+
 static void AddTraitPropertiesFromSelector(llvm::omp::TraitSet set,
     const parser::OmpTraitSelector &selector, llvm::omp::VariantMatchInfo &vmi,
     SemanticsContext &semaCtx,
@@ -2311,10 +2337,8 @@ static void AddTraitPropertiesFromSelector(llvm::omp::TraitSet set,
 
   // Construct trait selector with no properties (e.g. `construct={simd}`):
   // the selector itself implies the property.
-  llvm::omp::TraitProperty propKind{
-      llvm::omp::getOpenMPContextTraitPropertyForSelector(selectorKind)};
-  if (propKind != llvm::omp::TraitProperty::invalid) {
-    vmi.addTrait(set, propKind, traitName.ToString(), scorePtr);
+  if (const auto *dir{std::get_if<llvm::omp::Directive>(&traitName.u)}) {
+    AppendConstructTraitsForDirective(*dir, vmi);
   }
 }
 

--- a/flang/test/Lower/OpenMP/metadirective-construct.f90
+++ b/flang/test/Lower/OpenMP/metadirective-construct.f90
@@ -95,3 +95,22 @@ subroutine test_begin_construct_selected_parent()
     !$omp end metadirective
   !$omp end target
 end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_construct_combined_directive(
+! CHECK:         omp.target
+! CHECK:           omp.parallel
+! CHECK-NOT:         omp.taskyield
+! CHECK:             omp.barrier
+! CHECK:             omp.terminator
+! CHECK:           omp.terminator
+! CHECK:         return
+subroutine test_construct_combined_directive()
+  !$omp target
+    !$omp parallel
+      !$omp metadirective &
+      !$omp & when(construct={parallel}: taskyield) &
+      !$omp & when(construct={target parallel}: barrier) &
+      !$omp & default(nothing)
+    !$omp end parallel
+  !$omp end target
+end subroutine


### PR DESCRIPTION
The previous code resolved a `construct={...}` selector by mapping its name to a trait through a string lookup (`getOpenMPContextTraitSelectorKind` -> `getOpenMPContextTraitPropertyForSelector`). That works for a standalone leaf construct such as `parallel`, whose name matches a single construct selector string, but not for a combined/composite directive such as `target teams`: its name (`"target teams"`) matches no selector string, so the lookup returns `invalid` and the selector's construct traits are dropped.

This PR adds `AppendConstructTraitsForDirective` that walks the directive sets and adds each leaf trait, so combined directives are no longer reduced to a single (or dropped) trait. It also handles the standalone `dispatch` construct trait.

Fixes https://github.com/llvm/llvm-project/issues/205664

Assisted-by: Cursor