### PR TITLE
[Offload][OpenMP][Flang] Update no-loop test

### DIFF
--- a/offload/test/offloading/fortran/target-no-loop.f90
+++ b/offload/test/offloading/fortran/target-no-loop.f90
@@ -48,7 +48,7 @@ program main
 
    errors = errors + check_errors(array)
 
-   ! No-loop kernel
+   ! SPMD kernel
    array = 1
    !$omp target parallel do
    do i = 1, 1024
@@ -88,6 +88,8 @@ end program main
 ! CHECK:  info: #Args: 3 Teams x Thrds:   3x  16 {{.*}}
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD-No-Loop mode
 ! CHECK:  info: #Args: 3 Teams x Thrds:   64x  16 {{.*}}
+! TODO: This kernel is currently incorrectly tagged as no-loop. This is a known issue in the
+!       Flang frontend that currently does not result in any known runtime problems.
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD-No-Loop mode
 ! CHECK:  info: #Args: 3 Teams x Thrds:   1x  16
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} Generic mode

--- a/offload/test/offloading/fortran/target-no-loop.f90
+++ b/offload/test/offloading/fortran/target-no-loop.f90
@@ -48,7 +48,7 @@ program main
 
    errors = errors + check_errors(array)
 
-   ! SPMD kernel
+   ! No-loop kernel
    array = 1
    !$omp target parallel do
    do i = 1, 1024
@@ -88,7 +88,7 @@ end program main
 ! CHECK:  info: #Args: 3 Teams x Thrds:   3x  16 {{.*}}
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD-No-Loop mode
 ! CHECK:  info: #Args: 3 Teams x Thrds:   64x  16 {{.*}}
-! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD mode
+! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD-No-Loop mode
 ! CHECK:  info: #Args: 3 Teams x Thrds:   1x  16
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} Generic mode
 ! CHECK:  info: #Args: 3 Teams x Thrds:   16x  16 {{.*}}


### PR DESCRIPTION
Updates to the kernel type detection logic now allow `target parallel do` to be promoted to SPMD-No-Loop.

A currently broken offload test that was affected by this change is updated here.