### PR TITLE
[libc] Add libgen.h to target public headers

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -15,6 +15,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.fenv
     libc.include.float
     libc.include.inttypes
+    libc.include.libgen
     libc.include.limits
     libc.include.link
     libc.include.locale

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -6,6 +6,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.fenv
     libc.include.float
     libc.include.inttypes
+    libc.include.libgen
     libc.include.malloc
     libc.include.math
     libc.include.search

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -15,6 +15,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.fenv
     libc.include.float
     libc.include.inttypes
+    libc.include.libgen
     libc.include.limits
     libc.include.link
     libc.include.locale

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -15,6 +15,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.fenv
     libc.include.float
     libc.include.inttypes
+    libc.include.libgen
     libc.include.limits
     libc.include.link
     libc.include.locale


### PR DESCRIPTION
Ensure libgen.h is included in TARGET_PUBLIC_HEADERS for Linux targets so that it gets generated and installed.

Assisted-by: Automated tooling, human reviewed.