### PR TITLE
[LLVM][Intrinsics] Fix `llvm_anyptr_ty` to disallow vector of pointers

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -584,7 +584,7 @@ def llvm_anyvector_ty  : LLVMAnyType<vAny,
 
 // Note: CodeGenIntrinsics.cpp seems to check this class to check pointers.
 class LLVMAnyPointerType : LLVMAnyType<pAny,
-                                       AnyKindVectorConstraint.None,
+                                       AnyKindVectorConstraint.Scalar,
                                        AnyKindElementConstraint.Pointer>;
 
 def llvm_anyptr_ty     : LLVMAnyPointerType;      // ptr addrspace(N)

--- a/llvm/test/Verifier/anyptr-bad.ll
+++ b/llvm/test/Verifier/anyptr-bad.ll
@@ -1,0 +1,11 @@
+; RUN: not opt -passes=verify < %s 2>&1 | FileCheck %s
+
+; CHECK: intrinsic return type (overload type 0) expected any pointer type, but got <2 x ptr>
+; CHECK-NEXT: ptr @llvm.returnaddress
+
+declare <2 x ptr> @llvm.returnaddress(i32)
+
+define void @foo() {
+  call <2 x ptr> @llvm.returnaddress(i32 0)
+  ret void
+}


### PR DESCRIPTION
`llvm_anyptr_ty` should only allow scalar pointer types and disallow vector of pointers; fix the vector constraint for `llvm_anyptr_ty` accordingly.  This fixes a regression in `llvm_anyptr_ty` that was introduced in https://github.com/llvm/llvm-project/pull/203506.

Added a unit test to verify that use of a vector of pointers for `llvm_anyptr_ty` fails verification.