### PR TITLE
[libc++] Remove `noexcept` from `format_context::arg` method

### DIFF
--- a/libcxx/include/__format/format_context.h
+++ b/libcxx/include/__format/format_context.h
@@ -182,7 +182,7 @@ public:
         }) {
   }
 
-  _LIBCPP_HIDE_FROM_ABI basic_format_arg<basic_format_context> arg(size_t __id) const noexcept {
+  _LIBCPP_HIDE_FROM_ABI basic_format_arg<basic_format_context> arg(size_t __id) const {
     return __arg_(__ctx_, __id);
   }
 #  if _LIBCPP_HAS_LOCALIZATION


### PR DESCRIPTION
The `format_context` specialization for `__retarget_buffer` has the `arg` method marked as `noexcept`. However, the function pointer that it invokes throws exceptions which can cause in unwanted abortion of the program.

This PR removes the `noexcept` specifier from this method.