### PR TITLE
[Sparc] Enable CASA for the leon3 CPU target

### DIFF
--- a/llvm/lib/Target/Sparc/Sparc.td
+++ b/llvm/lib/Target/Sparc/Sparc.td
@@ -242,7 +242,7 @@ def : Processor<"at697f", LEON2Itineraries,
 
 // LEON 3 FT generic
 def : Processor<"leon3", LEON3Itineraries,
-                [FeatureLeon, UMACSMACSupport]>;
+                [FeatureLeon, UMACSMACSupport, LeonCASA]>;
 
 // LEON 3 FT (UT699). Provides features for the UT699 processor
 // - covers all the erratum fixes for LEON3, but does not support the CASA instruction.


### PR DESCRIPTION
This matches the leon3 CPU target in GCC.