### PR TITLE
[mlir][xegpu] Fix crash on 0D vector in vector-to-xegpu transfer lowering

### DIFF
--- a/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
+++ b/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
@@ -97,6 +97,8 @@ static LogicalResult transferPreconditions(PatternRewriter &rewriter,
 
   VectorType vecTy = xferOp.getVectorType();
   unsigned vecRank = vecTy.getRank();
+  if (vecRank == 0)
+    return rewriter.notifyMatchFailure(xferOp, "0D vectors are not supported");
   if (xferOp.hasOutOfBoundsDim() && vecRank < 2)
     return rewriter.notifyMatchFailure(
         xferOp, "Boundary check is available only for block instructions.");

--- a/mlir/test/Conversion/VectorToXeGPU/transfer-read-to-xegpu.mlir
+++ b/mlir/test/Conversion/VectorToXeGPU/transfer-read-to-xegpu.mlir
@@ -680,3 +680,21 @@ gpu.func @load_0D_memref_unsupported(%source: memref<f16>) -> vector<f16> {
 // CHECK: vector.transfer_read
 
 }
+
+// -----
+gpu.module @xevm_module {
+gpu.func @load_0D_vector_unsupported(%source: memref<3xf32>,
+    %offset: index) -> vector<f32> {
+  %c0 = arith.constant 0.0 : f32
+  %0 = vector.transfer_read %source[%offset], %c0
+    : memref<3xf32>, vector<f32>
+  gpu.return %0 : vector<f32>
+}
+
+// LOAD-ND-LABEL: @load_0D_vector_unsupported
+// LOAD-ND: vector.transfer_read
+
+// LOAD-GATHER-LABEL: @load_0D_vector_unsupported
+// LOAD-GATHER: vector.transfer_read
+
+}

--- a/mlir/test/Conversion/VectorToXeGPU/transfer-write-to-xegpu.mlir
+++ b/mlir/test/Conversion/VectorToXeGPU/transfer-write-to-xegpu.mlir
@@ -412,3 +412,20 @@ gpu.func @store_1D_vector_addrspace3_unsupported(%vec: vector<8xf32>,
 // STORE-SCATTER: vector.transfer_write
 
 }
+
+// -----
+gpu.module @xevm_module {
+gpu.func @store_0D_vector_unsupported(%vec: vector<f32>,
+    %source: memref<3xf32>, %offset: index) {
+  vector.transfer_write %vec, %source[%offset]
+    : vector<f32>, memref<3xf32>
+  gpu.return
+}
+
+// STORE-ND-LABEL: @store_0D_vector_unsupported
+// STORE-ND: vector.transfer_write
+
+// STORE-SCATTER-LABEL: @store_0D_vector_unsupported
+// STORE-SCATTER: vector.transfer_write
+
+}


### PR DESCRIPTION
`transferPreconditions` accepted rank-0 vectors, which then reached `computeOffsets` and indexed an empty `SmallVector` (`broadcasted[0]`), asserting `idx < size()` and crashing. For example:

```mlir
vector.transfer_write %arg0, %arg1[%1] : vector<f32>, memref<3xf32>
```

This is valid IR (the verifier accepts it; 0D vector transfers are part of the vector dialect spec), so the conversion pass should not crash on it.

Bail out via `notifyMatchFailure` for 0D vectors in the shared `transferPreconditions`, so both `transfer_read` and `transfer_write` are left unconverted instead of crashing. This matches how the core vector lowering already treats 0D transfers as an unsupported corner case (see `mlir/lib/Dialect/Vector/Transforms/LowerVectorTransfer.cpp`).

Regression tests are added for 0D `transfer_read` and `transfer_write`.

Fixes #205281
