### PR TITLE
[CodeGen] Avoid ambiguous Register comparison in C++20; NFC

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -691,7 +691,7 @@ static void interpretValues(const MachineInstr *CurMI,
     for (auto FwdRegIt = ForwardedRegWorklist.begin();
          FwdRegIt != ForwardedRegWorklist.end();) {
       Register CalleeSavedReg = MCRegister::NoRegister;
-      if (FwdRegIt->first == CopySrcReg)
+      if (static_cast<Register>(FwdRegIt->first) == CopySrcReg)
         CalleeSavedReg = CopyDestReg;
       else if (unsigned SubRegIdx =
                    TRI.getSubRegIndex(CopySrcReg, FwdRegIt->first))

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -585,7 +585,7 @@ struct FwdRegParamInfo {
 };
 
 /// Register worklist for finding call site values.
-using FwdRegWorklist = MapVector<uint64_t, SmallVector<FwdRegParamInfo, 2>>;
+using FwdRegWorklist = MapVector<Register, SmallVector<FwdRegParamInfo, 2>>;
 /// Container for the set of register units known to be clobbered on the path
 /// to a call site.
 using ClobberedRegUnitSet = SmallSet<MCRegUnit, 16>;
@@ -691,7 +691,7 @@ static void interpretValues(const MachineInstr *CurMI,
     for (auto FwdRegIt = ForwardedRegWorklist.begin();
          FwdRegIt != ForwardedRegWorklist.end();) {
       Register CalleeSavedReg = MCRegister::NoRegister;
-      if (static_cast<Register>(FwdRegIt->first) == CopySrcReg)
+      if (FwdRegIt->first == CopySrcReg)
         CalleeSavedReg = CopyDestReg;
       else if (unsigned SubRegIdx =
                    TRI.getSubRegIndex(CopySrcReg, FwdRegIt->first))


### PR DESCRIPTION
Fix an "ambiguous overload for ‘operator==’" error when compiling with `-std=c++20`, caused by C++20's rewritten operator== candidate rules.