### PR TITLE
GlobalISel/LegalizerHelper: Use type of input load dst for LowerLoad

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -4309,8 +4309,8 @@ LegalizerHelper::LegalizeResult LegalizerHelper::lowerLoad(GAnyLoad &LoadMI) {
     AnyExtTy = LLT::scalar(AnyExtSize);
     OffsetCstRes = LLT::scalar(PtrTy.getSizeInBits());
   } else {
-    AnyExtTy = EltTy.changeElementSize(AnyExtSize);
-    OffsetCstRes = EltTy.changeElementSize(PtrTy.getSizeInBits());
+    AnyExtTy = DstTy.changeElementSize(AnyExtSize);
+    OffsetCstRes = DstTy.changeElementSize(PtrTy.getSizeInBits());
   }
 
   auto LargeLoad = MIRBuilder.buildLoadInstr(TargetOpcode::G_ZEXTLOAD, AnyExtTy,

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-and.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-and.mir
@@ -29,44 +29,41 @@ body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: test_nonpow2
     ; CHECK: %ptr:_(p0) = COPY $x0
-    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(s64) = G_LOAD %ptr(p0) :: (load (s64), align 16)
-    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 0
-    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 8
-    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD %ptr, [[C1]](s64)
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(i64) = G_LOAD %ptr(p0) :: (load (s64), align 16)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 0
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(i64) = G_CONSTANT i64 8
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD %ptr, [[C1]](i64)
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY [[PTR_ADD]](p0)
-    ; CHECK-NEXT: [[ZEXTLOAD:%[0-9]+]]:_(s64) = G_ZEXTLOAD [[COPY]](p0) :: (load (s16) from unknown-address + 8, align 8)
-    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
-    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C2]](s64)
+    ; CHECK-NEXT: [[ZEXTLOAD:%[0-9]+]]:_(i64) = G_ZEXTLOAD [[COPY]](p0) :: (load (s16) from unknown-address + 8, align 8)
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(i64) = G_CONSTANT i64 2
+    ; CHECK-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY]], [[C2]](i64)
     ; CHECK-NEXT: [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD1]](p0) :: (load (s8) from unknown-address + 10, align 2)
     ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(i32) = G_IMPLICIT_DEF
-    ; CHECK-NEXT: [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[LOAD1]](s32), [[DEF]](i32)
-    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
-    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s64) = G_SHL [[MV]], [[C3]](s64)
-    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s64) = G_OR [[SHL]], [[ZEXTLOAD]]
+    ; CHECK-NEXT: [[MV:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[LOAD1]](s32), [[DEF]](i32)
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(i64) = G_CONSTANT i64 16
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(i64) = G_SHL [[MV]], [[C3]](i64)
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(i64) = G_OR [[SHL]], [[ZEXTLOAD]]
     ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(i64) = G_OR [[C]], [[LOAD]]
     ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(i64) = G_OR [[OR]], [[C]]
-    ; CHECK-NEXT: [[LOAD2:%[0-9]+]]:_(s64) = G_LOAD %ptr(p0) :: (load (s64), align 16)
-    ; CHECK-NEXT: [[ZEXTLOAD1:%[0-9]+]]:_(s64) = G_ZEXTLOAD [[PTR_ADD]](p0) :: (load (s16) from unknown-address + 8, align 8)
-    ; CHECK-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C2]](s64)
+    ; CHECK-NEXT: [[LOAD2:%[0-9]+]]:_(i64) = G_LOAD %ptr(p0) :: (load (s64), align 16)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY [[PTR_ADD]](p0)
+    ; CHECK-NEXT: [[ZEXTLOAD1:%[0-9]+]]:_(i64) = G_ZEXTLOAD [[COPY1]](p0) :: (load (s16) from unknown-address + 8, align 8)
+    ; CHECK-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[COPY1]], [[C2]](i64)
     ; CHECK-NEXT: [[LOAD3:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD2]](p0) :: (load (s8) from unknown-address + 10, align 2)
-    ; CHECK-NEXT: [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[LOAD3]](s32), [[DEF]](i32)
-    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s64) = G_SHL [[MV1]], [[C3]](s64)
-    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s64) = G_OR [[SHL1]], [[ZEXTLOAD1]]
+    ; CHECK-NEXT: [[MV1:%[0-9]+]]:_(i64) = G_MERGE_VALUES [[LOAD3]](s32), [[DEF]](i32)
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(i64) = G_SHL [[MV1]], [[C3]](i64)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(i64) = G_OR [[SHL1]], [[ZEXTLOAD1]]
     ; CHECK-NEXT: [[OR4:%[0-9]+]]:_(i64) = G_OR [[C]], [[LOAD2]]
     ; CHECK-NEXT: [[OR5:%[0-9]+]]:_(i64) = G_OR [[OR3]], [[C]]
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(i64) = G_AND [[OR1]], [[OR4]]
     ; CHECK-NEXT: [[AND1:%[0-9]+]]:_(i64) = G_AND [[OR2]], [[OR5]]
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(i64) = COPY [[AND]](i64)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(i64) = COPY [[AND]](i64)
     ; CHECK-NEXT: [[TRUNC:%[0-9]+]]:_(i32) = G_TRUNC [[AND1]](i64)
-    ; CHECK-NEXT: G_STORE [[COPY1]](i64), %ptr(p0) :: (store (i64), align 16)
-    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(i64) = G_CONSTANT i64 8
-    ; CHECK-NEXT: [[PTR_ADD3:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD %ptr, [[C4]](i64)
-    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(i64) = G_CONSTANT i64 16
-    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[TRUNC]], [[C5]](i64)
-    ; CHECK-NEXT: [[C6:%[0-9]+]]:_(i64) = G_CONSTANT i64 2
-    ; CHECK-NEXT: [[PTR_ADD4:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[PTR_ADD3]], [[C6]](i64)
-    ; CHECK-NEXT: G_STORE [[TRUNC]](i32), [[PTR_ADD3]](p0) :: (store (s16) into unknown-address + 8, align 8)
-    ; CHECK-NEXT: G_STORE [[LSHR]](i32), [[PTR_ADD4]](p0) :: (store (s8) into unknown-address + 10, align 2)
+    ; CHECK-NEXT: G_STORE [[COPY2]](i64), %ptr(p0) :: (store (i64), align 16)
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[TRUNC]], [[C3]](i64)
+    ; CHECK-NEXT: [[PTR_ADD3:%[0-9]+]]:_(p0) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C2]](i64)
+    ; CHECK-NEXT: G_STORE [[TRUNC]](i32), [[PTR_ADD]](p0) :: (store (s16) into unknown-address + 8, align 8)
+    ; CHECK-NEXT: G_STORE [[LSHR]](i32), [[PTR_ADD3]](p0) :: (store (s8) into unknown-address + 10, align 2)
     %ptr:_(p0) = COPY $x0
     %a:_(i88) = G_LOAD %ptr(p0) :: (load (s88))
     %b:_(i88) = G_LOAD %ptr(p0) :: (load (s88))


### PR DESCRIPTION
Deduce dst type for new instructions, that do the load lowering, from
destination type of original load instead of from MMO.
Makes a difference with extendedLLTs.