### PR TITLE
[libc++] Fix move-only types in std::make_shared

### DIFF
--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -657,7 +657,7 @@ _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> __allocate_shared_impl(const _Alloc& __all
 template <class _Tp, class _Alloc, class... _Args, __enable_if_t<!is_array<_Tp>::value, int> = 0>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI shared_ptr<_Tp> allocate_shared(const _Alloc& __a, _Args&&... __args) {
   using _ControlBlock = __shared_ptr_emplace<_Tp, __allocator_traits_rebind_t<_Alloc, __remove_cv_t<_Tp> > >;
-  return std::__allocate_shared_impl<_ControlBlock, _Tp>(__a, __args...);
+  return std::__allocate_shared_impl<_ControlBlock, _Tp>(__a, std::forward<_Args>(__args)...);
 }
 
 template <class _Tp, class... _Args, __enable_if_t<!is_array<_Tp>::value, int> = 0>

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/make_shared.pass.cpp
@@ -19,6 +19,7 @@
 #include "count_new.h"
 #include "operator_hijacker.h"
 #include "test_macros.h"
+#include "MoveOnly.h"
 
 struct A
 {
@@ -91,6 +92,11 @@ void test(const T &t0)
 
 int main(int, char**)
 {
+  {
+    auto val = std::make_shared<MoveOnly>(MoveOnly());
+    assert(val->get() == 1);
+  }
+
     int nc = globalMemCounter.outstanding_new;
     {
     int i = 67;


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/200401 broke `make_shared` and friends support for move-only types.