### PR TITLE
[Object] Fix offload bundle decompression on big endian

### DIFF
--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -1085,28 +1085,23 @@ CompressedOffloadBundle::compress(llvm::compression::Params P,
 
   SmallVector<char, 0> FinalBuffer;
   llvm::raw_svector_ostream OS(FinalBuffer);
+  support::endian::Writer Writer(OS, endianness::little);
   OS << MagicNumber;
-  OS.write(reinterpret_cast<const char *>(&Version), sizeof(Version));
-  OS.write(reinterpret_cast<const char *>(&CompressionMethod),
-           sizeof(CompressionMethod));
+  Writer.write(Version);
+  Writer.write(CompressionMethod);
 
   // Write size fields according to version
   if (Version == 2) {
     uint32_t TotalFileSize32 = static_cast<uint32_t>(TotalFileSize64);
     uint32_t UncompressedSize32 = static_cast<uint32_t>(UncompressedSize64);
-    OS.write(reinterpret_cast<const char *>(&TotalFileSize32),
-             sizeof(TotalFileSize32));
-    OS.write(reinterpret_cast<const char *>(&UncompressedSize32),
-             sizeof(UncompressedSize32));
+    Writer.write(TotalFileSize32);
+    Writer.write(UncompressedSize32);
   } else { // Version 3
-    OS.write(reinterpret_cast<const char *>(&TotalFileSize64),
-             sizeof(TotalFileSize64));
-    OS.write(reinterpret_cast<const char *>(&UncompressedSize64),
-             sizeof(UncompressedSize64));
+    Writer.write(TotalFileSize64);
+    Writer.write(UncompressedSize64);
   }
 
-  OS.write(reinterpret_cast<const char *>(&TruncatedHash),
-           sizeof(TruncatedHash));
+  Writer.write(TruncatedHash);
   OS.write(reinterpret_cast<const char *>(CompressedBuffer.data()),
            CompressedBuffer.size());
 
@@ -1146,29 +1141,29 @@ CompressedOffloadBundle::compress(llvm::compression::Params P,
 LLVM_PACKED_START
 union RawCompressedBundleHeader {
   struct CommonFields {
-    uint32_t Magic;
-    uint16_t Version;
-    uint16_t Method;
+    support::ulittle32_t Magic;
+    support::ulittle16_t Version;
+    support::ulittle16_t Method;
   };
 
   struct V1Header {
     CommonFields Common;
-    uint32_t UncompressedFileSize;
-    uint64_t Hash;
+    support::ulittle32_t UncompressedFileSize;
+    support::ulittle64_t Hash;
   };
 
   struct V2Header {
     CommonFields Common;
-    uint32_t FileSize;
-    uint32_t UncompressedFileSize;
-    uint64_t Hash;
+    support::ulittle32_t FileSize;
+    support::ulittle32_t UncompressedFileSize;
+    support::ulittle64_t Hash;
   };
 
   struct V3Header {
     CommonFields Common;
-    uint64_t FileSize;
-    uint64_t UncompressedFileSize;
-    uint64_t Hash;
+    support::ulittle64_t FileSize;
+    support::ulittle64_t UncompressedFileSize;
+    support::ulittle64_t Hash;
   };
 
   CommonFields Common;
@@ -1234,7 +1229,7 @@ CompressedOffloadBundle::CompressedBundleHeader::tryParse(StringRef Blob) {
   case static_cast<uint16_t>(compression::Format::Zlib):
   case static_cast<uint16_t>(compression::Format::Zstd):
     Normalized.CompressionFormat =
-        static_cast<compression::Format>(Header.Common.Method);
+        static_cast<compression::Format>(Header.Common.Method.value());
     break;
   default:
     return createStringError(inconvertibleErrorCode(),

--- a/llvm/lib/Object/OffloadBundle.cpp
+++ b/llvm/lib/Object/OffloadBundle.cpp
@@ -432,29 +432,29 @@ CompressedOffloadBundle::compress(compression::Params P,
 LLVM_PACKED_START
 union RawCompressedBundleHeader {
   struct CommonFields {
-    uint32_t Magic;
-    uint16_t Version;
-    uint16_t Method;
+    support::ulittle32_t Magic;
+    support::ulittle16_t Version;
+    support::ulittle16_t Method;
   };
 
   struct V1Header {
     CommonFields Common;
-    uint32_t UncompressedFileSize;
-    uint64_t Hash;
+    support::ulittle32_t UncompressedFileSize;
+    support::ulittle64_t Hash;
   };
 
   struct V2Header {
     CommonFields Common;
-    uint32_t FileSize;
-    uint32_t UncompressedFileSize;
-    uint64_t Hash;
+    support::ulittle32_t FileSize;
+    support::ulittle32_t UncompressedFileSize;
+    support::ulittle64_t Hash;
   };
 
   struct V3Header {
     CommonFields Common;
-    uint64_t FileSize;
-    uint64_t UncompressedFileSize;
-    uint64_t Hash;
+    support::ulittle64_t FileSize;
+    support::ulittle64_t UncompressedFileSize;
+    support::ulittle64_t Hash;
   };
 
   CommonFields Common;
@@ -518,7 +518,7 @@ CompressedOffloadBundle::CompressedBundleHeader::tryParse(StringRef Blob) {
   case static_cast<uint16_t>(compression::Format::Zlib):
   case static_cast<uint16_t>(compression::Format::Zstd):
     Normalized.CompressionFormat =
-        static_cast<compression::Format>(Header.Common.Method);
+        static_cast<compression::Format>(Header.Common.Method.value());
     break;
   default:
     return createStringError("unknown compressing method");


### PR DESCRIPTION
tools/llvm-objdump/Offloading/fatbin-coff-compress.test was crashing on s390x because the header fields read from the object were misinterpreted as big-endian. Fix this by using ulittleN_t types.