### PR TITLE
[mlir][SCF]: promote one-iteration loops with equal ub and step values

### DIFF
--- a/mlir/lib/Dialect/Utils/StaticValueUtils.cpp
+++ b/mlir/lib/Dialect/Utils/StaticValueUtils.cpp
@@ -322,6 +322,12 @@ std::optional<APInt> constantTripCount(
     // SSA values. That case cannot be detected here.
     return APInt(bitwidth, 0);
   }
+  if (isZeroInteger(lb) && ub == step) {
+    // Fast path: LB == 0 && UB == step. The loop has a single iteration.
+    // Note: LB and UB could match at runtime, even though they are different
+    // SSA values. That case cannot be detected here.
+    return APInt(bitwidth, 1);
+  }
 
   std::optional<std::pair<APInt, bool>> maybeStepCst =
       getConstantAPIntValue(step);

--- a/mlir/test/Dialect/SCF/transform-ops.mlir
+++ b/mlir/test/Dialect/SCF/transform-ops.mlir
@@ -449,6 +449,20 @@ func.func @test_promote_if_one_iteration(%a: index) -> index {
   return %0 : index
 }
 
+// CHECK-LABEL: func @test_promote_if_one_iteration_dynamic(
+//   CHECK-NOT:   scf.for
+//       CHECK:   %[[r:.*]] = "test.foo"
+//       CHECK:   return %[[r]]
+func.func @test_promote_if_one_iteration_dynamic(%a: index, %val: index) -> index {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = scf.for %j = %c0 to %val step %val iter_args(%arg0 = %a) -> index {
+    %1 = "test.foo"(%a) : (index) -> (index)
+    scf.yield %1 : index
+  }
+  return %0 : index
+}
+
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["scf.for"]} in %arg1 : (!transform.any_op) -> !transform.any_op


### PR DESCRIPTION
Adds a fast-path to `constantTripCount` to return 1 on and enables promotion of single-iteration loops of the form:

```
scf.for %j = %c0 to %val step %val ... { ... }
```