### PR TITLE
Revert "[mlir][vector] add consistent stride verification to `masked load/store` and `gather/scatter` ops"

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -1946,9 +1946,6 @@ def Vector_MaskedLoadOp :
        : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
     ```
 
-    The memref must have non-negative strides. Negative strides are not supported
-    and will trigger a verification error.
-
     An optional `alignment` attribute allows to specify the byte alignment of the
     load operation. It must be a positive power of 2. The operation must access
     memory at an address aligned to this boundary. Violating this requirement
@@ -2044,9 +2041,6 @@ def Vector_MaskedStoreOp :
       : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
     ```
 
-    The memref must have non-negative strides. Negative strides are not supported
-    and will trigger a verification error.
-
     An optional `alignment` attribute allows to specify the byte alignment of the
     store operation. It must be a positive power of 2. The operation must access
     memory at an address aligned to this boundary. Violating this requirement
@@ -2141,9 +2135,6 @@ def Vector_GatherOp :
     during progressively lowering to bring other memory operations closer to
     hardware ISA support for a gather.
 
-    The memref must have non-negative strides. Negative strides are not supported
-    and will trigger a verification error.
-
     An optional `alignment` attribute allows to specify the byte alignment of the
     gather operation. It must be a positive power of 2. The operation must access
     memory at an address aligned to this boundary. Violating this requirement
@@ -2236,9 +2227,6 @@ def Vector_ScatterOp
     hardware ISA support for a scatter. The semantics of the operation closely
     correspond to those of the `llvm.masked.scatter`
     [intrinsic](https://llvm.org/docs/LangRef.html#llvm-masked-scatter-intrinsics).
-
-    The memref must have non-negative strides. Negative strides are not supported
-    and will trigger a verification error.
 
     An optional `alignment` attribute allows to specify the byte alignment of the
     scatter operation. It must be a positive power of 2. The operation must access

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -6195,9 +6195,7 @@ LogicalResult vector::LoadOp::verify() {
   if (failed(verifyLoadStoreMemRefLayout(*this, resVecTy, memRefTy)))
     return failure();
 
-  // Negative strides are not supported on vector.load. The lowering to LLVM
-  // emits arithmetic operations (e.g., GEP, mul) with nuw flags that assume
-  // non-negative strides to avoid undefined behavior.
+  // Negative strides are not supported on vector.load.
   if (memref::hasNegativeStaticStride(memRefTy))
     return emitOpError("memref strides must be non-negative");
 
@@ -6247,9 +6245,7 @@ LogicalResult vector::StoreOp::verify() {
   if (failed(verifyLoadStoreMemRefLayout(*this, valueVecTy, memRefTy)))
     return failure();
 
-  // Negative strides are not supported on vector.store. The lowering to LLVM
-  // emits arithmetic operations (e.g., GEP, mul) with nuw flags that assume
-  // non-negative strides to avoid undefined behavior.
+  // Negative strides are not supported on vector.store.
   if (memref::hasNegativeStaticStride(memRefTy))
     return emitOpError("memref strides must be non-negative");
 
@@ -6296,15 +6292,6 @@ LogicalResult MaskedLoadOp::verify() {
   VectorType passVType = getPassThruVectorType();
   VectorType resVType = getVectorType();
   MemRefType memType = getMemRefType();
-
-  if (failed(verifyLoadStoreMemRefLayout(*this, resVType, memType)))
-    return failure();
-
-  // Negative strides are not supported on vector.maskedload. The lowering to
-  // LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
-  // assume non-negative strides to avoid undefined behavior.
-  if (memref::hasNegativeStaticStride(memType))
-    return emitOpError("memref strides must be non-negative");
 
   if (failed(
           verifyElementTypesMatch(*this, memType, resVType, "base", "result")))
@@ -6366,15 +6353,6 @@ LogicalResult MaskedStoreOp::verify() {
   VectorType valueVType = getVectorType();
   MemRefType memType = getMemRefType();
 
-  if (failed(verifyLoadStoreMemRefLayout(*this, valueVType, memType)))
-    return failure();
-
-  // Negative strides are not supported on vector.maskedstore. The lowering to
-  // LLVM emits arithmetic operations (e.g., GEP, mul) with nuw flags that
-  // assume non-negative strides to avoid undefined behavior.
-  if (memref::hasNegativeStaticStride(memType))
-    return emitOpError("memref strides must be non-negative");
-
   if (failed(verifyElementTypesMatch(*this, memType, valueVType, "base",
                                      "valueToStore")))
     return failure();
@@ -6435,13 +6413,6 @@ LogicalResult GatherOp::verify() {
 
   if (!llvm::isa<MemRefType, RankedTensorType>(baseType))
     return emitOpError("requires base to be a memref or ranked tensor type");
-
-  // Negative strides are not supported on vector.gather.
-  // The lowering to LLVM emits arithmetic operations (e.g., GEP, mul) with nuw
-  // flags that assume non-negative strides to avoid undefined behavior.
-  if (auto memRefType = dyn_cast<MemRefType>(baseType))
-    if (memref::hasNegativeStaticStride(memRefType))
-      return emitOpError("memref strides must be non-negative");
 
   if (failed(
           verifyElementTypesMatch(*this, baseType, resVType, "base", "result")))
@@ -6556,13 +6527,6 @@ LogicalResult ScatterOp::verify() {
 
   if (!llvm::isa<MemRefType, RankedTensorType>(baseType))
     return emitOpError("requires base to be a memref or ranked tensor type");
-
-  // Negative strides are not supported on vector.scatter.
-  // The lowering to LLVM emits arithmetic operations (e.g., GEP, mul) with nuw
-  // flags that assume non-negative strides to avoid undefined behavior.
-  if (auto memRefType = dyn_cast<MemRefType>(baseType))
-    if (memref::hasNegativeStaticStride(memRefType))
-      return emitOpError("memref strides must be non-negative");
 
   if (failed(verifyElementTypesMatch(*this, baseType, valueVType, "base",
                                      "valueToStore")))

--- a/mlir/test/Dialect/Vector/invalid.mlir
+++ b/mlir/test/Dialect/Vector/invalid.mlir
@@ -1413,15 +1413,6 @@ func.func @maskedload_memref_mismatch(%base: memref<?xf32>, %mask: vector<16xi1>
 
 // -----
 
-func.func @maskedload_negative_stride(%src: memref<100x100xf32, strided<[-100, 1]>>, %mask: vector<8xi1>, %pass: vector<8xf32>) -> vector<8xf32> {
-  %c0 = arith.constant 0 : index
-  // expected-error @+1 {{'vector.maskedload' op memref strides must be non-negative}}
-  %0 = vector.maskedload %src[%c0, %c0], %mask, %pass : memref<100x100xf32, strided<[-100, 1]>>, vector<8xi1>, vector<8xf32> into vector<8xf32>
-  return %0 : vector<8xf32>
-}
-
-// -----
-
 //===----------------------------------------------------------------------===//
 // vector.maskedstore
 //===----------------------------------------------------------------------===//
@@ -1462,15 +1453,6 @@ func.func @maskedstore_memref_mismatch(%base: memref<?xf32>, %mask: vector<16xi1
   %c0 = arith.constant 0 : index
   // expected-error@+1 {{'vector.maskedstore' op requires 1 indices}}
   vector.maskedstore %base[%c0, %c0], %mask, %value : memref<?xf32>, vector<16xi1>, vector<16xf32>
-}
-
-// -----
-
-func.func @maskedstore_negative_stride(%src: memref<100x100xf32, strided<[-100, 1]>>, %mask: vector<8xi1>, %value: vector<8xf32>) {
-  %c0 = arith.constant 0 : index
-  // expected-error @+1 {{'vector.maskedstore' op memref strides must be non-negative}}
-  vector.maskedstore %src[%c0, %c0], %mask, %value : memref<100x100xf32, strided<[-100, 1]>>, vector<8xi1>, vector<8xf32>
-  return
 }
 
 // -----
@@ -1572,16 +1554,6 @@ func.func @gather_tensor_alignment(%base: tensor<16xf32>, %indices: vector<16xi3
 
 // -----
 
-func.func @gather_negative_stride(%src: memref<100x100xf32, strided<[-100, 1]>>, %indices: vector<16xi32>,
-                                  %mask: vector<16xi1>, %pass_thru: vector<16xf32>, %idx: index) -> vector<16xf32> {
-  // expected-error @+1 {{'vector.gather' op memref strides must be non-negative}}
-  %0 = vector.gather %src[%idx, %idx][%indices], %mask, %pass_thru
-    : memref<100x100xf32, strided<[-100, 1]>>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
-  return %0 : vector<16xf32>
-}
-
-// -----
-
 func.func @scatter_to_vector(%base: vector<16xf32>, %indices: vector<16xi32>,
                              %mask: vector<16xi1>, %pass_thru: vector<16xf32>) {
   %c0 = arith.constant 0 : index
@@ -1666,16 +1638,6 @@ func.func @scatter_tensor_alignment(%base: tensor<?xf32>, %indices: vector<16xi3
   // expected-error@+1 {{'vector.scatter' op alignment is only supported for memref bases, not tensor bases}}
   vector.scatter %base[%c0][%indices], %mask, %value { alignment = 8 : i64 }
     : tensor<?xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> -> tensor<?xf32>
-}
-
-// -----
-
-func.func @scatter_negative_stride(%src: memref<100x100xf32, strided<[-100, 1]>>, %indices: vector<16xi32>,
-                                   %mask: vector<16xi1>, %value: vector<16xf32>, %idx: index) {
-  // expected-error @+1 {{'vector.scatter' op memref strides must be non-negative}}
-  vector.scatter %src[%idx, %idx][%indices], %mask, %value
-    : memref<100x100xf32, strided<[-100, 1]>>, vector<16xi32>, vector<16xi1>, vector<16xf32>
-  return
 }
 
 // -----


### PR DESCRIPTION
Reverts llvm/llvm-project#204842. That PR breaks the following two tests:

* `mlir/test/Integration/Dialect/SparseTensor/CPU/reshape_dot.mlir.test`
* `mlir/test/Integration/Dialect/SparseTensor/CPU/sparse_coo_test.mlir.test`