### PR TITLE
[offload][OpenMP] Fix partial warp reduction

### DIFF
--- a/offload/test/offloading/xteam_min_reduction_partial_wave.c
+++ b/offload/test/offloading/xteam_min_reduction_partial_wave.c
@@ -1,7 +1,9 @@
 // RUN: %libomptarget-compile-generic
-// RUN: env LIBOMPTARGET_INFO=16 %libomptarget-run-generic 2>&1 | %fcheck-generic
+// RUN: env LIBOMPTARGET_INFO=16 \
+// RUN:   %libomptarget-run-generic 2>&1 | %fcheck-generic
 // RUN: %libomptarget-compileopt-generic
-// RUN: env LIBOMPTARGET_INFO=16 %libomptarget-run-generic 2>&1 | %fcheck-generic
+// RUN: env LIBOMPTARGET_INFO=16 \
+// RUN:   %libomptarget-run-generic 2>&1 | %fcheck-generic
 
 // REQUIRES: amdgpu
 
@@ -39,8 +41,10 @@ int main(void) {
   unsigned min63 = reduce_min(TEAMS_BELOW_WAVE_SIZE_BOUNDARY);
   unsigned min64 = reduce_min(TEAMS_AT_WAVE_SIZE_BOUNDARY);
 
-  // CHECK: Launching kernel {{.*}} with [63,1,1] blocks and [32,1,1] threads in SPMD mode
-  // CHECK: Launching kernel {{.*}} with [64,1,1] blocks and [32,1,1] threads in SPMD mode
+  // CHECK: Launching kernel {{.*}} with [63,1,1] blocks and [32,1,1] threads
+  // CHECK-SAME: in SPMD mode
+  // CHECK: Launching kernel {{.*}} with [64,1,1] blocks and [32,1,1] threads
+  // CHECK-SAME: in SPMD mode
   // CHECK: min63 = 0xffffffff
   // CHECK: min64 = 0xffffffff
   printf("min63 = %#x\n", min63);

--- a/offload/test/offloading/xteam_min_reduction_partial_wave.c
+++ b/offload/test/offloading/xteam_min_reduction_partial_wave.c
@@ -1,8 +1,9 @@
-// RUN: %libomptarget-compile-run-and-check-generic
-// RUN: %libomptarget-compileopt-run-and-check-generic
+// RUN: %libomptarget-compile-generic
+// RUN: env LIBOMPTARGET_INFO=16 %libomptarget-run-generic 2>&1 | %fcheck-generic
+// RUN: %libomptarget-compileopt-generic
+// RUN: env LIBOMPTARGET_INFO=16 %libomptarget-run-generic 2>&1 | %fcheck-generic
 
-// REQUIRES: gpu
-// UNSUPPORTED: intelgpu
+// REQUIRES: amdgpu
 
 // Regression test for a cross-team reduction bug where the final xteam
 // reduction used a full-wave reduction path even though the kernel was launched
@@ -14,13 +15,19 @@
 #include <limits.h>
 #include <stdio.h>
 
-static unsigned reduce_min(int teams, int seed) {
+#define THREAD_LIMIT 32
+#define TEAMS_BELOW_WAVE_SIZE_BOUNDARY 63
+#define TEAMS_AT_WAVE_SIZE_BOUNDARY 64
+#define NUM_ITERS (THREAD_LIMIT * TEAMS_BELOW_WAVE_SIZE_BOUNDARY + 1)
+#define EXPECTED_MIN UINT_MAX
+
+static unsigned reduce_min(int teams) {
   unsigned min_val = UINT_MAX;
 
 #pragma omp target teams distribute parallel for num_teams(teams)              \
-    thread_limit(32) map(to : seed) reduction(min : min_val)
-  for (int i = 0; i < 2017; ++i) {
-    unsigned val = 0xdeadbeefU + ((i + seed) & 1);
+    thread_limit(THREAD_LIMIT) reduction(min : min_val)
+  for (int i = 0; i < NUM_ITERS; ++i) {
+    unsigned val = EXPECTED_MIN;
     if (val < min_val)
       min_val = val;
   }
@@ -28,14 +35,16 @@ static unsigned reduce_min(int teams, int seed) {
   return min_val;
 }
 
-int main(int argc, char **argv) {
-  unsigned min63 = reduce_min(63, argc);
-  unsigned min64 = reduce_min(64, argc);
+int main(void) {
+  unsigned min63 = reduce_min(TEAMS_BELOW_WAVE_SIZE_BOUNDARY);
+  unsigned min64 = reduce_min(TEAMS_AT_WAVE_SIZE_BOUNDARY);
 
-  // CHECK: min63 = 0xdeadbeef
-  // CHECK: min64 = 0xdeadbeef
+  // CHECK: Launching kernel {{.*}} with [63,1,1] blocks and [32,1,1] threads in SPMD mode
+  // CHECK: Launching kernel {{.*}} with [64,1,1] blocks and [32,1,1] threads in SPMD mode
+  // CHECK: min63 = 0xffffffff
+  // CHECK: min64 = 0xffffffff
   printf("min63 = %#x\n", min63);
   printf("min64 = %#x\n", min64);
 
-  return min63 == 0xdeadbeefU && min64 == 0xdeadbeefU ? 0 : 1;
+  return min63 == EXPECTED_MIN && min64 == EXPECTED_MIN ? 0 : 1;
 }

--- a/offload/test/offloading/xteam_min_reduction_partial_wave.c
+++ b/offload/test/offloading/xteam_min_reduction_partial_wave.c
@@ -1,0 +1,41 @@
+// RUN: %libomptarget-compile-run-and-check-generic
+// RUN: %libomptarget-compileopt-run-and-check-generic
+
+// REQUIRES: gpu
+// UNSUPPORTED: intelgpu
+
+// Regression test for a cross-team reduction bug where the final xteam
+// reduction used a full-wave reduction path even though the kernel was launched
+// with fewer threads than the device wave size.  On wave64 AMDGPU targets,
+// thread_limit(32) creates a partial wave.  The 63-team case uses the
+// single-thread final reduction path; the 64-team case crosses the wave-size
+// boundary and must still ignore inactive lanes.
+
+#include <limits.h>
+#include <stdio.h>
+
+static unsigned reduce_min(int teams, int seed) {
+  unsigned min_val = UINT_MAX;
+
+#pragma omp target teams distribute parallel for num_teams(teams)              \
+    thread_limit(32) map(to : seed) reduction(min : min_val)
+  for (int i = 0; i < 2017; ++i) {
+    unsigned val = 0xdeadbeefU + ((i + seed) & 1);
+    if (val < min_val)
+      min_val = val;
+  }
+
+  return min_val;
+}
+
+int main(int argc, char **argv) {
+  unsigned min63 = reduce_min(63, argc);
+  unsigned min64 = reduce_min(64, argc);
+
+  // CHECK: min63 = 0xdeadbeef
+  // CHECK: min64 = 0xdeadbeef
+  printf("min63 = %#x\n", min63);
+  printf("min64 = %#x\n", min64);
+
+  return min63 == 0xdeadbeefU && min64 == 0xdeadbeefU ? 0 : 1;
+}

--- a/openmp/device/src/Reduction.cpp
+++ b/openmp/device/src/Reduction.cpp
@@ -280,7 +280,7 @@ int32_t __kmpc_gpu_xteam_reduce_nowait(IdentTy *Loc, void *reduce_data,
     return 0;
 
   // The last team performs final reduction across all team values.
-  NumThreads = kmpc_min(NumThreads, round_down_to_warpsize(NumTeams));
+  NumThreads = round_down_to_warpsize(kmpc_min(NumThreads, NumTeams));
   if (ThreadId >= NumThreads)
     return 0;
 


### PR DESCRIPTION
Don't use a full warp for the final cross-team reduction if the reduction's thread limit is below the warp size.

Claude assisted with the test.