### PR TITLE
[AMDGPU] Do not fold hidden_grid_dims load from reqd_work_group_size

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
@@ -118,17 +118,10 @@ static bool annotateGroupSizeLoadWithRangeMD(LoadInst *Load, bool IsRemainder) {
   return true;
 }
 
-static bool annotateGridDimsLoadWithRangeMD(LoadInst *Load,
-                                            unsigned KnownNumGridDims) {
+static bool annotateGridDimsLoadWithRangeMD(LoadInst *Load) {
   IntegerType *Ty = dyn_cast<IntegerType>(Load->getType());
   if (!Ty || Ty->getBitWidth() < 3)
     return false;
-
-  if (KnownNumGridDims != 0) {
-    Load->replaceAllUsesWith(
-        ConstantInt::get(Load->getType(), KnownNumGridDims));
-    return true;
-  }
 
   // TODO: If there is existing range metadata, preserve it if it is stricter.
   if (Load->hasMetadata(LLVMContext::MD_range))
@@ -142,21 +135,6 @@ static bool annotateGridDimsLoadWithRangeMD(LoadInst *Load,
 }
 
 /// Compute the number of grid dimensions based on !reqd_work_group_size
-/// metadata
-static unsigned computeNumGridDims(const MDNode *ReqdWorkGroupSize) {
-  ConstantInt *KnownZ =
-      mdconst::extract<ConstantInt>(ReqdWorkGroupSize->getOperand(2));
-  if (KnownZ->getZExtValue() != 1)
-    return 3;
-
-  ConstantInt *KnownY =
-      mdconst::extract<ConstantInt>(ReqdWorkGroupSize->getOperand(1));
-  if (KnownY->getZExtValue() != 1)
-    return 2;
-
-  return 1;
-}
-
 static bool processUse(CallInst *CI, bool IsV5OrAbove) {
   Function *F = CI->getFunction();
 
@@ -177,8 +155,6 @@ static bool processUse(CallInst *CI, bool IsV5OrAbove) {
 
   const DataLayout &DL = F->getDataLayout();
   bool MadeChange = false;
-
-  unsigned KnownNumGridDims = HasReqdWorkGroupSize ? computeNumGridDims(MD) : 0;
 
   // We expect to see several GEP users, casted to the appropriate type and
   // loaded.
@@ -270,7 +246,7 @@ static bool processUse(CallInst *CI, bool IsV5OrAbove) {
 
       case GRID_DIMS:
         if (LoadSize <= 2)
-          MadeChange |= annotateGridDimsLoadWithRangeMD(Load, KnownNumGridDims);
+          MadeChange |= annotateGridDimsLoadWithRangeMD(Load);
         break;
       default:
         break;

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
@@ -134,7 +134,6 @@ static bool annotateGridDimsLoadWithRangeMD(LoadInst *Load) {
   return true;
 }
 
-/// Compute the number of grid dimensions based on !reqd_work_group_size
 static bool processUse(CallInst *CI, bool IsV5OrAbove) {
   Function *F = CI->getFunction();
 

--- a/llvm/test/CodeGen/AMDGPU/implicit-arg-v5-opt.ll
+++ b/llvm/test/CodeGen/AMDGPU/implicit-arg-v5-opt.ll
@@ -388,9 +388,15 @@ define i32 @get_grid_dims_i32() #2 {
   ret i32 %grid.dims
 }
 
+; hidden_grid_dims is the AQL dispatch packet setup.DIMENSIONS field -- a
+; runtime value that must not be replaced by a constant derived from
+; reqd_work_group_size.  Only range metadata [1,4) is valid here.
 define i16 @get_grid_dims_reqd_work_group_size_1d() #3 !reqd_work_group_size !2 {
 ; GCN-LABEL: @get_grid_dims_reqd_work_group_size_1d(
-; GCN-NEXT:    ret i16 1
+; GCN-NEXT:    [[IMPLICITARG_PTR:%.*]] = tail call dereferenceable(256) ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; GCN-NEXT:    [[GEP_GRID_DIMS:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[IMPLICITARG_PTR]], i64 64
+; GCN-NEXT:    [[GRID_DIMS:%.*]] = load i16, ptr addrspace(4) [[GEP_GRID_DIMS]], align 4, !range [[RNG5]]
+; GCN-NEXT:    ret i16 [[GRID_DIMS]]
 ;
   %implicitarg.ptr = tail call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
   %gep.grid.dims = getelementptr inbounds i8, ptr addrspace(4) %implicitarg.ptr, i64 64
@@ -400,7 +406,10 @@ define i16 @get_grid_dims_reqd_work_group_size_1d() #3 !reqd_work_group_size !2 
 
 define i16 @get_grid_dims_reqd_work_group_size_2d() #4 !reqd_work_group_size !3 {
 ; GCN-LABEL: @get_grid_dims_reqd_work_group_size_2d(
-; GCN-NEXT:    ret i16 2
+; GCN-NEXT:    [[IMPLICITARG_PTR:%.*]] = tail call dereferenceable(256) ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; GCN-NEXT:    [[GEP_GRID_DIMS:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[IMPLICITARG_PTR]], i64 64
+; GCN-NEXT:    [[GRID_DIMS:%.*]] = load i16, ptr addrspace(4) [[GEP_GRID_DIMS]], align 4, !range [[RNG5]]
+; GCN-NEXT:    ret i16 [[GRID_DIMS]]
 ;
   %implicitarg.ptr = tail call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
   %gep.grid.dims = getelementptr inbounds i8, ptr addrspace(4) %implicitarg.ptr, i64 64
@@ -410,7 +419,10 @@ define i16 @get_grid_dims_reqd_work_group_size_2d() #4 !reqd_work_group_size !3 
 
 define i16 @get_grid_dims_reqd_work_group_size_2d_weird() #5 !reqd_work_group_size !5 {
 ; GCN-LABEL: @get_grid_dims_reqd_work_group_size_2d_weird(
-; GCN-NEXT:    ret i16 2
+; GCN-NEXT:    [[IMPLICITARG_PTR:%.*]] = tail call dereferenceable(256) ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; GCN-NEXT:    [[GEP_GRID_DIMS:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[IMPLICITARG_PTR]], i64 64
+; GCN-NEXT:    [[GRID_DIMS:%.*]] = load i16, ptr addrspace(4) [[GEP_GRID_DIMS]], align 4, !range [[RNG5]]
+; GCN-NEXT:    ret i16 [[GRID_DIMS]]
 ;
   %implicitarg.ptr = tail call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
   %gep.grid.dims = getelementptr inbounds i8, ptr addrspace(4) %implicitarg.ptr, i64 64
@@ -420,7 +432,10 @@ define i16 @get_grid_dims_reqd_work_group_size_2d_weird() #5 !reqd_work_group_si
 
 define i16 @get_grid_dims_reqd_work_group_size_3d() #6 !reqd_work_group_size !0 {
 ; GCN-LABEL: @get_grid_dims_reqd_work_group_size_3d(
-; GCN-NEXT:    ret i16 3
+; GCN-NEXT:    [[IMPLICITARG_PTR:%.*]] = tail call dereferenceable(256) ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; GCN-NEXT:    [[GEP_GRID_DIMS:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[IMPLICITARG_PTR]], i64 64
+; GCN-NEXT:    [[GRID_DIMS:%.*]] = load i16, ptr addrspace(4) [[GEP_GRID_DIMS]], align 4, !range [[RNG5]]
+; GCN-NEXT:    ret i16 [[GRID_DIMS]]
 ;
   %implicitarg.ptr = tail call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
   %gep.grid.dims = getelementptr inbounds i8, ptr addrspace(4) %implicitarg.ptr, i64 64
@@ -430,7 +445,10 @@ define i16 @get_grid_dims_reqd_work_group_size_3d() #6 !reqd_work_group_size !0 
 
 define i16 @get_grid_dims_reqd_work_group_size_3d_weird() #3 !reqd_work_group_size !4 {
 ; GCN-LABEL: @get_grid_dims_reqd_work_group_size_3d_weird(
-; GCN-NEXT:    ret i16 3
+; GCN-NEXT:    [[IMPLICITARG_PTR:%.*]] = tail call dereferenceable(256) ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; GCN-NEXT:    [[GEP_GRID_DIMS:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[IMPLICITARG_PTR]], i64 64
+; GCN-NEXT:    [[GRID_DIMS:%.*]] = load i16, ptr addrspace(4) [[GEP_GRID_DIMS]], align 4, !range [[RNG5]]
+; GCN-NEXT:    ret i16 [[GRID_DIMS]]
 ;
   %implicitarg.ptr = tail call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
   %gep.grid.dims = getelementptr inbounds i8, ptr addrspace(4) %implicitarg.ptr, i64 64


### PR DESCRIPTION
AMDGPULowerKernelAttributes::processUse replaced a load of hidden_grid_dims (implicitarg.ptr + 64, COV5) with a compile-time constant derived from kernel-static !reqd_work_group_size metadata via computeNumGridDims:

  reqd_work_group_size(N, 1, 1) -> constant 1
  reqd_work_group_size(N, M, 1) -> constant 2
  otherwise                     -> constant 3

This is incorrect. hidden_grid_dims is the AQL dispatch packet setup.DIMENSIONS field -- a runtime value set by the host at launch time, independent of reqd_work_group_size. OpenCL and HIP explicitly allow dispatching a kernel with reqd_work_group_size(N,1,1) as a 2-D or 3-D NDRange (with grid_size_{y,z}=1), in which case get_work_dim() must return the runtime dimensionality, not the kernel-static 1.

Fix: remove computeNumGridDims and the replaceAllUsesWith branch. annotateGridDimsLoadWithRangeMD now only attaches !range [1,4) metadata, which is always valid (grid dims is always 1, 2, or 3) and does not change the loaded value.

Update implicit-arg-v5-opt.ll: the five get_grid_dims_reqd_work_group_size_* tests previously expected folded constants; they now expect a load with !range [1,4) metadata.