### PR TITLE
[NFC][CIR] Fix test that used 'DAG-SAME'

### DIFF
--- a/clang/test/CIR/CodeGen/constant-inits.cpp
+++ b/clang/test/CIR/CodeGen/constant-inits.cpp
@@ -111,53 +111,20 @@ void function() {
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE2p2 = #cir.const_record<{#cir.int<123> : !s8i, #cir.int<456> : !s32i}> : !rec_packed
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE3paa = #cir.const_record<{#cir.int<1> : !s16i, #cir.int<2> : !s8i, #cir.fp<3.000000e+00> : !cir.float, #cir.zero : !u8i}> : !rec_packed_and_aligned
 
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5array = #cir.const_array<[
-// CIR-DAG-SAME:   #cir.const_record<{#cir.int<123> : !s32i, #cir.int<456> : !s32i, #cir.const_array<[#cir.int<11> : !s8i, #cir.int<22> : !s8i, #cir.int<33> : !s8i]> : !cir.array<!s8i x 3>, #cir.int<789> : !s32i}> : !rec_Point
-// CIR-DAG-SAME:   #cir.const_record<{#cir.int<10> : !s32i, #cir.int<20> : !s32i, #cir.zero : !cir.array<!s8i x 3>, #cir.int<40> : !s32i}> : !rec_Point
-// CIR-DAG-SAME: ]> : !cir.array<!rec_Point x 2>
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5array = #cir.const_array<[#cir.const_record<{#cir.int<123> : !s32i, #cir.int<456> : !s32i, #cir.const_array<[#cir.int<11> : !s8i, #cir.int<22> : !s8i, #cir.int<33> : !s8i]> : !cir.array<!s8i x 3>, #cir.int<789> : !s32i}> : !rec_Point, #cir.const_record<{#cir.int<10> : !s32i, #cir.int<20> : !s32i, #cir.zero : !cir.array<!s8i x 3>, #cir.int<40> : !s32i}> : !rec_Point]> : !cir.array<!rec_Point x 2>
 
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE12simple_array = #cir.const_array<[
-// CIR-DAG-SAME:   #cir.const_record<{#cir.int<0> : !s32i, #cir.int<-1> : !s32i}> : !rec_simple,
-// CIR-DAG-SAME:   #cir.const_record<{#cir.int<1111> : !s32i, #cir.int<2222> : !s32i}> : !rec_simple,
-// CIR-DAG-SAME:   #cir.const_record<{#cir.int<0> : !s32i, #cir.int<-1> : !s32i}> : !rec_simple
-// CIR-DAG-SAME: ]> : !cir.array<!rec_simple x 3>
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE12simple_array = #cir.const_array<[#cir.const_record<{#cir.int<0> : !s32i, #cir.int<-1> : !s32i}> : !rec_simple, #cir.const_record<{#cir.int<1111> : !s32i, #cir.int<2222> : !s32i}> : !rec_simple, #cir.const_record<{#cir.int<0> : !s32i, #cir.int<-1> : !s32i}> : !rec_simple]> : !cir.array<!rec_simple x 3>
 
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE12packed_array = #cir.const_array<[
-// CIR-DAG-SAME:   #cir.const_record<{#cir.int<123> : !s8i, #cir.int<456> : !s32i}> : !rec_packed,
-// CIR-DAG-SAME:   #cir.const_record<{#cir.int<123> : !s8i, #cir.int<456> : !s32i}> : !rec_packed
-// CIR-DAG-SAME: ]> : !cir.array<!rec_packed x 2>
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE12packed_array = #cir.const_array<[#cir.const_record<{#cir.int<123> : !s8i, #cir.int<456> : !s32i}> : !rec_packed, #cir.const_record<{#cir.int<123> : !s8i, #cir.int<456> : !s32i}> : !rec_packed]> : !cir.array<!rec_packed x 2>
 
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE9paa_array = #cir.const_array<[
-// CIR-DAG-SAME:   #cir.const_record<{#cir.int<1> : !s16i, #cir.int<2> : !s8i, #cir.fp<3.000000e+00> : !cir.float, #cir.zero : !u8i}> : !rec_packed_and_aligned,
-// CIR-DAG-SAME:   #cir.zero : !rec_packed_and_aligned
-// CIR-DAG-SAME: ]> : !cir.array<!rec_packed_and_aligned x 2>
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE9paa_array = #cir.const_array<[#cir.const_record<{#cir.int<1> : !s16i, #cir.int<2> : !s8i, #cir.fp<3.000000e+00> : !cir.float, #cir.zero : !u8i}> : !rec_packed_and_aligned, #cir.zero : !rec_packed_and_aligned]> : !cir.array<!rec_packed_and_aligned x 2>
 
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf1 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<255> : !u8i,
-// CIR-DAG-SAME:   #cir.int<170> : !u8i,
-// CIR-DAG-SAME:   #cir.int<52> : !u8i,
-// CIR-DAG-SAME:   #cir.int<18> : !u8i
-// CIR-DAG-SAME: }> : !rec_anon_struct
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf2 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<255> : !u8i,
-// CIR-DAG-SAME:   #cir.int<127> : !u8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>
-// CIR-DAG-SAME: }> : !rec_anon_struct1
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf3 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<42> : !u8i
-// CIR-DAG-SAME: }> : !rec_single_byte_bitfield
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf1 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<17> : !u8i,
-// CIR-DAG-SAME:   #cir.int<3> : !u8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>
-// CIR-DAG-SAME: }> : !rec_anon_struct1
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf2 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<127> : !u8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>
-// CIR-DAG-SAME: }> : !rec_signed_partial_bitfields
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf3 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<125> : !u8i
-// CIR-DAG-SAME: }> : !rec_mixed_partial_bitfields
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf1 = #cir.const_record<{#cir.int<255> : !u8i, #cir.int<170> : !u8i, #cir.int<52> : !u8i, #cir.int<18> : !u8i}> : !rec_anon_struct
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf2 = #cir.const_record<{#cir.int<255> : !u8i, #cir.int<127> : !u8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>}> : !rec_anon_struct1
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf3 = #cir.const_record<{#cir.int<42> : !u8i}> : !rec_single_byte_bitfield
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf1 = #cir.const_record<{#cir.int<17> : !u8i, #cir.int<3> : !u8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>}> : !rec_anon_struct1
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf2 = #cir.const_record<{#cir.int<127> : !u8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>}> : !rec_signed_partial_bitfields
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf3 = #cir.const_record<{#cir.int<125> : !u8i}> : !rec_mixed_partial_bitfields
 
 // CIR-LABEL: cir.func {{.*}} @_Z8functionv()
 // CIR:   cir.return

--- a/clang/test/CIR/CodeGen/record-zero-init-padding.c
+++ b/clang/test/CIR/CodeGen/record-zero-init-padding.c
@@ -41,34 +41,16 @@ void test_zero_init_padding(void) {
 // CIR-DAG: !rec_anon_struct3 = !cir.struct<{!s8i, !cir.array<!u8i x 3>, !s32i}>
 
 // paf: char + 3 bytes padding + int -> uses !rec_anon_struct3
-// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.paf = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<1> : !s8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>,
-// CIR-DAG-SAME:   #cir.int<42> : !s32i
-// CIR-DAG-SAME: }> : !rec_anon_struct3
+// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.paf = #cir.const_record<{#cir.int<1> : !s8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>, #cir.int<42> : !s32i}> : !rec_anon_struct3
 
 // bfp: unsigned bitfield byte + 3 bytes padding + int -> uses !rec_anon_struct2
-// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.bfp = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<17> : !u8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>,
-// CIR-DAG-SAME:   #cir.int<99> : !s32i
-// CIR-DAG-SAME: }> : !rec_anon_struct2
+// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.bfp = #cir.const_record<{#cir.int<17> : !u8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>, #cir.int<99> : !s32i}> : !rec_anon_struct2
 
 // tp: int + char + 3 bytes tail padding -> uses !rec_anon_struct1
-// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.tp = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<10> : !s32i,
-// CIR-DAG-SAME:   #cir.int<20> : !s8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>
-// CIR-DAG-SAME: }> : !rec_anon_struct1
+// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.tp = #cir.const_record<{#cir.int<10> : !s32i, #cir.int<20> : !s8i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>}> : !rec_anon_struct1
 
 // mp: char + 1 byte padding + short + 4 bytes padding + long long -> uses !rec_anon_struct
-// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.mp = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<5> : !s8i,
-// CIR-DAG-SAME:   #cir.zero : !u8i,
-// CIR-DAG-SAME:   #cir.int<10> : !s16i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 4>,
-// CIR-DAG-SAME:   #cir.int<100> : !s64i
-// CIR-DAG-SAME: }> : !rec_anon_struct
+// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.mp = #cir.const_record<{#cir.int<5> : !s8i, #cir.zero : !u8i, #cir.int<10> : !s16i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 4>, #cir.int<100> : !s64i}> : !rec_anon_struct
 
 // CIR-LABEL: cir.func {{.*}}@test_zero_init_padding
 // CIR:   cir.return


### PR DESCRIPTION
'DAG-SAME' isn't a thing in file-check, so these lines weren't being checked.  This patch just puts them all on teh same line as they should be.