### PR TITLE
[CIR] Load enums with a boolean underlying type

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -769,9 +769,12 @@ mlir::Value CIRGenFunction::emitLoadOfScalar(Address addr, bool isVolatile,
 
   mlir::Value loadOp =
       builder.createLoad(getLoc(loc), addr, isVolatile, isNontemporal);
-  if (!ty->isBooleanType() && ty->hasBooleanRepresentation())
-    cgm.errorNYI("emitLoadOfScalar: boolean type with boolean representation");
 
+  // Types with a boolean representation that are not the builtin bool (an enum
+  // whose underlying type is bool, or a _BitInt(1)) need no register/memory
+  // conversion here: like bool and _BitInt(N), CIR keeps them in their literal
+  // type until LowerToLLVM widens them to the in-memory integer type (see
+  // emitToMemory).
   return loadOp;
 }
 

--- a/clang/test/CIR/CodeGen/enum-bool.cpp
+++ b/clang/test/CIR/CodeGen/enum-bool.cpp
@@ -1,0 +1,50 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+enum BoolEnum : bool { False, True };
+
+BoolEnum loadEnum(BoolEnum *p) { return *p; }
+
+// CIR-LABEL: cir.func{{.*}} @_Z8loadEnumP8BoolEnum(%arg0: !cir.ptr<!cir.bool>
+// CIR-SAME:    -> (!cir.bool
+// CIR:         %[[P:.*]] = cir.alloca {{.*}} : !cir.ptr<!cir.ptr<!cir.bool>>
+// CIR:         %[[PV:.*]] = cir.load deref {{.*}}%[[P]] : !cir.ptr<!cir.ptr<!cir.bool>>, !cir.ptr<!cir.bool>
+// CIR:         %[[V:.*]] = cir.load {{.*}}%[[PV]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:         cir.return
+
+// LLVM-LABEL: define dso_local noundef i1 @_Z8loadEnumP8BoolEnum(ptr noundef %0)
+// LLVM:         %[[PTR:.*]] = load ptr, ptr
+// LLVM:         %[[MEM:.*]] = load i8, ptr %[[PTR]], align 1
+// LLVM:         %[[BOOL:.*]] = trunc i8 %[[MEM]] to i1
+
+// OGCG-LABEL: define dso_local noundef zeroext i1 @_Z8loadEnumP8BoolEnum(ptr noundef %p)
+// OGCG:         %[[MEM:.*]] = load i8, ptr {{.*}}, align 1
+// OGCG:         %[[BOOL:.*]] = icmp ne i8 %[[MEM]], 0
+// OGCG:         ret i1 %[[BOOL]]
+
+void storeEnum(BoolEnum *p, BoolEnum v) { *p = v; }
+
+// CIR-LABEL: cir.func{{.*}} @_Z9storeEnumP8BoolEnumS_(%arg0: !cir.ptr<!cir.bool>
+// CIR-SAME:    %arg1: !cir.bool
+// CIR:         %[[V:.*]] = cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:         %[[P:.*]] = cir.load deref {{.*}} : !cir.ptr<!cir.ptr<!cir.bool>>, !cir.ptr<!cir.bool>
+// CIR:         cir.store {{.*}}%[[V]], %[[P]] : !cir.bool, !cir.ptr<!cir.bool>
+
+// LLVM-LABEL: define dso_local void @_Z9storeEnumP8BoolEnumS_(ptr noundef %0, i1 noundef %1)
+// LLVM:         %[[Z:.*]] = zext i1 %1 to i8
+// LLVM:         store i8 %[[Z]], ptr
+// LLVM:         %[[LD:.*]] = load i8, ptr
+// LLVM:         %[[TR:.*]] = trunc i8 %[[LD]] to i1
+// LLVM:         %[[ZB:.*]] = zext i1 %[[TR]] to i8
+// LLVM:         store i8 %[[ZB]], ptr
+
+// OGCG-LABEL: define dso_local void @_Z9storeEnumP8BoolEnumS_(ptr noundef %p, i1 noundef zeroext %v)
+// OGCG:         %[[SV:.*]] = zext i1 %v to i8
+// OGCG:         store i8 %[[SV]], ptr %v.addr
+// OGCG:         %[[LV:.*]] = icmp ne i8 {{.*}}, 0
+// OGCG:         %[[SV1:.*]] = zext i1 %[[LV]] to i8
+// OGCG:         store i8 %[[SV1]], ptr

--- a/clang/test/CIR/CodeGen/enum-bool.cpp
+++ b/clang/test/CIR/CodeGen/enum-bool.cpp
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 enum BoolEnum : bool { False, True };
 
@@ -16,15 +16,9 @@ BoolEnum loadEnum(BoolEnum *p) { return *p; }
 // CIR:         %[[V:.*]] = cir.load {{.*}}%[[PV]] : !cir.ptr<!cir.bool>, !cir.bool
 // CIR:         cir.return
 
-// LLVM-LABEL: define dso_local noundef i1 @_Z8loadEnumP8BoolEnum(ptr noundef %0)
-// LLVM:         %[[PTR:.*]] = load ptr, ptr
-// LLVM:         %[[MEM:.*]] = load i8, ptr %[[PTR]], align 1
-// LLVM:         %[[BOOL:.*]] = trunc i8 %[[MEM]] to i1
-
-// OGCG-LABEL: define dso_local noundef zeroext i1 @_Z8loadEnumP8BoolEnum(ptr noundef %p)
-// OGCG:         %[[MEM:.*]] = load i8, ptr {{.*}}, align 1
-// OGCG:         %[[BOOL:.*]] = icmp ne i8 %[[MEM]], 0
-// OGCG:         ret i1 %[[BOOL]]
+// LLVM-LABEL: define dso_local noundef {{(zeroext )?}}i1 @_Z8loadEnumP8BoolEnum(ptr noundef %{{.*}})
+// LLVM:         load i8, ptr %{{.*}}, align 1
+// LLVM:         ret i1 %{{.*}}
 
 void storeEnum(BoolEnum *p, BoolEnum v) { *p = v; }
 
@@ -34,17 +28,8 @@ void storeEnum(BoolEnum *p, BoolEnum v) { *p = v; }
 // CIR:         %[[P:.*]] = cir.load deref {{.*}} : !cir.ptr<!cir.ptr<!cir.bool>>, !cir.ptr<!cir.bool>
 // CIR:         cir.store {{.*}}%[[V]], %[[P]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM-LABEL: define dso_local void @_Z9storeEnumP8BoolEnumS_(ptr noundef %0, i1 noundef %1)
-// LLVM:         %[[Z:.*]] = zext i1 %1 to i8
-// LLVM:         store i8 %[[Z]], ptr
-// LLVM:         %[[LD:.*]] = load i8, ptr
-// LLVM:         %[[TR:.*]] = trunc i8 %[[LD]] to i1
-// LLVM:         %[[ZB:.*]] = zext i1 %[[TR]] to i8
-// LLVM:         store i8 %[[ZB]], ptr
-
-// OGCG-LABEL: define dso_local void @_Z9storeEnumP8BoolEnumS_(ptr noundef %p, i1 noundef zeroext %v)
-// OGCG:         %[[SV:.*]] = zext i1 %v to i8
-// OGCG:         store i8 %[[SV]], ptr %v.addr
-// OGCG:         %[[LV:.*]] = icmp ne i8 {{.*}}, 0
-// OGCG:         %[[SV1:.*]] = zext i1 %[[LV]] to i8
-// OGCG:         store i8 %[[SV1]], ptr
+// LLVM-LABEL: define dso_local void @_Z9storeEnumP8BoolEnumS_(ptr noundef %{{.*}}, i1 noundef {{(zeroext )?}}%{{.*}})
+// LLVM:         zext i1 %{{.*}} to i8
+// LLVM:         store i8 %{{.*}}, ptr %{{.*}}, align 1
+// LLVM:         load i8, ptr %{{.*}}, align 1
+// LLVM:         store i8 %{{.*}}, ptr %{{.*}}, align 1


### PR DESCRIPTION
`emitLoadOfScalar` reported NYI for any scalar whose type has a boolean
representation but isn't the builtin `bool`, so loading an `enum` with a fixed
`bool` underlying type (e.g. `enum E : bool`) failed to compile. The errorNYI
also left the function's entry block without a terminator, so the translation
unit then failed CIR module verification.

Such an enum converts to `!cir.bool` (via `convertType` of its underlying
type), and `convertTypeForMem` does not widen it, so the `cir.load` result is
already the literal CIR type CIR uses for that enum everywhere. CIR keeps bool
in `!cir.bool` through CIRGen and defers the in-memory i8 widening to
LowerToLLVM (see the `emitToMemory` comment), so no register/memory conversion
is needed at this point. The fix drops the errorNYI and returns the loaded
value, matching the plain-bool path directly above it.

The same guard also covered `_BitInt(1)`, which converts to `!cir.int<1>` and
follows the identical deferral; it now loads too. This does not change the
in-memory representation of either type, which LowerToLLVM still owns.

The test covers load and store of an `enum : bool` across CIR, the CIR-lowered
LLVM, and classic CodeGen.
