### PR TITLE
[libc++] Cast 0 to `__locale_t` in `text_encoding.cpp`

### DIFF
--- a/libcxx/src/text_encoding.cpp
+++ b/libcxx/src/text_encoding.cpp
@@ -31,7 +31,7 @@ static text_encoding __make_text_encoding(const char* __name) {
 
 std::text_encoding __get_locale_encoding(const char* __name) {
   if (__name == nullptr)
-    return __make_text_encoding(__locale::__get_locale_encoding(static_cast<__locale::__locale_t>(nullptr)));
+    return __make_text_encoding(__locale::__get_locale_encoding(static_cast<__locale::__locale_t>(0)));
 
   __locale::__locale_t __l = __locale::__newlocale(_LIBCPP_CTYPE_MASK, __name, static_cast<__locale::__locale_t>(0));
 

--- a/libcxx/test/std/localization/locales/locale/locale.members/encoding.pass.cpp
+++ b/libcxx/test/std/localization/locales/locale/locale.members/encoding.pass.cpp
@@ -12,6 +12,7 @@
 // REQUIRES: locale.en_US.UTF-8
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: availability-te-environment-missing
+// UNSUPPORTED: LLVM-LIBC-FIXME
 
 // class locale
 


### PR DESCRIPTION
- As mentioned https://github.com/llvm/llvm-project/pull/141312#issuecomment-4799649766, platforms which define `locale_t` as not a pointer fail would fail to compile. This should fix the picolibc case.
- As an aside, also disable the `encoding.pass.cpp` test for llvm-libc as that also uses `__get_locale_encoding()`