### PR TITLE
[MC][ARM] Set default Tag_ABI_VFP_args EABI attr

### DIFF
--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
@@ -50,6 +50,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/TargetParser/Triple.h"
 #include <cassert>
 #include <climits>
 #include <cstdint>
@@ -1067,6 +1068,21 @@ void ARMTargetELFStreamer::finishAttributeSection() {
 
   if (Arch != ARM::ArchKind::INVALID)
     emitArchDefaultAttributes();
+
+  // Set Tag_ABI_VFP_args based on the target triple environment.
+  // For hard-float environments (ending in 'hf') and Windows on ARM (which
+  // strictly mandates the AAPCS-VFP hard-float calling convention), we default
+  // Tag_ABI_VFP_args to HardFPAAPCS. We set OverwriteExisting to false to
+  // ensure that any explicit .eabi_attribute directives in the assembly source
+  // are respected and not overwritten.
+  const Triple &TT = S.getContext().getTargetTriple();
+  if (TT.getEnvironment() == Triple::GNUEABIHF ||
+      TT.getEnvironment() == Triple::GNUEABIHFT64 ||
+      TT.getEnvironment() == Triple::MuslEABIHF ||
+      TT.getEnvironment() == Triple::EABIHF || TT.isOSWindows()) {
+    S.setAttributeItem(ARMBuildAttrs::ABI_VFP_args, ARMBuildAttrs::HardFPAAPCS,
+                       /* OverwriteExisting= */ false);
+  }
 
   if (S.Contents.empty())
     return;

--- a/llvm/test/MC/ARM/elf-float-abi-explicit.s
+++ b/llvm/test/MC/ARM/elf-float-abi-explicit.s
@@ -1,0 +1,14 @@
+@ RUN: llvm-mc -triple armv7a-unknown-linux-gnueabihf -filetype=obj -o - %s \
+@ RUN:   | llvm-readobj --arch-specific - | FileCheck %s --check-prefix=EXPLICIT-SOFT
+
+@ EXPLICIT-SOFT:        Tag: 28
+@ EXPLICIT-SOFT-NEXT:   Value: 0
+@ EXPLICIT-SOFT-NEXT:   TagName: ABI_VFP_args
+@ EXPLICIT-SOFT-NEXT:   Description: AAPCS
+
+.syntax unified
+.eabi_attribute 28, 0 @ Explicitly declare Base AAPCS (soft-float/softfp)
+.text
+.global _start
+_start:
+    bx lr

--- a/llvm/test/MC/ARM/elf-float-abi.s
+++ b/llvm/test/MC/ARM/elf-float-abi.s
@@ -1,0 +1,21 @@
+@ RUN: llvm-mc -triple armv7a-unknown-linux-gnueabihf -filetype=obj -o - %s \
+@ RUN:   | llvm-readobj --arch-specific - | FileCheck %s --check-prefix=HARD
+
+@ RUN: llvm-mc -triple armv7a-unknown-linux-gnueabi -filetype=obj -o - %s \
+@ RUN:   | llvm-readobj --arch-specific - | FileCheck %s --check-prefix=SOFT
+
+@ RUN: llvm-mc -triple thumbv7-pc-windows-elf -filetype=obj -o - %s \
+@ RUN:   | llvm-readobj --arch-specific - | FileCheck %s --check-prefix=HARD
+
+@ HARD:        Tag: 28
+@ HARD-NEXT:   Value: 1
+@ HARD-NEXT:   TagName: ABI_VFP_args
+@ HARD-NEXT:   Description: AAPCS VFP
+
+@ SOFT-NOT: TagName: ABI_VFP_args
+
+.syntax unified
+.text
+.global _start
+_start:
+    bx lr


### PR DESCRIPTION
Clang's integrated assembler was not emitting any default 
ag_ABI_VFP_args (float ABI) attribute for ARM targets.
This made it look like the files were
calling-convention-neutral, which can lead to silent float ABI
mismatches during linking. This patch fixes that by automatically
setting the float ABI attribute in the ELF streamer which can be
used by the linker.
