### PR TITLE
[libc++] Add missing ABI changelog entry for #173283

### DIFF
--- a/libcxx/lib/abi/CHANGELOG.TXT
+++ b/libcxx/lib/abi/CHANGELOG.TXT
@@ -30,6 +30,15 @@ Version 23.0
 Version 22.0
 ------------
 
+* [libc++] Remove numpunct_byname::__init
+
+  numpunct_byname::__init is only used inside the dylib, so we can remove it.
+
+  All platforms
+  -------------
+  Symbol removed: _ZNSt3__115numpunct_bynameIcE6__initEPKc
+  Symbol removed: _ZNSt3__115numpunct_bynameIwE6__initEPKc
+
 * [libc++] Allows any types of size 4 and 8 to use native platform ulock_wait
 
   This patch added symbols for platform wait functions with the size of the type


### PR DESCRIPTION
PR #173283 (Remove numpunct_byname::__init) removed symbols but forgot to add the relevant entry in the ABI changelog.