### PR TITLE
[Flang-RT] Make __cuda_builtins dependency explicit

### DIFF
--- a/flang-rt/lib/runtime/__cuda_device.f90
+++ b/flang-rt/lib/runtime/__cuda_device.f90
@@ -9,6 +9,7 @@
 ! This module contains CUDA Fortran interfaces used in cudadevice.f90.
 
 module __cuda_device
+  use __cuda_builtins ! implicit dependency, made explicit for CMake
 implicit none
 
 end module

--- a/flang-rt/lib/runtime/cuda_runtime_api.f90
+++ b/flang-rt/lib/runtime/cuda_runtime_api.f90
@@ -7,6 +7,7 @@
 !===------------------------------------------------------------------------===!
 
 module cuda_runtime_api
+  use __cuda_builtins ! implicit dependency, made explicit for CMake
 implicit none
 
 integer, parameter :: cuda_stream_kind = int_ptr_kind()


### PR DESCRIPTION
When compiling CUDA-Fortran, a use of the module __cuda_builtins is added implicitly by the compiler. Add explicit use so CMake can consider it in the built order. The other modules that are compiled with CUDA enabled (`cudadevice.f90` and `cooperativegroups.f90`) transitively depend on depend on __cuda_builtins as well.

Fixes the [flang-aarch64-rel-assert](https://lab.llvm.org/buildbot/#/builders/29) buildbot.