### PR TITLE
[VPlan] Remove unused VPlanPrinter::getOrCreateName(const VPBlockBase*)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1315,13 +1315,6 @@ Twine VPlanPrinter::getUID(const VPBlockBase *Block) {
          Twine(getOrCreateBID(Block));
 }
 
-Twine VPlanPrinter::getOrCreateName(const VPBlockBase *Block) {
-  const std::string &Name = Block->getName();
-  if (!Name.empty())
-    return Name;
-  return "VPB" + Twine(getOrCreateBID(Block));
-}
-
 void VPlanPrinter::dump() {
   Depth = 1;
   bumpIndent(0);

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -475,8 +475,6 @@ class VPlanPrinter {
     return BlockID.count(Block) ? BlockID[Block] : BlockID[Block] = BID++;
   }
 
-  Twine getOrCreateName(const VPBlockBase *Block);
-
   Twine getUID(const VPBlockBase *Block);
 
   /// Print the information related to a CFG edge between two VPBlockBases.


### PR DESCRIPTION
The block-name printers use getName()/getUID() directly; this overload has no callers.