### PR TITLE
[AArch64] Add hip12 to release notes.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -895,7 +895,10 @@ X86 Support
 Arm and AArch64 Support
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Added support for the Arm AGI CPU via the ``-mcpu=armagicpu`` command-line option.
+- Support has been added for the following processors (-mcpu identifiers in parenthesis):
+
+* Arm AGI CPU (armagicpu).
+* Hisilicon hip12 core (hip12).
 
 Android Support
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
This adds the hip12 cpu added in #203446 to the release notes, and rejigs them to match the format used in previous releases.