### PR TITLE
[CIR] Emit trailing-zero array constants as a compact split

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -294,6 +294,13 @@ public:
 #include "clang/CIR/Dialect/IR/CIRLowering.inc"
 #undef GET_CIR_ATTR_TO_VALUE_VISITOR_DECLS
 
+  // Build the packed { <init>, [zeros x T] zeroinitializer } value for a
+  // splittable trailing-zeros array (see shouldSplitTrailingZeros).  Called
+  // from the ConstArrayAttr visitor, so it composes at any nesting level (a
+  // record member or array element that is a splittable array splits too, and
+  // the enclosing record/array type follows the produced value).
+  mlir::Value buildTrailingZeroSplit(cir::ConstArrayAttr attr);
+
 private:
   mlir::Operation *parentOp;
   mlir::ConversionPatternRewriter &rewriter;
@@ -504,10 +511,124 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::BlockAddrInfoAttr blockAddrInfo) {
   return blockAddressOp;
 }
 
+// Module attribute holding, for each global whose trailing-zero array
+// initializer is lowered to a packed { init, zeroinitializer } struct, the
+// global's original array type.  A cir.global_view's indices stay relative to
+// that array, but the source global may already be lowered to the struct when
+// the view is processed (and discardable attrs on the lowered global do not
+// survive the dialect conversion), so the basis is captured on the module
+// before conversion and removed after.  See collectGlobalAnnotations for the
+// same capture-before-lowering pattern.
+static constexpr llvm::StringLiteral tzSplitBasisAttr = "cir.tz_split_basis";
+
+// Return the original array type for a trailing-zero-split global, or a null
+// type when the symbol is not such a global.
+static mlir::Type lookupSplitArrayBasis(mlir::ModuleOp module,
+                                        llvm::StringRef symName) {
+  auto dict = module->getAttrOfType<mlir::DictionaryAttr>(tzSplitBasisAttr);
+  if (!dict)
+    return {};
+  if (auto basis = dict.getAs<mlir::TypeAttr>(symName))
+    return basis.getValue();
+  return {};
+}
+
+// A const array with a long run of trailing zeros and an immediate scalar
+// (int/float) element is lowered as a packed { <init>, zeroinitializer } struct
+// instead of a fully materialized array (see buildTrailingZeroSplit), mirroring
+// classic CodeGen.  The >= 8 trailing-zero gate matches EmitArrayConstant's
+// TrailingZeroes >= 8 split threshold (CGExprConstant.cpp).  Aggregate-element
+// (e.g. multidimensional), pointer, bool, and string-literal arrays are
+// excluded.
+static bool shouldSplitTrailingZeros(cir::ConstArrayAttr attr) {
+  auto elts = mlir::dyn_cast<mlir::ArrayAttr>(attr.getElts());
+  if (!elts || elts.empty() || attr.getTrailingZerosNum() < 8)
+    return false;
+  mlir::Type eltTy =
+      mlir::cast<cir::ArrayType>(attr.getType()).getElementType();
+  return mlir::isa<cir::IntType, cir::FPTypeInterface>(eltTy);
+}
+
+// Whether a constant initializer contains a trailing-zero array that will be
+// split into a packed struct (at any nesting level).  Such a global's lowered
+// type diverges from its declared type, so a cir.global_view into it must walk
+// the declared type (recorded in tzSplitBasisAttr) rather than the rewritten
+// one.
+static bool initContainsSplittableArray(mlir::Attribute attr) {
+  if (auto arr = mlir::dyn_cast<cir::ConstArrayAttr>(attr)) {
+    if (shouldSplitTrailingZeros(arr))
+      return true;
+    if (auto elts = mlir::dyn_cast<mlir::ArrayAttr>(arr.getElts()))
+      return llvm::any_of(elts, initContainsSplittableArray);
+    return false;
+  }
+  if (auto rec = mlir::dyn_cast<cir::ConstRecordAttr>(attr))
+    return llvm::any_of(rec.getMembers(), initContainsSplittableArray);
+  return false;
+}
+
+// Build the packed { <init>, [zeros x T] zeroinitializer } split for a
+// splittable trailing-zeros array (see shouldSplitTrailingZeros).  Mirrors
+// classic CodeGen's EmitArrayConstant (CGExprConstant.cpp): eight or more
+// leading nonzero elements use a single dense init array field
+// (CommonElementType && NonzeroLength >= 8), otherwise individual scalar
+// fields.
+mlir::Value CIRAttrToValue::buildTrailingZeroSplit(cir::ConstArrayAttr attr) {
+  mlir::Location loc = parentOp->getLoc();
+  auto elts = mlir::cast<mlir::ArrayAttr>(attr.getElts());
+  auto arrayTy = mlir::cast<cir::ArrayType>(attr.getType());
+  mlir::Type cirEltTy = arrayTy.getElementType();
+  mlir::Type eltTy = converter->convertType(cirEltTy);
+  unsigned numInit = elts.size();
+  unsigned numZeros = attr.getTrailingZerosNum();
+  auto zeroArrTy = mlir::LLVM::LLVMArrayType::get(eltTy, numZeros);
+  mlir::Value zeroTail = mlir::LLVM::ZeroOp::create(rewriter, loc, zeroArrTy);
+
+  if (numInit >= 8) {
+    auto initArrTy = mlir::LLVM::LLVMArrayType::get(eltTy, numInit);
+    auto initAttr =
+        cir::ConstArrayAttr::get(cir::ArrayType::get(cirEltTy, numInit), elts);
+    // Falls through to individual fields if a non-dense element (e.g. poison)
+    // prevents a single dense constant.
+    if (std::optional<mlir::Attribute> dense =
+            lowerConstArrayAttr(initAttr, converter)) {
+      auto structTy = mlir::LLVM::LLVMStructType::getLiteral(
+          rewriter.getContext(), {initArrTy, zeroArrTy}, /*isPacked=*/true);
+      mlir::Value s = mlir::LLVM::UndefOp::create(rewriter, loc, structTy);
+      mlir::Value initVal =
+          mlir::LLVM::ConstantOp::create(rewriter, loc, initArrTy, *dense);
+      s = mlir::LLVM::InsertValueOp::create(rewriter, loc, s, initVal,
+                                            llvm::ArrayRef<int64_t>{0});
+      return mlir::LLVM::InsertValueOp::create(rewriter, loc, s, zeroTail,
+                                               llvm::ArrayRef<int64_t>{1});
+    }
+  }
+
+  SmallVector<mlir::Type> fieldTys(numInit, eltTy);
+  fieldTys.push_back(zeroArrTy);
+  auto structTy = mlir::LLVM::LLVMStructType::getLiteral(
+      rewriter.getContext(), fieldTys, /*isPacked=*/true);
+  mlir::Value s = mlir::LLVM::UndefOp::create(rewriter, loc, structTy);
+  for (auto [idx, elt] : llvm::enumerate(elts)) {
+    mlir::Value v = lowerCirAttrAsValue(parentOp, elt, rewriter, converter,
+                                        /*blockInfoAddr=*/nullptr);
+    s = mlir::LLVM::InsertValueOp::create(rewriter, loc, s, v, idx);
+  }
+  return mlir::LLVM::InsertValueOp::create(rewriter, loc, s, zeroTail, numInit);
+}
+
 // ConstArrayAttr visitor
 mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstArrayAttr attr) {
-  mlir::Type llvmTy = converter->convertType(attr.getType());
   mlir::Location loc = parentOp->getLoc();
+
+  // A long trailing-zero tail lowers to a compact { init, zeroinitializer }
+  // split, mirroring classic CodeGen.  Checked before the dense form (which
+  // would materialize the whole zero tail) and applied at any nesting level, so
+  // an array nested in a record splits too.
+  if (shouldSplitTrailingZeros(attr))
+    return buildTrailingZeroSplit(attr);
+
+  mlir::Type llvmTy = converter->convertType(attr.getType());
   mlir::Value result;
 
   // When the array can be represented as a single dense constant, emit one
@@ -515,6 +636,46 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstArrayAttr attr) {
   if (std::optional<mlir::Attribute> denseAttr =
           lowerConstArrayAttr(attr, converter))
     return mlir::LLVM::ConstantOp::create(rewriter, loc, llvmTy, *denseAttr);
+
+  // An aggregate-element array whose elements contain a trailing-zero array
+  // (e.g. an array of records with a split member) produces element values
+  // whose type diverges from the declared element type.  Element types are then
+  // non-uniform, so emit a packed struct with one field per element (trailing
+  // zeros padded with the declared element type), matching classic CodeGen's
+  // mixed-type array constant.  The common case below keeps the original array
+  // form and op order.
+  if (auto arrayAttr = mlir::dyn_cast<mlir::ArrayAttr>(attr.getElts());
+      arrayAttr && llvm::any_of(arrayAttr, initContainsSplittableArray)) {
+    auto arrayTy = mlir::cast<cir::ArrayType>(attr.getType());
+    mlir::Type declaredEltTy = converter->convertType(arrayTy.getElementType());
+    llvm::SmallVector<mlir::Value> elems;
+    llvm::SmallVector<mlir::Type> fieldTys;
+    elems.reserve(arrayAttr.size());
+    fieldTys.reserve(arrayTy.getSize());
+    for (mlir::Attribute elt : arrayAttr) {
+      mlir::Value init = visit(elt);
+      elems.push_back(init);
+      fieldTys.push_back(init.getType());
+    }
+    fieldTys.resize(arrayTy.getSize(), declaredEltTy);
+    // When every produced element type matches, classic keeps an [N x T]
+    // array; only a genuinely heterogeneous mix (e.g. a split element beside
+    // declared-typed zero elements) becomes a packed struct.
+    mlir::Type aggTy =
+        llvm::all_equal(fieldTys)
+            ? mlir::Type(mlir::LLVM::LLVMArrayType::get(fieldTys.front(),
+                                                        arrayTy.getSize()))
+            : mlir::Type(mlir::LLVM::LLVMStructType::getLiteral(
+                  rewriter.getContext(), fieldTys, /*isPacked=*/true));
+    result =
+        attr.hasTrailingZeros()
+            ? mlir::Value(mlir::LLVM::ZeroOp::create(rewriter, loc, aggTy))
+            : mlir::Value(mlir::LLVM::UndefOp::create(rewriter, loc, aggTy));
+    for (auto [idx, init] : llvm::enumerate(elems))
+      result =
+          mlir::LLVM::InsertValueOp::create(rewriter, loc, result, init, idx);
+    return result;
+  }
 
   if (attr.hasTrailingZeros()) {
     mlir::Type arrayTy = attr.getType();
@@ -554,14 +715,42 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstArrayAttr attr) {
 mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstRecordAttr constRecord) {
   const mlir::Type llvmTy = converter->convertType(constRecord.getType());
   const mlir::Location loc = parentOp->getLoc();
-  mlir::Value result = mlir::LLVM::UndefOp::create(rewriter, loc, llvmTy);
 
-  // Iteratively lower each constant element of the record.
-  for (auto [idx, elt] : llvm::enumerate(constRecord.getMembers())) {
+  // A trailing-zero array member splits into a packed struct, so its produced
+  // type diverges from the declared member type and the record's type must
+  // follow (matching classic CodeGen, which emits an anonymous struct when a
+  // member's constant layout differs).  When no member diverges, keep the
+  // declared (possibly identified) struct type and lower in place, leaving the
+  // common case byte- and op-order-identical to before.
+  if (!llvm::any_of(constRecord.getMembers(), initContainsSplittableArray)) {
+    mlir::Value result = mlir::LLVM::UndefOp::create(rewriter, loc, llvmTy);
+    for (auto [idx, elt] : llvm::enumerate(constRecord.getMembers())) {
+      mlir::Value init = visit(elt);
+      result =
+          mlir::LLVM::InsertValueOp::create(rewriter, loc, result, init, idx);
+    }
+    return result;
+  }
+
+  // A member diverges: lower all members, then build a literal struct from the
+  // produced types (preserving the declared packedness).
+  llvm::SmallVector<mlir::Value> members;
+  llvm::SmallVector<mlir::Type> memberTypes;
+  members.reserve(constRecord.getMembers().size());
+  memberTypes.reserve(constRecord.getMembers().size());
+  for (mlir::Attribute elt : constRecord.getMembers()) {
     mlir::Value init = visit(elt);
+    members.push_back(init);
+    memberTypes.push_back(init.getType());
+  }
+
+  auto structTy = mlir::LLVM::LLVMStructType::getLiteral(
+      rewriter.getContext(), memberTypes,
+      mlir::cast<mlir::LLVM::LLVMStructType>(llvmTy).isPacked());
+  mlir::Value result = mlir::LLVM::UndefOp::create(rewriter, loc, structTy);
+  for (auto [idx, init] : llvm::enumerate(members))
     result =
         mlir::LLVM::InsertValueOp::create(rewriter, loc, result, init, idx);
-  }
 
   return result;
 }
@@ -604,6 +793,12 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::GlobalViewAttr globalAttr) {
       mlir::SymbolTable::lookupSymbolIn(moduleOp, globalAttr.getSymbol());
   if (auto llvmSymbol = dyn_cast<mlir::LLVM::GlobalOp>(sourceSymbol)) {
     sourceType = llvmSymbol.getType();
+    // If this global's trailing-zero array initializer was split into a packed
+    // struct, the view's indices are still relative to the original array.
+    // Walk that array (byte-identical layout) so the GEP stays in bounds.
+    if (mlir::Type basis =
+            lookupSplitArrayBasis(moduleOp, llvmSymbol.getSymName()))
+      sourceType = basis;
     symName = llvmSymbol.getSymName();
     sourceAddrSpace = llvmSymbol.getAddrSpace();
   } else if (auto cirSymbol = dyn_cast<cir::GlobalOp>(sourceSymbol)) {
@@ -2478,12 +2673,31 @@ CIRToLLVMGlobalOpLowering::matchAndRewriteRegionInitializedGlobal(
   // to the appropriate value.
   const mlir::Location loc = op.getLoc();
   setupRegionInitializedLLVMGlobalOp(op, rewriter);
+  auto newGlobalOp = mlir::cast<mlir::LLVM::GlobalOp>(
+      rewriter.getInsertionBlock()->getParentOp());
 
-  // Pass blockInfoAddr so that block address initializers (either as the whole
-  // initializer or nested inside an aggregate) can be resolved by the
-  // BlockAddrInfoAttr visitor.
+  // Pass blockInfoAddr so block address initializers (whole or nested in an
+  // aggregate) can be resolved by the BlockAddrInfoAttr visitor.  A trailing-
+  // zero array (top-level or nested) is split into a packed
+  // { init, zeroinitializer } inside the visitor; the global's type follows the
+  // produced value (see below).
   CIRAttrToValue valueConverter(op, rewriter, typeConverter, &blockInfoAddr);
   mlir::Value value = valueConverter.visit(init);
+
+  // A split initializer has a different type than the symType-derived global
+  // type, so the global's IR type follows the initializer; references are
+  // type-agnostic (addressof -> !llvm.ptr).
+  if (value.getType() != newGlobalOp.getGlobalType()) {
+    mlir::Type originalType = newGlobalOp.getGlobalType();
+    // The split replaces the naturally-aligned array type with a packed struct
+    // (ABI alignment 1).  Pin the global's alignment to the original array's so
+    // the split never under-aligns, even if the source global omitted an
+    // explicit alignment.
+    if (!newGlobalOp.getAlignment())
+      newGlobalOp.setAlignment(dataLayout.getTypeABIAlignment(originalType));
+    newGlobalOp.setGlobalType(value.getType());
+  }
+
   mlir::LLVM::ReturnOp::create(rewriter, loc, value);
   return mlir::success();
 }
@@ -2539,6 +2753,16 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
   }
 
   if (init.has_value()) {
+    // A trailing-zero array initializer (top-level or nested in a record or
+    // array) lowers to a packed { init, zeroinitializer } split in the
+    // region-initialized path, mirroring classic CodeGen.  Route such globals
+    // straight there so the bulk fast-paths below never materialize the whole
+    // zero tail.  The split changes the global's IR type to a struct, but
+    // references address it by byte offset, so this stays parity-correct (see
+    // matchAndRewriteRegionInitializedGlobal and the GlobalViewAttr visitor).
+    if (initContainsSplittableArray(init.value()))
+      return matchAndRewriteRegionInitializedGlobal(op, init.value(), rewriter);
+
     if (mlir::isa<cir::FPAttr, cir::IntAttr, cir::BoolAttr>(init.value())) {
       GlobalInitAttrRewriter initRewriter(llvmType, rewriter);
       init = initRewriter.visit(init.value());
@@ -2552,11 +2776,11 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
       }
     } else if (auto constArr =
                    mlir::dyn_cast<cir::ConstArrayAttr>(init.value())) {
-      // Bulk-emit llvm.mlir.global when lowerConstArrayAttr can build the
-      // whole initializer as one aggregate attribute (no insertvalue
-      // region). Leaf type must match what lowerConstArrayAttr handles
-      // (pointers, integers, bools, floats, and string literals with
-      // trailing_zeros).
+      // Bulk-emit llvm.mlir.global when lowerConstArrayAttr can build the whole
+      // initializer as one aggregate attribute (no insertvalue region). Leaf
+      // type must match what lowerConstArrayAttr handles (pointers, integers,
+      // bools, floats, and string literals with trailing_zeros).  Splittable
+      // trailing-zero arrays were already routed to the region path above.
       if (isBulkLowerableConstArrayBaseElement(
               getConstArrayBaseElementType(constArr.getType()))) {
         mlir::ModuleOp modOp = op->getParentOfType<mlir::ModuleOp>();
@@ -2577,7 +2801,9 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
       // lowered to a constant attribute. The LLVM dialect global translation
       // turns an ArrayAttr (one element per struct field) into an
       // llvm::ConstantStruct, so the whole initializer becomes a single
-      // attribute on the global instead of an insertvalue region.
+      // attribute on the global instead of an insertvalue region. A record
+      // containing a splittable trailing-zero array was already routed to the
+      // region path above.
       mlir::ModuleOp modOp = op->getParentOfType<mlir::ModuleOp>();
       if (std::optional<mlir::Attribute> bulkInit =
               lowerConstRecordAttr(constRecord, typeConverter, modOp)) {
@@ -3778,6 +4004,25 @@ void ConvertCIRToLLVMPass::runOnOperation() {
   // the annotations attribute is filtered out during FuncOp/GlobalOp lowering.
   collectGlobalAnnotations(module);
 
+  // Record the original array type of every global whose trailing-zero array
+  // initializer will be split into a packed struct, so a cir.global_view can
+  // walk those (array-relative) indices even after the source global's type is
+  // rewritten and (potentially) lowered before the view.
+  {
+    llvm::SmallVector<mlir::NamedAttribute> basis;
+    for (auto globalOp : module.getOps<cir::GlobalOp>()) {
+      std::optional<mlir::Attribute> init = globalOp.getInitialValue();
+      if (init && initContainsSplittableArray(*init))
+        basis.emplace_back(
+            mlir::StringAttr::get(&getContext(), globalOp.getSymName()),
+            mlir::TypeAttr::get(
+                convertTypeForMemory(converter, dl, globalOp.getSymType())));
+    }
+    if (!basis.empty())
+      module->setAttr(tzSplitBasisAttr,
+                      mlir::DictionaryAttr::get(&getContext(), basis));
+  }
+
   mlir::ConversionTarget target(getContext());
   target.addLegalOp<mlir::ModuleOp>();
   target.addLegalDialect<mlir::LLVM::LLVMDialect>();
@@ -3793,6 +4038,10 @@ void ConvertCIRToLLVMPass::runOnOperation() {
 
   if (failed(applyPartialConversion(ops, target, std::move(patterns))))
     signalPassFailure();
+
+  // The trailing-zero split basis is lowering-internal bookkeeping; drop it so
+  // it never reaches the emitted module.
+  module->removeAttr(tzSplitBasisAttr);
 
   // Emit the llvm.global_ctors array.
   buildCtorDtorList(module, cir::CIRDialect::getGlobalCtorsAttrName(),

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -54,8 +54,7 @@ int dd[3][2] = {{1, 2}, {3, 4}, {5, 6}};
 int e[10] = {1, 2};
 // CIR: cir.global external @e = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i], trailing_zeros> : !cir.array<!s32i x 10>
 
-// FIXME: we should figure out how to lower this with a 'trailing-zeros' type thing, like classic codegen.
-// LLVM: @e = global [10 x i32] [i32 1, i32 2, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
+// LLVM: @e = global <{ i32, i32, [8 x i32] }> <{ i32 1, i32 2, [8 x i32] zeroinitializer }>
 
 // OGCG: @e = global <{ i32, i32, [8 x i32] }> <{ i32 1, i32 2, [8 x i32] zeroinitializer }>
 
@@ -74,9 +73,11 @@ int g[16] = {1, 2, 3, 4, 5, 6, 7, 8};
 // CIR-SAME:                     #cir.int<7> : !s32i, #cir.int<8> : !s32i], trailing_zeros>
 // CIR-SAME:                     : !cir.array<!s32i x 16>
 
-// LLVM:       @g = global [16 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, 
-// LLVM-SAME:                          i32 6, i32 7, i32 8, i32 0, i32 0,
-// LLVM-SAME:                          i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
+// LLVM:       @g = global <{ [8 x i32], [8 x i32] }>
+// LLVM-SAME:          <{ [8 x i32]
+// LLVM-SAME:              [i32 1, i32 2, i32 3, i32 4,
+// LLVM-SAME:               i32 5, i32 6, i32 7, i32 8],
+// LLVM-SAME:             [8 x i32] zeroinitializer }>
 
 // OGCG:       @g = global <{ [8 x i32], [8 x i32] }> 
 // OGCG-SAME:          <{ [8 x i32]
@@ -95,9 +96,11 @@ int h[16] = {1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0};
 // CIR-SAME:                     #cir.int<7> : !s32i, #cir.int<8> : !s32i], trailing_zeros>
 // CIR-SAME:                     : !cir.array<!s32i x 16>
 
-// LLVM:       @h = global [16 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, i32 6,
-// LLVM-SAME:                          i32 7, i32 8, i32 0, i32 0, i32 0, i32 0,
-// LLVM-SAME:                          i32 0, i32 0, i32 0, i32 0]
+// LLVM:       @h = global <{ [8 x i32], [8 x i32] }>
+// LLVM-SAME:          <{ [8 x i32]
+// LLVM-SAME:              [i32 1, i32 2, i32 3, i32 4,
+// LLVM-SAME:               i32 5, i32 6, i32 7, i32 8],
+// LLVM-SAME:             [8 x i32] zeroinitializer }>
 
 // OGCG:       @h = global <{ [8 x i32], [8 x i32] }>
 // OGCG-SAME:          <{ [8 x i32]

--- a/clang/test/CIR/CodeGen/const-array-trailing-zeros.c
+++ b/clang/test/CIR/CodeGen/const-array-trailing-zeros.c
@@ -1,0 +1,45 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-CIR --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefixes=LLVM,OGCG --input-file=%t.ll %s
+
+// Fewer than 8 nonzero leading elements: individual scalar fields + zero tail.
+int sparse[100] = {1, 2, 3};
+
+// Eight or more nonzero leading elements: a dense leading array field.
+int dense[100] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+// Pointer-into-array constants must stay in bounds after the split: a view into
+// the zero tail and a view into the leading init region.
+int *tail = &sparse[50];
+int *head = &sparse[2];
+
+// The split composes through a record: the nested array splits and the record
+// type follows.
+struct S {
+  int arr[100];
+};
+struct S nested = {{1, 2, 3}};
+
+// An array of such records: uniform element types keep an array.
+struct S aos[2] = {{{1, 2, 3}}, {{4, 5, 6}}};
+
+// CIR: cir.global external @sparse = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i], trailing_zeros> : !cir.array<!s32i x 100>
+// CIR: cir.global external @dense = #cir.const_array<[#cir.int<1> : !s32i, {{.*}}#cir.int<10> : !s32i], trailing_zeros> : !cir.array<!s32i x 100>
+// CIR: cir.global external @tail = #cir.global_view<@sparse, [50 : i32]> : !cir.ptr<!s32i>
+// CIR: cir.global external @head = #cir.global_view<@sparse, [2 : i32]> : !cir.ptr<!s32i>
+// CIR: cir.global external @nested = #cir.const_record<{#cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i], trailing_zeros> : !cir.array<!s32i x 100>}> : !rec_S
+// CIR: cir.global external @aos = #cir.const_array<[#cir.const_record<{{.*}}> : !cir.array<!rec_S x 2>
+
+// LLVM: @sparse = global <{ i32, i32, i32, [97 x i32] }> <{ i32 1, i32 2, i32 3, [97 x i32] zeroinitializer }>, align 16
+// LLVM: @dense = global <{ [10 x i32], [90 x i32] }> <{ [10 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10], [90 x i32] zeroinitializer }>, align 16
+
+// LLVM-CIR: @tail = global ptr getelementptr inbounds nuw (i8, ptr @sparse, i64 200), align 8
+// OGCG: @tail = global ptr getelementptr (i8, ptr @sparse, i64 200), align 8
+// LLVM-CIR: @head = global ptr getelementptr inbounds nuw (i8, ptr @sparse, i64 8), align 8
+// OGCG: @head = global ptr getelementptr (i8, ptr @sparse, i64 8), align 8
+
+// LLVM: @nested = global { <{ i32, i32, i32, [97 x i32] }> } { <{ i32, i32, i32, [97 x i32] }> <{ i32 1, i32 2, i32 3, [97 x i32] zeroinitializer }> }, align 4
+// LLVM: @aos = global [2 x { <{ i32, i32, i32, [97 x i32] }> }] [{{.*}}i32 1, i32 2, i32 3{{.*}}i32 4, i32 5, i32 6{{.*}}], align 16

--- a/clang/test/CIR/CodeGen/replace-global.cpp
+++ b/clang/test/CIR/CodeGen/replace-global.cpp
@@ -58,7 +58,7 @@ char *get_ptr_to_element() { return ptrToElement; }
 // CIR:   %[[GLOBAL_PTR:.*]] = cir.const #cir.global_view<@_ZL2gS> : !cir.ptr<!rec_S>
 // CIR:   cir.store{{.*}} %[[GLOBAL_PTR]], %[[PTR_TO_S]] : !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>
 
-// LLVM: @_ZL2gS = internal global %struct.S { [28 x i8] c"PK\03\04\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00" }, align 1
+// LLVM: @_ZL2gS = internal global { <{ i8, i8, i8, i8, [24 x i8] }> } { <{ i8, i8, i8, i8, [24 x i8] }> <{ i8 80, i8 75, i8 3, i8 4, [24 x i8] zeroinitializer }> }, align 1
 // LLVM: @ptrToS = global ptr @_ZL2gS, align 8
 // LLVM: @gSMulti = global {{.*}} align 1
 // LLVM: @ptrToElement = global ptr getelementptr

--- a/clang/test/CIR/CodeGen/string-literals.cpp
+++ b/clang/test/CIR/CodeGen/string-literals.cpp
@@ -44,7 +44,8 @@ char const *array[] {
 
 wchar_t zeroPadding[20] = L"hi";
 // CIR: cir.global external @zeroPadding = #cir.const_array<[#cir.int<104> : !u32i, #cir.int<105> : !u32i], trailing_zeros> : !cir.array<!u32i x 20> 
-// LLVM: @zeroPadding = global [20 x i32] [i32 104, i32 105, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
+// CIR splits the wide string literal's trailing zeros; classic keeps it whole.
+// LLVM: @zeroPadding = global <{ i32, i32, [18 x i32] }> <{ i32 104, i32 105, [18 x i32] zeroinitializer }>
 // OGCG: @zeroPadding = global [20 x i32] [i32 104, i32 105, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
 
 // CIR: cir.global "private" constant cir_private dso_local @[[STR5_GLOBAL:.*]] = #cir.const_array<"abcd" : !cir.array<!s8i x 4>, trailing_zeros> : !cir.array<!s8i x 5>

--- a/clang/test/CIR/CodeGen/wide-string.cpp
+++ b/clang/test/CIR/CodeGen/wide-string.cpp
@@ -6,7 +6,8 @@
 // RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 // CIR: cir.global external @some_array = #cir.const_array<[#cir.int<97> : !u16i], trailing_zeros> : !cir.array<!u16i x 10>
-// LLVM: @some_array = global [10 x i16] [i16 97, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0]
+// CIR splits the wide string literal's trailing zeros; classic keeps it whole.
+// LLVM: @some_array = global <{ i16, [9 x i16] }> <{ i16 97, [9 x i16] zeroinitializer }>
 // OGCG: @some_array = global [10 x i16] [i16 97, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0]
 char16_t some_array[10] = u"a";
 

--- a/clang/test/CIR/Lowering/array.cpp
+++ b/clang/test/CIR/Lowering/array.cpp
@@ -25,7 +25,7 @@ int dd[3][2] = {{1, 2}, {3, 4}, {5, 6}};
 // CHECK: [i32 3, i32 4], [2 x i32] [i32 5, i32 6]]
 
 int e[10] = {1, 2};
-// CHECK: @e = global [10 x i32] [i32 1, i32 2, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
+// CHECK: @e = global <{ i32, i32, [8 x i32] }> <{ i32 1, i32 2, [8 x i32] zeroinitializer }>
 
 int f[5] = {1, 2};
 // CHECK: @f = global [5 x i32] [i32 1, i32 2, i32 0, i32 0, i32 0]

--- a/clang/test/CIR/Lowering/const-array-trailing-zeros-split.cir
+++ b/clang/test/CIR/Lowering/const-array-trailing-zeros-split.cir
@@ -1,0 +1,97 @@
+// RUN: cir-opt %s --cir-to-llvm -o - | FileCheck %s
+
+!s8i = !cir.int<s, 8>
+!s32i = !cir.int<s, 32>
+!rec_S = !cir.struct<"S" {!cir.array<!s32i x 111>}>
+!rec_P = !cir.struct<"P" {!s32i, !s32i}>
+
+module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
+  // Fewer than eight nonzero elements: individual scalar fields followed by a
+  // zeroinitializer array, in a packed struct.
+  cir.global constant external @top_lt8 =
+      #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i,
+                        #cir.int<3> : !s32i], trailing_zeros>
+          : !cir.array<!s32i x 111> {alignment = 16 : i64}
+  // CHECK-LABEL: llvm.mlir.global external constant @top_lt8()
+  // CHECK-SAME:    alignment = 16
+  // CHECK-SAME:    !llvm.struct<packed (i32, i32, i32, array<108 x i32>)>
+  // CHECK:         llvm.mlir.zero : !llvm.array<108 x i32>
+  // CHECK:         llvm.return
+
+  // Eight or more nonzero elements: a single dense init array field.
+  cir.global constant external @top_ge8 =
+      #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i,
+                        #cir.int<4> : !s32i, #cir.int<5> : !s32i, #cir.int<6> : !s32i,
+                        #cir.int<7> : !s32i, #cir.int<8> : !s32i, #cir.int<9> : !s32i],
+                       trailing_zeros> : !cir.array<!s32i x 111> {alignment = 16 : i64}
+  // CHECK-LABEL: llvm.mlir.global external constant @top_ge8()
+  // CHECK-SAME:    !llvm.struct<packed (array<9 x i32>, array<102 x i32>)>
+  // CHECK:         llvm.mlir.constant(dense<[1, 2, 3, 4, 5, 6, 7, 8, 9]> : tensor<9xi32>)
+
+  // Poison among the nonzero elements (>= 8): the dense init can't be formed,
+  // so fall back to individual fields (exercises the poison-safe path).
+  cir.global constant external @top_poison =
+      #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i,
+                        #cir.int<4> : !s32i, #cir.int<5> : !s32i, #cir.int<6> : !s32i,
+                        #cir.int<7> : !s32i, #cir.poison : !s32i],
+                       trailing_zeros> : !cir.array<!s32i x 111> {alignment = 16 : i64}
+  // CHECK-LABEL: llvm.mlir.global external constant @top_poison()
+  // CHECK-SAME:    !llvm.struct<packed (i32, i32, i32, i32, i32, i32, i32, i32, array<103 x i32>)>
+  // CHECK:         llvm.mlir.poison : i32
+
+  // Record-nested array: splits too (composes through the record).  The record
+  // type follows the produced value -- an outer struct wrapping the packed
+  // { init, zeroinitializer } split, matching classic CodeGen.
+  cir.global constant external @rec =
+      #cir.const_record<{#cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i,
+                                           #cir.int<3> : !s32i], trailing_zeros>
+          : !cir.array<!s32i x 111>}> : !rec_S {alignment = 4 : i64}
+  // CHECK-LABEL: llvm.mlir.global external constant @rec()
+  // CHECK-SAME:    !llvm.struct<(struct<packed (i32, i32, i32, array<108 x i32>)>)>
+
+  // Below the threshold (fewer than eight trailing zeros): not split.
+  cir.global constant external @no_split =
+      #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i],
+                       trailing_zeros> : !cir.array<!s32i x 8> {alignment = 16 : i64}
+  // CHECK-LABEL: llvm.mlir.global external constant @no_split(dense<[1, 2, 3, 0, 0, 0, 0, 0]> : tensor<8xi32>)
+
+  // String literal with trailing zeros: stays a compact dense constant.
+  cir.global constant external @str =
+      #cir.const_array<"abc" : !cir.array<!s8i x 3>, trailing_zeros>
+          : !cir.array<!s8i x 111> {alignment = 16 : i64}
+  // CHECK-LABEL: llvm.mlir.global external constant @str(
+  // CHECK-SAME:    dense<
+
+  // Multidimensional (aggregate element): falls back to full materialization.
+  cir.global constant external @multidim =
+      #cir.const_array<[#cir.const_array<[#cir.int<1> : !s32i], trailing_zeros>
+          : !cir.array<!s32i x 4>], trailing_zeros>
+          : !cir.array<!cir.array<!s32i x 4> x 16> {alignment = 16 : i64}
+  // CHECK-LABEL: llvm.mlir.global external constant @multidim(
+  // CHECK-SAME:    dense<
+
+  // No explicit alignment on the source global: the split must not under-align
+  // (the packed struct would otherwise get ABI alignment 1).  It keeps the
+  // array's natural ABI alignment.
+  cir.global constant external @noalign =
+      #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i,
+                        #cir.int<3> : !s32i], trailing_zeros>
+          : !cir.array<!s32i x 111>
+  // CHECK-LABEL: llvm.mlir.global external constant @noalign()
+  // CHECK-SAME:    alignment = 4
+
+  // A non-split record keeps its identified struct type.
+  cir.global constant external @plain =
+      #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s32i}> : !rec_P
+  // CHECK-LABEL: llvm.mlir.global external constant @plain
+  // CHECK-SAME:    !llvm.struct<"struct.P", (i32, i32)>
+
+  // A view into a split global: its indices stay relative to the original
+  // array, so the GEP walks that array (not the packed struct) and stays in
+  // bounds.  @top_lt8 is split and defined before this view -- i.e. lowered
+  // first -- which is the case that fails if the view walks the rewritten type.
+  cir.global external @view_into =
+      #cir.global_view<@top_lt8, [50 : i32]> : !cir.ptr<!s32i>
+  // CHECK-LABEL: llvm.mlir.global external @view_into()
+  // CHECK:         llvm.getelementptr {{.*}}[0, 50] {{.*}}!llvm.array<111 x i32>
+}


### PR DESCRIPTION
Trailing-zero array constants were lowered two ways under `-fclangir`, neither matching classic. A wide-string pad such as `char16_t buf[100000] = u"hi"` reached lowering as an array-typed `cir.const_array` and was materialized in full, with every trailing zero an explicit element. A plain init-list array instead went through CIRGen's `getAnonConstRecord`, which produced classic's compact `{ <init>, zeroinitializer }` shape but as an anonymous packed record, discarding the array type and forcing an enclosing record to an anonymous struct. Classic CodeGen emits the compact split while keeping the array's type (see `EmitArrayConstant` in `CGExprConstant.cpp`).

Unify both on the AST-matching array form and split it in lowering. `emitArrayConstant` returns a `cir.const_array` with a `trailing_zeros` hint for common integer/floating-point element arrays, and the CIR-to-LLVM lowering produces the packed `{ <init>, [zeros x T] zeroinitializer }` split: the `>= 8` trailing-zero gate, and a single dense init-array field when there are at least eight leading elements, individual scalar fields otherwise (or when a non-dense element such as `poison` prevents the dense form).

The split lives in the `ConstArrayAttr` value visitor, so it composes. An array nested in a record or in another array splits too, and the enclosing record/array type follows the produced value, a literal struct that matches the anonymous struct classic emits when a member's constant layout differs. When no trailing-zero array is present the lowering is byte- and op-order-identical to before, and pointer and `_Bool` element arrays keep the `getAnonConstRecord` path, since the lowering does not split those. Multidimensional and function-local const arrays are also left unchanged.

A `cir.global_view`'s indices stay relative to the original layout after the global's type is rewritten by the split, and the source global may already be lowered when the view is processed. Each splitting global's declared type (its `symType`) is recorded on the module before conversion, and removed after, so the view walks that type; the layout is byte-identical, so the GEP stays in bounds and the address is unchanged. The emitted bytes match the materialized array, so `.data`/`.rodata` are unchanged; the win is IR text size and the compiler's transient memory. A global that carried no explicit alignment is given the original type's natural ABI alignment so the align-1 packed struct never under-aligns.

Assisted-by: Cursor / claude-opus
