### PR TITLE
[Clang] Optionally use NewPM to run CodeGen Pipeline

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -351,6 +351,7 @@ CODEGENOPT(TimeTrace         , 1, 0, Benign) ///< Set when -ftime-trace is enabl
 VALUE_CODEGENOPT(TimeTraceGranularity, 32, 500, Benign) ///< Minimum time granularity (in microseconds),
                                                         ///< traced by time profiler
 CODEGENOPT(InterchangeLoops  , 1, 0, Benign) ///< Run loop-interchange.
+CODEGENOPT(EnableNewPMCodeGen, 1, 0, Benign) ///< Use NewPM for the CodeGen pipeline.
 CODEGENOPT(FuseLoops         , 1, 0, Benign) ///< Run loop-fusion.
 CODEGENOPT(UnrollLoops       , 1, 0, Benign) ///< Control whether loops are unrolled.
 CODEGENOPT(RerollLoops       , 1, 0, Benign) ///< Control whether loops are rerolled.

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -4694,6 +4694,14 @@ def floop_interchange : Flag<["-"], "floop-interchange">, Group<f_Group>,
   HelpText<"Enable the loop interchange pass">, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>;
 def fno_loop_interchange: Flag<["-"], "fno-loop-interchange">, Group<f_Group>,
   HelpText<"Disable the loop interchange pass">, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>;
+defm enable_new_pm_codegen
+    : BoolFOption<"enable-new-pm-codegen", CodeGenOpts<"EnableNewPMCodeGen">, DefaultFalse,
+                  NegFlag<SetFalse, [], [CC1Option],
+                          "Do not use the NewPM for the Codegen Pipeline">,
+                  PosFlag<SetTrue, [], [CC1Option],
+                          "Use the NewPM for the Codegen Pipeline">>,
+      DocBrief<
+          [{When enabled, use the NewPM to drive the Codegen pipeline.}]>;
 defm experimental_loop_fusion
     : OptInCC1FFlag<"experimental-loop-fusion", "Enable", "Disable",
                     "Enable the loop fusion pass",

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -25,6 +25,7 @@
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/Bitcode/BitcodeWriterPass.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Frontend/Driver/CodeGenOptions.h"
@@ -45,6 +46,7 @@
 #include "llvm/Plugins/PassPlugin.h"
 #include "llvm/ProfileData/InstrProfCorrelator.h"
 #include "llvm/Support/BuryPointer.h"
+#include "llvm/Support/CodeGen.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/IOSandbox.h"
@@ -188,6 +190,15 @@ class EmitAssemblyHelper {
   void RunCodegenPipeline(BackendAction Action,
                           std::unique_ptr<raw_pwrite_stream> &OS,
                           std::unique_ptr<llvm::ToolOutputFile> &DwoOS);
+  void RunCodegenPipelineLegacy(BackendAction Action,
+                                std::unique_ptr<raw_pwrite_stream> &OS,
+                                std::unique_ptr<llvm::ToolOutputFile> &DwoOS,
+                                CodeGenFileType CGFT);
+  void RunCodegenPipelineNewPM(BackendAction Action,
+                               std::unique_ptr<raw_pwrite_stream> &OS,
+                               std::unique_ptr<llvm::ToolOutputFile> &DwoOS,
+                               CodeGenFileType CGFT);
+  void TimeCodegenPasses(llvm::function_ref<void()> RunPasses);
 
   /// Check whether we should emit a module summary for regular LTO.
   /// The module summary should be emitted by default for regular LTO
@@ -1230,6 +1241,22 @@ void EmitAssemblyHelper::RunCodegenPipeline(
       return;
   }
 
+  if (!CodeGenOpts.SplitDwarfOutput.empty()) {
+    DwoOS = openOutputFile(CodeGenOpts.SplitDwarfOutput);
+    if (!DwoOS)
+      return;
+  }
+
+  if (CodeGenOpts.EnableNewPMCodeGen) {
+    RunCodegenPipelineNewPM(Action, OS, DwoOS, CGFT);
+  } else {
+    RunCodegenPipelineLegacy(Action, OS, DwoOS, CGFT);
+  }
+}
+
+void EmitAssemblyHelper::RunCodegenPipelineLegacy(
+    BackendAction Action, std::unique_ptr<raw_pwrite_stream> &OS,
+    std::unique_ptr<llvm::ToolOutputFile> &DwoOS, CodeGenFileType CGFT) {
   // We still use the legacy PM to run the codegen pipeline since the new PM
   // does not work with the codegen pipeline.
   // FIXME: make the new PM work with the codegen pipeline.
@@ -1247,12 +1274,6 @@ void EmitAssemblyHelper::RunCodegenPipeline(
       TargetTriple, Options.ExceptionModel, Options.FloatABIType,
       Options.EABIVersion, Options.MCOptions.ABIName, Options.VecLib));
 
-  if (!CodeGenOpts.SplitDwarfOutput.empty()) {
-    DwoOS = openOutputFile(CodeGenOpts.SplitDwarfOutput);
-    if (!DwoOS)
-      return;
-  }
-
   if (TM->addPassesToEmitFile(CodeGenPasses, *OS,
                               DwoOS ? &DwoOS->os() : nullptr, CGFT,
                               /*DisableVerify=*/!CodeGenOpts.VerifyModule)) {
@@ -1267,18 +1288,57 @@ void EmitAssemblyHelper::RunCodegenPipeline(
     return;
   }
 
-  {
-    PrettyStackTraceString CrashInfo("Code generation");
-    llvm::TimeTraceScope TimeScope("CodeGenPasses");
-    Timer timer;
-    if (CI.getCodeGenOpts().TimePasses) {
-      timer.init("codegen", "Machine code generation", CI.getTimerGroup());
-      CI.getFrontendTimer().yieldTo(timer);
-    }
-    CodeGenPasses.run(*TheModule);
-    if (CI.getCodeGenOpts().TimePasses)
-      timer.yieldTo(CI.getFrontendTimer());
+  TimeCodegenPasses([&] { CodeGenPasses.run(*TheModule); });
+}
+
+void EmitAssemblyHelper::RunCodegenPipelineNewPM(
+    BackendAction Action, std::unique_ptr<raw_pwrite_stream> &OS,
+    std::unique_ptr<llvm::ToolOutputFile> &DwoOS, CodeGenFileType CGFT) {
+  ModulePassManager MPM;
+  MachineFunctionAnalysisManager MFAM;
+  LoopAnalysisManager LAM;
+  FunctionAnalysisManager FAM;
+  CGSCCAnalysisManager CGAM;
+  ModuleAnalysisManager MAM;
+  CGPassBuilderOption Opt = getCGPassBuilderOption();
+  MachineModuleInfo MMI(TM.get());
+  PassInstrumentationCallbacks PIC;
+  PipelineTuningOptions PTOptions;
+  TargetMachine *TMPointer = TM.get();
+  PassBuilder PB(TMPointer, PTOptions, std::nullopt, &PIC,
+                 CI.getVirtualFileSystemPtr());
+  PB.registerModuleAnalyses(MAM);
+  PB.registerCGSCCAnalyses(CGAM);
+  PB.registerFunctionAnalyses(FAM);
+  PB.registerLoopAnalyses(LAM);
+  PB.registerMachineFunctionAnalyses(MFAM);
+  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM, &MFAM);
+
+  MAM.registerPass([&] { return MachineModuleAnalysis(MMI); });
+
+  Error BuildPipelineError =
+      TM->buildCodeGenPipeline(MPM, MAM, *OS, DwoOS ? &DwoOS->os() : nullptr,
+                               CGFT, Opt, MMI.getContext(), &PIC);
+  if (BuildPipelineError) {
+    Diags.Report(diag::err_fe_unable_to_interface_with_target);
+    return;
   }
+
+  TimeCodegenPasses([&] { MPM.run(*TheModule, MAM); });
+}
+
+void EmitAssemblyHelper::TimeCodegenPasses(
+    llvm::function_ref<void()> RunPasses) {
+  PrettyStackTraceString CrashInfo("Code generation");
+  llvm::TimeTraceScope TimeScope("CodeGenPasses");
+  Timer timer;
+  if (CI.getCodeGenOpts().TimePasses) {
+    timer.init("codegen", "Machine code generation", CI.getTimerGroup());
+    CI.getFrontendTimer().yieldTo(timer);
+  }
+  RunPasses();
+  if (CI.getCodeGenOpts().TimePasses)
+    timer.yieldTo(CI.getFrontendTimer());
 }
 
 void EmitAssemblyHelper::emitAssembly(BackendAction Action,

--- a/clang/test/CodeGen/X86/newpm.c
+++ b/clang/test/CodeGen/X86/newpm.c
@@ -1,0 +1,9 @@
+// REQUIRES: x86-registered-target
+// RUN: %clang_cc1 -triple=x86_64-unkown-linux-gnu -fenable-new-pm-codegen -S -o - %s | FileCheck %s
+
+int foo() {
+  // CHECK-LABEL: foo
+  // CHECK: xorl
+  // CHECK: retq
+  return 0;
+}


### PR DESCRIPTION
This patch adds a new -cc1 option to clang that runs the codegen pipeline using the NewPM. This enables easy testing of this flow through clang.

Lands #191579 actually, because that PR I accidentally landed into a user branch.