### PR TITLE
[lldb] Condense formatter output for null smart pointers

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -1056,6 +1056,7 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
                 "^std::__[[:alnum:]]+::span<.+>$", stl_summary_flags, true);
 
   stl_summary_flags.SetSkipPointers(true);
+  stl_summary_flags.SetHideEmptyAggregates(true);
 
   AddCXXSummary(cpp_category_sp,
                 lldb_private::formatters::LibcxxSmartPointerSummaryProvider,
@@ -1877,15 +1878,19 @@ static void LoadCommonStlFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
   AddCXXSummary(cpp_category_sp, ContainerSizeSummaryProvider,
                 "std::initializer_list summary provider",
                 "^std::initializer_list<.+>$", stl_summary_flags, true);
+
+  TypeSummaryImpl::Flags stl_smart_pointer_flags = stl_summary_flags;
+  stl_smart_pointer_flags.SetHideEmptyAggregates(true);
   AddCXXSummary(cpp_category_sp, GenericSmartPointerSummaryProvider,
                 "MSVC STL/libstdc++ std::shared_ptr summary provider",
-                "^std::shared_ptr<.+>(( )?&)?$", stl_summary_flags, true);
+                "^std::shared_ptr<.+>(( )?&)?$", stl_smart_pointer_flags, true);
   AddCXXSummary(cpp_category_sp, GenericSmartPointerSummaryProvider,
                 "MSVC STL/libstdc++ std::weak_ptr summary provider",
-                "^std::weak_ptr<.+>(( )?&)?$", stl_summary_flags, true);
+                "^std::weak_ptr<.+>(( )?&)?$", stl_smart_pointer_flags, true);
   AddCXXSummary(cpp_category_sp, GenericUniquePtrSummaryProvider,
                 "MSVC STL/libstdc++ std::unique_ptr summary provider",
-                "^std::unique_ptr<.+>(( )?&)?$", stl_summary_flags, true);
+                "^std::unique_ptr<.+>(( )?&)?$", stl_smart_pointer_flags, true);
+
   AddCXXSummary(cpp_category_sp, ContainerSizeSummaryProvider,
                 "MSVC STL/libstdc++ std::tuple summary provider",
                 "^std::tuple<.*>(( )?&)?$", stl_summary_flags, true);

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -350,10 +350,8 @@ lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
 
 llvm::Expected<uint32_t> lldb_private::formatters::
     LibcxxSharedPtrSyntheticFrontEnd::CalculateNumChildren() {
-  if (m_cntrl) {
-    if (m_ptr_obj && m_ptr_obj->GetValueAsUnsigned(0) != 0)
-      return 1;
-  }
+  if (m_cntrl && m_ptr_obj && m_ptr_obj->GetValueAsUnsigned(0) != 0)
+    return 1;
   return 0;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -350,7 +350,11 @@ lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::
 
 llvm::Expected<uint32_t> lldb_private::formatters::
     LibcxxSharedPtrSyntheticFrontEnd::CalculateNumChildren() {
-  return (m_cntrl ? 1 : 0);
+  if (m_cntrl) {
+    if (m_ptr_obj && m_ptr_obj->GetValueAsUnsigned(0) != 0)
+      return 1;
+  }
+  return 0;
 }
 
 lldb::ValueObjectSP
@@ -447,7 +451,7 @@ lldb_private::formatters::LibcxxUniquePtrSyntheticFrontEndCreator(
 
 llvm::Expected<uint32_t> lldb_private::formatters::
     LibcxxUniquePtrSyntheticFrontEnd::CalculateNumChildren() {
-  if (m_value_ptr_sp)
+  if (m_value_ptr_sp && m_value_ptr_sp->GetValueAsUnsigned(0) != 0)
     return m_deleter_sp ? 2 : 1;
   return 0;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -339,7 +339,9 @@ LibStdcppSharedPtrSyntheticFrontEnd::LibStdcppSharedPtrSyntheticFrontEnd(
 
 llvm::Expected<uint32_t>
 LibStdcppSharedPtrSyntheticFrontEnd::CalculateNumChildren() {
-  return 1;
+  if (m_ptr_obj && m_ptr_obj->GetValueAsUnsigned(0) != 0)
+    return 1;
+  return 0;
 }
 
 lldb::ValueObjectSP

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
@@ -133,9 +133,9 @@ LibStdcppUniquePtrSyntheticFrontEnd::GetChildAtIndex(uint32_t idx) {
 
 llvm::Expected<uint32_t>
 LibStdcppUniquePtrSyntheticFrontEnd::CalculateNumChildren() {
-  if (m_del_obj)
-    return 2;
-  return 1;
+  if (m_ptr_obj && m_ptr_obj->GetValueAsUnsigned(0) != 0)
+    return m_del_obj ? 2 : 1;
+  return 0;
 }
 
 llvm::Expected<size_t>

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
@@ -114,7 +114,9 @@ lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEnd::
 
 llvm::Expected<uint32_t> lldb_private::formatters::
     MsvcStlSmartPointerSyntheticFrontEnd::CalculateNumChildren() {
-  return (m_ptr_obj ? 1 : 0);
+  if (m_ptr_obj && m_ptr_obj->GetValueAsUnsigned(0) != 0)
+    return 1;
+  return 0;
 }
 
 lldb::ValueObjectSP
@@ -213,7 +215,7 @@ lldb_private::formatters::MsvcStlUniquePtrSyntheticFrontEnd::
 
 llvm::Expected<uint32_t> lldb_private::formatters::
     MsvcStlUniquePtrSyntheticFrontEnd::CalculateNumChildren() {
-  if (m_value_ptr_sp)
+  if (m_value_ptr_sp && m_value_ptr_sp->GetValueAsUnsigned(0) != 0)
     return m_deleter_sp ? 2 : 1;
   return 0;
 }

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
@@ -24,11 +24,9 @@ class TestCase(TestBase):
             summary="nullptr",
         )
         self.assertEqual(valobj.GetNumChildren(), 0)
+        self.assertEqual(valobj.GetIndexOfChildWithName("pointer"), 0)
         self.assertEqual(
             valobj.member["pointer"].GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
-        )
-        self.assertEqual(
-            valobj.GetChildAtIndex(0).GetID(), valobj.member["pointer"].GetID()
         )
 
         # Null shared_ptr should not output braces.

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
@@ -22,11 +22,14 @@ class TestCase(TestBase):
             "sp_empty",
             type="std::shared_ptr<int>",
             summary="nullptr",
-            children=[ValueCheck(name="pointer")],
         )
+        self.assertEqual(valobj.GetNumChildren(), 0)
         self.assertEqual(
             valobj.child[0].GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
         )
+
+        # Null shared_ptr should not output braces.
+        self.expect("frame variable sp_empty", patterns=[" = nullptr$"])
 
         self.expect(
             "frame variable *sp_empty", substrs=["(int) *sp_empty = <parent is NULL>"]
@@ -106,9 +109,11 @@ class TestCase(TestBase):
         valobj = self.expect_var_path(
             "sie", type="std::shared_ptr<int>", summary="nullptr strong=2 weak=2"
         )
+        self.assertEqual(valobj.GetNumChildren(), 0)
         valobj = self.expect_var_path(
             "wie", type="std::weak_ptr<int>", summary="nullptr strong=2 weak=2"
         )
+        self.assertEqual(valobj.GetNumChildren(), 0)
 
         self.expect_var_path("si.pointer", type="int *")
         self.expect_var_path("*si.pointer", type="int", value="47")

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
@@ -25,7 +25,7 @@ class TestCase(TestBase):
         )
         self.assertEqual(valobj.GetNumChildren(), 0)
         self.assertEqual(
-            valobj.GetChildAtIndex(0).GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
+            valobj.member["pointer"].GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
         )
         self.assertEqual(
             valobj.GetChildAtIndex(0).GetID(), valobj.member["pointer"].GetID()

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
@@ -27,6 +27,7 @@ class TestCase(TestBase):
         self.assertEqual(
             valobj.child[0].GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
         )
+        self.assertEqual(valobj.child[0].GetID(), valobj.member["pointer"].GetID())
 
         # Null shared_ptr should not output braces.
         self.expect("frame variable sp_empty", patterns=[" = nullptr$"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
@@ -25,9 +25,11 @@ class TestCase(TestBase):
         )
         self.assertEqual(valobj.GetNumChildren(), 0)
         self.assertEqual(
-            valobj.child[0].GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
+            valobj.GetChildAtIndex(0).GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
         )
-        self.assertEqual(valobj.child[0].GetID(), valobj.member["pointer"].GetID())
+        self.assertEqual(
+            valobj.GetChildAtIndex(0).GetID(), valobj.member["pointer"].GetID()
+        )
 
         # Null shared_ptr should not output braces.
         self.expect("frame variable sp_empty", patterns=[" = nullptr$"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
@@ -24,11 +24,9 @@ class TestCase(TestBase):
             summary="nullptr",
         )
         self.assertEqual(valobj.GetNumChildren(), 0)
+        self.assertEqual(valobj.GetIndexOfChildWithName("pointer"), 0)
         self.assertEqual(
             valobj.member["pointer"].GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
-        )
-        self.assertEqual(
-            valobj.GetChildAtIndex(0).GetID(), valobj.member["pointer"].GetID()
         )
 
         # Null unique_ptr should not output braces.

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
@@ -25,9 +25,11 @@ class TestCase(TestBase):
         )
         self.assertEqual(valobj.GetNumChildren(), 0)
         self.assertEqual(
-            valobj.child[0].GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
+            valobj.GetChildAtIndex(0).GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
         )
-        self.assertEqual(valobj.child[0].GetID(), valobj.member["pointer"].GetID())
+        self.assertEqual(
+            valobj.GetChildAtIndex(0).GetID(), valobj.member["pointer"].GetID()
+        )
 
         # Null unique_ptr should not output braces.
         self.expect("frame variable up_empty", patterns=[" = nullptr$"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
@@ -27,6 +27,7 @@ class TestCase(TestBase):
         self.assertEqual(
             valobj.child[0].GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
         )
+        self.assertEqual(valobj.child[0].GetID(), valobj.member["pointer"].GetID())
 
         # Null unique_ptr should not output braces.
         self.expect("frame variable up_empty", patterns=[" = nullptr$"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
@@ -22,11 +22,14 @@ class TestCase(TestBase):
         valobj = self.expect_var_path(
             "up_empty",
             summary="nullptr",
-            children=[ValueCheck(name="pointer")],
         )
+        self.assertEqual(valobj.GetNumChildren(), 0)
         self.assertEqual(
             valobj.child[0].GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
         )
+
+        # Null unique_ptr should not output braces.
+        self.expect("frame variable up_empty", patterns=[" = nullptr$"])
 
         self.expect(
             "frame variable *up_empty", substrs=["(int) *up_empty = <parent is NULL>"]

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
@@ -25,7 +25,7 @@ class TestCase(TestBase):
         )
         self.assertEqual(valobj.GetNumChildren(), 0)
         self.assertEqual(
-            valobj.GetChildAtIndex(0).GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
+            valobj.member["pointer"].GetValueAsUnsigned(lldb.LLDB_INVALID_ADDRESS), 0
         )
         self.assertEqual(
             valobj.GetChildAtIndex(0).GetID(), valobj.member["pointer"].GetID()


### PR DESCRIPTION
Elide output of the "pointer" child of smart pointers when the value is null. This avoids redudant output, which can add up when printing large data types with many smart pointers. The `pointer` child remains accessible by name and by index.

Prior to this change, a nullptr value would be printed like so:

```
(lldb) p name
(std::shared_ptr<std::string>) nullptr {
  pointer = nullptr
}
```

With this change, the braced output is eliminated, leaving:

```
(lldb) p name
(std::shared_ptr<std::string>) nullptr
(lldb) p name.pointer
(std::string *) nullptr
```

Assisted-by: claude