### PR TITLE
[clang-format] Add Wrapped option for merging short function body

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -2006,6 +2006,7 @@ the configuration (without a prefix: ``Auto``).
       Empty: false
       Inline: true
       Other: false
+      Wrapped: true
 
   * ``bool Empty`` Merge top-level empty functions.
 
@@ -2040,6 +2041,17 @@ the configuration (without a prefix: ``Auto``).
         void f() { foo(); }
       };
       void f() { bar(); }
+
+  * ``bool Wrapped`` Merge function bodies if the brace is wrapped.
+
+    .. code-block:: c++
+
+      void f()
+      {}
+      void f2()
+      { bar2(); }
+      void f3()
+      { /* comment */ }
 
 
 .. _AllowShortIfStatementsOnASingleLine:

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -1051,6 +1051,8 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
   enum assignments without affecting other assignments.
 - Add `BreakBeforeReturnType` option to break before the function return
   type.
+- Add `Wrapped` option to `AllowShortFunctionsOnASingleLine,` for allowing
+  control over merging short function bodies after a wrapped opening brace.
 
 ### libclang
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -894,6 +894,7 @@ struct FormatStyle {
   ///     Empty: false
   ///     Inline: true
   ///     Other: false
+  ///     Wrapped: true
   /// \endcode
   struct ShortFunctionStyle {
     /// Merge top-level empty functions.
@@ -927,26 +928,38 @@ struct FormatStyle {
     ///   void f() { bar(); }
     /// \endcode
     bool Other;
+    /// Merge function bodies if the brace is wrapped.
+    /// \code
+    ///   void f()
+    ///   {}
+    ///   void f2()
+    ///   { bar2(); }
+    ///   void f3()
+    ///   { /* comment */ }
+    /// \endcode
+    bool Wrapped;
 
     bool operator==(const ShortFunctionStyle &R) const {
-      return Empty == R.Empty && Inline == R.Inline && Other == R.Other;
+      return Empty == R.Empty && Inline == R.Inline && Other == R.Other &&
+             Wrapped == R.Wrapped;
     }
     bool operator!=(const ShortFunctionStyle &R) const { return !(*this == R); }
-    ShortFunctionStyle() : Empty(false), Inline(false), Other(false) {}
-    ShortFunctionStyle(bool Empty, bool Inline, bool Other)
-        : Empty(Empty), Inline(Inline), Other(Other) {}
+    ShortFunctionStyle()
+        : Empty(false), Inline(false), Other(false), Wrapped(false) {}
+    ShortFunctionStyle(bool Empty, bool Inline, bool Other, bool Wrapped)
+        : Empty(Empty), Inline(Inline), Other(Other), Wrapped(Wrapped) {}
     bool isAll() const { return Empty && Inline && Other; }
     static ShortFunctionStyle setEmptyOnly() {
-      return ShortFunctionStyle(true, false, false);
+      return ShortFunctionStyle(true, false, false, false);
     }
     static ShortFunctionStyle setEmptyAndInline() {
-      return ShortFunctionStyle(true, true, false);
+      return ShortFunctionStyle(true, true, false, false);
     }
     static ShortFunctionStyle setInlineOnly() {
-      return ShortFunctionStyle(false, true, false);
+      return ShortFunctionStyle(false, true, false, false);
     }
     static ShortFunctionStyle setAll() {
-      return ShortFunctionStyle(true, true, true);
+      return ShortFunctionStyle(true, true, true, false);
     }
   };
 

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -801,6 +801,7 @@ template <> struct MappingTraits<FormatStyle::ShortFunctionStyle> {
     IO.mapOptional("Empty", Value.Empty);
     IO.mapOptional("Inline", Value.Inline);
     IO.mapOptional("Other", Value.Other);
+    IO.mapOptional("Wrapped", Value.Wrapped);
   }
 };
 

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -314,14 +314,9 @@ private:
       }
     }
 
-    auto ShouldMergeShortFunctions = [&] {
+    auto ShouldMergeShortFunctions = [&](auto *LBrace, auto *NextLineFirst) {
       if (Style.AllowShortFunctionsOnASingleLine.isAll())
         return true;
-
-      if (Style.AllowShortFunctionsOnASingleLine.Empty &&
-          NextLine.First->is(tok::r_brace)) {
-        return true;
-      }
 
       if (Style.AllowShortFunctionsOnASingleLine.Inline &&
           !Style.AllowShortFunctionsOnASingleLine.Other) {
@@ -364,10 +359,14 @@ private:
         }
       }
 
-      return false;
-    };
+      assert(LBrace->is(TT_FunctionLBrace));
+      if ((NextLineFirst && NextLineFirst->is(tok::r_brace)) ||
+          (LBrace->Next && LBrace->Next->is(tok::r_brace))) {
+        return Style.AllowShortFunctionsOnASingleLine.Empty;
+      }
 
-    bool MergeShortFunctions = ShouldMergeShortFunctions();
+      return Style.AllowShortFunctionsOnASingleLine.Other;
+    };
 
     const auto *FirstNonComment = TheLine->getFirstNonComment();
     if (!FirstNonComment)
@@ -437,7 +436,9 @@ private:
     // Try to merge a function block with left brace unwrapped.
     if (LastNonComment->is(TT_FunctionLBrace) &&
         TheLine->First != LastNonComment) {
-      return MergeShortFunctions ? tryMergeSimpleBlock(I, E, Limit) : 0;
+      return ShouldMergeShortFunctions(LastNonComment, NextLine.First)
+                 ? tryMergeSimpleBlock(I, E, Limit)
+                 : 0;
     }
 
     // Try to merge a control statement block with left brace unwrapped.
@@ -545,7 +546,8 @@ private:
       Limit -= 2;
 
       unsigned MergedLines = 0;
-      if (MergeShortFunctions ||
+      if (ShouldMergeShortFunctions(NextLine.First,
+                                    I + 2 != E ? I[2]->First : nullptr) ||
           (Style.AllowShortFunctionsOnASingleLine.Empty &&
            NextLine.First == NextLine.Last && I + 2 != E &&
            I[2]->First->is(tok::r_brace))) {

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -268,7 +268,7 @@ private:
       const bool EmptyFunctionBody = NextLine.First->is(tok::r_brace);
       if ((EmptyFunctionBody && !Style.BraceWrapping.SplitEmptyFunction) ||
           (!EmptyFunctionBody &&
-           Style.AllowShortBlocksOnASingleLine == FormatStyle::SBS_Always)) {
+           Style.AllowShortFunctionsOnASingleLine.Wrapped)) {
         return tryMergeSimpleBlock(I, E, Limit);
       }
     }

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -235,6 +235,7 @@ TEST(ConfigParseTest, ParsesConfigurationBools) {
   CHECK_PARSE_NESTED_BOOL(AllowShortFunctionsOnASingleLine, Empty);
   CHECK_PARSE_NESTED_BOOL(AllowShortFunctionsOnASingleLine, Inline);
   CHECK_PARSE_NESTED_BOOL(AllowShortFunctionsOnASingleLine, Other);
+  CHECK_PARSE_NESTED_BOOL(AllowShortFunctionsOnASingleLine, Wrapped);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, AfterCaseLabel);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, AfterClass);
   CHECK_PARSE_NESTED_BOOL(BraceWrapping, AfterEnum);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -15587,6 +15587,21 @@ TEST_F(FormatTest, MergeShortFunctionBody) {
   verifyFormat("int foo()\n"
                "{ return 1; }",
                Style);
+
+  Style.AllowShortFunctionsOnASingleLine.Other = true;
+  verifyFormat("int foo() { return 1; }", Style);
+  verifyFormat("int foo()\n"
+               "{\n"
+               "}",
+               Style);
+
+  Style.BraceWrapping.SplitEmptyFunction = false;
+  verifyFormat("int foo()\n"
+               "{}",
+               Style);
+
+  Style.AllowShortFunctionsOnASingleLine.Empty = true;
+  verifyFormat("int foo() {}", Style);
 }
 
 TEST_F(FormatTest, KeepShortFunctionAfterPPElse) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -15578,6 +15578,13 @@ TEST_F(FormatTest, MergeShortFunctionBody) {
   Style.BraceWrapping.AfterFunction = true;
 
   verifyFormat("int foo()\n"
+               "{\n"
+               "  return 1;\n"
+               "}",
+               Style);
+
+  Style.AllowShortFunctionsOnASingleLine.Wrapped = true;
+  verifyFormat("int foo()\n"
                "{ return 1; }",
                Style);
 }


### PR DESCRIPTION
Add a new style suboption `Wrapped` to `AllowShortFunctionsOnASingleLine` that enables merging short function bodies if the opening brace was wrapped. 

This option is off by default, and the only way to turn it on currently is  to explicitly set `Wrapped: true` as a nested configuration flag.

While writing tests for the new suboption, I discovered that `AllowShortFunctionsOnASingleLine.Other` only works if `AllowShortFunctionsOnASingleLine.Empty` is also set. I fixed that also.

Fixes #183705 #187993 #206144

Updates #145161