### PR TITLE
[RISCV] Ignore Tune Features for Inlining

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1875,18 +1875,21 @@ def HasCheriot
 
 class RISCVTuneFeature<string name, string pos_directive, string neg_directive,
                        string field_name, string value, string description,
-                       list<RISCVTuneFeature> implied_features = []>
+                       list<RISCVTuneFeature> implied_features = [],
+                       InlineBehavior ib = InlineIgnore>
     : SubtargetFeature<name, field_name, value, description> {
   let Implies = implied_features;
+  let InlineBehavior = ib;
 
   string PositiveDirectiveName = pos_directive;
   string NegativeDirectiveName = neg_directive;
 }
 class RISCVSimpleTuneFeature<string name, string field_name, string value,
                              string description,
-                             list<RISCVTuneFeature> implied_features = []>
+                             list<RISCVTuneFeature> implied_features = [],
+                             InlineBehavior ib = InlineIgnore>
     : RISCVTuneFeature<name, name, "no-"#name, field_name, value, description,
-                       implied_features>;
+                       implied_features, ib>;
 
 // Feature32Bit exists to mark CPUs that support RV32 to distinguish them from
 // tuning CPU names.
@@ -1976,7 +1979,8 @@ def FeatureTaggedGlobals : SubtargetFeature<"tagged-globals",
 
 def TuneNLogNVRGather
    : SubtargetFeature<"log-vrgather", "RISCVVRGatherCostModel", "NLog2N",
-                      "Has vrgather.vv with LMUL*log2(LMUL) latency">;
+                      "Has vrgather.vv with LMUL*log2(LMUL) latency", [],
+                      InlineIgnore>;
 
 def TunePostRAScheduler
     : RISCVSimpleTuneFeature<"use-postra-scheduler", "UsePostRAScheduler",
@@ -2020,7 +2024,7 @@ def TuneDisableLatencySchedHeuristic
 
 def TuneEnableVsetvliSchedHeuristic
     : SubtargetFeature<"enable-vsetvli-sched-heuristic", "EnableVsetvliSchedHeuristic", "true",
-                       "Enable vsetvli-based scheduling heuristic">;
+                       "Enable vsetvli-based scheduling heuristic", [], InlineIgnore>;
 
 def TunePredictableSelectIsExpensive
     : RISCVSimpleTuneFeature<"predictable-select-expensive",
@@ -2030,24 +2034,26 @@ def TunePredictableSelectIsExpensive
 def TuneOptimizedZeroStrideLoad
    : SubtargetFeature<"optimized-zero-stride-load", "HasOptimizedZeroStrideLoad",
                       "true", "Optimized (perform fewer memory operations)"
-                      "zero-stride vector load">;
+                      "zero-stride vector load", [], InlineIgnore>;
 
 def TuneEnableSelectOptimize
     : SubtargetFeature<"enable-select-opt", "EnableSelectOptimize", "true",
-                       "Enable the select optimize pass for select loop heuristics">;
+                       "Enable the select optimize pass for select loop heuristics",
+                       [], InlineIgnore>;
 
 foreach nf = {2-8} in
   def TuneOptimizedNF#nf#SegmentLoadStore :
       SubtargetFeature<"optimized-nf"#nf#"-segment-load-store",
                        "HasOptimizedNF"#nf#"SegmentLoadStore",
                        "true", "vlseg"#nf#"eN.v and vsseg"#nf#"eN.v are "
-                       "implemented as a wide memory op and shuffle">;
+                       "implemented as a wide memory op and shuffle",
+                       [], InlineIgnore>;
 
 def TuneVLDependentLatency
     : RISCVSimpleTuneFeature<
           "vl-dependent-latency", "HasVLDependentLatency", "true",
           "Latency of vector instructions is dependent on the "
-          "dynamic value of vl">;
+          "dynamic value of vl", [], InlineIgnore>;
 
 def Experimental
    : SubtargetFeature<"experimental", "HasExperimental",
@@ -2058,7 +2064,8 @@ def Experimental
 // that can be done in parallel.
 def TuneDLenFactor2
    : SubtargetFeature<"dlen-factor-2", "DLenFactor2", "true",
-                      "Vector unit DLEN(data path width) is half of VLEN">;
+                      "Vector unit DLEN(data path width) is half of VLEN",
+                      [], InlineIgnore>;
 
 def TuneNoDefaultUnroll
     : RISCVTuneFeature<"no-default-unroll", "no-default-unroll",
@@ -2116,9 +2123,9 @@ def TuneShortForwardBranchILoad
 def HasShortForwardBranchILoad : Predicate<"Subtarget->hasShortForwardBranchILoad()">;
 
 def TuneShortForwardBranchImm
-    : SubtargetFeature<"short-forward-branch-imm", "HasShortForwardBranchImm",
-                       "true", "Enable short forward branch optimization for branches with immediates",
-                       [TuneShortForwardBranchIALU]>;
+    : RISCVSimpleTuneFeature<"short-forward-branch-imm", "HasShortForwardBranchImm",
+                             "true", "Enable short forward branch optimization for branches with immediates",
+                             [TuneShortForwardBranchIALU]>;
 def HasShortForwardBranchImm : Predicate<"Subtarget->hasShortForwardBranchImm()">;
 def NoShortForwardBranchImm : Predicate<"!Subtarget->hasShortForwardBranchImm()">;
 
@@ -2168,14 +2175,15 @@ def TunePreferVsetvliOverReadVLENB
 //===----------------------------------------------------------------------===//
 
 def TuneAndes45 : SubtargetFeature<"andes45", "RISCVProcFamily", "Andes45",
-                                   "Andes 45-Series processors">;
+                                   "Andes 45-Series processors", [], InlineIgnore>;
 
 def TuneMIPSP8700
     : SubtargetFeature<"mips-p8700", "RISCVProcFamily", "MIPSP8700",
-                       "MIPS p8700 processor">;
+                       "MIPS p8700 processor", [], InlineIgnore>;
 
 def TuneSiFive7 : SubtargetFeature<"sifive7", "RISCVProcFamily", "SiFive7",
-                                   "SiFive 7-Series processors">;
+                                   "SiFive 7-Series processors", [], InlineIgnore>;
 
 def TuneVentanaVeyron : SubtargetFeature<"ventana-veyron", "RISCVProcFamily", "VentanaVeyron",
-                                         "Ventana Veyron-Series processors">;
+                                         "Ventana Veyron-Series processors",
+                                         [], InlineIgnore>;

--- a/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVTargetParserTest.cpp
@@ -109,7 +109,7 @@ TEST(RISCVTuneFeature, AllTuneFeatures) {
   RISCV::getAllTuneFeatures(AllTuneFeatures);
   // Only allowed subtarget features that are explicitly marked by
   // special TableGen class.
-  EXPECT_EQ(AllTuneFeatures.size(), 20U);
+  EXPECT_EQ(AllTuneFeatures.size(), 21U);
   for (auto F : {"conditional-cmv-fusion",
                  "disable-latency-sched-heuristic",
                  "disable-misched-load-clustering",
@@ -128,6 +128,7 @@ TEST(RISCVTuneFeature, AllTuneFeatures) {
                  "short-forward-branch-iminmax",
                  "short-forward-branch-imul",
                  "short-forward-branch-iload",
+                 "short-forward-branch-imm",
                  "vl-dependent-latency",
                  "vxrm-pipeline-flush"})
     EXPECT_TRUE(is_contained(AllTuneFeatures, F));


### PR DESCRIPTION
Using the new InlineBehavior field of SubtargetFeature, ensure that RISC-V's tuning related features do not prevent inlining.

Architecture features still prevent inlining.