### PR TITLE
[llvm] produce a more consistent estimates of bit width needed when parsing an integer

### DIFF
--- a/llvm/lib/Support/StringRef.cpp
+++ b/llvm/lib/Support/StringRef.cpp
@@ -522,12 +522,35 @@ bool StringRef::consumeInteger(unsigned Radix, APInt &Result) {
     return false;
   }
 
-  // (Over-)estimate the required number of bits.
+  // The string is too long to be reasonable
+  if (Str.size() > std::numeric_limits<unsigned>::max())
+    return true;
+
   unsigned Log2Radix = 0;
   while ((1U << Log2Radix) < Radix) Log2Radix++;
   bool IsPowerOf2Radix = ((1U << Log2Radix) == Radix);
 
-  unsigned BitWidth = Log2Radix * Str.size();
+  // Estimate the required number of bits using a Q10 fixed-point
+  // approximation of log2(Radix) to avoid over-allocation. For radices in
+  // the supported range, the table ensures the overstimation is at most 1
+  // bit.
+  //
+  // Radix is guaranteed by the above assertion to be in the range [2, 36].
+  uint64_t EstimatedWidth = 0;
+  static const uint16_t Log2RadixTable[] = {
+      0,    0,    1024, 1624, 2048, 2378, 2648, 2875, 3072, 3247, 3402, // 2..10
+      3543, 3672, 3790, 3899, 4001, 4096, 4186, 4271, 4350, // 11..19
+      4426, 4498, 4567, 4633, 4696, 4756, 4814, 4870, 4923, // 20..28
+      4975, 5025, 5074, 5120, 5166, 5210, 5253, 5295        // 29..36
+  };
+  EstimatedWidth =
+      (static_cast<uint64_t>(Str.size()) * Log2RadixTable[Radix] + 1023) >> 10;
+
+  // For a 32-bit system, this would err at ~1.29B digits, or about 1.2GiB
+  if (EstimatedWidth > std::numeric_limits<unsigned>::max())
+    return true;
+
+  unsigned BitWidth = static_cast<unsigned>(EstimatedWidth);
   if (BitWidth < Result.getBitWidth())
     BitWidth = Result.getBitWidth(); // don't shrink the result
   else if (BitWidth > Result.getBitWidth())

--- a/llvm/lib/Support/StringRef.cpp
+++ b/llvm/lib/Support/StringRef.cpp
@@ -522,39 +522,17 @@ bool StringRef::consumeInteger(unsigned Radix, APInt &Result) {
     return false;
   }
 
-  // The string is too long to be reasonable
-  if (Str.size() > std::numeric_limits<unsigned>::max())
-    return true;
-
   unsigned Log2Radix = 0;
   while ((1U << Log2Radix) < Radix) Log2Radix++;
   bool IsPowerOf2Radix = ((1U << Log2Radix) == Radix);
 
-  // Estimate the required number of bits using a Q10 fixed-point
-  // approximation of log2(Radix) to avoid over-allocation. For radices in
-  // the supported range, the table ensures the overstimation is at most 1
-  // bit.
-  //
-  // Radix is guaranteed by the above assertion to be in the range [2, 36].
-  uint64_t EstimatedWidth = 0;
-  static const uint16_t Log2RadixTable[] = {
-      0,    0,    1024, 1624, 2048, 2378, 2648, 2875, 3072, 3247, 3402, // 2..10
-      3543, 3672, 3790, 3899, 4001, 4096, 4186, 4271, 4350, // 11..19
-      4426, 4498, 4567, 4633, 4696, 4756, 4814, 4870, 4923, // 20..28
-      4975, 5025, 5074, 5120, 5166, 5210, 5253, 5295        // 29..36
-  };
-  EstimatedWidth =
-      (static_cast<uint64_t>(Str.size()) * Log2RadixTable[Radix] + 1023) >> 10;
+  // Initialize Result to a reasonable starting width (at least 64 bits),
+  // but do not shrink it if it was already larger.
+  unsigned BitWidth = std::max(64U, Result.getBitWidth());
 
-  // For a 32-bit system, this would err at ~1.29B digits, or about 1.2GiB
-  if (EstimatedWidth > std::numeric_limits<unsigned>::max())
-    return true;
-
-  unsigned BitWidth = static_cast<unsigned>(EstimatedWidth);
-  if (BitWidth < Result.getBitWidth())
-    BitWidth = Result.getBitWidth(); // don't shrink the result
-  else if (BitWidth > Result.getBitWidth())
+  if (Result.getBitWidth() < BitWidth) {
     Result = Result.zext(BitWidth);
+  }
 
   APInt RadixAP, CharAP; // unused unless !IsPowerOf2Radix
   if (!IsPowerOf2Radix) {
@@ -580,6 +558,21 @@ bool StringRef::consumeInteger(unsigned Radix, APInt &Result) {
     // invalid.
     if (CharVal >= Radix)
       break;
+
+    // Check if one more digit will overflow, and grow if so.
+    if (Result.getActiveBits() + Log2Radix > Result.getBitWidth()) {
+      unsigned NewWidth = Result.getBitWidth() * 2;
+
+      // Guard against overflow of the NewWidth itself
+      if (NewWidth < Result.getBitWidth())
+        return true;
+
+      Result = Result.zext(NewWidth);
+      if (!IsPowerOf2Radix) {
+        RadixAP = RadixAP.zext(NewWidth);
+        CharAP = CharAP.zext(NewWidth);
+      }
+    }
 
     // Add in this character.
     if (IsPowerOf2Radix) {

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -970,36 +970,60 @@ TEST(StringRefTest, consumeIntegerSigned) {
 
 TEST(StringRefTest, consumeIntegerAPIntBitWidth) {
   // Decimal large number (12535824225335233)
-  // 17 digits, (17 * 3402 + 1023) >> 10 = 57 bits.
+  // Fits in 64 bits, so should not grow beyond initial 64 bits.
   {
     APInt U;
     StringRef Str = "12535824225335233";
     bool Success = Str.consumeInteger(10, U);
     ASSERT_FALSE(Success);
     EXPECT_EQ(U.getZExtValue(), 12535824225335233ULL);
-    EXPECT_EQ(U.getBitWidth(), 57U);
+    EXPECT_EQ(U.getBitWidth(), 64U);
   }
 
   // Hex version of same number (2c894405eaf7c1)
-  // 14 digits, (14 * 4096 + 1023) >> 10 = 56 bits.
+  // Fits in 64 bits, so should not grow beyond initial 64 bits.
   {
     APInt U;
     StringRef Str = "2c894405eaf7c1";
     bool Success = Str.consumeInteger(16, U);
     ASSERT_FALSE(Success);
     EXPECT_EQ(U.getZExtValue(), 12535824225335233ULL);
-    EXPECT_EQ(U.getBitWidth(), 56U);
+    EXPECT_EQ(U.getBitWidth(), 64U);
   }
 
   // A very large decimal number (100 digits)
-  // (100 * 3402 + 1023) >> 10 = 333 bits.
+  // Needs 333 bits. Started at 64, doubled to 128, 256, 512.
   {
     APInt U;
     std::string LargeDec(100, '9');
     StringRef Str = LargeDec;
     bool Success = Str.consumeInteger(10, U);
     ASSERT_FALSE(Success);
-    EXPECT_EQ(U.getBitWidth(), 333U);
+    EXPECT_EQ(U.getBitWidth(), 512U);
+  }
+
+  // Trailing garbage should not trigger growth or failure.
+  {
+    APInt U;
+    StringRef Str = "123g";
+    bool Success = Str.consumeInteger(10, U);
+    ASSERT_FALSE(Success);
+    EXPECT_EQ(U.getZExtValue(), 123ULL);
+    EXPECT_EQ(U.getBitWidth(), 64U);
+    EXPECT_EQ(Str, "g");
+  }
+
+  // Very long trailing garbage should also not trigger growth or failure.
+  {
+    APInt U;
+    std::string LongGarbage = "1";
+    LongGarbage.append(10000, 'g');
+    StringRef Str = LongGarbage;
+    bool Success = Str.consumeInteger(10, U);
+    ASSERT_FALSE(Success);
+    EXPECT_EQ(U.getZExtValue(), 1ULL);
+    EXPECT_EQ(U.getBitWidth(), 64U);
+    EXPECT_EQ(Str.size(), 10000U);
   }
 }
 

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -968,6 +968,41 @@ TEST(StringRefTest, consumeIntegerSigned) {
   }
 }
 
+TEST(StringRefTest, consumeIntegerAPIntBitWidth) {
+  // Decimal large number (12535824225335233)
+  // 17 digits, (17 * 3402 + 1023) >> 10 = 57 bits.
+  {
+    APInt U;
+    StringRef Str = "12535824225335233";
+    bool Success = Str.consumeInteger(10, U);
+    ASSERT_FALSE(Success);
+    EXPECT_EQ(U.getZExtValue(), 12535824225335233ULL);
+    EXPECT_EQ(U.getBitWidth(), 57U);
+  }
+
+  // Hex version of same number (2c894405eaf7c1)
+  // 14 digits, (14 * 4096 + 1023) >> 10 = 56 bits.
+  {
+    APInt U;
+    StringRef Str = "2c894405eaf7c1";
+    bool Success = Str.consumeInteger(16, U);
+    ASSERT_FALSE(Success);
+    EXPECT_EQ(U.getZExtValue(), 12535824225335233ULL);
+    EXPECT_EQ(U.getBitWidth(), 56U);
+  }
+
+  // A very large decimal number (100 digits)
+  // (100 * 3402 + 1023) >> 10 = 333 bits.
+  {
+    APInt U;
+    std::string LargeDec(100, '9');
+    StringRef Str = LargeDec;
+    bool Success = Str.consumeInteger(10, U);
+    ASSERT_FALSE(Success);
+    EXPECT_EQ(U.getBitWidth(), 333U);
+  }
+}
+
 struct GetDoubleStrings {
   const char *Str;
   bool AllowInexact;


### PR DESCRIPTION
A colleague of mine noticed that `"12535824225335233"` parses in MLIR's integer attribute parser as a 68-bit integer, even though it is a 53-bit constant. I traced this back to `StringRef::consumeInteger`'s heuristic estimate of the bit size. This change replaces that heuristic with a default 64-bit storage, doubling the storage as more digits are parsed. This produces a potentially larger over-estimate of the total storage required, but does so in a less arbitrary manner and reduces the over-approximation for numbers close to the 64-bit boundary.

Nb., A first iteration of this change tightened that estimate to at most a 1-bit overapproximation with a lookup-table.

Assisted by Gemini