### PR TITLE
[llvm][GVNSink] Avoid non-determistic iteration order over NeededPHIs

### DIFF
--- a/llvm/lib/Transforms/Scalar/GVNSink.cpp
+++ b/llvm/lib/Transforms/Scalar/GVNSink.cpp
@@ -35,10 +35,10 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
@@ -262,7 +262,7 @@ template <> struct llvm::DenseMapInfo<ModelledPHI> {
   }
 };
 
-using ModelledPHISet = DenseSet<ModelledPHI>;
+using ModelledPHISet = SetVector<ModelledPHI>;
 
 namespace {
 
@@ -645,7 +645,7 @@ GVNSink::analyzeInstructionForSinking(LockstepReverseIterator<false> &LRI,
   ModelledPHI NewPHI(NewInsts, ActivePreds, RPOTOrder);
 
   // Does sinking this instruction render previous PHIs redundant?
-  if (NeededPHIs.erase(NewPHI))
+  if (NeededPHIs.remove(NewPHI))
     RecomputePHIContents = true;
 
   if (RecomputePHIContents) {
@@ -693,7 +693,6 @@ GVNSink::analyzeInstructionForSinking(LockstepReverseIterator<false> &LRI,
         PHI.areAnyIncomingValuesConstant())
       return std::nullopt;
 
-    NeededPHIs.reserve(NeededPHIs.size());
     NeededPHIs.insert(PHI);
     PHIContents.insert_range(PHI.getValues());
   }


### PR DESCRIPTION
The iteration order of DenseSet is not guaranteed, which affects the
output of code generated with GVNSink enabled. This can cause code to be
emitted in differing order, affect section ordering and in some cases
was reported to sometimes result in larger binaries due to increased
padding between sections.

This patch addresses this by using SetVector, which has a deterministic
iteration order.