### PR TITLE
[clang][index][USR] Fix build issue introduced in #205430

### DIFF
--- a/clang/unittests/Index/CMakeLists.txt
+++ b/clang/unittests/Index/CMakeLists.txt
@@ -8,6 +8,7 @@ add_clang_unittest(IndexTests
   clangLex
   clangSerialization
   clangTooling
+  clangUnifiedSymbolResolution
   LLVM_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
   Support


### PR DESCRIPTION
Add clangUnifiedSymbolResolution as dependency of clang index unit test.