### PR TITLE
[mlir][xegpu] Support subgroup layout assignment for scatter stores

### DIFF
--- a/mlir/include/mlir/Dialect/XeGPU/Transforms/XeGPULayoutImpl.h
+++ b/mlir/include/mlir/Dialect/XeGPU/Transforms/XeGPULayoutImpl.h
@@ -234,15 +234,19 @@ DistributeLayoutAttr setupLoadMatrixAnchorLayout(
     DistributeLayoutAttr consumerLayout, const uArch::uArch *uArch);
 
 /// Sets up the anchor layout for a store scatter operation.
+/// `numSg` is only used for Subgroup-kind layouts.
 DistributeLayoutAttr setupStoreScatterAnchorLayout(LayoutKind layoutKind,
                                                    VectorType vectorTy,
                                                    int contigChunkSize,
+                                                   int numSg,
                                                    const uArch::uArch *uArch);
 
 /// Sets up the anchor layout for a store matrix operation.
+/// `numSg` is only used for Subgroup-kind layouts.
 DistributeLayoutAttr setupStoreMatrixAnchorLayout(LayoutKind layoutKind,
                                                   VectorType vectorTy,
                                                   int contigChunkSize,
+                                                  int numSg,
                                                   const uArch::uArch *uArch);
 
 /// If the consumer layout has only inst_data (no lane_layout/lane_data),

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
@@ -1744,31 +1744,39 @@ xegpu::setupLoadMatrixAnchorLayout(xegpu::LayoutKind layoutKind,
                                       maxChunkSize, resShape, subgroupSize);
 }
 
-/// Sets up the anchor layout for store scatter and store matrix operation.
-/// store matrix lowers to store scatter and 1d block store. All of them
-/// share the same layout setup logic. For Subgroup layout, not supported
-/// yet.
-///
-/// Lane layout is derived first via `computeScatterIOLaneLayoutAndData`;
-/// inst_data is then the element-wise product lane_layout * lane_data.
+/// Picks the subgroup layout for a scatter-style store (store_scatter /
+/// store_matrix): the most balanced `numSg` factorization that divides
+/// `wgShape` with sg_data a multiple of `instData`. A store has no consumer.
 static xegpu::DistributeLayoutAttr
-setupGenericStoreAnchorLayout(xegpu::LayoutKind layoutKind,
-                              mlir::MLIRContext *context, int maxChunkSize,
-                              ArrayRef<int64_t> srcShape, int subgroupSize) {
-
-  if (layoutKind == xegpu::LayoutKind::Subgroup) {
-    assert(false &&
-           "subgroup layout assignment not supported for storeScatter.");
+getStoreSubgroupLayouts(mlir::MLIRContext *context, ArrayRef<int64_t> wgShape,
+                        ArrayRef<int64_t> instData, int numSg) {
+  auto candidates = getSgLayoutCandidates(wgShape, instData, numSg);
+  if (candidates.empty())
     return nullptr;
-  }
+  // Candidates are ordered most-balanced first.
+  return buildSgLayout(context, wgShape, candidates.front(), /*dimK=*/-1);
+}
+
+/// Sets up the anchor layout for store scatter and store matrix operation,
+/// which share the same logic. Lane layout comes from
+/// `computeScatterIOLaneLayoutAndData`; inst_data is lane_layout * lane_data.
+static xegpu::DistributeLayoutAttr setupGenericStoreAnchorLayout(
+    xegpu::LayoutKind layoutKind, mlir::MLIRContext *context, int maxChunkSize,
+    ArrayRef<int64_t> srcShape, int subgroupSize, int numSg) {
 
   auto [laneLayout, laneData] =
       computeScatterIOLaneLayoutAndData(srcShape, subgroupSize, maxChunkSize);
 
+  SmallVector<int64_t> instData(srcShape.size());
+  for (size_t i = 0; i < srcShape.size(); ++i)
+    instData[i] = laneLayout[i] * laneData[i];
+
+  if (layoutKind == xegpu::LayoutKind::Subgroup) {
+    assert(numSg > 0 &&
+           "Number of subgroups must be provided for sg layout creation.");
+    return getStoreSubgroupLayouts(context, srcShape, instData, numSg);
+  }
   if (layoutKind == xegpu::LayoutKind::InstData) {
-    SmallVector<int64_t> instData(srcShape.size());
-    for (size_t i = 0; i < srcShape.size(); ++i)
-      instData[i] = laneLayout[i] * laneData[i];
     return buildInstDataLayoutWithLane(context, instData, laneLayout, laneData);
   }
   if (layoutKind == xegpu::LayoutKind::Lane) {
@@ -1781,7 +1789,7 @@ setupGenericStoreAnchorLayout(xegpu::LayoutKind layoutKind,
 xegpu::DistributeLayoutAttr
 xegpu::setupStoreScatterAnchorLayout(xegpu::LayoutKind layoutKind,
                                      VectorType srcVecTy, int contigChunkSize,
-                                     const uArch::uArch *uArch) {
+                                     int numSg, const uArch::uArch *uArch) {
 
   const int subgroupSize = uArch->getSubgroupSize();
   ArrayRef<int64_t> srcShape = srcVecTy.getShape();
@@ -1794,14 +1802,13 @@ xegpu::setupStoreScatterAnchorLayout(xegpu::LayoutKind layoutKind,
   int maxChunkSize = std::min(
       uArchInstruction->getMaxLaneStoreSize(elemBitWidth), contigChunkSize);
   return setupGenericStoreAnchorLayout(layoutKind, context, maxChunkSize,
-                                       srcShape, subgroupSize);
+                                       srcShape, subgroupSize, numSg);
 }
 
 /// Sets up the anchor layout for a store matrix operation.
-xegpu::DistributeLayoutAttr
-xegpu::setupStoreMatrixAnchorLayout(xegpu::LayoutKind layoutKind,
-                                    VectorType srcVecTy, int contigChunkSize,
-                                    const xegpu::uArch::uArch *uArch) {
+xegpu::DistributeLayoutAttr xegpu::setupStoreMatrixAnchorLayout(
+    xegpu::LayoutKind layoutKind, VectorType srcVecTy, int contigChunkSize,
+    int numSg, const xegpu::uArch::uArch *uArch) {
 
   const int subgroupSize = uArch->getSubgroupSize();
   ArrayRef<int64_t> srcShape = srcVecTy.getShape();
@@ -1815,7 +1822,7 @@ xegpu::setupStoreMatrixAnchorLayout(xegpu::LayoutKind layoutKind,
       uArchInstruction->getMaxLaneStoreSize(elemBitWidth), contigChunkSize);
 
   return setupGenericStoreAnchorLayout(layoutKind, context, maxChunkSize,
-                                       srcShape, subgroupSize);
+                                       srcShape, subgroupSize, numSg);
 }
 
 /// Completes a scatter IO layout by deriving lane_layout and lane_data from

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
@@ -1269,8 +1269,19 @@ void LayoutInfoPropagation::visitStoreScatterOp(
       storeScatter.emitWarning("Not propagating, non-vector payload supplied.");
       return;
     }
+    auto numSgOrErr = getNumSg(storeScatter, uArch->getSubgroupSize());
+    if (layoutKind == xegpu::LayoutKind::Subgroup && failed(numSgOrErr)) {
+      storeScatter.emitWarning(
+          "Unable to determine the number of subgroups for the operation.");
+      return;
+    }
     requiredAnchorLayoutAttr = xegpu::setupStoreScatterAnchorLayout(
-        layoutKind, srcVecTy, chunkSize, uArch);
+        layoutKind, srcVecTy, chunkSize, numSgOrErr.value_or(0), uArch);
+    if (!requiredAnchorLayoutAttr) {
+      storeScatter.emitWarning(
+          "Failed to determine required layout for store scatter.");
+      return;
+    }
     storeScatter.setLayoutAttr(requiredAnchorLayoutAttr);
   }
 
@@ -1352,8 +1363,19 @@ void LayoutInfoPropagation::visitStoreMatrixOp(
   } else {
     int chunkSize =
         1; // placeHolder for future use when StoreMatrix supports coalescing
+    auto numSgOrErr = getNumSg(storeMatrix, uArch->getSubgroupSize());
+    if (layoutKind == xegpu::LayoutKind::Subgroup && failed(numSgOrErr)) {
+      storeMatrix.emitWarning(
+          "Unable to determine the number of subgroups for the operation.");
+      return;
+    }
     requiredAnchorLayoutAttr = xegpu::setupStoreMatrixAnchorLayout(
-        layoutKind, srcVecTy, chunkSize, uArch);
+        layoutKind, srcVecTy, chunkSize, numSgOrErr.value_or(0), uArch);
+    if (!requiredAnchorLayoutAttr) {
+      storeMatrix.emitWarning(
+          "Failed to determine required layout for store matrix.");
+      return;
+    }
     storeMatrix.setLayoutAttr(requiredAnchorLayoutAttr);
   }
   layout = LayoutInfo(requiredAnchorLayoutAttr);

--- a/mlir/test/Dialect/XeGPU/propagate-layout-subgroup.mlir
+++ b/mlir/test/Dialect/XeGPU/propagate-layout-subgroup.mlir
@@ -592,6 +592,53 @@ gpu.module @test {
 
 // -----
 gpu.module @test {
+  // Self-derived sg layout: 256 threads / 16 = 16 subgroups, sg_data = 16.
+  // CHECK-LABEL: store_scatter
+  gpu.func @store_scatter(%dest: memref<256xf16>) kernel attributes {known_block_size = array<i32: 256, 1, 1>} {
+    %val = arith.constant dense<25.5> : vector<256xf16>
+    %offset = arith.constant dense<0> : vector<256xindex>
+    %mask = arith.constant dense<1> : vector<256xi1>
+    // CHECK: xegpu.store %{{.*}}, %{{.*}}[%{{.*}}], %{{.*}} <{chunk_size = 1 : i64, l1_hint = #xegpu.cache_hint<cached>, layout = #xegpu.layout<sg_layout = [16], sg_data = [16]>}>
+    // CHECK-SAME: : vector<256xf16>, memref<256xf16>, vector<256xindex>, vector<256xi1>
+    xegpu.store %val, %dest[%offset], %mask {chunk_size = 1, l1_hint = #xegpu.cache_hint<cached>}
+      : vector<256xf16>, memref<256xf16>, vector<256xindex>, vector<256xi1>
+    gpu.return
+  }
+}
+
+// -----
+gpu.module @test {
+  // Self-derived sg layout: 512 threads / 16 = 32 subgroups, most balanced
+  // factorization [4, 8] over [64, 128] -> sg_data [16, 16].
+  // CHECK-LABEL: store_matrix
+  gpu.func @store_matrix(%mem: !xegpu.mem_desc<64x128xf16>, %val: vector<64x128xf16>) kernel attributes {known_block_size = array<i32: 512, 1, 1>} {
+    %c0 = arith.constant 0 : index
+    // CHECK: xegpu.store_matrix %{{.*}}, %{{.*}}[%{{.*}}, %{{.*}}] <{layout = #xegpu.layout<sg_layout = [4, 8], sg_data = [16, 16]>}>
+    // CHECK-SAME: : vector<64x128xf16>, !xegpu.mem_desc<64x128xf16>, index, index
+    xegpu.store_matrix %val, %mem[%c0, %c0] : vector<64x128xf16>, !xegpu.mem_desc<64x128xf16>, index, index
+    gpu.return
+  }
+}
+
+// -----
+gpu.module @test {
+  // No valid sg layout: 32 subgroups over 256 elements forces sg_data = 8 <
+  // 16-lane tile, so every candidate is rejected; layout is left unassigned.
+  // CHECK-LABEL: store_scatter_no_valid_sg_layout
+  gpu.func @store_scatter_no_valid_sg_layout(%dest: memref<256xf16>) kernel attributes {known_block_size = array<i32: 512, 1, 1>} {
+    %val = arith.constant dense<25.5> : vector<256xf16>
+    %offset = arith.constant dense<0> : vector<256xindex>
+    %mask = arith.constant dense<1> : vector<256xi1>
+    // CHECK: xegpu.store %{{.*}}, %{{.*}}[%{{.*}}], %{{.*}} <{chunk_size = 1 : i64, l1_hint = #xegpu.cache_hint<cached>}>
+    // CHECK-SAME: : vector<256xf16>, memref<256xf16>, vector<256xindex>, vector<256xi1>
+    xegpu.store %val, %dest[%offset], %mask {chunk_size = 1, l1_hint = #xegpu.cache_hint<cached>}
+      : vector<256xf16>, memref<256xf16>, vector<256xindex>, vector<256xi1>
+    gpu.return
+  }
+}
+
+// -----
+gpu.module @test {
 // CHECK-LABEL: gpu.func @transpose_3d_order_remap(
 // CHECK: %[[TD_LD:.*]] = xegpu.create_nd_tdesc %{{.*}} : memref<32x2x32xf16> ->
 // CHECK-SAME: !xegpu.tensor_desc<32x2x32xf16, #xegpu.layout<sg_layout = [1, 2, 2], sg_data = [32, 1, 16], order = [0, 2, 1]>>


### PR DESCRIPTION
Add getStoreSubgroupLayouts() to derive the subgroup (sg_layout/sg_data) anchor layout for store_scatter and store_matrix. It factorizes numSg into the most balanced sg_layout that divides the workgroup tile with sg_data a multiple of inst_data (lane_layout * lane_data).
