### PR TITLE
[AArch64] Support 4-byte stack protector with large code model.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -2648,9 +2648,6 @@ bool AArch64InstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
           .addMemOperand(*MI.memoperands_begin());
     }
   } else if (TM.getCodeModel() == CodeModel::Large) {
-    if (GuardWidth == 4)
-      report_fatal_error("Large code model with 4-byte stack protector not yet "
-                         "supported");
     BuildMI(MBB, MI, DL, get(AArch64::MOVZXi), Reg)
         .addGlobalAddress(GV, 0, AArch64II::MO_G0 | MO_NC)
         .addImm(0);
@@ -2666,10 +2663,20 @@ bool AArch64InstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
         .addReg(Reg, RegState::Kill)
         .addGlobalAddress(GV, 0, AArch64II::MO_G3)
         .addImm(48);
-    BuildMI(MBB, MI, DL, get(AArch64::LDRXui), Reg)
-        .addReg(Reg, RegState::Kill)
-        .addImm(0)
-        .addMemOperand(*MI.memoperands_begin());
+    if (GuardWidth == 4) {
+      unsigned Reg32 = TRI->getSubReg(Reg, AArch64::sub_32);
+      BuildMI(MBB, MI, DL, get(AArch64::LDRWui))
+          .addDef(Reg32, RegState::Dead)
+          .addUse(Reg, RegState::Kill)
+          .addImm(0)
+          .addMemOperand(*MI.memoperands_begin())
+          .addDef(Reg, RegState::Implicit);
+    } else {
+      BuildMI(MBB, MI, DL, get(AArch64::LDRXui), Reg)
+          .addReg(Reg, RegState::Kill)
+          .addImm(0)
+          .addMemOperand(*MI.memoperands_begin());
+    }
   } else {
     BuildMI(MBB, MI, DL, get(AArch64::ADRP), Reg)
         .addGlobalAddress(GV, 0, OpFlags | AArch64II::MO_PAGE);

--- a/llvm/test/CodeGen/AArch64/stack-guard-width.ll
+++ b/llvm/test/CodeGen/AArch64/stack-guard-width.ll
@@ -5,6 +5,7 @@
 ; RUN: cat a.ll nopic.ll > b.ll
 ; RUN: cat a.ll pic.ll > c.ll
 ; RUN: llc < b.ll | FileCheck %s
+; RUN: llc -code-model=large < b.ll | FileCheck -check-prefix=LARGE %s
 ; RUN: llc < c.ll -relocation-model=pic | FileCheck %s -check-prefix=PIC
 
 ;--- a.ll
@@ -15,6 +16,12 @@ define dso_local void @f(ptr noundef %g) #0 {
 ; CHECK: ldr w9, [x9, :lo12:__stack_chk_guard]
 ; CHECK: adrp x8, __stack_chk_guard
 ; CHECK: ldr w8, [x8, :lo12:__stack_chk_guard]
+
+; LARGE: movz x9, #:abs_g0_nc:__stack_chk_guard
+; LARGE: movk x9, #:abs_g1_nc:__stack_chk_guard
+; LARGE: movk x9, #:abs_g2_nc:__stack_chk_guard
+; LARGE: movk x9, #:abs_g3:__stack_chk_guard
+; LARGE: ldr w9, [x9]
 
 ; PIC: adrp x9, :got:__stack_chk_guard
 ; PIC: ldr x9, [x9, :got_lo12:__stack_chk_guard]


### PR DESCRIPTION
This is a simple extension to existing code.  We might need this in the future.