### PR TITLE
[lit] Fix ProcessPoolExecutor shutdown hang on macOS with Python <= 3.11

### DIFF
--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -174,6 +174,14 @@ class Run:
             raise
         else:
             for ex in executors:
+                # For python <= 3.11 on macOS, Queue.join_thread() inside shutdown(wait=True)
+                # deadlocks: join_executor_internals() calls it before p.join(),
+                # but macOS requires the inverse order. cancel_join_thread() makes
+                # join_thread() a no-op. The feeder thread still delivers sentinels
+                # independently before the write end closes.
+                # TODO: Remove this workaround once Python > 3.11 is required.
+                if hasattr(ex, "_call_queue") and ex._call_queue is not None:
+                    ex._call_queue.cancel_join_thread()
                 ex.shutdown(wait=True)
 
     def _wait_for(self, future_to_test, deadline):


### PR DESCRIPTION
On macOS with Python <= 3.11, shutdown(wait=True) hangs indefinitely: the internal join_executor_threads() calls call_queue.join_thread() before p.join(), but macOS requires the inverse order, the Queue's feeder thread can't drain until worker processes are joined, so join_thread() blocks forever while workers wait for sentinels that the feeder can never deliver. To fix this, we call cancel_join_thread() on the call queue before shutdown(wait=True), making join_thread() a no-op and allowing the feeder thread to deliver sentinels independently. This matches how the existing abort path already handles cleanup using _abort_executors(). The issue is fixed upstream in CPython >= 3.12.