### PR TITLE
[lld] Make R_AARCH64_PREL32/16 only signed ints

### DIFF
--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -623,7 +623,6 @@ void AArch64::relocate(uint8_t *loc, const Relocation &rel,
     write16(ctx, loc, val);
     break;
   case R_AARCH64_ABS32:
-  case R_AARCH64_PREL32:
     checkIntUInt(ctx, loc, val, 32, rel);
     write32(ctx, loc, val);
     break;
@@ -633,6 +632,7 @@ void AArch64::relocate(uint8_t *loc, const Relocation &rel,
       write32le(loc, val);
     }
     break;
+  case R_AARCH64_PREL32:
   case R_AARCH64_PLT32:
   case R_AARCH64_GOTPCREL32:
     checkInt(ctx, loc, val, 32, rel);

--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -618,8 +618,11 @@ void AArch64::relocate(uint8_t *loc, const Relocation &rel,
                        uint64_t val) const {
   switch (rel.type) {
   case R_AARCH64_ABS16:
-  case R_AARCH64_PREL16:
     checkIntUInt(ctx, loc, val, 16, rel);
+    write16(ctx, loc, val);
+    break;
+  case R_AARCH64_PREL16:
+    checkInt(ctx, loc, val, 16, rel);
     write16(ctx, loc, val);
     break;
   case R_AARCH64_ABS32:

--- a/lld/test/ELF/aarch64-prel16.s
+++ b/lld/test/ELF/aarch64-prel16.s
@@ -14,7 +14,7 @@
 // RUN: llvm-objdump -s --section=.data a.be | FileCheck %s --check-prefixes=CHECK,BE
 
 // CHECK: Contents of section .data:
-// 202158: S = 0x100, A = 0x212157, P = 0x202158
+// 202158: S = 0x100, A = 0x202057, P = 0x202158
 //         S + A - P = 0xffff
 // 212a5a: S = 0x100, A = 0x1fa05a, P = 0x20215a
 //         S + A - P = 0x8000
@@ -22,13 +22,13 @@
 // BE-NEXT: 202158 ffff8000
 
 // RUN: not ld.lld -z max-page-size=4096 a.o --defsym foo=255 2>&1 | FileCheck %s --check-prefix=OVERFLOW1 --implicit-check-not=error:
-// OVERFLOW1: error: a.o:(.data+0x2): relocation R_AARCH64_PREL16 out of range: -32769 is not in [-32768, 65535]; references 'foo'
+// OVERFLOW1: error: a.o:(.data+0x2): relocation R_AARCH64_PREL16 out of range: -32769 is not in [-32768, 32767]; references 'foo'
 
-// RUN: not ld.lld -z max-page-size=4096 a.o --defsym foo=257 2>&1 | FileCheck %s --check-prefix=OVERFLOW2 --implicit-check-not=error:
-// OVERFLOW2: error: a.o:(.data+0x0): relocation R_AARCH64_PREL16 out of range: 65536 is not in [-32768, 65535]; references 'foo'
+// RUN: not ld.lld -z max-page-size=4096 a.o --defsym foo=33025 2>&1 | FileCheck %s --check-prefix=OVERFLOW2 --implicit-check-not=error:
+// OVERFLOW2: error: a.o:(.data+0x0): relocation R_AARCH64_PREL16 out of range: 32768 is not in [-32768, 32767]; references 'foo'
 
 .globl _start
 _start:
 .data
-  .hword foo - . + 0x212057
+  .hword foo - . + 0x202057
   .hword foo - . + 0x1fa05a

--- a/lld/test/ELF/aarch64-prel32.s
+++ b/lld/test/ELF/aarch64-prel32.s
@@ -14,7 +14,7 @@
 // RUN: llvm-objdump -s --section=.data a.be | FileCheck %s --check-prefixes=CHECK,BE
 
 // CHECK: Contents of section .data:
-// 202158: S = 0x100, A = 0x100202057, P = 0x202158
+// 202158: S = 0x100, A = 0x202057, P = 0x202158
 //         S + A - P = 0xffffffff
 // 20215c: S = 0x100, A = -0x7fdfdfa4, P = 0x20215c
 //         S + A - P = 0x80000000
@@ -22,13 +22,13 @@
 // BE-NEXT: 202158 ffffffff 80000000
 
 // RUN: not ld.lld -z max-page-size=4096 a.o --defsym foo=255 2>&1 | FileCheck %s --check-prefix=OVERFLOW1 --implicit-check-not=error:
-// OVERFLOW1: error: a.o:(.data+0x4): relocation R_AARCH64_PREL32 out of range: -2147483649 is not in [-2147483648, 4294967295]; references 'foo'
+// OVERFLOW1: error: a.o:(.data+0x4): relocation R_AARCH64_PREL32 out of range: -2147483649 is not in [-2147483648, 2147483647]; references 'foo'
 
-// RUN: not ld.lld -z max-page-size=4096 a.o --defsym foo=257 2>&1 | FileCheck %s --check-prefix=OVERFLOW2 --implicit-check-not=error:
-// OVERFLOW2: error: a.o:(.data+0x0): relocation R_AARCH64_PREL32 out of range: 4294967296 is not in [-2147483648, 4294967295]; references 'foo'
+// RUN: not ld.lld -z max-page-size=4096 a.o --defsym foo=2147483905 2>&1 | FileCheck %s --check-prefix=OVERFLOW2 --implicit-check-not=error:
+// OVERFLOW2: error: a.o:(.data+0x0): relocation R_AARCH64_PREL32 out of range: 2147483648 is not in [-2147483648, 2147483647]; references 'foo'
 
 .globl _start
 _start:
 .data
-  .word foo - . + 0x100202057
+  .word foo - . + 0x202057
   .word foo - . - 0x7fdfdfa4


### PR DESCRIPTION
After https://github.com/ARM-software/abi-aa/pull/401, these are defined to be only signed 32/16 bit ints rather than both signed and unsigned.

Assisted-by: Gemini