### PR TITLE
[clang][serialization] Fix crash on imported pack indexing type

### DIFF
--- a/clang/include/clang/AST/TypeProperties.td
+++ b/clang/include/clang/AST/TypeProperties.td
@@ -489,9 +489,12 @@ let Class = PackIndexingType in {
   def : Property<"expansions", Array<QualType>> {
     let Read = [{ node->getExpansions() }];
   }
+  def : Property<"index", UnsignedOrNone> {
+    let Read = [{ node->getSelectedIndex() }];
+  }
 
   def : Creator<[{
-    return ctx.getPackIndexingType(pattern, indexExpression, isFullySubstituted, expansions);
+    return ctx.getPackIndexingType(pattern, indexExpression, isFullySubstituted, expansions, index);
   }]>;
 }
 


### PR DESCRIPTION
The selected index of a PackIndexingType was not serialized, so on deserialization its canonical type was rebuilt as a dependent type, crashing CodeGen.

Fixes #204479
