### PR TITLE
Fix remove dead values poison crash

### DIFF
--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -522,12 +522,18 @@ static void processBranchOp(BranchOpInterface branchOp, RunLivenessAnalysis &la,
 
 /// Create ub.poison ops for the given values. If a value has no uses, return
 /// an "empty" value.
+static Value createPoisonedValue(OpBuilder &b, Value value) {
+  if (!value || value.use_empty())
+    return Value();
+  return ub::PoisonOp::create(b, value.getLoc(), value.getType()).getResult();
+}
+
+/// Create ub.poison ops for the given values. If a value has no uses, return
+/// an "empty" value.
 static SmallVector<Value> createPoisonedValues(OpBuilder &b,
                                                ValueRange values) {
-  return llvm::map_to_vector(values, [&](Value value) {
-    if (value.use_empty())
-      return Value();
-    return ub::PoisonOp::create(b, value.getLoc(), value.getType()).getResult();
+  return llvm::map_to_vector(values, [&](Value value) -> Value {
+    return createPoisonedValue(b, value);
   });
 }
 
@@ -689,9 +695,9 @@ static void cleanUpDeadVals(MLIRContext *ctx, RDVFinalCleanupList &list) {
       if (o.replaceWithPoison) {
         rewriter.setInsertionPoint(o.op);
         for (auto deadIdx : o.nonLive.set_bits()) {
-          o.op->setOperand(
-              deadIdx, createPoisonedValues(rewriter, o.op->getOperand(deadIdx))
-                           .front());
+          Value poisoned = createPoisonedValue(rewriter, o.op->getOperand(deadIdx));
+          if (poisoned)
+            o.op->setOperand(deadIdx, poisoned);
         }
       } else {
         o.op->eraseOperands(o.nonLive);

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -868,3 +868,26 @@ module @func_with_non_call_users {
   }
   spirv.EntryPoint "GLCompute" @callee
 }
+
+// -----
+
+// CHECK: pdl_interp.func private @matcher()
+// CHECK-LABEL: func.func private @callee()
+// CHECK: return
+module {
+  pdl_interp.func private @matcher(%arg0: !llvm.ptr) {
+    pdl_interp.finalize
+  }
+  module @rewriters {
+  }
+  func.func private @callee(%arg0: memref<f32>) -> memref<f32> {
+    %false = arith.constant false
+    %0 = scf.if %false -> (memref<f32>) {
+      scf.yield %arg0 : memref<f32>
+    } else {
+      %1 = bufferization.clone %arg0 : memref<f32> to memref<f32>
+      scf.yield %1 : memref<f32>
+    }
+    return %0 : memref<f32>
+  }
+}


### PR DESCRIPTION
Add a single-value poison creation helper for RemoveDeadValues, while keeping
the existing ValueRange helper for multi-result cleanup.

RemoveDeadValues used `createPoisonedValues` for both ranges of values and a
single operand value. The single-operand call site passed
`o.op->getOperand(deadIdx)` to a helper taking `ValueRange`, which could create
an invalid temporary range. The pass then crashed when the range was iterated
and `value.use_empty()` was called on the invalid value.

By spliting the poison creation logic into `createPoisonedValue` for one `Value` and
keep `createPoisonedValues` as the range wrapper, this result the single-operand cleanup
path now calls the single-value helper directly instead of constructing a
`ValueRange` from one operand.

Add a regression test to `remove-dead-values.mlir` covering the crash case with
a private function returning a `memref` through `scf.if`, including a
`bufferization.clone` branch. 

Assisted-by: Codex