### PR TITLE
[mlir][xegpu] Fix expandDim distribution for shape_cast layout inference

### DIFF
--- a/mlir/lib/Dialect/XeGPU/IR/XeGPUDialect.cpp
+++ b/mlir/lib/Dialect/XeGPU/IR/XeGPUDialect.cpp
@@ -704,40 +704,23 @@ DistributeLayoutAttr LayoutAttr::collapseDims(SmallVector<int64_t> dimGroup) {
 // Derive a new layout by expanding a single dimension `dim` into multiple
 // adjacent dimensions whose extents are given by `targetShape`.
 //
-// Distribution is always outer-to-inner to make sure larger contiguous
-// chunks are given to each compute unit first. Concretely: sg_layout and
-// lane_layout walk the new dims outer-to-inner so each compute unit owns a
-// contiguous run after collapse; sg_data / lane_data / inst_data fill
-// innermost-first so the per-unit data tile is contiguous in the
-// fastest-varying expanded dim. The expanded dims are assumed to be in
-// row-major (FCD-first) order, which is intrinsic to `vector.shape_cast`'s
-// linear-order-preserving semantics.
-//
-// Distribution policy on the expanded src dims (replacing `dim`):
-//   - sg_layout / lane_layout: spread outer-to-inner; each dim takes
-//     min(remaining, targetShape[i]); leftover spills into the next inner
-//     dim.
-//   - sg_data: fill innermost-first, capped per dim by
-//     targetShape[i] / sgLayout[i] (the per-sg share of the extent),
-//     or targetShape[i] (if sg_data is replicated across all subgroups).
-//   - lane_data: fill innermost-first, capped per dim by
-//     (targetShape[i] / sgLayout[i]) / laneLayout[i] (the per-lane share of
-//     the per-sg extent).
-//   - inst_data: seeded from laneLayout[i] * laneData[i] per dim, then the
-//     remaining factor is distributed innermost-first (capped per dim by
-//     the per-sg extent).
-//   - order: the original dim index is replaced by the expanded dim indices
-//     in innermost-fastest order; entries past `dim` shift up by
-//     `targetShape.size() - 1`.
+// The expanded dims are row-major (innermost is fastest-varying), so every
+// field is spread innermost-first. For sg and lane levels the data component
+// (sg_data / lane_data) is distributed first and the layout component
+// (sg_layout / lane_layout) then strides over the per-dim leftover; this
+// shared inner-first sweep is what makes "wrap-around" distributions correct.
+// When the data component spans the full extent (replicated/broadcast across
+// subgroups or lanes), the layout component is capped by the full extent
+// instead of the leftover. order entries past `dim` shift up by
+// `targetShape.size() - 1`.
 //
 // Examples (only the affected dim shown; assume rank-1 input):
-//   layout<sg_layout=[8], sg_data=[512]>, expandDim(0, [8, 16, 32])
-//     -> sg_layout=[8, 1, 1], sg_data=[1, 16, 32]
-//   layout<sg_layout=[16], sg_data=[32]>, expandDim(0, [2, 8, 32])
-//     -> sg_layout=[2, 8, 1], sg_data=[1, 1, 32]   (sg_layout spills inward)
-//   layout<inst_data=[32], lane_layout=[16], lane_data=[1]>,
-//     expandDim(0, [8, 16, 32])
-//     -> inst_data=[8, 2, 2], lane_layout=[8, 2, 1], lane_data=[1, 1, 1]
+//   sg_layout=[8], sg_data=[512],   expandDim(0, [8,16,32])
+//     -> sg_layout=[8,1,1],   sg_data=[1,16,32]
+//   sg_layout=[4], sg_data=[4],     expandDim(0, [2,16])
+//     -> sg_layout=[1,4],     sg_data=[1,4]      (wrap-around)
+//   inst_data=[32], lane_layout=[16], lane_data=[1], expandDim(0, [8,16,32])
+//     -> inst_data=[1,1,32], lane_layout=[1,1,16], lane_data=[1,1,1]
 DistributeLayoutAttr LayoutAttr::expandDim(int64_t dim,
                                            ArrayRef<int64_t> targetShape) {
   SmallVector<int64_t> sgLayout = getEffectiveSgLayoutAsInt();
@@ -761,29 +744,22 @@ DistributeLayoutAttr LayoutAttr::expandDim(int64_t dim,
   int64_t origLaneDataDim = laneData.empty() ? 1 : laneData[dim];
   int64_t origInstDataDim = instData.empty() ? 1 : instData[dim];
 
-  // Spread `total` across the new dims (length expCount), capped per dim by
-  // `dimSizeCap[i]`. `outerToInner` selects iteration direction
-  // (true = i=0..n-1).
-  auto spread = [&](int64_t total, ArrayRef<int64_t> dimSizeCap,
-                    bool outerToInner) -> SmallVector<int64_t> {
+  // Spread `total` across the new dims (length expCount), innermost-first,
+  // capped per dim by `dimSizeCap[i]`.
+  auto spread = [&](int64_t total,
+                    ArrayRef<int64_t> dimSizeCap) -> SmallVector<int64_t> {
     SmallVector<int64_t> out(expCount, 1);
     int64_t remaining = total;
-    auto step = [&](int64_t i) {
+    for (int64_t i = expCount - 1; i >= 0; --i) {
       if (remaining == 1)
-        return;
+        break;
       int64_t take = std::min(remaining, dimSizeCap[i]);
       assert(take > 0 && "expandDim distribution must not be zero");
       assert(remaining % take == 0 &&
              "expandDims must divide evenly across dims");
       out[i] = take;
       remaining /= take;
-    };
-    if (outerToInner)
-      for (int64_t i = 0; i < expCount; ++i)
-        step(i);
-    else
-      for (int64_t i = expCount - 1; i >= 0; --i)
-        step(i);
+    }
     assert(remaining == 1 && "expandDims total must fit within target shape");
     return out;
   };
@@ -803,60 +779,61 @@ DistributeLayoutAttr LayoutAttr::expandDim(int64_t dim,
   bool hasLaneData = !laneData.empty();
   bool hasInstData = !instData.empty();
 
-  // sg_layout / sg_data
-  SmallVector<int64_t> expSgLayout(expCount, 1);
-  if (hasSgLayout) {
-    expSgLayout = spread(origSgLayoutDim, targetShape, /*outerToInner=*/true);
-    splice(sgLayout, expSgLayout);
-  }
+  // sg_data first, then sg_layout into the per-dim leftover. When sg_data is
+  // replicated across subgroups it spans the full extent, so sg_layout is
+  // capped by targetShape itself instead of the leftover.
   bool sgDataReplicated =
       hasSgData && origSgDataDim == computeProduct(targetShape);
+  SmallVector<int64_t> expSgData(expCount, 1);
   if (hasSgData) {
-    SmallVector<int64_t> dimSizeCap(targetShape.begin(), targetShape.end());
-    if (hasSgLayout && !sgDataReplicated)
-      for (int64_t i = 0; i < expCount; ++i)
-        dimSizeCap[i] /= expSgLayout[i];
-    SmallVector<int64_t> expSgData =
-        spread(origSgDataDim, dimSizeCap, /*outerToInner=*/false);
+    expSgData = spread(origSgDataDim, targetShape);
     splice(sgData, expSgData);
   }
+  SmallVector<int64_t> expSgLayout(expCount, 1);
+  if (hasSgLayout) {
+    SmallVector<int64_t> dimSizeCap(targetShape.begin(), targetShape.end());
+    if (hasSgData && !sgDataReplicated)
+      for (int64_t i = 0; i < expCount; ++i)
+        dimSizeCap[i] /= expSgData[i];
+    expSgLayout = spread(origSgLayoutDim, dimSizeCap);
+    splice(sgLayout, expSgLayout);
+  }
 
-  // Per-sg view used as the base for lane_layout / lane_data / inst_data:
-  // targetShape[i] / sg_layout[i] when sg_layout is present (and not
-  // replicated), else targetShape itself.
+  // Per-sg extent feeding lane_layout / lane_data / inst_data.
   SmallVector<int64_t> perSgShape(targetShape.begin(), targetShape.end());
   if (hasSgLayout && !sgDataReplicated)
     for (int64_t i = 0; i < expCount; ++i)
       perSgShape[i] /= expSgLayout[i];
 
-  // lane_layout / lane_data
+  // lane_data first, then lane_layout into the per-dim leftover. When lane_data
+  // is replicated across lanes it spans the full per-sg extent, so lane_layout
+  // is capped by perSgShape itself instead of the leftover.
+  bool laneDataReplicated =
+      hasLaneData && origLaneDataDim == computeProduct(perSgShape);
   SmallVector<int64_t> expLaneLayout(expCount, 1);
   SmallVector<int64_t> expLaneData(expCount, 1);
+  if (hasLaneData)
+    expLaneData = spread(origLaneDataDim, perSgShape);
   if (hasLaneLayout) {
-    expLaneLayout = spread(origLaneLayoutDim, perSgShape,
-                           /*outerToInner=*/true);
-    splice(laneLayout, expLaneLayout);
-  }
-  if (hasLaneData) {
     SmallVector<int64_t> dimSizeCap(perSgShape.begin(), perSgShape.end());
-    if (hasLaneLayout)
+    if (hasLaneData && !laneDataReplicated)
       for (int64_t i = 0; i < expCount; ++i)
-        dimSizeCap[i] /= expLaneLayout[i];
-    expLaneData = spread(origLaneDataDim, dimSizeCap, /*outerToInner=*/false);
-    splice(laneData, expLaneData);
+        dimSizeCap[i] /= expLaneData[i];
+    expLaneLayout = spread(origLaneLayoutDim, dimSizeCap);
   }
+  if (hasLaneData)
+    splice(laneData, expLaneData);
+  if (hasLaneLayout)
+    splice(laneLayout, expLaneLayout);
 
-  // inst_data: when lane info is present, the per-lane atom
-  // `laneLayout[i] * laneData[i]` is the minimum granularity each new dim must
-  // hold to keep the lane-level distribution unit aligned with inst_data; the
-  // remaining factor `inst_data / laneAtom` is then spread innermost-first
-  // (capped by `perSgShape[i] / atom[i]`) and multiplied back onto the atom.
-  // Without lane info, fall back to a plain innermost-first spread over
-  // perSgShape.
+  // inst_data: seed each dim from the per-lane atom
+  // `laneLayout[i]*laneData[i]`, spread the remaining factor over the leftover,
+  // then scale back by the atom. Without lane info, spread inst_data directly
+  // over the per-sg extent.
   if (hasInstData) {
     SmallVector<int64_t> expInstData;
     if (!hasLaneLayout || !hasLaneData) {
-      expInstData = spread(origInstDataDim, perSgShape, /*outerToInner=*/false);
+      expInstData = spread(origInstDataDim, perSgShape);
     } else {
       int64_t laneAtom = origLaneLayoutDim * origLaneDataDim;
       SmallVector<int64_t> atom(expCount, 1);
@@ -865,8 +842,7 @@ DistributeLayoutAttr LayoutAttr::expandDim(int64_t dim,
         atom[i] = expLaneLayout[i] * expLaneData[i];
         dimSizeCap[i] = perSgShape[i] / atom[i];
       }
-      expInstData = spread(origInstDataDim / laneAtom, dimSizeCap,
-                           /*outerToInner=*/false);
+      expInstData = spread(origInstDataDim / laneAtom, dimSizeCap);
       for (int64_t i = 0; i < expCount; ++i)
         expInstData[i] *= atom[i];
     }

--- a/mlir/test/Dialect/XeGPU/propagate-layout-inst-data.mlir
+++ b/mlir/test/Dialect/XeGPU/propagate-layout-inst-data.mlir
@@ -242,7 +242,7 @@ gpu.module @test {
 // CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<inst_data = [32], lane_layout = [16], lane_data = [2]>} dense<true> : vector<256xi1>
 // CHECK: %[[STEP:.*]] = vector.step {layout_result_0 = #xegpu.layout<inst_data = [32], lane_layout = [16], lane_data = [2]>} : vector<256xindex>
 // CHECK: %[[LOAD:.*]] = xegpu.load %arg0[%[[STEP]]], %[[CST]] <{layout = #xegpu.layout<inst_data = [32], lane_layout = [16], lane_data = [2]>}> : memref<256xf16>, vector<256xindex>, vector<256xi1> -> vector<256xf16>
-// CHECK: %[[CAST_0:.*]] = vector.shape_cast %[[LOAD]] {layout_result_0 = #xegpu.layout<inst_data = [2, 4, 4], lane_layout = [2, 4, 2], lane_data = [1, 1, 2]>} : vector<256xf16> to vector<2x4x32xf16>
+// CHECK: %[[CAST_0:.*]] = vector.shape_cast %[[LOAD]] {layout_result_0 = #xegpu.layout<inst_data = [1, 1, 32], lane_layout = [1, 1, 16], lane_data = [1, 1, 2]>} : vector<256xf16> to vector<2x4x32xf16>
 // CHECK: %[[CAST_1:.*]] = vector.shape_cast %[[CAST_0]] {layout_result_0 = #xegpu.layout<inst_data = [1, 32], lane_layout = [1, 16], lane_data = [1, 2]>} : vector<2x4x32xf16> to vector<1x256xf16>
 // CHECK: %[[CAST_2:.*]] = vector.shape_cast %[[CAST_1]] {layout_result_0 = #xegpu.layout<inst_data = [32], lane_layout = [16], lane_data = [2]>} : vector<1x256xf16> to vector<256xf16>
 // CHECK: xegpu.store %[[CAST_2]], %arg1[%[[STEP]]], %[[CST]] <{layout = #xegpu.layout<inst_data = [32], lane_layout = [16], lane_data = [2]>}> : vector<256xf16>, memref<256xf16>, vector<256xindex>, vector<256xi1>
@@ -453,21 +453,11 @@ func.func @dpas_mx_f4e2m1(%arg0: memref<16x1024xf4E2M1FN>, %arg1: memref<1024x32
 }
 
 // -----
-// shape_cast that collapses all src dims into a single innermost dst dim.
-// Consumer carries inst_data + lane_layout=[..,subgroupSize] + lane_data=[..,1]
-// (the canonical inst-level anchor for this code path).
-// Distribution is always outer-to-inner to make sure larger contiguous chunks
-// are given to each compute unit first.
-// srcShape=[8, 16, 32], resShape=[4096], consumer inst_data=[32],
-// lane_layout=[16], lane_data=[1]
-// lane_layout outer-to-inner: dim0 take=min(16,8)=8 (rem=2);
-//   dim1 take=min(2,16)=2 (rem=1) -> [8, 2, 1].
-// lane_data innermost-first: total=1 -> [1, 1, 1].
-// inst_data: laneAtom=16, seed [8, 2, 1]; remaining=32/16=2 spreads
-//   innermost-first: dim2 cap=32/1=32, take=2 -> inst_data[2]=2 -> [8, 2, 2].
+// shape_cast collapse [8, 16, 32] -> [4096]: lane/inst factors fill the fast
+// innermost dim first.
 gpu.module @test {
 // CHECK-LABEL: func.func @vector_shape_cast_collapse_innermost(
-// CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<inst_data = [8, 2, 2], lane_layout = [8, 2, 1], lane_data = [1, 1, 1]>} dense<0.000000e+00> : vector<8x16x32xf16>
+// CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<inst_data = [1, 1, 32], lane_layout = [1, 1, 16], lane_data = [1, 1, 1]>} dense<0.000000e+00> : vector<8x16x32xf16>
 // CHECK: %[[CAST:.*]] = vector.shape_cast %[[CST]] {layout_result_0 = #xegpu.layout<inst_data = [32], lane_layout = [16], lane_data = [1]>} : vector<8x16x32xf16> to vector<4096xf16>
 func.func @vector_shape_cast_collapse_innermost(%arg0: memref<4096xf16>) {
     %cst_v = arith.constant dense<0.000000e+00> : vector<8x16x32xf16>
@@ -480,19 +470,11 @@ func.func @vector_shape_cast_collapse_innermost(%arg0: memref<4096xf16>) {
 }
 
 // -----
-// shape_cast collapse where the outermost src dim is too small to absorb the
-// full lane_layout, so it spills inward across multiple src dims.
-// srcShape=[2, 8, 32], resShape=[512], consumer inst_data=[64],
-// lane_layout=[16], lane_data=[2]
-// lane_layout outer-to-inner: dim0 take=min(16,2)=2 (rem=8);
-//   dim1 take=min(8,8)=8 (rem=1) -> [2, 8, 1].
-// lane_data innermost-first: total=2; dim2 cap=32/1=32, take=2 -> [1, 1, 2].
-// inst_data: laneAtom=16*2=32, seed [2*1, 8*1, 1*2] = [2, 8, 2];
-//   remaining=64/32=2 spreads innermost-first: dim2 cap=32/2=16, take=2
-//   -> inst_data[2] *= 2 -> [2, 8, 4].
+// shape_cast collapse [2, 8, 32] -> [512]: the innermost src dim absorbs the
+// full lane distribution, leaving the remaining inst_data factor for dim 1.
 gpu.module @test {
 // CHECK-LABEL: func.func @vector_shape_cast_collapse_lane_layout_spill_inward(
-// CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<inst_data = [2, 8, 4], lane_layout = [2, 8, 1], lane_data = [1, 1, 2]>} dense<0.000000e+00> : vector<2x8x32xf16>
+// CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<inst_data = [1, 2, 32], lane_layout = [1, 1, 16], lane_data = [1, 1, 2]>} dense<0.000000e+00> : vector<2x8x32xf16>
 // CHECK: %[[CAST:.*]] = vector.shape_cast %[[CST]] {layout_result_0 = #xegpu.layout<inst_data = [64], lane_layout = [16], lane_data = [2]>} : vector<2x8x32xf16> to vector<512xf16>
 func.func @vector_shape_cast_collapse_lane_layout_spill_inward(%arg0: memref<512xf16>) {
     %cst_v = arith.constant dense<0.000000e+00> : vector<2x8x32xf16>
@@ -505,20 +487,11 @@ func.func @vector_shape_cast_collapse_lane_layout_spill_inward(%arg0: memref<512
 }
 
 // -----
-// shape_cast collapse with multiple non-trivial groups: every dst dim
-// collapses >=2 src dims, exercising the general matchDimCollapse path.
-// srcShape=[2, 4, 8, 16], resShape=[8, 128], consumer inst_data=[1, 16],
-// lane_layout=[1, 16], lane_data=[1, 1]
-//  - dst[0]=8 collapses src[0, 1]: lane_layout=1, lane_data=1, inst_data=1
-//      -> [1, 1, _, _] for all three.
-//  - dst[1]=128 collapses src[2, 3]: lane_layout outer-to-inner over [2, 3]:
-//      dim2 take=min(16, 8)=8 (rem=2); dim3 take=min(2, 16)=2 (rem=1)
-//      -> [_, _, 8, 2]; lane_data=1 -> [_, _, 1, 1]; inst_data laneAtom=16,
-//      seed [_, _, 8*1, 2*1] = [_, _, 8, 2]; remaining=16/16=1 -> done
-//      -> inst_data=[_, _, 8, 2].
+// shape_cast collapse [2, 4, 8, 16] -> [8, 128]: multiple non-trivial groups,
+// exercising the general matchDimCollapse path.
 gpu.module @test {
 // CHECK-LABEL: func.func @vector_shape_cast_collapse_multi_groups(
-// CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<inst_data = [1, 1, 8, 2], lane_layout = [1, 1, 8, 2], lane_data = [1, 1, 1, 1]>} dense<0.000000e+00> : vector<2x4x8x16xf16>
+// CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<inst_data = [1, 1, 1, 16], lane_layout = [1, 1, 1, 16], lane_data = [1, 1, 1, 1]>} dense<0.000000e+00> : vector<2x4x8x16xf16>
 // CHECK: %[[CAST:.*]] = vector.shape_cast %[[CST]] {layout_result_0 = #xegpu.layout<inst_data = [1, 16], lane_layout = [1, 16], lane_data = [1, 1]>} : vector<2x4x8x16xf16> to vector<8x128xf16>
 func.func @vector_shape_cast_collapse_multi_groups(%arg0: memref<8x128xf16>) {
     %cst_v = arith.constant dense<0.000000e+00> : vector<2x4x8x16xf16>
@@ -526,6 +499,24 @@ func.func @vector_shape_cast_collapse_multi_groups(%arg0: memref<8x128xf16>) {
     %tdesc = xegpu.create_nd_tdesc %arg0 : memref<8x128xf16> -> !xegpu.tensor_desc<8x128xf16>
     xegpu.store_nd %0, %tdesc[0, 0] <{layout = #xegpu.layout<inst_data = [1, 16], lane_layout = [1, 16], lane_data = [1, 1]>}> : vector<8x128xf16>, !xegpu.tensor_desc<8x128xf16>
     return
+  }
+}
+
+// -----
+// broadcast feeding a shape_cast collapse [8, 32, 32] -> [256, 32]: lanes and
+// lane_data of the collapsed dim wrap around onto the fast innermost dim.
+gpu.module @test {
+// CHECK-LABEL: gpu.func @shape_cast_collapse_lane_layout(
+// CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<inst_data = [1, 1, 4], lane_layout = [1, 8, 4], lane_data = [1, 1, 1], order = [1, 0, 2]>} {{.*}} : vector<8x1x32xf8E8M0FNU>
+// CHECK: %[[BC:.*]] = vector.broadcast %[[CST]] {layout_result_0 = #xegpu.layout<inst_data = [1, 16, 4], lane_layout = [1, 8, 4], lane_data = [1, 2, 1], order = [1, 0, 2]>} : vector<8x1x32xf8E8M0FNU> to vector<8x32x32xf8E8M0FNU>
+// CHECK: %[[CAST:.*]] = vector.shape_cast %[[BC]] {layout_result_0 = #xegpu.layout<inst_data = [16, 4], lane_layout = [8, 4], lane_data = [2, 1], order = [0, 1]>} : vector<8x32x32xf8E8M0FNU> to vector<256x32xf8E8M0FNU>
+  gpu.func @shape_cast_collapse_lane_layout(%dst: memref<256x32xf8E8M0FNU>) kernel {
+    %cst = arith.constant dense<0.000000e+00> : vector<8x1x32xf8E8M0FNU>
+    %bc = vector.broadcast %cst : vector<8x1x32xf8E8M0FNU> to vector<8x32x32xf8E8M0FNU>
+    %sc = vector.shape_cast %bc : vector<8x32x32xf8E8M0FNU> to vector<256x32xf8E8M0FNU>
+    %tdesc = xegpu.create_nd_tdesc %dst : memref<256x32xf8E8M0FNU> -> !xegpu.tensor_desc<256x32xf8E8M0FNU>
+    xegpu.store_nd %sc, %tdesc[0, 0] <{layout = #xegpu.layout<inst_data = [16, 4], lane_layout = [8, 4], lane_data = [2, 1], order = [0, 1]>}> : vector<256x32xf8E8M0FNU>, !xegpu.tensor_desc<256x32xf8E8M0FNU>
+    gpu.return
   }
 }
 

--- a/mlir/test/Dialect/XeGPU/propagate-layout-subgroup.mlir
+++ b/mlir/test/Dialect/XeGPU/propagate-layout-subgroup.mlir
@@ -579,13 +579,30 @@ gpu.module @test {
 // -----
 gpu.module @test {
 // CHECK-LABEL: gpu.func @shape_cast_collapse_replicated(
-// CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<sg_layout = [2, 2, 1], sg_data = [8, 8, 8]>} dense<0.000000e+00> : vector<16x8x8xf16>
+// CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<sg_layout = [2, 1, 2], sg_data = [8, 8, 8]>} dense<0.000000e+00> : vector<16x8x8xf16>
 // CHECK: %[[CAST:.*]] = vector.shape_cast %[[CST]] {layout_result_0 = #xegpu.layout<sg_layout = [2, 2], sg_data = [8, 64]>} : vector<16x8x8xf16> to vector<16x64xf16>
   gpu.func @shape_cast_collapse_replicated(%dst: memref<16x64xf16>) kernel {
     %cst = arith.constant dense<0.000000e+00> : vector<16x8x8xf16>
     %0 = vector.shape_cast %cst : vector<16x8x8xf16> to vector<16x64xf16>
     %tdesc = xegpu.create_nd_tdesc %dst : memref<16x64xf16> -> !xegpu.tensor_desc<16x64xf16>
     xegpu.store_nd %0, %tdesc[0, 0] <{layout = #xegpu.layout<sg_layout = [2, 2], sg_data = [8, 64]>}> : vector<16x64xf16>, !xegpu.tensor_desc<16x64xf16>
+    gpu.return
+  }
+}
+
+// -----
+// shape_cast collapse [2, 16] -> [32] with sg_layout=[4], sg_data=[4]:
+// the 4 subgroups wrap around onto the fast innermost dim.
+gpu.module @test {
+// CHECK-LABEL: gpu.func @shape_cast_collapse_sg_wraparound(
+// CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<sg_layout = [1, 4], sg_data = [1, 4]>} dense<0.000000e+00> : vector<2x16xf16>
+// CHECK: %[[CAST:.*]] = vector.shape_cast %[[CST]] {layout_result_0 = #xegpu.layout<sg_layout = [4], sg_data = [4]>} : vector<2x16xf16> to vector<32xf16>
+  gpu.func @shape_cast_collapse_sg_wraparound(%dst: memref<32xf16>) kernel {
+    %cst = arith.constant dense<0.000000e+00> : vector<2x16xf16>
+    %0 = vector.shape_cast %cst : vector<2x16xf16> to vector<32xf16>
+    %mask = arith.constant dense<true> : vector<32xi1>
+    %offsets = vector.step : vector<32xindex>
+    xegpu.store %0, %dst[%offsets], %mask <{layout = #xegpu.layout<sg_layout = [4], sg_data = [4]>}> : vector<32xf16>, memref<32xf16>, vector<32xindex>, vector<32xi1>
     gpu.return
   }
 }

--- a/mlir/test/Dialect/XeGPU/propagate-layout.mlir
+++ b/mlir/test/Dialect/XeGPU/propagate-layout.mlir
@@ -808,7 +808,7 @@ gpu.module @test {
 // CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<lane_layout = [16], lane_data = [2]>} dense<true> : vector<256xi1>
 // CHECK: %[[STEP:.*]] = vector.step {layout_result_0 = #xegpu.layout<lane_layout = [16], lane_data = [2]>} : vector<256xindex>
 // CHECK: %[[LOAD:.*]] = xegpu.load %arg0[%[[STEP]]], %[[CST]] <{layout = #xegpu.layout<lane_layout = [16], lane_data = [2]>}> : memref<256xf16>, vector<256xindex>, vector<256xi1> -> vector<256xf16>
-// CHECK: %[[CAST_0:.*]] = vector.shape_cast %[[LOAD]] {layout_result_0 = #xegpu.layout<lane_layout = [2, 4, 2], lane_data = [1, 1, 2]>} : vector<256xf16> to vector<2x4x32xf16>
+// CHECK: %[[CAST_0:.*]] = vector.shape_cast %[[LOAD]] {layout_result_0 = #xegpu.layout<lane_layout = [1, 1, 16], lane_data = [1, 1, 2]>} : vector<256xf16> to vector<2x4x32xf16>
 // CHECK: %[[CAST_1:.*]] = vector.shape_cast %[[CAST_0]] {layout_result_0 = #xegpu.layout<lane_layout = [1, 16], lane_data = [1, 2]>} : vector<2x4x32xf16> to vector<1x256xf16>
 // CHECK: %[[CAST_2:.*]] = vector.shape_cast %[[CAST_1]] {layout_result_0 = #xegpu.layout<lane_layout = [16], lane_data = [2]>} : vector<1x256xf16> to vector<256xf16>
 // CHECK: xegpu.store %[[CAST_2]], %arg1[%[[STEP]]], %[[CST]] <{layout = #xegpu.layout<lane_layout = [16], lane_data = [2]>}> : vector<256xf16>, memref<256xf16>, vector<256xindex>, vector<256xi1>


### PR DESCRIPTION
The expanded dims of a shape_cast collapse are row-major  (innermost is fastest-varying), so sg_layout/lane_layout must be distributed inner-to-outer rather than outer-to-inner, and jointly with the data component: distribute sg_data/lane_data first, then stride sg_layout/lane_layout over the per-dim leftover.

  Example — shape_cast [8,32,32] -> [256,32] (consumer lane_layout=[8,4], lane_data=[2,1], order=[0,1]),  
  inferred source layout:
  before: inst_data=[8,2,4], lane_layout=[8,1,4], lane_data=[1,2,1], order=[1,0,2]   # lanes on slow dim
  after:  inst_data=[1,16,4], lane_layout=[1,8,4],  lane_data=[1,2,1], order=[1,0,2]   # lanes wrap to fast dim

  This also fixes wrap-around, e.g. [2,16]->[32] with sg_layout=[4], sg_data=[4] → sg_layout=[1,4], sg_data=[1,4].

assisted-by-claude