### PR TITLE
[Object] Disable test on big endian

### DIFF
--- a/llvm/test/tools/llvm-objdump/Offloading/fatbin-coff-compress.test
+++ b/llvm/test/tools/llvm-objdump/Offloading/fatbin-coff-compress.test
@@ -1,6 +1,7 @@
 ## Test that --offloading with a compressed fatbin works correctly in a COFF object.
 
-# REQUIRES: amdgpu-registered-target, zstd
+# The embedded compressed data is in little endian.
+# REQUIRES: amdgpu-registered-target, zstd, host-byteorder-little-endian
 # RUN: yaml2obj %s -o %t.coff
 # RUN: llvm-objdump --offloading %t.coff
 # RUN: llvm-objdump -d %t.coff.0.hip-amdgcn-hsa-amdhsa--gfx942 | FileCheck %s


### PR DESCRIPTION
The embedded compressed payload is in little endian, and offload assumes that host endianness is used. Skip the test if host endianness is not little endian.

Alternative to https://github.com/llvm/llvm-project/pull/205822.