### PR TITLE
[mlir] Fix repeated operand remapping in expressions

### DIFF
--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -417,14 +417,12 @@ struct RemoveRecurringExpressionOperands
   LogicalResult matchAndRewrite(ExpressionOp expressionOp,
                                 PatternRewriter &rewriter) const override {
     SetVector<Value> uniqueOperands;
-    DenseMap<Value, int> firstIndexOf;
 
     // Collect duplicate operands and prepare to remove excessive copies.
-    for (auto [i, operand] : llvm::enumerate(expressionOp.getDefs())) {
+    for (Value operand : expressionOp.getDefs()) {
       if (uniqueOperands.contains(operand))
         continue;
       uniqueOperands.insert(operand);
-      firstIndexOf[operand] = i;
     }
 
     // If every operand is unique, bail out.
@@ -438,13 +436,18 @@ struct RemoveRecurringExpressionOperands
         uniqueOperands.getArrayRef(), expressionOp.getDoNotInline());
     Block &uniqueExpressionBody = uniqueExpression.createBody();
 
+    DenseMap<Value, BlockArgument> uniqueArgFor;
+    for (auto [operand, arg] : llvm::zip(uniqueExpression.getOperands(),
+                                         uniqueExpressionBody.getArguments()))
+      uniqueArgFor[operand] = arg;
+
     // Map each original block arguments to the unique block argument taking
     // the same operand.
     IRMapping mapper;
     Block *expressionBody = expressionOp.getBody();
     for (auto [operand, arg] :
          llvm::zip(expressionOp.getOperands(), expressionBody->getArguments()))
-      mapper.map(arg, uniqueExpressionBody.getArgument(firstIndexOf[operand]));
+      mapper.map(arg, uniqueArgFor[operand]);
 
     rewriter.setInsertionPointToStart(&uniqueExpressionBody);
     for (Operation &opToClone : *expressionOp.getBody())

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -436,13 +436,15 @@ struct RemoveRecurringExpressionOperands
         uniqueOperands.getArrayRef(), expressionOp.getDoNotInline());
     Block &uniqueExpressionBody = uniqueExpression.createBody();
 
+    // Map operands directly because removing duplicates changes block argument
+    // indices, so indices from the original expression cannot be reused.
     DenseMap<Value, BlockArgument> uniqueArgFor;
     for (auto [operand, arg] : llvm::zip(uniqueExpression.getOperands(),
                                          uniqueExpressionBody.getArguments()))
       uniqueArgFor[operand] = arg;
 
-    // Map each original block arguments to the unique block argument taking
-    // the same operand.
+    // Map each original block argument to the unique block argument taking the
+    // same operand.
     IRMapping mapper;
     Block *expressionBody = expressionOp.getBody();
     for (auto [operand, arg] :

--- a/mlir/test/Dialect/EmitC/form-expressions.mlir
+++ b/mlir/test/Dialect/EmitC/form-expressions.mlir
@@ -39,6 +39,21 @@ func.func @expression_recurring_args(%arg0: i32, %arg1: i32) -> i1 {
   return %c : i1
 }
 
+// CHECK-LABEL:   func.func @expression_with_call_recurring_args(
+// CHECK-SAME:      %[[ARG0:.*]]: i32,
+// CHECK-SAME:      %[[ARG1:.*]]: i32) -> i32 {
+// CHECK:           %[[EXPRESSION_0:.*]] = emitc.expression %[[ARG0]], %[[ARG1]] : (i32, i32) -> i32 {
+// CHECK:             %[[VAL_0:.*]] = call_opaque "minsi"(%[[ARG0]], %[[ARG0]], %[[ARG1]]) : (i32, i32, i32) -> i32
+// CHECK:             yield %[[VAL_0]] : i32
+// CHECK:           }
+// CHECK:           return %[[EXPRESSION_0]] : i32
+// CHECK:         }
+
+func.func @expression_with_call_recurring_args(%arg0: i32, %arg1: i32) -> i32 {
+  %0 = emitc.call_opaque "minsi"(%arg0, %arg0, %arg1) : (i32, i32, i32) -> i32
+  return %0 : i32
+}
+
 // CHECK-LABEL: func.func @multiple_expressions(
 // CHECK-SAME:      %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32) -> (i32, i32) {
 // CHECK:         %[[VAL_4:.*]] = emitc.expression %[[VAL_2]], %[[VAL_0]], %[[VAL_1]] : (i32, i32, i32) -> i32 {


### PR DESCRIPTION
EmitC expressions keep a unique list of operands while allowing the same operand to be used multiple times in the expression body.

The previous implementation recorded each operand's first index in the original operand list. However, the expression block arguments correspond to the compacted list of unique operands. When an operand was repeated, these two index spaces diverged, causing subsequent operands to be mapped to the wrong block argument.

Replace the index-based lookup with a direct mapping from each operand to its expression block argument. Repeated uses now resolve to the same block argument without relying on indices from different operand lists.

Fixes #205742 