### PR TITLE
[NFC][AMDGPU][SIMemoryLegalizer] Use BitMaskUtils Helpers

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIMemoryLegalizer.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMemoryLegalizer.cpp
@@ -114,20 +114,20 @@ static StringRef toString(SIAtomicScope S) {
 }
 
 static raw_ostream &operator<<(raw_ostream &OS, SIAtomicAddrSpace AS) {
-  if (AS == SIAtomicAddrSpace::NONE) {
+  if (!AS) {
     OS << "none";
     return OS;
   }
   ListSeparator LS("|");
-  if ((AS & SIAtomicAddrSpace::GLOBAL) != SIAtomicAddrSpace::NONE)
+  if (any(AS & SIAtomicAddrSpace::GLOBAL))
     OS << LS << "global";
-  if ((AS & SIAtomicAddrSpace::LDS) != SIAtomicAddrSpace::NONE)
+  if (any(AS & SIAtomicAddrSpace::LDS))
     OS << LS << "lds";
-  if ((AS & SIAtomicAddrSpace::SCRATCH) != SIAtomicAddrSpace::NONE)
+  if (any(AS & SIAtomicAddrSpace::SCRATCH))
     OS << LS << "scratch";
-  if ((AS & SIAtomicAddrSpace::GDS) != SIAtomicAddrSpace::NONE)
+  if (any(AS & SIAtomicAddrSpace::GDS))
     OS << LS << "gds";
-  if ((AS & SIAtomicAddrSpace::OTHER) != SIAtomicAddrSpace::NONE)
+  if (any(AS & SIAtomicAddrSpace::OTHER))
     OS << LS << "other";
   return OS;
 }
@@ -178,10 +178,8 @@ private:
     }
 
     assert(Scope != SIAtomicScope::NONE &&
-           (OrderingAddrSpace & SIAtomicAddrSpace::ATOMIC) !=
-               SIAtomicAddrSpace::NONE &&
-           (InstrAddrSpace & SIAtomicAddrSpace::ATOMIC) !=
-               SIAtomicAddrSpace::NONE);
+           any(OrderingAddrSpace & SIAtomicAddrSpace::ATOMIC) &&
+           any(InstrAddrSpace & SIAtomicAddrSpace::ATOMIC));
 
     // There is also no cross address space ordering if the ordering
     // address space is the same as the instruction address space and
@@ -192,16 +190,14 @@ private:
 
     // Limit the scope to the maximum supported by the instruction's address
     // spaces.
-    if ((InstrAddrSpace & ~SIAtomicAddrSpace::SCRATCH) ==
-        SIAtomicAddrSpace::NONE) {
+    if (!(InstrAddrSpace & ~SIAtomicAddrSpace::SCRATCH)) {
       this->Scope = std::min(Scope, SIAtomicScope::SINGLETHREAD);
-    } else if ((InstrAddrSpace &
-                ~(SIAtomicAddrSpace::SCRATCH | SIAtomicAddrSpace::LDS)) ==
-               SIAtomicAddrSpace::NONE) {
+    } else if (!(InstrAddrSpace &
+                 ~(SIAtomicAddrSpace::SCRATCH | SIAtomicAddrSpace::LDS))) {
       this->Scope = std::min(Scope, SIAtomicScope::WORKGROUP);
-    } else if ((InstrAddrSpace &
-                ~(SIAtomicAddrSpace::SCRATCH | SIAtomicAddrSpace::LDS |
-                  SIAtomicAddrSpace::GDS)) == SIAtomicAddrSpace::NONE) {
+    } else if (!(InstrAddrSpace &
+                 ~(SIAtomicAddrSpace::SCRATCH | SIAtomicAddrSpace::LDS |
+                   SIAtomicAddrSpace::GDS))) {
       this->Scope = std::min(Scope, SIAtomicScope::AGENT);
     }
 
@@ -900,9 +896,10 @@ std::optional<SIMemOpInfo> SIMemOpAccess::constructFromMIWithMMO(
     }
     std::tie(Scope, OrderingAddrSpace, IsCrossAddressSpaceOrdering) =
         *ScopeOrNone;
-    if ((OrderingAddrSpace == SIAtomicAddrSpace::NONE) ||
-        ((OrderingAddrSpace & SIAtomicAddrSpace::ATOMIC) != OrderingAddrSpace) ||
-        ((InstrAddrSpace & SIAtomicAddrSpace::ATOMIC) == SIAtomicAddrSpace::NONE)) {
+    if (!OrderingAddrSpace ||
+        ((OrderingAddrSpace & SIAtomicAddrSpace::ATOMIC) !=
+         OrderingAddrSpace) ||
+        !(InstrAddrSpace & SIAtomicAddrSpace::ATOMIC)) {
       reportUnsupported(MI, "Unsupported atomic address space");
       return std::nullopt;
     }
@@ -1037,11 +1034,11 @@ bool SICacheControl::enableCPolBits(const MachineBasicBlock::iterator MI,
 
 bool SICacheControl::canAffectGlobalAddrSpace(SIAtomicAddrSpace AS) const {
   assert((!ST.hasGloballyAddressableScratch() ||
-          (AS & SIAtomicAddrSpace::GLOBAL) != SIAtomicAddrSpace::NONE ||
-          (AS & SIAtomicAddrSpace::SCRATCH) == SIAtomicAddrSpace::NONE) &&
+          any(AS & SIAtomicAddrSpace::GLOBAL) ||
+          !(AS & SIAtomicAddrSpace::SCRATCH)) &&
          "scratch instructions should already be replaced by flat "
          "instructions if GloballyAddressableScratch is enabled");
-  return (AS & SIAtomicAddrSpace::GLOBAL) != SIAtomicAddrSpace::NONE;
+  return any(AS & SIAtomicAddrSpace::GLOBAL);
 }
 
 /* static */
@@ -1273,8 +1270,9 @@ bool SIGfx6CacheControl::insertWait(MachineBasicBlock::iterator &MI,
     // the same CU, so no need to wait for global memory as all waves in the
     // work-group access the same the L1, nor wait for GDS as access are ordered
     // on a CU.
-    if (((AddrSpace & (SIAtomicAddrSpace::GLOBAL | SIAtomicAddrSpace::SCRATCH |
-                       SIAtomicAddrSpace::GDS)) != SIAtomicAddrSpace::NONE) &&
+    if (any(AddrSpace &
+            (SIAtomicAddrSpace::GLOBAL | SIAtomicAddrSpace::SCRATCH |
+             SIAtomicAddrSpace::GDS)) &&
         (Scope == SIAtomicScope::WORKGROUP)) {
       // Same as <GFX90A at AGENT scope;
       Scope = SIAtomicScope::AGENT;
@@ -1287,8 +1285,8 @@ bool SIGfx6CacheControl::insertWait(MachineBasicBlock::iterator &MI,
   bool VMCnt = false;
   bool LGKMCnt = false;
 
-  if ((AddrSpace & (SIAtomicAddrSpace::GLOBAL | SIAtomicAddrSpace::SCRATCH)) !=
-      SIAtomicAddrSpace::NONE) {
+  if (any(AddrSpace &
+          (SIAtomicAddrSpace::GLOBAL | SIAtomicAddrSpace::SCRATCH))) {
     switch (Scope) {
     case SIAtomicScope::SYSTEM:
     case SIAtomicScope::AGENT:
@@ -1305,7 +1303,7 @@ bool SIGfx6CacheControl::insertWait(MachineBasicBlock::iterator &MI,
     }
   }
 
-  if ((AddrSpace & SIAtomicAddrSpace::LDS) != SIAtomicAddrSpace::NONE) {
+  if (any(AddrSpace & SIAtomicAddrSpace::LDS)) {
     switch (Scope) {
     case SIAtomicScope::SYSTEM:
     case SIAtomicScope::AGENT:
@@ -1328,7 +1326,7 @@ bool SIGfx6CacheControl::insertWait(MachineBasicBlock::iterator &MI,
     }
   }
 
-  if ((AddrSpace & SIAtomicAddrSpace::GDS) != SIAtomicAddrSpace::NONE) {
+  if (any(AddrSpace & SIAtomicAddrSpace::GDS)) {
     switch (Scope) {
     case SIAtomicScope::SYSTEM:
     case SIAtomicScope::AGENT:
@@ -1367,7 +1365,7 @@ bool SIGfx6CacheControl::insertWait(MachineBasicBlock::iterator &MI,
   // SIInsertWaitcnts will later replace this with a vmcnt().
   if (ST.hasVMemToLDSLoad() && isReleaseOrStronger(Order) &&
       Scope == SIAtomicScope::WORKGROUP &&
-      (AddrSpace & SIAtomicAddrSpace::LDS) != SIAtomicAddrSpace::NONE) {
+      any(AddrSpace & SIAtomicAddrSpace::LDS)) {
     BuildMI(MBB, MI, DL, TII->get(AMDGPU::S_WAITCNT_lds_direct));
     Changed = true;
   }
@@ -1678,14 +1676,14 @@ bool SIGfx10CacheControl::insertWait(MachineBasicBlock::iterator &MI,
   bool VSCnt = false;
   bool LGKMCnt = false;
 
-  if ((AddrSpace & (SIAtomicAddrSpace::GLOBAL | SIAtomicAddrSpace::SCRATCH)) !=
-      SIAtomicAddrSpace::NONE) {
+  if (any(AddrSpace &
+          (SIAtomicAddrSpace::GLOBAL | SIAtomicAddrSpace::SCRATCH))) {
     switch (Scope) {
     case SIAtomicScope::SYSTEM:
     case SIAtomicScope::AGENT:
-      if ((Op & SIMemOp::LOAD) != SIMemOp::NONE)
+      if (any(Op & SIMemOp::LOAD))
         VMCnt |= true;
-      if ((Op & SIMemOp::STORE) != SIMemOp::NONE)
+      if (any(Op & SIMemOp::STORE))
         VSCnt |= true;
       break;
     case SIAtomicScope::WORKGROUP:
@@ -1698,9 +1696,9 @@ bool SIGfx10CacheControl::insertWait(MachineBasicBlock::iterator &MI,
       // happens-before, e.g. other waves of the workgroup must be able to
       // release the memory from another wave at a wider scope.
       if (!ST.isCuModeEnabled() || isReleaseOrStronger(Order)) {
-        if ((Op & SIMemOp::LOAD) != SIMemOp::NONE)
+        if (any(Op & SIMemOp::LOAD))
           VMCnt |= true;
-        if ((Op & SIMemOp::STORE) != SIMemOp::NONE)
+        if (any(Op & SIMemOp::STORE))
           VSCnt |= true;
       }
       break;
@@ -1714,7 +1712,7 @@ bool SIGfx10CacheControl::insertWait(MachineBasicBlock::iterator &MI,
     }
   }
 
-  if ((AddrSpace & SIAtomicAddrSpace::LDS) != SIAtomicAddrSpace::NONE) {
+  if (any(AddrSpace & SIAtomicAddrSpace::LDS)) {
     switch (Scope) {
     case SIAtomicScope::SYSTEM:
     case SIAtomicScope::AGENT:
@@ -1737,7 +1735,7 @@ bool SIGfx10CacheControl::insertWait(MachineBasicBlock::iterator &MI,
     }
   }
 
-  if ((AddrSpace & SIAtomicAddrSpace::GDS) != SIAtomicAddrSpace::NONE) {
+  if (any(AddrSpace & SIAtomicAddrSpace::GDS)) {
     switch (Scope) {
     case SIAtomicScope::SYSTEM:
     case SIAtomicScope::AGENT:
@@ -1776,7 +1774,7 @@ bool SIGfx10CacheControl::insertWait(MachineBasicBlock::iterator &MI,
   // SIInsertWaitcnts will later replace this with a vmcnt().
   if (ST.hasVMemToLDSLoad() && isReleaseOrStronger(Order) &&
       Scope == SIAtomicScope::WORKGROUP &&
-      (AddrSpace & SIAtomicAddrSpace::LDS) != SIAtomicAddrSpace::NONE) {
+      any(AddrSpace & SIAtomicAddrSpace::LDS)) {
     BuildMI(MBB, MI, DL, TII->get(AMDGPU::S_WAITCNT_lds_direct));
     Changed = true;
   }
@@ -1918,15 +1916,15 @@ bool SIGfx12CacheControl::insertWait(MachineBasicBlock::iterator &MI,
   if (Pos == Position::AFTER)
     ++MI;
 
-  if ((AddrSpace & (SIAtomicAddrSpace::GLOBAL | SIAtomicAddrSpace::SCRATCH)) !=
-      SIAtomicAddrSpace::NONE) {
+  if (any(AddrSpace &
+          (SIAtomicAddrSpace::GLOBAL | SIAtomicAddrSpace::SCRATCH))) {
     switch (Scope) {
     case SIAtomicScope::SYSTEM:
     case SIAtomicScope::AGENT:
     case SIAtomicScope::CLUSTER:
-      if ((Op & SIMemOp::LOAD) != SIMemOp::NONE)
+      if (any(Op & SIMemOp::LOAD))
         LOADCnt |= true;
-      if ((Op & SIMemOp::STORE) != SIMemOp::NONE)
+      if (any(Op & SIMemOp::STORE))
         STORECnt |= true;
       break;
     case SIAtomicScope::WORKGROUP:
@@ -1948,9 +1946,9 @@ bool SIGfx12CacheControl::insertWait(MachineBasicBlock::iterator &MI,
       //   guarantee between the ports.
       if (!ST.isCuModeEnabled() || ST.hasGFX1250Insts() ||
           isReleaseOrStronger(Order)) {
-        if ((Op & SIMemOp::LOAD) != SIMemOp::NONE)
+        if (any(Op & SIMemOp::LOAD))
           LOADCnt |= true;
-        if ((Op & SIMemOp::STORE) != SIMemOp::NONE)
+        if (any(Op & SIMemOp::STORE))
           STORECnt |= true;
       }
       break;
@@ -1964,7 +1962,7 @@ bool SIGfx12CacheControl::insertWait(MachineBasicBlock::iterator &MI,
     }
   }
 
-  if ((AddrSpace & SIAtomicAddrSpace::LDS) != SIAtomicAddrSpace::NONE) {
+  if (any(AddrSpace & SIAtomicAddrSpace::LDS)) {
     switch (Scope) {
     case SIAtomicScope::SYSTEM:
     case SIAtomicScope::AGENT:


### PR DESCRIPTION
We already used BitMaskUtils but did not use any of the helpers.
Fix it so the pass is a bit less verbose.

One unfortunate problem with BitMaskUtils is the lack of a bool operator,
so we need to use `any` instead. This is because C++ doesn't allow
conversion operators as free functions.