### PR TITLE
AMDGPU: Remove leftover test for old promote-alloca subtarget feature

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/target-cpu.ll
+++ b/llvm/test/CodeGen/AMDGPU/target-cpu.ll
@@ -72,18 +72,6 @@ define amdgpu_kernel void @target_fiji() #4 {
   ret void
 }
 
-; CHECK-LABEL: {{^}}promote_alloca_enabled:
-; CHECK: ds_read_b32
-define amdgpu_kernel void @promote_alloca_enabled(ptr addrspace(1) nocapture %out, ptr addrspace(1) nocapture %in) #5 {
-entry:
-  %stack = alloca [5 x i32], align 4, addrspace(5)
-  %tmp = load i32, ptr addrspace(1) %in, align 4
-  %arrayidx1 = getelementptr inbounds [5 x i32], ptr addrspace(5) %stack, i32 0, i32 %tmp
-  %load = load i32, ptr addrspace(5) %arrayidx1
-  store i32 %load, ptr addrspace(1) %out
-  ret void
-}
-
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readnone }
 attributes #2 = { nounwind "target-cpu"="tahiti" }


### PR DESCRIPTION
This feature was removed in a56993a694ed02775285b9fe0e23fce8346491c9.
The test used to have a pair testing the enabled and disabled case,
and there's no point leaving the enabled partner.