### PR TITLE
[lldb][Windows] Add Git utils to PATH in CI

### DIFF
--- a/.ci/green-dragon/lldb-windows.groovy
+++ b/.ci/green-dragon/lldb-windows.groovy
@@ -53,6 +53,8 @@ call "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary
 
 "C:\\Program Files\\Python313\\python.exe" -m pip install packaging || exit /b 1
 
+set "PATH=%PATH%;C:\\Program Files\\Git\\usr\\bin"
+
 cmake -G Ninja ^
     -S llvm ^
     -B ..\\llvm-build\\ ^


### PR DESCRIPTION
LLDB on Windows requires GNU tools like `dirname` which are not installed by default. They are bundled with Git for Windows which also depends on them. They are not in PATH however.

This patch adds those utilities to the PATH to fix lldb test targets build failures.