### PR TITLE
[lldb][windows] allow long paths in process launcher

### DIFF
--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Program.h"
+#include "llvm/Support/Windows/WindowsSupport.h"
 #include "llvm/Support/WindowsError.h"
 
 #include <string>
@@ -226,16 +227,20 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
   // command line is not empty, its contents may be modified by CreateProcessW.
   WCHAR *pwcommandLine = wcommandLine.empty() ? nullptr : &wcommandLine[0];
 
-  std::wstring wexecutable, wworkingDirectory;
-  llvm::ConvertUTF8toWide(launch_info.GetExecutableFile().GetPath(),
-                          wexecutable);
+  llvm::SmallVector<wchar_t, MAX_PATH> wexecutable;
+  if (std::error_code ec = llvm::sys::windows::widenPath(
+          launch_info.GetExecutableFile().GetPath(), wexecutable)) {
+    error = Status(ec);
+    return HostProcess();
+  }
+  std::wstring wworkingDirectory;
   llvm::ConvertUTF8toWide(launch_info.GetWorkingDirectory().GetPath(),
                           wworkingDirectory);
 
   PROCESS_INFORMATION pi = {};
 
   BOOL result = ::CreateProcessW(
-      wexecutable.c_str(), pwcommandLine, nullptr, nullptr,
+      wexecutable.data(), pwcommandLine, nullptr, nullptr,
       /*bInheritHandles=*/!inherited_handles.empty() ||
           pty_mode != PseudoConsole::Mode::None,
       flags, environment.data(),


### PR DESCRIPTION
`MAX_PATH` is defined as `260` on Windows. Unicode paths however can be up to `32,767` characters long. 

Use `llvm::sys::windows::widenPath` to convert paths to unicode paths to allow targets that have long path names.

This is the first part of a series of multiple commits that will fix long path support in lldb on Windows as well as adding regression tests.

rdar://180711797