### PR TITLE
[flang] Fix build with BUILD_SHARED_LIBS=ON

### DIFF
--- a/flang/unittests/Frontend/CMakeLists.txt
+++ b/flang/unittests/Frontend/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(FlangFrontendTests
 clang_target_link_libraries(FlangFrontendTests
   PRIVATE
   clangBasic
+  clangOptions
 )
 
 mlir_target_link_libraries(FlangFrontendTests


### PR DESCRIPTION
```
/usr/bin/ld: tools/flang/unittests/Frontend/CMakeFiles/FlangFrontendTests.dir/CompilerInstanceTest.cpp.o: undefined reference to symbol '_ZN5clang17getDriverOptTableEv'
/usr/bin/ld: b/x86/lib/libclangOptions.so.23.0git: error adding symbols: DSO missing from command line
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```