### PR TITLE
[lldb-dap][Windows] use Unicode path limit

### DIFF
--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -27,6 +27,7 @@
 #include "lldb/API/SBPlatform.h"
 #include "lldb/API/SBStream.h"
 #include "lldb/API/SBThread.h"
+#include "lldb/Host/PosixApi.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-types.h"
 #include "llvm/Support/Error.h"
@@ -36,15 +37,6 @@
 #include "llvm/Support/raw_ostream.h"
 #include <mutex>
 #include <utility>
-
-#if defined(_WIN32)
-#define NOMINMAX
-#include <windows.h>
-
-#ifndef PATH_MAX
-#define PATH_MAX MAX_PATH
-#endif
-#endif
 
 using namespace llvm;
 


### PR DESCRIPTION
`MAX_PATH` is defined as 260. `PosixApi.h` already defines `PATH_MAX` as `32,768` characters which is the max path limit for Unicode paths on Windows.

Use this in `lldb-dap` on Windows to avoid path truncation.