### PR TITLE
[X86] Fix boundary check in optimizeCompareInstr ImmDelta path

### DIFF
--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -5567,9 +5567,11 @@ bool X86InstrInfo::optimizeCompareInstr(MachineInstr &CmpInstr, Register SrcReg,
       unsigned BitWidth = RI.getRegSizeInBits(*MRI->getRegClass(SrcReg));
       // Shift amount for min/max constants to adjust for 8/16/32 instruction
       // sizes.
+      APInt CmpVal(BitWidth, static_cast<uint64_t>(CmpValue),
+                   /*isSigned=*/false, /*implicitTrunc=*/true);
       switch (OldCC) {
       case X86::COND_L: // x <s (C + 1)  -->  x <=s C
-        if (ImmDelta != 1 || APInt::getSignedMinValue(BitWidth) == CmpValue)
+        if (ImmDelta != 1 || APInt::getSignedMinValue(BitWidth) == CmpVal)
           return false;
         ReplacementCC = X86::COND_LE;
         break;
@@ -5579,7 +5581,7 @@ bool X86InstrInfo::optimizeCompareInstr(MachineInstr &CmpInstr, Register SrcReg,
         ReplacementCC = X86::COND_BE;
         break;
       case X86::COND_GE: // x >=s (C + 1)  -->  x >s C
-        if (ImmDelta != 1 || APInt::getSignedMinValue(BitWidth) == CmpValue)
+        if (ImmDelta != 1 || APInt::getSignedMinValue(BitWidth) == CmpVal)
           return false;
         ReplacementCC = X86::COND_G;
         break;
@@ -5589,22 +5591,22 @@ bool X86InstrInfo::optimizeCompareInstr(MachineInstr &CmpInstr, Register SrcReg,
         ReplacementCC = X86::COND_A;
         break;
       case X86::COND_G: // x >s (C - 1)  -->  x >=s C
-        if (ImmDelta != -1 || APInt::getSignedMaxValue(BitWidth) == CmpValue)
+        if (ImmDelta != -1 || APInt::getSignedMaxValue(BitWidth) == CmpVal)
           return false;
         ReplacementCC = X86::COND_GE;
         break;
       case X86::COND_A: // x >u (C - 1)  -->  x >=u C
-        if (ImmDelta != -1 || APInt::getMaxValue(BitWidth) == CmpValue)
+        if (ImmDelta != -1 || APInt::getMaxValue(BitWidth) == CmpVal)
           return false;
         ReplacementCC = X86::COND_AE;
         break;
       case X86::COND_LE: // x <=s (C - 1)  -->  x <s C
-        if (ImmDelta != -1 || APInt::getSignedMaxValue(BitWidth) == CmpValue)
+        if (ImmDelta != -1 || APInt::getSignedMaxValue(BitWidth) == CmpVal)
           return false;
         ReplacementCC = X86::COND_L;
         break;
       case X86::COND_BE: // x <=u (C - 1)  -->  x <u C
-        if (ImmDelta != -1 || APInt::getMaxValue(BitWidth) == CmpValue)
+        if (ImmDelta != -1 || APInt::getMaxValue(BitWidth) == CmpVal)
           return false;
         ReplacementCC = X86::COND_B;
         break;

--- a/llvm/test/CodeGen/X86/optimize-compare.mir
+++ b/llvm/test/CodeGen/X86/optimize-compare.mir
@@ -741,3 +741,28 @@ body: |
     liveins: $eflags
     $al = SETCCr 14, implicit $eflags
 ...
+---
+name: noopt_immdelta_at_umax
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: noopt_immdelta_at_umax
+    ; CHECK: [[COPY:%[0-9]+]]:gr8 = COPY $al
+    ; CHECK-NEXT: CMP8ri [[COPY]], 0, implicit-def $eflags
+    ; CHECK-NEXT: $cl = SETCCr 7, implicit $eflags
+    ; CHECK-NEXT: CMP8ri [[COPY]], -1, implicit-def $eflags
+    ; CHECK-NEXT: $bl = SETCCr 7, implicit $eflags
+    ; CHECK-NEXT: CMP8ri [[COPY]], 0, implicit-def $eflags
+    ; CHECK-NEXT: $cl = SETCCr 6, implicit $eflags
+    ; CHECK-NEXT: CMP8ri [[COPY]], -1, implicit-def $eflags
+    ; CHECK-NEXT: $bl = SETCCr 6, implicit $eflags
+    %0:gr8 = COPY $al
+    CMP8ri %0, 0, implicit-def $eflags
+    $cl = SETCCr 7, implicit $eflags
+    CMP8ri %0, -1, implicit-def $eflags
+    $bl = SETCCr 7, implicit $eflags
+
+    CMP8ri %0, 0, implicit-def $eflags
+    $cl = SETCCr 6, implicit $eflags
+    CMP8ri %0, -1, implicit-def $eflags
+    $bl = SETCCr 6, implicit $eflags
+...


### PR DESCRIPTION
This peephole reuses a neighbouring compare's flags when the constants differ by +/-1, shifting the condition code to compensate; min/max guards block it where that +/-1 would wrap.

Those guards compared a BitWidth-wide boundary APInt against the int64 CmpValue. APInt::operator==(uint64_t) compares the boundary's zero-extended value against the full 64-bit immediate, so a sign-extended immediate never matches the narrow, zero-extended boundary and the guard is silently skipped.

The reachable case is the unsigned upper edge (COND_A / COND_BE): the unsigned maximum is carried as -1 (all ones) and never equals the zero-extended getMaxValue(). So "x >u UMAX" (always false) is wrongly rewritten to "x >=u 0" (always true), and the mirror "x <=u UMAX" (always true) to "x <u 0" (always false).

Truncate CmpValue to a BitWidth-wide APInt before comparing so both sides have the same width. The fix is applied to every boundary guard, not just the reachable ones.

Found via @jlebar's X86 LLVM bug hunt / FuzzX effort: [https://github.com/SemiAnalysisAI/FuzzX/blob/master/x86/bugs/055-optimizeCmp-narrow-immDelta-signext/NOTES.md](https://github.com/SemiAnalysisAI/FuzzX/blob/master/x86/bugs/055-optimizeCmp-narrow-immDelta-signext/NOTES.md)

Assisted-By: Claude