### PR TITLE
[AMDGPU] Use an explicit S_MOV with V_MIN in FPToSSatI16Pat pattern

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -3275,7 +3275,7 @@ multiclass FPToSSatI16Pat<dag lhs, int hi, int lo> {
 }
 multiclass FPToUSatI16Pat<dag lhs, int hi> {
   defm : FPToIntSatI16Pat<lhs,
-      (V_MIN_U32_e64 (V_CVT_U32_F32_e64 $src0_modifiers, $src0), (i32 hi))>;
+      (V_MIN_U32_e64 (V_CVT_U32_F32_e64 $src0_modifiers, $src0), (S_MOV_B32 (i32 hi)))>;
 }
 
 let SubtargetPredicate = isGFX11Plus in {


### PR DESCRIPTION
This fixes the case where GFX7 fails expensive checks/machine verification with GISel due to passing a literal directly to V_MIN that is not supported on the architecture. This fixes the buildbot failure: https://lab.llvm.org/buildbot/#/builders/187/builds/21241 caused by #202680.