### PR TITLE
[IR] Add non-const DbgRecord::getInstruction() overload

### DIFF
--- a/llvm/include/llvm/IR/DebugProgramInstruction.h
+++ b/llvm/include/llvm/IR/DebugProgramInstruction.h
@@ -190,6 +190,8 @@ public:
   LLVM_ABI const LLVMContext &getContext() const;
 
   LLVM_ABI const Instruction *getInstruction() const;
+  LLVM_ABI Instruction *getInstruction();
+
   LLVM_ABI const BasicBlock *getParent() const;
   LLVM_ABI BasicBlock *getParent();
 
@@ -370,8 +372,8 @@ public:
                         const DILocation *DI, DbgVariableRecord &InsertBefore);
 
   /// Iterator for ValueAsMetadata that internally uses direct pointer iteration
-  /// over either a ValueAsMetadata* or a ValueAsMetadata**, dereferencing to the
-  /// ValueAsMetadata .
+  /// over either a ValueAsMetadata* or a ValueAsMetadata**, dereferencing to
+  /// the ValueAsMetadata .
   class location_op_iterator
       : public iterator_facade_base<location_op_iterator,
                                     std::bidirectional_iterator_tag, Value *> {

--- a/llvm/include/llvm/IR/DebugProgramInstruction.h
+++ b/llvm/include/llvm/IR/DebugProgramInstruction.h
@@ -372,8 +372,8 @@ public:
                         const DILocation *DI, DbgVariableRecord &InsertBefore);
 
   /// Iterator for ValueAsMetadata that internally uses direct pointer iteration
-  /// over either a ValueAsMetadata* or a ValueAsMetadata**, dereferencing to
-  /// the ValueAsMetadata .
+  /// over either a ValueAsMetadata* or a ValueAsMetadata**, dereferencing to the
+  /// ValueAsMetadata .
   class location_op_iterator
       : public iterator_facade_base<location_op_iterator,
                                     std::bidirectional_iterator_tag, Value *> {

--- a/llvm/include/llvm/IR/DebugProgramInstruction.h
+++ b/llvm/include/llvm/IR/DebugProgramInstruction.h
@@ -189,11 +189,11 @@ public:
   LLVM_ABI LLVMContext &getContext();
   LLVM_ABI const LLVMContext &getContext() const;
 
-  LLVM_ABI const Instruction *getInstruction() const;
   LLVM_ABI Instruction *getInstruction();
+  LLVM_ABI const Instruction *getInstruction() const;
 
-  LLVM_ABI const BasicBlock *getParent() const;
   LLVM_ABI BasicBlock *getParent();
+  LLVM_ABI const BasicBlock *getParent() const;
 
   LLVM_ABI void removeFromParent();
   LLVM_ABI void eraseFromParent();

--- a/llvm/lib/IR/DebugProgramInstruction.cpp
+++ b/llvm/lib/IR/DebugProgramInstruction.cpp
@@ -526,6 +526,8 @@ const Instruction *DbgRecord::getInstruction() const {
   return Marker->MarkedInstr;
 }
 
+Instruction *DbgRecord::getInstruction() { return Marker->MarkedInstr; }
+
 const BasicBlock *DbgRecord::getParent() const {
   return Marker->MarkedInstr->getParent();
 }


### PR DESCRIPTION
DbgRecord exposes const+non-const overload pairs for getParent(), getModule() and getContext(), but getInstruction() was const-only and returned a const Instruction*. Code holding a non-const DbgRecord that needs a mutable host instruction, for example to use as a DIBuilder insert position, was therefore forced to const_cast the result.

Add a non-const getInstruction() overload returning a mutable Instruction*, matching the existing accessor pairs and removing the need for those casts. The const overload is unchanged.

AI tools were used to write this description.