### PR TITLE
[lldb][Windows] use Unicode path limit

### DIFF
--- a/lldb/tools/driver/Platform.h
+++ b/lldb/tools/driver/Platform.h
@@ -28,9 +28,6 @@ typedef unsigned char cc_t;
 typedef unsigned int speed_t;
 typedef unsigned int tcflag_t;
 
-// fcntl.h
-#define O_NOCTTY 0400
-
 // ioctls.h
 #define TIOCGWINSZ 0x5413
 
@@ -60,8 +57,7 @@ struct timeval {
   long tv_sec;
   long tv_usec;
 };
-typedef long pid_t;
-#define PATH_MAX MAX_PATH
+#include "lldb/Host/PosixApi.h"
 #endif
 
 #define STDIN_FILENO 0


### PR DESCRIPTION
`MAX_PATH` is defined as `260`. `PosixApi.h` already defines `PATH_MAX` as `32,768` characters which is the max path limit for Unicode paths on Windows.

Use this in lldb on Windows to avoid path truncation.