### PR TITLE
[CodeGen] Search predecessors from the back in removePredecessor()

### DIFF
--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -936,6 +936,8 @@ void MachineBasicBlock::addPredecessor(MachineBasicBlock *Pred) {
 }
 
 void MachineBasicBlock::removePredecessor(MachineBasicBlock *Pred) {
+  // This is often called on many predecessors in reverse order.
+  // Do a reverse search and removal to avoid quadratic behavior in such cases.
   auto RI = llvm::find(reverse(Predecessors), Pred);
   assert(RI != Predecessors.rend() &&
          "Pred is not a predecessor of this block!");

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -936,9 +936,10 @@ void MachineBasicBlock::addPredecessor(MachineBasicBlock *Pred) {
 }
 
 void MachineBasicBlock::removePredecessor(MachineBasicBlock *Pred) {
-  pred_iterator I = find(Predecessors, Pred);
-  assert(I != Predecessors.end() && "Pred is not a predecessor of this block!");
-  Predecessors.erase(I);
+  auto RI = llvm::find(reverse(Predecessors), Pred);
+  assert(RI != Predecessors.rend() &&
+         "Pred is not a predecessor of this block!");
+  Predecessors.erase(std::prev(RI.base()));
 }
 
 void MachineBasicBlock::transferSuccessors(MachineBasicBlock *FromMBB) {


### PR DESCRIPTION
In many passes involving CFG updates, it is a common pattern to process the Predecessors vector from back to front for efficiency. However, the current forward search in removePredecessor often results in an O(N) complexity.

So this patch tries to change the search logic to a reverse search to better align with the majority of actual CFG manipulation scenarios.
And in a real-world case (with ~16k predecessors), this modification can help to reduce the execution time of the BranchFolder pass from 166.4951s to 6.0717s.