### PR TITLE
[AArch64] Enable software pipelining for the Cortex-A320

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -839,6 +839,10 @@ def FeatureNoNegativeImmediates : SubtargetFeature<"no-neg-immediates",
                                         "equivalent when the immediate does "
                                         "not fit in the encoding.">;
 
+// Use the MachinePipeliner for instruction scheduling for the subtarget.
+def FeatureUseMIPipeliner: SubtargetFeature<"use-mipipeliner", "UseMIPipeliner", "true",
+                                            "Use the MachinePipeliner">;
+
 // Address operands with shift amount 2 or 3 are fast on all Arm chips except
 // some old Apple cores (A7-A10?) which handle all shifts slowly. Cortex-A57
 // and derived designs through Cortex-X1 take an extra micro-op for shifts

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -36,6 +36,7 @@
 #include "llvm/CodeGen/MachineMemOperand.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineOperand.h"
+#include "llvm/CodeGen/MachinePipeliner.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/RegisterScavenging.h"
 #include "llvm/CodeGen/StackMaps.h"
@@ -102,6 +103,11 @@ static cl::opt<unsigned> GatherOptSearchLimit(
     "aarch64-search-limit", cl::Hidden, cl::init(2048),
     cl::desc("Restrict range of instructions to search for the "
              "machine-combiner gather pattern optimization"));
+
+static cl::opt<int> AArch64PipelinerMaxScalarII(
+    "aarch64-pipeliner-max-scalar-ii", cl::Hidden, cl::init(-1),
+    cl::desc("Reject scalar-only AArch64 MachinePipeliner schedules above this "
+             "initiation interval (-1 disables the check)"));
 
 AArch64InstrInfo::AArch64InstrInfo(const AArch64Subtarget &STI)
     : AArch64GenInstrInfo(STI, RI, AArch64::ADJCALLSTACKDOWN,
@@ -11695,6 +11701,8 @@ class AArch64PipelinerLoopInfo : public TargetInstrInfo::PipelinerLoopInfo {
   /// The normalized condition used by createTripCountGreaterCondition()
   SmallVector<MachineOperand, 4> Cond;
 
+  bool containsFpOrVectorRegisters(SwingSchedulerDAG &SSD) const;
+
 public:
   AArch64PipelinerLoopInfo(MachineBasicBlock *LoopBB, MachineInstr *CondBranch,
                            MachineInstr *Comp, unsigned CompCounterOprNum,
@@ -11713,6 +11721,15 @@ public:
     // Make the instructions for loop control be placed in stage 0.
     // The predecessors of Comp are considered by the caller.
     return MI == Comp;
+  }
+
+  bool shouldUseSchedule(SwingSchedulerDAG &SSD, SMSchedule &SMS) override {
+    if (AArch64PipelinerMaxScalarII >= 0 &&
+        SMS.getInitiationInterval() > AArch64PipelinerMaxScalarII &&
+        !containsFpOrVectorRegisters(SSD))
+      return false;
+
+    return true;
   }
 
   std::optional<bool> createTripCountGreaterCondition(
@@ -11735,6 +11752,44 @@ public:
 
   bool isMVEExpanderSupported() override { return true; }
 };
+
+bool AArch64PipelinerLoopInfo::containsFpOrVectorRegisters(
+    SwingSchedulerDAG &SSD) const {
+  auto IsFpOrVectorRC = [](const TargetRegisterClass *RC) {
+    return RC && (AArch64::FPR8RegClass.hasSubClassEq(RC) ||
+                  AArch64::FPR16RegClass.hasSubClassEq(RC) ||
+                  AArch64::FPR32RegClass.hasSubClassEq(RC) ||
+                  AArch64::FPR64RegClass.hasSubClassEq(RC) ||
+                  AArch64::FPR128RegClass.hasSubClassEq(RC) ||
+                  AArch64::PPRRegClass.hasSubClassEq(RC) ||
+                  AArch64::PNRRegClass.hasSubClassEq(RC) ||
+                  AArch64::ZPRRegClass.hasSubClassEq(RC) ||
+                  AArch64::ZPR2RegClass.hasSubClassEq(RC) ||
+                  AArch64::ZPR3RegClass.hasSubClassEq(RC) ||
+                  AArch64::ZPR4RegClass.hasSubClassEq(RC));
+  };
+
+  for (SUnit &SU : SSD.SUnits) {
+    const MachineInstr *MI = SU.getInstr();
+    for (const MachineOperand &MO : MI->operands()) {
+      if (!MO.isReg() || !MO.getReg())
+        continue;
+
+      Register Reg = MO.getReg();
+      const TargetRegisterClass *RC = nullptr;
+      if (Reg.isVirtual())
+        RC = MRI.getRegClassOrNull(Reg);
+      else if (Reg.isPhysical())
+        RC = TRI->getMinimalPhysRegClass(Reg.asMCReg());
+
+      if (IsFpOrVectorRC(RC))
+        return true;
+    }
+  }
+
+  return false;
+}
+
 } // namespace
 
 /// Clone an instruction from MI. The register of ReplaceOprNum-th operand

--- a/llvm/lib/Target/AArch64/AArch64Processors.td
+++ b/llvm/lib/Target/AArch64/AArch64Processors.td
@@ -22,6 +22,7 @@ def TuneA320 : SubtargetFeature<"a320", "ARMProcFamily", "CortexA320",
                                    FeatureFuseAES,
                                    FeatureFuseAdrpAdd,
                                    FeaturePostRAScheduler,
+                                   FeatureUseMIPipeliner,
                                    FeatureUseWzrToVecMove,
                                    FeatureUseFixedOverScalableIfEqualCost,
                                    FeatureAggressiveInterleaving]>;

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -98,6 +98,11 @@ static cl::opt<bool>
                                  cl::desc("Enable subreg liveness tracking"));
 
 static cl::opt<bool>
+    EnableMachinePipeliner("aarch64-enable-pipeliner",
+                           cl::desc("Enable Machine Pipeliner for AArch64"),
+                           cl::init(false), cl::Hidden);
+
+static cl::opt<bool>
     UseScalarIncVL("sve-use-scalar-inc-vl", cl::init(false), cl::Hidden,
                    cl::desc("Prefer add+cnt over addvl/inc/dec"));
 
@@ -648,5 +653,6 @@ bool AArch64Subtarget::isX16X17Safer() const {
 }
 
 bool AArch64Subtarget::enableMachinePipeliner() const {
-  return getSchedModel().hasInstrSchedModel();
+  return getSchedModel().hasInstrSchedModel() &&
+         (UseMIPipeliner || EnableMachinePipeliner);
 }

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -218,11 +218,6 @@ static cl::opt<bool>
                    cl::desc("Enable sinking and folding of instruction copies"),
                    cl::init(true), cl::Hidden);
 
-static cl::opt<bool>
-    EnableMachinePipeliner("aarch64-enable-pipeliner",
-                           cl::desc("Enable Machine Pipeliner for AArch64"),
-                           cl::init(false), cl::Hidden);
-
 static cl::opt<bool> EnableSRLTSubregToRegMitigation(
     "aarch64-srlt-mitigate-sr2r",
     cl::desc("Enable SUBREG_TO_REG mitigation by adding 'implicit-def' for "

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -119,9 +119,9 @@ static cl::opt<bool> EnableAtomicTidy(
     cl::init(true));
 
 static cl::opt<bool>
-EnableEarlyIfConversion("aarch64-enable-early-ifcvt", cl::Hidden,
-                        cl::desc("Run early if-conversion"),
-                        cl::init(true));
+    EnableEarlyIfConversion("aarch64-enable-early-ifcvt", cl::Hidden,
+                            cl::desc("Run early if-conversion"),
+                            cl::init(true));
 
 static cl::opt<bool>
     EnableCondOpt("aarch64-enable-condopt",
@@ -539,7 +539,7 @@ size_t AArch64TargetMachine::clearLinkerOptimizationHints(
   return FuncInfo->clearLinkerOptimizationHints(MIs);
 }
 
-void AArch64leTargetMachine::anchor() { }
+void AArch64leTargetMachine::anchor() {}
 
 AArch64leTargetMachine::AArch64leTargetMachine(
     const Target &T, const Triple &TT, StringRef CPU, StringRef FS,
@@ -547,7 +547,7 @@ AArch64leTargetMachine::AArch64leTargetMachine(
     std::optional<CodeModel::Model> CM, CodeGenOptLevel OL, bool JIT)
     : AArch64TargetMachine(T, TT, CPU, FS, Options, RM, CM, OL, JIT, true) {}
 
-void AArch64beTargetMachine::anchor() { }
+void AArch64beTargetMachine::anchor() {}
 
 AArch64beTargetMachine::AArch64beTargetMachine(
     const Target &T, const Triple &TT, StringRef CPU, StringRef FS,
@@ -571,7 +571,7 @@ public:
     return getTM<AArch64TargetMachine>();
   }
 
-  void addIRPasses()  override;
+  void addIRPasses() override;
   bool addPreISel() override;
   void addCodeGenPrepare() override;
   bool addInstSelector() override;
@@ -632,8 +632,7 @@ void AArch64PassConfig::addIRPasses() {
   addPass(createAtomicExpandLegacyPass());
 
   // Expand any SVE vector library calls that we can't code generate directly.
-  if (EnableSVEIntrinsicOpts &&
-      TM->getOptLevel() != CodeGenOptLevel::None)
+  if (EnableSVEIntrinsicOpts && TM->getOptLevel() != CodeGenOptLevel::None)
     addPass(createSVEIntrinsicOptsPass());
 
   // Cmpxchg instructions are often used with a subsequent comparison to
@@ -849,7 +848,7 @@ void AArch64PassConfig::addPreRegAlloc() {
     // be register coalescer friendly.
     addPass(&PeepholeOptimizerLegacyID);
   }
-  if (TM->getOptLevel() != CodeGenOptLevel::None && EnableMachinePipeliner)
+  if (TM->getOptLevel() != CodeGenOptLevel::None)
     addPass(&MachinePipelinerID);
 }
 


### PR DESCRIPTION
Software pipelining gives mostly positive performance improvements for the Cortex-A320. This enables MachinePipeliner for default for the Cortex-A320 and keeps the behaviour of -aarch64-enable-pipeliner for other CPUs.