### PR TITLE
[libc++] Mark LWG3498 as resolved

### DIFF
--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -111,7 +111,7 @@
 "`LWG3422 <https://wg21.link/LWG3422>`__","Issues of ``seed_seq``'s constructors","2021-10 (Virtual)","|Complete|","14","`#104372 <https://github.com/llvm/llvm-project/issues/104372>`__",""
 "`LWG3470 <https://wg21.link/LWG3470>`__","``convertible-to-non-slicing`` seems to reject valid case","2021-10 (Virtual)","|Complete|","14","`#104373 <https://github.com/llvm/llvm-project/issues/104373>`__",""
 "`LWG3480 <https://wg21.link/LWG3480>`__","``directory_iterator`` and ``recursive_directory_iterator`` are not C++20 ranges","2021-10 (Virtual)","|Complete|","14","`#104374 <https://github.com/llvm/llvm-project/issues/104374>`__",""
-"`LWG3498 <https://wg21.link/LWG3498>`__","Inconsistent ``noexcept``-specifiers for ``basic_syncbuf``","2021-10 (Virtual)","|Nothing To Do|","","`#104375 <https://github.com/llvm/llvm-project/issues/104375>`__",""
+"`LWG3498 <https://wg21.link/LWG3498>`__","Inconsistent ``noexcept``-specifiers for ``basic_syncbuf``","2021-10 (Virtual)","|Complete|","18","`#104375 <https://github.com/llvm/llvm-project/issues/104375>`__",""
 "`LWG3535 <https://wg21.link/LWG3535>`__","``join_view::iterator::iterator_category`` and ``::iterator_concept`` lie","2021-10 (Virtual)","|Complete|","15","`#104376 <https://github.com/llvm/llvm-project/issues/104376>`__",""
 "`LWG3554 <https://wg21.link/LWG3554>`__","``chrono::parse`` needs ``const charT*`` and ``basic_string_view<charT>`` overloads","2021-10 (Virtual)","","","`#104377 <https://github.com/llvm/llvm-project/issues/104377>`__",""
 "`LWG3557 <https://wg21.link/LWG3557>`__","The ``static_cast`` expression in ``convertible_to`` has the wrong operand","2021-10 (Virtual)","|Complete|","14","`#104378 <https://github.com/llvm/llvm-project/issues/104378>`__",""

--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -111,7 +111,7 @@
 "`LWG3422 <https://wg21.link/LWG3422>`__","Issues of ``seed_seq``'s constructors","2021-10 (Virtual)","|Complete|","14","`#104372 <https://github.com/llvm/llvm-project/issues/104372>`__",""
 "`LWG3470 <https://wg21.link/LWG3470>`__","``convertible-to-non-slicing`` seems to reject valid case","2021-10 (Virtual)","|Complete|","14","`#104373 <https://github.com/llvm/llvm-project/issues/104373>`__",""
 "`LWG3480 <https://wg21.link/LWG3480>`__","``directory_iterator`` and ``recursive_directory_iterator`` are not C++20 ranges","2021-10 (Virtual)","|Complete|","14","`#104374 <https://github.com/llvm/llvm-project/issues/104374>`__",""
-"`LWG3498 <https://wg21.link/LWG3498>`__","Inconsistent ``noexcept``-specifiers for ``basic_syncbuf``","2021-10 (Virtual)","","","`#104375 <https://github.com/llvm/llvm-project/issues/104375>`__",""
+"`LWG3498 <https://wg21.link/LWG3498>`__","Inconsistent ``noexcept``-specifiers for ``basic_syncbuf``","2021-10 (Virtual)","|Nothing To Do|","","`#104375 <https://github.com/llvm/llvm-project/issues/104375>`__",""
 "`LWG3535 <https://wg21.link/LWG3535>`__","``join_view::iterator::iterator_category`` and ``::iterator_concept`` lie","2021-10 (Virtual)","|Complete|","15","`#104376 <https://github.com/llvm/llvm-project/issues/104376>`__",""
 "`LWG3554 <https://wg21.link/LWG3554>`__","``chrono::parse`` needs ``const charT*`` and ``basic_string_view<charT>`` overloads","2021-10 (Virtual)","","","`#104377 <https://github.com/llvm/llvm-project/issues/104377>`__",""
 "`LWG3557 <https://wg21.link/LWG3557>`__","The ``static_cast`` expression in ``convertible_to`` has the wrong operand","2021-10 (Virtual)","|Complete|","14","`#104378 <https://github.com/llvm/llvm-project/issues/104378>`__",""

--- a/libcxx/test/std/input.output/syncstream/syncbuf/syncstream.syncbuf.assign/assign.pass.cpp
+++ b/libcxx/test/std/input.output/syncstream/syncbuf/syncstream.syncbuf.assign/assign.pass.cpp
@@ -169,6 +169,7 @@ static void test_basic() {
   { // Test properties
     std::basic_syncbuf<CharT> sync_buf1(nullptr);
     std::basic_syncbuf<CharT> sync_buf2(nullptr);
+    ASSERT_NOT_NOEXCEPT(sync_buf1 = std::move(sync_buf2)); // LWG3498
     [[maybe_unused]] std::same_as<std::basic_syncbuf<CharT>&> decltype(auto) ret =
         sync_buf1.operator=(std::move(sync_buf2));
   }

--- a/libcxx/test/std/input.output/syncstream/syncbuf/syncstream.syncbuf.assign/swap.pass.cpp
+++ b/libcxx/test/std/input.output/syncstream/syncbuf/syncstream.syncbuf.assign/swap.pass.cpp
@@ -15,7 +15,7 @@
 // template <class charT, class traits, class Allocator>
 // class basic_syncbuf;
 
-// void swap(basic_syncbuf& other) noexcept;
+// void swap(basic_syncbuf& other);
 
 #include <syncstream>
 #include <sstream>
@@ -43,6 +43,7 @@ static void test_basic() {
     assert(std::__wrapped_streambuf_mutex::__instance().__get_count(&sstr2) == 1);
 #endif
 
+    ASSERT_NOT_NOEXCEPT(sync_buf1.swap(sync_buf2)); // LWG3498
     sync_buf1.swap(sync_buf2);
     assert(sync_buf1.get_wrapped() == &sstr2);
     assert(sync_buf2.get_wrapped() == &sstr1);


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/104375.

LWG3498 was implemented in LLVM 18 together with P0053R7 via 7cc72a0a2ec22855572d96411febd4f2c4ac5a49.