### PR TITLE
[gn] port 0eefb2682bf8c (C++26 for libc++)

### DIFF
--- a/llvm/utils/gn/secondary/libcxx/src/BUILD.gn
+++ b/llvm/utils/gn/secondary/libcxx/src/BUILD.gn
@@ -50,7 +50,7 @@ config("cxx_config") {
     "-Wno-nullability-completeness",
   ]
   cflags_cc = [
-    "-std=c++23",
+    "-std=c++26",
     "-nostdinc++",
   ]
   defines = [


### PR DESCRIPTION
Other than in 8a7846fe86f95e82c (the C++23 bump), we apparently only bump the standard for libc++, but not for libc++abi.