### PR TITLE
[lldb] send 0x0 size packet if LLDB_LAUNCH_FLAG_USE_PIPES is set

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -559,6 +559,17 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
         server.send_ack()
 
     def add_verified_launch_packets(self, launch_args):
+        if os.environ.get("LLDB_LAUNCH_FLAG_USE_PIPES", 0) == 1:
+            self.test_sequence.add_log_lines(
+                [
+                    "read packet: %s"
+                    % gdbremote_packet_encode_string(
+                        "QSetSTDIOWindowSize:cols=0;rows=0"
+                    ),
+                    "send packet: $OK#00",
+                ],
+                True,
+            )
         self.test_sequence.add_log_lines(
             [
                 "read packet: %s" % build_gdbremote_A_packet(launch_args),


### PR DESCRIPTION
`LLDB_LAUNCH_FLAG_USE_PIPES=1` is used in tests to run lldb without the ConPTY on Windows. This reduces the flakyness of tests.

This patch ensures that we read the value of `LLDB_LAUNCH_FLAG_USE_PIPES` when setting up gdbremote tests, to make sure they don't use the ConPTY.

This fixes `tools/lldb-server/TestGdbRemote_qThreadStopInfo.py` on https://ci-external.swift.org/job/lldb-windows/job/main/.

rdar://178725958