### PR TITLE
[clang-tidy] Add AllowVirtualAndOverride to modernize-use-override

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.cpp
@@ -22,6 +22,7 @@ UseOverrideCheck::UseOverrideCheck(StringRef Name, ClangTidyContext *Context)
       IgnoreTemplateInstantiations(
           Options.get("IgnoreTemplateInstantiations", false)),
       AllowOverrideAndFinal(Options.get("AllowOverrideAndFinal", false)),
+      AllowVirtualAndOverride(Options.get("AllowVirtualAndOverride", false)),
       OverrideSpelling(Options.get("OverrideSpelling", "override")),
       FinalSpelling(Options.get("FinalSpelling", "final")) {}
 
@@ -30,6 +31,7 @@ void UseOverrideCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IgnoreTemplateInstantiations",
                 IgnoreTemplateInstantiations);
   Options.store(Opts, "AllowOverrideAndFinal", AllowOverrideAndFinal);
+  Options.store(Opts, "AllowVirtualAndOverride", AllowVirtualAndOverride);
   Options.store(Opts, "OverrideSpelling", OverrideSpelling);
   Options.store(Opts, "FinalSpelling", FinalSpelling);
 }
@@ -105,8 +107,14 @@ void UseOverrideCheck::check(const MatchFinder::MatchResult &Result) {
   const bool OnlyVirtualSpecified = HasVirtual && !HasOverride && !HasFinal;
   const unsigned KeywordCount = HasVirtual + HasOverride + HasFinal;
 
-  if ((!OnlyVirtualSpecified && KeywordCount == 1) ||
-      (!HasVirtual && HasOverride && HasFinal && AllowOverrideAndFinal))
+  const bool AcceptsOverrideAndFinal =
+      !HasVirtual && HasOverride && HasFinal && AllowOverrideAndFinal;
+  const bool AcceptsVirtualAndOverride = HasVirtual && HasOverride &&
+                                         AllowVirtualAndOverride &&
+                                         (!HasFinal || AllowOverrideAndFinal);
+
+  if ((!OnlyVirtualSpecified && KeywordCount == 1) || AcceptsOverrideAndFinal ||
+      AcceptsVirtualAndOverride)
     return; // Nothing to do.
 
   std::string Message;

--- a/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.h
@@ -29,6 +29,7 @@ private:
   const bool IgnoreDestructors;
   const bool IgnoreTemplateInstantiations;
   const bool AllowOverrideAndFinal;
+  const bool AllowVirtualAndOverride;
   const StringRef OverrideSpelling;
   const StringRef FinalSpelling;
 };

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -644,6 +644,11 @@ Changes in existing checks
   positives on functions returning specializations of class templates marked
   ``[[nodiscard]]``.
 
+- Improved :doc:`modernize-use-override
+  <clang-tidy/checks/modernize/use-override>` check by adding the
+  `AllowVirtualAndOverride` option to allow keeping ``virtual`` on methods
+  that are also marked ``override``.
+
 - Improved :doc:`modernize-use-ranges
   <clang-tidy/checks/modernize/use-ranges>` check:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-override.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-override.rst
@@ -40,6 +40,11 @@ Options
    members, such as ``gcc -Wsuggest-override``/``gcc -Werror=suggest-override``.
    Default is `false`.
 
+.. option:: AllowVirtualAndOverride
+
+   If set to `true`, this check will not diagnose ``virtual`` as redundant
+   with ``override``. Default is `false`.
+
 .. option:: OverrideSpelling
 
    Specifies a macro to use instead of ``override``. This is useful when

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-allow-virtual-and-override.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-allow-virtual-and-override.cpp
@@ -1,0 +1,42 @@
+// RUN: %check_clang_tidy -check-suffix=VO %s modernize-use-override %t -- \
+// RUN:   -config="{CheckOptions: {modernize-use-override.AllowVirtualAndOverride: true}}"
+// RUN: %check_clang_tidy -check-suffix=VOF %s modernize-use-override %t -- \
+// RUN:   -config="{CheckOptions: {modernize-use-override.AllowVirtualAndOverride: true, \
+// RUN:                            modernize-use-override.AllowOverrideAndFinal: true}}"
+
+struct Base {
+  virtual void a();
+  virtual void b();
+  virtual void c();
+  virtual void d();
+  virtual void e();
+  virtual void f();
+};
+
+struct Derived : public Base {
+  virtual void a() override;
+
+  void b() override;
+
+  virtual void c();
+  // CHECK-MESSAGES-VO: :[[@LINE-1]]:16: warning: prefer using 'override' or (rarely) 'final' instead of 'virtual'
+  // CHECK-MESSAGES-VOF: :[[@LINE-2]]:16: warning: prefer using 'override' or (rarely) 'final' instead of 'virtual'
+  // CHECK-FIXES-VO: void c() override;
+  // CHECK-FIXES-VOF: void c() override;
+
+  void d();
+  // CHECK-MESSAGES-VO: :[[@LINE-1]]:8: warning: annotate this function with 'override' or (rarely) 'final'
+  // CHECK-MESSAGES-VOF: :[[@LINE-2]]:8: warning: annotate this function with 'override' or (rarely) 'final'
+  // CHECK-FIXES-VO: void d() override;
+  // CHECK-FIXES-VOF: void d() override;
+
+  virtual void e() final;
+  // CHECK-MESSAGES-VO: :[[@LINE-1]]:16: warning: 'virtual' is redundant since the function is already declared 'final'
+  // CHECK-MESSAGES-VOF: :[[@LINE-2]]:16: warning: 'virtual' is redundant since the function is already declared 'final'
+  // CHECK-FIXES-VO: void e() final;
+  // CHECK-FIXES-VOF: void e() final;
+
+  virtual void f() override final;
+  // CHECK-MESSAGES-VO: :[[@LINE-1]]:16: warning: 'virtual' and 'override' are redundant since the function is already declared 'final'
+  // CHECK-FIXES-VO: void f() final;
+};


### PR DESCRIPTION
Add an `AllowVirtualAndOverride` option to `modernize-use-override` so codebases can keep virtual on methods that are also marked override.

AI Usage: Test cases assisted by Codex.
Closes https://github.com/llvm/llvm-project/issues/202030