### PR TITLE
[NFC][clang-tidy] Extend doc-comment of BranchCloneCheck

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/BranchCloneCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/BranchCloneCheck.h
@@ -18,6 +18,10 @@ namespace clang::tidy::bugprone {
 /// detecting switch statements where two or more consecutive branches are
 /// Type I clones of each other, and for detecting conditional operators where
 /// the true and false expressions are Type I clones of each other.
+/// Additionally, this check also reports situations like
+///   if (some && condition) { if (some && condition) { foo(); } }
+/// where an `if` statement directly contains another `if` statement that has
+/// exactly the same expression as its condition.
 ///
 /// For the user-facing documentation see:
 /// https://clang.llvm.org/extra/clang-tidy/checks/bugprone/branch-clone.html


### PR DESCRIPTION
Commit 8ac2b77a11c9db9879557ce1c26e38628e1ef45f extended the check bugprone-branch-clone with a new feature but forgot to mention this in the doc-comment at the beginning of BranchCloneCheck.h.

Although I don't think that this comment is read too often, let's still update it to provide accurate information.