### PR TITLE
[flang][cmake][bolt] Do not train on non-strictly-fortran test cases

### DIFF
--- a/flang/test/bolt.lit.cfg
+++ b/flang/test/bolt.lit.cfg
@@ -29,3 +29,27 @@ config.name = "Flang BOLT Training"
 config.flang_exe = perf_wrapper + flang_nowrapper
 
 config.llvm_profile_file = ''
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = [
+    ".f",
+    ".F",
+    ".ff",
+    ".FOR",
+    ".for",
+    ".f77",
+    ".f90",
+    ".F90",
+    ".ff90",
+    ".f95",
+    ".F95",
+    ".ff95",
+    ".fpp",
+    ".FPP",
+    ".f18",
+    ".F18",
+    ".f03",
+    ".F03",
+    ".f08",
+    ".F08",
+]

--- a/flang/test/lit.cfg.py
+++ b/flang/test/lit.cfg.py
@@ -32,38 +32,6 @@ if lit_shell_env:
 # the test runner updated.
 config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 
-# suffixes: A list of file extensions to treat as test files.
-config.suffixes = [
-    ".c",
-    ".cpp",
-    ".f",
-    ".F",
-    ".ff",
-    ".FOR",
-    ".for",
-    ".f77",
-    ".f90",
-    ".F90",
-    ".ff90",
-    ".f95",
-    ".F95",
-    ".ff95",
-    ".fpp",
-    ".FPP",
-    ".cuf",
-    ".CUF",
-    ".f18",
-    ".F18",
-    ".f03",
-    ".F03",
-    ".f08",
-    ".F08",
-    ".ll",
-    ".fir",
-    ".mlir",
-    ".s",
-]
-
 config.substitutions.append(("%PATH%", config.environment["PATH"]))
 config.substitutions.append(("%llvmshlibdir", config.llvm_shlib_dir))
 config.substitutions.append(("%pluginext", config.llvm_plugin_ext))

--- a/flang/test/pgo.lit.cfg
+++ b/flang/test/pgo.lit.cfg
@@ -9,3 +9,27 @@ config.name = 'Flang PGO Training'
 config.flang_exe = lit.util.which('flang', config.flang_opt_tools_dir).replace('\\', '/')
 
 config.llvm_profile_file = '../perf-training-%4m.profraw'
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = [
+    ".f",
+    ".F",
+    ".ff",
+    ".FOR",
+    ".for",
+    ".f77",
+    ".f90",
+    ".F90",
+    ".ff90",
+    ".f95",
+    ".F95",
+    ".ff95",
+    ".fpp",
+    ".FPP",
+    ".f18",
+    ".F18",
+    ".f03",
+    ".F03",
+    ".f08",
+    ".F08",
+]

--- a/flang/test/test.lit.cfg
+++ b/flang/test/test.lit.cfg
@@ -10,3 +10,35 @@ config.name = "Flang"
 config.flang_exe = lit.util.which("flang", config.flang_llvm_tools_dir)
 
 config.llvm_profile_file = ''
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = [
+    ".c",
+    ".cpp",
+    ".f",
+    ".F",
+    ".ff",
+    ".FOR",
+    ".for",
+    ".f77",
+    ".f90",
+    ".F90",
+    ".ff90",
+    ".f95",
+    ".F95",
+    ".ff95",
+    ".fpp",
+    ".FPP",
+    ".cuf",
+    ".CUF",
+    ".f18",
+    ".F18",
+    ".f03",
+    ".F03",
+    ".f08",
+    ".F08",
+    ".ll",
+    ".fir",
+    ".mlir",
+    ".s",
+]


### PR DESCRIPTION
During my experiments with those new CMake caches I've noticed that using the check-flang test suite for the performance training has a lot of the overhead. Namely, not only flang is being executed, but also bbc and tco and other things that do not participate in further flang optimization effort. This patch eliminates this overhead by limiting the number of processed suffixes.