### PR TITLE
[LLVM][CodeGen][SVE] Add ElementSize information to pseudo instructions.

### DIFF
--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -812,6 +812,7 @@ class PredTwoOpPseudo<string name, ZPRRegOp zprty,
                       FalseLanesEnum flags = FalseLanesNone>
 : SVEPseudo2Instr<name, 0>,
   Pseudo<(outs zprty:$Zd), (ins PPR3bAny:$Pg, zprty:$Zs1, zprty:$Zs2), []> {
+  let ElementSize = zprty.ElementSize;
   let FalseLanes = flags;
 }
 
@@ -819,6 +820,7 @@ class PredTwoOpImmPseudo<string name, ZPRRegOp zprty, Operand immty,
                          FalseLanesEnum flags = FalseLanesNone>
 : SVEPseudo2Instr<name, 0>,
   Pseudo<(outs zprty:$Zd), (ins PPR3bAny:$Pg, zprty:$Zs1, immty:$imm), []> {
+  let ElementSize = zprty.ElementSize;
   let FalseLanes = flags;
 }
 
@@ -826,6 +828,7 @@ class PredThreeOpPseudo<string name, ZPRRegOp zprty,
                         FalseLanesEnum flags = FalseLanesNone>
 : SVEPseudo2Instr<name, 0>,
   Pseudo<(outs zprty:$Zd), (ins PPR3bAny:$Pg, zprty:$Zs1, zprty:$Zs2, zprty:$Zs3), []> {
+  let ElementSize = zprty.ElementSize;
   let FalseLanes = flags;
 }
 
@@ -846,11 +849,13 @@ class UnpredTwoOpImmPseudo<string name, ZPRRegOp zprty, Operand immty>
 //
 
 class PredOneOpPassthruPseudo<string name, ZPRRegOp zprty,
-                              FalseLanesEnum flags = FalseLanesNone>
+                              FalseLanesEnum flags = FalseLanesNone,
+                              ElementSizeEnum size = zprty.ElementSize>
 : SVEPseudo2Instr<name, 0>,
   Pseudo<(outs zprty:$Zd), (ins zprty:$Passthru, PPR3bAny:$Pg, zprty:$Zs), []> {
-  let FalseLanes = flags;
   let Constraints = !if(!eq(flags, FalseLanesZero), "$Zd = $Passthru,@earlyclobber $Zd", "");
+  let ElementSize = size;
+  let FalseLanes = flags;
 }
 
 //===----------------------------------------------------------------------===//
@@ -3188,7 +3193,7 @@ multiclass sve_fp_2op_p_zd<bits<7> opc, string asm,
   def : SVE_3_Op_Pat<packedvt1, int_op, packedvt1, vt2, packedvt3, !cast<Instruction>(NAME)>;
   def : SVE_1_Op_Passthru_Pat<vt1, ir_op, vt2, vt3, !cast<Instruction>(NAME)>;
 
-  def _UNDEF : PredOneOpPassthruPseudo<NAME, !cast<ZPRRegOp>(i_zprtype), FalseLanesUndef>;
+  def _UNDEF : PredOneOpPassthruPseudo<NAME, !cast<ZPRRegOp>(i_zprtype), FalseLanesUndef, Sz>;
 
   defm : SVE_1_Op_PassthruUndef_Pat<vt1, ir_op, vt2, vt3, !cast<Instruction>(NAME # _UNDEF)>;
 }

--- a/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
@@ -110,40 +110,58 @@ void runSVEPseudoTestForCPU(const std::string &CPU) {
 }
 
 // TODO : Add more CPUs that support SVE/SVE2
-TEST(AArch64SVESchedPseudoTesta320, IsCorrect) {
+TEST(AArch64SVEPseudoTest, SchedCortexA320) {
   runSVEPseudoTestForCPU("cortex-a320");
 }
 
-TEST(AArch64SVESchedPseudoTesta510, IsCorrect) {
+TEST(AArch64SVEPseudoTest, SchedCortexA510) {
   runSVEPseudoTestForCPU("cortex-a510");
 }
 
-TEST(AArch64SVESchedPseudoTestn2, IsCorrect) {
+TEST(AArch64SVEPseudoTest, SchedNeoverseN2) {
   runSVEPseudoTestForCPU("neoverse-n2");
 }
 
-TEST(AArch64SVESchedPseudoTestn3, IsCorrect) {
+TEST(AArch64SVEPseudoTest, SchedNeoverseN3) {
   runSVEPseudoTestForCPU("neoverse-n3");
 }
 
-TEST(AArch64SVESchedPseudoTestv1, IsCorrect) {
+TEST(AArch64SVEPseudoTest, SchedNeoverseV1) {
   runSVEPseudoTestForCPU("neoverse-v1");
 }
 
-TEST(AArch64SVESchedPseudoTestv2, IsCorrect) {
+TEST(AArch64SVEPseudoTest, SchedNeoverseV2) {
   runSVEPseudoTestForCPU("neoverse-v2");
 }
 
-TEST(AArch64SVESchedPseudoTestv3, IsCorrect) {
+TEST(AArch64SVEPseudoTest, SchedNeoverseV3) {
   runSVEPseudoTestForCPU("neoverse-v3");
 }
 
-TEST(AArch64SVESchedPseudoTestv3ae, IsCorrect) {
+TEST(AArch64SVEPseudoTest, SchedNeoverseV3ae) {
   runSVEPseudoTestForCPU("neoverse-v3ae");
 }
 
-TEST(AArch64SVESchedPseudoTestOlympus, IsCorrect) {
-  runSVEPseudoTestForCPU("olympus");
+TEST(AArch64SVEPseudoTest, SchedOlympus) { runSVEPseudoTestForCPU("olympus"); }
+
+TEST(AArch64SVEPseudoTest, ElementSize) {
+  std::unique_ptr<TargetMachine> TM = createTargetMachine("generic");
+  ASSERT_TRUE(TM);
+  std::unique_ptr<AArch64InstrInfo> II = createInstrInfo(TM.get());
+  ASSERT_TRUE(II);
+
+  for (unsigned Opc = 0; Opc < AArch64::INSTRUCTION_LIST_END; ++Opc) {
+    // If Opc is a pseudo, return its equivalent real instruction opcode.
+    int RealOpc = AArch64::getSVEPseudoMap(Opc);
+    if (RealOpc == -1)
+      continue;
+
+    unsigned OpcElementSize = II->getElementSizeForOpcode(Opc);
+    unsigned RealOpcElementSize = II->getElementSizeForOpcode(RealOpc);
+    EXPECT_EQ(OpcElementSize, RealOpcElementSize)
+        << "PsuedoOpcode: " << II->getName(Opc)
+        << " Opcode: " << II->getName(RealOpc);
+  }
 }
 
 } // namespace

--- a/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
@@ -138,7 +138,7 @@ TEST(AArch64SVEPseudoTest, SchedNeoverseV3) {
   runSVEPseudoTestForCPU("neoverse-v3");
 }
 
-TEST(AArch64SVEPseudoTest, SchedNeoverseV3ae) {
+TEST(AArch64SVEPseudoTest, SchedNeoverseV3AE) {
   runSVEPseudoTestForCPU("neoverse-v3ae");
 }
 
@@ -159,7 +159,7 @@ TEST(AArch64SVEPseudoTest, ElementSize) {
     unsigned OpcElementSize = II->getElementSizeForOpcode(Opc);
     unsigned RealOpcElementSize = II->getElementSizeForOpcode(RealOpc);
     EXPECT_EQ(OpcElementSize, RealOpcElementSize)
-        << "PsuedoOpcode: " << II->getName(Opc)
+        << "PseudoOpcode: " << II->getName(Opc)
         << " Opcode: " << II->getName(RealOpc);
   }
 }


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/204820 is making more use of an SVE instruction's element size. To make best use of this the pseudo instructions need to carry the same information because the pass is run before expansion.  This PR adds the necessary data and updates AArch64SVESchedPseudoTest to verify the data matches the real instruction it represents.