### PR TITLE
[Offload][AMDGPU] Flush RPC server on abnormal queue exit

### DIFF
--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -4469,6 +4469,10 @@ void AMDGPUQueueTy::callbackError(hsa_status_t Status, hsa_queue_t *Source,
                                   void *Data) {
   auto &AMDGPUDevice = *reinterpret_cast<AMDGPUDeviceTy *>(Data);
 
+  // Drain any pending RPC work the device pushed before its queue died.
+  if (RPCServerTy *RPCServer = AMDGPUDevice.getRPCServer())
+    RPCServer->flushDevice(AMDGPUDevice);
+
   if (Status == HSA_STATUS_ERROR_EXCEPTION) {
     auto KernelTraceInfoRecord =
         AMDGPUDevice.KernelLaunchTraces.getExclusiveAccessor();

--- a/offload/plugins-nextgen/common/include/RPC.h
+++ b/offload/plugins-nextgen/common/include/RPC.h
@@ -69,6 +69,9 @@ public:
   /// memory associated with the k
   llvm::Error deinitDevice(plugin::GenericDeviceTy &Device);
 
+  /// Drain any pending requests the device pushed without freeing the server.
+  void flushDevice(plugin::GenericDeviceTy &Device);
+
   /// Register a custom callback for the RPC server to manage.
   void registerCallback(RPCServerCallbackTy FnPtr);
 

--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -261,6 +261,12 @@ Error RPCServerTy::deinitDevice(plugin::GenericDeviceTy &Device) {
   return Error::success();
 }
 
+void RPCServerTy::flushDevice(plugin::GenericDeviceTy &Device) {
+  std::lock_guard<decltype(BufferMutex)> Lock(BufferMutex);
+  if (void *Buffer = Buffers[Device.getDeviceId()])
+    flushServer(Device, Buffer, Callbacks);
+}
+
 void RPCServerTy::registerCallback(RPCServerCallbackTy FnPtr) {
   std::lock_guard<decltype(BufferMutex)> Lock(BufferMutex);
   Callbacks.insert(FnPtr);


### PR DESCRIPTION
Summary:
In the case of, say, a GPU sanitizer, there could be a pending report
that isn't flushed before the queue dies and the program terminates. Add
an explicit flush to ensure that all work at least posted *before* the
trap fired is cleared in the HSA error callback before actually
quitting.
