### PR TITLE
[lldb] Move Diagnostics from Utility to Core (NFC)

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "lldb/Core/DebuggerEvents.h"
+#include "lldb/Core/Diagnostics.h"
 #include "lldb/Core/FormatEntity.h"
 #include "lldb/Core/IOHandler.h"
 #include "lldb/Core/SourceManager.h"
@@ -31,7 +32,6 @@
 #include "lldb/Target/TargetList.h"
 #include "lldb/Utility/Broadcaster.h"
 #include "lldb/Utility/ConstString.h"
-#include "lldb/Utility/Diagnostics.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/StructuredData.h"

--- a/lldb/include/lldb/Core/Diagnostics.h
+++ b/lldb/include/lldb/Core/Diagnostics.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLDB_UTILITY_DIAGNOSTICS_H
-#define LLDB_UTILITY_DIAGNOSTICS_H
+#ifndef LLDB_CORE_DIAGNOSTICS_H
+#define LLDB_CORE_DIAGNOSTICS_H
 
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/Log.h"

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -37,6 +37,7 @@
 
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/DebuggerEvents.h"
+#include "lldb/Core/Diagnostics.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Progress.h"
 #include "lldb/Core/StructuredDataImpl.h"
@@ -51,7 +52,6 @@
 #include "lldb/Target/Process.h"
 #include "lldb/Target/TargetList.h"
 #include "lldb/Utility/Args.h"
-#include "lldb/Utility/Diagnostics.h"
 #include "lldb/Utility/State.h"
 #include "lldb/Version/Version.h"
 

--- a/lldb/source/Commands/CommandObjectDiagnostics.cpp
+++ b/lldb/source/Commands/CommandObjectDiagnostics.cpp
@@ -8,6 +8,7 @@
 
 #include "CommandObjectDiagnostics.h"
 #include "lldb/Core/Debugger.h"
+#include "lldb/Core/Diagnostics.h"
 #include "lldb/Host/OptionParser.h"
 #include "lldb/Interpreter/CommandOptionArgumentTable.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
@@ -15,7 +16,6 @@
 #include "lldb/Interpreter/OptionValueEnumeration.h"
 #include "lldb/Interpreter/OptionValueUInt64.h"
 #include "lldb/Interpreter/Options.h"
-#include "lldb/Utility/Diagnostics.h"
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Core/CMakeLists.txt
+++ b/lldb/source/Core/CMakeLists.txt
@@ -32,6 +32,7 @@ add_lldb_library(lldbCore NO_PLUGIN_DEPENDENCIES
   DebuggerEvents.cpp
   Declaration.cpp
   DemangledNameInfo.cpp
+  Diagnostics.cpp
   Disassembler.cpp
   DumpDataExtractor.cpp
   DumpRegisterValue.cpp

--- a/lldb/source/Core/Diagnostics.cpp
+++ b/lldb/source/Core/Diagnostics.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "lldb/Utility/Diagnostics.h"
+#include "lldb/Core/Diagnostics.h"
 #include "lldb/Utility/LLDBAssert.h"
 
 #include "llvm/Support/Error.h"

--- a/lldb/source/Initialization/SystemInitializerCommon.cpp
+++ b/lldb/source/Initialization/SystemInitializerCommon.cpp
@@ -9,11 +9,11 @@
 #include "lldb/Initialization/SystemInitializerCommon.h"
 
 #include "Plugins/Process/gdb-remote/ProcessGDBRemoteLog.h"
+#include "lldb/Core/Diagnostics.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/Socket.h"
 #include "lldb/Target/Statistics.h"
-#include "lldb/Utility/Diagnostics.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Timer.h"
 #include "lldb/Version/Version.h"

--- a/lldb/source/Utility/CMakeLists.txt
+++ b/lldb/source/Utility/CMakeLists.txt
@@ -37,7 +37,6 @@ add_lldb_library(lldbUtility NO_INTERNAL_DEPENDENCIES
   DataBufferLLVM.cpp
   DataEncoder.cpp
   DataExtractor.cpp
-  Diagnostics.cpp
   Environment.cpp
   ErrorMessages.cpp
   Event.cpp


### PR DESCRIPTION
Nothing in the Utility or Host layers uses Diagnostics. Its only callers are Debugger (the always-on log feeder), SBDebugger, and the SystemInitializerCommon lifecycle. Those all live in Core or above. The header depends only on Utility primitives (FileSpec, Log, Error), and lldbInitialization already links lldbCore, so the move adds no new link dependency anywhere.

Relocating it to Core lets Diagnostics reach Debugger, Target, CommandInterpreter, and Host, which simplifies an upcoming change that collect a richer diagnostics bundle (statistics, command snapshots, invocation, etc) and allows us to implement that directly in the Diagnostics class.