### PR TITLE
[libc++] Don't include `<langinfo.h>` for macOS in locale base API

### DIFF
--- a/libcxx/include/__locale_dir/support/bsd_like.h
+++ b/libcxx/include/__locale_dir/support/bsd_like.h
@@ -15,7 +15,9 @@
 #include <__utility/forward.h>
 #include <clocale> // std::lconv
 #include <ctype.h>
-#include <langinfo.h>
+#ifndef __APPLE__
+#  include <langinfo.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -182,9 +184,11 @@ __mbsrtowcs(wchar_t* __dest, const char** __src, size_t __len, mbstate_t* __ps, 
 }
 #  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
+#  ifndef __APPLE__
 inline _LIBCPP_HIDE_FROM_ABI const char* __get_locale_encoding(__locale_t __loc) {
   return ::nl_langinfo_l(CODESET, __loc);
 }
+#  endif
 #endif // _LIBCPP_BUILDING_LIBRARY
 
 _LIBCPP_DIAGNOSTIC_PUSH

--- a/libcxx/src/text_encoding.cpp
+++ b/libcxx/src/text_encoding.cpp
@@ -11,6 +11,12 @@
 #include <__utility/scope_guard.h>
 #include <text_encoding>
 
+// FIXME: Including <langinfo.h> in the locale base API in Clang modules on Apple introduces a circular dependency and
+// breaks certain builds.
+#if defined(__APPLE__)
+#  include <langinfo.h>
+#endif
+
 _LIBCPP_BEGIN_NAMESPACE_STD
 _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 
@@ -31,7 +37,11 @@ static text_encoding __make_text_encoding(const char* __name) {
 
 std::text_encoding __get_locale_encoding(const char* __name) {
   if (__name == nullptr)
+#  if defined(__APPLE__)
+    return __make_text_encoding(::nl_langinfo_l(CODESET, static_cast<::__locale::__locale_t>(0)));
+#  else
     return __make_text_encoding(__locale::__get_locale_encoding(static_cast<__locale::__locale_t>(0)));
+#  endif
 
   __locale::__locale_t __l = __locale::__newlocale(_LIBCPP_CTYPE_MASK, __name, static_cast<__locale::__locale_t>(0));
 
@@ -45,7 +55,11 @@ std::text_encoding __get_locale_encoding(const char* __name) {
     return text_encoding{};
   }
 
+#  if defined(__APPLE__)
+  return __make_text_encoding(::nl_langinfo_l(CODESET, __l));
+#  else
   return __make_text_encoding(__locale::__get_locale_encoding(__l));
+#  endif
 }
 
 #endif // __ANDROID__


### PR DESCRIPTION
- The current method broke certain builds on macOS. e.g. [Green Dragon](https://ci.swift.org/job/llvm.org/view/LLDB/job/lldb-cmake/22413/) due to a circular dependency introduced by `<langinfo.h>`.
- As an unfortunate workaround: Don't include it and subsequently unimplement `__get_locale_encoding()` for Apple, and use `nl_langinfo_l` directly in `text_encoding.cpp` 