### PR TITLE
[X86] Mark AsmPrinter Module Passes as Required

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.h
+++ b/llvm/lib/Target/X86/X86AsmPrinter.h
@@ -206,7 +206,7 @@ public:
 };
 
 class X86AsmPrinterBeginPass
-    : public OptionalPassInfoMixin<X86AsmPrinterBeginPass> {
+    : public RequiredPassInfoMixin<X86AsmPrinterBeginPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };
@@ -219,7 +219,7 @@ public:
 };
 
 class X86AsmPrinterEndPass
-    : public OptionalPassInfoMixin<X86AsmPrinterEndPass> {
+    : public RequiredPassInfoMixin<X86AsmPrinterEndPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };


### PR DESCRIPTION
This won't impact them working on optnone functions, but could impact whether or not they get called in opt-bisect, which would be wrong.