### PR TITLE
[X86] Add target verifier

### DIFF
--- a/llvm/lib/Target/X86/CMakeLists.txt
+++ b/llvm/lib/Target/X86/CMakeLists.txt
@@ -88,6 +88,7 @@ set(sources
   X86TargetMachine.cpp
   X86TargetObjectFile.cpp
   X86TargetTransformInfo.cpp
+  X86TargetVerifier.cpp
   X86WinEHState.cpp
   X86WinEHUnwindV2.cpp
   X86WinEHUnwindV3.cpp

--- a/llvm/lib/Target/X86/X86.h
+++ b/llvm/lib/Target/X86/X86.h
@@ -26,10 +26,16 @@ namespace llvm {
 
 class FunctionPass;
 class InstructionSelector;
+class Module;
 class PassRegistry;
+class TargetVerify;
 class X86RegisterBankInfo;
 class X86Subtarget;
 class X86TargetMachine;
+
+/// Create the X86 implementation of the target-dependent IR verifier. Used by
+/// the TargetVerifierPass, which dispatches by triple.
+TargetVerify *createX86TargetVerify(Module &M);
 
 /// This pass converts a legalized DAG into a X86-specific DAG, ready for
 /// instruction scheduling.

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -45,6 +45,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Target/TargetLoweringObjectFile.h"
+#include "llvm/Target/TargetVerifier.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/CFGuard.h"
@@ -67,6 +68,11 @@ extern "C" LLVM_C_ABI void LLVMInitializeX86Target() {
   // Register the target.
   RegisterTargetMachine<X86TargetMachine> X(getTheX86_32Target());
   RegisterTargetMachine<X86TargetMachine> Y(getTheX86_64Target());
+
+  // Register the target-dependent IR verifier, keyed by triple, so the
+  // target-independent TargetVerifierPass can dispatch to it.
+  registerTargetVerify(Triple::x86, createX86TargetVerify);
+  registerTargetVerify(Triple::x86_64, createX86TargetVerify);
 
   PassRegistry &PR = *PassRegistry::getPassRegistry();
   initializeX86LowerAMXIntrinsicsLegacyPassPass(PR);

--- a/llvm/lib/Target/X86/X86TargetVerifier.cpp
+++ b/llvm/lib/Target/X86/X86TargetVerifier.cpp
@@ -1,0 +1,43 @@
+//===-- X86TargetVerifier.cpp - X86 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This is the X86 implementation of the target-dependent verifier. It is the
+// "TargetVerify" half of the verification the (target-independent)
+// TargetVerifierPass runs for X86 modules; the other half is the generic IR
+// verifier.
+//
+//===----------------------------------------------------------------------===//
+
+#include "X86.h"
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Target/TargetVerifier.h"
+
+using namespace llvm;
+
+namespace {
+
+class X86TargetVerify : public TargetVerify {
+public:
+  X86TargetVerify(Module *Mod) : TargetVerify(Mod) {}
+  bool run(Function &F) override;
+};
+
+bool X86TargetVerify::run(Function &F) {
+  IsValid = true;
+  return IsValid;
+}
+
+} // anonymous namespace
+
+namespace llvm {
+TargetVerify *createX86TargetVerify(Module &M) {
+  return new X86TargetVerify(&M);
+}
+} // namespace llvm


### PR DESCRIPTION
Add an X86 TargetVerify and register it by triple so the
TargetVerifierPass dispatches to it for X86 modules. It performs no
checks yet; the subtarget-dependent checks are added in a follow-up.

Stacked above https://github.com/llvm/llvm-project/pull/205703; and below https://github.com/llvm/llvm-project/pull/206545.