### PR TITLE
[lldb][test] Require macOS 16 SDK or higher for import-std-module tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -78,6 +78,21 @@ def _check_expected_version(comparison, expected, actual):
     return op_lookup[comparison](version.parse(actual), version.parse(expected))
 
 
+def _get_macos_sdk_version() -> str | None:
+    """ Returns the current macOS SDK version or None if this system doesn't
+    use a macOS SDK."""
+    if platform.mac_ver()[0] == "":
+        return None
+    try:
+        return (
+            subprocess.check_output(["xcrun", "--sdk", "macosx", "--show-sdk-version"])
+            .rstrip()
+            .decode("utf-8")
+        )
+    except Exception:
+        return None
+
+
 def _match_decorator_property(expected, actual):
     if expected is None:
         return True
@@ -256,6 +271,7 @@ def _decorateTest(
     swig_version=None,
     py_version=None,
     macos_version=None,
+    macos_sdk_version=None,
     remote=None,
     dwarf_version=None,
     setting=None,
@@ -306,6 +322,12 @@ def _decorateTest(
                 )
             )
         )
+        _sdk_ver = _get_macos_sdk_version()
+        skip_for_macos_sdk_version = macos_sdk_version is None
+        if macos_sdk_version is not None and _sdk_ver is not None:
+            skip_for_macos_sdk_version = _check_expected_version(
+                macos_sdk_version[0], macos_sdk_version[1], _sdk_ver
+            )
         skip_for_dwarf_version = (dwarf_version is None) or (
             _check_expected_version(
                 dwarf_version[0], dwarf_version[1], lldbplatformutil.getDwarfVersion()
@@ -327,6 +349,7 @@ def _decorateTest(
             (swig_version, skip_for_swig_version, "swig version"),
             (py_version, skip_for_py_version, "python version"),
             (macos_version, skip_for_macos_version, "macOS version"),
+            (macos_sdk_version, skip_for_macos_sdk_version, "macOS SDK version"),
             (remote, skip_for_remote, "platform locality (remote/local)"),
             (dwarf_version, skip_for_dwarf_version, "dwarf version"),
             (setting, skip_for_setting, "setting"),
@@ -386,6 +409,7 @@ def expectedFailureAll(
     swig_version=None,
     py_version=None,
     macos_version=None,
+    macos_sdk_version=None,
     remote=None,
     dwarf_version=None,
     setting=None,
@@ -404,6 +428,7 @@ def expectedFailureAll(
         swig_version=swig_version,
         py_version=py_version,
         macos_version=macos_version,
+        macos_sdk_version=macos_sdk_version,
         remote=remote,
         dwarf_version=dwarf_version,
         setting=setting,
@@ -429,6 +454,7 @@ def skipIf(
     swig_version=None,
     py_version=None,
     macos_version=None,
+    macos_sdk_version=None,
     remote=None,
     dwarf_version=None,
     setting=None,
@@ -447,6 +473,7 @@ def skipIf(
         swig_version=swig_version,
         py_version=py_version,
         macos_version=macos_version,
+        macos_sdk_version=macos_sdk_version,
         remote=remote,
         dwarf_version=dwarf_version,
         setting=setting,

--- a/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
@@ -14,6 +14,7 @@ class TestCase(TestBase):
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"
     )
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/basic/TestImportStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/basic/TestImportStdModule.py
@@ -11,6 +11,7 @@ class ImportStdModule(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(macos_version=["<", "15.0"])
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 
@@ -40,6 +41,7 @@ class ImportStdModule(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(macos_version=["<", "15.0"])
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test_non_cpp_language(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/conflicts/TestStdModuleWithConflicts.py
+++ b/lldb/test/API/commands/expression/import-std-module/conflicts/TestStdModuleWithConflicts.py
@@ -16,6 +16,7 @@ class TestImportStdModuleConflicts(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(macos_version=["<", "15.0"])
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/deque-basic/TestDequeFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/deque-basic/TestDequeFromStdModule.py
@@ -14,6 +14,7 @@ class TestBasicDeque(TestBase):
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"
     )
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/TestDbgInfoContentDequeFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/TestDbgInfoContentDequeFromStdModule.py
@@ -15,6 +15,7 @@ class TestDbgInfoContentDeque(TestBase):
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"
     )
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/empty-module/TestEmptyStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/empty-module/TestEmptyStdModule.py
@@ -15,6 +15,7 @@ class ImportStdModule(TestBase):
     @add_test_categories(["libc++"])
     @skipIfRemote
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/forward_decl_from_module/TestForwardDeclFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/forward_decl_from_module/TestForwardDeclFromStdModule.py
@@ -15,6 +15,7 @@ class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIfRemote
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/forward_list-dbg-info-content/TestDbgInfoContentForwardListFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/forward_list-dbg-info-content/TestDbgInfoContentForwardListFromStdModule.py
@@ -11,6 +11,7 @@ class TestDbgInfoContentForwardList(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(macos_version=["<", "15.0"])
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/forward_list/TestForwardListFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/forward_list/TestForwardListFromStdModule.py
@@ -14,6 +14,7 @@ class TestBasicForwardList(TestBase):
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"
     )
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/iterator/TestIteratorFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/iterator/TestIteratorFromStdModule.py
@@ -11,6 +11,7 @@ class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(macos_version=["<", "15.0"])
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 
@@ -30,6 +31,7 @@ class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @expectedFailureAll(bugnumber="https://github.com/llvm/llvm-project/issues/149477")
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test_xfail(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/list-dbg-info-content/TestDbgInfoContentListFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/list-dbg-info-content/TestDbgInfoContentListFromStdModule.py
@@ -16,6 +16,7 @@ class TestDbgInfoContentList(TestBase):
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"
     )
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/list/TestListFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/list/TestListFromStdModule.py
@@ -14,6 +14,7 @@ class TestBasicList(TestBase):
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"
     )
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/missing-module-sources/TestStdModuleSourcesMissing.py
+++ b/lldb/test/API/commands/expression/import-std-module/missing-module-sources/TestStdModuleSourcesMissing.py
@@ -16,6 +16,7 @@ class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIfRemote
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         # The path to our temporary target root that contains the temporary
         # module sources.

--- a/lldb/test/API/commands/expression/import-std-module/module-build-errors/TestStdModuleBuildErrors.py
+++ b/lldb/test/API/commands/expression/import-std-module/module-build-errors/TestStdModuleBuildErrors.py
@@ -19,6 +19,7 @@ class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIfRemote
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/no-std-module/TestMissingStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/no-std-module/TestMissingStdModule.py
@@ -16,6 +16,7 @@ from lldbsuite.test import lldbutil
 class STLTestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/non-module-type-separation/TestNonModuleTypeSeparation.py
+++ b/lldb/test/API/commands/expression/import-std-module/non-module-type-separation/TestNonModuleTypeSeparation.py
@@ -12,6 +12,7 @@ class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(macos_version=["<", "15.0"])
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         """
         This test is creating ValueObjects with both C++ module and debug

--- a/lldb/test/API/commands/expression/import-std-module/pair/TestPairFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/pair/TestPairFromStdModule.py
@@ -14,6 +14,7 @@ class TestCase(TestBase):
     # but needs further investigation for what underlying Clang/LLDB bug can't
     # handle that code change.
     @skip
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/queue/TestQueueFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/queue/TestQueueFromStdModule.py
@@ -19,6 +19,7 @@ class TestQueue(TestBase):
         compiler="clang",
         compiler_version=["<", "17.0"],
     )
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/retry-with-std-module/TestRetryWithStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/retry-with-std-module/TestRetryWithStdModule.py
@@ -7,6 +7,7 @@ class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(macos_version=["<", "15.0"])
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/shared_ptr-dbg-info-content/TestSharedPtrDbgInfoContentFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/shared_ptr-dbg-info-content/TestSharedPtrDbgInfoContentFromStdModule.py
@@ -11,6 +11,7 @@ class TestSharedPtrDbgInfoContent(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(macos_version=["<", "15.0"])
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/shared_ptr/TestSharedPtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/shared_ptr/TestSharedPtrFromStdModule.py
@@ -13,6 +13,7 @@ class TestSharedPtr(TestBase):
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(compiler="clang", compiler_version=["<", "17.0"])
     @skipIf(bugnumber="https://llvm.org/PR200154")
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/stack/TestStackFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/stack/TestStackFromStdModule.py
@@ -12,6 +12,7 @@ class TestStack(TestBase):
     @skipIf(compiler=no_match("clang"))
     @skipIfLinux  # Declaration in some Linux headers causes LLDB to crash.
     @skipIf(bugnumber="rdar://97622854")
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/sysroot/TestStdModuleSysroot.py
+++ b/lldb/test/API/commands/expression/import-std-module/sysroot/TestStdModuleSysroot.py
@@ -15,6 +15,7 @@ class ImportStdModule(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIfRemote  # This test messes with the platform, can't be run remotely.
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/unique_ptr-dbg-info-content/TestUniquePtrDbgInfoContent.py
+++ b/lldb/test/API/commands/expression/import-std-module/unique_ptr-dbg-info-content/TestUniquePtrDbgInfoContent.py
@@ -13,6 +13,7 @@ class TestUniquePtrDbgInfoContent(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "9.0"])
     @skipIf(macos_version=["<", "15.0"])
     @skipIfLinux  # s.reset() causes link errors on ubuntu 18.04/Clang 9
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/unique_ptr/TestUniquePtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/unique_ptr/TestUniquePtrFromStdModule.py
@@ -13,6 +13,7 @@ class TestUniquePtr(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "9.0"])
     @skipIf(macos_version=["<", "15.0"])
     @skipIfLinux  # s.reset() causes link errors on ubuntu 18.04/Clang 9
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/vector-bool/TestVectorBoolFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-bool/TestVectorBoolFromStdModule.py
@@ -11,6 +11,7 @@ class TestBoolVector(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(bugnumber="rdar://100741983")
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/TestDbgInfoContentVectorFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/TestDbgInfoContentVectorFromStdModule.py
@@ -16,6 +16,7 @@ class TestDbgInfoContentVector(TestBase):
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"
     )
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
@@ -14,6 +14,7 @@ class TestVectorOfVectors(TestBase):
     @skipIf(
         bugnumber="ASTImport of lambdas not supported: https://github.com/llvm/llvm-project/issues/149477"
     )
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/vector/TestVectorFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector/TestVectorFromStdModule.py
@@ -11,6 +11,7 @@ class TestBasicVector(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(bugnumber="rdar://100741983")
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/weak_ptr-dbg-info-content/TestDbgInfoContentWeakPtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/weak_ptr-dbg-info-content/TestDbgInfoContentWeakPtrFromStdModule.py
@@ -12,6 +12,7 @@ class TestDbgInfoContentWeakPtr(TestBase):
     @skipIf(compiler=no_match("clang"))
     @skipIf(compiler="clang", compiler_version=["<", "17.0"])
     @skipIf(macos_version=["<", "15.0"])
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/weak_ptr/TestWeakPtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/weak_ptr/TestWeakPtrFromStdModule.py
@@ -13,6 +13,7 @@ class TestSharedPtr(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "17.0"])
     @skipIf(macos_version=["<", "15.0"])
     @skipIf(bugnumber="https://llvm.org/PR200154")
+    @skipIf(macos_sdk_version=["<", "16.0"])
     def test(self):
         self.build()
 


### PR DESCRIPTION
Older macOS SDKs have Darwin modules that create cyclic dependencies with the libc++ module since PR #141312.

These older SDKs are anyway not supported with a ToT libc++, so we can just skip the test in this config.

assisted-by: claude