### PR TITLE
[TargetLowering] Remove isCtlzFast TLI hook (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -726,11 +726,6 @@ public:
     return false;
   }
 
-  /// Return true if ctlz instruction is fast.
-  virtual bool isCtlzFast() const {
-    return false;
-  }
-
   /// Return true if ctpop instruction is fast.
   virtual bool isCtpopFast(EVT VT) const {
     return isOperationLegal(ISD::CTPOP, VT);
@@ -6002,12 +5997,6 @@ public:
   virtual SDValue expandIndirectJTBranch(const SDLoc &dl, SDValue Value,
                                          SDValue Addr, int JTI,
                                          SelectionDAG &DAG) const;
-
-  // seteq(x, 0) -> truncate(srl(ctlz(zext(x)), log2(#bits)))
-  // If we're comparing for equality to zero and isCtlzFast is true, expose the
-  // fact that this can be implemented as a ctlz/srl pair, so that the dag
-  // combiner can fold the new nodes.
-  SDValue lowerCmpEqZeroToCtlzSrl(SDValue Op, SelectionDAG &DAG) const;
 
   // Return true if `X & Y eq/ne 0` is preferable to `X & Y ne/eq Y`
   virtual bool isXAndYEqZeroPreferableToXAndYEqY(ISD::CondCode, EVT) const {

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -12319,29 +12319,6 @@ SDValue TargetLowering::LowerToTLSEmulatedModel(const GlobalAddressSDNode *GA,
   return CallResult.first;
 }
 
-SDValue TargetLowering::lowerCmpEqZeroToCtlzSrl(SDValue Op,
-                                                SelectionDAG &DAG) const {
-  assert((Op->getOpcode() == ISD::SETCC) && "Input has to be a SETCC node.");
-  if (!isCtlzFast())
-    return SDValue();
-  ISD::CondCode CC = cast<CondCodeSDNode>(Op.getOperand(2))->get();
-  SDLoc dl(Op);
-  if (isNullConstant(Op.getOperand(1)) && CC == ISD::SETEQ) {
-    EVT VT = Op.getOperand(0).getValueType();
-    SDValue Zext = Op.getOperand(0);
-    if (VT.bitsLT(MVT::i32)) {
-      VT = MVT::i32;
-      Zext = DAG.getNode(ISD::ZERO_EXTEND, dl, VT, Op.getOperand(0));
-    }
-    unsigned Log2b = Log2_32(VT.getSizeInBits());
-    SDValue Clz = DAG.getNode(ISD::CTLZ, dl, VT, Zext);
-    SDValue Scc = DAG.getNode(ISD::SRL, dl, VT, Clz,
-                              DAG.getConstant(Log2b, dl, MVT::i32));
-    return DAG.getNode(ISD::TRUNCATE, dl, MVT::i32, Scc);
-  }
-  return SDValue();
-}
-
 SDValue TargetLowering::expandIntMINMAX(SDNode *Node, SelectionDAG &DAG) const {
   SDValue Op0 = Node->getOperand(0);
   SDValue Op1 = Node->getOperand(1);

--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.h
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.h
@@ -58,7 +58,6 @@ public:
 
   bool isCheapToSpeculateCttz(Type *) const override { return true; }
   bool isCheapToSpeculateCtlz(Type *) const override { return true; }
-  bool isCtlzFast() const override { return true; }
 
   bool hasBitTest(SDValue X, SDValue Y) const override;
 

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -3663,11 +3663,23 @@ SDValue PPCTargetLowering::LowerSETCC(SDValue Op, SelectionDAG &DAG) const {
   // If we're comparing for equality to zero, expose the fact that this is
   // implemented as a ctlz/srl pair on ppc, so that the dag combiner can
   // fold the new nodes.
-  if (SDValue V = lowerCmpEqZeroToCtlzSrl(Op, DAG))
-    return V;
+  if (isNullConstant(RHS) && CC == ISD::SETEQ) {
+    EVT VT = LHS.getValueType();
+    SDValue Zext = LHS;
+    if (VT.bitsLT(MVT::i32)) {
+      VT = MVT::i32;
+      Zext = DAG.getNode(ISD::ZERO_EXTEND, dl, VT, LHS);
+    }
+    unsigned Log2b = Log2_32(VT.getSizeInBits());
+    SDValue Clz = DAG.getNode(ISD::CTLZ, dl, VT, Zext);
+    SDValue Scc = DAG.getNode(ISD::SRL, dl, VT, Clz,
+                              DAG.getConstant(Log2b, dl, MVT::i32));
+    return DAG.getNode(ISD::TRUNCATE, dl, MVT::i32, Scc);
+  }
 
   if (ConstantSDNode *C = dyn_cast<ConstantSDNode>(RHS)) {
-    // Leave comparisons against 0 and -1 alone for now, since they're usually
+    // Leave comparisons against -1 and comparisons against 0 (other than SETEQ
+    // against 0, which is handled above) alone for now, since they're usually
     // optimized.  FIXME: revisit this when we can custom lower all setcc
     // optimizations.
     if (C->isAllOnes() || C->isZero())

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.h
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.h
@@ -231,10 +231,6 @@ namespace llvm {
                                                unsigned ElemSizeInBits,
                                                unsigned &Index) const override;
 
-    bool isCtlzFast() const override {
-      return true;
-    }
-
     bool isEqualityCmpFoldedWithSignedCmp() const override {
       return false;
     }

--- a/llvm/lib/Target/Sparc/SparcISelLowering.cpp
+++ b/llvm/lib/Target/Sparc/SparcISelLowering.cpp
@@ -3705,7 +3705,9 @@ bool SparcTargetLowering::isFPImmLegal(const APFloat &Imm, EVT VT,
   return false;
 }
 
-bool SparcTargetLowering::isCtlzFast() const { return Subtarget->isVIS3(); }
+bool SparcTargetLowering::isCheapToSpeculateCtlz(Type *Ty) const {
+  return Subtarget->isVIS3();
+}
 
 bool SparcTargetLowering::isCheapToSpeculateCttz(Type *Ty) const {
   // We lack native cttz, however,

--- a/llvm/lib/Target/Sparc/SparcISelLowering.h
+++ b/llvm/lib/Target/Sparc/SparcISelLowering.h
@@ -171,11 +171,7 @@ namespace llvm {
     bool isFPImmLegal(const APFloat &Imm, EVT VT,
                       bool ForCodeSize) const override;
 
-    bool isCtlzFast() const override;
-
-    bool isCheapToSpeculateCtlz(Type *Ty) const override {
-      return isCtlzFast();
-    }
+    bool isCheapToSpeculateCtlz(Type *Ty) const override;
 
     bool isCheapToSpeculateCttz(Type *Ty) const override;
 

--- a/llvm/lib/Target/VE/VEISelLowering.h
+++ b/llvm/lib/Target/VE/VEISelLowering.h
@@ -289,8 +289,6 @@ public:
   bool hasStandaloneRem(EVT) const override { return false; }
   // VE LDZ instruction returns 64 if the input is zero.
   bool isCheapToSpeculateCtlz(Type *) const override { return true; }
-  // VE LDZ instruction is fast.
-  bool isCtlzFast() const override { return true; }
   // VE has NND instruction.
   bool hasAndNot(SDValue Y) const override;
   /// } Target Optimization

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -3682,10 +3682,6 @@ bool X86TargetLowering::canMergeStoresTo(unsigned AddressSpace, EVT MemVT,
   return true;
 }
 
-bool X86TargetLowering::isCtlzFast() const {
-  return Subtarget.hasFastLZCNT();
-}
-
 bool X86TargetLowering::isMaskAndCmp0FoldingBeneficial(
     const Instruction &AndI) const {
   return true;
@@ -53333,7 +53329,7 @@ static SDValue lowerX86CmpEqZeroToCtlzSrl(SDValue Op, SelectionDAG &DAG) {
 static SDValue combineOrCmpEqZeroToCtlzSrl(SDNode *N, SelectionDAG &DAG,
                                            TargetLowering::DAGCombinerInfo &DCI,
                                            const X86Subtarget &Subtarget) {
-  if (DCI.isBeforeLegalize() || !Subtarget.getTargetLowering()->isCtlzFast())
+  if (DCI.isBeforeLegalize() || !Subtarget.hasFastLZCNT())
     return SDValue();
 
   auto isORCandidate = [](SDValue N) {

--- a/llvm/lib/Target/X86/X86ISelLowering.h
+++ b/llvm/lib/Target/X86/X86ISelLowering.h
@@ -236,8 +236,6 @@ namespace llvm {
 
     bool isCheapToSpeculateCtlz(Type *Ty) const override;
 
-    bool isCtlzFast() const override;
-
     bool isMultiStoresCheaperThanBitsMerge(EVT LTy, EVT HTy) const override {
       // If the pair to store is a mixture of float and int values, we will
       // save two bitwise instructions and one float-to-int instruction and


### PR DESCRIPTION
It was literally only used by one function, called by one backend.