### PR TITLE
[lldb][windows] fix always falsy comparison

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -559,7 +559,7 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
         server.send_ack()
 
     def add_verified_launch_packets(self, launch_args):
-        if os.environ.get("LLDB_LAUNCH_FLAG_USE_PIPES", 0) == 1:
+        if os.environ.get("LLDB_LAUNCH_FLAG_USE_PIPES", "0") == "1":
             self.test_sequence.add_log_lines(
                 [
                     "read packet: %s"

--- a/lldb/test/API/tools/lldb-server/main.cpp
+++ b/lldb/test/API/tools/lldb-server/main.cpp
@@ -402,6 +402,7 @@ int main(int argc, char **argv) {
     } else {
       // Treat the argument as text for stdout.
       printf("%s\n", argv[i]);
+      // Make the test more reliable on Windows.
       fflush(stdout);
     }
   }

--- a/lldb/test/API/tools/lldb-server/main.cpp
+++ b/lldb/test/API/tools/lldb-server/main.cpp
@@ -402,6 +402,7 @@ int main(int argc, char **argv) {
     } else {
       // Treat the argument as text for stdout.
       printf("%s\n", argv[i]);
+      fflush(stdout);
     }
   }
 


### PR DESCRIPTION
This is a follow up to https://github.com/llvm/llvm-project/pull/206107, which introduced a comparison that is always falsy. `os.environ.get` returns a string and `('1' == 1) == False` in Python.

Compare to a string and return a string as a default value.