### PR TITLE
[libc++][test] XFAIL `text/text_encoding/environment.pass.cpp` test on Armv7/Linux Ubuntu targets.

### DIFF
--- a/libcxx/test/libcxx/text/text_encoding/environment.pass.cpp
+++ b/libcxx/test/libcxx/text/text_encoding/environment.pass.cpp
@@ -17,7 +17,7 @@
 // UNSUPPORTED: LLVM-LIBC-FIXME
 
 // FIXME: gets failed on Armv7/Linux Ubuntu 18.04 LTS board (remote exec) with
-// FIXME: "Environment mismatch: Expected ID 3, received: {106,UTF-8}"
+//        "Environment mismatch: Expected ID 3, received: {106,UTF-8}"
 // XFAIL: buildhost=windows && target=armv7-unknown-linux-gnueabihf
 
 // std::text_encoding::environment()

--- a/libcxx/test/libcxx/text/text_encoding/environment.pass.cpp
+++ b/libcxx/test/libcxx/text/text_encoding/environment.pass.cpp
@@ -16,6 +16,10 @@
 // UNSUPPORTED: availability-te-environment-missing
 // UNSUPPORTED: LLVM-LIBC-FIXME
 
+// FIXME: gets failed on Armv7/Linux Ubuntu 18.04 LTS board (remote exec) with
+// FIXME: "Environment mismatch: Expected ID 3, received: {106,UTF-8}"
+// XFAIL: buildhost=windows && target=armv7-unknown-linux-gnueabihf
+
 // std::text_encoding::environment()
 
 #include <algorithm>


### PR DESCRIPTION
The test gets failed on Armv7/Linux Ubuntu board during remote execution when cross-compiling on the Windows build host with the following message:

  Environment mismatch: Expected ID 3, received: {106,UTF-8}

Temporary XFAIL this test till investigation of the problem.

See #141312 for details