### PR TITLE
[flang][openacc] Add ACCHoistAllocatableRealloc pass

### DIFF
--- a/flang/include/flang/Optimizer/OpenACC/Passes.h
+++ b/flang/include/flang/Optimizer/OpenACC/Passes.h
@@ -28,6 +28,7 @@ namespace acc {
 #define GEN_PASS_REGISTRATION
 #include "flang/Optimizer/OpenACC/Passes.h.inc"
 
+std::unique_ptr<mlir::Pass> createACCHoistAllocatableReallocPass();
 std::unique_ptr<mlir::Pass> createACCInitializeFIRAnalysesPass();
 std::unique_ptr<mlir::Pass> createACCOptimizeFirstprivateMapPass();
 std::unique_ptr<mlir::Pass> createACCRecipeBufferizationPass();

--- a/flang/include/flang/Optimizer/OpenACC/Passes.td
+++ b/flang/include/flang/Optimizer/OpenACC/Passes.td
@@ -83,6 +83,26 @@ def ACCDeclareActionConversion
   let dependentDialects = ["fir::FIROpsDialect"];
 }
 
+def ACCHoistAllocatableRealloc
+    : Pass<"acc-hoist-allocatable-realloc", "mlir::func::FuncOp"> {
+  let summary = "Hoist allocatable reallocation out of OpenACC compute regions";
+  let description = [{
+    Intrinsic assignment to an allocatable inside an OpenACC compute construct
+    can (re)allocate the left-hand side. SeparateAllocatableAssign splits that
+    reallocation from the assignment but leaves it in place, inside the compute
+    region, so the (re)allocation would run on the device -- which the OpenACC
+    spec lists as undefined behavior.
+
+    This pass moves the separated reallocation (the conditional
+    allocmem/freemem/embox/store sequence that writes the allocatable
+    descriptor) out of the compute construct to the host, leaving only the
+    assignment in the kernel. The reallocation is hoisted only when all its
+    inputs are defined outside the region; self-dependent assignments are not
+    split by SeparateAllocatableAssign, so they are never matched here.
+  }];
+  let dependentDialects = ["mlir::acc::OpenACCDialect", "fir::FIROpsDialect"];
+}
+
 def ACCOptimizeFirstprivateMap
     : Pass<"acc-optimize-firstprivate-map", "mlir::func::FuncOp"> {
   let summary = "Optimize firstprivate mapping";

--- a/flang/lib/Optimizer/OpenACC/Transforms/ACCHoistAllocatableRealloc.cpp
+++ b/flang/lib/Optimizer/OpenACC/Transforms/ACCHoistAllocatableRealloc.cpp
@@ -1,0 +1,208 @@
+//===- ACCHoistAllocatableRealloc.cpp ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Hoist the allocatable reallocation that SeparateAllocatableAssign leaves
+// inside an OpenACC kernels construct out to the host, so only the assignment
+// runs on the device. A device-side allocate/deallocate is undefined behavior
+// under the OpenACC specification.
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Dialect/FIROps.h"
+#include "flang/Optimizer/Dialect/FIRType.h"
+#include "flang/Optimizer/OpenACC/Passes.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace fir::acc {
+#define GEN_PASS_DEF_ACCHOISTALLOCATABLEREALLOC
+#include "flang/Optimizer/OpenACC/Passes.h.inc"
+} // namespace fir::acc
+
+using namespace mlir;
+
+namespace {
+
+/// True for an allocatable descriptor reference:
+/// !fir.ref<!fir.box<!fir.heap<>>>.
+static bool isAllocatableDescRef(Type t) {
+  auto ref = dyn_cast<fir::ReferenceType>(t);
+  if (!ref)
+    return false;
+  auto box = dyn_cast<fir::BaseBoxType>(ref.getEleTy());
+  if (!box)
+    return false;
+  return isa<fir::HeapType>(box.getEleTy());
+}
+
+/// True if `v` is defined outside `region` (and therefore dominates the op that
+/// owns the region).
+static bool definedOutside(Value v, Region &region) {
+  return !region.isAncestor(v.getParentRegion());
+}
+
+/// Return the ancestor of `op` that is a direct child of `region`'s entry
+/// block, or null if `op` is not nested within that entry block.
+static Operation *topLevelInEntry(Operation *op, Region &region) {
+  Block *entry = &region.front();
+  for (Operation *cur = op; cur; cur = cur->getParentOp()) {
+    if (cur->getBlock() == entry)
+      return cur;
+  }
+  return nullptr;
+}
+
+/// Collect into `slice` the entry-block ops of `region` that `root` depends on
+/// (its backward SSA slice, including values used by nested ops). Returns false
+/// if a dependency is a region-local block argument, i.e. it cannot be hoisted.
+static bool collectReallocSlice(Operation *root, Region &region,
+                                llvm::SmallPtrSetImpl<Operation *> &slice) {
+  llvm::SmallVector<Operation *> worklist{root};
+  bool ok = true;
+  auto use = [&](Value v) {
+    if (definedOutside(v, region))
+      return;
+    if (Operation *def = v.getDefiningOp()) {
+      if (Operation *top = topLevelInEntry(def, region))
+        worklist.push_back(top);
+      else
+        ok = false;
+    } else {
+      ok = false; // region block argument
+    }
+  };
+  while (!worklist.empty()) {
+    Operation *op = worklist.pop_back_val();
+    if (!slice.insert(op).second)
+      continue;
+    for (Value v : op->getOperands())
+      use(v);
+    op->walk([&](Operation *nested) {
+      for (Value v : nested->getOperands())
+        use(v);
+    });
+  }
+  return ok;
+}
+
+/// True if hoisting the realloc (whose backward slice is `slice`, ending at
+/// `anchor`) past the kernel is safe. It is unsafe when a descriptor load that
+/// is not strictly after the realloc feeds an op that stays in the kernel: that
+/// op would read storage the realloc has already freed.
+static bool isSafeToHoist(Value desc, Operation *anchor, Region &region,
+                          const llvm::SmallPtrSetImpl<Operation *> &slice) {
+  for (Operation *user : desc.getUsers()) {
+    auto load = dyn_cast<fir::LoadOp>(user);
+    if (!load)
+      continue;
+    Operation *loadTop = topLevelInEntry(load, region);
+    if (!loadTop || anchor->isBeforeInBlock(loadTop))
+      continue; // outside region, or the post-realloc reload
+    for (Operation *consumer : load.getResult().getUsers()) {
+      Operation *consTop = topLevelInEntry(consumer, region);
+      if (consTop && !slice.contains(consTop))
+        return false;
+    }
+  }
+  return true;
+}
+
+/// True if `st` sits at the region's outer level, guarded only by the
+/// `genReallocIfNeeded` `fir.if`s (never inside a loop). Hoisting an in-loop
+/// realloc out of the construct would be wrong.
+static bool reallocAtRegionTop(Operation *st, Block *entry) {
+  for (Operation *cur = st->getParentOp(); cur; cur = cur->getParentOp()) {
+    if (!isa<fir::IfOp>(cur))
+      return false;
+    if (cur->getBlock() == entry)
+      return true;
+  }
+  return false;
+}
+
+/// True if `slice` contains the `.auto.alloc` allocation that identifies a
+/// SeparateAllocatableAssign realloc (not a user allocate or other store).
+static bool hasAutoAlloc(const llvm::SmallPtrSetImpl<Operation *> &slice) {
+  bool found = false;
+  for (Operation *op : slice)
+    op->walk([&](fir::AllocMemOp a) {
+      if (auto name = a.getUniqName(); name && *name == ".auto.alloc")
+        found = true;
+    });
+  return found;
+}
+
+/// Hoist any in-region reallocation out of a single compute construct.
+static void hoistFromComputeOp(Operation *computeOp) {
+  Region &region = computeOp->getRegion(0);
+  if (region.empty())
+    return;
+
+  // Descriptor stores writing an allocatable defined outside the region are the
+  // reallocation's publish step.
+  llvm::SmallVector<fir::StoreOp> reallocStores;
+  computeOp->walk([&](fir::StoreOp st) {
+    if (isAllocatableDescRef(st.getMemref().getType()) &&
+        definedOutside(st.getMemref(), region))
+      reallocStores.push_back(st);
+  });
+  if (reallocStores.empty())
+    return;
+
+  llvm::SmallPtrSet<Operation *, 16> slice;
+  for (fir::StoreOp st : reallocStores) {
+    Operation *anchor = topLevelInEntry(st, region);
+    if (!anchor)
+      continue;
+    // Outer artificial-loop level only: never hoist a loop-body realloc.
+    if (!reallocAtRegionTop(st, &region.front()))
+      continue;
+    llvm::SmallPtrSet<Operation *, 16> local;
+    if (!collectReallocSlice(anchor, region, local))
+      continue;
+    // Must be the SeparateAllocatableAssign realloc, not some other store.
+    if (!hasAutoAlloc(local))
+      continue;
+    // Unsafe to hoist if the assignment reads the old storage the realloc
+    // frees: any consumer of a pre-realloc descriptor load that stays in the
+    // kernel would read freed memory (e.g. a self-dependent `b = b + 1`).
+    if (!isSafeToHoist(st.getMemref(), anchor, region, local))
+      continue;
+    slice.insert(local.begin(), local.end());
+  }
+  if (slice.empty())
+    return;
+
+  // Move the collected ops before the compute op, preserving their order.
+  for (Operation &op : llvm::make_early_inc_range(region.front()))
+    if (slice.contains(&op))
+      op.moveBefore(computeOp);
+}
+
+class ACCHoistAllocatableRealloc
+    : public fir::acc::impl::ACCHoistAllocatableReallocBase<
+          ACCHoistAllocatableRealloc> {
+public:
+  void runOnOperation() override {
+    // Only acc kernels: the compiler-introduced realloc is hoisted to the
+    // host. For acc parallel/serial the (de)allocation is the user's
+    // responsibility and is left untouched.
+    llvm::SmallVector<mlir::acc::KernelsOp> kernels;
+    getOperation().walk(
+        [&](mlir::acc::KernelsOp op) { kernels.push_back(op); });
+    for (mlir::acc::KernelsOp op : kernels)
+      hoistFromComputeOp(op);
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> fir::acc::createACCHoistAllocatableReallocPass() {
+  return std::make_unique<ACCHoistAllocatableRealloc>();
+}

--- a/flang/lib/Optimizer/OpenACC/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_flang_library(FIROpenACCTransforms
   ACCDeclareActionConversion.cpp
+  ACCHoistAllocatableRealloc.cpp
   ACCInitializeFIRAnalyses.cpp
   ACCOptimizeFirstprivateMap.cpp
   ACCRecipeBufferization.cpp

--- a/flang/test/Transforms/OpenACC/acc-hoist-allocatable-realloc.fir
+++ b/flang/test/Transforms/OpenACC/acc-hoist-allocatable-realloc.fir
@@ -1,0 +1,126 @@
+// RUN: fir-opt %s --acc-hoist-allocatable-realloc -split-input-file | FileCheck %s
+
+// The separated reallocation is hoisted out of acc kernels; only the
+// assignment stays on the device.
+
+// CHECK-LABEL: func.func @hoist
+// CHECK: fir.allocmem {{.*}} {uniq_name = ".auto.alloc"}
+// CHECK: fir.store {{.*}} to %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+// CHECK: acc.kernels {
+// CHECK-NOT: fir.allocmem
+// CHECK: hlfir.assign
+// CHECK: acc.terminator
+func.func @hoist(%b: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, %n: index, %cond: i1, %v: f32) {
+  acc.kernels {
+    %m = fir.if %cond -> !fir.heap<!fir.array<?xf32>> {
+      %a = fir.allocmem !fir.array<?xf32>, %n {uniq_name = ".auto.alloc"}
+      fir.result %a : !fir.heap<!fir.array<?xf32>>
+    } else {
+      %z = fir.zero_bits !fir.heap<!fir.array<?xf32>>
+      fir.result %z : !fir.heap<!fir.array<?xf32>>
+    }
+    fir.if %cond {
+      %sh = fir.shape %n : (index) -> !fir.shape<1>
+      %box = fir.embox %m(%sh) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
+      fir.store %box to %b : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+    }
+    %ld = fir.load %b : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+    hlfir.assign %v to %ld : f32, !fir.box<!fir.heap<!fir.array<?xf32>>>
+    acc.terminator
+  }
+  return
+}
+
+// -----
+
+// The RHS reads the old storage that the reallocation frees, so it must stay
+// inside the kernel (e.g. `b = b + 1`).
+
+// CHECK-LABEL: func.func @selfdep_no_hoist
+// CHECK: acc.kernels {
+// CHECK: fir.allocmem {{.*}} {uniq_name = ".auto.alloc"}
+// CHECK: acc.terminator
+func.func @selfdep_no_hoist(%b: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, %n: index, %cond: i1, %v: f32) {
+  acc.kernels {
+    %old = fir.load %b : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+    %m = fir.if %cond -> !fir.heap<!fir.array<?xf32>> {
+      %a = fir.allocmem !fir.array<?xf32>, %n {uniq_name = ".auto.alloc"}
+      fir.result %a : !fir.heap<!fir.array<?xf32>>
+    } else {
+      %z = fir.zero_bits !fir.heap<!fir.array<?xf32>>
+      fir.result %z : !fir.heap<!fir.array<?xf32>>
+    }
+    fir.if %cond {
+      %sh = fir.shape %n : (index) -> !fir.shape<1>
+      %box = fir.embox %m(%sh) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
+      fir.store %box to %b : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+    }
+    %new = fir.load %b : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+    hlfir.assign %old to %new : !fir.box<!fir.heap<!fir.array<?xf32>>>, !fir.box<!fir.heap<!fir.array<?xf32>>>
+    acc.terminator
+  }
+  return
+}
+
+// -----
+
+// acc parallel reallocation is the user's responsibility; only acc kernels is
+// hoisted.
+
+// CHECK-LABEL: func.func @parallel_no_hoist
+// CHECK: acc.parallel {
+// CHECK: fir.allocmem {{.*}} {uniq_name = ".auto.alloc"}
+// CHECK: acc.yield
+func.func @parallel_no_hoist(%b: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, %n: index, %cond: i1, %v: f32) {
+  acc.parallel {
+    %m = fir.if %cond -> !fir.heap<!fir.array<?xf32>> {
+      %a = fir.allocmem !fir.array<?xf32>, %n {uniq_name = ".auto.alloc"}
+      fir.result %a : !fir.heap<!fir.array<?xf32>>
+    } else {
+      %z = fir.zero_bits !fir.heap<!fir.array<?xf32>>
+      fir.result %z : !fir.heap<!fir.array<?xf32>>
+    }
+    fir.if %cond {
+      %sh = fir.shape %n : (index) -> !fir.shape<1>
+      %box = fir.embox %m(%sh) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
+      fir.store %box to %b : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+    }
+    %ld = fir.load %b : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+    hlfir.assign %v to %ld : f32, !fir.box<!fir.heap<!fir.array<?xf32>>>
+    acc.yield
+  }
+  return
+}
+
+// -----
+
+// An in-loop reallocation (nested in a loop, not at the construct's outer
+// level) must stay inside the kernel.
+
+// CHECK-LABEL: func.func @inloop_no_hoist
+// CHECK: acc.kernels {
+// CHECK: fir.do_loop
+// CHECK: fir.allocmem {{.*}} {uniq_name = ".auto.alloc"}
+// CHECK: acc.terminator
+func.func @inloop_no_hoist(%b: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>, %n: index, %cond: i1, %v: f32, %lb: index, %ub: index, %step: index) {
+  acc.kernels {
+    fir.do_loop %i = %lb to %ub step %step {
+      %m = fir.if %cond -> !fir.heap<!fir.array<?xf32>> {
+        %a = fir.allocmem !fir.array<?xf32>, %n {uniq_name = ".auto.alloc"}
+        fir.result %a : !fir.heap<!fir.array<?xf32>>
+      } else {
+        %z = fir.zero_bits !fir.heap<!fir.array<?xf32>>
+        fir.result %z : !fir.heap<!fir.array<?xf32>>
+      }
+      fir.if %cond {
+        %sh = fir.shape %n : (index) -> !fir.shape<1>
+        %box = fir.embox %m(%sh) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
+        fir.store %box to %b : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+      }
+      %ld = fir.load %b : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+      hlfir.assign %v to %ld : f32, !fir.box<!fir.heap<!fir.array<?xf32>>>
+    }
+    acc.terminator
+  }
+  return
+}


### PR DESCRIPTION
Hoist the allocatable reallocation that SeparateAllocatableAssign leaves inside an OpenACC acc kernels compute region out to the host, so only the assignment runs on the device. A device-side allocate/deallocate is undefined behavior under the OpenACC specification.

The hoist is scoped to acc kernels, to the construct's outer artificial-loop level (fir.if-guarded prologue/epilogue), and to the compiler-introduced .auto.alloc reallocation whose size/shape values dominate the hoisted allocate. A safety check keeps the realloc in place when the kernel reads the freed buffer (e.g. b = b + 1).