### PR TITLE
[scudo] Make death tests use SCUDO_XXX_DEATH_TEST.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/chunk_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/chunk_test.cpp
@@ -33,7 +33,7 @@ TEST(ScudoChunkDeathTest, ChunkBasic) {
   scudo::Chunk::loadHeader(Cookie, P, &Header);
   EXPECT_TRUE(scudo::Chunk::isValid(Cookie, P, &Header));
   EXPECT_FALSE(scudo::Chunk::isValid(InvalidCookie, P, &Header));
-  EXPECT_DEATH(scudo::Chunk::loadHeader(InvalidCookie, P, &Header), "");
+  SCUDO_EXPECT_DEATH(scudo::Chunk::loadHeader(InvalidCookie, P, &Header), "");
   free(Block);
 }
 
@@ -50,7 +50,7 @@ TEST(ScudoChunkDeathTest, CorruptHeader) {
   // Simulate a couple of corrupted bits per byte of header data.
   for (scudo::uptr I = 0; I < sizeof(scudo::Chunk::PackedHeader); I++) {
     *(reinterpret_cast<scudo::u8 *>(Block) + I) ^= 0x42U;
-    EXPECT_DEATH(scudo::Chunk::loadHeader(Cookie, P, &Header), "");
+    SCUDO_EXPECT_DEATH(scudo::Chunk::loadHeader(Cookie, P, &Header), "");
     *(reinterpret_cast<scudo::u8 *>(Block) + I) ^= 0x42U;
   }
   free(Block);

--- a/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
@@ -32,15 +32,6 @@
 static constexpr scudo::Chunk::Origin Origin = scudo::Chunk::Origin::Malloc;
 static constexpr scudo::uptr MinAlignLog = FIRST_32_SECOND_64(3U, 4U);
 
-// Fuchsia complains that the function is not used.
-UNUSED static void disableDebuggerdMaybe() {
-#if SCUDO_ANDROID
-  // Disable the debuggerd signal handler on Android, without this we can end
-  // up spending a significant amount of time creating tombstones.
-  signal(SIGSEGV, SIG_DFL);
-#endif
-}
-
 template <class AllocatorT>
 bool isPrimaryAllocation(scudo::uptr Size, scudo::uptr Alignment) {
   const scudo::uptr MinAlignment = 1UL << SCUDO_MIN_ALIGNMENT_LOG;
@@ -58,23 +49,13 @@ void checkMemoryTaggingMaybe(AllocatorT *Allocator, void *P, scudo::uptr Size,
   const scudo::uptr MinAlignment = 1UL << SCUDO_MIN_ALIGNMENT_LOG;
   Size = scudo::roundUp(Size, MinAlignment);
   if (Allocator->useMemoryTaggingTestOnly()) {
-    EXPECT_DEATH(
-        {
-          disableDebuggerdMaybe();
-          reinterpret_cast<char *>(P)[-1] = 'A';
-        },
-        "");
+    SCUDO_EXPECT_DEATH(reinterpret_cast<char *>(P)[-1] = 'A', "");
   }
   if (isPrimaryAllocation<AllocatorT>(Size, Alignment)
           ? Allocator->useMemoryTaggingTestOnly()
           : Alignment == MinAlignment &&
                 AllocatorT::SecondaryT::getGuardPageSize() > 0) {
-    EXPECT_DEATH(
-        {
-          disableDebuggerdMaybe();
-          reinterpret_cast<char *>(P)[Size] = 'A';
-        },
-        "");
+    SCUDO_EXPECT_DEATH(reinterpret_cast<char *>(P)[Size] = 'A', "");
   }
 }
 
@@ -551,12 +532,7 @@ SCUDO_TYPED_TEST(ScudoCombinedDeathTest, ReallocateDecreasingTagged) {
 
   // Check that accessing the entire allocation after new size causes a crash.
   for (size_t I = NewSize; I < Size; I++) {
-    EXPECT_DEATH(
-        {
-          disableDebuggerdMaybe();
-          reinterpret_cast<char *>(NewP)[I] = 'A';
-        },
-        "");
+    SCUDO_EXPECT_DEATH(reinterpret_cast<char *>(NewP)[I] = 'A', "");
   }
   Allocator->deallocate(P, Origin);
 }
@@ -594,17 +570,15 @@ SCUDO_TYPED_TEST(ScudoCombinedDeathTest, UseAfterFree) {
     const scudo::uptr Size = 1U << SizeLog;
     if (!Allocator->useMemoryTaggingTestOnly())
       continue;
-    EXPECT_DEATH(
+    SCUDO_EXPECT_DEATH(
         {
-          disableDebuggerdMaybe();
           void *P = Allocator->allocate(Size, Origin);
           Allocator->deallocate(P, Origin);
           reinterpret_cast<char *>(P)[0] = 'A';
         },
         "");
-    EXPECT_DEATH(
+    SCUDO_EXPECT_DEATH(
         {
-          disableDebuggerdMaybe();
           void *P = Allocator->allocate(Size, Origin);
           Allocator->deallocate(P, Origin);
           reinterpret_cast<char *>(P)[Size - 1] = 'A';
@@ -622,7 +596,7 @@ SCUDO_TYPED_TEST(ScudoCombinedDeathTest, DoubleFreeFromPrimary) {
       break;
 
     // Verify that a double free results in a chunk state error.
-    EXPECT_DEATH(
+    SCUDO_EXPECT_DEATH(
         {
           // Allocate from primary
           void *P = Allocator->allocate(Size, Origin);
@@ -640,7 +614,7 @@ SCUDO_TYPED_TEST(ScudoCombinedDeathTest, DisableMemoryTagging) {
   if (Allocator->useMemoryTaggingTestOnly()) {
     // Check that disabling memory tagging works correctly.
     void *P = Allocator->allocate(2048, Origin);
-    EXPECT_DEATH(reinterpret_cast<char *>(P)[2048] = 'A', "");
+    SCUDO_EXPECT_DEATH(reinterpret_cast<char *>(P)[2048] = 'A', "");
     scudo::ScopedDisableMemoryTagChecks NoTagChecks;
     Allocator->disableMemoryTagging();
     reinterpret_cast<char *>(P)[2048] = 'A';
@@ -777,7 +751,7 @@ TEST(ScudoCombinedDeathTest, SKIP_ON_FUCHSIA(testSEGV)) {
   ASSERT_TRUE(ReservedMemory.create(/*Addr=*/0U, Size, "testSEGV"));
   void *P = reinterpret_cast<void *>(ReservedMemory.getBase());
   ASSERT_NE(P, nullptr);
-  EXPECT_DEATH(memset(P, 0xaa, Size), "");
+  SCUDO_EXPECT_DEATH(memset(P, 0xaa, Size), "");
   ReservedMemory.release();
 }
 
@@ -828,28 +802,28 @@ TEST(ScudoCombinedDeathTest, DeathCombined) {
   EXPECT_NE(P, nullptr);
 
   // Invalid sized deallocation.
-  EXPECT_DEATH(Allocator->deallocateSized(P, Origin, Size + 8U), "");
+  SCUDO_EXPECT_DEATH(Allocator->deallocateSized(P, Origin, Size + 8U), "");
 
   // Misaligned pointer. Potentially unused if EXPECT_DEATH isn't available.
   UNUSED void *MisalignedP =
       reinterpret_cast<void *>(reinterpret_cast<scudo::uptr>(P) | 1U);
-  EXPECT_DEATH(Allocator->deallocateSized(MisalignedP, Origin, Size), "");
-  EXPECT_DEATH(Allocator->reallocate(MisalignedP, Size * 2U), "");
+  SCUDO_EXPECT_DEATH(Allocator->deallocateSized(MisalignedP, Origin, Size), "");
+  SCUDO_EXPECT_DEATH(Allocator->reallocate(MisalignedP, Size * 2U), "");
 
   // Header corruption.
   scudo::u64 *H =
       reinterpret_cast<scudo::u64 *>(scudo::Chunk::getAtomicHeader(P));
   *H ^= 0x42U;
-  EXPECT_DEATH(Allocator->deallocateSized(P, Origin, Size), "");
+  SCUDO_EXPECT_DEATH(Allocator->deallocateSized(P, Origin, Size), "");
   *H ^= 0x420042U;
-  EXPECT_DEATH(Allocator->deallocateSized(P, Origin, Size), "");
+  SCUDO_EXPECT_DEATH(Allocator->deallocateSized(P, Origin, Size), "");
   *H ^= 0x420000U;
 
   // Invalid chunk state.
   Allocator->deallocateSized(P, Origin, Size);
-  EXPECT_DEATH(Allocator->deallocateSized(P, Origin, Size), "");
-  EXPECT_DEATH(Allocator->reallocate(P, Size * 2U), "");
-  EXPECT_DEATH(Allocator->getUsableSize(P), "");
+  SCUDO_EXPECT_DEATH(Allocator->deallocateSized(P, Origin, Size), "");
+  SCUDO_EXPECT_DEATH(Allocator->reallocate(P, Size * 2U), "");
+  SCUDO_EXPECT_DEATH(Allocator->getUsableSize(P), "");
 }
 
 // Verify that when a region gets full, the allocator will still manage to
@@ -1836,7 +1810,7 @@ TEST(ScudoCombinedDeathTest, DeallocateAlignNotPowerOfTwo) {
   auto Allocator = std::unique_ptr<AllocatorT>(new AllocatorT());
 
   void *Ptr = Allocator->allocate(10, scudo::Chunk::Origin::Memalign, 32);
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       Allocator->deallocateAligned(Ptr, scudo::Chunk::Origin::Memalign, 9),
       "alignment must be a power of two");
   Allocator->deallocateAligned(Ptr, scudo::Chunk::Origin::Memalign, 32);
@@ -1850,26 +1824,26 @@ TEST(ScudoCombinedDeathTest, TypeMismatch) {
 
   void *Ptr = Allocator->allocate(10, scudo::Chunk::Origin::Malloc);
   EXPECT_TRUE(Ptr != nullptr);
-  EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::New),
-               "deallocating.*\\(malloc vs new\\)");
-  EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::NewArray),
-               "deallocating.*\\(malloc vs new\\[\\]\\)");
+  SCUDO_EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::New),
+                     "deallocating.*\\(malloc vs new\\)");
+  SCUDO_EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::NewArray),
+                     "deallocating.*\\(malloc vs new\\[\\]\\)");
   Allocator->deallocate(Ptr, scudo::Chunk::Origin::Malloc);
 
   Ptr = Allocator->allocate(10, scudo::Chunk::Origin::New);
   EXPECT_TRUE(Ptr != nullptr);
-  EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::Malloc),
-               "deallocating.*\\(new vs malloc\\)");
-  EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::NewArray),
-               "deallocating.*\\(new vs new\\[\\]\\)");
+  SCUDO_EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::Malloc),
+                     "deallocating.*\\(new vs malloc\\)");
+  SCUDO_EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::NewArray),
+                     "deallocating.*\\(new vs new\\[\\]\\)");
   Allocator->deallocate(Ptr, scudo::Chunk::Origin::New);
 
   Ptr = Allocator->allocate(10, scudo::Chunk::Origin::NewArray);
   EXPECT_TRUE(Ptr != nullptr);
-  EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::Malloc),
-               "deallocating.*\\(new\\[\\] vs malloc\\)");
-  EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::New),
-               "deallocating.*\\(new\\[\\] vs new\\)");
+  SCUDO_EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::Malloc),
+                     "deallocating.*\\(new\\[\\] vs malloc\\)");
+  SCUDO_EXPECT_DEATH(Allocator->deallocate(Ptr, scudo::Chunk::Origin::New),
+                     "deallocating.*\\(new\\[\\] vs new\\)");
   Allocator->deallocate(Ptr, scudo::Chunk::Origin::NewArray);
 }
 
@@ -1881,20 +1855,20 @@ TEST(ScudoCombinedDeathTest, ReallocTypeMismatch) {
 
   void *Ptr = Allocator->allocate(10, scudo::Chunk::Origin::New);
   EXPECT_TRUE(Ptr != nullptr);
-  EXPECT_DEATH(Allocator->reallocate(Ptr, 1000000),
-               "reallocating.*\\(new vs malloc\\)");
+  SCUDO_EXPECT_DEATH(Allocator->reallocate(Ptr, 1000000),
+                     "reallocating.*\\(new vs malloc\\)");
   Allocator->deallocate(Ptr, scudo::Chunk::Origin::New);
 
   Ptr = Allocator->allocate(10, scudo::Chunk::Origin::NewArray);
   EXPECT_TRUE(Ptr != nullptr);
-  EXPECT_DEATH(Allocator->reallocate(Ptr, 1000000),
-               "reallocating.*\\(new\\[\\] vs malloc\\)");
+  SCUDO_EXPECT_DEATH(Allocator->reallocate(Ptr, 1000000),
+                     "reallocating.*\\(new\\[\\] vs malloc\\)");
   Allocator->deallocate(Ptr, scudo::Chunk::Origin::NewArray);
 
   Ptr = Allocator->allocate(10, scudo::Chunk::Origin::Memalign, 32);
   EXPECT_TRUE(Ptr != nullptr);
-  EXPECT_DEATH(Allocator->reallocate(Ptr, 1000000),
-               "reallocating.*\\(aligned malloc vs malloc\\)");
+  SCUDO_EXPECT_DEATH(Allocator->reallocate(Ptr, 1000000),
+                     "reallocating.*\\(aligned malloc vs malloc\\)");
   Allocator->deallocateAligned(Ptr, scudo::Chunk::Origin::Memalign, 32);
 }
 
@@ -1906,8 +1880,8 @@ TEST(ScudoCombinedDeathTest, AlignTypeMismatch) {
 
   void *Ptr = Allocator->allocate(10, scudo::Chunk::Origin::Memalign, 32);
   EXPECT_TRUE(Ptr != nullptr);
-  EXPECT_DEATH(Allocator->reallocate(Ptr, 1000),
-               "reallocating.*\\(aligned malloc vs malloc\\)");
+  SCUDO_EXPECT_DEATH(Allocator->reallocate(Ptr, 1000),
+                     "reallocating.*\\(aligned malloc vs malloc\\)");
   // Aligned allocate with non-aligned deallocate is okay.
   Allocator->deallocate(Ptr, scudo::Chunk::Origin::Malloc);
 }
@@ -1937,16 +1911,17 @@ TEST(ScudoCombinedDeathTest, SizeMismatch) {
 
   void *Ptr = Allocator->allocate(10, scudo::Chunk::Origin::Malloc);
   EXPECT_TRUE(Ptr != nullptr);
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       Allocator->deallocateSized(Ptr, scudo::Chunk::Origin::Malloc, 1000000),
       "invalid sized delete when deallocating.*\\(1000000 vs 10\\)");
   Allocator->deallocate(Ptr, scudo::Chunk::Origin::Malloc);
 
   Ptr = Allocator->allocate(10, scudo::Chunk::Origin::Memalign, 32);
   EXPECT_TRUE(Ptr != nullptr);
-  EXPECT_DEATH(Allocator->deallocateSizedAligned(
-                   Ptr, scudo::Chunk::Origin::Malloc, 1000000, 32),
-               "invalid sized delete when deallocating.*\\(1000000 vs 10\\)");
+  SCUDO_EXPECT_DEATH(
+      Allocator->deallocateSizedAligned(Ptr, scudo::Chunk::Origin::Malloc,
+                                        1000000, 32),
+      "invalid sized delete when deallocating.*\\(1000000 vs 10\\)");
   Allocator->deallocateAligned(Ptr, scudo::Chunk::Origin::Malloc, 32);
 }
 
@@ -1962,14 +1937,14 @@ TEST(ScudoCombinedDeathTest, SizeNotExactUsableMismatch) {
 
   void *Ptr = Allocator->allocate(10, scudo::Chunk::Origin::Malloc);
   EXPECT_TRUE(Ptr != nullptr);
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       Allocator->deallocateSized(Ptr, scudo::Chunk::Origin::Malloc, 1000000),
       "invalid sized delete when deallocating.*\\(1000000 vs 10 or .*\\)");
   Allocator->deallocateSized(Ptr, scudo::Chunk::Origin::Malloc, 10);
 
   Ptr = Allocator->allocate(10, scudo::Chunk::Origin::Memalign, 32);
   EXPECT_TRUE(Ptr != nullptr);
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       Allocator->deallocateSizedAligned(Ptr, scudo::Chunk::Origin::Malloc,
                                         1000000, 32),
       "invalid sized delete when deallocating.*\\(1000000 vs 10 or .*\\)");
@@ -2019,12 +1994,13 @@ TEST(ScudoCombinedDeathTest, AlignMismatch) {
   }
 
   scudo::uptr Alignment = 2 * scudo::getPageSizeCached();
-  EXPECT_DEATH(Allocator->deallocateAligned(
-                   AlignedPtr, scudo::Chunk::Origin::Malloc, Alignment),
-               "invalid aligned delete when deallocating");
-  EXPECT_DEATH(Allocator->deallocateSizedAligned(
-                   AlignedPtr, scudo::Chunk::Origin::Malloc, 10, Alignment),
-               "invalid aligned delete when deallocating");
+  SCUDO_EXPECT_DEATH(Allocator->deallocateAligned(
+                         AlignedPtr, scudo::Chunk::Origin::Malloc, Alignment),
+                     "invalid aligned delete when deallocating");
+  SCUDO_EXPECT_DEATH(
+      Allocator->deallocateSizedAligned(
+          AlignedPtr, scudo::Chunk::Origin::Malloc, 10, Alignment),
+      "invalid aligned delete when deallocating");
 
   Allocator->deallocateAligned(AlignedPtr, scudo::Chunk::Origin::Malloc, 32);
 }

--- a/compiler-rt/lib/scudo/standalone/tests/flags_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/flags_test.cpp
@@ -41,16 +41,21 @@ TEST(ScudoFlagsTest, BooleanFlags) {
 }
 
 TEST(ScudoFlagsDeathTest, BooleanFlags) {
-  EXPECT_DEATH(testFlag(scudo::FlagType::FT_bool, false, "flag_name", true),
-               "expected '='");
-  EXPECT_DEATH(testFlag(scudo::FlagType::FT_bool, false, "flag_name=", true),
-               "invalid value for bool option: ''");
-  EXPECT_DEATH(testFlag(scudo::FlagType::FT_bool, false, "flag_name=2", true),
-               "invalid value for bool option: '2'");
-  EXPECT_DEATH(testFlag(scudo::FlagType::FT_bool, false, "flag_name=-1", true),
-               "invalid value for bool option: '-1'");
-  EXPECT_DEATH(testFlag(scudo::FlagType::FT_bool, false, "flag_name=on", true),
-               "invalid value for bool option: 'on'");
+  SCUDO_EXPECT_DEATH(
+      testFlag(scudo::FlagType::FT_bool, false, "flag_name", true),
+      "expected '='");
+  SCUDO_EXPECT_DEATH(
+      testFlag(scudo::FlagType::FT_bool, false, "flag_name=", true),
+      "invalid value for bool option: ''");
+  SCUDO_EXPECT_DEATH(
+      testFlag(scudo::FlagType::FT_bool, false, "flag_name=2", true),
+      "invalid value for bool option: '2'");
+  SCUDO_EXPECT_DEATH(
+      testFlag(scudo::FlagType::FT_bool, false, "flag_name=-1", true),
+      "invalid value for bool option: '-1'");
+  SCUDO_EXPECT_DEATH(
+      testFlag(scudo::FlagType::FT_bool, false, "flag_name=on", true),
+      "invalid value for bool option: 'on'");
 }
 
 TEST(ScudoFlagsTest, IntFlags) {
@@ -67,10 +72,10 @@ TEST(ScudoFlagsTest, IntFlags) {
 }
 
 TEST(ScudoFlagsDeathTest, IntFlags) {
-  EXPECT_DEATH(testFlag(scudo::FlagType::FT_int, -11, "flag_name", 0),
-               "expected '='");
-  EXPECT_DEATH(testFlag(scudo::FlagType::FT_int, -11, "flag_name=42U", 0),
-               "invalid value for int option");
+  SCUDO_EXPECT_DEATH(testFlag(scudo::FlagType::FT_int, -11, "flag_name", 0),
+                     "expected '='");
+  SCUDO_EXPECT_DEATH(testFlag(scudo::FlagType::FT_int, -11, "flag_name=42U", 0),
+                     "invalid value for int option");
 }
 
 static void testTwoFlags(const char *Env, bool ExpectedFlag1,

--- a/compiler-rt/lib/scudo/standalone/tests/map_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/map_test.cpp
@@ -129,7 +129,7 @@ TEST(ScudoMapDeathTest, MapNoAccessUnmap) {
 
   ASSERT_TRUE(ReservedMemory.create(/*Addr=*/0U, Size, MappingName));
   EXPECT_NE(ReservedMemory.getBase(), 0U);
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       memset(reinterpret_cast<void *>(ReservedMemory.getBase()), 0xaa, Size),
       "");
 
@@ -138,7 +138,7 @@ TEST(ScudoMapDeathTest, MapNoAccessUnmap) {
 
 TEST(ScudoMapDeathTest, MapUnmap) {
   const scudo::uptr Size = 4 * scudo::getPageSizeCached();
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       {
         // Repeat few time to avoid missing crash if it's mmaped by unrelated
         // code.
@@ -169,7 +169,7 @@ TEST(ScudoMapDeathTest, MapWithGuardUnmap) {
   scudo::uptr Q = MemMap.getBase() + PageSize;
   ASSERT_TRUE(MemMap.remap(Q, Size, MappingName));
   memset(reinterpret_cast<void *>(Q), 0xaa, Size);
-  EXPECT_DEATH(memset(reinterpret_cast<void *>(Q), 0xaa, Size + 1), "");
+  SCUDO_EXPECT_DEATH(memset(reinterpret_cast<void *>(Q), 0xaa, Size + 1), "");
   MemMap.unmap();
 }
 

--- a/compiler-rt/lib/scudo/standalone/tests/memtag_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/memtag_test.cpp
@@ -24,23 +24,24 @@ TEST(MemtagBasicDeathTest, Unsupported) {
   if (&__hwasan_init != 0)
     TEST_SKIP("Incompatible with HWASan");
 
-  EXPECT_DEATH(archMemoryTagGranuleSize(), "not supported");
-  EXPECT_DEATH(untagPointer((uptr)0), "not supported");
-  EXPECT_DEATH(extractTag((uptr)0), "not supported");
+  SCUDO_EXPECT_DEATH(archMemoryTagGranuleSize(), "not supported");
+  SCUDO_EXPECT_DEATH(untagPointer((uptr)0), "not supported");
+  SCUDO_EXPECT_DEATH(extractTag((uptr)0), "not supported");
 
-  EXPECT_DEATH(systemDetectsMemoryTagFaultsTestOnly(), "not supported");
-  EXPECT_DEATH(enableSystemMemoryTaggingTestOnly(), "not supported");
+  SCUDO_EXPECT_DEATH(systemDetectsMemoryTagFaultsTestOnly(), "not supported");
+  SCUDO_EXPECT_DEATH(enableSystemMemoryTaggingTestOnly(), "not supported");
 
-  EXPECT_DEATH(selectRandomTag((uptr)0, 0), "not supported");
-  EXPECT_DEATH(addFixedTag((uptr)0, 1), "not supported");
-  EXPECT_DEATH(storeTags((uptr)0, (uptr)0 + sizeof(0)), "not supported");
-  EXPECT_DEATH(storeTag((uptr)0), "not supported");
-  EXPECT_DEATH(loadTag((uptr)0), "not supported");
+  SCUDO_EXPECT_DEATH(selectRandomTag((uptr)0, 0), "not supported");
+  SCUDO_EXPECT_DEATH(addFixedTag((uptr)0, 1), "not supported");
+  SCUDO_EXPECT_DEATH(storeTags((uptr)0, (uptr)0 + sizeof(0)), "not supported");
+  SCUDO_EXPECT_DEATH(storeTag((uptr)0), "not supported");
+  SCUDO_EXPECT_DEATH(loadTag((uptr)0), "not supported");
 
-  EXPECT_DEATH(setRandomTag(nullptr, 64, 0, nullptr, nullptr), "not supported");
-  EXPECT_DEATH(untagPointer(nullptr), "not supported");
-  EXPECT_DEATH(loadTag(nullptr), "not supported");
-  EXPECT_DEATH(addFixedTag(nullptr, 0), "not supported");
+  SCUDO_EXPECT_DEATH(setRandomTag(nullptr, 64, 0, nullptr, nullptr),
+                     "not supported");
+  SCUDO_EXPECT_DEATH(untagPointer(nullptr), "not supported");
+  SCUDO_EXPECT_DEATH(loadTag(nullptr), "not supported");
+  SCUDO_EXPECT_DEATH(addFixedTag(nullptr, 0), "not supported");
 }
 
 class MemtagTest : public Test {
@@ -96,8 +97,8 @@ TEST_F(MemtagDeathTest, AddFixedTag) {
   for (uptr Tag = 0; Tag < 0x10; ++Tag)
     EXPECT_EQ(Tag, extractTag(addFixedTag(Addr, Tag)));
   if (SCUDO_DEBUG) {
-    EXPECT_DEATH(addFixedTag(Addr, 16), "");
-    EXPECT_DEATH(addFixedTag(~Addr, 0), "");
+    SCUDO_EXPECT_DEATH(addFixedTag(Addr, 16), "");
+    SCUDO_EXPECT_DEATH(addFixedTag(~Addr, 0), "");
   }
 }
 
@@ -113,7 +114,7 @@ TEST_F(MemtagDeathTest, ScopedDisableMemoryTagChecks) {
   u8 *P = reinterpret_cast<u8 *>(addFixedTag(Addr, 1));
   EXPECT_NE(P, Buffer);
 
-  EXPECT_DEATH(*P = 20, "");
+  SCUDO_EXPECT_DEATH(*P = 20, "");
   ScopedDisableMemoryTagChecks Disable;
   *P = 10;
 }
@@ -151,8 +152,8 @@ TEST_F(MemtagDeathTest, SKIP_NO_DEBUG(LoadStoreTagUnaligned)) {
   for (uptr P = Addr; P < Addr + 4 * archMemoryTagGranuleSize(); ++P) {
     if (P % archMemoryTagGranuleSize() == 0)
       continue;
-    EXPECT_DEATH(loadTag(P), "");
-    EXPECT_DEATH(storeTag(P), "");
+    SCUDO_EXPECT_DEATH(loadTag(P), "");
+    SCUDO_EXPECT_DEATH(storeTag(P), "");
   }
 }
 
@@ -173,7 +174,7 @@ TEST_F(MemtagDeathTest, SKIP_NO_DEBUG(StoreTagsUnaligned)) {
     uptr Tagged = addFixedTag(P, 5);
     if (Tagged % archMemoryTagGranuleSize() == 0)
       continue;
-    EXPECT_DEATH(storeTags(Tagged, Tagged), "");
+    SCUDO_EXPECT_DEATH(storeTags(Tagged, Tagged), "");
   }
 }
 

--- a/compiler-rt/lib/scudo/standalone/tests/report_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/report_test.cpp
@@ -13,82 +13,90 @@
 
 TEST(ScudoReportDeathTest, Check) {
   CHECK_LT(-1, 1);
-  EXPECT_DEATH(CHECK_GT(-1, 1),
-               "\\(-1\\) > \\(1\\) \\(\\(u64\\)op1=18446744073709551615, "
-               "\\(u64\\)op2=1");
+  SCUDO_EXPECT_DEATH(CHECK_GT(-1, 1),
+                     "\\(-1\\) > \\(1\\) \\(\\(u64\\)op1=18446744073709551615, "
+                     "\\(u64\\)op2=1");
 }
 
 TEST(ScudoReportDeathTest, Generic) {
   // Potentially unused if EXPECT_DEATH isn't defined.
   UNUSED void *P = reinterpret_cast<void *>(0x42424242U);
   UNUSED scudo::Chunk::PackedHeader Header = {};
-  EXPECT_DEATH(scudo::reportError("TEST123"), "Scudo ERROR.*TEST123");
-  EXPECT_DEATH(scudo::reportInvalidFlag("ABC", "DEF"), "Scudo ERROR.*ABC.*DEF");
-  EXPECT_DEATH(scudo::reportHeaderCorruption(&Header, P),
-               "Scudo ERROR.*42424242");
-  EXPECT_DEATH(scudo::reportSanityCheckError("XYZ"), "Scudo ERROR.*XYZ");
-  EXPECT_DEATH(scudo::reportAlignmentTooBig(123, 456), "Scudo ERROR.*123.*456");
-  EXPECT_DEATH(scudo::reportAllocationSizeTooBig(123, 456, 789),
-               "Scudo ERROR.*123.*456.*789");
-  EXPECT_DEATH(scudo::reportOutOfMemory(4242), "Scudo ERROR.*4242");
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(scudo::reportError("TEST123"), "Scudo ERROR.*TEST123");
+  SCUDO_EXPECT_DEATH(scudo::reportInvalidFlag("ABC", "DEF"),
+                     "Scudo ERROR.*ABC.*DEF");
+  SCUDO_EXPECT_DEATH(scudo::reportHeaderCorruption(&Header, P),
+                     "Scudo ERROR.*42424242");
+  SCUDO_EXPECT_DEATH(scudo::reportSanityCheckError("XYZ"), "Scudo ERROR.*XYZ");
+  SCUDO_EXPECT_DEATH(scudo::reportAlignmentTooBig(123, 456),
+                     "Scudo ERROR.*123.*456");
+  SCUDO_EXPECT_DEATH(scudo::reportAllocationSizeTooBig(123, 456, 789),
+                     "Scudo ERROR.*123.*456.*789");
+  SCUDO_EXPECT_DEATH(scudo::reportOutOfMemory(4242), "Scudo ERROR.*4242");
+  SCUDO_EXPECT_DEATH(
       scudo::reportInvalidChunkState(scudo::AllocatorAction::Recycling, P),
       "Scudo ERROR.*recycling.*42424242");
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       scudo::reportInvalidChunkState(scudo::AllocatorAction::Sizing, P),
       "Scudo ERROR.*sizing.*42424242");
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       scudo::reportMisalignedPointer(scudo::AllocatorAction::Deallocating, P),
       "Scudo ERROR.*deallocating.*42424242");
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       scudo::reportDeallocTypeMismatch(scudo::AllocatorAction::Reallocating, P,
                                        scudo::Chunk::Origin::New,
                                        scudo::Chunk::Origin::Memalign),
       "Scudo ERROR.*reallocating.*42424242.*\\(new vs aligned malloc\\)");
-  EXPECT_DEATH(scudo::reportDeallocTypeMismatch(
-                   scudo::AllocatorAction::Deallocating, P,
-                   scudo::Chunk::Origin::Memalign, scudo::Chunk::Origin::New),
-               "Scudo ERROR.*deallocating.*\\(aligned malloc vs new\\)");
-  EXPECT_DEATH(scudo::reportDeallocTypeMismatch(
-                   scudo::AllocatorAction::Deallocating, P,
-                   scudo::Chunk::Origin::Malloc | scudo::Chunk::Origin::Size,
-                   scudo::Chunk::Origin::NewArray | scudo::Chunk::Origin::Size |
-                       scudo::Chunk::Origin::Align),
-               "Scudo ERROR.*deallocating.*\\(sized malloc vs sized aligned "
-               "new\\[\\]\\)");
-  EXPECT_DEATH(scudo::reportDeleteSizeMismatch(P, 123, 456),
-               "Scudo ERROR.*42424242.*\\(123 vs 456\\)");
-  EXPECT_DEATH(scudo::reportDeleteSizeMismatch(P, 123, 456, 789),
-               "Scudo ERROR.*42424242.*\\(123 vs 456 or 789\\)");
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
+      scudo::reportDeallocTypeMismatch(scudo::AllocatorAction::Deallocating, P,
+                                       scudo::Chunk::Origin::Memalign,
+                                       scudo::Chunk::Origin::New),
+      "Scudo ERROR.*deallocating.*\\(aligned malloc vs new\\)");
+  SCUDO_EXPECT_DEATH(
+      scudo::reportDeallocTypeMismatch(
+          scudo::AllocatorAction::Deallocating, P,
+          scudo::Chunk::Origin::Malloc | scudo::Chunk::Origin::Size,
+          scudo::Chunk::Origin::NewArray | scudo::Chunk::Origin::Size |
+              scudo::Chunk::Origin::Align),
+      "Scudo ERROR.*deallocating.*\\(sized malloc vs sized aligned "
+      "new\\[\\]\\)");
+  SCUDO_EXPECT_DEATH(scudo::reportDeleteSizeMismatch(P, 123, 456),
+                     "Scudo ERROR.*42424242.*\\(123 vs 456\\)");
+  SCUDO_EXPECT_DEATH(scudo::reportDeleteSizeMismatch(P, 123, 456, 789),
+                     "Scudo ERROR.*42424242.*\\(123 vs 456 or 789\\)");
+  SCUDO_EXPECT_DEATH(
       scudo::reportDeleteAlignmentMismatch(reinterpret_cast<void *>(0x80),
                                            0x100),
       "Scudo ERROR.*invalid aligned delete.*\\(7 bit align vs 8 bit align\\)");
 }
 
 TEST(ScudoReportDeathTest, CSpecific) {
-  EXPECT_DEATH(scudo::reportAlignmentNotPowerOfTwo(123), "Scudo ERROR.*123");
-  EXPECT_DEATH(scudo::reportCallocOverflow(123, 456), "Scudo ERROR.*123.*456");
-  EXPECT_DEATH(scudo::reportReallocarrayOverflow(123, 456),
-               "Scudo ERROR.*reallocarray parameters.*123.*456");
-  EXPECT_DEATH(scudo::reportInvalidPosixMemalignAlignment(789),
-               "Scudo ERROR.*789");
-  EXPECT_DEATH(scudo::reportPvallocOverflow(123), "Scudo ERROR.*123");
-  EXPECT_DEATH(scudo::reportInvalidAlignedAllocAlignment(123, 456),
-               "Scudo ERROR.*123.*456");
+  SCUDO_EXPECT_DEATH(scudo::reportAlignmentNotPowerOfTwo(123),
+                     "Scudo ERROR.*123");
+  SCUDO_EXPECT_DEATH(scudo::reportCallocOverflow(123, 456),
+                     "Scudo ERROR.*123.*456");
+  SCUDO_EXPECT_DEATH(scudo::reportReallocarrayOverflow(123, 456),
+                     "Scudo ERROR.*reallocarray parameters.*123.*456");
+  SCUDO_EXPECT_DEATH(scudo::reportInvalidPosixMemalignAlignment(789),
+                     "Scudo ERROR.*789");
+  SCUDO_EXPECT_DEATH(scudo::reportPvallocOverflow(123), "Scudo ERROR.*123");
+  SCUDO_EXPECT_DEATH(scudo::reportInvalidAlignedAllocAlignment(123, 456),
+                     "Scudo ERROR.*123.*456");
 }
 
 TEST(ScudoReportDeathTest, HeaderCorruption) {
   UNUSED void *P = reinterpret_cast<void *>(0x42424242U);
   UNUSED scudo::Chunk::PackedHeader Header = {};
-  EXPECT_DEATH(scudo::reportHeaderCorruption(&Header, P),
-               "Scudo ERROR.*corrupted chunk header at address 0x.*42424242: "
-               "chunk header is zero and might indicate memory "
-               "corruption or a double free");
+  SCUDO_EXPECT_DEATH(
+      scudo::reportHeaderCorruption(&Header, P),
+      "Scudo ERROR.*corrupted chunk header at address 0x.*42424242: "
+      "chunk header is zero and might indicate memory "
+      "corruption or a double free");
   Header = 10U;
-  EXPECT_DEATH(scudo::reportHeaderCorruption(&Header, P),
-               "Scudo ERROR.*corrupted chunk header at address 0x.*42424242: "
-               "most likely due to memory corruption");
+  SCUDO_EXPECT_DEATH(
+      scudo::reportHeaderCorruption(&Header, P),
+      "Scudo ERROR.*corrupted chunk header at address 0x.*42424242: "
+      "most likely due to memory corruption");
 }
 
 #if SCUDO_LINUX || SCUDO_TRUSTY || SCUDO_ANDROID
@@ -99,22 +107,24 @@ TEST(ScudoReportDeathTest, HeaderCorruption) {
 
 TEST(ScudoReportDeathTest, Linux) {
   errno = ENOMEM;
-  EXPECT_DEATH(scudo::reportMapError(),
-               "Scudo ERROR:.*internal map failure \\(error desc=.*\\)");
+  SCUDO_EXPECT_DEATH(scudo::reportMapError(),
+                     "Scudo ERROR:.*internal map failure \\(error desc=.*\\)");
   errno = ENOMEM;
-  EXPECT_DEATH(scudo::reportMapError(1024U),
-               "Scudo ERROR:.*internal map failure \\(error desc=.*\\) "
-               "requesting 1KB");
-  EXPECT_DEATH(scudo::reportMapFixedError(0x1000U, 0x2000U),
-               "Scudo ERROR:.*internal map failure using fixed address "
-               "\\(expected: 0x1000 requested: 0x2000\\)");
+  SCUDO_EXPECT_DEATH(scudo::reportMapError(1024U),
+                     "Scudo ERROR:.*internal map failure \\(error desc=.*\\) "
+                     "requesting 1KB");
+  SCUDO_EXPECT_DEATH(scudo::reportMapFixedError(0x1000U, 0x2000U),
+                     "Scudo ERROR:.*internal map failure using fixed address "
+                     "\\(expected: 0x1000 requested: 0x2000\\)");
   errno = ENOMEM;
-  EXPECT_DEATH(scudo::reportUnmapError(0x1000U, 100U),
-               "Scudo ERROR:.*internal unmap failure \\(error desc=.*\\) Addr "
-               "0x1000 Size 100");
+  SCUDO_EXPECT_DEATH(
+      scudo::reportUnmapError(0x1000U, 100U),
+      "Scudo ERROR:.*internal unmap failure \\(error desc=.*\\) Addr "
+      "0x1000 Size 100");
   errno = ENOMEM;
-  EXPECT_DEATH(scudo::reportProtectError(0x1000U, 100U, PROT_READ),
-               "Scudo ERROR:.*internal protect failure \\(error desc=.*\\) "
-               "Addr 0x1000 Size 100 Prot 1");
+  SCUDO_EXPECT_DEATH(
+      scudo::reportProtectError(0x1000U, 100U, PROT_READ),
+      "Scudo ERROR:.*internal protect failure \\(error desc=.*\\) "
+      "Addr 0x1000 Size 100 Prot 1");
 }
 #endif

--- a/compiler-rt/lib/scudo/standalone/tests/scudo_unit_test.h
+++ b/compiler-rt/lib/scudo/standalone/tests/scudo_unit_test.h
@@ -58,4 +58,33 @@ using Test = ::testing::Test;
 #define SCUDO_NO_TEST_MAIN
 #endif
 
+#if SCUDO_ANDROID
+static void DisableDebuggerdMaybe() {
+  // Disable the debuggerd signal handler on Android, without this we can end
+  // up spending a significant amount of time creating tombstones.
+  signal(SIGSEGV, SIG_DFL);
+  signal(SIGABRT, SIG_DFL);
+}
+
+#define SCUDO_EXPECT_DEATH(X, Y)                                               \
+  EXPECT_DEATH(                                                                \
+      {                                                                        \
+        DisableDebuggerdMaybe();                                               \
+        X;                                                                     \
+      },                                                                       \
+      Y);
+#define SCUDO_ASSERT_DEATH(X, Y)                                               \
+  ASSERT_DEATH(                                                                \
+      {                                                                        \
+        DisableDebuggerdMaybe();                                               \
+        X;                                                                     \
+      },                                                                       \
+      Y);
+#else
+
+#define SCUDO_EXPECT_DEATH(X, Y) EXPECT_DEATH(X, Y);
+#define SCUDO_ASSERT_DEATH(X, Y) ASSERT_DEATH(X, Y);
+
+#endif
+
 extern bool UseQuarantine;

--- a/compiler-rt/lib/scudo/standalone/tests/secondary_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/secondary_test.cpp
@@ -145,7 +145,7 @@ template <typename Config> static void testBasic() {
 
   // If the Secondary can't cache that pointer, it will be unmapped.
   if (!Info.Allocator->canCache(Size)) {
-    EXPECT_DEATH(
+    SCUDO_EXPECT_DEATH(
         {
           // Repeat few time to avoid missing crash if it's mmaped by unrelated
           // code.

--- a/compiler-rt/lib/scudo/standalone/tests/wrappers_c_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/wrappers_c_test.cpp
@@ -188,7 +188,7 @@ TEST_F(ScudoWrappersCDeathTest, Malloc) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfree-nonheap-object"
 #endif
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       free(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(P) | 1U)), "");
 #if defined(__has_warning) && __has_warning("-Wfree-nonheap-object")
 #pragma GCC diagnostic pop
@@ -202,7 +202,7 @@ TEST_F(ScudoWrappersCDeathTest, Malloc) {
   // allocations before creating a new process. There is a possibility
   // that the previously freed P is reused, therefore, in the new
   // process doing free(P) is not a double free.
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       {
         // Note: volatile here prevents the calls from being optimized out.
         void *volatile Ptr = malloc(Size);
@@ -374,7 +374,7 @@ TEST_F(ScudoWrappersCDeathTest, Realloc) {
   verifyReallocHookPtrs(OldP, P, Size / 2U);
   free(P);
 
-  EXPECT_DEATH(P = realloc(P, Size), "");
+  SCUDO_EXPECT_DEATH(P = realloc(P, Size), "");
 
   errno = 0;
   EXPECT_EQ(realloc(nullptr, SIZE_MAX), nullptr);
@@ -425,8 +425,8 @@ TEST_F(ScudoWrappersCTest, MallocFreeSized) {
   verifyAllocHookSize(Size);
 
   if (VERIFY_FREE_SIZED_DEATH) {
-    EXPECT_DEATH(free_sized(P, Size - 1), "");
-    EXPECT_DEATH(free_sized(P, Size + 1), "");
+    SCUDO_EXPECT_DEATH(free_sized(P, Size - 1), "");
+    SCUDO_EXPECT_DEATH(free_sized(P, Size + 1), "");
 
     // An update to this warning in Clang now triggers in this line, but it's ok
     // because the check is expecting a bad pointer and should fail.
@@ -434,10 +434,10 @@ TEST_F(ScudoWrappersCTest, MallocFreeSized) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfree-nonheap-object"
 #endif
-    EXPECT_DEATH(free_sized(reinterpret_cast<void *>(
-                                reinterpret_cast<uintptr_t>(P) | 1U),
-                            Size),
-                 "");
+    SCUDO_EXPECT_DEATH(free_sized(reinterpret_cast<void *>(
+                                      reinterpret_cast<uintptr_t>(P) | 1U),
+                                  Size),
+                       "");
 #if defined(__has_warning) && __has_warning("-Wfree-nonheap-object")
 #pragma GCC diagnostic pop
 #endif
@@ -447,7 +447,7 @@ TEST_F(ScudoWrappersCTest, MallocFreeSized) {
   verifyDeallocHookPtr(P);
 
   if (VERIFY_FREE_SIZED_DEATH)
-    EXPECT_DEATH(free_sized(P, Size), "");
+    SCUDO_EXPECT_DEATH(free_sized(P, Size), "");
 }
 
 TEST_F(ScudoWrappersCTest, AlignedAllocFreeAlignedSized) {
@@ -461,9 +461,9 @@ TEST_F(ScudoWrappersCTest, AlignedAllocFreeAlignedSized) {
   verifyAllocHookSize(Size);
 
   if (VERIFY_FREE_ALIGNED_SIZED_DEATH) {
-    EXPECT_DEATH(free_aligned_sized(P, Alignment, Size - 1), "");
-    EXPECT_DEATH(free_aligned_sized(P, Alignment, Size + 1), "");
-    EXPECT_DEATH(
+    SCUDO_EXPECT_DEATH(free_aligned_sized(P, Alignment, Size - 1), "");
+    SCUDO_EXPECT_DEATH(free_aligned_sized(P, Alignment, Size + 1), "");
+    SCUDO_EXPECT_DEATH(
         free_aligned_sized(P, size_t{1} << (sizeof(size_t) * 8 - 1), Size), "");
 
     // An update to this warning in Clang now triggers in this line, but it's ok
@@ -472,10 +472,11 @@ TEST_F(ScudoWrappersCTest, AlignedAllocFreeAlignedSized) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfree-nonheap-object"
 #endif
-    EXPECT_DEATH(free_aligned_sized(reinterpret_cast<void *>(
-                                        reinterpret_cast<uintptr_t>(P) | 1U),
-                                    Alignment, Size),
-                 "");
+    SCUDO_EXPECT_DEATH(
+        free_aligned_sized(
+            reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(P) | 1U),
+            Alignment, Size),
+        "");
 #if defined(__has_warning) && __has_warning("-Wfree-nonheap-object")
 #pragma GCC diagnostic pop
 #endif
@@ -483,7 +484,7 @@ TEST_F(ScudoWrappersCTest, AlignedAllocFreeAlignedSized) {
 
   free_aligned_sized(P, Alignment, Size);
   verifyDeallocHookPtr(P);
-  EXPECT_DEATH(free_aligned_sized(P, Alignment, Size), "");
+  SCUDO_EXPECT_DEATH(free_aligned_sized(P, Alignment, Size), "");
 }
 
 TEST_F(ScudoWrappersCDeathTest, MallocFreeAlignedSized) {
@@ -495,8 +496,9 @@ TEST_F(ScudoWrappersCDeathTest, MallocFreeAlignedSized) {
   verifyAllocHookSize(Size);
 
   if (VERIFY_FREE_ALIGNED_SIZED_DEATH) {
-    EXPECT_DEATH(free_aligned_sized(P, 8, Size), "");
-    EXPECT_DEATH(free_aligned_sized(P, alignof(std::max_align_t), Size), "");
+    SCUDO_EXPECT_DEATH(free_aligned_sized(P, 8, Size), "");
+    SCUDO_EXPECT_DEATH(free_aligned_sized(P, alignof(std::max_align_t), Size),
+                       "");
   }
 
   free_sized(P, Size);
@@ -514,7 +516,7 @@ TEST_F(ScudoWrappersCDeathTest, AlignedAllocFreeSized) {
   verifyAllocHookSize(Size);
 
   if (VERIFY_FREE_SIZED_DEATH)
-    EXPECT_DEATH(free_sized(P, Size), "");
+    SCUDO_EXPECT_DEATH(free_sized(P, Size), "");
 
   free_aligned_sized(P, Alignment, Size);
   verifyDeallocHookPtr(P);
@@ -532,7 +534,7 @@ TEST_F(ScudoWrappersCDeathTest, PosixMemalignFreeSized) {
   verifyAllocHookSize(Size);
 
   if (VERIFY_FREE_SIZED_DEATH)
-    EXPECT_DEATH(free_sized(P, Size), "");
+    SCUDO_EXPECT_DEATH(free_sized(P, Size), "");
 
   free(P);
   verifyDeallocHookPtr(P);
@@ -549,7 +551,7 @@ TEST_F(ScudoWrappersCDeathTest, MemalignFreeSized) {
   verifyAllocHookSize(Size);
 
   if (VERIFY_FREE_SIZED_DEATH)
-    EXPECT_DEATH(free_sized(P, Size), "");
+    SCUDO_EXPECT_DEATH(free_sized(P, Size), "");
 
   free(P);
   verifyDeallocHookPtr(P);
@@ -565,7 +567,7 @@ TEST_F(ScudoWrappersCDeathTest, PvallocFreeSized) {
   verifyAllocHookSize(Size);
 
   if (VERIFY_FREE_SIZED_DEATH)
-    EXPECT_DEATH(free_sized(P, Size), "");
+    SCUDO_EXPECT_DEATH(free_sized(P, Size), "");
 
   free(P);
   verifyDeallocHookPtr(P);
@@ -582,7 +584,7 @@ TEST_F(ScudoWrappersCDeathTest, VallocFreeSized) {
   verifyAllocHookSize(Size);
 
   if (VERIFY_FREE_SIZED_DEATH)
-    EXPECT_DEATH(free_sized(P, Size), "");
+    SCUDO_EXPECT_DEATH(free_sized(P, Size), "");
 
   free(P);
   verifyDeallocHookPtr(P);
@@ -756,7 +758,7 @@ TEST_F(ScudoWrappersCTest, MallocIterateBoundary) {
 #if !SCUDO_FUCHSIA
 TEST_F(ScudoWrappersCDeathTest, MallocDisableDeadlock) {
   // We expect heap operations within a disable/enable scope to deadlock.
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       {
         void *P = malloc(Size);
         EXPECT_NE(P, nullptr);
@@ -812,7 +814,7 @@ TEST_F(ScudoWrappersCDeathTest, Fork) {
   free(P);
 
   // fork should stall if the allocator has been disabled.
-  EXPECT_DEATH(
+  SCUDO_EXPECT_DEATH(
       {
         malloc_disable();
         alarm(1);

--- a/compiler-rt/lib/scudo/standalone/tests/wrappers_cpp_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/wrappers_cpp_test.cpp
@@ -84,10 +84,10 @@ protected:
     verifyAllocHookPtr(P);
     verifyAllocHookSize(sizeof(T));
     memset(P, 0x42, sizeof(T));
-    EXPECT_DEATH(delete[] P, "");
+    SCUDO_EXPECT_DEATH(delete[] P, "");
     delete P;
     verifyDeallocHookPtr(P);
-    EXPECT_DEATH(delete P, "");
+    SCUDO_EXPECT_DEATH(delete P, "");
 
     P = new T;
     EXPECT_NE(P, nullptr);
@@ -109,10 +109,10 @@ protected:
     verifyAllocHookPtr(A);
     verifyAllocHookSize(sizeof(T) * N);
     memset(A, 0x42, sizeof(T) * N);
-    EXPECT_DEATH(delete A, "");
+    SCUDO_EXPECT_DEATH(delete A, "");
     delete[] A;
     verifyDeallocHookPtr(A);
-    EXPECT_DEATH(delete[] A, "");
+    SCUDO_EXPECT_DEATH(delete[] A, "");
 
     A = new T[N];
     EXPECT_NE(A, nullptr);


### PR DESCRIPTION
On Android, we want to disable the tombstone generation on expected crashes to speed up running the tests. Also, this means that any tombstone files will be real crashes and it's not necessary to search for the right tombstone if one of the tests crashes unexpectedly.

In order to do the above, add SCUDO_EXPECT_DEATH_TEST and SCUDO_ASSERT_DEATH_TEST that will disable tombstoned on Android but do nothing on all other platforms.