### PR TITLE
[mlir][memref] Add invariant attribute to memref.load

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -1292,6 +1292,12 @@ def LoadOp : MemRef_Op<"load",
     be reused in the cache. For details, refer to the
     [LLVM load instruction](https://llvm.org/docs/LangRef.html#load-instruction).
 
+    A set `invariant` attribute indicates that the referenced memory location
+    contains the same value at all points in the program where it is
+    dereferenceable, so the load may be treated as invariant. For details, refer
+    to the
+    [LLVM load instruction](https://llvm.org/docs/LangRef.html#load-instruction).
+
     An optional `alignment` attribute allows to specify the byte alignment of the
     load operation. It must be a positive power of 2. The operation must access
     memory at an address aligned to this boundary. Violations may lead to
@@ -1308,7 +1314,8 @@ def LoadOp : MemRef_Op<"load",
                            [MemRead]>:$memref,
                        Variadic<Index>:$indices,
                        DefaultValuedOptionalAttr<BoolAttr, "false">:$nontemporal,
-                       OptionalAttr<IntValidAlignment<I64Attr>>:$alignment);
+                       OptionalAttr<IntValidAlignment<I64Attr>>:$alignment,
+                       DefaultValuedOptionalAttr<BoolAttr, "false">:$invariant);
 
   let builders = [
     OpBuilder<(ins "Value":$memref,

--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -981,7 +981,8 @@ struct LoadOpLowering : public LoadStoreOpLowering<memref::LoadOp> {
         adaptor.getIndices(), getLoadStoreNoWrapFlags(type));
     rewriter.replaceOpWithNewOp<LLVM::LoadOp>(
         loadOp, typeConverter->convertType(type.getElementType()), dataPtr,
-        loadOp.getAlignment().value_or(0), false, loadOp.getNontemporal());
+        loadOp.getAlignment().value_or(0), false, loadOp.getNontemporal(),
+        /*isInvariant=*/loadOp.getInvariant());
     return success();
   }
 };

--- a/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
@@ -816,6 +816,18 @@ func.func @load_non_temporal(%arg0 : memref<32xf32, affine_map<(d0) -> (d0)>>) {
 
 // -----
 
+// CHECK-LABEL: func @load_invariant(
+// CHECK-INTERFACE-LABEL: func @load_invariant(
+func.func @load_invariant(%arg0 : memref<32xf32, affine_map<(d0) -> (d0)>>) {
+  %1 = arith.constant 7 : index
+  // CHECK: llvm.load %{{.*}} invariant : !llvm.ptr -> f32
+  // CHECK-INTERFACE: llvm.load
+  %2 = memref.load %arg0[%1] {invariant = true} : memref<32xf32, affine_map<(d0) -> (d0)>>
+  func.return
+}
+
+// -----
+
 // CHECK-LABEL: func @load_with_alignment(
 // CHECK-INTERFACE-LABEL: func @load_with_alignment(
 func.func @load_with_alignment(%arg0 : memref<32xf32>, %arg1 : index) {

--- a/mlir/test/Dialect/MemRef/ops.mlir
+++ b/mlir/test/Dialect/MemRef/ops.mlir
@@ -285,6 +285,14 @@ func.func @load_store_alignment(%memref: memref<4xi32>) {
   return
 }
 
+// CHECK-LABEL: func @load_invariant
+func.func @load_invariant(%memref: memref<4xi32>) {
+  %c0 = arith.constant 0 : index
+  // CHECK: memref.load {{.*}} {invariant = true}
+  %val = memref.load %memref[%c0] { invariant = true } : memref<4xi32>
+  return
+}
+
 // CHECK-LABEL: func @memref_view(%arg0
 func.func @memref_view(%arg0 : index, %arg1 : index, %arg2 : index) {
   %0 = memref.alloc() : memref<2048xi8>


### PR DESCRIPTION
Add an optional `invariant` attribute to `memref.load`, modeled on the
existing `nontemporal` attribute. When set, it indicates the referenced
memory location holds the same value at all points in the program where it
is dereferenceable, so the load may be treated as invariant.

The MemRefToLLVM LoadOpLowering forwards the attribute to the invariant
flag of `llvm.load` (which lowers to `!invariant.load`).
