### PR TITLE
[flang][fir] Add invariant attribute to fir.load

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -310,10 +310,15 @@ def fir_LoadOp : fir_OneResultOp<"load", [
 
     The ssa-value has an undefined value if the memory reference is undefined
     or null.
+
+    A set `invariant` attribute indicates that the referenced memory location
+    contains the same value at all points in the program where it is
+    dereferenceable, so the load may be treated as invariant.
   }];
 
   let arguments = (ins AnyReferenceLike:$memref,
       OptionalAttr<LLVM_TBAATagArrayAttr>:$tbaa, UnitAttr:$nontemporal,
+      UnitAttr:$invariant,
       OptionalAttr<LLVM_AccessGroupArrayAttr>:$accessGroups);
 
   let builders = [OpBuilder<(ins "mlir::Value":$refVal)>,

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -3713,6 +3713,8 @@ struct LoadOpConversion : public fir::FIROpConversion<fir::LoadOp> {
         loadOp.setTBAATags(*optionalTag);
       else
         attachTBAATag(loadOp, load.getType(), load.getType(), nullptr);
+      if (load.getInvariant())
+        loadOp.setInvariant(true);
       if (std::optional<mlir::ArrayAttr> optionalAccessGroups =
               load.getAccessGroups())
         loadOp.setAccessGroups(*optionalAccessGroups);

--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -963,6 +963,23 @@ func.func @test_load_index(%addr : !fir.ref<index>) {
 // CHECK-NEXT:    llvm.return
 // CHECK-NEXT:  }
 
+// -----
+
+// Test `fir.load` with the `invariant` attribute forwards to `llvm.load invariant`
+
+func.func @test_load_invariant(%addr : !fir.ref<i32>) {
+  %0 = fir.load %addr {invariant} : !fir.ref<i32>
+  return
+}
+
+// CHECK-LABEL: llvm.func @test_load_invariant(
+// CHECK-SAME:  %[[arg1:.*]]: !llvm.ptr) {
+// CHECK-NEXT:    %0 = llvm.load %[[arg1]] invariant : !llvm.ptr -> i32
+// CHECK-NEXT:    llvm.return
+// CHECK-NEXT:  }
+
+// -----
+
 func.func private @takes_box(!fir.box<!fir.array<10xf32>>) -> ()
 
 func.func @test_load_box(%addr : !fir.ref<!fir.box<!fir.array<10xf32>>>) {

--- a/flang/test/Fir/fir-ops.fir
+++ b/flang/test/Fir/fir-ops.fir
@@ -805,6 +805,14 @@ func.func @llvm_ptr_load_store_coordinate(%arg0: !fir.ref<tuple<!fir.ref<!fir.bo
   return %1 : !fir.ref<!fir.box<!fir.ptr<f32>>>
 }
 
+// CHECK-LABEL: func @load_invariant(
+// CHECK-SAME:  %[[ARG0:.*]]: !fir.ref<i32>)
+func.func @load_invariant(%arg0: !fir.ref<i32>) -> i32 {
+  // CHECK-NEXT: %[[VAL:.*]] = fir.load %[[ARG0]] {invariant} : !fir.ref<i32>
+  %0 = fir.load %arg0 {invariant} : !fir.ref<i32>
+  return %0 : i32
+}
+
 func.func @array_access_ops(%a : !fir.ref<!fir.array<?x?xf32>>) {
   %c1 = arith.constant 1 : index
   %n = arith.constant 0 : index


### PR DESCRIPTION
Add an optional `invariant` unit attribute to `fir.load`, modeled on the
existing `nontemporal` attribute. When set, it indicates the referenced
memory location holds the same value at all points in the program where it
is dereferenceable, so the load may be treated as invariant.

The FIR-to-LLVM LoadOpConversion forwards the attribute to the invariant
flag of `llvm.load` (which lowers to `!invariant.load`).

`!invariant.load` metadata might be useful for OpenACC/OpenMP offload,
e.g. by using MLIR AA we can mark `fir.load`s inside the GPU kernels
letting the target codegen to generate read-only data cache load
instructions.
