### PR TITLE
Fixing the testcase failure in arm64 darwin systems

### DIFF
--- a/flang/test/Integration/split-lto-unit-2.f90
+++ b/flang/test/Integration/split-lto-unit-2.f90
@@ -1,4 +1,7 @@
 ! Check that -flto=thin without -fsplit-lto-unit has EnableSplitLTOUnit = 0
+
+! UNSUPPORTED: system-darwin
+
 ! RUN: %flang -flto=thin  -S -o - %s |  FileCheck %s --check-prefix=SPLIT0
 ! RUN: %if x86-registered-target %{ %flang -flto=thin --target=x86_64-linux-gnu -S -o - %s |  FileCheck %s --check-prefix=SPLIT0 %}
 ! RUN: %if x86-registered-target %{ %flang -flto=thin --target=x86_64-apple-macosx -S -o - %s | FileCheck %s --check-prefix=SPLIT0 %}


### PR DESCRIPTION
For apple targets, the string EnableSplitLTOUnit is not emitted in fulllto. Marking the test unsupported for this targets.