### PR TITLE
[libc++] Remove ClangTidyModuleRegistry.h from the clang-tidy checks

### DIFF
--- a/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "abi_tag_on_virtual.hpp"
 

--- a/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "llvm/ADT/ArrayRef.h"
 

--- a/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "hide_from_abi.hpp"
 

--- a/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyModule.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "abi_tag_on_virtual.hpp"
 #include "header_exportable_declarations.hpp"

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "robust_against_adl.hpp"
 

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Tooling/FixIt.h"
 

--- a/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "uglify_attributes.hpp"
 #include "utilities.hpp"


### PR DESCRIPTION
The header has been deprecated in favour of `ClangTidyModule.h`.
