### PR TITLE
[InlineAsm] Diagnose pointer input tied to larger aggregate output

### DIFF
--- a/clang/lib/Sema/SemaStmtAsm.cpp
+++ b/clang/lib/Sema/SemaStmtAsm.cpp
@@ -743,6 +743,18 @@ StmtResult Sema::ActOnGCCAsmStmt(SourceLocation AsmLoc, bool IsSimple,
         return NS;
       }
 
+      // FIXME: GCC supports this, but codegen currently crashes when lowering
+      // a pointer input tied to a larger aggregate register output.
+      if (OutputDomain == AD_Other && InTy->isPointerType() &&
+          OutSize > InSize &&
+          !Context.getIntTypeForBitwidth(OutSize, /*Signed*/ false).isNull()) {
+        targetDiag(InputExpr->getBeginLoc(),
+                   diag::err_asm_tying_incompatible_types)
+            << InTy << OutTy << OutputExpr->getSourceRange()
+            << InputExpr->getSourceRange();
+        return NS;
+      }
+
       continue;
     }
 

--- a/clang/test/Sema/asm.c
+++ b/clang/test/Sema/asm.c
@@ -352,6 +352,7 @@ void test19(long long x)
   st_size16 c;
   st_size32 d;
   st_size128 e;
+  char f[16];
   asm ("" : "=rm" (a): "0" (1)); // no-error
   asm ("" : "=rm" (d): "0" (1)); // no-error
   asm ("" : "=rm" (c): "0" (x)); // no-error
@@ -364,6 +365,8 @@ void test19(long long x)
   asm ("" : "=rm" (e): "0" (1)); // no-error
   // FIXME: This case should be supported by codegen, but it fails now.
   asm ("" : "=rm" (x): "0" (e)); // expected-error {{unsupported inline asm: input with type 'st_size128' (aka 'struct _st_size128') matching output with type 'long long'}}
+  // FIXME: This case should be supported by codegen, but it fails now.
+  asm ("" : "=r" (f): "0" (f)); // expected-error {{unsupported inline asm: input with type 'char *' matching output with type 'char[16]'}}
 }
 
 typedef int int2 __attribute__((ext_vector_type(2)));


### PR DESCRIPTION
GCC supports tying an aggregate register output to a pointer input in cases such as an array operand after array-to-pointer decay. Clang currently accepts this, but codegen crashes when lowering the mismatched tied operands.

Add a Sema check for pointer inputs tied to larger aggregate register outputs when the aggregate can be scalarized to an integer register value. This turns the crash into an unsupported inline asm diagnostic.

Fixes #204775