### PR TITLE
[WebAssembly][NFC] Remove direct access to FeatureKV

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyAsmPrinter.cpp
@@ -532,7 +532,13 @@ void WebAssemblyAsmPrinter::EmitTargetFeatures(Module &M) {
     EmittedFeatures.push_back(Entry);
   };
 
-  for (const SubtargetFeatureKV &KV : WebAssemblyFeatureKV) {
+  // If we never compiled a single function, Subtarget is null.
+  if (!Subtarget) {
+    Subtarget = static_cast<WebAssemblyTargetMachine &>(TM).getSubtargetImpl(
+        std::string(TM.getTargetCPU()),
+        std::string(TM.getTargetFeatureString()));
+  }
+  for (const SubtargetFeatureKV &KV : Subtarget->getAllProcessorFeatures()) {
     EmitFeature(KV.key());
   }
   // This pseudo-feature tells the linker whether shared memory would be safe
@@ -540,8 +546,7 @@ void WebAssemblyAsmPrinter::EmitTargetFeatures(Module &M) {
 
   // This is an "architecture", not a "feature", but we emit it as such for
   // the benefit of tools like Binaryen and consistency with other producers.
-  // FIXME: Subtarget is null here, so can't Subtarget->hasAddr64() ?
-  if (M.getDataLayout().getPointerSize() == 8) {
+  if (Subtarget->hasAddr64()) {
     // Can't use EmitFeature since "wasm-feature-memory64" is not a module
     // flag.
     EmittedFeatures.push_back({wasm::WASM_FEATURE_PREFIX_USED, "memory64"});

--- a/llvm/lib/Target/WebAssembly/WebAssemblySubtarget.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblySubtarget.h
@@ -32,10 +32,6 @@
 
 namespace llvm {
 
-// Defined in WebAssemblyGenSubtargetInfo.inc.
-extern const SubtargetFeatureKV
-    WebAssemblyFeatureKV[WebAssembly::NumSubtargetFeatures];
-
 class WebAssemblySubtarget final : public WebAssemblyGenSubtargetInfo {
   enum SIMDEnum {
     NoSIMD,

--- a/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyTargetMachine.cpp
@@ -267,9 +267,8 @@ public:
       : ModulePass(ID), WasmTM(WasmTM) {}
 
   bool runOnModule(Module &M) override {
-    FeatureBitset Features = coalesceFeatures(M);
+    auto [Features, FeatureStr] = coalesceFeatures(M);
 
-    std::string FeatureStr = getFeatureString(Features);
     WasmTM->setTargetFeatureString(FeatureStr);
     for (auto &F : M)
       replaceFeatures(F, FeatureStr);
@@ -279,8 +278,8 @@ public:
 
     // In cooperative threading mode, thread locals are meaningful even without
     // atomics.
-    bool CooperativeThreading =
-        WasmTM->getSubtargetImpl()->hasCooperativeMultithreading();
+    const WebAssemblySubtarget *ST = WasmTM->getSubtargetImpl();
+    bool CooperativeThreading = ST->hasCooperativeMultithreading();
 
     if (!Features[WebAssembly::FeatureAtomics]) {
       StrippedAtomics = stripAtomics(M);
@@ -296,44 +295,45 @@ public:
     else if (StrippedTLS && !StrippedAtomics)
       stripAtomics(M);
 
-    recordFeatures(M, Features, StrippedAtomics || StrippedTLS);
+    recordFeatures(M, ST, Features, StrippedAtomics || StrippedTLS);
 
     // Conservatively assume we have made some change
     return true;
   }
 
 private:
-  FeatureBitset coalesceFeatures(const Module &M) {
+  std::pair<FeatureBitset, std::string> coalesceFeatures(const Module &M) {
     // Union the features of all defined functions. Start with an empty set, so
     // that if a feature is disabled in every function, we'll compute it as
     // disabled. If any function lacks a target-features attribute, it'll
     // default to the target CPU from the `TargetMachine`.
     FeatureBitset Features;
-    bool AnyDefinedFuncs = false;
+    // We need any MCSubtargetInfo to access WebAssemblyFeatureKV.
+    const WebAssemblySubtarget *AnyST = nullptr;
     for (auto &F : M) {
       if (F.isDeclaration())
         continue;
 
-      Features |= WasmTM->getSubtargetImpl(F)->getFeatureBits();
-      AnyDefinedFuncs = true;
+      AnyST = WasmTM->getSubtargetImpl(F);
+      Features |= AnyST->getFeatureBits();
     }
 
     // If we have no defined functions, use the target CPU from the
     // `TargetMachine`.
-    if (!AnyDefinedFuncs) {
-      Features =
-          WasmTM
-              ->getSubtargetImpl(std::string(WasmTM->getTargetCPU()),
-                                 std::string(WasmTM->getTargetFeatureString()))
-              ->getFeatureBits();
+    if (!AnyST) {
+      AnyST = WasmTM->getSubtargetImpl(
+          std::string(WasmTM->getTargetCPU()),
+          std::string(WasmTM->getTargetFeatureString()));
+      Features = AnyST->getFeatureBits();
     }
 
-    return Features;
+    return {Features, getFeatureString(AnyST, Features)};
   }
 
-  static std::string getFeatureString(const FeatureBitset &Features) {
+  static std::string getFeatureString(const WebAssemblySubtarget *ST,
+                                      const FeatureBitset &Features) {
     std::string Ret;
-    for (const SubtargetFeatureKV &KV : WebAssemblyFeatureKV) {
+    for (const SubtargetFeatureKV &KV : ST->getAllProcessorFeatures()) {
       if (Features[KV.Value])
         Ret += (StringRef("+") + KV.key() + ",").str();
       else
@@ -399,8 +399,9 @@ private:
     return Stripped;
   }
 
-  void recordFeatures(Module &M, const FeatureBitset &Features, bool Stripped) {
-    for (const SubtargetFeatureKV &KV : WebAssemblyFeatureKV) {
+  void recordFeatures(Module &M, const WebAssemblySubtarget *ST,
+                      const FeatureBitset &Features, bool Stripped) {
+    for (const SubtargetFeatureKV &KV : ST->getAllProcessorFeatures()) {
       if (Features[KV.Value]) {
         // Mark features as used
         std::string MDKey = (StringRef("wasm-feature-") + KV.key()).str();


### PR DESCRIPTION
This is preparatory work for changing the representation of
FeatureKV/SubTypeKV, in which they will no longer be that easily
accessible as global variables. Therefore, get them from the subtarget
instead.
