### PR TITLE
[RISCV][NFC] Remove direct access to FeatureKV

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -54,10 +54,6 @@ STATISTIC(RISCVNumInstrsCompressed,
 static cl::opt<bool> AddBuildAttributes("riscv-add-build-attributes",
                                         cl::init(false));
 
-namespace llvm {
-extern const SubtargetFeatureKV RISCVFeatureKV[RISCV::NumSubtargetFeatures];
-} // namespace llvm
-
 namespace {
 struct RISCVOperand;
 
@@ -333,8 +329,7 @@ public:
 
     // Use computeTargetABI to check if ABIName is valid. If invalid, output
     // error message.
-    RISCVABI::computeTargetABI(STI.getTargetTriple(), STI.getFeatureBits(),
-                               ABIName);
+    RISCVABI::computeTargetABI(STI, ABIName);
 
     const MCObjectFileInfo *MOFI = Parser.getContext().getObjectFileInfo();
     ParserOptions.IsPicEnabled = MOFI->isPositionIndependent();
@@ -2083,18 +2078,19 @@ ParseStatus RISCVAsmParser::parseCSRSystemRegister(OperandVector &Operands) {
 
       // Accept a named Sys Reg if the required features are present.
       const auto &FeatureBits = getSTI().getFeatureBits();
+      const auto &AllFeatures = getSTI().getAllProcessorFeatures();
       if (!SysReg->haveRequiredFeatures(FeatureBits)) {
         const auto *Feature =
-            llvm::find_if(RISCVFeatureKV, [&](const auto &Feature) {
+            llvm::find_if(AllFeatures, [&](const auto &Feature) {
               return SysReg->FeaturesRequired[Feature.Value];
             });
         auto ErrorMsg = std::string("system register '") + SysReg->Name + "' ";
         if (SysReg->IsRV32Only && FeatureBits[RISCV::Feature64Bit]) {
           ErrorMsg += "is RV32 only";
-          if (Feature != std::end(RISCVFeatureKV))
+          if (Feature != std::end(AllFeatures))
             ErrorMsg += " and ";
         }
-        if (Feature != std::end(RISCVFeatureKV)) {
+        if (Feature != std::end(AllFeatures)) {
           ErrorMsg +=
               "requires '" + std::string(Feature->key()) + "' to be enabled";
         }
@@ -3131,7 +3127,8 @@ ParseStatus RISCVAsmParser::parseDirective(AsmToken DirectiveID) {
 
 bool RISCVAsmParser::resetToArch(StringRef Arch, SMLoc Loc, std::string &Result,
                                  bool FromOptionDirective) {
-  for (auto &Feature : RISCVFeatureKV)
+  const auto &AllFeatures = getSTI().getAllProcessorFeatures();
+  for (auto &Feature : AllFeatures)
     if (llvm::RISCVISAInfo::isSupportedExtensionFeature(Feature.key()))
       clearFeatureBits(Feature.Value, Feature.key());
 
@@ -3150,7 +3147,7 @@ bool RISCVAsmParser::resetToArch(StringRef Arch, SMLoc Loc, std::string &Result,
   }
   auto &ISAInfo = *ParseResult;
 
-  for (auto &Feature : RISCVFeatureKV)
+  for (auto &Feature : AllFeatures)
     if (ISAInfo->hasExtension(Feature.key()))
       setFeatureBits(Feature.Value, Feature.key());
 
@@ -3246,8 +3243,9 @@ bool RISCVAsmParser::parseDirectiveOption() {
       if (!enableExperimentalExtension() &&
           StringRef(Feature).starts_with("experimental-"))
         return Error(Loc, "unexpected experimental extensions");
-      auto Ext = llvm::lower_bound(RISCVFeatureKV, Feature);
-      if (Ext == std::end(RISCVFeatureKV) || StringRef(Ext->key()) != Feature)
+      const auto &AllFeatures = getSTI().getAllProcessorFeatures();
+      auto Ext = llvm::lower_bound(AllFeatures, Feature);
+      if (Ext == std::end(AllFeatures) || StringRef(Ext->key()) != Feature)
         return Error(Loc, "unknown extension feature");
 
       Args.emplace_back(Type, Arch.str());
@@ -3256,7 +3254,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
         FeatureBitset OldFeatureBits = STI->getFeatureBits();
 
         setFeatureBits(Ext->Value, Ext->key());
-        auto ParseResult = RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits());
+        auto ParseResult = RISCVFeatures::parseFeatureBits(*STI);
         if (!ParseResult) {
           copySTI().setFeatureBits(OldFeatureBits);
           setAvailableFeatures(ComputeAvailableFeatures(OldFeatureBits));
@@ -3274,7 +3272,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
         // It is invalid to disable an extension that there are other enabled
         // extensions depend on it.
         // TODO: Make use of RISCVISAInfo to handle this
-        for (auto &Feature : RISCVFeatureKV) {
+        for (auto &Feature : AllFeatures) {
           if (getSTI().hasFeature(Feature.Value) &&
               Feature.Implies.test(Ext->Value))
             return Error(Loc, Twine("can't disable ") + Ext->key() +
@@ -3292,8 +3290,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
 
     getTargetStreamer().emitDirectiveOptionArch(Args);
 
-    if (auto ParseResult =
-            RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
+    if (auto ParseResult = RISCVFeatures::parseFeatureBits(*STI))
       getTargetStreamer().setArchString((*ParseResult)->toString());
     return false;
   }
@@ -3324,8 +3321,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
 
     getTargetStreamer().emitDirectiveOptionRVC();
     setFeatureBits(RISCV::FeatureStdExtC, "c");
-    if (auto ParseResult =
-            RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
+    if (auto ParseResult = RISCVFeatures::parseFeatureBits(*STI))
       getTargetStreamer().setArchString((*ParseResult)->toString());
     return false;
   }
@@ -3337,8 +3333,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
     getTargetStreamer().emitDirectiveOptionNoRVC();
     clearFeatureBits(RISCV::FeatureStdExtC, "c");
     clearFeatureBits(RISCV::FeatureStdExtZca, "zca");
-    if (auto ParseResult =
-            RISCVFeatures::parseFeatureBits(isRV64(), STI->getFeatureBits()))
+    if (auto ParseResult = RISCVFeatures::parseFeatureBits(*STI))
       getTargetStreamer().setArchString((*ParseResult)->toString());
     return false;
   }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
@@ -23,8 +23,6 @@
 
 namespace llvm {
 
-extern const SubtargetFeatureKV RISCVFeatureKV[RISCV::NumSubtargetFeatures];
-
 namespace RISCVSysReg {
 #define GET_SysRegsList_IMPL
 #include "RISCVGenSearchableTables.inc"
@@ -55,8 +53,9 @@ namespace RISCV {
 } // namespace RISCV
 
 namespace RISCVABI {
-ABI computeTargetABI(const Triple &TT, const FeatureBitset &FeatureBits,
-                     StringRef ABIName) {
+ABI computeTargetABI(const MCSubtargetInfo &STI, StringRef ABIName) {
+  const Triple &TT = STI.getTargetTriple();
+  const FeatureBitset &FeatureBits = STI.getFeatureBits();
   auto TargetABI = getTargetABI(ABIName);
   bool IsRV64 = TT.isArch64Bit();
   bool IsRVE = FeatureBits[RISCV::FeatureStdExtE];
@@ -102,7 +101,7 @@ ABI computeTargetABI(const Triple &TT, const FeatureBitset &FeatureBits,
     return TargetABI;
 
   // If no explicit ABI is given, try to compute the default ABI.
-  auto ISAInfo = RISCVFeatures::parseFeatureBits(IsRV64, FeatureBits);
+  auto ISAInfo = RISCVFeatures::parseFeatureBits(STI);
   if (!ISAInfo)
     reportFatalUsageError(ISAInfo.takeError());
   return getTargetABI((*ISAInfo)->computeDefaultABI());
@@ -153,11 +152,12 @@ void validate(const Triple &TT, const FeatureBitset &FeatureBits) {
 }
 
 llvm::Expected<std::unique_ptr<RISCVISAInfo>>
-parseFeatureBits(bool IsRV64, const FeatureBitset &FeatureBits) {
-  unsigned XLen = IsRV64 ? 64 : 32;
+parseFeatureBits(const MCSubtargetInfo &STI) {
+  const FeatureBitset &FeatureBits = STI.getFeatureBits();
+  unsigned XLen = FeatureBits[RISCV::Feature64Bit] ? 64 : 32;
   std::vector<std::string> FeatureVector;
   // Convert FeatureBitset to FeatureVector.
-  for (const auto &Feature : RISCVFeatureKV) {
+  for (const auto &Feature : STI.getAllProcessorFeatures()) {
     if (FeatureBits[Feature.Value] &&
         llvm::RISCVISAInfo::isSupportedExtensionFeature(Feature.key()))
       FeatureVector.push_back(std::string("+") + Feature.key());

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -25,6 +25,8 @@
 
 namespace llvm {
 
+class MCSubtargetInfo;
+
 namespace RISCVOp {
 enum OperandType : unsigned {
   OPERAND_FIRST_RISCV_IMM = MCOI::OPERAND_FIRST_TARGET,
@@ -687,9 +689,8 @@ enum ABI {
 };
 
 // Returns the target ABI, or else a StringError if the requested ABIName is
-// not supported for the given TT and FeatureBits combination.
-ABI computeTargetABI(const Triple &TT, const FeatureBitset &FeatureBits,
-                     StringRef ABIName);
+// not supported for the subtargets triple and FeatureBits combination.
+ABI computeTargetABI(const MCSubtargetInfo &STI, StringRef ABIName);
 
 ABI getTargetABI(StringRef ABIName);
 
@@ -708,7 +709,7 @@ namespace RISCVFeatures {
 void validate(const Triple &TT, const FeatureBitset &FeatureBits);
 
 llvm::Expected<std::unique_ptr<RISCVISAInfo>>
-parseFeatureBits(bool IsRV64, const FeatureBitset &FeatureBits);
+parseFeatureBits(const MCSubtargetInfo &STI);
 
 } // namespace RISCVFeatures
 

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.cpp
@@ -29,10 +29,9 @@ RISCVTargetELFStreamer::RISCVTargetELFStreamer(MCStreamer &S,
                                                const MCSubtargetInfo &STI)
     : RISCVTargetStreamer(S), CurrentVendor("riscv") {
   MCAssembler &MCA = getStreamer().getAssembler();
-  const FeatureBitset &Features = STI.getFeatureBits();
   auto &MAB = static_cast<RISCVAsmBackend &>(MCA.getBackend());
-  setTargetABI(RISCVABI::computeTargetABI(STI.getTargetTriple(), Features,
-                                          MAB.getTargetOptions().getABIName()));
+  setTargetABI(
+      RISCVABI::computeTargetABI(STI, MAB.getTargetOptions().getABIName()));
   setFlagsFromFeatures(STI);
 
   // Compute the initial ISA string.  This serves two purposes:
@@ -41,8 +40,7 @@ RISCVTargetELFStreamer::RISCVTargetELFStreamer(MCStreamer &S,
   //   2. Initial symbol: seed the streamer's active ISA so a "$x<ArchString>"
   //      mapping symbol is emitted before the first instruction, recording
   //      the full ISA in the object even when no .option directive is present.
-  if (auto ParseResult = RISCVFeatures::parseFeatureBits(
-          STI.hasFeature(RISCV::Feature64Bit), Features)) {
+  if (auto ParseResult = RISCVFeatures::parseFeatureBits(STI)) {
     InitialArchString = (*ParseResult)->toString();
     ArchString = InitialArchString;
     getStreamer().setMappingSymbolArch(ArchString);

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
@@ -84,8 +84,7 @@ void RISCVTargetStreamer::emitTargetAttributes(const MCSubtargetInfo &STI,
     emitAttribute(RISCVAttrs::STACK_ALIGN, StackAlign);
   }
 
-  auto ParseResult = RISCVFeatures::parseFeatureBits(
-      STI.hasFeature(RISCV::Feature64Bit), STI.getFeatureBits());
+  auto ParseResult = RISCVFeatures::parseFeatureBits(STI);
   if (!ParseResult) {
     report_fatal_error(ParseResult.takeError());
   } else {

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -51,10 +51,6 @@ using namespace llvm;
 STATISTIC(RISCVNumInstrsCompressed,
           "Number of RISC-V Compressed instructions emitted");
 
-namespace llvm {
-extern const SubtargetFeatureKV RISCVFeatureKV[RISCV::NumSubtargetFeatures];
-} // namespace llvm
-
 namespace {
 class RISCVAsmPrinter : public AsmPrinter {
 public:
@@ -531,7 +527,7 @@ bool RISCVAsmPrinter::emitDirectiveOptionArch() {
   RISCVTargetStreamer &RTS = getTargetStreamer();
   SmallVector<RISCVOptionArchArg> NeedEmitStdOptionArgs;
   const MCSubtargetInfo &MCSTI = TM.getMCSubtargetInfo();
-  for (const auto &Feature : RISCVFeatureKV) {
+  for (const auto &Feature : MCSTI.getAllProcessorFeatures()) {
     if (STI->hasFeature(Feature.Value) == MCSTI.hasFeature(Feature.Value))
       continue;
 
@@ -642,7 +638,7 @@ void RISCVAsmPrinter::emitStartOfAsmFile(Module &M) {
             /*ExperimentalExtensionVersionCheck=*/true);
         if (!errorToBool(ParseResult.takeError())) {
           auto &ISAInfo = *ParseResult;
-          for (const auto &Feature : RISCVFeatureKV) {
+          for (const auto &Feature : SubtargetInfo.getAllProcessorFeatures()) {
             if (ISAInfo->hasExtension(Feature.key()) &&
                 !SubtargetInfo.hasFeature(Feature.Value))
               SubtargetInfo.ToggleFeature(Feature.key());

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -103,7 +103,7 @@ RISCVSubtarget::initializeSubtargetDependencies(const Triple &TT, StringRef CPU,
   HasStdExtC = hasFeature(RISCV::FeatureStdExtC);
   HasStdExtZce = hasFeature(RISCV::FeatureStdExtZce);
 
-  TargetABI = RISCVABI::computeTargetABI(TT, getFeatureBits(), ABIName);
+  TargetABI = RISCVABI::computeTargetABI(*this, ABIName);
   RISCVFeatures::validate(TT, getFeatureBits());
   return *this;
 }


### PR DESCRIPTION
This is preparatory work for changing the representation of
FeatureKV/SubTypeKV, in which they will no longer be that easily
accessible as global variables. Therefore, get them from the subtarget
instead.
