### PR TITLE
[mlir] Handle non-string alias test markers

### DIFF
--- a/mlir/test/Analysis/test-alias-analysis.mlir
+++ b/mlir/test/Analysis/test-alias-analysis.mlir
@@ -280,3 +280,13 @@ func.func @non_string_test_ptr(%arg0: memref<100xf32>, %arg1: index) -> f32 attr
   %0 = memref.load %arg0[%arg1] {sibling = 0 : i64} : memref<100xf32>
   return %0 : f32
 }
+
+// -----
+
+// CHECK-LABEL: Testing : "non_string_op_result_test_ptr"
+// CHECK-DAG: string_result#0 <-> func.region0#0: NoAlias
+func.func @non_string_op_result_test_ptr(%arg0: memref<100xf32>) attributes {test.ptr = "func"} {
+  %0 = memref.alloc() {test.ptr = {llvm.ptr = "ptr_a", test.a = 123 : i64}} : memref<100xf32>
+  %1 = memref.alloc() {test.ptr = "string_result"} : memref<100xf32>
+  return
+}

--- a/mlir/test/Analysis/test-alias-analysis.mlir
+++ b/mlir/test/Analysis/test-alias-analysis.mlir
@@ -272,3 +272,11 @@ func.func @distinct_objects(%arg: memref<?xf32>, %arg1: memref<?xf32>) attribute
   %0, %1 = memref.distinct_objects %arg, %arg1 {test.ptr = "distinct"} : memref<?xf32>, memref<?xf32>
   return
 }
+
+// -----
+
+// CHECK-LABEL: Testing : "non_string_test_ptr"
+func.func @non_string_test_ptr(%arg0: memref<100xf32>, %arg1: index) -> f32 attributes {test.ptr = {llvm.ptr = "ptr_a", test.a = 123 : i64}} {
+  %0 = memref.load %arg0[%arg1] {sibling = 0 : i64} : memref<100xf32>
+  return %0 : f32
+}

--- a/mlir/test/lib/Analysis/TestAliasAnalysis.cpp
+++ b/mlir/test/lib/Analysis/TestAliasAnalysis.cpp
@@ -19,17 +19,19 @@
 
 using namespace mlir;
 
+static StringAttr getTestPtrAttr(Operation *op) {
+  return op->getAttrOfType<StringAttr>("test.ptr");
+}
+
 /// Print a value that is used as an operand of an alias query.
 static void printAliasOperand(Operation *op) {
-  llvm::errs() << op->getAttrOfType<StringAttr>("test.ptr").getValue();
+  llvm::errs() << getTestPtrAttr(op).getValue();
 }
 static void printAliasOperand(Value value) {
   if (BlockArgument arg = dyn_cast<BlockArgument>(value)) {
     Region *region = arg.getParentRegion();
     unsigned parentBlockNumber = arg.getOwner()->computeBlockNumber();
-    llvm::errs() << region->getParentOp()
-                        ->getAttrOfType<StringAttr>("test.ptr")
-                        .getValue()
+    llvm::errs() << getTestPtrAttr(region->getParentOp()).getValue()
                  << ".region" << region->getRegionNumber();
     if (parentBlockNumber != 0)
       llvm::errs() << ".block" << parentBlockNumber;
@@ -65,7 +67,7 @@ void TestAliasAnalysisBase::runAliasAnalysisOnOperation(
   // Collect all of the values to check for aliasing behavior.
   SmallVector<Value, 32> valsToCheck;
   op->walk([&](Operation *op) {
-    if (!op->getDiscardableAttr("test.ptr"))
+    if (!getTestPtrAttr(op))
       return;
     valsToCheck.append(op->result_begin(), op->result_end());
     for (Region &region : op->getRegions())
@@ -86,7 +88,7 @@ void TestAliasAnalysisModRefBase::runAliasAnalysisOnOperation(
   // Collect all of the values to check for aliasing behavior.
   SmallVector<Value, 32> valsToCheck;
   op->walk([&](Operation *op) {
-    if (!op->getDiscardableAttr("test.ptr"))
+    if (!getTestPtrAttr(op))
       return;
     valsToCheck.append(op->result_begin(), op->result_end());
     for (Region &region : op->getRegions())
@@ -97,7 +99,7 @@ void TestAliasAnalysisModRefBase::runAliasAnalysisOnOperation(
   // Check for aliasing behavior between each of the values.
   for (auto &it : valsToCheck) {
     op->walk([&](Operation *op) {
-      if (!op->getDiscardableAttr("test.ptr"))
+      if (!getTestPtrAttr(op))
         return;
       printModRefResult(aliasAnalysis.getModRef(op, it), op, it);
     });


### PR DESCRIPTION
I made the alias analysis test pass only treat string-valued `test.ptr` attributes as test markers. This keeps unrelated structured attributes from being collected and later printed as labels.
Fixes #206096 