### PR TITLE
[HashRecognize] Rename ByteOrderSwapped to IsBigEndian (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/HashRecognize.h
+++ b/llvm/include/llvm/Analysis/HashRecognize.h
@@ -57,8 +57,9 @@ struct PolynomialInfo {
   // the case of CRC, which must be zero.
   Value *ComputedValue;
 
-  // Set to true in the case of big-endian.
-  bool ByteOrderSwapped;
+  // The big-endian case implies that bits are reversed, in the case of bit-wise
+  // algorithms such as CRC.
+  bool IsBigEndian;
 
   // An optional auxiliary checksum that augments the LHS. In the case of CRC,
   // it is XOR'ed with the LHS, so that the computation's final remainder is
@@ -66,7 +67,7 @@ struct PolynomialInfo {
   Value *LHSAux;
 
   LLVM_ABI PolynomialInfo(unsigned TripCount, Value *LHS, const APInt &RHS,
-                          Value *ComputedValue, bool ByteOrderSwapped,
+                          Value *ComputedValue, bool IsBigEndian,
                           Value *LHSAux = nullptr);
 };
 
@@ -85,7 +86,7 @@ public:
   // Auxilary entry point after analysis to interleave the generating polynomial
   // and return a 256-entry CRC table.
   LLVM_ABI static CRCTable genSarwateTable(const APInt &GenPoly,
-                                           bool ByteOrderSwapped);
+                                           bool IsBigEndian);
 
   LLVM_ABI void print(raw_ostream &OS) const;
 

--- a/llvm/lib/Analysis/HashRecognize.cpp
+++ b/llvm/lib/Analysis/HashRecognize.cpp
@@ -150,21 +150,21 @@ private:
 };
 
 /// Check the well-formedness of the (most|least) significant bit check given \p
-/// ConditionalRecurrence, \p SimpleRecurrence, depending on \p
-/// ByteOrderSwapped. We check that ConditionalRecurrence.Step is a
-/// Select(Cmp()) where the compare is `>= 0` in the big-endian case, and `== 0`
-/// in the little-endian case (or the inverse, in which case the branches of the
-/// compare are swapped). We check that the LHS is (ConditionalRecurrence.Phi
-/// [xor SimpleRecurrence.Phi]) in the big-endian case, and additionally check
-/// for an AND with one in the little-endian case. We then check AllowedByR
-/// against CheckAllowedByR, which is [0, smin) in the big-endian case, and is
-/// [0, 1) in the little-endian case. CheckAllowedByR checks for
-/// significant-bit-clear, and we match the corresponding arms of the select
-/// against bit-shift and bit-shift-and-xor-gen-poly.
+/// ConditionalRecurrence, \p SimpleRecurrence, depending on \p IsBigEndian. We
+/// check that ConditionalRecurrence.Step is a Select(Cmp()) where the compare
+/// is `>= 0` in the big-endian case, and `== 0` in the little-endian case (or
+/// the inverse, in which case the branches of the compare are swapped). We
+/// check that the LHS is (ConditionalRecurrence.Phi [xor SimpleRecurrence.Phi])
+/// in the big-endian case, and additionally check for an AND with one in the
+/// little-endian case. We then check AllowedByR against CheckAllowedByR, which
+/// is [0, smin) in the big-endian case, and is [0, 1) in the little-endian
+/// case. CheckAllowedByR checks for significant-bit-clear, and we match the
+/// corresponding arms of the select against bit-shift and
+/// bit-shift-and-xor-gen-poly.
 static bool
 isSignificantBitCheckWellFormed(const RecurrenceInfo &ConditionalRecurrence,
                                 const RecurrenceInfo &SimpleRecurrence,
-                                bool ByteOrderSwapped) {
+                                bool IsBigEndian) {
   auto *SI = cast<SelectInst>(ConditionalRecurrence.Step);
   CmpPredicate Pred;
   const Value *L;
@@ -180,8 +180,8 @@ isSignificantBitCheckWellFormed(const RecurrenceInfo &ConditionalRecurrence,
       m_Specific(ConditionalRecurrence.Phi),
       m_c_Xor(m_ZExtOrTruncOrSelf(m_Specific(ConditionalRecurrence.Phi)),
               m_ZExtOrTruncOrSelf(m_Specific(SimpleRecurrence.Phi))));
-  bool LWellFormed = ByteOrderSwapped ? match(L, MatchPred)
-                                      : match(L, m_c_And(MatchPred, m_One()));
+  bool LWellFormed =
+      IsBigEndian ? match(L, MatchPred) : match(L, m_c_And(MatchPred, m_One()));
   if (!LWellFormed)
     return false;
 
@@ -190,8 +190,8 @@ isSignificantBitCheckWellFormed(const RecurrenceInfo &ConditionalRecurrence,
   auto RCR = ConstantRange::fromKnownBits(KnownR, false);
   auto AllowedByR = ConstantRange::makeAllowedICmpRegion(Pred, RCR);
   ConstantRange CheckAllowedByR(APInt::getZero(BW),
-                                ByteOrderSwapped ? APInt::getSignedMinValue(BW)
-                                                 : APInt(BW, 1));
+                                IsBigEndian ? APInt::getSignedMinValue(BW)
+                                            : APInt(BW, 1));
 
   BinaryOperator *BitShift = ConditionalRecurrence.BO;
   if (AllowedByR == CheckAllowedByR)
@@ -342,21 +342,21 @@ getRecurrences(BasicBlock *LoopLatch, const PHINode *IndVar, const Loop &L) {
 }
 
 PolynomialInfo::PolynomialInfo(unsigned TripCount, Value *LHS, const APInt &RHS,
-                               Value *ComputedValue, bool ByteOrderSwapped,
+                               Value *ComputedValue, bool IsBigEndian,
                                Value *LHSAux)
     : TripCount(TripCount), LHS(LHS), RHS(RHS), ComputedValue(ComputedValue),
-      ByteOrderSwapped(ByteOrderSwapped), LHSAux(LHSAux) {}
+      IsBigEndian(IsBigEndian), LHSAux(LHSAux) {}
 
 /// Generate a lookup table of 256 entries by interleaving the generating
 /// polynomial. The optimization technique of table-lookup for CRC is also
 /// called the Sarwate algorithm.
 CRCTable HashRecognize::genSarwateTable(const APInt &GenPoly,
-                                        bool ByteOrderSwapped) {
+                                        bool IsBigEndian) {
   unsigned BW = GenPoly.getBitWidth();
   CRCTable Table;
   Table[0] = APInt::getZero(BW);
 
-  if (ByteOrderSwapped) {
+  if (IsBigEndian) {
     APInt CRCInit = APInt::getSignedMinValue(BW);
     for (unsigned I = 1; I < 256; I <<= 1) {
       CRCInit = CRCInit.shl(1) ^
@@ -458,12 +458,12 @@ std::variant<PolynomialInfo, StringRef> HashRecognize::recognizeCRC() const {
 
   // Make sure that all recurrences are either all SCEVMul with two or SCEVDiv
   // with two, or in other words, that they're single bit-shifts.
-  std::optional<bool> ByteOrderSwapped =
+  std::optional<bool> IsBigEndian =
       isBigEndianBitShift(ConditionalRecurrence.BO, SE);
-  if (!ByteOrderSwapped)
+  if (!IsBigEndian)
     return "Loop with non-unit bitshifts";
   if (SimpleRecurrence) {
-    if (isBigEndianBitShift(SimpleRecurrence.BO, SE) != ByteOrderSwapped)
+    if (isBigEndianBitShift(SimpleRecurrence.BO, SE) != IsBigEndian)
       return "Loop with non-unit bitshifts";
 
     // Ensure that the PHIs have exactly two uses:
@@ -505,7 +505,7 @@ std::variant<PolynomialInfo, StringRef> HashRecognize::recognizeCRC() const {
   const APInt &GenPoly = *ConditionalRecurrence.ExtraConst;
 
   if (!isSignificantBitCheckWellFormed(ConditionalRecurrence, SimpleRecurrence,
-                                       *ByteOrderSwapped))
+                                       *IsBigEndian))
     return "Malformed significant-bit check";
 
   SmallVector<const Instruction *> Roots(
@@ -517,8 +517,7 @@ std::variant<PolynomialInfo, StringRef> HashRecognize::recognizeCRC() const {
   if (containsUnreachable(L, Roots))
     return "Found stray unvisited instructions";
 
-  return PolynomialInfo(TC, LHS, GenPoly, ComputedValue, *ByteOrderSwapped,
-                        LHSAux);
+  return PolynomialInfo(TC, LHS, GenPoly, ComputedValue, *IsBigEndian, LHSAux);
 }
 
 void CRCTable::print(raw_ostream &OS) const {
@@ -547,7 +546,7 @@ void HashRecognize::print(raw_ostream &OS) const {
   }
 
   auto Info = std::get<PolynomialInfo>(Ret);
-  OS << "Found" << (Info.ByteOrderSwapped ? " big-endian " : " little-endian ")
+  OS << "Found" << (Info.IsBigEndian ? " big-endian " : " little-endian ")
      << "CRC-" << Info.RHS.getBitWidth() << " loop with trip count "
      << Info.TripCount << "\n";
   OS.indent(2) << "Initial CRC: ";
@@ -565,7 +564,7 @@ void HashRecognize::print(raw_ostream &OS) const {
     OS << "\n";
   }
   OS.indent(2) << "Computed CRC lookup table:\n";
-  genSarwateTable(Info.RHS, Info.ByteOrderSwapped).print(OS);
+  genSarwateTable(Info.RHS, Info.IsBigEndian).print(OS);
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)

--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -1565,7 +1565,7 @@ bool LoopIdiomRecognize::optimizeCRCLoop(const PolynomialInfo &Info) {
   Type *CRCTy = Info.LHS->getType();
   unsigned CRCBW = CRCTy->getIntegerBitWidth();
   std::array<Constant *, 256> CRCConstants;
-  transform(HashRecognize::genSarwateTable(Info.RHS, Info.ByteOrderSwapped),
+  transform(HashRecognize::genSarwateTable(Info.RHS, Info.IsBigEndian),
             CRCConstants.begin(),
             [CRCTy](const APInt &E) { return ConstantInt::get(CRCTy, E); });
   Constant *ConstArray =
@@ -1653,17 +1653,16 @@ bool LoopIdiomRecognize::optimizeCRCLoop(const PolynomialInfo &Info) {
       Value *IVBits = Builder.CreateZExtOrTrunc(
           Builder.CreateShl(IV, 3, "iv.bits"), DataTy, "iv.indexer");
       Value *DataIndexer =
-          Info.ByteOrderSwapped
-              ? Builder.CreateShl(Data, IVBits, "data.indexer")
-              : Builder.CreateLShr(Data, IVBits, "data.indexer");
+          Info.IsBigEndian ? Builder.CreateShl(Data, IVBits, "data.indexer")
+                           : Builder.CreateLShr(Data, IVBits, "data.indexer");
       Indexer = Builder.CreateXor(
           DataIndexer,
           Builder.CreateZExtOrTrunc(Indexer, DataTy, "crc.indexer.cast"),
           "crc.data.indexer");
     }
 
-    Indexer = Info.ByteOrderSwapped ? HiIdx(Builder, Indexer, "indexer.hi")
-                                    : LoByte(Builder, Indexer, "indexer.lo");
+    Indexer = Info.IsBigEndian ? HiIdx(Builder, Indexer, "indexer.hi")
+                               : LoByte(Builder, Indexer, "indexer.lo");
 
     // Always index into a GEP using the index type.
     Indexer = Builder.CreateZExt(
@@ -1679,7 +1678,7 @@ bool LoopIdiomRecognize::optimizeCRCLoop(const PolynomialInfo &Info) {
     // CRC-8.
     Value *CRCNext = CRCTableLd;
     if (CRCBW > 8) {
-      Value *CRCShift = Info.ByteOrderSwapped
+      Value *CRCShift = Info.IsBigEndian
                             ? Builder.CreateShl(CRC, 8, "crc.be.shift")
                             : Builder.CreateLShr(CRC, 8, "crc.le.shift");
       CRCNext = Builder.CreateXor(CRCShift, CRCTableLd, "crc.next");


### PR DESCRIPTION
In order to avoid talking about bit-endianness versus byte-endianness, rename ByteOrderSwapped to IsBigEndian, which is algorithm-agnostic. In fact, CRC is a bitwise-algorithm, and hence the bit order is reversed.