### PR TITLE
[libc++][NFC] Mark random_device::__padding_ as [[maybe_unused]]

### DIFF
--- a/libcxx/include/__random/random_device.h
+++ b/libcxx/include/__random/random_device.h
@@ -28,19 +28,15 @@ class _LIBCPP_EXPORTED_FROM_ABI random_device {
 #  ifdef _LIBCPP_USING_DEV_RANDOM
   int __f_;
 #  elif !defined(_LIBCPP_ABI_NO_RANDOM_DEVICE_COMPATIBILITY_LAYOUT)
-  _LIBCPP_DIAGNOSTIC_PUSH
-  _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wunused-private-field")
-
   // Apple platforms used to use the `_LIBCPP_USING_DEV_RANDOM` code path, and now
   // use `arc4random()` as of this comment. In order to avoid breaking the ABI, we
   // retain the same layout as before.
 #    if defined(__APPLE__)
-  int __padding_; // padding to fake the `__f_` field above
+  [[__maybe_unused__]] int __padding_; // padding to fake the `__f_` field above
 #    endif
 
   // ... vendors can add workarounds here if they switch to a different representation ...
 
-  _LIBCPP_DIAGNOSTIC_POP
 #  endif
 
 public:


### PR DESCRIPTION
Instead of pushing and popping warnings we can just mark the offending member as `[[maybe_unused]]`, improving compile times a bit and simplifying the code.
