### PR TITLE
[SLP] Allow non-power-of-2 VF in tryToVectorizeList

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -29477,7 +29477,7 @@ bool SLPVectorizerPass::tryToVectorizeList(ArrayRef<Value *> VL, BoUpSLP &R,
       unsigned ActualVF = std::min(MaxInst - I, VF);
 
       if (!hasFullVectorsOrPowerOf2(*TTI, ScalarTy, ActualVF) &&
-          !isAllowedNonPowerOf2VF(ActualVF))
+          !(ActualVF == VL.size() && isAllowedNonPowerOf2VF(ActualVF)))
         continue;
 
       if (MaxVFOnly && ActualVF < MaxVF)

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -29476,7 +29476,7 @@ bool SLPVectorizerPass::tryToVectorizeList(ArrayRef<Value *> VL, BoUpSLP &R,
       unsigned ActualVF = std::min(MaxInst - I, VF);
 
       if (!hasFullVectorsOrPowerOf2(*TTI, ScalarTy, ActualVF) &&
-          !(ActualVF == VL.size() && isAllowedNonPowerOf2VF(ActualVF)))
+          (ActualVF != VL.size() || !isAllowedNonPowerOf2VF(ActualVF)))
         continue;
 
       if (MaxVFOnly && ActualVF < MaxVF)

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -29442,12 +29442,11 @@ bool SLPVectorizerPass::tryToVectorizeList(ArrayRef<Value *> VL, BoUpSLP &R,
   unsigned Sz = R.getVectorElementSize(I0);
   unsigned MinVF = R.getMinVF(Sz);
   unsigned MaxVF = std::max<unsigned>(
-      getFloorFullVectorNumberOfElements(*TTI, ScalarTy, VL.size()), MinVF);
+      isAllowedNonPowerOf2VF(VL.size())
+          ? VL.size()
+          : getFloorFullVectorNumberOfElements(*TTI, ScalarTy, VL.size()),
+      MinVF);
   MaxVF = std::min(R.getMaximumVF(Sz, S.getOpcode()), MaxVF);
-  if (isAllowedNonPowerOf2VF(VL.size()))
-    MaxVF = std::max<unsigned>(
-        MaxVF,
-        std::min<unsigned>(VL.size(), R.getMaximumVF(Sz, S.getOpcode())));
   // Standalone seeds only need one register worth of lanes.
   if (StandaloneSeeds && Sz != 0)
     MaxVF = std::min(MaxVF, std::max(MinVF, R.getMaxVecRegSize() / Sz));

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -29444,6 +29444,10 @@ bool SLPVectorizerPass::tryToVectorizeList(ArrayRef<Value *> VL, BoUpSLP &R,
   unsigned MaxVF = std::max<unsigned>(
       getFloorFullVectorNumberOfElements(*TTI, ScalarTy, VL.size()), MinVF);
   MaxVF = std::min(R.getMaximumVF(Sz, S.getOpcode()), MaxVF);
+  if (isAllowedNonPowerOf2VF(VL.size()))
+    MaxVF = std::max<unsigned>(
+        MaxVF,
+        std::min<unsigned>(VL.size(), R.getMaximumVF(Sz, S.getOpcode())));
   // Standalone seeds only need one register worth of lanes.
   if (StandaloneSeeds && Sz != 0)
     MaxVF = std::min(MaxVF, std::max(MinVF, R.getMaxVecRegSize() / Sz));
@@ -29472,7 +29476,8 @@ bool SLPVectorizerPass::tryToVectorizeList(ArrayRef<Value *> VL, BoUpSLP &R,
     for (unsigned I = NextInst; I < MaxInst; ++I) {
       unsigned ActualVF = std::min(MaxInst - I, VF);
 
-      if (!hasFullVectorsOrPowerOf2(*TTI, ScalarTy, ActualVF))
+      if (!hasFullVectorsOrPowerOf2(*TTI, ScalarTy, ActualVF) &&
+          !isAllowedNonPowerOf2VF(ActualVF))
         continue;
 
       if (MaxVFOnly && ActualVF < MaxVF)

--- a/llvm/test/Transforms/SLPVectorizer/X86/odd_store.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/odd_store.ll
@@ -9,29 +9,48 @@
 ;}
 
 define void @foo(ptr noalias nocapture %A, ptr noalias nocapture %B, float %T) {
-; CHECK-LABEL: @foo(
-; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds float, ptr [[B:%.*]], i64 10
-; CHECK-NEXT:    [[TMP2:%.*]] = load float, ptr [[TMP1]], align 4
-; CHECK-NEXT:    [[TMP3:%.*]] = fmul float [[TMP2]], [[T:%.*]]
-; CHECK-NEXT:    [[TMP4:%.*]] = fpext float [[TMP3]] to double
-; CHECK-NEXT:    [[TMP5:%.*]] = fadd double [[TMP4]], 4.000000e+00
-; CHECK-NEXT:    [[TMP6:%.*]] = fptosi double [[TMP5]] to i8
-; CHECK-NEXT:    store i8 [[TMP6]], ptr [[A:%.*]], align 1
-; CHECK-NEXT:    [[TMP7:%.*]] = getelementptr inbounds float, ptr [[B]], i64 11
-; CHECK-NEXT:    [[TMP13:%.*]] = getelementptr inbounds i8, ptr [[A]], i64 1
-; CHECK-NEXT:    [[TMP9:%.*]] = load <2 x float>, ptr [[TMP7]], align 4
-; CHECK-NEXT:    [[TMP10:%.*]] = insertelement <2 x float> poison, float [[T]], i64 0
-; CHECK-NEXT:    [[TMP11:%.*]] = shufflevector <2 x float> [[TMP10]], <2 x float> poison, <2 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP16:%.*]] = fmul <2 x float> [[TMP9]], [[TMP11]]
-; CHECK-NEXT:    [[TMP17:%.*]] = fpext <2 x float> [[TMP16]] to <2 x double>
-; CHECK-NEXT:    [[TMP14:%.*]] = fadd <2 x double> [[TMP17]], <double 5.000000e+00, double 6.000000e+00>
-; CHECK-NEXT:    [[TMP15:%.*]] = fptosi <2 x double> [[TMP14]] to <2 x i8>
-; CHECK-NEXT:    [[TMP12:%.*]] = extractelement <2 x i8> [[TMP15]], i64 0
-; CHECK-NEXT:    store i8 [[TMP12]], ptr [[TMP13]], align 1
-; CHECK-NEXT:    [[TMP20:%.*]] = getelementptr inbounds i8, ptr [[A]], i64 2
-; CHECK-NEXT:    [[TMP19:%.*]] = extractelement <2 x i8> [[TMP15]], i64 1
-; CHECK-NEXT:    store i8 [[TMP19]], ptr [[TMP20]], align 1
-; CHECK-NEXT:    ret void
+; NON-POW2-LABEL: @foo(
+; NON-POW2-NEXT:    [[TMP1:%.*]] = getelementptr inbounds float, ptr [[B:%.*]], i64 10
+; NON-POW2-NEXT:    [[TMP2:%.*]] = getelementptr inbounds i8, ptr [[A:%.*]], i64 1
+; NON-POW2-NEXT:    [[TMP3:%.*]] = load <3 x float>, ptr [[TMP1]], align 4
+; NON-POW2-NEXT:    [[TMP4:%.*]] = insertelement <3 x float> poison, float [[T:%.*]], i64 0
+; NON-POW2-NEXT:    [[TMP5:%.*]] = shufflevector <3 x float> [[TMP4]], <3 x float> poison, <3 x i32> zeroinitializer
+; NON-POW2-NEXT:    [[TMP6:%.*]] = fmul <3 x float> [[TMP3]], [[TMP5]]
+; NON-POW2-NEXT:    [[TMP7:%.*]] = fpext <3 x float> [[TMP6]] to <3 x double>
+; NON-POW2-NEXT:    [[TMP8:%.*]] = fadd <3 x double> [[TMP7]], <double 4.000000e+00, double 5.000000e+00, double 6.000000e+00>
+; NON-POW2-NEXT:    [[TMP9:%.*]] = fptosi <3 x double> [[TMP8]] to <3 x i8>
+; NON-POW2-NEXT:    [[TMP10:%.*]] = extractelement <3 x i8> [[TMP9]], i64 0
+; NON-POW2-NEXT:    store i8 [[TMP10]], ptr [[A]], align 1
+; NON-POW2-NEXT:    [[TMP11:%.*]] = extractelement <3 x i8> [[TMP9]], i64 1
+; NON-POW2-NEXT:    store i8 [[TMP11]], ptr [[TMP2]], align 1
+; NON-POW2-NEXT:    [[TMP12:%.*]] = getelementptr inbounds i8, ptr [[A]], i64 2
+; NON-POW2-NEXT:    [[TMP13:%.*]] = extractelement <3 x i8> [[TMP9]], i64 2
+; NON-POW2-NEXT:    store i8 [[TMP13]], ptr [[TMP12]], align 1
+; NON-POW2-NEXT:    ret void
+;
+; POW2-ONLY-LABEL: @foo(
+; POW2-ONLY-NEXT:    [[TMP1:%.*]] = getelementptr inbounds float, ptr [[B:%.*]], i64 10
+; POW2-ONLY-NEXT:    [[TMP2:%.*]] = load float, ptr [[TMP1]], align 4
+; POW2-ONLY-NEXT:    [[TMP3:%.*]] = fmul float [[TMP2]], [[T:%.*]]
+; POW2-ONLY-NEXT:    [[TMP4:%.*]] = fpext float [[TMP3]] to double
+; POW2-ONLY-NEXT:    [[TMP5:%.*]] = fadd double [[TMP4]], 4.000000e+00
+; POW2-ONLY-NEXT:    [[TMP6:%.*]] = fptosi double [[TMP5]] to i8
+; POW2-ONLY-NEXT:    store i8 [[TMP6]], ptr [[A:%.*]], align 1
+; POW2-ONLY-NEXT:    [[TMP7:%.*]] = getelementptr inbounds float, ptr [[B]], i64 11
+; POW2-ONLY-NEXT:    [[TMP8:%.*]] = getelementptr inbounds i8, ptr [[A]], i64 1
+; POW2-ONLY-NEXT:    [[TMP9:%.*]] = load <2 x float>, ptr [[TMP7]], align 4
+; POW2-ONLY-NEXT:    [[TMP10:%.*]] = insertelement <2 x float> poison, float [[T]], i64 0
+; POW2-ONLY-NEXT:    [[TMP11:%.*]] = shufflevector <2 x float> [[TMP10]], <2 x float> poison, <2 x i32> zeroinitializer
+; POW2-ONLY-NEXT:    [[TMP12:%.*]] = fmul <2 x float> [[TMP9]], [[TMP11]]
+; POW2-ONLY-NEXT:    [[TMP13:%.*]] = fpext <2 x float> [[TMP12]] to <2 x double>
+; POW2-ONLY-NEXT:    [[TMP14:%.*]] = fadd <2 x double> [[TMP13]], <double 5.000000e+00, double 6.000000e+00>
+; POW2-ONLY-NEXT:    [[TMP15:%.*]] = fptosi <2 x double> [[TMP14]] to <2 x i8>
+; POW2-ONLY-NEXT:    [[TMP16:%.*]] = extractelement <2 x i8> [[TMP15]], i64 0
+; POW2-ONLY-NEXT:    store i8 [[TMP16]], ptr [[TMP8]], align 1
+; POW2-ONLY-NEXT:    [[TMP17:%.*]] = getelementptr inbounds i8, ptr [[A]], i64 2
+; POW2-ONLY-NEXT:    [[TMP18:%.*]] = extractelement <2 x i8> [[TMP15]], i64 1
+; POW2-ONLY-NEXT:    store i8 [[TMP18]], ptr [[TMP17]], align 1
+; POW2-ONLY-NEXT:    ret void
 ;
   %1 = getelementptr inbounds float, ptr %B, i64 10
   %2 = load float, ptr %1, align 4

--- a/llvm/test/Transforms/SLPVectorizer/non-power-of-2-buildvector.ll
+++ b/llvm/test/Transforms/SLPVectorizer/non-power-of-2-buildvector.ll
@@ -6,29 +6,9 @@ define <15 x half> @func(ptr %buffer) {
 ; CHECK-SAME: ptr [[BUFFER:%.*]]) {
 ; CHECK-NEXT:  [[_ENTRY:.*:]]
 ; CHECK-NEXT:    [[DATA:%.*]] = load <15 x half>, ptr [[BUFFER]], align 32
-; CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <15 x half> [[DATA]], <15 x half> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-; CHECK-NEXT:    [[TMP1:%.*]] = fcmp olt <8 x half> [[TMP0]], zeroinitializer
-; CHECK-NEXT:    [[TMP19:%.*]] = fmul fast <8 x half> [[TMP0]], splat (half 1.000210e-02)
-; CHECK-NEXT:    [[TMP3:%.*]] = select <8 x i1> [[TMP1]], <8 x half> [[TMP19]], <8 x half> [[TMP0]]
-; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <8 x half> [[TMP3]], <8 x half> poison, <15 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; CHECK-NEXT:    [[DOT14_VEC_INSERT18211:%.*]] = shufflevector <15 x half> [[DATA]], <15 x half> [[TMP4]], <15 x i32> <i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14>
-; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <15 x half> [[DATA]], i64 8
-; CHECK-NEXT:    [[TMP6:%.*]] = fcmp olt half [[TMP5]], 0.000000e+00
-; CHECK-NEXT:    [[TMP7:%.*]] = fmul fast half [[TMP5]], 1.000210e-02
-; CHECK-NEXT:    [[TMP8:%.*]] = select i1 [[TMP6]], half [[TMP7]], half [[TMP5]]
-; CHECK-NEXT:    [[DOT16_VEC_INSERT1823:%.*]] = insertelement <15 x half> [[DOT14_VEC_INSERT18211]], half [[TMP8]], i64 8
-; CHECK-NEXT:    [[TMP9:%.*]] = shufflevector <15 x half> [[DATA]], <15 x half> poison, <2 x i32> <i32 9, i32 10>
-; CHECK-NEXT:    [[TMP10:%.*]] = fcmp olt <2 x half> [[TMP9]], zeroinitializer
-; CHECK-NEXT:    [[TMP11:%.*]] = fmul fast <2 x half> [[TMP9]], splat (half 1.000210e-02)
-; CHECK-NEXT:    [[TMP12:%.*]] = select <2 x i1> [[TMP10]], <2 x half> [[TMP11]], <2 x half> [[TMP9]]
-; CHECK-NEXT:    [[TMP13:%.*]] = shufflevector <2 x half> [[TMP12]], <2 x half> poison, <15 x i32> <i32 0, i32 1, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; CHECK-NEXT:    [[DOT20_VEC_INSERT18273:%.*]] = shufflevector <15 x half> [[DOT16_VEC_INSERT1823]], <15 x half> [[TMP13]], <15 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 15, i32 16, i32 11, i32 12, i32 13, i32 14>
-; CHECK-NEXT:    [[TMP14:%.*]] = shufflevector <15 x half> [[DATA]], <15 x half> poison, <4 x i32> <i32 11, i32 12, i32 13, i32 14>
-; CHECK-NEXT:    [[TMP15:%.*]] = fcmp olt <4 x half> [[TMP14]], zeroinitializer
-; CHECK-NEXT:    [[TMP16:%.*]] = fmul fast <4 x half> [[TMP14]], splat (half 1.000210e-02)
-; CHECK-NEXT:    [[TMP17:%.*]] = select <4 x i1> [[TMP15]], <4 x half> [[TMP16]], <4 x half> [[TMP14]]
-; CHECK-NEXT:    [[TMP18:%.*]] = shufflevector <4 x half> [[TMP17]], <4 x half> poison, <15 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <15 x half> [[DOT20_VEC_INSERT18273]], <15 x half> [[TMP18]], <15 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 15, i32 16, i32 17, i32 18>
+; CHECK-NEXT:    [[TMP0:%.*]] = fcmp olt <15 x half> [[DATA]], zeroinitializer
+; CHECK-NEXT:    [[TMP1:%.*]] = fmul fast <15 x half> [[DATA]], splat (half 1.000210e-02)
+; CHECK-NEXT:    [[TMP2:%.*]] = select <15 x i1> [[TMP0]], <15 x half> [[TMP1]], <15 x half> [[DATA]]
 ; CHECK-NEXT:    ret <15 x half> [[TMP2]]
 ;
 .entry:


### PR DESCRIPTION
Non-power-of-2 VF support (-slp-vectorize-non-power-of-2) was wired into
the `load/store/reduction` paths but not into `tryToVectorizeList`, so
`buildvector/insertelement` seeds like <15 x half> were split into
power-of-2 pieces instead of a single vector op.

Consult `isAllowedNonPowerOf2VF()` when computing `MaxVF` and in the inner
full-vector guard so supported widths are tried. No change unless
`-slp-vectorize-non-power-of-2` is enabled.

https://godbolt.org/z/1b8GebPEW