### PR TITLE
[DirectX][ObjectYAML] Attempt to fix flaky PRIVPart.yaml

### DIFF
--- a/llvm/test/tools/obj2yaml/DXContainer/PRIVPart.yaml
+++ b/llvm/test/tools/obj2yaml/DXContainer/PRIVPart.yaml
@@ -2,7 +2,8 @@
 ## part size is not a multiple of 4. The pipeline is run twice to ensure obj2yaml
 ## output with a non-multiple-of-4 FileSize can be fed back through yaml2obj.
 
-# RUN: yaml2obj %s 2>&1 | obj2yaml 2>&1 | yaml2obj %s 2>&1 | obj2yaml 2>&1 | FileCheck %s
+# RUN: yaml2obj %s 2>&1 | obj2yaml -o %t.yaml
+# RUN: yaml2obj %t.yaml 2>&1 | obj2yaml 2>&1 | FileCheck %s
 
 --- !dxcontainer
 Header:

--- a/llvm/test/tools/obj2yaml/DXContainer/PRIVPart.yaml
+++ b/llvm/test/tools/obj2yaml/DXContainer/PRIVPart.yaml
@@ -2,8 +2,9 @@
 ## part size is not a multiple of 4. The pipeline is run twice to ensure obj2yaml
 ## output with a non-multiple-of-4 FileSize can be fed back through yaml2obj.
 
-# RUN: yaml2obj %s 2>&1 | obj2yaml -o %t.yaml
-# RUN: yaml2obj %t.yaml 2>&1 | obj2yaml 2>&1 | FileCheck %s
+# RUN: yaml2obj %s -o %t.dxbc
+# RUN: obj2yaml %t.dxbc | yaml2obj -o %t2.dxbc
+# RUN: obj2yaml %t2.dxbc | FileCheck %s
 
 --- !dxcontainer
 Header:


### PR DESCRIPTION
This test was meant to round-trip YAML twice, to ensure correct processing of non-4-byte-padded PRIV section.
However, second invocation of yaml2obj had wrong arguments (it was reading from test file instead of stdin). Fix that.

Also, round-trips were split into two RUN lines, to make it clear on which line an error occurs if the test is still flaky.