### PR TITLE
[PowerPC] Extend select_cc lhs, 0, 1, 0, cc optimization to PowerPC 64

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
@@ -5891,17 +5891,25 @@ void PPCDAGToDAGISel::Select(SDNode *N) {
       }
     }
 
-    // Handle the setcc cases here.  select_cc lhs, 0, 1, 0, cc
-    if (!isPPC64 && isNullConstant(N->getOperand(1)) &&
-        isOneConstant(N->getOperand(2)) && isNullConstant(N->getOperand(3)) &&
-        CC == ISD::SETNE &&
-        // FIXME: Implement this optzn for PPC64.
-        N->getValueType(0) == MVT::i32) {
-      SDNode *Tmp =
-          CurDAG->getMachineNode(PPC::ADDIC, dl, MVT::i32, MVT::Glue,
-                                 N->getOperand(0), getI32Imm(~0U, dl));
-      CurDAG->SelectNodeTo(N, PPC::SUBFE, MVT::i32, SDValue(Tmp, 0),
-                           N->getOperand(0), SDValue(Tmp, 1));
+    // Handle the setcc cases here.  select_cc lhs, 0, 1, 0, setne
+    // Compute (lhs != 0) as: addic tmp, lhs, -1; subfe res, tmp, lhs
+    // FIXME: Is it worth sign extending/zero extending on 64-bit if data is
+    // 32-bit?
+    if (isNullConstant(N->getOperand(1)) && isOneConstant(N->getOperand(2)) &&
+        isNullConstant(N->getOperand(3)) && CC == ISD::SETNE &&
+        N->getOperand(0).getValueType() == N->getValueType(0) &&
+        ((!isPPC64 && N->getValueType(0) == MVT::i32) ||
+         (isPPC64 && N->getValueType(0) == MVT::i64))) {
+      bool Is64Bit = N->getValueType(0) == MVT::i64;
+      unsigned AddicOpc = Is64Bit ? PPC::ADDIC8 : PPC::ADDIC;
+      unsigned SubfeOpc = Is64Bit ? PPC::SUBFE8 : PPC::SUBFE;
+      MVT VT = Is64Bit ? MVT::i64 : MVT::i32;
+      SDValue ImmOp = Is64Bit ? getI64Imm(~0ULL, dl) : getI32Imm(~0U, dl);
+
+      SDNode *Tmp = CurDAG->getMachineNode(AddicOpc, dl, VT, MVT::Glue,
+                                           N->getOperand(0), ImmOp);
+      CurDAG->SelectNodeTo(N, SubfeOpc, VT, SDValue(Tmp, 0), N->getOperand(0),
+                           SDValue(Tmp, 1));
       return;
     }
 

--- a/llvm/test/CodeGen/PowerPC/ppc-crbits-onoff.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc-crbits-onoff.ll
@@ -66,6 +66,64 @@ entry:
 
 }
 
+define i64 @crbitsoff_64(i64 %v1, i64 %v2) #0 {
+; CHECK-LABEL: crbitsoff_64:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    cmpldi 7, 3, 0
+; CHECK-NEXT:    mfocrf 3, 1
+; CHECK-NEXT:    cmpldi 7, 4, 0
+; CHECK-NEXT:    mfocrf 4, 1
+; CHECK-NEXT:    rlwinm 3, 3, 31, 31, 31
+; CHECK-NEXT:    xori 3, 3, 1
+; CHECK-NEXT:    rlwinm 4, 4, 31, 31, 31
+; CHECK-NEXT:    and 3, 3, 4
+; CHECK-NEXT:    blr
+;
+; CHECK-NO-ISEL-LABEL: crbitsoff_64:
+; CHECK-NO-ISEL:       # %bb.0: # %entry
+; CHECK-NO-ISEL-NEXT:    cmpldi 7, 3, 0
+; CHECK-NO-ISEL-NEXT:    mfocrf 3, 1
+; CHECK-NO-ISEL-NEXT:    cmpldi 7, 4, 0
+; CHECK-NO-ISEL-NEXT:    mfocrf 4, 1
+; CHECK-NO-ISEL-NEXT:    rlwinm 3, 3, 31, 31, 31
+; CHECK-NO-ISEL-NEXT:    xori 3, 3, 1
+; CHECK-NO-ISEL-NEXT:    rlwinm 4, 4, 31, 31, 31
+; CHECK-NO-ISEL-NEXT:    and 3, 3, 4
+; CHECK-NO-ISEL-NEXT:    blr
+entry:
+  %tobool = icmp ne i64 %v1, 0
+  %lnot = icmp eq i64 %v2, 0
+  %and3 = and i1 %tobool, %lnot
+  %and = zext i1 %and3 to i64
+  ret i64 %and
+}
+
+define i64 @crbitson_64(i64 %v1, i64 %v2) #1 {
+; CHECK-LABEL: crbitson_64:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    cntlzd 4, 4
+; CHECK-NEXT:    addic 5, 3, -1
+; CHECK-NEXT:    subfe 3, 5, 3
+; CHECK-NEXT:    rldicl 4, 4, 58, 63
+; CHECK-NEXT:    and 3, 3, 4
+; CHECK-NEXT:    blr
+;
+; CHECK-NO-ISEL-LABEL: crbitson_64:
+; CHECK-NO-ISEL:       # %bb.0: # %entry
+; CHECK-NO-ISEL-NEXT:    cntlzd 4, 4
+; CHECK-NO-ISEL-NEXT:    addic 5, 3, -1
+; CHECK-NO-ISEL-NEXT:    subfe 3, 5, 3
+; CHECK-NO-ISEL-NEXT:    rldicl 4, 4, 58, 63
+; CHECK-NO-ISEL-NEXT:    and 3, 3, 4
+; CHECK-NO-ISEL-NEXT:    blr
+entry:
+  %tobool = icmp ne i64 %v1, 0
+  %lnot = icmp eq i64 %v2, 0
+  %and3 = and i1 %tobool, %lnot
+  %and = zext i1 %and3 to i64
+  ret i64 %and
+}
+
 
 attributes #0 = { nounwind readnone "target-features"="-crbits" }
 attributes #1 = { nounwind readnone }


### PR DESCRIPTION
We should extend this optimization to 64-bit where applicable.