### PR TITLE
[NFC] Fix "is is" typos

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-bind.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-bind.rst
@@ -50,7 +50,7 @@ Options
   of every placeholder parameter list. Without this, it is possible for a fix-it
   to perform an incorrect transformation in the case where the result of the ``bind``
   is used in the context of a type erased functor such as ``std::function`` which
-  allows mismatched arguments. Default is is `false`.
+  allows mismatched arguments. Default is `false`.
 
 For example:
 

--- a/clang/include/clang/Lex/MultipleIncludeOpt.h
+++ b/clang/include/clang/Lex/MultipleIncludeOpt.h
@@ -110,7 +110,7 @@ public:
 
   /// SetReadToken - Set whether the value of 'ReadAnyTokens'.  Called to
   /// override when encountering tokens outside of the include guard that have
-  /// no effect if the file in question is is included multiple times (e.g. the
+  /// no effect if the file in question is included multiple times (e.g. the
   /// null directive).
   void SetReadToken(bool Value) { ReadAnyTokens = Value; }
 

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -2625,7 +2625,7 @@ bool CXXMethodDecl::isUsualDeallocationFunction(
     if (!PrimaryTemplate)
       return true;
 
-    // A template instance is is only a usual deallocation function if it has a
+    // A template instance is only a usual deallocation function if it has a
     // type-identity parameter, the type-identity parameter is a dependent type
     // (i.e. the type-identity parameter is of type std::type_identity<U> where
     // U shall be a dependent type), and the type-identity parameter is the only
@@ -2645,7 +2645,7 @@ bool CXXMethodDecl::isUsualDeallocationFunction(
   //   A template instance is never a usual deallocation function,
   //   regardless of its signature.
   // Post-P2719 adoption:
-  //   A template instance is is only a usual deallocation function if it has a
+  //   A template instance is only a usual deallocation function if it has a
   //   type-identity parameter
   if (getPrimaryTemplate())
     return false;

--- a/clang/lib/CodeGen/README.txt
+++ b/clang/lib/CodeGen/README.txt
@@ -13,7 +13,7 @@ generates an zext/sext of x which can easily be avoided.
 
 Bitfields accesses can be shifted to simplify masking and sign
 extension. For example, if the bitfield width is 8 and it is
-appropriately aligned then is is a lot shorter to just load the char
+appropriately aligned then it is a lot shorter to just load the char
 directly.
 
 //===---------------------------------------------------------------------===//

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -87,7 +87,7 @@ void Flang::addPreprocessingOptions(const ArgList &Args,
 ///  -Ofast
 ///  -O4
 ///  -O3
-/// For all other cases, loop versioning is is disabled.
+/// For all other cases, loop versioning is disabled.
 ///
 /// The gfortran compiler automatically enables the option for -O3 or -Ofast.
 ///

--- a/clang/lib/Headers/avx2intrin.h
+++ b/clang/lib/Headers/avx2intrin.h
@@ -3058,7 +3058,7 @@ _mm256_broadcastsi128_si256(__m128i __X) {
 ///    An immediate 8-bit integer operand, with bits [7:0] specifying the
 ///    source for each element of the result. The position of the mask bit
 ///    corresponds to the index of a copied value. When a mask bit is 0, the
-///    element is copied from \a V1; otherwise, it is is copied from \a V2.
+///    element is copied from \a V1; otherwise, it is copied from \a V2.
 /// \returns A 256-bit vector of [8 x i32] containing the result.
 #define _mm256_blend_epi32(V1, V2, M) \
   ((__m256i)__builtin_ia32_pblendd256((__v8si)(__m256i)(V1), \

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4208,7 +4208,7 @@ static void handleFormatAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (!S.checkUInt32Argument(AL, FirstArgExpr, FirstArg, 3))
     return;
 
-  // FirstArg == 0 is is always valid.
+  // FirstArg == 0 is always valid.
   if (FirstArg != 0) {
     if (Info.Kind == StrftimeFormat) {
       // If the kind is strftime, FirstArg must be 0 because strftime does not

--- a/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
@@ -866,7 +866,7 @@ void GenericTaintChecker::checkBeginFunction(CheckerContext &C) const {
   if (auto N = ArgcSVal.getAs<NonLoc>()) {
     ConstraintManager &CM = C.getConstraintManager();
     // The upper bound is the ARG_MAX on an arbitrary Linux
-    // to model that is is typically smaller than INT_MAX.
+    // to model that is typically smaller than INT_MAX.
     State = CM.assumeInclusiveRange(State, *N, llvm::APSInt::getUnsigned(1),
                                     llvm::APSInt::getUnsigned(2097152), true);
   }

--- a/clang/lib/StaticAnalyzer/Checkers/NullabilityChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/NullabilityChecker.cpp
@@ -590,7 +590,7 @@ void NullabilityChecker::checkBeginFunction(CheckerContext &C) const {
 }
 
 // Whenever we see a load from a typed memory region that's been annotated as
-// 'nonnull', we want to trust the user on that and assume that it is is indeed
+// 'nonnull', we want to trust the user on that and assume that it is indeed
 // non-null.
 //
 // We do so even if the value is known to have been assigned to null.

--- a/compiler-rt/lib/hwasan/hwasan_tag_mismatch_aarch64.S
+++ b/compiler-rt/lib/hwasan/hwasan_tag_mismatch_aarch64.S
@@ -20,7 +20,7 @@
 // particularly important as hwasan_check_* instances are duplicated in every
 // translation unit where HWASan is enabled.
 // This function calls HwasanTagMismatch to step back into the C++ code that
-// completes the stack unwinding and error printing. This function is is not
+// completes the stack unwinding and error printing. This function is not
 // permitted to return.
 
 

--- a/compiler-rt/lib/hwasan/hwasan_tag_mismatch_riscv64.S
+++ b/compiler-rt/lib/hwasan/hwasan_tag_mismatch_riscv64.S
@@ -19,7 +19,7 @@
 // This is particularly important as hwasan_check_* instances are duplicated in every
 // translation unit where HWASan is enabled.
 // This function calls HwasanTagMismatch to step back into the C++ code that
-// completes the stack unwinding and error printing. This function is is not
+// completes the stack unwinding and error printing. This function is not
 // permitted to return.
 
 

--- a/flang/docs/Semantics.md
+++ b/flang/docs/Semantics.md
@@ -15,7 +15,7 @@ local:
 ```
 
 The semantic analysis pass determines if a syntactically correct Fortran
-program is is legal by enforcing the constraints of the language.
+program is legal by enforcing the constraints of the language.
 
 The input is a parse tree with a `Program` node at the root;
 and a "cooked" character stream, a contiguous stream of characters

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -1574,7 +1574,7 @@ Fortran::lower::CallInterface<T>::getProcedureAttrs(
     // called is recursive or not.
     if (const Fortran::semantics::Symbol *sym = side().getProcedureSymbol()) {
       // Note: By default procedures are RECURSIVE unless
-      // -fno-automatic/-save/-Msave is set. NON_RECURSIVE is is made explicit
+      // -fno-automatic/-save/-Msave is set. NON_RECURSIVE is made explicit
       // in that case in FIR.
       if (sym->attrs().test(Fortran::semantics::Attr::NON_RECURSIVE) ||
           (sym->owner().context().languageFeatures().IsEnabled(

--- a/flang/lib/Optimizer/Transforms/LoopInvariantCodeMotion.cpp
+++ b/flang/lib/Optimizer/Transforms/LoopInvariantCodeMotion.cpp
@@ -47,7 +47,7 @@ using namespace mlir;
 /// may be added later).
 /// The safety of hoisting is proven by:
 ///   * Proving that the loop runs at least one iteration.
-///   * Proving that is is always safe to load from this location
+///   * Proving that it is always safe to load from this location
 ///     (see isSafeToHoistLoad() comments below).
 struct LoopInvariantCodeMotion
     : fir::impl::LoopInvariantCodeMotionBase<LoopInvariantCodeMotion> {

--- a/libc/src/string/memory_utils/arm/inline_memcpy.h
+++ b/libc/src/string/memory_utils/arm/inline_memcpy.h
@@ -199,7 +199,7 @@ copy_bytes_and_bump_pointers(Ptr &dst, CPtr &src, size_t size) {
   // `memcpy` prototype. This allows the compiler to merge consecutive
   // load/store (LDR, STR) instructions generated in
   // `copy_block_and_bump_pointers` with `BlockOp::kByWord` into load/store
-  // double (LDRD, STRD) instructions, this is is undesirable so we prevent the
+  // double (LDRD, STRD) instructions, this is undesirable so we prevent the
   // compiler from inferring `__restrict` with the following line.
   asm volatile("" : "+r"(dst), "+r"(src));
 #ifdef __ARM_FEATURE_UNALIGNED

--- a/libcxx/docs/DesignDocs/FeatureTestMacros.rst
+++ b/libcxx/docs/DesignDocs/FeatureTestMacros.rst
@@ -21,7 +21,7 @@ They must be available from a list of headers, they may have different values in
 different dialects, and they may or may not be implemented by libc++. In order to
 track all of these conditions correctly and easily, we want a Single Source of
 Truth (SSoT) that defines each feature test macro, its values, the headers it
-lives in, and whether or not is is implemented by libc++. From this SSoA we
+lives in, and whether or not it is implemented by libc++. From this SSoA we
 have enough information to automatically generate the `<version>` header,
 the tests, and the documentation.
 

--- a/llvm/docs/AMDGPUDwarfExtensionAllowLocationDescriptionOnTheDwarfExpressionStack/AMDGPUDwarfExtensionAllowLocationDescriptionOnTheDwarfExpressionStack.md
+++ b/llvm/docs/AMDGPUDwarfExtensionAllowLocationDescriptionOnTheDwarfExpressionStack/AMDGPUDwarfExtensionAllowLocationDescriptionOnTheDwarfExpressionStack.md
@@ -3205,7 +3205,7 @@ location list expressions.</i>
     subprogram instance that immediately lexically encloses the current call
     frame's subprogram or entry point.
 
-    The DWARF is ill-formed if L is is not comprised of one memory location
+    The DWARF is ill-formed if L is not comprised of one memory location
     description for one of the target architecture specific address spaces.
 
 ### A.3.4 Call Site Entries and Parameters

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -15663,7 +15663,7 @@ knows those logical layouts are lowered to the same physical layout:
     - `{ i32, i32, i32, i32 }`
     - `[ i32 x 4 ]`
 
-This means is is valid to lower the following code to either:
+This means it is valid to lower the following code to either:
 
 .. code-block:: llvm
 

--- a/llvm/docs/RISCVUsage.rst
+++ b/llvm/docs/RISCVUsage.rst
@@ -627,7 +627,7 @@ To use this functionality, you need to be doing all of the following:
 
 LLD will relax (rewrite) any code sequences that materialize an address within 2048 bytes of ``__global_pointer$`` (which will be defined if it is used and does not already exist) to instead generate the address using ``gp`` and the correct (signed) 12-bit immediate. This usually saves at least one instruction compared to materialising a full 32-bit address value.
 
-There can only be one ``gp`` value in a process (as ``gp`` is not changed when calling into a function in a shared library), so the symbol is is only defined and this relaxation is only done for executables, and not for shared libraries. The linker expects executable startup code to put the value of ``__global_pointer$`` (from the executable) into ``gp`` before any user code is run.
+There can only be one ``gp`` value in a process (as ``gp`` is not changed when calling into a function in a shared library), so the symbol is only defined and this relaxation is only done for executables, and not for shared libraries. The linker expects executable startup code to put the value of ``__global_pointer$`` (from the executable) into ``gp`` before any user code is run.
 
 Arguably, the most efficient use for this addressing mode is for smaller global variables, as larger global variables likely need many more loads or stores when they are being accessed anyway, so the cost of materializing the upper bits can be shared.
 

--- a/llvm/lib/Analysis/BlockFrequencyInfoImpl.cpp
+++ b/llvm/lib/Analysis/BlockFrequencyInfoImpl.cpp
@@ -483,7 +483,7 @@ static void convertFloatingToInteger(BlockFrequencyInfoImplBase &BFI,
                                      const Scaled64 &Min, const Scaled64 &Max) {
   // Scale the Factor to a size that creates integers.  If possible scale
   // integers so that Max == UINT64_MAX so that they can be best differentiated.
-  // Is is possible that the range between min and max cannot be accurately
+  // It is possible that the range between min and max cannot be accurately
   // represented in a 64bit integer without either loosing precision for small
   // values (so small unequal numbers all map to 1) or saturaturing big numbers
   // loosing precision for big numbers (so unequal big numbers may map to

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -2900,7 +2900,7 @@ void SITargetLowering::allocateSpecialEntryInputVGPRs(
 
 // Try to allocate a VGPR at the end of the argument list, or if no argument
 // VGPRs are left allocating a stack slot.
-// If \p Mask is is given it indicates bitfield position in the register.
+// If \p Mask is given it indicates bitfield position in the register.
 // If \p Arg is given use it with new ]p Mask instead of allocating new.
 static ArgDescriptor allocateVGPR32Input(CCState &CCInfo, unsigned Mask = ~0u,
                                          ArgDescriptor Arg = ArgDescriptor()) {

--- a/llvm/lib/Target/ARM/ARMInstrNEON.td
+++ b/llvm/lib/Target/ARM/ARMInstrNEON.td
@@ -5564,7 +5564,7 @@ def : Pat<(v16i8 (vnotq QPR:$src)),
 
 // The TwoAddress pass will not go looking for equivalent operations
 // with different register constraints; it just inserts copies.
-// That is why pseudo VBSP implemented. Is is expanded later into
+// That is why pseudo VBSP implemented. It is expanded later into
 // VBIT/VBIF/VBSL taking into account register constraints to avoid copies.
 def  VBSPd : PseudoNeonI<(outs DPR:$Vd), (ins DPR:$src1, DPR:$Vn, DPR:$Vm),
                          IIC_VBINiD, "", []>;

--- a/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
@@ -2089,7 +2089,7 @@ bool NumericalStabilitySanitizer::sanitizeFunction(
   //
   //    For example, in the following example, the instrumentation in
   //    `instrumented_1` rejects the shadow return value from `instrumented_3`
-  //    because is is not tagged as expected (`&instrumented_3` instead of
+  //    because it is not tagged as expected (`&instrumented_3` instead of
   //    `non_instrumented_2`):
   //
   //        instrumented_1()

--- a/llvm/test/CodeGen/AArch64/regcoal-physreg.mir
+++ b/llvm/test/CodeGen/AArch64/regcoal-physreg.mir
@@ -32,7 +32,7 @@ body: |
     $fp = SUBXri $fp, 4, 0
     STRXui %2, $x1, 0
 
-    ; Is is fine to coalesce copies from constant physregs even when they are
+    ; It is fine to coalesce copies from constant physregs even when they are
     ; clobbered.
     ; CHECK-NOT: COPY
     ; CHECK: STRWui $wzr, $x1
@@ -40,7 +40,7 @@ body: |
     dead $wzr = SUBSWri $w1, 0, 0, implicit-def $nzcv
     STRWui %3, $x1, 0
 
-    ; Is is fine to coalesce copies from constant physregs even when they are
+    ; It is fine to coalesce copies from constant physregs even when they are
     ; clobbered.
     ; CHECK-NOT: COPY
     ; CHECK: STRXui $xzr, $x1

--- a/llvm/test/CodeGen/PowerPC/pgo-ref-directive.ll
+++ b/llvm/test/CodeGen/PowerPC/pgo-ref-directive.ll
@@ -83,7 +83,7 @@ entry:
 }
 ; There will be two __llvm_prf_cnts .csects, one to represent the actual csect 
 ; that holds @__profc_main, and one generated to hold the .ref directives. In 
-; XCOFF, a csect can be defined in pieces, so this is is legal assembly.
+; XCOFF, a csect can be defined in pieces, so this is a legal assembly.
 ;
 ; NOVNDS:      .csect __llvm_prf_cnts[RW],3
 ; NOVNDS:      .csect __llvm_prf_cnts[RW],3

--- a/llvm/test/CodeGen/PowerPC/pgo-ref-directive.ll
+++ b/llvm/test/CodeGen/PowerPC/pgo-ref-directive.ll
@@ -83,7 +83,7 @@ entry:
 }
 ; There will be two __llvm_prf_cnts .csects, one to represent the actual csect 
 ; that holds @__profc_main, and one generated to hold the .ref directives. In 
-; XCOFF, a csect can be defined in pieces, so this is a legal assembly.
+; XCOFF, a csect can be defined in pieces, so this is legal assembly.
 ;
 ; NOVNDS:      .csect __llvm_prf_cnts[RW],3
 ; NOVNDS:      .csect __llvm_prf_cnts[RW],3

--- a/mlir/include/mlir/Dialect/Async/IR/AsyncOps.td
+++ b/mlir/include/mlir/Dialect/Async/IR/AsyncOps.td
@@ -486,7 +486,7 @@ def Async_CoroEndOp : Async_Op<"coro.end"> {
   let description = [{
     The `async.coro.end` marks the point where a coroutine needs to return
     control back to the caller if it is not an initial invocation of the
-    coroutine. It the start part of the coroutine is is no-op.
+    coroutine. In the start part of the coroutine it is no-op.
   }];
 
   let arguments = (ins Async_CoroHandleType:$handle);

--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgInterfaces.h
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgInterfaces.h
@@ -154,7 +154,7 @@ isaTransposeOpInterface(GenericOp genericOp);
 /// the category op.
 /// A linalg.generic body could be a series of unary elementwise ops e.g.
 /// `exp(neg(x))`, such as formed by linalg op fusion. Here we restrict it to
-/// detecting cases where body is is a single computation op.
+/// detecting cases where body is a single computation op.
 bool isaElemwiseSingleUnaryOpInterface(GenericOp genericOp,
                                        bool allowNonIdentityMaps = false);
 

--- a/mlir/include/mlir/Dialect/NVGPU/IR/NVGPUOps.td
+++ b/mlir/include/mlir/Dialect/NVGPU/IR/NVGPUOps.td
@@ -363,7 +363,7 @@ def NVGPU_MBarrierInitOp : NVGPU_Op<"mbarrier.init", []> {
 def NVGPU_MBarrierTestWaitOp : NVGPU_Op<"mbarrier.test.wait", []> {
   let summary = "Checks if the `nvgpu.mbarrier` has completed its current phase.";
   let description = [{
-    Checks whether the mbarrier object has completed the phase. It is is a 
+    Checks whether the mbarrier object has completed the phase. It is a 
     non-blocking instruction which tests for the completion of the phase.
 
     Example:
@@ -438,7 +438,7 @@ def NVGPU_MBarrierArriveExpectTxOp : NVGPU_Op<"mbarrier.arrive.expect_tx", []> {
 def NVGPU_MBarrierTryWaitParityOp : NVGPU_Op<"mbarrier.try_wait.parity", []> {
   let summary = "Waits for the `nvgpu.mbarrier` to complete its current phase.";
   let description = [{
-    Checks whether the mbarrier object has completed the phase. It is is a 
+    Checks whether the mbarrier object has completed the phase. It is a 
     potentially blocking instruction which tests for the completion of the 
     phase. Suspended thread resumes execution when the specified phase completes 
     OR before the phase completes following a system-dependent time limit. 

--- a/polly/lib/External/isl/isl_union_map.c
+++ b/polly/lib/External/isl/isl_union_map.c
@@ -3136,7 +3136,7 @@ isl_bool isl_union_map_is_injective(__isl_keep isl_union_map *umap)
  * In particular, if the domain and range spaces are the same,
  * then the map is not considered to obviously not be an identity relation.
  * Otherwise, the map is considered to obviously not be an identity relation
- * if it is is non-empty.
+ * if it is non-empty.
  *
  * If "map" is determined to obviously not be an identity relation,
  * then the search is aborted.


### PR DESCRIPTION
These changes aim to fix common "is is" typos.