### PR TITLE
[AArch64][llvm-jitlink] Fix two QNX cross-compile build failures

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -4123,7 +4123,7 @@ bool AArch64InstructionSelector::selectUnmergeValues(MachineInstr &I,
   // directly. Otherwise, we need to do a bit of setup with some subregister
   // inserts.
   if (NarrowTy.getSizeInBits() * NumElts == 128) {
-    InsertRegs = SmallVector<Register, 4>(NumInsertRegs, SrcReg);
+    InsertRegs.assign(NumInsertRegs, SrcReg);
   } else {
     // No. We have to perform subregister inserts. For each insert, create an
     // implicit def and a subregister insert, and save the register we create.

--- a/llvm/tools/llvm-jitlink/CMakeLists.txt
+++ b/llvm/tools/llvm-jitlink/CMakeLists.txt
@@ -37,3 +37,7 @@ endif()
 if("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
   target_link_libraries(llvm-jitlink PRIVATE socket)
 endif()
+
+if("${CMAKE_SYSTEM_NAME}" MATCHES "QNX")
+  target_link_libraries(llvm-jitlink PRIVATE socket)
+endif()


### PR DESCRIPTION
## Summary

Fixes two build failures when cross-compiling LLVM for QNX (aarch64-unknown-nto-qnx8.0.0).

### 1. `AArch64InstructionSelector.cpp` — GCC `-Wstringop-overread` false positive

GCC's static analysis misreads the SmallVector fill constructor in
`selectUnmergeValues()` as potentially reading `NumInsertRegs * sizeof(Register)`
bytes from the 16-byte inline buffer of `SmallVector<Register, 4>`, emitting:

```
warning: reading between 20 and 17179869180 bytes from a region of size 16 [-Wstringop-overread]
```

This is a false positive — `SmallVector` heap-allocates when the inline buffer is exceeded.
Replacing the constructor-then-move with `assign()` fills the already-live object in place,
which GCC can analyze correctly.

**No functional change.**

### 2. `llvm-jitlink` — undefined references to socket functions on QNX

On QNX, POSIX socket functions (`getaddrinfo`, `socket`, `connect`, `freeaddrinfo`, `gai_strerror`)
live in `libsocket` rather than libc. Without it the QNX cross-compile linker fails with
undefined references in `llvm::Session::Create()`:

```
undefined reference to `getaddrinfo'
undefined reference to `socket'
undefined reference to `connect'
undefined reference to `freeaddrinfo'
undefined reference to `gai_strerror'
```

Mirrors the existing `target_link_libraries` pattern already present for SunOS and Haiku.

---

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>