### PR TITLE
[Serialization] Delete an unreachable BlockDecl check (NFC)

### DIFF
--- a/clang/lib/Serialization/ASTCommon.cpp
+++ b/clang/lib/Serialization/ASTCommon.cpp
@@ -499,7 +499,7 @@ bool serialization::needsAnonymousDeclarationNumber(const NamedDecl *D) {
     if (auto *VD = dyn_cast<VarDecl>(D))
       return VD->isStaticLocal();
     // FIXME: What about CapturedDecls (and declarations nested within them)?
-    return isa<TagDecl, BlockDecl>(D);
+    return isa<TagDecl>(D);
   }
 
   // Otherwise, we only care about anonymous class members / block-scope decls.


### PR DESCRIPTION
`needsAnonymousDeclarationNumber()` takes a `const NamedDecl *`. Both `BlockDecl` and `NamedDecl` derive from `Decl`, in other words they're siblings.

* https://clang.llvm.org/doxygen/classclang_1_1BlockDecl.html
* https://clang.llvm.org/doxygen/classclang_1_1NamedDecl.html

Thus `isa<BlockDecl>(D)` is statically false.