### PR TITLE
[clang-format] Set Context.IsExpression for C++ ternary operators

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2500,6 +2500,8 @@ private:
         Current.setType(TT_Unknown);
       } else {
         Current.setType(TT_ConditionalExpr);
+        if (IsCpp)
+          Contexts.back().IsExpression = true;
       }
     } else if (Current.isBinaryOperator() &&
                (!Current.Previous || Current.Previous->isNot(tok::l_square)) &&
@@ -3039,14 +3041,6 @@ private:
     // && in C# must be a binary operator.
     if (Style.isCSharp() && Tok.is(tok::ampamp))
       return TT_BinaryOperator;
-
-    // The keyword `and` (tok::ampamp) is always binary, never a declarator.
-    // Not extended to `bitand` (tok::amp), which can be a reference.
-    if (Tok.is(tok::ampamp)) {
-      const auto *Info = Tok.Tok.getIdentifierInfo();
-      if (Info && Info->isCPlusPlusOperatorKeyword())
-        return TT_BinaryOperator;
-    }
 
     if (Style.isVerilog()) {
       // In Verilog, `*` can only be a binary operator.  `&` can be either unary

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22558,7 +22558,7 @@ TEST_F(FormatTest, DoNotCrashOnInvalidInput) {
                 "LY52:                   ! [internal]");
   verifyNoCrash("operator foo *;");
   verifyNoCrash(
-      "  #xxxx??x<xxxxxxx||??x<xxxxxxx and xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+      "#xxxx??x<xxxxxxx||??x<xxxxxxx and xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
 }
 
 TEST_F(FormatTest, FormatsTableGenCode) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -445,6 +445,11 @@ TEST_F(TokenAnnotatorTest, UnderstandsUsesOfStarAndAmp) {
   ASSERT_EQ(Tokens.size(), 30u) << Tokens;
   EXPECT_TOKEN(Tokens[18], tok::star, TT_PointerOrReference);
   EXPECT_TOKEN(Tokens[19], tok::identifier, TT_StartOfName);
+
+  Tokens = annotate("foo ? a < b && c : bar");
+  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
+  EXPECT_TOKEN(Tokens[5], tok::ampamp, TT_BinaryOperator);
+  EXPECT_TOKEN(Tokens[6], tok::identifier, TT_Unknown); // Not TT_StartOfName
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsUsesOfPlusAndMinus) {
@@ -4197,10 +4202,6 @@ TEST_F(TokenAnnotatorTest, CppAltOperatorKeywords) {
   Tokens = annotate("a = b xor_eq c;");
   ASSERT_EQ(Tokens.size(), 7u) << Tokens;
   EXPECT_TOKEN(Tokens[3], tok::caretequal, TT_BinaryOperator);
-
-  Tokens = annotate("if (a and b) {}");
-  ASSERT_EQ(Tokens.size(), 9u) << Tokens;
-  EXPECT_TOKEN(Tokens[3], tok::ampamp, TT_BinaryOperator);
 
   const auto StyleC = getLLVMStyle(FormatStyle::LK_C);
 


### PR DESCRIPTION
This reverts e99e343dfdb2b1b490789a7bcba6d646a4824f15 (#199112).

Fixes #199027