### PR TITLE
[compiler-rt][sanitizer_common] Remove internal linkage from RegisterFlag (NFC)

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_flag_parser.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_flag_parser.h
@@ -189,8 +189,8 @@ class FlagParser {
 };
 
 template <typename T>
-static void RegisterFlag(FlagParser *parser, const char *name, const char *desc,
-                         T *var) {
+void RegisterFlag(FlagParser* parser, const char* name, const char* desc,
+                  T* var) {
   FlagHandler<T> *fh = new (GetGlobalLowLevelAllocator()) FlagHandler<T>(var);
   parser->RegisterHandler(name, fh, desc);
 }


### PR DESCRIPTION
RegisterFlag is a static function template in a header, so every TU that includes it without calling it trips `-Wunused-template`. Dropping static gives it normal external linkage and clears the warning.

NFC. Part of #202945.