### PR TITLE
[MLIR] Prevent CF to SCF transform from erasing blocks still in use

### DIFF
--- a/mlir/include/mlir/Transforms/CFGToSCF.h
+++ b/mlir/include/mlir/Transforms/CFGToSCF.h
@@ -149,9 +149,10 @@ public:
 /// Otherwise a single control flow graph operation branching to one block
 /// per return-like operation kind remains.
 ///
-/// The transformation currently requires that all control flow graph operations
-/// have no side effects, implement the BranchOpInterface and does not have any
-/// operation produced successor operands.
+/// The transformation currently requires that the region has no unreachable
+/// blocks and that all control flow graph operations have no side effects,
+/// implement the BranchOpInterface and does not have any operation produced
+/// successor operands.
 /// Returns failure if any of the preconditions are violated or if any of the
 /// methods of `interface` failed. The IR is left in an unspecified state.
 ///

--- a/mlir/lib/Transforms/Utils/CFGToSCF.cpp
+++ b/mlir/lib/Transforms/Utils/CFGToSCF.cpp
@@ -1234,8 +1234,13 @@ static ReturnLikeExitCombiner createSingleExitBlocksForReturnLike(
 /// Returns failure if any precondition is violated.
 static LogicalResult
 checkTransformationPreconditions(Region &region, CFGToSCFInterface &interface) {
+  llvm::df_iterator_default_set<Block *, 16> reachable;
+  // Find all blocks reachable from the entry.
+  for (Block *block : depth_first_ext(&region.front(), reachable))
+    (void)block;
+
   for (Block &block : region.getBlocks())
-    if (block.hasNoPredecessors() && !block.isEntryBlock())
+    if (!reachable.contains(&block))
       return block.front().emitOpError(
           "transformation does not support unreachable blocks");
 

--- a/mlir/test/Conversion/ControlFlowToSCF/unreachable-blocks.mlir
+++ b/mlir/test/Conversion/ControlFlowToSCF/unreachable-blocks.mlir
@@ -1,0 +1,18 @@
+// RUN: mlir-opt --lift-cf-to-scf -verify-diagnostics -split-input-file %s
+
+// Verify that --lift-cf-to-scf does not crash when it encounters an
+// unreachable blocks (dead code).  Instead it should emit a clean error.
+// See: https://github.com/llvm/llvm-project/issues/206086
+
+module {
+  func.func @single_return_statement(%arg0: i32) -> i32 {
+    return %arg0 : i32
+  ^bb1:  // pred: ^bb1
+    // expected-error@below {{'arith.constant' op transformation does not support unreachable blocks}}
+    %true = arith.constant true
+    cf.cond_br %true, ^bb2, ^bb1
+  ^bb2:  // pred: ^bb1
+    return %arg0 : i32
+  }
+}
+


### PR DESCRIPTION
While merging blocks, `transformToStructuredCFBranches` may try to erase blocks that still have uses. This may happen when the block has self-loop or when it has 1 successor, but the successor has multiple predecessors. This probably happens only with unreachable blocks in the function.

Note that running a DCE pass before CF to SCF transform would remove the triggering assert in the lit test.

Fixes #206086.