### PR TITLE
[clangd] Remove unused onlyValue<bool> overload (NFC)

### DIFF
--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -556,14 +556,6 @@ private:
     return &(B->*Member);
   }
 
-  template <bool BundledEntry::*Member> const bool *onlyValue() const {
-    auto B = Bundled.begin(), E = Bundled.end();
-    for (auto *I = B + 1; I != E; ++I)
-      if (I->*Member != B->*Member)
-        return nullptr;
-    return &(B->*Member);
-  }
-
   std::string summarizeReturnType() const {
     if (auto *RT = onlyValue<&BundledEntry::ReturnType>())
       return *RT;


### PR DESCRIPTION
BundledEntry has three `std::string` members and no bool member, so the bool overload of onlyValue can never be instantiated. It has been dead since it was added and trips -Wunused-template.

NFC. Part of #202945.