### PR TITLE
Update UnicodeNameToCodepointGenerator.cpp to refer to Unicode 18

### DIFF
--- a/llvm/utils/UnicodeData/UnicodeNameMappingGenerator.cpp
+++ b/llvm/utils/UnicodeData/UnicodeNameMappingGenerator.cpp
@@ -8,7 +8,7 @@
 //
 // This file is used to generate lib/Support/UnicodeNameToCodepointGenerated.cpp
 // using UnicodeData.txt and NameAliases.txt available at
-// https://unicode.org/Public/15.1.0/ucd/
+// https://unicode.org/Public/draft/ucd/
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/DenseMap.h"
@@ -356,9 +356,9 @@ int main(int argc, char **argv) {
          "Usage: %s UnicodeData.txt NameAliases.txt output\n\n",
          argv[0]);
   printf("NameAliases.txt can be found at "
-         "https://unicode.org/Public/15.1.0/ucd/NameAliases.txt\n"
+         "https://unicode.org/Public/draft/ucd/NameAliases.txt\n"
          "UnicodeData.txt can be found at "
-         "https://unicode.org/Public/15.1.0/ucd/UnicodeData.txt\n\n");
+         "https://unicode.org/Public/draft/ucd/UnicodeData.txt\n\n");
 
   if (argc != 4)
     return EXIT_FAILURE;


### PR DESCRIPTION
#198255 updated our generated Unicode tables to Unicode 18, but didn't update any of the string literals or comments that still refer to Unicode 15.