### PR TITLE
[Support] Make format_object non-virtual

### DIFF
--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -10179,11 +10179,6 @@ Logger &cxindex::Logger::operator<<(CXString Str) {
   return *this;
 }
 
-Logger &cxindex::Logger::operator<<(const llvm::format_object_base &Fmt) {
-  LogOS << Fmt;
-  return *this;
-}
-
 static llvm::ManagedStatic<std::mutex> LoggingMutex;
 
 cxindex::Logger::~Logger() {

--- a/clang/tools/libclang/CLog.h
+++ b/clang/tools/libclang/CLog.h
@@ -16,6 +16,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
 #include <string>
 
@@ -82,7 +83,12 @@ public:
   Logger &operator<<(char C) { LogOS << C; return *this; }
   Logger &operator<<(unsigned char C) { LogOS << C; return *this; }
   Logger &operator<<(signed char C) { LogOS << C; return *this; }
-  Logger &operator<<(const llvm::format_object_base &Fmt);
+
+  template <typename... Ts>
+  Logger &operator<<(const llvm::format_object<Ts...> &Fmt) {
+    LogOS << Fmt;
+    return *this;
+  }
 };
 
 }

--- a/llvm/include/llvm/Support/Format.h
+++ b/llvm/include/llvm/Support/Format.h
@@ -27,6 +27,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <cstdio>
 #include <optional>
@@ -35,24 +36,47 @@
 
 namespace llvm {
 
-/// This is a helper class used for handling formatted output.  It is the
-/// abstract base class of a templated derived class.
-class LLVM_ABI format_object_base {
-protected:
-  const char *Fmt;
-  ~format_object_base() = default; // Disallow polymorphic deletion.
-  format_object_base(const format_object_base &) = default;
-  virtual void home(); // Out of line virtual method.
+/// These are templated helper classes used by the format function that
+/// capture the object to be formatted and the format string. When actually
+/// printed, this synthesizes the string into a temporary buffer provided and
+/// returns whether or not it is big enough.
 
-  /// Call snprintf() for this object, on the given buffer and size.
-  virtual int snprint(char *Buffer, unsigned BufferSize) const = 0;
+namespace detail {
+template <typename T> struct decay_if_c_char_array {
+  using type = T;
+};
+template <std::size_t N> struct decay_if_c_char_array<char[N]> {
+  using type = const char *;
+};
+template <typename T>
+using decay_if_c_char_array_t = typename decay_if_c_char_array<T>::type;
+} // namespace detail
+
+template <typename... Ts> class format_object {
+  const char *Fmt;
+  std::tuple<detail::decay_if_c_char_array_t<Ts>...> Vals;
+
+  template <std::size_t... Is>
+  int snprint_tuple(char *Buffer, unsigned BufferSize,
+                    std::index_sequence<Is...>) const {
+#ifdef _MSC_VER
+    return _snprintf(Buffer, BufferSize, Fmt, std::get<Is>(Vals)...);
+#else
+    return snprintf(Buffer, BufferSize, Fmt, std::get<Is>(Vals)...);
+#endif
+  }
 
 public:
-  format_object_base(const char *fmt) : Fmt(fmt) {}
+  format_object(const char *fmt, const Ts &...vals) : Fmt(fmt), Vals(vals...) {
+    static_assert(
+        (std::is_scalar_v<detail::decay_if_c_char_array_t<Ts>> && ...),
+        "format can't be used with non fundamental / non pointer type");
+  }
 
-  /// Format the object into the specified buffer.  On success, this returns
-  /// the length of the formatted string.  If the buffer is too small, this
-  /// returns a length to retry with, which will be larger than BufferSize.
+  int snprint(char *Buffer, unsigned BufferSize) const {
+    return snprint_tuple(Buffer, BufferSize, std::index_sequence_for<Ts...>());
+  }
+
   unsigned print(char *Buffer, unsigned BufferSize) const {
     assert(BufferSize && "Invalid buffer size!");
 
@@ -73,48 +97,12 @@ public:
   }
 };
 
-/// These are templated helper classes used by the format function that
-/// capture the object to be formatted and the format string. When actually
-/// printed, this synthesizes the string into a temporary buffer provided and
-/// returns whether or not it is big enough.
-
-namespace detail {
-template <typename T> struct decay_if_c_char_array {
-  using type = T;
-};
-template <std::size_t N> struct decay_if_c_char_array<char[N]> {
-  using type = const char *;
-};
-template <typename T>
-using decay_if_c_char_array_t = typename decay_if_c_char_array<T>::type;
-} // namespace detail
-
 template <typename... Ts>
-class format_object final : public format_object_base {
-  std::tuple<detail::decay_if_c_char_array_t<Ts>...> Vals;
-
-  template <std::size_t... Is>
-  int snprint_tuple(char *Buffer, unsigned BufferSize,
-                    std::index_sequence<Is...>) const {
-#ifdef _MSC_VER
-    return _snprintf(Buffer, BufferSize, Fmt, std::get<Is>(Vals)...);
-#else
-    return snprintf(Buffer, BufferSize, Fmt, std::get<Is>(Vals)...);
-#endif
-  }
-
-public:
-  format_object(const char *fmt, const Ts &... vals)
-      : format_object_base(fmt), Vals(vals...) {
-    static_assert(
-        (std::is_scalar_v<detail::decay_if_c_char_array_t<Ts>> && ...),
-        "format can't be used with non fundamental / non pointer type");
-  }
-
-  int snprint(char *Buffer, unsigned BufferSize) const override {
-    return snprint_tuple(Buffer, BufferSize, std::index_sequence_for<Ts...>());
-  }
-};
+raw_ostream &operator<<(raw_ostream &OS, format_object<Ts...> Fmt) {
+  OS <<
+      [&Fmt](char *Buf, size_t Size) -> size_t { return Fmt.print(Buf, Size); };
+  return OS;
+}
 
 /// These are helper functions used to produce formatted output.  They use
 /// template type deduction to construct the appropriate instance of the

--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_RAW_OSTREAM_H
 #define LLVM_SUPPORT_RAW_OSTREAM_H
 
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compiler.h"
@@ -305,7 +306,7 @@ public:
   raw_ostream &write(const char *Ptr, size_t Size);
 
   // Formatted output, see the format() function in Support/Format.h.
-  raw_ostream &operator<<(const format_object_base &Fmt);
+  raw_ostream &operator<<(function_ref<size_t(char *, size_t)> Print);
 
   // Formatted output, see the leftJustify() function in Support/Format.h.
   raw_ostream &operator<<(const FormattedString &);

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -295,13 +295,14 @@ void raw_ostream::copy_to_buffer(const char *Ptr, size_t Size) {
 }
 
 // Formatted output.
-raw_ostream &raw_ostream::operator<<(const format_object_base &Fmt) {
+raw_ostream &
+raw_ostream::operator<<(function_ref<size_t(char *, size_t)> Print) {
   // If we have more than a few bytes left in our output buffer, try
   // formatting directly onto its end.
   size_t NextBufferSize = 127;
   size_t BufferBytesLeft = OutBufEnd - OutBufCur;
   if (BufferBytesLeft > 3) {
-    size_t BytesUsed = Fmt.print(OutBufCur, BufferBytesLeft);
+    size_t BytesUsed = Print(OutBufCur, BufferBytesLeft);
 
     // Common case is that we have plenty of space.
     if (BytesUsed <= BufferBytesLeft) {
@@ -323,7 +324,7 @@ raw_ostream &raw_ostream::operator<<(const format_object_base &Fmt) {
     V.resize(NextBufferSize);
 
     // Try formatting into the SmallVector.
-    size_t BytesUsed = Fmt.print(V.data(), NextBufferSize);
+    size_t BytesUsed = Print(V.data(), NextBufferSize);
 
     // If BytesUsed fit into the vector, we win.
     if (BytesUsed <= NextBufferSize)
@@ -539,14 +540,6 @@ raw_ostream &raw_ostream::reverseColor() {
 }
 
 void raw_ostream::anchor() {}
-
-//===----------------------------------------------------------------------===//
-//  Formatted Output
-//===----------------------------------------------------------------------===//
-
-// Out of line virtual method.
-void format_object_base::home() {
-}
 
 //===----------------------------------------------------------------------===//
 //  raw_fd_ostream


### PR DESCRIPTION
Currently, format_object creates a 32B vtable for every instantiation.
This is costs space and dynamic relocations. Make format_object
non-virtual and adapt the two printing users to use a function_ref
instead.
