### PR TITLE
[libc++] Implement LWG3662 basic_string::append/assign(NTBS, pos, n) suboptimal

### DIFF
--- a/libcxx/docs/Status/Cxx26Issues.csv
+++ b/libcxx/docs/Status/Cxx26Issues.csv
@@ -264,7 +264,7 @@
 "`LWG2746 <https://wg21.link/LWG2746>`__","Inconsistency between requirements for ``emplace`` between ``optional`` and ``variant``","2026-03 (Croydon)","","","`#189806 <https://github.com/llvm/llvm-project/issues/189806>`__",""
 "`LWG3504 <https://wg21.link/LWG3504>`__","``condition_variable::wait_for`` is overspecified","2026-03 (Croydon)","","","`#189807 <https://github.com/llvm/llvm-project/issues/189807>`__",""
 "`LWG3599 <https://wg21.link/LWG3599>`__","The ``const`` overload of ``lazy_split_view::begin`` should be constrained by ``const Pattern``","2026-03 (Croydon)","","","`#189808 <https://github.com/llvm/llvm-project/issues/189808>`__",""
-"`LWG3662 <https://wg21.link/LWG3662>`__","``basic_string::append/assign(NTBS, pos, n)`` suboptimal","2026-03 (Croydon)","","","`#189809 <https://github.com/llvm/llvm-project/issues/189809>`__",""
+"`LWG3662 <https://wg21.link/LWG3662>`__","``basic_string::append/assign(NTBS, pos, n)`` suboptimal","2026-03 (Croydon)","|Complete|","23","`#189809 <https://github.com/llvm/llvm-project/issues/189809>`__",""
 "`LWG3777 <https://wg21.link/LWG3777>`__","Common ``cartesian_product_view`` produces an invalid range if the first range is input and one of the ranges is empty","2026-03 (Croydon)","","","`#189810 <https://github.com/llvm/llvm-project/issues/189810>`__",""
 "`LWG3797 <https://wg21.link/LWG3797>`__","``elements_view`` insufficiently constrained","2026-03 (Croydon)","","","`#189811 <https://github.com/llvm/llvm-project/issues/189811>`__",""
 "`LWG3831 <https://wg21.link/LWG3831>`__","Two-digit formatting of negative ``year`` is ambiguous","2026-03 (Croydon)","","","`#189812 <https://github.com/llvm/llvm-project/issues/189812>`__",""

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -201,6 +201,7 @@ public:
         basic_string& append(const T& t, size_type pos, size_type n=npos);                      // C++17, constexpr since C++20
     basic_string& append(const value_type* s, size_type n);                                     // constexpr since C++20
     basic_string& append(const value_type* s);                                                  // constexpr since C++20
+    basic_string& append(const value_type* s, size_type pos, size_type n);                      // constexpr since C++20
     basic_string& append(size_type n, value_type c);                                            // constexpr since C++20
     template<class InputIterator>
         basic_string& append(InputIterator first, InputIterator last);                          // constexpr since C++20
@@ -224,6 +225,7 @@ public:
         basic_string& assign(const T& t, size_type pos, size_type n=npos);                      // C++17, constexpr since C++20
     basic_string& assign(const value_type* s, size_type n);                                     // constexpr since C++20
     basic_string& assign(const value_type* s);                                                  // constexpr since C++20
+    basic_string& assign(const value_type* s, size_type pos, size_type n);                      // constexpr since C++20
     basic_string& assign(size_type n, value_type c);                                            // constexpr since C++20
     template<class InputIterator>
         basic_string& assign(InputIterator first, InputIterator last);                          // constexpr since C++20
@@ -1342,6 +1344,8 @@ public:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& append(const value_type* __s, size_type __n)
       _LIBCPP_DIAGNOSE_NULLPTR_IF(__n != 0 && __s == nullptr, " if n is not zero");
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& append(const value_type* _LIBCPP_DIAGNOSE_NULLPTR __s);
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& append(const value_type* __s, size_type __pos, size_type __n)
+      _LIBCPP_DIAGNOSE_NULLPTR_IF(__n != 0 && __s == nullptr, " if n is not zero");
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& append(size_type __n, value_type __c);
 
   template <class _InputIterator, __enable_if_t<__has_exactly_input_iterator_category<_InputIterator>::value, int> = 0>
@@ -1468,6 +1472,8 @@ public:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& assign(const value_type* __s, size_type __n)
       _LIBCPP_DIAGNOSE_NULLPTR_IF(__n != 0 && __s == nullptr, " if n is not zero");
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& assign(const value_type* _LIBCPP_DIAGNOSE_NULLPTR __s);
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& assign(const value_type* __s, size_type __pos, size_type __n)
+      _LIBCPP_DIAGNOSE_NULLPTR_IF(__n != 0 && __s == nullptr, " if n is not zero");
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& assign(size_type __n, value_type __c);
 
   template <class _InputIterator, __enable_if_t<__has_exactly_input_iterator_category<_InputIterator>::value, int> = 0>
@@ -2759,6 +2765,13 @@ basic_string<_CharT, _Traits, _Allocator>::assign(const value_type* __s, size_ty
 
 template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>&
+basic_string<_CharT, _Traits, _Allocator>::assign(const value_type* __s, size_type __pos, size_type __n) {
+  _LIBCPP_ASSERT_NON_NULL(__n == 0 || __s != nullptr, "string::assign received nullptr");
+  return assign(__self_view(__s).substr(__pos, __n));
+}
+
+template <class _CharT, class _Traits, class _Allocator>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>&
 basic_string<_CharT, _Traits, _Allocator>::assign(size_type __n, value_type __c) {
   size_type __cap      = capacity();
   size_type __old_size = size();
@@ -3022,6 +3035,13 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>&
 basic_string<_CharT, _Traits, _Allocator>::append(const value_type* __s) {
   _LIBCPP_ASSERT_NON_NULL(__s != nullptr, "string::append received nullptr");
   return append(__s, traits_type::length(__s));
+}
+
+template <class _CharT, class _Traits, class _Allocator>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>&
+basic_string<_CharT, _Traits, _Allocator>::append(const value_type* __s, size_type __pos, size_type __n) {
+  _LIBCPP_ASSERT_NON_NULL(__n == 0 || __s != nullptr, "string::append received nullptr");
+  return append(__self_view(__s).substr(__pos, __n));
 }
 
 // insert

--- a/libcxx/test/libcxx/strings/basic.string/nonnull.verify.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/nonnull.verify.cpp
@@ -25,8 +25,12 @@ void func() {
   std::string str2(np, std::allocator<char>{}); // expected-warning {{null passed}}
   str2 = np;                                    // expected-warning {{null passed}}
   str2 += np;                                   // expected-warning {{null passed}}
+  str2.assign(np, 1);                           // expected-warning {{null passed}}
   str2.assign(np);                              // expected-warning {{null passed}}
+  str2.assign(np, 0, 1);                        // expected-warning {{null passed}}
+  str2.append(np, 1);                           // expected-warning {{null passed}}
   str2.append(np);                              // expected-warning {{null passed}}
+  str2.append(np, 0, 1);                        // expected-warning {{null passed}}
   str2.insert(0, np);                           // expected-warning {{null passed}}
   str2.find(np);                                // expected-warning {{null passed}}
   str2.rfind(np);                               // expected-warning {{null passed}}

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_append/pointer_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_append/pointer_size_size.pass.cpp
@@ -87,7 +87,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 
 int main(int, char**) {
   test();
-#if TEST_STD_VER > 17
+#if TEST_STD_VER >= 20
   static_assert(test());
 #endif
 

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_append/pointer_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_append/pointer_size_size.pass.cpp
@@ -10,13 +10,14 @@
 
 // constexpr basic_string& append(const charT* s, size_type pos, size_type n);
 
-#include <string>
-#include <stdexcept>
 #include <cassert>
+#include <stdexcept>
+#include <string>
 
-#include "test_macros.h"
-#include "min_allocator.h"
 #include "asan_testing.h"
+#include "min_allocator.h"
+#include "test_allocator.h"
+#include "test_macros.h"
 
 template <class S>
 TEST_CONSTEXPR_CXX20 void
@@ -67,7 +68,7 @@ TEST_CONSTEXPR_CXX20 void test_string() {
   test(S("123456789012345678901234567890"), "", 0, 0, S("123456789012345678901234567890"));
   test(S("123456789012345678901234567890"), "12345", 1, 3, S("123456789012345678901234567890234"));
   test(S("123456789012345678901234567890"),
-       "12345678901234567890",
+       "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
        5,
        10,
        S("1234567890123456789012345678906789012345"));
@@ -78,6 +79,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 #if TEST_STD_VER >= 11
   test_string<std::basic_string<char, std::char_traits<char>, min_allocator<char>>>();
   test_string<std::basic_string<char, std::char_traits<char>, safe_allocator<char>>>();
+  test_string<std::basic_string<char, std::char_traits<char>, limited_allocator<char, 96>>>();
 #endif
 
   return true;

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_append/pointer_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_append/pointer_size_size.pass.cpp
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <string>
+
+// constexpr basic_string& append(const charT* s, size_type pos, size_type n);
+
+#include <string>
+#include <stdexcept>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+template <class S>
+TEST_CONSTEXPR_CXX20 void
+test(S s, const typename S::value_type* str, typename S::size_type pos, typename S::size_type n, S expected) {
+  typename S::size_type str_len = S::traits_type::length(str);
+  if (pos <= str_len) {
+    s.append(str, pos, n);
+    LIBCPP_ASSERT(s.__invariants());
+    assert(s == expected);
+    LIBCPP_ASSERT(is_string_asan_correct(s));
+  }
+#ifndef TEST_HAS_NO_EXCEPTIONS
+  else if (!TEST_IS_CONSTANT_EVALUATED) {
+    try {
+      s.append(str, pos, n);
+      assert(false);
+    } catch (std::out_of_range&) {
+      assert(pos > str_len);
+    }
+  }
+#endif
+}
+
+template <class S>
+TEST_CONSTEXPR_CXX20 void test_string() {
+  test(S(), "", 0, 0, S());
+  test(S(), "", 1, 0, S("not happening"));
+  test(S(), "12345", 0, 3, S("123"));
+  test(S(), "12345", 1, 4, S("2345"));
+  test(S(), "12345", 3, 15, S("45"));
+  test(S(), "12345", 5, 15, S(""));
+  test(S(), "12345", 6, 15, S("not happening"));
+  test(S(), "12345678901234567890", 0, 0, S());
+  test(S(), "12345678901234567890", 1, 1, S("2"));
+  test(S(), "12345678901234567890", 2, 3, S("345"));
+  test(S(), "12345678901234567890", 12, 13, S("34567890"));
+  test(S(), "12345678901234567890", 21, 13, S("not happening"));
+
+  test(S("12345"), "", 0, 0, S("12345"));
+  test(S("12345"), "12345", 2, 2, S("1234534"));
+  test(S("12345"), "1234567890", 0, 100, S("123451234567890"));
+
+  test(S("12345678901234567890"), "", 0, 0, S("12345678901234567890"));
+  test(S("12345678901234567890"), "12345", 1, 3, S("12345678901234567890234"));
+  test(S("12345678901234567890"), "12345678901234567890", 5, 10, S("123456789012345678906789012345"));
+
+  // Starting from long string (no SSO)
+  test(S("123456789012345678901234567890"), "", 0, 0, S("123456789012345678901234567890"));
+  test(S("123456789012345678901234567890"), "12345", 1, 3, S("123456789012345678901234567890234"));
+  test(S("123456789012345678901234567890"),
+       "12345678901234567890",
+       5,
+       10,
+       S("1234567890123456789012345678906789012345"));
+}
+
+TEST_CONSTEXPR_CXX20 bool test() {
+  test_string<std::string>();
+#if TEST_STD_VER >= 11
+  test_string<std::basic_string<char, std::char_traits<char>, min_allocator<char>>>();
+  test_string<std::basic_string<char, std::char_traits<char>, safe_allocator<char>>>();
+#endif
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER > 17
+  static_assert(test());
+#endif
+
+  return 0;
+}

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/pointer_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/pointer_size_size.pass.cpp
@@ -74,7 +74,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 #if TEST_STD_VER >= 11
   test_string<std::basic_string<char, std::char_traits<char>, min_allocator<char>>>();
   test_string<std::basic_string<char, std::char_traits<char>, safe_allocator<char>>>();
-  test_string<std::basic_string<char, std::char_traits<char>, limited_allocator<char, 30>>>();
+  test_string<std::basic_string<char, std::char_traits<char>, limited_allocator<char, 33>>>();
 #endif
 
   return true;

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/pointer_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/pointer_size_size.pass.cpp
@@ -82,7 +82,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 
 int main(int, char**) {
   test();
-#if TEST_STD_VER > 17
+#if TEST_STD_VER >= 20
   static_assert(test());
 #endif
 

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/pointer_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/pointer_size_size.pass.cpp
@@ -10,13 +10,14 @@
 
 // constexpr basic_string& assign(const charT* s, size_type pos, size_type n);
 
-#include <string>
-#include <stdexcept>
 #include <cassert>
+#include <stdexcept>
+#include <string>
 
-#include "test_macros.h"
-#include "min_allocator.h"
 #include "asan_testing.h"
+#include "min_allocator.h"
+#include "test_allocator.h"
+#include "test_macros.h"
 
 template <class S>
 TEST_CONSTEXPR_CXX20 void
@@ -61,7 +62,11 @@ TEST_CONSTEXPR_CXX20 void test_string() {
 
   test(S("12345678901234567890"), "", 0, 0, S());
   test(S("12345678901234567890"), "12345", 1, 3, S("234"));
-  test(S("12345678901234567890"), "12345678901234567890", 5, 10, S("6789012345"));
+  test(S("12345678901234567890"),
+       "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
+       5,
+       10,
+       S("6789012345"));
 }
 
 TEST_CONSTEXPR_CXX20 bool test() {
@@ -69,6 +74,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 #if TEST_STD_VER >= 11
   test_string<std::basic_string<char, std::char_traits<char>, min_allocator<char>>>();
   test_string<std::basic_string<char, std::char_traits<char>, safe_allocator<char>>>();
+  test_string<std::basic_string<char, std::char_traits<char>, limited_allocator<char, 30>>>();
 #endif
 
   return true;

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/pointer_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_assign/pointer_size_size.pass.cpp
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <string>
+
+// constexpr basic_string& assign(const charT* s, size_type pos, size_type n);
+
+#include <string>
+#include <stdexcept>
+#include <cassert>
+
+#include "test_macros.h"
+#include "min_allocator.h"
+#include "asan_testing.h"
+
+template <class S>
+TEST_CONSTEXPR_CXX20 void
+test(S s, const typename S::value_type* str, typename S::size_type pos, typename S::size_type n, S expected) {
+  typename S::size_type str_len = S::traits_type::length(str);
+  if (pos <= str_len) {
+    s.assign(str, pos, n);
+    LIBCPP_ASSERT(s.__invariants());
+    assert(s == expected);
+    LIBCPP_ASSERT(is_string_asan_correct(s));
+  }
+#ifndef TEST_HAS_NO_EXCEPTIONS
+  else if (!TEST_IS_CONSTANT_EVALUATED) {
+    try {
+      s.assign(str, pos, n);
+      assert(false);
+    } catch (std::out_of_range&) {
+      assert(pos > str_len);
+    }
+  }
+#endif
+}
+
+template <class S>
+TEST_CONSTEXPR_CXX20 void test_string() {
+  test(S(), "", 0, 0, S());
+  test(S(), "", 1, 0, S("not happening"));
+  test(S(), "12345", 0, 3, S("123"));
+  test(S(), "12345", 1, 4, S("2345"));
+  test(S(), "12345", 3, 15, S("45"));
+  test(S(), "12345", 5, 15, S(""));
+  test(S(), "12345", 6, 15, S("not happening"));
+  test(S(), "12345678901234567890", 0, 0, S());
+  test(S(), "12345678901234567890", 1, 1, S("2"));
+  test(S(), "12345678901234567890", 2, 3, S("345"));
+  test(S(), "12345678901234567890", 12, 13, S("34567890"));
+  test(S(), "12345678901234567890", 21, 13, S("not happening"));
+
+  test(S("12345"), "", 0, 0, S());
+  test(S("12345"), "12345", 2, 2, S("34"));
+  test(S("12345"), "1234567890", 0, 100, S("1234567890"));
+
+  test(S("12345678901234567890"), "", 0, 0, S());
+  test(S("12345678901234567890"), "12345", 1, 3, S("234"));
+  test(S("12345678901234567890"), "12345678901234567890", 5, 10, S("6789012345"));
+}
+
+TEST_CONSTEXPR_CXX20 bool test() {
+  test_string<std::string>();
+#if TEST_STD_VER >= 11
+  test_string<std::basic_string<char, std::char_traits<char>, min_allocator<char>>>();
+  test_string<std::basic_string<char, std::char_traits<char>, safe_allocator<char>>>();
+#endif
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER > 17
+  static_assert(test());
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/189809

This patch implements LWG 3662 and adds the related functional and nonnull tests.