### PR TITLE
[lld][ELF] Account for `R_{RISCV,LARCH}_ALIGN` deltas when `--no-relax --emit-relocs`

### DIFF
--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -431,15 +431,60 @@ InputSectionBase *InputSection::getRelocatedSection() const {
 
 template <class ELFT, class RelTy>
 void InputSection::copyRelocations(Ctx &ctx, uint8_t *buf) {
-  bool linkerRelax =
+  const InputSectionBase *const sec = getRelocatedSection();
+
+  const bool linkerRelax =
       ctx.arg.relax && is_contained({EM_RISCV, EM_LOONGARCH}, ctx.arg.emachine);
+  const bool mayReAlign =
+      ctx.arg.emitRelocs &&
+      is_contained({EM_RISCV, EM_LOONGARCH}, ctx.arg.emachine) && sec->relaxAux;
   if (!ctx.arg.relocatable && (linkerRelax || ctx.arg.branchToBranch)) {
     // On LoongArch and RISC-V, relaxation might change relocations: copy
     // from internal ones that are updated by relaxation.
-    InputSectionBase *sec = getRelocatedSection();
     copyRelocations<ELFT, RelTy>(
         ctx, buf,
         llvm::make_range(sec->relocations.begin(), sec->relocations.end()));
+  } else if (!ctx.arg.relocatable && mayReAlign) {
+    // On LoongArch and RISC-V, even with --no-relax, R_{RISCV,LARCH}_ALIGN will
+    // still be processed by the pipeline for alignment requirements. Thus,
+    // these offsets must be accounted for.
+    SmallVector<std::pair<uint64_t, uint32_t>> alignDeltas;
+    std::optional<uint64_t> prevRawOffset;
+    for (const auto &[i, r] : enumerate(sec->relocations)) {
+      // See comments on RelaxAux::relocDeltas.
+      const uint64_t lastDelta = i ? sec->relaxAux->relocDeltas[i - 1] : 0;
+      const uint64_t rawOffset = r.offset + lastDelta;
+      if (!prevRawOffset.has_value() || rawOffset != prevRawOffset) {
+        alignDeltas.emplace_back(rawOffset, lastDelta);
+        prevRawOffset = rawOffset;
+      }
+    }
+
+    // Convert the raw relocations in the input section into Relocation objects
+    // suitable to be used by copyRelocations below.
+    struct MapRel {
+      const ObjFile<ELFT> &file;
+      const SmallVector<std::pair<uint64_t, uint32_t>> &alignDeltas;
+      Relocation operator()(const RelTy &rel) const {
+        auto it = llvm::upper_bound(
+            alignDeltas, rel.r_offset,
+            [](uint64_t val, const auto &entry) { return val < entry.first; });
+        const uint32_t delta =
+            it != alignDeltas.begin() ? std::prev(it)->second : 0;
+        // RelExpr is not used so set to a dummy value.
+        return Relocation{R_NONE, rel.getType(false), rel.r_offset - delta,
+                          getAddend<ELFT>(rel), &file.getRelocTargetSym(rel)};
+      }
+    };
+
+    using RawRels = ArrayRef<RelTy>;
+    using MapRelIter =
+        llvm::mapped_iterator<typename RawRels::iterator, MapRel>;
+    auto mapRel = MapRel{*getFile<ELFT>(), alignDeltas};
+    RawRels rawRels = getDataAs<RelTy>();
+    auto rels = llvm::make_range(MapRelIter(rawRels.begin(), mapRel),
+                                 MapRelIter(rawRels.end(), mapRel));
+    copyRelocations<ELFT, RelTy>(ctx, buf, rels);
   } else {
     // Convert the raw relocations in the input section into Relocation objects
     // suitable to be used by copyRelocations below.

--- a/lld/test/ELF/loongarch-no-relax-emit-relocs-align.s
+++ b/lld/test/ELF/loongarch-no-relax-emit-relocs-align.s
@@ -1,0 +1,55 @@
+# REQUIRES: loongarch
+## Test that --emit-relocs plus --no-relax produces correct offsets
+## when R_LARCH_ALIGN is in effect.
+
+# RUN: llvm-mc --filetype=obj --triple=loongarch32 --mattr=+relax %s -o %t.32.o
+# RUN: llvm-mc --filetype=obj --triple=loongarch64 --mattr=+relax --defsym ELF64=1 %s -o %t.64.o
+# RUN: ld.lld -Ttext=0x10000 --emit-relocs --no-relax %t.32.o -o %t.32
+# RUN: ld.lld -Ttext=0x10000 --emit-relocs --no-relax %t.64.o -o %t.64
+# RUN: llvm-objdump -dr %t.32 | FileCheck %s --check-prefixes=CHECK32
+# RUN: llvm-objdump -dr %t.64 | FileCheck %s --check-prefixes=CHECK64
+
+.text
+.globl _start
+_start:
+  .reloc ., R_LARCH_ALIGN, 0x4
+  nop
+  la.pcrel $a0, _start
+.ifdef ELF64
+  la.pcrel $a1, $t0, _start
+.endif
+  nop
+## For catching any trailing relocs
+  nop
+.size _start, .-_start
+
+# CHECK32:      00010000 <_start>:
+# CHECK32-NEXT:     pcaddu12i $a0, 0
+# CHECK32-NEXT:         R_LARCH_ALIGN *ABS*+0x4
+# CHECK32-NEXT:         R_LARCH_PCADD_HI20 _start
+# CHECK32-NEXT:         R_LARCH_RELAX *ABS*
+# CHECK32-NEXT:     addi.w $a0, $a0, 0
+# CHECK32-NEXT:         R_LARCH_PCADD_LO12
+# CHECK32-NEXT:         R_LARCH_RELAX *ABS*
+# CHECK32-NEXT:     nop
+# CHECK32-NEXT:     nop
+
+# CHECK64:      00010000 <_start>:
+# CHECK64-NEXT:     pcalau12i $a0, 0
+# CHECK64-NEXT:         R_LARCH_ALIGN *ABS*+0x4
+# CHECK64-NEXT:         R_LARCH_PCALA_HI20 _start
+# CHECK64-NEXT:         R_LARCH_RELAX *ABS*
+# CHECK64-NEXT:     addi.d $a0, $a0, 0
+# CHECK64-NEXT:         R_LARCH_PCALA_LO12 _start
+# CHECK64-NEXT:         R_LARCH_RELAX *ABS*
+# CHECK64-NEXT:     pcalau12i $a1, 0
+# CHECK64-NEXT:         R_LARCH_PCALA_HI20 _start
+# CHECK64-NEXT:     addi.d $t0, $zero, 0
+# CHECK64-NEXT:         R_LARCH_PCALA_LO12 _start
+# CHECK64-NEXT:     lu32i.d $t0, 0
+# CHECK64-NEXT:         R_LARCH_PCALA64_LO20 _start
+# CHECK64-NEXT:     lu52i.d $t0, $t0, 0
+# CHECK64-NEXT:         R_LARCH_PCALA64_HI12 _start
+# CHECK64-NEXT:     add.d $a1, $a1, $t0
+# CHECK64-NEXT:     nop
+# CHECK64-NEXT:     nop

--- a/lld/test/ELF/riscv-no-relax-emit-relocs-align.s
+++ b/lld/test/ELF/riscv-no-relax-emit-relocs-align.s
@@ -1,0 +1,45 @@
+# REQUIRES: riscv
+## Test that --emit-relocs plus --no-relax produces correct offsets
+## when R_RISCV_ALIGN is in effect.
+
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax %s -o %t.32.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+relax %s -o %t.64.o
+# RUN: ld.lld -Ttext=0x10000 --emit-relocs --no-relax %t.32.o -o %t.32
+# RUN: ld.lld -Ttext=0x10000 --emit-relocs --no-relax %t.64.o -o %t.64
+# RUN: llvm-objdump -dr --no-show-raw-insn -M no-aliases %t.32 | FileCheck %s --check-prefixes=CHECK32
+# RUN: llvm-objdump -dr --no-show-raw-insn -M no-aliases %t.64 | FileCheck %s --check-prefixes=CHECK64
+
+.text
+.globl _start
+_start:
+  .reloc ., R_RISCV_ALIGN, 0x4
+  nop
+.L1:
+  auipc a0, %pcrel_hi(_start)
+  addi a0, a0, %pcrel_lo(.L1)
+  nop
+## For catching any trailing relocs
+  nop
+.size _start, .-_start
+
+# CHECK32:      0000000000010000 <_start>:
+# CHECK32-NEXT:     auipc a0, 0x0
+# CHECK32-NEXT:         R_RISCV_ALIGN *ABS*+0x4
+# CHECK32-NEXT:         R_RISCV_PCREL_HI20 _start
+# CHECK32-NEXT:         R_RISCV_RELAX *ABS*
+# CHECK32-NEXT:     addi a0, a0, 0x0
+# CHECK32-NEXT:         R_RISCV_PCREL_LO12_I .L1
+# CHECK32-NEXT:         R_RISCV_RELAX *ABS*
+# CHECK32-NEXT:     addi zero, zero, 0x0
+# CHECK32-NEXT:     addi zero, zero, 0x0
+
+# CHECK64:      0000000000010000 <_start>:
+# CHECK64-NEXT:     auipc a0, 0x0
+# CHECK64-NEXT:         R_RISCV_ALIGN *ABS*+0x4
+# CHECK64-NEXT:         R_RISCV_PCREL_HI20 _start
+# CHECK64-NEXT:         R_RISCV_RELAX *ABS*
+# CHECK64-NEXT:     addi a0, a0, 0x0
+# CHECK64-NEXT:         R_RISCV_PCREL_LO12_I .L1
+# CHECK64-NEXT:         R_RISCV_RELAX *ABS*
+# CHECK64-NEXT:     addi zero, zero, 0x0
+# CHECK64-NEXT:     addi zero, zero, 0x0


### PR DESCRIPTION
This PR fixes drifting relocations on LoongArch and RISCV lld when linking with `--emit-relocs --no-relax` by adjusting raw relocation offsets for the delta of bytes consumed by alignment.

One point to note is that, in the new `mayReAlign` path, the creation of each new relocation needs to undergo `llvm::upper_bound()`, which may make linking slower. However, I'm not sure whether `--emit-relocs` is commonly used, and whether the impact is measurable or broad-ish.

Fixes #206318.

---
**v2** (90cbd711fca973a293837b93fd7394a9b6cb6453):
- Use current location instead of constants in `.reloc` directives 