### PR TITLE
[OpenMP][OMPT] Correctly pass `parallel_data` for serial league

### DIFF
--- a/openmp/runtime/src/kmp_runtime.cpp
+++ b/openmp/runtime/src/kmp_runtime.cpp
@@ -1805,6 +1805,9 @@ __kmp_serial_fork_call(ident_t *loc, int gtid, enum fork_context_e call_context,
     } else if (microtask == (microtask_t)__kmp_teams_master) {
       KMP_DEBUG_ASSERT(master_th->th.th_team == master_th->th.th_serial_team);
       team = master_th->th.th_team;
+#if OMPT_SUPPORT
+      __ompt_team_assign_id(team, *ompt_parallel_data);
+#endif
       // team->t.t_pkfn = microtask;
       team->t.t_invoke = invoker;
       __kmp_alloc_argv_entries(argc, team, TRUE);

--- a/openmp/runtime/test/ompt/callback.h
+++ b/openmp/runtime/test/ompt/callback.h
@@ -682,7 +682,8 @@ static void on_ompt_callback_implicit_task(ompt_scope_endpoint_t endpoint,
       // Only check initial task not created by teams construct
       if (team_size == 1 && thread_num == 1 && parallel_data->ptr)
         printf("%s\n", "0: parallel_data initially not null");
-      parallel_data->value = ompt_get_unique_id();
+      if (!parallel_data->value)
+        parallel_data->value = ompt_get_unique_id();
       printf("%" PRIu64 ":" _TOOL_PREFIX
              " ompt_event_initial_task_begin: parallel_id=%" PRIx64
              ", task_id=%" PRIx64 ", actual_parallelism=%" PRIu32

--- a/openmp/runtime/test/ompt/teams/serialized.c
+++ b/openmp/runtime/test/ompt/teams/serialized.c
@@ -27,12 +27,13 @@ int main() {
 
 // CHECK: {{^}}[[MASTER]]: ompt_event_teams_begin:
 // CHECK-SAME: parent_task_id=[[INIT_TASK]]
+// CHECK-SAME: {{.*}} parallel_id=[[TEAMS_ID:[0-9]+]]
 // CHECK-SAME: {{.*}} requested_num_teams=1
 // CHECK-SAME: {{.*}} invoker=[[TEAMS_FLAGS:[0-9]+]]
 
 // initial task in the teams construct starts
 // CHECK: {{^}}[[MASTER]]: ompt_event_initial_task_begin:
-// CHECK-SAME: task_id=[[INIT_TASK_0:[0-f]+]], actual_parallelism=1, index=0
+// CHECK-SAME: parallel_id=[[TEAMS_ID]], task_id=[[INIT_TASK_0:[0-f]+]], actual_parallelism=1, index=0
 
 // parallel region forked by runtime
 // CHECK: {{^}}[[MASTER]]: ompt_event_parallel_begin:


### PR DESCRIPTION
Per OpenMP specification, the `teams` construct largely dispatches the same event sequence dispatched by the `parallel` construct. On _teams-begin_, a `parallel_begin` callback with `(flags & ompt_parallel_league)` is dispatched. Following that, an `implicit_task` callback with `(flags & ompt_task_initial)` and, starting with OpenMP v6.0, `(flags & ompt_task_implicit)` evaluating to true is dispatched.

For the `implicit_task` callback, the `parallel_data` set during `parallel_begin` should get passed, regardless of the actual number of teams in the created league.
However, in #64734, it was found that this is not the case when only a single team is created.

This is due to the `parallel_data` assignment happening during `__kmp_allocate_team`, which is skipped for serial leagues. Serial parallel regions call `__ompt_lw_taskteam_init` during `__kmp_serial_fork_call`. However, serial leagues branch differently in the same function, hence were missing an assignment of the `parallel_data` at all.
To fix the issue, add a call to `__ompt_team_assign_id` for serial leagues, passing the `parallel_data`.

To ensure that this fixes the issue, adapt the serialized team test to check if the `parallel_data` matches for `parallel_begin` and the following `implicit_task` callback.
This needs a slight adaption in the OMPT test header, since it was setting `parallel_data` during `implicit_task_begin` for _any_ `initial_task`, which should have only been set if no `parallel_data` was set beforehand.

Closes #64734