### PR TITLE
[AMDGPU][GlobalISel] Improve odd size s16 vector store legalization

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -1575,6 +1575,19 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
     return false;
   };
 
+  const auto isOddS16VectorStore = [=](const LegalityQuery &Query,
+                                       bool IsStore) -> bool {
+    const LLT DstTy = Query.Types[0];
+    const LLT MemTy = Query.MMODescrs[0].MemoryTy;
+
+    if (IsStore && DstTy.isVector() && DstTy == MemTy &&
+        DstTy.getElementType().getSizeInBits() == 16 &&
+        DstTy.getNumElements() % 2 != 0)
+      return true;
+
+    return false;
+  };
+
   unsigned GlobalAlign32 = ST.hasUnalignedBufferAccessEnabled() ? 0 : 32;
   unsigned GlobalAlign16 = ST.hasUnalignedBufferAccessEnabled() ? 0 : 16;
   unsigned GlobalAlign8 = ST.hasUnalignedBufferAccessEnabled() ? 0 : 8;
@@ -1699,7 +1712,8 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
         .fewerElementsIf(
             [=](const LegalityQuery &Query) -> bool {
               return Query.Types[0].isVector() &&
-                     needToSplitMemOp(Query, Op == G_LOAD);
+                     (needToSplitMemOp(Query, Op == G_LOAD) ||
+                      isOddS16VectorStore(Query, IsStore));
             },
             [=](const LegalityQuery &Query) -> std::pair<unsigned, LLT> {
               const LLT DstTy = Query.Types[0];

--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -1580,12 +1580,9 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
     const LLT DstTy = Query.Types[0];
     const LLT MemTy = Query.MMODescrs[0].MemoryTy;
 
-    if (IsStore && DstTy.isVector() && DstTy == MemTy &&
-        DstTy.getElementType().getSizeInBits() == 16 &&
-        DstTy.getNumElements() % 2 != 0)
-      return true;
-
-    return false;
+    return IsStore && DstTy == MemTy &&
+           DstTy.getElementType().getSizeInBits() == 16 &&
+           DstTy.getNumElements() % 2 != 0;
   };
 
   unsigned GlobalAlign32 = ST.hasUnalignedBufferAccessEnabled() ? 0 : 32;

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/add.vni16.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/add.vni16.ll
@@ -21,22 +21,20 @@ define void @add_v3i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb, ptr addrs
 ; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v3, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v6, vcc, 4, v2
 ; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, 0, v3, vcc
-; GFX8-NEXT:    flat_load_ushort v11, v[2:3]
-; GFX8-NEXT:    flat_load_ushort v12, v[0:1]
-; GFX8-NEXT:    flat_load_ushort v6, v[6:7]
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 2, v4
+; GFX8-NEXT:    flat_load_ushort v2, v[2:3]
+; GFX8-NEXT:    flat_load_ushort v3, v[6:7]
+; GFX8-NEXT:    flat_load_ushort v6, v[0:1]
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 4, v4
 ; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v5, vcc
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 4, v4
-; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, 0, v5, vcc
 ; GFX8-NEXT:    s_waitcnt vmcnt(2)
-; GFX8-NEXT:    v_add_u16_e32 v7, v8, v11
+; GFX8-NEXT:    v_add_u16_e32 v2, v8, v2
 ; GFX8-NEXT:    s_waitcnt vmcnt(1)
-; GFX8-NEXT:    v_add_u16_e32 v8, v9, v12
+; GFX8-NEXT:    v_add_u16_e32 v3, v10, v3
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_add_u16_e32 v6, v10, v6
-; GFX8-NEXT:    flat_store_short v[4:5], v7
-; GFX8-NEXT:    flat_store_short v[0:1], v8
-; GFX8-NEXT:    flat_store_short v[2:3], v6
+; GFX8-NEXT:    v_add_u16_sdwa v6, v9, v6 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX8-NEXT:    v_or_b32_e32 v2, v2, v6
+; GFX8-NEXT:    flat_store_dword v[4:5], v2
+; GFX8-NEXT:    flat_store_short v[0:1], v3
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -65,8 +63,7 @@ define void @add_v3i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb, ptr addrs
 ; GFX9-NEXT:    v_lshl_or_b32 v3, s4, 16, v3
 ; GFX9-NEXT:    v_pk_add_u16 v0, v0, v2
 ; GFX9-NEXT:    v_pk_add_u16 v1, v1, v3
-; GFX9-NEXT:    global_store_short v[4:5], v0, off
-; GFX9-NEXT:    global_store_short_d16_hi v[4:5], v0, off offset:2
+; GFX9-NEXT:    global_store_dword v[4:5], v0, off
 ; GFX9-NEXT:    global_store_short v[4:5], v1, off offset:4
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -179,34 +176,27 @@ define void @add_v5i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb, ptr addrs
 ; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v3, vcc
 ; GFX8-NEXT:    v_add_u32_e32 v10, vcc, 8, v2
 ; GFX8-NEXT:    v_addc_u32_e32 v11, vcc, 0, v3, vcc
-; GFX8-NEXT:    flat_load_ushort v17, v[2:3]
-; GFX8-NEXT:    flat_load_ushort v18, v[0:1]
-; GFX8-NEXT:    flat_load_ushort v19, v[6:7]
-; GFX8-NEXT:    flat_load_ushort v20, v[8:9]
-; GFX8-NEXT:    flat_load_ushort v10, v[10:11]
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 2, v4
+; GFX8-NEXT:    flat_load_ushort v2, v[2:3]
+; GFX8-NEXT:    flat_load_ushort v3, v[10:11]
+; GFX8-NEXT:    flat_load_ushort v10, v[0:1]
+; GFX8-NEXT:    flat_load_ushort v6, v[6:7]
+; GFX8-NEXT:    flat_load_ushort v7, v[8:9]
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 8, v4
 ; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v5, vcc
-; GFX8-NEXT:    v_add_u32_e32 v2, vcc, 4, v4
-; GFX8-NEXT:    v_addc_u32_e32 v3, vcc, 0, v5, vcc
-; GFX8-NEXT:    v_add_u32_e32 v6, vcc, 6, v4
-; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, 0, v5, vcc
-; GFX8-NEXT:    v_add_u32_e32 v8, vcc, 8, v4
-; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v5, vcc
 ; GFX8-NEXT:    s_waitcnt vmcnt(4)
-; GFX8-NEXT:    v_add_u16_e32 v11, v12, v17
+; GFX8-NEXT:    v_add_u16_e32 v2, v12, v2
 ; GFX8-NEXT:    s_waitcnt vmcnt(3)
-; GFX8-NEXT:    v_add_u16_e32 v12, v13, v18
+; GFX8-NEXT:    v_add_u16_e32 v8, v16, v3
 ; GFX8-NEXT:    s_waitcnt vmcnt(2)
-; GFX8-NEXT:    v_add_u16_e32 v13, v14, v19
+; GFX8-NEXT:    v_add_u16_sdwa v3, v13, v10 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
 ; GFX8-NEXT:    s_waitcnt vmcnt(1)
-; GFX8-NEXT:    v_add_u16_e32 v14, v15, v20
+; GFX8-NEXT:    v_add_u16_e32 v6, v14, v6
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_add_u16_e32 v10, v16, v10
-; GFX8-NEXT:    flat_store_short v[4:5], v11
-; GFX8-NEXT:    flat_store_short v[0:1], v12
-; GFX8-NEXT:    flat_store_short v[2:3], v13
-; GFX8-NEXT:    flat_store_short v[6:7], v14
-; GFX8-NEXT:    flat_store_short v[8:9], v10
+; GFX8-NEXT:    v_add_u16_sdwa v7, v15, v7 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX8-NEXT:    v_or_b32_e32 v2, v2, v3
+; GFX8-NEXT:    v_or_b32_e32 v3, v6, v7
+; GFX8-NEXT:    flat_store_dwordx2 v[4:5], v[2:3]
+; GFX8-NEXT:    flat_store_short v[0:1], v8
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -241,17 +231,14 @@ define void @add_v5i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb, ptr addrs
 ; GFX9-NEXT:    v_lshl_or_b32 v1, v13, 16, v1
 ; GFX9-NEXT:    s_waitcnt vmcnt(1)
 ; GFX9-NEXT:    v_lshl_or_b32 v3, v14, 16, v3
-; GFX9-NEXT:    v_lshl_or_b32 v2, s4, 16, v2
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    v_lshl_or_b32 v6, v15, 16, v6
+; GFX9-NEXT:    v_lshl_or_b32 v2, s4, 16, v2
 ; GFX9-NEXT:    v_lshl_or_b32 v7, s4, 16, v7
 ; GFX9-NEXT:    v_pk_add_u16 v0, v0, v3
 ; GFX9-NEXT:    v_pk_add_u16 v1, v1, v6
 ; GFX9-NEXT:    v_pk_add_u16 v2, v2, v7
-; GFX9-NEXT:    global_store_short v[4:5], v0, off
-; GFX9-NEXT:    global_store_short_d16_hi v[4:5], v0, off offset:2
-; GFX9-NEXT:    global_store_short v[4:5], v1, off offset:4
-; GFX9-NEXT:    global_store_short_d16_hi v[4:5], v1, off offset:6
+; GFX9-NEXT:    global_store_dwordx2 v[4:5], v[0:1], off
 ; GFX9-NEXT:    global_store_short v[4:5], v2, off offset:8
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -387,43 +374,34 @@ define void @addv_7i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb, ptr addrs
 ; GFX8-NEXT:    v_add_u32_e32 v14, vcc, 12, v2
 ; GFX8-NEXT:    v_addc_u32_e32 v15, vcc, 0, v3, vcc
 ; GFX8-NEXT:    flat_load_ushort v2, v[2:3]
-; GFX8-NEXT:    flat_load_ushort v3, v[0:1]
+; GFX8-NEXT:    flat_load_ushort v3, v[14:15]
+; GFX8-NEXT:    flat_load_ushort v14, v[0:1]
 ; GFX8-NEXT:    flat_load_ushort v6, v[6:7]
 ; GFX8-NEXT:    flat_load_ushort v7, v[8:9]
 ; GFX8-NEXT:    flat_load_ushort v8, v[10:11]
 ; GFX8-NEXT:    flat_load_ushort v9, v[12:13]
-; GFX8-NEXT:    flat_load_ushort v10, v[14:15]
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 2, v4
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 8, v4
 ; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v5, vcc
 ; GFX8-NEXT:    s_waitcnt vmcnt(6)
 ; GFX8-NEXT:    v_add_u16_e32 v2, v16, v2
 ; GFX8-NEXT:    s_waitcnt vmcnt(5)
-; GFX8-NEXT:    v_add_u16_e32 v3, v17, v3
-; GFX8-NEXT:    flat_store_short v[4:5], v2
-; GFX8-NEXT:    flat_store_short v[0:1], v3
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 4, v4
-; GFX8-NEXT:    s_waitcnt vmcnt(6)
+; GFX8-NEXT:    v_add_u16_e32 v10, v22, v3
+; GFX8-NEXT:    s_waitcnt vmcnt(4)
+; GFX8-NEXT:    v_add_u16_sdwa v3, v17, v14 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX8-NEXT:    s_waitcnt vmcnt(3)
 ; GFX8-NEXT:    v_add_u16_e32 v6, v18, v6
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v5, vcc
-; GFX8-NEXT:    flat_store_short v[0:1], v6
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 6, v4
-; GFX8-NEXT:    s_waitcnt vmcnt(6)
-; GFX8-NEXT:    v_add_u16_e32 v7, v19, v7
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v5, vcc
-; GFX8-NEXT:    flat_store_short v[0:1], v7
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 8, v4
-; GFX8-NEXT:    s_waitcnt vmcnt(6)
+; GFX8-NEXT:    s_waitcnt vmcnt(2)
+; GFX8-NEXT:    v_add_u16_sdwa v7, v19, v7 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX8-NEXT:    s_waitcnt vmcnt(1)
 ; GFX8-NEXT:    v_add_u16_e32 v8, v20, v8
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v5, vcc
-; GFX8-NEXT:    flat_store_short v[0:1], v8
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 10, v4
-; GFX8-NEXT:    s_waitcnt vmcnt(6)
-; GFX8-NEXT:    v_add_u16_e32 v9, v21, v9
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v5, vcc
-; GFX8-NEXT:    flat_store_short v[0:1], v9
+; GFX8-NEXT:    s_waitcnt vmcnt(0)
+; GFX8-NEXT:    v_add_u16_sdwa v9, v21, v9 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX8-NEXT:    v_or_b32_e32 v2, v2, v3
+; GFX8-NEXT:    v_or_b32_e32 v3, v6, v7
+; GFX8-NEXT:    v_or_b32_e32 v6, v8, v9
+; GFX8-NEXT:    flat_store_dwordx2 v[4:5], v[2:3]
+; GFX8-NEXT:    flat_store_dword v[0:1], v6
 ; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 12, v4
-; GFX8-NEXT:    s_waitcnt vmcnt(6)
-; GFX8-NEXT:    v_add_u16_e32 v10, v22, v10
 ; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v5, vcc
 ; GFX8-NEXT:    flat_store_short v[0:1], v10
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
@@ -470,22 +448,17 @@ define void @addv_7i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb, ptr addrs
 ; GFX9-NEXT:    v_lshl_or_b32 v2, v16, 16, v2
 ; GFX9-NEXT:    s_waitcnt vmcnt(2)
 ; GFX9-NEXT:    v_lshl_or_b32 v6, v17, 16, v6
-; GFX9-NEXT:    v_lshl_or_b32 v3, s4, 16, v3
 ; GFX9-NEXT:    s_waitcnt vmcnt(1)
 ; GFX9-NEXT:    v_lshl_or_b32 v7, v18, 16, v7
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    v_lshl_or_b32 v8, v19, 16, v8
+; GFX9-NEXT:    v_lshl_or_b32 v3, s4, 16, v3
 ; GFX9-NEXT:    v_lshl_or_b32 v9, s4, 16, v9
 ; GFX9-NEXT:    v_pk_add_u16 v0, v0, v6
 ; GFX9-NEXT:    v_pk_add_u16 v1, v1, v7
 ; GFX9-NEXT:    v_pk_add_u16 v2, v2, v8
 ; GFX9-NEXT:    v_pk_add_u16 v3, v3, v9
-; GFX9-NEXT:    global_store_short v[4:5], v0, off
-; GFX9-NEXT:    global_store_short_d16_hi v[4:5], v0, off offset:2
-; GFX9-NEXT:    global_store_short v[4:5], v1, off offset:4
-; GFX9-NEXT:    global_store_short_d16_hi v[4:5], v1, off offset:6
-; GFX9-NEXT:    global_store_short v[4:5], v2, off offset:8
-; GFX9-NEXT:    global_store_short_d16_hi v[4:5], v2, off offset:10
+; GFX9-NEXT:    global_store_dwordx3 v[4:5], v[0:2], off
 ; GFX9-NEXT:    global_store_short v[4:5], v3, off offset:12
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -701,39 +674,37 @@ define void @add_v11i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb, ptr addr
 ; GFX8-NEXT:    s_waitcnt vmcnt(3)
 ; GFX8-NEXT:    v_add_u16_e32 v17, v6, v10
 ; GFX8-NEXT:    v_add_u16_sdwa v10, v6, v10 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
-; GFX8-NEXT:    v_add_u32_e32 v6, vcc, 18, v0
+; GFX8-NEXT:    v_add_u32_e32 v6, vcc, 20, v0
 ; GFX8-NEXT:    v_add_u16_e32 v18, v7, v11
 ; GFX8-NEXT:    v_add_u16_sdwa v11, v7, v11 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, 0, v1, vcc
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 20, v0
-; GFX8-NEXT:    flat_load_ushort v2, v[2:3]
-; GFX8-NEXT:    flat_load_ushort v3, v[6:7]
+; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 18, v0
 ; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; GFX8-NEXT:    flat_load_ushort v21, v[0:1]
-; GFX8-NEXT:    v_add_u32_e32 v6, vcc, 16, v4
-; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, 0, v5, vcc
+; GFX8-NEXT:    flat_load_ushort v22, v[2:3]
+; GFX8-NEXT:    flat_load_ushort v23, v[0:1]
+; GFX8-NEXT:    flat_load_ushort v21, v[6:7]
 ; GFX8-NEXT:    v_add_u16_e32 v19, v8, v12
 ; GFX8-NEXT:    v_add_u16_sdwa v12, v8, v12 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
-; GFX8-NEXT:    v_add_u32_e32 v8, vcc, 18, v4
 ; GFX8-NEXT:    v_add_u16_e32 v20, v9, v13
 ; GFX8-NEXT:    v_add_u16_sdwa v13, v9, v13 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
-; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v5, vcc
+; GFX8-NEXT:    v_add_u32_e32 v6, vcc, 16, v4
+; GFX8-NEXT:    v_addc_u32_e32 v7, vcc, 0, v5, vcc
 ; GFX8-NEXT:    v_or_b32_e32 v0, v17, v10
 ; GFX8-NEXT:    v_or_b32_e32 v1, v18, v11
-; GFX8-NEXT:    v_add_u32_e32 v10, vcc, 20, v4
-; GFX8-NEXT:    v_addc_u32_e32 v11, vcc, 0, v5, vcc
-; GFX8-NEXT:    s_waitcnt vmcnt(2)
-; GFX8-NEXT:    v_add_u16_e32 v14, v2, v14
-; GFX8-NEXT:    s_waitcnt vmcnt(1)
-; GFX8-NEXT:    v_add_u16_e32 v15, v3, v15
 ; GFX8-NEXT:    v_or_b32_e32 v2, v19, v12
 ; GFX8-NEXT:    v_or_b32_e32 v3, v20, v13
-; GFX8-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-NEXT:    v_add_u16_e32 v16, v21, v16
+; GFX8-NEXT:    v_add_u32_e32 v8, vcc, 20, v4
 ; GFX8-NEXT:    flat_store_dwordx4 v[4:5], v[0:3]
-; GFX8-NEXT:    flat_store_short v[6:7], v14
-; GFX8-NEXT:    flat_store_short v[8:9], v15
-; GFX8-NEXT:    flat_store_short v[10:11], v16
+; GFX8-NEXT:    v_addc_u32_e32 v9, vcc, 0, v5, vcc
+; GFX8-NEXT:    s_waitcnt vmcnt(3)
+; GFX8-NEXT:    v_add_u16_e32 v11, v22, v14
+; GFX8-NEXT:    s_waitcnt vmcnt(2)
+; GFX8-NEXT:    v_add_u16_sdwa v12, v23, v15 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX8-NEXT:    v_or_b32_e32 v0, v11, v12
+; GFX8-NEXT:    s_waitcnt vmcnt(1)
+; GFX8-NEXT:    v_add_u16_e32 v10, v21, v16
+; GFX8-NEXT:    flat_store_dword v[6:7], v0
+; GFX8-NEXT:    flat_store_short v[8:9], v10
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -771,8 +742,7 @@ define void @add_v11i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb, ptr addr
 ; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    v_pk_add_u16 v0, v6, v8
 ; GFX9-NEXT:    v_pk_add_u16 v1, v7, v9
-; GFX9-NEXT:    global_store_short v[4:5], v0, off offset:16
-; GFX9-NEXT:    global_store_short_d16_hi v[4:5], v0, off offset:18
+; GFX9-NEXT:    global_store_dword v[4:5], v0, off offset:16
 ; GFX9-NEXT:    global_store_short v[4:5], v1, off offset:20
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-store-global.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-store-global.mir
@@ -12155,3 +12155,131 @@ body: |
     %4:_(<9 x s32>) = G_CONCAT_VECTORS %1, %2, %3
     G_STORE %4, %0 :: (store (<9 x s32>), align 16, addrspace 1)
 ...
+
+---
+name: test_store_global_v3s16_align4
+body: |
+  bb.0:
+    liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
+
+    ; SI-LABEL: name: test_store_global_v3s16_align4
+    ; SI: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
+    ; SI-NEXT: {{  $}}
+    ; SI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
+    ; SI-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
+    ; SI-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY1]](<2 x s16>)
+    ; SI-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $vgpr2
+    ; SI-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr3
+    ; SI-NEXT: [[MV:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
+    ; SI-NEXT: G_STORE [[COPY]](<2 x s16>), [[MV]](p1) :: (store (<2 x s16>), addrspace 1)
+    ; SI-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; SI-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[MV]], [[C]](s64)
+    ; SI-NEXT: G_STORE [[BITCAST]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 4, align 4, addrspace 1)
+    ;
+    ; CI-LABEL: name: test_store_global_v3s16_align4
+    ; CI: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
+    ; CI-NEXT: {{  $}}
+    ; CI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
+    ; CI-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
+    ; CI-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY1]](<2 x s16>)
+    ; CI-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $vgpr2
+    ; CI-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr3
+    ; CI-NEXT: [[MV:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
+    ; CI-NEXT: G_STORE [[COPY]](<2 x s16>), [[MV]](p1) :: (store (<2 x s16>), addrspace 1)
+    ; CI-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; CI-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[MV]], [[C]](s64)
+    ; CI-NEXT: G_STORE [[BITCAST]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 4, align 4, addrspace 1)
+    ;
+    ; VI-LABEL: name: test_store_global_v3s16_align4
+    ; VI: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
+    ; VI-NEXT: {{  $}}
+    ; VI-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
+    ; VI-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
+    ; VI-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY1]](<2 x s16>)
+    ; VI-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $vgpr2
+    ; VI-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr3
+    ; VI-NEXT: [[MV:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
+    ; VI-NEXT: G_STORE [[COPY]](<2 x s16>), [[MV]](p1) :: (store (<2 x s16>), addrspace 1)
+    ; VI-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; VI-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[MV]], [[C]](s64)
+    ; VI-NEXT: G_STORE [[BITCAST]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 4, align 4, addrspace 1)
+    ;
+    ; GFX9-LABEL: name: test_store_global_v3s16_align4
+    ; GFX9: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
+    ; GFX9-NEXT: {{  $}}
+    ; GFX9-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
+    ; GFX9-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
+    ; GFX9-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY1]](<2 x s16>)
+    ; GFX9-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $vgpr2
+    ; GFX9-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr3
+    ; GFX9-NEXT: [[MV:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
+    ; GFX9-NEXT: G_STORE [[COPY]](<2 x s16>), [[MV]](p1) :: (store (<2 x s16>), addrspace 1)
+    ; GFX9-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; GFX9-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[MV]], [[C]](s64)
+    ; GFX9-NEXT: G_STORE [[BITCAST]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 4, align 4, addrspace 1)
+    ;
+    ; GFX11-TRUE16-LABEL: name: test_store_global_v3s16_align4
+    ; GFX11-TRUE16: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
+    ; GFX11-TRUE16-NEXT: {{  $}}
+    ; GFX11-TRUE16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
+    ; GFX11-TRUE16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
+    ; GFX11-TRUE16-NEXT: [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY1]](<2 x s16>)
+    ; GFX11-TRUE16-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $vgpr2
+    ; GFX11-TRUE16-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr3
+    ; GFX11-TRUE16-NEXT: [[MV:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
+    ; GFX11-TRUE16-NEXT: G_STORE [[COPY]](<2 x s16>), [[MV]](p1) :: (store (<2 x s16>), addrspace 1)
+    ; GFX11-TRUE16-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; GFX11-TRUE16-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[MV]], [[C]](s64)
+    ; GFX11-TRUE16-NEXT: G_STORE [[UV]](s16), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 4, align 4, addrspace 1)
+    ;
+    ; GFX11-FAKE16-LABEL: name: test_store_global_v3s16_align4
+    ; GFX11-FAKE16: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
+    ; GFX11-FAKE16-NEXT: {{  $}}
+    ; GFX11-FAKE16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
+    ; GFX11-FAKE16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
+    ; GFX11-FAKE16-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY1]](<2 x s16>)
+    ; GFX11-FAKE16-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $vgpr2
+    ; GFX11-FAKE16-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr3
+    ; GFX11-FAKE16-NEXT: [[MV:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
+    ; GFX11-FAKE16-NEXT: G_STORE [[COPY]](<2 x s16>), [[MV]](p1) :: (store (<2 x s16>), addrspace 1)
+    ; GFX11-FAKE16-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; GFX11-FAKE16-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[MV]], [[C]](s64)
+    ; GFX11-FAKE16-NEXT: G_STORE [[BITCAST]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 4, align 4, addrspace 1)
+    ;
+    ; GFX12-TRUE16-LABEL: name: test_store_global_v3s16_align4
+    ; GFX12-TRUE16: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
+    ; GFX12-TRUE16-NEXT: {{  $}}
+    ; GFX12-TRUE16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
+    ; GFX12-TRUE16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
+    ; GFX12-TRUE16-NEXT: [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[COPY1]](<2 x s16>)
+    ; GFX12-TRUE16-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $vgpr2
+    ; GFX12-TRUE16-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr3
+    ; GFX12-TRUE16-NEXT: [[MV:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
+    ; GFX12-TRUE16-NEXT: G_STORE [[COPY]](<2 x s16>), [[MV]](p1) :: (store (<2 x s16>), addrspace 1)
+    ; GFX12-TRUE16-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; GFX12-TRUE16-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[MV]], [[C]](s64)
+    ; GFX12-TRUE16-NEXT: G_STORE [[UV]](s16), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 4, align 4, addrspace 1)
+    ;
+    ; GFX12-FAKE16-LABEL: name: test_store_global_v3s16_align4
+    ; GFX12-FAKE16: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
+    ; GFX12-FAKE16-NEXT: {{  $}}
+    ; GFX12-FAKE16-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
+    ; GFX12-FAKE16-NEXT: [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
+    ; GFX12-FAKE16-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY1]](<2 x s16>)
+    ; GFX12-FAKE16-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $vgpr2
+    ; GFX12-FAKE16-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr3
+    ; GFX12-FAKE16-NEXT: [[MV:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
+    ; GFX12-FAKE16-NEXT: G_STORE [[COPY]](<2 x s16>), [[MV]](p1) :: (store (<2 x s16>), addrspace 1)
+    ; GFX12-FAKE16-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
+    ; GFX12-FAKE16-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[MV]], [[C]](s64)
+    ; GFX12-FAKE16-NEXT: G_STORE [[BITCAST]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 4, align 4, addrspace 1)
+    %2:_(<2 x s16>) = COPY $vgpr0
+    %3:_(<2 x s16>) = COPY $vgpr1
+    %4:_(<4 x s16>) = G_CONCAT_VECTORS %2:_(<2 x s16>), %3:_(<2 x s16>)
+    %5:_(s16), %6:_(s16), %7:_(s16), %8:_(s16) = G_UNMERGE_VALUES %4:_(<4 x s16>)
+    %0:_(<3 x s16>) = G_BUILD_VECTOR %5:_(s16), %6:_(s16), %7:_(s16)
+    %9:_(s32) = COPY $vgpr2
+    %10:_(s32) = COPY $vgpr3
+    %1:_(p1) = G_MERGE_VALUES %9:_(s32), %10:_(s32)
+    G_STORE %0:_(<3 x s16>), %1:_(p1) :: (store (<3 x s16>), align 4, addrspace 1)
+...

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-store-global.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-store-global.mir
@@ -8443,14 +8443,14 @@ body: |
     ; SI-NEXT: G_STORE [[BITCAST4]](<4 x s32>), [[COPY]](p1) :: (store (<4 x s32>), addrspace 1)
     ; SI-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
     ; SI-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[COPY]], [[C2]](s64)
-    ; SI-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; SI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 16, align 16, addrspace 1)
-    ; SI-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; SI-NEXT: [[SHL4:%[0-9]+]]:_(s32) = G_SHL [[C]], [[C1]](s32)
+    ; SI-NEXT: [[OR4:%[0-9]+]]:_(s32) = G_OR [[C]], [[SHL4]]
+    ; SI-NEXT: [[BITCAST5:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR4]](s32)
+    ; SI-NEXT: G_STORE [[BITCAST5]](<2 x s16>), [[PTR_ADD]](p1) :: (store (<2 x s16>) into unknown-address + 16, align 16, addrspace 1)
+    ; SI-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
     ; SI-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C3]](s64)
-    ; SI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 18, addrspace 1)
-    ; SI-NEXT: [[C4:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
-    ; SI-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C4]](s64)
-    ; SI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD2]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
+    ; SI-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
+    ; SI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
     ;
     ; CI-LABEL: name: test_store_global_v11s16_align4
     ; CI: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5_vgpr6
@@ -8475,14 +8475,14 @@ body: |
     ; CI-NEXT: G_STORE [[BITCAST4]](<4 x s32>), [[COPY]](p1) :: (store (<4 x s32>), addrspace 1)
     ; CI-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
     ; CI-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[COPY]], [[C2]](s64)
-    ; CI-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; CI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 16, align 16, addrspace 1)
-    ; CI-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; CI-NEXT: [[SHL4:%[0-9]+]]:_(s32) = G_SHL [[C]], [[C1]](s32)
+    ; CI-NEXT: [[OR4:%[0-9]+]]:_(s32) = G_OR [[C]], [[SHL4]]
+    ; CI-NEXT: [[BITCAST5:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR4]](s32)
+    ; CI-NEXT: G_STORE [[BITCAST5]](<2 x s16>), [[PTR_ADD]](p1) :: (store (<2 x s16>) into unknown-address + 16, align 16, addrspace 1)
+    ; CI-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
     ; CI-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C3]](s64)
-    ; CI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 18, addrspace 1)
-    ; CI-NEXT: [[C4:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
-    ; CI-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C4]](s64)
-    ; CI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD2]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
+    ; CI-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
+    ; CI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
     ;
     ; VI-LABEL: name: test_store_global_v11s16_align4
     ; VI: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5_vgpr6
@@ -8507,14 +8507,14 @@ body: |
     ; VI-NEXT: G_STORE [[BITCAST4]](<4 x s32>), [[COPY]](p1) :: (store (<4 x s32>), addrspace 1)
     ; VI-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
     ; VI-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[COPY]], [[C2]](s64)
-    ; VI-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; VI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 16, align 16, addrspace 1)
-    ; VI-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; VI-NEXT: [[SHL4:%[0-9]+]]:_(s32) = G_SHL [[C]], [[C1]](s32)
+    ; VI-NEXT: [[OR4:%[0-9]+]]:_(s32) = G_OR [[C]], [[SHL4]]
+    ; VI-NEXT: [[BITCAST5:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR4]](s32)
+    ; VI-NEXT: G_STORE [[BITCAST5]](<2 x s16>), [[PTR_ADD]](p1) :: (store (<2 x s16>) into unknown-address + 16, align 16, addrspace 1)
+    ; VI-NEXT: [[C3:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
     ; VI-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C3]](s64)
-    ; VI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 18, addrspace 1)
-    ; VI-NEXT: [[C4:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
-    ; VI-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C4]](s64)
-    ; VI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD2]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
+    ; VI-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
+    ; VI-NEXT: G_STORE [[DEF]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
     ;
     ; GFX9-LABEL: name: test_store_global_v11s16_align4
     ; GFX9: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5_vgpr6
@@ -8530,14 +8530,12 @@ body: |
     ; GFX9-NEXT: G_STORE [[BITCAST]](<4 x s32>), [[COPY]](p1) :: (store (<4 x s32>), addrspace 1)
     ; GFX9-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
     ; GFX9-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[COPY]], [[C]](s64)
-    ; GFX9-NEXT: [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; GFX9-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 16, align 16, addrspace 1)
-    ; GFX9-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; GFX9-NEXT: [[BUILD_VECTOR4:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[DEF]](s16)
+    ; GFX9-NEXT: G_STORE [[BUILD_VECTOR4]](<2 x s16>), [[PTR_ADD]](p1) :: (store (<2 x s16>) into unknown-address + 16, align 16, addrspace 1)
+    ; GFX9-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
     ; GFX9-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C1]](s64)
-    ; GFX9-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 18, addrspace 1)
-    ; GFX9-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
-    ; GFX9-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C2]](s64)
-    ; GFX9-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD2]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
+    ; GFX9-NEXT: [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
+    ; GFX9-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
     ;
     ; GFX11-TRUE16-LABEL: name: test_store_global_v11s16_align4
     ; GFX11-TRUE16: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5_vgpr6
@@ -8553,13 +8551,11 @@ body: |
     ; GFX11-TRUE16-NEXT: G_STORE [[BITCAST]](<4 x s32>), [[COPY]](p1) :: (store (<4 x s32>), addrspace 1)
     ; GFX11-TRUE16-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
     ; GFX11-TRUE16-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[COPY]], [[C]](s64)
-    ; GFX11-TRUE16-NEXT: G_STORE [[DEF]](s16), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 16, align 16, addrspace 1)
-    ; GFX11-TRUE16-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; GFX11-TRUE16-NEXT: [[BUILD_VECTOR4:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[DEF]](s16)
+    ; GFX11-TRUE16-NEXT: G_STORE [[BUILD_VECTOR4]](<2 x s16>), [[PTR_ADD]](p1) :: (store (<2 x s16>) into unknown-address + 16, align 16, addrspace 1)
+    ; GFX11-TRUE16-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
     ; GFX11-TRUE16-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C1]](s64)
-    ; GFX11-TRUE16-NEXT: G_STORE [[DEF]](s16), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 18, addrspace 1)
-    ; GFX11-TRUE16-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
-    ; GFX11-TRUE16-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C2]](s64)
-    ; GFX11-TRUE16-NEXT: G_STORE [[DEF]](s16), [[PTR_ADD2]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
+    ; GFX11-TRUE16-NEXT: G_STORE [[DEF]](s16), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
     ;
     ; GFX11-FAKE16-LABEL: name: test_store_global_v11s16_align4
     ; GFX11-FAKE16: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5_vgpr6
@@ -8575,14 +8571,12 @@ body: |
     ; GFX11-FAKE16-NEXT: G_STORE [[BITCAST]](<4 x s32>), [[COPY]](p1) :: (store (<4 x s32>), addrspace 1)
     ; GFX11-FAKE16-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
     ; GFX11-FAKE16-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[COPY]], [[C]](s64)
-    ; GFX11-FAKE16-NEXT: [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; GFX11-FAKE16-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 16, align 16, addrspace 1)
-    ; GFX11-FAKE16-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; GFX11-FAKE16-NEXT: [[BUILD_VECTOR4:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[DEF]](s16)
+    ; GFX11-FAKE16-NEXT: G_STORE [[BUILD_VECTOR4]](<2 x s16>), [[PTR_ADD]](p1) :: (store (<2 x s16>) into unknown-address + 16, align 16, addrspace 1)
+    ; GFX11-FAKE16-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
     ; GFX11-FAKE16-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C1]](s64)
-    ; GFX11-FAKE16-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 18, addrspace 1)
-    ; GFX11-FAKE16-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
-    ; GFX11-FAKE16-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C2]](s64)
-    ; GFX11-FAKE16-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD2]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
+    ; GFX11-FAKE16-NEXT: [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
+    ; GFX11-FAKE16-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
     ;
     ; GFX12-TRUE16-LABEL: name: test_store_global_v11s16_align4
     ; GFX12-TRUE16: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5_vgpr6
@@ -8598,13 +8592,11 @@ body: |
     ; GFX12-TRUE16-NEXT: G_STORE [[BITCAST]](<4 x s32>), [[COPY]](p1) :: (store (<4 x s32>), addrspace 1)
     ; GFX12-TRUE16-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
     ; GFX12-TRUE16-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[COPY]], [[C]](s64)
-    ; GFX12-TRUE16-NEXT: G_STORE [[DEF]](s16), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 16, align 16, addrspace 1)
-    ; GFX12-TRUE16-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; GFX12-TRUE16-NEXT: [[BUILD_VECTOR4:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[DEF]](s16)
+    ; GFX12-TRUE16-NEXT: G_STORE [[BUILD_VECTOR4]](<2 x s16>), [[PTR_ADD]](p1) :: (store (<2 x s16>) into unknown-address + 16, align 16, addrspace 1)
+    ; GFX12-TRUE16-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
     ; GFX12-TRUE16-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C1]](s64)
-    ; GFX12-TRUE16-NEXT: G_STORE [[DEF]](s16), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 18, addrspace 1)
-    ; GFX12-TRUE16-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
-    ; GFX12-TRUE16-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C2]](s64)
-    ; GFX12-TRUE16-NEXT: G_STORE [[DEF]](s16), [[PTR_ADD2]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
+    ; GFX12-TRUE16-NEXT: G_STORE [[DEF]](s16), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
     ;
     ; GFX12-FAKE16-LABEL: name: test_store_global_v11s16_align4
     ; GFX12-FAKE16: liveins: $vgpr0_vgpr1, $vgpr2_vgpr3_vgpr4_vgpr5_vgpr6
@@ -8620,14 +8612,12 @@ body: |
     ; GFX12-FAKE16-NEXT: G_STORE [[BITCAST]](<4 x s32>), [[COPY]](p1) :: (store (<4 x s32>), addrspace 1)
     ; GFX12-FAKE16-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
     ; GFX12-FAKE16-NEXT: [[PTR_ADD:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[COPY]], [[C]](s64)
-    ; GFX12-FAKE16-NEXT: [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-    ; GFX12-FAKE16-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD]](p1) :: (store (s16) into unknown-address + 16, align 16, addrspace 1)
-    ; GFX12-FAKE16-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 2
+    ; GFX12-FAKE16-NEXT: [[BUILD_VECTOR4:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[DEF]](s16)
+    ; GFX12-FAKE16-NEXT: G_STORE [[BUILD_VECTOR4]](<2 x s16>), [[PTR_ADD]](p1) :: (store (<2 x s16>) into unknown-address + 16, align 16, addrspace 1)
+    ; GFX12-FAKE16-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
     ; GFX12-FAKE16-NEXT: [[PTR_ADD1:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C1]](s64)
-    ; GFX12-FAKE16-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 18, addrspace 1)
-    ; GFX12-FAKE16-NEXT: [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
-    ; GFX12-FAKE16-NEXT: [[PTR_ADD2:%[0-9]+]]:_(p1) = nuw inbounds G_PTR_ADD [[PTR_ADD]], [[C2]](s64)
-    ; GFX12-FAKE16-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD2]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
+    ; GFX12-FAKE16-NEXT: [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
+    ; GFX12-FAKE16-NEXT: G_STORE [[DEF1]](s32), [[PTR_ADD1]](p1) :: (store (s16) into unknown-address + 20, align 4, addrspace 1)
     %0:_(p1) = COPY $vgpr0_vgpr1
     %1:_(<11 x s16>) = G_IMPLICIT_DEF
     G_STORE %1, %0 :: (store (<11 x s16>), align 16, addrspace 1)

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/strict_fma.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/strict_fma.f16.ll
@@ -256,15 +256,14 @@ define void @v_constained_fma_v3f16_fpexcept_strict_div(<3 x half> %x, <3 x half
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v8, 16, v0
-; GFX8-NEXT:    v_fma_f16 v0, v0, v2, v4
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v10, 16, v4
-; GFX8-NEXT:    flat_store_short v[6:7], v0
-; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 2, v6
+; GFX8-NEXT:    v_fma_f16 v0, v0, v2, v4
 ; GFX8-NEXT:    v_fma_f16 v2, v8, v9, v10
 ; GFX8-NEXT:    v_fma_f16 v3, v1, v3, v5
-; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v7, vcc
-; GFX8-NEXT:    flat_store_short v[0:1], v2
+; GFX8-NEXT:    v_lshlrev_b32_e32 v1, 16, v2
+; GFX8-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX8-NEXT:    flat_store_dword v[6:7], v0
 ; GFX8-NEXT:    v_add_u32_e32 v0, vcc, 4, v6
 ; GFX8-NEXT:    v_addc_u32_e32 v1, vcc, 0, v7, vcc
 ; GFX8-NEXT:    flat_store_short v[0:1], v3
@@ -276,8 +275,7 @@ define void @v_constained_fma_v3f16_fpexcept_strict_div(<3 x half> %x, <3 x half
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_pk_fma_f16 v0, v0, v2, v4
 ; GFX9-NEXT:    v_pk_fma_f16 v1, v1, v3, v5
-; GFX9-NEXT:    global_store_short v[6:7], v0, off
-; GFX9-NEXT:    global_store_short_d16_hi v[6:7], v0, off offset:2
+; GFX9-NEXT:    global_store_dword v[6:7], v0, off
 ; GFX9-NEXT:    global_store_short v[6:7], v1, off offset:4
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -287,9 +285,8 @@ define void @v_constained_fma_v3f16_fpexcept_strict_div(<3 x half> %x, <3 x half
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_pk_fma_f16 v0, v0, v2, v4
 ; GFX11-NEXT:    v_pk_fma_f16 v1, v1, v3, v5
-; GFX11-NEXT:    s_clause 0x2
-; GFX11-NEXT:    global_store_b16 v[6:7], v0, off
-; GFX11-NEXT:    global_store_d16_hi_b16 v[6:7], v0, off offset:2
+; GFX11-NEXT:    s_clause 0x1
+; GFX11-NEXT:    global_store_b32 v[6:7], v0, off
 ; GFX11-NEXT:    global_store_b16 v[6:7], v1, off offset:4
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -302,9 +299,8 @@ define void @v_constained_fma_v3f16_fpexcept_strict_div(<3 x half> %x, <3 x half
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-NEXT:    v_pk_fma_f16 v0, v0, v2, v4
 ; GFX12-NEXT:    v_pk_fma_f16 v1, v1, v3, v5
-; GFX12-NEXT:    s_clause 0x2
-; GFX12-NEXT:    global_store_b16 v[6:7], v0, off
-; GFX12-NEXT:    global_store_d16_hi_b16 v[6:7], v0, off offset:2
+; GFX12-NEXT:    s_clause 0x1
+; GFX12-NEXT:    global_store_b32 v[6:7], v0, off
 ; GFX12-NEXT:    global_store_b16 v[6:7], v1, off offset:4
 ; GFX12-NEXT:    s_setpc_b64 s[30:31]
   %val = call <3 x half> @llvm.experimental.constrained.fma.v3f16(<3 x half> %x, <3 x half> %y, <3 x half> %z, metadata !"round.tonearest", metadata !"fpexcept.strict")

--- a/llvm/test/CodeGen/AMDGPU/freeze.ll
+++ b/llvm/test/CodeGen/AMDGPU/freeze.ll
@@ -6808,9 +6808,7 @@ define void @freeze_v3i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX6-GISEL-NEXT:    s_mov_b64 s[4:5], 0
 ; GFX6-GISEL-NEXT:    buffer_load_dwordx2 v[0:1], v[0:1], s[4:7], 0 addr64
 ; GFX6-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX6-GISEL-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX6-GISEL-NEXT:    buffer_store_short v0, v[2:3], s[4:7], 0 addr64
-; GFX6-GISEL-NEXT:    buffer_store_short v4, v[2:3], s[4:7], 0 addr64 offset:2
+; GFX6-GISEL-NEXT:    buffer_store_dword v0, v[2:3], s[4:7], 0 addr64
 ; GFX6-GISEL-NEXT:    buffer_store_short v1, v[2:3], s[4:7], 0 addr64 offset:4
 ; GFX6-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; GFX6-GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -6837,9 +6835,7 @@ define void @freeze_v3i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX7-GISEL-NEXT:    s_mov_b64 s[4:5], 0
 ; GFX7-GISEL-NEXT:    buffer_load_dwordx2 v[0:1], v[0:1], s[4:7], 0 addr64
 ; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-GISEL-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX7-GISEL-NEXT:    buffer_store_short v0, v[2:3], s[4:7], 0 addr64
-; GFX7-GISEL-NEXT:    buffer_store_short v4, v[2:3], s[4:7], 0 addr64 offset:2
+; GFX7-GISEL-NEXT:    buffer_store_dword v0, v[2:3], s[4:7], 0 addr64
 ; GFX7-GISEL-NEXT:    buffer_store_short v1, v[2:3], s[4:7], 0 addr64 offset:4
 ; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX7-GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -6860,15 +6856,11 @@ define void @freeze_v3i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX8-GISEL:       ; %bb.0:
 ; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-GISEL-NEXT:    flat_load_dwordx2 v[0:1], v[0:1]
-; GFX8-GISEL-NEXT:    v_add_u32_e32 v4, vcc, 2, v2
+; GFX8-GISEL-NEXT:    v_add_u32_e32 v4, vcc, 4, v2
 ; GFX8-GISEL-NEXT:    v_addc_u32_e32 v5, vcc, 0, v3, vcc
-; GFX8-GISEL-NEXT:    v_add_u32_e32 v6, vcc, 4, v2
-; GFX8-GISEL-NEXT:    v_addc_u32_e32 v7, vcc, 0, v3, vcc
 ; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-GISEL-NEXT:    v_lshrrev_b32_e32 v8, 16, v0
-; GFX8-GISEL-NEXT:    flat_store_short v[2:3], v0
-; GFX8-GISEL-NEXT:    flat_store_short v[4:5], v8
-; GFX8-GISEL-NEXT:    flat_store_short v[6:7], v1
+; GFX8-GISEL-NEXT:    flat_store_dword v[2:3], v0
+; GFX8-GISEL-NEXT:    flat_store_short v[4:5], v1
 ; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -6887,8 +6879,7 @@ define void @freeze_v3i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-GISEL-NEXT:    global_load_dwordx2 v[0:1], v[0:1], off
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-GISEL-NEXT:    global_store_short v[2:3], v0, off
-; GFX9-GISEL-NEXT:    global_store_short_d16_hi v[2:3], v0, off offset:2
+; GFX9-GISEL-NEXT:    global_store_dword v[2:3], v0, off
 ; GFX9-GISEL-NEXT:    global_store_short v[2:3], v1, off offset:4
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -6907,8 +6898,7 @@ define void @freeze_v3i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-GISEL-NEXT:    global_load_dwordx2 v[0:1], v[0:1], off
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-GISEL-NEXT:    global_store_short v[2:3], v0, off
-; GFX10-GISEL-NEXT:    global_store_short_d16_hi v[2:3], v0, off offset:2
+; GFX10-GISEL-NEXT:    global_store_dword v[2:3], v0, off
 ; GFX10-GISEL-NEXT:    global_store_short v[2:3], v1, off offset:4
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -6927,9 +6917,8 @@ define void @freeze_v3i16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-GISEL-NEXT:    global_load_b64 v[0:1], v[0:1], off
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-NEXT:    s_clause 0x2
-; GFX11-GISEL-NEXT:    global_store_b16 v[2:3], v0, off
-; GFX11-GISEL-NEXT:    global_store_d16_hi_b16 v[2:3], v0, off offset:2
+; GFX11-GISEL-NEXT:    s_clause 0x1
+; GFX11-GISEL-NEXT:    global_store_b32 v[2:3], v0, off
 ; GFX11-GISEL-NEXT:    global_store_b16 v[2:3], v1, off offset:4
 ; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %a = load <3 x i16>, ptr addrspace(1) %ptra
@@ -7522,9 +7511,7 @@ define void @freeze_v3f16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX6-GISEL-NEXT:    s_mov_b64 s[4:5], 0
 ; GFX6-GISEL-NEXT:    buffer_load_dwordx2 v[0:1], v[0:1], s[4:7], 0 addr64
 ; GFX6-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX6-GISEL-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX6-GISEL-NEXT:    buffer_store_short v0, v[2:3], s[4:7], 0 addr64
-; GFX6-GISEL-NEXT:    buffer_store_short v4, v[2:3], s[4:7], 0 addr64 offset:2
+; GFX6-GISEL-NEXT:    buffer_store_dword v0, v[2:3], s[4:7], 0 addr64
 ; GFX6-GISEL-NEXT:    buffer_store_short v1, v[2:3], s[4:7], 0 addr64 offset:4
 ; GFX6-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; GFX6-GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -7560,9 +7547,7 @@ define void @freeze_v3f16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX7-GISEL-NEXT:    s_mov_b64 s[4:5], 0
 ; GFX7-GISEL-NEXT:    buffer_load_dwordx2 v[0:1], v[0:1], s[4:7], 0 addr64
 ; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-GISEL-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX7-GISEL-NEXT:    buffer_store_short v0, v[2:3], s[4:7], 0 addr64
-; GFX7-GISEL-NEXT:    buffer_store_short v4, v[2:3], s[4:7], 0 addr64 offset:2
+; GFX7-GISEL-NEXT:    buffer_store_dword v0, v[2:3], s[4:7], 0 addr64
 ; GFX7-GISEL-NEXT:    buffer_store_short v1, v[2:3], s[4:7], 0 addr64 offset:4
 ; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX7-GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -7583,15 +7568,11 @@ define void @freeze_v3f16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX8-GISEL:       ; %bb.0:
 ; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-GISEL-NEXT:    flat_load_dwordx2 v[0:1], v[0:1]
-; GFX8-GISEL-NEXT:    v_add_u32_e32 v4, vcc, 2, v2
+; GFX8-GISEL-NEXT:    v_add_u32_e32 v4, vcc, 4, v2
 ; GFX8-GISEL-NEXT:    v_addc_u32_e32 v5, vcc, 0, v3, vcc
-; GFX8-GISEL-NEXT:    v_add_u32_e32 v6, vcc, 4, v2
-; GFX8-GISEL-NEXT:    v_addc_u32_e32 v7, vcc, 0, v3, vcc
 ; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-GISEL-NEXT:    v_lshrrev_b32_e32 v8, 16, v0
-; GFX8-GISEL-NEXT:    flat_store_short v[2:3], v0
-; GFX8-GISEL-NEXT:    flat_store_short v[4:5], v8
-; GFX8-GISEL-NEXT:    flat_store_short v[6:7], v1
+; GFX8-GISEL-NEXT:    flat_store_dword v[2:3], v0
+; GFX8-GISEL-NEXT:    flat_store_short v[4:5], v1
 ; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7610,8 +7591,7 @@ define void @freeze_v3f16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-GISEL-NEXT:    global_load_dwordx2 v[0:1], v[0:1], off
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-GISEL-NEXT:    global_store_short v[2:3], v0, off
-; GFX9-GISEL-NEXT:    global_store_short_d16_hi v[2:3], v0, off offset:2
+; GFX9-GISEL-NEXT:    global_store_dword v[2:3], v0, off
 ; GFX9-GISEL-NEXT:    global_store_short v[2:3], v1, off offset:4
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -7630,8 +7610,7 @@ define void @freeze_v3f16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-GISEL-NEXT:    global_load_dwordx2 v[0:1], v[0:1], off
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-GISEL-NEXT:    global_store_short v[2:3], v0, off
-; GFX10-GISEL-NEXT:    global_store_short_d16_hi v[2:3], v0, off offset:2
+; GFX10-GISEL-NEXT:    global_store_dword v[2:3], v0, off
 ; GFX10-GISEL-NEXT:    global_store_short v[2:3], v1, off offset:4
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7650,9 +7629,8 @@ define void @freeze_v3f16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-GISEL-NEXT:    global_load_b64 v[0:1], v[0:1], off
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-NEXT:    s_clause 0x2
-; GFX11-GISEL-NEXT:    global_store_b16 v[2:3], v0, off
-; GFX11-GISEL-NEXT:    global_store_d16_hi_b16 v[2:3], v0, off offset:2
+; GFX11-GISEL-NEXT:    s_clause 0x1
+; GFX11-GISEL-NEXT:    global_store_b32 v[2:3], v0, off
 ; GFX11-GISEL-NEXT:    global_store_b16 v[2:3], v1, off offset:4
 ; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %a = load <3 x half>, ptr addrspace(1) %ptra
@@ -8247,9 +8225,7 @@ define void @freeze_v3bf16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX6-GISEL-NEXT:    s_mov_b64 s[4:5], 0
 ; GFX6-GISEL-NEXT:    buffer_load_dwordx2 v[0:1], v[0:1], s[4:7], 0 addr64
 ; GFX6-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX6-GISEL-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX6-GISEL-NEXT:    buffer_store_short v0, v[2:3], s[4:7], 0 addr64
-; GFX6-GISEL-NEXT:    buffer_store_short v4, v[2:3], s[4:7], 0 addr64 offset:2
+; GFX6-GISEL-NEXT:    buffer_store_dword v0, v[2:3], s[4:7], 0 addr64
 ; GFX6-GISEL-NEXT:    buffer_store_short v1, v[2:3], s[4:7], 0 addr64 offset:4
 ; GFX6-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; GFX6-GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -8285,9 +8261,7 @@ define void @freeze_v3bf16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX7-GISEL-NEXT:    s_mov_b64 s[4:5], 0
 ; GFX7-GISEL-NEXT:    buffer_load_dwordx2 v[0:1], v[0:1], s[4:7], 0 addr64
 ; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-GISEL-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX7-GISEL-NEXT:    buffer_store_short v0, v[2:3], s[4:7], 0 addr64
-; GFX7-GISEL-NEXT:    buffer_store_short v4, v[2:3], s[4:7], 0 addr64 offset:2
+; GFX7-GISEL-NEXT:    buffer_store_dword v0, v[2:3], s[4:7], 0 addr64
 ; GFX7-GISEL-NEXT:    buffer_store_short v1, v[2:3], s[4:7], 0 addr64 offset:4
 ; GFX7-GISEL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX7-GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -8308,15 +8282,11 @@ define void @freeze_v3bf16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX8-GISEL:       ; %bb.0:
 ; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-GISEL-NEXT:    flat_load_dwordx2 v[0:1], v[0:1]
-; GFX8-GISEL-NEXT:    v_add_u32_e32 v4, vcc, 2, v2
+; GFX8-GISEL-NEXT:    v_add_u32_e32 v4, vcc, 4, v2
 ; GFX8-GISEL-NEXT:    v_addc_u32_e32 v5, vcc, 0, v3, vcc
-; GFX8-GISEL-NEXT:    v_add_u32_e32 v6, vcc, 4, v2
-; GFX8-GISEL-NEXT:    v_addc_u32_e32 v7, vcc, 0, v3, vcc
 ; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX8-GISEL-NEXT:    v_lshrrev_b32_e32 v8, 16, v0
-; GFX8-GISEL-NEXT:    flat_store_short v[2:3], v0
-; GFX8-GISEL-NEXT:    flat_store_short v[4:5], v8
-; GFX8-GISEL-NEXT:    flat_store_short v[6:7], v1
+; GFX8-GISEL-NEXT:    flat_store_dword v[2:3], v0
+; GFX8-GISEL-NEXT:    flat_store_short v[4:5], v1
 ; GFX8-GISEL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -8335,8 +8305,7 @@ define void @freeze_v3bf16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-GISEL-NEXT:    global_load_dwordx2 v[0:1], v[0:1], off
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-GISEL-NEXT:    global_store_short v[2:3], v0, off
-; GFX9-GISEL-NEXT:    global_store_short_d16_hi v[2:3], v0, off offset:2
+; GFX9-GISEL-NEXT:    global_store_dword v[2:3], v0, off
 ; GFX9-GISEL-NEXT:    global_store_short v[2:3], v1, off offset:4
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -8355,8 +8324,7 @@ define void @freeze_v3bf16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-GISEL-NEXT:    global_load_dwordx2 v[0:1], v[0:1], off
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-GISEL-NEXT:    global_store_short v[2:3], v0, off
-; GFX10-GISEL-NEXT:    global_store_short_d16_hi v[2:3], v0, off offset:2
+; GFX10-GISEL-NEXT:    global_store_dword v[2:3], v0, off
 ; GFX10-GISEL-NEXT:    global_store_short v[2:3], v1, off offset:4
 ; GFX10-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -8375,9 +8343,8 @@ define void @freeze_v3bf16(ptr addrspace(1) %ptra, ptr addrspace(1) %ptrb) {
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-GISEL-NEXT:    global_load_b64 v[0:1], v[0:1], off
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-NEXT:    s_clause 0x2
-; GFX11-GISEL-NEXT:    global_store_b16 v[2:3], v0, off
-; GFX11-GISEL-NEXT:    global_store_d16_hi_b16 v[2:3], v0, off offset:2
+; GFX11-GISEL-NEXT:    s_clause 0x1
+; GFX11-GISEL-NEXT:    global_store_b32 v[2:3], v0, off
 ; GFX11-GISEL-NEXT:    global_store_b16 v[2:3], v1, off offset:4
 ; GFX11-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %a = load <3 x bfloat>, ptr addrspace(1) %ptra

--- a/llvm/test/CodeGen/AMDGPU/global-load-xcnt.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-load-xcnt.ll
@@ -108,28 +108,21 @@ define i16 @test_v7i16_load_store(ptr addrspace(1) %ptr1, ptr addrspace(1) %ptr2
 ; GCN-GISEL-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GCN-GISEL-FAKE16-NEXT:    global_load_b128 v[4:7], v[0:1], off
 ; GCN-GISEL-FAKE16-NEXT:    global_load_b128 v[8:11], v[2:3], off
-; GCN-GISEL-FAKE16-NEXT:    s_wait_xcnt 0x0
-; GCN-GISEL-FAKE16-NEXT:    v_mov_b64_e32 v[2:3], 0
-; GCN-GISEL-FAKE16-NEXT:    v_mov_b64_e32 v[12:13], 2
-; GCN-GISEL-FAKE16-NEXT:    v_mov_b64_e32 v[14:15], 4
-; GCN-GISEL-FAKE16-NEXT:    v_mov_b64_e32 v[16:17], 6
-; GCN-GISEL-FAKE16-NEXT:    v_mov_b64_e32 v[18:19], 8
-; GCN-GISEL-FAKE16-NEXT:    v_mov_b64_e32 v[20:21], 10
-; GCN-GISEL-FAKE16-NEXT:    v_mov_b64_e32 v[22:23], 12
+; GCN-GISEL-FAKE16-NEXT:    v_mov_b64_e32 v[12:13], 12
 ; GCN-GISEL-FAKE16-NEXT:    s_wait_loadcnt 0x0
+; GCN-GISEL-FAKE16-NEXT:    s_wait_xcnt 0x1
 ; GCN-GISEL-FAKE16-NEXT:    v_pk_add_u16 v1, v6, v10
-; GCN-GISEL-FAKE16-NEXT:    v_pk_add_u16 v4, v4, v8
-; GCN-GISEL-FAKE16-NEXT:    v_pk_add_u16 v5, v5, v9
-; GCN-GISEL-FAKE16-NEXT:    v_pk_add_u16 v6, v7, v11
-; GCN-GISEL-FAKE16-NEXT:    s_clause 0x6
-; GCN-GISEL-FAKE16-NEXT:    global_store_b16 v[2:3], v4, off
-; GCN-GISEL-FAKE16-NEXT:    global_store_d16_hi_b16 v[12:13], v4, off
-; GCN-GISEL-FAKE16-NEXT:    global_store_b16 v[14:15], v5, off
-; GCN-GISEL-FAKE16-NEXT:    global_store_d16_hi_b16 v[16:17], v5, off
-; GCN-GISEL-FAKE16-NEXT:    global_store_b16 v[18:19], v1, off
-; GCN-GISEL-FAKE16-NEXT:    global_store_d16_hi_b16 v[20:21], v1, off
-; GCN-GISEL-FAKE16-NEXT:    global_store_b16 v[22:23], v6, off
+; GCN-GISEL-FAKE16-NEXT:    s_wait_xcnt 0x0
+; GCN-GISEL-FAKE16-NEXT:    v_pk_add_u16 v2, v4, v8
+; GCN-GISEL-FAKE16-NEXT:    v_pk_add_u16 v3, v5, v9
+; GCN-GISEL-FAKE16-NEXT:    v_mov_b64_e32 v[4:5], 0
+; GCN-GISEL-FAKE16-NEXT:    v_mov_b64_e32 v[8:9], 8
 ; GCN-GISEL-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 16, v1
+; GCN-GISEL-FAKE16-NEXT:    v_pk_add_u16 v6, v7, v11
+; GCN-GISEL-FAKE16-NEXT:    s_clause 0x2
+; GCN-GISEL-FAKE16-NEXT:    global_store_b64 v[4:5], v[2:3], off
+; GCN-GISEL-FAKE16-NEXT:    global_store_b32 v[8:9], v1, off
+; GCN-GISEL-FAKE16-NEXT:    global_store_b16 v[12:13], v6, off
 ; GCN-GISEL-FAKE16-NEXT:    s_set_pc_i64 s[30:31]
 ;
 ; GCN-SDAG-REAL16-LABEL: test_v7i16_load_store:
@@ -161,28 +154,21 @@ define i16 @test_v7i16_load_store(ptr addrspace(1) %ptr1, ptr addrspace(1) %ptr2
 ; GCN-GISEL-REAL16-NEXT:    s_wait_kmcnt 0x0
 ; GCN-GISEL-REAL16-NEXT:    global_load_b128 v[4:7], v[0:1], off
 ; GCN-GISEL-REAL16-NEXT:    global_load_b128 v[8:11], v[2:3], off
-; GCN-GISEL-REAL16-NEXT:    s_wait_xcnt 0x0
-; GCN-GISEL-REAL16-NEXT:    v_mov_b64_e32 v[2:3], 0
-; GCN-GISEL-REAL16-NEXT:    v_mov_b64_e32 v[12:13], 2
-; GCN-GISEL-REAL16-NEXT:    v_mov_b64_e32 v[14:15], 4
-; GCN-GISEL-REAL16-NEXT:    v_mov_b64_e32 v[16:17], 6
-; GCN-GISEL-REAL16-NEXT:    v_mov_b64_e32 v[18:19], 8
-; GCN-GISEL-REAL16-NEXT:    v_mov_b64_e32 v[20:21], 10
-; GCN-GISEL-REAL16-NEXT:    v_mov_b64_e32 v[22:23], 12
+; GCN-GISEL-REAL16-NEXT:    v_mov_b64_e32 v[12:13], 12
 ; GCN-GISEL-REAL16-NEXT:    s_wait_loadcnt 0x0
+; GCN-GISEL-REAL16-NEXT:    s_wait_xcnt 0x1
 ; GCN-GISEL-REAL16-NEXT:    v_pk_add_u16 v1, v6, v10
-; GCN-GISEL-REAL16-NEXT:    v_pk_add_u16 v4, v4, v8
-; GCN-GISEL-REAL16-NEXT:    v_pk_add_u16 v5, v5, v9
-; GCN-GISEL-REAL16-NEXT:    v_pk_add_u16 v6, v7, v11
-; GCN-GISEL-REAL16-NEXT:    s_clause 0x6
-; GCN-GISEL-REAL16-NEXT:    global_store_b16 v[2:3], v4, off
-; GCN-GISEL-REAL16-NEXT:    global_store_d16_hi_b16 v[12:13], v4, off
-; GCN-GISEL-REAL16-NEXT:    global_store_b16 v[14:15], v5, off
-; GCN-GISEL-REAL16-NEXT:    global_store_d16_hi_b16 v[16:17], v5, off
-; GCN-GISEL-REAL16-NEXT:    global_store_b16 v[18:19], v1, off
-; GCN-GISEL-REAL16-NEXT:    global_store_d16_hi_b16 v[20:21], v1, off
-; GCN-GISEL-REAL16-NEXT:    global_store_b16 v[22:23], v6, off
+; GCN-GISEL-REAL16-NEXT:    s_wait_xcnt 0x0
+; GCN-GISEL-REAL16-NEXT:    v_pk_add_u16 v2, v4, v8
+; GCN-GISEL-REAL16-NEXT:    v_pk_add_u16 v3, v5, v9
+; GCN-GISEL-REAL16-NEXT:    v_mov_b64_e32 v[4:5], 0
+; GCN-GISEL-REAL16-NEXT:    v_mov_b64_e32 v[8:9], 8
 ; GCN-GISEL-REAL16-NEXT:    v_mov_b16_e32 v0.l, v1.h
+; GCN-GISEL-REAL16-NEXT:    v_pk_add_u16 v6, v7, v11
+; GCN-GISEL-REAL16-NEXT:    s_clause 0x2
+; GCN-GISEL-REAL16-NEXT:    global_store_b64 v[4:5], v[2:3], off
+; GCN-GISEL-REAL16-NEXT:    global_store_b32 v[8:9], v1, off
+; GCN-GISEL-REAL16-NEXT:    global_store_b16 v[12:13], v6, off
 ; GCN-GISEL-REAL16-NEXT:    s_set_pc_i64 s[30:31]
   %vec1 = load <7 x i16>, ptr addrspace(1) %ptr1
   %insert = insertelement <7 x i16> %vec1, i16 20, i32 4
@@ -511,12 +497,8 @@ define amdgpu_kernel void @test_v7i16_load_store_kernel(ptr addrspace(1) %ptr1, 
 ; GCN-GISEL-NEXT:    v_and_b32_e32 v8, 0x3ff, v0
 ; GCN-GISEL-NEXT:    s_wait_xcnt 0x0
 ; GCN-GISEL-NEXT:    s_load_b64 s[4:5], s[4:5], 0x10 nv
-; GCN-GISEL-NEXT:    v_mov_b64_e32 v[10:11], 2
-; GCN-GISEL-NEXT:    v_mov_b64_e32 v[12:13], 4
-; GCN-GISEL-NEXT:    v_mov_b64_e32 v[14:15], 6
-; GCN-GISEL-NEXT:    v_mov_b64_e32 v[16:17], 8
-; GCN-GISEL-NEXT:    v_mov_b64_e32 v[18:19], 10
-; GCN-GISEL-NEXT:    v_mov_b64_e32 v[20:21], 12
+; GCN-GISEL-NEXT:    v_mov_b64_e32 v[10:11], 8
+; GCN-GISEL-NEXT:    v_mov_b64_e32 v[12:13], 12
 ; GCN-GISEL-NEXT:    s_wait_kmcnt 0x0
 ; GCN-GISEL-NEXT:    s_clause 0x1
 ; GCN-GISEL-NEXT:    global_load_b128 v[0:3], v8, s[0:1] scale_offset
@@ -527,16 +509,12 @@ define amdgpu_kernel void @test_v7i16_load_store_kernel(ptr addrspace(1) %ptr1, 
 ; GCN-GISEL-NEXT:    v_pk_add_u16 v0, v0, v4
 ; GCN-GISEL-NEXT:    v_pk_add_u16 v1, v1, v5
 ; GCN-GISEL-NEXT:    v_pk_add_u16 v2, v2, v6
-; GCN-GISEL-NEXT:    v_mov_b32_e32 v4, 0
 ; GCN-GISEL-NEXT:    v_pk_add_u16 v3, v3, v7
-; GCN-GISEL-NEXT:    s_clause 0x6
-; GCN-GISEL-NEXT:    global_store_b16 v[8:9], v0, off
-; GCN-GISEL-NEXT:    global_store_d16_hi_b16 v[10:11], v0, off
-; GCN-GISEL-NEXT:    global_store_b16 v[12:13], v1, off
-; GCN-GISEL-NEXT:    global_store_d16_hi_b16 v[14:15], v1, off
-; GCN-GISEL-NEXT:    global_store_b16 v[16:17], v2, off
-; GCN-GISEL-NEXT:    global_store_d16_hi_b16 v[18:19], v2, off
-; GCN-GISEL-NEXT:    global_store_b16 v[20:21], v3, off
+; GCN-GISEL-NEXT:    v_mov_b32_e32 v4, 0
+; GCN-GISEL-NEXT:    s_clause 0x2
+; GCN-GISEL-NEXT:    global_store_b64 v[8:9], v[0:1], off
+; GCN-GISEL-NEXT:    global_store_b32 v[10:11], v2, off
+; GCN-GISEL-NEXT:    global_store_b16 v[12:13], v3, off
 ; GCN-GISEL-NEXT:    global_store_d16_hi_b16 v4, v2, s[4:5]
 ; GCN-GISEL-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/205569.

Odd s16 vector stores, such as `<3 x s16>`, currently fall through to `lower` during legalization and are split into multiple s16 stores.

This patch adds a predicate to route odd s16 vector stores through the existing `fewerElements` path, allowing them to be split into wider stores if possible. For example, `<3 x s16>` is split into a `<2 x s16>` store and a `s16` store.

This changes the expected output of a few existing tests, which have been updated with the test update script. A new legalizer regression test is also added to verify the behaviour.