### PR TITLE
[mlir][affine] Remove redundant copyNests.clear() after declaration (NFC)

### DIFF
--- a/mlir/lib/Dialect/Affine/Transforms/AffineDataCopyGeneration.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/AffineDataCopyGeneration.cpp
@@ -208,9 +208,6 @@ void AffineDataCopyGeneration::runOnOperation() {
   // nests are stored herein.
   DenseSet<Operation *> copyNests;
 
-  // Clear recorded copy nests.
-  copyNests.clear();
-
   for (auto &block : f)
     runOnBlock(&block, copyNests);
 


### PR DESCRIPTION
The clear() call immediately following the declaration of copyNests is redundant since a default-constructed DenseSet is already empty. Remove it.