### PR TITLE
[lit] Truncate process output to 10 kiB

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -550,23 +550,20 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
             res = 1 if res != 0 else 0
 
         # Ensure the resulting output is always of string type.
-        # Truncate output as soon as possible so that we don't serialize/process
-        # overly large strings. 10kiB output ought to be enough.
-        def convert_output(out, limit=10 * 1024) -> str:
+        try:
             if out is None:
-                return ""
-            truncated = len(out) > limit
-            out = out[:limit]
-            try:
+                out = ""
+            else:
                 out = out.decode("utf-8", errors="replace")
-            except:
-                out = str(out)
-            if truncated:
-                out += "\n...\ndata was truncated"
-            return out
-
-        out = convert_output(out)
-        err = convert_output(err)
+        except:
+            out = str(out)
+        try:
+            if err is None:
+                err = ""
+            else:
+                err = err.decode("utf-8", errors="replace")
+        except:
+            err = str(err)
 
         # Gather the redirected output files for failed commands.
         output_files = []
@@ -776,9 +773,9 @@ def executeScriptInternal(
             data = data.decode("utf-8", errors="replace")
             out += formatOutput(f"redirected output from '{name}'", data, limit=1024)
         if result.stdout.strip():
-            out += formatOutput("command stdout", result.stdout)
+            out += formatOutput("command stdout", result.stdout, limit=10*1024)
         if result.stderr.strip():
-            out += formatOutput("command stderr", result.stderr)
+            out += formatOutput("command stderr", result.stderr, limit=10*1024)
         if not result.stdout.strip() and not result.stderr.strip():
             out += "# note: command had no output on stdout or stderr\n"
 

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -773,9 +773,9 @@ def executeScriptInternal(
             data = data.decode("utf-8", errors="replace")
             out += formatOutput(f"redirected output from '{name}'", data, limit=1024)
         if result.stdout.strip():
-            out += formatOutput("command stdout", result.stdout, limit=10*1024)
+            out += formatOutput("command stdout", result.stdout, limit=10240)
         if result.stderr.strip():
-            out += formatOutput("command stderr", result.stderr, limit=10*1024)
+            out += formatOutput("command stderr", result.stderr, limit=10240)
         if not result.stdout.strip() and not result.stderr.strip():
             out += "# note: command had no output on stdout or stderr\n"
 

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -627,7 +627,8 @@ def formatOutput(title, data, limit=None):
         return ""
     if not limit is None and len(data) > limit:
         data = data[:limit] + "\n...\n"
-        msg = "data was truncated"
+        msg = (f"data was truncated ({limit}/{len(data)})" +
+               "(change limit with -D output_limit=N)")
     else:
         msg = ""
     ndashes = 30
@@ -769,13 +770,14 @@ def executeScriptInternal(
         # Otherwise, something failed or was printed, show it.
 
         # Add the command output, if redirected.
+        outputLimit = int(litConfig.params.get("output_limit", 10240))
         for (name, path, data) in result.outputFiles:
             data = data.decode("utf-8", errors="replace")
-            out += formatOutput(f"redirected output from '{name}'", data, limit=1024)
+            out += formatOutput(f"redirected output from '{name}'", data, limit=outputLimit)
         if result.stdout.strip():
-            out += formatOutput("command stdout", result.stdout, limit=10240)
+            out += formatOutput("command stdout", result.stdout, limit=outputLimit)
         if result.stderr.strip():
-            out += formatOutput("command stderr", result.stderr, limit=10240)
+            out += formatOutput("command stderr", result.stderr, limit=outputLimit)
         if not result.stdout.strip() and not result.stderr.strip():
             out += "# note: command had no output on stdout or stderr\n"
 

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -626,9 +626,11 @@ def formatOutput(title, data, limit=None):
     if not data.strip():
         return ""
     if not limit is None and len(data) > limit:
+        msg = (
+            f"data was truncated ({limit}/{len(data)})" +
+            " (change limit with -D output_limit=N)"
+        )
         data = data[:limit] + "\n...\n"
-        msg = (f"data was truncated ({limit}/{len(data)})" +
-               "(change limit with -D output_limit=N)")
     else:
         msg = ""
     ndashes = 30
@@ -773,7 +775,9 @@ def executeScriptInternal(
         outputLimit = int(litConfig.params.get("output_limit", 10240))
         for (name, path, data) in result.outputFiles:
             data = data.decode("utf-8", errors="replace")
-            out += formatOutput(f"redirected output from '{name}'", data, limit=outputLimit)
+            out += formatOutput(
+                f"redirected output from '{name}'", data, limit=outputLimit
+            )
         if result.stdout.strip():
             out += formatOutput("command stdout", result.stdout, limit=outputLimit)
         if result.stderr.strip():

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -627,8 +627,8 @@ def formatOutput(title, data, limit=None):
         return ""
     if not limit is None and len(data) > limit:
         msg = (
-            f"data was truncated ({limit}/{len(data)})" +
-            " (change limit with -D output_limit=N)"
+            f"data was truncated ({limit}/{len(data)})"
+            + " (change limit with -D output_limit=N)"
         )
         data = data[:limit] + "\n...\n"
     else:

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -550,20 +550,23 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
             res = 1 if res != 0 else 0
 
         # Ensure the resulting output is always of string type.
-        try:
+        # Truncate output as soon as possible so that we don't serialize/process
+        # overly large strings. 10kiB output ought to be enough.
+        def convert_output(out, limit=10 * 1024) -> str:
             if out is None:
-                out = ""
-            else:
+                return ""
+            truncated = len(out) > limit
+            out = out[:limit]
+            try:
                 out = out.decode("utf-8", errors="replace")
-        except:
-            out = str(out)
-        try:
-            if err is None:
-                err = ""
-            else:
-                err = err.decode("utf-8", errors="replace")
-        except:
-            err = str(err)
+            except:
+                out = str(out)
+            if truncated:
+                out += "\n...\ndata was truncated"
+            return out
+
+        out = convert_output(out)
+        err = convert_output(err)
 
         # Gather the redirected output files for failed commands.
         output_files = []

--- a/llvm/utils/lit/tests/shtest-output-printing.py
+++ b/llvm/utils/lit/tests/shtest-output-printing.py
@@ -47,7 +47,7 @@
 #  CHECK-NEXT: # | All work and no play makes Jack a dull boy.
 #  CHECK-NEXT: # | All work and no play makes Jack a dull boy.
 #       CHECK: # | ...
-#  CHECK-NEXT: # `---data was truncated--------
+#  CHECK-NEXT: # `---data was truncated (10240/44000) (change limit with -D output_limit=N)
 #  CHECK-NEXT: # note: command had no output on stdout or stderr
 #  CHECK-NEXT: # error: command failed with exit status: 1
 # CHECK-EMPTY:

--- a/llvm/utils/lit/tests/shtest-output-printing.py
+++ b/llvm/utils/lit/tests/shtest-output-printing.py
@@ -47,7 +47,7 @@
 #  CHECK-NEXT: # | All work and no play makes Jack a dull boy.
 #  CHECK-NEXT: # | All work and no play makes Jack a dull boy.
 #       CHECK: # | ...
-#  CHECK-NEXT: # `---data was truncated (10240/44000) (change limit with -D output_limit=N)
+#  CHECK-NEXT: # `---data was truncated (10240/{{[0-9]+}}) (change limit with -D output_limit=N)
 #  CHECK-NEXT: # note: command had no output on stdout or stderr
 #  CHECK-NEXT: # error: command failed with exit status: 1
 # CHECK-EMPTY:


### PR DESCRIPTION
The output of processes is transformed multiple times:

1. All non-piped/redirected output of processes is collected
   (communicate() for the last process of the pipe, read() for all
   previous.)
   - It's not good that we *collect* the entire output at all (frequent
     realloc+memcpy for large buffers) and I'd rather not have a
     possibly large output stored in Python at all.
2. The output is converted into strings (memcpy/utf-8 decode) and stored
   in the results list of executeScriptInternal.
3. executeScriptInternal builds the debug output combining all these
   stdout/stderr.
   - It performs a lot of `out += ...`, which allocates (malloc+memcpy)
     a new string every time. There are many of these concatenations.
4. The combined debug output is returned (together with other things) to
   _runShTest, which determines whether the test passed, executing the
   test multiple times if necessary. It also string-formats the output.
5. ShTest returns the result, which is pickled, sent to the main process
   (write/read), unpickled, and processed further e.g. for writing the
   test result to stdout.

Due to locking, no other tests can start during this time and as most of
this happens in C code, interrupting also has some delay.

We have some tests that produce a large amount of output (llvm-exegesis
in particular has tests that output >50 MiB). This causes the tests to
stall for several seconds, sometimes more than a minute.

Therefore, truncate the output of processes to 10 kiB when adding it to
the debug output (step 3 above). This avoids most, but not all, of the
cost related to large outputs. The limit can be changed with the command
line option -Doutput_limit=N.

On one of my systems, this reduces the time of check-llvm by 22%:

    Before: 1085.27user 718.78system 1:53.75elapsed 1585%CPU
    After:  1050.81user 702.01system 1:28.42elapsed 1982%CPU

Reproducer of the problem:

    RUN: head -c500000000 /dev/zero
