### PR TITLE
[clang][Lex] Optimize the FileCheckPoints search in Preprocessor

### DIFF
--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -1746,16 +1746,13 @@ void Preprocessor::removePPCallbacks() {
 const char *Preprocessor::getCheckPoint(FileID FID, const char *Start) const {
   if (auto It = CheckPoints.find(FID); It != CheckPoints.end()) {
     const SmallVector<const char *> &FileCheckPoints = It->second;
-    const char *Last = nullptr;
-    // FIXME: Do better than a linear search.
-    for (const char *P : FileCheckPoints) {
-      if (P > Start)
-        break;
-      Last = P;
+    auto P =
+        std::upper_bound(FileCheckPoints.begin(), FileCheckPoints.end(), Start);
+    if (P == FileCheckPoints.begin()) {
+      return nullptr;
     }
-    return Last;
+    return *std::prev(P);
   }
-
   return nullptr;
 }
 

--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -1746,11 +1746,9 @@ void Preprocessor::removePPCallbacks() {
 const char *Preprocessor::getCheckPoint(FileID FID, const char *Start) const {
   if (auto It = CheckPoints.find(FID); It != CheckPoints.end()) {
     const SmallVector<const char *> &FileCheckPoints = It->second;
-    auto P =
-        std::upper_bound(FileCheckPoints.begin(), FileCheckPoints.end(), Start);
-    if (P == FileCheckPoints.begin()) {
+    auto P = llvm::upper_bound(FileCheckPoints, Start);
+    if (P == FileCheckPoints.begin())
       return nullptr;
-    }
     return *std::prev(P);
   }
   return nullptr;


### PR DESCRIPTION
Resolves a FIXME and improved linear search by replacing with a binary search on the FileCheckPoints SmallVector in Lex/Preprocessor.

- used std::upper_bound to find the upper bound of the Start position.
- handle special case if the Start is less than all elements in FileCheckPoints so returns a nullptr;
- else return the dereferenced value of the CheckPoint just before Start point.