### PR TITLE
[MIR] Fix check-line-and-variables.mir test for external shell

### DIFF
--- a/llvm/test/CodeGen/Generic/MIRDebugify/check-line-and-variables.mir
+++ b/llvm/test/CodeGen/Generic/MIRDebugify/check-line-and-variables.mir
@@ -2,7 +2,7 @@
 # RUN: llc -mtriple=x86_64-unknown-linux-gnu -run-pass=mir-debugify,dead-mi-elimination,mir-check-debugify -o - %s 2>&1 | FileCheck %s
 # RUN: llc -mtriple=x86_64-unknown-linux-gnu -run-pass=mir-debugify,mir-check-debugify -o - %s 2>&1 | FileCheck %s --check-prefix=CHECK-PASS
 
-# RUN: llc -mtriple=x86_64-unknown-linux-gnu -passes=mir-debugify,function(machine-function(dead-mi-elimination)),mir-check-debugify -o - %s 2>&1 | FileCheck %s
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -passes="mir-debugify,function(machine-function(dead-mi-elimination)),mir-check-debugify" -o - %s 2>&1 | FileCheck %s
 # RUN: llc -mtriple=x86_64-unknown-linux-gnu -passes=mir-debugify,mir-check-debugify -o - %s 2>&1 | FileCheck %s --check-prefix=CHECK-PASS
 --- |
   ; ModuleID = 'check-line-and-variables.mir'


### PR DESCRIPTION
We need to quote the new pass sequence given it involves parentheses.