### PR TITLE
[mlir][python] Fix Python binding cast diagnostics for nanobind 2.13

### DIFF
--- a/mlir/include/mlir/Bindings/Python/IRAttributes.h
+++ b/mlir/include/mlir/Bindings/Python/IRAttributes.h
@@ -100,14 +100,15 @@ template <typename T>
 static T pyTryCast(nanobind::handle object) {
   try {
     return nanobind::cast<T>(object);
-  } catch (nanobind::cast_error &err) {
+  } catch (std::exception &err) {
+    if (object.is_none()) {
+      std::string msg = std::string("Invalid attribute (None?) when attempting "
+                                    "to create an ArrayAttribute (") +
+                        err.what() + ")";
+      throw std::runtime_error(msg.c_str());
+    }
     std::string msg = std::string("Invalid attribute when attempting to "
                                   "create an ArrayAttribute (") +
-                      err.what() + ")";
-    throw std::runtime_error(msg.c_str());
-  } catch (std::runtime_error &err) {
-    std::string msg = std::string("Invalid attribute (None?) when attempting "
-                                  "to create an ArrayAttribute (") +
                       err.what() + ")";
     throw std::runtime_error(msg.c_str());
   }

--- a/mlir/lib/Bindings/Python/IRAffine.cpp
+++ b/mlir/lib/Bindings/Python/IRAffine.cpp
@@ -43,13 +43,14 @@ static void pyListToVector(const nb::sequence &list, std::vector<CType> &result,
   for (nb::handle item : list) {
     try {
       result.push_back(nb::cast<PyType>(item));
-    } catch (nb::cast_error &err) {
+    } catch (std::exception &err) {
+      if (item.is_none()) {
+        std::string msg = nanobind::detail::join(
+            "Invalid expression (None?) when ", action, " (", err.what(), ")");
+        throw std::runtime_error(msg.c_str());
+      }
       std::string msg = nanobind::detail::join("Invalid expression when ",
                                                action, " (", err.what(), ")");
-      throw std::runtime_error(msg.c_str());
-    } catch (std::runtime_error &err) {
-      std::string msg = nanobind::detail::join(
-          "Invalid expression (None?) when ", action, " (", err.what(), ")");
       throw std::runtime_error(msg.c_str());
     }
   }

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -1272,17 +1272,17 @@ nb::object PyOperation::create(std::string_view name,
         auto &attribute = nb::cast<PyAttribute &>(it.second);
         // TODO: Verify attribute originates from the same context.
         mlirAttributes.emplace_back(std::move(key), attribute);
-      } catch (nb::cast_error &err) {
+      } catch (std::exception &err) {
+        if (it.second.is_none()) {
+          std::string msg = join(
+              "Found an invalid (`None`?) attribute value for the key \"", key,
+              "\" when attempting to create the operation \"", name, "\"");
+          throw std::runtime_error(msg);
+        }
         std::string msg = join("Invalid attribute value for the key \"", key,
                                "\" when attempting to create the operation \"",
                                name, "\" (", err.what(), ")");
         throw nb::type_error(msg.c_str());
-      } catch (std::runtime_error &) {
-        // This exception seems thrown when the value is "None".
-        std::string msg = join(
-            "Found an invalid (`None`?) attribute value for the key \"", key,
-            "\" when attempting to create the operation \"", name, "\"");
-        throw std::runtime_error(msg);
       }
     }
   }


### PR DESCRIPTION
nanobind 2.13.0 changed failing `nb::cast<T>()` to raise `cast_error` (an alias for `std::bad_cast`) for all failures, including `None`, instead of the previous distinct exception types. The bindings relied on catching `std::runtime_error` separately from `cast_error` to emit a helpful "(None?)" hint, so that branch became dead code and the `None` diagnostics regressed (e.g. "(std::bad_cast)" instead of "(None?)"), breaking check-mlir Python tests.

Fix: Decide the `None` hint from the value via `is_none()` rather than the exception type. This is robust across nanobind versions (2.10-2.13).

Fixes #205329 

Assisted by: Claude