### PR TITLE
[BPF] Avoid stack argument fatal error with O0 optimization

### DIFF
--- a/llvm/lib/Target/BPF/BPFMIPeephole.cpp
+++ b/llvm/lib/Target/BPF/BPFMIPeephole.cpp
@@ -329,19 +329,18 @@ public:
 
   // Main entry point for this pass.
   bool runOnMachineFunction(MachineFunction &MF) override {
-    if (skipFunction(MF.getFunction()))
-      return false;
-
     initialize(MF);
 
-    bool Changed;
-    Changed = eliminateRedundantMov();
+    bool Changed = expandStackArgPseudos();
+    if (skipFunction(MF.getFunction()))
+      return Changed;
+
+    Changed |= eliminateRedundantMov();
     if (SupportGotol)
-      Changed = adjustBranch() || Changed;
+      Changed |= adjustBranch();
     Changed |= insertMissingCallerSavedSpills();
     Changed |= removeMayGotoZero();
     Changed |= addExitAfterUnreachable();
-    Changed |= expandStackArgPseudos();
     return Changed;
   }
 };

--- a/llvm/lib/Target/BPF/BPFTargetMachine.cpp
+++ b/llvm/lib/Target/BPF/BPFTargetMachine.cpp
@@ -185,9 +185,8 @@ void BPFPassConfig::addMachineSSAOptimization() {
 
 void BPFPassConfig::addPreEmitPass() {
   addPass(createBPFMIPreEmitCheckingPass());
-  if (getOptLevel() != CodeGenOptLevel::None)
-    if (!DisableMIPeephole)
-      addPass(createBPFMIPreEmitPeepholePass());
+  if (!DisableMIPeephole)
+    addPass(createBPFMIPreEmitPeepholePass());
 }
 
 bool BPFPassConfig::addIRTranslator() {


### PR DESCRIPTION
Upstream reported a compiler fatal error with stack arguments ([1]). The source code:
```
  void f(int, int, int, int, int, int);
  int main(void)
  {
        f(0, 0, 0, 0, 0, 0);
        return 0;
  }
```
The compilation flag: `clang --target=bpf -O0 -c t.c`

The failure symptom:
```
  fatal error: error in backend: Unsupported instruction : <MCInst 338 <MCOperand Imm:-8> <MCOperand Reg:2>>
```
The failure reason is due to `BPF PreEmit Peephole Optimization`. It is supposed to convert
```
  STORE_STACK_ARG_PSEUDO -8, killed $r1
```
to
```
  STD killed $r1, $r11, -8
```

Otherwise, the `BPF Assembly Printer` pass does not understand `STORE_STACK_ARG_PSEUDO` and caused the crash.

To fix the issue, two things happened:
  1. In `BPFTargetMachine.cpp`, remove `getOptLevel() != CodeGenOptLevel::None` checking. This is redundant as the same checking (with `skipFunction())` in `BPFMIPeephole.cpp`. For `skipFunction()`, if opt level is `None`, the function will be skipped.
  2. In `BPFMIPeephole.cpp`, do `expandStackArgPseudos()` before `skipFunction()` checking. This fixed the problem.

  [1] https://github.com/llvm/llvm-project/issues/205647