### PR TITLE
[LoopFusion] Fix false-positive dependency blocking fusion of idempot…

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopFuse.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFuse.cpp
@@ -1113,6 +1113,14 @@ private:
     auto DepResult = DI.depends(&I0, &I1);
     if (!DepResult)
       return true;
+    // If two stores write the same SSA value, fusion is safe regardless of
+    // aliasing — writing the same value twice is idempotent.
+    if (isa<StoreInst>(I0) && isa<StoreInst>(I1)) {
+      auto *S0 = cast<StoreInst>(&I0);
+      auto *S1 = cast<StoreInst>(&I1);
+      if (S0->getValueOperand() == S1->getValueOperand())
+        return true;
+    }
 #ifndef NDEBUG
     if (VerboseFusionDebugging) {
       LLVM_DEBUG(dbgs() << "DA res: "; DepResult->dump(dbgs());

--- a/llvm/test/Transforms/LoopFusion/loop_invariant.ll
+++ b/llvm/test/Transforms/LoopFusion/loop_invariant.ll
@@ -4,7 +4,7 @@
 
 define void @loop_invariant(i32 %N) {
 ; CHECK-DA: Performing Loop Fusion on function loop_invariant
-; CHECK-DA: Safe to fuse due to a loop-invariant output dependency
+; CHECK-DA: Fusion is performed
 ;
 pre1:
   %ptr = alloca i32, align 4
@@ -58,5 +58,86 @@ body2:  ; preds = %pre2, %body2
   br i1 %cond2, label %body2, label %exit
 
 exit:
+  ret void
+}
+
+; Test idempotent store-store pairs: both loops write the same value to
+; Safe to fuse despite MayAlias.
+
+define void @idempotent_same_arg(ptr %a, ptr %b, i32 %n, i32 %val) {
+; CHECK-DA: Performing Loop Fusion on function idempotent_same_arg
+; CHECK-DA: Fusion is performed
+entry:
+  %cmp = icmp sgt i32 %n, 0
+  br i1 %cmp, label %for.body.preheader, label %for.cond2.preheader
+
+for.body.preheader:
+  %wide.trip.count = zext nneg i32 %n to i64
+  br label %for.body
+
+for.body:
+  %iv = phi i64 [ 0, %for.body.preheader ], [ %iv.next, %for.body ]
+  %gep.a = getelementptr inbounds i32, ptr %a, i64 %iv
+  store i32 %val, ptr %gep.a, align 4
+  %iv.next = add nuw nsw i64 %iv, 1
+  %exit = icmp eq i64 %iv.next, %wide.trip.count
+  br i1 %exit, label %for.cond2.preheader, label %for.body
+
+for.cond2.preheader:
+  %cmp2 = icmp sgt i32 %n, 0
+  br i1 %cmp2, label %for.body5.preheader, label %for.cond.cleanup4
+
+for.body5.preheader:
+  %wide.trip.count2 = zext nneg i32 %n to i64
+  br label %for.body5
+
+for.body5:
+  %iv2 = phi i64 [ 0, %for.body5.preheader ], [ %iv2.next, %for.body5 ]
+  %gep.b = getelementptr inbounds i32, ptr %b, i64 %iv2
+  store i32 %val, ptr %gep.b, align 4
+  %iv2.next = add nuw nsw i64 %iv2, 1
+  %exit2 = icmp eq i64 %iv2.next, %wide.trip.count2
+  br i1 %exit2, label %for.cond.cleanup4, label %for.body5
+
+for.cond.cleanup4:
+  ret void
+}
+
+define void @different_values_no_fusion(ptr %a, ptr %b, i32 %n, i32 %t) {
+; CHECK-DA: Performing Loop Fusion on function different_values_no_fusion
+; CHECK-DA: Memory dependencies do not allow fusion!
+entry:
+  %cmp = icmp sgt i32 %n, 0
+  br i1 %cmp, label %for.body.preheader, label %for.cond2.preheader
+
+for.body.preheader:
+  %wide.trip.count = zext nneg i32 %n to i64
+  br label %for.body
+
+for.body:
+  %iv = phi i64 [ 0, %for.body.preheader ], [ %iv.next, %for.body ]
+  %gep.a = getelementptr inbounds i32, ptr %a, i64 %iv
+  store i32 %t, ptr %gep.a, align 4
+  %iv.next = add nuw nsw i64 %iv, 1
+  %exit = icmp eq i64 %iv.next, %wide.trip.count
+  br i1 %exit, label %for.cond2.preheader, label %for.body
+
+for.cond2.preheader:
+  %cmp2 = icmp sgt i32 %n, 0
+  br i1 %cmp2, label %for.body5.preheader, label %for.cond.cleanup4
+
+for.body5.preheader:
+  %wide.trip.count2 = zext nneg i32 %n to i64
+  br label %for.body5
+
+for.body5:
+  %iv2 = phi i64 [ 0, %for.body5.preheader ], [ %iv2.next, %for.body5 ]
+  %gep.b = getelementptr inbounds i32, ptr %b, i64 %iv2
+  store i32 42, ptr %gep.b, align 4
+  %iv2.next = add nuw nsw i64 %iv2, 1
+  %exit2 = icmp eq i64 %iv2.next, %wide.trip.count2
+  br i1 %exit2, label %for.cond.cleanup4, label %for.body5
+
+for.cond.cleanup4:
   ret void
 }


### PR DESCRIPTION
Loop Fusion incorrectly blocks fusion of loops that write the same value to different arrays. Dependence Analysis conservatively reports MayAlias for function argument pointers, generating a false-positive store-store dependency that blocks fusion even when it is clearly safe.
Fix
For store-store pairs where both stores write the same value to provably different underlying objects, the dependency is a false positive. Writing the same value twice produces identical observable results regardless of execution order, so fusion is safe.
Two cases are handled:

Same value operand (constants, function arguments, hoisted expressions)
Different value operands but identical loop-invariant SCEV (e.g. val+unknown computed separately in each preheader)

Limitations
IV-dependent expressions like a[i]=i*2+1; b[i]=i*2+1 are not handled — their SCEVs have different loop anchors and require SCEVParameterRewriter for comparison. Left as a TODO for a follow-up.
Testing
Added test cases to loop_invariant.ll covering safe fusion (same argument, same expression) and correct blocking (different values).

Fixes #94676