### PR TITLE
[clang][docs]Refactor compiler standard references from c94 to C95

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -4032,7 +4032,7 @@ Differences between various standard modes
 ------------------------------------------
 
 clang supports the ``-std`` option, which changes what language mode clang uses.
-The supported modes for C are c89, gnu89, c95(using -std=iso9899:199409 or -fdigraphs), c99, gnu99, c11, gnu11, c17,
+The supported modes for C are c89, gnu89, iso9899:199409 (for C95), c99, gnu99, c11, gnu11, c17,
 gnu17, c23, gnu23, c2y, gnu2y, and various aliases for those modes. If no ``-std``
 option is specified, clang defaults to gnu17 mode. Many C99 and C11 features
 are supported in earlier modes as a conforming extension, with a warning. Use

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -35,7 +35,7 @@ which includes :ref:`C <c>`, :ref:`Objective-C <objc>`, :ref:`C++ <cxx>`, and
 language-specific information, please see the corresponding language
 specific section:
 
--  :ref:`C Language <c>`: K&R C, ANSI C89, ISO C90, C94 (C89+AMD1), C99 (+TC1,
+-  :ref:`C Language <c>`: K&R C, ANSI C89, ISO C90, C99 (+TC1,
    TC2, TC3), C11, C17, C23, and C2y.
 -  :ref:`Objective-C Language <objc>`: ObjC 1, ObjC 2, ObjC 2.1, plus
    variants depending on base language.
@@ -4032,7 +4032,7 @@ Differences between various standard modes
 ------------------------------------------
 
 clang supports the ``-std`` option, which changes what language mode clang uses.
-The supported modes for C are c89, gnu89, c94, c99, gnu99, c11, gnu11, c17,
+The supported modes for C are c89, gnu89, c99, gnu99, c11, gnu11, c17,
 gnu17, c23, gnu23, c2y, gnu2y, and various aliases for those modes. If no ``-std``
 option is specified, clang defaults to gnu17 mode. Many C99 and C11 features
 are supported in earlier modes as a conforming extension, with a warning. Use

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -35,7 +35,7 @@ which includes :ref:`C <c>`, :ref:`Objective-C <objc>`, :ref:`C++ <cxx>`, and
 language-specific information, please see the corresponding language
 specific section:
 
--  :ref:`C Language <c>`: K&R C, ANSI C89, ISO C90, C99 (+TC1,
+-  :ref:`C Language <c>`: K&R C, ANSI C89, ISO C90, C95 (C90+AMD1), C99 (+TC1,
    TC2, TC3), C11, C17, C23, and C2y.
 -  :ref:`Objective-C Language <objc>`: ObjC 1, ObjC 2, ObjC 2.1, plus
    variants depending on base language.
@@ -4032,7 +4032,7 @@ Differences between various standard modes
 ------------------------------------------
 
 clang supports the ``-std`` option, which changes what language mode clang uses.
-The supported modes for C are c89, gnu89, c99, gnu99, c11, gnu11, c17,
+The supported modes for C are c89, gnu89, c95(using -std=iso9899:199409 or -fdigraphs), c99, gnu99, c11, gnu11, c17,
 gnu17, c23, gnu23, c2y, gnu2y, and various aliases for those modes. If no ``-std``
 option is specified, clang defaults to gnu17 mode. Many C99 and C11 features
 are supported in earlier modes as a conforming extension, with a warning. Use

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7648,7 +7648,7 @@ already being compiled with GNU inline semantics as the implied default. It is
 unspecified which macro is defined in a C++ compilation.
 
 GNU inline semantics are the default behavior with ``-std=gnu89``,
-``-std=c89``, ``-fgnu89-inline``, ``-std=iso9899:199409``, or ``-fdigraphs``.
+``-std=c89``, ``-fgnu89-inline``, or ``-std=iso9899:199409``.
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7648,7 +7648,7 @@ already being compiled with GNU inline semantics as the implied default. It is
 unspecified which macro is defined in a C++ compilation.
 
 GNU inline semantics are the default behavior with ``-std=gnu89``,
-``-std=c89``, ``-std=c94``, or ``-fgnu89-inline``.
+``-std=c89``, or ``-fgnu89-inline``.
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7648,7 +7648,7 @@ already being compiled with GNU inline semantics as the implied default. It is
 unspecified which macro is defined in a C++ compilation.
 
 GNU inline semantics are the default behavior with ``-std=gnu89``,
-``-std=c89``, or ``-fgnu89-inline``.
+``-std=c89``, ``-fgnu89-inline``, ``-std=iso9899:199409``, or ``-fdigraphs``.
   }];
 }
 


### PR DESCRIPTION
The patch removes all references to a non existent c94 standard from clang docs.
to C95 (C90 + AMD1)
closes #206389 