### PR TITLE
[clang-format] Respect definition separators when MaxEmptyLinesToKeep: 0

### DIFF
--- a/clang/lib/Format/DefinitionBlockSeparator.cpp
+++ b/clang/lib/Format/DefinitionBlockSeparator.cpp
@@ -66,8 +66,13 @@ void DefinitionBlockSeparator::separateBlocks(
   };
   unsigned NewlineCount =
       (Style.SeparateDefinitionBlocks == FormatStyle::SDS_Always ? 1 : 0) + 1;
+
+  FormatStyle SeparatorStyle = Style;
+  SeparatorStyle.MaxEmptyLinesToKeep =
+      std::max(SeparatorStyle.MaxEmptyLinesToKeep, NewlineCount - 1);
+
   WhitespaceManager Whitespaces(
-      Env.getSourceManager(), Style,
+      Env.getSourceManager(), SeparatorStyle,
       Style.LineEnding > FormatStyle::LE_CRLF
           ? WhitespaceManager::inputUsesCRLF(
                 Env.getSourceManager().getBufferData(Env.getFileID()),

--- a/clang/lib/Format/DefinitionBlockSeparator.cpp
+++ b/clang/lib/Format/DefinitionBlockSeparator.cpp
@@ -67,12 +67,11 @@ void DefinitionBlockSeparator::separateBlocks(
   unsigned NewlineCount =
       (Style.SeparateDefinitionBlocks == FormatStyle::SDS_Always ? 1 : 0) + 1;
 
-  FormatStyle SeparatorStyle = Style;
-  SeparatorStyle.MaxEmptyLinesToKeep =
-      std::max(SeparatorStyle.MaxEmptyLinesToKeep, NewlineCount - 1);
+  Style.MaxEmptyLinesToKeep =
+      std::max(Style.MaxEmptyLinesToKeep, NewlineCount - 1);
 
   WhitespaceManager Whitespaces(
-      Env.getSourceManager(), SeparatorStyle,
+      Env.getSourceManager(), Style,
       Style.LineEnding > FormatStyle::LE_CRLF
           ? WhitespaceManager::inputUsesCRLF(
                 Env.getSourceManager().getBufferData(Env.getFileID()),

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -4330,12 +4330,6 @@ reformat(const FormatStyle &Style, StringRef Code,
     }
   }
 
-  if (Style.SeparateDefinitionBlocks != FormatStyle::SDS_Leave) {
-    Passes.emplace_back([&](const Environment &Env) {
-      return DefinitionBlockSeparator(Env, Expanded).process();
-    });
-  }
-
   if (Style.Language == FormatStyle::LK_ObjC &&
       !Style.ObjCPropertyAttributeOrder.empty()) {
     Passes.emplace_back([&](const Environment &Env) {
@@ -4353,6 +4347,12 @@ reformat(const FormatStyle &Style, StringRef Code,
   Passes.emplace_back([&](const Environment &Env) {
     return Formatter(Env, Expanded, Status).process();
   });
+
+  if (Style.SeparateDefinitionBlocks != FormatStyle::SDS_Leave) {
+    Passes.emplace_back([&](const Environment &Env) {
+      return DefinitionBlockSeparator(Env, Expanded).process();
+    });
+  }
 
   if (Style.isJavaScript() &&
       Style.InsertTrailingCommas == FormatStyle::TCS_Wrapped) {

--- a/clang/unittests/Format/DefinitionBlockSeparatorTest.cpp
+++ b/clang/unittests/Format/DefinitionBlockSeparatorTest.cpp
@@ -391,6 +391,35 @@ TEST_F(DefinitionBlockSeparatorTest, Always) {
                Style, Prefix + Infix + Postfix);
 }
 
+TEST_F(DefinitionBlockSeparatorTest, AlwaysMaxEmptyLinesZeroAllman) {
+  FormatStyle Style = getLLVMStyle();
+  Style.BreakBeforeBraces = FormatStyle::BS_Allman;
+  Style.MaxEmptyLinesToKeep = 0;
+  Style.SeparateDefinitionBlocks = FormatStyle::SDS_Always;
+  Style.AllowShortFunctionsOnASingleLine = FormatStyle::ShortFunctionStyle();
+
+  verifyFormat("int my_function(int a)\n"
+               "\n"
+               "{\n"
+               "  return a;\n"
+               "}\n"
+               "int other_function(int a)\n"
+               "\n"
+               "{\n"
+               "  return a;\n"
+               "}",
+               Style,
+               "int my_function(int a)\n"
+               "{\n"
+               "  return a;\n"
+               "}\n"
+               "\n"
+               "int other_function(int a)\n"
+               "{\n"
+               "  return a;\n"
+               "}");
+}
+
 TEST_F(DefinitionBlockSeparatorTest, Never) {
   FormatStyle Style = getLLVMStyle();
   Style.SeparateDefinitionBlocks = FormatStyle::SDS_Never;


### PR DESCRIPTION
Fixes #206340.

The formatter should remove empty lines before Allman opening braces, but should preserve the required empty line between function definitions.

I have added a test case "AlwaysMaxEmptyLinesZeroAllman", and have ensured other test cases run fine along with this one.