### PR TITLE
[ARM] Add basic bf16 fpround support

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -571,6 +571,8 @@ ARMTargetLowering::ARMTargetLowering(const TargetMachine &TM_,
     setAllExpand(MVT::bf16);
     if (!Subtarget->hasFullFP16())
       setOperationAction(ISD::BITCAST, MVT::bf16, Custom);
+    setOperationAction(ISD::FP_ROUND, MVT::bf16, Custom);
+    setOperationAction(ISD::STRICT_FP_ROUND, MVT::bf16, Custom);
   } else {
     setOperationAction(ISD::BF16_TO_FP, MVT::f32, Expand);
     setOperationAction(ISD::BF16_TO_FP, MVT::f64, Expand);
@@ -21098,6 +21100,13 @@ SDValue ARMTargetLowering::LowerFP_ROUND(SDValue Op, SelectionDAG &DAG) const {
   SDValue SrcVal = Op.getOperand(IsStrict ? 1 : 0);
   EVT SrcVT = SrcVal.getValueType();
   EVT DstVT = Op.getValueType();
+
+  if (DstVT == MVT::bf16) {
+    if (Subtarget->hasBF16() && SrcVT == MVT::f32)
+      return Op;
+    return SDValue();
+  }
+
   const unsigned DstSz = Op.getValueType().getSizeInBits();
   const unsigned SrcSz = SrcVT.getSizeInBits();
   (void)DstSz;

--- a/llvm/lib/Target/ARM/ARMInstrVFP.td
+++ b/llvm/lib/Target/ARM/ARMInstrVFP.td
@@ -2102,6 +2102,10 @@ class BF16_VCVT<string opc, bits<2> op7_6>
 def BF16_VCVTB : BF16_VCVT<"vcvtb", 0b01>;
 def BF16_VCVTT : BF16_VCVT<"vcvtt", 0b11>;
 
+let Predicates = [HasBF16] in
+def : Pat<(bf16 (any_fpround (f32 SPR:$Sm))),
+          (COPY_TO_REGCLASS (BF16_VCVTB (IMPLICIT_DEF), SPR:$Sm), HPR)>;
+
 //===----------------------------------------------------------------------===//
 // FP Multiply-Accumulate Operations.
 //

--- a/llvm/test/CodeGen/ARM/bf16-instructions.ll
+++ b/llvm/test/CodeGen/ARM/bf16-instructions.ll
@@ -348,20 +348,42 @@ declare i1 @test_dummy(ptr %p1) #0
 ;  ret bfloat %r
 ;}
 
-;define bfloat @test_fptrunc_float(float %a) #0 {
-;  %r = fptrunc float %a to bfloat
-;  ret bfloat %r
-;}
+define bfloat @test_fptrunc_float(float %a) #0 {
+; CHECK-CVT-LABEL: test_fptrunc_float:
+; CHECK-CVT:       @ %bb.0:
+; CHECK-CVT-NEXT:    .save {r11, lr}
+; CHECK-CVT-NEXT:    push {r11, lr}
+; CHECK-CVT-NEXT:    bl __truncsfbf2
+; CHECK-CVT-NEXT:    pop {r11, pc}
+;
+; CHECK-BF16-LABEL: test_fptrunc_float:
+; CHECK-BF16:       @ %bb.0:
+; CHECK-BF16-NEXT:    vcvtb.bf16.f32 s0, s0
+; CHECK-BF16-NEXT:    bx lr
+  %r = fptrunc float %a to bfloat
+  ret bfloat %r
+}
 
 ;define bfloat @test_fptrunc_double(double %a) #0 {
 ;  %r = fptrunc double %a to bfloat
 ;  ret bfloat %r
 ;}
 
-;define bfloat @test_fptrunc_float_fast(float %a) #0 {
-;  %r = fptrunc fast float %a to bfloat
-;  ret bfloat %r
-;}
+define bfloat @test_fptrunc_float_fast(float %a) #0 {
+; CHECK-CVT-LABEL: test_fptrunc_float_fast:
+; CHECK-CVT:       @ %bb.0:
+; CHECK-CVT-NEXT:    .save {r11, lr}
+; CHECK-CVT-NEXT:    push {r11, lr}
+; CHECK-CVT-NEXT:    bl __truncsfbf2
+; CHECK-CVT-NEXT:    pop {r11, pc}
+;
+; CHECK-BF16-LABEL: test_fptrunc_float_fast:
+; CHECK-BF16:       @ %bb.0:
+; CHECK-BF16-NEXT:    vcvtb.bf16.f32 s0, s0
+; CHECK-BF16-NEXT:    bx lr
+  %r = fptrunc fast float %a to bfloat
+  ret bfloat %r
+}
 
 ;define bfloat @test_fptrunc_double_fast(double %a) #0 {
 ;  %r = fptrunc fast double %a to bfloat


### PR DESCRIPTION
This adds basic bf16 fpround support, custom lowering f32 operations to vcvtb
instructions.