### PR TITLE
[AArch64][NFC] remove CPUInfo.getImpliedExtensions()

### DIFF
--- a/llvm/include/llvm/TargetParser/AArch64TargetParser.h
+++ b/llvm/include/llvm/TargetParser/AArch64TargetParser.h
@@ -161,10 +161,6 @@ struct CpuInfo {
   const ArchInfo &Arch;
   AArch64::ExtensionBitset
       DefaultExtensions; // Default extensions for this CPU.
-
-  AArch64::ExtensionBitset getImpliedExtensions() const {
-    return DefaultExtensions;
-  }
 };
 
 #define EMIT_CPU_INFO

--- a/llvm/lib/TargetParser/AArch64TargetParser.cpp
+++ b/llvm/lib/TargetParser/AArch64TargetParser.cpp
@@ -344,9 +344,8 @@ void AArch64::ExtensionSet::addCPUDefaults(const CpuInfo &CPU) {
   LLVM_DEBUG(llvm::dbgs() << "addCPUDefaults(" << CPU.Name << ")\n");
   BaseArch = &CPU.Arch;
 
-  AArch64::ExtensionBitset CPUExtensions = CPU.getImpliedExtensions();
   for (const auto &E : Extensions)
-    if (CPUExtensions.test(E.ID))
+    if (CPU.DefaultExtensions.test(E.ID))
       enable(E.ID);
 }
 

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -1227,7 +1227,7 @@ TEST_P(AArch64CPUAliasTestFixture, testCPUAlias) {
   StringRef MainName = params.Aliases[0];
   const std::optional<AArch64::CpuInfo> Cpu = AArch64::parseCpu(MainName);
   const AArch64::ArchInfo &MainAI = Cpu->Arch;
-  AArch64::ExtensionBitset MainFlags = Cpu->getImpliedExtensions();
+  AArch64::ExtensionBitset MainFlags = Cpu->DefaultExtensions;
 
   for (size_t I = 1, E = params.Aliases.size(); I != E; ++I) {
     StringRef OtherName = params.Aliases[I];
@@ -1244,7 +1244,7 @@ TEST_P(AArch64CPUAliasTestFixture, testCPUAlias) {
         << MainName << " vs " << OtherName;
     EXPECT_EQ(MainAI, OtherAI) << MainName << " vs " << OtherName;
 
-    AArch64::ExtensionBitset OtherFlags = OtherCpu->getImpliedExtensions();
+    AArch64::ExtensionBitset OtherFlags = OtherCpu->DefaultExtensions;
 
     EXPECT_EQ(MainFlags, OtherFlags) << MainName << " vs " << OtherName;
 
@@ -1319,7 +1319,7 @@ bool testAArch64Extension(StringRef CPUName, StringRef ArchExt) {
   if (!Extension)
     return false;
   std::optional<AArch64::CpuInfo> CpuInfo = AArch64::parseCpu(CPUName);
-  return CpuInfo->getImpliedExtensions().test(Extension->ID);
+  return CpuInfo->DefaultExtensions.test(Extension->ID);
 }
 
 bool testAArch64Extension(const AArch64::ArchInfo &AI, StringRef ArchExt) {


### PR DESCRIPTION
The name was slightly misleading (getDefaultExtensions would be better) and the function is not doing anything interesting.