### PR TITLE
[DebugInfo] Clear subregister mask state after use

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -770,6 +770,8 @@ void DwarfExpression::maskSubRegister() {
     addShr(SubRegisterOffsetInBits);
   uint64_t Mask = (1ULL << (uint64_t)SubRegisterSizeInBits) - 1ULL;
   addAnd(Mask);
+  // The mask consumes the pending subregister description.
+  setSubRegisterPiece(0, 0);
 }
 
 void DwarfExpression::finalize() {

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -763,7 +763,9 @@ bool DwarfExpression::addExpression(
   return true;
 }
 
-/// add masking operations to stencil out a subregister.
+/// Emit shift/mask operations for the pending subregister. After the operations
+/// are emitted, consume the pending subregister description by clearing
+/// SubRegisterSizeInBits and SubRegisterOffsetInBits.
 void DwarfExpression::maskSubRegister() {
   assert(SubRegisterSizeInBits && "no subregister was registered");
   if (SubRegisterOffsetInBits > 0)

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
@@ -118,7 +118,9 @@ protected:
     SubRegisterOffsetInBits = OffsetInBits;
   }
 
-  /// Add masking operations to stencil out a subregister.
+  /// Emit shift/mask operations for the pending subregister. After the
+  /// operations are emitted, consume the pending subregister description by
+  /// clearing SubRegisterSizeInBits and SubRegisterOffsetInBits.
   void maskSubRegister();
 
   /// Output a dwarf operand and an optional assembler comment.

--- a/llvm/test/DebugInfo/X86/diarglist-subregister-mask.ll
+++ b/llvm/test/DebugInfo/X86/diarglist-subregister-mask.ll
@@ -1,0 +1,56 @@
+; RUN: llc -mtriple=x86_64-pc-linux-gnu -dwarf-version=5 -filetype=obj -o - %s \
+; RUN:   | llvm-dwarfdump -debug-info - | FileCheck %s
+
+;; Check that masking a subregister location for one DW_OP_LLVM_arg does not
+;; leak into a following full-register DW_OP_LLVM_arg in the same expression.
+
+; CHECK: DW_AT_location (DW_OP_breg5 RDI+0, DW_OP_constu 0xffffffff, DW_OP_and, DW_OP_convert {{.*}}"DW_ATE_signed_32", DW_OP_convert {{.*}}"DW_ATE_signed_64", DW_OP_breg4 RSI+0, DW_OP_eq, DW_OP_convert {{.*}}"DW_ATE_unsigned_1", DW_OP_convert {{.*}}"DW_ATE_unsigned_32", DW_OP_stack_value)
+; CHECK-NEXT: DW_AT_name ("x")
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+
+@sinki = global i32 0, align 4
+@sinku64 = global i64 0, align 8
+
+define i32 @test(i32 %a, i64 %b) !dbg !7 {
+entry:
+    #dbg_value(i32 %a, !14, !DIExpression(), !17)
+    #dbg_value(i64 %b, !15, !DIExpression(), !17)
+    #dbg_value(!DIArgList(i32 %a, i64 %b), !16, !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_convert, 32, DW_ATE_signed, DW_OP_LLVM_convert, 64, DW_ATE_signed, DW_OP_LLVM_arg, 1, DW_OP_eq, DW_OP_LLVM_convert, 1, DW_ATE_unsigned, DW_OP_LLVM_convert, 32, DW_ATE_unsigned, DW_OP_stack_value), !17)
+  %0 = load volatile i32, ptr @sinki, align 4
+  %add = add i32 %0, %a, !dbg !18
+  store volatile i32 %add, ptr @sinki, align 4, !dbg !19
+  %1 = load volatile i64, ptr @sinku64, align 8, !dbg !20
+  %add2 = add i64 %1, %b, !dbg !21
+  store volatile i64 %add2, ptr @sinku64, align 8, !dbg !22
+  ret i32 0, !dbg !23
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !24}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "test", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, globals: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "diarglist-subregister-mask.c", directory: "/")
+!2 = !{}
+!3 = !{i32 7, !"Dwarf Version", i32 5}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!6 = !DIBasicType(name: "unsigned long", size: 64, encoding: DW_ATE_unsigned)
+!7 = distinct !DISubprogram(name: "test", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !13, keyInstructions: true)
+!8 = !DISubroutineType(types: !9)
+!9 = !{!5, !10, !6}
+!10 = !DIDerivedType(tag: DW_TAG_typedef, name: "int32_t", file: !1, line: 1, baseType: !5)
+!11 = !DIDerivedType(tag: DW_TAG_typedef, name: "uint64_t", file: !1, line: 1, baseType: !6)
+!12 = !{}
+!13 = !{!14, !15, !16}
+!14 = !DILocalVariable(name: "a", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!15 = !DILocalVariable(name: "b", arg: 2, scope: !7, file: !1, line: 1, type: !11)
+!16 = !DILocalVariable(name: "x", scope: !7, file: !1, line: 2, type: !5)
+!17 = !DILocation(line: 0, scope: !7)
+!18 = !DILocation(line: 3, column: 9, scope: !7, atomGroup: 1, atomRank: 2)
+!19 = !DILocation(line: 3, column: 9, scope: !7, atomGroup: 1, atomRank: 1)
+!20 = !DILocation(line: 4, column: 11, scope: !7)
+!21 = !DILocation(line: 4, column: 11, scope: !7, atomGroup: 2, atomRank: 2)
+!22 = !DILocation(line: 4, column: 11, scope: !7, atomGroup: 2, atomRank: 1)
+!23 = !DILocation(line: 5, column: 3, scope: !7, atomGroup: 3, atomRank: 1)
+!24 = !{i32 7, !"debug-info-assignment-tracking", i1 true}


### PR DESCRIPTION
## Summary

This patch fixes a DWARF debug-info emission bug where the pending subregister mask state used for one `DW_OP_LLVM_arg` could leak into a following full-register `DW_OP_LLVM_arg` in the same `DIArgList` expression.

For example, when an `i32` value is described through the x86-64 super-register `RDI`, LLVM correctly emits:

```text
DW_OP_breg5 RDI+0
DW_OP_constu 0xffffffff
DW_OP_and
```

However, before this patch, the subregister state remained live after emitting that mask. If the next `DW_OP_LLVM_arg` used a full 64-bit register such as `RSI`, LLVM could incorrectly emit the same 32-bit mask for it too:

```text
DW_OP_breg4 RSI+0
DW_OP_constu 0xffffffff
DW_OP_and
```

## Reproducer
Source code:
```c
#include <stdint.h>

volatile int sinki;
volatile uint64_t sinku64;

__attribute__((noinline))
int test(int32_t a, uint64_t b) {
  int x = a == b;
  sinki += a;
  sinku64 += b;
  return 0;
}

int main(void) {
  return test(-1, UINT64_MAX);
}
```
Compile with: `clang -O2 -g -gdwarf-5 repro.c -o repro`

DebugInfo in IR for variable `x` (still correct at this point):
```
#dbg_value(!DIArgList(i32 %a, i64 %b), !x,
  !DIExpression(DW_OP_LLVM_arg, 0,
                DW_OP_LLVM_convert, 32, DW_ATE_signed,
                DW_OP_LLVM_convert, 64, DW_ATE_signed,
                DW_OP_LLVM_arg, 1,
                DW_OP_eq,
                DW_OP_LLVM_convert, 1, DW_ATE_unsigned,
                DW_OP_LLVM_convert, 32, DW_ATE_unsigned,
                DW_OP_stack_value), !loc)
```

Emitted DWARF Expression in binary:
```text
# get value of a
DW_OP_breg5 RDI+0
DW_OP_constu 0xffffffff
DW_OP_and
DW_OP_convert <signed_32>
DW_OP_convert <signed_64>
# get value of b (wrong)
DW_OP_breg4 RSI+0
DW_OP_constu 0xffffffff
DW_OP_and
# comparison
DW_OP_eq
DW_OP_stack_value
```

With the buggy DWARF expression, LLDB can evaluate `x` as `0`, even though the source-level value is `1`.

## Fix
`DwarfExpression::maskSubRegister()` consumes the pending subregister description when it emits the mask. This patch clears that state inside `maskSubRegister()` after emitting the shift/mask operations, preventing it from affecting later operands in the same expression.

A regression test (`test/DebugInfo/X86/diarglist-subregister-mask.ll`) was added to check that the first subregister operand is masked, while the following full-register operand is not.

## Validation

Locally verified with:
```
llvm-lit -sv llvm/test/DebugInfo/X86/diarglist-subregister-mask.ll
ninja -C build check-llvm
ninja -C build check-lldb
```
Both `check-llvm` and `check-lldb` completed with no unexpected failures.