### PR TITLE
[AMDGPU][InsertWaitCnts] Improve testing coverage for VMemTypes

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/mixed-vmem-types.ll
+++ b/llvm/test/CodeGen/AMDGPU/mixed-vmem-types.ll
@@ -3,8 +3,8 @@
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1200 < %s | FileCheck -check-prefixes=GFX12 %s
 ; RUN: llc -global-isel -mtriple=amdgcn -mcpu=gfx1200 < %s | FileCheck -check-prefixes=GFX12-GISEL %s
 
-define amdgpu_cs void @mixed_vmem_types(i32 inreg %globalTable, i32 inreg %perShaderTable, i32 inreg %descTable0, i32 inreg %descTable1, <3 x i32> inreg %WorkgroupId, i32 inreg %MultiDispatchInfo, <3 x i32> %LocalInvocationId) #0 {
-; GFX11-LABEL: mixed_vmem_types:
+define amdgpu_cs void @mixed_vmem_types_sampler_reads(i32 inreg %globalTable, i32 inreg %perShaderTable, i32 inreg %descTable0, i32 inreg %descTable1, <3 x i32> inreg %WorkgroupId, i32 inreg %MultiDispatchInfo, <3 x i32> %LocalInvocationId) #0 {
+; GFX11-LABEL: mixed_vmem_types_sampler_reads:
 ; GFX11:       ; %bb.0: ; %.entry
 ; GFX11-NEXT:    s_getpc_b64 s[4:5]
 ; GFX11-NEXT:    s_mov_b32 s0, s3
@@ -40,7 +40,7 @@ define amdgpu_cs void @mixed_vmem_types(i32 inreg %globalTable, i32 inreg %perSh
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[24:27], 0
 ; GFX11-NEXT:    s_endpgm
 ;
-; GFX12-LABEL: mixed_vmem_types:
+; GFX12-LABEL: mixed_vmem_types_sampler_reads:
 ; GFX12:       ; %bb.0: ; %.entry
 ; GFX12-NEXT:    s_getpc_b64 s[4:5]
 ; GFX12-NEXT:    s_mov_b32 s0, s3
@@ -77,7 +77,7 @@ define amdgpu_cs void @mixed_vmem_types(i32 inreg %globalTable, i32 inreg %perSh
 ; GFX12-NEXT:    buffer_store_b32 v0, off, s[24:27], null
 ; GFX12-NEXT:    s_endpgm
 ;
-; GFX12-GISEL-LABEL: mixed_vmem_types:
+; GFX12-GISEL-LABEL: mixed_vmem_types_sampler_reads:
 ; GFX12-GISEL:       ; %bb.0: ; %.entry
 ; GFX12-GISEL-NEXT:    s_getpc_b64 s[4:5]
 ; GFX12-GISEL-NEXT:    s_mov_b32 s0, s3
@@ -160,6 +160,243 @@ define amdgpu_cs void @mixed_vmem_types(i32 inreg %globalTable, i32 inreg %perSh
   %i23 = load <8 x i32>, ptr addrspace(4) %i22, align 32
   %i24 = load <4 x i32>, ptr addrspace(4) %i3, align 16
   %i25 = call float @llvm.amdgcn.image.sample.lz.2d.f32.f16.v8i32.v4i32(i32 1, half 0xHBC00, half 0xHBC00, <8 x i32> %i23, <4 x i32> %i24, i1 false, i32 0, i32 0)
+  %i26 = fcmp oeq float %i25, 1.000000e+00
+  %i27 = call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> %i10, i32 0, i32 0, i32 0)
+  %.not2 = icmp eq i32 %i27, 2752
+  %i28 = select i1 %.not2, i1 %i26, i1 false
+  %i29 = select i1 %i28, i1 %.not1, i1 false
+  %i30 = select i1 %i29, i1 %.not, i1 false
+  %narrow2 = select i1 %i30, i1 %i19, i1 false
+  %.4 = zext i1 %narrow2 to i32
+  call void @llvm.amdgcn.raw.buffer.store.i32(i32 %.4, <4 x i32> %i8, i32 0, i32 0, i32 0)
+  ret void
+}
+
+define amdgpu_cs void @mixed_vmem_types_bvh_reads(i32 inreg %descTable0, i32 inreg %descTable1, i64 %node_ptr, float %ray_extent, <3 x float> %ray_origin, <3 x float> %ray_dir, <3 x float> %ray_inv_dir, <4 x i32> %tdescr) #0 {
+; GFX11-LABEL: mixed_vmem_types_bvh_reads:
+; GFX11:       ; %bb.0: ; %.entry
+; GFX11-NEXT:    s_getpc_b64 s[2:3]
+; GFX11-NEXT:    s_mov_b32 s12, s1
+; GFX11-NEXT:    s_mov_b32 s1, s3
+; GFX11-NEXT:    s_mov_b32 s13, s3
+; GFX11-NEXT:    s_clause 0x1
+; GFX11-NEXT:    s_load_b128 s[8:11], s[0:1], 0x10
+; GFX11-NEXT:    s_load_b256 s[0:7], s[0:1], 0x40
+; GFX11-NEXT:    s_load_b128 s[12:15], s[12:13], 0x30
+; GFX11-NEXT:    s_mov_b32 s20, exec_lo
+; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-NEXT:    s_mov_b32 s21, s20
+; GFX11-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX11-NEXT:    v_readfirstlane_b32 s16, v12
+; GFX11-NEXT:    v_readfirstlane_b32 s17, v13
+; GFX11-NEXT:    v_readfirstlane_b32 s18, v14
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    v_readfirstlane_b32 s19, v15
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cmpx_eq_u64_e32 s[16:17], v[12:13]
+; GFX11-NEXT:    v_cmpx_eq_u64_e32 s[18:19], v[14:15]
+; GFX11-NEXT:    image_bvh64_intersect_ray v[15:18], v[0:11], s[16:19]
+; GFX11-NEXT:    s_and_not1_wrexec_b32 s21, s21
+; GFX11-NEXT:    ; implicit-def: $vgpr12_vgpr13_vgpr14_vgpr15
+; GFX11-NEXT:    ; implicit-def: $vgpr0_vgpr1
+; GFX11-NEXT:    ; implicit-def: $vgpr2
+; GFX11-NEXT:    ; implicit-def: $vgpr3_vgpr4_vgpr5
+; GFX11-NEXT:    ; implicit-def: $vgpr6_vgpr7_vgpr8
+; GFX11-NEXT:    ; implicit-def: $vgpr9_vgpr10_vgpr11
+; GFX11-NEXT:    s_cbranch_execnz .LBB1_1
+; GFX11-NEXT:  ; %bb.2:
+; GFX11-NEXT:    s_mov_b32 exec_lo, s20
+; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-NEXT:    buffer_load_b32 v0, off, s[0:3], 0
+; GFX11-NEXT:    buffer_load_b32 v1, off, s[12:15], 0
+; GFX11-NEXT:    buffer_load_b32 v2, off, s[8:11], 0
+; GFX11-NEXT:    s_waitcnt vmcnt(3)
+; GFX11-NEXT:    v_cmp_eq_f32_e64 s1, 1.0, v16
+; GFX11-NEXT:    s_waitcnt vmcnt(2)
+; GFX11-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0xac0, v0
+; GFX11-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-NEXT:    v_cmp_eq_u32_e64 s0, 0xac0, v1
+; GFX11-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-NEXT:    v_cmp_eq_u32_e64 s2, 0xac0, v2
+; GFX11-NEXT:    s_and_b32 s0, s0, vcc_lo
+; GFX11-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v16
+; GFX11-NEXT:    s_and_b32 s0, s0, s1
+; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX11-NEXT:    s_and_b32 s0, s0, s2
+; GFX11-NEXT:    s_and_b32 s0, s0, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s0
+; GFX11-NEXT:    buffer_store_b32 v0, off, s[4:7], 0
+; GFX11-NEXT:    s_endpgm
+;
+; GFX12-LABEL: mixed_vmem_types_bvh_reads:
+; GFX12:       ; %bb.0: ; %.entry
+; GFX12-NEXT:    s_getpc_b64 s[2:3]
+; GFX12-NEXT:    s_mov_b32 s12, s1
+; GFX12-NEXT:    s_sext_i32_i16 s3, s3
+; GFX12-NEXT:    s_mov_b32 s20, exec_lo
+; GFX12-NEXT:    s_mov_b32 s1, s3
+; GFX12-NEXT:    s_mov_b32 s13, s3
+; GFX12-NEXT:    s_clause 0x1
+; GFX12-NEXT:    s_load_b128 s[8:11], s[0:1], 0x10
+; GFX12-NEXT:    s_load_b256 s[0:7], s[0:1], 0x40
+; GFX12-NEXT:    s_load_b128 s[12:15], s[12:13], 0x30
+; GFX12-NEXT:    s_mov_b32 s21, s20
+; GFX12-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX12-NEXT:    v_readfirstlane_b32 s16, v12
+; GFX12-NEXT:    v_readfirstlane_b32 s17, v13
+; GFX12-NEXT:    v_readfirstlane_b32 s18, v14
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    v_readfirstlane_b32 s19, v15
+; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-NEXT:    v_cmpx_eq_u64_e32 s[16:17], v[12:13]
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX12-NEXT:    v_cmpx_eq_u64_e32 s[18:19], v[14:15]
+; GFX12-NEXT:    image_bvh64_intersect_ray v[15:18], [v[0:1], v2, v[3:5], v[6:8], v[9:11]], s[16:19]
+; GFX12-NEXT:    s_and_not1_wrexec_b32 s21, s21
+; GFX12-NEXT:    ; implicit-def: $vgpr12_vgpr13_vgpr14_vgpr15
+; GFX12-NEXT:    ; implicit-def: $vgpr0_vgpr1
+; GFX12-NEXT:    ; implicit-def: $vgpr2
+; GFX12-NEXT:    ; implicit-def: $vgpr3_vgpr4_vgpr5
+; GFX12-NEXT:    ; implicit-def: $vgpr6_vgpr7_vgpr8
+; GFX12-NEXT:    ; implicit-def: $vgpr9_vgpr10_vgpr11
+; GFX12-NEXT:    s_cbranch_execnz .LBB1_1
+; GFX12-NEXT:  ; %bb.2:
+; GFX12-NEXT:    s_mov_b32 exec_lo, s20
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    buffer_load_b32 v0, off, s[0:3], null
+; GFX12-NEXT:    buffer_load_b32 v1, off, s[12:15], null
+; GFX12-NEXT:    buffer_load_b32 v2, off, s[8:11], null
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    v_cmp_eq_f32_e64 s1, 1.0, v16
+; GFX12-NEXT:    s_wait_loadcnt 0x2
+; GFX12-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0xac0, v0
+; GFX12-NEXT:    s_wait_loadcnt 0x1
+; GFX12-NEXT:    v_cmp_eq_u32_e64 s0, 0xac0, v1
+; GFX12-NEXT:    s_wait_loadcnt 0x0
+; GFX12-NEXT:    v_cmp_eq_u32_e64 s2, 0xac0, v2
+; GFX12-NEXT:    s_and_b32 s0, s0, vcc_lo
+; GFX12-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v16
+; GFX12-NEXT:    s_and_b32 s0, s0, s1
+; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX12-NEXT:    s_and_b32 s0, s0, s2
+; GFX12-NEXT:    s_and_b32 s0, s0, vcc_lo
+; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX12-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s0
+; GFX12-NEXT:    buffer_store_b32 v0, off, s[4:7], null
+; GFX12-NEXT:    s_endpgm
+;
+; GFX12-GISEL-LABEL: mixed_vmem_types_bvh_reads:
+; GFX12-GISEL:       ; %bb.0: ; %.entry
+; GFX12-GISEL-NEXT:    s_getpc_b64 s[4:5]
+; GFX12-GISEL-NEXT:    s_mov_b32 s2, s1
+; GFX12-GISEL-NEXT:    s_sext_i32_i16 s5, s5
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX12-GISEL-NEXT:    s_mov_b32 s1, s5
+; GFX12-GISEL-NEXT:    s_mov_b32 s3, s5
+; GFX12-GISEL-NEXT:    s_load_b256 s[4:11], s[0:1], 0x40
+; GFX12-GISEL-NEXT:    s_load_b128 s[12:15], s[2:3], 0x30
+; GFX12-GISEL-NEXT:    s_load_b128 s[16:19], s[0:1], 0x10
+; GFX12-GISEL-NEXT:    s_mov_b32 s1, exec_lo
+; GFX12-GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX12-GISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GISEL-NEXT:    v_readfirstlane_b32 s20, v12
+; GFX12-GISEL-NEXT:    v_readfirstlane_b32 s21, v13
+; GFX12-GISEL-NEXT:    v_readfirstlane_b32 s22, v14
+; GFX12-GISEL-NEXT:    v_readfirstlane_b32 s23, v15
+; GFX12-GISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX12-GISEL-NEXT:    v_cmp_eq_u64_e32 vcc_lo, s[20:21], v[12:13]
+; GFX12-GISEL-NEXT:    v_cmp_eq_u64_e64 s0, s[22:23], v[14:15]
+; GFX12-GISEL-NEXT:    s_and_b32 s0, vcc_lo, s0
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX12-GISEL-NEXT:    s_and_saveexec_b32 s0, s0
+; GFX12-GISEL-NEXT:    image_bvh64_intersect_ray v[12:15], [v[0:1], v2, v[3:5], v[6:8], v[9:11]], s[20:23]
+; GFX12-GISEL-NEXT:    ; implicit-def: $vgpr12
+; GFX12-GISEL-NEXT:    ; implicit-def: $vgpr0_vgpr1
+; GFX12-GISEL-NEXT:    ; implicit-def: $vgpr2
+; GFX12-GISEL-NEXT:    ; implicit-def: $vgpr3_vgpr4_vgpr5
+; GFX12-GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7_vgpr8
+; GFX12-GISEL-NEXT:    ; implicit-def: $vgpr9_vgpr10_vgpr11
+; GFX12-GISEL-NEXT:    ; implicit-def: $vgpr14_vgpr15
+; GFX12-GISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
+; GFX12-GISEL-NEXT:    s_cbranch_execnz .LBB1_1
+; GFX12-GISEL-NEXT:  ; %bb.2:
+; GFX12-GISEL-NEXT:    s_mov_b32 exec_lo, s1
+; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-NEXT:    buffer_load_b32 v0, off, s[16:19], null
+; GFX12-GISEL-NEXT:    buffer_load_b32 v1, off, s[4:7], null
+; GFX12-GISEL-NEXT:    buffer_load_b32 v2, off, s[12:15], null
+; GFX12-GISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GISEL-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 1.0, v13
+; GFX12-GISEL-NEXT:    s_wait_loadcnt 0x2
+; GFX12-GISEL-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX12-GISEL-NEXT:    s_wait_loadcnt 0x1
+; GFX12-GISEL-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX12-GISEL-NEXT:    s_wait_loadcnt 0x0
+; GFX12-GISEL-NEXT:    v_readfirstlane_b32 s2, v2
+; GFX12-GISEL-NEXT:    s_cmp_eq_u32 s0, 0xac0
+; GFX12-GISEL-NEXT:    s_cselect_b32 s0, 1, 0
+; GFX12-GISEL-NEXT:    s_cmp_eq_u32 s1, 0xac0
+; GFX12-GISEL-NEXT:    s_cselect_b32 s1, 1, 0
+; GFX12-GISEL-NEXT:    s_cmp_eq_u32 s2, 0xac0
+; GFX12-GISEL-NEXT:    s_cselect_b32 s2, exec_lo, 0
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(SALU_CYCLE_1)
+; GFX12-GISEL-NEXT:    s_and_b32 s2, s2, vcc_lo
+; GFX12-GISEL-NEXT:    s_cmp_lg_u32 s1, 0
+; GFX12-GISEL-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v13
+; GFX12-GISEL-NEXT:    s_cselect_b32 s1, exec_lo, 0
+; GFX12-GISEL-NEXT:    s_and_b32 s1, s2, s1
+; GFX12-GISEL-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX12-GISEL-NEXT:    s_cselect_b32 s0, exec_lo, 0
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX12-GISEL-NEXT:    s_and_b32 s0, s1, s0
+; GFX12-GISEL-NEXT:    s_and_b32 s0, s0, vcc_lo
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX12-GISEL-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s0
+; GFX12-GISEL-NEXT:    buffer_store_b32 v0, off, s[8:11], null
+; GFX12-GISEL-NEXT:    s_endpgm
+.entry:
+  %i = call i64 @llvm.amdgcn.s.getpc()
+  %extelt.offset = lshr i64 %i, 32
+  %.i1 = trunc i64 %extelt.offset to i32
+  %.upto0 = insertelement <2 x i32> poison, i32 %descTable1, i64 0
+  %i1 = insertelement <2 x i32> %.upto0, i32 %.i1, i64 1
+  %i2 = bitcast <2 x i32> %i1 to i64
+  %i3 = inttoptr i64 %i2 to ptr addrspace(4)
+  %.upto03 = insertelement <2 x i32> poison, i32 %descTable0, i64 0
+  %i4 = insertelement <2 x i32> %.upto03, i32 %.i1, i64 1
+  %i5 = bitcast <2 x i32> %i4 to i64
+  %i6 = inttoptr i64 %i5 to ptr addrspace(4)
+  %i7 = getelementptr i8, ptr addrspace(4) %i6, i64 80
+  %i8 = load <4 x i32>, ptr addrspace(4) %i7, align 16
+  %i9 = getelementptr i8, ptr addrspace(4) %i3, i64 48
+  %i10 = load <4 x i32>, ptr addrspace(4) %i9, align 16
+  %i11 = getelementptr i8, ptr addrspace(4) %i6, i64 64
+  %i12 = load <4 x i32>, ptr addrspace(4) %i11, align 16
+  %i13 = getelementptr i8, ptr addrspace(4) %i6, i64 16
+  %i14 = load <4 x i32>, ptr addrspace(4) %i13, align 16
+  %i15 = getelementptr i8, ptr addrspace(4) %i6, i64 32
+  %i16 = load <8 x i32>, ptr addrspace(4) %i15, align 32
+  %i17 = load <4 x i32>, ptr addrspace(4) %i6, align 16
+
+  %i18.res = call <4 x i32> @llvm.amdgcn.image.bvh.intersect.ray.i64.v4f32(i64 %node_ptr, float %ray_extent, <3 x float> %ray_origin, <3 x float> %ray_dir, <3 x float> %ray_inv_dir, <4 x i32> %tdescr)
+  %i18.cast = bitcast <4 x i32> %i18.res to <4 x float>
+  %i18 = extractelement <4 x float> %i18.cast, i32 1
+
+  %i19 = fcmp oeq float %i18, 0.000000e+00
+  %i20 = call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> %i14, i32 0, i32 0, i32 0)
+  %.not = icmp eq i32 %i20, 2752
+  %i21 = call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> %i12, i32 0, i32 0, i32 0)
+  %.not1 = icmp eq i32 %i21, 2752
+  %i22 = getelementptr i8, ptr addrspace(4) %i3, i64 16
+  %i23 = load <8 x i32>, ptr addrspace(4) %i22, align 32
+  %i24 = load <4 x i32>, ptr addrspace(4) %i3, align 16
+
+  %i25.res = call <4 x i32> @llvm.amdgcn.image.bvh.intersect.ray.i64.v4f32(i64 %node_ptr, float %ray_extent, <3 x float> %ray_origin, <3 x float> %ray_dir, <3 x float> %ray_inv_dir, <4 x i32> %tdescr)
+  %i25.cast = bitcast <4 x i32> %i18.res to <4 x float>
+  %i25 = extractelement <4 x float> %i18.cast, i32 1
+
   %i26 = fcmp oeq float %i25, 1.000000e+00
   %i27 = call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> %i10, i32 0, i32 0, i32 0)
   %.not2 = icmp eq i32 %i27, 2752

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-bvh.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-bvh.mir
@@ -23,8 +23,10 @@ body: |
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr0 = BUFFER_LOAD_DWORD_OFFEN $vgpr16, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
+    ; GCN-NEXT: $vgpr0 = BUFFER_LOAD_DWORD_OFFEN $vgpr16, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
+    $vgpr0 = BUFFER_LOAD_DWORD_OFFEN $vgpr16, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
     $vgpr0 = BUFFER_LOAD_DWORD_OFFEN $vgpr16, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
     S_ENDPGM 0
 ...
@@ -37,8 +39,10 @@ body: |
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_SAMPLE_V4_V2 $vgpr20_vgpr21, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
+    ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_SAMPLE_V4_V2 $vgpr20_vgpr21, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
+    $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_SAMPLE_V4_V2 $vgpr20_vgpr21, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
     $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_SAMPLE_V4_V2 $vgpr20_vgpr21, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
     S_ENDPGM 0
 ...
@@ -51,8 +55,10 @@ body: |
     ; GCN-NEXT: $vgpr0 = BUFFER_LOAD_DWORD_OFFEN $vgpr20, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
     ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
+    ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr0 = BUFFER_LOAD_DWORD_OFFEN $vgpr20, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec
+    $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     S_ENDPGM 0
 ...
@@ -65,8 +71,10 @@ body: |
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_SAMPLE_V4_V2 $vgpr16_vgpr17, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
     ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
+    ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_SAMPLE_V4_V2 $vgpr16_vgpr17, $sgpr4_sgpr5_sgpr6_sgpr7_sgpr8_sgpr9_sgpr10_sgpr11, $sgpr0_sgpr1_sgpr2_sgpr3, 15, 0, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), align 4, addrspace 4)
+    $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_BVH_INTERSECT_RAY_sa_gfx10 killed $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14, killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, 0, implicit $exec :: (dereferenceable load (s128), addrspace 7)
     S_ENDPGM 0
 ...


### PR DESCRIPTION
The next patch will get rid of VMEMTypes, but some of its functionality
was not tested well. This patch adds more tests to fix gaps in testing
so that the next patch in the stack can be shown to have no impact
on codegen.

The 2 issues I had noticed was that we didn't have a test for mixed
vmem types w/ BVH, only for sampler; we also did not have a test
that was affected by `clearVmemTypes`, so removing that call
had no effect.

This patch adds tests for both cases.