### PR TITLE
[lldb] Reduce output of TestDataFormatterStdVBool

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/TestDataFormatterStdVBool.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/TestDataFormatterStdVBool.py
@@ -44,11 +44,12 @@ class StdVBoolDataFormatterTestCase(TestBase):
             self.runCmd("type synth clear", check=False)
             self.runCmd("settings set target.max-children-count 24", check=False)
 
+        self.runCmd("settings set target.max-children-count 128", check=False)
         # Execute the cleanup function during test case tear down.
         self.addTearDownHook(cleanup)
 
         self.expect(
-            "frame variable -A vBool",
+            "frame variable vBool",
             substrs=[
                 "size=73",
                 "[0] = false",
@@ -69,7 +70,7 @@ class StdVBoolDataFormatterTestCase(TestBase):
         )
 
         self.expect(
-            "expr -A -- vBool",
+            "expr -- vBool",
             substrs=[
                 "size=73",
                 "[0] = false",


### PR DESCRIPTION
Tests should not be printing an unbounded amount of data, especially when said data is the subject of corruption or misinterpretation by the printer (the formatter, in this case).

This test is currently failing on the matrix bots, with the result that close to 3GB of text is produced.