### PR TITLE
[clang][bytecode] Fix an assertion failure in dynamic_cast handling

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -2139,14 +2139,15 @@ bool DynamicCast(InterpState &S, CodePtr OpPC, const Type *DestTypePtr,
   std::optional<PtrView> Result;
   // First, check simple downcasts without ambiguities.
   for (PtrView Iter = Ptr.view();;) {
+    if (Iter.isRoot() || !Iter.isBaseClass())
+      break;
+
     if (typesMatch(TargetType, Iter.getType())) {
       Result = Iter;
       break;
     }
     // Moving DOWN the type hierarchy.
     Iter = Iter.getBase();
-    if (Iter.isRoot() || !Iter.isBaseClass())
-      break;
   }
 
   // Simply walking down the type hierarchy has produced a valid result, use

--- a/clang/test/AST/ByteCode/dynamic-cast.cpp
+++ b/clang/test/AST/ByteCode/dynamic-cast.cpp
@@ -295,6 +295,20 @@ namespace UnrelatedAndRootPtr{
   static_assert(f());
 }
 
+namespace UnrelatedAndRootReference {
+  struct A {
+    virtual void foo();
+  };
+  struct B1 : A {};
+
+  struct B2 : A {};
+  struct C : B2 {};
+
+  constexpr C c;
+  static_assert(&dynamic_cast<B2 &>((B1 &)c), ""); // both-error {{not an integral constant expression}} \
+                                                   // both-note {{cast that performs the conversions of a reinterpret_cast is not allowed in a constant expression}}
+}
+
 namespace Invalid {
   struct S { virtual void s(); };
   struct A : S {};


### PR DESCRIPTION
If `Ptr` is already a root pointer, the `getBase()` call ran into an assertion. Fix this by moving the check to the start of the loop.