### PR TITLE
[EarlyCSE] Do not forward memset zero to intrinsic

### DIFF
--- a/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
+++ b/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
@@ -1185,7 +1185,8 @@ Value *EarlyCSE::getMatchingValue(LoadValue &InVal, ParseMemoryInst &MemInst,
   if (InVal.DefInst == nullptr)
     return nullptr;
   if (auto *MSI = dyn_cast<MemSetInst>(InVal.DefInst)) {
-    if (!MemInst.isLoad() || MemInst.isVolatile() || !MemInst.isUnordered())
+    if (!MemInst.isLoad() || MemInst.isVolatile() || !MemInst.isUnordered() ||
+        MemInst.getMatchingId() != -1)
       return nullptr;
     if (MSI->isVolatile())
       return nullptr;

--- a/llvm/test/Transforms/EarlyCSE/memset-load.ll
+++ b/llvm/test/Transforms/EarlyCSE/memset-load.ll
@@ -91,7 +91,8 @@ define <4 x i32> @masked_load_from_zero_memset(ptr %p) {
 ; CHECK-LABEL: define <4 x i32> @masked_load_from_zero_memset(
 ; CHECK-SAME: ptr [[P:%.*]]) {
 ; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr [[P]], i8 0, i64 16, i1 false)
-; CHECK-NEXT:    ret <4 x i32> zeroinitializer
+; CHECK-NEXT:    [[V:%.*]] = call <4 x i32> @llvm.masked.load.v4i32.p0(ptr align 16 [[P]], <4 x i1> <i1 true, i1 false, i1 false, i1 false>, <4 x i32> splat (i32 7))
+; CHECK-NEXT:    ret <4 x i32> [[V]]
 ;
   call void @llvm.memset.p0.i64(ptr %p, i8 0, i64 16, i1 false)
   %v = call <4 x i32> @llvm.masked.load(ptr %p, i32 16, <4 x i1> <i1 true, i1 false, i1 false, i1 false>, <4 x i32> <i32 7, i32 7, i32 7, i32 7>)

--- a/llvm/test/Transforms/EarlyCSE/memset-load.ll
+++ b/llvm/test/Transforms/EarlyCSE/memset-load.ll
@@ -87,6 +87,17 @@ entry:
   ret ptr addrspace(1) %v
 }
 
+define <4 x i32> @masked_load_from_zero_memset(ptr %p) {
+; CHECK-LABEL: define <4 x i32> @masked_load_from_zero_memset(
+; CHECK-SAME: ptr [[P:%.*]]) {
+; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr [[P]], i8 0, i64 16, i1 false)
+; CHECK-NEXT:    ret <4 x i32> zeroinitializer
+;
+  call void @llvm.memset.p0.i64(ptr %p, i8 0, i64 16, i1 false)
+  %v = call <4 x i32> @llvm.masked.load(ptr %p, i32 16, <4 x i1> <i1 true, i1 false, i1 false, i1 false>, <4 x i32> <i32 7, i32 7, i32 7, i32 7>)
+  ret <4 x i32> %v
+}
+
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly, i8, i64, i1 immarg)
 declare void @llvm.memset.p1.i64(ptr addrspace(1) nocapture writeonly, i8, i64, i1 immarg)
 declare void @clobber(ptr)


### PR DESCRIPTION
We can do this in principle, but it would require more precise handling. E.g. for masked.load we'd have to respect the passthru argument for masked out lanes. I don't think this is worthwhile, so just bail out.