### PR TITLE
[Docs][TestSuite] Document additional debugify option for test suite

### DIFF
--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -428,6 +428,8 @@ tests. Changes to this pass are not allowed to break existing tests.
    check lines. In cases where this can't be avoided (say, if a test wouldn't
    be precise enough), moving the test to its own file is preferred.
 
+.. _DebugifyCoverageTracking:
+
 Using Coverage Tracking to remove false positives
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/llvm/docs/TestSuiteGuide.md
+++ b/llvm/docs/TestSuiteGuide.md
@@ -281,6 +281,19 @@ benchmarks. CMake can print a list of them:
   more information about expected versions or usage in the README files in the
   `External` directory (such as `External/SPEC/README`)
 
+- `TEST_SUITE_COLLECT_DEBUGIFY_LOC_COVERAGE`
+
+  If this is set to `ON` then LLVM will use DebugLoc coverage and origin
+  tracking to produce a report of unexpectedly missing debug locations,
+  accumulating bugs from all C/C++ compilations in the file
+  `<build-dir>/debugify-report.json`; this report can be prettified by using the
+  `llvm/utils/llvm-original-di-preservation.py` script (documented
+  [here](project:HowToUpdateDebugInfo.md#test-original-debug-info-preservation-in-optimizations)).
+  This requires the C and C++ compilers to be a version of Clang built with the
+  feature `LLVM_ENABLE_DEBUGLOC_COVERAGE_TRACKING=COVERAGE_AND_ORIGIN` (see
+  [here](project:HowToUpdateDebugInfo.md#using-coverage-tracking-to-remove-false-positives)
+  for more info).
+
 ### Common CMake Flags
 
 - `-GNinja`

--- a/llvm/docs/TestSuiteGuide.md
+++ b/llvm/docs/TestSuiteGuide.md
@@ -288,10 +288,10 @@ benchmarks. CMake can print a list of them:
   accumulating bugs from all C/C++ compilations in the file
   `<build-dir>/debugify-report.json`; this report can be prettified by using the
   `llvm/utils/llvm-original-di-preservation.py` script (documented
-  [here](project:HowToUpdateDebugInfo.rst#OriginalDI)).
+  {ref}`here <OriginalDI>`).
   This requires the C and C++ compilers to be a version of Clang built with the
   feature `LLVM_ENABLE_DEBUGLOC_COVERAGE_TRACKING=COVERAGE_AND_ORIGIN` (see
-  [here](project:HowToUpdateDebugInfo.rst#using-coverage-tracking-to-remove-false-positives)
+  {ref}`here <DebugifyCoverageTracking>`)
   for more info).
 
 ### Common CMake Flags

--- a/llvm/docs/TestSuiteGuide.md
+++ b/llvm/docs/TestSuiteGuide.md
@@ -291,8 +291,7 @@ benchmarks. CMake can print a list of them:
   {ref}`here <OriginalDI>`).
   This requires the C and C++ compilers to be a version of Clang built with the
   feature `LLVM_ENABLE_DEBUGLOC_COVERAGE_TRACKING=COVERAGE_AND_ORIGIN` (see
-  {ref}`here <DebugifyCoverageTracking>`)
-  for more info).
+  {ref}`here <DebugifyCoverageTracking>` for more info).
 
 ### Common CMake Flags
 

--- a/llvm/docs/TestSuiteGuide.md
+++ b/llvm/docs/TestSuiteGuide.md
@@ -288,10 +288,10 @@ benchmarks. CMake can print a list of them:
   accumulating bugs from all C/C++ compilations in the file
   `<build-dir>/debugify-report.json`; this report can be prettified by using the
   `llvm/utils/llvm-original-di-preservation.py` script (documented
-  [here](project:HowToUpdateDebugInfo.md#test-original-debug-info-preservation-in-optimizations)).
+  [here](project:HowToUpdateDebugInfo.rst#test-original-debug-info-preservation-in-optimizations)).
   This requires the C and C++ compilers to be a version of Clang built with the
   feature `LLVM_ENABLE_DEBUGLOC_COVERAGE_TRACKING=COVERAGE_AND_ORIGIN` (see
-  [here](project:HowToUpdateDebugInfo.md#using-coverage-tracking-to-remove-false-positives)
+  [here](project:HowToUpdateDebugInfo.rst#using-coverage-tracking-to-remove-false-positives)
   for more info).
 
 ### Common CMake Flags

--- a/llvm/docs/TestSuiteGuide.md
+++ b/llvm/docs/TestSuiteGuide.md
@@ -288,7 +288,7 @@ benchmarks. CMake can print a list of them:
   accumulating bugs from all C/C++ compilations in the file
   `<build-dir>/debugify-report.json`; this report can be prettified by using the
   `llvm/utils/llvm-original-di-preservation.py` script (documented
-  [here](project:HowToUpdateDebugInfo.rst#test-original-debug-info-preservation-in-optimizations)).
+  [here](project:HowToUpdateDebugInfo.rst#OriginalDI)).
   This requires the C and C++ compilers to be a version of Clang built with the
   feature `LLVM_ENABLE_DEBUGLOC_COVERAGE_TRACKING=COVERAGE_AND_ORIGIN` (see
   [here](project:HowToUpdateDebugInfo.rst#using-coverage-tracking-to-remove-false-positives)


### PR DESCRIPTION
This patch adds documentation for the changes at:
https://github.com/llvm/llvm-test-suite/pull/432

The llvm-test-suite changes add a new CMake flag that enables the collection of Debugify location coverage stats using the coverage+origin tracking feature. When enabled, a wrapper script will be invoked that runs a coverage-tracking build for all compile commands, and then follows with a second origin-tracking build if any coverage failures are detected, accumulating the results into a single report file at `<build-dir>/debugify-report.json`. For more information on the implementation, see the above PR.