### PR TITLE
[VPlan] Relax type of DerivedIV start value (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -406,7 +406,7 @@ public:
   /// induction with \p Start and \p Step values, using \p Start + \p Current *
   /// \p Step.
   VPDerivedIVRecipe *createDerivedIV(InductionDescriptor::InductionKind Kind,
-                                     FPMathOperator *FPBinOp, VPIRValue *Start,
+                                     FPMathOperator *FPBinOp, VPValue *Start,
                                      VPValue *Current, VPValue *Step) {
     return tryInsertInstruction(
         new VPDerivedIVRecipe(Kind, FPBinOp, Start, Current, Step));

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -4181,8 +4181,8 @@ class VPDerivedIVRecipe : public VPSingleDefRecipe {
 
 public:
   VPDerivedIVRecipe(InductionDescriptor::InductionKind Kind,
-                    const FPMathOperator *FPBinOp, VPIRValue *Start,
-                    VPValue *IV, VPValue *Step)
+                    const FPMathOperator *FPBinOp, VPValue *Start, VPValue *IV,
+                    VPValue *Step)
       : VPSingleDefRecipe(VPRecipeBase::VPDerivedIVSC, {Start, IV, Step},
                           Start->getScalarType(), nullptr),
         Kind(Kind), FPBinOp(FPBinOp) {}
@@ -4204,7 +4204,7 @@ public:
   InstructionCost computeCost(ElementCount VF,
                               VPCostContext &Ctx) const override;
 
-  VPIRValue *getStartValue() const { return cast<VPIRValue>(getOperand(0)); }
+  VPValue *getStartValue() const { return getOperand(0); }
   VPValue *getIndex() const { return getOperand(1); }
   VPValue *getStepValue() const { return getOperand(2); }
   const FPMathOperator *getFPBinOp() const { return FPBinOp; }

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -4086,7 +4086,7 @@ static void expandVPWidenPointerInduction(VPWidenPointerInductionRecipe *R) {
 /// Expand a VPDerivedIVRecipe into executable recipes.
 static void expandVPDerivedIV(VPDerivedIVRecipe *R) {
   VPBuilder Builder(R);
-  VPIRValue *Start = R->getStartValue();
+  VPValue *Start = R->getStartValue();
   VPValue *Step = R->getStepValue();
   VPValue *Index = R->getIndex();
   Type *StepTy = Step->getScalarType();

--- a/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
@@ -334,6 +334,13 @@ bool VPlanVerifier::verifyVPBasicBlock(const VPBasicBlock *VPBB) {
         break;
       }
     }
+    if (const auto *DIV = dyn_cast<VPDerivedIVRecipe>(&R)) {
+      if (!DIV->getStartValue()->isDefinedOutsideLoopRegions()) {
+        errs() << "VPDerivedIVRecipe must have start value defined outside "
+                  "loop regions\n";
+        return false;
+      }
+    }
     if (const auto *ScalarIVSteps = dyn_cast<VPScalarIVStepsRecipe>(&R)) {
       unsigned NumOps = ScalarIVSteps->getNumOperands();
       if (NumOps != 3 && NumOps != 4) {

--- a/llvm/unittests/Transforms/Vectorize/VPlanVerifierTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanVerifierTest.cpp
@@ -330,6 +330,41 @@ TEST_F(VPVerifierTest, NonHeaderPHIInHeader) {
   delete PHINode;
 }
 
+TEST_F(VPVerifierTest, DerivedIVWithStartInLoopRegions) {
+  VPlan &Plan = getPlan();
+  auto *I32Ty = Type::getInt32Ty(C);
+  VPBasicBlock *Entry = Plan.getEntry();
+  VPBasicBlock *Latch = Plan.createVPBasicBlock("latch");
+  VPInstruction *DefI = new VPInstruction(
+      Instruction::Add, {Plan.getPoison(I32Ty), Plan.getPoison(I32Ty)},
+      VPIRFlags::getDefaultFlags(Instruction::Add));
+  Entry->appendRecipe(DefI);
+
+  auto *Start = new VPInstruction(VPInstruction::Not, Plan.getPoison(I32Ty));
+  Latch->appendRecipe(Start);
+  auto *DIV = new VPDerivedIVRecipe(InductionDescriptor::IK_IntInduction,
+                                    nullptr, Start, Plan.getPoison(I32Ty),
+                                    Plan.getPoison(I32Ty));
+  Latch->appendRecipe(DIV);
+  Latch->appendRecipe(
+      new VPInstruction(VPInstruction::BranchOnCond, Plan.getTrue()));
+
+  VPRegionBlock *LoopR = Plan.createLoopRegion(I32Ty, DebugLoc::getUnknown(),
+                                               "loop", Latch, Latch);
+  VPBlockUtils::connectBlocks(Entry, LoopR);
+  VPBlockUtils::connectBlocks(LoopR, Plan.getScalarHeader());
+
+#if GTEST_HAS_STREAM_REDIRECTION
+  ::testing::internal::CaptureStderr();
+#endif
+  EXPECT_FALSE(verifyVPlanIsValid(Plan));
+#if GTEST_HAS_STREAM_REDIRECTION
+  EXPECT_STREQ(
+      "VPDerivedIVRecipe must have start value defined outside loop regions\n",
+      ::testing::internal::GetCapturedStderr().c_str());
+#endif
+}
+
 TEST_F(VPVerifierTest, testRUN_VPLAN_PASS) {
   VPlan &Plan = getPlan();
   VPIRValue *Zero = Plan.getConstantInt(32, 0);

--- a/llvm/unittests/Transforms/Vectorize/VPlanVerifierTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanVerifierTest.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "../lib/Transforms/Vectorize/VPlanVerifier.h"
+#include "../lib/Transforms/Vectorize/LoopVectorizationPlanner.h"
 #include "../lib/Transforms/Vectorize/VPlan.h"
-#include "../lib/Transforms/Vectorize/VPlanCFG.h"
 #include "VPlanTestBase.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
@@ -335,19 +335,12 @@ TEST_F(VPVerifierTest, DerivedIVWithStartInLoopRegions) {
   auto *I32Ty = Type::getInt32Ty(C);
   VPBasicBlock *Entry = Plan.getEntry();
   VPBasicBlock *Latch = Plan.createVPBasicBlock("latch");
-  VPInstruction *DefI = new VPInstruction(
-      Instruction::Add, {Plan.getPoison(I32Ty), Plan.getPoison(I32Ty)},
-      VPIRFlags::getDefaultFlags(Instruction::Add));
-  Entry->appendRecipe(DefI);
 
-  auto *Start = new VPInstruction(VPInstruction::Not, Plan.getPoison(I32Ty));
-  Latch->appendRecipe(Start);
-  auto *DIV = new VPDerivedIVRecipe(InductionDescriptor::IK_IntInduction,
-                                    nullptr, Start, Plan.getPoison(I32Ty),
-                                    Plan.getPoison(I32Ty));
-  Latch->appendRecipe(DIV);
-  Latch->appendRecipe(
-      new VPInstruction(VPInstruction::BranchOnCond, Plan.getTrue()));
+  VPBuilder Builder(Latch);
+  VPValue *Start = Builder.createNot(Plan.getPoison(I32Ty));
+  Builder.createDerivedIV(InductionDescriptor::IK_IntInduction, nullptr, Start,
+                          Plan.getPoison(I32Ty), Plan.getPoison(I32Ty));
+  Builder.createNaryOp(VPInstruction::BranchOnCond, Plan.getTrue());
 
   VPRegionBlock *LoopR = Plan.createLoopRegion(I32Ty, DebugLoc::getUnknown(),
                                                "loop", Latch, Latch);


### PR DESCRIPTION
Change it from VPIRValue -> VPValue, as several usecases require it, while adding a check in the verifier.