### PR TITLE
RFC: Asan: global description in binary file

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -698,6 +698,22 @@ static void addPGOAndCoverageFlags(const ToolChain &TC, Compilation &C,
         llvm::sys::path::append(CoverageFilename, Gcno);
       }
       llvm::sys::path::replace_extension(CoverageFilename, "gcda");
+      // Apply -ffile-prefix-map / -fcoverage-prefix-map to the embedded .gcda
+      // path only.  The .gcno path must remain unchanged so the compiler can
+      // write it to disk at build time.  The .gcda path is stored verbatim in
+      // llvm.gcov metadata and embedded in the binary for runtime use; without
+      // remapping, the absolute build-directory path leaks into the binary
+      // even when -ffile-prefix-map= remaps everything else.
+      for (const Arg *A : Args.filtered(options::OPT_ffile_prefix_map_EQ,
+                                        options::OPT_fcoverage_prefix_map_EQ)) {
+        StringRef Map = A->getValue();
+        auto Sep = Map.find('=');
+        if (Sep == StringRef::npos)
+          continue;
+        if (llvm::sys::path::replace_path_prefix(
+                CoverageFilename, Map.substr(0, Sep), Map.substr(Sep + 1)))
+          break;
+      }
       CmdArgs.push_back(
           Args.MakeArgString("-coverage-data-file=" + CoverageFilename));
     }

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -2833,8 +2833,21 @@ GlobalVariable *ModuleAddressSanitizer::getOrCreateModuleName() {
   if (!ModuleName) {
     // We shouldn't merge same module names, as this string serves as unique
     // module ID in runtime.
+    //
+    // The raw M.getModuleIdentifier() is never remapped through
+    // -ffile-prefix-map, so using it here leaks absolute build-directory
+    // paths into ASan global descriptors and __asan_before_dynamic_init()
+    // arguments even when prefix maps are specified.  When debug info is
+    // present, the DICompileUnit source file already has the prefix map
+    // applied by the frontend; prefer it to avoid the leak.
+    StringRef ModuleId = M.getModuleIdentifier();
+    if (NamedMDNode *CUs = M.getNamedMetadata("llvm.dbg.cu"))
+      if (CUs->getNumOperands() > 0)
+        if (auto *CU = dyn_cast<DICompileUnit>(CUs->getOperand(0)))
+          if (!CU->getFilename().empty())
+            ModuleId = CU->getFilename();
     ModuleName =
-        createPrivateGlobalForString(M, M.getModuleIdentifier(),
+        createPrivateGlobalForString(M, ModuleId,
                                      /*AllowMerging*/ false, genName("module"));
   }
   return ModuleName;


### PR DESCRIPTION
Hi,

The ASAN globals instrumentation embeds the source filename into the
generated code. We hit this issue when we build our projects in Yocto/OpenEmbedded
cross build. We enable ASAN in our pipelines and then Yocto build fails QA check [buildpaths] because of the unmapped TMPDIR path. With AI help we found the issue and prepare a paths witch fix that issue. Each commit contains details descriptions about the issue in commit message. I don't understand llvm-project codebase well and have less knowledge about that problematic. This MR is more draft and RFC issue. We are interesting to know opinions what you think about the issue and commits, which we prepare with AI help.

Thank you