### PR TITLE
[IR][NFC] Add LoadStoreProperties to copy load/store attrs

### DIFF
--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -1919,9 +1919,7 @@ public:
   LoadInst *CreateLoad(Type *Ty, Value *Ptr,
                        const LoadStoreInstProperties &Props,
                        const Twine &Name = "") {
-    return Insert(new LoadInst(Ty, Ptr, Twine(), Props.IsVolatile,
-                               Props.Alignment, Props.Ordering, Props.SSID),
-                  Name);
+    return Insert(new LoadInst(Ty, Ptr, Twine(), Props), Name);
   }
 
   StoreInst *CreateStore(Value *Val, Value *Ptr, bool isVolatile = false) {
@@ -1930,8 +1928,7 @@ public:
 
   StoreInst *CreateStore(Value *Val, Value *Ptr,
                          const LoadStoreInstProperties &Props) {
-    return Insert(new StoreInst(Val, Ptr, Props.IsVolatile, Props.Alignment,
-                                Props.Ordering, Props.SSID));
+    return Insert(new StoreInst(Val, Ptr, Props));
   }
 
   LoadInst *CreateAlignedLoad(Type *Ty, Value *Ptr, MaybeAlign Align,

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -1916,8 +1916,22 @@ public:
     return CreateAlignedLoad(Ty, Ptr, MaybeAlign(), isVolatile, Name);
   }
 
+  LoadInst *CreateLoad(Type *Ty, Value *Ptr,
+                       const LoadStoreInstProperties &Props,
+                       const Twine &Name = "") {
+    return Insert(new LoadInst(Ty, Ptr, Twine(), Props.IsVolatile,
+                               Props.Alignment, Props.Ordering, Props.SSID),
+                  Name);
+  }
+
   StoreInst *CreateStore(Value *Val, Value *Ptr, bool isVolatile = false) {
     return CreateAlignedStore(Val, Ptr, MaybeAlign(), isVolatile);
+  }
+
+  StoreInst *CreateStore(Value *Val, Value *Ptr,
+                         const LoadStoreInstProperties &Props) {
+    return Insert(new StoreInst(Val, Ptr, Props.IsVolatile, Props.Alignment,
+                                Props.Ordering, Props.SSID));
   }
 
   LoadInst *CreateAlignedLoad(Type *Ty, Value *Ptr, MaybeAlign Align,

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -172,6 +172,10 @@ private:
   }
 };
 
+//===----------------------------------------------------------------------===//
+//                         Load/Store Properties
+//===----------------------------------------------------------------------===//
+
 /// A structure representing the properties of a load or store instruction.
 struct LoadStoreInstProperties {
   bool IsVolatile = false;

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -172,6 +172,14 @@ private:
   }
 };
 
+/// A structure representing the attributes of a load or store instruction.
+struct LoadStoreInstAttributes {
+  bool IsVolatile = false;
+  Align Alignment;
+  AtomicOrdering Ordering = AtomicOrdering::NotAtomic;
+  SyncScope::ID SSID = SyncScope::System;
+};
+
 //===----------------------------------------------------------------------===//
 //                                LoadInst Class
 //===----------------------------------------------------------------------===//
@@ -247,6 +255,19 @@ public:
                  SyncScope::ID SSID = SyncScope::System) {
     setOrdering(Ordering);
     setSyncScopeID(SSID);
+  }
+
+  /// Returns the attributes of this load instruction.
+  LoadStoreInstAttributes getAttributes() const {
+    return {isVolatile(), getAlign(), getOrdering(), getSyncScopeID()};
+  }
+
+  /// Sets the attributes of this load instruction.
+  void setAttributes(const LoadStoreInstAttributes &Attrs) {
+    setVolatile(Attrs.IsVolatile);
+    setAlignment(Attrs.Alignment);
+    setOrdering(Attrs.Ordering);
+    setSyncScopeID(Attrs.SSID);
   }
 
   bool isSimple() const { return !isAtomic() && !isVolatile(); }
@@ -371,6 +392,19 @@ public:
                  SyncScope::ID SSID = SyncScope::System) {
     setOrdering(Ordering);
     setSyncScopeID(SSID);
+  }
+
+  /// Returns the attributes of this store instruction.
+  LoadStoreInstAttributes getAttributes() const {
+    return {isVolatile(), getAlign(), getOrdering(), getSyncScopeID()};
+  }
+
+  /// Sets the attributes of this store instruction.
+  void setAttributes(const LoadStoreInstAttributes &Attrs) {
+    setVolatile(Attrs.IsVolatile);
+    setAlignment(Attrs.Alignment);
+    setOrdering(Attrs.Ordering);
+    setSyncScopeID(Attrs.SSID);
   }
 
   bool isSimple() const { return !isAtomic() && !isVolatile(); }

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -173,7 +173,7 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
-//                         Load/Store Properties
+//                                LoadInst Class
 //===----------------------------------------------------------------------===//
 
 /// A structure representing the properties of a load or store instruction.
@@ -183,10 +183,6 @@ struct LoadStoreInstProperties {
   AtomicOrdering Ordering = AtomicOrdering::NotAtomic;
   SyncScope::ID SSID = SyncScope::System;
 };
-
-//===----------------------------------------------------------------------===//
-//                                LoadInst Class
-//===----------------------------------------------------------------------===//
 
 /// An instruction for reading from memory. This uses the SubclassData field in
 /// Value to store whether or not the load is volatile.

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -172,8 +172,8 @@ private:
   }
 };
 
-/// A structure representing the attributes of a load or store instruction.
-struct LoadStoreInstAttributes {
+/// A structure representing the properties of a load or store instruction.
+struct LoadStoreInstProperties {
   bool IsVolatile = false;
   Align Alignment;
   AtomicOrdering Ordering = AtomicOrdering::NotAtomic;
@@ -257,17 +257,17 @@ public:
     setSyncScopeID(SSID);
   }
 
-  /// Returns the attributes of this load instruction.
-  LoadStoreInstAttributes getAttributes() const {
+  /// Returns the properties of this load instruction.
+  LoadStoreInstProperties getProperties() const {
     return {isVolatile(), getAlign(), getOrdering(), getSyncScopeID()};
   }
 
-  /// Sets the attributes of this load instruction.
-  void setAttributes(const LoadStoreInstAttributes &Attrs) {
-    setVolatile(Attrs.IsVolatile);
-    setAlignment(Attrs.Alignment);
-    setOrdering(Attrs.Ordering);
-    setSyncScopeID(Attrs.SSID);
+  /// Sets the properties of this load instruction.
+  void setProperties(const LoadStoreInstProperties &Props) {
+    setVolatile(Props.IsVolatile);
+    setAlignment(Props.Alignment);
+    setOrdering(Props.Ordering);
+    setSyncScopeID(Props.SSID);
   }
 
   bool isSimple() const { return !isAtomic() && !isVolatile(); }
@@ -394,17 +394,17 @@ public:
     setSyncScopeID(SSID);
   }
 
-  /// Returns the attributes of this store instruction.
-  LoadStoreInstAttributes getAttributes() const {
+  /// Returns the properties of this store instruction.
+  LoadStoreInstProperties getProperties() const {
     return {isVolatile(), getAlign(), getOrdering(), getSyncScopeID()};
   }
 
-  /// Sets the attributes of this store instruction.
-  void setAttributes(const LoadStoreInstAttributes &Attrs) {
-    setVolatile(Attrs.IsVolatile);
-    setAlignment(Attrs.Alignment);
-    setOrdering(Attrs.Ordering);
-    setSyncScopeID(Attrs.SSID);
+  /// Sets the properties of this store instruction.
+  void setProperties(const LoadStoreInstProperties &Props) {
+    setVolatile(Props.IsVolatile);
+    setAlignment(Props.Alignment);
+    setOrdering(Props.Ordering);
+    setSyncScopeID(Props.SSID);
   }
 
   bool isSimple() const { return !isAtomic() && !isVolatile(); }

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -178,10 +178,10 @@ private:
 
 /// A structure representing the properties of a load or store instruction.
 struct LoadStoreInstProperties {
-  bool IsVolatile = false;
+  bool IsVolatile;
   Align Alignment;
-  AtomicOrdering Ordering = AtomicOrdering::NotAtomic;
-  SyncScope::ID SSID = SyncScope::System;
+  AtomicOrdering Ordering;
+  SyncScope::ID SSID;
 };
 
 /// An instruction for reading from memory. This uses the SubclassData field in
@@ -212,6 +212,9 @@ public:
   LLVM_ABI LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
                     Align Align, AtomicOrdering Order,
                     SyncScope::ID SSID = SyncScope::System,
+                    InsertPosition InsertBefore = nullptr);
+  LLVM_ABI LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr,
+                    const LoadStoreInstProperties &Props,
                     InsertPosition InsertBefore = nullptr);
 
   /// Return true if this is a load from a volatile memory location.
@@ -342,6 +345,9 @@ public:
   LLVM_ABI StoreInst(Value *Val, Value *Ptr, bool isVolatile, Align Align,
                      AtomicOrdering Order,
                      SyncScope::ID SSID = SyncScope::System,
+                     InsertPosition InsertBefore = nullptr);
+  LLVM_ABI StoreInst(Value *Val, Value *Ptr,
+                     const LoadStoreInstProperties &Props,
                      InsertPosition InsertBefore = nullptr);
 
   // allocate space for exactly two operands

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -564,9 +564,7 @@ LoadInst *AtomicExpandImpl::convertAtomicLoadToIntegerType(LoadInst *LI) {
   Value *Addr = LI->getPointerOperand();
 
   auto *NewLI = Builder.CreateLoad(NewTy, Addr);
-  NewLI->setAlignment(LI->getAlign());
-  NewLI->setVolatile(LI->isVolatile());
-  NewLI->setAtomic(LI->getOrdering(), LI->getSyncScopeID());
+  NewLI->setAttributes(LI->getAttributes());
   LLVM_DEBUG(dbgs() << "Replaced " << *LI << " with " << *NewLI << "\n");
 
   Value *NewVal = LI->getType()->isPtrOrPtrVectorTy()
@@ -720,9 +718,7 @@ StoreInst *AtomicExpandImpl::convertAtomicStoreToIntegerType(StoreInst *SI) {
   Value *Addr = SI->getPointerOperand();
 
   StoreInst *NewSI = Builder.CreateStore(NewVal, Addr);
-  NewSI->setAlignment(SI->getAlign());
-  NewSI->setVolatile(SI->isVolatile());
-  NewSI->setAtomic(SI->getOrdering(), SI->getSyncScopeID());
+  NewSI->setAttributes(SI->getAttributes());
   LLVM_DEBUG(dbgs() << "Replaced " << *SI << " with " << *NewSI << "\n");
   SI->eraseFromParent();
   return NewSI;

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -564,7 +564,7 @@ LoadInst *AtomicExpandImpl::convertAtomicLoadToIntegerType(LoadInst *LI) {
   Value *Addr = LI->getPointerOperand();
 
   auto *NewLI = Builder.CreateLoad(NewTy, Addr);
-  NewLI->setAttributes(LI->getAttributes());
+  NewLI->setProperties(LI->getProperties());
   LLVM_DEBUG(dbgs() << "Replaced " << *LI << " with " << *NewLI << "\n");
 
   Value *NewVal = LI->getType()->isPtrOrPtrVectorTy()
@@ -718,7 +718,7 @@ StoreInst *AtomicExpandImpl::convertAtomicStoreToIntegerType(StoreInst *SI) {
   Value *Addr = SI->getPointerOperand();
 
   StoreInst *NewSI = Builder.CreateStore(NewVal, Addr);
-  NewSI->setAttributes(SI->getAttributes());
+  NewSI->setProperties(SI->getProperties());
   LLVM_DEBUG(dbgs() << "Replaced " << *SI << " with " << *NewSI << "\n");
   SI->eraseFromParent();
   return NewSI;

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -563,8 +563,7 @@ LoadInst *AtomicExpandImpl::convertAtomicLoadToIntegerType(LoadInst *LI) {
 
   Value *Addr = LI->getPointerOperand();
 
-  auto *NewLI = Builder.CreateLoad(NewTy, Addr);
-  NewLI->setProperties(LI->getProperties());
+  auto *NewLI = Builder.CreateLoad(NewTy, Addr, LI->getProperties());
   LLVM_DEBUG(dbgs() << "Replaced " << *LI << " with " << *NewLI << "\n");
 
   Value *NewVal = LI->getType()->isPtrOrPtrVectorTy()
@@ -717,8 +716,7 @@ StoreInst *AtomicExpandImpl::convertAtomicStoreToIntegerType(StoreInst *SI) {
 
   Value *Addr = SI->getPointerOperand();
 
-  StoreInst *NewSI = Builder.CreateStore(NewVal, Addr);
-  NewSI->setProperties(SI->getProperties());
+  StoreInst *NewSI = Builder.CreateStore(NewVal, Addr, SI->getProperties());
   LLVM_DEBUG(dbgs() << "Replaced " << *SI << " with " << *NewSI << "\n");
   SI->eraseFromParent();
   return NewSI;

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -1365,6 +1365,12 @@ LoadInst::LoadInst(Type *Ty, Value *Ptr, const Twine &Name, bool isVolatile,
     : LoadInst(Ty, Ptr, Name, isVolatile, Align, AtomicOrdering::NotAtomic,
                SyncScope::System, InsertBef) {}
 
+LoadInst::LoadInst(Type *Ty, Value *Ptr, const Twine &Name,
+                   const LoadStoreInstProperties &Props,
+                   InsertPosition InsertBef)
+    : LoadInst(Ty, Ptr, Name, Props.IsVolatile, Props.Alignment, Props.Ordering,
+               Props.SSID, InsertBef) {}
+
 LoadInst::LoadInst(Type *Ty, Value *Ptr, const Twine &Name, bool isVolatile,
                    Align Align, AtomicOrdering Order, SyncScope::ID SSID,
                    InsertPosition InsertBef)
@@ -1399,6 +1405,12 @@ StoreInst::StoreInst(Value *val, Value *addr, bool isVolatile, Align Align,
                      InsertPosition InsertBefore)
     : StoreInst(val, addr, isVolatile, Align, AtomicOrdering::NotAtomic,
                 SyncScope::System, InsertBefore) {}
+
+StoreInst::StoreInst(Value *Val, Value *Ptr,
+                     const LoadStoreInstProperties &Props,
+                     InsertPosition InsertBefore)
+    : StoreInst(Val, Ptr, Props.IsVolatile, Props.Alignment, Props.Ordering,
+                Props.SSID, InsertBefore) {}
 
 StoreInst::StoreInst(Value *val, Value *addr, bool isVolatile, Align Align,
                      AtomicOrdering Order, SyncScope::ID SSID,

--- a/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
@@ -696,7 +696,7 @@ void AMDGPUSwLowerLDS::translateLDSMemoryOperationsToGlobalMemory(
           getTranslatedGlobalMemoryPtrOfLDS(LoadMallocPtr, LIOperand);
       LoadInst *NewLI = IRB.CreateAlignedLoad(LI->getType(), Replacement,
                                               LI->getAlign(), LI->isVolatile());
-      NewLI->setAttributes(LI->getAttributes());
+      NewLI->setProperties(LI->getProperties());
       AsanInfo.Instructions.insert(NewLI);
       LI->replaceAllUsesWith(NewLI);
       LI->eraseFromParent();
@@ -706,7 +706,7 @@ void AMDGPUSwLowerLDS::translateLDSMemoryOperationsToGlobalMemory(
           getTranslatedGlobalMemoryPtrOfLDS(LoadMallocPtr, SIOperand);
       StoreInst *NewSI = IRB.CreateAlignedStore(
           SI->getValueOperand(), Replacement, SI->getAlign(), SI->isVolatile());
-      NewSI->setAttributes(SI->getAttributes());
+      NewSI->setProperties(SI->getProperties());
       AsanInfo.Instructions.insert(NewSI);
       SI->replaceAllUsesWith(NewSI);
       SI->eraseFromParent();

--- a/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
@@ -696,7 +696,7 @@ void AMDGPUSwLowerLDS::translateLDSMemoryOperationsToGlobalMemory(
           getTranslatedGlobalMemoryPtrOfLDS(LoadMallocPtr, LIOperand);
       LoadInst *NewLI = IRB.CreateAlignedLoad(LI->getType(), Replacement,
                                               LI->getAlign(), LI->isVolatile());
-      NewLI->setAtomic(LI->getOrdering(), LI->getSyncScopeID());
+      NewLI->setAttributes(LI->getAttributes());
       AsanInfo.Instructions.insert(NewLI);
       LI->replaceAllUsesWith(NewLI);
       LI->eraseFromParent();
@@ -706,7 +706,7 @@ void AMDGPUSwLowerLDS::translateLDSMemoryOperationsToGlobalMemory(
           getTranslatedGlobalMemoryPtrOfLDS(LoadMallocPtr, SIOperand);
       StoreInst *NewSI = IRB.CreateAlignedStore(
           SI->getValueOperand(), Replacement, SI->getAlign(), SI->isVolatile());
-      NewSI->setAtomic(SI->getOrdering(), SI->getSyncScopeID());
+      NewSI->setAttributes(SI->getAttributes());
       AsanInfo.Instructions.insert(NewSI);
       SI->replaceAllUsesWith(NewSI);
       SI->eraseFromParent();

--- a/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSwLowerLDS.cpp
@@ -694,9 +694,8 @@ void AMDGPUSwLowerLDS::translateLDSMemoryOperationsToGlobalMemory(
       Value *LIOperand = LI->getPointerOperand();
       Value *Replacement =
           getTranslatedGlobalMemoryPtrOfLDS(LoadMallocPtr, LIOperand);
-      LoadInst *NewLI = IRB.CreateAlignedLoad(LI->getType(), Replacement,
-                                              LI->getAlign(), LI->isVolatile());
-      NewLI->setProperties(LI->getProperties());
+      LoadInst *NewLI =
+          IRB.CreateLoad(LI->getType(), Replacement, LI->getProperties());
       AsanInfo.Instructions.insert(NewLI);
       LI->replaceAllUsesWith(NewLI);
       LI->eraseFromParent();
@@ -704,9 +703,8 @@ void AMDGPUSwLowerLDS::translateLDSMemoryOperationsToGlobalMemory(
       Value *SIOperand = SI->getPointerOperand();
       Value *Replacement =
           getTranslatedGlobalMemoryPtrOfLDS(LoadMallocPtr, SIOperand);
-      StoreInst *NewSI = IRB.CreateAlignedStore(
-          SI->getValueOperand(), Replacement, SI->getAlign(), SI->isVolatile());
-      NewSI->setProperties(SI->getProperties());
+      StoreInst *NewSI = IRB.CreateStore(SI->getValueOperand(), Replacement,
+                                         SI->getProperties());
       AsanInfo.Instructions.insert(NewSI);
       SI->replaceAllUsesWith(NewSI);
       SI->eraseFromParent();

--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -605,7 +605,7 @@ LoadInst *InstCombinerImpl::combineLoadToNewType(LoadInst &LI, Type *NewTy,
   LoadInst *NewLoad =
       Builder.CreateAlignedLoad(NewTy, LI.getPointerOperand(), LI.getAlign(),
                                 LI.isVolatile(), LI.getName() + Suffix);
-  NewLoad->setAtomic(LI.getOrdering(), LI.getSyncScopeID());
+  NewLoad->setAttributes(LI.getAttributes());
   copyMetadataForLoad(*NewLoad, LI);
   return NewLoad;
 }
@@ -624,7 +624,7 @@ static StoreInst *combineStoreToNewValue(InstCombinerImpl &IC, StoreInst &SI,
 
   StoreInst *NewStore =
       IC.Builder.CreateAlignedStore(V, Ptr, SI.getAlign(), SI.isVolatile());
-  NewStore->setAtomic(SI.getOrdering(), SI.getSyncScopeID());
+  NewStore->setAttributes(SI.getAttributes());
   for (const auto &MDPair : MD) {
     unsigned ID = MDPair.first;
     MDNode *N = MDPair.second;
@@ -1166,10 +1166,8 @@ Instruction *InstCombinerImpl::visitLoadInst(LoadInst &LI) {
         LoadInst *V2 = Builder.CreateLoad(LI.getType(), LoadOp2,
                                           LoadOp2->getName() + ".val");
         assert(LI.isUnordered() && "implied by above");
-        V1->setAlignment(Alignment);
-        V1->setAtomic(LI.getOrdering(), LI.getSyncScopeID());
-        V2->setAlignment(Alignment);
-        V2->setAtomic(LI.getOrdering(), LI.getSyncScopeID());
+        V1->setAttributes(LI.getAttributes());
+        V2->setAttributes(LI.getAttributes());
         // It is safe to copy any metadata that does not trigger UB. Copy any
         // poison-generating metadata.
         V1->copyMetadata(LI, Metadata::PoisonGeneratingIDs);

--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -605,7 +605,7 @@ LoadInst *InstCombinerImpl::combineLoadToNewType(LoadInst &LI, Type *NewTy,
   LoadInst *NewLoad =
       Builder.CreateAlignedLoad(NewTy, LI.getPointerOperand(), LI.getAlign(),
                                 LI.isVolatile(), LI.getName() + Suffix);
-  NewLoad->setAttributes(LI.getAttributes());
+  NewLoad->setProperties(LI.getProperties());
   copyMetadataForLoad(*NewLoad, LI);
   return NewLoad;
 }
@@ -624,7 +624,7 @@ static StoreInst *combineStoreToNewValue(InstCombinerImpl &IC, StoreInst &SI,
 
   StoreInst *NewStore =
       IC.Builder.CreateAlignedStore(V, Ptr, SI.getAlign(), SI.isVolatile());
-  NewStore->setAttributes(SI.getAttributes());
+  NewStore->setProperties(SI.getProperties());
   for (const auto &MDPair : MD) {
     unsigned ID = MDPair.first;
     MDNode *N = MDPair.second;
@@ -1166,8 +1166,8 @@ Instruction *InstCombinerImpl::visitLoadInst(LoadInst &LI) {
         LoadInst *V2 = Builder.CreateLoad(LI.getType(), LoadOp2,
                                           LoadOp2->getName() + ".val");
         assert(LI.isUnordered() && "implied by above");
-        V1->setAttributes(LI.getAttributes());
-        V2->setAttributes(LI.getAttributes());
+        V1->setProperties(LI.getProperties());
+        V2->setProperties(LI.getProperties());
         // It is safe to copy any metadata that does not trigger UB. Copy any
         // poison-generating metadata.
         V1->copyMetadata(LI, Metadata::PoisonGeneratingIDs);

--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -412,9 +412,7 @@ void PointerReplacer::replace(Instruction *I) {
   if (auto *LT = dyn_cast<LoadInst>(I)) {
     auto *V = getReplacement(LT->getPointerOperand());
     assert(V && "Operand not replaced");
-    auto *NewI = new LoadInst(LT->getType(), V, "", LT->isVolatile(),
-                              LT->getAlign(), LT->getOrdering(),
-                              LT->getSyncScopeID());
+    auto *NewI = new LoadInst(LT->getType(), V, "", LT->getProperties());
     NewI->takeName(LT);
     NewI->copyMetadata(*LT);
 
@@ -1727,8 +1725,7 @@ bool InstCombinerImpl::mergeStoreIntoSuccessor(StoreInst &SI) {
   // Advance to a place where it is safe to insert the new store and insert it.
   BBI = DestBB->getFirstInsertionPt();
   StoreInst *NewSI =
-      new StoreInst(MergedVal, SI.getOperand(1), SI.isVolatile(), SI.getAlign(),
-                    SI.getOrdering(), SI.getSyncScopeID());
+      new StoreInst(MergedVal, SI.getOperand(1), SI.getProperties());
   InsertNewInstBefore(NewSI, BBI);
   NewSI->setDebugLoc(MergedLoc);
   NewSI->mergeDIAssignID({&SI, OtherStore});

--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -602,10 +602,8 @@ LoadInst *InstCombinerImpl::combineLoadToNewType(LoadInst &LI, Type *NewTy,
   assert((!LI.isAtomic() || isSupportedAtomicType(NewTy)) &&
          "can't fold an atomic load to requested type");
 
-  LoadInst *NewLoad =
-      Builder.CreateAlignedLoad(NewTy, LI.getPointerOperand(), LI.getAlign(),
-                                LI.isVolatile(), LI.getName() + Suffix);
-  NewLoad->setProperties(LI.getProperties());
+  LoadInst *NewLoad = Builder.CreateLoad(
+      NewTy, LI.getPointerOperand(), LI.getProperties(), LI.getName() + Suffix);
   copyMetadataForLoad(*NewLoad, LI);
   return NewLoad;
 }
@@ -622,9 +620,7 @@ static StoreInst *combineStoreToNewValue(InstCombinerImpl &IC, StoreInst &SI,
   SmallVector<std::pair<unsigned, MDNode *>, 8> MD;
   SI.getAllMetadata(MD);
 
-  StoreInst *NewStore =
-      IC.Builder.CreateAlignedStore(V, Ptr, SI.getAlign(), SI.isVolatile());
-  NewStore->setProperties(SI.getProperties());
+  StoreInst *NewStore = IC.Builder.CreateStore(V, Ptr, SI.getProperties());
   for (const auto &MDPair : MD) {
     unsigned ID = MDPair.first;
     MDNode *N = MDPair.second;
@@ -1159,15 +1155,15 @@ Instruction *InstCombinerImpl::visitLoadInst(LoadInst &LI) {
           return Op;
         };
         Value *LoadOp1 = MaybeCastedLoadOperand(SI->getOperand(1));
-        LoadInst *V1 = Builder.CreateLoad(LI.getType(), LoadOp1,
-                                          LoadOp1->getName() + ".val");
+        LoadInst *V1 =
+            Builder.CreateLoad(LI.getType(), LoadOp1, LI.getProperties(),
+                               LoadOp1->getName() + ".val");
 
         Value *LoadOp2 = MaybeCastedLoadOperand(SI->getOperand(2));
-        LoadInst *V2 = Builder.CreateLoad(LI.getType(), LoadOp2,
-                                          LoadOp2->getName() + ".val");
+        LoadInst *V2 =
+            Builder.CreateLoad(LI.getType(), LoadOp2, LI.getProperties(),
+                               LoadOp2->getName() + ".val");
         assert(LI.isUnordered() && "implied by above");
-        V1->setProperties(LI.getProperties());
-        V2->setProperties(LI.getProperties());
         // It is safe to copy any metadata that does not trigger UB. Copy any
         // poison-generating metadata.
         V1->copyMetadata(LI, Metadata::PoisonGeneratingIDs);


### PR DESCRIPTION
Introduce a small `LoadStoreProperties` struct plus get/setAttributes on
`LoadInst` and `StoreInst` so volatile/align/ordering/syncscope can be copied
together instead of one field at a time. Switch the obvious load->load and
store->store clone sites over to it.