### PR TITLE
[lldb] Return llvm::Error from EnableLogChannel

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -258,11 +258,10 @@ public:
 
   void ClearIOHandlers();
 
-  bool EnableLog(llvm::StringRef channel,
-                 llvm::ArrayRef<const char *> categories,
-                 llvm::StringRef log_file, uint32_t log_options,
-                 size_t buffer_size, LogHandlerKind log_handler_kind,
-                 llvm::raw_ostream &error_stream);
+  llvm::Error EnableLog(llvm::StringRef channel,
+                        llvm::ArrayRef<const char *> categories,
+                        llvm::StringRef log_file, uint32_t log_options,
+                        size_t buffer_size, LogHandlerKind log_handler_kind);
 
   void SetLoggingCallback(lldb::LogOutputCallback log_callback, void *baton);
 

--- a/lldb/include/lldb/Utility/Log.h
+++ b/lldb/include/lldb/Utility/Log.h
@@ -198,11 +198,10 @@ public:
   static void Register(llvm::StringRef name, Channel &channel);
   static void Unregister(llvm::StringRef name);
 
-  static bool
+  static llvm::Error
   EnableLogChannel(const std::shared_ptr<LogHandler> &log_handler_sp,
                    uint32_t log_options, llvm::StringRef channel,
-                   llvm::ArrayRef<const char *> categories,
-                   llvm::raw_ostream &error_stream);
+                   llvm::ArrayRef<const char *> categories);
 
   static bool DisableLogChannel(llvm::StringRef channel,
                                 llvm::ArrayRef<const char *> categories,
@@ -319,11 +318,11 @@ private:
                              const ChannelMap::value_type &entry);
 
   /// Convert an array of category names into a set of category flags.
-  /// Returns a bitmask of categories, or an empty optional in the case that
+  /// Returns a bitmask of categories, or an error message in the case that
   /// at least one category name was not recognised. All unknown category names
-  /// are reported as errors in the provided stream.
-  static std::optional<Log::MaskType>
-  GetFlags(llvm::raw_ostream &stream, const ChannelMap::value_type &entry,
+  /// are included in the error.
+  static llvm::Expected<Log::MaskType>
+  GetFlags(const ChannelMap::value_type &entry,
            llvm::ArrayRef<const char *> categories);
 
   Log(const Log &) = delete;

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -1642,11 +1642,10 @@ bool SBDebugger::EnableLog(const char *channel, const char **categories) {
   if (m_opaque_sp) {
     uint32_t log_options =
         LLDB_LOG_OPTION_PREPEND_TIMESTAMP | LLDB_LOG_OPTION_PREPEND_THREAD_NAME;
-    std::string error;
-    llvm::raw_string_ostream error_stream(error);
-    return m_opaque_sp->EnableLog(channel, GetCategoryArray(categories), "",
-                                  log_options, /*buffer_size=*/0,
-                                  eLogHandlerStream, error_stream);
+    llvm::Error err = m_opaque_sp->EnableLog(
+        channel, GetCategoryArray(categories), "", log_options,
+        /*buffer_size=*/0, eLogHandlerStream);
+    return !bool(err);
   } else
     return false;
 }

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -1645,7 +1645,9 @@ bool SBDebugger::EnableLog(const char *channel, const char **categories) {
     llvm::Error err = m_opaque_sp->EnableLog(
         channel, GetCategoryArray(categories), "", log_options,
         /*buffer_size=*/0, eLogHandlerStream);
-    return !bool(err);
+    bool succeeded = !bool(err);
+    llvm::consumeError(std::move(err));
+    return succeeded;
   } else
     return false;
 }

--- a/lldb/source/Commands/CommandObjectLog.cpp
+++ b/lldb/source/Commands/CommandObjectLog.cpp
@@ -21,6 +21,8 @@
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/Timer.h"
 
+#include "llvm/Support/FormatAdapters.h"
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -201,19 +203,16 @@ protected:
     else
       log_file[0] = '\0';
 
-    std::string error;
-    llvm::raw_string_ostream error_stream(error);
-    bool success = GetDebugger().EnableLog(
+    llvm::Error error = GetDebugger().EnableLog(
         channel, args.GetArgumentArrayRef(), log_file, m_options.log_options,
-        m_options.buffer_size.GetCurrentValue(), m_options.handler,
-        error_stream);
+        m_options.buffer_size.GetCurrentValue(), m_options.handler);
 
-    if (success)
-      result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    else {
-      result.GetErrorStream() << error;
+    if (error) {
+      result.GetErrorStream()
+          << llvm::formatv("{}", llvm::fmt_consume(std::move(error)));
       result.SetStatus(eReturnStatusFailed);
-    }
+    } else
+      result.SetStatus(eReturnStatusSuccessFinishNoResult);
   }
 
   CommandOptions m_options;

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -71,6 +71,7 @@
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/Threading.h"
@@ -1879,11 +1880,11 @@ CreateLogHandler(LogHandlerKind log_handler_kind, int fd, bool should_close,
   return {};
 }
 
-bool Debugger::EnableLog(llvm::StringRef channel,
-                         llvm::ArrayRef<const char *> categories,
-                         llvm::StringRef log_file, uint32_t log_options,
-                         size_t buffer_size, LogHandlerKind log_handler_kind,
-                         llvm::raw_ostream &error_stream) {
+llvm::Error Debugger::EnableLog(llvm::StringRef channel,
+                                llvm::ArrayRef<const char *> categories,
+                                llvm::StringRef log_file, uint32_t log_options,
+                                size_t buffer_size,
+                                LogHandlerKind log_handler_kind) {
 
   std::shared_ptr<LogHandler> log_handler_sp;
   if (m_callback_handler_sp) {
@@ -1908,11 +1909,10 @@ bool Debugger::EnableLog(llvm::StringRef channel,
         flags |= File::eOpenOptionTruncate;
       llvm::Expected<FileUP> file = FileSystem::Instance().Open(
           FileSpec(log_file), flags, lldb::eFilePermissionsFileDefault, false);
-      if (!file) {
-        error_stream << "Unable to open log file '" << log_file
-                     << "': " << llvm::toString(file.takeError()) << "\n";
-        return false;
-      }
+      if (!file)
+        return llvm::createStringErrorV("Unable to open log file '{}': {}",
+                                        log_file,
+                                        llvm::fmt_consume(file.takeError()));
 
       log_handler_sp =
           CreateLogHandler(log_handler_kind, (*file)->GetDescriptor(),
@@ -1925,8 +1925,8 @@ bool Debugger::EnableLog(llvm::StringRef channel,
   if (log_options == 0)
     log_options = LLDB_LOG_OPTION_PREPEND_THREAD_NAME;
 
-  return Log::EnableLogChannel(log_handler_sp, log_options, channel, categories,
-                               error_stream);
+  return Log::EnableLogChannel(log_handler_sp, log_options, channel,
+                               categories);
 }
 
 ScriptInterpreter *

--- a/lldb/source/Utility/Log.cpp
+++ b/lldb/source/Utility/Log.cpp
@@ -16,6 +16,7 @@
 
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Chrono.h"
+#include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Path.h"
@@ -71,8 +72,8 @@ void Log::ListCategories(llvm::raw_ostream &stream,
                   });
 }
 
-std::optional<Log::MaskType>
-Log::GetFlags(llvm::raw_ostream &stream, const ChannelMap::value_type &entry,
+llvm::Expected<Log::MaskType>
+Log::GetFlags(const ChannelMap::value_type &entry,
               llvm::ArrayRef<const char *> categories) {
   Log::MaskType flags = 0;
   llvm::SmallVector<std::string> unrecognized_categories;
@@ -97,14 +98,16 @@ Log::GetFlags(llvm::raw_ostream &stream, const ChannelMap::value_type &entry,
   }
 
   if (unrecognized_categories.size()) {
-    stream << "error: unrecognized log "
-           << ((unrecognized_categories.size() == 1) ? "category "
-                                                     : "categories ")
-           << llvm::join(unrecognized_categories.begin(),
-                         unrecognized_categories.end(), ", ")
-           << "\n";
-    ListCategories(stream, entry);
-    return {};
+    std::string error_str;
+    llvm::raw_string_ostream error_stream(error_str);
+    error_stream << "error: unrecognized log "
+                 << ((unrecognized_categories.size() == 1) ? "category "
+                                                           : "categories ")
+                 << llvm::join(unrecognized_categories.begin(),
+                               unrecognized_categories.end(), ", ")
+                 << "\n";
+    ListCategories(error_stream, entry);
+    return llvm::createStringError(error_str);
   }
 
   return flags;
@@ -223,26 +226,25 @@ void Log::Unregister(llvm::StringRef name) {
   g_channel_map->erase(iter);
 }
 
-bool Log::EnableLogChannel(const std::shared_ptr<LogHandler> &log_handler_sp,
-                           uint32_t log_options, llvm::StringRef channel,
-                           llvm::ArrayRef<const char *> categories,
-                           llvm::raw_ostream &error_stream) {
+llvm::Error
+Log::EnableLogChannel(const std::shared_ptr<LogHandler> &log_handler_sp,
+                      uint32_t log_options, llvm::StringRef channel,
+                      llvm::ArrayRef<const char *> categories) {
   auto iter = g_channel_map->find(channel);
-  if (iter == g_channel_map->end()) {
-    error_stream << llvm::formatv("Invalid log channel '{0}'.\n", channel);
-    return false;
+  if (iter == g_channel_map->end())
+    return llvm::createStringErrorV("Invalid log channel '{0}'.\n", channel);
+
+  if (categories.empty()) {
+    iter->second.Enable(log_handler_sp, std::nullopt, log_options);
+    return llvm::Error::success();
   }
 
-  std::optional<MaskType> flags;
+  llvm::Expected<MaskType> flags = GetFlags(*iter, categories);
+  if (!flags)
+    return flags.takeError();
 
-  if (!categories.empty()) {
-    flags = GetFlags(error_stream, *iter, categories);
-    if (!flags)
-      return false;
-  }
-
-  iter->second.Enable(log_handler_sp, flags, log_options);
-  return true;
+  iter->second.Enable(log_handler_sp, *flags, log_options);
+  return llvm::Error::success();
 }
 
 bool Log::DisableLogChannel(llvm::StringRef channel,
@@ -254,15 +256,18 @@ bool Log::DisableLogChannel(llvm::StringRef channel,
     return false;
   }
 
-  std::optional<MaskType> flags;
-
-  if (!categories.empty()) {
-    flags = GetFlags(error_stream, *iter, categories);
-    if (!flags)
-      return false;
+  if (categories.empty()) {
+    iter->second.Disable(std::nullopt);
+    return true;
   }
 
-  iter->second.Disable(flags);
+  llvm::Expected<MaskType> flags = GetFlags(*iter, categories);
+  if (!flags) {
+    error_stream << toString(flags.takeError()) << "\n";
+    return false;
+  }
+
+  iter->second.Disable(*flags);
   return true;
 }
 

--- a/lldb/test/API/commands/log/invalid-args/TestInvalidArgsLog.py
+++ b/lldb/test/API/commands/log/invalid-args/TestInvalidArgsLog.py
@@ -28,5 +28,5 @@ class InvalidArgsLogTestCase(TestBase):
         self.expect(
             "log enable lldb all -f " + invalid_path,
             error=True,
-            substrs=["Unable to open log file '" + invalid_path + "': ", "\n"],
+            substrs=["Unable to open log file '" + invalid_path + "': "],
         )

--- a/lldb/tools/lldb-server/LLDBServerUtilities.cpp
+++ b/lldb/tools/lldb-server/LLDBServerUtilities.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormatAdapters.h"
 
 using namespace lldb;
 using namespace lldb_private::lldb_server;
@@ -62,18 +63,16 @@ bool LLDBServerUtilities::SetupLogging(const std::string &log_file,
   SmallVector<StringRef, 32> channel_array;
   log_channels.split(channel_array, ":", /*MaxSplit*/ -1, /*KeepEmpty*/ false);
   for (auto channel_with_categories : channel_array) {
-    std::string error;
-    llvm::raw_string_ostream error_stream(error);
     Args channel_then_categories(channel_with_categories);
     std::string channel(channel_then_categories.GetArgumentAtIndex(0));
     channel_then_categories.Shift(); // Shift off the channel
 
-    bool success = Log::EnableLogChannel(
-        log_stream_sp, log_options, channel,
-        channel_then_categories.GetArgumentArrayRef(), error_stream);
-    if (!success) {
+    llvm::Error error =
+        Log::EnableLogChannel(log_stream_sp, log_options, channel,
+                              channel_then_categories.GetArgumentArrayRef());
+    if (error) {
       errs() << formatv("Unable to setup logging for channel \"{0}\": {1}",
-                        channel, error);
+                        channel, fmt_consume(std::move(error)));
       return false;
     }
   }

--- a/lldb/tools/lldb-test/lldb-test.cpp
+++ b/lldb/tools/lldb-test/lldb-test.cpp
@@ -1269,7 +1269,10 @@ int main(int argc, const char *argv[]) {
       /*add_to_history*/ eLazyBoolNo, Result);
 
   if (!opts::Log.empty())
-    Dbg->EnableLog("lldb", {"all"}, opts::Log, 0, 0, eLogHandlerStream, errs());
+    if (llvm::Error e =
+            Dbg->EnableLog("lldb", {"all"}, opts::Log, 0, 0, eLogHandlerStream))
+      WithColor::error() << "failed to enable logs: " << toString(std::move(e))
+                         << '\n';
 
   if (opts::BreakpointSubcommand)
     return opts::breakpoint::evaluateBreakpoints(*Dbg);

--- a/lldb/unittests/Utility/LogTest.cpp
+++ b/lldb/unittests/Utility/LogTest.cpp
@@ -352,12 +352,12 @@ TEST_F(LogChannelEnabledTest, log_options) {
 }
 
 TEST_F(LogChannelEnabledTest, JSONLOutput) {
-  std::string Err;
-
   // With JSON, every line must parse as JSON and contain exactly the message we
   // logged.
-  EXPECT_TRUE(EnableChannel(
-      getLogHandler(), /*log_options=*/LLDB_LOG_OPTION_JSON, "chan", {}, Err));
+  EXPECT_THAT_ERROR(Log::EnableLogChannel(getLogHandler(),
+                                          /*log_options=*/LLDB_LOG_OPTION_JSON,
+                                          "chan", {}),
+                    llvm::Succeeded());
   llvm::StringRef Msg = logAndTakeOutput("Hello \"World\"\nsecond line");
   ASSERT_TRUE(Msg.ends_with("\n"));
   ASSERT_EQ(Msg.count('\n'), 1u) << "expected one JSON object per line";
@@ -377,7 +377,8 @@ TEST_F(LogChannelEnabledTest, JSONLOutput) {
                   LLDB_LOG_OPTION_PREPEND_THREAD_NAME |
                   LLDB_LOG_OPTION_BACKTRACE |
                   LLDB_LOG_OPTION_PREPEND_FILE_FUNCTION;
-  EXPECT_TRUE(EnableChannel(getLogHandler(), Opts, "chan", {}, Err));
+  EXPECT_THAT_ERROR(Log::EnableLogChannel(getLogHandler(), Opts, "chan", {}),
+                    llvm::Succeeded());
   Msg = logAndTakeOutput("payload");
   Parsed = llvm::json::parse(Msg);
   ASSERT_TRUE(static_cast<bool>(Parsed)) << llvm::toString(Parsed.takeError());

--- a/lldb/unittests/Utility/LogTest.cpp
+++ b/lldb/unittests/Utility/LogTest.cpp
@@ -15,6 +15,7 @@
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Threading.h"
+#include "llvm/Testing/Support/Error.h"
 #include <thread>
 
 using namespace lldb;
@@ -39,17 +40,7 @@ namespace lldb_private {
 template <> Log::Channel &LogChannelFor<TestChannel>() { return test_channel; }
 } // namespace lldb_private
 
-// Wrap enable, disable and list functions to make them easier to test.
-static bool EnableChannel(std::shared_ptr<LogHandler> log_handler_sp,
-                          uint32_t log_options, llvm::StringRef channel,
-                          llvm::ArrayRef<const char *> categories,
-                          std::string &error) {
-  error.clear();
-  llvm::raw_string_ostream error_stream(error);
-  return Log::EnableLogChannel(log_handler_sp, log_options, channel, categories,
-                               error_stream);
-}
-
+// Wrap disable and list functions to make them easier to test.
 static bool DisableChannel(llvm::StringRef channel,
                            llvm::ArrayRef<const char *> categories,
                            std::string &error) {
@@ -118,8 +109,8 @@ static std::string GetDumpAsString(const RotatingLogHandler &handler) {
 void LogChannelEnabledTest::SetUp() {
   LogChannelTest::SetUp();
 
-  std::string error;
-  ASSERT_TRUE(EnableChannel(m_log_handler_sp, 0, "chan", {}, error));
+  ASSERT_THAT_ERROR(Log::EnableLogChannel(m_log_handler_sp, 0, "chan", {}),
+                    llvm::Succeeded());
 
   m_log = GetLog(TestChannel::FOO);
   ASSERT_NE(nullptr, m_log);
@@ -162,8 +153,8 @@ TEST(LogTest, Unregister) {
   Log::Register("chan", test_channel);
   EXPECT_EQ(nullptr, GetLog(TestChannel::FOO));
   auto log_handler_sp = std::make_shared<TestLogHandler>();
-  EXPECT_TRUE(
-      Log::EnableLogChannel(log_handler_sp, 0, "chan", {"foo"}, llvm::nulls()));
+  EXPECT_THAT_ERROR(Log::EnableLogChannel(log_handler_sp, 0, "chan", {"foo"}),
+                    llvm::Succeeded());
   EXPECT_NE(nullptr, GetLog(TestChannel::FOO));
   Log::Unregister("chan");
   EXPECT_EQ(nullptr, GetLog(TestChannel::FOO));
@@ -215,36 +206,47 @@ TEST(LogHandlerTest, TeeLogHandler) {
 TEST_F(LogChannelTest, Enable) {
   EXPECT_EQ(nullptr, GetLog(TestChannel::FOO));
   auto log_handler_sp = std::make_shared<TestLogHandler>();
-  std::string error;
-  ASSERT_FALSE(EnableChannel(log_handler_sp, 0, "chanchan", {}, error));
-  EXPECT_EQ("Invalid log channel 'chanchan'.\n", error);
+  ASSERT_THAT_ERROR(
+      Log::EnableLogChannel(log_handler_sp, 0, "chanchan", {}),
+      llvm::FailedWithMessage("Invalid log channel 'chanchan'.\n"));
 
-  EXPECT_TRUE(EnableChannel(log_handler_sp, 0, "chan", {}, error));
+  EXPECT_THAT_ERROR(Log::EnableLogChannel(log_handler_sp, 0, "chan", {}),
+                    llvm::Succeeded());
   EXPECT_NE(nullptr, GetLog(TestChannel::FOO));
   EXPECT_EQ(nullptr, GetLog(TestChannel::BAR));
   EXPECT_NE(nullptr, GetLog(TestChannel::FOO | TestChannel::BAR));
 
-  EXPECT_TRUE(EnableChannel(log_handler_sp, 0, "chan", {"bar"}, error));
+  EXPECT_THAT_ERROR(Log::EnableLogChannel(log_handler_sp, 0, "chan", {"bar"}),
+                    llvm::Succeeded());
   EXPECT_NE(nullptr, GetLog(TestChannel::FOO));
   EXPECT_NE(nullptr, GetLog(TestChannel::BAR));
 
-  EXPECT_FALSE(EnableChannel(log_handler_sp, 0, "chan", {"baz"}, error));
-  EXPECT_NE(std::string::npos, error.find("unrecognized log category 'baz'"))
-      << "error: " << error;
+  EXPECT_THAT_ERROR(
+      Log::EnableLogChannel(log_handler_sp, 0, "chan", {"baz"}),
+      llvm::FailedWithMessage("error: unrecognized log category 'baz'\n"
+                              "Logging categories for 'chan':\n"
+                              "  all - all available logging categories\n"
+                              "  default - default set of logging categories\n"
+                              "  foo - log foo\n"
+                              "  bar - log bar\n"));
 
-  EXPECT_FALSE(
-      EnableChannel(log_handler_sp, 0, "chan", {"baz", "bar", "abc"}, error));
-  EXPECT_NE(std::string::npos,
-            error.find("unrecognized log categories 'baz', 'abc'"))
-      << "error: " << error;
+  EXPECT_THAT_ERROR(
+      Log::EnableLogChannel(log_handler_sp, 0, "chan", {"baz", "bar", "abc"}),
+      llvm::FailedWithMessage(
+          "error: unrecognized log categories 'baz', 'abc'\n"
+          "Logging categories for 'chan':\n"
+          "  all - all available logging categories\n"
+          "  default - default set of logging categories\n"
+          "  foo - log foo\n"
+          "  bar - log bar\n"));
 }
 
 TEST_F(LogChannelTest, EnableOptions) {
   EXPECT_EQ(nullptr, GetLog(TestChannel::FOO));
   auto log_handler_sp = std::make_shared<TestLogHandler>();
-  std::string error;
-  EXPECT_TRUE(EnableChannel(log_handler_sp, LLDB_LOG_OPTION_VERBOSE, "chan", {},
-                            error));
+  EXPECT_THAT_ERROR(Log::EnableLogChannel(log_handler_sp,
+                                          LLDB_LOG_OPTION_VERBOSE, "chan", {}),
+                    llvm::Succeeded());
 
   Log *log = GetLog(TestChannel::FOO);
   ASSERT_NE(nullptr, log);
@@ -254,11 +256,13 @@ TEST_F(LogChannelTest, EnableOptions) {
 TEST_F(LogChannelTest, Disable) {
   EXPECT_EQ(nullptr, GetLog(TestChannel::FOO));
   auto log_handler_sp = std::make_shared<TestLogHandler>();
-  std::string error;
-  EXPECT_TRUE(EnableChannel(log_handler_sp, 0, "chan", {"foo", "bar"}, error));
+  EXPECT_THAT_ERROR(
+      Log::EnableLogChannel(log_handler_sp, 0, "chan", {"foo", "bar"}),
+      llvm::Succeeded());
   EXPECT_NE(nullptr, GetLog(TestChannel::FOO));
   EXPECT_NE(nullptr, GetLog(TestChannel::BAR));
 
+  std::string error;
   EXPECT_TRUE(DisableChannel("chan", {"bar"}, error));
   EXPECT_NE(nullptr, GetLog(TestChannel::FOO));
   EXPECT_EQ(nullptr, GetLog(TestChannel::BAR));
@@ -290,23 +294,26 @@ TEST_F(LogChannelTest, List) {
 }
 
 TEST_F(LogChannelEnabledTest, log_options) {
-  std::string Err;
   EXPECT_EQ("Hello World\n", logAndTakeOutput("Hello World"));
-  EXPECT_TRUE(EnableChannel(getLogHandler(), 0, "chan", {}, Err));
+  EXPECT_THAT_ERROR(Log::EnableLogChannel(getLogHandler(), 0, "chan", {}),
+                    llvm::Succeeded());
   EXPECT_EQ("Hello World\n", logAndTakeOutput("Hello World"));
 
   {
-    EXPECT_TRUE(EnableChannel(getLogHandler(), LLDB_LOG_OPTION_PREPEND_SEQUENCE,
-                              "chan", {}, Err));
+    EXPECT_THAT_ERROR(Log::EnableLogChannel(getLogHandler(),
+                                            LLDB_LOG_OPTION_PREPEND_SEQUENCE,
+                                            "chan", {}),
+                      llvm::Succeeded());
     llvm::StringRef Msg = logAndTakeOutput("Hello World");
     int seq_no;
     EXPECT_EQ(1, sscanf(Msg.str().c_str(), "%d Hello World", &seq_no));
   }
 
   {
-    EXPECT_TRUE(EnableChannel(getLogHandler(),
-                              LLDB_LOG_OPTION_PREPEND_FILE_FUNCTION, "chan", {},
-                              Err));
+    EXPECT_THAT_ERROR(
+        Log::EnableLogChannel(
+            getLogHandler(), LLDB_LOG_OPTION_PREPEND_FILE_FUNCTION, "chan", {}),
+        llvm::Succeeded());
     llvm::StringRef Msg = logAndTakeOutput("Hello World");
     char File[12];
     char Function[17];
@@ -319,9 +326,10 @@ TEST_F(LogChannelEnabledTest, log_options) {
   }
 
   {
-    EXPECT_TRUE(EnableChannel(getLogHandler(),
-                              LLDB_LOG_OPTION_PREPEND_FILE_FUNCTION, "chan", {},
-                              Err));
+    EXPECT_THAT_ERROR(
+        Log::EnableLogChannel(
+            getLogHandler(), LLDB_LOG_OPTION_PREPEND_FILE_FUNCTION, "chan", {}),
+        llvm::Succeeded());
     llvm::StringRef Msg = logAndTakeOutputf("Hello World");
     char File[12];
     char Function[18];
@@ -333,9 +341,10 @@ TEST_F(LogChannelEnabledTest, log_options) {
     EXPECT_STREQ("logAndTakeOutputf", Function);
   }
 
-  EXPECT_TRUE(EnableChannel(getLogHandler(),
-                            LLDB_LOG_OPTION_PREPEND_PROC_AND_THREAD, "chan", {},
-                            Err));
+  EXPECT_THAT_ERROR(
+      Log::EnableLogChannel(
+          getLogHandler(), LLDB_LOG_OPTION_PREPEND_PROC_AND_THREAD, "chan", {}),
+      llvm::Succeeded());
   EXPECT_EQ(llvm::formatv("[{0,0+4}/{1,0+4}] Hello World\n", ::getpid(),
                           llvm::get_threadid())
                 .str(),
@@ -419,13 +428,13 @@ TEST_F(LogChannelEnabledTest, LogThread) {
 TEST_F(LogChannelEnabledTest, LogVerboseThread) {
   // Test that we are able to concurrently check the verbose flag of a log
   // channel and enable it.
-  std::string err;
 
   // Start logging on one thread. Concurrently, try enabling the log channel
   // (with different log options).
   std::thread log_thread([this] { LLDB_LOG_VERBOSE(getLog(), "Hello World"); });
-  EXPECT_TRUE(
-      EnableChannel(getLogHandler(), LLDB_LOG_OPTION_VERBOSE, "chan", {}, err));
+  EXPECT_THAT_ERROR(Log::EnableLogChannel(getLogHandler(),
+                                          LLDB_LOG_OPTION_VERBOSE, "chan", {}),
+                    llvm::Succeeded());
   log_thread.join();
 
   // The log thread either managed to write to the log, or it didn't. In either


### PR DESCRIPTION
Instead of a boolean plus writing errors to a stream.

llvm::Error is either success or an error message, unlike
before where we could (and did sometimes) succeed but 
also have an error message.

We can do this for DisableLogChannel too but 
I'll do that in a follow up.