### PR TITLE
[AIX][libc++] fopen() does not support the 'x' (exclusive/noreplace) mode suffix.

### DIFF
--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -256,17 +256,19 @@ public:
 
   // 27.9.1.4 Members:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
+  basic_filebuf* open(const char* __s, ios_base::openmode __mode)
 #    if defined(_AIX)
-  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #    endif
-  basic_filebuf* open(const char* __s, ios_base::openmode __mode);
+      ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
+  basic_filebuf* open(const wchar_t* __s, ios_base::openmode __mode)
 #      if defined(_AIX)
-  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #      endif
-  basic_filebuf* open(const wchar_t* __s, ios_base::openmode __mode);
+      ;
 #    endif
   _LIBCPP_HIDE_FROM_ABI basic_filebuf* open(const string& __s, ios_base::openmode __mode);
 
@@ -1218,17 +1220,19 @@ public:
   }
 #    endif
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
+  void open(const char* __s, ios_base::openmode __mode = ios_base::in)
 #    if defined(_AIX)
-  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #    endif
-  void open(const char* __s, ios_base::openmode __mode = ios_base::in);
+      ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
+  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in)
 #      if defined(_AIX)
-  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #      endif
-  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in);
+      ;
 #    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::in);
 #    if _LIBCPP_STD_VER >= 17
@@ -1384,17 +1388,19 @@ public:
   }
 #    endif
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
+  void open(const char* __s, ios_base::openmode __mode = ios_base::out)
 #    if defined(_AIX)
-  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #    endif
-  void open(const char* __s, ios_base::openmode __mode = ios_base::out);
+      ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
+  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::out)
 #      if defined(_AIX)
-  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #      endif
-  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::out);
+      ;
 #    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::out);
 
@@ -1556,17 +1562,19 @@ public:
   }
 #    endif
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
+  _LIBCPP_HIDE_FROM_ABI void open(const char* __s, ios_base::openmode __mode = ios_base::in | ios_base::out)
 #    if defined(_AIX)
-  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #    endif
-  _LIBCPP_HIDE_FROM_ABI void open(const char* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
+      ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
+  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in | ios_base::out)
 #      if defined(_AIX)
-  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #      endif
-  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
+      ;
 #    endif
   _LIBCPP_HIDE_FROM_ABI void open(const string& __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
 

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -261,14 +261,14 @@ public:
       _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                                "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #    endif
-      ;
+          ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   basic_filebuf* open(const wchar_t* __s, ios_base::openmode __mode)
 #      if defined(_AIX)
       _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                                "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #      endif
-      ;
+          ;
 #    endif
   _LIBCPP_HIDE_FROM_ABI basic_filebuf* open(const string& __s, ios_base::openmode __mode);
 
@@ -1225,14 +1225,14 @@ public:
       _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                                "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #    endif
-      ;
+          ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in)
 #      if defined(_AIX)
       _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                                "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #      endif
-      ;
+          ;
 #    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::in);
 #    if _LIBCPP_STD_VER >= 17
@@ -1393,14 +1393,14 @@ public:
       _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                                "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #    endif
-      ;
+          ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::out)
 #      if defined(_AIX)
       _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                                "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #      endif
-      ;
+          ;
 #    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::out);
 
@@ -1567,14 +1567,14 @@ public:
       _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                                "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #    endif
-      ;
+          ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in | ios_base::out)
 #      if defined(_AIX)
       _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                                "fstream::open() with noreplace is not supported on AIX; open() will return failure")
 #      endif
-      ;
+          ;
 #    endif
   _LIBCPP_HIDE_FROM_ABI void open(const string& __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
 

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -256,10 +256,16 @@ public:
 
   // 27.9.1.4 Members:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
+#    if defined(_AIX)
+  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+#    endif
   basic_filebuf* open(const char* __s, ios_base::openmode __mode);
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
-  _LIBCPP_DIAGNOSE_WARNING((__mode & ios_base::noreplace) && defined(_AIX),
+#      if defined(_AIX)
+  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                            "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+#      endif
   basic_filebuf* open(const wchar_t* __s, ios_base::openmode __mode);
 #    endif
   _LIBCPP_HIDE_FROM_ABI basic_filebuf* open(const string& __s, ios_base::openmode __mode);
@@ -666,14 +672,8 @@ const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode _
   case ios_base::in | ios_base::app | ios_base::binary:
     return "a+b" _LIBCPP_FOPEN_CLOEXEC_MODE;
 #    if _LIBCPP_STD_VER >= 23
-// AIX fopen() does not support the 'x' (exclusive/noreplace) mode suffix, so these
-// cases are omitted on AIX and fall through to default (return nullptr), signalling
-// failure to the caller. This is conformant: C23 (7.21.5.3p5), which C++ relies on
-// by proxy, requires that if the implementation cannot atomically check for the
-// existence of the file and create it, it shall fail rather than perform a
-// non-atomic check and creation. Since AIX cannot provide atomic exclusive-open
-// semantics via fopen(), returning nullptr is the correct behaviour.
-// _AIX is defined on AIX by all supported compilers.
+// AIX fopen() does not support the 'x' (noreplace) mode suffix; these cases fall through to
+// default (return nullptr), which is conformant per C23 7.21.5.3p5 (fail if atomic check-and-create is unsupported).
 #      if !defined(_AIX)
   case ios_base::out | ios_base::noreplace:
   case ios_base::out | ios_base::trunc | ios_base::noreplace:
@@ -686,7 +686,7 @@ const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode _
   case ios_base::in | ios_base::out | ios_base::trunc | ios_base::binary | ios_base::noreplace:
     return "w+bx" _LIBCPP_FOPEN_CLOEXEC_MODE;
 #      endif // !defined(_AIX)
-#    endif // _LIBCPP_STD_VER >= 23
+#    endif   // _LIBCPP_STD_VER >= 23
   default:
     return nullptr;
   }
@@ -778,6 +778,7 @@ basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const wchar
   const wchar_t* __mdstr = __make_mdwstring(__mode);
   if (!__mdstr)
     return nullptr;
+
   return __do_open(_wfopen(__s, __mdstr), __mode);
 }
 #    endif
@@ -1217,10 +1218,16 @@ public:
   }
 #    endif
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
+#    if defined(_AIX)
+  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+#    endif
   void open(const char* __s, ios_base::openmode __mode = ios_base::in);
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
-  _LIBCPP_DIAGNOSE_WARNING((__mode & ios_base::noreplace) && defined(_AIX),
+#      if defined(_AIX)
+  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                            "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+#      endif
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in);
 #    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::in);
@@ -1377,10 +1384,16 @@ public:
   }
 #    endif
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
+#    if defined(_AIX)
+  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+#    endif
   void open(const char* __s, ios_base::openmode __mode = ios_base::out);
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
-  _LIBCPP_DIAGNOSE_WARNING((__mode & ios_base::noreplace) && defined(_AIX),
+#      if defined(_AIX)
+  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                            "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+#      endif
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::out);
 #    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::out);
@@ -1543,10 +1556,16 @@ public:
   }
 #    endif
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
+#    if defined(_AIX)
+  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
+                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+#    endif
   _LIBCPP_HIDE_FROM_ABI void open(const char* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
-  _LIBCPP_DIAGNOSE_WARNING((__mode & ios_base::noreplace) && defined(_AIX),
+#      if defined(_AIX)
+  _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
                            "fstream::open() with noreplace is not supported on AIX; open() will return failure")
+#      endif
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
 #    endif
   _LIBCPP_HIDE_FROM_ABI void open(const string& __s, ios_base::openmode __mode = ios_base::in | ios_base::out);

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -263,12 +263,7 @@ public:
 #    endif
           ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
-  basic_filebuf* open(const wchar_t* __s, ios_base::openmode __mode)
-#      if defined(_AIX)
-      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
-#      endif
-          ;
+  basic_filebuf* open(const wchar_t* __s, ios_base::openmode __mode);
 #    endif
   _LIBCPP_HIDE_FROM_ABI basic_filebuf* open(const string& __s, ios_base::openmode __mode);
 
@@ -1227,12 +1222,7 @@ public:
 #    endif
           ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
-  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in)
-#      if defined(_AIX)
-      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
-#      endif
-          ;
+  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in);
 #    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::in);
 #    if _LIBCPP_STD_VER >= 17
@@ -1395,12 +1385,7 @@ public:
 #    endif
           ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
-  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::out)
-#      if defined(_AIX)
-      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
-#      endif
-          ;
+  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::out);
 #    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::out);
 
@@ -1569,12 +1554,7 @@ public:
 #    endif
           ;
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
-  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in | ios_base::out)
-#      if defined(_AIX)
-      _LIBCPP_DIAGNOSE_WARNING(__mode& ios_base::noreplace,
-                               "fstream::open() with noreplace is not supported on AIX; open() will return failure")
-#      endif
-          ;
+  void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
 #    endif
   _LIBCPP_HIDE_FROM_ABI void open(const string& __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
 

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -258,6 +258,8 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
   basic_filebuf* open(const char* __s, ios_base::openmode __mode);
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
+  _LIBCPP_DIAGNOSE_WARNING((__mode & ios_base::noreplace) && defined(_AIX),
+                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
   basic_filebuf* open(const wchar_t* __s, ios_base::openmode __mode);
 #    endif
   _LIBCPP_HIDE_FROM_ABI basic_filebuf* open(const string& __s, ios_base::openmode __mode);
@@ -671,8 +673,8 @@ const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode _
 // existence of the file and create it, it shall fail rather than perform a
 // non-atomic check and creation. Since AIX cannot provide atomic exclusive-open
 // semantics via fopen(), returning nullptr is the correct behaviour.
-// _AIX is defined by clang on AIX; __TOS_AIX__ is defined by both clang and XLC.
-#      if !defined(_AIX) && !defined(__TOS_AIX__)
+// _AIX is defined on AIX by all supported compilers.
+#      if !defined(_AIX)
   case ios_base::out | ios_base::noreplace:
   case ios_base::out | ios_base::trunc | ios_base::noreplace:
     return "wx" _LIBCPP_FOPEN_CLOEXEC_MODE;
@@ -683,7 +685,7 @@ const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode _
     return "wbx" _LIBCPP_FOPEN_CLOEXEC_MODE;
   case ios_base::in | ios_base::out | ios_base::trunc | ios_base::binary | ios_base::noreplace:
     return "w+bx" _LIBCPP_FOPEN_CLOEXEC_MODE;
-#      endif // !defined(_AIX) && !defined(__TOS_AIX__)
+#      endif // !defined(_AIX)
 #    endif // _LIBCPP_STD_VER >= 23
   default:
     return nullptr;
@@ -774,13 +776,8 @@ basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const wchar
   if (__file_)
     return nullptr;
   const wchar_t* __mdstr = __make_mdwstring(__mode);
-  if (!__mdstr) {
-#      if defined(_AIX) || defined(__TOS_AIX__)
-    if (__mode & ios_base::noreplace)
-      fprintf(stderr, "warning: fstream::open() with noreplace is not supported on AIX; returning failure\n");
-#      endif
+  if (!__mdstr)
     return nullptr;
-  }
   return __do_open(_wfopen(__s, __mdstr), __mode);
 }
 #    endif
@@ -1222,6 +1219,8 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
   void open(const char* __s, ios_base::openmode __mode = ios_base::in);
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
+  _LIBCPP_DIAGNOSE_WARNING((__mode & ios_base::noreplace) && defined(_AIX),
+                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in);
 #    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::in);
@@ -1380,6 +1379,8 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
   void open(const char* __s, ios_base::openmode __mode = ios_base::out);
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
+  _LIBCPP_DIAGNOSE_WARNING((__mode & ios_base::noreplace) && defined(_AIX),
+                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::out);
 #    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::out);
@@ -1544,6 +1545,8 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_open() const;
   _LIBCPP_HIDE_FROM_ABI void open(const char* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
 #    if _LIBCPP_HAS_OPEN_WITH_WCHAR
+  _LIBCPP_DIAGNOSE_WARNING((__mode & ios_base::noreplace) && defined(_AIX),
+                           "fstream::open() with noreplace is not supported on AIX; open() will return failure")
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
 #    endif
   _LIBCPP_HIDE_FROM_ABI void open(const string& __s, ios_base::openmode __mode = ios_base::in | ios_base::out);

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -672,6 +672,9 @@ const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode _
 // non-atomic check and creation. Since AIX cannot provide atomic exclusive-open
 // semantics via fopen(), returning nullptr is the correct behaviour.
 // _AIX is defined by clang on AIX; __TOS_AIX__ is defined by both clang and XLC.
+#      if defined(_AIX) || defined(__TOS_AIX__)
+#        warning 'exclusive mode is unsupported on this target'
+#      endif
 #      if !defined(_AIX) && !defined(__TOS_AIX__)
   case ios_base::out | ios_base::noreplace:
   case ios_base::out | ios_base::trunc | ios_base::noreplace:

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -774,13 +774,13 @@ basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const wchar
   if (__file_)
     return nullptr;
   const wchar_t* __mdstr = __make_mdwstring(__mode);
-  if (!__mdstr){
-#     if defined(_AIX) || defined(__TOS_AIX__)
+  if (!__mdstr) {
+#      if defined(_AIX) || defined(__TOS_AIX__)
     if (__mode & ios_base::noreplace)
       fprintf(stderr, "warning: fstream::open() with noreplace is not supported on AIX; returning failure\n");
-#     endif
+#      endif
     return nullptr;
-}
+  }
   return __do_open(_wfopen(__s, __mdstr), __mode);
 }
 #    endif

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -664,6 +664,15 @@ const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode _
   case ios_base::in | ios_base::app | ios_base::binary:
     return "a+b" _LIBCPP_FOPEN_CLOEXEC_MODE;
 #    if _LIBCPP_STD_VER >= 23
+// AIX fopen() does not support the 'x' (exclusive/noreplace) mode suffix, so these
+// cases are omitted on AIX and fall through to default (return nullptr), signalling
+// failure to the caller. This is conformant: C23 (7.21.5.3p5), which C++ relies on
+// by proxy, requires that if the implementation cannot atomically check for the
+// existence of the file and create it, it shall fail rather than perform a
+// non-atomic check and creation. Since AIX cannot provide atomic exclusive-open
+// semantics via fopen(), returning nullptr is the correct behaviour.
+// _AIX is defined by clang on AIX; __TOS_AIX__ is defined by both clang and XLC.
+#      if !defined(_AIX) && !defined(__TOS_AIX__)
   case ios_base::out | ios_base::noreplace:
   case ios_base::out | ios_base::trunc | ios_base::noreplace:
     return "wx" _LIBCPP_FOPEN_CLOEXEC_MODE;
@@ -674,6 +683,7 @@ const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode _
     return "wbx" _LIBCPP_FOPEN_CLOEXEC_MODE;
   case ios_base::in | ios_base::out | ios_base::trunc | ios_base::binary | ios_base::noreplace:
     return "w+bx" _LIBCPP_FOPEN_CLOEXEC_MODE;
+#      endif // !defined(_AIX) && !defined(__TOS_AIX__)
 #    endif // _LIBCPP_STD_VER >= 23
   default:
     return nullptr;

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -673,7 +673,10 @@ const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode _
 // semantics via fopen(), returning nullptr is the correct behaviour.
 // _AIX is defined by clang on AIX; __TOS_AIX__ is defined by both clang and XLC.
 #      if defined(_AIX) || defined(__TOS_AIX__)
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic warning "-Wcpp"
 #        warning 'exclusive mode is unsupported on this target'
+#        pragma GCC diagnostic pop
 #      endif
 #      if !defined(_AIX) && !defined(__TOS_AIX__)
   case ios_base::out | ios_base::noreplace:

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -672,12 +672,6 @@ const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode _
 // non-atomic check and creation. Since AIX cannot provide atomic exclusive-open
 // semantics via fopen(), returning nullptr is the correct behaviour.
 // _AIX is defined by clang on AIX; __TOS_AIX__ is defined by both clang and XLC.
-#      if defined(_AIX) || defined(__TOS_AIX__)
-#        pragma GCC diagnostic push
-#        pragma GCC diagnostic warning "-Wcpp"
-#        warning 'exclusive mode is unsupported on this target'
-#        pragma GCC diagnostic pop
-#      endif
 #      if !defined(_AIX) && !defined(__TOS_AIX__)
   case ios_base::out | ios_base::noreplace:
   case ios_base::out | ios_base::trunc | ios_base::noreplace:
@@ -780,9 +774,13 @@ basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const wchar
   if (__file_)
     return nullptr;
   const wchar_t* __mdstr = __make_mdwstring(__mode);
-  if (!__mdstr)
+  if (!__mdstr){
+#     if defined(_AIX) || defined(__TOS_AIX__)
+    if (__mode & ios_base::noreplace)
+      fprintf(stderr, "warning: fstream::open() with noreplace is not supported on AIX; returning failure\n");
+#     endif
     return nullptr;
-
+}
   return __do_open(_wfopen(__s, __mdstr), __mode);
 }
 #    endif

--- a/libcxx/test/libcxx/input.output/file.streams/fstreams/diagnose_noreplace.verify.cpp
+++ b/libcxx/test/libcxx/input.output/file.streams/fstreams/diagnose_noreplace.verify.cpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// AIX fopen() does not support the 'x' mode.
+
+// REQUIRES: aix
+
+#include <fstream>
+
+void test() {
+  std::filebuf fb;
+  fb.open("f", std::ios_base::out | std::ios_base::noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
+
+  std::ifstream ifs;
+  ifs.open("f", std::ios_base::in | std::ios_base::noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
+
+  std::ofstream ofs;
+  ofs.open("f", std::ios_base::out | std::ios_base::noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
+
+  std::fstream fs;
+  fs.open("f", std::ios_base::out | std::ios_base::noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
+}

--- a/libcxx/test/libcxx/input.output/file.streams/fstreams/diagnose_noreplace.verify.cpp
+++ b/libcxx/test/libcxx/input.output/file.streams/fstreams/diagnose_noreplace.verify.cpp
@@ -8,20 +8,36 @@
 
 // AIX fopen() does not support the 'x' mode.
 
-// REQUIRES: aix
+// REQUIRES: target={{.+}}-aix{{.*}}
 
 #include <fstream>
 
 void test() {
   std::filebuf fb;
-  fb.open("f", std::ios_base::out | std::ios_base::noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
+  fb.open(
+      "f",
+      std::ios_base::out |
+          std::ios_base::
+              noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
 
   std::ifstream ifs;
-  ifs.open("f", std::ios_base::in | std::ios_base::noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
+  ifs.open(
+      "f",
+      std::ios_base::in |
+          std::ios_base::
+              noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
 
   std::ofstream ofs;
-  ofs.open("f", std::ios_base::out | std::ios_base::noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
+  ofs.open(
+      "f",
+      std::ios_base::out |
+          std::ios_base::
+              noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
 
   std::fstream fs;
-  fs.open("f", std::ios_base::out | std::ios_base::noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
+  fs.open(
+      "f",
+      std::ios_base::out |
+          std::ios_base::
+              noreplace); // expected-warning {{fstream::open() with noreplace is not supported on AIX; open() will return failure}}
 }

--- a/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
@@ -13,8 +13,6 @@
 // In C++23 and later, this test requires support for P2467R1 in the dylib (a3f17ba3febbd546f2342ffc780ac93b694fdc8d)
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
-// XFAIL: LIBCXX-AIX-FIXME
-
 #include <fstream>
 #include <cassert>
 #include "test_macros.h"
@@ -75,7 +73,10 @@ int main(int, char**)
           {
             std::filebuf f;
             f.open(tmp.c_str(), mode);
-            assert(!f.is_open()); // since it already exists
+            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
+            // returns nullptr for all noreplace modes. On other platforms, the file already
+            // exists so noreplace causes open() to fail.
+            assert(!f.is_open());
           }
 
           {
@@ -83,7 +84,13 @@ int main(int, char**)
 
             std::filebuf f;
             f.open(tmp.c_str(), mode);
+#if defined(_AIX) || defined(__TOS_AIX__)
+            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
+            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+            assert(!f.is_open());
+#else
             assert(f.is_open()); // since it doesn't exist
+#endif
           }
         }
 
@@ -94,7 +101,10 @@ int main(int, char**)
           {
             std::wfilebuf f;
             f.open(tmp.c_str(), mode);
-            assert(!f.is_open()); // since it already exists
+            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
+            // returns nullptr for all noreplace modes. On other platforms, the file already
+            // exists so noreplace causes open() to fail.
+            assert(!f.is_open());
           }
 
           {
@@ -102,7 +112,13 @@ int main(int, char**)
 
             std::wfilebuf f;
             f.open(tmp.c_str(), mode);
+#if defined(_AIX) || defined(__TOS_AIX__)
+            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
+            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+            assert(!f.is_open());
+#else
             assert(f.is_open()); // since it doesn't exist
+#endif
           }
         }
 #  endif

--- a/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
@@ -84,13 +84,13 @@ int main(int, char**)
 
             std::filebuf f;
             f.open(tmp.c_str(), mode);
-#if defined(_AIX) || defined(__TOS_AIX__)
+#  if defined(_AIX) || defined(__TOS_AIX__)
             // AIX fopen() does not support the 'x' (exclusive) mode suffix;
             // open() returns nullptr for all noreplace modes regardless of whether the file exists.
             assert(!f.is_open());
-#else
+#  else
             assert(f.is_open()); // since it doesn't exist
-#endif
+#  endif
           }
         }
 
@@ -112,13 +112,13 @@ int main(int, char**)
 
             std::wfilebuf f;
             f.open(tmp.c_str(), mode);
-#if defined(_AIX) || defined(__TOS_AIX__)
+#    if defined(_AIX) || defined(__TOS_AIX__)
             // AIX fopen() does not support the 'x' (exclusive) mode suffix;
             // open() returns nullptr for all noreplace modes regardless of whether the file exists.
             assert(!f.is_open());
-#else
+#    else
             assert(f.is_open()); // since it doesn't exist
-#endif
+#    endif
           }
         }
 #  endif

--- a/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
@@ -73,10 +73,7 @@ int main(int, char**)
           {
             std::filebuf f;
             f.open(tmp.c_str(), mode);
-            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
-            // returns nullptr for all noreplace modes. On other platforms, the file already
-            // exists so noreplace causes open() to fail.
-            assert(!f.is_open());
+            assert(!f.is_open()); // since it already exists
           }
 
           {
@@ -84,9 +81,7 @@ int main(int, char**)
 
             std::filebuf f;
             f.open(tmp.c_str(), mode);
-#  if defined(_AIX) || defined(__TOS_AIX__)
-            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
-            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+#  if defined(_AIX)
             assert(!f.is_open());
 #  else
             assert(f.is_open()); // since it doesn't exist
@@ -101,10 +96,7 @@ int main(int, char**)
           {
             std::wfilebuf f;
             f.open(tmp.c_str(), mode);
-            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
-            // returns nullptr for all noreplace modes. On other platforms, the file already
-            // exists so noreplace causes open() to fail.
-            assert(!f.is_open());
+            assert(!f.is_open()); // since it already exists
           }
 
           {
@@ -112,9 +104,7 @@ int main(int, char**)
 
             std::wfilebuf f;
             f.open(tmp.c_str(), mode);
-#    if defined(_AIX) || defined(__TOS_AIX__)
-            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
-            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+#    if defined(_AIX)
             assert(!f.is_open());
 #    else
             assert(f.is_open()); // since it doesn't exist

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.cons/pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.cons/pointer.pass.cpp
@@ -16,8 +16,6 @@
 // In C++23 and later, this test requires support for P2467R1 in the dylib (a3f17ba3febbd546f2342ffc780ac93b694fdc8d)
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
-// XFAIL: LIBCXX-AIX-FIXME
-
 #include <fstream>
 #include <cassert>
 
@@ -91,14 +89,23 @@ int main(int, char**)
 
           {
             std::fstream f(tmp.c_str(), mode);
-            assert(!f.is_open()); // since it already exists
+            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
+            // returns nullptr for all noreplace modes. On other platforms, the file already
+            // exists so noreplace causes open() to fail.
+            assert(!f.is_open());
           }
 
           {
             std::remove(tmp.c_str());
 
             std::fstream f(tmp.c_str(), mode);
+#  if defined(_AIX) || defined(__TOS_AIX__)
+            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
+            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+            assert(!f.is_open());
+#  else
             assert(f.is_open()); // since it doesn't exist
+#  endif
           }
         }
 
@@ -108,14 +115,23 @@ int main(int, char**)
 
           {
             std::wfstream f(tmp.c_str(), mode);
-            assert(!f.is_open()); // since it already exists
+            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
+            // returns nullptr for all noreplace modes. On other platforms, the file already
+            // exists so noreplace causes open() to fail.
+            assert(!f.is_open());
           }
 
           {
             std::remove(tmp.c_str());
 
             std::wfstream f(tmp.c_str(), mode);
+#    if defined(_AIX) || defined(__TOS_AIX__)
+            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
+            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+            assert(!f.is_open());
+#    else
             assert(f.is_open()); // since it doesn't exist
+#    endif
           }
         }
 #  endif

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.cons/pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.cons/pointer.pass.cpp
@@ -89,19 +89,14 @@ int main(int, char**)
 
           {
             std::fstream f(tmp.c_str(), mode);
-            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
-            // returns nullptr for all noreplace modes. On other platforms, the file already
-            // exists so noreplace causes open() to fail.
-            assert(!f.is_open());
+            assert(!f.is_open()); // since it already exists
           }
 
           {
             std::remove(tmp.c_str());
 
             std::fstream f(tmp.c_str(), mode);
-#  if defined(_AIX) || defined(__TOS_AIX__)
-            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
-            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+#  if defined(_AIX)
             assert(!f.is_open());
 #  else
             assert(f.is_open()); // since it doesn't exist
@@ -115,19 +110,14 @@ int main(int, char**)
 
           {
             std::wfstream f(tmp.c_str(), mode);
-            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
-            // returns nullptr for all noreplace modes. On other platforms, the file already
-            // exists so noreplace causes open() to fail.
-            assert(!f.is_open());
+            assert(!f.is_open()); // since it already exists
           }
 
           {
             std::remove(tmp.c_str());
 
             std::wfstream f(tmp.c_str(), mode);
-#    if defined(_AIX) || defined(__TOS_AIX__)
-            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
-            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+#    if defined(_AIX)
             assert(!f.is_open());
 #    else
             assert(f.is_open()); // since it doesn't exist

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/open_pointer.pass.cpp
@@ -16,8 +16,6 @@
 // In C++23 and later, this test requires support for P2467R1 in the dylib (a3f17ba3febbd546f2342ffc780ac93b694fdc8d)
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
-// XFAIL: LIBCXX-AIX-FIXME
-
 #include <fstream>
 #include <cassert>
 #include "test_macros.h"
@@ -74,7 +72,10 @@ int main(int, char**)
           {
             std::fstream f;
             f.open(tmp.c_str(), mode);
-            assert(!f.is_open()); // since it already exists
+            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
+            // returns nullptr for all noreplace modes. On other platforms, the file already
+            // exists so noreplace causes open() to fail.
+            assert(!f.is_open());
           }
 
           {
@@ -82,7 +83,13 @@ int main(int, char**)
 
             std::fstream f;
             f.open(tmp.c_str(), mode);
+#  if defined(_AIX) || defined(__TOS_AIX__)
+            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
+            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+            assert(!f.is_open());
+#  else
             assert(f.is_open()); // since it doesn't exist
+#  endif
           }
         }
 
@@ -93,7 +100,10 @@ int main(int, char**)
           {
             std::wfstream f;
             f.open(tmp.c_str(), mode);
-            assert(!f.is_open()); // since it already exists
+            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
+            // returns nullptr for all noreplace modes. On other platforms, the file already
+            // exists so noreplace causes open() to fail.
+            assert(!f.is_open());
           }
 
           {
@@ -101,7 +111,13 @@ int main(int, char**)
 
             std::wfstream f;
             f.open(tmp.c_str(), mode);
+#    if defined(_AIX) || defined(__TOS_AIX__)
+            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
+            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+            assert(!f.is_open());
+#    else
             assert(f.is_open()); // since it doesn't exist
+#    endif
           }
         }
 #  endif

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/open_pointer.pass.cpp
@@ -72,10 +72,7 @@ int main(int, char**)
           {
             std::fstream f;
             f.open(tmp.c_str(), mode);
-            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
-            // returns nullptr for all noreplace modes. On other platforms, the file already
-            // exists so noreplace causes open() to fail.
-            assert(!f.is_open());
+            assert(!f.is_open()); // since it already exists
           }
 
           {
@@ -83,9 +80,7 @@ int main(int, char**)
 
             std::fstream f;
             f.open(tmp.c_str(), mode);
-#  if defined(_AIX) || defined(__TOS_AIX__)
-            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
-            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+#  if defined(_AIX)
             assert(!f.is_open());
 #  else
             assert(f.is_open()); // since it doesn't exist
@@ -100,10 +95,7 @@ int main(int, char**)
           {
             std::wfstream f;
             f.open(tmp.c_str(), mode);
-            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
-            // returns nullptr for all noreplace modes. On other platforms, the file already
-            // exists so noreplace causes open() to fail.
-            assert(!f.is_open());
+            assert(!f.is_open()); // since it already exists
           }
 
           {
@@ -111,9 +103,7 @@ int main(int, char**)
 
             std::wfstream f;
             f.open(tmp.c_str(), mode);
-#    if defined(_AIX) || defined(__TOS_AIX__)
-            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
-            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+#    if defined(_AIX)
             assert(!f.is_open());
 #    else
             assert(f.is_open()); // since it doesn't exist

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.cons/pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.cons/pointer.pass.cpp
@@ -16,8 +16,6 @@
 // In C++23 and later, this test requires support for P2467R1 in the dylib (a3f17ba3febbd546f2342ffc780ac93b694fdc8d)
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
-// XFAIL: LIBCXX-AIX-FIXME
-
 #include <fstream>
 #include <cassert>
 #include <ios>
@@ -145,14 +143,23 @@ int main(int, char**)
 
           {
             std::ofstream f(tmp.c_str(), mode);
-            assert(!f.is_open()); // since it already exists
+            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
+            // returns nullptr for all noreplace modes. On other platforms, the file already
+            // exists so noreplace causes open() to fail.
+            assert(!f.is_open());
           }
 
           {
             std::remove(tmp.c_str());
 
             std::ofstream f(tmp.c_str(), mode);
+#  if defined(_AIX) || defined(__TOS_AIX__)
+            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
+            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+            assert(!f.is_open());
+#  else
             assert(f.is_open()); // since it doesn't exist
+#  endif
           }
         }
 
@@ -162,14 +169,23 @@ int main(int, char**)
 
           {
             std::wofstream f(tmp.c_str(), mode);
-            assert(!f.is_open()); // since it already exists
+            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
+            // returns nullptr for all noreplace modes. On other platforms, the file already
+            // exists so noreplace causes open() to fail.
+            assert(!f.is_open());
           }
 
           {
             std::remove(tmp.c_str());
 
             std::wofstream f(tmp.c_str(), mode);
+#    if defined(_AIX) || defined(__TOS_AIX__)
+            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
+            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+            assert(!f.is_open());
+#    else
             assert(f.is_open()); // since it doesn't exist
+#    endif
           }
         }
 #  endif

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.cons/pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.cons/pointer.pass.cpp
@@ -143,19 +143,14 @@ int main(int, char**)
 
           {
             std::ofstream f(tmp.c_str(), mode);
-            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
-            // returns nullptr for all noreplace modes. On other platforms, the file already
-            // exists so noreplace causes open() to fail.
-            assert(!f.is_open());
+            assert(!f.is_open()); // since it already exists
           }
 
           {
             std::remove(tmp.c_str());
 
             std::ofstream f(tmp.c_str(), mode);
-#  if defined(_AIX) || defined(__TOS_AIX__)
-            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
-            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+#  if defined(_AIX)
             assert(!f.is_open());
 #  else
             assert(f.is_open()); // since it doesn't exist
@@ -169,19 +164,14 @@ int main(int, char**)
 
           {
             std::wofstream f(tmp.c_str(), mode);
-            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
-            // returns nullptr for all noreplace modes. On other platforms, the file already
-            // exists so noreplace causes open() to fail.
-            assert(!f.is_open());
+            assert(!f.is_open()); // since it already exists
           }
 
           {
             std::remove(tmp.c_str());
 
             std::wofstream f(tmp.c_str(), mode);
-#    if defined(_AIX) || defined(__TOS_AIX__)
-            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
-            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+#    if defined(_AIX)
             assert(!f.is_open());
 #    else
             assert(f.is_open()); // since it doesn't exist

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
@@ -16,8 +16,6 @@
 // In C++23 and later, this test requires support for P2467R1 in the dylib (a3f17ba3febbd546f2342ffc780ac93b694fdc8d)
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
-// XFAIL: LIBCXX-AIX-FIXME
-
 #include <fstream>
 #include <cassert>
 #include "test_macros.h"
@@ -82,7 +80,10 @@ int main(int, char**)
           {
             std::ofstream f;
             f.open(tmp.c_str(), mode);
-            assert(!f.is_open()); // since it already exists
+            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
+            // returns nullptr for all noreplace modes. On other platforms, the file already
+            // exists so noreplace causes open() to fail.
+            assert(!f.is_open());
           }
 
           {
@@ -90,7 +91,13 @@ int main(int, char**)
 
             std::ofstream f;
             f.open(tmp.c_str(), mode);
+#  if defined(_AIX) || defined(__TOS_AIX__)
+            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
+            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+            assert(!f.is_open());
+#  else
             assert(f.is_open()); // since it doesn't exist
+#  endif
           }
         }
 
@@ -101,14 +108,24 @@ int main(int, char**)
           {
             std::wofstream f;
             f.open(tmp.c_str(), mode);
-            assert(!f.is_open()); // since it already exists
+            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
+            // returns nullptr for all noreplace modes. On other platforms, the file already
+            // exists so noreplace causes open() to fail.
+            assert(!f.is_open());
           }
+
           {
             std::remove(tmp.c_str());
 
             std::wofstream f;
             f.open(tmp.c_str(), mode);
+#    if defined(_AIX) || defined(__TOS_AIX__)
+            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
+            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+            assert(!f.is_open());
+#    else
             assert(f.is_open()); // since it doesn't exist
+#    endif
           }
         }
 #  endif

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
@@ -105,7 +105,6 @@ int main(int, char**)
             f.open(tmp.c_str(), mode);
             assert(!f.is_open()); // since it already exists
           }
-
           {
             std::remove(tmp.c_str());
 

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
@@ -80,10 +80,7 @@ int main(int, char**)
           {
             std::ofstream f;
             f.open(tmp.c_str(), mode);
-            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
-            // returns nullptr for all noreplace modes. On other platforms, the file already
-            // exists so noreplace causes open() to fail.
-            assert(!f.is_open());
+            assert(!f.is_open()); // since it already exists
           }
 
           {
@@ -91,9 +88,7 @@ int main(int, char**)
 
             std::ofstream f;
             f.open(tmp.c_str(), mode);
-#  if defined(_AIX) || defined(__TOS_AIX__)
-            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
-            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+#  if defined(_AIX)
             assert(!f.is_open());
 #  else
             assert(f.is_open()); // since it doesn't exist
@@ -108,10 +103,7 @@ int main(int, char**)
           {
             std::wofstream f;
             f.open(tmp.c_str(), mode);
-            // On AIX, fopen() does not support the 'x' (exclusive) mode suffix so open()
-            // returns nullptr for all noreplace modes. On other platforms, the file already
-            // exists so noreplace causes open() to fail.
-            assert(!f.is_open());
+            assert(!f.is_open()); // since it already exists
           }
 
           {
@@ -119,9 +111,7 @@ int main(int, char**)
 
             std::wofstream f;
             f.open(tmp.c_str(), mode);
-#    if defined(_AIX) || defined(__TOS_AIX__)
-            // AIX fopen() does not support the 'x' (exclusive) mode suffix;
-            // open() returns nullptr for all noreplace modes regardless of whether the file exists.
+#    if defined(_AIX)
             assert(!f.is_open());
 #    else
             assert(f.is_open()); // since it doesn't exist


### PR DESCRIPTION
AIX fopen() does not support the 'x' (exclusive/noreplace) mode suffix. 
Return null for all instances of `noreplace` as the check happens non-atomically.
Note that the wording of this mode in C23, Specifically (para 5):

`If the implementation is not capable of performing the check for the existence of the file and the
creation of the file atomically, it shall fail instead of performing a non-atomic check and creation` 
Ref: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf
