### PR TITLE
[MLIR][Vector] Generalize broadcast lowering for single-element vector to nD

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorBroadcast.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorBroadcast.cpp
@@ -52,8 +52,7 @@ public:
     int64_t srcRank = srcType.getRank();
     int64_t dstRank = dstType.getRank();
 
-    // A broadcast from a single-element source vector is equivalent to scalar
-    // broadcasting to an nD shape.
+    // Single-element fixed-size source: extract the scalar and broadcast it.
     if (srcType.getNumElements() == 1 && !srcType.isScalable()) {
       SmallVector<int64_t> fullRankPosition(srcRank, 0);
       Value ext = vector::ExtractOp::create(rewriter, loc, op.getSource(),

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorBroadcast.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorBroadcast.cpp
@@ -52,9 +52,9 @@ public:
     int64_t srcRank = srcType.getRank();
     int64_t dstRank = dstType.getRank();
 
-    // Here we are broadcasting to a rank-1 vector. Ensure that the source is a
-    // scalar.
-    if (srcRank <= 1 && dstRank == 1) {
+    // A broadcast from a single-element source vector is equivalent to scalar
+    // broadcasting to an nD shape.
+    if (srcType.getNumElements() == 1 && !srcType.isScalable()) {
       SmallVector<int64_t> fullRankPosition(srcRank, 0);
       Value ext = vector::ExtractOp::create(rewriter, loc, op.getSource(),
                                             fullRankPosition);

--- a/mlir/test/Conversion/VectorToLLVM/vector-to-llvm.mlir
+++ b/mlir/test/Conversion/VectorToLLVM/vector-to-llvm.mlir
@@ -197,17 +197,16 @@ func.func @broadcast_vec2d_from_vec0d(%arg0: vector<f32>) -> vector<3x2xf32> {
 // CHECK-LABEL: @broadcast_vec2d_from_vec0d(
 // CHECK-SAME:  %[[A:.*]]: vector<f32>)
 //       CHECK: %[[T0:.*]] = builtin.unrealized_conversion_cast %[[A]] : vector<f32> to vector<1xf32>
-//       CHECK: %[[T1:.*]] = ub.poison : vector<3x2xf32>
-//       CHECK: %[[T2:.*]] = builtin.unrealized_conversion_cast %[[T1]] : vector<3x2xf32> to !llvm.array<3 x vector<2xf32>>
-//       CHECK: %[[T4:.*]] = llvm.mlir.constant(0 : i64) : i64
-//       CHECK: %[[T5:.*]] = llvm.extractelement %[[T0]][%[[T4]] : i64] : vector<1xf32>
-//       CHECK: %[[T6Insert:.*]] = llvm.insertelement %[[T5]]
-//       CHECK: %[[T6:.*]] = llvm.shufflevector %[[T6Insert]]
-//       CHECK: %[[T7:.*]] = llvm.insertvalue %[[T6]], %[[T2]][0] : !llvm.array<3 x vector<2xf32>>
-//       CHECK: %[[T8:.*]] = llvm.insertvalue %[[T6]], %[[T7]][1] : !llvm.array<3 x vector<2xf32>>
-//       CHECK: %[[T9:.*]] = llvm.insertvalue %[[T6]], %[[T8]][2] : !llvm.array<3 x vector<2xf32>>
-//       CHECK: %[[T10:.*]] = builtin.unrealized_conversion_cast %[[T9]] : !llvm.array<3 x vector<2xf32>> to vector<3x2xf32>
-//       CHECK: return %[[T10]] : vector<3x2xf32>
+//       CHECK: %[[T1:.*]] = llvm.mlir.constant(0 : i64) : i64
+//       CHECK: %[[T2:.*]] = llvm.extractelement %[[T0]][%[[T1]] : i64] : vector<1xf32>
+//       CHECK: %[[T3:.*]] = llvm.mlir.poison : !llvm.array<3 x vector<2xf32>>
+//       CHECK: %[[T4Insert:.*]] = llvm.insertelement %[[T2]]
+//       CHECK: %[[T4:.*]] = llvm.shufflevector %[[T4Insert]]
+//       CHECK: %[[T5:.*]] = llvm.insertvalue %[[T4]], %[[T3]][0] : !llvm.array<3 x vector<2xf32>>
+//       CHECK: %[[T6:.*]] = llvm.insertvalue %[[T4]], %[[T5]][1] : !llvm.array<3 x vector<2xf32>>
+//       CHECK: %[[T7:.*]] = llvm.insertvalue %[[T4]], %[[T6]][2] : !llvm.array<3 x vector<2xf32>>
+//       CHECK: %[[T8:.*]] = builtin.unrealized_conversion_cast %[[T7]] : !llvm.array<3 x vector<2xf32>> to vector<3x2xf32>
+//       CHECK: return %[[T8]] : vector<3x2xf32>
 
 // -----
 
@@ -1499,7 +1498,7 @@ func.func @constant_mask_2d() -> vector<4x4xi1> {
 }
 
 // CHECK-LABEL: func @constant_mask_2d
-// CHECK: %[[VAL_0:.*]] = arith.constant 
+// CHECK: %[[VAL_0:.*]] = arith.constant
 // CHECK-SAME{LITERAL}: dense<[[true, true, false, false], [true, true, false, false], [false, false, false, false], [false, false, false, false]]> : vector<4x4xi1>
 // CHECK: return %[[VAL_0]] : vector<4x4xi1>
 

--- a/mlir/test/Dialect/Vector/vector-broadcast-lowering-transforms.mlir
+++ b/mlir/test/Dialect/Vector/vector-broadcast-lowering-transforms.mlir
@@ -117,7 +117,7 @@ func.func @broadcast_vec2d_from_vec2d_single_element(%arg0: vector<1x1xf32>) -> 
   return %0 : vector<4x3xf32>
 }
 
-// CHECK-LABEL: func @broadcast_single_elem_scalable_src
+// CHECK-LABEL: func @broadcast_vec2d_from_vec1d_unit_scalable_dim
 // CHECK-SAME: %[[A:.*0]]: vector<[1]xf32>
 // CHECK:      %[[U0:.*]] = ub.poison : vector<4x[1]xf32>
 // CHECK:      %[[T0:.*]] = vector.insert %[[A]], %[[U0]] [0] : vector<[1]xf32> into vector<4x[1]xf32>
@@ -126,7 +126,7 @@ func.func @broadcast_vec2d_from_vec2d_single_element(%arg0: vector<1x1xf32>) -> 
 // CHECK:      %[[T3:.*]] = vector.insert %[[A]], %[[T2]] [3] : vector<[1]xf32> into vector<4x[1]xf32>
 // CHECK:      return %[[T3]] : vector<4x[1]xf32>
 
-func.func @broadcast_single_elem_scalable_src(%arg0: vector<[1]xf32>) -> vector<4x[1]xf32> {
+func.func @broadcast_vec2d_from_vec1d_unit_scalable_dim(%arg0: vector<[1]xf32>) -> vector<4x[1]xf32> {
   %0 = vector.broadcast %arg0 : vector<[1]xf32> to vector<4x[1]xf32>
   return %0 : vector<4x[1]xf32>
 }

--- a/mlir/test/Dialect/Vector/vector-broadcast-lowering-transforms.mlir
+++ b/mlir/test/Dialect/Vector/vector-broadcast-lowering-transforms.mlir
@@ -95,24 +95,24 @@ func.func @broadcast_stretch(%arg0: vector<1xf32>) -> vector<4xf32> {
   return %0 : vector<4xf32>
 }
 
-// CHECK-LABEL: func @broadcast_single_elem_vec1d_to_vec2d
+// CHECK-LABEL: func @broadcast_vec2d_from_vec1d_single_element
 // CHECK-SAME: %[[A:.*0]]: vector<1xf32>
 // CHECK:      %[[T0:.*]] = vector.extract %[[A]][0] : f32 from vector<1xf32>
 // CHECK:      %[[T1:.*]] = vector.broadcast %[[T0]] : f32 to vector<16x1xf32>
 // CHECK:      return %[[T1]] : vector<16x1xf32>
 
-func.func @broadcast_single_elem_vec1d_to_vec2d(%arg0: vector<1xf32>) -> vector<16x1xf32> {
+func.func @broadcast_vec2d_from_vec1d_single_element(%arg0: vector<1xf32>) -> vector<16x1xf32> {
   %0 = vector.broadcast %arg0 : vector<1xf32> to vector<16x1xf32>
   return %0 : vector<16x1xf32>
 }
 
-// CHECK-LABEL: func @broadcast_single_elem_vec2d_to_vec2d
+// CHECK-LABEL: func @broadcast_vec2d_from_vec2d_single_element
 // CHECK-SAME: %[[A:.*0]]: vector<1x1xf32>
 // CHECK:      %[[T0:.*]] = vector.extract %[[A]][0, 0] : f32 from vector<1x1xf32>
 // CHECK:      %[[T1:.*]] = vector.broadcast %[[T0]] : f32 to vector<4x3xf32>
 // CHECK:      return %[[T1]] : vector<4x3xf32>
 
-func.func @broadcast_single_elem_vec2d_to_vec2d(%arg0: vector<1x1xf32>) -> vector<4x3xf32> {
+func.func @broadcast_vec2d_from_vec2d_single_element(%arg0: vector<1x1xf32>) -> vector<4x3xf32> {
   %0 = vector.broadcast %arg0 : vector<1x1xf32> to vector<4x3xf32>
   return %0 : vector<4x3xf32>
 }

--- a/mlir/test/Dialect/Vector/vector-broadcast-lowering-transforms.mlir
+++ b/mlir/test/Dialect/Vector/vector-broadcast-lowering-transforms.mlir
@@ -95,6 +95,42 @@ func.func @broadcast_stretch(%arg0: vector<1xf32>) -> vector<4xf32> {
   return %0 : vector<4xf32>
 }
 
+// CHECK-LABEL: func @broadcast_single_elem_vec1d_to_vec2d
+// CHECK-SAME: %[[A:.*0]]: vector<1xf32>
+// CHECK:      %[[T0:.*]] = vector.extract %[[A]][0] : f32 from vector<1xf32>
+// CHECK:      %[[T1:.*]] = vector.broadcast %[[T0]] : f32 to vector<16x1xf32>
+// CHECK:      return %[[T1]] : vector<16x1xf32>
+
+func.func @broadcast_single_elem_vec1d_to_vec2d(%arg0: vector<1xf32>) -> vector<16x1xf32> {
+  %0 = vector.broadcast %arg0 : vector<1xf32> to vector<16x1xf32>
+  return %0 : vector<16x1xf32>
+}
+
+// CHECK-LABEL: func @broadcast_single_elem_vec2d_to_vec2d
+// CHECK-SAME: %[[A:.*0]]: vector<1x1xf32>
+// CHECK:      %[[T0:.*]] = vector.extract %[[A]][0, 0] : f32 from vector<1x1xf32>
+// CHECK:      %[[T1:.*]] = vector.broadcast %[[T0]] : f32 to vector<4x3xf32>
+// CHECK:      return %[[T1]] : vector<4x3xf32>
+
+func.func @broadcast_single_elem_vec2d_to_vec2d(%arg0: vector<1x1xf32>) -> vector<4x3xf32> {
+  %0 = vector.broadcast %arg0 : vector<1x1xf32> to vector<4x3xf32>
+  return %0 : vector<4x3xf32>
+}
+
+// CHECK-LABEL: func @broadcast_single_elem_scalable_src
+// CHECK-SAME: %[[A:.*0]]: vector<[1]xf32>
+// CHECK:      %[[U0:.*]] = ub.poison : vector<4x[1]xf32>
+// CHECK:      %[[T0:.*]] = vector.insert %[[A]], %[[U0]] [0] : vector<[1]xf32> into vector<4x[1]xf32>
+// CHECK:      %[[T1:.*]] = vector.insert %[[A]], %[[T0]] [1] : vector<[1]xf32> into vector<4x[1]xf32>
+// CHECK:      %[[T2:.*]] = vector.insert %[[A]], %[[T1]] [2] : vector<[1]xf32> into vector<4x[1]xf32>
+// CHECK:      %[[T3:.*]] = vector.insert %[[A]], %[[T2]] [3] : vector<[1]xf32> into vector<4x[1]xf32>
+// CHECK:      return %[[T3]] : vector<4x[1]xf32>
+
+func.func @broadcast_single_elem_scalable_src(%arg0: vector<[1]xf32>) -> vector<4x[1]xf32> {
+  %0 = vector.broadcast %arg0 : vector<[1]xf32> to vector<4x[1]xf32>
+  return %0 : vector<4x[1]xf32>
+}
+
 // CHECK-LABEL: func @broadcast_stretch_at_start
 // CHECK-SAME: %[[A:.*0]]: vector<1x4xf32>
 // CHECK:      %[[U0:.*]] = ub.poison : vector<3x4xf32>


### PR DESCRIPTION
This PR generalizes the broadcast optimization from `Before: 0D/1D to 1D` to `After: single-element vector to nD vector`. 
Example:

```mlir
func.func @broadcast_vec2d_from_vec1d_single_element(%arg0: vector<1xf32>) -> vector<16x1xf32> {
  %0 = vector.broadcast %arg0 : vector<1xf32> to vector<16x1xf32>
  return %0 : vector<16x1xf32>
}
```

becomes

```mlir
  func.func @broadcast_vec2d_from_vec1d_single_element(%arg0: vector<1xf32>) -> vector<16x1xf32> {
    %0 = vector.extract %arg0[0] : f32 from vector<1xf32>
    %1 = vector.broadcast %0 : f32 to vector<16x1xf32>
    return %1 : vector<16x1xf32>
  }
```
which further transforms into a single shuffle, instead of:

```mlir
  func.func @broadcast_vec2d_from_vec1d_single_element(%arg0: vector<1xf32>) -> vector<16x1xf32> {
    %0 = ub.poison : vector<16x1xf32>
    %1 = vector.insert %arg0, %0 [0] : vector<1xf32> into vector<16x1xf32>
    %2 = vector.insert %arg0, %1 [1] : vector<1xf32> into vector<16x1xf32>
    %3 = vector.insert %arg0, %2 [2] : vector<1xf32> into vector<16x1xf32>
    %4 = vector.insert %arg0, %3 [3] : vector<1xf32> into vector<16x1xf32>
    %5 = vector.insert %arg0, %4 [4] : vector<1xf32> into vector<16x1xf32>
    %6 = vector.insert %arg0, %5 [5] : vector<1xf32> into vector<16x1xf32>
    %7 = vector.insert %arg0, %6 [6] : vector<1xf32> into vector<16x1xf32>
    %8 = vector.insert %arg0, %7 [7] : vector<1xf32> into vector<16x1xf32>
    %9 = vector.insert %arg0, %8 [8] : vector<1xf32> into vector<16x1xf32>
    %10 = vector.insert %arg0, %9 [9] : vector<1xf32> into vector<16x1xf32>
    %11 = vector.insert %arg0, %10 [10] : vector<1xf32> into vector<16x1xf32>
    %12 = vector.insert %arg0, %11 [11] : vector<1xf32> into vector<16x1xf32>
    %13 = vector.insert %arg0, %12 [12] : vector<1xf32> into vector<16x1xf32>
    %14 = vector.insert %arg0, %13 [13] : vector<1xf32> into vector<16x1xf32>
    %15 = vector.insert %arg0, %14 [14] : vector<1xf32> into vector<16x1xf32>
    %16 = vector.insert %arg0, %15 [15] : vector<1xf32> into vector<16x1xf32>
    return %16 : vector<16x1xf32>
  }
```
which transforms into 16 shuffles.

Application: MX block scale for `arith.scaling_extf` elementwise requirement.