### PR TITLE
[mlir][arith] Add ValueBoundsOpInterface external models for the arith operations DivUI and DivSI

### DIFF
--- a/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
@@ -56,9 +56,9 @@ void arith::ArithDialect::initialize() {
   declarePromisedInterfaces<bufferization::BufferizableOpInterface, ConstantOp,
                             IndexCastOp, SelectOp>();
   declarePromisedInterfaces<ValueBoundsOpInterface, ConstantOp, ExtSIOp, AddIOp,
-                            ConstantOp, SubIOp, MulIOp, SelectOp, FloorDivSIOp,
+                            SubIOp, MulIOp, SelectOp, FloorDivSIOp,
                             CeilDivSIOp, MinSIOp, MaxSIOp, MinUIOp, MaxUIOp,
-                            RemSIOp, RemUIOp>();
+                            RemSIOp, RemUIOp, DivUIOp, DivSIOp>();
 }
 
 /// Materialize an integer or floating point constant.

--- a/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
@@ -59,7 +59,7 @@ void arith::ArithDialect::initialize() {
                             SubIOp, MulIOp, SelectOp, FloorDivSIOp, CeilDivSIOp,
                             MinSIOp, MaxSIOp, MinUIOp, MaxUIOp, RemSIOp,
                             RemUIOp, DivUIOp, DivSIOp>();
-  }
+}
 
 /// Materialize an integer or floating point constant.
 Operation *arith::ArithDialect::materializeConstant(OpBuilder &builder,

--- a/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
@@ -55,11 +55,24 @@ void arith::ArithDialect::initialize() {
                            SelectOp>();
   declarePromisedInterfaces<bufferization::BufferizableOpInterface, ConstantOp,
                             IndexCastOp, SelectOp>();
-  declarePromisedInterfaces<ValueBoundsOpInterface, ConstantOp, ExtSIOp, AddIOp,
-                            SubIOp, MulIOp, SelectOp, FloorDivSIOp,
-                            CeilDivSIOp, MinSIOp, MaxSIOp, MinUIOp, MaxUIOp,
-                            RemSIOp, RemUIOp, DivUIOp, DivSIOp>();
-}
+  declarePromisedInterfaces<ValueBoundsOpInterface,
+                            ConstantOp,
+                            ExtSIOp,
+                            AddIOp,
+                            SubIOp,
+                            MulIOp,
+                            SelectOp,
+                            FloorDivSIOp,
+                            CeilDivSIOp,
+                            MinSIOp,
+                            MaxSIOp,
+                            MinUIOp,
+                            MaxUIOp,
+                            RemSIOp,
+                            RemUIOp,
+                            DivUIOp,
+                            DivSIOp>();
+  }
 
 /// Materialize an integer or floating point constant.
 Operation *arith::ArithDialect::materializeConstant(OpBuilder &builder,

--- a/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
@@ -55,11 +55,10 @@ void arith::ArithDialect::initialize() {
                            SelectOp>();
   declarePromisedInterfaces<bufferization::BufferizableOpInterface, ConstantOp,
                             IndexCastOp, SelectOp>();
-  declarePromisedInterfaces<ValueBoundsOpInterface, ConstantOp, ExtSIOp,
-                            AddIOp, SubIOp, MulIOp, SelectOp,
-                            FloorDivSIOp, CeilDivSIOp, MinSIOp,
-                            MaxSIOp, MinUIOp, MaxUIOp, RemSIOp, RemUIOp,
-                            DivUIOp, DivSIOp>();
+  declarePromisedInterfaces<ValueBoundsOpInterface, ConstantOp, ExtSIOp, AddIOp,
+                            SubIOp, MulIOp, SelectOp, FloorDivSIOp, CeilDivSIOp,
+                            MinSIOp, MaxSIOp, MinUIOp, MaxUIOp, RemSIOp,
+                            RemUIOp, DivUIOp, DivSIOp>();
   }
 
 /// Materialize an integer or floating point constant.

--- a/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithDialect.cpp
@@ -55,23 +55,11 @@ void arith::ArithDialect::initialize() {
                            SelectOp>();
   declarePromisedInterfaces<bufferization::BufferizableOpInterface, ConstantOp,
                             IndexCastOp, SelectOp>();
-  declarePromisedInterfaces<ValueBoundsOpInterface,
-                            ConstantOp,
-                            ExtSIOp,
-                            AddIOp,
-                            SubIOp,
-                            MulIOp,
-                            SelectOp,
-                            FloorDivSIOp,
-                            CeilDivSIOp,
-                            MinSIOp,
-                            MaxSIOp,
-                            MinUIOp,
-                            MaxUIOp,
-                            RemSIOp,
-                            RemUIOp,
-                            DivUIOp,
-                            DivSIOp>();
+  declarePromisedInterfaces<ValueBoundsOpInterface, ConstantOp, ExtSIOp,
+                            AddIOp, SubIOp, MulIOp, SelectOp,
+                            FloorDivSIOp, CeilDivSIOp, MinSIOp,
+                            MaxSIOp, MinUIOp, MaxUIOp, RemSIOp, RemUIOp,
+                            DivUIOp, DivSIOp>();
   }
 
 /// Materialize an integer or floating point constant.

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -62,6 +62,62 @@ struct AddIOpInterface
   }
 };
 
+struct DivUIOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<DivUIOpInterface,
+                                                   arith::DivUIOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto divOp = cast<arith::DivUIOp>(op);
+    assert(value == divOp.getResult() && "invalid value");
+
+    bool lhsNonNegative =
+        ValueBoundsConstraintSet::isProvablyNonNegative(divOp.getLhs(), cstr);
+    bool rhsPositive =
+        ValueBoundsConstraintSet::isProvablyPositive(divOp.getRhs(), cstr);
+    if (!lhsNonNegative || !rhsPositive)
+      return;
+
+    AffineExpr lhs = cstr.getExpr(divOp.getLhs());
+    AffineExpr rhs = cstr.getExpr(divOp.getRhs());
+    cstr.bound(value) >= 0;
+    cstr.bound(value) == lhs.floorDiv(rhs);
+  }
+};
+
+struct DivSIOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<DivSIOpInterface,
+                                                   arith::DivSIOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto divOp = cast<arith::DivSIOp>(op);
+    assert(value == divOp.getResult() && "invalid value");
+
+    Value lhsValue = divOp.getLhs();
+    Value rhsValue = divOp.getRhs();
+
+    bool lhsNonNegative =
+        ValueBoundsConstraintSet::isProvablyNonNegative(lhsValue, cstr);
+    bool lhsNonPositive =
+        ValueBoundsConstraintSet::isProvablyNonPositive(lhsValue, cstr);
+    bool rhsPositive =
+        ValueBoundsConstraintSet::isProvablyPositive(rhsValue, cstr);
+    bool rhsNegative =
+        ValueBoundsConstraintSet::isProvablyNegative(rhsValue, cstr);
+    if ((!lhsNonNegative && !lhsNonPositive) || (!rhsPositive && !rhsNegative))
+      return;
+
+    AffineExpr lhs = cstr.getExpr(lhsValue);
+    AffineExpr rhs = cstr.getExpr(rhsValue);
+    if ((lhsNonNegative && rhsPositive) || (lhsNonPositive && rhsNegative)) {
+      cstr.bound(value) == lhs.floorDiv(rhs);
+      cstr.bound(value) >= 0;
+    } else if ((lhsNonPositive && rhsPositive) || (lhsNonNegative && rhsNegative)) {
+      cstr.bound(value) == lhs.ceilDiv(rhs);
+      cstr.bound(value) <= 0;
+    }
+  }
+};
+
 struct SubIOpInterface
     : public ValueBoundsOpInterface::ExternalModel<SubIOpInterface, SubIOp> {
   void populateBoundsForIndexValue(Operation *op, Value value,
@@ -338,6 +394,8 @@ void mlir::arith::registerValueBoundsOpInterfaceExternalModels(
     arith::ConstantOp::attachInterface<arith::ConstantOpInterface>(*ctx);
     arith::ExtSIOp::attachInterface<arith::ExtSIOpInterface>(*ctx);
     arith::AddIOp::attachInterface<arith::AddIOpInterface>(*ctx);
+    arith::DivUIOp::attachInterface<arith::DivUIOpInterface>(*ctx);
+    arith::DivSIOp::attachInterface<arith::DivSIOpInterface>(*ctx);
     arith::SubIOp::attachInterface<arith::SubIOpInterface>(*ctx);
     arith::MulIOp::attachInterface<arith::MulIOpInterface>(*ctx);
     arith::FloorDivSIOp::attachInterface<arith::FloorDivSIOpInterface>(*ctx);

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -107,12 +107,14 @@ struct DivSIOpInterface
     AffineExpr lhs = cstr.getExpr(lhsValue);
     AffineExpr rhs = cstr.getExpr(rhsValue);
 
+    // divsi rounds toward zero, unlike floorDiv/ceilDiv which round toward
+    // negative/positive infinity respectively. When the result is non-negative,
+    // divsi equals floorDiv(lhs, rhs); when negative, it equals ceilDiv(lhs, rhs).
+    // Without knowing the sign, bound the result between those two expressions.
     cstr.bound(value) >= lhs.floorDiv(rhs);
     cstr.bound(value) <= lhs.ceilDiv(rhs);
 
-    if ((!lhsNonNegative && !lhsNonPositive) || (!rhsPositive && !rhsNegative))
-      return;
-
+    // If the sign of the result is known, we can use the exact expression.
     if ((lhsNonNegative && rhsPositive) || (lhsNonPositive && rhsNegative)) {
       cstr.bound(value) == lhs.floorDiv(rhs);
       cstr.bound(value) >= 0;

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -109,8 +109,9 @@ struct DivSIOpInterface
 
     // divsi rounds toward zero, unlike floorDiv/ceilDiv which round toward
     // negative/positive infinity respectively. When the result is non-negative,
-    // divsi equals floorDiv(lhs, rhs); when negative, it equals ceilDiv(lhs, rhs).
-    // Without knowing the sign, bound the result between those two expressions.
+    // divsi equals floorDiv(lhs, rhs); when negative, it equals ceilDiv(lhs,
+    // rhs). Without knowing the sign, bound the result between those two
+    // expressions.
     cstr.bound(value) >= lhs.floorDiv(rhs);
     cstr.bound(value) <= lhs.ceilDiv(rhs);
 

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -111,7 +111,7 @@ struct DivSIOpInterface
     // negative/positive infinity respectively. When the result is non-negative,
     // divsi equals floorDiv(lhs, rhs); when negative, it equals ceilDiv(lhs,
     // rhs). Without knowing the sign, bound the result between those two
-    // expressions.
+    // expressions, which is always correct.
     cstr.bound(value) >= lhs.floorDiv(rhs);
     cstr.bound(value) <= lhs.ceilDiv(rhs);
 

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -103,11 +103,16 @@ struct DivSIOpInterface
         ValueBoundsConstraintSet::isProvablyPositive(rhsValue, cstr);
     bool rhsNegative =
         ValueBoundsConstraintSet::isProvablyNegative(rhsValue, cstr);
-    if ((!lhsNonNegative && !lhsNonPositive) || (!rhsPositive && !rhsNegative))
-      return;
 
     AffineExpr lhs = cstr.getExpr(lhsValue);
     AffineExpr rhs = cstr.getExpr(rhsValue);
+
+    cstr.bound(value) >= lhs.floorDiv(rhs);
+    cstr.bound(value) <= lhs.ceilDiv(rhs);
+
+    if ((!lhsNonNegative && !lhsNonPositive) || (!rhsPositive && !rhsNegative))
+      return;
+
     if ((lhsNonNegative && rhsPositive) || (lhsNonPositive && rhsNegative)) {
       cstr.bound(value) == lhs.floorDiv(rhs);
       cstr.bound(value) >= 0;

--- a/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -111,7 +111,8 @@ struct DivSIOpInterface
     if ((lhsNonNegative && rhsPositive) || (lhsNonPositive && rhsNegative)) {
       cstr.bound(value) == lhs.floorDiv(rhs);
       cstr.bound(value) >= 0;
-    } else if ((lhsNonPositive && rhsPositive) || (lhsNonNegative && rhsNegative)) {
+    } else if ((lhsNonPositive && rhsPositive) ||
+               (lhsNonNegative && rhsNegative)) {
       cstr.bound(value) == lhs.ceilDiv(rhs);
       cstr.bound(value) <= 0;
     }

--- a/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
+++ b/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
@@ -195,6 +195,24 @@ func.func @arith_divsi_negative_lhs() -> index {
 
 // -----
 
+func.func @arith_divsi_unknown_lhs_constant_rhs(%a: index) {
+  %c5 = arith.constant 5 : index
+  %0 = arith.divsi %a, %c5 : index
+  // expected-remark @below{{true}}
+  "test.compare"(%0, %a) {
+      cmp = "GE",
+      rhs_map = affine_map<()[s0] -> (s0 floordiv 5)>
+  } : (index, index) -> ()
+  // expected-remark @below{{true}}
+  "test.compare"(%0, %a) {
+      cmp = "LE",
+      rhs_map = affine_map<()[s0] -> (s0 ceildiv 5)>
+  } : (index, index) -> ()
+  return
+}
+
+// -----
+
 // CHECK-LABEL: func @arith_remsi_positive_positive()
 //       CHECK:   %[[c0:.*]] = arith.constant 0 : index
 //       CHECK:   %[[c5:.*]] = arith.constant 5 : index

--- a/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
+++ b/mlir/test/Dialect/Arith/value-bounds-op-interface-impl.mlir
@@ -136,6 +136,65 @@ func.func @arith_ceildivsi_non_pure(%a: index, %b: index) -> index {
 
 // -----
 
+// CHECK-LABEL: func @arith_divui_constant()
+//       CHECK:   %[[c1:.*]] = arith.constant 1 : index
+//       CHECK:   return %[[c1]]
+func.func @arith_divui_constant() -> index {
+  %c7 = arith.constant 7 : index
+  %c5 = arith.constant 5 : index
+  %0 = arith.divui %c7, %c5 : index
+  %1 = "test.reify_bound"(%0) : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+
+// CHECK-LABEL: func @arith_divui_positive_lhs()
+//       CHECK:   %[[c1:.*]] = arith.constant 1 : index
+//       CHECK:   return %[[c1]]
+
+func.func @arith_divui_positive_lhs() -> index {
+  %c7 = arith.constant 7 : index
+  %c5 = arith.constant 5 : index
+  %c1 = arith.constant 1 : index
+  %lhs = arith.maxsi %c7, %c1 : index
+  %0 = arith.divui %lhs, %c5 : index
+  %1 = "test.reify_bound"(%0) {type = "LB", constant} : (index) -> (index)
+  return %1 : index
+}
+
+
+// -----
+
+// CHECK-LABEL: func @arith_divsi_negative_positive()
+//       CHECK:   %[[cm1:.*]] = arith.constant -1 : index
+//       CHECK:   return %[[cm1]]
+func.func @arith_divsi_negative_positive() -> index {
+  %cm7 = arith.constant -7 : index
+  %c5 = arith.constant 5 : index
+  %0 = arith.divsi %cm7, %c5 : index
+  %1 = "test.reify_bound"(%0) : (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
+// CHECK-LABEL: func @arith_divsi_negative_lhs()
+//       CHECK:   %[[cm2:.*]] = arith.constant -2 : index
+//       CHECK:   return %[[cm2]]
+func.func @arith_divsi_negative_lhs() -> index {
+  %c2 = arith.constant 2 : index
+  %cm7 = arith.constant -7 : index
+  %cm5 = arith.constant -5 : index
+  %lhs = arith.minsi %cm5, %cm7 : index
+  %0 = arith.divsi %lhs, %c2 : index
+  %1 = "test.reify_bound"(%0) {type = "UB", constant}: (index) -> (index)
+  return %1 : index
+}
+
+// -----
+
 // CHECK-LABEL: func @arith_remsi_positive_positive()
 //       CHECK:   %[[c0:.*]] = arith.constant 0 : index
 //       CHECK:   %[[c5:.*]] = arith.constant 5 : index


### PR DESCRIPTION
Add ValueBoundsOpInterface external models for the arith operations DivUI and DivSI.