### PR TITLE
Clang format numeric literal validity

### DIFF
--- a/clang/lib/Format/NumericLiteralCaseFixer.cpp
+++ b/clang/lib/Format/NumericLiteralCaseFixer.cpp
@@ -78,6 +78,10 @@ static bool matchesReservedSuffix(StringRef Suffix) {
 static std::string format(StringRef NumericLiteral, const FormatStyle &Style) {
   const char Separator = Style.isCpp() ? '\'' : '_';
   const NumericLiteralInfo Info(NumericLiteral, Separator);
+
+  if (!Info.IsValid)
+    return NumericLiteral.str();
+
   const bool HasBaseLetter = Info.BaseLetterPos != StringRef::npos;
   const bool HasExponent = Info.ExponentLetterPos != StringRef::npos;
   const bool HasSuffix = Info.SuffixPos != StringRef::npos;

--- a/clang/lib/Format/NumericLiteralInfo.cpp
+++ b/clang/lib/Format/NumericLiteralInfo.cpp
@@ -59,6 +59,20 @@ NumericLiteralInfo::NumericLiteralInfo(StringRef Text, char Separator) {
                C == Separator;
       },
       HasExponent ? ExponentLetterPos + 2 : Pos); // e.g. 1e-2f
+
+  const size_t DigitsStart =
+      BaseLetterPos == StringRef::npos ? 0 : BaseLetterPos + 1;
+  const size_t DigitsEnd = ExponentLetterPos != StringRef::npos
+                               ? ExponentLetterPos
+                           : SuffixPos != StringRef::npos ? SuffixPos
+                                                          : Text.size();
+  for (size_t I = DigitsStart; I < DigitsEnd; ++I) {
+    const char C = Text[I];
+    if (C != '.' && C != Separator && !(IsHex ? isHexDigit : isDigit)(C))
+      return; // non-digit,  invalid numeric literal
+  }
+
+  IsValid = true;
 }
 
 } // namespace format

--- a/clang/lib/Format/NumericLiteralInfo.h
+++ b/clang/lib/Format/NumericLiteralInfo.h
@@ -19,6 +19,7 @@ struct NumericLiteralInfo {
   size_t DotPos = llvm::StringRef::npos;            // pos of decimal/hex point
   size_t ExponentLetterPos = llvm::StringRef::npos; // as in 9e9 and 0xFp9
   size_t SuffixPos = llvm::StringRef::npos;         // starting pos of suffix
+  bool IsValid = false;                             // valid numeric literal
 
   NumericLiteralInfo(llvm::StringRef Text, char Separator = '\'');
 };

--- a/clang/unittests/Format/NumericLiteralCaseTest.cpp
+++ b/clang/unittests/Format/NumericLiteralCaseTest.cpp
@@ -340,6 +340,14 @@ TEST_F(NumericLiteralCaseTest, UnderScoreSeparatorLanguages) {
   verifyFormat("o = 0o0_10_010;", "o = 0O0_10_010;", Style);
 }
 
+TEST_F(NumericLiteralCaseTest, IgnoresInvalidNumericConstants) {
+  auto Style = getLLVMStyle();
+  Style.NumericLiteralCase.HexDigit = FormatStyle::NLCS_Upper;
+
+  verifyFormat("#include <path/to/16header.h>", Style);
+  verifyFormat("16header;", Style);
+}
+
 } // namespace
 } // namespace test
 } // namespace format


### PR DESCRIPTION
pp-numbers such as `16header` lex as `numeric_constant` but aren't valid numeric literals. NumericLiteralCaseFixer transformed them anyway, modifying non-literals in `#include` paths and macro arguments, e.g. `<path/to/16header.h>` became `<path/to/16HEADER.h>`.

NumericLiteralInfo now validates that the literal's digit portion contains only digits valid for its base, and format() skips tokens that fail.

Fixes https://github.com/llvm/llvm-project/issues/200731