### PR TITLE
[CI][flang][OpenMP] Build OpenMP runtime mod files for flang tests

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -75,6 +75,7 @@ DEPENDENTS_TO_TEST = {
 # but not necessarily run for testing. The only case of this currently is lldb
 # which needs some runtimes enabled for tests.
 DEPENDENT_RUNTIMES_TO_BUILD = {
+    "flang": {"openmp"},
     "lldb": {"libcxx", "libcxxabi", "libunwind", "compiler-rt"}
 }
 

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -219,9 +219,9 @@ class TestComputeProjects(unittest.TestCase):
         env_variables = compute_projects.get_env_variables(
             ["flang/CMakeLists.txt"], "Linux"
         )
-        self.assertEqual(env_variables["projects_to_build"], "clang;flang;llvm")
+        self.assertEqual(env_variables["projects_to_build"], "clang;flang;lld;llvm")
         self.assertEqual(env_variables["project_check_targets"], "check-flang")
-        self.assertEqual(env_variables["runtimes_to_build"], "flang-rt")
+        self.assertEqual(env_variables["runtimes_to_build"], "flang-rt;openmp")
         self.assertEqual(env_variables["runtimes_check_targets"], "check-flang-rt")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
         self.assertEqual(env_variables["enable_cir"], "OFF")

--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -38,11 +38,6 @@ if [[ " ${runtime_targets} " == *" check-libclc "* ]]; then
     -D LLVM_RUNTIME_TARGETS="default;amdgcn-amd-amdhsa-llvm"
   )
 fi
-if [[ ";${runtimes};" == *";openmp;"* && " ${runtime_targets} " != *" openmp "* ]]; then
-  runtime_cmake_args+=(
-    -D LIBOMP_FORTRAN_MODULES_ONLY=ON
-  )
-fi
 
 start-group "CMake"
 

--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -38,6 +38,11 @@ if [[ " ${runtime_targets} " == *" check-libclc "* ]]; then
     -D LLVM_RUNTIME_TARGETS="default;amdgcn-amd-amdhsa-llvm"
   )
 fi
+if [[ ";${runtimes};" == *";openmp;"* && " ${runtime_targets} " != *" openmp "* ]]; then
+  runtime_cmake_args+=(
+    -D LIBOMP_FORTRAN_MODULES_ONLY=ON
+  )
+fi
 
 start-group "CMake"
 


### PR DESCRIPTION
Some flang openmp lit tests require mod files (a bit like C header files, except they are compiler generated) from the openmp runtime. As the openmp runtime is not currently built in this configuration, these 71 flang tests get skipped and a warning is emitted.

Here I enable openmp as a dependency for flang but add -DLIBOMP_FORTRAN_MODULES_ONLY=ON so that only the required mod files are built and not the whole of the openmp runtime.

This only effects linux bots: Windows and MacOS explicitly exclude openmp so it will still not be enabled there.

Assited-by: Codex