### PR TITLE
[AMDGPU] Use `v_cvt_pk_*` instructions for i8_f32 saturated conversions

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -3921,6 +3921,7 @@ SDValue AMDGPUTargetLowering::LowerFP_TO_INT_SAT(const SDValue Op,
   EVT DstVT = Op.getValueType();
   SDValue SatVTOp = Op.getNode()->getOperand(1);
   EVT SatVT = cast<VTSDNode>(SatVTOp)->getVT();
+  const GCNSubtarget &ST = DAG.getSubtarget<GCNSubtarget>();
   SDLoc DL(Op);
 
   uint64_t DstWidth = DstVT.getScalarSizeInBits();
@@ -3935,6 +3936,14 @@ SDValue AMDGPUTargetLowering::LowerFP_TO_INT_SAT(const SDValue Op,
         (DstVT == MVT::v2i16 && SrcVT == MVT::v2f32))
       return Op;
   }
+
+  // Native selection also applies to some 8-bit width cases to allow use of
+  // packed instructions.
+  if (SatWidth == 8 &&
+      ((DstVT == MVT::i16 && SrcVT == MVT::f32) ||
+       (DstVT == MVT::v2i16 && SrcVT == MVT::v2f32)) &&
+      ST.hasVCvtPkIU16F32())
+    return Op;
 
   // Vectors can only be selected natively.
   if (DstVT.isVector())

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -3939,10 +3939,8 @@ SDValue AMDGPUTargetLowering::LowerFP_TO_INT_SAT(const SDValue Op,
 
   // Native selection also applies to some 8-bit width cases to allow use of
   // packed instructions.
-  if (SatWidth == 8 &&
-      ((DstVT == MVT::i16 && SrcVT == MVT::f32) ||
-       (DstVT == MVT::v2i16 && SrcVT == MVT::v2f32)) &&
-      ST.hasVCvtPkIU16F32())
+  if (SatWidth == 8 && DstVT.getScalarType() == MVT::i16 &&
+      SrcVT.getScalarType() == MVT::f32 && ST.hasVCvtPkIU16F32())
     return Op;
 
   // Vectors can only be selected natively.

--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -1245,8 +1245,17 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
   auto &FPToISat = getActionDefinitionsBuilder({G_FPTOSI_SAT, G_FPTOUI_SAT})
     .legalFor({{S32, S32}, {S32, S64}, {S16, S32}})
     .legalFor(ST.has16BitInsts(), {{S16, S16}})
-    .legalFor(ST.hasVCvtPkIU16F32(), {{V2S16, V2S32}})
-    .narrowScalarFor({{S64, S16}}, changeTo(0, S32));
+    .legalFor(ST.hasVCvtPkIU16F32(), {{V2S16, V2S32}});
+
+  // Widen vNf32 -> vNi8 into vNf32 -> vNi16, so we can select a packed
+  // instruction.
+  if (ST.hasVCvtPkIU16F32())
+    FPToISat.widenScalarIf(
+        all(isVector(0), elementTypeIs(0, S8),
+            isVector(1), elementTypeIs(1, S32)),
+        changeElementTo(0, S16));
+
+  FPToISat.narrowScalarFor({{S64, S16}}, changeTo(0, S32));
 
   // If available, widen width <16 to i16, intead of i32 so v_cvt_i16/u16_f16 can be used.
   if (ST.has16BitInsts())

--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -1249,11 +1249,12 @@ AMDGPULegalizerInfo::AMDGPULegalizerInfo(const GCNSubtarget &ST_,
 
   // Widen vNf32 -> vNi8 into vNf32 -> vNi16, so we can select a packed
   // instruction.
-  if (ST.hasVCvtPkIU16F32())
+  if (ST.hasVCvtPkIU16F32()) {
     FPToISat.widenScalarIf(
         all(isVector(0), elementTypeIs(0, S8),
             isVector(1), elementTypeIs(1, S32)),
         changeElementTo(0, S16));
+  }
 
   FPToISat.narrowScalarFor({{S64, S16}}, changeTo(0, S32));
 

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -684,11 +684,15 @@ SITargetLowering::SITargetLowering(const TargetMachine &TM,
     setOperationAction(ISD::BSWAP, MVT::v4i16, Custom);
 
     // Legalize vector types for sat conversions to select v_cvt_pk_[iu]16_f32.
-    if (Subtarget->hasVCvtPkIU16F32())
+    if (Subtarget->hasVCvtPkIU16F32()) {
       setOperationAction(
           {ISD::FP_TO_SINT_SAT, ISD::FP_TO_UINT_SAT},
           {MVT::v2i16, MVT::v4i16, MVT::v8i16, MVT::v16i16, MVT::v32i16},
           Custom);
+      setOperationAction(
+          {ISD::FP_TO_SINT_SAT, ISD::FP_TO_UINT_SAT},
+          {MVT::v2i8, MVT::v4i8, MVT::v8i8, MVT::v16i8, MVT::v32i8}, Custom);
+    }
 
     // XXX - Do these do anything? Vector constants turn into build_vector.
     setOperationAction(ISD::Constant, {MVT::v2i16, MVT::v2f16}, Legal);
@@ -8231,6 +8235,23 @@ void SITargetLowering::ReplaceNodeResults(SDNode *N,
   case ISD::EXTRACT_VECTOR_ELT: {
     if (SDValue Res = lowerEXTRACT_VECTOR_ELT(SDValue(N, 0), DAG))
       Results.push_back(Res);
+    return;
+  }
+  case ISD::FP_TO_SINT_SAT:
+  case ISD::FP_TO_UINT_SAT: {
+    // Re-write vNi8 vector into vNi16 vector with a truncate, so we can select
+    // a packed conversion.
+    EVT DstVT = N->getValueType(0);
+    EVT SrcVT = N->getOperand(0).getValueType();
+    if (!DstVT.isVector() || DstVT.getScalarSizeInBits() != 8 ||
+        SrcVT.getScalarType() != MVT::f32)
+      return;
+
+    SDLoc SL(N);
+    EVT NewDstVT = DstVT.changeVectorElementType(*DAG.getContext(), MVT::i16);
+    SDValue SatVTOp = DAG.getNode(N->getOpcode(), SL, NewDstVT,
+                                  N->getOperand(0), N->getOperand(1));
+    Results.push_back(DAG.getNode(ISD::TRUNCATE, SL, DstVT, SatVTOp));
     return;
   }
   case ISD::INTRINSIC_WO_CHAIN: {

--- a/llvm/lib/Target/AMDGPU/SOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SOPInstructions.td
@@ -723,6 +723,10 @@ let SubtargetPredicate = HasSALUFloatInsts, AddedComplexity = 9 in {
                        0xffff>;
   def : SOP_FPToSSatPat<(i16 (UniformBinFrag<fp_to_sint_sat> f32:$src0, i16)),
                        0x7fff, 0xffff8000>;
+  def : SOP_FPToUSatPat<(i16 (UniformBinFrag<fp_to_uint_sat> f32:$src0, i8)),
+                       0xff>;
+  def : SOP_FPToSSatPat<(i16 (UniformBinFrag<fp_to_sint_sat> f32:$src0, i8)),
+                       0x7f, 0xffffff80>;
 }
 
 let SubtargetPredicate = isGFX12Plus in {

--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -3278,10 +3278,33 @@ multiclass FPToUSatI16Pat<dag lhs, int hi> {
       (V_MIN_U32_e64 (V_CVT_U32_F32_e64 $src0_modifiers, $src0), (S_MOV_B32 (i32 hi)))>;
 }
 
+multiclass CvtPkF32ToS8Pat<RegisterClass rc> {
+  def : GCNPat<(v2i16 (fp_to_sint_sat (v2f32 rc:$src), i8)),
+    (V_PK_MAX_I16 SRCMODS.OP_SEL_1,
+      (V_PK_MIN_I16 SRCMODS.OP_SEL_1,
+        (V_CVT_PK_I16_F32_e64 0, (EXTRACT_SUBREG rc:$src, sub0),
+                              0, (EXTRACT_SUBREG rc:$src, sub1)),
+        SRCMODS.OP_SEL_1, (i32 0x007f007f), DSTCLAMP.NONE),
+      SRCMODS.OP_SEL_1, (i32 0xff80ff80), DSTCLAMP.NONE)>;
+}
+multiclass CvtPkF32ToU8Pat<RegisterClass rc> {
+  def : GCNPat<(v2i16 (fp_to_uint_sat (v2f32 rc:$src), i8)),
+    (V_PK_MIN_U16 SRCMODS.OP_SEL_1,
+      (V_CVT_PK_U16_F32_e64 0, (EXTRACT_SUBREG rc:$src, sub0),
+                            0, (EXTRACT_SUBREG rc:$src, sub1)),
+      SRCMODS.OP_SEL_1, (i32 0x00ff00ff), DSTCLAMP.NONE)>;
+}
+
 let SubtargetPredicate = isGFX11Plus in {
   // f32 -> i16 saturated conversion (vector and scalar types).
   defm : CvtPkF32ToI16Pat<fp_to_sint_sat, V_CVT_PK_I16_F32_e64>;
   defm : CvtPkF32ToI16Pat<fp_to_uint_sat, V_CVT_PK_U16_F32_e64>;
+
+  // Packed f32 -> i8 saturated conversion.
+  defm : CvtPkF32ToS8Pat<VReg_64>;
+  defm : CvtPkF32ToS8Pat<SReg_64>;
+  defm : CvtPkF32ToU8Pat<VReg_64>;
+  defm : CvtPkF32ToU8Pat<SReg_64>;
 }
 
 // Fallback for f32 -> i16 saturated conversion on pre-GFX11. Required because
@@ -3290,3 +3313,7 @@ let SubtargetPredicate = isGFX6GFX7GFX8GFX9GFX10 in {
   defm : FPToSSatI16Pat<(i16 (fp_to_sint_sat (f32 (VOP3Mods f32:$src0, i32:$src0_modifiers)), i16)), 0x7fff, 0x8000>;
   defm : FPToUSatI16Pat<(i16 (fp_to_uint_sat (f32 (VOP3Mods f32:$src0, i32:$src0_modifiers)), i16)), 0xffff>;
 }
+
+// Fallback for f32 -> i8.
+defm : FPToSSatI16Pat<(i16 (fp_to_sint_sat (f32 (VOP3Mods f32:$src0, i32:$src0_modifiers)), i8)), 0x7f, -128>;
+defm : FPToUSatI16Pat<(i16 (fp_to_uint_sat (f32 (VOP3Mods f32:$src0, i32:$src0_modifiers)), i8)), 0xff>;

--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -3268,31 +3268,14 @@ multiclass CvtPkF32ToI16Pat<SDPatternOperator dagOp, Instruction inst> {
                           (inst $src0_modifiers, $src0, 0, (f32 (IMPLICIT_DEF)))>;
 }
 
-multiclass FPToSSatI16Pat<dag lhs, int hi, int lo> {
+multiclass FPToSSatI16Pat<dag lhs, dag hiOp, dag loOp> {
   defm : FPToIntSatI16Pat<lhs,
       (V_MED3_I32_e64 (V_CVT_I32_F32_e64 $src0_modifiers, $src0),
-                      (V_MOV_B32_e32 (i32 lo)), (S_MOV_B32 (i32 hi)))>;
+                      hiOp, loOp)>;
 }
 multiclass FPToUSatI16Pat<dag lhs, int hi> {
   defm : FPToIntSatI16Pat<lhs,
       (V_MIN_U32_e64 (V_CVT_U32_F32_e64 $src0_modifiers, $src0), (S_MOV_B32 (i32 hi)))>;
-}
-
-multiclass CvtPkF32ToS8Pat<RegisterClass rc> {
-  def : GCNPat<(v2i16 (fp_to_sint_sat (v2f32 rc:$src), i8)),
-    (V_PK_MAX_I16 SRCMODS.OP_SEL_1,
-      (V_PK_MIN_I16 SRCMODS.OP_SEL_1,
-        (V_CVT_PK_I16_F32_e64 0, (EXTRACT_SUBREG rc:$src, sub0),
-                              0, (EXTRACT_SUBREG rc:$src, sub1)),
-        SRCMODS.OP_SEL_1, (i32 0x007f007f), DSTCLAMP.NONE),
-      SRCMODS.OP_SEL_1, (i32 0xff80ff80), DSTCLAMP.NONE)>;
-}
-multiclass CvtPkF32ToU8Pat<RegisterClass rc> {
-  def : GCNPat<(v2i16 (fp_to_uint_sat (v2f32 rc:$src), i8)),
-    (V_PK_MIN_U16 SRCMODS.OP_SEL_1,
-      (V_CVT_PK_U16_F32_e64 0, (EXTRACT_SUBREG rc:$src, sub0),
-                            0, (EXTRACT_SUBREG rc:$src, sub1)),
-      SRCMODS.OP_SEL_1, (i32 0x00ff00ff), DSTCLAMP.NONE)>;
 }
 
 let SubtargetPredicate = isGFX11Plus in {
@@ -3301,19 +3284,29 @@ let SubtargetPredicate = isGFX11Plus in {
   defm : CvtPkF32ToI16Pat<fp_to_uint_sat, V_CVT_PK_U16_F32_e64>;
 
   // Packed f32 -> i8 saturated conversion.
-  defm : CvtPkF32ToS8Pat<VReg_64>;
-  defm : CvtPkF32ToS8Pat<SReg_64>;
-  defm : CvtPkF32ToU8Pat<VReg_64>;
-  defm : CvtPkF32ToU8Pat<SReg_64>;
+  def : GCNPat<(v2i16 (fp_to_sint_sat v2f32:$src, i8)),
+    (V_PK_MAX_I16 SRCMODS.OP_SEL_1,
+      (V_PK_MIN_I16 SRCMODS.OP_SEL_1,
+        (V_CVT_PK_I16_F32_e64 0, (EXTRACT_SUBREG $src, sub0),
+                              0, (EXTRACT_SUBREG $src, sub1)),
+        SRCMODS.OP_SEL_1, (i32 0x007f007f), DSTCLAMP.NONE),
+      SRCMODS.OP_SEL_1, (i32 0xff80ff80), DSTCLAMP.NONE)>;
+  def : GCNPat<(v2i16 (fp_to_uint_sat v2f32:$src, i8)),
+    (V_PK_MIN_U16 SRCMODS.OP_SEL_1,
+      (V_CVT_PK_U16_F32_e64 0, (EXTRACT_SUBREG $src, sub0),
+                            0, (EXTRACT_SUBREG $src, sub1)),
+      SRCMODS.OP_SEL_1, (i32 0x00ff00ff), DSTCLAMP.NONE)>;
 }
 
 // Fallback for f32 -> i16 saturated conversion on pre-GFX11. Required because
 // f32 -> i16 has to be legal so that the packed pattern above can match.
 let SubtargetPredicate = isGFX6GFX7GFX8GFX9GFX10 in {
-  defm : FPToSSatI16Pat<(i16 (fp_to_sint_sat (f32 (VOP3Mods f32:$src0, i32:$src0_modifiers)), i16)), 0x7fff, 0x8000>;
+  defm : FPToSSatI16Pat<(i16 (fp_to_sint_sat (f32 (VOP3Mods f32:$src0, i32:$src0_modifiers)), i16)),
+                        (V_MOV_B32_e32 (i32 0x7fff)), (S_MOV_B32 (i32 0x8000))>;
   defm : FPToUSatI16Pat<(i16 (fp_to_uint_sat (f32 (VOP3Mods f32:$src0, i32:$src0_modifiers)), i16)), 0xffff>;
 }
 
 // Fallback for f32 -> i8.
-defm : FPToSSatI16Pat<(i16 (fp_to_sint_sat (f32 (VOP3Mods f32:$src0, i32:$src0_modifiers)), i8)), 0x7f, -128>;
+defm : FPToSSatI16Pat<(i16 (fp_to_sint_sat (f32 (VOP3Mods f32:$src0, i32:$src0_modifiers)), i8)),
+                      (S_MOV_B32 (i32 0x7f)), (i32 -128)>;
 defm : FPToUSatI16Pat<(i16 (fp_to_uint_sat (f32 (VOP3Mods f32:$src0, i32:$src0_modifiers)), i8)), 0xff>;

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
@@ -86,34 +86,21 @@ define i8 @test_signed_i8_f32(float %f) nounwind {
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX11-NEXT:    s_movk_i32 s0, 0xff80
-; GFX11-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0xffffff80
+; GFX11-NEXT:    v_med3_i32 v0, v0, v1, 0x7f
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX12-ISEL-LABEL: test_signed_i8_f32:
-; GFX12-ISEL:       ; %bb.0:
-; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
-; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
-; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
-; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-ISEL-NEXT:    s_movk_i32 s0, 0xff80
-; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
-; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX12-GI-LABEL: test_signed_i8_f32:
-; GFX12-GI:       ; %bb.0:
-; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX12-GI-NEXT:    s_wait_expcnt 0x0
-; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
-; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
-; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0xffffff80
-; GFX12-GI-NEXT:    v_med3_i32 v0, v0, v1, 0x7f
-; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+; GFX12-LABEL: test_signed_i8_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX12-NEXT:    v_mov_b32_e32 v1, 0xffffff80
+; GFX12-NEXT:    v_med3_i32 v0, v0, v1, 0x7f
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
     %x = call i8 @llvm.fptosi.sat.i8.f32(float %f)
     ret i8 %x
 }
@@ -491,38 +478,25 @@ define i8 @test_s_signed_i8_f32(float inreg %f) nounwind {
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
-; GFX11-NEXT:    s_movk_i32 s0, 0xff80
-; GFX11-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
+; GFX11-NEXT:    v_mov_b32_e32 v1, 0xffffff80
+; GFX11-NEXT:    v_med3_i32 v0, v0, v1, 0x7f
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX12-ISEL-LABEL: test_s_signed_i8_f32:
-; GFX12-ISEL:       ; %bb.0:
-; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
-; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
-; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
-; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-ISEL-NEXT:    v_mov_b32_e32 v0, 0x7f
-; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s0, s0
-; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_med3_i32 v0, 0xffffff80, s0, v0
-; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
-;
-; GFX12-GI-LABEL: test_s_signed_i8_f32:
-; GFX12-GI:       ; %bb.0:
-; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX12-GI-NEXT:    s_wait_expcnt 0x0
-; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
-; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
-; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
-; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
+; GFX12-LABEL: test_s_signed_i8_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-NEXT:    s_wait_expcnt 0x0
+; GFX12-NEXT:    s_wait_samplecnt 0x0
+; GFX12-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_cvt_i32_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_min_i32 s0, s0, 0x7f
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_max_i32 s0, s0, 0xffffff80
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    s_setpc_b64 s[30:31]
     %x = call i8 @llvm.fptosi.sat.i8.f32(float %f)
     ret i8 %x
 }

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-scalar.ll
@@ -86,21 +86,34 @@ define i8 @test_signed_i8_f32(float %f) nounwind {
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX11-NEXT:    v_mov_b32_e32 v1, 0xffffff80
-; GFX11-NEXT:    v_med3_i32 v0, v0, v1, 0x7f
+; GFX11-NEXT:    s_movk_i32 s0, 0x7f
+; GFX11-NEXT:    v_med3_i32 v0, v0, s0, 0xffffff80
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
-; GFX12-LABEL: test_signed_i8_f32:
-; GFX12:       ; %bb.0:
-; GFX12-NEXT:    s_wait_loadcnt_dscnt 0x0
-; GFX12-NEXT:    s_wait_expcnt 0x0
-; GFX12-NEXT:    s_wait_samplecnt 0x0
-; GFX12-NEXT:    s_wait_bvhcnt 0x0
-; GFX12-NEXT:    s_wait_kmcnt 0x0
-; GFX12-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-NEXT:    v_mov_b32_e32 v1, 0xffffff80
-; GFX12-NEXT:    v_med3_i32 v0, v0, v1, 0x7f
-; GFX12-NEXT:    s_setpc_b64 s[30:31]
+; GFX12-ISEL-LABEL: test_signed_i8_f32:
+; GFX12-ISEL:       ; %bb.0:
+; GFX12-ISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-ISEL-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX12-ISEL-NEXT:    s_movk_i32 s0, 0x7f
+; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-ISEL-NEXT:    v_med3_i32 v0, v0, s0, 0xffffff80
+; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12-GI-LABEL: test_signed_i8_f32:
+; GFX12-GI:       ; %bb.0:
+; GFX12-GI-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12-GI-NEXT:    s_wait_expcnt 0x0
+; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
+; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
+; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
+; GFX12-GI-NEXT:    v_mov_b32_e32 v1, 0xffffff80
+; GFX12-GI-NEXT:    v_med3_i32 v0, v0, v1, 0x7f
+; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call i8 @llvm.fptosi.sat.i8.f32(float %f)
     ret i8 %x
 }
@@ -119,8 +132,8 @@ define i16 @test_signed_i16_f32(float %f) nounwind {
 ; GFX7-GI:       ; %bb.0:
 ; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX7-GI-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x8000
+; GFX7-GI-NEXT:    s_mov_b32 s4, 0x8000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7fff
 ; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v1, s4
 ; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -128,8 +141,8 @@ define i16 @test_signed_i16_f32(float %f) nounwind {
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX9-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX9-NEXT:    v_mov_b32_e32 v1, 0x8000
+; GFX9-NEXT:    s_mov_b32 s4, 0x8000
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7fff
 ; GFX9-NEXT:    v_med3_i32 v0, v0, v1, s4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -478,8 +491,8 @@ define i8 @test_s_signed_i8_f32(float inreg %f) nounwind {
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s0
-; GFX11-NEXT:    v_mov_b32_e32 v1, 0xffffff80
-; GFX11-NEXT:    v_med3_i32 v0, v0, v1, 0x7f
+; GFX11-NEXT:    s_movk_i32 s0, 0x7f
+; GFX11-NEXT:    v_med3_i32 v0, v0, s0, 0xffffff80
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: test_s_signed_i8_f32:
@@ -515,8 +528,8 @@ define i16 @test_s_signed_i16_f32(float inreg %f) nounwind {
 ; GFX7-GI:       ; %bb.0:
 ; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, s16
-; GFX7-GI-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x8000
+; GFX7-GI-NEXT:    s_mov_b32 s4, 0x8000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7fff
 ; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v1, s4
 ; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -524,8 +537,8 @@ define i16 @test_s_signed_i16_f32(float inreg %f) nounwind {
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, s16
-; GFX9-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX9-NEXT:    v_mov_b32_e32 v1, 0x8000
+; GFX9-NEXT:    s_mov_b32 s4, 0x8000
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7fff
 ; GFX9-NEXT:    v_med3_i32 v0, v0, v1, s4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1796,8 +1809,8 @@ define i16 @test_signed_i16_f16(half %f) nounwind {
 ; GFX7-GI:       ; %bb.0:
 ; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX7-GI-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x8000
+; GFX7-GI-NEXT:    s_mov_b32 s4, 0x8000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7fff
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
 ; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v1, s4
 ; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]
@@ -2205,8 +2218,8 @@ define i16 @test_s_signed_i16_f16(half inreg %f) nounwind {
 ; GFX7-GI:       ; %bb.0:
 ; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
-; GFX7-GI-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x8000
+; GFX7-GI-NEXT:    s_mov_b32 s4, 0x8000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7fff
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
 ; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v1, s4
 ; GFX7-GI-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
@@ -2882,8 +2882,8 @@ define <4 x i16> @test_signed_v4f16_v4i16(<4 x half> %f) {
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX7-GI-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX7-GI-NEXT:    v_mov_b32_e32 v4, 0x8000
+; GFX7-GI-NEXT:    s_mov_b32 s4, 0x8000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v4, 0x7fff
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v1, v1
 ; GFX7-GI-NEXT:    v_med3_i32 v2, v2, v4, s4
 ; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v4, s4
@@ -3784,8 +3784,8 @@ define <4 x i16> @test_s_signed_v4f16_v4i16(<4 x half> inreg %f) {
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
 ; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s17
 ; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v4, s5
-; GFX7-GI-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x8000
+; GFX7-GI-NEXT:    s_mov_b32 s4, 0x8000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7fff
 ; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v1, s4
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
 ; GFX7-GI-NEXT:    v_readfirstlane_b32 s5, v0
@@ -4708,8 +4708,8 @@ define <8 x i16> @test_signed_v8f16_v8i16(<8 x half> %f) {
 ; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v2, v2
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v5, v5
 ; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; GFX7-GI-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX7-GI-NEXT:    v_mov_b32_e32 v8, 0x8000
+; GFX7-GI-NEXT:    s_mov_b32 s4, 0x8000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v8, 0x7fff
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v1, v1
 ; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, v3
 ; GFX7-GI-NEXT:    v_med3_i32 v4, v4, v8, s4
@@ -6247,10 +6247,10 @@ define <8 x i16> @test_s_signed_v8f16_v8i16(<8 x half> inreg %f) {
 ; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v0, s16
 ; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v1, s4
 ; GFX7-GI-NEXT:    v_cvt_f32_f16_e32 v3, s17
-; GFX7-GI-NEXT:    s_movk_i32 s4, 0x7fff
+; GFX7-GI-NEXT:    s_mov_b32 s4, 0x8000
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0x8000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v2, 0x7fff
 ; GFX7-GI-NEXT:    s_lshr_b32 s5, s17, 16
 ; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v2, s4
 ; GFX7-GI-NEXT:    v_readfirstlane_b32 s8, v0
@@ -6716,8 +6716,8 @@ define <4 x i16> @test_signed_v4f32_v4i16(<4 x float> %f) {
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX7-GI-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX7-GI-NEXT:    v_mov_b32_e32 v4, 0x8000
+; GFX7-GI-NEXT:    s_mov_b32 s4, 0x8000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v4, 0x7fff
 ; GFX7-GI-NEXT:    v_med3_i32 v1, v1, v4, s4
 ; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v4, s4
 ; GFX7-GI-NEXT:    v_and_b32_e32 v1, 0xffff, v1
@@ -6739,8 +6739,8 @@ define <4 x i16> @test_signed_v4f32_v4i16(<4 x float> %f) {
 ; GFX9-NEXT:    v_cvt_i32_f32_e32 v3, v3
 ; GFX9-NEXT:    v_cvt_i32_f32_e32 v0, v0
 ; GFX9-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX9-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX9-NEXT:    v_mov_b32_e32 v4, 0x8000
+; GFX9-NEXT:    s_mov_b32 s4, 0x8000
+; GFX9-NEXT:    v_mov_b32_e32 v4, 0x7fff
 ; GFX9-NEXT:    v_med3_i32 v2, v2, v4, s4
 ; GFX9-NEXT:    v_med3_i32 v3, v3, v4, s4
 ; GFX9-NEXT:    v_med3_i32 v0, v0, v4, s4
@@ -6797,8 +6797,8 @@ define <4 x i16> @test_s_signed_v4f32_v4i16(<4 x float> inreg %f) {
 ; GFX7-GI:       ; %bb.0:
 ; GFX7-GI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v0, s16
-; GFX7-GI-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x8000
+; GFX7-GI-NEXT:    s_mov_b32 s4, 0x8000
+; GFX7-GI-NEXT:    v_mov_b32_e32 v1, 0x7fff
 ; GFX7-GI-NEXT:    v_cvt_i32_f32_e32 v2, s17
 ; GFX7-GI-NEXT:    v_med3_i32 v0, v0, v1, s4
 ; GFX7-GI-NEXT:    v_readfirstlane_b32 s5, v0
@@ -6829,8 +6829,8 @@ define <4 x i16> @test_s_signed_v4f32_v4i16(<4 x float> inreg %f) {
 ; GFX9-NEXT:    v_cvt_i32_f32_e32 v2, s18
 ; GFX9-NEXT:    v_cvt_i32_f32_e32 v3, s17
 ; GFX9-NEXT:    v_cvt_i32_f32_e32 v4, s16
-; GFX9-NEXT:    s_movk_i32 s4, 0x7fff
-; GFX9-NEXT:    v_mov_b32_e32 v1, 0x8000
+; GFX9-NEXT:    s_mov_b32 s4, 0x8000
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7fff
 ; GFX9-NEXT:    v_med3_i32 v5, v0, v1, s4
 ; GFX9-NEXT:    v_med3_i32 v2, v2, v1, s4
 ; GFX9-NEXT:    v_med3_i32 v0, v3, v1, s4

--- a/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptosi-sat-vector.ll
@@ -6935,50 +6935,46 @@ define <4 x i8> @test_signed_v4f32_v4i8(<4 x float> %f) {
 ; GFX11-FAKE16-LABEL: test_signed_v4f32_v4i8:
 ; GFX11-FAKE16:       ; %bb.0:
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX11-FAKE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX11-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
-; GFX11-FAKE16-NEXT:    v_med3_i32 v2, v2, s0, 0x7f
-; GFX11-FAKE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7f
-; GFX11-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
-; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v3
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v2, 0xff, v2
-; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v1
+; GFX11-FAKE16-NEXT:    v_cvt_pk_i16_f32 v2, v2, v3
+; GFX11-FAKE16-NEXT:    v_cvt_pk_i16_f32 v0, v0, v1
+; GFX11-FAKE16-NEXT:    v_pk_min_i16 v1, 0x7f007f, v2
+; GFX11-FAKE16-NEXT:    v_pk_min_i16 v0, 0x7f007f, v0
+; GFX11-FAKE16-NEXT:    v_pk_max_i16 v1, 0xff80ff80, v1
+; GFX11-FAKE16-NEXT:    v_pk_max_i16 v0, 0xff80ff80, v0
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xff, v1
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
-; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v2, v3
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v1
-; GFX11-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v2, 8, v2
+; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v3
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v2
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v3
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v3
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v3, v2, 16, v3
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v3
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v1, v2, 16, v1
 ; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v4
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: test_signed_v4f32_v4i8:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX11-TRUE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX11-TRUE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX11-TRUE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_med3_i32 v4, v2, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v3.l
-; GFX11-TRUE16-NEXT:    v_and_b16 v2.h, 0xff, v4.l
+; GFX11-TRUE16-NEXT:    v_cvt_pk_i16_f32 v2, v2, v3
+; GFX11-TRUE16-NEXT:    v_cvt_pk_i16_f32 v1, v0, v1
+; GFX11-TRUE16-NEXT:    v_pk_min_i16 v2, 0x7f007f, v2
+; GFX11-TRUE16-NEXT:    v_pk_min_i16 v1, 0x7f007f, v1
+; GFX11-TRUE16-NEXT:    v_pk_max_i16 v2, 0xff80ff80, v2
+; GFX11-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v2.l
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v0.h, 8, v2.h
+; GFX11-TRUE16-NEXT:    v_or_b16 v2.h, v0.l, v0.h
+; GFX11-TRUE16-NEXT:    v_pk_max_i16 v0, 0xff80ff80, v1
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v2.h
 ; GFX11-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v0.l
-; GFX11-TRUE16-NEXT:    v_or_b16 v2.h, v2.h, v2.l
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v1.l
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v2.h
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v0.h
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v1
 ; GFX11-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v2.l
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v2
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v2.h
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -6989,27 +6985,25 @@ define <4 x i8> @test_signed_v4f32_v4i8(<4 x float> %f) {
 ; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX12-FAKE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX12-FAKE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-FAKE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
-; GFX12-FAKE16-NEXT:    v_med3_i32 v2, v2, s0, 0x7f
-; GFX12-FAKE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7f
-; GFX12-FAKE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
-; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v3
-; GFX12-FAKE16-NEXT:    v_and_b32_e32 v2, 0xff, v2
-; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v1
+; GFX12-FAKE16-NEXT:    v_cvt_pk_i16_f32 v2, v2, v3
+; GFX12-FAKE16-NEXT:    v_cvt_pk_i16_f32 v0, v0, v1
+; GFX12-FAKE16-NEXT:    v_pk_min_i16 v1, 0x7f007f, v2
+; GFX12-FAKE16-NEXT:    v_pk_min_i16 v0, 0x7f007f, v0
+; GFX12-FAKE16-NEXT:    v_pk_max_i16 v1, 0xff80ff80, v1
+; GFX12-FAKE16-NEXT:    v_pk_max_i16 v0, 0xff80ff80, v0
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xff, v1
 ; GFX12-FAKE16-NEXT:    v_and_b32_e32 v0, 0xff, v0
-; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v2, v3
-; GFX12-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v1
-; GFX12-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v2, 8, v2
+; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v3
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v2
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v3
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v3
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
-; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v3, v2, 16, v3
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v3
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v1, v2, 16, v1
 ; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v4
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-TRUE16-LABEL: test_signed_v4f32_v4i8:
@@ -7019,26 +7013,22 @@ define <4 x i8> @test_signed_v4f32_v4i8(<4 x float> %f) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-TRUE16-NEXT:    s_movk_i32 s0, 0xff80
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX12-TRUE16-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-TRUE16-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-TRUE16-NEXT:    v_med3_i32 v3, v3, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_med3_i32 v4, v2, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_med3_i32 v1, v1, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_med3_i32 v0, v0, s0, 0x7f
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v3.l
-; GFX12-TRUE16-NEXT:    v_and_b16 v2.h, 0xff, v4.l
+; GFX12-TRUE16-NEXT:    v_cvt_pk_i16_f32 v2, v2, v3
+; GFX12-TRUE16-NEXT:    v_cvt_pk_i16_f32 v1, v0, v1
+; GFX12-TRUE16-NEXT:    v_pk_min_i16 v2, 0x7f007f, v2
+; GFX12-TRUE16-NEXT:    v_pk_min_i16 v1, 0x7f007f, v1
+; GFX12-TRUE16-NEXT:    v_pk_max_i16 v2, 0xff80ff80, v2
+; GFX12-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v2.l
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v0.h, 8, v2.h
+; GFX12-TRUE16-NEXT:    v_or_b16 v2.h, v0.l, v0.h
+; GFX12-TRUE16-NEXT:    v_pk_max_i16 v0, 0xff80ff80, v1
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v2.h
 ; GFX12-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v0.l
-; GFX12-TRUE16-NEXT:    v_or_b16 v2.h, v2.h, v2.l
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v1.l
-; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v2.h
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v0.h
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v1
 ; GFX12-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v2.l
 ; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v2
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v2.h
-; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
 ; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -7049,15 +7039,14 @@ define <4 x i8> @test_signed_v4f32_v4i8(<4 x float> %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_mov_b32_e32 v4, 0xffffff80
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v0, v0
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v1, v1
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GFX12-GI-NEXT:    v_cvt_i32_f32_e32 v3, v3
-; GFX12-GI-NEXT:    v_med3_i32 v0, v0, v4, 0x7f
-; GFX12-GI-NEXT:    v_med3_i32 v1, v1, v4, 0x7f
-; GFX12-GI-NEXT:    v_med3_i32 v2, v2, v4, 0x7f
-; GFX12-GI-NEXT:    v_med3_i32 v3, v3, v4, 0x7f
+; GFX12-GI-NEXT:    v_cvt_pk_i16_f32 v0, v0, v1
+; GFX12-GI-NEXT:    v_cvt_pk_i16_f32 v1, v2, v3
+; GFX12-GI-NEXT:    v_pk_min_i16 v0, 0x7f007f, v0
+; GFX12-GI-NEXT:    v_pk_min_i16 v1, 0x7f007f, v1
+; GFX12-GI-NEXT:    v_pk_max_i16 v0, 0xff80ff80, v0
+; GFX12-GI-NEXT:    v_pk_max_i16 v2, 0xff80ff80, v1
+; GFX12-GI-NEXT:    v_mov_b16_e32 v1.l, v0.h
+; GFX12-GI-NEXT:    v_mov_b16_e32 v3.l, v2.h
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptosi.sat.v4f32.v4i8(<4 x float> %f)
     ret <4 x i8> %x
@@ -7143,26 +7132,25 @@ define <4 x i8> @test_s_signed_v4f32_v4i8(<4 x float> inreg %f) {
 ; GFX11-LABEL: test_s_signed_v4f32_v4i8:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_cvt_i32_f32_e32 v0, s3
-; GFX11-NEXT:    v_cvt_i32_f32_e32 v1, s2
-; GFX11-NEXT:    s_movk_i32 s2, 0xff80
-; GFX11-NEXT:    v_cvt_i32_f32_e32 v2, s1
-; GFX11-NEXT:    v_cvt_i32_f32_e32 v3, s0
-; GFX11-NEXT:    v_med3_i32 v0, v0, s2, 0x7f
-; GFX11-NEXT:    v_med3_i32 v1, v1, s2, 0x7f
-; GFX11-NEXT:    v_med3_i32 v2, v2, s2, 0x7f
-; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
-; GFX11-NEXT:    v_and_b32_e32 v1, 0xff, v1
-; GFX11-NEXT:    v_lshlrev_b32_e32 v4, 8, v2
-; GFX11-NEXT:    v_or_b32_e32 v2, v1, v0
-; GFX11-NEXT:    v_med3_i32 v0, v3, s2, 0x7f
-; GFX11-NEXT:    v_and_b32_e32 v1, 0xff00, v4
-; GFX11-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX11-NEXT:    v_cvt_pk_i16_f32 v0, s2, s3
+; GFX11-NEXT:    v_cvt_pk_i16_f32 v1, s0, s1
+; GFX11-NEXT:    v_pk_min_i16 v0, 0x7f007f, v0
+; GFX11-NEXT:    v_pk_min_i16 v1, 0x7f007f, v1
+; GFX11-NEXT:    v_pk_max_i16 v0, 0xff80ff80, v0
+; GFX11-NEXT:    v_pk_max_i16 v1, 0xff80ff80, v1
+; GFX11-NEXT:    v_lshrrev_b32_e32 v2, 8, v0
 ; GFX11-NEXT:    v_and_b32_e32 v0, 0xff, v0
-; GFX11-NEXT:    v_or_b32_e32 v1, v1, v3
-; GFX11-NEXT:    v_or_b32_e32 v0, v0, v4
-; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
-; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 8, v1
+; GFX11-NEXT:    v_and_b32_e32 v1, 0xff, v1
+; GFX11-NEXT:    v_and_b32_e32 v2, 0xffff00, v2
+; GFX11-NEXT:    v_or_b32_e32 v2, v0, v2
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xff00, v3
+; GFX11-NEXT:    v_and_b32_e32 v3, 0xffff00, v3
+; GFX11-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
+; GFX11-NEXT:    v_or_b32_e32 v4, v0, v4
+; GFX11-NEXT:    v_or_b32_e32 v0, v1, v3
+; GFX11-NEXT:    v_bfe_u32 v3, v2, 8, 8
+; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_s_signed_v4f32_v4i8:
@@ -7172,27 +7160,25 @@ define <4 x i8> @test_s_signed_v4f32_v4i8(<4 x float> inreg %f) {
 ; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-ISEL-NEXT:    v_mov_b32_e32 v0, 0x7f
-; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s3, s3
-; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s2, s2
-; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s1, s1
-; GFX12-ISEL-NEXT:    s_cvt_i32_f32 s0, s0
-; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_med3_i32 v1, 0xffffff80, s3, v0
-; GFX12-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
-; GFX12-ISEL-NEXT:    v_med3_i32 v2, 0xffffff80, s2, v0
-; GFX12-ISEL-NEXT:    v_med3_i32 v3, 0xffffff80, s1, v0
-; GFX12-ISEL-NEXT:    v_med3_i32 v0, 0xffffff80, s0, v0
-; GFX12-ISEL-NEXT:    v_and_b32_e32 v2, 0xff, v2
-; GFX12-ISEL-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
+; GFX12-ISEL-NEXT:    v_cvt_pk_i16_f32 v0, s2, s3
+; GFX12-ISEL-NEXT:    v_cvt_pk_i16_f32 v1, s0, s1
+; GFX12-ISEL-NEXT:    v_pk_min_i16 v0, 0x7f007f, v0
+; GFX12-ISEL-NEXT:    v_pk_min_i16 v1, 0x7f007f, v1
+; GFX12-ISEL-NEXT:    v_pk_max_i16 v0, 0xff80ff80, v0
+; GFX12-ISEL-NEXT:    v_pk_max_i16 v1, 0xff80ff80, v1
+; GFX12-ISEL-NEXT:    v_lshrrev_b32_e32 v2, 8, v0
 ; GFX12-ISEL-NEXT:    v_and_b32_e32 v0, 0xff, v0
-; GFX12-ISEL-NEXT:    v_or_b32_e32 v2, v2, v1
-; GFX12-ISEL-NEXT:    v_and_b32_e32 v1, 0xff00, v3
-; GFX12-ISEL-NEXT:    v_or_b32_e32 v0, v0, v3
+; GFX12-ISEL-NEXT:    v_lshrrev_b32_e32 v3, 8, v1
+; GFX12-ISEL-NEXT:    v_and_b32_e32 v1, 0xff, v1
+; GFX12-ISEL-NEXT:    v_and_b32_e32 v2, 0xffff00, v2
+; GFX12-ISEL-NEXT:    v_or_b32_e32 v2, v0, v2
+; GFX12-ISEL-NEXT:    v_and_b32_e32 v0, 0xff00, v3
+; GFX12-ISEL-NEXT:    v_and_b32_e32 v3, 0xffff00, v3
 ; GFX12-ISEL-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
-; GFX12-ISEL-NEXT:    v_or_b32_e32 v1, v1, v4
-; GFX12-ISEL-NEXT:    v_lshrrev_b32_e32 v3, 24, v4
-; GFX12-ISEL-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
+; GFX12-ISEL-NEXT:    v_or_b32_e32 v4, v0, v4
+; GFX12-ISEL-NEXT:    v_or_b32_e32 v0, v1, v3
+; GFX12-ISEL-NEXT:    v_bfe_u32 v3, v2, 8, 8
+; GFX12-ISEL-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_s_signed_v4f32_v4i8:
@@ -7202,23 +7188,43 @@ define <4 x i8> @test_s_signed_v4f32_v4i8(<4 x float> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s0, s0
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s1, s1
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_i32_f32 s3, s3
+; GFX12-GI-NEXT:    v_cvt_pk_i16_f32 v0, s0, s1
+; GFX12-GI-NEXT:    v_cvt_pk_i16_f32 v1, s2, s3
+; GFX12-GI-NEXT:    s_sext_i32_i16 s2, 0x7f007f
+; GFX12-GI-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX12-GI-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX12-GI-NEXT:    s_sext_i32_i16 s3, s0
+; GFX12-GI-NEXT:    s_ashr_i32 s0, s0, 16
+; GFX12-GI-NEXT:    s_sext_i32_i16 s4, s1
+; GFX12-GI-NEXT:    s_ashr_i32 s1, s1, 16
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_min_i32 s3, s3, s2
 ; GFX12-GI-NEXT:    s_min_i32 s0, s0, 0x7f
+; GFX12-GI-NEXT:    s_min_i32 s2, s4, s2
 ; GFX12-GI-NEXT:    s_min_i32 s1, s1, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s2, s2, 0x7f
-; GFX12-GI-NEXT:    s_min_i32 s3, s3, 0x7f
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_pack_ll_b32_b16 s0, s3, s0
+; GFX12-GI-NEXT:    s_pack_ll_b32_b16 s1, s2, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_sext_i32_i16 s2, s0
+; GFX12-GI-NEXT:    s_sext_i32_i16 s3, 0xff80ff80
+; GFX12-GI-NEXT:    s_ashr_i32 s0, s0, 16
+; GFX12-GI-NEXT:    s_sext_i32_i16 s4, s1
+; GFX12-GI-NEXT:    s_ashr_i32 s1, s1, 16
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_max_i32 s2, s2, s3
 ; GFX12-GI-NEXT:    s_max_i32 s0, s0, 0xffffff80
+; GFX12-GI-NEXT:    s_max_i32 s3, s4, s3
 ; GFX12-GI-NEXT:    s_max_i32 s1, s1, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s2, s2, 0xffffff80
-; GFX12-GI-NEXT:    s_max_i32 s3, s3, 0xffffff80
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-GI-NEXT:    s_pack_ll_b32_b16 s0, s2, s0
+; GFX12-GI-NEXT:    s_pack_ll_b32_b16 s1, s3, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s2
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s3
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptosi.sat.v4f32.v4i8(<4 x float> %f)
     ret <4 x i8> %x

--- a/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptoui-sat-vector.ll
@@ -6425,45 +6425,40 @@ define <4 x i8> @test_unsigned_v4f32_v4i8(<4 x float> %f) {
 ; GFX11-FAKE16-LABEL: test_unsigned_v4f32_v4i8:
 ; GFX11-FAKE16:       ; %bb.0:
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX11-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v2, 0xff, v2
-; GFX11-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX11-FAKE16-NEXT:    v_cvt_pk_u16_f32 v0, v0, v1
+; GFX11-FAKE16-NEXT:    v_cvt_pk_u16_f32 v1, v2, v3
+; GFX11-FAKE16-NEXT:    v_pk_min_u16 v0, 0xff00ff, v0
+; GFX11-FAKE16-NEXT:    v_pk_min_u16 v1, 0xff00ff, v1
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
+; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v2, 8, v2
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v3
-; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v1
-; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v2, v3
-; GFX11-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v1
-; GFX11-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
-; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
-; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v3, v2, 16, v3
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v3
-; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v4
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v3
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v0
+; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX11-FAKE16-NEXT:    v_lshl_or_b32 v1, v2, 16, v1
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX11-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX11-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-TRUE16-LABEL: test_unsigned_v4f32_v4i8:
 ; GFX11-TRUE16:       ; %bb.0:
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v2
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX11-TRUE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v3.l
-; GFX11-TRUE16-NEXT:    v_min_u32_e32 v3, 0xff, v4
-; GFX11-TRUE16-NEXT:    v_or_b16 v2.h, v3.l, v2.l
-; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v1.l
+; GFX11-TRUE16-NEXT:    v_cvt_pk_u16_f32 v2, v2, v3
+; GFX11-TRUE16-NEXT:    v_cvt_pk_u16_f32 v1, v0, v1
+; GFX11-TRUE16-NEXT:    v_pk_min_u16 v2, 0xff00ff, v2
+; GFX11-TRUE16-NEXT:    v_pk_min_u16 v1, 0xff00ff, v1
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v0.l, 8, v2.h
+; GFX11-TRUE16-NEXT:    v_or_b16 v2.h, v2.l, v0.l
+; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v0.l, 8, v1.h
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v2.h
-; GFX11-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v2.l
+; GFX11-TRUE16-NEXT:    v_or_b16 v2.l, v1.l, v0.l
+; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v3
 ; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v2
+; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v2.l
 ; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v2.h
-; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX11-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
 ; GFX11-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-FAKE16-LABEL: test_unsigned_v4f32_v4i8:
@@ -6473,23 +6468,21 @@ define <4 x i8> @test_unsigned_v4f32_v4i8(<4 x float> %f) {
 ; GFX12-FAKE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-FAKE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX12-FAKE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v2, 0xff, v2
-; GFX12-FAKE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
+; GFX12-FAKE16-NEXT:    v_cvt_pk_u16_f32 v0, v0, v1
+; GFX12-FAKE16-NEXT:    v_cvt_pk_u16_f32 v1, v2, v3
+; GFX12-FAKE16-NEXT:    v_pk_min_u16 v0, 0xff00ff, v0
+; GFX12-FAKE16-NEXT:    v_pk_min_u16 v1, 0xff00ff, v1
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
+; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v2, 8, v2
 ; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v3
-; GFX12-FAKE16-NEXT:    v_lshlrev_b16 v1, 8, v1
-; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v2, v3
-; GFX12-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v1
-; GFX12-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v1
-; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v4, 16, v2
-; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v3, v2, 16, v3
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v3
-; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v4
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v0, v0, v2
+; GFX12-FAKE16-NEXT:    v_or_b32_e32 v2, v1, v3
+; GFX12-FAKE16-NEXT:    v_and_b32_e32 v1, 0xffff, v0
+; GFX12-FAKE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
+; GFX12-FAKE16-NEXT:    v_lshl_or_b32 v1, v2, 16, v1
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
+; GFX12-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX12-FAKE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-TRUE16-LABEL: test_unsigned_v4f32_v4i8:
@@ -6499,23 +6492,20 @@ define <4 x i8> @test_unsigned_v4f32_v4i8(<4 x float> %f) {
 ; GFX12-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v4, v2
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX12-TRUE16-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v3, 0xff, v3
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v0, 0xff, v0
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v3.l
-; GFX12-TRUE16-NEXT:    v_min_u32_e32 v3, 0xff, v4
-; GFX12-TRUE16-NEXT:    v_or_b16 v2.h, v3.l, v2.l
-; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v2.l, 8, v1.l
+; GFX12-TRUE16-NEXT:    v_cvt_pk_u16_f32 v2, v2, v3
+; GFX12-TRUE16-NEXT:    v_cvt_pk_u16_f32 v1, v0, v1
+; GFX12-TRUE16-NEXT:    v_pk_min_u16 v2, 0xff00ff, v2
+; GFX12-TRUE16-NEXT:    v_pk_min_u16 v1, 0xff00ff, v1
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v0.l, 8, v2.h
+; GFX12-TRUE16-NEXT:    v_or_b16 v2.h, v2.l, v0.l
+; GFX12-TRUE16-NEXT:    v_lshlrev_b16 v0.l, 8, v1.h
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v3.l, v2.h
-; GFX12-TRUE16-NEXT:    v_or_b16 v0.l, v0.l, v2.l
+; GFX12-TRUE16-NEXT:    v_or_b16 v2.l, v1.l, v0.l
+; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 16, v3
 ; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v1, 8, v2
+; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v0
+; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v2.l
 ; GFX12-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v2.h
-; GFX12-TRUE16-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX12-TRUE16-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
 ; GFX12-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_unsigned_v4f32_v4i8:
@@ -6525,14 +6515,12 @@ define <4 x i8> @test_unsigned_v4f32_v4i8(<4 x float> %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v1, v1
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX12-GI-NEXT:    v_cvt_u32_f32_e32 v3, v3
-; GFX12-GI-NEXT:    v_min_u32_e32 v0, 0xff, v0
-; GFX12-GI-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX12-GI-NEXT:    v_min_u32_e32 v2, 0xff, v2
-; GFX12-GI-NEXT:    v_min_u32_e32 v3, 0xff, v3
+; GFX12-GI-NEXT:    v_cvt_pk_u16_f32 v0, v0, v1
+; GFX12-GI-NEXT:    v_cvt_pk_u16_f32 v1, v2, v3
+; GFX12-GI-NEXT:    v_pk_min_u16 v0, 0xff00ff, v0
+; GFX12-GI-NEXT:    v_pk_min_u16 v2, 0xff00ff, v1
+; GFX12-GI-NEXT:    v_mov_b16_e32 v1.l, v0.h
+; GFX12-GI-NEXT:    v_mov_b16_e32 v3.l, v2.h
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptoui.sat.v4f32.v4i8(<4 x float> %f)
     ret <4 x i8> %x
@@ -6605,22 +6593,19 @@ define <4 x i8> @test_s_unsigned_v4f32_v4i8(<4 x float> inreg %f) {
 ; GFX11-LABEL: test_s_unsigned_v4f32_v4i8:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s3
-; GFX11-NEXT:    v_cvt_u32_f32_e32 v1, s2
-; GFX11-NEXT:    v_cvt_u32_f32_e32 v2, s1
-; GFX11-NEXT:    v_min_u32_e32 v0, 0xff, v0
-; GFX11-NEXT:    v_min_u32_e32 v1, 0xff, v1
-; GFX11-NEXT:    v_min_u32_e32 v3, 0xff, v2
-; GFX11-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
-; GFX11-NEXT:    v_or_b32_e32 v2, v1, v0
-; GFX11-NEXT:    v_cvt_u32_f32_e32 v0, s0
-; GFX11-NEXT:    v_lshlrev_b32_e32 v1, 8, v3
-; GFX11-NEXT:    v_lshlrev_b32_e32 v3, 16, v2
-; GFX11-NEXT:    v_min_u32_e32 v0, 0xff, v0
-; GFX11-NEXT:    v_or_b32_e32 v4, v1, v3
-; GFX11-NEXT:    v_or_b32_e32 v0, v0, v1
-; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 24, v3
-; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 8, v4
+; GFX11-NEXT:    v_cvt_pk_u16_f32 v0, s2, s3
+; GFX11-NEXT:    v_cvt_pk_u16_f32 v1, s0, s1
+; GFX11-NEXT:    v_pk_min_u16 v0, 0xff00ff, v0
+; GFX11-NEXT:    v_pk_min_u16 v1, 0xff00ff, v1
+; GFX11-NEXT:    v_lshrrev_b32_e32 v2, 8, v0
+; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 8, v1
+; GFX11-NEXT:    v_or_b32_e32 v2, v0, v2
+; GFX11-NEXT:    v_or_b32_e32 v0, v1, v3
+; GFX11-NEXT:    v_lshlrev_b32_e32 v1, 16, v2
+; GFX11-NEXT:    v_and_b32_e32 v3, 0xff00, v0
+; GFX11-NEXT:    v_or_b32_e32 v1, v3, v1
+; GFX11-NEXT:    v_bfe_u32 v3, v2, 8, 8
+; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-ISEL-LABEL: test_s_unsigned_v4f32_v4i8:
@@ -6630,31 +6615,19 @@ define <4 x i8> @test_s_unsigned_v4f32_v4i8(<4 x float> inreg %f) {
 ; GFX12-ISEL-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-ISEL-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-ISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s3, s3
-; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s2, s2
-; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s1, s1
-; GFX12-ISEL-NEXT:    s_cvt_u32_f32 s0, s0
-; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    s_min_u32 s3, s3, 0xff
-; GFX12-ISEL-NEXT:    s_min_u32 s2, s2, 0xff
-; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    s_lshl_b32 s3, s3, 8
-; GFX12-ISEL-NEXT:    s_min_u32 s1, s1, 0xff
-; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    s_or_b32 s2, s2, s3
-; GFX12-ISEL-NEXT:    s_min_u32 s0, s0, 0xff
-; GFX12-ISEL-NEXT:    s_lshl_b32 s1, s1, 8
-; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    s_lshl_b32 s3, s2, 16
-; GFX12-ISEL-NEXT:    s_or_b32 s0, s0, s1
-; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    s_or_b32 s1, s1, s3
-; GFX12-ISEL-NEXT:    s_lshr_b32 s3, s3, 24
-; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    s_lshr_b32 s1, s1, 8
-; GFX12-ISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-ISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
-; GFX12-ISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-ISEL-NEXT:    v_cvt_pk_u16_f32 v0, s2, s3
+; GFX12-ISEL-NEXT:    v_cvt_pk_u16_f32 v1, s0, s1
+; GFX12-ISEL-NEXT:    v_pk_min_u16 v0, 0xff00ff, v0
+; GFX12-ISEL-NEXT:    v_pk_min_u16 v1, 0xff00ff, v1
+; GFX12-ISEL-NEXT:    v_lshrrev_b32_e32 v2, 8, v0
+; GFX12-ISEL-NEXT:    v_lshrrev_b32_e32 v3, 8, v1
+; GFX12-ISEL-NEXT:    v_or_b32_e32 v2, v0, v2
+; GFX12-ISEL-NEXT:    v_or_b32_e32 v0, v1, v3
+; GFX12-ISEL-NEXT:    v_lshlrev_b32_e32 v1, 16, v2
+; GFX12-ISEL-NEXT:    v_and_b32_e32 v3, 0xff00, v0
+; GFX12-ISEL-NEXT:    v_or_b32_e32 v1, v3, v1
+; GFX12-ISEL-NEXT:    v_bfe_u32 v3, v2, 8, 8
+; GFX12-ISEL-NEXT:    v_lshrrev_b32_e32 v1, 8, v1
 ; GFX12-ISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-GI-LABEL: test_s_unsigned_v4f32_v4i8:
@@ -6664,18 +6637,28 @@ define <4 x i8> @test_s_unsigned_v4f32_v4i8(<4 x float> inreg %f) {
 ; GFX12-GI-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-GI-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-GI-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s0, s0
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s1, s1
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s2, s2
-; GFX12-GI-NEXT:    s_cvt_u32_f32 s3, s3
+; GFX12-GI-NEXT:    v_cvt_pk_u16_f32 v0, s0, s1
+; GFX12-GI-NEXT:    v_cvt_pk_u16_f32 v1, s2, s3
+; GFX12-GI-NEXT:    v_readfirstlane_b32 s0, v0
+; GFX12-GI-NEXT:    v_readfirstlane_b32 s1, v1
+; GFX12-GI-NEXT:    s_and_b32 s2, s0, 0xffff
+; GFX12-GI-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX12-GI-NEXT:    s_and_b32 s3, s1, 0xffff
+; GFX12-GI-NEXT:    s_lshr_b32 s1, s1, 16
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
-; GFX12-GI-NEXT:    s_min_u32 s1, s1, 0xff
 ; GFX12-GI-NEXT:    s_min_u32 s2, s2, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s0, s0, 0xff
 ; GFX12-GI-NEXT:    s_min_u32 s3, s3, 0xff
+; GFX12-GI-NEXT:    s_min_u32 s1, s1, 0xff
 ; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
-; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
+; GFX12-GI-NEXT:    s_pack_ll_b32_b16 s0, s2, s0
+; GFX12-GI-NEXT:    s_pack_ll_b32_b16 s1, s3, s1
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    s_lshr_b32 s2, s0, 16
+; GFX12-GI-NEXT:    s_lshr_b32 s3, s1, 16
+; GFX12-GI-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-GI-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s2
+; GFX12-GI-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s3
 ; GFX12-GI-NEXT:    s_setpc_b64 s[30:31]
     %x = call <4 x i8> @llvm.fptoui.sat.v4f32.v4i8(<4 x float> %f)
     ret <4 x i8> %x


### PR DESCRIPTION
The improvement is limited in some cases due to extra 8-bit-related shuffling, however in all cases, beside the one described below, there is at least one less instruction.

The real problem is the GFX12 GISel uniform case that has a significantly larger number of instructions. This is due to the fact that the widening rule introduces MAX and MIN nodes. For uniform case those nodes later hit `UnpackMinMax` that introduce a sequence of SALU instructions, instead of using `v_pk_max/min_*`  as in the selectiondag case. We could change how MAX/MIN are handled in general by favoring packed VALU instructions over a sequence of SALU instructions, but that would affect other tests as well.

Assisted-by: Claude Code