### PR TITLE
[Hexagon] Fix PostRA QFP pass crash on pre-v79 targets

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
@@ -495,7 +495,10 @@ void HexagonPassConfig::addPreRegAlloc() {
 }
 
 void HexagonPassConfig::addPostRegAlloc() {
-  if (EnablePostRAHandleQFP)
+  HexagonTargetMachine &HTM = getHexagonTargetMachine();
+  const HexagonSubtarget *HST = HTM.getHexagonSubtarget();
+  // Run PostRAQFP on v79 and above.
+  if (EnablePostRAHandleQFP && HST->useHVXV79Ops())
     addPass(createHexagonPostRAHandleQFP());
 
   if (getOptLevel() != CodeGenOptLevel::None) {

--- a/llvm/test/CodeGen/Hexagon/autohvx/postRA-qfp-v69-no-crash.ll
+++ b/llvm/test/CodeGen/Hexagon/autohvx/postRA-qfp-v69-no-crash.ll
@@ -1,0 +1,21 @@
+; Test that the PostRA QFP handle pass does not crash
+; on <v79 with qfloat intrinsics.
+;
+; REQUIRES: asserts
+; RUN: llc -mtriple=hexagon-unknown-linux-musl -mcpu=hexagonv69 \
+; RUN:   -mattr=+hvx-length128b,+hvxv69 -O2 -filetype=obj \
+; RUN:   < %s -o /dev/null
+
+define <32 x i32> @main() {
+entry:
+  %0 = tail call <32 x i32> @llvm.hexagon.V6.vadd.qf32.mix.128B(<32 x i32> zeroinitializer, <32 x i32> zeroinitializer)
+  %puts = call i32 @puts()
+  %1 = tail call <32 x i32> @llvm.hexagon.V6.vconv.sf.qf32.128B(<32 x i32> %0)
+  ret <32 x i32> %1
+}
+
+declare <32 x i32> @llvm.hexagon.V6.vadd.qf32.mix.128B(<32 x i32>, <32 x i32>) #0
+declare <32 x i32> @llvm.hexagon.V6.vconv.sf.qf32.128B(<32 x i32>) #0
+declare i32 @puts()
+
+attributes #0 = { nocallback nofree nosync nounwind willreturn memory(none) }


### PR DESCRIPTION
Gate the HexagonPostRAHandleQFP pass to only
run for v79+.

Fixes: https://github.com/llvm/llvm-project/issues/206301