### PR TITLE
[CIR] Emit comdat for weak global temporaries

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -3997,8 +3997,7 @@ CIRGenModule::getAddrOfGlobalTemporary(const MaterializeTemporaryExpr *mte,
 
   gv.setAlignment(align.getAsAlign().value());
   if (supportsCOMDAT() && gv.isWeakForLinker())
-    errorNYI(mte->getSourceRange(),
-             "Global temporary with comdat/weak linkage");
+    gv.setComdat(true);
   if (varDecl->getTLSKind())
     setTLSMode(gv, *varDecl, /*isExtendingDecl=*/true);
   mlir::Operation *cv = gv;

--- a/clang/test/CIR/CodeGen/global-temporary-comdat.cpp
+++ b/clang/test/CIR/CodeGen/global-temporary-comdat.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+inline const int &ref = 42;
+
+const int *use() { return &ref; }
+
+// CIR: cir.global constant linkonce_odr comdat @_ZGR3ref_ = #cir.int<42> : !s32i
+// CIR: cir.func{{.*}} @_Z3usev()
+// CIR: cir.const #cir.global_view<@_ZGR3ref_> : !cir.ptr<!s32i>
+
+// LLVM: $_ZGR3ref_ = comdat any
+// LLVM: @_ZGR3ref_ = linkonce_odr constant i32 42, comdat, align 4


### PR DESCRIPTION
A lifetime-extended temporary with static or thread storage takes its
extending variable's linkage.  When that linkage is weak-for-linker -- an
inline variable or a variable template binding a const reference to a
temporary -- and the target supports COMDAT, classic CodeGen puts the
temporary's global in a comdat.  CIRGen's getAddrOfGlobalTemporary hit
errorNYI for that case, so `inline const int &r = 42;` failed to compile
under -fclangir.  It is a recurring blocker in the libcxx std/ suite
(flat_map/flat_set construction, vector<bool>, format ranges).

CIR globals already carry a comdat flag, and the weak-for-linker path
elsewhere in CIRGenModule already sets it; this does the same for the
materialized temporary.  The existing comdat lowering emits the symbol-named
`comdat any`, so the lowered IR matches classic byte-for-byte.
