### PR TITLE
[mlir-c] Add mlirOperationGetParentWithName

### DIFF
--- a/mlir/include/mlir-c/IR.h
+++ b/mlir/include/mlir-c/IR.h
@@ -667,6 +667,12 @@ MLIR_CAPI_EXPORTED MlirBlock mlirOperationGetBlock(MlirOperation op);
 MLIR_CAPI_EXPORTED MlirOperation
 mlirOperationGetParentOperation(MlirOperation op);
 
+/// Walks up the ancestor chain of the given operation (not including the
+/// operation itself) and returns the first parent operation whose name matches
+/// `opName`. Returns a null operation if no such ancestor exists.
+MLIR_CAPI_EXPORTED MlirOperation
+mlirOperationGetParentWithName(MlirOperation op, MlirStringRef opName);
+
 /// Returns the number of regions attached to the given operation.
 MLIR_CAPI_EXPORTED intptr_t mlirOperationGetNumRegions(MlirOperation op);
 

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -696,9 +696,10 @@ MlirOperation mlirOperationGetParentWithName(MlirOperation op,
                                              MlirStringRef opName) {
   StringRef name = unwrap(opName);
   for (Operation *parent = unwrap(op)->getParentOp(); parent;
-       parent = parent->getParentOp())
+       parent = parent->getParentOp()) {
     if (parent->getName().getStringRef() == name)
       return wrap(parent);
+  }
   return {nullptr};
 }
 

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -692,6 +692,16 @@ MlirOperation mlirOperationGetParentOperation(MlirOperation op) {
   return wrap(unwrap(op)->getParentOp());
 }
 
+MlirOperation mlirOperationGetParentWithName(MlirOperation op,
+                                             MlirStringRef opName) {
+  StringRef name = unwrap(opName);
+  for (Operation *parent = unwrap(op)->getParentOp(); parent;
+       parent = parent->getParentOp())
+    if (parent->getName().getStringRef() == name)
+      return wrap(parent);
+  return {nullptr};
+}
+
 intptr_t mlirOperationGetNumRegions(MlirOperation op) {
   return static_cast<intptr_t>(unwrap(op)->getNumRegions());
 }

--- a/mlir/test/CAPI/ir.c
+++ b/mlir/test/CAPI/ir.c
@@ -2943,6 +2943,54 @@ int testDominanceInfo(MlirContext ctx) {
   return 0;
 }
 
+int testGetParentWithName(MlirContext ctx) {
+  fprintf(stderr, "@testGetParentWithName\n");
+  // CHECK-LABEL: @testGetParentWithName
+
+  mlirContextGetOrLoadDialect(ctx, mlirStringRefCreateFromCString("arith"));
+
+  const char *moduleStr = "func.func @f() {\n"
+                          "  %c0 = arith.constant 0 : i32\n"
+                          "  return\n"
+                          "}\n";
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(moduleStr));
+
+  MlirOperation moduleOp = mlirModuleGetOperation(module);
+  MlirBlock moduleBody = mlirModuleGetBody(module);
+  MlirOperation funcOp = mlirBlockGetFirstOperation(moduleBody);
+  MlirRegion funcRegion = mlirOperationGetRegion(funcOp, 0);
+  MlirBlock funcBody = mlirRegionGetFirstBlock(funcRegion);
+  MlirOperation constOp = mlirBlockGetFirstOperation(funcBody);
+
+  // Nearest enclosing func.func ancestor.
+  MlirOperation foundFunc = mlirOperationGetParentWithName(
+      constOp, mlirStringRefCreateFromCString("func.func"));
+  assert(mlirOperationEqual(foundFunc, funcOp));
+
+  // Walks past func.func to find the enclosing builtin.module ancestor.
+  MlirOperation foundModule = mlirOperationGetParentWithName(
+      constOp, mlirStringRefCreateFromCString("builtin.module"));
+  assert(mlirOperationEqual(foundModule, moduleOp));
+
+  // A name that matches no ancestor returns null.
+  MlirOperation notFound = mlirOperationGetParentWithName(
+      constOp, mlirStringRefCreateFromCString("scf.for"));
+  assert(mlirOperationIsNull(notFound));
+
+  // The lookup excludes the operation itself: arith.constant is not its own
+  // ancestor.
+  MlirOperation notSelf = mlirOperationGetParentWithName(
+      constOp, mlirStringRefCreateFromCString("arith.constant"));
+  assert(mlirOperationIsNull(notSelf));
+
+  mlirModuleDestroy(module);
+
+  // CHECK: testGetParentWithName: PASSED
+  fprintf(stderr, "testGetParentWithName: PASSED\n");
+  return 0;
+}
+
 int main(void) {
   MlirContext ctx = mlirContextCreate();
   registerAllUpstreamDialects(ctx);
@@ -2998,6 +3046,8 @@ int main(void) {
     return 19;
   if (testDominanceInfo(ctx))
     return 20;
+  if (testGetParentWithName(ctx))
+    return 21;
 
   // CHECK: DESTROY MAIN CONTEXT
   // CHECK: reportResourceDelete: resource_i64_blob

--- a/mlir/test/CAPI/ir.c
+++ b/mlir/test/CAPI/ir.c
@@ -2949,16 +2949,27 @@ int testGetParentWithName(MlirContext ctx) {
 
   mlirContextGetOrLoadDialect(ctx, mlirStringRefCreateFromCString("arith"));
 
-  const char *moduleStr = "func.func @f() {\n"
-                          "  %c0 = arith.constant 0 : i32\n"
-                          "  return\n"
+  // A nested module puts two `builtin.module` ops in the ancestor chain so we
+  // can verify the walk returns the *nearest* match rather than the outermost.
+  // Chain from the constant: arith.constant -> func.func -> builtin.module
+  // (inner) -> builtin.module (outer).
+  const char *moduleStr = "module {\n"
+                          "  module {\n"
+                          "    func.func @f() {\n"
+                          "      %c0 = arith.constant 0 : i32\n"
+                          "      return\n"
+                          "    }\n"
+                          "  }\n"
                           "}\n";
   MlirModule module =
       mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(moduleStr));
 
-  MlirOperation moduleOp = mlirModuleGetOperation(module);
-  MlirBlock moduleBody = mlirModuleGetBody(module);
-  MlirOperation funcOp = mlirBlockGetFirstOperation(moduleBody);
+  MlirOperation outerModuleOp = mlirModuleGetOperation(module);
+  MlirBlock outerModuleBody = mlirModuleGetBody(module);
+  MlirOperation innerModuleOp = mlirBlockGetFirstOperation(outerModuleBody);
+  MlirRegion innerModuleRegion = mlirOperationGetRegion(innerModuleOp, 0);
+  MlirBlock innerModuleBody = mlirRegionGetFirstBlock(innerModuleRegion);
+  MlirOperation funcOp = mlirBlockGetFirstOperation(innerModuleBody);
   MlirRegion funcRegion = mlirOperationGetRegion(funcOp, 0);
   MlirBlock funcBody = mlirRegionGetFirstBlock(funcRegion);
   MlirOperation constOp = mlirBlockGetFirstOperation(funcBody);
@@ -2968,10 +2979,18 @@ int testGetParentWithName(MlirContext ctx) {
       constOp, mlirStringRefCreateFromCString("func.func"));
   assert(mlirOperationEqual(foundFunc, funcOp));
 
-  // Walks past func.func to find the enclosing builtin.module ancestor.
+  // Walks past func.func to find the enclosing builtin.module ancestor, and
+  // returns the *nearest* one (the inner module), not the outer module.
   MlirOperation foundModule = mlirOperationGetParentWithName(
       constOp, mlirStringRefCreateFromCString("builtin.module"));
-  assert(mlirOperationEqual(foundModule, moduleOp));
+  assert(mlirOperationEqual(foundModule, innerModuleOp));
+  assert(!mlirOperationEqual(foundModule, outerModuleOp));
+
+  // Starting the walk from the inner module skips it (the op itself is
+  // excluded) and finds the outer module instead.
+  MlirOperation foundOuterModule = mlirOperationGetParentWithName(
+      innerModuleOp, mlirStringRefCreateFromCString("builtin.module"));
+  assert(mlirOperationEqual(foundOuterModule, outerModuleOp));
 
   // A name that matches no ancestor returns null.
   MlirOperation notFound = mlirOperationGetParentWithName(
@@ -2983,6 +3002,12 @@ int testGetParentWithName(MlirContext ctx) {
   MlirOperation notSelf = mlirOperationGetParentWithName(
       constOp, mlirStringRefCreateFromCString("arith.constant"));
   assert(mlirOperationIsNull(notSelf));
+
+  // The top-level op has no parent, so any lookup returns null (exercises the
+  // loop's null-parent guard).
+  MlirOperation noParent = mlirOperationGetParentWithName(
+      outerModuleOp, mlirStringRefCreateFromCString("builtin.module"));
+  assert(mlirOperationIsNull(noParent));
 
   mlirModuleDestroy(module);
 


### PR DESCRIPTION
Adds a C API helper to walk an operation's ancestor chain and find the nearest enclosing op with a given name, mirroring the common `getParentOfType<T>()` idiom in C++.

Assisted by: Claude