### PR TITLE
[CIR] Fix getNewInitValue on string-literal arrays

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1063,13 +1063,16 @@ static mlir::Attribute getNewInitValue(CIRGenModule &cgm, cir::GlobalOp newGlob,
   };
 
   if (auto oldArray = mlir::dyn_cast<cir::ConstArrayAttr>(oldInit)) {
-    // A ConstArrayAttr backed by a StringAttr (a string-literal initializer)
-    // stores raw bytes and holds no global references to rewrite, so it is
-    // returned unchanged.
-    auto oldElts = mlir::dyn_cast<mlir::ArrayAttr>(oldArray.getElts());
-    if (!oldElts)
+    // ConstArrayAttr::verify guarantees the elements are either an ArrayAttr or
+    // a StringAttr.  A StringAttr is a string-literal initializer: raw 8-bit
+    // character bytes with no nested global references, so there is nothing to
+    // rewrite and it is returned unchanged.  The ArrayAttr case recurses to
+    // rewrite any nested global views.
+    mlir::Attribute oldElts = oldArray.getElts();
+    if (mlir::isa<mlir::StringAttr>(oldElts))
       return oldInit;
-    mlir::Attribute newElements = getNewInitElements(oldElts);
+    mlir::Attribute newElements =
+        getNewInitElements(mlir::cast<mlir::ArrayAttr>(oldElts));
     return cgm.getBuilder().getConstArray(
         newElements, mlir::cast<cir::ArrayType>(oldArray.getType()));
   }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1063,8 +1063,13 @@ static mlir::Attribute getNewInitValue(CIRGenModule &cgm, cir::GlobalOp newGlob,
   };
 
   if (auto oldArray = mlir::dyn_cast<cir::ConstArrayAttr>(oldInit)) {
-    mlir::Attribute newElements =
-        getNewInitElements(mlir::cast<mlir::ArrayAttr>(oldArray.getElts()));
+    // A ConstArrayAttr backed by a StringAttr (a string-literal initializer)
+    // stores raw bytes and holds no global references to rewrite, so it is
+    // returned unchanged.
+    auto oldElts = mlir::dyn_cast<mlir::ArrayAttr>(oldArray.getElts());
+    if (!oldElts)
+      return oldInit;
+    mlir::Attribute newElements = getNewInitElements(oldElts);
     return cgm.getBuilder().getConstArray(
         newElements, mlir::cast<cir::ArrayType>(oldArray.getType()));
   }

--- a/clang/test/CIR/CodeGen/global-replace-string-array.c
+++ b/clang/test/CIR/CodeGen/global-replace-string-array.c
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-CIR --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefixes=LLVM,OGCG --input-file=%t.ll %s
+
+extern int arr[];
+struct S {
+  int *p;
+  char name[4];
+};
+struct S a = {arr, "aa"};
+int arr[5] = {1, 2, 3, 4, 5};
+
+// CIR-DAG: cir.global external @arr = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i, #cir.int<4> : !s32i, #cir.int<5> : !s32i]> : !cir.array<!s32i x 5>
+// CIR-DAG: cir.global external @a = #cir.const_record<{#cir.global_view<@arr> : !cir.ptr<!s32i>, #cir.const_array<"aa" : !cir.array<!s8i x 2>, trailing_zeros> : !cir.array<!s8i x 4>}>
+
+// LLVM-DAG: @arr = global [5 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5]
+// LLVM-CIR-DAG: @a = global %struct.S { ptr @arr, [4 x i8] c"aa\00\00" }
+// OGCG-DAG: @a = global { ptr, [4 x i8], [4 x i8] } { ptr @arr, [4 x i8] c"aa\00\00", [4 x i8] zeroinitializer }


### PR DESCRIPTION
`getNewInitValue` in `CIRGenModule.cpp` rebuilds a global's initializer when
`replaceGlobal` fixes up references after a global's type changes -- for
example when an `extern` array is referenced while still incomplete and then
completed. Its `ConstArrayAttr` branch cast `getElts()` to an `mlir::ArrayAttr`,
but a `ConstArrayAttr` built from a string literal stores its elements as a
`StringAttr`. A struct global that both points at the replaced global and has a
`char` array member therefore aborted on a failed `cast<ArrayAttr>` during
CIRGen.

A `StringAttr` holds raw bytes and references no globals, so there is nothing
to rewrite. The fix `dyn_cast`s the elements and returns the initializer
unchanged when they are not an `ArrayAttr`.

This surfaced compiling CPython's deep-frozen module data (SPEC CPU 2026
714.cpython_r), where frozen objects cross-reference each other and carry
string payloads. The benchmark advances past this abort to a const-record
type-identity issue that is tracked separately.
