### PR TITLE
[mlir-c] Add mlirEmitWarning and mlirEmitRemark

### DIFF
--- a/mlir/include/mlir-c/Diagnostics.h
+++ b/mlir/include/mlir-c/Diagnostics.h
@@ -94,6 +94,16 @@ mlirContextDetachDiagnosticHandler(MlirContext context,
 MLIR_CAPI_EXPORTED void mlirEmitError(MlirLocation location,
                                       const char *message);
 
+/// Emits a warning at the given location through the diagnostics engine. Used
+/// for testing purposes.
+MLIR_CAPI_EXPORTED void mlirEmitWarning(MlirLocation location,
+                                        const char *message);
+
+/// Emits a remark at the given location through the diagnostics engine. Used
+/// for testing purposes.
+MLIR_CAPI_EXPORTED void mlirEmitRemark(MlirLocation location,
+                                       const char *message);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mlir/lib/CAPI/IR/Diagnostics.cpp
+++ b/mlir/lib/CAPI/IR/Diagnostics.cpp
@@ -78,3 +78,11 @@ void mlirContextDetachDiagnosticHandler(MlirContext context,
 void mlirEmitError(MlirLocation location, const char *message) {
   emitError(unwrap(location)) << message;
 }
+
+void mlirEmitWarning(MlirLocation location, const char *message) {
+  emitWarning(unwrap(location)) << message;
+}
+
+void mlirEmitRemark(MlirLocation location, const char *message) {
+  emitRemark(unwrap(location)) << message;
+}

--- a/mlir/test/CAPI/ir.c
+++ b/mlir/test/CAPI/ir.c
@@ -2425,6 +2425,8 @@ void testDiagnostics(void) {
   MlirAttribute nullAttr = {0};
   MlirLocation fusedLoc = mlirLocationFusedGet(ctx, 2, locs, nullAttr);
   mlirEmitError(fusedLoc, "test diagnostics");
+  mlirEmitWarning(unknownLoc, "test warning");
+  mlirEmitRemark(unknownLoc, "test remark");
   mlirContextDetachDiagnosticHandler(ctx, id);
   mlirEmitError(unknownLoc, "more test diagnostics");
   // CHECK-LABEL: @test_diagnostics
@@ -2454,6 +2456,12 @@ void testDiagnostics(void) {
   // CHECK: processing diagnostic (userData: 42) <<
   // CHECK:   test diagnostics
   // CHECK:   loc(fused["named", callsite("other-file.c":2:3 at "file.c":1:2)])
+  // CHECK: processing diagnostic (userData: 42) <<
+  // CHECK:   test warning
+  // CHECK:   loc(unknown)
+  // CHECK: processing diagnostic (userData: 42) <<
+  // CHECK:   test remark
+  // CHECK:   loc(unknown)
   // CHECK: deleting user data (userData: 42)
   // CHECK-NOT: processing diagnostic
   // CHECK:     more test diagnostics


### PR DESCRIPTION
Adds C API entry points for emitting warning and remark diagnostics, complementing the existing `mlirEmitError`.

## Changes

`mlir/include/mlir-c/Diagnostics.h` / `mlir/lib/CAPI/IR/Diagnostics.cpp`:
- `mlirEmitWarning(MlirLocation, const char *message)` — wraps `emitWarning`.
- `mlirEmitRemark(MlirLocation, const char *message)` — wraps `emitRemark`.

Both mirror the existing `mlirEmitError` signature and conventions.

## Tests

`mlir/test/CAPI/ir.c`: extends the existing `testDiagnostics` to emit a warning and a remark through the attached diagnostic handler, with FileCheck lines verifying both are processed (the handler prints diagnostics of any severity).

The full `mlir-capi-ir-test` suite passes under FileCheck.