### PR TITLE
[X86] Add subtarget-dependent checks

### DIFF
--- a/llvm/lib/Target/X86/X86TargetVerifier.cpp
+++ b/llvm/lib/Target/X86/X86TargetVerifier.cpp
@@ -11,15 +11,34 @@
 // TargetVerifierPass runs for X86 modules; the other half is the generic IR
 // verifier.
 //
+// The checks here are the ones that are *subtarget/feature-dependent*:
+// they need to know the specific CPU/features selected via the
+// target-cpu/target-features function attributes. The MCSubtargetInfo is
+// derived from those attributes, so no TargetMachine is required and the
+// verifier can run from generic pipelines.
+//
 //===----------------------------------------------------------------------===//
 
+#include "MCTargetDesc/X86MCTargetDesc.h"
 #include "X86.h"
 
 #include "llvm/IR/Function.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Target/TargetVerifier.h"
 
 using namespace llvm;
+
+// Check - We know that cond should be true, if not print an error message.
+#define Check(C, ...)                                                          \
+  do {                                                                         \
+    if (!(C))                                                                  \
+      checkFailed(__VA_ARGS__);                                                \
+  } while (false)
 
 namespace {
 
@@ -27,10 +46,95 @@ class X86TargetVerify : public TargetVerify {
 public:
   X86TargetVerify(Module *Mod) : TargetVerify(Mod) {}
   bool run(Function &F) override;
+
+private:
+  /// Per-function subtarget/feature-dependent checks.
+  void verifyFunctionChecks(Function &F, const MCSubtargetInfo &STI);
+
+  MCSubtargetInfo *getSubtargetInfo(const Function &F) const;
 };
+
+static bool usesAMXType(const Instruction &I) {
+  if (I.getType()->isX86_AMXTy())
+    return true;
+  for (const Value *Op : I.operands())
+    if (Op->getType()->isX86_AMXTy())
+      return true;
+  return false;
+}
+
+MCSubtargetInfo *X86TargetVerify::getSubtargetInfo(const Function &F) const {
+  std::string Error;
+  const Target *T = TargetRegistry::lookupTarget(TT, Error);
+  if (!T)
+    return nullptr;
+  StringRef CPU = F.getFnAttribute("target-cpu").getValueAsString();
+  StringRef FS = F.getFnAttribute("target-features").getValueAsString();
+  return T->createMCSubtargetInfo(TT, CPU, FS);
+}
+
+/// Instruction-set intrinsic families, each gated on a subtarget feature. The
+/// name prefixes are disjoint (the trailing '.' keeps e.g. "avx" from matching
+/// "avx2"/"avx512"), so an intrinsic matches at most one entry.
+static const struct {
+  StringRef Prefix;
+  unsigned Feature;
+  StringRef Name;
+} IntrinsicFeatures[] = {
+    {"llvm.x86.avx512.", X86::FeatureAVX512, "AVX-512"},
+    {"llvm.x86.avx2.", X86::FeatureAVX2, "AVX2"},
+    {"llvm.x86.avx.", X86::FeatureAVX, "AVX"},
+};
+
+void X86TargetVerify::verifyFunctionChecks(Function &F,
+                                           const MCSubtargetInfo &STI) {
+  bool HasAMXTILE = STI.hasFeature(X86::FeatureAMXTILE);
+
+  for (const Instruction &I : instructions(F)) {
+    // An instruction-set intrinsic requires its feature on the selected
+    // subtarget.
+    if (const auto *CB = dyn_cast<CallBase>(&I)) {
+      if (const Function *CF = CB->getCalledFunction()) {
+        StringRef Name = CF->getName();
+        for (const auto &IF : IntrinsicFeatures)
+          if (Name.starts_with(IF.Prefix))
+            Check(STI.hasFeature(IF.Feature),
+                  Twine(IF.Name) +
+                      " intrinsic used, but the subtarget does not support " +
+                      IF.Name + ".",
+                  &I);
+
+        // The 128/256-bit (EVEX.128/256) forms of an AVX-512 intrinsic
+        // additionally require AVX512VL, which AVX512F alone does not provide.
+        // The width is encoded as a ".128"/".256" suffix on the intrinsic name.
+        if (Name.starts_with("llvm.x86.avx512.") &&
+            (Name.ends_with(".128") || Name.ends_with(".256")))
+          Check(STI.hasFeature(X86::FeatureVLX),
+                "128/256-bit AVX-512 intrinsic used, but the subtarget does "
+                "not support AVX512VL.",
+                &I);
+      }
+    }
+
+    // The x86_amx type requires the AMX-TILE feature on the selected
+    // subtarget.
+    if (usesAMXType(I))
+      Check(HasAMXTILE,
+            "x86_amx type used, but the subtarget does not support AMX-TILE.",
+            &I);
+  }
+}
 
 bool X86TargetVerify::run(Function &F) {
   IsValid = true;
+
+  MCSubtargetInfo *STI = getSubtargetInfo(F);
+  if (!STI)
+    return IsValid;
+
+  verifyFunctionChecks(F, *STI);
+
+  delete STI;
   return IsValid;
 }
 

--- a/llvm/test/Verifier/X86/lit.local.cfg
+++ b/llvm/test/Verifier/X86/lit.local.cfg
@@ -1,0 +1,2 @@
+if not "X86" in config.root.targets:
+    config.unsupported = True

--- a/llvm/test/Verifier/X86/target-verifier.ll
+++ b/llvm/test/Verifier/X86/target-verifier.ll
@@ -1,0 +1,41 @@
+; RUN: opt -passes=target-verifier -disable-output %s 2>&1 | FileCheck %s
+
+target triple = "x86_64-unknown-linux-gnu"
+
+declare <16 x float> @llvm.x86.avx512.max.ps.512(<16 x float>, <16 x float>, i32)
+declare <8 x float> @llvm.x86.avx.max.ps.256(<8 x float>, <8 x float>)
+declare <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8>, <32 x i8>)
+declare <4 x i32> @llvm.x86.avx512.conflict.d.128(<4 x i32>)
+declare x86_amx @llvm.x86.tilezero.internal(i16, i16)
+
+; CHECK: AVX-512 intrinsic used, but the subtarget does not support AVX-512.
+define <16 x float> @avx512_without_feature(<16 x float> %a, <16 x float> %b) {
+  %r = call <16 x float> @llvm.x86.avx512.max.ps.512(<16 x float> %a, <16 x float> %b, i32 4)
+  ret <16 x float> %r
+}
+
+; CHECK: AVX intrinsic used, but the subtarget does not support AVX.
+define <8 x float> @avx_without_feature(<8 x float> %a, <8 x float> %b) {
+  %r = call <8 x float> @llvm.x86.avx.max.ps.256(<8 x float> %a, <8 x float> %b)
+  ret <8 x float> %r
+}
+
+; CHECK: AVX2 intrinsic used, but the subtarget does not support AVX2.
+define <4 x i64> @avx2_without_feature(<32 x i8> %a, <32 x i8> %b) {
+  %r = call <4 x i64> @llvm.x86.avx2.psad.bw(<32 x i8> %a, <32 x i8> %b)
+  ret <4 x i64> %r
+}
+
+; CHECK: x86_amx type used, but the subtarget does not support AMX-TILE.
+define void @amx_without_feature() {
+  %t = call x86_amx @llvm.x86.tilezero.internal(i16 8, i16 8)
+  ret void
+}
+
+; CHECK: 128/256-bit AVX-512 intrinsic used, but the subtarget does not support AVX512VL.
+define <4 x i32> @avx512vl_without_feature(<4 x i32> %a) #0 {
+  %r = call <4 x i32> @llvm.x86.avx512.conflict.d.128(<4 x i32> %a)
+  ret <4 x i32> %r
+}
+
+attributes #0 = { "target-features"="+avx512f" }


### PR DESCRIPTION
Checks that depend on a function's target-cpu/target-features (built into
an MCSubtargetInfo), which the triple-only IR verifier cannot express:

  - x86 intrinsics (llvm.x86.avx/avx2/avx512.*) require AVX/AVX2/AVX-512.
  - 128/256-bit AVX-512 intrinsics additionally require AVX512VL.
  - The x86_amx type requires AMX-TILE.

Stacked above https://github.com/llvm/llvm-project/pull/206166.
