### PR TITLE
[Lanai] Add missing dependencies

### DIFF
--- a/llvm/lib/Target/Lanai/CMakeLists.txt
+++ b/llvm/lib/Target/Lanai/CMakeLists.txt
@@ -38,10 +38,13 @@ add_llvm_target(LanaiCodeGen
   CodeGen
   CodeGenTypes
   Core
+  IRPrinter
   LanaiAsmParser
   LanaiDesc
   LanaiInfo
   MC
+  ObjCARC
+  Scalar
   SelectionDAG
   Support
   Target


### PR DESCRIPTION
For LanaiCodeGenPassBuilder introduced in
016954e1489dbd8daf94baf3372dae2b7f2684e3.