### PR TITLE
[NFC][LLVM] Adopt vector overload types for vp cast intrinsics

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -577,17 +577,25 @@ def llvm_any_vector_float_ty : LLVMAnyType<iAny,
 def llvm_any_scalar_float_ty : LLVMAnyType<iAny,
                                      AnyKindVectorConstraint.Scalar,
                                      AnyKindElementConstraint.Float>;
-// Other overloaded types.
-def llvm_anyvector_ty  : LLVMAnyType<vAny,
-                                     AnyKindVectorConstraint.Vector,
-                                     AnyKindElementConstraint.None>;
 
+// Pointer overload types.
 // Note: CodeGenIntrinsics.cpp seems to check this class to check pointers.
 class LLVMAnyPointerType : LLVMAnyType<pAny,
                                        AnyKindVectorConstraint.Scalar,
                                        AnyKindElementConstraint.Pointer>;
 
+// Any scalar pointer type.
 def llvm_anyptr_ty     : LLVMAnyPointerType;      // ptr addrspace(N)
+
+// Any vector of pointers.
+def llvm_any_vector_ptr_ty : LLVMAnyType<pAny,
+                                       AnyKindVectorConstraint.Vector,
+                                       AnyKindElementConstraint.Pointer>;
+
+// Other overloaded types.
+def llvm_anyvector_ty  : LLVMAnyType<vAny,
+                                     AnyKindVectorConstraint.Vector,
+                                     AnyKindElementConstraint.None>;
 
 def llvm_i1_ty         : LLVMType<i1>;
 def llvm_i8_ty         : LLVMType<i8>;
@@ -2425,58 +2433,58 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable] in {
                              [ LLVMMatchType<0>,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_lrint : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_lrint : DefaultAttrsIntrinsic<[ llvm_any_vector_int_ty ],
+                             [ llvm_any_vector_float_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_llrint : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_llrint : DefaultAttrsIntrinsic<[ llvm_any_vector_int_ty ],
+                             [ llvm_any_vector_float_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
 
   // Casts
-  def int_vp_trunc : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_trunc : DefaultAttrsIntrinsic<[ llvm_any_vector_int_ty ],
+                             [ llvm_any_vector_int_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_zext : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_zext : DefaultAttrsIntrinsic<[ llvm_any_vector_int_ty ],
+                             [ llvm_any_vector_int_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_sext : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_sext : DefaultAttrsIntrinsic<[ llvm_any_vector_int_ty ],
+                             [ llvm_any_vector_int_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_fptrunc : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_fptrunc : DefaultAttrsIntrinsic<[ llvm_any_vector_float_ty ],
+                             [ llvm_any_vector_float_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_fpext : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_fpext : DefaultAttrsIntrinsic<[ llvm_any_vector_float_ty ],
+                             [ llvm_any_vector_float_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_fptoui : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_fptoui : DefaultAttrsIntrinsic<[ llvm_any_vector_int_ty ],
+                             [ llvm_any_vector_float_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_fptosi : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_fptosi : DefaultAttrsIntrinsic<[ llvm_any_vector_int_ty ],
+                             [ llvm_any_vector_float_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_uitofp : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_uitofp : DefaultAttrsIntrinsic<[ llvm_any_vector_float_ty ],
+                             [ llvm_any_vector_int_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_sitofp : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_sitofp : DefaultAttrsIntrinsic<[ llvm_any_vector_float_ty ],
+                             [ llvm_any_vector_int_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_ptrtoint : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_ptrtoint : DefaultAttrsIntrinsic<[ llvm_any_vector_int_ty ],
+                             [ llvm_any_vector_ptr_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_inttoptr : DefaultAttrsIntrinsic<[ llvm_anyvector_ty ],
-                             [ llvm_anyvector_ty,
+  def int_vp_inttoptr : DefaultAttrsIntrinsic<[ llvm_any_vector_ptr_ty ],
+                             [ llvm_any_vector_int_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
   // Shuffles

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -7182,13 +7182,7 @@ void Verifier::visitVPIntrinsic(VPIntrinsic &VPI) {
           *VPCast);
 
     switch (VPCast->getIntrinsicID()) {
-    default:
-      llvm_unreachable("Unknown VP cast intrinsic");
     case Intrinsic::vp_trunc:
-      Check(RetTy->isIntOrIntVectorTy() && ValTy->isIntOrIntVectorTy(),
-            "llvm.vp.trunc intrinsic first argument and result element type "
-            "must be integer",
-            *VPCast);
       Check(RetTy->getScalarSizeInBits() < ValTy->getScalarSizeInBits(),
             "llvm.vp.trunc intrinsic the bit size of first argument must be "
             "larger than the bit size of the return type",
@@ -7196,64 +7190,24 @@ void Verifier::visitVPIntrinsic(VPIntrinsic &VPI) {
       break;
     case Intrinsic::vp_zext:
     case Intrinsic::vp_sext:
-      Check(RetTy->isIntOrIntVectorTy() && ValTy->isIntOrIntVectorTy(),
-            "llvm.vp.zext or llvm.vp.sext intrinsic first argument and result "
-            "element type must be integer",
-            *VPCast);
       Check(RetTy->getScalarSizeInBits() > ValTy->getScalarSizeInBits(),
             "llvm.vp.zext or llvm.vp.sext intrinsic the bit size of first "
             "argument must be smaller than the bit size of the return type",
             *VPCast);
       break;
-    case Intrinsic::vp_fptoui:
-    case Intrinsic::vp_fptosi:
-    case Intrinsic::vp_lrint:
-    case Intrinsic::vp_llrint:
-      Check(
-          RetTy->isIntOrIntVectorTy() && ValTy->isFPOrFPVectorTy(),
-          "llvm.vp.fptoui, llvm.vp.fptosi, llvm.vp.lrint or llvm.vp.llrint" "intrinsic first argument element "
-          "type must be floating-point and result element type must be integer",
-          *VPCast);
-      break;
-    case Intrinsic::vp_uitofp:
-    case Intrinsic::vp_sitofp:
-      Check(
-          RetTy->isFPOrFPVectorTy() && ValTy->isIntOrIntVectorTy(),
-          "llvm.vp.uitofp or llvm.vp.sitofp intrinsic first argument element "
-          "type must be integer and result element type must be floating-point",
-          *VPCast);
-      break;
     case Intrinsic::vp_fptrunc:
-      Check(RetTy->isFPOrFPVectorTy() && ValTy->isFPOrFPVectorTy(),
-            "llvm.vp.fptrunc intrinsic first argument and result element type "
-            "must be floating-point",
-            *VPCast);
       Check(RetTy->getScalarSizeInBits() < ValTy->getScalarSizeInBits(),
             "llvm.vp.fptrunc intrinsic the bit size of first argument must be "
             "larger than the bit size of the return type",
             *VPCast);
       break;
     case Intrinsic::vp_fpext:
-      Check(RetTy->isFPOrFPVectorTy() && ValTy->isFPOrFPVectorTy(),
-            "llvm.vp.fpext intrinsic first argument and result element type "
-            "must be floating-point",
-            *VPCast);
       Check(RetTy->getScalarSizeInBits() > ValTy->getScalarSizeInBits(),
             "llvm.vp.fpext intrinsic the bit size of first argument must be "
             "smaller than the bit size of the return type",
             *VPCast);
       break;
-    case Intrinsic::vp_ptrtoint:
-      Check(RetTy->isIntOrIntVectorTy() && ValTy->isPtrOrPtrVectorTy(),
-            "llvm.vp.ptrtoint intrinsic first argument element type must be "
-            "pointer and result element type must be integer",
-            *VPCast);
-      break;
-    case Intrinsic::vp_inttoptr:
-      Check(RetTy->isPtrOrPtrVectorTy() && ValTy->isIntOrIntVectorTy(),
-            "llvm.vp.inttoptr intrinsic first argument element type must be "
-            "integer and result element type must be pointer",
-            *VPCast);
+    default:
       break;
     }
   }

--- a/llvm/test/Verifier/vp-intrinsics-bad.ll
+++ b/llvm/test/Verifier/vp-intrinsics-bad.ll
@@ -1,0 +1,75 @@
+; RUN: not opt -passes=verify --disable-output %s 2>&1 | FileCheck %s
+
+
+; Casts
+; CHECK: intrinsic return type (overload type 0) expected any integer vector, but got <8 x float>
+; CHECK-NEXT: declare <8 x float> @llvm.vp.fptoui.v8f32.v8f32(<8 x float>, <8 x i1>, i32)
+declare <8 x float> @llvm.vp.fptoui.v8f32.v8f32(<8 x float>, <8 x i1>, i32)
+
+; CHECK: intrinsic argument 0 type (overload type 1) expected any fp vector, but got <8 x i32>
+; CHECK-NEXT: declare <8 x i32> @llvm.vp.fptoui.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+declare <8 x i32> @llvm.vp.fptoui.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+
+; CHECK: intrinsic return type (overload type 0) expected any integer vector, but got <8 x float>
+; CHECK-NEXT: declare <8 x float> @llvm.vp.fptosi.v8f32.v8f32(<8 x float>, <8 x i1>, i32)
+declare <8 x float> @llvm.vp.fptosi.v8f32.v8f32(<8 x float>, <8 x i1>, i32)
+
+; CHECK: intrinsic argument 0 type (overload type 1) expected any fp vector, but got <8 x i32>
+; CHECK-NEXT: declare <8 x i32> @llvm.vp.fptosi.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+declare <8 x i32> @llvm.vp.fptosi.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+
+; CHECK: intrinsic return type (overload type 0) expected any fp vector, but got <8 x i32>
+; CHECK-NEXT: declare <8 x i32> @llvm.vp.uitofp.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+declare <8 x i32> @llvm.vp.uitofp.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+
+; CHECK: intrinsic argument 0 type (overload type 1) expected any integer vector, but got <8 x float>
+; CHECK-NEXT: declare <8 x float> @llvm.vp.uitofp.v8f32.v8f32(<8 x float>, <8 x i1>, i32)
+declare <8 x float> @llvm.vp.uitofp.v8f32.v8f32(<8 x float>, <8 x i1>, i32)
+
+; CHECK: intrinsic return type (overload type 0) expected any fp vector, but got <8 x i32>
+; CHECK-NEXT: declare <8 x i32> @llvm.vp.sitofp.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+declare <8 x i32> @llvm.vp.sitofp.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+
+; CHECK: intrinsic argument 0 type (overload type 1) expected any integer vector, but got <8 x float>
+; CHECK-NEXT: declare <8 x float> @llvm.vp.sitofp.v8f32.v8f32(<8 x float>, <8 x i1>, i32)
+declare <8 x float> @llvm.vp.sitofp.v8f32.v8f32(<8 x float>, <8 x i1>, i32)
+
+; CHECK: intrinsic return type (overload type 0) expected any fp vector, but got <8 x i32>
+; CHECK-NEXT: declare <8 x i32> @llvm.vp.fptrunc.v8i32.v8f64(<8 x double>, <8 x i1>, i32)
+declare <8 x i32> @llvm.vp.fptrunc.v8i32.v8f64(<8 x double>, <8 x i1>, i32)
+
+; CHECK: intrinsic argument 0 type (overload type 1) expected any fp vector, but got <8 x i32>
+; CHECK-NEXT: declare <8 x double> @llvm.vp.fpext.v8f64.v8i32(<8 x i32>, <8 x i1>, i32)
+declare <8 x double> @llvm.vp.fpext.v8f64.v8i32(<8 x i32>, <8 x i1>, i32)
+
+; CHECK: intrinsic return type (overload type 0) expected any integer vector, but got <8 x float>
+; CHECK-NEXT: declare <8 x float> @llvm.vp.trunc.v8i32.v8i64(<8 x i64>, <8 x i1>, i32)
+declare <8 x float> @llvm.vp.trunc.v8i32.v8i64(<8 x i64>, <8 x i1>, i32)
+
+; CHECK: intrinsic argument 0 type (overload type 1) expected any integer vector, but got <8 x float>
+; CHECK-NEXT: declare <8 x i64> @llvm.vp.zext.v8i64.v8f32(<8 x float>, <8 x i1>, i32)
+declare <8 x i64> @llvm.vp.zext.v8i64.v8f32(<8 x float>, <8 x i1>, i32)
+
+; CHECK: intrinsic return type (overload type 0) expected any integer vector, but got <8 x double>
+; CHECK-NEXT: declare <8 x double> @llvm.vp.sext.v8f64.v8i32(<8 x i32>, <8 x i1>, i32)
+declare <8 x double> @llvm.vp.sext.v8f64.v8i32(<8 x i32>, <8 x i1>, i32)
+
+; CHECK: intrinsic argument 0 type (overload type 1) expected any pointer vector, but got <8 x i32>
+; CHECK-NEXT: declare <8 x i32> @llvm.vp.ptrtoint.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+declare <8 x i32> @llvm.vp.ptrtoint.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+
+; CHECK: intrinsic argument 0 type (overload type 1) expected any pointer vector, but got ptr
+; CHECK-NEXT: declare <8 x i32> @llvm.vp.ptrtoint.v8i32.p0(ptr, <8 x i1>, i32)
+declare <8 x i32> @llvm.vp.ptrtoint.v8i32.p0(ptr, <8 x i1>, i32)
+
+; CHECK: intrinsic return type (overload type 0) expected any pointer vector, but got ptr
+; CHECK-NEXT: declare ptr @llvm.vp.inttoptr.p0.v8i32(<8 x i32>, <8 x i1>, i32)
+declare ptr @llvm.vp.inttoptr.p0.v8i32(<8 x i32>, <8 x i1>, i32)
+
+; CHECK: intrinsic return type (overload type 0) expected any pointer vector, but got <8 x i32>
+; CHECK-NEXT: declare <8 x i32> @llvm.vp.inttoptr.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+declare <8 x i32>  @llvm.vp.inttoptr.v8i32.v8i32(<8 x i32>, <8 x i1>, i32)
+
+; CHECK: intrinsic argument 1 type (same vector width of overload type 0) expected vector with 7 elements (overload type 0 is <7 x ptr>), but got <8 x i1>
+; CHECK-NEXT: declare <7 x ptr> @llvm.vp.inttoptr.v7p0.v8i32(<8 x i32>, <8 x i1>, i32)
+declare <7 x ptr>  @llvm.vp.inttoptr.v7p0.v8i32(<8 x i32>, <8 x i1>, i32)


### PR DESCRIPTION
Adopt float/int vector overload types in vp cast intrinsics. Also add `llvm_any_vector_ptr_ty` for any vector of pointers and adopt it as well in the `vp.ptrtoint` and `vp.inttoptrr` intrinsics.