### PR TITLE
[mlir-c] Add mlirDialectMaterializeConstant

### DIFF
--- a/mlir/include/mlir-c/Rewrite.h
+++ b/mlir/include/mlir-c/Rewrite.h
@@ -330,6 +330,19 @@ mlirIRRewriterCreateFromOp(MlirOperation op);
 MLIR_CAPI_EXPORTED void mlirIRRewriterDestroy(MlirRewriterBase rewriter);
 
 //===----------------------------------------------------------------------===//
+/// Dialect constant materialization API
+//===----------------------------------------------------------------------===//
+
+/// Materializes a constant for the given attribute `value` and `type` using the
+/// dialect's `materializeConstant` hook. The operation is created with the
+/// given rewriter (used as an OpBuilder) at its current insertion point,
+/// without changing that insertion point. Returns a null operation if the
+/// dialect does not support materializing the given constant.
+MLIR_CAPI_EXPORTED MlirOperation mlirDialectMaterializeConstant(
+    MlirDialect dialect, MlirRewriterBase rewriter, MlirAttribute value,
+    MlirType type, MlirLocation loc);
+
+//===----------------------------------------------------------------------===//
 /// FrozenRewritePatternSet API
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -279,6 +279,18 @@ void mlirIRRewriterDestroy(MlirRewriterBase rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
+/// Dialect constant materialization API
+//===----------------------------------------------------------------------===//
+
+MlirOperation mlirDialectMaterializeConstant(MlirDialect dialect,
+                                             MlirRewriterBase rewriter,
+                                             MlirAttribute value, MlirType type,
+                                             MlirLocation loc) {
+  return wrap(unwrap(dialect)->materializeConstant(
+      *unwrap(rewriter), unwrap(value), unwrap(type), unwrap(loc)));
+}
+
+//===----------------------------------------------------------------------===//
 /// RewritePatternSet and FrozenRewritePatternSet API
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/CAPI/rewrite.c
+++ b/mlir/test/CAPI/rewrite.c
@@ -10,8 +10,10 @@
 // RUN: mlir-capi-rewrite-test 2>&1 | FileCheck %s
 
 #include "mlir-c/Rewrite.h"
+#include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/BuiltinTypes.h"
 #include "mlir-c/IR.h"
+#include "mlir-c/RegisterEverything.h"
 
 #include <assert.h>
 #include <inttypes.h>
@@ -802,6 +804,57 @@ void testConversionTargetDynamicLegality(MlirContext ctx) {
   fprintf(stderr, "testConversionTargetDynamicLegality: PASSED\n");
 }
 
+void testDialectMaterializeConstant(MlirContext ctx) {
+  // CHECK-LABEL: @testDialectMaterializeConstant
+  fprintf(stderr, "@testDialectMaterializeConstant\n");
+
+  MlirDialectRegistry registry = mlirDialectRegistryCreate();
+  mlirRegisterAllDialects(registry);
+  mlirContextAppendDialectRegistry(ctx, registry);
+  mlirDialectRegistryDestroy(registry);
+
+  MlirDialect arith =
+      mlirContextGetOrLoadDialect(ctx, mlirStringRefCreateFromCString("arith"));
+  mlirContextGetOrLoadDialect(ctx, mlirStringRefCreateFromCString("func"));
+
+  const char *moduleString = "func.func @f() {\n"
+                             "  return\n"
+                             "}\n";
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(moduleString));
+  MlirBlock body = mlirModuleGetBody(module);
+  MlirOperation funcOp = mlirBlockGetFirstOperation(body);
+  MlirRegion funcRegion = mlirOperationGetRegion(funcOp, 0);
+  MlirBlock funcBody = mlirRegionGetFirstBlock(funcRegion);
+
+  MlirRewriterBase rewriter = mlirIRRewriterCreate(ctx);
+  mlirRewriterBaseSetInsertionPointToStart(rewriter, funcBody);
+
+  // Materialize an i32 constant of value 42 using the arith dialect's hook.
+  MlirType i32 = mlirIntegerTypeGet(ctx, 32);
+  MlirAttribute value = mlirIntegerAttrGet(i32, 42);
+  MlirLocation loc = mlirLocationUnknownGet(ctx);
+  MlirOperation constOp =
+      mlirDialectMaterializeConstant(arith, rewriter, value, i32, loc);
+  assert(!mlirOperationIsNull(constOp));
+  mlirOperationDump(constOp);
+  // CHECK: arith.constant 42 : i32
+
+  // A dialect that does not materialize the given constant returns null. The
+  // func dialect has no constant materializer, so it returns a null operation.
+  MlirDialect func =
+      mlirContextGetOrLoadDialect(ctx, mlirStringRefCreateFromCString("func"));
+  MlirOperation none =
+      mlirDialectMaterializeConstant(func, rewriter, value, i32, loc);
+  assert(mlirOperationIsNull(none));
+
+  mlirIRRewriterDestroy(rewriter);
+  mlirModuleDestroy(module);
+
+  // CHECK: testDialectMaterializeConstant: PASSED
+  fprintf(stderr, "testDialectMaterializeConstant: PASSED\n");
+}
+
 int main(void) {
   MlirContext ctx = mlirContextCreate();
   mlirContextSetAllowUnregisteredDialects(ctx, true);
@@ -818,6 +871,7 @@ int main(void) {
   testGreedyRewriteDriverConfig(ctx);
   testCloneWithMapping(ctx);
   testConversionTargetDynamicLegality(ctx);
+  testDialectMaterializeConstant(ctx);
 
   mlirContextDestroy(ctx);
   return 0;


### PR DESCRIPTION
Exposes `Dialect::materializeConstant` through the MLIR C API, letting callers ask a dialect to build a constant operation for a given attribute and type.

## Changes

`mlir/include/mlir-c/Rewrite.h` / `mlir/lib/CAPI/Transforms/Rewrite.cpp`:
- `mlirDialectMaterializeConstant(dialect, rewriter, value, type, loc)` — wraps `Dialect::materializeConstant`, using the rewriter as the `OpBuilder` (creating the op at its current insertion point without changing it). Returns a null operation if the dialect has no constant materializer for the given inputs.

The dialect is passed explicitly (rather than derived from the type/attribute): `materializeConstant` is a `Dialect` method, and e.g. an `i32` attribute belongs to the builtin dialect while the desired constant op (`arith.constant`) belongs to arith. This binding lives in `Rewrite.h` because it needs `MlirRewriterBase` (the only C handle that maps to an `OpBuilder`).

## Tests

`mlir/test/CAPI/rewrite.c` adds `testDialectMaterializeConstant`: materializes an `i32` constant `42` via the arith dialect and checks the resulting `arith.constant`, and verifies that a dialect without a constant materializer (func) returns a null operation.

The full `mlir-capi-rewrite-test` suite passes under FileCheck.