### PR TITLE
[BOLT] Implement platform independent distribution and shuffle algorithm

### DIFF
--- a/bolt/lib/Passes/SplitFunctions.cpp
+++ b/bolt/lib/Passes/SplitFunctions.cpp
@@ -582,6 +582,29 @@ private:
   }
 };
 
+// std::uniform_int_distribution and std::shuffle are implementation-defined:
+// libstdc++ and libc++ produce different sequences from the same engine and
+// seed. The helpers below provide reproducible alternatives so that random
+// splitting is deterministic across C++ standard library implementations (and
+// therefore across host platforms) for a given --bolt-seed.
+
+// Draw a value uniformly from the inclusive range [Lo, Hi].
+template <typename DiffT, typename GenT>
+static DiffT portableUniform(GenT &Gen, DiffT Lo, DiffT Hi) {
+  assert(Hi >= Lo && "Empty range");
+  const uint64_t Range = static_cast<uint64_t>(Hi - Lo) + 1;
+  const uint64_t Draw = static_cast<uint64_t>(Gen()) - GenT::min();
+  return Lo + static_cast<DiffT>(Draw % Range);
+}
+
+// Fisher-Yates shuffle using portableUniform for index selection.
+template <typename It, typename GenT>
+static void portableShuffle(It First, It Last, GenT &Gen) {
+  using DiffT = typename std::iterator_traits<It>::difference_type;
+  for (DiffT I = (Last - First) - 1; I > 0; --I)
+    std::swap(First[I], First[portableUniform<DiffT>(Gen, 0, I)]);
+}
+
 struct SplitRandom2 final : public SplitStrategy {
   std::minstd_rand0 Gen;
 
@@ -598,8 +621,7 @@ struct SplitRandom2 final : public SplitStrategy {
 
     // We want to split at least one block
     const auto LastSplitPoint = std::max<DiffT>(NumBlocks - 1, 1);
-    std::uniform_int_distribution<DiffT> Dist(1, LastSplitPoint);
-    const DiffT SplitPoint = Dist(Gen);
+    const DiffT SplitPoint = portableUniform<DiffT>(Gen, 1, LastSplitPoint);
     for (BinaryBasicBlock *BB : llvm::make_range(Start + SplitPoint, End))
       BB->setFragmentNum(FragmentNum::cold());
 
@@ -628,16 +650,16 @@ struct SplitRandomN final : public SplitStrategy {
     // We want to generate at least two fragment if possible, but if there is
     // only one block, no splits are possible.
     const auto MinimumSplits = std::min<DiffT>(MaximumSplits, 1);
-    std::uniform_int_distribution<DiffT> Dist(MinimumSplits, MaximumSplits);
     // Choose how many splits to perform
-    const DiffT NumSplits = Dist(Gen);
+    const DiffT NumSplits =
+        portableUniform<DiffT>(Gen, MinimumSplits, MaximumSplits);
 
     // Draw split points from a lottery
     SmallVector<unsigned, 0> Lottery(MaximumSplits);
     // Start lottery at 1, because there is no meaningful splitpoint before the
     // first block.
     std::iota(Lottery.begin(), Lottery.end(), 1u);
-    std::shuffle(Lottery.begin(), Lottery.end(), Gen);
+    portableShuffle(Lottery.begin(), Lottery.end(), Gen);
     Lottery.resize(NumSplits);
     llvm::sort(Lottery);
 

--- a/bolt/test/X86/register-fragments-bolt-symbols.s
+++ b/bolt/test/X86/register-fragments-bolt-symbols.s
@@ -20,11 +20,12 @@
 # CHECK-FDATA-WARM: chain
 # CHECK-YAML-WARM: chain
 
-# RUN: sed -i 's|chain|chain/2|g' %t.fdata
+# RUN: sed 's|chain|chain/2|g' %t.fdata > %t.fdata.tmp
+# RUN: mv %t.fdata.tmp %t.fdata
 # RUN: llvm-objcopy --localize-symbol=chain %t.main.o
 # RUN: %clang %cflags %t.chain.o %t.main.o -o %t.exe -Wl,-q
 # RUN: llvm-bolt %t.exe -o %t.bolt --split-functions --split-strategy=randomN \
-# RUN:   --reorder-blocks=ext-tsp --enable-bat --bolt-seed=7 --data=%t.fdata
+# RUN:   --reorder-blocks=ext-tsp --enable-bat --bolt-seed=20 --data=%t.fdata
 # RUN: llvm-objdump --syms %t.bolt | FileCheck %s --check-prefix=CHECK-SYMS
 
 # RUN: link_fdata %s %t.bolt %t.preagg PREAGG
@@ -40,21 +41,32 @@
 # RUN: perf2bolt %t.bolt -p %t.preagg2 --pa -o %t.bat2.fdata -w %t.bat2.yaml
 # RUN: FileCheck %s --input-file %t.bat2.yaml --check-prefix=CHECK-YAML2
 
-# CHECK-SYMS: l df *ABS*          [[#]] chain.s
-# CHECK-SYMS: l  F .bolt.org.text [[#]] chain
-# CHECK-SYMS: l  F .text.cold     [[#]] chain.cold.0
-# CHECK-SYMS: l  F .text          [[#]] chain
-# CHECK-SYMS: l df *ABS*          [[#]] bolt-pseudo.o
-# CHECK-SYMS: l  F .text.cold     [[#]] dummy.cold.0
-# CHECK-SYMS: l  F .text.cold.1   [[#]] dummy.cold.1
-# CHECK-SYMS: l  F .text.cold.2   [[#]] dummy.cold.2
+## With --bolt-seed=20 the randomN strategy splits chain into eight cold
+## fragments and dummy into two. The split is now deterministic across C++
+## standard library implementations, so we can match the fragments exactly.
+# CHECK-SYMS: l df *ABS*          {{[0-9a-f]+}} chain.s
+# CHECK-SYMS: l  F .bolt.org.text {{[0-9a-f]+}} chain
+# CHECK-SYMS: l  F .text.cold     {{[0-9a-f]+}} chain.cold.0
+# CHECK-SYMS: l  F .text.cold.1   {{[0-9a-f]+}} chain.cold.1
+# CHECK-SYMS: l  F .text.cold.2   {{[0-9a-f]+}} chain.cold.2
+# CHECK-SYMS: l  F .text.cold.3   {{[0-9a-f]+}} chain.cold.3
+# CHECK-SYMS: l  F .text.cold.4   {{[0-9a-f]+}} chain.cold.4
+# CHECK-SYMS: l  F .text.cold.5   {{[0-9a-f]+}} chain.cold.5
+# CHECK-SYMS: l  F .text.cold.6   {{[0-9a-f]+}} chain.cold.6
+# CHECK-SYMS: l  F .text.cold.7   {{[0-9a-f]+}} chain.cold.7
+# CHECK-SYMS: l  F .text          {{[0-9a-f]+}} chain
+# CHECK-SYMS: l df *ABS*          {{[0-9a-f]+}} bolt-pseudo.o
+# CHECK-SYMS: l  F .text.cold     {{[0-9a-f]+}} dummy.cold.0
+# CHECK-SYMS: l  F .text.cold.1   {{[0-9a-f]+}} dummy.cold.1
 
 # CHECK-REGISTER: BOLT-INFO: marking dummy.cold.0/1(*2) as a fragment of dummy
 # CHECK-REGISTER: BOLT-INFO: marking dummy.cold.1/1(*2) as a fragment of dummy
-# CHECK-REGISTER: BOLT-INFO: marking dummy.cold.2/1(*2) as a fragment of dummy
 # CHECK-REGISTER: BOLT-INFO: marking chain.cold.0/1(*2) as a fragment of chain/2(*2)
+# CHECK-REGISTER: BOLT-INFO: marking chain.cold.1/1(*2) as a fragment of chain/2(*2)
+# CHECK-REGISTER: BOLT-INFO: marking chain.cold.2/1(*2) as a fragment of chain/2(*2)
+# CHECK-REGISTER: BOLT-INFO: marking chain.cold.3/1(*2) as a fragment of chain/2(*2)
 
-# CHECK-FDATA: 0 [unknown] 0 1 chain/chain.s/2 10 0 1
+# CHECK-FDATA: 0 [unknown] 0 1 chain/chain.s/2 9 0 1
 # CHECK-YAML: - name: 'chain/chain.s/2'
 # CHECK-YAML2: - name: 'chain/chain.s/1'
 ## non-BAT function has non-zero insns:


### PR DESCRIPTION
std::uniform_int_distribution and std::shuffle are implementation-defined, so binary built with libc++ and libstdc++ can produce different fragment layouts when using SplitStrategy. In this case, the FreeBSD build emits only one fragment instead of three.

The output geenrate by --bolt-seed should be deterministic for the same binary regardless of the standard library implementation. Implement a portable shuffle and uniform distribution to guarantee identical results for a given seed.

After this change, we generate 1 fragment, which decrease the strength of the testcase. As a result, we change the seed to different value to allow it generate different number of fragments.

Also, replace in-place file modifcation with a write-and-replace approach for better portability in sed.