### PR TITLE
[mlir-c] Add mlirOperationTryFold

### DIFF
--- a/mlir/include/mlir-c/Rewrite.h
+++ b/mlir/include/mlir-c/Rewrite.h
@@ -330,6 +330,25 @@ mlirIRRewriterCreateFromOp(MlirOperation op);
 MLIR_CAPI_EXPORTED void mlirIRRewriterDestroy(MlirRewriterBase rewriter);
 
 //===----------------------------------------------------------------------===//
+/// Folding API
+//===----------------------------------------------------------------------===//
+
+/// Attempts to fold the given operation using the given rewriter (as an
+/// OpBuilder). On a successful fold the operation is NOT erased; the folded
+/// values are written into the caller-allocated `results` buffer, up to
+/// `maxResults` entries, and the total number of results is returned. An
+/// in-place fold succeeds with no results and returns 0. A negative return
+/// value indicates the operation could not be folded.
+///
+/// This is the C counterpart of OpBuilder::createOrFold split in two steps:
+/// create the operation, then call mlirOperationTryFold; on a non-negative
+/// result use the folded values and erase the operation.
+MLIR_CAPI_EXPORTED intptr_t mlirOperationTryFold(MlirRewriterBase rewriter,
+                                                 MlirOperation op,
+                                                 intptr_t maxResults,
+                                                 MlirValue *results);
+
+//===----------------------------------------------------------------------===//
 /// FrozenRewritePatternSet API
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -279,6 +279,21 @@ void mlirIRRewriterDestroy(MlirRewriterBase rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
+/// Folding API
+//===----------------------------------------------------------------------===//
+
+intptr_t mlirOperationTryFold(MlirRewriterBase rewriter, MlirOperation op,
+                              intptr_t maxResults, MlirValue *results) {
+  SmallVector<Value> foldResults;
+  if (failed(unwrap(rewriter)->tryFold(unwrap(op), foldResults)))
+    return -1;
+  intptr_t n = static_cast<intptr_t>(foldResults.size());
+  for (intptr_t i = 0; i < n && i < maxResults; ++i)
+    results[i] = wrap(foldResults[i]);
+  return n;
+}
+
+//===----------------------------------------------------------------------===//
 /// RewritePatternSet and FrozenRewritePatternSet API
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/CAPI/rewrite.c
+++ b/mlir/test/CAPI/rewrite.c
@@ -12,6 +12,7 @@
 #include "mlir-c/Rewrite.h"
 #include "mlir-c/BuiltinTypes.h"
 #include "mlir-c/IR.h"
+#include "mlir-c/RegisterEverything.h"
 
 #include <assert.h>
 #include <inttypes.h>
@@ -802,6 +803,55 @@ void testConversionTargetDynamicLegality(MlirContext ctx) {
   fprintf(stderr, "testConversionTargetDynamicLegality: PASSED\n");
 }
 
+void testOperationTryFold(MlirContext ctx) {
+  // CHECK-LABEL: @testOperationTryFold
+  fprintf(stderr, "@testOperationTryFold\n");
+
+  MlirDialectRegistry registry = mlirDialectRegistryCreate();
+  mlirRegisterAllDialects(registry);
+  mlirContextAppendDialectRegistry(ctx, registry);
+  mlirDialectRegistryDestroy(registry);
+  mlirContextGetOrLoadDialect(ctx, mlirStringRefCreateFromCString("arith"));
+  mlirContextGetOrLoadDialect(ctx, mlirStringRefCreateFromCString("func"));
+
+  const char *moduleString = "func.func @f(%arg0: i32) -> i32 {\n"
+                             "  %c2 = arith.constant 2 : i32\n"
+                             "  %c3 = arith.constant 3 : i32\n"
+                             "  %sum = arith.addi %c2, %c3 : i32\n"
+                             "  %dyn = arith.addi %arg0, %arg0 : i32\n"
+                             "  return %sum : i32\n"
+                             "}\n";
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(moduleString));
+  MlirBlock body = mlirModuleGetBody(module);
+  MlirOperation funcOp = mlirBlockGetFirstOperation(body);
+  MlirRegion funcRegion = mlirOperationGetRegion(funcOp, 0);
+  MlirBlock funcBody = mlirRegionGetFirstBlock(funcRegion);
+  MlirOperation c2Op = mlirBlockGetFirstOperation(funcBody);
+  MlirOperation c3Op = mlirOperationGetNextInBlock(c2Op);
+  MlirOperation sumOp = mlirOperationGetNextInBlock(c3Op);
+  MlirOperation dynOp = mlirOperationGetNextInBlock(sumOp);
+
+  MlirRewriterBase rewriter = mlirIRRewriterCreate(ctx);
+  mlirRewriterBaseSetInsertionPointAfter(rewriter, dynOp);
+
+  // `addi 2, 3` has constant operands and folds to a single constant value.
+  MlirValue results[1];
+  intptr_t n = mlirOperationTryFold(rewriter, sumOp, 1, results);
+  assert(n == 1);
+  assert(!mlirValueIsNull(results[0]));
+
+  // `addi %arg0, %arg0` is not constant-foldable: tryFold reports failure.
+  intptr_t failed = mlirOperationTryFold(rewriter, dynOp, 1, results);
+  assert(failed < 0);
+
+  mlirIRRewriterDestroy(rewriter);
+  mlirModuleDestroy(module);
+
+  // CHECK: testOperationTryFold: PASSED
+  fprintf(stderr, "testOperationTryFold: PASSED\n");
+}
+
 int main(void) {
   MlirContext ctx = mlirContextCreate();
   mlirContextSetAllowUnregisteredDialects(ctx, true);
@@ -818,6 +868,7 @@ int main(void) {
   testGreedyRewriteDriverConfig(ctx);
   testCloneWithMapping(ctx);
   testConversionTargetDynamicLegality(ctx);
+  testOperationTryFold(ctx);
 
   mlirContextDestroy(ctx);
   return 0;


### PR DESCRIPTION
Exposes `OpBuilder::tryFold` through the MLIR C API, the building block for a `createOrFold`-style flow.

## Changes

`mlir/include/mlir-c/Rewrite.h` / `mlir/lib/CAPI/Transforms/Rewrite.cpp`:
- `mlirOperationTryFold(rewriter, op, maxResults, results)` — wraps `OpBuilder::tryFold` (via the rewriter). On success the operation is **not** erased; the folded values are written into the caller-allocated `results` buffer (up to `maxResults`) and the total result count is returned. An in-place fold returns 0; a negative return value indicates the op could not be folded.

Lives in `Rewrite.h` because it needs `MlirRewriterBase` (the C handle for an `OpBuilder`). Results use the caller-buffer + returned-count convention.

## Tests

`mlir/test/CAPI/rewrite.c` adds `testOperationTryFold`: folding `arith.addi 2, 3` yields one constant result, while `arith.addi %arg0, %arg0` (non-constant) reports failure.

The full `mlir-capi-rewrite-test` suite passes under FileCheck.