### PR TITLE
[mlir-c] Add mlirOperationIsAncestor and mlirOperationIsProperAncestor

### DIFF
--- a/mlir/include/mlir-c/IR.h
+++ b/mlir/include/mlir-c/IR.h
@@ -667,6 +667,16 @@ MLIR_CAPI_EXPORTED MlirBlock mlirOperationGetBlock(MlirOperation op);
 MLIR_CAPI_EXPORTED MlirOperation
 mlirOperationGetParentOperation(MlirOperation op);
 
+/// Returns true if `a` is an ancestor of `b`, i.e. `a` contains `b` or
+/// `a == b`.
+MLIR_CAPI_EXPORTED bool mlirOperationIsAncestor(MlirOperation a,
+                                                MlirOperation b);
+
+/// Returns true if `a` is a proper ancestor of `b`, i.e. `a` contains `b` but
+/// `a != b`.
+MLIR_CAPI_EXPORTED bool mlirOperationIsProperAncestor(MlirOperation a,
+                                                      MlirOperation b);
+
 /// Returns the number of regions attached to the given operation.
 MLIR_CAPI_EXPORTED intptr_t mlirOperationGetNumRegions(MlirOperation op);
 

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -692,6 +692,14 @@ MlirOperation mlirOperationGetParentOperation(MlirOperation op) {
   return wrap(unwrap(op)->getParentOp());
 }
 
+bool mlirOperationIsAncestor(MlirOperation a, MlirOperation b) {
+  return unwrap(a)->isAncestor(unwrap(b));
+}
+
+bool mlirOperationIsProperAncestor(MlirOperation a, MlirOperation b) {
+  return unwrap(a)->isProperAncestor(unwrap(b));
+}
+
 intptr_t mlirOperationGetNumRegions(MlirOperation op) {
   return static_cast<intptr_t>(unwrap(op)->getNumRegions());
 }

--- a/mlir/test/CAPI/ir.c
+++ b/mlir/test/CAPI/ir.c
@@ -2900,6 +2900,45 @@ int testDominanceInfo(MlirContext ctx) {
   return 0;
 }
 
+int testOperationIsAncestor(MlirContext ctx) {
+  fprintf(stderr, "@testOperationIsAncestor\n");
+  // CHECK-LABEL: @testOperationIsAncestor
+
+  mlirContextGetOrLoadDialect(ctx, mlirStringRefCreateFromCString("arith"));
+
+  const char *moduleStr = "func.func @f() {\n"
+                          "  %c0 = arith.constant 0 : i32\n"
+                          "  return\n"
+                          "}\n";
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(moduleStr));
+  MlirOperation moduleOp = mlirModuleGetOperation(module);
+  MlirBlock moduleBody = mlirModuleGetBody(module);
+  MlirOperation funcOp = mlirBlockGetFirstOperation(moduleBody);
+  MlirRegion funcRegion = mlirOperationGetRegion(funcOp, 0);
+  MlirBlock funcBody = mlirRegionGetFirstBlock(funcRegion);
+  MlirOperation constOp = mlirBlockGetFirstOperation(funcBody);
+
+  // The module and the func both (properly) contain the constant.
+  assert(mlirOperationIsAncestor(moduleOp, constOp));
+  assert(mlirOperationIsProperAncestor(moduleOp, constOp));
+  assert(mlirOperationIsAncestor(funcOp, constOp));
+  assert(mlirOperationIsProperAncestor(funcOp, constOp));
+
+  // An operation is its own ancestor, but not its own proper ancestor.
+  assert(mlirOperationIsAncestor(constOp, constOp));
+  assert(!mlirOperationIsProperAncestor(constOp, constOp));
+
+  // The containment relation is not symmetric.
+  assert(!mlirOperationIsAncestor(constOp, moduleOp));
+
+  mlirModuleDestroy(module);
+
+  // CHECK: testOperationIsAncestor: PASSED
+  fprintf(stderr, "testOperationIsAncestor: PASSED\n");
+  return 0;
+}
+
 int main(void) {
   MlirContext ctx = mlirContextCreate();
   registerAllUpstreamDialects(ctx);
@@ -2955,6 +2994,8 @@ int main(void) {
     return 19;
   if (testDominanceInfo(ctx))
     return 20;
+  if (testOperationIsAncestor(ctx))
+    return 21;
 
   // CHECK: DESTROY MAIN CONTEXT
   // CHECK: reportResourceDelete: resource_i64_blob


### PR DESCRIPTION
Exposes `Operation::isAncestor` and `Operation::isProperAncestor` through the MLIR C API.

## Changes

`mlir/include/mlir-c/IR.h` / `mlir/lib/CAPI/IR/IR.cpp`:
- `mlirOperationIsAncestor(a, b)` — true if `a` contains `b` or `a == b`.
- `mlirOperationIsProperAncestor(a, b)` — true if `a` contains `b` but `a != b`.

## Tests

`mlir/test/CAPI/ir.c` adds `testOperationIsAncestor`: the enclosing module and func are (proper) ancestors of a nested constant; an operation is its own ancestor but not its own proper ancestor; and the relation is not symmetric.

The full `mlir-capi-ir-test` suite passes under FileCheck.