### PR TITLE
[PGO] Fix malformed raw profile test

### DIFF
--- a/llvm/test/tools/llvm-profdata/malformed-ptr-to-counter-array.test
+++ b/llvm/test/tools/llvm-profdata/malformed-ptr-to-counter-array.test
@@ -62,7 +62,6 @@ RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\02\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw
-RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw
 
 // Counter Section
 


### PR DESCRIPTION
PR #190708 added a uniform counter pointer to the raw profile data record, but a hand-written raw profile test gained one extra zero word in the record.

Remove the extra word so the name section starts at the offset expected by the reader. This fixes the regression while keeping the test focused on the malformed counter pointer.

Buildbot failure: https://lab.llvm.org/buildbot/#/builders/24/builds/21581

Test:

```
~/git/scripts_shared/scripts/llvm/llvm-dev.sh llvm test llvm/test/tools/llvm-profdata/malformed-ptr-to-counter-array.test
```
