### PR TITLE
[CIR] Skip int_to_bool when value is already bool

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -442,6 +442,12 @@ public:
   }
 
   mlir::Value emitIntToBoolConversion(mlir::Value srcVal, mlir::Location loc) {
+    // The enumerator of an enum with an integral underlying type is lowered to
+    // that type, which can be bool.  In that case the operand is already a
+    // !cir.bool, so return it -- int_to_bool requires a !cir.int source.
+    if (mlir::isa<cir::BoolType>(srcVal.getType()))
+      return srcVal;
+
     // Because of the type rules of C, we often end up computing a
     // logical value, then zero extending it to int, then wanting it
     // as a logical value again.

--- a/clang/test/CIR/CodeGen/enum-bool.cpp
+++ b/clang/test/CIR/CodeGen/enum-bool.cpp
@@ -33,3 +33,14 @@ void storeEnum(BoolEnum *p, BoolEnum v) { *p = v; }
 // LLVM:         store i8 %{{.*}}, ptr %{{.*}}, align 1
 // LLVM:         load i8, ptr %{{.*}}, align 1
 // LLVM:         store i8 %{{.*}}, ptr %{{.*}}, align 1
+
+bool toBool(BoolEnum e) { return static_cast<bool>(e); }
+
+// CIR-LABEL: cir.func{{.*}} @_Z6toBool8BoolEnum(%arg0: !cir.bool
+// CIR-SAME:    -> (!cir.bool
+// CIR:         cir.load {{.*}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR-NOT:     cir.cast int_to_bool
+// CIR:         cir.return
+
+// LLVM-LABEL: define dso_local noundef {{(zeroext )?}}i1 @_Z6toBool8BoolEnum(i1 noundef {{(zeroext )?}}%{{.*}})
+// LLVM:         ret i1 %{{.*}}


### PR DESCRIPTION
A conversion to bool from a type whose representation is already boolean --
most commonly an enum with a `bool` underlying type -- reaches
`emitIntToBoolConversion`, which always emits `cir.cast int_to_bool`.  Since
[#205880](https://github.com/llvm/llvm-project/pull/205880) made such enums
load as `!cir.bool`, that cast now receives a `!cir.bool` source and the
`int_to_bool` verifier (which requires a `!cir.int` source) rejects the
module.  It shows up across the libcxx `std/` hash tests, whose shared
`poisoned_hash_helper.h` hashes an `enum : bool` by `static_cast`-ing it to
its underlying type.

The fix returns the value unchanged when it is already `!cir.bool`: a boolean
is its own truth value, so no conversion is needed.  The guard sits in
`emitIntToBoolConversion`, the choke point shared by the
`CK_IntegralToBoolean` cast path and the integer branch of
`emitConversionToBool`.  This is the cast-side companion to
[#205880](https://github.com/llvm/llvm-project/pull/205880), which handled
the load side.

`enum-bool.cpp` gains a `static_cast<bool>` case checked across CIR, the
CIR-lowered LLVM, and classic codegen.
