### PR TITLE
[mlir][dataflow] Handle call operands to callees with unknown callers

### DIFF
--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -525,18 +525,28 @@ AbstractSparseBackwardDataFlowAnalysis::visitOperation(Operation *op) {
         return success();
       }
 
-      // Otherwise, propagate information from the entry point of the function
-      // back to operands whenever possible.
-      Block &block = region->front();
-      for (auto [blockArg, argOpOperand] :
-           llvm::zip(block.getArguments(), argOpOperands)) {
-        meet(getLatticeElement(argOpOperand.get()),
-             *getLatticeElementFor(getProgramPointAfter(op), blockArg));
-        unaccounted.reset(argOpOperand.getOperandNumber());
+      // When not all callers are known, the entry-block argument lattices
+      // under-approximate how the forwarded operands are used and the callee's
+      // signature cannot be changed, so propagation from them is unsound. This
+      // mirrors `visitCallableOperation`, which sets the callee's return
+      // operands to the exit state when `!allPredecessorsKnown()`.
+      const PredecessorState *callsites = getOrCreateFor<PredecessorState>(
+          getProgramPointAfter(op), getProgramPointAfter(callable));
+      if (callsites->allPredecessorsKnown()) {
+        // Propagate information from the entry point of the function back to
+        // operands whenever possible.
+        Block &block = region->front();
+        for (auto [blockArg, argOpOperand] :
+             llvm::zip(block.getArguments(), argOpOperands)) {
+          meet(getLatticeElement(argOpOperand.get()),
+               *getLatticeElementFor(getProgramPointAfter(op), blockArg));
+          unaccounted.reset(argOpOperand.getOperandNumber());
+        }
       }
 
       // Handle the operands of the call op that aren't forwarded to any
-      // arguments.
+      // arguments. When not all callers are known, this conservatively covers
+      // all forwarded operands as well (none were accounted for above).
       for (int index : unaccounted.set_bits()) {
         OpOperand &opOperand = op->getOpOperand(index);
         visitCallOperand(opOperand);

--- a/mlir/test/Analysis/DataFlow/test-liveness-analysis.mlir
+++ b/mlir/test/Analysis/DataFlow/test-liveness-analysis.mlir
@@ -108,6 +108,24 @@ func.func @test_4_type_1.d(%arg0: i32, %arg1: i32, %device: i32, %m0: memref<i32
 
 // -----
 
+func.func public @public(%arg0 : i32) -> i32 {
+  %0 = arith.constant 0 : i32
+  func.return %0 : i32
+}
+
+// Positive test: a forwarded operand of a call to a callee with unknown callers
+// (here a public function) is live. The callee's signature cannot be changed,
+// so the operand cannot be derived from its entry-block arguments and must be
+// treated conservatively as live, even though %arg0 is unused in the body.
+// CHECK-LABEL: test_tag: call_public:
+// CHECK-NEXT:  operand #0: live
+func.func @test_4_call_to_public_callee(%arg0: i32) -> i32 {
+  %0 = func.call @public(%arg0) {tag = "call_public"} : (i32) -> i32
+  return %0 : i32
+}
+
+// -----
+
 // Positive test: Type (2) "is returned by a public function"
 // zero is live because it is returned by a public function.
 // CHECK-LABEL: test_tag: zero:

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -868,3 +868,25 @@ module @func_with_non_call_users {
   }
   spirv.EntryPoint "GLCompute" @callee
 }
+
+// -----
+
+// The argument of a public function cannot be removed because its signature is
+// externally visible. Liveness analysis must therefore treat the forwarded
+// operands of a call to such a function conservatively (as live), so that the
+// call is not left with a dangling operand when the callee has a non-live
+// argument. Previously this produced an invalid `func.call` with a null operand.
+
+// CHECK-LABEL: func.func public @caller
+// CHECK-SAME:    (%[[X:.*]]: i32)
+// CHECK:         %[[R:.*]] = call @public_callee(%[[X]]) : (i32) -> i32
+// CHECK:         return %[[R]]
+// CHECK:       func.func public @public_callee(%{{.*}}: i32) -> i32
+func.func public @caller(%x: i32) -> i32 {
+  %0 = call @public_callee(%x) : (i32) -> i32
+  return %0 : i32
+}
+func.func public @public_callee(%arg0: i32) -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  return %c0_i32 : i32
+}


### PR DESCRIPTION
The backward sparse data-flow analysis connects a call's forwarded operands to the callee's entry-block arguments to derive their lattices interprocedurally. That is only valid when all callers of the callee are known. If not all callers are known (for example a public function), an unknown caller may depend on any argument and the callee's signature cannot be changed, so the forwarded operands must be handled conservatively instead of being meet-ed with the (under-approximated) entry argument lattices.

For liveness analysis this made the forwarded operands of a call to a public callee with a non-live argument appear non-live, which let -remove-dead-values erase the operand while leaving the public callee signature intact, producing an invalid `func.call` with a null operand.

Only propagate from the callee's entry arguments when all of its callers are known; otherwise fall back to `visitCallOperand` for every operand. This mirrors `visitCallableOperation`, which sets the callee's return operands to the exit state when `!allPredecessorsKnown()`.