### PR TITLE
[lldb][Windows] Use (lib)python3.dll when linking with limited API

### DIFF
--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -109,12 +109,22 @@ if (LLDB_ENABLE_PYTHON)
   if(WIN32)
     # On Windows, FindPython3 doesn't reliably expose the runtime DLL path,
     # only the import library. CPython's DLL naming is standard.
-    if(MINGW)
-      set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
-          "libpython${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}.dll")
+    if(LLDB_ENABLE_PYTHON_LIMITED_API)
+      if(MINGW)
+        set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
+            "libpython${Python3_VERSION_MAJOR}.dll")
+      else()
+        set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
+            "python${Python3_VERSION_MAJOR}.dll")
+      endif()
     else()
-      set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
-          "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}.dll")
+      if(MINGW)
+        set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
+            "libpython${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}.dll")
+      else()
+        set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
+            "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}.dll")
+      endif()
     endif()
     message(STATUS "LLDB Python runtime DLL: ${LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME} "
                    "(Python3_VERSION=${Python3_VERSION}, "


### PR DESCRIPTION
In release builds, we already link liblldb against `(lib)python3.dll` (#201407). However, we still defined `LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME` to `(lib)python3(.)xx.dll`. So `LoadPythonRuntime` will try to load the version specific library. You can reproduce this when trying to run a release build with a different Python version in PATH.

With this PR, `LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME` will use the stable ABI library name if we use the limited Python API.