### PR TITLE
[flang][OpenMP] Add explicit return type to visitor lambdas

### DIFF
--- a/flang/lib/Semantics/openmp-utils.cpp
+++ b/flang/lib/Semantics/openmp-utils.cpp
@@ -156,8 +156,10 @@ const Symbol *GetObjectSymbol(const parser::OmpObject &object, bool ultimate) {
   } else if (auto *locator{GetLocatorFromObj(object)}) {
     const Symbol *sym = common::visit( //
         common::visitors{
-            [](const parser::OmpReservedIdentifier &x) { return x.v.symbol; },
-            [](const parser::FunctionReference &x) {
+            [](const parser::OmpReservedIdentifier &x) -> const Symbol * {
+              return x.v.symbol;
+            },
+            [](const parser::FunctionReference &x) -> const Symbol * {
               return GetFunctionReferenceSymbol(x);
             },
         },


### PR DESCRIPTION
This should silence MSVC (14.51.36231) error:
error C2338: static assertion failed: 'visit() requires the result of all potential invocations to have the same type and value category (N4950 [variant.visit]/5).'

e.g. https://lab.llvm.org/buildbot/#/builders/166/builds/9664