### PR TITLE
[HIP] Pass backend options to non-LTO wrapper codegen

### DIFF
--- a/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper-hip-no-rdc.c
+++ b/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper-hip-no-rdc.c
@@ -67,3 +67,18 @@ __attribute__((visibility("protected"), used)) int x;
 // handing it to the LTO link.
 // RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --wrapper-verbose --dry-run --no-lto --emit-fatbin-only --linker-path=/usr/bin/ld %t.out -o %t.nolto.hipfb 2>&1 | FileCheck %s --check-prefix=NO-LTO
 // NO-LTO: clang{{.*}} -mcpu=gfx1200{{.*}} -x ir {{.*}}-flto=none
+
+// With --no-lto, device-link codegen happens in the clang -x ir step.
+// Device-linker -mllvm options must still reach that backend invocation.
+// RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --wrapper-verbose --dry-run --no-lto --emit-fatbin-only --linker-path=/usr/bin/ld \
+// RUN:   --device-linker=amdgcn-amd-amdhsa=-mllvm \
+// RUN:   --device-linker=amdgcn-amd-amdhsa=-time-passes \
+// RUN:   --device-linker=amdgcn-amd-amdhsa=-mllvm=-stats \
+// RUN:   %t.out -o %t.nolto.opts.hipfb 2>&1 | FileCheck %s --check-prefix=NO-LTO-OPTS
+// NO-LTO-OPTS: clang{{.*}} -mcpu=gfx1200
+// NO-LTO-OPTS-SAME: -mllvm -time-passes
+// NO-LTO-OPTS-SAME: -mllvm -stats
+// NO-LTO-OPTS-SAME: -x ir
+// NO-LTO-OPTS-SAME: -Xlinker -mllvm
+// NO-LTO-OPTS-SAME: -Xlinker -time-passes
+// NO-LTO-OPTS-SAME: -Xlinker -mllvm=-stats

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -534,11 +534,36 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
     Triple.isAMDGPU() ? CmdArgs.push_back(Args.MakeArgString("-mcpu=" + Arch))
                       : CmdArgs.push_back(Args.MakeArgString("-march=" + Arch));
 
+  bool NonLTO = Args.hasArg(OPT_no_lto) && !Triple.isSPIRV();
+
+  auto AddBackendOption = [&](StringRef Arg) {
+    CmdArgs.append({"-mllvm", Args.MakeArgString(Arg)});
+  };
+
   // Forward all of the `--offload-opt` and `-mllvm` options to the device.
-  for (auto &Arg : Args.filtered(OPT_offload_opt_eq_minus, OPT_mllvm))
+  for (auto &Arg : Args.filtered(OPT_offload_opt_eq_minus, OPT_mllvm)) {
+    if (NonLTO && Arg->getOption().matches(OPT_mllvm))
+      AddBackendOption(Arg->getValue());
     CmdArgs.append(
         {"-Xlinker",
          Args.MakeArgString("--plugin-opt=" + StringRef(Arg->getValue()))});
+  }
+
+  // In the non-LTO path, this Clang invocation performs device-link codegen.
+  // Mirror explicit device-linker -mllvm options so they reach that backend
+  // invocation as they do in the LTO path.
+  if (NonLTO) {
+    auto LinkerArgs = Args.getAllArgValues(OPT_linker_arg_EQ);
+    for (auto I = LinkerArgs.begin(), E = LinkerArgs.end(); I != E; ++I) {
+      StringRef Arg = *I;
+      if (Arg == "-mllvm") {
+        if (++I != E)
+          AddBackendOption(*I);
+      } else if (Arg.consume_front("-mllvm=")) {
+        AddBackendOption(Arg);
+      }
+    }
+  }
 
   if (!Triple.isNVPTX() && !Triple.isSPIRV())
     CmdArgs.push_back("-Wl,--no-undefined");
@@ -551,7 +576,7 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
   //        share a unified interface.
   // SPIR-V has no non-LTO pipeline so a --no-lto leaked from a concrete arch in
   // a multi-target compile is ignored. Which is a workaround to remove.
-  if (Args.hasArg(OPT_no_lto) && !Triple.isSPIRV())
+  if (NonLTO)
     CmdArgs.append({"-x", "ir"});
   for (StringRef InputFile : InputFiles)
     CmdArgs.push_back(InputFile);
@@ -615,7 +640,7 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
   for (StringRef Arg : Args.getAllArgValues(OPT_compiler_arg_EQ))
     CmdArgs.push_back(Args.MakeArgString(Arg));
 
-  if (Args.hasArg(OPT_no_lto) && !Triple.isSPIRV())
+  if (NonLTO)
     CmdArgs.append({"-flto=none", "-Wno-unused-command-line-argument"});
 
   if (Error Err = executeCommands(*ClangPath, CmdArgs))


### PR DESCRIPTION
For example, CK passes device tuning options such as
-mllvm -greedy-reverse-local-assignment=1 through hipcc. In
non-RDC mode these options are needed by the device mid-end and
backend, but clang-linker-wrapper did not pass linker-routed
-mllvm options to its non-LTO device codegen pipeline. That can
drop backend tuning and cause performance loss.

Mirror explicit device-linker -mllvm options into the non-LTO
pipeline in clang-linker-wrapper, as the LTO path already makes
them available to device-link codegen.

FIXES: LCOMPILER-2371