### PR TITLE
[clang-format] Fix crash on numeric literals with an incomplete exponent

### DIFF
--- a/clang/lib/Format/NumericLiteralInfo.cpp
+++ b/clang/lib/Format/NumericLiteralInfo.cpp
@@ -61,7 +61,8 @@ NumericLiteralInfo::NumericLiteralInfo(StringRef Text, char Separator) {
         return (HasExponent || !IsHex ? isDigit : isHexDigit)(C) ||
                C == Separator;
       },
-      std::min(HasExponent ? ExponentLetterPos + 2 : Pos, Text.size())); // e.g. 1e-2f
+      std::min(HasExponent ? ExponentLetterPos + 2 : Pos,
+               Text.size())); // e.g. 1e-2f
 }
 
 } // namespace format

--- a/clang/lib/Format/NumericLiteralInfo.cpp
+++ b/clang/lib/Format/NumericLiteralInfo.cpp
@@ -61,8 +61,7 @@ NumericLiteralInfo::NumericLiteralInfo(StringRef Text, char Separator) {
         return (HasExponent || !IsHex ? isDigit : isHexDigit)(C) ||
                C == Separator;
       },
-      std::min(HasExponent ? ExponentLetterPos + 2 : Pos,
-               Text.size())); // e.g. 1e-2f
+      std::min(HasExponent ? ExponentLetterPos + 2 : Pos, Text.size())); // e.g. 1e-2f
 }
 
 } // namespace format

--- a/clang/lib/Format/NumericLiteralInfo.cpp
+++ b/clang/lib/Format/NumericLiteralInfo.cpp
@@ -61,7 +61,7 @@ NumericLiteralInfo::NumericLiteralInfo(StringRef Text, char Separator) {
         return (HasExponent || !IsHex ? isDigit : isHexDigit)(C) ||
                C == Separator;
       },
-      std::min(HasExponent ? ExponentLetterPos + 2 : Pos, Text.size()); // e.g. 1e-2f
+      std::min(HasExponent ? ExponentLetterPos + 2 : Pos, Text.size())); // e.g. 1e-2f
 }
 
 } // namespace format

--- a/clang/lib/Format/NumericLiteralInfo.cpp
+++ b/clang/lib/Format/NumericLiteralInfo.cpp
@@ -51,7 +51,7 @@ NumericLiteralInfo::NumericLiteralInfo(StringRef Text, char Separator) {
   const auto TrimmedText =
       Separator == '\'' ? Text.take_front(Text.find('_')) : Text;
 
-  // Clamp searches due to possible incomplete literals
+  // Clamp searches due to possible incomplete literals.
   ExponentLetterPos = TrimmedText.find_insensitive(
       IsHex ? 'p' : 'e', std::min(Pos, TrimmedText.size()));
 
@@ -61,8 +61,7 @@ NumericLiteralInfo::NumericLiteralInfo(StringRef Text, char Separator) {
         return (HasExponent || !IsHex ? isDigit : isHexDigit)(C) ||
                C == Separator;
       },
-      HasExponent ? std::min(ExponentLetterPos + 2, Text.size())
-                  : std::min(Pos, Text.size())); // e.g. 1e-2f
+      std::min(HasExponent ? ExponentLetterPos + 2 : Pos, Text.size()); // e.g. 1e-2f
 }
 
 } // namespace format

--- a/clang/lib/Format/NumericLiteralInfo.cpp
+++ b/clang/lib/Format/NumericLiteralInfo.cpp
@@ -16,6 +16,7 @@
 
 #include "NumericLiteralInfo.h"
 #include "llvm/ADT/StringExtras.h"
+#include <algorithm>
 
 namespace clang {
 namespace format {
@@ -46,11 +47,13 @@ NumericLiteralInfo::NumericLiteralInfo(StringRef Text, char Separator) {
 
   // e.g. 1.e2 or 0xFp2
   const auto Pos = DotPos != StringRef::npos ? DotPos + 1 : BaseLetterPos + 2;
+  // Trim C++ user-defined suffix as in `1_Pa`.
+  const auto TrimmedText =
+      Separator == '\'' ? Text.take_front(Text.find('_')) : Text;
 
-  ExponentLetterPos =
-      // Trim C++ user-defined suffix as in `1_Pa`.
-      (Separator == '\'' ? Text.take_front(Text.find('_')) : Text)
-          .find_insensitive(IsHex ? 'p' : 'e', Pos);
+  // Clamp searches due to possible incomplete literals
+  ExponentLetterPos = TrimmedText.find_insensitive(
+      IsHex ? 'p' : 'e', std::min(Pos, TrimmedText.size()));
 
   const bool HasExponent = ExponentLetterPos != StringRef::npos;
   SuffixPos = Text.find_if_not(
@@ -58,7 +61,8 @@ NumericLiteralInfo::NumericLiteralInfo(StringRef Text, char Separator) {
         return (HasExponent || !IsHex ? isDigit : isHexDigit)(C) ||
                C == Separator;
       },
-      HasExponent ? ExponentLetterPos + 2 : Pos); // e.g. 1e-2f
+      HasExponent ? std::min(ExponentLetterPos + 2, Text.size())
+                  : std::min(Pos, Text.size())); // e.g. 1e-2f
 }
 
 } // namespace format

--- a/clang/unittests/Format/NumericLiteralCaseTest.cpp
+++ b/clang/unittests/Format/NumericLiteralCaseTest.cpp
@@ -340,17 +340,6 @@ TEST_F(NumericLiteralCaseTest, UnderScoreSeparatorLanguages) {
   verifyFormat("o = 0o0_10_010;", "o = 0O0_10_010;", Style);
 }
 
-TEST_F(NumericLiteralCaseTest, IncompleteLiteralDoesNotCrash) {
-  auto Style = getLLVMStyle();
-  Style.NumericLiteralCase.HexDigit = FormatStyle::NLCS_Upper;
-
-  verifyFormat("i = 1e;", Style);
-  verifyFormat("i = 1.0e;", Style);
-  verifyFormat("i = 0x1p;", Style);
-  verifyFormat("i = 0x;", Style);
-  verifyFormat("i = 0x_;", Style);
-}
-
 } // namespace
 } // namespace test
 } // namespace format

--- a/clang/unittests/Format/NumericLiteralCaseTest.cpp
+++ b/clang/unittests/Format/NumericLiteralCaseTest.cpp
@@ -340,6 +340,17 @@ TEST_F(NumericLiteralCaseTest, UnderScoreSeparatorLanguages) {
   verifyFormat("o = 0o0_10_010;", "o = 0O0_10_010;", Style);
 }
 
+TEST_F(NumericLiteralCaseTest, IncompleteLiteralDoesNotCrash) {
+  auto Style = getLLVMStyle();
+  Style.NumericLiteralCase.HexDigit = FormatStyle::NLCS_Upper;
+
+  verifyFormat("i = 1e;", Style);
+  verifyFormat("i = 1.0e;", Style);
+  verifyFormat("i = 0x1p;", Style);
+  verifyFormat("i = 0x;", Style);
+  verifyFormat("i = 0x_;", Style);
+}
+
 } // namespace
 } // namespace test
 } // namespace format

--- a/clang/unittests/Format/NumericLiteralInfoTest.cpp
+++ b/clang/unittests/Format/NumericLiteralInfoTest.cpp
@@ -66,6 +66,14 @@ TEST_F(NumericLiteralInfoTest, FloatingPointLiteral) {
   EXPECT_TRUE(verifyInfo(NumericLiteralInfo("0xF.Fp-9_Pa"), 1, 3, 5, 8));
 }
 
+TEST_F(NumericLiteralInfoTest, InvalidNumericLiteral) {
+  EXPECT_TRUE(verifyInfo(NumericLiteralInfo("1e"), npos, npos, 1, npos));
+  EXPECT_TRUE(verifyInfo(NumericLiteralInfo("1.0e"), npos, 1, 3, npos));
+  EXPECT_TRUE(verifyInfo(NumericLiteralInfo("0x"), 1, npos, npos, npos));
+  EXPECT_TRUE(verifyInfo(NumericLiteralInfo("0x_"), 1, npos, npos, npos));
+  EXPECT_TRUE(verifyInfo(NumericLiteralInfo("0x1p"), 1, npos, 3, npos));
+}
+
 } // namespace
 } // namespace format
 } // namespace clang


### PR DESCRIPTION
NumericLiteralInfo could read into tokens out of bounds due to the token processing assuming well-formed numeric literals and incrementing pointers to read past them. The fix properly bounds the searches to the token size via std::min and accounts for the new trimmed string size.

Fixes #206593

Used Claude Code for help with identifying the source of the bug and checking correctness with fuzzing, wrote the solution myself