### PR TITLE
[CIR] Lower add/sub-with-carry builtins

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -2236,6 +2236,8 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__warn_memset_zero_len:
   case Builtin::BI__annotation:
   case Builtin::BI__builtin_annotation:
+    return errorBuiltinNYI(*this, e, builtinID);
+
   case Builtin::BI__builtin_addcb:
   case Builtin::BI__builtin_addcs:
   case Builtin::BI__builtin_addc:
@@ -2245,8 +2247,47 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__builtin_subcs:
   case Builtin::BI__builtin_subc:
   case Builtin::BI__builtin_subcl:
-  case Builtin::BI__builtin_subcll:
-    return errorBuiltinNYI(*this, e, builtinID);
+  case Builtin::BI__builtin_subcll: {
+    // Multiprecision add/sub-with-carry.  Lower as two chained checked
+    // add/sub overflow ops, matching classic CodeGen:
+    //   sum1, carry1 = x +/- y
+    //   result, carry2 = sum1 +/- carryin
+    //   *carryout = carry1 | carry2
+    // All operands and the result share the builtin's integer type, so no
+    // encompassing-type widening is needed.
+    mlir::Value x = emitScalarExpr(e->getArg(0));
+    mlir::Value y = emitScalarExpr(e->getArg(1));
+    mlir::Value carryin = emitScalarExpr(e->getArg(2));
+    Address carryOutPtr = emitPointerWithAlignment(e->getArg(3));
+
+    mlir::Location loc = getLoc(e->getSourceRange());
+    mlir::Type resultTy = convertType(e->getType());
+
+    bool isAdd = builtinID == Builtin::BI__builtin_addcb ||
+                 builtinID == Builtin::BI__builtin_addcs ||
+                 builtinID == Builtin::BI__builtin_addc ||
+                 builtinID == Builtin::BI__builtin_addcl ||
+                 builtinID == Builtin::BI__builtin_addcll;
+
+    mlir::Value sum1, carry1, sum2, carry2;
+    if (isAdd) {
+      std::tie(sum1, carry1) =
+          emitOverflowOp<cir::AddOverflowOp>(builder, loc, resultTy, x, y);
+      std::tie(sum2, carry2) = emitOverflowOp<cir::AddOverflowOp>(
+          builder, loc, resultTy, sum1, carryin);
+    } else {
+      std::tie(sum1, carry1) =
+          emitOverflowOp<cir::SubOverflowOp>(builder, loc, resultTy, x, y);
+      std::tie(sum2, carry2) = emitOverflowOp<cir::SubOverflowOp>(
+          builder, loc, resultTy, sum1, carryin);
+    }
+
+    // Combine the two carry bits, then widen to the result integer type.
+    mlir::Value carryOut = builder.createBoolToInt(
+        builder.createOr(loc, carry1, carry2), resultTy);
+    builder.createStore(loc, carryOut, carryOutPtr);
+    return RValue::get(sum2);
+  }
 
   case Builtin::BI__builtin_add_overflow:
   case Builtin::BI__builtin_sub_overflow:

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -26,6 +26,7 @@
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/MissingFeatures.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -2263,11 +2264,11 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     mlir::Location loc = getLoc(e->getSourceRange());
     mlir::Type resultTy = convertType(e->getType());
 
-    bool isAdd = builtinID == Builtin::BI__builtin_addcb ||
-                 builtinID == Builtin::BI__builtin_addcs ||
-                 builtinID == Builtin::BI__builtin_addc ||
-                 builtinID == Builtin::BI__builtin_addcl ||
-                 builtinID == Builtin::BI__builtin_addcll;
+    static constexpr unsigned addcBuiltins[] = {
+        Builtin::BI__builtin_addcb, Builtin::BI__builtin_addcs,
+        Builtin::BI__builtin_addc, Builtin::BI__builtin_addcl,
+        Builtin::BI__builtin_addcll};
+    bool isAdd = llvm::is_contained(addcBuiltins, builtinID);
 
     mlir::Value sum1, carry1, sum2, carry2;
     if (isAdd) {

--- a/clang/test/CIR/CodeGen/builtin-multiprecision.c
+++ b/clang/test/CIR/CodeGen/builtin-multiprecision.c
@@ -1,0 +1,140 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+unsigned char test_addcb(unsigned char x, unsigned char y,
+                         unsigned char carryin, unsigned char *carryout) {
+  return __builtin_addcb(x, y, carryin, carryout);
+}
+
+// CIR-LABEL: cir.func{{.*}}@test_addcb
+// CIR: cir.add.overflow %{{.+}}, %{{.+}} : !u8i -> !u8i
+// CIR: cir.add.overflow %{{.+}}, %{{.+}} : !u8i -> !u8i
+// CIR: cir.or %{{.+}}, %{{.+}} : !cir.bool
+// CIR: cir.cast bool_to_int %{{.+}} : !cir.bool -> !u8i
+
+// LLVM-LABEL: define {{.*}}@test_addcb
+// LLVM: call { i8, i1 } @llvm.uadd.with.overflow.i8(i8 %{{.+}}, i8 %{{.+}})
+// LLVM: extractvalue { i8, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i8, i1 } %{{.+}}, {{[01]}}
+// LLVM: call { i8, i1 } @llvm.uadd.with.overflow.i8(i8 %{{.+}}, i8 %{{.+}})
+// LLVM: extractvalue { i8, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i8, i1 } %{{.+}}, {{[01]}}
+// LLVM: or i1 %{{.+}}, %{{.+}}
+// LLVM: zext i1 %{{.+}} to i8
+// LLVM: store i8 %{{.+}}, ptr %{{.+}}
+
+unsigned int test_addc(unsigned int x, unsigned int y,
+                       unsigned int carryin, unsigned int *carryout) {
+  return __builtin_addc(x, y, carryin, carryout);
+}
+
+// CIR-LABEL: cir.func{{.*}}@test_addc
+// CIR: cir.add.overflow %{{.+}}, %{{.+}} : !u32i -> !u32i
+// CIR: cir.add.overflow %{{.+}}, %{{.+}} : !u32i -> !u32i
+// CIR: cir.or %{{.+}}, %{{.+}} : !cir.bool
+// CIR: cir.cast bool_to_int %{{.+}} : !cir.bool -> !u32i
+
+// LLVM-LABEL: define {{.*}}@test_addc
+// LLVM: call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %{{.+}}, i32 %{{.+}})
+// LLVM: extractvalue { i32, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i32, i1 } %{{.+}}, {{[01]}}
+// LLVM: call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %{{.+}}, i32 %{{.+}})
+// LLVM: extractvalue { i32, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i32, i1 } %{{.+}}, {{[01]}}
+// LLVM: or i1 %{{.+}}, %{{.+}}
+// LLVM: zext i1 %{{.+}} to i32
+// LLVM: store i32 %{{.+}}, ptr %{{.+}}
+
+unsigned long long test_addcll(unsigned long long x, unsigned long long y,
+                               unsigned long long carryin,
+                               unsigned long long *carryout) {
+  return __builtin_addcll(x, y, carryin, carryout);
+}
+
+// CIR-LABEL: cir.func{{.*}}@test_addcll
+// CIR: cir.add.overflow %{{.+}}, %{{.+}} : !u64i -> !u64i
+// CIR: cir.add.overflow %{{.+}}, %{{.+}} : !u64i -> !u64i
+// CIR: cir.or %{{.+}}, %{{.+}} : !cir.bool
+// CIR: cir.cast bool_to_int %{{.+}} : !cir.bool -> !u64i
+
+// LLVM-LABEL: define {{.*}}@test_addcll
+// LLVM: call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 %{{.+}}, i64 %{{.+}})
+// LLVM: extractvalue { i64, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i64, i1 } %{{.+}}, {{[01]}}
+// LLVM: call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 %{{.+}}, i64 %{{.+}})
+// LLVM: extractvalue { i64, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i64, i1 } %{{.+}}, {{[01]}}
+// LLVM: or i1 %{{.+}}, %{{.+}}
+// LLVM: zext i1 %{{.+}} to i64
+// LLVM: store i64 %{{.+}}, ptr %{{.+}}
+
+unsigned char test_subcb(unsigned char x, unsigned char y,
+                         unsigned char carryin, unsigned char *carryout) {
+  return __builtin_subcb(x, y, carryin, carryout);
+}
+
+// CIR-LABEL: cir.func{{.*}}@test_subcb
+// CIR: cir.sub.overflow %{{.+}}, %{{.+}} : !u8i -> !u8i
+// CIR: cir.sub.overflow %{{.+}}, %{{.+}} : !u8i -> !u8i
+// CIR: cir.or %{{.+}}, %{{.+}} : !cir.bool
+// CIR: cir.cast bool_to_int %{{.+}} : !cir.bool -> !u8i
+
+// LLVM-LABEL: define {{.*}}@test_subcb
+// LLVM: call { i8, i1 } @llvm.usub.with.overflow.i8(i8 %{{.+}}, i8 %{{.+}})
+// LLVM: extractvalue { i8, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i8, i1 } %{{.+}}, {{[01]}}
+// LLVM: call { i8, i1 } @llvm.usub.with.overflow.i8(i8 %{{.+}}, i8 %{{.+}})
+// LLVM: extractvalue { i8, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i8, i1 } %{{.+}}, {{[01]}}
+// LLVM: or i1 %{{.+}}, %{{.+}}
+// LLVM: zext i1 %{{.+}} to i8
+// LLVM: store i8 %{{.+}}, ptr %{{.+}}
+
+unsigned int test_subc(unsigned int x, unsigned int y,
+                       unsigned int carryin, unsigned int *carryout) {
+  return __builtin_subc(x, y, carryin, carryout);
+}
+
+// CIR-LABEL: cir.func{{.*}}@test_subc
+// CIR: cir.sub.overflow %{{.+}}, %{{.+}} : !u32i -> !u32i
+// CIR: cir.sub.overflow %{{.+}}, %{{.+}} : !u32i -> !u32i
+// CIR: cir.or %{{.+}}, %{{.+}} : !cir.bool
+// CIR: cir.cast bool_to_int %{{.+}} : !cir.bool -> !u32i
+
+// LLVM-LABEL: define {{.*}}@test_subc
+// LLVM: call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %{{.+}}, i32 %{{.+}})
+// LLVM: extractvalue { i32, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i32, i1 } %{{.+}}, {{[01]}}
+// LLVM: call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %{{.+}}, i32 %{{.+}})
+// LLVM: extractvalue { i32, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i32, i1 } %{{.+}}, {{[01]}}
+// LLVM: or i1 %{{.+}}, %{{.+}}
+// LLVM: zext i1 %{{.+}} to i32
+// LLVM: store i32 %{{.+}}, ptr %{{.+}}
+
+unsigned long long test_subcll(unsigned long long x, unsigned long long y,
+                               unsigned long long carryin,
+                               unsigned long long *carryout) {
+  return __builtin_subcll(x, y, carryin, carryout);
+}
+
+// CIR-LABEL: cir.func{{.*}}@test_subcll
+// CIR: cir.sub.overflow %{{.+}}, %{{.+}} : !u64i -> !u64i
+// CIR: cir.sub.overflow %{{.+}}, %{{.+}} : !u64i -> !u64i
+// CIR: cir.or %{{.+}}, %{{.+}} : !cir.bool
+// CIR: cir.cast bool_to_int %{{.+}} : !cir.bool -> !u64i
+
+// LLVM-LABEL: define {{.*}}@test_subcll
+// LLVM: call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %{{.+}}, i64 %{{.+}})
+// LLVM: extractvalue { i64, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i64, i1 } %{{.+}}, {{[01]}}
+// LLVM: call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %{{.+}}, i64 %{{.+}})
+// LLVM: extractvalue { i64, i1 } %{{.+}}, {{[01]}}
+// LLVM: extractvalue { i64, i1 } %{{.+}}, {{[01]}}
+// LLVM: or i1 %{{.+}}, %{{.+}}
+// LLVM: zext i1 %{{.+}} to i64
+// LLVM: store i64 %{{.+}}, ptr %{{.+}}


### PR DESCRIPTION
The multiprecision add/sub-with-carry builtins -- `__builtin_addc{b,s,,l,ll}`
and `__builtin_subc{b,s,,l,ll}` -- were stubbed with errorNYI in CIRGen, so
any translation unit that uses them fails to compile. They are used by
128-bit fallback arithmetic in libraries such as libfmt (its
`uint128_fallback` add path calls `__builtin_addcll`).

The lowering mirrors classic CodeGen in `CGBuiltin.cpp`: emit two chained
checked-overflow operations (`sum1 = x +/- y`, then `result = sum1 +/-
carryin`), OR the two overflow flags for the carry-out, widen that to the
operand type, and store it through the carry-out pointer. CIR already has
the checked-overflow ops that `__builtin_add_overflow` uses
(`AddOverflowOp` / `SubOverflowOp`), so this reuses that path rather than
adding anything new.

The new `builtin-multiprecision.c` exercises add and sub across i8/i32/i64
and checks both the CIR ops and the lowered unsigned `uadd`/`usub.with.overflow`
form against classic CodeGen.
