### PR TITLE
[lldb] Adjust SourceFileCompleter to use StringRef

### DIFF
--- a/lldb/source/Commands/CommandCompletions.cpp
+++ b/lldb/source/Commands/CommandCompletions.cpp
@@ -139,37 +139,38 @@ class SourceFileCompleter : public Completer {
 public:
   SourceFileCompleter(CommandInterpreter &interpreter,
                       CompletionRequest &request)
-      : Completer(interpreter, request) {
-    FileSpec partial_spec(m_request.GetCursorArgumentPrefix());
-    m_file_name = partial_spec.GetFilename().GetCString();
-    m_dir_name = partial_spec.GetDirectory().GetCString();
-  }
+      : Completer(interpreter, request),
+        m_partial_spec(m_request.GetCursorArgumentPrefix()) {}
 
   lldb::SearchDepth GetDepth() override { return lldb::eSearchDepthCompUnit; }
 
   Searcher::CallbackReturn SearchCallback(SearchFilter &filter,
                                           SymbolContext &context,
                                           Address *addr) override {
+    llvm::StringRef spec_file_name =
+        m_partial_spec.GetFilename().GetStringRef();
+    llvm::StringRef spec_dir_name =
+        m_partial_spec.GetDirectory().GetStringRef();
     if (context.comp_unit != nullptr) {
-      const char *cur_file_name =
-          context.comp_unit->GetPrimaryFile().GetFilename().GetCString();
-      const char *cur_dir_name =
-          context.comp_unit->GetPrimaryFile().GetDirectory().GetCString();
+      llvm::StringRef cur_file_name =
+          context.comp_unit->GetPrimaryFile().GetFilename().GetStringRef();
+      llvm::StringRef cur_dir_name =
+          context.comp_unit->GetPrimaryFile().GetDirectory().GetStringRef();
 
       bool match = false;
-      if (m_file_name && cur_file_name &&
-          strstr(cur_file_name, m_file_name) == cur_file_name)
+      if (!spec_file_name.empty() && cur_file_name.starts_with(spec_file_name))
         match = true;
 
-      if (match && m_dir_name && cur_dir_name &&
-          strstr(cur_dir_name, m_dir_name) != cur_dir_name)
+      if (match && !spec_dir_name.empty() &&
+          !cur_dir_name.starts_with(spec_dir_name))
         match = false;
 
       if (match) {
         m_matching_files.AppendIfUnique(context.comp_unit->GetPrimaryFile());
       }
     }
-    return m_matching_files.GetSize() >= m_request.GetMaxNumberOfCompletionsToAdd()
+    return m_matching_files.GetSize() >=
+                   m_request.GetMaxNumberOfCompletionsToAdd()
                ? Searcher::eCallbackReturnStop
                : Searcher::eCallbackReturnContinue;
   }
@@ -184,9 +185,8 @@ public:
   }
 
 private:
+  FileSpec m_partial_spec;
   FileSpecList m_matching_files;
-  const char *m_file_name;
-  const char *m_dir_name;
 
   SourceFileCompleter(const SourceFileCompleter &) = delete;
   const SourceFileCompleter &operator=(const SourceFileCompleter &) = delete;


### PR DESCRIPTION
Instead of storing `const char *` (which are currently backed by ConstStrings), it should instead store the FileSpec and extract the Filename and Directory as needed.