### PR TITLE
[flang][openacc] Skip implicit global declare constructor in managed mode

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -3962,6 +3962,9 @@ genGlobalCtors(Fortran::lower::AbstractConverter &converter,
                mlir::acc::DataClause clause,
                Fortran::semantics::Symbol::Flag declareMappingFlag) {
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
+  const auto &langFeatures = converter.getFoldingContext().languageFeatures();
+  const bool managedMode =
+      langFeatures.IsEnabled(Fortran::common::LanguageFeature::CudaManaged);
   auto genCtors = [&](const mlir::Location operandLocation,
                       const Fortran::semantics::Symbol &symbol) {
     std::string globalName = converter.mangleName(symbol);
@@ -3998,10 +4001,15 @@ genGlobalCtors(Fortran::lower::AbstractConverter &converter,
     auto crtPos = builder.saveInsertionPoint();
     modBuilder.setInsertionPointAfter(globalOp);
     if (mlir::isa<fir::BaseBoxType>(fir::unwrapRefType(globalOp.getType()))) {
-      createDeclareGlobalOp<mlir::acc::GlobalConstructorOp, mlir::acc::CopyinOp,
-                            mlir::acc::DeclareEnterOp, ExitOp>(
-          modBuilder, builder, operandLocation, globalOp, clause,
-          declareGlobalCtorName.str(), /*implicit=*/true, asFortran);
+      if (!managedMode || clause == mlir::acc::DataClause::acc_declare_link ||
+          clause == mlir::acc::DataClause::acc_declare_device_resident) {
+        createDeclareGlobalOp<mlir::acc::GlobalConstructorOp,
+                              mlir::acc::CopyinOp, mlir::acc::DeclareEnterOp,
+                              ExitOp>(modBuilder, builder, operandLocation,
+                                      globalOp, clause,
+                                      declareGlobalCtorName.str(),
+                                      /*implicit=*/true, asFortran);
+      }
       createDeclareAllocFunc<EntryOp>(modBuilder, builder, operandLocation,
                                       globalOp, clause);
       if constexpr (!std::is_same_v<EntryOp, ExitOp>)
@@ -4014,6 +4022,13 @@ genGlobalCtors(Fortran::lower::AbstractConverter &converter,
           declareGlobalCtorName.str(), /*implicit=*/false, asFortran);
     }
     if constexpr (!std::is_same_v<EntryOp, ExitOp>) {
+      if (managedMode &&
+          mlir::isa<fir::BaseBoxType>(fir::unwrapRefType(globalOp.getType())) &&
+          clause != mlir::acc::DataClause::acc_declare_link &&
+          clause != mlir::acc::DataClause::acc_declare_device_resident) {
+        builder.restoreInsertionPoint(crtPos);
+        return;
+      }
       createDeclareGlobalOp<mlir::acc::GlobalDestructorOp,
                             mlir::acc::GetDevicePtrOp, mlir::acc::DeclareExitOp,
                             ExitOp>(

--- a/flang/test/Lower/OpenACC/acc-declare-managed-no-global-ctor.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-managed-no-global-ctor.f90
@@ -3,19 +3,28 @@
 module acc_declare_managed_no_global_ctor
   integer, allocatable :: data(:)
   !$acc declare create(data)
+
+  integer, allocatable :: data2(:)
+  !$acc declare copyin(data2)
 contains
   subroutine init()
     allocate(data(16))
+    allocate(data2(16))
   end subroutine
 end module
 
 ! CHECK-LABEL: func.func @_QMacc_declare_managed_no_global_ctorPinit()
-! CHECK: cuf.allocate
+! CHECK-COUNT-2: cuf.allocate
 
 ! CHECK-LABEL: func.func @_QMacc_declare_managed_no_global_ctorEdata_acc_declare_post_alloc() attributes {acc.declare_action} {
 ! CHECK: %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_managed_no_global_ctorEdata)
 ! CHECK: %[[CREATE_DESC:.*]] = acc.create varPtr(%[[GLOBAL_ADDR]]
 ! CHECK: acc.declare_enter dataOperands(%[[CREATE_DESC]]
+
+! CHECK-LABEL: func.func @_QMacc_declare_managed_no_global_ctorEdata2_acc_declare_post_alloc() attributes {acc.declare_action} {
+! CHECK: %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_managed_no_global_ctorEdata2)
+! CHECK: %[[COPYIN_DESC:.*]] = acc.copyin varPtr(%[[GLOBAL_ADDR]]
+! CHECK: acc.declare_enter dataOperands(%[[COPYIN_DESC]]
 
 ! CHECK-NOT: acc.global_ctor
 ! CHECK-NOT: acc.global_dtor

--- a/flang/test/Lower/OpenACC/acc-declare-managed-no-global-ctor.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-managed-no-global-ctor.f90
@@ -1,0 +1,21 @@
+! RUN: bbc -fcuda -fopenacc -emit-hlfir -gpu=managed %s -o - | FileCheck %s
+
+module acc_declare_managed_no_global_ctor
+  integer, allocatable :: data(:)
+  !$acc declare create(data)
+contains
+  subroutine init()
+    allocate(data(16))
+  end subroutine
+end module
+
+! CHECK-LABEL: func.func @_QMacc_declare_managed_no_global_ctorPinit()
+! CHECK: cuf.allocate
+
+! CHECK-LABEL: func.func @_QMacc_declare_managed_no_global_ctorEdata_acc_declare_post_alloc() attributes {acc.declare_action} {
+! CHECK: %[[GLOBAL_ADDR:.*]] = fir.address_of(@_QMacc_declare_managed_no_global_ctorEdata)
+! CHECK: %[[CREATE_DESC:.*]] = acc.create varPtr(%[[GLOBAL_ADDR]]
+! CHECK: acc.declare_enter dataOperands(%[[CREATE_DESC]]
+
+! CHECK-NOT: acc.global_ctor
+! CHECK-NOT: acc.global_dtor


### PR DESCRIPTION
When `-gpu=mem:managed` is enabled, the allocatable is placed in managed memory. Skip the global declare constructor for the create case.