### PR TITLE
[SLP] Apply reused-scalar reduction counters at the vectorized lane

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -2210,10 +2210,10 @@ public:
     return VectorizableTree.front()->Scalars;
   }
 
-  /// Returns true if the root node has copyable elements.
-  bool isRootNodeWithCopyableElements() const {
+  /// Returns the lane the given value is vectorized to in the root node.
+  unsigned findRootLaneForValue(Value *V) const {
     assert(!VectorizableTree.empty() && "No graph to get the first node from");
-    return VectorizableTree.front()->hasCopyableElements();
+    return VectorizableTree.front()->findLaneForValue(V);
   }
 
   /// Returns the type/is-signed info for the root node in the graph without
@@ -30047,30 +30047,17 @@ public:
 
         // Emit code to correctly handle reused reduced values, if required.
         if (OptReusedScalars && !SameScaleFactor) {
-          // The reuse counters must be aligned with the lane order of the
-          // emitted reduction vector. For a root node without copyable
-          // elements the emitted lane order matches getRootNodeScalars(),
-          // which may differ from the Candidates order due to tree reordering,
-          // so remap the counters through the candidates. For a root node with
-          // copyable elements getRootNodeScalars() may be reordered while the
-          // emitted lanes still follow the reduced values (candidates) order,
-          // so use that order directly to avoid applying a counter to the wrong
-          // lane.
+          // The reuse counters are stored in the deduplicated candidates
+          // order, but the emitted reduction vector lane order is defined by
+          // the root node, which may be reordered, split or have copyable
+          // elements. Place each counter at the lane the matching candidate is
+          // vectorized to, so the counter is applied to the correct lane.
           ArrayRef<Value *> RootVL = V.getRootNodeScalars();
           ArrayRef<Value *> CandSlice(Candidates.begin() + Pos, ReduxWidth);
           SmallVector<Value *> RootTrackedToOrig(RootVL.size());
-          if (V.isRootNodeWithCopyableElements()) {
-            for (unsigned Idx : seq<unsigned>(RootVL.size()))
-              RootTrackedToOrig[Idx] = TrackedToOrig[Pos + Idx];
-          } else {
-            for (auto [Idx, Val] : enumerate(RootVL)) {
-              auto *It = find(CandSlice, Val);
-              assert(It != CandSlice.end() &&
-                     "Root scalar not found in candidates");
-              RootTrackedToOrig[Idx] =
-                  TrackedToOrig[Pos + std::distance(CandSlice.begin(), It)];
-            }
-          }
+          for (auto [Idx, Val] : enumerate(CandSlice))
+            RootTrackedToOrig[V.findRootLaneForValue(Val)] =
+                TrackedToOrig[Pos + Idx];
           VectorizedRoot = emitReusedOps(VectorizedRoot, Builder, V,
                                          SameValuesCounter, RootTrackedToOrig);
         }

--- a/llvm/test/Transforms/SLPVectorizer/X86/reduction-copyable-reused-scalars.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/reduction-copyable-reused-scalars.ll
@@ -46,7 +46,7 @@ define fastcc i32 @func_nno0tw_28(ptr %v1) {
 ; CHECK-NEXT:    [[TMP11:%.*]] = shufflevector <2 x i32> [[TMP5]], <2 x i32> poison, <4 x i32> <i32 0, i32 1, i32 poison, i32 poison>
 ; CHECK-NEXT:    [[TMP12:%.*]] = shufflevector <4 x i32> [[TMP6]], <4 x i32> [[TMP11]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 5, i32 poison, i32 poison>
 ; CHECK-NEXT:    [[TMP13:%.*]] = shufflevector <16 x i32> [[TMP12]], <16 x i32> [[TMP8]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 12, i32 13, i32 31>
-; CHECK-NEXT:    [[TMP14:%.*]] = mul <16 x i32> [[TMP13]], <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 7, i32 1>
+; CHECK-NEXT:    [[TMP14:%.*]] = mul <16 x i32> [[TMP13]], <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 7, i32 1, i32 1, i32 1>
 ; CHECK-NEXT:    [[TMP15:%.*]] = call i32 @llvm.vector.reduce.add.v16i32(<16 x i32> [[TMP14]])
 ; CHECK-NEXT:    [[TMP16:%.*]] = call i32 @llvm.vector.reduce.add.v4i32(<4 x i32> [[TMP4]])
 ; CHECK-NEXT:    [[OP_RDX5:%.*]] = add i32 [[TMP16]], [[REASS_SUB]]


### PR DESCRIPTION
The horizontal reduction reuse-counter scale was placed by deduplicated
candidate order, but the emitted reduction vector lane order is defined by
the root node, which may be reordered or split (SplitVectorize). As a
result a repeat count could be applied to the wrong lane, producing a wrong
reduction result. Place each counter at the lane the matching candidate is
vectorized to.

Fixes #206476
