### PR TITLE
[BOLT] Preserve relocation to rela/relr association

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -1409,7 +1409,8 @@ public:
 
   /// Register dynamic relocation at \p Address.
   void addDynamicRelocation(uint64_t Address, MCSymbol *Symbol, uint32_t Type,
-                            uint64_t Addend, uint64_t Value = 0);
+                            uint64_t Addend, uint64_t Value = 0,
+                            bool IsRELR = false);
 
   /// Return a dynamic relocation registered at a given \p Address, or nullptr
   /// if there is no dynamic relocation at such address.

--- a/bolt/include/bolt/Core/BinarySection.h
+++ b/bolt/include/bolt/Core/BinarySection.h
@@ -366,8 +366,10 @@ public:
 
   /// Add a dynamic relocation at the given /p Offset.
   void addDynamicRelocation(uint64_t Offset, MCSymbol *Symbol, uint32_t Type,
-                            uint64_t Addend, uint64_t Value = 0) {
-    addDynamicRelocation(Relocation{Offset, Symbol, Type, Addend, Value});
+                            uint64_t Addend, uint64_t Value = 0,
+                            bool IsRELR = false) {
+    addDynamicRelocation(
+        Relocation{Offset, Symbol, Type, Addend, Value, IsRELR});
   }
 
   void addDynamicRelocation(const Relocation &Reloc) {

--- a/bolt/include/bolt/Core/Relocation.h
+++ b/bolt/include/bolt/Core/Relocation.h
@@ -38,12 +38,16 @@ namespace bolt {
 class Relocation {
 public:
   Relocation(uint64_t Offset, MCSymbol *Symbol, uint32_t Type, uint64_t Addend,
-             uint64_t Value)
+             uint64_t Value, bool IsRELR = false)
       : Offset(Offset), Symbol(Symbol), Type(Type), Optional(false),
-        Addend(Addend), Value(Value) {}
+        IsRELR(IsRELR), Addend(Addend), Value(Value) {
+    assert((isRelative() || !isRELR()) &&
+           "Only relative relocations can be relr.");
+  }
 
   Relocation()
-      : Offset(0), Symbol(0), Type(0), Optional(0), Addend(0), Value(0) {}
+      : Offset(0), Symbol(0), Type(0), Optional(0), IsRELR(0), Addend(0),
+        Value(0) {}
 
   static Triple::ArchType Arch; /// set by BinaryContext ctor.
 
@@ -61,6 +65,11 @@ private:
   /// omitted under certain circumstances.
   bool Optional = false;
 
+  /// Track which relocations originate from a relr section. Emit these
+  /// exclusively into the relr section and do not accidentally promote relative
+  /// rela entries, because that would require growing the relr section.
+  bool IsRELR = false;
+
 public:
   /// The offset from the \p Symbol base used to compute the final
   /// value of this relocation.
@@ -76,6 +85,8 @@ public:
   void setOptional() { Optional = true; }
 
   bool isOptional() { return Optional; }
+
+  bool isRELR() const { return IsRELR; }
 
   /// Return size of this relocation.
   size_t getSize() const { return getSizeForType(Type); }

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2462,11 +2462,11 @@ void BinaryContext::addRelocation(uint64_t Address, MCSymbol *Symbol,
 
 void BinaryContext::addDynamicRelocation(uint64_t Address, MCSymbol *Symbol,
                                          uint32_t Type, uint64_t Addend,
-                                         uint64_t Value) {
+                                         uint64_t Value, bool IsRELR) {
   ErrorOr<BinarySection &> Section = getSectionForAddress(Address);
   assert(Section && "cannot find section for address");
   Section->addDynamicRelocation(Address - Section->getAddress(), Symbol, Type,
-                                Addend, Value);
+                                Addend, Value, IsRELR);
 }
 
 bool BinaryContext::removeRelocationAt(uint64_t Address) {

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2859,7 +2859,8 @@ void RewriteInstance::readDynamicRelrRelocations(BinarySection &Section) {
     LLVM_DEBUG(dbgs() << "BOLT-DEBUG: R_*_RELATIVE relocation at 0x"
                       << Twine::utohexstr(Address) << " to 0x"
                       << Twine::utohexstr(Addend) << '\n';);
-    BC->addDynamicRelocation(Address, nullptr, RType, Addend);
+    BC->addDynamicRelocation(Address, nullptr, RType, Addend, /*Value=*/0,
+                             /*IsRELR=*/true);
   };
 
   DataExtractor DE(Section.getContents(), BC->AsmInfo->isLittleEndian());
@@ -5794,7 +5795,7 @@ void RewriteInstance::patchELFAllocatableRelrSection(
       SectionAddress = SectionInputAddress;
 
     for (const Relocation &Rel : Section.dynamicRelocations()) {
-      if (!Rel.isRelative())
+      if (!Rel.isRELR())
         continue;
 
       uint64_t RelOffset =
@@ -5896,7 +5897,7 @@ RewriteInstance::patchELFAllocatableRelaSections(ELFObjectFile<ELFT> *File) {
 
       for (const Relocation &Rel : Section.dynamicRelocations()) {
         const bool IsRelative = Rel.isRelative();
-        if (PatchRelative != IsRelative)
+        if (PatchRelative != IsRelative || Rel.isRELR())
           continue;
 
         if (IsRelative)
@@ -5942,11 +5943,9 @@ RewriteInstance::patchELFAllocatableRelaSections(ELFObjectFile<ELFT> *File) {
     }
   };
 
-  // Place R_*_RELATIVE relocations in RELA section if RELR is not presented.
   // The dynamic linker expects all R_*_RELATIVE relocations in RELA
   // to be emitted first.
-  if (!DynamicRelrAddress)
-    writeRelocations(/* PatchRelative */ true);
+  writeRelocations(/* PatchRelative */ true);
   writeRelocations(/* PatchRelative */ false);
 
   auto fillNone = [&](uint64_t &Offset, uint64_t EndOffset) {

--- a/bolt/test/X86/relr-odd-unaligned.c
+++ b/bolt/test/X86/relr-odd-unaligned.c
@@ -1,0 +1,42 @@
+// Binaries with relative relocations targeting odd addresses that are not word
+// aligned are handled correctly in the presence of a relr section.
+
+// RUN: %clang %cflags -fPIC -pie %s -o %t -Wl,-z,pack-relative-relocs -Wl,-q
+
+// The binary contains 2 relocations in .rela.dyn, one of them is at an odd
+// offset. It contains one relocation in .relr.dyn.
+//
+// RUN: llvm-readobj -r %t | FileCheck %s --check-prefix=SANITY
+// SANITY:     Relocations [
+// SANITY:       Section {{.*}} .rela.dyn {
+// SANITY-DAG:     0x{{[0-9A-F]*[02468ACE]}} R_X86_64_RELATIVE
+// SANITY-DAG:     0x{{[0-9A-F]*[13579BDF]}} R_X86_64_RELATIVE
+// SANITY:       }
+// SANITY:       Section {{.*}} .relr.dyn {
+// SANITY:         R_X86_64_RELATIVE
+// SANITY:       }
+
+// Rewrite the binary with BOLT.
+//
+// RUN: llvm-bolt %t -o %t.bolt
+// RUN: llvm-readobj -r %t.bolt | FileCheck %s --check-prefix=SANITY
+
+struct __attribute__((packed)) S {
+  const char *Ptr;
+  char Pad;
+};
+
+/// Ends up in .data.rel.ro with section alignment 1. lld cannot turn these into
+/// relr relocations for two reasons: one of the relocations will be at an odd
+/// offset, which cannot be represented with a relr relocation. BOLT has to emit
+/// this one as rela. The other relocation will be at an even offset. lld
+/// (currently) only promotes rela to relr for input sections with alignment
+/// >= 2. BOLT can re-emit this one either as rela or promote it to an relr.
+/// However, BOLT (currently) cannot grow the relr section, which forces
+/// emissions as rela.
+__attribute__((aligned(1))) const struct S RO[] = {{"s1", 1}, {"s2", 2}};
+
+/// Ends up in .data with section alignment 8. Emits relr relocation.
+static void *RW = &RW;
+
+int main() { return (long)RO[0].Ptr + (long)RO[1].Ptr + (long)RW; }


### PR DESCRIPTION
BOLT emits all dynamic relative relocations in .relr.dyn if it exists in the input, including relative relocations from .rela.dyn. This can fail for two reasons: first, relative relocations can target odd addresses. These can never be emitted as relr relocations. Second, BOLT reuses the existing .relr.dyn section. Even if a relative relocation from .rela.dyn can be emitted as relr, there is simply no space in the existing .relr.dyn section. This causes an overflow. Prevent this by emitting relative relocations in the same section they originate from.