### PR TITLE
[flang][cuda] Propagate CUDA attrs from parent variable to component allocations

### DIFF
--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -470,8 +470,7 @@ private:
       const Fortran::parser::Name &baseName =
           Fortran::parser::GetFirstName(*sc);
       if (baseName.symbol &&
-          (Fortran::semantics::HasCUDAAttr(*baseName.symbol) ||
-           Fortran::semantics::HasCUDAComponent(*baseName.symbol))) {
+          Fortran::semantics::HasCUDAAttr(*baseName.symbol)) {
         sym = baseName.symbol;
         return true;
       }
@@ -662,7 +661,7 @@ private:
     fir::ExtendedValue exv = isSource ? sourceExv : moldExv;
 
     bool sourceIsDevice = false;
-    if (const Fortran::semantics::Symbol * sym{GetLastSymbol(sourceExpr)})
+    if (const Fortran::semantics::Symbol *sym{GetLastSymbol(sourceExpr)})
       if (Fortran::semantics::IsCUDADevice(*sym))
         sourceIsDevice = true;
 
@@ -825,7 +824,7 @@ private:
     mlir::Type retTy = fir::runtime::getModel<int>()(builder.getContext());
 
     bool isSourceDevice = false;
-    if (const Fortran::semantics::Symbol * sym{GetLastSymbol(sourceExpr)})
+    if (const Fortran::semantics::Symbol *sym{GetLastSymbol(sourceExpr)})
       if (Fortran::semantics::IsCUDADevice(*sym))
         isSourceDevice = true;
 

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -459,17 +459,41 @@ private:
     fir::StoreOp::create(builder, loc, falseConv, pinned);
   }
 
+  /// When the allocate object is a structure component
+  /// (e.g., managed_var(1)%component), check whether the base variable has
+  /// CUDA attributes. If so, update \p sym to the base symbol and return true
+  /// so allocations use the parent's memory space.
+  bool propagateCUDAAttrsFromParent(const Allocation &alloc,
+                                    const Fortran::semantics::Symbol *&sym) {
+    if (const auto *sc = std::get_if<Fortran::parser::StructureComponent>(
+            &alloc.getAllocObj().u)) {
+      const Fortran::parser::Name &baseName =
+          Fortran::parser::GetFirstName(*sc);
+      if (baseName.symbol &&
+          (Fortran::semantics::HasCUDAAttr(*baseName.symbol) ||
+           Fortran::semantics::HasCUDAComponent(*baseName.symbol))) {
+        sym = baseName.symbol;
+        return true;
+      }
+    }
+    return false;
+  }
+
   void genSimpleAllocation(const Allocation &alloc,
                            const fir::MutableBoxValue &box) {
     bool isCudaAllocate =
         Fortran::semantics::HasCUDAAttr(alloc.getSymbol()) ||
         Fortran::semantics::HasCUDAComponent(alloc.getSymbol());
+    const Fortran::semantics::Symbol *cudaSymForAlloc = &alloc.getSymbol();
+    if (!isCudaAllocate)
+      isCudaAllocate = propagateCUDAAttrsFromParent(alloc, cudaSymForAlloc);
+
     bool isCudaDeviceContext = cuf::isCUDADeviceContext(builder.getRegion());
     bool inlineAllocation = !box.isDerived() && !errorManager.hasStatSpec() &&
                             !alloc.type.IsPolymorphic() &&
                             !alloc.hasCoarraySpec() && !useAllocateRuntime &&
                             !box.isPointer();
-    unsigned allocatorIdx = Fortran::lower::getAllocatorIdx(alloc.getSymbol());
+    unsigned allocatorIdx = Fortran::lower::getAllocatorIdx(*cudaSymForAlloc);
 
     if (inlineAllocation && !alloc.hasCoarraySpec() &&
         ((isCudaAllocate && isCudaDeviceContext) || !isCudaAllocate)) {
@@ -508,8 +532,7 @@ private:
       stat = genRuntimeAllocate(builder, loc, box, errorManager);
       setPinnedToFalse();
     } else {
-      stat =
-          genCudaAllocate(builder, loc, box, errorManager, alloc.getSymbol());
+      stat = genCudaAllocate(builder, loc, box, errorManager, *cudaSymForAlloc);
     }
     fir::factory::syncMutableBoxFromIRBox(builder, loc, box);
     postAllocationAction(alloc, box);
@@ -570,8 +593,16 @@ private:
       fir::StoreOp::create(builder, loc, nullPointer, box.getAddr());
     } else {
       assert(box.isAllocatable() && "must be an allocatable");
-      // For allocatables, sync the MutableBoxValue and descriptor before the
-      // calls in case it is tracked locally by a set of variables.
+      // For allocatables, re-establish the descriptor with the correct
+      // allocator index so that AllocatableAllocate uses the right memory
+      // space.
+      if (allocatorIdx != kDefaultAllocator) {
+        fir::factory::disassociateMutableBox(builder, loc, box,
+                                             /*polymorphicSetType=*/false,
+                                             allocatorIdx);
+      }
+      // Sync the MutableBoxValue and descriptor before the calls in case
+      // it is tracked locally by a set of variables.
       fir::factory::getMutableIRBox(builder, loc, box);
     }
   }
@@ -623,11 +654,15 @@ private:
 
   void genSourceMoldAllocation(const Allocation &alloc,
                                const fir::MutableBoxValue &box, bool isSource) {
-    unsigned allocatorIdx = Fortran::lower::getAllocatorIdx(alloc.getSymbol());
+    bool isCudaAllocate = Fortran::semantics::HasCUDAAttr(alloc.getSymbol());
+    const Fortran::semantics::Symbol *cudaSymForAlloc = &alloc.getSymbol();
+    if (!isCudaAllocate)
+      isCudaAllocate = propagateCUDAAttrsFromParent(alloc, cudaSymForAlloc);
+    unsigned allocatorIdx = Fortran::lower::getAllocatorIdx(*cudaSymForAlloc);
     fir::ExtendedValue exv = isSource ? sourceExv : moldExv;
 
     bool sourceIsDevice = false;
-    if (const Fortran::semantics::Symbol *sym{GetLastSymbol(sourceExpr)})
+    if (const Fortran::semantics::Symbol * sym{GetLastSymbol(sourceExpr)})
       if (Fortran::semantics::IsCUDADevice(*sym))
         sourceIsDevice = true;
 
@@ -652,10 +687,8 @@ private:
           converter, loc, alloc.getSymbol(), box.getAddr(),
           alloc.getCoarraySpec(), errorManager.errMsgAddr,
           errorManager.hasStatSpec());
-    } else if (Fortran::semantics::HasCUDAAttr(alloc.getSymbol()) ||
-               sourceIsDevice) {
-      stat =
-          genCudaAllocate(builder, loc, box, errorManager, alloc.getSymbol());
+    } else if (isCudaAllocate || sourceIsDevice) {
+      stat = genCudaAllocate(builder, loc, box, errorManager, *cudaSymForAlloc);
     } else {
       if (isSource)
         stat = genRuntimeAllocateSource(builder, loc, box, exv, errorManager);
@@ -792,7 +825,7 @@ private:
     mlir::Type retTy = fir::runtime::getModel<int>()(builder.getContext());
 
     bool isSourceDevice = false;
-    if (const Fortran::semantics::Symbol *sym{GetLastSymbol(sourceExpr)})
+    if (const Fortran::semantics::Symbol * sym{GetLastSymbol(sourceExpr)})
       if (Fortran::semantics::IsCUDADevice(*sym))
         isSourceDevice = true;
 

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -459,22 +459,49 @@ private:
     fir::StoreOp::create(builder, loc, falseConv, pinned);
   }
 
-  /// When the allocate object is a structure component
-  /// (e.g., managed_var(1)%component), check whether the base variable has
-  /// CUDA attributes. If so, update \p sym to the base symbol and return true
-  /// so allocations use the parent's memory space.
+  /// Search a DataRef for a symbol with CUDA attributes. Returns true and
+  /// sets \p sym if found.
+  static bool findCUDAAttrInDataRef(const Fortran::parser::DataRef &ref,
+                                    const Fortran::semantics::Symbol *&sym) {
+    return Fortran::common::visit(
+        Fortran::common::visitors{
+            [&](const Fortran::parser::Name &name) {
+              if (name.symbol &&
+                  Fortran::semantics::HasCUDAAttr(*name.symbol)) {
+                sym = name.symbol;
+                return true;
+              }
+              return false;
+            },
+            [&](const Fortran::common::Indirection<
+                Fortran::parser::StructureComponent> &sc) {
+              if (sc.value().Component().symbol &&
+                  Fortran::semantics::HasCUDAAttr(
+                      *sc.value().Component().symbol)) {
+                sym = sc.value().Component().symbol;
+                return true;
+              }
+              return findCUDAAttrInDataRef(sc.value().Base(), sym);
+            },
+            [&](const Fortran::common::Indirection<
+                Fortran::parser::ArrayElement> &ae) {
+              return findCUDAAttrInDataRef(ae.value().Base(), sym);
+            },
+            [&](const Fortran::common::Indirection<
+                Fortran::parser::CoindexedNamedObject> &) { return false; },
+        },
+        ref.u);
+  }
+
+  /// When the allocate object is a structure component (e.g.,
+  /// managed_var(1)%component or a%b%c), walk the DataRef chain and check
+  /// whether any parent has CUDA attributes. If so, update \p sym to that
+  /// symbol and return true so allocations use its memory space.
   bool propagateCUDAAttrsFromParent(const Allocation &alloc,
                                     const Fortran::semantics::Symbol *&sym) {
     if (const auto *sc = std::get_if<Fortran::parser::StructureComponent>(
-            &alloc.getAllocObj().u)) {
-      const Fortran::parser::Name &baseName =
-          Fortran::parser::GetFirstName(*sc);
-      if (baseName.symbol &&
-          Fortran::semantics::HasCUDAAttr(*baseName.symbol)) {
-        sym = baseName.symbol;
-        return true;
-      }
-    }
+            &alloc.getAllocObj().u))
+      return findCUDAAttrInDataRef(sc->Base(), sym);
     return false;
   }
 

--- a/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
+++ b/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
@@ -41,7 +41,7 @@ end subroutine
 ! CHECK: fir.embox %{{.*}} {allocator_idx = 2 : i32}
 ! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<device>} -> i32
 
-! SOURCE= allocation of a managed component.
+! Managed component with source allocation.
 subroutine managed_component_source()
   use m
   type(chunk_type), managed, allocatable :: chunks(:)

--- a/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
+++ b/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
@@ -8,6 +8,9 @@ module m
   type :: chunk_type
     real(8), dimension(:,:), allocatable :: arr
   end type
+  type :: outer_type
+    type(chunk_type), allocatable :: inner(:)
+  end type
 end module
 
 ! Explicit managed attribute on variable with allocatable component.
@@ -57,3 +60,19 @@ end subroutine
 ! CHECK: hlfir.designate %{{.*}}{"arr"} {{.*}} : {{.*}} -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>>
 ! CHECK: fir.embox %{{.*}} {allocator_idx = 3 : i32}
 ! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> source({{.*}}) {data_attr = #cuf.cuda<managed>} -> i32
+
+! Nested structure component: outer(1)%inner(1)%arr walks the full chain.
+subroutine nested_managed_component()
+  use m
+  type(outer_type), managed, allocatable :: outer(:)
+  allocate(outer(1))
+  allocate(outer(1)%inner(1))
+  allocate(outer(1)%inner(1)%arr(10,10))
+  deallocate(outer)
+end subroutine
+
+! CHECK-LABEL: func.func @_QPnested_managed_component()
+! CHECK: cuf.allocate %{{.*}} : {{.*}} {data_attr = #cuf.cuda<managed>} -> i32
+! CHECK: hlfir.designate %{{.*}}{"arr"} {{.*}} : {{.*}} -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>>
+! CHECK: fir.embox %{{.*}} {allocator_idx = 3 : i32}
+! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<managed>} -> i32

--- a/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
+++ b/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
@@ -1,0 +1,59 @@
+! RUN: bbc -emit-hlfir -fcuda %s -o - | FileCheck %s
+
+! Test that allocating a component of a CUDA-attributed derived type variable
+! routes through the CUF allocator, not the default (host) allocator.
+! This ensures the component data lives in the same memory space as its parent.
+
+module m
+  type :: chunk_type
+    real(8), dimension(:,:), allocatable :: arr
+  end type
+end module
+
+! Explicit managed attribute on variable with allocatable component.
+subroutine managed_component()
+  use m
+  type(chunk_type), managed, allocatable :: chunks(:)
+  allocate(chunks(1))
+  allocate(chunks(1)%arr(10,10))
+  deallocate(chunks)
+end subroutine
+
+! CHECK-LABEL: func.func @_QPmanaged_component()
+! CHECK: cuf.allocate %{{.*}} : {{.*}} {data_attr = #cuf.cuda<managed>} -> i32
+! The component descriptor must be re-established with the managed allocator.
+! CHECK: hlfir.designate %{{.*}}{"arr"} {{.*}} : {{.*}} -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>>
+! CHECK: fir.embox %{{.*}} {allocator_idx = 3 : i32}
+! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<managed>} -> i32
+
+! Device attribute on variable with allocatable component.
+subroutine device_component()
+  use m
+  type(chunk_type), device, allocatable :: chunks(:)
+  allocate(chunks(1))
+  allocate(chunks(1)%arr(10,10))
+  deallocate(chunks)
+end subroutine
+
+! CHECK-LABEL: func.func @_QPdevice_component()
+! CHECK: cuf.allocate %{{.*}} : {{.*}} {data_attr = #cuf.cuda<device>} -> i32
+! CHECK: hlfir.designate %{{.*}}{"arr"} {{.*}} : {{.*}} -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>>
+! CHECK: fir.embox %{{.*}} {allocator_idx = 2 : i32}
+! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<device>} -> i32
+
+! SOURCE= allocation of a managed component.
+subroutine managed_component_source()
+  use m
+  type(chunk_type), managed, allocatable :: chunks(:)
+  real(8), allocatable :: src(:,:)
+  allocate(chunks(1))
+  allocate(src(10,10))
+  allocate(chunks(1)%arr, source=src)
+  deallocate(chunks)
+end subroutine
+
+! CHECK-LABEL: func.func @_QPmanaged_component_source()
+! CHECK: cuf.allocate %{{.*}} : {{.*}} {data_attr = #cuf.cuda<managed>} -> i32
+! CHECK: hlfir.designate %{{.*}}{"arr"} {{.*}} : {{.*}} -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>>
+! CHECK: fir.embox %{{.*}} {allocator_idx = 3 : i32}
+! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> source({{.*}}) {data_attr = #cuf.cuda<managed>} -> i32

--- a/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
+++ b/flang/test/Lower/CUDA/cuda-allocatable-component.cuf
@@ -8,8 +8,8 @@ module m
   type :: chunk_type
     real(8), dimension(:,:), allocatable :: arr
   end type
-  type :: outer_type
-    type(chunk_type), allocatable :: inner(:)
+  type :: outer_device_type
+    type(chunk_type), device, allocatable :: inner(:)
   end type
 end module
 
@@ -24,7 +24,6 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPmanaged_component()
 ! CHECK: cuf.allocate %{{.*}} : {{.*}} {data_attr = #cuf.cuda<managed>} -> i32
-! The component descriptor must be re-established with the managed allocator.
 ! CHECK: hlfir.designate %{{.*}}{"arr"} {{.*}} : {{.*}} -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>>
 ! CHECK: fir.embox %{{.*}} {allocator_idx = 3 : i32}
 ! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<managed>} -> i32
@@ -61,18 +60,17 @@ end subroutine
 ! CHECK: fir.embox %{{.*}} {allocator_idx = 3 : i32}
 ! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> source({{.*}}) {data_attr = #cuf.cuda<managed>} -> i32
 
-! Nested structure component: outer(1)%inner(1)%arr walks the full chain.
-subroutine nested_managed_component()
+! Intermediate component has device attribute, outermost variable does not.
+subroutine intermediate_device_component()
   use m
-  type(outer_type), managed, allocatable :: outer(:)
+  type(outer_device_type), allocatable :: outer(:)
   allocate(outer(1))
   allocate(outer(1)%inner(1))
   allocate(outer(1)%inner(1)%arr(10,10))
   deallocate(outer)
 end subroutine
 
-! CHECK-LABEL: func.func @_QPnested_managed_component()
-! CHECK: cuf.allocate %{{.*}} : {{.*}} {data_attr = #cuf.cuda<managed>} -> i32
+! CHECK-LABEL: func.func @_QPintermediate_device_component()
 ! CHECK: hlfir.designate %{{.*}}{"arr"} {{.*}} : {{.*}} -> !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>>
-! CHECK: fir.embox %{{.*}} {allocator_idx = 3 : i32}
-! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<managed>} -> i32
+! CHECK: fir.embox %{{.*}} {allocator_idx = 2 : i32}
+! CHECK: cuf.allocate %{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf64>>>> {data_attr = #cuf.cuda<device>} -> i32

--- a/flang/test/Lower/CUDA/cuda-data-transfer.cuf
+++ b/flang/test/Lower/CUDA/cuda-data-transfer.cuf
@@ -576,7 +576,7 @@ subroutine sub29()
 end subroutine
 
 ! CHECK-LABEL:  func.func @_QPsub29()
-! CHECK: %[[TMP:.*]] = fir.allocmem !fir.array<?xf16>, %24#1 {bindc_name = ".tmp", uniq_name = ""}
+! CHECK: %[[TMP:.*]] = fir.allocmem !fir.array<?xf16>, %{{.*}}#1 {bindc_name = ".tmp", uniq_name = ""}
 ! CHECK: %[[TMP_BUFFER:.*]]:2 = hlfir.declare %[[TMP]](%{{.*}}) {uniq_name = ".tmp"} : (!fir.heap<!fir.array<?xf16>>, !fir.shape<1>) -> (!fir.box<!fir.array<?xf16>>, !fir.heap<!fir.array<?xf16>>)
 ! CHECK: cuf.data_transfer %{{.*}} to %[[TMP_BUFFER]]#0 {transfer_kind = #cuf.cuda_transfer<device_host>} : !fir.box<!fir.heap<!fir.array<?xf16>>>, !fir.box<!fir.array<?xf16>>
 ! CHECK: hlfir.elemental 


### PR DESCRIPTION
When allocating a component of a CUDA-attributed derived type (e.g., `allocate(managed_var(1)%arr)`), Flang's lowering only checked the component symbol (`arr`) for CUDA attributes — not the parent variable (`managed_var`). Since `arr` has no CUDA attribute, the allocation used `fir.allocmem` (host `malloc`) instead of `cuf.allocate`. Additionally, the component descriptor's `allocator_idx` remained 0 (host default), so `Descriptor::Allocate()` also dispatched to `std::malloc`.

## Changes

- **Attribute propagation**: For `StructureComponent` allocations, propagate CUDA attributes from the base variable to the component in both `genSimpleAllocation` and `genSourceMoldAllocation`.

- **Allocator index**: In `genAllocateObjectInit`, re-establish the component descriptor with the correct `allocator_idx` via `disassociateMutableBox` before allocation.

- Added lit test `cuda-allocatable-component.cuf` covering managed, device, and `source=` component allocations.