### PR TITLE
[SystemZ][z/OS] Reapply "Add support of stack guard on z/OS (#206045)"

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3642,6 +3642,12 @@ static void RenderSSPOptions(const Driver &D, const ToolChain &TC,
         !EffectiveTriple.isSystemZ())
       D.Diag(diag::err_drv_unsupported_opt_for_target)
           << A->getAsString(Args) << TripleStr;
+    // z/OS only supports the tls mode.
+    if (EffectiveTriple.isOSzOS() && GuardValue != "tls") {
+      D.Diag(diag::err_drv_invalid_value_with_suggestion)
+          << A->getOption().getName() << GuardValue << "tls";
+      return;
+    }
     if ((EffectiveTriple.isX86() || EffectiveTriple.isARM() ||
          EffectiveTriple.isThumb() || EffectiveTriple.isSystemZ()) &&
         GuardValue != "tls" && GuardValue != "global") {

--- a/clang/test/Driver/stack-protector-guard.c
+++ b/clang/test/Driver/stack-protector-guard.c
@@ -178,3 +178,11 @@
 // RUN:  -mstack-protector-guard-record %s 2>&1 | \
 // RUN:  FileCheck -check-prefix=INVALID_TLS_RECORD_SYSTEMZ %s
 // INVALID_TLS_RECORD_SYSTEMZ: error: invalid argument '-mstack-protector-guard-record' only allowed with '-mstack-protector-guard=global'
+
+// RUN: %clang -### -target s390x-ibm-zos -mstack-protector-guard=tls %s 2>&1 | \
+// RUN:  FileCheck -check-prefix=CHECK_TLS_ZOS %s
+// CHECK_TLS_ZOS: "-cc1" {{.*}}"-mstack-protector-guard=tls"
+
+// RUN: not %clang -### -target s390x-ibm-zos -mstack-protector-guard=global %s 2>&1 | \
+// RUN:  FileCheck -check-prefix=INVALID_GLOBAL_ZOS %s
+// INVALID_GLOBAL_ZOS: invalid value 'global' in 'mstack-protector-guard=', expected one of: tls

--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -3544,7 +3544,8 @@ def isZOS : RuntimeLibcallPredicate<"TT.isOSzOS()">;
 def SystemZZOSSystemLibrary
     : SystemRuntimeLibrary<
           isSystemZZOS, (add DefaultLibcallImpls64,
-                            LibcallImpls<(add ZOSRuntimeLibcalls), isZOS>)>;
+                            LibcallImpls<(add ZOSRuntimeLibcalls), isZOS>,
+                            DefaultStackProtector)>;
 
 //===----------------------------------------------------------------------===//
 // WebAssembly Runtime Libcalls

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -1813,10 +1813,23 @@ void SystemZInstrInfo::expandStackGuardPseudo(MachineInstr &MI,
   // Emit an appropriate pseudo for the guard type, which loads the address of
   // said guard into the scratch register AddrReg.
   if (GuardType.empty() || (GuardType == "tls")) {
-    // Emit a load of the TLS block's address
-    BuildMI(MBB, MI, DL, get(SystemZ::LOAD_TLS_BLOCK_ADDR), AddrReg);
-    // Record the appropriate stack guard offset (40 in the tls case).
-    Offset = 40;
+    if (STI.isTargetzOS()) {
+      enum { OFFSET_PSALAA = 0x4B8 };
+      enum { OFFSET_CEELAA_STACK_GUARD = 0x98 };
+      // Load LAA
+      // LLGT <reg>,1208
+      BuildMI(MBB, MI, MI.getDebugLoc(), get(SystemZ::LLGT))
+          .addReg(MI.getOperand(0).getReg())
+          .addReg(0)
+          .addImm(OFFSET_PSALAA)
+          .addReg(0);
+      Offset = OFFSET_CEELAA_STACK_GUARD;
+    } else {
+      // Emit a load of the TLS block's address
+      BuildMI(MBB, MI, DL, get(SystemZ::LOAD_TLS_BLOCK_ADDR), AddrReg);
+      // Record the appropriate stack guard offset (40 in the tls case).
+      Offset = 40;
+    }
   } else if (GuardType == "global") {
     // Emit a load of the global stack guard's address
     BuildMI(MBB, MI, DL, get(SystemZ::LOAD_GLOBAL_STACKGUARD_ADDR), AddrReg);

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -1818,8 +1818,7 @@ void SystemZInstrInfo::expandStackGuardPseudo(MachineInstr &MI,
       enum { OFFSET_CEELAA_STACK_GUARD = 0x98 };
       // Load LAA
       // LLGT <reg>,1208
-      BuildMI(MBB, MI, MI.getDebugLoc(), get(SystemZ::LLGT))
-          .addReg(MI.getOperand(0).getReg())
+      BuildMI(MBB, MI, MI.getDebugLoc(), get(SystemZ::LLGT), AddrReg)
           .addReg(0)
           .addImm(OFFSET_PSALAA)
           .addReg(0);

--- a/llvm/test/CodeGen/SystemZ/zos-stack-protector.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-stack-protector.ll
@@ -1,0 +1,161 @@
+; Test the stack protector under XPLINK on z/OS
+;
+; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z13 | FileCheck --check-prefixes=CHECK %s
+
+; Test stack protector for non-XPLEAF.
+
+; Small stack frame.
+; CHECK-LABEL: func0
+; CHECK:                    * DSA Size [[#%#x,DSA_SIZE:]]
+; CHECK:                    aghi  4,-[[#%u,mul(div(DSA_SIZE,32),32)]]
+; CHECK:                    llgt  [[REG1:[0-9]+]],1208
+; CHECK:                    mvc   [[#%u,2040+mul(div(DSA_SIZE,32),32)]](8,4),152([[REG1]])
+; ...
+; CHECK:                    llgt  [[REG3:[0-9]+]],1208
+; CHECK:                    clc   [[#%u,2040+mul(div(DSA_SIZE,32),32)]](8,4),152([[REG3]])
+; CHECK:                    jlh   [[FAIL_LABEL:L#BB[0-9_]+]]
+; success block
+; CHECK:                    aghi  4,[[#%u,mul(div(DSA_SIZE,32),32)]]
+; CHECK:                    b     2(7)
+; failure block
+; CHECK:                    [[FAIL_LABEL]] DS 0H
+; invoke __stack_chk_fail
+; CHECK:                    lg    6,[[#CHK_FAIL_OFF:]]({{[0-9]+}})
+; CHECK:                    lg    5,[[#CHK_FAIL_OFF-8]]({{[0-9]+}})
+; CHECK:                    basr  7,6
+; CHECK-NEXT:               bcr   0,0
+
+define void @func0() sspreq {
+  call i64 (i64) @fun(i64 10)
+  ret void
+}
+
+; Large stack frame.
+; Larger than 1M in XPLINK64.
+; CHECK-LABEL: func1
+; CHECK:                    * DSA Size [[#%#x,DSA_SIZE:]]
+; CHECK:                    stmg  6,{{[0-9]+}},2064(4)
+; CHECK:                    llilh [[REG_CANARY_OFF_HIGH:[0-9]+]],[[#%u,CANARY_OFF_HIGH:div(DSA_SIZE,65536)]]
+; CHECK-DAG:                la    [[REG_CANARY_OFF_HIGH]],0([[REG_CANARY_OFF_HIGH]],4)
+; CHECK-DAG:                llgt  [[REG1:[0-9]+]],1208
+; CHECK:                    mvc   [[#%u,2040+mul(div(DSA_SIZE,32),32)-mul(CANARY_OFF_HIGH,65536)]](8,[[REG_CANARY_OFF_HIGH]]),152([[REG1]])
+; ...
+; CHECK:                    llilh [[REG_CANARY_OFF_HIGH_2:[0-9]+]],[[#%u,CANARY_OFF_HIGH_2:div(DSA_SIZE,65536)]]
+; CHECK:                    la    [[REG_CANARY_OFF_HIGH_2]],0([[REG_CANARY_OFF_HIGH_2]],4)
+; CHECK:                    llgt  [[REG3:[0-9]+]],1208
+; CHECK:                    clc   [[#%u,2040+mul(div(DSA_SIZE,32),32)-mul(CANARY_OFF_HIGH_2,65536)]](8,[[REG_CANARY_OFF_HIGH_2]]),152([[REG3]])
+; CHECK:                    jlh   [[FAIL_LABEL:L#BB[0-9_]+]]
+; success block
+; CHECK:                    agfi  4,[[#%u,mul(div(DSA_SIZE,32),32)]]
+; CHECK:                    b     2(7)
+; failure block
+; CHECK:                    [[FAIL_LABEL]] DS 0H
+; invoke __stack_chk_fail
+; CHECK:                    lg    6,[[#CHK_FAIL_OFF:]]({{[0-9]+}})
+; CHECK:                    lg    5,[[#CHK_FAIL_OFF-8]]({{[0-9]+}})
+; CHECK:                    basr  7,6
+; CHECK-NEXT:               bcr   0,0
+
+define void @func1() sspreq {
+  %arr = alloca [131072 x i64], align 8
+  call i64 (ptr) @fun1(ptr %arr)
+  ret void
+}
+
+; Test converting XPLeaf functions to non-leaf functions if they need stack protection
+
+; Based on func3_64 in call-zos-03.ll
+; CHECK-LABEL: func2_64
+; CHECK:                    * Entry Flags
+; CHECK-NEXT:               *   Bit 1: 0 = Non-leaf function
+define i64 @func2_64(i64 %arg0) sspreq {
+  %out = add i64 %arg0, 55
+  ret i64 %out
+}
+
+; Based on func6 in zos-prologue-epilog.ll. R15 is callee-saved, so needs to be
+; spilled to the stack before we use it. As a result this currently gets
+; converted to a non-leaf function (even without sspreq).
+; CHECK-LABEL: func3
+; CHECK:                    * Entry Flags
+; CHECK-NEXT:               *   Bit 1: 0 = Non-leaf function
+define void @func3() local_unnamed_addr sspreq #0 {
+entry:
+  tail call void asm sideeffect " lhi 15,1\0A", "~{r15}"()
+  ret void
+}
+
+; Test stack protector for function that uses alloca()
+
+; CHECK-LABEL: func4
+; CHECK:                    * DSA Size [[#%#x,DSA_SIZE:]]
+; CHECK:                    * Entry Flags
+; CHECK-NEXT:               *   Bit 1: 0 = Non-leaf function
+; CHECK-NEXT:               *   Bit 2: 1 = Uses alloca
+; CHECK:                    stmg  4,[[SPILLHI:[0-9]+]],[[#%u,2048-mul(div(DSA_SIZE,32),32)]](4)
+; CHECK:                    aghi  4,-[[#%u,mul(div(DSA_SIZE,32),32)]]
+; CHECK-DAG:                lgr   [[ALLOCAREG:[0-9]+]],4
+; CHECK-DAG:                llgt  [[REG1:[0-9]+]],1208
+; CHECK:                    mvc   [[#%u,2040+mul(div(DSA_SIZE,32),32)]](8,[[ALLOCAREG]]),152([[REG1]])
+; ...
+; CHECK:                    llgt  [[REG3:[0-9]+]],1208
+; CHECK:                    clc   [[#%u,2040+mul(div(DSA_SIZE,32),32)]](8,[[ALLOCAREG]]),152([[REG3]])
+; CHECK:                    jlh   [[FAIL_LABEL:L#BB[0-9_]+]]
+; success block
+; CHECK:                    lmg   4,[[SPILLHI]],2048(4)
+; CHECK:                    b     2(7)
+; failure block
+; CHECK:                    [[FAIL_LABEL]] DS 0H
+; invoke __stack_chk_fail
+; CHECK:                    lg    6,[[#CHK_FAIL_OFF:]]({{[0-9]+}})
+; CHECK:                    lg    5,[[#CHK_FAIL_OFF-8]]({{[0-9]+}})
+; CHECK:                    basr  7,6
+; CHECK-NEXT:               bcr   0,0
+
+define i64 @func4(i64 %n) sspreq {
+  %vla = alloca i64, i64 %n, align 8
+  %call = call i64 @fun2(i64 %n, ptr nonnull %vla, ptr nonnull %vla)
+  ret i64 %call
+}
+
+; Test stack protector off.
+
+; CHECK-LABEL: func5
+define void @func5() {
+  call i64 (i64) @fun(i64 10)
+  ret void
+}
+
+declare i64 @fun(i64 %arg0)
+declare i64 @fun1(ptr %ptr)
+declare i64 @fun2(i64 %n, ptr %arr0, ptr %arr1)
+
+; CHECK-LABEL: L#PPA1_func0_0 DS 0H
+; CHECK:                    * PPA1 Flags 2
+; CHECK-NOT:                * PPA1 Flags 3
+; CHECK:                    *   Bit 3: 1 = STACKPROTECT is enabled
+
+; CHECK-LABEL: L#PPA1_func1_0 DS 0H
+; CHECK:                    * PPA1 Flags 2
+; CHECK-NOT:                * PPA1 Flags 3
+; CHECK:                    *   Bit 3: 1 = STACKPROTECT is enabled
+
+; CHECK-LABEL: L#PPA1_func2_64_0 DS 0H
+; CHECK:                    * PPA1 Flags 2
+; CHECK-NOT:                * PPA1 Flags 3
+; CHECK:                    *   Bit 3: 1 = STACKPROTECT is enabled
+
+; CHECK-LABEL: L#PPA1_func3_0 DS 0H
+; CHECK:                    * PPA1 Flags 2
+; CHECK-NOT:                * PPA1 Flags 3
+; CHECK:                    *   Bit 3: 1 = STACKPROTECT is enabled
+
+; CHECK-LABEL: L#PPA1_func4_0 DS 0H
+; CHECK:                    * PPA1 Flags 2
+; CHECK-NOT:                * PPA1 Flags 3
+; CHECK:                    *   Bit 3: 1 = STACKPROTECT is enabled
+
+; CHECK-LABEL: L#PPA1_func5_0 DS 0H
+; CHECK:                    * PPA1 Flags 2
+; CHECK-NOT:                * PPA1 Flags 3
+; CHECK:                    *   Bit 3: 0 = STACKPROTECT is not enabled

--- a/llvm/test/CodeGen/SystemZ/zos-stack-protector.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-stack-protector.ll
@@ -1,6 +1,6 @@
 ; Test the stack protector under XPLINK on z/OS
 ;
-; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z13 | FileCheck --check-prefixes=CHECK %s
+; RUN: llc < %s -mtriple=s390x-ibm-zos -mcpu=z13 --verify-machineinstrs | FileCheck --check-prefixes=CHECK %s
 
 ; Test stack protector for non-XPLEAF.
 
@@ -35,14 +35,14 @@ define void @func0() sspreq {
 ; CHECK-LABEL: func1
 ; CHECK:                    * DSA Size [[#%#x,DSA_SIZE:]]
 ; CHECK:                    stmg  6,{{[0-9]+}},2064(4)
+; CHECK:                    llgt  [[REG1:[0-9]+]],1208
 ; CHECK:                    llilh [[REG_CANARY_OFF_HIGH:[0-9]+]],[[#%u,CANARY_OFF_HIGH:div(DSA_SIZE,65536)]]
-; CHECK-DAG:                la    [[REG_CANARY_OFF_HIGH]],0([[REG_CANARY_OFF_HIGH]],4)
-; CHECK-DAG:                llgt  [[REG1:[0-9]+]],1208
+; CHECK:                    la    [[REG_CANARY_OFF_HIGH]],0([[REG_CANARY_OFF_HIGH]],4)
 ; CHECK:                    mvc   [[#%u,2040+mul(div(DSA_SIZE,32),32)-mul(CANARY_OFF_HIGH,65536)]](8,[[REG_CANARY_OFF_HIGH]]),152([[REG1]])
 ; ...
+; CHECK:                    llgt  [[REG3:[0-9]+]],1208
 ; CHECK:                    llilh [[REG_CANARY_OFF_HIGH_2:[0-9]+]],[[#%u,CANARY_OFF_HIGH_2:div(DSA_SIZE,65536)]]
 ; CHECK:                    la    [[REG_CANARY_OFF_HIGH_2]],0([[REG_CANARY_OFF_HIGH_2]],4)
-; CHECK:                    llgt  [[REG3:[0-9]+]],1208
 ; CHECK:                    clc   [[#%u,2040+mul(div(DSA_SIZE,32),32)-mul(CANARY_OFF_HIGH_2,65536)]](8,[[REG_CANARY_OFF_HIGH_2]]),152([[REG3]])
 ; CHECK:                    jlh   [[FAIL_LABEL:L#BB[0-9_]+]]
 ; success block
@@ -94,8 +94,8 @@ entry:
 ; CHECK-NEXT:               *   Bit 2: 1 = Uses alloca
 ; CHECK:                    stmg  4,[[SPILLHI:[0-9]+]],[[#%u,2048-mul(div(DSA_SIZE,32),32)]](4)
 ; CHECK:                    aghi  4,-[[#%u,mul(div(DSA_SIZE,32),32)]]
-; CHECK-DAG:                lgr   [[ALLOCAREG:[0-9]+]],4
-; CHECK-DAG:                llgt  [[REG1:[0-9]+]],1208
+; CHECK:                    llgt  [[REG1:[0-9]+]],1208
+; CHECK:                    lgr   [[ALLOCAREG:[0-9]+]],4
 ; CHECK:                    mvc   [[#%u,2040+mul(div(DSA_SIZE,32),32)]](8,[[ALLOCAREG]]),152([[REG1]])
 ; ...
 ; CHECK:                    llgt  [[REG3:[0-9]+]],1208


### PR DESCRIPTION
This PR reapplies changes in PR Add support of stack guard on z/OS (#206045) and then
- Fixes a bug when emitting instruction `llgt`. The dest reg should be def.
- Adds `--verify-machineinstr` to lit test.