### PR TITLE
[Lanai] Force AsmPrinterEndPass

### DIFF
--- a/llvm/lib/Target/Lanai/LanaiCodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/Lanai/LanaiCodeGenPassBuilder.cpp
@@ -68,7 +68,7 @@ void LanaiCodeGenPassBuilder::addAsmPrinter(PassManagerWrapper &PMW) const {
 }
 
 void LanaiCodeGenPassBuilder::addAsmPrinterEnd(PassManagerWrapper &PMW) const {
-  addModulePass(LanaiAsmPrinterEndPass(), PMW);
+  addModulePass(LanaiAsmPrinterEndPass(), PMW, /*Force=*/true);
 }
 
 } // namespace


### PR DESCRIPTION
So that no pass instrumentation ends up preventing the addition of this necessary pass.

Also makes this consistent with X86.