### PR TITLE
[sema] Fix recursive concept detection

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -918,6 +918,8 @@ public:
        CodeCompleteConsumer *CompletionConsumer = nullptr);
   ~Sema();
 
+  llvm::SmallPtrSet<const NamedDecl *, 8> ActiveConcepts;
+
   /// Perform initialization that occurs after the parser has been
   /// initialized but before it parses anything.
   void Initialize();

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1051,6 +1051,16 @@ ExprResult ConstraintSatisfactionChecker::Evaluate(
     const MultiLevelTemplateArgumentList &MLTAL) {
 
   const ConceptReference *ConceptId = Constraint.getConceptId();
+  const NamedDecl *ConceptDecl = cast<clang::NamedDecl>(ConceptId->getNamedConcept()->getCanonicalDecl());
+
+  if (S.ActiveConcepts.contains(ConceptDecl)) {
+    S.Diag(ConceptId->getBeginLoc(), diag::err_recursive_concept)
+        << ConceptId->getNamedConcept()->getName();
+    Satisfaction.IsSatisfied = false;
+    Satisfaction.ContainsErrors = true;
+    return ExprError();
+  }
+
   Sema::InstantiatingTemplate InstTemplate(
       S, ConceptId->getBeginLoc(),
       Sema::InstantiatingTemplate::ConstraintsCheck{},
@@ -1069,7 +1079,7 @@ ExprResult ConstraintSatisfactionChecker::Evaluate(
   unsigned Size = Satisfaction.Details.size();
 
   llvm::SaveAndRestore PushConceptDecl(
-      ParentConcept, cast<ConceptDecl>(ConceptId->getNamedConcept()));
+      ParentConcept, cast<clang::ConceptDecl>(ConceptId->getNamedConcept()));
 
   ExprResult E = Evaluate(Constraint.getNormalizedConstraint(), MLTAL);
 

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1051,7 +1051,7 @@ ExprResult ConstraintSatisfactionChecker::Evaluate(
     const MultiLevelTemplateArgumentList &MLTAL) {
 
   const ConceptReference *ConceptId = Constraint.getConceptId();
-  const NamedDecl *ConceptDecl = 
+  const NamedDecl *ConceptDecl =
       cast<clang::NamedDecl>(ConceptId->getNamedConcept()->getCanonicalDecl());
 
   if (S.ActiveConcepts.contains(ConceptDecl)) {

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1051,7 +1051,8 @@ ExprResult ConstraintSatisfactionChecker::Evaluate(
     const MultiLevelTemplateArgumentList &MLTAL) {
 
   const ConceptReference *ConceptId = Constraint.getConceptId();
-  const NamedDecl *ConceptDecl = cast<clang::NamedDecl>(ConceptId->getNamedConcept()->getCanonicalDecl());
+  const NamedDecl *ConceptDecl = 
+      cast<clang::NamedDecl>(ConceptId->getNamedConcept()->getCanonicalDecl());
 
   if (S.ActiveConcepts.contains(ConceptDecl)) {
     S.Diag(ConceptId->getBeginLoc(), diag::err_recursive_concept)

--- a/clang/test/SemaCXX/recursive-concept-alias.cpp
+++ b/clang/test/SemaCXX/recursive-concept-alias.cpp
@@ -1,0 +1,3 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+template<typename T> concept C1 = C1<T>; // expected-error {{a concept definition cannot refer to itself}} expected-note {{here}}


### PR DESCRIPTION
This patch improves Clang's handling of recursive concept alias expansions in C++20 concepts. Previously, recursive concept definitions caused infinite recursion during semantic analysis, leading to compiler crashes or undefined behavior.

Fixes #206336 