### PR TITLE
[RISCV] Make Za64rs imply Za128rs

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -256,11 +256,12 @@ def HasStdExtZtso : Predicate<"Subtarget->hasStdExtZtso()">,
                         "'Ztso' (Memory Model - Total Store Order)">;
 def NoStdExtZtso : Predicate<"!Subtarget->hasStdExtZtso()">;
 
-def FeatureStdExtZa64rs
-    : RISCVExtension<1, 0, "Reservation Set Size of at Most 64 Bytes">;
-
 def FeatureStdExtZa128rs
     : RISCVExtension<1, 0, "Reservation Set Size of at Most 128 Bytes">;
+
+def FeatureStdExtZa64rs
+    : RISCVExtension<1, 0, "Reservation Set Size of at Most 64 Bytes",
+                     [FeatureStdExtZa128rs]>;
 
 def FeatureStdExtZabha
     : RISCVExtension<1, 0, "Byte and Halfword Atomic Memory Operations",

--- a/llvm/test/MC/RISCV/attribute-arch.s
+++ b/llvm/test/MC/RISCV/attribute-arch.s
@@ -286,7 +286,7 @@
 # CHECK: attribute      5, "rv32i2p1_za128rs1p0"
 
 .attribute arch, "rv32iza64rs1p0"
-# CHECK: attribute      5, "rv32i2p1_za64rs1p0"
+# CHECK: attribute      5, "rv32i2p1_za128rs1p0_za64rs1p0"
 
 .attribute arch, "rv32izama16b"
 # CHECK: attribute      5, "rv32i2p1_zama16b1p0"


### PR DESCRIPTION
Per the RISC-V ISA specification, the Za64rs extension implies the Za128rs extension. This change adds Za128rs to the implied extensions list of Za64rs in RISCVFeatures.td, so that enabling Za64rs automatically enables Za128rs.

Specification reference:
https://github.com/riscv/riscv-isa-manual/blob/riscv-isa-release-dc8bf2a-2026-06-26/src/unpriv/zars.adoc

The test expectation in attribute-arch.s is updated to reflect that za64rs now implies za128rs in the arch attribute string.