### PR TITLE
[flang-rt][AIX] Set OBJECT_MODE=any in flang-rt test

### DIFF
--- a/flang-rt/test/lit.cfg.py
+++ b/flang-rt/test/lit.cfg.py
@@ -117,3 +117,8 @@ if config.flang_rt_experimental_offload_support == "CUDA":
 
 if config.flang_rt_fortran_modules:
     config.available_features.add("fortran-modules")
+
+# Tools that support OBJECT_MODE default to 32-bit on AIX. Set
+# OBJECT_MODE=any to handle both 32-bit and 64-bit objects.
+if "system-aix" in config.available_features:
+    config.environment["OBJECT_MODE"] = "any"


### PR DESCRIPTION
This patch to set OBJECT_MODE=any on AIX to have tools able to handle both different bit mode objects.

This fixes the compare_iso_fortran_env_symbols.f90 failure on AIX. The default of llvm-nm is 32-bit but the objects in the test is 64-bit. Setting OBJECT_MODE=any allows the tool accepts either bit modes.