### PR TITLE
[SimplifyCFG] Don't hoist instructions with mismatched !nontemporal

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -1963,8 +1963,11 @@ bool SimplifyCFGOpt::hoistCommonCodeFromSuccessors(Instruction *TI,
     for (auto &SuccIter : OtherSuccIterRange) {
       Instruction *I2 = &*SuccIter;
       HasTerminator |= I2->isTerminator();
-      if (AllInstsAreIdentical && (!areIdenticalUpToCommutativity(I1, I2) ||
-                                   MMRAMetadata(*I1) != MMRAMetadata(*I2)))
+      if (AllInstsAreIdentical &&
+          (!areIdenticalUpToCommutativity(I1, I2) ||
+           MMRAMetadata(*I1) != MMRAMetadata(*I2) ||
+           I1->getMetadata(LLVMContext::MD_nontemporal) !=
+               I2->getMetadata(LLVMContext::MD_nontemporal)))
         AllInstsAreIdentical = false;
     }
 

--- a/llvm/test/Transforms/SimplifyCFG/hoist-with-metadata.ll
+++ b/llvm/test/Transforms/SimplifyCFG/hoist-with-metadata.ll
@@ -689,6 +689,94 @@ out:
   ret void
 }
 
+define void @hoist_memcpy_nontemporal_both(i1 %c, ptr %d, ptr %s) {
+; CHECK-LABEL: @hoist_memcpy_nontemporal_both(
+; CHECK-NEXT:  if:
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr [[D:%.*]], ptr [[S:%.*]], i64 64, i1 false), !nontemporal [[META15:![0-9]+]]
+; CHECK-NEXT:    ret void
+;
+if:
+  br i1 %c, label %then, label %else
+then:
+  call void @llvm.memcpy.p0.p0.i64(ptr %d, ptr %s, i64 64, i1 false), !nontemporal !15
+  br label %out
+else:
+  call void @llvm.memcpy.p0.p0.i64(ptr %d, ptr %s, i64 64, i1 false), !nontemporal !15
+  br label %out
+out:
+  ret void
+}
+
+define void @hoist_memcpy_nontemporal_one(i1 %c, ptr %d, ptr %s) {
+; CHECK-LABEL: @hoist_memcpy_nontemporal_one(
+; CHECK-NEXT:  if:
+; CHECK-NEXT:    br i1 [[C:%.*]], label [[THEN:%.*]], label [[ELSE:%.*]]
+; CHECK:       then:
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr [[D:%.*]], ptr [[S:%.*]], i64 64, i1 false), !nontemporal [[META15]]
+; CHECK-NEXT:    br label [[OUT:%.*]]
+; CHECK:       else:
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr [[D]], ptr [[S]], i64 64, i1 false)
+; CHECK-NEXT:    br label [[OUT]]
+; CHECK:       out:
+; CHECK-NEXT:    ret void
+;
+if:
+  br i1 %c, label %then, label %else
+then:
+  call void @llvm.memcpy.p0.p0.i64(ptr %d, ptr %s, i64 64, i1 false), !nontemporal !15
+  br label %out
+else:
+  call void @llvm.memcpy.p0.p0.i64(ptr %d, ptr %s, i64 64, i1 false)
+  br label %out
+out:
+  ret void
+}
+
+declare void @llvm.memcpy.p0.p0.i64(ptr, ptr, i64, i1)
+
+define void @hoist_store_nontemporal_both(i1 %c, ptr %p) {
+; CHECK-LABEL: @hoist_store_nontemporal_both(
+; CHECK-NEXT:  if:
+; CHECK-NEXT:    store i32 0, ptr [[P:%.*]], align 4, !nontemporal [[META15]]
+; CHECK-NEXT:    ret void
+;
+if:
+  br i1 %c, label %then, label %else
+then:
+  store i32 0, ptr %p, !nontemporal !15
+  br label %out
+else:
+  store i32 0, ptr %p, !nontemporal !15
+  br label %out
+out:
+  ret void
+}
+
+define void @hoist_store_nontemporal_one(i1 %c, ptr %p) {
+; CHECK-LABEL: @hoist_store_nontemporal_one(
+; CHECK-NEXT:  if:
+; CHECK-NEXT:    br i1 [[C:%.*]], label [[THEN:%.*]], label [[ELSE:%.*]]
+; CHECK:       then:
+; CHECK-NEXT:    store i32 0, ptr [[P:%.*]], align 4, !nontemporal [[META15]]
+; CHECK-NEXT:    br label [[OUT:%.*]]
+; CHECK:       else:
+; CHECK-NEXT:    store i32 0, ptr [[P]], align 4
+; CHECK-NEXT:    br label [[OUT]]
+; CHECK:       out:
+; CHECK-NEXT:    ret void
+;
+if:
+  br i1 %c, label %then, label %else
+then:
+  store i32 0, ptr %p, !nontemporal !15
+  br label %out
+else:
+  store i32 0, ptr %p
+  br label %out
+out:
+  ret void
+}
+
 !0 = !{ i8 0, i8 1 }
 !1 = !{ i8 3, i8 5 }
 !2 = !{}
@@ -704,6 +792,9 @@ out:
 !12 = !{ !"nvvm.l1_eviction", !"first" }
 !13 = !{ i32 0, !14 }
 !14 = !{ !"nvvm.l1_eviction", !"last" }
+!15 = !{ i32 1 }
+;.
+; CHECK: attributes #[[ATTR0:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 ;.
 ; CHECK: [[RNG0]] = !{i8 0, i8 1, i8 3, i8 5}
 ; CHECK: [[RNG1]] = !{i8 0, i8 1, i8 3, i8 5, i8 7, i8 9}
@@ -720,4 +811,5 @@ out:
 ; CHECK: [[META12]] = !{i32 3}
 ; CHECK: [[META13]] = !{i32 1, [[META14:![0-9]+]]}
 ; CHECK: [[META14]] = !{!"nvvm.l1_eviction", !"first"}
+; CHECK: [[META15]] = !{i32 1}
 ;.


### PR DESCRIPTION
## Summary

`SimplifyCFG`'s `hoistCommonCodeFromSuccessors()` can merge two identical
instructions from sibling blocks even when only one carries `!nontemporal`,
silently dropping the cache-bypass hint. This treats `!nontemporal` as part of
the operation identity so the asymmetric case is no longer merged.

## Problem

The equivalence check (`areIdenticalUpToCommutativity` → `isSameOperationAs`)
ignores metadata, so two ops differing only in `!nontemporal` are hoisted into
one. `combineMetadataForCSE()` then keeps the hint only if *both* had it, so when
one side lacks it the hint is dropped. It is a hint (no UB), but the loss is
asymmetric and unrecoverable after SimplifyCFG (e.g. a hoisted memcpy lowers to a
normal copy instead of streaming `movnt*`).

```llvm
define void @hoist_memcpy(i1 %c, ptr %d, ptr %s) {
entry:
  br i1 %c, label %then, label %else
then:
  call void @llvm.memcpy.p0.p0.i64(ptr %d, ptr %s, i64 64, i1 false), !nontemporal !0
  br label %tail
else:
  call void @llvm.memcpy.p0.p0.i64(ptr %d, ptr %s, i64 64, i1 false)
  br label %tail
tail:
  ret void
}
!0 = !{ i32 1 }
```

## Fix

Compare `!nontemporal` in the equivalence check, alongside the existing `MMRA`
check: don't merge when only one side carries it; when both do, hoist and preserve
it. The check applies to any instruction, but is a no-op except for the ops that
can carry the hint (loads, stores, memory intrinsics) — so it also covers the
load/store variants of the same defect, not just memcpy.

## Testing

Added both/one-sided `memcpy` and `store` cases to
`llvm/test/Transforms/SimplifyCFG/hoist-with-metadata.ll`

## Related

Same `!nontemporal`-dropped-on-merge family from the FuzzX effort; this PR fixes
only the SimplifyCFG hoisting case (bug 183). Others tracked separately: SimplifyCFG
`mergeConditionalStores` (192), InstCombine `mergeStoreIntoSuccessor` (221), MemCpyOpt
(200, 201), LoopUnroll load-CSE (225).

Question: would you prefer separate per-pass PRs (like this one) for
the rest, or a single combined PR?

## Credit

Found via @jlebar's X86 LLVM bug-hunt / FuzzX effort:
https://github.com/SemiAnalysisAI/FuzzX/tree/master/x86/bugs/183-simplifycfg-hoist-memintrinsic-drops-nontemporal

cc @jlebar 