### PR TITLE
[sanitizer] Raise kMaxAllowedMallocSize to 1TB on AArch64

### DIFF
--- a/compiler-rt/lib/lsan/lsan_allocator.cpp
+++ b/compiler-rt/lib/lsan/lsan_allocator.cpp
@@ -28,7 +28,7 @@ extern "C" void *memset(void *ptr, int value, uptr num);
 namespace __lsan {
 #if defined(__i386__) || defined(__arm__)
 static const uptr kMaxAllowedMallocSize = 1ULL << 30;
-#elif defined(__mips64) || defined(__aarch64__)
+#elif defined(__mips64)
 static const uptr kMaxAllowedMallocSize = 4ULL << 30;
 #else
 static const uptr kMaxAllowedMallocSize = 1ULL << 40;

--- a/compiler-rt/lib/msan/msan_allocator.cpp
+++ b/compiler-rt/lib/msan/msan_allocator.cpp
@@ -145,7 +145,7 @@ struct AP32 {
 };
 using PrimaryAllocator = SizeClassAllocator32<AP32>;
 #elif defined(__aarch64__)
-const uptr kMaxAllowedMallocSize = 8UL << 30;
+const uptr kMaxAllowedMallocSize = 1UL << 40;
 
 struct AP64 {
   static const uptr kSpaceBeg = 0xE00000000000ULL;


### PR DESCRIPTION
lsan capped AArch64 allocations at 4GB and msan at 8GB. These limits were tied to the smaller address space of the 32-bit-style allocator.

This became possible after 8e0c1aaf6ba3 ("[msan] Use SizeClassAllocator64 for AArch64"), which (together with the 48-bit VMA requirement) switched AArch64 to SizeClassAllocator64, so the limit can now match the other 64-bit targets (1ULL << 40).

Follow-up for #89728