### PR TITLE
[libunwind] Fix comment about phase (NFC)

### DIFF
--- a/libunwind/src/Unwind-wasm.c
+++ b/libunwind/src/Unwind-wasm.c
@@ -54,7 +54,7 @@ _Unwind_Reason_Code _Unwind_CallPersonality(void *exception_ptr) {
   __wasm_lpad_context.selector = 0;
 
   // Call personality function. Wasm does not have two-phase unwinding, so we
-  // only do the cleanup phase.
+  // only do the search phase.
   return __gxx_personality_wasm0(
       1, _UA_SEARCH_PHASE, exception_object->exception_class, exception_object,
       (struct _Unwind_Context *)&__wasm_lpad_context);


### PR DESCRIPTION
We switched to use `_UA_SEARCH_PHASE` in https://github.com/emscripten-core/emscripten/pull/17991, but the comment above was not fixed, and it was upstreamed that way later.