### PR TITLE
[libc++][test][NFC] Remove implementation-detail noise from _BitInt test comments

### DIFF
--- a/libcxx/test/libcxx/concepts/concepts.arithmetic/__libcpp_signed_integer.compile.pass.cpp
+++ b/libcxx/test/libcxx/concepts/concepts.arithmetic/__libcpp_signed_integer.compile.pass.cpp
@@ -62,9 +62,8 @@ static_assert(!std::__signed_integer<SomeObject>);
 static_assert(!std::__signed_integer<SomeEnum>);
 static_assert(!std::__signed_integer<SomeScopedEnum>);
 
-// cv-qualified versions are distinct types ([basic.type.qualifier]) and so
-// not signed integer types per [basic.fundamental]/p1. The three meaningful
-// flavors in C++ are const, volatile, and const volatile.
+// cv-qualified versions are distinct types ([basic.type.qualifier]) and not
+// signed integer types per [basic.fundamental]/p1.
 static_assert(!std::__signed_integer<const int>);
 static_assert(!std::__signed_integer<volatile int>);
 static_assert(!std::__signed_integer<const volatile int>);

--- a/libcxx/test/libcxx/concepts/concepts.arithmetic/__libcpp_unsigned_integer.compile.pass.cpp
+++ b/libcxx/test/libcxx/concepts/concepts.arithmetic/__libcpp_unsigned_integer.compile.pass.cpp
@@ -62,9 +62,8 @@ static_assert(!std::__unsigned_integer<SomeObject>);
 static_assert(!std::__unsigned_integer<SomeEnum>);
 static_assert(!std::__unsigned_integer<SomeScopedEnum>);
 
-// cv-qualified versions are distinct types ([basic.type.qualifier]) and so
-// not unsigned integer types per [basic.fundamental]/p2. The three meaningful
-// flavors in C++ are const, volatile, and const volatile.
+// cv-qualified versions are distinct types ([basic.type.qualifier]) and not
+// unsigned integer types per [basic.fundamental]/p2.
 static_assert(!std::__unsigned_integer<const unsigned int>);
 static_assert(!std::__unsigned_integer<volatile unsigned int>);
 static_assert(!std::__unsigned_integer<const volatile unsigned int>);

--- a/libcxx/test/std/containers/views/mdspan/extents/bitint.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/bitint.pass.cpp
@@ -13,12 +13,9 @@
 // template<class IndexType, size_t... Extents>
 //  class extents;
 //
-// After [libc++] recognized _BitInt as an integer type in
-// __type_traits/integer_traits.h, extents silently starts accepting
-// _BitInt(N) as IndexType because __signed_or_unsigned_integer is now
-// satisfied. This test pins that behavior: construction, extent() and
-// static_extent() all work, and the representability static_assert on
-// static extents fires when the extent does not fit in the index type.
+// extents accepts _BitInt(N) as IndexType now that libc++ treats it as an
+// integer type. Pin construction, extent(), static_extent(), and the
+// representability static_assert on static extents that exceed the index type.
 
 #include <cassert>
 #include <cstddef>

--- a/libcxx/test/std/language.support/support.limits/limits/numeric.limits.members/digits10.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/limits/numeric.limits.members/digits10.pass.cpp
@@ -87,10 +87,8 @@ int main(int, char**)
     test<signed _BitInt(4096), 1232>();   // digits=4095, log10=1232.7
 #  endif
 
-    // Very wide _BitInt: pin the log10(2) approximation used by digits10.
-    // Each width is the first point at which a coarser rational convergent
-    // of log10(2) would give the wrong floor, so these tests bite if the
-    // formula ever regresses.
+    // Each width is the first point where a coarser rational convergent of
+    // log10(2) would give the wrong floor.
 #  if __BITINT_MAXWIDTH__ >= 15437
     // A coarser convergent (643/2136) would give 4646 here; correct is 4647.
     test<unsigned _BitInt(15437), 4647>();
@@ -106,9 +104,8 @@ int main(int, char**)
     // Pin the exact upper bound of the approximation.
     test<unsigned _BitInt(8388608), 2525222>();
 #  endif
-    // The 1936274/6432163 convergent stays exact up to d=51132156. 8388608 is
-    // the largest width tested above, so if Clang raises __BITINT_MAXWIDTH__,
-    // extend the coverage before trusting the formula at the new range.
+    // The 1936274/6432163 convergent stays exact to d=51132156, above the
+    // current max width; the static_assert flags any future increase.
     LIBCPP_STATIC_ASSERT(__BITINT_MAXWIDTH__ <= 8388608, "extend digits10 _BitInt coverage for the new maximum width");
 #endif // TEST_HAS_BITINT
 

--- a/libcxx/test/std/language.support/support.limits/limits/numeric.limits.members/max.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/limits/numeric.limits.members/max.pass.cpp
@@ -66,12 +66,8 @@ int main(int, char**)
     test<long double>(LDBL_MAX);
 
     // _BitInt(N): max is 2^N - 1 for unsigned and 2^(N-1) - 1 for signed.
-    // Exercises the digits fix through `__max = ~0 ^ __min`.
-    // TODO: Remove guards for MSan once https://llvm.org/PR204217 is fixed.
-    // MSan does not track _BitInt padding bits, so non-byte-aligned widths
-    // surface as false-positive use-of-uninitialized-value through the
-    // numeric_limits::max() shift; restrict to byte-aligned widths under
-    // memory sanitizer.
+    // MSan flags the padding bits of non-byte-aligned widths; guarded below.
+    // TODO: drop the MSan guards once https://llvm.org/PR204217 is fixed.
 #if TEST_HAS_BITINT
     test<unsigned _BitInt(8)>((unsigned _BitInt(8)) ~(unsigned _BitInt(8))0);
     test<signed _BitInt(8)>((signed _BitInt(8))0x7F);

--- a/libcxx/test/std/language.support/support.limits/limits/numeric.limits.members/min.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/limits/numeric.limits.members/min.pass.cpp
@@ -65,14 +65,9 @@ int main(int, char**)
     test<double>(DBL_MIN);
     test<long double>(LDBL_MIN);
 
-    // _BitInt(N): min is 0 for unsigned and -2^(N-1) for signed. The shift
-    // `1 << digits` flowed through the buggy digits field, so this also
-    // exercises the digits fix for non-byte-aligned widths.
-    // TODO: Remove guards for MSan once https://llvm.org/PR204217 is fixed.
-    // MSan does not track _BitInt padding bits, so non-byte-aligned widths
-    // surface as false-positive use-of-uninitialized-value through the
-    // numeric_limits::min() shift; restrict to byte-aligned widths under
-    // memory sanitizer.
+    // _BitInt(N): min is 0 for unsigned and -2^(N-1) for signed.
+    // MSan flags the padding bits of non-byte-aligned widths; guarded below.
+    // TODO: drop the MSan guards once https://llvm.org/PR204217 is fixed.
 #if TEST_HAS_BITINT
     // signed _BitInt(N) min is -2^(N-1). Build via unsigned shift then cast to
     // avoid integer-overflow warnings (-Werror,-Winteger-overflow).

--- a/libcxx/test/std/numerics/bit/bit.pow.two/bit_floor.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bit.pow.two/bit_floor.pass.cpp
@@ -140,8 +140,7 @@ int main(int, char**)
     test<std::size_t>();
 
     // _BitInt tests. Width tiers follow C23 7.18.2.5.
-    // bit_floor uses numeric_limits::digits via __bit_log2, so only
-    // byte-aligned widths are safe.
+    // bit_floor depends on numeric_limits::digits, so only byte-aligned widths.
 #if TEST_HAS_BITINT
     {
       using T32 = unsigned _BitInt(32);

--- a/libcxx/test/std/numerics/bit/bit.pow.two/bit_width.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bit.pow.two/bit_width.pass.cpp
@@ -143,8 +143,7 @@ int main(int, char**)
     test<std::size_t>();
 
     // _BitInt tests. Width tiers follow C23 7.18.2.5.
-    // bit_width uses numeric_limits::digits via __bit_log2, so only
-    // byte-aligned widths are safe.
+    // bit_width depends on numeric_limits::digits, so only byte-aligned widths.
 #if TEST_HAS_BITINT
     {
       using T32 = unsigned _BitInt(32);

--- a/libcxx/test/std/numerics/bit/bitops.count/countl_zero.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bitops.count/countl_zero.pass.cpp
@@ -167,8 +167,7 @@ int main(int, char**)
       assert(std::countl_zero(T64(T64(1) << 63)) == 0);
       assert(std::countl_zero(T64(~T64(0))) == 0);
 
-      // Odd widths: safe for nonzero inputs only (digits is the fallback
-      // for zero via __builtin_clzg).
+      // Odd widths: safe for nonzero inputs only.
       assert(std::countl_zero(T13(1)) == 12);
       assert(std::countl_zero(T13(2)) == 11);
       assert(std::countl_zero(T13(3)) == 11);

--- a/libcxx/test/std/numerics/bit/bitops.rot/rotl.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bitops.rot/rotl.pass.cpp
@@ -166,8 +166,7 @@ int main(int, char**)
     test<std::size_t>();
 
     // _BitInt tests. Width tiers follow C23 7.18.2.5.
-    // rotl uses numeric_limits::digits internally, so only byte-aligned
-    // widths are safe (where digits matches the actual bit width).
+    // rotl depends on numeric_limits::digits, so only byte-aligned widths.
 #if TEST_HAS_BITINT
     {
       using T32 = unsigned _BitInt(32);

--- a/libcxx/test/std/numerics/bit/bitops.rot/rotr.pass.cpp
+++ b/libcxx/test/std/numerics/bit/bitops.rot/rotr.pass.cpp
@@ -166,8 +166,7 @@ int main(int, char**)
     test<std::size_t>();
 
     // _BitInt tests. Width tiers follow C23 7.18.2.5.
-    // rotr uses numeric_limits::digits internally, so only byte-aligned
-    // widths are safe.
+    // rotr depends on numeric_limits::digits, so only byte-aligned widths.
 #if TEST_HAS_BITINT
     {
       using T32 = unsigned _BitInt(32);

--- a/libcxx/test/std/numerics/bit/byteswap.pass.cpp
+++ b/libcxx/test/std/numerics/bit/byteswap.pass.cpp
@@ -27,10 +27,7 @@ static_assert(!has_byteswap<float>);
 static_assert(!has_byteswap<char[2]>);
 static_assert(!has_byteswap<std::byte>);
 
-// _BitInt(N) candidacy is controlled by the `integral` constraint; the
-// padding-bit rejection (per [bit.byteswap]/Mandates) is a static_assert
-// inside the function body, not a SFINAE check. See byteswap.verify.cpp
-// for diagnostic verification of the rejected widths.
+// _BitInt(N) widths with padding bits are rejected; see byteswap.verify.cpp.
 
 template <class T>
 constexpr void test_num(T in, T expected) {
@@ -100,32 +97,26 @@ constexpr bool test() {
   test_implementation_defined_size<unsigned long long>();
 
 #if TEST_HAS_BITINT
-  // _BitInt(N) where digits + is_signed == sizeof * CHAR_BIT (no padding
-  // bits) is accepted; other widths are rejected by the static_assert
-  // inside the function body (see byteswap.verify.cpp).
+  // Widths below have no padding bits.
 
   // sizeof == 1
   test_num<unsigned _BitInt(8)>(0xAB, 0xAB);
   test_num<signed _BitInt(8)>(0x12, 0x12);
 
-  // sizeof == 2: __builtin_bswap16 fallback or __builtin_bswapg
+  // sizeof == 2
   test_num<unsigned _BitInt(16)>(0xCDEF, 0xEFCD);
   test_num<signed _BitInt(16)>(0x1234, 0x3412);
 
-  // sizeof == 4: __builtin_bswap32 fallback or __builtin_bswapg
+  // sizeof == 4
   test_num<unsigned _BitInt(32)>(0x01234567U, 0x67452301U);
   test_num<signed _BitInt(32)>(0x01234567, 0x67452301);
 
-  // sizeof == 8: __builtin_bswap64 fallback or __builtin_bswapg
+  // sizeof == 8
   test_num<unsigned _BitInt(64)>(0x0123456789ABCDEFULL, 0xEFCDAB8967452301ULL);
   test_num<signed _BitInt(64)>(0x0123456789ABCDEFLL, static_cast<signed _BitInt(64)>(0xEFCDAB8967452301ULL));
 
 #  if __BITINT_MAXWIDTH__ >= 128 && (TEST_HAS_BUILTIN(__builtin_bswapg) || !defined(TEST_HAS_NO_INT128))
-  // sizeof == 16: __builtin_bswap128 fallback or __builtin_bswapg. Targets
-  // without libc++ __int128 (32-bit ARM, MSVC ABI on Windows clang-cl) and an
-  // older compiler that lacks __builtin_bswapg cannot byteswap a 16-byte
-  // value; skip the block. TEST_HAS_NO_INT128 mirrors libc++'s
-  // _LIBCPP_HAS_INT128 (false on _MSC_VER even when __SIZEOF_INT128__ is set).
+  // sizeof == 16
   unsigned _BitInt(128) v128 =
       (static_cast<unsigned _BitInt(128)>(0x0123456789ABCDEFULL) << 64) |
       static_cast<unsigned _BitInt(128)>(0x13579BDF02468ACEULL);
@@ -137,8 +128,7 @@ constexpr bool test() {
 #  endif
 
 #  if TEST_HAS_BUILTIN(__builtin_bswapg) && __BITINT_MAXWIDTH__ >= 256
-  // sizeof > 16: only the __builtin_bswapg path supports widths beyond what
-  // __builtin_bswap16/32/64/128 cover.
+  // sizeof > 16
   unsigned _BitInt(256) v256 =
       (static_cast<unsigned _BitInt(256)>(0xDEADBEEFCAFEBABEULL) << 128) |
       (static_cast<unsigned _BitInt(256)>(0x1234567890ABCDEFULL) << 64) |
@@ -147,13 +137,12 @@ constexpr bool test() {
   ASSERT_SAME_TYPE(decltype(std::byteswap(v256)), unsigned _BitInt(256));
   ASSERT_NOEXCEPT(std::byteswap(v256));
 
-  // Spot check: low byte of input must end up as the high byte of the output.
+  // Low byte of the input must become the high byte of the output.
   unsigned _BitInt(256) lo_only = 0xAB;
   auto lo_swapped               = std::byteswap(lo_only);
   assert(static_cast<unsigned char>(lo_swapped >> ((sizeof(lo_swapped) - 1) * CHAR_BIT)) == 0xAB);
 
-  // Mid-value test: a distinct byte at every position so an off-by-one in the
-  // generated code surfaces directly.
+  // A distinct byte at every position catches an off-by-one in the swap.
   unsigned _BitInt(256) ramp = 0;
   for (int i = 0; i < 32; ++i)
     ramp |= static_cast<unsigned _BitInt(256)>(i) << (i * CHAR_BIT);

--- a/libcxx/test/std/numerics/numeric.ops/numeric.ops.sat/saturating.bitint.pass.cpp
+++ b/libcxx/test/std/numerics/numeric.ops/numeric.ops.sat/saturating.bitint.pass.cpp
@@ -8,11 +8,8 @@
 
 // REQUIRES: std-at-least-c++26
 
-// TODO(LLVM25): Remove these restrictions.
-// Clang <= 22 mis-evaluates std::saturating_mul on non-byte-aligned _BitInt at
-// compile time. See https://llvm.org/PR204085 (fixed in Clang 23 via
-// https://llvm.org/PR192568). The latest version of Android Clang still has
-// this bug.
+// TODO(LLVM25): remove these guards. Clang <= 22 mis-evaluates
+// std::saturating_mul on non-byte-aligned _BitInt. https://llvm.org/PR204085
 // UNSUPPORTED: clang-19, clang-20, clang-21, clang-22
 // UNSUPPORTED: apple-clang-17, apple-clang-18, apple-clang-19, apple-clang-20, apple-clang-21
 // UNSUPPORTED: target={{.+}}-android{{.*}}
@@ -191,9 +188,8 @@ constexpr bool test() {
   test_saturate_cast<_BitInt(128), unsigned _BitInt(128)>();
 #  endif
 
-  // TODO: __builtin_mul_overflow is currently broken for (unsigned) _BitInt(N)
-  // where N > 128 (https://llvm.org/PR46337). Cover them once this bug gets
-  // fixed.
+  // TODO: cover N > 128 once __builtin_mul_overflow is fixed for wide
+  // _BitInt(N); see https://llvm.org/PR46337.
 
   return true;
 }

--- a/libcxx/test/std/utilities/utility/utility.intcmp/intcmp.bitint.pass.cpp
+++ b/libcxx/test/std/utilities/utility/utility.intcmp/intcmp.bitint.pass.cpp
@@ -11,24 +11,9 @@
 // <utility>
 
 // cmp_equal, cmp_not_equal, cmp_less, cmp_less_equal, cmp_greater,
-// cmp_greater_equal, in_range applied to _BitInt(N).
-//
-// Exercises the four implementation branches of cmp_less/cmp_equal:
-//   1. same-signedness shortcut                             (__t < __u)
-//   2. both promote to int                                  (branch via int)
-//   3. both promote to long long                            (branch via long long)
-//   4. fallback using make_unsigned_t                       (wider than long long)
-//
-// _BitInt widths chosen to land in each branch:
-//   -  _BitInt(7)   sizeof==1, < sizeof(int)                -> branch 2
-//   -  _BitInt(13)  sizeof==2                               -> branch 2
-//   -  _BitInt(32)  sizeof==4 == sizeof(int)                -> branch 2 (signed) / 3 (unsigned)
-//   -  _BitInt(33)  sizeof==8                               -> branch 3
-//   -  _BitInt(63)  sizeof==8                               -> branch 3
-//   -  _BitInt(65)  sizeof==16                              -> branch 4
-//   -  _BitInt(128) sizeof==16                              -> branch 4
-//   -  _BitInt(200) sizeof==32 (requires __BITINT_MAXWIDTH__ >= 200)
-//                                                           -> branch 4
+// cmp_greater_equal, in_range applied to _BitInt(N). Widths span the int,
+// long long, and __int128 size boundaries for same-sign, mixed-sign, and
+// in_range checks.
 
 #include <cassert>
 #include <limits>
@@ -40,7 +25,7 @@
 
 template <class T, class U>
 constexpr bool test_same_sign() {
-  // Branch 1: same signedness. Trivial equality/ordering.
+  // Same signedness: trivial equality/ordering.
   static_assert(std::cmp_equal(T(0), U(0)));
   static_assert(std::cmp_equal(T(42), U(42)));
   static_assert(!std::cmp_equal(T(0), U(1)));
@@ -95,7 +80,7 @@ constexpr bool test_in_range() {
 }
 
 constexpr bool test() {
-  // Branch 2 territory (sizeof <= sizeof(int)).
+  // sizeof <= sizeof(int).
   test_same_sign<_BitInt(7), _BitInt(7)>();
   test_same_sign<unsigned _BitInt(7), unsigned _BitInt(7)>();
   test_same_sign<_BitInt(13), _BitInt(13)>();
@@ -104,15 +89,13 @@ constexpr bool test() {
   test_in_range<_BitInt(7), unsigned _BitInt(7)>();
   test_in_range<_BitInt(13), unsigned _BitInt(13)>();
 
-  // Equal-sizeof-as-int boundary: signed _BitInt(32) can promote to int,
-  // unsigned _BitInt(32) cannot (would lose the high bit), so it falls
-  // into branch 3.
+  // signed _BitInt(32) fits in int; unsigned _BitInt(32) does not.
   test_same_sign<_BitInt(32), _BitInt(32)>();
   test_same_sign<unsigned _BitInt(32), unsigned _BitInt(32)>();
   test_mixed_sign<_BitInt(32), unsigned _BitInt(32)>();
   test_in_range<_BitInt(32), unsigned _BitInt(32)>();
 
-  // Branch 3 territory (sizeof <= sizeof(long long)).
+  // sizeof <= sizeof(long long).
   test_same_sign<_BitInt(33), _BitInt(33)>();
   test_same_sign<_BitInt(63), _BitInt(63)>();
   test_same_sign<unsigned _BitInt(63), unsigned _BitInt(63)>();
@@ -121,16 +104,14 @@ constexpr bool test() {
   test_in_range<_BitInt(33), unsigned _BitInt(33)>();
   test_in_range<_BitInt(63), unsigned _BitInt(63)>();
 
-  // Equal-sizeof-as-long-long boundary: _BitInt(64) signed promotes,
-  // unsigned _BitInt(64) does not, so the mixed-sign case lands in
-  // branch 4.
+  // signed _BitInt(64) fits in long long; unsigned _BitInt(64) does not.
   test_same_sign<_BitInt(64), _BitInt(64)>();
   test_same_sign<unsigned _BitInt(64), unsigned _BitInt(64)>();
   test_mixed_sign<_BitInt(64), unsigned _BitInt(64)>();
   test_in_range<_BitInt(64), unsigned _BitInt(64)>();
 
 #  if __BITINT_MAXWIDTH__ >= 128
-  // Branch 4 territory (sizeof > sizeof(long long)).
+  // sizeof > sizeof(long long).
   test_same_sign<_BitInt(65), _BitInt(65)>();
   test_same_sign<_BitInt(128), _BitInt(128)>();
   test_same_sign<unsigned _BitInt(128), unsigned _BitInt(128)>();
@@ -141,8 +122,7 @@ constexpr bool test() {
 #  endif
 
 #  if __BITINT_MAXWIDTH__ >= 200
-  // Beyond __int128: verifies make_unsigned_t<_BitInt(N)> works on the
-  // fallback path for widths with no builtin mapping.
+  // Beyond __int128: widths with no builtin integer mapping.
   test_same_sign<_BitInt(200), _BitInt(200)>();
   test_same_sign<unsigned _BitInt(200), unsigned _BitInt(200)>();
   test_mixed_sign<_BitInt(200), unsigned _BitInt(200)>();


### PR DESCRIPTION
Several `_BitInt` test comments named the builtin the code lowers to, restated macro equivalences, or pointed at another test file's internals. They read as machine-generated and do not help a reader. This rewords them across the `_BitInt` tests touched by #203876, where the pattern was flagged in review.

Assisted-by: Claude (Anthropic)