### PR TITLE
[Hexagon] Lower vselect instruction

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonPatternsHVX.td
+++ b/llvm/lib/Target/Hexagon/HexagonPatternsHVX.td
@@ -1018,6 +1018,15 @@ let Predicates = [UseHVX] in {
   def: AccRRR_pat<V6_vgtuw_xor,   Xor, setugt,   HQ32, HVI32, HVI32>;
 }
 
+let Predicates = [UseHVX] in {
+  def: Pat<(vselect VecQ8:$Qu, VecQ8:$Qs, VecQ8:$Qt),
+           (V6_pred_or (V6_pred_and $Qs, $Qu), (V6_pred_and_n $Qt, $Qu))>;
+  def: Pat<(vselect VecQ16:$Qu, VecQ16:$Qs, VecQ16:$Qt),
+           (V6_pred_or (V6_pred_and $Qs, $Qu), (V6_pred_and_n $Qt, $Qu))>;
+  def: Pat<(vselect VecQ32:$Qu, VecQ32:$Qs, VecQ32:$Qt),
+           (V6_pred_or (V6_pred_and $Qs, $Qu), (V6_pred_and_n $Qt, $Qu))>;
+}
+
 let Predicates = [UseHVXV68, UseHVXFloatingPoint] in {
   def: OpR_RR_pat<V6_veqh,              seteq,  VecQ16, HVF16>;
   def: OpR_RR_pat<V6_veqh,             setoeq,  VecQ16, HVF16>;

--- a/llvm/test/CodeGen/Hexagon/vselect.ll
+++ b/llvm/test/CodeGen/Hexagon/vselect.ll
@@ -1,0 +1,25 @@
+; RUN: llc -mtriple=hexagon -mcpu=hexagonv68 -mattr=+hvx-length128b < %s | FileCheck %s
+
+; Add patterns to lower vselect q, q, q.
+
+; CHECK-LABEL: vselect_v32i1
+; CHECK-DAG: q[[Q1:[0-9]+]] = and(q{{[0-9]+}},!q{{[0-9]+}})
+; CHECK-DAG: q[[Q2:[0-9]+]] = and(q{{[0-9]+}},q{{[0-9]+}})
+; CHECK: q{{[0-9]+}} = or(q[[Q2]],q[[Q1]])
+define <32 x i1> @vselect_v32i1(<32 x i1> %f, <32 x i1> %cond, <32 x i1> %t) #0 {
+entry:
+  %sel = select <32 x i1> %cond, <32 x i1> %t, <32 x i1> %f
+  ret <32 x i1> %sel
+}
+
+; CHECK-LABEL: vselect_v64i1
+; CHECK-DAG: q[[Q3:[0-9]+]] = and(q{{[0-9]+}},!q{{[0-9]+}})
+; CHECK-DAG: q[[Q4:[0-9]+]] = and(q{{[0-9]+}},q{{[0-9]+}})
+; CHECK: q{{[0-9]+}} = or(q[[Q4]],q[[Q3]])
+define <64 x i1> @vselect_v64i1(<64 x i1> %f, <64 x i1> %cond, <64 x i1> %t) #0 {
+entry:
+  %sel = select <64 x i1> %cond, <64 x i1> %t, <64 x i1> %f
+  ret <64 x i1> %sel
+}
+
+attributes #0 = { "target-cpu"="hexagonv68" "target-features"="+hvx-length128b" }


### PR DESCRIPTION
Selection fails with "Cannot select: vselect" when the condition and both data operands of an HVX vselect are predicate vectors (e.g. v32i1, v64i1, v128i1). This patch adds patterns for vselect on HVX predicate vectors of all three element widths (VecQ8, VecQ16, VecQ32), expanding them to V6_pred_or/V6_pred_and/V6_pred_and_n on Q registers.

Patch-By: @iajbar 
Fixes #206353 