### PR TITLE
[ORC] Support new ORC runtime in UnwindInfoRegistrationPlugin.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -93,6 +93,18 @@ struct SimpleExecutorDylibManagerSymbolNames {
 extern const LLVM_ABI SimpleExecutorDylibManagerSymbolNames
     orc_rt_NativeDylibManagerSPSSymbols;
 
+/// Symbol names for the ORC runtime's StandaloneMachOUnwindInfoRegistrar
+/// SPS interface.
+struct MachOUnwindInfoRegistrarSymbolNames {
+  StringRef RegisterSectionsName;
+  StringRef DeregisterSectionsName;
+};
+
+/// Default symbol names for the ORC runtime's
+/// StandaloneMachOUnwindInfoRegistrar SPS interface.
+extern const LLVM_ABI MachOUnwindInfoRegistrarSymbolNames
+    orc_rt_MachOUnwindInfoRegistrarSPSSymbols;
+
 using SPSSimpleExecutorDylibManagerOpenSignature =
     shared::SPSExpected<shared::SPSExecutorAddr>(shared::SPSExecutorAddr,
                                                  shared::SPSString, uint64_t);

--- a/llvm/include/llvm/ExecutionEngine/Orc/UnwindInfoRegistrationPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/UnwindInfoRegistrationPlugin.h
@@ -14,6 +14,7 @@
 #define LLVM_EXECUTIONENGINE_ORC_UNWINDINFOREGISTRATIONPLUGIN_H
 
 #include "llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h"
+#include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/Support/Compiler.h"
 
 namespace llvm::orc {
@@ -21,17 +22,18 @@ namespace llvm::orc {
 class LLVM_ABI UnwindInfoRegistrationPlugin
     : public LinkGraphLinkingLayer::Plugin {
 public:
-  UnwindInfoRegistrationPlugin(ExecutionSession &ES, ExecutorAddr Register,
-                               ExecutorAddr Deregister)
-      : ES(ES), Register(Register), Deregister(Deregister) {
+  UnwindInfoRegistrationPlugin(ExecutionSession &ES,
+                               ExecutorAddr RegisterSections,
+                               ExecutorAddr DeregisterSections)
+      : RegisterSections(RegisterSections),
+        DeregisterSections(DeregisterSections) {
     DSOBaseName = ES.intern("__jitlink$libunwind_dso_base");
   }
 
   static Expected<std::shared_ptr<UnwindInfoRegistrationPlugin>>
-  Create(ExecutionSession &ES, ExecutorAddr Register, ExecutorAddr Deregister);
-
-  static Expected<std::shared_ptr<UnwindInfoRegistrationPlugin>>
-  Create(ExecutionSession &ES);
+  Create(ExecutionSession &ES,
+         rt::MachOUnwindInfoRegistrarSymbolNames SNs =
+             rt::orc_rt_MachOUnwindInfoRegistrarSPSSymbols);
 
   void modifyPassConfig(MaterializationResponsibility &MR,
                         jitlink::LinkGraph &G,
@@ -55,9 +57,8 @@ public:
 private:
   Error addUnwindInfoRegistrationActions(jitlink::LinkGraph &G);
 
-  ExecutionSession &ES;
   SymbolStringPtr DSOBaseName;
-  ExecutorAddr Register, Deregister;
+  ExecutorAddr RegisterSections, DeregisterSections;
 };
 
 } // namespace llvm::orc

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -99,6 +99,11 @@ const SimpleExecutorDylibManagerSymbolNames
         "orc_rt_ci_sps_NativeDylibManager_lookup",
 };
 
+const MachOUnwindInfoRegistrarSymbolNames
+    orc_rt_MachOUnwindInfoRegistrarSPSSymbols = {
+        "orc_rt_ci_aa_sps_MachOUnwindInfoRegistrar_registerSections",
+        "orc_rt_ci_aa_sps_MachOUnwindInfoRegistrar_deregisterSections"};
+
 } // end namespace rt
 namespace rt_alt {
 const char *UnwindInfoManagerRegisterActionName =

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.cpp
@@ -110,6 +110,16 @@ void UnwindInfoManager::addBootstrapSymbols(StringMap<ExecutorAddr> &M) {
       ExecutorAddr::fromPtr(llvm_orc_rt_alt_UnwindInfoManager_register);
   M[rt_alt::UnwindInfoManagerDeregisterActionName] =
       ExecutorAddr::fromPtr(llvm_orc_rt_alt_UnwindInfoManager_deregister);
+
+  {
+    // Also provide symbols defined by StandaloneMachOUnwindInfoRegistrar
+    // in the new ORC runtime.
+    const auto &SNs = rt::orc_rt_MachOUnwindInfoRegistrarSPSSymbols;
+    M[SNs.RegisterSectionsName] =
+        ExecutorAddr::fromPtr(llvm_orc_rt_alt_UnwindInfoManager_register);
+    M[SNs.DeregisterSectionsName] =
+        ExecutorAddr::fromPtr(llvm_orc_rt_alt_UnwindInfoManager_deregister);
+  }
 }
 
 Error UnwindInfoManager::registerSections(

--- a/llvm/lib/ExecutionEngine/Orc/UnwindInfoRegistrationPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/UnwindInfoRegistrationPlugin.cpp
@@ -19,18 +19,19 @@ using namespace llvm::jitlink;
 namespace llvm::orc {
 
 Expected<std::shared_ptr<UnwindInfoRegistrationPlugin>>
-UnwindInfoRegistrationPlugin::Create(ExecutionSession &ES) {
+UnwindInfoRegistrationPlugin::Create(
+    ExecutionSession &ES, rt::MachOUnwindInfoRegistrarSymbolNames SNs) {
 
-  ExecutorAddr Register, Deregister;
+  ExecutorAddr RegisterSections, DeregisterSections;
 
   auto &EPC = ES.getExecutorProcessControl();
   if (auto Err = EPC.getBootstrapSymbols(
-          {{Register, rt_alt::UnwindInfoManagerRegisterActionName},
-           {Deregister, rt_alt::UnwindInfoManagerDeregisterActionName}}))
+          {{RegisterSections, SNs.RegisterSectionsName},
+           {DeregisterSections, SNs.DeregisterSectionsName}}))
     return std::move(Err);
 
-  return std::make_shared<UnwindInfoRegistrationPlugin>(ES, Register,
-                                                        Deregister);
+  return std::make_shared<UnwindInfoRegistrationPlugin>(ES, RegisterSections,
+                                                        DeregisterSections);
 }
 
 void UnwindInfoRegistrationPlugin::modifyPassConfig(
@@ -105,16 +106,18 @@ Error UnwindInfoRegistrationPlugin::addUnwindInfoRegistrationActions(
                                    inconvertibleErrorCode());
 
   using namespace shared;
-  using SPSRegisterArgs =
+  using SPSRegisterSectionsArgs =
       SPSArgList<SPSSequence<SPSExecutorAddrRange>, SPSExecutorAddr,
                  SPSExecutorAddrRange, SPSExecutorAddrRange>;
-  using SPSDeregisterArgs = SPSArgList<SPSSequence<SPSExecutorAddrRange>>;
+  using SPSDeregisterSectionsArgs =
+      SPSArgList<SPSSequence<SPSExecutorAddrRange>>;
 
   G.allocActions().push_back(
-      {cantFail(WrapperFunctionCall::Create<SPSRegisterArgs>(
-           Register, CodeRanges, DSOBase, EHFrameRange, UnwindInfoRange)),
-       cantFail(WrapperFunctionCall::Create<SPSDeregisterArgs>(Deregister,
-                                                               CodeRanges))});
+      {cantFail(WrapperFunctionCall::Create<SPSRegisterSectionsArgs>(
+           RegisterSections, CodeRanges, DSOBase, EHFrameRange,
+           UnwindInfoRange)),
+       cantFail(WrapperFunctionCall::Create<SPSDeregisterSectionsArgs>(
+           DeregisterSections, CodeRanges))});
 
   return Error::success();
 }


### PR DESCRIPTION
Reworks UnwindInfoRegistrationPlugin::Create(ES) to look up the register/deregister implementation addresses by symbol name, with default names matching the SPS-CI alloc actions provided by
orc_rt::StandaloneMachOUnwindInfoRegistrar. In OrcTargetProcess, UnwindInfoManager::addBootstrapSymbols now also vends its register and deregister actions under those same names, so the new Create overloads work against either backend.

Also removes a declared but unused (and undefined) Create overload.