### PR TITLE
[X86] Fold zero-sized dynamic allocas in X86DynAllocaExpander

### DIFF
--- a/llvm/lib/Target/X86/X86DynAllocaExpander.cpp
+++ b/llvm/lib/Target/X86/X86DynAllocaExpander.cpp
@@ -96,6 +96,15 @@ static int64_t getDynAllocaAmount(MachineInstr *MI, MachineRegisterInfo *MRI) {
   Register AmountReg = MI->getOperand(0).getReg();
   MachineInstr *Def = MRI->getUniqueVRegDef(AmountReg);
 
+  // A zero amount uses the MOV32r0 idiom, not MOV32ri 0 / MOV64ri 0. For
+  // DYN_ALLOCA_64 the 32-bit zero is widened to 64 bits via SUBREG_TO_REG.
+  if (Def && Def->getOpcode() == X86::SUBREG_TO_REG &&
+      Def->getOperand(1).isReg() &&
+      Def->getOperand(2).getImm() == X86::sub_32bit)
+    Def = MRI->getUniqueVRegDef(Def->getOperand(1).getReg());
+  if (Def && Def->getOpcode() == X86::MOV32r0)
+    return 0;
+
   if (!Def ||
       (Def->getOpcode() != X86::MOV32ri && Def->getOpcode() != X86::MOV64ri) ||
       !Def->getOperand(1).isImm())
@@ -211,7 +220,22 @@ void X86DynAllocaExpander::lower(MachineInstr *MI, Lowering L) {
 
   int64_t Amount = getDynAllocaAmount(MI, MRI);
   if (Amount == 0) {
+    Register AmountReg = MI->getOperand(0).getReg();
     MI->eraseFromParent();
+    // Delete the now-dead amount def. Zero is materialized as MOV32r0 (or, in
+    // principle, MOV32ri/MOV64ri 0), widened to 64 bits via SUBREG_TO_REG for
+    // DYN_ALLOCA_64; peel that widening first, if present.
+    if (MRI->use_empty(AmountReg)) {
+      MachineInstr *Def = MRI->getUniqueVRegDef(AmountReg);
+      if (Def && Def->getOpcode() == X86::SUBREG_TO_REG &&
+          Def->getOperand(1).isReg()) {
+        Register SubReg = Def->getOperand(1).getReg();
+        Def->eraseFromParent();
+        Def = MRI->use_empty(SubReg) ? MRI->getUniqueVRegDef(SubReg) : nullptr;
+      }
+      if (Def)
+        Def->eraseFromParent();
+    }
     return;
   }
 

--- a/llvm/test/CodeGen/X86/dyn-alloca-expander-zero.ll
+++ b/llvm/test/CodeGen/X86/dyn-alloca-expander-zero.ll
@@ -1,0 +1,32 @@
+; RUN: llc < %s -mtriple=i686-pc-win32 | FileCheck %s --check-prefix=X86
+; RUN: llc < %s -mtriple=x86_64-pc-windows-msvc | FileCheck %s --check-prefix=X64
+
+; A zero-sized dynamic alloca (materialized as the MOV32r0 idiom, widened via
+; SUBREG_TO_REG on 64-bit) should be folded and elided, not probed.
+define void @zero_const(i32 %n) {
+; X86-LABEL: zero_const:
+; X86-NOT: __chkstk
+; X64-LABEL: zero_const:
+; X64-NOT: __chkstk
+entry:
+  br label %b
+b:
+  %p = alloca i8, i32 0
+  call void @use(ptr %p)
+  ret void
+}
+
+; A dynamic size that folds to zero reaches the pass the same way.
+define void @zero_folded(i32 %n) {
+; X86-LABEL: zero_folded:
+; X86-NOT: __chkstk
+; X64-LABEL: zero_folded:
+; X64-NOT: __chkstk
+entry:
+  %z = sub i32 %n, %n
+  %p = alloca i8, i32 %z
+  call void @use(ptr %p)
+  ret void
+}
+
+declare void @use(ptr)


### PR DESCRIPTION
A zero allocation amount is materialized with the MOV32r0 (xor-zero) idiom rather than MOV32ri 0 / MOV64ri 0, and on 64-bit it is widened to 64 bits via SUBREG_TO_REG. getDynAllocaAmount did not recognize this, so it returned -1 ("unknown"), the DynAlloca was lowered as a stack probe, and a zero-byte allocation needlessly emitted __chkstk(0). The intended Amount == 0 elision in lower() was therefore dead code.

Recognize the MOV32r0 zero idiom (directly and through SUBREG_TO_REG) so the amount folds to 0, and erase the now-dead amount definition(s) when the DynAlloca is elided, matching the cleanup on the non-zero path.

Assisted By: Cursor <cursoragent@cursor.com>

Found via @jlebar's X86 LLVM Bug Hunt / FuzzX Effort: https://github.com/SemiAnalysisAI/FuzzX/blob/master/x86/bugs/048-dynalloca-amount-zero-leaks-mov