### PR TITLE
[GVN] Support critical-edge splitting in loop-load PRE

### DIFF
--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -2024,15 +2024,12 @@ bool GVNPass::performLoopLoadPRE(LoadInst *Load,
   // the reload only runs on the path that feeds the header.
   BasicBlock *InsertBlock = LoopBlock;
   if (LoopBlock->getTerminator()->getNumSuccessors() != 1) {
-    if (isa<IndirectBrInst>(LoopBlock->getTerminator()))
-      return false;
-
     BasicBlock *InLoopSucc = nullptr;
     for (BasicBlock *Succ : successors(LoopBlock)) {
       if (!L->contains(Succ))
         continue;
-      // Bail if there is more than one in-loop successor: it is unclear which
-      // edge feeds the header.
+      // Bail if there is more than one in-loop successor: it is then unclear
+      // which edge carries the value back to the header.
       if (InLoopSucc)
         return false;
       InLoopSucc = Succ;
@@ -2040,12 +2037,11 @@ bool GVNPass::performLoopLoadPRE(LoadInst *Load,
     if (!InLoopSucc)
       return false;
 
-    // Do not split a backedge unless explicitly enabled; it would break
-    // canonical loop form.
-    if (!isLoadPRESplitBackedgeEnabled() &&
-        DT->dominates(InLoopSucc, LoopBlock))
-      return false;
-
+    // splitCriticalEdges() returns nullptr for edges it cannot split, e.g. an
+    // indirectbr terminator or an EH-pad successor; bail out in that case. The
+    // in-loop successor cannot be a backedge target here: LoopBlock does not
+    // dominate the latch, and a single-latch loop only has the latch->header
+    // backedge, so no critical loop backedge is split.
     InsertBlock = splitCriticalEdges(LoopBlock, InLoopSucc);
     if (!InsertBlock)
       return false;

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -2017,9 +2017,42 @@ bool GVNPass::performLoopLoadPRE(LoadInst *Load,
   if (LoadPtr->canBeFreed())
     return false;
 
-  // TODO: Support critical edge splitting if blocker has more than 1 successor.
+  // The reload is inserted at the end of the chosen in-loop block so its value
+  // reaches the header along the path back to the latch. If that block has
+  // multiple successors, inserting there would also run the load on paths that
+  // leave the loop. Split the critical edge to the unique in-loop successor so
+  // the reload only runs on the path that feeds the header.
+  BasicBlock *InsertBlock = LoopBlock;
+  if (LoopBlock->getTerminator()->getNumSuccessors() != 1) {
+    if (isa<IndirectBrInst>(LoopBlock->getTerminator()))
+      return false;
+
+    BasicBlock *InLoopSucc = nullptr;
+    for (BasicBlock *Succ : successors(LoopBlock)) {
+      if (!L->contains(Succ))
+        continue;
+      // Bail if there is more than one in-loop successor: it is unclear which
+      // edge feeds the header.
+      if (InLoopSucc)
+        return false;
+      InLoopSucc = Succ;
+    }
+    if (!InLoopSucc)
+      return false;
+
+    // Do not split a backedge unless explicitly enabled; it would break
+    // canonical loop form.
+    if (!isLoadPRESplitBackedgeEnabled() &&
+        DT->dominates(InLoopSucc, LoopBlock))
+      return false;
+
+    InsertBlock = splitCriticalEdges(LoopBlock, InLoopSucc);
+    if (!InsertBlock)
+      return false;
+  }
+
   MapVector<BasicBlock *, Value *> AvailableLoads;
-  AvailableLoads[LoopBlock] = LoadPtr;
+  AvailableLoads[InsertBlock] = LoadPtr;
   AvailableLoads[Preheader] = LoadPtr;
 
   LLVM_DEBUG(dbgs() << "GVN REMOVING PRE LOOP LOAD: " << *Load << '\n');

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -2017,34 +2017,43 @@ bool GVNPass::performLoopLoadPRE(LoadInst *Load,
   if (LoadPtr->canBeFreed())
     return false;
 
-  // The reload is inserted at the end of the chosen in-loop block so its value
-  // reaches the header along the path back to the latch. If that block has
-  // multiple successors, inserting there would also run the load on paths that
-  // leave the loop. Split the critical edge to the unique in-loop successor so
-  // the reload only runs on the path that feeds the header.
+  // eliminatePartiallyRedundantLoad() inserts the reload at the end of the
+  // chosen in-loop block. When that block has a single successor there is no
+  // critical edge and the reload can go there directly. When it has several
+  // successors but stays in the loop on all of them, the reload still only
+  // runs inside the loop, so LoopBlock is fine. The only problematic case is a
+  // successor that leaves the loop: inserting in LoopBlock would then run the
+  // reload on the exit edge too. Redirect it onto the in-loop edge by splitting
+  // that critical edge so the reload only runs on the path back to the header.
   BasicBlock *InsertBlock = LoopBlock;
   if (LoopBlock->getTerminator()->getNumSuccessors() != 1) {
     BasicBlock *InLoopSucc = nullptr;
+    bool MultipleInLoopSucc = false;
+    bool ExitsLoop = false;
     for (BasicBlock *Succ : successors(LoopBlock)) {
-      if (!L->contains(Succ))
+      if (!L->contains(Succ)) {
+        ExitsLoop = true;
         continue;
-      // Bail if there is more than one in-loop successor: it is then unclear
-      // which edge carries the value back to the header.
+      }
       if (InLoopSucc)
-        return false;
-      InLoopSucc = Succ;
+        MultipleInLoopSucc = true;
+      else
+        InLoopSucc = Succ;
     }
-    if (!InLoopSucc)
-      return false;
 
-    // splitCriticalEdges() returns nullptr for edges it cannot split, e.g. an
-    // indirectbr terminator or an EH-pad successor; bail out in that case. The
-    // in-loop successor cannot be a backedge target here: LoopBlock does not
-    // dominate the latch, and a single-latch loop only has the latch->header
-    // backedge, so no critical loop backedge is split.
-    InsertBlock = splitCriticalEdges(LoopBlock, InLoopSucc);
-    if (!InsertBlock)
-      return false;
+    if (ExitsLoop) {
+      // A single edge split cannot keep the reload off the exit path when
+      // there is more than one in-loop successor, and there must be one to
+      // split.
+      if (MultipleInLoopSucc || !InLoopSucc)
+        return false;
+
+      // splitCriticalEdges() returns nullptr when the edge cannot be split
+      // (e.g. an indirectbr terminator or an EH-pad successor).
+      InsertBlock = splitCriticalEdges(LoopBlock, InLoopSucc);
+      if (!InsertBlock)
+        return false;
+    }
   }
 
   MapVector<BasicBlock *, Value *> AvailableLoads;

--- a/llvm/test/Transforms/GVN/PRE/pre-loop-load.ll
+++ b/llvm/test/Transforms/GVN/PRE/pre-loop-load.ll
@@ -355,7 +355,8 @@ exit:
   ret i32 %x
 }
 
-; TODO: We can PRE via splitting of the critical edge in the cold path.
+; TODO: not PRE'd because the pointer may be freed, so reloading is unsafe.
+; The cold-path critical edge is split once the pointer is known non-freeable.
 define i32 @test_load_on_exiting_cold_path_01(ptr %p) {
 ; CHECK-LABEL: @test_load_on_exiting_cold_path_01(
 ; CHECK-NEXT:  entry:
@@ -407,7 +408,8 @@ cold_exit:
   ret i32 -1
 }
 
-; TODO: We can PRE via splitting of the critical edge in the cold path.
+; TODO: not PRE'd because the pointer may be freed, so reloading is unsafe.
+; The cold-path critical edge is split once the pointer is known non-freeable.
 define i32 @test_load_on_exiting_cold_path_02(ptr %p) gc "statepoint-example" personality ptr @personality_function {
 ; CHECK-LABEL: @test_load_on_exiting_cold_path_02(
 ; CHECK-NEXT:  entry:
@@ -462,9 +464,9 @@ cold_exit:
   ret i32 -1
 }
 
-; The gc-managed pointer cannot be freed, so loop-load PRE fires, but the
-; reload is sunk into the cold path and also runs on the loop side-exit.
-; TODO: split the critical edge so it only runs on the path back to the header.
+; PRE the load from gc-managed memory by splitting the critical edge in the
+; cold path. The reload runs only on the path back to the header, not on the
+; loop side-exit. The pointer is gc-managed so it cannot be freed.
 define i32 @test_load_on_exiting_cold_path_gc(ptr addrspace(1) %p) gc "statepoint-example" personality ptr @personality_function {
 ; CHECK-LABEL: @test_load_on_exiting_cold_path_gc(
 ; CHECK-NEXT:  entry:
@@ -479,10 +481,12 @@ define i32 @test_load_on_exiting_cold_path_gc(ptr addrspace(1) %p) gc "statepoin
 ; CHECK-NEXT:    br label [[BACKEDGE]]
 ; CHECK:       cold_path:
 ; CHECK-NEXT:    [[SIDE_COND:%.*]] = call i1 @side_effect_cond() #[[ATTR0]]
+; CHECK-NEXT:    br i1 [[SIDE_COND]], label [[COLD_PATH_BACKEDGE_CRIT_EDGE:%.*]], label [[COLD_EXIT:%.*]]
+; CHECK:       cold_path.backedge_crit_edge:
 ; CHECK-NEXT:    [[X_PRE:%.*]] = load i32, ptr addrspace(1) [[P]], align 4
-; CHECK-NEXT:    br i1 [[SIDE_COND]], label [[BACKEDGE]], label [[COLD_EXIT:%.*]]
+; CHECK-NEXT:    br label [[BACKEDGE]]
 ; CHECK:       backedge:
-; CHECK-NEXT:    [[X3]] = phi i32 [ [[X_PRE]], [[COLD_PATH]] ], [ [[X]], [[HOT_PATH]] ]
+; CHECK-NEXT:    [[X3]] = phi i32 [ [[X_PRE]], [[COLD_PATH_BACKEDGE_CRIT_EDGE]] ], [ [[X]], [[HOT_PATH]] ]
 ; CHECK-NEXT:    [[IV_NEXT]] = add i32 [[IV]], [[X]]
 ; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp ult i32 [[IV_NEXT]], 1000
 ; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT:%.*]]
@@ -519,9 +523,9 @@ cold_exit:
   ret i32 -1
 }
 
-; The function is nofree, so the pointer cannot be freed and loop-load PRE
-; fires, but the reload is sunk into the cold path and also runs on the loop
-; side-exit. TODO: split the critical edge so it only runs on the backedge.
+; PRE the load when the pointer cannot be freed because the enclosing function
+; is nofree. The cold-path critical edge is split so the reload runs only on
+; the path back to the header.
 define i32 @test_load_on_exiting_cold_path_nofree_fn(ptr %p) nofree {
 ; CHECK-LABEL: @test_load_on_exiting_cold_path_nofree_fn(
 ; CHECK-NEXT:  entry:
@@ -536,10 +540,12 @@ define i32 @test_load_on_exiting_cold_path_nofree_fn(ptr %p) nofree {
 ; CHECK-NEXT:    br label [[BACKEDGE]]
 ; CHECK:       cold_path:
 ; CHECK-NEXT:    [[SIDE_COND:%.*]] = call i1 @side_effect_cond() #[[ATTR0]]
+; CHECK-NEXT:    br i1 [[SIDE_COND]], label [[COLD_PATH_BACKEDGE_CRIT_EDGE:%.*]], label [[COLD_EXIT:%.*]]
+; CHECK:       cold_path.backedge_crit_edge:
 ; CHECK-NEXT:    [[X_PRE:%.*]] = load i32, ptr [[P]], align 4
-; CHECK-NEXT:    br i1 [[SIDE_COND]], label [[BACKEDGE]], label [[COLD_EXIT:%.*]]
+; CHECK-NEXT:    br label [[BACKEDGE]]
 ; CHECK:       backedge:
-; CHECK-NEXT:    [[X3]] = phi i32 [ [[X_PRE]], [[COLD_PATH]] ], [ [[X]], [[HOT_PATH]] ]
+; CHECK-NEXT:    [[X3]] = phi i32 [ [[X_PRE]], [[COLD_PATH_BACKEDGE_CRIT_EDGE]] ], [ [[X]], [[HOT_PATH]] ]
 ; CHECK-NEXT:    [[IV_NEXT]] = add i32 [[IV]], [[X]]
 ; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp ult i32 [[IV_NEXT]], 1000
 ; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT:%.*]]
@@ -684,7 +690,9 @@ exit:
   ret i32 %x
 }
 
-; TODO: We can PRE via splitting of the critical edge in the cold path. Make sure we only insert 1 load.
+; TODO: not PRE'd because the pointer may be freed, so reloading is unsafe.
+; The cold-path critical edge is split once the pointer is known non-freeable,
+; inserting a single reload before the latch.
 define i32 @test_load_on_multi_exiting_cold_path(ptr %p) {
 ; CHECK-LABEL: @test_load_on_multi_exiting_cold_path(
 ; CHECK-NEXT:  entry:

--- a/llvm/test/Transforms/GVN/PRE/pre-loop-load.ll
+++ b/llvm/test/Transforms/GVN/PRE/pre-loop-load.ll
@@ -355,8 +355,7 @@ exit:
   ret i32 %x
 }
 
-; TODO: not PRE'd because the pointer may be freed, so reloading is unsafe.
-; The cold-path critical edge is split once the pointer is known non-freeable.
+; Not PRE'd because the pointer may be freed, so reloading would be unsafe.
 define i32 @test_load_on_exiting_cold_path_01(ptr %p) {
 ; CHECK-LABEL: @test_load_on_exiting_cold_path_01(
 ; CHECK-NEXT:  entry:
@@ -408,8 +407,7 @@ cold_exit:
   ret i32 -1
 }
 
-; TODO: not PRE'd because the pointer may be freed, so reloading is unsafe.
-; The cold-path critical edge is split once the pointer is known non-freeable.
+; Not PRE'd because the pointer may be freed, so reloading would be unsafe.
 define i32 @test_load_on_exiting_cold_path_02(ptr %p) gc "statepoint-example" personality ptr @personality_function {
 ; CHECK-LABEL: @test_load_on_exiting_cold_path_02(
 ; CHECK-NEXT:  entry:
@@ -582,28 +580,31 @@ cold_exit:
   ret i32 -1
 }
 
-; Not PRE'd: the cold path has more than one in-loop successor, so it is unclear
-; which edge carries the reloaded value back to the header. The pointer cannot
-; be freed (nofree function), so freeability is not the blocker here.
+; The cold path has multiple successors but none leaves the loop, so the reload
+; is inserted at the end of the cold path (no edge split needed) and reaches the
+; header. The pointer cannot be freed (nofree function).
 define i32 @test_load_on_cold_path_multi_inloop_succ(ptr %p) nofree {
 ; CHECK-LABEL: @test_load_on_cold_path_multi_inloop_succ(
 ; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[X_PRE1:%.*]] = load i32, ptr [[P:%.*]], align 4
 ; CHECK-NEXT:    br label [[LOOP:%.*]]
 ; CHECK:       loop:
-; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
-; CHECK-NEXT:    [[X:%.*]] = load i32, ptr [[P:%.*]], align 4
+; CHECK-NEXT:    [[X:%.*]] = phi i32 [ [[X_PRE1]], [[ENTRY:%.*]] ], [ [[X2:%.*]], [[BACKEDGE:%.*]] ]
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE]] ]
 ; CHECK-NEXT:    [[COND:%.*]] = icmp ne i32 [[X]], 0
 ; CHECK-NEXT:    br i1 [[COND]], label [[HOT_PATH:%.*]], label [[COLD_PATH:%.*]]
 ; CHECK:       hot_path:
 ; CHECK-NEXT:    br label [[BACKEDGE]]
 ; CHECK:       cold_path:
 ; CHECK-NEXT:    [[SIDE_COND:%.*]] = call i1 @side_effect_cond() #[[ATTR0]]
+; CHECK-NEXT:    [[X_PRE:%.*]] = load i32, ptr [[P]], align 4
 ; CHECK-NEXT:    br i1 [[SIDE_COND]], label [[COLD_SUCC_A:%.*]], label [[COLD_SUCC_B:%.*]]
 ; CHECK:       cold_succ_a:
 ; CHECK-NEXT:    br label [[BACKEDGE]]
 ; CHECK:       cold_succ_b:
 ; CHECK-NEXT:    br label [[BACKEDGE]]
 ; CHECK:       backedge:
+; CHECK-NEXT:    [[X2]] = phi i32 [ [[X_PRE]], [[COLD_SUCC_B]] ], [ [[X_PRE]], [[COLD_SUCC_A]] ], [ [[X]], [[HOT_PATH]] ]
 ; CHECK-NEXT:    [[IV_NEXT]] = add i32 [[IV]], [[X]]
 ; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp ult i32 [[IV_NEXT]], 1000
 ; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT:%.*]]
@@ -639,6 +640,75 @@ backedge:
 
 exit:
   ret i32 %x
+}
+
+; Not PRE'd: the cold path has more than one in-loop successor AND a loop-exit
+; successor, so a single critical-edge split cannot keep the reload off the exit
+; edge on every in-loop path. The pointer cannot be freed (nofree function), so
+; freeability is not the blocker here.
+define i32 @test_load_on_exiting_cold_path_multi_inloop_succ(ptr %p) nofree {
+; CHECK-LABEL: @test_load_on_exiting_cold_path_multi_inloop_succ(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
+; CHECK-NEXT:    [[X:%.*]] = load i32, ptr [[P:%.*]], align 4
+; CHECK-NEXT:    [[COND:%.*]] = icmp ne i32 [[X]], 0
+; CHECK-NEXT:    br i1 [[COND]], label [[HOT_PATH:%.*]], label [[COLD_PATH:%.*]]
+; CHECK:       hot_path:
+; CHECK-NEXT:    br label [[BACKEDGE]]
+; CHECK:       cold_path:
+; CHECK-NEXT:    [[SIDE_COND:%.*]] = call i1 @side_effect_cond() #[[ATTR0]]
+; CHECK-NEXT:    switch i32 [[IV]], label [[COLD_EXIT:%.*]] [
+; CHECK-NEXT:      i32 0, label [[COLD_SUCC_A:%.*]]
+; CHECK-NEXT:      i32 1, label [[COLD_SUCC_B:%.*]]
+; CHECK-NEXT:    ]
+; CHECK:       cold_succ_a:
+; CHECK-NEXT:    br label [[BACKEDGE]]
+; CHECK:       cold_succ_b:
+; CHECK-NEXT:    br label [[BACKEDGE]]
+; CHECK:       backedge:
+; CHECK-NEXT:    [[IV_NEXT]] = add i32 [[IV]], [[X]]
+; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp ult i32 [[IV_NEXT]], 1000
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT:%.*]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret i32 [[X]]
+; CHECK:       cold_exit:
+; CHECK-NEXT:    ret i32 -1
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i32 [ 0, %entry], [%iv.next, %backedge]
+  %x = load i32, ptr %p
+  %cond = icmp ne i32 %x, 0
+  br i1 %cond, label %hot_path, label %cold_path
+
+hot_path:
+  br label %backedge
+
+cold_path:
+  %side_cond = call i1 @side_effect_cond() nofree
+  switch i32 %iv, label %cold_exit [ i32 0, label %cold_succ_a
+                                     i32 1, label %cold_succ_b ]
+
+cold_succ_a:
+  br label %backedge
+
+cold_succ_b:
+  br label %backedge
+
+backedge:
+  %iv.next = add i32 %iv, %x
+  %loop.cond = icmp ult i32 %iv.next, 1000
+  br i1 %loop.cond, label %loop, label %exit
+
+exit:
+  ret i32 %x
+
+cold_exit:
+  ret i32 -1
 }
 
 ; Make sure we do not insert load into both cold path & backedge.
@@ -749,9 +819,7 @@ exit:
   ret i32 %x
 }
 
-; TODO: not PRE'd because the pointer may be freed, so reloading is unsafe.
-; The cold-path critical edge is split once the pointer is known non-freeable,
-; inserting a single reload before the latch.
+; Not PRE'd because the pointer may be freed, so reloading would be unsafe.
 define i32 @test_load_on_multi_exiting_cold_path(ptr %p) {
 ; CHECK-LABEL: @test_load_on_multi_exiting_cold_path(
 ; CHECK-NEXT:  entry:

--- a/llvm/test/Transforms/GVN/PRE/pre-loop-load.ll
+++ b/llvm/test/Transforms/GVN/PRE/pre-loop-load.ll
@@ -582,6 +582,65 @@ cold_exit:
   ret i32 -1
 }
 
+; Not PRE'd: the cold path has more than one in-loop successor, so it is unclear
+; which edge carries the reloaded value back to the header. The pointer cannot
+; be freed (nofree function), so freeability is not the blocker here.
+define i32 @test_load_on_cold_path_multi_inloop_succ(ptr %p) nofree {
+; CHECK-LABEL: @test_load_on_cold_path_multi_inloop_succ(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[IV_NEXT:%.*]], [[BACKEDGE:%.*]] ]
+; CHECK-NEXT:    [[X:%.*]] = load i32, ptr [[P:%.*]], align 4
+; CHECK-NEXT:    [[COND:%.*]] = icmp ne i32 [[X]], 0
+; CHECK-NEXT:    br i1 [[COND]], label [[HOT_PATH:%.*]], label [[COLD_PATH:%.*]]
+; CHECK:       hot_path:
+; CHECK-NEXT:    br label [[BACKEDGE]]
+; CHECK:       cold_path:
+; CHECK-NEXT:    [[SIDE_COND:%.*]] = call i1 @side_effect_cond() #[[ATTR0]]
+; CHECK-NEXT:    br i1 [[SIDE_COND]], label [[COLD_SUCC_A:%.*]], label [[COLD_SUCC_B:%.*]]
+; CHECK:       cold_succ_a:
+; CHECK-NEXT:    br label [[BACKEDGE]]
+; CHECK:       cold_succ_b:
+; CHECK-NEXT:    br label [[BACKEDGE]]
+; CHECK:       backedge:
+; CHECK-NEXT:    [[IV_NEXT]] = add i32 [[IV]], [[X]]
+; CHECK-NEXT:    [[LOOP_COND:%.*]] = icmp ult i32 [[IV_NEXT]], 1000
+; CHECK-NEXT:    br i1 [[LOOP_COND]], label [[LOOP]], label [[EXIT:%.*]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret i32 [[X]]
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i32 [ 0, %entry], [%iv.next, %backedge]
+  %x = load i32, ptr %p
+  %cond = icmp ne i32 %x, 0
+  br i1 %cond, label %hot_path, label %cold_path
+
+hot_path:
+  br label %backedge
+
+cold_path:
+  %side_cond = call i1 @side_effect_cond() nofree
+  br i1 %side_cond, label %cold_succ_a, label %cold_succ_b
+
+cold_succ_a:
+  br label %backedge
+
+cold_succ_b:
+  br label %backedge
+
+backedge:
+  %iv.next = add i32 %iv, %x
+  %loop.cond = icmp ult i32 %iv.next, 1000
+  br i1 %loop.cond, label %loop, label %exit
+
+exit:
+  ret i32 %x
+}
+
 ; Make sure we do not insert load into both cold path & backedge.
 define i32 @test_load_on_cold_path_and_backedge(ptr %p) {
 ; CHECK-LABEL: @test_load_on_cold_path_and_backedge(


### PR DESCRIPTION
When the only in-loop blocker of a loop-load PRE candidate has multiple successors, the reload was placed at the end of that block, so it also ran on the loop-exit edge. Split the critical edge to the unique in-loop successor and insert the reload there, so it runs only on the path back to the header. Bail out on indirectbr or multiple in-loop successors, and keep backedge splitting gated behind the existing flag. Also refresh the stale TODO comments on the freeable-pointer tests, which stay un-PRE'd because the pointer may be freed.