### PR TITLE
[libc] Implement cpp::unique_ptr utility

### DIFF
--- a/libc/src/__support/CPP/CMakeLists.txt
+++ b/libc/src/__support/CPP/CMakeLists.txt
@@ -202,6 +202,18 @@ add_header_library(
     expected.h
 )
 
+add_header_library(
+  unique_ptr
+  HDRS
+    unique_ptr.h
+  DEPENDS
+    .new
+    .type_traits
+    .utility
+    libc.src.__support.macros.attributes
+    libc.src.__support.macros.config
+)
+
 add_object_library(
   new
   SRCS

--- a/libc/src/__support/CPP/type_traits.h
+++ b/libc/src/__support/CPP/type_traits.h
@@ -1,9 +1,14 @@
-//===-- Self contained C++ type_traits --------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Self contained C++ type_traits.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC___SUPPORT_CPP_TYPE_TRAITS_H
@@ -24,6 +29,7 @@
 #include "src/__support/CPP/type_traits/invoke_result.h"
 #include "src/__support/CPP/type_traits/is_arithmetic.h"
 #include "src/__support/CPP/type_traits/is_array.h"
+#include "src/__support/CPP/type_traits/is_assignable.h"
 #include "src/__support/CPP/type_traits/is_base_of.h"
 #include "src/__support/CPP/type_traits/is_class.h"
 #include "src/__support/CPP/type_traits/is_complex.h"

--- a/libc/src/__support/CPP/unique_ptr.h
+++ b/libc/src/__support/CPP/unique_ptr.h
@@ -1,0 +1,214 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Standalone implementation of std::unique_ptr.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_CPP_UNIQUE_PTR_H
+#define LLVM_LIBC_SRC___SUPPORT_CPP_UNIQUE_PTR_H
+
+#include "src/__support/CPP/new.h"
+#include "src/__support/CPP/type_traits.h"
+#include "src/__support/CPP/utility.h"
+#include "src/__support/macros/attributes.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace cpp {
+
+/// A wrapper for deleting objects by default.
+template <typename T> struct default_delete {
+  LIBC_INLINE constexpr default_delete() = default;
+
+  template <typename U, typename = typename enable_if<
+                            is_convertible<U *, T *>::value>::type>
+  LIBC_INLINE constexpr default_delete(const default_delete<U> &) {}
+
+  LIBC_INLINE constexpr void operator()(T *ptr) const {
+    static_assert(sizeof(T) > 0, "cannot delete an incomplete type");
+    delete ptr;
+  }
+};
+
+/// A wrapper for deleting array objects by default.
+template <typename T> struct default_delete<T[]> {
+  LIBC_INLINE constexpr default_delete() = default;
+
+  template <typename U, typename = typename enable_if<
+                            is_convertible<U (*)[], T (*)[]>::value>::type>
+  LIBC_INLINE constexpr default_delete(const default_delete<U[]> &) {}
+
+  template <typename U, typename = typename enable_if<
+                            is_convertible<U (*)[], T (*)[]>::value>::type>
+  LIBC_INLINE constexpr void operator()(U *ptr) const {
+    static_assert(sizeof(U) > 0, "cannot delete an incomplete type");
+    delete[] ptr;
+  }
+};
+
+/// A smart pointer that owns and manages another object through a pointer.
+template <typename T, typename Deleter = default_delete<T>> class unique_ptr {
+  T *ptr_ = nullptr;
+  Deleter deleter_;
+
+  template <typename U, typename E> friend class unique_ptr;
+
+public:
+  using element_type = T;
+  using deleter_type = Deleter;
+  using pointer = T *;
+
+  LIBC_INLINE constexpr unique_ptr() = default;
+  LIBC_INLINE constexpr unique_ptr(decltype(nullptr)) : ptr_(nullptr) {}
+  LIBC_INLINE constexpr explicit unique_ptr(pointer p) : ptr_(p) {}
+
+  LIBC_INLINE constexpr unique_ptr(pointer p, const deleter_type &d)
+      : ptr_(p), deleter_(d) {}
+  LIBC_INLINE constexpr unique_ptr(pointer p, deleter_type &&d)
+      : ptr_(p), deleter_(move(d)) {}
+
+  // Move constructor
+  LIBC_INLINE constexpr unique_ptr(unique_ptr &&other)
+      : ptr_(other.release()), deleter_(forward<Deleter>(other.get_deleter())) {
+  }
+
+  // Move assignment
+  LIBC_INLINE constexpr unique_ptr &operator=(unique_ptr &&other) {
+    reset(other.release());
+    deleter_ = forward<Deleter>(other.get_deleter());
+    return *this;
+  }
+
+  // Conversion move constructor
+  template <
+      typename U, typename E,
+      typename = typename enable_if<
+          is_convertible<typename unique_ptr<U, E>::pointer, pointer>::value &&
+          !is_array<U>::value && is_convertible<E, Deleter>::value>::type>
+  LIBC_INLINE constexpr unique_ptr(unique_ptr<U, E> &&other)
+      : ptr_(other.release()), deleter_(forward<E>(other.get_deleter())) {}
+
+  // Conversion move assignment
+  template <
+      typename U, typename E,
+      typename = typename enable_if<
+          is_convertible<typename unique_ptr<U, E>::pointer, pointer>::value &&
+          !is_array<U>::value && is_assignable<Deleter &, E &&>::value>::type>
+  LIBC_INLINE constexpr unique_ptr &operator=(unique_ptr<U, E> &&other) {
+    reset(other.release());
+    deleter_ = forward<E>(other.get_deleter());
+    return *this;
+  }
+
+  // Disable copy
+  unique_ptr(const unique_ptr &) = delete;
+  unique_ptr &operator=(const unique_ptr &) = delete;
+
+  LIBC_INLINE ~unique_ptr() { reset(); }
+
+  LIBC_INLINE constexpr pointer get() const { return ptr_; }
+  LIBC_INLINE constexpr deleter_type &get_deleter() { return deleter_; }
+  LIBC_INLINE constexpr const deleter_type &get_deleter() const {
+    return deleter_;
+  }
+
+  LIBC_INLINE constexpr explicit operator bool() const {
+    return ptr_ != nullptr;
+  }
+
+  LIBC_INLINE constexpr pointer release() {
+    pointer temp = ptr_;
+    ptr_ = nullptr;
+    return temp;
+  }
+
+  LIBC_INLINE constexpr void reset(pointer p = pointer()) {
+    pointer old_ptr = ptr_;
+    ptr_ = p;
+    if (old_ptr)
+      deleter_(old_ptr);
+  }
+
+  LIBC_INLINE constexpr typename add_lvalue_reference<T>::type
+  operator*() const {
+    return *ptr_;
+  }
+  LIBC_INLINE constexpr pointer operator->() const { return ptr_; }
+};
+
+/// A smart pointer that owns and manages an array of objects through a pointer.
+template <typename T, typename Deleter> class unique_ptr<T[], Deleter> {
+  T *ptr_ = nullptr;
+  Deleter deleter_;
+
+  template <typename U, typename E> friend class unique_ptr;
+
+public:
+  using element_type = T;
+  using deleter_type = Deleter;
+  using pointer = T *;
+
+  LIBC_INLINE constexpr unique_ptr() = default;
+  LIBC_INLINE constexpr unique_ptr(decltype(nullptr)) : ptr_(nullptr) {}
+  LIBC_INLINE constexpr explicit unique_ptr(pointer p) : ptr_(p) {}
+
+  LIBC_INLINE constexpr unique_ptr(pointer p, const deleter_type &d)
+      : ptr_(p), deleter_(d) {}
+  LIBC_INLINE constexpr unique_ptr(pointer p, deleter_type &&d)
+      : ptr_(p), deleter_(move(d)) {}
+
+  // Move constructor
+  LIBC_INLINE constexpr unique_ptr(unique_ptr &&other)
+      : ptr_(other.release()), deleter_(forward<Deleter>(other.get_deleter())) {
+  }
+
+  // Move assignment
+  LIBC_INLINE constexpr unique_ptr &operator=(unique_ptr &&other) {
+    reset(other.release());
+    deleter_ = forward<Deleter>(other.get_deleter());
+    return *this;
+  }
+
+  // Disable copy
+  unique_ptr(const unique_ptr &) = delete;
+  unique_ptr &operator=(const unique_ptr &) = delete;
+
+  LIBC_INLINE ~unique_ptr() { reset(); }
+
+  LIBC_INLINE constexpr pointer get() const { return ptr_; }
+  LIBC_INLINE constexpr deleter_type &get_deleter() { return deleter_; }
+  LIBC_INLINE constexpr const deleter_type &get_deleter() const {
+    return deleter_;
+  }
+
+  LIBC_INLINE constexpr explicit operator bool() const {
+    return ptr_ != nullptr;
+  }
+
+  LIBC_INLINE constexpr pointer release() {
+    pointer temp = ptr_;
+    ptr_ = nullptr;
+    return temp;
+  }
+
+  LIBC_INLINE constexpr void reset(pointer p = pointer()) {
+    pointer old_ptr = ptr_;
+    ptr_ = p;
+    if (old_ptr)
+      deleter_(old_ptr);
+  }
+
+  LIBC_INLINE constexpr T &operator[](size_t i) const { return ptr_[i]; }
+};
+
+} // namespace cpp
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_CPP_UNIQUE_PTR_H

--- a/libc/src/__support/CPP/unique_ptr.h
+++ b/libc/src/__support/CPP/unique_ptr.h
@@ -27,8 +27,7 @@ namespace cpp {
 template <typename T> struct default_delete {
   LIBC_INLINE constexpr default_delete() = default;
 
-  template <typename U, typename = typename enable_if<
-                            is_convertible<U *, T *>::value>::type>
+  template <typename U, typename = enable_if_t<is_convertible_v<U *, T *>>>
   LIBC_INLINE constexpr default_delete(const default_delete<U> &) {}
 
   LIBC_INLINE constexpr void operator()(T *ptr) const {
@@ -41,12 +40,12 @@ template <typename T> struct default_delete {
 template <typename T> struct default_delete<T[]> {
   LIBC_INLINE constexpr default_delete() = default;
 
-  template <typename U, typename = typename enable_if<
-                            is_convertible<U (*)[], T (*)[]>::value>::type>
+  template <typename U,
+            typename = enable_if_t<is_convertible_v<U (*)[], T (*)[]>>>
   LIBC_INLINE constexpr default_delete(const default_delete<U[]> &) {}
 
-  template <typename U, typename = typename enable_if<
-                            is_convertible<U (*)[], T (*)[]>::value>::type>
+  template <typename U,
+            typename = enable_if_t<is_convertible_v<U (*)[], T (*)[]>>>
   LIBC_INLINE constexpr void operator()(U *ptr) const {
     static_assert(sizeof(U) > 0, "cannot delete an incomplete type");
     delete[] ptr;
@@ -54,11 +53,10 @@ template <typename T> struct default_delete<T[]> {
 };
 
 /// A smart pointer that owns and manages another object through a pointer.
-template <typename T, typename Deleter = default_delete<T>> class unique_ptr {
-  T *ptr_ = nullptr;
-  Deleter deleter_;
-
-  template <typename U, typename E> friend class unique_ptr;
+template <typename T, typename Deleter = default_delete<T>>
+class LIBC_TRIVIAL_ABI unique_ptr {
+  T *ptr = nullptr;
+  LIBC_NO_UNIQUE_ADDRESS Deleter deleter;
 
 public:
   using element_type = T;
@@ -66,44 +64,41 @@ public:
   using pointer = T *;
 
   LIBC_INLINE constexpr unique_ptr() = default;
-  LIBC_INLINE constexpr unique_ptr(decltype(nullptr)) : ptr_(nullptr) {}
-  LIBC_INLINE constexpr explicit unique_ptr(pointer p) : ptr_(p) {}
+  LIBC_INLINE constexpr unique_ptr(decltype(nullptr)) : ptr(nullptr) {}
+  LIBC_INLINE constexpr explicit unique_ptr(pointer p) : ptr(p) {}
 
   LIBC_INLINE constexpr unique_ptr(pointer p, const deleter_type &d)
-      : ptr_(p), deleter_(d) {}
+      : ptr(p), deleter(d) {}
   LIBC_INLINE constexpr unique_ptr(pointer p, deleter_type &&d)
-      : ptr_(p), deleter_(move(d)) {}
+      : ptr(p), deleter(move(d)) {}
 
   // Move constructor
   LIBC_INLINE constexpr unique_ptr(unique_ptr &&other)
-      : ptr_(other.release()), deleter_(forward<Deleter>(other.get_deleter())) {
-  }
+      : ptr(other.release()), deleter(forward<Deleter>(other.get_deleter())) {}
 
   // Move assignment
   LIBC_INLINE constexpr unique_ptr &operator=(unique_ptr &&other) {
     reset(other.release());
-    deleter_ = forward<Deleter>(other.get_deleter());
+    deleter = forward<Deleter>(other.get_deleter());
     return *this;
   }
 
   // Conversion move constructor
-  template <
-      typename U, typename E,
-      typename = typename enable_if<
-          is_convertible<typename unique_ptr<U, E>::pointer, pointer>::value &&
-          !is_array<U>::value && is_convertible<E, Deleter>::value>::type>
+  template <typename U, typename E,
+            typename = enable_if_t<
+                is_convertible_v<typename unique_ptr<U, E>::pointer, pointer> &&
+                !is_array<U>::value && is_convertible_v<E, Deleter>>>
   LIBC_INLINE constexpr unique_ptr(unique_ptr<U, E> &&other)
-      : ptr_(other.release()), deleter_(forward<E>(other.get_deleter())) {}
+      : ptr(other.release()), deleter(forward<E>(other.get_deleter())) {}
 
   // Conversion move assignment
-  template <
-      typename U, typename E,
-      typename = typename enable_if<
-          is_convertible<typename unique_ptr<U, E>::pointer, pointer>::value &&
-          !is_array<U>::value && is_assignable<Deleter &, E &&>::value>::type>
+  template <typename U, typename E,
+            typename = enable_if_t<
+                is_convertible_v<typename unique_ptr<U, E>::pointer, pointer> &&
+                !is_array<U>::value && is_assignable_v<Deleter &, E &&>>>
   LIBC_INLINE constexpr unique_ptr &operator=(unique_ptr<U, E> &&other) {
     reset(other.release());
-    deleter_ = forward<E>(other.get_deleter());
+    deleter = forward<E>(other.get_deleter());
     return *this;
   }
 
@@ -113,42 +108,41 @@ public:
 
   LIBC_INLINE ~unique_ptr() { reset(); }
 
-  LIBC_INLINE constexpr pointer get() const { return ptr_; }
-  LIBC_INLINE constexpr deleter_type &get_deleter() { return deleter_; }
+  LIBC_INLINE constexpr pointer get() const { return ptr; }
+  LIBC_INLINE constexpr deleter_type &get_deleter() { return deleter; }
   LIBC_INLINE constexpr const deleter_type &get_deleter() const {
-    return deleter_;
+    return deleter;
   }
 
   LIBC_INLINE constexpr explicit operator bool() const {
-    return ptr_ != nullptr;
+    return ptr != nullptr;
   }
 
   LIBC_INLINE constexpr pointer release() {
-    pointer temp = ptr_;
-    ptr_ = nullptr;
+    pointer temp = ptr;
+    ptr = nullptr;
     return temp;
   }
 
   LIBC_INLINE constexpr void reset(pointer p = pointer()) {
-    pointer old_ptr = ptr_;
-    ptr_ = p;
+    pointer old_ptr = ptr;
+    ptr = p;
     if (old_ptr)
-      deleter_(old_ptr);
+      deleter(old_ptr);
   }
 
   LIBC_INLINE constexpr typename add_lvalue_reference<T>::type
   operator*() const {
-    return *ptr_;
+    return *ptr;
   }
-  LIBC_INLINE constexpr pointer operator->() const { return ptr_; }
+  LIBC_INLINE constexpr pointer operator->() const { return ptr; }
 };
 
 /// A smart pointer that owns and manages an array of objects through a pointer.
-template <typename T, typename Deleter> class unique_ptr<T[], Deleter> {
-  T *ptr_ = nullptr;
-  Deleter deleter_;
-
-  template <typename U, typename E> friend class unique_ptr;
+template <typename T, typename Deleter>
+class LIBC_TRIVIAL_ABI unique_ptr<T[], Deleter> {
+  T *ptr = nullptr;
+  LIBC_NO_UNIQUE_ADDRESS Deleter deleter;
 
 public:
   using element_type = T;
@@ -156,23 +150,22 @@ public:
   using pointer = T *;
 
   LIBC_INLINE constexpr unique_ptr() = default;
-  LIBC_INLINE constexpr unique_ptr(decltype(nullptr)) : ptr_(nullptr) {}
-  LIBC_INLINE constexpr explicit unique_ptr(pointer p) : ptr_(p) {}
+  LIBC_INLINE constexpr unique_ptr(decltype(nullptr)) : ptr(nullptr) {}
+  LIBC_INLINE constexpr explicit unique_ptr(pointer p) : ptr(p) {}
 
   LIBC_INLINE constexpr unique_ptr(pointer p, const deleter_type &d)
-      : ptr_(p), deleter_(d) {}
+      : ptr(p), deleter(d) {}
   LIBC_INLINE constexpr unique_ptr(pointer p, deleter_type &&d)
-      : ptr_(p), deleter_(move(d)) {}
+      : ptr(p), deleter(move(d)) {}
 
   // Move constructor
   LIBC_INLINE constexpr unique_ptr(unique_ptr &&other)
-      : ptr_(other.release()), deleter_(forward<Deleter>(other.get_deleter())) {
-  }
+      : ptr(other.release()), deleter(forward<Deleter>(other.get_deleter())) {}
 
   // Move assignment
   LIBC_INLINE constexpr unique_ptr &operator=(unique_ptr &&other) {
     reset(other.release());
-    deleter_ = forward<Deleter>(other.get_deleter());
+    deleter = forward<Deleter>(other.get_deleter());
     return *this;
   }
 
@@ -182,30 +175,30 @@ public:
 
   LIBC_INLINE ~unique_ptr() { reset(); }
 
-  LIBC_INLINE constexpr pointer get() const { return ptr_; }
-  LIBC_INLINE constexpr deleter_type &get_deleter() { return deleter_; }
+  LIBC_INLINE constexpr pointer get() const { return ptr; }
+  LIBC_INLINE constexpr deleter_type &get_deleter() { return deleter; }
   LIBC_INLINE constexpr const deleter_type &get_deleter() const {
-    return deleter_;
+    return deleter;
   }
 
   LIBC_INLINE constexpr explicit operator bool() const {
-    return ptr_ != nullptr;
+    return ptr != nullptr;
   }
 
   LIBC_INLINE constexpr pointer release() {
-    pointer temp = ptr_;
-    ptr_ = nullptr;
+    pointer temp = ptr;
+    ptr = nullptr;
     return temp;
   }
 
   LIBC_INLINE constexpr void reset(pointer p = pointer()) {
-    pointer old_ptr = ptr_;
-    ptr_ = p;
+    pointer old_ptr = ptr;
+    ptr = p;
     if (old_ptr)
-      deleter_(old_ptr);
+      deleter(old_ptr);
   }
 
-  LIBC_INLINE constexpr T &operator[](size_t i) const { return ptr_[i]; }
+  LIBC_INLINE constexpr T &operator[](size_t i) const { return ptr[i]; }
 };
 
 } // namespace cpp

--- a/libc/src/__support/macros/attributes.h
+++ b/libc/src/__support/macros/attributes.h
@@ -24,6 +24,10 @@
 #define __has_attribute(x) 0
 #endif
 
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(x) 0
+#endif
+
 #define LIBC_INLINE inline
 #define LIBC_INLINE_VAR inline
 #define LIBC_INLINE_ASM __asm__ __volatile__
@@ -146,6 +150,18 @@ LIBC_THREAD_MODE_EXTERNAL.
 #define LIBC_PREFERED_TYPE(TYPE) [[clang::preferred_type(TYPE)]]
 #else
 #define LIBC_PREFERED_TYPE(TYPE)
+#endif
+
+#if __has_cpp_attribute(no_unique_address)
+#define LIBC_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+#define LIBC_NO_UNIQUE_ADDRESS
+#endif
+
+#if __has_attribute(trivial_abi)
+#define LIBC_TRIVIAL_ABI [[clang::trivial_abi]]
+#else
+#define LIBC_TRIVIAL_ABI
 #endif
 
 #if __has_attribute(ext_vector_type) &&                                        \

--- a/libc/test/src/__support/CPP/CMakeLists.txt
+++ b/libc/test/src/__support/CPP/CMakeLists.txt
@@ -108,7 +108,6 @@ add_libc_test(
     libc.src.__support.CPP.utility
 )
 
-
 # This test fails with invalid address space operations on sm_60
 if(NOT LIBC_TARGET_ARCHITECTURE_IS_NVPTX)
   add_libc_test(
@@ -141,6 +140,17 @@ add_libc_test(
     optional_test.cpp
   DEPENDS
     libc.src.__support.CPP.optional
+)
+
+add_libc_test(
+  unique_ptr_test
+  SUITE
+    libc-cpp-utils-tests
+  SRCS
+    unique_ptr_test.cpp
+  DEPENDS
+    libc.src.__support.CPP.unique_ptr
+    libc.src.__support.CPP.utility
 )
 
 add_libc_test(
@@ -180,9 +190,9 @@ add_libc_test(
   SRCS
     string_test.cpp
   DEPENDS
-  libc.hdr.func.free
-  libc.src.__support.CPP.string
-  libc.src.__support.CPP.string_view
+    libc.hdr.func.free
+    libc.src.__support.CPP.string
+    libc.src.__support.CPP.string_view
 )
 
 add_libc_test(
@@ -190,9 +200,9 @@ add_libc_test(
   SUITE
     libc-cpp-utils-tests
   SRCS
-  type_traits_test.cpp
+    type_traits_test.cpp
   DEPENDS
-  libc.src.__support.CPP.type_traits
+    libc.src.__support.CPP.type_traits
 )
 
 if(LIBC_COMPILER_HAS_EXT_VECTOR_TYPE)

--- a/libc/test/src/__support/CPP/unique_ptr_test.cpp
+++ b/libc/test/src/__support/CPP/unique_ptr_test.cpp
@@ -1,0 +1,146 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for UniquePtr.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/CPP/unique_ptr.h"
+#include "src/__support/CPP/utility.h"
+#include "test/UnitTest/Test.h"
+
+using LIBC_NAMESPACE::cpp::unique_ptr;
+
+struct DestructTracker {
+  int *destruct_count = nullptr;
+  DestructTracker() = default;
+  DestructTracker(int *count) : destruct_count(count) {}
+  ~DestructTracker() {
+    if (destruct_count)
+      (*destruct_count)++;
+  }
+};
+
+// Test basic construction, ownership, and destruction.
+TEST(LlvmLibcUniquePtrTest, Basic) {
+  int destruct_count = 0;
+  {
+    unique_ptr<DestructTracker> ptr(new DestructTracker(&destruct_count));
+    ASSERT_TRUE(static_cast<bool>(ptr));
+    ASSERT_EQ(destruct_count, 0);
+  }
+  ASSERT_EQ(destruct_count, 1);
+}
+
+// Test nullptr construction and behavior.
+TEST(LlvmLibcUniquePtrTest, Nullptr) {
+  unique_ptr<int> ptr(nullptr);
+  ASSERT_FALSE(static_cast<bool>(ptr));
+  ASSERT_EQ(ptr.get(), static_cast<int *>(nullptr));
+}
+
+// Test move construction transferring ownership.
+TEST(LlvmLibcUniquePtrTest, Move) {
+  int destruct_count = 0;
+  {
+    unique_ptr<DestructTracker> ptr1(new DestructTracker(&destruct_count));
+    unique_ptr<DestructTracker> ptr2(LIBC_NAMESPACE::cpp::move(ptr1));
+    ASSERT_FALSE(static_cast<bool>(ptr1));
+    ASSERT_TRUE(static_cast<bool>(ptr2));
+    ASSERT_EQ(destruct_count, 0);
+  }
+  ASSERT_EQ(destruct_count, 1);
+}
+
+// Test move assignment transferring ownership and releasing old resource.
+TEST(LlvmLibcUniquePtrTest, MoveAssignment) {
+  int destruct_count1 = 0;
+  int destruct_count2 = 0;
+  {
+    unique_ptr<DestructTracker> ptr1(new DestructTracker(&destruct_count1));
+    unique_ptr<DestructTracker> ptr2(new DestructTracker(&destruct_count2));
+    ptr2 = LIBC_NAMESPACE::cpp::move(ptr1);
+    ASSERT_FALSE(static_cast<bool>(ptr1));
+    ASSERT_TRUE(static_cast<bool>(ptr2));
+    ASSERT_EQ(destruct_count1, 0);
+    ASSERT_EQ(destruct_count2, 1); // ptr2's original object should be destroyed
+  }
+  ASSERT_EQ(destruct_count1, 1);
+}
+
+// Test release of ownership without destroying the object.
+TEST(LlvmLibcUniquePtrTest, Release) {
+  int destruct_count = 0;
+  DestructTracker *raw_ptr = nullptr;
+  {
+    unique_ptr<DestructTracker> ptr(new DestructTracker(&destruct_count));
+    raw_ptr = ptr.release();
+    ASSERT_FALSE(static_cast<bool>(ptr));
+    ASSERT_EQ(destruct_count, 0);
+  }
+  ASSERT_EQ(destruct_count, 0);
+  delete raw_ptr;
+  ASSERT_EQ(destruct_count, 1);
+}
+
+// Test reset replacing the owned object and destroying the old one.
+TEST(LlvmLibcUniquePtrTest, Reset) {
+  int destruct_count1 = 0;
+  int destruct_count2 = 0;
+  {
+    unique_ptr<DestructTracker> ptr(new DestructTracker(&destruct_count1));
+    ptr.reset(new DestructTracker(&destruct_count2));
+    ASSERT_EQ(destruct_count1, 1);
+    ASSERT_EQ(destruct_count2, 0);
+  }
+  ASSERT_EQ(destruct_count2, 1);
+}
+
+// Test dereference operators (operator* and operator->).
+TEST(LlvmLibcUniquePtrTest, Dereference) {
+  struct Foo {
+    int val;
+  };
+  unique_ptr<Foo> ptr(new Foo{42});
+  ASSERT_EQ((*ptr).val, 42);
+  ASSERT_EQ(ptr->val, 42);
+}
+
+// Test array specialization behavior and destruction.
+TEST(LlvmLibcUniquePtrTest, Array) {
+  int destruct_count = 0;
+  {
+    unique_ptr<DestructTracker[]> ptr(new DestructTracker[3]);
+    ptr[0].destruct_count = &destruct_count;
+    ptr[1].destruct_count = &destruct_count;
+    ptr[2].destruct_count = &destruct_count;
+    ASSERT_TRUE(static_cast<bool>(ptr));
+    ASSERT_EQ(destruct_count, 0);
+  }
+  ASSERT_EQ(destruct_count, 3);
+}
+
+struct CustomDeleter {
+  int *count;
+  void operator()(int *p) const {
+    (*count)++;
+    delete p;
+  }
+};
+
+// Test support for custom deleters.
+TEST(LlvmLibcUniquePtrTest, CustomDeleter) {
+  int deleter_count = 0;
+  {
+    unique_ptr<int, CustomDeleter> ptr(new int(42),
+                                       CustomDeleter{&deleter_count});
+    ASSERT_EQ(deleter_count, 0);
+  }
+  ASSERT_EQ(deleter_count, 1);
+}

--- a/libc/test/src/__support/CPP/unique_ptr_test.cpp
+++ b/libc/test/src/__support/CPP/unique_ptr_test.cpp
@@ -144,3 +144,50 @@ TEST(LlvmLibcUniquePtrTest, CustomDeleter) {
   }
   ASSERT_EQ(deleter_count, 1);
 }
+
+struct ReentrancyTracker {
+  unique_ptr<ReentrancyTracker> *owner;
+  bool *checked;
+  ReentrancyTracker(unique_ptr<ReentrancyTracker> *o, bool *c)
+      : owner(o), checked(c) {}
+  ~ReentrancyTracker() {
+    if (owner)
+      *checked = (owner->get() == nullptr);
+  }
+};
+
+// Test that reset() clears the pointer before invoking the deleter.
+TEST(LlvmLibcUniquePtrTest, ResetSequencing) {
+  bool checked = false;
+  unique_ptr<ReentrancyTracker> ptr;
+  ptr.reset(new ReentrancyTracker(&ptr, &checked));
+  ptr.reset(); // trigger destructor
+  ASSERT_TRUE(checked);
+}
+
+// Test conversion constructor for const types.
+TEST(LlvmLibcUniquePtrTest, ConstConversion) {
+  unique_ptr<int> ptr1(new int(42));
+  unique_ptr<const int> ptr2(LIBC_NAMESPACE::cpp::move(ptr1));
+  ASSERT_FALSE(static_cast<bool>(ptr1));
+  ASSERT_TRUE(static_cast<bool>(ptr2));
+  ASSERT_EQ(*ptr2, 42);
+}
+
+struct Base {
+  int val;
+  virtual ~Base() = default;
+  Base(int v) : val(v) {}
+};
+struct Derived : public Base {
+  Derived(int v) : Base(v) {}
+};
+
+// Test conversion constructor for base/derived types.
+TEST(LlvmLibcUniquePtrTest, BaseDerivedConversion) {
+  unique_ptr<Derived> derived_ptr(new Derived(100));
+  unique_ptr<Base> base_ptr(LIBC_NAMESPACE::cpp::move(derived_ptr));
+  ASSERT_FALSE(static_cast<bool>(derived_ptr));
+  ASSERT_TRUE(static_cast<bool>(base_ptr));
+  ASSERT_EQ(base_ptr->val, 100);
+}

--- a/libc/test/src/__support/CPP/unique_ptr_test.cpp
+++ b/libc/test/src/__support/CPP/unique_ptr_test.cpp
@@ -145,6 +145,27 @@ TEST(LlvmLibcUniquePtrTest, CustomDeleter) {
   ASSERT_EQ(deleter_count, 1);
 }
 
+struct CustomArrayDeleter {
+  int *count;
+  void operator()(int *p) const {
+    if (count)
+      (*count)++;
+    delete[] p;
+  }
+};
+
+// Test support for custom deleters on array unique_ptr.
+TEST(LlvmLibcUniquePtrTest, CustomArrayDeleter) {
+  int deleter_count = 0;
+  {
+    CustomArrayDeleter d{&deleter_count};
+    unique_ptr<int[], CustomArrayDeleter> ptr(new int[3], d);
+    ASSERT_EQ(deleter_count, 0);
+    ASSERT_EQ(ptr.get_deleter().count, d.count);
+  }
+  ASSERT_EQ(deleter_count, 1);
+}
+
 struct ReentrancyTracker {
   unique_ptr<ReentrancyTracker> *owner;
   bool *checked;


### PR DESCRIPTION
[libc] Implement cpp::unique_ptr utility

Implemented cpp::unique_ptr and cpp::default_delete in
libc/src/__support/CPP/unique_ptr.h for internal use within LLVM-libc.

* Added cpp::default_delete and its array specialization.
* Implemented cpp::unique_ptr with support for custom deleters and
  array specialization.
* Applied LIBC_TRIVIAL_ABI to unique_ptr and LIBC_NO_UNIQUE_ADDRESS to the
  deleter to enable empty member optimization and register-passing ABI.
* Defined portable LIBC_NO_UNIQUE_ADDRESS and LIBC_TRIVIAL_ABI macros in
  attributes.h.
* Included is_assignable.h in type_traits.h to support conversion
  assignment constraints.
* Modernized template constraints using enable_if_t and is_convertible_v.
* Added comprehensive unit tests in
  libc/test/src/__support/CPP/unique_ptr_test.cpp, including coverage for
  reset sequencing, custom deleters, and conversion constructors.

This is a simplified implementation with the following limitations:
* No support for custom pointer types (hardcoded to T*).
* No support for reference deleter types or array conversion.

Adding this to LLVM libc because some things (like regex) require dynamic
memory allocation, and this will help with correct memory management.

Assisted-by: Automated tooling, human reviewed.