### PR TITLE
[clang] Check `T` and `U` operands of __reference_constructs_from_temporary are complete types

### DIFF
--- a/clang/lib/Sema/SemaTypeTraits.cpp
+++ b/clang/lib/Sema/SemaTypeTraits.cpp
@@ -1292,8 +1292,6 @@ static bool EvaluateBooleanTypeTrait(Sema &S, TypeTrait Kind,
         Kind == clang::BTT_ReferenceBindsToTemporary ||
         Kind == clang::BTT_ReferenceConstructsFromTemporary ||
         Kind == clang::BTT_ReferenceConvertsFromTemporary;
-    if (UseRawObjectType && !Args[0]->getType()->isReferenceType())
-      return false;
 
     // Precondition: T and all types in the parameter pack Args shall be
     // complete types, (possibly cv-qualified) void, or arrays of
@@ -1310,7 +1308,8 @@ static bool EvaluateBooleanTypeTrait(Sema &S, TypeTrait Kind,
 
     // Make sure the first argument is not incomplete nor a function type.
     QualType T = Args[0]->getType();
-    if (T->isIncompleteType() || T->isFunctionType())
+    if (T->isIncompleteType() || T->isFunctionType() ||
+        (UseRawObjectType && !T->isReferenceType()))
       return false;
 
     // Make sure the first argument is not an abstract type.

--- a/clang/test/SemaCXX/type-traits-incomplete.cpp
+++ b/clang/test/SemaCXX/type-traits-incomplete.cpp
@@ -12,3 +12,9 @@ void f() {
   __is_trivially_relocatable(S); // expected-error{{incomplete type 'S' used in type trait expression}}
   __is_trivially_relocatable(S[]); // expected-error{{incomplete type 'S' used in type trait expression}}
 }
+
+struct NoConv;
+struct Bad;
+
+constexpr bool a = __reference_constructs_from_temporary(S, NoConv&&); // expected-error{{incomplete type 'Bad' used in type trait expression}}
+

--- a/clang/test/SemaCXX/type-traits-incomplete.cpp
+++ b/clang/test/SemaCXX/type-traits-incomplete.cpp
@@ -1,6 +1,9 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s 
 
-struct S; // expected-note 6 {{forward declaration of 'S'}}
+struct S; // expected-note 8 {{forward declaration of 'S'}}
+
+struct NoConv {};
+struct Bad { template<class T> Bad(T v) noexcept(noexcept(member_ = v)) {} int member_; };
 
 void f() {
   __is_pod(S); // expected-error{{incomplete type 'S' used in type trait expression}}
@@ -11,10 +14,7 @@ void f() {
 
   __is_trivially_relocatable(S); // expected-error{{incomplete type 'S' used in type trait expression}}
   __is_trivially_relocatable(S[]); // expected-error{{incomplete type 'S' used in type trait expression}}
+
+  static_assert(!__reference_constructs_from_temporary(S, NoConv&&)); // expected-error{{incomplete type 'S' used in type trait expression}}
+  static_assert(!__reference_constructs_from_temporary(Bad, S)); // expected-error{{incomplete type 'S' used in type trait expression}}
 }
-
-struct NoConv;
-struct Bad;
-
-constexpr bool a = __reference_constructs_from_temporary(S, NoConv&&); // expected-error{{incomplete type 'Bad' used in type trait expression}}
-


### PR DESCRIPTION

This PR fix a bug introduce by https://github.com/llvm/llvm-project/pull/206527.

[type.traits] Precondition : "T and U shall be complete types, cv void, or arrays of unknown bound first.

The check for which [#206527](https://github.com/llvm/llvm-project/pull/206527.) disables if the first argument isn't a reference type.