### PR TITLE
[LegalizeTypes] Don't pad cttz_elts_zero_poison with ones when widening op

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -8734,9 +8734,9 @@ SDValue DAGTypeLegalizer::WidenVecOp_CttzElements(SDNode *N) {
       TLI.getTypeToTransformTo(*DAG.getContext(), Source.getValueType());
 
   SDValue WideSource;
-  if (N->getOpcode() == ISD::CTTZ_ELTS_ZERO_POISON)
+  if (N->getOpcode() == ISD::CTTZ_ELTS_ZERO_POISON) {
     WideSource = GetWidenedVector(Source);
-  else {
+  } else {
     // Pad the widened portion with all-ones so the extra lanes appear as
     // active (non-zero) elements and do not contribute trailing zeros.
     SDValue AllOnes = DAG.getAllOnesConstant(DL, WideVT);

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -8730,12 +8730,18 @@ SDValue DAGTypeLegalizer::WidenVecOp_VSELECT(SDNode *N) {
 SDValue DAGTypeLegalizer::WidenVecOp_CttzElements(SDNode *N) {
   SDLoc DL(N);
   SDValue Source = N->getOperand(0);
-  EVT WideVT = GetWidenedVector(Source).getValueType();
+  EVT WideVT =
+      TLI.getTypeToTransformTo(*DAG.getContext(), Source.getValueType());
 
-  // Pad the widened portion with all-ones so the extra lanes appear as
-  // active (non-zero) elements and do not contribute trailing zeros.
-  SDValue AllOnes = DAG.getAllOnesConstant(DL, WideVT);
-  SDValue WideSource = DAG.getInsertSubvector(DL, AllOnes, Source, 0);
+  SDValue WideSource;
+  if (N->getOpcode() == ISD::CTTZ_ELTS_ZERO_POISON)
+    WideSource = GetWidenedVector(Source);
+  else {
+    // Pad the widened portion with all-ones so the extra lanes appear as
+    // active (non-zero) elements and do not contribute trailing zeros.
+    SDValue AllOnes = DAG.getAllOnesConstant(DL, WideVT);
+    WideSource = DAG.getInsertSubvector(DL, AllOnes, Source, 0);
+  }
 
   return DAG.getNode(N->getOpcode(), DL, N->getValueType(0), WideSource,
                      N->getFlags());

--- a/llvm/test/CodeGen/AArch64/intrinsic-cttz-elts-sve.ll
+++ b/llvm/test/CodeGen/AArch64/intrinsic-cttz-elts-sve.ll
@@ -142,15 +142,8 @@ define i32 @ctz_nxv3i1(<vscale x 3 x i1> %a) {
 define i32 @ctz_nxv3i1_poison(<vscale x 3 x i1> %a) {
 ; CHECK-LABEL: ctz_nxv3i1_poison:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    rdvl x8, #1
-; CHECK-NEXT:    mov w9, #3 // =0x3
-; CHECK-NEXT:    ptrue p2.s
-; CHECK-NEXT:    lsr x8, x8, #4
-; CHECK-NEXT:    mul x8, x8, x9
-; CHECK-NEXT:    whilelo p1.s, xzr, x8
-; CHECK-NEXT:    not p1.b, p2/z, p1.b
-; CHECK-NEXT:    mov p0.b, p1/m, p1.b
-; CHECK-NEXT:    brkb p0.b, p2/z, p0.b
+; CHECK-NEXT:    ptrue p1.s
+; CHECK-NEXT:    brkb p0.b, p1/z, p0.b
 ; CHECK-NEXT:    cntp x0, p0, p0.s
 ; CHECK-NEXT:    ret
   %res = call i32 @llvm.experimental.cttz.elts.i32.nxv3i1(<vscale x 3 x i1> %a, i1 1)

--- a/llvm/test/CodeGen/Hexagon/cttz-elts-widen.ll
+++ b/llvm/test/CodeGen/Hexagon/cttz-elts-widen.ll
@@ -39,8 +39,8 @@ define i32 @cttz_elts_v3i32(<3 x i32> %v) {
 ; Same shape for the zero-poison variant; padding must still be emitted.
 define i32 @cttz_elts_zero_poison_v3i32(<3 x i32> %v) {
 ; CHECK-LABEL: cttz_elts_zero_poison_v3i32:
-; CHECK:     p2 = vcmpw.eq(r1:0,r5:4)
-; CHECK:     p0 = vcmpw.eq(r7:6,r5:4)
+; CHECK:     p0 = vcmpw.eq(r1:0,r3:2)
+; CHECK:     p1 = vcmpw.eq(r7:6,r3:2)
 ; CHECK:     r0 = sub(#4,r0)
   %res = call i32 @llvm.experimental.cttz.elts.i32.v3i32(<3 x i32> %v, i1 true)
   ret i32 %res

--- a/llvm/test/CodeGen/RISCV/rvv/cttz-elts.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/cttz-elts.ll
@@ -261,4 +261,56 @@ define i32 @ctz_v3i32(<3 x i32> %a) {
   ret i32 %res
 }
 
+define i32 @ctz_v3i32_poison(<3 x i32> %a) {
+; RV32-LABEL: ctz_v3i32_poison:
+; RV32:       # %bb.0:
+; RV32-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
+; RV32-NEXT:    vmv.v.i v9, 0
+; RV32-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
+; RV32-NEXT:    vmsne.vi v0, v8, 0
+; RV32-NEXT:    vfirst.m a0, v0
+; RV32-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
+; RV32-NEXT:    vmerge.vim v8, v9, 1, v0
+; RV32-NEXT:    vslidedown.vi v9, v8, 1
+; RV32-NEXT:    vmv.x.s a1, v9
+; RV32-NEXT:    vslidedown.vi v8, v8, 2
+; RV32-NEXT:    vmv.x.s a2, v8
+; RV32-NEXT:    seqz a0, a0
+; RV32-NEXT:    vmv.v.x v8, a0
+; RV32-NEXT:    vslide1down.vx v8, v8, a1
+; RV32-NEXT:    vslide1down.vx v8, v8, a2
+; RV32-NEXT:    li a0, 1
+; RV32-NEXT:    vslide1down.vx v8, v8, a0
+; RV32-NEXT:    vand.vi v8, v8, 1
+; RV32-NEXT:    vmsne.vi v8, v8, 0
+; RV32-NEXT:    vfirst.m a0, v8
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: ctz_v3i32_poison:
+; RV64:       # %bb.0:
+; RV64-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
+; RV64-NEXT:    vmv.v.i v9, 0
+; RV64-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
+; RV64-NEXT:    vmsne.vi v0, v8, 0
+; RV64-NEXT:    vfirst.m a0, v0
+; RV64-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
+; RV64-NEXT:    vmerge.vim v8, v9, 1, v0
+; RV64-NEXT:    vslidedown.vi v9, v8, 1
+; RV64-NEXT:    vmv.x.s a1, v9
+; RV64-NEXT:    vslidedown.vi v8, v8, 2
+; RV64-NEXT:    vmv.x.s a2, v8
+; RV64-NEXT:    seqz a0, a0
+; RV64-NEXT:    vmv.v.x v8, a0
+; RV64-NEXT:    vslide1down.vx v8, v8, a1
+; RV64-NEXT:    vslide1down.vx v8, v8, a2
+; RV64-NEXT:    li a0, 1
+; RV64-NEXT:    vslide1down.vx v8, v8, a0
+; RV64-NEXT:    vand.vi v8, v8, 1
+; RV64-NEXT:    vmsne.vi v8, v8, 0
+; RV64-NEXT:    vfirst.m a0, v8
+; RV64-NEXT:    ret
+  %res = call i32 @llvm.experimental.cttz.elts.i32.v3i32(<3 x i32> %a, i1 1)
+  ret i32 %res
+}
+
 attributes #0 = { vscale_range(2,1024) }

--- a/llvm/test/CodeGen/RISCV/rvv/cttz-elts.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/cttz-elts.ll
@@ -264,52 +264,36 @@ define i32 @ctz_v3i32(<3 x i32> %a) {
 define i32 @ctz_v3i32_poison(<3 x i32> %a) {
 ; RV32-LABEL: ctz_v3i32_poison:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; RV32-NEXT:    vmv.v.i v9, 0
-; RV32-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; RV32-NEXT:    vmsne.vi v0, v8, 0
-; RV32-NEXT:    vfirst.m a0, v0
-; RV32-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
-; RV32-NEXT:    vmerge.vim v8, v9, 1, v0
-; RV32-NEXT:    vslidedown.vi v9, v8, 1
-; RV32-NEXT:    vmv.x.s a1, v9
-; RV32-NEXT:    vslidedown.vi v8, v8, 2
-; RV32-NEXT:    vmv.x.s a2, v8
-; RV32-NEXT:    seqz a0, a0
-; RV32-NEXT:    vmv.v.x v8, a0
-; RV32-NEXT:    vslide1down.vx v8, v8, a1
-; RV32-NEXT:    vslide1down.vx v8, v8, a2
-; RV32-NEXT:    li a0, 1
-; RV32-NEXT:    vslide1down.vx v8, v8, a0
-; RV32-NEXT:    vand.vi v8, v8, 1
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; RV32-NEXT:    vmsne.vi v8, v8, 0
 ; RV32-NEXT:    vfirst.m a0, v8
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: ctz_v3i32_poison:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    vsetivli zero, 4, e8, mf4, ta, ma
-; RV64-NEXT:    vmv.v.i v9, 0
-; RV64-NEXT:    vsetvli zero, zero, e32, m1, ta, ma
-; RV64-NEXT:    vmsne.vi v0, v8, 0
-; RV64-NEXT:    vfirst.m a0, v0
-; RV64-NEXT:    vsetvli zero, zero, e8, mf4, ta, ma
-; RV64-NEXT:    vmerge.vim v8, v9, 1, v0
-; RV64-NEXT:    vslidedown.vi v9, v8, 1
-; RV64-NEXT:    vmv.x.s a1, v9
-; RV64-NEXT:    vslidedown.vi v8, v8, 2
-; RV64-NEXT:    vmv.x.s a2, v8
-; RV64-NEXT:    seqz a0, a0
-; RV64-NEXT:    vmv.v.x v8, a0
-; RV64-NEXT:    vslide1down.vx v8, v8, a1
-; RV64-NEXT:    vslide1down.vx v8, v8, a2
-; RV64-NEXT:    li a0, 1
-; RV64-NEXT:    vslide1down.vx v8, v8, a0
-; RV64-NEXT:    vand.vi v8, v8, 1
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; RV64-NEXT:    vmsne.vi v8, v8, 0
 ; RV64-NEXT:    vfirst.m a0, v8
 ; RV64-NEXT:    ret
-  %res = call i32 @llvm.experimental.cttz.elts.i32.v3i32(<3 x i32> %a, i1 1)
+  %res = call i32 @llvm.experimental.cttz.elts(<3 x i32> %a, i1 1)
+  ret i32 %res
+}
+
+define i32 @ctz_nxv3i32_poison(<vscale x 3 x i32> %a) {
+; RV32-LABEL: ctz_nxv3i32_poison:
+; RV32:       # %bb.0:
+; RV32-NEXT:    vsetvli a0, zero, e32, m2, ta, ma
+; RV32-NEXT:    vmsne.vi v10, v8, 0
+; RV32-NEXT:    vfirst.m a0, v10
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: ctz_nxv3i32_poison:
+; RV64:       # %bb.0:
+; RV64-NEXT:    vsetvli a0, zero, e32, m2, ta, ma
+; RV64-NEXT:    vmsne.vi v10, v8, 0
+; RV64-NEXT:    vfirst.m a0, v10
+; RV64-NEXT:    ret
+  %res = call i32 @llvm.experimental.cttz.elts(<vscale x 3 x i32> %a, i1 1)
   ret i32 %res
 }
 


### PR DESCRIPTION
We only need to pad the widened lanes with ones to handle the case for an all zeroes input. But for cttz_elts_zero_poison, this is already poison.

The RISC-V scalable vector test can't be precomitted because it crashes otherwise trying to lower a get_active_lane_mask from getMaskFromElementCount.

Also while we're here, switch to using TLI.getTypeToTransformTo to be consistent with other `WidenVecOp_*` implementations.