### PR TITLE
[GlobalISel] Exclude scalar to ptr unmerges from unmerge_dead_to_trunc combiner

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -2469,8 +2469,8 @@ bool CombinerHelper::matchCombineUnmergeWithDeadLanesToTrunc(
     MachineInstr &MI) const {
   assert(MI.getOpcode() == TargetOpcode::G_UNMERGE_VALUES &&
          "Expected an unmerge");
-  if (MRI.getType(MI.getOperand(0).getReg()).isVector() ||
-      MRI.getType(MI.getOperand(MI.getNumDefs()).getReg()).isVector())
+  if (!MRI.getType(MI.getOperand(0).getReg()).isScalar() ||
+      !MRI.getType(MI.getOperand(MI.getNumDefs()).getReg()).isScalar())
     return false;
   // Check that all the lanes are dead except the first one.
   for (unsigned Idx = 1, EndIdx = MI.getNumDefs(); Idx != EndIdx; ++Idx) {

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-unmerge.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-unmerge.mir
@@ -340,6 +340,32 @@ body:             |
     $h0 = COPY %1(s16)
 ...
 
+---
+name:            test_combine_unmerge_dead_to_trunc_ptr_out
+body:             |
+  bb.1:
+    ; CHECK-LABEL: name: test_combine_unmerge_dead_to_trunc_ptr_out
+    ; CHECK: [[COPY:%[0-9]+]]:_(i128) = COPY $q0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(p0), [[UV1:%[0-9]+]]:_(p0) = G_UNMERGE_VALUES [[COPY]](i128)
+    ; CHECK-NEXT: $x0 = COPY [[UV]](p0)
+    %0:_(i128) = COPY $q0
+    %1:_(p0), %2:_(p0) = G_UNMERGE_VALUES %0(i128)
+    $x0 = COPY %1(p0)
+...
+
+---
+name:            test_combine_unmerge_dead_to_trunc_ptr_in
+body:             |
+  bb.1:
+    ; CHECK-LABEL: name: test_combine_unmerge_dead_to_trunc_ptr_in
+    ; CHECK: [[COPY:%[0-9]+]]:_(p0) = COPY $x0
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(i32), [[UV1:%[0-9]+]]:_(i32) = G_UNMERGE_VALUES [[COPY]](p0)
+    ; CHECK-NEXT: $w0 = COPY [[UV]](i32)
+    %0:_(p0) = COPY $x0
+    %1:_(i32), %2:_(i32) = G_UNMERGE_VALUES %0(p0)
+    $w0 = COPY %1(i32)
+...
+
 # Transform unmerge(zext) into zext.
 # In that test, the source of the zext is same size as the first definition
 # of the unmerge. Therefore a we can just reuse the input of the zext for


### PR DESCRIPTION
This combiner is supposed to replace a G_UNMERGE_VALUES with a truncate if only the first element is used. Vector types are excluded because the combiner will not insert bitcasts before/after the truncate, but the case where either the src/dst type is a scalar and the other type is a pointer is not handled even though this case would also need bitcasts.