### PR TITLE
[SDAG][X86] Support shrinking target-independent nodes

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -4393,7 +4393,8 @@ public:
   /// equal to the demanded part of the vector and less than the original
   /// vector size. Return 0 to disable shrinking.
   virtual unsigned
-  getPreferredShrunkVectorSize(SDValue Op, const APInt &DemandedElts) const {
+  getPreferredShrunkVectorSizeInBits(SDValue Op,
+                                     const APInt &DemandedElts) const {
     return 0;
   }
 

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -4385,6 +4385,18 @@ public:
     return true;
   }
 
+  /// If only low elements of a vector are demanded, shrink the operation to the
+  /// returned size in bits by converting
+  /// (op x) to insert_subvector (op (extract_subvector x)).
+  ///
+  /// The returned size must be a multiple of the element size, greater than or
+  /// equal to the demanded part of the vector and less than the original
+  /// vector size. Return 0 to disable shrinking.
+  virtual unsigned
+  getPreferredShrunkVectorSize(SDValue Op, const APInt &DemandedElts) const {
+    return 0;
+  }
+
   /// Determine which of the bits specified in Mask are known to be either zero
   /// or one and return them in the KnownZero/KnownOne bitsets. The DemandedElts
   /// argument allows us to only collect the known bits that are shared by the

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -3826,7 +3826,8 @@ bool TargetLowering::SimplifyDemandedVectorElts(
       if (SimplifyDemandedVectorEltsBinOp(Op0, Op1))
         return true;
 
-    if (unsigned ShrunkSize = getPreferredShrunkVectorSize(Op, DemandedElts)) {
+    if (unsigned ShrunkSize =
+            getPreferredShrunkVectorSizeInBits(Op, DemandedElts)) {
       assert(ShrunkSize % EltSizeInBits == 0 &&
              "Shrunk size not a multiple of element size");
       assert(ShrunkSize < VT.getSizeInBits() &&

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -3285,6 +3285,29 @@ bool TargetLowering::SimplifyDemandedVectorElts(
   unsigned EltSizeInBits = VT.getScalarSizeInBits();
   bool IsLE = TLO.DAG.getDataLayout().isLittleEndian();
 
+  auto TryShrinkBinOp = [&](SDValue Op0, SDValue Op1) {
+    unsigned ShrunkSize = getPreferredShrunkVectorSizeInBits(Op, DemandedElts);
+    if (!ShrunkSize)
+      return false;
+
+    assert(ShrunkSize % EltSizeInBits == 0 &&
+           "Shrunk size not a multiple of element size");
+    assert(ShrunkSize < VT.getSizeInBits() &&
+           "Shrunk size must be < original vector size");
+    assert(ShrunkSize >= EltSizeInBits * DemandedElts.getActiveBits() &&
+           "Shrunk size must be >= demanded size");
+
+    EVT ShrunkVT = VT.changeVectorElementCount(
+        *TLO.DAG.getContext(),
+        ElementCount::getFixed(ShrunkSize / EltSizeInBits));
+    Op0 = TLO.DAG.getExtractSubvector(DL, ShrunkVT, Op0, 0);
+    Op1 = TLO.DAG.getExtractSubvector(DL, ShrunkVT, Op1, 0);
+    SDValue NewOp =
+        TLO.DAG.getNode(Opcode, DL, ShrunkVT, Op0, Op1, Op->getFlags());
+    return TLO.CombineTo(
+        Op, TLO.DAG.getInsertSubvector(DL, TLO.DAG.getUNDEF(VT), NewOp, 0));
+  };
+
   // Helper for demanding the specified elements and all the bits of both binary
   // operands.
   auto SimplifyDemandedVectorEltsBinOp = [&](SDValue Op0, SDValue Op1) {
@@ -3298,6 +3321,10 @@ bool TargetLowering::SimplifyDemandedVectorElts(
                           NewOp1 ? NewOp1 : Op1, Op->getFlags());
       return TLO.CombineTo(Op, NewOp);
     }
+
+    if (TryShrinkBinOp(Op0, Op1))
+      return true;
+
     return false;
   };
 
@@ -3825,28 +3852,6 @@ bool TargetLowering::SimplifyDemandedVectorElts(
     if (!DemandedElts.isAllOnes())
       if (SimplifyDemandedVectorEltsBinOp(Op0, Op1))
         return true;
-
-    if (unsigned ShrunkSize =
-            getPreferredShrunkVectorSizeInBits(Op, DemandedElts)) {
-      assert(ShrunkSize % EltSizeInBits == 0 &&
-             "Shrunk size not a multiple of element size");
-      assert(ShrunkSize < VT.getSizeInBits() &&
-             "Shrunk size must be < original vector size");
-      assert(ShrunkSize >= EltSizeInBits * DemandedElts.getActiveBits() &&
-             "Shrunk size must be >= demanded size");
-
-      SDLoc DL(Op);
-      EVT ShrunkVT = VT.changeVectorElementCount(
-          *TLO.DAG.getContext(),
-          ElementCount::getFixed(ShrunkSize / EltSizeInBits));
-      Op0 = TLO.DAG.getExtractSubvector(DL, ShrunkVT, Op0, 0);
-      Op1 = TLO.DAG.getExtractSubvector(DL, ShrunkVT, Op1, 0);
-      SDValue NewOp =
-          TLO.DAG.getNode(Opcode, DL, ShrunkVT, Op0, Op1, Op->getFlags());
-      return TLO.CombineTo(
-          Op, TLO.DAG.getInsertSubvector(DL, TLO.DAG.getUNDEF(VT), NewOp, 0));
-    }
-
     break;
   }
   case ISD::SHL:

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -3825,6 +3825,27 @@ bool TargetLowering::SimplifyDemandedVectorElts(
     if (!DemandedElts.isAllOnes())
       if (SimplifyDemandedVectorEltsBinOp(Op0, Op1))
         return true;
+
+    if (unsigned ShrunkSize = getPreferredShrunkVectorSize(Op, DemandedElts)) {
+      assert(ShrunkSize % EltSizeInBits == 0 &&
+             "Shrunk size not a multiple of element size");
+      assert(ShrunkSize < VT.getSizeInBits() &&
+             "Shrunk size must be < original vector size");
+      assert(ShrunkSize >= EltSizeInBits * DemandedElts.getActiveBits() &&
+             "Shrunk size must be >= demanded size");
+
+      SDLoc DL(Op);
+      EVT ShrunkVT = VT.changeVectorElementCount(
+          *TLO.DAG.getContext(),
+          ElementCount::getFixed(ShrunkSize / EltSizeInBits));
+      Op0 = TLO.DAG.getExtractSubvector(DL, ShrunkVT, Op0, 0);
+      Op1 = TLO.DAG.getExtractSubvector(DL, ShrunkVT, Op1, 0);
+      SDValue NewOp =
+          TLO.DAG.getNode(Opcode, DL, ShrunkVT, Op0, Op1, Op->getFlags());
+      return TLO.CombineTo(
+          Op, TLO.DAG.getInsertSubvector(DL, TLO.DAG.getUNDEF(VT), NewOp, 0));
+    }
+
     break;
   }
   case ISD::SHL:

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -45102,6 +45102,32 @@ bool X86TargetLowering::SimplifyDemandedVectorEltsForTargetNode(
   return false;
 }
 
+unsigned X86TargetLowering::getPreferredShrunkVectorSize(
+    SDValue Op, const APInt &DemandedElts) const {
+  EVT VT = Op.getValueType();
+  unsigned SizeInBits = VT.getSizeInBits();
+  unsigned NumElts = VT.getVectorNumElements();
+
+  switch (Op.getOpcode()) {
+  case ISD::FSUB:
+  case ISD::FMUL:
+    break;
+  default:
+    return 0;
+  }
+
+  // For 256/512-bit ops that are 128/256-bit ops glued together, if we do not
+  // demand any of the high elements, then narrow the op to 128/256-bits: e.g.
+  // (op ymm0, ymm1) --> insert undef, (op xmm0, xmm1), 0
+  if (SizeInBits == 512 && DemandedElts.lshr(NumElts / 4) == 0)
+    return SizeInBits / 4;
+  if ((SizeInBits == 256 || SizeInBits == 512) &&
+      DemandedElts.lshr(NumElts / 2) == 0)
+    return SizeInBits / 2;
+
+  return 0;
+}
+
 bool X86TargetLowering::SimplifyDemandedBitsForTargetNode(
     SDValue Op, const APInt &OriginalDemandedBits,
     const APInt &OriginalDemandedElts, KnownBits &Known, TargetLoweringOpt &TLO,

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -45102,7 +45102,7 @@ bool X86TargetLowering::SimplifyDemandedVectorEltsForTargetNode(
   return false;
 }
 
-unsigned X86TargetLowering::getPreferredShrunkVectorSize(
+unsigned X86TargetLowering::getPreferredShrunkVectorSizeInBits(
     SDValue Op, const APInt &DemandedElts) const {
   EVT VT = Op.getValueType();
   unsigned SizeInBits = VT.getSizeInBits();

--- a/llvm/lib/Target/X86/X86ISelLowering.h
+++ b/llvm/lib/Target/X86/X86ISelLowering.h
@@ -354,9 +354,8 @@ namespace llvm {
                                                     TargetLoweringOpt &TLO,
                                                     unsigned Depth) const;
 
-    unsigned
-    getPreferredShrunkVectorSize(SDValue Op,
-                                 const APInt &DemandedElts) const override;
+    unsigned getPreferredShrunkVectorSizeInBits(
+        SDValue Op, const APInt &DemandedElts) const override;
 
     bool SimplifyDemandedBitsForTargetNode(SDValue Op,
                                            const APInt &DemandedBits,

--- a/llvm/lib/Target/X86/X86ISelLowering.h
+++ b/llvm/lib/Target/X86/X86ISelLowering.h
@@ -354,6 +354,10 @@ namespace llvm {
                                                     TargetLoweringOpt &TLO,
                                                     unsigned Depth) const;
 
+    unsigned
+    getPreferredShrunkVectorSize(SDValue Op,
+                                 const APInt &DemandedElts) const override;
+
     bool SimplifyDemandedBitsForTargetNode(SDValue Op,
                                            const APInt &DemandedBits,
                                            const APInt &DemandedElts,

--- a/llvm/test/CodeGen/X86/avx512-intrinsics-fast-isel.ll
+++ b/llvm/test/CodeGen/X86/avx512-intrinsics-fast-isel.ll
@@ -7150,7 +7150,7 @@ define double @test_mm512_reduce_mul_pd(<8 x double> %__W) nounwind {
 ; X86-NEXT:    andl $-8, %esp
 ; X86-NEXT:    subl $8, %esp
 ; X86-NEXT:    vextractf64x4 $1, %zmm0, %ymm1
-; X86-NEXT:    vmulpd %zmm1, %zmm0, %zmm0
+; X86-NEXT:    vmulpd %ymm1, %ymm0, %ymm0
 ; X86-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X86-NEXT:    vmulpd %xmm1, %xmm0, %xmm0
 ; X86-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -7165,7 +7165,7 @@ define double @test_mm512_reduce_mul_pd(<8 x double> %__W) nounwind {
 ; X64-LABEL: test_mm512_reduce_mul_pd:
 ; X64:       # %bb.0: # %entry
 ; X64-NEXT:    vextractf64x4 $1, %zmm0, %ymm1
-; X64-NEXT:    vmulpd %zmm1, %zmm0, %zmm0
+; X64-NEXT:    vmulpd %ymm1, %ymm0, %ymm0
 ; X64-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-NEXT:    vmulpd %xmm1, %xmm0, %xmm0
 ; X64-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -7221,7 +7221,7 @@ define float @test_mm512_reduce_mul_ps(<16 x float> %__W) nounwind {
 ; X86:       # %bb.0: # %entry
 ; X86-NEXT:    pushl %eax
 ; X86-NEXT:    vextractf64x4 $1, %zmm0, %ymm1
-; X86-NEXT:    vmulps %zmm1, %zmm0, %zmm0
+; X86-NEXT:    vmulps %ymm1, %ymm0, %ymm0
 ; X86-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X86-NEXT:    vmulps %xmm1, %xmm0, %xmm0
 ; X86-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -7237,7 +7237,7 @@ define float @test_mm512_reduce_mul_ps(<16 x float> %__W) nounwind {
 ; X64-LABEL: test_mm512_reduce_mul_ps:
 ; X64:       # %bb.0: # %entry
 ; X64-NEXT:    vextractf64x4 $1, %zmm0, %ymm1
-; X64-NEXT:    vmulps %zmm1, %zmm0, %zmm0
+; X64-NEXT:    vmulps %ymm1, %ymm0, %ymm0
 ; X64-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-NEXT:    vmulps %xmm1, %xmm0, %xmm0
 ; X64-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -7309,7 +7309,7 @@ define double @test_mm512_mask_reduce_mul_pd(i8 zeroext %__M, <8 x double> %__W)
 ; X86-NEXT:    vbroadcastsd {{.*#+}} zmm1 = [1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0]
 ; X86-NEXT:    vmovapd %zmm0, %zmm1 {%k1}
 ; X86-NEXT:    vextractf64x4 $1, %zmm1, %ymm0
-; X86-NEXT:    vmulpd %zmm0, %zmm1, %zmm0
+; X86-NEXT:    vmulpd %ymm0, %ymm1, %ymm0
 ; X86-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X86-NEXT:    vmulpd %xmm1, %xmm0, %xmm0
 ; X86-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -7327,7 +7327,7 @@ define double @test_mm512_mask_reduce_mul_pd(i8 zeroext %__M, <8 x double> %__W)
 ; X64-NEXT:    vbroadcastsd {{.*#+}} zmm1 = [1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0]
 ; X64-NEXT:    vmovapd %zmm0, %zmm1 {%k1}
 ; X64-NEXT:    vextractf64x4 $1, %zmm1, %ymm0
-; X64-NEXT:    vmulpd %zmm0, %zmm1, %zmm0
+; X64-NEXT:    vmulpd %ymm0, %ymm1, %ymm0
 ; X64-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-NEXT:    vmulpd %xmm1, %xmm0, %xmm0
 ; X64-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -7396,7 +7396,7 @@ define float @test_mm512_mask_reduce_mul_ps(i16 zeroext %__M, <16 x float> %__W)
 ; X86-NEXT:    vbroadcastss {{.*#+}} zmm1 = [1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0]
 ; X86-NEXT:    vmovaps %zmm0, %zmm1 {%k1}
 ; X86-NEXT:    vextractf64x4 $1, %zmm1, %ymm0
-; X86-NEXT:    vmulps %zmm0, %zmm1, %zmm0
+; X86-NEXT:    vmulps %ymm0, %ymm1, %ymm0
 ; X86-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X86-NEXT:    vmulps %xmm1, %xmm0, %xmm0
 ; X86-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -7415,7 +7415,7 @@ define float @test_mm512_mask_reduce_mul_ps(i16 zeroext %__M, <16 x float> %__W)
 ; X64-NEXT:    vbroadcastss {{.*#+}} zmm1 = [1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0]
 ; X64-NEXT:    vmovaps %zmm0, %zmm1 {%k1}
 ; X64-NEXT:    vextractf64x4 $1, %zmm1, %ymm0
-; X64-NEXT:    vmulps %zmm0, %zmm1, %zmm0
+; X64-NEXT:    vmulps %ymm0, %ymm1, %ymm0
 ; X64-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-NEXT:    vmulps %xmm1, %xmm0, %xmm0
 ; X64-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]

--- a/llvm/test/CodeGen/X86/avx512fp16-combine-shuffle-fma.ll
+++ b/llvm/test/CodeGen/X86/avx512fp16-combine-shuffle-fma.ll
@@ -33,7 +33,7 @@ define <2 x half> @foo(<2 x half> %0) nounwind {
 ; F16C-NEXT:    vcvtps2ph $4, %ymm1, %xmm1
 ; F16C-NEXT:    vcvtph2ps %xmm0, %ymm0
 ; F16C-NEXT:    vcvtph2ps %xmm1, %ymm1
-; F16C-NEXT:    vsubps %ymm0, %ymm1, %ymm2
+; F16C-NEXT:    vsubps %xmm0, %xmm1, %xmm2
 ; F16C-NEXT:    vcvtps2ph $4, %ymm2, %xmm2
 ; F16C-NEXT:    vaddps %ymm0, %ymm1, %ymm0
 ; F16C-NEXT:    vcvtps2ph $4, %ymm0, %xmm0

--- a/llvm/test/CodeGen/X86/vector-narrow-binop.ll
+++ b/llvm/test/CodeGen/X86/vector-narrow-binop.ll
@@ -160,21 +160,21 @@ define <4 x double> @fmul_v2f64(<2 x  double> %x, <2 x double> %y) {
 ;
 ; AVX1-LABEL: fmul_v2f64:
 ; AVX1:       # %bb.0:
-; AVX1-NEXT:    vunpcklpd {{.*#+}} xmm2 = xmm1[0],xmm0[0]
-; AVX1-NEXT:    vunpckhpd {{.*#+}} xmm0 = xmm0[1],xmm1[1]
+; AVX1-NEXT:    vunpckhpd {{.*#+}} xmm2 = xmm0[1],xmm1[1]
+; AVX1-NEXT:    vunpcklpd {{.*#+}} xmm0 = xmm1[0],xmm0[0]
 ; AVX1-NEXT:    vmulpd %xmm0, %xmm0, %xmm0
 ; AVX1-NEXT:    vmulpd %xmm2, %xmm2, %xmm1
-; AVX1-NEXT:    vaddpd %xmm0, %xmm1, %xmm0
+; AVX1-NEXT:    vaddpd %xmm1, %xmm0, %xmm0
 ; AVX1-NEXT:    vshufpd {{.*#+}} xmm0 = xmm0[1,0]
 ; AVX1-NEXT:    retq
 ;
 ; AVX2-LABEL: fmul_v2f64:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vunpcklpd {{.*#+}} xmm2 = xmm1[0],xmm0[0]
-; AVX2-NEXT:    vunpckhpd {{.*#+}} xmm0 = xmm0[1],xmm1[1]
+; AVX2-NEXT:    vunpckhpd {{.*#+}} xmm2 = xmm0[1],xmm1[1]
+; AVX2-NEXT:    vunpcklpd {{.*#+}} xmm0 = xmm1[0],xmm0[0]
 ; AVX2-NEXT:    vmulpd %xmm0, %xmm0, %xmm0
 ; AVX2-NEXT:    vmulpd %xmm2, %xmm2, %xmm1
-; AVX2-NEXT:    vaddpd %xmm0, %xmm1, %xmm0
+; AVX2-NEXT:    vaddpd %xmm1, %xmm0, %xmm0
 ; AVX2-NEXT:    vshufpd {{.*#+}} xmm0 = xmm0[1,0]
 ; AVX2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/vector-reduce-fmul-fast.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-fmul-fast.ll
@@ -181,7 +181,7 @@ define float @test_v16f32(float %a0, <16 x float> %a1) {
 ; AVX512-LABEL: test_v16f32:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vextractf64x4 $1, %zmm1, %ymm2
-; AVX512-NEXT:    vmulps %zmm2, %zmm1, %zmm1
+; AVX512-NEXT:    vmulps %ymm2, %ymm1, %ymm1
 ; AVX512-NEXT:    vextractf128 $1, %ymm1, %xmm2
 ; AVX512-NEXT:    vmulps %xmm2, %xmm1, %xmm1
 ; AVX512-NEXT:    vshufpd {{.*#+}} xmm2 = xmm1[1,0]
@@ -355,7 +355,7 @@ define float @test_v16f32_zero(<16 x float> %a0) {
 ; AVX512-LABEL: test_v16f32_zero:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vextractf64x4 $1, %zmm0, %ymm1
-; AVX512-NEXT:    vmulps %zmm1, %zmm0, %zmm0
+; AVX512-NEXT:    vmulps %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; AVX512-NEXT:    vmulps %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -528,7 +528,7 @@ define float @test_v16f32_undef(<16 x float> %a0) {
 ; AVX512-LABEL: test_v16f32_undef:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vextractf64x4 $1, %zmm0, %ymm1
-; AVX512-NEXT:    vmulps %zmm1, %zmm0, %zmm0
+; AVX512-NEXT:    vmulps %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; AVX512-NEXT:    vmulps %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -630,7 +630,7 @@ define double @test_v8f64(double %a0, <8 x double> %a1) {
 ; AVX512-LABEL: test_v8f64:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vextractf64x4 $1, %zmm1, %ymm2
-; AVX512-NEXT:    vmulpd %zmm2, %zmm1, %zmm1
+; AVX512-NEXT:    vmulpd %ymm2, %ymm1, %ymm1
 ; AVX512-NEXT:    vextractf128 $1, %ymm1, %xmm2
 ; AVX512-NEXT:    vmulpd %xmm2, %xmm1, %xmm1
 ; AVX512-NEXT:    vshufpd {{.*#+}} xmm2 = xmm1[1,0]
@@ -675,7 +675,7 @@ define double @test_v16f64(double %a0, <16 x double> %a1) {
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vmulpd %zmm2, %zmm1, %zmm1
 ; AVX512-NEXT:    vextractf64x4 $1, %zmm1, %ymm2
-; AVX512-NEXT:    vmulpd %zmm2, %zmm1, %zmm1
+; AVX512-NEXT:    vmulpd %ymm2, %ymm1, %ymm1
 ; AVX512-NEXT:    vextractf128 $1, %ymm1, %xmm2
 ; AVX512-NEXT:    vmulpd %xmm2, %xmm1, %xmm1
 ; AVX512-NEXT:    vshufpd {{.*#+}} xmm2 = xmm1[1,0]
@@ -768,7 +768,7 @@ define double @test_v8f64_zero(<8 x double> %a0) {
 ; AVX512-LABEL: test_v8f64_zero:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vextractf64x4 $1, %zmm0, %ymm1
-; AVX512-NEXT:    vmulpd %zmm1, %zmm0, %zmm0
+; AVX512-NEXT:    vmulpd %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; AVX512-NEXT:    vmulpd %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -810,7 +810,7 @@ define double @test_v16f64_zero(<16 x double> %a0) {
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vmulpd %zmm1, %zmm0, %zmm0
 ; AVX512-NEXT:    vextractf64x4 $1, %zmm0, %ymm1
-; AVX512-NEXT:    vmulpd %zmm1, %zmm0, %zmm0
+; AVX512-NEXT:    vmulpd %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; AVX512-NEXT:    vmulpd %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -902,7 +902,7 @@ define double @test_v8f64_undef(<8 x double> %a0) {
 ; AVX512-LABEL: test_v8f64_undef:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vextractf64x4 $1, %zmm0, %ymm1
-; AVX512-NEXT:    vmulpd %zmm1, %zmm0, %zmm0
+; AVX512-NEXT:    vmulpd %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; AVX512-NEXT:    vmulpd %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]
@@ -944,7 +944,7 @@ define double @test_v16f64_undef(<16 x double> %a0) {
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vmulpd %zmm1, %zmm0, %zmm0
 ; AVX512-NEXT:    vextractf64x4 $1, %zmm0, %ymm1
-; AVX512-NEXT:    vmulpd %zmm1, %zmm0, %zmm0
+; AVX512-NEXT:    vmulpd %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; AVX512-NEXT:    vmulpd %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vshufpd {{.*#+}} xmm1 = xmm0[1,0]


### PR DESCRIPTION
X86 generally tries to shrink operations to work on smaller vector sizes if possible. This happens in
SimplifyDemandedVectorEltsForTargetNode() for target-specific opcodes, but it's currently not possible to do this for generic opcodes.

This introduces a getPreferredShrunkVectorSize() TLI hook to allow shrinking generic ops based on demanded elements.

The primary motivation for this is to avoid regressions due to https://github.com/llvm/llvm-project/pull/188489, which uplifts a previously x86-specific node to become target-independent.

This PR enables the shrinking for fsub and fmul as examples. Unfortunately, for many other ops we get various regressions, mostly because horizontal operations are no longer formed.