### PR TITLE
[ProfCheck] Exclude FixIrreducible Test

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -57,6 +57,7 @@ Transforms/FixIrreducible/basic.ll
 Transforms/FixIrreducible/bug45623.ll
 Transforms/FixIrreducible/callbr.ll
 Transforms/FixIrreducible/nested.ll
+Transforms/FixIrreducible/pr191979.ll
 Transforms/FixIrreducible/switch.ll
 Transforms/GVN/PRE/pre-load-through-select.ll
 Transforms/GVN/PRE/pre-loop-load-through-select.ll


### PR DESCRIPTION
From #206057. We have not gotten to fixing FixIrreducible yet, so exclude the test for now.