### PR TITLE
[Dexter] Avoid incorrect state matching against frames below main

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -971,6 +971,10 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
         for stackframe in stackframes:
             # Some frames are marked "deemphasize" to indicate that they are not interesting; these frames can be
             # skipped by Dexter.
+            # NB: This is by no means guaranteed to be set by the debug adapter, so is not a perfectly reliable check;
+            #     however, if it *is* set, it's generally a safe bet that we are not looking at user code and so can
+            #     skip this frame. We may check for more presentationHint values in future if/as we add support for more
+            #     debug adapters.
             if stackframe.get("source", {}).get("presentationHint") == "deemphasize":
                 continue
             # No source, skip the frame! Currently I've only observed this for frames below main, so we break here; if

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -969,12 +969,13 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
         frames = []
 
         for stackframe in stackframes:
+            # Some frames are marked "deemphasize" to indicate that they are not interesting; these frames can be
+            # skipped by Dexter.
+            if stackframe.get("source", {}).get("presentationHint") == "deemphasize":
+                continue
             # No source, skip the frame! Currently I've only observed this for frames below main, so we break here; if
             # it happens elsewhere, then this will break more stuff and we'll come up with a better solution.
-            if (
-                stackframe.get("source") is None
-                or stackframe["source"].get("path") is None
-            ):
+            if stackframe.get("source", {}).get("path") is None:
                 break
 
             loc_dict = {

--- a/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/StateMatch.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/StateMatch.py
@@ -9,7 +9,7 @@ hitcounts) to descriptions of expected state in a DexterScript."""
 
 from dataclasses import dataclass, field
 import os
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from dex.dextIR import FrameIR, StepIR
 from dex.test_script import DexterScript, Scope
@@ -29,9 +29,13 @@ def match_where_to_frame(
     where: Where,
     frame: FrameIR,
     labels: FileLabels,
+    default_path: Optional[str] = None,
 ) -> bool:
     """A very simple matcher, returns True iff `where` matches `frame`."""
-    if where.file is not None and not is_subpath(where.file, frame.loc.path):
+    file = where.file
+    if not file and where.lines and not where.function:
+        file = default_path
+    if file is not None and not is_subpath(file, frame.loc.path):
         return False
     if where.function is not None:
         fn = frame.function
@@ -100,7 +104,7 @@ def get_active_where_matches(
         matching_frame_idx = None
         for frame_idx, frame in reversed(list(enumerate(step_info.frames))):
             labels = script.get_labels(expected_file or frame.loc.path)
-            if match_where_to_frame(where, frame, labels):
+            if match_where_to_frame(where, frame, labels, script.root_scope.file):
                 matching_frame_idx = frame_idx
                 break
 


### PR DESCRIPTION
This patch fixes an error that caused some Dexter test failures, driven by two separate causes. The first issue is that frames below main were appearing in the program stacktrace; while Dexter tries to filter frames below main during the stacktrace collection step based on a pre-written list, this list may not be comprehensive enough, as the symbol "___lldb_unnamed_symbol_2a150" has also appeared. In order to guard against this and future cases that might appear, this patch adds a check to Dexter for "presentationHint: deemphasize" in the DAP response; this is added by LLDB (and other dap-based debuggers) as a hint that the frame is not user source, and should be a generally useful way of avoiding evaluating frames that are not wanted.

The second issue is a mismatch between the breakpoint-setting logic and the state-matching logic: the former allows root !where nodes to omit the "file" field, using the script file as a default file. The state matching logic does not perform any checking for an omitted file. Together, this means that we may correctly set breakpoints for e.g. "test.cpp:10", but when we go to match against frames, the !where node may match against some other line-10 that appears below (e.g. as a caller of) the frame at test.cpp:10. This patch copies the default_file logic to state matching, meaning that we will only match against the intended frame.