### PR TITLE
[Dexter] Require lldb-dap for Dexter and log when Dexter is disabled

### DIFF
--- a/cross-project-tests/CMakeLists.txt
+++ b/cross-project-tests/CMakeLists.txt
@@ -61,7 +61,7 @@ if("compiler-rt" IN_LIST LLVM_ENABLE_PROJECTS)
 endif()
 # Many dexter tests depend on lldb.
 if("lldb" IN_LIST LLVM_ENABLE_PROJECTS)
-  list(APPEND CROSS_PROJECT_TEST_DEPS lldb lldb-server)
+  list(APPEND CROSS_PROJECT_TEST_DEPS lldb lldb-server lldb-dap)
 endif()
 
 if ("lld" IN_LIST LLVM_ENABLE_PROJECTS)

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -282,6 +282,11 @@ else:
     dependencies = configure_dexter_substitutions()
     if all(d in config.available_features for d in dependencies):
         config.available_features.add("dexter")
+    else:
+        print(
+            "Skipping Dexter tests due to missing required projects: "
+            + ", ".join(d for d in dependencies if d not in config.available_features)
+        )
 
 tool_dirs = [config.llvm_tools_dir]
 


### PR DESCRIPTION
For some time, Dexter tests have been run using lldb-dap when it is available rather than just lldb/lldb-server. However, the cross project test dependencies have not been updated since then, meaning that lldb-dap is not automatically built by check-cross-project. The Dexter-specific lit config then skips the Dexter tests if lldb-dap is unavailable, which leads to some check-cross-project builds never running the Dexter tests. This patch adds lldb-dap to the build dependencies, and also adds a small log message to inform when the Dexter tests are skipped; most cases where we skip the Dexter test were already logged, and this addition expands that to cover all cases.