### PR TITLE
[PGO] Fix malformed raw profile test

### DIFF
--- a/llvm/test/tools/llvm-profdata/malformed-not-space-for-another-header.test
+++ b/llvm/test/tools/llvm-profdata/malformed-not-space-for-another-header.test
@@ -57,7 +57,6 @@ RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\1\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw
-RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw
 
 RUN: printf '\023\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\3\0foo\0\0\0' >> %t.profraw


### PR DESCRIPTION
A hand-written raw profile test still wrote one extra word in the data
record after the raw profile format changed.

Remove the extra word so the name section starts at the offset expected
by the reader. This keeps the test focused on the trailing garbage that
should report that there is not enough space for another header.

Buildbot failure: https://github.com/llvm/llvm-project/pull/190708#issuecomment-4839831651

