### PR TITLE
[MC][TableGen] Make MCRegisterClasses relocation-free

### DIFF
--- a/bolt/lib/Core/MCPlusBuilder.cpp
+++ b/bolt/lib/Core/MCPlusBuilder.cpp
@@ -603,7 +603,7 @@ void MCPlusBuilder::initAliases() {
 void MCPlusBuilder::initSizeMap() {
   SizeMap.resize(RegInfo->getNumRegs());
   // Build size map
-  for (auto RC : RegInfo->regclasses())
+  for (const auto &RC : RegInfo->regclasses())
     for (MCPhysReg Reg : RC)
       SizeMap[Reg] = RC.getSizeInBits() / 8;
 }

--- a/llvm/include/llvm/MC/MCRegisterInfo.h
+++ b/llvm/include/llvm/MC/MCRegisterInfo.h
@@ -39,8 +39,8 @@ public:
   using iterator = const MCPhysReg*;
   using const_iterator = const MCPhysReg*;
 
-  const iterator RegsBegin;
-  const uint8_t *const RegSet;
+  const uint32_t RegsOff;   ///< Relative offset to MCPhysReg array.
+  const uint32_t RegSetOff; ///< Relative offset to uint8_t array.
   const uint32_t NameIdx;
   const uint32_t RegSizeInBits;
   const uint16_t RegsSize;
@@ -56,8 +56,11 @@ public:
 
   /// begin/end - Return all of the registers in this class.
   ///
-  iterator       begin() const { return RegsBegin; }
-  iterator         end() const { return RegsBegin + RegsSize; }
+  iterator begin() const {
+    return reinterpret_cast<iterator>(reinterpret_cast<const char *>(this) +
+                                      RegsOff);
+  }
+  iterator end() const { return begin() + RegsSize; }
 
   /// getNumRegs - Return the number of registers in this class.
   ///
@@ -67,7 +70,7 @@ public:
   ///
   MCRegister getRegister(unsigned i) const {
     assert(i < getNumRegs() && "Register number out of range!");
-    return RegsBegin[i];
+    return begin()[i];
   }
 
   /// contains - Return true if the specified register is included in this
@@ -78,6 +81,7 @@ public:
     unsigned Byte = RegNo / 8;
     if (Byte >= RegSetSize)
       return false;
+    const uint8_t *RegSet = reinterpret_cast<const uint8_t *>(this) + RegSetOff;
     return (RegSet[Byte] & (1 << InByte)) != 0;
   }
 
@@ -103,6 +107,13 @@ public:
 
   /// Return true if this register class has a defined BaseClassOrder.
   bool isBaseClass() const { return BaseClass; }
+};
+
+template <unsigned RegClassCount, unsigned RegCount, unsigned BitSetSize>
+struct MCRegisterClassStorage {
+  MCRegisterClass Classes[RegClassCount];
+  MCPhysReg Regs[RegCount];
+  uint8_t BitSets[BitSetSize];
 };
 
 /// MCRegisterDesc - This record contains information about a particular

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -1286,16 +1286,16 @@ public:
 
   bool isNeonVectorRegLo() const {
     return Kind == k_Register && Reg.Kind == RegKind::NeonVector &&
-           (AArch64MCRegisterClasses[AArch64::FPR128_loRegClassID].contains(
-                Reg.Reg) ||
-            AArch64MCRegisterClasses[AArch64::FPR64_loRegClassID].contains(
-                Reg.Reg));
+           (getAArch64MCRegisterClass(AArch64::FPR128_loRegClassID)
+                .contains(Reg.Reg) ||
+            getAArch64MCRegisterClass(AArch64::FPR64_loRegClassID)
+                .contains(Reg.Reg));
   }
 
   bool isNeonVectorReg0to7() const {
     return Kind == k_Register && Reg.Kind == RegKind::NeonVector &&
-           (AArch64MCRegisterClasses[AArch64::FPR128_0to7RegClassID].contains(
-               Reg.Reg));
+           (getAArch64MCRegisterClass(AArch64::FPR128_0to7RegClassID)
+                .contains(Reg.Reg));
   }
 
   bool isMatrix() const { return Kind == k_MatrixRegister; }
@@ -1317,7 +1317,7 @@ public:
     }
 
     return (Kind == k_Register && Reg.Kind == RK) &&
-           AArch64MCRegisterClasses[Class].contains(getReg());
+           getAArch64MCRegisterClass(Class).contains(getReg());
   }
 
   template <unsigned Class> bool isSVEVectorReg() const {
@@ -1344,12 +1344,12 @@ public:
     }
 
     return (Kind == k_Register && Reg.Kind == RK) &&
-           AArch64MCRegisterClasses[Class].contains(getReg());
+           getAArch64MCRegisterClass(Class).contains(getReg());
   }
 
   template <unsigned Class> bool isFPRasZPR() const {
     return Kind == k_Register && Reg.Kind == RegKind::Scalar &&
-           AArch64MCRegisterClasses[Class].contains(getReg());
+           getAArch64MCRegisterClass(Class).contains(getReg());
   }
 
   template <int ElementWidth, unsigned Class>
@@ -1424,30 +1424,32 @@ public:
 
   bool isGPR32as64() const {
     return Kind == k_Register && Reg.Kind == RegKind::Scalar &&
-           AArch64MCRegisterClasses[AArch64::GPR64RegClassID].contains(Reg.Reg);
+           getAArch64MCRegisterClass(AArch64::GPR64RegClassID)
+               .contains(Reg.Reg);
   }
 
   bool isGPR64as32() const {
     return Kind == k_Register && Reg.Kind == RegKind::Scalar &&
-           AArch64MCRegisterClasses[AArch64::GPR32RegClassID].contains(Reg.Reg);
+           getAArch64MCRegisterClass(AArch64::GPR32RegClassID)
+               .contains(Reg.Reg);
   }
 
   bool isGPR64x8() const {
     return Kind == k_Register && Reg.Kind == RegKind::Scalar &&
-           AArch64MCRegisterClasses[AArch64::GPR64x8ClassRegClassID].contains(
-               Reg.Reg);
+           getAArch64MCRegisterClass(AArch64::GPR64x8ClassRegClassID)
+               .contains(Reg.Reg);
   }
 
   bool isWSeqPair() const {
     return Kind == k_Register && Reg.Kind == RegKind::Scalar &&
-           AArch64MCRegisterClasses[AArch64::WSeqPairsClassRegClassID].contains(
-               Reg.Reg);
+           getAArch64MCRegisterClass(AArch64::WSeqPairsClassRegClassID)
+               .contains(Reg.Reg);
   }
 
   bool isXSeqPair() const {
     return Kind == k_Register && Reg.Kind == RegKind::Scalar &&
-           AArch64MCRegisterClasses[AArch64::XSeqPairsClassRegClassID].contains(
-               Reg.Reg);
+           getAArch64MCRegisterClass(AArch64::XSeqPairsClassRegClassID)
+               .contains(Reg.Reg);
   }
 
   bool isSyspXzrPair() const {
@@ -1471,7 +1473,7 @@ public:
 
   template <unsigned RegClassID> bool isGPR64() const {
     return Kind == k_Register && Reg.Kind == RegKind::Scalar &&
-           AArch64MCRegisterClasses[RegClassID].contains(getReg());
+           getAArch64MCRegisterClass(RegClassID).contains(getReg());
   }
 
   template <unsigned RegClassID, int ExtWidth>
@@ -1518,7 +1520,7 @@ public:
         isTypedVectorList<VectorKind, NumRegs, NumElements, ElementWidth>();
     if (!Res)
       return DiagnosticPredicate::NoMatch;
-    if (!AArch64MCRegisterClasses[RegClass].contains(VectorList.Reg))
+    if (!getAArch64MCRegisterClass(RegClass).contains(VectorList.Reg))
       return DiagnosticPredicate::NearMatch;
     return DiagnosticPredicate::Match;
   }
@@ -1784,7 +1786,7 @@ public:
     if (!isMatrix())
       return DiagnosticPredicate::NoMatch;
     if (getMatrixKind() != Kind ||
-        !AArch64MCRegisterClasses[RegClass].contains(getMatrixReg()) ||
+        !getAArch64MCRegisterClass(RegClass).contains(getMatrixReg()) ||
         EltSize != getMatrixElementWidth())
       return DiagnosticPredicate::NearMatch;
     return DiagnosticPredicate::Match;
@@ -1828,7 +1830,7 @@ public:
   void addGPR32as64Operands(MCInst &Inst, unsigned N) const {
     assert(N == 1 && "Invalid number of operands!");
     assert(
-        AArch64MCRegisterClasses[AArch64::GPR64RegClassID].contains(getReg()));
+        getAArch64MCRegisterClass(AArch64::GPR64RegClassID).contains(getReg()));
 
     const MCRegisterInfo *RI = Ctx.getRegisterInfo();
     MCRegister Reg = RI->getRegClass(AArch64::GPR32RegClassID)
@@ -1840,7 +1842,7 @@ public:
   void addGPR64as32Operands(MCInst &Inst, unsigned N) const {
     assert(N == 1 && "Invalid number of operands!");
     assert(
-        AArch64MCRegisterClasses[AArch64::GPR32RegClassID].contains(getReg()));
+        getAArch64MCRegisterClass(AArch64::GPR32RegClassID).contains(getReg()));
 
     const MCRegisterInfo *RI = Ctx.getRegisterInfo();
     MCRegister Reg = RI->getRegClass(AArch64::GPR64RegClassID)
@@ -1881,15 +1883,15 @@ public:
 
   void addVectorReg64Operands(MCInst &Inst, unsigned N) const {
     assert(N == 1 && "Invalid number of operands!");
-    assert(
-        AArch64MCRegisterClasses[AArch64::FPR128RegClassID].contains(getReg()));
+    assert(getAArch64MCRegisterClass(AArch64::FPR128RegClassID)
+               .contains(getReg()));
     Inst.addOperand(MCOperand::createReg(AArch64::D0 + getReg() - AArch64::Q0));
   }
 
   void addVectorReg128Operands(MCInst &Inst, unsigned N) const {
     assert(N == 1 && "Invalid number of operands!");
-    assert(
-        AArch64MCRegisterClasses[AArch64::FPR128RegClassID].contains(getReg()));
+    assert(getAArch64MCRegisterClass(AArch64::FPR128RegClassID)
+               .contains(getReg()));
     Inst.addOperand(MCOperand::createReg(getReg()));
   }
 
@@ -5340,9 +5342,8 @@ bool AArch64AsmParser::parseOperand(OperandVector &Operands, bool isCondCode,
         !static_cast<AArch64Operand &>(*Operands[1]).isScalarReg())
       return Error(Loc, "Only valid when first operand is register");
 
-    bool IsXReg =
-        AArch64MCRegisterClasses[AArch64::GPR64allRegClassID].contains(
-            Operands[1]->getReg());
+    bool IsXReg = getAArch64MCRegisterClass(AArch64::GPR64allRegClassID)
+                      .contains(Operands[1]->getReg());
 
     MCContext& Ctx = getContext();
     E = SMLoc::getFromPointer(Loc.getPointer() - 1);
@@ -5680,7 +5681,7 @@ bool AArch64AsmParser::validateInstruction(MCInst &Inst, SMLoc &IDLoc,
                      " source");
     }
 
-    auto PPRRegClass = AArch64MCRegisterClasses[AArch64::PPRRegClassID];
+    const auto &PPRRegClass = getAArch64MCRegisterClass(AArch64::PPRRegClassID);
     if (Prefix.isPredicated()) {
       int PgIdx = -1;
 
@@ -6679,8 +6680,8 @@ bool AArch64AsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
         uint64_t Op3Val = Op3CE->getValue();
         uint64_t NewOp3Val = 0;
         uint64_t NewOp4Val = 0;
-        if (AArch64MCRegisterClasses[AArch64::GPR32allRegClassID].contains(
-                Op2.getReg())) {
+        if (getAArch64MCRegisterClass(AArch64::GPR32allRegClassID)
+                .contains(Op2.getReg())) {
           NewOp3Val = (32 - Op3Val) & 0x1f;
           NewOp4Val = 31 - Op3Val;
         } else {
@@ -6714,8 +6715,8 @@ bool AArch64AsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
         uint64_t Width = WidthCE->getValue();
 
         uint64_t RegWidth = 0;
-        if (AArch64MCRegisterClasses[AArch64::GPR64allRegClassID].contains(
-                Op1.getReg()))
+        if (getAArch64MCRegisterClass(AArch64::GPR64allRegClassID)
+                .contains(Op1.getReg()))
           RegWidth = 64;
         else
           RegWidth = 32;
@@ -6770,8 +6771,8 @@ bool AArch64AsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
           uint64_t Op4Val = Op4CE->getValue();
 
           uint64_t RegWidth = 0;
-          if (AArch64MCRegisterClasses[AArch64::GPR64allRegClassID].contains(
-                  Op1.getReg()))
+          if (getAArch64MCRegisterClass(AArch64::GPR64allRegClassID)
+                  .contains(Op1.getReg()))
             RegWidth = 64;
           else
             RegWidth = 32;
@@ -6834,8 +6835,8 @@ bool AArch64AsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
           uint64_t Op4Val = Op4CE->getValue();
 
           uint64_t RegWidth = 0;
-          if (AArch64MCRegisterClasses[AArch64::GPR64allRegClassID].contains(
-                  Op1.getReg()))
+          if (getAArch64MCRegisterClass(AArch64::GPR64allRegClassID)
+                  .contains(Op1.getReg()))
             RegWidth = 64;
           else
             RegWidth = 32;
@@ -6915,8 +6916,8 @@ bool AArch64AsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
   else if (NumOperands == 3 && (Tok == "sxtb" || Tok == "sxth")) {
     AArch64Operand &Op = static_cast<AArch64Operand &>(*Operands[1]);
     if (Op.isScalarReg() &&
-        AArch64MCRegisterClasses[AArch64::GPR64allRegClassID].contains(
-            Op.getReg())) {
+        getAArch64MCRegisterClass(AArch64::GPR64allRegClassID)
+            .contains(Op.getReg())) {
       // The source register can be Wn here, but the matcher expects a
       // GPR64. Twiddle it here if necessary.
       AArch64Operand &Op = static_cast<AArch64Operand &>(*Operands[2]);
@@ -6932,8 +6933,8 @@ bool AArch64AsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
   else if (NumOperands == 3 && (Tok == "uxtb" || Tok == "uxth")) {
     AArch64Operand &Op = static_cast<AArch64Operand &>(*Operands[1]);
     if (Op.isScalarReg() &&
-        AArch64MCRegisterClasses[AArch64::GPR64allRegClassID].contains(
-            Op.getReg())) {
+        getAArch64MCRegisterClass(AArch64::GPR64allRegClassID)
+            .contains(Op.getReg())) {
       // The source register can be Wn here, but the matcher expects a
       // GPR32. Twiddle it here if necessary.
       AArch64Operand &Op = static_cast<AArch64Operand &>(*Operands[1]);
@@ -8718,9 +8719,9 @@ ParseStatus AArch64AsmParser::tryParseGPRSeqPair(OperandVector &Operands) {
                     "even/odd register pair");
 
   const MCRegisterClass &WRegClass =
-      AArch64MCRegisterClasses[AArch64::GPR32RegClassID];
+      getAArch64MCRegisterClass(AArch64::GPR32RegClassID);
   const MCRegisterClass &XRegClass =
-      AArch64MCRegisterClasses[AArch64::GPR64RegClassID];
+      getAArch64MCRegisterClass(AArch64::GPR64RegClassID);
 
   bool isXReg = XRegClass.contains(FirstReg),
        isWReg = WRegClass.contains(FirstReg);
@@ -8755,11 +8756,13 @@ ParseStatus AArch64AsmParser::tryParseGPRSeqPair(OperandVector &Operands) {
 
   MCRegister Pair;
   if (isXReg) {
-    Pair = RI->getMatchingSuperReg(FirstReg, AArch64::sube64,
-           &AArch64MCRegisterClasses[AArch64::XSeqPairsClassRegClassID]);
+    Pair = RI->getMatchingSuperReg(
+        FirstReg, AArch64::sube64,
+        &getAArch64MCRegisterClass(AArch64::XSeqPairsClassRegClassID));
   } else {
-    Pair = RI->getMatchingSuperReg(FirstReg, AArch64::sube32,
-           &AArch64MCRegisterClasses[AArch64::WSeqPairsClassRegClassID]);
+    Pair = RI->getMatchingSuperReg(
+        FirstReg, AArch64::sube32,
+        &getAArch64MCRegisterClass(AArch64::WSeqPairsClassRegClassID));
   }
 
   Operands.push_back(AArch64Operand::CreateReg(Pair, RegKind::Scalar, S,
@@ -8895,7 +8898,7 @@ ParseStatus AArch64AsmParser::tryParseGPR64x8(OperandVector &Operands) {
   const MCRegisterInfo *RI = ctx.getRegisterInfo();
   MCRegister X8Reg = RI->getMatchingSuperReg(
       XReg, AArch64::x8sub_0,
-      &AArch64MCRegisterClasses[AArch64::GPR64x8ClassRegClassID]);
+      &getAArch64MCRegisterClass(AArch64::GPR64x8ClassRegClassID));
   if (!X8Reg)
     return Error(SS,
                  "expected an even-numbered x-register in the range [x0,x22]");

--- a/llvm/lib/Target/AArch64/Disassembler/AArch64Disassembler.cpp
+++ b/llvm/lib/Target/AArch64/Disassembler/AArch64Disassembler.cpp
@@ -54,7 +54,7 @@ static DecodeStatus DecodeSimpleRegisterClass(MCInst &Inst, unsigned RegNo,
     return Fail;
 
   MCRegister Register =
-      AArch64MCRegisterClasses[RegClassID].getRegister(RegNo + FirstReg);
+      getAArch64MCRegisterClass(RegClassID).getRegister(RegNo + FirstReg);
   Inst.addOperand(MCOperand::createReg(Register));
   return Success;
 }
@@ -68,8 +68,8 @@ DecodeGPR64x8ClassRegisterClass(MCInst &Inst, unsigned RegNo, uint64_t Address,
     return Fail;
 
   MCRegister Register =
-      AArch64MCRegisterClasses[AArch64::GPR64x8ClassRegClassID].getRegister(
-          RegNo >> 1);
+      getAArch64MCRegisterClass(AArch64::GPR64x8ClassRegClassID)
+          .getRegister(RegNo >> 1);
   Inst.addOperand(MCOperand::createReg(Register));
   return Success;
 }
@@ -82,7 +82,7 @@ static DecodeStatus DecodeZPRMul2_MinMax(MCInst &Inst, unsigned RegNo,
   if (Reg < Min || Reg > Max || (Reg & 1))
     return Fail;
   MCRegister Register =
-      AArch64MCRegisterClasses[AArch64::ZPRRegClassID].getRegister(Reg);
+      getAArch64MCRegisterClass(AArch64::ZPRRegClassID).getRegister(Reg);
   Inst.addOperand(MCOperand::createReg(Register));
   return Success;
 }
@@ -96,7 +96,7 @@ static DecodeStatus DecodeZPR2Mul2RegisterClass(MCInst &Inst, unsigned RegNo,
     return Fail;
 
   MCRegister Register =
-      AArch64MCRegisterClasses[AArch64::ZPR2RegClassID].getRegister(Reg);
+      getAArch64MCRegisterClass(AArch64::ZPR2RegClassID).getRegister(Reg);
   Inst.addOperand(MCOperand::createReg(Register));
   return Success;
 }
@@ -107,7 +107,7 @@ static DecodeStatus DecodeZK(MCInst &Inst, unsigned RegNo, uint64_t Address,
     return Fail;
 
   MCRegister Register =
-      AArch64MCRegisterClasses[AArch64::ZPR_KRegClassID].getRegister(RegNo);
+      getAArch64MCRegisterClass(AArch64::ZPR_KRegClassID).getRegister(RegNo);
   Inst.addOperand(MCOperand::createReg(Register));
   return Success;
 }
@@ -118,7 +118,7 @@ static DecodeStatus DecodeZPR4Mul4RegisterClass(MCInst &Inst, unsigned RegNo,
   if (RegNo * 4 > 28)
     return Fail;
   MCRegister Register =
-      AArch64MCRegisterClasses[AArch64::ZPR4RegClassID].getRegister(RegNo * 4);
+      getAArch64MCRegisterClass(AArch64::ZPR4RegClassID).getRegister(RegNo * 4);
   Inst.addOperand(MCOperand::createReg(Register));
   return Success;
 }
@@ -155,7 +155,7 @@ static DecodeStatus DecodeMPR16RegisterClass(MCInst &Inst, unsigned RegNo,
                                              uint64_t Address,
                                              const MCDisassembler *Decoder) {
   MCRegister Reg =
-      AArch64MCRegisterClasses[AArch64::MPR16RegClassID].getRegister(RegNo);
+      getAArch64MCRegisterClass(AArch64::MPR16RegClassID).getRegister(RegNo);
   Inst.addOperand(MCOperand::createReg(Reg));
   return Success;
 }
@@ -164,7 +164,7 @@ static DecodeStatus DecodeMPR32RegisterClass(MCInst &Inst, unsigned RegNo,
                                              uint64_t Address,
                                              const MCDisassembler *Decoder) {
   MCRegister Reg =
-      AArch64MCRegisterClasses[AArch64::MPR32RegClassID].getRegister(RegNo);
+      getAArch64MCRegisterClass(AArch64::MPR32RegClassID).getRegister(RegNo);
   Inst.addOperand(MCOperand::createReg(Reg));
   return Success;
 }
@@ -173,7 +173,7 @@ static DecodeStatus DecodeMPR64RegisterClass(MCInst &Inst, unsigned RegNo,
                                              uint64_t Address,
                                              const MCDisassembler *Decoder) {
   MCRegister Reg =
-      AArch64MCRegisterClasses[AArch64::MPR64RegClassID].getRegister(RegNo);
+      getAArch64MCRegisterClass(AArch64::MPR64RegClassID).getRegister(RegNo);
   Inst.addOperand(MCOperand::createReg(Reg));
   return Success;
 }
@@ -182,7 +182,7 @@ static DecodeStatus DecodeMPR128RegisterClass(MCInst &Inst, unsigned RegNo,
                                               uint64_t Address,
                                               const MCDisassembler *Decoder) {
   MCRegister Reg =
-      AArch64MCRegisterClasses[AArch64::MPR128RegClassID].getRegister(RegNo);
+      getAArch64MCRegisterClass(AArch64::MPR128RegClassID).getRegister(RegNo);
   Inst.addOperand(MCOperand::createReg(Reg));
   return Success;
 }
@@ -193,7 +193,7 @@ static DecodeStatus DecodePPR2Mul2RegisterClass(MCInst &Inst, unsigned RegNo,
   if ((RegNo * 2) > 14)
     return Fail;
   MCRegister Register =
-      AArch64MCRegisterClasses[AArch64::PPR2RegClassID].getRegister(RegNo * 2);
+      getAArch64MCRegisterClass(AArch64::PPR2RegClassID).getRegister(RegNo * 2);
   Inst.addOperand(MCOperand::createReg(Register));
   return Success;
 }
@@ -1368,7 +1368,7 @@ DecodeGPRSeqPairsClassRegisterClass(MCInst &Inst, unsigned RegClassID,
   if (RegNo & 0x1)
     return Fail;
 
-  MCRegister Reg = AArch64MCRegisterClasses[RegClassID].getRegister(RegNo / 2);
+  MCRegister Reg = getAArch64MCRegisterClass(RegClassID).getRegister(RegNo / 2);
   Inst.addOperand(MCOperand::createReg(Reg));
   return Success;
 }

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
@@ -306,25 +306,25 @@ void AArch64_MC::initLLVMToCVRegMapping(MCRegisterInfo *MRI) {
 }
 
 bool AArch64_MC::isHForm(const MCInst &MI, const MCInstrInfo *MCII) {
-  const auto &FPR16 = AArch64MCRegisterClasses[AArch64::FPR16RegClassID];
+  const auto &FPR16 = getAArch64MCRegisterClass(AArch64::FPR16RegClassID);
   return llvm::any_of(MI, [&](const MCOperand &Op) {
     return Op.isReg() && FPR16.contains(Op.getReg());
   });
 }
 
 bool AArch64_MC::isQForm(const MCInst &MI, const MCInstrInfo *MCII) {
-  const auto &FPR128 = AArch64MCRegisterClasses[AArch64::FPR128RegClassID];
+  const auto &FPR128 = getAArch64MCRegisterClass(AArch64::FPR128RegClassID);
   return llvm::any_of(MI, [&](const MCOperand &Op) {
     return Op.isReg() && FPR128.contains(Op.getReg());
   });
 }
 
 bool AArch64_MC::isFpOrNEON(const MCInst &MI, const MCInstrInfo *MCII) {
-  const auto &FPR128 = AArch64MCRegisterClasses[AArch64::FPR128RegClassID];
-  const auto &FPR64 = AArch64MCRegisterClasses[AArch64::FPR64RegClassID];
-  const auto &FPR32 = AArch64MCRegisterClasses[AArch64::FPR32RegClassID];
-  const auto &FPR16 = AArch64MCRegisterClasses[AArch64::FPR16RegClassID];
-  const auto &FPR8 = AArch64MCRegisterClasses[AArch64::FPR8RegClassID];
+  const auto &FPR128 = getAArch64MCRegisterClass(AArch64::FPR128RegClassID);
+  const auto &FPR64 = getAArch64MCRegisterClass(AArch64::FPR64RegClassID);
+  const auto &FPR32 = getAArch64MCRegisterClass(AArch64::FPR32RegClassID);
+  const auto &FPR16 = getAArch64MCRegisterClass(AArch64::FPR16RegClassID);
+  const auto &FPR8 = getAArch64MCRegisterClass(AArch64::FPR8RegClassID);
 
   auto IsFPR = [&](const MCOperand &Op) {
     if (!Op.isReg())
@@ -434,7 +434,7 @@ public:
     const MCRegisterClass &FPR128RC =
         MRI.getRegClass(AArch64::FPR128RegClassID);
 
-    auto ClearsSuperReg = [=](MCRegister Reg) {
+    auto ClearsSuperReg = [&](MCRegister Reg) {
       // An update to the lower 32 bits of a 64 bit integer register is
       // architecturally defined to zero extend the upper 32 bits on a write.
       if (GPR32RC.contains(Reg))

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -2997,7 +2997,7 @@ MCRegister AMDGPUAsmParser::getRegularReg(RegisterKind RegKind, unsigned RegNum,
   }
 
   const MCRegisterInfo *TRI = getContext().getRegisterInfo();
-  const MCRegisterClass RC = TRI->getRegClass(RCID);
+  const MCRegisterClass &RC = TRI->getRegClass(RCID);
   if (RegIdx >= RC.getNumRegs() || (RegKind == IS_VGPR && RegIdx > 255)) {
     Error(Loc, "register index is out of range");
     return AMDGPU::NoRegister;

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -1552,8 +1552,8 @@ void AMDGPUDisassembler::convertFMAanyK(MCInst &MI) const {
 }
 
 const char* AMDGPUDisassembler::getRegClassName(unsigned RegClassID) const {
-  return getContext().getRegisterInfo()->
-    getRegClassName(&AMDGPUMCRegisterClasses[RegClassID]);
+  return getContext().getRegisterInfo()->getRegClassName(
+      &getAMDGPUMCRegisterClass(RegClassID));
 }
 
 inline
@@ -1573,7 +1573,7 @@ inline MCOperand AMDGPUDisassembler::createRegOperand(MCRegister Reg) const {
 inline
 MCOperand AMDGPUDisassembler::createRegOperand(unsigned RegClassID,
                                                unsigned Val) const {
-  const auto& RegCl = AMDGPUMCRegisterClasses[RegClassID];
+  const auto &RegCl = getAMDGPUMCRegisterClass(RegClassID);
   if (Val >= RegCl.getNumRegs())
     return errOperand(Val, Twine(getRegClassName(RegClassID)) +
                            ": unknown register " + Twine(Val));

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -2706,7 +2706,8 @@ int32_t getTotalNumVGPRs(bool has90AInsts, int32_t ArgNumAGPR,
 }
 
 bool isSGPR(MCRegister Reg, const MCRegisterInfo *TRI) {
-  const MCRegisterClass SGPRClass = TRI->getRegClass(AMDGPU::SReg_32RegClassID);
+  const MCRegisterClass &SGPRClass =
+      TRI->getRegClass(AMDGPU::SReg_32RegClassID);
   const MCRegister FirstSubReg = TRI->getSubReg(Reg, AMDGPU::sub0);
   return SGPRClass.contains(FirstSubReg != 0 ? FirstSubReg : Reg) ||
          Reg == AMDGPU::SCC;

--- a/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
+++ b/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
@@ -1376,11 +1376,11 @@ public:
   }
   bool isDReg() const {
     return isReg() &&
-           ARMMCRegisterClasses[ARM::DPRRegClassID].contains(Reg.RegNum);
+           getARMMCRegisterClass(ARM::DPRRegClassID).contains(Reg.RegNum);
   }
   bool isQReg() const {
     return isReg() &&
-           ARMMCRegisterClasses[ARM::QPRRegClassID].contains(Reg.RegNum);
+           getARMMCRegisterClass(ARM::QPRRegClassID).contains(Reg.RegNum);
   }
   bool isDPRRegList() const { return Kind == k_DPRRegisterList; }
   bool isSPRRegList() const { return Kind == k_SPRRegisterList; }
@@ -1397,12 +1397,12 @@ public:
     if (Kind != k_Memory)
       return false;
     if (Memory.BaseRegNum &&
-        !ARMMCRegisterClasses[ARM::GPRRegClassID].contains(Memory.BaseRegNum) &&
-        !ARMMCRegisterClasses[ARM::MQPRRegClassID].contains(Memory.BaseRegNum))
+        !getARMMCRegisterClass(ARM::GPRRegClassID)
+             .contains(Memory.BaseRegNum) &&
+        !getARMMCRegisterClass(ARM::MQPRRegClassID).contains(Memory.BaseRegNum))
       return false;
-    if (Memory.OffsetRegNum &&
-        !ARMMCRegisterClasses[ARM::MQPRRegClassID].contains(
-            Memory.OffsetRegNum))
+    if (Memory.OffsetRegNum && !getARMMCRegisterClass(ARM::MQPRRegClassID)
+                                    .contains(Memory.OffsetRegNum))
       return false;
     return true;
   }
@@ -1410,25 +1410,25 @@ public:
     if (Kind != k_Memory)
       return false;
     if (Memory.BaseRegNum &&
-        !ARMMCRegisterClasses[ARM::GPRRegClassID].contains(Memory.BaseRegNum))
+        !getARMMCRegisterClass(ARM::GPRRegClassID).contains(Memory.BaseRegNum))
       return false;
-    if (Memory.OffsetRegNum &&
-        !ARMMCRegisterClasses[ARM::GPRRegClassID].contains(Memory.OffsetRegNum))
+    if (Memory.OffsetRegNum && !getARMMCRegisterClass(ARM::GPRRegClassID)
+                                    .contains(Memory.OffsetRegNum))
       return false;
     return true;
   }
   bool isShifterImm() const { return Kind == k_ShifterImmediate; }
   bool isRegShiftedReg() const {
     return Kind == k_ShiftedRegister &&
-           ARMMCRegisterClasses[ARM::GPRRegClassID].contains(
-               RegShiftedReg.SrcReg) &&
-           ARMMCRegisterClasses[ARM::GPRRegClassID].contains(
-               RegShiftedReg.ShiftReg);
+           getARMMCRegisterClass(ARM::GPRRegClassID)
+               .contains(RegShiftedReg.SrcReg) &&
+           getARMMCRegisterClass(ARM::GPRRegClassID)
+               .contains(RegShiftedReg.ShiftReg);
   }
   bool isRegShiftedImm() const {
     return Kind == k_ShiftedImmediate &&
-           ARMMCRegisterClasses[ARM::GPRRegClassID].contains(
-               RegShiftedImm.SrcReg);
+           getARMMCRegisterClass(ARM::GPRRegClassID)
+               .contains(RegShiftedImm.SrcReg);
   }
   bool isRotImm() const { return Kind == k_RotateImmediate; }
 
@@ -1480,7 +1480,8 @@ public:
   bool isBitfield() const { return Kind == k_BitfieldDescriptor; }
   bool isPostIdxRegShifted() const {
     return Kind == k_PostIndexRegister &&
-           ARMMCRegisterClasses[ARM::GPRRegClassID].contains(PostIdxReg.RegNum);
+           getARMMCRegisterClass(ARM::GPRRegClassID)
+               .contains(PostIdxReg.RegNum);
   }
   bool isPostIdxReg() const {
     return isPostIdxRegShifted() && PostIdxReg.ShiftTy == ARM_AM::no_shift;
@@ -1496,8 +1497,8 @@ public:
     if (!isGPRMem())
       return false;
 
-    if (!ARMMCRegisterClasses[ARM::GPRnopcRegClassID].contains(
-            Memory.BaseRegNum))
+    if (!getARMMCRegisterClass(ARM::GPRnopcRegClassID)
+             .contains(Memory.BaseRegNum))
       return false;
 
     // No offset of any kind.
@@ -1508,8 +1509,7 @@ public:
     if (!isGPRMem())
       return false;
 
-    if (!ARMMCRegisterClasses[ARM::rGPRRegClassID].contains(
-            Memory.BaseRegNum))
+    if (!getARMMCRegisterClass(ARM::rGPRRegClassID).contains(Memory.BaseRegNum))
       return false;
 
     // No offset of any kind.
@@ -1520,8 +1520,7 @@ public:
     if (!isGPRMem())
       return false;
 
-    if (!ARMMCRegisterClasses[ARM::tGPRRegClassID].contains(
-            Memory.BaseRegNum))
+    if (!getARMMCRegisterClass(ARM::tGPRRegClassID).contains(Memory.BaseRegNum))
       return false;
 
     // No offset of any kind.
@@ -1837,8 +1836,8 @@ public:
     if (isImm() && !isa<MCConstantExpr>(getImm()))
       return true;
     if (!isGPRMem() || Memory.OffsetRegNum || Memory.Alignment != 0 ||
-        !ARMMCRegisterClasses[ARM::GPRnopcRegClassID].contains(
-            Memory.BaseRegNum))
+        !getARMMCRegisterClass(ARM::GPRnopcRegClassID)
+             .contains(Memory.BaseRegNum))
       return false;
     // Immediate offset a multiple of 4 in range [-508, 508].
     if (!Memory.OffsetImm) return true;
@@ -1880,7 +1879,7 @@ public:
   template<unsigned Bits, unsigned RegClassID>
   bool isMemImm7ShiftedOffset() const {
     if (!isGPRMem() || Memory.OffsetRegNum || Memory.Alignment != 0 ||
-        !ARMMCRegisterClasses[RegClassID].contains(Memory.BaseRegNum))
+        !getARMMCRegisterClass(RegClassID).contains(Memory.BaseRegNum))
       return false;
 
     // Expect an immediate offset equal to an element of the range
@@ -1912,11 +1911,11 @@ public:
     if (!isMVEMem() || Memory.OffsetImm != nullptr || Memory.Alignment != 0)
       return false;
 
-    if (!ARMMCRegisterClasses[ARM::GPRnopcRegClassID].contains(
-            Memory.BaseRegNum))
+    if (!getARMMCRegisterClass(ARM::GPRnopcRegClassID)
+             .contains(Memory.BaseRegNum))
       return false;
-    if (!ARMMCRegisterClasses[ARM::MQPRRegClassID].contains(
-            Memory.OffsetRegNum))
+    if (!getARMMCRegisterClass(ARM::MQPRRegClassID)
+             .contains(Memory.OffsetRegNum))
       return false;
 
     if (shift == 0 && Memory.ShiftType != ARM_AM::no_shift)
@@ -1933,8 +1932,7 @@ public:
     if (!isMVEMem() || Memory.OffsetRegNum || Memory.Alignment != 0)
       return false;
 
-    if (!ARMMCRegisterClasses[ARM::MQPRRegClassID].contains(
-            Memory.BaseRegNum))
+    if (!getARMMCRegisterClass(ARM::MQPRRegClassID).contains(Memory.BaseRegNum))
       return false;
 
     if (!Memory.OffsetImm)
@@ -2072,8 +2070,8 @@ public:
 
   bool isVecListTwoMQ() const {
     return isSingleSpacedVectorList() && VectorList.Count == 2 &&
-           ARMMCRegisterClasses[ARM::MQPRRegClassID].contains(
-               VectorList.RegNum);
+           getARMMCRegisterClass(ARM::MQPRRegClassID)
+               .contains(VectorList.RegNum);
   }
 
   bool isVecListDPair() const {
@@ -2082,8 +2080,8 @@ public:
     if (isQReg() && !Parser->hasMVE())
       return true;
     if (!isSingleSpacedVectorList()) return false;
-    return (ARMMCRegisterClasses[ARM::DPairRegClassID]
-              .contains(VectorList.RegNum));
+    return (getARMMCRegisterClass(ARM::DPairRegClassID)
+                .contains(VectorList.RegNum));
   }
 
   bool isVecListThreeD() const {
@@ -2099,8 +2097,8 @@ public:
   bool isVecListDPairSpaced() const {
     if (Kind != k_VectorList) return false;
     if (isSingleSpacedVectorList()) return false;
-    return (ARMMCRegisterClasses[ARM::DPairSpcRegClassID]
-              .contains(VectorList.RegNum));
+    return (getARMMCRegisterClass(ARM::DPairSpcRegClassID)
+                .contains(VectorList.RegNum));
   }
 
   bool isVecListThreeQ() const {
@@ -2115,8 +2113,8 @@ public:
 
   bool isVecListFourMQ() const {
     return isSingleSpacedVectorList() && VectorList.Count == 4 &&
-           ARMMCRegisterClasses[ARM::MQPRRegClassID].contains(
-               VectorList.RegNum);
+           getARMMCRegisterClass(ARM::MQPRRegClassID)
+               .contains(VectorList.RegNum);
   }
 
   bool isSingleSpacedVectorAllLanes() const {
@@ -2134,8 +2132,8 @@ public:
 
   bool isVecListDPairAllLanes() const {
     if (!isSingleSpacedVectorAllLanes()) return false;
-    return (ARMMCRegisterClasses[ARM::DPairRegClassID]
-              .contains(VectorList.RegNum));
+    return (getARMMCRegisterClass(ARM::DPairRegClassID)
+                .contains(VectorList.RegNum));
   }
 
   bool isVecListDPairSpacedAllLanes() const {
@@ -3401,7 +3399,7 @@ public:
     } else if (isQReg() && !Parser->hasMVE()) {
       MCRegister DPair = Parser->getDRegFromQReg(Reg.RegNum);
       DPair = Parser->getMRI()->getMatchingSuperReg(
-          DPair, ARM::dsub_0, &ARMMCRegisterClasses[ARM::DPairRegClassID]);
+          DPair, ARM::dsub_0, &getARMMCRegisterClass(ARM::DPairRegClassID));
       Inst.addOperand(MCOperand::createReg(DPair));
     } else {
       LLVM_DEBUG(dbgs() << "TYPE: " << Kind << "\n");
@@ -3427,10 +3425,11 @@ public:
     // class, and returning the super-register at the corresponding
     // index in the target class.
 
-    const MCRegisterClass *RC_in = &ARMMCRegisterClasses[ARM::MQPRRegClassID];
+    const MCRegisterClass *RC_in = &getARMMCRegisterClass(ARM::MQPRRegClassID);
     const MCRegisterClass *RC_out =
-        (VectorList.Count == 2) ? &ARMMCRegisterClasses[ARM::MQQPRRegClassID]
-                                : &ARMMCRegisterClasses[ARM::MQQQQPRRegClassID];
+        (VectorList.Count == 2)
+            ? &getARMMCRegisterClass(ARM::MQQPRRegClassID)
+            : &getARMMCRegisterClass(ARM::MQQQQPRRegClassID);
 
     unsigned I, E = RC_out->getNumRegs();
     for (I = 0; I < E; I++)
@@ -3804,14 +3803,14 @@ public:
     assert(Regs.size() > 0 && "RegList contains no registers?");
     KindTy Kind = k_RegisterList;
 
-    if (ARMMCRegisterClasses[ARM::DPRRegClassID].contains(
-            Regs.front().second)) {
+    if (getARMMCRegisterClass(ARM::DPRRegClassID)
+            .contains(Regs.front().second)) {
       if (Regs.back().second == ARM::VPR)
         Kind = k_FPDRegisterListWithVPR;
       else
         Kind = k_DPRRegisterList;
-    } else if (ARMMCRegisterClasses[ARM::SPRRegClassID].contains(
-                   Regs.front().second)) {
+    } else if (getARMMCRegisterClass(ARM::SPRRegClassID)
+                   .contains(Regs.front().second)) {
       if (Regs.back().second == ARM::VPR)
         Kind = k_FPSRegisterListWithVPR;
       else
@@ -4585,7 +4584,7 @@ static MCRegister getNextRegister(MCRegister Reg) {
   // If this is a GPR, we need to do it manually, otherwise we can rely
   // on the sort ordering of the enumeration since the other reg-classes
   // are sane.
-  if (!ARMMCRegisterClasses[ARM::GPRRegClassID].contains(Reg))
+  if (!getARMMCRegisterClass(ARM::GPRRegClassID).contains(Reg))
     return Reg + 1;
   switch (Reg.id()) {
   default: llvm_unreachable("Invalid GPR number!");
@@ -4650,7 +4649,7 @@ bool ARMAsmParser::parseRegisterList(OperandVector &Operands, bool EnforceOrder,
   bool VSCCLRMAdjustEncoding = false;
 
   // Allow Q regs and just interpret them as the two D sub-registers.
-  if (ARMMCRegisterClasses[ARM::QPRRegClassID].contains(Reg)) {
+  if (getARMMCRegisterClass(ARM::QPRRegClassID).contains(Reg)) {
     Reg = getDRegFromQReg(Reg);
     EReg = MRI->getEncodingValue(Reg);
     Registers.emplace_back(EReg, Reg);
@@ -4658,16 +4657,16 @@ bool ARMAsmParser::parseRegisterList(OperandVector &Operands, bool EnforceOrder,
   }
   const MCRegisterClass *RC;
   if (Reg == ARM::RA_AUTH_CODE ||
-      ARMMCRegisterClasses[ARM::GPRRegClassID].contains(Reg))
-    RC = &ARMMCRegisterClasses[ARM::GPRRegClassID];
-  else if (ARMMCRegisterClasses[ARM::DPRRegClassID].contains(Reg))
-    RC = &ARMMCRegisterClasses[ARM::DPRRegClassID];
-  else if (ARMMCRegisterClasses[ARM::SPRRegClassID].contains(Reg))
-    RC = &ARMMCRegisterClasses[ARM::SPRRegClassID];
-  else if (ARMMCRegisterClasses[ARM::GPRwithAPSRnospRegClassID].contains(Reg))
-    RC = &ARMMCRegisterClasses[ARM::GPRwithAPSRnospRegClassID];
+      getARMMCRegisterClass(ARM::GPRRegClassID).contains(Reg))
+    RC = &getARMMCRegisterClass(ARM::GPRRegClassID);
+  else if (getARMMCRegisterClass(ARM::DPRRegClassID).contains(Reg))
+    RC = &getARMMCRegisterClass(ARM::DPRRegClassID);
+  else if (getARMMCRegisterClass(ARM::SPRRegClassID).contains(Reg))
+    RC = &getARMMCRegisterClass(ARM::SPRRegClassID);
+  else if (getARMMCRegisterClass(ARM::GPRwithAPSRnospRegClassID).contains(Reg))
+    RC = &getARMMCRegisterClass(ARM::GPRwithAPSRnospRegClassID);
   else if (Reg == ARM::VPR)
-    RC = &ARMMCRegisterClasses[ARM::FPWithVPRRegClassID];
+    RC = &getARMMCRegisterClass(ARM::FPWithVPRRegClassID);
   else
     return Error(RegLoc, "invalid register in register list");
 
@@ -4691,7 +4690,7 @@ bool ARMAsmParser::parseRegisterList(OperandVector &Operands, bool EnforceOrder,
       if (EndReg == ARM::RA_AUTH_CODE)
         return Error(AfterMinusLoc, "pseudo-register not allowed");
       // Allow Q regs and just interpret them as the two D sub-registers.
-      if (ARMMCRegisterClasses[ARM::QPRRegClassID].contains(EndReg))
+      if (getARMMCRegisterClass(ARM::QPRRegClassID).contains(EndReg))
         EndReg = getDRegFromQReg(EndReg) + 1;
       // If the register is the same as the start reg, there's nothing
       // more to do.
@@ -4730,22 +4729,22 @@ bool ARMAsmParser::parseRegisterList(OperandVector &Operands, bool EnforceOrder,
       return Error(RegLoc, "pseudo-register not allowed");
     // Allow Q regs and just interpret them as the two D sub-registers.
     bool isQReg = false;
-    if (ARMMCRegisterClasses[ARM::QPRRegClassID].contains(Reg)) {
+    if (getARMMCRegisterClass(ARM::QPRRegClassID).contains(Reg)) {
       Reg = getDRegFromQReg(Reg);
       isQReg = true;
     }
     if (Reg != ARM::RA_AUTH_CODE && !RC->contains(Reg) &&
-        RC->getID() == ARMMCRegisterClasses[ARM::GPRRegClassID].getID() &&
-        ARMMCRegisterClasses[ARM::GPRwithAPSRnospRegClassID].contains(Reg)) {
+        RC->getID() == getARMMCRegisterClass(ARM::GPRRegClassID).getID() &&
+        getARMMCRegisterClass(ARM::GPRwithAPSRnospRegClassID).contains(Reg)) {
       // switch the register classes, as GPRwithAPSRnospRegClassID is a partial
       // subset of GPRRegClassId except it contains APSR as well.
-      RC = &ARMMCRegisterClasses[ARM::GPRwithAPSRnospRegClassID];
+      RC = &getARMMCRegisterClass(ARM::GPRwithAPSRnospRegClassID);
     }
     if (Reg == ARM::VPR &&
-        (RC == &ARMMCRegisterClasses[ARM::SPRRegClassID] ||
-         RC == &ARMMCRegisterClasses[ARM::DPRRegClassID] ||
-         RC == &ARMMCRegisterClasses[ARM::FPWithVPRRegClassID])) {
-      RC = &ARMMCRegisterClasses[ARM::FPWithVPRRegClassID];
+        (RC == &getARMMCRegisterClass(ARM::SPRRegClassID) ||
+         RC == &getARMMCRegisterClass(ARM::DPRRegClassID) ||
+         RC == &getARMMCRegisterClass(ARM::FPWithVPRRegClassID))) {
+      RC = &getARMMCRegisterClass(ARM::FPWithVPRRegClassID);
       EReg = MRI->getEncodingValue(Reg);
       if (!insertNoDuplicates(Registers, EReg, Reg)) {
         Warning(RegLoc, "duplicated register (" + RegTok.getString() +
@@ -4757,11 +4756,11 @@ bool ARMAsmParser::parseRegisterList(OperandVector &Operands, bool EnforceOrder,
     // S31 is followed by D16.
     if (IsVSCCLRM && OldReg == ARM::S31 && Reg == ARM::D16) {
       VSCCLRMAdjustEncoding = true;
-      RC = &ARMMCRegisterClasses[ARM::FPWithVPRRegClassID];
+      RC = &getARMMCRegisterClass(ARM::FPWithVPRRegClassID);
     }
     // The register must be in the same register class as the first.
     if ((Reg == ARM::RA_AUTH_CODE &&
-         RC != &ARMMCRegisterClasses[ARM::GPRRegClassID]) ||
+         RC != &getARMMCRegisterClass(ARM::GPRRegClassID)) ||
         (Reg != ARM::RA_AUTH_CODE && !RC->contains(Reg)))
       return Error(RegLoc, "invalid register in register list");
     // In most cases, the list must be monotonically increasing. An
@@ -4772,14 +4771,15 @@ bool ARMAsmParser::parseRegisterList(OperandVector &Operands, bool EnforceOrder,
     if (VSCCLRMAdjustEncoding)
       EReg += 16;
     if (EnforceOrder && EReg < EOldReg) {
-      if (ARMMCRegisterClasses[ARM::GPRRegClassID].contains(Reg))
+      if (getARMMCRegisterClass(ARM::GPRRegClassID).contains(Reg))
         Warning(RegLoc, "register list not in ascending order");
-      else if (!ARMMCRegisterClasses[ARM::GPRwithAPSRnospRegClassID].contains(Reg))
+      else if (!getARMMCRegisterClass(ARM::GPRwithAPSRnospRegClassID)
+                    .contains(Reg))
         return Error(RegLoc, "register list not in ascending order");
     }
     // VFP register lists must also be contiguous.
-    if (RC != &ARMMCRegisterClasses[ARM::GPRRegClassID] &&
-        RC != &ARMMCRegisterClasses[ARM::GPRwithAPSRnospRegClassID] &&
+    if (RC != &getARMMCRegisterClass(ARM::GPRRegClassID) &&
+        RC != &getARMMCRegisterClass(ARM::GPRwithAPSRnospRegClassID) &&
         EReg != EOldReg + 1)
       return Error(RegLoc, "non-contiguous register range");
 
@@ -4872,7 +4872,7 @@ ParseStatus ARMAsmParser::parseVectorList(OperandVector &Operands) {
     MCRegister Reg = tryParseRegister();
     if (!Reg)
       return ParseStatus::NoMatch;
-    if (ARMMCRegisterClasses[ARM::DPRRegClassID].contains(Reg)) {
+    if (getARMMCRegisterClass(ARM::DPRRegClassID).contains(Reg)) {
       ParseStatus Res = parseVectorLane(LaneKind, LaneIndex, E);
       if (!Res.isSuccess())
         return Res;
@@ -4891,7 +4891,7 @@ ParseStatus ARMAsmParser::parseVectorList(OperandVector &Operands) {
       }
       return ParseStatus::Success;
     }
-    if (ARMMCRegisterClasses[ARM::QPRRegClassID].contains(Reg)) {
+    if (getARMMCRegisterClass(ARM::QPRRegClassID).contains(Reg)) {
       Reg = getDRegFromQReg(Reg);
       ParseStatus Res = parseVectorLane(LaneKind, LaneIndex, E);
       if (!Res.isSuccess())
@@ -4901,8 +4901,8 @@ ParseStatus ARMAsmParser::parseVectorList(OperandVector &Operands) {
         Operands.push_back(ARMOperand::CreateReg(Reg, S, E, *this));
         break;
       case AllLanes:
-        Reg = MRI->getMatchingSuperReg(Reg, ARM::dsub_0,
-                                   &ARMMCRegisterClasses[ARM::DPairRegClassID]);
+        Reg = MRI->getMatchingSuperReg(
+            Reg, ARM::dsub_0, &getARMMCRegisterClass(ARM::DPairRegClassID));
         Operands.push_back(
             ARMOperand::CreateVectorListAllLanes(Reg, 2, false, S, E, *this));
         break;
@@ -4930,12 +4930,13 @@ ParseStatus ARMAsmParser::parseVectorList(OperandVector &Operands) {
   int Spacing = 0;
   MCRegister FirstReg = Reg;
 
-  if (hasMVE() && !ARMMCRegisterClasses[ARM::MQPRRegClassID].contains(Reg))
+  if (hasMVE() && !getARMMCRegisterClass(ARM::MQPRRegClassID).contains(Reg))
     return Error(Parser.getTok().getLoc(),
                  "vector register in range Q0-Q7 expected");
   // The list is of D registers, but we also allow Q regs and just interpret
   // them as the two D sub-registers.
-  else if (!hasMVE() && ARMMCRegisterClasses[ARM::QPRRegClassID].contains(Reg)) {
+  else if (!hasMVE() &&
+           getARMMCRegisterClass(ARM::QPRRegClassID).contains(Reg)) {
     FirstReg = Reg = getDRegFromQReg(Reg);
     Spacing = 1; // double-spacing requires explicit D registers, otherwise
                  // it's ambiguous with four-register single spaced.
@@ -4961,7 +4962,8 @@ ParseStatus ARMAsmParser::parseVectorList(OperandVector &Operands) {
       if (!EndReg)
         return Error(AfterMinusLoc, "register expected");
       // Allow Q regs and just interpret them as the two D sub-registers.
-      if (!hasMVE() && ARMMCRegisterClasses[ARM::QPRRegClassID].contains(EndReg))
+      if (!hasMVE() &&
+          getARMMCRegisterClass(ARM::QPRRegClassID).contains(EndReg))
         EndReg = getDRegFromQReg(EndReg) + 1;
       // If the register is the same as the start reg, there's nothing
       // more to do.
@@ -4969,9 +4971,9 @@ ParseStatus ARMAsmParser::parseVectorList(OperandVector &Operands) {
         continue;
       // The register must be in the same register class as the first.
       if ((hasMVE() &&
-           !ARMMCRegisterClasses[ARM::MQPRRegClassID].contains(EndReg)) ||
+           !getARMMCRegisterClass(ARM::MQPRRegClassID).contains(EndReg)) ||
           (!hasMVE() &&
-           !ARMMCRegisterClasses[ARM::DPRRegClassID].contains(EndReg)))
+           !getARMMCRegisterClass(ARM::DPRRegClassID).contains(EndReg)))
         return Error(AfterMinusLoc, "invalid register in register list");
       // Ranges must go from low to high.
       if (Reg > EndReg)
@@ -4997,7 +4999,7 @@ ParseStatus ARMAsmParser::parseVectorList(OperandVector &Operands) {
       return Error(RegLoc, "register expected");
 
     if (hasMVE()) {
-      if (!ARMMCRegisterClasses[ARM::MQPRRegClassID].contains(Reg))
+      if (!getARMMCRegisterClass(ARM::MQPRRegClassID).contains(Reg))
         return Error(RegLoc, "vector register in range Q0-Q7 expected");
       Spacing = 1;
     }
@@ -5007,7 +5009,7 @@ ParseStatus ARMAsmParser::parseVectorList(OperandVector &Operands) {
     //
     // The list is of D registers, but we also allow Q regs and just interpret
     // them as the two D sub-registers.
-    else if (ARMMCRegisterClasses[ARM::QPRRegClassID].contains(Reg)) {
+    else if (getARMMCRegisterClass(ARM::QPRRegClassID).contains(Reg)) {
       if (!Spacing)
         Spacing = 1; // Register range implies a single spaced list.
       else if (Spacing == 2)
@@ -5060,9 +5062,9 @@ ParseStatus ARMAsmParser::parseVectorList(OperandVector &Operands) {
     // Two-register operands have been converted to the
     // composite register classes.
     if (Count == 2 && !hasMVE()) {
-      const MCRegisterClass *RC = (Spacing == 1) ?
-        &ARMMCRegisterClasses[ARM::DPairRegClassID] :
-        &ARMMCRegisterClasses[ARM::DPairSpcRegClassID];
+      const MCRegisterClass *RC =
+          (Spacing == 1) ? &getARMMCRegisterClass(ARM::DPairRegClassID)
+                         : &getARMMCRegisterClass(ARM::DPairSpcRegClassID);
       FirstReg = MRI->getMatchingSuperReg(FirstReg, ARM::dsub_0, RC);
     }
     auto Create = (LaneKind == NoLanes ? ARMOperand::CreateVectorList :
@@ -6908,11 +6910,10 @@ bool ARMAsmParser::shouldOmitVectorPredicateOperand(
         Mnemonic.starts_with("vmovx"))) {
     for (auto &Operand : Operands) {
       if (static_cast<ARMOperand &>(*Operand).isVectorIndex() ||
-          ((*Operand).isReg() &&
-           (ARMMCRegisterClasses[ARM::SPRRegClassID].contains(
-             (*Operand).getReg()) ||
-            ARMMCRegisterClasses[ARM::DPRRegClassID].contains(
-              (*Operand).getReg())))) {
+          ((*Operand).isReg() && (getARMMCRegisterClass(ARM::SPRRegClassID)
+                                      .contains((*Operand).getReg()) ||
+                                  getARMMCRegisterClass(ARM::DPRRegClassID)
+                                      .contains((*Operand).getReg())))) {
         return true;
       }
     }
@@ -8376,8 +8377,8 @@ bool ARMAsmParser::validateInstruction(MCInst &Inst,
   case ARM::t2CLRM: {
     for (unsigned i = 2; i < Inst.getNumOperands(); i++) {
       if (Inst.getOperand(i).isReg() &&
-          !ARMMCRegisterClasses[ARM::GPRwithAPSRnospRegClassID].contains(
-              Inst.getOperand(i).getReg())) {
+          !getARMMCRegisterClass(ARM::GPRwithAPSRnospRegClassID)
+               .contains(Inst.getOperand(i).getReg())) {
         return Error(Operands[MnemonicOpsEndInd]->getStartLoc(),
                      "invalid register in register list. Valid registers are "
                      "r0-r12, lr/r14 and APSR.");

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -1223,9 +1223,9 @@ uint64_t ARMAsmBackendDarwin::generateCompactUnwindEncoding(
       break;
     case MCCFIInstruction::OpOffset: // DW_CFA_offset
       Reg = *MRI.getLLVMRegNum(Inst.getRegister(), true);
-      if (ARMMCRegisterClasses[ARM::GPRRegClassID].contains(Reg))
+      if (getARMMCRegisterClass(ARM::GPRRegClassID).contains(Reg))
         RegOffsets[Reg] = Inst.getOffset();
-      else if (ARMMCRegisterClasses[ARM::DPRRegClassID].contains(Reg)) {
+      else if (getARMMCRegisterClass(ARM::DPRRegClassID).contains(Reg)) {
         RegOffsets[Reg] = Inst.getOffset();
         ++FloatRegCount;
       } else {

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCCodeEmitter.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCCodeEmitter.cpp
@@ -1781,8 +1781,8 @@ getRegisterListOpValue(const MCInst &MI, unsigned Op,
   // LDM/STM:
   //   {15-0}  = Bitfield of GPRs.
   MCRegister Reg = MI.getOperand(Op).getReg();
-  bool SPRRegs = ARMMCRegisterClasses[ARM::SPRRegClassID].contains(Reg);
-  bool DPRRegs = ARMMCRegisterClasses[ARM::DPRRegClassID].contains(Reg);
+  bool SPRRegs = getARMMCRegisterClass(ARM::SPRRegClassID).contains(Reg);
+  bool DPRRegs = getARMMCRegisterClass(ARM::DPRRegClassID).contains(Reg);
 
   unsigned Binary = 0;
 
@@ -1802,9 +1802,9 @@ getRegisterListOpValue(const MCInst &MI, unsigned Op,
       NumRegs = 0;
       for (unsigned I = Op, E = MI.getNumOperands(); I < E; ++I) {
         Reg = MI.getOperand(I).getReg();
-        if (ARMMCRegisterClasses[ARM::SPRRegClassID].contains(Reg))
+        if (getARMMCRegisterClass(ARM::SPRRegClassID).contains(Reg))
           NumRegs += 1;
-        else if (ARMMCRegisterClasses[ARM::DPRRegClassID].contains(Reg))
+        else if (getARMMCRegisterClass(ARM::DPRRegClassID).contains(Reg))
           NumRegs += 2;
       }
     }

--- a/llvm/lib/Target/AVR/AsmParser/AVRAsmParser.cpp
+++ b/llvm/lib/Target/AVR/AsmParser/AVRAsmParser.cpp
@@ -78,7 +78,7 @@ class AVRAsmParser : public MCTargetAsmParser {
                                       unsigned Kind) override;
 
   MCRegister toDREG(MCRegister Reg, unsigned From = AVR::sub_lo) {
-    MCRegisterClass const *Class = &AVRMCRegisterClasses[AVR::DREGSRegClassID];
+    MCRegisterClass const *Class = &getAVRMCRegisterClass(AVR::DREGSRegClassID);
     return MRI->getMatchingSuperReg(Reg, From, Class);
   }
 

--- a/llvm/lib/Target/BPF/BPFMIChecking.cpp
+++ b/llvm/lib/Target/BPF/BPFMIChecking.cpp
@@ -101,7 +101,7 @@ void BPFMIPreEmitChecking::initialize(MachineFunction &MFParm) {
 // Dead correctly, and it is safe to use such information or our purpose.
 static bool hasLiveDefs(const MachineInstr &MI, const TargetRegisterInfo *TRI) {
   const MCRegisterClass *GPR64RegClass =
-      &BPFMCRegisterClasses[BPF::GPRRegClassID];
+      &getBPFMCRegisterClass(BPF::GPRRegClassID);
   std::vector<unsigned> GPR32LiveDefs;
   std::vector<unsigned> GPR64DeadDefs;
 

--- a/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
+++ b/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
@@ -869,7 +869,7 @@ bool HexagonAsmParser::ParseDirectiveComm(bool IsLocal, SMLoc Loc) {
 
 // validate register against architecture
 bool HexagonAsmParser::RegisterMatchesArch(MCRegister MatchNum) const {
-  if (HexagonMCRegisterClasses[Hexagon::V62RegsRegClassID].contains(MatchNum))
+  if (getHexagonMCRegisterClass(Hexagon::V62RegsRegClassID).contains(MatchNum))
     if (!getSTI().hasFeature(Hexagon::ArchV62))
       return false;
   return true;

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
@@ -724,7 +724,8 @@ unsigned Hexagon_MC::GetELFFlags(const MCSubtargetInfo &STI) {
 }
 
 llvm::ArrayRef<MCPhysReg> Hexagon_MC::GetVectRegRev() {
-  return ArrayRef(VectRegRev);
+  const auto &RC = getHexagonMCRegisterClass(Hexagon::VectRegRevRegClassID);
+  return ArrayRef(RC.begin(), RC.end());
 }
 
 namespace {

--- a/llvm/lib/Target/LoongArch/AsmParser/LoongArchAsmParser.cpp
+++ b/llvm/lib/Target/LoongArch/AsmParser/LoongArchAsmParser.cpp
@@ -240,8 +240,8 @@ public:
   void setReg(MCRegister PhysReg) { Reg.RegNum = PhysReg; }
   bool isGPR() const {
     return Kind == KindTy::Register &&
-           LoongArchMCRegisterClasses[LoongArch::GPRRegClassID].contains(
-               Reg.RegNum);
+           getLoongArchMCRegisterClass(LoongArch::GPRRegClassID)
+               .contains(Reg.RegNum);
   }
 
   static bool evaluateConstantImm(const MCExpr *Expr, int64_t &Imm,
@@ -683,8 +683,8 @@ bool LoongArchAsmParser::parseRegister(MCRegister &Reg, SMLoc &StartLoc,
   if (!tryParseRegister(Reg, StartLoc, EndLoc).isSuccess())
     return Error(getLoc(), "invalid register name");
 
-  if (!LoongArchMCRegisterClasses[LoongArch::GPRRegClassID].contains(Reg) &&
-      !LoongArchMCRegisterClasses[LoongArch::FPR32RegClassID].contains(Reg))
+  if (!getLoongArchMCRegisterClass(LoongArch::GPRRegClassID).contains(Reg) &&
+      !getLoongArchMCRegisterClass(LoongArch::FPR32RegClassID).contains(Reg))
     return Error(getLoc(), "invalid register name");
 
   return false;
@@ -1757,7 +1757,7 @@ LoongArchAsmParser::validateTargetOperandClass(MCParsedAsmOperand &AsmOp,
   MCRegister Reg = Op.getReg();
   // As the parser couldn't differentiate an FPR32 from an FPR64, coerce the
   // register from FPR32 to FPR64 if necessary.
-  if (LoongArchMCRegisterClasses[LoongArch::FPR32RegClassID].contains(Reg) &&
+  if (getLoongArchMCRegisterClass(LoongArch::FPR32RegClassID).contains(Reg) &&
       Kind == MCK_FPR64) {
     Op.setReg(convertFPR32ToFPR64(Reg));
     return Match_Success;

--- a/llvm/lib/Target/MSP430/AsmParser/MSP430AsmParser.cpp
+++ b/llvm/lib/Target/MSP430/AsmParser/MSP430AsmParser.cpp
@@ -576,8 +576,7 @@ unsigned MSP430AsmParser::validateTargetOperandClass(MCParsedAsmOperand &AsmOp,
     return Match_InvalidOperand;
 
   MCRegister Reg = Op.getReg();
-  bool isGR16 =
-      MSP430MCRegisterClasses[MSP430::GR16RegClassID].contains(Reg);
+  bool isGR16 = getMSP430MCRegisterClass(MSP430::GR16RegClassID).contains(Reg);
 
   if (isGR16 && (Kind == MCK_GR8)) {
     Op.setReg(convertGR16ToGR8(Reg));

--- a/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -3254,7 +3254,7 @@ bool MipsAsmParser::loadAndAddSymbolAddress(const MCExpr *SymExpr,
 // precision registers F0-F31. As an example, all of the following hold true:
 // D0 + 1 == F1, F1 + 1 == D1, F1 + 1 == F2, depending on the context.
 static MCRegister nextReg(MCRegister Reg) {
-  if (MipsMCRegisterClasses[Mips::FGR32RegClassID].contains(Reg))
+  if (getMipsMCRegisterClass(Mips::FGR32RegClassID).contains(Reg))
     return Reg == (unsigned)Mips::F31 ? (unsigned)Mips::F0 : Reg + 1;
   switch (Reg.id()) {
   default: llvm_unreachable("Unknown register in assembly macro expansion!");

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -471,14 +471,14 @@ public:
   }
   bool isAnyReg() const {
     return Kind == KindTy::Register &&
-           (RISCVMCRegisterClasses[RISCV::GPRRegClassID].contains(Reg.Reg) ||
-            RISCVMCRegisterClasses[RISCV::FPR64RegClassID].contains(Reg.Reg) ||
-            RISCVMCRegisterClasses[RISCV::VRRegClassID].contains(Reg.Reg));
+           (getRISCVMCRegisterClass(RISCV::GPRRegClassID).contains(Reg.Reg) ||
+            getRISCVMCRegisterClass(RISCV::FPR64RegClassID).contains(Reg.Reg) ||
+            getRISCVMCRegisterClass(RISCV::VRRegClassID).contains(Reg.Reg));
   }
   bool isAnyRegC() const {
     return Kind == KindTy::Register &&
-           (RISCVMCRegisterClasses[RISCV::GPRCRegClassID].contains(Reg.Reg) ||
-            RISCVMCRegisterClasses[RISCV::FPR64CRegClassID].contains(Reg.Reg));
+           (getRISCVMCRegisterClass(RISCV::GPRCRegClassID).contains(Reg.Reg) ||
+            getRISCVMCRegisterClass(RISCV::FPR64CRegClassID).contains(Reg.Reg));
   }
   bool isImm() const override { return isExpr(); }
   bool isMem() const override { return false; }
@@ -492,38 +492,38 @@ public:
 
   bool isGPR() const {
     return Kind == KindTy::Register &&
-           RISCVMCRegisterClasses[RISCV::GPRRegClassID].contains(Reg.Reg);
+           getRISCVMCRegisterClass(RISCV::GPRRegClassID).contains(Reg.Reg);
   }
 
   bool isYGPR() const {
     return Kind == KindTy::Register &&
-           RISCVMCRegisterClasses[RISCV::YGPRRegClassID].contains(Reg.Reg);
+           getRISCVMCRegisterClass(RISCV::YGPRRegClassID).contains(Reg.Reg);
   }
 
   bool isGPRPair() const {
     return Kind == KindTy::Register &&
-           RISCVMCRegisterClasses[RISCV::GPRPairRegClassID].contains(Reg.Reg);
+           getRISCVMCRegisterClass(RISCV::GPRPairRegClassID).contains(Reg.Reg);
   }
 
   bool isGPRPairC() const {
     return Kind == KindTy::Register &&
-           RISCVMCRegisterClasses[RISCV::GPRPairCRegClassID].contains(Reg.Reg);
+           getRISCVMCRegisterClass(RISCV::GPRPairCRegClassID).contains(Reg.Reg);
   }
 
   bool isGPRPairNoX0() const {
     return Kind == KindTy::Register &&
-           RISCVMCRegisterClasses[RISCV::GPRPairNoX0RegClassID].contains(
-               Reg.Reg);
+           getRISCVMCRegisterClass(RISCV::GPRPairNoX0RegClassID)
+               .contains(Reg.Reg);
   }
 
   bool isGPRF16() const {
     return Kind == KindTy::Register &&
-           RISCVMCRegisterClasses[RISCV::GPRF16RegClassID].contains(Reg.Reg);
+           getRISCVMCRegisterClass(RISCV::GPRF16RegClassID).contains(Reg.Reg);
   }
 
   bool isGPRF32() const {
     return Kind == KindTy::Register &&
-           RISCVMCRegisterClasses[RISCV::GPRF32RegClassID].contains(Reg.Reg);
+           getRISCVMCRegisterClass(RISCV::GPRF32RegClassID).contains(Reg.Reg);
   }
 
   bool isGPRAsFPR() const { return isGPR() && Reg.IsGPRAsFPR; }
@@ -1373,7 +1373,7 @@ static MCRegister convertVRToVRMx(const MCRegisterInfo &RI, MCRegister Reg,
   else
     return MCRegister();
   return RI.getMatchingSuperReg(Reg, RISCV::sub_vrm1_0,
-                                &RISCVMCRegisterClasses[RegClassID]);
+                                &getRISCVMCRegisterClass(RegClassID));
 }
 
 static MCRegister convertFPR64ToFPR256(MCRegister Reg) {
@@ -1389,10 +1389,10 @@ unsigned RISCVAsmParser::validateTargetOperandClass(MCParsedAsmOperand &AsmOp,
 
   MCRegister Reg = Op.getReg();
   bool IsRegFPR64 =
-      RISCVMCRegisterClasses[RISCV::FPR64RegClassID].contains(Reg);
+      getRISCVMCRegisterClass(RISCV::FPR64RegClassID).contains(Reg);
   bool IsRegFPR64C =
-      RISCVMCRegisterClasses[RISCV::FPR64CRegClassID].contains(Reg);
-  bool IsRegVR = RISCVMCRegisterClasses[RISCV::VRRegClassID].contains(Reg);
+      getRISCVMCRegisterClass(RISCV::FPR64CRegClassID).contains(Reg);
+  bool IsRegVR = getRISCVMCRegisterClass(RISCV::VRRegClassID).contains(Reg);
 
   if (Op.isGPR() && Kind == MCK_YGPR) {
     // GPR and capability GPR use the same register names, convert if required.
@@ -1433,7 +1433,7 @@ unsigned RISCVAsmParser::validateTargetOperandClass(MCParsedAsmOperand &AsmOp,
   // reject them at parsing thinking we should match as GPRPairAsFPR for RV32.
   // So we explicitly accept them here for RV32 to allow the generic code to
   // report that the instruction requires RV64.
-  if (RISCVMCRegisterClasses[RISCV::GPRRegClassID].contains(Reg) &&
+  if (getRISCVMCRegisterClass(RISCV::GPRRegClassID).contains(Reg) &&
       Kind == MCK_GPRF64AsFPR && STI->hasFeature(RISCV::FeatureStdExtZdinx) &&
       !isRV64())
     return Match_Success;
@@ -2635,7 +2635,7 @@ ParseStatus RISCVAsmParser::parseGPRPairAsFPR64(OperandVector &Operands) {
   if (!Reg)
     return ParseStatus::NoMatch;
 
-  if (!RISCVMCRegisterClasses[RISCV::GPRRegClassID].contains(Reg))
+  if (!getRISCVMCRegisterClass(RISCV::GPRRegClassID).contains(Reg))
     return ParseStatus::NoMatch;
 
   if ((Reg - RISCV::X0) & 1) {
@@ -2654,7 +2654,7 @@ ParseStatus RISCVAsmParser::parseGPRPairAsFPR64(OperandVector &Operands) {
   const MCRegisterInfo *RI = getContext().getRegisterInfo();
   MCRegister Pair = RI->getMatchingSuperReg(
       Reg, RISCV::sub_gpr_even,
-      &RISCVMCRegisterClasses[RISCV::GPRPairRegClassID]);
+      &getRISCVMCRegisterClass(RISCV::GPRPairRegClassID));
   Operands.push_back(RISCVOperand::createReg(Pair, S, E, /*isGPRAsFPR=*/true));
   return ParseStatus::Success;
 }
@@ -2683,7 +2683,7 @@ ParseStatus RISCVAsmParser::parseGPRPair(OperandVector &Operands,
   if (!Reg)
     return ParseStatus::NoMatch;
 
-  if (!RISCVMCRegisterClasses[RISCV::GPRRegClassID].contains(Reg))
+  if (!getRISCVMCRegisterClass(RISCV::GPRRegClassID).contains(Reg))
     return ParseStatus::NoMatch;
 
   if ((Reg - RISCV::X0) & 1)
@@ -2696,7 +2696,7 @@ ParseStatus RISCVAsmParser::parseGPRPair(OperandVector &Operands,
   const MCRegisterInfo *RI = getContext().getRegisterInfo();
   MCRegister Pair = RI->getMatchingSuperReg(
       Reg, RISCV::sub_gpr_even,
-      &RISCVMCRegisterClasses[RISCV::GPRPairRegClassID]);
+      &getRISCVMCRegisterClass(RISCV::GPRPairRegClassID));
   Operands.push_back(RISCVOperand::createReg(Pair, S, E));
   return ParseStatus::Success;
 }
@@ -2861,7 +2861,7 @@ ParseStatus RISCVAsmParser::parseRegReg(OperandVector &Operands) {
   StringRef OffsetRegName = getLexer().getTok().getIdentifier();
   MCRegister OffsetReg = matchRegisterNameHelper(OffsetRegName);
   if (!OffsetReg ||
-      !RISCVMCRegisterClasses[RISCV::GPRRegClassID].contains(OffsetReg))
+      !getRISCVMCRegisterClass(RISCV::GPRRegClassID).contains(OffsetReg))
     return Error(getLoc(), "expected GPR register");
   getLexer().Lex();
 
@@ -2874,7 +2874,7 @@ ParseStatus RISCVAsmParser::parseRegReg(OperandVector &Operands) {
   StringRef BaseRegName = getLexer().getTok().getIdentifier();
   MCRegister BaseReg = matchRegisterNameHelper(BaseRegName);
   if (!BaseReg ||
-      !RISCVMCRegisterClasses[RISCV::GPRRegClassID].contains(BaseReg))
+      !getRISCVMCRegisterClass(RISCV::GPRRegClassID).contains(BaseReg))
     return Error(getLoc(), "expected GPR register");
   getLexer().Lex();
 
@@ -3735,7 +3735,7 @@ void RISCVAsmParser::emitLoadStoreSymbol(MCInst &Inst, unsigned Opcode,
   MCRegister TmpReg = Inst.getOperand(0).getReg();
 
   // If TmpReg is a GPR pair, get the even register.
-  if (RISCVMCRegisterClasses[RISCV::GPRPairRegClassID].contains(TmpReg)) {
+  if (getRISCVMCRegisterClass(RISCV::GPRPairRegClassID).contains(TmpReg)) {
     const MCRegisterInfo *RI = getContext().getRegisterInfo();
     TmpReg = RI->getSubReg(TmpReg, RISCV::sub_gpr_even);
   }
@@ -3803,11 +3803,11 @@ void RISCVAsmParser::emitQCELILoadStoreSymbol(MCInst &Inst, unsigned Opcode,
   // For stores, both the data register and the address register must be in
   // GPRC for the compressed form; for loads AddrReg serves as both.
   bool CanUseGPRC =
-      RISCVMCRegisterClasses[RISCV::GPRCRegClassID].contains(AddrReg);
+      getRISCVMCRegisterClass(RISCV::GPRCRegClassID).contains(AddrReg);
   if (HasTmpReg && CanUseGPRC) {
     MCRegister DataReg = Inst.getOperand(1).getReg();
     CanUseGPRC =
-        RISCVMCRegisterClasses[RISCV::GPRCRegClassID].contains(DataReg);
+        getRISCVMCRegisterClass(RISCV::GPRCRegClassID).contains(DataReg);
   }
 
   bool UseCompressed =
@@ -4059,11 +4059,11 @@ static unsigned getNFforLXSEG(unsigned Opcode) {
 }
 
 unsigned getLMULFromVectorRegister(MCRegister Reg) {
-  if (RISCVMCRegisterClasses[RISCV::VRM2RegClassID].contains(Reg))
+  if (getRISCVMCRegisterClass(RISCV::VRM2RegClassID).contains(Reg))
     return 2;
-  if (RISCVMCRegisterClasses[RISCV::VRM4RegClassID].contains(Reg))
+  if (getRISCVMCRegisterClass(RISCV::VRM4RegClassID).contains(Reg))
     return 4;
-  if (RISCVMCRegisterClasses[RISCV::VRM8RegClassID].contains(Reg))
+  if (getRISCVMCRegisterClass(RISCV::VRM8RegClassID).contains(Reg))
     return 8;
   return 1;
 }

--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -164,7 +164,7 @@ static DecodeStatus DecodeGPRPairRegisterClass(MCInst &Inst, uint32_t RegNo,
   const MCRegisterInfo *RI = Dis->getContext().getRegisterInfo();
   MCRegister Reg = RI->getMatchingSuperReg(
       RISCV::X0 + RegNo, RISCV::sub_gpr_even,
-      &RISCVMCRegisterClasses[RISCV::GPRPairRegClassID]);
+      &getRISCVMCRegisterClass(RISCV::GPRPairRegClassID));
   Inst.addOperand(MCOperand::createReg(Reg));
   return MCDisassembler::Success;
 }
@@ -183,7 +183,7 @@ static DecodeStatus DecodeGPRPairCRegisterClass(MCInst &Inst, uint32_t RegNo,
   const MCRegisterInfo *RI = Dis->getContext().getRegisterInfo();
   MCRegister Reg = RI->getMatchingSuperReg(
       RISCV::X8 + RegNo, RISCV::sub_gpr_even,
-      &RISCVMCRegisterClasses[RISCV::GPRPairCRegClassID]);
+      &getRISCVMCRegisterClass(RISCV::GPRPairCRegClassID));
   Inst.addOperand(MCOperand::createReg(Reg));
   return MCDisassembler::Success;
 }
@@ -211,7 +211,7 @@ static DecodeStatus DecodeVectorRegisterClass(MCInst &Inst, uint32_t RegNo,
   const MCRegisterInfo *RI = Dis->getContext().getRegisterInfo();
   MCRegister Reg =
       RI->getMatchingSuperReg(RISCV::V0 + RegNo, RISCV::sub_vrm1_0,
-                              &RISCVMCRegisterClasses[RegisterClass]);
+                              &getRISCVMCRegisterClass(RegisterClass));
 
   Inst.addOperand(MCOperand::createReg(Reg));
   return MCDisassembler::Success;

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -1370,21 +1370,21 @@ static bool CheckBaseRegAndIndexRegAndScale(MCRegister BaseReg,
 
   if (BaseReg &&
       !(BaseReg == X86::RIP || BaseReg == X86::EIP ||
-        X86MCRegisterClasses[X86::GR16RegClassID].contains(BaseReg) ||
-        X86MCRegisterClasses[X86::GR32RegClassID].contains(BaseReg) ||
-        X86MCRegisterClasses[X86::GR64RegClassID].contains(BaseReg))) {
+        getX86MCRegisterClass(X86::GR16RegClassID).contains(BaseReg) ||
+        getX86MCRegisterClass(X86::GR32RegClassID).contains(BaseReg) ||
+        getX86MCRegisterClass(X86::GR64RegClassID).contains(BaseReg))) {
     ErrMsg = "invalid base+index expression";
     return true;
   }
 
   if (IndexReg &&
       !(IndexReg == X86::EIZ || IndexReg == X86::RIZ ||
-        X86MCRegisterClasses[X86::GR16RegClassID].contains(IndexReg) ||
-        X86MCRegisterClasses[X86::GR32RegClassID].contains(IndexReg) ||
-        X86MCRegisterClasses[X86::GR64RegClassID].contains(IndexReg) ||
-        X86MCRegisterClasses[X86::VR128XRegClassID].contains(IndexReg) ||
-        X86MCRegisterClasses[X86::VR256XRegClassID].contains(IndexReg) ||
-        X86MCRegisterClasses[X86::VR512RegClassID].contains(IndexReg))) {
+        getX86MCRegisterClass(X86::GR16RegClassID).contains(IndexReg) ||
+        getX86MCRegisterClass(X86::GR32RegClassID).contains(IndexReg) ||
+        getX86MCRegisterClass(X86::GR64RegClassID).contains(IndexReg) ||
+        getX86MCRegisterClass(X86::VR128XRegClassID).contains(IndexReg) ||
+        getX86MCRegisterClass(X86::VR256XRegClassID).contains(IndexReg) ||
+        getX86MCRegisterClass(X86::VR512RegClassID).contains(IndexReg))) {
     ErrMsg = "invalid base+index expression";
     return true;
   }
@@ -1398,7 +1398,7 @@ static bool CheckBaseRegAndIndexRegAndScale(MCRegister BaseReg,
 
   // Check for use of invalid 16-bit registers. Only BX/BP/SI/DI are allowed,
   // and then only in non-64-bit modes.
-  if (X86MCRegisterClasses[X86::GR16RegClassID].contains(BaseReg) &&
+  if (getX86MCRegisterClass(X86::GR16RegClassID).contains(BaseReg) &&
       (Is64BitMode || (BaseReg != X86::BX && BaseReg != X86::BP &&
                        BaseReg != X86::SI && BaseReg != X86::DI))) {
     ErrMsg = "invalid 16-bit base register";
@@ -1406,29 +1406,29 @@ static bool CheckBaseRegAndIndexRegAndScale(MCRegister BaseReg,
   }
 
   if (!BaseReg &&
-      X86MCRegisterClasses[X86::GR16RegClassID].contains(IndexReg)) {
+      getX86MCRegisterClass(X86::GR16RegClassID).contains(IndexReg)) {
     ErrMsg = "16-bit memory operand may not include only index register";
     return true;
   }
 
   if (BaseReg && IndexReg) {
-    if (X86MCRegisterClasses[X86::GR64RegClassID].contains(BaseReg) &&
-        (X86MCRegisterClasses[X86::GR16RegClassID].contains(IndexReg) ||
-         X86MCRegisterClasses[X86::GR32RegClassID].contains(IndexReg) ||
+    if (getX86MCRegisterClass(X86::GR64RegClassID).contains(BaseReg) &&
+        (getX86MCRegisterClass(X86::GR16RegClassID).contains(IndexReg) ||
+         getX86MCRegisterClass(X86::GR32RegClassID).contains(IndexReg) ||
          IndexReg == X86::EIZ)) {
       ErrMsg = "base register is 64-bit, but index register is not";
       return true;
     }
-    if (X86MCRegisterClasses[X86::GR32RegClassID].contains(BaseReg) &&
-        (X86MCRegisterClasses[X86::GR16RegClassID].contains(IndexReg) ||
-         X86MCRegisterClasses[X86::GR64RegClassID].contains(IndexReg) ||
+    if (getX86MCRegisterClass(X86::GR32RegClassID).contains(BaseReg) &&
+        (getX86MCRegisterClass(X86::GR16RegClassID).contains(IndexReg) ||
+         getX86MCRegisterClass(X86::GR64RegClassID).contains(IndexReg) ||
          IndexReg == X86::RIZ)) {
       ErrMsg = "base register is 32-bit, but index register is not";
       return true;
     }
-    if (X86MCRegisterClasses[X86::GR16RegClassID].contains(BaseReg)) {
-      if (X86MCRegisterClasses[X86::GR32RegClassID].contains(IndexReg) ||
-          X86MCRegisterClasses[X86::GR64RegClassID].contains(IndexReg)) {
+    if (getX86MCRegisterClass(X86::GR16RegClassID).contains(BaseReg)) {
+      if (getX86MCRegisterClass(X86::GR32RegClassID).contains(IndexReg) ||
+          getX86MCRegisterClass(X86::GR64RegClassID).contains(IndexReg)) {
         ErrMsg = "base register is 16-bit, but index register is not";
         return true;
       }
@@ -1472,7 +1472,7 @@ bool X86AsmParser::MatchRegisterByName(MCRegister &RegNo, StringRef RegName,
     // Requires<In64BitMode> so "eiz" usage in 64-bit instructions can be also
     // checked.
     if (RegNo == X86::RIZ || RegNo == X86::RIP ||
-        X86MCRegisterClasses[X86::GR64RegClassID].contains(RegNo) ||
+        getX86MCRegisterClass(X86::GR64RegClassID).contains(RegNo) ||
         X86II::isX86_64NonExtLowByteReg(RegNo) ||
         X86II::isX86_64ExtendedReg(RegNo)) {
       return Error(StartLoc,
@@ -1757,16 +1757,16 @@ bool X86AsmParser::VerifyAndAdjustOperands(OperandVector &OrigOperands,
         // If we've already encounterd a register class, make sure all register
         // bases are of the same register class
         if (RegClassID != -1 &&
-            !X86MCRegisterClasses[RegClassID].contains(OrigReg)) {
+            !getX86MCRegisterClass(RegClassID).contains(OrigReg)) {
           return Error(OrigOp.getStartLoc(),
                        "mismatching source and destination index registers");
         }
 
-        if (X86MCRegisterClasses[X86::GR64RegClassID].contains(OrigReg))
+        if (getX86MCRegisterClass(X86::GR64RegClassID).contains(OrigReg))
           RegClassID = X86::GR64RegClassID;
-        else if (X86MCRegisterClasses[X86::GR32RegClassID].contains(OrigReg))
+        else if (getX86MCRegisterClass(X86::GR32RegClassID).contains(OrigReg))
           RegClassID = X86::GR32RegClassID;
-        else if (X86MCRegisterClasses[X86::GR16RegClassID].contains(OrigReg))
+        else if (getX86MCRegisterClass(X86::GR16RegClassID).contains(OrigReg))
           RegClassID = X86::GR16RegClassID;
         else
           // Unexpected register class type
@@ -2642,13 +2642,13 @@ bool X86AsmParser::ParseIntelMemoryOperandSize(unsigned &Size,
 }
 
 uint16_t RegSizeInBits(const MCRegisterInfo &MRI, MCRegister RegNo) {
-  if (X86MCRegisterClasses[X86::GR8RegClassID].contains(RegNo))
+  if (getX86MCRegisterClass(X86::GR8RegClassID).contains(RegNo))
     return 8;
-  if (X86MCRegisterClasses[X86::GR16RegClassID].contains(RegNo))
+  if (getX86MCRegisterClass(X86::GR16RegClassID).contains(RegNo))
     return 16;
-  if (X86MCRegisterClasses[X86::GR32RegClassID].contains(RegNo))
+  if (getX86MCRegisterClass(X86::GR32RegClassID).contains(RegNo))
     return 32;
-  if (X86MCRegisterClasses[X86::GR64RegClassID].contains(RegNo))
+  if (getX86MCRegisterClass(X86::GR64RegClassID).contains(RegNo))
     return 64;
   // Unknown register size
   return 0;
@@ -2706,7 +2706,7 @@ bool X86AsmParser::parseIntelOperand(OperandVector &Operands, StringRef Name) {
       return false;
     }
     // An alleged segment override. check if we have a valid segment register
-    if (!X86MCRegisterClasses[X86::SEGMENT_REGRegClassID].contains(RegNo))
+    if (!getX86MCRegisterClass(X86::SEGMENT_REGRegClassID).contains(RegNo))
       return Error(Start, "invalid segment register");
     // Eat ':' and update Start location
     Start = Lex().getLoc();
@@ -2763,16 +2763,16 @@ bool X86AsmParser::parseIntelOperand(OperandVector &Operands, StringRef Name) {
   // If BaseReg is a vector register and IndexReg is not, swap them unless
   // Scale was specified in which case it would be an error.
   if (Scale == 0 &&
-      !(X86MCRegisterClasses[X86::VR128XRegClassID].contains(IndexReg) ||
-        X86MCRegisterClasses[X86::VR256XRegClassID].contains(IndexReg) ||
-        X86MCRegisterClasses[X86::VR512RegClassID].contains(IndexReg)) &&
-      (X86MCRegisterClasses[X86::VR128XRegClassID].contains(BaseReg) ||
-       X86MCRegisterClasses[X86::VR256XRegClassID].contains(BaseReg) ||
-       X86MCRegisterClasses[X86::VR512RegClassID].contains(BaseReg)))
+      !(getX86MCRegisterClass(X86::VR128XRegClassID).contains(IndexReg) ||
+        getX86MCRegisterClass(X86::VR256XRegClassID).contains(IndexReg) ||
+        getX86MCRegisterClass(X86::VR512RegClassID).contains(IndexReg)) &&
+      (getX86MCRegisterClass(X86::VR128XRegClassID).contains(BaseReg) ||
+       getX86MCRegisterClass(X86::VR256XRegClassID).contains(BaseReg) ||
+       getX86MCRegisterClass(X86::VR512RegClassID).contains(BaseReg)))
     std::swap(BaseReg, IndexReg);
 
   if (Scale != 0 &&
-      X86MCRegisterClasses[X86::GR16RegClassID].contains(IndexReg))
+      getX86MCRegisterClass(X86::GR16RegClassID).contains(IndexReg))
     return Error(Start, "16-bit addresses cannot have a scale");
 
   // If there was no explicit scale specified, change it to 1.
@@ -2905,7 +2905,7 @@ bool X86AsmParser::parseATTOperand(OperandVector &Operands) {
           Operands.push_back(X86Operand::CreateReg(Reg, Loc, EndLoc));
           return false;
         }
-        if (!X86MCRegisterClasses[X86::SEGMENT_REGRegClassID].contains(Reg))
+        if (!getX86MCRegisterClass(X86::SEGMENT_REGRegClassID).contains(Reg))
           return Error(Loc, "invalid segment register");
         // Accept a '*' absolute memory reference after the segment. Place it
         // before the full memory operand.
@@ -3019,7 +3019,7 @@ bool X86AsmParser::HandleAVX512Operand(OperandVector &Operands) {
         MCRegister RegNo;
         SMLoc RegLoc;
         if (!parseRegister(RegNo, RegLoc, StartLoc) &&
-            X86MCRegisterClasses[X86::VK1RegClassID].contains(RegNo)) {
+            getX86MCRegisterClass(X86::VK1RegClassID).contains(RegNo)) {
           if (RegNo == X86::K0)
             return Error(RegLoc, "Register k0 can't be used as write mask");
           if (!getLexer().is(AsmToken::RCurly))
@@ -3062,9 +3062,10 @@ bool X86AsmParser::CheckDispOverflow(MCRegister BaseReg, MCRegister IndexReg,
   if (BaseReg || IndexReg) {
     if (auto CE = dyn_cast<MCConstantExpr>(Disp)) {
       auto Imm = CE->getValue();
-      bool Is64 = X86MCRegisterClasses[X86::GR64RegClassID].contains(BaseReg) ||
-                  X86MCRegisterClasses[X86::GR64RegClassID].contains(IndexReg);
-      bool Is16 = X86MCRegisterClasses[X86::GR16RegClassID].contains(BaseReg);
+      bool Is64 =
+          getX86MCRegisterClass(X86::GR64RegClassID).contains(BaseReg) ||
+          getX86MCRegisterClass(X86::GR64RegClassID).contains(IndexReg);
+      bool Is16 = getX86MCRegisterClass(X86::GR16RegClassID).contains(BaseReg);
       if (Is64) {
         if (!isInt<32>(Imm))
           return Error(Loc, "displacement " + Twine(Imm) +
@@ -3234,7 +3235,7 @@ bool X86AsmParser::ParseMemOperand(MCRegister SegReg, const MCExpr *Disp,
               return Error(Loc, "expected scale expression");
             Scale = (unsigned)ScaleVal;
             // Validate the scale amount.
-            if (X86MCRegisterClasses[X86::GR16RegClassID].contains(BaseReg) &&
+            if (getX86MCRegisterClass(X86::GR16RegClassID).contains(BaseReg) &&
                 Scale != 1)
               return Error(Loc, "scale factor in 16-bit address must be 1");
             if (checkScale(Scale, ErrMsg))
@@ -3721,10 +3722,10 @@ bool X86AsmParser::parseInstruction(ParseInstructionInfo &Info, StringRef Name,
     // Moving a 32 or 16 bit value into a segment register has the same
     // behavior. Modify such instructions to always take shorter form.
     if (Op1.isReg() && Op2.isReg() &&
-        X86MCRegisterClasses[X86::SEGMENT_REGRegClassID].contains(
-            Op2.getReg()) &&
-        (X86MCRegisterClasses[X86::GR16RegClassID].contains(Op1.getReg()) ||
-         X86MCRegisterClasses[X86::GR32RegClassID].contains(Op1.getReg()))) {
+        getX86MCRegisterClass(X86::SEGMENT_REGRegClassID)
+            .contains(Op2.getReg()) &&
+        (getX86MCRegisterClass(X86::GR16RegClassID).contains(Op1.getReg()) ||
+         getX86MCRegisterClass(X86::GR32RegClassID).contains(Op1.getReg()))) {
       // Change instruction name to match new instruction.
       if (Name != "mov" && Name[3] == (is16BitMode() ? 'l' : 'w')) {
         Name = is16BitMode() ? "movw" : "movl";
@@ -4790,7 +4791,7 @@ bool X86AsmParser::matchAndEmitIntelInstruction(
 }
 
 bool X86AsmParser::omitRegisterFromClobberLists(MCRegister Reg) {
-  return X86MCRegisterClasses[X86::SEGMENT_REGRegClassID].contains(Reg);
+  return getX86MCRegisterClass(X86::SEGMENT_REGRegClassID).contains(Reg);
 }
 
 bool X86AsmParser::ParseDirective(AsmToken DirectiveID) {
@@ -5076,7 +5077,7 @@ bool X86AsmParser::parseSEHRegisterNumber(unsigned RegClassID,
     if (parseRegister(RegNo, startLoc, endLoc))
       return true;
 
-    if (!X86MCRegisterClasses[RegClassID].contains(RegNo)) {
+    if (!getX86MCRegisterClass(RegClassID).contains(RegNo)) {
       return Error(startLoc,
                    "register is not supported for use with this directive");
     }
@@ -5090,7 +5091,7 @@ bool X86AsmParser::parseSEHRegisterNumber(unsigned RegClassID,
     // The SEH register number is the same as the encoding register number. Map
     // from the encoding back to the LLVM register number.
     RegNo = MCRegister();
-    for (MCPhysReg Reg : X86MCRegisterClasses[RegClassID]) {
+    for (MCPhysReg Reg : getX86MCRegisterClass(RegClassID)) {
       if (MRI->getEncodingValue(Reg) == EncodedReg) {
         RegNo = Reg;
         break;

--- a/llvm/lib/Target/X86/AsmParser/X86Operand.h
+++ b/llvm/lib/Target/X86/AsmParser/X86Operand.h
@@ -384,7 +384,7 @@ struct X86Operand final : public MCParsedAsmOperand {
     if (!isMem512())
       return false;
     if (getMemBaseReg() &&
-        !X86MCRegisterClasses[X86::GR16RegClassID].contains(getMemBaseReg()))
+        !getX86MCRegisterClass(X86::GR16RegClassID).contains(getMemBaseReg()))
       return false;
     return true;
   }
@@ -392,11 +392,12 @@ struct X86Operand final : public MCParsedAsmOperand {
     if (!isMem512())
       return false;
     if (getMemBaseReg() &&
-        !X86MCRegisterClasses[X86::GR32RegClassID].contains(getMemBaseReg()) &&
+        !getX86MCRegisterClass(X86::GR32RegClassID).contains(getMemBaseReg()) &&
         getMemBaseReg() != X86::EIP)
       return false;
     if (getMemIndexReg() &&
-        !X86MCRegisterClasses[X86::GR32RegClassID].contains(getMemIndexReg()) &&
+        !getX86MCRegisterClass(X86::GR32RegClassID)
+             .contains(getMemIndexReg()) &&
         getMemIndexReg() != X86::EIZ)
       return false;
     return true;
@@ -405,11 +406,12 @@ struct X86Operand final : public MCParsedAsmOperand {
     if (!isMem512())
       return false;
     if (getMemBaseReg() &&
-        !X86MCRegisterClasses[X86::GR64RegClassID].contains(getMemBaseReg()) &&
+        !getX86MCRegisterClass(X86::GR64RegClassID).contains(getMemBaseReg()) &&
         getMemBaseReg() != X86::RIP)
       return false;
     if (getMemIndexReg() &&
-        !X86MCRegisterClasses[X86::GR64RegClassID].contains(getMemIndexReg()) &&
+        !getX86MCRegisterClass(X86::GR64RegClassID)
+             .contains(getMemIndexReg()) &&
         getMemIndexReg() != X86::RIZ)
       return false;
     return true;
@@ -533,48 +535,48 @@ struct X86Operand final : public MCParsedAsmOperand {
 
   bool isGR32orGR64() const {
     return Kind == Register &&
-      (X86MCRegisterClasses[X86::GR32RegClassID].contains(getReg()) ||
-       X86MCRegisterClasses[X86::GR64RegClassID].contains(getReg()));
+           (getX86MCRegisterClass(X86::GR32RegClassID).contains(getReg()) ||
+            getX86MCRegisterClass(X86::GR64RegClassID).contains(getReg()));
   }
 
   bool isGR16orGR32orGR64() const {
     return Kind == Register &&
-      (X86MCRegisterClasses[X86::GR16RegClassID].contains(getReg()) ||
-       X86MCRegisterClasses[X86::GR32RegClassID].contains(getReg()) ||
-       X86MCRegisterClasses[X86::GR64RegClassID].contains(getReg()));
+           (getX86MCRegisterClass(X86::GR16RegClassID).contains(getReg()) ||
+            getX86MCRegisterClass(X86::GR32RegClassID).contains(getReg()) ||
+            getX86MCRegisterClass(X86::GR64RegClassID).contains(getReg()));
   }
 
   bool isVectorReg() const {
     return Kind == Register &&
-           (X86MCRegisterClasses[X86::VR64RegClassID].contains(getReg()) ||
-            X86MCRegisterClasses[X86::VR128XRegClassID].contains(getReg()) ||
-            X86MCRegisterClasses[X86::VR256XRegClassID].contains(getReg()) ||
-            X86MCRegisterClasses[X86::VR512RegClassID].contains(getReg()));
+           (getX86MCRegisterClass(X86::VR64RegClassID).contains(getReg()) ||
+            getX86MCRegisterClass(X86::VR128XRegClassID).contains(getReg()) ||
+            getX86MCRegisterClass(X86::VR256XRegClassID).contains(getReg()) ||
+            getX86MCRegisterClass(X86::VR512RegClassID).contains(getReg()));
   }
 
   bool isVK1Pair() const {
     return Kind == Register &&
-      X86MCRegisterClasses[X86::VK1RegClassID].contains(getReg());
+           getX86MCRegisterClass(X86::VK1RegClassID).contains(getReg());
   }
 
   bool isVK2Pair() const {
     return Kind == Register &&
-      X86MCRegisterClasses[X86::VK2RegClassID].contains(getReg());
+           getX86MCRegisterClass(X86::VK2RegClassID).contains(getReg());
   }
 
   bool isVK4Pair() const {
     return Kind == Register &&
-      X86MCRegisterClasses[X86::VK4RegClassID].contains(getReg());
+           getX86MCRegisterClass(X86::VK4RegClassID).contains(getReg());
   }
 
   bool isVK8Pair() const {
     return Kind == Register &&
-      X86MCRegisterClasses[X86::VK8RegClassID].contains(getReg());
+           getX86MCRegisterClass(X86::VK8RegClassID).contains(getReg());
   }
 
   bool isVK16Pair() const {
     return Kind == Register &&
-      X86MCRegisterClasses[X86::VK16RegClassID].contains(getReg());
+           getX86MCRegisterClass(X86::VK16RegClassID).contains(getReg());
   }
 
   void addExpr(MCInst &Inst, const MCExpr *Expr) const {
@@ -593,7 +595,7 @@ struct X86Operand final : public MCParsedAsmOperand {
   void addGR32orGR64Operands(MCInst &Inst, unsigned N) const {
     assert(N == 1 && "Invalid number of operands!");
     MCRegister RegNo = getReg();
-    if (X86MCRegisterClasses[X86::GR64RegClassID].contains(RegNo))
+    if (getX86MCRegisterClass(X86::GR64RegClassID).contains(RegNo))
       RegNo = getX86SubSuperRegister(RegNo, 32);
     Inst.addOperand(MCOperand::createReg(RegNo));
   }
@@ -601,8 +603,8 @@ struct X86Operand final : public MCParsedAsmOperand {
   void addGR16orGR32orGR64Operands(MCInst &Inst, unsigned N) const {
     assert(N == 1 && "Invalid number of operands!");
     MCRegister RegNo = getReg();
-    if (X86MCRegisterClasses[X86::GR32RegClassID].contains(RegNo) ||
-        X86MCRegisterClasses[X86::GR64RegClassID].contains(RegNo))
+    if (getX86MCRegisterClass(X86::GR32RegClassID).contains(RegNo) ||
+        getX86MCRegisterClass(X86::GR64RegClassID).contains(RegNo))
       RegNo = getX86SubSuperRegister(RegNo, 16);
     Inst.addOperand(MCOperand::createReg(RegNo));
   }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
@@ -80,7 +80,7 @@ bool X86_MC::hasLockPrefix(const MCInst &MI) {
 static bool isMemOperand(const MCInst &MI, unsigned Op, unsigned RegClassID) {
   const MCOperand &Base = MI.getOperand(Op + X86::AddrBaseReg);
   const MCOperand &Index = MI.getOperand(Op + X86::AddrIndexReg);
-  const MCRegisterClass &RC = X86MCRegisterClasses[RegClassID];
+  const MCRegisterClass &RC = getX86MCRegisterClass(RegClassID);
 
   return (Base.isReg() && Base.getReg() && RC.contains(Base.getReg())) ||
          (Index.isReg() && Index.getReg() && RC.contains(Index.getReg()));
@@ -624,7 +624,7 @@ bool X86MCInstrAnalysis::clearsSuperRegisters(const MCRegisterInfo &MRI,
   const MCRegisterClass &VR128XRC = MRI.getRegClass(X86::VR128XRegClassID);
   const MCRegisterClass &VR256XRC = MRI.getRegClass(X86::VR256XRegClassID);
 
-  auto ClearsSuperReg = [=](MCRegister RegID) {
+  auto ClearsSuperReg = [&](MCRegister RegID) {
     // On X86-64, a general purpose integer register is viewed as a 64-bit
     // register internal to the processor.
     // An update to the lower 32 bits of a 64 bit integer register is

--- a/llvm/lib/Target/X86/X86ExpandPseudo.cpp
+++ b/llvm/lib/Target/X86/X86ExpandPseudo.cpp
@@ -771,8 +771,8 @@ bool X86ExpandPseudoImpl::expandMI(MachineBasicBlock &MBB,
     unsigned Count = !!MI.getOperand(MemOpNo + X86::AddrSegmentReg).getReg();
     if (X86II::needSIB(Base, Index, /*In64BitMode=*/true))
       ++Count;
-    if (X86MCRegisterClasses[X86::GR32RegClassID].contains(Base) ||
-        X86MCRegisterClasses[X86::GR32RegClassID].contains(Index))
+    if (getX86MCRegisterClass(X86::GR32RegClassID).contains(Base) ||
+        getX86MCRegisterClass(X86::GR32RegClassID).contains(Index))
       ++Count;
     if (Count < 2)
       return false;

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -10400,7 +10400,7 @@ X86InstrInfo::describeLoadedValue(const MachineInstr &MI, Register Reg) const {
     if (Reg == MI.getOperand(0).getReg())
       Expr = DIExpression::appendExt(Expr, 32, 64, true);
     else
-      assert(X86MCRegisterClasses[X86::GR32RegClassID].contains(Reg) &&
+      assert(getX86MCRegisterClass(X86::GR32RegClassID).contains(Reg) &&
              "Unhandled sub-register case for MOVSX64rr32");
 
     return ParamLoadedValue(MI.getOperand(1), Expr);

--- a/llvm/test/TableGen/AsmPredicateCombiningRISCV.td
+++ b/llvm/test/TableGen/AsmPredicateCombiningRISCV.td
@@ -61,7 +61,7 @@ def SmallInst1 : RVInst16<1, []>;
 def : CompressPat<(BigInst Regs:$r), (SmallInst1 Regs:$r), [AsmPred1]>;
 // COMPRESS:      if (STI.getFeatureBits()[arch::AsmCond1] &&
 // COMPRESS-NEXT: MI.getOperand(0).isReg() &&
-// COMPRESS-NEXT: archMCRegisterClasses[arch::RegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// COMPRESS-NEXT: getarchMCRegisterClass(arch::RegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // COMPRESS-NEXT: // SmallInst1 $r
 
 def SmallInst2 : RVInst16<2, []>;
@@ -69,14 +69,14 @@ def : CompressPat<(BigInst Regs:$r), (SmallInst2 Regs:$r), [AsmPred2]>;
 // COMPRESS:      if (STI.getFeatureBits()[arch::AsmCond2a] &&
 // COMPRESS-NEXT: STI.getFeatureBits()[arch::AsmCond2b] &&
 // COMPRESS-NEXT: MI.getOperand(0).isReg() &&
-// COMPRESS-NEXT: archMCRegisterClasses[arch::RegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// COMPRESS-NEXT: getarchMCRegisterClass(arch::RegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // COMPRESS-NEXT: // SmallInst2 $r
 
 def SmallInst3 : RVInst16<2, []>;
 def : CompressPat<(BigInst Regs:$r), (SmallInst3 Regs:$r), [AsmPred3]>;
 // COMPRESS:      if ((STI.getFeatureBits()[arch::AsmCond3a] || STI.getFeatureBits()[arch::AsmCond3b]) &&
 // COMPRESS-NEXT: MI.getOperand(0).isReg() &&
-// COMPRESS-NEXT: archMCRegisterClasses[arch::RegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// COMPRESS-NEXT: getarchMCRegisterClass(arch::RegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // COMPRESS-NEXT: // SmallInst3 $r
 
 def SmallInst4 : RVInst16<2, []>;
@@ -85,7 +85,7 @@ def : CompressPat<(BigInst Regs:$r), (SmallInst4 Regs:$r), [AsmPred1, AsmPred2]>
 // COMPRESS-NEXT: STI.getFeatureBits()[arch::AsmCond2a] &&
 // COMPRESS-NEXT: STI.getFeatureBits()[arch::AsmCond2b] &&
 // COMPRESS-NEXT: MI.getOperand(0).isReg() &&
-// COMPRESS-NEXT: archMCRegisterClasses[arch::RegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// COMPRESS-NEXT: getarchMCRegisterClass(arch::RegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // COMPRESS-NEXT: // SmallInst4 $r
 
 def SmallInst5 : RVInst16<2, []>;
@@ -93,7 +93,7 @@ def : CompressPat<(BigInst Regs:$r), (SmallInst5 Regs:$r), [AsmPred1, AsmPred3]>
 // COMPRESS:      if (STI.getFeatureBits()[arch::AsmCond1] &&
 // COMPRESS-NEXT: (STI.getFeatureBits()[arch::AsmCond3a] || STI.getFeatureBits()[arch::AsmCond3b]) &&
 // COMPRESS-NEXT: MI.getOperand(0).isReg() &&
-// COMPRESS-NEXT: archMCRegisterClasses[arch::RegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// COMPRESS-NEXT: getarchMCRegisterClass(arch::RegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // COMPRESS-NEXT: // SmallInst5 $r
 
 // COMPRESS-LABEL: static bool uncompressInst
@@ -102,29 +102,29 @@ def : CompressPat<(BigInst Regs:$r), (SmallInst5 Regs:$r), [AsmPred1, AsmPred3]>
 
 // COMPRESS:      if (STI.getFeatureBits()[arch::AsmCond1] &&
 // COMPRESS-NEXT: MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// COMPRESS-NEXT: archMCRegisterClasses[arch::RegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// COMPRESS-NEXT: getarchMCRegisterClass(arch::RegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // COMPRESS-NEXT: // SmallInst1 $r
 
 // COMPRESS:      if (STI.getFeatureBits()[arch::AsmCond2a] &&
 // COMPRESS-NEXT: STI.getFeatureBits()[arch::AsmCond2b] &&
 // COMPRESS-NEXT: MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// COMPRESS-NEXT: archMCRegisterClasses[arch::RegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// COMPRESS-NEXT: getarchMCRegisterClass(arch::RegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // COMPRESS-NEXT: // SmallInst2 $r
 
 // COMPRESS:      if ((STI.getFeatureBits()[arch::AsmCond3a] || STI.getFeatureBits()[arch::AsmCond3b]) &&
 // COMPRESS-NEXT: MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// COMPRESS-NEXT: archMCRegisterClasses[arch::RegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// COMPRESS-NEXT: getarchMCRegisterClass(arch::RegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // COMPRESS-NEXT: // SmallInst3 $r
 
 // COMPRESS:      if (STI.getFeatureBits()[arch::AsmCond1] &&
 // COMPRESS-NEXT: STI.getFeatureBits()[arch::AsmCond2a] &&
 // COMPRESS-NEXT: STI.getFeatureBits()[arch::AsmCond2b] &&
 // COMPRESS-NEXT: MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// COMPRESS-NEXT: archMCRegisterClasses[arch::RegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// COMPRESS-NEXT: getarchMCRegisterClass(arch::RegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // COMPRESS-NEXT: // SmallInst4 $r
 
 // COMPRESS:      if (STI.getFeatureBits()[arch::AsmCond1] &&
 // COMPRESS-NEXT: (STI.getFeatureBits()[arch::AsmCond3a] || STI.getFeatureBits()[arch::AsmCond3b]) &&
 // COMPRESS-NEXT: MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// COMPRESS-NEXT: archMCRegisterClasses[arch::RegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// COMPRESS-NEXT: getarchMCRegisterClass(arch::RegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // COMPRESS-NEXT: // SmallInst5 $r

--- a/llvm/test/TableGen/CompressInstEmitter/suboperands.td
+++ b/llvm/test/TableGen/CompressInstEmitter/suboperands.td
@@ -112,9 +112,9 @@ def : CompressPat<(BigInst3 RegsC:$dst, RegsC:$src, simm6:$imm),
 // CHECK-LABEL: compressInst
 // CHECK: case Arch::BigInst
 // CHECK-NEXT: if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT: MI.getOperand(1).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(1).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(1).getReg()) &&
 // CHECK-NEXT: ArchValidateMCOperandForCompress(MI.getOperand(2), STI, 1 /* simm6 */)) {
 // CHECK-NEXT: // small $dst, $addr
 // CHECK-NEXT: OutInst.setOpcode(Arch::SmallInst);
@@ -128,9 +128,9 @@ def : CompressPat<(BigInst3 RegsC:$dst, RegsC:$src, simm6:$imm),
 // CHECK-NEXT: } // if
 // CHECK: case Arch::BigInst2
 // CHECK-NEXT: if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT: MI.getOperand(1).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(1).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(1).getReg()) &&
 // CHECK-NEXT: ArchValidateMCOperandForCompress(MI.getOperand(2), STI, 1 /* simm6 */)) {
 // CHECK-NEXT: // small $dst, $src, $imm
 // CHECK-NEXT: OutInst.setOpcode(Arch::SmallInst2);
@@ -145,9 +145,9 @@ def : CompressPat<(BigInst3 RegsC:$dst, RegsC:$src, simm6:$imm),
 // CHECK-NEXT: } // if
 // CHECK: case Arch::BigInst3
 // CHECK-NEXT: if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT: MI.getOperand(1).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(1).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(1).getReg()) &&
 // CHECK-NEXT: ArchValidateMCOperandForCompress(MI.getOperand(2), STI, 1 /* simm6 */)) {
 // CHECK-NEXT: // small $dst, $addr
 // CHECK-NEXT: OutInst.setOpcode(Arch::SmallInst3);
@@ -167,9 +167,9 @@ def : CompressPat<(BigInst3 RegsC:$dst, RegsC:$src, simm6:$imm),
 // CHECK-LABEL: uncompressInst
 // CHECK: case Arch::SmallInst:
 // CHECK-NEXT:  if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT: MI.getOperand(1).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(1).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(1).getReg()) &&
 // CHECK-NEXT: ArchValidateMCOperandForUncompress(MI.getOperand(2), STI, 1 /* simm6 */) &&
 // CHECK-NEXT: ArchValidateMCOperandForUncompress(MI.getOperand(2), STI, 2 /* simm12 */))
 // CHECK-NEXT: // big $dst, $addr
@@ -184,9 +184,9 @@ def : CompressPat<(BigInst3 RegsC:$dst, RegsC:$src, simm6:$imm),
 // CHECK-NEXT: } // if
 // CHECK: case Arch::SmallInst2:
 // CHECK-NEXT:  if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT: MI.getOperand(1).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(1).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(1).getReg()) &&
 // CHECK-NEXT: ArchValidateMCOperandForUncompress(MI.getOperand(2), STI, 1 /* simm6 */) &&
 // CHECK-NEXT: ArchValidateMCOperandForUncompress(MI.getOperand(2), STI, 2 /* simm12 */)) {
 // CHECK-NEXT: // big $dst, $addr
@@ -201,9 +201,9 @@ def : CompressPat<(BigInst3 RegsC:$dst, RegsC:$src, simm6:$imm),
 // CHECK-NEXT: } // if
 // CHECK: case Arch::SmallInst3:
 // CHECK-NEXT:  if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT: MI.getOperand(1).isReg() &&
-// CHECK-NEXT: ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(1).getReg()) &&
+// CHECK-NEXT: getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(1).getReg()) &&
 // CHECK-NEXT: ArchValidateMCOperandForUncompress(MI.getOperand(2), STI, 1 /* simm6 */) &&
 // CHECK-NEXT: ArchValidateMCOperandForUncompress(MI.getOperand(2), STI, 2 /* simm12 */)) {
 // CHECK-NEXT: // big $dst, $src, $imm
@@ -225,9 +225,9 @@ def : CompressPat<(BigInst3 RegsC:$dst, RegsC:$src, simm6:$imm),
 // CHECK-LABEL: isCompressibleInst
 // CHECK:  case Arch::BigInst: {
 // CHECK-NEXT:  if (MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// CHECK-NEXT:    ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT:    getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:    MI.getOperand(1).isReg() && MI.getOperand(1).getReg().isPhysical() &&
-// CHECK-NEXT:    ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(1).getReg()) &&
+// CHECK-NEXT:    getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(1).getReg()) &&
 // CHECK-NEXT:    MI.getOperand(2).isImm() &&
 // CHECK-NEXT:    ArchValidateMachineOperand(MI.getOperand(2), &STI, 1 /* simm6 */)) {
 // CHECK-NEXT:    // small $dst, $addr
@@ -237,9 +237,9 @@ def : CompressPat<(BigInst3 RegsC:$dst, RegsC:$src, simm6:$imm),
 // CHECK-NEXT: } // if
 // CHECK:  case Arch::BigInst2: {
 // CHECK-NEXT:  if (MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// CHECK-NEXT:    ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT:    getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:    MI.getOperand(1).isReg() && MI.getOperand(1).getReg().isPhysical() &&
-// CHECK-NEXT:    ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(1).getReg()) &&
+// CHECK-NEXT:    getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(1).getReg()) &&
 // CHECK-NEXT:    MI.getOperand(2).isImm() &&
 // CHECK-NEXT:    ArchValidateMachineOperand(MI.getOperand(2), &STI, 1 /* simm6 */)) {
 // CHECK-NEXT:    // small $dst, $src, $imm
@@ -250,9 +250,9 @@ def : CompressPat<(BigInst3 RegsC:$dst, RegsC:$src, simm6:$imm),
 // CHECK-NEXT: } // if
 // CHECK:  case Arch::BigInst3: {
 // CHECK-NEXT:  if (MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// CHECK-NEXT:    ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT:    getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:    MI.getOperand(1).isReg() && MI.getOperand(1).getReg().isPhysical() &&
-// CHECK-NEXT:    ArchMCRegisterClasses[Arch::RegsCRegClassID].contains(MI.getOperand(1).getReg()) &&
+// CHECK-NEXT:    getArchMCRegisterClass(Arch::RegsCRegClassID).contains(MI.getOperand(1).getReg()) &&
 // CHECK-NEXT:    MI.getOperand(2).isImm() &&
 // CHECK-NEXT:    ArchValidateMachineOperand(MI.getOperand(2), &STI, 1 /* simm6 */)) {
 // CHECK-NEXT:    // small $dst, $addr

--- a/llvm/test/TableGen/RegClassByHwModeCompressPat.td
+++ b/llvm/test/TableGen/RegClassByHwModeCompressPat.td
@@ -91,7 +91,7 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:     if (MI.getOperand(1).isReg() &&
 // CHECK-NEXT:         (MI.getOperand(1).getReg() == MyTarget::RegisterByHwMode::getNullReg(HwModeId)) &&
 // CHECK-NEXT:         MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(0).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(0).getReg())) {
 // CHECK-NEXT:       // ptr_mov.zero $dst
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::PTR_MOV_ZERO);
 // CHECK-NEXT:       // Operand: dst
@@ -102,7 +102,7 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:     if (MI.getOperand(1).isReg() && MI.getOperand(0).isReg() &&
 // CHECK-NEXT:         (MI.getOperand(1).getReg() == MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(1).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(1).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(1).getReg())) {
 // CHECK-NEXT:       // ptr_mov.tied $dst, $src
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::PTR_MOV_TIED);
 // CHECK-NEXT:       // Operand: dst
@@ -113,9 +113,9 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:       return true;
 // CHECK-NEXT:     } // if
 // CHECK-NEXT:     if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(1).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(1).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(1).getReg())) {
 // CHECK-NEXT:       // ptr_mov.small $dst, $src
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::PTR_MOV_SMALL);
 // CHECK-NEXT:       // Operand: dst
@@ -131,7 +131,7 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:     if (MI.getOperand(1).isReg() &&
 // CHECK-NEXT:         (MI.getOperand(1).getReg() == MyTarget::X0) &&
 // CHECK-NEXT:         MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // CHECK-NEXT:       // x_mov.zero $dst
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::X_MOV_ZERO);
 // CHECK-NEXT:       // Operand: dst
@@ -142,7 +142,7 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:     if (MI.getOperand(1).isReg() && MI.getOperand(0).isReg() &&
 // CHECK-NEXT:         (MI.getOperand(1).getReg() == MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(1).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(1).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(1).getReg())) {
 // CHECK-NEXT:       // x_mov.tied $dst, $src
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::X_MOV_TIED);
 // CHECK-NEXT:       // Operand: dst
@@ -153,9 +153,9 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:       return true;
 // CHECK-NEXT:     } // if
 // CHECK-NEXT:     if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(1).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(1).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(1).getReg())) {
 // CHECK-NEXT:       // x_mov.small $dst, $src
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::X_MOV_SMALL);
 // CHECK-NEXT:       // Operand: dst
@@ -179,9 +179,9 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:   default: return false;
 // CHECK-NEXT:   case MyTarget::PTR_MOV_SMALL: {
 // CHECK-NEXT:     if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(1).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(1).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(1).getReg())) {
 // CHECK-NEXT:       // ptr_mov $dst, $src
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::PTR_MOV);
 // CHECK-NEXT:       // Operand: dst
@@ -195,9 +195,9 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:   } // case PTR_MOV_SMALL
 // CHECK-NEXT:   case MyTarget::PTR_MOV_TIED: {
 // CHECK-NEXT:     if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(0).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(0).getReg())) {
 // CHECK-NEXT:       // ptr_mov $dst, $src
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::PTR_MOV);
 // CHECK-NEXT:       // Operand: dst
@@ -211,7 +211,7 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:   } // case PTR_MOV_TIED
 // CHECK-NEXT:   case MyTarget::PTR_MOV_ZERO: {
 // CHECK-NEXT:     if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(0).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(0).getReg())) {
 // CHECK-NEXT:       // ptr_mov $dst, $src
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::PTR_MOV);
 // CHECK-NEXT:       // Operand: dst
@@ -225,9 +225,9 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:   } // case PTR_MOV_ZERO
 // CHECK-NEXT:   case MyTarget::X_MOV_SMALL: {
 // CHECK-NEXT:     if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(1).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(1).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(1).getReg())) {
 // CHECK-NEXT:       // x_mov $dst, $src
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::X_MOV);
 // CHECK-NEXT:       // Operand: dst
@@ -241,9 +241,9 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:   } // case X_MOV_SMALL
 // CHECK-NEXT:   case MyTarget::X_MOV_TIED: {
 // CHECK-NEXT:     if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // CHECK-NEXT:       // x_mov $dst, $src
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::X_MOV);
 // CHECK-NEXT:       // Operand: dst
@@ -257,7 +257,7 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:   } // case X_MOV_TIED
 // CHECK-NEXT:   case MyTarget::X_MOV_ZERO: {
 // CHECK-NEXT:     if (MI.getOperand(0).isReg() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // CHECK-NEXT:       // x_mov $dst, $src
 // CHECK-NEXT:       OutInst.setOpcode(MyTarget::X_MOV);
 // CHECK-NEXT:       // Operand: dst
@@ -280,9 +280,9 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:   default: return false;
 // CHECK-NEXT:   case MyTarget::PTR_MOV: {
 // CHECK-NEXT:     if (MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(1).isReg() && MI.getOperand(1).getReg().isPhysical() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(1).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(1).getReg())) {
 // CHECK-NEXT:       // ptr_mov.small $dst, $src
 // CHECK-NEXT:       // Operand: dst
 // CHECK-NEXT:       // Operand: src
@@ -291,7 +291,7 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:     if (MI.getOperand(1).isReg() && MI.getOperand(0).isReg() &&
 // CHECK-NEXT:         (MI.getOperand(1).getReg() == MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(1).isReg() && MI.getOperand(1).getReg().isPhysical() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(1).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(1).getReg())) {
 // CHECK-NEXT:       // ptr_mov.tied $dst, $src
 // CHECK-NEXT:       // Operand: dst
 // CHECK-NEXT:       // Operand: src
@@ -300,7 +300,7 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:     if (MI.getOperand(1).isReg() &&
 // CHECK-NEXT:         (MI.getOperand(1).getReg() == MyTarget::RegisterByHwMode::getNullReg(HwModeId)) &&
 // CHECK-NEXT:         MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]].contains(MI.getOperand(0).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTargetRegClassByHwModeTables[HwModeId][MyTarget::PtrRC]).contains(MI.getOperand(0).getReg())) {
 // CHECK-NEXT:       // ptr_mov.zero $dst
 // CHECK-NEXT:       // Operand: dst
 // CHECK-NEXT:       return true;
@@ -309,9 +309,9 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:   } // case PTR_MOV
 // CHECK-NEXT:   case MyTarget::X_MOV: {
 // CHECK-NEXT:     if (MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(0).getReg()) &&
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(1).isReg() && MI.getOperand(1).getReg().isPhysical() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(1).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(1).getReg())) {
 // CHECK-NEXT:       // x_mov.small $dst, $src
 // CHECK-NEXT:       // Operand: dst
 // CHECK-NEXT:       // Operand: src
@@ -320,7 +320,7 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:     if (MI.getOperand(1).isReg() && MI.getOperand(0).isReg() &&
 // CHECK-NEXT:         (MI.getOperand(1).getReg() == MI.getOperand(0).getReg()) &&
 // CHECK-NEXT:         MI.getOperand(1).isReg() && MI.getOperand(1).getReg().isPhysical() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(1).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(1).getReg())) {
 // CHECK-NEXT:       // x_mov.tied $dst, $src
 // CHECK-NEXT:       // Operand: dst
 // CHECK-NEXT:       // Operand: src
@@ -329,7 +329,7 @@ def : CompressPat<(PTR_MOV PtrRC:$dst, PtrRC:$src),
 // CHECK-NEXT:     if (MI.getOperand(1).isReg() &&
 // CHECK-NEXT:         (MI.getOperand(1).getReg() == MyTarget::X0) &&
 // CHECK-NEXT:         MI.getOperand(0).isReg() && MI.getOperand(0).getReg().isPhysical() &&
-// CHECK-NEXT:         MyTargetMCRegisterClasses[MyTarget::XRegsRegClassID].contains(MI.getOperand(0).getReg())) {
+// CHECK-NEXT:         getMyTargetMCRegisterClass(MyTarget::XRegsRegClassID).contains(MI.getOperand(0).getReg())) {
 // CHECK-NEXT:       // x_mov.zero $dst
 // CHECK-NEXT:       // Operand: dst
 // CHECK-NEXT:       return true;

--- a/llvm/test/TableGen/RegisterClassCopyCost.td
+++ b/llvm/test/TableGen/RegisterClassCopyCost.td
@@ -7,10 +7,11 @@
 
 include "llvm/Target/Target.td"
 
-// CHECK: extern const MCRegisterClass MyTargetMCRegisterClasses[] = {
-// CHECK-NEXT: { GPR32, GPR32Bits, 0, 32, 2, sizeof(GPR32Bits), MyTarget::GPR32RegClassID, 1, true, false },
-// CHECK-NEXT:   { SPECIAL_CLASS, SPECIAL_CLASSBits, 6, 32, 1, sizeof(SPECIAL_CLASSBits), MyTarget::SPECIAL_CLASSRegClassID, 255, true, false },
-// CHECK-NEXT: };
+// CHECK: static constexpr MCRegisterClassStorage<{{[0-9, ]+}}> MyTargetMCRegisterClassStorage = {
+// CHECK-NEXT: {
+// CHECK-NEXT:   { {{[^,]+}}, {{[^,]+}}, 0, 32, 2, {{[0-9]+}}, MyTarget::GPR32RegClassID, 1, true, false },
+// CHECK-NEXT:   { {{[^,]+}}, {{[^,]+}}, 6, 32, 1, {{[0-9]+}}, MyTarget::SPECIAL_CLASSRegClassID, 255, true, false },
+// CHECK-NEXT: },
 
 def MyTargetISA : InstrInfo;
 def MyTarget : Target { let InstructionSet = MyTargetISA; }

--- a/llvm/test/TableGen/RegisterClassCopyCost.td
+++ b/llvm/test/TableGen/RegisterClassCopyCost.td
@@ -7,7 +7,7 @@
 
 include "llvm/Target/Target.td"
 
-// CHECK: static constexpr MCRegisterClassStorage<{{[0-9, ]+}}> MyTargetMCRegisterClassStorage = {
+// CHECK: extern const MCRegisterClassStorage<{{[0-9, ]+}}> MyTargetMCRegisterClassStorage = {
 // CHECK-NEXT: {
 // CHECK-NEXT:   { {{[^,]+}}, {{[^,]+}}, 0, 32, 2, {{[0-9]+}}, MyTarget::GPR32RegClassID, 1, true, false },
 // CHECK-NEXT:   { {{[^,]+}}, {{[^,]+}}, 6, 32, 1, {{[0-9]+}}, MyTarget::SPECIAL_CLASSRegClassID, 255, true, false },

--- a/llvm/utils/TableGen/CompressInstEmitter.cpp
+++ b/llvm/utils/TableGen/CompressInstEmitter.cpp
@@ -806,7 +806,8 @@ void CompressInstEmitter::emitCompressInstEmitter(raw_ostream &OS,
               if (EType == EmitterType::CheckCompress)
                 CondStream << " && MI.getOperand(" << OpIdx
                            << ").getReg().isPhysical()";
-              CondStream << CondSep << TargetName << "MCRegisterClasses[";
+              CondStream << CondSep << "get" << TargetName
+                         << "MCRegisterClass(";
               if (ClassRec->isSubClassOf("RegClassByHwMode")) {
                 CondStream << TargetName << "RegClassByHwModeTables[HwModeId]["
                            << TargetName << "::" << ClassRec->getName() << "]";
@@ -814,7 +815,7 @@ void CompressInstEmitter::emitCompressInstEmitter(raw_ostream &OS,
                 CondStream << TargetName << "::" << ClassRec->getName()
                            << "RegClassID";
               }
-              CondStream << "].contains(MI.getOperand(" << OpIdx
+              CondStream << ").contains(MI.getOperand(" << OpIdx
                          << ").getReg())";
             }
 

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -64,6 +64,8 @@ class RegisterInfoEmitter {
   const CodeGenTarget Target;
   CodeGenRegBank &RegBank;
 
+  std::string MCRegisterClassStorageType;
+
 public:
   RegisterInfoEmitter(const RecordKeeper &R)
       : Records(R), Target(R), RegBank(Target.getRegBank()) {
@@ -128,9 +130,9 @@ void RegisterInfoEmitter::runEnums(raw_ostream &OS, raw_ostream &MainOS,
 
   NamespaceEmitter LlvmNS(OS, "llvm");
 
-  OS << "class MCRegisterClass;\n"
-     << "extern const MCRegisterClass " << Target.getName()
-     << "MCRegisterClasses[];\n\n";
+  OS << "class MCRegisterClass;\n";
+  OS << "const MCRegisterClass &get" << Target.getName()
+     << "MCRegisterClass(unsigned RC);\n";
 
   {
     NamespaceEmitter RegNS(OS, Namespace);
@@ -619,6 +621,8 @@ public:
     Values[v] = true;
   }
 
+  unsigned byteSize() const { return (Values.size() + 7) / 8; }
+
   void print(raw_ostream &OS) { printBitVectorAsHex(OS, Values, 8); }
 };
 
@@ -1071,65 +1075,97 @@ void RegisterInfoEmitter::runMCDesc(raw_ostream &OS, raw_ostream &MainOS,
 
   const auto &RegisterClasses = RegBank.getRegClasses();
 
+  OS << "// Register classes...\n";
+
   SequenceToOffsetTable<std::string> RegClassStrings;
+  SmallVector<unsigned> BitSetSizes;
+  BitSetSizes.reserve(RegisterClasses.size());
+  unsigned TotalRegCount = 0;
+  unsigned TotalBitSetSize = 0;
+  for (const auto &RC : RegisterClasses) {
+    ArrayRef<const Record *> Order = RC.getOrder();
+    RegClassStrings.add(RC.getName());
 
-  // Loop over all of the register classes... emitting each one.
-  {
-    AnonNamespaceEmitter AnonNS(OS);
-    OS << "// Register classes...\n";
-
-    // Emit the register enum value arrays for each RegisterClass
-    for (const auto &RC : RegisterClasses) {
-      ArrayRef<const Record *> Order = RC.getOrder();
-
-      // Give the register class a legal C name if it's anonymous.
-      const std::string &Name = RC.getName();
-
-      RegClassStrings.add(Name);
-
-      // Emit the register list now (unless it would be a zero-length array).
-      if (!Order.empty()) {
-        OS << "  // " << Name << " Register Class...\n"
-           << "  const MCPhysReg " << Name << "[] = {\n    ";
-        for (const Record *Reg : Order)
-          OS << getQualifiedName(Reg) << ", ";
-        OS << "\n  };\n\n";
-
-        OS << "  // " << Name << " Bit set.\n"
-           << "  const uint8_t " << Name << "Bits[] = {\n    ";
-        BitVectorEmitter BVE;
-        for (const Record *Reg : Order)
-          BVE.add(RegBank.getReg(Reg)->EnumValue);
-        BVE.print(OS);
-        OS << "\n  };\n\n";
-      }
-    }
+    unsigned MaxRegVal = 0;
+    for (const Record *Reg : Order)
+      MaxRegVal = std::max(MaxRegVal, RegBank.getReg(Reg)->EnumValue);
+    // Round to next byte size.
+    BitSetSizes.push_back(Order.empty() ? 0 : (MaxRegVal / 8) + 1);
+    TotalRegCount += Order.size();
+    TotalBitSetSize += BitSetSizes.back();
   }
 
   RegClassStrings.layout();
   RegClassStrings.emitStringLiteralDef(
       OS, Twine("extern const char ") + TargetName + "RegClassStrings[]");
 
-  OS << "extern const MCRegisterClass " << TargetName
-     << "MCRegisterClasses[] = {\n";
+  raw_string_ostream(MCRegisterClassStorageType)
+      << "MCRegisterClassStorage<" << RegisterClasses.size() << ", "
+      << TotalRegCount << ", " << TotalBitSetSize << ">";
+  OS << "extern const " << MCRegisterClassStorageType << " " << TargetName
+     << "MCRegisterClassStorage = {\n"
+     << "  {\n";
 
-  for (const auto &RC : RegisterClasses) {
+  unsigned RegCount = 0;   // Number of entries in registers array.
+  unsigned BitSetSize = 0; // Number of entries in bitset array.
+  for (const auto &[Idx, RC] : enumerate(RegisterClasses)) {
     ArrayRef<const Record *> Order = RC.getOrder();
-    std::string RCName = Order.empty() ? "nullptr" : RC.getName();
-    std::string RCBitsName = Order.empty() ? "nullptr" : RC.getName() + "Bits";
-    std::string RCBitsSize = Order.empty() ? "0" : "sizeof(" + RCBitsName + ")";
     uint32_t RegSize = 0;
     if (RC.RSI.isSimple())
       RegSize = RC.RSI.getSimple().RegSize;
-    OS << "  { " << RCName << ", " << RCBitsName << ", "
-       << RegClassStrings.get(RC.getName()) << ", " << RegSize << ", "
-       << RC.getOrder().size() << ", " << RCBitsSize << ", "
+    OS << "    { " << (RegisterClasses.size() - Idx)
+       << " * sizeof(MCRegisterClass)"
+       << " + sizeof(MCPhysReg) * " << RegCount << ", "
+       << (RegisterClasses.size() - Idx) << " * sizeof(MCRegisterClass)"
+       << " + sizeof(MCPhysReg) * " << TotalRegCount << " + " << BitSetSize
+       << ", " << RegClassStrings.get(RC.getName()) << ", " << RegSize << ", "
+       << RC.getOrder().size() << ", " << BitSetSizes[Idx] << ", "
        << RC.getQualifiedIdName() << ", " << static_cast<unsigned>(RC.CopyCost)
        << ", " << (RC.Allocatable ? "true" : "false") << ", "
        << (RC.getBaseClassOrder() ? "true" : "false") << " },\n";
+
+    RegCount += Order.size();
+    BitSetSize += BitSetSizes[Idx];
   }
 
-  OS << "};\n\n";
+  OS << "  },\n  {\n";
+
+  // Emit registers.
+  // TODO: these sequences often have overlaps which could be deduplicated.
+  RegCount = 0;
+  for (const auto &RC : RegisterClasses) {
+    ArrayRef<const Record *> Order = RC.getOrder();
+    if (Order.empty())
+      continue;
+    OS << "    /* " << RegCount << " */ ";
+    for (const Record *Reg : Order)
+      OS << getQualifiedName(Reg) << ", ";
+    OS << "\n";
+    RegCount += Order.size();
+  }
+
+  OS << "  },\n  {\n";
+
+  // Emit register bit sets.
+  BitSetSize = 0;
+  for (const auto &[Idx, RC] : enumerate(RegisterClasses)) {
+    ArrayRef<const Record *> Order = RC.getOrder();
+    if (!Order.empty()) {
+      OS << "    /* " << BitSetSize << " */ ";
+      BitVectorEmitter BVE;
+      for (const Record *Reg : Order)
+        BVE.add(RegBank.getReg(Reg)->EnumValue);
+      BVE.print(OS);
+      OS << "\n";
+      BitSetSize += BitSetSizes[Idx];
+    }
+  }
+  OS << "  }\n};\n\n";
+  OS << "const MCRegisterClass &get" << Target.getName()
+     << "MCRegisterClass(unsigned RC) {\n"
+     << "  return " << Target.getName()
+     << "MCRegisterClassStorage.Classes[RC];\n"
+     << "}\n\n";
 
   EmitRegMappingTables(OS, Regs, false);
 
@@ -1152,12 +1188,13 @@ void RegisterInfoEmitter::runMCDesc(raw_ostream &OS, raw_ostream &MainOS,
      << "unsigned DwarfFlavour = 0, unsigned EHFlavour = 0, unsigned PC = 0) "
         "{\n"
      << "  RI->InitMCRegisterInfo(" << TargetName << "RegDesc, "
-     << Regs.size() + 1 << ", RA, PC, " << TargetName << "MCRegisterClasses, "
-     << RegisterClasses.size() << ", " << TargetName << "RegUnitRoots, "
-     << RegBank.getNumNativeRegUnits() << ", " << TargetName << "RegDiffLists, "
-     << TargetName << "LaneMaskLists, " << TargetName << "RegStrings, "
-     << TargetName << "RegClassStrings, " << TargetName << "SubRegIdxLists, "
-     << (llvm::size(SubRegIndices) + 1) << ",\n"
+     << Regs.size() + 1 << ", RA, PC, " << TargetName
+     << "MCRegisterClassStorage.Classes, " << RegisterClasses.size() << ", "
+     << TargetName << "RegUnitRoots, " << RegBank.getNumNativeRegUnits() << ", "
+     << TargetName << "RegDiffLists, " << TargetName << "LaneMaskLists, "
+     << TargetName << "RegStrings, " << TargetName << "RegClassStrings, "
+     << TargetName << "SubRegIdxLists, " << (llvm::size(SubRegIndices) + 1)
+     << ",\n"
      << TargetName << "RegEncodingTable, "
      << (Target.getRegistersAreIntervals() ? TargetName + "RegUnitIntervals"
                                            : "nullptr")
@@ -1295,8 +1332,8 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
   NamespaceEmitter LlvmNS(OS, "llvm");
 
   // Get access to MCRegisterClass data.
-  OS << "extern const MCRegisterClass " << Target.getName()
-     << "MCRegisterClasses[];\n";
+  OS << "extern const " << MCRegisterClassStorageType << " " << Target.getName()
+     << "MCRegisterClassStorage;\n";
 
   // Start out by emitting each of the register classes.
   const auto &RegisterClasses = RegBank.getRegClasses();
@@ -1485,8 +1522,8 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
             OS << " };\n";
           }
         }
-        OS << "  const MCRegisterClass &MCR = " << Target.getName()
-           << "MCRegisterClasses[" << RC.getQualifiedName() + "RegClassID];\n"
+        OS << "  const MCRegisterClass &MCR = get" << Target.getName()
+           << "MCRegisterClass(" << RC.getQualifiedName() + "RegClassID);\n"
            << "  const ArrayRef<MCPhysReg> Order[] = {\n"
            << "    ArrayRef(MCR.begin(), MCR.getNumRegs()";
         for (unsigned oi = 1, oe = RC.getNumOrders(); oi != oe; ++oi)
@@ -1506,9 +1543,9 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
 
     for (const auto &RC : RegisterClasses) {
       OS << "  extern const TargetRegisterClass " << RC.getName()
-         << "RegClass = {\n    " << '&' << Target.getName()
-         << "MCRegisterClasses[" << RC.getName() << "RegClassID],\n    "
-         << RC.getName() << "SubClassMask,\n    SuperRegIdxSeqs + "
+         << "RegClass = {\n    " << "&" << Target.getName()
+         << "MCRegisterClassStorage.Classes[" << RC.getName() << "RegClassID],"
+         << "\n    " << RC.getName() << "SubClassMask,\n    SuperRegIdxSeqs + "
          << SuperRegIdxSeqs.get(SuperRegIdxLists[RC.EnumValue]) << ",\n    ";
       printMask(OS, RC.LaneMask);
       OS << ",\n    " << (unsigned)RC.AllocationPriority << ",\n    "
@@ -1782,7 +1819,7 @@ void RegisterInfoEmitter::runTargetDesc(raw_ostream &OS, raw_ostream &MainOS,
   printMask(OS, RegBank.CoveringLanes);
   OS << formatv(R"(, {0}RegClassInfos, {0}VTLists, HwMode) {{
   InitMCRegisterInfo({0}RegDesc, {1}, RA, PC,
-    {0}MCRegisterClasses, {2}, {0}RegUnitRoots, {3}, {0}RegDiffLists,
+    &get{0}MCRegisterClass(0), {2}, {0}RegUnitRoots, {3}, {0}RegDiffLists,
     {0}LaneMaskLists, {0}RegStrings, {0}RegClassStrings, {0}SubRegIdxLists, {4},
     {0}RegEncodingTable, {5});
 


### PR DESCRIPTION
MCRegisterClasses currently store pointers to the register list and the
bit set. Store these three types together in one data structure and use
relative offsets to avoid these relocations and move the large
MCRegisterClasses array from .data.rel.ro into .data. This reduces the
amount of data that needs to be relocated by 86 KB.

This has two side effects: first, MCRegisterClass is not copyable and
the few uses that did copy were changed. Second, the MCRegisterClasses
array is no longer easily accessible as a global (well, it *technically*
is, but that requires the type of the entire storage struct, which I
don't want to expose). Therefore, these accesses need to go through a
function; which shouldn't be too costly and be inlined in an LTO build.
