### PR TITLE
[offload] check olInit error in unittests initialisation

### DIFF
--- a/offload/unittests/OffloadAPI/common/Environment.cpp
+++ b/offload/unittests/OffloadAPI/common/Environment.cpp
@@ -28,7 +28,14 @@ struct OffloadInitWrapper {
       std::abort();
     }
   }
-  ~OffloadInitWrapper() { olShutDown(); }
+  ~OffloadInitWrapper() {
+    if (ol_result_t Res = olShutDown()) {
+      errs() << "olShutDown failed: "
+             << (Res->Details ? Res->Details : "(no details)") << " (code "
+             << Res->Code << ")\n";
+      std::abort();
+    }
+  }
 };
 static OffloadInitWrapper Wrapper{};
 #endif

--- a/offload/unittests/OffloadAPI/common/Environment.cpp
+++ b/offload/unittests/OffloadAPI/common/Environment.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <OffloadAPI.h>
+#include <cstdlib>
 #include <fstream>
 
 using namespace llvm;
@@ -19,7 +20,14 @@ using namespace llvm;
 // test, while having sensible lifetime for the platform environment
 #ifndef DISABLE_WRAPPER
 struct OffloadInitWrapper {
-  OffloadInitWrapper() { olInit(nullptr); }
+  OffloadInitWrapper() {
+    if (ol_result_t Res = olInit(nullptr)) {
+      errs() << "olInit failed: "
+             << (Res->Details ? Res->Details : "(no details)") << " (code "
+             << Res->Code << ")\n";
+      std::abort();
+    }
+  }
   ~OffloadInitWrapper() { olShutDown(); }
 };
 static OffloadInitWrapper Wrapper{};


### PR DESCRIPTION
if olInit fails, it leaves liboffload in an inconsistent state (proper cleanup will be addressed in a follow-up patch). This can lead to seemingly unrelated test failures (e.g. the host device is missing). This patch makes such tests fail immediately with a clear error message.