### PR TITLE
[BOLT] Update DW_AT_GNU_locviews when rewriting .debug_loclists

### DIFF
--- a/bolt/include/bolt/Core/DebugData.h
+++ b/bolt/include/bolt/Core/DebugData.h
@@ -14,6 +14,7 @@
 #ifndef BOLT_CORE_DEBUG_DATA_H
 #define BOLT_CORE_DEBUG_DATA_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/DIE.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
@@ -104,12 +105,25 @@ inline raw_ostream &operator<<(raw_ostream &OS,
 /// DebugAddressRangesVector - represents a set of absolute address ranges.
 using DebugAddressRangesVector = SmallVector<DebugAddressRange, 2>;
 
+/// A single GNU location view pair (DW_AT_GNU_locviews), describing the
+/// begin/end view numbers associated with a location list entry. GCC emits
+/// these as a sequence of ULEB128 pairs immediately preceding the matching
+/// loclist in .debug_loclists.
+struct DebugLocationViewPair {
+  uint64_t ViewBegin;
+  uint64_t ViewEnd;
+};
+
 /// Address range with location used by .debug_loc section.
 /// More compact than DWARFLocationEntry and uses absolute addresses.
 struct DebugLocationEntry {
   uint64_t LowPC;
   uint64_t HighPC;
   SmallVector<uint8_t, 4> Expr;
+  /// GNU location view pair (DW_AT_GNU_locviews) tied to this entry. Only
+  /// meaningful when the DIE has DW_AT_GNU_locviews; it travels with the entry
+  /// through translation/merge/sort so it stays 1:1 with the emitted range.
+  DebugLocationViewPair View{0, 0};
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS,
@@ -161,9 +175,9 @@ class DebugRangesSectionWriter {
 public:
   DebugRangesSectionWriter();
 
-  DebugRangesSectionWriter(RangesWriterKind K) : Kind(K){};
+  DebugRangesSectionWriter(RangesWriterKind K) : Kind(K) {};
 
-  virtual ~DebugRangesSectionWriter(){};
+  virtual ~DebugRangesSectionWriter() {};
 
   /// Add ranges with caching.
   virtual uint64_t
@@ -234,7 +248,7 @@ public:
     RangesBuffer = std::make_unique<DebugBufferVector>();
     RangesStream = std::make_unique<raw_svector_ostream>(*RangesBuffer);
   };
-  virtual ~DebugRangeListsSectionWriter(){};
+  virtual ~DebugRangeListsSectionWriter() {};
 
   void setAddressWriter(DebugAddrWriter *AddrW) { AddrWriter = AddrW; }
 
@@ -318,7 +332,7 @@ public:
   DebugAddrWriter() = delete;
   DebugAddrWriter(BinaryContext *BC_) : DebugAddrWriter(BC_, UCHAR_MAX) {};
   DebugAddrWriter(BinaryContext *BC_, uint8_t AddressByteSize);
-  virtual ~DebugAddrWriter(){};
+  virtual ~DebugAddrWriter() {};
   /// Given an address returns an index in .debug_addr.
   /// Adds Address to map.
   uint32_t getIndexFromAddress(uint64_t Address, DWARFUnit &CU);
@@ -553,11 +567,12 @@ protected:
 
 public:
   DebugLocWriter() { init(); };
-  virtual ~DebugLocWriter(){};
+  virtual ~DebugLocWriter() {};
 
   /// Writes out location lists and stores internal patches.
   virtual void addList(DIEBuilder &DIEBldr, DIE &Die, DIEValue &AttrInfo,
-                       DebugLocationsVector &LocList);
+                       DebugLocationsVector &LocList,
+                       bool HasGNULocViews = false);
 
   /// Writes out locations in to a local buffer, and adds Debug Info patches.
   virtual void finalize(DIEBuilder &DIEBldr, DIE &Die);
@@ -627,12 +642,19 @@ public:
   }
 
   /// Stores location lists internally to be written out during finalize phase.
-  virtual void addList(DIEBuilder &DIEBldr, DIE &Die, DIEValue &AttrInfo,
-                       DebugLocationsVector &LocList) override;
+  void addList(DIEBuilder &DIEBldr, DIE &Die, DIEValue &AttrInfo,
+               DebugLocationsVector &LocList,
+               bool HasGNULocViews = false) override;
 
   /// Writes out locations in to a local buffer and applies debug info patches.
   void finalize(DIEBuilder &DIEBldr, DIE &Die) override;
 
+  /// Updates DW_AT_GNU_locviews using the CU's final offset in .debug_loclists.
+  /// \p GlobalCUOffset is the absolute offset of this CU contribution
+  /// (including its unit header) in the merged section. View bytes are
+  /// addressed relative to the CU body that follows the header and loclist
+  /// offset table.
+  void applyViewOffsets(DIEBuilder &Bldr, uint64_t GlobalCUOffset);
   /// Returns CU ID.
   /// For Skeleton CU it is a CU Offset.
   /// For DWO CU it is a DWO ID.
@@ -653,6 +675,16 @@ public:
 private:
   /// Writes out locations in to a local buffer and applies debug info patches.
   void finalizeDWARF5(DIEBuilder &DIEBldr, DIE &Die);
+
+  struct LocViewPatch {
+    DIE *Die;
+    uint64_t LocalViewOffset;
+  };
+
+  void writeDWARF5LocList(DIEBuilder &DIEBldr, DIE &Die, DIEValue &AttrInfo,
+                          DebugLocationsVector &LocList, bool HasGNULocViews);
+
+  std::vector<LocViewPatch> LocViewPatches;
 
   DebugAddrWriter &AddrWriter;
   DWARFUnit &CU;

--- a/bolt/lib/Core/DebugData.cpp
+++ b/bolt/lib/Core/DebugData.cpp
@@ -571,7 +571,8 @@ void DebugLocWriter::init() {
 }
 
 void DebugLocWriter::addList(DIEBuilder &DIEBldr, DIE &Die, DIEValue &AttrInfo,
-                             DebugLocationsVector &LocList) {
+                             DebugLocationsVector &LocList,
+                             bool HasGNULocViews) {
   if (LocList.empty()) {
     replaceLocValbyForm(DIEBldr, Die, AttrInfo, AttrInfo.getForm(),
                         DebugLocWriter::EmptyListOffset);
@@ -673,64 +674,96 @@ static void writeLegacyLocList(DIEValue &AttrInfo,
   replaceLocValbyForm(DIEBldr, Die, AttrInfo, AttrInfo.getForm(), EntryOffset);
 }
 
-static void writeDWARF5LocList(uint32_t &NumberOfEntries, DIEValue &AttrInfo,
-                               DebugLocationsVector &LocList, DIE &Die,
-                               DIEBuilder &DIEBldr, DebugAddrWriter &AddrWriter,
-                               DebugBufferVector &LocBodyBuffer,
-                               std::vector<uint32_t> &RelativeLocListOffsets,
-                               DWARFUnit &CU,
-                               raw_svector_ostream &LocBodyStream) {
+void DebugLoclistWriter::writeDWARF5LocList(DIEBuilder &DIEBldr, DIE &Die,
+                                            DIEValue &AttrInfo,
+                                            DebugLocationsVector &LocList,
+                                            bool HasGNULocViews) {
 
   replaceLocValbyForm(DIEBldr, Die, AttrInfo, dwarf::DW_FORM_loclistx,
                       NumberOfEntries);
 
-  RelativeLocListOffsets.push_back(LocBodyBuffer.size());
+  if (HasGNULocViews && !LocList.empty()) {
+    const uint64_t ViewLocalOff = LocBodyBuffer->size();
+    // Emit exactly one view pair per emitted range so the view list stays in
+    // sync with the (possibly merged) loclist -> no orphaned/surplus pairs.
+    for (const DebugLocationEntry &E : LocList) {
+      encodeULEB128(E.View.ViewBegin, *LocBodyStream);
+      encodeULEB128(E.View.ViewEnd, *LocBodyStream);
+    }
+    LocViewPatches.push_back({&Die, ViewLocalOff});
+  } else if (HasGNULocViews) {
+    DIEBldr.deleteValue(&Die, dwarf::DW_AT_GNU_locviews);
+  }
+
+  RelativeLocListOffsets.push_back(LocBodyBuffer->size());
   ++NumberOfEntries;
   if (LocList.empty()) {
-    writeEmptyListDwarf5(LocBodyStream);
+    writeEmptyListDwarf5(*LocBodyStream);
     return;
   }
 
   auto writeExpression = [&](uint32_t Index) -> void {
     const DebugLocationEntry &Entry = LocList[Index];
-    encodeULEB128(Entry.Expr.size(), LocBodyStream);
-    LocBodyStream << StringRef(
+    encodeULEB128(Entry.Expr.size(), *LocBodyStream);
+    *LocBodyStream << StringRef(
         reinterpret_cast<const char *>(Entry.Expr.data()), Entry.Expr.size());
   };
   for (unsigned I = 0; I < LocList.size();) {
     if (emitWithBase<DebugLocationsVector, dwarf::LoclistEntries,
-                     DebugLocationEntry>(LocBodyStream, LocList, AddrWriter, CU,
-                                         I, dwarf::DW_LLE_base_addressx,
+                     DebugLocationEntry>(*LocBodyStream, LocList, AddrWriter,
+                                         CU, I, dwarf::DW_LLE_base_addressx,
                                          dwarf::DW_LLE_offset_pair,
                                          writeExpression))
       continue;
 
     const DebugLocationEntry &Entry = LocList[I];
-    support::endian::write(LocBodyStream,
+    support::endian::write(*LocBodyStream,
                            static_cast<uint8_t>(dwarf::DW_LLE_startx_length),
                            llvm::endianness::little);
     const uint32_t Index = AddrWriter.getIndexFromAddress(Entry.LowPC, CU);
-    encodeULEB128(Index, LocBodyStream);
-    encodeULEB128(Entry.HighPC - Entry.LowPC, LocBodyStream);
+    encodeULEB128(Index, *LocBodyStream);
+    encodeULEB128(Entry.HighPC - Entry.LowPC, *LocBodyStream);
     writeExpression(I);
     ++I;
   }
 
-  support::endian::write(LocBodyStream,
+  support::endian::write(*LocBodyStream,
                          static_cast<uint8_t>(dwarf::DW_LLE_end_of_list),
                          llvm::endianness::little);
 }
 
 void DebugLoclistWriter::addList(DIEBuilder &DIEBldr, DIE &Die,
                                  DIEValue &AttrInfo,
-                                 DebugLocationsVector &LocList) {
+                                 DebugLocationsVector &LocList,
+                                 bool HasGNULocViews) {
   if (DwarfVersion < 5)
     writeLegacyLocList(AttrInfo, LocList, DIEBldr, Die, AddrWriter, *LocBuffer,
                        CU, *LocStream);
   else
-    writeDWARF5LocList(NumberOfEntries, AttrInfo, LocList, Die, DIEBldr,
-                       AddrWriter, *LocBodyBuffer, RelativeLocListOffsets, CU,
-                       *LocBodyStream);
+    writeDWARF5LocList(DIEBldr, Die, AttrInfo, LocList, HasGNULocViews);
+}
+
+void DebugLoclistWriter::applyViewOffsets(DIEBuilder &Bldr,
+                                          uint64_t GlobalCUOffset) {
+  if (LocViewPatches.empty())
+    return;
+
+  const uint64_t BodySectionOffset =
+      GlobalCUOffset + getDWARF5RngListLocListHeaderSize() +
+      static_cast<uint64_t>(NumberOfEntries) * sizeof(uint32_t);
+  for (const LocViewPatch &P : LocViewPatches) {
+    if (!P.Die)
+      continue;
+    const uint64_t AbsOffset = BodySectionOffset + P.LocalViewOffset;
+    DIEValue Attr = P.Die->findAttribute(dwarf::DW_AT_GNU_locviews);
+    if (!Attr.getType())
+      Bldr.addValue(P.Die, dwarf::DW_AT_GNU_locviews, dwarf::DW_FORM_sec_offset,
+                    DIEInteger(AbsOffset));
+    else
+      Bldr.replaceValue(P.Die, dwarf::DW_AT_GNU_locviews, Attr.getForm(),
+                        DIEInteger(AbsOffset));
+  }
+  LocViewPatches.clear();
 }
 
 void DebugLoclistWriter::finalizeDWARF5(DIEBuilder &DIEBldr, DIE &Die) {

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -168,12 +168,16 @@ translateInputToOutputLocationList(const BinaryFunction &BF,
           Entry.Expr == OutputLL.back().Expr) {
         OutputLL.back().HighPC =
             std::max(OutputLL.back().HighPC, OutRanges.front().HighPC);
+        // Extending the range: keep the merged entry's ViewBegin and take the
+        // ViewEnd of the absorbed range so the view pair still brackets it.
+        OutputLL.back().View.ViewEnd = Entry.View.ViewEnd;
         OutRanges.erase(OutRanges.begin());
       }
     }
     llvm::transform(OutRanges, std::back_inserter(OutputLL),
                     [&Entry](const DebugAddressRange &R) {
-                      return DebugLocationEntry{R.LowPC, R.HighPC, Entry.Expr};
+                      return DebugLocationEntry{R.LowPC, R.HighPC, Entry.Expr,
+                                                Entry.View};
                     });
   }
 
@@ -188,10 +192,13 @@ translateInputToOutputLocationList(const BinaryFunction &BF,
   for (const DebugLocationEntry &Entry : OutputLL) {
     if (Entry.LowPC <= PrevHighPC && *PrevExpr == Entry.Expr) {
       MergedLL.back().HighPC = std::max(Entry.HighPC, MergedLL.back().HighPC);
+      // Same as above: absorbing a range only advances the merged ViewEnd.
+      MergedLL.back().View.ViewEnd = Entry.View.ViewEnd;
     } else {
       const uint64_t Begin = std::max(Entry.LowPC, PrevHighPC);
       const uint64_t End = std::max(Begin, Entry.HighPC);
-      MergedLL.emplace_back(DebugLocationEntry{Begin, End, Entry.Expr});
+      MergedLL.emplace_back(
+          DebugLocationEntry{Begin, End, Entry.Expr, Entry.View});
     }
     PrevHighPC = MergedLL.back().HighPC;
     PrevExpr = &MergedLL.back().Expr;
@@ -561,6 +568,74 @@ static void emitDWOBuilder(const std::string &DWOName,
                          StrOffstsWriter, StrWriter, TempRangesSectionWriter);
 }
 
+static StringRef getLoclistsSectionData(const DWARFUnit &Unit) {
+  const DWARFObject &Obj = Unit.getContext().getDWARFObj();
+  if (Unit.isDWOUnit())
+    return Obj.getLoclistsDWOSection().Data;
+  return Obj.getLoclistsSection().Data;
+}
+
+static std::optional<uint64_t>
+resolveInputLoclistSectionOffset(DWARFUnit &Unit, const DIEValue &LocAttrInfo) {
+  if (!LocAttrInfo)
+    return std::nullopt;
+
+  if (LocAttrInfo.getForm() == dwarf::DW_FORM_loclistx) {
+    if (Unit.getVersion() < 5)
+      return std::nullopt;
+    return Unit.getLoclistOffset(LocAttrInfo.getDIELocList().getValue());
+  }
+
+  if (doesFormBelongToClass(LocAttrInfo.getForm(),
+                            DWARFFormValue::FC_SectionOffset,
+                            Unit.getVersion()) ||
+      doesFormBelongToClass(LocAttrInfo.getForm(), DWARFFormValue::FC_Constant,
+                            Unit.getVersion()))
+    return LocAttrInfo.getDIEInteger().getValue();
+
+  return std::nullopt;
+}
+
+static SmallVector<DebugLocationViewPair, 4>
+parseLocViewList(StringRef Sec, uint64_t ViewOff, uint64_t ListOff,
+                 bool IsLittleEndian) {
+  SmallVector<DebugLocationViewPair, 4> Views;
+  if (ViewOff >= ListOff || ListOff > Sec.size())
+    return Views;
+
+  DataExtractor Data(Sec, IsLittleEndian);
+  DataExtractor::Cursor C(ViewOff);
+  while (C && C.tell() < ListOff) {
+    const uint64_t VB = Data.getULEB128(C);
+    if (!C || C.tell() > ListOff)
+      break;
+    const uint64_t VE = Data.getULEB128(C);
+    if (!C || C.tell() > ListOff)
+      break;
+    Views.emplace_back(DebugLocationViewPair{VB, VE});
+  }
+  return Views;
+}
+
+static SmallVector<DebugLocationViewPair, 4>
+parseInputLocViews(DWARFUnit &Unit, const DIEValue &LocViewsAttr,
+                   const DIEValue &LocAttrInfo) {
+  if (!LocViewsAttr || !LocAttrInfo || Unit.getVersion() < 5)
+    return {};
+
+  const std::optional<uint64_t> ListOff =
+      resolveInputLoclistSectionOffset(Unit, LocAttrInfo);
+  if (!ListOff)
+    return {};
+
+  const uint64_t ViewOff = LocViewsAttr.getDIEInteger().getValue();
+  if (*ListOff <= ViewOff)
+    return {};
+
+  return parseLocViewList(getLoclistsSectionData(Unit), ViewOff, *ListOff,
+                          Unit.getContext().isLittleEndian());
+}
+
 static SmallVector<SmallVector<DWARFUnit *>> partitionCUs(DWARFContext &DwCtx,
                                                           const size_t Size) {
   SmallVector<DWARFUnit *, 0> AllCUs;
@@ -727,16 +802,19 @@ void DWARFRewriter::mergePerBucketLocs(DIEBuilder &PartDIEBlder,
     Accum.LocListCUOrder.push_back(CUOffset);
     uint64_t LoclistsBase = 0;
     uint64_t LegacyLocBase = 0;
+    uint64_t GlobalCUOffset = 0;
+    DebugLoclistWriter *LocListWriter = nullptr;
 
     auto LocIt = LocListWritersByCU.find(CUOffset);
     if (LocIt != LocListWritersByCU.end()) {
       DebugLocWriter *LocWriter = LocIt->second.get();
-      auto *LocListWriter = dyn_cast<DebugLoclistWriter>(LocWriter);
+      LocListWriter = dyn_cast<DebugLoclistWriter>(LocWriter);
       const uint64_t BufferSize = LocWriter->getLocBufferSize();
 
       if (LocListWriter && LocListWriter->getDwarfVersion() >= 5 &&
           !LocListWriter->isSplitDwarf() && BufferSize != 0) {
-        LoclistsBase = Accum.LoclistsOffset;
+        GlobalCUOffset = Accum.LoclistsOffset;
+        LoclistsBase = GlobalCUOffset;
         Accum.LoclistsOffset += BufferSize;
       } else if (!LocListWriter) {
         LegacyLocBase = Accum.LegacyLocOffset;
@@ -765,6 +843,9 @@ void DWARFRewriter::mergePerBucketLocs(DIEBuilder &PartDIEBlder,
     }
     if (LegacyLocBase)
       LocIt->second->applyBase(PartDIEBlder, LegacyLocBase);
+
+    if (LocListWriter)
+      LocListWriter->applyViewOffsets(PartDIEBlder, GlobalCUOffset);
   }
 }
 
@@ -1344,6 +1425,13 @@ void DWARFRewriter::updateUnitDebugInfo(
       // Handle any tag that can have DW_AT_location attribute.
       DIEValue LocAttrInfo = Die->findAttribute(dwarf::DW_AT_location);
       DIEValue LowPCAttrInfo = Die->findAttribute(dwarf::DW_AT_low_pc);
+
+      DIEValue LocViewsAttr = Die->findAttribute(dwarf::DW_AT_GNU_locviews);
+      const bool HasGNULocViews = static_cast<bool>(LocViewsAttr);
+      SmallVector<DebugLocationViewPair, 4> InputViews;
+      if (HasGNULocViews)
+        InputViews = parseInputLocViews(Unit, LocViewsAttr, LocAttrInfo);
+
       if (LocAttrInfo) {
         if (doesFormBelongToClass(LocAttrInfo.getForm(),
                                   DWARFFormValue::FC_Constant,
@@ -1433,6 +1521,13 @@ void DWARFRewriter::updateUnitDebugInfo(
                    << " in CU at 0x" << Twine::utohexstr(Unit.getOffset())
                    << '\n';
           } else {
+            // Attach each parsed view pair to its bounded loclist entry so the
+            // view travels with the entry through translation/merge/sort and
+            // stays 1:1 with the emitted range.
+            if (HasGNULocViews)
+              for (size_t I = 0; I < InputLL.size() && I < InputViews.size();
+                   ++I)
+                InputLL[I].View = InputViews[I];
             const uint64_t Address = InputLL.front().LowPC;
             DebugLocationsVector OutputLL;
             if (const BinaryFunction *Function =
@@ -1450,7 +1545,8 @@ void DWARFRewriter::updateUnitDebugInfo(
               // information.
               OutputLL = InputLL;
             }
-            DebugLocWriter.addList(DIEBldr, *Die, LocAttrInfo, OutputLL);
+            DebugLocWriter.addList(DIEBldr, *Die, LocAttrInfo, OutputLL,
+                                   HasGNULocViews);
           }
         } else {
           assert((doesFormBelongToClass(LocAttrInfo.getForm(),

--- a/bolt/test/X86/Inputs/dwarf5-gnu-locviews-main.s
+++ b/bolt/test/X86/Inputs/dwarf5-gnu-locviews-main.s
@@ -1,0 +1,410 @@
+# Derived from Inputs/dwarf5_main.s, with GNU location views added.
+# extern int fooVar; (defined locally below so the object links standalone)
+# void use(int * x, int * y) {
+# *x += 4;
+# *y -= 2;
+# }
+#
+# int  main(int argc, char *argv[]) {
+#    int x = argc;
+#    int y = fooVar + 3;
+#    use(&x, &y);
+#    return x + y;
+# }
+#
+# DW_AT_GNU_locviews (0x2137, DW_FORM_sec_offset) is added to both local
+# variables. In .debug_loclists each location list is preceded by a sequence of
+# ULEB128 view pairs, and DW_AT_GNU_locviews holds the absolute section offset of
+# those view pairs.
+
+	.text
+	.file	"main.cpp"
+	.globl	_Z3usePiS_                      # -- Begin function _Z3usePiS_
+	.p2align	4, 0x90
+	.type	_Z3usePiS_,@function
+_Z3usePiS_:                             # @_Z3usePiS_
+.Lfunc_begin0:
+	.file	0 "/testLocViews" "main.cpp" md5 0xb1a1551182284263b0faa0cae08277da
+	.loc	0 1 0                           # main.cpp:1:0
+	.cfi_startproc
+# %bb.0:                                # %entry
+	.loc	0 2 4 prologue_end              # main.cpp:2:4
+	addl	$4, (%rdi)
+	.loc	0 3 4                           # main.cpp:3:4
+	addl	$-2, (%rsi)
+	.loc	0 4 1                           # main.cpp:4:1
+	retq
+.Ltmp0:
+.Lfunc_end0:
+	.size	_Z3usePiS_, .Lfunc_end0-_Z3usePiS_
+	.cfi_endproc
+                                        # -- End function
+	.globl	main                            # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+.Lfunc_begin1:
+	.loc	0 7 0                           # main.cpp:7:0
+	.cfi_startproc
+# %bb.0:                                # %entry
+	.loc	0 9 12 prologue_end             # main.cpp:9:12
+	movl	fooVar(%rip), %eax
+.Ltmp1:
+	.loc	0 11 13                         # main.cpp:11:13
+	addl	%edi, %eax
+.Ltmp2:
+	addl	$5, %eax
+	.loc	0 11 4 is_stmt 0                # main.cpp:11:4
+	retq
+.Ltmp3:
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main
+	.cfi_endproc
+                                        # -- End function
+	.type	fooVar,@object                  # @fooVar
+	.bss
+	.globl	fooVar
+	.p2align	2, 0x0
+fooVar:
+	.long	0                               # 0x0
+	.size	fooVar, 4
+
+	.section	.debug_loclists,"",@progbits
+.Lloclists_section_start0:
+	.long	.Ldebug_list_header_end0-.Ldebug_list_header_start0 # Length
+.Ldebug_list_header_start0:
+	.short	5                               # Version
+	.byte	8                               # Address size
+	.byte	0                               # Segment selector size
+	.long	2                               # Offset entry count
+.Lloclists_table_base0:
+	.long	.Ldebug_loc0-.Lloclists_table_base0
+	.long	.Ldebug_loc1-.Lloclists_table_base0
+.Lview_pair0:
+	.uleb128 0                              # entry 0 view begin
+	.uleb128 1                              # entry 0 view end
+	.uleb128 1                              # entry 1 view begin
+	.uleb128 2                              # entry 1 view end
+.Ldebug_loc0:
+	.byte	4                               # DW_LLE_offset_pair
+	.uleb128 .Lfunc_begin1-.Lfunc_begin0    #   starting offset
+	.uleb128 .Ltmp1-.Lfunc_begin0           #   ending offset
+	.byte	1                               # Loc expr size
+	.byte	85                              # super-register DW_OP_reg5
+	.byte	4                               # DW_LLE_offset_pair
+	.uleb128 .Ltmp1-.Lfunc_begin0           #   starting offset
+	.uleb128 .Lfunc_end1-.Lfunc_begin0      #   ending offset
+	.byte	10                              # Loc expr size
+	.byte	117                             # DW_OP_breg5
+	.byte	4                               # 4
+	.byte	16                              # DW_OP_constu
+	.byte	255                             # 4294967295
+	.byte	255                             #
+	.byte	255                             #
+	.byte	255                             #
+	.byte	15                              #
+	.byte	26                              # DW_OP_and
+	.byte	159                             # DW_OP_stack_value
+	.byte	0                               # DW_LLE_end_of_list
+.Lview_pair1:
+	.uleb128 0                              # entry 0 view begin
+	.uleb128 1                              # entry 0 view end
+.Ldebug_loc1:
+	.byte	4                               # DW_LLE_offset_pair
+	.uleb128 .Ltmp1-.Lfunc_begin0           #   starting offset
+	.uleb128 .Ltmp2-.Lfunc_begin0           #   ending offset
+	.byte	10                              # Loc expr size
+	.byte	112                             # DW_OP_breg0
+	.byte	1                               # 1
+	.byte	16                              # DW_OP_constu
+	.byte	255                             # 4294967295
+	.byte	255                             #
+	.byte	255                             #
+	.byte	255                             #
+	.byte	15                              #
+	.byte	26                              # DW_OP_and
+	.byte	159                             # DW_OP_stack_value
+	.byte	0                               # DW_LLE_end_of_list
+.Ldebug_list_header_end0:
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               # Abbreviation Code
+	.byte	17                              # DW_TAG_compile_unit
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	37                              # DW_AT_producer
+	.byte	37                              # DW_FORM_strx1
+	.byte	19                              # DW_AT_language
+	.byte	5                               # DW_FORM_data2
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	114                             # DW_AT_str_offsets_base
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	16                              # DW_AT_stmt_list
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	27                              # DW_AT_comp_dir
+	.byte	37                              # DW_FORM_strx1
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	115                             # DW_AT_addr_base
+	.byte	23                              # DW_FORM_sec_offset
+	.ascii	"\214\001"                      # DW_AT_loclists_base
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	2                               # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	64                              # DW_AT_frame_base
+	.byte	24                              # DW_FORM_exprloc
+	.byte	122                             # DW_AT_call_all_calls
+	.byte	25                              # DW_FORM_flag_present
+	.byte	110                             # DW_AT_linkage_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	63                              # DW_AT_external
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	3                               # Abbreviation Code
+	.byte	5                               # DW_TAG_formal_parameter
+	.byte	0                               # DW_CHILDREN_no
+	.byte	2                               # DW_AT_location
+	.byte	24                              # DW_FORM_exprloc
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	4                               # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	64                              # DW_AT_frame_base
+	.byte	24                              # DW_FORM_exprloc
+	.byte	122                             # DW_AT_call_all_calls
+	.byte	25                              # DW_FORM_flag_present
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	63                              # DW_AT_external
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	5                               # Abbreviation Code
+	.byte	52                              # DW_TAG_variable
+	.byte	0                               # DW_CHILDREN_no
+	.ascii	"\267\102"                      # DW_AT_GNU_locviews
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	2                               # DW_AT_location
+	.byte	34                              # DW_FORM_loclistx
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	6                               # Abbreviation Code
+	.byte	36                              # DW_TAG_base_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	62                              # DW_AT_encoding
+	.byte	11                              # DW_FORM_data1
+	.byte	11                              # DW_AT_byte_size
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	7                               # Abbreviation Code
+	.byte	15                              # DW_TAG_pointer_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	0                               # EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 # Length of Unit
+.Ldebug_info_start0:
+	.short	5                               # DWARF version number
+	.byte	1                               # DWARF Unit Type
+	.byte	8                               # Address Size (in bytes)
+	.long	.debug_abbrev                   # Offset Into Abbrev. Section
+	.byte	1                               # Abbrev [1] DW_TAG_compile_unit
+	.byte	0                               # DW_AT_producer
+	.short	33                              # DW_AT_language
+	.byte	1                               # DW_AT_name
+	.long	.Lstr_offsets_base0             # DW_AT_str_offsets_base
+	.long	.Lline_table_start0             # DW_AT_stmt_list
+	.byte	2                               # DW_AT_comp_dir
+	.byte	0                               # DW_AT_low_pc
+	.long	.Lfunc_end1-.Lfunc_begin0       # DW_AT_high_pc
+	.long	.Laddr_table_base0              # DW_AT_addr_base
+	.long	.Lloclists_table_base0          # DW_AT_loclists_base
+	.byte	2                               # Abbrev [2] DW_TAG_subprogram
+	.byte	0                               # DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       # DW_AT_high_pc
+	.byte	1                               # DW_AT_frame_base
+	.byte	87
+                                        # DW_AT_call_all_calls
+	.byte	3                               # DW_AT_linkage_name
+	.byte	4                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	1                               # DW_AT_decl_line
+                                        # DW_AT_external
+	.byte	3                               # Abbrev [3] DW_TAG_formal_parameter
+	.byte	1                               # DW_AT_location
+	.byte	85
+	.byte	7                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	1                               # DW_AT_decl_line
+	.long	138                             # DW_AT_type
+	.byte	3                               # Abbrev [3] DW_TAG_formal_parameter
+	.byte	1                               # DW_AT_location
+	.byte	84
+	.byte	8                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	1                               # DW_AT_decl_line
+	.long	138                             # DW_AT_type
+	.byte	0                               # End Of Children Mark
+	.byte	4                               # Abbrev [4] DW_TAG_subprogram
+	.byte	1                               # DW_AT_low_pc
+	.long	.Lfunc_end1-.Lfunc_begin1       # DW_AT_high_pc
+	.byte	1                               # DW_AT_frame_base
+	.byte	87
+                                        # DW_AT_call_all_calls
+	.byte	5                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	7                               # DW_AT_decl_line
+	.long	134                             # DW_AT_type
+                                        # DW_AT_external
+	.byte	3                               # Abbrev [3] DW_TAG_formal_parameter
+	.byte	1                               # DW_AT_location
+	.byte	85
+	.byte	9                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	7                               # DW_AT_decl_line
+	.long	134                             # DW_AT_type
+	.byte	3                               # Abbrev [3] DW_TAG_formal_parameter
+	.byte	1                               # DW_AT_location
+	.byte	84
+	.byte	10                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	7                               # DW_AT_decl_line
+	.long	143                             # DW_AT_type
+	.byte	5                               # Abbrev [5] DW_TAG_variable
+	.long	.Lview_pair0-.Lloclists_section_start0 # DW_AT_GNU_locviews
+	.byte	0                               # DW_AT_location (loclistx 0)
+	.byte	7                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	8                               # DW_AT_decl_line
+	.long	134                             # DW_AT_type
+	.byte	5                               # Abbrev [5] DW_TAG_variable
+	.long	.Lview_pair1-.Lloclists_section_start0 # DW_AT_GNU_locviews
+	.byte	1                               # DW_AT_location (loclistx 1)
+	.byte	8                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	9                               # DW_AT_decl_line
+	.long	134                             # DW_AT_type
+	.byte	0                               # End Of Children Mark
+	.byte	6                               # Abbrev [6] DW_TAG_base_type
+	.byte	6                               # DW_AT_name
+	.byte	5                               # DW_AT_encoding
+	.byte	4                               # DW_AT_byte_size
+	.byte	7                               # Abbrev [7] DW_TAG_pointer_type
+	.long	134                             # DW_AT_type
+	.byte	7                               # Abbrev [7] DW_TAG_pointer_type
+	.long	148                             # DW_AT_type
+	.byte	7                               # Abbrev [7] DW_TAG_pointer_type
+	.long	153                             # DW_AT_type
+	.byte	6                               # Abbrev [6] DW_TAG_base_type
+	.byte	11                              # DW_AT_name
+	.byte	6                               # DW_AT_encoding
+	.byte	1                               # DW_AT_byte_size
+	.byte	0                               # End Of Children Mark
+.Ldebug_info_end0:
+	.section	.debug_str_offsets,"",@progbits
+	.long	52                              # Length of String Offsets Set
+	.short	5
+	.short	0
+.Lstr_offsets_base0:
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"clang version 15.0.0" # string offset=0
+.Linfo_string1:
+	.asciz	"main.cpp"                      # string offset=134
+.Linfo_string2:
+	.asciz	"/testLocViews" # string offset=143
+.Linfo_string3:
+	.asciz	"_Z3usePiS_"                    # string offset=200
+.Linfo_string4:
+	.asciz	"use"                           # string offset=211
+.Linfo_string5:
+	.asciz	"main"                          # string offset=215
+.Linfo_string6:
+	.asciz	"int"                           # string offset=220
+.Linfo_string7:
+	.asciz	"x"                             # string offset=224
+.Linfo_string8:
+	.asciz	"y"                             # string offset=226
+.Linfo_string9:
+	.asciz	"argc"                          # string offset=228
+.Linfo_string10:
+	.asciz	"argv"                          # string offset=233
+.Linfo_string11:
+	.asciz	"char"                          # string offset=238
+	.section	.debug_str_offsets,"",@progbits
+	.long	.Linfo_string0
+	.long	.Linfo_string1
+	.long	.Linfo_string2
+	.long	.Linfo_string3
+	.long	.Linfo_string4
+	.long	.Linfo_string5
+	.long	.Linfo_string6
+	.long	.Linfo_string7
+	.long	.Linfo_string8
+	.long	.Linfo_string9
+	.long	.Linfo_string10
+	.long	.Linfo_string11
+	.section	.debug_addr,"",@progbits
+	.long	.Ldebug_addr_end0-.Ldebug_addr_start0 # Length of contribution
+.Ldebug_addr_start0:
+	.short	5                               # DWARF version number
+	.byte	8                               # Address size
+	.byte	0                               # Segment selector size
+.Laddr_table_base0:
+	.quad	.Lfunc_begin0
+	.quad	.Lfunc_begin1
+.Ldebug_addr_end0:
+	.ident	"clang version 15.0.0"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:

--- a/bolt/test/X86/dwarf5-gnu-locviews.test
+++ b/bolt/test/X86/dwarf5-gnu-locviews.test
@@ -1,0 +1,41 @@
+# REQUIRES: system-linux
+
+# RUN: llvm-mc -dwarf-version=5 -filetype=obj -triple x86_64-unknown-linux %p/Inputs/dwarf5-gnu-locviews-main.s -o %tmain.o
+# RUN: %clang %cflags -dwarf-5 %tmain.o -o %t.exe -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt --update-debug-sections
+# RUN: llvm-dwarfdump --show-form --verbose --debug-info %t.exe | FileCheck --check-prefix=PRECHECK %s
+# RUN: llvm-dwarfdump --show-form --verbose --debug-info %t.bolt | FileCheck --check-prefix=POSTCHECK %s
+
+## This test checks that re-writing of .debug_loclists preserves GCC location
+## views: DW_AT_GNU_locviews is updated to the new section offset and continues
+## to point at the view pairs that immediately precede the matching location
+## list. The input encodes two location lists (two and one view pairs), so the
+## post-BOLT view offset must be exactly 4 and 2 bytes before its loclist.
+
+# PRECHECK: version = 0x0005
+# PRECHECK: DW_TAG_variable
+# PRECHECK: DW_AT_GNU_locviews [DW_FORM_sec_offset]
+# PRECHECK-SAME: (0x[[#%.8x,IVIEW0:]])
+# PRECHECK: DW_AT_location [DW_FORM_loclistx]
+# PRECHECK-SAME: indexed (0x0)
+# PRECHECK-SAME: loclist = 0x[[#%.8x,IVIEW0+4]]
+# PRECHECK: DW_TAG_variable
+# PRECHECK: DW_AT_GNU_locviews [DW_FORM_sec_offset]
+# PRECHECK-SAME: (0x[[#%.8x,IVIEW1:]])
+# PRECHECK: DW_AT_location [DW_FORM_loclistx]
+# PRECHECK-SAME: indexed (0x1)
+# PRECHECK-SAME: loclist = 0x[[#%.8x,IVIEW1+2]]
+
+# POSTCHECK: version = 0x0005
+# POSTCHECK: DW_TAG_variable
+# POSTCHECK: DW_AT_GNU_locviews [DW_FORM_sec_offset]
+# POSTCHECK-SAME: (0x[[#%.8x,VIEW0:]])
+# POSTCHECK: DW_AT_location [DW_FORM_loclistx]
+# POSTCHECK-SAME: indexed (0x0)
+# POSTCHECK-SAME: loclist = 0x[[#%.8x,VIEW0+4]]
+# POSTCHECK: DW_TAG_variable
+# POSTCHECK: DW_AT_GNU_locviews [DW_FORM_sec_offset]
+# POSTCHECK-SAME: (0x[[#%.8x,VIEW1:]])
+# POSTCHECK: DW_AT_location [DW_FORM_loclistx]
+# POSTCHECK-SAME: indexed (0x1)
+# POSTCHECK-SAME: loclist = 0x[[#%.8x,VIEW1+2]]


### PR DESCRIPTION
Preserve GCC location view pairs in .debug_loclists and patch DW_AT_GNU_locviews after --update-debug-sections rewrites the section. Fixes #206552