### PR TITLE
[Clang] Fix clang build with GCC 7.5

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -626,7 +626,7 @@ void FactsGenerator::VisitCXXOperatorCallExpr(const CXXOperatorCallExpr *OCE) {
     }
   }
 
-  ArrayRef Args = {OCE->getArgs(), OCE->getNumArgs()};
+  ArrayRef<const Expr *> Args(OCE->getArgs(), OCE->getNumArgs());
   // For `static operator()`, the first argument is the object argument,
   // remove it from the argument list to avoid off-by-one errors.
   if (OCE->getOperator() == OO_Call && OCE->getDirectCallee()->isStatic())

--- a/clang/lib/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowAnalysis.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/PointerFlow/PointerFlowAnalysis.cpp
@@ -91,7 +91,7 @@ Expected<std::unique_ptr<AnalysisResult>> deserializePointerFlowAnalysisResult(
   auto Ret = std::make_unique<PointerFlowAnalysisResult>();
 
   Ret->Edges = std::move(Edges);
-  return Ret;
+  return std::move(Ret);
 }
 
 JSONFormat::AnalysisResultRegistry::Add<PointerFlowAnalysisResult>

--- a/clang/lib/ScalableStaticAnalysis/Analyses/UnsafeBufferUsage/UnsafeBufferUsageAnalysis.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/UnsafeBufferUsage/UnsafeBufferUsageAnalysis.cpp
@@ -57,7 +57,7 @@ deserializeUnsafeBufferUsageAnalysisResult(
   auto Ret = std::make_unique<UnsafeBufferUsageAnalysisResult>();
 
   Ret->UnsafeBuffers = std::move(*UnsafeBuffers);
-  return Ret;
+  return std::move(Ret);
 }
 
 JSONFormat::AnalysisResultRegistry::Add<UnsafeBufferUsageAnalysisResult>
@@ -116,7 +116,7 @@ deserializeUnsafeBufferReachableAnalysisResult(
   auto Ret = std::make_unique<UnsafeBufferReachableAnalysisResult>();
 
   Ret->Reachables = std::move(*Reachables);
-  return Ret;
+  return std::move(Ret);
 }
 
 JSONFormat::AnalysisResultRegistry::Add<UnsafeBufferReachableAnalysisResult>


### PR DESCRIPTION
GCC 7.5 rejects two newer C++ idioms:

- LifetimeSafety/FactsGenerator: replace ArrayRef CTAD with an explicit ArrayRef<const Expr *> to avoid GCC 7's broken brace-init deduction.
- ScalableStaticAnalysisFramework: add explicit std::move() on unique_ptr<Derived> returns (pre-P1825, GCC 7 won't implicitly move).

No behavior change; restores compatibility with GCC 7.5.