### PR TITLE
[LLVM][Autoupgrade] Delete invalid lifetime.start/lifetime.end intrinsic decls and calls

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1571,7 +1571,7 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
         // https://github.com/llvm/llvm-project/pull/204601. This is an invalid
         // intrinsic with no expected calls. To allow auto-upgrade process to
         // delete such invalid intrinsic declaration, set NewFn = nullptr
-        // and return true here. If there are actual calls to this intrinsics
+        // and return true here. If there are actual calls to this intrinsic
         // (which is not expected), they will be deleted in
         // UpgradeIntrinsicCall.
         NewFn = nullptr;

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1552,21 +1552,34 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
       return true;
     }
     break;
-  case 'l':
-    if ((Name.starts_with("lifetime.start") ||
-         Name.starts_with("lifetime.end")) &&
-        F->arg_size() == 2) {
-      Intrinsic::ID IID = Name.starts_with("lifetime.start")
-                              ? Intrinsic::lifetime_start
-                              : Intrinsic::lifetime_end;
-      rename(F);
-      // Old 2 argument form of these intrinsics have [Size, Ptr] as arguments.
-      // Use the Ptr argument to create new declaration.
-      NewFn = Intrinsic::getOrInsertDeclaration(F->getParent(), IID,
-                                                F->getArg(1)->getType());
-      return true;
+  case 'l': {
+    bool IsLifetimeStart = Name.consume_front("lifetime.start");
+    bool IsLifetimeEnd = !IsLifetimeStart && Name.consume_front("lifetime.end");
+    if (IsLifetimeStart || IsLifetimeEnd) {
+      if (F->arg_size() == 2) {
+        Intrinsic::ID IID = IsLifetimeStart ? Intrinsic::lifetime_start
+                                            : Intrinsic::lifetime_end;
+        rename(F);
+        // Old 2 argument form of these intrinsics have [Size, Ptr] as
+        // arguments. Use the Ptr argument to create new declaration.
+        NewFn = Intrinsic::getOrInsertDeclaration(F->getParent(), IID,
+                                                  F->getArg(1)->getType());
+        return true;
+      } else if (F->arg_size() == 1 && Name == ".i64") {
+        // Matches @llvm.lifetime.{start/end}.i64 which used to be created by
+        // Autoupgrade prior to
+        // https://github.com/llvm/llvm-project/pull/204601. This is an invalid
+        // intrinsic with no expected calls. To allow auto-upgrade process to
+        // delete such invalid intrinsic declaration, set NewFn = nullptr
+        // and return true here. If there are actual calls to this intrinsics
+        // (which is not expected), they will be deleted in
+        // UpgradeIntrinsicCall.
+        NewFn = nullptr;
+        return true;
+      }
     }
     break;
+  }
   case 'm': {
     // Updating the memory intrinsics (memcpy/memmove/memset) that have an
     // alignment parameter to embedding the alignment as an attribute of
@@ -5125,6 +5138,9 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
       Rep = upgradeVectorSplice(CI, Builder);
     } else if (Name.consume_front("convert.")) {
       Rep = upgradeConvertIntrinsicCall(Name, CI, F, Builder);
+    } else if (Name == "lifetime.start.i64" || Name == "lifetime.end.i64") {
+      // Delete calls to invalid @llvm.lifetime.{start,end}.i64 intrinsics.
+      Rep = nullptr;
     } else {
       llvm_unreachable("Unknown function for CallBase upgrade.");
     }

--- a/llvm/test/Assembler/autoupgrade-lifetime-intrinsics-invalid.ll
+++ b/llvm/test/Assembler/autoupgrade-lifetime-intrinsics-invalid.ll
@@ -1,0 +1,30 @@
+; RUN: split-file %s %t
+
+;--- test1.ll
+; Verify that auto-upgrade eliminate the unused invalid declaration of lifetime
+; start and end intrinsics. 
+; RUN: llvm-as < %t/test1.ll | llvm-dis | FileCheck %t/test1.ll
+; CHECK-NOT: @llvm.lifetime.start.i64(i64)
+; CHECK-NOT: @llvm.lifetime.end.i64(i64)
+
+declare void @llvm.lifetime.start.i64(i64)
+declare void @llvm.lifetime.end.i64(i64)
+
+;--- test2.ll
+; Verify that if there is an actual call to the invalid lifetime intrinsics,
+; the calls and the declaration will be deleted.
+; RUN: llvm-as < %t/test2.ll | llvm-dis | FileCheck %t/test2.ll
+
+; CHECK-NOT: @llvm.lifetime.start.i64(i64)
+; CHECK-NOT: @llvm.lifetime.end.i64(i64)
+; CHECK-NOT: call void @llvm.lifetime.start.i64(i64 0)
+; CHECK-NOT: call void @llvm.lifetime.end.i64(i64 0)
+
+declare void @llvm.lifetime.start.i64(i64)
+declare void @llvm.lifetime.end.i64(i64)
+
+define void @foo() {
+  call void @llvm.lifetime.start.i64(i64 0)
+  call void @llvm.lifetime.end.i64(i64 0)
+  ret void
+}

--- a/llvm/test/Assembler/autoupgrade-lifetime-intrinsics-invalid.ll
+++ b/llvm/test/Assembler/autoupgrade-lifetime-intrinsics-invalid.ll
@@ -1,8 +1,8 @@
 ; RUN: split-file %s %t
 
 ;--- test1.ll
-; Verify that auto-upgrade eliminate the unused invalid declaration of lifetime
-; start and end intrinsics. 
+; Verify that auto-upgrade eliminates unused invalid declaration of lifetime
+; start and end intrinsics.
 ; RUN: llvm-as < %t/test1.ll | llvm-dis | FileCheck %t/test1.ll
 ; CHECK-NOT: @llvm.lifetime.start.i64(i64)
 ; CHECK-NOT: @llvm.lifetime.end.i64(i64)
@@ -11,8 +11,8 @@ declare void @llvm.lifetime.start.i64(i64)
 declare void @llvm.lifetime.end.i64(i64)
 
 ;--- test2.ll
-; Verify that if there is an actual call to the invalid lifetime intrinsics,
-; the calls and the declaration will be deleted.
+; Verify that auto-upgrade eliminates calls to invalid lifetime start and end
+; intrinsics.
 ; RUN: llvm-as < %t/test2.ll | llvm-dis | FileCheck %t/test2.ll
 
 ; CHECK-NOT: @llvm.lifetime.start.i64(i64)


### PR DESCRIPTION
AutoUpgrade used to create invalid and unused `lifetime.start.i64` and `lifetime.end.i64` intrinsics. This was fixed with https://github.com/llvm/llvm-project/pull/204601. However, existing bitcode generated prior to this fix might still have these unused and invalid declarations in them, which now fail IR verification. Adopt Autoupgrade to clean them up.

Invalid declaration of these intrinsics will be deleted, and if there exists calls to these invalid intrinsics (not expected to be generated by AutoUpgrade prior to the bug fix, but handling this case just for completeness) these calls will be deleted as well.

Also tested with `sap_fct_splitting.bc` reported in https://github.com/llvm/llvm-project/pull/204478#issuecomment-4845475424 (though not committing that as a unit test).