### PR TITLE
[lldb] Forward the inferior's environment to the Wasm runtime

### DIFF
--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
@@ -17,6 +17,7 @@
 #include "lldb/Interpreter/OptionValueProperties.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/Target.h"
+#include "lldb/Utility/Environment.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Listener.h"
 #include "lldb/Utility/Log.h"
@@ -57,6 +58,10 @@ public:
 
   llvm::StringRef GetPortArg() const {
     return GetPropertyAtIndexAs<llvm::StringRef>(ePropertyPortArg, {});
+  }
+
+  llvm::StringRef GetEnvArg() const {
+    return GetPropertyAtIndexAs<llvm::StringRef>(ePropertyEnvArg, {});
   }
 };
 
@@ -170,6 +175,14 @@ lldb::ProcessSP PlatformWasm::DebugProcess(ProcessLaunchInfo &launch_info,
   Args args({runtime.GetPath(),
              llvm::formatv("{0}{1}", properties.GetPortArg(), port).str()});
   args.AppendArguments(properties.GetRuntimeArgs());
+
+  // Forward the inferior's environment into the WASI runtime. How arguments are
+  // passed is configurable. When not configured, no environment is passed.
+  if (llvm::StringRef env_arg = properties.GetEnvArg(); !env_arg.empty())
+    for (const auto &kv : launch_info.GetEnvironment())
+      args.AppendArgument(
+          llvm::formatv("{0}{1}", env_arg, Environment::compose(kv)).str());
+
   args.AppendArguments(launch_info.GetArguments());
 
   launch_info.SetArguments(args, true);
@@ -177,6 +190,7 @@ lldb::ProcessSP PlatformWasm::DebugProcess(ProcessLaunchInfo &launch_info,
   // We're launching the Wasm runtime (a native host binary), not the target
   // being debugged. Clear flags that don't apply to the runtime process.
   launch_info.GetFlags().Clear(eLaunchFlagDebug | eLaunchFlagDisableASLR);
+  // The runtime itself runs with the host environment.
   launch_info.GetEnvironment() = Host::GetEnvironment();
 
   auto exit_code = std::make_shared<std::optional<int>>();

--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasmProperties.td
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasmProperties.td
@@ -14,6 +14,14 @@ let Definition = "platformwasm", Path = "platform.plugin.wasm" in {
                      "GDB remote port. The port number chosen by LLDB will be "
                      "concatenated to this argument. For example: "
                      "`-g=127.0.0.1:` or `--debugger-port `.">;
+  def EnvArg : Property<"env-arg", "String">,
+               Global,
+               DefaultStringValue<"">,
+               Desc<"Argument to the WebAssembly runtime to forward an "
+                    "environment variable to the inferior. A `key=value` pair "
+                    "is concatenated to this argument, once per variable in the "
+                    "inferior's environment. For example: `--env=`. If empty, "
+                    "no environment is forwarded to the runtime.">;
   def RuntimeArgs : Property<"runtime-args", "Args">,
                     Global,
                     DefaultStringValue<"">,


### PR DESCRIPTION
PlatformWasm::DebugProcess launches the Wasm runtime and lets it debug the actual inferior. Environment variables requested for the inferior (via target.env-vars / target.inherit-env, or a DAP launch "env") were dropped. The runtime itself is launched with the host environment. A Wasm inferior's environment must be set explicitly by the runtime.

Forward each variable from launch_info.GetEnvironment() to the runtime. How a runtime accepts environment variables is runtime-specific, so the per-variable argument prefix is a new configurable setting, platform.plugin.wasm.env-arg, mirroring the port-arg. The new setting defaults to empty, in which case no environment is forwarded.

For WAMR/iwasm, the option is `--env=`. This fixes various tests that expect inferior args to be set when targeting Wasm running under the micro runtime.