### PR TITLE
[lldb][Windows] reconfigure project in the correct directory

### DIFF
--- a/.ci/green-dragon/lldb-windows.groovy
+++ b/.ci/green-dragon/lldb-windows.groovy
@@ -81,24 +81,8 @@ ninja check-lldb -C ..\\llvm-build || exit /b 1
 cmake -G Ninja ^
     -S llvm ^
     -B ..\\llvm-build\\ ^
-    -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
-    -DCMAKE_INSTALL_PREFIX=..\\llvm-install\\base ^
-    -DCMAKE_TOOLCHAIN_FILE=C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake ^
-    -DLLVM_ENABLE_PROJECTS="clang;lld;lldb" ^
-    -DLLVM_ENABLE_ASSERTIONS=ON ^
-    -DLLVM_ENABLE_LIBEDIT=OFF ^
-    -DLLVM_OPTIMIZED_TABLEGEN=ON ^
-    -DLLVM_BUILD_TOOLS=ON ^
-    -DLLVM_BUILD_UTILS=ON ^
-    -DLLVM_ENABLE_LIBXML2=FORCE_ON ^
-    -DLLDB_ENABLE_SWIG=ON ^
-    -DLLDB_ENABLE_PYTHON=ON ^
-    -DLLDB_ENABLE_LUA=OFF ^
-    -DLLDB_ENABLE_LIBXML2=ON ^
-    -DLLVM_TARGETS_TO_BUILD=Native ^
     -DLLDB_TEST_USE_LLDB_SERVER=1 ^
-    -DLLVM_LIT_ARGS="-v --time-tests --xunit-xml-output=C:\\workspace\\llvm-build\\test\\results-lldb-server.xml" ^
-    -DPython3_EXECUTABLE="C:\\Program Files\\Python313\\python.exe" || exit /b 1
+    -DLLVM_LIT_ARGS="-v --time-tests --xunit-xml-output=C:\\workspace\\llvm-build\\test\\results-lldb-server.xml" || exit /b 1
 ninja check-lldb -C ..\\llvm-build || exit /b 1
 '''
                         bat '''

--- a/.ci/green-dragon/lldb-windows.groovy
+++ b/.ci/green-dragon/lldb-windows.groovy
@@ -53,6 +53,8 @@ call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Au
 
 set "PATH=%PATH%;C:\\Program Files\\Git\\usr\\bin"
 
+if not exist ..\\llvm-build\\test mkdir ..\\llvm-build\\test
+
 cmake -G Ninja ^
     -S llvm ^
     -B ..\\llvm-build\\ ^
@@ -74,14 +76,29 @@ cmake -G Ninja ^
     -DLLDB_TEST_USE_LLDB_SERVER=0 ^
     -DLLVM_LIT_ARGS="-v --time-tests --xunit-xml-output=C:\\workspace\\llvm-build\\test\\results-no-lldb-server.xml" ^
     -DPython3_EXECUTABLE="C:\\Program Files\\Python313\\python.exe" || exit /b 1
-
-if not exist ..\\llvm-build\\test mkdir ..\\llvm-build\\test
-
 ninja check-lldb -C ..\\llvm-build || exit /b 1
 
-cmake -B ..\\llvm-build\\ ^
+cmake -G Ninja ^
+    -S llvm ^
+    -B ..\\llvm-build\\ ^
+    -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
+    -DCMAKE_INSTALL_PREFIX=..\\llvm-install\\base ^
+    -DCMAKE_TOOLCHAIN_FILE=C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake ^
+    -DLLVM_ENABLE_PROJECTS="clang;lld;lldb" ^
+    -DLLVM_ENABLE_ASSERTIONS=ON ^
+    -DLLVM_ENABLE_LIBEDIT=OFF ^
+    -DLLVM_OPTIMIZED_TABLEGEN=ON ^
+    -DLLVM_BUILD_TOOLS=ON ^
+    -DLLVM_BUILD_UTILS=ON ^
+    -DLLVM_ENABLE_LIBXML2=FORCE_ON ^
+    -DLLDB_ENABLE_SWIG=ON ^
+    -DLLDB_ENABLE_PYTHON=ON ^
+    -DLLDB_ENABLE_LUA=OFF ^
+    -DLLDB_ENABLE_LIBXML2=ON ^
+    -DLLVM_TARGETS_TO_BUILD=Native ^
     -DLLDB_TEST_USE_LLDB_SERVER=1 ^
-    -DLLVM_LIT_ARGS="-v --time-tests --xunit-xml-output=C:\\workspace\\llvm-build\\test\\results-lldb-server.xml" || exit /b 1
+    -DLLVM_LIT_ARGS="-v --time-tests --xunit-xml-output=C:\\workspace\\llvm-build\\test\\results-lldb-server.xml" ^
+    -DPython3_EXECUTABLE="C:\\Program Files\\Python313\\python.exe" || exit /b 1
 ninja check-lldb -C ..\\llvm-build || exit /b 1
 '''
                         bat '''


### PR DESCRIPTION
Currently, the second reconfigure fails with `CMake Error: The source directory "C:/workspace/llvm-project" does not appear to contain CMakeLists.txt.`.

This patch copies the full cmake invocation to properly reconfigure the project with `LLDB_TEST_USE_LLDB_SERVER=1`.

This is a follow up to https://github.com/llvm/llvm-project/pull/206511.