### PR TITLE
[include-cleaner] Treat used function-template using-decls as explicit

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
+++ b/clang-tools-extra/include-cleaner/lib/WalkAST.cpp
@@ -234,6 +234,15 @@ public:
       // But for record decls, spelling of the type always refers to primary
       // decl non-ambiguously. Hence spelling is already a use.
       auto IsUsed = TD->isUsed() || TD->isReferenced() || !TD->getAsFunction();
+      // A call to a function template named through the using-decl marks the
+      // (implicitly instantiated) specialization as used, not the primary
+      // FunctionTemplateDecl. Consult the specializations so a used function
+      // template isn't mistaken for an unused transitively-visible overload.
+      if (!IsUsed)
+        if (const auto *FTD = llvm::dyn_cast<FunctionTemplateDecl>(TD))
+          IsUsed = llvm::any_of(FTD->specializations(), [](const auto *Spec) {
+            return Spec->isUsed() || Spec->isReferenced();
+          });
       report(UD->getLocation(), TD,
              IsUsed ? RefType::Explicit : RefType::Ambiguous);
 

--- a/clang-tools-extra/include-cleaner/test/Inputs/func_template.h
+++ b/clang-tools-extra/include-cleaner/test/Inputs/func_template.h
@@ -1,0 +1,7 @@
+#ifndef FUNC_TEMPLATE_H
+#define FUNC_TEMPLATE_H
+// Origin header: defines the function template ns::ft.
+namespace ns {
+template <class T> void ft(T) {}
+} // namespace ns
+#endif

--- a/clang-tools-extra/include-cleaner/test/Inputs/func_template_reexport.h
+++ b/clang-tools-extra/include-cleaner/test/Inputs/func_template_reexport.h
@@ -1,0 +1,6 @@
+#ifndef FUNC_TEMPLATE_REEXPORT_H
+#define FUNC_TEMPLATE_REEXPORT_H
+// Indirect header: only pulls in the origin header, does NOT itself provide
+// (e.g. re-export) ns::ft. Including this to get ns::ft is a stale include.
+#include "func_template.h"
+#endif

--- a/clang-tools-extra/include-cleaner/test/using-decl-function-template.cpp
+++ b/clang-tools-extra/include-cleaner/test/using-decl-function-template.cpp
@@ -1,0 +1,29 @@
+// Regression test for a function-template named through a using-declaration.
+//
+// ns::ft is defined in func_template.h ("a.h"). We only #include the indirect
+// func_template_reexport.h ("b.h"), bring ns::ft into scope with a local
+// using-declaration, then call it. include-cleaner should report that the
+// indirect header is stale (remove it) AND that the origin header is missing
+// (insert it).
+//
+// BUG: for a *function template* (unlike a plain function, a class template, or
+// a variable template) the use is recorded on the specialization / using-shadow
+// decl, never on the primary FunctionTemplateDecl. So WalkAST's VisitUsingDecl
+// downgrades the reference to the origin to RefType::Ambiguous, the origin
+// header is never *demanded*, and include-cleaner removes the indirect header
+// without inserting the origin -- a build-breaking suggestion.
+//
+// Once WalkAST.cpp treats a used function-template using-decl as an explicit
+// reference, this should pass; drop the XFAIL below at that point.
+//
+// XFAIL: *
+
+#include "func_template_reexport.h"
+
+using ::ns::ft;
+
+void use() { ft<int>(0); }
+
+//      RUN: clang-include-cleaner -print=changes %s -- -I%S/Inputs/ | FileCheck %s
+//      CHECK: - "func_template_reexport.h"
+// CHECK-NEXT: + "func_template.h"

--- a/clang-tools-extra/include-cleaner/test/using-decl-function-template.cpp
+++ b/clang-tools-extra/include-cleaner/test/using-decl-function-template.cpp
@@ -6,17 +6,14 @@
 // indirect header is stale (remove it) AND that the origin header is missing
 // (insert it).
 //
-// BUG: for a *function template* (unlike a plain function, a class template, or
-// a variable template) the use is recorded on the specialization / using-shadow
-// decl, never on the primary FunctionTemplateDecl. So WalkAST's VisitUsingDecl
-// downgrades the reference to the origin to RefType::Ambiguous, the origin
-// header is never *demanded*, and include-cleaner removes the indirect header
-// without inserting the origin -- a build-breaking suggestion.
-//
-// Once WalkAST.cpp treats a used function-template using-decl as an explicit
-// reference, this should pass; drop the XFAIL below at that point.
-//
-// XFAIL: *
+// Regression: for a *function template* (unlike a plain function, a class
+// template, or a variable template) the call is recorded on the implicitly
+// instantiated specialization, not on the primary FunctionTemplateDecl. If
+// WalkAST's VisitUsingDecl only inspected the primary decl it would downgrade
+// the reference to the origin to RefType::Ambiguous, never *demand* the origin
+// header, and remove the indirect header without inserting the origin -- a
+// build-breaking suggestion. VisitUsingDecl consults the specializations to
+// avoid this.
 
 #include "func_template_reexport.h"
 

--- a/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/WalkASTTest.cpp
@@ -281,6 +281,22 @@ template<> void $ambiguous^function(int);       // full specialization
            "using ns::^function;");
 }
 
+TEST(WalkAST, UsedFunctionTemplateFromUsingDecl) {
+  // A call to a function template named through a using-decl marks the
+  // specialization (not the primary FunctionTemplateDecl) as used. The
+  // using-decl must still report the primary template as an explicit reference,
+  // otherwise the origin header is never demanded. See the unused case above,
+  // which stays ambiguous.
+  testWalk(R"cpp(
+namespace ns {
+template<class T> void $explicit^function(T);  // primary template
+template<> void $ambiguous^function(int);      // full specialization
+}
+  )cpp",
+           "using ns::^function;\n"
+           "void run() { function(0); }");
+}
+
 TEST(WalkAST, Alias) {
   testWalk(R"cpp(
     namespace ns { int x; }
@@ -331,6 +347,22 @@ TEST(WalkAST, Using) {
     })cpp",
            "using ns::^x;");
   testWalk("namespace ns { struct S; } using ns::$explicit^S;", "^S *s;");
+
+  // A used function template named via a using-decl is explicit, even though
+  // the call is recorded against the (instantiated) specialization rather than
+  // the primary FunctionTemplateDecl. The specialization is additionally
+  // reported as ambiguous at the same location.
+  testWalk(R"cpp(
+    namespace ns {
+      template <class T> void $explicit^$ambiguous^x(T);
+    })cpp",
+           "using ns::^x; void foo() { x(0); }");
+  // An unused function template stays ambiguous.
+  testWalk(R"cpp(
+    namespace ns {
+      template <class T> void $ambiguous^x(T);
+    })cpp",
+           "using ns::^x;");
 
   testWalk(R"cpp(
     namespace ns {


### PR DESCRIPTION
Consult the function template's specializations when deciding whether the using-decl is used.

Fixes https://github.com/llvm/llvm-project/issues/206635.

Prior to this change, for a function template, calling `foo<int>(0)` would mark the implicitly-instantiated specialization as used, not the primary FunctionTemplateDecl that the using-decl points at — so isUsed()/isReferenced() on the target decl are both false, and the reference is wrongly marked Ambiguous.

I am fairly new to this codebase, and I did this investigation with the help of Claude/Opus.