### PR TITLE
[clang][scan-build-py] Fix configure scripts when using Python 3.14

### DIFF
--- a/clang/tools/scan-build-py/lib/libscanbuild/__init__.py
+++ b/clang/tools/scan-build-py/lib/libscanbuild/__init__.py
@@ -196,9 +196,8 @@ def compiler_wrapper(function):
         function(result, call)
     except:
         logging.exception("Compiler wrapper failed complete.")
-    finally:
-        # Always return the real compiler exit code.
-        return result
+    # Always return the real compiler exit code.
+    return result
 
 
 def wrapper_environment(args):


### PR DESCRIPTION
Python 3.14 (PEP 765) warns about return statements inside finally blocks. This warning breaks intercept-build and friends for configure scripts.

The bare except already catches everything, so falling through to the return is equivalent and silences the SyntaxWarning.