### PR TITLE
[MC] Emit Mach-O pseudo-probe sections in the __LLVM segment

### DIFF
--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -321,12 +321,15 @@ void MCObjectFileInfo::initMachOMCObjectFileInfo(const Triple &T) {
   RemarksSection = Ctx->getMachOSection(
       "__LLVM", "__remarks", MachO::S_ATTR_DEBUG, SectionKind::getMetadata());
 
+  // Emit the pseudoprobe sections in the __LLVM segment. Current ld ignores the
+  // __LLVM and __DWARF segment, so the probe metadata is dropped from the final
+  // linked image on every toolchain.
   PseudoProbeSection =
-      Ctx->getMachOSection("__PSEUDO_PROBE", "__probes",
+      Ctx->getMachOSection("__LLVM", "__probes",
                            MachO::S_ATTR_DEBUG | MachO::S_ATTR_NO_DEAD_STRIP,
                            SectionKind::getMetadata());
   PseudoProbeDescSection =
-      Ctx->getMachOSection("__PSEUDO_PROBE", "__probe_descs",
+      Ctx->getMachOSection("__LLVM", "__probe_descs",
                            MachO::S_ATTR_DEBUG | MachO::S_ATTR_NO_DEAD_STRIP,
                            SectionKind::getMetadata());
 

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -324,10 +324,9 @@ void MCObjectFileInfo::initMachOMCObjectFileInfo(const Triple &T) {
   // Emit the pseudoprobe sections in the __LLVM segment. Current ld ignores the
   // __LLVM and __DWARF segment, so the probe metadata is dropped from the final
   // linked image on every toolchain.
-  PseudoProbeSection =
-      Ctx->getMachOSection("__LLVM", "__probes",
-                           MachO::S_ATTR_DEBUG | MachO::S_ATTR_NO_DEAD_STRIP,
-                           SectionKind::getMetadata());
+  PseudoProbeSection = Ctx->getMachOSection(
+      "__LLVM", "__probes", MachO::S_ATTR_DEBUG | MachO::S_ATTR_NO_DEAD_STRIP,
+      SectionKind::getMetadata());
   PseudoProbeDescSection =
       Ctx->getMachOSection("__LLVM", "__probe_descs",
                            MachO::S_ATTR_DEBUG | MachO::S_ATTR_NO_DEAD_STRIP,

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-emit-macho.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-emit-macho.ll
@@ -83,7 +83,7 @@ entry:
 ; CHECK-IL: ![[#SCOPE1]] = !DILexicalBlockFile(scope: ![[#]], file: ![[#]], discriminator: 455082015)
 
 ; Check the generation of pseudo_probe_desc section for MachO
-; CHECK-ASM-MACHO:      .section	__PSEUDO_PROBE,__probe_descs,regular,no_dead_strip+debug
+; CHECK-ASM-MACHO:      .section	__LLVM,__probe_descs,regular,no_dead_strip+debug
 ; CHECK-ASM-MACHO-NEXT: .quad	[[#GUID]]
 ; CHECK-ASM-MACHO-NEXT: .quad	[[#HASH:]]
 ; CHECK-ASM-MACHO-NEXT: .byte	3
@@ -95,24 +95,24 @@ entry:
 
 ; CHECK-SEC-MACHO-LABEL: Sections [
 ; CHECK-SEC-MACHO:       Name: __probe_descs
-; CHECK-SEC-MACHO-NEXT:  Segment: __PSEUDO_PROBE
+; CHECK-SEC-MACHO-NEXT:  Segment: __LLVM
 ; CHECK-SEC-MACHO:       Attributes [ (0x120000)
 ; CHECK-SEC-MACHO-NEXT:    Debug (0x20000)
 ; CHECK-SEC-MACHO-NEXT:    NoDeadStrip (0x100000)
 ; CHECK-SEC-MACHO:       Name: __probes
-; CHECK-SEC-MACHO-NEXT:  Segment: __PSEUDO_PROBE
+; CHECK-SEC-MACHO-NEXT:  Segment: __LLVM
 ; CHECK-SEC-MACHO:       Attributes [ (0x120000)
 ; CHECK-SEC-MACHO-NEXT:    Debug (0x20000)
 ; CHECK-SEC-MACHO-NEXT:    NoDeadStrip (0x100000)
 
 ; CHECK-SEC-MACHO-MC-LABEL: Sections [
 ; CHECK-SEC-MACHO-MC:       Name: __probe_descs
-; CHECK-SEC-MACHO-MC-NEXT:  Segment: __PSEUDO_PROBE
+; CHECK-SEC-MACHO-MC-NEXT:  Segment: __LLVM
 ; CHECK-SEC-MACHO-MC:       Attributes [ (0x120000)
 ; CHECK-SEC-MACHO-MC-NEXT:    Debug (0x20000)
 ; CHECK-SEC-MACHO-MC-NEXT:    NoDeadStrip (0x100000)
 ; CHECK-SEC-MACHO-MC:       Name: __probes
-; CHECK-SEC-MACHO-MC-NEXT:  Segment: __PSEUDO_PROBE
+; CHECK-SEC-MACHO-MC-NEXT:  Segment: __LLVM
 ; CHECK-SEC-MACHO-MC:       Attributes [ (0x120000)
 ; CHECK-SEC-MACHO-MC-NEXT:    Debug (0x20000)
 ; CHECK-SEC-MACHO-MC-NEXT:    NoDeadStrip (0x100000)


### PR DESCRIPTION
Let's back this out in favor of emitting pseudoprobe data in favor of emitting in the __LLVM segment, and let dsymutil collect the debug map objects and merge them into the final sections. 

This is to prevent older ld toolchains that don't ignore the new `__PSEUDO_PROBE` segments from accidentally leaking the probe metadata into the final image. 