### PR TITLE
[clang][DependencyScanning] Remove Public Uses of `CompilerInstanceWithContext`

### DIFF
--- a/clang/include/clang/DependencyScanning/CompilerInstanceWithContext.h
+++ b/clang/include/clang/DependencyScanning/CompilerInstanceWithContext.h
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_DEPENDENCYSCANNING_COMPILERINSTANCEWITHCONTEXT_H
+#define LLVM_CLANG_DEPENDENCYSCANNING_COMPILERINSTANCEWITHCONTEXT_H
+
+#include "clang/DependencyScanning/DependencyScanningWorker.h"
+
+namespace clang {
+namespace dependencies {
+class CompilerInstanceWithContext {
+  // Context
+  DependencyScanningWorker &Worker;
+  llvm::StringRef CWD;
+  std::vector<std::string> CommandLine;
+
+  // Context - compiler invocation
+  std::unique_ptr<CompilerInvocation> OriginalInvocation;
+
+  // Context - output options
+  std::unique_ptr<DependencyOutputOptions> OutputOpts;
+
+  // Context - stable directory handling
+  llvm::SmallVector<StringRef> StableDirs;
+  PrebuiltModulesAttrsMap PrebuiltModuleASTMap;
+
+  // Compiler Instance
+  std::unique_ptr<CompilerInstance> CIPtr;
+
+  // Source location offset.
+  int32_t SrcLocOffset = 0;
+
+  CompilerInstanceWithContext(DependencyScanningWorker &Worker, StringRef CWD,
+                              ArrayRef<std::string> CMD)
+      : Worker(Worker), CWD(CWD), CommandLine(CMD.begin(), CMD.end()) {}
+
+  bool initialize(
+      DependencyActionController &Controller,
+      std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithDiagOpts,
+      IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS);
+
+public:
+  /// @brief Initialize the tool's compiler instance from the cc1 commandline.
+  /// @param Worker The dependency scanning worker to initialize the compiler
+  ///        instance.
+  /// @param CWD The current working directory.
+  /// @param CC1CommandLine A cc1 command.
+  /// @param DiagEngineWithDiagOpts The diagnostic engine used during scan.
+  /// @param OverlayFS An overlay FS containing the input file, which may be
+  ///        from an in-memory buffer.
+  /// @param Controller A dependency action controller to gather some results.
+  static std::optional<CompilerInstanceWithContext>
+  initializeFromCC1Commandline(
+      DependencyScanningWorker &Worker, StringRef CWD,
+      ArrayRef<std::string> CC1CommandLine,
+      std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithDiagOpts,
+      IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS,
+      DependencyActionController &Controller);
+
+  bool computeDependencies(StringRef ModuleName, DependencyConsumer &Consumer,
+                           DependencyActionController &Controller);
+
+  // MaxNumOfQueries is the upper limit of the number of names the by-name
+  // scanning API (computeDependencies) can support after a
+  // CompilerInstanceWithContext is initialized. At the time of this commit, the
+  // estimated number of total unique importable names is around 3000 from
+  // Apple's SDKs. We usually import them in parallel, so it is unlikely that
+  // all names are all scanned by the same dependency scanning worker. Therefore
+  // the 64k (20x bigger than our estimate) size is sufficient to hold the
+  // unique source locations to report diagnostics per worker.
+  static const int32_t MaxNumOfQueries = 1 << 16;
+};
+} // namespace dependencies
+} // namespace clang
+
+#endif

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -28,10 +28,6 @@ namespace clang {
 
 class DependencyOutputOptions;
 
-namespace tooling {
-class CompilerInstanceWithContext;
-}
-
 namespace dependencies {
 
 class DependencyConsumer;
@@ -89,7 +85,7 @@ private:
   /// The tracing VFS overlaid on top of the base VFS.
   IntrusiveRefCntPtr<llvm::vfs::TracingFileSystem> TracingFS;
 
-  friend tooling::CompilerInstanceWithContext;
+  friend class CompilerInstanceWithContext;
 };
 } // end namespace dependencies
 } // end namespace clang

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -117,6 +117,8 @@ public:
     return Worker.getTracingVFS();
   }
 
+  dependencies::DependencyScanningWorker &getWorker() { return Worker; }
+
 private:
   dependencies::DependencyScanningWorker Worker;
 
@@ -172,9 +174,8 @@ class CompilerInstanceWithContext {
   int32_t SrcLocOffset = 0;
 
   CompilerInstanceWithContext(dependencies::DependencyScanningWorker &Worker,
-                              StringRef CWD,
-                              const std::vector<std::string> &CMD)
-      : Worker(Worker), CWD(CWD), CommandLine(CMD) {};
+                              StringRef CWD, ArrayRef<std::string> CMD)
+      : Worker(Worker), CWD(CWD), CommandLine(CMD.begin(), CMD.end()) {}
 
   bool initialize(dependencies::DependencyActionController &Controller,
                   std::unique_ptr<dependencies::DiagnosticsEngineWithDiagOpts>
@@ -182,21 +183,23 @@ class CompilerInstanceWithContext {
                   IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS);
 
 public:
-  /// @brief Initialize the tool's compiler instance from the commandline.
-  ///        The compiler instance only takes a `-cc1` job, so this method
-  ///        builds the `-cc1` job from the CommandLine input.
-  /// @param Tool The dependency scanning tool whose compiler instance
-  ///        with context is initialized.
+  /// @brief Initialize the tool's compiler instance from the cc1 commandline.
+  /// @param Worker The dependency scanning worker to initialize the compiler
+  ///        instance.
   /// @param CWD The current working directory.
-  /// @param CommandLine This command line may be a driver command or a cc1
-  ///        command.
-  /// @param DC A diagnostics consumer to report error if the initialization
-  ///        fails.
-  static std::optional<CompilerInstanceWithContext> initializeFromCommandline(
-      DependencyScanningTool &Tool, StringRef CWD,
-      ArrayRef<std::string> CommandLine,
-      dependencies::DependencyActionController &Controller,
-      DiagnosticConsumer &DC);
+  /// @param CC1CommandLine A cc1 command.
+  /// @param DiagEngineWithDiagOpts The diagnostic engine used during scan.
+  /// @param OverlayFS An overlay FS containing the input file, which may be
+  ///        from an in-memory buffer.
+  /// @param Controller A dependency action controller to gather some results.
+  static std::optional<CompilerInstanceWithContext>
+  initializeFromCC1Commandline(
+      dependencies::DependencyScanningWorker &Worker, StringRef CWD,
+      ArrayRef<std::string> CC1CommandLine,
+      std::unique_ptr<dependencies::DiagnosticsEngineWithDiagOpts>
+          DiagEngineWithDiagOpts,
+      IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS,
+      dependencies::DependencyActionController &Controller);
 
   /// @brief Initializing the context and the compiler instance.
   ///        This method must be called before calling

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_TOOLING_DEPENDENCYSCANNINGTOOL_H
 #define LLVM_CLANG_TOOLING_DEPENDENCYSCANNINGTOOL_H
 
+#include "clang/DependencyScanning/CompilerInstanceWithContext.h"
 #include "clang/DependencyScanning/DependencyScannerImpl.h"
 #include "clang/DependencyScanning/DependencyScanningService.h"
 #include "clang/DependencyScanning/DependencyScanningUtils.h"
@@ -132,7 +133,7 @@ public:
 private:
   dependencies::DependencyScanningWorker Worker;
   std::unique_ptr<dependencies::TextDiagnosticsPrinterWithOutput> DiagPrinter;
-  std::unique_ptr<CompilerInstanceWithContext> ByNameCIWC;
+  std::unique_ptr<dependencies::CompilerInstanceWithContext> ByNameCIWC;
 };
 
 /// Run the dependency scanning worker for the given driver or frontend
@@ -153,72 +154,6 @@ bool computeDependencies(
     dependencies::DependencyActionController &Controller,
     DiagnosticConsumer &DiagConsumer,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS = nullptr);
-
-class CompilerInstanceWithContext {
-  // Context
-  dependencies::DependencyScanningWorker &Worker;
-  llvm::StringRef CWD;
-  std::vector<std::string> CommandLine;
-
-  // Context - compiler invocation
-  std::unique_ptr<CompilerInvocation> OriginalInvocation;
-
-  // Context - output options
-  std::unique_ptr<DependencyOutputOptions> OutputOpts;
-
-  // Context - stable directory handling
-  llvm::SmallVector<StringRef> StableDirs;
-  dependencies::PrebuiltModulesAttrsMap PrebuiltModuleASTMap;
-
-  // Compiler Instance
-  std::unique_ptr<CompilerInstance> CIPtr;
-
-  // Source location offset.
-  int32_t SrcLocOffset = 0;
-
-  CompilerInstanceWithContext(dependencies::DependencyScanningWorker &Worker,
-                              StringRef CWD, ArrayRef<std::string> CMD)
-      : Worker(Worker), CWD(CWD), CommandLine(CMD.begin(), CMD.end()) {}
-
-  bool initialize(dependencies::DependencyActionController &Controller,
-                  std::unique_ptr<dependencies::DiagnosticsEngineWithDiagOpts>
-                      DiagEngineWithDiagOpts,
-                  IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS);
-
-public:
-  /// @brief Initialize the tool's compiler instance from the cc1 commandline.
-  /// @param Worker The dependency scanning worker to initialize the compiler
-  ///        instance.
-  /// @param CWD The current working directory.
-  /// @param CC1CommandLine A cc1 command.
-  /// @param DiagEngineWithDiagOpts The diagnostic engine used during scan.
-  /// @param OverlayFS An overlay FS containing the input file, which may be
-  ///        from an in-memory buffer.
-  /// @param Controller A dependency action controller to gather some results.
-  static std::optional<CompilerInstanceWithContext>
-  initializeFromCC1Commandline(
-      dependencies::DependencyScanningWorker &Worker, StringRef CWD,
-      ArrayRef<std::string> CC1CommandLine,
-      std::unique_ptr<dependencies::DiagnosticsEngineWithDiagOpts>
-          DiagEngineWithDiagOpts,
-      IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS,
-      dependencies::DependencyActionController &Controller);
-
-  bool
-  computeDependencies(StringRef ModuleName,
-                      dependencies::DependencyConsumer &Consumer,
-                      dependencies::DependencyActionController &Controller);
-
-  // MaxNumOfQueries is the upper limit of the number of names the by-name
-  // scanning API (computeDependencies) can support after a
-  // CompilerInstanceWithContext is initialized. At the time of this commit, the
-  // estimated number of total unique importable names is around 3000 from
-  // Apple's SDKs. We usually import them in parallel, so it is unlikely that
-  // all names are all scanned by the same dependency scanning worker. Therefore
-  // the 64k (20x bigger than our estimate) size is sufficient to hold the
-  // unique source locations to report diagnostics per worker.
-  static const int32_t MaxNumOfQueries = 1 << 16;
-};
 
 } // end namespace tooling
 } // end namespace clang

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -119,10 +119,20 @@ public:
 
   dependencies::DependencyScanningWorker &getWorker() { return Worker; }
 
+  llvm::Error initializeForByNameLookup(
+      StringRef CWD, ArrayRef<std::string> CommandLine,
+      dependencies::DependencyActionController &Controller);
+
+  llvm::Expected<dependencies::TranslationUnitDeps>
+  computeDependenciesByNameOrError(
+      StringRef ModuleName,
+      const llvm::DenseSet<dependencies::ModuleID> &AlreadySeen,
+      dependencies::DependencyActionController &Controller);
+
 private:
   dependencies::DependencyScanningWorker Worker;
-
-  friend class CompilerInstanceWithContext;
+  std::unique_ptr<dependencies::TextDiagnosticsPrinterWithOutput> DiagPrinter;
+  std::unique_ptr<CompilerInstanceWithContext> ByNameCIWC;
 };
 
 /// Run the dependency scanning worker for the given driver or frontend
@@ -149,13 +159,6 @@ class CompilerInstanceWithContext {
   dependencies::DependencyScanningWorker &Worker;
   llvm::StringRef CWD;
   std::vector<std::string> CommandLine;
-
-  // Context - Diagnostics engine.
-  DiagnosticConsumer *DiagConsumer = nullptr;
-  std::unique_ptr<dependencies::DiagnosticsEngineWithDiagOpts>
-      DiagEngineWithCmdAndOpts;
-  std::unique_ptr<dependencies::TextDiagnosticsPrinterWithOutput>
-      DiagPrinterWithOS;
 
   // Context - compiler invocation
   std::unique_ptr<CompilerInvocation> OriginalInvocation;
@@ -201,41 +204,10 @@ public:
       IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS,
       dependencies::DependencyActionController &Controller);
 
-  /// @brief Initializing the context and the compiler instance.
-  ///        This method must be called before calling
-  ///        computeDependenciesByNameWithContext.
-  /// @param CWD The current working directory used during the scan.
-  /// @param CommandLine The commandline used for the scan.
-  /// @return Error if the initializaiton fails.
-  static llvm::Expected<CompilerInstanceWithContext>
-  initializeOrError(DependencyScanningTool &Tool, StringRef CWD,
-                    ArrayRef<std::string> CommandLine,
-                    dependencies::DependencyActionController &Controller);
-
   bool
   computeDependencies(StringRef ModuleName,
                       dependencies::DependencyConsumer &Consumer,
                       dependencies::DependencyActionController &Controller);
-
-  /// @brief Computes the dependeny for the module named ModuleName.
-  /// @param ModuleName The name of the module for which this method computes
-  ///.                  dependencies.
-  /// @param AlreadySeen This stores modules which have previously been
-  ///                    reported. Use the same instance for all calls to this
-  ///                    function for a single \c DependencyScanningTool in a
-  ///                    single build. Note that this parameter is not part of
-  ///                    the context because it can be shared across different
-  ///                    worker threads and each worker thread may update it.
-  /// @param LookupModuleOutput This function is called to fill in
-  ///                           "-fmodule-file=", "-o" and other output
-  ///                           arguments for dependencies.
-  /// @return An instance of \c TranslationUnitDeps if the scan is successful.
-  ///         Otherwise it returns an error.
-  llvm::Expected<dependencies::TranslationUnitDeps>
-  computeDependenciesByNameOrError(
-      StringRef ModuleName,
-      const llvm::DenseSet<dependencies::ModuleID> &AlreadySeen,
-      dependencies::DependencyActionController &Controller);
 
   // MaxNumOfQueries is the upper limit of the number of names the by-name
   // scanning API (computeDependencies) can support after a

--- a/clang/lib/DependencyScanning/CMakeLists.txt
+++ b/clang/lib/DependencyScanning/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_clang_library(clangDependencyScanning
+  CompilerInstanceWithContext.cpp
   DependencyGraph.cpp
   DependencyScanningFilesystem.cpp
   DependencyScanningService.cpp

--- a/clang/lib/DependencyScanning/CompilerInstanceWithContext.cpp
+++ b/clang/lib/DependencyScanning/CompilerInstanceWithContext.cpp
@@ -1,0 +1,201 @@
+//===- CompilerInstanceWithContext.cpp - CI for dependency scanning -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/DependencyScanning/CompilerInstanceWithContext.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticFrontend.h"
+#include "clang/DependencyScanning/DependencyActionController.h"
+#include "clang/DependencyScanning/DependencyConsumer.h"
+#include "clang/DependencyScanning/DependencyScannerImpl.h"
+#include "clang/Frontend/FrontendActions.h"
+#include "llvm/ADT/ScopeExit.h"
+
+using namespace clang;
+using namespace dependencies;
+
+std::optional<CompilerInstanceWithContext>
+CompilerInstanceWithContext::initializeFromCC1Commandline(
+    DependencyScanningWorker &Worker, StringRef CWD,
+    ArrayRef<std::string> CC1CommandLine,
+    std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithDiagOpts,
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS,
+    DependencyActionController &Controller) {
+  CompilerInstanceWithContext CIWC(Worker, CWD, CC1CommandLine);
+  if (!CIWC.initialize(Controller, std::move(DiagEngineWithDiagOpts),
+                       std::move(OverlayFS)))
+    return std::nullopt;
+  return std::move(CIWC);
+}
+
+bool CompilerInstanceWithContext::initialize(
+    DependencyActionController &Controller,
+    std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithDiagOpts,
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS) {
+  {
+    auto LogLine = Worker.Service.getLogger().log();
+    LogLine.logArray("init_compiler_instance_with_context:", " ", CommandLine);
+  }
+  assert(DiagEngineWithDiagOpts && "Valid diagnostics engine required!");
+  assert(OverlayFS && "OverlayFS required!");
+  auto FS = Worker.makeEffectiveVFS(CWD, std::move(OverlayFS));
+
+  OriginalInvocation = createCompilerInvocation(
+      CommandLine, *DiagEngineWithDiagOpts->DiagEngine);
+  if (!OriginalInvocation) {
+    DiagEngineWithDiagOpts->DiagEngine->Report(
+        diag::err_fe_expected_compiler_job)
+        << llvm::join(CommandLine, " ");
+    return false;
+  }
+
+  if (any(Worker.Service.getOpts().OptimizeArgs &
+          ScanningOptimizations::Macros))
+    canonicalizeDefines(OriginalInvocation->getPreprocessorOpts());
+
+  // Create the CompilerInstance.
+  std::shared_ptr<ModuleCache> ModCache = makeInProcessModuleCache(
+      Worker.Service.getModuleCacheEntries(), Worker.Service.getLogger());
+  CIPtr = std::make_unique<CompilerInstance>(
+      createScanCompilerInvocation(*OriginalInvocation, Worker.Service,
+                                   Controller),
+      Worker.PCHContainerOps, std::move(ModCache));
+  auto &CI = *CIPtr;
+
+  initializeScanCompilerInstance(
+      CI, std::move(FS), DiagEngineWithDiagOpts->DiagEngine->getClient(),
+      Worker.Service, Worker.DepFS);
+
+  StableDirs = getInitialStableDirs(CI);
+  auto MaybePrebuiltModulesASTMap =
+      computePrebuiltModulesASTMap(CI, StableDirs);
+  if (!MaybePrebuiltModulesASTMap)
+    return false;
+
+  PrebuiltModuleASTMap = std::move(*MaybePrebuiltModulesASTMap);
+  OutputOpts = createDependencyOutputOptions(*OriginalInvocation);
+
+  // We do not create the target in initializeScanCompilerInstance because
+  // setting it here is unique for by-name lookups. We create the target only
+  // once here, and the information is reused for all computeDependencies calls.
+  // We do not need to call createTarget explicitly if we go through
+  // CompilerInstance::ExecuteAction to perform scanning.
+  CI.createTarget();
+
+  return true;
+}
+
+bool CompilerInstanceWithContext::computeDependencies(
+    StringRef ModuleName, DependencyConsumer &Consumer,
+    DependencyActionController &Controller) {
+  Worker.Service.getLogger().log() << "start scan_by_name: " << ModuleName;
+  llvm::scope_exit ExitLogging([&]() {
+    Worker.Service.getLogger().log() << "finish scan_by_name: " << ModuleName;
+  });
+  if (SrcLocOffset >= MaxNumOfQueries)
+    llvm::report_fatal_error("exceeded maximum by-name scans for worker");
+
+  assert(CIPtr && "CIPtr must be initialized before calling this method");
+  auto &CI = *CIPtr;
+
+  // We need to reset the diagnostics, so that the diagnostics issued
+  // during a previous computeDependencies call do not affect the current call.
+  // If we do not reset, we may inherit fatal errors from a previous call.
+  CI.getDiagnostics().Reset();
+
+  // We create this cleanup object because computeDependencies may exit
+  // early with errors.
+  llvm::scope_exit CleanUp([&]() {
+    CI.clearDependencyCollectors();
+    // The preprocessor may not be created at the entry of this method,
+    // but it must have been created when this method returns, whether
+    // there are errors during scanning or not.
+    CI.getPreprocessor().removePPCallbacks();
+  });
+
+  auto MDC = initializeScanInstanceDependencyCollector(
+      CI, std::make_unique<DependencyOutputOptions>(*OutputOpts),
+      Worker.Service,
+      /* The MDC's constructor makes a copy of the OriginalInvocation, so
+      we can pass it in without worrying that it might be changed across
+      invocations of computeDependencies. */
+      *OriginalInvocation, Controller, PrebuiltModuleASTMap, StableDirs);
+
+  CompilerInvocation ModuleInvocation(*OriginalInvocation);
+  if (!Controller.initialize(CI, ModuleInvocation))
+    return false;
+
+  if (!SrcLocOffset) {
+    // When SrcLocOffset is zero, we are at the beginning of the fake source
+    // file. In this case, we call BeginSourceFile to initialize.
+    std::unique_ptr<FrontendAction> Action =
+        std::make_unique<PreprocessOnlyAction>();
+    auto *InputFile = CI.getFrontendOpts().Inputs.begin();
+    bool ActionBeginSucceeded = Action->BeginSourceFile(CI, *InputFile);
+    assert(ActionBeginSucceeded && "Action BeginSourceFile must succeed");
+    (void)ActionBeginSucceeded;
+  }
+
+  Preprocessor &PP = CI.getPreprocessor();
+  SourceManager &SM = PP.getSourceManager();
+  FileID MainFileID = SM.getMainFileID();
+  SourceLocation FileStart = SM.getLocForStartOfFile(MainFileID);
+  SourceLocation IDLocation = FileStart.getLocWithOffset(SrcLocOffset);
+  PPCallbacks *CB = nullptr;
+  if (!SrcLocOffset) {
+    // We need to call EnterSourceFile when SrcLocOffset is zero to initialize
+    // the preprocessor.
+    bool PPFailed = PP.EnterSourceFile(MainFileID, nullptr, SourceLocation());
+    assert(!PPFailed && "Preprocess must be able to enter the main file.");
+    (void)PPFailed;
+    CB = MDC->getPPCallbacks();
+  } else {
+    // When SrcLocOffset is non-zero, the preprocessor has already been
+    // initialized through a previous call of computeDependencies. We want to
+    // preserve the PP's state, hence we do not call EnterSourceFile again.
+    MDC->attachToPreprocessor(PP);
+    CB = MDC->getPPCallbacks();
+
+    FileID PrevFID;
+    SrcMgr::CharacteristicKind FileType = SM.getFileCharacteristic(IDLocation);
+    CB->LexedFileChanged(MainFileID,
+                         PPChainedCallbacks::LexedFileChangeReason::EnterFile,
+                         FileType, PrevFID, IDLocation);
+  }
+
+  // FIXME: Scan modules asynchronously here as well.
+
+  SrcLocOffset++;
+  SmallVector<IdentifierLoc, 2> Path;
+  IdentifierInfo *ModuleID = PP.getIdentifierInfo(ModuleName);
+  Path.emplace_back(IDLocation, ModuleID);
+  auto ModResult = CI.loadModule(IDLocation, Path, Module::Hidden, false);
+
+  assert(CB && "Must have PPCallbacks after module loading");
+  CB->moduleImport(SourceLocation(), Path, ModResult);
+
+  if (!ModResult)
+    return false;
+
+  if (CI.getDiagnostics().hasErrorOccurred())
+    return false;
+
+  MDC->run(Consumer);
+  MDC->applyDiscoveredDependencies(ModuleInvocation);
+
+  bool Success = ModuleInvocation.withCowRef<bool>(
+      [&](CowCompilerInvocation &CowModuleInvocation) {
+        return Controller.finalize(CI, CowModuleInvocation);
+      });
+  if (!Success)
+    return false;
+
+  Consumer.handleBuildCommand(
+      {CommandLine[0], ModuleInvocation.getCC1CommandLine()});
+
+  return true;
+}

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -286,7 +286,7 @@ initVFSForByNameScanning(ArrayRef<std::string> CommandLine) {
   // locations for the diagnostics. Therefore, sharing this global buffer across
   // threads is ok.
   static const std::string FakeInput(
-      CompilerInstanceWithContext::MaxNumOfQueries, ' ');
+      dependencies::CompilerInstanceWithContext::MaxNumOfQueries, ' ');
 
   StringRef InputPath =
       llvm::sys::path::is_style_windows(llvm::sys::path::Style::native)
@@ -362,7 +362,7 @@ getFirstCC1CommandLine(ArrayRef<std::string> CommandLine,
   return std::nullopt;
 }
 
-static std::optional<CompilerInstanceWithContext>
+static std::optional<dependencies::CompilerInstanceWithContext>
 createCompilerInstanceWithContextFromCommandline(
     DependencyScanningTool &Tool, StringRef CWD,
     ArrayRef<std::string> CommandLine, DependencyActionController &Controller,
@@ -377,9 +377,10 @@ createCompilerInstanceWithContextFromCommandline(
   if (ModifiedCommandLine.size() >= 2 && ModifiedCommandLine[1] == "-cc1") {
     // The input command line is already a -cc1 invocation; initialize the
     // compiler instance directly from it.
-    return CompilerInstanceWithContext::initializeFromCC1Commandline(
-        Tool.getWorker(), CWD, ModifiedCommandLine,
-        std::move(DiagEngineWithCmdAndOpts), std::move(OverlayFS), Controller);
+    return dependencies::CompilerInstanceWithContext::
+        initializeFromCC1Commandline(Tool.getWorker(), CWD, ModifiedCommandLine,
+                                     std::move(DiagEngineWithCmdAndOpts),
+                                     std::move(OverlayFS), Controller);
   }
 
   // The input command line is either a driver-style command line, or
@@ -392,9 +393,10 @@ createCompilerInstanceWithContextFromCommandline(
 
   std::vector<std::string> CC1CommandLine(MaybeFirstCC1->begin(),
                                           MaybeFirstCC1->end());
-  return CompilerInstanceWithContext::initializeFromCC1Commandline(
-      Tool.getWorker(), CWD, CC1CommandLine,
-      std::move(DiagEngineWithCmdAndOpts), std::move(OverlayFS), Controller);
+  return dependencies::CompilerInstanceWithContext::
+      initializeFromCC1Commandline(Tool.getWorker(), CWD, CC1CommandLine,
+                                   std::move(DiagEngineWithCmdAndOpts),
+                                   std::move(OverlayFS), Controller);
 }
 
 llvm::Error DependencyScanningTool::initializeForByNameLookup(
@@ -406,8 +408,8 @@ llvm::Error DependencyScanningTool::initializeForByNameLookup(
       *this, CWD, CommandLine, Controller, DiagPrinter->DiagPrinter);
   if (!Result)
     return makeErrorFromDiagnosticsOS(*DiagPrinter);
-  ByNameCIWC =
-      std::make_unique<CompilerInstanceWithContext>(std::move(*Result));
+  ByNameCIWC = std::make_unique<dependencies::CompilerInstanceWithContext>(
+      std::move(*Result));
   return llvm::Error::success();
 }
 
@@ -421,187 +423,4 @@ DependencyScanningTool::computeDependenciesByNameOrError(
   if (ByNameCIWC->computeDependencies(ModuleName, Consumer, Controller))
     return Consumer.takeTranslationUnitDeps();
   return makeErrorFromDiagnosticsOS(*DiagPrinter);
-}
-
-std::optional<CompilerInstanceWithContext>
-CompilerInstanceWithContext::initializeFromCC1Commandline(
-    DependencyScanningWorker &Worker, StringRef CWD,
-    ArrayRef<std::string> CC1CommandLine,
-    std::unique_ptr<dependencies::DiagnosticsEngineWithDiagOpts>
-        DiagEngineWithDiagOpts,
-    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS,
-    DependencyActionController &Controller) {
-  CompilerInstanceWithContext CIWC(Worker, CWD, CC1CommandLine);
-  if (!CIWC.initialize(Controller, std::move(DiagEngineWithDiagOpts),
-                       std::move(OverlayFS)))
-    return std::nullopt;
-  return std::move(CIWC);
-}
-
-bool CompilerInstanceWithContext::initialize(
-    DependencyActionController &Controller,
-    std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithDiagOpts,
-    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS) {
-  {
-    auto LogLine = Worker.Service.getLogger().log();
-    LogLine.logArray("init_compiler_instance_with_context:", " ", CommandLine);
-  }
-  assert(DiagEngineWithDiagOpts && "Valid diagnostics engine required!");
-  assert(OverlayFS && "OverlayFS required!");
-  auto FS = Worker.makeEffectiveVFS(CWD, std::move(OverlayFS));
-
-  OriginalInvocation = createCompilerInvocation(
-      CommandLine, *DiagEngineWithDiagOpts->DiagEngine);
-  if (!OriginalInvocation) {
-    DiagEngineWithDiagOpts->DiagEngine->Report(
-        diag::err_fe_expected_compiler_job)
-        << llvm::join(CommandLine, " ");
-    return false;
-  }
-
-  if (any(Worker.Service.getOpts().OptimizeArgs &
-          ScanningOptimizations::Macros))
-    canonicalizeDefines(OriginalInvocation->getPreprocessorOpts());
-
-  // Create the CompilerInstance.
-  std::shared_ptr<ModuleCache> ModCache = makeInProcessModuleCache(
-      Worker.Service.getModuleCacheEntries(), Worker.Service.getLogger());
-  CIPtr = std::make_unique<CompilerInstance>(
-      createScanCompilerInvocation(*OriginalInvocation, Worker.Service,
-                                   Controller),
-      Worker.PCHContainerOps, std::move(ModCache));
-  auto &CI = *CIPtr;
-
-  initializeScanCompilerInstance(
-      CI, std::move(FS), DiagEngineWithDiagOpts->DiagEngine->getClient(),
-      Worker.Service, Worker.DepFS);
-
-  StableDirs = getInitialStableDirs(CI);
-  auto MaybePrebuiltModulesASTMap =
-      computePrebuiltModulesASTMap(CI, StableDirs);
-  if (!MaybePrebuiltModulesASTMap)
-    return false;
-
-  PrebuiltModuleASTMap = std::move(*MaybePrebuiltModulesASTMap);
-  OutputOpts = createDependencyOutputOptions(*OriginalInvocation);
-
-  // We do not create the target in initializeScanCompilerInstance because
-  // setting it here is unique for by-name lookups. We create the target only
-  // once here, and the information is reused for all computeDependencies calls.
-  // We do not need to call createTarget explicitly if we go through
-  // CompilerInstance::ExecuteAction to perform scanning.
-  CI.createTarget();
-
-  return true;
-}
-
-bool CompilerInstanceWithContext::computeDependencies(
-    StringRef ModuleName, DependencyConsumer &Consumer,
-    DependencyActionController &Controller) {
-  Worker.Service.getLogger().log() << "start scan_by_name: " << ModuleName;
-  llvm::scope_exit ExitLogging([&]() {
-    Worker.Service.getLogger().log() << "finish scan_by_name: " << ModuleName;
-  });
-  if (SrcLocOffset >= MaxNumOfQueries)
-    llvm::report_fatal_error("exceeded maximum by-name scans for worker");
-
-  assert(CIPtr && "CIPtr must be initialized before calling this method");
-  auto &CI = *CIPtr;
-
-  // We need to reset the diagnostics, so that the diagnostics issued
-  // during a previous computeDependencies call do not affect the current call.
-  // If we do not reset, we may inherit fatal errors from a previous call.
-  CI.getDiagnostics().Reset();
-
-  // We create this cleanup object because computeDependencies may exit
-  // early with errors.
-  llvm::scope_exit CleanUp([&]() {
-    CI.clearDependencyCollectors();
-    // The preprocessor may not be created at the entry of this method,
-    // but it must have been created when this method returns, whether
-    // there are errors during scanning or not.
-    CI.getPreprocessor().removePPCallbacks();
-  });
-
-  auto MDC = initializeScanInstanceDependencyCollector(
-      CI, std::make_unique<DependencyOutputOptions>(*OutputOpts),
-      Worker.Service,
-      /* The MDC's constructor makes a copy of the OriginalInvocation, so
-      we can pass it in without worrying that it might be changed across
-      invocations of computeDependencies. */
-      *OriginalInvocation, Controller, PrebuiltModuleASTMap, StableDirs);
-
-  CompilerInvocation ModuleInvocation(*OriginalInvocation);
-  if (!Controller.initialize(CI, ModuleInvocation))
-    return false;
-
-  if (!SrcLocOffset) {
-    // When SrcLocOffset is zero, we are at the beginning of the fake source
-    // file. In this case, we call BeginSourceFile to initialize.
-    std::unique_ptr<FrontendAction> Action =
-        std::make_unique<PreprocessOnlyAction>();
-    auto *InputFile = CI.getFrontendOpts().Inputs.begin();
-    bool ActionBeginSucceeded = Action->BeginSourceFile(CI, *InputFile);
-    assert(ActionBeginSucceeded && "Action BeginSourceFile must succeed");
-    (void)ActionBeginSucceeded;
-  }
-
-  Preprocessor &PP = CI.getPreprocessor();
-  SourceManager &SM = PP.getSourceManager();
-  FileID MainFileID = SM.getMainFileID();
-  SourceLocation FileStart = SM.getLocForStartOfFile(MainFileID);
-  SourceLocation IDLocation = FileStart.getLocWithOffset(SrcLocOffset);
-  PPCallbacks *CB = nullptr;
-  if (!SrcLocOffset) {
-    // We need to call EnterSourceFile when SrcLocOffset is zero to initialize
-    // the preprocessor.
-    bool PPFailed = PP.EnterSourceFile(MainFileID, nullptr, SourceLocation());
-    assert(!PPFailed && "Preprocess must be able to enter the main file.");
-    (void)PPFailed;
-    CB = MDC->getPPCallbacks();
-  } else {
-    // When SrcLocOffset is non-zero, the preprocessor has already been
-    // initialized through a previous call of computeDependencies. We want to
-    // preserve the PP's state, hence we do not call EnterSourceFile again.
-    MDC->attachToPreprocessor(PP);
-    CB = MDC->getPPCallbacks();
-
-    FileID PrevFID;
-    SrcMgr::CharacteristicKind FileType = SM.getFileCharacteristic(IDLocation);
-    CB->LexedFileChanged(MainFileID,
-                         PPChainedCallbacks::LexedFileChangeReason::EnterFile,
-                         FileType, PrevFID, IDLocation);
-  }
-
-  // FIXME: Scan modules asynchronously here as well.
-
-  SrcLocOffset++;
-  SmallVector<IdentifierLoc, 2> Path;
-  IdentifierInfo *ModuleID = PP.getIdentifierInfo(ModuleName);
-  Path.emplace_back(IDLocation, ModuleID);
-  auto ModResult = CI.loadModule(IDLocation, Path, Module::Hidden, false);
-
-  assert(CB && "Must have PPCallbacks after module loading");
-  CB->moduleImport(SourceLocation(), Path, ModResult);
-
-  if (!ModResult)
-    return false;
-
-  if (CI.getDiagnostics().hasErrorOccurred())
-    return false;
-
-  MDC->run(Consumer);
-  MDC->applyDiscoveredDependencies(ModuleInvocation);
-
-  bool Success = ModuleInvocation.withCowRef<bool>(
-      [&](CowCompilerInvocation &CowModuleInvocation) {
-        return Controller.finalize(CI, CowModuleInvocation);
-      });
-  if (!Success)
-    return false;
-
-  Consumer.handleBuildCommand(
-      {CommandLine[0], ModuleInvocation.getCC1CommandLine()});
-
-  return true;
 }

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -334,13 +334,9 @@ DependencyScanningTool::getModuleDependencies(
     StringRef ModuleName, ArrayRef<std::string> CommandLine, StringRef CWD,
     const llvm::DenseSet<ModuleID> &AlreadySeen,
     DependencyActionController &Controller) {
-  auto MaybeCIWithContext = CompilerInstanceWithContext::initializeOrError(
-      *this, CWD, CommandLine, Controller);
-  if (auto Error = MaybeCIWithContext.takeError())
-    return Error;
-
-  return MaybeCIWithContext->computeDependenciesByNameOrError(
-      ModuleName, AlreadySeen, Controller);
+  if (llvm::Error Err = initializeForByNameLookup(CWD, CommandLine, Controller))
+    return std::move(Err);
+  return computeDependenciesByNameOrError(ModuleName, AlreadySeen, Controller);
 }
 
 static std::optional<SmallVector<std::string, 0>>
@@ -401,6 +397,32 @@ createCompilerInstanceWithContextFromCommandline(
       std::move(DiagEngineWithCmdAndOpts), std::move(OverlayFS), Controller);
 }
 
+llvm::Error DependencyScanningTool::initializeForByNameLookup(
+    StringRef CWD, ArrayRef<std::string> CommandLine,
+    DependencyActionController &Controller) {
+  ByNameCIWC.reset();
+  DiagPrinter = std::make_unique<TextDiagnosticsPrinterWithOutput>(CommandLine);
+  auto Result = createCompilerInstanceWithContextFromCommandline(
+      *this, CWD, CommandLine, Controller, DiagPrinter->DiagPrinter);
+  if (!Result)
+    return makeErrorFromDiagnosticsOS(*DiagPrinter);
+  ByNameCIWC =
+      std::make_unique<CompilerInstanceWithContext>(std::move(*Result));
+  return llvm::Error::success();
+}
+
+llvm::Expected<TranslationUnitDeps>
+DependencyScanningTool::computeDependenciesByNameOrError(
+    StringRef ModuleName, const llvm::DenseSet<ModuleID> &AlreadySeen,
+    DependencyActionController &Controller) {
+  assert(ByNameCIWC && "initializeForByNameLookup must be called first");
+  FullDependencyConsumer Consumer(AlreadySeen);
+  DiagPrinter->DiagnosticOutput.clear();
+  if (ByNameCIWC->computeDependencies(ModuleName, Consumer, Controller))
+    return Consumer.takeTranslationUnitDeps();
+  return makeErrorFromDiagnosticsOS(*DiagPrinter);
+}
+
 std::optional<CompilerInstanceWithContext>
 CompilerInstanceWithContext::initializeFromCC1Commandline(
     DependencyScanningWorker &Worker, StringRef CWD,
@@ -416,62 +438,22 @@ CompilerInstanceWithContext::initializeFromCC1Commandline(
   return std::move(CIWC);
 }
 
-llvm::Expected<CompilerInstanceWithContext>
-CompilerInstanceWithContext::initializeOrError(
-    DependencyScanningTool &Tool, StringRef CWD,
-    ArrayRef<std::string> CommandLine, DependencyActionController &Controller) {
-  {
-    auto LogLine = Tool.Worker.Service.getLogger().log();
-    LogLine << "init_compiler_instance_with_context:";
-    for (const auto &C : CommandLine) {
-      LogLine << " " << C;
-    }
-  }
-  auto DiagPrinterWithOS =
-      std::make_unique<TextDiagnosticsPrinterWithOutput>(CommandLine);
-
-  auto Result = createCompilerInstanceWithContextFromCommandline(
-      Tool, CWD, CommandLine, Controller, DiagPrinterWithOS->DiagPrinter);
-  if (Result) {
-    Result->DiagPrinterWithOS = std::move(DiagPrinterWithOS);
-    return std::move(*Result);
-  }
-  return makeErrorFromDiagnosticsOS(*DiagPrinterWithOS);
-}
-
-llvm::Expected<TranslationUnitDeps>
-CompilerInstanceWithContext::computeDependenciesByNameOrError(
-    StringRef ModuleName, const llvm::DenseSet<ModuleID> &AlreadySeen,
-    DependencyActionController &Controller) {
-  Worker.Service.getLogger().log() << "start scan_by_name: " << ModuleName;
-  llvm::scope_exit ExitLogging([&] {
-    Worker.Service.getLogger().log() << "finish scan_by_name: " << ModuleName;
-  });
-
-  FullDependencyConsumer Consumer(AlreadySeen);
-  // We need to clear the DiagnosticOutput so that each by-name lookup
-  // has a clean diagnostics buffer.
-  DiagPrinterWithOS->DiagnosticOutput.clear();
-  if (computeDependencies(ModuleName, Consumer, Controller))
-    return Consumer.takeTranslationUnitDeps();
-  return makeErrorFromDiagnosticsOS(*DiagPrinterWithOS);
-}
-
 bool CompilerInstanceWithContext::initialize(
     DependencyActionController &Controller,
     std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithDiagOpts,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS) {
+  {
+    auto LogLine = Worker.Service.getLogger().log();
+    LogLine.logArray("init_compiler_instance_with_context:", " ", CommandLine);
+  }
   assert(DiagEngineWithDiagOpts && "Valid diagnostics engine required!");
-  DiagEngineWithCmdAndOpts = std::move(DiagEngineWithDiagOpts);
-  DiagConsumer = DiagEngineWithCmdAndOpts->DiagEngine->getClient();
-
   assert(OverlayFS && "OverlayFS required!");
   auto FS = Worker.makeEffectiveVFS(CWD, std::move(OverlayFS));
 
   OriginalInvocation = createCompilerInvocation(
-      CommandLine, *DiagEngineWithCmdAndOpts->DiagEngine);
+      CommandLine, *DiagEngineWithDiagOpts->DiagEngine);
   if (!OriginalInvocation) {
-    DiagEngineWithCmdAndOpts->DiagEngine->Report(
+    DiagEngineWithDiagOpts->DiagEngine->Report(
         diag::err_fe_expected_compiler_job)
         << llvm::join(CommandLine, " ");
     return false;
@@ -491,7 +473,7 @@ bool CompilerInstanceWithContext::initialize(
   auto &CI = *CIPtr;
 
   initializeScanCompilerInstance(
-      CI, std::move(FS), DiagEngineWithCmdAndOpts->DiagEngine->getClient(),
+      CI, std::move(FS), DiagEngineWithDiagOpts->DiagEngine->getClient(),
       Worker.Service, Worker.DepFS);
 
   StableDirs = getInitialStableDirs(CI);
@@ -516,6 +498,10 @@ bool CompilerInstanceWithContext::initialize(
 bool CompilerInstanceWithContext::computeDependencies(
     StringRef ModuleName, DependencyConsumer &Consumer,
     DependencyActionController &Controller) {
+  Worker.Service.getLogger().log() << "start scan_by_name: " << ModuleName;
+  llvm::scope_exit ExitLogging([&]() {
+    Worker.Service.getLogger().log() << "finish scan_by_name: " << ModuleName;
+  });
   if (SrcLocOffset >= MaxNumOfQueries)
     llvm::report_fatal_error("exceeded maximum by-name scans for worker");
 

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -366,13 +366,13 @@ getFirstCC1CommandLine(ArrayRef<std::string> CommandLine,
   return std::nullopt;
 }
 
-std::optional<CompilerInstanceWithContext>
-CompilerInstanceWithContext::initializeFromCommandline(
+static std::optional<CompilerInstanceWithContext>
+createCompilerInstanceWithContextFromCommandline(
     DependencyScanningTool &Tool, StringRef CWD,
     ArrayRef<std::string> CommandLine, DependencyActionController &Controller,
     DiagnosticConsumer &DC) {
   auto [OverlayFS, ModifiedCommandLine] = initVFSForByNameScanning(CommandLine);
-  auto FS = Tool.Worker.makeEffectiveVFS(CWD, OverlayFS);
+  auto FS = Tool.getWorker().makeEffectiveVFS(CWD, OverlayFS);
 
   auto DiagEngineWithCmdAndOpts =
       std::make_unique<DiagnosticsEngineWithDiagOpts>(ModifiedCommandLine, FS,
@@ -381,13 +381,9 @@ CompilerInstanceWithContext::initializeFromCommandline(
   if (ModifiedCommandLine.size() >= 2 && ModifiedCommandLine[1] == "-cc1") {
     // The input command line is already a -cc1 invocation; initialize the
     // compiler instance directly from it.
-    CompilerInstanceWithContext CIWithContext(Tool.Worker, CWD,
-                                              ModifiedCommandLine);
-    if (!CIWithContext.initialize(Controller,
-                                  std::move(DiagEngineWithCmdAndOpts),
-                                  std::move(OverlayFS)))
-      return std::nullopt;
-    return std::move(CIWithContext);
+    return CompilerInstanceWithContext::initializeFromCC1Commandline(
+        Tool.getWorker(), CWD, ModifiedCommandLine,
+        std::move(DiagEngineWithCmdAndOpts), std::move(OverlayFS), Controller);
   }
 
   // The input command line is either a driver-style command line, or
@@ -400,12 +396,24 @@ CompilerInstanceWithContext::initializeFromCommandline(
 
   std::vector<std::string> CC1CommandLine(MaybeFirstCC1->begin(),
                                           MaybeFirstCC1->end());
-  CompilerInstanceWithContext CIWithContext(Tool.Worker, CWD,
-                                            std::move(CC1CommandLine));
-  if (!CIWithContext.initialize(Controller, std::move(DiagEngineWithCmdAndOpts),
-                                std::move(OverlayFS)))
+  return CompilerInstanceWithContext::initializeFromCC1Commandline(
+      Tool.getWorker(), CWD, CC1CommandLine,
+      std::move(DiagEngineWithCmdAndOpts), std::move(OverlayFS), Controller);
+}
+
+std::optional<CompilerInstanceWithContext>
+CompilerInstanceWithContext::initializeFromCC1Commandline(
+    DependencyScanningWorker &Worker, StringRef CWD,
+    ArrayRef<std::string> CC1CommandLine,
+    std::unique_ptr<dependencies::DiagnosticsEngineWithDiagOpts>
+        DiagEngineWithDiagOpts,
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS,
+    DependencyActionController &Controller) {
+  CompilerInstanceWithContext CIWC(Worker, CWD, CC1CommandLine);
+  if (!CIWC.initialize(Controller, std::move(DiagEngineWithDiagOpts),
+                       std::move(OverlayFS)))
     return std::nullopt;
-  return std::move(CIWithContext);
+  return std::move(CIWC);
 }
 
 llvm::Expected<CompilerInstanceWithContext>
@@ -422,8 +430,8 @@ CompilerInstanceWithContext::initializeOrError(
   auto DiagPrinterWithOS =
       std::make_unique<TextDiagnosticsPrinterWithOutput>(CommandLine);
 
-  auto Result = initializeFromCommandline(Tool, CWD, CommandLine, Controller,
-                                          DiagPrinterWithOS->DiagPrinter);
+  auto Result = createCompilerInstanceWithContextFromCommandline(
+      Tool, CWD, CommandLine, Controller, DiagPrinterWithOS->DiagPrinter);
   if (Result) {
     Result->DiagPrinterWithOS = std::move(DiagPrinterWithOS);
     return std::move(*Result);

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1119,9 +1119,8 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
                                  LocalIndex, DependencyOS, Errs))
             HadErrors = true;
         } else {
-          auto CIWithCtx = CompilerInstanceWithContext::initializeOrError(
-              WorkerTool, CWD, Input->CommandLine, Controller);
-          if (llvm::Error Err = CIWithCtx.takeError()) {
+          if (llvm::Error Err = WorkerTool.initializeForByNameLookup(
+                  CWD, Input->CommandLine, Controller)) {
             handleErrorWithInfoString(
                 "Compiler instance with context setup error", std::move(Err),
                 DependencyOS, Errs);
@@ -1131,7 +1130,7 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
 
           for (auto N : Names) {
             auto MaybeModuleDepsGraph =
-                CIWithCtx->computeDependenciesByNameOrError(
+                WorkerTool.computeDependenciesByNameOrError(
                     N, AlreadySeenModules, Controller);
             if (handleModuleResult(N, MaybeModuleDepsGraph, *FD, LocalIndex,
                                    DependencyOS, Errs)) {


### PR DESCRIPTION
This PR removes direct uses of `CompilerInstaneWithConrtext` (CIWC), since it is the scanning engine, not an interface. Its uses are sunk into `DependencyScanningTool`. 

Specifically, this PR does three things (corresponding to the three commits):
1. Removes CIWC's dependency on `Driver`. The code that handles the driver command stays in the tool, and CIWC is initialized from a cc1 command. 
2. Replaces public uses of the CIWC and hides it in `DependencyScanningTool`. The CIWC will be sunk deeper into a local variable in a Worker method eventually, and this step gets us closer. 
3. Moves the CIWC code to its own file.