### PR TITLE
[lldb][test] Don't dead-strip WebAssembly test inferiors

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/WASI.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/WASI.rules
@@ -10,3 +10,7 @@ ARCH_CXXFLAGS += \
 ARCH_LDFLAGS += \
 	$(if $(RESOURCE_DIR),-resource-dir $(RESOURCE_DIR)) \
 	-Wl,--allow-undefined
+
+# Unlike most native linkers, wasm-ld garbage-collects unreferenced sections by
+# default, which strips globals and functions that a test wants to inspect.
+LDFLAGS += -Wl,--no-gc-sections


### PR DESCRIPTION
Unlike most native linkers, wasm-ld garbage-collects unreferenced sections by default. Globals and functions that a test inspects but the program never references therefore get dead-stripped from the inferior, even though they would survive on other targets.

Default to `-Wl,--no-gc-sections` in WASI.rules so debug-info coverage matches other targets.