### PR TITLE
[lldb] Remove ConstString getters from FileSpec

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolFileOnDemand.h
+++ b/lldb/include/lldb/Symbol/SymbolFileOnDemand.h
@@ -256,7 +256,7 @@ public:
 private:
   Log *GetLog() const { return ::lldb_private::GetLog(LLDBLog::OnDemand); }
 
-  ConstString GetSymbolFileName() {
+  llvm::StringRef GetSymbolFileName() {
     return GetObjectFile()->GetFileSpec().GetFilename();
   }
 

--- a/lldb/include/lldb/Utility/FileSpec.h
+++ b/lldb/include/lldb/Utility/FileSpec.h
@@ -231,7 +231,7 @@ public:
   ///
   /// \return
   ///     A const reference to the directory string object.
-  const ConstString &GetDirectory() const { return m_directory; }
+  llvm::StringRef GetDirectory() const { return m_directory; }
 
   /// Directory string set accessor.
   ///
@@ -246,7 +246,7 @@ public:
   ///
   /// \return
   ///     A const reference to the filename string object.
-  const ConstString &GetFilename() const { return m_filename; }
+  llvm::StringRef GetFilename() const { return m_filename; }
 
   /// Filename string set accessor.
   ///
@@ -462,10 +462,8 @@ template <> struct format_provider<lldb_private::FileSpec> {
 template <> struct DenseMapInfo<lldb_private::FileSpec> {
   static unsigned getHashValue(lldb_private::FileSpec file_spec) {
     return llvm::hash_combine(
-        DenseMapInfo<lldb_private::ConstString>::getHashValue(
-            file_spec.GetDirectory()),
-        DenseMapInfo<lldb_private::ConstString>::getHashValue(
-            file_spec.GetFilename()),
+        DenseMapInfo<llvm::StringRef>::getHashValue(file_spec.GetDirectory()),
+        DenseMapInfo<llvm::StringRef>::getHashValue(file_spec.GetFilename()),
         DenseMapInfo<llvm::sys::path::Style>::getHashValue(
             file_spec.GetPathStyle()));
   }

--- a/lldb/include/lldb/Utility/XcodeSDK.h
+++ b/lldb/include/lldb/Utility/XcodeSDK.h
@@ -66,7 +66,7 @@ public:
   XcodeSDK(std::string &&name) : m_name(std::move(name)) {}
   XcodeSDK(std::string name, FileSpec sysroot)
       : m_name(std::move(name)), m_sysroot(std::move(sysroot)) {
-    assert(!m_sysroot || m_name == m_sysroot.GetFilename().GetStringRef());
+    assert(!m_sysroot || m_name == m_sysroot.GetFilename());
   }
   static XcodeSDK GetAnyMacOS() { return XcodeSDK("MacOSX.sdk"); }
 

--- a/lldb/source/API/SBFileSpec.cpp
+++ b/lldb/source/API/SBFileSpec.cpp
@@ -108,7 +108,7 @@ int SBFileSpec::ResolvePath(const char *src_path, char *dst_path,
 const char *SBFileSpec::GetFilename() const {
   LLDB_INSTRUMENT_VA(this);
 
-  return m_opaque_up->GetFilename().AsCString(nullptr);
+  return ConstString(m_opaque_up->GetFilename()).AsCString(nullptr);
 }
 
 const char *SBFileSpec::GetDirectory() const {

--- a/lldb/source/API/SBProcess.cpp
+++ b/lldb/source/API/SBProcess.cpp
@@ -1014,7 +1014,8 @@ bool SBProcess::GetDescription(SBStream &description) {
     Module *exe_module = process_sp->GetTarget().GetExecutableModulePointer();
     const char *exe_name = nullptr;
     if (exe_module)
-      exe_name = exe_module->GetFileSpec().GetFilename().AsCString(nullptr);
+      exe_name = ConstString(exe_module->GetFileSpec().GetFilename())
+                     .AsCString(nullptr);
 
     strm.Printf("SBProcess: pid = %" PRIu64 ", state = %s, threads = %d%s%s",
                 process_sp->GetID(), lldb_private::StateAsCString(GetState()),

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -608,7 +608,7 @@ void BreakpointLocation::GetDescription(Stream *s,
       if (sc.comp_unit != nullptr) {
         s->EOL();
         s->Indent("compile unit = ");
-        sc.comp_unit->GetPrimaryFile().GetFilename().Dump(s);
+        s->PutCString(sc.comp_unit->GetPrimaryFile().GetFilename());
 
         if (sc.function != nullptr) {
           s->EOL();

--- a/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
@@ -238,9 +238,8 @@ void BreakpointResolverFileLine::DeduceSourceMapping(
     if (FileSpec::Equal(sc_file, request_file, /*full*/ true))
       continue;
 
-    llvm::StringRef sc_file_dir = sc_file.GetDirectory().GetStringRef();
-    llvm::StringRef request_file_dir =
-        request_file.GetDirectory().GetStringRef();
+    llvm::StringRef sc_file_dir = sc_file.GetDirectory();
+    llvm::StringRef request_file_dir = request_file.GetDirectory();
 
     llvm::StringRef new_mapping_from;
     llvm::SmallString<256> new_mapping_to;
@@ -323,8 +322,8 @@ Searcher::CallbackReturn BreakpointResolverFileLine::SearchCallback(
   DeduceSourceMapping(sc_list);
 
   StreamString s;
-  s.Printf("for %s:%d ",
-           m_location_spec.GetFileSpec().GetFilename().AsCString("<Unknown>"),
+  s.Format("for {0}:{1} ",
+           m_location_spec.GetFileSpec().GetFilename().nonEmptyOr("<Unknown>"),
            line);
 
   SetSCMatchesByLine(filter, sc_list, m_skip_prologue, s.GetString(), line,

--- a/lldb/source/Commands/CommandCompletions.cpp
+++ b/lldb/source/Commands/CommandCompletions.cpp
@@ -147,15 +147,13 @@ public:
   Searcher::CallbackReturn SearchCallback(SearchFilter &filter,
                                           SymbolContext &context,
                                           Address *addr) override {
-    llvm::StringRef spec_file_name =
-        m_partial_spec.GetFilename().GetStringRef();
-    llvm::StringRef spec_dir_name =
-        m_partial_spec.GetDirectory().GetStringRef();
+    llvm::StringRef spec_file_name = m_partial_spec.GetFilename();
+    llvm::StringRef spec_dir_name = m_partial_spec.GetDirectory();
     if (context.comp_unit != nullptr) {
       llvm::StringRef cur_file_name =
-          context.comp_unit->GetPrimaryFile().GetFilename().GetStringRef();
+          context.comp_unit->GetPrimaryFile().GetFilename();
       llvm::StringRef cur_dir_name =
-          context.comp_unit->GetPrimaryFile().GetDirectory().GetStringRef();
+          context.comp_unit->GetPrimaryFile().GetDirectory();
 
       bool match = false;
       if (!spec_file_name.empty() && cur_file_name.starts_with(spec_file_name))
@@ -180,7 +178,7 @@ public:
     // Now convert the filelist to completions:
     for (size_t i = 0; i < m_matching_files.GetSize(); i++) {
       m_request.AddCompletion(
-          m_matching_files.GetFileSpecAtIndex(i).GetFilename().GetCString());
+          m_matching_files.GetFileSpecAtIndex(i).GetFilename());
     }
   }
 
@@ -309,7 +307,7 @@ public:
       // And a file name match.
       if (m_file_name) {
         llvm::StringRef cur_file_name =
-            context.module_sp->GetFileSpec().GetFilename().GetStringRef();
+            context.module_sp->GetFileSpec().GetFilename();
         if (cur_file_name.starts_with(*m_file_name))
           m_request.AddCompletion(cur_file_name);
       }

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -1020,7 +1020,7 @@ public:
 
     FileSpec src_fs(src);
     FileSystem::Instance().Resolve(src_fs);
-    FileSpec dst_fs(dst ? dst : src_fs.GetFilename().GetCString());
+    FileSpec dst_fs(dst ? dst : src_fs.GetFilename());
 
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -146,7 +146,7 @@ protected:
     assert(target && "target guaranteed by eCommandRequiresTarget");
     uint32_t num_matches = 0;
     // Dump all the line entries for the file in the list.
-    ConstString last_module_file_name;
+    llvm::StringRef last_module_file_name;
     for (const SymbolContext &sc : sc_list) {
       if (sc.comp_unit) {
         Module *module = sc.module_sp.get();
@@ -168,8 +168,8 @@ protected:
           continue;
 
         // Print a new header if the module changed.
-        ConstString module_file_name = module->GetFileSpec().GetFilename();
-        assert(module_file_name);
+        llvm::StringRef module_file_name = module->GetFileSpec().GetFilename();
+        assert(!module_file_name.empty());
         if (module_file_name != last_module_file_name) {
           if (num_matches > 0)
             strm << "\n\n";
@@ -202,8 +202,8 @@ protected:
     uint32_t num_matches = 0;
     assert(module);
     if (cu) {
-      assert(file_spec.GetFilename().AsCString(nullptr));
-      bool has_path = (file_spec.GetDirectory().AsCString(nullptr) != nullptr);
+      assert(!file_spec.GetFilename().empty());
+      bool has_path = !file_spec.GetDirectory().empty();
       const SupportFileList &cu_file_list = cu->GetSupportFiles();
       size_t file_idx = cu_file_list.FindFileIndex(0, file_spec, has_path);
       if (file_idx != UINT32_MAX) {
@@ -213,8 +213,8 @@ protected:
 
         // Dump all matching lines at or above start_line for the file in the
         // CU.
-        ConstString file_spec_name = file_spec.GetFilename();
-        ConstString module_file_name = module->GetFileSpec().GetFilename();
+        llvm::StringRef file_spec_name = file_spec.GetFilename();
+        llvm::StringRef module_file_name = module->GetFileSpec().GetFilename();
         bool cu_header_printed = false;
         uint32_t line = start_line;
         while (true) {
@@ -753,11 +753,11 @@ protected:
     bool operator<(const SourceInfo &rhs) const {
       if (function.GetCString() < rhs.function.GetCString())
         return true;
-      if (line_entry.GetFile().GetDirectory().GetCString() <
-          rhs.line_entry.GetFile().GetDirectory().GetCString())
+      if (line_entry.GetFile().GetDirectory() <
+          rhs.line_entry.GetFile().GetDirectory())
         return true;
-      if (line_entry.GetFile().GetFilename().GetCString() <
-          rhs.line_entry.GetFile().GetFilename().GetCString())
+      if (line_entry.GetFile().GetFilename() <
+          rhs.line_entry.GetFile().GetFilename())
         return true;
       if (line_entry.line < rhs.line_entry.line)
         return true;

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -1338,9 +1338,10 @@ static void DumpDirectory(Stream &strm, const FileSpec *file_spec_ptr,
                           uint32_t width) {
   if (file_spec_ptr) {
     if (width > 0)
-      strm.Printf("%-*s", width, file_spec_ptr->GetDirectory().AsCString(""));
+      strm.Format("{0}", fmt_align(file_spec_ptr->GetDirectory(),
+                                   llvm::AlignStyle::Left, width));
     else
-      file_spec_ptr->GetDirectory().Dump(&strm);
+      strm.PutCString(file_spec_ptr->GetDirectory());
     return;
   }
   // Keep the width spacing correct if things go wrong...
@@ -1352,9 +1353,10 @@ static void DumpBasename(Stream &strm, const FileSpec *file_spec_ptr,
                          uint32_t width) {
   if (file_spec_ptr) {
     if (width > 0)
-      strm.Printf("%-*s", width, file_spec_ptr->GetFilename().AsCString(""));
+      strm.Format("{0}", fmt_align(file_spec_ptr->GetFilename(),
+                                   llvm::AlignStyle::Left, width));
     else
-      file_spec_ptr->GetFilename().Dump(&strm);
+      strm.PutCString(file_spec_ptr->GetFilename());
     return;
   }
   // Keep the width spacing correct if things go wrong...

--- a/lldb/source/Core/Address.cpp
+++ b/lldb/source/Core/Address.cpp
@@ -386,7 +386,7 @@ bool Address::GetDescription(Stream &s, Target &target,
          "Non-brief descriptions not implemented");
   LineEntry line_entry;
   if (CalculateSymbolContextLineEntry(line_entry)) {
-    s.Printf(" (%s:%u:%u)", line_entry.GetFile().GetFilename().GetCString(),
+    s.Format(" ({0}:{1}:{2})", line_entry.GetFile().GetFilename(),
              line_entry.line, line_entry.column);
     return true;
   }
@@ -437,8 +437,8 @@ bool Address::Dump(Stream *s, ExecutionContextScope *exe_scope, DumpStyle style,
     if (section_sp) {
       ModuleSP module_sp = section_sp->GetModule();
       if (module_sp)
-        s->Printf("%s[", module_sp->GetFileSpec().GetFilename().AsCString(
-                             "<Unknown>"));
+        s->Format("{0}[", module_sp->GetFileSpec().GetFilename().nonEmptyOr(
+                              "<Unknown>"));
       else
         s->Printf("%s[", "<Unknown>");
     }

--- a/lldb/source/Core/AddressRange.cpp
+++ b/lldb/source/Core/AddressRange.cpp
@@ -191,8 +191,8 @@ bool AddressRange::Dump(Stream *s, Target *target, Address::DumpStyle style,
     if (show_module) {
       ModuleSP module_sp(GetBaseAddress().GetModule());
       if (module_sp)
-        s->Printf("%s", module_sp->GetFileSpec().GetFilename().AsCString(
-                            "<Unknown>"));
+        s->Format("{0}", module_sp->GetFileSpec().GetFilename().nonEmptyOr(
+                             "<Unknown>"));
     }
     DumpAddressRange(s->AsRawOstream(), vmaddr, vmaddr + GetByteSize(),
                      addr_size);
@@ -225,17 +225,17 @@ bool AddressRange::GetDescription(Stream *s, Target *target) const {
 
   // Either no target or the address wasn't resolved, print as
   // <module>[<file-addr>-<file-addr>)
-  const char *file_name = "";
+  llvm::StringRef file_name;
   const auto section_sp = m_base_addr.GetSection();
   if (section_sp) {
     if (const auto object_file = section_sp->GetObjectFile())
-      file_name = object_file->GetFileSpec().GetFilename().AsCString(nullptr);
+      file_name = object_file->GetFileSpec().GetFilename();
   }
   start_addr = m_base_addr.GetFileAddress();
   const addr_t end_addr = (start_addr == LLDB_INVALID_ADDRESS)
                               ? LLDB_INVALID_ADDRESS
                               : start_addr + GetByteSize();
-  s->Printf("%s[0x%" PRIx64 "-0x%" PRIx64 ")", file_name, start_addr, end_addr);
+  s->Format("{0}[{1:x}-{2:x})", file_name, start_addr, end_addr);
   return true;
 }
 

--- a/lldb/source/Core/AddressResolverFileLine.cpp
+++ b/lldb/source/Core/AddressResolverFileLine.cpp
@@ -52,13 +52,13 @@ AddressResolverFileLine::SearchCallback(SearchFilter &filter,
       AddressRange new_range(line_start, byte_size);
       m_address_ranges.push_back(new_range);
     } else {
-      LLDB_LOGF(log,
-                "error: Unable to resolve address at file address 0x%" PRIx64
-                " for %s:%d\n",
-                line_start.GetFileAddress(),
-                m_src_location_spec.GetFileSpec().GetFilename().AsCString(
-                    "<Unknown>"),
-                m_src_location_spec.GetLine().value_or(0));
+      LLDB_LOG(log,
+               "error: Unable to resolve address at file address {0:x}"
+               " for {1}:{2}\n",
+               line_start.GetFileAddress(),
+               m_src_location_spec.GetFileSpec().GetFilename().nonEmptyOr(
+                   "<Unknown>"),
+               m_src_location_spec.GetLine().value_or(0));
     }
   }
   return Searcher::eCallbackReturnContinue;
@@ -69,8 +69,8 @@ lldb::SearchDepth AddressResolverFileLine::GetDepth() {
 }
 
 void AddressResolverFileLine::GetDescription(Stream *s) {
-  s->Printf(
-      "File and line address - file: \"%s\" line: %u",
-      m_src_location_spec.GetFileSpec().GetFilename().AsCString("<Unknown>"),
+  s->Format(
+      "File and line address - file: \"{0}\" line: {1}",
+      m_src_location_spec.GetFileSpec().GetFilename().nonEmptyOr("<Unknown>"),
       m_src_location_spec.GetLine().value_or(0));
 }

--- a/lldb/source/Core/Declaration.cpp
+++ b/lldb/source/Core/Declaration.cpp
@@ -37,7 +37,7 @@ bool Declaration::DumpStopContext(Stream *s, bool show_fullpaths) const {
     if (show_fullpaths)
       *s << m_file;
     else
-      m_file.GetFilename().Dump(s);
+      s->PutCString(m_file.GetFilename());
 
     if (m_line > 0)
       s->Printf(":%u", m_line);

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -413,7 +413,7 @@ VariableAnnotator::AnnotateStructured(Instruction &inst) {
 
     const Declaration &decl = v->GetDeclaration();
     if (decl.GetFile()) {
-      decl_file = decl.GetFile().GetFilename().GetString();
+      decl_file = decl.GetFile().GetFilename().str();
       if (decl.GetLine() > 0)
         decl_line = decl.GetLine();
     }

--- a/lldb/source/Core/FileLineResolver.cpp
+++ b/lldb/source/Core/FileLineResolver.cpp
@@ -37,7 +37,7 @@ FileLineResolver::SearchCallback(SearchFilter &filter, SymbolContext &context,
   CompileUnit *cu = context.comp_unit;
 
   if (m_inlines || m_file_spec.Compare(cu->GetPrimaryFile(), m_file_spec,
-                                       (bool)m_file_spec.GetDirectory())) {
+                                       !m_file_spec.GetDirectory().empty())) {
     uint32_t start_file_idx = 0;
     uint32_t file_idx =
         cu->GetSupportFiles().FindFileIndex(start_file_idx, m_file_spec, false);

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -626,14 +626,14 @@ static bool DumpFile(Stream &s, const FileSpec &file, FileKind file_kind) {
     break;
 
   case FileKind::Basename:
-    if (file.GetFilename()) {
+    if (!file.GetFilename().empty()) {
       s << file.GetFilename();
       return true;
     }
     break;
 
   case FileKind::Dirname:
-    if (file.GetDirectory()) {
+    if (!file.GetDirectory().empty()) {
       s << file.GetDirectory();
       return true;
     }
@@ -2557,10 +2557,10 @@ bool FormatEntity::FormatFileSpec(const FileSpec &file_spec, Stream &s,
     file_spec.Dump(s.AsRawOstream());
     return true;
   } else if (variable_name == ".basename") {
-    s.PutCString(file_spec.GetFilename().GetStringRef());
+    s.PutCString(file_spec.GetFilename());
     return true;
   } else if (variable_name == ".dirname") {
-    s.PutCString(file_spec.GetFilename().GetStringRef());
+    s.PutCString(file_spec.GetFilename());
     return true;
   }
   return false;

--- a/lldb/source/Core/IOHandlerCursesGUI.cpp
+++ b/lldb/source/Core/IOHandlerCursesGUI.cpp
@@ -2964,7 +2964,7 @@ public:
     if (!module_sp->IsExecutable())
       return "";
 
-    return module_sp->GetFileSpec().GetFilename().GetString();
+    return module_sp->GetFileSpec().GetFilename().str();
   }
 
   bool StopRunningProcess() {
@@ -5396,8 +5396,8 @@ public:
     if (symbol_context.comp_unit != nullptr) {
       StreamString compile_unit_stream;
       compile_unit_stream.PutCString("compile unit = ");
-      symbol_context.comp_unit->GetPrimaryFile().GetFilename().Dump(
-          &compile_unit_stream);
+      compile_unit_stream.PutCString(
+          symbol_context.comp_unit->GetPrimaryFile().GetFilename());
       details.AppendString(compile_unit_stream.GetString());
 
       if (symbol_context.function != nullptr) {
@@ -6926,8 +6926,7 @@ public:
       if (frame_sp) {
         m_sc = frame_sp->GetSymbolContext(eSymbolContextEverything);
         if (m_sc.module_sp) {
-          m_title.Printf(
-              "%s", m_sc.module_sp->GetFileSpec().GetFilename().GetCString());
+          m_title.Format("{0}", m_sc.module_sp->GetFileSpec().GetFilename());
           ConstString func_name = m_sc.GetFunctionName();
           if (func_name)
             m_title.Printf("`%s", func_name.GetCString());

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1041,8 +1041,8 @@ void Module::GetDescription(llvm::raw_ostream &s,
   }
 
   if (level == eDescriptionLevelBrief) {
-    const char *filename = m_file.GetFilename().GetCString();
-    if (filename)
+    llvm::StringRef filename = m_file.GetFilename();
+    if (!filename.empty())
       s << filename;
   } else {
     char path[PATH_MAX];
@@ -1070,8 +1070,8 @@ bool Module::FileHasChanged() const {
 
 void Module::ReportWarningOptimization(
     std::optional<lldb::user_id_t> debugger_id) {
-  ConstString file_name = GetFileSpec().GetFilename();
-  if (file_name.IsEmpty())
+  llvm::StringRef file_name = GetFileSpec().GetFilename();
+  if (file_name.empty())
     return;
 
   StreamString ss;
@@ -1183,7 +1183,7 @@ ObjectFile *Module::GetObjectFile() {
     std::lock_guard<std::recursive_mutex> guard(m_mutex);
     if (!m_did_load_objfile.load()) {
       LLDB_SCOPED_TIMERF("Module::GetObjectFile () module = %s",
-                         GetFileSpec().GetFilename().AsCString(""));
+                         GetFileSpec().GetFilename().str().c_str());
       lldb::offset_t data_offset = 0;
       lldb::offset_t file_size = 0;
 

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -792,7 +792,7 @@ public:
     // different filename. For example, when searching by UUID and finding a
     // module with an alias.
     assert((matching_module_list.IsEmpty() ||
-            module_spec.GetFileSpec().GetFilename().IsEmpty() ||
+            module_spec.GetFileSpec().GetFilename().empty() ||
             module_spec.GetFileSpec().GetFilename() !=
                 matching_module_list.GetModuleAtIndex(0)
                     ->GetFileSpec()
@@ -870,10 +870,10 @@ public:
 
 private:
   ModuleSP FindModuleInMap(const Module &module) const {
-    if (!module.GetFileSpec().GetFilename())
+    if (module.GetFileSpec().GetFilename().empty())
       return ModuleSP();
-    ConstString name = module.GetFileSpec().GetFilename();
-    auto it = m_name_to_modules.find(name);
+    llvm::StringRef name = module.GetFileSpec().GetFilename();
+    auto it = m_name_to_modules.find(ConstString(name));
     if (it == m_name_to_modules.end())
       return ModuleSP();
     const llvm::SmallVectorImpl<ModuleSP> &vector = it->second;
@@ -886,7 +886,8 @@ private:
 
   void FindModulesInMap(const ModuleSpec &module_spec,
                         ModuleList &matching_module_list) const {
-    auto it = m_name_to_modules.find(module_spec.GetFileSpec().GetFilename());
+    auto it = m_name_to_modules.find(
+        ConstString(module_spec.GetFileSpec().GetFilename()));
     if (it == m_name_to_modules.end())
       return;
     const llvm::SmallVectorImpl<ModuleSP> &vector = it->second;
@@ -897,15 +898,15 @@ private:
   }
 
   void AddToMap(const ModuleSP &module_sp) {
-    ConstString name = module_sp->GetFileSpec().GetFilename();
-    if (name.IsEmpty())
+    llvm::StringRef name = module_sp->GetFileSpec().GetFilename();
+    if (name.empty())
       return;
-    m_name_to_modules[name].push_back(module_sp);
+    m_name_to_modules[ConstString(name)].push_back(module_sp);
   }
 
   void RemoveFromMap(const ModuleWP module_wp, bool if_orphaned = false) {
     if (auto module_sp = module_wp.lock()) {
-      ConstString name = module_sp->GetFileSpec().GetFilename();
+      ConstString name = ConstString(module_sp->GetFileSpec().GetFilename());
       if (!m_name_to_modules.contains(name))
         return;
       llvm::SmallVectorImpl<ModuleSP> &vec = m_name_to_modules[name];
@@ -930,11 +931,11 @@ private:
   }
 
   void RemoveEquivalentModulesFromMap(const ModuleSP &module_sp) {
-    ConstString name = module_sp->GetFileSpec().GetFilename();
-    if (name.IsEmpty())
+    llvm::StringRef name = module_sp->GetFileSpec().GetFilename();
+    if (name.empty())
       return;
 
-    auto it = m_name_to_modules.find(name);
+    auto it = m_name_to_modules.find(ConstString(name));
     if (it == m_name_to_modules.end())
       return;
 
@@ -1087,10 +1088,11 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
             old_modules->push_back(module_sp);
 
           Log *log = GetLog(LLDBLog::Modules);
-          LLDB_LOGF(log,
-                    "%p '%s' module changed: removing from global module list",
-                    static_cast<void *>(module_sp.get()),
-                    module_sp->GetFileSpec().GetFilename().GetCString());
+          LLDB_LOG(
+              log,
+              "{0:x} '{1}' module changed: removing from global module list",
+              static_cast<void *>(module_sp.get()),
+              module_sp->GetFileSpec().GetFilename());
 
           shared_module_list.Remove(module_sp);
           module_sp.reset();
@@ -1171,7 +1173,7 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
       if (!FileSystem::Instance().IsDirectory(search_path_spec))
         continue;
       search_path_spec.AppendPathComponent(
-          module_spec.GetFileSpec().GetFilename().GetStringRef());
+          module_spec.GetFileSpec().GetFilename());
       if (!FileSystem::Instance().Exists(search_path_spec))
         continue;
 

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -233,8 +233,7 @@ LoadPluginCallback(void *baton, llvm::sys::fs::file_type ft,
     // requested.
     PluginDir::LoadPolicy *policy = (PluginDir::LoadPolicy *)baton;
     if (*policy == PluginDir::LoadOnlyWithLLDBPrefix &&
-        !plugin_file_spec.GetFilename().GetStringRef().starts_with(
-            g_plugin_prefix))
+        !plugin_file_spec.GetFilename().starts_with(g_plugin_prefix))
       return FileSystem::eEnumerateDirectoryResultNext;
 
     // Don't try to load an already loaded plugin again.

--- a/lldb/source/Core/SearchFilter.cpp
+++ b/lldb/source/Core/SearchFilter.cpp
@@ -436,7 +436,7 @@ void SearchFilterByModule::Search(Searcher &searcher) {
 
 void SearchFilterByModule::GetDescription(Stream *s) {
   s->PutCString(", module = ");
-  s->PutCString(m_module_spec.GetFilename().AsCString("<Unknown>"));
+  s->PutCString(m_module_spec.GetFilename().nonEmptyOr("<Unknown>"));
 }
 
 uint32_t SearchFilterByModule::GetFilterRequiredItems() {
@@ -557,7 +557,7 @@ void SearchFilterByModuleList::GetDescription(Stream *s) {
   if (num_modules == 1) {
     s->Printf(", module = ");
     s->PutCString(
-        m_module_spec_list.GetFileSpecAtIndex(0).GetFilename().AsCString(
+        m_module_spec_list.GetFileSpecAtIndex(0).GetFilename().nonEmptyOr(
             "<Unknown>"));
     return;
   }
@@ -565,7 +565,7 @@ void SearchFilterByModuleList::GetDescription(Stream *s) {
   s->Printf(", modules(%" PRIu64 ") = ", (uint64_t)num_modules);
   for (size_t i = 0; i < num_modules; i++) {
     s->PutCString(
-        m_module_spec_list.GetFileSpecAtIndex(i).GetFilename().AsCString(
+        m_module_spec_list.GetFileSpecAtIndex(i).GetFilename().nonEmptyOr(
             "<Unknown>"));
     if (i != num_modules - 1)
       s->PutCString(", ");
@@ -777,13 +777,13 @@ void SearchFilterByModuleListAndCU::GetDescription(Stream *s) {
   if (num_modules == 1) {
     s->Printf(", module = ");
     s->PutCString(
-        m_module_spec_list.GetFileSpecAtIndex(0).GetFilename().AsCString(
+        m_module_spec_list.GetFileSpecAtIndex(0).GetFilename().nonEmptyOr(
             "<Unknown>"));
   } else if (num_modules > 0) {
     s->Printf(", modules(%" PRIu64 ") = ", static_cast<uint64_t>(num_modules));
     for (size_t i = 0; i < num_modules; i++) {
       s->PutCString(
-          m_module_spec_list.GetFileSpecAtIndex(i).GetFilename().AsCString(
+          m_module_spec_list.GetFileSpecAtIndex(i).GetFilename().nonEmptyOr(
               "<Unknown>"));
       if (i != num_modules - 1)
         s->PutCString(", ");

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -312,16 +312,16 @@ void Section::DumpName(llvm::raw_ostream &s) const {
     s << '.';
   } else {
     // The top most section prints the module basename
-    const char *name = nullptr;
+    llvm::StringRef name;
     ModuleSP module_sp(GetModule());
 
     if (m_obj_file) {
       const FileSpec &file_spec = m_obj_file->GetFileSpec();
-      name = file_spec.GetFilename().AsCString(nullptr);
+      name = file_spec.GetFilename();
     }
-    if ((!name || !name[0]) && module_sp)
-      name = module_sp->GetFileSpec().GetFilename().AsCString(nullptr);
-    if (name && name[0])
+    if (name.empty() && module_sp)
+      name = module_sp->GetFileSpec().GetFilename();
+    if (!name.empty())
       s << name << '.';
   }
   s << m_name;

--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -56,8 +56,9 @@ using namespace lldb_private;
 static inline bool is_newline_char(char ch) { return ch == '\n' || ch == '\r'; }
 
 static void resolve_tilde(FileSpec &file_spec) {
-  if (!FileSystem::Instance().Exists(file_spec) && file_spec.GetDirectory() &&
-      file_spec.GetDirectory().GetCString()[0] == '~') {
+  if (!FileSystem::Instance().Exists(file_spec) &&
+      !file_spec.GetDirectory().empty() &&
+      file_spec.GetDirectory().front() == '~') {
     FileSystem::Instance().Resolve(file_spec);
   }
 }
@@ -493,8 +494,8 @@ void SourceManager::File::CommonInitializer(SupportFileNSP support_file_nsp,
   if (future.wait_for(g_progress_delay) == std::future_status::timeout) {
     Debugger *debugger = target_sp ? &target_sp->GetDebugger() : nullptr;
     progress.emplace("Loading source file",
-                     support_file_nsp->GetSpecOnly().GetFilename().GetString(),
-                     1, debugger);
+                     support_file_nsp->GetSpecOnly().GetFilename().str(), 1,
+                     debugger);
   }
   future.wait();
 }
@@ -514,12 +515,14 @@ void SourceManager::File::CommonInitializerImpl(SupportFileNSP support_file_nsp,
       // If this is just a file name, try finding it in the target.
       {
         FileSpec file_spec = support_file_nsp->GetSpecOnly();
-        if (!file_spec.GetDirectory() && file_spec.GetFilename()) {
+        if (file_spec.GetDirectory().empty() &&
+            !file_spec.GetFilename().empty()) {
           bool check_inlines = false;
           SymbolContextList sc_list;
           size_t num_matches =
               target_sp->GetImages().ResolveSymbolContextForFilePath(
-                  file_spec.GetFilename().AsCString(nullptr), 0, check_inlines,
+                  ConstString(file_spec.GetFilename()).AsCString(nullptr), 0,
+                  check_inlines,
                   SymbolContextItem(eSymbolContextModule |
                                     eSymbolContextCompUnit),
                   sc_list);

--- a/lldb/source/Host/common/FileSystem.cpp
+++ b/lldb/source/Host/common/FileSystem.cpp
@@ -257,7 +257,7 @@ void FileSystem::Resolve(FileSpec &file_spec, bool force_make_absolute) {
   Resolve(path, force_make_absolute);
 
   // Update the FileSpec with the resolved path.
-  if (file_spec.GetFilename().IsEmpty())
+  if (file_spec.GetFilename().empty())
     file_spec.SetDirectory(path);
   else
     file_spec.SetPath(path);
@@ -318,17 +318,17 @@ FileSystem::CreateDataBuffer(const FileSpec &file_spec, uint64_t size,
 
 bool FileSystem::ResolveExecutableLocation(FileSpec &file_spec) {
   // If the directory is set there's nothing to do.
-  ConstString directory = file_spec.GetDirectory();
-  if (directory)
+  llvm::StringRef directory = file_spec.GetDirectory();
+  if (!directory.empty())
     return false;
 
   // We cannot look for a file if there's no file name.
-  ConstString filename = file_spec.GetFilename();
-  if (!filename)
+  llvm::StringRef filename = file_spec.GetFilename();
+  if (filename.empty())
     return false;
 
   // Search for the file on the host.
-  const std::string filename_str(filename.GetCString());
+  const std::string filename_str(filename);
   llvm::ErrorOr<std::string> error_or_path =
       llvm::sys::findProgramByName(filename_str);
   if (!error_or_path)

--- a/lldb/source/Host/common/HostInfoBase.cpp
+++ b/lldb/source/Host/common/HostInfoBase.cpp
@@ -274,7 +274,7 @@ bool HostInfoBase::ComputePathRelativeToLibrary(FileSpec &file_spec,
   raw_path = (parent_path + dir).str();
   LLDB_LOG(log, "Derived the path as: {0}", raw_path);
   file_spec.SetDirectory(raw_path);
-  return (bool)file_spec.GetDirectory();
+  return !file_spec.GetDirectory().empty();
 }
 
 void HostInfoBase::SetSharedLibraryDirectoryHelper(
@@ -302,7 +302,7 @@ bool HostInfoBase::ComputeSharedLibraryDirectory(
   // Remove the filename so that this FileSpec only represents the directory.
   file_spec.SetDirectory(lldb_file_spec.GetDirectory());
 
-  return (bool)file_spec.GetDirectory();
+  return !file_spec.GetDirectory().empty();
 }
 
 bool HostInfoBase::ComputeSupportExeDirectory(FileSpec &file_spec) {

--- a/lldb/source/Host/macosx/objcxx/Host.mm
+++ b/lldb/source/Host/macosx/objcxx/Host.mm
@@ -607,10 +607,9 @@ static bool GetMacOSXProcessArgs(const ProcessInstanceInfoMatch *match_info_ptr,
         process_info.GetExecutableFile().SetFile(cstr, FileSpec::Style::native);
 
         if (match_info_ptr == NULL ||
-            NameMatches(
-                process_info.GetExecutableFile().GetFilename().GetCString(),
-                match_info_ptr->GetNameMatchType(),
-                match_info_ptr->GetProcessInfo().GetName())) {
+            NameMatches(process_info.GetExecutableFile().GetFilename(),
+                        match_info_ptr->GetNameMatchType(),
+                        match_info_ptr->GetProcessInfo().GetName())) {
           // Skip NULLs
           while (true) {
             const uint8_t *p = data.PeekData(offset, 1);

--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -191,7 +191,7 @@ bool HostInfoMacOSX::ComputeSupportExeDirectory(FileSpec &file_spec) {
   }
 
   file_spec.SetDirectory(raw_path);
-  return (bool)file_spec.GetDirectory();
+  return !file_spec.GetDirectory().empty();
 }
 
 bool HostInfoMacOSX::ComputeHeaderDirectory(FileSpec &file_spec) {

--- a/lldb/source/Host/posix/HostInfoPosix.cpp
+++ b/lldb/source/Host/posix/HostInfoPosix.cpp
@@ -173,7 +173,7 @@ bool HostInfoPosix::ComputeSupportExeDirectory(FileSpec &file_spec) {
       file_spec.IsAbsolute() && FileSystem::Instance().Exists(file_spec))
     return true;
   file_spec.SetDirectory(HostInfo::GetProgramFileSpec().GetDirectory());
-  return !file_spec.GetDirectory().IsEmpty();
+  return !file_spec.GetDirectory().empty();
 }
 
 bool HostInfoPosix::ComputeSystemPluginsDirectory(FileSpec &file_spec) {

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2711,8 +2711,7 @@ void CommandInterpreter::SourceInitFileHome(CommandReturnObject &result,
     GetHomeInitFile(init_file);
 
   if (!m_skip_app_init_files) {
-    llvm::StringRef program_name =
-        HostInfo::GetProgramFileSpec().GetFilename().GetStringRef();
+    llvm::StringRef program_name = HostInfo::GetProgramFileSpec().GetFilename();
     FileSpec program_init_file;
     GetHomeInitFile(program_init_file, program_name);
     if (FileSystem::Instance().Exists(program_init_file))
@@ -2956,9 +2955,9 @@ void CommandInterpreter::HandleCommandsFromFile(
     FileSpec &cmd_file, const CommandInterpreterRunOptions &options,
     CommandReturnObject &result) {
   if (!FileSystem::Instance().Exists(cmd_file)) {
-    result.AppendErrorWithFormat(
-        "Error reading commands from file %s - file not found",
-        cmd_file.GetFilename().AsCString("<Unknown>"));
+    result.AppendErrorWithFormatv(
+        "Error reading commands from file {0} - file not found",
+        cmd_file.GetFilename().nonEmptyOr("<Unknown>"));
     return;
   }
 

--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -1054,9 +1054,9 @@ void DynamicLoaderDarwinKernel::LoadKernelModuleIfNeeded() {
              ->GetObjectFile()
              ->GetFileSpec()
              .GetFilename()
-             .IsEmpty()) {
-      kernel_name =
-          m_kernel.GetModule()->GetObjectFile()->GetFileSpec().GetFilename();
+             .empty()) {
+      kernel_name = ConstString(
+          m_kernel.GetModule()->GetObjectFile()->GetFileSpec().GetFilename());
     }
     m_kernel.SetName(kernel_name.AsCString(nullptr));
 

--- a/lldb/source/Plugins/DynamicLoader/FreeBSD-Kernel/DynamicLoaderFreeBSDKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/FreeBSD-Kernel/DynamicLoaderFreeBSDKernel.cpp
@@ -716,11 +716,8 @@ void DynamicLoaderFreeBSDKernel::LoadKernelModules() {
     llvm::StringRef kernel_name("freebsd_kernel");
     module_sp = m_kernel_image_info.GetModule();
     if (module_sp.get() && module_sp->GetObjectFile() &&
-        !module_sp->GetObjectFile()->GetFileSpec().GetFilename().IsEmpty())
-      kernel_name = module_sp->GetObjectFile()
-                        ->GetFileSpec()
-                        .GetFilename()
-                        .GetStringRef();
+        !module_sp->GetObjectFile()->GetFileSpec().GetFilename().empty())
+      kernel_name = module_sp->GetObjectFile()->GetFileSpec().GetFilename();
     m_kernel_image_info.SetName(kernel_name.data());
 
     if (m_kernel_image_info.GetLoadAddress() == LLDB_INVALID_ADDRESS) {

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -310,19 +310,19 @@ bool DynamicLoaderDarwin::UpdateImageLoadAddress(Module *module,
               // If a segment was eliminated for the in-memory image,
               // don't map it into lldb's target section load list.
               if (info.segments[i].vmsize == 0) {
-                LLDB_LOGF(log, "%s: Omitting zero-size segment %s",
-                          info.file_spec.GetFilename().AsCString(""),
-                          info.segments[i].name.AsCString(""));
+                LLDB_LOG(log, "{0}: Omitting zero-size segment {1}",
+                         info.file_spec.GetFilename(),
+                         info.segments[i].name.AsCString(""));
                 continue;
               }
 
               if (info.segments[i].vmsize != section_sp->GetByteSize())
-                LLDB_LOGF(log,
-                          "%s: In-memory segment size for %s is 0x%" PRIx64
-                          " but file segment size is 0x%" PRIx64,
-                          info.file_spec.GetFilename().AsCString(""),
-                          info.segments[i].name.AsCString(""),
-                          info.segments[i].vmsize, section_sp->GetByteSize());
+                LLDB_LOG(log,
+                         "{0}: In-memory segment size for {1} is {2:x}"
+                         " but file segment size is {3:x}",
+                         info.file_spec.GetFilename(),
+                         info.segments[i].name.AsCString(""),
+                         info.segments[i].vmsize, section_sp->GetByteSize());
 
               changed = m_process->GetTarget().SetSectionLoadAddress(
                   section_sp, new_section_load_addr, warn_multiple);

--- a/lldb/source/Plugins/ExpressionParser/Clang/CppModuleConfiguration.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/CppModuleConfiguration.cpp
@@ -63,7 +63,7 @@ bool CppModuleConfiguration::analyzeFile(const FileSpec &f,
                                          const llvm::Triple &triple) {
   using namespace llvm::sys::path;
   // Convert to slashes to make following operations simpler.
-  std::string dir_buffer = convert_to_slash(f.GetDirectory().GetStringRef());
+  std::string dir_buffer = convert_to_slash(f.GetDirectory());
   llvm::StringRef posix_dir(dir_buffer);
 
   // Check for /c++/vX/ that is used by libc++.

--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.cpp
@@ -23,7 +23,7 @@ GetPreferredAsanModule(const Target &target) {
   lldb::ModuleSP module;
   llvm::Regex pattern(R"(libclang_rt\.asan_.*_dynamic\.dylib)");
   target.GetImages().ForEach([&](const lldb::ModuleSP &m) {
-    if (pattern.match(m->GetFileSpec().GetFilename().GetStringRef())) {
+    if (pattern.match(m->GetFileSpec().GetFilename())) {
       module = m;
       return IterationAction::Stop;
     }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -158,16 +158,14 @@ bool lldb_private::formatters::LibcxxFunctionSummaryProvider(
     return false;
     break;
   case CPPLanguageRuntime::LibCppStdFunctionCallableCase::Lambda:
-    stream.Printf(
-        " Lambda in File %s at Line %u",
-        callable_info.callable_line_entry.GetFile().GetFilename().GetCString(),
-        callable_info.callable_line_entry.line);
+    stream.Format(" Lambda in File {0} at Line {1}",
+                  callable_info.callable_line_entry.GetFile().GetFilename(),
+                  callable_info.callable_line_entry.line);
     break;
   case CPPLanguageRuntime::LibCppStdFunctionCallableCase::CallableObject:
-    stream.Printf(
-        " Function in File %s at Line %u",
-        callable_info.callable_line_entry.GetFile().GetFilename().GetCString(),
-        callable_info.callable_line_entry.line);
+    stream.Format(" Function in File {0} at Line {1}",
+                  callable_info.callable_line_entry.GetFile().GetFilename(),
+                  callable_info.callable_line_entry.line);
     break;
   case CPPLanguageRuntime::LibCppStdFunctionCallableCase::FreeOrMemberFunction:
     stream.Printf(" Function = %s ",

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
@@ -332,8 +332,7 @@ uint32_t AppleObjCRuntime::GetFoundationVersion() {
       lldb::ModuleSP module_sp = modules.GetModuleAtIndex(idx);
       if (!module_sp)
         continue;
-      if (strcmp(module_sp->GetFileSpec().GetFilename().AsCString(""),
-                 "Foundation") == 0) {
+      if (module_sp->GetFileSpec().GetFilename() == "Foundation") {
         m_Foundation_major = module_sp->GetVersion().getMajor();
         return *m_Foundation_major;
       }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -3629,6 +3629,7 @@ static void RegisterObjCExceptionRecognizer(Process *process) {
 
   process->GetTarget().GetFrameRecognizerManager().AddRecognizer(
       StackFrameRecognizerSP(new ObjCExceptionThrowFrameRecognizer()),
-      module.GetFilename(), symbols, Mangled::NamePreference::ePreferDemangled,
+      ConstString(module.GetFilename()), symbols,
+      Mangled::NamePreference::ePreferDemangled,
       /*first_instruction_only*/ true);
 }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.cpp
@@ -44,7 +44,7 @@ static bool CanModuleBeGNUstepObjCLibrary(const ModuleSP &module_sp,
   const FileSpec &module_file_spec = module_sp->GetFileSpec();
   if (!module_file_spec)
     return false;
-  llvm::StringRef filename = module_file_spec.GetFilename().GetStringRef();
+  llvm::StringRef filename = module_file_spec.GetFilename();
   if (TT.isOSBinFormatELF())
     return filename.starts_with("libobjc.so");
   if (TT.isOSWindows())

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
@@ -389,7 +389,7 @@ FileSpec GetChildFileSpecificationsFromThin(llvm::StringRef childPath,
   if (llvm::sys::path::is_absolute(childPath)) {
     FullPath = childPath;
   } else {
-    FullPath = parentFileSpec.GetDirectory().GetStringRef();
+    FullPath = parentFileSpec.GetDirectory();
     llvm::sys::path::append(FullPath, childPath);
   }
   FileSpec child = FileSpec(FullPath.str(), llvm::sys::path::Style::posix);

--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
@@ -87,7 +87,7 @@ ObjectFileCOFF::CreateInstance(const ModuleSP &module_sp,
   }
 
   MemoryBufferRef buffer{toStringRef(contiguous_extractor_sp->GetData()),
-                         file->GetFilename().GetStringRef()};
+                         file->GetFilename()};
 
   Expected<std::unique_ptr<Binary>> binary = createBinary(buffer);
   if (!binary) {
@@ -131,7 +131,7 @@ ObjectFileCOFF::GetModuleSpecifications(const FileSpec &file,
     return {};
 
   MemoryBufferRef buffer{toStringRef(contiguous_extractor_sp->GetData()),
-                         file.GetFilename().GetStringRef()};
+                         file.GetFilename()};
   Expected<std::unique_ptr<Binary>> binary = createBinary(buffer);
   if (!binary) {
     Log *log = GetLog(LLDBLog::Object);

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -683,7 +683,7 @@ ModuleSpecList ObjectFileELF::GetModuleSpecifications(
           if (!gnu_debuglink_crc) {
             LLDB_SCOPED_TIMERF("Calculating module crc32 %s with size %" PRIu64
                                " KiB",
-                               file.GetFilename().AsCString(""),
+                               file.GetFilename().str().c_str(),
                                (length - file_offset) / 1024);
 
             // For core files - which usually don't happen to have a
@@ -3212,7 +3212,7 @@ void ObjectFileELF::ParseSymtab(Symtab &lldb_symtab) {
     return;
 
   Progress progress("Parsing symbol table",
-                    m_file.GetFilename().AsCString("<Unknown>"));
+                    m_file.GetFilename().nonEmptyOr("<Unknown>").str());
   ElapsedTime elapsed(module_sp->GetSymtabParseTime());
 
   // We always want to use the main object file so we (hopefully) only have one
@@ -3741,7 +3741,7 @@ void ObjectFileELF::DumpDependentModules(lldb_private::Stream *s) {
     s->PutCString("Dependent Modules:\n");
     for (unsigned i = 0; i < num_modules; ++i) {
       const FileSpec &spec = m_filespec_up->GetFileSpecAtIndex(i);
-      s->Printf("   %s\n", spec.GetFilename().GetCString());
+      s->Format("   {0}\n", spec.GetFilename());
     }
   }
 }

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -1647,14 +1647,11 @@ void ObjectFileMachO::ProcessSegmentCommand(
     // addresses will differ from what the ObjectFile had originally,
     // and what the dSYM has.
     if (is_dsym && unified_section_sp->GetFileAddress() != load_cmd.vmaddr) {
-      Log *log = GetLog(LLDBLog::Symbols);
-      if (log) {
-        log->Printf(
-            "Installing dSYM's %s segment file address over ObjectFile's "
-            "so symbol table/debug info resolves correctly for %s",
-            const_segname.AsCString(""),
-            module_sp->GetFileSpec().GetFilename().AsCString(""));
-      }
+      LLDB_LOG(GetLog(LLDBLog::Symbols),
+               "Installing dSYM's {0} segment file address over ObjectFile's "
+               "so symbol table/debug info resolves correctly for {1}",
+               const_segname.AsCString(""),
+               module_sp->GetFileSpec().GetFilename());
 
       // Make sure we've parsed the symbol table from the ObjectFile before
       // we go around changing its Sections.
@@ -2078,10 +2075,11 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
   Log *log = GetLog(LLDBLog::Symbols);
 
   const FileSpec &file = m_file ? m_file : module_sp->GetFileSpec();
-  const char *file_name = file.GetFilename().AsCString("<Unknown>");
-  LLDB_SCOPED_TIMERF("ObjectFileMachO::ParseSymtab () module = %s", file_name);
+  llvm::StringRef file_name = file.GetFilename().nonEmptyOr("<Unknown>");
+  LLDB_SCOPED_TIMERF("ObjectFileMachO::ParseSymtab () module = %s",
+                     file_name.str().c_str());
   LLDB_LOG(log, "Parsing symbol table for {0}", file_name);
-  Progress progress("Parsing symbol table", file_name);
+  Progress progress("Parsing symbol table", file_name.str());
 
   LinkeditDataCommandLargeOffsets function_starts_load_command;
   LinkeditDataCommandLargeOffsets exports_trie_load_command;
@@ -4826,8 +4824,7 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
 
   if (!rpath_paths.empty()) {
     // Fixup all LC_RPATH values to be absolute paths.
-    const std::string this_directory =
-        this_file_spec.GetDirectory().GetString();
+    const std::string this_directory = this_file_spec.GetDirectory().str();
     for (auto &rpath : rpath_paths) {
       if (llvm::StringRef(rpath).starts_with(g_loader_path))
         rpath = this_directory + rpath.substr(g_loader_path.size());

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -165,7 +165,7 @@ static UUID GetCoffUUID(llvm::object::COFFObjectFile &coff_obj) {
     auto raw_data = coff_obj.getData();
     LLDB_SCOPED_TIMERF(
         "Calculating module crc32 %s with size %" PRIu64 " KiB",
-        FileSpec(coff_obj.getFileName()).GetFilename().AsCString(""),
+        FileSpec(coff_obj.getFileName()).GetFilename().str().c_str(),
         static_cast<lldb::offset_t>(raw_data.size()) / 1024);
     gnu_debuglink_crc = llvm::crc32(0, llvm::arrayRefFromStringRef(raw_data));
   }
@@ -268,7 +268,7 @@ ModuleSpecList ObjectFilePECOFF::GetModuleSpecifications(
       extractor_sp->SetData(std::move(full_sp));
   auto binary = llvm::object::createBinary(llvm::MemoryBufferRef(
       toStringRef(extractor_sp->GetSharedDataBuffer()->GetData()),
-      file.GetFilename().GetStringRef()));
+      file.GetFilename()));
 
   if (!binary) {
     LLDB_LOG_ERROR(log, binary.takeError(),
@@ -304,12 +304,12 @@ ModuleSpecList ObjectFilePECOFF::GetModuleSpecifications(
     module_env_option = map->GetValueForKey(name);
     if (!module_env_option) {
       // Step 2: Try with the file name in lowercase.
-      auto name_lower = name.GetStringRef().lower();
+      auto name_lower = name.lower();
       module_env_option = map->GetValueForKey(llvm::StringRef(name_lower));
     }
     if (!module_env_option) {
       // Step 3: Try with the file name with ".debug" suffix stripped.
-      auto name_stripped = name.GetStringRef();
+      auto name_stripped = name;
       if (name_stripped.consume_back_insensitive(".debug")) {
         module_env_option = map->GetValueForKey(name_stripped);
         if (!module_env_option) {
@@ -402,7 +402,7 @@ bool ObjectFilePECOFF::CreateBinary() {
   Log *log = GetLog(LLDBLog::Object);
 
   auto binary = llvm::object::createBinary(llvm::MemoryBufferRef(
-      toStringRef(m_data_nsp->GetData()), m_file.GetFilename().GetStringRef()));
+      toStringRef(m_data_nsp->GetData()), m_file.GetFilename()));
   if (!binary) {
     LLDB_LOG_ERROR(log, binary.takeError(),
                    "Failed to create binary for file ({1}): {0}", m_file);
@@ -1394,7 +1394,7 @@ void ObjectFilePECOFF::DumpDependentModules(lldb_private::Stream *s) {
     s->PutCString("Dependent Modules\n");
     for (unsigned i = 0; i < num_modules; ++i) {
       auto spec = m_deps_filespec->GetFileSpecAtIndex(i);
-      s->Printf("  %s\n", spec.GetFilename().GetCString());
+      s->Format("  {0}\n", spec.GetFilename());
     }
   }
 }

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -98,7 +98,7 @@ bool ObjectFileXCOFF::CreateBinary() {
   Log *log = GetLog(LLDBLog::Object);
 
   auto memory_ref = llvm::MemoryBufferRef(toStringRef(m_data_nsp->GetData()),
-                                          m_file.GetFilename().GetStringRef());
+                                          m_file.GetFilename());
   llvm::file_magic magic = llvm::identify_magic(memory_ref.getBuffer());
 
   auto binary = llvm::object::ObjectFile::createObjectFile(memory_ref, magic);

--- a/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
+++ b/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
@@ -84,8 +84,7 @@ OperatingSystemPython::OperatingSystemPython(lldb_private::Process *process,
   if (!m_interpreter)
     return;
 
-  std::string os_plugin_class_name(
-      python_module_path.GetFilename().AsCString(""));
+  std::string os_plugin_class_name(python_module_path.GetFilename());
   if (os_plugin_class_name.empty())
     return;
 

--- a/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
@@ -482,8 +482,7 @@ std::string PlatformAndroid::GetRunAs() {
 }
 
 static bool NeedsCmdlineSupplement(const ProcessInstanceInfo &proc_info) {
-  llvm::StringRef name =
-      proc_info.GetExecutableFile().GetFilename().GetStringRef();
+  llvm::StringRef name = proc_info.GetExecutableFile().GetFilename();
   return name.contains("app_process") || name.contains("zygote");
 }
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -209,12 +209,11 @@ PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
 
   llvm::SmallDenseMap<FileSpec, LoadScriptFromSymFile> file_specs;
   const FileSpec original_module_spec = module_spec;
-  while (module_spec.GetFilename()) {
+  while (!module_spec.GetFilename().empty()) {
     ScriptInterpreter::SanitizedScriptingModuleName sanitized_name =
         target.GetDebugger()
             .GetScriptInterpreter()
-            ->GetSanitizedScriptingModuleName(
-                module_spec.GetFilename().GetStringRef());
+            ->GetSanitizedScriptingModuleName(module_spec.GetFilename());
 
     StreamString path_string;
     StreamString original_path_string;
@@ -222,11 +221,10 @@ PlatformDarwin::LocateExecutableScriptingResourcesFromDSYM(
     // .dSYM/Contents/Resources/DWARF/<basename> let us go to
     // .dSYM/Contents/Resources/Python/<basename>.py and see if the
     // file exists
-    path_string.Format("{0}/../Python/{1}.py",
-                       symfile_spec.GetDirectory().GetStringRef(),
+    path_string.Format("{0}/../Python/{1}.py", symfile_spec.GetDirectory(),
                        sanitized_name.GetSanitizedName());
     original_path_string.Format("{0}/../Python/{1}.py",
-                                symfile_spec.GetDirectory().GetStringRef(),
+                                symfile_spec.GetDirectory(),
                                 sanitized_name.GetOriginalName());
 
     FileSpec script_fspec(path_string.GetString());
@@ -1465,7 +1463,7 @@ PlatformDarwin::GetSDKPathFromDebugInfo(Module &module) {
     return llvm::createStringError(
         llvm::inconvertibleErrorCode(),
         llvm::formatv("No symbol file available for module '{0}'",
-                      module.GetFileSpec().GetFilename().AsCString("")));
+                      module.GetFileSpec().GetFilename()));
 
   if (sym_file->GetNumCompileUnits() == 0)
     return llvm::createStringError(

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
@@ -49,8 +49,7 @@ void PlatformDarwinDevice::AddSharedCacheDirectory(
     FileSpec sc_directory_symbols = sc_directory;
     sc_directory_symbols.AppendPathComponent("Symbols");
     if (FileSystem::Instance().Exists(sc_directory_symbols)) {
-      SDKDirectoryInfo thisdir(sc_directory,
-                               sc_directory.GetFilename().GetStringRef());
+      SDKDirectoryInfo thisdir(sc_directory, sc_directory.GetFilename());
       m_sdk_directory_infos.push_back(thisdir);
       LLDB_LOGF(log,
                 "PlatformDarwinDevice::UpdateSDKDirectoryInfosIfNeeded "
@@ -69,8 +68,7 @@ void PlatformDarwinDevice::AddSharedCacheDirectory(
       FileSpec subdir_directory_symbols = subdir;
       subdir_directory_symbols.AppendPathComponent("Symbols");
       if (FileSystem::Instance().Exists(subdir_directory_symbols)) {
-        SDKDirectoryInfo thisdir(subdir,
-                                 sc_directory.GetFilename().GetStringRef());
+        SDKDirectoryInfo thisdir(subdir, sc_directory.GetFilename());
         m_sdk_directory_infos.push_back(thisdir);
         LLDB_LOGF(log,
                   "PlatformDarwinDevice::UpdateSDKDirectoryInfosIfNeeded "

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -489,7 +489,7 @@ PlatformDarwinKernel::GetKernelsAndKextsInDirectoryHelper(
 
   PlatformDarwinKernel *thisp = (PlatformDarwinKernel *)baton;
 
-  llvm::StringRef filename = file_spec.GetFilename().GetStringRef();
+  llvm::StringRef filename = file_spec.GetFilename();
   bool is_kernel_filename =
       filename.starts_with("kernel") || filename.starts_with("mach");
   bool is_dsym_yaa = filename.ends_with(".dSYM.yaa");
@@ -611,7 +611,7 @@ void PlatformDarwinKernel::AddKextToMap(PlatformDarwinKernel *thisp,
 bool PlatformDarwinKernel::KextHasdSYMSibling(
     const FileSpec &kext_bundle_filepath) {
   FileSpec dsym_fspec = kext_bundle_filepath;
-  std::string filename = dsym_fspec.GetFilename().GetString();
+  std::string filename = dsym_fspec.GetFilename().str();
   filename += ".dSYM";
   dsym_fspec.SetFilename(filename);
   if (FileSystem::Instance().IsDirectory(dsym_fspec)) {
@@ -648,7 +648,7 @@ bool PlatformDarwinKernel::KextHasdSYMSibling(
 //    /dir/dir/mach.development.t7004.dSYM
 bool PlatformDarwinKernel::KernelHasdSYMSibling(const FileSpec &kernel_binary) {
   FileSpec kernel_dsym = kernel_binary;
-  std::string filename = kernel_binary.GetFilename().GetString();
+  std::string filename = kernel_binary.GetFilename().str();
   filename += ".dSYM";
   kernel_dsym.SetFilename(filename);
   return FileSystem::Instance().IsDirectory(kernel_dsym);
@@ -697,7 +697,7 @@ PlatformDarwinKernel::GetDWARFBinaryInDSYMBundle(const FileSpec &dsym_bundle) {
   }
   // Drop the '.dSYM' from the filename
   llvm::StringRef filename = dsym_bundle.GetFileNameStrippingExtension();
-  std::string dirname = dsym_bundle.GetDirectory().GetCString();
+  std::string dirname = dsym_bundle.GetDirectory().str();
 
   std::string binary_filepath = dsym_bundle.GetPath();
   binary_filepath += "/Contents/Resources/DWARF/";

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
@@ -291,8 +291,7 @@ uint32_t PlatformRemoteDarwinDevice::GetConnectedSDKIndex() {
         const uint32_t num_sdk_infos = m_sdk_directory_infos.size();
         for (uint32_t i = 0; i < num_sdk_infos; ++i) {
           const SDKDirectoryInfo &sdk_dir_info = m_sdk_directory_infos[i];
-          if (strstr(sdk_dir_info.directory.GetFilename().AsCString(""),
-                     build->c_str())) {
+          if (sdk_dir_info.directory.GetFilename().contains(build->c_str())) {
             m_connected_module_sdk_idx = i;
           }
         }

--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
@@ -504,7 +504,8 @@ ScriptedProcess::GetLoadedDynamicLibrariesInfos(
       return error_with_message("Couldn't set the load address for module.");
 
     FileSpec objfile(path);
-    module_sp->SetFileSpecAndObjectName(objfile, objfile.GetFilename());
+    module_sp->SetFileSpecAndObjectName(objfile,
+                                        ConstString(objfile.GetFilename()));
 
     if (is_placeholder_module) {
       target.GetImages().AppendIfNeeded(module_sp, true /*notify=*/);

--- a/lldb/source/Plugins/Protocol/MCP/Resource.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Resource.cpp
@@ -81,7 +81,7 @@ DebuggerResourceProvider::GetTargetResource(size_t target_idx, Target &target) {
   std::string target_name = llvm::formatv("target {0}", target_idx);
 
   if (Module *exe_module = target.GetExecutableModulePointer())
-    target_name = exe_module->GetFileSpec().GetFilename().GetString();
+    target_name = exe_module->GetFileSpec().GetFilename().str();
 
   lldb_protocol::mcp::Resource resource;
   resource.uri =

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -2343,17 +2343,16 @@ bool ScriptInterpreterPythonImpl::LoadScriptingModule(
       // Not a filename, probably a package of some sort, let it go through.
       possible_package = true;
     } else if (is_directory(st) || is_regular_file(st)) {
-      if (module_file.GetDirectory().IsEmpty()) {
+      if (module_file.GetDirectory().empty()) {
         error = Status::FromErrorStringWithFormatv(
             "invalid directory name '{0}'", pathname);
         return false;
       }
-      if (llvm::Error e =
-              ExtendSysPath(module_file.GetDirectory().GetCString())) {
+      if (llvm::Error e = ExtendSysPath(module_file.GetDirectory().str())) {
         error = Status::FromError(std::move(e));
         return false;
       }
-      module_name = module_file.GetFilename().GetCString();
+      module_name = module_file.GetFilename().str();
     } else {
       error = Status::FromErrorString(
           "no known way to import this module specification");

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -268,7 +268,7 @@ static void ParseSupportFilesFromPrologue(
                 return tmp_file;
               llvm::SmallString<0> name;
               int fd;
-              auto orig_name = m_file_spec.GetFilename().GetStringRef();
+              auto orig_name = m_file_spec.GetFilename();
               auto ec = llvm::sys::fs::createTemporaryFile(
                   "", llvm::sys::path::filename(orig_name, style), fd, name);
               if (ec || fd <= 0) {
@@ -652,8 +652,7 @@ uint32_t SymbolFileDWARF::CalculateAbilities() {
       if (section)
         debug_line_file_size = section->GetFileSize();
     } else {
-      llvm::StringRef symfile_dir =
-          m_objfile_sp->GetFileSpec().GetDirectory().GetStringRef();
+      llvm::StringRef symfile_dir = m_objfile_sp->GetFileSpec().GetDirectory();
       if (symfile_dir.contains_insensitive(".dsym")) {
         if (m_objfile_sp->GetType() == ObjectFile::eTypeDebugInfo) {
           // We have a dSYM file that didn't have a any debug info. If the
@@ -1828,7 +1827,7 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
         // launched.
         FileSpec relative_to_binary = dwo_file;
         relative_to_binary.PrependPathComponent(
-            m_objfile_sp->GetFileSpec().GetDirectory().GetStringRef());
+            m_objfile_sp->GetFileSpec().GetDirectory());
         FileSystem::Instance().Resolve(relative_to_binary);
         relative_to_binary.AppendPathComponent(dwo_name);
         dwo_paths.Append(relative_to_binary);
@@ -1871,8 +1870,7 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
     FileSpec dwo_name_spec(dwo_name);
     llvm::StringRef filename_only = dwo_name_spec.GetFilename();
 
-    FileSpec binary_directory(
-        m_objfile_sp->GetFileSpec().GetDirectory().GetStringRef());
+    FileSpec binary_directory(m_objfile_sp->GetFileSpec().GetDirectory());
     FileSystem::Instance().Resolve(binary_directory);
 
     if (dwo_name_spec.IsRelative()) {
@@ -3162,9 +3160,9 @@ SymbolFileDWARF::FindDefinitionDIE(const DWARFDIE &die) {
   if (!die.GetAttributeValueAsUnsigned(DW_AT_declaration, 0))
     return die;
 
-  Progress progress(llvm::formatv(
-      "Searching definition DIE in {0}: '{1}'",
-      GetObjectFile()->GetFileSpec().GetFilename().GetString(), name));
+  Progress progress(llvm::formatv("Searching definition DIE in {0}: '{1}'",
+                                  GetObjectFile()->GetFileSpec().GetFilename(),
+                                  name));
 
   const dw_tag_t tag = die.Tag();
 

--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -906,7 +906,7 @@ uint32_t SymbolFilePDB::ResolveSymbolContext(
         if (source_file.empty())
           continue;
         FileSpec this_spec(source_file, FileSpec::Style::windows);
-        bool need_full_match = !file_spec.GetDirectory().IsEmpty();
+        bool need_full_match = !file_spec.GetDirectory().empty();
         if (FileSpec::Compare(file_spec, this_spec, need_full_match) != 0)
           continue;
       }

--- a/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
+++ b/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
@@ -397,11 +397,11 @@ static bool FileAtPathContainsArchAndUUID(const FileSpec &file_fspec,
 static bool LookForDsymNextToExecutablePath(const ModuleSpec &mod_spec,
                                             const FileSpec &exec_fspec,
                                             FileSpec &dsym_fspec) {
-  ConstString filename = exec_fspec.GetFilename();
+  llvm::StringRef filename = exec_fspec.GetFilename();
   FileSpec dsym_directory = exec_fspec;
   dsym_directory.RemoveLastPathComponent();
 
-  std::string dsym_filename = filename.GetString();
+  std::string dsym_filename = filename.str();
   dsym_filename += ".dSYM";
   dsym_directory.AppendPathComponent(dsym_filename);
   dsym_directory.AppendPathComponent("Contents");
@@ -413,7 +413,7 @@ static bool LookForDsymNextToExecutablePath(const ModuleSpec &mod_spec,
     // See if the binary name exists in the dSYM DWARF
     // subdir.
     dsym_fspec = dsym_directory;
-    dsym_fspec.AppendPathComponent(filename.AsCString(nullptr));
+    dsym_fspec.AppendPathComponent(filename);
     if (FileSystem::Instance().Exists(dsym_fspec) &&
         FileAtPathContainsArchAndUUID(dsym_fspec, mod_spec.GetArchitecturePtr(),
                                       mod_spec.GetUUIDPtr())) {
@@ -424,7 +424,7 @@ static bool LookForDsymNextToExecutablePath(const ModuleSpec &mod_spec,
     // CF.framework.dSYM/Contents/Resources/DWARF/CF
     // We need to drop the last suffix after '.' to match
     // 'CF' in the DWARF subdir.
-    std::string binary_name = filename.GetString();
+    std::string binary_name = filename.str();
     auto last_dot = binary_name.find_last_of('.');
     if (last_dot != std::string::npos) {
       binary_name.erase(last_dot);
@@ -442,7 +442,7 @@ static bool LookForDsymNextToExecutablePath(const ModuleSpec &mod_spec,
   // See if we have a .dSYM.yaa next to this executable path.
   FileSpec dsym_yaa_fspec = exec_fspec;
   dsym_yaa_fspec.RemoveLastPathComponent();
-  std::string dsym_yaa_filename = filename.GetString();
+  std::string dsym_yaa_filename = filename.str();
   dsym_yaa_filename += ".dSYM.yaa";
   dsym_yaa_fspec.AppendPathComponent(dsym_yaa_filename);
 
@@ -502,10 +502,10 @@ static bool LocateDSYMInVincinityOfExecutable(const ModuleSpec &module_spec,
       for (int i = 0; i < 4; i++) {
         // Does this part of the path have a "." character - could it be a
         // bundle's top level directory?
-        const char *fn = parent_dirs.GetFilename().AsCString(nullptr);
-        if (fn == nullptr)
+        llvm::StringRef fn = parent_dirs.GetFilename();
+        if (fn.empty())
           break;
-        if (::strchr(fn, '.') != nullptr) {
+        if (fn.contains('.')) {
           if (::LookForDsymNextToExecutablePath(module_spec, parent_dirs,
                                                 dsym_fspec)) {
             LLDB_LOGF(log, "dSYM with matching UUID & arch found at %s",
@@ -772,12 +772,13 @@ std::optional<FileSpec> SymbolLocatorDebugSymbols::LocateExecutableSymbolFile(
 
   LLDB_SCOPED_TIMERF(
       "LocateExecutableSymbolFileDsym (file = %s, arch = %s, uuid = %p)",
-      exec_fspec ? exec_fspec->GetFilename().AsCString("<NULL>") : "<NULL>",
+      exec_fspec ? exec_fspec->GetFilename().nonEmptyOr("<NULL>").str().c_str()
+                 : "<NULL>",
       arch ? arch->GetArchitectureName() : "<NULL>", (const void *)uuid);
 
   Progress progress(
       "Locating external symbol file",
-      module_spec.GetFileSpec().GetFilename().AsCString("<Unknown>"));
+      module_spec.GetFileSpec().GetFilename().nonEmptyOr("<Unknown>").str());
 
   FileSpec symbol_fspec;
   ModuleSpec dsym_module_spec;
@@ -1067,13 +1068,12 @@ bool SymbolLocatorDebugSymbols::DownloadObjectAndSymbolFile(
   // Log and report progress.
   std::string lookup_desc;
   if (uuid_ptr && file_spec_ptr)
-    lookup_desc =
-        llvm::formatv("{0} ({1})", file_spec_ptr->GetFilename().GetString(),
-                      uuid_ptr->GetAsString());
+    lookup_desc = llvm::formatv("{0} ({1})", file_spec_ptr->GetFilename(),
+                                uuid_ptr->GetAsString());
   else if (uuid_ptr)
     lookup_desc = uuid_ptr->GetAsString();
   else if (file_spec_ptr)
-    lookup_desc = file_spec_ptr->GetFilename().GetString();
+    lookup_desc = file_spec_ptr->GetFilename().str();
 
   Log *log = GetLog(LLDBLog::Host);
   LLDB_LOG(log, "Calling {0} for {1} to find dSYM: {2}", dsymForUUID_exe_path,

--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
@@ -145,9 +145,8 @@ static llvm::StringRef getFileName(const ModuleSpec &module_spec,
   // Check if the URL path requests an executable file or a symbol file
   bool is_executable = url_path.find("debuginfo") == std::string::npos;
   if (is_executable)
-    return module_spec.GetFileSpec().GetFilename().GetStringRef();
-  llvm::StringRef symbol_file =
-      module_spec.GetSymbolFileSpec().GetFilename().GetStringRef();
+    return module_spec.GetFileSpec().GetFilename();
+  llvm::StringRef symbol_file = module_spec.GetSymbolFileSpec().GetFilename();
   // Remove llvmcache- prefix and hash, keep origin file name
   if (symbol_file.starts_with("llvmcache-")) {
     size_t pos = symbol_file.rfind('-');

--- a/lldb/source/Plugins/SymbolLocator/Default/SymbolLocatorDefault.cpp
+++ b/lldb/source/Plugins/SymbolLocator/Default/SymbolLocatorDefault.cpp
@@ -77,7 +77,8 @@ std::optional<ModuleSpec> SymbolLocatorDefault::LocateExecutableObjectFile(
   const UUID *uuid = module_spec.GetUUIDPtr();
   LLDB_SCOPED_TIMERF(
       "LocateExecutableObjectFile (file = %s, arch = %s, uuid = %p)",
-      exec_fspec ? exec_fspec.GetFilename().AsCString("<NULL>") : "<NULL>",
+      exec_fspec ? exec_fspec.GetFilename().nonEmptyOr("<NULL>").str().c_str()
+                 : "<NULL>",
       arch ? arch->GetArchitectureName() : "<NULL>", (const void *)uuid);
 
   ModuleSpec matched_module_spec;
@@ -105,7 +106,7 @@ std::optional<FileSpec> SymbolLocatorDefault::LocateExecutableSymbolFile(
 
   Progress progress(
       "Locating external symbol file",
-      module_spec.GetFileSpec().GetFilename().AsCString("<Unknown>"));
+      module_spec.GetFileSpec().GetFilename().nonEmptyOr("<Unknown>").str());
 
   FileSpecList debug_file_search_paths = default_search_paths;
 
@@ -115,9 +116,9 @@ std::optional<FileSpec> SymbolLocatorDefault::LocateExecutableSymbolFile(
   FileSystem::Instance().ResolveSymbolicLink(module_file_spec,
                                              module_file_spec);
 
-  ConstString file_dir = module_file_spec.GetDirectory();
+  llvm::StringRef file_dir = module_file_spec.GetDirectory();
   {
-    FileSpec file_spec(file_dir.AsCString("."));
+    FileSpec file_spec(file_dir.nonEmptyOr("."));
     FileSystem::Instance().Resolve(file_spec);
     debug_file_search_paths.AppendIfUnique(file_spec);
   }
@@ -192,17 +193,16 @@ std::optional<FileSpec> SymbolLocatorDefault::LocateExecutableSymbolFile(
 
     if (!uuid_str.empty())
       files.push_back(dirname + "/.build-id/" + uuid_str);
-    if (symbol_file_spec.GetFilename()) {
-      files.push_back(dirname + "/" +
-                      symbol_file_spec.GetFilename().GetCString());
+    if (!symbol_file_spec.GetFilename().empty()) {
+      files.push_back(dirname + "/" + symbol_file_spec.GetFilename().str());
       files.push_back(dirname + "/.debug/" +
-                      symbol_file_spec.GetFilename().GetCString());
+                      symbol_file_spec.GetFilename().str());
 
       // Some debug files may stored in the module directory like this:
       //   /usr/lib/debug/usr/lib/library.so.debug
-      if (!file_dir.IsEmpty())
-        files.push_back(dirname + file_dir.GetString() + "/" +
-                        symbol_file_spec.GetFilename().GetCString());
+      if (!file_dir.empty())
+        files.push_back(dirname + file_dir.str() + "/" +
+                        symbol_file_spec.GetFilename().str());
     }
 
     const uint32_t num_files = files.size();

--- a/lldb/source/Plugins/SymbolLocator/SymStore/SymbolLocatorSymStore.cpp
+++ b/lldb/source/Plugins/SymbolLocator/SymStore/SymbolLocatorSymStore.cpp
@@ -444,8 +444,7 @@ std::optional<FileSpec> SymbolLocatorSymStore::LocateExecutableSymbolFile(
     return {};
 
   Log *log = GetLog(LLDBLog::Symbols);
-  std::string pdb_name =
-      module_spec.GetSymbolFileSpec().GetFilename().GetStringRef().str();
+  std::string pdb_name = module_spec.GetSymbolFileSpec().GetFilename().str();
   if (pdb_name.empty()) {
     LLDB_LOG(log, "Failed to resolve symbol PDB module: PDB name empty");
     return {};

--- a/lldb/source/Plugins/SymbolVendor/PECOFF/SymbolVendorPECOFF.cpp
+++ b/lldb/source/Plugins/SymbolVendor/PECOFF/SymbolVendorPECOFF.cpp
@@ -79,7 +79,8 @@ SymbolVendorPECOFF::CreateInstance(const lldb::ModuleSP &module_sp,
   if (!fspec) {
     if (auto pdb_spec = obj_file->GetPDBPath()) {
       fspec = *pdb_spec;
-      if (ConstString dir = obj_file->GetFileSpec().GetDirectory())
+      if (llvm::StringRef dir = obj_file->GetFileSpec().GetDirectory();
+          !dir.empty())
         search_paths.Insert(0, FileSpec(dir));
     }
   }

--- a/lldb/source/Symbol/DWARFCallFrameInfo.cpp
+++ b/lldb/source/Symbol/DWARFCallFrameInfo.cpp
@@ -474,7 +474,7 @@ void DWARFCallFrameInfo::GetFDEIndex() {
   if (m_fde_index_initialized) // if two threads hit the locker
     return;
 
-  LLDB_SCOPED_TIMERF("%s", m_objfile.GetFileSpec().GetFilename().AsCString(""));
+  LLDB_SCOPED_TIMERF("%s", m_objfile.GetFileSpec().GetFilename().str().c_str());
 
   bool clear_address_zeroth_bit = false;
   if (ArchSpec arch = m_objfile.GetArchitecture()) {

--- a/lldb/source/Symbol/LineEntry.cpp
+++ b/lldb/source/Symbol/LineEntry.cpp
@@ -43,7 +43,7 @@ bool LineEntry::DumpStopContext(Stream *s, bool show_fullpaths) const {
     if (show_fullpaths)
       file.Dump(s->AsRawOstream());
     else
-      file.GetFilename().Dump(s);
+      s->PutCString(file.GetFilename());
 
     if (line)
       s->PutChar(':');

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -814,10 +814,10 @@ uint32_t ObjectFile::GetCacheHash() {
 std::string ObjectFile::GetObjectName() const {
   if (ModuleSP module_sp = GetModule())
     if (ConstString object_name = module_sp->GetObjectName())
-      return llvm::formatv("{0}({1})", GetFileSpec().GetFilename().GetString(),
+      return llvm::formatv("{0}({1})", GetFileSpec().GetFilename(),
                            object_name.GetString())
           .str();
-  return GetFileSpec().GetFilename().GetString();
+  return GetFileSpec().GetFilename().str();
 }
 
 namespace llvm {

--- a/lldb/source/Target/AssertFrameRecognizer.cpp
+++ b/lldb/source/Target/AssertFrameRecognizer.cpp
@@ -100,13 +100,13 @@ void RegisterAssertFrameRecognizer(Process *process) {
   if (!location.symbols_are_regex) {
     target.GetFrameRecognizerManager().AddRecognizer(
         std::make_shared<AssertFrameRecognizer>(),
-        location.module_spec.GetFilename(), location.symbols,
+        ConstString(location.module_spec.GetFilename()), location.symbols,
         Mangled::ePreferDemangled,
         /*first_instruction_only*/ false);
     return;
   }
   std::string module_re = "^";
-  for (char c : location.module_spec.GetFilename().GetStringRef()) {
+  for (char c : location.module_spec.GetFilename()) {
     if (c == '.')
       module_re += '\\';
     module_re += c;

--- a/lldb/source/Target/InstrumentationRuntime.cpp
+++ b/lldb/source/Target/InstrumentationRuntime.cpp
@@ -43,8 +43,7 @@ void InstrumentationRuntime::ModulesDidLoad(
       return IterationAction::Continue;
 
     const RegularExpression &runtime_regex = GetPatternForRuntimeLibrary();
-    if (MatchAllModules() ||
-        runtime_regex.Execute(file_spec.GetFilename().GetCString()) ||
+    if (MatchAllModules() || runtime_regex.Execute(file_spec.GetFilename()) ||
         module_sp->IsExecutable()) {
       if (CheckIfRuntimeIsValid(module_sp)) {
         SetRuntimeModuleSP(module_sp);

--- a/lldb/source/Target/InstrumentationRuntimeStopInfo.cpp
+++ b/lldb/source/Target/InstrumentationRuntimeStopInfo.cpp
@@ -18,8 +18,7 @@ using namespace lldb;
 using namespace lldb_private;
 
 static bool IsStoppedInDarwinSanitizer(Thread &thread, Module &module) {
-  return module.GetFileSpec().GetFilename().GetStringRef().starts_with(
-      "libclang_rt.");
+  return module.GetFileSpec().GetFilename().starts_with("libclang_rt.");
 }
 
 InstrumentationRuntimeStopInfo::InstrumentationRuntimeStopInfo(

--- a/lldb/source/Target/ModuleCache.cpp
+++ b/lldb/source/Target/ModuleCache.cpp
@@ -58,7 +58,7 @@ public:
   void Delete();
 };
 
-static FileSpec JoinPath(const FileSpec &path1, const char *path2) {
+static FileSpec JoinPath(const FileSpec &path1, llvm::StringRef path2) {
   FileSpec result_spec(path1);
   result_spec.AppendPathComponent(path2);
   return result_spec;
@@ -194,7 +194,7 @@ Status ModuleCache::Put(const FileSpec &root_dir_spec, const char *hostname,
   const auto module_spec_dir =
       GetModuleDirectory(root_dir_spec, module_spec.GetUUID());
   const auto module_file_path =
-      JoinPath(module_spec_dir, target_file.GetFilename().AsCString(nullptr));
+      JoinPath(module_spec_dir, target_file.GetFilename());
 
   const auto tmp_file_path = tmp_file.GetPath();
   const auto err_code =
@@ -228,8 +228,7 @@ Status ModuleCache::Get(const FileSpec &root_dir_spec, const char *hostname,
   const auto module_spec_dir =
       GetModuleDirectory(root_dir_spec, module_spec.GetUUID());
   const auto module_file_path =
-      JoinPath(module_spec_dir,
-               module_spec.GetFileSpec().GetFilename().AsCString(nullptr));
+      JoinPath(module_spec_dir, module_spec.GetFileSpec().GetFilename());
 
   if (!FileSystem::Instance().Exists(module_file_path))
     return Status::FromErrorStringWithFormat(

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -490,7 +490,7 @@ RecurseCopy_Callback(void *baton, llvm::sys::fs::file_type ft,
   case fs::file_type::directory_file: {
     // make the new directory and get in there
     FileSpec dst_dir = rc_baton->dst;
-    if (!dst_dir.GetFilename())
+    if (dst_dir.GetFilename().empty())
       dst_dir.SetFilename(src.GetFilename());
     Status error = rc_baton->platform_ptr->MakeDirectory(
         dst_dir, lldb::eFilePermissionsDirectoryDefault);
@@ -521,7 +521,7 @@ RecurseCopy_Callback(void *baton, llvm::sys::fs::file_type ft,
   case fs::file_type::symlink_file: {
     // copy the file and keep going
     FileSpec dst_file = rc_baton->dst;
-    if (!dst_file.GetFilename())
+    if (dst_file.GetFilename().empty())
       dst_file.SetFilename(src.GetFilename());
 
     FileSpec src_resolved;
@@ -543,7 +543,7 @@ RecurseCopy_Callback(void *baton, llvm::sys::fs::file_type ft,
   case fs::file_type::regular_file: {
     // copy the file and keep going
     FileSpec dst_file = rc_baton->dst;
-    if (!dst_file.GetFilename())
+    if (dst_file.GetFilename().empty())
       dst_file.SetFilename(src.GetFilename());
     Status err = rc_baton->platform_ptr->PutFile(src, dst_file);
     if (err.Fail()) {
@@ -570,21 +570,21 @@ Status Platform::Install(const FileSpec &src, const FileSpec &dst) {
             src.GetPath().c_str(), dst.GetPath().c_str());
   FileSpec fixed_dst(dst);
 
-  if (!fixed_dst.GetFilename())
+  if (fixed_dst.GetFilename().empty())
     fixed_dst.SetFilename(src.GetFilename());
 
   FileSpec working_dir = GetWorkingDirectory();
 
   if (dst) {
-    if (dst.GetDirectory()) {
-      const char first_dst_dir_char = dst.GetDirectory().GetCString()[0];
+    if (!dst.GetDirectory().empty()) {
+      const char first_dst_dir_char = dst.GetDirectory().front();
       if (first_dst_dir_char == '/' || first_dst_dir_char == '\\') {
         fixed_dst.SetDirectory(dst.GetDirectory());
       }
       // If the fixed destination file doesn't have a directory yet, then we
       // must have a relative path. We will resolve this relative path against
       // the platform's working directory
-      if (!fixed_dst.GetDirectory()) {
+      if (fixed_dst.GetDirectory().empty()) {
         FileSpec relative_spec;
         if (working_dir) {
           relative_spec = working_dir;
@@ -1951,9 +1951,8 @@ uint32_t Platform::LoadImageUsingPaths(lldb_private::Process *process,
 {
   FileSpec file_to_use;
   if (remote_filename.IsAbsolute())
-    file_to_use = FileSpec(remote_filename.GetFilename().GetStringRef(),
-
-                           remote_filename.GetPathStyle());
+    file_to_use =
+        FileSpec(remote_filename.GetFilename(), remote_filename.GetPathStyle());
   else
     file_to_use = remote_filename;
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2791,8 +2791,8 @@ Process::ReadModuleFromMemory(const FileSpec &file_spec,
   // only print a progress update if we're reading from a
   // live session which might go over gdb remote serial protocol.
   if (IsLiveDebugSession())
-    progress_up = std::make_unique<Progress>(
-        "Reading binary from memory", file_spec.GetFilename().GetString());
+    progress_up = std::make_unique<Progress>("Reading binary from memory",
+                                             file_spec.GetFilename().str());
 
   if (ObjectFile *_ = module_sp->GetMemoryObjectFile(
           shared_from_this(), header_addr, error, size_to_read))

--- a/lldb/source/Target/SectionLoadList.cpp
+++ b/lldb/source/Target/SectionLoadList.cpp
@@ -117,9 +117,9 @@ bool SectionLoadList::SetSectionLoadAddress(const lldb::SectionSP &section,
         module_sp->ReportWarning(
             "address {0:x16} maps to more than one section: {1}.{2} and "
             "{3}.{4}",
-            load_addr, module_sp->GetFileSpec().GetFilename().GetCString(),
+            load_addr, module_sp->GetFileSpec().GetFilename(),
             section->GetName().GetCString(),
-            curr_module_sp->GetFileSpec().GetFilename().GetCString(),
+            curr_module_sp->GetFileSpec().GetFilename(),
             ats_pos->second->GetName().GetCString());
       }
     }

--- a/lldb/source/Target/StackFrameRecognizer.cpp
+++ b/lldb/source/Target/StackFrameRecognizer.cpp
@@ -145,7 +145,7 @@ StackFrameRecognizerManager::GetRecognizerForFrame(StackFrameSP frame) {
   ModuleSP module_sp = symctx.module_sp;
   if (!module_sp)
     return StackFrameRecognizerSP();
-  ConstString module_name = module_sp->GetFileSpec().GetFilename();
+  llvm::StringRef module_name = module_sp->GetFileSpec().GetFilename();
   const Symbol *symbol = symctx.symbol;
   if (!symbol)
     return StackFrameRecognizerSP();
@@ -161,7 +161,7 @@ StackFrameRecognizerManager::GetRecognizerForFrame(StackFrameSP frame) {
         continue;
 
     if (entry.module_regexp)
-      if (!entry.module_regexp->Execute(module_name.GetStringRef()))
+      if (!entry.module_regexp->Execute(module_name))
         continue;
 
     ConstString function_name = symctx.GetFunctionName(entry.symbol_mangling);

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -137,7 +137,7 @@ private:
       return {};
 
     remote_file = platform->GetRemoteWorkingDirectory();
-    remote_file.AppendPathComponent(local_file.GetFilename().GetCString());
+    remote_file.AppendPathComponent(local_file.GetFilename());
 
     return remote_file;
   }
@@ -268,7 +268,7 @@ void Target::Dump(Stream *s, lldb::DescriptionLevel description_level) {
   } else {
     Module *exe_module = GetExecutableModulePointer();
     if (exe_module)
-      s->PutCString(exe_module->GetFileSpec().GetFilename().GetCString());
+      s->PutCString(exe_module->GetFileSpec().GetFilename());
     else
       s->PutCString("No executable module.");
   }
@@ -2469,7 +2469,8 @@ ModuleSP Target::GetOrCreateModule(const ModuleSpec &orig_module_spec,
         ModuleSpec transformed_spec(module_spec);
         ConstString transformed_dir;
         if (m_image_search_paths.RemapPath(
-                module_spec.GetFileSpec().GetDirectory(), transformed_dir)) {
+                ConstString(module_spec.GetFileSpec().GetDirectory()),
+                transformed_dir)) {
           transformed_spec.GetFileSpec().SetDirectory(transformed_dir);
           transformed_spec.GetFileSpec().SetFilename(
                 module_spec.GetFileSpec().GetFilename());
@@ -2555,8 +2556,8 @@ ModuleSP Target::GetOrCreateModule(const ModuleSpec &orig_module_spec,
         // in the target's module list. Only do this if there is SOMETHING else
         // in the module spec...
         if (module_spec.GetUUID().IsValid() &&
-            !module_spec.GetFileSpec().GetFilename().IsEmpty() &&
-            !module_spec.GetFileSpec().GetDirectory().IsEmpty()) {
+            !module_spec.GetFileSpec().GetFilename().empty() &&
+            !module_spec.GetFileSpec().GetDirectory().empty()) {
           ModuleSpec module_spec_copy(module_spec.GetFileSpec());
           module_spec_copy.GetUUID().Clear();
 
@@ -3052,7 +3053,7 @@ llvm::Expected<lldb_private::Address> Target::GetEntryPointAddress() {
 
   return llvm::createStringError(
       "Could not find entry point address for primary executable module \"" +
-      exe_module->GetFileSpec().GetFilename().GetStringRef() + "\"");
+      exe_module->GetFileSpec().GetFilename() + "\"");
 }
 
 lldb::addr_t Target::GetCallableLoadAddress(lldb::addr_t load_addr,

--- a/lldb/source/Target/TargetList.cpp
+++ b/lldb/source/Target/TargetList.cpp
@@ -356,7 +356,7 @@ Status TargetList::CreateTargetInternal(Debugger &debugger,
       target_sp->SetArg0(file.GetPath().c_str());
     }
   }
-  if (file.GetDirectory()) {
+  if (!file.GetDirectory().empty()) {
     FileSpec file_dir;
     file_dir.SetDirectory(file.GetDirectory());
     target_sp->AppendExecutableSearchPaths(file_dir);

--- a/lldb/source/Target/Trace.cpp
+++ b/lldb/source/Target/Trace.cpp
@@ -112,8 +112,7 @@ Trace::LoadPostMortemTraceFromFile(Debugger &debugger,
   }
 
   return Trace::FindPluginForPostMortemProcess(
-      debugger, *session_file,
-      trace_description_file.GetDirectory().GetStringRef());
+      debugger, *session_file, trace_description_file.GetDirectory());
 }
 
 Expected<lldb::TraceSP> Trace::FindPluginForPostMortemProcess(

--- a/lldb/source/Target/TraceDumper.cpp
+++ b/lldb/source/Target/TraceDumper.cpp
@@ -30,7 +30,7 @@ static std::optional<llvm::StringRef> ToOptionalString(llvm::StringRef s) {
 static llvm::StringRef GetModuleName(const SymbolContext &sc) {
   if (!sc.module_sp)
     return {};
-  return sc.module_sp->GetFileSpec().GetFilename().GetStringRef();
+  return sc.module_sp->GetFileSpec().GetFilename();
 }
 
 /// \return

--- a/lldb/source/Utility/Args.cpp
+++ b/lldb/source/Utility/Args.cpp
@@ -407,7 +407,7 @@ std::string Args::GetShellSafeArgument(const FileSpec &shell,
   // safe minimal set
   llvm::StringRef escapables = " '\"";
 
-  auto basename = shell.GetFilename().GetStringRef();
+  auto basename = shell.GetFilename();
   if (!basename.empty()) {
     for (const auto &Shell : g_Shells) {
       if (Shell.m_basename == basename) {

--- a/lldb/source/Utility/FileSpec.cpp
+++ b/lldb/source/Utility/FileSpec.cpp
@@ -292,16 +292,16 @@ int FileSpec::Compare(const FileSpec &a, const FileSpec &b, bool full) {
 }
 
 bool FileSpec::Equal(const FileSpec &a, const FileSpec &b, bool full) {
-  if (full || (a.GetDirectory() && b.GetDirectory()))
+  if (full || (!a.GetDirectory().empty() && !b.GetDirectory().empty()))
     return a == b;
 
   return a.FileEquals(b);
 }
 
 bool FileSpec::Match(const FileSpec &pattern, const FileSpec &file) {
-  if (pattern.GetDirectory())
+  if (!pattern.GetDirectory().empty())
     return pattern == file;
-  if (pattern.GetFilename())
+  if (!pattern.GetFilename().empty())
     return pattern.FileEquals(file);
   return true;
 }
@@ -532,8 +532,8 @@ void llvm::format_provider<FileSpec>::format(const FileSpec &F,
           Style.equals_insensitive("D")) &&
          "Invalid FileSpec style!");
 
-  StringRef dir = F.GetDirectory().GetStringRef();
-  StringRef file = F.GetFilename().GetStringRef();
+  StringRef dir = F.GetDirectory();
+  StringRef file = F.GetFilename();
 
   if (dir.empty() && file.empty()) {
     Stream << "(empty)";

--- a/lldb/source/Utility/FileSpecList.cpp
+++ b/lldb/source/Utility/FileSpecList.cpp
@@ -75,14 +75,12 @@ static size_t FindFileIndex(size_t start_idx, const FileSpec &file_spec,
                             std::function<const FileSpec &(size_t)> get_ith) {
   // When looking for files, we will compare only the filename if the FILE_SPEC
   // argument is empty
-  bool compare_filename_only = file_spec.GetDirectory().IsEmpty();
+  bool compare_filename_only = file_spec.GetDirectory().empty();
 
   for (size_t idx = start_idx; idx < num_files; ++idx) {
     const FileSpec &ith = get_ith(idx);
     if (compare_filename_only) {
-      if (ConstString::Equals(ith.GetFilename(), file_spec.GetFilename(),
-                              file_spec.IsCaseSensitive() ||
-                                  ith.IsCaseSensitive()))
+      if (file_spec.FileEquals(ith))
         return idx;
     } else {
       if (FileSpec::Equal(ith, file_spec, full))
@@ -122,7 +120,7 @@ IsCompatibleResult IsCompatible(const FileSpec &curr_file,
   const bool file_spec_case_sensitive = file_spec.IsCaseSensitive();
   // When looking for files, we will compare only the filename if the directory
   // argument is empty in file_spec
-  const bool full = !file_spec.GetDirectory().IsEmpty();
+  const bool full = !file_spec.GetDirectory().empty();
 
   // Always start by matching the filename first
   if (!curr_file.FileEquals(file_spec))
@@ -134,14 +132,14 @@ IsCompatibleResult IsCompatible(const FileSpec &curr_file,
   if (FileSpec::Equal(curr_file, file_spec, full)) {
     return IsCompatibleResult::kBothDirectoryAndFileMatch;
   } else if (curr_file.IsRelative() || file_spec_relative) {
-    llvm::StringRef curr_file_dir = curr_file.GetDirectory().GetStringRef();
+    llvm::StringRef curr_file_dir = curr_file.GetDirectory();
     if (curr_file_dir.empty())
       // Basename match only for this file in the list
       return IsCompatibleResult::kBothDirectoryAndFileMatch;
 
     // Check if we have a relative path in our file list, or if "file_spec" is
     // relative, if so, check if either ends with the other.
-    llvm::StringRef file_spec_dir = file_spec.GetDirectory().GetStringRef();
+    llvm::StringRef file_spec_dir = file_spec.GetDirectory();
     // We have a relative path in our file list, it matches if the
     // specified path ends with this path, but we must ensure the full
     // component matches (we don't want "foo/bar.cpp" to match "oo/bar.cpp").

--- a/lldb/source/Utility/ProcessInfo.cpp
+++ b/lldb/source/Utility/ProcessInfo.cpp
@@ -43,7 +43,7 @@ void ProcessInfo::Clear() {
 }
 
 llvm::StringRef ProcessInfo::GetName() const {
-  return m_executable.GetFilename().GetStringRef();
+  return m_executable.GetFilename();
 }
 
 void ProcessInfo::Dump(Stream &s, Platform *platform) const {
@@ -121,7 +121,7 @@ void ProcessInstanceInfo::Dump(Stream &s, UserIDResolver &resolver) const {
     s.Printf(" parent = %" PRIu64 "\n", GetParentProcessID());
 
   if (m_executable) {
-    s.Printf("   name = %s\n", m_executable.GetFilename().GetCString());
+    s.Format("   name = {0}\n", m_executable.GetFilename());
     s.PutCString("   file = ");
     m_executable.Dump(s.AsRawOstream());
     s.EOL();

--- a/lldb/source/Utility/XcodeSDK.cpp
+++ b/lldb/source/Utility/XcodeSDK.cpp
@@ -170,7 +170,7 @@ void XcodeSDK::Merge(const XcodeSDK &other) {
   }
 
   // We changed the SDK name. Adjust the sysroot accordingly.
-  if (m_sysroot && m_sysroot.GetFilename().GetStringRef() != m_name)
+  if (m_sysroot && m_sysroot.GetFilename() != m_name)
     m_sysroot.SetFilename(m_name);
 }
 
@@ -245,12 +245,12 @@ bool XcodeSDK::SDKSupportsModules(XcodeSDK::Type sdk_type,
 
 bool XcodeSDK::SDKSupportsModules(XcodeSDK::Type desired_type,
                                   const FileSpec &sdk_path) {
-  ConstString last_path_component = sdk_path.GetFilename();
+  llvm::StringRef last_path_component = sdk_path.GetFilename();
 
-  if (!last_path_component)
+  if (last_path_component.empty())
     return false;
 
-  XcodeSDK sdk(last_path_component.GetStringRef().str());
+  XcodeSDK sdk(last_path_component.str());
   if (sdk.GetType() != desired_type)
     return false;
   return SDKSupportsModules(sdk.GetType(), sdk.GetVersion());

--- a/lldb/tools/lldb-server/lldb-platform.cpp
+++ b/lldb/tools/lldb-server/lldb-platform.cpp
@@ -203,7 +203,7 @@ static Status parse_listen_host_port(Socket::SocketProtocol &protocol,
 
 static Status save_socket_id_to_file(const std::string &socket_id,
                                      const FileSpec &file_spec) {
-  FileSpec temp_file_spec(file_spec.GetDirectory().GetStringRef());
+  FileSpec temp_file_spec(file_spec.GetDirectory());
   Status status(llvm::sys::fs::create_directory(temp_file_spec.GetPath()));
   if (status.Fail())
     return Status::FromErrorStringWithFormat(

--- a/lldb/tools/lldb-test/lldb-test.cpp
+++ b/lldb/tools/lldb-test/lldb-test.cpp
@@ -665,8 +665,7 @@ Error opts::symbols::findVariables(lldb_private::Module &Module) {
     CompUnitSP CU;
     for (size_t Ind = 0; !CU && Ind < Module.GetNumCompileUnits(); ++Ind) {
       CompUnitSP Candidate = Module.GetCompileUnitAtIndex(Ind);
-      if (!Candidate ||
-          Candidate->GetPrimaryFile().GetFilename().GetStringRef() != File)
+      if (!Candidate || Candidate->GetPrimaryFile().GetFilename() != File)
         continue;
       if (CU)
         return make_string_error("Multiple compile units for file `{0}` found.",

--- a/lldb/unittests/Symbol/LocateSymbolFileTest.cpp
+++ b/lldb/unittests/Symbol/LocateSymbolFileTest.cpp
@@ -32,7 +32,7 @@ TEST_F(
   StatisticsMap map;
   FileSpec symbol_file_spec =
       PluginManager::LocateExecutableSymbolFile(module_spec, search_paths, map);
-  EXPECT_TRUE(symbol_file_spec.GetFilename().IsEmpty());
+  EXPECT_TRUE(symbol_file_spec.GetFilename().empty());
 }
 
 TEST_F(SymbolsTest,
@@ -45,5 +45,5 @@ TEST_F(SymbolsTest,
   StatisticsMap map;
   FileSpec symbol_file_spec =
       PluginManager::LocateExecutableSymbolFile(module_spec, search_paths, map);
-  EXPECT_TRUE(symbol_file_spec.GetFilename().IsEmpty());
+  EXPECT_TRUE(symbol_file_spec.GetFilename().empty());
 }

--- a/lldb/unittests/Target/LocateModuleCallbackTest.cpp
+++ b/lldb/unittests/Target/LocateModuleCallbackTest.cpp
@@ -112,7 +112,7 @@ void BuildEmptyCacheDir(const FileSpec &test_dir) {
 FileSpec BuildCacheDir(const FileSpec &test_dir) {
   FileSpec uuid_view = GetUuidView(test_dir);
   std::error_code ec =
-      llvm::sys::fs::create_directories(uuid_view.GetDirectory().GetCString());
+      llvm::sys::fs::create_directories(uuid_view.GetDirectory());
   EXPECT_FALSE(ec);
   ec = llvm::sys::fs::copy_file(GetInputFilePath(k_module_file),
                                 uuid_view.GetPath().c_str());

--- a/lldb/unittests/Target/ModuleCacheTest.cpp
+++ b/lldb/unittests/Target/ModuleCacheTest.cpp
@@ -138,7 +138,7 @@ TEST_F(ModuleCacheTest, GetAndPutUuidExists) {
 
   FileSpec uuid_view = GetUuidView(test_cache_dir);
   std::error_code ec =
-      llvm::sys::fs::create_directories(uuid_view.GetDirectory().GetCString());
+      llvm::sys::fs::create_directories(uuid_view.GetDirectory());
   ASSERT_FALSE(ec);
   ec = llvm::sys::fs::copy_file(s_test_executable, uuid_view.GetPath().c_str());
   ASSERT_FALSE(ec);

--- a/lldb/unittests/Utility/FileSpecTest.cpp
+++ b/lldb/unittests/Utility/FileSpecTest.cpp
@@ -23,101 +23,101 @@ static FileSpec WindowsSpec(llvm::StringRef path) {
 TEST(FileSpecTest, FileAndDirectoryComponents) {
   FileSpec fs_posix("/foo/bar", FileSpec::Style::posix);
   EXPECT_STREQ("/foo/bar", fs_posix.GetPath().c_str());
-  EXPECT_STREQ("/foo", fs_posix.GetDirectory().GetCString());
-  EXPECT_STREQ("bar", fs_posix.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("/foo"), fs_posix.GetDirectory());
+  EXPECT_EQ(llvm::StringRef("bar"), fs_posix.GetFilename());
 
   FileSpec fs_windows("F:\\bar", FileSpec::Style::windows);
   EXPECT_STREQ("F:\\bar", fs_windows.GetPath().c_str());
   // EXPECT_STREQ("F:\\", fs_windows.GetDirectory().GetPath().c_str()); // It returns
   // "F:/"
-  EXPECT_STREQ("bar", fs_windows.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("bar"), fs_windows.GetFilename());
 
   FileSpec fs_posix_root("/", FileSpec::Style::posix);
   EXPECT_STREQ("/", fs_posix_root.GetPath().c_str());
-  EXPECT_EQ(nullptr, fs_posix_root.GetDirectory().GetCString());
-  EXPECT_STREQ("/", fs_posix_root.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef(), fs_posix_root.GetDirectory());
+  EXPECT_EQ(llvm::StringRef("/"), fs_posix_root.GetFilename());
 
   FileSpec fs_net_drive("//net", FileSpec::Style::posix);
   EXPECT_STREQ("//net", fs_net_drive.GetPath().c_str());
-  EXPECT_EQ(nullptr, fs_net_drive.GetDirectory().GetCString());
-  EXPECT_STREQ("//net", fs_net_drive.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef(), fs_net_drive.GetDirectory());
+  EXPECT_EQ(llvm::StringRef("//net"), fs_net_drive.GetFilename());
 
   FileSpec fs_net_root("//net/", FileSpec::Style::posix);
   EXPECT_STREQ("//net/", fs_net_root.GetPath().c_str());
-  EXPECT_STREQ("//net", fs_net_root.GetDirectory().GetCString());
-  EXPECT_STREQ("/", fs_net_root.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("//net"), fs_net_root.GetDirectory());
+  EXPECT_EQ(llvm::StringRef("/"), fs_net_root.GetFilename());
 
   FileSpec fs_windows_drive("F:", FileSpec::Style::windows);
   EXPECT_STREQ("F:", fs_windows_drive.GetPath().c_str());
-  EXPECT_EQ(nullptr, fs_windows_drive.GetDirectory().GetCString());
-  EXPECT_STREQ("F:", fs_windows_drive.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef(), fs_windows_drive.GetDirectory());
+  EXPECT_EQ(llvm::StringRef("F:"), fs_windows_drive.GetFilename());
 
   FileSpec fs_windows_root("F:\\", FileSpec::Style::windows);
   EXPECT_STREQ("F:\\", fs_windows_root.GetPath().c_str());
-  EXPECT_STREQ("F:", fs_windows_root.GetDirectory().GetCString());
+  EXPECT_EQ(llvm::StringRef("F:"), fs_windows_root.GetDirectory());
   // EXPECT_STREQ("\\", fs_windows_root.GetFilename().GetCString()); // It
   // returns "/"
 
   FileSpec fs_posix_long("/foo/bar/baz", FileSpec::Style::posix);
   EXPECT_STREQ("/foo/bar/baz", fs_posix_long.GetPath().c_str());
-  EXPECT_STREQ("/foo/bar", fs_posix_long.GetDirectory().GetCString());
-  EXPECT_STREQ("baz", fs_posix_long.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("/foo/bar"), fs_posix_long.GetDirectory());
+  EXPECT_EQ(llvm::StringRef("baz"), fs_posix_long.GetFilename());
 
   FileSpec fs_windows_long("F:\\bar\\baz", FileSpec::Style::windows);
   EXPECT_STREQ("F:\\bar\\baz", fs_windows_long.GetPath().c_str());
   // EXPECT_STREQ("F:\\bar", fs_windows_long.GetDirectory().GetCString()); // It
   // returns "F:/bar"
-  EXPECT_STREQ("baz", fs_windows_long.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("baz"), fs_windows_long.GetFilename());
 
   FileSpec fs_posix_trailing_slash("/foo/bar/", FileSpec::Style::posix);
   EXPECT_STREQ("/foo/bar", fs_posix_trailing_slash.GetPath().c_str());
-  EXPECT_STREQ("/foo", fs_posix_trailing_slash.GetDirectory().GetCString());
-  EXPECT_STREQ("bar", fs_posix_trailing_slash.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("/foo"), fs_posix_trailing_slash.GetDirectory());
+  EXPECT_EQ(llvm::StringRef("bar"), fs_posix_trailing_slash.GetFilename());
 
   FileSpec fs_windows_trailing_slash("F:\\bar\\", FileSpec::Style::windows);
   EXPECT_STREQ("F:\\bar", fs_windows_trailing_slash.GetPath().c_str());
-  EXPECT_STREQ("bar", fs_windows_trailing_slash.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("bar"), fs_windows_trailing_slash.GetFilename());
 }
 
 TEST(FileSpecTest, AppendPathComponent) {
   FileSpec fs_posix("/foo", FileSpec::Style::posix);
   fs_posix.AppendPathComponent("bar");
   EXPECT_STREQ("/foo/bar", fs_posix.GetPath().c_str());
-  EXPECT_STREQ("/foo", fs_posix.GetDirectory().GetCString());
-  EXPECT_STREQ("bar", fs_posix.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("/foo"), fs_posix.GetDirectory());
+  EXPECT_EQ(llvm::StringRef("bar"), fs_posix.GetFilename());
 
   FileSpec fs_posix_2("/foo", FileSpec::Style::posix);
   fs_posix_2.AppendPathComponent("//bar/baz");
   EXPECT_STREQ("/foo/bar/baz", fs_posix_2.GetPath().c_str());
-  EXPECT_STREQ("/foo/bar", fs_posix_2.GetDirectory().GetCString());
-  EXPECT_STREQ("baz", fs_posix_2.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("/foo/bar"), fs_posix_2.GetDirectory());
+  EXPECT_EQ(llvm::StringRef("baz"), fs_posix_2.GetFilename());
 
   FileSpec fs_windows("F:\\bar", FileSpec::Style::windows);
   fs_windows.AppendPathComponent("baz");
   EXPECT_STREQ("F:\\bar\\baz", fs_windows.GetPath().c_str());
   // EXPECT_STREQ("F:\\bar", fs_windows.GetDirectory().GetCString()); // It
   // returns "F:/bar"
-  EXPECT_STREQ("baz", fs_windows.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("baz"), fs_windows.GetFilename());
 
   FileSpec fs_posix_root("/", FileSpec::Style::posix);
   fs_posix_root.AppendPathComponent("bar");
   EXPECT_STREQ("/bar", fs_posix_root.GetPath().c_str());
-  EXPECT_STREQ("/", fs_posix_root.GetDirectory().GetCString());
-  EXPECT_STREQ("bar", fs_posix_root.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("/"), fs_posix_root.GetDirectory());
+  EXPECT_EQ(llvm::StringRef("bar"), fs_posix_root.GetFilename());
 
   FileSpec fs_windows_root("F:\\", FileSpec::Style::windows);
   fs_windows_root.AppendPathComponent("bar");
   EXPECT_STREQ("F:\\bar", fs_windows_root.GetPath().c_str());
   // EXPECT_STREQ("F:\\", fs_windows_root.GetDirectory().GetCString()); // It
   // returns "F:/"
-  EXPECT_STREQ("bar", fs_windows_root.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("bar"), fs_windows_root.GetFilename());
 }
 
 TEST(FileSpecTest, CopyByAppendingPathComponent) {
   FileSpec fs = PosixSpec("/foo").CopyByAppendingPathComponent("bar");
   EXPECT_STREQ("/foo/bar", fs.GetPath().c_str());
-  EXPECT_STREQ("/foo", fs.GetDirectory().GetCString());
-  EXPECT_STREQ("bar", fs.GetFilename().GetCString());
+  EXPECT_EQ(llvm::StringRef("/foo"), fs.GetDirectory());
+  EXPECT_EQ(llvm::StringRef("bar"), fs.GetFilename());
 }
 
 TEST(FileSpecTest, PrependPathComponent) {


### PR DESCRIPTION
This finishes the removal of ConstString from FileSpec's interface. Note that FileSpec is still _backed_ by ConstStrings, that will be changed in a follow-up.

A non-goal for this change is to rewrite business logic, so I kept the type of some variables as ConstString where a refactor would necessary to change that. I converted printf-style formatting to formatv-style formatting where required, and otherwise tried to leave callsites alone to the extent that was possible.