### PR TITLE
[libc++] Assume that <wchar.h> in llvm-libc has const-overloads.

### DIFF
--- a/libcxx/include/wchar.h
+++ b/libcxx/include/wchar.h
@@ -133,6 +133,8 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 #      if defined(_CRT_CONST_CORRECT_OVERLOADS)
 #        define _LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS 1
 #      endif
+#    elif _LIBCPP_LIBC_LLVM_LIBC
+#      define _LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS 1
 #    endif
 
 #    if _LIBCPP_HAS_WIDE_CHARACTERS


### PR DESCRIPTION
See discussion in https://github.com/llvm/llvm-project/pull/201236 - we're close to enabling wide characters in libc++ when it's built on top of llvm-libc.

llvm-libc headers use `const wchar_t*` return type for selected wchar functions, so we need to configure libc++ to assume that const-overloads for these functions are available in this case, and the implementations in libc++ wrapper around `<wchar.h>` are not needed.