### PR TITLE
[clang-format] Fix annotating paren after in

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2821,10 +2821,8 @@ private:
       // If there is an identifier (or with a few exceptions a keyword) right
       // before the parentheses, this is unlikely to be a cast.
       if (LeftOfParens->Tok.getIdentifierInfo() &&
-          (LeftOfParens->isNoneOf(Keywords.kw_in, tok::kw_return, tok::kw_case,
-                                  tok::kw_delete, tok::kw_throw) ||
-           (LeftOfParens->Previous &&
-            LeftOfParens->Previous->is(tok::period)))) {
+          LeftOfParens->isNoneOf(TT_ObjCForIn, tok::kw_return, tok::kw_case,
+                                 tok::kw_delete, tok::kw_throw)) {
         return false;
       }
 

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2821,8 +2821,10 @@ private:
       // If there is an identifier (or with a few exceptions a keyword) right
       // before the parentheses, this is unlikely to be a cast.
       if (LeftOfParens->Tok.getIdentifierInfo() &&
-          LeftOfParens->isNoneOf(Keywords.kw_in, tok::kw_return, tok::kw_case,
-                                 tok::kw_delete, tok::kw_throw)) {
+          (LeftOfParens->isNoneOf(Keywords.kw_in, tok::kw_return, tok::kw_case,
+                                  tok::kw_delete, tok::kw_throw) ||
+           (LeftOfParens->Previous &&
+            LeftOfParens->Previous->is(tok::period)))) {
         return false;
       }
 

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1000,6 +1000,7 @@ TEST_F(TokenAnnotatorTest, UnderstandsCasts) {
   Tokens = annotate("auto x = y.in(foo) - w;");
   ASSERT_EQ(Tokens.size(), 13u) << Tokens;
   EXPECT_TOKEN(Tokens[8], tok::r_paren, TT_Unknown); // NOT TT_CastRParen
+  EXPECT_TOKEN(Tokens[9], tok::minus, TT_BinaryOperator);
 
   auto Style = getLLVMStyle();
   Style.TypeNames.push_back("Foo");

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -997,6 +997,10 @@ TEST_F(TokenAnnotatorTest, UnderstandsCasts) {
   EXPECT_TOKEN(Tokens[10], tok::r_paren, TT_CastRParen);
   EXPECT_TOKEN(Tokens[11], tok::amp, TT_UnaryOperator);
 
+  Tokens = annotate("auto x = y.in(foo) - w;");
+  ASSERT_EQ(Tokens.size(), 13u) << Tokens;
+  EXPECT_TOKEN(Tokens[8], tok::r_paren, TT_Unknown); // NOT TT_CastRParen
+
   auto Style = getLLVMStyle();
   Style.TypeNames.push_back("Foo");
   Tokens = annotate("#define FOO(bar) foo((Foo)&bar)", Style);


### PR DESCRIPTION
The y.in(foo) was considered a cast, and thus the following - annotated as unary operator.

Fixes #206339