### PR TITLE
[dsymutil] collect pseudoprobe sections from debug map into __LLVM segment

### DIFF
--- a/llvm/test/tools/dsymutil/AArch64/pseudo-probe-universal.test
+++ b/llvm/test/tools/dsymutil/AArch64/pseudo-probe-universal.test
@@ -1,3 +1,4 @@
+# REQUIRES: system-darwin
 # REQUIRES: aarch64-registered-target
 # REQUIRES: host-byteorder-little-endian
 

--- a/llvm/test/tools/dsymutil/AArch64/pseudo-probe-universal.test
+++ b/llvm/test/tools/dsymutil/AArch64/pseudo-probe-universal.test
@@ -1,6 +1,5 @@
 # REQUIRES: system-darwin
 # REQUIRES: aarch64-registered-target
-# REQUIRES: host-byteorder-little-endian
 
 # RUN: rm -rf %t && split-file %s %t
 # RUN: yaml2obj %t/fat.dylib.yaml -o %t/fat.dylib
@@ -8,52 +7,31 @@
 # RUN: yaml2obj %t/e.o.yaml -o %t/e.o
 
 # RUN: dsymutil --linker classic --no-object-timestamp %t/fat.dylib -oso-prepend-path=%t -o %t/classic.dSYM
-# RUN: llvm-readobj --file-headers --sections %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 \
-# RUN:    | FileCheck %s --check-prefix=ARM64
-# RUN: llvm-readobj --file-headers --sections %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64e \
-# RUN:    | FileCheck %s --check-prefix=ARM64E
-# RUN: llvm-objdump -s --section=__probes --section=__probe_descs %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 \
-# RUN:    | FileCheck %s --check-prefix=DATA
+# RUN: od -t x1 %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 | FileCheck %s --check-prefix=PROBES
+# RUN: od -t x1 %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64e | FileCheck %s --check-prefix=PROBES
+# RUN: od -t x1 %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probe_descs-arm64 | FileCheck %s --check-prefix=DESCS
+# RUN: od -t x1 %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probe_descs-arm64e | FileCheck %s --check-prefix=DESCS
+# RUN: wc -c < %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 | FileCheck %s --check-prefix=PROBES-SIZE
+# RUN: wc -c < %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probe_descs-arm64 | FileCheck %s --check-prefix=DESCS-SIZE
 
 # RUN: dsymutil --linker parallel --no-object-timestamp %t/fat.dylib -oso-prepend-path=%t -o %t/parallel.dSYM
-# RUN: llvm-readobj --file-headers --sections %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 \
-# RUN:    | FileCheck %s --check-prefix=ARM64
-# RUN: llvm-readobj --file-headers --sections %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64e \
-# RUN:    | FileCheck %s --check-prefix=ARM64E
-# RUN: llvm-objdump -s --section=__probes --section=__probe_descs %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 \
-# RUN:    | FileCheck %s --check-prefix=DATA
+# RUN: od -t x1 %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 | FileCheck %s --check-prefix=PROBES
+# RUN: od -t x1 %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64e | FileCheck %s --check-prefix=PROBES
+# RUN: od -t x1 %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probe_descs-arm64 | FileCheck %s --check-prefix=DESCS
+# RUN: od -t x1 %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probe_descs-arm64e | FileCheck %s --check-prefix=DESCS
+# RUN: wc -c < %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 | FileCheck %s --check-prefix=PROBES-SIZE
+# RUN: wc -c < %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probe_descs-arm64 | FileCheck %s --check-prefix=DESCS-SIZE
 
-# ARM64:      CpuType: Arm64
-# ARM64:      CpuSubType: CPU_SUBTYPE_ARM64_ALL
-# ARM64:      Name: __probes
-# ARM64-NEXT: Segment: __LLVM
-# ARM64-NEXT: Address: 0x0
-# ARM64-NEXT: Size: 0x3C
-# ARM64-NEXT: Offset: 368
-# ARM64:      Name: __probe_descs
-# ARM64-NEXT: Segment: __LLVM
-# ARM64-NEXT: Address: 0x3C
-# ARM64-NEXT: Size: 0x27
-# ARM64-NEXT: Offset: 428
+# PROBES:      0000000 fa d5 8d e7 36 64 95 db 02 01 00 20 01 41 1f ae
+# PROBES-NEXT: 0000020 90 f5 72 26 01 80 00 02 8f a1 4c dd 75 4f 91 cc
+# PROBES-NEXT: 0000040 01 00 01 80 00 8f a1 4c dd 75 4f 91 cc 02 00 00
+# PROBES-NEXT: 0000060 20 e9 90 36 e9 13 02 d0 8b 01 80 00
+# PROBES-SIZE: 60
 
-# ARM64E:      CpuType: Arm64
-# ARM64E:      CpuSubType: CPU_SUBTYPE_ARM64E
-# ARM64E:      Name: __probes
-# ARM64E-NEXT: Segment: __LLVM
-# ARM64E-NEXT: Address: 0x0
-# ARM64E-NEXT: Size: 0x3C
-# ARM64E-NEXT: Offset: 368
-# ARM64E:      Name: __probe_descs
-# ARM64E-NEXT: Segment: __LLVM
-# ARM64E-NEXT: Address: 0x3C
-# ARM64E-NEXT: Size: 0x27
-# ARM64E-NEXT: Offset: 428
-
-# DATA:      Contents of section __LLVM,__probes:
-# DATA-NEXT: 0000 fad58de7 366495db
-# DATA:      Contents of section __LLVM,__probe_descs:
-# DATA-NEXT: 003c 8fa14cdd 754f91cc
-# DATA:      046d 61696e
+# DESCS:      0000000 8f a1 4c dd 75 4f 91 cc ff ff ff ff 00 00 00 00
+# DESCS-NEXT: 0000020 01 66 fa d5 8d e7 36 64 95 db ff ff ff ff 00 00
+# DESCS-NEXT: 0000040 01 00 04 6d 61 69 6e
+# DESCS-SIZE: 39
 
 
 #--- fat.dylib.yaml

--- a/llvm/test/tools/dsymutil/AArch64/pseudo-probe-universal.test
+++ b/llvm/test/tools/dsymutil/AArch64/pseudo-probe-universal.test
@@ -1,0 +1,439 @@
+# REQUIRES: aarch64-registered-target
+# REQUIRES: host-byteorder-little-endian
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: yaml2obj %t/fat.dylib.yaml -o %t/fat.dylib
+# RUN: yaml2obj %t/a.o.yaml -o %t/a.o
+# RUN: yaml2obj %t/e.o.yaml -o %t/e.o
+
+# RUN: dsymutil --linker classic --no-object-timestamp %t/fat.dylib -oso-prepend-path=%t -o %t/classic.dSYM
+# RUN: llvm-readobj --file-headers --sections %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 \
+# RUN:    | FileCheck %s --check-prefix=ARM64
+# RUN: llvm-readobj --file-headers --sections %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64e \
+# RUN:    | FileCheck %s --check-prefix=ARM64E
+# RUN: llvm-objdump -s --section=__probes --section=__probe_descs %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 \
+# RUN:    | FileCheck %s --check-prefix=DATA
+
+# RUN: dsymutil --linker parallel --no-object-timestamp %t/fat.dylib -oso-prepend-path=%t -o %t/parallel.dSYM
+# RUN: llvm-readobj --file-headers --sections %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 \
+# RUN:    | FileCheck %s --check-prefix=ARM64
+# RUN: llvm-readobj --file-headers --sections %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64e \
+# RUN:    | FileCheck %s --check-prefix=ARM64E
+# RUN: llvm-objdump -s --section=__probes --section=__probe_descs %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes-arm64 \
+# RUN:    | FileCheck %s --check-prefix=DATA
+
+# ARM64:      CpuType: Arm64
+# ARM64:      CpuSubType: CPU_SUBTYPE_ARM64_ALL
+# ARM64:      Name: __probes
+# ARM64-NEXT: Segment: __LLVM
+# ARM64-NEXT: Address: 0x0
+# ARM64-NEXT: Size: 0x3C
+# ARM64-NEXT: Offset: 368
+# ARM64:      Name: __probe_descs
+# ARM64-NEXT: Segment: __LLVM
+# ARM64-NEXT: Address: 0x3C
+# ARM64-NEXT: Size: 0x27
+# ARM64-NEXT: Offset: 428
+
+# ARM64E:      CpuType: Arm64
+# ARM64E:      CpuSubType: CPU_SUBTYPE_ARM64E
+# ARM64E:      Name: __probes
+# ARM64E-NEXT: Segment: __LLVM
+# ARM64E-NEXT: Address: 0x0
+# ARM64E-NEXT: Size: 0x3C
+# ARM64E-NEXT: Offset: 368
+# ARM64E:      Name: __probe_descs
+# ARM64E-NEXT: Segment: __LLVM
+# ARM64E-NEXT: Address: 0x3C
+# ARM64E-NEXT: Size: 0x27
+# ARM64E-NEXT: Offset: 428
+
+# DATA:      Contents of section __LLVM,__probes:
+# DATA-NEXT: 0000 fad58de7 366495db
+# DATA:      Contents of section __LLVM,__probe_descs:
+# DATA-NEXT: 003c 8fa14cdd 754f91cc
+# DATA:      046d 61696e
+
+
+#--- fat.dylib.yaml
+--- !fat-mach-o
+FatHeader:
+  magic:           0xCAFEBABE
+  nfat_arch:       2
+FatArchs:
+  - cputype:         0x100000C
+    cpusubtype:      0x0
+    offset:          0x4000
+    size:            181
+    align:           14
+  - cputype:         0x100000C
+    cpusubtype:      0x2
+    offset:          0x8000
+    size:            181
+    align:           14
+Slices:
+  - !mach-o
+    FileHeader:
+      magic:           0xFEEDFACF
+      cputype:         0x100000C
+      cpusubtype:      0x0
+      filetype:        0x6
+      ncmds:           3
+      sizeofcmds:      128
+      flags:           0x100085
+      reserved:        0x0
+    LoadCommands:
+      - cmd:             LC_SEGMENT_64
+        cmdsize:         72
+        segname:         __LINKEDIT
+        vmaddr:          16384
+        vmsize:          4096
+        fileoff:         160
+        filesize:        21
+        maxprot:         1
+        initprot:        1
+        nsects:          0
+        flags:           0
+      - cmd:             LC_ID_DYLIB
+        cmdsize:         32
+        dylib:
+          name:            24
+          timestamp:       0
+          current_version: 0
+          compatibility_version: 0
+        Content:         probe
+        ZeroPadBytes:    3
+      - cmd:             LC_SYMTAB
+        cmdsize:         24
+        symoff:          160
+        nsyms:           1
+        stroff:          176
+        strsize:         5
+    LinkEditData:
+      NameList:
+        - n_strx:          1
+          n_type:          0x66
+          n_sect:          0
+          n_desc:          1
+          n_value:         0
+      StringTable:
+        - ''
+        - a.o
+  - !mach-o
+    FileHeader:
+      magic:           0xFEEDFACF
+      cputype:         0x100000C
+      cpusubtype:      0x2
+      filetype:        0x6
+      ncmds:           3
+      sizeofcmds:      128
+      flags:           0x100085
+      reserved:        0x0
+    LoadCommands:
+      - cmd:             LC_SEGMENT_64
+        cmdsize:         72
+        segname:         __LINKEDIT
+        vmaddr:          16384
+        vmsize:          4096
+        fileoff:         160
+        filesize:        21
+        maxprot:         1
+        initprot:        1
+        nsects:          0
+        flags:           0
+      - cmd:             LC_ID_DYLIB
+        cmdsize:         32
+        dylib:
+          name:            24
+          timestamp:       0
+          current_version: 0
+          compatibility_version: 0
+        Content:         probe
+        ZeroPadBytes:    3
+      - cmd:             LC_SYMTAB
+        cmdsize:         24
+        symoff:          160
+        nsyms:           1
+        stroff:          176
+        strsize:         5
+    LinkEditData:
+      NameList:
+        - n_strx:          1
+          n_type:          0x66
+          n_sect:          0
+          n_desc:          1
+          n_value:         0
+      StringTable:
+        - ''
+        - e.o
+...
+
+#--- a.o.yaml
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x100000C
+  cpusubtype:      0x0
+  filetype:        0x1
+  ncmds:           4
+  sizeofcmds:      440
+  flags:           0x2000
+  reserved:        0x0
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         312
+    segname:         ''
+    vmaddr:          0
+    vmsize:          813
+    fileoff:         472
+    filesize:        115
+    maxprot:         7
+    initprot:        7
+    nsects:          3
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0
+        size:            16
+        offset:          0x1D8
+        align:           2
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         00040011C0035FD640008052C0035FD6
+      - sectname:        __probe_descs
+        segname:         __PSEUDO_PROBE
+        addr:            0x10
+        size:            39
+        offset:          0x1E8
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x12000000
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         8FA14CDD754F91CCFFFFFFFF000000000166FAD58DE7366495DBFFFFFFFF00000100046D61696E
+      - sectname:        __probes
+        segname:         __PSEUDO_PROBE
+        addr:            0x2F1
+        size:            60
+        offset:          0x20F
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x12000000
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         FAD58DE7366495DB0201002001411FAE90F57226018000028FA14CDD754F91CC01000180008FA14CDD754F91CC02000020E99036E91302D08B018000
+  - cmd:             LC_BUILD_VERSION
+    cmdsize:         24
+    platform:        1
+    minos:           1703936
+    sdk:             1704960
+    ntools:          0
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          587
+    nsyms:           5
+    stroff:          667
+    strsize:         32
+  - cmd:             LC_DYSYMTAB
+    cmdsize:         80
+    ilocalsym:       0
+    nlocalsym:       3
+    iextdefsym:      3
+    nextdefsym:      2
+    iundefsym:       5
+    nundefsym:       0
+    tocoff:          0
+    ntoc:            0
+    modtaboff:       0
+    nmodtab:         0
+    extrefsymoff:    0
+    nextrefsyms:     0
+    indirectsymoff:  0
+    nindirectsyms:   0
+    extreloff:       0
+    nextrel:         0
+    locreloff:       0
+    nlocrel:         0
+LinkEditData:
+  NameList:
+    - n_strx:          22
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         0
+    - n_strx:          16
+      n_type:          0xE
+      n_sect:          2
+      n_desc:          0
+      n_value:         16
+    - n_strx:          10
+      n_type:          0xE
+      n_sect:          3
+      n_desc:          0
+      n_value:         753
+    - n_strx:          7
+      n_type:          0xF
+      n_sect:          1
+      n_desc:          0
+      n_value:         0
+    - n_strx:          1
+      n_type:          0xF
+      n_sect:          1
+      n_desc:          0
+      n_value:         8
+  StringTable:
+    - ''
+    - _main
+    - _f
+    - ltmp2
+    - ltmp1
+    - ltmp0
+    - ''
+    - ''
+    - ''
+    - ''
+...
+
+#--- e.o.yaml
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x100000C
+  cpusubtype:      0x80000002
+  filetype:        0x1
+  ncmds:           4
+  sizeofcmds:      440
+  flags:           0x2000
+  reserved:        0x0
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         312
+    segname:         ''
+    vmaddr:          0
+    vmsize:          813
+    fileoff:         472
+    filesize:        115
+    maxprot:         7
+    initprot:        7
+    nsects:          3
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0
+        size:            16
+        offset:          0x1D8
+        align:           2
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         00040011C0035FD640008052C0035FD6
+      - sectname:        __probe_descs
+        segname:         __PSEUDO_PROBE
+        addr:            0x10
+        size:            39
+        offset:          0x1E8
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x12000000
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         8FA14CDD754F91CCFFFFFFFF000000000166FAD58DE7366495DBFFFFFFFF00000100046D61696E
+      - sectname:        __probes
+        segname:         __PSEUDO_PROBE
+        addr:            0x2F1
+        size:            60
+        offset:          0x20F
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x12000000
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         FAD58DE7366495DB0201002001411FAE90F57226018000028FA14CDD754F91CC01000180008FA14CDD754F91CC02000020E99036E91302D08B018000
+  - cmd:             LC_BUILD_VERSION
+    cmdsize:         24
+    platform:        1
+    minos:           1703936
+    sdk:             1704960
+    ntools:          0
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          587
+    nsyms:           5
+    stroff:          667
+    strsize:         32
+  - cmd:             LC_DYSYMTAB
+    cmdsize:         80
+    ilocalsym:       0
+    nlocalsym:       3
+    iextdefsym:      3
+    nextdefsym:      2
+    iundefsym:       5
+    nundefsym:       0
+    tocoff:          0
+    ntoc:            0
+    modtaboff:       0
+    nmodtab:         0
+    extrefsymoff:    0
+    nextrefsyms:     0
+    indirectsymoff:  0
+    nindirectsyms:   0
+    extreloff:       0
+    nextrel:         0
+    locreloff:       0
+    nlocrel:         0
+LinkEditData:
+  NameList:
+    - n_strx:          22
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         0
+    - n_strx:          16
+      n_type:          0xE
+      n_sect:          2
+      n_desc:          0
+      n_value:         16
+    - n_strx:          10
+      n_type:          0xE
+      n_sect:          3
+      n_desc:          0
+      n_value:         753
+    - n_strx:          7
+      n_type:          0xF
+      n_sect:          1
+      n_desc:          0
+      n_value:         0
+    - n_strx:          1
+      n_type:          0xF
+      n_sect:          1
+      n_desc:          0
+      n_value:         8
+  StringTable:
+    - ''
+    - _main
+    - _f
+    - ltmp2
+    - ltmp1
+    - ltmp0
+    - ''
+    - ''
+    - ''
+    - ''
+...

--- a/llvm/test/tools/dsymutil/AArch64/pseudo-probe.test
+++ b/llvm/test/tools/dsymutil/AArch64/pseudo-probe.test
@@ -1,0 +1,366 @@
+# REQUIRES: aarch64-registered-target
+# REQUIRES: host-byteorder-little-endian
+
+# RUN: rm -rf %t
+# RUN: split-file %s %t
+# RUN: mkdir -p %t
+# RUN: yaml2obj %t/a.yaml -o %t/a.o
+# RUN: yaml2obj %t/b.yaml -o %t/b.o
+
+# RUN: dsymutil --linker classic -y %t/debug.map -oso-prepend-path=%t -o %t/classic.dSYM
+# RUN: llvm-objdump --section-headers %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes \
+# RUN:    | FileCheck %s --check-prefix=SIZE
+# RUN: llvm-readobj --sections %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes \
+# RUN:    | FileCheck %s --check-prefix=SEG
+# RUN: llvm-objdump -s --section=__probes --section=__probe_descs \
+# RUN:    %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes | FileCheck %s --check-prefix=DATA
+
+# RUN: dsymutil --linker parallel -y %t/debug.map -oso-prepend-path=%t -o %t/parallel.dSYM
+# RUN: llvm-objdump --section-headers %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes \
+# RUN:    | FileCheck %s --check-prefix=SIZE
+# RUN: llvm-readobj --sections %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes \
+# RUN:    | FileCheck %s --check-prefix=SEG
+# RUN: llvm-objdump -s --section=__probes --section=__probe_descs \
+# RUN:    %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes | FileCheck %s --check-prefix=DATA
+
+# SEG:      Name: __probes
+# SEG-NEXT: Segment: __LLVM
+# SEG:      Name: __probe_descs
+# SEG-NEXT: Segment: __LLVM
+
+# SIZE: __probes      00000040
+# SIZE: __probe_descs 00000024
+
+# DATA:      Contents of section __LLVM,__probes:
+# DATA-NEXT: {{[0-9a-f]+}} 0cc175b9 c0f1b6a8 05000020 5c855e09
+# DATA-NEXT: {{[0-9a-f]+}} 4bdf284e 01800c02 80140380 0c048008
+# DATA-NEXT: {{[0-9a-f]+}} 92eb5ffe e6ae2fec 05000020 c716fb29
+# DATA-NEXT: {{[0-9a-f]+}} 298ad96a 01800c02 80140380 0c048008
+# DATA:      Contents of section __LLVM,__probe_descs:
+# DATA-NEXT: {{[0-9a-f]+}} 0cc175b9 c0f1b6a8 94da52e8 10000000
+# DATA-NEXT: {{[0-9a-f]+}} 016192eb 5ffee6ae 2fec94da 52e81000
+# DATA-NEXT: {{[0-9a-f]+}} 00000162
+
+#--- debug.map
+---
+triple:          'arm64-apple-darwin'
+objects:
+  - filename: a.o
+    symbols:         []
+  - filename: b.o
+    symbols:         []
+...
+
+#--- a.yaml
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x100000C
+  cpusubtype:      0x0
+  filetype:        0x1
+  ncmds:           4
+  sizeofcmds:      520
+  flags:           0x2000
+  reserved:        0x0
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         392
+    segname:         ''
+    vmaddr:          0
+    vmsize:          144
+    fileoff:         552
+    filesize:        144
+    maxprot:         7
+    initprot:        7
+    nsects:          4
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0
+        size:            60
+        offset:          0x228
+        align:           2
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         FF4300D1E00B00B9E80B40B9C800003401000014E80B40B908050011E80F00B90400001408008052E80F00B901000014E00F40B9FF430091C0035FD6
+      - sectname:        __probe_descs
+        segname:         __LLVM
+        addr:            0x3C
+        size:            18
+        offset:          0x264
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x12000000
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         0CC175B9C0F1B6A894DA52E8100000000161
+      - sectname:        __compact_unwind
+        segname:         __LD
+        addr:            0x50
+        size:            32
+        offset:          0x278
+        align:           3
+        reloff:          0x2B8
+        nreloc:          1
+        flags:           0x2000000
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         00000000000000003C0000000010000200000000000000000000000000000000
+        relocations:
+          - address:         0x0
+            symbolnum:       1
+            pcrel:           false
+            length:          3
+            extern:          false
+            type:            0
+            scattered:       false
+            value:           0
+      - sectname:        __probes
+        segname:         __LLVM
+        addr:            0x70
+        size:            32
+        offset:          0x298
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x12000000
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         0CC175B9C0F1B6A8050000205C855E094BDF284E01800C02801403800C048008
+  - cmd:             LC_BUILD_VERSION
+    cmdsize:         24
+    platform:        1
+    minos:           1703936
+    sdk:             1704960
+    ntools:          0
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          704
+    nsyms:           5
+    stroff:          784
+    strsize:         32
+  - cmd:             LC_DYSYMTAB
+    cmdsize:         80
+    ilocalsym:       0
+    nlocalsym:       4
+    iextdefsym:      4
+    nextdefsym:      1
+    iundefsym:       5
+    nundefsym:       0
+    tocoff:          0
+    ntoc:            0
+    modtaboff:       0
+    nmodtab:         0
+    extrefsymoff:    0
+    nextrefsyms:     0
+    indirectsymoff:  0
+    nindirectsyms:   0
+    extreloff:       0
+    nextrel:         0
+    locreloff:       0
+    nlocrel:         0
+LinkEditData:
+  NameList:
+    - n_strx:          22
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         0
+    - n_strx:          16
+      n_type:          0xE
+      n_sect:          2
+      n_desc:          0
+      n_value:         60
+    - n_strx:          10
+      n_type:          0xE
+      n_sect:          3
+      n_desc:          0
+      n_value:         80
+    - n_strx:          4
+      n_type:          0xE
+      n_sect:          4
+      n_desc:          0
+      n_value:         112
+    - n_strx:          1
+      n_type:          0xF
+      n_sect:          1
+      n_desc:          0
+      n_value:         0
+  StringTable:
+    - ''
+    - _a
+    - ltmp3
+    - ltmp2
+    - ltmp1
+    - ltmp0
+    - ''
+    - ''
+    - ''
+    - ''
+...
+
+#--- b.yaml
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x100000C
+  cpusubtype:      0x0
+  filetype:        0x1
+  ncmds:           4
+  sizeofcmds:      520
+  flags:           0x2000
+  reserved:        0x0
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         392
+    segname:         ''
+    vmaddr:          0
+    vmsize:          144
+    fileoff:         552
+    filesize:        144
+    maxprot:         7
+    initprot:        7
+    nsects:          4
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0
+        size:            60
+        offset:          0x228
+        align:           2
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         FF4300D1E00B00B9E80B40B9C800003401000014E80B40B908791F53E80F00B90400001428008052E80F00B901000014E00F40B9FF430091C0035FD6
+      - sectname:        __probe_descs
+        segname:         __LLVM
+        addr:            0x3C
+        size:            18
+        offset:          0x264
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x12000000
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         92EB5FFEE6AE2FEC94DA52E8100000000162
+      - sectname:        __compact_unwind
+        segname:         __LD
+        addr:            0x50
+        size:            32
+        offset:          0x278
+        align:           3
+        reloff:          0x2B8
+        nreloc:          1
+        flags:           0x2000000
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         00000000000000003C0000000010000200000000000000000000000000000000
+        relocations:
+          - address:         0x0
+            symbolnum:       1
+            pcrel:           false
+            length:          3
+            extern:          false
+            type:            0
+            scattered:       false
+            value:           0
+      - sectname:        __probes
+        segname:         __LLVM
+        addr:            0x70
+        size:            32
+        offset:          0x298
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x12000000
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0
+        content:         92EB5FFEE6AE2FEC05000020C716FB29298AD96A01800C02801403800C048008
+  - cmd:             LC_BUILD_VERSION
+    cmdsize:         24
+    platform:        1
+    minos:           1703936
+    sdk:             1704960
+    ntools:          0
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          704
+    nsyms:           5
+    stroff:          784
+    strsize:         32
+  - cmd:             LC_DYSYMTAB
+    cmdsize:         80
+    ilocalsym:       0
+    nlocalsym:       4
+    iextdefsym:      4
+    nextdefsym:      1
+    iundefsym:       5
+    nundefsym:       0
+    tocoff:          0
+    ntoc:            0
+    modtaboff:       0
+    nmodtab:         0
+    extrefsymoff:    0
+    nextrefsyms:     0
+    indirectsymoff:  0
+    nindirectsyms:   0
+    extreloff:       0
+    nextrel:         0
+    locreloff:       0
+    nlocrel:         0
+LinkEditData:
+  NameList:
+    - n_strx:          22
+      n_type:          0xE
+      n_sect:          1
+      n_desc:          0
+      n_value:         0
+    - n_strx:          16
+      n_type:          0xE
+      n_sect:          2
+      n_desc:          0
+      n_value:         60
+    - n_strx:          10
+      n_type:          0xE
+      n_sect:          3
+      n_desc:          0
+      n_value:         80
+    - n_strx:          4
+      n_type:          0xE
+      n_sect:          4
+      n_desc:          0
+      n_value:         112
+    - n_strx:          1
+      n_type:          0xF
+      n_sect:          1
+      n_desc:          0
+      n_value:         0
+  StringTable:
+    - ''
+    - _b
+    - ltmp3
+    - ltmp2
+    - ltmp1
+    - ltmp0
+    - ''
+    - ''
+    - ''
+    - ''
+...

--- a/llvm/test/tools/dsymutil/AArch64/pseudo-probe.test
+++ b/llvm/test/tools/dsymutil/AArch64/pseudo-probe.test
@@ -1,5 +1,4 @@
 # REQUIRES: aarch64-registered-target
-# REQUIRES: host-byteorder-little-endian
 
 # RUN: rm -rf %t
 # RUN: split-file %s %t
@@ -8,38 +7,27 @@
 # RUN: yaml2obj %t/b.yaml -o %t/b.o
 
 # RUN: dsymutil --linker classic -y %t/debug.map -oso-prepend-path=%t -o %t/classic.dSYM
-# RUN: llvm-objdump --section-headers %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes \
-# RUN:    | FileCheck %s --check-prefix=SIZE
-# RUN: llvm-readobj --sections %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes \
-# RUN:    | FileCheck %s --check-prefix=SEG
-# RUN: llvm-objdump -s --section=__probes --section=__probe_descs \
-# RUN:    %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes | FileCheck %s --check-prefix=DATA
+# RUN: od -t x1 %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes | FileCheck %s --check-prefix=PROBES
+# RUN: od -t x1 %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probe_descs | FileCheck %s --check-prefix=DESCS
+# RUN: wc -c < %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probes | FileCheck %s --check-prefix=PROBES-SIZE
+# RUN: wc -c < %t/classic.dSYM/Contents/Resources/Profiling/pseudo_probe_descs | FileCheck %s --check-prefix=DESCS-SIZE
 
 # RUN: dsymutil --linker parallel -y %t/debug.map -oso-prepend-path=%t -o %t/parallel.dSYM
-# RUN: llvm-objdump --section-headers %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes \
-# RUN:    | FileCheck %s --check-prefix=SIZE
-# RUN: llvm-readobj --sections %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes \
-# RUN:    | FileCheck %s --check-prefix=SEG
-# RUN: llvm-objdump -s --section=__probes --section=__probe_descs \
-# RUN:    %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes | FileCheck %s --check-prefix=DATA
+# RUN: od -t x1 %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes | FileCheck %s --check-prefix=PROBES
+# RUN: od -t x1 %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probe_descs | FileCheck %s --check-prefix=DESCS
+# RUN: wc -c < %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probes | FileCheck %s --check-prefix=PROBES-SIZE
+# RUN: wc -c < %t/parallel.dSYM/Contents/Resources/Profiling/pseudo_probe_descs | FileCheck %s --check-prefix=DESCS-SIZE
 
-# SEG:      Name: __probes
-# SEG-NEXT: Segment: __LLVM
-# SEG:      Name: __probe_descs
-# SEG-NEXT: Segment: __LLVM
+# PROBES:      0000000 0c c1 75 b9 c0 f1 b6 a8 05 00 00 20 5c 85 5e 09
+# PROBES-NEXT: 0000020 4b df 28 4e 01 80 0c 02 80 14 03 80 0c 04 80 08
+# PROBES-NEXT: 0000040 92 eb 5f fe e6 ae 2f ec 05 00 00 20 c7 16 fb 29
+# PROBES-NEXT: 0000060 29 8a d9 6a 01 80 0c 02 80 14 03 80 0c 04 80 08
+# PROBES-SIZE: 64
 
-# SIZE: __probes      00000040
-# SIZE: __probe_descs 00000024
-
-# DATA:      Contents of section __LLVM,__probes:
-# DATA-NEXT: {{[0-9a-f]+}} 0cc175b9 c0f1b6a8 05000020 5c855e09
-# DATA-NEXT: {{[0-9a-f]+}} 4bdf284e 01800c02 80140380 0c048008
-# DATA-NEXT: {{[0-9a-f]+}} 92eb5ffe e6ae2fec 05000020 c716fb29
-# DATA-NEXT: {{[0-9a-f]+}} 298ad96a 01800c02 80140380 0c048008
-# DATA:      Contents of section __LLVM,__probe_descs:
-# DATA-NEXT: {{[0-9a-f]+}} 0cc175b9 c0f1b6a8 94da52e8 10000000
-# DATA-NEXT: {{[0-9a-f]+}} 016192eb 5ffee6ae 2fec94da 52e81000
-# DATA-NEXT: {{[0-9a-f]+}} 00000162
+# DESCS:      0000000 0c c1 75 b9 c0 f1 b6 a8 94 da 52 e8 10 00 00 00
+# DESCS-NEXT: 0000020 01 61 92 eb 5f fe e6 ae 2f ec 94 da 52 e8 10 00
+# DESCS-NEXT: 0000040 00 00 01 62
+# DESCS-SIZE: 36
 
 #--- debug.map
 ---

--- a/llvm/tools/dsymutil/CMakeLists.txt
+++ b/llvm/tools/dsymutil/CMakeLists.txt
@@ -33,6 +33,7 @@ add_llvm_tool(dsymutil
   DwarfLinkerForBinary.cpp
   MachODebugMapParser.cpp
   MachOUtils.cpp
+  PseudoProbeLinker.cpp
   Reproducer.cpp
   RelocationMap.cpp
   SwiftModule.cpp

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -10,6 +10,7 @@
 #include "BinaryHolder.h"
 #include "DebugMap.h"
 #include "MachOUtils.h"
+#include "PseudoProbeLinker.h"
 #include "SwiftModule.h"
 #include "dsymutil.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -264,7 +265,7 @@ static Error emitRemarks(const LinkOptions &Options, StringRef BinaryPath,
 
 ErrorOr<std::unique_ptr<DWARFFile>> DwarfLinkerForBinary::loadObject(
     const DebugMapObject &Obj, const DebugMap &DebugMap,
-    remarks::RemarkLinker &RL,
+    remarks::RemarkLinker &RL, PseudoProbeLinker &PL,
     std::shared_ptr<DwarfLinkerForBinaryRelocationMap> DLBRM) {
   auto ErrorOrObj = loadObject(Obj, DebugMap.getTriple());
   std::unique_ptr<DWARFFile> Res;
@@ -288,6 +289,8 @@ ErrorOr<std::unique_ptr<DWARFFile>> DwarfLinkerForBinary::loadObject(
         Obj.getObjectFilename(), std::move(Context),
         std::make_unique<AddressManager>(*this, *ErrorOrObj, Obj, DLBRM),
         [&](StringRef FileName) { BinHolder.eraseObjectEntry(FileName); });
+
+    PL.collect(*ErrorOrObj);
 
     Error E = RL.link(*ErrorOrObj);
     // FIXME: Remark parsing errors are not propagated to the user.
@@ -729,6 +732,7 @@ bool DwarfLinkerForBinary::linkImpl(
       GeneralLinker->setOutputDWARFEmitter(Streamer.get());
   }
 
+  PseudoProbeLinker PL(Options);
   remarks::RemarkLinker RL;
   if (!Options.RemarksPrependPath.empty())
     RL.setExternalFilePrependPath(Options.RemarksPrependPath);
@@ -759,7 +763,7 @@ bool DwarfLinkerForBinary::linkImpl(
 
     auto DLBRelocMap = std::make_shared<DwarfLinkerForBinaryRelocationMap>();
     if (ErrorOr<std::unique_ptr<DWARFFile>> ErrorOrObj =
-            loadObject(Obj, DebugMap, RL, DLBRelocMap)) {
+            loadObject(Obj, DebugMap, RL, PL, DLBRelocMap)) {
       ObjectsForLinking.emplace_back(std::move(*ErrorOrObj), DLBRelocMap);
       return *ObjectsForLinking.back().Object;
     } else {
@@ -944,7 +948,7 @@ bool DwarfLinkerForBinary::linkImpl(
 
     auto DLBRelocMap = std::make_shared<DwarfLinkerForBinaryRelocationMap>();
     if (ErrorOr<std::unique_ptr<DWARFFile>> ErrorOrObj =
-            loadObject(*Obj, Map, RL, DLBRelocMap)) {
+            loadObject(*Obj, Map, RL, PL, DLBRelocMap)) {
       ObjectsForLinking.emplace_back(std::move(*ErrorOrObj), DLBRelocMap);
       GeneralLinker->addObjectFile(*ObjectsForLinking.back().Object, Loader,
                                    OnCUDieLoaded);
@@ -973,6 +977,9 @@ bool DwarfLinkerForBinary::linkImpl(
 
   StringRef ArchName = Map.getTriple().getArchName();
   if (Error E = emitRemarks(Options, Map.getBinaryPath(), ArchName, RL))
+    return error(toString(std::move(E)));
+
+  if (Error E = PL.emit(Map.getTriple()))
     return error(toString(std::move(E)));
 
   if (Options.NoOutput)

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -290,7 +290,8 @@ ErrorOr<std::unique_ptr<DWARFFile>> DwarfLinkerForBinary::loadObject(
         std::make_unique<AddressManager>(*this, *ErrorOrObj, Obj, DLBRM),
         [&](StringRef FileName) { BinHolder.eraseObjectEntry(FileName); });
 
-    PL.collect(*ErrorOrObj);
+    if (Error E = PL.collect(*ErrorOrObj))
+      reportWarning(toString(std::move(E)), Obj.getObjectFilename());
 
     Error E = RL.link(*ErrorOrObj);
     // FIXME: Remark parsing errors are not propagated to the user.

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.h
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.h
@@ -26,6 +26,8 @@ using namespace dwarf_linker;
 
 namespace dsymutil {
 
+class PseudoProbeLinker;
+
 /// DwarfLinkerForBinaryRelocationMap contains the logic to handle the
 /// relocations and to store them inside an associated RelocationMap.
 class DwarfLinkerForBinaryRelocationMap {
@@ -264,7 +266,7 @@ private:
                                                  const Triple &triple);
   ErrorOr<std::unique_ptr<dwarf_linker::DWARFFile>>
   loadObject(const DebugMapObject &Obj, const DebugMap &DebugMap,
-             remarks::RemarkLinker &RL,
+             remarks::RemarkLinker &RL, PseudoProbeLinker &PL,
              std::shared_ptr<DwarfLinkerForBinaryRelocationMap> DLBRM);
 
   void collectRelocationsToApplyToSwiftReflectionSections(

--- a/llvm/tools/dsymutil/PseudoProbeLinker.cpp
+++ b/llvm/tools/dsymutil/PseudoProbeLinker.cpp
@@ -1,4 +1,4 @@
-//===- tools/dsymutil/PseudoProbeLinker.cpp -------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,151 +7,18 @@
 //===----------------------------------------------------------------------===//
 
 #include "PseudoProbeLinker.h"
-#include "BinaryHolder.h"
-#include "DebugMap.h"
 #include "LinkUtils.h"
 #include "llvm/ADT/SmallString.h"
-#include "llvm/MC/MCAsmBackend.h"
-#include "llvm/MC/MCAsmInfo.h"
-#include "llvm/MC/MCCodeEmitter.h"
-#include "llvm/MC/MCContext.h"
-#include "llvm/MC/MCInstrInfo.h"
-#include "llvm/MC/MCObjectFileInfo.h"
-#include "llvm/MC/MCObjectWriter.h"
-#include "llvm/MC/MCRegisterInfo.h"
-#include "llvm/MC/MCSectionMachO.h"
-#include "llvm/MC/MCStreamer.h"
-#include "llvm/MC/MCSubtargetInfo.h"
-#include "llvm/MC/MCTargetOptions.h"
-#include "llvm/MC/SectionKind.h"
-#include "llvm/MC/TargetRegistry.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Object/MachO.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
 
 namespace llvm {
 namespace dsymutil {
-
-Error PseudoProbeLinker::emit(const Triple &TheTriple) const {
-  // Don't create the directory and the file if there is nothing to write.
-  if (empty())
-    return Error::success();
-
-  // Without a resource directory (e.g. --flat) there is no dSYM bundle to place
-  // the content. Nothing to do in this case.
-  if (!Options.ResourceDir)
-    return Error::success();
-
-  SmallString<128> Path;
-  sys::path::append(Path, *Options.ResourceDir, "Profiling");
-  if (std::error_code EC = sys::fs::create_directories(Path.str(), true,
-                                                       sys::fs::perms::all_all))
-    return errorCodeToError(EC);
-
-  // For fat binaries, also append a dash and the architecture name.
-  sys::path::append(Path, "pseudo_probes");
-  if (Options.NumDebugMaps > 1) {
-    Path += '-';
-    Path += TheTriple.getArchName();
-  }
-
-  // Build the minimal MC machinery needed to write a MachO object holding the
-  // probe sections. All targets and their MC layers are registered by
-  // dsymutil_main.
-  std::string TripleName = TheTriple.getTriple();
-  std::string ErrorStr;
-  const Target *TheTarget = TargetRegistry::lookupTarget(TheTriple, ErrorStr);
-  if (!TheTarget)
-    return createStringError(inconvertibleErrorCode(), ErrorStr);
-
-  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TheTriple));
-  if (!MRI)
-    return createStringError(inconvertibleErrorCode(),
-                             "no register info for target " + TripleName);
-
-  MCTargetOptions MCOptions;
-  std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
-  if (!MAI)
-    return createStringError(inconvertibleErrorCode(),
-                             "no asm info for target " + TripleName);
-
-  std::unique_ptr<MCSubtargetInfo> MSTI(
-      TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
-  if (!MSTI)
-    return createStringError(inconvertibleErrorCode(),
-                             "no subtarget info for target " + TripleName);
-
-  MCContext Ctx(TheTriple, *MAI, *MRI, *MSTI);
-  std::unique_ptr<MCObjectFileInfo> MOFI(
-      TheTarget->createMCObjectFileInfo(Ctx, /*PIC=*/false));
-  Ctx.setObjectFileInfo(MOFI.get());
-
-  std::unique_ptr<MCInstrInfo> MII(TheTarget->createMCInstrInfo());
-  std::unique_ptr<MCCodeEmitter> MCE(TheTarget->createMCCodeEmitter(*MII, Ctx));
-  std::unique_ptr<MCAsmBackend> MAB(
-      TheTarget->createMCAsmBackend(*MSTI, *MRI, MCOptions));
-  if (!MCE || !MAB)
-    return createStringError(inconvertibleErrorCode(),
-                             "no code emitter/asm backend for target " +
-                                 TripleName);
-
-  std::error_code EC;
-  raw_fd_ostream OS(Options.NoOutput ? "-" : Path.str(), EC, sys::fs::OF_None);
-  if (EC)
-    return errorCodeToError(EC);
-
-  std::unique_ptr<MCObjectWriter> OW = MAB->createObjectWriter(OS);
-  std::unique_ptr<MCStreamer> MS(TheTarget->createMCObjectStreamer(
-      TheTriple, Ctx, std::move(MAB), std::move(OW), std::move(MCE), *MSTI));
-  if (!MS)
-    return createStringError(inconvertibleErrorCode(),
-                             "no object streamer for target " + TripleName);
-
-  auto emitSection = [&](StringRef Name, StringRef Data) {
-    if (Data.empty())
-      return;
-    MCSectionMachO *Sec = Ctx.getMachOSection(
-        "__LLVM", Name, /*TypeAndAttributes=*/0, SectionKind::getMetadata());
-    MS->switchSection(Sec);
-    MS->emitBytes(Data);
-  };
-  emitSection("__probes", getProbes());
-  emitSection("__probe_descs", getProbeDescs());
-  MS->finish();
-
-  return Error::success();
-}
-
-bool PseudoProbeLinker::link(const DebugMap &Map) {
-  for (const auto &Obj : Map.objects()) {
-    // Load the object. Any load error is reported by the DWARF link; skip
-    // silently here to avoid duplicate diagnostics.
-    auto ObjectEntry =
-        BinHolder.getObjectEntry(Obj->getObjectFilename(), Obj->getTimestamp());
-    if (!ObjectEntry) {
-      consumeError(ObjectEntry.takeError());
-      continue;
-    }
-    auto Object = ObjectEntry->getObject(Map.getTriple());
-    if (!Object) {
-      consumeError(Object.takeError());
-      continue;
-    }
-
-    collect(*Object);
-  }
-
-  if (Error E = emit(Map.getTriple())) {
-    handleAllErrors(std::move(E), [](const ErrorInfoBase &EI) {
-      WithColor::error() << EI.message() << '\n';
-    });
-    return false;
-  }
-  return true;
-}
 
 void PseudoProbeLinker::collect(const object::ObjectFile &Obj) {
   const auto *MO = dyn_cast<object::MachOObjectFile>(&Obj);
@@ -172,6 +39,11 @@ void PseudoProbeLinker::collect(const object::ObjectFile &Obj) {
     else
       continue;
 
+    if (!Section.relocations().empty())
+      report_fatal_error(
+          Twine("unexpected relocations in pseudo-probe section ") + *NameOrErr,
+          /*GenCrashDiag=*/false);
+
     Expected<StringRef> ContentsOrErr = Section.getContents();
     if (!ContentsOrErr) {
       consumeError(ContentsOrErr.takeError());
@@ -180,5 +52,45 @@ void PseudoProbeLinker::collect(const object::ObjectFile &Obj) {
     *Dest += *ContentsOrErr;
   }
 }
+
+Error PseudoProbeLinker::emit(const Triple &TheTriple) const {
+  if (empty())
+    return Error::success();
+
+  if (!Options.ResourceDir || Options.NoOutput)
+    return Error::success();
+
+  SmallString<128> Path;
+  sys::path::append(Path, *Options.ResourceDir, "Profiling");
+  if (std::error_code EC = sys::fs::create_directories(Path.str(), true,
+                                                       sys::fs::perms::all_all))
+    return errorCodeToError(EC);
+
+  std::string Suffix;
+  if (Options.NumDebugMaps > 1)
+    Suffix = ("-" + TheTriple.getArchName()).str();
+
+  // write pseudo_probes metadata
+  Path.clear();
+  sys::path::append(Path, *Options.ResourceDir, "Profiling",
+                    "pseudo_probes" + Suffix);
+  std::error_code EC;
+  raw_fd_ostream ProbesOS(Path.str(), EC, sys::fs::OF_None);
+  if (EC)
+    return errorCodeToError(EC);
+  ProbesOS << getProbes();
+
+  // write pseudo_probe_descs metadata
+  Path.clear();
+  sys::path::append(Path, *Options.ResourceDir, "Profiling",
+                    "pseudo_probe_descs" + Suffix);
+  raw_fd_ostream DescsOS(Path.str(), EC, sys::fs::OF_None);
+  if (EC)
+    return errorCodeToError(EC);
+  DescsOS << getProbeDescs();
+
+  return Error::success();
+}
+
 } // end namespace dsymutil
 } // end namespace llvm

--- a/llvm/tools/dsymutil/PseudoProbeLinker.cpp
+++ b/llvm/tools/dsymutil/PseudoProbeLinker.cpp
@@ -1,0 +1,184 @@
+//===- tools/dsymutil/PseudoProbeLinker.cpp -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PseudoProbeLinker.h"
+#include "BinaryHolder.h"
+#include "DebugMap.h"
+#include "LinkUtils.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCObjectFileInfo.h"
+#include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCSectionMachO.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/MCTargetOptions.h"
+#include "llvm/MC/SectionKind.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/WithColor.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/TargetParser/Triple.h"
+
+namespace llvm {
+namespace dsymutil {
+
+Error PseudoProbeLinker::emit(const Triple &TheTriple) const {
+  // Don't create the directory and the file if there is nothing to write.
+  if (empty())
+    return Error::success();
+
+  // Without a resource directory (e.g. --flat) there is no dSYM bundle to place
+  // the content. Nothing to do in this case.
+  if (!Options.ResourceDir)
+    return Error::success();
+
+  SmallString<128> Path;
+  sys::path::append(Path, *Options.ResourceDir, "Profiling");
+  if (std::error_code EC = sys::fs::create_directories(Path.str(), true,
+                                                       sys::fs::perms::all_all))
+    return errorCodeToError(EC);
+
+  // For fat binaries, also append a dash and the architecture name.
+  sys::path::append(Path, "pseudo_probes");
+  if (Options.NumDebugMaps > 1) {
+    Path += '-';
+    Path += TheTriple.getArchName();
+  }
+
+  // Build the minimal MC machinery needed to write a MachO object holding the
+  // probe sections. All targets and their MC layers are registered by
+  // dsymutil_main.
+  std::string TripleName = TheTriple.getTriple();
+  std::string ErrorStr;
+  const Target *TheTarget = TargetRegistry::lookupTarget(TheTriple, ErrorStr);
+  if (!TheTarget)
+    return createStringError(inconvertibleErrorCode(), ErrorStr);
+
+  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TheTriple));
+  if (!MRI)
+    return createStringError(inconvertibleErrorCode(),
+                             "no register info for target " + TripleName);
+
+  MCTargetOptions MCOptions;
+  std::unique_ptr<MCAsmInfo> MAI(
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
+  if (!MAI)
+    return createStringError(inconvertibleErrorCode(),
+                             "no asm info for target " + TripleName);
+
+  std::unique_ptr<MCSubtargetInfo> MSTI(
+      TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
+  if (!MSTI)
+    return createStringError(inconvertibleErrorCode(),
+                             "no subtarget info for target " + TripleName);
+
+  MCContext Ctx(TheTriple, *MAI, *MRI, *MSTI);
+  std::unique_ptr<MCObjectFileInfo> MOFI(
+      TheTarget->createMCObjectFileInfo(Ctx, /*PIC=*/false));
+  Ctx.setObjectFileInfo(MOFI.get());
+
+  std::unique_ptr<MCInstrInfo> MII(TheTarget->createMCInstrInfo());
+  std::unique_ptr<MCCodeEmitter> MCE(TheTarget->createMCCodeEmitter(*MII, Ctx));
+  std::unique_ptr<MCAsmBackend> MAB(
+      TheTarget->createMCAsmBackend(*MSTI, *MRI, MCOptions));
+  if (!MCE || !MAB)
+    return createStringError(inconvertibleErrorCode(),
+                             "no code emitter/asm backend for target " +
+                                 TripleName);
+
+  std::error_code EC;
+  raw_fd_ostream OS(Options.NoOutput ? "-" : Path.str(), EC, sys::fs::OF_None);
+  if (EC)
+    return errorCodeToError(EC);
+
+  std::unique_ptr<MCObjectWriter> OW = MAB->createObjectWriter(OS);
+  std::unique_ptr<MCStreamer> MS(TheTarget->createMCObjectStreamer(
+      TheTriple, Ctx, std::move(MAB), std::move(OW), std::move(MCE), *MSTI));
+  if (!MS)
+    return createStringError(inconvertibleErrorCode(),
+                             "no object streamer for target " + TripleName);
+
+  auto emitSection = [&](StringRef Name, StringRef Data) {
+    if (Data.empty())
+      return;
+    MCSectionMachO *Sec = Ctx.getMachOSection(
+        "__LLVM", Name, /*TypeAndAttributes=*/0, SectionKind::getMetadata());
+    MS->switchSection(Sec);
+    MS->emitBytes(Data);
+  };
+  emitSection("__probes", getProbes());
+  emitSection("__probe_descs", getProbeDescs());
+  MS->finish();
+
+  return Error::success();
+}
+
+bool PseudoProbeLinker::link(const DebugMap &Map) {
+  for (const auto &Obj : Map.objects()) {
+    // Load the object. Any load error is reported by the DWARF link; skip
+    // silently here to avoid duplicate diagnostics.
+    auto ObjectEntry =
+        BinHolder.getObjectEntry(Obj->getObjectFilename(), Obj->getTimestamp());
+    if (!ObjectEntry) {
+      consumeError(ObjectEntry.takeError());
+      continue;
+    }
+    auto Object = ObjectEntry->getObject(Map.getTriple());
+    if (!Object) {
+      consumeError(Object.takeError());
+      continue;
+    }
+
+    collect(*Object);
+  }
+
+  if (Error E = emit(Map.getTriple())) {
+    handleAllErrors(std::move(E), [](const ErrorInfoBase &EI) {
+      WithColor::error() << EI.message() << '\n';
+    });
+    return false;
+  }
+  return true;
+}
+
+void PseudoProbeLinker::collect(const object::ObjectFile &Obj) {
+  const auto *MO = dyn_cast<object::MachOObjectFile>(&Obj);
+  if (!MO)
+    return;
+
+  for (const object::SectionRef &Section : MO->sections()) {
+    Expected<StringRef> NameOrErr = Section.getName();
+    if (!NameOrErr) {
+      consumeError(NameOrErr.takeError());
+      continue;
+    }
+    std::string *Dest = nullptr;
+    if (*NameOrErr == "__probes")
+      Dest = &Probes;
+    else if (*NameOrErr == "__probe_descs")
+      Dest = &ProbeDescs;
+    else
+      continue;
+
+    Expected<StringRef> ContentsOrErr = Section.getContents();
+    if (!ContentsOrErr) {
+      consumeError(ContentsOrErr.takeError());
+      continue;
+    }
+    *Dest += *ContentsOrErr;
+  }
+}
+} // end namespace dsymutil
+} // end namespace llvm

--- a/llvm/tools/dsymutil/PseudoProbeLinker.cpp
+++ b/llvm/tools/dsymutil/PseudoProbeLinker.cpp
@@ -9,48 +9,48 @@
 #include "PseudoProbeLinker.h"
 #include "LinkUtils.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Object/MachO.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
+#include <cassert>
 
 namespace llvm {
 namespace dsymutil {
 
-void PseudoProbeLinker::collect(const object::ObjectFile &Obj) {
+Error PseudoProbeLinker::collect(const object::ObjectFile &Obj) {
   const auto *MO = dyn_cast<object::MachOObjectFile>(&Obj);
   if (!MO)
-    return;
+    return Error::success();
 
   for (const object::SectionRef &Section : MO->sections()) {
     Expected<StringRef> NameOrErr = Section.getName();
-    if (!NameOrErr) {
-      consumeError(NameOrErr.takeError());
-      continue;
-    }
-    std::string *Dest = nullptr;
-    if (*NameOrErr == "__probes")
-      Dest = &Probes;
-    else if (*NameOrErr == "__probe_descs")
-      Dest = &ProbeDescs;
-    else
+    if (!NameOrErr)
+      return NameOrErr.takeError();
+
+    std::string *Dest = StringSwitch<std::string *>(*NameOrErr)
+                            .Case("__probes", &Probes)
+                            .Case("__probe_descs", &ProbeDescs)
+                            .Default(nullptr);
+    if (!Dest)
       continue;
 
+    assert(Section.relocations().empty() &&
+           "pseudo-probe section unexpectedly carries relocations");
     if (!Section.relocations().empty())
-      report_fatal_error(
-          Twine("unexpected relocations in pseudo-probe section ") + *NameOrErr,
-          /*GenCrashDiag=*/false);
+      return createStringError(
+          inconvertibleErrorCode(),
+          "unexpected relocations in pseudo-probe section " + *NameOrErr);
 
     Expected<StringRef> ContentsOrErr = Section.getContents();
-    if (!ContentsOrErr) {
-      consumeError(ContentsOrErr.takeError());
-      continue;
-    }
+    if (!ContentsOrErr)
+      return ContentsOrErr.takeError();
     *Dest += *ContentsOrErr;
   }
+  return Error::success();
 }
 
 Error PseudoProbeLinker::emit(const Triple &TheTriple) const {
@@ -70,7 +70,7 @@ Error PseudoProbeLinker::emit(const Triple &TheTriple) const {
   if (Options.NumDebugMaps > 1)
     Suffix = ("-" + TheTriple.getArchName()).str();
 
-  // write pseudo_probes metadata
+  // Write pseudo_probes metadata.
   Path.clear();
   sys::path::append(Path, *Options.ResourceDir, "Profiling",
                     "pseudo_probes" + Suffix);
@@ -80,7 +80,7 @@ Error PseudoProbeLinker::emit(const Triple &TheTriple) const {
     return errorCodeToError(EC);
   ProbesOS << getProbes();
 
-  // write pseudo_probe_descs metadata
+  // Write pseudo_probe_descs metadata.
   Path.clear();
   sys::path::append(Path, *Options.ResourceDir, "Profiling",
                     "pseudo_probe_descs" + Suffix);

--- a/llvm/tools/dsymutil/PseudoProbeLinker.h
+++ b/llvm/tools/dsymutil/PseudoProbeLinker.h
@@ -1,4 +1,4 @@
-//===- tools/dsymutil/PseudoProbeLinker.h ---------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -19,30 +19,17 @@ namespace llvm {
 class Triple;
 namespace dsymutil {
 
-class BinaryHolder;
-class DebugMap;
-
-/// Collect and merge the __probes and __probe_descs sections from the debug map
-/// object into the companion Contents/Resources/Profiling/pseudo_probes-<arch>.
-/// Note: the probe sections contain no relocations.
 class PseudoProbeLinker {
-  BinaryHolder &BinHolder;
   const LinkOptions &Options;
   std::string Probes;
   std::string ProbeDescs;
 
-  Error emit(const Triple &TheTriple) const;
-
 public:
-  PseudoProbeLinker(BinaryHolder &BinHolder, const LinkOptions &Options)
-      : BinHolder(BinHolder), Options(Options) {}
+  PseudoProbeLinker(const LinkOptions &Options) : Options(Options) {}
 
-  /// Emit the collected probe sections as a single MachO object sidecar for the
-  /// \p TheTriple architecture. No-op if nothing was collected.
-  bool link(const DebugMap &Map);
-
-  /// Append the pseudo-probe sections found in \p Obj, if any.
   void collect(const object::ObjectFile &Obj);
+
+  Error emit(const Triple &TheTriple) const;
 
   bool empty() const { return Probes.empty() && ProbeDescs.empty(); }
   StringRef getProbes() const { return Probes; }

--- a/llvm/tools/dsymutil/PseudoProbeLinker.h
+++ b/llvm/tools/dsymutil/PseudoProbeLinker.h
@@ -1,0 +1,55 @@
+//===- tools/dsymutil/PseudoProbeLinker.h ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TOOLS_DSYMUTIL_PSEUDOPROBELINKER_H
+#define LLVM_TOOLS_DSYMUTIL_PSEUDOPROBELINKER_H
+
+#include "LinkUtils.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/Error.h"
+#include <string>
+
+namespace llvm {
+class Triple;
+namespace dsymutil {
+
+class BinaryHolder;
+class DebugMap;
+
+/// Collect and merge the __probes and __probe_descs sections from the debug map
+/// object into the companion Contents/Resources/Profiling/pseudo_probes-<arch>.
+/// Note: the probe sections contain no relocations.
+class PseudoProbeLinker {
+  BinaryHolder &BinHolder;
+  const LinkOptions &Options;
+  std::string Probes;
+  std::string ProbeDescs;
+
+  Error emit(const Triple &TheTriple) const;
+
+public:
+  PseudoProbeLinker(BinaryHolder &BinHolder, const LinkOptions &Options)
+      : BinHolder(BinHolder), Options(Options) {}
+
+  /// Emit the collected probe sections as a single MachO object sidecar for the
+  /// \p TheTriple architecture. No-op if nothing was collected.
+  bool link(const DebugMap &Map);
+
+  /// Append the pseudo-probe sections found in \p Obj, if any.
+  void collect(const object::ObjectFile &Obj);
+
+  bool empty() const { return Probes.empty() && ProbeDescs.empty(); }
+  StringRef getProbes() const { return Probes; }
+  StringRef getProbeDescs() const { return ProbeDescs; }
+};
+
+} // end namespace dsymutil
+} // end namespace llvm
+
+#endif // LLVM_TOOLS_DSYMUTIL_PSEUDOPROBELINKER_H

--- a/llvm/tools/dsymutil/PseudoProbeLinker.h
+++ b/llvm/tools/dsymutil/PseudoProbeLinker.h
@@ -19,6 +19,9 @@ namespace llvm {
 class Triple;
 namespace dsymutil {
 
+/// The PseudoProbeLinker collects and concatenates pseudo probe sections
+/// __probes and __probe_descs from the debug map objects and writes them as
+/// binary blobs into the .dSYM bundle.
 class PseudoProbeLinker {
   const LinkOptions &Options;
   std::string Probes;
@@ -27,7 +30,7 @@ class PseudoProbeLinker {
 public:
   PseudoProbeLinker(const LinkOptions &Options) : Options(Options) {}
 
-  void collect(const object::ObjectFile &Obj);
+  Error collect(const object::ObjectFile &Obj);
 
   Error emit(const Triple &TheTriple) const;
 

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -17,6 +17,7 @@
 #include "DwarfLinkerForBinary.h"
 #include "LinkUtils.h"
 #include "MachOUtils.h"
+#include "PseudoProbeLinker.h"
 #include "Reproducer.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
@@ -948,6 +949,10 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
           DwarfLinkerForBinary Linker(*Stream, BinHolder, Options.LinkOpts,
                                       ErrorHandlerMutex, &ThreadPool);
           AllOK.fetch_and(Linker.link(*Map));
+
+          PseudoProbeLinker ProbeLinker(BinHolder, Options.LinkOpts);
+          AllOK.fetch_and(ProbeLinker.link(*Map));
+
           Stream->flush();
           if (flagIsSet(Options.Verify, DWARFVerify::Output) ||
               (flagIsSet(Options.Verify, DWARFVerify::OutputOnValidInput) &&

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -17,7 +17,6 @@
 #include "DwarfLinkerForBinary.h"
 #include "LinkUtils.h"
 #include "MachOUtils.h"
-#include "PseudoProbeLinker.h"
 #include "Reproducer.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
@@ -949,10 +948,6 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
           DwarfLinkerForBinary Linker(*Stream, BinHolder, Options.LinkOpts,
                                       ErrorHandlerMutex, &ThreadPool);
           AllOK.fetch_and(Linker.link(*Map));
-
-          PseudoProbeLinker ProbeLinker(BinHolder, Options.LinkOpts);
-          AllOK.fetch_and(ProbeLinker.link(*Map));
-
           Stream->flush();
           if (flagIsSet(Options.Verify, DWARFVerify::Output) ||
               (flagIsSet(Options.Verify, DWARFVerify::OutputOnValidInput) &&


### PR DESCRIPTION
Introduce a new `PseudoProbeLinker` in `dsymutil` that collects `__probes/__probe_descs` sections from the debug map objects and merges the sections and places the probes metadata under `Contents/Resources/Profiling/{pseudo_probes[-<arch>],pseudo_probe_descs[-<arch>]}` respectively.

Dependent on the revert commit: https://github.com/llvm/llvm-project/pull/206789
