### PR TITLE
[lldb] Recover mangled symbol names from DWARF on WebAssembly

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileWasm.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileWasm.cpp
@@ -7,19 +7,59 @@
 //===----------------------------------------------------------------------===//
 
 #include "SymbolFileWasm.h"
+#include "Plugins/SymbolFile/DWARF/DWARFDebugInfo.h"
+#include "Plugins/SymbolFile/DWARF/DWARFUnit.h"
 #include "Plugins/SymbolFile/DWARF/LogChannelDWARF.h"
 #include "Utility/WasmVirtualRegisters.h"
+#include "lldb/Symbol/Symbol.h"
+#include "lldb/Symbol/Symtab.h"
 #include "lldb/Utility/LLDBLog.h"
 
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::plugin::dwarf;
+using namespace llvm::dwarf;
 
 SymbolFileWasm::SymbolFileWasm(ObjectFileSP objfile_sp,
                                SectionList *dwo_section_list)
     : SymbolFileDWARF(objfile_sp, dwo_section_list) {}
 
 SymbolFileWasm::~SymbolFileWasm() = default;
+
+void SymbolFileWasm::AddSymbols(Symtab &symtab) {
+  SymbolFileDWARF::AddSymbols(symtab);
+
+  // Copy each function's mangled name from its DWARF DW_AT_linkage_name onto
+  // the matching symbol. The match is by file address: a subprogram's
+  // DW_AT_low_pc resolves to the same code-section file address as its symbol.
+  DWARFDebugInfo &debug_info = DebugInfo();
+  const size_t num_units = debug_info.GetNumUnits();
+  for (size_t i = 0; i < num_units; ++i) {
+    DWARFUnit *unit = debug_info.GetUnitAtIndex(i);
+    if (!unit)
+      continue;
+
+    for (const DWARFDebugInfoEntry &entry : unit->dies()) {
+      if (entry.Tag() != DW_TAG_subprogram)
+        continue;
+
+      DWARFDIE die(unit, &entry);
+      const char *mangled =
+          die.GetMangledName(/*substitute_name_allowed=*/false);
+      if (!mangled)
+        continue;
+
+      const addr_t file_addr =
+          die.GetAttributeValueAsAddress(DW_AT_low_pc, LLDB_INVALID_ADDRESS);
+      if (file_addr == LLDB_INVALID_ADDRESS)
+        continue;
+
+      Symbol *symbol = symtab.FindSymbolAtFileAddress(file_addr);
+      if (symbol && !symbol->GetMangled().GetMangledName())
+        symbol->GetMangled().SetMangledName(ConstString(mangled));
+    }
+  }
+}
 
 lldb::offset_t
 SymbolFileWasm::GetVendorDWARFOpcodeSize(const DataExtractor &data,

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileWasm.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileWasm.h
@@ -19,6 +19,11 @@ public:
 
   ~SymbolFileWasm() override;
 
+  /// The Wasm "name" section stores only demangled names, so symbols parsed
+  /// from it have no mangled name to index C++ name variants or to match
+  /// lookups by mangled name. Recover the mangled names from the DWARF.
+  void AddSymbols(Symtab &symtab) override;
+
   lldb::offset_t GetVendorDWARFOpcodeSize(const DataExtractor &data,
                                           const lldb::offset_t data_offset,
                                           const uint8_t op) const override;

--- a/lldb/test/API/functionalities/breakpoint/cpp/TestCPPBreakpointLocations.py
+++ b/lldb/test/API/functionalities/breakpoint/cpp/TestCPPBreakpointLocations.py
@@ -138,6 +138,9 @@ class TestCPPBreakpointLocations(TestBase):
             self.verify_breakpoint_locations(target, bp_dict)
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
+    # Wasm emits a single merged destructor rather than the distinct D1/D2
+    # variants whose mangled names this test looks up by hand.
+    @skipIfWasm
     def test_destructors(self):
         self.build()
         exe = self.getBuildArtifact("a.out")


### PR DESCRIPTION
The Wasm "name" section stores only demangled names, so the symbols ObjectFileWasm builds from it have no mangled name. Without one, the symbol table indexes neither the mangled name nor the C++ base and method name variants derived from it, so looking up a symbol by mangled name fails and breakpoints set by a template or operator name find no locations.

Override SymbolFileWasm::AddSymbols to copy each function's mangled name from its DWARF DW_AT_linkage_name onto the matching symbol, matched by file address. This is confined to the Wasm symbol file, so other targets are unaffected.