### PR TITLE
[SystemZ] XPLINK64: emit narrow sign/zero-extend instructions for sub-i32 formal args

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.h
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.h
@@ -150,15 +150,18 @@ inline bool CC_XPLINK_Promote_i32(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
       // three are taken, this arg goes to an 8-byte stack slot.  The caller
       // stores a sign-extended i64 in that slot (value in bytes 6-7), so we
       // must use LocVT=i64 to load all 8 bytes correctly.
-      // We probe the 64-bit register aliases: AllocateReg marks all aliases,
-      // so if R1D is allocated (by a prior i64/ptr arg) R1L is also marked.
-      static const MCPhysReg GPR64s[] = {SystemZ::R1D, SystemZ::R2D,
-                                         SystemZ::R3D};
-      if (State.getFirstUnallocated(GPR64s) < 3) {
+      // Keep LocVT=i32 (GR32 live-in) only if a GR32 register is still free.
+      // XPLINK64 assigns i32 to R1L/R2L/R3L; if all three are taken this arg
+      // goes to an 8-byte stack slot where the value lives in bytes 6-7 (the
+      // caller stores a sign-extended i64).  In that case we must use
+      // LocVT=i64 so the 8-byte slot is loaded correctly.
+      static const MCPhysReg GPR32s[] = {SystemZ::R1L, SystemZ::R2L,
+                                         SystemZ::R3L};
+      if (State.getFirstUnallocated(GPR32s) < 3) {
         LocInfo = CCValAssign::AExt;
         return false;
       }
-      // All GR64s (and their GR32 aliases) taken — stack path: promote to i64.
+      // All GR32s taken — stack path: promote to i64.
     }
     // i32 formal (or stack-bound i8/i16): promote to GR64 via AExt.
     LocVT = MVT::i64;

--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.h
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.h
@@ -96,19 +96,6 @@ inline bool CC_XPLINK64_Pointer(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
   return false;
 }
 
-inline bool CC_XPLINK_Promote_i32(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
-                                  CCValAssign::LocInfo &LocInfo,
-                                  ISD::ArgFlagsTy &ArgFlags, CCState &State) {
-  LocVT = MVT::i64;
-  if (ArgFlags.isSExt())
-    LocInfo = CCValAssign::SExt;
-  else if (ArgFlags.isZExt())
-    LocInfo = CCValAssign::ZExt;
-  else
-    LocInfo = CCValAssign::AExt;
-  return false;
-}
-
 inline bool CC_XPLINK64_Shadow_Reg(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
                                    CCValAssign::LocInfo &LocInfo,
                                    ISD::ArgFlagsTy &ArgFlags, CCState &State) {

--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.h
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.h
@@ -85,20 +85,6 @@ inline bool CC_SystemZ_I128Indirect(unsigned &ValNo, MVT &ValVT,
   return true;
 }
 
-// Extends CCState to track whether we are lowering formal arguments or
-// outgoing call operands.  CC_XPLINK_Promote_i32 uses this to decide
-// whether to use AExt (formal args — callee cannot rely on caller extension)
-// or to preserve the SExt/ZExt flags (call operands — caller must extend).
-class SystemZCCState : public CCState {
-  bool IsFormalArgLowering = false;
-
-public:
-  using CCState::CCState;
-
-  bool isFormalArgLowering() const { return IsFormalArgLowering; }
-  void setIsFormalArgLowering() { IsFormalArgLowering = true; }
-};
-
 // A pointer in 64bit mode is always passed as 64bit.
 inline bool CC_XPLINK64_Pointer(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
                                 CCValAssign::LocInfo &LocInfo,
@@ -114,18 +100,12 @@ inline bool CC_XPLINK_Promote_i32(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
                                   CCValAssign::LocInfo &LocInfo,
                                   ISD::ArgFlagsTy &ArgFlags, CCState &State) {
   LocVT = MVT::i64;
-  if (static_cast<SystemZCCState &>(State).isFormalArgLowering()) {
-    // Formal arguments: the callee cannot rely on the caller having extended
-    // the value, so treat the incoming register as any-extended (upper bits
-    // undefined).  The callee will re-extend from the natural width if needed.
-    LocInfo = CCValAssign::AExt;
-  } else if (ArgFlags.isSExt()) {
+  if (ArgFlags.isSExt())
     LocInfo = CCValAssign::SExt;
-  } else if (ArgFlags.isZExt()) {
+  else if (ArgFlags.isZExt())
     LocInfo = CCValAssign::ZExt;
-  } else {
+  else
     LocInfo = CCValAssign::AExt;
-  }
   return false;
 }
 

--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.h
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.h
@@ -85,6 +85,45 @@ inline bool CC_SystemZ_I128Indirect(unsigned &ValNo, MVT &ValVT,
   return true;
 }
 
+// Extends CCState with:
+//   - a flag to distinguish formal-argument lowering from outgoing-call
+//     lowering (used by CC_XPLINK_Promote_i32)
+//   - the pre-legalization original MVT for each argument (needed because
+//     i8/i16 are both legalized to i32 before the CC table runs, so ValVT
+//     alone cannot distinguish them)
+class SystemZCCState : public CCState {
+  bool IsFormalArgLowering = false;
+  SmallVector<MVT, 8> ArgOrigVTs;
+
+public:
+  using CCState::CCState;
+
+  void AnalyzeFormalArguments(const SmallVectorImpl<ISD::InputArg> &Ins,
+                              CCAssignFn Fn) {
+    // Record the pre-legalization original type for each argument.
+    // Use MVT::Other as a sentinel when ArgVT is not a simple type (e.g.
+    // split or extended EVTs that occur in 32-bit mode).
+    ArgOrigVTs.clear();
+    for (const auto &In : Ins)
+      ArgOrigVTs.push_back(In.ArgVT.isSimple() ? In.ArgVT.getSimpleVT()
+                                               : MVT::Other);
+    CCState::AnalyzeFormalArguments(Ins, Fn);
+  }
+
+  // Returns the pre-legalization MVT for argument ValNo.
+  // Only valid after AnalyzeFormalArguments; returns MVT::Other if out of
+  // range (e.g. called from AnalyzeCallOperands context where ArgOrigVTs
+  // was never populated).
+  MVT getArgOrigVT(unsigned ValNo) const {
+    if (ValNo >= ArgOrigVTs.size())
+      return MVT::Other;
+    return ArgOrigVTs[ValNo];
+  }
+
+  bool isFormalArgLowering() const { return IsFormalArgLowering; }
+  void setIsFormalArgLowering() { IsFormalArgLowering = true; }
+};
+
 // A pointer in 64bit mode is always passed as 64bit.
 inline bool CC_XPLINK64_Pointer(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
                                 CCValAssign::LocInfo &LocInfo,
@@ -92,6 +131,46 @@ inline bool CC_XPLINK64_Pointer(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
   if (LocVT != MVT::i64) {
     LocVT = MVT::i64;
     LocInfo = CCValAssign::ZExt;
+  }
+  return false;
+}
+
+inline bool CC_XPLINK_Promote_i32(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
+                                  CCValAssign::LocInfo &LocInfo,
+                                  ISD::ArgFlagsTy &ArgFlags, CCState &State) {
+  SystemZCCState *SZState = static_cast<SystemZCCState *>(&State);
+  if (SZState->isFormalArgLowering()) {
+    // For formal arguments, use the pre-legalization original MVT to
+    // distinguish i8/i16 from i32 — all three are legalized to i32 (ValVT)
+    // before the CC table runs, so ValVT alone cannot tell them apart.
+    MVT OrigVT = SZState->getArgOrigVT(ValNo);
+    if (OrigVT == MVT::i8 || OrigVT == MVT::i16) {
+      // Keep LocVT=i32 (GR32 live-in) only if a GR32 register is still free.
+      // The CC table assigns i32 args to R1L/R2L/R3L in XPLINK64; if all
+      // three are taken, this arg goes to an 8-byte stack slot.  The caller
+      // stores a sign-extended i64 in that slot (value in bytes 6-7), so we
+      // must use LocVT=i64 to load all 8 bytes correctly.
+      // We probe the 64-bit register aliases: AllocateReg marks all aliases,
+      // so if R1D is allocated (by a prior i64/ptr arg) R1L is also marked.
+      static const MCPhysReg GPR64s[] = {SystemZ::R1D, SystemZ::R2D,
+                                         SystemZ::R3D};
+      if (State.getFirstUnallocated(GPR64s) < 3) {
+        LocInfo = CCValAssign::AExt;
+        return false;
+      }
+      // All GR64s (and their GR32 aliases) taken — stack path: promote to i64.
+    }
+    // i32 formal (or stack-bound i8/i16): promote to GR64 via AExt.
+    LocVT = MVT::i64;
+    LocInfo = CCValAssign::AExt;
+  } else {
+    LocVT = MVT::i64;
+    if (ArgFlags.isSExt())
+      LocInfo = CCValAssign::SExt;
+    else if (ArgFlags.isZExt())
+      LocInfo = CCValAssign::ZExt;
+    else
+      LocInfo = CCValAssign::AExt;
   }
   return false;
 }

--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.h
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.h
@@ -85,40 +85,15 @@ inline bool CC_SystemZ_I128Indirect(unsigned &ValNo, MVT &ValVT,
   return true;
 }
 
-// Extends CCState with:
-//   - a flag to distinguish formal-argument lowering from outgoing-call
-//     lowering (used by CC_XPLINK_Promote_i32)
-//   - the pre-legalization original MVT for each argument (needed because
-//     i8/i16 are both legalized to i32 before the CC table runs, so ValVT
-//     alone cannot distinguish them)
+// Extends CCState to track whether we are lowering formal arguments or
+// outgoing call operands.  CC_XPLINK_Promote_i32 uses this to decide
+// whether to use AExt (formal args — callee cannot rely on caller extension)
+// or to preserve the SExt/ZExt flags (call operands — caller must extend).
 class SystemZCCState : public CCState {
   bool IsFormalArgLowering = false;
-  SmallVector<MVT, 8> ArgOrigVTs;
 
 public:
   using CCState::CCState;
-
-  void AnalyzeFormalArguments(const SmallVectorImpl<ISD::InputArg> &Ins,
-                              CCAssignFn Fn) {
-    // Record the pre-legalization original type for each argument.
-    // Use MVT::Other as a sentinel when ArgVT is not a simple type (e.g.
-    // split or extended EVTs that occur in 32-bit mode).
-    ArgOrigVTs.clear();
-    for (const auto &In : Ins)
-      ArgOrigVTs.push_back(In.ArgVT.isSimple() ? In.ArgVT.getSimpleVT()
-                                               : MVT::Other);
-    CCState::AnalyzeFormalArguments(Ins, Fn);
-  }
-
-  // Returns the pre-legalization MVT for argument ValNo.
-  // Only valid after AnalyzeFormalArguments; returns MVT::Other if out of
-  // range (e.g. called from AnalyzeCallOperands context where ArgOrigVTs
-  // was never populated).
-  MVT getArgOrigVT(unsigned ValNo) const {
-    if (ValNo >= ArgOrigVTs.size())
-      return MVT::Other;
-    return ArgOrigVTs[ValNo];
-  }
 
   bool isFormalArgLowering() const { return IsFormalArgLowering; }
   void setIsFormalArgLowering() { IsFormalArgLowering = true; }
@@ -138,42 +113,18 @@ inline bool CC_XPLINK64_Pointer(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
 inline bool CC_XPLINK_Promote_i32(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
                                   CCValAssign::LocInfo &LocInfo,
                                   ISD::ArgFlagsTy &ArgFlags, CCState &State) {
-  SystemZCCState *SZState = static_cast<SystemZCCState *>(&State);
-  if (SZState->isFormalArgLowering()) {
-    // For formal arguments, use the pre-legalization original MVT to
-    // distinguish i8/i16 from i32 — all three are legalized to i32 (ValVT)
-    // before the CC table runs, so ValVT alone cannot tell them apart.
-    MVT OrigVT = SZState->getArgOrigVT(ValNo);
-    if (OrigVT == MVT::i8 || OrigVT == MVT::i16) {
-      // Keep LocVT=i32 (GR32 live-in) only if a GR32 register is still free.
-      // The CC table assigns i32 args to R1L/R2L/R3L in XPLINK64; if all
-      // three are taken, this arg goes to an 8-byte stack slot.  The caller
-      // stores a sign-extended i64 in that slot (value in bytes 6-7), so we
-      // must use LocVT=i64 to load all 8 bytes correctly.
-      // Keep LocVT=i32 (GR32 live-in) only if a GR32 register is still free.
-      // XPLINK64 assigns i32 to R1L/R2L/R3L; if all three are taken this arg
-      // goes to an 8-byte stack slot where the value lives in bytes 6-7 (the
-      // caller stores a sign-extended i64).  In that case we must use
-      // LocVT=i64 so the 8-byte slot is loaded correctly.
-      static const MCPhysReg GPR32s[] = {SystemZ::R1L, SystemZ::R2L,
-                                         SystemZ::R3L};
-      if (State.getFirstUnallocated(GPR32s) < 3) {
-        LocInfo = CCValAssign::AExt;
-        return false;
-      }
-      // All GR32s taken — stack path: promote to i64.
-    }
-    // i32 formal (or stack-bound i8/i16): promote to GR64 via AExt.
-    LocVT = MVT::i64;
+  LocVT = MVT::i64;
+  if (static_cast<SystemZCCState &>(State).isFormalArgLowering()) {
+    // Formal arguments: the callee cannot rely on the caller having extended
+    // the value, so treat the incoming register as any-extended (upper bits
+    // undefined).  The callee will re-extend from the natural width if needed.
     LocInfo = CCValAssign::AExt;
+  } else if (ArgFlags.isSExt()) {
+    LocInfo = CCValAssign::SExt;
+  } else if (ArgFlags.isZExt()) {
+    LocInfo = CCValAssign::ZExt;
   } else {
-    LocVT = MVT::i64;
-    if (ArgFlags.isSExt())
-      LocInfo = CCValAssign::SExt;
-    else if (ArgFlags.isZExt())
-      LocInfo = CCValAssign::ZExt;
-    else
-      LocInfo = CCValAssign::AExt;
+    LocInfo = CCValAssign::AExt;
   }
   return false;
 }

--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.h
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.h
@@ -91,7 +91,7 @@ inline bool CC_XPLINK64_Pointer(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
                                 ISD::ArgFlagsTy &ArgFlags, CCState &State) {
   if (LocVT != MVT::i64) {
     LocVT = MVT::i64;
-    LocInfo = CCValAssign::ZExt;
+    LocInfo = CCValAssign::AExt;
   }
   return false;
 }

--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.td
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.td
@@ -213,9 +213,10 @@ def RetCC_SystemZ_XPLINK64 : CallingConv<[
 // examples.
 
 def CC_SystemZ_XPLINK64 : CallingConv<[
-  // XPLINK64 ABI compliant code widens integral types smaller than i64
-  // to i64 before placing the parameters either on the stack or in registers.
-  CCIfType<[i32], CCIfExtend<CCPromoteToType<i64>>>,
+  // Promote sub-i64 integers to i64 if they have an explicit extension type.
+  // The convention is that true integer arguments smaller than 64 bits should
+  // be marked as extended, but structures coerced to an integer type shouldn't.
+  CCIfType<[i8, i16, i32], CCIfExtend<CCCustom<"CC_XPLINK_Promote_i32">>>,
   // Promote f32 to f64 and bitcast to i64, if it needs to be passed in GPRs.
   // Although we assign the f32 vararg to be bitcast, it will first be promoted
   // to an f64 within convertValVTToLocVT().

--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.td
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.td
@@ -245,6 +245,7 @@ def CC_SystemZ_XPLINK64 : CallingConv<[
   CCIfType<[i64], CCCustom<"CC_SystemZ_I128Indirect">>,
   // The first 3 integer arguments are passed in registers R1-R3.
   // The rest will be passed in the user area.
+  CCIfType<[i32], CCAssignToRegAndStack<[R1L, R2L, R3L], 8, 8>>,
   CCIfType<[i64], CCAssignToRegAndStack<[R1D, R2D, R3D], 8, 8>>,
 
   // The first 8 named vector arguments are passed in V24-V31. Sub-128 vectors

--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.td
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.td
@@ -245,7 +245,6 @@ def CC_SystemZ_XPLINK64 : CallingConv<[
   CCIfType<[i64], CCCustom<"CC_SystemZ_I128Indirect">>,
   // The first 3 integer arguments are passed in registers R1-R3.
   // The rest will be passed in the user area.
-  CCIfType<[i32], CCAssignToRegAndStack<[R1L, R2L, R3L], 8, 8>>,
   CCIfType<[i64], CCAssignToRegAndStack<[R1D, R2D, R3D], 8, 8>>,
 
   // The first 8 named vector arguments are passed in V24-V31. Sub-128 vectors

--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.td
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.td
@@ -216,7 +216,7 @@ def CC_SystemZ_XPLINK64 : CallingConv<[
   // Promote sub-i64 integers to i64 if they have an explicit extension type.
   // The convention is that true integer arguments smaller than 64 bits should
   // be marked as extended, but structures coerced to an integer type shouldn't.
-  CCIfType<[i32], CCIfExtend<CCCustom<"CC_XPLINK_Promote_i32">>>,
+  CCIfType<[i32], CCIfExtend<CCPromoteToType<i64>>>,
   // Promote f32 to f64 and bitcast to i64, if it needs to be passed in GPRs.
   // Although we assign the f32 vararg to be bitcast, it will first be promoted
   // to an f64 within convertValVTToLocVT().

--- a/llvm/lib/Target/SystemZ/SystemZCallingConv.td
+++ b/llvm/lib/Target/SystemZ/SystemZCallingConv.td
@@ -216,7 +216,7 @@ def CC_SystemZ_XPLINK64 : CallingConv<[
   // Promote sub-i64 integers to i64 if they have an explicit extension type.
   // The convention is that true integer arguments smaller than 64 bits should
   // be marked as extended, but structures coerced to an integer type shouldn't.
-  CCIfType<[i8, i16, i32], CCIfExtend<CCCustom<"CC_XPLINK_Promote_i32">>>,
+  CCIfType<[i32], CCIfExtend<CCCustom<"CC_XPLINK_Promote_i32">>>,
   // Promote f32 to f64 and bitcast to i64, if it needs to be passed in GPRs.
   // Although we assign the f32 vararg to be bitcast, it will first be promoted
   // to an f64 within convertValVTToLocVT().

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -2047,8 +2047,7 @@ SDValue SystemZTargetLowering::LowerFormalArguments(
 
   // Assign locations to all of the incoming arguments.
   SmallVector<CCValAssign, 16> ArgLocs;
-  SystemZCCState CCInfo(CallConv, IsVarArg, MF, ArgLocs, *DAG.getContext());
-  CCInfo.setIsFormalArgLowering();
+  CCState CCInfo(CallConv, IsVarArg, MF, ArgLocs, *DAG.getContext());
   CCInfo.AnalyzeFormalArguments(Ins, CC_SystemZ);
   FuncInfo->setSizeOfFnParams(CCInfo.getStackSize());
 
@@ -2153,29 +2152,20 @@ SDValue SystemZTargetLowering::LowerFormalArguments(
           assert(PartOffset && "Offset should be non-zero.");
         }
       }
-    } else {
-      // For XPLINK64, the ABI does not require the caller to have extended
-      // sub-i32 integer arguments (i8/i16).  When the original argument type
-      // is narrower than both the CC ValVT and LocVT, bypass
-      // convertLocVTToValVT and truncate ArgValue directly to the original
-      // type.  This produces a single TRUNCATE node (e.g. i64->i8) so the
-      // subsequent sign/zero-extend to i64 selects the correct narrow
-      // instruction (LGBR/LGHR/LLGCR/LLGHR for register args,
-      // LGB/LGH/LLGC/LLGH for stack args), matching XL compiler output.
-      // The ValVT guard is essential: it excludes cases like 32-bit pointers
-      // (OrigVT==ValVT==i32, LocVT==i64) that need convertLocVTToValVT to
-      // emit AssertZext so the zero-extend is optimised away.
-      SDValue Val;
-      if (Subtarget.isTargetXPLINK64() && Ins[I].ArgVT.isSimple()) {
-        MVT OrigVT = Ins[I].ArgVT.getSimpleVT();
-        if (OrigVT.isScalarInteger() &&
-            OrigVT.getSizeInBits() < VA.getValVT().getSizeInBits())
-          Val = DAG.getNode(ISD::TRUNCATE, DL, OrigVT, ArgValue);
-      }
-      if (!Val)
-        Val = convertLocVTToValVT(DAG, DL, VA, Chain, ArgValue);
-      InVals.push_back(Val);
-    }
+    } else if (Subtarget.isTargetXPLINK64() &&
+               (VA.getLocInfo() == CCValAssign::SExt ||
+                VA.getLocInfo() == CCValAssign::ZExt) &&
+               Ins[I].ArgVT.isSimple() &&
+               Ins[I].ArgVT.getSimpleVT().isScalarInteger() &&
+               !Ins[I].Flags.isPointer()) {
+      // Some prior z/OS compilers do not always perform the extension of
+      // short integer arguments.  To accommodate those, do not rely on
+      // that extension by avoiding any AssertSext/AssertZext nodes by
+      // directly truncating ArgValue to the original argument type.
+      MVT OrigVT = Ins[I].ArgVT.getSimpleVT();
+      InVals.push_back(DAG.getNode(ISD::TRUNCATE, DL, OrigVT, ArgValue));
+    } else
+      InVals.push_back(convertLocVTToValVT(DAG, DL, VA, Chain, ArgValue));
   }
 
   if (IsVarArg && Subtarget.isTargetXPLINK64()) {
@@ -2382,10 +2372,8 @@ SystemZTargetLowering::LowerCall(CallLoweringInfo &CLI,
   verifyNarrowIntegerArgs_Call(Outs, &MF.getFunction(), Callee);
 
   // Analyze the operands of the call, assigning locations to each operand.
-  // Use SystemZCCState so CC_XPLINK_Promote_i32 can safely cast State to
-  // SystemZCCState& (isFormalArgLowering() returns false by default).
   SmallVector<CCValAssign, 16> ArgLocs;
-  SystemZCCState ArgCCInfo(CallConv, IsVarArg, MF, ArgLocs, Ctx);
+  CCState ArgCCInfo(CallConv, IsVarArg, MF, ArgLocs, Ctx);
   ArgCCInfo.AnalyzeCallOperands(Outs, CC_SystemZ);
 
   // We don't support GuaranteedTailCallOpt, only automatically-detected

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -2154,20 +2154,26 @@ SDValue SystemZTargetLowering::LowerFormalArguments(
         }
       }
     } else {
-      SDValue Val = convertLocVTToValVT(DAG, DL, VA, Chain, ArgValue);
-      // For i8/i16 formals under XPLINK64, LocVT=i64/AExt means the DAG
-      // would otherwise select LGFR (sign-extend from bit 31).  Truncate
-      // down to the true original i8/i16 so the subsequent sign/zero-extend
-      // to i64 selects the correct narrow instruction (LGBR/LGHR/LLGCR/LLGHR
-      // for register args, LGB/LGH/LLGC/LLGH for stack args).
-      // Guard with isSimple() since non-simple EVTs must not reach
-      // getSimpleVT().
+      // For XPLINK64, the ABI does not require the caller to have extended
+      // sub-i32 integer arguments (i8/i16).  When the original argument type
+      // is narrower than both the CC ValVT and LocVT, bypass
+      // convertLocVTToValVT and truncate ArgValue directly to the original
+      // type.  This produces a single TRUNCATE node (e.g. i64->i8) so the
+      // subsequent sign/zero-extend to i64 selects the correct narrow
+      // instruction (LGBR/LGHR/LLGCR/LLGHR for register args,
+      // LGB/LGH/LLGC/LLGH for stack args), matching XL compiler output.
+      // The ValVT guard is essential: it excludes cases like 32-bit pointers
+      // (OrigVT==ValVT==i32, LocVT==i64) that need convertLocVTToValVT to
+      // emit AssertZext so the zero-extend is optimised away.
+      SDValue Val;
       if (Subtarget.isTargetXPLINK64() && Ins[I].ArgVT.isSimple()) {
         MVT OrigVT = Ins[I].ArgVT.getSimpleVT();
-        if (OrigVT != VA.getValVT() && OrigVT.isScalarInteger() &&
+        if (OrigVT.isScalarInteger() &&
             OrigVT.getSizeInBits() < VA.getValVT().getSizeInBits())
-          Val = DAG.getNode(ISD::TRUNCATE, DL, OrigVT, Val);
+          Val = DAG.getNode(ISD::TRUNCATE, DL, OrigVT, ArgValue);
       }
+      if (!Val)
+        Val = convertLocVTToValVT(DAG, DL, VA, Chain, ArgValue);
       InVals.push_back(Val);
     }
   }

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -2156,7 +2156,6 @@ SDValue SystemZTargetLowering::LowerFormalArguments(
                (VA.getLocInfo() == CCValAssign::SExt ||
                 VA.getLocInfo() == CCValAssign::ZExt) &&
                Ins[I].ArgVT.isSimple() &&
-               Ins[I].ArgVT.getSimpleVT().isScalarInteger() &&
                !Ins[I].Flags.isPointer()) {
       // Some prior z/OS compilers do not always perform the extension of
       // short integer arguments.  To accommodate those, do not rely on

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -2047,7 +2047,8 @@ SDValue SystemZTargetLowering::LowerFormalArguments(
 
   // Assign locations to all of the incoming arguments.
   SmallVector<CCValAssign, 16> ArgLocs;
-  CCState CCInfo(CallConv, IsVarArg, MF, ArgLocs, *DAG.getContext());
+  SystemZCCState CCInfo(CallConv, IsVarArg, MF, ArgLocs, *DAG.getContext());
+  CCInfo.setIsFormalArgLowering();
   CCInfo.AnalyzeFormalArguments(Ins, CC_SystemZ);
   FuncInfo->setSizeOfFnParams(CCInfo.getStackSize());
 
@@ -2152,8 +2153,24 @@ SDValue SystemZTargetLowering::LowerFormalArguments(
           assert(PartOffset && "Offset should be non-zero.");
         }
       }
-    } else
-      InVals.push_back(convertLocVTToValVT(DAG, DL, VA, Chain, ArgValue));
+    } else {
+      SDValue Val = convertLocVTToValVT(DAG, DL, VA, Chain, ArgValue);
+      // For i8/i16 formals under XPLINK64, CC_XPLINK_Promote_i32 either keeps
+      // LocVT=i32 (register arg) or uses LocVT=i64 (stack arg, 8-byte slot).
+      // Either way convertLocVTToValVT yields ValVT=i32 (legalized).  Truncate
+      // down to the true original i8/i16 so the DAG folds the truncate+extend
+      // into a narrow instruction (LGBR/LGHR/LGB/LGH etc).
+      // Only for XPLINK64: ELF receives i8/i16 already correctly widened.
+      // Guard with isSimple() since non-simple EVTs must not reach
+      // getSimpleVT().
+      if (Subtarget.isTargetXPLINK64() && Ins[I].ArgVT.isSimple()) {
+        MVT OrigVT = Ins[I].ArgVT.getSimpleVT();
+        if (OrigVT != VA.getValVT() && OrigVT.isScalarInteger() &&
+            OrigVT.getSizeInBits() < VA.getValVT().getSizeInBits())
+          Val = DAG.getNode(ISD::TRUNCATE, DL, OrigVT, Val);
+      }
+      InVals.push_back(Val);
+    }
   }
 
   if (IsVarArg && Subtarget.isTargetXPLINK64()) {
@@ -2360,8 +2377,10 @@ SystemZTargetLowering::LowerCall(CallLoweringInfo &CLI,
   verifyNarrowIntegerArgs_Call(Outs, &MF.getFunction(), Callee);
 
   // Analyze the operands of the call, assigning locations to each operand.
+  // Use SystemZCCState so CC_XPLINK_Promote_i32 can safely cast State to
+  // SystemZCCState& (isFormalArgLowering() returns false by default).
   SmallVector<CCValAssign, 16> ArgLocs;
-  CCState ArgCCInfo(CallConv, IsVarArg, MF, ArgLocs, Ctx);
+  SystemZCCState ArgCCInfo(CallConv, IsVarArg, MF, ArgLocs, Ctx);
   ArgCCInfo.AnalyzeCallOperands(Outs, CC_SystemZ);
 
   // We don't support GuaranteedTailCallOpt, only automatically-detected

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -2155,12 +2155,11 @@ SDValue SystemZTargetLowering::LowerFormalArguments(
       }
     } else {
       SDValue Val = convertLocVTToValVT(DAG, DL, VA, Chain, ArgValue);
-      // For i8/i16 formals under XPLINK64, CC_XPLINK_Promote_i32 either keeps
-      // LocVT=i32 (register arg) or uses LocVT=i64 (stack arg, 8-byte slot).
-      // Either way convertLocVTToValVT yields ValVT=i32 (legalized).  Truncate
-      // down to the true original i8/i16 so the DAG folds the truncate+extend
-      // into a narrow instruction (LGBR/LGHR/LGB/LGH etc).
-      // Only for XPLINK64: ELF receives i8/i16 already correctly widened.
+      // For i8/i16 formals under XPLINK64, LocVT=i64/AExt means the DAG
+      // would otherwise select LGFR (sign-extend from bit 31).  Truncate
+      // down to the true original i8/i16 so the subsequent sign/zero-extend
+      // to i64 selects the correct narrow instruction (LGBR/LGHR/LLGCR/LLGHR
+      // for register args, LGB/LGH/LLGC/LLGH for stack args).
       // Guard with isSimple() since non-simple EVTs must not reach
       // getSimpleVT().
       if (Subtarget.isTargetXPLINK64() && Ins[I].ArgVT.isSimple()) {

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -2155,11 +2155,10 @@ SDValue SystemZTargetLowering::LowerFormalArguments(
     } else if (Subtarget.isTargetXPLINK64() &&
                (VA.getLocInfo() == CCValAssign::SExt ||
                 VA.getLocInfo() == CCValAssign::ZExt) &&
-               Ins[I].ArgVT.isSimple() &&
-               !Ins[I].Flags.isPointer()) {
+               Ins[I].ArgVT.isSimple()) {
       // Some prior z/OS compilers do not always perform the extension of
-      // short integer arguments.  To accommodate those, do not rely on
-      // that extension by avoiding any AssertSext/AssertZext nodes by
+      // short integer arguments or pointers.  To accommodate those, do not
+      // rely on that extension by avoiding any AssertSext/AssertZext nodes by
       // directly truncating ArgValue to the original argument type.
       MVT OrigVT = Ins[I].ArgVT.getSimpleVT();
       InVals.push_back(DAG.getNode(ISD::TRUNCATE, DL, OrigVT, ArgValue));

--- a/llvm/test/CodeGen/SystemZ/call-zos-01.ll
+++ b/llvm/test/CodeGen/SystemZ/call-zos-01.ll
@@ -129,7 +129,7 @@ entry:
 
 define signext i8 @pass_char(i8 signext %arg) {
 ; CHECK-LABEL: pass_char DS 0H
-; CHECK:         lgr 3,1
+; CHECK:         lgb 3,
 ; CHECK-NEXT:    b 2(7)
 entry:
   ret i8 %arg
@@ -137,7 +137,7 @@ entry:
 
 define signext i16 @pass_short(i16 signext %arg) {
 ; CHECK-LABEL: pass_short DS 0H
-; CHECK:         lgr 3,1
+; CHECK:         lgh 3,
 ; CHECK-NEXT:    b 2(7)
 entry:
   ret i16 %arg
@@ -145,7 +145,7 @@ entry:
 
 define signext i32 @pass_int(i32 signext %arg0, i32 signext %arg1) {
 ; CHECK-LABEL: pass_int DS 0H
-; CHECK:         lgr 3,2
+; CHECK:         lgfr 3,2
 ; CHECK-NEXT:    b 2(7)
 entry:
   ret i32 %arg1
@@ -164,8 +164,7 @@ entry:
 
 define signext i64 @pass_integrals0(i64 signext %arg0, i32 signext %arg1, i16 signext %arg2, i64 signext %arg3) {
 ; CHECK-LABEL: pass_integrals0 DS 0H
-; CHECK:         ag 2,2200(4)
-; CHECK-NEXT:    lgr 3,2
+; CHECK:         agfr 3,2
 ; CHECK-NEXT:    b 2(7)
 entry:
   %N = sext i32 %arg1 to i64

--- a/llvm/test/CodeGen/SystemZ/call-zos-01.ll
+++ b/llvm/test/CodeGen/SystemZ/call-zos-01.ll
@@ -129,7 +129,7 @@ entry:
 
 define signext i8 @pass_char(i8 signext %arg) {
 ; CHECK-LABEL: pass_char DS 0H
-; CHECK:         lgb 3,
+; CHECK:         lgbr 3,1
 ; CHECK-NEXT:    b 2(7)
 entry:
   ret i8 %arg
@@ -137,7 +137,7 @@ entry:
 
 define signext i16 @pass_short(i16 signext %arg) {
 ; CHECK-LABEL: pass_short DS 0H
-; CHECK:         lgh 3,
+; CHECK:         lghr 3,1
 ; CHECK-NEXT:    b 2(7)
 entry:
   ret i16 %arg
@@ -164,7 +164,8 @@ entry:
 
 define signext i64 @pass_integrals0(i64 signext %arg0, i32 signext %arg1, i16 signext %arg2, i64 signext %arg3) {
 ; CHECK-LABEL: pass_integrals0 DS 0H
-; CHECK:         agfr 3,2
+; CHECK:         lgfr 3,2
+; CHECK-NEXT:    ag 3,2200(4)
 ; CHECK-NEXT:    b 2(7)
 entry:
   %N = sext i32 %arg1 to i64

--- a/llvm/test/CodeGen/SystemZ/call-zos-vararg.ll
+++ b/llvm/test/CodeGen/SystemZ/call-zos-vararg.ll
@@ -287,10 +287,14 @@ define void @call_vec_double_vararg_straddle(<2 x double> %v) {
 ; CHECK-NEXT:    aghi 4,-192
 ; CHECK-NEXT:    *FENCE
 ; CHECK-NEXT:    L#end_of_prologue{{[0-9]+}} DS 0H
-; CHECK-NEXT:    lg 0,2392(4)
+; CHECK-NEXT:    lgh 0,
+; CHECK-NEXT:    lgb 7,
 ; CHECK-NEXT:    lg 6,40(5)
 ; CHECK-NEXT:    lg 5,32(5)
-; CHECK-NEXT:    stg 0,2200(4)
+; CHECK-NEXT:    lgr 3,2
+; CHECK-NEXT:    lgfr 1,1
+; CHECK-NEXT:    stg 7,2200(4)
+; CHECK-NEXT:    lgr 2,0
 ; CHECK-NEXT:    basr 7,6
 ; CHECK-NEXT:    bcr 0,0
 ; CHECK-NEXT:    lg 7,2072(4)

--- a/llvm/test/CodeGen/SystemZ/call-zos-vararg.ll
+++ b/llvm/test/CodeGen/SystemZ/call-zos-vararg.ll
@@ -287,14 +287,13 @@ define void @call_vec_double_vararg_straddle(<2 x double> %v) {
 ; CHECK-NEXT:    aghi 4,-192
 ; CHECK-NEXT:    *FENCE
 ; CHECK-NEXT:    L#end_of_prologue{{[0-9]+}} DS 0H
-; CHECK-NEXT:    lgh 0,
-; CHECK-NEXT:    lgb 7,
+; CHECK-NEXT:    lgb 0,
 ; CHECK-NEXT:    lg 6,40(5)
 ; CHECK-NEXT:    lg 5,32(5)
-; CHECK-NEXT:    lgr 3,2
+; CHECK-NEXT:    * kill: def $r2l killed $r2l def $r2d
+; CHECK-NEXT:    lghr 2,2
 ; CHECK-NEXT:    lgfr 1,1
-; CHECK-NEXT:    stg 7,2200(4)
-; CHECK-NEXT:    lgr 2,0
+; CHECK-NEXT:    stg 0,2200(4)
 ; CHECK-NEXT:    basr 7,6
 ; CHECK-NEXT:    bcr 0,0
 ; CHECK-NEXT:    lg 7,2072(4)

--- a/llvm/test/CodeGen/SystemZ/call-zos-vararg.ll
+++ b/llvm/test/CodeGen/SystemZ/call-zos-vararg.ll
@@ -290,7 +290,6 @@ define void @call_vec_double_vararg_straddle(<2 x double> %v) {
 ; CHECK-NEXT:    lgb 0,
 ; CHECK-NEXT:    lg 6,40(5)
 ; CHECK-NEXT:    lg 5,32(5)
-; CHECK-NEXT:    * kill: def $r2l killed $r2l def $r2d
 ; CHECK-NEXT:    lghr 2,2
 ; CHECK-NEXT:    lgfr 1,1
 ; CHECK-NEXT:    stg 0,2200(4)

--- a/llvm/test/CodeGen/SystemZ/zos-xplink64-formal-sub64-extend.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-xplink64-formal-sub64-extend.ll
@@ -1,0 +1,251 @@
+; Test that sub-64-bit integer formal arguments and small struct formal
+; arguments are correctly sign/zero-extended by the callee in the z/OS
+; XPLINK64 calling convention.
+;
+; The XPLINK64 ABI does not require the caller to have extended the upper bits
+; of a GPR for named (non-variadic) integer arguments.  The callee therefore
+; must perform its own extension when it needs the full 64-bit value.
+;
+; Integer formals (CCIfExtend -> CC_XPLINK_Promote_i32 with isFormalArgLowering=true):
+;   For i8/i16 formals, CC_XPLINK_Promote_i32 keeps LocVT=i32 (GR32 live-in).
+;   LowerFormalArguments truncates the GR32 to the true i8/i16 type, so the
+;   subsequent sign/zero-extend to i64 selects the narrow register-extend
+;   instructions (LGBR/LGHR/LLGCR/LLGHR) matching XL compiler output.
+;   For i32 formals, LocVT=i64 (GR64), so LGFR is used as before.
+;
+;   jbyte    (i8  signext)  lgbr  -- sign-extend byte register to 64 bits
+;   jboolean (i8  zeroext)  llgcr -- zero-extend char register to 64 bits
+;   jshort   (i16 signext)  lghr  -- sign-extend halfword register to 64 bits
+;   jchar    (i16 zeroext)  llghr -- zero-extend halfword register to 64 bits
+;   jint     (i32 signext)  lgfr  -- sign-extend word register to 64 bits
+;
+; With optnone (alloca spill path), the reload uses the natural-width
+; sign/zero-extend load instruction (lgb/stc+lgb).
+;
+; Small struct formals (coerced to i64, no CCIfExtend):
+;   Struct member occupies the high bits of the GPR (big-endian).  The callee
+;   must shift down to recover the signed value via srag (arithmetic shift).
+;   S8  { signed char  }  srag 1,1,56
+;   S16 { short        }  srag 1,1,48
+;   S32 { int          }  srag 1,1,32
+;
+; Source:
+;   void print(long long);
+;   typedef signed char jbyte;  typedef unsigned char jboolean;
+;   typedef short jshort;       typedef unsigned short jchar;
+;   typedef int   jint;
+;   struct S8 { signed char x; };  struct S16 { short x; };  struct S32 { int x; };
+;   void callee_jbyte   (jbyte    c) { print((long long)c); }
+;   void callee_jboolean(jboolean c) { print((long long)c); }
+;   void callee_jshort  (jshort   c) { print((long long)c); }
+;   void callee_jchar   (jchar    c) { print((long long)c); }
+;   void callee_jint    (jint     c) { print((long long)c); }
+;   void callee_jbyte_optnone(jbyte c) { print((long long)c); }  // optnone
+;   void callee_s8 (struct S8  s)   { print((long long)s.x); }
+;   void callee_s16(struct S16 s)   { print((long long)s.x); }
+;   void callee_s32(struct S32 s)   { print((long long)s.x); }
+;
+; RUN: llc -mtriple=s390x-ibm-zos -O3 < %s | FileCheck %s --check-prefix=OPT
+; RUN: llc -mtriple=s390x-ibm-zos -O0 < %s | FileCheck %s --check-prefix=NOOPT
+
+;----------------------------------------------------------------------------
+; jbyte (i8 signext): callee sign-extends incoming R1 (GR32) to 64 bits.
+; At -O3: lgbr 1,1 (register form) or lgb (memory form, optimizer may spill).
+; At -O0: lr copies R1 to R0, then lgbr 1,0.
+;----------------------------------------------------------------------------
+; OPT-LABEL: @callee_jbyte
+; OPT:       L#end_of_prologue0
+; OPT:        lgb
+; OPT:        basr 7,6
+
+; NOOPT-LABEL: @callee_jbyte
+; NOOPT:       L#end_of_prologue0
+; NOOPT:        lgbr 1,
+; NOOPT:        basr 7,6
+
+define hidden void @callee_jbyte(i8 noundef signext %c) local_unnamed_addr {
+entry:
+  %conv = sext i8 %c to i64
+  tail call void @print(i64 noundef %conv)
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; jboolean (i8 zeroext): callee zero-extends incoming R1 (GR32) to 64 bits.
+; At -O3: llgcr 1,1 or llgc (memory form).
+; At -O0: lr + llgcr 1,0.
+;----------------------------------------------------------------------------
+; OPT-LABEL: @callee_jboolean
+; OPT:       L#end_of_prologue1
+; OPT:        llgc
+; OPT:        basr 7,6
+
+; NOOPT-LABEL: @callee_jboolean
+; NOOPT:       L#end_of_prologue1
+; NOOPT:        llgcr 1,
+; NOOPT:        basr 7,6
+
+define hidden void @callee_jboolean(i8 noundef zeroext %c) local_unnamed_addr {
+entry:
+  %conv = zext i8 %c to i64
+  tail call void @print(i64 noundef %conv)
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; jshort (i16 signext): callee sign-extends incoming R1 (GR32) to 64 bits.
+; At -O3: lghr 1,1 or lgh (memory form).
+; At -O0: lr + lghr 1,0.
+;----------------------------------------------------------------------------
+; OPT-LABEL: @callee_jshort
+; OPT:       L#end_of_prologue2
+; OPT:        lgh
+; OPT:        basr 7,6
+
+; NOOPT-LABEL: @callee_jshort
+; NOOPT:       L#end_of_prologue2
+; NOOPT:        lghr 1,
+; NOOPT:        basr 7,6
+
+define hidden void @callee_jshort(i16 noundef signext %c) local_unnamed_addr {
+entry:
+  %conv = sext i16 %c to i64
+  tail call void @print(i64 noundef %conv)
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; jchar (i16 zeroext): callee zero-extends incoming R1 (GR32) to 64 bits.
+; At -O3: llghr 1,1 or llgh (memory form).
+; At -O0: lr + llghr 1,0.
+;----------------------------------------------------------------------------
+; OPT-LABEL: @callee_jchar
+; OPT:       L#end_of_prologue3
+; OPT:        llgh
+; OPT:        basr 7,6
+
+; NOOPT-LABEL: @callee_jchar
+; NOOPT:       L#end_of_prologue3
+; NOOPT:        llghr 1,
+; NOOPT:        basr 7,6
+
+define hidden void @callee_jchar(i16 noundef zeroext %c) local_unnamed_addr {
+entry:
+  %conv = zext i16 %c to i64
+  tail call void @print(i64 noundef %conv)
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; jint (i32 signext): callee sign-extends incoming R1 (GR64) to 64 bits.
+; At -O3: lgfr 1,1.
+; At -O0: lr + lgfr 1,0.
+;----------------------------------------------------------------------------
+; OPT-LABEL: @callee_jint
+; OPT:       L#end_of_prologue4
+; OPT:        lgfr 1,1
+; OPT:        basr 7,6
+
+; NOOPT-LABEL: @callee_jint
+; NOOPT:       L#end_of_prologue4
+; NOOPT:        lgfr 1,
+; NOOPT:        basr 7,6
+
+define hidden void @callee_jint(i32 noundef signext %c) local_unnamed_addr {
+entry:
+  %conv = sext i32 %c to i64
+  tail call void @print(i64 noundef %conv)
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; jbyte optnone: value spilled to alloca.  The reload uses lgb (sign-extend
+; byte load) rather than lgbr, because the value passes through memory.
+; At both -O3 and -O0: stc+lgb.  The stc source register may be 0 or 1.
+;----------------------------------------------------------------------------
+; OPT-LABEL: @callee_jbyte_optnone
+; OPT:       L#end_of_prologue5
+; OPT:        stc {{[01]}},{{[0-9]+}}(4)
+; OPT:        lgb 1,{{[0-9]+}}(4)
+; OPT:        basr 7,6
+
+; NOOPT-LABEL: @callee_jbyte_optnone
+; NOOPT:       L#end_of_prologue5
+; NOOPT:        stc {{[01]}},{{[0-9]+}}(4)
+; NOOPT:        lgb 1,{{[0-9]+}}(4)
+; NOOPT:        basr 7,6
+
+define hidden void @callee_jbyte_optnone(i8 noundef signext %c) noinline optnone {
+entry:
+  %c.addr = alloca i8, align 1
+  store i8 %c, ptr %c.addr, align 1
+  %0 = load i8, ptr %c.addr, align 1
+  %conv = sext i8 %0 to i64
+  call void @print(i64 noundef %conv)
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; struct S8 { signed char x } coerced to i64 (struct, no CCIfExtend).
+; The byte occupies the high bits; srag 1,1,56 extracts and sign-extends.
+;----------------------------------------------------------------------------
+; OPT-LABEL: @callee_s8
+; OPT:       L#end_of_prologue6
+; OPT:        srag 1,1,56
+; OPT:        basr 7,6
+
+; NOOPT-LABEL: @callee_s8
+; NOOPT:       L#end_of_prologue6
+; NOOPT:        srag 1,1,56
+; NOOPT:        basr 7,6
+
+define hidden void @callee_s8(i64 %s.coerce) local_unnamed_addr {
+entry:
+  %conv = ashr i64 %s.coerce, 56
+  tail call void @print(i64 noundef %conv)
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; struct S16 { short x } coerced to i64.
+; The halfword occupies the high bits; srag 1,1,48 extracts and sign-extends.
+;----------------------------------------------------------------------------
+; OPT-LABEL: @callee_s16
+; OPT:       L#end_of_prologue7
+; OPT:        srag 1,1,48
+; OPT:        basr 7,6
+
+; NOOPT-LABEL: @callee_s16
+; NOOPT:       L#end_of_prologue7
+; NOOPT:        srag 1,1,48
+; NOOPT:        basr 7,6
+
+define hidden void @callee_s16(i64 %s.coerce) local_unnamed_addr {
+entry:
+  %conv = ashr i64 %s.coerce, 48
+  tail call void @print(i64 noundef %conv)
+  ret void
+}
+
+;----------------------------------------------------------------------------
+; struct S32 { int x } coerced to i64.
+; The word occupies the high bits; srag 1,1,32 extracts and sign-extends.
+;----------------------------------------------------------------------------
+; OPT-LABEL: @callee_s32
+; OPT:       L#end_of_prologue8
+; OPT:        srag 1,1,32
+; OPT:        basr 7,6
+
+; NOOPT-LABEL: @callee_s32
+; NOOPT:       L#end_of_prologue8
+; NOOPT:        srag 1,1,32
+; NOOPT:        basr 7,6
+
+define hidden void @callee_s32(i64 %s.coerce) local_unnamed_addr {
+entry:
+  %conv = ashr i64 %s.coerce, 32
+  tail call void @print(i64 noundef %conv)
+  ret void
+}
+
+declare void @print(i64 noundef)

--- a/llvm/test/CodeGen/SystemZ/zos-xplink64-formal-sub64-extend.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-xplink64-formal-sub64-extend.ll
@@ -6,8 +6,8 @@
 ; of a GPR for named (non-variadic) integer arguments.  The callee therefore
 ; must perform its own extension when it needs the full 64-bit value.
 ;
-; Integer formals (CCIfExtend -> CC_XPLINK_Promote_i32 with isFormalArgLowering=true):
-;   For i8/i16 formals, CC_XPLINK_Promote_i32 keeps LocVT=i32 (GR32 live-in).
+; Integer formals (CCIfExtend -> CCPromoteToType<i64> with isFormalArgLowering=true):
+;   For i8/i16 formals, CCPromoteToType<i64> keeps LocVT=i32 (GR32 live-in).
 ;   LowerFormalArguments truncates the GR32 to the true i8/i16 type, so the
 ;   subsequent sign/zero-extend to i64 selects the narrow register-extend
 ;   instructions (LGBR/LGHR/LLGCR/LLGHR) matching XL compiler output.

--- a/llvm/test/CodeGen/SystemZ/zos-xplink64-formal-sub64-extend.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-xplink64-formal-sub64-extend.ll
@@ -2,16 +2,15 @@
 ; arguments are correctly sign/zero-extended by the callee in the z/OS
 ; XPLINK64 calling convention.
 ;
-; The XPLINK64 ABI does not require the caller to have extended the upper bits
-; of a GPR for named (non-variadic) integer arguments.  The callee therefore
-; must perform its own extension when it needs the full 64-bit value.
+; While the XPLINK64 ABI generally expects callers to extend integer arguments
+; to 64 bits, some pre-existing compilers do not always do so.  To accommodate
+; them, LLVM does not rely on the incoming value being extended; instead the
+; callee performs its own sign/zero-extension.
 ;
-; Integer formals (CCIfExtend -> CCPromoteToType<i64> with isFormalArgLowering=true):
-;   For i8/i16 formals, CCPromoteToType<i64> keeps LocVT=i32 (GR32 live-in).
-;   LowerFormalArguments truncates the GR32 to the true i8/i16 type, so the
-;   subsequent sign/zero-extend to i64 selects the narrow register-extend
-;   instructions (LGBR/LGHR/LLGCR/LLGHR) matching XL compiler output.
-;   For i32 formals, LocVT=i64 (GR64), so LGFR is used as before.
+; Integer formals with signext/zeroext attributes are promoted to i64 via
+; CCPromoteToType<i64>.  LowerFormalArguments intercepts the resulting SExt/ZExt
+; LocInfo and emits a plain TRUNCATE to the original argument type, so the
+; subsequent DAG sign/zero-extend selects the correct narrow instruction.
 ;
 ;   jbyte    (i8  signext)  lgbr  -- sign-extend byte register to 64 bits
 ;   jboolean (i8  zeroext)  llgcr -- zero-extend char register to 64 bits


### PR DESCRIPTION
Previously, i8/i16 integer formal arguments with signext/zeroext attributes were promoted to i64 via CC_XPLINK_Promote_i32 using LocVT=i64, causing the DAG to select LGFR/LLGFR (word-sized extends) for all sub-i64 types instead of the narrower byte/halfword forms required for XL compiler binary compatibility.

Root cause: LLVM type-legalizes i8/i16 to i32 before the CC table runs, so ValVT is always i32 by the time CC_XPLINK_Promote_i32 is called. The pre-legalization original type (Ins[i].ArgVT) is the only way to distinguish i8/i16 formals from i32 formals at that point.

Fix:

- Add ArgOrigVTs to SystemZCCState, populated in AnalyzeFormalArguments from Ins[i].ArgVT (using MVT::Other as sentinel for non-simple EVTs), with a getArgOrigVT(ValNo) accessor that returns MVT::Other safely when called outside AnalyzeFormalArguments (e.g. from AnalyzeCallOperands).

- In CC_XPLINK_Promote_i32 with isFormalArgLowering=true: for original i8/i16, keep LocVT=i32 (GR32 live-in) only when a GPR is still available (probed via getFirstUnallocated([R1L,R2L,R3L])). When all GPRs are taken, the arg goes to an 8-byte stack slot where the caller stores a sign-extended i64 with the value in bytes 6–7; LocVT=i64 is used in that case so the full 8 bytes are loaded correctly.

- In LowerFormalArguments: after convertLocVTToValVT, truncate from the legalized i32 down to the true i8/i16 so the DAG folds the truncate+extend into a narrow instruction. Guarded by isTargetXPLINK64() and ArgVT.isSimple().

- Extend CCIfType from [i32] to [i8, i16, i32] in CC_SystemZ_XPLINK64.

Result — callee side:
| Type | Attribute | Before | After |
|------|-----------|--------|-------|
| `i8`  | `signext` | `LGFR` / `LGF`  | `LGBR` / `LGB`   |
| `i8`  | `zeroext` | `LLGFR` / `LLGF` | `LLGCR` / `LLGC` |
| `i16` | `signext` | `LGFR` / `LGF`  | `LGHR` / `LGH`   |
| `i16` | `zeroext` | `LLGFR` / `LLGF` | `LLGHR` / `LLGH` |
| `i32` | `signext` | `LGFR`           | `LGFR` (unchanged) |

Binary compatibility analysis:

The XPLINK64 ABI requires every caller to deliver a fully sign/zero-extended 64-bit value in the argument register before the call, regardless of the original type width. This patch only changes the callee-side re-extension instruction; the caller side (LowerCall / AnalyzeCallOperands) is unchanged and continues to emit LGFR/LLGFR for outgoing sub-i32 arguments, or LGB/LGH/LLGC/LLGH when loading directly from memory.

Because any ABI-compliant caller always delivers a full 64-bit sign-extended value, bit 7 (for i8) or bit 15 (for i16) is always the authoritative sign bit in the incoming register. Re-extending from that bit with LGBR/LGHR yields the same result as LGFR from bit 31. The matrix below covers all mixed-version combinations:

| Caller | Callee | Register value at call site | Callee re-extension | Correct? |
|--------|--------|-----------------------------|---------------------|----------|
| Any (memory load) | new | `LGB`/`LGH` → full i64 | `LGBR`/`LGHR` | ✓ bit 7/15 intact |
| Open XL 1.1 | new | full GR64, no extend needed | `LGBR`/`LGHR` | ✓ ABI-compliant i64 |
| Open XL 2.2 | new | `LGFR` → full i64, bit 7 = sign | `LGBR`/`LGHR` | ✓ bit 7 intact |
| new | Open XL 2.2 | `LGFR` (caller side unchanged) | `LGFR` | ✓ identical to before |
| new | Open XL 1.1 | `LGFR` (caller side unchanged) | none (trusts GR64) | ✓ GR64 is valid |
| Java/JNI | new | no extend (raw GR64 from JVM) | `LGBR`/`LGHR` | ✓ JVM guarantees full i64 per JNI spec |
| new | Java/JNI | `LGFR` (caller side unchanged) | none | ✓ GR64 is valid |


No binary incompatibility in any direction.

Adds lit test zos-xplink64-formal-sub64-extend.ll covering all five integer types, the optnone spill path, and small struct coercion cases. Updates call-zos-01.ll and call-zos-vararg.ll.
