### PR TITLE
[SPIRV] Expand aggregate instructions with mutated-type uses

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -262,6 +262,7 @@ class SPIRVEmitIntrinsics
   void preprocessCompositeConstants(IRBuilder<> &B);
   Value *lowerUndefOrPoison(Value *Op, IRBuilder<> &B, bool HasPoisonExt);
   void preprocessUndefsAndPoisons(IRBuilder<> &B);
+  void insertCompositeAggregateArms(Instruction *I, IRBuilder<> &B);
   void simplifyNullAddrSpaceCasts();
 
   Type *reconstructType(Value *Op, bool UnknownElemTypeI8,
@@ -1704,6 +1705,48 @@ void SPIRVEmitIntrinsics::simplifyNullAddrSpaceCasts() {
             ConstantPointerNull::get(cast<PointerType>(ASC->getType())));
         ASC->eraseFromParent();
       }
+}
+
+// True for an aggregate value the legalizer splits into a multi-result op
+// (with.overflow -> G_UADDO, frexp/sincos/modf -> G_FFREXP/...). These keep a
+// genuine multi-register result; all other aggregates become a single value-id.
+static bool isMultiRegisterAggregate(Value *V) {
+  if (!V->getType()->isAggregateType())
+    return false;
+  return isa<IntrinsicInst>(V) && !isSpvIntrinsic(V);
+}
+
+// True for an aggregate PHI/select/freeze, which is lowered to a single
+// value-id.
+static bool isAggregateValueIdInstr(const Instruction &I) {
+  return (isa<PHINode>(I) || isa<SelectInst>(I) || isa<FreezeInst>(I)) &&
+         I.getType()->isAggregateType();
+}
+
+// Give each multi-register aggregate arm of an aggregate PHI/select/freeze a
+// single value-id by reassembling it with extractvalue + insertvalue, so the
+// arm matches the result once it is mutated to a value-id.
+void SPIRVEmitIntrinsics::insertCompositeAggregateArms(Instruction *I,
+                                                       IRBuilder<> &B) {
+  auto *Phi = dyn_cast<PHINode>(I);
+  for (Use &U : I->operands()) {
+    Value *Op = U.get();
+    if (!isMultiRegisterAggregate(Op))
+      continue;
+    // A PHI arm materializes in its incoming block, everything else after the
+    // producer.
+    if (Phi)
+      B.SetInsertPoint(Phi->getIncomingBlock(U)->getTerminator());
+    else
+      setInsertPointAfterDef(B, cast<Instruction>(Op));
+    auto *AggrTy = cast<StructType>(Op->getType());
+    Value *Composite = PoisonValue::get(AggrTy);
+    for (unsigned Idx = 0, E = AggrTy->getNumElements(); Idx != E; ++Idx) {
+      Value *Field = B.CreateExtractValue(Op, Idx);
+      Composite = B.CreateInsertValue(Composite, Field, Idx);
+    }
+    U.set(Composite);
+  }
 }
 
 void SPIRVEmitIntrinsics::preprocessCompositeConstants(IRBuilder<> &B) {
@@ -3611,10 +3654,10 @@ bool SPIRVEmitIntrinsics::runOnFunction(Function &Func) {
   // users are lowered to spv_extractv.
   Type *I32Ty = B.getInt32Ty();
   for (Instruction &I : instructions(Func)) {
-    if (!isa<PHINode>(I) && !isa<SelectInst>(I) && !isa<FreezeInst>(I))
+    if (!isAggregateValueIdInstr(I))
       continue;
-    if (!I.getType()->isAggregateType())
-      continue;
+    // Give multi-register arms a value-id first, before the result is mutated.
+    insertCompositeAggregateArms(&I, B);
     AggrConstTypes[&I] = I.getType();
     I.mutateType(I32Ty);
   }

--- a/llvm/test/CodeGen/SPIRV/instructions/phi-aggregate-call.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/phi-aggregate-call.ll
@@ -1,0 +1,33 @@
+; A non-intrinsic aggregate-returning call is already a single value-id
+; (OpFunctionCall returns one result id), so an aggregate PHI arm fed by one
+; must NOT be reassembled: no OpCompositeInsert is emitted for the arms.
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64 %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64 %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: %[[#I64:]] = OpTypeInt 64 0
+; CHECK-DAG: %[[#STRUCT:]] = OpTypeStruct %[[#I64]]
+
+; CHECK: %[[#]] = OpFunctionCall %[[#STRUCT]]
+; CHECK-NOT: OpCompositeInsert
+; CHECK: %[[#PHI:]] = OpPhi %[[#STRUCT]]
+; CHECK: OpCompositeExtract %[[#I64]] %[[#PHI]] 0
+define i64 @phi_call_aggregate(i1 %c) {
+entry:
+  br i1 %c, label %bb0, label %bb1
+
+bb0:
+  %0 = call { i64 } @producer()
+  br label %epilog
+
+bb1:
+  %1 = call { i64 } @producer()
+  br label %epilog
+
+epilog:
+  %2 = phi { i64 } [ %0, %bb0 ], [ %1, %bb1 ]
+  %3 = extractvalue { i64 } %2, 0
+  ret i64 %3
+}
+
+declare { i64 } @producer()

--- a/llvm/test/CodeGen/SPIRV/instructions/phi-aggregate-with-overflow-zeroinitializer.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/phi-aggregate-with-overflow-zeroinitializer.ll
@@ -1,0 +1,35 @@
+; A constant aggregate PHI arm (zeroinitializer) is already a value-id (a shared
+; OpConstantNull), so it must coexist with reassembled multi-register arms in
+; the same PHI. See https://github.com/llvm/llvm-project/issues/203586.
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64 %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64 %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: %[[#I64:]] = OpTypeInt 64 0
+; CHECK-DAG: %[[#BOOL:]] = OpTypeBool
+; CHECK-DAG: %[[#STRUCT:]] = OpTypeStruct %[[#I64]] %[[#BOOL]]
+; CHECK-DAG: %[[#NULL:]] = OpConstantNull %[[#STRUCT]]
+
+; CHECK: %[[#PHI:]] = OpPhi %[[#STRUCT]] {{.*}}%[[#NULL]]
+; CHECK: OpCompositeExtract %[[#I64]] %[[#PHI]] 0
+define i64 @phi_overflow_zeroinitializer(i64 %a, i64 %b, i1 %c) {
+entry:
+  br i1 %c, label %bb0, label %bb1
+
+bb0:
+  %0 = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
+  br label %epilog
+
+bb1:
+  br label %epilog
+
+epilog:
+  %1 = phi { i64, i1 } [ %0, %bb0 ], [ zeroinitializer, %bb1 ]
+  %2 = extractvalue { i64, i1 } %1, 0
+  %3 = extractvalue { i64, i1 } %1, 1
+  %4 = zext i1 %3 to i64
+  %5 = add i64 %2, %4
+  ret i64 %5
+}
+
+declare { i64, i1 } @llvm.uadd.with.overflow.i64(i64, i64)

--- a/llvm/test/CodeGen/SPIRV/instructions/phi-aggregate-with-overflow.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/phi-aggregate-with-overflow.ll
@@ -1,0 +1,38 @@
+; A `with.overflow` result is a multi-register aggregate that is never rewritten
+; to a value-id, but PHI is, so verify there is no type mismatch in the PHI.
+; See https://github.com/llvm/llvm-project/issues/203586.
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64 %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64 %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: %[[#I64:]] = OpTypeInt 64 0
+; CHECK-DAG: %[[#BOOL:]] = OpTypeBool
+; CHECK-DAG: %[[#STRUCT:]] = OpTypeStruct %[[#I64]] %[[#BOOL]]
+
+; CHECK: %[[#PHI:]] = OpPhi %[[#STRUCT]]
+; CHECK: OpCompositeExtract %[[#I64]] %[[#PHI]] 0
+; CHECK: OpCompositeExtract %[[#BOOL]] %[[#PHI]] 1
+
+define i64 @phi_overflow(i64 %a, i64 %b, i1 %c) {
+entry:
+  br i1 %c, label %bb0, label %bb1
+
+bb0:
+  %0 = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
+  br label %epilog
+
+bb1:
+  %1 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
+  br label %epilog
+
+epilog:
+  %2 = phi { i64, i1 } [ %0, %bb0 ], [ %1, %bb1 ]
+  %3 = extractvalue { i64, i1 } %2, 0
+  %4 = extractvalue { i64, i1 } %2, 1
+  %5 = zext i1 %4 to i64
+  %6 = add i64 %3, %5
+  ret i64 %6
+}
+
+declare { i64, i1 } @llvm.uadd.with.overflow.i64(i64, i64)
+declare { i64, i1 } @llvm.usub.with.overflow.i64(i64, i64)

--- a/llvm/test/CodeGen/SPIRV/instructions/select-freeze-aggregate-with-overflow.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/select-freeze-aggregate-with-overflow.ll
@@ -1,0 +1,36 @@
+; A select or freeze of an aggregate is lowered to a single value-id just like a
+; PHI, so a multi-register `with.overflow` arm must likewise be reassembled into
+; a composite. See https://github.com/llvm/llvm-project/issues/203586.
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64 %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64 %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: %[[#I64:]] = OpTypeInt 64 0
+; CHECK-DAG: %[[#BOOL:]] = OpTypeBool
+; CHECK-DAG: %[[#STRUCT:]] = OpTypeStruct %[[#I64]] %[[#BOOL]]
+
+; CHECK: OpSelect %[[#STRUCT]]
+define i64 @select_overflow(i64 %a, i64 %b, i1 %c) {
+  %add = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
+  %sub = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
+  %sel = select i1 %c, { i64, i1 } %add, { i64, i1 } %sub
+  %v = extractvalue { i64, i1 } %sel, 0
+  %o = extractvalue { i64, i1 } %sel, 1
+  %z = zext i1 %o to i64
+  %r = add i64 %v, %z
+  ret i64 %r
+}
+
+define i64 @freeze_overflow(i64 %a, i64 %b) {
+  %mul = call { i64, i1 } @llvm.umul.with.overflow.i64(i64 %a, i64 %b)
+  %frz = freeze { i64, i1 } %mul
+  %v = extractvalue { i64, i1 } %frz, 0
+  %o = extractvalue { i64, i1 } %frz, 1
+  %z = zext i1 %o to i64
+  %r = add i64 %v, %z
+  ret i64 %r
+}
+
+declare { i64, i1 } @llvm.uadd.with.overflow.i64(i64, i64)
+declare { i64, i1 } @llvm.usub.with.overflow.i64(i64, i64)
+declare { i64, i1 } @llvm.umul.with.overflow.i64(i64, i64)


### PR DESCRIPTION
This is a workaround for the problem in GH issue https://github.com/llvm/llvm-project/issues/203586.

The problem is that we need to mutate aggregate-typed PHI nodes to `i32`, however that means all incoming values need to have a matching type, but we can't always easily mutate the incoming types to i32, as in the case in the GH issue with a math intrinsic that returns a struct by-value.

We do the same mutation for some other cases like `freeze`, the workaround is the same.

The workaround is to expand the incoming values to a form that will also be mutated to i32 so the types match. An example transformation is below:

Before
```
...
bb1:                                              ; preds = %entry
  %0 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
  br label %epilog
...
  %2 = phi { i64, i1 } [ %1, %bb0 ], [ %0, %bb1 ]
```

After
```
...
bb1:                                              ; preds = %entry
  %0 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
  %1 = extractvalue { i64, i1 } %0, 0
  %2 = insertvalue { i64, i1 } poison, i64 %1, 0
  %3 = extractvalue { i64, i1 } %0, 1
  %4 = insertvalue { i64, i1 } %2, i1 %3, 1
  br label %epilog
...
  %10 = phi { i64, i1 } [ %9, %bb0 ], [ %4, %bb1 ]
```

`insertvalue` get replaced with a SPIR-V intrinsic later in the pass which is also type-mutated, so the IR is correct:

```
...
bb1:                                              ; preds = %entry
  %0 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
  call void @llvm.spv.value.md(metadata !0)
  call void (...) @llvm.fake.use({ i64, i1 } %0)
  %1 = extractvalue { i64, i1 } %0, 0
  call void @llvm.spv.assign.type.i64(i64 %1, metadata i64 poison)
  call void @llvm.spv.assign.type.i32(i32 undef, metadata { i64, i1 } poison)
  %2 = call i32 (i32, i64, ...) @llvm.spv.insertv.i64(i32 undef, i64 %1, i32 0)
  call void @llvm.spv.assign.type.i32(i32 %2, metadata { i64, i1 } poison)
  %3 = extractvalue { i64, i1 } %0, 1
  call void @llvm.spv.assign.type.i1(i1 %3, metadata i1 poison)
  %4 = call i32 (i32, i1, ...) @llvm.spv.insertv.i1(i32 %2, i1 %3, i32 1)
  call void @llvm.spv.assign.type.i32(i32 %4, metadata { i64, i1 } poison)
  br label %epilog
...
  %10 = phi i32 [ %9, %bb0 ], [ %4, %bb1 ]
```

This is the simplest change I could come up with, my other ideas were much more complicated and/or risky.

This fix is important for us because this pattern comes up in libc's implementation on FMA, so this is blocking SPIR-V libc support.

Fixes: https://github.com/llvm/llvm-project/issues/203586

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>