### PR TITLE
[llvm][SplitModuleByCategory] Fix infinite loop on cyclic global uses

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/SplitModuleByCategory.h
+++ b/llvm/include/llvm/Transforms/Utils/SplitModuleByCategory.h
@@ -53,8 +53,8 @@ class Function;
 ///    there is a function B with signature S. An "A" -> "B" edge will be added
 ///    to the graph;
 ///
-/// FIXME: For now, the algorithm assumes no recursion in the input Module. This
-/// will be addressed in the near future.
+/// Recursion and other cycles in the input Module (e.g. directly or mutually
+/// recursive functions, or self-referencing global variables) are supported.
 LLVM_ABI Error splitModuleTransitiveFromEntryPoints(
     std::unique_ptr<Module> M,
     function_ref<std::optional<int>(const Function &F)> EntryPointCategorizer,

--- a/llvm/lib/Transforms/Utils/SplitModuleByCategory.cpp
+++ b/llvm/lib/Transforms/Utils/SplitModuleByCategory.cpp
@@ -159,7 +159,9 @@ public:
 private:
   void addUserToGraphRecursively(const User *Root, const GlobalValue *V) {
     SmallVector<const User *, 8> WorkList;
+    SmallPtrSet<const User *, 8> Visited;
     WorkList.push_back(Root);
+    Visited.insert(Root);
 
     while (!WorkList.empty()) {
       const User *U = WorkList.pop_back_val();
@@ -173,7 +175,8 @@ private:
         // bitcast or gep). We trace users of this constant further to reach
         // global objects they are used by and add them to the graph.
         for (const User *UU : U->users())
-          WorkList.push_back(UU);
+          if (Visited.insert(UU).second)
+            WorkList.push_back(UU);
       } else {
         llvm_unreachable("Unhandled type of function user");
       }

--- a/llvm/test/tools/llvm-split/SplitByCategory/recursion-and-cycles.ll
+++ b/llvm/test/tools/llvm-split/SplitByCategory/recursion-and-cycles.ll
@@ -1,0 +1,47 @@
+; Check that Module splitting produces correct output in the presence of cycles
+; in the dependency graph.
+
+; RUN: llvm-split -split-by-category=kernel -S < %s -o %t
+; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK0 \
+; RUN:     --implicit-check-not @gptr --implicit-check-not @kernel_A
+; RUN: FileCheck %s -input-file=%t_1.ll --check-prefix CHECK1 \
+; RUN:     --implicit-check-not @self --implicit-check-not @kernel_B
+
+; CHECK0-DAG: define spir_func void @ping()
+; CHECK0-DAG: define spir_func void @pong()
+; CHECK0-DAG: define spir_func void @self()
+; CHECK0-DAG: define spir_kernel void @kernel_B()
+
+; CHECK1-DAG: @gptr = private global ptr @gptr
+; CHECK1-DAG: define spir_func void @ping()
+; CHECK1-DAG: define spir_func void @pong()
+; CHECK1-DAG: define spir_kernel void @kernel_A()
+
+@gptr = private global ptr @gptr
+
+define spir_func void @ping() {
+  call spir_func void @pong()
+  ret void
+}
+
+define spir_func void @pong() {
+  call spir_func void @ping()
+  ret void
+}
+
+define spir_func void @self() {
+  call spir_func void @self()
+  ret void
+}
+
+define spir_kernel void @kernel_A() {
+  call spir_func void @ping()
+  %v = load ptr, ptr @gptr
+  ret void
+}
+
+define spir_kernel void @kernel_B() {
+  call spir_func void @ping()
+  call spir_func void @self()
+  ret void
+}


### PR DESCRIPTION
The dependency graph construction in `addUserToGraphRecursively` walked the users of globals without visited set. A cycle in the use graph caused it to push the same users forever, hanging the splitter.

Track visited users so each is processed once.

Co-Authored-By: Claude
