### PR TITLE
Handle the case where the ISA we find when looking up a method implementation has masked bits

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
@@ -418,7 +418,7 @@ private:
 
   AppleObjCRuntimeV2(Process *process, const lldb::ModuleSP &objc_module_sp);
 
-  ObjCISA GetPointerISA(ObjCISA isa);
+  ObjCISA GetPointerISA(ObjCISA isa) override;
 
   lldb::addr_t GetISAHashTablePointer();
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
@@ -977,6 +977,10 @@ AppleObjCTrampolineHandler::GetStepThroughDispatchPlan(Thread &thread,
       ObjCLanguageRuntime *objc_runtime =
           ObjCLanguageRuntime::Get(*thread.GetProcess());
       assert(objc_runtime != nullptr);
+      // We have the address in the ISA pointer of our object, but it might
+      // be a masked value, so we need to get the Pointer ISA:
+      isa_addr = objc_runtime->GetPointerISA(isa_addr);
+
       LLDB_LOG(log, "Resolving call for class - {0} and selector - {1}",
                isa_addr, sel_addr);
       impl_addr = objc_runtime->LookupInMethodCache(isa_addr, sel_addr);

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -307,6 +307,8 @@ public:
 
   virtual ObjCISA GetParentClass(ObjCISA isa);
 
+  virtual ObjCISA GetPointerISA(ObjCISA isa) {return isa; };  
+
   // Finds the byte offset of the child_type ivar in parent_type.  If it can't
   // find the offset, returns LLDB_INVALID_IVAR_OFFSET.
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -307,7 +307,7 @@ public:
 
   virtual ObjCISA GetParentClass(ObjCISA isa);
 
-  virtual ObjCISA GetPointerISA(ObjCISA isa) {return isa; };  
+  virtual ObjCISA GetPointerISA(ObjCISA isa) { return isa; };
 
   // Finds the byte offset of the child_type ivar in parent_type.  If it can't
   // find the offset, returns LLDB_INVALID_IVAR_OFFSET.


### PR DESCRIPTION
We need to canonicalize these since we look them up, and the PointerISA is the right thing to use since it actually points at the class.

I can't write a test for this because ObjC mostly uses the masks for swift/objc interop.  I will add a test on the swift fork.