### PR TITLE
[orc-rt] Simplify CallableTraitsHelper specialization inheritance NFC.

### DIFF
--- a/orc-rt/include/orc-rt/CallableTraitsHelper.h
+++ b/orc-rt/include/orc-rt/CallableTraitsHelper.h
@@ -39,22 +39,22 @@ struct CallableTraitsHelper<ImplT, RetT(ArgTs...)>
 template <template <typename...> typename ImplT, typename RetT,
           typename... ArgTs>
 struct CallableTraitsHelper<ImplT, RetT (*)(ArgTs...)>
-    : public CallableTraitsHelper<ImplT, RetT(ArgTs...)> {};
+    : public ImplT<RetT, ArgTs...> {};
 
 template <template <typename...> typename ImplT, typename RetT,
           typename... ArgTs>
 struct CallableTraitsHelper<ImplT, RetT (&)(ArgTs...)>
-    : public CallableTraitsHelper<ImplT, RetT(ArgTs...)> {};
+    : public ImplT<RetT, ArgTs...> {};
 
 template <template <typename...> typename ImplT, typename ClassT, typename RetT,
           typename... ArgTs>
 struct CallableTraitsHelper<ImplT, RetT (ClassT::*)(ArgTs...)>
-    : public CallableTraitsHelper<ImplT, RetT(ArgTs...)> {};
+    : public ImplT<RetT, ArgTs...> {};
 
 template <template <typename...> typename ImplT, typename ClassT, typename RetT,
           typename... ArgTs>
 struct CallableTraitsHelper<ImplT, RetT (ClassT::*)(ArgTs...) const>
-    : public CallableTraitsHelper<ImplT, RetT(ArgTs...)> {};
+    : public ImplT<RetT, ArgTs...> {};
 
 namespace detail {
 template <typename RetT, typename... ArgTs> struct CallableArgInfoImpl {


### PR DESCRIPTION
Make CallableTraitsHelper specializations inherit directly from ImplT. This is a no-op, but will simplify upcoming patches that will capture more information about the callable type.