### PR TITLE
[libc++] Fix behavior for `get_temporary_buffer` with non-positive size

### DIFF
--- a/libcxx/include/__memory/temporary_buffer.h
+++ b/libcxx/include/__memory/temporary_buffer.h
@@ -26,6 +26,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Tp>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_CFI _LIBCPP_DEPRECATED_IN_CXX17 pair<_Tp*, ptrdiff_t>
 get_temporary_buffer(ptrdiff_t __n) _NOEXCEPT {
+  if (__n <= 0)
+    return pair<_Tp*, ptrdiff_t>();
+
   __unique_temporary_buffer<_Tp> __unique_buf = std::__allocate_unique_temporary_buffer<_Tp>(__n);
   pair<_Tp*, ptrdiff_t> __result(__unique_buf.get(), __unique_buf.get_deleter().__count_);
   __unique_buf.release();

--- a/libcxx/test/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
+++ b/libcxx/test/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
@@ -38,5 +38,19 @@ int main(int, char**)
     assert(reinterpret_cast<std::uintptr_t>(ip.first) % alignof(A) == 0);
     std::return_temporary_buffer(ip.first);
 
+    // C++17 [depr.temporary.buffer]/4
+    // Returns: If n <= 0 or if no storage could be obtained,
+    // returns a pair P such that P.first is a null pointer value and P.second == 0;
+    {
+      std::pair<A*, std::ptrdiff_t> ret = std::get_temporary_buffer<A>(0);
+      assert(ret.first == NULL);
+      assert(ret.second == 0);
+    }
+    {
+      std::pair<A*, std::ptrdiff_t> ret = std::get_temporary_buffer<A>(-5);
+      assert(ret.first == NULL);
+      assert(ret.second == 0);
+    }
+
   return 0;
 }

--- a/libcxx/test/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
+++ b/libcxx/test/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <utility>
 
@@ -51,8 +52,8 @@ int main(int, char**)
     {
       TEST_DIAGNOSTIC_PUSH
       // This warning is coupled with completeness of control flow analysis which is affected by optimizations.
-      TEST_GCC_DIAGNOSTIC_IGNORED("-Wno-alloc-size-larger-than")
-      std::pair<A*, std::ptrdiff_t> ret = std::get_temporary_buffer<A>(-5);
+      TEST_GCC_DIAGNOSTIC_IGNORED("-Walloc-size-larger-than=")
+      std::pair<A*, std::ptrdiff_t> ret = std::get_temporary_buffer<A>(std::numeric_limits<std::ptrdiff_t>::min());
       TEST_DIAGNOSTIC_POP
       assert(ret.first == NULL);
       assert(ret.second == 0);

--- a/libcxx/test/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
+++ b/libcxx/test/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
@@ -29,9 +29,6 @@
 
 #include "test_macros.h"
 
-// This warning is coupled with completeness of control flow analysis which is affected by optimizations.
-TEST_GCC_DIAGNOSTIC_IGNORED("-Wno-alloc-size-larger-than")
-
 struct alignas(32) A {
     int field;
 };
@@ -52,7 +49,11 @@ int main(int, char**)
       assert(ret.second == 0);
     }
     {
+      TEST_DIAGNOSTIC_PUSH
+      // This warning is coupled with completeness of control flow analysis which is affected by optimizations.
+      TEST_GCC_DIAGNOSTIC_IGNORED("-Wno-alloc-size-larger-than")
       std::pair<A*, std::ptrdiff_t> ret = std::get_temporary_buffer<A>(-5);
+      TEST_DIAGNOSTIC_POP
       assert(ret.first == NULL);
       assert(ret.second == 0);
     }

--- a/libcxx/test/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
+++ b/libcxx/test/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
@@ -27,6 +27,11 @@
 #include <memory>
 #include <utility>
 
+#include "test_macros.h"
+
+// This warning is coupled with completeness of control flow analysis which is affected by optimizations.
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wno-alloc-size-larger-than")
+
 struct alignas(32) A {
     int field;
 };

--- a/libcxx/test/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
+++ b/libcxx/test/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
@@ -21,6 +21,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <utility>
 
@@ -44,8 +45,17 @@ int main(int, char**)
     {
       TEST_DIAGNOSTIC_PUSH
       // This warning is coupled with completeness of control flow analysis which is affected by optimizations.
-      TEST_GCC_DIAGNOSTIC_IGNORED("-Wno-alloc-size-larger-than")
+      TEST_GCC_DIAGNOSTIC_IGNORED("-Walloc-size-larger-than=")
       std::pair<int*, std::ptrdiff_t> ret = std::get_temporary_buffer<int>(-5);
+      TEST_DIAGNOSTIC_POP
+      assert(ret.first == NULL);
+      assert(ret.second == 0);
+    }
+    {
+      TEST_DIAGNOSTIC_PUSH
+      // This warning is coupled with completeness of control flow analysis which is affected by optimizations.
+      TEST_GCC_DIAGNOSTIC_IGNORED("-Walloc-size-larger-than=")
+      std::pair<int*, std::ptrdiff_t> ret = std::get_temporary_buffer<int>(std::numeric_limits<std::ptrdiff_t>::min());
       TEST_DIAGNOSTIC_POP
       assert(ret.first == NULL);
       assert(ret.second == 0);

--- a/libcxx/test/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
+++ b/libcxx/test/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
@@ -31,5 +31,19 @@ int main(int, char**)
     assert(ip.second == 5);
     std::return_temporary_buffer(ip.first);
 
+    // C++17 [depr.temporary.buffer]/4
+    // Returns: If n <= 0 or if no storage could be obtained,
+    // returns a pair P such that P.first is a null pointer value and P.second == 0;
+    {
+      std::pair<int*, std::ptrdiff_t> ret = std::get_temporary_buffer<int>(0);
+      assert(ret.first == NULL);
+      assert(ret.second == 0);
+    }
+    {
+      std::pair<int*, std::ptrdiff_t> ret = std::get_temporary_buffer<int>(-5);
+      assert(ret.first == NULL);
+      assert(ret.second == 0);
+    }
+
   return 0;
 }

--- a/libcxx/test/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
+++ b/libcxx/test/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
@@ -24,6 +24,11 @@
 #include <memory>
 #include <utility>
 
+#include "test_macros.h"
+
+// This warning is coupled with completeness of control flow analysis which is affected by optimizations.
+TEST_GCC_DIAGNOSTIC_IGNORED("-Wno-alloc-size-larger-than")
+
 int main(int, char**)
 {
     std::pair<int*, std::ptrdiff_t> ip = std::get_temporary_buffer<int>(5);

--- a/libcxx/test/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
+++ b/libcxx/test/std/utilities/memory/temporary.buffer/temporary_buffer.pass.cpp
@@ -26,9 +26,6 @@
 
 #include "test_macros.h"
 
-// This warning is coupled with completeness of control flow analysis which is affected by optimizations.
-TEST_GCC_DIAGNOSTIC_IGNORED("-Wno-alloc-size-larger-than")
-
 int main(int, char**)
 {
     std::pair<int*, std::ptrdiff_t> ip = std::get_temporary_buffer<int>(5);
@@ -45,7 +42,11 @@ int main(int, char**)
       assert(ret.second == 0);
     }
     {
+      TEST_DIAGNOSTIC_PUSH
+      // This warning is coupled with completeness of control flow analysis which is affected by optimizations.
+      TEST_GCC_DIAGNOSTIC_IGNORED("-Wno-alloc-size-larger-than")
       std::pair<int*, std::ptrdiff_t> ret = std::get_temporary_buffer<int>(-5);
+      TEST_DIAGNOSTIC_POP
       assert(ret.first == NULL);
       assert(ret.second == 0);
     }


### PR DESCRIPTION
Per C++17 [depr.temporary.buffer]/4, `get_temporary_buffer` is required to return `{nullptr, 0}` when the size argument is zero or negative. libc++ used to correctly handle this, but the refactoring in 94e7c0b051c79fd56205f115771980f2e7812306 got this wrong.

GCC generally warns on negative size due to `-Walloc-size-larger-than=`, which is false positive due to incomplete control flow analysis. The warning is coupled with optimizations, and this patch make tests suppress it instead.

Fixes #204082.