### PR TITLE
[X86] Verify inline-asm register operands against the subtarget

### DIFF
--- a/llvm/lib/Target/X86/X86TargetVerifier.cpp
+++ b/llvm/lib/Target/X86/X86TargetVerifier.cpp
@@ -23,6 +23,7 @@
 #include "X86.h"
 
 #include "llvm/IR/Function.h"
+#include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Module.h"
@@ -86,6 +87,18 @@ static const struct {
     {"llvm.x86.avx.", X86::FeatureAVX, "AVX"},
 };
 
+/// \returns true if the inline-asm constraint string \p C names an AVX-512
+/// mask register, i.e. a "{k0}"..."{k7}" token.
+static bool referencesMaskReg(StringRef C) {
+  for (size_t Pos = C.find("{k"); Pos != StringRef::npos;
+       Pos = C.find("{k", Pos + 2)) {
+    if (Pos + 3 < C.size() && C[Pos + 2] >= '0' && C[Pos + 2] <= '7' &&
+        C[Pos + 3] == '}')
+      return true;
+  }
+  return false;
+}
+
 void X86TargetVerify::verifyFunctionChecks(Function &F,
                                            const MCSubtargetInfo &STI) {
   bool HasAMXTILE = STI.hasFeature(X86::FeatureAMXTILE);
@@ -122,6 +135,26 @@ void X86TargetVerify::verifyFunctionChecks(Function &F,
       Check(HasAMXTILE,
             "x86_amx type used, but the subtarget does not support AMX-TILE.",
             &I);
+
+    // Inline asm may name physical registers (in clobbers or register
+    // constraints) that only exist on subtargets with a given feature. zmm and
+    // mask (k) registers require AVX-512; ymm registers require AVX.
+    if (const auto *CB = dyn_cast<CallBase>(&I)) {
+      if (CB->isInlineAsm()) {
+        StringRef Constraints =
+            cast<InlineAsm>(CB->getCalledOperand())->getConstraintString();
+        if (Constraints.contains("zmm") || referencesMaskReg(Constraints))
+          Check(STI.hasFeature(X86::FeatureAVX512),
+                "inline asm references an AVX-512 register (zmm/k), but the "
+                "subtarget does not support AVX-512.",
+                &I);
+        if (Constraints.contains("ymm"))
+          Check(STI.hasFeature(X86::FeatureAVX),
+                "inline asm references an AVX register (ymm), but the "
+                "subtarget does not support AVX.",
+                &I);
+      }
+    }
   }
 }
 

--- a/llvm/test/Verifier/X86/inline-asm-registers.ll
+++ b/llvm/test/Verifier/X86/inline-asm-registers.ll
@@ -1,0 +1,27 @@
+; The X86 target verifier flags inline asm that names a physical register only
+; available on a subtarget with a feature the selected subtarget lacks.
+;
+; RUN: opt -passes=target-verifier -disable-output %s 2>&1 | FileCheck %s
+
+target triple = "x86_64-unknown-linux-gnu"
+
+; Clobbering a zmm register requires AVX-512 (default x86_64 is SSE2-level).
+; CHECK: inline asm references an AVX-512 register (zmm/k), but the subtarget does not support AVX-512.
+define void @asm_zmm_without_avx512() {
+  call void asm sideeffect "", "~{zmm16}"()
+  ret void
+}
+
+; Clobbering a mask register (k1) likewise requires AVX-512.
+; CHECK: inline asm references an AVX-512 register (zmm/k), but the subtarget does not support AVX-512.
+define void @asm_mask_without_avx512() {
+  call void asm sideeffect "", "~{k1}"()
+  ret void
+}
+
+; Clobbering a ymm register requires AVX.
+; CHECK: inline asm references an AVX register (ymm), but the subtarget does not support AVX.
+define void @asm_ymm_without_avx() {
+  call void asm sideeffect "", "~{ymm0}"()
+  ret void
+}


### PR DESCRIPTION
Inline asm can name physical registers that require a subtarget feature
the selected subtarget lacks: zmm and mask (k) registers need AVX-512,
ymm registers need AVX. The subtarget is derived from the function's
target-cpu/target-features, so no MachineFunction is required.
