### PR TITLE
[modules][test] Loosen size check in embed-files-compressed.cpp

### DIFF
--- a/clang/test/Modules/embed-files-compressed.cpp
+++ b/clang/test/Modules/embed-files-compressed.cpp
@@ -16,7 +16,8 @@
 // RUN: %clang_cc1 -fmodules -I%t -fmodules-cache-path=%t -fmodule-name=a -emit-module %t/modulemap -fmodules-embed-all-files -o %t/a.pcm
 //
 // The above embeds ~4.5MB of highly-predictable /s and \ns into the pcm file.
-// Check that the resulting file is under 80KB:
+// Check that the resulting file is under 100KB (zlib-ng compresses a bit
+// worse than zlib):
 //
 // RUN: wc -c %t/a.pcm | FileCheck --check-prefix=CHECK-SIZE %s
-// CHECK-SIZE: {{(^|[^0-9])[1-7][0-9][0-9][0-9][0-9]($|[^0-9])}}
+// CHECK-SIZE: {{(^|[^0-9])[1-9][0-9][0-9][0-9][0-9]($|[^0-9])}}


### PR DESCRIPTION
zlib-ng compresses the repetitive input slightly worse than zlib (~84KB vs ~67KB), exceeding the 80KB bound. Raise it to 100KB.

Assisted-by: claude-opus