### PR TITLE
[lld][ELF][test] Accept zlib-ng compressed size

### DIFF
--- a/lld/test/ELF/compressed-debug-level.test
+++ b/lld/test/ELF/compressed-debug-level.test
@@ -18,7 +18,7 @@
 # RUN: llvm-readelf --sections %t.6 | FileCheck -check-prefixes=HEADER,LEVEL6 %s
 
 # HEADER: [Nr] Name        Type     Address  Off    Size
-# LEVEL1: [ 1] .debug_info PROGBITS 00000000 000094 0000{{1[cdef]|21}}
+# LEVEL1: [ 1] .debug_info PROGBITS 00000000 000094 0000{{1[cdef]|2[01]}}
 # LEVEL6: [ 1] .debug_info PROGBITS 00000000 000094 00001{{[abc]}}
 
 ## A little arbitrary debug section which has a different size after


### PR DESCRIPTION
zlib-ng 2.3.2 deflates slightly differently from zlib; the level-1 default is 0x20, just outside the LEVEL1 pattern. Widen it to accept 0x20.

Assisted-by: claude-opus