### PR TITLE
[orc-rt] CallableTraitsHelper - record call operator's const-qualifier

### DIFF
--- a/orc-rt/include/orc-rt/CallableTraitsHelper.h
+++ b/orc-rt/include/orc-rt/CallableTraitsHelper.h
@@ -24,39 +24,48 @@ namespace orc_rt {
 ///
 /// This can be used to simplify the implementation of classes that need to
 /// operate on callable types.
-template <template <typename...> typename ImplT, typename C>
+template <template <bool /* is_const */, typename...> typename ImplT,
+          typename C>
 struct CallableTraitsHelper
     : CallableTraitsHelper<
           ImplT,
           decltype(&std::remove_cv_t<std::remove_reference_t<C>>::operator())> {
 };
 
-template <template <typename...> typename ImplT, typename RetT,
-          typename... ArgTs>
-struct CallableTraitsHelper<ImplT, RetT(ArgTs...)> : ImplT<RetT, ArgTs...> {};
+template <template <bool /* is_const */, typename...> typename ImplT,
+          typename RetT, typename... ArgTs>
+struct CallableTraitsHelper<ImplT, RetT(ArgTs...)>
+    : ImplT</* is_const = */ false, RetT, ArgTs...> {};
 
-template <template <typename...> typename ImplT, typename RetT,
-          typename... ArgTs>
-struct CallableTraitsHelper<ImplT, RetT (*)(ArgTs...)> : ImplT<RetT, ArgTs...> {
-};
+template <template <bool /* is_const */, typename...> typename ImplT,
+          typename RetT, typename... ArgTs>
+struct CallableTraitsHelper<ImplT, RetT(ArgTs...) const>
+    : ImplT</* is_const = */ true, RetT, ArgTs...> {};
 
-template <template <typename...> typename ImplT, typename RetT,
-          typename... ArgTs>
-struct CallableTraitsHelper<ImplT, RetT (&)(ArgTs...)> : ImplT<RetT, ArgTs...> {
-};
+template <template <bool /* is_const */, typename...> typename ImplT,
+          typename RetT, typename... ArgTs>
+struct CallableTraitsHelper<ImplT, RetT (*)(ArgTs...)>
+    : ImplT</* is_const = */ false, RetT, ArgTs...> {};
 
-template <template <typename...> typename ImplT, typename ClassT, typename RetT,
-          typename... ArgTs>
+template <template <bool /* is_const */, typename...> typename ImplT,
+          typename RetT, typename... ArgTs>
+struct CallableTraitsHelper<ImplT, RetT (&)(ArgTs...)>
+    : ImplT</* is_const = */ false, RetT, ArgTs...> {};
+
+template <template <bool /* is_const */, typename...> typename ImplT,
+          typename ClassT, typename RetT, typename... ArgTs>
 struct CallableTraitsHelper<ImplT, RetT (ClassT::*)(ArgTs...)>
-    : ImplT<RetT, ArgTs...> {};
+    : ImplT</* is_const = */ false, RetT, ArgTs...> {};
 
-template <template <typename...> typename ImplT, typename ClassT, typename RetT,
-          typename... ArgTs>
+template <template <bool /* is_const */, typename...> typename ImplT,
+          typename ClassT, typename RetT, typename... ArgTs>
 struct CallableTraitsHelper<ImplT, RetT (ClassT::*)(ArgTs...) const>
-    : ImplT<RetT, ArgTs...> {};
+    : ImplT</* is_const = */ true, RetT, ArgTs...> {};
 
 namespace detail {
-template <typename RetT, typename... ArgTs> struct CallableArgInfoImpl {
+template <bool IsConst, typename RetT, typename... ArgTs>
+struct CallableArgInfoImpl {
+  static constexpr bool is_const = IsConst;
   typedef RetT return_type;
   typedef std::tuple<ArgTs...> args_tuple_type;
 };

--- a/orc-rt/include/orc-rt/Error.h
+++ b/orc-rt/include/orc-rt/Error.h
@@ -283,11 +283,14 @@ struct ErrorHandlerTraitsImpl<void, std::unique_ptr<ErrT>> {
   }
 };
 
+template <bool /* const */, typename RetT, typename ArgT>
+struct ErrorHandlerTraitsImplAdapter : ErrorHandlerTraitsImpl<RetT, ArgT> {};
+
 } // namespace detail.
 
 template <typename C>
 struct ErrorHandlerTraits
-    : public CallableTraitsHelper<detail::ErrorHandlerTraitsImpl, C> {};
+    : public CallableTraitsHelper<detail::ErrorHandlerTraitsImplAdapter, C> {};
 
 inline Error handleErrorsImpl(std::unique_ptr<ErrorInfoBase> Payload) {
   return make_error(std::move(Payload));
@@ -649,9 +652,12 @@ template <> struct ErrorWrapImpl<void> {
   }
 };
 
+template <bool /* const */, typename RetT>
+struct ErrorWrapImplAdapter : ErrorWrapImpl<RetT> {};
+
 template <typename Callable>
 struct ErrorWrap
-    : public CallableTraitsHelper<detail::ErrorWrapImpl, Callable> {};
+    : public CallableTraitsHelper<detail::ErrorWrapImplAdapter, Callable> {};
 
 } // namespace detail
 

--- a/orc-rt/include/orc-rt/WrapperFunction.h
+++ b/orc-rt/include/orc-rt/WrapperFunction.h
@@ -135,8 +135,11 @@ struct WFHandlerTraitsImpl {
   }
 };
 
+template <bool /* is_const */, typename... Ts>
+struct WFHandlerTraitsImplAdapter : WFHandlerTraitsImpl<Ts...> {};
+
 template <typename C>
-using WFHandlerTraits = CallableTraitsHelper<WFHandlerTraitsImpl, C>;
+using WFHandlerTraits = CallableTraitsHelper<WFHandlerTraitsImplAdapter, C>;
 
 template <typename Serializer> class StructuredYieldBase {
 public:

--- a/orc-rt/unittests/CallableTraitsHelperTest.cpp
+++ b/orc-rt/unittests/CallableTraitsHelperTest.cpp
@@ -67,3 +67,66 @@ TEST(CallableTraitsHelperTest, PreservesRValueRef) {
   typedef CallableArgInfo<decltype(RefOp)> CAI;
   static_assert(std::is_same_v<CAI::args_tuple_type, std::tuple<int &&>>);
 }
+
+// Free functions cannot be const-qualified.
+TEST(CallableTraitsHelperTest, FreeFunctionIsNonConst) {
+  static_assert(!CallableArgInfo<decltype(freeVoidVoid)>::is_const);
+  static_assert(!CallableArgInfo<decltype(freeBinaryOp)>::is_const);
+}
+
+TEST(CallableTraitsHelperTest, FunctionPointerIsNonConst) {
+  static_assert(!CallableArgInfo<int (*)(int, float)>::is_const);
+}
+
+TEST(CallableTraitsHelperTest, FunctionReferenceIsNonConst) {
+  static_assert(!CallableArgInfo<int (&)(int, float)>::is_const);
+}
+
+// A non-mutable lambda's call operator is const-qualified.
+TEST(CallableTraitsHelperTest, NonMutableLambdaIsConst) {
+  auto L = []() {};
+  static_assert(CallableArgInfo<decltype(L)>::is_const);
+}
+
+// A mutable lambda's call operator is not const-qualified.
+TEST(CallableTraitsHelperTest, MutableLambdaIsNonConst) {
+  auto L = []() mutable {};
+  static_assert(!CallableArgInfo<decltype(L)>::is_const);
+}
+
+TEST(CallableTraitsHelperTest, ConstFunctorIsConst) {
+  struct F {
+    void operator()() const {}
+  };
+  static_assert(CallableArgInfo<F>::is_const);
+}
+
+TEST(CallableTraitsHelperTest, NonConstFunctorIsNonConst) {
+  struct F {
+    void operator()() {}
+  };
+  static_assert(!CallableArgInfo<F>::is_const);
+}
+
+TEST(CallableTraitsHelperTest, NonConstMemberFnPtrIsNonConst) {
+  struct C {
+    void m(int) {}
+  };
+  static_assert(!CallableArgInfo<decltype(&C::m)>::is_const);
+}
+
+TEST(CallableTraitsHelperTest, ConstMemberFnPtrIsConst) {
+  struct C {
+    void m(int) const {}
+  };
+  static_assert(CallableArgInfo<decltype(&C::m)>::is_const);
+}
+
+TEST(CallableTraitsHelperTest, FunctionTypeIsNonConst) {
+  static_assert(!CallableArgInfo<int(int, float)>::is_const);
+}
+
+// Abominable function type: const cv-qualifier on the function type itself.
+TEST(CallableTraitsHelperTest, AbominableFunctionTypeIsConst) {
+  static_assert(CallableArgInfo<int(int, float) const>::is_const);
+}


### PR DESCRIPTION
Adds a leading `bool IsConst` template parameter to CallableTraitsHelper's impl-class template argument to record the const-qualifier on the callable's function type.

Existing specializations are updated to report their const qualifiers, and a new specialization handles `RetT(ArgTs...) const`.

CallableArgInfo is updated to expose the captured bool as `static constexpr bool is_const`.

Existing impls that do not consume the new parameter are adapted via pass-through wrappers (ErrorHandlerTraitsImplAdapter, ErrorWrapImplAdapter, WFHandlerTraitsImplAdapter) that discard the leading bool.