### PR TITLE
[NFC][LLVM][Verifier] Eliminate redundant checks for GC intrinsics

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3267,25 +3267,10 @@ void Verifier::visitFunction(const Function &F) {
   }
 
   // Check intrinsics' signatures.
-  switch (IID) {
-  case Intrinsic::experimental_gc_get_pointer_base: {
+  if (IID == Intrinsic::experimental_gc_get_pointer_base) {
     FunctionType *FT = F.getFunctionType();
-    Check(FT->getNumParams() == 1, "wrong number of parameters", F);
-    Check(isa<PointerType>(F.getReturnType()),
-          "gc.get.pointer.base must return a pointer", F);
     Check(FT->getParamType(0) == F.getReturnType(),
           "gc.get.pointer.base operand and result must be of the same type", F);
-    break;
-  }
-  case Intrinsic::experimental_gc_get_pointer_offset: {
-    FunctionType *FT = F.getFunctionType();
-    Check(FT->getNumParams() == 1, "wrong number of parameters", F);
-    Check(isa<PointerType>(FT->getParamType(0)),
-          "gc.get.pointer.offset operand must be a pointer", F);
-    Check(F.getReturnType()->isIntegerTy(),
-          "gc.get.pointer.offset must return integer", F);
-    break;
-  }
   }
 
   auto *N = F.getSubprogram();

--- a/llvm/test/Verifier/intrinsic-bad-arg-type1.ll
+++ b/llvm/test/Verifier/intrinsic-bad-arg-type1.ll
@@ -162,6 +162,29 @@ declare <4 x double> @llvm.aarch64.sve.sdot.v4f64(<4 x double>, <16 x half>, flo
 ; type signature = [llvm_anyvector_ty], [LLVMMatchType<0>, LLVMMatchType<0>, LLVMVectorOfBitcastsToInt<0>, llvm_anyint_ty]
 declare <4 x float> @llvm.riscv.vrgather.vv.v4f32.i32(<4 x float>, <4 x float>, i32, i32)
 
+; CHECK: intrinsic has incorrect number of args. Expected 1, but got 2
+; CHECK-NEXT: declare i64 @llvm.experimental.gc.get.pointer.offset.p0p0(ptr, ptr)
+declare i64 @llvm.experimental.gc.get.pointer.offset.p0p0(ptr, ptr)
+
+; CHECK: intrinsic return type expected i64, but got i32
+; CHECK-NEXT: declare i32 @llvm.experimental.gc.get.pointer.offset.p0(ptr)
+declare i32 @llvm.experimental.gc.get.pointer.offset.p0(ptr)
+
+; CHECK:intrinsic argument 0 type (overload type 0) expected any pointer type, but got i32
+; CHECK-NEXT: declare i64 @llvm.experimental.gc.get.pointer.offset.i32(i32)
+declare i64 @llvm.experimental.gc.get.pointer.offset.i32(i32)
+
+; CHECK: intrinsic has incorrect number of args. Expected 1, but got 2
+; CHECK-NEXT: declare ptr @llvm.experimental.gc.get.pointer.base.p0p0(ptr, ptr)
+declare ptr @llvm.experimental.gc.get.pointer.base.p0p0(ptr, ptr)
+
+; CHECK: intrinsic return type (overload type 0) expected any pointer type, but got i32
+; CHECK-NEXT: declare i32 @llvm.experimental.gc.get.pointer.base.i32.p0(ptr)
+declare i32 @llvm.experimental.gc.get.pointer.base.i32.p0(ptr)
+
+; CHECK: gc.get.pointer.base operand and result must be of the same type
+; CHECK-NEXT: ptr @llvm.experimental.gc.get.pointer.base.p0.p1
+declare ptr @llvm.experimental.gc.get.pointer.base.p0.p1(ptr addrspace(1))
 
 ;--- test1.ll
 ; RUN: not opt -S -passes=verify -disable-output 2>&1 < %t/test1.ll | FileCheck %t/test1.ll


### PR DESCRIPTION
Remove verifier checks for `experimental.gc.get.pointer.offset` and `experimental.gc.get.pointer.base` intrinsics as they are covered by the generic intrinsic signature verification.