### PR TITLE
[orc-rt] Silence an unneeded-internal-decl warning in testcase.

### DIFF
--- a/orc-rt/unittests/CallableTraitsHelperTest.cpp
+++ b/orc-rt/unittests/CallableTraitsHelperTest.cpp
@@ -136,6 +136,7 @@ TEST(CallableTraitsHelperTest, AbominableFunctionTypeIsConst) {
 static void freeVoidVoidNoexcept() noexcept {}
 
 TEST(CallableTraitsHelperTest, FreeFunctionNoexcept) {
+  (void)freeVoidVoidNoexcept;
   static_assert(!CallableArgInfo<decltype(freeVoidVoid)>::is_noexcept);
   static_assert(CallableArgInfo<decltype(freeVoidVoidNoexcept)>::is_noexcept);
 }


### PR DESCRIPTION
Add an ODR-use of freeVoidVoidNoexcept to silence clang's -Wunneeded-internal-declaration warning.