### PR TITLE
[Darwin] Use macOS product version in ensureTargetInitialized

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1223,6 +1223,10 @@ void Darwin::ensureTargetInitialized() const {
   setTarget(Platform, Environment, OsVer.getMajor(),
             OsVer.getMinor().value_or(0), OsVer.getSubminor().value_or(0),
             VersionTuple());
+  // The version above is a guess from the triple alone; AddDeploymentTarget()
+  // may later derive a different deployment target from flags, environment
+  // variables, or the SDK, and overwrite this initialization.
+  TargetInitializedLazily = true;
 }
 
 AppleMachO::~AppleMachO() {}

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1210,7 +1210,16 @@ void Darwin::ensureTargetInitialized() const {
   else if (getTriple().isMacCatalystEnvironment())
     Environment = MacCatalyst;
 
-  VersionTuple OsVer = getTriple().getOSVersion();
+  VersionTuple OsVer;
+  if (Platform == MacOS) {
+    // Record the macOS product version (e.g. macosx15), not the Darwin kernel
+    // version (e.g. darwin24.3): version checks against the lazily-recorded
+    // target must behave as if AddDeploymentTarget() had computed it.
+    if (!getTriple().getMacOSXVersion(OsVer))
+      return;
+  } else {
+    OsVer = getTriple().getOSVersion();
+  }
   setTarget(Platform, Environment, OsVer.getMajor(),
             OsVer.getMinor().value_or(0), OsVer.getSubminor().value_or(0),
             VersionTuple());

--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -355,6 +355,11 @@ public:
   // the argument translation business.
   mutable bool TargetInitialized;
 
+  /// Whether the target was lazily initialized from the triple by
+  /// ensureTargetInitialized() rather than by AddDeploymentTarget(). Such a
+  /// target is a best-effort guess that setTarget() may overwrite.
+  mutable bool TargetInitializedLazily = false;
+
   // TODO: Are these useful? Can we use Triple::OSType/EnvironmentType instead?
   enum DarwinPlatformKind {
     MacOS,
@@ -447,10 +452,17 @@ protected:
     if (TargetInitialized && TargetPlatform == Platform &&
         TargetEnvironment == Environment &&
         (Environment == MacCatalyst ? OSTargetVersion : TargetVersion) ==
-            VersionTuple(Major, Minor, Micro))
+            VersionTuple(Major, Minor, Micro)) {
+      TargetInitializedLazily = false;
       return;
+    }
 
-    assert(!TargetInitialized && "Target already initialized!");
+    // A lazily-initialized target (see ensureTargetInitialized()) is a
+    // best-effort guess from the triple alone; the authoritative
+    // initialization from AddDeploymentTarget() may overwrite it.
+    assert((!TargetInitialized || TargetInitializedLazily) &&
+           "Target already initialized!");
+    TargetInitializedLazily = false;
     TargetInitialized = true;
     TargetPlatform = Platform;
     TargetEnvironment = Environment;

--- a/clang/test/Driver/darwin-hip-spirv-version.hip
+++ b/clang/test/Driver/darwin-hip-spirv-version.hip
@@ -1,0 +1,33 @@
+// The HIP-SPIR-V offload path lazily initializes the Darwin host target from
+// the triple (ensureTargetInitialized) before AddDeploymentTarget() computes
+// the authoritative deployment target; a disagreement between the two used to
+// trip setTarget()'s "Target already initialized!" assertion.
+
+// REQUIRES: spirv-registered-target
+// UNSUPPORTED: system-windows, system-cygwin
+
+// A Darwin *kernel* version in the triple (darwin24.3.0) is recorded as the
+// macOS *product* version (macosx15) and the driver does not crash.
+// RUN: %clang -### -x hip --offload=spirv64 --target=arm64-apple-darwin24.3.0 \
+// RUN:   -nogpulib -nogpuinc %s 2>&1 | FileCheck %s
+// CHECK: "-triple" "arm64-apple-macosx15{{[0-9.]*}}"
+// CHECK-NOT: "-triple" "arm64-apple-darwin
+
+// A deployment target from the environment overrides the lazily-recorded
+// triple version instead of asserting.
+// RUN: env MACOSX_DEPLOYMENT_TARGET=14.0 %clang -### -x hip \
+// RUN:   --offload=spirv64 --target=arm64-apple-darwin24.3.0 \
+// RUN:   -nogpulib -nogpuinc %s 2>&1 | FileCheck --check-prefix=DEPLOY %s
+// DEPLOY: "-triple" "arm64-apple-macosx14.0.0"
+
+// Same for -mmacosx-version-min.
+// RUN: %clang -### -x hip --offload=spirv64 --target=arm64-apple-darwin24.3.0 \
+// RUN:   -mmacosx-version-min=14.0 -nogpulib -nogpuinc %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=VERMIN %s
+// VERMIN: "-triple" "arm64-apple-macosx14.0.0"
+
+// An unversioned triple must not crash either; the version is inferred (and
+// on a macOS host may differ from the lazily-recorded default).
+// RUN: %clang -### -x hip --offload=spirv64 --target=arm64-apple-darwin \
+// RUN:   -nogpulib -nogpuinc %s 2>&1 | FileCheck --check-prefix=NOVER %s
+// NOVER: "-triple" "arm64-apple-macosx{{[0-9.]+}}"


### PR DESCRIPTION
`Darwin::ensureTargetInitialized()` recorded the raw triple OS version from `getOSVersion()`, which on macOS is the Darwin *kernel* version (e.g. `24.3.0`), not the macOS *product* version (`15.x`). The offload host job later calls `setTarget()` again from `AddDeploymentTarget()` with the product version; `setTarget()`'s reinit guard only short-circuits when the versions match, so the mismatch trips `assert(!TargetInitialized && "Target already initialized!")` and clang aborts on every `-x hip --offload=spirv64* --target=arm64-apple-darwin` compile.

Convert macOS kernel versions via `getMacOSXVersion()` so the lazy init records the same version `AddDeploymentTarget()` uses later.