### PR TITLE
[orc-rt] Rewrite move_only_function in terms of CallableTraitsHelper.

### DIFF
--- a/orc-rt/include/orc-rt/move_only_function.h
+++ b/orc-rt/include/orc-rt/move_only_function.h
@@ -6,8 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 ///
-/// A substitute for std::move_only_function that can be used until the ORC
-/// runtime is allowed to assume c++-23.
+/// Provides orc_rt::move_only_function, a substitute for
+/// std::move_only_function usable prior to C++23. See the
+/// move_only_function class documentation for supported signatures and
+/// semantics.
 ///
 /// TODO: Replace all uses with std::move_only_function once we can assume
 ///       c++-23.
@@ -25,6 +27,8 @@
 #ifndef ORC_RT_MOVE_ONLY_FUNCTION_H
 #define ORC_RT_MOVE_ONLY_FUNCTION_H
 
+#include "orc-rt/CallableTraitsHelper.h"
+
 #include <memory>
 #include <type_traits>
 
@@ -32,19 +36,48 @@ namespace orc_rt {
 
 namespace move_only_function_detail {
 
-template <typename RetT, typename... ArgTs> class GenericCallable {
+/// Type-erased call interface. Two partial specializations on IsConst
+/// select a const or non-const virtual call operator, so an
+/// InvocableStorage's operator() can dispatch through the vtable with
+/// the correct cv-qualifier.
+template <bool IsConst, bool IsNoexcept, typename RetT, typename... ArgTs>
+class Callable;
+
+template <bool IsNoexcept, typename RetT, typename... ArgTs>
+class Callable<false, IsNoexcept, RetT, ArgTs...> {
 public:
-  virtual ~GenericCallable() = default;
-  virtual RetT call(ArgTs &&...Args) = 0;
+  virtual ~Callable() = default;
+  virtual RetT call(ArgTs &&...Args) noexcept(IsNoexcept) = 0;
 };
 
-template <typename CallableT, typename RetT, typename... ArgTs>
-class GenericCallableImpl : public GenericCallable<RetT, ArgTs...> {
+template <bool IsNoexcept, typename RetT, typename... ArgTs>
+class Callable<true, IsNoexcept, RetT, ArgTs...> {
+public:
+  virtual ~Callable() = default;
+  virtual RetT call(ArgTs &&...Args) const noexcept(IsNoexcept) = 0;
+};
+
+/// Concrete Callable holding a callable object and forwarding
+/// invocations to it. The templated constructor static-asserts that the
+/// stored callable is nothrow-invocable when IsNoexcept is true.
+template <typename CallableT, bool IsConst, bool IsNoexcept, typename RetT,
+          typename... ArgTs>
+class CallableImpl;
+
+template <typename CallableT, bool IsNoexcept, typename RetT, typename... ArgTs>
+class CallableImpl<CallableT, false, IsNoexcept, RetT, ArgTs...>
+    : public Callable<false, IsNoexcept, RetT, ArgTs...> {
 public:
   template <typename CallableInitT>
-  GenericCallableImpl(CallableInitT &&Callable)
-      : Callable(std::forward<CallableInitT>(Callable)) {}
-  RetT call(ArgTs &&...Args) override {
+  CallableImpl(CallableInitT &&Callable)
+      : Callable(std::forward<CallableInitT>(Callable)) {
+    static_assert(
+        !IsNoexcept ||
+            std::is_nothrow_invocable_r_v<RetT, CallableT &, ArgTs...>,
+        "Callable stored in a noexcept-qualified move_only_function must be "
+        "nothrow-invocable.");
+  }
+  RetT call(ArgTs &&...Args) noexcept(IsNoexcept) override {
     return Callable(std::forward<ArgTs>(Args)...);
   }
 
@@ -52,39 +85,93 @@ private:
   CallableT Callable;
 };
 
-template <typename RetT, typename... ArgTs> class GenericConstCallable {
-public:
-  virtual ~GenericConstCallable() = default;
-  virtual RetT call(ArgTs &&...Args) const = 0;
-};
-
-template <typename CallableT, typename RetT, typename... ArgTs>
-class GenericConstCallableImpl : public GenericConstCallable<RetT, ArgTs...> {
+template <typename CallableT, bool IsNoexcept, typename RetT, typename... ArgTs>
+class CallableImpl<CallableT, true, IsNoexcept, RetT, ArgTs...>
+    : public Callable<true, IsNoexcept, RetT, ArgTs...> {
 public:
   template <typename CallableInitT>
-  GenericConstCallableImpl(CallableInitT &&Callable)
-      : Callable(std::forward<CallableInitT>(Callable)) {}
-  RetT call(ArgTs &&...Args) const override {
+  CallableImpl(CallableInitT &&Callable)
+      : Callable(std::forward<CallableInitT>(Callable)) {
+    static_assert(
+        !IsNoexcept ||
+            std::is_nothrow_invocable_r_v<RetT, const CallableT &, ArgTs...>,
+        "Callable stored in a const noexcept-qualified move_only_function "
+        "must be nothrow-invocable.");
+  }
+  RetT call(ArgTs &&...Args) const noexcept(IsNoexcept) override {
     return Callable(std::forward<ArgTs>(Args)...);
   }
 
 private:
   CallableT Callable;
 };
+
+/// Owns the type-erased Callable pointer and exposes state-only ops
+/// (operator bool). Shared base for both InvocableStorage specializations.
+template <bool IsConst, bool IsNoexcept, typename RetT, typename... ArgTs>
+class Storage {
+protected:
+  template <typename CallableT>
+  using WrappedCallable =
+      CallableImpl<CallableT, IsConst, IsNoexcept, RetT, ArgTs...>;
+
+  std::unique_ptr<Callable<IsConst, IsNoexcept, RetT, ArgTs...>> C;
+
+public:
+  explicit operator bool() const noexcept { return !!C; }
+};
+
+/// Extends Storage with an operator() qualified per IsConst and
+/// IsNoexcept. Two specializations on IsConst yield either a non-const
+/// or const operator().
+template <bool IsConst, bool IsNoexcept, typename RetT, typename... ArgTs>
+class InvocableStorage;
+
+template <bool IsNoexcept, typename RetT, typename... ArgTs>
+class InvocableStorage<false, IsNoexcept, RetT, ArgTs...>
+    : public Storage<false, IsNoexcept, RetT, ArgTs...> {
+public:
+  RetT operator()(ArgTs... Params) noexcept(IsNoexcept) {
+    return this->C->call(std::forward<ArgTs>(Params)...);
+  }
+};
+
+template <bool IsNoexcept, typename RetT, typename... ArgTs>
+class InvocableStorage<true, IsNoexcept, RetT, ArgTs...>
+    : public Storage<true, IsNoexcept, RetT, ArgTs...> {
+public:
+  RetT operator()(ArgTs... Params) const noexcept(IsNoexcept) {
+    return this->C->call(std::forward<ArgTs>(Params)...);
+  }
+};
+
+/// Applies CallableTraitsHelper to a signature FnT to decompose it into
+/// (IsConst, IsNoexcept, RetT, ArgTs...) and expose the resulting
+/// InvocableStorage as the base of move_only_function.
+template <typename FnT>
+class MOFBase : public CallableTraitsHelper<InvocableStorage, FnT> {};
 
 } // namespace move_only_function_detail
 
-template <typename FnT> class move_only_function;
-
-template <typename RetT, typename... ArgTs>
-class move_only_function<RetT(ArgTs...)> {
-private:
-  using GenericCallable =
-      move_only_function_detail::GenericCallable<RetT, ArgTs...>;
-  template <typename CallableT>
-  using GenericCallableImpl =
-      move_only_function_detail::GenericCallableImpl<CallableT, RetT, ArgTs...>;
-
+/// A move-only, type-erasing wrapper for a callable. Mirrors C++23's
+/// std::move_only_function.
+///
+/// The template argument FnT is a function type that may carry the const
+/// and/or noexcept cv-qualifiers:
+///
+///     R(A...)                - mutable, may throw
+///     R(A...) const          - const-callable, may throw
+///     R(A...) noexcept       - mutable, guaranteed nothrow
+///     R(A...) const noexcept - const-callable, guaranteed nothrow
+///
+/// operator()'s const and noexcept qualifiers are derived from the
+/// signature; constructing a noexcept-qualified move_only_function from a
+/// throwing callable is rejected at compile time (via a static_assert on
+/// nothrow-invocability), and constructing a const-qualified
+/// move_only_function from a mutable callable is rejected at compile time
+/// (via the const-qualified call to the stored callable).
+template <typename FnT>
+class move_only_function : public move_only_function_detail::MOFBase<FnT> {
 public:
   move_only_function() = default;
   move_only_function(std::nullptr_t) {}
@@ -93,52 +180,11 @@ public:
   move_only_function &operator=(move_only_function &&) = default;
   move_only_function &operator=(const move_only_function &) = delete;
 
-  template <typename CallableT>
-  move_only_function(CallableT &&Callable)
-      : C(std::make_unique<GenericCallableImpl<std::decay_t<CallableT>>>(
-            std::forward<CallableT>(Callable))) {}
-
-  RetT operator()(ArgTs... Params) const {
-    return C->call(std::forward<ArgTs>(Params)...);
+  template <typename CallableT> move_only_function(CallableT &&C) {
+    using WrappedCallable = typename move_only_function_detail::MOFBase<
+        FnT>::template WrappedCallable<CallableT>;
+    this->C = std::make_unique<WrappedCallable>(std::forward<CallableT>(C));
   }
-
-  explicit operator bool() const { return !!C; }
-
-private:
-  std::unique_ptr<GenericCallable> C;
-};
-
-template <typename RetT, typename... ArgTs>
-class move_only_function<RetT(ArgTs...) const> {
-private:
-  using GenericCallable =
-      move_only_function_detail::GenericConstCallable<RetT, ArgTs...>;
-  template <typename CallableT>
-  using GenericCallableImpl =
-      move_only_function_detail::GenericConstCallableImpl<CallableT, RetT,
-                                                          ArgTs...>;
-
-public:
-  move_only_function() = default;
-  move_only_function(std::nullptr_t) {}
-  move_only_function(move_only_function &&) = default;
-  move_only_function(const move_only_function &) = delete;
-  move_only_function &operator=(move_only_function &&) = default;
-  move_only_function &operator=(const move_only_function &) = delete;
-
-  template <typename CallableT>
-  move_only_function(CallableT &&Callable)
-      : C(std::make_unique<const GenericCallableImpl<std::decay_t<CallableT>>>(
-            std::forward<CallableT>(Callable))) {}
-
-  RetT operator()(ArgTs... Params) const {
-    return C->call(std::forward<ArgTs>(Params)...);
-  }
-
-  explicit operator bool() const { return !!C; }
-
-private:
-  std::unique_ptr<const GenericCallable> C;
 };
 
 } // namespace orc_rt

--- a/orc-rt/unittests/move_only_function-test.cpp
+++ b/orc-rt/unittests/move_only_function-test.cpp
@@ -199,13 +199,12 @@ TEST(MoveOnlyFunctionTest, Constness) {
   }
 
   {
-    // const move-only-function, non-const callable.
-    size_t NonConst = 0;
-    size_t Const = 0;
-    const move_only_function<void()> F(ConstCallCounter(NonConst, Const));
-    F();
-    EXPECT_EQ(NonConst, 1U);
-    EXPECT_EQ(Const, 0U);
+    // const move-only-function of a non-const signature is not invocable:
+    // operator() on move_only_function<void()> is non-const, so calling it on
+    // a const instance is ill-formed.
+    static_assert(!std::is_invocable_v<const move_only_function<void()>>,
+                  "const move_only_function<Sig> where Sig is non-const must "
+                  "not be invocable");
   }
 
   {
@@ -245,4 +244,65 @@ TEST(MoveOnlyFunctionTest, ShouldCopyInitialize) {
   ShouldCopy SC(DidMove);
   move_only_function<void()> F(SC);
   EXPECT_FALSE(DidMove);
+}
+
+TEST(MoveOnlyFunctionTest, NoexceptSignature) {
+  move_only_function<int(int) noexcept> Inc = [](int X) noexcept {
+    return X + 1;
+  };
+  EXPECT_EQ(Inc(41), 42);
+
+  static_assert(noexcept(Inc(0)),
+                "operator() on a noexcept-qualified move_only_function must "
+                "itself be noexcept");
+}
+
+TEST(MoveOnlyFunctionTest, ConstNoexceptSignature) {
+  const move_only_function<int(int) const noexcept> Inc = [](int X) noexcept {
+    return X + 1;
+  };
+  EXPECT_EQ(Inc(41), 42);
+
+  static_assert(noexcept(Inc(0)));
+}
+
+TEST(MoveOnlyFunctionTest, NonNoexceptSignatureIsNotNoexcept) {
+  move_only_function<void()> F = []() {};
+  move_only_function<void() const> FC = []() {};
+  static_assert(!noexcept(F()));
+  static_assert(!noexcept(FC()));
+}
+
+TEST(MoveOnlyFunctionTest, InvocabilityMatrix) {
+  // Non-const signatures: not invocable on a const instance.
+  static_assert(std::is_invocable_v<move_only_function<void()> &>);
+  static_assert(!std::is_invocable_v<const move_only_function<void()> &>);
+
+  static_assert(std::is_invocable_v<move_only_function<void() noexcept> &>);
+  static_assert(
+      !std::is_invocable_v<const move_only_function<void() noexcept> &>);
+
+  // Const signatures: invocable on both const and non-const instances.
+  static_assert(std::is_invocable_v<move_only_function<void() const> &>);
+  static_assert(std::is_invocable_v<const move_only_function<void() const> &>);
+
+  static_assert(
+      std::is_invocable_v<move_only_function<void() const noexcept> &>);
+  static_assert(
+      std::is_invocable_v<const move_only_function<void() const noexcept> &>);
+}
+
+TEST(MoveOnlyFunctionTest, MovePreservesWrappedCallableForNoexceptSigs) {
+  {
+    move_only_function<int() noexcept> F1 = []() noexcept { return 1; };
+    move_only_function<int() noexcept> F2 = std::move(F1);
+    EXPECT_EQ(F2(), 1);
+    EXPECT_FALSE(F1);
+  }
+  {
+    move_only_function<int() const noexcept> F1 = []() noexcept { return 2; };
+    move_only_function<int() const noexcept> F2 = std::move(F1);
+    EXPECT_EQ(F2(), 2);
+    EXPECT_FALSE(F1);
+  }
 }


### PR DESCRIPTION
Uses CallableTraitsHelper to decompose the signature template argument into (IsConst, IsNoexcept, RetT, ArgTs...), collapsing the previous per-signature-shape partial specializations of move_only_function into a two-tier type-erasure hierarchy (Callable / CallableImpl + Storage / InvocableStorage) driven by CallableTraitsHelper.

User-visible effect: move_only_function now supports the four signature shapes matching std::move_only_function's C++23 semantics, and operator()'s const and noexcept qualifiers track the signature:

    R(A...)                - mutable, may throw
    R(A...) const          - const-callable, may throw
    R(A...) noexcept       - mutable, guaranteed nothrow
    R(A...) const noexcept - const-callable, guaranteed nothrow

Two ill-formed combinations are rejected at compile time:

- A throwing callable passed to a noexcept-qualified move_only_function fails a static_assert on nothrow-invocability in CallableImpl's constructor.
- A mutable callable passed to a const-qualified move_only_function fails to compile because the const-qualified virtual call() body cannot invoke the stored callable through a const path.

Adds tests exercising the new signature shapes at runtime and static checks for the invocability and noexcept-propagation matrices across all four combinations.