### PR TITLE
ValueTracking: Improve frexp known range from dominating conditions

### DIFF
--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -20,6 +20,7 @@
 
 namespace llvm {
 class APFloat;
+class APInt;
 struct fltSemantics;
 struct KnownBits;
 
@@ -448,10 +449,17 @@ struct KnownFPClass {
   static LLVM_ABI KnownFPClass frexp_mant(
       const KnownFPClass &Src, DenormalMode Mode = DenormalMode::getDynamic());
 
-  /// Propagate known class for ldexp
+  /// Propagate known class for ldexp, assuming the exponent is known to be
+  /// within [\p ConstantRangeMin, \p ConstantRangeMax]
+  ///
+  // TODO: This really ought to use ConstantRange, but it's in IR not Support.
   static LLVM_ABI KnownFPClass
-  ldexp(const KnownFPClass &Src, const KnownBits &N, const fltSemantics &Flt,
+  ldexp(const KnownFPClass &Src, const APInt &ConstantRangeMin,
+        const APInt &ConstantRangeMax, const fltSemantics &Flt,
         DenormalMode Mode = DenormalMode::getDynamic());
+  static LLVM_ABI KnownFPClass ldexp(
+      const KnownFPClass &Src, const KnownBits &ExpBits,
+      const fltSemantics &Flt, DenormalMode Mode = DenormalMode::getDynamic());
 
   /// Propagate known class for powi
   static LLVM_ABI KnownFPClass powi(const KnownFPClass &Src,

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -4867,6 +4867,49 @@ static void computeKnownFPClassFromCond(const Value *V, Value *Cond,
   }
 }
 
+/// Compute the minimum and maximum values (inclusive) for the exponent of \p V,
+/// assuming it is not nan.
+static std::pair<int, int>
+computeKnownExponentRangeFromContext(const Value *V, const SimplifyQuery &Q) {
+  if (!Q.CxtI || !Q.DC || !Q.DT)
+    return {APFloat::IEK_NaN, APFloat::IEK_Inf};
+
+  for (CondBrInst *BI : Q.DC->conditionsFor(V)) {
+    CmpPredicate Pred;
+    const APFloat *LimitC;
+    if (!match(BI->getCondition(),
+               m_FCmp(Pred, m_FAbs(m_Specific(V)), m_Finite(LimitC))))
+      continue;
+
+    if (Pred == FCmpInst::FCMP_ORD || Pred == FCmpInst::FCMP_UNO ||
+        Pred == FCmpInst::FCMP_TRUE || Pred == FCmpInst::FCMP_FALSE)
+      continue;
+
+    APFloat::cmpResult CmpOne =
+        LimitC->compare(APFloat::getOne(LimitC->getSemantics()));
+    if (CmpOne > APFloat::cmpEqual)
+      continue;
+
+    // If fabs(x) <= K, K <= 1.0 => exponent min exp range
+    // if fabs(x) >= K, K <= 1.0 swap the successor
+    bool IsLessEqual =
+        Pred == FCmpInst::FCMP_OLT || Pred == FCmpInst::FCMP_OLE ||
+        Pred == FCmpInst::FCMP_ULT || Pred == FCmpInst::FCMP_ULE ||
+        Pred == FCmpInst::FCMP_OEQ || Pred == FCmpInst::FCMP_UEQ;
+
+    BasicBlockEdge Edge1(BI->getParent(),
+                         BI->getSuccessor(IsLessEqual ? 0 : 1));
+    if (Q.DT->dominates(Edge1, Q.CxtI->getParent())) {
+      int Exp = ilogb(*LimitC);
+
+      // TODO: Figure out lower bound to detect no-underflow.
+      return {APFloat::IEK_NaN, Exp};
+    }
+  }
+
+  return {APFloat::IEK_NaN, APFloat::IEK_Inf};
+}
+
 static KnownFPClass computeKnownFPClassFromContext(const Value *V,
                                                    const SimplifyQuery &Q) {
   KnownFPClass KnownFromContext;
@@ -4990,6 +5033,7 @@ static constexpr KnownFPClass::MinMaxKind getMinMaxKind(Intrinsic::ID IID) {
 static bool isAbsoluteValueULEOne(const Value *V) {
   // TODO: Handle frexp
   // TODO: Other rounding intrinsics?
+  // TODO: Try computeKnownExponentRangeFromContext
 
   // fabs(x - floor(x)) <= 1
   const Value *SubFloorX;
@@ -5507,11 +5551,12 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
       // Can refine inf/zero handling based on the exponent operand.
       const FPClassTest ExpInfoMask = fcZero | fcSubnormal | fcInf;
 
-      KnownBits ExpBits;
-      if ((KnownSrc.KnownFPClasses & ExpInfoMask) != fcNone) {
-        const Value *ExpArg = II->getArgOperand(1);
-        ExpBits = computeKnownBits(ExpArg, DemandedElts, Q, Depth + 1);
-      }
+      const Value *ExpArg = II->getArgOperand(1);
+      ConstantRange ExpKnownRange =
+          ((KnownSrc.KnownFPClasses & ExpInfoMask) != fcNone)
+              ? computeConstantRange(ExpArg, /*ForSigned=*/true, Q, Depth + 1)
+              : ConstantRange::getFull(
+                    ExpArg->getType()->getScalarSizeInBits());
 
       const fltSemantics &Flt =
           II->getType()->getScalarType()->getFltSemantics();
@@ -5520,7 +5565,8 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
       DenormalMode Mode =
           F ? F->getDenormalMode(Flt) : DenormalMode::getDynamic();
 
-      Known = KnownFPClass::ldexp(KnownSrc, ExpBits, Flt, Mode);
+      Known = KnownFPClass::ldexp(KnownSrc, ExpKnownRange.getSignedMin(),
+                                  ExpKnownRange.getSignedMax(), Flt, Mode);
       break;
     }
     case Intrinsic::arithmetic_fence: {
@@ -10474,9 +10520,17 @@ ConstantRange llvm::computeConstantRange(const Value *V, bool ForSigned,
             MinExp -= (APFloat::semanticsPrecision(FltSem) - 1);
 
           int MaxExp = APFloat::semanticsMaxExponent(FltSem) + 1;
+
+          auto [AdjustedMin, AdjustedMax] =
+              computeKnownExponentRangeFromContext(FrexpSrc, SQ);
+
+          MinExp = std::max(AdjustedMin, MinExp);
+          MaxExp = std::min(AdjustedMax, MaxExp);
+
           CR = ConstantRange::getNonEmpty(
-              APInt(BitWidth, MinExp, /*isSigned=*/true),
-              APInt(BitWidth, MaxExp + 1, /*isSigned=*/true));
+              APInt(BitWidth, static_cast<int64_t>(MinExp), /*isSigned=*/true),
+              APInt(BitWidth, static_cast<int64_t>(MaxExp) + 1,
+                    /*isSigned=*/true));
         }
       }
     }

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -789,7 +789,8 @@ KnownFPClass KnownFPClass::frexp_mant(const KnownFPClass &KnownSrc,
 }
 
 KnownFPClass KnownFPClass::ldexp(const KnownFPClass &KnownSrc,
-                                 const KnownBits &ExpBits,
+                                 const APInt &ConstantRangeExpMin,
+                                 const APInt &ConstantRangeExpMax,
                                  const fltSemantics &Flt, DenormalMode Mode) {
   KnownFPClass Known;
   Known.propagateNaN(KnownSrc, /*PropagateSign=*/true);
@@ -807,20 +808,19 @@ KnownFPClass KnownFPClass::ldexp(const KnownFPClass &KnownSrc,
 
   unsigned Precision = APFloat::semanticsPrecision(Flt);
   const int MantissaBits = Precision - 1;
-
-  if (ExpBits.getSignedMinValue().sge(static_cast<int64_t>(MantissaBits)))
+  if (ConstantRangeExpMin.sge(MantissaBits))
     Known.knownNot(fcSubnormal);
 
-  if (ExpBits.isConstant() && ExpBits.getConstant().isZero()) {
+  if (ConstantRangeExpMin.isZero() && ConstantRangeExpMax.isZero()) {
     // ldexp(x, 0) -> x, so propagate everything.
     Known.propagateCanonicalizingSrc(KnownSrc, Mode);
-  } else if (ExpBits.isNegative()) {
+  } else if (ConstantRangeExpMax.isNonPositive()) {
     // If we know the power is <= 0, can't introduce inf
     if (KnownSrc.isKnownNeverPosInfinity())
       Known.knownNot(fcPosInf);
     if (KnownSrc.isKnownNeverNegInfinity())
       Known.knownNot(fcNegInf);
-  } else if (ExpBits.isNonNegative()) {
+  } else if (ConstantRangeExpMin.isNonNegative()) {
     // If we know the power is >= 0, can't introduce subnormal or zero
     if (KnownSrc.isKnownNeverPosSubnormal())
       Known.knownNot(fcPosSubnormal);
@@ -833,6 +833,13 @@ KnownFPClass KnownFPClass::ldexp(const KnownFPClass &KnownSrc,
   }
 
   return Known;
+}
+
+KnownFPClass KnownFPClass::ldexp(const KnownFPClass &KnownSrc,
+                                 const KnownBits &ExpBits,
+                                 const fltSemantics &Flt, DenormalMode Mode) {
+  return ldexp(KnownSrc, ExpBits.getSignedMinValue(),
+               ExpBits.getSignedMaxValue(), Flt, Mode);
 }
 
 KnownFPClass KnownFPClass::powi(const KnownFPClass &KnownSrc,

--- a/llvm/test/Transforms/Attributor/nofpclass-ldexp.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-ldexp.ll
@@ -701,11 +701,24 @@ define <2 x float> @ret_ldexp_v2f32_known_pos_exp_noinf(<2 x float> nofpclass(in
   ret <2 x float> %call
 }
 
-define <2 x float> @ret_ldexp_v2f32_known_neg_exp_noinf(<2 x float> nofpclass(inf) %arg0, <2 x i32> %arg1) #0 {
-; CHECK-LABEL: define nofpclass(inf) <2 x float> @ret_ldexp_v2f32_known_neg_exp_noinf
+define <2 x float> @ret_ldexp_v2f32_known_neg_exp_noinf_splat(<2 x float> nofpclass(inf) %arg0, <2 x i32> %arg1) #0 {
+; CHECK-LABEL: define nofpclass(inf) <2 x float> @ret_ldexp_v2f32_known_neg_exp_noinf_splat
+; CHECK-SAME: (<2 x float> nofpclass(inf) [[ARG0:%.*]], <2 x i32> [[ARG1:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:    [[OR_ARG1:%.*]] = or <2 x i32> [[ARG1]], splat (i32 -32)
+; CHECK-NEXT:    [[CALL:%.*]] = call nofpclass(inf) <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> nofpclass(inf) [[ARG0]], <2 x i32> [[OR_ARG1]]) #[[ATTR10]]
+; CHECK-NEXT:    ret <2 x float> [[CALL]]
+;
+  %or.arg1 = or <2 x i32> %arg1, splat (i32 -32)
+  %call = call <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> %arg0, <2 x i32> %or.arg1)
+  ret <2 x float> %call
+}
+
+; TODO: computeConstantRange does not handle non-splat operator constants.
+define <2 x float> @ret_ldexp_v2f32_known_neg_exp_noinf_nonsplat(<2 x float> nofpclass(inf) %arg0, <2 x i32> %arg1) #0 {
+; CHECK-LABEL: define <2 x float> @ret_ldexp_v2f32_known_neg_exp_noinf_nonsplat
 ; CHECK-SAME: (<2 x float> nofpclass(inf) [[ARG0:%.*]], <2 x i32> [[ARG1:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[OR_ARG1:%.*]] = or <2 x i32> [[ARG1]], <i32 -16, i32 -32>
-; CHECK-NEXT:    [[CALL:%.*]] = call nofpclass(inf) <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> nofpclass(inf) [[ARG0]], <2 x i32> [[OR_ARG1]]) #[[ATTR10]]
+; CHECK-NEXT:    [[CALL:%.*]] = call <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> nofpclass(inf) [[ARG0]], <2 x i32> [[OR_ARG1]]) #[[ATTR10]]
 ; CHECK-NEXT:    ret <2 x float> [[CALL]]
 ;
   %or.arg1 = or <2 x i32> %arg1, <i32 -16, i32 -32>
@@ -1032,6 +1045,16 @@ define float @ret_ldexp_f32_neg127(float %arg0) #0 {
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %call = call float @llvm.ldexp.f32.i32(float %arg0, i32 -127)
+  ret float %call
+}
+
+define float @ret_ldexp_f32_noinf_exp_known_neg_or_0(float nofpclass(inf) %arg0, i32 range(i32 -256, 1) %arg1) #0 {
+; CHECK-LABEL: define nofpclass(inf) float @ret_ldexp_f32_noinf_exp_known_neg_or_0
+; CHECK-SAME: (float nofpclass(inf) [[ARG0:%.*]], i32 range(i32 -256, 1) [[ARG1:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:    [[CALL:%.*]] = call nofpclass(inf) float @llvm.ldexp.f32.i32(float nofpclass(inf) [[ARG0]], i32 [[ARG1]]) #[[ATTR10]]
+; CHECK-NEXT:    ret float [[CALL]]
+;
+  %call = call float @llvm.ldexp.f32.i32(float %arg0, i32 %arg1)
   ret float %call
 }
 

--- a/llvm/test/Transforms/InstCombine/frexp-implied-exponent-range-dominating-conditions.ll
+++ b/llvm/test/Transforms/InstCombine/frexp-implied-exponent-range-dominating-conditions.ll
@@ -17,9 +17,7 @@ define float @frexp_fcmp_ogt_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -49,9 +47,7 @@ define float @frexp_fcmp_oge_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -81,9 +77,7 @@ define float @frexp_fcmp_ugt_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -113,9 +107,7 @@ define float @frexp_fcmp_uge_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -145,9 +137,7 @@ define float @frexp_fcmp_olt_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -177,9 +167,7 @@ define float @frexp_fcmp_ole_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -210,9 +198,7 @@ define float @frexp_fcmp_ult_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -242,9 +228,7 @@ define float @frexp_fcmp_ule_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -274,9 +258,7 @@ define float @frexp_cmp_ugt_0.5(float nofpclass(nan inf) %x, float nofpclass(inf
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -306,9 +288,7 @@ define float @frexp_cmp_uge_0.5(float nofpclass(nan inf) %x, float nofpclass(inf
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -338,9 +318,7 @@ define float @frexp_fcmp_ult_0.5(float nofpclass(nan inf) %x, float nofpclass(in
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -370,9 +348,7 @@ define float @frexp_fcmp_ule_0.5(float nofpclass(nan inf) %x, float nofpclass(in
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -402,9 +378,7 @@ define float @frexp_fcmp_ugt_0.5(float nofpclass(nan inf) %x, float nofpclass(in
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -434,9 +408,7 @@ define float @frexp_fcmp_uge_0.5(float nofpclass(nan inf) %x, float nofpclass(in
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -466,9 +438,7 @@ define float @frexp_fcmp_oeq_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -498,9 +468,7 @@ define float @frexp_fcmp_ueq_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -530,9 +498,7 @@ define float @frexp_fcmp_one_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -562,9 +528,7 @@ define float @frexp_fcmp_une_1(float nofpclass(nan inf) %x, float nofpclass(inf)
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -594,9 +558,7 @@ define float @frexp_fcmp_oeq_0.5(float nofpclass(nan inf) %x, float nofpclass(in
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -626,9 +588,7 @@ define float @frexp_fcmp_ueq_0.5(float nofpclass(nan inf) %x, float nofpclass(in
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -658,9 +618,7 @@ define float @frexp_fcmp_one_0.5(float nofpclass(nan inf) %x, float nofpclass(in
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -690,9 +648,7 @@ define float @frexp_fcmp_une_0.5(float nofpclass(nan inf) %x, float nofpclass(in
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -899,9 +855,7 @@ define float @frexp_fcmp_ogt_nextdown1(float nofpclass(nan inf) %x, float nofpcl
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -932,9 +886,7 @@ define float @frexp_fcmp_ole_nextdown1(float nofpclass(nan inf) %x, float nofpcl
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -1066,9 +1018,7 @@ define float @frexp_fcmp_olt_1_multiple_conditions_wrong_constant(float nofpclas
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -1106,9 +1056,7 @@ define float @frexp_fcmp_olt_1_multiple_conditions_nonfinite_constant(float nofp
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -1144,9 +1092,7 @@ define float @frexp_fcmp_olt_1_multiple_conditions_edge_case_compare(float nofpc
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -1184,9 +1130,7 @@ define float @frexp_fcmp_olt_1_multiple_conditions_other(float nofpclass(nan inf
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i32 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i32(float [[NOT_INF]], i32 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
@@ -1221,9 +1165,7 @@ define float @frexp_fcmp_ogt_1_large_int(float nofpclass(nan inf) %x, float nofp
 ; CHECK-NEXT:    [[FREXP:%.*]] = call { float, i128 } @llvm.frexp.f32.i128(float [[X]])
 ; CHECK-NEXT:    [[EXP:%.*]] = extractvalue { float, i128 } [[FREXP]], 1
 ; CHECK-NEXT:    [[SCALED:%.*]] = call float @llvm.ldexp.f32.i128(float [[NOT_INF]], i128 [[EXP]])
-; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[SCALED]], +inf
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 0.000000e+00, float [[SCALED]]
-; CHECK-NEXT:    ret float [[SELECT]]
+; CHECK-NEXT:    ret float [[SCALED]]
 ; CHECK:       [[LARGE]]:
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-ldexp.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-ldexp.ll
@@ -487,3 +487,17 @@ define nofpclass(snan) float @qnan_result_demands_snan_src(i1 %cond, float %unkn
   %ldexp = call float @llvm.ldexp.f32.i32(float %select, i32 %unknown.int)
   ret float %ldexp
 }
+
+; Make sure there's no assertion from trying to query
+; getIntegerBitWidth on the vector type.
+define <2 x float> @ldexp_v2f32_v2i32_fmul_crash(<2 x i32> %exp) {
+; CHECK-LABEL: define <2 x float> @ldexp_v2f32_v2i32_fmul_crash(
+; CHECK-SAME: <2 x i32> [[EXP:%.*]]) {
+; CHECK-NEXT:    [[LDEXP:%.*]] = call nnan <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> splat (float 1.000000e+00), <2 x i32> [[EXP]])
+; CHECK-NEXT:    [[MUL:%.*]] = fmul <2 x float> [[LDEXP]], zeroinitializer
+; CHECK-NEXT:    ret <2 x float> [[MUL]]
+;
+  %ldexp = call <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float> splat (float 1.0), <2 x i32> %exp)
+  %mul = fmul <2 x float> %ldexp, zeroinitializer
+  ret <2 x float> %mul
+}


### PR DESCRIPTION
Try to restrict the known range of the exponent result of llvm.frexp
based on dominating conditions. Identify comparisons that imply the
incoming value cannot introduce an overflow in a downstream ldexp
use. This pattern appears in the implementation of some complex math
functions and allows finite only math to prune out more edge case
paths.

One attributor test for ldexp regresses due to the switch from
computeKnownBits to computeConstantRange. computeConstantRange
does not try to handle non-splat vector constants for the binary
operators.

As a side effect, this also improves knowing that ldexp can't
introduce overflow for the 0 case.