### PR TITLE
[AArch64][SVE] Fold predicate SETCC negations

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -20480,11 +20480,40 @@ static SDValue performBICiCombine(SDNode *N, SelectionDAG &DAG,
   return SDValue();
 }
 
+static SDValue performPredicateSetCCNotCombine(SDNode *N, SelectionDAG &DAG) {
+  assert(N->getOpcode() == ISD::XOR && "Unexpected opcode!");
+
+  SDValue N0 = N->getOperand(0);
+  SDValue N1 = N->getOperand(1);
+  if (N1->getOpcode() == AArch64ISD::SETCC_MERGE_ZERO)
+    std::swap(N0, N1);
+
+  if (N0->getOpcode() != AArch64ISD::SETCC_MERGE_ZERO || !N0.hasOneUse())
+    return SDValue();
+
+  SDValue Pred = N0->getOperand(0);
+  if (N1 != Pred)
+    return SDValue();
+
+  SDLoc DL(N);
+  SDValue LHS = N0->getOperand(1);
+  SDValue RHS = N0->getOperand(2);
+  ISD::CondCode CC = cast<CondCodeSDNode>(N0->getOperand(3))->get();
+  if (CC != ISD::CondCode::SETNE && CC != ISD::CondCode::SETEQ)
+    return SDValue();
+  ISD::CondCode InvCC = ISD::getSetCCInverse(CC, LHS.getValueType());
+  return DAG.getNode(AArch64ISD::SETCC_MERGE_ZERO, DL, N->getValueType(0), Pred,
+                     LHS, RHS, DAG.getCondCode(InvCC));
+}
+
 static SDValue performXorCombine(SDNode *N, SelectionDAG &DAG,
                                  TargetLowering::DAGCombinerInfo &DCI,
                                  const AArch64Subtarget *Subtarget) {
   if (DCI.isBeforeLegalizeOps())
     return SDValue();
+
+  if (SDValue V = performPredicateSetCCNotCombine(N, DAG))
+    return V;
 
   return foldVectorXorShiftIntoCmp(N, DAG, Subtarget);
 }

--- a/llvm/test/CodeGen/AArch64/sve-setcc.ll
+++ b/llvm/test/CodeGen/AArch64/sve-setcc.ll
@@ -116,6 +116,50 @@ define <vscale x 16 x i1> @sve_cmpne_setcc_different_pred(<vscale x 16 x i8> %ve
   ret <vscale x 16 x i1> %cmp2
 }
 
+define <vscale x 16 x i1> @sve_not_cmpne_setcc(<vscale x 16 x i8> %vec, <vscale x 16 x i1> %pg) {
+; CHECK-LABEL: sve_not_cmpne_setcc:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmpeq p0.b, p0/z, z0.b, #0
+; CHECK-NEXT:    ret
+  %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> %pg, <vscale x 16 x i8> %vec, <vscale x 16 x i8> zeroinitializer)
+  %not = xor <vscale x 16 x i1> %cmp, %pg
+  ret <vscale x 16 x i1> %not
+}
+
+define <vscale x 16 x i1> @sve_not_cmpne_setcc_true(<vscale x 16 x i8> %vec) {
+; CHECK-LABEL: sve_not_cmpne_setcc_true:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.b
+; CHECK-NEXT:    cmpeq p0.b, p0/z, z0.b, #0
+; CHECK-NEXT:    ret
+  %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> %vec, <vscale x 16 x i8> zeroinitializer)
+  %not = xor <vscale x 16 x i1> %cmp, splat (i1 true)
+  ret <vscale x 16 x i1> %not
+}
+
+define <vscale x 16 x i1> @sve_not_cmpeq_setcc(<vscale x 16 x i8> %vec, <vscale x 16 x i1> %pg) {
+; CHECK-LABEL: sve_not_cmpeq_setcc:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmpne p0.b, p0/z, z0.b, #0
+; CHECK-NEXT:    ret
+  %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpeq.nxv16i8(<vscale x 16 x i1> %pg, <vscale x 16 x i8> %vec, <vscale x 16 x i8> zeroinitializer)
+  %not = xor <vscale x 16 x i1> %cmp, %pg
+  ret <vscale x 16 x i1> %not
+}
+
+define <vscale x 16 x i1> @sve_not_cmpeq_setcc_true(<vscale x 16 x i8> %vec) {
+; CHECK-LABEL: sve_not_cmpeq_setcc_true:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ptrue p0.b
+; CHECK-NEXT:    cmpne p0.b, p0/z, z0.b, #0
+; CHECK-NEXT:    ret
+  %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpeq.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> %vec, <vscale x 16 x i8> zeroinitializer)
+  %not = xor <vscale x 16 x i1> %cmp, splat (i1 true)
+  ret <vscale x 16 x i1> %not
+}
+
+
+
 declare <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1>, <vscale x 16 x i8>, <vscale x 16 x i8>)
 
 declare i1 @llvm.aarch64.sve.ptest.any.nxv8i1(<vscale x 8 x i1>, <vscale x 8 x i1>)


### PR DESCRIPTION
Fold XORs of an SVE SETCC_MERGE_ZERO result with its governing predicate into the inverse SETCC_MERGE_ZERO condition. This lets patterns like `xor (cmpne pg, ...), pg` lower directly to `cmpeq`, and likewise folds `cmpeq` negations to `cmpne`.