### PR TITLE
[lldb] Fix compiler warning in LibStdcpp.cpp

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -1006,7 +1006,7 @@ bool lldb_private::formatters::LibcxxSourceLocationSummaryProvider(
     return false;
 
   const char *file = file_sp->GetSummaryAsCString();
-  stream.Printf("%s:%lu:%lu", file ? file : "<unknown>", line, column);
+  stream.Format("{0}:{1}:{2}", file ? file : "<unknown>", line, column);
 
   if (const char *function = function_sp->GetSummaryAsCString())
     stream.Printf(" (%s)", function);

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -602,7 +602,7 @@ bool lldb_private::formatters::LibStdcppSourceLocationSummaryProvider(
     return false;
 
   const char *file = file_sp->GetSummaryAsCString();
-  stream.Printf("%s:%lu:%lu", file ? file : "<unknown>", line, column);
+  stream.Format("{0}:{1}:{2}", file ? file : "<unknown>", line, column);
 
   if (const char *function = function_sp->GetSummaryAsCString())
     stream.Printf(" (%s)", function);


### PR DESCRIPTION
This triggered -Wformat warnings. Use the non-printf version to avoid this issue.