### PR TITLE
[DA] Update stale weak-crossing SIV FIXMEs (NFC)

### DIFF
--- a/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-delta-signed-min.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-delta-signed-min.ll
@@ -12,8 +12,6 @@
 ;   }
 ; }
 ;
-; FIXME: There is a dependency between the two stores in all directions.
-;
 define void @weak_crossing_siv_delta_signed_min(ptr %A) {
 ; CHECK-ALL-LABEL: 'weak_crossing_siv_delta_signed_min'
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 0, ptr %gep.0, align 1

--- a/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-large-btc.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-large-btc.ll
@@ -13,9 +13,6 @@
 ;     A[i1] = 0;
 ; }
 ;
-; FIXME: Both `A[i0] = 0` and `A[i1] = 0` must be executed, so there is a
-; dependency between them.
-;
 define void @weak_crossing_siv_large_btc(ptr %A) {
 ; CHECK-ALL-LABEL: 'weak_crossing_siv_large_btc'
 ; CHECK-ALL-NEXT:  Src: store i8 0, ptr %gep.0, align 1 --> Dst: store i8 0, ptr %gep.0, align 1

--- a/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/weak-crossing-siv-overflow.ll
@@ -11,16 +11,13 @@
 ;     A[3*i - 2] = 1;
 ; }
 ;
-; FIXME: DependenceAnalysis currently detects no dependency between
-; `A[-3*i + INT64_MAX]` and `A[3*i - 2]`, but it does exist. For example,
+; There is a dependency between `A[-3*i + INT64_MAX]` and `A[3*i - 2]`, for example,
 ;
 ;  memory access       | i == 1           | i == max_i
 ; ---------------------|------------------|------------------
 ;  A[-3*i + INT64_MAX] | A[INT64_MAX - 3] | A[1]
 ;  A[3*i - 2]          | A[1]             | A[INT64_MAX - 3]
 ;
-; The root cause is that the calculation of the differenct between the two
-; constants (INT64_MAX and -2) triggers an overflow.
 
 define void @weakcorssing_delta_ovfl(ptr %A) {
 ; CHECK-ALL-LABEL: 'weakcorssing_delta_ovfl'
@@ -73,7 +70,7 @@ exit:
 ;   A[3*i + 1] = 1;
 ; }
 ;
-; There is a dependency between `A[-3*i + INT64_MAX]` and `A[3*i - 2]`, for example,
+; There is a dependency between `A[-3*i + INT64_MAX]` and `A[3*i + 1]`, for example,
 ;
 ;  memory access       | i == 0 | i == 1           | i == max_i - 1 | i == max_i
 ; ---------------------|--------|------------------|----------------|------------------


### PR DESCRIPTION
Remove outdated FIXME comments from weak-crossing SIV tests where the expected dependence results are now documented by the CHECK lines.

Also clarify the overflow test comment and fix the described second access from A[3*i - 2] to A[3*i + 1].