### PR TITLE
[BOLT] Fix test for systems where dl/pthread are not part of libc

### DIFF
--- a/bolt/test/runtime/setup-race.cpp
+++ b/bolt/test/runtime/setup-race.cpp
@@ -3,7 +3,7 @@
 // when libstdcxx.so invokes global constructors that call malloc.
 
 // REQUIRES: system-linux
-// RUN: %clangxx %cxxflags -Wl,-q %s -o %t.exe -D_GNU_SOURCE -g
+// RUN: %clangxx %cxxflags -Wl,-q %s -o %t.exe -D_GNU_SOURCE -g -ldl -lpthread
 // RUN: llvm-bolt -instrument %t.exe -o %t.bolt.exe
 // RUN: %t.bolt.exe
 


### PR DESCRIPTION
The bolt/test/runtime/setup-race.cpp test (including the original one) crashes with a segfault on Ubuntu 20.04 (glibc 2.31) because the dlsym symbol is not found.
According to the glibc 2.34 release notes, libpthread, libdl, libutil, and libanl have been integrated into libc. For older glibc versions, it is still necessary to link against libdl (for dlsym) and libpthread (for pthread_* symbols).