### PR TITLE
[M68k] Use getM68kMCRegisterClass accessor after MCRegisterClasses became relocation-free

### DIFF
--- a/llvm/lib/Target/M68k/AsmParser/M68kAsmParser.cpp
+++ b/llvm/lib/Target/M68k/AsmParser/M68kAsmParser.cpp
@@ -513,11 +513,12 @@ bool M68kOperand::isPCIBD32() const {
          // If InnerReg is NoReg, this is essentially a PCD with larger
          // displacement.
          (!MemOp.InnerReg.isValid() ||
-          M68kMCRegisterClasses[M68k::XR32RegClassID].contains(MemOp.InnerReg));
+          getM68kMCRegisterClass(M68k::XR32RegClassID)
+              .contains(MemOp.InnerReg));
 }
 bool M68kOperand::isPCIBD16() const {
   return isPCIBD() &&
-         M68kMCRegisterClasses[M68k::XR16RegClassID].contains(MemOp.InnerReg);
+         getM68kMCRegisterClass(M68k::XR16RegClassID).contains(MemOp.InnerReg);
 }
 void M68kOperand::addPCIBDOperands(MCInst &Inst, unsigned N) const {
   M68kOperand::addExpr(Inst, MemOp.OuterDisp);


### PR DESCRIPTION


Regressed by 0b413b7d0f5a, #206753


Issue:

```
  /build/source/llvm/lib/Target/M68k/AsmParser/M68kAsmParser.cpp: In member function 'bool
  {anonymous}::M68kOperand::isPCIBD32() const':
  /build/source/llvm/lib/Target/M68k/AsmParser/M68kAsmParser.cpp:516:11: error:
  'M68kMCRegisterClasses' was not declared in this scope
    516 |           M68kMCRegisterClasses[M68k::XR32RegClassID].contains(MemOp.InnerReg));
        |           ^~~~~~~~~~~~~~~~~~~~~
```