### PR TITLE
[lldb][Windows][CI] split steps

### DIFF
--- a/.ci/green-dragon/lldb-windows.groovy
+++ b/.ci/green-dragon/lldb-windows.groovy
@@ -44,9 +44,9 @@ pipeline {
             }
         }
 
-        stage('Build and Test') {
+        stage('Build and Test (No LLDB Server)') {
             steps {
-                timeout(240) {
+                timeout(60) {
                     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                         writeFile file: 'build.bat', text: '''@echo off
 call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat" || exit /b 1
@@ -77,6 +77,28 @@ cmake -G Ninja ^
     -DLLVM_LIT_ARGS="-v --time-tests --xunit-xml-output=C:\\workspace\\llvm-build\\test\\results-no-lldb-server.xml" ^
     -DPython3_EXECUTABLE="C:\\Program Files\\Python313\\python.exe" || exit /b 1
 ninja check-lldb -C ..\\llvm-build || exit /b 1
+'''
+                        bat '''
+                            docker run --rm ^
+                                -e BUILD_TYPE=%BUILD_TYPE% ^
+                                -v "%CD%:C:\\workspace" ^
+                                -w "C:\\workspace\\llvm-project" ^
+                                swiftlang/swift-ci:lldb-windowsservercore-1809 ^
+                                cmd /C C:\\workspace\\build.bat
+                        '''
+                    }
+                }
+            }
+        }
+
+        stage('Test (LLDB Server)') {
+            steps {
+                timeout(30) {
+                    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                        writeFile file: 'test-lldb-server.bat', text: '''@echo off
+call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat" || exit /b 1
+
+set "PATH=%PATH%;C:\\Program Files\\Git\\usr\\bin"
 
 cmake -G Ninja ^
     -S llvm ^
@@ -91,13 +113,12 @@ ninja check-lldb -C ..\\llvm-build || exit /b 1
                                 -v "%CD%:C:\\workspace" ^
                                 -w "C:\\workspace\\llvm-project" ^
                                 swiftlang/swift-ci:lldb-windowsservercore-1809 ^
-                                cmd /C C:\\workspace\\build.bat
+                                cmd /C C:\\workspace\\test-lldb-server.bat
                         '''
                     }
                 }
             }
         }
-    }
 
     post {
         always {


### PR DESCRIPTION
Split the lldb green-dragon lldb testing steps into 2:
1. Build and run the tests without `lldb-server.exe`
2. Run the tests with `lldb-server.exe`

This gives better separation in the UI and if the first step fails, the second step will still attempt to run.