### PR TITLE
[lldb][test] Modernize and expand data-formatter-stl/generic/vbool

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/TestDataFormatterStdVBool.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/TestDataFormatterStdVBool.py
@@ -1,5 +1,5 @@
 """
-Test lldb data formatter subsystem.
+Test lldb data formatter subsystem for std::vector<bool>.
 """
 
 import lldb
@@ -12,83 +12,54 @@ class StdVBoolDataFormatterTestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
     TEST_WITH_PDB_DEBUG_INFO = True
 
-    def setUp(self):
-        # Call super's setUp().
-        TestBase.setUp(self)
-        # Find the line number to break at.
-        self.line = line_number("main.cpp", "// Set break point at this line.")
-
     def do_test(self):
-        """Test that that file and class static variables display correctly."""
-        self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
-
-        lldbutil.run_break_set_by_file_and_line(
-            self, "main.cpp", self.line, num_expected_locations=-1
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp")
         )
 
-        self.runCmd("run", RUN_SUCCEEDED)
-
-        # The stop reason of the thread should be breakpoint.
-        self.expect(
-            "thread list",
-            STOPPED_DUE_TO_BREAKPOINT,
-            substrs=["stopped", "stop reason = breakpoint"],
+        self.runCmd("settings set target.max-children-count 128")
+        self.addTearDownHook(
+            lambda: self.runCmd("settings set target.max-children-count 24")
         )
 
-        # This is the function to remove the custom formats in order to have a
-        # clean slate for the next test case.
-        def cleanup():
-            self.runCmd("type format clear", check=False)
-            self.runCmd("type summary clear", check=False)
-            self.runCmd("type filter clear", check=False)
-            self.runCmd("type synth clear", check=False)
-            self.runCmd("settings set target.max-children-count 24", check=False)
+        self.expect("frame variable vBoolEmpty", substrs=["size=0"])
+        self.expect("expr -- vBoolEmpty", substrs=["size=0"])
 
-        self.runCmd("settings set target.max-children-count 128", check=False)
-        # Execute the cleanup function during test case tear down.
-        self.addTearDownHook(cleanup)
+        expected_small = [
+            "size=10",
+            "[0] = true",
+            "[1] = false",
+            "[2] = true",
+            "[3] = true",
+            "[4] = false",
+            "[5] = false",
+            "[6] = true",
+            "[7] = false",
+            "[8] = true",
+            "[9] = true",
+        ]
+        self.expect("frame variable vBoolSmall", substrs=expected_small)
+        self.expect("expr -- vBoolSmall", substrs=expected_small)
 
-        self.expect(
-            "frame variable vBool",
-            substrs=[
-                "size=73",
-                "[0] = false",
-                "[1] = true",
-                "[18] = false",
-                "[27] = true",
-                "[36] = false",
-                "[47] = true",
-                "[48] = true",
-                "[49] = true",
-                "[50] = false",
-                "[56] = false",
-                "[65] = true",
-                "[70] = false",
-                "[71] = true",
-                "[72] = true",
-            ],
-        )
-
-        self.expect(
-            "expr -- vBool",
-            substrs=[
-                "size=73",
-                "[0] = false",
-                "[1] = true",
-                "[18] = false",
-                "[27] = true",
-                "[36] = false",
-                "[47] = true",
-                "[48] = true",
-                "[49] = true",
-                "[50] = false",
-                "[56] = false",
-                "[65] = true",
-                "[70] = false",
-                "[71] = true",
-                "[72] = true",
-            ],
-        )
+        expected = [
+            "size=73",
+            "[0] = false",
+            "[1] = true",
+            "[18] = false",
+            "[27] = true",
+            "[36] = false",
+            "[47] = true",
+            "[48] = true",
+            "[49] = true",
+            "[50] = false",
+            "[56] = false",
+            "[65] = true",
+            "[70] = false",
+            "[71] = true",
+            "[72] = true",
+        ]
+        self.expect("frame variable vBool", substrs=expected)
+        self.expect("expr -- vBool", substrs=expected)
 
     @add_test_categories(["libc++"])
     def test_libcxx(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/main.cpp
@@ -1,102 +1,92 @@
-#include <cstdio>
 #include <vector>
 
 int main() {
-  std::vector<bool> vBool;
+  std::vector<bool> vBoolEmpty;
 
-  // 0..=7
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
+  std::vector<bool> vBoolSmall = {true,  false, true,  true, false,
+                                  false, true,  false, true, true};
 
-  // 8..=15
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
+  // Make a bit vector that is larger than 64 bit.
+  std::vector<bool> vBool = {
+      // 0..=47: alternating false, true
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      // 48..=55: pattern breaks at 48
+      true,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      // 56..=63: alternating again
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      // 64..=71: pattern breaks at 68
+      false,
+      true,
+      false,
+      true,
+      true,
+      true,
+      false,
+      true,
+      // 72
+      true,
+  };
 
-  // 16..=23
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-
-  // 24..=31
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-
-  // 32..=39
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-
-  // 40..=47
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-
-  // 48..=55
-  vBool.push_back(true);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-
-  // 56..=63
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-
-  // 64..=71
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-  vBool.push_back(true);
-  vBool.push_back(true);
-  vBool.push_back(false);
-  vBool.push_back(true);
-
-  // 72
-  vBool.push_back(true);
-
-  std::puts("// Set break point at this line.");
-  return 0;
+  return 0; // break here
 }


### PR DESCRIPTION
This fixes several issues with this test:
* We use modern test utils for setting up the process.
* We get rid of the state-reset code which is no longer necessary these days.
* Expand the test to also cover an empty and sub-word-size vector of bool.

assisted-by: claude