### PR TITLE
[lldb][Windows] allow test_convenience_registers to PASS

### DIFF
--- a/lldb/test/API/commands/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register_command/TestRegisters.py
@@ -126,7 +126,7 @@ class RegisterCommandsTestCase(TestBase):
 
     @skipIfiOSSimulator
     @skipIf(archs=no_match(["amd64", "x86_64"]))
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr37683")
+    @expectedFailureWindowsAndNoLLDBServer(bugnumber="llvm.org/pr37683")
     def test_convenience_registers(self):
         """Test convenience registers."""
         self.build()


### PR DESCRIPTION
`RegisterCommandsTestCase.test_convenience_registers` passes when using `LLDB_USE_LLDB_SERVER=1` since https://github.com/llvm/llvm-project/pull/203498 was merged.

rdar://180307995