### PR TITLE
[LangRef] Clarify cttz.elts returns poison for undersized result types

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -22221,8 +22221,8 @@ Arguments:
 The first argument is the vector to be counted. This argument must be a vector
 with integer element type. The return type must also be an integer type which is
 wide enough to hold the maximum number of elements of the source vector. The
-behavior of this intrinsic is undefined if the return type is not wide enough
-for the number of elements in the input vector.
+result is poison if the return type is not wide enough for the number of
+elements in the input vector.
 
 The second argument is a constant flag that indicates whether the intrinsic
 returns a valid result if the first argument is all zero. If the first argument
@@ -27737,8 +27737,8 @@ Arguments:
 The first argument is the vector to be counted. This argument must be a vector
 with integer element type. The return type must also be an integer type which is
 wide enough to hold the maximum number of elements of the source vector. The
-behavior of this intrinsic is undefined if the return type is not wide enough
-for the number of elements in the input vector.
+result is poison if the return type is not wide enough for the number of
+elements in the input vector.
 
 The second argument is a constant flag that indicates whether the intrinsic
 returns a valid result if the first argument is all zero.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -22221,8 +22221,8 @@ Arguments:
 The first argument is the vector to be counted. This argument must be a vector
 with integer element type. The return type must also be an integer type which is
 wide enough to hold the maximum number of elements of the source vector. The
-result is a :ref:`poison value <poisonvalues>` if the return type is not wide enough for the number of
-elements in the input vector.
+result is a :ref:`poison value <poisonvalues>` if the return type is not wide enough
+for the number of elements in the input vector.
 
 The second argument is a constant flag that indicates whether the intrinsic
 returns a valid result if the first argument is all zero. If the first argument
@@ -27737,8 +27737,8 @@ Arguments:
 The first argument is the vector to be counted. This argument must be a vector
 with integer element type. The return type must also be an integer type which is
 wide enough to hold the maximum number of elements of the source vector. The
-result is a :ref:`poison value <poisonvalues>` if the return type is not wide enough for the number of
-elements in the input vector.
+result is a :ref:`poison value <poisonvalues>` if the return type is not wide enough
+for the number of elements in the input vector.
 
 The second argument is a constant flag that indicates whether the intrinsic
 returns a valid result if the first argument is all zero.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -22221,7 +22221,7 @@ Arguments:
 The first argument is the vector to be counted. This argument must be a vector
 with integer element type. The return type must also be an integer type which is
 wide enough to hold the maximum number of elements of the source vector. The
-result is poison if the return type is not wide enough for the number of
+result is a :ref:`poison value <poisonvalues>` if the return type is not wide enough for the number of
 elements in the input vector.
 
 The second argument is a constant flag that indicates whether the intrinsic
@@ -27737,7 +27737,7 @@ Arguments:
 The first argument is the vector to be counted. This argument must be a vector
 with integer element type. The return type must also be an integer type which is
 wide enough to hold the maximum number of elements of the source vector. The
-result is poison if the return type is not wide enough for the number of
+result is a :ref:`poison value <poisonvalues>` if the return type is not wide enough for the number of
 elements in the input vector.
 
 The second argument is a constant flag that indicates whether the intrinsic


### PR DESCRIPTION
Update the LangRef for `llvm.experimental.cttz.elts` and `llvm.vp.cttz.elts` to state that an undersized return type produces poison rather than UB, matching the intrinsic's speculatable behavior.

See also https://github.com/llvm/llvm-project/pull/206899#discussion_r3504289653.