### PR TITLE
[libc++] Don't #define __unused with glibc in system_reserved_names.gen.py

### DIFF
--- a/libcxx/test/libcxx/system_reserved_names.gen.py
+++ b/libcxx/test/libcxx/system_reserved_names.gen.py
@@ -122,7 +122,7 @@ for header in public_headers:
 #define __release SYSTEM_RESERVED_NAME
 
 // Android and FreeBSD use this for __attribute__((__unused__))
-#if !defined(__FreeBSD__)  && !defined(__ANDROID__)
+#if !defined(__FreeBSD__)  && !defined(__ANDROID__) && !defined(__GLIBC__)
 #define __unused SYSTEM_RESERVED_NAME
 #endif
 


### PR DESCRIPTION
Newer glibc versions use the identifier `__unused`. To run the test successufly again disable the `__unused` check with glibc.
