### PR TITLE
[Clang] Try to fix data race on HasColors after #202441

### DIFF
--- a/clang/lib/Basic/Warnings.cpp
+++ b/clang/lib/Basic/Warnings.cpp
@@ -21,15 +21,18 @@
 //
 // Remark options are also handled here, analogously, except that they are much
 // simpler because a remark can't be promoted to an error.
+
 #include "clang/Basic/AllDiagnostics.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticDriver.h"
 #include "clang/Basic/DiagnosticIDs.h"
 #include "clang/Basic/DiagnosticOptions.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstring>
+
 using namespace clang;
 
 // EmitUnknownDiagWarning - Emit a warning and typo hint for unknown warning
@@ -54,7 +57,8 @@ void clang::ProcessWarningOptions(DiagnosticsEngine &Diags,
 
   Diags.setElideType(Opts.ElideType);
   Diags.setPrintTemplateTree(Opts.ShowTemplateTree);
-  Diags.setShowColors(Opts.showColors(llvm::errs().has_colors()));
+  Diags.setShowColors(
+      Opts.showColors(llvm::sys::Process::StandardErrHasColors()));
 
   // Handle -ferror-limit
   if (Opts.ErrorLimit)


### PR DESCRIPTION
Summary:
The clangd users call these functions in multi-thraeded contexts. The
raw_fd_stream has_colors query is cached, which was giving some data
races. Just use the process-level check for now.
