### PR TITLE
[orc-rt] Add missing noexcept specifiers to RTTI.h.

### DIFF
--- a/orc-rt/include/orc-rt/RTTI.h
+++ b/orc-rt/include/orc-rt/RTTI.h
@@ -66,7 +66,7 @@ template <typename ThisT, typename ParentT> class RTTIExtends;
 /// type comparisons.
 class RTTIRoot {
 public:
-  virtual ~RTTIRoot() = default;
+  virtual ~RTTIRoot() noexcept = default;
 
   /// Returns the class ID for this type.
   static const void *classID() noexcept { return &ID; }
@@ -87,7 +87,7 @@ public:
   static bool classof(const RTTIRoot *R) noexcept { return R->isA<RTTIRoot>(); }
 
 private:
-  virtual void anchor();
+  virtual void anchor() noexcept;
 
   static char ID;
 };
@@ -129,7 +129,7 @@ public:
     return ClassID == classID() || ParentT::isA(ClassID);
   }
 
-  static bool classof(const RTTIRoot *R) { return R->isA<ThisT>(); }
+  static bool classof(const RTTIRoot *R) noexcept { return R->isA<ThisT>(); }
 };
 
 template <typename ThisT, typename ParentT>

--- a/orc-rt/lib/executor/RTTI.cpp
+++ b/orc-rt/lib/executor/RTTI.cpp
@@ -15,6 +15,6 @@
 namespace orc_rt {
 
 char RTTIRoot::ID = 0;
-void RTTIRoot::anchor() {}
+void RTTIRoot::anchor() noexcept {}
 
 } // namespace orc_rt


### PR DESCRIPTION
Adds noexcept specifiers that were missing from some methods in RTTI.h.