### PR TITLE
[libc++] Don't add #pragma clang attribute with GCC

### DIFF
--- a/libcxx/include/__configuration/namespace.h
+++ b/libcxx/include/__configuration/namespace.h
@@ -46,15 +46,20 @@
 #  define _LIBCPP_POP_ABI_PRAGMA_DIAGNOSTICS
 #endif
 
-#define _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS                                                                           \
-  _LIBCPP_PUSH_ABI_PRAGMA_DIAGNOSTICS                                                                                  \
-  _Pragma(_LIBCPP_TOSTRING(clang attribute _LibcxxExplicitABIAnnotations.push(                                         \
-      __attribute__((__exclude_from_explicit_instantiation__,                                                          \
-                     __visibility__("hidden"),                                                                         \
-                     __abi_tag__(_LIBCPP_TOSTRING(_LIBCPP_ODR_SIGNATURE)))),                                           \
-      apply_to = function))) _LIBCPP_POP_ABI_PRAGMA_DIAGNOSTICS
+#ifdef _LIBCPP_COMPILER_CLANG_BASED
+#  define _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS                                                                         \
+    _LIBCPP_PUSH_ABI_PRAGMA_DIAGNOSTICS                                                                                \
+    _Pragma(_LIBCPP_TOSTRING(clang attribute _LibcxxExplicitABIAnnotations.push(                                       \
+        __attribute__((__exclude_from_explicit_instantiation__,                                                        \
+                       __visibility__("hidden"),                                                                       \
+                       __abi_tag__(_LIBCPP_TOSTRING(_LIBCPP_ODR_SIGNATURE)))),                                         \
+        apply_to = function))) _LIBCPP_POP_ABI_PRAGMA_DIAGNOSTICS
 
-#define _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS _Pragma("clang attribute _LibcxxExplicitABIAnnotations.pop")
+#  define _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS _Pragma("clang attribute _LibcxxExplicitABIAnnotations.pop")
+#else
+#  define _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
+#  define _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
+#endif
 
 // clang-format off
 


### PR DESCRIPTION
GCC doesn't support `#pragma clang attribute`, which causes a bunch of diagnostics. Since we have it behind a macro anyways we can simply define the macro as empty with GCC.
