### PR TITLE
Fix MSVC build after #206326

### DIFF
--- a/clang/unittests/Basic/CMakeLists.txt
+++ b/clang/unittests/Basic/CMakeLists.txt
@@ -21,3 +21,4 @@ add_distinct_clang_unittest(BasicTests
   Support
   TargetParser
   )
+target_compile_options(BasicTests PRIVATE "$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")


### PR DESCRIPTION
MSVC defaults to a non-utf8 encoding, and we added unicode characters in some test files, which causes CI failures