### PR TITLE
[BOLT] ICF: Use nameStartsWith instead of getName

### DIFF
--- a/bolt/lib/Passes/IdenticalCodeFolding.cpp
+++ b/bolt/lib/Passes/IdenticalCodeFolding.cpp
@@ -384,8 +384,8 @@ namespace bolt {
 void IdenticalCodeFolding::initVTableReferences(const BinaryContext &BC) {
   for (const auto &[Address, Data] : BC.getBinaryData()) {
     // Filter out all symbols that are not vtables.
-    if (!Data->getName().starts_with("_ZTV") && // vtable
-        !Data->getName().starts_with("_ZTCN"))  // construction vtable
+    if (!Data->nameStartsWith("_ZTV") && // vtable
+        !Data->nameStartsWith("_ZTCN"))  // construction vtable
       continue;
     for (uint64_t I = Address, End = I + Data->getSize(); I < End;
          I += VTableAddressGranularity)

--- a/bolt/test/safe-icf-relative-vtable.cpp
+++ b/bolt/test/safe-icf-relative-vtable.cpp
@@ -6,9 +6,9 @@
 // RUN: llvm-bolt %t.so -o %t.bolt --no-threads --icf=safe \
 // RUN:   --debug-only=bolt-icf 2>&1 | FileCheck %s
 
-// RUN: %clang %cxxflags -o %t.so %s -Wl,-q -fno-rtti \
+// RUN: %clang %cxxflags -o %t.exp.so %s -Wl,-q -fno-rtti \
 // RUN:   -fexperimental-relative-c++-abi-vtables
-// RUN: llvm-bolt %t.so -o %t.bolt --no-threads --icf=safe \
+// RUN: llvm-bolt %t.exp.so -o %t.exp.bolt --no-threads --icf=safe \
 // RUN:   --debug-only=bolt-icf 2>&1 | FileCheck %s
 
 // CHECK: folding {{.*bar.*}} into {{.*foo.*}}
@@ -19,6 +19,12 @@ public:
   virtual int foo(int a) { return ++a; }
   virtual int bar(int a) { return ++a; }
 };
+
+// __init_array_end was added to check that ICF works correctly even if the
+// symbol has the same address as a vtable symbol
+extern void (*__init_array_end[])();
+__attribute__((used)) static void *dummy__init_array_end = __init_array_end;
+__attribute__((constructor)) void dummy_ctor() {};
 
 int main() {
   TT T;


### PR DESCRIPTION
The getName method returns the name of the first symbol for a given BinaryData. If a symbol is associated with the same address as a vtable symbol, the ICF check for vtable mangled names may behave unexpectedly. The correct approach is to use nameStartsWith, which checks all symbols associated with the BinaryData.