### PR TITLE
[DSE] Don't eliminate addrspace(5) stores in convergent functions wit…

### DIFF
--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -986,6 +986,10 @@ struct DSEState {
   DenseMap<const Value *, uint64_t> InvisibleToCallerAfterRetBounded;
   // Keep track of blocks with throwing instructions not modeled in MemorySSA.
   SmallPtrSet<BasicBlock *, 16> ThrowingBlocks;
+  // True if the function contains any convergent memory(none) calls. Such calls
+  // observe addrspace(5) per-lane private scratch across all lanes without
+  // appearing as reads in MemorySSA.
+  bool HasConvergentNoMemCall = false;
   // Post-order numbers for each basic block. Used to figure out if memory
   // accesses are executed before another access.
   DenseMap<BasicBlock *, unsigned> PostOrderNumbers;
@@ -1198,6 +1202,10 @@ DSEState::DSEState(Function &F, AliasAnalysis &AA, MemorySSA &MSSA,
       MemoryAccess *MA = MSSA.getMemoryAccess(&I);
       if (I.mayThrow() && !MA)
         ThrowingBlocks.insert(I.getParent());
+      if (!HasConvergentNoMemCall)
+        if (auto *CB = dyn_cast<CallBase>(&I))
+          if (CB->isConvergent() && CB->doesNotAccessMemory())
+            HasConvergentNoMemCall = true;
 
       auto *MD = dyn_cast_or_null<MemoryDef>(MA);
       if (MD && MemDefs.size() < MemorySSADefsPerBlockLimit &&
@@ -1465,7 +1473,17 @@ DSEState::getLocForInst(Instruction *I, bool ConsiderInitializesAttr) {
 }
 
 bool DSEState::isRemovable(Instruction *I) {
-  assert(getLocForWrite(I) && "Must have analyzable write");
+  auto MaybeLoc = getLocForWrite(I);
+  assert(MaybeLoc && "Must have analyzable write");
+
+  // Warp-wide operations (e.g. ballot/bpermute/shuffle on AMPGPU) carry
+  // memory(none) so MemorySSA does not model them as reads. However, they
+  // observe addrspace(5) per-lane private scratch across all lanes, making it
+  // unsound for DSE to eliminate writes to addrspace(5) in convergent
+  // functions that contain such calls.
+  if (F.isConvergent() && HasConvergentNoMemCall &&
+      MaybeLoc->Ptr->getType()->getPointerAddressSpace() == 5)
+    return false;
 
   // Don't remove volatile/atomic stores.
   if (StoreInst *SI = dyn_cast<StoreInst>(I))

--- a/llvm/test/Transforms/DeadStoreElimination/convergent-private-addrspace.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/convergent-private-addrspace.ll
@@ -1,0 +1,48 @@
+; RUN: opt -S -passes=dse < %s | FileCheck %s
+
+; DSE must not remove stores to addrspace(5) (per-lane private scratch) when
+; the function contains convergent memory(none) calls (e.g. ballot/bpermute).
+; Such calls are invisible to MemorySSA but observe private scratch cross-lane.
+
+declare void @shfl(ptr addrspace(5)) convergent readnone
+declare i32 @llvm.amdgcn.ballot.i32(i1) convergent memory(none)
+declare void @llvm.memcpy.p5.p0.i64(ptr addrspace(5) noalias writeonly, ptr noalias readonly, i64, i1 immarg)
+
+; Warp reduction: store intermediate result, shuffle reads it cross-lane,
+; then overwrite. DSE must not remove the first store.
+define void @warp_reduction_intermediate_store(ptr addrspace(5) %warpVal) #0 {
+; CHECK-LABEL: @warp_reduction_intermediate_store(
+; CHECK: store float 1.000000e+00, ptr addrspace(5) %warpVal
+;
+entry:
+  store float 1.0, ptr addrspace(5) %warpVal, align 4
+  call void @shfl(ptr addrspace(5) %warpVal)
+  store float 2.0, ptr addrspace(5) %warpVal, align 4
+  ret void
+}
+
+; Conditional kill: zero-init is overwritten by memcpy only on active lanes.
+; Inactive lanes still hold the zero-init when the ballot observes all lanes.
+; DSE must not remove the zero-init store.
+define i32 @fitbounds_conditional_kill(i1 %active, ptr %src) #0 {
+; CHECK-LABEL: @fitbounds_conditional_kill(
+; CHECK: store i32 0, ptr addrspace(5) %node
+;
+entry:
+  %node = alloca i32, align 4, addrspace(5)
+  store i32 0, ptr addrspace(5) %node, align 4
+  br i1 %active, label %if.then, label %if.end
+
+if.then:
+  call void @llvm.memcpy.p5.p0.i64(ptr addrspace(5) %node, ptr %src, i64 4, i1 false)
+  %loaded = load i32, ptr addrspace(5) %node, align 4
+  %pred = icmp ne i32 %loaded, 0
+  br label %if.end
+
+if.end:
+  %p = phi i1 [ false, %entry ], [ %pred, %if.then ]
+  %v = call i32 @llvm.amdgcn.ballot.i32(i1 %p)
+  ret i32 %v
+}
+
+attributes #0 = { convergent }


### PR DESCRIPTION
…h warp-wide ops

Warp-wide operations (e.g., ballot, bpermute, shuffle on AMDGPU) are marked memory(none) (IntrNoMem) because they operate on scalar register values and do not access addressable memory through pointers. However, they implicitly observe addrspace(5) per-lane private scratch across all lanes simultaneously. Since memory(none) makes these calls invisible to MemorySSA, DSE incorrectly removes addrspace(5) stores that other lanes still observe through these ops.

Fix: during DSE initialization, scan the function for convergent memory(none) calls (HasConvergentNoMemCall). In isRemovable(), treat addrspace(5) stores as non-removable when all three conditions hold:
  - F.isConvergent(): the function is a GPU kernel/device function
  - HasConvergentNoMemCall: the function contains a warp-wide memory(none) call
  - getPointerAddressSpace() == 5: the store targets per-lane private scratch

Note: GPUs whose warp-wide intrinsics use IntrInaccessibleMemOnly instead of IntrNoMem (e.g. NVPTX) are not affected. IntrInaccessibleMemOnly gives those calls MemoryAccesses in MemorySSA, so DSE already treats them as barriers. HasConvergentNoMemCall will never be true for such targets, leaving their DSE behavior completely unchanged.

Add convergent-private-addrspace.ll covering two patterns: a warp reduction with an intermediate store between shuffle rounds, and a conditional killing store where inactive lanes still hold the init value at the wavefront barrier.