### PR TITLE
[Bazel] Port e7290b1f1815626c4461d38671d93093590bf405

### DIFF
--- a/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVIRReader.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVIRReader.h
@@ -15,6 +15,7 @@
 #define LLVM_DEBUGINFO_LOGICALVIEW_READERS_LVIRREADER_H
 
 #include "llvm/DebugInfo/LogicalView/Core/LVReader.h"
+#include "llvm/Object/IRObjectFile.h"
 #include "llvm/Transforms/Utils/DebugSSAUpdater.h"
 #include <unordered_map>
 

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -655,16 +655,20 @@ cc_library(
     copts = llvm_copts,
     deps = [
         ":BinaryFormat",
+        ":CodeGen",
+        ":Core",
         ":DebugInfo",
         ":DebugInfoCodeView",
         ":DebugInfoDWARF",
         ":DebugInfoDWARFLowLevel",
         ":DebugInfoPDB",
         ":Demangle",
+        ":IRReader",
         ":MC",
         ":MCDisassembler",
         ":Object",
         ":Support",
+        ":TransformUtils",
     ],
 )
 


### PR DESCRIPTION
We also need to add a header or otherwise we end up with incomplete types for template instanation in modules builds which are used for header parsing.