### PR TITLE
[NFC][LLVM] Remove `XFAIL: vg_leaks` from TableGen lit tests

### DIFF
--- a/llvm/test/TableGen/2010-03-24-PrematureDefaults.td
+++ b/llvm/test/TableGen/2010-03-24-PrematureDefaults.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen --no-warn-on-unused-template-args %s | FileCheck %s
-// XFAIL: vg_leak
 
 class A<int k, bits<2> x = 1> {
   int K = k;

--- a/llvm/test/TableGen/AnonDefinitionOnDemand.td
+++ b/llvm/test/TableGen/AnonDefinitionOnDemand.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Defs ---
 

--- a/llvm/test/TableGen/ClassInstanceValue.td
+++ b/llvm/test/TableGen/ClassInstanceValue.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class Struct<int i> {
   int I = !shl(i, 1);

--- a/llvm/test/TableGen/Dag.td
+++ b/llvm/test/TableGen/Dag.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 //===----------------------------------------------------------------------===//
 // Substitution of an int.

--- a/llvm/test/TableGen/DefmInherit.td
+++ b/llvm/test/TableGen/DefmInherit.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: zing = 4
 // CHECK: zing = 4

--- a/llvm/test/TableGen/DefmInsideMultiClass.td
+++ b/llvm/test/TableGen/DefmInsideMultiClass.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: ADDPSrr
 // CHECK-NOT: ADDPSrr

--- a/llvm/test/TableGen/FieldAccess.td
+++ b/llvm/test/TableGen/FieldAccess.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Defs ---
 

--- a/llvm/test/TableGen/ForwardRef.td
+++ b/llvm/test/TableGen/ForwardRef.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s -o -
-// XFAIL: vg_leak
 
 class bar {
   list<bar> x;

--- a/llvm/test/TableGen/LetInsideMultiClasses.td
+++ b/llvm/test/TableGen/LetInsideMultiClasses.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: bit IsDouble = 1;
 // CHECK: bit IsDouble = 1;

--- a/llvm/test/TableGen/ListArgs.td
+++ b/llvm/test/TableGen/ListArgs.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s
-// XFAIL: vg_leak
 
 class B<list<int> v> {
   list<int> vals = v;

--- a/llvm/test/TableGen/ListArgsSimple.td
+++ b/llvm/test/TableGen/ListArgsSimple.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s
-// XFAIL: vg_leak
 
 class B<int v> {
   int val = v;

--- a/llvm/test/TableGen/ListConversion.td
+++ b/llvm/test/TableGen/ListConversion.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s
-// XFAIL: vg_leak
 class A;
 class B : A;
 

--- a/llvm/test/TableGen/ListManip.td
+++ b/llvm/test/TableGen/ListManip.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s
-// XFAIL: vg_leak
 
 class Bli<string _t>
 {

--- a/llvm/test/TableGen/ListOfList.td
+++ b/llvm/test/TableGen/ListOfList.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class Base<string t> {
   string text = t;

--- a/llvm/test/TableGen/ListSlices.td
+++ b/llvm/test/TableGen/ListSlices.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // This file has tests for the list slice suffix.
 

--- a/llvm/test/TableGen/LoLoL.td
+++ b/llvm/test/TableGen/LoLoL.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class Base<list<int> v> {
   list<int> values = v;

--- a/llvm/test/TableGen/MultiClass-def-fail.td
+++ b/llvm/test/TableGen/MultiClass-def-fail.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 // This test checks that using def instead of defm gives a meaningful error
 multiclass M2 {

--- a/llvm/test/TableGen/MultiClass-defm-fail.td
+++ b/llvm/test/TableGen/MultiClass-defm-fail.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 // This test verifies that tablegen does fail if it can't resolve an unresolved
 // !cast() during processing top-level defm.

--- a/llvm/test/TableGen/MultiClass-defm.td
+++ b/llvm/test/TableGen/MultiClass-defm.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class A {}
 class B<A a> {

--- a/llvm/test/TableGen/MultiClass.td
+++ b/llvm/test/TableGen/MultiClass.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: zing = 4
 // CHECK: zing = 4

--- a/llvm/test/TableGen/MultiClassDefName.td
+++ b/llvm/test/TableGen/MultiClassDefName.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: WorldHelloCC
 // CHECK-NOT: WorldHelloCC

--- a/llvm/test/TableGen/MultiClassInherit.td
+++ b/llvm/test/TableGen/MultiClassInherit.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // "zing = 4" x 28
 // CHECK: zing = 4

--- a/llvm/test/TableGen/MultiPat.td
+++ b/llvm/test/TableGen/MultiPat.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class ValueType<int size, int value> {
   int Size = size;

--- a/llvm/test/TableGen/Paste.td
+++ b/llvm/test/TableGen/Paste.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class Instr<int i> {
   int index = i;

--- a/llvm/test/TableGen/SetTheory.td
+++ b/llvm/test/TableGen/SetTheory.td
@@ -1,6 +1,5 @@
 // Test evaluation of set operations in dags.
 // RUN: llvm-tblgen -print-sets %s | FileCheck %s
-// XFAIL: vg_leak
 //
 // The -print-sets driver configures a primitive SetTheory instance that
 // understands these sets:

--- a/llvm/test/TableGen/Slice.td
+++ b/llvm/test/TableGen/Slice.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class ValueType<int size, int value> {
   int Size = size;

--- a/llvm/test/TableGen/SuperSubclassSameName.td
+++ b/llvm/test/TableGen/SuperSubclassSameName.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen < %s
-// XFAIL: vg_leak
 // Test for template arguments that have the same name as superclass template
 // arguments.
 

--- a/llvm/test/TableGen/TargetInstrInfo.td
+++ b/llvm/test/TableGen/TargetInstrInfo.td
@@ -1,7 +1,6 @@
 // This test describes how we eventually want to describe instructions in
 // the target independent code generators.
 // RUN: llvm-tblgen %s
-// XFAIL: vg_leak
 
 // Target indep stuff.
 class Instruction {   // Would have other stuff eventually

--- a/llvm/test/TableGen/TargetInstrSpec.td
+++ b/llvm/test/TableGen/TargetInstrSpec.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: [(set VR128:$dst, (int_x86_sse2_add_pd VR128:$src1, VR128:$src2))]
 // CHECK-NOT: [(set VR128:$dst, (int_x86_sse2_add_pd VR128:$src1, VR128:$src2))]

--- a/llvm/test/TableGen/TemplateArgRename.td
+++ b/llvm/test/TableGen/TemplateArgRename.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen --no-warn-on-unused-template-args %s
-// XFAIL: vg_leak
 
 // Make sure there is no collision between XX and XX.
 def S;

--- a/llvm/test/TableGen/Tree.td
+++ b/llvm/test/TableGen/Tree.td
@@ -1,6 +1,5 @@
 // This tests to make sure we can parse tree patterns.
 // RUN: llvm-tblgen %s
-// XFAIL: vg_leak
 
 class TreeNode;
 class RegisterClass;

--- a/llvm/test/TableGen/TreeNames.td
+++ b/llvm/test/TableGen/TreeNames.td
@@ -1,6 +1,5 @@
 // This tests to make sure we can parse tree patterns with names.
 // RUN: llvm-tblgen %s
-// XFAIL: vg_leak
 
 class TreeNode;
 class RegisterClass;

--- a/llvm/test/TableGen/TwoLevelName.td
+++ b/llvm/test/TableGen/TwoLevelName.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class Type<string name, int length, int width> {
   string Name = name;

--- a/llvm/test/TableGen/UnsetBitInit.td
+++ b/llvm/test/TableGen/UnsetBitInit.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Defs ---
 

--- a/llvm/test/TableGen/ValidIdentifiers.td
+++ b/llvm/test/TableGen/ValidIdentifiers.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen -gen-ctags %s | FileCheck %s
-// XFAIL: vg_leak
 
 // Ensure that generated names for anonymous records are valid identifiers via the ctags index.
 

--- a/llvm/test/TableGen/arithmetic.td
+++ b/llvm/test/TableGen/arithmetic.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Defs ---
 

--- a/llvm/test/TableGen/cast-typeerror.td
+++ b/llvm/test/TableGen/cast-typeerror.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 class A;
 class B;

--- a/llvm/test/TableGen/cast.td
+++ b/llvm/test/TableGen/cast.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: add_ps
 // CHECK: add_ps

--- a/llvm/test/TableGen/code.td
+++ b/llvm/test/TableGen/code.td
@@ -1,6 +1,5 @@
 // RUN: llvm-tblgen %s | FileCheck %s
 // RUN: not llvm-tblgen -DERROR1 %s 2>&1 | FileCheck --check-prefix=ERROR1 %s
-// XFAIL: vg_leak
 
 // CHECK: def A1
 // CHECK:   code CodeCode = [{code here;}]

--- a/llvm/test/TableGen/cond-bitlist.td
+++ b/llvm/test/TableGen/cond-bitlist.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class S<int s> {
   bits<2> val = !cond(!eq(s, 8):  {0, 0},

--- a/llvm/test/TableGen/cond-default.td
+++ b/llvm/test/TableGen/cond-default.td
@@ -1,7 +1,6 @@
 // Check that not specifying a valid condition results in error
 
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 class C<int x> {
   string s  = !cond(!lt(x,0) : "negative", !gt(x,0) : "positive");

--- a/llvm/test/TableGen/cond-empty-list-arg.td
+++ b/llvm/test/TableGen/cond-empty-list-arg.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // Check that !cond works with an empty list value.
 

--- a/llvm/test/TableGen/cond-inheritance.td
+++ b/llvm/test/TableGen/cond-inheritance.td
@@ -1,6 +1,5 @@
 // Make sure !cond gets propagated across multiple layers of inheritance.
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class getInt<int c> {
   int ret = !cond(c: 0, 1 : 1);

--- a/llvm/test/TableGen/cond-let.td
+++ b/llvm/test/TableGen/cond-let.td
@@ -1,6 +1,5 @@
 // Check support for `!cond' operator as part of a `let' statement.
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 
 class C<bits<3> x, bits<4> y, bit z> {

--- a/llvm/test/TableGen/cond-list.td
+++ b/llvm/test/TableGen/cond-list.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 
 class A<list<list<int>> vals> {

--- a/llvm/test/TableGen/cond-subclass.td
+++ b/llvm/test/TableGen/cond-subclass.td
@@ -1,7 +1,6 @@
 // Check that !cond with operands of different subtypes can
 // initialize a supertype variable.
 // RUN: llvm-tblgen --no-warn-on-unused-template-args %s | FileCheck %s
-// XFAIL: vg_leak
 
 class E<int dummy> {}
 class E1<int dummy> : E<dummy> {}

--- a/llvm/test/TableGen/cond-type.td
+++ b/llvm/test/TableGen/cond-type.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 class A<int dummy> {}
 class B<int dummy> : A<dummy> {}

--- a/llvm/test/TableGen/cond-usage.td
+++ b/llvm/test/TableGen/cond-usage.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // Check that !cond picks the first true value
 // CHECK:       class A

--- a/llvm/test/TableGen/condsbit.td
+++ b/llvm/test/TableGen/condsbit.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // Check that !cond works well with bit conditional values.
 

--- a/llvm/test/TableGen/dag-functional.td
+++ b/llvm/test/TableGen/dag-functional.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Defs ---
 

--- a/llvm/test/TableGen/defmclass.td
+++ b/llvm/test/TableGen/defmclass.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen --no-warn-on-unused-template-args %s | FileCheck %s
-// XFAIL: vg_leak
 
 class XD { bits<4> Prefix = 11; }
 // CHECK: Prefix = { 1, 1, 0, 0 };

--- a/llvm/test/TableGen/defset-typeerror.td
+++ b/llvm/test/TableGen/defset-typeerror.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: error: adding record of incompatible type 'A' to defset
 

--- a/llvm/test/TableGen/defset.td
+++ b/llvm/test/TableGen/defset.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Defs ---
 

--- a/llvm/test/TableGen/empty.td
+++ b/llvm/test/TableGen/empty.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 defvar LongList = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 defvar EmptyStr = "";

--- a/llvm/test/TableGen/eq.td
+++ b/llvm/test/TableGen/eq.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK-LABEL: def FALSE {
 //       CHECK:   int Value = 0;

--- a/llvm/test/TableGen/eqbit.td
+++ b/llvm/test/TableGen/eqbit.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK-LABEL: def X {
 //       CHECK:   int a = 6;

--- a/llvm/test/TableGen/exists-error-non-string.td
+++ b/llvm/test/TableGen/exists-error-non-string.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen --no-warn-on-unused-template-args %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 //CHECK: expected string type argument in !exists operator
 

--- a/llvm/test/TableGen/exists-error-record.td
+++ b/llvm/test/TableGen/exists-error-record.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen --no-warn-on-unused-template-args %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 //CHECK: expected string type argument in !exists operator, please use !isa instead
 

--- a/llvm/test/TableGen/exists-error-uninitialized.td
+++ b/llvm/test/TableGen/exists-error-uninitialized.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen --no-warn-on-unused-template-args %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 //CHECK: expected string type argument in !exists operator
 

--- a/llvm/test/TableGen/exists.td
+++ b/llvm/test/TableGen/exists.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen --no-warn-on-unused-template-args %s | FileCheck %s
-// XFAIL: vg_leak
 
 class A;
 def a0 : A;

--- a/llvm/test/TableGen/field-access-initializers.td
+++ b/llvm/test/TableGen/field-access-initializers.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: class B<A B:impl = ?> {
 // CHECK:   string value = B:impl.value;

--- a/llvm/test/TableGen/foldl.td
+++ b/llvm/test/TableGen/foldl.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Defs ---
 

--- a/llvm/test/TableGen/foreach-eval.td
+++ b/llvm/test/TableGen/foreach-eval.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // Tests evaluation of !foreach operator.
 

--- a/llvm/test/TableGen/foreach-leak.td
+++ b/llvm/test/TableGen/foreach-leak.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Classes ---
 // CHECK: list<int> ret = !foreach(a,

--- a/llvm/test/TableGen/foreach-multiclass.td
+++ b/llvm/test/TableGen/foreach-multiclass.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Defs ---
 

--- a/llvm/test/TableGen/foreach.td
+++ b/llvm/test/TableGen/foreach.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: Classes
 // CHECK: Sr

--- a/llvm/test/TableGen/generic-tables-instruction.td
+++ b/llvm/test/TableGen/generic-tables-instruction.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen -gen-searchable-tables -I %p/../../include %s | FileCheck %s
-// XFAIL: vg_leak
 
 include "llvm/TableGen/SearchableTable.td"
 include "llvm/Target/Target.td"

--- a/llvm/test/TableGen/generic-tables.td
+++ b/llvm/test/TableGen/generic-tables.td
@@ -1,6 +1,5 @@
 // RUN: llvm-tblgen -gen-searchable-tables -I %p/../../include %s | FileCheck %s
 // RUN: not llvm-tblgen -gen-searchable-tables -I %p/../../include -DERROR1 %s 2>&1 | FileCheck --check-prefix=ERROR1 %s
-// XFAIL: vg_leak
 
 include "llvm/TableGen/SearchableTable.td"
 

--- a/llvm/test/TableGen/if-empty-list-arg.td
+++ b/llvm/test/TableGen/if-empty-list-arg.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s
-// XFAIL: vg_leak
 
 class C<bit cond> {
   list<int> X = !if(cond, [1, 2, 3], []);

--- a/llvm/test/TableGen/if-type.td
+++ b/llvm/test/TableGen/if-type.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 class A<int dummy> {}
 class B<int dummy> : A<dummy> {}

--- a/llvm/test/TableGen/if-unresolved-cast.td
+++ b/llvm/test/TableGen/if-unresolved-cast.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 class A { int x; }
 

--- a/llvm/test/TableGen/if.td
+++ b/llvm/test/TableGen/if.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen --no-warn-on-unused-template-args %s | FileCheck %s
-// XFAIL: vg_leak
 
 // Support for an `!if' operator as part of a `let' statement.
 // CHECK:      class C

--- a/llvm/test/TableGen/ifbit.td
+++ b/llvm/test/TableGen/ifbit.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 // CHECK: a = 6
 // CHECK: a = 5
 

--- a/llvm/test/TableGen/instances.td
+++ b/llvm/test/TableGen/instances.td
@@ -2,7 +2,6 @@
 // RUN: not llvm-tblgen -DERROR1 %s 2>&1 | FileCheck --check-prefix=ERROR1 %s
 // RUN: not llvm-tblgen -DERROR2 %s 2>&1 | FileCheck --check-prefix=ERROR2 %s
 // RUN: not llvm-tblgen -DERROR3 %s 2>&1 | FileCheck --check-prefix=ERROR3 %s
-// XFAIL: vg_leak
 
 class A;
 def a0 : A;

--- a/llvm/test/TableGen/intrinsic-long-name.td
+++ b/llvm/test/TableGen/intrinsic-long-name.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen -gen-intrinsic-enums -I %p/../../include %s -DTEST_INTRINSICS_SUPPRESS_DEFS | FileCheck %s
-// XFAIL: vg_leak
 
 include "llvm/IR/Intrinsics.td"
 

--- a/llvm/test/TableGen/intrinsic-varargs.td
+++ b/llvm/test/TableGen/intrinsic-varargs.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen -gen-intrinsic-impl -I %p/../../include %s -DTEST_INTRINSICS_SUPPRESS_DEFS | FileCheck %s
-// XFAIL: vg_leak
 
 include "llvm/IR/Intrinsics.td"
 

--- a/llvm/test/TableGen/isa.td
+++ b/llvm/test/TableGen/isa.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen --no-warn-on-unused-template-args %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Defs ---
 

--- a/llvm/test/TableGen/list-element-bitref.td
+++ b/llvm/test/TableGen/list-element-bitref.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class C<list<bits<4>> L> {
   bits<2> V0 = L[0]{1...0};

--- a/llvm/test/TableGen/match.td
+++ b/llvm/test/TableGen/match.td
@@ -3,7 +3,6 @@
 // RUN: not llvm-tblgen -DERROR2 %s 2>&1 | FileCheck --check-prefix=ERROR2 %s
 // RUN: not llvm-tblgen -DERROR3 %s 2>&1 | FileCheck --check-prefix=ERROR3 %s
 // RUN: not llvm-tblgen -DERROR4 %s 2>&1 | FileCheck --check-prefix=ERROR4 %s
-// XFAIL: vg_leak
 
 def test {
   bit test0 = !match("123 abc ABC", "[0-9 a-z A-Z]+");

--- a/llvm/test/TableGen/math.td
+++ b/llvm/test/TableGen/math.td
@@ -6,7 +6,6 @@
 // RUN: not llvm-tblgen -DERROR5 %s 2>&1 | FileCheck --check-prefix=ERROR5 %s
 // RUN: not llvm-tblgen -DERROR6 %s 2>&1 | FileCheck --check-prefix=ERROR6 %s
 // RUN: not llvm-tblgen -DERROR7 %s 2>&1 | FileCheck --check-prefix=ERROR7 %s
-// XFAIL: vg_leak
 
 // CHECK: def shifts
 // CHECK: shifted_b = 8

--- a/llvm/test/TableGen/name-resolution-consistency.td
+++ b/llvm/test/TableGen/name-resolution-consistency.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: def B0a {
 // CHECK:   string e = "B0";

--- a/llvm/test/TableGen/pr8330.td
+++ b/llvm/test/TableGen/pr8330.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen --no-warn-on-unused-template-args %s | FileCheck %s
-// XFAIL: vg_leak
 
 class Or4<bits<8> Val> {
   bits<8> V = {Val{7}, Val{6}, Val{5}, Val{4}, Val{3}, 1, Val{1}, Val{0} };

--- a/llvm/test/TableGen/range-lists.td
+++ b/llvm/test/TableGen/range-lists.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // This file has tests for range lists and range pieces. Some use the
 // deprecated '-' range punctuation just to be sure it still works.

--- a/llvm/test/TableGen/range-op.td
+++ b/llvm/test/TableGen/range-op.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: def range_op_ranges {
 def range_op_ranges {

--- a/llvm/test/TableGen/searchabletables-intrinsic.td
+++ b/llvm/test/TableGen/searchabletables-intrinsic.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen -gen-searchable-tables -I %p/../../include -DTEST_INTRINSICS_SUPPRESS_DEFS %s | FileCheck %s
-// XFAIL: vg_leak
 
 include "llvm/TableGen/SearchableTable.td"
 include "llvm/Target/Target.td"

--- a/llvm/test/TableGen/self-reference-recursion.td
+++ b/llvm/test/TableGen/self-reference-recursion.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 class A<string self> {
   int x = !cast<A>(self).x;

--- a/llvm/test/TableGen/self-reference-typeerror.td
+++ b/llvm/test/TableGen/self-reference-typeerror.td
@@ -1,5 +1,4 @@
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
 
 class Cl<Cl rec> {
   Cl Arec = rec;

--- a/llvm/test/TableGen/self-reference.td
+++ b/llvm/test/TableGen/self-reference.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Defs ---
 

--- a/llvm/test/TableGen/size.td
+++ b/llvm/test/TableGen/size.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // Test !size of lists.
 

--- a/llvm/test/TableGen/submulticlass-leteq.td
+++ b/llvm/test/TableGen/submulticlass-leteq.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 // CHECK:      def X0 { // C
 // CHECK-NEXT:   bit x = 1;
 // CHECK-NEXT: }

--- a/llvm/test/TableGen/submulticlass-typecheck.td
+++ b/llvm/test/TableGen/submulticlass-typecheck.td
@@ -1,6 +1,5 @@
 // RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
-// XFAIL: vg_leak
-// CHECK: {{.*}}:11:30: error: Value specified for template argument 'B::op' is of type bits<4>; expected type bits<8>: C::op
+// CHECK: {{.*}}:10:30: error: Value specified for template argument 'B::op' is of type bits<4>; expected type bits<8>: C::op
 // CHECK-NEXT: multiclass C<bits<4> op> : B<op>;
 class A<bits<8> op> {
   bits<8> f = op;

--- a/llvm/test/TableGen/subst.td
+++ b/llvm/test/TableGen/subst.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class Honorific<string t> {
   string honorific = t;

--- a/llvm/test/TableGen/subst2.td
+++ b/llvm/test/TableGen/subst2.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 // CHECK: No subst
 // CHECK: No foo
 // CHECK: RECURSE foo

--- a/llvm/test/TableGen/template-arg-dependency.td
+++ b/llvm/test/TableGen/template-arg-dependency.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 // CHECK: --- Defs ---
 

--- a/llvm/test/TableGen/usevalname.td
+++ b/llvm/test/TableGen/usevalname.td
@@ -1,5 +1,4 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// XFAIL: vg_leak
 
 class Instr<list<dag> pat> {
   list<dag> Pattern = pat;


### PR DESCRIPTION
This was added with https://github.com/llvm/llvm-project/commit/5c0be2f67ac0d23281b56918f6fe66ed78b9d65b a while back but new TableGen lit tests don't have it, so it seems this is unnecessary. Removing it so that it does not continue to proliferate in new tests through copy-paste.