### PR TITLE
[lldb][Windows] Return EOF from PipeWindows::Read on a closed write end

### DIFF
--- a/lldb/source/Host/windows/PipeWindows.cpp
+++ b/lldb/source/Host/windows/PipeWindows.cpp
@@ -291,8 +291,15 @@ llvm::Expected<size_t> PipeWindows::Read(void *buf, size_t size,
     return bytes_read;
 
   DWORD failure_error = ::GetLastError();
-  if (failure_error != ERROR_IO_PENDING)
+  switch (failure_error) {
+  case ERROR_BROKEN_PIPE:
+  case ERROR_HANDLE_EOF:
+    return 0;
+  case ERROR_IO_PENDING:
+    break;
+  default:
     return Status(failure_error, eErrorTypeWin32).takeError();
+  }
 
   DWORD timeout_msec =
       timeout ? std::chrono::ceil<std::chrono::milliseconds>(*timeout).count()
@@ -319,8 +326,13 @@ llvm::Expected<size_t> PipeWindows::Read(void *buf, size_t size,
 
   // Now we call GetOverlappedResult setting bWait to false, since we've
   // already waited as long as we're willing to.
-  if (!::GetOverlappedResult(m_read, &m_read_overlapped, &bytes_read, FALSE))
-    return Status(::GetLastError(), eErrorTypeWin32).takeError();
+  if (!::GetOverlappedResult(m_read, &m_read_overlapped, &bytes_read, FALSE)) {
+    DWORD overlapped_error = ::GetLastError();
+    if (overlapped_error == ERROR_BROKEN_PIPE ||
+        overlapped_error == ERROR_HANDLE_EOF)
+      return 0;
+    return Status(overlapped_error, eErrorTypeWin32).takeError();
+  }
 
   return bytes_read;
 }

--- a/lldb/source/Host/windows/PipeWindows.cpp
+++ b/lldb/source/Host/windows/PipeWindows.cpp
@@ -292,6 +292,9 @@ llvm::Expected<size_t> PipeWindows::Read(void *buf, size_t size,
 
   DWORD failure_error = ::GetLastError();
   switch (failure_error) {
+  // A closed write end is EOF, not an error. POSIX read() returns 0
+  // in this case. Mirror that so cross-platform callers can detect EOF
+  // uniformly.
   case ERROR_BROKEN_PIPE:
   case ERROR_HANDLE_EOF:
     return 0;
@@ -328,6 +331,7 @@ llvm::Expected<size_t> PipeWindows::Read(void *buf, size_t size,
   // already waited as long as we're willing to.
   if (!::GetOverlappedResult(m_read, &m_read_overlapped, &bytes_read, FALSE)) {
     DWORD overlapped_error = ::GetLastError();
+    // See above: a closed write end is end-of-file, not an error.
     if (overlapped_error == ERROR_BROKEN_PIPE ||
         overlapped_error == ERROR_HANDLE_EOF)
       return 0;


### PR DESCRIPTION
A closed pipe write end is EOF, not an error. On POSIX, `read()` returns 0, but on Windows `ReadFile` fails with `ERROR_BROKEN_PIPE`. The lldb-server `gdbserver/platform` pipe synchronization in `GDBRemoteCommunication::StartDebugserverProcess` reads the pipe until EOF, so without this it sees an error instead of EOF and reports the sync as failed.

Translate both broken-pipe conditions to a zero-length read so cross-platform callers can detect EOF uniformly.

rdar://180736036