### PR TITLE
[TableGen] Fix SearchableTable lookup comparator w/ multiple string keys

### DIFF
--- a/llvm/test/TableGen/searchabletables-multi-string-key.td
+++ b/llvm/test/TableGen/searchabletables-multi-string-key.td
@@ -1,11 +1,5 @@
 // RUN: llvm-tblgen -gen-searchable-tables -I %p/../../include %s | FileCheck %s
 
-// When SearchIndex has multiple string-typed key fields, the emitted
-// comparator declares the local helper variables `StringRef LHSStr` and
-// `StringRef RHSStr` once per field in the same scope, producing C++ that
-// fails to compile due to variable redeclaration. See
-// SearchableTableEmitter.cpp's emitComparator lambda.
-
 include "llvm/TableGen/SearchableTable.td"
 
 class MyTableEntry<string first, string second, int val> {
@@ -31,14 +25,14 @@ def lookupMyTableByFirstAndSecond : SearchIndex {
 // CHECK-LABEL: const MyTableEntry *lookupMyTableByFirstAndSecond(StringRef First, StringRef Second)
 // CHECK:        struct Comp {
 // CHECK-NEXT:     bool operator()(const IndexType &LHS, const KeyType &RHS) const {
-// CHECK-NEXT:       StringRef LHSStr = MyTableStrings[LHS.First];
-// CHECK-NEXT:       StringRef RHSStr = RHS.First;
-// CHECK-NEXT:       int CmpFirst = LHSStr.compare(RHSStr);
+// CHECK-NEXT:       StringRef LHSFirstStr = MyTableStrings[LHS.First];
+// CHECK-NEXT:       StringRef RHSFirstStr = RHS.First;
+// CHECK-NEXT:       int CmpFirst = LHSFirstStr.compare(RHSFirstStr);
 // CHECK-NEXT:       if (CmpFirst < 0) return true;
 // CHECK-NEXT:       if (CmpFirst > 0) return false;
-// CHECK-NEXT:       StringRef LHSStr = MyTableStrings[LHS.Second];
-// CHECK-NEXT:       StringRef RHSStr = RHS.Second;
-// CHECK-NEXT:       int CmpSecond = LHSStr.compare(RHSStr);
+// CHECK-NEXT:       StringRef LHSSecondStr = MyTableStrings[LHS.Second];
+// CHECK-NEXT:       StringRef RHSSecondStr = RHS.Second;
+// CHECK-NEXT:       int CmpSecond = LHSSecondStr.compare(RHSSecondStr);
 // CHECK-NEXT:       if (CmpSecond < 0) return true;
 // CHECK-NEXT:       if (CmpSecond > 0) return false;
 // CHECK-NEXT:       return false;

--- a/llvm/test/TableGen/searchabletables-multi-string-key.td
+++ b/llvm/test/TableGen/searchabletables-multi-string-key.td
@@ -1,0 +1,46 @@
+// RUN: llvm-tblgen -gen-searchable-tables -I %p/../../include %s | FileCheck %s
+
+// When SearchIndex has multiple string-typed key fields, the emitted
+// comparator declares the local helper variables `StringRef LHSStr` and
+// `StringRef RHSStr` once per field in the same scope, producing C++ that
+// fails to compile due to variable redeclaration. See
+// SearchableTableEmitter.cpp's emitComparator lambda.
+
+include "llvm/TableGen/SearchableTable.td"
+
+class MyTableEntry<string first, string second, int val> {
+  string First = first;
+  string Second = second;
+  bits<8> Val = val;
+}
+
+def : MyTableEntry<"foo", "baz", 1>;
+def : MyTableEntry<"foo", "quux", 2>;
+def : MyTableEntry<"bar", "baz", 3>;
+
+def MyTable : GenericTable {
+  let FilterClass = "MyTableEntry";
+  let Fields = ["First", "Second", "Val"];
+}
+
+def lookupMyTableByFirstAndSecond : SearchIndex {
+  let Table = MyTable;
+  let Key = ["First", "Second"];
+}
+
+// CHECK-LABEL: const MyTableEntry *lookupMyTableByFirstAndSecond(StringRef First, StringRef Second)
+// CHECK:        struct Comp {
+// CHECK-NEXT:     bool operator()(const IndexType &LHS, const KeyType &RHS) const {
+// CHECK-NEXT:       StringRef LHSStr = MyTableStrings[LHS.First];
+// CHECK-NEXT:       StringRef RHSStr = RHS.First;
+// CHECK-NEXT:       int CmpFirst = LHSStr.compare(RHSStr);
+// CHECK-NEXT:       if (CmpFirst < 0) return true;
+// CHECK-NEXT:       if (CmpFirst > 0) return false;
+// CHECK-NEXT:       StringRef LHSStr = MyTableStrings[LHS.Second];
+// CHECK-NEXT:       StringRef RHSStr = RHS.Second;
+// CHECK-NEXT:       int CmpSecond = LHSStr.compare(RHSStr);
+// CHECK-NEXT:       if (CmpSecond < 0) return true;
+// CHECK-NEXT:       if (CmpSecond > 0) return false;
+// CHECK-NEXT:       return false;
+// CHECK-NEXT:     }
+// CHECK-NEXT:   };

--- a/llvm/utils/TableGen/SearchableTableEmitter.cpp
+++ b/llvm/utils/TableGen/SearchableTableEmitter.cpp
@@ -497,19 +497,25 @@ void SearchableTableEmitter::emitLookupFunction(const GenericTable &Table,
   auto emitComparator = [&](bool LHSIsKey, bool RHSIsKey) {
     for (const auto &Field : Index.Fields) {
       if (isa<StringRecTy>(Field.RecType)) {
+        std::string LHSVar = "LHS" + Field.Name + "Str";
+        std::string RHSVar = "RHS" + Field.Name + "Str";
+        std::string CmpVar = "Cmp" + Field.Name;
         if (LHSIsKey)
-          OS << "      StringRef LHSStr = LHS." << Field.Name << ";\n";
+          OS << "      StringRef " << LHSVar << " = LHS." << Field.Name
+             << ";\n";
         else
-          OS << "      StringRef LHSStr = " << Table.Name << "Strings[LHS."
-             << Field.Name << "];\n";
+          OS << "      StringRef " << LHSVar << " = " << Table.Name
+             << "Strings[LHS." << Field.Name << "];\n";
         if (RHSIsKey)
-          OS << "      StringRef RHSStr = RHS." << Field.Name << ";\n";
+          OS << "      StringRef " << RHSVar << " = RHS." << Field.Name
+             << ";\n";
         else
-          OS << "      StringRef RHSStr = " << Table.Name << "Strings[RHS."
-             << Field.Name << "];\n";
-        OS << "      int Cmp" << Field.Name << " = LHSStr.compare(RHSStr);\n";
-        OS << "      if (Cmp" << Field.Name << " < 0) return true;\n";
-        OS << "      if (Cmp" << Field.Name << " > 0) return false;\n";
+          OS << "      StringRef " << RHSVar << " = " << Table.Name
+             << "Strings[RHS." << Field.Name << "];\n";
+        OS << "      int " << CmpVar << " = " << LHSVar << ".compare(" << RHSVar
+           << ");\n";
+        OS << "      if (" << CmpVar << " < 0) return true;\n";
+        OS << "      if (" << CmpVar << " > 0) return false;\n";
       } else if (Field.Enum) {
         // Explicitly cast to unsigned, because the signedness of enums is
         // compiler-dependent.


### PR DESCRIPTION
This change fixes a bug in `SearchableTableEmitter::emitLookupFunction` where `emitComparator` redeclares `LHSStr`/`RHSStr` in the same scope. This fix simply attaches the Field.Name to the emitted `LHSStr`/`RHSStr` variable names.