### PR TITLE
[lldb][Windows] Don't let the inferior inherit the --pipe handle

### DIFF
--- a/lldb/tools/lldb-server/lldb-gdbserver.cpp
+++ b/lldb/tools/lldb-server/lldb-gdbserver.cpp
@@ -11,7 +11,9 @@
 #include <cstdio>
 #include <cstring>
 
-#ifndef _WIN32
+#ifdef _WIN32
+#include "lldb/Host/windows/windows.h"
+#else
 #include <csignal>
 #include <unistd.h>
 #endif
@@ -423,6 +425,11 @@ int main_gdbserver(int argc, char *argv[]) {
       return EXIT_FAILURE;
     }
     unnamed_pipe = (pipe_t)Arg;
+#ifdef _WIN32
+    // Prevent the inferior we later launch from inheriting this pipe's write
+    // handle.
+    ::SetHandleInformation((HANDLE)unnamed_pipe, HANDLE_FLAG_INHERIT, 0);
+#endif
   }
   if (Args.hasArg(OPT_fd)) {
     int64_t fd;

--- a/lldb/tools/lldb-server/lldb-gdbserver.cpp
+++ b/lldb/tools/lldb-server/lldb-gdbserver.cpp
@@ -426,6 +426,11 @@ int main_gdbserver(int argc, char *argv[]) {
     }
     unnamed_pipe = (pipe_t)Arg;
 #ifdef _WIN32
+    if (::GetFileType((HANDLE)unnamed_pipe) != FILE_TYPE_PIPE) {
+      WithColor::error() << "'--pipe' argument is not a pipe handle\n"
+                         << HelpText;
+      return EXIT_FAILURE;
+    }
     // Prevent the inferior we later launch from inheriting this pipe's write
     // handle.
     ::SetHandleInformation((HANDLE)unnamed_pipe, HANDLE_FLAG_INHERIT, 0);


### PR DESCRIPTION
`lldb-server` writes its listening socket id to the `--pipe` handle and then closes it. The parent process that spawned it reads the pipe until EOF purely as a synchronization point (`"the server is now listening"`).

On Windows the inferior is launched with `bInheritHandles=TRUE` (it needs the ConPTY handles), so it also inherited the pipe's write end. That kept the write end open after `lldb-server` closed its own handle, so the parent never saw EOF: it blocked until its read timeout and the client's connection handshake timed out first.

This patch clears `HANDLE_FLAG_INHERIT` on the `--pipe` handle so the inferior cannot keep the write end open, while leaving it valid for lldb-server's own use.

rdar://180736036