### PR TITLE
[RISCV][P-ext] Tighten checks for what scalar<->vector bitcasts are legal

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -7959,16 +7959,12 @@ SDValue RISCVTargetLowering::LowerOperation(SDValue Op,
       return DAG.getNode(RISCVISD::BuildPairF64, DL, MVT::f64, Lo, Hi);
     }
 
-    if (Subtarget.hasStdExtP()) {
-      bool Is32BitCast =
-          (VT == MVT::i32 && (Op0VT == MVT::v4i8 || Op0VT == MVT::v2i16)) ||
-          (Op0VT == MVT::i32 && (VT == MVT::v4i8 || VT == MVT::v2i16));
-      bool Is64BitCast =
-          (VT == MVT::i64 && (Op0VT == MVT::v8i8 || Op0VT == MVT::v4i16 ||
-                              Op0VT == MVT::v2i32)) ||
-          (Op0VT == MVT::i64 &&
-           (VT == MVT::v8i8 || VT == MVT::v4i16 || VT == MVT::v2i32));
-      if (Is32BitCast || Is64BitCast)
+    if (Subtarget.hasStdExtP() && VT.isSimple() && Op0VT.isSimple()) {
+      if (VT.getSimpleVT() == Subtarget.getXLenVT() &&
+          Subtarget.isPExtPackedType(Op0VT.getSimpleVT()))
+        return Op;
+      if (Op0VT.getSimpleVT() == Subtarget.getXLenVT() &&
+          Subtarget.isPExtPackedType(VT.getSimpleVT()))
         return Op;
     }
 

--- a/llvm/test/CodeGen/RISCV/rvp-bitcast-paired.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-bitcast-paired.ll
@@ -2,6 +2,9 @@
 ; RUN: llc -mtriple=riscv32 -mattr=+experimental-p,+m,+zbb \
 ; RUN:   -verify-machineinstrs < %s | \
 ; RUN:   FileCheck --check-prefixes=CHECK-RV32 %s
+; RUN: llc -mtriple=riscv32 -mattr=+experimental-p,+m,+zbb,+d \
+; RUN:   -verify-machineinstrs < %s | \
+; RUN:   FileCheck --check-prefixes=CHECK-RV32 %s
 ; RUN: llc -mtriple=riscv64 -mattr=+experimental-p,+m,+zbb \
 ; RUN:   -verify-machineinstrs < %s | \
 ; RUN:   FileCheck --check-prefixes=CHECK-RV64 %s


### PR DESCRIPTION
We were incorrectly treating i64<->vector casts as legal on RV32. This only shows up when the D extension is enabled because it marks i64 bitcast as custom for i64<->f64 conversions.

Rewrite the checks in terms of XLenVT.