### PR TITLE
[Sema] Strip atomic qualifier in TryObjectArgumentInitialization

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -754,6 +754,7 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
   calling `__builtin_bit_cast`. (#GH200112)
 - Clang now SFINAE friendly when the ``__reference_meows_from_temporary`` builtins
   should SFINAE friendly when the 1st type is not a reference type. (#GH206524)
+- Fixed an assertion failure when calling a member function on an `_Atomic`-qualified struct. (#GH206860)
 
 
 #### Bug Fixes to Attribute Support

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -6122,6 +6122,11 @@ static ImplicitConversionSequence TryObjectArgumentInitialization(
     assert(FromClassification.isLValue());
   }
 
+  // Strip atomic qualifier - accessing members of _Atomic structs
+  // is undefined behavior but shouldn't crash the compiler.
+  if (const auto *AT = FromType->getAs<AtomicType>())
+    FromType = AT->getValueType();
+
   auto ValueKindFromClassification = [](Expr::Classification C) {
     if (C.isPRValue())
       return clang::VK_PRValue;

--- a/clang/test/SemaCXX/atomic-member-access-crash.cpp
+++ b/clang/test/SemaCXX/atomic-member-access-crash.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+// This test verifies that accessing members of an _Atomic struct
+// produces diagnostics instead of crashing.
+
+struct S {};
+constexpr S s;
+
+struct SS {
+  consteval const S *operator->() const { return &s; }
+  consteval int foo() const { return 42; }
+};
+
+_Atomic SS ss; // expected-note {{declared here}}
+
+int v = ss->bar; // expected-error {{no member named 'bar' in 'SS'}} \
+                 // expected-error {{call to consteval function 'SS::operator->' is not a constant expression}} \
+                 // expected-note {{read of non-constexpr variable 'ss' is not allowed in a constant expression}}
+int x = ss.foo(); // expected-error {{accessing a member of an atomic structure or union is undefined behavior}}


### PR DESCRIPTION
TryObjectArgumentInitialization strips pointer types from FromType but not atomic qualifiers. When calling a member function on an _Atomic struct (e.g. _Atomic SS ss; ss.foo()), FromType is _Atomic SS which is not a record type, hitting assert(FromType->isRecordType()).
This patch strips the atomic qualifier the same way other conversion paths in SemaOverload.cpp already do (e.g. line 2447). Accessing members of an _Atomic struct is undefined behavior and already produces a warning, but shouldn't crash the compiler.
Fixes #206860.