### PR TITLE
[lldb] Find the default source file's main by base name

### DIFF
--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -429,12 +429,15 @@ SourceManager::GetDefaultFileAndLine() {
         function_options.include_symbols =
             false; // Force it to be a debug symbol.
         function_options.include_inlines = true;
-        // The linkage name can differ from the source name, so match on the
-        // base name to find the function regardless of how it was mangled or
-        // renamed.
         executable_ptr->FindFunctions(main_name, CompilerDeclContext(),
-                                      lldb::eFunctionNameTypeBase,
+                                      lldb::eFunctionNameTypeFull,
                                       function_options, sc_list);
+        // The linkage name can differ from the source name, so match on the
+        // base name as a fallback.
+        if (sc_list.GetSize() == 0)
+          executable_ptr->FindFunctions(main_name, CompilerDeclContext(),
+                                        lldb::eFunctionNameTypeBase,
+                                        function_options, sc_list);
         for (const SymbolContext &sc : sc_list) {
           if (sc.function) {
             lldb_private::LineEntry line_entry;

--- a/lldb/source/Core/SourceManager.cpp
+++ b/lldb/source/Core/SourceManager.cpp
@@ -429,8 +429,11 @@ SourceManager::GetDefaultFileAndLine() {
         function_options.include_symbols =
             false; // Force it to be a debug symbol.
         function_options.include_inlines = true;
+        // The linkage name can differ from the source name, so match on the
+        // base name to find the function regardless of how it was mangled or
+        // renamed.
         executable_ptr->FindFunctions(main_name, CompilerDeclContext(),
-                                      lldb::eFunctionNameTypeFull,
+                                      lldb::eFunctionNameTypeBase,
                                       function_options, sc_list);
         for (const SymbolContext &sc : sc_list) {
           if (sc.function) {

--- a/lldb/test/API/functionalities/breakpoint/default_source_file/Makefile
+++ b/lldb/test/API/functionalities/breakpoint/default_source_file/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp other.cpp
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/breakpoint/default_source_file/TestDefaultSourceFile.py
+++ b/lldb/test/API/functionalities/breakpoint/default_source_file/TestDefaultSourceFile.py
@@ -1,0 +1,27 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class DefaultSourceFileTestCase(TestBase):
+    def test_default_source_file_is_entry_point(self):
+        """The default file for a line breakpoint is main's file, not Foo::main's."""
+        self.build()
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+
+        entry_line = line_number("main.cpp", "BREAK: entry point")
+
+        # "break set -l" with no file picks the default source file: the one
+        # containing the entry point. Foo::main in other.cpp shares the base
+        # name "main" and must not be chosen instead.
+        lldbutil.run_break_set_by_file_and_line(
+            self, None, entry_line, num_expected_locations=1, loc_exact=True
+        )
+
+        bp = target.GetBreakpointAtIndex(0)
+        loc = bp.GetLocationAtIndex(0)
+        line_entry = loc.GetAddress().GetLineEntry()
+        self.assertEqual(line_entry.GetFileSpec().GetFilename(), "main.cpp")
+        self.assertEqual(line_entry.GetLine(), entry_line)

--- a/lldb/test/API/functionalities/breakpoint/default_source_file/main.cpp
+++ b/lldb/test/API/functionalities/breakpoint/default_source_file/main.cpp
@@ -1,0 +1,10 @@
+// The real entry point. The default source file for line-only breakpoints
+// should resolve to this file, not to other.cpp's ns::main.
+namespace ns {
+int main();
+}
+
+int main(int argc, char **argv) {
+  int local = argc; // BREAK: entry point
+  return ns::main() + local;
+}

--- a/lldb/test/API/functionalities/breakpoint/default_source_file/other.cpp
+++ b/lldb/test/API/functionalities/breakpoint/default_source_file/other.cpp
@@ -1,0 +1,9 @@
+// A function whose base name is also "main". Being a real debug function (not
+// just a symbol), it competes with the entry point in a base-name lookup and
+// must not be mistaken for it when choosing the default source file.
+namespace ns {
+int main() {
+  int value = 1;
+  return value; // ns::main body
+}
+} // namespace ns


### PR DESCRIPTION
SourceManager::GetDefaultFileAndLine locates the executable's main to pick a default source file, used for input like "break set -l N" with no file specified. It searched for main by full name, but a function's linkage name can differ from its source name, in which case a full-name search for "main" does not find it and no default file is chosen.

For example, wasi-libc renames main to __main_argc_argv, so on WebAssembly the debug function for main was never matched and "break set -l N" failed with "no default file available".

Search by base name instead. The base name is "main" regardless of the linkage name, and where the two coincide the behavior is unchanged.