### PR TITLE
[clang][deps] Only disable app extension without PCHs

### DIFF
--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -450,9 +450,14 @@ std::shared_ptr<CompilerInvocation> dependencies::createScanCompilerInvocation(
       true;
   ScanInvocation->getHeaderSearchOpts().ModulesForceValidateUserHeaders = false;
 
-  // Application extension only affects the handling of availability attributes,
-  // which cannot change the dependencies.
-  ScanInvocation->getLangOpts().AppExt = false;
+  // FIXME: Do this even with PCHs by marking the option as something like
+  // "preprocessor benign" in LangOptions.def so that it passes the
+  // compatibility checks in ASTReader.
+  if (ScanInvocation->getPreprocessorOpts().ImplicitPCHInclude.empty()) {
+    // Application extension only affects the handling of availability
+    // attributes, which cannot change the dependencies.
+    ScanInvocation->getLangOpts().AppExt = false;
+  }
 
   // Ensure that the scanner does not create new dependency collectors,
   // and thus won't write out the extra '.d' files to disk.

--- a/clang/test/ClangScanDeps/modules-pch-compatibility.c
+++ b/clang/test/ClangScanDeps/modules-pch-compatibility.c
@@ -1,0 +1,30 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+//--- module.modulemap
+module A { header "A.h" }
+module B { header "B.h" }
+//--- A.h
+//--- B.h
+//--- pch.h
+#include "A.h"
+//--- tu.c
+#include "B.h"
+
+// RUN: clang-scan-deps -format experimental-full -module-files-dir %t/build -o %t/result_pch.json \
+// RUN:   -- %clang -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache \
+// RUN:      -x c-header %t/pch.h -o %t/pch.h.pch \
+// RUN:      -fapplication-extension
+// RUN: %deps-to-rsp %t/result_pch.json --module-name=A > %t/A.rsp
+// RUN: %deps-to-rsp %t/result_pch.json --tu-index=0 > %t/pch.rsp
+// RUN: %clang @%t/A.rsp
+// RUN: %clang @%t/pch.rsp
+
+// RUN: clang-scan-deps -format experimental-full -module-files-dir %t/build -o %t/result_tu.json \
+// RUN:   -- %clang -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache \
+// RUN:      -c %t/tu.c -o %t/tu.o -include %t/pch.h \
+// RUN:      -fapplication-extension
+// RUN: %deps-to-rsp %t/result_tu.json --module-name=B > %t/B.rsp
+// RUN: %deps-to-rsp %t/result_tu.json --tu-index=0 > %t/tu.rsp
+// RUN: %clang @%t/B.rsp
+// RUN: %clang @%t/tu.rsp


### PR DESCRIPTION
PR #200041 disabled application extension during scanning to increase module cache reuse. To keep the build semantics intact, the setting was preserved for the compile steps. When scanning with an explicitly-built PCH, this triggers a mismatch  error in `ASTReader`:

```
error: Objective-C App Extension was enabled in precompiled file 'X.pch' but is currently disabled
```

This PR fixes this by only performing the optimization for non-PCH compiles, adds a test, and a FIXME outlining how this optimization could be applied even for compiles with PCHs.

rdar://180978125