### PR TITLE
[lldb] Remove extra newline from ValueObject errors

### DIFF
--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -452,7 +452,7 @@ bool ValueObjectPrinter::PrintValueAndSummaryIfNeeded(bool &value_printed,
       }
 
       error_printed = true;
-      m_stream->Printf(" <%s>\n", m_error.c_str());
+      m_stream->Printf(" <%s>", m_error.c_str());
     } else {
       // Make sure we have a value and make sure the summary didn't specify
       // that the value should not be printed - and do not print the value if

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
@@ -29,7 +29,8 @@ class TestCase(TestBase):
         )
 
         self.expect(
-            "frame variable *sp_empty", substrs=["(int) *sp_empty = <parent is NULL>"]
+            "frame variable *sp_empty",
+            patterns=[r"\(int\) \*sp_empty = <parent is NULL>\n\Z"],
         )
 
         valobj = self.expect_var_path(

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
@@ -29,7 +29,8 @@ class TestCase(TestBase):
         )
 
         self.expect(
-            "frame variable *up_empty", substrs=["(int) *up_empty = <parent is NULL>"]
+            "frame variable *up_empty",
+            patterns=[r"\(int\) \*up_empty = <parent is NULL>\n\Z"],
         )
 
         valobj = self.expect_var_path(


### PR DESCRIPTION
Change `ValueObjectPrinter` to print only a single newlines after errors.