### PR TITLE
[clang] fix error recovery for invalid member specializations

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -2196,13 +2196,12 @@ DeclResult Sema::CheckClassTemplate(
   if (SS.isSet()) {
     // If the name of the template was qualified, we must be defining the
     // template out-of-line.
-    if (!SS.isInvalid() && !Invalid && !PrevClassTemplate) {
-      Diag(NameLoc, TUK == TagUseKind::Friend
-                        ? diag::err_friend_decl_does_not_match
-                        : diag::err_member_decl_does_not_match)
-          << Name << SemanticContext << /*IsDefinition*/ true << SS.getRange();
-      Invalid = true;
-    }
+    if (!SS.isInvalid() && !Invalid && !PrevClassTemplate)
+      return Diag(NameLoc, TUK == TagUseKind::Friend
+                               ? diag::err_friend_decl_does_not_match
+                               : diag::err_member_decl_does_not_match)
+             << Name << SemanticContext << /*IsDefinition*/ true
+             << SS.getRange();
   }
 
   // If this is a templated friend in a dependent context we should not put it
@@ -2246,7 +2245,7 @@ DeclResult Sema::CheckClassTemplate(
   if (ModulePrivateLoc.isValid())
     NewTemplate->setModulePrivate();
 
-  if (!Invalid && IsMemberSpecialization) {
+  if (IsMemberSpecialization) {
     assert(PrevClassTemplate &&
            "Member specialization without a primary template?");
     NewTemplate->setMemberSpecialization();

--- a/clang/test/SemaTemplate/member-specialization.cpp
+++ b/clang/test/SemaTemplate/member-specialization.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -std=c++17 -verify %s
-// expected-no-diagnostics
 
 template<typename T, typename U> struct X {
   template<typename V> const V &as() { return V::error; }
@@ -9,3 +8,17 @@ template<typename T, typename U> struct X {
 int f(X<int, int> x) {
   return x.as<int>();
 }
+
+namespace GH205971 {
+  template<class> struct A {};
+
+  template<>
+  template<class>
+  struct A<int>::B;
+  // expected-error@-1 {{out-of-line definition of 'B' does not match any declaration}}
+
+  template<>
+  template<class>
+  struct A<int>::B;
+  // expected-error@-1 {{out-of-line definition of 'B' does not match any declaration}}
+} // namespace GH205971


### PR DESCRIPTION
Recover from invalid member specializations as if it wasn't declared.

This undoes the change introduced in #201506 for a more robust approach which keeps the AST valid.

There are no release notes since this fixes a regression which was never released.

Fixes #201490
Fixes #205971