### PR TITLE
[clang][Modules] Support ODR merging of `UsingEnumDecl`

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -874,6 +874,8 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 - Fixed a missing vtable for `dynamic_cast<FinalClass *>(this)` in a function template. (#GH198511)
 - Fixed an assertion failure during init-list checking of an array whose element type is an incomplete class. (#GH140685)
 - Fixed a crash when using a pack indexing type (e.g. ``Ts...[0]``) imported from another module. (#GH204479)
+- Fixed an ODR-merging error in modules, where class-scope `using enum` declarations were not recognized as matching across module
+  boundaries.  (#GH207066)
 
 #### Bug Fixes to AST Handling
 

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -7961,6 +7961,12 @@ bool ASTContext::isSameEntity(const NamedDecl *X, const NamedDecl *Y) const {
     return NAX->getNamespace()->Equals(NAY->getNamespace());
   }
 
+  if (const auto *UX = dyn_cast<UsingEnumDecl>(X)) {
+    const auto *UY = cast<UsingEnumDecl>(Y);
+    return isSameQualifier(UX->getQualifier(), UY->getQualifier()) &&
+           declaresSameEntity(UX->getEnumDecl(), UY->getEnumDecl());
+  }
+
   return false;
 }
 

--- a/clang/test/Modules/modules-using-enum-class-scope.cppm
+++ b/clang/test/Modules/modules-using-enum-class-scope.cppm
@@ -1,0 +1,53 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+// RUN: cd %t
+//
+// RUN: %clang_cc1 -std=c++20 -fmodules -fimplicit-module-maps -x c++ -I%t \
+// RUN:   -emit-module -fmodule-name=ModuleA -o %t/ModuleA.pcm \
+// RUN:   %t/module.modulemap
+//
+// RUN: %clang_cc1 -std=c++20 -fmodules -fimplicit-module-maps -x c++ -I%t \
+// RUN:   -emit-module -fmodule-name=ModuleB -o %t/ModuleB.pcm \
+// RUN:   %t/module.modulemap
+//
+// RUN: %clang_cc1 -std=c++20 -fmodules -fimplicit-module-maps -x c++ -I%t \
+// RUN:   -fmodule-file=%t/ModuleA.pcm \
+// RUN:   -fmodule-file=%t/ModuleB.pcm \
+// RUN:   -verify %t/main.cpp
+
+//--- common.h
+#pragma once
+struct MyStruct {
+  enum class MyEnum { A };
+  using enum MyEnum;
+};
+
+//--- a.h
+#pragma once
+#include "common.h"
+
+//--- b.h
+#pragma once
+#include "common.h"
+
+//--- module.modulemap
+module ModuleA {
+  header "a.h"
+  export *
+}
+
+module ModuleB {
+  header "b.h"
+  export *
+}
+
+//--- main.cpp
+#include "a.h"
+#include "b.h"
+
+inline void use() {
+  auto x = MyStruct::A;
+}
+
+// expected-no-diagnostics


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/207066.

When compiling with C++20 modules, Clang performs ODR merging of class definitions across different modules. During this process, `ASTContext::isSameEntity` is used to check if member declarations match between the definitions.

However, `UsingEnumDecl` (representing C++20 `using enum` declarations) was not handled in `ASTContext::isSameEntity`, causing it to default to returning `false`. Consequently, identical class definitions containing a `using enum` statement failed to merge, resulting in spurious ODR mismatch errors such as: `error: 'MyStruct::MyEnum' from module 'ModuleB' is not present in definition of 'MyStruct' in module 'ModuleA'`.

This patch implements merging support for `UsingEnumDecl` in `ASTContext::isSameEntity` by comparing the nested-name-specifier qualifiers and the underlying `EnumDecl` target.