### PR TITLE
[lldb] Fix build after FileSpec::GetDirectory() ConstString removal

### DIFF
--- a/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTBundleSaver.cpp
+++ b/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTBundleSaver.cpp
@@ -272,8 +272,7 @@ BuildModulesSection(Process &process, FileSpec directory) {
     FileSpec path_to_copy_module = directory;
     path_to_copy_module.AppendPathComponent("modules");
     path_to_copy_module.AppendPathComponent(system_path);
-    sys::fs::create_directories(
-        path_to_copy_module.GetDirectory().GetStringRef());
+    sys::fs::create_directories(path_to_copy_module.GetDirectory());
 
     if (std::error_code ec =
             llvm::sys::fs::copy_file(file, path_to_copy_module.GetPath()))


### PR DESCRIPTION
FileSpec::GetDirectory() now returns llvm::StringRef instead of ConstString, so the .GetStringRef() call no longer compiles.

Regressed by f9b5264523b1 ("[lldb] Remove ConstString getters from FileSpec", #206802).

failed with
```

/build/source/lldb/source/Plugins/Trace/intel-pt/TraceIntelPTBundleSaver.cpp:276:44: error: no member named 'GetStringRef' in 'llvm::StringRef'
  276 |         path_to_copy_module.GetDirectory().GetStringRef());
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
1 error generated.
```