### PR TITLE
[libfuzzer] Improve error message for file not found

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerIO.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerIO.cpp
@@ -8,12 +8,14 @@
 // IO functions.
 //===----------------------------------------------------------------------===//
 
+#include "FuzzerIO.h"
 #include "FuzzerDefs.h"
 #include "FuzzerExtFunctions.h"
-#include "FuzzerIO.h"
 #include "FuzzerUtil.h"
 #include <algorithm>
+#include <cerrno>
 #include <cstdarg>
+#include <cstring>
 #include <fstream>
 #include <iterator>
 #include <sys/stat.h>
@@ -41,7 +43,7 @@ long GetEpoch(const std::string &Path) {
 Unit FileToVector(const std::string &Path, size_t MaxSize, bool ExitOnError) {
   std::ifstream T(Path, std::ios::binary);
   if (ExitOnError && !T) {
-    Printf("No such directory: %s; exiting\n", Path.c_str());
+    Printf("No such file: %s (%s); exiting\n", Path.c_str(), strerror(errno));
     exit(1);
   }
 


### PR DESCRIPTION
We're seeing many instances of this issue on ClusterFuzz. This PR adds more information to help debug the cause of the problem.

See https://crbug.com/529865766 for more context.