### PR TITLE
[clang] Fix enum/non-enum conditional warning in ParseStmt

### DIFF
--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1741,7 +1741,8 @@ StmtResult Parser::ParseWhileStatement(SourceLocation *TrailingElseLoc,
   // while, for, and switch statements are local to the if, while, for, or
   // switch statement (including the controlled statement).
   //
-  unsigned ScopeFlags = Scope::ControlScope | (C99orCXX ? Scope::DeclScope : 0);
+  unsigned ScopeFlags =
+      Scope::ControlScope | (C99orCXX ? Scope::DeclScope : Scope::NoScope);
   ParseScope WhileScope(this, ScopeFlags);
 
   // Parse the condition.


### PR DESCRIPTION
Use Scope::NoScope instead of 0, fixes
```
llvm-project/clang/lib/Parse/ParseStmt.cpp:1744:57: warning: enumerated and non-enumerated type in conditional expression [-Wextra]
 1744 |   unsigned ScopeFlags = Scope::ControlScope | (C99orCXX ? Scope::DeclScope : 0);
```