### PR TITLE
[flang][OpenMP][NFC] Move variant-matching context to semantics

### DIFF
--- a/flang/include/flang/Semantics/openmp-utils.h
+++ b/flang/include/flang/Semantics/openmp-utils.h
@@ -209,6 +209,22 @@ std::optional<DynamicUserCondition> MakeVariantMatchInfo(
     const parser::traits::OmpContextSelectorSpecification &ctxSel,
     SemanticsContext &semaCtx);
 
+/// An `llvm::omp::OMPContext` describing the current compilation, used for
+/// OpenMP variant matching. It overrides ISA-trait matching to test against
+/// the target features.
+class OmpVariantMatchContext : public llvm::omp::OMPContext {
+public:
+  OmpVariantMatchContext(bool isDeviceCompilation, llvm::Triple targetTriple,
+      llvm::Triple targetOffloadTriple, std::string targetFeatures,
+      llvm::ArrayRef<llvm::omp::TraitProperty> constructTraits = {});
+  OmpVariantMatchContext(const SemanticsContext &context,
+      llvm::ArrayRef<llvm::omp::TraitProperty> constructTraits = {});
+  bool matchesISATrait(llvm::StringRef rawString) const override;
+
+private:
+  std::string features_;
+};
+
 std::vector<SomeExpr> GetTopLevelDesignators(const SomeExpr &expr);
 const SomeExpr *HasStorageOverlap(
     const SomeExpr &base, llvm::ArrayRef<SomeExpr> exprs);

--- a/flang/include/flang/Semantics/semantics.h
+++ b/flang/include/flang/Semantics/semantics.h
@@ -113,6 +113,8 @@ public:
   evaluate::TargetCharacteristics &targetCharacteristics() {
     return targetCharacteristics_;
   }
+  const std::string &targetTriple() const { return targetTriple_; }
+  const std::string &targetFeatures() const { return targetFeatures_; }
   Scope &globalScope() { return globalScope_; }
   Scope &intrinsicModulesScope() { return intrinsicModulesScope_; }
   Scope *currentHermeticModuleFileScope() {
@@ -174,6 +176,14 @@ public:
   SemanticsContext &set_openAccDefaultNoneScalarsStrictDisableOption(
       std::string x) {
     openAccDefaultNoneScalarsStrictDisableOption_ = std::move(x);
+    return *this;
+  }
+  SemanticsContext &set_targetTriple(const std::string &x) {
+    targetTriple_ = x;
+    return *this;
+  }
+  SemanticsContext &set_targetFeatures(const std::string &x) {
+    targetFeatures_ = x;
     return *this;
   }
 
@@ -383,6 +393,8 @@ private:
   std::vector<std::string> intrinsicModuleDirectories_;
   std::string moduleDirectory_{"."s};
   std::string moduleFileSuffix_{".mod"};
+  std::string targetTriple_;
+  std::string targetFeatures_;
   bool underscoring_{true};
   bool warnOnNonstandardUsage_{false};
   bool warningsAreErrors_{false};

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1978,7 +1978,9 @@ CompilerInvocation::getSemanticsCtx(
           clang::getDriverOptTable()
               .getOptionPrefixedName(
                   clang::options::OPT_fno_openacc_default_none_scalars_strict)
-              .str());
+              .str())
+      .set_targetTriple(targetMachine.getTargetTriple().str())
+      .set_targetFeatures(targetMachine.getTargetFeatureString().str());
 
   std::string compilerVersion = Fortran::common::getFlangFullVersion();
   Fortran::tools::setUpTargetCharacteristics(

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -5098,7 +5098,8 @@ static void genMetadirective(lower::AbstractConverter &converter,
   llvm::SmallVector<llvm::omp::TraitProperty, 8> constructTraits;
   collectEnclosingConstructTraits(builder.getInsertionBlock()->getParentOp(),
                                   constructTraits);
-  FlangOMPContext ompCtx(builder.getModule(), constructTraits);
+  semantics::omp::OmpVariantMatchContext ompCtx =
+      makeVariantMatchContext(builder.getModule(), constructTraits);
 
   llvm::SmallVector<MetadirectiveCandidate, 4> candidates;
   // A null directive specification represents either the implicit `nothing`
@@ -5295,7 +5296,8 @@ static void genMetadirective(lower::AbstractConverter &converter,
   auto selectBestCandidate =
       [](llvm::ArrayRef<unsigned> candidateIndices,
          llvm::ArrayRef<MetadirectiveCandidate> candidates,
-         const FlangOMPContext &ompCtx) -> std::optional<unsigned> {
+         const semantics::omp::OmpVariantMatchContext &ompCtx)
+      -> std::optional<unsigned> {
     if (candidateIndices.empty())
       return std::nullopt;
     if (candidateIndices.size() == 1)

--- a/flang/lib/Lower/OpenMP/Utils.cpp
+++ b/flang/lib/Lower/OpenMP/Utils.cpp
@@ -1319,7 +1319,7 @@ mlir::Value genIteratorCoordinate(Fortran::lower::AbstractConverter &converter,
 }
 
 // ---------------------------------------------------------------------------
-// FlangOMPContext — shared OMPContext for metadirective variant-matching
+// OpenMP variant-matching context construction from an MLIR module
 // ---------------------------------------------------------------------------
 
 static llvm::Triple getOffloadTargetTriple(mlir::ModuleOp module) {
@@ -1333,29 +1333,17 @@ static llvm::Triple getOffloadTargetTriple(mlir::ModuleOp module) {
   return llvm::Triple();
 }
 
-bool FlangOMPContext::isDeviceCompilation(mlir::ModuleOp module) {
-  return llvm::cast<mlir::omp::OffloadModuleInterface>(module.getOperation())
-      .getIsTargetDevice();
-}
-
-FlangOMPContext::FlangOMPContext(
+semantics::omp::OmpVariantMatchContext makeVariantMatchContext(
     mlir::ModuleOp module,
-    llvm::ArrayRef<llvm::omp::TraitProperty> constructTraits)
-    // No specific device is selected during variant matching; use an unknown
-    // device number so OMPContext does not inadvertently describe the host
-    // device (which would cause target-device selectors to match incorrectly).
-    : OMPContext(isDeviceCompilation(module), fir::getTargetTriple(module),
-                 getOffloadTargetTriple(module),
-                 /*DeviceNum=*/-1),
-      targetFeatures(fir::getTargetFeatures(module)) {
-  for (llvm::omp::TraitProperty trait : constructTraits)
-    addTrait(trait);
-}
-
-bool FlangOMPContext::matchesISATrait(llvm::StringRef rawString) const {
-  if (!targetFeatures || targetFeatures.nullOrEmpty())
-    return false;
-  return targetFeatures.contains(("+" + rawString).str());
+    llvm::ArrayRef<llvm::omp::TraitProperty> constructTraits) {
+  bool isDeviceCompilation =
+      llvm::cast<mlir::omp::OffloadModuleInterface>(module.getOperation())
+          .getIsTargetDevice();
+  mlir::LLVM::TargetFeaturesAttr features = fir::getTargetFeatures(module);
+  return semantics::omp::OmpVariantMatchContext(
+      isDeviceCompilation, fir::getTargetTriple(module),
+      getOffloadTargetTriple(module),
+      features ? features.getFeaturesString() : std::string{}, constructTraits);
 }
 
 void collectEnclosingConstructTraits(

--- a/flang/lib/Lower/OpenMP/Utils.h
+++ b/flang/lib/Lower/OpenMP/Utils.h
@@ -30,6 +30,9 @@ namespace Fortran {
 
 namespace semantics {
 class Symbol;
+namespace omp {
+class OmpVariantMatchContext;
+} // namespace omp
 } // namespace semantics
 
 namespace parser {
@@ -264,18 +267,12 @@ void collectEnclosingConstructTraits(
     mlir::Operation *op,
     llvm::SmallVectorImpl<llvm::omp::TraitProperty> &constructTraits);
 
-/// `OMPContext` flavour used by Flang's OpenMP variant matching. Adds an
-/// ISA-trait override based on the module's target-features attribute.
-class FlangOMPContext final : public llvm::omp::OMPContext {
-public:
-  FlangOMPContext(mlir::ModuleOp module,
-                  llvm::ArrayRef<llvm::omp::TraitProperty> constructTraits);
-  bool matchesISATrait(llvm::StringRef rawString) const override;
-
-private:
-  static bool isDeviceCompilation(mlir::ModuleOp module);
-  mlir::LLVM::TargetFeaturesAttr targetFeatures;
-};
+/// Build the OpenMP variant-matching context for \p module. The device flag,
+/// host triple, offload triple, and target features are read from the module;
+/// \p constructTraits seeds the enclosing-construct traits.
+semantics::omp::OmpVariantMatchContext makeVariantMatchContext(
+    mlir::ModuleOp module,
+    llvm::ArrayRef<llvm::omp::TraitProperty> constructTraits);
 
 } // namespace omp
 } // namespace lower

--- a/flang/lib/Semantics/openmp-utils.cpp
+++ b/flang/lib/Semantics/openmp-utils.cpp
@@ -2419,4 +2419,38 @@ std::optional<DynamicUserCondition> MakeVariantMatchInfo(
   }
   return dynamicCond;
 }
+
+OmpVariantMatchContext::OmpVariantMatchContext(bool isDeviceCompilation,
+    llvm::Triple targetTriple, llvm::Triple targetOffloadTriple,
+    std::string targetFeatures,
+    llvm::ArrayRef<llvm::omp::TraitProperty> constructTraits)
+    // No specific device is selected during variant matching; use an unknown
+    // device number so OMPContext does not inadvertently describe the host
+    // device (which would cause target-device selectors to match incorrectly).
+    : llvm::omp::OMPContext(isDeviceCompilation, std::move(targetTriple),
+          std::move(targetOffloadTriple), /*DeviceNum=*/-1),
+      features_(std::move(targetFeatures)) {
+  for (llvm::omp::TraitProperty trait : constructTraits) {
+    addTrait(trait);
+  }
+}
+
+OmpVariantMatchContext::OmpVariantMatchContext(const SemanticsContext &context,
+    llvm::ArrayRef<llvm::omp::TraitProperty> constructTraits)
+    : OmpVariantMatchContext(context.langOptions().OpenMPIsTargetDevice,
+          llvm::Triple(context.targetTriple()),
+          context.langOptions().OMPTargetTriples.empty()
+              ? llvm::Triple()
+              : context.langOptions().OMPTargetTriples.front(),
+          context.targetFeatures(), constructTraits) {}
+
+bool OmpVariantMatchContext::matchesISATrait(llvm::StringRef rawString) const {
+  // The target feature list is a comma-separated string such as
+  // "+sse,+avx2,-foo"; an ISA trait matches when its "+" form is present.
+  std::string want{("+" + rawString).str()};
+  llvm::SmallVector<llvm::StringRef> tokens;
+  llvm::StringRef(features_).split(
+      tokens, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+  return llvm::is_contained(tokens, want);
+}
 } // namespace Fortran::semantics::omp


### PR DESCRIPTION
Move FlangOMPContext from lowering into semantics as the MLIR-independent OmpVariantMatchContext. This lets an upcoming semantic check reuse the matcher to skip the loop-nest checks for a metadirective variant that cannot be selected on the current target, such as a `device={kind(nohost)}` variant in a host compilation. No functional change to metadirective lowering.

Assisted with copilot.