### PR TITLE
[clang][tablegen] Allow qualifiers on _Vector builtin types

### DIFF
--- a/clang/test/TableGen/target-builtins-prototype-parser.td
+++ b/clang/test/TableGen/target-builtins-prototype-parser.td
@@ -87,6 +87,30 @@ def : Builtin {
   let Spellings = ["__builtin_13"];
 }
 
+def : Builtin {
+// CHECK: Builtin::Info{{.*}} __builtin_14 {{.*}} /* vV2iC* */
+  let Prototype = "void(_Vector<2, int> const *)";
+  let Spellings = ["__builtin_14"];
+}
+
+def : Builtin {
+// CHECK: Builtin::Info{{.*}} __builtin_15 {{.*}} /* vV2iD* */
+  let Prototype = "void(_Vector<2, int> volatile *)";
+  let Spellings = ["__builtin_15"];
+}
+
+def : Builtin {
+// CHECK: Builtin::Info{{.*}} __builtin_16 {{.*}} /* vV2iR* */
+  let Prototype = "void(_Vector<2, int> restrict *)";
+  let Spellings = ["__builtin_16"];
+}
+
+def : Builtin {
+// CHECK: Builtin::Info{{.*}} __builtin_17 {{.*}} /* V2iC*i */
+  let Prototype = "_Vector<2, int> const *(int)";
+  let Spellings = ["__builtin_17"];
+}
+
 #ifdef ERROR_EXPECTED_LANES
 def : Builtin {
 // ERROR_EXPECTED_LANES: :[[# @LINE + 1]]:7: error: Expected number of lanes after '_ExtVector<'

--- a/clang/utils/TableGen/ClangBuiltinsEmitter.cpp
+++ b/clang/utils/TableGen/ClangBuiltinsEmitter.cpp
@@ -274,13 +274,16 @@ private:
       if (AS)
         Type += std::to_string(*AS);
     } else if (T.consume_back("const")) {
-      ParseType(T);
+      if (!T.empty())
+        ParseType(T);
       Type += "C";
     } else if (T.consume_back("volatile")) {
-      ParseType(T);
+      if (!T.empty())
+        ParseType(T);
       Type += "D";
     } else if (T.consume_back("restrict")) {
-      ParseType(T);
+      if (!T.empty())
+        ParseType(T);
       Type += "R";
     } else if (T.consume_back("&")) {
       // References may have an address space qualifier immediately before them.


### PR DESCRIPTION
The builtin prototype parser accepts pointers to _Vector<> template types but not const/volatile/restrict pointers. Currently, _Vector<> types are parsed in a special way, first parsing the type itself, and then parsing the remaining string. For this to work, the remaining type can be empty as " *" and qualifiers are peeled off from the right and the type itself has been already parsed.

This change extends the same approach to const/volatile/restrict qualifiers.