### PR TITLE
[lldb][test] Use a valid main signature in the inlines test

### DIFF
--- a/lldb/test/API/lang/c/inlines/main.c
+++ b/lldb/test/API/lang/c/inlines/main.c
@@ -17,7 +17,7 @@ void test1(int a) {
     test2(a + 1); // third breakpoint
 }
 
-int main(int argc) {
+int main() {
   test2(42);
   test1(23);
   return 0;


### PR DESCRIPTION
lang/c/inlines/main.c declared "int main(int argc)", a single-int- parameter main that clang warns about (-Wmain) and that argc is never used for. Declare it as "int main()".