### PR TITLE
[RISCV] Rework vmsge(u).vx pseudos to work better with near-miss assembler support

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -3894,7 +3894,7 @@ void RISCVAsmParser::emitPseudoExtend(MCInst &Inst, bool SignExtend,
 
 void RISCVAsmParser::emitVMSGE(MCInst &Inst, unsigned Opcode, SMLoc IDLoc,
                                MCStreamer &Out) {
-  if (Inst.getNumOperands() == 3) {
+  if (Inst.getNumOperands() == 4 && !Inst.getOperand(3).getReg()) {
     // unmasked va >= x
     //
     //  pseudoinstruction: vmsge{u}.vx vd, va, x
@@ -3917,6 +3917,7 @@ void RISCVAsmParser::emitVMSGE(MCInst &Inst, unsigned Opcode, SMLoc IDLoc,
     //  expansion: vmslt{u}.vx vd, va, x, v0.t; vmxor.mm vd, vd, v0
     assert(Inst.getOperand(0).getReg() != RISCV::V0 &&
            "The destination register should not be V0.");
+    assert(Inst.getOperand(3).getReg() == RISCV::V0 && "Expected a mask");
     emitToStreamer(Out, MCInstBuilder(Opcode)
                             .addOperand(Inst.getOperand(0))
                             .addOperand(Inst.getOperand(1))
@@ -3934,8 +3935,6 @@ void RISCVAsmParser::emitVMSGE(MCInst &Inst, unsigned Opcode, SMLoc IDLoc,
     //
     //  pseudoinstruction: vmsge{u}.vx vd, va, x, v0.t, vt
     //  expansion: vmslt{u}.vx vt, va, x;  vmandn.mm vd, vd, vt
-    assert(Inst.getOperand(0).getReg() == RISCV::V0 &&
-           "The destination register should be V0.");
     assert(Inst.getOperand(1).getReg() != RISCV::V0 &&
            "The temporary vector register should not be V0.");
     emitToStreamer(Out, MCInstBuilder(Opcode)
@@ -4127,6 +4126,17 @@ bool RISCVAsmParser::validateInstruction(MCInst &Inst,
       SMLoc Loc = Operands.back()->getStartLoc();
       return Error(Loc, "the temporary vector register cannot be the same as "
                         "the destination register");
+    }
+  }
+
+  if (Opcode == RISCV::PseudoVMSGEU_VX_M || Opcode == RISCV::PseudoVMSGE_VX_M) {
+    MCRegister DestReg = Inst.getOperand(0).getReg();
+    MCRegister MaskReg = Inst.getOperand(3).getReg();
+    if (MaskReg == RISCV::V0 && DestReg == RISCV::V0) {
+      SMLoc Loc = Operands.back()->getStartLoc();
+      return Error(Loc, "the destination vector register cannot overlap the "
+                        "mask register unless a temporary register is "
+                        "provided");
     }
   }
 
@@ -4439,12 +4449,10 @@ bool RISCVAsmParser::processInstruction(MCInst &Inst, SMLoc IDLoc,
   case RISCV::PseudoZEXT_W:
     emitPseudoExtend(Inst, /*SignExtend=*/false, /*Width=*/32, IDLoc, Out);
     return false;
-  case RISCV::PseudoVMSGEU_VX:
   case RISCV::PseudoVMSGEU_VX_M:
   case RISCV::PseudoVMSGEU_VX_M_T:
     emitVMSGE(Inst, RISCV::VMSLTU_VX, IDLoc, Out);
     return false;
-  case RISCV::PseudoVMSGE_VX:
   case RISCV::PseudoVMSGE_VX_M:
   case RISCV::PseudoVMSGE_VX_M_T:
     emitVMSGE(Inst, RISCV::VMSLT_VX, IDLoc, Out);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
@@ -1318,16 +1318,10 @@ def PseudoVMSLT_VI : Pseudo<(outs VR:$vd),
 
 let isCodeGenOnly = 0, hasSideEffects = 0, mayLoad = 0,
     mayStore = 0, DestEEW = EEW1 in {
-def PseudoVMSGEU_VX : Pseudo<(outs VR:$vd),
-                             (ins VR:$vs2, GPR:$rs1),
-                             [], "vmsgeu.vx", "$vd, $vs2, $rs1">;
-def PseudoVMSGE_VX : Pseudo<(outs VR:$vd),
-                            (ins VR:$vs2, GPR:$rs1),
-                            [], "vmsge.vx", "$vd, $vs2, $rs1">;
-def PseudoVMSGEU_VX_M : Pseudo<(outs VRNoV0:$vd),
+def PseudoVMSGEU_VX_M : Pseudo<(outs VR:$vd),
                                (ins VR:$vs2, GPR:$rs1, VMaskOp:$vm),
                                [], "vmsgeu.vx", "$vd, $vs2, $rs1$vm">;
-def PseudoVMSGE_VX_M : Pseudo<(outs VRNoV0:$vd),
+def PseudoVMSGE_VX_M : Pseudo<(outs VR:$vd),
                               (ins VR:$vs2, GPR:$rs1, VMaskOp:$vm),
                               [], "vmsge.vx", "$vd, $vs2, $rs1$vm">;
 def PseudoVMSGEU_VX_M_T : Pseudo<(outs VR:$vd, VRNoV0:$scratch),

--- a/llvm/test/MC/RISCV/rvv/invalid.s
+++ b/llvm/test/MC/RISCV/rvv/invalid.s
@@ -557,11 +557,8 @@ vadd.vi v0, v2, 1, v0.t
 # CHECK-ERROR-LABEL: vadd.vi v0, v2, 1, v0.t
 
 vmsge.vx v0, v4, a0, v0.t
-# CHECK-ERROR: invalid instruction, any one of the following would fix this:
+# CHECK-ERROR: the destination vector register cannot overlap the mask register unless a temporary register is provided
 # CHECK-ERROR-LABEL: vmsge.vx v0, v4, a0, v0.t
-# CHECK-ERROR: note: invalid operand for instruction
-# CHECK-ERROR: note: invalid operand for instruction
-# CHECK-ERROR: note: too few operands for instruction
 
 vmerge.vim v0, v1, 1, v0
 # CHECK-ERROR: the destination vector register group cannot be V0


### PR DESCRIPTION
Previously we had 3 pseudos:
 vr destination with no mask
 vrnov0 destination with mask
 vr destination with mask and temporary dest

This was intended to prevent a v0 destination with mask and no temporary. The vrnov0 case confused the near miss code and caused multiple errors.

This patch reduces to 2 pseudos:
 vr destination with optional mask
 vr destination with mask and pseudo

The v0 destination with mask error is moved to validateInstruction which allows us to give a better error.