### PR TITLE
[mlir][vector] Fold vector.to_elements from constants

### DIFF
--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -2621,9 +2621,29 @@ foldToElementsOfBroadcast(ToElementsOp toElementsOp,
   return success();
 }
 
+/// Folds vector.to_elements(arith.constant) into per-element constants:
+///
+///  %v = arith.constant dense<[1, 2]> : vector<2xi32>
+///  %e:2 = vector.to_elements %v : vector<2xi32>
+/// becomes:
+///  %e0 = arith.constant 1 : i32
+///  %e1 = arith.constant 2 : i32
+static LogicalResult
+foldToElementsOfConstant(ToElementsOp toElementsOp, Attribute source,
+                         SmallVectorImpl<OpFoldResult> &results) {
+  auto denseAttr = dyn_cast_if_present<DenseElementsAttr>(source);
+  if (!denseAttr)
+    return failure();
+  llvm::append_range(results, denseAttr.getValues<Attribute>());
+  return success();
+}
+
 LogicalResult ToElementsOp::fold(FoldAdaptor adaptor,
                                  SmallVectorImpl<OpFoldResult> &results) {
   if (succeeded(foldToElementsFromElements(*this, results)))
+    return success();
+
+  if (succeeded(foldToElementsOfConstant(*this, adaptor.getSource(), results)))
     return success();
 
   // Y = ToElements(ShapeCast(X)) -> Y = ToElements(X)

--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -3588,6 +3588,53 @@ func.func @to_elements_from_elements_no_op(%a: f32, %b: f32) -> (f32, f32) {
 
 // -----
 
+// CHECK-LABEL: func @to_elements_of_constant(
+func.func @to_elements_of_constant() -> (i32, i32, i32) {
+  // CHECK-NOT: vector.to_elements
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : i32
+  // CHECK-DAG: %[[C2:.*]] = arith.constant 2 : i32
+  // CHECK-DAG: %[[C3:.*]] = arith.constant 3 : i32
+  %0 = arith.constant dense<[1, 2, 3]> : vector<3xi32>
+  %1:3 = vector.to_elements %0 : vector<3xi32>
+  // CHECK: return %[[C1]], %[[C2]], %[[C3]]
+  return %1#0, %1#1, %1#2 : i32, i32, i32
+}
+
+// -----
+
+// Rebuilding a wider constant from the elements of a constant (e.g. leftover
+// from mask broadcast lowering) must fold to a single constant.
+// CHECK-LABEL: func @from_elements_of_constant_elements(
+func.func @from_elements_of_constant_elements() -> vector<2x3xi1> {
+  // CHECK-NOT: vector.to_elements
+  // CHECK-NOT: vector.from_elements
+  // CHECK: %[[RES:.*]] = arith.constant dense<{{\[}}[true, true, false], [true, true, false]]> : vector<2x3xi1>
+  %0 = arith.constant dense<[true, true, false]> : vector<3xi1>
+  %1:3 = vector.to_elements %0 : vector<3xi1>
+  %2 = vector.from_elements %1#0, %1#1, %1#2, %1#0, %1#1, %1#2 : vector<2x3xi1>
+  // CHECK: return %[[RES]]
+  return %2 : vector<2x3xi1>
+}
+
+// -----
+
+// Rebuilding into a different shape with a permutation (a transpose written
+// via to_elements/from_elements) checks that the folds agree on row-major
+// element order.
+// CHECK-LABEL: func @from_elements_of_constant_elements_permuted(
+func.func @from_elements_of_constant_elements_permuted() -> vector<3x2xi32> {
+  // CHECK-NOT: vector.to_elements
+  // CHECK-NOT: vector.from_elements
+  // CHECK: %[[RES:.*]] = arith.constant dense<{{\[}}[1, 4], [2, 5], [3, 6]]> : vector<3x2xi32>
+  %0 = arith.constant dense<[[1, 2, 3], [4, 5, 6]]> : vector<2x3xi32>
+  %1:6 = vector.to_elements %0 : vector<2x3xi32>
+  %2 = vector.from_elements %1#0, %1#3, %1#1, %1#4, %1#2, %1#5 : vector<3x2xi32>
+  // CHECK: return %[[RES]]
+  return %2 : vector<3x2xi32>
+}
+
+// -----
+
 // CHECK-LABEL: func @from_elements_to_elements_no_op(
 // CHECK-SAME:     %[[A:.*]]: vector<4x2xf32>
 func.func @from_elements_to_elements_no_op(%a: vector<4x2xf32>) -> vector<4x2xf32> {


### PR DESCRIPTION
   For a single `linalg.matmul` (17x13x25, vector sizes [32, 32, 16],
  masked vectorization + mask lowering + canonicalize/cse), this leaves
  ~2000 lines of IR including `from_elements` ops with 512 operands:

  ```mlir
  %c = arith.constant dense<[true, ..., false]> : vector<16xi1>
  %e:16 = vector.to_elements %c : vector<16xi1>
  %m = vector.from_elements %e#0, %e#1, ... (512 operands) : vector<32x32x16xi1>
  ```
  
  With this fold, the existing from_elements folder collapses the whole
  chain into a single arith.constant, and the function reduces to the
  expected 17 ops (~100x fewer). None of this is cleaned up further down
  the pipeline: without the fold, the chain survives into the LLVM
  dialect as ~16k insertelement ops.
