### PR TITLE
[lldb][test] Skip tests for features unsupported on WebAssembly

### DIFF
--- a/lldb/test/API/functionalities/return-value/TestReturnValue.py
+++ b/lldb/test/API/functionalities/return-value/TestReturnValue.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # return value is unrecoverable from the operand stack at a step-out
 class ReturnValueTestCase(TestBase):
     def affected_by_pr33042(self):
         return (

--- a/lldb/test/API/functionalities/scripted_frame_provider/TestScriptedFrameProvider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/TestScriptedFrameProvider.py
@@ -10,6 +10,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import TestBase
 from lldbsuite.test import lldbutil
 
+@skipIfWasm  # multithreaded C++ inferior; wasm has no threads or exceptions
 class ScriptedFrameProviderTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
@@ -10,6 +10,7 @@ from lldbsuite.test.lldbtest import TestBase
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # multithreaded C++ inferior; wasm has no threads or exceptions
 class FrameProviderThreadFilterTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/lang/cpp/thread_local/TestThreadLocal.py
+++ b/lldb/test/API/lang/cpp/thread_local/TestThreadLocal.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test import lldbtest
 
 
+@skipIfWasm  # checks the platform-specific TLS-uninitialized error, N/A to wasm
 class PlatformProcessCrashInfoTestCase(TestBase):
     @expectedFailureAll(oslist=["windows", "linux", "freebsd", "netbsd"])
     @skipIfDarwin  # rdar://120795095

--- a/lldb/test/API/lang/cpp/trivial_abi/TestTrivialABI.py
+++ b/lldb/test/API/lang/cpp/trivial_abi/TestTrivialABI.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # return value is unrecoverable from the operand stack at a step-out
 class TestTrivialABI(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 


### PR DESCRIPTION
- TestReturnValue, TestTrivialABI: a WebAssembly return value lives on the operand stack with no way to locate it at a step-out, so the returned value can't be recovered.
- TestScriptedFrameProvider, TestFrameProviderThreadFilter: the inferior is multithreaded C++, which wasip1 can't build (no threads, and inferiors are compiled without exception support).
- TestThreadLocal: reading thread-locals works, but the test checks the platform-specific error reported when TLS isn't initialized yet, which WebAssembly doesn't have (already xfail/skip on other platforms).