### PR TITLE
[Triple] Add target triple support for Motor OS.

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -681,6 +681,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     }
     case llvm::Triple::Haiku:
       return std::make_unique<HaikuTargetInfo<X86_64TargetInfo>>(Triple, Opts);
+    case llvm::Triple::Motor:
+      return std::make_unique<MotorTargetInfo<X86_64TargetInfo>>(Triple, Opts);
     case llvm::Triple::PS4:
       return std::make_unique<PS4OSTargetInfo<X86_64TargetInfo>>(Triple, Opts);
     case llvm::Triple::PS5:

--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -1115,6 +1115,21 @@ public:
   using OSTargetInfo<Target>::OSTargetInfo;
 };
 
+// Motor OS Target
+template <typename Target>
+class LLVM_LIBRARY_VISIBILITY MotorTargetInfo : public OSTargetInfo<Target> {
+protected:
+  void getOSDefines(const LangOptions &Opts, const llvm::Triple &Triple,
+                    MacroBuilder &Builder) const override {
+    Builder.defineMacro("__motor__");
+    if (Opts.POSIXThreads)
+      Builder.defineMacro("_REENTRANT");
+  }
+
+public:
+  using OSTargetInfo<Target>::OSTargetInfo;
+};
+
 // SerenityOS target
 template <typename Target>
 class LLVM_LIBRARY_VISIBILITY SerenityTargetInfo : public OSTargetInfo<Target> {

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -261,7 +261,8 @@ public:
     Firmware,
     QURT,
     H2,
-    LastOSType = H2
+    Motor, // Motor OS
+    LastOSType = Motor
   };
   enum EnvironmentType {
     UnknownEnvironment,
@@ -659,6 +660,8 @@ public:
   bool isOSFreeBSD() const { return getOS() == Triple::FreeBSD; }
 
   bool isOSFuchsia() const { return getOS() == Triple::Fuchsia; }
+
+  bool isOSMotor() const { return getOS() == Triple::Motor; }
 
   bool isOSDragonFly() const { return getOS() == Triple::DragonFly; }
 
@@ -1180,7 +1183,7 @@ public:
   /// Note: Android API level 29 (10) introduced ELF TLS.
   bool hasDefaultEmulatedTLS() const {
     return (isAndroid() && isAndroidVersionLT(29)) || isOSOpenBSD() ||
-           isWindowsCygwinEnvironment() || isOHOSFamily();
+           isWindowsCygwinEnvironment() || isOHOSFamily() || isOSMotor();
   }
 
   /// True if the target uses TLSDESC by default.

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -509,6 +509,8 @@ StringRef Triple::getOSTypeName(OSType Kind) {
     return "qurt";
   case H2:
     return "h2";
+  case Motor:
+    return "motor";
   }
 
   llvm_unreachable("Invalid OSType");
@@ -980,6 +982,7 @@ static Triple::OSType parseOS(StringRef OSName) {
       .StartsWith("firmware", Triple::Firmware)
       .StartsWith("qurt", Triple::QURT)
       .StartsWith("h2", Triple::H2)
+      .StartsWith("motor", Triple::Motor)
       .Default(Triple::UnknownOS);
 }
 

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -1471,6 +1471,11 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::CheriotRTOS, T.getOS());
 
+  T = Triple("x86_64-unknown-motor");
+  EXPECT_EQ(Triple::x86_64, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::Motor, T.getOS());
+
   T = Triple("spirv64-unknown-chipstar");
   EXPECT_EQ(Triple::spirv64, T.getArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());


### PR DESCRIPTION
Motor OS https://github.com/moturus/motor-os already has x86_64-unknown-motor triple in Rust:

https://doc.rust-lang.org/rustc/platform-support/motor.html

So the same triple is used here.