### PR TITLE
 [InstCombine] Fold (1 << a) to (a + 1) and (2 >> a) to (2 - a) when a is in [0,1]

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
@@ -1385,7 +1385,11 @@ Instruction *InstCombinerImpl::visitShl(BinaryOperator &I) {
     if (computeKnownBits(Op1, &I).countMaxActiveBits() <= 1) {
       auto *Add = BinaryOperator::CreateAdd(Op1, ConstantInt::get(Ty, 1));
       Add->setHasNoUnsignedWrap();
-      Add->setHasNoSignedWrap();
+      // The result can be as large as 2, which is only representable as a
+      // non-negative signed value when Ty has more than 2 bits (otherwise
+      // the constant 2 is itself already negative, e.g. i2 2 == -2).
+      if (BitWidth > 2)
+        Add->setHasNoSignedWrap();
       return Add;
     }
   }
@@ -1419,7 +1423,11 @@ Instruction *InstCombinerImpl::visitLShr(BinaryOperator &I) {
       computeKnownBits(Op1, &I).countMaxActiveBits() <= 1) {
     auto *Sub = BinaryOperator::CreateSub(ConstantInt::get(Ty, 2), Op1);
     Sub->setHasNoUnsignedWrap();
-    Sub->setHasNoSignedWrap();
+    // The result can be as large as 2, which is only representable as a
+    // non-negative signed value when Ty has more than 2 bits (otherwise
+    // the constant 2 is itself already negative, e.g. i2 2 == -2).
+    if (BitWidth > 2)
+      Sub->setHasNoSignedWrap();
     return Sub;
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
@@ -1380,6 +1380,14 @@ Instruction *InstCombinerImpl::visitShl(BinaryOperator &I) {
       Value *NegX = Builder.CreateNeg(X, "neg");
       return BinaryOperator::CreateAnd(NegX, X);
     }
+
+    // 1 << X --> X + 1 if 0 <= X <= 1.
+    if (computeKnownBits(Op1, &I).countMaxActiveBits() <= 1) {
+      auto *Add = BinaryOperator::CreateAdd(Op1, ConstantInt::get(Ty, 1));
+      Add->setHasNoUnsignedWrap();
+      Add->setHasNoSignedWrap();
+      return Add;
+    }
   }
 
   return nullptr;
@@ -1405,6 +1413,15 @@ Instruction *InstCombinerImpl::visitLShr(BinaryOperator &I) {
   // lshr 1, X --> zext (X == 0)
   if (match(Op0, m_One()))
     return new ZExtInst(Builder.CreateIsNull(Op1), Ty);
+
+  // 2 >> X --> 2 - X if 0 <= X <= 1.
+  if (match(Op0, m_SpecificInt(2)) &&
+      computeKnownBits(Op1, &I).countMaxActiveBits() <= 1) {
+    auto *Sub = BinaryOperator::CreateSub(ConstantInt::get(Ty, 2), Op1);
+    Sub->setHasNoUnsignedWrap();
+    Sub->setHasNoSignedWrap();
+    return Sub;
+  }
 
   // (iN (~X) u>> (N - 1)) --> zext (X > -1)
   if (match(Op0, m_OneUse(m_Not(m_Value(X)))) &&

--- a/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
@@ -1383,8 +1383,7 @@ Instruction *InstCombinerImpl::visitShl(BinaryOperator &I) {
 
     // 1 << X --> X + 1 if 0 <= X <= 1.
     if (computeKnownBits(Op1, &I).countMaxActiveBits() <= 1) {
-      auto *Add = BinaryOperator::CreateAdd(Op1, ConstantInt::get(Ty, 1));
-      Add->setHasNoUnsignedWrap();
+      auto *Add = BinaryOperator::CreateNUWAdd(Op1, ConstantInt::get(Ty, 1));
       // The result can be as large as 2, which is only representable as a
       // non-negative signed value when Ty has more than 2 bits (otherwise
       // the constant 2 is itself already negative, e.g. i2 2 == -2).
@@ -1421,8 +1420,7 @@ Instruction *InstCombinerImpl::visitLShr(BinaryOperator &I) {
   // 2 >> X --> 2 - X if 0 <= X <= 1.
   if (match(Op0, m_SpecificInt(2)) &&
       computeKnownBits(Op1, &I).countMaxActiveBits() <= 1) {
-    auto *Sub = BinaryOperator::CreateSub(ConstantInt::get(Ty, 2), Op1);
-    Sub->setHasNoUnsignedWrap();
+    auto *Sub = BinaryOperator::CreateNUWSub(ConstantInt::get(Ty, 2), Op1);
     // The result can be as large as 2, which is only representable as a
     // non-negative signed value when Ty has more than 2 bits (otherwise
     // the constant 2 is itself already negative, e.g. i2 2 == -2).

--- a/llvm/test/Transforms/InstCombine/lshr.ll
+++ b/llvm/test/Transforms/InstCombine/lshr.ll
@@ -1667,3 +1667,14 @@ define i32 @lshr_two_range_zero_two_fail(i32 range(i32 0, 3) %x) {
   %shr = lshr i32 2, %x
   ret i32 %shr
 }
+
+; The constant 2 is not representable as a non-negative signed i2, so nsw
+; must not be added on the replacement sub (PR207089 regression).
+define i2 @lshr_two_i2(i2 range(i2 0, 2) %x) {
+; CHECK-LABEL: @lshr_two_i2(
+; CHECK-NEXT:    [[SHR:%.*]] = sub nuw i2 -2, [[X:%.*]]
+; CHECK-NEXT:    ret i2 [[SHR]]
+;
+  %shr = lshr i2 2, %x
+  ret i2 %shr
+}

--- a/llvm/test/Transforms/InstCombine/lshr.ll
+++ b/llvm/test/Transforms/InstCombine/lshr.ll
@@ -1627,3 +1627,43 @@ define i32 @lshr_two_i32(i32 %x) {
   %shr = lshr i32 2, %x
   ret i32 %shr
 }
+
+; 2 >> X --> 2 - X if 0 <= X <= 1.
+
+define i32 @lshr_two_range_zero_one(i32 range(i32 0, 2) %x) {
+; CHECK-LABEL: @lshr_two_range_zero_one(
+; CHECK-NEXT:    [[SHR:%.*]] = sub nuw nsw i32 2, [[X:%.*]]
+; CHECK-NEXT:    ret i32 [[SHR]]
+;
+  %shr = lshr i32 2, %x
+  ret i32 %shr
+}
+
+define i32 @lshr_two_zext_i1(i1 %b) {
+; CHECK-LABEL: @lshr_two_zext_i1(
+; CHECK-NEXT:    [[SHR:%.*]] = select i1 [[B:%.*]], i32 1, i32 2
+; CHECK-NEXT:    ret i32 [[SHR]]
+;
+  %x = zext i1 %b to i32
+  %shr = lshr i32 2, %x
+  ret i32 %shr
+}
+
+define <4 x i32> @lshr_two_range_zero_one_vec(<4 x i32> range(i32 0, 2) %x) {
+; CHECK-LABEL: @lshr_two_range_zero_one_vec(
+; CHECK-NEXT:    [[SHR:%.*]] = sub nuw nsw <4 x i32> splat (i32 2), [[X:%.*]]
+; CHECK-NEXT:    ret <4 x i32> [[SHR]]
+;
+  %shr = lshr <4 x i32> splat (i32 2), %x
+  ret <4 x i32> %shr
+}
+
+; Negative test - x is not known to be 0 or 1.
+define i32 @lshr_two_range_zero_two_fail(i32 range(i32 0, 3) %x) {
+; CHECK-LABEL: @lshr_two_range_zero_two_fail(
+; CHECK-NEXT:    [[SHR:%.*]] = lshr i32 2, [[X:%.*]]
+; CHECK-NEXT:    ret i32 [[SHR]]
+;
+  %shr = lshr i32 2, %x
+  ret i32 %shr
+}

--- a/llvm/test/Transforms/InstCombine/shift.ll
+++ b/llvm/test/Transforms/InstCombine/shift.ll
@@ -2321,4 +2321,44 @@ define i8 @src_ashr_exact_fail(i8 %x) {
   ret i8 %r
 }
 
+; 1 << X --> X + 1 if 0 <= X <= 1.
+
+define i32 @shl1_range_zero_one(i32 range(i32 0, 2) %x) {
+; CHECK-LABEL: @shl1_range_zero_one(
+; CHECK-NEXT:    [[SHL:%.*]] = add nuw nsw i32 [[X:%.*]], 1
+; CHECK-NEXT:    ret i32 [[SHL]]
+;
+  %shl = shl i32 1, %x
+  ret i32 %shl
+}
+
+define i32 @shl1_zext_i1(i1 %b) {
+; CHECK-LABEL: @shl1_zext_i1(
+; CHECK-NEXT:    [[SHL:%.*]] = select i1 [[B:%.*]], i32 2, i32 1
+; CHECK-NEXT:    ret i32 [[SHL]]
+;
+  %x = zext i1 %b to i32
+  %shl = shl i32 1, %x
+  ret i32 %shl
+}
+
+define <2 x i32> @shl1_range_zero_one_vec(<2 x i32> range(i32 0, 2) %x) {
+; CHECK-LABEL: @shl1_range_zero_one_vec(
+; CHECK-NEXT:    [[SHL:%.*]] = add nuw nsw <2 x i32> [[X:%.*]], splat (i32 1)
+; CHECK-NEXT:    ret <2 x i32> [[SHL]]
+;
+  %shl = shl <2 x i32> splat (i32 1), %x
+  ret <2 x i32> %shl
+}
+
+; Negative test - x is not known to be 0 or 1.
+define i32 @shl1_range_zero_two_fail(i32 range(i32 0, 3) %x) {
+; CHECK-LABEL: @shl1_range_zero_two_fail(
+; CHECK-NEXT:    [[SHL:%.*]] = shl nuw nsw i32 1, [[X:%.*]]
+; CHECK-NEXT:    ret i32 [[SHL]]
+;
+  %shl = shl i32 1, %x
+  ret i32 %shl
+}
+
 declare i16 @llvm.umax.i16(i16, i16)

--- a/llvm/test/Transforms/InstCombine/shift.ll
+++ b/llvm/test/Transforms/InstCombine/shift.ll
@@ -2361,4 +2361,15 @@ define i32 @shl1_range_zero_two_fail(i32 range(i32 0, 3) %x) {
   ret i32 %shl
 }
 
+; The constant 2 is not representable as a non-negative signed i2, so nsw
+; must not be added on the replacement add (PR207089 regression).
+define i2 @shl1_i2(i2 range(i2 0, 2) %x) {
+; CHECK-LABEL: @shl1_i2(
+; CHECK-NEXT:    [[SHL:%.*]] = add nuw i2 [[X:%.*]], 1
+; CHECK-NEXT:    ret i2 [[SHL]]
+;
+  %shl = shl i2 1, %x
+  ret i2 %shl
+}
+
 declare i16 @llvm.umax.i16(i16, i16)


### PR DESCRIPTION
Fixes #207089

Adds two InstCombine folds for shifts where the shift amount is known to be 0 or 1 (e.g. constrained by range metadata, `zext i1`, or `llvm.assume`). This enables further simplification/reassociation once the shift is turned into simple arithmetic.

  - `1 << X` → `X + 1` (nuw nsw)
  - `2 >> X` → `2 - X` (nuw nsw)