### PR TITLE
[RISCV] Constant fold bitcast of constant 0 in combineVectorSizedSetCCEquality.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -18072,7 +18072,13 @@ combineVectorSizedSetCCEquality(EVT VT, SDValue X, SDValue Y, ISD::CondCode CC,
   EVT CmpVT = EVT::getVectorVT(*DAG.getContext(), MVT::i1, NumElts);
 
   SDValue VecX = DAG.getBitcast(VecVT, X);
-  SDValue VecY = DAG.getBitcast(VecVT, Y);
+  SDValue VecY;
+  // Constant fold the common case of comparing with zero. Later optimizations
+  // might not do this for us.
+  if (isNullConstant(Y))
+    VecY = DAG.getConstant(0, DL, VecVT);
+  else
+    VecY = DAG.getBitcast(VecVT, Y);
   SDValue Mask = DAG.getAllOnesConstant(DL, CmpVT);
   SDValue VL = DAG.getConstant(NumElts, DL, XLenVT);
 

--- a/llvm/test/CodeGen/RISCV/rvv/pr206788.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/pr206788.ll
@@ -16,11 +16,9 @@ define i1 @test() {
 ;
 ; ZVL64-LABEL: test:
 ; ZVL64:       # %bb.0:
-; ZVL64-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
-; ZVL64-NEXT:    vmv.v.i v8, 0
 ; ZVL64-NEXT:    vsetivli zero, 8, e8, m1, ta, ma
-; ZVL64-NEXT:    vle8.v v9, (zero)
-; ZVL64-NEXT:    vmsne.vv v8, v9, v8
+; ZVL64-NEXT:    vle8.v v8, (zero)
+; ZVL64-NEXT:    vmsne.vi v8, v8, 0
 ; ZVL64-NEXT:    vcpop.m a0, v8
 ; ZVL64-NEXT:    seqz a0, a0
 ; ZVL64-NEXT:    ret


### PR DESCRIPTION
There seem to be some combinations of vector type and scalar type where a bitcast of constant 0 doesn't get folded or type legalized to a build_vector of 0 with the vector type we want. I think it's when the integer type is 2*xlen and <2 x iXLen> is a legal type, but I'm not sure.

I don't have any other tests to know if adding/improving a DAG combine is worthwhile so I just did this quick fix at the source.