### PR TITLE
[Clang] Remove unused TokenKey::KEYNOZOS

### DIFF
--- a/clang/include/clang/Basic/IdentifierTable.h
+++ b/clang/include/clang/Basic/IdentifierTable.h
@@ -74,15 +74,20 @@ enum TokenKey : unsigned {
   KEYSYCL = 0x800000,
   KEYCUDA = 0x1000000,
   KEYZOS = 0x2000000,
-  KEYNOZOS = 0x4000000,
+  // 0x4000000 was KEYNOZOS, which was unused. The value is kept reserved
+  // so that KEYALL's bit-mask computation remains correct: keywords like
+  // 'volatile' (KEYALL|KEYNOHLSL) go through the per-bit loop in
+  // getKeywordStatus, and every bit set in KEYALL must map to a valid
+  // TokenKey with a handler in getKeywordStatusHelper.
   KEYHLSL = 0x8000000,
   KEYFIXEDPOINT = 0x10000000,
   KEYDEFERTS = 0x20000000,
   KEYNOHLSL = 0x40000000,
   KEYMAX = KEYNOHLSL, // The maximum key
   KEYALLCXX = KEYCXX | KEYCXX11 | KEYCXX20,
-  KEYALL = (KEYMAX | (KEYMAX - 1)) & ~KEYNOMS18 & ~KEYNOOPENCL & ~KEYNOZOS &
-           ~KEYNOHLSL // KEYNOMS18, KEYNOOPENCL, KEYNOZOS, KEYNOHLSL excluded.
+  KEYALL = (KEYMAX | (KEYMAX - 1)) & ~KEYNOMS18 & ~KEYNOOPENCL & ~0x4000000u &
+           ~KEYNOHLSL // KEYNOMS18, KEYNOOPENCL, 0x4000000 (reserved),
+                      // KEYNOHLSL excluded.
 };
 
 /// How a keyword is treated in the selected standard. This enum is ordered

--- a/clang/lib/Basic/IdentifierTable.cpp
+++ b/clang/lib/Basic/IdentifierTable.cpp
@@ -159,7 +159,6 @@ static KeywordStatus getKeywordStatusHelper(const LangOptions &LangOpts,
     return LangOpts.CPlusPlus ? KS_Unknown : KS_Enabled;
   case KEYNOOPENCL:
   case KEYNOMS18:
-  case KEYNOZOS:
   case KEYNOHLSL:
     // The disable behavior for this is handled in getKeywordStatus.
     return KS_Unknown;
@@ -183,8 +182,6 @@ KeywordStatus clang::getKeywordStatus(const LangOptions &LangOpts,
     return KS_Disabled;
   if (LangOpts.MSVCCompat && (Flags & KEYNOMS18) &&
       !LangOpts.isCompatibleWithMSVC(LangOptions::MSVC2015))
-    return KS_Disabled;
-  if (LangOpts.ZOSExt && (Flags & KEYNOZOS))
     return KS_Disabled;
   KeywordStatus CurStatus = KS_Unknown;
 


### PR DESCRIPTION
  [Clang] Remove unused TokenKey::KEYNOZOS

  KEYNOZOS was defined as a TokenKey flag to mark keywords not supported
  on z/OS, but no keyword in TokenKinds.def actually uses it. This patch
  removes the unused enum value and its associated handling code.

  Build: `ninja clang` succeeded (2923/2923 targets).
  Tests: `ninja check-clang` passed — 51180 passed, 0 failed.

  AI assistance was used for code review analysis and CI failure debugging.

  Fixes #206877