### PR TITLE
[lldb] Fix misleading error message when re-importing command script

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1363,9 +1363,9 @@ Status CommandInterpreter::AddUserCommand(llvm::StringRef name,
   if (UserCommandExists(name)) {
     if (!can_replace) {
       result = Status::FromErrorStringWithFormatv(
-          "user command \"{0}\" already exists and force replace was not set "
-          "by --overwrite or 'settings set interpreter.require-overwrite "
-          "false'",
+          "user command \"{0}\" already exists. To allow overwriting, "
+          "pass --overwrite to 'command script add' or run 'settings set "
+          "interpreter.require-overwrite false'",
           name);
       return result;
     }

--- a/lldb/test/API/commands/command/script/TestCommandScript.py
+++ b/lldb/test/API/commands/command/script/TestCommandScript.py
@@ -166,9 +166,10 @@ class CmdPythonTestCase(TestBase):
             "command script add my_command --class welcome.TargetnameCommand",
             substrs=[
                 (
-                    'user command "my_command" already exists and force replace was'
-                    " not set by --overwrite or 'settings set"
-                    " interpreter.require-overwrite false'"
+                    'user command "my_command" already exists. To allow'
+                    " overwriting, pass --overwrite to 'command script add'"
+                    " or run 'settings set interpreter.require-overwrite"
+                    " false'"
                 ),
             ],
             error=True,


### PR DESCRIPTION
When running "command script import" a second time, the error message suggested using --overwrite, but that flag only exists on "command script add", not on "command script import". This was confusing because the user has no way to pass --overwrite through the import command.

The new message explicitly states that --overwrite applies to "command script add" and presents the settings alternative as a clear, standalone option:

Before:
  user command "foo" already exists and force replace was not set
  by --overwrite or 'settings set interpreter.require-overwrite false'

After:
  user command "foo" already exists. To allow overwriting, pass
  --overwrite to 'command script add' or run 'settings set
  interpreter.require-overwrite false'

Fixes #206508