### PR TITLE
[RISCV] Report "unexpected extra operand" for surplus operands in AsmParser

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -1705,10 +1705,25 @@ void RISCVAsmParser::FilterNearMisses(
   std::multimap<unsigned, unsigned> OperandMissesSeen;
   SmallSet<FeatureBitset, 4> FeatureMissesSeen;
   bool ReportedTooFewOperands = false;
+  bool ReportedTooManyOperands = false;
 
   for (NearMissInfo &I : NearMissesIn) {
     switch (I.getKind()) {
     case NearMissInfo::NearMissOperand: {
+      // When the matcher finds surplus operands, it records them as
+      // NearMissOperand with InvalidMatchClass. We detect this and report
+      // "too many operands" instead of "invalid operand".
+      if (I.getOperandClass() == InvalidMatchClass) {
+        if (!ReportedTooManyOperands) {
+          SMLoc OperandLoc =
+              ((RISCVOperand &)*Operands[I.getOperandIndex()]).getStartLoc();
+          NearMissesOut.emplace_back(
+              NearMissMessage{OperandLoc, "too many operands for instruction"});
+          ReportedTooManyOperands = true;
+        }
+        break;
+      }
+
       SMLoc OperandLoc =
           ((RISCVOperand &)*Operands[I.getOperandIndex()]).getStartLoc();
       std::string OperandDiag = getCustomOperandDiag(I.getOperandError());

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -1710,13 +1710,14 @@ void RISCVAsmParser::FilterNearMisses(
   for (NearMissInfo &I : NearMissesIn) {
     switch (I.getKind()) {
     case NearMissInfo::NearMissOperand: {
+      SMLoc OperandLoc =
+          ((RISCVOperand &)*Operands[I.getOperandIndex()]).getStartLoc();
+
       // When the matcher finds surplus operands, it records them as
       // NearMissOperand with InvalidMatchClass. We detect this and report
       // "too many operands" instead of "invalid operand".
       if (I.getOperandClass() == InvalidMatchClass) {
         if (!ReportedTooManyOperands) {
-          SMLoc OperandLoc =
-              ((RISCVOperand &)*Operands[I.getOperandIndex()]).getStartLoc();
           NearMissesOut.emplace_back(
               NearMissMessage{OperandLoc, "too many operands for instruction"});
           ReportedTooManyOperands = true;
@@ -1724,8 +1725,6 @@ void RISCVAsmParser::FilterNearMisses(
         break;
       }
 
-      SMLoc OperandLoc =
-          ((RISCVOperand &)*Operands[I.getOperandIndex()]).getStartLoc();
       std::string OperandDiag = getCustomOperandDiag(I.getOperandError());
 
       // If we have already emitted a message for a superclass on this operand,

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -1715,11 +1715,11 @@ void RISCVAsmParser::FilterNearMisses(
 
       // When the matcher finds surplus operands, it records them as
       // NearMissOperand with InvalidMatchClass. We detect this and report
-      // "too many operands" instead of "invalid operand".
+      // "unexpected extra operand" instead of "invalid operand".
       if (I.getOperandClass() == InvalidMatchClass) {
         if (!ReportedTooManyOperands) {
-          NearMissesOut.emplace_back(
-              NearMissMessage{OperandLoc, "too many operands for instruction"});
+          NearMissesOut.emplace_back(NearMissMessage{
+              OperandLoc, "unexpected extra operand for instruction"});
           ReportedTooManyOperands = true;
         }
         break;

--- a/llvm/test/MC/RISCV/corev/XCValu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCValu-invalid.s
@@ -14,7 +14,7 @@ cv.addrnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.addrnr t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.addun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -38,7 +38,7 @@ cv.addun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.addun t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.extbz t0, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -50,7 +50,7 @@ cv.extbz t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.extbz t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.addnr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -65,7 +65,7 @@ cv.addnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.addnr t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.clipu t0, t1, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -86,7 +86,7 @@ cv.clipu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.clipu t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.minu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -101,7 +101,7 @@ cv.minu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.minu t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.abs t0, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -113,7 +113,7 @@ cv.abs t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.abs t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.addrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -137,7 +137,7 @@ cv.addrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.addrn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.suburn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -161,7 +161,7 @@ cv.suburn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.suburn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.clip t0, t1, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -182,7 +182,7 @@ cv.clip t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.clip t0, t1, 0, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.addunr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -197,7 +197,7 @@ cv.addunr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.addunr t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.addurn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -221,7 +221,7 @@ cv.addurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.addurn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.subun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -245,7 +245,7 @@ cv.subun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.subun t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.subn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -269,7 +269,7 @@ cv.subn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.subn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.subrnr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -284,7 +284,7 @@ cv.subrnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.subrnr t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.slet t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -299,7 +299,7 @@ cv.slet t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.slet t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.suburnr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -314,7 +314,7 @@ cv.suburnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.suburnr t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.maxu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -329,7 +329,7 @@ cv.maxu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.maxu t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.extbs t0, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -341,7 +341,7 @@ cv.extbs t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.extbs t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.exths t0, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -353,7 +353,7 @@ cv.exths t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.exths t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.max t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -368,7 +368,7 @@ cv.max t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.max t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.subunr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -383,7 +383,7 @@ cv.subunr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.subunr t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.exthz t0, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -395,7 +395,7 @@ cv.exthz t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.exthz t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.clipur t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -410,7 +410,7 @@ cv.clipur t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.clipur t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.addurnr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -425,7 +425,7 @@ cv.addurnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.addurnr t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.addn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -449,7 +449,7 @@ cv.addn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.addn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.subrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -473,7 +473,7 @@ cv.subrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.subrn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.subnr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -488,7 +488,7 @@ cv.subnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.subnr t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.clipr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -503,7 +503,7 @@ cv.clipr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.clipr t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sletu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -518,7 +518,7 @@ cv.sletu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.sletu t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.min t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -533,4 +533,4 @@ cv.min t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.min t0, t1, t2, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction

--- a/llvm/test/MC/RISCV/corev/XCValu-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCValu-invalid.s
@@ -14,7 +14,7 @@ cv.addrnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.addrnr t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.addun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -38,7 +38,7 @@ cv.addun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.addun t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.extbz t0, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -50,7 +50,7 @@ cv.extbz t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.extbz t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.addnr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -65,7 +65,7 @@ cv.addnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.addnr t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.clipu t0, t1, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -86,7 +86,7 @@ cv.clipu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.clipu t0, t1, 0, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.minu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -101,7 +101,7 @@ cv.minu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.minu t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.abs t0, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -113,7 +113,7 @@ cv.abs t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.abs t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.addrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -137,7 +137,7 @@ cv.addrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.addrn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.suburn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -161,7 +161,7 @@ cv.suburn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.suburn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.clip t0, t1, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -182,7 +182,7 @@ cv.clip t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.clip t0, t1, 0, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.addunr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -197,7 +197,7 @@ cv.addunr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.addunr t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.addurn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -221,7 +221,7 @@ cv.addurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.addurn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -245,7 +245,7 @@ cv.subun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.subun t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -269,7 +269,7 @@ cv.subn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.subn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subrnr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -284,7 +284,7 @@ cv.subrnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.subrnr t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.slet t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -299,7 +299,7 @@ cv.slet t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.slet t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.suburnr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -314,7 +314,7 @@ cv.suburnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.suburnr t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.maxu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -329,7 +329,7 @@ cv.maxu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.maxu t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.extbs t0, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -341,7 +341,7 @@ cv.extbs t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.extbs t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.exths t0, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -353,7 +353,7 @@ cv.exths t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.exths t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.max t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -368,7 +368,7 @@ cv.max t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.max t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subunr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -383,7 +383,7 @@ cv.subunr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.subunr t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.exthz t0, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -395,7 +395,7 @@ cv.exthz t0
 # CHECK-ERROR: too few operands for instruction
 
 cv.exthz t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.clipur t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -410,7 +410,7 @@ cv.clipur t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.clipur t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.addurnr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -425,7 +425,7 @@ cv.addurnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.addurnr t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.addn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -449,7 +449,7 @@ cv.addn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.addn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -473,7 +473,7 @@ cv.subrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.subrn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subnr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -488,7 +488,7 @@ cv.subnr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.subnr t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.clipr t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -503,7 +503,7 @@ cv.clipr t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.clipr t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sletu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -518,7 +518,7 @@ cv.sletu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.sletu t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.min t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -533,4 +533,4 @@ cv.min t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.min t0, t1, t2, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/corev/XCVbitmanip-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVbitmanip-invalid.s
@@ -224,10 +224,10 @@ cv.ff1 t0, 0
 # CHECK-ERROR: invalid operand for instruction
 
 cv.ff1 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.ff1 t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction 
+# CHECK-ERROR: too many operands for instruction
 
 cv.fl1 t0
 # CHECK-ERROR: too few operands for instruction
@@ -236,10 +236,10 @@ cv.fl1 t0, 0
 # CHECK-ERROR: invalid operand for instruction
 
 cv.fl1 t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.fl1 t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction 
+# CHECK-ERROR: too many operands for instruction
 
 cv.clb t0
 # CHECK-ERROR: too few operands for instruction
@@ -248,10 +248,10 @@ cv.clb t0, 0
 # CHECK-ERROR: invalid operand for instruction
 
 cv.clb t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.clb t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction 
+# CHECK-ERROR: too many operands for instruction
 
 cv.cnt t0
 # CHECK-ERROR: too few operands for instruction
@@ -260,8 +260,8 @@ cv.cnt t0, 0
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cnt t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cnt t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction 
+# CHECK-ERROR: too many operands for instruction
 

--- a/llvm/test/MC/RISCV/corev/XCVbitmanip-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVbitmanip-invalid.s
@@ -224,10 +224,10 @@ cv.ff1 t0, 0
 # CHECK-ERROR: invalid operand for instruction
 
 cv.ff1 t0, t1, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.ff1 t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.fl1 t0
 # CHECK-ERROR: too few operands for instruction
@@ -236,10 +236,10 @@ cv.fl1 t0, 0
 # CHECK-ERROR: invalid operand for instruction
 
 cv.fl1 t0, t1, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.fl1 t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.clb t0
 # CHECK-ERROR: too few operands for instruction
@@ -248,10 +248,10 @@ cv.clb t0, 0
 # CHECK-ERROR: invalid operand for instruction
 
 cv.clb t0, t1, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.clb t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cnt t0
 # CHECK-ERROR: too few operands for instruction
@@ -260,8 +260,8 @@ cv.cnt t0, 0
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cnt t0, t1, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cnt t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 

--- a/llvm/test/MC/RISCV/corev/XCVmac-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVmac-invalid.s
@@ -14,7 +14,7 @@ cv.mac t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.mac t0, t1, t2, t4
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.machhsn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -38,7 +38,7 @@ cv.machhsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.machhsn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.machhsrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -62,7 +62,7 @@ cv.machhsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.machhsrn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.machhun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -86,7 +86,7 @@ cv.machhun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.machhun t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.machhurn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -110,7 +110,7 @@ cv.machhurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.machhurn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.macsn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -134,7 +134,7 @@ cv.macsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.macsn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.macsrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -158,7 +158,7 @@ cv.macsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.macsrn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.macun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -182,7 +182,7 @@ cv.macun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.macun t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.macurn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -206,7 +206,7 @@ cv.macurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.macurn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.msu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -221,7 +221,7 @@ cv.msu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.msu t0, t1, t2, t4
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.mulhhs t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -236,7 +236,7 @@ cv.mulhhs t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhs t0, t1, t2, t4
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.mulhhsn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -260,7 +260,7 @@ cv.mulhhsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhsn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.mulhhsrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -284,7 +284,7 @@ cv.mulhhsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhsrn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.mulhhu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -299,7 +299,7 @@ cv.mulhhu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhu t0, t1, t2, t4
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.mulhhun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -323,7 +323,7 @@ cv.mulhhun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhun t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.mulhhurn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -347,7 +347,7 @@ cv.mulhhurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhurn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.muls t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -362,7 +362,7 @@ cv.muls t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.muls t0, t1, t2, t4
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.mulsn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -386,7 +386,7 @@ cv.mulsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulsn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.mulsrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -410,7 +410,7 @@ cv.mulsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulsrn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.mulu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -425,7 +425,7 @@ cv.mulu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulu t0, t1, t2, t4
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.mulun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -449,7 +449,7 @@ cv.mulun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulun t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.mulurn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -473,4 +473,4 @@ cv.mulurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulurn t0, t1, t2, 0, a0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction

--- a/llvm/test/MC/RISCV/corev/XCVmac-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVmac-invalid.s
@@ -14,7 +14,7 @@ cv.mac t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.mac t0, t1, t2, t4
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.machhsn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -38,7 +38,7 @@ cv.machhsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.machhsn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.machhsrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -62,7 +62,7 @@ cv.machhsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.machhsrn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.machhun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -86,7 +86,7 @@ cv.machhun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.machhun t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.machhurn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -110,7 +110,7 @@ cv.machhurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.machhurn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.macsn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -134,7 +134,7 @@ cv.macsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.macsn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.macsrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -158,7 +158,7 @@ cv.macsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.macsrn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.macun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -182,7 +182,7 @@ cv.macun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.macun t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.macurn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -206,7 +206,7 @@ cv.macurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.macurn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.msu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -221,7 +221,7 @@ cv.msu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.msu t0, t1, t2, t4
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulhhs t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -236,7 +236,7 @@ cv.mulhhs t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhs t0, t1, t2, t4
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulhhsn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -260,7 +260,7 @@ cv.mulhhsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhsn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulhhsrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -284,7 +284,7 @@ cv.mulhhsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhsrn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulhhu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -299,7 +299,7 @@ cv.mulhhu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhu t0, t1, t2, t4
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulhhun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -323,7 +323,7 @@ cv.mulhhun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhun t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulhhurn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -347,7 +347,7 @@ cv.mulhhurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulhhurn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.muls t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -362,7 +362,7 @@ cv.muls t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.muls t0, t1, t2, t4
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulsn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -386,7 +386,7 @@ cv.mulsn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulsn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulsrn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -410,7 +410,7 @@ cv.mulsrn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulsrn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulu t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -425,7 +425,7 @@ cv.mulu t0, t1
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulu t0, t1, t2, t4
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulun t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -449,7 +449,7 @@ cv.mulun t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulun t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.mulurn t0, t1, t2, -1
 # CHECK-ERROR: immediate must be an integer in the range [0, 31]
@@ -473,4 +473,4 @@ cv.mulurn t0, t1, t2
 # CHECK-ERROR: too few operands for instruction
 
 cv.mulurn t0, t1, t2, 0, a0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/corev/XCVmem-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVmem-invalid.s
@@ -33,7 +33,7 @@ cv.lb t0, (t2)
 # CHECK-ERROR: :[[@LINE-1]]:15: error: too few operands for instruction
 
 cv.lb t0, (t1), t2, t3
-# CHECK-ERROR: :[[@LINE-1]]:21: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:21: error: too many operands for instruction
 
 cv.lbu t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:12: error: invalid operand for instruction
@@ -67,7 +67,7 @@ cv.lbu t0, (t2)
 # CHECK-ERROR: :[[@LINE-1]]:16: error: too few operands for instruction
 
 cv.lbu t0, (t1), t2, t3 
-# CHECK-ERROR: :[[@LINE-1]]:22: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:22: error: too many operands for instruction
 
 cv.lh t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
@@ -104,7 +104,7 @@ cv.lh t0, (t1)
 # CHECK-ERROR: :[[@LINE-1]]:15: error: too few operands for instruction
 
 cv.lh t0, (t1), t2, t3
-# CHECK-ERROR: :[[@LINE-1]]:21: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:21: error: too many operands for instruction
 
 cv.lhu t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:12: error: invalid operand for instruction
@@ -141,7 +141,7 @@ cv.lhu t0, (t1)
 # CHECK-ERROR: :[[@LINE-1]]:16: error: too few operands for instruction
 
 cv.lhu t0, (t1), t2, t3
-# CHECK-ERROR: :[[@LINE-1]]:22: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:22: error: too many operands for instruction
 
 cv.lw t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
@@ -178,7 +178,7 @@ cv.lw t0, (t1)
 # CHECK-ERROR: :[[@LINE-1]]:15: error: too few operands for instruction
 
 cv.lw t0, (t1), t2, t3
-# CHECK-ERROR: :[[@LINE-1]]:21: error: invalid operand for instruction
+# CHECK-ERROR: :[[@LINE-1]]:21: error: too many operands for instruction
 
 cv.sb t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/corev/XCVmem-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVmem-invalid.s
@@ -33,7 +33,7 @@ cv.lb t0, (t2)
 # CHECK-ERROR: :[[@LINE-1]]:15: error: too few operands for instruction
 
 cv.lb t0, (t1), t2, t3
-# CHECK-ERROR: :[[@LINE-1]]:21: error: too many operands for instruction
+# CHECK-ERROR: :[[@LINE-1]]:21: error: unexpected extra operand for instruction
 
 cv.lbu t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:12: error: invalid operand for instruction
@@ -67,7 +67,7 @@ cv.lbu t0, (t2)
 # CHECK-ERROR: :[[@LINE-1]]:16: error: too few operands for instruction
 
 cv.lbu t0, (t1), t2, t3 
-# CHECK-ERROR: :[[@LINE-1]]:22: error: too many operands for instruction
+# CHECK-ERROR: :[[@LINE-1]]:22: error: unexpected extra operand for instruction
 
 cv.lh t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
@@ -104,7 +104,7 @@ cv.lh t0, (t1)
 # CHECK-ERROR: :[[@LINE-1]]:15: error: too few operands for instruction
 
 cv.lh t0, (t1), t2, t3
-# CHECK-ERROR: :[[@LINE-1]]:21: error: too many operands for instruction
+# CHECK-ERROR: :[[@LINE-1]]:21: error: unexpected extra operand for instruction
 
 cv.lhu t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:12: error: invalid operand for instruction
@@ -141,7 +141,7 @@ cv.lhu t0, (t1)
 # CHECK-ERROR: :[[@LINE-1]]:16: error: too few operands for instruction
 
 cv.lhu t0, (t1), t2, t3
-# CHECK-ERROR: :[[@LINE-1]]:22: error: too many operands for instruction
+# CHECK-ERROR: :[[@LINE-1]]:22: error: unexpected extra operand for instruction
 
 cv.lw t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
@@ -178,7 +178,7 @@ cv.lw t0, (t1)
 # CHECK-ERROR: :[[@LINE-1]]:15: error: too few operands for instruction
 
 cv.lw t0, (t1), t2, t3
-# CHECK-ERROR: :[[@LINE-1]]:21: error: too many operands for instruction
+# CHECK-ERROR: :[[@LINE-1]]:21: error: unexpected extra operand for instruction
 
 cv.sb t0, (0), 0
 # CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/corev/XCVsimd-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVsimd-invalid.s
@@ -12,7 +12,7 @@ cv.add.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.add.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -34,7 +34,7 @@ cv.add.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.add.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -56,7 +56,7 @@ cv.add.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.add.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -78,7 +78,7 @@ cv.add.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.add.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -144,7 +144,7 @@ cv.sub.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sub.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -166,7 +166,7 @@ cv.sub.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sub.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -188,7 +188,7 @@ cv.sub.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sub.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -210,7 +210,7 @@ cv.sub.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sub.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -276,7 +276,7 @@ cv.avg.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avg.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.avg.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -298,7 +298,7 @@ cv.avg.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avg.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.avg.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -320,7 +320,7 @@ cv.avg.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avg.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.avg.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -342,7 +342,7 @@ cv.avg.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avg.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.avg.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -408,7 +408,7 @@ cv.avgu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avgu.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.avgu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -430,7 +430,7 @@ cv.avgu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avgu.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.avgu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -452,7 +452,7 @@ cv.avgu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avgu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.avgu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -474,7 +474,7 @@ cv.avgu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avgu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.avgu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -546,7 +546,7 @@ cv.min.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.min.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.min.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -568,7 +568,7 @@ cv.min.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.min.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.min.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -590,7 +590,7 @@ cv.min.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.min.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.min.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -612,7 +612,7 @@ cv.min.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.min.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.min.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -678,7 +678,7 @@ cv.minu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.minu.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.minu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -700,7 +700,7 @@ cv.minu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.minu.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.minu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -722,7 +722,7 @@ cv.minu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.minu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.minu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -744,7 +744,7 @@ cv.minu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.minu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.minu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -816,7 +816,7 @@ cv.max.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.max.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.max.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -838,7 +838,7 @@ cv.max.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.max.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.max.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -860,7 +860,7 @@ cv.max.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.max.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.max.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -882,7 +882,7 @@ cv.max.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.max.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.max.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -948,7 +948,7 @@ cv.maxu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.maxu.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.maxu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -970,7 +970,7 @@ cv.maxu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.maxu.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.maxu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -992,7 +992,7 @@ cv.maxu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.maxu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.maxu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1014,7 +1014,7 @@ cv.maxu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.maxu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.maxu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1086,7 +1086,7 @@ cv.srl.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.srl.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.srl.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1108,7 +1108,7 @@ cv.srl.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.srl.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.srl.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1130,7 +1130,7 @@ cv.srl.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.srl.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.srl.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1152,7 +1152,7 @@ cv.srl.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.srl.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.srl.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1224,7 +1224,7 @@ cv.sra.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sra.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sra.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1246,7 +1246,7 @@ cv.sra.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sra.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sra.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1268,7 +1268,7 @@ cv.sra.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sra.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sra.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1290,7 +1290,7 @@ cv.sra.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sra.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sra.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1362,7 +1362,7 @@ cv.sll.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sll.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sll.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1384,7 +1384,7 @@ cv.sll.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sll.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sll.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1406,7 +1406,7 @@ cv.sll.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sll.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sll.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1428,7 +1428,7 @@ cv.sll.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sll.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sll.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1500,7 +1500,7 @@ cv.or.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.or.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.or.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1522,7 +1522,7 @@ cv.or.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.or.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.or.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1544,7 +1544,7 @@ cv.or.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.or.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.or.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1566,7 +1566,7 @@ cv.or.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.or.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.or.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1632,7 +1632,7 @@ cv.xor.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.xor.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.xor.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1654,7 +1654,7 @@ cv.xor.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.xor.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.xor.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1676,7 +1676,7 @@ cv.xor.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.xor.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.xor.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1698,7 +1698,7 @@ cv.xor.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.xor.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.xor.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1764,7 +1764,7 @@ cv.and.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.and.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.and.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1786,7 +1786,7 @@ cv.and.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.and.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.and.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1808,7 +1808,7 @@ cv.and.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.and.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.and.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1830,7 +1830,7 @@ cv.and.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.and.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.and.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1896,16 +1896,16 @@ cv.abs.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.abs.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.abs.h t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.abs.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.abs.h t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 //===----------------------------------------------------------------------===//
 // cv.abs.b
@@ -1918,16 +1918,16 @@ cv.abs.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.abs.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.abs.b t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.abs.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.abs.b t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 //===----------------------------------------------------------------------===//
 // cv.dotup.h
@@ -1940,7 +1940,7 @@ cv.dotup.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotup.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotup.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1962,7 +1962,7 @@ cv.dotup.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotup.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotup.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1984,7 +1984,7 @@ cv.dotup.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotup.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotup.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2006,7 +2006,7 @@ cv.dotup.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotup.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotup.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2078,7 +2078,7 @@ cv.dotusp.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotusp.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotusp.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2100,7 +2100,7 @@ cv.dotusp.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotusp.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotusp.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2122,7 +2122,7 @@ cv.dotusp.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotusp.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotusp.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2144,7 +2144,7 @@ cv.dotusp.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotusp.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotusp.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2210,7 +2210,7 @@ cv.dotsp.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotsp.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotsp.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2232,7 +2232,7 @@ cv.dotsp.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotsp.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotsp.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2254,7 +2254,7 @@ cv.dotsp.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotsp.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotsp.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2276,7 +2276,7 @@ cv.dotsp.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotsp.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.dotsp.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2342,7 +2342,7 @@ cv.sdotup.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotup.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotup.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2364,7 +2364,7 @@ cv.sdotup.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotup.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotup.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2386,7 +2386,7 @@ cv.sdotup.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotup.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotup.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2408,7 +2408,7 @@ cv.sdotup.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotup.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotup.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2480,7 +2480,7 @@ cv.sdotusp.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotusp.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotusp.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2502,7 +2502,7 @@ cv.sdotusp.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotusp.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotusp.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2524,7 +2524,7 @@ cv.sdotusp.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotusp.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotusp.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2546,7 +2546,7 @@ cv.sdotusp.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotusp.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotusp.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2612,7 +2612,7 @@ cv.sdotsp.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotsp.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotsp.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2634,7 +2634,7 @@ cv.sdotsp.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotsp.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotsp.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2656,7 +2656,7 @@ cv.sdotsp.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotsp.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotsp.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2678,7 +2678,7 @@ cv.sdotsp.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotsp.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sdotsp.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2894,7 +2894,7 @@ cv.shuffle.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffle.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.shuffle.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2916,7 +2916,7 @@ cv.shuffle.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffle.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.shuffle.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3063,7 +3063,7 @@ cv.shuffle2.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffle2.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.shuffle2.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3085,7 +3085,7 @@ cv.shuffle2.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffle2.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.shuffle2.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3107,7 +3107,7 @@ cv.pack t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.pack t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.pack t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3129,7 +3129,7 @@ cv.pack.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.pack.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.pack.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3151,7 +3151,7 @@ cv.packhi.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.packhi.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.packhi.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3173,7 +3173,7 @@ cv.packlo.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.packlo.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.packlo.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3195,7 +3195,7 @@ cv.cmpeq.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpeq.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpeq.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3217,7 +3217,7 @@ cv.cmpeq.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpeq.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpeq.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3239,7 +3239,7 @@ cv.cmpeq.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpeq.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpeq.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3261,7 +3261,7 @@ cv.cmpeq.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpeq.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpeq.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3327,7 +3327,7 @@ cv.cmpne.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpne.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpne.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3349,7 +3349,7 @@ cv.cmpne.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpne.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpne.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3371,7 +3371,7 @@ cv.cmpne.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpne.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpne.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3393,7 +3393,7 @@ cv.cmpne.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpne.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpne.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3459,7 +3459,7 @@ cv.cmpgt.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgt.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgt.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3481,7 +3481,7 @@ cv.cmpgt.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgt.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgt.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3503,7 +3503,7 @@ cv.cmpgt.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgt.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgt.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3525,7 +3525,7 @@ cv.cmpgt.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgt.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgt.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3591,7 +3591,7 @@ cv.cmpge.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpge.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpge.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3613,7 +3613,7 @@ cv.cmpge.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpge.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpge.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3635,7 +3635,7 @@ cv.cmpge.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpge.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpge.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3657,7 +3657,7 @@ cv.cmpge.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpge.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpge.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3723,7 +3723,7 @@ cv.cmplt.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmplt.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmplt.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3745,7 +3745,7 @@ cv.cmplt.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmplt.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmplt.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3767,7 +3767,7 @@ cv.cmplt.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmplt.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmplt.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3789,7 +3789,7 @@ cv.cmplt.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmplt.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmplt.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3855,7 +3855,7 @@ cv.cmple.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmple.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmple.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3877,7 +3877,7 @@ cv.cmple.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmple.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmple.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3899,7 +3899,7 @@ cv.cmple.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmple.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmple.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3921,7 +3921,7 @@ cv.cmple.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmple.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmple.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3987,7 +3987,7 @@ cv.cmpgtu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgtu.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgtu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4009,7 +4009,7 @@ cv.cmpgtu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgtu.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgtu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4031,7 +4031,7 @@ cv.cmpgtu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgtu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgtu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4053,7 +4053,7 @@ cv.cmpgtu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgtu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgtu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4125,7 +4125,7 @@ cv.cmpgeu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgeu.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgeu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4147,7 +4147,7 @@ cv.cmpgeu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgeu.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgeu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4169,7 +4169,7 @@ cv.cmpgeu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgeu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgeu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4191,7 +4191,7 @@ cv.cmpgeu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgeu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpgeu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4263,7 +4263,7 @@ cv.cmpltu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpltu.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpltu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4285,7 +4285,7 @@ cv.cmpltu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpltu.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpltu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4307,7 +4307,7 @@ cv.cmpltu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpltu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpltu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4329,7 +4329,7 @@ cv.cmpltu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpltu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpltu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4401,7 +4401,7 @@ cv.cmpleu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpleu.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpleu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4423,7 +4423,7 @@ cv.cmpleu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpleu.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpleu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4445,7 +4445,7 @@ cv.cmpleu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpleu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpleu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4467,7 +4467,7 @@ cv.cmpleu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpleu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cmpleu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4539,7 +4539,7 @@ cv.cplxmul.r t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.r t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cplxmul.r t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4561,7 +4561,7 @@ cv.cplxmul.i t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.i t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cplxmul.i t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4583,7 +4583,7 @@ cv.cplxmul.r.div2 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.r.div2 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cplxmul.r.div2 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4605,7 +4605,7 @@ cv.cplxmul.i.div2 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.i.div2 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cplxmul.i.div2 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4627,7 +4627,7 @@ cv.cplxmul.r.div4 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.r.div4 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cplxmul.r.div4 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4649,7 +4649,7 @@ cv.cplxmul.i.div4 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.i.div4 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cplxmul.i.div4 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4671,7 +4671,7 @@ cv.cplxmul.r.div8 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.r.div8 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cplxmul.r.div8 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4693,7 +4693,7 @@ cv.cplxmul.i.div8 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.i.div8 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cplxmul.i.div8 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4715,16 +4715,16 @@ cv.cplxconj t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxconj t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cplxconj t0, t1, t2
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cplxconj t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.cplxconj t0, t1, 0
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 //===----------------------------------------------------------------------===//
 // cv.subrotmj
@@ -4737,7 +4737,7 @@ cv.subrotmj t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.subrotmj t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.subrotmj t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4759,7 +4759,7 @@ cv.subrotmj.div2 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.subrotmj.div2 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.subrotmj.div2 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4781,7 +4781,7 @@ cv.subrotmj.div4 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.subrotmj.div4 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.subrotmj.div4 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4803,7 +4803,7 @@ cv.subrotmj.div8 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.subrotmj.div8 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.subrotmj.div8 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4825,7 +4825,7 @@ cv.add.div2 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.div2 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.add.div2 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4847,7 +4847,7 @@ cv.add.div4 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.div4 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.add.div4 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4869,7 +4869,7 @@ cv.add.div8 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.div8 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.add.div8 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4891,7 +4891,7 @@ cv.sub.div2 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.div2 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sub.div2 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4913,7 +4913,7 @@ cv.sub.div4 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.div4 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sub.div4 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4935,7 +4935,7 @@ cv.sub.div8 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.div8 t0, t1, t2, t3
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 
 cv.sub.div8 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction

--- a/llvm/test/MC/RISCV/corev/XCVsimd-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVsimd-invalid.s
@@ -12,7 +12,7 @@ cv.add.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -34,7 +34,7 @@ cv.add.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -56,7 +56,7 @@ cv.add.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -78,7 +78,7 @@ cv.add.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -144,7 +144,7 @@ cv.sub.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -166,7 +166,7 @@ cv.sub.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -188,7 +188,7 @@ cv.sub.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -210,7 +210,7 @@ cv.sub.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -276,7 +276,7 @@ cv.avg.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avg.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avg.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -298,7 +298,7 @@ cv.avg.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avg.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avg.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -320,7 +320,7 @@ cv.avg.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avg.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avg.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -342,7 +342,7 @@ cv.avg.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avg.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avg.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -408,7 +408,7 @@ cv.avgu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avgu.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avgu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -430,7 +430,7 @@ cv.avgu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avgu.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avgu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -452,7 +452,7 @@ cv.avgu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avgu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avgu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -474,7 +474,7 @@ cv.avgu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.avgu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.avgu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -546,7 +546,7 @@ cv.min.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.min.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.min.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -568,7 +568,7 @@ cv.min.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.min.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.min.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -590,7 +590,7 @@ cv.min.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.min.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.min.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -612,7 +612,7 @@ cv.min.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.min.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.min.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -678,7 +678,7 @@ cv.minu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.minu.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.minu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -700,7 +700,7 @@ cv.minu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.minu.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.minu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -722,7 +722,7 @@ cv.minu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.minu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.minu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -744,7 +744,7 @@ cv.minu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.minu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.minu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -816,7 +816,7 @@ cv.max.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.max.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.max.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -838,7 +838,7 @@ cv.max.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.max.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.max.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -860,7 +860,7 @@ cv.max.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.max.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.max.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -882,7 +882,7 @@ cv.max.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.max.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.max.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -948,7 +948,7 @@ cv.maxu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.maxu.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.maxu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -970,7 +970,7 @@ cv.maxu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.maxu.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.maxu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -992,7 +992,7 @@ cv.maxu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.maxu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.maxu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1014,7 +1014,7 @@ cv.maxu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.maxu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.maxu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1086,7 +1086,7 @@ cv.srl.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.srl.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.srl.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1108,7 +1108,7 @@ cv.srl.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.srl.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.srl.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1130,7 +1130,7 @@ cv.srl.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.srl.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.srl.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1152,7 +1152,7 @@ cv.srl.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.srl.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.srl.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1224,7 +1224,7 @@ cv.sra.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sra.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sra.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1246,7 +1246,7 @@ cv.sra.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sra.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sra.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1268,7 +1268,7 @@ cv.sra.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sra.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sra.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1290,7 +1290,7 @@ cv.sra.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sra.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sra.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1362,7 +1362,7 @@ cv.sll.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sll.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sll.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1384,7 +1384,7 @@ cv.sll.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sll.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sll.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1406,7 +1406,7 @@ cv.sll.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sll.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sll.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1428,7 +1428,7 @@ cv.sll.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sll.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sll.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1500,7 +1500,7 @@ cv.or.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.or.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.or.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1522,7 +1522,7 @@ cv.or.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.or.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.or.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1544,7 +1544,7 @@ cv.or.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.or.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.or.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1566,7 +1566,7 @@ cv.or.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.or.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.or.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1632,7 +1632,7 @@ cv.xor.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.xor.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.xor.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1654,7 +1654,7 @@ cv.xor.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.xor.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.xor.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1676,7 +1676,7 @@ cv.xor.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.xor.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.xor.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1698,7 +1698,7 @@ cv.xor.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.xor.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.xor.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1764,7 +1764,7 @@ cv.and.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.and.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.and.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1786,7 +1786,7 @@ cv.and.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.and.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.and.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1808,7 +1808,7 @@ cv.and.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.and.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.and.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1830,7 +1830,7 @@ cv.and.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.and.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.and.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1896,16 +1896,16 @@ cv.abs.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.abs.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.abs.h t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.abs.h t0, t1, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.abs.h t0, t1, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 //===----------------------------------------------------------------------===//
 // cv.abs.b
@@ -1918,16 +1918,16 @@ cv.abs.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.abs.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.abs.b t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.abs.b t0, t1, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.abs.b t0, t1, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 //===----------------------------------------------------------------------===//
 // cv.dotup.h
@@ -1940,7 +1940,7 @@ cv.dotup.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotup.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotup.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1962,7 +1962,7 @@ cv.dotup.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotup.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotup.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -1984,7 +1984,7 @@ cv.dotup.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotup.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotup.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2006,7 +2006,7 @@ cv.dotup.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotup.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotup.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2078,7 +2078,7 @@ cv.dotusp.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotusp.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotusp.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2100,7 +2100,7 @@ cv.dotusp.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotusp.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotusp.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2122,7 +2122,7 @@ cv.dotusp.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotusp.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotusp.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2144,7 +2144,7 @@ cv.dotusp.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotusp.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotusp.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2210,7 +2210,7 @@ cv.dotsp.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotsp.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotsp.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2232,7 +2232,7 @@ cv.dotsp.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotsp.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotsp.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2254,7 +2254,7 @@ cv.dotsp.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotsp.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotsp.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2276,7 +2276,7 @@ cv.dotsp.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.dotsp.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.dotsp.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2342,7 +2342,7 @@ cv.sdotup.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotup.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotup.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2364,7 +2364,7 @@ cv.sdotup.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotup.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotup.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2386,7 +2386,7 @@ cv.sdotup.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotup.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotup.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2408,7 +2408,7 @@ cv.sdotup.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotup.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotup.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2480,7 +2480,7 @@ cv.sdotusp.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotusp.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotusp.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2502,7 +2502,7 @@ cv.sdotusp.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotusp.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotusp.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2524,7 +2524,7 @@ cv.sdotusp.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotusp.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotusp.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2546,7 +2546,7 @@ cv.sdotusp.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotusp.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotusp.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2612,7 +2612,7 @@ cv.sdotsp.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotsp.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotsp.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2634,7 +2634,7 @@ cv.sdotsp.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotsp.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotsp.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2656,7 +2656,7 @@ cv.sdotsp.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotsp.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotsp.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2678,7 +2678,7 @@ cv.sdotsp.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sdotsp.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sdotsp.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2894,7 +2894,7 @@ cv.shuffle.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffle.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.shuffle.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -2916,7 +2916,7 @@ cv.shuffle.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffle.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.shuffle.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3063,7 +3063,7 @@ cv.shuffle2.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffle2.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.shuffle2.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3085,7 +3085,7 @@ cv.shuffle2.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.shuffle2.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.shuffle2.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3107,7 +3107,7 @@ cv.pack t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.pack t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.pack t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3129,7 +3129,7 @@ cv.pack.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.pack.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.pack.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3151,7 +3151,7 @@ cv.packhi.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.packhi.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.packhi.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3173,7 +3173,7 @@ cv.packlo.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.packlo.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.packlo.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3195,7 +3195,7 @@ cv.cmpeq.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpeq.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpeq.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3217,7 +3217,7 @@ cv.cmpeq.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpeq.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpeq.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3239,7 +3239,7 @@ cv.cmpeq.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpeq.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpeq.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3261,7 +3261,7 @@ cv.cmpeq.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpeq.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpeq.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3327,7 +3327,7 @@ cv.cmpne.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpne.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpne.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3349,7 +3349,7 @@ cv.cmpne.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpne.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpne.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3371,7 +3371,7 @@ cv.cmpne.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpne.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpne.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3393,7 +3393,7 @@ cv.cmpne.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpne.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpne.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3459,7 +3459,7 @@ cv.cmpgt.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgt.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgt.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3481,7 +3481,7 @@ cv.cmpgt.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgt.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgt.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3503,7 +3503,7 @@ cv.cmpgt.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgt.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgt.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3525,7 +3525,7 @@ cv.cmpgt.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgt.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgt.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3591,7 +3591,7 @@ cv.cmpge.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpge.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpge.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3613,7 +3613,7 @@ cv.cmpge.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpge.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpge.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3635,7 +3635,7 @@ cv.cmpge.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpge.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpge.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3657,7 +3657,7 @@ cv.cmpge.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpge.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpge.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3723,7 +3723,7 @@ cv.cmplt.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmplt.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmplt.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3745,7 +3745,7 @@ cv.cmplt.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmplt.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmplt.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3767,7 +3767,7 @@ cv.cmplt.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmplt.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmplt.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3789,7 +3789,7 @@ cv.cmplt.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmplt.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmplt.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3855,7 +3855,7 @@ cv.cmple.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmple.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmple.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3877,7 +3877,7 @@ cv.cmple.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmple.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmple.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3899,7 +3899,7 @@ cv.cmple.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmple.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmple.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3921,7 +3921,7 @@ cv.cmple.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmple.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmple.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -3987,7 +3987,7 @@ cv.cmpgtu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgtu.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgtu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4009,7 +4009,7 @@ cv.cmpgtu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgtu.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgtu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4031,7 +4031,7 @@ cv.cmpgtu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgtu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgtu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4053,7 +4053,7 @@ cv.cmpgtu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgtu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgtu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4125,7 +4125,7 @@ cv.cmpgeu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgeu.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgeu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4147,7 +4147,7 @@ cv.cmpgeu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgeu.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgeu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4169,7 +4169,7 @@ cv.cmpgeu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgeu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgeu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4191,7 +4191,7 @@ cv.cmpgeu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpgeu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpgeu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4263,7 +4263,7 @@ cv.cmpltu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpltu.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpltu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4285,7 +4285,7 @@ cv.cmpltu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpltu.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpltu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4307,7 +4307,7 @@ cv.cmpltu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpltu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpltu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4329,7 +4329,7 @@ cv.cmpltu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpltu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpltu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4401,7 +4401,7 @@ cv.cmpleu.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpleu.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpleu.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4423,7 +4423,7 @@ cv.cmpleu.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpleu.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpleu.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4445,7 +4445,7 @@ cv.cmpleu.sc.h t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpleu.sc.h t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpleu.sc.h t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4467,7 +4467,7 @@ cv.cmpleu.sc.b t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cmpleu.sc.b t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cmpleu.sc.b t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4539,7 +4539,7 @@ cv.cplxmul.r t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.r t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.r t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4561,7 +4561,7 @@ cv.cplxmul.i t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.i t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.i t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4583,7 +4583,7 @@ cv.cplxmul.r.div2 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.r.div2 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.r.div2 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4605,7 +4605,7 @@ cv.cplxmul.i.div2 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.i.div2 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.i.div2 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4627,7 +4627,7 @@ cv.cplxmul.r.div4 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.r.div4 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.r.div4 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4649,7 +4649,7 @@ cv.cplxmul.i.div4 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.i.div4 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.i.div4 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4671,7 +4671,7 @@ cv.cplxmul.r.div8 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.r.div8 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.r.div8 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4693,7 +4693,7 @@ cv.cplxmul.i.div8 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxmul.i.div8 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxmul.i.div8 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4715,16 +4715,16 @@ cv.cplxconj t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.cplxconj t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxconj t0, t1, t2
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxconj t0, t1, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.cplxconj t0, t1, 0
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 //===----------------------------------------------------------------------===//
 // cv.subrotmj
@@ -4737,7 +4737,7 @@ cv.subrotmj t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.subrotmj t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subrotmj t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4759,7 +4759,7 @@ cv.subrotmj.div2 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.subrotmj.div2 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subrotmj.div2 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4781,7 +4781,7 @@ cv.subrotmj.div4 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.subrotmj.div4 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subrotmj.div4 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4803,7 +4803,7 @@ cv.subrotmj.div8 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.subrotmj.div8 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.subrotmj.div8 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4825,7 +4825,7 @@ cv.add.div2 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.div2 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.div2 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4847,7 +4847,7 @@ cv.add.div4 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.div4 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.div4 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4869,7 +4869,7 @@ cv.add.div8 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.add.div8 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.add.div8 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4891,7 +4891,7 @@ cv.sub.div2 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.div2 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.div2 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4913,7 +4913,7 @@ cv.sub.div4 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.div4 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.div4 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction
@@ -4935,7 +4935,7 @@ cv.sub.div8 t0, 0, t2
 # CHECK-ERROR: invalid operand for instruction
 
 cv.sub.div8 t0, t1, t2, t3
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 
 cv.sub.div8 t0, t1, 0
 # CHECK-ERROR: invalid operand for instruction

--- a/llvm/test/MC/RISCV/insn-invalid.s
+++ b/llvm/test/MC/RISCV/insn-invalid.s
@@ -1,8 +1,8 @@
 # RUN: not llvm-mc -triple riscv32 < %s 2>&1 | FileCheck %s
 
 # Too many operands
-.insn i  0x13,  0,  a0, a1, 13, 14 # CHECK: :[[@LINE]]:33: error: invalid operand for instruction
-.insn r  0x43,  0,  0, fa0, fa1, fa2, fa3, fa4 # CHECK: :[[@LINE]]:44: error: invalid operand for instruction
+.insn i  0x13,  0,  a0, a1, 13, 14 # CHECK: :[[@LINE]]:33: error: too many operands for instruction
+.insn r  0x43,  0,  0, fa0, fa1, fa2, fa3, fa4 # CHECK: :[[@LINE]]:44: error: too many operands for instruction
 
 # Too few operands
 .insn r  0x33,  0,  0, a0, a1 # CHECK: :[[@LINE]]:30: error: too few operands for instruction

--- a/llvm/test/MC/RISCV/insn-invalid.s
+++ b/llvm/test/MC/RISCV/insn-invalid.s
@@ -1,8 +1,8 @@
 # RUN: not llvm-mc -triple riscv32 < %s 2>&1 | FileCheck %s
 
 # Too many operands
-.insn i  0x13,  0,  a0, a1, 13, 14 # CHECK: :[[@LINE]]:33: error: too many operands for instruction
-.insn r  0x43,  0,  0, fa0, fa1, fa2, fa3, fa4 # CHECK: :[[@LINE]]:44: error: too many operands for instruction
+.insn i  0x13,  0,  a0, a1, 13, 14 # CHECK: :[[@LINE]]:33: error: unexpected extra operand for instruction
+.insn r  0x43,  0,  0, fa0, fa1, fa2, fa3, fa4 # CHECK: :[[@LINE]]:44: error: unexpected extra operand for instruction
 
 # Too few operands
 .insn r  0x33,  0,  0, a0, a1 # CHECK: :[[@LINE]]:30: error: too few operands for instruction

--- a/llvm/test/MC/RISCV/insn_c-invalid.s
+++ b/llvm/test/MC/RISCV/insn_c-invalid.s
@@ -1,8 +1,8 @@
 # RUN: not llvm-mc -triple riscv32 -mattr=+c < %s 2>&1 | FileCheck %s
 
 # Too many operands
-.insn ci  1, 0, a0, 13, 14 # CHECK: :[[#@LINE]]:25: error: invalid operand for instruction
-.insn cr  2, 9, a0, a1, a2 # CHECK: :[[#@LINE]]:25: error: invalid operand for instruction
+.insn ci  1, 0, a0, 13, 14 # CHECK: :[[#@LINE]]:25: error: too many operands for instruction
+.insn cr  2, 9, a0, a1, a2 # CHECK: :[[#@LINE]]:25: error: too many operands for instruction
 
 ## Too few operands
 .insn ci  1, 0, a0 # CHECK: :[[#@LINE]]:19: error: too few operands for instruction

--- a/llvm/test/MC/RISCV/insn_c-invalid.s
+++ b/llvm/test/MC/RISCV/insn_c-invalid.s
@@ -1,8 +1,8 @@
 # RUN: not llvm-mc -triple riscv32 -mattr=+c < %s 2>&1 | FileCheck %s
 
 # Too many operands
-.insn ci  1, 0, a0, 13, 14 # CHECK: :[[#@LINE]]:25: error: too many operands for instruction
-.insn cr  2, 9, a0, a1, a2 # CHECK: :[[#@LINE]]:25: error: too many operands for instruction
+.insn ci  1, 0, a0, 13, 14 # CHECK: :[[#@LINE]]:25: error: unexpected extra operand for instruction
+.insn cr  2, 9, a0, a1, a2 # CHECK: :[[#@LINE]]:25: error: unexpected extra operand for instruction
 
 ## Too few operands
 .insn ci  1, 0, a0 # CHECK: :[[#@LINE]]:19: error: too few operands for instruction

--- a/llvm/test/MC/RISCV/insn_xqci-invalid.s
+++ b/llvm/test/MC/RISCV/insn_xqci-invalid.s
@@ -17,7 +17,7 @@
 # CHECK-ERR: [[@LINE-1]]:30: error: immediate must be an integer in the range [-2147483648, 4294967295]
 
 .insn qc.eai 126, 7, 1, x31, 0xFFFFFFFF, extra
-# CHECK-ERR: [[@LINE-1]]:42: error: invalid operand for instruction
+# CHECK-ERR: [[@LINE-1]]:42: error: too many operands for instruction
 
 .insn qc.ei 128, 0, 0, x31, x0, 0
 # CHECK-ERR: [[@LINE-1]]:13: error: opcode must be a valid opcode name or an immediate in the range [0, 127]
@@ -38,7 +38,7 @@
 # CHECK-ERR: [[@LINE-1]]:34: error: immediate must be an integer in the range [-33554432, 33554431]
 
 .insn qc.ei 127, 7, 3, x31, x31, 0x1000000, extra
-# CHECK-ERR: [[@LINE-1]]:45: error: invalid operand for instruction
+# CHECK-ERR: [[@LINE-1]]:45: error: too many operands for instruction
 
 .insn qc.ei 126, 7, 3, x31, 0x2000000(x0)
 # CHECK-ERR: [[@LINE-1]]:29: error: immediate must be an integer in the range [-33554432, 33554431]
@@ -47,7 +47,7 @@
 # CHECK-ERR: [[@LINE-1]]:39: error: expected register
 
 .insn qc.ei 126, 7, 3, x31, 0x1000000(x31), extra
-# CHECK-ERR: [[@LINE-1]]:45: error: invalid operand for instruction
+# CHECK-ERR: [[@LINE-1]]:45: error: too many operands for instruction
 
 .insn qc.eb 128, 0, 0, x0, 0, 0
 # CHECK-ERR: [[@LINE-1]]:13: error: opcode must be a valid opcode name or an immediate in the range [0, 127]
@@ -68,7 +68,7 @@
 # CHECK-ERR: [[@LINE-1]]:38: error: immediate must be a multiple of 2 bytes in the range [-4096, 4094]
 
 .insn qc.eb 127, 7, 31, x31, 0x4000, 0x800, extra
-# CHECK-ERR: [[@LINE-1]]:45: error: invalid operand for instruction
+# CHECK-ERR: [[@LINE-1]]:45: error: too many operands for instruction
 
 
 .insn qc.ej 128, 0, 0, 0, 0
@@ -87,7 +87,7 @@
 # CHECK-ERR: [[@LINE-1]]:28: error: operand must be a multiple of 2 bytes in the range [-2147483648, 2147483646]
 
 .insn qc.ej 127, 7, 3, 31, 0x80000000, extra
-# CHECK-ERR: [[@LINE-1]]:40: error: invalid operand for instruction
+# CHECK-ERR: [[@LINE-1]]:40: error: too many operands for instruction
 
 .insn qc.es 128, 0, 0, x0, 0(x0)
 # CHECK-ERR: [[@LINE-1]]:13: error: opcode must be a valid opcode name or an immediate in the range [0, 127]
@@ -108,4 +108,4 @@
 # CHECK-ERR: [[@LINE-1]]:39: error: expected register
 
 .insn qc.es 127, 7, 3, x31, 0x1000000(x31), extra
-# CHECK-ERR: [[@LINE-1]]:45: error: invalid operand for instruction
+# CHECK-ERR: [[@LINE-1]]:45: error: too many operands for instruction

--- a/llvm/test/MC/RISCV/insn_xqci-invalid.s
+++ b/llvm/test/MC/RISCV/insn_xqci-invalid.s
@@ -17,7 +17,7 @@
 # CHECK-ERR: [[@LINE-1]]:30: error: immediate must be an integer in the range [-2147483648, 4294967295]
 
 .insn qc.eai 126, 7, 1, x31, 0xFFFFFFFF, extra
-# CHECK-ERR: [[@LINE-1]]:42: error: too many operands for instruction
+# CHECK-ERR: [[@LINE-1]]:42: error: unexpected extra operand for instruction
 
 .insn qc.ei 128, 0, 0, x31, x0, 0
 # CHECK-ERR: [[@LINE-1]]:13: error: opcode must be a valid opcode name or an immediate in the range [0, 127]
@@ -38,7 +38,7 @@
 # CHECK-ERR: [[@LINE-1]]:34: error: immediate must be an integer in the range [-33554432, 33554431]
 
 .insn qc.ei 127, 7, 3, x31, x31, 0x1000000, extra
-# CHECK-ERR: [[@LINE-1]]:45: error: too many operands for instruction
+# CHECK-ERR: [[@LINE-1]]:45: error: unexpected extra operand for instruction
 
 .insn qc.ei 126, 7, 3, x31, 0x2000000(x0)
 # CHECK-ERR: [[@LINE-1]]:29: error: immediate must be an integer in the range [-33554432, 33554431]
@@ -47,7 +47,7 @@
 # CHECK-ERR: [[@LINE-1]]:39: error: expected register
 
 .insn qc.ei 126, 7, 3, x31, 0x1000000(x31), extra
-# CHECK-ERR: [[@LINE-1]]:45: error: too many operands for instruction
+# CHECK-ERR: [[@LINE-1]]:45: error: unexpected extra operand for instruction
 
 .insn qc.eb 128, 0, 0, x0, 0, 0
 # CHECK-ERR: [[@LINE-1]]:13: error: opcode must be a valid opcode name or an immediate in the range [0, 127]
@@ -68,7 +68,7 @@
 # CHECK-ERR: [[@LINE-1]]:38: error: immediate must be a multiple of 2 bytes in the range [-4096, 4094]
 
 .insn qc.eb 127, 7, 31, x31, 0x4000, 0x800, extra
-# CHECK-ERR: [[@LINE-1]]:45: error: too many operands for instruction
+# CHECK-ERR: [[@LINE-1]]:45: error: unexpected extra operand for instruction
 
 
 .insn qc.ej 128, 0, 0, 0, 0
@@ -87,7 +87,7 @@
 # CHECK-ERR: [[@LINE-1]]:28: error: operand must be a multiple of 2 bytes in the range [-2147483648, 2147483646]
 
 .insn qc.ej 127, 7, 3, 31, 0x80000000, extra
-# CHECK-ERR: [[@LINE-1]]:40: error: too many operands for instruction
+# CHECK-ERR: [[@LINE-1]]:40: error: unexpected extra operand for instruction
 
 .insn qc.es 128, 0, 0, x0, 0(x0)
 # CHECK-ERR: [[@LINE-1]]:13: error: opcode must be a valid opcode name or an immediate in the range [0, 127]
@@ -108,4 +108,4 @@
 # CHECK-ERR: [[@LINE-1]]:39: error: expected register
 
 .insn qc.es 127, 7, 3, x31, 0x1000000(x31), extra
-# CHECK-ERR: [[@LINE-1]]:45: error: too many operands for instruction
+# CHECK-ERR: [[@LINE-1]]:45: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/priv-invalid.s
+++ b/llvm/test/MC/RISCV/priv-invalid.s
@@ -1,10 +1,13 @@
 # RUN: not llvm-mc -triple riscv32 < %s 2>&1 | FileCheck %s
 
-mret 0x10 # CHECK: :[[@LINE]]:6: error: invalid operand for instruction
+mret 0x10 # CHECK: :[[@LINE]]:6: error: too many operands for instruction
 
-sfence.vma zero, a1, a2 # CHECK: :[[@LINE]]:22: error: invalid operand for instruction
+sfence.vma zero, a1, a2 # CHECK: :[[@LINE]]:22: error: too many operands for instruction
 
-sfence.vma a0, 0x10 # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
+sfence.vma a0, 0x10
+# CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
+# CHECK: :[[@LINE-2]]:16: note: too many operands for instruction
+# CHECK: :[[@LINE-3]]:16: note: invalid operand for instruction
 
 sinval.vma zero, a1, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
@@ -14,19 +17,13 @@ sfence.w.inval 0x10 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 sfence.inval.ir 0x10 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
-hfence.vvma zero, a1, a2
-# CHECK: :[[#@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[#@LINE-2]]:13: note: invalid operand for instruction
-# CHECK: :[[#@LINE-3]]:19: note: invalid operand for instruction
+hfence.vvma zero, a1, a2 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
 
-hfence.vvma a0, 0x10 # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
+hfence.vvma a0, 0x10 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
 
-hfence.gvma zero, a1, a2
-# CHECK: :[[#@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[#@LINE-2]]:13: note: invalid operand for instruction
-# CHECK: :[[#@LINE-3]]:19: note: invalid operand for instruction
+hfence.gvma zero, a1, a2 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
 
-hfence.gvma a0, 0x10 # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
+hfence.gvma a0, 0x10 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
 
 hinval.vvma zero, a1, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 

--- a/llvm/test/MC/RISCV/priv-invalid.s
+++ b/llvm/test/MC/RISCV/priv-invalid.s
@@ -1,12 +1,12 @@
 # RUN: not llvm-mc -triple riscv32 < %s 2>&1 | FileCheck %s
 
-mret 0x10 # CHECK: :[[@LINE]]:6: error: too many operands for instruction
+mret 0x10 # CHECK: :[[@LINE]]:6: error: unexpected extra operand for instruction
 
-sfence.vma zero, a1, a2 # CHECK: :[[@LINE]]:22: error: too many operands for instruction
+sfence.vma zero, a1, a2 # CHECK: :[[@LINE]]:22: error: unexpected extra operand for instruction
 
 sfence.vma a0, 0x10
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:16: note: too many operands for instruction
+# CHECK: :[[@LINE-2]]:16: note: unexpected extra operand for instruction
 # CHECK: :[[@LINE-3]]:16: note: invalid operand for instruction
 
 sinval.vma zero, a1, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
@@ -17,13 +17,13 @@ sfence.w.inval 0x10 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
 sfence.inval.ir 0x10 # CHECK: :[[@LINE]]:1: error: invalid instruction
 
-hfence.vvma zero, a1, a2 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
+hfence.vvma zero, a1, a2 # CHECK: :[[@LINE]]:13: error: unexpected extra operand for instruction
 
-hfence.vvma a0, 0x10 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
+hfence.vvma a0, 0x10 # CHECK: :[[@LINE]]:13: error: unexpected extra operand for instruction
 
-hfence.gvma zero, a1, a2 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
+hfence.gvma zero, a1, a2 # CHECK: :[[@LINE]]:13: error: unexpected extra operand for instruction
 
-hfence.gvma a0, 0x10 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
+hfence.gvma a0, 0x10 # CHECK: :[[@LINE]]:13: error: unexpected extra operand for instruction
 
 hinval.vvma zero, a1, a2 # CHECK: :[[@LINE]]:1: error: invalid instruction
 

--- a/llvm/test/MC/RISCV/rv32c-invalid.s
+++ b/llvm/test/MC/RISCV/rv32c-invalid.s
@@ -42,7 +42,7 @@ c.jalr  zero
 c.mv  ra, x0
 # CHECK: :[[#@LINE-1]]:11: error: register must be a GPR excluding zero (x0)
 c.add  ra, ra, x0
-# CHECK: :[[#@LINE-1]]:16: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:16: error: too many operands for instruction
 
 ## GPRNoX2
 c.lui x2, 4
@@ -93,7 +93,7 @@ c.addi t0, %hi(foo)
 ## simm6nonzero
 c.nop 32
 # CHECK: :[[#@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[#@LINE-2]]:7: note: invalid operand for instruction
+# CHECK: :[[#@LINE-2]]:7: note: too many operands for instruction
 # CHECK: :[[#@LINE-3]]:7: note: immediate must be non-zero in the range [-32, 31]
 
 ## c_lui_imm

--- a/llvm/test/MC/RISCV/rv32c-invalid.s
+++ b/llvm/test/MC/RISCV/rv32c-invalid.s
@@ -42,7 +42,7 @@ c.jalr  zero
 c.mv  ra, x0
 # CHECK: :[[#@LINE-1]]:11: error: register must be a GPR excluding zero (x0)
 c.add  ra, ra, x0
-# CHECK: :[[#@LINE-1]]:16: error: too many operands for instruction
+# CHECK: :[[#@LINE-1]]:16: error: unexpected extra operand for instruction
 
 ## GPRNoX2
 c.lui x2, 4
@@ -93,7 +93,7 @@ c.addi t0, %hi(foo)
 ## simm6nonzero
 c.nop 32
 # CHECK: :[[#@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[#@LINE-2]]:7: note: too many operands for instruction
+# CHECK: :[[#@LINE-2]]:7: note: unexpected extra operand for instruction
 # CHECK: :[[#@LINE-3]]:7: note: immediate must be non-zero in the range [-32, 31]
 
 ## c_lui_imm

--- a/llvm/test/MC/RISCV/rv32i-invalid.s
+++ b/llvm/test/MC/RISCV/rv32i-invalid.s
@@ -154,7 +154,7 @@ auipc a0, %pcrel_lo(foo) # CHECK: :[[@LINE]]:11: error: operand must be a symbol
 add a0, a0, tp, zero # CHECK: :[[@LINE]]:17: error: expected '%' relocation specifier
 add a0, a0, tp, %hi(foo)
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:17: note: invalid operand for instruction
+# CHECK: :[[@LINE-2]]:17: note: too many operands for instruction
 # CHECK: :[[@LINE-3]]:17: note: operand must be a symbol with %tprel_add specifier
 
 add a0, tp, a0, %tprel_add(foo) # CHECK: :[[@LINE]]:13: error: the second input operand must be tp/x4 when using %tprel_add specifier
@@ -184,10 +184,10 @@ xori sp, 22, 220 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
 sub t0, t2, 1 # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
 
 # Too many operands
-sltiu s2, s3, 0x50, 0x60 # CHECK: :[[@LINE]]:21: error: invalid operand for instruction
+sltiu s2, s3, 0x50, 0x60 # CHECK: :[[@LINE]]:21: error: too many operands for instruction
 
 # Memory operand not formatted correctly
-lw a4, a5, 111 # CHECK: :[[@LINE]]:12: error: invalid operand for instruction
+lw a4, a5, 111 # CHECK: :[[@LINE]]:12: error: too many operands for instruction
 
 # Too few operands
 ori a0, a1 # CHECK: :[[@LINE]]:11: error: too few operands for instruction
@@ -212,4 +212,4 @@ bset a0, a1, a2 # CHECK: :[[@LINE]]:1: error: instruction requires the following
 addi a2, ft0, 24 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
 
 # fence.tso accepts no operands
-fence.tso rw, rw # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+fence.tso rw, rw # CHECK: :[[@LINE]]:11: error: too many operands for instruction

--- a/llvm/test/MC/RISCV/rv32i-invalid.s
+++ b/llvm/test/MC/RISCV/rv32i-invalid.s
@@ -154,7 +154,7 @@ auipc a0, %pcrel_lo(foo) # CHECK: :[[@LINE]]:11: error: operand must be a symbol
 add a0, a0, tp, zero # CHECK: :[[@LINE]]:17: error: expected '%' relocation specifier
 add a0, a0, tp, %hi(foo)
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[@LINE-2]]:17: note: too many operands for instruction
+# CHECK: :[[@LINE-2]]:17: note: unexpected extra operand for instruction
 # CHECK: :[[@LINE-3]]:17: note: operand must be a symbol with %tprel_add specifier
 
 add a0, tp, a0, %tprel_add(foo) # CHECK: :[[@LINE]]:13: error: the second input operand must be tp/x4 when using %tprel_add specifier
@@ -184,10 +184,10 @@ xori sp, 22, 220 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
 sub t0, t2, 1 # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
 
 # Too many operands
-sltiu s2, s3, 0x50, 0x60 # CHECK: :[[@LINE]]:21: error: too many operands for instruction
+sltiu s2, s3, 0x50, 0x60 # CHECK: :[[@LINE]]:21: error: unexpected extra operand for instruction
 
 # Memory operand not formatted correctly
-lw a4, a5, 111 # CHECK: :[[@LINE]]:12: error: too many operands for instruction
+lw a4, a5, 111 # CHECK: :[[@LINE]]:12: error: unexpected extra operand for instruction
 
 # Too few operands
 ori a0, a1 # CHECK: :[[@LINE]]:11: error: too few operands for instruction
@@ -212,4 +212,4 @@ bset a0, a1, a2 # CHECK: :[[@LINE]]:1: error: instruction requires the following
 addi a2, ft0, 24 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
 
 # fence.tso accepts no operands
-fence.tso rw, rw # CHECK: :[[@LINE]]:11: error: too many operands for instruction
+fence.tso rw, rw # CHECK: :[[@LINE]]:11: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/rv32zalrsc-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zalrsc-invalid.s
@@ -5,4 +5,4 @@
 lr.w a4, a5 # CHECK: :[[@LINE]]:10: error: expected '(' or optional integer offset
 
 # lr only takes two operands
-lr.w s0, (s1), s2 # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
+lr.w s0, (s1), s2 # CHECK: :[[@LINE]]:16: error: too many operands for instruction

--- a/llvm/test/MC/RISCV/rv32zalrsc-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zalrsc-invalid.s
@@ -5,4 +5,4 @@
 lr.w a4, a5 # CHECK: :[[@LINE]]:10: error: expected '(' or optional integer offset
 
 # lr only takes two operands
-lr.w s0, (s1), s2 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
+lr.w s0, (s1), s2 # CHECK: :[[@LINE]]:16: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/rv32zbb-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zbb-invalid.s
@@ -1,15 +1,15 @@
 # RUN: not llvm-mc -triple riscv32 -mattr=+zbb < %s 2>&1 | FileCheck %s
 
 # Too many operands
-clz t0, t1, t2 # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
+clz t0, t1, t2 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
 # Too many operands
-ctz t0, t1, t2 # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
+ctz t0, t1, t2 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
 # Too many operands
-cpop t0, t1, t2 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
+cpop t0, t1, t2 # CHECK: :[[@LINE]]:14: error: too many operands for instruction
 # Too many operands
-sext.b t0, t1, t2 # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
+sext.b t0, t1, t2 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
 # Too many operands
-sext.h t0, t1, t2 # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
+sext.h t0, t1, t2 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
 # Too few operands
 min t0, t1 # CHECK: :[[@LINE]]:11: error: too few operands for instruction
 # Too few operands

--- a/llvm/test/MC/RISCV/rv32zbb-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zbb-invalid.s
@@ -1,15 +1,15 @@
 # RUN: not llvm-mc -triple riscv32 -mattr=+zbb < %s 2>&1 | FileCheck %s
 
 # Too many operands
-clz t0, t1, t2 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
+clz t0, t1, t2 # CHECK: :[[@LINE]]:13: error: unexpected extra operand for instruction
 # Too many operands
-ctz t0, t1, t2 # CHECK: :[[@LINE]]:13: error: too many operands for instruction
+ctz t0, t1, t2 # CHECK: :[[@LINE]]:13: error: unexpected extra operand for instruction
 # Too many operands
-cpop t0, t1, t2 # CHECK: :[[@LINE]]:14: error: too many operands for instruction
+cpop t0, t1, t2 # CHECK: :[[@LINE]]:14: error: unexpected extra operand for instruction
 # Too many operands
-sext.b t0, t1, t2 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
+sext.b t0, t1, t2 # CHECK: :[[@LINE]]:16: error: unexpected extra operand for instruction
 # Too many operands
-sext.h t0, t1, t2 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
+sext.h t0, t1, t2 # CHECK: :[[@LINE]]:16: error: unexpected extra operand for instruction
 # Too few operands
 min t0, t1 # CHECK: :[[@LINE]]:11: error: too few operands for instruction
 # Too few operands

--- a/llvm/test/MC/RISCV/rv32zcmop-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zcmop-invalid.s
@@ -2,6 +2,6 @@
 
 c.mop.0 # CHECK: :[[@LINE]]:1: error: unrecognized instruction mnemonic, did you mean: c.mop.1, c.mop.3, c.mop.5, c.mop.7, c.mop.9?
 
-c.mop.1 t0 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+c.mop.1 t0 # CHECK: :[[@LINE]]:9: error: too many operands for instruction
 
-c.mop.1 0x0 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+c.mop.1 0x0 # CHECK: :[[@LINE]]:9: error: too many operands for instruction

--- a/llvm/test/MC/RISCV/rv32zcmop-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zcmop-invalid.s
@@ -2,6 +2,6 @@
 
 c.mop.0 # CHECK: :[[@LINE]]:1: error: unrecognized instruction mnemonic, did you mean: c.mop.1, c.mop.3, c.mop.5, c.mop.7, c.mop.9?
 
-c.mop.1 t0 # CHECK: :[[@LINE]]:9: error: too many operands for instruction
+c.mop.1 t0 # CHECK: :[[@LINE]]:9: error: unexpected extra operand for instruction
 
-c.mop.1 0x0 # CHECK: :[[@LINE]]:9: error: too many operands for instruction
+c.mop.1 0x0 # CHECK: :[[@LINE]]:9: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/rv64zalrsc-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zalrsc-invalid.s
@@ -5,4 +5,4 @@
 lr.d a4, a5 # CHECK: :[[@LINE]]:10: error: expected '(' or optional integer offset
 
 # lr only takes two operands
-lr.d s0, (s1), s2 # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
+lr.d s0, (s1), s2 # CHECK: :[[@LINE]]:16: error: too many operands for instruction

--- a/llvm/test/MC/RISCV/rv64zalrsc-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zalrsc-invalid.s
@@ -5,4 +5,4 @@
 lr.d a4, a5 # CHECK: :[[@LINE]]:10: error: expected '(' or optional integer offset
 
 # lr only takes two operands
-lr.d s0, (s1), s2 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
+lr.d s0, (s1), s2 # CHECK: :[[@LINE]]:16: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/rv64zbb-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zbb-invalid.s
@@ -1,11 +1,11 @@
 # RUN: not llvm-mc -triple riscv64 -mattr=+zbb < %s 2>&1 | FileCheck %s
 
 # Too many operands
-clzw t0, t1, t2 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
+clzw t0, t1, t2 # CHECK: :[[@LINE]]:14: error: too many operands for instruction
 # Too many operands
-ctzw t0, t1, t2 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
+ctzw t0, t1, t2 # CHECK: :[[@LINE]]:14: error: too many operands for instruction
 # Too many operands
-cpopw t0, t1, t2 # CHECK: :[[@LINE]]:15: error: invalid operand for instruction
+cpopw t0, t1, t2 # CHECK: :[[@LINE]]:15: error: too many operands for instruction
 # Too few operands
 rolw t0, t1 # CHECK: :[[@LINE]]:12: error: too few operands for instruction
 # Too few operands

--- a/llvm/test/MC/RISCV/rv64zbb-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zbb-invalid.s
@@ -1,11 +1,11 @@
 # RUN: not llvm-mc -triple riscv64 -mattr=+zbb < %s 2>&1 | FileCheck %s
 
 # Too many operands
-clzw t0, t1, t2 # CHECK: :[[@LINE]]:14: error: too many operands for instruction
+clzw t0, t1, t2 # CHECK: :[[@LINE]]:14: error: unexpected extra operand for instruction
 # Too many operands
-ctzw t0, t1, t2 # CHECK: :[[@LINE]]:14: error: too many operands for instruction
+ctzw t0, t1, t2 # CHECK: :[[@LINE]]:14: error: unexpected extra operand for instruction
 # Too many operands
-cpopw t0, t1, t2 # CHECK: :[[@LINE]]:15: error: too many operands for instruction
+cpopw t0, t1, t2 # CHECK: :[[@LINE]]:15: error: unexpected extra operand for instruction
 # Too few operands
 rolw t0, t1 # CHECK: :[[@LINE]]:12: error: too few operands for instruction
 # Too few operands

--- a/llvm/test/MC/RISCV/rvc-hints-invalid.s
+++ b/llvm/test/MC/RISCV/rvc-hints-invalid.s
@@ -5,7 +5,7 @@
 
 c.nop 0
 # CHECK: :[[#@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[#@LINE-2]]:7: note: invalid operand for instruction
+# CHECK: :[[#@LINE-2]]:7: note: too many operands for instruction
 # CHECK: :[[#@LINE-3]]:7: note: immediate must be non-zero in the range [-32, 31]
 
 c.addi x0, 33

--- a/llvm/test/MC/RISCV/rvc-hints-invalid.s
+++ b/llvm/test/MC/RISCV/rvc-hints-invalid.s
@@ -5,7 +5,7 @@
 
 c.nop 0
 # CHECK: :[[#@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK: :[[#@LINE-2]]:7: note: too many operands for instruction
+# CHECK: :[[#@LINE-2]]:7: note: unexpected extra operand for instruction
 # CHECK: :[[#@LINE-3]]:7: note: immediate must be non-zero in the range [-32, 31]
 
 c.addi x0, 33

--- a/llvm/test/MC/RISCV/rvv/zvvfmm-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/zvvfmm-invalid.s
@@ -2,12 +2,12 @@
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 
 vfmmacc.vv v8, v4, v20, v0.t
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 # CHECK-ERROR-LABEL: vfmmacc.vv v8, v4, v20, v0.t
 
 # vm=0 is reserved for non-widening vfmmacc.vv.
 vfmmacc.vv v8, v4, v20, v0.scale
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 # CHECK-ERROR-LABEL: vfmmacc.vv v8, v4, v20, v0.scale
 
 vfwmmacc.vv v8, v4, v20, v0.t
@@ -16,7 +16,7 @@ vfwmmacc.vv v8, v4, v20, v0.t
 
 vfwmmacc.vv v8, v4, v20, v1.scale
 # CHECK-ERROR: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: note: invalid operand for instruction
+# CHECK-ERROR: note: too many operands for instruction
 # CHECK-ERROR: note: operand must be v0.scale
 # CHECK-ERROR: vfwmmacc.vv v8, v4, v20, v1.scale
 
@@ -26,7 +26,7 @@ vfqmmacc.vv v8, v4, v20, v0.t
 
 vfqmmacc.vv v8, v4, v20, v1.scale
 # CHECK-ERROR: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: note: invalid operand for instruction
+# CHECK-ERROR: note: too many operands for instruction
 # CHECK-ERROR: note: operand must be v0.scale
 # CHECK-ERROR: vfqmmacc.vv v8, v4, v20, v1.scale
 
@@ -36,7 +36,7 @@ vf8wmmacc.vv v8, v4, v20, v0.t
 
 vf8wmmacc.vv v8, v4, v20, v1.scale
 # CHECK-ERROR: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: note: invalid operand for instruction
+# CHECK-ERROR: note: too many operands for instruction
 # CHECK-ERROR: note: operand must be v0.scale
 # CHECK-ERROR: vf8wmmacc.vv v8, v4, v20, v1.scale
 

--- a/llvm/test/MC/RISCV/rvv/zvvfmm-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/zvvfmm-invalid.s
@@ -2,12 +2,12 @@
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 
 vfmmacc.vv v8, v4, v20, v0.t
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 # CHECK-ERROR-LABEL: vfmmacc.vv v8, v4, v20, v0.t
 
 # vm=0 is reserved for non-widening vfmmacc.vv.
 vfmmacc.vv v8, v4, v20, v0.scale
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 # CHECK-ERROR-LABEL: vfmmacc.vv v8, v4, v20, v0.scale
 
 vfwmmacc.vv v8, v4, v20, v0.t
@@ -16,7 +16,7 @@ vfwmmacc.vv v8, v4, v20, v0.t
 
 vfwmmacc.vv v8, v4, v20, v1.scale
 # CHECK-ERROR: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: note: too many operands for instruction
+# CHECK-ERROR: note: unexpected extra operand for instruction
 # CHECK-ERROR: note: operand must be v0.scale
 # CHECK-ERROR: vfwmmacc.vv v8, v4, v20, v1.scale
 
@@ -26,7 +26,7 @@ vfqmmacc.vv v8, v4, v20, v0.t
 
 vfqmmacc.vv v8, v4, v20, v1.scale
 # CHECK-ERROR: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: note: too many operands for instruction
+# CHECK-ERROR: note: unexpected extra operand for instruction
 # CHECK-ERROR: note: operand must be v0.scale
 # CHECK-ERROR: vfqmmacc.vv v8, v4, v20, v1.scale
 
@@ -36,7 +36,7 @@ vf8wmmacc.vv v8, v4, v20, v0.t
 
 vf8wmmacc.vv v8, v4, v20, v1.scale
 # CHECK-ERROR: error: invalid instruction, any one of the following would fix this:
-# CHECK-ERROR: note: too many operands for instruction
+# CHECK-ERROR: note: unexpected extra operand for instruction
 # CHECK-ERROR: note: operand must be v0.scale
 # CHECK-ERROR: vf8wmmacc.vv v8, v4, v20, v1.scale
 

--- a/llvm/test/MC/RISCV/rvv/zvvmm-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/zvvmm-invalid.s
@@ -2,17 +2,17 @@
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 
 vmmacc.vv v8, v4, v20, v0.t
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 # CHECK-ERROR-LABEL: vmmacc.vv v8, v4, v20, v0.t
 
 vwmmacc.vv v8, v4, v20, v0.t
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 # CHECK-ERROR-LABEL: vwmmacc.vv v8, v4, v20, v0.t
 
 vqmmacc.vv v8, v4, v20, v0.t
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 # CHECK-ERROR-LABEL: vqmmacc.vv v8, v4, v20, v0.t
 
 v8wmmacc.vv v8, v4, v20, v0.t
-# CHECK-ERROR: invalid operand for instruction
+# CHECK-ERROR: too many operands for instruction
 # CHECK-ERROR-LABEL: v8wmmacc.vv v8, v4, v20, v0.t

--- a/llvm/test/MC/RISCV/rvv/zvvmm-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/zvvmm-invalid.s
@@ -2,17 +2,17 @@
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 
 vmmacc.vv v8, v4, v20, v0.t
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 # CHECK-ERROR-LABEL: vmmacc.vv v8, v4, v20, v0.t
 
 vwmmacc.vv v8, v4, v20, v0.t
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 # CHECK-ERROR-LABEL: vwmmacc.vv v8, v4, v20, v0.t
 
 vqmmacc.vv v8, v4, v20, v0.t
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 # CHECK-ERROR-LABEL: vqmmacc.vv v8, v4, v20, v0.t
 
 v8wmmacc.vv v8, v4, v20, v0.t
-# CHECK-ERROR: too many operands for instruction
+# CHECK-ERROR: unexpected extra operand for instruction
 # CHECK-ERROR-LABEL: v8wmmacc.vv v8, v4, v20, v0.t

--- a/llvm/test/MC/RISCV/rvv/zvvmtls-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/zvvmtls-invalid.s
@@ -14,7 +14,7 @@ vmtl.v v8, (a0), a1, L4, v1.t
 # CHECK: error: operand must be v0.t
 
 vmtl.v v8, (a0), a1, v0.t, L4
-# CHECK: error: invalid operand for instruction
+# CHECK: error: too many operands for instruction
 
 vmts.v v12, (a0), a1, L0
 # CHECK: error: operand must be L1, L2, L4, L8, L16, L32, or L64
@@ -29,4 +29,4 @@ vmts.v v12, (a0), a1, L4, v1.t
 # CHECK: error: operand must be v0.t
 
 vmts.v v12, (a0), a1, v0.t, L4
-# CHECK: error: invalid operand for instruction
+# CHECK: error: too many operands for instruction

--- a/llvm/test/MC/RISCV/rvv/zvvmtls-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/zvvmtls-invalid.s
@@ -14,7 +14,7 @@ vmtl.v v8, (a0), a1, L4, v1.t
 # CHECK: error: operand must be v0.t
 
 vmtl.v v8, (a0), a1, v0.t, L4
-# CHECK: error: too many operands for instruction
+# CHECK: error: unexpected extra operand for instruction
 
 vmts.v v12, (a0), a1, L0
 # CHECK: error: operand must be L1, L2, L4, L8, L16, L32, or L64
@@ -29,4 +29,4 @@ vmts.v v12, (a0), a1, L4, v1.t
 # CHECK: error: operand must be v0.t
 
 vmts.v v12, (a0), a1, v0.t, L4
-# CHECK: error: too many operands for instruction
+# CHECK: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/rvv/zvvmttls-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/zvvmttls-invalid.s
@@ -14,7 +14,7 @@ vmttl.v v8, (a0), a1, L4, v1.t
 # CHECK: error: operand must be v0.t
 
 vmttl.v v8, (a0), a1, v0.t, L4
-# CHECK: error: invalid operand for instruction
+# CHECK: error: too many operands for instruction
 
 vmtts.v v12, (a0), a1, L0
 # CHECK: error: operand must be L1, L2, L4, L8, L16, L32, or L64
@@ -29,4 +29,4 @@ vmtts.v v12, (a0), a1, L4, v1.t
 # CHECK: error: operand must be v0.t
 
 vmtts.v v12, (a0), a1, v0.t, L4
-# CHECK: error: invalid operand for instruction
+# CHECK: error: too many operands for instruction

--- a/llvm/test/MC/RISCV/rvv/zvvmttls-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/zvvmttls-invalid.s
@@ -14,7 +14,7 @@ vmttl.v v8, (a0), a1, L4, v1.t
 # CHECK: error: operand must be v0.t
 
 vmttl.v v8, (a0), a1, v0.t, L4
-# CHECK: error: too many operands for instruction
+# CHECK: error: unexpected extra operand for instruction
 
 vmtts.v v12, (a0), a1, L0
 # CHECK: error: operand must be L1, L2, L4, L8, L16, L32, or L64
@@ -29,4 +29,4 @@ vmtts.v v12, (a0), a1, L4, v1.t
 # CHECK: error: operand must be v0.t
 
 vmtts.v v12, (a0), a1, v0.t, L4
-# CHECK: error: too many operands for instruction
+# CHECK: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/rvzicond-invalid.s
+++ b/llvm/test/MC/RISCV/rvzicond-invalid.s
@@ -11,8 +11,8 @@ czero.nez a4, a3, foo # CHECK: :[[@LINE]]:19: error: invalid operand for instruc
 czero.eqz t1, 2, t3 # CHECK: :[[@LINE]]:15: error: invalid operand for instruction
 
 # Too many operands
-czero.eqz t1, t2, t3, t4 # CHECK: :[[@LINE]]:23: error: invalid operand for instruction
-czero.nez t1, t2, t3, 4 # CHECK: :[[@LINE]]:23: error: invalid operand for instruction
+czero.eqz t1, t2, t3, t4 # CHECK: :[[@LINE]]:23: error: too many operands for instruction
+czero.nez t1, t2, t3, 4 # CHECK: :[[@LINE]]:23: error: too many operands for instruction
 
 # Too few operands
 czero.eqz t1, t2 # CHECK: :[[@LINE]]:17: error: too few operands for instruction

--- a/llvm/test/MC/RISCV/rvzicond-invalid.s
+++ b/llvm/test/MC/RISCV/rvzicond-invalid.s
@@ -11,8 +11,8 @@ czero.nez a4, a3, foo # CHECK: :[[@LINE]]:19: error: invalid operand for instruc
 czero.eqz t1, 2, t3 # CHECK: :[[@LINE]]:15: error: invalid operand for instruction
 
 # Too many operands
-czero.eqz t1, t2, t3, t4 # CHECK: :[[@LINE]]:23: error: too many operands for instruction
-czero.nez t1, t2, t3, 4 # CHECK: :[[@LINE]]:23: error: too many operands for instruction
+czero.eqz t1, t2, t3, t4 # CHECK: :[[@LINE]]:23: error: unexpected extra operand for instruction
+czero.nez t1, t2, t3, 4 # CHECK: :[[@LINE]]:23: error: unexpected extra operand for instruction
 
 # Too few operands
 czero.eqz t1, t2 # CHECK: :[[@LINE]]:17: error: too few operands for instruction

--- a/llvm/test/MC/RISCV/rvzihintntl-invalid.s
+++ b/llvm/test/MC/RISCV/rvzihintntl-invalid.s
@@ -7,12 +7,12 @@
 # RUN: not llvm-mc -triple riscv32 < %s 2>&1 | FileCheck %s
 # RUN: not llvm-mc -triple riscv64 < %s 2>&1 | FileCheck %s
 
-ntl.p1 1 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
-ntl.pall 2 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-ntl.s1 3 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
-ntl.all 4 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+ntl.p1 1 # CHECK: :[[@LINE]]:8: error: too many operands for instruction
+ntl.pall 2 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
+ntl.s1 3 # CHECK: :[[@LINE]]:8: error: too many operands for instruction
+ntl.all 4 # CHECK: :[[@LINE]]:9: error: too many operands for instruction
 
-ntl.p1 t0, t1 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
-ntl.pall t0, t1 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-ntl.s1 t0, t1 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
-ntl.all t0, t1 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+ntl.p1 t0, t1 # CHECK: :[[@LINE]]:8: error: too many operands for instruction
+ntl.pall t0, t1 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
+ntl.s1 t0, t1 # CHECK: :[[@LINE]]:8: error: too many operands for instruction
+ntl.all t0, t1 # CHECK: :[[@LINE]]:9: error: too many operands for instruction

--- a/llvm/test/MC/RISCV/rvzihintntl-invalid.s
+++ b/llvm/test/MC/RISCV/rvzihintntl-invalid.s
@@ -7,12 +7,12 @@
 # RUN: not llvm-mc -triple riscv32 < %s 2>&1 | FileCheck %s
 # RUN: not llvm-mc -triple riscv64 < %s 2>&1 | FileCheck %s
 
-ntl.p1 1 # CHECK: :[[@LINE]]:8: error: too many operands for instruction
-ntl.pall 2 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
-ntl.s1 3 # CHECK: :[[@LINE]]:8: error: too many operands for instruction
-ntl.all 4 # CHECK: :[[@LINE]]:9: error: too many operands for instruction
+ntl.p1 1 # CHECK: :[[@LINE]]:8: error: unexpected extra operand for instruction
+ntl.pall 2 # CHECK: :[[@LINE]]:10: error: unexpected extra operand for instruction
+ntl.s1 3 # CHECK: :[[@LINE]]:8: error: unexpected extra operand for instruction
+ntl.all 4 # CHECK: :[[@LINE]]:9: error: unexpected extra operand for instruction
 
-ntl.p1 t0, t1 # CHECK: :[[@LINE]]:8: error: too many operands for instruction
-ntl.pall t0, t1 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
-ntl.s1 t0, t1 # CHECK: :[[@LINE]]:8: error: too many operands for instruction
-ntl.all t0, t1 # CHECK: :[[@LINE]]:9: error: too many operands for instruction
+ntl.p1 t0, t1 # CHECK: :[[@LINE]]:8: error: unexpected extra operand for instruction
+ntl.pall t0, t1 # CHECK: :[[@LINE]]:10: error: unexpected extra operand for instruction
+ntl.s1 t0, t1 # CHECK: :[[@LINE]]:8: error: unexpected extra operand for instruction
+ntl.all t0, t1 # CHECK: :[[@LINE]]:9: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/rvzihintntlc-invalid.s
+++ b/llvm/test/MC/RISCV/rvzihintntlc-invalid.s
@@ -1,13 +1,13 @@
 # RUN: not llvm-mc -triple riscv32 -mattr=+zihintntl,+c < %s 2>&1 | FileCheck %s
 # RUN: not llvm-mc -triple riscv64 -mattr=+zihintntl,+c < %s 2>&1 | FileCheck %s
 
-c.ntl.p1 1 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-c.ntl.pall 2 # CHECK: :[[@LINE]]:12: error: invalid operand for instruction
-c.ntl.s1 3 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-c.ntl.all 4 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+c.ntl.p1 1 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
+c.ntl.pall 2 # CHECK: :[[@LINE]]:12: error: too many operands for instruction
+c.ntl.s1 3 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
+c.ntl.all 4 # CHECK: :[[@LINE]]:11: error: too many operands for instruction
 
-c.ntl.p1 t0, t1 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-c.ntl.pall t0, t1 # CHECK: :[[@LINE]]:12: error: invalid operand for instruction
-c.ntl.s1 t0, t1 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
-c.ntl.all t0, t1 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+c.ntl.p1 t0, t1 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
+c.ntl.pall t0, t1 # CHECK: :[[@LINE]]:12: error: too many operands for instruction
+c.ntl.s1 t0, t1 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
+c.ntl.all t0, t1 # CHECK: :[[@LINE]]:11: error: too many operands for instruction
 

--- a/llvm/test/MC/RISCV/rvzihintntlc-invalid.s
+++ b/llvm/test/MC/RISCV/rvzihintntlc-invalid.s
@@ -1,13 +1,13 @@
 # RUN: not llvm-mc -triple riscv32 -mattr=+zihintntl,+c < %s 2>&1 | FileCheck %s
 # RUN: not llvm-mc -triple riscv64 -mattr=+zihintntl,+c < %s 2>&1 | FileCheck %s
 
-c.ntl.p1 1 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
-c.ntl.pall 2 # CHECK: :[[@LINE]]:12: error: too many operands for instruction
-c.ntl.s1 3 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
-c.ntl.all 4 # CHECK: :[[@LINE]]:11: error: too many operands for instruction
+c.ntl.p1 1 # CHECK: :[[@LINE]]:10: error: unexpected extra operand for instruction
+c.ntl.pall 2 # CHECK: :[[@LINE]]:12: error: unexpected extra operand for instruction
+c.ntl.s1 3 # CHECK: :[[@LINE]]:10: error: unexpected extra operand for instruction
+c.ntl.all 4 # CHECK: :[[@LINE]]:11: error: unexpected extra operand for instruction
 
-c.ntl.p1 t0, t1 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
-c.ntl.pall t0, t1 # CHECK: :[[@LINE]]:12: error: too many operands for instruction
-c.ntl.s1 t0, t1 # CHECK: :[[@LINE]]:10: error: too many operands for instruction
-c.ntl.all t0, t1 # CHECK: :[[@LINE]]:11: error: too many operands for instruction
+c.ntl.p1 t0, t1 # CHECK: :[[@LINE]]:10: error: unexpected extra operand for instruction
+c.ntl.pall t0, t1 # CHECK: :[[@LINE]]:12: error: unexpected extra operand for instruction
+c.ntl.s1 t0, t1 # CHECK: :[[@LINE]]:10: error: unexpected extra operand for instruction
+c.ntl.all t0, t1 # CHECK: :[[@LINE]]:11: error: unexpected extra operand for instruction
 

--- a/llvm/test/MC/RISCV/smrnmi-invalid.s
+++ b/llvm/test/MC/RISCV/smrnmi-invalid.s
@@ -1,4 +1,4 @@
 # RUN: not llvm-mc -triple riscv32 -mattr=+smrnmi < %s 2>&1 | FileCheck %s
 # RUN: not llvm-mc -triple riscv64 -mattr=+smrnmi < %s 2>&1 | FileCheck %s
 
-mnret 0x10 # CHECK: :[[@LINE]]:7: error: invalid operand for instruction
+mnret 0x10 # CHECK: :[[@LINE]]:7: error: too many operands for instruction

--- a/llvm/test/MC/RISCV/smrnmi-invalid.s
+++ b/llvm/test/MC/RISCV/smrnmi-invalid.s
@@ -1,4 +1,4 @@
 # RUN: not llvm-mc -triple riscv32 -mattr=+smrnmi < %s 2>&1 | FileCheck %s
 # RUN: not llvm-mc -triple riscv64 -mattr=+smrnmi < %s 2>&1 | FileCheck %s
 
-mnret 0x10 # CHECK: :[[@LINE]]:7: error: too many operands for instruction
+mnret 0x10 # CHECK: :[[@LINE]]:7: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/tlsdesc.s
+++ b/llvm/test/MC/RISCV/tlsdesc.s
@@ -44,21 +44,21 @@ start:                                  # @start
 	auipc x1, %tlsdesc_call(1234) # ERR: :[[#@LINE]]:12: error: operand must be a symbol with a %pcrel_hi/%got_pcrel_hi/%tls_ie_pcrel_hi/%tls_gd_pcrel_hi specifier or an integer in the range
 	auipc a0, %tlsdesc_hi(a+b) # ERR: :[[#@LINE]]:12: error: operand must be a symbol with a %pcrel_hi/%got_pcrel_hi/%tls_ie_pcrel_hi/%tls_gd_pcrel_hi specifier or an integer in the range
 
-	lw   a0, t0, %tlsdesc_load_lo(a_symbol) # ERR: :[[#@LINE]]:15: error: invalid operand for instruction
+	lw   a0, t0, %tlsdesc_load_lo(a_symbol) # ERR: :[[#@LINE]]:15: error: too many operands for instruction
 	lw   a0, t0, %tlsdesc_load_lo(a_symbol)(a4)
 # ERR: :[[#@LINE-1]]:2: error: invalid instruction, any one of the following would fix this:
-# ERR: :[[#@LINE-2]]:15: note: invalid operand for instruction
+# ERR: :[[#@LINE-2]]:15: note: too many operands for instruction
 # ERR: :[[#@LINE-3]]:11: note: invalid operand for instruction
 # ERR: :[[#@LINE-4]]:11: note: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 # ERR: :[[#@LINE-5]]:11: note: immediate must be an integer in the range [-2048, 2047]
 
-	addi a0, t0, %tlsdesc_add_lo(a_symbol)(a4) # ERR: :[[#@LINE]]:41: error: invalid operand for instruction
+	addi a0, t0, %tlsdesc_add_lo(a_symbol)(a4) # ERR: :[[#@LINE]]:41: error: too many operands for instruction
 	addi a0, %tlsdesc_add_lo(a_symbol) # ERR: :[[#@LINE]]:11: error: invalid operand for instruction
 	addi x1, %tlsdesc_load_lo(a_symbol)(a0) # ERR: :[[#@LINE]]:11: error: invalid operand for instruction
 
 	jalr x5, 0(a1), %tlsdesc_hi(a_symbol)
 # ERR: :[[#@LINE-1]]:2: error: invalid instruction, any one of the following would fix this:
-# ERR: :[[#@LINE-2]]:18: note: invalid operand for instruction
+# ERR: :[[#@LINE-2]]:18: note: too many operands for instruction
 # ERR: :[[#@LINE-3]]:18: note: operand must be a symbol with %tlsdesc_call specifier
 	jalr x1, 0(a1), %tlsdesc_call(a_symbol) # ERR: :[[#@LINE]]:13: error: the output operand must be t0/x5 when using %tlsdesc_call specifier
 .endif

--- a/llvm/test/MC/RISCV/tlsdesc.s
+++ b/llvm/test/MC/RISCV/tlsdesc.s
@@ -44,21 +44,21 @@ start:                                  # @start
 	auipc x1, %tlsdesc_call(1234) # ERR: :[[#@LINE]]:12: error: operand must be a symbol with a %pcrel_hi/%got_pcrel_hi/%tls_ie_pcrel_hi/%tls_gd_pcrel_hi specifier or an integer in the range
 	auipc a0, %tlsdesc_hi(a+b) # ERR: :[[#@LINE]]:12: error: operand must be a symbol with a %pcrel_hi/%got_pcrel_hi/%tls_ie_pcrel_hi/%tls_gd_pcrel_hi specifier or an integer in the range
 
-	lw   a0, t0, %tlsdesc_load_lo(a_symbol) # ERR: :[[#@LINE]]:15: error: too many operands for instruction
+	lw   a0, t0, %tlsdesc_load_lo(a_symbol) # ERR: :[[#@LINE]]:15: error: unexpected extra operand for instruction
 	lw   a0, t0, %tlsdesc_load_lo(a_symbol)(a4)
 # ERR: :[[#@LINE-1]]:2: error: invalid instruction, any one of the following would fix this:
-# ERR: :[[#@LINE-2]]:15: note: too many operands for instruction
+# ERR: :[[#@LINE-2]]:15: note: unexpected extra operand for instruction
 # ERR: :[[#@LINE-3]]:11: note: invalid operand for instruction
 # ERR: :[[#@LINE-4]]:11: note: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 # ERR: :[[#@LINE-5]]:11: note: immediate must be an integer in the range [-2048, 2047]
 
-	addi a0, t0, %tlsdesc_add_lo(a_symbol)(a4) # ERR: :[[#@LINE]]:41: error: too many operands for instruction
+	addi a0, t0, %tlsdesc_add_lo(a_symbol)(a4) # ERR: :[[#@LINE]]:41: error: unexpected extra operand for instruction
 	addi a0, %tlsdesc_add_lo(a_symbol) # ERR: :[[#@LINE]]:11: error: invalid operand for instruction
 	addi x1, %tlsdesc_load_lo(a_symbol)(a0) # ERR: :[[#@LINE]]:11: error: invalid operand for instruction
 
 	jalr x5, 0(a1), %tlsdesc_hi(a_symbol)
 # ERR: :[[#@LINE-1]]:2: error: invalid instruction, any one of the following would fix this:
-# ERR: :[[#@LINE-2]]:18: note: too many operands for instruction
+# ERR: :[[#@LINE-2]]:18: note: unexpected extra operand for instruction
 # ERR: :[[#@LINE-3]]:18: note: operand must be a symbol with %tlsdesc_call specifier
 	jalr x1, 0(a1), %tlsdesc_call(a_symbol) # ERR: :[[#@LINE]]:13: error: the output operand must be t0/x5 when using %tlsdesc_call specifier
 .endif

--- a/llvm/test/MC/RISCV/xmips-invalid.s
+++ b/llvm/test/MC/RISCV/xmips-invalid.s
@@ -2,13 +2,13 @@
 # RUN: not llvm-mc -triple=riscv64 -mattr=+xmipslsp,+xmipscmov,+xmipscbop,+xmipsexectl < %s 2>&1 | FileCheck %s
 
 mips.pause 10
-# CHECK: error: invalid operand for instruction
+# CHECK: error: too many operands for instruction
 
 mips.ehb 10
-# CHECK: error: invalid operand for instruction 
+# CHECK: error: too many operands for instruction
 
 mips.ihb 10
-# CHECK: error: invalid operand for instruction
+# CHECK: error: too many operands for instruction
 
 mips.pref   8, 512(a0)
 # CHECK: error: immediate offset must be in the range [0, 511]

--- a/llvm/test/MC/RISCV/xmips-invalid.s
+++ b/llvm/test/MC/RISCV/xmips-invalid.s
@@ -2,13 +2,13 @@
 # RUN: not llvm-mc -triple=riscv64 -mattr=+xmipslsp,+xmipscmov,+xmipscbop,+xmipsexectl < %s 2>&1 | FileCheck %s
 
 mips.pause 10
-# CHECK: error: too many operands for instruction
+# CHECK: error: unexpected extra operand for instruction
 
 mips.ehb 10
-# CHECK: error: too many operands for instruction
+# CHECK: error: unexpected extra operand for instruction
 
 mips.ihb 10
-# CHECK: error: too many operands for instruction
+# CHECK: error: unexpected extra operand for instruction
 
 mips.pref   8, 512(a0)
 # CHECK: error: immediate offset must be in the range [0, 511]

--- a/llvm/test/MC/RISCV/xqci-access-pseudos.s
+++ b/llvm/test/MC/RISCV/xqci-access-pseudos.s
@@ -21,7 +21,7 @@ lb a0, 0(a1), %qc.access(extern1)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern1
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 lbu a0, 0(a1), %qc.access(extern1)
@@ -32,7 +32,7 @@ lbu a0, 0(a1), %qc.access(extern1)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern1
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:16: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:16: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 lh a2, 0(a3), %qc.access(extern2)
@@ -43,7 +43,7 @@ lh a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 lhu a2, 0(a3), %qc.access(extern2)
@@ -54,7 +54,7 @@ lhu a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:16: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:16: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 lw a4, 0(a5), %qc.access(extern4)
@@ -65,7 +65,7 @@ lw a4, 0(a5), %qc.access(extern4)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern4
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 sb a0, 0(a1), %qc.access(extern1)
@@ -76,7 +76,7 @@ sb a0, 0(a1), %qc.access(extern1)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern1
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 sh a2, 0(a3), %qc.access(extern2)
@@ -87,7 +87,7 @@ sh a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 sw a4, 0(a5), %qc.access(extern4)
@@ -98,7 +98,7 @@ sw a4, 0(a5), %qc.access(extern4)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern4
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 ## No c.lb
@@ -111,7 +111,7 @@ c.lbu a0, 0(a1), %qc.access(extern1)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern1
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:18: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:18: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.lh a2, 0(a3), %qc.access(extern2)
@@ -122,7 +122,7 @@ c.lh a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:17: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:17: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.lhu a2, 0(a3), %qc.access(extern2)
@@ -133,7 +133,7 @@ c.lhu a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:18: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:18: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.lw a4, 0(a5), %qc.access(extern4)
@@ -144,7 +144,7 @@ c.lw a4, 0(a5), %qc.access(extern4)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern4
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:17: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:17: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.sb a0, 0(a1), %qc.access(extern1)
@@ -155,7 +155,7 @@ c.sb a0, 0(a1), %qc.access(extern1)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern1
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:17: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:17: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.sh a2, 0(a3), %qc.access(extern2)
@@ -166,7 +166,7 @@ c.sh a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:17: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:17: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.sw a4, 0(a5), %qc.access(extern4)
@@ -177,5 +177,5 @@ c.sw a4, 0(a5), %qc.access(extern4)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern4
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:17: note: invalid operand for instruction
+# CHECK-RV64: [[@LINE-8]]:17: note: too many operands for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set

--- a/llvm/test/MC/RISCV/xqci-access-pseudos.s
+++ b/llvm/test/MC/RISCV/xqci-access-pseudos.s
@@ -21,7 +21,7 @@ lb a0, 0(a1), %qc.access(extern1)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern1
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 lbu a0, 0(a1), %qc.access(extern1)
@@ -32,7 +32,7 @@ lbu a0, 0(a1), %qc.access(extern1)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern1
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:16: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:16: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 lh a2, 0(a3), %qc.access(extern2)
@@ -43,7 +43,7 @@ lh a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 lhu a2, 0(a3), %qc.access(extern2)
@@ -54,7 +54,7 @@ lhu a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:16: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:16: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 lw a4, 0(a5), %qc.access(extern4)
@@ -65,7 +65,7 @@ lw a4, 0(a5), %qc.access(extern4)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern4
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 sb a0, 0(a1), %qc.access(extern1)
@@ -76,7 +76,7 @@ sb a0, 0(a1), %qc.access(extern1)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern1
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 sh a2, 0(a3), %qc.access(extern2)
@@ -87,7 +87,7 @@ sh a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 sw a4, 0(a5), %qc.access(extern4)
@@ -98,7 +98,7 @@ sw a4, 0(a5), %qc.access(extern4)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_32 extern4
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:15: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:15: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 ## No c.lb
@@ -111,7 +111,7 @@ c.lbu a0, 0(a1), %qc.access(extern1)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern1
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:18: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:18: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.lh a2, 0(a3), %qc.access(extern2)
@@ -122,7 +122,7 @@ c.lh a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:17: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:17: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.lhu a2, 0(a3), %qc.access(extern2)
@@ -133,7 +133,7 @@ c.lhu a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:18: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:18: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.lw a4, 0(a5), %qc.access(extern4)
@@ -144,7 +144,7 @@ c.lw a4, 0(a5), %qc.access(extern4)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern4
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:17: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:17: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.sb a0, 0(a1), %qc.access(extern1)
@@ -155,7 +155,7 @@ c.sb a0, 0(a1), %qc.access(extern1)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern1
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:17: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:17: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.sh a2, 0(a3), %qc.access(extern2)
@@ -166,7 +166,7 @@ c.sh a2, 0(a3), %qc.access(extern2)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern2
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:17: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:17: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set
 
 c.sw a4, 0(a5), %qc.access(extern4)
@@ -177,5 +177,5 @@ c.sw a4, 0(a5), %qc.access(extern4)
 # CHECK-RELOC-NEXT: R_RISCV_QC_ACCESS_16 extern4
 # CHECK-RELOC-NEXT: R_RISCV_RELAX
 # CHECK-RV64: [[@LINE-7]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-RV64: [[@LINE-8]]:17: note: too many operands for instruction
+# CHECK-RV64: [[@LINE-8]]:17: note: unexpected extra operand for instruction
 # CHECK-RV64: [[@LINE-9]]:1: note: instruction requires the following: RV32I Base Instruction Set

--- a/llvm/test/MC/RISCV/xqciint-invalid.s
+++ b/llvm/test/MC/RISCV/xqciint-invalid.s
@@ -8,7 +8,7 @@
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.setinti 1025
 
-# CHECK: :[[@LINE+1]]:{{16: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
 qc.setinti 11, 12
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -21,7 +21,7 @@ qc.setinti   10
 # CHECK-PLUS: :[[@LINE+1]]:12: error: immediate must be an integer in the range [0, 1023]
 qc.clrinti 2000
 
-# CHECK: :[[@LINE+1]]:{{16: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
 qc.clrinti 22, x4
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -42,7 +42,7 @@ qc.c.clrint
 qc.c.clrint x8
 
 
-# CHECK: :[[@LINE+1]]:{{9: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{9: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.di 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
@@ -60,7 +60,7 @@ qc.c.dir
 qc.c.dir x8
 
 
-# CHECK: :[[@LINE+1]]:{{9: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{9: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.ei 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
@@ -78,21 +78,21 @@ qc.c.eir
 qc.c.eir x8
 
 
-# CHECK: :[[@LINE+1]]:{{19: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{19: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.mienter.nest 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.mienter.nest
 
 
-# CHECK: :[[@LINE+1]]:{{14: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.mienter 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.mienter
 
 
-# CHECK: :[[@LINE+1]]:{{17: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{17: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.mileaveret 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
@@ -110,14 +110,14 @@ qc.c.setint
 qc.c.setint x8
 
 
-# CHECK: :[[@LINE+1]]:{{11: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{11: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.mret x8
 
 # CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.mret
 
 
-# CHECK: :[[@LINE+1]]:{{12: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{12: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.mnret 10
 
 # CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)

--- a/llvm/test/MC/RISCV/xqciint-invalid.s
+++ b/llvm/test/MC/RISCV/xqciint-invalid.s
@@ -8,7 +8,7 @@
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.setinti 1025
 
-# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.setinti 11, 12
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -21,7 +21,7 @@ qc.setinti   10
 # CHECK-PLUS: :[[@LINE+1]]:12: error: immediate must be an integer in the range [0, 1023]
 qc.clrinti 2000
 
-# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.clrinti 22, x4
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -42,7 +42,7 @@ qc.c.clrint
 qc.c.clrint x8
 
 
-# CHECK: :[[@LINE+1]]:{{9: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{9: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.di 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
@@ -60,7 +60,7 @@ qc.c.dir
 qc.c.dir x8
 
 
-# CHECK: :[[@LINE+1]]:{{9: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{9: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.ei 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
@@ -78,21 +78,21 @@ qc.c.eir
 qc.c.eir x8
 
 
-# CHECK: :[[@LINE+1]]:{{19: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{19: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.mienter.nest 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.mienter.nest
 
 
-# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.mienter 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.mienter
 
 
-# CHECK: :[[@LINE+1]]:{{17: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{17: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.mileaveret 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
@@ -110,14 +110,14 @@ qc.c.setint
 qc.c.setint x8
 
 
-# CHECK: :[[@LINE+1]]:{{11: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{11: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.mret x8
 
 # CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.mret
 
 
-# CHECK: :[[@LINE+1]]:{{12: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{12: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.mnret 10
 
 # CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)

--- a/llvm/test/MC/RISCV/xqcisim-invalid.s
+++ b/llvm/test/MC/RISCV/xqcisim-invalid.s
@@ -10,7 +10,7 @@ qc.psyscalli 1024
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
 qc.psyscalli
 
-# CHECK: :[[@LINE+1]]:{{18: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{18: error: too many operands for instruction|1: error: invalid instruction}}
 qc.psyscalli 23, x0
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
@@ -23,44 +23,44 @@ qc.pputci 256
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
 qc.pputci
 
-# CHECK: :[[@LINE+1]]:{{16: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
 qc.pputci 200, x8
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.pputci  255
 
 
-# CHECK: :[[@LINE+1]]:{{13: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{13: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.ptrace x0
 
-# CHECK: :[[@LINE+1]]:{{13: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{13: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.ptrace 1
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.c.ptrace
 
 
-# CHECK: :[[@LINE+1]]:{{14: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
 qc.pcoredump 12
 
-# CHECK: :[[@LINE+1]]:{{14: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
 qc.pcoredump x4
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.pcoredump
 
 
-# CHECK: :[[@LINE+1]]:{{11: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{11: error: too many operands for instruction|1: error: invalid instruction}}
 qc.ppregs x1
 
-# CHECK: :[[@LINE+1]]:{{11: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{11: error: too many operands for instruction|1: error: invalid instruction}}
 qc.ppregs 23
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.ppregs
 
 
-# CHECK: :[[@LINE+1]]:{{15: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{15: error: too many operands for instruction|1: error: invalid instruction}}
 qc.ppreg x10, x2
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -73,7 +73,7 @@ qc.ppreg 23
 qc.ppreg   a0
 
 
-# CHECK: :[[@LINE+1]]:{{14: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
 qc.pputc x7, x3
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -86,7 +86,7 @@ qc.pputc 34
 qc.pputc   t2
 
 
-# CHECK: :[[@LINE+1]]:{{15: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{15: error: too many operands for instruction|1: error: invalid instruction}}
 qc.pputs x15, x18
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -99,7 +99,7 @@ qc.pputs 45
 qc.pputs   a5
 
 
-# CHECK: :[[@LINE+1]]:{{15: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{15: error: too many operands for instruction|1: error: invalid instruction}}
 qc.pexit x26, x23
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -112,7 +112,7 @@ qc.pexit 78
 qc.pexit   s10
 
 
-# CHECK: :[[@LINE+1]]:{{18: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{18: error: too many operands for instruction|1: error: invalid instruction}}
 qc.psyscall x11, x5
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}

--- a/llvm/test/MC/RISCV/xqcisim-invalid.s
+++ b/llvm/test/MC/RISCV/xqcisim-invalid.s
@@ -10,7 +10,7 @@ qc.psyscalli 1024
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
 qc.psyscalli
 
-# CHECK: :[[@LINE+1]]:{{18: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{18: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.psyscalli 23, x0
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
@@ -23,44 +23,44 @@ qc.pputci 256
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
 qc.pputci
 
-# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.pputci 200, x8
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.pputci  255
 
 
-# CHECK: :[[@LINE+1]]:{{13: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{13: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.ptrace x0
 
-# CHECK: :[[@LINE+1]]:{{13: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{13: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.ptrace 1
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.c.ptrace
 
 
-# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.pcoredump 12
 
-# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.pcoredump x4
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.pcoredump
 
 
-# CHECK: :[[@LINE+1]]:{{11: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{11: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.ppregs x1
 
-# CHECK: :[[@LINE+1]]:{{11: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{11: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.ppregs 23
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.ppregs
 
 
-# CHECK: :[[@LINE+1]]:{{15: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{15: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.ppreg x10, x2
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -73,7 +73,7 @@ qc.ppreg 23
 qc.ppreg   a0
 
 
-# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.pputc x7, x3
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -86,7 +86,7 @@ qc.pputc 34
 qc.pputc   t2
 
 
-# CHECK: :[[@LINE+1]]:{{15: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{15: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.pputs x15, x18
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -99,7 +99,7 @@ qc.pputs 45
 qc.pputs   a5
 
 
-# CHECK: :[[@LINE+1]]:{{15: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{15: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.pexit x26, x23
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -112,7 +112,7 @@ qc.pexit 78
 qc.pexit   s10
 
 
-# CHECK: :[[@LINE+1]]:{{18: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{18: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.psyscall x11, x5
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}

--- a/llvm/test/MC/RISCV/xqcisync-invalid.s
+++ b/llvm/test/MC/RISCV/xqcisync-invalid.s
@@ -7,7 +7,7 @@
 # CHECK-PLUS: :[[@LINE+1]]:12: error: immediate must be an integer in the range [1, 31]
 qc.c.delay 34
 
-# CHECK: :[[@LINE+1]]:{{16: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.delay 11, 12
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -20,7 +20,7 @@ qc.c.delay   10
 # CHECK-PLUS: :[[@LINE+1]]:9: error: immediate must be an integer in the range [0, 31]
 qc.sync 45
 
-# CHECK: :[[@LINE+1]]:{{13: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{13: error: too many operands for instruction|1: error: invalid instruction}}
 qc.sync 22, x4
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -33,7 +33,7 @@ qc.sync 8
 # CHECK-PLUS: :[[@LINE+1]]:10: error: immediate must be an integer in the range [0, 31]
 qc.syncr 56
 
-# CHECK: :[[@LINE+1]]:{{14: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
 qc.syncr 31, 45
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -46,7 +46,7 @@ qc.syncr   23
 # CHECK-PLUS: :[[@LINE+1]]:11: error: immediate must be an integer in the range [0, 31]
 qc.syncwf 88
 
-# CHECK: :[[@LINE+1]]:{{14: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
 qc.syncwf 5, 44
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -59,7 +59,7 @@ qc.syncwf  31
 # CHECK-PLUS: :[[@LINE+1]]:11: error: immediate must be an integer in the range [0, 31]
 qc.syncwl 99
 
-# CHECK: :[[@LINE+1]]:{{15: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{15: error: too many operands for instruction|1: error: invalid instruction}}
 qc.syncwl 11, x10
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -72,7 +72,7 @@ qc.syncwl  1
 # CHECK-PLUS: :[[@LINE+1]]:11: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.sync 45
 
-# CHECK: :[[@LINE+1]]:{{15: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{15: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.sync 31, x4
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -85,7 +85,7 @@ qc.c.sync 8
 # CHECK-PLUS: :[[@LINE+1]]:12: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.syncr 56
 
-# CHECK: :[[@LINE+1]]:{{16: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.syncr 31, 45
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -98,7 +98,7 @@ qc.c.syncr   8
 # CHECK-PLUS: :[[@LINE+1]]:13: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.syncwf 88
 
-# CHECK: :[[@LINE+1]]:{{16: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.syncwf 8, 44
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -111,7 +111,7 @@ qc.c.syncwf  31
 # CHECK-PLUS: :[[@LINE+1]]:13: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.syncwl 99
 
-# CHECK: :[[@LINE+1]]:{{17: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{17: error: too many operands for instruction|1: error: invalid instruction}}
 qc.c.syncwl 15, x10
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}

--- a/llvm/test/MC/RISCV/xqcisync-invalid.s
+++ b/llvm/test/MC/RISCV/xqcisync-invalid.s
@@ -7,7 +7,7 @@
 # CHECK-PLUS: :[[@LINE+1]]:12: error: immediate must be an integer in the range [1, 31]
 qc.c.delay 34
 
-# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.delay 11, 12
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -20,7 +20,7 @@ qc.c.delay   10
 # CHECK-PLUS: :[[@LINE+1]]:9: error: immediate must be an integer in the range [0, 31]
 qc.sync 45
 
-# CHECK: :[[@LINE+1]]:{{13: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{13: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.sync 22, x4
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -33,7 +33,7 @@ qc.sync 8
 # CHECK-PLUS: :[[@LINE+1]]:10: error: immediate must be an integer in the range [0, 31]
 qc.syncr 56
 
-# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.syncr 31, 45
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -46,7 +46,7 @@ qc.syncr   23
 # CHECK-PLUS: :[[@LINE+1]]:11: error: immediate must be an integer in the range [0, 31]
 qc.syncwf 88
 
-# CHECK: :[[@LINE+1]]:{{14: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.syncwf 5, 44
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -59,7 +59,7 @@ qc.syncwf  31
 # CHECK-PLUS: :[[@LINE+1]]:11: error: immediate must be an integer in the range [0, 31]
 qc.syncwl 99
 
-# CHECK: :[[@LINE+1]]:{{15: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{15: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.syncwl 11, x10
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -72,7 +72,7 @@ qc.syncwl  1
 # CHECK-PLUS: :[[@LINE+1]]:11: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.sync 45
 
-# CHECK: :[[@LINE+1]]:{{15: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{15: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.sync 31, x4
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -85,7 +85,7 @@ qc.c.sync 8
 # CHECK-PLUS: :[[@LINE+1]]:12: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.syncr 56
 
-# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.syncr 31, 45
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -98,7 +98,7 @@ qc.c.syncr   8
 # CHECK-PLUS: :[[@LINE+1]]:13: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.syncwf 88
 
-# CHECK: :[[@LINE+1]]:{{16: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.syncwf 8, 44
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
@@ -111,7 +111,7 @@ qc.c.syncwf  31
 # CHECK-PLUS: :[[@LINE+1]]:13: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.syncwl 99
 
-# CHECK: :[[@LINE+1]]:{{17: error: too many operands for instruction|1: error: invalid instruction}}
+# CHECK: :[[@LINE+1]]:{{17: error: unexpected extra operand for instruction|1: error: invalid instruction}}
 qc.c.syncwl 15, x10
 
 # CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}

--- a/llvm/test/MC/RISCV/xtheadcmo-invalid.s
+++ b/llvm/test/MC/RISCV/xtheadcmo-invalid.s
@@ -15,11 +15,11 @@ th.dcache.cipa # CHECK: :[[@LINE]]:1: error: too few operands for instruction
 th.icache.iva # CHECK: :[[@LINE]]:1: error: too few operands for instruction
 th.icache.ipa # CHECK: :[[@LINE]]:1: error: too few operands for instruction
 
-th.dcache.call t0 # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
-th.dcache.iall t0 # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
-th.dcache.ciall t0 # CHECK: :[[@LINE]]:17: error: invalid operand for instruction
-th.icache.iall t0 # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
-th.icache.ialls t0 # CHECK: :[[@LINE]]:17: error: invalid operand for instruction
-th.l2cache.call t0 # CHECK: :[[@LINE]]:17: error: invalid operand for instruction
-th.l2cache.iall t0 # CHECK: :[[@LINE]]:17: error: invalid operand for instruction
-th.l2cache.ciall t0 # CHECK: :[[@LINE]]:18: error: invalid operand for instruction
+th.dcache.call t0 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
+th.dcache.iall t0 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
+th.dcache.ciall t0 # CHECK: :[[@LINE]]:17: error: too many operands for instruction
+th.icache.iall t0 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
+th.icache.ialls t0 # CHECK: :[[@LINE]]:17: error: too many operands for instruction
+th.l2cache.call t0 # CHECK: :[[@LINE]]:17: error: too many operands for instruction
+th.l2cache.iall t0 # CHECK: :[[@LINE]]:17: error: too many operands for instruction
+th.l2cache.ciall t0 # CHECK: :[[@LINE]]:18: error: too many operands for instruction

--- a/llvm/test/MC/RISCV/xtheadcmo-invalid.s
+++ b/llvm/test/MC/RISCV/xtheadcmo-invalid.s
@@ -15,11 +15,11 @@ th.dcache.cipa # CHECK: :[[@LINE]]:1: error: too few operands for instruction
 th.icache.iva # CHECK: :[[@LINE]]:1: error: too few operands for instruction
 th.icache.ipa # CHECK: :[[@LINE]]:1: error: too few operands for instruction
 
-th.dcache.call t0 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
-th.dcache.iall t0 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
-th.dcache.ciall t0 # CHECK: :[[@LINE]]:17: error: too many operands for instruction
-th.icache.iall t0 # CHECK: :[[@LINE]]:16: error: too many operands for instruction
-th.icache.ialls t0 # CHECK: :[[@LINE]]:17: error: too many operands for instruction
-th.l2cache.call t0 # CHECK: :[[@LINE]]:17: error: too many operands for instruction
-th.l2cache.iall t0 # CHECK: :[[@LINE]]:17: error: too many operands for instruction
-th.l2cache.ciall t0 # CHECK: :[[@LINE]]:18: error: too many operands for instruction
+th.dcache.call t0 # CHECK: :[[@LINE]]:16: error: unexpected extra operand for instruction
+th.dcache.iall t0 # CHECK: :[[@LINE]]:16: error: unexpected extra operand for instruction
+th.dcache.ciall t0 # CHECK: :[[@LINE]]:17: error: unexpected extra operand for instruction
+th.icache.iall t0 # CHECK: :[[@LINE]]:16: error: unexpected extra operand for instruction
+th.icache.ialls t0 # CHECK: :[[@LINE]]:17: error: unexpected extra operand for instruction
+th.l2cache.call t0 # CHECK: :[[@LINE]]:17: error: unexpected extra operand for instruction
+th.l2cache.iall t0 # CHECK: :[[@LINE]]:17: error: unexpected extra operand for instruction
+th.l2cache.ciall t0 # CHECK: :[[@LINE]]:18: error: unexpected extra operand for instruction

--- a/llvm/test/MC/RISCV/xtheadcondmov-invalid.s
+++ b/llvm/test/MC/RISCV/xtheadcondmov-invalid.s
@@ -2,8 +2,8 @@
 # RUN: not llvm-mc -triple riscv64 -mattr=+xtheadcondmov < %s 2>&1 | FileCheck %s
 
 th.mveqz a0,a1        # CHECK: :[[@LINE]]:15: error: too few operands for instruction
-th.mveqz a0,a1,a2,a3  # CHECK: :[[@LINE]]:19: error: invalid operand for instruction
+th.mveqz a0,a1,a2,a3  # CHECK: :[[@LINE]]:19: error: too many operands for instruction
 th.mveqz a0,a1,1      # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
 th.mvnez a0,a1        # CHECK: :[[@LINE]]:15: error: too few operands for instruction
-th.mvnez a0,a1,a2,a3  # CHECK: :[[@LINE]]:19: error: invalid operand for instruction
+th.mvnez a0,a1,a2,a3  # CHECK: :[[@LINE]]:19: error: too many operands for instruction
 th.mvnez a0,a1,1      # CHECK: :[[@LINE]]:16: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/xtheadcondmov-invalid.s
+++ b/llvm/test/MC/RISCV/xtheadcondmov-invalid.s
@@ -2,8 +2,8 @@
 # RUN: not llvm-mc -triple riscv64 -mattr=+xtheadcondmov < %s 2>&1 | FileCheck %s
 
 th.mveqz a0,a1        # CHECK: :[[@LINE]]:15: error: too few operands for instruction
-th.mveqz a0,a1,a2,a3  # CHECK: :[[@LINE]]:19: error: too many operands for instruction
+th.mveqz a0,a1,a2,a3  # CHECK: :[[@LINE]]:19: error: unexpected extra operand for instruction
 th.mveqz a0,a1,1      # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
 th.mvnez a0,a1        # CHECK: :[[@LINE]]:15: error: too few operands for instruction
-th.mvnez a0,a1,a2,a3  # CHECK: :[[@LINE]]:19: error: too many operands for instruction
+th.mvnez a0,a1,a2,a3  # CHECK: :[[@LINE]]:19: error: unexpected extra operand for instruction
 th.mvnez a0,a1,1      # CHECK: :[[@LINE]]:16: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/xtheadsync-invalid.s
+++ b/llvm/test/MC/RISCV/xtheadsync-invalid.s
@@ -2,7 +2,7 @@
 # RUN: not llvm-mc -triple riscv64 -mattr=+xtheadsync < %s 2>&1 | FileCheck %s
 
 th.sfence.vmas t0 # CHECK: :[[@LINE]]:18: error: too few operands for instruction
-th.sync t0 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
-th.sync.s t0 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
-th.sync.i t0 # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
-th.sync.is t0 # CHECK: :[[@LINE]]:12: error: invalid operand for instruction
+th.sync t0 # CHECK: :[[@LINE]]:9: error: too many operands for instruction
+th.sync.s t0 # CHECK: :[[@LINE]]:11: error: too many operands for instruction
+th.sync.i t0 # CHECK: :[[@LINE]]:11: error: too many operands for instruction
+th.sync.is t0 # CHECK: :[[@LINE]]:12: error: too many operands for instruction

--- a/llvm/test/MC/RISCV/xtheadsync-invalid.s
+++ b/llvm/test/MC/RISCV/xtheadsync-invalid.s
@@ -2,7 +2,7 @@
 # RUN: not llvm-mc -triple riscv64 -mattr=+xtheadsync < %s 2>&1 | FileCheck %s
 
 th.sfence.vmas t0 # CHECK: :[[@LINE]]:18: error: too few operands for instruction
-th.sync t0 # CHECK: :[[@LINE]]:9: error: too many operands for instruction
-th.sync.s t0 # CHECK: :[[@LINE]]:11: error: too many operands for instruction
-th.sync.i t0 # CHECK: :[[@LINE]]:11: error: too many operands for instruction
-th.sync.is t0 # CHECK: :[[@LINE]]:12: error: too many operands for instruction
+th.sync t0 # CHECK: :[[@LINE]]:9: error: unexpected extra operand for instruction
+th.sync.s t0 # CHECK: :[[@LINE]]:11: error: unexpected extra operand for instruction
+th.sync.i t0 # CHECK: :[[@LINE]]:11: error: unexpected extra operand for instruction
+th.sync.is t0 # CHECK: :[[@LINE]]:12: error: unexpected extra operand for instruction


### PR DESCRIPTION
This improves upon the shared near-miss reporting infrastructure added in #205721 by handling a case that was deferred during that PR's review.

Assisted-by: claude-opus