### PR TITLE
[lldb][AArch64][Linux][NFC] Move RegisterSetType enum into header

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
@@ -773,25 +773,10 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
   return Status::FromErrorString("Failed to write register value");
 }
 
-enum RegisterSetType : uint32_t {
-  GPR, // General purpose registers.
-  SVE, // Used for SVE registers in streaming or non-streaming mode.
-  FPR, // When there is no SVE, or SVE in FPSIMD mode, or streaming only SVE
-       // that is in non-streaming mode.
-  // Pointer authentication registers are read only, so not included here.
-  MTE,  // Memory tagging control registers.
-  TLS,  // Thread local storage registers.
-  SME,  // ZA only, because SVCR and SVG are pseudo registers.
-  SME2, // ZT only.
-  FPMR, // Floating point mode control registers.
-  GCS,  // Guarded Control Stack registers.
-  POE,  // Permission Overlay registers.
-};
-
-static uint8_t *AddRegisterSetType(uint8_t *dst,
-                                   RegisterSetType register_set_type) {
-  *(reinterpret_cast<uint32_t *>(dst)) = register_set_type;
-  return dst + sizeof(uint32_t);
+uint8_t *NativeRegisterContextLinux_arm64::AddRegisterSetType(
+    uint8_t *dst, RegisterSetType register_set_type) {
+  *(reinterpret_cast<RegisterSetType *>(dst)) = register_set_type;
+  return dst + sizeof(RegisterSetType);
 }
 
 static uint8_t *AddSavedRegistersData(uint8_t *dst, void *src, size_t size) {
@@ -799,9 +784,8 @@ static uint8_t *AddSavedRegistersData(uint8_t *dst, void *src, size_t size) {
   return dst + size;
 }
 
-static uint8_t *AddSavedRegisters(uint8_t *dst,
-                                  enum RegisterSetType register_set_type,
-                                  void *src, size_t size) {
+uint8_t *NativeRegisterContextLinux_arm64::AddSavedRegisters(
+    uint8_t *dst, RegisterSetType register_set_type, void *src, size_t size) {
   dst = AddRegisterSetType(dst, register_set_type);
   return AddSavedRegistersData(dst, src, size);
 }

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
@@ -79,6 +79,21 @@ protected:
   lldb::addr_t FixWatchpointHitAddress(lldb::addr_t hit_addr) override;
 
 private:
+  enum RegisterSetType : uint32_t {
+    GPR, // General purpose registers.
+    SVE, // Used for SVE registers in streaming or non-streaming mode.
+    FPR, // When there is no SVE, or SVE in FPSIMD mode, or streaming only SVE
+         // that is in non-streaming mode.
+    // Pointer authentication registers are read only, so not included here.
+    MTE,  // Memory tagging control registers.
+    TLS,  // Thread local storage registers.
+    SME,  // ZA only, because SVCR and SVG are pseudo registers.
+    SME2, // ZT only.
+    FPMR, // Floating point mode control registers.
+    GCS,  // Guarded Control Stack registers.
+    POE,  // Permission Overlay registers.
+  };
+
   bool m_gpr_is_valid;
   bool m_fpu_is_valid;
   bool m_sve_buffer_is_valid;
@@ -260,6 +275,11 @@ private:
   uint32_t CalculateSVEOffset(const RegisterInfo *reg_info) const;
 
   Status CacheAllRegisters(uint32_t &cached_size);
+
+  uint8_t *AddRegisterSetType(uint8_t *dst, RegisterSetType register_set_type);
+
+  uint8_t *AddSavedRegisters(uint8_t *dst, RegisterSetType register_set_type,
+                             void *src, size_t size);
 };
 
 } // namespace process_linux


### PR DESCRIPTION
I will be using this later to replace all the register specific functions this class has (WriteSVE/ReadSVE and so on) with single functions that use RegisterSetType to decide what to do.

While I'm here, I've made some sizeof and casts use RegisterSetType in case the underlying type changes later.