### PR TITLE
[lldb][Windows] Mark test as expected failure

### DIFF
--- a/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
+++ b/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
@@ -63,7 +63,7 @@ class TestPlatformProcessConnect(TestBase):
     @skipIfRemote
     @expectedFailureAll(hostoslist=["windows"], triple=".*-android")
     @skipIfDarwin  # lldb-server not found correctly
-    @expectedFailureWindowsAndNoLLDBServer()  # process modules not loaded
+    @expectedFailureWindows  # process modules not loaded
     # lldb-server platform times out waiting for the gdbserver port number to be
     # written to the pipe, yet it seems the gdbserver already has written it.
     @expectedFailureAll(


### PR DESCRIPTION
In f31853255c300e07b93783425e40948cc0dfdb0f, this test was marked as expected failure only when running with `lldb-server.exe`. It shoulds not have been, it is still failing. Revert the decorator to `expectedFailureWindows`.