### PR TITLE
[clang][bytecode] Reject functions with invalid parameters

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -680,7 +680,8 @@ const Function *Context::getOrCreateFunction(const FunctionDecl *FuncDecl) {
     bool IsConst = PD->getType().isConstQualified();
     bool IsVolatile = PD->getType().isVolatileQualified();
 
-    if (!getASTContext().hasSameType(PD->getType(),
+    if (PD->isInvalidDecl() ||
+        !getASTContext().hasSameType(PD->getType(),
                                      FuncProto->getParamType(ParamIndex)))
       return nullptr;
 

--- a/clang/test/AST/ByteCode/cxx23.cpp
+++ b/clang/test/AST/ByteCode/cxx23.cpp
@@ -268,8 +268,11 @@ namespace ExplicitLambdaInstancePointer {
   };
   constexpr auto b = [](this K) { return 1; }; // all20-error {{explicit object parameters are incompatible with C++ standards before C++2b}} \
                                                // all-error {{unknown type name 'K'}}
-  constexpr int (*fp)(K) = b; // all-error {{unknown type name 'K'}}
-  static_assert(fp(1) == 1, ""); // expected-error {{not an integral constant expression}}
+  constexpr int (*fp)(K) = b; // all-error {{unknown type name 'K'}} \
+                              // expected-error {{must be initialized by a constant expression}} \
+                              // expected-note {{declared here}}
+  static_assert(fp(1) == 1, ""); // expected-error {{not an integral constant expression}} \
+                                 // expected-note {{initializer of 'fp' is not a constant expression}}
 }
 
 namespace TwosComplementShifts {
@@ -658,4 +661,10 @@ namespace BrokenShuffleVector {
   constexpr __m128 kf1{1.0f, 2.0f, 3.0f, 4.0f};
   constexpr __m128 v_mm_cvtps_pd = _mm_cvtps_pd(kf1); // all-error {{must be initialized by a constant expression}}
 }
+
+namespace BrokenExplicitInstanceParam {
+  auto b = [](this C) { return 1; }; // all-error {{unknown type name 'C'}}
+  static_assert( (&decltype(b)::operator())(1) == 1); // expected-error {{not an integral constant expression}}
+}
+
 #endif


### PR DESCRIPTION
They will just cause problems later when calling them.