### PR TITLE
[Offload] Guard __llvm_write_custom_profile null check on non-Windows

### DIFF
--- a/offload/plugins-nextgen/common/src/GlobalHandler.cpp
+++ b/offload/plugins-nextgen/common/src/GlobalHandler.cpp
@@ -275,11 +275,15 @@ void GPUProfGlobals::dump() const {
 }
 
 Error GPUProfGlobals::write() const {
+#ifndef _WIN32
+  // On Windows __llvm_write_custom_profile is a strong stub (see above), so its
+  // address is never null and this check triggers -Wpointer-bool-conversion.
   if (!__llvm_write_custom_profile)
     return Plugin::error(ErrorCode::INVALID_BINARY,
                          "could not find symbol __llvm_write_custom_profile. "
                          "The compiler-rt profiling library must be linked for "
                          "GPU PGO to work.");
+#endif
 
   // Lay out as [Data][Counters][Names] to match the raw profile format order.
   // TODO: Move this interface to compiler-rt.


### PR DESCRIPTION
On Windows __llvm_write_custom_profile is defined as a strong stub (MSVC lacks proper weak symbol support) by 09a51b2818e2, so its address is a compile-time constant that is never null. The `if (!__llvm_write_custom_profile)` check therefore triggers -Wpointer-bool-conversion, which is fatal under -Werror.

Assisted-by: Claude