### PR TITLE
[lldb][test] Always kill test processes

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1203,6 +1203,18 @@ class Base(unittest.TestCase):
                 for dict in reversed(self.dicts):
                     self.cleanup(dictionary=dict)
 
+        # Kill any process a target is still holding on to.
+        for i in range(self.dbg.GetNumTargets()):
+            process = self.dbg.GetTargetAtIndex(i).GetProcess()
+            # Only kill processes that are still alive.
+            if process.IsValid() and process.is_alive:
+                process.Kill()
+                self.assertEqual(
+                    process.GetState(),
+                    lldb.eStateExited,
+                    "Failed to kill process during teardown",
+                )
+
         # Remove subprocesses created by the test.
         self.cleanupSubprocesses()
 

--- a/lldb/test/API/commands/process/attach/TestProcessAttach.py
+++ b/lldb/test/API/commands/process/attach/TestProcessAttach.py
@@ -142,10 +142,3 @@ class ProcessAttachTestCase(TestBase):
         )
         self.runCmd("process continue")
         self.expect("v g_val", substrs=["12345"])
-
-    def tearDown(self):
-        # Destroy process before TestBase.tearDown()
-        self.dbg.GetSelectedTarget().GetProcess().Destroy()
-
-        # Call super's tearDown().
-        TestBase.tearDown(self)


### PR DESCRIPTION
TestProcessAttach.py calls Destroy() on the test SBProcess when tearing down the test. However, Destroy() only detaches us from the process but keeps it running. The correct way would be to call Kill() which does the same as Destroy but also kills a process we attached to.

To avoid this issue in future tests, I moved this tear down logic to the common test tear-down logic used for all tests. I don't see any reason for why we should not try to kill an alive test inferior at the end of a test.

This should also fix the flaky TestProcessAttach.py test. Here, the `test_attach_to_process_by_id_autocontinue` subtest attaches to the test inferior which is just sleeping for a minute. At the end of the test we currently detach and the inferior keeps sleeping. If we reach the `test_attach_to_process_by_name` then we launch the new inferior and the old one might still be around, so we end up finding two with the same name.

Resolves #206981