### PR TITLE
[AArch64] Minor simplification in aarch64-ldst-opt with an early return

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
@@ -2017,7 +2017,6 @@ AArch64LoadStoreOpt::findMatchingInsn(MachineBasicBlock::iterator I,
                                       bool FindNarrowMerge) {
   MachineBasicBlock::iterator E = I->getParent()->end();
   MachineBasicBlock::iterator MBBI = I;
-  MachineBasicBlock::iterator MBBIWithRenameReg;
   MachineInstr &FirstMI = *I;
   MBBI = next_nodbg(MBBI, E);
 
@@ -2247,16 +2246,13 @@ AArch64LoadStoreOpt::findMatchingInsn(MachineBasicBlock::iterator I,
           if (RenameReg) {
             Flags.setMergeForward(true);
             Flags.setRenameReg(*RenameReg);
-            MBBIWithRenameReg = MBBI;
+            return MBBI;
           }
         }
         LLVM_DEBUG(dbgs() << "Unable to combine these instructions due to "
                           << "interference in between, keep looking.\n");
       }
     }
-
-    if (Flags.getRenameReg())
-      return MBBIWithRenameReg;
 
     // If the instruction wasn't a matching load or store.  Stop searching if we
     // encounter a call instruction that might modify memory.


### PR DESCRIPTION
Remove the local `MBBIWithRenameReg` by moving an early return at an
even earlier point.

When `MBBIWithRenameReg` is set we always return early. By moving the
early return to `MBBIWithRenameReg` update we get rid of a local
variable which spans  200+ lines. This also fixes a misleading debug
print between `MBBIWithRenameReg` update and early return:

```
LLVM_DEBUG(dbgs() << "Unable to combine these instructions due to "
                << "interference in between, keep looking.\n");
```

This line shouldn't be printed when we set `MBBIWithRenameReg`, which is
fixed with this change.