### PR TITLE
[clang-format] Fix BlockIndent compat mapping of AlignAfterOpenBracket

### DIFF
--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1159,14 +1159,14 @@ template <> struct MappingTraits<FormatStyle> {
         break;
       case BAS_BlockIndent:
         Style.AlignAfterOpenBracket = true;
+        Style.BreakAfterOpenBracketBracedList = true;
+        Style.BreakAfterOpenBracketFunction = true;
+        Style.BreakAfterOpenBracketIf = true;
+        Style.BreakAfterOpenBracketLoop = false;
+        Style.BreakAfterOpenBracketSwitch = false;
         Style.BreakBeforeCloseBracketBracedList = true;
         Style.BreakBeforeCloseBracketFunction = true;
         Style.BreakBeforeCloseBracketIf = true;
-        Style.BreakAfterOpenBracketLoop = false;
-        Style.BreakAfterOpenBracketSwitch = false;
-        Style.BreakBeforeCloseBracketBracedList = false;
-        Style.BreakBeforeCloseBracketFunction = false;
-        Style.BreakBeforeCloseBracketIf = false;
         Style.BreakBeforeCloseBracketLoop = false;
         Style.BreakBeforeCloseBracketSwitch = false;
         break;

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -652,6 +652,31 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("AlignAfterOpenBracket: false", AlignAfterOpenBracket, false);
   CHECK_PARSE("AlignAfterOpenBracket: BlockIndent", AlignAfterOpenBracket,
               true);
+  // BlockIndent implies breaking after the open bracket and before the close
+  // bracket of braced lists, function calls/declarations, and if conditions.
+  Style.BreakAfterOpenBracketBracedList = false;
+  Style.BreakAfterOpenBracketFunction = false;
+  Style.BreakAfterOpenBracketIf = false;
+  Style.BreakAfterOpenBracketLoop = true;
+  Style.BreakAfterOpenBracketSwitch = true;
+  Style.BreakBeforeCloseBracketBracedList = false;
+  Style.BreakBeforeCloseBracketFunction = false;
+  Style.BreakBeforeCloseBracketIf = false;
+  Style.BreakBeforeCloseBracketLoop = true;
+  Style.BreakBeforeCloseBracketSwitch = true;
+  EXPECT_EQ(
+      0,
+      parseConfiguration("AlignAfterOpenBracket: BlockIndent", &Style).value());
+  EXPECT_TRUE(Style.BreakAfterOpenBracketBracedList);
+  EXPECT_TRUE(Style.BreakAfterOpenBracketFunction);
+  EXPECT_TRUE(Style.BreakAfterOpenBracketIf);
+  EXPECT_FALSE(Style.BreakAfterOpenBracketLoop);
+  EXPECT_FALSE(Style.BreakAfterOpenBracketSwitch);
+  EXPECT_TRUE(Style.BreakBeforeCloseBracketBracedList);
+  EXPECT_TRUE(Style.BreakBeforeCloseBracketFunction);
+  EXPECT_TRUE(Style.BreakBeforeCloseBracketIf);
+  EXPECT_FALSE(Style.BreakBeforeCloseBracketLoop);
+  EXPECT_FALSE(Style.BreakBeforeCloseBracketSwitch);
   Style.AlignAfterOpenBracket = false;
   CHECK_PARSE("AlignAfterOpenBracket: true", AlignAfterOpenBracket, true);
 

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -650,8 +650,6 @@ TEST(ConfigParseTest, ParsesConfiguration) {
               "AlignAfterOpenBracket: AlwaysBreak",
               BreakAfterOpenBracketLoop, true);
   CHECK_PARSE("AlignAfterOpenBracket: false", AlignAfterOpenBracket, false);
-  CHECK_PARSE("AlignAfterOpenBracket: BlockIndent", AlignAfterOpenBracket,
-              true);
   // BlockIndent implies breaking after the open bracket and before the close
   // bracket of braced lists, function calls/declarations, and if conditions.
   Style.BreakAfterOpenBracketBracedList = false;
@@ -664,9 +662,8 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   Style.BreakBeforeCloseBracketIf = false;
   Style.BreakBeforeCloseBracketLoop = true;
   Style.BreakBeforeCloseBracketSwitch = true;
-  EXPECT_EQ(
-      0,
-      parseConfiguration("AlignAfterOpenBracket: BlockIndent", &Style).value());
+  CHECK_PARSE("AlignAfterOpenBracket: BlockIndent", AlignAfterOpenBracket,
+              true);
   EXPECT_TRUE(Style.BreakAfterOpenBracketBracedList);
   EXPECT_TRUE(Style.BreakAfterOpenBracketFunction);
   EXPECT_TRUE(Style.BreakAfterOpenBracketIf);


### PR DESCRIPTION
be11e2b3d25 (#192283) replaced the `[[fallthrough]]` chain in the `AlignAfterOpenBracket` backward-compatibility switch with explicit per-case assignments. In the `BAS_BlockIndent` case the `BreakBeforeCloseBracket{BracedList,Function,If} = true` assignments are immediately overwritten with `false`, and `BreakAfterOpenBracket{BracedList,Function,If}` (previously inherited from the `BAS_AlwaysBreak` case via fallthrough) are never set. As a result, `AlignAfterOpenBracket: BlockIndent` parses to the same flag set as `Align`, silently dropping the block-indent style for existing configurations.

Restore the pre-#192283 mapping and pin the full BlockIndent flag mapping in ConfigParseTest so the compat shim cannot regress silently again.

Fixes #207186.

Note for the release branch: if #205920 (backport of #192283 to release/22.x) lands, this fix needs to be backported together with it.
