### PR TITLE
[SimplifyCFG] Avoid calling `paramHasNonNullAttr` on a ptr vector argument

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -8914,7 +8914,7 @@ static bool passingValueIsAlwaysUndefined(Value *V, Instruction *I, bool PtrValu
       if (CB->isArgOperand(&Use)) {
         unsigned ArgIdx = CB->getArgOperandNo(&Use);
         // Passing null to a nonnnull+noundef argument is undefined.
-        if (isa<ConstantPointerNull>(C) &&
+        if (isa<ConstantPointerNull>(C) && C->getType()->isPointerTy() &&
             CB->paramHasNonNullAttr(ArgIdx, /*AllowUndefOrPoison=*/false))
           return !PtrValueMayBeModified;
         // Passing undef to a noundef argument is undefined.

--- a/llvm/test/Transforms/SimplifyCFG/UnreachableEliminate.ll
+++ b/llvm/test/Transforms/SimplifyCFG/UnreachableEliminate.ll
@@ -1211,6 +1211,23 @@ return:
   ret i8 %r
 }
 
+; Make sure we don't call paramHasNonNullAttr on a ptr vector argument.
+
+define void @pr207188() {
+; CHECK-LABEL: @pr207188(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @fn_arg_vec(<2 x ptr> splat (ptr null))
+; CHECK-NEXT:    ret void
+;
+entry:
+  br label %bb
+
+bb:
+  %phi = phi <2 x ptr> [ splat (ptr null), %entry ]
+  call void @fn_arg_vec(<2 x ptr> %phi)
+  ret void
+}
+
 attributes #0 = { null_pointer_is_valid }
 ;.
 ; CHECK: attributes #[[ATTR0:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: write) }


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/commit/f8467698d8cdbac6e02cdc1aab643d1ac733ec19, `ConstantPointerNull` also represents a null ptr vector. However, `paramHasNonNullAttr` only accepts scalar pointer arguments.

Closes https://github.com/llvm/llvm-project/issues/207188.
