### PR TITLE
[OpenACC] Fix reduction var equality check for member variables

### DIFF
--- a/clang/lib/Sema/SemaOpenACCClause.cpp
+++ b/clang/lib/Sema/SemaOpenACCClause.cpp
@@ -1846,6 +1846,20 @@ bool areVarsEqual(Expr *VarExpr1, Expr *VarExpr2) {
            Expr2DRE->getDecl()->getMostRecentDecl();
   }
 
+  // References to a member.
+  if (auto *Expr1ME = dyn_cast<MemberExpr>(VarExpr1)) {
+    auto *Expr2ME = dyn_cast<MemberExpr>(VarExpr2);
+    if (!Expr2ME)
+      return false;
+
+    return Expr1ME->getMemberDecl()->getMostRecentDecl() ==
+               Expr2ME->getMemberDecl()->getMostRecentDecl() &&
+           areVarsEqual(Expr1ME->getBase(), Expr2ME->getBase());
+  }
+
+  if (isa<CXXThisExpr>(VarExpr1))
+    return isa<CXXThisExpr>(VarExpr2);
+
   llvm_unreachable("Unknown variable type encountered");
 }
 } // namespace

--- a/clang/test/SemaOpenACC/loop-construct-reduction-clause.cpp
+++ b/clang/test/SemaOpenACC/loop-construct-reduction-clause.cpp
@@ -377,4 +377,47 @@ void inst() {
   templ_uses<int, CompositeOfScalars, CompositeHasComposite, 1, 2>();
 }
 
+namespace gh207180 {
+struct InlineDefFunc {
+  int I;
+  void func() {
+#pragma acc loop reduction(+:I)
+    // expected-error@+3{{OpenACC 'reduction' variable must have the same operator in all nested constructs (& vs +)}}
+    for(int i = 0; i < 5; ++i)
+    // expected-note@-3{{previous 'reduction' clause is here}}
+#pragma acc loop reduction(&:I)
+    for(int j = 0; j < 5; ++j);
+  }
+};
+struct OutlineDefFunc {
+  int I;
+  void func();
+};
+void OutlineDefFunc::func() {
+#pragma acc loop reduction(+:I)
+  // expected-error@+3{{OpenACC 'reduction' variable must have the same operator in all nested constructs (& vs +)}}
+    for(int i = 0; i < 5; ++i)
+  // expected-note@-3{{previous 'reduction' clause is here}}
+#pragma acc loop reduction(&:I)
+  for(int j = 0; j < 5; ++j);
+}
 
+template<typename T>
+struct TemplDefFunc {
+  T I;
+  void func() {
+#pragma acc loop reduction(+:I)
+    // expected-error@+3{{OpenACC 'reduction' variable must have the same operator in all nested constructs (& vs +)}}
+    for(int i = 0; i < 5; ++i)
+    // expected-note@-3{{previous 'reduction' clause is here}}
+#pragma acc loop reduction(&:I)
+    for(int j = 0; j < 5; ++j);
+  }
+};
+
+void use() {
+  TemplDefFunc<int> d;
+  d.func(); // expected-note{{in instantiation of}}
+}
+
+}


### PR DESCRIPTION
OpenACC requires we check that a variable have the same operator in all nested constructs with a reduction. The implementation for this checks everything I could think of, but I apparently missed member expressions. This patch adds checks for that as well as 'this' so we should correctly get the checks.

Fixes: #207180