### PR TITLE
[AArch64] NFC: Factor out code from FP_TO_INT (SVE).

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -5082,28 +5082,8 @@ SDValue AArch64TargetLowering::LowerVectorFP_TO_INT(SDValue Op,
         DAG.getNode(ISD::FP_EXTEND, DL, NewVT, Op.getOperand(0)));
   }
 
-  if (VT.isScalableVector()) {
-    if (VT.getVectorElementType() == MVT::i1) {
-      SDLoc DL(Op);
-      EVT CvtVT = getPromotedVTForPredicate(VT);
-      SDValue Cvt = DAG.getNode(Op.getOpcode(), DL, CvtVT, Op.getOperand(0));
-      SDValue Zero = DAG.getConstant(0, DL, CvtVT);
-      return DAG.getSetCC(DL, VT, Cvt, Zero, ISD::SETNE);
-    }
-
-    // Let common code split the operation.
-    if (InVT == MVT::nxv8f32)
-      return Op;
-
-    unsigned Opcode = Op.getOpcode() == ISD::FP_TO_UINT
-                          ? AArch64ISD::FCVTZU_MERGE_PASSTHRU
-                          : AArch64ISD::FCVTZS_MERGE_PASSTHRU;
-    return LowerToPredicatedOp(Op, DAG, Opcode);
-  }
-
-  if (useSVEForFixedLengthVectorVT(VT, !Subtarget->isNeonAvailable()) ||
-      useSVEForFixedLengthVectorVT(InVT, !Subtarget->isNeonAvailable()))
-    return LowerFixedLengthFPToIntToSVE(Op, DAG);
+  if (SDValue Res = tryLowerFPToIntToSVE(Op, DAG))
+    return Res;
 
   uint64_t VTSize = VT.getFixedSizeInBits();
   uint64_t InVTSize = InVT.getFixedSizeInBits();
@@ -34492,15 +34472,63 @@ AArch64TargetLowering::LowerGET_ACTIVE_LANE_MASK(SDValue Op,
                      DAG.getVectorIdxConstant(0, DL));
 }
 
-SDValue
-AArch64TargetLowering::LowerFixedLengthFPToIntToSVE(SDValue Op,
+SDValue AArch64TargetLowering::tryLowerFPToIntToSVE(SDValue Op,
                                                     SelectionDAG &DAG) const {
+  // Strict FP_TO_INT is not yet implemented.
+  if (Op->isStrictFPOpcode())
+    return SDValue();
+
+  EVT InVT = Op.getOperand(0).getValueType();
+  EVT VT = Op.getValueType();
+
+  unsigned NewOpcode;
+  switch (Op.getOpcode()) {
+  case ISD::FP_TO_UINT:
+  case ISD::STRICT_FP_TO_UINT:
+    NewOpcode = AArch64ISD::FCVTZU_MERGE_PASSTHRU;
+    break;
+  case ISD::FP_TO_SINT:
+  case ISD::STRICT_FP_TO_SINT:
+    NewOpcode = AArch64ISD::FCVTZS_MERGE_PASSTHRU;
+    break;
+  default:
+    llvm_unreachable("Unexpected opcode");
+  }
+
+  SDLoc DL(Op);
+  if (VT.isScalableVector()) {
+    // Optimize the i1 case by using setcc.
+    if (VT.getVectorElementType() == MVT::i1) {
+      EVT CvtVT = getPromotedVTForPredicate(VT);
+      SDValue Cvt = DAG.getNode(Op.getOpcode(), DL, CvtVT, Op.getOperand(0));
+      SDValue Zero = DAG.getConstant(0, DL, CvtVT);
+      return DAG.getSetCC(DL, VT, Cvt, Zero, ISD::SETNE);
+    }
+
+    // Let common code split the operation.
+    if (InVT == MVT::nxv8f32)
+      return Op;
+
+    SmallVector<SDValue, 4> Operands;
+    Operands.push_back(getPredicateForVector(DAG, DL, VT));
+    Operands.push_back(Op.getOperand(0));
+    Operands.push_back(DAG.getPOISON(VT));
+    return DAG.getNode(NewOpcode, DL, VT, Operands, Op->getFlags());
+  }
+
+  bool UseSVE = !Subtarget->isNeonAvailable();
+  if (useSVEForFixedLengthVectorVT(VT, UseSVE) ||
+      useSVEForFixedLengthVectorVT(InVT, UseSVE))
+    return LowerFixedLengthFPToIntToSVE(Op, DAG, NewOpcode);
+
+  return SDValue();
+}
+
+SDValue AArch64TargetLowering::LowerFixedLengthFPToIntToSVE(
+    SDValue Op, SelectionDAG &DAG, unsigned Opcode) const {
   EVT VT = Op.getValueType();
   assert(VT.isFixedLengthVector() && "Expected fixed length vector type!");
-
-  bool IsSigned = Op.getOpcode() == ISD::FP_TO_SINT;
-  unsigned Opcode = IsSigned ? AArch64ISD::FCVTZS_MERGE_PASSTHRU
-                             : AArch64ISD::FCVTZU_MERGE_PASSTHRU;
+  assert(!Op->isStrictFPOpcode() && "Strict FP_TO_INT not yet supported");
 
   SDLoc DL(Op);
   SDValue Val = Op.getOperand(0);

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -34484,11 +34484,9 @@ SDValue AArch64TargetLowering::tryLowerFPToIntToSVE(SDValue Op,
   unsigned NewOpcode;
   switch (Op.getOpcode()) {
   case ISD::FP_TO_UINT:
-  case ISD::STRICT_FP_TO_UINT:
     NewOpcode = AArch64ISD::FCVTZU_MERGE_PASSTHRU;
     break;
   case ISD::FP_TO_SINT:
-  case ISD::STRICT_FP_TO_SINT:
     NewOpcode = AArch64ISD::FCVTZS_MERGE_PASSTHRU;
     break;
   default:
@@ -34508,12 +34506,7 @@ SDValue AArch64TargetLowering::tryLowerFPToIntToSVE(SDValue Op,
     // Let common code split the operation.
     if (InVT == MVT::nxv8f32)
       return Op;
-
-    SmallVector<SDValue, 4> Operands;
-    Operands.push_back(getPredicateForVector(DAG, DL, VT));
-    Operands.push_back(Op.getOperand(0));
-    Operands.push_back(DAG.getPOISON(VT));
-    return DAG.getNode(NewOpcode, DL, VT, Operands, Op->getFlags());
+    return LowerToPredicatedOp(Op, DAG, NewOpcode);
   }
 
   bool UseSVE = !Subtarget->isNeonAvailable();

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -34472,6 +34472,17 @@ AArch64TargetLowering::LowerGET_ACTIVE_LANE_MASK(SDValue Op,
                      DAG.getVectorIdxConstant(0, DL));
 }
 
+static unsigned getSVEOpcodeForFPToInt(unsigned Opc) {
+  switch (Opc) {
+  case ISD::FP_TO_UINT:
+    return AArch64ISD::FCVTZU_MERGE_PASSTHRU;
+  case ISD::FP_TO_SINT:
+    return AArch64ISD::FCVTZS_MERGE_PASSTHRU;
+  default:
+    llvm_unreachable("Unexpected opcode");
+  }
+}
+
 SDValue AArch64TargetLowering::tryLowerFPToIntToSVE(SDValue Op,
                                                     SelectionDAG &DAG) const {
   // Strict FP_TO_INT is not yet implemented.
@@ -34480,18 +34491,6 @@ SDValue AArch64TargetLowering::tryLowerFPToIntToSVE(SDValue Op,
 
   EVT InVT = Op.getOperand(0).getValueType();
   EVT VT = Op.getValueType();
-
-  unsigned NewOpcode;
-  switch (Op.getOpcode()) {
-  case ISD::FP_TO_UINT:
-    NewOpcode = AArch64ISD::FCVTZU_MERGE_PASSTHRU;
-    break;
-  case ISD::FP_TO_SINT:
-    NewOpcode = AArch64ISD::FCVTZS_MERGE_PASSTHRU;
-    break;
-  default:
-    llvm_unreachable("Unexpected opcode");
-  }
 
   SDLoc DL(Op);
   if (VT.isScalableVector()) {
@@ -34506,22 +34505,30 @@ SDValue AArch64TargetLowering::tryLowerFPToIntToSVE(SDValue Op,
     // Let common code split the operation.
     if (InVT == MVT::nxv8f32)
       return Op;
-    return LowerToPredicatedOp(Op, DAG, NewOpcode);
+
+    SmallVector<SDValue, 4> Operands;
+    Operands.push_back(getPredicateForVector(DAG, DL, VT));
+    Operands.push_back(Op.getOperand(0));
+    Operands.push_back(DAG.getPOISON(VT));
+    return DAG.getNode(getSVEOpcodeForFPToInt(Op.getOpcode()), DL, VT, Operands,
+                       Op->getFlags());
   }
 
   bool UseSVE = !Subtarget->isNeonAvailable();
   if (useSVEForFixedLengthVectorVT(VT, UseSVE) ||
       useSVEForFixedLengthVectorVT(InVT, UseSVE))
-    return LowerFixedLengthFPToIntToSVE(Op, DAG, NewOpcode);
+    return LowerFixedLengthFPToIntToSVE(Op, DAG);
 
   return SDValue();
 }
 
-SDValue AArch64TargetLowering::LowerFixedLengthFPToIntToSVE(
-    SDValue Op, SelectionDAG &DAG, unsigned Opcode) const {
+SDValue
+AArch64TargetLowering::LowerFixedLengthFPToIntToSVE(SDValue Op,
+                                                    SelectionDAG &DAG) const {
   EVT VT = Op.getValueType();
   assert(VT.isFixedLengthVector() && "Expected fixed length vector type!");
   assert(!Op->isStrictFPOpcode() && "Strict FP_TO_INT not yet supported");
+  unsigned Opcode = getSVEOpcodeForFPToInt(Op.getOpcode());
 
   SDLoc DL(Op);
   SDValue Val = Op.getOperand(0);

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -808,6 +808,8 @@ private:
   SDValue LowerFCANONICALIZE(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerAVG(SDValue Op, SelectionDAG &DAG, unsigned NewOp) const;
 
+  SDValue tryLowerFPToIntToSVE(SDValue Op, SelectionDAG &DAG) const;
+
   SDValue LowerFixedLengthVectorIntDivideToSVE(SDValue Op,
                                                SelectionDAG &DAG) const;
   SDValue LowerFixedLengthVectorIntExtendToSVE(SDValue Op,
@@ -832,7 +834,8 @@ private:
   SDValue LowerFixedLengthFPExtendToSVE(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFixedLengthFPRoundToSVE(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFixedLengthIntToFPToSVE(SDValue Op, SelectionDAG &DAG) const;
-  SDValue LowerFixedLengthFPToIntToSVE(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerFixedLengthFPToIntToSVE(SDValue Op, SelectionDAG &DAG,
+                                       unsigned Opcode) const;
   SDValue LowerFixedLengthVECTOR_SHUFFLEToSVE(SDValue Op,
                                               SelectionDAG &DAG) const;
   SDValue LowerFixedLengthBuildVectorToSVE(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -834,8 +834,7 @@ private:
   SDValue LowerFixedLengthFPExtendToSVE(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFixedLengthFPRoundToSVE(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFixedLengthIntToFPToSVE(SDValue Op, SelectionDAG &DAG) const;
-  SDValue LowerFixedLengthFPToIntToSVE(SDValue Op, SelectionDAG &DAG,
-                                       unsigned Opcode) const;
+  SDValue LowerFixedLengthFPToIntToSVE(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFixedLengthVECTOR_SHUFFLEToSVE(SDValue Op,
                                               SelectionDAG &DAG) const;
   SDValue LowerFixedLengthBuildVectorToSVE(SDValue Op, SelectionDAG &DAG) const;


### PR DESCRIPTION
This just moves out some of the SVE lowering code from LowerVectorFP_TO_INT into a separate function, so that we can reuse that in LowerVectorFP_TO_INT_SAT.