### PR TITLE
clang: Use getFloatingPointType instead of reinventing it

### DIFF
--- a/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -299,25 +299,6 @@ void CodeGenTypes::RefreshTypeCacheForClass(const CXXRecordDecl *RD) {
   }
 }
 
-static llvm::Type *getTypeForFormat(llvm::LLVMContext &VMContext,
-                                    const llvm::fltSemantics &format) {
-  if (&format == &llvm::APFloat::IEEEhalf())
-    return llvm::Type::getHalfTy(VMContext);
-  if (&format == &llvm::APFloat::BFloat())
-    return llvm::Type::getBFloatTy(VMContext);
-  if (&format == &llvm::APFloat::IEEEsingle())
-    return llvm::Type::getFloatTy(VMContext);
-  if (&format == &llvm::APFloat::IEEEdouble())
-    return llvm::Type::getDoubleTy(VMContext);
-  if (&format == &llvm::APFloat::IEEEquad())
-    return llvm::Type::getFP128Ty(VMContext);
-  if (&format == &llvm::APFloat::PPCDoubleDouble())
-    return llvm::Type::getPPC_FP128Ty(VMContext);
-  if (&format == &llvm::APFloat::x87DoubleExtended())
-    return llvm::Type::getX86_FP80Ty(VMContext);
-  llvm_unreachable("Unknown float format!");
-}
-
 llvm::Type *CodeGenTypes::ConvertFunctionTypeInternal(QualType QFT) {
   assert(QFT.isCanonical());
   const FunctionType *FT = cast<FunctionType>(QFT.getTypePtr());
@@ -479,15 +460,15 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
       break;
 
     case BuiltinType::Float16:
-      ResultType =
-          getTypeForFormat(getLLVMContext(), Context.getFloatTypeSemantics(T));
+      ResultType = llvm::Type::getFloatingPointTy(
+          getLLVMContext(), Context.getFloatTypeSemantics(T));
       break;
 
     case BuiltinType::Half:
       // Half FP can either be storage-only (lowered to i16 for ABI purposes) or
       // native.
-      ResultType =
-          getTypeForFormat(getLLVMContext(), Context.getFloatTypeSemantics(T));
+      ResultType = llvm::Type::getFloatingPointTy(
+          getLLVMContext(), Context.getFloatTypeSemantics(T));
       break;
     case BuiltinType::LongDouble:
       LongDoubleReferenced = true;
@@ -497,8 +478,8 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
     case BuiltinType::Double:
     case BuiltinType::Float128:
     case BuiltinType::Ibm128:
-      ResultType =
-          getTypeForFormat(getLLVMContext(), Context.getFloatTypeSemantics(T));
+      ResultType = llvm::Type::getFloatingPointTy(
+          getLLVMContext(), Context.getFloatTypeSemantics(T));
       break;
 
     case BuiltinType::NullPtr:


### PR DESCRIPTION
Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>