### PR TITLE
[libc] Improve Dir class safety, performance, and style

### DIFF
--- a/libc/src/__support/File/CMakeLists.txt
+++ b/libc/src/__support/File/CMakeLists.txt
@@ -43,6 +43,11 @@ add_object_library(
     libc.src.__support.CPP.new
     libc.src.__support.CPP.span
     libc.src.__support.threads.mutex
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.src.__support.alloc_checker
+    libc.hdr.errno_macros
+    libc.hdr.types.struct_dirent
 )
 
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})

--- a/libc/src/__support/File/dir.cpp
+++ b/libc/src/__support/File/dir.cpp
@@ -1,18 +1,23 @@
-//===--- Implementation of a platform independent Dir data structure ------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of the platform independent Dir class.
+///
+//===----------------------------------------------------------------------===//
 
-#include "dir.h"
+#include "src/__support/File/dir.h"
 
+#include "hdr/errno_macros.h"
 #include "src/__support/CPP/mutex.h" // lock_guard
 #include "src/__support/CPP/new.h"
 #include "src/__support/alloc-checker.h"
 #include "src/__support/error_or.h"
-#include "src/__support/libc_errno.h" // For error macros
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
@@ -45,14 +50,20 @@ ErrorOr<struct dirent *> Dir::read() {
   if (fillsize == 0)
     return nullptr;
 
-  struct dirent *d = reinterpret_cast<struct dirent *>(buffer + readptr);
-#ifdef __linux__
-  // The d_reclen field is available on Linux but not required by POSIX.
-  readptr += d->d_reclen;
-#else
-  // Other platforms have to implement how the read pointer is to be updated.
-#error "DIR read pointer update is missing."
-#endif
+  cpp::span<uint8_t> buf_span(buffer, BUFSIZE);
+
+  if (fillsize - readptr < sizeof(struct dirent))
+    return Error(EIO);
+
+  struct dirent *d =
+      reinterpret_cast<struct dirent *>(buf_span.subspan(readptr).data());
+
+  size_t reclen = platform_dir_reclen(d);
+
+  if (reclen == 0 || readptr + reclen > fillsize)
+    return Error(EIO);
+
+  readptr += reclen;
   return d;
 }
 

--- a/libc/src/__support/File/dir.h
+++ b/libc/src/__support/File/dir.h
@@ -1,9 +1,14 @@
-//===--- A platform independent Dir class ---------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Platform independent Dir class definition.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC___SUPPORT_FILE_DIR_H
@@ -14,7 +19,7 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/threads/mutex.h"
 
-#include <dirent.h>
+#include "hdr/types/struct_dirent.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -36,11 +41,14 @@ ErrorOr<size_t> platform_fetch_dirents(int fd, cpp::span<uint8_t> buffer);
 // error number on failure.
 int platform_check_dir(int fd);
 
+// Platform specific function to get the size of the directory entry record.
+size_t platform_dir_reclen(struct dirent *d);
+
 // This class is designed to allow implementation of the POSIX dirent.h API.
 // By itself, it is platform independent but calls platform specific
 // functions to perform OS operations.
 class Dir {
-  static constexpr size_t BUFSIZE = 1024;
+  static constexpr size_t BUFSIZE = 4096;
   int fd;
   size_t readptr = 0;  // The current read pointer.
   size_t fillsize = 0; // The number of valid bytes availabe in the buffer.
@@ -48,7 +56,8 @@ class Dir {
   // This is a buffer of struct dirent values which will be fetched
   // from the OS. Since the d_name of struct dirent can be of a variable
   // size, we store the data in a byte array.
-  uint8_t buffer[BUFSIZE];
+  // We align the buffer to struct dirent to avoid unaligned accesses.
+  alignas(struct dirent) uint8_t buffer[BUFSIZE];
 
   Mutex mutex;
 

--- a/libc/src/__support/File/linux/dir.cpp
+++ b/libc/src/__support/File/linux/dir.cpp
@@ -71,4 +71,6 @@ int platform_check_dir(int fd) {
   return 0;
 }
 
+size_t platform_dir_reclen(struct dirent *d) { return d->d_reclen; }
+
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
Addressed issues in the Dir class identified during review:

* Safety: Added bounds and validation checks in Dir::read to prevent out-of-bounds reads on corrupted input.
* Performance: Aligned the internal buffer to struct dirent to prevent unaligned memory access, and increased the buffer size to 4096 to reduce syscall overhead.
* Style: Replaced the system <dirent.h> include with a new proxy header (struct_dirent.h) to avoid system dependencies, and fixed relative includes.
* Refactoring: Moved platform-specific record length access to a platform helper (platform_dir_reclen).
* CMake: Updated dependencies for the dir target.

Assisted-by: Automated tooling, human reviewed.