### PR TITLE
[analyzer][docs] Fix invalid MyST toctree 'numbered' option after Markdown migration

### DIFF
--- a/clang/docs/ClangStaticAnalyzer.md
+++ b/clang/docs/ClangStaticAnalyzer.md
@@ -10,7 +10,7 @@ This is the documentation page of the Static Analyzer; there is also an old [Off
 ```{toctree}
 :caption: Table of Contents
 :maxdepth: 2
-:numbered: true
+:numbered:
 
 analyzer/checkers
 analyzer/user-docs

--- a/clang/docs/ScalableStaticAnalysis/index.md
+++ b/clang/docs/ScalableStaticAnalysis/index.md
@@ -5,7 +5,7 @@ This is a framework for writing cross-translation unit analyses in a scalable an
 ```{toctree}
 :glob: true
 :maxdepth: 2
-:numbered: true
+:numbered:
 
 user-docs/*
 ```


### PR DESCRIPTION
The RST-to-Markdown migration (#206181) converted the RST flag `:numbered:` into `:numbered: true`.

MyST parses the toctree `numbered` option as `int_or_nothing`, so the string `true` fails with:

```
'toctree': Invalid option value for 'numbered': true:
invalid literal for int() with base 10: 'true'
```

This breaks the `-W` (warnings-as-errors) `docs-clang-html` build.
Make `numbered` a valueless flag, which MyST accepts (equivalent to the original RST behavior of numbering all levels).

Assisted-By: claude