### PR TITLE
[IR][NVVM] Fixed null pointer deference in AsmWriter pretty printer

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -4623,7 +4623,7 @@ void AssemblyWriter::printInstruction(const Instruction &I) {
     Function *CalledFunc = CI->getCalledFunction();
     auto PrintArgComment = [&](unsigned ArgNo) {
       const auto *ConstArg = dyn_cast<Constant>(CI->getArgOperand(ArgNo));
-      if (!ConstArg)
+      if (!ConstArg || !CalledFunc)
         return;
       std::string ArgComment;
       raw_string_ostream ArgCommentStream(ArgComment);

--- a/llvm/test/CodeGen/NVPTX/intrinsic-immarg-print-mismatched-signature.ll
+++ b/llvm/test/CodeGen/NVPTX/intrinsic-immarg-print-mismatched-signature.ll
@@ -1,0 +1,24 @@
+; NOTE: This test guards AsmWriter's intrinsic immediate-argument pretty-printer
+;       against a null-pointer dereference.
+; RUN: llvm-as -disable-verify < %s | llvm-dis | FileCheck %s
+
+target triple = "nvptx64-nvidia-cuda"
+
+declare void @llvm.nvvm.tensormap.replace.elemtype.p0(ptr, i32)
+
+; A well-formed call: the elemtype immediate is pretty-printed.
+define void @valid(ptr %p) {
+  ; CHECK-LABEL: define void @valid(
+  ; CHECK: call void @llvm.nvvm.tensormap.replace.elemtype.p0(ptr %p, /* elemtype=u8 */ i32 0)
+  call void @llvm.nvvm.tensormap.replace.elemtype.p0(ptr %p, i32 0)
+  ret void
+}
+
+; A call with a mismatched signature (an extra operand): getCalledFunction() is
+; null, so no comment is emitted and printing must not crash.
+define void @mismatched_signature(ptr %p) {
+  ; CHECK-LABEL: define void @mismatched_signature(
+  ; CHECK: call void @llvm.nvvm.tensormap.replace.elemtype.p0(ptr %p, i32 0, i32 0)
+  call void @llvm.nvvm.tensormap.replace.elemtype.p0(ptr %p, i32 0, i32 0)
+  ret void
+}

--- a/llvm/test/CodeGen/NVPTX/intrinsic-immarg-print-mismatched-signature.ll
+++ b/llvm/test/CodeGen/NVPTX/intrinsic-immarg-print-mismatched-signature.ll
@@ -2,8 +2,6 @@
 ;       against a null-pointer dereference.
 ; RUN: llvm-as -disable-verify < %s | llvm-dis | FileCheck %s
 
-target triple = "nvptx64-nvidia-cuda"
-
 declare void @llvm.nvvm.tensormap.replace.elemtype.p0(ptr, i32)
 
 ; A well-formed call: the elemtype immediate is pretty-printed.


### PR DESCRIPTION
ASMWriter can deference a null pointer on intrinsics with pretty printed args when those intrinsics are called with an invalid number of arguments. This check avoids the null dereference and turns this into a graceful failure. 

