### PR TITLE
[HLSL][NFC] Update test check to be more specific

### DIFF
--- a/clang/test/CodeGenHLSL/resources/resources-in-structs-method-call.hlsl
+++ b/clang/test/CodeGenHLSL/resources/resources-in-structs-method-call.hlsl
@@ -40,7 +40,7 @@ struct MyConstants {
 
 ConstantBuffer<MyConstants> Constants;
 
-// CHECK-LABEL: main
+// CHECK-LABEL: define internal void @main()()
 [numthreads(4,1,1)]
 void main() {
 // CHECK: [[TMP1:%.*]] = alloca %struct.MyStruct, align 4


### PR DESCRIPTION
If the repo path contains "main", the test was matching it against the ModuleID in the output because it contains a path to the test file, and the follow-up checks were failing.

Based on feedback in https://github.com/llvm/llvm-project/pull/206596#discussion_r3510725223.