### PR TITLE
[SandboxIR] Fix pass pipeline parsing after aux arguments

### DIFF
--- a/llvm/include/llvm/SandboxIR/PassManager.h
+++ b/llvm/include/llvm/SandboxIR/PassManager.h
@@ -235,9 +235,14 @@ public:
         }
         break;
       case State::AuxArgsEnded:
-        if (C == EndToken || C == PassDelimToken) {
+        if (C == EndToken) {
           AddPass(PassName, StringRef(), AuxArg);
-          CurrentState = State::ScanArgs;
+          CurrentState = State::ScanName;
+        } else if (C == PassDelimToken) {
+          AddPass(PassName, StringRef(), AuxArg);
+          PassBeginIdx = Idx + 1;
+          AuxArg = StringRef();
+          CurrentState = State::ScanName;
         } else if (C == BeginArgsToken) {
           ++NestedArgs;
           ArgsBeginIdx = Idx + 1;

--- a/llvm/unittests/SandboxIR/PassTest.cpp
+++ b/llvm/unittests/SandboxIR/PassTest.cpp
@@ -323,6 +323,22 @@ define void @f() {
   EXPECT_EQ(Str,
             "foo(aux1)<abc>bar<nested1(aux2)<nested2<nested3()>>>foo(aux3)<>");
 
+  // A pass with an aux argument followed by another pass in a flat pipeline.
+  std::string AuxArgStr;
+  auto CreatePassWithAuxArg =
+      [&AuxArgStr](llvm::StringRef Name, llvm::StringRef Args,
+                   llvm::StringRef AuxArg) -> std::unique_ptr<FunctionPass> {
+    if (Name == "foo")
+      return std::make_unique<FooPass>(AuxArgStr, Args, AuxArg);
+    if (Name == "bar")
+      return std::make_unique<BarPass>(AuxArgStr, Args, AuxArg);
+    return nullptr;
+  };
+  FunctionPassManager FPMWithAuxArg("test-fpm");
+  FPMWithAuxArg.setPassPipeline("foo(aux1),bar", CreatePassWithAuxArg);
+  FPMWithAuxArg.runOnFunction(*F, Analyses::emptyForTesting());
+  EXPECT_EQ(AuxArgStr, "foo(aux1)<>bar<>");
+
   // A second call to setPassPipeline will trigger an assertion in debug mode.
 #ifndef NDEBUG
   EXPECT_DEATH(FPM.setPassPipeline("bar,bar,foo", CreatePass),


### PR DESCRIPTION
## Summary
- Fix `sandboxir::PassManager::setPassPipeline` to resume scanning pass names after a pass aux argument when the next token is a delimiter.
- Add a unit test covering flat pipelines like `foo(aux1),bar`.

This fixes parsing of region pass pipelines such as `bottom-up-vec(top-down),tr-accept` that will be used by the SandboxVectorizer.

## Test plan
- [x] `ninja SandboxIRTests`
- [x] `./unittests/SandboxIR/SandboxIRTests --gtest_filter=PassTest.SetPassPipeline`


Made with [Cursor](https://cursor.com)