### PR TITLE
[LegalizeType] Fix VECTOR_DEINTERLEAVE widening with incorrect insert_subvector

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -7489,19 +7489,16 @@ void DAGTypeLegalizer::WidenVecRes_VECTOR_DEINTERLEAVE(SDNode *N) {
   // We cannot just use the widened operands directly: since they might be
   // individually widened, using them directly will result in de-interleaving
   // the "padded" lanes that sit in the middle of the vector. Instead, we should
-  // not just concat but also "re-pack" these operands before extracting new
+  // not concat the widened operands but the original ones to effectively
+  // generate a "packed" concated and widened vector, before extracting new
   // operand vectors with the widened type.
   EVT PackedWidenVT = EVT::getVectorVT(*DAG.getContext(), EltVT,
                                        WidenEC.multiplyCoefficientBy(Factor));
-  SDValue PackedWidenVec = DAG.getUNDEF(PackedWidenVT);
-  for (unsigned Idx = 0U; Idx < Factor; ++Idx) {
-    const SDValue Op = N->getOperand(Idx);
-    // Note that we insert these widened operands with offsets derived from
-    // the original vector length.
-    PackedWidenVec = DAG.getInsertSubvector(
-        DL, PackedWidenVec, GetWidenedVector(Op),
-        OrigEC.multiplyCoefficientBy(Idx).getKnownMinValue());
-  }
+  EVT ConcatVT = EVT::getVectorVT(*DAG.getContext(), EltVT,
+                                  OrigEC.multiplyCoefficientBy(Factor));
+  SDValue ConcatOp = DAG.getNode(ISD::CONCAT_VECTORS, DL, ConcatVT, N->ops());
+  SDValue PackedWidenVec = DAG.getInsertSubvector(
+      DL, DAG.getUNDEF(PackedWidenVT), ConcatOp, /*Idx=*/0U);
 
   // Extract the new widened operand vectors.
   SmallVector<SDValue, 8> NewOps(Factor, SDValue());

--- a/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave.ll
@@ -126,6 +126,11 @@ define {<vscale x 4 x i32>, <vscale x 4 x i32>} @vector_deinterleave_nxv4i32_nxv
 ret {<vscale x 4 x i32>, <vscale x 4 x i32>} %retval
 }
 
+define {<vscale x 5 x i32>, <vscale x 5 x i32>, <vscale x 5 x i32>} @vector_deinterleave3_nxv5i32_nxv15i32(<vscale x 15 x i32> %v) nounwind {
+  %d = call {<vscale x 5 x i32>, <vscale x 5 x i32>, <vscale x 5 x i32>} @llvm.vector.deinterleave3(<vscale x 15 x i32> %v)
+  ret {<vscale x 5 x i32>, <vscale x 5 x i32>, <vscale x 5 x i32>} %d
+}
+
 define {<vscale x 2 x i64>, <vscale x 2 x i64>} @vector_deinterleave_nxv2i64_nxv4i64(<vscale x 4 x i64> %vec) {
 ; V-LABEL: vector_deinterleave_nxv2i64_nxv4i64:
 ; V:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave.ll
@@ -127,6 +127,33 @@ ret {<vscale x 4 x i32>, <vscale x 4 x i32>} %retval
 }
 
 define {<vscale x 5 x i32>, <vscale x 5 x i32>, <vscale x 5 x i32>} @vector_deinterleave3_nxv5i32_nxv15i32(<vscale x 15 x i32> %v) nounwind {
+; CHECK-LABEL: vector_deinterleave3_nxv5i32_nxv15i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    addi sp, sp, -16
+; CHECK-NEXT:    csrr a0, vlenb
+; CHECK-NEXT:    slli a0, a0, 4
+; CHECK-NEXT:    sub sp, sp, a0
+; CHECK-NEXT:    addi a0, sp, 16
+; CHECK-NEXT:    vs8r.v v8, (a0)
+; CHECK-NEXT:    vsetvli a1, zero, e32, m2, ta, ma
+; CHECK-NEXT:    vmv2r.v v8, v14
+; CHECK-NEXT:    csrr a1, vlenb
+; CHECK-NEXT:    slli a1, a1, 3
+; CHECK-NEXT:    add a1, sp, a1
+; CHECK-NEXT:    addi a1, a1, 16
+; CHECK-NEXT:    vs8r.v v8, (a1)
+; CHECK-NEXT:    vlseg3e32.v v12, (a0)
+; CHECK-NEXT:    vlseg3e32.v v20, (a1)
+; CHECK-NEXT:    vmv4r.v v8, v12
+; CHECK-NEXT:    vmv2r.v v10, v20
+; CHECK-NEXT:    vmv2r.v v20, v14
+; CHECK-NEXT:    vmv2r.v v18, v24
+; CHECK-NEXT:    vmv4r.v v12, v20
+; CHECK-NEXT:    csrr a0, vlenb
+; CHECK-NEXT:    slli a0, a0, 4
+; CHECK-NEXT:    add sp, sp, a0
+; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    ret
   %d = call {<vscale x 5 x i32>, <vscale x 5 x i32>, <vscale x 5 x i32>} @llvm.vector.deinterleave3(<vscale x 15 x i32> %v)
   ret {<vscale x 5 x i32>, <vscale x 5 x i32>, <vscale x 5 x i32>} %d
 }


### PR DESCRIPTION
Partially address #207136 

There are really two parts in the associated issue: (1) incorrect type widening logics that `insert_subvector` with indices that are not a multiple of the sub-vector's minimum number of elements, and (2) incorrect RISC-V lowering logics when it comes to fixed vector.

This PR addresses the first part: It turns out in order to have a widened, packed concat vector, we don't need to use any insert_subvector that involves widened operands -- just `concat_vectors` on the _original_ (narrow) operands (before adjusting to the size of the desired widened concat vector)