### PR TITLE
Put TextEncoding class in clang namespace to prevent naming conflicts

### DIFF
--- a/clang/include/clang/Lex/TextEncoding.h
+++ b/clang/include/clang/Lex/TextEncoding.h
@@ -13,6 +13,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/TextEncoding.h"
 
+namespace clang {
 enum ConversionAction { CA_NoConversion, CA_ToLiteralEncoding };
 
 class TextEncoding {
@@ -26,5 +27,5 @@ public:
 
   llvm::StringRef getLiteralEncoding() { return LiteralEncoding; }
 };
-
+} // namespace clang
 #endif

--- a/clang/lib/Lex/TextEncoding.cpp
+++ b/clang/lib/Lex/TextEncoding.cpp
@@ -9,6 +9,8 @@
 #include "clang/Lex/TextEncoding.h"
 #include "clang/Basic/DiagnosticDriver.h"
 
+using namespace clang;
+
 llvm::TextEncodingConverter *
 TextEncoding::getConverter(ConversionAction Action) const {
   switch (Action) {


### PR DESCRIPTION
Put TextEncoding class in the clang namespace to prevent naming conflicts

This is to fix the error mentioned here
https://github.com/llvm/llvm-project/pull/138895#issuecomment-4868950718