### PR TITLE
lit: improve long path support on Windows

### DIFF
--- a/llvm/utils/lit/lit/InprocBuiltins.py
+++ b/llvm/utils/lit/lit/InprocBuiltins.py
@@ -251,6 +251,7 @@ def executeBuiltinRm(cmd, cmd_shenv):
                 else:
                     shutil.rmtree(path, onerror=on_rm_error if force else None)
             else:
+                path = lit.util.get_windows_extended_path(path)
                 if force and not os.access(path, os.W_OK):
                     os.chmod(path, stat.S_IMODE(os.stat(path).st_mode) | stat.S_IWRITE)
                 os.remove(path)

--- a/llvm/utils/lit/lit/ShellEnvironment.py
+++ b/llvm/utils/lit/lit/ShellEnvironment.py
@@ -190,6 +190,7 @@ def processRedirects(cmd, stdin_source, cmd_shenv, opened_files):
         else:
             # Make sure relative paths are relative to the cwd.
             redir_filename = os.path.join(cmd_shenv.cwd, name)
+            redir_filename = lit.util.get_windows_extended_path(redir_filename)
             fd = open(redir_filename, mode, encoding="utf-8")
         # Workaround a Win32 and/or subprocess bug when appending.
         #

--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -476,3 +476,28 @@ def runCommandCached(lit_config, cmd, allow_failure, **kwargs):
         lit_config.fatal(msg)
 
     return None
+
+
+def get_windows_extended_path(path: str) -> str:
+    """
+    Return *path* in Windows extended-length (``\\\\?\\``) form.
+
+    On non-Windows platforms the path is returned unchanged. On Windows,
+    the path is made absolute and given the ``\\\\?\\`` prefix so it can
+    exceed the Win32 ``MAX_PATH`` (260-character) limit. UNC paths
+    (those beginning with ``\\\\``) are converted to the ``\\\\?\\UNC\\``
+    form instead.
+
+    Args:
+        path: The filesystem path to normalize.
+
+    Returns:
+        The original path on non-Windows platforms, otherwise the
+        absolute path in extended-length form.
+    """
+    if not platform.system() == "Windows":
+        return path
+    path = os.path.abspath(path)
+    if path.startswith("\\\\"):
+        return "\\\\?\\UNC\\{0}".format(path[2:])
+    return "\\\\?\\{0}".format(path)


### PR DESCRIPTION
This pull request improves Windows path handling in the `llvm/utils/lit/lit` utilities by introducing and applying an `extended` function to correctly format file paths for Windows APIs, especially for long paths and UNC paths. The changes ensure that file operations such as removal and redirection work reliably on Windows systems.

**Windows path handling improvements:**

* Added an `extended` function in both `InprocBuiltins.py` and `ShellEnvironment.py` to convert paths to the extended-length format required by Windows, handling both regular and UNC paths. [[1]](diffhunk://#diff-7b75d403cff61cebbd12ef3915054dee6a887deaa2300fbc73a33f64ce2d1255R179-R186) [[2]](diffhunk://#diff-31c539a1c64eb53261e543eeda1966733230d2b7613f5d500deed3f2f1ce2baeR121-R128)
* Applied the `extended` function to file removal operations in `InprocBuiltins.py`, ensuring paths are properly formatted before deletion, which helps avoid issues with long or special Windows paths.
* Used the `extended` function for redirected file paths in `ShellEnvironment.py`, ensuring that redirections to files handle Windows path limitations correctly.