### PR TITLE
[RISCV] Fix incorrect fixed vector lowering for VECTOR_DEINTERLEAVE

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -13175,8 +13175,12 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
   if (VecVT.getVectorElementType() == MVT::i1)
     return widenVectorOpsToi8(Op, DL, DAG);
 
+  MVT ContainerVecVT = VecVT;
+  if (VecVT.isFixedLengthVector())
+    ContainerVecVT = getContainerForFixedLengthVector(VecVT);
+
   // If concatenating would exceed LMUL=8, we need to split.
-  if ((VecVT.getSizeInBits().getKnownMinValue() * Factor) >
+  if ((ContainerVecVT.getSizeInBits().getKnownMinValue() * Factor) >
       (8 * RISCV::RVVBitsPerBlock)) {
     SmallVector<SDValue, 8> Ops(Factor * 2);
     for (unsigned i = 0; i != Factor; ++i) {
@@ -13246,8 +13250,7 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
     ConcatVec =
         convertToScalableVector(ConcatContainerVT, ConcatVec, DAG, Subtarget);
 
-    MVT ContainerVT = getContainerForFixedLengthVector(VecVT);
-    ElementCount ContainerEC = ContainerVT.getVectorElementCount();
+    ElementCount ContainerEC = ContainerVecVT.getVectorElementCount();
 
     SmallVector<SDValue, 8> Ops(Factor);
     // Then, we extract the new scalable sub-vectors.
@@ -13260,13 +13263,13 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
       // VECTOR_DEINTERLEAVE will just concat them back together later
       // anyway.
       if (ElementCount::isKnownGE(Idx, ConcatContainerEC))
-        Ops[i] = DAG.getUNDEF(ContainerVT);
+        Ops[i] = DAG.getUNDEF(ContainerVecVT);
       else
-        Ops[i] = DAG.getExtractSubvector(DL, ContainerVT, ConcatVec,
+        Ops[i] = DAG.getExtractSubvector(DL, ContainerVecVT, ConcatVec,
                                          Idx.getKnownMinValue());
     }
 
-    SmallVector<EVT, 8> VTs(Factor, ContainerVT);
+    SmallVector<EVT, 8> VTs(Factor, ContainerVecVT);
     SDValue NewDeinterleave =
         DAG.getNode(ISD::VECTOR_DEINTERLEAVE, DL, VTs, Ops);
 

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -13290,24 +13290,25 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
 
     // If this is a fixed vector, instead of using the concat vector, we simply
     // store each fixed vector operand directly onto the stack, individually.
-    // The reason being that if the fixed vector is (much) small than the
+    // The reason being that if the fixed vector is (much) smaller than the
     // container vector, we will be wasting space on stack.
     TypeSize VecSize = VecVT.getStoreSize();
     SDValue BasePtr = StackPtr;
     MachinePointerInfo PI = PtrInfo;
+    SmallVector<SDValue, 8> Tokens(Factor);
     for (auto [Idx, FieldOp] : enumerate(Op->op_values())) {
       if (Idx) {
         // Advance the pointer.
         BasePtr = DAG.getObjectPtrOffset(DL, BasePtr, VecSize);
         PI = PI.getWithOffset(VecSize);
       }
-      Chain = DAG.getStore(Chain, DL, FieldOp, BasePtr, PI, Alignment);
+      Tokens[Idx] = DAG.getStore(Chain, DL, FieldOp, BasePtr, PI, Alignment);
     }
+    Chain = DAG.getTokenFactor(DL, Tokens);
 
     // Calculating Mask and VL for later usages.
     std::tie(Mask, VL) =
-        getDefaultVLOps(VecVT.getVectorElementCount().getFixedValue(),
-                        ContainerVecVT, DL, DAG, Subtarget);
+        getDefaultVLOps(VecVT, ContainerVecVT, DL, DAG, Subtarget);
     ConcatVT = getContainerForFixedLengthVector(ConcatVT);
   } else {
     std::tie(Mask, VL) = getDefaultScalableVLOps(VecVT, DL, DAG, Subtarget);

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -13219,11 +13219,11 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
     // (legal) vector one by one, or concat_vectors with additional
     // operands to pad to legal type. The first way seems to lead to
     // worse codegen primarily because we don't run DAGCombiner to
-    // simplify stuffs before some of the insert_subvector got
-    // lower into vslideup/down prematurely.
+    // simplify stuff before some of the insert_subvector get
+    // lowered into vslideup/down prematurely.
     EVT ConcatVecEVT = EVT(VecVT).changeVectorElementCount(
         *DAG.getContext(), OrigEC.multiplyCoefficientBy(Factor));
-    SmallVector<SDValue, 8> ConcatOps(Op->op_begin(), Op->op_end());
+    SmallVector<SDValue, 8> ConcatOps(Op->ops());
     MVT ConcatVecVT;
     if (!isTypeLegal(ConcatVecEVT)) {
       // SplitVector should already be handled above.
@@ -13257,7 +13257,7 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
     for (unsigned i = 0U; i < Factor; ++i) {
       ElementCount Idx = ContainerEC.multiplyCoefficientBy(i);
       // Index might be out-of-bound. This usually happens on large
-      // VLEN where a single or a few VR registers is enough to caputre
+      // VLEN where a single or a few VR registers is enough to capture
       // the entire concat vector. In this case we can just use poison
       // on other VECTOR_DEINTERLEAVE operands -- semantically
       // VECTOR_DEINTERLEAVE will just concat them back together later

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -13258,7 +13258,7 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
       ElementCount Idx = ContainerEC.multiplyCoefficientBy(i);
       // Index might be out-of-bound. This usually happens on large
       // VLEN where a single or a few VR registers is enough to capture
-      // the entire concat vector. In this case we can just use poison
+      // the entire concat vector. In this case we can just use undef
       // on other VECTOR_DEINTERLEAVE operands -- semantically
       // VECTOR_DEINTERLEAVE will just concat them back together later
       // anyway.

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -13175,25 +13175,6 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
   if (VecVT.getVectorElementType() == MVT::i1)
     return widenVectorOpsToi8(Op, DL, DAG);
 
-  // Convert to scalable vectors first.
-  if (VecVT.isFixedLengthVector()) {
-    MVT ContainerVT = getContainerForFixedLengthVector(VecVT);
-    SmallVector<SDValue, 8> Ops(Factor);
-    for (unsigned i = 0U; i < Factor; ++i)
-      Ops[i] = convertToScalableVector(ContainerVT, Op.getOperand(i), DAG,
-                                       Subtarget);
-
-    SmallVector<EVT, 8> VTs(Factor, ContainerVT);
-    SDValue NewDeinterleave =
-        DAG.getNode(ISD::VECTOR_DEINTERLEAVE, DL, VTs, Ops);
-
-    SmallVector<SDValue, 8> Res(Factor);
-    for (unsigned i = 0U; i < Factor; ++i)
-      Res[i] = convertFromScalableVector(VecVT, NewDeinterleave.getValue(i),
-                                         DAG, Subtarget);
-    return DAG.getMergeValues(Res, DL);
-  }
-
   // If concatenating would exceed LMUL=8, we need to split.
   if ((VecVT.getSizeInBits().getKnownMinValue() * Factor) >
       (8 * RISCV::RVVBitsPerBlock)) {
@@ -13216,6 +13197,83 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
       Res[i] = DAG.getNode(ISD::CONCAT_VECTORS, DL, VecVT, Lo.getValue(i),
                            Hi.getValue(i));
 
+    return DAG.getMergeValues(Res, DL);
+  }
+
+  // Convert to scalable vectors.
+  if (VecVT.isFixedLengthVector()) {
+    ElementCount OrigEC = VecVT.getVectorElementCount();
+    // Note that we cannot just convert individual operands to scalable vectors
+    // and call it a day: as scalable vector container is always equal or
+    // larger than the fixed vector subject, in the case where it is larger
+    // than fixed vector, this approach will create "padded" lanes in the
+    // conceptually concated vector created by VECTOR_DEINTERLEAVE per its
+    // semantics.
+
+    // First, concat operands into a larger (fixed) vector.
+    // There are two ways to do this: insert each operands into a larger
+    // (legal) vector one by one, or concat_vectors with additional
+    // operands to pad to legal type. The first way seems to lead to
+    // worse codegen primarily because we don't run DAGCombiner to
+    // simplify stuffs before some of the insert_subvector got
+    // lower into vslideup/down prematurely.
+    EVT ConcatVecEVT = EVT(VecVT).changeVectorElementCount(
+        *DAG.getContext(), OrigEC.multiplyCoefficientBy(Factor));
+    SmallVector<SDValue, 8> ConcatOps(Op->op_begin(), Op->op_end());
+    MVT ConcatVecVT;
+    if (!isTypeLegal(ConcatVecEVT)) {
+      // SplitVector should already be handled above.
+      assert(getTypeAction(*DAG.getContext(), ConcatVecEVT) ==
+             TargetLowering::TypeWidenVector);
+      ConcatVecVT =
+          getTypeToTransformTo(*DAG.getContext(), ConcatVecEVT).getSimpleVT();
+      ElementCount WidenedConcatEC = ConcatVecVT.getVectorElementCount();
+      // Both OrigEC and WidenedConcatEC are both derived from legal fixed
+      // vector types. A legal fixed vector's element count is always power of
+      // two, so WidenedConcatEC will always be a multiple of OrigEC.
+      assert(WidenedConcatEC.hasKnownScalarFactor(OrigEC));
+      unsigned NumTotalConcatOps = WidenedConcatEC.getKnownScalarFactor(OrigEC);
+      assert(NumTotalConcatOps > Factor);
+      ConcatOps.append(NumTotalConcatOps - Factor, DAG.getUNDEF(VecVT));
+    } else {
+      ConcatVecVT = ConcatVecEVT.getSimpleVT();
+    }
+
+    SDValue ConcatVec =
+        DAG.getNode(ISD::CONCAT_VECTORS, DL, ConcatVecVT, ConcatOps);
+    MVT ConcatContainerVT = getContainerForFixedLengthVector(ConcatVecVT);
+    ElementCount ConcatContainerEC = ConcatContainerVT.getVectorElementCount();
+    ConcatVec =
+        convertToScalableVector(ConcatContainerVT, ConcatVec, DAG, Subtarget);
+
+    MVT ContainerVT = getContainerForFixedLengthVector(VecVT);
+    ElementCount ContainerEC = ContainerVT.getVectorElementCount();
+
+    SmallVector<SDValue, 8> Ops(Factor);
+    // Then, we extract the new scalable sub-vectors.
+    for (unsigned i = 0U; i < Factor; ++i) {
+      ElementCount Idx = ContainerEC.multiplyCoefficientBy(i);
+      // Index might be out-of-bound. This usually happens on large
+      // VLEN where a single or a few VR registers is enough to caputre
+      // the entire concat vector. In this case we can just use poison
+      // on other VECTOR_DEINTERLEAVE operands -- semantically
+      // VECTOR_DEINTERLEAVE will just concat them back together later
+      // anyway.
+      if (ElementCount::isKnownGE(Idx, ConcatContainerEC))
+        Ops[i] = DAG.getUNDEF(ContainerVT);
+      else
+        Ops[i] = DAG.getExtractSubvector(DL, ContainerVT, ConcatVec,
+                                         Idx.getKnownMinValue());
+    }
+
+    SmallVector<EVT, 8> VTs(Factor, ContainerVT);
+    SDValue NewDeinterleave =
+        DAG.getNode(ISD::VECTOR_DEINTERLEAVE, DL, VTs, Ops);
+
+    SmallVector<SDValue, 8> Res(Factor);
+    for (unsigned i = 0U; i < Factor; ++i)
+      Res[i] = convertFromScalableVector(VecVT, NewDeinterleave.getValue(i),
+                                         DAG, Subtarget);
     return DAG.getMergeValues(Res, DL);
   }
 

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -13175,8 +13175,10 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
   if (VecVT.getVectorElementType() == MVT::i1)
     return widenVectorOpsToi8(Op, DL, DAG);
 
+  bool IsFixedVector = VecVT.isFixedLengthVector();
+
   MVT ContainerVecVT = VecVT;
-  if (VecVT.isFixedLengthVector())
+  if (IsFixedVector)
     ContainerVecVT = getContainerForFixedLengthVector(VecVT);
 
   // If concatenating would exceed LMUL=8, we need to split.
@@ -13204,83 +13206,7 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
     return DAG.getMergeValues(Res, DL);
   }
 
-  // Convert to scalable vectors.
-  if (VecVT.isFixedLengthVector()) {
-    ElementCount OrigEC = VecVT.getVectorElementCount();
-    // Note that we cannot just convert individual operands to scalable vectors
-    // and call it a day: as scalable vector container is always equal or
-    // larger than the fixed vector subject, in the case where it is larger
-    // than fixed vector, this approach will create "padded" lanes in the
-    // conceptually concated vector created by VECTOR_DEINTERLEAVE per its
-    // semantics.
-
-    // First, concat operands into a larger (fixed) vector.
-    // There are two ways to do this: insert each operands into a larger
-    // (legal) vector one by one, or concat_vectors with additional
-    // operands to pad to legal type. The first way seems to lead to
-    // worse codegen primarily because we don't run DAGCombiner to
-    // simplify stuff before some of the insert_subvector get
-    // lowered into vslideup/down prematurely.
-    EVT ConcatVecEVT = EVT(VecVT).changeVectorElementCount(
-        *DAG.getContext(), OrigEC.multiplyCoefficientBy(Factor));
-    SmallVector<SDValue, 8> ConcatOps(Op->ops());
-    MVT ConcatVecVT;
-    if (!isTypeLegal(ConcatVecEVT)) {
-      // SplitVector should already be handled above.
-      assert(getTypeAction(*DAG.getContext(), ConcatVecEVT) ==
-             TargetLowering::TypeWidenVector);
-      ConcatVecVT =
-          getTypeToTransformTo(*DAG.getContext(), ConcatVecEVT).getSimpleVT();
-      ElementCount WidenedConcatEC = ConcatVecVT.getVectorElementCount();
-      // Both OrigEC and WidenedConcatEC are both derived from legal fixed
-      // vector types. A legal fixed vector's element count is always power of
-      // two, so WidenedConcatEC will always be a multiple of OrigEC.
-      assert(WidenedConcatEC.hasKnownScalarFactor(OrigEC));
-      unsigned NumTotalConcatOps = WidenedConcatEC.getKnownScalarFactor(OrigEC);
-      assert(NumTotalConcatOps > Factor);
-      ConcatOps.append(NumTotalConcatOps - Factor, DAG.getUNDEF(VecVT));
-    } else {
-      ConcatVecVT = ConcatVecEVT.getSimpleVT();
-    }
-
-    SDValue ConcatVec =
-        DAG.getNode(ISD::CONCAT_VECTORS, DL, ConcatVecVT, ConcatOps);
-    MVT ConcatContainerVT = getContainerForFixedLengthVector(ConcatVecVT);
-    ElementCount ConcatContainerEC = ConcatContainerVT.getVectorElementCount();
-    ConcatVec =
-        convertToScalableVector(ConcatContainerVT, ConcatVec, DAG, Subtarget);
-
-    ElementCount ContainerEC = ContainerVecVT.getVectorElementCount();
-
-    SmallVector<SDValue, 8> Ops(Factor);
-    // Then, we extract the new scalable sub-vectors.
-    for (unsigned i = 0U; i < Factor; ++i) {
-      ElementCount Idx = ContainerEC.multiplyCoefficientBy(i);
-      // Index might be out-of-bound. This usually happens on large
-      // VLEN where a single or a few VR registers is enough to capture
-      // the entire concat vector. In this case we can just use undef
-      // on other VECTOR_DEINTERLEAVE operands -- semantically
-      // VECTOR_DEINTERLEAVE will just concat them back together later
-      // anyway.
-      if (ElementCount::isKnownGE(Idx, ConcatContainerEC))
-        Ops[i] = DAG.getUNDEF(ContainerVecVT);
-      else
-        Ops[i] = DAG.getExtractSubvector(DL, ContainerVecVT, ConcatVec,
-                                         Idx.getKnownMinValue());
-    }
-
-    SmallVector<EVT, 8> VTs(Factor, ContainerVecVT);
-    SDValue NewDeinterleave =
-        DAG.getNode(ISD::VECTOR_DEINTERLEAVE, DL, VTs, Ops);
-
-    SmallVector<SDValue, 8> Res(Factor);
-    for (unsigned i = 0U; i < Factor; ++i)
-      Res[i] = convertFromScalableVector(VecVT, NewDeinterleave.getValue(i),
-                                         DAG, Subtarget);
-    return DAG.getMergeValues(Res, DL);
-  }
-
-  if (Subtarget.hasStdExtZvzip() && Factor == 2) {
+  if (Subtarget.hasStdExtZvzip() && Factor == 2 && !IsFixedVector) {
     MVT VT = Op->getSimpleValueType(0);
     MVT NewVT = VT.getDoubleNumVectorElementsVT();
     if (isTypeLegal(NewVT) && isLegalVTForZvzipOperand(VT, Subtarget)) {
@@ -13306,7 +13232,7 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
     Ops.append(PowerOf2Ceil(Factor) - Factor, DAG.getUNDEF(VecVT));
   SDValue Concat = DAG.getNode(ISD::CONCAT_VECTORS, DL, ConcatVT, Ops);
 
-  if (Factor == 2) {
+  if (Factor == 2 && !IsFixedVector) {
     // We can deinterleave through vnsrl.wi if the element type is smaller than
     // ELEN
     if (VecVT.getScalarSizeInBits() < Subtarget.getELen()) {
@@ -13345,27 +13271,62 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
   }
 
   // Store with unit-stride store and load it back with segmented load.
+  SDValue Mask, VL;
   MVT XLenVT = Subtarget.getXLenVT();
-  auto [Mask, VL] = getDefaultScalableVLOps(VecVT, DL, DAG, Subtarget);
-  SDValue Passthru = DAG.getUNDEF(ConcatVT);
-
-  // Allocate a stack slot.
-  Align Alignment = DAG.getReducedAlign(VecVT, /*UseABI=*/false);
-  SDValue StackPtr =
-      DAG.CreateStackTemporary(ConcatVT.getStoreSize(), Alignment);
   auto &MF = DAG.getMachineFunction();
-  auto FrameIndex = cast<FrameIndexSDNode>(StackPtr.getNode())->getIndex();
-  auto PtrInfo = MachinePointerInfo::getFixedStack(MF, FrameIndex);
+  SDValue Chain = DAG.getEntryNode();
+  Align Alignment = DAG.getReducedAlign(VecVT, /*UseABI=*/false);
+  SDValue StackPtr;
+  MachinePointerInfo PtrInfo;
+  if (IsFixedVector) {
+    // Calculating the stack size.
+    ElementCount ActualConcatEC =
+        VecVT.getVectorElementCount().multiplyCoefficientBy(Factor);
+    EVT ConcatEVT = EVT::getVectorVT(
+        *DAG.getContext(), VecVT.getVectorElementType(), ActualConcatEC);
+    StackPtr = DAG.CreateStackTemporary(ConcatEVT.getStoreSize(), Alignment);
+    auto FrameIndex = cast<FrameIndexSDNode>(StackPtr.getNode())->getIndex();
+    PtrInfo = MachinePointerInfo::getFixedStack(MF, FrameIndex);
 
-  SDValue StoreOps[] = {DAG.getEntryNode(),
-                        DAG.getTargetConstant(Intrinsic::riscv_vse, DL, XLenVT),
-                        Concat, StackPtr, VL};
+    // If this is a fixed vector, instead of using the concat vector, we simply
+    // store each fixed vector operand directly onto the stack, individually.
+    // The reason being that if the fixed vector is (much) small than the
+    // container vector, we will be wasting space on stack.
+    TypeSize VecSize = VecVT.getStoreSize();
+    SDValue BasePtr = StackPtr;
+    MachinePointerInfo PI = PtrInfo;
+    for (auto [Idx, FieldOp] : enumerate(Op->op_values())) {
+      if (Idx) {
+        // Advance the pointer.
+        BasePtr = DAG.getObjectPtrOffset(DL, BasePtr, VecSize);
+        PI = PI.getWithOffset(VecSize);
+      }
+      Chain = DAG.getStore(Chain, DL, FieldOp, BasePtr, PI, Alignment);
+    }
 
-  SDValue Chain = DAG.getMemIntrinsicNode(
-      ISD::INTRINSIC_VOID, DL, DAG.getVTList(MVT::Other), StoreOps,
-      ConcatVT.getVectorElementType(), PtrInfo, Alignment,
-      MachineMemOperand::MOStore, LocationSize::beforeOrAfterPointer());
+    // Calculating Mask and VL for later usages.
+    std::tie(Mask, VL) =
+        getDefaultVLOps(VecVT.getVectorElementCount().getFixedValue(),
+                        ContainerVecVT, DL, DAG, Subtarget);
+    ConcatVT = getContainerForFixedLengthVector(ConcatVT);
+  } else {
+    std::tie(Mask, VL) = getDefaultScalableVLOps(VecVT, DL, DAG, Subtarget);
+    StackPtr = DAG.CreateStackTemporary(ConcatVT.getStoreSize(), Alignment);
+    auto FrameIndex = cast<FrameIndexSDNode>(StackPtr.getNode())->getIndex();
+    PtrInfo = MachinePointerInfo::getFixedStack(MF, FrameIndex);
 
+    SDValue StoreOps[] = {
+        Chain, DAG.getTargetConstant(Intrinsic::riscv_vse, DL, XLenVT), Concat,
+        StackPtr, VL};
+
+    Chain = DAG.getMemIntrinsicNode(
+        ISD::INTRINSIC_VOID, DL, DAG.getVTList(MVT::Other), StoreOps,
+        ConcatVT.getVectorElementType(), PtrInfo, Alignment,
+        MachineMemOperand::MOStore, LocationSize::beforeOrAfterPointer());
+  }
+
+  // Load it back with segmented load.
+  SDValue Passthru = DAG.getUNDEF(ConcatVT);
   static const Intrinsic::ID VlsegIntrinsicsIds[] = {
       Intrinsic::riscv_vlseg2_mask, Intrinsic::riscv_vlseg3_mask,
       Intrinsic::riscv_vlseg4_mask, Intrinsic::riscv_vlseg5_mask,
@@ -13383,8 +13344,8 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
           RISCVVType::TAIL_AGNOSTIC | RISCVVType::MASK_AGNOSTIC, DL, XLenVT),
       DAG.getTargetConstant(Log2_64(VecVT.getScalarSizeInBits()), DL, XLenVT)};
 
-  unsigned Sz =
-      Factor * VecVT.getVectorMinNumElements() * VecVT.getScalarSizeInBits();
+  unsigned Sz = Factor * ContainerVecVT.getVectorMinNumElements() *
+                ContainerVecVT.getScalarSizeInBits();
   EVT VecTupTy = MVT::getRISCVVectorTupleVT(Sz, Factor);
 
   SDValue Load = DAG.getMemIntrinsicNode(
@@ -13394,9 +13355,14 @@ SDValue RISCVTargetLowering::lowerVECTOR_DEINTERLEAVE(SDValue Op,
 
   SmallVector<SDValue, 8> Res(Factor);
 
-  for (unsigned i = 0U; i < Factor; ++i)
-    Res[i] = DAG.getNode(RISCVISD::TUPLE_EXTRACT, DL, VecVT, Load,
-                         DAG.getTargetConstant(i, DL, MVT::i32));
+  for (unsigned i = 0U; i < Factor; ++i) {
+    SDValue FieldRes =
+        DAG.getNode(RISCVISD::TUPLE_EXTRACT, DL, ContainerVecVT, Load,
+                    DAG.getTargetConstant(i, DL, MVT::i32));
+    if (IsFixedVector)
+      FieldRes = convertFromScalableVector(VecVT, FieldRes, DAG, Subtarget);
+    Res[i] = FieldRes;
+  }
 
   return DAG.getMergeValues(Res, DL);
 }

--- a/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
@@ -190,11 +190,15 @@ define {<2 x i32>, <2 x i32>, <2 x i32>} @vector_deinterleave3_v2i32_v6i32(<6 x 
 ; CHECK-NEXT:    vslidedown.vi v10, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v9, v8, 2
+; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v9, 2
+; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v10, 4
 ; CHECK-NEXT:    csrr a0, vlenb
 ; CHECK-NEXT:    srli a0, a0, 3
 ; CHECK-NEXT:    vsetvli a1, zero, e32, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v8, v9, a0
-; CHECK-NEXT:    vmv1r.v v9, v10
+; CHECK-NEXT:    vslidedown.vx v10, v8, a0
+; CHECK-NEXT:    vslideup.vx v8, v10, a0
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
@@ -217,12 +221,15 @@ define {<3 x i32>, <3 x i32>, <3 x i32>} @vector_deinterleave3_v3i32_v9i32(<9 x 
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    vsetivli zero, 4, e32, m4, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v12, v8, 8
+; CHECK-NEXT:    vmv2r.v v16, v8
 ; CHECK-NEXT:    vsetivli zero, 4, e32, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 4
-; CHECK-NEXT:    vmv1r.v v9, v10
-; CHECK-NEXT:    vmv2r.v v10, v12
+; CHECK-NEXT:    vslidedown.vi v8, v8, 4
+; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; CHECK-NEXT:    vslideup.vi v16, v8, 4
+; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; CHECK-NEXT:    vslideup.vi v16, v12, 8
 ; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs4r.v v8, (a0)
+; CHECK-NEXT:    vs4r.v v16, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e32, m1, ta, ma
 ; CHECK-NEXT:    vlseg3e32.v v8, (a0)
 ; CHECK-NEXT:    csrr a0, vlenb
@@ -241,17 +248,6 @@ define {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} @vector_deinterleave4_v2i32_
 ; CHECK-NEXT:    csrr a0, vlenb
 ; CHECK-NEXT:    slli a0, a0, 1
 ; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 6
-; CHECK-NEXT:    vslidedown.vi v12, v8, 4
-; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 2
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a0, a0, 3
-; CHECK-NEXT:    vsetvli a1, zero, e32, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v12, v10, a0
-; CHECK-NEXT:    vslideup.vx v8, v9, a0
-; CHECK-NEXT:    vmv.v.v v9, v12
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
@@ -273,20 +269,31 @@ define {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} @vector_deinterle
 ; CHECK-NEXT:    slli a0, a0, 1
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v10, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v9, v8, 6
-; CHECK-NEXT:    vslidedown.vi v11, v8, 4
-; CHECK-NEXT:    vslidedown.vi v12, v8, 2
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v9, a1
-; CHECK-NEXT:    vslideup.vx v8, v12, a1
+; CHECK-NEXT:    vslidedown.vi v12, v8, 4
+; CHECK-NEXT:    vslidedown.vi v13, v8, 2
+; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v12, v9, 2
+; CHECK-NEXT:    vslideup.vi v8, v13, 2
+; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v12, 4
+; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v10, 8
+; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    srli a0, a0, 2
+; CHECK-NEXT:    add a2, a0, a1
+; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vx v10, v8, a2
+; CHECK-NEXT:    vslidedown.vx v11, v8, a0
+; CHECK-NEXT:    vslidedown.vx v12, v8, a1
+; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vx v11, v10, a1
+; CHECK-NEXT:    vslideup.vx v8, v12, a1
 ; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    vmv1r.v v9, v10
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
@@ -308,7 +315,6 @@ define {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} @vecto
 ; CHECK-NEXT:    slli a0, a0, 1
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v10, v8, 10
 ; CHECK-NEXT:    vslidedown.vi v12, v8, 8
@@ -316,14 +322,30 @@ define {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} @vecto
 ; CHECK-NEXT:    vslidedown.vi v9, v8, 6
 ; CHECK-NEXT:    vslidedown.vi v11, v8, 4
 ; CHECK-NEXT:    vslidedown.vi v13, v8, 2
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v9, a1
-; CHECK-NEXT:    vslideup.vx v8, v13, a1
-; CHECK-NEXT:    vslideup.vx v12, v10, a1
+; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v11, v9, 2
+; CHECK-NEXT:    vslideup.vi v8, v13, 2
+; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v11, 4
+; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v12, v10, 2
+; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v12, 8
+; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
+; CHECK-NEXT:    add a2, a0, a1
+; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vx v10, v8, a2
+; CHECK-NEXT:    vslidedown.vx v11, v8, a0
+; CHECK-NEXT:    vslidedown.vx v12, v8, a1
+; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vx v11, v10, a1
+; CHECK-NEXT:    vslideup.vx v8, v12, a1
+; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    vmv1r.v v9, v12
+; CHECK-NEXT:    vslidedown.vx v10, v9, a1
+; CHECK-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vx v9, v10, a1
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
@@ -352,22 +374,42 @@ define {<2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>} @v
 ; CHECK-NEXT:    vslidedown.vi v13, v8, 4
 ; CHECK-NEXT:    vmv1r.v v14, v8
 ; CHECK-NEXT:    vslidedown.vi v8, v8, 6
-; CHECK-NEXT:    srli a1, a0, 2
-; CHECK-NEXT:    srli a2, a0, 3
-; CHECK-NEXT:    vsetvli zero, a1, e8, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vx v14, v12, a2
-; CHECK-NEXT:    add a3, a1, a2
-; CHECK-NEXT:    vslideup.vx v10, v9, a2
+; CHECK-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
+; CHECK-NEXT:    vslideup.vi v14, v12, 2
+; CHECK-NEXT:    vslideup.vi v10, v9, 2
+; CHECK-NEXT:    vsetivli zero, 6, e8, mf2, tu, ma
+; CHECK-NEXT:    vslideup.vi v14, v13, 4
+; CHECK-NEXT:    vslideup.vi v10, v11, 4
+; CHECK-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v14, v8, 6
+; CHECK-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
+; CHECK-NEXT:    vslideup.vi v14, v10, 8
+; CHECK-NEXT:    srli a1, a0, 3
+; CHECK-NEXT:    srli a2, a0, 1
+; CHECK-NEXT:    add a3, a2, a1
+; CHECK-NEXT:    vsetvli a4, zero, e8, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vx v8, v14, a3
+; CHECK-NEXT:    vslidedown.vx v9, v14, a2
+; CHECK-NEXT:    srli a3, a0, 2
+; CHECK-NEXT:    sub a0, a0, a3
+; CHECK-NEXT:    vslidedown.vx v10, v14, a0
+; CHECK-NEXT:    vslidedown.vx v11, v14, a1
+; CHECK-NEXT:    vslidedown.vx v12, v14, a3
+; CHECK-NEXT:    add a0, a3, a1
+; CHECK-NEXT:    vmv1r.v v13, v14
+; CHECK-NEXT:    vslidedown.vx v14, v14, a0
 ; CHECK-NEXT:    vsetvli zero, a3, e8, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vx v14, v13, a1
-; CHECK-NEXT:    vslideup.vx v10, v11, a1
+; CHECK-NEXT:    vslideup.vx v13, v11, a1
+; CHECK-NEXT:    vslideup.vx v9, v8, a1
+; CHECK-NEXT:    vsetvli zero, a0, e8, mf2, tu, ma
+; CHECK-NEXT:    vslideup.vx v13, v12, a3
+; CHECK-NEXT:    vslideup.vx v9, v10, a3
 ; CHECK-NEXT:    vsetvli a1, zero, e8, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v14, v8, a3
-; CHECK-NEXT:    srli a0, a0, 1
-; CHECK-NEXT:    vsetvli a1, zero, e8, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v14, v10, a0
+; CHECK-NEXT:    vslideup.vx v13, v14, a0
+; CHECK-NEXT:    vsetvli a0, zero, e8, m1, ta, ma
+; CHECK-NEXT:    vslideup.vx v13, v9, a2
 ; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs1r.v v14, (a0)
+; CHECK-NEXT:    vs1r.v v13, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
 ; CHECK-NEXT:    vlseg7e8.v v8, (a0)
 ; CHECK-NEXT:    csrr a0, vlenb
@@ -384,30 +426,6 @@ define {<2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    csrr a0, vlenb
 ; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 10
-; CHECK-NEXT:    vslidedown.vi v10, v8, 8
-; CHECK-NEXT:    vslidedown.vi v11, v8, 12
-; CHECK-NEXT:    vslidedown.vi v12, v8, 14
-; CHECK-NEXT:    vslidedown.vi v13, v8, 2
-; CHECK-NEXT:    vslidedown.vi v14, v8, 4
-; CHECK-NEXT:    vslidedown.vi v15, v8, 6
-; CHECK-NEXT:    srli a1, a0, 2
-; CHECK-NEXT:    srli a2, a0, 3
-; CHECK-NEXT:    vsetvli zero, a1, e8, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vx v10, v9, a2
-; CHECK-NEXT:    vslideup.vx v8, v13, a2
-; CHECK-NEXT:    add a2, a1, a2
-; CHECK-NEXT:    vsetvli zero, a2, e8, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vx v10, v11, a1
-; CHECK-NEXT:    vslideup.vx v8, v14, a1
-; CHECK-NEXT:    vsetvli a1, zero, e8, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v10, v12, a2
-; CHECK-NEXT:    vslideup.vx v8, v15, a2
-; CHECK-NEXT:    srli a0, a0, 1
-; CHECK-NEXT:    vsetvli a1, zero, e8, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v8, v10, a0
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs1r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
@@ -605,11 +623,15 @@ define {<2 x float>, <2 x float>, <2 x float>} @vector_deinterleave3_v6f32_v2f32
 ; CHECK-NEXT:    vslidedown.vi v10, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v9, v8, 2
+; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v9, 2
+; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v10, 4
 ; CHECK-NEXT:    csrr a0, vlenb
 ; CHECK-NEXT:    srli a0, a0, 3
 ; CHECK-NEXT:    vsetvli a1, zero, e32, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v8, v9, a0
-; CHECK-NEXT:    vmv1r.v v9, v10
+; CHECK-NEXT:    vslidedown.vx v10, v8, a0
+; CHECK-NEXT:    vslideup.vx v8, v10, a0
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
@@ -634,17 +656,6 @@ define {<2 x float>, <2 x float>, <2 x float>, <2 x float>} @vector_deinterleave
 ; CHECK-NEXT:    slli a0, a0, 1
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
-; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 6
-; CHECK-NEXT:    vslidedown.vi v12, v8, 4
-; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 2
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a0, a0, 3
-; CHECK-NEXT:    vsetvli a1, zero, e32, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v12, v10, a0
-; CHECK-NEXT:    vslideup.vx v8, v9, a0
-; CHECK-NEXT:    vmv.v.v v9, v12
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
@@ -670,20 +681,31 @@ define {<2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>} @vector_dein
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v10, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v9, v8, 6
-; CHECK-NEXT:    vslidedown.vi v11, v8, 4
-; CHECK-NEXT:    vslidedown.vi v12, v8, 2
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v9, a1
-; CHECK-NEXT:    vslideup.vx v8, v12, a1
+; CHECK-NEXT:    vslidedown.vi v12, v8, 4
+; CHECK-NEXT:    vslidedown.vi v13, v8, 2
+; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v12, v9, 2
+; CHECK-NEXT:    vslideup.vi v8, v13, 2
+; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v12, 4
+; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v10, 8
+; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    srli a0, a0, 2
+; CHECK-NEXT:    add a2, a0, a1
+; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vx v10, v8, a2
+; CHECK-NEXT:    vslidedown.vx v11, v8, a0
+; CHECK-NEXT:    vslidedown.vx v12, v8, a1
+; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vx v11, v10, a1
+; CHECK-NEXT:    vslideup.vx v8, v12, a1
 ; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    vmv1r.v v9, v10
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
@@ -709,20 +731,31 @@ define {<2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>} @v
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v10, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v9, v8, 6
-; CHECK-NEXT:    vslidedown.vi v11, v8, 4
-; CHECK-NEXT:    vslidedown.vi v12, v8, 2
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v9, a1
-; CHECK-NEXT:    vslideup.vx v8, v12, a1
+; CHECK-NEXT:    vslidedown.vi v12, v8, 4
+; CHECK-NEXT:    vslidedown.vi v13, v8, 2
+; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v12, v9, 2
+; CHECK-NEXT:    vslideup.vi v8, v13, 2
+; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v12, 4
+; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v10, 8
+; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    srli a0, a0, 2
+; CHECK-NEXT:    add a2, a0, a1
+; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vx v10, v8, a2
+; CHECK-NEXT:    vslidedown.vx v11, v8, a0
+; CHECK-NEXT:    vslidedown.vx v12, v8, a1
+; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vx v11, v10, a1
+; CHECK-NEXT:    vslideup.vx v8, v12, a1
 ; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    vmv1r.v v9, v10
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
@@ -748,7 +781,6 @@ define {<2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>} 
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v10, v8, 10
 ; CHECK-NEXT:    vslidedown.vi v12, v8, 8
@@ -756,14 +788,30 @@ define {<2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>} 
 ; CHECK-NEXT:    vslidedown.vi v9, v8, 6
 ; CHECK-NEXT:    vslidedown.vi v11, v8, 4
 ; CHECK-NEXT:    vslidedown.vi v13, v8, 2
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v9, a1
-; CHECK-NEXT:    vslideup.vx v8, v13, a1
-; CHECK-NEXT:    vslideup.vx v12, v10, a1
+; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v11, v9, 2
+; CHECK-NEXT:    vslideup.vi v8, v13, 2
+; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v11, 4
+; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v12, v10, 2
+; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v12, 8
+; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
+; CHECK-NEXT:    add a2, a0, a1
+; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vx v10, v8, a2
+; CHECK-NEXT:    vslidedown.vx v11, v8, a0
+; CHECK-NEXT:    vslidedown.vx v12, v8, a1
+; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vx v11, v10, a1
+; CHECK-NEXT:    vslideup.vx v8, v12, a1
+; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    vmv1r.v v9, v12
+; CHECK-NEXT:    vslidedown.vx v10, v9, a1
+; CHECK-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vx v9, v10, a1
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
@@ -789,7 +837,6 @@ define {<2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v10, v8, 10
 ; CHECK-NEXT:    vslidedown.vi v12, v8, 8
@@ -797,14 +844,30 @@ define {<2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2
 ; CHECK-NEXT:    vslidedown.vi v9, v8, 6
 ; CHECK-NEXT:    vslidedown.vi v11, v8, 4
 ; CHECK-NEXT:    vslidedown.vi v13, v8, 2
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v9, a1
-; CHECK-NEXT:    vslideup.vx v8, v13, a1
-; CHECK-NEXT:    vslideup.vx v12, v10, a1
+; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v11, v9, 2
+; CHECK-NEXT:    vslideup.vi v8, v13, 2
+; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v11, 4
+; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v12, v10, 2
+; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vslideup.vi v8, v12, 8
+; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
+; CHECK-NEXT:    add a2, a0, a1
+; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vx v10, v8, a2
+; CHECK-NEXT:    vslidedown.vx v11, v8, a0
+; CHECK-NEXT:    vslidedown.vx v12, v8, a1
+; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vx v11, v10, a1
+; CHECK-NEXT:    vslideup.vx v8, v12, a1
+; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
 ; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    vmv1r.v v9, v12
+; CHECK-NEXT:    vslidedown.vx v10, v9, a1
+; CHECK-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vx v9, v10, a1
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
@@ -830,25 +893,36 @@ define {<1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, 
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 3
-; CHECK-NEXT:    vslidedown.vi v11, v8, 2
-; CHECK-NEXT:    vmv1r.v v10, v8
-; CHECK-NEXT:    vslidedown.vi v12, v8, 1
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v9, a1
-; CHECK-NEXT:    vslideup.vx v10, v12, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v9, v8, 5
-; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    vslideup.vx v10, v11, a0
 ; CHECK-NEXT:    vslidedown.vi v11, v8, 4
+; CHECK-NEXT:    vslidedown.vi v12, v8, 6
+; CHECK-NEXT:    vslidedown.vi v13, v8, 1
+; CHECK-NEXT:    vslidedown.vi v14, v8, 2
+; CHECK-NEXT:    vmv1r.v v10, v8
+; CHECK-NEXT:    vslidedown.vi v8, v8, 3
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
+; CHECK-NEXT:    vslideup.vi v10, v13, 1
+; CHECK-NEXT:    vslideup.vi v11, v9, 1
+; CHECK-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
+; CHECK-NEXT:    vslideup.vi v10, v14, 2
+; CHECK-NEXT:    vslideup.vi v11, v12, 2
+; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v10, v8, 3
+; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vi v10, v11, 4
+; CHECK-NEXT:    srli a1, a0, 3
+; CHECK-NEXT:    srli a0, a0, 2
+; CHECK-NEXT:    add a2, a0, a1
+; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vx v8, v10, a2
+; CHECK-NEXT:    vslidedown.vx v9, v10, a0
+; CHECK-NEXT:    vslidedown.vx v11, v10, a1
 ; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v9, a1
+; CHECK-NEXT:    vslideup.vx v9, v8, a1
+; CHECK-NEXT:    vslideup.vx v10, v11, a1
 ; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 6
-; CHECK-NEXT:    vslideup.vx v11, v8, a0
+; CHECK-NEXT:    vslideup.vx v10, v9, a0
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v10, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
@@ -874,25 +948,36 @@ define {<1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 3
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 3
-; CHECK-NEXT:    vslidedown.vi v11, v8, 2
-; CHECK-NEXT:    vmv1r.v v10, v8
-; CHECK-NEXT:    vslidedown.vi v12, v8, 1
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v9, a1
-; CHECK-NEXT:    vslideup.vx v10, v12, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v9, v8, 5
-; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    vslideup.vx v10, v11, a0
 ; CHECK-NEXT:    vslidedown.vi v11, v8, 4
+; CHECK-NEXT:    vslidedown.vi v12, v8, 6
+; CHECK-NEXT:    vslidedown.vi v13, v8, 1
+; CHECK-NEXT:    vslidedown.vi v14, v8, 2
+; CHECK-NEXT:    vmv1r.v v10, v8
+; CHECK-NEXT:    vslidedown.vi v8, v8, 3
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
+; CHECK-NEXT:    vslideup.vi v10, v13, 1
+; CHECK-NEXT:    vslideup.vi v11, v9, 1
+; CHECK-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
+; CHECK-NEXT:    vslideup.vi v10, v14, 2
+; CHECK-NEXT:    vslideup.vi v11, v12, 2
+; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vslideup.vi v10, v8, 3
+; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vi v10, v11, 4
+; CHECK-NEXT:    srli a1, a0, 3
+; CHECK-NEXT:    srli a0, a0, 2
+; CHECK-NEXT:    add a2, a0, a1
+; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vx v8, v10, a2
+; CHECK-NEXT:    vslidedown.vx v9, v10, a0
+; CHECK-NEXT:    vslidedown.vx v11, v10, a1
 ; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v9, a1
+; CHECK-NEXT:    vslideup.vx v9, v8, a1
+; CHECK-NEXT:    vslideup.vx v10, v11, a1
 ; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 6
-; CHECK-NEXT:    vslideup.vx v11, v8, a0
+; CHECK-NEXT:    vslideup.vx v10, v9, a0
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v10, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
@@ -918,26 +1003,18 @@ define {<1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, 
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 7
-; CHECK-NEXT:    vslidedown.vi v11, v8, 6
-; CHECK-NEXT:    vslidedown.vi v12, v8, 5
-; CHECK-NEXT:    vslidedown.vi v9, v8, 4
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v10, a1
-; CHECK-NEXT:    vslideup.vx v9, v12, a1
-; CHECK-NEXT:    srli a0, a0, 2
+; CHECK-NEXT:    srli a1, a0, 2
 ; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v9, v11, a0
-; CHECK-NEXT:    vslidedown.vi v10, v8, 3
-; CHECK-NEXT:    vslidedown.vi v11, v8, 2
-; CHECK-NEXT:    vslidedown.vi v12, v8, 1
+; CHECK-NEXT:    vslidedown.vx v9, v8, a1
+; CHECK-NEXT:    srli a0, a0, 3
+; CHECK-NEXT:    add a2, a1, a0
+; CHECK-NEXT:    vslidedown.vx v10, v8, a2
+; CHECK-NEXT:    vslidedown.vx v11, v8, a0
 ; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v10, a1
-; CHECK-NEXT:    vslideup.vx v8, v12, a1
-; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vx v9, v10, a0
 ; CHECK-NEXT:    vslideup.vx v8, v11, a0
+; CHECK-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vx v8, v9, a1
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
@@ -963,26 +1040,18 @@ define {<1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1
 ; CHECK-NEXT:    sub sp, sp, a0
 ; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
 ; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 7
-; CHECK-NEXT:    vslidedown.vi v11, v8, 6
-; CHECK-NEXT:    vslidedown.vi v12, v8, 5
-; CHECK-NEXT:    vslidedown.vi v9, v8, 4
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v10, a1
-; CHECK-NEXT:    vslideup.vx v9, v12, a1
-; CHECK-NEXT:    srli a0, a0, 2
+; CHECK-NEXT:    srli a1, a0, 2
 ; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v9, v11, a0
-; CHECK-NEXT:    vslidedown.vi v10, v8, 3
-; CHECK-NEXT:    vslidedown.vi v11, v8, 2
-; CHECK-NEXT:    vslidedown.vi v12, v8, 1
+; CHECK-NEXT:    vslidedown.vx v9, v8, a1
+; CHECK-NEXT:    srli a0, a0, 3
+; CHECK-NEXT:    add a2, a1, a0
+; CHECK-NEXT:    vslidedown.vx v10, v8, a2
+; CHECK-NEXT:    vslidedown.vx v11, v8, a0
 ; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v10, a1
-; CHECK-NEXT:    vslideup.vx v8, v12, a1
-; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vx v9, v10, a0
 ; CHECK-NEXT:    vslideup.vx v8, v11, a0
+; CHECK-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
+; CHECK-NEXT:    vslideup.vx v8, v9, a1
 ; CHECK-NEXT:    addi a0, sp, 16
 ; CHECK-NEXT:    vs2r.v v8, (a0)
 ; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma

--- a/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
@@ -264,12 +264,8 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV32-NEXT:    vse32.v v9, (a1)
 ; RV32-NEXT:    addi a1, sp, 192
 ; RV32-NEXT:    vse32.v v8, (a1)
-; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV32-NEXT:    vle32.v v12, (a1)
-; RV32-NEXT:    mv a1, sp
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vse32.v v12, (a1)
 ; RV32-NEXT:    addi a2, a0, 64
+; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV32-NEXT:    vle32.v v8, (a2)
 ; RV32-NEXT:    addi a2, sp, 384
 ; RV32-NEXT:    vse32.v v8, (a2)
@@ -280,27 +276,32 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV32-NEXT:    vse32.v v8, (a3)
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV32-NEXT:    vle32.v v8, (a0)
-; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; RV32-NEXT:    vslidedown.vi v16, v8, 8
-; RV32-NEXT:    vslidedown.vi v12, v12, 8
-; RV32-NEXT:    addi a3, sp, 96
+; RV32-NEXT:    addi a3, sp, 64
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV32-NEXT:    vse32.v v8, (a3)
+; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV32-NEXT:    vle32.v v12, (a1)
+; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
+; RV32-NEXT:    vslidedown.vi v16, v12, 8
+; RV32-NEXT:    mv a1, sp
+; RV32-NEXT:    vslidedown.vi v8, v8, 8
+; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV32-NEXT:    vse32.v v12, (a1)
+; RV32-NEXT:    addi a3, sp, 32
 ; RV32-NEXT:    vse32.v v16, (a3)
-; RV32-NEXT:    addi a4, sp, 32
-; RV32-NEXT:    vse32.v v12, (a4)
+; RV32-NEXT:    addi a3, sp, 96
+; RV32-NEXT:    vse32.v v8, (a3)
 ; RV32-NEXT:    lw a0, 112(a0)
 ; RV32-NEXT:    sw a0, 432(sp)
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV32-NEXT:    vle32.v v12, (a2)
-; RV32-NEXT:    addi a0, sp, 128
+; RV32-NEXT:    vle32.v v8, (a2)
 ; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; RV32-NEXT:    vslidedown.vi v16, v12, 8
+; RV32-NEXT:    vslidedown.vi v12, v8, 8
+; RV32-NEXT:    addi a0, sp, 128
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vse32.v v12, (a0)
-; RV32-NEXT:    addi a0, sp, 64
 ; RV32-NEXT:    vse32.v v8, (a0)
 ; RV32-NEXT:    addi a0, sp, 160
-; RV32-NEXT:    vse32.v v16, (a0)
+; RV32-NEXT:    vse32.v v12, (a0)
 ; RV32-NEXT:    vlseg3e32.v v20, (a3)
 ; RV32-NEXT:    vlseg3e32.v v12, (a1)
 ; RV32-NEXT:    vmv4r.v v28, v20
@@ -360,12 +361,8 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV64-NEXT:    vse32.v v9, (a1)
 ; RV64-NEXT:    addi a1, sp, 192
 ; RV64-NEXT:    vse32.v v8, (a1)
-; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vle32.v v12, (a1)
-; RV64-NEXT:    mv a1, sp
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vse32.v v12, (a1)
 ; RV64-NEXT:    addi a2, a0, 64
+; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV64-NEXT:    vle32.v v8, (a2)
 ; RV64-NEXT:    addi a2, sp, 384
 ; RV64-NEXT:    vse32.v v8, (a2)
@@ -379,27 +376,32 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV64-NEXT:    vse32.v v24, (a3)
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV64-NEXT:    vle32.v v8, (a0)
-; RV64-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; RV64-NEXT:    vslidedown.vi v16, v8, 8
-; RV64-NEXT:    vslidedown.vi v12, v12, 8
-; RV64-NEXT:    addi a0, sp, 96
+; RV64-NEXT:    addi a0, sp, 64
 ; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vse32.v v16, (a0)
-; RV64-NEXT:    addi a3, sp, 32
-; RV64-NEXT:    vse32.v v12, (a3)
+; RV64-NEXT:    vse32.v v8, (a0)
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vle32.v v12, (a2)
-; RV64-NEXT:    addi a2, sp, 128
+; RV64-NEXT:    vle32.v v12, (a1)
 ; RV64-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
 ; RV64-NEXT:    vslidedown.vi v16, v12, 8
+; RV64-NEXT:    mv a0, sp
+; RV64-NEXT:    vslidedown.vi v8, v8, 8
 ; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vse32.v v12, (a2)
-; RV64-NEXT:    addi a2, sp, 64
+; RV64-NEXT:    vse32.v v12, (a0)
+; RV64-NEXT:    addi a1, sp, 32
+; RV64-NEXT:    vse32.v v16, (a1)
+; RV64-NEXT:    addi a1, sp, 96
+; RV64-NEXT:    vse32.v v8, (a1)
+; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV64-NEXT:    vle32.v v8, (a2)
+; RV64-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
+; RV64-NEXT:    vslidedown.vi v12, v8, 8
+; RV64-NEXT:    addi a2, sp, 128
+; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; RV64-NEXT:    vse32.v v8, (a2)
 ; RV64-NEXT:    addi a2, sp, 160
-; RV64-NEXT:    vse32.v v16, (a2)
-; RV64-NEXT:    vlseg3e32.v v20, (a0)
-; RV64-NEXT:    vlseg3e32.v v12, (a1)
+; RV64-NEXT:    vse32.v v12, (a2)
+; RV64-NEXT:    vlseg3e32.v v20, (a1)
+; RV64-NEXT:    vlseg3e32.v v12, (a0)
 ; RV64-NEXT:    vmv4r.v v28, v20
 ; RV64-NEXT:    vmv2r.v v30, v8
 ; RV64-NEXT:    vmv4r.v v8, v12
@@ -457,12 +459,8 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; ZVZIP-NEXT:    vse32.v v9, (a1)
 ; ZVZIP-NEXT:    addi a1, sp, 192
 ; ZVZIP-NEXT:    vse32.v v8, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vle32.v v12, (a1)
-; ZVZIP-NEXT:    mv a1, sp
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vse32.v v12, (a1)
 ; ZVZIP-NEXT:    addi a2, a0, 64
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVZIP-NEXT:    vle32.v v8, (a2)
 ; ZVZIP-NEXT:    addi a2, sp, 384
 ; ZVZIP-NEXT:    vse32.v v8, (a2)
@@ -476,27 +474,32 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; ZVZIP-NEXT:    vse32.v v24, (a3)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; ZVZIP-NEXT:    vle32.v v8, (a0)
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v16, v8, 8
-; ZVZIP-NEXT:    vslidedown.vi v12, v12, 8
-; ZVZIP-NEXT:    addi a0, sp, 96
+; ZVZIP-NEXT:    addi a0, sp, 64
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vse32.v v16, (a0)
-; ZVZIP-NEXT:    addi a3, sp, 32
-; ZVZIP-NEXT:    vse32.v v12, (a3)
+; ZVZIP-NEXT:    vse32.v v8, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vle32.v v12, (a2)
-; ZVZIP-NEXT:    addi a2, sp, 128
+; ZVZIP-NEXT:    vle32.v v12, (a1)
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
 ; ZVZIP-NEXT:    vslidedown.vi v16, v12, 8
+; ZVZIP-NEXT:    mv a0, sp
+; ZVZIP-NEXT:    vslidedown.vi v8, v8, 8
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vse32.v v12, (a2)
-; ZVZIP-NEXT:    addi a2, sp, 64
+; ZVZIP-NEXT:    vse32.v v12, (a0)
+; ZVZIP-NEXT:    addi a1, sp, 32
+; ZVZIP-NEXT:    vse32.v v16, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 96
+; ZVZIP-NEXT:    vse32.v v8, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vle32.v v8, (a2)
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
+; ZVZIP-NEXT:    vslidedown.vi v12, v8, 8
+; ZVZIP-NEXT:    addi a2, sp, 128
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
 ; ZVZIP-NEXT:    vse32.v v8, (a2)
 ; ZVZIP-NEXT:    addi a2, sp, 160
-; ZVZIP-NEXT:    vse32.v v16, (a2)
-; ZVZIP-NEXT:    vlseg3e32.v v20, (a0)
-; ZVZIP-NEXT:    vlseg3e32.v v12, (a1)
+; ZVZIP-NEXT:    vse32.v v12, (a2)
+; ZVZIP-NEXT:    vlseg3e32.v v20, (a1)
+; ZVZIP-NEXT:    vlseg3e32.v v12, (a0)
 ; ZVZIP-NEXT:    vmv4r.v v28, v20
 ; ZVZIP-NEXT:    vmv2r.v v30, v8
 ; ZVZIP-NEXT:    vmv4r.v v8, v12
@@ -520,20 +523,19 @@ define {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} @vector_deinterleave4_v2i32_
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -32
 ; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 4
-; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v11, v8, 2
+; CHECK-NEXT:    vslidedown.vi v10, v8, 6
+; CHECK-NEXT:    vslidedown.vi v12, v8, 4
 ; CHECK-NEXT:    mv a0, sp
 ; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; CHECK-NEXT:    vse32.v v8, (a0)
-; CHECK-NEXT:    addi a1, sp, 8
-; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 6
-; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-NEXT:    vse32.v v11, (a1)
-; CHECK-NEXT:    addi a1, sp, 16
-; CHECK-NEXT:    vse32.v v10, (a1)
 ; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse32.v v10, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 2
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vse32.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
 ; CHECK-NEXT:    vse32.v v8, (a1)
 ; CHECK-NEXT:    vlseg4e32.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 32
@@ -546,25 +548,26 @@ define {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} @vector_deinterle
 ; CHECK-LABEL: vector_deinterleave5_v2i16_v10i16:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -32
-; CHECK-NEXT:    addi a0, sp, 12
+; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 2
-; CHECK-NEXT:    vslidedown.vi v11, v8, 4
+; CHECK-NEXT:    vslidedown.vi v9, v8, 6
+; CHECK-NEXT:    addi a0, sp, 12
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 28
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v12, v8, 6
-; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vslidedown.vi v11, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 2
 ; CHECK-NEXT:    addi a1, sp, 20
-; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v11, (a1)
-; CHECK-NEXT:    addi a1, sp, 24
-; CHECK-NEXT:    vse16.v v12, (a1)
-; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    addi a1, sp, 16
 ; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg5e16.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 32
@@ -579,27 +582,28 @@ define {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} @vecto
 ; CHECK-NEXT:    addi sp, sp, -32
 ; CHECK-NEXT:    addi a0, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 8
-; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v11, v8, 2
-; CHECK-NEXT:    vslidedown.vi v12, v8, 4
+; CHECK-NEXT:    vslidedown.vi v10, v8, 10
+; CHECK-NEXT:    vslidedown.vi v12, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v8, (a0)
-; CHECK-NEXT:    addi a1, sp, 12
-; CHECK-NEXT:    vse16.v v11, (a1)
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v11, v8, 6
-; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vslidedown.vi v9, v8, 6
+; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v12, (a1)
 ; CHECK-NEXT:    addi a1, sp, 20
-; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 10
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 2
+; CHECK-NEXT:    addi a1, sp, 16
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
-; CHECK-NEXT:    vse16.v v11, (a1)
-; CHECK-NEXT:    addi a1, sp, 24
 ; CHECK-NEXT:    vse16.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    addi a1, sp, 12
 ; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg6e16.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 32
@@ -614,31 +618,31 @@ define {<2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>} @v
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    addi a0, sp, 2
 ; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 2
-; CHECK-NEXT:    vslidedown.vi v10, v8, 4
-; CHECK-NEXT:    vslidedown.vi v11, v8, 6
+; CHECK-NEXT:    vslidedown.vi v9, v8, 12
+; CHECK-NEXT:    vslidedown.vi v10, v8, 10
+; CHECK-NEXT:    vslidedown.vi v11, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; CHECK-NEXT:    vse8.v v8, (a0)
-; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    addi a1, sp, 14
 ; CHECK-NEXT:    vse8.v v9, (a1)
 ; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 8
-; CHECK-NEXT:    addi a1, sp, 6
-; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
-; CHECK-NEXT:    vse8.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 8
-; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 10
-; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
-; CHECK-NEXT:    vse8.v v11, (a1)
-; CHECK-NEXT:    addi a1, sp, 10
-; CHECK-NEXT:    vse8.v v9, (a1)
-; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 12
+; CHECK-NEXT:    vslidedown.vi v9, v8, 6
 ; CHECK-NEXT:    addi a1, sp, 12
 ; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; CHECK-NEXT:    vse8.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 4
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vse8.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vse8.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 2
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vse8.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 4
 ; CHECK-NEXT:    vse8.v v8, (a1)
 ; CHECK-NEXT:    vlseg7e8.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 16
@@ -652,37 +656,37 @@ define {<2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 2
-; CHECK-NEXT:    vslidedown.vi v10, v8, 4
-; CHECK-NEXT:    vslidedown.vi v11, v8, 6
+; CHECK-NEXT:    vslidedown.vi v9, v8, 14
+; CHECK-NEXT:    vslidedown.vi v10, v8, 12
+; CHECK-NEXT:    vslidedown.vi v11, v8, 10
 ; CHECK-NEXT:    mv a0, sp
 ; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; CHECK-NEXT:    vse8.v v8, (a0)
-; CHECK-NEXT:    addi a1, sp, 2
+; CHECK-NEXT:    addi a1, sp, 14
 ; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v12, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; CHECK-NEXT:    vse8.v v9, (a1)
-; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    addi a1, sp, 12
 ; CHECK-NEXT:    vse8.v v10, (a1)
 ; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 10
-; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vslidedown.vi v9, v8, 6
+; CHECK-NEXT:    addi a1, sp, 10
 ; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; CHECK-NEXT:    vse8.v v11, (a1)
 ; CHECK-NEXT:    addi a1, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 12
+; CHECK-NEXT:    vslidedown.vi v10, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; CHECK-NEXT:    vse8.v v12, (a1)
-; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    addi a1, sp, 6
 ; CHECK-NEXT:    vse8.v v9, (a1)
 ; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 14
-; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vslidedown.vi v8, v8, 2
+; CHECK-NEXT:    addi a1, sp, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
 ; CHECK-NEXT:    vse8.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    addi a1, sp, 2
 ; CHECK-NEXT:    vse8.v v8, (a1)
 ; CHECK-NEXT:    vlseg8e8.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 16
@@ -893,20 +897,19 @@ define {<2 x float>, <2 x float>, <2 x float>, <2 x float>} @vector_deinterleave
 ; CHECK-NEXT:    addi sp, sp, -32
 ; CHECK-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 4
-; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v11, v8, 2
+; CHECK-NEXT:    vslidedown.vi v10, v8, 6
+; CHECK-NEXT:    vslidedown.vi v12, v8, 4
 ; CHECK-NEXT:    mv a0, sp
 ; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
 ; CHECK-NEXT:    vse32.v v8, (a0)
-; CHECK-NEXT:    addi a1, sp, 8
-; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 6
-; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; CHECK-NEXT:    vse32.v v11, (a1)
-; CHECK-NEXT:    addi a1, sp, 16
-; CHECK-NEXT:    vse32.v v10, (a1)
 ; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse32.v v10, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 2
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vse32.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
 ; CHECK-NEXT:    vse32.v v8, (a1)
 ; CHECK-NEXT:    vlseg4e32.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 32
@@ -921,25 +924,26 @@ define {<2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>} @vector_dein
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -32
 ; CHECK-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NEXT:    addi a0, sp, 12
+; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 2
-; CHECK-NEXT:    vslidedown.vi v11, v8, 4
+; CHECK-NEXT:    vslidedown.vi v9, v8, 6
+; CHECK-NEXT:    addi a0, sp, 12
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 28
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v12, v8, 6
-; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vslidedown.vi v11, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 2
 ; CHECK-NEXT:    addi a1, sp, 20
-; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v11, (a1)
-; CHECK-NEXT:    addi a1, sp, 24
-; CHECK-NEXT:    vse16.v v12, (a1)
-; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    addi a1, sp, 16
 ; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg5e16.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 32
@@ -954,25 +958,26 @@ define {<2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>} @v
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -32
 ; CHECK-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-NEXT:    addi a0, sp, 12
+; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 2
-; CHECK-NEXT:    vslidedown.vi v11, v8, 4
+; CHECK-NEXT:    vslidedown.vi v9, v8, 6
+; CHECK-NEXT:    addi a0, sp, 12
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 28
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v12, v8, 6
-; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vslidedown.vi v11, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 2
 ; CHECK-NEXT:    addi a1, sp, 20
-; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v11, (a1)
-; CHECK-NEXT:    addi a1, sp, 24
-; CHECK-NEXT:    vse16.v v12, (a1)
-; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    addi a1, sp, 16
 ; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg5e16.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 32
@@ -989,27 +994,28 @@ define {<2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>} 
 ; CHECK-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-NEXT:    addi a0, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 8
-; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v11, v8, 2
-; CHECK-NEXT:    vslidedown.vi v12, v8, 4
+; CHECK-NEXT:    vslidedown.vi v10, v8, 10
+; CHECK-NEXT:    vslidedown.vi v12, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v8, (a0)
-; CHECK-NEXT:    addi a1, sp, 12
-; CHECK-NEXT:    vse16.v v11, (a1)
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v11, v8, 6
-; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vslidedown.vi v9, v8, 6
+; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v12, (a1)
 ; CHECK-NEXT:    addi a1, sp, 20
-; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 10
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 2
+; CHECK-NEXT:    addi a1, sp, 16
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
-; CHECK-NEXT:    vse16.v v11, (a1)
-; CHECK-NEXT:    addi a1, sp, 24
 ; CHECK-NEXT:    vse16.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    addi a1, sp, 12
 ; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg6e16.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 32
@@ -1026,27 +1032,28 @@ define {<2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2
 ; CHECK-NEXT:    .cfi_def_cfa_offset 32
 ; CHECK-NEXT:    addi a0, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 8
-; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v11, v8, 2
-; CHECK-NEXT:    vslidedown.vi v12, v8, 4
+; CHECK-NEXT:    vslidedown.vi v10, v8, 10
+; CHECK-NEXT:    vslidedown.vi v12, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v8, (a0)
-; CHECK-NEXT:    addi a1, sp, 12
-; CHECK-NEXT:    vse16.v v11, (a1)
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v11, v8, 6
-; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vslidedown.vi v9, v8, 6
+; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v12, (a1)
 ; CHECK-NEXT:    addi a1, sp, 20
-; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 10
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 2
+; CHECK-NEXT:    addi a1, sp, 16
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
-; CHECK-NEXT:    vse16.v v11, (a1)
-; CHECK-NEXT:    addi a1, sp, 24
 ; CHECK-NEXT:    vse16.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    addi a1, sp, 12
 ; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg6e16.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 32
@@ -1063,31 +1070,31 @@ define {<1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, 
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
 ; CHECK-NEXT:    addi a0, sp, 2
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-NEXT:    vslidedown.vi v10, v8, 2
-; CHECK-NEXT:    vslidedown.vi v11, v8, 3
+; CHECK-NEXT:    vslidedown.vi v9, v8, 6
+; CHECK-NEXT:    vslidedown.vi v10, v8, 5
+; CHECK-NEXT:    vslidedown.vi v11, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v8, (a0)
-; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    addi a1, sp, 14
 ; CHECK-NEXT:    vse16.v v9, (a1)
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 4
-; CHECK-NEXT:    addi a1, sp, 6
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
-; CHECK-NEXT:    vse16.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 8
-; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 5
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
-; CHECK-NEXT:    vse16.v v11, (a1)
-; CHECK-NEXT:    addi a1, sp, 10
-; CHECK-NEXT:    vse16.v v9, (a1)
-; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 6
+; CHECK-NEXT:    vslidedown.vi v9, v8, 3
 ; CHECK-NEXT:    addi a1, sp, 12
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 2
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 1
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 4
 ; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg7e16.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 16
@@ -1104,31 +1111,31 @@ define {<1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
 ; CHECK-NEXT:    addi a0, sp, 2
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-NEXT:    vslidedown.vi v10, v8, 2
-; CHECK-NEXT:    vslidedown.vi v11, v8, 3
+; CHECK-NEXT:    vslidedown.vi v9, v8, 6
+; CHECK-NEXT:    vslidedown.vi v10, v8, 5
+; CHECK-NEXT:    vslidedown.vi v11, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v8, (a0)
-; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    addi a1, sp, 14
 ; CHECK-NEXT:    vse16.v v9, (a1)
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 4
-; CHECK-NEXT:    addi a1, sp, 6
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
-; CHECK-NEXT:    vse16.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 8
-; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 5
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
-; CHECK-NEXT:    vse16.v v11, (a1)
-; CHECK-NEXT:    addi a1, sp, 10
-; CHECK-NEXT:    vse16.v v9, (a1)
-; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 6
+; CHECK-NEXT:    vslidedown.vi v9, v8, 3
 ; CHECK-NEXT:    addi a1, sp, 12
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 2
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 1
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 4
 ; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg7e16.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 16
@@ -1144,37 +1151,37 @@ define {<1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, 
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-NEXT:    vslidedown.vi v10, v8, 2
-; CHECK-NEXT:    vslidedown.vi v11, v8, 3
+; CHECK-NEXT:    vslidedown.vi v9, v8, 7
+; CHECK-NEXT:    vslidedown.vi v10, v8, 6
+; CHECK-NEXT:    vslidedown.vi v11, v8, 5
 ; CHECK-NEXT:    mv a0, sp
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v8, (a0)
-; CHECK-NEXT:    addi a1, sp, 2
+; CHECK-NEXT:    addi a1, sp, 14
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v12, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v9, (a1)
-; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    addi a1, sp, 12
 ; CHECK-NEXT:    vse16.v v10, (a1)
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 5
-; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vslidedown.vi v9, v8, 3
+; CHECK-NEXT:    addi a1, sp, 10
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v11, (a1)
 ; CHECK-NEXT:    addi a1, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 6
+; CHECK-NEXT:    vslidedown.vi v10, v8, 2
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v12, (a1)
-; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    addi a1, sp, 6
 ; CHECK-NEXT:    vse16.v v9, (a1)
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 7
-; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vslidedown.vi v8, v8, 1
+; CHECK-NEXT:    addi a1, sp, 4
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    addi a1, sp, 2
 ; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg8e16.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 16
@@ -1190,37 +1197,37 @@ define {<1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 1
-; CHECK-NEXT:    vslidedown.vi v10, v8, 2
-; CHECK-NEXT:    vslidedown.vi v11, v8, 3
+; CHECK-NEXT:    vslidedown.vi v9, v8, 7
+; CHECK-NEXT:    vslidedown.vi v10, v8, 6
+; CHECK-NEXT:    vslidedown.vi v11, v8, 5
 ; CHECK-NEXT:    mv a0, sp
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v8, (a0)
-; CHECK-NEXT:    addi a1, sp, 2
+; CHECK-NEXT:    addi a1, sp, 14
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v12, v8, 4
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v9, (a1)
-; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    addi a1, sp, 12
 ; CHECK-NEXT:    vse16.v v10, (a1)
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 5
-; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vslidedown.vi v9, v8, 3
+; CHECK-NEXT:    addi a1, sp, 10
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v11, (a1)
 ; CHECK-NEXT:    addi a1, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 6
+; CHECK-NEXT:    vslidedown.vi v10, v8, 2
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v12, (a1)
-; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    addi a1, sp, 6
 ; CHECK-NEXT:    vse16.v v9, (a1)
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 7
-; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vslidedown.vi v8, v8, 1
+; CHECK-NEXT:    addi a1, sp, 4
 ; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
 ; CHECK-NEXT:    vse16.v v10, (a1)
-; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    addi a1, sp, 2
 ; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg8e16.v v8, (a0)
 ; CHECK-NEXT:    addi sp, sp, 16

--- a/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
@@ -241,6 +241,649 @@ define {<3 x i32>, <3 x i32>, <3 x i32>} @vector_deinterleave3_v3i32_v9i32(<9 x 
   ret {<3 x i32>, <3 x i32>, <3 x i32>} %d
 }
 
+define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(<45 x i32> %v) nounwind {
+; RV32-LABEL: vector_deinterleave3_v15i32_v45i32:
+; RV32:       # %bb.0:
+; RV32-NEXT:    addi sp, sp, -528
+; RV32-NEXT:    sw ra, 524(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s0, 520(sp) # 4-byte Folded Spill
+; RV32-NEXT:    addi s0, sp, 528
+; RV32-NEXT:    csrr a1, vlenb
+; RV32-NEXT:    slli a1, a1, 4
+; RV32-NEXT:    sub sp, sp, a1
+; RV32-NEXT:    andi sp, sp, -128
+; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:    vmv1r.v v24, v23
+; RV32-NEXT:    vslideup.vi v14, v15, 1
+; RV32-NEXT:    vslideup.vi v10, v11, 1
+; RV32-NEXT:    addi a1, a0, 8
+; RV32-NEXT:    vslideup.vi v12, v13, 1
+; RV32-NEXT:    vslideup.vi v18, v19, 1
+; RV32-NEXT:    vslideup.vi v8, v9, 1
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV32-NEXT:    vslideup.vi v8, v10, 2
+; RV32-NEXT:    vslideup.vi v12, v14, 2
+; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV32-NEXT:    vslideup.vi v8, v12, 4
+; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:    vslideup.vi v16, v17, 1
+; RV32-NEXT:    vslideup.vi v20, v21, 1
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV32-NEXT:    vslideup.vi v16, v18, 2
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v13, (a1)
+; RV32-NEXT:    addi a1, a0, 4
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV32-NEXT:    vslideup.vi v20, v22, 2
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v14, (a1)
+; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV32-NEXT:    vslideup.vi v16, v20, 4
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v15, (a0)
+; RV32-NEXT:    addi a1, a0, 16
+; RV32-NEXT:    vle32.v v20, (a1)
+; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV32-NEXT:    vslideup.vi v8, v16, 8
+; RV32-NEXT:    addi a1, a0, 12
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v12, (a1)
+; RV32-NEXT:    addi a1, a0, 24
+; RV32-NEXT:    vle32.v v16, (a1)
+; RV32-NEXT:    addi a1, a0, 20
+; RV32-NEXT:    vle32.v v17, (a1)
+; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:    vslideup.vi v24, v15, 1
+; RV32-NEXT:    addi a1, a0, 48
+; RV32-NEXT:    vslideup.vi v14, v13, 1
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v15, (a1)
+; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:    vslideup.vi v17, v16, 1
+; RV32-NEXT:    addi a1, a0, 32
+; RV32-NEXT:    vslideup.vi v12, v20, 1
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v16, (a1)
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV32-NEXT:    vslideup.vi v24, v14, 2
+; RV32-NEXT:    addi a1, a0, 40
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v14, (a1)
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV32-NEXT:    vslideup.vi v12, v17, 2
+; RV32-NEXT:    addi a1, a0, 36
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v17, (a1)
+; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV32-NEXT:    vslideup.vi v24, v12, 4
+; RV32-NEXT:    addi a1, a0, 28
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v12, (a1)
+; RV32-NEXT:    addi a1, a0, 44
+; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:    vslideup.vi v17, v14, 1
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v14, (a1)
+; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:    vslideup.vi v12, v16, 1
+; RV32-NEXT:    addi a1, a0, 52
+; RV32-NEXT:    vslideup.vi v14, v15, 1
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v13, (a1)
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV32-NEXT:    vslideup.vi v12, v17, 2
+; RV32-NEXT:    vslideup.vi v14, v13, 2
+; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV32-NEXT:    vslideup.vi v12, v14, 4
+; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV32-NEXT:    vslideup.vi v24, v12, 8
+; RV32-NEXT:    addi a1, a0, 108
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v18, (a1)
+; RV32-NEXT:    addi a1, a0, 60
+; RV32-NEXT:    vle32.v v17, (a1)
+; RV32-NEXT:    addi a1, a0, 56
+; RV32-NEXT:    vle32.v v16, (a1)
+; RV32-NEXT:    vsetivli zero, 31, e32, m8, tu, ma
+; RV32-NEXT:    vslideup.vi v8, v24, 15
+; RV32-NEXT:    addi a1, a0, 68
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v19, (a1)
+; RV32-NEXT:    addi a1, a0, 64
+; RV32-NEXT:    vle32.v v20, (a1)
+; RV32-NEXT:    addi a1, a0, 76
+; RV32-NEXT:    vle32.v v21, (a1)
+; RV32-NEXT:    addi a1, a0, 84
+; RV32-NEXT:    vle32.v v23, (a1)
+; RV32-NEXT:    addi a1, a0, 80
+; RV32-NEXT:    vle32.v v24, (a1)
+; RV32-NEXT:    addi a1, a0, 72
+; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:    vslideup.vi v20, v19, 1
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v22, (a1)
+; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:    vslideup.vi v16, v17, 1
+; RV32-NEXT:    addi a1, a0, 92
+; RV32-NEXT:    vslideup.vi v24, v23, 1
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v19, (a1)
+; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:    vslideup.vi v22, v21, 1
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV32-NEXT:    vslideup.vi v16, v20, 2
+; RV32-NEXT:    addi a1, a0, 88
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v20, (a1)
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV32-NEXT:    vslideup.vi v22, v24, 2
+; RV32-NEXT:    addi a1, a0, 100
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v21, (a1)
+; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV32-NEXT:    vslideup.vi v16, v22, 4
+; RV32-NEXT:    addi a1, a0, 96
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v23, (a1)
+; RV32-NEXT:    addi a1, a0, 104
+; RV32-NEXT:    vle32.v v22, (a1)
+; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:    vslideup.vi v23, v21, 1
+; RV32-NEXT:    vslideup.vi v20, v19, 1
+; RV32-NEXT:    addi a0, a0, 112
+; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV32-NEXT:    vle32.v v19, (a0)
+; RV32-NEXT:    li a0, 32
+; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV32-NEXT:    vslideup.vi v22, v18, 1
+; RV32-NEXT:    addi a1, sp, 128
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV32-NEXT:    vslideup.vi v20, v23, 2
+; RV32-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; RV32-NEXT:    vse32.v v8, (a1)
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV32-NEXT:    vslideup.vi v22, v19, 2
+; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV32-NEXT:    vslideup.vi v20, v22, 4
+; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV32-NEXT:    vslideup.vi v16, v20, 8
+; RV32-NEXT:    addi a2, sp, 248
+; RV32-NEXT:    vse32.v v16, (a2)
+; RV32-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; RV32-NEXT:    vle32.v v24, (a1)
+; RV32-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
+; RV32-NEXT:    vslidedown.vi v8, v24, 16
+; RV32-NEXT:    vmv4r.v v16, v24
+; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
+; RV32-NEXT:    vslidedown.vi v20, v24, 8
+; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV32-NEXT:    vslideup.vi v16, v20, 8
+; RV32-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; RV32-NEXT:    vslideup.vi v16, v8, 16
+; RV32-NEXT:    csrr a1, vlenb
+; RV32-NEXT:    slli a1, a1, 3
+; RV32-NEXT:    add a1, sp, a1
+; RV32-NEXT:    addi a1, a1, 512
+; RV32-NEXT:    vs8r.v v16, (a1)
+; RV32-NEXT:    addi a2, sp, 256
+; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV32-NEXT:    vle32.v v12, (a2)
+; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
+; RV32-NEXT:    vslidedown.vi v16, v12, 8
+; RV32-NEXT:    vslidedown.vi v8, v8, 8
+; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV32-NEXT:    vslideup.vi v8, v12, 8
+; RV32-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; RV32-NEXT:    vslideup.vi v8, v16, 16
+; RV32-NEXT:    addi a0, sp, 512
+; RV32-NEXT:    vs8r.v v8, (a0)
+; RV32-NEXT:    vsetvli a2, zero, e32, m2, ta, ma
+; RV32-NEXT:    vlseg3e32.v v20, (a0)
+; RV32-NEXT:    vlseg3e32.v v12, (a1)
+; RV32-NEXT:    vmv4r.v v28, v20
+; RV32-NEXT:    vmv2r.v v30, v8
+; RV32-NEXT:    vmv4r.v v8, v12
+; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV32-NEXT:    vslideup.vi v8, v28, 8
+; RV32-NEXT:    vmv2r.v v20, v22
+; RV32-NEXT:    vmv2r.v v12, v14
+; RV32-NEXT:    vslideup.vi v16, v24, 8
+; RV32-NEXT:    vslideup.vi v12, v20, 8
+; RV32-NEXT:    addi sp, s0, -528
+; RV32-NEXT:    lw ra, 524(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s0, 520(sp) # 4-byte Folded Reload
+; RV32-NEXT:    addi sp, sp, 528
+; RV32-NEXT:    ret
+;
+; RV64-LABEL: vector_deinterleave3_v15i32_v45i32:
+; RV64:       # %bb.0:
+; RV64-NEXT:    addi sp, sp, -512
+; RV64-NEXT:    sd ra, 504(sp) # 8-byte Folded Spill
+; RV64-NEXT:    sd s0, 496(sp) # 8-byte Folded Spill
+; RV64-NEXT:    addi s0, sp, 512
+; RV64-NEXT:    csrr a1, vlenb
+; RV64-NEXT:    slli a1, a1, 4
+; RV64-NEXT:    sub sp, sp, a1
+; RV64-NEXT:    andi sp, sp, -128
+; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:    vmv1r.v v24, v23
+; RV64-NEXT:    vslideup.vi v14, v15, 1
+; RV64-NEXT:    vslideup.vi v10, v11, 1
+; RV64-NEXT:    addi a1, a0, 8
+; RV64-NEXT:    vslideup.vi v12, v13, 1
+; RV64-NEXT:    vslideup.vi v18, v19, 1
+; RV64-NEXT:    vslideup.vi v8, v9, 1
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV64-NEXT:    vslideup.vi v8, v10, 2
+; RV64-NEXT:    vslideup.vi v12, v14, 2
+; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV64-NEXT:    vslideup.vi v8, v12, 4
+; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:    vslideup.vi v16, v17, 1
+; RV64-NEXT:    vslideup.vi v20, v21, 1
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV64-NEXT:    vslideup.vi v16, v18, 2
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v13, (a1)
+; RV64-NEXT:    addi a1, a0, 4
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV64-NEXT:    vslideup.vi v20, v22, 2
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v14, (a1)
+; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV64-NEXT:    vslideup.vi v16, v20, 4
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v15, (a0)
+; RV64-NEXT:    addi a1, a0, 16
+; RV64-NEXT:    vle32.v v20, (a1)
+; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV64-NEXT:    vslideup.vi v8, v16, 8
+; RV64-NEXT:    addi a1, a0, 12
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v12, (a1)
+; RV64-NEXT:    addi a1, a0, 24
+; RV64-NEXT:    vle32.v v16, (a1)
+; RV64-NEXT:    addi a1, a0, 20
+; RV64-NEXT:    vle32.v v17, (a1)
+; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:    vslideup.vi v24, v15, 1
+; RV64-NEXT:    addi a1, a0, 48
+; RV64-NEXT:    vslideup.vi v14, v13, 1
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v15, (a1)
+; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:    vslideup.vi v17, v16, 1
+; RV64-NEXT:    addi a1, a0, 32
+; RV64-NEXT:    vslideup.vi v12, v20, 1
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v16, (a1)
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV64-NEXT:    vslideup.vi v24, v14, 2
+; RV64-NEXT:    addi a1, a0, 40
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v14, (a1)
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV64-NEXT:    vslideup.vi v12, v17, 2
+; RV64-NEXT:    addi a1, a0, 36
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v17, (a1)
+; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV64-NEXT:    vslideup.vi v24, v12, 4
+; RV64-NEXT:    addi a1, a0, 28
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v12, (a1)
+; RV64-NEXT:    addi a1, a0, 44
+; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:    vslideup.vi v17, v14, 1
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v14, (a1)
+; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:    vslideup.vi v12, v16, 1
+; RV64-NEXT:    addi a1, a0, 52
+; RV64-NEXT:    vslideup.vi v14, v15, 1
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v13, (a1)
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV64-NEXT:    vslideup.vi v12, v17, 2
+; RV64-NEXT:    vslideup.vi v14, v13, 2
+; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV64-NEXT:    vslideup.vi v12, v14, 4
+; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV64-NEXT:    vslideup.vi v24, v12, 8
+; RV64-NEXT:    addi a1, a0, 108
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v18, (a1)
+; RV64-NEXT:    addi a1, a0, 60
+; RV64-NEXT:    vle32.v v17, (a1)
+; RV64-NEXT:    addi a1, a0, 56
+; RV64-NEXT:    vle32.v v16, (a1)
+; RV64-NEXT:    vsetivli zero, 31, e32, m8, tu, ma
+; RV64-NEXT:    vslideup.vi v8, v24, 15
+; RV64-NEXT:    addi a1, a0, 68
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v19, (a1)
+; RV64-NEXT:    addi a1, a0, 64
+; RV64-NEXT:    vle32.v v20, (a1)
+; RV64-NEXT:    addi a1, a0, 76
+; RV64-NEXT:    vle32.v v21, (a1)
+; RV64-NEXT:    addi a1, a0, 84
+; RV64-NEXT:    vle32.v v23, (a1)
+; RV64-NEXT:    addi a1, a0, 80
+; RV64-NEXT:    vle32.v v24, (a1)
+; RV64-NEXT:    addi a1, a0, 72
+; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:    vslideup.vi v20, v19, 1
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v22, (a1)
+; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:    vslideup.vi v16, v17, 1
+; RV64-NEXT:    addi a1, a0, 92
+; RV64-NEXT:    vslideup.vi v24, v23, 1
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v19, (a1)
+; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:    vslideup.vi v22, v21, 1
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV64-NEXT:    vslideup.vi v16, v20, 2
+; RV64-NEXT:    addi a1, a0, 88
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v20, (a1)
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV64-NEXT:    vslideup.vi v22, v24, 2
+; RV64-NEXT:    addi a1, a0, 100
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v21, (a1)
+; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV64-NEXT:    vslideup.vi v16, v22, 4
+; RV64-NEXT:    addi a1, a0, 96
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v23, (a1)
+; RV64-NEXT:    addi a1, a0, 104
+; RV64-NEXT:    vle32.v v22, (a1)
+; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:    vslideup.vi v23, v21, 1
+; RV64-NEXT:    vslideup.vi v20, v19, 1
+; RV64-NEXT:    addi a0, a0, 112
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vle32.v v19, (a0)
+; RV64-NEXT:    li a0, 32
+; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; RV64-NEXT:    vslideup.vi v22, v18, 1
+; RV64-NEXT:    addi a1, sp, 128
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV64-NEXT:    vslideup.vi v20, v23, 2
+; RV64-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; RV64-NEXT:    vse32.v v8, (a1)
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV64-NEXT:    vslideup.vi v22, v19, 2
+; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV64-NEXT:    vslideup.vi v20, v22, 4
+; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV64-NEXT:    vslideup.vi v16, v20, 8
+; RV64-NEXT:    addi a2, sp, 248
+; RV64-NEXT:    vse32.v v16, (a2)
+; RV64-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; RV64-NEXT:    vle32.v v24, (a1)
+; RV64-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
+; RV64-NEXT:    vslidedown.vi v8, v24, 16
+; RV64-NEXT:    vmv4r.v v16, v24
+; RV64-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
+; RV64-NEXT:    vslidedown.vi v20, v24, 8
+; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV64-NEXT:    vslideup.vi v16, v20, 8
+; RV64-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; RV64-NEXT:    vslideup.vi v16, v8, 16
+; RV64-NEXT:    csrr a1, vlenb
+; RV64-NEXT:    slli a1, a1, 3
+; RV64-NEXT:    add a1, sp, a1
+; RV64-NEXT:    addi a1, a1, 496
+; RV64-NEXT:    vs8r.v v16, (a1)
+; RV64-NEXT:    addi a2, sp, 256
+; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV64-NEXT:    vle32.v v12, (a2)
+; RV64-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
+; RV64-NEXT:    vslidedown.vi v16, v12, 8
+; RV64-NEXT:    vslidedown.vi v8, v8, 8
+; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV64-NEXT:    vslideup.vi v8, v12, 8
+; RV64-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; RV64-NEXT:    vslideup.vi v8, v16, 16
+; RV64-NEXT:    addi a0, sp, 496
+; RV64-NEXT:    vs8r.v v8, (a0)
+; RV64-NEXT:    vsetvli a2, zero, e32, m2, ta, ma
+; RV64-NEXT:    vlseg3e32.v v20, (a0)
+; RV64-NEXT:    vlseg3e32.v v12, (a1)
+; RV64-NEXT:    vmv4r.v v28, v20
+; RV64-NEXT:    vmv2r.v v30, v8
+; RV64-NEXT:    vmv4r.v v8, v12
+; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV64-NEXT:    vslideup.vi v8, v28, 8
+; RV64-NEXT:    vmv2r.v v20, v22
+; RV64-NEXT:    vmv2r.v v12, v14
+; RV64-NEXT:    vslideup.vi v16, v24, 8
+; RV64-NEXT:    vslideup.vi v12, v20, 8
+; RV64-NEXT:    addi sp, s0, -512
+; RV64-NEXT:    ld ra, 504(sp) # 8-byte Folded Reload
+; RV64-NEXT:    ld s0, 496(sp) # 8-byte Folded Reload
+; RV64-NEXT:    addi sp, sp, 512
+; RV64-NEXT:    ret
+;
+; ZVZIP-LABEL: vector_deinterleave3_v15i32_v45i32:
+; ZVZIP:       # %bb.0:
+; ZVZIP-NEXT:    addi sp, sp, -512
+; ZVZIP-NEXT:    sd ra, 504(sp) # 8-byte Folded Spill
+; ZVZIP-NEXT:    sd s0, 496(sp) # 8-byte Folded Spill
+; ZVZIP-NEXT:    addi s0, sp, 512
+; ZVZIP-NEXT:    csrr a1, vlenb
+; ZVZIP-NEXT:    slli a1, a1, 4
+; ZVZIP-NEXT:    sub sp, sp, a1
+; ZVZIP-NEXT:    andi sp, sp, -128
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vmv1r.v v24, v23
+; ZVZIP-NEXT:    vslideup.vi v14, v15, 1
+; ZVZIP-NEXT:    vslideup.vi v10, v11, 1
+; ZVZIP-NEXT:    addi a1, a0, 8
+; ZVZIP-NEXT:    vslideup.vi v12, v13, 1
+; ZVZIP-NEXT:    vslideup.vi v18, v19, 1
+; ZVZIP-NEXT:    vslideup.vi v8, v9, 1
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v8, v10, 2
+; ZVZIP-NEXT:    vslideup.vi v12, v14, 2
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v8, v12, 4
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v16, v17, 1
+; ZVZIP-NEXT:    vslideup.vi v20, v21, 1
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v16, v18, 2
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v13, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 4
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v20, v22, 2
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v14, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v16, v20, 4
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v15, (a0)
+; ZVZIP-NEXT:    addi a1, a0, 16
+; ZVZIP-NEXT:    vle32.v v20, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v8, v16, 8
+; ZVZIP-NEXT:    addi a1, a0, 12
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v12, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 24
+; ZVZIP-NEXT:    vle32.v v16, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 20
+; ZVZIP-NEXT:    vle32.v v17, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v24, v15, 1
+; ZVZIP-NEXT:    addi a1, a0, 48
+; ZVZIP-NEXT:    vslideup.vi v14, v13, 1
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v15, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v17, v16, 1
+; ZVZIP-NEXT:    addi a1, a0, 32
+; ZVZIP-NEXT:    vslideup.vi v12, v20, 1
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v16, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v24, v14, 2
+; ZVZIP-NEXT:    addi a1, a0, 40
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v14, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v12, v17, 2
+; ZVZIP-NEXT:    addi a1, a0, 36
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v17, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v24, v12, 4
+; ZVZIP-NEXT:    addi a1, a0, 28
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v12, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 44
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v17, v14, 1
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v14, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v12, v16, 1
+; ZVZIP-NEXT:    addi a1, a0, 52
+; ZVZIP-NEXT:    vslideup.vi v14, v15, 1
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v13, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v12, v17, 2
+; ZVZIP-NEXT:    vslideup.vi v14, v13, 2
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v12, v14, 4
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v24, v12, 8
+; ZVZIP-NEXT:    addi a1, a0, 108
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v18, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 60
+; ZVZIP-NEXT:    vle32.v v17, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 56
+; ZVZIP-NEXT:    vle32.v v16, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 31, e32, m8, tu, ma
+; ZVZIP-NEXT:    vslideup.vi v8, v24, 15
+; ZVZIP-NEXT:    addi a1, a0, 68
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v19, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 64
+; ZVZIP-NEXT:    vle32.v v20, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 76
+; ZVZIP-NEXT:    vle32.v v21, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 84
+; ZVZIP-NEXT:    vle32.v v23, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 80
+; ZVZIP-NEXT:    vle32.v v24, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 72
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v20, v19, 1
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v22, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v16, v17, 1
+; ZVZIP-NEXT:    addi a1, a0, 92
+; ZVZIP-NEXT:    vslideup.vi v24, v23, 1
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v19, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v22, v21, 1
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v16, v20, 2
+; ZVZIP-NEXT:    addi a1, a0, 88
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v20, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v22, v24, 2
+; ZVZIP-NEXT:    addi a1, a0, 100
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v21, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v16, v22, 4
+; ZVZIP-NEXT:    addi a1, a0, 96
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v23, (a1)
+; ZVZIP-NEXT:    addi a1, a0, 104
+; ZVZIP-NEXT:    vle32.v v22, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v23, v21, 1
+; ZVZIP-NEXT:    vslideup.vi v20, v19, 1
+; ZVZIP-NEXT:    addi a0, a0, 112
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vle32.v v19, (a0)
+; ZVZIP-NEXT:    li a0, 32
+; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v22, v18, 1
+; ZVZIP-NEXT:    addi a1, sp, 128
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v20, v23, 2
+; ZVZIP-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; ZVZIP-NEXT:    vse32.v v8, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v22, v19, 2
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v20, v22, 4
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v16, v20, 8
+; ZVZIP-NEXT:    addi a2, sp, 248
+; ZVZIP-NEXT:    vse32.v v16, (a2)
+; ZVZIP-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; ZVZIP-NEXT:    vle32.v v24, (a1)
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
+; ZVZIP-NEXT:    vslidedown.vi v8, v24, 16
+; ZVZIP-NEXT:    vmv4r.v v16, v24
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
+; ZVZIP-NEXT:    vslidedown.vi v20, v24, 8
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v16, v20, 8
+; ZVZIP-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v16, v8, 16
+; ZVZIP-NEXT:    csrr a1, vlenb
+; ZVZIP-NEXT:    slli a1, a1, 3
+; ZVZIP-NEXT:    add a1, sp, a1
+; ZVZIP-NEXT:    addi a1, a1, 496
+; ZVZIP-NEXT:    vs8r.v v16, (a1)
+; ZVZIP-NEXT:    addi a2, sp, 256
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vle32.v v12, (a2)
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
+; ZVZIP-NEXT:    vslidedown.vi v16, v12, 8
+; ZVZIP-NEXT:    vslidedown.vi v8, v8, 8
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v8, v12, 8
+; ZVZIP-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v8, v16, 16
+; ZVZIP-NEXT:    addi a0, sp, 496
+; ZVZIP-NEXT:    vs8r.v v8, (a0)
+; ZVZIP-NEXT:    vsetvli a2, zero, e32, m2, ta, ma
+; ZVZIP-NEXT:    vlseg3e32.v v20, (a0)
+; ZVZIP-NEXT:    vlseg3e32.v v12, (a1)
+; ZVZIP-NEXT:    vmv4r.v v28, v20
+; ZVZIP-NEXT:    vmv2r.v v30, v8
+; ZVZIP-NEXT:    vmv4r.v v8, v12
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vslideup.vi v8, v28, 8
+; ZVZIP-NEXT:    vmv2r.v v20, v22
+; ZVZIP-NEXT:    vmv2r.v v12, v14
+; ZVZIP-NEXT:    vslideup.vi v16, v24, 8
+; ZVZIP-NEXT:    vslideup.vi v12, v20, 8
+; ZVZIP-NEXT:    addi sp, s0, -512
+; ZVZIP-NEXT:    ld ra, 504(sp) # 8-byte Folded Reload
+; ZVZIP-NEXT:    ld s0, 496(sp) # 8-byte Folded Reload
+; ZVZIP-NEXT:    addi sp, sp, 512
+; ZVZIP-NEXT:    ret
+  %d = call {<15 x i32>, <15 x i32>, <15 x i32>} @llvm.vector.deinterleave3(<45 x i32> %v)
+  ret {<15 x i32>, <15 x i32>, <15 x i32>} %d
+}
+
 define {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} @vector_deinterleave4_v2i32_v8i32(<8 x i32> %v) nounwind {
 ; CHECK-LABEL: vector_deinterleave4_v2i32_v8i32:
 ; CHECK:       # %bb.0:
@@ -1066,6 +1709,3 @@ define {<1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1
 	   %res = call {<1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>} @llvm.vector.deinterleave8.v8bf16(<8 x bfloat> %v)
 	   ret {<1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>} %res
 }
-;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
-; RV32: {{.*}}
-; RV64: {{.*}}

--- a/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
@@ -182,31 +182,20 @@ define {<8 x i64>, <8 x i64>} @vector_deinterleave_v8i64_v16i64(<16 x i64> %vec)
 define {<2 x i32>, <2 x i32>, <2 x i32>} @vector_deinterleave3_v2i32_v6i32(<6 x i32> %v) nounwind {
 ; CHECK-LABEL: vector_deinterleave3_v2i32_v6i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    addi a0, sp, 8
+; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v12, v8, 2
 ; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v10, v8, 4
-; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 2
-; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v10, 4
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a0, a0, 3
-; CHECK-NEXT:    vsetvli a1, zero, e32, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v10, v8, a0
-; CHECK-NEXT:    vslideup.vx v8, v10, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vse32.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vse32.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse32.v v10, (a1)
 ; CHECK-NEXT:    vlseg3e32.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x i32>, <2 x i32>, <2 x i32>} @llvm.vector.deinterleave3.v6i32(<6 x i32> %v)
 	   ret {<2 x i32>, <2 x i32>, <2 x i32>} %res
@@ -215,27 +204,20 @@ define {<2 x i32>, <2 x i32>, <2 x i32>} @vector_deinterleave3_v2i32_v6i32(<6 x 
 define {<3 x i32>, <3 x i32>, <3 x i32>} @vector_deinterleave3_v3i32_v9i32(<9 x i32> %v) nounwind {
 ; CHECK-LABEL: vector_deinterleave3_v3i32_v9i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 2
-; CHECK-NEXT:    sub sp, sp, a0
+; CHECK-NEXT:    addi sp, sp, -48
 ; CHECK-NEXT:    vsetivli zero, 4, e32, m4, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v12, v8, 8
-; CHECK-NEXT:    vmv2r.v v16, v8
 ; CHECK-NEXT:    vsetivli zero, 4, e32, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v8, v8, 4
-; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; CHECK-NEXT:    vslideup.vi v16, v8, 4
-; CHECK-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; CHECK-NEXT:    vslideup.vi v16, v12, 8
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs4r.v v16, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e32, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 4
+; CHECK-NEXT:    mv a0, sp
+; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; CHECK-NEXT:    vse32.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vse32.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 32
+; CHECK-NEXT:    vse32.v v12, (a1)
 ; CHECK-NEXT:    vlseg3e32.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 2
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 48
 ; CHECK-NEXT:    ret
   %d = call {<3 x i32>, <3 x i32>, <3 x i32>} @llvm.vector.deinterleave3(<9 x i32> %v)
   ret {<3 x i32>, <3 x i32>, <3 x i32>} %d
@@ -244,88 +226,83 @@ define {<3 x i32>, <3 x i32>, <3 x i32>} @vector_deinterleave3_v3i32_v9i32(<9 x 
 define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(<45 x i32> %v) nounwind {
 ; RV32-LABEL: vector_deinterleave3_v15i32_v45i32:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -528
-; RV32-NEXT:    sw ra, 524(sp) # 4-byte Folded Spill
-; RV32-NEXT:    sw s0, 520(sp) # 4-byte Folded Spill
-; RV32-NEXT:    addi s0, sp, 528
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 4
-; RV32-NEXT:    sub sp, sp, a1
+; RV32-NEXT:    addi sp, sp, -640
+; RV32-NEXT:    sw ra, 636(sp) # 4-byte Folded Spill
+; RV32-NEXT:    sw s0, 632(sp) # 4-byte Folded Spill
+; RV32-NEXT:    addi s0, sp, 640
 ; RV32-NEXT:    andi sp, sp, -128
-; RV32-NEXT:    addi a1, sp, 124
+; RV32-NEXT:    addi a1, sp, 252
 ; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
 ; RV32-NEXT:    vse32.v v23, (a1)
-; RV32-NEXT:    addi a1, sp, 120
+; RV32-NEXT:    addi a1, sp, 248
 ; RV32-NEXT:    vse32.v v22, (a1)
-; RV32-NEXT:    addi a1, sp, 116
+; RV32-NEXT:    addi a1, sp, 244
 ; RV32-NEXT:    vse32.v v21, (a1)
-; RV32-NEXT:    addi a1, sp, 112
+; RV32-NEXT:    addi a1, sp, 240
 ; RV32-NEXT:    vse32.v v20, (a1)
-; RV32-NEXT:    addi a1, sp, 108
+; RV32-NEXT:    addi a1, sp, 236
 ; RV32-NEXT:    vse32.v v19, (a1)
-; RV32-NEXT:    addi a1, sp, 104
+; RV32-NEXT:    addi a1, sp, 232
 ; RV32-NEXT:    vse32.v v18, (a1)
-; RV32-NEXT:    addi a1, sp, 100
+; RV32-NEXT:    addi a1, sp, 228
 ; RV32-NEXT:    vse32.v v17, (a1)
-; RV32-NEXT:    addi a1, sp, 96
+; RV32-NEXT:    addi a1, sp, 224
 ; RV32-NEXT:    vse32.v v16, (a1)
-; RV32-NEXT:    addi a1, sp, 92
+; RV32-NEXT:    addi a1, sp, 220
 ; RV32-NEXT:    vse32.v v15, (a1)
-; RV32-NEXT:    addi a1, sp, 88
+; RV32-NEXT:    addi a1, sp, 216
 ; RV32-NEXT:    vse32.v v14, (a1)
-; RV32-NEXT:    addi a1, sp, 84
+; RV32-NEXT:    addi a1, sp, 212
 ; RV32-NEXT:    vse32.v v13, (a1)
-; RV32-NEXT:    addi a1, sp, 80
+; RV32-NEXT:    addi a1, sp, 208
 ; RV32-NEXT:    vse32.v v12, (a1)
-; RV32-NEXT:    addi a1, sp, 76
+; RV32-NEXT:    addi a1, sp, 204
 ; RV32-NEXT:    vse32.v v11, (a1)
-; RV32-NEXT:    addi a1, sp, 72
+; RV32-NEXT:    addi a1, sp, 200
 ; RV32-NEXT:    vse32.v v10, (a1)
-; RV32-NEXT:    addi a1, sp, 68
+; RV32-NEXT:    addi a1, sp, 196
 ; RV32-NEXT:    vse32.v v9, (a1)
-; RV32-NEXT:    addi a1, sp, 64
+; RV32-NEXT:    addi a1, sp, 192
 ; RV32-NEXT:    vse32.v v8, (a1)
-; RV32-NEXT:    addi a2, a0, 64
+; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV32-NEXT:    vle32.v v12, (a1)
+; RV32-NEXT:    mv a1, sp
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV32-NEXT:    vse32.v v12, (a1)
+; RV32-NEXT:    addi a2, a0, 64
 ; RV32-NEXT:    vle32.v v8, (a2)
-; RV32-NEXT:    addi a2, sp, 256
+; RV32-NEXT:    addi a2, sp, 384
 ; RV32-NEXT:    vse32.v v8, (a2)
 ; RV32-NEXT:    addi a3, a0, 96
 ; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; RV32-NEXT:    vle32.v v8, (a3)
-; RV32-NEXT:    addi a3, sp, 288
+; RV32-NEXT:    addi a3, sp, 416
 ; RV32-NEXT:    vse32.v v8, (a3)
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV32-NEXT:    vle32.v v16, (a1)
-; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v16, 8
-; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV32-NEXT:    vslideup.vi v16, v8, 8
 ; RV32-NEXT:    vle32.v v8, (a0)
-; RV32-NEXT:    li a1, 32
-; RV32-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; RV32-NEXT:    vslideup.vi v16, v8, 16
-; RV32-NEXT:    csrr a3, vlenb
-; RV32-NEXT:    slli a3, a3, 3
-; RV32-NEXT:    add a3, sp, a3
-; RV32-NEXT:    addi a3, a3, 512
-; RV32-NEXT:    vs8r.v v16, (a3)
+; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
+; RV32-NEXT:    vslidedown.vi v16, v8, 8
+; RV32-NEXT:    vslidedown.vi v12, v12, 8
+; RV32-NEXT:    addi a3, sp, 96
+; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV32-NEXT:    vse32.v v16, (a3)
+; RV32-NEXT:    addi a4, sp, 32
+; RV32-NEXT:    vse32.v v12, (a4)
 ; RV32-NEXT:    lw a0, 112(a0)
-; RV32-NEXT:    sw a0, 304(sp)
+; RV32-NEXT:    sw a0, 432(sp)
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV32-NEXT:    vle32.v v12, (a2)
+; RV32-NEXT:    addi a0, sp, 128
 ; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
 ; RV32-NEXT:    vslidedown.vi v16, v12, 8
-; RV32-NEXT:    vslidedown.vi v8, v8, 8
-; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV32-NEXT:    vslideup.vi v8, v12, 8
-; RV32-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
-; RV32-NEXT:    vslideup.vi v8, v16, 16
-; RV32-NEXT:    addi a0, sp, 512
-; RV32-NEXT:    vs8r.v v8, (a0)
-; RV32-NEXT:    vsetvli a1, zero, e32, m2, ta, ma
-; RV32-NEXT:    vlseg3e32.v v20, (a0)
-; RV32-NEXT:    vlseg3e32.v v12, (a3)
+; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV32-NEXT:    vse32.v v12, (a0)
+; RV32-NEXT:    addi a0, sp, 64
+; RV32-NEXT:    vse32.v v8, (a0)
+; RV32-NEXT:    addi a0, sp, 160
+; RV32-NEXT:    vse32.v v16, (a0)
+; RV32-NEXT:    vlseg3e32.v v20, (a3)
+; RV32-NEXT:    vlseg3e32.v v12, (a1)
 ; RV32-NEXT:    vmv4r.v v28, v20
 ; RV32-NEXT:    vmv2r.v v30, v8
 ; RV32-NEXT:    vmv4r.v v8, v12
@@ -335,97 +312,92 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV32-NEXT:    vmv2r.v v20, v22
 ; RV32-NEXT:    vslideup.vi v12, v20, 8
 ; RV32-NEXT:    vslideup.vi v16, v24, 8
-; RV32-NEXT:    addi sp, s0, -528
-; RV32-NEXT:    lw ra, 524(sp) # 4-byte Folded Reload
-; RV32-NEXT:    lw s0, 520(sp) # 4-byte Folded Reload
-; RV32-NEXT:    addi sp, sp, 528
+; RV32-NEXT:    addi sp, s0, -640
+; RV32-NEXT:    lw ra, 636(sp) # 4-byte Folded Reload
+; RV32-NEXT:    lw s0, 632(sp) # 4-byte Folded Reload
+; RV32-NEXT:    addi sp, sp, 640
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: vector_deinterleave3_v15i32_v45i32:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    addi sp, sp, -512
-; RV64-NEXT:    sd ra, 504(sp) # 8-byte Folded Spill
-; RV64-NEXT:    sd s0, 496(sp) # 8-byte Folded Spill
-; RV64-NEXT:    addi s0, sp, 512
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 4
-; RV64-NEXT:    sub sp, sp, a1
+; RV64-NEXT:    addi sp, sp, -640
+; RV64-NEXT:    sd ra, 632(sp) # 8-byte Folded Spill
+; RV64-NEXT:    sd s0, 624(sp) # 8-byte Folded Spill
+; RV64-NEXT:    addi s0, sp, 640
 ; RV64-NEXT:    andi sp, sp, -128
 ; RV64-NEXT:    addi a1, a0, 112
 ; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
 ; RV64-NEXT:    vle32.v v24, (a1)
-; RV64-NEXT:    addi a1, sp, 124
+; RV64-NEXT:    addi a1, sp, 252
 ; RV64-NEXT:    vse32.v v23, (a1)
-; RV64-NEXT:    addi a1, sp, 120
+; RV64-NEXT:    addi a1, sp, 248
 ; RV64-NEXT:    vse32.v v22, (a1)
-; RV64-NEXT:    addi a1, sp, 116
+; RV64-NEXT:    addi a1, sp, 244
 ; RV64-NEXT:    vse32.v v21, (a1)
-; RV64-NEXT:    addi a1, sp, 112
+; RV64-NEXT:    addi a1, sp, 240
 ; RV64-NEXT:    vse32.v v20, (a1)
-; RV64-NEXT:    addi a1, sp, 108
+; RV64-NEXT:    addi a1, sp, 236
 ; RV64-NEXT:    vse32.v v19, (a1)
-; RV64-NEXT:    addi a1, sp, 104
+; RV64-NEXT:    addi a1, sp, 232
 ; RV64-NEXT:    vse32.v v18, (a1)
-; RV64-NEXT:    addi a1, sp, 100
+; RV64-NEXT:    addi a1, sp, 228
 ; RV64-NEXT:    vse32.v v17, (a1)
-; RV64-NEXT:    addi a1, sp, 96
+; RV64-NEXT:    addi a1, sp, 224
 ; RV64-NEXT:    vse32.v v16, (a1)
-; RV64-NEXT:    addi a1, sp, 92
+; RV64-NEXT:    addi a1, sp, 220
 ; RV64-NEXT:    vse32.v v15, (a1)
-; RV64-NEXT:    addi a1, sp, 88
+; RV64-NEXT:    addi a1, sp, 216
 ; RV64-NEXT:    vse32.v v14, (a1)
-; RV64-NEXT:    addi a1, sp, 84
+; RV64-NEXT:    addi a1, sp, 212
 ; RV64-NEXT:    vse32.v v13, (a1)
-; RV64-NEXT:    addi a1, sp, 80
+; RV64-NEXT:    addi a1, sp, 208
 ; RV64-NEXT:    vse32.v v12, (a1)
-; RV64-NEXT:    addi a1, sp, 76
+; RV64-NEXT:    addi a1, sp, 204
 ; RV64-NEXT:    vse32.v v11, (a1)
-; RV64-NEXT:    addi a1, sp, 72
+; RV64-NEXT:    addi a1, sp, 200
 ; RV64-NEXT:    vse32.v v10, (a1)
-; RV64-NEXT:    addi a1, sp, 68
+; RV64-NEXT:    addi a1, sp, 196
 ; RV64-NEXT:    vse32.v v9, (a1)
-; RV64-NEXT:    addi a1, sp, 64
+; RV64-NEXT:    addi a1, sp, 192
 ; RV64-NEXT:    vse32.v v8, (a1)
-; RV64-NEXT:    addi a2, a0, 64
+; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV64-NEXT:    vle32.v v12, (a1)
+; RV64-NEXT:    mv a1, sp
 ; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV64-NEXT:    vse32.v v12, (a1)
+; RV64-NEXT:    addi a2, a0, 64
 ; RV64-NEXT:    vle32.v v8, (a2)
-; RV64-NEXT:    addi a2, sp, 256
+; RV64-NEXT:    addi a2, sp, 384
 ; RV64-NEXT:    vse32.v v8, (a2)
 ; RV64-NEXT:    addi a3, a0, 96
 ; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; RV64-NEXT:    vle32.v v8, (a3)
-; RV64-NEXT:    addi a3, sp, 288
+; RV64-NEXT:    addi a3, sp, 416
 ; RV64-NEXT:    vse32.v v8, (a3)
-; RV64-NEXT:    addi a3, sp, 304
+; RV64-NEXT:    addi a3, sp, 432
 ; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
 ; RV64-NEXT:    vse32.v v24, (a3)
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vle32.v v8, (a1)
+; RV64-NEXT:    vle32.v v8, (a0)
 ; RV64-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; RV64-NEXT:    vslidedown.vi v12, v8, 8
-; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vslideup.vi v8, v12, 8
-; RV64-NEXT:    vle32.v v16, (a0)
-; RV64-NEXT:    li a0, 32
-; RV64-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; RV64-NEXT:    vslideup.vi v8, v16, 16
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    slli a1, a1, 3
-; RV64-NEXT:    add a1, sp, a1
-; RV64-NEXT:    addi a1, a1, 496
-; RV64-NEXT:    vs8r.v v8, (a1)
+; RV64-NEXT:    vslidedown.vi v16, v8, 8
+; RV64-NEXT:    vslidedown.vi v12, v12, 8
+; RV64-NEXT:    addi a0, sp, 96
+; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV64-NEXT:    vse32.v v16, (a0)
+; RV64-NEXT:    addi a3, sp, 32
+; RV64-NEXT:    vse32.v v12, (a3)
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV64-NEXT:    vle32.v v12, (a2)
+; RV64-NEXT:    addi a2, sp, 128
 ; RV64-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; RV64-NEXT:    vslidedown.vi v24, v12, 8
-; RV64-NEXT:    vslidedown.vi v8, v16, 8
-; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vslideup.vi v8, v12, 8
-; RV64-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; RV64-NEXT:    vslideup.vi v8, v24, 16
-; RV64-NEXT:    addi a0, sp, 496
-; RV64-NEXT:    vs8r.v v8, (a0)
-; RV64-NEXT:    vsetvli a2, zero, e32, m2, ta, ma
+; RV64-NEXT:    vslidedown.vi v16, v12, 8
+; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; RV64-NEXT:    vse32.v v12, (a2)
+; RV64-NEXT:    addi a2, sp, 64
+; RV64-NEXT:    vse32.v v8, (a2)
+; RV64-NEXT:    addi a2, sp, 160
+; RV64-NEXT:    vse32.v v16, (a2)
 ; RV64-NEXT:    vlseg3e32.v v20, (a0)
 ; RV64-NEXT:    vlseg3e32.v v12, (a1)
 ; RV64-NEXT:    vmv4r.v v28, v20
@@ -437,97 +409,92 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV64-NEXT:    vmv2r.v v20, v22
 ; RV64-NEXT:    vslideup.vi v12, v20, 8
 ; RV64-NEXT:    vslideup.vi v16, v24, 8
-; RV64-NEXT:    addi sp, s0, -512
-; RV64-NEXT:    ld ra, 504(sp) # 8-byte Folded Reload
-; RV64-NEXT:    ld s0, 496(sp) # 8-byte Folded Reload
-; RV64-NEXT:    addi sp, sp, 512
+; RV64-NEXT:    addi sp, s0, -640
+; RV64-NEXT:    ld ra, 632(sp) # 8-byte Folded Reload
+; RV64-NEXT:    ld s0, 624(sp) # 8-byte Folded Reload
+; RV64-NEXT:    addi sp, sp, 640
 ; RV64-NEXT:    ret
 ;
 ; ZVZIP-LABEL: vector_deinterleave3_v15i32_v45i32:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    addi sp, sp, -512
-; ZVZIP-NEXT:    sd ra, 504(sp) # 8-byte Folded Spill
-; ZVZIP-NEXT:    sd s0, 496(sp) # 8-byte Folded Spill
-; ZVZIP-NEXT:    addi s0, sp, 512
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    slli a1, a1, 4
-; ZVZIP-NEXT:    sub sp, sp, a1
+; ZVZIP-NEXT:    addi sp, sp, -640
+; ZVZIP-NEXT:    sd ra, 632(sp) # 8-byte Folded Spill
+; ZVZIP-NEXT:    sd s0, 624(sp) # 8-byte Folded Spill
+; ZVZIP-NEXT:    addi s0, sp, 640
 ; ZVZIP-NEXT:    andi sp, sp, -128
 ; ZVZIP-NEXT:    addi a1, a0, 112
 ; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
 ; ZVZIP-NEXT:    vle32.v v24, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 124
+; ZVZIP-NEXT:    addi a1, sp, 252
 ; ZVZIP-NEXT:    vse32.v v23, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 120
+; ZVZIP-NEXT:    addi a1, sp, 248
 ; ZVZIP-NEXT:    vse32.v v22, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 116
+; ZVZIP-NEXT:    addi a1, sp, 244
 ; ZVZIP-NEXT:    vse32.v v21, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 112
+; ZVZIP-NEXT:    addi a1, sp, 240
 ; ZVZIP-NEXT:    vse32.v v20, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 108
+; ZVZIP-NEXT:    addi a1, sp, 236
 ; ZVZIP-NEXT:    vse32.v v19, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 104
+; ZVZIP-NEXT:    addi a1, sp, 232
 ; ZVZIP-NEXT:    vse32.v v18, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 100
+; ZVZIP-NEXT:    addi a1, sp, 228
 ; ZVZIP-NEXT:    vse32.v v17, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 96
+; ZVZIP-NEXT:    addi a1, sp, 224
 ; ZVZIP-NEXT:    vse32.v v16, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 92
+; ZVZIP-NEXT:    addi a1, sp, 220
 ; ZVZIP-NEXT:    vse32.v v15, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 88
+; ZVZIP-NEXT:    addi a1, sp, 216
 ; ZVZIP-NEXT:    vse32.v v14, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 84
+; ZVZIP-NEXT:    addi a1, sp, 212
 ; ZVZIP-NEXT:    vse32.v v13, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 80
+; ZVZIP-NEXT:    addi a1, sp, 208
 ; ZVZIP-NEXT:    vse32.v v12, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 76
+; ZVZIP-NEXT:    addi a1, sp, 204
 ; ZVZIP-NEXT:    vse32.v v11, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 72
+; ZVZIP-NEXT:    addi a1, sp, 200
 ; ZVZIP-NEXT:    vse32.v v10, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 68
+; ZVZIP-NEXT:    addi a1, sp, 196
 ; ZVZIP-NEXT:    vse32.v v9, (a1)
-; ZVZIP-NEXT:    addi a1, sp, 64
+; ZVZIP-NEXT:    addi a1, sp, 192
 ; ZVZIP-NEXT:    vse32.v v8, (a1)
-; ZVZIP-NEXT:    addi a2, a0, 64
+; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; ZVZIP-NEXT:    vle32.v v12, (a1)
+; ZVZIP-NEXT:    mv a1, sp
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vse32.v v12, (a1)
+; ZVZIP-NEXT:    addi a2, a0, 64
 ; ZVZIP-NEXT:    vle32.v v8, (a2)
-; ZVZIP-NEXT:    addi a2, sp, 256
+; ZVZIP-NEXT:    addi a2, sp, 384
 ; ZVZIP-NEXT:    vse32.v v8, (a2)
 ; ZVZIP-NEXT:    addi a3, a0, 96
 ; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; ZVZIP-NEXT:    vle32.v v8, (a3)
-; ZVZIP-NEXT:    addi a3, sp, 288
+; ZVZIP-NEXT:    addi a3, sp, 416
 ; ZVZIP-NEXT:    vse32.v v8, (a3)
-; ZVZIP-NEXT:    addi a3, sp, 304
+; ZVZIP-NEXT:    addi a3, sp, 432
 ; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
 ; ZVZIP-NEXT:    vse32.v v24, (a3)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vle32.v v8, (a1)
+; ZVZIP-NEXT:    vle32.v v8, (a0)
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v12, v8, 8
-; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v8, v12, 8
-; ZVZIP-NEXT:    vle32.v v16, (a0)
-; ZVZIP-NEXT:    li a0, 32
-; ZVZIP-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v8, v16, 16
-; ZVZIP-NEXT:    csrr a1, vlenb
-; ZVZIP-NEXT:    slli a1, a1, 3
-; ZVZIP-NEXT:    add a1, sp, a1
-; ZVZIP-NEXT:    addi a1, a1, 496
-; ZVZIP-NEXT:    vs8r.v v8, (a1)
+; ZVZIP-NEXT:    vslidedown.vi v16, v8, 8
+; ZVZIP-NEXT:    vslidedown.vi v12, v12, 8
+; ZVZIP-NEXT:    addi a0, sp, 96
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vse32.v v16, (a0)
+; ZVZIP-NEXT:    addi a3, sp, 32
+; ZVZIP-NEXT:    vse32.v v12, (a3)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; ZVZIP-NEXT:    vle32.v v12, (a2)
+; ZVZIP-NEXT:    addi a2, sp, 128
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v24, v12, 8
-; ZVZIP-NEXT:    vslidedown.vi v8, v16, 8
-; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v8, v12, 8
-; ZVZIP-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v8, v24, 16
-; ZVZIP-NEXT:    addi a0, sp, 496
-; ZVZIP-NEXT:    vs8r.v v8, (a0)
-; ZVZIP-NEXT:    vsetvli a2, zero, e32, m2, ta, ma
+; ZVZIP-NEXT:    vslidedown.vi v16, v12, 8
+; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
+; ZVZIP-NEXT:    vse32.v v12, (a2)
+; ZVZIP-NEXT:    addi a2, sp, 64
+; ZVZIP-NEXT:    vse32.v v8, (a2)
+; ZVZIP-NEXT:    addi a2, sp, 160
+; ZVZIP-NEXT:    vse32.v v16, (a2)
 ; ZVZIP-NEXT:    vlseg3e32.v v20, (a0)
 ; ZVZIP-NEXT:    vlseg3e32.v v12, (a1)
 ; ZVZIP-NEXT:    vmv4r.v v28, v20
@@ -539,10 +506,10 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; ZVZIP-NEXT:    vmv2r.v v20, v22
 ; ZVZIP-NEXT:    vslideup.vi v12, v20, 8
 ; ZVZIP-NEXT:    vslideup.vi v16, v24, 8
-; ZVZIP-NEXT:    addi sp, s0, -512
-; ZVZIP-NEXT:    ld ra, 504(sp) # 8-byte Folded Reload
-; ZVZIP-NEXT:    ld s0, 496(sp) # 8-byte Folded Reload
-; ZVZIP-NEXT:    addi sp, sp, 512
+; ZVZIP-NEXT:    addi sp, s0, -640
+; ZVZIP-NEXT:    ld ra, 632(sp) # 8-byte Folded Reload
+; ZVZIP-NEXT:    ld s0, 624(sp) # 8-byte Folded Reload
+; ZVZIP-NEXT:    addi sp, sp, 640
 ; ZVZIP-NEXT:    ret
   %d = call {<15 x i32>, <15 x i32>, <15 x i32>} @llvm.vector.deinterleave3(<45 x i32> %v)
   ret {<15 x i32>, <15 x i32>, <15 x i32>} %d
@@ -551,18 +518,25 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 define {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} @vector_deinterleave4_v2i32_v8i32(<8 x i32> %v) nounwind {
 ; CHECK-LABEL: vector_deinterleave4_v2i32_v8i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 4
+; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v11, v8, 2
+; CHECK-NEXT:    mv a0, sp
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vse32.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 6
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vse32.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vse32.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse32.v v8, (a1)
 ; CHECK-NEXT:    vlseg4e32.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} @llvm.vector.deinterleave4.v8i32(<8 x i32> %v)
 	   ret {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} %res
@@ -571,44 +545,29 @@ define {<2 x i32>, <2 x i32>, <2 x i32>, <2 x i32>} @vector_deinterleave4_v2i32_
 define {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} @vector_deinterleave5_v2i16_v10i16(<10 x i16> %v) nounwind {
 ; CHECK-LABEL: vector_deinterleave5_v2i16_v10i16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 8
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    addi a0, sp, 12
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 6
-; CHECK-NEXT:    vslidedown.vi v12, v8, 4
-; CHECK-NEXT:    vslidedown.vi v13, v8, 2
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v12, v9, 2
-; CHECK-NEXT:    vslideup.vi v8, v13, 2
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v12, 4
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v10, 8
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v10, v8, a2
-; CHECK-NEXT:    vslidedown.vx v11, v8, a0
-; CHECK-NEXT:    vslidedown.vx v12, v8, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v10, a1
-; CHECK-NEXT:    vslideup.vx v8, v12, a1
-; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 2
+; CHECK-NEXT:    vslidedown.vi v11, v8, 4
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v12, v8, 6
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 8
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse16.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg5e16.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} @llvm.vector.deinterleave5.v10i16(<10 x i16> %v)
 	   ret {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} %res
@@ -617,50 +576,33 @@ define {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} @vector_deinterle
 define {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} @vector_deinterleave6_v2i16_v12i16(<12 x i16> %v) nounwind {
 ; CHECK-LABEL: vector_deinterleave6_v2i16_v12i16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    csrr a0, vlenb
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    addi a0, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 10
-; CHECK-NEXT:    vslidedown.vi v12, v8, 8
+; CHECK-NEXT:    vslidedown.vi v10, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 6
-; CHECK-NEXT:    vslidedown.vi v11, v8, 4
-; CHECK-NEXT:    vslidedown.vi v13, v8, 2
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v11, v9, 2
-; CHECK-NEXT:    vslideup.vi v8, v13, 2
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v11, 4
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v12, v10, 2
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v12, 8
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v10, v8, a2
-; CHECK-NEXT:    vslidedown.vx v11, v8, a0
-; CHECK-NEXT:    vslidedown.vx v12, v8, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v10, a1
-; CHECK-NEXT:    vslideup.vx v8, v12, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    vslidedown.vx v10, v9, a1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v9, v10, a1
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    vslidedown.vi v11, v8, 2
+; CHECK-NEXT:    vslidedown.vi v12, v8, 4
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v11, v8, 6
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 10
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg6e16.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} @llvm.vector.deinterleave6.v12i16(<12 x i16> %v)
 	   ret {<2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>, <2 x i16>} %res
@@ -670,57 +612,35 @@ define {<2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>} @v
 ; CHECK-LABEL: vector_deinterleave7_v14i8_v2i8:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    csrr a0, vlenb
+; CHECK-NEXT:    addi a0, sp, 2
 ; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 10
-; CHECK-NEXT:    vslidedown.vi v10, v8, 8
-; CHECK-NEXT:    vslidedown.vi v11, v8, 12
-; CHECK-NEXT:    vslidedown.vi v12, v8, 2
-; CHECK-NEXT:    vslidedown.vi v13, v8, 4
-; CHECK-NEXT:    vmv1r.v v14, v8
-; CHECK-NEXT:    vslidedown.vi v8, v8, 6
-; CHECK-NEXT:    vsetivli zero, 4, e8, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vi v14, v12, 2
-; CHECK-NEXT:    vslideup.vi v10, v9, 2
-; CHECK-NEXT:    vsetivli zero, 6, e8, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vi v14, v13, 4
-; CHECK-NEXT:    vslideup.vi v10, v11, 4
-; CHECK-NEXT:    vsetivli zero, 8, e8, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v14, v8, 6
-; CHECK-NEXT:    vsetivli zero, 16, e8, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v14, v10, 8
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    srli a2, a0, 1
-; CHECK-NEXT:    add a3, a2, a1
-; CHECK-NEXT:    vsetvli a4, zero, e8, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v8, v14, a3
-; CHECK-NEXT:    vslidedown.vx v9, v14, a2
-; CHECK-NEXT:    srli a3, a0, 2
-; CHECK-NEXT:    sub a0, a0, a3
-; CHECK-NEXT:    vslidedown.vx v10, v14, a0
-; CHECK-NEXT:    vslidedown.vx v11, v14, a1
-; CHECK-NEXT:    vslidedown.vx v12, v14, a3
-; CHECK-NEXT:    add a0, a3, a1
-; CHECK-NEXT:    vmv1r.v v13, v14
-; CHECK-NEXT:    vslidedown.vx v14, v14, a0
-; CHECK-NEXT:    vsetvli zero, a3, e8, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vx v13, v11, a1
-; CHECK-NEXT:    vslideup.vx v9, v8, a1
-; CHECK-NEXT:    vsetvli zero, a0, e8, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vx v13, v12, a3
-; CHECK-NEXT:    vslideup.vx v9, v10, a3
-; CHECK-NEXT:    vsetvli a1, zero, e8, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v13, v14, a0
-; CHECK-NEXT:    vsetvli a0, zero, e8, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v13, v9, a2
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs1r.v v13, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 2
+; CHECK-NEXT:    vslidedown.vi v10, v8, 4
+; CHECK-NEXT:    vslidedown.vi v11, v8, 6
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vse8.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    vse8.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 8
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vse8.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 10
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vse8.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vse8.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 12
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vse8.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    vse8.v v8, (a1)
 ; CHECK-NEXT:    vlseg7e8.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add sp, sp, a0
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>} @llvm.vector.deinterleave7.v14i8(<14 x i8> %v)
@@ -731,14 +651,40 @@ define {<2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2
 ; CHECK-LABEL: vector_deinterleave8_v16i8_v2i8:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs1r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e8, mf8, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 2
+; CHECK-NEXT:    vslidedown.vi v10, v8, 4
+; CHECK-NEXT:    vslidedown.vi v11, v8, 6
+; CHECK-NEXT:    mv a0, sp
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vse8.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 2
+; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v12, v8, 8
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vse8.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    vse8.v v10, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 10
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vse8.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 12
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vse8.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vse8.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e8, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 14
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vsetivli zero, 2, e8, mf8, ta, ma
+; CHECK-NEXT:    vse8.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    vse8.v v8, (a1)
 ; CHECK-NEXT:    vlseg8e8.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    add sp, sp, a0
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>, <2 x i8>} @llvm.vector.deinterleave8.v16i8(<16 x i8> %v)
@@ -920,34 +866,21 @@ ret {<4 x double>, <4 x double>} %retval
 define {<2 x float>, <2 x float>, <2 x float>} @vector_deinterleave3_v6f32_v2f32(<6 x float> %v) {
 ; CHECK-LABEL: vector_deinterleave3_v6f32_v2f32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NEXT:    addi a0, sp, 8
+; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v12, v8, 2
 ; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
 ; CHECK-NEXT:    vslidedown.vi v10, v8, 4
-; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 2
-; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v9, 2
-; CHECK-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v10, 4
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a0, a0, 3
-; CHECK-NEXT:    vsetvli a1, zero, e32, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v10, v8, a0
-; CHECK-NEXT:    vslideup.vx v8, v10, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vse32.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vse32.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse32.v v10, (a1)
 ; CHECK-NEXT:    vlseg3e32.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    .cfi_def_cfa sp, 16
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x float>, <2 x float>, <2 x float>} @llvm.vector.deinterleave3.v6f32(<6 x float> %v)
@@ -957,21 +890,26 @@ define {<2 x float>, <2 x float>, <2 x float>} @vector_deinterleave3_v6f32_v2f32
 define {<2 x float>, <2 x float>, <2 x float>, <2 x float>} @vector_deinterleave4_v8f32_v2f32(<8 x float> %v) {
 ; CHECK-LABEL: vector_deinterleave4_v8f32_v2f32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e32, mf2, ta, ma
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 4
+; CHECK-NEXT:    vsetivli zero, 2, e32, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v11, v8, 2
+; CHECK-NEXT:    mv a0, sp
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vse32.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vsetivli zero, 2, e32, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 6
+; CHECK-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
+; CHECK-NEXT:    vse32.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vse32.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse32.v v8, (a1)
 ; CHECK-NEXT:    vlseg4e32.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    .cfi_def_cfa sp, 16
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x float>, <2 x float>, <2 x float>, <2 x float>} @llvm.vector.deinterleave4.v8f32(<8 x float> %v)
@@ -981,47 +919,30 @@ define {<2 x float>, <2 x float>, <2 x float>, <2 x float>} @vector_deinterleave
 define {<2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>} @vector_deinterleave5_v10f16_v2f16(<10 x half> %v) {
 ; CHECK-LABEL: vector_deinterleave5_v10f16_v2f16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 8
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NEXT:    addi a0, sp, 12
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 6
-; CHECK-NEXT:    vslidedown.vi v12, v8, 4
-; CHECK-NEXT:    vslidedown.vi v13, v8, 2
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v12, v9, 2
-; CHECK-NEXT:    vslideup.vi v8, v13, 2
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v12, 4
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v10, 8
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v10, v8, a2
-; CHECK-NEXT:    vslidedown.vx v11, v8, a0
-; CHECK-NEXT:    vslidedown.vx v12, v8, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v10, a1
-; CHECK-NEXT:    vslideup.vx v8, v12, a1
-; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 2
+; CHECK-NEXT:    vslidedown.vi v11, v8, 4
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v12, v8, 6
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 8
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse16.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg5e16.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    .cfi_def_cfa sp, 16
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>} @llvm.vector.deinterleave5.v10f16(<10 x half> %v)
@@ -1031,47 +952,30 @@ define {<2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>} @vector_dein
 define {<2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>} @vector_deinterleave5_v10bf16_v2bf16(<10 x bfloat> %v) {
 ; CHECK-LABEL: vector_deinterleave5_v10bf16_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 8
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NEXT:    addi a0, sp, 12
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 6
-; CHECK-NEXT:    vslidedown.vi v12, v8, 4
-; CHECK-NEXT:    vslidedown.vi v13, v8, 2
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v12, v9, 2
-; CHECK-NEXT:    vslideup.vi v8, v13, 2
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v12, 4
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v10, 8
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v10, v8, a2
-; CHECK-NEXT:    vslidedown.vx v11, v8, a0
-; CHECK-NEXT:    vslidedown.vx v12, v8, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v10, a1
-; CHECK-NEXT:    vslideup.vx v8, v12, a1
-; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 2
+; CHECK-NEXT:    vslidedown.vi v11, v8, 4
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v12, v8, 6
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 8
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse16.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg5e16.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    .cfi_def_cfa sp, 16
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>} @llvm.vector.deinterleave5.v10bf16(<10 x bfloat> %v)
@@ -1081,53 +985,34 @@ define {<2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>} @v
 define {<2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>} @vector_deinterleave6_v12f16_v2f16(<12 x half> %v) {
 ; CHECK-LABEL: vector_deinterleave6_v12f16_v2f16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
-; CHECK-NEXT:    csrr a0, vlenb
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NEXT:    addi a0, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 10
-; CHECK-NEXT:    vslidedown.vi v12, v8, 8
+; CHECK-NEXT:    vslidedown.vi v10, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 6
-; CHECK-NEXT:    vslidedown.vi v11, v8, 4
-; CHECK-NEXT:    vslidedown.vi v13, v8, 2
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v11, v9, 2
-; CHECK-NEXT:    vslideup.vi v8, v13, 2
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v11, 4
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v12, v10, 2
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v12, 8
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v10, v8, a2
-; CHECK-NEXT:    vslidedown.vx v11, v8, a0
-; CHECK-NEXT:    vslidedown.vx v12, v8, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v10, a1
-; CHECK-NEXT:    vslideup.vx v8, v12, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    vslidedown.vx v10, v9, a1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v9, v10, a1
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    vslidedown.vi v11, v8, 2
+; CHECK-NEXT:    vslidedown.vi v12, v8, 4
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v11, v8, 6
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 10
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg6e16.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    .cfi_def_cfa sp, 16
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>} @llvm.vector.deinterleave6.v12f16(<12 x half> %v)
@@ -1137,53 +1022,34 @@ define {<2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>} 
 define {<2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>} @vector_deinterleave6_v12bf16_v2bf16(<12 x bfloat> %v) {
 ; CHECK-LABEL: vector_deinterleave6_v12bf16_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
-; CHECK-NEXT:    csrr a0, vlenb
+; CHECK-NEXT:    addi sp, sp, -32
+; CHECK-NEXT:    .cfi_def_cfa_offset 32
+; CHECK-NEXT:    addi a0, sp, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
-; CHECK-NEXT:    vslidedown.vi v10, v8, 10
-; CHECK-NEXT:    vslidedown.vi v12, v8, 8
+; CHECK-NEXT:    vslidedown.vi v10, v8, 8
 ; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 6
-; CHECK-NEXT:    vslidedown.vi v11, v8, 4
-; CHECK-NEXT:    vslidedown.vi v13, v8, 2
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v11, v9, 2
-; CHECK-NEXT:    vslideup.vi v8, v13, 2
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v11, 4
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v12, v10, 2
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
-; CHECK-NEXT:    vslideup.vi v8, v12, 8
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v10, v8, a2
-; CHECK-NEXT:    vslidedown.vx v11, v8, a0
-; CHECK-NEXT:    vslidedown.vx v12, v8, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v11, v10, a1
-; CHECK-NEXT:    vslideup.vx v8, v12, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    vslidedown.vx v10, v9, a1
-; CHECK-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v9, v10, a1
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    vslidedown.vi v11, v8, 2
+; CHECK-NEXT:    vslidedown.vi v12, v8, 4
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    vsetivli zero, 2, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v11, v8, 6
+; CHECK-NEXT:    addi a1, sp, 16
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 20
+; CHECK-NEXT:    vsetivli zero, 2, e16, m2, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 10
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 24
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 28
+; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg6e16.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    .cfi_def_cfa sp, 16
-; CHECK-NEXT:    addi sp, sp, 16
+; CHECK-NEXT:    addi sp, sp, 32
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
 	   %res = call {<2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>, <2 x bfloat>} @llvm.vector.deinterleave6.v12bf16(<12 x bfloat> %v)
@@ -1195,49 +1061,35 @@ define {<1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, 
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
-; CHECK-NEXT:    csrr a0, vlenb
+; CHECK-NEXT:    addi a0, sp, 2
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 5
-; CHECK-NEXT:    vslidedown.vi v11, v8, 4
-; CHECK-NEXT:    vslidedown.vi v12, v8, 6
-; CHECK-NEXT:    vslidedown.vi v13, v8, 1
-; CHECK-NEXT:    vslidedown.vi v14, v8, 2
-; CHECK-NEXT:    vmv1r.v v10, v8
-; CHECK-NEXT:    vslidedown.vi v8, v8, 3
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vi v10, v13, 1
-; CHECK-NEXT:    vslideup.vi v11, v9, 1
-; CHECK-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vi v10, v14, 2
-; CHECK-NEXT:    vslideup.vi v11, v12, 2
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v10, v8, 3
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v10, v11, 4
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v8, v10, a2
-; CHECK-NEXT:    vslidedown.vx v9, v10, a0
-; CHECK-NEXT:    vslidedown.vx v11, v10, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v9, v8, a1
-; CHECK-NEXT:    vslideup.vx v10, v11, a1
-; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v10, v9, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v10, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 1
+; CHECK-NEXT:    vslidedown.vi v10, v8, 2
+; CHECK-NEXT:    vslidedown.vi v11, v8, 3
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 4
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 5
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 6
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg7e16.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    .cfi_def_cfa sp, 16
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
@@ -1250,49 +1102,35 @@ define {<1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
-; CHECK-NEXT:    csrr a0, vlenb
+; CHECK-NEXT:    addi a0, sp, 2
 ; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vi v9, v8, 5
-; CHECK-NEXT:    vslidedown.vi v11, v8, 4
-; CHECK-NEXT:    vslidedown.vi v12, v8, 6
-; CHECK-NEXT:    vslidedown.vi v13, v8, 1
-; CHECK-NEXT:    vslidedown.vi v14, v8, 2
-; CHECK-NEXT:    vmv1r.v v10, v8
-; CHECK-NEXT:    vslidedown.vi v8, v8, 3
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vi v10, v13, 1
-; CHECK-NEXT:    vslideup.vi v11, v9, 1
-; CHECK-NEXT:    vsetivli zero, 3, e16, mf2, tu, ma
-; CHECK-NEXT:    vslideup.vi v10, v14, 2
-; CHECK-NEXT:    vslideup.vi v11, v12, 2
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vi v10, v8, 3
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vi v10, v11, 4
-; CHECK-NEXT:    srli a1, a0, 3
-; CHECK-NEXT:    srli a0, a0, 2
-; CHECK-NEXT:    add a2, a0, a1
-; CHECK-NEXT:    vsetvli a3, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v8, v10, a2
-; CHECK-NEXT:    vslidedown.vx v9, v10, a0
-; CHECK-NEXT:    vslidedown.vx v11, v10, a1
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v9, v8, a1
-; CHECK-NEXT:    vslideup.vx v10, v11, a1
-; CHECK-NEXT:    vsetvli a1, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v10, v9, a0
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v10, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 1
+; CHECK-NEXT:    vslidedown.vi v10, v8, 2
+; CHECK-NEXT:    vslidedown.vi v11, v8, 3
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 4
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 5
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 6
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg7e16.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    .cfi_def_cfa sp, 16
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
@@ -1305,31 +1143,40 @@ define {<1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, <1 x half>, 
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 2
-; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v9, v8, a1
-; CHECK-NEXT:    srli a0, a0, 3
-; CHECK-NEXT:    add a2, a1, a0
-; CHECK-NEXT:    vslidedown.vx v10, v8, a2
-; CHECK-NEXT:    vslidedown.vx v11, v8, a0
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v9, v10, a0
-; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v8, v9, a1
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 1
+; CHECK-NEXT:    vslidedown.vi v10, v8, 2
+; CHECK-NEXT:    vslidedown.vi v11, v8, 3
+; CHECK-NEXT:    mv a0, sp
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 2
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v12, v8, 4
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 5
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 6
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 7
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg8e16.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    .cfi_def_cfa sp, 16
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret
@@ -1342,31 +1189,40 @@ define {<1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1 x bfloat>, <1
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addi sp, sp, -16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 16
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    sub sp, sp, a0
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0d, 0x72, 0x00, 0x11, 0x10, 0x22, 0x11, 0x02, 0x92, 0xa2, 0x38, 0x00, 0x1e, 0x22 # sp + 16 + 2 * vlenb
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    srli a1, a0, 2
-; CHECK-NEXT:    vsetvli a2, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslidedown.vx v9, v8, a1
-; CHECK-NEXT:    srli a0, a0, 3
-; CHECK-NEXT:    add a2, a1, a0
-; CHECK-NEXT:    vslidedown.vx v10, v8, a2
-; CHECK-NEXT:    vslidedown.vx v11, v8, a0
-; CHECK-NEXT:    vsetvli a2, zero, e16, mf2, ta, ma
-; CHECK-NEXT:    vslideup.vx v9, v10, a0
-; CHECK-NEXT:    vslideup.vx v8, v11, a0
-; CHECK-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
-; CHECK-NEXT:    vslideup.vx v8, v9, a1
-; CHECK-NEXT:    addi a0, sp, 16
-; CHECK-NEXT:    vs2r.v v8, (a0)
-; CHECK-NEXT:    vsetvli a1, zero, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 1
+; CHECK-NEXT:    vslidedown.vi v10, v8, 2
+; CHECK-NEXT:    vslidedown.vi v11, v8, 3
+; CHECK-NEXT:    mv a0, sp
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v8, (a0)
+; CHECK-NEXT:    addi a1, sp, 2
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v12, v8, 4
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    addi a1, sp, 4
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v9, v8, 5
+; CHECK-NEXT:    addi a1, sp, 6
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v11, (a1)
+; CHECK-NEXT:    addi a1, sp, 8
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v10, v8, 6
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v12, (a1)
+; CHECK-NEXT:    addi a1, sp, 10
+; CHECK-NEXT:    vse16.v v9, (a1)
+; CHECK-NEXT:    vsetivli zero, 1, e16, m1, ta, ma
+; CHECK-NEXT:    vslidedown.vi v8, v8, 7
+; CHECK-NEXT:    addi a1, sp, 12
+; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vse16.v v10, (a1)
+; CHECK-NEXT:    addi a1, sp, 14
+; CHECK-NEXT:    vse16.v v8, (a1)
 ; CHECK-NEXT:    vlseg8e16.v v8, (a0)
-; CHECK-NEXT:    csrr a0, vlenb
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    add sp, sp, a0
-; CHECK-NEXT:    .cfi_def_cfa sp, 16
 ; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-deinterleave-fixed.ll
@@ -252,180 +252,66 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV32-NEXT:    slli a1, a1, 4
 ; RV32-NEXT:    sub sp, sp, a1
 ; RV32-NEXT:    andi sp, sp, -128
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vmv1r.v v24, v23
-; RV32-NEXT:    vslideup.vi v14, v15, 1
-; RV32-NEXT:    vslideup.vi v10, v11, 1
-; RV32-NEXT:    addi a1, a0, 8
-; RV32-NEXT:    vslideup.vi v12, v13, 1
-; RV32-NEXT:    vslideup.vi v18, v19, 1
-; RV32-NEXT:    vslideup.vi v8, v9, 1
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vslideup.vi v8, v10, 2
-; RV32-NEXT:    vslideup.vi v12, v14, 2
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vslideup.vi v8, v12, 4
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vslideup.vi v16, v17, 1
-; RV32-NEXT:    vslideup.vi v20, v21, 1
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vslideup.vi v16, v18, 2
+; RV32-NEXT:    addi a1, sp, 124
 ; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v13, (a1)
-; RV32-NEXT:    addi a1, a0, 4
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vslideup.vi v20, v22, 2
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v14, (a1)
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vslideup.vi v16, v20, 4
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v15, (a0)
-; RV32-NEXT:    addi a1, a0, 16
-; RV32-NEXT:    vle32.v v20, (a1)
-; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV32-NEXT:    vslideup.vi v8, v16, 8
-; RV32-NEXT:    addi a1, a0, 12
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v12, (a1)
-; RV32-NEXT:    addi a1, a0, 24
-; RV32-NEXT:    vle32.v v16, (a1)
-; RV32-NEXT:    addi a1, a0, 20
-; RV32-NEXT:    vle32.v v17, (a1)
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vslideup.vi v24, v15, 1
-; RV32-NEXT:    addi a1, a0, 48
-; RV32-NEXT:    vslideup.vi v14, v13, 1
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v15, (a1)
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vslideup.vi v17, v16, 1
-; RV32-NEXT:    addi a1, a0, 32
-; RV32-NEXT:    vslideup.vi v12, v20, 1
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v16, (a1)
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vslideup.vi v24, v14, 2
-; RV32-NEXT:    addi a1, a0, 40
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v14, (a1)
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vslideup.vi v12, v17, 2
-; RV32-NEXT:    addi a1, a0, 36
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v17, (a1)
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vslideup.vi v24, v12, 4
-; RV32-NEXT:    addi a1, a0, 28
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v12, (a1)
-; RV32-NEXT:    addi a1, a0, 44
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vslideup.vi v17, v14, 1
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v14, (a1)
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vslideup.vi v12, v16, 1
-; RV32-NEXT:    addi a1, a0, 52
-; RV32-NEXT:    vslideup.vi v14, v15, 1
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v13, (a1)
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vslideup.vi v12, v17, 2
-; RV32-NEXT:    vslideup.vi v14, v13, 2
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vslideup.vi v12, v14, 4
-; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV32-NEXT:    vslideup.vi v24, v12, 8
-; RV32-NEXT:    addi a1, a0, 108
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v18, (a1)
-; RV32-NEXT:    addi a1, a0, 60
-; RV32-NEXT:    vle32.v v17, (a1)
-; RV32-NEXT:    addi a1, a0, 56
-; RV32-NEXT:    vle32.v v16, (a1)
-; RV32-NEXT:    vsetivli zero, 31, e32, m8, tu, ma
-; RV32-NEXT:    vslideup.vi v8, v24, 15
-; RV32-NEXT:    addi a1, a0, 68
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v19, (a1)
-; RV32-NEXT:    addi a1, a0, 64
-; RV32-NEXT:    vle32.v v20, (a1)
-; RV32-NEXT:    addi a1, a0, 76
-; RV32-NEXT:    vle32.v v21, (a1)
-; RV32-NEXT:    addi a1, a0, 84
-; RV32-NEXT:    vle32.v v23, (a1)
-; RV32-NEXT:    addi a1, a0, 80
-; RV32-NEXT:    vle32.v v24, (a1)
-; RV32-NEXT:    addi a1, a0, 72
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vslideup.vi v20, v19, 1
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v22, (a1)
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vslideup.vi v16, v17, 1
-; RV32-NEXT:    addi a1, a0, 92
-; RV32-NEXT:    vslideup.vi v24, v23, 1
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v19, (a1)
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vslideup.vi v22, v21, 1
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vslideup.vi v16, v20, 2
-; RV32-NEXT:    addi a1, a0, 88
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v20, (a1)
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vslideup.vi v22, v24, 2
-; RV32-NEXT:    addi a1, a0, 100
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v21, (a1)
-; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vslideup.vi v16, v22, 4
-; RV32-NEXT:    addi a1, a0, 96
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v23, (a1)
-; RV32-NEXT:    addi a1, a0, 104
-; RV32-NEXT:    vle32.v v22, (a1)
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vslideup.vi v23, v21, 1
-; RV32-NEXT:    vslideup.vi v20, v19, 1
-; RV32-NEXT:    addi a0, a0, 112
-; RV32-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV32-NEXT:    vle32.v v19, (a0)
-; RV32-NEXT:    li a0, 32
-; RV32-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV32-NEXT:    vslideup.vi v22, v18, 1
-; RV32-NEXT:    addi a1, sp, 128
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vslideup.vi v20, v23, 2
-; RV32-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; RV32-NEXT:    vse32.v v23, (a1)
+; RV32-NEXT:    addi a1, sp, 120
+; RV32-NEXT:    vse32.v v22, (a1)
+; RV32-NEXT:    addi a1, sp, 116
+; RV32-NEXT:    vse32.v v21, (a1)
+; RV32-NEXT:    addi a1, sp, 112
+; RV32-NEXT:    vse32.v v20, (a1)
+; RV32-NEXT:    addi a1, sp, 108
+; RV32-NEXT:    vse32.v v19, (a1)
+; RV32-NEXT:    addi a1, sp, 104
+; RV32-NEXT:    vse32.v v18, (a1)
+; RV32-NEXT:    addi a1, sp, 100
+; RV32-NEXT:    vse32.v v17, (a1)
+; RV32-NEXT:    addi a1, sp, 96
+; RV32-NEXT:    vse32.v v16, (a1)
+; RV32-NEXT:    addi a1, sp, 92
+; RV32-NEXT:    vse32.v v15, (a1)
+; RV32-NEXT:    addi a1, sp, 88
+; RV32-NEXT:    vse32.v v14, (a1)
+; RV32-NEXT:    addi a1, sp, 84
+; RV32-NEXT:    vse32.v v13, (a1)
+; RV32-NEXT:    addi a1, sp, 80
+; RV32-NEXT:    vse32.v v12, (a1)
+; RV32-NEXT:    addi a1, sp, 76
+; RV32-NEXT:    vse32.v v11, (a1)
+; RV32-NEXT:    addi a1, sp, 72
+; RV32-NEXT:    vse32.v v10, (a1)
+; RV32-NEXT:    addi a1, sp, 68
+; RV32-NEXT:    vse32.v v9, (a1)
+; RV32-NEXT:    addi a1, sp, 64
 ; RV32-NEXT:    vse32.v v8, (a1)
-; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV32-NEXT:    vslideup.vi v22, v19, 2
+; RV32-NEXT:    addi a2, a0, 64
 ; RV32-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV32-NEXT:    vslideup.vi v20, v22, 4
-; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV32-NEXT:    vslideup.vi v16, v20, 8
-; RV32-NEXT:    addi a2, sp, 248
-; RV32-NEXT:    vse32.v v16, (a2)
-; RV32-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; RV32-NEXT:    vle32.v v24, (a1)
-; RV32-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
-; RV32-NEXT:    vslidedown.vi v8, v24, 16
-; RV32-NEXT:    vmv4r.v v16, v24
-; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; RV32-NEXT:    vslidedown.vi v20, v24, 8
-; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV32-NEXT:    vslideup.vi v16, v20, 8
-; RV32-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; RV32-NEXT:    vslideup.vi v16, v8, 16
-; RV32-NEXT:    csrr a1, vlenb
-; RV32-NEXT:    slli a1, a1, 3
-; RV32-NEXT:    add a1, sp, a1
-; RV32-NEXT:    addi a1, a1, 512
-; RV32-NEXT:    vs8r.v v16, (a1)
+; RV32-NEXT:    vle32.v v8, (a2)
 ; RV32-NEXT:    addi a2, sp, 256
+; RV32-NEXT:    vse32.v v8, (a2)
+; RV32-NEXT:    addi a3, a0, 96
+; RV32-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV32-NEXT:    vle32.v v8, (a3)
+; RV32-NEXT:    addi a3, sp, 288
+; RV32-NEXT:    vse32.v v8, (a3)
+; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV32-NEXT:    vle32.v v16, (a1)
+; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
+; RV32-NEXT:    vslidedown.vi v8, v16, 8
+; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
+; RV32-NEXT:    vslideup.vi v16, v8, 8
+; RV32-NEXT:    vle32.v v8, (a0)
+; RV32-NEXT:    li a1, 32
+; RV32-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
+; RV32-NEXT:    vslideup.vi v16, v8, 16
+; RV32-NEXT:    csrr a3, vlenb
+; RV32-NEXT:    slli a3, a3, 3
+; RV32-NEXT:    add a3, sp, a3
+; RV32-NEXT:    addi a3, a3, 512
+; RV32-NEXT:    vs8r.v v16, (a3)
+; RV32-NEXT:    lw a0, 112(a0)
+; RV32-NEXT:    sw a0, 304(sp)
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV32-NEXT:    vle32.v v12, (a2)
 ; RV32-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
@@ -433,22 +319,22 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV32-NEXT:    vslidedown.vi v8, v8, 8
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV32-NEXT:    vslideup.vi v8, v12, 8
-; RV32-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; RV32-NEXT:    vsetvli zero, a1, e32, m8, ta, ma
 ; RV32-NEXT:    vslideup.vi v8, v16, 16
 ; RV32-NEXT:    addi a0, sp, 512
 ; RV32-NEXT:    vs8r.v v8, (a0)
-; RV32-NEXT:    vsetvli a2, zero, e32, m2, ta, ma
+; RV32-NEXT:    vsetvli a1, zero, e32, m2, ta, ma
 ; RV32-NEXT:    vlseg3e32.v v20, (a0)
-; RV32-NEXT:    vlseg3e32.v v12, (a1)
+; RV32-NEXT:    vlseg3e32.v v12, (a3)
 ; RV32-NEXT:    vmv4r.v v28, v20
 ; RV32-NEXT:    vmv2r.v v30, v8
 ; RV32-NEXT:    vmv4r.v v8, v12
 ; RV32-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV32-NEXT:    vslideup.vi v8, v28, 8
-; RV32-NEXT:    vmv2r.v v20, v22
 ; RV32-NEXT:    vmv2r.v v12, v14
-; RV32-NEXT:    vslideup.vi v16, v24, 8
+; RV32-NEXT:    vmv2r.v v20, v22
 ; RV32-NEXT:    vslideup.vi v12, v20, 8
+; RV32-NEXT:    vslideup.vi v16, v24, 8
 ; RV32-NEXT:    addi sp, s0, -528
 ; RV32-NEXT:    lw ra, 524(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    lw s0, 520(sp) # 4-byte Folded Reload
@@ -465,189 +351,78 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV64-NEXT:    slli a1, a1, 4
 ; RV64-NEXT:    sub sp, sp, a1
 ; RV64-NEXT:    andi sp, sp, -128
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vmv1r.v v24, v23
-; RV64-NEXT:    vslideup.vi v14, v15, 1
-; RV64-NEXT:    vslideup.vi v10, v11, 1
-; RV64-NEXT:    addi a1, a0, 8
-; RV64-NEXT:    vslideup.vi v12, v13, 1
-; RV64-NEXT:    vslideup.vi v18, v19, 1
-; RV64-NEXT:    vslideup.vi v8, v9, 1
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vslideup.vi v8, v10, 2
-; RV64-NEXT:    vslideup.vi v12, v14, 2
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vslideup.vi v8, v12, 4
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vslideup.vi v16, v17, 1
-; RV64-NEXT:    vslideup.vi v20, v21, 1
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vslideup.vi v16, v18, 2
+; RV64-NEXT:    addi a1, a0, 112
 ; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v13, (a1)
-; RV64-NEXT:    addi a1, a0, 4
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vslideup.vi v20, v22, 2
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v14, (a1)
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vslideup.vi v16, v20, 4
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v15, (a0)
-; RV64-NEXT:    addi a1, a0, 16
-; RV64-NEXT:    vle32.v v20, (a1)
-; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vslideup.vi v8, v16, 8
-; RV64-NEXT:    addi a1, a0, 12
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v12, (a1)
-; RV64-NEXT:    addi a1, a0, 24
-; RV64-NEXT:    vle32.v v16, (a1)
-; RV64-NEXT:    addi a1, a0, 20
-; RV64-NEXT:    vle32.v v17, (a1)
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vslideup.vi v24, v15, 1
-; RV64-NEXT:    addi a1, a0, 48
-; RV64-NEXT:    vslideup.vi v14, v13, 1
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v15, (a1)
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vslideup.vi v17, v16, 1
-; RV64-NEXT:    addi a1, a0, 32
-; RV64-NEXT:    vslideup.vi v12, v20, 1
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v16, (a1)
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vslideup.vi v24, v14, 2
-; RV64-NEXT:    addi a1, a0, 40
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v14, (a1)
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vslideup.vi v12, v17, 2
-; RV64-NEXT:    addi a1, a0, 36
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v17, (a1)
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vslideup.vi v24, v12, 4
-; RV64-NEXT:    addi a1, a0, 28
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v12, (a1)
-; RV64-NEXT:    addi a1, a0, 44
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vslideup.vi v17, v14, 1
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v14, (a1)
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vslideup.vi v12, v16, 1
-; RV64-NEXT:    addi a1, a0, 52
-; RV64-NEXT:    vslideup.vi v14, v15, 1
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v13, (a1)
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vslideup.vi v12, v17, 2
-; RV64-NEXT:    vslideup.vi v14, v13, 2
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vslideup.vi v12, v14, 4
-; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vslideup.vi v24, v12, 8
-; RV64-NEXT:    addi a1, a0, 108
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v18, (a1)
-; RV64-NEXT:    addi a1, a0, 60
-; RV64-NEXT:    vle32.v v17, (a1)
-; RV64-NEXT:    addi a1, a0, 56
-; RV64-NEXT:    vle32.v v16, (a1)
-; RV64-NEXT:    vsetivli zero, 31, e32, m8, tu, ma
-; RV64-NEXT:    vslideup.vi v8, v24, 15
-; RV64-NEXT:    addi a1, a0, 68
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v19, (a1)
-; RV64-NEXT:    addi a1, a0, 64
-; RV64-NEXT:    vle32.v v20, (a1)
-; RV64-NEXT:    addi a1, a0, 76
-; RV64-NEXT:    vle32.v v21, (a1)
-; RV64-NEXT:    addi a1, a0, 84
-; RV64-NEXT:    vle32.v v23, (a1)
-; RV64-NEXT:    addi a1, a0, 80
 ; RV64-NEXT:    vle32.v v24, (a1)
-; RV64-NEXT:    addi a1, a0, 72
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vslideup.vi v20, v19, 1
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v22, (a1)
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vslideup.vi v16, v17, 1
-; RV64-NEXT:    addi a1, a0, 92
-; RV64-NEXT:    vslideup.vi v24, v23, 1
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v19, (a1)
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vslideup.vi v22, v21, 1
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vslideup.vi v16, v20, 2
-; RV64-NEXT:    addi a1, a0, 88
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v20, (a1)
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vslideup.vi v22, v24, 2
-; RV64-NEXT:    addi a1, a0, 100
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v21, (a1)
-; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vslideup.vi v16, v22, 4
-; RV64-NEXT:    addi a1, a0, 96
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v23, (a1)
-; RV64-NEXT:    addi a1, a0, 104
-; RV64-NEXT:    vle32.v v22, (a1)
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vslideup.vi v23, v21, 1
-; RV64-NEXT:    vslideup.vi v20, v19, 1
-; RV64-NEXT:    addi a0, a0, 112
-; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; RV64-NEXT:    vle32.v v19, (a0)
-; RV64-NEXT:    li a0, 32
-; RV64-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; RV64-NEXT:    vslideup.vi v22, v18, 1
-; RV64-NEXT:    addi a1, sp, 128
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vslideup.vi v20, v23, 2
-; RV64-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; RV64-NEXT:    addi a1, sp, 124
+; RV64-NEXT:    vse32.v v23, (a1)
+; RV64-NEXT:    addi a1, sp, 120
+; RV64-NEXT:    vse32.v v22, (a1)
+; RV64-NEXT:    addi a1, sp, 116
+; RV64-NEXT:    vse32.v v21, (a1)
+; RV64-NEXT:    addi a1, sp, 112
+; RV64-NEXT:    vse32.v v20, (a1)
+; RV64-NEXT:    addi a1, sp, 108
+; RV64-NEXT:    vse32.v v19, (a1)
+; RV64-NEXT:    addi a1, sp, 104
+; RV64-NEXT:    vse32.v v18, (a1)
+; RV64-NEXT:    addi a1, sp, 100
+; RV64-NEXT:    vse32.v v17, (a1)
+; RV64-NEXT:    addi a1, sp, 96
+; RV64-NEXT:    vse32.v v16, (a1)
+; RV64-NEXT:    addi a1, sp, 92
+; RV64-NEXT:    vse32.v v15, (a1)
+; RV64-NEXT:    addi a1, sp, 88
+; RV64-NEXT:    vse32.v v14, (a1)
+; RV64-NEXT:    addi a1, sp, 84
+; RV64-NEXT:    vse32.v v13, (a1)
+; RV64-NEXT:    addi a1, sp, 80
+; RV64-NEXT:    vse32.v v12, (a1)
+; RV64-NEXT:    addi a1, sp, 76
+; RV64-NEXT:    vse32.v v11, (a1)
+; RV64-NEXT:    addi a1, sp, 72
+; RV64-NEXT:    vse32.v v10, (a1)
+; RV64-NEXT:    addi a1, sp, 68
+; RV64-NEXT:    vse32.v v9, (a1)
+; RV64-NEXT:    addi a1, sp, 64
 ; RV64-NEXT:    vse32.v v8, (a1)
-; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; RV64-NEXT:    vslideup.vi v22, v19, 2
+; RV64-NEXT:    addi a2, a0, 64
 ; RV64-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; RV64-NEXT:    vslideup.vi v20, v22, 4
+; RV64-NEXT:    vle32.v v8, (a2)
+; RV64-NEXT:    addi a2, sp, 256
+; RV64-NEXT:    vse32.v v8, (a2)
+; RV64-NEXT:    addi a3, a0, 96
+; RV64-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; RV64-NEXT:    vle32.v v8, (a3)
+; RV64-NEXT:    addi a3, sp, 288
+; RV64-NEXT:    vse32.v v8, (a3)
+; RV64-NEXT:    addi a3, sp, 304
+; RV64-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; RV64-NEXT:    vse32.v v24, (a3)
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vslideup.vi v16, v20, 8
-; RV64-NEXT:    addi a2, sp, 248
-; RV64-NEXT:    vse32.v v16, (a2)
-; RV64-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; RV64-NEXT:    vle32.v v24, (a1)
-; RV64-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
-; RV64-NEXT:    vslidedown.vi v8, v24, 16
-; RV64-NEXT:    vmv4r.v v16, v24
+; RV64-NEXT:    vle32.v v8, (a1)
 ; RV64-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; RV64-NEXT:    vslidedown.vi v20, v24, 8
+; RV64-NEXT:    vslidedown.vi v12, v8, 8
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; RV64-NEXT:    vslideup.vi v16, v20, 8
+; RV64-NEXT:    vslideup.vi v8, v12, 8
+; RV64-NEXT:    vle32.v v16, (a0)
+; RV64-NEXT:    li a0, 32
 ; RV64-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; RV64-NEXT:    vslideup.vi v16, v8, 16
+; RV64-NEXT:    vslideup.vi v8, v16, 16
 ; RV64-NEXT:    csrr a1, vlenb
 ; RV64-NEXT:    slli a1, a1, 3
 ; RV64-NEXT:    add a1, sp, a1
 ; RV64-NEXT:    addi a1, a1, 496
-; RV64-NEXT:    vs8r.v v16, (a1)
-; RV64-NEXT:    addi a2, sp, 256
+; RV64-NEXT:    vs8r.v v8, (a1)
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV64-NEXT:    vle32.v v12, (a2)
 ; RV64-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; RV64-NEXT:    vslidedown.vi v16, v12, 8
-; RV64-NEXT:    vslidedown.vi v8, v8, 8
+; RV64-NEXT:    vslidedown.vi v24, v12, 8
+; RV64-NEXT:    vslidedown.vi v8, v16, 8
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV64-NEXT:    vslideup.vi v8, v12, 8
 ; RV64-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; RV64-NEXT:    vslideup.vi v8, v16, 16
+; RV64-NEXT:    vslideup.vi v8, v24, 16
 ; RV64-NEXT:    addi a0, sp, 496
 ; RV64-NEXT:    vs8r.v v8, (a0)
 ; RV64-NEXT:    vsetvli a2, zero, e32, m2, ta, ma
@@ -658,10 +433,10 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; RV64-NEXT:    vmv4r.v v8, v12
 ; RV64-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; RV64-NEXT:    vslideup.vi v8, v28, 8
-; RV64-NEXT:    vmv2r.v v20, v22
 ; RV64-NEXT:    vmv2r.v v12, v14
-; RV64-NEXT:    vslideup.vi v16, v24, 8
+; RV64-NEXT:    vmv2r.v v20, v22
 ; RV64-NEXT:    vslideup.vi v12, v20, 8
+; RV64-NEXT:    vslideup.vi v16, v24, 8
 ; RV64-NEXT:    addi sp, s0, -512
 ; RV64-NEXT:    ld ra, 504(sp) # 8-byte Folded Reload
 ; RV64-NEXT:    ld s0, 496(sp) # 8-byte Folded Reload
@@ -678,189 +453,78 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; ZVZIP-NEXT:    slli a1, a1, 4
 ; ZVZIP-NEXT:    sub sp, sp, a1
 ; ZVZIP-NEXT:    andi sp, sp, -128
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vmv1r.v v24, v23
-; ZVZIP-NEXT:    vslideup.vi v14, v15, 1
-; ZVZIP-NEXT:    vslideup.vi v10, v11, 1
-; ZVZIP-NEXT:    addi a1, a0, 8
-; ZVZIP-NEXT:    vslideup.vi v12, v13, 1
-; ZVZIP-NEXT:    vslideup.vi v18, v19, 1
-; ZVZIP-NEXT:    vslideup.vi v8, v9, 1
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v8, v10, 2
-; ZVZIP-NEXT:    vslideup.vi v12, v14, 2
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v8, v12, 4
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v16, v17, 1
-; ZVZIP-NEXT:    vslideup.vi v20, v21, 1
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v16, v18, 2
+; ZVZIP-NEXT:    addi a1, a0, 112
 ; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v13, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 4
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v20, v22, 2
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v14, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v16, v20, 4
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v15, (a0)
-; ZVZIP-NEXT:    addi a1, a0, 16
-; ZVZIP-NEXT:    vle32.v v20, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v8, v16, 8
-; ZVZIP-NEXT:    addi a1, a0, 12
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v12, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 24
-; ZVZIP-NEXT:    vle32.v v16, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 20
-; ZVZIP-NEXT:    vle32.v v17, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v24, v15, 1
-; ZVZIP-NEXT:    addi a1, a0, 48
-; ZVZIP-NEXT:    vslideup.vi v14, v13, 1
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v15, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v17, v16, 1
-; ZVZIP-NEXT:    addi a1, a0, 32
-; ZVZIP-NEXT:    vslideup.vi v12, v20, 1
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v16, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v24, v14, 2
-; ZVZIP-NEXT:    addi a1, a0, 40
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v14, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v12, v17, 2
-; ZVZIP-NEXT:    addi a1, a0, 36
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v17, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v24, v12, 4
-; ZVZIP-NEXT:    addi a1, a0, 28
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v12, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 44
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v17, v14, 1
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v14, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v12, v16, 1
-; ZVZIP-NEXT:    addi a1, a0, 52
-; ZVZIP-NEXT:    vslideup.vi v14, v15, 1
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v13, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v12, v17, 2
-; ZVZIP-NEXT:    vslideup.vi v14, v13, 2
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v12, v14, 4
-; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v24, v12, 8
-; ZVZIP-NEXT:    addi a1, a0, 108
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v18, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 60
-; ZVZIP-NEXT:    vle32.v v17, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 56
-; ZVZIP-NEXT:    vle32.v v16, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 31, e32, m8, tu, ma
-; ZVZIP-NEXT:    vslideup.vi v8, v24, 15
-; ZVZIP-NEXT:    addi a1, a0, 68
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v19, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 64
-; ZVZIP-NEXT:    vle32.v v20, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 76
-; ZVZIP-NEXT:    vle32.v v21, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 84
-; ZVZIP-NEXT:    vle32.v v23, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 80
 ; ZVZIP-NEXT:    vle32.v v24, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 72
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v20, v19, 1
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v22, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v16, v17, 1
-; ZVZIP-NEXT:    addi a1, a0, 92
-; ZVZIP-NEXT:    vslideup.vi v24, v23, 1
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v19, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v22, v21, 1
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v16, v20, 2
-; ZVZIP-NEXT:    addi a1, a0, 88
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v20, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v22, v24, 2
-; ZVZIP-NEXT:    addi a1, a0, 100
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v21, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v16, v22, 4
-; ZVZIP-NEXT:    addi a1, a0, 96
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v23, (a1)
-; ZVZIP-NEXT:    addi a1, a0, 104
-; ZVZIP-NEXT:    vle32.v v22, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v23, v21, 1
-; ZVZIP-NEXT:    vslideup.vi v20, v19, 1
-; ZVZIP-NEXT:    addi a0, a0, 112
-; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vle32.v v19, (a0)
-; ZVZIP-NEXT:    li a0, 32
-; ZVZIP-NEXT:    vsetivli zero, 2, e32, mf2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v22, v18, 1
-; ZVZIP-NEXT:    addi a1, sp, 128
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v20, v23, 2
-; ZVZIP-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
+; ZVZIP-NEXT:    addi a1, sp, 124
+; ZVZIP-NEXT:    vse32.v v23, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 120
+; ZVZIP-NEXT:    vse32.v v22, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 116
+; ZVZIP-NEXT:    vse32.v v21, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 112
+; ZVZIP-NEXT:    vse32.v v20, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 108
+; ZVZIP-NEXT:    vse32.v v19, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 104
+; ZVZIP-NEXT:    vse32.v v18, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 100
+; ZVZIP-NEXT:    vse32.v v17, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 96
+; ZVZIP-NEXT:    vse32.v v16, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 92
+; ZVZIP-NEXT:    vse32.v v15, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 88
+; ZVZIP-NEXT:    vse32.v v14, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 84
+; ZVZIP-NEXT:    vse32.v v13, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 80
+; ZVZIP-NEXT:    vse32.v v12, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 76
+; ZVZIP-NEXT:    vse32.v v11, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 72
+; ZVZIP-NEXT:    vse32.v v10, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 68
+; ZVZIP-NEXT:    vse32.v v9, (a1)
+; ZVZIP-NEXT:    addi a1, sp, 64
 ; ZVZIP-NEXT:    vse32.v v8, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v22, v19, 2
+; ZVZIP-NEXT:    addi a2, a0, 64
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v20, v22, 4
+; ZVZIP-NEXT:    vle32.v v8, (a2)
+; ZVZIP-NEXT:    addi a2, sp, 256
+; ZVZIP-NEXT:    vse32.v v8, (a2)
+; ZVZIP-NEXT:    addi a3, a0, 96
+; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
+; ZVZIP-NEXT:    vle32.v v8, (a3)
+; ZVZIP-NEXT:    addi a3, sp, 288
+; ZVZIP-NEXT:    vse32.v v8, (a3)
+; ZVZIP-NEXT:    addi a3, sp, 304
+; ZVZIP-NEXT:    vsetivli zero, 1, e32, mf2, ta, ma
+; ZVZIP-NEXT:    vse32.v v24, (a3)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v16, v20, 8
-; ZVZIP-NEXT:    addi a2, sp, 248
-; ZVZIP-NEXT:    vse32.v v16, (a2)
-; ZVZIP-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; ZVZIP-NEXT:    vle32.v v24, (a1)
-; ZVZIP-NEXT:    vsetivli zero, 16, e32, m8, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v8, v24, 16
-; ZVZIP-NEXT:    vmv4r.v v16, v24
+; ZVZIP-NEXT:    vle32.v v8, (a1)
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v20, v24, 8
+; ZVZIP-NEXT:    vslidedown.vi v12, v8, 8
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v16, v20, 8
+; ZVZIP-NEXT:    vslideup.vi v8, v12, 8
+; ZVZIP-NEXT:    vle32.v v16, (a0)
+; ZVZIP-NEXT:    li a0, 32
 ; ZVZIP-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v16, v8, 16
+; ZVZIP-NEXT:    vslideup.vi v8, v16, 16
 ; ZVZIP-NEXT:    csrr a1, vlenb
 ; ZVZIP-NEXT:    slli a1, a1, 3
 ; ZVZIP-NEXT:    add a1, sp, a1
 ; ZVZIP-NEXT:    addi a1, a1, 496
-; ZVZIP-NEXT:    vs8r.v v16, (a1)
-; ZVZIP-NEXT:    addi a2, sp, 256
+; ZVZIP-NEXT:    vs8r.v v8, (a1)
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; ZVZIP-NEXT:    vle32.v v12, (a2)
 ; ZVZIP-NEXT:    vsetivli zero, 8, e32, m4, ta, ma
-; ZVZIP-NEXT:    vslidedown.vi v16, v12, 8
-; ZVZIP-NEXT:    vslidedown.vi v8, v8, 8
+; ZVZIP-NEXT:    vslidedown.vi v24, v12, 8
+; ZVZIP-NEXT:    vslidedown.vi v8, v16, 8
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v12, 8
 ; ZVZIP-NEXT:    vsetvli zero, a0, e32, m8, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v8, v16, 16
+; ZVZIP-NEXT:    vslideup.vi v8, v24, 16
 ; ZVZIP-NEXT:    addi a0, sp, 496
 ; ZVZIP-NEXT:    vs8r.v v8, (a0)
 ; ZVZIP-NEXT:    vsetvli a2, zero, e32, m2, ta, ma
@@ -871,10 +535,10 @@ define {<15 x i32>, <15 x i32>, <15 x i32>} @vector_deinterleave3_v15i32_v45i32(
 ; ZVZIP-NEXT:    vmv4r.v v8, v12
 ; ZVZIP-NEXT:    vsetivli zero, 16, e32, m4, ta, ma
 ; ZVZIP-NEXT:    vslideup.vi v8, v28, 8
-; ZVZIP-NEXT:    vmv2r.v v20, v22
 ; ZVZIP-NEXT:    vmv2r.v v12, v14
-; ZVZIP-NEXT:    vslideup.vi v16, v24, 8
+; ZVZIP-NEXT:    vmv2r.v v20, v22
 ; ZVZIP-NEXT:    vslideup.vi v12, v20, 8
+; ZVZIP-NEXT:    vslideup.vi v16, v24, 8
 ; ZVZIP-NEXT:    addi sp, s0, -512
 ; ZVZIP-NEXT:    ld ra, 504(sp) # 8-byte Folded Reload
 ; ZVZIP-NEXT:    ld s0, 496(sp) # 8-byte Folded Reload


### PR DESCRIPTION
Partially address #207136

Previously this part of the logic simply converts each operand into scalable vector and pass on. This will run into problem when the scalable vector container is larger than the actual fixed vector. 
This patch fixes this issue by storing individual fixed vector operands directly onto the stack, before loading them back with segmented load just like its scalable vector counterpart