### PR TITLE
Change ToLiteralEncodingConverter to a unique_ptr

### DIFF
--- a/clang/include/clang/Lex/TextEncoding.h
+++ b/clang/include/clang/Lex/TextEncoding.h
@@ -17,7 +17,7 @@ enum ConversionAction { CA_NoConversion, CA_ToLiteralEncoding };
 
 class TextEncoding {
   llvm::StringRef LiteralEncoding;
-  llvm::TextEncodingConverter *ToLiteralEncodingConverter = nullptr;
+  std::unique_ptr<llvm::TextEncodingConverter> ToLiteralEncodingConverter;
 
 public:
   llvm::TextEncodingConverter *getConverter(ConversionAction Action) const;

--- a/clang/lib/Lex/TextEncoding.cpp
+++ b/clang/lib/Lex/TextEncoding.cpp
@@ -13,7 +13,7 @@ llvm::TextEncodingConverter *
 TextEncoding::getConverter(ConversionAction Action) const {
   switch (Action) {
   case CA_ToLiteralEncoding:
-    return ToLiteralEncodingConverter;
+    return ToLiteralEncodingConverter.get();
   default:
     return nullptr;
   }
@@ -36,7 +36,7 @@ TextEncoding::setConvertersFromOptions(TextEncoding &TE,
       llvm::TextEncodingConverter::create(UTF8, TE.LiteralEncoding);
   if (ErrorOrConverter)
     TE.ToLiteralEncodingConverter =
-        new TextEncodingConverter(std::move(*ErrorOrConverter));
+        std::make_unique<TextEncodingConverter>(std::move(*ErrorOrConverter));
   else
     return ErrorOrConverter.getError();
   return std::error_code();


### PR DESCRIPTION
This patch is to fix the test regressions seen here https://lab.llvm.org/buildbot/#/builders/55/builds/29895/steps/11/logs/stdio

```
Failed Tests (4):
  Clang :: CodeGen/systemz-charset-diag.cpp
  Clang :: CodeGen/systemz-charset.c
  Clang :: CodeGen/systemz-charset.cpp
  Clang :: Lexer/string-literal-encoding.c
```

```
********************
Testing:  0..
FAIL: Clang :: CodeGen/systemz-charset.c (9847 of 100115)
******************** TEST 'Clang :: CodeGen/systemz-charset.c' FAILED ********************
Exit Code: -6
Command Output (stdout):
--
# RUN: at line 1
/home/b/sanitizer-aarch64-linux-bootstrap-hwasan/build/llvm_build_hwasan/bin/clang -cc1 -internal-isystem /home/b/sanitizer-aarch64-linux-bootstrap-hwasan/build/llvm_build_hwasan/lib/clang/23/include -nostdsysteminc /home/b/sanitizer-aarch64-linux-bootstrap-hwasan/build/llvm-project/clang/test/CodeGen/systemz-charset.c -emit-llvm -triple s390x-none-zos -fexec-charset IBM-1047 -o - | /home/b/sanitizer-aarch64-linux-bootstrap-hwasan/build/llvm_build_hwasan/bin/FileCheck /home/b/sanitizer-aarch64-linux-bootstrap-hwasan/build/llvm-project/clang/test/CodeGen/systemz-charset.c
# executed command: /home/b/sanitizer-aarch64-linux-bootstrap-hwasan/build/llvm_build_hwasan/bin/clang -cc1 -internal-isystem /home/b/sanitizer-aarch64-linux-bootstrap-hwasan/build/llvm_build_hwasan/lib/clang/23/include -nostdsysteminc /home/b/sanitizer-aarch64-linux-bootstrap-hwasan/build/llvm-project/clang/test/CodeGen/systemz-charset.c -emit-llvm -triple s390x-none-zos -fexec-charset IBM-1047 -o -
# .---command stderr------------
# | /home/b/sanitizer-aarch64-linux-bootstrap-hwasan/build/llvm-project/clang/test/CodeGen/systemz-charset.c:24:30: warning: unknown escape sequence '\y' [-Wunknown-escape-sequence]
# |    24 | const char *InvalidEscape = "\y\z";
# |       |                              ^~
# | /home/b/sanitizer-aarch64-linux-bootstrap-hwasan/build/llvm-project/clang/test/CodeGen/systemz-charset.c:24:32: warning: unknown escape sequence '\z' [-Wunknown-escape-sequence]
# |    24 | const char *InvalidEscape = "\y\z";
# |       |                                ^~
# | 2 warnings generated.
# | libc++abi: Pure virtual function called!
# `-----------------------------
```