### PR TITLE
[DirectX] Remove now unreachable blocks in dxil legalize

### DIFF
--- a/llvm/lib/Target/DirectX/DXILLegalizePass.cpp
+++ b/llvm/lib/Target/DirectX/DXILLegalizePass.cpp
@@ -18,6 +18,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
+#include "llvm/Transforms/Utils/Local.h"
 #include <functional>
 
 #define DEBUG_TYPE "dxil-legalize"
@@ -526,6 +527,8 @@ public:
       for (auto *Inst : reverse(ToRemove))
         Inst->eraseFromParent();
     }
+
+    MadeChange |= removeUnreachableBlocks(F);
     return MadeChange;
   }
 

--- a/llvm/lib/Target/DirectX/DXILLegalizePass.cpp
+++ b/llvm/lib/Target/DirectX/DXILLegalizePass.cpp
@@ -528,7 +528,8 @@ public:
         Inst->eraseFromParent();
     }
 
-    MadeChange |= removeUnreachableBlocks(F);
+    if (MadeChange)
+      MadeChange |= removeUnreachableBlocks(F);
     return MadeChange;
   }
 

--- a/llvm/test/CodeGen/DirectX/legalize-switch-unreachable.ll
+++ b/llvm/test/CodeGen/DirectX/legalize-switch-unreachable.ll
@@ -75,22 +75,31 @@ case1:
   ret i32 20
 }
 
-; Test that a switch with a reachable default keeps its default destination.
-; The two-way switch is folded into a conditional branch.
+; Test that a switch with a reachable default and three or more successors is
+; not folded and keeps its default destination.
 
 define i32 @test_reachable_default(i32 %val) {
 ; CHECK-LABEL: define i32 @test_reachable_default(
 ; CHECK:       entry:
-; CHECK-NEXT:    %cond = icmp eq i32 %val, 0
-; CHECK-NEXT:    br i1 %cond, label %case0, label %default
+; CHECK-NEXT:    switch i32 %val, label %default [
+; CHECK-NEXT:      i32 0, label %case0
+; CHECK-NEXT:      i32 1, label %case1
+; CHECK-NEXT:      i32 2, label %case2
+; CHECK-NEXT:    ]
 ; CHECK:       default:
 ; CHECK-NEXT:    ret i32 -1
 ; CHECK:       case0:
 ; CHECK-NEXT:    ret i32 10
+; CHECK:       case1:
+; CHECK-NEXT:    ret i32 20
+; CHECK:       case2:
+; CHECK-NEXT:    ret i32 30
 ;
 entry:
   switch i32 %val, label %default [
     i32 0, label %case0
+    i32 1, label %case1
+    i32 2, label %case2
   ]
 
 default:
@@ -98,6 +107,50 @@ default:
 
 case0:
   ret i32 10
+
+case1:
+  ret i32 20
+
+case2:
+  ret i32 30
+}
+
+; Test that a switch with an unreachable default, no common successor and three
+; or more remaining successors has its default redirected to the first case
+; block and is not folded into a conditional branch.
+
+define i32 @test_no_common_successor_unfolded(i32 %val) {
+; CHECK-LABEL: define i32 @test_no_common_successor_unfolded(
+; CHECK:       entry:
+; CHECK-NEXT:    switch i32 %val, label %case0 [
+; CHECK-NEXT:      i32 2, label %case2
+; CHECK-NEXT:      i32 1, label %case1
+; CHECK-NEXT:    ]
+; CHECK:       case0:
+; CHECK-NEXT:    ret i32 10
+; CHECK:       case1:
+; CHECK-NEXT:    ret i32 20
+; CHECK:       case2:
+; CHECK-NEXT:    ret i32 30
+;
+entry:
+  switch i32 %val, label %default [
+    i32 0, label %case0
+    i32 1, label %case1
+    i32 2, label %case2
+  ]
+
+default:
+  unreachable
+
+case0:
+  ret i32 10
+
+case1:
+  ret i32 20
+
+case2:
+  ret i32 30
 }
 
 ; Test with conditional branches in case blocks (no common successor) and

--- a/llvm/test/CodeGen/DirectX/legalize-switch-unreachable.ll
+++ b/llvm/test/CodeGen/DirectX/legalize-switch-unreachable.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S -passes='dxil-legalize' -mtriple=dxil-pc-shadermodel6.3-library %s | FileCheck %s
+; RUN: opt -S -passes='dxil-legalize' -mtriple=dxil-pc-shadermodel6.3-library %s | FileCheck %s --implicit-check-not='{{^ +unreachable$}}'
 
 ; Test that a switch with an unreachable default and a common successor across
 ; all case blocks has its default redirected to the common successor.

--- a/llvm/test/CodeGen/DirectX/legalize-switch-unreachable.ll
+++ b/llvm/test/CodeGen/DirectX/legalize-switch-unreachable.ll
@@ -46,15 +46,14 @@ merge:
 }
 
 ; Test that a switch with an unreachable default and no common successor
-; has its default redirected to the first case block.
+; has its default redirected to the first case block. The resulting two-way
+; switch is then folded into a conditional branch.
 
 define i32 @test_no_common_successor(i32 %val) {
 ; CHECK-LABEL: define i32 @test_no_common_successor(
 ; CHECK:       entry:
-; CHECK-NEXT:    switch i32 %val, label %case0 [
-; CHECK-NEXT:      i32 0, label %case0
-; CHECK-NEXT:      i32 1, label %case1
-; CHECK-NEXT:    ]
+; CHECK-NEXT:    %cond = icmp eq i32 %val, 1
+; CHECK-NEXT:    br i1 %cond, label %case1, label %case0
 ; CHECK:       case0:
 ; CHECK-NEXT:    ret i32 10
 ; CHECK:       case1:
@@ -76,14 +75,14 @@ case1:
   ret i32 20
 }
 
-; Test that a switch with a reachable default is not modified.
+; Test that a switch with a reachable default keeps its default destination.
+; The two-way switch is folded into a conditional branch.
 
 define i32 @test_reachable_default(i32 %val) {
 ; CHECK-LABEL: define i32 @test_reachable_default(
 ; CHECK:       entry:
-; CHECK-NEXT:    switch i32 %val, label %default [
-; CHECK-NEXT:      i32 0, label %case0
-; CHECK-NEXT:    ]
+; CHECK-NEXT:    %cond = icmp eq i32 %val, 0
+; CHECK-NEXT:    br i1 %cond, label %case0, label %default
 ; CHECK:       default:
 ; CHECK-NEXT:    ret i32 -1
 ; CHECK:       case0:
@@ -107,10 +106,8 @@ case0:
 define i32 @test_conditional_case_blocks(i32 %val, i1 %cond) {
 ; CHECK-LABEL: define i32 @test_conditional_case_blocks(
 ; CHECK:       entry:
-; CHECK-NEXT:    switch i32 %val, label %case0 [
-; CHECK-NEXT:      i32 0, label %case0
-; CHECK-NEXT:      i32 1, label %case1
-; CHECK-NEXT:    ]
+; CHECK-NEXT:    %cond1 = icmp eq i32 %val, 1
+; CHECK-NEXT:    br i1 %cond1, label %case1, label %case0
 ; CHECK:       case0:
 ; CHECK-NEXT:    br i1 %cond, label %merge_a, label %merge_b
 ; CHECK:       case1:


### PR DESCRIPTION
I think when I first wrote https://github.com/llvm/llvm-project/pull/193592, I had been under the assumption that the dead block would be removed for us so the test and pass did not check that the branch was removed in the pass.

This was a wrong assumption and we need to manually remove the blocks. This change does so by invoking the helper to do so.

For context: this issue reappeared in the offload test suite after https://github.com/llvm/llvm-project/pull/205433 landed because the loop could no longer unroll and the dangling branch appeared. 

Resolves: https://github.com/llvm/llvm-project/issues/207095