### PR TITLE
[clang] fix crash-on-invalid with deduction guides

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -11905,9 +11905,10 @@ bool Sema::CheckDeductionGuideDeclarator(Declarator &D, QualType &R,
 
       const QualifiedTemplateName *Qualifiers =
           SpecifiedName.getAsQualifiedTemplateName();
-      assert(Qualifiers && "expected QualifiedTemplate");
-      bool SimplyWritten =
-          !Qualifiers->hasTemplateKeyword() && !Qualifiers->getQualifier();
+      // A Template template parameter is never wrapped in a
+      // QualifiedTemplateName, but it's always simply-written.
+      bool SimplyWritten = !Qualifiers || (!Qualifiers->hasTemplateKeyword() &&
+                                           !Qualifiers->getQualifier());
       if (SimplyWritten && TemplateMatches)
         AcceptableReturnType = true;
       else {

--- a/clang/test/SemaTemplate/ctad.cpp
+++ b/clang/test/SemaTemplate/ctad.cpp
@@ -140,3 +140,20 @@ namespace GH200418 {
   using T = S<A>::X<0>;
 } // namespace GH200418
 #endif
+
+namespace GH203261 {
+  template <class> struct A {}; // expected-note {{template is declared here}}
+  template <template <class> class TT> struct S {
+    A(int) -> TT<int>;
+    // expected-error@-1 {{deduction guide must be declared in the same scope as template 'GH203261::A'}}
+    // expected-error@-2 {{deduced type 'TT<int>' of deduction guide is not written as a specialization of template 'A'}}
+  };
+} // namespace GH203261
+
+namespace TemplateTemplateParm1 {
+  template <template <class> class TT> struct S {
+    template <class> struct A {};
+    A(int) -> TT<int>;
+    // expected-error@-1 {{deduced type 'TT<int>' of deduction guide is not written as a specialization of template 'A'}}
+  };
+} // namespace TemplateTemplateParm1


### PR DESCRIPTION
Fix crash when a template template parameter specialization is used as a deduced type.

This is a regression since Clang 22, and this will be backported, so no release notes.

Fixes #203261