### PR TITLE
release/22.x: [libclc] mark __clc_flush_denormal_if_not_supported as static inline

### DIFF
--- a/libclc/clc/include/clc/math/math.h
+++ b/libclc/clc/include/clc/math/math.h
@@ -65,7 +65,7 @@ bool __attribute__((noinline)) __clc_runtime_has_hw_fma32(void);
 
 #define LOG_MAGIC_NUM_SP32 (1 + NUMEXPBITS_SP32 - EXPBIAS_SP32)
 
-_CLC_OVERLOAD _CLC_INLINE float __clc_flush_denormal_if_not_supported(float x) {
+_CLC_OVERLOAD static _CLC_INLINE float __clc_flush_denormal_if_not_supported(float x) {
   int ix = __clc_as_int(x);
   if (!__clc_fp32_subnormals_supported() && ((ix & EXPBITS_SP32) == 0) &&
       ((ix & MANTBITS_SP32) != 0)) {


### PR DESCRIPTION
The compiled SPIR-V libclc binaries ended up with an empty definition for __clc_flush_denormal_if_not_supported.

b8a5888d8d32 ("[libclc] Fix memory fence scope mapping for OpenCL (#170542)") also added the static keyword probably due to the same issue.

Fixes: 7f3661128b1e ("[libclc] Remove __attribute__((always_inline)) (#158791)")