### PR TITLE
[PAC][Headers] Fix incorrect comment in ptrauth.h

### DIFF
--- a/clang/lib/Headers/ptrauth.h
+++ b/clang/lib/Headers/ptrauth.h
@@ -38,7 +38,7 @@ typedef enum {
      The extra data is always 0. */
   ptrauth_key_function_pointer = ptrauth_key_process_independent_code,
 
-  /* The key used to sign C++ v-table pointers. */
+  /* The key used to sign pointers to C++ v-tables. */
   ptrauth_key_cxx_vtable_pointer = ptrauth_key_process_independent_data,
 
   /* The key used to sign metadata pointers to Objective-C method-lists. */

--- a/clang/lib/Headers/ptrauth.h
+++ b/clang/lib/Headers/ptrauth.h
@@ -38,8 +38,7 @@ typedef enum {
      The extra data is always 0. */
   ptrauth_key_function_pointer = ptrauth_key_process_independent_code,
 
-  /* The key used to sign C++ v-table pointers.
-     The extra data is always 0. */
+  /* The key used to sign C++ v-table pointers. */
   ptrauth_key_cxx_vtable_pointer = ptrauth_key_process_independent_data,
 
   /* The key used to sign metadata pointers to Objective-C method-lists. */


### PR DESCRIPTION
The discriminator which is used to sign pointers to v-tables is not always zero.