### PR TITLE
[flang][cuda] Make the second LAUNCH_BOUNDS() operand optional

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/CUF/Attributes/CUFAttr.td
+++ b/flang/include/flang/Optimizer/Dialect/CUF/Attributes/CUFAttr.td
@@ -62,7 +62,7 @@ def cuf_LaunchBoundsAttr : cuf_Attr<"LaunchBounds"> {
 
   let parameters = (ins
     "mlir::IntegerAttr":$maxTPB,
-    "mlir::IntegerAttr":$minBPM,
+    OptionalParameter<"mlir::IntegerAttr">:$minBPM,
     OptionalParameter<"mlir::IntegerAttr">:$upperBoundClusterSize
   );
 

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -643,12 +643,16 @@ setCUDAAttributes(mlir::func::FuncOp func,
                 .detailsIf<Fortran::semantics::SubprogramDetails>()) {
       mlir::Type i64Ty = mlir::IntegerType::get(func.getContext(), 64);
       if (!details->cudaLaunchBounds().empty()) {
-        assert(details->cudaLaunchBounds().size() >= 2 &&
-               "expect at least 2 values");
+        assert(details->cudaLaunchBounds().size() >= 1 &&
+               details->cudaLaunchBounds().size() <= 3 &&
+               "expect 1, 2, or 3 values");
         auto maxTPBAttr =
             mlir::IntegerAttr::get(i64Ty, details->cudaLaunchBounds()[0]);
-        auto minBPMAttr =
-            mlir::IntegerAttr::get(i64Ty, details->cudaLaunchBounds()[1]);
+        // The minimum-blocks-per-multiprocessor operand is optional.
+        mlir::IntegerAttr minBPMAttr;
+        if (details->cudaLaunchBounds().size() > 1)
+          minBPMAttr =
+              mlir::IntegerAttr::get(i64Ty, details->cudaLaunchBounds()[1]);
         mlir::IntegerAttr ubAttr;
         if (details->cudaLaunchBounds().size() > 2)
           ubAttr =

--- a/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceFuncTransform.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceFuncTransform.cpp
@@ -151,8 +151,10 @@ class CUFDeviceFuncTransform
       auto maxntid =
           builder.getDenseI32ArrayAttr({static_cast<int32_t>(maxTPB), 1, 1});
       deviceFuncOp->setAttr(NVVM::NVVMDialect::getMaxntidAttrName(), maxntid);
-      deviceFuncOp->setAttr(NVVM::NVVMDialect::getMinctasmAttrName(),
-                            launchBoundsAttr.getMinBPM());
+      // The minimum-blocks-per-multiprocessor operand is optional.
+      if (launchBoundsAttr.getMinBPM())
+        deviceFuncOp->setAttr(NVVM::NVVMDialect::getMinctasmAttrName(),
+                              launchBoundsAttr.getMinBPM());
       if (computeCap >= 90 && launchBoundsAttr.getUpperBoundClusterSize())
         deviceFuncOp->setAttr(NVVM::NVVMDialect::getClusterMaxBlocksAttrName(),
                               launchBoundsAttr.getUpperBoundClusterSize());

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -5031,17 +5031,24 @@ void SubprogramVisitor::Post(const parser::PrefixSpec::Launch_Bounds &x) {
       ok = false;
     }
   }
-  if (!ok || bounds.size() < 2 || bounds.size() > 3) {
-    Say(currStmtSource().value(),
-        "Operands of LAUNCH_BOUNDS() must be 2 or 3 integer constants"_err_en_US);
+  // The second (minimum blocks per multiprocessor) and third (maximum blocks
+  // per cluster) operands of LAUNCH_BOUNDS() are optional, so 1, 2, or 3
+  // integer constants are accepted.  This handler runs during the direct walk
+  // of the subprogram statement performed by ResolveSpecificationParts(), where
+  // currStmtSource() may not be set, so derive the diagnostic source from the
+  // prefix instead of dereferencing it.
+  parser::CharBlock source{parser::GetSource(x).value_or(
+      currStmtSource().value_or(parser::CharBlock{}))};
+  if (!ok || bounds.empty() || bounds.size() > 3) {
+    Say(source,
+        "Operands of LAUNCH_BOUNDS() must be 1, 2, or 3 integer constants"_err_en_US);
   } else if (auto *subp{currScope().symbol()
                      ? currScope().symbol()->detailsIf<SubprogramDetails>()
                      : nullptr}) {
     if (subp->cudaLaunchBounds().empty()) {
       subp->set_cudaLaunchBounds(std::move(bounds));
     } else {
-      Say(currStmtSource().value(),
-          "LAUNCH_BOUNDS() may only appear once"_err_en_US);
+      Say(source, "LAUNCH_BOUNDS() may only appear once"_err_en_US);
     }
   }
 }
@@ -5056,8 +5063,12 @@ void SubprogramVisitor::Post(const parser::PrefixSpec::Cluster_Dims &x) {
       ok = false;
     }
   }
+  // As in Post(Launch_Bounds), currStmtSource() may be unset on this path, so
+  // take the diagnostic source from the prefix.
+  parser::CharBlock source{parser::GetSource(x).value_or(
+      currStmtSource().value_or(parser::CharBlock{}))};
   if (!ok || dims.size() != 3) {
-    Say(currStmtSource().value(),
+    Say(source,
         "Operands of CLUSTER_DIMS() must be three integer constants"_err_en_US);
   } else if (auto *subp{currScope().symbol()
                      ? currScope().symbol()->detailsIf<SubprogramDetails>()
@@ -5065,8 +5076,7 @@ void SubprogramVisitor::Post(const parser::PrefixSpec::Cluster_Dims &x) {
     if (subp->cudaClusterDims().empty()) {
       subp->set_cudaClusterDims(std::move(dims));
     } else {
-      Say(currStmtSource().value(),
-          "CLUSTER_DIMS() may only appear once"_err_en_US);
+      Say(source, "CLUSTER_DIMS() may only appear once"_err_en_US);
     }
   }
 }

--- a/flang/test/Fir/CUDA/cuda-device-func-transform.mlir
+++ b/flang/test/Fir/CUDA/cuda-device-func-transform.mlir
@@ -190,3 +190,14 @@ func.func @_QPsub_maxtnid() attributes {cuf.launch_bounds = #cuf.launch_bounds<m
 }
 
 // CHECK: gpu.func @_QPsub_maxtnid() kernel attributes {nvvm.maxntid = array<i32: 256, 1, 1>, nvvm.minctasm = 2 : i64}
+
+// -----
+
+// The minimum-blocks-per-multiprocessor operand is optional: only maxntid is set.
+func.func @_QPsub_maxtnid_only() attributes {cuf.launch_bounds = #cuf.launch_bounds<maxTPB = 256 : i64>, cuf.proc_attr = #cuf.cuda_proc<global>} {
+  %cst = arith.constant 2.000000e+00 : f32
+  return
+}
+
+// CHECK: gpu.func @_QPsub_maxtnid_only() kernel attributes {nvvm.maxntid = array<i32: 256, 1, 1>}
+// CHECK-NOT: nvvm.minctasm

--- a/flang/test/Lower/CUDA/cuda-proc-attribute.cuf
+++ b/flang/test/Lower/CUDA/cuda-proc-attribute.cuf
@@ -33,6 +33,9 @@ attributes(host) attributes(device) integer function fct_host_device; end
 attributes(device) attributes(host) integer function fct_device_host; end
 ! CHECK: func.func @_QPfct_device_host() -> i32 attributes {cuf.proc_attr = #cuf.cuda_proc<host_device>}
 
+attributes(global) launch_bounds(1) subroutine sub_lbounds0(); end
+! CHECK: func.func @_QPsub_lbounds0() attributes {cuf.launch_bounds = #cuf.launch_bounds<maxTPB = 1 : i64>, cuf.proc_attr = #cuf.cuda_proc<global>}
+
 attributes(global) launch_bounds(1, 2) subroutine sub_lbounds1(); end
 ! CHECK: func.func @_QPsub_lbounds1() attributes {cuf.launch_bounds = #cuf.launch_bounds<maxTPB = 1 : i64, minBPM = 2 : i64>, cuf.proc_attr = #cuf.cuda_proc<global>}
 

--- a/flang/test/Semantics/CUDA/cuf08.cuf
+++ b/flang/test/Semantics/CUDA/cuf08.cuf
@@ -5,13 +5,12 @@ module m
   launch_bounds(1,2) subroutine bad1; end
   !ERROR: A subroutine may not have LAUNCH_BOUNDS() or CLUSTER_DIMS() unless it has ATTRIBUTES(GLOBAL) or ATTRIBUTES(GRID_GLOBAL)
   cluster_dims(1,2,3) subroutine bad2; end
+  attributes(global) launch_bounds(1) subroutine good1a; end
   attributes(global) launch_bounds(1,2) subroutine good1; end
   attributes(global) launch_bounds(1,2,3) subroutine good2; end
   !ERROR: LAUNCH_BOUNDS() may only appear once
   attributes(global) launch_bounds(1,2) launch_bounds(3,4) subroutine bad3; end
-  !ERROR: Operands of LAUNCH_BOUNDS() must be 2 or 3 integer constants
-  attributes(global) launch_bounds(1) subroutine bad4; end
-  !ERROR: Operands of LAUNCH_BOUNDS() must be 2 or 3 integer constants
+  !ERROR: Operands of LAUNCH_BOUNDS() must be 1, 2, or 3 integer constants
   attributes(global) launch_bounds(1,2,3,4) subroutine bad5; end
   attributes(global) cluster_dims(1,2,3) subroutine good3; end
   !ERROR: CLUSTER_DIMS() may only appear once

--- a/flang/test/Semantics/CUDA/cuf31.cuf
+++ b/flang/test/Semantics/CUDA/cuf31.cuf
@@ -1,0 +1,38 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1
+! Regression test for a compiler crash on CUDA Fortran LAUNCH_BOUNDS() /
+! CLUSTER_DIMS() when the operand list is rejected: the diagnostic dereferenced
+! an empty currStmtSource() during ResolveSpecificationParts and aborted.  The
+! crash only reproduces when the offending construct is the first program unit
+! processed (a later unit leaves currStmtSource() set, masking it), so an
+! invalid module leads here.  m_lb_ok is the valid case -- the second and third
+! LAUNCH_BOUNDS operands are optional; the rest are invalid and must diagnose
+! cleanly rather than crash.
+
+module m_lb_dup
+ contains
+  !ERROR: LAUNCH_BOUNDS() may only appear once
+  attributes(global) launch_bounds(1,2) launch_bounds(3,4) subroutine s; end
+end module
+
+module m_lb_ok
+ contains
+  attributes(global) launch_bounds(32) subroutine s; end
+end module
+
+module m_lb_toomany
+ contains
+  !ERROR: Operands of LAUNCH_BOUNDS() must be 1, 2, or 3 integer constants
+  attributes(global) launch_bounds(1,2,3,4) subroutine s; end
+end module
+
+module m_cd_wrongcount
+ contains
+  !ERROR: Operands of CLUSTER_DIMS() must be three integer constants
+  attributes(global) cluster_dims(1) subroutine s; end
+end module
+
+module m_cd_dup
+ contains
+  !ERROR: CLUSTER_DIMS() may only appear once
+  attributes(global) cluster_dims(1,2,3) cluster_dims(4,5,6) subroutine s; end
+end module


### PR DESCRIPTION
The minimum-blocks-per-multiprocessor (second) and maximum-blocks-per-cluster
(third) operands of the CUDA Fortran `LAUNCH_BOUNDS()` prefix are optional, as in
CUDA C++ `__launch_bounds__`. A single-operand `LAUNCH_BOUNDS(N)` is now accepted;
1, 2, or 3 integer constants are valid.

Previously `LAUNCH_BOUNDS(N)` with a single operand was rejected, and the
diagnostic path dereferenced an empty `std::optional` (`currStmtSource()`). That
handler runs during the direct statement walk in `ResolveSpecificationParts`,
where the statement source is not set, so the dereference aborted the compiler.
The diagnostic source is now derived from the prefix, and the same fix is applied
to every diagnostic in the `LAUNCH_BOUNDS()` and `CLUSTER_DIMS()` handlers.

When only the maximum-threads-per-block operand is present, the
`cuf.launch_bounds` attribute omits `minBPM` (now an optional parameter) and no
`nvvm.minctasm` attribute is generated.
