### PR TITLE
[ADT][NFC] Remove unused ValueInfoT from DenseSetImpl

### DIFF
--- a/llvm/include/llvm/ADT/DenseSet.h
+++ b/llvm/include/llvm/ADT/DenseSet.h
@@ -47,13 +47,10 @@ public:
 ///
 /// MapTy should be either
 ///
-///   DenseMap<ValueT, detail::DenseSetEmpty, ValueInfoT,
-///            detail::DenseSetPair<ValueT>>
+///   DenseMap<ValueT, detail::DenseSetEmpty, detail::DenseSetPair<ValueT>>
 ///
-/// or the equivalent SmallDenseMap type.  ValueInfoT must implement the
-/// DenseMapInfo "concept".
-template <typename ValueT, typename MapTy, typename ValueInfoT>
-class DenseSetImpl {
+/// or the equivalent SmallDenseMap type.
+template <typename ValueT, typename MapTy> class DenseSetImpl {
   static_assert(sizeof(typename MapTy::value_type) == sizeof(ValueT),
                 "DenseMap buckets unexpectedly large!");
   MapTy TheMap;
@@ -246,10 +243,9 @@ public:
 /// of RHS, and that RHS contains no additional values.
 /// Equivalent to N calls to RHS.count. Amortized complexity is linear, worst
 /// case is O(N^2) (if every hash collides).
-template <typename ValueT, typename MapTy, typename ValueInfoT>
-[[nodiscard]] bool
-operator==(const DenseSetImpl<ValueT, MapTy, ValueInfoT> &LHS,
-           const DenseSetImpl<ValueT, MapTy, ValueInfoT> &RHS) {
+template <typename ValueT, typename MapTy>
+[[nodiscard]] bool operator==(const DenseSetImpl<ValueT, MapTy> &LHS,
+                              const DenseSetImpl<ValueT, MapTy> &RHS) {
   if (LHS.size() != RHS.size())
     return false;
 
@@ -263,24 +259,20 @@ operator==(const DenseSetImpl<ValueT, MapTy, ValueInfoT> &LHS,
 /// Inequality comparison for DenseSet.
 ///
 /// Equivalent to !(LHS == RHS). See operator== for performance notes.
-template <typename ValueT, typename MapTy, typename ValueInfoT>
-[[nodiscard]] bool
-operator!=(const DenseSetImpl<ValueT, MapTy, ValueInfoT> &LHS,
-           const DenseSetImpl<ValueT, MapTy, ValueInfoT> &RHS) {
+template <typename ValueT, typename MapTy>
+[[nodiscard]] bool operator!=(const DenseSetImpl<ValueT, MapTy> &LHS,
+                              const DenseSetImpl<ValueT, MapTy> &RHS) {
   return !(LHS == RHS);
 }
 
 template <typename ValueT, typename ValueInfoT>
 using DenseSet = DenseSetImpl<
-    ValueT, DenseMap<ValueT, DenseSetEmpty, ValueInfoT, DenseSetPair<ValueT>>,
-    ValueInfoT>;
+    ValueT, DenseMap<ValueT, DenseSetEmpty, ValueInfoT, DenseSetPair<ValueT>>>;
 
 template <typename ValueT, unsigned InlineBuckets, typename ValueInfoT>
 using SmallDenseSet =
-    DenseSetImpl<ValueT,
-                 SmallDenseMap<ValueT, DenseSetEmpty, InlineBuckets, ValueInfoT,
-                               DenseSetPair<ValueT>>,
-                 ValueInfoT>;
+    DenseSetImpl<ValueT, SmallDenseMap<ValueT, DenseSetEmpty, InlineBuckets,
+                                       ValueInfoT, DenseSetPair<ValueT>>>;
 
 } // end namespace detail
 

--- a/llvm/include/llvm/ADT/DenseSet.h
+++ b/llvm/include/llvm/ADT/DenseSet.h
@@ -47,9 +47,11 @@ public:
 ///
 /// MapTy should be either
 ///
-///   DenseMap<ValueT, detail::DenseSetEmpty, detail::DenseSetPair<ValueT>>
+///   DenseMap<ValueT, detail::DenseSetEmpty, ValueInfoT,
+///            detail::DenseSetPair<ValueT>>
 ///
-/// or the equivalent SmallDenseMap type.
+/// or the equivalent SmallDenseMap type.  ValueInfoT must implement the
+/// DenseMapInfo "concept".
 template <typename ValueT, typename MapTy> class DenseSetImpl {
   static_assert(sizeof(typename MapTy::value_type) == sizeof(ValueT),
                 "DenseMap buckets unexpectedly large!");

--- a/llvm/include/llvm/ADT/DenseSet.h
+++ b/llvm/include/llvm/ADT/DenseSet.h
@@ -50,8 +50,7 @@ public:
 ///   DenseMap<ValueT, detail::DenseSetEmpty, ValueInfoT,
 ///            detail::DenseSetPair<ValueT>>
 ///
-/// or the equivalent SmallDenseMap type.  ValueInfoT must implement the
-/// DenseMapInfo "concept".
+/// or the equivalent SmallDenseMap type.
 template <typename ValueT, typename MapTy> class DenseSetImpl {
   static_assert(sizeof(typename MapTy::value_type) == sizeof(ValueT),
                 "DenseMap buckets unexpectedly large!");


### PR DESCRIPTION
The `ValueInfoT` template type was unused and is removed in this patch.