### PR TITLE
[OpenMP] Fix a few race conditions in the OpenMP runtime

### DIFF
--- a/openmp/device/include/State.h
+++ b/openmp/device/include/State.h
@@ -18,6 +18,7 @@
 #include "DeviceTypes.h"
 #include "DeviceUtils.h"
 #include "Mapping.h"
+#include "Synchronization.h"
 
 // Forward declaration.
 struct KernelEnvironmentTy;
@@ -234,8 +235,9 @@ lookupPtr(ValueKind Kind, bool IsReadonly, bool ForceTeamState) {
 /// update ICV values we can declare in global scope.
 template <typename Ty, ValueKind Kind> struct Value {
   [[gnu::flatten, gnu::always_inline]] operator Ty() {
-    return lookup(/*IsReadonly=*/true, /*IdentTy=*/nullptr,
-                  /*ForceTeamState=*/false);
+    return atomic::load(&lookup(/*IsReadonly=*/true, /*IdentTy=*/nullptr,
+                                /*ForceTeamState=*/false),
+                        atomic::relaxed);
   }
 
   [[gnu::flatten, gnu::always_inline]] Value &operator=(const Ty &Other) {
@@ -256,7 +258,9 @@ template <typename Ty, ValueKind Kind> struct Value {
   [[gnu::flatten, gnu::always_inline]] void
   assert_eq(const Ty &V, IdentTy *Ident = nullptr,
             bool ForceTeamState = false) {
-    ASSERT(lookup(/*IsReadonly=*/true, Ident, ForceTeamState) == V, nullptr);
+    ASSERT(atomic::load(&lookup(/*IsReadonly=*/true, Ident, ForceTeamState),
+                        atomic::relaxed) == V,
+           nullptr);
   }
 
 private:
@@ -266,14 +270,15 @@ private:
     return t;
   }
 
-  [[gnu::flatten, gnu::always_inline]] Ty &inc(int UpdateVal, IdentTy *Ident) {
-    return (lookup(/*IsReadonly=*/false, Ident, /*ForceTeamState=*/false) +=
-            UpdateVal);
+  [[gnu::flatten, gnu::always_inline]] void inc(int UpdateVal, IdentTy *Ident) {
+    atomic::add(&lookup(/*IsReadonly=*/false, Ident, /*ForceTeamState=*/false),
+                UpdateVal, atomic::relaxed);
   }
 
-  [[gnu::flatten, gnu::always_inline]] Ty &set(Ty UpdateVal, IdentTy *Ident) {
-    return (lookup(/*IsReadonly=*/false, Ident, /*ForceTeamState=*/false) =
-                UpdateVal);
+  [[gnu::flatten, gnu::always_inline]] void set(Ty UpdateVal, IdentTy *Ident) {
+    atomic::store(
+        &lookup(/*IsReadonly=*/false, Ident, /*ForceTeamState=*/false),
+        UpdateVal, atomic::relaxed);
   }
 
   template <typename VTy, typename Ty2> friend struct ValueRAII;
@@ -314,12 +319,13 @@ template <typename VTy, typename Ty> struct ValueRAII {
         Val(OldValue), Active(Active) {
     if (!Active)
       return;
-    ASSERT(*Ptr == OldValue, "ValueRAII initialization with wrong old value!");
-    *Ptr = NewValue;
+    ASSERT(atomic::load(Ptr, atomic::relaxed) == OldValue,
+           "ValueRAII initialization with wrong old value!");
+    atomic::store(Ptr, NewValue, atomic::relaxed);
   }
   ~ValueRAII() {
     if (Active)
-      *Ptr = Val;
+      atomic::store(Ptr, Val, atomic::relaxed);
   }
 
 private:

--- a/openmp/device/src/Parallelism.cpp
+++ b/openmp/device/src/Parallelism.cpp
@@ -109,10 +109,12 @@ extern "C" {
     // team state properly.
     synchronize::threadsAligned(atomic::acq_rel);
 
-    state::ParallelTeamSize.assert_eq(PTeamSize, ident,
-                                      /*ForceTeamState=*/true);
-    icv::ActiveLevel.assert_eq(1u, ident, /*ForceTeamState=*/true);
-    icv::Level.assert_eq(1u, ident, /*ForceTeamState=*/true);
+    if (mapping::isInitialThreadInLevel0(/*IsSPMD=*/true)) {
+      state::ParallelTeamSize.assert_eq(PTeamSize, ident,
+                                        /*ForceTeamState=*/true);
+      icv::ActiveLevel.assert_eq(1u, ident, /*ForceTeamState=*/true);
+      icv::Level.assert_eq(1u, ident, /*ForceTeamState=*/true);
+    }
 
     // Ensure we synchronize before we run user code to avoid invalidating the
     // assumptions above.
@@ -130,9 +132,11 @@ extern "C" {
   // __kmpc_target_deinit may not hold.
   synchronize::threadsAligned(atomic::acq_rel);
 
-  state::ParallelTeamSize.assert_eq(1u, ident, /*ForceTeamState=*/true);
-  icv::ActiveLevel.assert_eq(0u, ident, /*ForceTeamState=*/true);
-  icv::Level.assert_eq(0u, ident, /*ForceTeamState=*/true);
+  if (mapping::isInitialThreadInLevel0(/*IsSPMD=*/true)) {
+    state::ParallelTeamSize.assert_eq(1u, ident, /*ForceTeamState=*/true);
+    icv::ActiveLevel.assert_eq(0u, ident, /*ForceTeamState=*/true);
+    icv::Level.assert_eq(0u, ident, /*ForceTeamState=*/true);
+  }
 
   // Ensure we synchronize to create an aligned region around the assumptions.
   synchronize::threadsAligned(atomic::relaxed);

--- a/openmp/device/src/Reduction.cpp
+++ b/openmp/device/src/Reduction.cpp
@@ -266,8 +266,9 @@ int32_t __kmpc_gpu_xteam_reduce_nowait(IdentTy *Loc, void *reduce_data,
     lgcpyFct(GlobalBuffer, TeamId, reduce_data);
     // We let the atomic inc wrap around if the value gets larger than
     // NumTeams-1, which makes the counter self-reset.
-    TeamsDoneResult = atomic::inc(&TeamsDone, NumTeams - 1u, atomic::acq_rel,
-                                  atomic::MemScopeTy::device);
+    uint32_t Done = atomic::inc(&TeamsDone, NumTeams - 1u, atomic::acq_rel,
+                                atomic::MemScopeTy::device);
+    atomic::store(&TeamsDoneResult, Done, atomic::relaxed);
   }
 
   // This sync is needed so that all threads from last team see the shared teams
@@ -276,7 +277,7 @@ int32_t __kmpc_gpu_xteam_reduce_nowait(IdentTy *Loc, void *reduce_data,
     synchronize::threadsAligned(atomic::acq_rel);
 
   // If teams done counter reaches NumTeams-1, this is the last team.
-  if (TeamsDoneResult != NumTeams - 1u)
+  if (atomic::load(&TeamsDoneResult, atomic::relaxed) != NumTeams - 1u)
     return 0;
 
   // The last team performs final reduction across all team values.


### PR DESCRIPTION
Summary:
These were found while working on my concurrency sanitizer and
consistently flagged. All of these are benign, as they are aligned loads
in practice so data is not corrupted and synchronization is handled
implicitly by other barriers, but it's best to be explicit. This is
effectively an NFC.

This is also a good study on how easy it is to instrument runtimes,
since i just added a GPU multilib and did `-Xarch_device
-fmultilib-flag=tsan` and it worked.
