### PR TITLE
[lldb] Move RegisterInfo and RegisterSet into their own header

### DIFF
--- a/lldb/include/lldb/Core/EmulateInstruction.h
+++ b/lldb/include/lldb/Core/EmulateInstruction.h
@@ -16,6 +16,7 @@
 #include "lldb/Core/Opcode.h"
 #include "lldb/Core/PluginInterface.h"
 #include "lldb/Utility/ArchSpec.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-private-enumerations.h"

--- a/lldb/include/lldb/Core/Value.h
+++ b/lldb/include/lldb/Core/Value.h
@@ -11,6 +11,7 @@
 
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Utility/DataBufferHeap.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include "lldb/Utility/Scalar.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/lldb-enumerations.h"

--- a/lldb/include/lldb/Expression/Materializer.h
+++ b/lldb/include/lldb/Expression/Materializer.h
@@ -15,6 +15,7 @@
 #include "lldb/Expression/IRMemoryMap.h"
 #include "lldb/Symbol/TaggedASTType.h"
 #include "lldb/Target/StackFrame.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/lldb-private-types.h"
 

--- a/lldb/include/lldb/Host/common/NativeRegisterContext.h
+++ b/lldb/include/lldb/Host/common/NativeRegisterContext.h
@@ -10,6 +10,7 @@
 #define LLDB_HOST_COMMON_NATIVEREGISTERCONTEXT_H
 
 #include "lldb/Host/common/NativeWatchpointList.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include "lldb/lldb-private.h"
 
 namespace lldb_private {

--- a/lldb/include/lldb/Symbol/UnwindPlan.h
+++ b/lldb/include/lldb/Symbol/UnwindPlan.h
@@ -15,6 +15,7 @@
 
 #include "lldb/Core/AddressRange.h"
 #include "lldb/Utility/ConstString.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/lldb-private.h"
 

--- a/lldb/include/lldb/Target/DynamicRegisterInfo.h
+++ b/lldb/include/lldb/Target/DynamicRegisterInfo.h
@@ -14,6 +14,7 @@
 
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/RegisterFlags.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/lldb-private.h"
 

--- a/lldb/include/lldb/Target/RegisterContext.h
+++ b/lldb/include/lldb/Target/RegisterContext.h
@@ -10,6 +10,7 @@
 #define LLDB_TARGET_REGISTERCONTEXT_H
 
 #include "lldb/Target/ExecutionContextScope.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include "lldb/lldb-private.h"
 
 namespace lldb_private {

--- a/lldb/include/lldb/Utility/RegisterInfo.h
+++ b/lldb/include/lldb/Utility/RegisterInfo.h
@@ -1,0 +1,90 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_UTILITY_REGISTERINFO_H
+#define LLDB_UTILITY_REGISTERINFO_H
+
+#include "lldb/Utility/RegisterFlags.h"
+#include "lldb/lldb-enumerations.h"
+
+#include "llvm/ADT/ArrayRef.h"
+
+#include <cstdint>
+
+namespace lldb_private {
+
+/// Every register is described in detail including its name, alternate name
+/// (optional), encoding, size in bytes and the default display format.
+struct RegisterInfo {
+  /// Name of this register, can't be NULL.
+  const char *name;
+  /// Alternate name of this register, can be NULL.
+  const char *alt_name;
+  /// Size in bytes of the register.
+  uint32_t byte_size;
+  /// The byte offset in the register context data where this register's value
+  /// is found.
+  /// This is optional, and can be 0 if a particular RegisterContext does not
+  /// need to address its registers by byte offset.
+  uint32_t byte_offset;
+  /// Encoding of the register bits.
+  lldb::Encoding encoding;
+  /// Default display format.
+  lldb::Format format;
+  /// Holds all of the various register numbers for all register kinds.
+  uint32_t kinds[lldb::kNumRegisterKinds];
+  /// List of registers (terminated with LLDB_INVALID_REGNUM). If this value is
+  /// not null, all registers in this list will be read first, at which point
+  /// the value for this register will be valid. FOr example, the value list for
+  /// ah would be eax (x86) or rax (x64). Register numbers are of
+  /// eRegisterKindLLDB. If multiple registers are listed, the final value will
+  /// be the concatenation of them.
+  uint32_t *value_regs;
+  /// List of registers (terminated with LLDB_INVALID_REGNUM). If this value is
+  /// not null, all registers in this list will be invalidated when the value of
+  /// this register changes. For example, the invalidate list for eax would be
+  /// rax ax, ah, and al
+  uint32_t *invalidate_regs;
+  /// If not nullptr, a type defined by XML descriptions.
+  /// Register info tables are constructed as const, but this field may need to
+  /// be updated if a specific target OS has a different layout. To enable that,
+  /// this is mutable. The data pointed to is still const, so you must swap a
+  /// whole set of flags for another.
+  mutable const RegisterFlags *flags_type;
+
+  llvm::ArrayRef<uint8_t> data(const uint8_t *context_base) const {
+    return llvm::ArrayRef<uint8_t>(context_base + byte_offset, byte_size);
+  }
+
+  llvm::MutableArrayRef<uint8_t> mutable_data(uint8_t *context_base) const {
+    return llvm::MutableArrayRef<uint8_t>(context_base + byte_offset,
+                                          byte_size);
+  }
+};
+static_assert(std::is_trivial<RegisterInfo>::value,
+              "RegisterInfo must be trivial.");
+
+/// Registers are grouped into register sets
+struct RegisterSet {
+  /// Name of this register set.
+  const char *name;
+  /// A short name for this register set.
+  const char *short_name;
+  /// The number of registers in REGISTERS array below.
+  size_t num_registers;
+  /// An array of register indicies in this set. The values in this array are
+  /// *indices* (not register numbers) into a particular RegisterContext's
+  /// register array. For example, if eax is defined at index 4 for a particular
+  /// RegisterContext, eax would be included in this RegisterSet by adding the
+  /// value 4. Not by adding the value lldb_eax_i386.
+  const uint32_t *registers;
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_UTILITY_REGISTERINFO_H

--- a/lldb/include/lldb/Utility/RegisterValue.h
+++ b/lldb/include/lldb/Utility/RegisterValue.h
@@ -10,6 +10,7 @@
 #define LLDB_UTILITY_REGISTERVALUE_H
 
 #include "lldb/Utility/Endian.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include "lldb/Utility/Scalar.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/lldb-enumerations.h"
@@ -24,7 +25,6 @@
 namespace lldb_private {
 class DataExtractor;
 class Stream;
-struct RegisterInfo;
 
 class RegisterValue {
 public:

--- a/lldb/include/lldb/lldb-private-types.h
+++ b/lldb/include/lldb/lldb-private-types.h
@@ -23,79 +23,11 @@ class DynamicLibrary;
 namespace lldb_private {
 class Platform;
 class ExecutionContext;
-class RegisterFlags;
 
 typedef llvm::SmallString<256> PathSmallString;
 
 typedef llvm::sys::DynamicLibrary (*LoadPluginCallbackType)(
     const lldb::DebuggerSP &debugger_sp, const FileSpec &spec, Status &error);
-
-/// Every register is described in detail including its name, alternate name
-/// (optional), encoding, size in bytes and the default display format.
-struct RegisterInfo {
-  /// Name of this register, can't be NULL.
-  const char *name;
-  /// Alternate name of this register, can be NULL.
-  const char *alt_name;
-  /// Size in bytes of the register.
-  uint32_t byte_size;
-  /// The byte offset in the register context data where this register's
-  /// value is found.
-  /// This is optional, and can be 0 if a particular RegisterContext does not
-  /// need to address its registers by byte offset.
-  uint32_t byte_offset;
-  /// Encoding of the register bits.
-  lldb::Encoding encoding;
-  /// Default display format.
-  lldb::Format format;
-  /// Holds all of the various register numbers for all register kinds.
-  uint32_t kinds[lldb::kNumRegisterKinds]; //
-  /// List of registers (terminated with LLDB_INVALID_REGNUM). If this value is
-  /// not null, all registers in this list will be read first, at which point
-  /// the value for this register will be valid. For example, the value list
-  /// for ah would be eax (x86) or rax (x64). Register numbers are
-  /// of eRegisterKindLLDB. If multiple registers are listed, the final
-  /// value will be the concatenation of them.
-  uint32_t *value_regs;
-  /// List of registers (terminated with LLDB_INVALID_REGNUM). If this value is
-  /// not null, all registers in this list will be invalidated when the value of
-  /// this register changes. For example, the invalidate list for eax would be
-  /// rax ax, ah, and al.
-  uint32_t *invalidate_regs;
-  /// If not nullptr, a type defined by XML descriptions.
-  /// Register info tables are constructed as const, but this field may need to
-  /// be updated if a specific target OS has a different layout. To enable that,
-  /// this is mutable. The data pointed to is still const, so you must swap a
-  /// whole set of flags for another.
-  mutable const RegisterFlags *flags_type;
-
-  llvm::ArrayRef<uint8_t> data(const uint8_t *context_base) const {
-    return llvm::ArrayRef<uint8_t>(context_base + byte_offset, byte_size);
-  }
-
-  llvm::MutableArrayRef<uint8_t> mutable_data(uint8_t *context_base) const {
-    return llvm::MutableArrayRef<uint8_t>(context_base + byte_offset,
-                                          byte_size);
-  }
-};
-static_assert(std::is_trivial<RegisterInfo>::value,
-              "RegisterInfo must be trivial.");
-
-/// Registers are grouped into register sets
-struct RegisterSet {
-  /// Name of this register set.
-  const char *name;
-  /// A short name for this register set.
-  const char *short_name;
-  /// The number of registers in REGISTERS array below.
-  size_t num_registers;
-  /// An array of register indices in this set. The values in this array are
-  /// *indices* (not register numbers) into a particular RegisterContext's
-  /// register array.  For example, if eax is defined at index 4 for a
-  /// particular RegisterContext, eax would be included in this RegisterSet by
-  /// adding the value 4.  Not by adding the value lldb_eax_i386.
-  const uint32_t *registers;
-};
 
 /// A type-erased pair of llvm::dwarf::SourceLanguageName and version.
 struct SourceLanguage {

--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.h
@@ -10,6 +10,7 @@
 #define LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERFLAGSDETECTOR_ARM64_H
 
 #include "lldb/Utility/RegisterFlags.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include "llvm/ADT/StringRef.h"
 #include <functional>
 

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoInterface.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoInterface.h
@@ -10,7 +10,7 @@
 #define LLDB_SOURCE_PLUGINS_PROCESS_UTILITY_REGISTERINFOINTERFACE_H
 
 #include "lldb/Utility/ArchSpec.h"
-#include "lldb/lldb-private-types.h"
+#include "lldb/Utility/RegisterInfo.h"
 #include <vector>
 
 namespace lldb_private {


### PR DESCRIPTION
RegisterInfo holds onto a pointer to RegisterFlags which is in lldbUtility. My understanding of lldb-private-types is that it contains types used throughout LLDB but should generally stand on their own (i.e. without dependencies on specific lldb types and headers). Thus I am moving it to lldbUtility.

RegisterSet _does_ stand on its own but it is pretty strongly coupled to RegisterInfo.