### PR TITLE
[clang] Do not diagnose float-equal for 0 and 1 

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -11672,6 +11672,14 @@ void Sema::CheckFloatComparison(SourceLocation Loc, const Expr *LHS,
   } else if (const auto *FLR = dyn_cast<FloatingLiteral>(RightExprSansParen))
     if (FLR->isExact())
       return;
+  if (const auto *ILL = dyn_cast<IntegerLiteral>(LeftExprSansParen)) {
+    if (ILL->getValue() == 0 || ILL->getValue() == 1)
+      return;
+  }
+  if (const auto *ILR = dyn_cast<IntegerLiteral>(RightExprSansParen)) {
+    if (ILR->getValue() == 0 || ILR->getValue() == 1)
+      return;
+  }
 
   // Check for comparisons with builtin types.
   if (const auto *CL = dyn_cast<CallExpr>(LeftExprSansParen);


### PR DESCRIPTION
The values 0 and 1 are commonly used for checking if something is initialized and are both exactly representable as floats. Emitting a diagnostic when comparing with these values seems a bit obtuse.