### PR TITLE
[PGO][HIP][NFC] Fix hipModuleGetGlobal -Wunused-function warning

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingPlatformROCm.cpp
+++ b/compiler-rt/lib/profile/InstrProfilingPlatformROCm.cpp
@@ -303,6 +303,7 @@ int __prof_rocm::memcpyDeviceToHost(void *Dst, const void *Src, size_t Size) {
   return hipMemcpy(Dst, Src, Size, 2 /* DToH */);
 }
 
+[[maybe_unused]]
 static int hipModuleGetGlobal(void **DevPtr, size_t *Bytes, void *Module,
                               const char *Name) {
   ensureHipLoaded();


### PR DESCRIPTION
The functions trigger the warning on Windows (without elf.h) and is fatal under -Werror.
Fix by adding [[maybe_unused]]. Alternatively it could be moved inside the existing __has_include(<elf.h>) block,; however that would trigger -Wunused-but-set-global on pHipModuleGetGlobal.
Current fix is minimal and can be removed once hipModuleGetGlobal is supported without elf.h.