### PR TITLE
Fix CODEOWNERS error, remove Lanza from ClangIR owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,9 +36,11 @@
 /clang/www/cxx_dr_status.html @Endilll
 /clang/www/make_cxx_dr_status @Endilll
 
-/clang/include/clang/CIR @lanza @bcardosolopes @xlauko @andykaylor
-/clang/lib/CIR @lanza @bcardosolopes @xlauko @andykaylor
-/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp @lanza @bcardosolopes @xlauko @andykaylor @banach-space
+# ClangIR
+# Emeritus owner: @lanza
+/clang/include/clang/CIR @bcardosolopes @xlauko @andykaylor
+/clang/lib/CIR @bcardosolopes @xlauko @andykaylor
+/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp @bcardosolopes @xlauko @andykaylor @banach-space
 /clang/tools/cir-* @lanza @bcardosolopes @xlauko @andykaylor
 
 /lldb/ @JDevlieghere


### PR DESCRIPTION
The github project reports:
Unknown owner on line 39: make sure <name> exists and has write access to the repository

I assume Nathan's commit access lapsed and he has the `triage` role now.

I added a comment saying he is an emeritus owner. This is reversible, and I assume if he needs or wants write access, we can revisit this in the future.