### PR TITLE
[clang-tidy] Add regression tests for readability-redundant-typename. NFC.

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
@@ -378,3 +378,22 @@ template <typename T>
 struct SubClass : BaseClass<typename T::R> {};
 
 template struct SubClass<Int>;
+
+template <typename T>
+struct Sink {};
+
+template <typename...>
+using VoidT = void;
+
+template <typename C, typename = void>
+inline constexpr bool HasValueType = false;
+
+template <typename C>
+inline constexpr bool HasValueType<C, VoidT<typename C::value_type>> =
+    sizeof(Sink<typename C::value_type>) != 0;
+
+struct IntVector {
+  using value_type = int;
+};
+
+static_assert(HasValueType<IntVector>);


### PR DESCRIPTION
Part of https://github.com/llvm/llvm-project/issues/206995