### PR TITLE
[clangd] fix crashes in SemanticHighlighting on NTTP typed `decltype(constexpr-auto-variable)`

### DIFF
--- a/clang-tools-extra/clangd/SemanticHighlighting.cpp
+++ b/clang-tools-extra/clangd/SemanticHighlighting.cpp
@@ -833,8 +833,10 @@ public:
     auto *TSI = D->getTypeSourceInfo();
     if (!TSI)
       return true;
-    SourceLocation StartLoc =
-        TSI->getTypeLoc().getContainedAutoTypeLoc().getNameLoc();
+    auto ATL = TSI->getTypeLoc().getContainedAutoTypeLoc();
+    if (!ATL)
+      return true;
+    SourceLocation StartLoc = ATL.getNameLoc();
     // The AutoType may not have a corresponding token, e.g. in the case of
     // init-captures. In this case, StartLoc overlaps with the location
     // of the decl itself, and producing a token for the type here would result

--- a/clang-tools-extra/clangd/unittests/SemanticHighlightingTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SemanticHighlightingTests.cpp
@@ -1164,6 +1164,10 @@ TEST(SemanticHighlighting, NoCrash) {
       template < template <> class a > using b = a<>;  // error-ok
       template <class c>
       using e = b<c::template d>
+    )cpp",
+      R"cpp(
+      constexpr auto v = 0;
+      template <decltype(v) t> class c {};
     )cpp"};
   for (const auto &TestCase : TestCases) {
     TestTU TU;

--- a/clang-tools-extra/clangd/unittests/SemanticHighlightingTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SemanticHighlightingTests.cpp
@@ -1230,11 +1230,12 @@ TEST(SemanticHighlighting, ScopeModifiers) {
 std::vector<HighlightingToken> tokens(llvm::StringRef MarkedText) {
   Annotations A(MarkedText);
   std::vector<HighlightingToken> Results;
-  for (const Range& R : A.ranges())
+  for (const Range &R : A.ranges())
     Results.push_back({HighlightingKind::Variable, 0, R});
-  for (unsigned I = 0; I < static_cast<unsigned>(HighlightingKind::LastKind); ++I) {
+  for (unsigned I = 0; I < static_cast<unsigned>(HighlightingKind::LastKind);
+       ++I) {
     HighlightingKind Kind = static_cast<HighlightingKind>(I);
-    for (const Range& R : A.ranges(llvm::to_string(Kind)))
+    for (const Range &R : A.ranges(llvm::to_string(Kind)))
       Results.push_back({Kind, 0, R});
   }
   llvm::sort(Results);


### PR DESCRIPTION
fixes #207139 

- additional null check in `VisitDeclaratorDecl` for this edge case
- regression test