### PR TITLE
[libc++abi] Add a clang-tidy config and test

### DIFF
--- a/libcxx/test/libcxx/clang_tidy.sh.py
+++ b/libcxx/test/libcxx/clang_tidy.sh.py
@@ -11,5 +11,6 @@
 # RUN: %{python} %{libcxx-dir}/../clang-tools-extra/clang-tidy/tool/run-clang-tidy.py   \
 # RUN:      -clang-tidy-binary %{clang-tidy}                                            \
 # RUN:      -warnings-as-errors "*"                                                     \
-# RUN:      -source-filter=".*libcxx/src.*"                                             \
-# RUN:      -quiet -p %{bin-dir}/..
+# RUN:      -source-filter=".*libcxx(abi?)/src.*"                                       \
+# RUN:      -quiet -p %{bin-dir}/..                                                     \
+# RUN:      -header-filter=".*libcxx(abi?)/src.*"

--- a/libcxxabi/.clang-tidy
+++ b/libcxxabi/.clang-tidy
@@ -1,0 +1,55 @@
+Checks: >
+  bugprone-copy-constructor-init,
+  bugprone-dangling-handle,
+  bugprone-infinite-loop,
+  bugprone-stringview-nullptr,
+  bugprone-use-after-move,
+
+  misc-definitions-in-headers,
+  misc-misplaced-const,
+  misc-non-copyable-objects,
+  misc-uniqueptr-reset-release,
+
+  modernize-redundant-void-arg,
+
+  readability-duplicate-include,
+  readability-function-cognitive-complexity,
+  readability-function-size,
+  readability-misplaced-array-index,
+  readability-redundant-control-flow,
+  readability-redundant-function-ptr-dereference,
+  readability-redundant-preprocessor,
+  readability-simplify-subscript-expr,
+  readability-uniqueptr-delete-release,
+
+CheckOptions:
+  - key:   readability-function-cognitive-complexity.Threshold
+    value: 176 # TODO: bring that number down
+  - key:   readability-function-size.LineThreshold
+    value: 491 # TODO: bring that number down
+  - key:   readability-identifier-naming.GetConfigPerFile
+    value: false
+  - key:   readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key:   readability-identifier-naming.PrivateMemberCase
+    value: lower_case
+  - key:   readability-identifier-naming.PrivateMemberSuffix
+    value: _
+  - key:   readability-identifier-naming.LocalVariableCase
+    value: lower_case
+  - key:   readability-identifier-naming.TemplateParameterCase
+    value: CamelCase
+  - key:   readability-identifier-naming.ValueTemplateParameterCase
+    value: CamelCase
+  - key:   readability-identifier-naming.ValueTemplateParameterIgnoredRegexp
+    value: (__[a-z_]|_[A-Z]).* # TODO: Converge on a single style for value template parameters
+
+# TODO: Enable these checks
+# llvm-include-order,
+# llvm-namespace-comment,
+# modernize-loop-convert,
+# modernize-use-equals-delete,
+# modernize-use-nullptr,
+# modernize-use-override,
+# readability-identifier-naming,
+# readability-simplify-boolean-expr,


### PR DESCRIPTION
This essentially copies the `.clang-tidy` file from libc++ into libc++abi, except that the naming conventions are updated to not add underscores and some checks are disabled that don't pass currently. They will be fixed in follow-ups.
