### PR TITLE
[mlir][ArithToAMDGPU] Skip tensor scaling ops

### DIFF
--- a/mlir/lib/Conversion/ArithToAMDGPU/ArithToAMDGPU.cpp
+++ b/mlir/lib/Conversion/ArithToAMDGPU/ArithToAMDGPU.cpp
@@ -464,6 +464,11 @@ ScalingExtFRewritePattern::matchAndRewrite(arith::ScalingExtFOp op,
   if (outVecType && outVecType.isScalable())
     return failure();
 
+  if (isa<RankedTensorType>(out.getType()) ||
+      isa<RankedTensorType>(in.getType()) ||
+      isa<RankedTensorType>(scale.getType()))
+    return failure();
+
   Type scaleF32Type =
       scaleVecType ? VectorType::get(scaleVecType.getShape(), f32) : f32;
   if (scaleType.getIntOrFloatBitWidth() < 32)
@@ -575,6 +580,11 @@ ScalingTruncFRewritePattern::matchAndRewrite(arith::ScalingTruncFOp op,
   VectorType outVecType = dyn_cast<VectorType>(out.getType());
   VectorType scaleVecType = dyn_cast<VectorType>(scale.getType());
   if (outVecType && outVecType.isScalable())
+    return failure();
+
+  if (isa<RankedTensorType>(out.getType()) ||
+      isa<RankedTensorType>(in.getType()) ||
+      isa<RankedTensorType>(scale.getType()))
     return failure();
 
   Type scaleF32Type =

--- a/mlir/test/Conversion/ArithToAMDGPU/scaling-truncf-tensor.mlir
+++ b/mlir/test/Conversion/ArithToAMDGPU/scaling-truncf-tensor.mlir
@@ -1,0 +1,17 @@
+// RUN: mlir-opt %s -convert-arith-to-amdgpu=chipset=gfx950 | FileCheck %s
+
+// CHECK-LABEL: func.func @m0
+// CHECK: arith.scaling_truncf
+func.func @m0(%arg0: tensor<16xf16>, %arg1: tensor<16xf8E8M0FNU>) -> tensor<16xf4E2M1FN> {
+  %0 = arith.scaling_truncf %arg0, %arg1 : tensor<16xf16>, tensor<16xf8E8M0FNU> to tensor<16xf4E2M1FN>
+  return %0 : tensor<16xf4E2M1FN>
+}
+
+// CHECK-LABEL: func.func @m1
+// CHECK: arith.constant
+// CHECK: arith.scaling_truncf
+func.func @m1(%arg0: tensor<4xf32>) -> tensor<4xf4E2M1FN> {
+  %cst = arith.constant dense<1.000000e+00> : tensor<4xf8E8M0FNU>
+  %0 = arith.scaling_truncf %arg0, %cst : tensor<4xf32>, tensor<4xf8E8M0FNU> to tensor<4xf4E2M1FN>
+  return %0 : tensor<4xf4E2M1FN>
+}


### PR DESCRIPTION
This fixes a crash in -convert-arith-to-amdgpu=chipset=gfx950 when the input contains tensor arith.scaling_truncf operations.

The scaling rewrite patterns are written for scalar/vector values. Tensor values should not be rewritten by these patterns, so this patch returns failure for tensor operands and leaves those ops unchanged.

A regression test is added for the tensor reproducer from #207311.