### PR TITLE
[libc++abi] Always enable -fvisibility=hidden

### DIFF
--- a/libcxxabi/src/CMakeLists.txt
+++ b/libcxxabi/src/CMakeLists.txt
@@ -195,6 +195,7 @@ if (LIBCXXABI_SUPPORTS_SHARED_LIBRARY)
   # Build with -fsized-deallocation, which is default in recent versions of Clang.
   # TODO(LLVM 21): This can be dropped once we only support Clang >= 19.
   target_add_compile_flags_if_supported(cxxabi_shared_objects PRIVATE -fsized-deallocation)
+  target_add_compile_flags_if_supported(cxxabi_shared_objects PRIVATE -fvisibility=hidden)
 
   add_library(cxxabi_shared SHARED)
   set_target_properties(cxxabi_shared
@@ -285,9 +286,9 @@ target_compile_options(cxxabi_static_objects PRIVATE "${LIBCXXABI_ADDITIONAL_COM
 # Build with -fsized-deallocation, which is default in recent versions of Clang.
 # TODO(LLVM 21): This can be dropped once we only support Clang >= 19.
 target_add_compile_flags_if_supported(cxxabi_static_objects PRIVATE -fsized-deallocation)
+target_add_compile_flags_if_supported(cxxabi_static_objects PRIVATE -fvisibility=hidden)
 
 if(LIBCXXABI_HERMETIC_STATIC_LIBRARY)
-  target_add_compile_flags_if_supported(cxxabi_static_objects PRIVATE -fvisibility=hidden)
   # If the hermetic library doesn't define the operator new/delete functions
   # then its code shouldn't declare them with hidden visibility.  They might
   # actually be provided by a shared library at link time.


### PR DESCRIPTION
Building with `-fvisibility=hidden` is generally a good idea, since it avoids unnecessary relocations when loading a dylib. For libc++abi this should be a no-op, since most things are annotated explicitly. By enabling `-fvisibility=hidden` we can remove these explicit annotations however.
