### PR TITLE
[clang][bytecode][NFC] Report error if HasGroup is set without types

### DIFF
--- a/clang/utils/TableGen/ClangOpcodesEmitter.cpp
+++ b/clang/utils/TableGen/ClangOpcodesEmitter.cpp
@@ -320,6 +320,11 @@ void ClangOpcodesEmitter::EmitGroup(raw_ostream &OS, StringRef N,
   const auto *Types = R->getValueAsListInit("Types");
   const auto &Args = R->getValueAsListOfDefs("Args");
 
+  if (Types->empty()) {
+    PrintFatalError("HasGroup only makes sense for opcodes with types");
+    return;
+  }
+
   Twine EmitFuncName = "emit" + N;
 
   // Emit the prototype of the group emitter in the header.


### PR DESCRIPTION
Setting `HasGroup = 1` in tablegen without the types being non-empty causes problems later, so diagnose it.