### PR TITLE
[CrossProjectTests] Fixup expect in ctor.cpp to accept multiple steps

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter-tests/ctor.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/ctor.cpp
@@ -19,7 +19,9 @@ int main() {
 	return 0;
 }
 
-// CHECK-DAG: total_watched_steps: 1
+// We should step on ctor_start 1 (or more) times, and `this` should not be
+// irretrievable when we do so.
+// CHECK-DAG: total_watched_steps: {{[1-9]}}
 // CHECK-DAG: irretrievable_steps: 0
 
 /*


### PR DESCRIPTION
In the test `ctor.cpp`, Dexter tests that when we step into the constructor used in the test, the value of `this` isn't irretrievable. To protect against a rotten pass it also checked that we stepped once, but this caused failures on some platforms where we would step twice on the constructor - this patch resolves the issue by accepting any non-zero value for the number of steps.