### PR TITLE
[libc++abi][NFC] Use C++11 spelling of [[noreturn]]

### DIFF
--- a/libcxxabi/include/cxxabi.h
+++ b/libcxxabi/include/cxxabi.h
@@ -20,7 +20,6 @@
 #include <__cxxabi_config.h>
 
 #define _LIBCPPABI_VERSION 230000
-#define _LIBCXXABI_NORETURN  __attribute__((noreturn))
 #define _LIBCXXABI_ALWAYS_COLD __attribute__((cold))
 
 #ifdef __cplusplus
@@ -56,7 +55,7 @@ __cxa_init_primary_exception(void* object, std::type_info* tinfo, void(_LIBCXXAB
 #endif
 
 // 2.4.3 Throwing the Exception Object
-extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void
+[[__noreturn__]] extern _LIBCXXABI_FUNC_VIS void
 __cxa_throw(void *thrown_exception, std::type_info *tinfo,
 #ifdef __wasm__
             void *(_LIBCXXABI_DTOR_FUNC *dest)(void *));
@@ -80,22 +79,22 @@ extern _LIBCXXABI_FUNC_VIS std::type_info *__cxa_current_exception_type();
 // GNU extension
 // Calls `terminate` with the current exception being caught. This function is used by GCC when a `noexcept` function
 // throws an exception inside a try/catch block and doesn't catch it.
-extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void __cxa_call_terminate(void*) _LIBCXXABI_NOEXCEPT;
+[[__noreturn__]] extern _LIBCXXABI_FUNC_VIS void __cxa_call_terminate(void*) _LIBCXXABI_NOEXCEPT;
 
 // 2.5.4 Rethrowing Exceptions
-extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void __cxa_rethrow();
+[[__noreturn__]] extern _LIBCXXABI_FUNC_VIS void __cxa_rethrow();
 
 // 2.6 Auxiliary Runtime APIs
-extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void __cxa_bad_cast(void);
-extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void __cxa_bad_typeid(void);
-extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void
+[[__noreturn__]] extern _LIBCXXABI_FUNC_VIS void __cxa_bad_cast(void);
+[[__noreturn__]] extern _LIBCXXABI_FUNC_VIS void __cxa_bad_typeid(void);
+[[__noreturn__]] extern _LIBCXXABI_FUNC_VIS void
 __cxa_throw_bad_array_new_length(void);
 
 // 3.2.6 Pure Virtual Function API
-extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void __cxa_pure_virtual(void);
+[[__noreturn__]] extern _LIBCXXABI_FUNC_VIS void __cxa_pure_virtual(void);
 
 // 3.2.7 Deleted Virtual Function API
-extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void __cxa_deleted_virtual(void);
+[[__noreturn__]] extern _LIBCXXABI_FUNC_VIS void __cxa_deleted_virtual(void);
 
 // 3.3.2 One-time Construction API
 #if defined(_LIBCXXABI_GUARD_ABI_ARM)

--- a/libcxxabi/src/abort_message.h
+++ b/libcxxabi/src/abort_message.h
@@ -11,7 +11,7 @@
 
 #include "cxxabi.h"
 
-extern "C" _LIBCXXABI_HIDDEN _LIBCXXABI_NORETURN void
+extern "C" [[noreturn]] _LIBCXXABI_HIDDEN void
 __abort_message(const char *format, ...) __attribute__((format(printf, 1, 2)));
 
 #ifndef _LIBCXXABI_ASSERT

--- a/libcxxabi/src/cxa_aux_runtime.cpp
+++ b/libcxxabi/src/cxa_aux_runtime.cpp
@@ -16,7 +16,7 @@
 
 namespace __cxxabiv1 {
 extern "C" {
-_LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void __cxa_bad_cast(void) {
+[[noreturn]] _LIBCXXABI_FUNC_VIS void __cxa_bad_cast(void) {
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
   throw std::bad_cast();
 #else
@@ -24,7 +24,7 @@ _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void __cxa_bad_cast(void) {
 #endif
 }
 
-_LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void __cxa_bad_typeid(void) {
+[[noreturn]] _LIBCXXABI_FUNC_VIS void __cxa_bad_typeid(void) {
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
   throw std::bad_typeid();
 #else
@@ -32,7 +32,7 @@ _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void __cxa_bad_typeid(void) {
 #endif
 }
 
-_LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void
+[[noreturn]] _LIBCXXABI_FUNC_VIS void
 __cxa_throw_bad_array_new_length(void) {
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
   throw std::bad_array_new_length();

--- a/libcxxabi/src/cxa_default_handlers.cpp
+++ b/libcxxabi/src/cxa_default_handlers.cpp
@@ -24,8 +24,7 @@
 static constinit const char* cause = "uncaught";
 
 #  ifndef _LIBCXXABI_NO_EXCEPTIONS
-__attribute__((noreturn))
-static void demangling_terminate_handler()
+[[noreturn]] static void demangling_terminate_handler()
 {
     using namespace __cxxabiv1;
     __cxa_eh_globals* globals = __cxa_get_globals_fast();
@@ -78,16 +77,14 @@ static void demangling_terminate_handler()
     }
 }
 #else // !_LIBCXXABI_NO_EXCEPTIONS
-__attribute__((noreturn))
-static void demangling_terminate_handler()
+[[noreturn]] static void demangling_terminate_handler()
 {
     (void)cause;
     __abort_message("terminating");
 }
 #endif // !_LIBCXXABI_NO_EXCEPTIONS
 
-__attribute__((noreturn))
-static void demangling_unexpected_handler()
+[[noreturn]] static void demangling_unexpected_handler()
 {
     cause = "unexpected";
     std::terminate();

--- a/libcxxabi/src/cxa_exception.cpp
+++ b/libcxxabi/src/cxa_exception.cpp
@@ -140,7 +140,7 @@ exception_cleanup_func(_Unwind_Reason_Code reason, _Unwind_Exception* unwind_exc
     __cxa_decrement_exception_refcount(unwind_exception + 1);
 }
 
-static _LIBCXXABI_NORETURN void failed_throw(__cxa_exception* exception_header) {
+[[noreturn]] static void failed_throw(__cxa_exception* exception_header) {
 //  Section 2.5.3 says:
 //      * For purposes of this ABI, several things are considered exception handlers:
 //      ** A terminate() call due to a throw.

--- a/libcxxabi/src/cxa_handlers.cpp
+++ b/libcxxabi/src/cxa_handlers.cpp
@@ -36,8 +36,7 @@ __unexpected(unexpected_handler func)
     __abort_message("unexpected_handler unexpectedly returned");
 }
 
-__attribute__((noreturn))
-void
+[[noreturn]] void
 unexpected()
 {
     __unexpected(get_unexpected());
@@ -69,8 +68,7 @@ __terminate(terminate_handler func) noexcept
 #endif // _LIBCXXABI_NO_EXCEPTIONS
 }
 
-__attribute__((noreturn))
-void
+[[noreturn]] void
 terminate() noexcept
 {
 #ifndef _LIBCXXABI_NO_EXCEPTIONS

--- a/libcxxabi/src/cxa_handlers.h
+++ b/libcxxabi/src/cxa_handlers.h
@@ -19,11 +19,11 @@
 namespace std
 {
 
-_LIBCXXABI_HIDDEN _LIBCXXABI_NORETURN
+[[noreturn]] _LIBCXXABI_HIDDEN
 void
 __unexpected(unexpected_handler func);
 
-_LIBCXXABI_HIDDEN _LIBCXXABI_NORETURN
+[[noreturn]] _LIBCXXABI_HIDDEN
 void
 __terminate(terminate_handler func) noexcept;
 

--- a/libcxxabi/src/cxa_personality.cpp
+++ b/libcxxabi/src/cxa_personality.cpp
@@ -1272,8 +1272,7 @@ __gxx_personality_v0(_Unwind_State state,
 #endif
 
 
-__attribute__((noreturn))
-_LIBCXXABI_FUNC_VIS void
+[[noreturn]] _LIBCXXABI_FUNC_VIS void
 __cxa_call_unexpected(void* arg)
 {
     _Unwind_Exception* unwind_exception = static_cast<_Unwind_Exception*>(arg);

--- a/libcxxabi/src/cxa_vector.cpp
+++ b/libcxxabi/src/cxa_vector.cpp
@@ -116,8 +116,7 @@ namespace {
 //
 
 namespace {
-_LIBCXXABI_NORETURN
-void throw_bad_array_new_length() {
+[[noreturn]] void throw_bad_array_new_length() {
 #ifndef _LIBCXXABI_NO_EXCEPTIONS
   throw std::bad_array_new_length();
 #else

--- a/libcxxabi/src/cxa_virtual.cpp
+++ b/libcxxabi/src/cxa_virtual.cpp
@@ -11,12 +11,12 @@
 
 namespace __cxxabiv1 {
 extern "C" {
-_LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN
+[[noreturn]] _LIBCXXABI_FUNC_VIS
 void __cxa_pure_virtual(void) {
   __abort_message("Pure virtual function called!");
 }
 
-_LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN
+[[noreturn]] _LIBCXXABI_FUNC_VIS
 void __cxa_deleted_virtual(void) {
   __abort_message("Deleted virtual function called!");
 }


### PR DESCRIPTION
We already use the C++11 spelling for libc++, and there isn't much of a reason not to use it. Except for the changes in `cxxabi.h` this is even fully standard code.
