### PR TITLE
[M68k] Fix build after removal of RegisterClasses pointer array

### DIFF
--- a/llvm/lib/Target/M68k/M68kRegisterInfo.cpp
+++ b/llvm/lib/Target/M68k/M68kRegisterInfo.cpp
@@ -89,14 +89,11 @@ M68kRegisterInfo::getMaximalPhysRegClass(unsigned reg, MVT VT) const {
   // Pick the most sub register class of the right type that contains
   // this physreg.
   const TargetRegisterClass *BestRC = nullptr;
-  for (regclass_iterator I = regclass_begin(), E = regclass_end(); I != E;
-       ++I) {
-    const TargetRegisterClass *RC = *I;
-    if ((VT == MVT::Other || isTypeLegalForClass(*RC, VT)) &&
-        RC->contains(reg) &&
+  for (const TargetRegisterClass &RC : regclasses()) {
+    if ((VT == MVT::Other || isTypeLegalForClass(RC, VT)) && RC.contains(reg) &&
         (!BestRC ||
-         (BestRC->hasSubClass(RC) && RC->getNumRegs() > BestRC->getNumRegs())))
-      BestRC = RC;
+         (BestRC->hasSubClass(&RC) && RC.getNumRegs() > BestRC->getNumRegs())))
+      BestRC = &RC;
   }
 
   assert(BestRC && "Couldn't find the register class");


### PR DESCRIPTION
Commit 4d8ec1968023 ("[CodeGen][NFC] Remove RegisterClasses pointer array (#207204)") removed regclass_begin()/regclass_end() from TargetRegisterInfo, so those names now resolve to the MCRegisterInfo versions whose iterator dereferences to a MCRegisterClass rather than a const TargetRegisterClass *, breaking getMaximalPhysRegClass():

  error: cannot convert 'const llvm::MCRegisterClass' to
  'const llvm::TargetRegisterClass*' in initialization

M68k was not updated in that commit. Switch to the range-based regclasses() idiom used elsewhere in the same change.

Regressor: 4d8ec1968023 ("[CodeGen][NFC] Remove RegisterClasses pointer array") (#207204)