### PR TITLE
[X86] haddsub-undef.ll - sync more testnames with their phaseordering equivalents

### DIFF
--- a/llvm/test/CodeGen/X86/haddsub-undef.ll
+++ b/llvm/test/CodeGen/X86/haddsub-undef.ll
@@ -615,13 +615,13 @@ define <4 x double> @add_pd_011(<4 x double> %0, <4 x double> %1) {
   ret <4 x double> %6
 }
 
-define <4 x float> @v8f32_inputs_v4f32_output_0101(<8 x float> %a, <8 x float> %b) {
-; SSE-LABEL: v8f32_inputs_v4f32_output_0101:
+define <4 x float> @add_8f32_0u2u(<8 x float> %a, <8 x float> %b) {
+; SSE-LABEL: add_8f32_0u2u:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    haddps %xmm2, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: v8f32_inputs_v4f32_output_0101:
+; AVX-LABEL: add_8f32_0u2u:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vhaddps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    vzeroupper
@@ -637,13 +637,13 @@ define <4 x float> @v8f32_inputs_v4f32_output_0101(<8 x float> %a, <8 x float> %
   ret <4 x float> %r
 }
 
-define <4 x float> @v8f32_input0_v4f32_output_0123(<8 x float> %a, <4 x float> %b) {
-; SSE-LABEL: v8f32_input0_v4f32_output_0123:
+define <4 x float> @add_8f32_v4f32_0uuu3(<8 x float> %a, <4 x float> %b) {
+; SSE-LABEL: add_8f32_v4f32_0uuu3:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    haddps %xmm2, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: v8f32_input0_v4f32_output_0123:
+; AVX-LABEL: add_8f32_v4f32_0uuu3:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vhaddps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    vzeroupper
@@ -659,13 +659,13 @@ define <4 x float> @v8f32_input0_v4f32_output_0123(<8 x float> %a, <4 x float> %
   ret <4 x float> %r
 }
 
-define <4 x float> @v8f32_input1_v4f32_output_2301(<4 x float> %a, <8 x float> %b) {
-; SSE-LABEL: v8f32_input1_v4f32_output_2301:
+define <4 x float> @add_v4f32_8f32_u12u(<4 x float> %a, <8 x float> %b) {
+; SSE-LABEL: add_v4f32_8f32_u12u:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    haddps %xmm1, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: v8f32_input1_v4f32_output_2301:
+; AVX-LABEL: add_v4f32_8f32_u12u:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vhaddps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    vzeroupper
@@ -681,13 +681,13 @@ define <4 x float> @v8f32_input1_v4f32_output_2301(<4 x float> %a, <8 x float> %
   ret <4 x float> %r
 }
 
-define <4 x float> @v8f32_inputs_v4f32_output_2323(<8 x float> %a, <8 x float> %b) {
-; SSE-LABEL: v8f32_inputs_v4f32_output_2323:
+define <4 x float> @add_8f32_u1u3(<8 x float> %a, <8 x float> %b) {
+; SSE-LABEL: add_8f32_u1u3:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    haddps %xmm2, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: v8f32_inputs_v4f32_output_2323:
+; AVX-LABEL: add_8f32_u1u3:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vhaddps %xmm1, %xmm0, %xmm0
 ; AVX-NEXT:    vzeroupper
@@ -703,25 +703,25 @@ define <4 x float> @v8f32_inputs_v4f32_output_2323(<8 x float> %a, <8 x float> %
   ret <4 x float> %r
 }
 
-define <4 x float> @v16f32_inputs_v4f32_output_0123(<16 x float> %a, <16 x float> %b) {
-; SSE-LABEL: v16f32_inputs_v4f32_output_0123:
+define <4 x float> @add_16f32_0uu3(<16 x float> %a, <16 x float> %b) {
+; SSE-LABEL: add_16f32_0uu3:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    haddps %xmm4, %xmm0
 ; SSE-NEXT:    retq
 ;
-; AVX1-SLOW-LABEL: v16f32_inputs_v4f32_output_0123:
+; AVX1-SLOW-LABEL: add_16f32_0uu3:
 ; AVX1-SLOW:       # %bb.0:
 ; AVX1-SLOW-NEXT:    vhaddps %xmm2, %xmm0, %xmm0
 ; AVX1-SLOW-NEXT:    vzeroupper
 ; AVX1-SLOW-NEXT:    retq
 ;
-; AVX1-FAST-LABEL: v16f32_inputs_v4f32_output_0123:
+; AVX1-FAST-LABEL: add_16f32_0uu3:
 ; AVX1-FAST:       # %bb.0:
 ; AVX1-FAST-NEXT:    vhaddps %xmm2, %xmm0, %xmm0
 ; AVX1-FAST-NEXT:    vzeroupper
 ; AVX1-FAST-NEXT:    retq
 ;
-; AVX512-LABEL: v16f32_inputs_v4f32_output_0123:
+; AVX512-LABEL: add_16f32_0uu3:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vhaddps %xmm1, %xmm0, %xmm0
 ; AVX512-NEXT:    vzeroupper
@@ -737,23 +737,23 @@ define <4 x float> @v16f32_inputs_v4f32_output_0123(<16 x float> %a, <16 x float
   ret <4 x float> %r
 }
 
-define <8 x float> @v16f32_inputs_v8f32_output_4567(<16 x float> %a, <16 x float> %b) {
-; SSE-LABEL: v16f32_inputs_v8f32_output_4567:
+define <8 x float> @add_16f32_uuuu4uu7(<16 x float> %a, <16 x float> %b) {
+; SSE-LABEL: add_16f32_uuuu4uu7:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    haddps %xmm5, %xmm1
 ; SSE-NEXT:    retq
 ;
-; AVX1-SLOW-LABEL: v16f32_inputs_v8f32_output_4567:
+; AVX1-SLOW-LABEL: add_16f32_uuuu4uu7:
 ; AVX1-SLOW:       # %bb.0:
 ; AVX1-SLOW-NEXT:    vhaddps %ymm2, %ymm0, %ymm0
 ; AVX1-SLOW-NEXT:    retq
 ;
-; AVX1-FAST-LABEL: v16f32_inputs_v8f32_output_4567:
+; AVX1-FAST-LABEL: add_16f32_uuuu4uu7:
 ; AVX1-FAST:       # %bb.0:
 ; AVX1-FAST-NEXT:    vhaddps %ymm2, %ymm0, %ymm0
 ; AVX1-FAST-NEXT:    retq
 ;
-; AVX512-LABEL: v16f32_inputs_v8f32_output_4567:
+; AVX512-LABEL: add_16f32_uuuu4uu7:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vhaddps %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    retq
@@ -768,13 +768,13 @@ define <8 x float> @v16f32_inputs_v8f32_output_4567(<16 x float> %a, <16 x float
   ret <8 x float> %r
 }
 
-define <8 x float> @PR40243(<8 x float> %a, <8 x float> %b) {
-; SSE-LABEL: PR40243:
+define <8 x float> @PR40243_add_v8f32_uuuu4uu7(<8 x float> %a, <8 x float> %b) {
+; SSE-LABEL: PR40243_add_v8f32_uuuu4uu7:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    haddps %xmm3, %xmm1
 ; SSE-NEXT:    retq
 ;
-; AVX-LABEL: PR40243:
+; AVX-LABEL: PR40243_add_v8f32_uuuu4uu7:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vhaddps %ymm1, %ymm0, %ymm0
 ; AVX-NEXT:    retq
@@ -789,8 +789,8 @@ define <8 x float> @PR40243(<8 x float> %a, <8 x float> %b) {
   ret <8 x float> %r
 }
 
-define <4 x double> @PR44694(<4 x double> %0, <4 x double> %1) {
-; SSE-SLOW-LABEL: PR44694:
+define <4 x double> @PR44694_add_v4f64_u123(<4 x double> %0, <4 x double> %1) {
+; SSE-SLOW-LABEL: PR44694_add_v4f64_u123:
 ; SSE-SLOW:       # %bb.0:
 ; SSE-SLOW-NEXT:    movddup {{.*#+}} xmm0 = xmm1[0,0]
 ; SSE-SLOW-NEXT:    haddpd %xmm3, %xmm2
@@ -798,7 +798,7 @@ define <4 x double> @PR44694(<4 x double> %0, <4 x double> %1) {
 ; SSE-SLOW-NEXT:    movapd %xmm2, %xmm1
 ; SSE-SLOW-NEXT:    retq
 ;
-; SSE-FAST-LABEL: PR44694:
+; SSE-FAST-LABEL: PR44694_add_v4f64_u123:
 ; SSE-FAST:       # %bb.0:
 ; SSE-FAST-NEXT:    movapd %xmm1, %xmm0
 ; SSE-FAST-NEXT:    haddpd %xmm3, %xmm2
@@ -806,21 +806,21 @@ define <4 x double> @PR44694(<4 x double> %0, <4 x double> %1) {
 ; SSE-FAST-NEXT:    movapd %xmm2, %xmm1
 ; SSE-FAST-NEXT:    retq
 ;
-; AVX1-SLOW-LABEL: PR44694:
+; AVX1-SLOW-LABEL: PR44694_add_v4f64_u123:
 ; AVX1-SLOW:       # %bb.0:
 ; AVX1-SLOW-NEXT:    vperm2f128 {{.*#+}} ymm0 = ymm0[2,3],ymm1[2,3]
 ; AVX1-SLOW-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm1
 ; AVX1-SLOW-NEXT:    vhaddpd %ymm0, %ymm1, %ymm0
 ; AVX1-SLOW-NEXT:    retq
 ;
-; AVX1-FAST-LABEL: PR44694:
+; AVX1-FAST-LABEL: PR44694_add_v4f64_u123:
 ; AVX1-FAST:       # %bb.0:
 ; AVX1-FAST-NEXT:    vperm2f128 {{.*#+}} ymm0 = ymm0[2,3],ymm1[2,3]
 ; AVX1-FAST-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm1
 ; AVX1-FAST-NEXT:    vhaddpd %ymm0, %ymm1, %ymm0
 ; AVX1-FAST-NEXT:    retq
 ;
-; AVX512-LABEL: PR44694:
+; AVX512-LABEL: PR44694_add_v4f64_u123:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vhaddpd %ymm1, %ymm0, %ymm0
 ; AVX512-NEXT:    vpermpd {{.*#+}} ymm0 = ymm0[0,2,1,3]

--- a/llvm/test/Transforms/PhaseOrdering/X86/hadd.ll
+++ b/llvm/test/Transforms/PhaseOrdering/X86/hadd.ll
@@ -1914,6 +1914,66 @@ define <8 x float> @add_v8f32_0145uuuu(<8 x float> %a, <8 x float> %b) {
   ret <8 x float> %result
 }
 
+define <8 x float> @add_v8f32_uuuu4uu7(<8 x float> %a, <8 x float> %b) {
+; SSE2-LABEL: @add_v8f32_uuuu4uu7(
+; SSE2-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[B:%.*]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 14>
+; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[B]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 poison, i32 poison, i32 15>
+; SSE2-NEXT:    [[RESULT1:%.*]] = fadd <8 x float> [[TMP1]], [[TMP2]]
+; SSE2-NEXT:    ret <8 x float> [[RESULT1]]
+;
+; SSE4-LABEL: @add_v8f32_uuuu4uu7(
+; SSE4-NEXT:    [[A4:%.*]] = extractelement <8 x float> [[A:%.*]], i64 4
+; SSE4-NEXT:    [[A5:%.*]] = extractelement <8 x float> [[A]], i64 5
+; SSE4-NEXT:    [[A45:%.*]] = fadd float [[A4]], [[A5]]
+; SSE4-NEXT:    [[B6:%.*]] = extractelement <8 x float> [[B:%.*]], i64 6
+; SSE4-NEXT:    [[B7:%.*]] = extractelement <8 x float> [[B]], i64 7
+; SSE4-NEXT:    [[B67:%.*]] = fadd float [[B6]], [[B7]]
+; SSE4-NEXT:    [[TMP1:%.*]] = insertelement <8 x float> poison, float [[A45]], i64 4
+; SSE4-NEXT:    [[RESULT:%.*]] = insertelement <8 x float> [[TMP1]], float [[B67]], i64 7
+; SSE4-NEXT:    ret <8 x float> [[RESULT]]
+;
+; AVX-LABEL: @add_v8f32_uuuu4uu7(
+; AVX-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[B:%.*]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 14>
+; AVX-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[B]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 poison, i32 poison, i32 15>
+; AVX-NEXT:    [[RESULT1:%.*]] = fadd <8 x float> [[TMP1]], [[TMP2]]
+; AVX-NEXT:    ret <8 x float> [[RESULT1]]
+;
+  %a0 = extractelement <8 x float> %a, i32 0
+  %a1 = extractelement <8 x float> %a, i32 1
+  %a2 = extractelement <8 x float> %a, i32 2
+  %a3 = extractelement <8 x float> %a, i32 3
+  %a4 = extractelement <8 x float> %a, i32 4
+  %a5 = extractelement <8 x float> %a, i32 5
+  %a6 = extractelement <8 x float> %a, i32 6
+  %a7 = extractelement <8 x float> %a, i32 7
+  %a01 = fadd float %a0, %a1
+  %a23 = fadd float %a2, %a3
+  %a45 = fadd float %a4, %a5
+  %a67 = fadd float %a6, %a7
+  %b0 = extractelement <8 x float> %b, i32 0
+  %b1 = extractelement <8 x float> %b, i32 1
+  %b2 = extractelement <8 x float> %b, i32 2
+  %b3 = extractelement <8 x float> %b, i32 3
+  %b4 = extractelement <8 x float> %b, i32 4
+  %b5 = extractelement <8 x float> %b, i32 5
+  %b6 = extractelement <8 x float> %b, i32 6
+  %b7 = extractelement <8 x float> %b, i32 7
+  %b01 = fadd float %b0, %b1
+  %b23 = fadd float %b2, %b3
+  %b45 = fadd float %b4, %b5
+  %b67 = fadd float %b6, %b7
+  %hadd0 = insertelement <8 x float> poison, float %a01, i32 0
+  %hadd1 = insertelement <8 x float> %hadd0, float %a23, i32 1
+  %hadd2 = insertelement <8 x float> %hadd1, float %b01, i32 2
+  %hadd3 = insertelement <8 x float> %hadd2, float %b23, i32 3
+  %hadd4 = insertelement <8 x float> %hadd3, float %a45, i32 4
+  %hadd5 = insertelement <8 x float> %hadd4, float %a67, i32 5
+  %hadd6 = insertelement <8 x float> %hadd5, float %b45, i32 6
+  %hadd7 = insertelement <8 x float> %hadd6, float %b67, i32 7
+  %result = shufflevector <8 x float> %hadd7, <8 x float> %a, <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 7>
+  ret <8 x float> %result
+}
+
 define <8 x float> @add_v8f32_76u43210(<8 x float> %a, <8 x float> %b) {
 ; SSE2-LABEL: @add_v8f32_76u43210(
 ; SSE2-NEXT:    [[B0:%.*]] = extractelement <8 x float> [[A:%.*]], i64 4
@@ -1977,6 +2037,206 @@ define <8 x float> @add_v8f32_76u43210(<8 x float> %a, <8 x float> %b) {
   %hadd7 = insertelement <8 x float> %hadd6, float %b67, i32 7
   %result = shufflevector <8 x float> %hadd7, <8 x float> %a, <8 x i32> <i32 7, i32 6, i32 poison, i32 4, i32 3, i32 2, i32 1, i32 0>
   ret <8 x float> %result
+}
+
+define <4 x float> @add_8f32_0u2u(<8 x float> %a, <8 x float> %b) {
+; SSE2-LABEL: @add_8f32_0u2u(
+; SSE2-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[B:%.*]], <4 x i32> <i32 0, i32 poison, i32 8, i32 poison>
+; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[B]], <4 x i32> <i32 1, i32 poison, i32 9, i32 poison>
+; SSE2-NEXT:    [[TMP3:%.*]] = fadd <4 x float> [[TMP1]], [[TMP2]]
+; SSE2-NEXT:    ret <4 x float> [[TMP3]]
+;
+; SSE4-LABEL: @add_8f32_0u2u(
+; SSE4-NEXT:    [[A0:%.*]] = extractelement <8 x float> [[A:%.*]], i64 0
+; SSE4-NEXT:    [[A1:%.*]] = extractelement <8 x float> [[A]], i64 1
+; SSE4-NEXT:    [[A01:%.*]] = fadd float [[A0]], [[A1]]
+; SSE4-NEXT:    [[B0:%.*]] = extractelement <8 x float> [[B:%.*]], i64 0
+; SSE4-NEXT:    [[B1:%.*]] = extractelement <8 x float> [[B]], i64 1
+; SSE4-NEXT:    [[B01:%.*]] = fadd float [[B0]], [[B1]]
+; SSE4-NEXT:    [[TMP1:%.*]] = insertelement <4 x float> poison, float [[A01]], i64 0
+; SSE4-NEXT:    [[RESULT:%.*]] = insertelement <4 x float> [[TMP1]], float [[B01]], i64 2
+; SSE4-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX2-LABEL: @add_8f32_0u2u(
+; AVX2-NEXT:    [[SHIFT:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> poison, <8 x i32> <i32 1, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[FOLDEXTEXTBINOP:%.*]] = fadd <8 x float> [[A]], [[SHIFT]]
+; AVX2-NEXT:    [[SHIFT2:%.*]] = shufflevector <8 x float> [[B:%.*]], <8 x float> poison, <8 x i32> <i32 1, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[FOLDEXTEXTBINOP3:%.*]] = fadd <8 x float> [[B]], [[SHIFT2]]
+; AVX2-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[FOLDEXTEXTBINOP]], <8 x float> poison, <4 x i32> <i32 0, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[FOLDEXTEXTBINOP3]], <8 x float> poison, <4 x i32> <i32 0, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[RESULT:%.*]] = shufflevector <4 x float> [[TMP1]], <4 x float> [[TMP2]], <4 x i32> <i32 0, i32 poison, i32 4, i32 poison>
+; AVX2-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX512-LABEL: @add_8f32_0u2u(
+; AVX512-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[B:%.*]], <4 x i32> <i32 0, i32 poison, i32 8, i32 poison>
+; AVX512-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[B]], <4 x i32> <i32 1, i32 poison, i32 9, i32 poison>
+; AVX512-NEXT:    [[TMP3:%.*]] = fadd <4 x float> [[TMP1]], [[TMP2]]
+; AVX512-NEXT:    ret <4 x float> [[TMP3]]
+;
+  %a0 = extractelement <8 x float> %a, i32 0
+  %a1 = extractelement <8 x float> %a, i32 1
+  %a2 = extractelement <8 x float> %a, i32 2
+  %a3 = extractelement <8 x float> %a, i32 3
+  %a4 = extractelement <8 x float> %a, i32 4
+  %a5 = extractelement <8 x float> %a, i32 5
+  %a6 = extractelement <8 x float> %a, i32 6
+  %a7 = extractelement <8 x float> %a, i32 7
+  %a01 = fadd float %a0, %a1
+  %a23 = fadd float %a2, %a3
+  %a45 = fadd float %a4, %a5
+  %a67 = fadd float %a6, %a7
+  %b0 = extractelement <8 x float> %b, i32 0
+  %b1 = extractelement <8 x float> %b, i32 1
+  %b2 = extractelement <8 x float> %b, i32 2
+  %b3 = extractelement <8 x float> %b, i32 3
+  %b4 = extractelement <8 x float> %b, i32 4
+  %b5 = extractelement <8 x float> %b, i32 5
+  %b6 = extractelement <8 x float> %b, i32 6
+  %b7 = extractelement <8 x float> %b, i32 7
+  %b01 = fadd float %b0, %b1
+  %b23 = fadd float %b2, %b3
+  %b45 = fadd float %b4, %b5
+  %b67 = fadd float %b6, %b7
+  %hadd0 = insertelement <4 x float> poison, float %a01, i32 0
+  %hadd1 = insertelement <4 x float> %hadd0, float %a23, i32 1
+  %hadd2 = insertelement <4 x float> %hadd1, float %b01, i32 2
+  %hadd3 = insertelement <4 x float> %hadd2, float %b23, i32 3
+  %result = shufflevector <4 x float> %hadd3, <4 x float> poison, <4 x i32> <i32 0, i32 poison, i32 2, i32 poison>
+  ret <4x float> %result
+}
+
+define <4 x float> @add_8f32_u1u3(<8 x float> %a, <8 x float> %b) {
+; CHECK-LABEL: @add_8f32_u1u3(
+; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[B:%.*]], <4 x i32> <i32 poison, i32 2, i32 poison, i32 10>
+; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[B]], <4 x i32> <i32 poison, i32 3, i32 poison, i32 11>
+; CHECK-NEXT:    [[RESULT1:%.*]] = fadd <4 x float> [[TMP1]], [[TMP2]]
+; CHECK-NEXT:    ret <4 x float> [[RESULT1]]
+;
+  %a0 = extractelement <8 x float> %a, i32 0
+  %a1 = extractelement <8 x float> %a, i32 1
+  %a2 = extractelement <8 x float> %a, i32 2
+  %a3 = extractelement <8 x float> %a, i32 3
+  %a4 = extractelement <8 x float> %a, i32 4
+  %a5 = extractelement <8 x float> %a, i32 5
+  %a6 = extractelement <8 x float> %a, i32 6
+  %a7 = extractelement <8 x float> %a, i32 7
+  %a01 = fadd float %a0, %a1
+  %a23 = fadd float %a2, %a3
+  %a45 = fadd float %a4, %a5
+  %a67 = fadd float %a6, %a7
+  %b0 = extractelement <8 x float> %b, i32 0
+  %b1 = extractelement <8 x float> %b, i32 1
+  %b2 = extractelement <8 x float> %b, i32 2
+  %b3 = extractelement <8 x float> %b, i32 3
+  %b4 = extractelement <8 x float> %b, i32 4
+  %b5 = extractelement <8 x float> %b, i32 5
+  %b6 = extractelement <8 x float> %b, i32 6
+  %b7 = extractelement <8 x float> %b, i32 7
+  %b01 = fadd float %b0, %b1
+  %b23 = fadd float %b2, %b3
+  %b45 = fadd float %b4, %b5
+  %b67 = fadd float %b6, %b7
+  %hadd0 = insertelement <4 x float> poison, float %a01, i32 0
+  %hadd1 = insertelement <4 x float> %hadd0, float %a23, i32 1
+  %hadd2 = insertelement <4 x float> %hadd1, float %b01, i32 2
+  %hadd3 = insertelement <4 x float> %hadd2, float %b23, i32 3
+  %result = shufflevector <4 x float> %hadd3, <4 x float> poison, <4 x i32> <i32 poison, i32 1, i32 poison, i32 3>
+  ret <4x float> %result
+}
+
+define <4 x float> @add_8f32_v4f32_0uuu3(<8 x float> %a, <4 x float> %b) {
+; SSE2-LABEL: @add_8f32_v4f32_0uuu3(
+; SSE2-NEXT:    [[TMP1:%.*]] = shufflevector <4 x float> [[B:%.*]], <4 x float> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
+; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[TMP1]], <4 x i32> <i32 0, i32 poison, i32 poison, i32 10>
+; SSE2-NEXT:    [[TMP3:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[TMP1]], <4 x i32> <i32 1, i32 poison, i32 poison, i32 11>
+; SSE2-NEXT:    [[TMP4:%.*]] = fadd <4 x float> [[TMP2]], [[TMP3]]
+; SSE2-NEXT:    ret <4 x float> [[TMP4]]
+;
+; SSE4-LABEL: @add_8f32_v4f32_0uuu3(
+; SSE4-NEXT:    [[A0:%.*]] = extractelement <8 x float> [[A:%.*]], i64 0
+; SSE4-NEXT:    [[A1:%.*]] = extractelement <8 x float> [[A]], i64 1
+; SSE4-NEXT:    [[A01:%.*]] = fadd float [[A0]], [[A1]]
+; SSE4-NEXT:    [[SHIFT:%.*]] = shufflevector <4 x float> [[B:%.*]], <4 x float> poison, <4 x i32> <i32 poison, i32 poison, i32 poison, i32 2>
+; SSE4-NEXT:    [[FOLDEXTEXTBINOP:%.*]] = fadd <4 x float> [[SHIFT]], [[B]]
+; SSE4-NEXT:    [[RESULT:%.*]] = insertelement <4 x float> [[FOLDEXTEXTBINOP]], float [[A01]], i64 0
+; SSE4-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX2-LABEL: @add_8f32_v4f32_0uuu3(
+; AVX2-NEXT:    [[SHIFT:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> poison, <8 x i32> <i32 1, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[FOLDEXTEXTBINOP:%.*]] = fadd <8 x float> [[A]], [[SHIFT]]
+; AVX2-NEXT:    [[SHIFT2:%.*]] = shufflevector <4 x float> [[B:%.*]], <4 x float> poison, <4 x i32> <i32 poison, i32 poison, i32 poison, i32 2>
+; AVX2-NEXT:    [[FOLDEXTEXTBINOP3:%.*]] = fadd <4 x float> [[SHIFT2]], [[B]]
+; AVX2-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[FOLDEXTEXTBINOP]], <8 x float> poison, <4 x i32> <i32 0, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[RESULT:%.*]] = shufflevector <4 x float> [[TMP1]], <4 x float> [[FOLDEXTEXTBINOP3]], <4 x i32> <i32 0, i32 poison, i32 poison, i32 7>
+; AVX2-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX512-LABEL: @add_8f32_v4f32_0uuu3(
+; AVX512-NEXT:    [[TMP1:%.*]] = shufflevector <4 x float> [[B:%.*]], <4 x float> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
+; AVX512-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[TMP1]], <4 x i32> <i32 0, i32 poison, i32 poison, i32 10>
+; AVX512-NEXT:    [[TMP3:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[TMP1]], <4 x i32> <i32 1, i32 poison, i32 poison, i32 11>
+; AVX512-NEXT:    [[TMP4:%.*]] = fadd <4 x float> [[TMP2]], [[TMP3]]
+; AVX512-NEXT:    ret <4 x float> [[TMP4]]
+;
+  %a0 = extractelement <8 x float> %a, i32 0
+  %a1 = extractelement <8 x float> %a, i32 1
+  %a2 = extractelement <8 x float> %a, i32 2
+  %a3 = extractelement <8 x float> %a, i32 3
+  %a4 = extractelement <8 x float> %a, i32 4
+  %a5 = extractelement <8 x float> %a, i32 5
+  %a6 = extractelement <8 x float> %a, i32 6
+  %a7 = extractelement <8 x float> %a, i32 7
+  %a01 = fadd float %a0, %a1
+  %a23 = fadd float %a2, %a3
+  %a45 = fadd float %a4, %a5
+  %a67 = fadd float %a6, %a7
+  %b0 = extractelement <4 x float> %b, i32 0
+  %b1 = extractelement <4 x float> %b, i32 1
+  %b2 = extractelement <4 x float> %b, i32 2
+  %b3 = extractelement <4 x float> %b, i32 3
+  %b01 = fadd float %b0, %b1
+  %b23 = fadd float %b2, %b3
+  %hadd0 = insertelement <8 x float> poison, float %a01, i32 0
+  %hadd1 = insertelement <8 x float> %hadd0, float %a23, i32 1
+  %hadd2 = insertelement <8 x float> %hadd1, float %b01, i32 2
+  %hadd3 = insertelement <8 x float> %hadd2, float %b23, i32 3
+  %hadd4 = insertelement <8 x float> %hadd3, float %a45, i32 4
+  %hadd5 = insertelement <8 x float> %hadd4, float %a67, i32 5
+  %result = shufflevector <8 x float> %hadd5, <8 x float> poison, <4 x i32> <i32 0, i32 poison, i32 poison, i32 3>
+  ret <4 x float> %result
+}
+
+define <4 x float> @add_v4f32_8f32_u12u(<4 x float> %a, <8 x float> %b) {
+; CHECK-LABEL: @add_v4f32_8f32_u12u(
+; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <4 x float> [[A:%.*]], <4 x float> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
+; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[TMP1]], <8 x float> [[B:%.*]], <4 x i32> <i32 poison, i32 2, i32 8, i32 poison>
+; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <8 x float> [[TMP1]], <8 x float> [[B]], <4 x i32> <i32 poison, i32 3, i32 9, i32 poison>
+; CHECK-NEXT:    [[RESULT1:%.*]] = fadd <4 x float> [[TMP2]], [[TMP3]]
+; CHECK-NEXT:    ret <4 x float> [[RESULT1]]
+;
+  %a0 = extractelement <4 x float> %a, i32 0
+  %a1 = extractelement <4 x float> %a, i32 1
+  %a2 = extractelement <4 x float> %a, i32 2
+  %a3 = extractelement <4 x float> %a, i32 3
+  %a01 = fadd float %a0, %a1
+  %a23 = fadd float %a2, %a3
+  %b0 = extractelement <8 x float> %b, i32 0
+  %b1 = extractelement <8 x float> %b, i32 1
+  %b2 = extractelement <8 x float> %b, i32 2
+  %b3 = extractelement <8 x float> %b, i32 3
+  %b4 = extractelement <8 x float> %b, i32 4
+  %b5 = extractelement <8 x float> %b, i32 5
+  %b6 = extractelement <8 x float> %b, i32 6
+  %b7 = extractelement <8 x float> %b, i32 7
+  %b01 = fadd float %b0, %b1
+  %b23 = fadd float %b2, %b3
+  %b45 = fadd float %b4, %b5
+  %b67 = fadd float %b6, %b7
+  %hadd0 = insertelement <4 x float> poison, float %a01, i32 0
+  %hadd1 = insertelement <4 x float> %hadd0, float %a23, i32 1
+  %hadd2 = insertelement <4 x float> %hadd1, float %b01, i32 2
+  %hadd3 = insertelement <4 x float> %hadd2, float %b23, i32 3
+  %result = shufflevector <4 x float> %hadd3, <4 x float> poison, <4 x i32> <i32 poison, i32 1, i32 2, i32 poison>
+  ret <4 x float> %result
 }
 
 ;
@@ -2070,6 +2330,201 @@ define <16 x float> @add_v16f32_0145uuuuuuuuuuuu(<16 x float> %a, <16 x float> %
   %haddF = insertelement <16 x float> %haddE, float %bEF, i32 15
   %result = shufflevector <16 x float> %haddF, <16 x float> poison, <16 x i32> <i32 0, i32 1, i32 4, i32 5, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   ret <16 x float> %result
+}
+
+define <4 x float> @add_16f32_0uu3(<16 x float> %a, <16 x float> %b) {
+; SSE2-LABEL: @add_16f32_0uu3(
+; SSE2-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[A:%.*]], <16 x float> [[B:%.*]], <4 x i32> <i32 0, i32 poison, i32 poison, i32 18>
+; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <16 x float> [[A]], <16 x float> [[B]], <4 x i32> <i32 1, i32 poison, i32 poison, i32 19>
+; SSE2-NEXT:    [[TMP3:%.*]] = fadd <4 x float> [[TMP1]], [[TMP2]]
+; SSE2-NEXT:    ret <4 x float> [[TMP3]]
+;
+; SSE4-LABEL: @add_16f32_0uu3(
+; SSE4-NEXT:    [[A0:%.*]] = extractelement <16 x float> [[A:%.*]], i64 0
+; SSE4-NEXT:    [[A1:%.*]] = extractelement <16 x float> [[A]], i64 1
+; SSE4-NEXT:    [[A01:%.*]] = fadd float [[A0]], [[A1]]
+; SSE4-NEXT:    [[B2:%.*]] = extractelement <16 x float> [[B:%.*]], i64 2
+; SSE4-NEXT:    [[B3:%.*]] = extractelement <16 x float> [[B]], i64 3
+; SSE4-NEXT:    [[B23:%.*]] = fadd float [[B2]], [[B3]]
+; SSE4-NEXT:    [[TMP1:%.*]] = insertelement <4 x float> poison, float [[A01]], i64 0
+; SSE4-NEXT:    [[RESULT:%.*]] = insertelement <4 x float> [[TMP1]], float [[B23]], i64 3
+; SSE4-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX2-LABEL: @add_16f32_0uu3(
+; AVX2-NEXT:    [[A0:%.*]] = extractelement <16 x float> [[A:%.*]], i64 0
+; AVX2-NEXT:    [[A1:%.*]] = extractelement <16 x float> [[A]], i64 1
+; AVX2-NEXT:    [[A01:%.*]] = fadd float [[A0]], [[A1]]
+; AVX2-NEXT:    [[B2:%.*]] = extractelement <16 x float> [[B:%.*]], i64 2
+; AVX2-NEXT:    [[B3:%.*]] = extractelement <16 x float> [[B]], i64 3
+; AVX2-NEXT:    [[B23:%.*]] = fadd float [[B2]], [[B3]]
+; AVX2-NEXT:    [[TMP1:%.*]] = insertelement <4 x float> poison, float [[A01]], i64 0
+; AVX2-NEXT:    [[RESULT:%.*]] = insertelement <4 x float> [[TMP1]], float [[B23]], i64 3
+; AVX2-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX512-LABEL: @add_16f32_0uu3(
+; AVX512-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[A:%.*]], <16 x float> [[B:%.*]], <4 x i32> <i32 0, i32 poison, i32 poison, i32 18>
+; AVX512-NEXT:    [[TMP2:%.*]] = shufflevector <16 x float> [[A]], <16 x float> [[B]], <4 x i32> <i32 1, i32 poison, i32 poison, i32 19>
+; AVX512-NEXT:    [[TMP3:%.*]] = fadd <4 x float> [[TMP1]], [[TMP2]]
+; AVX512-NEXT:    ret <4 x float> [[TMP3]]
+;
+  %a0 = extractelement <16 x float> %a, i32 0
+  %a1 = extractelement <16 x float> %a, i32 1
+  %a2 = extractelement <16 x float> %a, i32 2
+  %a3 = extractelement <16 x float> %a, i32 3
+  %a4 = extractelement <16 x float> %a, i32 4
+  %a5 = extractelement <16 x float> %a, i32 5
+  %a6 = extractelement <16 x float> %a, i32 6
+  %a7 = extractelement <16 x float> %a, i32 7
+  %a8 = extractelement <16 x float> %a, i32 8
+  %a9 = extractelement <16 x float> %a, i32 9
+  %aA = extractelement <16 x float> %a, i32 10
+  %aB = extractelement <16 x float> %a, i32 11
+  %aC = extractelement <16 x float> %a, i32 12
+  %aD = extractelement <16 x float> %a, i32 13
+  %aE = extractelement <16 x float> %a, i32 14
+  %aF = extractelement <16 x float> %a, i32 15
+  %a01 = fadd float %a0, %a1
+  %a23 = fadd float %a2, %a3
+  %a45 = fadd float %a4, %a5
+  %a67 = fadd float %a6, %a7
+  %a89 = fadd float %a8, %a9
+  %aAB = fadd float %aA, %aB
+  %aCD = fadd float %aC, %aD
+  %aEF = fadd float %aE, %aF
+  %b0 = extractelement <16 x float> %b, i32 0
+  %b1 = extractelement <16 x float> %b, i32 1
+  %b2 = extractelement <16 x float> %b, i32 2
+  %b3 = extractelement <16 x float> %b, i32 3
+  %b4 = extractelement <16 x float> %b, i32 4
+  %b5 = extractelement <16 x float> %b, i32 5
+  %b6 = extractelement <16 x float> %b, i32 6
+  %b7 = extractelement <16 x float> %b, i32 7
+  %b8 = extractelement <16 x float> %b, i32 8
+  %b9 = extractelement <16 x float> %b, i32 9
+  %bA = extractelement <16 x float> %b, i32 10
+  %bB = extractelement <16 x float> %b, i32 11
+  %bC = extractelement <16 x float> %b, i32 12
+  %bD = extractelement <16 x float> %b, i32 13
+  %bE = extractelement <16 x float> %b, i32 14
+  %bF = extractelement <16 x float> %b, i32 15
+  %b01 = fadd float %b0, %b1
+  %b23 = fadd float %b2, %b3
+  %b45 = fadd float %b4, %b5
+  %b67 = fadd float %b6, %b7
+  %b89 = fadd float %b8, %b9
+  %bAB = fadd float %bA, %bB
+  %bCD = fadd float %bC, %bD
+  %bEF = fadd float %bE, %bF
+  %hadd0 = insertelement <16 x float> poison, float %a01, i32 0
+  %hadd1 = insertelement <16 x float> %hadd0, float %a23, i32 1
+  %hadd2 = insertelement <16 x float> %hadd1, float %b01, i32 2
+  %hadd3 = insertelement <16 x float> %hadd2, float %b23, i32 3
+  %hadd4 = insertelement <16 x float> %hadd3, float %a45, i32 4
+  %hadd5 = insertelement <16 x float> %hadd4, float %a67, i32 5
+  %hadd6 = insertelement <16 x float> %hadd5, float %b45, i32 6
+  %hadd7 = insertelement <16 x float> %hadd6, float %b67, i32 7
+  %hadd8 = insertelement <16 x float> %hadd7, float %a89, i32 8
+  %hadd9 = insertelement <16 x float> %hadd8, float %aAB, i32 9
+  %haddA = insertelement <16 x float> %hadd9, float %b89, i32 10
+  %haddB = insertelement <16 x float> %haddA, float %bAB, i32 11
+  %haddC = insertelement <16 x float> %haddB, float %aCD, i32 12
+  %haddD = insertelement <16 x float> %haddC, float %aEF, i32 13
+  %haddE = insertelement <16 x float> %haddD, float %bCD, i32 14
+  %haddF = insertelement <16 x float> %haddE, float %bEF, i32 15
+  %result = shufflevector <16 x float> %haddF, <16 x float> poison, <4 x i32> <i32 0, i32 poison, i32 poison, i32 3>
+  ret <4 x float> %result
+}
+
+define <8 x float> @add_16f32_uuuu4uu7(<16 x float> %a, <16 x float> %b) {
+; SSE2-LABEL: @add_16f32_uuuu4uu7(
+; SSE2-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[A:%.*]], <16 x float> [[B:%.*]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 22>
+; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <16 x float> [[A]], <16 x float> [[B]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 poison, i32 poison, i32 23>
+; SSE2-NEXT:    [[RESULT1:%.*]] = fadd <8 x float> [[TMP1]], [[TMP2]]
+; SSE2-NEXT:    ret <8 x float> [[RESULT1]]
+;
+; SSE4-LABEL: @add_16f32_uuuu4uu7(
+; SSE4-NEXT:    [[A4:%.*]] = extractelement <16 x float> [[A:%.*]], i64 4
+; SSE4-NEXT:    [[A5:%.*]] = extractelement <16 x float> [[A]], i64 5
+; SSE4-NEXT:    [[A45:%.*]] = fadd float [[A4]], [[A5]]
+; SSE4-NEXT:    [[B6:%.*]] = extractelement <16 x float> [[B:%.*]], i64 6
+; SSE4-NEXT:    [[B7:%.*]] = extractelement <16 x float> [[B]], i64 7
+; SSE4-NEXT:    [[B67:%.*]] = fadd float [[B6]], [[B7]]
+; SSE4-NEXT:    [[TMP1:%.*]] = insertelement <8 x float> poison, float [[A45]], i64 4
+; SSE4-NEXT:    [[RESULT:%.*]] = insertelement <8 x float> [[TMP1]], float [[B67]], i64 7
+; SSE4-NEXT:    ret <8 x float> [[RESULT]]
+;
+; AVX-LABEL: @add_16f32_uuuu4uu7(
+; AVX-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[A:%.*]], <16 x float> [[B:%.*]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 22>
+; AVX-NEXT:    [[TMP2:%.*]] = shufflevector <16 x float> [[A]], <16 x float> [[B]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 poison, i32 poison, i32 23>
+; AVX-NEXT:    [[RESULT1:%.*]] = fadd <8 x float> [[TMP1]], [[TMP2]]
+; AVX-NEXT:    ret <8 x float> [[RESULT1]]
+;
+  %a0 = extractelement <16 x float> %a, i32 0
+  %a1 = extractelement <16 x float> %a, i32 1
+  %a2 = extractelement <16 x float> %a, i32 2
+  %a3 = extractelement <16 x float> %a, i32 3
+  %a4 = extractelement <16 x float> %a, i32 4
+  %a5 = extractelement <16 x float> %a, i32 5
+  %a6 = extractelement <16 x float> %a, i32 6
+  %a7 = extractelement <16 x float> %a, i32 7
+  %a8 = extractelement <16 x float> %a, i32 8
+  %a9 = extractelement <16 x float> %a, i32 9
+  %aA = extractelement <16 x float> %a, i32 10
+  %aB = extractelement <16 x float> %a, i32 11
+  %aC = extractelement <16 x float> %a, i32 12
+  %aD = extractelement <16 x float> %a, i32 13
+  %aE = extractelement <16 x float> %a, i32 14
+  %aF = extractelement <16 x float> %a, i32 15
+  %a01 = fadd float %a0, %a1
+  %a23 = fadd float %a2, %a3
+  %a45 = fadd float %a4, %a5
+  %a67 = fadd float %a6, %a7
+  %a89 = fadd float %a8, %a9
+  %aAB = fadd float %aA, %aB
+  %aCD = fadd float %aC, %aD
+  %aEF = fadd float %aE, %aF
+  %b0 = extractelement <16 x float> %b, i32 0
+  %b1 = extractelement <16 x float> %b, i32 1
+  %b2 = extractelement <16 x float> %b, i32 2
+  %b3 = extractelement <16 x float> %b, i32 3
+  %b4 = extractelement <16 x float> %b, i32 4
+  %b5 = extractelement <16 x float> %b, i32 5
+  %b6 = extractelement <16 x float> %b, i32 6
+  %b7 = extractelement <16 x float> %b, i32 7
+  %b8 = extractelement <16 x float> %b, i32 8
+  %b9 = extractelement <16 x float> %b, i32 9
+  %bA = extractelement <16 x float> %b, i32 10
+  %bB = extractelement <16 x float> %b, i32 11
+  %bC = extractelement <16 x float> %b, i32 12
+  %bD = extractelement <16 x float> %b, i32 13
+  %bE = extractelement <16 x float> %b, i32 14
+  %bF = extractelement <16 x float> %b, i32 15
+  %b01 = fadd float %b0, %b1
+  %b23 = fadd float %b2, %b3
+  %b45 = fadd float %b4, %b5
+  %b67 = fadd float %b6, %b7
+  %b89 = fadd float %b8, %b9
+  %bAB = fadd float %bA, %bB
+  %bCD = fadd float %bC, %bD
+  %bEF = fadd float %bE, %bF
+  %hadd0 = insertelement <16 x float> poison, float %a01, i32 0
+  %hadd1 = insertelement <16 x float> %hadd0, float %a23, i32 1
+  %hadd2 = insertelement <16 x float> %hadd1, float %b01, i32 2
+  %hadd3 = insertelement <16 x float> %hadd2, float %b23, i32 3
+  %hadd4 = insertelement <16 x float> %hadd3, float %a45, i32 4
+  %hadd5 = insertelement <16 x float> %hadd4, float %a67, i32 5
+  %hadd6 = insertelement <16 x float> %hadd5, float %b45, i32 6
+  %hadd7 = insertelement <16 x float> %hadd6, float %b67, i32 7
+  %hadd8 = insertelement <16 x float> %hadd7, float %a89, i32 8
+  %hadd9 = insertelement <16 x float> %hadd8, float %aAB, i32 9
+  %haddA = insertelement <16 x float> %hadd9, float %b89, i32 10
+  %haddB = insertelement <16 x float> %haddA, float %bAB, i32 11
+  %haddC = insertelement <16 x float> %haddB, float %aCD, i32 12
+  %haddD = insertelement <16 x float> %haddC, float %aEF, i32 13
+  %haddE = insertelement <16 x float> %haddD, float %bCD, i32 14
+  %haddF = insertelement <16 x float> %haddE, float %bEF, i32 15
+  %result = shufflevector <16 x float> %haddF, <16 x float> poison, <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 7>
+  ret <8 x float> %result
 }
 
 ;

--- a/llvm/test/Transforms/PhaseOrdering/X86/hsub.ll
+++ b/llvm/test/Transforms/PhaseOrdering/X86/hsub.ll
@@ -1907,6 +1907,66 @@ define <8 x float> @sub_v8f32_0145uuuu(<8 x float> %a, <8 x float> %b) {
   ret <8 x float> %result
 }
 
+define <8 x float> @sub_v8f32_uuuu4uu7(<8 x float> %a, <8 x float> %b) {
+; SSE2-LABEL: @sub_v8f32_uuuu4uu7(
+; SSE2-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[B:%.*]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 14>
+; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[B]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 poison, i32 poison, i32 15>
+; SSE2-NEXT:    [[RESULT1:%.*]] = fsub <8 x float> [[TMP1]], [[TMP2]]
+; SSE2-NEXT:    ret <8 x float> [[RESULT1]]
+;
+; SSE4-LABEL: @sub_v8f32_uuuu4uu7(
+; SSE4-NEXT:    [[A4:%.*]] = extractelement <8 x float> [[A:%.*]], i64 4
+; SSE4-NEXT:    [[A5:%.*]] = extractelement <8 x float> [[A]], i64 5
+; SSE4-NEXT:    [[A45:%.*]] = fsub float [[A4]], [[A5]]
+; SSE4-NEXT:    [[B6:%.*]] = extractelement <8 x float> [[B:%.*]], i64 6
+; SSE4-NEXT:    [[B7:%.*]] = extractelement <8 x float> [[B]], i64 7
+; SSE4-NEXT:    [[B67:%.*]] = fsub float [[B6]], [[B7]]
+; SSE4-NEXT:    [[TMP1:%.*]] = insertelement <8 x float> poison, float [[A45]], i64 4
+; SSE4-NEXT:    [[RESULT:%.*]] = insertelement <8 x float> [[TMP1]], float [[B67]], i64 7
+; SSE4-NEXT:    ret <8 x float> [[RESULT]]
+;
+; AVX-LABEL: @sub_v8f32_uuuu4uu7(
+; AVX-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[B:%.*]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 14>
+; AVX-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[B]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 poison, i32 poison, i32 15>
+; AVX-NEXT:    [[RESULT1:%.*]] = fsub <8 x float> [[TMP1]], [[TMP2]]
+; AVX-NEXT:    ret <8 x float> [[RESULT1]]
+;
+  %a0 = extractelement <8 x float> %a, i32 0
+  %a1 = extractelement <8 x float> %a, i32 1
+  %a2 = extractelement <8 x float> %a, i32 2
+  %a3 = extractelement <8 x float> %a, i32 3
+  %a4 = extractelement <8 x float> %a, i32 4
+  %a5 = extractelement <8 x float> %a, i32 5
+  %a6 = extractelement <8 x float> %a, i32 6
+  %a7 = extractelement <8 x float> %a, i32 7
+  %a01 = fsub float %a0, %a1
+  %a23 = fsub float %a2, %a3
+  %a45 = fsub float %a4, %a5
+  %a67 = fsub float %a6, %a7
+  %b0 = extractelement <8 x float> %b, i32 0
+  %b1 = extractelement <8 x float> %b, i32 1
+  %b2 = extractelement <8 x float> %b, i32 2
+  %b3 = extractelement <8 x float> %b, i32 3
+  %b4 = extractelement <8 x float> %b, i32 4
+  %b5 = extractelement <8 x float> %b, i32 5
+  %b6 = extractelement <8 x float> %b, i32 6
+  %b7 = extractelement <8 x float> %b, i32 7
+  %b01 = fsub float %b0, %b1
+  %b23 = fsub float %b2, %b3
+  %b45 = fsub float %b4, %b5
+  %b67 = fsub float %b6, %b7
+  %hsub0 = insertelement <8 x float> poison, float %a01, i32 0
+  %hsub1 = insertelement <8 x float> %hsub0, float %a23, i32 1
+  %hsub2 = insertelement <8 x float> %hsub1, float %b01, i32 2
+  %hsub3 = insertelement <8 x float> %hsub2, float %b23, i32 3
+  %hsub4 = insertelement <8 x float> %hsub3, float %a45, i32 4
+  %hsub5 = insertelement <8 x float> %hsub4, float %a67, i32 5
+  %hsub6 = insertelement <8 x float> %hsub5, float %b45, i32 6
+  %hsub7 = insertelement <8 x float> %hsub6, float %b67, i32 7
+  %result = shufflevector <8 x float> %hsub7, <8 x float> %a, <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 7>
+  ret <8 x float> %result
+}
+
 define <8 x float> @sub_v8f32_76u43210(<8 x float> %a, <8 x float> %b) {
 ; SSE2-LABEL: @sub_v8f32_76u43210(
 ; SSE2-NEXT:    [[B0:%.*]] = extractelement <8 x float> [[A:%.*]], i64 4
@@ -1970,6 +2030,206 @@ define <8 x float> @sub_v8f32_76u43210(<8 x float> %a, <8 x float> %b) {
   %hsub7 = insertelement <8 x float> %hsub6, float %b67, i32 7
   %result = shufflevector <8 x float> %hsub7, <8 x float> %a, <8 x i32> <i32 7, i32 6, i32 poison, i32 4, i32 3, i32 2, i32 1, i32 0>
   ret <8 x float> %result
+}
+
+define <4 x float> @sub_8f32_0u2u(<8 x float> %a, <8 x float> %b) {
+; SSE2-LABEL: @sub_8f32_0u2u(
+; SSE2-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[B:%.*]], <4 x i32> <i32 0, i32 poison, i32 8, i32 poison>
+; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[B]], <4 x i32> <i32 1, i32 poison, i32 9, i32 poison>
+; SSE2-NEXT:    [[TMP3:%.*]] = fsub <4 x float> [[TMP1]], [[TMP2]]
+; SSE2-NEXT:    ret <4 x float> [[TMP3]]
+;
+; SSE4-LABEL: @sub_8f32_0u2u(
+; SSE4-NEXT:    [[A0:%.*]] = extractelement <8 x float> [[A:%.*]], i64 0
+; SSE4-NEXT:    [[A1:%.*]] = extractelement <8 x float> [[A]], i64 1
+; SSE4-NEXT:    [[A01:%.*]] = fsub float [[A0]], [[A1]]
+; SSE4-NEXT:    [[B0:%.*]] = extractelement <8 x float> [[B:%.*]], i64 0
+; SSE4-NEXT:    [[B1:%.*]] = extractelement <8 x float> [[B]], i64 1
+; SSE4-NEXT:    [[B01:%.*]] = fsub float [[B0]], [[B1]]
+; SSE4-NEXT:    [[TMP1:%.*]] = insertelement <4 x float> poison, float [[A01]], i64 0
+; SSE4-NEXT:    [[RESULT:%.*]] = insertelement <4 x float> [[TMP1]], float [[B01]], i64 2
+; SSE4-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX2-LABEL: @sub_8f32_0u2u(
+; AVX2-NEXT:    [[SHIFT:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> poison, <8 x i32> <i32 1, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[FOLDEXTEXTBINOP:%.*]] = fsub <8 x float> [[A]], [[SHIFT]]
+; AVX2-NEXT:    [[SHIFT2:%.*]] = shufflevector <8 x float> [[B:%.*]], <8 x float> poison, <8 x i32> <i32 1, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[FOLDEXTEXTBINOP3:%.*]] = fsub <8 x float> [[B]], [[SHIFT2]]
+; AVX2-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[FOLDEXTEXTBINOP]], <8 x float> poison, <4 x i32> <i32 0, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[FOLDEXTEXTBINOP3]], <8 x float> poison, <4 x i32> <i32 0, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[RESULT:%.*]] = shufflevector <4 x float> [[TMP1]], <4 x float> [[TMP2]], <4 x i32> <i32 0, i32 poison, i32 4, i32 poison>
+; AVX2-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX512-LABEL: @sub_8f32_0u2u(
+; AVX512-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[B:%.*]], <4 x i32> <i32 0, i32 poison, i32 8, i32 poison>
+; AVX512-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[B]], <4 x i32> <i32 1, i32 poison, i32 9, i32 poison>
+; AVX512-NEXT:    [[TMP3:%.*]] = fsub <4 x float> [[TMP1]], [[TMP2]]
+; AVX512-NEXT:    ret <4 x float> [[TMP3]]
+;
+  %a0 = extractelement <8 x float> %a, i32 0
+  %a1 = extractelement <8 x float> %a, i32 1
+  %a2 = extractelement <8 x float> %a, i32 2
+  %a3 = extractelement <8 x float> %a, i32 3
+  %a4 = extractelement <8 x float> %a, i32 4
+  %a5 = extractelement <8 x float> %a, i32 5
+  %a6 = extractelement <8 x float> %a, i32 6
+  %a7 = extractelement <8 x float> %a, i32 7
+  %a01 = fsub float %a0, %a1
+  %a23 = fsub float %a2, %a3
+  %a45 = fsub float %a4, %a5
+  %a67 = fsub float %a6, %a7
+  %b0 = extractelement <8 x float> %b, i32 0
+  %b1 = extractelement <8 x float> %b, i32 1
+  %b2 = extractelement <8 x float> %b, i32 2
+  %b3 = extractelement <8 x float> %b, i32 3
+  %b4 = extractelement <8 x float> %b, i32 4
+  %b5 = extractelement <8 x float> %b, i32 5
+  %b6 = extractelement <8 x float> %b, i32 6
+  %b7 = extractelement <8 x float> %b, i32 7
+  %b01 = fsub float %b0, %b1
+  %b23 = fsub float %b2, %b3
+  %b45 = fsub float %b4, %b5
+  %b67 = fsub float %b6, %b7
+  %hsub0 = insertelement <4 x float> poison, float %a01, i32 0
+  %hsub1 = insertelement <4 x float> %hsub0, float %a23, i32 1
+  %hsub2 = insertelement <4 x float> %hsub1, float %b01, i32 2
+  %hsub3 = insertelement <4 x float> %hsub2, float %b23, i32 3
+  %result = shufflevector <4 x float> %hsub3, <4 x float> poison, <4 x i32> <i32 0, i32 poison, i32 2, i32 poison>
+  ret <4x float> %result
+}
+
+define <4 x float> @sub_8f32_u1u3(<8 x float> %a, <8 x float> %b) {
+; CHECK-LABEL: @sub_8f32_u1u3(
+; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[B:%.*]], <4 x i32> <i32 poison, i32 2, i32 poison, i32 10>
+; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[B]], <4 x i32> <i32 poison, i32 3, i32 poison, i32 11>
+; CHECK-NEXT:    [[RESULT1:%.*]] = fsub <4 x float> [[TMP1]], [[TMP2]]
+; CHECK-NEXT:    ret <4 x float> [[RESULT1]]
+;
+  %a0 = extractelement <8 x float> %a, i32 0
+  %a1 = extractelement <8 x float> %a, i32 1
+  %a2 = extractelement <8 x float> %a, i32 2
+  %a3 = extractelement <8 x float> %a, i32 3
+  %a4 = extractelement <8 x float> %a, i32 4
+  %a5 = extractelement <8 x float> %a, i32 5
+  %a6 = extractelement <8 x float> %a, i32 6
+  %a7 = extractelement <8 x float> %a, i32 7
+  %a01 = fsub float %a0, %a1
+  %a23 = fsub float %a2, %a3
+  %a45 = fsub float %a4, %a5
+  %a67 = fsub float %a6, %a7
+  %b0 = extractelement <8 x float> %b, i32 0
+  %b1 = extractelement <8 x float> %b, i32 1
+  %b2 = extractelement <8 x float> %b, i32 2
+  %b3 = extractelement <8 x float> %b, i32 3
+  %b4 = extractelement <8 x float> %b, i32 4
+  %b5 = extractelement <8 x float> %b, i32 5
+  %b6 = extractelement <8 x float> %b, i32 6
+  %b7 = extractelement <8 x float> %b, i32 7
+  %b01 = fsub float %b0, %b1
+  %b23 = fsub float %b2, %b3
+  %b45 = fsub float %b4, %b5
+  %b67 = fsub float %b6, %b7
+  %hsub0 = insertelement <4 x float> poison, float %a01, i32 0
+  %hsub1 = insertelement <4 x float> %hsub0, float %a23, i32 1
+  %hsub2 = insertelement <4 x float> %hsub1, float %b01, i32 2
+  %hsub3 = insertelement <4 x float> %hsub2, float %b23, i32 3
+  %result = shufflevector <4 x float> %hsub3, <4 x float> poison, <4 x i32> <i32 poison, i32 1, i32 poison, i32 3>
+  ret <4x float> %result
+}
+
+define <4 x float> @sub_8f32_v4f32_0uuu3(<8 x float> %a, <4 x float> %b) {
+; SSE2-LABEL: @sub_8f32_v4f32_0uuu3(
+; SSE2-NEXT:    [[TMP1:%.*]] = shufflevector <4 x float> [[B:%.*]], <4 x float> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
+; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[TMP1]], <4 x i32> <i32 0, i32 poison, i32 poison, i32 10>
+; SSE2-NEXT:    [[TMP3:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[TMP1]], <4 x i32> <i32 1, i32 poison, i32 poison, i32 11>
+; SSE2-NEXT:    [[TMP4:%.*]] = fsub <4 x float> [[TMP2]], [[TMP3]]
+; SSE2-NEXT:    ret <4 x float> [[TMP4]]
+;
+; SSE4-LABEL: @sub_8f32_v4f32_0uuu3(
+; SSE4-NEXT:    [[A0:%.*]] = extractelement <8 x float> [[A:%.*]], i64 0
+; SSE4-NEXT:    [[A1:%.*]] = extractelement <8 x float> [[A]], i64 1
+; SSE4-NEXT:    [[A01:%.*]] = fsub float [[A0]], [[A1]]
+; SSE4-NEXT:    [[SHIFT:%.*]] = shufflevector <4 x float> [[B:%.*]], <4 x float> poison, <4 x i32> <i32 poison, i32 poison, i32 poison, i32 2>
+; SSE4-NEXT:    [[FOLDEXTEXTBINOP:%.*]] = fsub <4 x float> [[SHIFT]], [[B]]
+; SSE4-NEXT:    [[RESULT:%.*]] = insertelement <4 x float> [[FOLDEXTEXTBINOP]], float [[A01]], i64 0
+; SSE4-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX2-LABEL: @sub_8f32_v4f32_0uuu3(
+; AVX2-NEXT:    [[SHIFT:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> poison, <8 x i32> <i32 1, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[FOLDEXTEXTBINOP:%.*]] = fsub <8 x float> [[A]], [[SHIFT]]
+; AVX2-NEXT:    [[SHIFT2:%.*]] = shufflevector <4 x float> [[B:%.*]], <4 x float> poison, <4 x i32> <i32 poison, i32 poison, i32 poison, i32 2>
+; AVX2-NEXT:    [[FOLDEXTEXTBINOP3:%.*]] = fsub <4 x float> [[SHIFT2]], [[B]]
+; AVX2-NEXT:    [[TMP1:%.*]] = shufflevector <8 x float> [[FOLDEXTEXTBINOP]], <8 x float> poison, <4 x i32> <i32 0, i32 poison, i32 poison, i32 poison>
+; AVX2-NEXT:    [[RESULT:%.*]] = shufflevector <4 x float> [[TMP1]], <4 x float> [[FOLDEXTEXTBINOP3]], <4 x i32> <i32 0, i32 poison, i32 poison, i32 7>
+; AVX2-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX512-LABEL: @sub_8f32_v4f32_0uuu3(
+; AVX512-NEXT:    [[TMP1:%.*]] = shufflevector <4 x float> [[B:%.*]], <4 x float> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
+; AVX512-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[A:%.*]], <8 x float> [[TMP1]], <4 x i32> <i32 0, i32 poison, i32 poison, i32 10>
+; AVX512-NEXT:    [[TMP3:%.*]] = shufflevector <8 x float> [[A]], <8 x float> [[TMP1]], <4 x i32> <i32 1, i32 poison, i32 poison, i32 11>
+; AVX512-NEXT:    [[TMP4:%.*]] = fsub <4 x float> [[TMP2]], [[TMP3]]
+; AVX512-NEXT:    ret <4 x float> [[TMP4]]
+;
+  %a0 = extractelement <8 x float> %a, i32 0
+  %a1 = extractelement <8 x float> %a, i32 1
+  %a2 = extractelement <8 x float> %a, i32 2
+  %a3 = extractelement <8 x float> %a, i32 3
+  %a4 = extractelement <8 x float> %a, i32 4
+  %a5 = extractelement <8 x float> %a, i32 5
+  %a6 = extractelement <8 x float> %a, i32 6
+  %a7 = extractelement <8 x float> %a, i32 7
+  %a01 = fsub float %a0, %a1
+  %a23 = fsub float %a2, %a3
+  %a45 = fsub float %a4, %a5
+  %a67 = fsub float %a6, %a7
+  %b0 = extractelement <4 x float> %b, i32 0
+  %b1 = extractelement <4 x float> %b, i32 1
+  %b2 = extractelement <4 x float> %b, i32 2
+  %b3 = extractelement <4 x float> %b, i32 3
+  %b01 = fsub float %b0, %b1
+  %b23 = fsub float %b2, %b3
+  %hsub0 = insertelement <8 x float> poison, float %a01, i32 0
+  %hsub1 = insertelement <8 x float> %hsub0, float %a23, i32 1
+  %hsub2 = insertelement <8 x float> %hsub1, float %b01, i32 2
+  %hsub3 = insertelement <8 x float> %hsub2, float %b23, i32 3
+  %hsub4 = insertelement <8 x float> %hsub3, float %a45, i32 4
+  %hsub5 = insertelement <8 x float> %hsub4, float %a67, i32 5
+  %result = shufflevector <8 x float> %hsub5, <8 x float> poison, <4 x i32> <i32 0, i32 poison, i32 poison, i32 3>
+  ret <4 x float> %result
+}
+
+define <4 x float> @sub_v4f32_8f32_u12u(<4 x float> %a, <8 x float> %b) {
+; CHECK-LABEL: @sub_v4f32_8f32_u12u(
+; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <4 x float> [[A:%.*]], <4 x float> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
+; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <8 x float> [[TMP1]], <8 x float> [[B:%.*]], <4 x i32> <i32 poison, i32 2, i32 8, i32 poison>
+; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <8 x float> [[TMP1]], <8 x float> [[B]], <4 x i32> <i32 poison, i32 3, i32 9, i32 poison>
+; CHECK-NEXT:    [[RESULT1:%.*]] = fsub <4 x float> [[TMP2]], [[TMP3]]
+; CHECK-NEXT:    ret <4 x float> [[RESULT1]]
+;
+  %a0 = extractelement <4 x float> %a, i32 0
+  %a1 = extractelement <4 x float> %a, i32 1
+  %a2 = extractelement <4 x float> %a, i32 2
+  %a3 = extractelement <4 x float> %a, i32 3
+  %a01 = fsub float %a0, %a1
+  %a23 = fsub float %a2, %a3
+  %b0 = extractelement <8 x float> %b, i32 0
+  %b1 = extractelement <8 x float> %b, i32 1
+  %b2 = extractelement <8 x float> %b, i32 2
+  %b3 = extractelement <8 x float> %b, i32 3
+  %b4 = extractelement <8 x float> %b, i32 4
+  %b5 = extractelement <8 x float> %b, i32 5
+  %b6 = extractelement <8 x float> %b, i32 6
+  %b7 = extractelement <8 x float> %b, i32 7
+  %b01 = fsub float %b0, %b1
+  %b23 = fsub float %b2, %b3
+  %b45 = fsub float %b4, %b5
+  %b67 = fsub float %b6, %b7
+  %hsub0 = insertelement <4 x float> poison, float %a01, i32 0
+  %hsub1 = insertelement <4 x float> %hsub0, float %a23, i32 1
+  %hsub2 = insertelement <4 x float> %hsub1, float %b01, i32 2
+  %hsub3 = insertelement <4 x float> %hsub2, float %b23, i32 3
+  %result = shufflevector <4 x float> %hsub3, <4 x float> poison, <4 x i32> <i32 poison, i32 1, i32 2, i32 poison>
+  ret <4 x float> %result
 }
 
 ;
@@ -2063,6 +2323,201 @@ define <16 x float> @sub_v16f32_0145uuuuuuuuuuuu(<16 x float> %a, <16 x float> %
   %hsubF = insertelement <16 x float> %hsubE, float %bEF, i32 15
   %result = shufflevector <16 x float> %hsubF, <16 x float> poison, <16 x i32> <i32 0, i32 1, i32 4, i32 5, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   ret <16 x float> %result
+}
+
+define <4 x float> @sub_16f32_0uu3(<16 x float> %a, <16 x float> %b) {
+; SSE2-LABEL: @sub_16f32_0uu3(
+; SSE2-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[A:%.*]], <16 x float> [[B:%.*]], <4 x i32> <i32 0, i32 poison, i32 poison, i32 18>
+; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <16 x float> [[A]], <16 x float> [[B]], <4 x i32> <i32 1, i32 poison, i32 poison, i32 19>
+; SSE2-NEXT:    [[TMP3:%.*]] = fsub <4 x float> [[TMP1]], [[TMP2]]
+; SSE2-NEXT:    ret <4 x float> [[TMP3]]
+;
+; SSE4-LABEL: @sub_16f32_0uu3(
+; SSE4-NEXT:    [[A0:%.*]] = extractelement <16 x float> [[A:%.*]], i64 0
+; SSE4-NEXT:    [[A1:%.*]] = extractelement <16 x float> [[A]], i64 1
+; SSE4-NEXT:    [[A01:%.*]] = fsub float [[A0]], [[A1]]
+; SSE4-NEXT:    [[B2:%.*]] = extractelement <16 x float> [[B:%.*]], i64 2
+; SSE4-NEXT:    [[B3:%.*]] = extractelement <16 x float> [[B]], i64 3
+; SSE4-NEXT:    [[B23:%.*]] = fsub float [[B2]], [[B3]]
+; SSE4-NEXT:    [[TMP1:%.*]] = insertelement <4 x float> poison, float [[A01]], i64 0
+; SSE4-NEXT:    [[RESULT:%.*]] = insertelement <4 x float> [[TMP1]], float [[B23]], i64 3
+; SSE4-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX2-LABEL: @sub_16f32_0uu3(
+; AVX2-NEXT:    [[A0:%.*]] = extractelement <16 x float> [[A:%.*]], i64 0
+; AVX2-NEXT:    [[A1:%.*]] = extractelement <16 x float> [[A]], i64 1
+; AVX2-NEXT:    [[A01:%.*]] = fsub float [[A0]], [[A1]]
+; AVX2-NEXT:    [[B2:%.*]] = extractelement <16 x float> [[B:%.*]], i64 2
+; AVX2-NEXT:    [[B3:%.*]] = extractelement <16 x float> [[B]], i64 3
+; AVX2-NEXT:    [[B23:%.*]] = fsub float [[B2]], [[B3]]
+; AVX2-NEXT:    [[TMP1:%.*]] = insertelement <4 x float> poison, float [[A01]], i64 0
+; AVX2-NEXT:    [[RESULT:%.*]] = insertelement <4 x float> [[TMP1]], float [[B23]], i64 3
+; AVX2-NEXT:    ret <4 x float> [[RESULT]]
+;
+; AVX512-LABEL: @sub_16f32_0uu3(
+; AVX512-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[A:%.*]], <16 x float> [[B:%.*]], <4 x i32> <i32 0, i32 poison, i32 poison, i32 18>
+; AVX512-NEXT:    [[TMP2:%.*]] = shufflevector <16 x float> [[A]], <16 x float> [[B]], <4 x i32> <i32 1, i32 poison, i32 poison, i32 19>
+; AVX512-NEXT:    [[TMP3:%.*]] = fsub <4 x float> [[TMP1]], [[TMP2]]
+; AVX512-NEXT:    ret <4 x float> [[TMP3]]
+;
+  %a0 = extractelement <16 x float> %a, i32 0
+  %a1 = extractelement <16 x float> %a, i32 1
+  %a2 = extractelement <16 x float> %a, i32 2
+  %a3 = extractelement <16 x float> %a, i32 3
+  %a4 = extractelement <16 x float> %a, i32 4
+  %a5 = extractelement <16 x float> %a, i32 5
+  %a6 = extractelement <16 x float> %a, i32 6
+  %a7 = extractelement <16 x float> %a, i32 7
+  %a8 = extractelement <16 x float> %a, i32 8
+  %a9 = extractelement <16 x float> %a, i32 9
+  %aA = extractelement <16 x float> %a, i32 10
+  %aB = extractelement <16 x float> %a, i32 11
+  %aC = extractelement <16 x float> %a, i32 12
+  %aD = extractelement <16 x float> %a, i32 13
+  %aE = extractelement <16 x float> %a, i32 14
+  %aF = extractelement <16 x float> %a, i32 15
+  %a01 = fsub float %a0, %a1
+  %a23 = fsub float %a2, %a3
+  %a45 = fsub float %a4, %a5
+  %a67 = fsub float %a6, %a7
+  %a89 = fsub float %a8, %a9
+  %aAB = fsub float %aA, %aB
+  %aCD = fsub float %aC, %aD
+  %aEF = fsub float %aE, %aF
+  %b0 = extractelement <16 x float> %b, i32 0
+  %b1 = extractelement <16 x float> %b, i32 1
+  %b2 = extractelement <16 x float> %b, i32 2
+  %b3 = extractelement <16 x float> %b, i32 3
+  %b4 = extractelement <16 x float> %b, i32 4
+  %b5 = extractelement <16 x float> %b, i32 5
+  %b6 = extractelement <16 x float> %b, i32 6
+  %b7 = extractelement <16 x float> %b, i32 7
+  %b8 = extractelement <16 x float> %b, i32 8
+  %b9 = extractelement <16 x float> %b, i32 9
+  %bA = extractelement <16 x float> %b, i32 10
+  %bB = extractelement <16 x float> %b, i32 11
+  %bC = extractelement <16 x float> %b, i32 12
+  %bD = extractelement <16 x float> %b, i32 13
+  %bE = extractelement <16 x float> %b, i32 14
+  %bF = extractelement <16 x float> %b, i32 15
+  %b01 = fsub float %b0, %b1
+  %b23 = fsub float %b2, %b3
+  %b45 = fsub float %b4, %b5
+  %b67 = fsub float %b6, %b7
+  %b89 = fsub float %b8, %b9
+  %bAB = fsub float %bA, %bB
+  %bCD = fsub float %bC, %bD
+  %bEF = fsub float %bE, %bF
+  %hsub0 = insertelement <16 x float> poison, float %a01, i32 0
+  %hsub1 = insertelement <16 x float> %hsub0, float %a23, i32 1
+  %hsub2 = insertelement <16 x float> %hsub1, float %b01, i32 2
+  %hsub3 = insertelement <16 x float> %hsub2, float %b23, i32 3
+  %hsub4 = insertelement <16 x float> %hsub3, float %a45, i32 4
+  %hsub5 = insertelement <16 x float> %hsub4, float %a67, i32 5
+  %hsub6 = insertelement <16 x float> %hsub5, float %b45, i32 6
+  %hsub7 = insertelement <16 x float> %hsub6, float %b67, i32 7
+  %hsub8 = insertelement <16 x float> %hsub7, float %a89, i32 8
+  %hsub9 = insertelement <16 x float> %hsub8, float %aAB, i32 9
+  %hsubA = insertelement <16 x float> %hsub9, float %b89, i32 10
+  %hsubB = insertelement <16 x float> %hsubA, float %bAB, i32 11
+  %hsubC = insertelement <16 x float> %hsubB, float %aCD, i32 12
+  %hsubD = insertelement <16 x float> %hsubC, float %aEF, i32 13
+  %hsubE = insertelement <16 x float> %hsubD, float %bCD, i32 14
+  %hsubF = insertelement <16 x float> %hsubE, float %bEF, i32 15
+  %result = shufflevector <16 x float> %hsubF, <16 x float> poison, <4 x i32> <i32 0, i32 poison, i32 poison, i32 3>
+  ret <4 x float> %result
+}
+
+define <8 x float> @sub_16f32_uuuu4uu7(<16 x float> %a, <16 x float> %b) {
+; SSE2-LABEL: @sub_16f32_uuuu4uu7(
+; SSE2-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[A:%.*]], <16 x float> [[B:%.*]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 22>
+; SSE2-NEXT:    [[TMP2:%.*]] = shufflevector <16 x float> [[A]], <16 x float> [[B]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 poison, i32 poison, i32 23>
+; SSE2-NEXT:    [[RESULT1:%.*]] = fsub <8 x float> [[TMP1]], [[TMP2]]
+; SSE2-NEXT:    ret <8 x float> [[RESULT1]]
+;
+; SSE4-LABEL: @sub_16f32_uuuu4uu7(
+; SSE4-NEXT:    [[A4:%.*]] = extractelement <16 x float> [[A:%.*]], i64 4
+; SSE4-NEXT:    [[A5:%.*]] = extractelement <16 x float> [[A]], i64 5
+; SSE4-NEXT:    [[A45:%.*]] = fsub float [[A4]], [[A5]]
+; SSE4-NEXT:    [[B6:%.*]] = extractelement <16 x float> [[B:%.*]], i64 6
+; SSE4-NEXT:    [[B7:%.*]] = extractelement <16 x float> [[B]], i64 7
+; SSE4-NEXT:    [[B67:%.*]] = fsub float [[B6]], [[B7]]
+; SSE4-NEXT:    [[TMP1:%.*]] = insertelement <8 x float> poison, float [[A45]], i64 4
+; SSE4-NEXT:    [[RESULT:%.*]] = insertelement <8 x float> [[TMP1]], float [[B67]], i64 7
+; SSE4-NEXT:    ret <8 x float> [[RESULT]]
+;
+; AVX-LABEL: @sub_16f32_uuuu4uu7(
+; AVX-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[A:%.*]], <16 x float> [[B:%.*]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 22>
+; AVX-NEXT:    [[TMP2:%.*]] = shufflevector <16 x float> [[A]], <16 x float> [[B]], <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 poison, i32 poison, i32 23>
+; AVX-NEXT:    [[RESULT1:%.*]] = fsub <8 x float> [[TMP1]], [[TMP2]]
+; AVX-NEXT:    ret <8 x float> [[RESULT1]]
+;
+  %a0 = extractelement <16 x float> %a, i32 0
+  %a1 = extractelement <16 x float> %a, i32 1
+  %a2 = extractelement <16 x float> %a, i32 2
+  %a3 = extractelement <16 x float> %a, i32 3
+  %a4 = extractelement <16 x float> %a, i32 4
+  %a5 = extractelement <16 x float> %a, i32 5
+  %a6 = extractelement <16 x float> %a, i32 6
+  %a7 = extractelement <16 x float> %a, i32 7
+  %a8 = extractelement <16 x float> %a, i32 8
+  %a9 = extractelement <16 x float> %a, i32 9
+  %aA = extractelement <16 x float> %a, i32 10
+  %aB = extractelement <16 x float> %a, i32 11
+  %aC = extractelement <16 x float> %a, i32 12
+  %aD = extractelement <16 x float> %a, i32 13
+  %aE = extractelement <16 x float> %a, i32 14
+  %aF = extractelement <16 x float> %a, i32 15
+  %a01 = fsub float %a0, %a1
+  %a23 = fsub float %a2, %a3
+  %a45 = fsub float %a4, %a5
+  %a67 = fsub float %a6, %a7
+  %a89 = fsub float %a8, %a9
+  %aAB = fsub float %aA, %aB
+  %aCD = fsub float %aC, %aD
+  %aEF = fsub float %aE, %aF
+  %b0 = extractelement <16 x float> %b, i32 0
+  %b1 = extractelement <16 x float> %b, i32 1
+  %b2 = extractelement <16 x float> %b, i32 2
+  %b3 = extractelement <16 x float> %b, i32 3
+  %b4 = extractelement <16 x float> %b, i32 4
+  %b5 = extractelement <16 x float> %b, i32 5
+  %b6 = extractelement <16 x float> %b, i32 6
+  %b7 = extractelement <16 x float> %b, i32 7
+  %b8 = extractelement <16 x float> %b, i32 8
+  %b9 = extractelement <16 x float> %b, i32 9
+  %bA = extractelement <16 x float> %b, i32 10
+  %bB = extractelement <16 x float> %b, i32 11
+  %bC = extractelement <16 x float> %b, i32 12
+  %bD = extractelement <16 x float> %b, i32 13
+  %bE = extractelement <16 x float> %b, i32 14
+  %bF = extractelement <16 x float> %b, i32 15
+  %b01 = fsub float %b0, %b1
+  %b23 = fsub float %b2, %b3
+  %b45 = fsub float %b4, %b5
+  %b67 = fsub float %b6, %b7
+  %b89 = fsub float %b8, %b9
+  %bAB = fsub float %bA, %bB
+  %bCD = fsub float %bC, %bD
+  %bEF = fsub float %bE, %bF
+  %hsub0 = insertelement <16 x float> poison, float %a01, i32 0
+  %hsub1 = insertelement <16 x float> %hsub0, float %a23, i32 1
+  %hsub2 = insertelement <16 x float> %hsub1, float %b01, i32 2
+  %hsub3 = insertelement <16 x float> %hsub2, float %b23, i32 3
+  %hsub4 = insertelement <16 x float> %hsub3, float %a45, i32 4
+  %hsub5 = insertelement <16 x float> %hsub4, float %a67, i32 5
+  %hsub6 = insertelement <16 x float> %hsub5, float %b45, i32 6
+  %hsub7 = insertelement <16 x float> %hsub6, float %b67, i32 7
+  %hsub8 = insertelement <16 x float> %hsub7, float %a89, i32 8
+  %hsub9 = insertelement <16 x float> %hsub8, float %aAB, i32 9
+  %hsubA = insertelement <16 x float> %hsub9, float %b89, i32 10
+  %hsubB = insertelement <16 x float> %hsubA, float %bAB, i32 11
+  %hsubC = insertelement <16 x float> %hsubB, float %aCD, i32 12
+  %hsubD = insertelement <16 x float> %hsubC, float %aEF, i32 13
+  %hsubE = insertelement <16 x float> %hsubD, float %bCD, i32 14
+  %hsubF = insertelement <16 x float> %hsubE, float %bEF, i32 15
+  %result = shufflevector <16 x float> %hsubF, <16 x float> poison, <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 4, i32 poison, i32 poison, i32 7>
+  ret <8 x float> %result
 }
 
 ;


### PR DESCRIPTION
Ensure we have equivalent hadd/sub middle-end test coverage with similar names for lookup