### PR TITLE
[libunwind] include alloca.h in test/aarch64_za_unwind.pass.cpp

### DIFF
--- a/libunwind/test/aarch64_za_unwind.pass.cpp
+++ b/libunwind/test/aarch64_za_unwind.pass.cpp
@@ -9,6 +9,7 @@
 // REQUIRES: target={{aarch64-.+}}
 // UNSUPPORTED: target={{.*-windows.*}}
 
+#include <alloca.h>
 #include <libunwind.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
Glibc provides the alloca function as a part of stdlib.h when _GNU_SOURCE is declared (which is the case with standard linux builds). [1]

On non-glibc systems, this may not be the case (for example, picolibc). These libraries may not implicitly include alloca.h as a part of the standard lib.

[1] https://github.com/bminor/glibc/blob/04e750e75b73957cf1c791535a3f4319534a52fc/stdlib/stdlib.h#L728