### PR TITLE
[lldb] Give every command a single-line short description

### DIFF
--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -536,7 +536,8 @@ public:
   CommandObjectBreakpointAddException(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "breakpoint add exception",
-            "Add breakpoints on language exceptions.  If no language is "
+            "Add breakpoints on language exceptions.\n"
+            "If no language is "
             "specified, break on exceptions for all supported languages",
             nullptr, eCommandAllowsDummyTarget) {
     // Define the first (and only) variant of this arg.
@@ -2041,7 +2042,7 @@ public:
   CommandObjectBreakpointModify(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "breakpoint modify",
                             "Modify the options on a breakpoint or set of "
-                            "breakpoints in the executable.  "
+                            "breakpoints in the executable.\n"
                             "If no breakpoint is specified, acts on the last "
                             "created breakpoint.  "
                             "With the exception of -e, -d and -i, passing an "
@@ -2116,7 +2117,8 @@ class CommandObjectBreakpointEnable : public CommandObjectParsed {
 public:
   CommandObjectBreakpointEnable(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "enable",
-                            "Enable the specified disabled breakpoint(s). If "
+                            "Enable the specified disabled breakpoint(s).\n"
+                            "If "
                             "no breakpoints are specified, enable all of them.",
                             nullptr, eCommandAllowsDummyTarget) {
     CommandObject::AddIDsArgumentData(eBreakpointArgs);
@@ -2203,7 +2205,7 @@ public:
       : CommandObjectParsed(
             interpreter, "breakpoint disable",
             "Disable the specified breakpoint(s) without deleting "
-            "them.  If none are specified, disable all "
+            "them.\nIf none are specified, disable all "
             "breakpoints.",
             nullptr, eCommandAllowsDummyTarget) {
     SetHelpLong(
@@ -2584,7 +2586,7 @@ class CommandObjectBreakpointDelete : public CommandObjectParsed {
 public:
   CommandObjectBreakpointDelete(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "breakpoint delete",
-                            "Delete the specified breakpoint(s).  If no "
+                            "Delete the specified breakpoint(s).\nIf no "
                             "breakpoints are specified, delete them all.",
                             nullptr, eCommandAllowsDummyTarget) {
     CommandObject::AddIDsArgumentData(eBreakpointArgs);
@@ -2890,7 +2892,7 @@ public:
       : CommandObjectParsed(
             interpreter, "configure",
             "Configure the options for the breakpoint"
-            " name provided.  "
+            " name provided.\n"
             "If you provide a breakpoint id, the options will be copied from "
             "the breakpoint, otherwise only the options specified will be set "
             "on the name.",
@@ -3130,7 +3132,7 @@ public:
   CommandObjectBreakpointNameList(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "list",
                             "List either the names for a breakpoint or info "
-                            "about a given name.  With no arguments, lists all "
+                            "about a given name.\nWith no arguments, lists all "
                             "names",
                             "breakpoint name list <command-options>",
                             eCommandAllowsDummyTarget) {
@@ -3507,7 +3509,7 @@ public:
   CommandObjectBreakpointWrite(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "breakpoint write",
                             "Write the breakpoints listed to a file that can "
-                            "be read in with \"breakpoint read\".  "
+                            "be read in with \"breakpoint read\".\n"
                             "If given no arguments, writes all breakpoints.",
                             nullptr, eCommandAllowsDummyTarget) {
     CommandObject::AddIDsArgumentData(eBreakpointArgs);

--- a/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
@@ -32,7 +32,7 @@ public:
   CommandObjectBreakpointCommandAdd(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "add",
                             "Add LLDB commands to a breakpoint, to be executed "
-                            "whenever the breakpoint is hit.  "
+                            "whenever the breakpoint is hit.\n"
                             "The commands added to the breakpoint replace any "
                             "commands previously added to it."
                             "  If no breakpoint is specified, adds the "

--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -2738,7 +2738,8 @@ public:
   CommandObjectCommandsContainerAdd(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "command container add",
-            "Add a container command to lldb.  Adding to built-"
+            "Add a container command to lldb.\n"
+            "Adding to built-"
             "in container commands is not allowed.",
             "command container add [[path1]...] container-name") {
     AddSimpleArgumentList(eArgTypeCommand, eArgRepeatPlus);
@@ -2951,7 +2952,7 @@ public:
   CommandObjectCommandContainer(CommandInterpreter &interpreter)
       : CommandObjectMultiword(
             interpreter, "command container",
-            "Commands for adding container commands to lldb.  "
+            "Commands for adding container commands to lldb.\n"
             "Container commands are containers for other commands.  You can "
             "add nested container commands by specifying a command path, "
             "but you can't add commands into the built-in command hierarchy.",

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -235,7 +235,7 @@ CommandObjectDisassemble::CommandObjectDisassemble(
     CommandInterpreter &interpreter)
     : CommandObjectParsed(
           interpreter, "disassemble",
-          "Disassemble specified instructions in the current target.  "
+          "Disassemble specified instructions in the current target.\n"
           "Defaults to the current function for the current thread and "
           "stack frame.",
           "disassemble [<cmd-options>]", eCommandRequiresTarget) {}

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -258,7 +258,7 @@ CommandObjectExpression::CommandObjectExpression(
     CommandInterpreter &interpreter)
     : CommandObjectRaw(interpreter, "expression",
                        "Evaluate an expression on the current "
-                       "thread.  Displays any returned value "
+                       "thread.\nDisplays any returned value "
                        "with LLDB's default formatting.",
                        "",
                        eCommandProcessMustBePaused | eCommandTryTargetAPILock |

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -402,7 +402,8 @@ public:
   CommandObjectFrameVariable(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "frame variable",
-            "Show variables for the current stack frame. Defaults to all "
+            "Show variables for the current stack frame.\n"
+            "Defaults to all "
             "arguments and local variables in scope. Names of argument, "
             "local, file static and file global variables can be specified.",
             nullptr,

--- a/lldb/source/Commands/CommandObjectLog.cpp
+++ b/lldb/source/Commands/CommandObjectLog.cpp
@@ -288,7 +288,7 @@ public:
   CommandObjectLogList(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "log list",
                             "List the log categories for one or more log "
-                            "channels.  If none specified, lists them all.",
+                            "channels.\nIf none specified, lists them all.",
                             nullptr) {
     AddSimpleArgumentList(eArgTypeLogChannel, eArgRepeatStar);
   }

--- a/lldb/source/Commands/CommandObjectMemoryTag.cpp
+++ b/lldb/source/Commands/CommandObjectMemoryTag.cpp
@@ -26,8 +26,8 @@ class CommandObjectMemoryTagRead : public CommandObjectParsed {
 public:
   CommandObjectMemoryTagRead(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "tag",
-                            "Read memory tags for the given range of memory."
-                            " Mismatched tags will be marked.",
+                            "Read memory tags for the given range of memory.\n"
+                            "Mismatched tags will be marked.",
                             nullptr,
                             eCommandRequiresTarget | eCommandRequiresProcess |
                                 eCommandProcessMustBePaused) {

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -118,7 +118,8 @@ public:
   CommandObjectProcessLaunch(CommandInterpreter &interpreter)
       : CommandObjectProcessLaunchOrAttach(
             interpreter, "process launch",
-            "Launch the executable in the debugger. If no run-args are "
+            "Launch the executable in the debugger.\n"
+            "If no run-args are "
             "specified, the arguments from target.run-args are used.",
             nullptr, eCommandRequiresTarget, "restart"),
 
@@ -1587,7 +1588,8 @@ public:
   CommandObjectProcessHandle(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "process handle",
                             "Manage LLDB handling of OS signals for the "
-                            "current target process.  Defaults to showing "
+                            "current target process.\n"
+                            "Defaults to showing "
                             "current policy.",
                             nullptr, eCommandAllowsDummyTarget) {
     SetHelpLong("\nIf no signals are specified but one or more actions are, "
@@ -1857,7 +1859,8 @@ class CommandObjectProcessTraceStop : public CommandObjectParsed {
 public:
   CommandObjectProcessTraceStop(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "process trace stop",
-                            "Stop tracing this process. This does not affect "
+                            "Stop tracing this process.\n"
+                            "This does not affect "
                             "traces started with the "
                             "\"thread trace start\" command.",
                             "process trace stop",

--- a/lldb/source/Commands/CommandObjectRegister.cpp
+++ b/lldb/source/Commands/CommandObjectRegister.cpp
@@ -42,7 +42,8 @@ public:
       : CommandObjectParsed(
             interpreter, "register read",
             "Dump the contents of one or more register values from the current "
-            "frame.  If no register is specified, dumps them all.",
+            "frame.\n"
+            "If no register is specified, dumps them all.",
             nullptr,
             eCommandRequiresFrame | eCommandRequiresRegContext |
                 eCommandProcessMustBeLaunched | eCommandProcessMustBePaused),

--- a/lldb/source/Commands/CommandObjectScripting.cpp
+++ b/lldb/source/Commands/CommandObjectScripting.cpp
@@ -32,7 +32,7 @@ public:
       : CommandObjectRaw(
             interpreter, "scripting run",
             "Invoke the script interpreter with provided code and display any "
-            "results.  Start the interactive interpreter if no code is "
+            "results.\nStart the interactive interpreter if no code is "
             "supplied.",
             "scripting run [--language <scripting-language> --] "
             "[<script-code>]") {}

--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -248,7 +248,8 @@ public:
   CommandObjectSettingsShow(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "settings show",
                             "Show matching debugger settings and their current "
-                            "values.  Defaults to showing all settings.") {
+                            "values.\n"
+                            "Defaults to showing all settings.") {
     AddSimpleArgumentList(eArgTypeSettingVariableName, eArgRepeatOptional);
   }
 
@@ -339,7 +340,7 @@ public:
             interpreter, "settings export",
             "Write matching debugger settings and their "
             "current values to a file that can be read in with "
-            "\"settings read\". Defaults to writing all settings.",
+            "\"settings read\".\nDefaults to writing all settings.",
             nullptr) {
     AddSimpleArgumentList(eArgTypeSettingVariableName, eArgRepeatOptional);
   }
@@ -504,7 +505,7 @@ class CommandObjectSettingsList : public CommandObjectParsed {
 public:
   CommandObjectSettingsList(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "settings list",
-                            "List and describe matching debugger settings.  "
+                            "List and describe matching debugger settings.\n"
                             "Defaults to all listing all settings.",
                             nullptr) {
     CommandArgumentEntry arg;
@@ -1030,7 +1031,7 @@ public:
   CommandObjectSettingsClear(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "settings clear",
-            "Clear a debugger setting array, dictionary, or string. "
+            "Clear a debugger setting array, dictionary, or string.\n"
             "If '-a' option is specified, it clears all settings.", nullptr) {
     AddSimpleArgumentList(eArgTypeSettingVariableName);
   }

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -119,7 +119,7 @@ public:
       : CommandObjectParsed(
             interpreter, "source info",
             "Display source line information for the current target "
-            "process.  Defaults to instruction pointer in current stack "
+            "process.\nDefaults to instruction pointer in current stack "
             "frame.",
             nullptr, eCommandRequiresTarget) {}
 
@@ -1221,7 +1221,8 @@ class CommandObjectSourceCacheDump : public CommandObjectParsed {
 public:
   CommandObjectSourceCacheDump(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "source cache dump",
-                            "Dump the state of the source code cache. Intended "
+                            "Dump the state of the source code cache.\n"
+                            "Intended "
                             "to be used for debugging LLDB itself.",
                             nullptr) {}
 

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -4886,7 +4886,7 @@ public:
 
   CommandObjectTargetStopHookAdd(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "target stop-hook add",
-                            "Add a hook to be executed when the target stops."
+                            "Add a hook to be executed when the target stops.\n"
                             "The hook can either be a list of commands or an "
                             "appropriately defined Python class.  You can also "
                             "add filters so the hook only runs a certain stop "
@@ -6054,7 +6054,8 @@ public:
   CommandObjectTargetDumpTypesystem(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "target dump typesystem",
-            "Dump the state of the target's internal type system. Intended to "
+            "Dump the state of the target's internal type system.\n"
+            "Intended to "
             "be used for debugging LLDB itself.",
             nullptr, eCommandRequiresTarget) {}
 
@@ -6080,7 +6081,7 @@ public:
   CommandObjectTargetDumpSectionLoadList(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "target dump section-load-list",
-            "Dump the state of the target's internal section load list. "
+            "Dump the state of the target's internal section load list.\n"
             "Intended to be used for debugging LLDB itself.",
             nullptr, eCommandRequiresTarget) {}
 

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -197,7 +197,8 @@ public:
   CommandObjectThreadBacktrace(CommandInterpreter &interpreter)
       : CommandObjectIterateOverThreads(
             interpreter, "thread backtrace",
-            "Show backtraces of thread call stacks.  Defaults to the current "
+            "Show backtraces of thread call stacks.\n"
+            "Defaults to the current "
             "thread, thread indexes can be specified as arguments.\n"
             "Use the thread-index \"all\" to see all threads.\n"
             "Use the thread-index \"unique\" to see threads grouped by unique "
@@ -823,7 +824,8 @@ public:
   CommandObjectThreadContinue(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "thread continue",
-            "Continue execution of the current target process.  One "
+            "Continue execution of the current target process.\n"
+            "One "
             "or more threads may be specified, by default all "
             "threads continue.",
             nullptr,
@@ -1050,7 +1052,8 @@ public:
       : CommandObjectParsed(
             interpreter, "thread until",
             "Continue until a line number or address is reached by the "
-            "current or specified thread.  Stops when returning from "
+            "current or specified thread.\n"
+            "Stops when returning from "
             "the current function as a safety measure.  "
             "The target line number(s) are given as arguments, and if more "
             "than one"
@@ -1492,7 +1495,8 @@ public:
       : CommandObjectIterateOverThreads(
             interpreter, "thread info",
             "Show an extended summary of one or "
-            "more threads.  Defaults to the "
+            "more threads.\n"
+            "Defaults to the "
             "current thread.",
             "thread info",
             eCommandRequiresProcess | eCommandTryTargetAPILock |
@@ -1545,7 +1549,8 @@ public:
   CommandObjectThreadException(CommandInterpreter &interpreter)
       : CommandObjectIterateOverThreads(
             interpreter, "thread exception",
-            "Display the current exception object for a thread. Defaults to "
+            "Display the current exception object for a thread.\n"
+            "Defaults to "
             "the current thread.",
             "thread exception",
             eCommandRequiresProcess | eCommandTryTargetAPILock |
@@ -1596,7 +1601,8 @@ public:
   CommandObjectThreadSiginfo(CommandInterpreter &interpreter)
       : CommandObjectIterateOverThreads(
             interpreter, "thread siginfo",
-            "Display the current siginfo object for a thread. Defaults to "
+            "Display the current siginfo object for a thread.\n"
+            "Defaults to "
             "the current thread.",
             "thread siginfo",
             eCommandRequiresProcess | eCommandTryTargetAPILock |
@@ -1697,7 +1703,8 @@ public:
       : CommandObjectRaw(interpreter, "thread return",
                          "Prematurely return from a stack frame, "
                          "short-circuiting execution of newer frames "
-                         "and optionally yielding a specified value.  Defaults "
+                         "and optionally yielding a specified value.\n"
+                         "Defaults "
                          "to the exiting the current stack "
                          "frame.",
                          "thread return",
@@ -1997,7 +2004,8 @@ public:
   CommandObjectThreadPlanList(CommandInterpreter &interpreter)
       : CommandObjectIterateOverThreads(
             interpreter, "thread plan list",
-            "Show thread plans for one or more threads.  If no threads are "
+            "Show thread plans for one or more threads.\n"
+            "If no threads are "
             "specified, show the "
             "current thread.  Use the thread-index \"all\" to see all threads.",
             nullptr,
@@ -2071,7 +2079,7 @@ public:
   CommandObjectThreadPlanDiscard(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "thread plan discard",
                             "Discards thread plans up to and including the "
-                            "specified index (see 'thread plan list'.)  "
+                            "specified index (see 'thread plan list'.)\n"
                             "Only user visible plans can be discarded.",
                             nullptr,
                             eCommandRequiresProcess | eCommandRequiresThread |
@@ -2130,7 +2138,7 @@ public:
   CommandObjectThreadPlanPrune(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "thread plan prune",
                             "Removes any thread plans associated with "
-                            "currently unreported threads.  "
+                            "currently unreported threads.\n"
                             "Specify one or more TID's to remove, or if no "
                             "TID's are provides, remove threads for all "
                             "unreported threads",
@@ -2243,7 +2251,7 @@ public:
       : CommandObjectMultipleThreads(
             interpreter, "thread trace stop",
             "Stop tracing threads, including the ones traced with the "
-            "\"process trace start\" command."
+            "\"process trace start\" command.\n"
             "Defaults to the current thread. Thread indices can be "
             "specified as arguments.\n Use the thread-index \"all\" to stop "
             "tracing "
@@ -2345,7 +2353,8 @@ public:
   CommandObjectTraceDumpFunctionCalls(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "thread trace dump function-calls",
-            "Dump the traced function-calls for one thread. If no "
+            "Dump the traced function-calls for one thread.\n"
+            "If no "
             "thread is specified, the current thread is used.",
             nullptr,
             eCommandRequiresProcess | eCommandRequiresThread |
@@ -2518,7 +2527,8 @@ public:
   CommandObjectTraceDumpInstructions(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "thread trace dump instructions",
-            "Dump the traced instructions for one thread. If no "
+            "Dump the traced instructions for one thread.\n"
+            "If no "
             "thread is specified, show the current thread.",
             nullptr,
             eCommandRequiresProcess | eCommandRequiresThread |
@@ -2646,7 +2656,8 @@ public:
   CommandObjectTraceDumpInfo(CommandInterpreter &interpreter)
       : CommandObjectIterateOverThreads(
             interpreter, "thread trace dump info",
-            "Dump the traced information for one or more threads.  If no "
+            "Dump the traced information for one or more threads.\n"
+            "If no "
             "threads are specified, show the current thread. Use the "
             "thread-index \"all\" to see all threads.",
             nullptr,
@@ -2746,7 +2757,8 @@ CommandObjectMultiwordThread::CommandObjectMultiwordThread(
   LoadSubCommand("step-in",
                  CommandObjectSP(new CommandObjectThreadStepWithTypeAndScope(
                      interpreter, "thread step-in",
-                     "Source level single step, stepping into calls.  Defaults "
+                     "Source level single step, stepping into calls.\n"
+                     "Defaults "
                      "to current thread unless specified.",
                      nullptr, eStepTypeInto)));
 
@@ -2754,27 +2766,29 @@ CommandObjectMultiwordThread::CommandObjectMultiwordThread(
                  CommandObjectSP(new CommandObjectThreadStepWithTypeAndScope(
                      interpreter, "thread step-out",
                      "Finish executing the current stack frame and stop after "
-                     "returning.  Defaults to current thread unless specified.",
+                     "returning.\n"
+                     "Defaults to current thread unless specified.",
                      nullptr, eStepTypeOut)));
 
   LoadSubCommand("step-over",
                  CommandObjectSP(new CommandObjectThreadStepWithTypeAndScope(
                      interpreter, "thread step-over",
-                     "Source level single step, stepping over calls.  Defaults "
+                     "Source level single step, stepping over calls.\n"
+                     "Defaults "
                      "to current thread unless specified.",
                      nullptr, eStepTypeOver)));
 
   LoadSubCommand("step-inst",
                  CommandObjectSP(new CommandObjectThreadStepWithTypeAndScope(
                      interpreter, "thread step-inst",
-                     "Instruction level single step, stepping into calls.  "
+                     "Instruction level single step, stepping into calls.\n"
                      "Defaults to current thread unless specified.",
                      nullptr, eStepTypeTrace)));
 
   LoadSubCommand("step-inst-over",
                  CommandObjectSP(new CommandObjectThreadStepWithTypeAndScope(
                      interpreter, "thread step-inst-over",
-                     "Instruction level single step, stepping over calls.  "
+                     "Instruction level single step, stepping over calls.\n"
                      "Defaults to current thread unless specified.",
                      nullptr, eStepTypeTraceOver)));
 
@@ -2782,7 +2796,7 @@ CommandObjectMultiwordThread::CommandObjectMultiwordThread(
       "step-scripted",
       CommandObjectSP(new CommandObjectThreadStepWithTypeAndScope(
           interpreter, "thread step-scripted",
-          "Step as instructed by the script class passed in the -C option.  "
+          "Step as instructed by the script class passed in the -C option.\n"
           "You can also specify a dictionary of key (-k) and value (-v) pairs "
           "that will be used to populate an SBStructuredData Dictionary, which "
           "will be passed to the constructor of the class implementing the "

--- a/lldb/source/Commands/CommandObjectTrace.cpp
+++ b/lldb/source/Commands/CommandObjectTrace.cpp
@@ -76,7 +76,7 @@ public:
       : CommandObjectParsed(
             interpreter, "trace save",
             "Save the trace of the current target in the specified directory, "
-            "which will be created if needed. "
+            "which will be created if needed.\n"
             "This directory will contain a trace bundle, with all the "
             "necessary files the reconstruct the trace session even on a "
             "different computer. "

--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -268,7 +268,8 @@ class CommandObjectWatchpointEnable : public CommandObjectParsed {
 public:
   CommandObjectWatchpointEnable(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "enable",
-                            "Enable the specified disabled watchpoint(s). If "
+                            "Enable the specified disabled watchpoint(s).\n"
+                            "If "
                             "no watchpoints are specified, enable all of them.",
                             nullptr, eCommandRequiresTarget) {
     CommandObject::AddIDsArgumentData(eWatchpointArgs);
@@ -338,7 +339,7 @@ public:
   CommandObjectWatchpointDisable(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "watchpoint disable",
                             "Disable the specified watchpoint(s) without "
-                            "removing it/them.  If no watchpoints are "
+                            "removing it/them.\nIf no watchpoints are "
                             "specified, disable them all.",
                             nullptr, eCommandRequiresTarget) {
     CommandObject::AddIDsArgumentData(eWatchpointArgs);
@@ -413,7 +414,7 @@ class CommandObjectWatchpointDelete : public CommandObjectParsed {
 public:
   CommandObjectWatchpointDelete(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "watchpoint delete",
-                            "Delete the specified watchpoint(s).  If no "
+                            "Delete the specified watchpoint(s).\nIf no "
                             "watchpoints are specified, delete them all.",
                             nullptr, eCommandRequiresTarget) {
     CommandObject::AddIDsArgumentData(eWatchpointArgs);
@@ -530,7 +531,7 @@ class CommandObjectWatchpointIgnore : public CommandObjectParsed {
 public:
   CommandObjectWatchpointIgnore(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "watchpoint ignore",
-                            "Set ignore count on the specified watchpoint(s).  "
+                            "Set ignore count on the specified watchpoint(s).\n"
                             "If no watchpoints are specified, set them all.",
                             nullptr, eCommandRequiresTarget) {
     CommandObject::AddIDsArgumentData(eWatchpointArgs);
@@ -647,7 +648,7 @@ public:
       : CommandObjectParsed(
             interpreter, "watchpoint modify",
             "Modify the options on a watchpoint or set of watchpoints in the "
-            "executable.  "
+            "executable.\n"
             "If no watchpoint is specified, act on the last created "
             "watchpoint.  "
             "Passing an empty argument clears the modification.",
@@ -763,7 +764,7 @@ public:
   CommandObjectWatchpointSetVariable(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "watchpoint set variable",
-            "Set a watchpoint on a variable. "
+            "Set a watchpoint on a variable.\n"
             "Use the '-w' option to specify the type of watchpoint and "
             "the '-s' option to specify the byte size to watch for. "
             "If no '-w' option is specified, it defaults to modify. "
@@ -950,7 +951,7 @@ public:
   CommandObjectWatchpointSetExpression(CommandInterpreter &interpreter)
       : CommandObjectRaw(
             interpreter, "watchpoint set expression",
-            "Set a watchpoint on an address by supplying an expression. "
+            "Set a watchpoint on an address by supplying an expression.\n"
             "Use the '-l' option to specify the language of the expression. "
             "Use the '-w' option to specify the type of watchpoint and "
             "the '-s' option to specify the byte size to watch for. "

--- a/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
@@ -34,7 +34,7 @@ public:
   CommandObjectWatchpointCommandAdd(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "add",
                             "Add a set of LLDB commands to a watchpoint, to be "
-                            "executed whenever the watchpoint is hit.  "
+                            "executed whenever the watchpoint is hit.\n"
                             "The commands added to the watchpoint replace any "
                             "commands previously added to it.",
                             nullptr, eCommandRequiresTarget),

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -839,7 +839,8 @@ void CommandInterpreter::LoadCommandDictionary() {
 
   std::unique_ptr<CommandObjectRegexCommand> down_regex_cmd_up(
       new CommandObjectRegexCommand(*this, "_regexp-down",
-                                    "Select a newer stack frame.  Defaults to "
+                                    "Select a newer stack frame.\n"
+                                    "Defaults to "
                                     "moving one frame, a numeric argument can "
                                     "specify an arbitrary number.",
                                     "_regexp-down [<count>]", 0, false));
@@ -856,7 +857,8 @@ void CommandInterpreter::LoadCommandDictionary() {
   std::unique_ptr<CommandObjectRegexCommand> up_regex_cmd_up(
       new CommandObjectRegexCommand(
           *this, "_regexp-up",
-          "Select an older stack frame.  Defaults to moving one "
+          "Select an older stack frame.\n"
+          "Defaults to moving one "
           "frame, a numeric argument can specify an arbitrary number.",
           "_regexp-up [<count>]", 0, false));
   if (up_regex_cmd_up) {
@@ -939,7 +941,8 @@ void CommandInterpreter::LoadCommandDictionary() {
   std::unique_ptr<CommandObjectRegexCommand> bt_regex_cmd_up(
       new CommandObjectRegexCommand(
           *this, "_regexp-bt",
-          "Show backtrace of the current thread's call stack. Any numeric "
+          "Show backtrace of the current thread's call stack.\n"
+          "Any numeric "
           "argument displays at most that many frames. The argument 'all' "
           "displays all threads. Use 'settings set frame-format' to customize "
           "the printing of individual frames and 'settings set thread-format' "

--- a/lldb/test/Shell/Watchpoint/SetErrorCases.test
+++ b/lldb/test/Shell/Watchpoint/SetErrorCases.test
@@ -12,7 +12,7 @@ run
 watchpoint set
 # CHECK: Commands for setting a watchpoint.
 # CHECK: The following subcommands are supported:
-# CHECK: Set a watchpoint on an address by supplying an expression.
+# CHECK: Set a watchpoint on an address by supplying an
 # CHECK: Set a watchpoint on a variable.
 
 watchpoint set variable -w read_write


### PR DESCRIPTION
This patch gives every command a short single-line description on its first line. In combination with #207379, this makes the tab-completion of a large set of commands far less verbose.

assisted-by: claude