### PR TITLE
Forward declare TextEncodingConverter in TextEncoding.h, move config.h into TextEncoding.cpp

### DIFF
--- a/clang/include/clang/Lex/TextEncoding.h
+++ b/clang/include/clang/Lex/TextEncoding.h
@@ -11,7 +11,10 @@
 
 #include "clang/Basic/LangOptions.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/TextEncoding.h"
+
+namespace llvm {
+class TextEncodingConverter;
+} // namespace llvm
 
 namespace clang {
 enum ConversionAction { CA_NoConversion, CA_ToLiteralEncoding };

--- a/clang/lib/Lex/TextEncoding.cpp
+++ b/clang/lib/Lex/TextEncoding.cpp
@@ -8,6 +8,7 @@
 
 #include "clang/Lex/TextEncoding.h"
 #include "clang/Basic/DiagnosticDriver.h"
+#include "llvm/Support/TextEncoding.h"
 
 using namespace clang;
 

--- a/llvm/include/llvm/Support/TextEncoding.h
+++ b/llvm/include/llvm/Support/TextEncoding.h
@@ -17,7 +17,6 @@
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Config/config.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorOr.h"
 

--- a/llvm/lib/Support/TextEncoding.cpp
+++ b/llvm/lib/Support/TextEncoding.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Config/config.h"
 #include "llvm/Support/ConvertEBCDIC.h"
 #include <system_error>
 


### PR DESCRIPTION
This patch forward declares TextEncodingConverter in clang/include/clang/Lex/TextEncoding.h, and moves config.h into llvm/lib/Support/TextEncoding.cpp instead of the header.

This is to fix the lldb error here https://github.com/llvm/llvm-project/pull/138895#issuecomment-4873800781
and the issue mentioned here https://github.com/llvm/llvm-project/pull/138895#issuecomment-4872876628