### PR TITLE
[VectorCombine] isExtractExtractCheap - add dbg message showing OldCost vs NewCost

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -568,6 +568,10 @@ bool VectorCombine::isExtractExtractCheap(ExtractElementInst *Ext0,
     }
   }
 
+  LLVM_DEBUG(dbgs() << "Found a binop of extractions: " << I
+                    << "\n  OldCost: " << OldCost << " vs NewCost: " << NewCost
+                    << "\n");
+
   // Aggressively form a vector op if the cost is equal because the transform
   // may enable further optimization.
   // Codegen can reverse this transform (scalarize) if it was not profitable.

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -568,9 +568,8 @@ bool VectorCombine::isExtractExtractCheap(ExtractElementInst *Ext0,
     }
   }
 
-  LLVM_DEBUG(dbgs() << "Found a binop of extractions: " << I
-                    << "\n  OldCost: " << OldCost << " vs NewCost: " << NewCost
-                    << "\n");
+  LLVM_DEBUG(dbgs() << "Found a binop of extractions: " << I << "\n  OldCost: "
+                    << OldCost << " vs NewCost: " << NewCost << "\n");
 
   // Aggressively form a vector op if the cost is equal because the transform
   // may enable further optimization.


### PR DESCRIPTION
Add missing dbs message for VC fold costs decision