### PR TITLE
[BOLT] Prevent .rela.plt reordering

### DIFF
--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -17,6 +17,7 @@
 #include "bolt/Core/Linker.h"
 #include "bolt/Rewrite/MetadataManager.h"
 #include "bolt/Utils/NameResolver.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/MC/StringTableBuilder.h"
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Object/ObjectFile.h"
@@ -513,6 +514,9 @@ private:
 
   /// True if relocation of specified type came from .rela.plt
   DenseMap<uint64_t, bool> IsJmpRelocation;
+
+  /// Original dynamic relocation order.
+  SmallVector<uint64_t, 0> DynamicRelocationOrder;
 
   /// Index of specified symbol in the dynamic symbol table. NOTE Currently it
   /// is filled and used only with the relocations-related symbols.

--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -516,7 +516,7 @@ private:
   DenseMap<uint64_t, bool> IsJmpRelocation;
 
   /// Original dynamic relocation order.
-  SmallVector<uint64_t, 0> DynamicRelocationOrder;
+  std::vector<uint64_t> DynamicRelocationOrder;
 
   /// Index of specified symbol in the dynamic symbol table. NOTE Currently it
   /// is filled and used only with the relocations-related symbols.

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2799,6 +2799,7 @@ void RewriteInstance::readDynamicRelocations(const SectionRef &Section,
              << " : + 0x" << Twine::utohexstr(Addend) << '\n'
     );
 
+    DynamicRelocationOrder.push_back(Rel.getOffset());
     if (IsJmpRel)
       IsJmpRelocation[RType] = true;
 
@@ -5888,16 +5889,28 @@ RewriteInstance::patchELFAllocatableRelaSections(ELFObjectFile<ELFT> *File) {
     Offset += sizeof(*RelA);
   };
 
-  auto writeRelocations = [&](bool PatchRelative) {
-    for (BinarySection &Section : BC->allocatableSections()) {
+  {
+    for (const uint64_t Address : DynamicRelocationOrder) {
+      ErrorOr<BinarySection &> SectionOrError = BC->getSectionForAddress(Address);
+      if (!SectionOrError) {
+        BC->errs()
+          << "Cannot find section for dynamic relocation at 0x"
+          << Twine::utohexstr(Address)
+          << "\n";
+        exit(1);
+      }
+
+      BinarySection &Section = *SectionOrError;
       const uint64_t SectionInputAddress = Section.getAddress();
       uint64_t SectionAddress = Section.getOutputAddress();
       if (!SectionAddress)
         SectionAddress = SectionInputAddress;
 
-      for (const Relocation &Rel : Section.dynamicRelocations()) {
+      const Relocation &Rel = *Section.getDynamicRelocationAt(Address - SectionInputAddress);
+
+      {
         const bool IsRelative = Rel.isRelative();
-        if (PatchRelative != IsRelative || Rel.isRELR())
+        if (Rel.isRELR())
           continue;
 
         if (IsRelative)
@@ -5941,12 +5954,7 @@ RewriteInstance::patchELFAllocatableRelaSections(ELFObjectFile<ELFT> *File) {
         writeRela(&NewRelA, Offset);
       }
     }
-  };
-
-  // The dynamic linker expects all R_*_RELATIVE relocations in RELA
-  // to be emitted first.
-  writeRelocations(/* PatchRelative */ true);
-  writeRelocations(/* PatchRelative */ false);
+  }
 
   auto fillNone = [&](uint64_t &Offset, uint64_t EndOffset) {
     if (!Offset)

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -5891,12 +5891,11 @@ RewriteInstance::patchELFAllocatableRelaSections(ELFObjectFile<ELFT> *File) {
 
   {
     for (const uint64_t Address : DynamicRelocationOrder) {
-      ErrorOr<BinarySection &> SectionOrError = BC->getSectionForAddress(Address);
+      ErrorOr<BinarySection &> SectionOrError =
+          BC->getSectionForAddress(Address);
       if (!SectionOrError) {
-        BC->errs()
-          << "Cannot find section for dynamic relocation at 0x"
-          << Twine::utohexstr(Address)
-          << "\n";
+        BC->errs() << "Cannot find section for dynamic relocation at 0x"
+                   << Twine::utohexstr(Address) << "\n";
         exit(1);
       }
 
@@ -5906,7 +5905,8 @@ RewriteInstance::patchELFAllocatableRelaSections(ELFObjectFile<ELFT> *File) {
       if (!SectionAddress)
         SectionAddress = SectionInputAddress;
 
-      const Relocation &Rel = *Section.getDynamicRelocationAt(Address - SectionInputAddress);
+      const Relocation &Rel =
+          *Section.getDynamicRelocationAt(Address - SectionInputAddress);
 
       {
         const bool IsRelative = Rel.isRelative();

--- a/bolt/test/AArch64/runtime-relocs.test
+++ b/bolt/test/AArch64/runtime-relocs.test
@@ -10,8 +10,8 @@ RUN: llvm-bolt %t.exe -o %t.bolt.exe --use-old-text=0 --lite=0
 RUN: llvm-readelf -rW %t.bolt.so | FileCheck %s -check-prefix=CHECKLIB
 
 CHECKLIB: {{.*}} R_AARCH64_GLOB_DAT     {{.*}} a + 0
-CHECKLIB: {{.*}} R_AARCH64_TLSDESC      {{.*}} t1 + 0
 CHECKLIB: {{.*}} R_AARCH64_ABS64        {{.*}} a + 0
+CHECKLIB: {{.*}} R_AARCH64_TLSDESC      {{.*}} t1 + 0
 
 // Check relocations in executable:
 

--- a/bolt/test/runtime/X86/rela-plt-order.c
+++ b/bolt/test/runtime/X86/rela-plt-order.c
@@ -1,0 +1,31 @@
+// REQUIRES: x86_64-linux, gnu_ld
+//
+// RUN: split-file %s %t
+// RUN: %clang %cflags -fPIC -shared -o %t/libexample.so \
+// RUN:   %t/example.c
+// RUN: %clang %cflags -fno-pie -no-pie -fuse-ld=bfd \
+// RUN:   -Wl,--emit-relocs -Wl,-rpath,\$ORIGIN -o %t/main %t/main.c \
+// RUN:   -L%t -lexample
+// RUN: llvm-bolt %t/main -o %t/main.bolt
+// RUN: llvm-readelf --dyn-relocations %t/main.bolt | FileCheck %s
+// RUN: %t/main.bolt
+
+// CHECK-LABEL: 'PLT' relocation section
+// CHECK:      R_X86_64_JUMP_SLOT{{.*}}long_name
+// CHECK-NEXT: R_X86_64_IRELATIVE
+
+//--- main.c
+extern int long_name(void);
+
+__attribute__((target_clones("default,avx2"))) int foo(int x) { return x + 1; }
+
+int main(void) {
+  if (foo(1) != 2)
+    return 1;
+  if (long_name() != 0)
+    return 1;
+  return 0;
+}
+
+//--- example.c
+int long_name(void) { return 0; }


### PR DESCRIPTION
BOLT reorders .rela.plt entries without also updating the corresponding PLT stub relocation indices. Rather than patching the stubs, prevent reordering the relocations.

Fixes GH-207222

Can't say I'm super confident working on this code. I tried to come up with a solution with a minimal diff. Please let me know if this is the wrong approach.