### PR TITLE
[AArch64] Fold any/sign-extend of CSET.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -25442,6 +25442,16 @@ static SDValue performExtendCombine(SDNode *N,
   if (SDValue R = performExtendDuplaneTruncCombine(N, DAG))
     return R;
 
+  // Fold an extend of a CSET into its arms:
+  //   ?ext (CSEL 0/1, 1/0, cc, cond) -> CSEL (zext 0/1), (zext 1/0), cc, cond
+  // This is not done for zero-extend since (i64 zext (i32 CSET)) is free.
+  if (N->getOpcode() != ISD::ZERO_EXTEND && VT == MVT::i64 && N0.hasOneUse() &&
+      getCSETCondCode(N0))
+    return DAG.getNode(AArch64ISD::CSEL, dl, VT,
+                       DAG.getNode(ISD::ZERO_EXTEND, dl, VT, N0.getOperand(0)),
+                       DAG.getNode(ISD::ZERO_EXTEND, dl, VT, N0.getOperand(1)),
+                       N0.getOperand(2), N0.getOperand(3));
+
   return SDValue();
 }
 

--- a/llvm/test/CodeGen/AArch64/arm64-fp128.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-fp128.ll
@@ -947,16 +947,14 @@ define <2 x i1> @vec_setcc1(<2 x fp128> %lhs, <2 x fp128> %rhs) {
 ; CHECK-SD-NEXT:    mov v0.16b, v1.16b
 ; CHECK-SD-NEXT:    mov v1.16b, v3.16b
 ; CHECK-SD-NEXT:    bl __letf2
-; CHECK-SD-NEXT:    cmp w0, #0
 ; CHECK-SD-NEXT:    ldp q0, q1, [sp] // 32-byte Folded Reload
-; CHECK-SD-NEXT:    cset w8, le
-; CHECK-SD-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-SD-NEXT:    cmp w0, #0
+; CHECK-SD-NEXT:    csetm x8, le
 ; CHECK-SD-NEXT:    fmov d8, x8
 ; CHECK-SD-NEXT:    bl __letf2
 ; CHECK-SD-NEXT:    cmp w0, #0
 ; CHECK-SD-NEXT:    ldr x30, [sp, #40] // 8-byte Reload
-; CHECK-SD-NEXT:    cset w8, le
-; CHECK-SD-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-SD-NEXT:    csetm x8, le
 ; CHECK-SD-NEXT:    fmov d0, x8
 ; CHECK-SD-NEXT:    zip1 v0.2s, v0.2s, v8.2s
 ; CHECK-SD-NEXT:    ldr d8, [sp, #32] // 8-byte Reload
@@ -1002,16 +1000,14 @@ define <2 x i1> @vec_setcc2(<2 x fp128> %lhs, <2 x fp128> %rhs) {
 ; CHECK-SD-NEXT:    mov v0.16b, v1.16b
 ; CHECK-SD-NEXT:    mov v1.16b, v3.16b
 ; CHECK-SD-NEXT:    bl __letf2
-; CHECK-SD-NEXT:    cmp w0, #0
 ; CHECK-SD-NEXT:    ldp q0, q1, [sp] // 32-byte Folded Reload
-; CHECK-SD-NEXT:    cset w8, gt
-; CHECK-SD-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-SD-NEXT:    cmp w0, #0
+; CHECK-SD-NEXT:    csetm x8, gt
 ; CHECK-SD-NEXT:    fmov d8, x8
 ; CHECK-SD-NEXT:    bl __letf2
 ; CHECK-SD-NEXT:    cmp w0, #0
 ; CHECK-SD-NEXT:    ldr x30, [sp, #40] // 8-byte Reload
-; CHECK-SD-NEXT:    cset w8, gt
-; CHECK-SD-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-SD-NEXT:    csetm x8, gt
 ; CHECK-SD-NEXT:    fmov d0, x8
 ; CHECK-SD-NEXT:    zip1 v0.2s, v0.2s, v8.2s
 ; CHECK-SD-NEXT:    ldr d8, [sp, #32] // 8-byte Reload
@@ -1065,8 +1061,7 @@ define <2 x i1> @vec_setcc3(<2 x fp128> %lhs, <2 x fp128> %rhs) {
 ; CHECK-SD-NEXT:    cmp w0, #0
 ; CHECK-SD-NEXT:    ldp q0, q1, [sp, #32] // 32-byte Folded Reload
 ; CHECK-SD-NEXT:    ccmp w19, #0, #4, eq
-; CHECK-SD-NEXT:    cset w8, eq
-; CHECK-SD-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-SD-NEXT:    csetm x8, eq
 ; CHECK-SD-NEXT:    fmov d8, x8
 ; CHECK-SD-NEXT:    bl __eqtf2
 ; CHECK-SD-NEXT:    ldp q0, q1, [sp, #32] // 32-byte Folded Reload
@@ -1075,8 +1070,7 @@ define <2 x i1> @vec_setcc3(<2 x fp128> %lhs, <2 x fp128> %rhs) {
 ; CHECK-SD-NEXT:    cmp w0, #0
 ; CHECK-SD-NEXT:    ccmp w19, #0, #4, eq
 ; CHECK-SD-NEXT:    ldp x30, x19, [sp, #80] // 16-byte Folded Reload
-; CHECK-SD-NEXT:    cset w8, eq
-; CHECK-SD-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-SD-NEXT:    csetm x8, eq
 ; CHECK-SD-NEXT:    fmov d0, x8
 ; CHECK-SD-NEXT:    zip1 v0.2s, v0.2s, v8.2s
 ; CHECK-SD-NEXT:    ldr d8, [sp, #64] // 8-byte Reload

--- a/llvm/test/CodeGen/AArch64/arm64-neon-v1i1-setcc.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-neon-v1i1-setcc.ll
@@ -13,8 +13,7 @@ define i64 @test_sext_extr_cmp_0(<1 x i64> %v1, <1 x i64> %v2) {
 ; CHECK-NEXT:    fmov x8, d1
 ; CHECK-NEXT:    fmov x9, d0
 ; CHECK-NEXT:    cmp x9, x8
-; CHECK-NEXT:    cset w8, ge
-; CHECK-NEXT:    sbfx x0, x8, #0, #1
+; CHECK-NEXT:    csetm x0, ge
 ; CHECK-NEXT:    ret
   %1 = icmp sge <1 x i64> %v1, %v2
   %2 = extractelement <1 x i1> %1, i32 0
@@ -26,8 +25,7 @@ define i64 @test_sext_extr_cmp_1(<1 x double> %v1, <1 x double> %v2) {
 ; CHECK-LABEL: test_sext_extr_cmp_1:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    fcmp d0, d1
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x0, x8, #0, #1
+; CHECK-NEXT:    csetm x0, eq
 ; CHECK-NEXT:    ret
   %1 = fcmp oeq <1 x double> %v1, %v2
   %2 = extractelement <1 x i1> %1, i32 0

--- a/llvm/test/CodeGen/AArch64/extract-vector-cmp.ll
+++ b/llvm/test/CodeGen/AArch64/extract-vector-cmp.ll
@@ -60,8 +60,7 @@ define i128 @extract_icmp_v1i128(ptr %p) {
 ; CHECK-NEXT:    ldp x9, x8, [x0]
 ; CHECK-NEXT:    orr x8, x9, x8
 ; CHECK-NEXT:    cmp x8, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x0, x8, #0, #1
+; CHECK-NEXT:    csetm x0, eq
 ; CHECK-NEXT:    mov x1, x0
 ; CHECK-NEXT:    ret
   %load = load <1 x i128>, ptr %p, align 16

--- a/llvm/test/CodeGen/AArch64/fcmp.ll
+++ b/llvm/test/CodeGen/AArch64/fcmp.ll
@@ -621,8 +621,7 @@ define <2 x double> @v2f128_double(<2 x fp128> %a, <2 x fp128> %b, <2 x double> 
 ; CHECK-SD-NEXT:    bl __lttf2
 ; CHECK-SD-NEXT:    cmp w0, #0
 ; CHECK-SD-NEXT:    ldr q1, [sp, #32] // 16-byte Reload
-; CHECK-SD-NEXT:    cset w8, mi
-; CHECK-SD-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-SD-NEXT:    csetm x8, mi
 ; CHECK-SD-NEXT:    fmov d0, x8
 ; CHECK-SD-NEXT:    str q0, [sp, #16] // 16-byte Spill
 ; CHECK-SD-NEXT:    ldr q0, [sp] // 16-byte Reload
@@ -630,8 +629,7 @@ define <2 x double> @v2f128_double(<2 x fp128> %a, <2 x fp128> %b, <2 x double> 
 ; CHECK-SD-NEXT:    cmp w0, #0
 ; CHECK-SD-NEXT:    ldr q1, [sp, #16] // 16-byte Reload
 ; CHECK-SD-NEXT:    ldr x30, [sp, #80] // 8-byte Reload
-; CHECK-SD-NEXT:    cset w8, mi
-; CHECK-SD-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-SD-NEXT:    csetm x8, mi
 ; CHECK-SD-NEXT:    fmov d0, x8
 ; CHECK-SD-NEXT:    mov v0.d[1], v1.d[0]
 ; CHECK-SD-NEXT:    ldp q2, q1, [sp, #48] // 32-byte Folded Reload
@@ -696,31 +694,28 @@ define <3 x double> @v3f128_double(<3 x fp128> %a, <3 x fp128> %b, <3 x double> 
 ; CHECK-SD-NEXT:    bl __lttf2
 ; CHECK-SD-NEXT:    cmp w0, #0
 ; CHECK-SD-NEXT:    ldr q1, [sp, #64] // 16-byte Reload
-; CHECK-SD-NEXT:    cset w8, mi
-; CHECK-SD-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-SD-NEXT:    csetm x8, mi
 ; CHECK-SD-NEXT:    fmov d0, x8
 ; CHECK-SD-NEXT:    str q0, [sp] // 16-byte Spill
 ; CHECK-SD-NEXT:    ldr q0, [sp, #16] // 16-byte Reload
 ; CHECK-SD-NEXT:    bl __lttf2
 ; CHECK-SD-NEXT:    cmp w0, #0
 ; CHECK-SD-NEXT:    ldr q0, [sp] // 16-byte Reload
-; CHECK-SD-NEXT:    cset w8, mi
-; CHECK-SD-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-SD-NEXT:    csetm x8, mi
 ; CHECK-SD-NEXT:    fmov d1, x8
 ; CHECK-SD-NEXT:    mov v1.d[1], v0.d[0]
 ; CHECK-SD-NEXT:    str q1, [sp, #64] // 16-byte Spill
 ; CHECK-SD-NEXT:    ldp q0, q1, [sp, #112] // 32-byte Folded Reload
 ; CHECK-SD-NEXT:    bl __lttf2
-; CHECK-SD-NEXT:    cmp w0, #0
 ; CHECK-SD-NEXT:    ldp q1, q0, [sp, #32] // 32-byte Folded Reload
-; CHECK-SD-NEXT:    ldp q2, q4, [sp, #64] // 32-byte Folded Reload
-; CHECK-SD-NEXT:    cset w8, mi
-; CHECK-SD-NEXT:    sbfx x8, x8, #0, #1
-; CHECK-SD-NEXT:    ldr q3, [sp, #96] // 16-byte Reload
+; CHECK-SD-NEXT:    cmp w0, #0
+; CHECK-SD-NEXT:    ldp q2, q3, [sp, #64] // 32-byte Folded Reload
+; CHECK-SD-NEXT:    csetm x8, mi
 ; CHECK-SD-NEXT:    ldr x30, [sp, #144] // 8-byte Reload
 ; CHECK-SD-NEXT:    bit v0.16b, v1.16b, v2.16b
-; CHECK-SD-NEXT:    fmov d2, x8
-; CHECK-SD-NEXT:    bsl v2.16b, v4.16b, v3.16b
+; CHECK-SD-NEXT:    fmov d1, x8
+; CHECK-SD-NEXT:    ldr q2, [sp, #96] // 16-byte Reload
+; CHECK-SD-NEXT:    bit v2.16b, v3.16b, v1.16b
 ; CHECK-SD-NEXT:    mov d1, v0.d[1]
 ; CHECK-SD-NEXT:    // kill: def $d0 killed $d0 killed $q0
 ; CHECK-SD-NEXT:    // kill: def $d2 killed $d2 killed $q2

--- a/llvm/test/CodeGen/AArch64/sme-aarch64-svcount.ll
+++ b/llvm/test/CodeGen/AArch64/sme-aarch64-svcount.ll
@@ -148,10 +148,7 @@ define target("aarch64.svcount") @test_sel_cc(target("aarch64.svcount") %x, targ
 ; CHECK-O0-NEXT:    mov p2.b, p1.b
 ; CHECK-O0-NEXT:    mov p1.b, p0.b
 ; CHECK-O0-NEXT:    subs w8, w0, #42
-; CHECK-O0-NEXT:    cset w9, gt
-; CHECK-O0-NEXT:    // implicit-def: $x8
-; CHECK-O0-NEXT:    mov w8, w9
-; CHECK-O0-NEXT:    sbfx x9, x8, #0, #1
+; CHECK-O0-NEXT:    csetm x9, gt
 ; CHECK-O0-NEXT:    mov x8, xzr
 ; CHECK-O0-NEXT:    whilelo p0.b, x8, x9
 ; CHECK-O0-NEXT:    sel p0.b, p0, p1.b, p2.b
@@ -160,8 +157,7 @@ define target("aarch64.svcount") @test_sel_cc(target("aarch64.svcount") %x, targ
 ; CHECK-O3-LABEL: test_sel_cc:
 ; CHECK-O3:       // %bb.0:
 ; CHECK-O3-NEXT:    cmp w0, #42
-; CHECK-O3-NEXT:    cset w8, gt
-; CHECK-O3-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-O3-NEXT:    csetm x8, gt
 ; CHECK-O3-NEXT:    whilelo p2.b, xzr, x8
 ; CHECK-O3-NEXT:    sel p0.b, p2, p0.b, p1.b
 ; CHECK-O3-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/sve-select.ll
+++ b/llvm/test/CodeGen/AArch64/sve-select.ll
@@ -450,8 +450,7 @@ define <vscale x 2 x half> @icmp_select_nxv2f16(<vscale x 2 x half> %a, <vscale 
 ; CHECK-LABEL: icmp_select_nxv2f16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.d, xzr, x8
 ; CHECK-NEXT:    sel z0.d, p0, z0.d, z1.d
 ; CHECK-NEXT:    ret
@@ -464,8 +463,7 @@ define <vscale x 2 x float> @icmp_select_nxv2f32(<vscale x 2 x float> %a, <vscal
 ; CHECK-LABEL: icmp_select_nxv2f32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.d, xzr, x8
 ; CHECK-NEXT:    sel z0.d, p0, z0.d, z1.d
 ; CHECK-NEXT:    ret
@@ -478,8 +476,7 @@ define <vscale x 2 x double> @icmp_select_nxv2f64(<vscale x 2 x double> %a, <vsc
 ; CHECK-LABEL: icmp_select_nxv2f64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.d, xzr, x8
 ; CHECK-NEXT:    sel z0.d, p0, z0.d, z1.d
 ; CHECK-NEXT:    ret
@@ -492,8 +489,7 @@ define <vscale x 2 x bfloat> @icmp_select_nxv2bf16(<vscale x 2 x bfloat> %a, <vs
 ; CHECK-LABEL: icmp_select_nxv2bf16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.d, xzr, x8
 ; CHECK-NEXT:    sel z0.d, p0, z0.d, z1.d
 ; CHECK-NEXT:    ret
@@ -506,8 +502,7 @@ define <vscale x 4 x half> @icmp_select_nxv4f16(<vscale x 4 x half> %a, <vscale 
 ; CHECK-LABEL: icmp_select_nxv4f16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.s, xzr, x8
 ; CHECK-NEXT:    sel z0.s, p0, z0.s, z1.s
 ; CHECK-NEXT:    ret
@@ -520,8 +515,7 @@ define <vscale x 4 x float> @icmp_select_nxv4f32(<vscale x 4 x float> %a, <vscal
 ; CHECK-LABEL: icmp_select_nxv4f32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.s, xzr, x8
 ; CHECK-NEXT:    sel z0.s, p0, z0.s, z1.s
 ; CHECK-NEXT:    ret
@@ -534,8 +528,7 @@ define <vscale x 4 x bfloat> @icmp_select_nxv4bf16(<vscale x 4 x bfloat> %a, <vs
 ; CHECK-LABEL: icmp_select_nxv4bf16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.s, xzr, x8
 ; CHECK-NEXT:    sel z0.s, p0, z0.s, z1.s
 ; CHECK-NEXT:    ret
@@ -548,8 +541,7 @@ define <vscale x 8 x half> @icmp_select_nxv8f16(<vscale x 8 x half> %a, <vscale 
 ; CHECK-LABEL: icmp_select_nxv8f16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.h, xzr, x8
 ; CHECK-NEXT:    sel z0.h, p0, z0.h, z1.h
 ; CHECK-NEXT:    ret
@@ -562,8 +554,7 @@ define <vscale x 8 x bfloat> @icmp_select_nxv8bf16(<vscale x 8 x bfloat> %a, <vs
 ; CHECK-LABEL: icmp_select_nxv8bf16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.h, xzr, x8
 ; CHECK-NEXT:    sel z0.h, p0, z0.h, z1.h
 ; CHECK-NEXT:    ret
@@ -576,8 +567,7 @@ define <vscale x 1 x i64> @icmp_select_nxv1i64(<vscale x 1 x i64> %a, <vscale x 
 ; CHECK-LABEL: icmp_select_nxv1i64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.d, xzr, x8
 ; CHECK-NEXT:    sel z0.d, p0, z0.d, z1.d
 ; CHECK-NEXT:    ret
@@ -590,8 +580,7 @@ define <vscale x 2 x i64> @icmp_select_nxv2i64(<vscale x 2 x i64> %a, <vscale x 
 ; CHECK-LABEL: icmp_select_nxv2i64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.d, xzr, x8
 ; CHECK-NEXT:    sel z0.d, p0, z0.d, z1.d
 ; CHECK-NEXT:    ret
@@ -604,8 +593,7 @@ define <vscale x 1 x i32> @icmp_select_nxv1i32(<vscale x 1 x i32> %a, <vscale x 
 ; CHECK-LABEL: icmp_select_nxv1i32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.s, xzr, x8
 ; CHECK-NEXT:    sel z0.s, p0, z0.s, z1.s
 ; CHECK-NEXT:    ret
@@ -618,8 +606,7 @@ define <vscale x 4 x i32> @icmp_select_nxv4i32(<vscale x 4 x i32> %a, <vscale x 
 ; CHECK-LABEL: icmp_select_nxv4i32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.s, xzr, x8
 ; CHECK-NEXT:    sel z0.s, p0, z0.s, z1.s
 ; CHECK-NEXT:    ret
@@ -632,8 +619,7 @@ define <vscale x 1 x i16> @icmp_select_nxv1i16(<vscale x 1 x i16> %a, <vscale x 
 ; CHECK-LABEL: icmp_select_nxv1i16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.h, xzr, x8
 ; CHECK-NEXT:    sel z0.h, p0, z0.h, z1.h
 ; CHECK-NEXT:    ret
@@ -646,8 +632,7 @@ define <vscale x 8 x i16> @icmp_select_nxv8i16(<vscale x 8 x i16> %a, <vscale x 
 ; CHECK-LABEL: icmp_select_nxv8i16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.h, xzr, x8
 ; CHECK-NEXT:    sel z0.h, p0, z0.h, z1.h
 ; CHECK-NEXT:    ret
@@ -660,8 +645,7 @@ define  <vscale x 1 x i8> @icmp_select_nxv1i8(<vscale x 1 x i8> %a, <vscale x 1 
 ; CHECK-LABEL: icmp_select_nxv1i8:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.b, xzr, x8
 ; CHECK-NEXT:    sel z0.b, p0, z0.b, z1.b
 ; CHECK-NEXT:    ret
@@ -674,8 +658,7 @@ define  <vscale x 16 x i8> @icmp_select_nxv16i8(<vscale x 16 x i8> %a, <vscale x
 ; CHECK-LABEL: icmp_select_nxv16i8:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p0.b, xzr, x8
 ; CHECK-NEXT:    sel z0.b, p0, z0.b, z1.b
 ; CHECK-NEXT:    ret
@@ -688,8 +671,7 @@ define <vscale x 1 x i1> @icmp_select_nxv1i1(<vscale x 1 x i1> %a, <vscale x 1 x
 ; CHECK-LABEL: icmp_select_nxv1i1:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p2.d, xzr, x8
 ; CHECK-NEXT:    punpklo p2.h, p2.b
 ; CHECK-NEXT:    sel p0.b, p2, p0.b, p1.b
@@ -703,8 +685,7 @@ define <vscale x 2 x i1> @icmp_select_nxv2i1(<vscale x 2 x i1> %a, <vscale x 2 x
 ; CHECK-LABEL: icmp_select_nxv2i1:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p2.d, xzr, x8
 ; CHECK-NEXT:    sel p0.b, p2, p0.b, p1.b
 ; CHECK-NEXT:    ret
@@ -716,8 +697,7 @@ define <vscale x 4 x i1> @icmp_select_nxv4i1(<vscale x 4 x i1> %a, <vscale x 4 x
 ; CHECK-LABEL: icmp_select_nxv4i1:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p2.s, xzr, x8
 ; CHECK-NEXT:    sel p0.b, p2, p0.b, p1.b
 ; CHECK-NEXT:    ret
@@ -729,8 +709,7 @@ define <vscale x 8 x i1> @icmp_select_nxv8i1(<vscale x 8 x i1> %a, <vscale x 8 x
 ; CHECK-LABEL: icmp_select_nxv8i1:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p2.h, xzr, x8
 ; CHECK-NEXT:    sel p0.b, p2, p0.b, p1.b
 ; CHECK-NEXT:    ret
@@ -742,8 +721,7 @@ define <vscale x 16 x i1> @icmp_select_nxv16i1(<vscale x 16 x i1> %a, <vscale x 
 ; CHECK-LABEL: icmp_select_nxv16i1:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    cmp x0, #0
-; CHECK-NEXT:    cset w8, eq
-; CHECK-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-NEXT:    csetm x8, eq
 ; CHECK-NEXT:    whilelo p2.b, xzr, x8
 ; CHECK-NEXT:    sel p0.b, p2, p0.b, p1.b
 ; CHECK-NEXT:    ret


### PR DESCRIPTION
This is useful to enable selecting i64 CSETM when legalisation places an extend between a CSET and sext_inreg.