### PR TITLE
[AMDGPU] Remove obsolet __keep_alive declare in test

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/vgpr-spill-placement-issue61083.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-spill-placement-issue61083.ll
@@ -91,7 +91,6 @@ bb202:                                            ; preds = %bb194, %bb170, %bb9
   ret void
 }
 
-declare hidden void @__keep_alive()
 declare i32 @llvm.amdgcn.workitem.id.x()
 declare align 4 ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
 declare void @llvm.assume(i1 noundef)


### PR DESCRIPTION
__keep_alive doesn't exist anymore since
https://reviews.llvm.org/D151324