### PR TITLE
[lldb] fix a bug in the "Socket::Read" method

### DIFF
--- a/lldb/source/Host/common/Socket.cpp
+++ b/lldb/source/Host/common/Socket.cpp
@@ -63,6 +63,14 @@ static bool IsInterrupted() {
 #endif
 }
 
+static bool WouldBlock() {
+#if defined(_WIN32)
+  return ::WSAGetLastError() == WSAEWOULDBLOCK;
+#else
+  return false;
+#endif
+}
+
 SharedSocket::SharedSocket(const Socket *socket, Status &error) {
 #ifdef _WIN32
   m_socket = socket->GetNativeSocket();
@@ -330,7 +338,7 @@ Status Socket::Read(void *buf, size_t &num_bytes) {
   int bytes_received = 0;
   do {
     bytes_received = ::recv(m_socket, static_cast<char *>(buf), num_bytes, 0);
-  } while (bytes_received < 0 && IsInterrupted());
+  } while (bytes_received < 0 && (IsInterrupted() || WouldBlock()));
 
   if (bytes_received < 0) {
     SetLastError(error);


### PR DESCRIPTION
On Windows, the "Socket::Read" method contains a hidden bug. The original condition

  } while (bytes_received < 0 && IsInterrupted());

for retrying the "::recv" call is too strict.
The "::recv" call may return value "-1" even if the buffer is (accidentally) empty. If the buffer is empty, that should not be regarded as an error. Instead "::recv" should be called again
(similarly to the situation when we have realized that the "::recv" call was interrupted).

See:

  https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv

and

  https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2

    WSAEWOULDBLOCK
    --------------
    Resource temporarily unavailable.
    This error is returned from operations on nonblocking sockets that cannot be completed immediately,
    for example recv when no data is queued to be read from the socket.
    It is a nonfatal error, and the operation should be retried later.