### PR TITLE
[VPlan] Eliminate some vec temps with ArrayRef (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -3468,9 +3468,6 @@ public:
   operand_range operandsWithoutMask() {
     return isPredicated() ? drop_end(operands()) : operands();
   }
-  const_operand_range operandsWithoutMask() const {
-    return isPredicated() ? drop_end(operands()) : operands();
-  }
 
   /// Returns the number of operands, excluding the mask if the recipe is
   /// predicated.

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -3468,6 +3468,9 @@ public:
   operand_range operandsWithoutMask() {
     return isPredicated() ? drop_end(operands()) : operands();
   }
+  const_operand_range operandsWithoutMask() const {
+    return isPredicated() ? drop_end(operands()) : operands();
+  }
 
   /// Returns the number of operands, excluding the mask if the recipe is
   /// predicated.

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -3796,7 +3796,7 @@ InstructionCost VPReplicateRecipe::computeCost(ElementCount VF,
     auto *CalledFn =
         cast<Function>(getOperand(getNumOperands() - 1)->getLiveInIRValue());
     Type *ResultTy = this->getScalarType();
-    return computeCallCost(CalledFn, ResultTy, operandsWithoutMask(),
+    return computeCallCost(CalledFn, ResultTy, drop_end(operands()),
                            isSingleScalar(), VF, Ctx);
   }
   case Instruction::Add:

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2307,8 +2307,7 @@ InstructionCost VPWidenIntrinsicRecipe::computeCallCost(
 
 InstructionCost VPWidenIntrinsicRecipe::computeCost(ElementCount VF,
                                                     VPCostContext &Ctx) const {
-  SmallVector<const VPValue *> ArgOps(operands());
-  return computeCallCost(VectorIntrinsicID, ArgOps, *this, VF, Ctx);
+  return computeCallCost(VectorIntrinsicID, operands(), *this, VF, Ctx);
 }
 
 StringRef VPWidenIntrinsicRecipe::getIntrinsicName() const {
@@ -3797,9 +3796,8 @@ InstructionCost VPReplicateRecipe::computeCost(ElementCount VF,
     auto *CalledFn =
         cast<Function>(getOperand(getNumOperands() - 1)->getLiveInIRValue());
     Type *ResultTy = this->getScalarType();
-    SmallVector<const VPValue *> ArgOps(drop_end(operands()));
-    return computeCallCost(CalledFn, ResultTy, ArgOps, isSingleScalar(), VF,
-                           Ctx);
+    return computeCallCost(CalledFn, ResultTy, operandsWithoutMask(),
+                           isSingleScalar(), VF, Ctx);
   }
   case Instruction::Add:
   case Instruction::Sub:


### PR DESCRIPTION
The enabling change is e56187575 ([ArrayRef] Make iterator_range constructor const-agnostic, #205183).