### PR TITLE
[VPlan] Strip op-UV-check in select-costing

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -1283,8 +1283,7 @@ InstructionCost VPRecipeWithIRFlags::getCostForRecipeWithOpcode(
       const auto [Op2VK, Op2VP] = Ctx.getOperandInfo(Op1);
 
       SmallVector<const Value *, 2> Operands;
-      if (SI && all_of(operands(),
-                       [](VPValue *Op) { return Op->getUnderlyingValue(); }))
+      if (SI)
         append_range(Operands, SI->operands());
       return Ctx.TTI.getArithmeticInstrCost(
           IsLogicalOr ? Instruction::Or : Instruction::And, ResultTy,


### PR DESCRIPTION
It does not make sense to check that the recipe's operands have underlying values when all we're using is the operands of its underlying instruction.