### PR TITLE
[PowerPC] Remove asmstring from PPCPostRAExpPseudo

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -370,23 +370,22 @@ def STQCX : XForm_1_memOp<31, 182, (outs), (ins g8prc:$RST, (memrr $RA, $RB):$ad
 
 def SPLIT_QUADWORD : PPCCustomInserterPseudo<(outs g8rc:$lo, g8rc:$hi),
                                              (ins g8prc:$src)>;
-class AtomicRMW128<string asmstr>
+class AtomicRMW128
   : PPCPostRAExpPseudo<(outs g8prc:$RTp, g8prc:$scratch),
-                       (ins memrr:$ptr, g8rc:$incr_lo, g8rc:$incr_hi),
-                       [], asmstr>;
+                       (ins memrr:$ptr, g8rc:$incr_lo, g8rc:$incr_hi)>;
 // We have to keep values in MI's uses during LL/SC looping as they are,
 // so set both $RTp and $scratch earlyclobber.
 let mayStore = 1, mayLoad = 1,
     Defs = [CR0],
     Constraints = "@earlyclobber $scratch,@earlyclobber $RTp" in {
 // Atomic pseudo instructions expanded post-ra.
-def ATOMIC_SWAP_I128      : AtomicRMW128<"#ATOMIC_SWAP_I128">;
-def ATOMIC_LOAD_ADD_I128  : AtomicRMW128<"#ATOMIC_LOAD_ADD_I128">;
-def ATOMIC_LOAD_SUB_I128  : AtomicRMW128<"#ATOMIC_LOAD_SUB_I128">;
-def ATOMIC_LOAD_AND_I128  : AtomicRMW128<"#ATOMIC_LOAD_AND_I128">;
-def ATOMIC_LOAD_XOR_I128  : AtomicRMW128<"#ATOMIC_LOAD_XOR_I128">;
-def ATOMIC_LOAD_OR_I128   : AtomicRMW128<"#ATOMIC_LOAD_OR_I128">;
-def ATOMIC_LOAD_NAND_I128 : AtomicRMW128<"#ATOMIC_LOAD_NAND_I128">;
+def ATOMIC_SWAP_I128      : AtomicRMW128;
+def ATOMIC_LOAD_ADD_I128  : AtomicRMW128;
+def ATOMIC_LOAD_SUB_I128  : AtomicRMW128;
+def ATOMIC_LOAD_AND_I128  : AtomicRMW128;
+def ATOMIC_LOAD_XOR_I128  : AtomicRMW128;
+def ATOMIC_LOAD_OR_I128   : AtomicRMW128;
+def ATOMIC_LOAD_NAND_I128 : AtomicRMW128;
 
 def ATOMIC_CMP_SWAP_I128 : PPCPostRAExpPseudo<
                               (outs g8prc:$RTp, g8prc:$scratch),

--- a/llvm/lib/Target/PowerPC/PPCInstrFormats.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrFormats.td
@@ -2405,13 +2405,11 @@ class PPCCustomInserterPseudo<dag OOL, dag IOL, list<dag> pattern = []>
 
 // PostRAPseudo will be expanded in expandPostRAPseudo, isPseudo flag in td
 // files is set only for PostRAPseudo
-class PPCPostRAExpPseudo<dag OOL, dag IOL, list<dag> pattern = [],
-                         string asmstr = "#" # NAME>
-    : PPCEmitTimePseudo<OOL, IOL, asmstr, pattern> {
+class PPCPostRAExpPseudo<dag OOL, dag IOL, list<dag> pattern = []>
+    : PPCEmitTimePseudo<OOL, IOL, "", pattern> {
   let isPseudo = 1;
 }
 
-class PseudoXFormMemOp<dag OOL, dag IOL, list<dag> pattern = [],
-                       string asmstr = "#" # NAME>
-    : PPCPostRAExpPseudo<OOL, IOL, pattern, asmstr>, XFormMemOp;
+class PseudoXFormMemOp<dag OOL, dag IOL, list<dag> pattern = []>
+    : PPCPostRAExpPseudo<OOL, IOL, pattern>, XFormMemOp;
 

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -5136,8 +5136,7 @@ def RLWNMbm_rec : PPCAsmPseudo<"rlwnm. $rA, $rS, $n, $b",
                            (ins g8rc:$rA, g8rc:$rS, u5imm:$n, i32imm:$b)>;
 def PPCLdFixedAddr :
   PPCPostRAExpPseudo<(outs gprc:$rT), (ins i32imm:$imm),
-                     [(set i32:$rT, (int_ppc_fixed_addr_ld timm:$imm))],
-                     "#FA_LOAD">;
+                     [(set i32:$rT, (int_ppc_fixed_addr_ld timm:$imm))]>;
 
 // These generic branch instruction forms are used for the assembler parser only.
 // Defs and Uses are conservative, since we don't know the BO value.

--- a/llvm/lib/Target/PowerPC/PPCInstrMMA.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrMMA.td
@@ -505,8 +505,7 @@ let Predicates = [MMA, IsNotISAFuture] in {
               RegConstraint<"$ATi = $AT">;
   def KILL_PAIR : PPCPostRAExpPseudo<(outs vsrprc:$XTp), (ins vsrprc:$XSp)>,
                                       RegConstraint<"$XTp = $XSp">;
-  def BUILD_UACC : PPCPostRAExpPseudo<(outs acc:$AT), (ins uacc:$AS), [],
-                                      "#BUILD_UACC $AT, $AS">;
+  def BUILD_UACC : PPCPostRAExpPseudo<(outs acc:$AT), (ins uacc:$AS)>;
   // We define XXSETACCZ as rematerializable to undo CSE of that intrinsic in
   // the backend. We avoid CSE here because it generates a copy of the acc
   // register and this copy is more expensive than calling the intrinsic again.


### PR DESCRIPTION
The `asmstring` is only used in the `PPCInstPrinter`, but these pseudos are replaced post-RA. Remove the strings since they are never used.