### PR TITLE
[libc++] Inline `text_encoding` alias offset table std::count to 884

### DIFF
--- a/libcxx/include/text_encoding
+++ b/libcxx/include/text_encoding
@@ -792,8 +792,8 @@ private:
       "11\0CP50220\0csCP50220\0";
 
   struct __offset_table {
-    constexpr static unsigned long long __num_aliases =
-        std::count(__aliases_string, __aliases_string + sizeof(__aliases_string), '\0') + 1;
+    constexpr static unsigned long long __num_aliases = 884;
+    // +2 for id::unknown, id::other sentinels
     unsigned short __table[__num_aliases];
   };
 

--- a/libcxx/include/text_encoding
+++ b/libcxx/include/text_encoding
@@ -68,7 +68,6 @@ struct text_encoding
 
 #  if _LIBCPP_STD_VER >= 26
 
-#    include <__algorithm/count.h>
 #    include <__algorithm/find_if.h>
 #    include <__algorithm/lower_bound.h>
 #    include <__cstddef/ptrdiff_t.h>
@@ -623,6 +622,8 @@ public:
   static bool environment_is() = delete;
 #    endif
 
+  constexpr static unsigned long long __num_aliases = 884;
+
 private:
   constexpr const __te_data& __get() const { return __entries[__encoding_idx_]; }
 
@@ -792,8 +793,6 @@ private:
       "11\0CP50220\0csCP50220\0";
 
   struct __offset_table {
-    constexpr static unsigned long long __num_aliases = 884;
-    // +2 for id::unknown, id::other sentinels
     unsigned short __table[__num_aliases];
   };
 
@@ -805,8 +804,7 @@ private:
 
     unsigned long long __idx = 3;
 
-    for (unsigned short __pos = 0; __pos < sizeof(__aliases_string) - 1 && __idx < __offset_table::__num_aliases;
-         __pos++) {
+    for (unsigned short __pos = 0; __pos < sizeof(__aliases_string) - 1 && __idx < __num_aliases; __pos++) {
       if (__aliases_string[__pos] == '\0') {
         __aliases.__table[__idx++] = __pos + 1;
       }

--- a/libcxx/test/libcxx/text/text_encoding/aliases_count.pass.cpp
+++ b/libcxx/test/libcxx/text/text_encoding/aliases_count.pass.cpp
@@ -12,10 +12,7 @@
 // ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-steps): -fconstexpr-steps=40000000
 // ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-ops-limit): -fconstexpr-ops-limit=1000000000
 
-// Our table has 882 aliases exactly, test to make sure that number matches with the total alias count
-// Internally, there are a total of 884 entries in our offset table, 882 for the actual aliases,
-// and +2 reserved as sentinels for id::unknown and id::other
-
+// We implement 882 aliases, test to make sure that number matches with the total alias count.
 #include <cassert>
 #include <ranges>
 #include <text_encoding>
@@ -30,6 +27,8 @@ constexpr bool test() {
     sum += std::ranges::size(te.aliases());
   }
 
+  // +2 reserved as sentinels for id::unknown and id::other
+  // Meaning, our offset table actually contains 884 entries.
   assert(sum == std::text_encoding::__num_aliases - 2);
 
   return true;

--- a/libcxx/test/libcxx/text/text_encoding/aliases_count.pass.cpp
+++ b/libcxx/test/libcxx/text/text_encoding/aliases_count.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <text_encoding>
+
+// REQUIRES: std-at-least-c++26
+// ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-steps): -fconstexpr-steps=40000000
+// ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-ops-limit): -fconstexpr-ops-limit=1000000000
+
+// Our table has 882 aliases exactly, test to make sure that number matches with the total alias count
+// Internally, there are 884 entries with 2 reserved for id::unknown and id::other
+#include <cassert>
+#include <ranges>
+#include <text_encoding>
+
+#include "test_text_encoding.h"
+
+constexpr bool test() {
+  long long sum = 0;
+  for (auto& enc : unique_encoding_data) {
+    std::text_encoding te{std::text_encoding::id(enc.mib)};
+
+    sum += std::ranges::size(te.aliases());
+  }
+
+  assert(sum == 882);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcxx/test/libcxx/text/text_encoding/aliases_count.pass.cpp
+++ b/libcxx/test/libcxx/text/text_encoding/aliases_count.pass.cpp
@@ -13,7 +13,9 @@
 // ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-ops-limit): -fconstexpr-ops-limit=1000000000
 
 // Our table has 882 aliases exactly, test to make sure that number matches with the total alias count
-// Internally, there are 884 entries with 2 reserved for id::unknown and id::other
+// Internally, there are a total of 884 entries in our offset table, 882 for the actual aliases,
+// and +2 reserved as sentinels for id::unknown and id::other
+
 #include <cassert>
 #include <ranges>
 #include <text_encoding>
@@ -28,7 +30,7 @@ constexpr bool test() {
     sum += std::ranges::size(te.aliases());
   }
 
-  assert(sum == 882);
+  assert(sum == std::text_encoding::__num_aliases - 2);
 
   return true;
 }

--- a/libcxx/test/std/text/text_encoding/text_encoding.ctor/id.pass.cpp
+++ b/libcxx/test/std/text/text_encoding/text_encoding.ctor/id.pass.cpp
@@ -19,7 +19,7 @@
 #include <text_encoding>
 #include <type_traits>
 
-#include "../test_text_encoding.h"
+#include "test_text_encoding.h"
 
 using id = std::text_encoding::id;
 

--- a/libcxx/test/std/text/text_encoding/text_encoding.ctor/string_view.pass.cpp
+++ b/libcxx/test/std/text/text_encoding/text_encoding.ctor/string_view.pass.cpp
@@ -19,7 +19,7 @@
 #include <text_encoding>
 #include <type_traits>
 
-#include "../test_text_encoding.h"
+#include "test_text_encoding.h"
 
 using id = std::text_encoding::id;
 

--- a/libcxx/test/std/text/text_encoding/text_encoding.eq/equal.id.pass.cpp
+++ b/libcxx/test/std/text/text_encoding/text_encoding.eq/equal.id.pass.cpp
@@ -16,7 +16,7 @@
 #include <text_encoding>
 
 #include "test_macros.h"
-#include "../test_text_encoding.h"
+#include "test_text_encoding.h"
 
 using id = std::text_encoding::id;
 

--- a/libcxx/test/std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/empty.pass.cpp
+++ b/libcxx/test/std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/empty.pass.cpp
@@ -16,7 +16,7 @@
 #include <ranges>
 #include <text_encoding>
 
-#include "../../test_text_encoding.h"
+#include "test_text_encoding.h"
 
 using id = std::text_encoding::id;
 

--- a/libcxx/test/std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/operator-bool.pass.cpp
+++ b/libcxx/test/std/text/text_encoding/text_encoding.members/text_encoding.aliases_view/operator-bool.pass.cpp
@@ -16,7 +16,7 @@
 #include <ranges>
 #include <text_encoding>
 
-#include "../../test_text_encoding.h"
+#include "test_text_encoding.h"
 
 using id = std::text_encoding::id;
 

--- a/libcxx/test/support/module.modulemap
+++ b/libcxx/test/support/module.modulemap
@@ -7,6 +7,6 @@ module test {
   module double_move_tracker    { header "double_move_tracker.h" }
   module test_allocator         { header "test_allocator.h" }
   module test_iterators         { header "test_iterators.h" }
-  module type_algorithms        { header "type_algorithms.h" }
   module test_text_encoding     { header "test_text_encoding.h" }
+  module type_algorithms        { header "type_algorithms.h" }
 }

--- a/libcxx/test/support/module.modulemap
+++ b/libcxx/test/support/module.modulemap
@@ -8,4 +8,5 @@ module test {
   module test_allocator         { header "test_allocator.h" }
   module test_iterators         { header "test_iterators.h" }
   module type_algorithms        { header "type_algorithms.h" }
+  module test_text_encoding     { header "test_text_encoding.h" }
 }

--- a/libcxx/test/support/test_text_encoding.h
+++ b/libcxx/test/support/test_text_encoding.h
@@ -295,7 +295,6 @@ constexpr inline enc_data all_encoding_data[] = {
     {3, "csASCII"},
     {3, "iso-ir-6"},
     {3, "us"},
-    {3, "ASCII"}, // extension to match libstdc++
     {4, "ISO-8859-1"},
     {4, "ISO_8859-1:1987"},
     {4, "CP819"},

--- a/libcxx/test/support/test_text_encoding.h
+++ b/libcxx/test/support/test_text_encoding.h
@@ -295,6 +295,7 @@ constexpr inline enc_data all_encoding_data[] = {
     {3, "csASCII"},
     {3, "iso-ir-6"},
     {3, "us"},
+    {3, "ASCII"}, // extension to match libstdc++
     {4, "ISO-8859-1"},
     {4, "ISO_8859-1:1987"},
     {4, "CP819"},


### PR DESCRIPTION
- Add count test to verify the exact number of aliases our table contains
- Should reduce compile time cost of gathering that count
