### PR TITLE
Fix APInt::concat for zero-width operands

### DIFF
--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -952,6 +952,8 @@ public:
   /// equivalent to:
   ///   (this->zext(NewWidth) << NewLSB.getBitWidth()) | NewLSB.zext(NewWidth)
   APInt concat(const APInt &NewLSB) const {
+    if (getBitWidth() == 0)
+      return NewLSB;
     /// If the result will be small, then both the merged values are small.
     unsigned NewWidth = getBitWidth() + NewLSB.getBitWidth();
     if (NewWidth <= APINT_BITS_PER_WORD)

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -3132,6 +3132,7 @@ TEST(APIntTest, concat) {
 
   APInt I65(65, 0x3ULL);
   APInt I0 = APInt::getZeroWidth();
+  EXPECT_EQ(I64, I0.concat(I64));
   EXPECT_EQ(I65, I65.concat(I0));
   EXPECT_EQ(I65, I0.concat(I65));
 }


### PR DESCRIPTION
APInt::concat triggered undefined behavior (invalid shift exponent) when concatenating a zero-width operand with a 64-bit operand on the fast path (combined width <= 64).  For example, `I0.concat(I64)` resulted in `U.VAL << 64`, which is UB.
Fix by checking for zero-width operands early and returning the other operand. Added regression tests to `APIntTest.cpp`.