### PR TITLE
Mark test introduced in #205586 as unsupported on Windows because it creates paths that are too long

### DIFF
--- a/clang-tools-extra/test/clang-doc/html/long-name.cpp
+++ b/clang-tools-extra/test/clang-doc/html/long-name.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: clang-doc --output=%t --format=html --executor=standalone %S/../Inputs/long-name.cpp
 // RUN: ls %t/html/GlobalNamespace | FileCheck %s -check-prefix=CHECK-HTML


### PR DESCRIPTION
PR #205586 refactored existing tests and created a new test `clang-tools-extra/test/clang-doc/html/long-name.cpp` which when run on Windows generates a file that exceeds the maximum path length, leading to the directory not being able to be easily deleted. From my bot:
```
Z:\b\llvm-clang-x86_64-sie-win>rmdir /S /Q build
build\tools\clang\tools\extra\test\clang-doc\html\Output\long-name.cpp.tmp\html\GlobalNamespace\_ZTV243ThisStructHasANameThatResultsInAMangledNameThatIsExactly250CharactersLongThatIsSupposedToTestTheFilenameLengthLimitsWithinClangDocInOrdertoSeeifclangdocwillcrashornotdependingonthelengthofthestructIfTheLengthIsTooLongThenClangDocWillCrashAnd12.html - The system cannot find the path specified.
build\tools\clang\tools\extra\test\clang-doc\html\Output\long-name.cpp.tmp\html\GlobalNamespace\_ZTV244ThisStructHasANameThatResultsInAMangledNameThatIsExactly251CharactersLongThatIsSupposedToTestTheFilenameLengthLimitsWithinClangDocInOrdertoSeeifclangdocwillcrashornotdependingonthelengthofthestructIfTheL29DE8558215A13A506661C0E01E50AA3E5C9C7FA.html - The system cannot find the path specified.
build\tools\clang\tools\extra\test\clang-doc\html\Output\long-name.cpp.tmp\json\GlobalNamespace\_ZTV243ThisStructHasANameThatResultsInAMangledNameThatIsExactly250CharactersLongThatIsSupposedToTestTheFilenameLengthLimitsWithinClangDocInOrdertoSeeifclangdocwillcrashornotdependingonthelengthofthestructIfTheLengthIsTooLongThenClangDocWillCrashAnd12.json - The system cannot find the path specified.
build\tools\clang\tools\extra\test\clang-doc\html\Output\long-name.cpp.tmp\json\GlobalNamespace\_ZTV244ThisStructHasANameThatResultsInAMangledNameThatIsExactly251CharactersLongThatIsSupposedToTestTheFilenameLengthLimitsWithinClangDocInOrdertoSeeifclangdocwillcrashornotdependingonthelengthofthestructIfTheL29DE8558215A13A506661C0E01E50AA3E5C9C7FA.json - The system cannot find the path specified.
```
When looking into this, I noticed that there was a practically identical test checked in as `clang-tools-extra/test/clang-doc/json/long-name.cpp` that was marked as `UNSUPPORTED: system-windows`, so this change extends that to this similar test as well.

This should fix build bots being unable to successfully clean the build directory between runs. See https://lab.llvm.org/buildbot/#/builders/46/builds/37142 for an example of a build where the deletion of the build directory failed. The previous run was where the change was first run on the bot and would have introduced the problematic files.