### PR TITLE
[Tooling] Preserve backslashes in POSIX source paths

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -202,6 +202,9 @@ Improvements to clang-tidy
 - Improved :program:`clang-tidy` ``-store-check-profile`` by generating valid
   JSON when the source file path contains characters that require JSON escaping.
 
+- Improved :program:`clang-tidy` by preserving literal backslash characters in
+  POSIX source paths.
+
 - Ensured that :program:`clang-tidy` and the clang compiler uses the same logic
   for the suppression of compiler diagnostics in system headers and expansions
   of macros defined in system headers. Previously the default setting of tidy

--- a/clang/lib/Tooling/Tooling.cpp
+++ b/clang/lib/Tooling/Tooling.cpp
@@ -260,7 +260,7 @@ llvm::Expected<std::string> getAbsolutePath(llvm::vfs::FileSystem &FS,
   SmallString<1024> AbsolutePath = RelativePath;
   if (auto EC = FS.makeAbsolute(AbsolutePath))
     return llvm::errorCodeToError(EC);
-  llvm::sys::path::native(AbsolutePath);
+  llvm::sys::path::make_preferred(AbsolutePath);
   return std::string(AbsolutePath);
 }
 

--- a/clang/unittests/Tooling/ToolingTest.cpp
+++ b/clang/unittests/Tooling/ToolingTest.cpp
@@ -686,8 +686,7 @@ TEST(runToolOnCodeWithArgs, DiagnosticsColor) {
       {"-fcolor-diagnostics"}));
 }
 
-#if !defined(_WIN32)
-TEST(getAbsolutePath, PosixPreservesBackslashes) {
+TEST(getAbsolutePath, BackslashPath) {
   auto FS = llvm::vfs::getRealFileSystem();
   llvm::Expected<std::string> Path = getAbsolutePath(*FS, "a\\b.cc");
   if (!Path)
@@ -696,15 +695,20 @@ TEST(getAbsolutePath, PosixPreservesBackslashes) {
   llvm::ErrorOr<std::string> CWD = FS->getCurrentWorkingDirectory();
   ASSERT_TRUE(CWD) << CWD.getError().message();
 
+#if defined(_WIN32)
+  SmallString<128> Expected(*CWD);
+  llvm::sys::path::append(Expected, "a", "b.cc");
+  llvm::sys::path::make_preferred(Expected);
+  EXPECT_EQ(std::string(Expected), *Path);
+#else
   SmallString<128> Expected(*CWD);
   llvm::sys::path::append(Expected, "a\\b.cc");
   SmallString<128> WithSlash(*CWD);
   llvm::sys::path::append(WithSlash, "a/b.cc");
-
   EXPECT_EQ(std::string(Expected), *Path);
   EXPECT_NE(std::string(WithSlash), *Path);
-}
 #endif
+}
 
 TEST(ClangToolTest, ArgumentAdjusters) {
   FixedCompilationDatabase Compilations("/", std::vector<std::string>());

--- a/clang/unittests/Tooling/ToolingTest.cpp
+++ b/clang/unittests/Tooling/ToolingTest.cpp
@@ -686,6 +686,26 @@ TEST(runToolOnCodeWithArgs, DiagnosticsColor) {
       {"-fcolor-diagnostics"}));
 }
 
+#if !defined(_WIN32)
+TEST(getAbsolutePath, PosixPreservesBackslashes) {
+  auto FS = llvm::vfs::getRealFileSystem();
+  llvm::Expected<std::string> Path = getAbsolutePath(*FS, "a\\b.cc");
+  if (!Path)
+    FAIL() << llvm::toString(Path.takeError());
+
+  llvm::ErrorOr<std::string> CWD = FS->getCurrentWorkingDirectory();
+  ASSERT_TRUE(CWD) << CWD.getError().message();
+
+  SmallString<128> Expected(*CWD);
+  llvm::sys::path::append(Expected, "a\\b.cc");
+  SmallString<128> WithSlash(*CWD);
+  llvm::sys::path::append(WithSlash, "a/b.cc");
+
+  EXPECT_EQ(std::string(Expected), *Path);
+  EXPECT_NE(std::string(WithSlash), *Path);
+}
+#endif
+
 TEST(ClangToolTest, ArgumentAdjusters) {
   FixedCompilationDatabase Compilations("/", std::vector<std::string>());
 


### PR DESCRIPTION
On POSIX, backslashes are valid filename characters. Avoid converting them to slashes when computing absolute source paths in LibTooling, since doing so changes paths such as `a\b.cc` into `a/b.cc`.

Closes #207396