### PR TITLE
[clang] Add noipa attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2420,6 +2420,13 @@ def NoOutline : DeclOrStmtAttr {
   let SimpleHandler = true;
 }
 
+def NoIPA : InheritableAttr {
+  let Spellings = [GCC<"noipa">];
+  let Subjects = SubjectList<[Function]>;
+  let Documentation = [NoIPADocs];
+  let SimpleHandler = 1;
+}
+
 def NoMips16 : InheritableAttr, TargetSpecificAttr<TargetMips32> {
   let Spellings = [GCC<"nomips16">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1046,10 +1046,9 @@ the opposite of inlining. It can help to reduce code size.
 def NoIPADocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{
-This function attribute suppresses interprocedural optimization involving the
-annotated function. Clang lowers it to LLVM IR's ``noipa`` function attribute
-and sets the ```noinline`` function attribute as well, unless always_inline
-is specified.
+This function attribute prevents interprocedural optimizations that require
+analyzing the annotated function's body. It also prevents inlining unless
+``always_inline`` is specified.
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1043,6 +1043,16 @@ the opposite of inlining. It can help to reduce code size.
   }];
 }
 
+def NoIPADocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+This function attribute suppresses interprocedural optimization involving the
+annotated function. Clang lowers it to LLVM IR's ``noipa`` function attribute
+and sets the ```noinline`` function attribute as well, unless always_inline
+is specified.
+  }];
+}
+
 def MustTailDocs : Documentation {
   let Category = DocCatStmt;
   let Content = [{

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3105,6 +3105,12 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
   if (CodeGenOpts.DisableOutlining || D->hasAttr<NoOutlineAttr>())
     B.addAttribute(llvm::Attribute::NoOutline);
 
+  if (D->hasAttr<NoIPAAttr>()) {
+    B.addAttribute(llvm::Attribute::NoIPA);
+    if (!F->hasFnAttribute(llvm::Attribute::AlwaysInline))
+      B.addAttribute(llvm::Attribute::NoInline);
+  }
+
   F->addFnAttrs(B);
 
   llvm::MaybeAlign ExplicitAlignment;

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3107,7 +3107,8 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
 
   if (D->hasAttr<NoIPAAttr>()) {
     B.addAttribute(llvm::Attribute::NoIPA);
-    if (!F->hasFnAttribute(llvm::Attribute::AlwaysInline))
+    if (!D->hasAttr<AlwaysInlineAttr>() &&
+        !F->hasFnAttribute(llvm::Attribute::AlwaysInline))
       B.addAttribute(llvm::Attribute::NoInline);
   }
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3105,12 +3105,8 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
   if (CodeGenOpts.DisableOutlining || D->hasAttr<NoOutlineAttr>())
     B.addAttribute(llvm::Attribute::NoOutline);
 
-  if (D->hasAttr<NoIPAAttr>()) {
+  if (D->hasAttr<NoIPAAttr>())
     B.addAttribute(llvm::Attribute::NoIPA);
-    if (!D->hasAttr<AlwaysInlineAttr>() &&
-        !F->hasFnAttribute(llvm::Attribute::AlwaysInline))
-      B.addAttribute(llvm::Attribute::NoInline);
-  }
 
   F->addFnAttrs(B);
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5220,6 +5220,13 @@ AlwaysInlineAttr *Sema::mergeAlwaysInlineAttr(Decl *D,
   if (D->hasAttr<AlwaysInlineAttr>())
     return nullptr;
 
+  if (const auto *NoIPA = D->getAttr<NoIPAAttr>()) {
+    if (NoInlineAttr *NoInline = D->getAttr<NoInlineAttr>();
+        NoInline && NoInline->isImplicit() &&
+        NoInline->getLocation() == NoIPA->getLocation())
+      D->dropAttr<NoInlineAttr>();
+  }
+
   return ::new (Context) AlwaysInlineAttr(Context, CI);
 }
 
@@ -5296,6 +5303,14 @@ OptimizeNoneAttr *Sema::mergeOptimizeNoneAttr(Decl *D,
     return nullptr;
 
   return ::new (Context) OptimizeNoneAttr(Context, CI);
+}
+
+static void addImplicitNoInlineAttrForNoIPA(Sema &S, Decl *D,
+                                            const NoIPAAttr *A) {
+  if (!A || D->hasAttr<AlwaysInlineAttr>() || D->hasAttr<NoInlineAttr>())
+    return;
+
+  D->addAttr(NoInlineAttr::CreateImplicit(S.Context, A->getLocation()));
 }
 
 static void handleAlwaysInlineAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
@@ -8478,6 +8493,8 @@ void Sema::ProcessDeclAttributeList(
 
   for (const ParsedAttr &AL : AttrList)
     ProcessDeclAttribute(*this, S, D, AL, Options);
+
+  addImplicitNoInlineAttrForNoIPA(*this, D, D->getAttr<NoIPAAttr>());
 
   // FIXME: We should be able to handle these cases in TableGen.
   // GCC accepts

--- a/clang/test/AST/ast-dump-attr.cpp
+++ b/clang/test/AST/ast-dump-attr.cpp
@@ -36,6 +36,27 @@ void TestAttributedStmt() {
 // CHECK:      FunctionDecl{{.*}}TestCXX11DeclAttr
 // CHECK-NEXT:   WarnUnusedResultAttr
 
+void TestNoIPA(void) __attribute__((noipa));
+// CHECK:      FunctionDecl{{.*}}TestNoIPA
+// CHECK-NEXT:   NoIPAAttr
+// CHECK-NEXT:   NoInlineAttr{{.*}} Implicit
+
+void TestNoIPAAlwaysInline(void) __attribute__((noipa, always_inline));
+// CHECK:      FunctionDecl{{.*}}TestNoIPAAlwaysInline
+// CHECK-NEXT:   NoIPAAttr
+// CHECK-NEXT:   AlwaysInlineAttr
+// CHECK-NOT:    NoInlineAttr
+
+void TestInheritedNoIPA(void) __attribute__((noipa));
+void TestInheritedNoIPA(void) {}
+// CHECK:      FunctionDecl{{.*}}TestInheritedNoIPA
+// CHECK-NEXT:   NoIPAAttr
+// CHECK-NEXT:   NoInlineAttr{{.*}} Implicit
+// CHECK:      FunctionDecl{{.*}}TestInheritedNoIPA
+// CHECK-NEXT:   CompoundStmt
+// CHECK-NEXT:   NoIPAAttr{{.*}} Inherited
+// CHECK-NEXT:   NoInlineAttr{{.*}} Implicit
+
 int TestAlignedNull __attribute__((aligned));
 // CHECK:      VarDecl{{.*}}TestAlignedNull
 // CHECK-NEXT:   AlignedAttr {{.*}} aligned

--- a/clang/test/CodeGen/attr-noipa.c
+++ b/clang/test/CodeGen/attr-noipa.c
@@ -26,3 +26,5 @@ static inline __attribute__((noipa, always_inline)) int always_inline_callee(int
 int always_inline_caller(int x) {
   return always_inline_callee(x);
 }
+
+// CHECK: attributes #0 = { {{.*}}noipa noinline

--- a/clang/test/CodeGen/attr-noipa.c
+++ b/clang/test/CodeGen/attr-noipa.c
@@ -1,28 +1,28 @@
-// RUN: %clang_cc1 -emit-llvm -x c %s -triple x86_64-unknown-linux-gnu -O1 -o - | FileCheck %s --check-prefix=C
-// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -std=c++23 -O1 -o - | FileCheck %s --check-prefix=CXX
+// RUN: %clang_cc1 -emit-llvm -x c %s -triple x86_64-unknown-linux-gnu -O1 -o - | FileCheck %s
+// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -O1 -o - | FileCheck %s
 
-// C-LABEL: define {{.*}} @with_noipa(
-// C-SAME: ) {{.*}}#[[NOIPA_ATTR:[0-9]+]] {
+// CHECK-LABEL: define {{.*}} @{{.*}}with_noipa{{.*}}(
+// CHECK-SAME: ) {{.*}}#0 {
 __attribute__((noipa)) int with_noipa(int x) {
   return x + 1;
 }
 
-// C-LABEL: define {{.*}} @without_noipa(
-// C-SAME: ) {{.*}}#[[PLAIN_ATTR:[0-9]+]] {
+// CHECK-LABEL: define {{.*}} @{{.*}}without_noipa{{.*}}(
+// CHECK-SAME: ) {{.*}}#1 {
 int without_noipa(int x) {
   return x - 1;
 }
 
-// CXX-LABEL: define {{.*}} @_Z10with_noipai(
-// CXX-SAME: ) {{.*}}#[[NOIPA_ATTR:[0-9]+]] {
 
-// CXX-LABEL: define {{.*}} @_Z13without_noipai(
-// CXX-SAME: ) {{.*}}#[[PLAIN_ATTR:[0-9]+]] {
+static inline __attribute__((noipa, always_inline)) int always_inline_callee(int x) {
+  return x * 3 + 1;
+}
 
-// C: attributes #[[NOIPA_ATTR]] = { {{.*}}noipa{{.*}} }
-// C: attributes #[[PLAIN_ATTR]] = { {{.*}} }
-// C-NOT: attributes #[[PLAIN_ATTR]] = { {{.*}}noipa{{.*}} }
-
-// CXX: attributes #[[NOIPA_ATTR]] = { {{.*}}noipa{{.*}} }
-// CXX: attributes #[[PLAIN_ATTR]] = { {{.*}} }
-// CXX-NOT: attributes #[[PLAIN_ATTR]] = { {{.*}}noipa{{.*}} }
+// CHECK-LABEL: define {{.*}} @{{.*}}always_inline_caller{{.*}}(
+// CHECK-NOT: call {{.*}}always_inline_callee{{.*}}
+// CHECK: mul nsw i32
+// CHECK: add nsw i32
+// CHECK: ret i32
+int always_inline_caller(int x) {
+  return always_inline_callee(x);
+}

--- a/clang/test/CodeGen/attr-noipa.c
+++ b/clang/test/CodeGen/attr-noipa.c
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -emit-llvm -x c %s -triple x86_64-unknown-linux-gnu -O1 -o - | FileCheck %s --check-prefix=C
+// RUN: %clang_cc1 -emit-llvm -x c++ %s -triple x86_64-unknown-linux-gnu -std=c++23 -O1 -o - | FileCheck %s --check-prefix=CXX
+
+// C-LABEL: define {{.*}} @with_noipa(
+// C-SAME: ) {{.*}}#[[NOIPA_ATTR:[0-9]+]] {
+__attribute__((noipa)) int with_noipa(int x) {
+  return x + 1;
+}
+
+// C-LABEL: define {{.*}} @without_noipa(
+// C-SAME: ) {{.*}}#[[PLAIN_ATTR:[0-9]+]] {
+int without_noipa(int x) {
+  return x - 1;
+}
+
+// CXX-LABEL: define {{.*}} @_Z10with_noipai(
+// CXX-SAME: ) {{.*}}#[[NOIPA_ATTR:[0-9]+]] {
+
+// CXX-LABEL: define {{.*}} @_Z13without_noipai(
+// CXX-SAME: ) {{.*}}#[[PLAIN_ATTR:[0-9]+]] {
+
+// C: attributes #[[NOIPA_ATTR]] = { {{.*}}noipa{{.*}} }
+// C: attributes #[[PLAIN_ATTR]] = { {{.*}} }
+// C-NOT: attributes #[[PLAIN_ATTR]] = { {{.*}}noipa{{.*}} }
+
+// CXX: attributes #[[NOIPA_ATTR]] = { {{.*}}noipa{{.*}} }
+// CXX: attributes #[[PLAIN_ATTR]] = { {{.*}} }
+// CXX-NOT: attributes #[[PLAIN_ATTR]] = { {{.*}}noipa{{.*}} }

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -127,6 +127,7 @@
 // CHECK-NEXT: NoDuplicate (SubjectMatchRule_function)
 // CHECK-NEXT: NoEscape (SubjectMatchRule_variable_is_parameter)
 // CHECK-NEXT: NoFieldProtection (SubjectMatchRule_field)
+// CHECK-NEXT: NoIPA (SubjectMatchRule_function)
 // CHECK-NEXT: NoInline (SubjectMatchRule_function)
 // CHECK-NEXT: NoInstrumentFunction (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: NoMerge (SubjectMatchRule_function, SubjectMatchRule_variable)

--- a/clang/test/Sema/attr-noipa.c
+++ b/clang/test/Sema/attr-noipa.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -verify -fsyntax-only %s
+// RUN: %clang_cc1 -verify -fsyntax-only -x c++ %s
 
 __attribute__((noipa)) int a; // expected-warning {{'noipa' attribute only applies to functions}}
 

--- a/clang/test/Sema/attr-noipa.c
+++ b/clang/test/Sema/attr-noipa.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -verify -fsyntax-only %s
+
+__attribute__((noipa)) int a; // expected-warning {{'noipa' attribute only applies to functions}}
+
+__attribute__((noipa)) void t1(void);
+
+__attribute__((noipa(2))) void t2(void); // expected-error {{'noipa' attribute takes no arguments}}

--- a/clang/test/Sema/attr-noipa.cpp
+++ b/clang/test/Sema/attr-noipa.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -verify -fsyntax-only %s
+
+__attribute__((noipa)) int a; // expected-warning {{'noipa' attribute only applies to functions}}
+
+__attribute__((noipa)) void t1();
+
+__attribute__((noipa(2))) void t2(); // expected-error {{'noipa' attribute takes no arguments}}

--- a/clang/test/Sema/attr-noipa.cpp
+++ b/clang/test/Sema/attr-noipa.cpp
@@ -1,7 +1,0 @@
-// RUN: %clang_cc1 -verify -fsyntax-only %s
-
-__attribute__((noipa)) int a; // expected-warning {{'noipa' attribute only applies to functions}}
-
-__attribute__((noipa)) void t1();
-
-__attribute__((noipa(2))) void t2(); // expected-error {{'noipa' attribute takes no arguments}}


### PR DESCRIPTION
Adds a `__attribute__((noipa))` attribute to clang, more info on this attribute can be found in #203304.

We also set the noinline attribute on the targeted function as pointed out in https://github.com/llvm/llvm-project/pull/203304#discussion_r3397264117.

fixes https://github.com/llvm/llvm-project/issues/40819

Assisted by GPT 5.4 for tests