### PR TITLE
[clang][NFC] Fix enum/non-enum conditional warning in ParseStmt Followup

### DIFF
--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1795,7 +1795,7 @@ StmtResult Parser::ParseDoStatement(LabelDecl *PrecedingLabel) {
 
   // C99 6.8.5p5 - In C99, the do statement is a block.  This is not
   // the case for C90.  Start the loop scope.
-  unsigned ScopeFlags = getLangOpts().C99 ? Scope::DeclScope : 0;
+  unsigned ScopeFlags = getLangOpts().C99 ? Scope::DeclScope : Scope::NoScope;
   ParseScope DoScope(this, ScopeFlags);
 
   // OpenACC Restricts a do-while-loop inside of certain construct/clause
@@ -1922,8 +1922,8 @@ StmtResult Parser::ParseForStatement(SourceLocation *TrailingElseLoc,
   // doesn't cause declarations to bind to this scope. We use this to avoid
   // diagnosing a comma operator in e.g. the third part of a for loop when
   // '-Wcomma' is enabled.
-  unsigned ScopeFlags =
-      Scope::ControlScope | (C99orCXXorObjC ? Scope::DeclScope : 0);
+  unsigned ScopeFlags = Scope::ControlScope |
+                        (C99orCXXorObjC ? Scope::DeclScope : Scope::NoScope);
   ParseScope ForScope(this, ScopeFlags);
 
   BalancedDelimiterTracker T(*this, tok::l_paren);


### PR DESCRIPTION
Missed two other cases, so a follow up to https://github.com/llvm/llvm-project/pull/207085