### PR TITLE
[clang] Remove always false comparisons

### DIFF
--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -1368,7 +1368,7 @@ ExprResult Sema::BuildPackIndexingExpr(Expr *PackExpression,
   }
 
   if (Index && FullySubstituted) {
-    if (*Index < 0 || *Index >= ExpandedExprs.size()) {
+    if (*Index >= ExpandedExprs.size()) {
       Diag(PackExpression->getBeginLoc(), diag::err_pack_index_out_of_bound)
           << *Index << PackExpression << ExpandedExprs.size();
       return ExprError();

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -10127,7 +10127,7 @@ QualType Sema::BuildPackIndexingType(QualType Pattern, Expr *IndexExpr,
 
     IndexExpr = Res.get();
     uint64_t V = Value.getZExtValue();
-    if (FullySubstituted && (V < 0 || V >= Expansions.size())) {
+    if (FullySubstituted && V >= Expansions.size()) {
       Diag(IndexExpr->getBeginLoc(), diag::err_pack_index_out_of_bound)
           << V << Pattern << Expansions.size();
       return QualType();


### PR DESCRIPTION
```
llvm-project/clang/lib/Sema/SemaTemplateVariadic.cpp:1371:16: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
 1371 |     if (*Index < 0 || *Index >= ExpandedExprs.size()) {
      |         ~~~~~~~^~~

llvm-project/clang/lib/Sema/SemaType.cpp:10130:32: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
10130 |     if (FullySubstituted && (V < 0 || V >= Expansions.size())) {
```

https://github.com/llvm/llvm-project/commit/9b132a2ff80dac4bc8e78b242bebb97551c292c7 changed the types from int64_t to uint64_t so those comparisons are always false now