### PR TITLE
[X86] Update #error to mention the right header name

### DIFF
--- a/clang/lib/Headers/avx512vp2intersectintrin.h
+++ b/clang/lib/Headers/avx512vp2intersectintrin.h
@@ -22,7 +22,7 @@
  *===-----------------------------------------------------------------------===
  */
 #ifndef __IMMINTRIN_H
-#error "Never use <avx512vp2intersect.h> directly; include <immintrin.h> instead."
+#error "Never use <avx512vp2intersectintrin.h> directly; include <immintrin.h> instead."
 #endif
 
 #ifndef _AVX512VP2INTERSECT_H


### PR DESCRIPTION
Practically every internal intrinsics header has a little public/private check to force users to use public *intrin.h header names.

avx512vp2intersectintrin.h is the only one with a discrepancy between the #error directive and the actual filename.

Fix them to agree. No functional change expected.