### PR TITLE
[cmake][NFC] Use `EXTRA_INCLUDES` in `tablegen` commands

### DIFF
--- a/clang/include/clang/Basic/CMakeLists.txt
+++ b/clang/include/clang/Basic/CMakeLists.txt
@@ -52,40 +52,40 @@ clang_tablegen(DiagnosticAllCompatIDs.inc
   TARGET ClangDiagnosticAllCompatIDs)
 
 clang_tablegen(AttrList.inc -gen-clang-attr-list
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE Attr.td
   TARGET ClangAttrList)
 
 clang_tablegen(AttrParsedAttrList.inc -gen-clang-attr-parsed-attr-list
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE Attr.td
   TARGET ClangAttrParsedAttrList)
 
 clang_tablegen(AttrSubMatchRulesList.inc -gen-clang-attr-subject-match-rule-list
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE Attr.td
   TARGET ClangAttrSubjectMatchRuleList)
 
 clang_tablegen(RegularKeywordAttrInfo.inc -gen-clang-regular-keyword-attr-info
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE Attr.td
   TARGET ClangRegularKeywordAttrInfo
   )
 
 clang_tablegen(AttrHasAttributeImpl.inc -gen-clang-attr-has-attribute-impl
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE Attr.td
   TARGET ClangAttrHasAttributeImpl
   )
 
 clang_tablegen(CXX11AttributeInfo.inc -gen-cxx11-attribute-info
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE Attr.td
   TARGET CXX11AttributeInfo
   )
 
   clang_tablegen(AttributeSpellingList.inc -gen-attribute-spelling-list
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE Attr.td
   TARGET AttributeSpellingList
   )

--- a/clang/include/clang/CIR/Dialect/CMakeLists.txt
+++ b/clang/include/clang/CIR/Dialect/CMakeLists.txt
@@ -6,7 +6,7 @@ add_custom_target(clang-cir-doc)
 function(add_clang_mlir_doc doc_filename output_file output_directory command)
   set(LLVM_TARGET_DEFINITIONS ${doc_filename}.td)
   tablegen(MLIR ${output_file}.md ${command} ${ARGN}
-           "-I${MLIR_MAIN_SRC_DIR}" "-I${MLIR_INCLUDE_DIR}")
+           EXTRA_INCLUDES ${MLIR_MAIN_SRC_DIR} ${MLIR_INCLUDE_DIR})
   set(GEN_DOC_FILE ${CLANG_BINARY_DIR}/docs/CIR/_raw/${output_directory}${output_file}.md)
   add_custom_command(
           OUTPUT ${GEN_DOC_FILE}

--- a/clang/include/clang/Parse/CMakeLists.txt
+++ b/clang/include/clang/Parse/CMakeLists.txt
@@ -1,10 +1,10 @@
 clang_tablegen(AttrParserStringSwitches.inc -gen-clang-attr-parser-string-switches
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE ../Basic/Attr.td
   TARGET ClangAttrParserStringSwitches)
 
 clang_tablegen(AttrSubMatchRulesParserStringSwitches.inc
   -gen-clang-attr-subject-match-rules-parser-string-switches
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE ../Basic/Attr.td
   TARGET ClangAttrSubMatchRulesParserStringSwitches)

--- a/clang/include/clang/Sema/CMakeLists.txt
+++ b/clang/include/clang/Sema/CMakeLists.txt
@@ -1,24 +1,24 @@
 clang_tablegen(AttrTemplateInstantiate.inc -gen-clang-attr-template-instantiate
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE ../Basic/Attr.td
   TARGET ClangAttrTemplateInstantiate)
 
 clang_tablegen(AttrParsedAttrKinds.inc -gen-clang-attr-parsed-attr-kinds
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE ../Basic/Attr.td
   TARGET ClangAttrParsedAttrKinds)
 
 clang_tablegen(AttrIsTypeDependent.inc -gen-clang-attr-is-type-dependent
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE ../Basic/Attr.td
   TARGET ClangAttrIsTypeDependent)
 
 clang_tablegen(AttrSpellingListIndex.inc -gen-clang-attr-spelling-index
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE ../Basic/Attr.td
   TARGET ClangAttrSpellingListIndex)
 
 clang_tablegen(AttrParsedAttrImpl.inc -gen-clang-attr-parsed-attr-impl
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE ../Basic/Attr.td
   TARGET ClangAttrParsedAttrImpl)

--- a/clang/include/clang/Serialization/CMakeLists.txt
+++ b/clang/include/clang/Serialization/CMakeLists.txt
@@ -1,9 +1,9 @@
 clang_tablegen(AttrPCHRead.inc -gen-clang-attr-pch-read
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE ../Basic/Attr.td
   TARGET ClangAttrPCHRead)
 
 clang_tablegen(AttrPCHWrite.inc -gen-clang-attr-pch-write
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE ../Basic/Attr.td
   TARGET ClangAttrPCHWrite)

--- a/clang/lib/AST/CMakeLists.txt
+++ b/clang/lib/AST/CMakeLists.txt
@@ -16,7 +16,7 @@ clang_tablegen(Opcodes.inc
   TARGET Opcodes)
 
 clang_tablegen(AttrDocTable.inc -gen-clang-attr-doc-table
-  -I ${CMAKE_CURRENT_SOURCE_DIR}/../../include/
+  EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../include/
   SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/../../include/clang/Basic/Attr.td
   TARGET ClangAttrDocTable)
 

--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -454,7 +454,7 @@ endfunction(copy_header_to_output_dir)
 
 function(clang_generate_header td_option td_file out_file)
   clang_tablegen(${out_file} ${td_option}
-  -I ${CLANG_SOURCE_DIR}/include/clang/Basic/
+  EXTRA_INCLUDES ${CLANG_SOURCE_DIR}/include/clang/Basic/
   SOURCE ${CLANG_SOURCE_DIR}/include/clang/Basic/${td_file})
 
   copy_header_to_output_dir(${CMAKE_CURRENT_BINARY_DIR} ${out_file})

--- a/llvm/include/llvm/TargetParser/CMakeLists.txt
+++ b/llvm/include/llvm/TargetParser/CMakeLists.txt
@@ -8,7 +8,7 @@ set(LLVM_TARGET_DEFINITIONS ${PROJECT_SOURCE_DIR}/lib/Target/RISCV/RISCV.td)
 tablegen(LLVM RISCVTargetParserDef.inc -gen-riscv-target-def EXTRA_INCLUDES ${PROJECT_SOURCE_DIR}/lib/Target/RISCV)
 
 set(LLVM_TARGET_DEFINITIONS ${PROJECT_SOURCE_DIR}/lib/Target/PowerPC/PPC.td)
-tablegen(LLVM PPCGenTargetFeatures.inc -gen-target-features -I${PROJECT_SOURCE_DIR}/lib/Target/PowerPC)
+tablegen(LLVM PPCGenTargetFeatures.inc -gen-target-features EXTRA_INCLUDES ${PROJECT_SOURCE_DIR}/lib/Target/PowerPC)
 
 # This covers all of the tablegen calls above.
 add_public_tablegen_target(target_parser_gen)

--- a/offload/plugins-nextgen/common/CMakeLists.txt
+++ b/offload/plugins-nextgen/common/CMakeLists.txt
@@ -3,8 +3,8 @@
 include(TableGen)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include)
 set(LLVM_TARGET_DEFINITIONS ${CMAKE_CURRENT_SOURCE_DIR}/../../liboffload/API/OffloadAPI.td)
-tablegen(OFFLOAD include/OffloadErrcodes.inc -gen-errcodes -I ${CMAKE_CURRENT_SOURCE_DIR}/../../liboffload/API)
-tablegen(OFFLOAD include/OffloadInfo.inc -gen-info -I ${CMAKE_CURRENT_SOURCE_DIR}/../../liboffload/API)
+tablegen(OFFLOAD include/OffloadErrcodes.inc -gen-errcodes EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../liboffload/API)
+tablegen(OFFLOAD include/OffloadInfo.inc -gen-info EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../liboffload/API)
 add_public_tablegen_target(PluginErrcodes)
 
 # NOTE: Don't try to build `PluginInterface` using `add_llvm_library` because we


### PR DESCRIPTION
Not only is it more declarative than using the `-I` directory, it additionally adds the given directory to the `tablegen_compile_commands.yml` which allows the LSP and IDE tooling to also be aware of the extra include directories used to compile that TableGen file