### PR TITLE
[flang][cuda] Only strip internal linkage for device globals

### DIFF
--- a/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceGlobal.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFDeviceGlobal.cpp
@@ -183,10 +183,12 @@ public:
         clonedGlobal.removeInitValAttr();
         clonedGlobal.removeLinkNameAttr();
       }
-      // Registered CUDA globals must have a visible device symbol so runtime
-      // lookups (cudaGetSymbolAddress) can resolve them. Drop explicit linkage
-      // from the GPU clone so it uses default external linkage.
-      if (cuf::isRegisteredDeviceGlobal(globalOp))
+      // Registered CUDA globals with internal linkage must have a visible
+      // device symbol so runtime lookups (cudaGetSymbolAddress) can resolve
+      // them. Drop internal linkage from the GPU clone so it uses default
+      // external linkage.
+      if (cuf::isRegisteredDeviceGlobal(globalOp) &&
+          globalOp.getLinkName() == "internal")
         clonedGlobal.removeLinkNameAttr();
       gpuSymTable.insert(cloned);
     }

--- a/flang/test/Fir/CUDA/cuda-device-global.f90
+++ b/flang/test/Fir/CUDA/cuda-device-global.f90
@@ -5,13 +5,17 @@
 
 module attributes {fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", gpu.container_module} {
   fir.global @_QMmtestsEn(dense<[3, 4, 5, 6, 7]> : tensor<5xi32>) {data_attr = #cuf.cuda<device>} : !fir.array<5xi32>
+  fir.global internal @_QMmtestsEinternal(dense<[1, 2]> : tensor<2xi32>) {data_attr = #cuf.cuda<device>} : !fir.array<2xi32>
+  fir.global linkonce_odr @_QMmtestsElinkonce(dense<[8, 9]> : tensor<2xi32>) {data_attr = #cuf.cuda<device>} : !fir.array<2xi32>
 
   gpu.module @cuda_device_mod {
   }
 }
 
 // CHECK: gpu.module @cuda_device_mo
-// CHECK-NEXT: fir.global @_QMmtestsEn(dense<[3, 4, 5, 6, 7]> : tensor<5xi32>) {data_attr = #cuf.cuda<device>} : !fir.array<5xi32>
+// CHECK-DAG: fir.global @_QMmtestsEn(dense<[3, 4, 5, 6, 7]> : tensor<5xi32>) {data_attr = #cuf.cuda<device>} : !fir.array<5xi32>
+// CHECK-DAG: fir.global @_QMmtestsEinternal(dense<[1, 2]> : tensor<2xi32>) {data_attr = #cuf.cuda<device>} : !fir.array<2xi32>
+// CHECK-DAG: fir.global linkonce_odr @_QMmtestsElinkonce(dense<[8, 9]> : tensor<2xi32>) {data_attr = #cuf.cuda<device>} : !fir.array<2xi32>
 
 // -----
 


### PR DESCRIPTION
Stripping all linkage was too much. Only strip internal linkage so the symbol is visible to CUDA API. 