### PR TITLE
[LifetimeSafety] Support container interior paths and invalidations

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
@@ -48,6 +48,11 @@ public:
     /// it. Otherwise, the source's loan set is merged into the destination's
     /// loan set.
     OriginFlow,
+    /// Loans held by the origin are projected (their access paths are
+    /// extended by a path element).
+    /// Example: if `obj` holds loan `{x}`, `p = obj.field` projects `{x}` with
+    /// `field` to `{x.field}`before flowing into `p`.
+    Projection,
     /// An origin is used (eg. appears as l-value expression like DeclRefExpr).
     Use,
     /// An origin that is moved (e.g., passed to an rvalue reference parameter).
@@ -155,6 +160,25 @@ public:
   OriginID getDestOriginID() const { return OIDDest; }
   OriginID getSrcOriginID() const { return OIDSrc; }
   bool getKillDest() const { return KillDest; }
+
+  void dump(llvm::raw_ostream &OS, const LoanManager &, const OriginManager &OM,
+            const LoanPropagationAnalysis *LPA = nullptr) const override;
+};
+
+class ProjectionFact : public Fact {
+  OriginID OID;
+  PathElement Element;
+
+public:
+  static bool classof(const Fact *F) {
+    return F->getKind() == Kind::Projection;
+  }
+
+  ProjectionFact(OriginID OID, PathElement Element)
+      : Fact(Kind::Projection), OID(OID), Element(Element) {}
+
+  OriginID getOriginID() const { return OID; }
+  PathElement getPathElement() const { return Element; }
 
   void dump(llvm::raw_ostream &OS, const LoanManager &, const OriginManager &OM,
             const LoanPropagationAnalysis *LPA = nullptr) const override;

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
@@ -37,6 +37,9 @@ public:
 
   LoanSet getLoans(OriginID OID, ProgramPoint P) const;
 
+  void dumpLoans(OriginID OID, ProgramPoint P, llvm::raw_ostream &OS,
+                 const LoanManager &LM) const;
+
   /// Builds the chain of origins through which a loan has propagated.
   ///
   /// Starting from the last fact of the block containing StartPoint, this

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Loans.h
@@ -208,6 +208,7 @@ public:
 
 /// Manages the creation, storage and retrieval of loans.
 class LoanManager {
+  using ExtensionCacheKey = std::pair<LoanID, PathElement>;
 
 public:
   LoanManager() = default;
@@ -226,6 +227,14 @@ public:
     return createLoan(AccessPath(getOrCreatePlaceholderBase(MD)));
   }
 
+  /// Gets or creates a loan by extending BaseLoanID with Element.
+  /// Caches the result to ensure convergence in LoanPropagation.
+  Loan *getOrCreateExtendedLoan(LoanID BaseLoanID, PathElement Element);
+
+  /// Finds the base loan ID that was extended to produce ExtendedLoanID, if
+  /// any.
+  std::optional<LoanID> getBaseLoan(LoanID ExtendedLoanID) const;
+
   const Loan *getLoan(LoanID ID) const {
     assert(ID.Value < AllLoans.size());
     return AllLoans[ID.Value];
@@ -243,6 +252,14 @@ private:
   LoanID NextLoanID{0};
 
   llvm::FoldingSet<PlaceholderBase> PlaceholderBases;
+  /// Cache for extended loans. Maps (BaseLoanID, PathElement) to the extended
+  /// loan. Ensures that extending the same loan with the same path element
+  /// always returns the same loan object, which is necessary for dataflow
+  /// analysis convergence.
+  llvm::DenseMap<ExtensionCacheKey, Loan *> ExtensionCache;
+
+  /// Maps an extended loan ID back to its base loan ID.
+  llvm::DenseMap<LoanID, LoanID> BaseLoansMap;
 
   /// TODO(opt): Profile and evaluate the usefullness of small buffer
   /// optimisation.
@@ -250,5 +267,17 @@ private:
   llvm::BumpPtrAllocator LoanAllocator;
 };
 } // namespace clang::lifetimes::internal
+
+namespace llvm {
+template <> struct DenseMapInfo<clang::lifetimes::internal::PathElement> {
+  using PathElement = clang::lifetimes::internal::PathElement;
+  static unsigned getHashValue(const PathElement &Val) {
+    return llvm::hash_combine(Val.isInterior(), Val.getFieldDecl());
+  }
+  static bool isEqual(const PathElement &LHS, const PathElement &RHS) {
+    return LHS == RHS;
+  }
+};
+} // namespace llvm
 
 #endif // LLVM_CLANG_ANALYSIS_ANALYSES_LIFETIMESAFETY_LOANS_H

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -222,11 +222,18 @@ public:
     /// Get loans directly pointing to the invalidated container
     LoanSet DirectlyInvalidatedLoans =
         LoanPropagation.getLoans(InvalidatedOrigin, IOF);
+    bool AllowEquality =
+        isa_and_nonnull<CXXDeleteExpr>(IOF->getInvalidationExpr());
     auto IsInvalidated = [&](const Loan *L) {
       for (LoanID InvalidID : DirectlyInvalidatedLoans) {
         const Loan *InvalidL = FactMgr.getLoanMgr().getLoan(InvalidID);
-        if (InvalidL->getAccessPath().isPrefixOf(L->getAccessPath()))
-          return true;
+        if (AllowEquality) {
+          if (InvalidL->getAccessPath().isPrefixOf(L->getAccessPath()))
+            return true;
+        } else {
+          if (InvalidL->getAccessPath().isStrictPrefixOf(L->getAccessPath()))
+            return true;
+        }
       }
       return false;
     };

--- a/clang/lib/Analysis/LifetimeSafety/Dataflow.h
+++ b/clang/lib/Analysis/LifetimeSafety/Dataflow.h
@@ -60,9 +60,6 @@ public:
   using Base = DataflowAnalysis<Derived, Lattice, Dir>;
 
 private:
-  const CFG &Cfg;
-  AnalysisDeclContext &AC;
-
   /// The dataflow state before a basic block is processed.
   llvm::DenseMap<const CFGBlock *, Lattice> InStates;
   /// The dataflow state after a basic block is processed.
@@ -75,6 +72,8 @@ private:
   static constexpr bool isForward() { return Dir == Direction::Forward; }
 
 protected:
+  const CFG &Cfg;
+  AnalysisDeclContext &AC;
   FactManager &FactMgr;
 
   explicit DataflowAnalysis(const CFG &Cfg, AnalysisDeclContext &AC,
@@ -170,6 +169,8 @@ private:
       return D->transfer(In, *F->getAs<ExpireFact>());
     case Fact::Kind::OriginFlow:
       return D->transfer(In, *F->getAs<OriginFlowFact>());
+    case Fact::Kind::Projection:
+      return D->transfer(In, *F->getAs<ProjectionFact>());
     case Fact::Kind::MovedOrigin:
       return D->transfer(In, *F->getAs<MovedOriginFact>());
     case Fact::Kind::OriginEscapes:
@@ -190,6 +191,7 @@ public:
   Lattice transfer(Lattice In, const IssueFact &) { return In; }
   Lattice transfer(Lattice In, const ExpireFact &) { return In; }
   Lattice transfer(Lattice In, const OriginFlowFact &) { return In; }
+  Lattice transfer(Lattice In, const ProjectionFact &) { return In; }
   Lattice transfer(Lattice In, const MovedOriginFact &) { return In; }
   Lattice transfer(Lattice In, const OriginEscapesFact &) { return In; }
   Lattice transfer(Lattice In, const UseFact &) { return In; }

--- a/clang/lib/Analysis/LifetimeSafety/Facts.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Facts.cpp
@@ -47,22 +47,26 @@ void OriginFlowFact::dump(llvm::raw_ostream &OS, const LoanManager &LM,
   OS << "\tDest: ";
   OM.dump(getDestOriginID(), OS);
   if (LPA) {
-    LoanSet DestinationLoans = LPA->getLoans(getDestOriginID(), this);
-    if (DestinationLoans.isEmpty())
-      OS << " has no loans";
-    else {
-      OS << " has loans to { ";
-      for (LoanID LID : DestinationLoans) {
-        LM.getLoan(LID)->getAccessPath().dump(OS);
-        OS << " ";
-      }
-      OS << "}";
-    }
+    LPA->dumpLoans(getDestOriginID(), this, OS, LM);
   }
   OS << "\n";
   OS << "\tSrc:  ";
   OM.dump(getSrcOriginID(), OS);
   OS << (getKillDest() ? "" : ", Merge");
+  OS << "\n";
+}
+
+void ProjectionFact::dump(llvm::raw_ostream &OS, const LoanManager &LM,
+                          const OriginManager &OM,
+                          const LoanPropagationAnalysis *LPA) const {
+  OS << "Projection: \n";
+  OS << "\tOrigin: ";
+  OM.dump(getOriginID(), OS);
+  if (LPA) {
+    LPA->dumpLoans(getOriginID(), this, OS, LM);
+  }
+  OS << "\n\tElement: ";
+  getPathElement().dump(OS);
   OS << "\n";
 }
 

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -958,12 +958,6 @@ void FactsGenerator::handleInvalidatingCall(const Expr *Call,
   if (!isInvalidationMethod(*MD))
     return;
 
-  // Heuristics to turn-down false positives. Skip member field expressions for
-  // now. This is not a perfect filter and will still surface some false
-  // positives (e.g. `auto& r = s.v`).
-  if (!isa<DeclRefExpr>(Args[0]->IgnoreImpCasts()))
-    return;
-
   OriginList *ThisList = getOriginsList(*Args[0]);
   if (ThisList)
     CurrentBlockFacts.push_back(FactMgr.createFact<InvalidateOriginFact>(
@@ -1071,6 +1065,27 @@ void FactsGenerator::handleLifetimeCaptureBy(const FunctionDecl *FD,
   }
 }
 
+static std::optional<PathElement>
+getPathElementForLifetimeBoundArg(const FunctionDecl *FD, unsigned ArgIndex,
+                                  const Expr *ArgExpr) {
+  if (!ArgExpr)
+    return std::nullopt;
+  if (ArgIndex == 0) {
+    const auto *Method = dyn_cast<CXXMethodDecl>(FD);
+    bool IsContainerArg =
+        (Method && Method->isInstance()) || shouldTrackFirstArgument(FD);
+    if (IsContainerArg) {
+      QualType ArgType = ArgExpr->getType();
+      if (const Type *ArgTypePtr = ArgType.getTypePtrOrNull()) {
+        if (isGslOwnerType(ArgType) ||
+            (ArgTypePtr->isPointerType() &&
+             isGslOwnerType(ArgTypePtr->getPointeeType())))
+          return PathElement::getInterior();
+      }
+    }
+  }
+  return std::nullopt;
+}
 void FactsGenerator::handleFunctionCall(const Expr *Call,
                                         const FunctionDecl *FD,
                                         ArrayRef<const Expr *> Args,
@@ -1145,12 +1160,13 @@ void FactsGenerator::handleFunctionCall(const Expr *Call,
         ArgList = getRValueOrigins(Args[I], ArgList);
       }
       if (isGslOwnerType(Args[I]->getType())) {
-        // The constructed gsl::Pointer borrows from the Owner's storage, not
-        // from what the Owner itself borrows, so only the outermost origin is
-        // needed.
+        // GSL construction creates a view that borrows from arguments.
+        // Only flow the outer origin because inner lengths may mismatch.
         CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
             CallList->getOuterOriginID(), ArgList->getOuterOriginID(),
             KillSrc));
+        CurrentBlockFacts.push_back(FactMgr.createFact<ProjectionFact>(
+            CallList->getOuterOriginID(), PathElement::getInterior()));
         KillSrc = false;
       } else if (IsArgLifetimeBound(I)) {
         // Only flow the outer origin here. For lifetimebound args in
@@ -1164,7 +1180,7 @@ void FactsGenerator::handleFunctionCall(const Expr *Call,
             KillSrc));
         KillSrc = false;
       }
-    } else if (shouldTrackPointerImplicitObjectArg(I)) {
+    } else if (I == 0 && shouldTrackPointerImplicitObjectArg(I)) {
       assert(ArgList->getLength() >= 2 &&
              "Object arg of pointer type should have at least two origins");
       // See through the GSLPointer reference to see the pointer's value.
@@ -1178,6 +1194,10 @@ void FactsGenerator::handleFunctionCall(const Expr *Call,
       // only constrains the top-level origin.
       CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
           CallList->getOuterOriginID(), ArgList->getOuterOriginID(), KillSrc));
+      if (auto Element = getPathElementForLifetimeBoundArg(FD, I, Args[I])) {
+        CurrentBlockFacts.push_back(FactMgr.createFact<ProjectionFact>(
+            CallList->getOuterOriginID(), *Element));
+      }
       KillSrc = false;
     }
   }

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -274,17 +274,18 @@ void FactsGenerator::VisitCXXMemberCallExpr(const CXXMemberCallExpr *MCE) {
 
 void FactsGenerator::VisitMemberExpr(const MemberExpr *ME) {
   auto *MD = ME->getMemberDecl();
-  if (isa<FieldDecl>(MD) && doesDeclHaveStorage(MD)) {
+  if (auto *FD = dyn_cast<FieldDecl>(MD); FD && doesDeclHaveStorage(FD)) {
     assert(ME->isGLValue() && "Field member should be GL value");
     OriginList *Dst = getOriginsList(*ME);
     assert(Dst && "Field member should have an origin list as it is GL value");
     OriginList *Src = getOriginsList(*ME->getBase());
     assert(Src && "Base expression should be a pointer/reference type");
-    // The field's glvalue (outermost origin) holds the same loans as the base
-    // expression.
+    // Flow loans from base to field, extending each loan's path with the field.
+    // E.g., if base has loan to `obj`, field gets loan to `obj.field`.
     CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
-        Dst->getOuterOriginID(), Src->getOuterOriginID(),
-        /*Kill=*/true));
+        Dst->getOuterOriginID(), Src->getOuterOriginID(), /*KillDest=*/true));
+    CurrentBlockFacts.push_back(FactMgr.createFact<ProjectionFact>(
+        Dst->getOuterOriginID(), PathElement::getField(*FD)));
   }
 }
 

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -59,6 +59,11 @@ static llvm::BitVector computePersistentOrigins(const FactManager &FactMgr,
         CheckOrigin(OF->getSrcOriginID());
         break;
       }
+      case Fact::Kind::Projection: {
+        const auto *PF = F->getAs<ProjectionFact>();
+        CheckOrigin(PF->getOriginID());
+        break;
+      }
       case Fact::Kind::Use:
         for (const OriginList *Cur = F->getAs<UseFact>()->getUsedOrigins(); Cur;
              Cur = Cur->peelOuterOrigin())
@@ -189,6 +194,21 @@ public:
     return setLoans(In, DestOID, MergedLoans);
   }
 
+  /// A projection projects the loans currently held by the origin in-place.
+  Lattice transfer(Lattice In, const ProjectionFact &F) {
+    OriginID OID = F.getOriginID();
+    LoanSet Loans = getLoans(In, OID);
+    LoanSet ProjectedLoans = LoanSetFactory.getEmptySet();
+    PathElement Element = F.getPathElement();
+    for (LoanID LID : Loans) {
+      Loan *ExtendedLoan =
+          FactMgr.getLoanMgr().getOrCreateExtendedLoan(LID, Element);
+      ProjectedLoans =
+          LoanSetFactory.add(ProjectedLoans, ExtendedLoan->getID());
+    }
+    return setLoans(In, OID, ProjectedLoans);
+  }
+
   Lattice transfer(Lattice In, const KillOriginFact &F) {
     return setLoans(In, F.getKilledOrigin(), LoanSetFactory.getEmptySet());
   }
@@ -218,11 +238,12 @@ public:
         EndBlock = Block;
         break;
       }
+    assert(EndBlock && "Could not find CFGBlock containing StartPoint");
 
-    // Set up DFS traversal state
-    // SearchState tracks which block we're in and which origin we're tracing
+    // Set up DFS traversal state.
+    // SearchState tracks which block we're in and which origin we're tracing.
     // Each DFSNode maintains its own OriginFlowChain.
-    using SearchState = std::pair<const CFGBlock *, OriginID>;
+    using SearchState = std::tuple<const CFGBlock *, OriginID, LoanID>;
     struct DFSNode {
       SearchState CurrState;
       llvm::SmallVector<OriginID> OriginFlowChain;
@@ -230,30 +251,32 @@ public:
 
     llvm::SmallVector<DFSNode> PendingStates;
     llvm::SmallSet<SearchState, 16> VistedStates;
-    PendingStates.push_back({{EndBlock, StartOID}, {}});
+    PendingStates.push_back({{EndBlock, StartOID, TargetLoan}, {}});
 
     // DFS loop to trace loan backwards through CFG
     while (!PendingStates.empty()) {
       DFSNode CurrNode = PendingStates.pop_back_val();
-      auto [CurrBlock, CurrOID] = CurrNode.CurrState;
+      auto [CurrBlock, CurrOID, CurrLoanID] = CurrNode.CurrState;
 
-      // Trace origins within the current block
-      const auto [BuildResult, Complete] =
-          buildOriginFlowChain(CurrBlock, CurrOID, TargetLoan);
-      if (!BuildResult.empty()) {
-        CurrNode.OriginFlowChain.append(BuildResult);
-        CurrOID = BuildResult.back();
-      }
+      // Trace origins within the current block.
+      BlockTraceResult TraceResult =
+          buildOriginFlowChain(CurrBlock, CurrOID, CurrLoanID);
+      if (!TraceResult.Chain.empty())
+        CurrNode.OriginFlowChain.append(TraceResult.Chain);
+      CurrOID = TraceResult.OutOID;
+      CurrLoanID = TraceResult.OutLoanID;
 
-      // If we found the IssueFact, we're done
-      if (Complete)
+      // If we found the IssueFact, we're done.
+      if (TraceResult.Complete)
         return CurrNode.OriginFlowChain;
 
       // Only explore predecessor blocks where the target loan is present in the
       // current origin.
       for (const CFGBlock *PredBlock : CurrBlock->preds()) {
-        SearchState NextState = {PredBlock, CurrOID};
-        if (getLoans(getOutState(PredBlock), CurrOID).contains(TargetLoan) &&
+        if (!PredBlock)
+          continue;
+        SearchState NextState = {PredBlock, CurrOID, CurrLoanID};
+        if (getLoans(getOutState(PredBlock), CurrOID).contains(CurrLoanID) &&
             VistedStates.insert(NextState).second)
           PendingStates.push_back({NextState, CurrNode.OriginFlowChain});
       }
@@ -297,38 +320,69 @@ private:
     return LoanSetFactory.getEmptySet();
   }
 
+  struct BlockTraceResult {
+    llvm::SmallVector<OriginID> Chain;
+    bool Complete;
+    OriginID OutOID;
+    LoanID OutLoanID;
+  };
+
   /// Builds the chain of origins through which a loan has propagated.
   ///
   /// This procedure operates strictly within a single Block. Starting from the
   /// last fact of the Block, it traces backwards through OriginFlowFacts to
   /// identify the sequence of origins through which the loan flowed.
   ///
-  /// Returns (chain, true) if the target loan origin is found during the
-  /// traversal, otherwise returns (chain, false).
-  std::pair<llvm::SmallVector<OriginID>, bool>
-  buildOriginFlowChain(const CFGBlock *Block, const OriginID StartOID,
-                       const LoanID TargetLoan) const {
+  /// Returns (chain, true, outOID, outLoanID) if the target loan origin is
+  /// found during the traversal, otherwise returns (chain, false, outOID,
+  /// outLoanID).
+  BlockTraceResult buildOriginFlowChain(const CFGBlock *Block,
+                                        const OriginID StartOID,
+                                        const LoanID StartLoanID) const {
     OriginID CurrOID = StartOID;
+    LoanID CurrLoanID = StartLoanID;
     llvm::SmallVector<OriginID> OriginFlowChain;
 
+    llvm::ArrayRef<const Fact *> Facts = FactMgr.getFacts(Block);
+    auto GetStateBefore = [&](const Fact *F) -> Lattice {
+      const auto *It = llvm::find(Facts, F);
+      assert(It != Facts.end());
+      if (It == Facts.begin()) {
+        auto InState = getInState(Block);
+        assert(InState);
+        return *InState;
+      }
+      return getState(*(It - 1));
+    };
+
     for (const Fact *F : llvm::reverse(FactMgr.getFacts(Block))) {
-      if (const auto *IF = F->getAs<IssueFact>())
-        if (IF->getLoanID() == TargetLoan && IF->getOriginID() == CurrOID)
-          return {OriginFlowChain, true};
-
-      const auto *OFF = F->getAs<OriginFlowFact>();
-      if (!OFF || OFF->getDestOriginID() != CurrOID)
-        continue;
-
-      const OriginID SrcOriginID = OFF->getSrcOriginID();
-      if (!getLoans(SrcOriginID, OFF).contains(TargetLoan))
-        continue;
-
-      OriginFlowChain.push_back(SrcOriginID);
-      CurrOID = SrcOriginID;
+      if (const auto *IF = F->getAs<IssueFact>()) {
+        // Search is complete.
+        if (IF->getLoanID() == CurrLoanID && IF->getOriginID() == CurrOID)
+          return {OriginFlowChain, true, CurrOID, CurrLoanID};
+      } else if (const auto *OFF = F->getAs<OriginFlowFact>()) {
+        // Trace the loan back to its source origin if it flowed from there.
+        if (OFF->getDestOriginID() != CurrOID)
+          continue;
+        OriginID SrcOriginID = OFF->getSrcOriginID();
+        if (!getLoans(SrcOriginID, OFF).contains(CurrLoanID))
+          continue;
+        CurrOID = SrcOriginID;
+        OriginFlowChain.push_back(SrcOriginID);
+      } else if (const auto *PF = F->getAs<ProjectionFact>()) {
+        // Step back from a projected field loan to its base loan (e.g., from
+        // 'obj.field' to 'obj').
+        if (PF->getOriginID() != CurrOID)
+          continue;
+        std::optional<LoanID> BaseLoanID =
+            FactMgr.getLoanMgr().getBaseLoan(CurrLoanID);
+        if (BaseLoanID &&
+            getLoans(GetStateBefore(PF), CurrOID).contains(*BaseLoanID))
+          CurrLoanID = *BaseLoanID;
+      }
     }
 
-    return {OriginFlowChain, false};
+    return {OriginFlowChain, false, CurrOID, CurrLoanID};
   }
 
   OriginLoanMap::Factory &OriginLoanMapFactory;
@@ -357,6 +411,22 @@ LoanPropagationAnalysis::~LoanPropagationAnalysis() = default;
 
 LoanSet LoanPropagationAnalysis::getLoans(OriginID OID, ProgramPoint P) const {
   return PImpl->getLoans(OID, P);
+}
+
+void LoanPropagationAnalysis::dumpLoans(OriginID OID, ProgramPoint P,
+                                        llvm::raw_ostream &OS,
+                                        const LoanManager &LM) const {
+  LoanSet Loans = getLoans(OID, P);
+  if (Loans.isEmpty())
+    OS << " has no loans";
+  else {
+    OS << " has loans to { ";
+    for (LoanID LID : Loans) {
+      LM.getLoan(LID)->getAccessPath().dump(OS);
+      OS << " ";
+    }
+    OS << "}";
+  }
 }
 
 llvm::SmallVector<OriginID> LoanPropagationAnalysis::buildOriginFlowChain(

--- a/clang/lib/Analysis/LifetimeSafety/Loans.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Loans.cpp
@@ -72,6 +72,18 @@ Loan *LoanManager::getOrCreateExtendedLoan(LoanID BaseLoanID,
   if (It != ExtensionCache.end())
     return It->second;
   const auto *BaseLoan = getLoan(BaseLoanID);
+
+  // Stop appending if Element is already in the path to prevent infinite path
+  // accumulation (divergence) on recursive types or casts.
+  //
+  // This sound over-approximation guarantees termination at the cost of
+  // precision. Conflating infinitely deep paths into a single truncated loan
+  // may cause false positives via spurious invalidations, but never causes
+  // false negatives.
+  for (const PathElement &E : BaseLoan->getAccessPath().getElements())
+    if (E == Element)
+      return ExtensionCache[Key] = const_cast<Loan *>(BaseLoan);
+
   AccessPath ExtendedPath(BaseLoan->getAccessPath(), Element);
   Loan *NewLoan = createLoan(ExtendedPath, BaseLoan->getIssueExpr());
   BaseLoansMap[NewLoan->getID()] = BaseLoanID;

--- a/clang/lib/Analysis/LifetimeSafety/Loans.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Loans.cpp
@@ -64,4 +64,24 @@ LoanManager::getOrCreatePlaceholderBase(const CXXMethodDecl *MD) {
   PlaceholderBases.InsertNode(NewPB, InsertPos);
   return NewPB;
 }
+
+Loan *LoanManager::getOrCreateExtendedLoan(LoanID BaseLoanID,
+                                           PathElement Element) {
+  ExtensionCacheKey Key = {BaseLoanID, Element};
+  auto It = ExtensionCache.find(Key);
+  if (It != ExtensionCache.end())
+    return It->second;
+  const auto *BaseLoan = getLoan(BaseLoanID);
+  AccessPath ExtendedPath(BaseLoan->getAccessPath(), Element);
+  Loan *NewLoan = createLoan(ExtendedPath, BaseLoan->getIssueExpr());
+  BaseLoansMap[NewLoan->getID()] = BaseLoanID;
+  return ExtensionCache[Key] = NewLoan;
+}
+
+std::optional<LoanID> LoanManager::getBaseLoan(LoanID ExtendedLoanID) const {
+  auto It = BaseLoansMap.find(ExtendedLoanID);
+  if (It != BaseLoansMap.end())
+    return It->second;
+  return std::nullopt;
+}
 } // namespace clang::lifetimes::internal

--- a/clang/test/Sema/LifetimeSafety/Inputs/lifetime-analysis.h
+++ b/clang/test/Sema/LifetimeSafety/Inputs/lifetime-analysis.h
@@ -1,4 +1,3 @@
-
 namespace __gnu_cxx {
 template <typename T>
 struct basic_iterator {
@@ -28,11 +27,11 @@ template<typename T> struct remove_reference<T &>  { typedef T type; };
 template<typename T> struct remove_reference<T &&> { typedef T type; };
 
 template< class InputIt, class T >
-InputIt find( InputIt first, InputIt last, const T& value );
+InputIt find(InputIt first, InputIt last, const T& value);
 
 template< class ForwardIt1, class ForwardIt2 >
-ForwardIt1 search( ForwardIt1 first, ForwardIt1 last,
-                   ForwardIt2 s_first, ForwardIt2 s_last );
+ForwardIt1 search(ForwardIt1 first, ForwardIt1 last,
+                  ForwardIt2 s_first, ForwardIt2 s_last);
 
 template<typename T>
 typename remove_reference<T>::type &&move(T &&t) noexcept;
@@ -109,7 +108,10 @@ struct vector {
 
   void push_back(const T&);
   void push_back(T&&);
+  T& back();
   const T& back() const;
+  T& front();
+  const T& front() const;
   void pop_back();
   iterator insert(iterator, T&&);
   void resize(size_t);
@@ -225,6 +227,9 @@ struct basic_string {
   ~basic_string();
   basic_string& operator=(const basic_string&);
   basic_string& operator+=(const basic_string&);
+  basic_string& append(const basic_string&);
+  basic_string& replace(unsigned pos, unsigned count,
+                        const basic_string& str);
   basic_string& operator+=(const T*);
   void push_back(T);
 

--- a/clang/test/Sema/LifetimeSafety/invalidations.cpp
+++ b/clang/test/Sema/LifetimeSafety/invalidations.cpp
@@ -519,14 +519,12 @@ void ConditionalFieldInvalidatesIterator(bool flag) {
     (flag ? s.strings1 : s.strings2).push_back("1");
     *it;
 }
-// FIXME: Requires field-sensitive AccessPaths to fix.
 void Invalidate1Use2ViaRefIsOk() {
     S s;
-    auto it = s.strings2.begin(); // expected-warning {{local variable 's' is later invalidated}} \
-                                  // expected-note {{result of call to 'begin' aliases the storage of local variable 's'}}
+    auto it = s.strings2.begin();
     auto& strings1 = s.strings1;
-    strings1.push_back("1");      // expected-note {{local variable 's' is invalidated here}}
-    *it;                          // expected-note {{later used here}}
+    strings1.push_back("1");      // OK
+    *it;
 }
 void Invalidate1UseSIsOk() {
   S s;
@@ -942,13 +940,11 @@ struct StringOwner {
   std::string s, t;
 };
 
-// FIXME: False-positive
 void member_destructor_invalidates_pointer() {
   StringOwner owner = {"42", "43"};
-  const char *p = owner.s.data(); // expected-warning {{local variable 'owner' is later invalidated}} \
-                                  // expected-note {{result of call to 'data' aliases the storage of local variable 'owner'}}
-  owner.t.~basic_string();        // expected-note {{local variable 'owner' is invalidated here}}
-  (void)*p;                       // expected-note {{later used here}}
+  const char *p = owner.s.data();
+  owner.t.~basic_string();        // OK
+  (void)*p;
 }
 
 } // namespace explicit_destructor
@@ -990,3 +986,79 @@ void invalid_after_ternary_reset(bool flag) {
 }
 
 } // namespace unique_ptr_invalidation
+
+namespace DeepFieldNesting {
+struct Level3 {
+  std::vector<std::string> vec;
+  int x;
+};
+struct Level2 {
+  Level3 inner3_1;
+  Level3 inner3_2;
+};
+struct Level1 {
+  Level2 inner2_1;
+  Level2 inner2_2;
+};
+
+// Modifying sibling at Level 3: OK
+void SiblingLevel3Ok() {
+  Level1 obj;
+  auto it = obj.inner2_1.inner3_1.vec.begin();
+  obj.inner2_1.inner3_2.vec.push_back("1"); 
+  *it; 
+}
+
+// Modifying sibling at Level 2: OK
+void SiblingLevel2Ok() {
+  Level1 obj;
+  auto it = obj.inner2_1.inner3_1.vec.begin();
+  obj.inner2_2.inner3_1.vec.push_back("1");
+  *it;
+}
+
+// Modifying sibling non-container field at Level 3: OK
+void SiblingFieldLevel3Ok() {
+  Level1 obj;
+  auto it = obj.inner2_1.inner3_1.vec.begin();
+  obj.inner2_1.inner3_1.x = 42;
+  *it;
+}
+
+// Modifying parent structure after use: OK
+void ParentModifiedAfterUseOk() {
+  Level1 obj;
+  auto it = obj.inner2_1.inner3_1.vec.begin();
+  *it; // Use here
+  Level3 new_val;
+  obj.inner2_1.inner3_1 = new_val; // OK, because 'it' is no longer used!
+}
+
+// Pointers with sibling modification: OK
+void PointerSiblingLevel3Ok(Level1* ptr) {
+  auto it = ptr->inner2_1.inner3_1.vec.begin();
+  ptr->inner2_1.inner3_2.vec.push_back("1"); // OK
+  *it;
+}
+
+// References with sibling modification: OK
+void ReferenceSiblingLevel3Ok(Level1& ref) {
+  auto it = ref.inner2_1.inner3_1.vec.begin();
+  ref.inner2_1.inner3_2.vec.push_back("1"); // OK
+  *it;
+}
+} // namespace DeepFieldNesting
+
+namespace StructFieldDisambiguation {
+struct S {
+  std::vector<int> v;
+  int x;
+};
+
+void TestStructVsField(S& s) {
+  int* px = &s.x;
+  s.v.push_back(1); // Invalidates s.v.* (interior), but must NOT invalidate s.x
+  *px = 42;         // OK
+}
+} // namespace StructFieldDisambiguation
+

--- a/clang/test/Sema/LifetimeSafety/invalidations.cpp
+++ b/clang/test/Sema/LifetimeSafety/invalidations.cpp
@@ -364,37 +364,41 @@ void IteratorInvalidatedThroughPointerParameter(std::vector<int> *v) { // expect
   (void)it;         // expected-note {{later used here}}
 }
 
+void IteratorInvalidatedThroughPointerParameterNotUsed(std::vector<int> *v) {
+  // Ok as 'it' is not used. Only 'v' is used.
+  auto it = v->begin();
+  v->push_back(42);
+  v->push_back(43);
+  v->clear();
+}
+
 void ParenthesizedContainerInvalidatesIterator() {
-  // FIXME: Support invalidation through non-DRE lvalue expressions.
   std::vector<int> v;
-  auto it = v.begin();
-  (v).push_back(42);
-  (void)it;
+  auto it = v.begin();  // expected-warning {{local variable 'v' is later invalidated}}
+  (v).push_back(42);    // expected-note {{local variable 'v' is invalidated here}}
+  (void)it;             // expected-note {{later used here}}
 }
 
 } // namespace InvalidatingThroughContainerAliases
 
 namespace ContainerObjectAliases {
-// FIXME: Distinguish owner-borrow from content-borrow.
-void PointerParameterObjectUseIsOk(std::vector<int> *v) { // expected-warning {{parameter 'v' is later invalidated}}
-  v->push_back(42); // expected-note {{parameter 'v' is invalidated here}}
-  (void)v;          // expected-note {{later used here}}
+void PointerParameterObjectUseIsOk(std::vector<int> *v) {
+  v->push_back(42);
+  (void)v;
 }
 
-// FIXME: Distinguish owner-borrow from content-borrow.
 void LocalPointerAliasObjectUseIsOk() {
   std::vector<int> vv;
-  std::vector<int> *v = &vv; // expected-warning {{local variable 'vv' is later invalidated}}
-  v->push_back(42);          // expected-note {{local variable 'vv' is invalidated here}}
-  (void)*v;                  // expected-note {{later used here}}
+  std::vector<int> *v = &vv;
+  v->push_back(42);
+  (void)*v;
 }
 
-// FIXME: Distinguish owner-borrow from content-borrow.
 void LocalReferenceAliasObjectUseIsOk() {
   std::vector<int> vv;
-  std::vector<int> &v = vv; // expected-warning {{local variable 'vv' is later invalidated}}
-  v.push_back(42);          // expected-note {{local variable 'vv' is invalidated here}}
-  (void)v;                  // expected-note {{later used here}}
+  std::vector<int> &v = vv;
+  v.push_back(42);
+  (void)v;
 }
 } // namespace ContainerObjectAliases
 
@@ -434,20 +438,11 @@ void SelfInvalidatingMap() {
   // Therefore the following is safe in practice.
   // On the other hand, std::flat_map (since C++23) does not provide pointer stability on
   // insertion and following is unsafe for this container.
-  // FIXME: The warnings below are false positives (self-invalidation of the Owner).
-  // Modifying a container should not invalidate the container object itself.
-  // To resolve this, we need to:
-  // 1. Distinguish owner-borrow (borrowing the container object) from content-borrow (borrowing elements inside the container).
-  // 2. Make AccessPaths more precise to reason at element/field granularity rather than treating the whole container as a single storage location.
-  mp[1] = "42"; // expected-warning {{local variable 'mp' is later invalidated}} \
-                // expected-note {{local variable 'mp' is invalidated here}} \
-                // expected-note {{later used here}}
+  mp[1] = "42";
   mp[2] = mp[1]; // expected-warning {{local variable 'mp' is later invalidated}} \
-                 // expected-warning {{local variable 'mp' is later invalidated}} \
                  // expected-note {{local variable 'mp' is invalidated here}} \
                  // expected-note {{later used here}} \
                  // expected-note {{local variable 'mp' is invalidated here}} \
-                 // expected-note {{expression aliases the storage of local variable 'mp'}} \
                  // expected-note {{later used here}}
 }
 
@@ -459,6 +454,20 @@ void InvalidateErase() {
   mp.erase(mp.find(4)); // expected-note {{local variable 'mp' is invalidated here}}
   if (it != mp.end())   // expected-note {{later used here}}
     *it;
+}
+
+void FrontInvalidated() {
+  std::vector<int> v = {1, 2, 3};
+  int& ref = v.front(); // expected-warning {{local variable 'v' is later invalidated}}
+  v.clear();            // expected-note {{local variable 'v' is invalidated here}}
+  (void)ref;            // expected-note {{later used here}}
+}
+
+void BackInvalidated() {
+  std::vector<int> v = {1, 2, 3};
+  int& ref = v.back();  // expected-warning {{local variable 'v' is later invalidated}}
+  v.push_back(4);       // expected-note {{local variable 'v' is invalidated here}}
+  (void)ref;            // expected-note {{later used here}}
 }
 } // namespace ElementReferences
 
@@ -473,6 +482,25 @@ void reassign(std::string str, std::string str2) {
   std::string_view view = str;  // expected-warning {{parameter 'str' is later invalidated}}
   str = str2;                   // expected-note {{parameter 'str' is invalidated here}}
   (void)view;                   // expected-note {{later used here}}
+}
+
+void append_call(std::string str) {
+  std::string_view view = str;  // expected-warning {{parameter 'str' is later invalidated}}
+  str.append("456");            // expected-note {{parameter 'str' is invalidated here}}
+  (void)view;                   // expected-note {{later used here}}
+}
+
+void replace_call(std::string str) {
+  std::string_view view = str;  // expected-warning {{parameter 'str' is later invalidated}}
+  str.replace(0, 1, "456");     // expected-note {{parameter 'str' is invalidated here}}
+  (void)view;                   // expected-note {{later used here}}
+}
+
+void ViewFromVectorOfStrings() {
+  std::vector<std::string> v = {"hello"};
+  std::string_view sv = v[0]; // expected-warning {{local variable 'v' is later invalidated}}
+  v.push_back("world");       // expected-note {{local variable 'v' is invalidated here}}
+  (void)sv;                   // expected-note {{later used here}}
 }
 } // namespace Strings
 
@@ -490,14 +518,11 @@ struct S {
   std::vector<std::string> strings1;
   std::vector<std::string> strings2;
 };
-// FIXME: Make Paths more precise to reason at field granularity.
-//        Currently we only detect invalidations to direct declarations and not members.
 void Invalidate1Use1IsInvalid() {
-  // FIXME: Detect this.
   S s;
-  auto it = s.strings1.begin();
-  s.strings1.push_back("1");
-  *it;
+  auto it = s.strings1.begin(); // expected-warning {{local variable 's' is later invalidated}}
+  s.strings1.push_back("1"); // expected-note {{local variable 's' is invalidated here}}
+  *it; // expected-note {{later used here}}
 }
 void Invalidate2Use1IsOk() {
     S s;
@@ -506,24 +531,26 @@ void Invalidate2Use1IsOk() {
     *it;
 }
 void ConditionalContainerInvalidatesIterator(bool flag) {
-    // FIXME: Support invalidation through conditional lvalue expressions.
     std::vector<int> v1, v2;
-    auto it = v1.begin();
-    (flag ? v1 : v2).push_back(42);
-    (void)it;
+    auto it = v1.begin();           // expected-warning {{local variable 'v1' is later invalidated}}
+    (flag ? v1 : v2).push_back(42); // expected-note {{local variable 'v1' is invalidated here}}
+    (void)it;                       // expected-note {{later used here}}
 }
 void ConditionalFieldInvalidatesIterator(bool flag) {
-    // FIXME: Support conditional invalidation through field expressions.
     S s;
-    auto it = s.strings1.begin();
-    (flag ? s.strings1 : s.strings2).push_back("1");
-    *it;
+    auto it1 = s.strings1.begin();                    // expected-warning {{local variable 's' is later invalidated}}
+    auto it2 = s.strings2.begin();                    // expected-warning {{local variable 's' is later invalidated}}
+    // FIXME: This note is inaccurate.
+    // It should say 's.strings1' is invalidated. Same for 's.strings2'.
+    (flag ? s.strings1 : s.strings2).push_back("1");  // expected-note 2 {{local variable 's' is invalidated here}}
+    *it1;                                             // expected-note {{later used here}}
+    *it2;                                             // expected-note {{later used here}}
 }
 void Invalidate1Use2ViaRefIsOk() {
     S s;
     auto it = s.strings2.begin();
     auto& strings1 = s.strings1;
-    strings1.push_back("1");      // OK
+    strings1.push_back("1");
     *it;
 }
 void Invalidate1UseSIsOk() {
@@ -532,12 +559,11 @@ void Invalidate1UseSIsOk() {
   s.strings2.push_back("1");
   (void)*p;
 }
-// FIXME: Distinguish owner-borrow from content-borrow.
 void PointerToContainerIsOk() {
   std::vector<std::string> s;
-  std::vector<std::string>* p = &s; // expected-warning {{local variable 's' is later invalidated}}
-  p->push_back("1");                // expected-note {{local variable 's' is invalidated here}}
-  (void)*p;                         // expected-note {{later used here}}
+  std::vector<std::string>* p = &s;
+  p->push_back("1");
+  (void)*p;
 }
 void IteratorFromPointerToContainerIsInvalidated() {
   std::vector<std::string> s;
@@ -547,27 +573,50 @@ void IteratorFromPointerToContainerIsInvalidated() {
   p->push_back("1");                // expected-note {{local variable 's' is invalidated here}}
   *it;                              // expected-note {{later used here}}
 }
-// FIXME: Distinguish invalidating an element's contents from invalidating
-// iterators into the outer container.
 void ChangingRegionOwnedByContainerIsOk() {
   std::vector<std::string> subdirs;
-  for (std::string& path : subdirs) // expected-warning {{local variable 'subdirs' is later invalidated}} expected-note {{later used here}} \
-                                    // expected-note {{result of call to 'end' aliases the storage of local variable 'subdirs'}}
-    path = std::string();           // expected-note {{local variable 'subdirs' is invalidated here}}
+  for (std::string& path : subdirs)
+    path = std::string();
 }
 
+struct SField { int a; int b;};
+void PointerToVectorElementField() {
+  std::vector<SField> v = {{1, 2}, {3, 4}};
+  int* ptr = &v[0].a; // expected-warning {{local variable 'v' is later invalidated}}
+  v.resize(100);      // expected-note {{local variable 'v' is invalidated here}}
+  *ptr = 10;          // expected-note {{later used here}}
+}
+
+void Invalidate1Use2ViaRefIsInvalid() {
+  S s;
+  auto it1 = s.strings1.begin();
+  auto it2 = s.strings2.begin();  // expected-warning {{local variable 's' is later invalidated}}
+  auto& strings2 = s.strings2;
+  strings2.push_back("1");        // expected-note {{local variable 's' is invalidated here}}
+  *it1;
+  *it2;                           // expected-note {{later used here}}
+}
+
+void InvalidateBothInASingleExpression(bool cond) {
+  S s;
+  auto it1 = s.strings1.begin();  // expected-warning {{local variable 's' is later invalidated}}
+  auto it2 = s.strings2.begin();  // expected-warning {{local variable 's' is later invalidated}}
+  auto& both = cond ? s.strings1 : s.strings2;
+  both.push_back("1");            // expected-note 2 {{local variable 's' is invalidated here}}
+  *it1;                           // expected-note {{later used here}}
+  *it2;                           // expected-note {{later used here}}
+}
 } // namespace ContainersAsFields
 
 namespace InvalidatedField {
 std::string StableString;
 
-// FIXME: Distinguish owner-borrow from interior-borrow.
 struct SinkOwnerBorrow {
-  std::string *dest_; // expected-note {{this field dangles}}
+  std::string *dest_;
 
-  SinkOwnerBorrow(std::string *dest, int n) : dest_(dest) { // expected-warning {{parameter 'dest' escapes to the field 'dest_' and is later invalidated}}
+  SinkOwnerBorrow(std::string *dest, int n) : dest_(dest) {
     if (n > 0)
-      dest->clear(); // expected-note {{parameter 'dest' is invalidated here}}
+      dest->clear();
   }
 };
 
@@ -634,6 +683,25 @@ struct S {
     FieldReassigned = StableString;
     strings.push_back("1");
   }
+};
+
+// FIXME: Detect invalidation of fields.
+// https://github.com/llvm/llvm-project/issues/180992
+struct InvalidateMemberFields {
+  InvalidateMemberFields();
+  void invalidateField() {
+    auto it = container.begin();
+    container.push_back("1");
+    *it;
+  }
+  void invalidateFieldRef() {
+    auto it = contiainerRef.begin();
+    contiainerRef.push_back("1");
+    *it;
+  }
+private:
+  std::vector<std::string> container;
+  std::vector<std::string>& contiainerRef;
 };
 } // namespace InvalidatedField
 
@@ -780,6 +848,13 @@ void MapSubscriptDoesNotInvalidate() {
   *it;
 }
 
+void MapOperatorBracket() {
+  std::unordered_map<int, int> m;
+  auto it = m.begin();
+  m[1];
+  *it;
+}
+
 void PrintMax(const int& a, const int& b);
 
 void MapSubscriptMultipleCallsDoesNotInvalidate(std::map<int, int> mp, int a, int b) {
@@ -787,16 +862,10 @@ void MapSubscriptMultipleCallsDoesNotInvalidate(std::map<int, int> mp, int a, in
 }
 
 void FlatMapSubscriptMultipleCallsInvalidate(std::flat_map<int, int> mp, int a, int b) {
-    // FIXME: The duplicate warning below is a false positive caused by self-invalidation of the Owner 'mp'.
-    // While the warning on the temporary reference returned by mp[a] is a true positive (it dangles),
-    // the second warning on 'mp' itself is redundant and incorrect.
-    // Resolving this requires distinguishing owner-borrow from content-borrow.
     PrintMax(mp[a], mp[b]); // expected-warning {{parameter 'mp' is later invalidated}} \
-                            // expected-warning {{parameter 'mp' is later invalidated}} \
                             // expected-note {{parameter 'mp' is invalidated here}} \
                             // expected-note {{later used here}} \
                             // expected-note {{parameter 'mp' is invalidated here}} \
-                            // expected-note 2 {{expression aliases the storage of parameter 'mp'}} \
                             // expected-note {{later used here}}
 }
 
@@ -943,7 +1012,7 @@ struct StringOwner {
 void member_destructor_invalidates_pointer() {
   StringOwner owner = {"42", "43"};
   const char *p = owner.s.data();
-  owner.t.~basic_string();        // OK
+  owner.t.~basic_string();
   (void)*p;
 }
 
@@ -987,6 +1056,38 @@ void invalid_after_ternary_reset(bool flag) {
 
 } // namespace unique_ptr_invalidation
 
+
+
+namespace NestedContainers {
+// FIXME: Maybe come up with a access path representation to detect this.
+void InnerIteratorInvalidated() {
+  std::vector<std::vector<int>> v;
+  v.resize(1);
+  // FIXME: Detect this.
+  // We cannot differentiate between v.* and v.*.*.
+  // An annotation system along with lifetimebound could be helpful to describe the paths returned.
+  auto it = v[0].begin();
+  v[0].push_back(1);
+  *it;
+}
+void InnerIteratorInvalidatedOneUseOtherIsStillBad() {
+  // FIXME: Detect this.
+  std::vector<std::vector<int>> v;
+  v.resize(100);
+  auto it = v[0].begin();
+  v[1].push_back(1);
+  *it;
+}
+
+void OuterIteratorNotInvalidated() {
+  std::vector<std::vector<int>> v;
+  v.resize(1);
+  auto it = v.begin();
+  v[0].push_back(1);
+  it->clear(); // OK
+}
+} // namespace NestedContainers
+
 namespace DeepFieldNesting {
 struct Level3 {
   std::vector<std::string> vec;
@@ -1017,6 +1118,14 @@ void SiblingLevel2Ok() {
   *it;
 }
 
+// Modifying same vector: Invalid
+void SameVectorInvalid() {
+  Level1 obj;
+  auto it = obj.inner2_1.inner3_1.vec.begin(); // expected-warning {{local variable 'obj' is later invalidated}}
+  obj.inner2_1.inner3_1.vec.push_back("1");    // expected-note {{local variable 'obj' is invalidated here}}
+  *it;                                         // expected-note {{later used here}}
+}
+
 // Modifying sibling non-container field at Level 3: OK
 void SiblingFieldLevel3Ok() {
   Level1 obj;
@@ -1025,7 +1134,31 @@ void SiblingFieldLevel3Ok() {
   *it;
 }
 
-// Modifying parent structure after use: OK
+// Modifying parent at Level 2 (reassigning struct): Invalid
+// FIXME: We don't currently detect invalidation of member containers when the parent struct is reassigned.
+void ParentLevel2Invalid() {
+  Level1 obj;
+  auto it = obj.inner2_1.inner3_1.vec.begin();
+  Level3 new_val;
+  obj.inner2_1.inner3_1 = new_val;
+  *it;
+}
+
+// Deep nesting with pointers: Invalid
+void PointerNestedInvalid(Level1* ptr) { // expected-warning {{parameter 'ptr' is later invalidated}}
+  auto it = ptr->inner2_1.inner3_1.vec.begin();
+  ptr->inner2_1.inner3_1.vec.push_back("1");    // expected-note {{parameter 'ptr' is invalidated here}}
+  *it;                                          // expected-note {{later used here}}
+}
+
+// 7. Deep nesting with references: Invalid
+void ReferenceNestedInvalid(Level1& ref) {  // expected-warning {{parameter 'ref' is later invalidated}}
+  auto it = ref.inner2_1.inner3_1.vec.begin();
+  ref.inner2_1.inner3_1.vec.push_back("1"); // expected-note {{parameter 'ref' is invalidated here}}
+  *it;                                      // expected-note {{later used here}}
+}
+
+// 8. Modifying parent structure after use: OK
 void ParentModifiedAfterUseOk() {
   Level1 obj;
   auto it = obj.inner2_1.inner3_1.vec.begin();
@@ -1034,14 +1167,14 @@ void ParentModifiedAfterUseOk() {
   obj.inner2_1.inner3_1 = new_val; // OK, because 'it' is no longer used!
 }
 
-// Pointers with sibling modification: OK
+// 9. Pointers with sibling modification: OK
 void PointerSiblingLevel3Ok(Level1* ptr) {
   auto it = ptr->inner2_1.inner3_1.vec.begin();
   ptr->inner2_1.inner3_2.vec.push_back("1"); // OK
   *it;
 }
 
-// References with sibling modification: OK
+// 10. References with sibling modification: OK
 void ReferenceSiblingLevel3Ok(Level1& ref) {
   auto it = ref.inner2_1.inner3_1.vec.begin();
   ref.inner2_1.inner3_2.vec.push_back("1"); // OK
@@ -1062,3 +1195,49 @@ void TestStructVsField(S& s) {
 }
 } // namespace StructFieldDisambiguation
 
+namespace GlobalFieldEscapes {
+std::string StableString;
+struct GlobalStruct {
+  std::string_view sv;
+};
+GlobalStruct g_struct;
+
+// FIXME: Fields of global variables are treated as FieldDecl origins, so they escape
+// as FieldEscapeFact instead of GlobalEscapeFact, causing us to miss the escape warning.
+void TestGlobalFieldInvalidated() {
+  std::string s;
+  g_struct.sv = s;
+  s.clear();
+}
+
+// Even after fixing the global field escape tracking, this should be OK because g_struct is reassigned.
+void GlobalReassignedBeforeInvalidationOk() {
+  std::string s;
+  g_struct.sv = s;
+  g_struct.sv = StableString; // Reassigned!
+  s.clear();                  // OK
+}
+} // namespace GlobalFieldEscapes
+
+namespace PointerToStructField {
+struct S {
+  std::vector<int> v;
+};
+
+void TestPointerToField(S* s) { // expected-warning {{parameter 's' is later invalidated}}
+  auto it = s->v.begin();
+  s->v.push_back(1);      // expected-note {{parameter 's' is invalidated here}}
+  *it;                    // expected-note {{later used here}}
+}
+
+struct S2 {
+  std::vector<int> v1;
+  std::vector<int> v2;
+};
+
+void TestPointerToSiblingFieldOk(S2* s) {
+  auto it = s->v1.begin();
+  s->v2.push_back(1); // OK: different field
+  *it;
+}
+} // namespace PointerToStructField

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -12,6 +12,7 @@
 #include "clang/Analysis/Analyses/LifetimeSafety/Loans.h"
 #include "clang/Testing/TestAST.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Support/raw_ostream.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <optional>
@@ -141,6 +142,14 @@ public:
                .getLoan(LID)
                ->getAccessPath()
                .getAsMaterializeTemporaryExpr() != nullptr;
+  }
+
+  std::string getAccessPathString(LoanID LID) {
+    const Loan *L = Analysis.getFactManager().getLoanMgr().getLoan(LID);
+    std::string S;
+    llvm::raw_string_ostream OS(S);
+    L->getAccessPath().dump(OS);
+    return S;
   }
 
   // Gets the set of loans that are live at the given program point. A loan is
@@ -287,7 +296,7 @@ public:
 /// variable expected to be the source of a loan.
 /// \param Annotation A string identifying the program point (created with
 /// POINT()) where the check should be performed.
-MATCHER_P2(HasLoansToImpl, LoanVars, Annotation, "") {
+MATCHER_P2(HasLoansToImpl, LoanPathStrs, Annotation, "") {
   const OriginInfo &Info = arg;
   std::optional<OriginID> OIDOpt = Info.Helper.getOriginForDecl(Info.OriginVar);
   if (!OIDOpt) {
@@ -303,36 +312,12 @@ MATCHER_P2(HasLoansToImpl, LoanVars, Annotation, "") {
                      << Annotation << "'";
     return false;
   }
-  std::vector<LoanID> ActualLoans(ActualLoansSetOpt->begin(),
-                                  ActualLoansSetOpt->end());
+  std::vector<std::string> ActualLoanPaths;
+  for (LoanID LID : *ActualLoansSetOpt)
+    ActualLoanPaths.push_back(Info.Helper.getAccessPathString(LID));
 
-  std::vector<LoanID> ExpectedLoans;
-  for (const auto &LoanVar : LoanVars) {
-    std::vector<LoanID> ExpectedLIDs = Info.Helper.getLoansForVar(LoanVar);
-    if (ExpectedLIDs.empty()) {
-      *result_listener << "could not find loan for var '" << LoanVar << "'";
-      return false;
-    }
-    ExpectedLoans.insert(ExpectedLoans.end(), ExpectedLIDs.begin(),
-                         ExpectedLIDs.end());
-  }
-  std::sort(ExpectedLoans.begin(), ExpectedLoans.end());
-  std::sort(ActualLoans.begin(), ActualLoans.end());
-  if (ExpectedLoans != ActualLoans) {
-    *result_listener << "Expected: {";
-    for (const auto &LoanID : ExpectedLoans) {
-      *result_listener << LoanID.Value << ", ";
-    }
-    *result_listener << "} Actual: {";
-    for (const auto &LoanID : ActualLoans) {
-      *result_listener << LoanID.Value << ", ";
-    }
-    *result_listener << "}";
-    return false;
-  }
-
-  return ExplainMatchResult(UnorderedElementsAreArray(ExpectedLoans),
-                            ActualLoans, result_listener);
+  return ExplainMatchResult(UnorderedElementsAreArray(LoanPathStrs),
+                            ActualLoanPaths, result_listener);
 }
 
 enum class LivenessKindFilter { Maybe, Must, All };
@@ -1211,6 +1196,63 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundConversionOperator) {
     }
   )");
   EXPECT_THAT(Origin("v"), HasLoansTo({"owner"}, "p1"));
+}
+
+TEST_F(LifetimeAnalysisTest, NestedFieldAccess) {
+  SetupTest(R"(
+    struct Inner { int val; };
+    struct Outer { Inner f; };
+    void target() {
+        Outer o;
+        Outer *p = &o;
+        int* p1 = &o.f.val;
+        POINT(a);
+        int* p2 = &p->f.val;
+        POINT(b);
+    }
+  )");
+  EXPECT_THAT(Origin("p1"), HasLoansTo({"o.f.val"}, "a"));
+  EXPECT_THAT(Origin("p2"), HasLoansTo({"o.f.val"}, "b"));
+}
+
+TEST_F(LifetimeAnalysisTest, PlaceholderParamField) {
+  SetupTest(R"(
+    struct S { int val; };
+    void target(S* p) {
+      int* p1 = &p->val;
+      POINT(a);
+    }
+  )");
+  EXPECT_THAT(Origin("p1"), HasLoansTo({"$p.val"}, "a"));
+}
+
+TEST_F(LifetimeAnalysisTest, PlaceholderThisField) {
+  SetupTest(R"(
+    struct S {
+      int f;
+      void target() {
+        int* p1 = &f;
+        POINT(a);
+      }
+    };
+  )");
+  EXPECT_THAT(Origin("p1"), HasLoansTo({"$this.f"}, "a"));
+}
+
+TEST_F(LifetimeAnalysisTest, PlaceholderThisNestedField) {
+  SetupTest(R"(
+    struct S1 {
+      int f;
+    };
+    struct S {
+      S1 s1;
+      void target() {
+        int* p1 = &s1.f;
+        POINT(a);
+      }
+    };
+  )");
+  EXPECT_THAT(Origin("p1"), HasLoansTo({"$this.s1.f"}, "a"));
 }
 
 TEST_F(LifetimeAnalysisTest, LivenessDeadPointer) {

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -292,8 +292,8 @@ public:
 ///
 /// This matcher is intended to be used with an \c OriginInfo object.
 ///
-/// \param LoanVars A vector of strings, where each string is the name of a
-/// variable expected to be the source of a loan.
+/// \param LoanPathStrs A vector of strings, where each string is the
+/// string representation of an access path of a loan.
 /// \param Annotation A string identifying the program point (created with
 /// POINT()) where the check should be performed.
 MATCHER_P2(HasLoansToImpl, LoanPathStrs, Annotation, "") {
@@ -782,7 +782,7 @@ TEST_F(LifetimeAnalysisTest, GslPointerSimpleLoan) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("x"), HasLoansTo({"a"}, "p1"));
+  EXPECT_THAT(Origin("x"), HasLoansTo({"a.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, GslPointerConstructFromOwner) {
@@ -798,12 +798,12 @@ TEST_F(LifetimeAnalysisTest, GslPointerConstructFromOwner) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("a"), HasLoansTo({"al"}, "p1"));
-  EXPECT_THAT(Origin("b"), HasLoansTo({"bl"}, "p1"));
-  EXPECT_THAT(Origin("c"), HasLoansTo({"cl"}, "p1"));
-  EXPECT_THAT(Origin("d"), HasLoansTo({"dl"}, "p1"));
-  EXPECT_THAT(Origin("e"), HasLoansTo({"el"}, "p1"));
-  EXPECT_THAT(Origin("f"), HasLoansTo({"fl"}, "p1"));
+  EXPECT_THAT(Origin("a"), HasLoansTo({"al.*"}, "p1"));
+  EXPECT_THAT(Origin("b"), HasLoansTo({"bl.*"}, "p1"));
+  EXPECT_THAT(Origin("c"), HasLoansTo({"cl.*"}, "p1"));
+  EXPECT_THAT(Origin("d"), HasLoansTo({"dl.*"}, "p1"));
+  EXPECT_THAT(Origin("e"), HasLoansTo({"el.*"}, "p1"));
+  EXPECT_THAT(Origin("f"), HasLoansTo({"fl.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, GslPointerConstructFromView) {
@@ -818,11 +818,11 @@ TEST_F(LifetimeAnalysisTest, GslPointerConstructFromView) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("x"), HasLoansTo({"a"}, "p1"));
-  EXPECT_THAT(Origin("y"), HasLoansTo({"a"}, "p1"));
-  EXPECT_THAT(Origin("z"), HasLoansTo({"a"}, "p1"));
-  EXPECT_THAT(Origin("p"), HasLoansTo({"a"}, "p1"));
-  EXPECT_THAT(Origin("q"), HasLoansTo({"a"}, "p1"));
+  EXPECT_THAT(Origin("x"), HasLoansTo({"a.*"}, "p1"));
+  EXPECT_THAT(Origin("y"), HasLoansTo({"a.*"}, "p1"));
+  EXPECT_THAT(Origin("z"), HasLoansTo({"a.*"}, "p1"));
+  EXPECT_THAT(Origin("p"), HasLoansTo({"a.*"}, "p1"));
+  EXPECT_THAT(Origin("q"), HasLoansTo({"a.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, GslPointerInConditionalOperator) {
@@ -833,7 +833,7 @@ TEST_F(LifetimeAnalysisTest, GslPointerInConditionalOperator) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("v"), HasLoansTo({"a", "b"}, "p1"));
+  EXPECT_THAT(Origin("v"), HasLoansTo({"a.*", "b.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, ExtraParenthesis) {
@@ -847,10 +847,10 @@ TEST_F(LifetimeAnalysisTest, ExtraParenthesis) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("x"), HasLoansTo({"a"}, "p1"));
-  EXPECT_THAT(Origin("y"), HasLoansTo({"a"}, "p1"));
-  EXPECT_THAT(Origin("z"), HasLoansTo({"a"}, "p1"));
-  EXPECT_THAT(Origin("p"), HasLoansTo({"a"}, "p1"));
+  EXPECT_THAT(Origin("x"), HasLoansTo({"a.*"}, "p1"));
+  EXPECT_THAT(Origin("y"), HasLoansTo({"a.*"}, "p1"));
+  EXPECT_THAT(Origin("z"), HasLoansTo({"a.*"}, "p1"));
+  EXPECT_THAT(Origin("p"), HasLoansTo({"a.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, ViewFromTemporary) {
@@ -877,8 +877,8 @@ TEST_F(LifetimeAnalysisTest, GslPointerWithConstAndAuto) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("v1"), HasLoansTo({"a"}, "p1"));
-  EXPECT_THAT(Origin("v2"), HasLoansTo({"a"}, "p1"));
+  EXPECT_THAT(Origin("v1"), HasLoansTo({"a.*"}, "p1"));
+  EXPECT_THAT(Origin("v2"), HasLoansTo({"a.*"}, "p1"));
   EXPECT_THAT(Origin("v3"), HasLoansTo({"v2"}, "p1"));
 }
 
@@ -898,9 +898,9 @@ TEST_F(LifetimeAnalysisTest, GslPointerPropagation) {
     }
   )");
 
-  EXPECT_THAT(Origin("x"), HasLoansTo({"a"}, "p1"));
-  EXPECT_THAT(Origin("y"), HasLoansTo({"a"}, "p2"));
-  EXPECT_THAT(Origin("z"), HasLoansTo({"a"}, "p3"));
+  EXPECT_THAT(Origin("x"), HasLoansTo({"a.*"}, "p1"));
+  EXPECT_THAT(Origin("y"), HasLoansTo({"a.*"}, "p2"));
+  EXPECT_THAT(Origin("z"), HasLoansTo({"a.*"}, "p3"));
 }
 
 TEST_F(LifetimeAnalysisTest, GslPointerReassignment) {
@@ -919,9 +919,9 @@ TEST_F(LifetimeAnalysisTest, GslPointerReassignment) {
     }
   )");
 
-  EXPECT_THAT(Origin("v"), HasLoansTo({"safe"}, "p1"));
-  EXPECT_THAT(Origin("v"), HasLoansTo({"unsafe"}, "p2"));
-  EXPECT_THAT(Origin("v"), HasLoansTo({"unsafe"}, "p3"));
+  EXPECT_THAT(Origin("v"), HasLoansTo({"safe.*"}, "p1"));
+  EXPECT_THAT(Origin("v"), HasLoansTo({"unsafe.*"}, "p2"));
+  EXPECT_THAT(Origin("v"), HasLoansTo({"unsafe.*"}, "p3"));
 }
 
 TEST_F(LifetimeAnalysisTest, GslPointerConversionOperator) {
@@ -945,8 +945,8 @@ TEST_F(LifetimeAnalysisTest, GslPointerConversionOperator) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("x"), HasLoansTo({"xl"}, "p1"));
-  EXPECT_THAT(Origin("y"), HasLoansTo({"yl"}, "p1"));
+  EXPECT_THAT(Origin("x"), HasLoansTo({"xl.*"}, "p1"));
+  EXPECT_THAT(Origin("y"), HasLoansTo({"yl.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, LifetimeboundSimple) {
@@ -962,10 +962,10 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundSimple) {
       POINT(p2);
     }
   )");
-  EXPECT_THAT(Origin("v1"), HasLoansTo({"a"}, "p1"));
+  EXPECT_THAT(Origin("v1"), HasLoansTo({"a.*"}, "p1"));
   // The origin of v2 should now contain the loan to 'o' from v1.
-  EXPECT_THAT(Origin("v2"), HasLoansTo({"a"}, "p2"));
-  EXPECT_THAT(Origin("v3"), HasLoansTo({"b"}, "p2"));
+  EXPECT_THAT(Origin("v2"), HasLoansTo({"a.*"}, "p2"));
+  EXPECT_THAT(Origin("v3"), HasLoansTo({"b.*"}, "p2"));
 }
 
 TEST_F(LifetimeAnalysisTest, LifetimeboundMemberFunctionOfAView) {
@@ -982,7 +982,7 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundMemberFunctionOfAView) {
       POINT(p2);
     }
   )");
-  EXPECT_THAT(Origin("v1"), HasLoansTo({"o"}, "p1"));
+  EXPECT_THAT(Origin("v1"), HasLoansTo({"o.*"}, "p1"));
   // The call v1.pass() is bound to 'v1'.
   EXPECT_THAT(Origin("v2"), HasLoansTo({"v1"}, "p2"));
 }
@@ -1014,11 +1014,11 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundMultipleArgs) {
       POINT(p2);
     }
   )");
-  EXPECT_THAT(Origin("v1"), HasLoansTo({"o1"}, "p1"));
-  EXPECT_THAT(Origin("v2"), HasLoansTo({"o2"}, "p2"));
+  EXPECT_THAT(Origin("v1"), HasLoansTo({"o1.*"}, "p1"));
+  EXPECT_THAT(Origin("v2"), HasLoansTo({"o2.*"}, "p2"));
   // v3 should have loans from both v1 and v2, demonstrating the union of
   // loans.
-  EXPECT_THAT(Origin("v3"), HasLoansTo({"o1", "o2"}, "p2"));
+  EXPECT_THAT(Origin("v3"), HasLoansTo({"o1.*", "o2.*"}, "p2"));
 }
 
 TEST_F(LifetimeAnalysisTest, LifetimeboundMixedArgs) {
@@ -1034,10 +1034,10 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundMixedArgs) {
       POINT(p2);
     }
   )");
-  EXPECT_THAT(Origin("v1"), HasLoansTo({"o1"}, "p1"));
-  EXPECT_THAT(Origin("v2"), HasLoansTo({"o2"}, "p1"));
+  EXPECT_THAT(Origin("v1"), HasLoansTo({"o1.*"}, "p1"));
+  EXPECT_THAT(Origin("v2"), HasLoansTo({"o2.*"}, "p1"));
   // v3 should only have loans from v1, as v2 is not lifetimebound.
-  EXPECT_THAT(Origin("v3"), HasLoansTo({"o1"}, "p2"));
+  EXPECT_THAT(Origin("v3"), HasLoansTo({"o1.*"}, "p2"));
 }
 
 TEST_F(LifetimeAnalysisTest, LifetimeboundChainOfViews) {
@@ -1053,9 +1053,9 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundChainOfViews) {
       POINT(p2);
     }
   )");
-  EXPECT_THAT(Origin("v1"), HasLoansTo({"obj"}, "p1"));
+  EXPECT_THAT(Origin("v1"), HasLoansTo({"obj.*"}, "p1"));
   // v2 should inherit the loan from v1 through the chain of calls.
-  EXPECT_THAT(Origin("v2"), HasLoansTo({"obj"}, "p2"));
+  EXPECT_THAT(Origin("v2"), HasLoansTo({"obj.*"}, "p2"));
 }
 
 TEST_F(LifetimeAnalysisTest, LifetimeboundRawPointerParameter) {
@@ -1082,7 +1082,7 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundRawPointerParameter) {
   EXPECT_THAT(Origin("v"), HasLoansTo({"a"}, "p1"));
   EXPECT_THAT(Origin("ptr1"), HasLoansTo({"b"}, "p2"));
   EXPECT_THAT(Origin("ptr2"), HasLoansTo({"b"}, "p2"));
-  EXPECT_THAT(Origin("v2"), HasLoansTo({"c"}, "p3"));
+  EXPECT_THAT(Origin("v2"), HasLoansTo({"c.*"}, "p3"));
 }
 
 TEST_F(LifetimeAnalysisTest, LifetimeboundConstRefViewParameter) {
@@ -1095,7 +1095,7 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundConstRefViewParameter) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("v1"), HasLoansTo({"o"}, "p1"));
+  EXPECT_THAT(Origin("v1"), HasLoansTo({"o.*"}, "p1"));
   EXPECT_THAT(Origin("v2"), HasLoansTo({"v1"}, "p1"));
 }
 
@@ -1130,12 +1130,31 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundReturnReference) {
       POINT(p3);
     }
   )");
-  EXPECT_THAT(Origin("v1"), HasLoansTo({"a"}, "p1"));
-  EXPECT_THAT(Origin("v2"), HasLoansTo({"a"}, "p2"));
+  // All views have a single interior path (`.*`) because the implementation
+  // prevents accumulation of multiple `.*` suffixes (see
+  // DoNotAddMultipleInteriors test). When `Identity(v1)` returns a `MyObj&`
+  // with loan `a.*`, constructing `View v2` from it would normally add another
+  // `.*`, but the implementation actively prevents duplication of '.*'.
+  EXPECT_THAT(Origin("v1"), HasLoansTo({"a.*"}, "p1"));
+  EXPECT_THAT(Origin("v2"), HasLoansTo({"a.*"}, "p2"));
+  EXPECT_THAT(Origin("v3"), HasLoansTo({"a.*"}, "p2"));
+  EXPECT_THAT(Origin("v4"), HasLoansTo({"c.*"}, "p3"));
+}
 
-  EXPECT_THAT(Origin("v3"), HasLoansTo({"a"}, "p2"));
-
-  EXPECT_THAT(Origin("v4"), HasLoansTo({"c"}, "p3"));
+TEST_F(LifetimeAnalysisTest, DoNotAddMultipleInteriors) {
+  SetupTest(R"(
+    const MyObj& Identity(View v [[clang::lifetimebound]]);
+    void target() {
+      MyObj a;
+      View v = a;      
+      for (int i = 0; i < 10; ++i) {
+        const MyObj& b = Identity(v);
+        v = Identity(b);
+        POINT(p1);
+      }
+    }
+  )");
+  EXPECT_THAT(Origin("v"), HasLoansTo({"a.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, LifetimeboundTemplateFunctionReturnRef) {
@@ -1152,7 +1171,7 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundTemplateFunctionReturnRef) {
       POINT(p2);
     }
   )");
-  EXPECT_THAT(Origin("v1"), HasLoansTo({"a"}, "p1"));
+  EXPECT_THAT(Origin("v1"), HasLoansTo({"a.*"}, "p1"));
   EXPECT_THAT(Origin("v2"), HasLoansTo({}, "p2"));
   EXPECT_THAT(Origin("v3"), HasLoansTo({"v2"}, "p2"));
 }
@@ -1176,7 +1195,7 @@ TEST_F(LifetimeAnalysisTest, LifetimeboundTemplateFunctionReturnVal) {
   )");
   EXPECT_THAT(Origin("v1"), HasLoanToATemporary("p1"));
 
-  EXPECT_THAT(Origin("v2"), HasLoansTo({"b"}, "p2"));
+  EXPECT_THAT(Origin("v2"), HasLoansTo({"b.*"}, "p2"));
   EXPECT_THAT(Origin("v3"), HasLoansTo({"v2"}, "p2"));
   // View temporary on RHS is lifetime-extended.
   EXPECT_THAT(Origin("v4"), HasLoansTo({}, "p2"));
@@ -1215,6 +1234,16 @@ TEST_F(LifetimeAnalysisTest, NestedFieldAccess) {
   EXPECT_THAT(Origin("p2"), HasLoansTo({"o.f.val"}, "b"));
 }
 
+TEST_F(LifetimeAnalysisTest, PlaceholderInterior) {
+  SetupTest(R"(
+    void target(const MyObj& p) {
+      View v = p;
+      POINT(a);
+    }
+  )");
+  EXPECT_THAT(Origin("v"), HasLoansTo({"$p.*"}, "a"));
+}
+
 TEST_F(LifetimeAnalysisTest, PlaceholderParamField) {
   SetupTest(R"(
     struct S { int val; };
@@ -1237,6 +1266,19 @@ TEST_F(LifetimeAnalysisTest, PlaceholderThisField) {
     };
   )");
   EXPECT_THAT(Origin("p1"), HasLoansTo({"$this.f"}, "a"));
+}
+
+TEST_F(LifetimeAnalysisTest, PlaceholderThisInterior) {
+  SetupTest(R"(
+    struct S {
+      MyObj o;
+      void target() {
+        View v = o;
+        POINT(a);
+      }
+    };
+  )");
+  EXPECT_THAT(Origin("v"), HasLoansTo({"$this.o.*"}, "a"));
 }
 
 TEST_F(LifetimeAnalysisTest, PlaceholderThisNestedField) {
@@ -1720,7 +1762,7 @@ TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_STLBegin) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("it"), HasLoansTo({"vec"}, "p1"));
+  EXPECT_THAT(Origin("it"), HasLoansTo({"vec.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_OwnerDeref) {
@@ -1738,7 +1780,7 @@ TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_OwnerDeref) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("r"), HasLoansTo({"opt"}, "p1"));
+  EXPECT_THAT(Origin("r"), HasLoansTo({"opt.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_Value) {
@@ -1756,7 +1798,7 @@ TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_Value) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("r"), HasLoansTo({"opt"}, "p1"));
+  EXPECT_THAT(Origin("r"), HasLoansTo({"opt.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_UniquePtr_Get) {
@@ -1774,7 +1816,7 @@ TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_UniquePtr_Get) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("r"), HasLoansTo({"up"}, "p1"));
+  EXPECT_THAT(Origin("r"), HasLoansTo({"up.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_ConversionOperator) {
@@ -1793,7 +1835,7 @@ TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_ConversionOperator) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("ptr"), HasLoansTo({"owner"}, "p1"));
+  EXPECT_THAT(Origin("ptr"), HasLoansTo({"owner.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_MapFind) {
@@ -1812,7 +1854,7 @@ TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_MapFind) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("it"), HasLoansTo({"m"}, "p1"));
+  EXPECT_THAT(Origin("it"), HasLoansTo({"m.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_GSLPointerArg) {
@@ -1858,11 +1900,11 @@ TEST_F(LifetimeAnalysisTest, TrackImplicitObjectArg_GSLPointerArg) {
       POINT(end);
     }
   )");
-  EXPECT_THAT(Origin("sv1"), HasLoansTo({"s1"}, "end"));
-  EXPECT_THAT(Origin("sv2"), HasLoansTo({"s2"}, "end"));
-  EXPECT_THAT(Origin("sv3"), HasLoansTo({"s3"}, "end"));
-  EXPECT_THAT(Origin("sv4"), HasLoansTo({"s4"}, "end"));
-  EXPECT_THAT(Origin("sv5"), HasLoansTo({"s5"}, "end"));
+  EXPECT_THAT(Origin("sv1"), HasLoansTo({"s1.*"}, "end"));
+  EXPECT_THAT(Origin("sv2"), HasLoansTo({"s2.*"}, "end"));
+  EXPECT_THAT(Origin("sv3"), HasLoansTo({"s3.*"}, "end"));
+  EXPECT_THAT(Origin("sv4"), HasLoansTo({"s4.*"}, "end"));
+  EXPECT_THAT(Origin("sv5"), HasLoansTo({"s5.*"}, "end"));
 }
 
 // ========================================================================= //
@@ -1888,7 +1930,7 @@ TEST_F(LifetimeAnalysisTest, TrackFirstArgument_StdBegin) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("it"), HasLoansTo({"vec"}, "p1"));
+  EXPECT_THAT(Origin("it"), HasLoansTo({"vec.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, TrackFirstArgument_StdData) {
@@ -1909,7 +1951,7 @@ TEST_F(LifetimeAnalysisTest, TrackFirstArgument_StdData) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("p"), HasLoansTo({"vec"}, "p1"));
+  EXPECT_THAT(Origin("p"), HasLoansTo({"vec.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, TrackFirstArgument_StdAnyCast) {
@@ -1927,7 +1969,7 @@ TEST_F(LifetimeAnalysisTest, TrackFirstArgument_StdAnyCast) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("r"), HasLoansTo({"a"}, "p1"));
+  EXPECT_THAT(Origin("r"), HasLoansTo({"a.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, DerivedToBaseThisArg) {
@@ -1951,7 +1993,7 @@ TEST_F(LifetimeAnalysisTest, DerivedToBaseThisArg) {
       POINT(p1);
     }
   )");
-  EXPECT_THAT(Origin("view"), HasLoansTo({"my_obj_or"}, "p1"));
+  EXPECT_THAT(Origin("view"), HasLoansTo({"my_obj_or.*"}, "p1"));
 }
 
 TEST_F(LifetimeAnalysisTest, DerivedViewWithNoAnnotation) {
@@ -1986,7 +2028,7 @@ TEST_F(LifetimeAnalysisTest, LambdaCaptureViewByValue) {
       POINT(after_lambda);
     }
   )");
-  EXPECT_THAT(Origin("lambda"), HasLoansTo({"obj"}, "after_lambda"));
+  EXPECT_THAT(Origin("lambda"), HasLoansTo({"obj.*"}, "after_lambda"));
 }
 
 TEST_F(LifetimeAnalysisTest, LambdaInitCaptureRawPointerByValue) {
@@ -2010,7 +2052,7 @@ TEST_F(LifetimeAnalysisTest, LambdaInitCaptureViewByValue) {
       POINT(after_lambda);
     }
   )");
-  EXPECT_THAT(Origin("lambda"), HasLoansTo({"obj"}, "after_lambda"));
+  EXPECT_THAT(Origin("lambda"), HasLoansTo({"obj.*"}, "after_lambda"));
 }
 
 // ========================================================================= //
@@ -2164,6 +2206,125 @@ TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithLifetimeBound) {
   EXPECT_THAT(ChainForTgtB, Contains(*Helper->getOriginForDecl("b")));
   EXPECT_THAT(ChainForTgtB, Contains(*Helper->getOriginForDecl("result")));
   EXPECT_THAT(ChainForTgtB, Not(Contains(*Helper->getOriginForDecl("a"))));
+}
+
+TEST_F(LifetimeAnalysisTest, AlternatingPathsShouldNotDiverge) {
+  SetupTest(R"(
+    template <typename T>
+    struct [[gsl::Owner]] Box {
+      T& get() [[clang::lifetimebound]];
+    };
+
+    struct S {
+      Box<S> box;
+    };
+
+    void target(S& s) {
+      S* p = &s;
+      while (true) {
+        p = &p->box.get();
+        POINT(inside_loop);
+      }
+    }
+  )");
+
+  EXPECT_THAT(Origin("p"), HasLoansTo({"$s.box.*"}, "inside_loop"));
+}
+
+TEST_F(LifetimeAnalysisTest, DivergenceWithFieldConversion) {
+  SetupTest(R"(
+    struct S {
+      struct Inner {
+        S& operator()() [[clang::lifetimebound]];
+      } inner;
+    };
+
+    void target(S& s) {
+      S* p = &s;
+      while (true) {
+        p = &p->inner();
+        POINT(inside_loop);
+      }
+    }
+  )");
+
+  EXPECT_THAT(Origin("p"), HasLoansTo({"$s.inner"}, "inside_loop"));
+}
+
+TEST_F(LifetimeAnalysisTest, DivergenceWithReinterpretCast) {
+  SetupTest(R"(
+    struct S {
+      struct Inner { int x; } inner;
+    };
+
+    void target(S& s) {
+      S* p = &s;
+      while (true) {
+        p = reinterpret_cast<S*>(&p->inner);
+        POINT(inside_loop);
+      }
+    }
+  )");
+
+  EXPECT_THAT(Origin("p"), HasLoansTo({"$s.inner"}, "inside_loop"));
+}
+
+TEST_F(LifetimeAnalysisTest, DivergenceWithVoidCast) {
+  SetupTest(R"(
+    struct S {
+      struct Inner { int x; } inner;
+    };
+
+    void target(S& s) {
+      S* p = &s;
+      while (true) {
+        void* v = &p->inner;
+        p = static_cast<S*>(v);
+        POINT(inside_loop);
+      }
+    }
+  )");
+
+  EXPECT_THAT(Origin("p"), HasLoansTo({"$s.inner"}, "inside_loop"));
+}
+
+TEST_F(LifetimeAnalysisTest, DivergenceWithBitCast) {
+  SetupTest(R"(
+    struct S {
+      struct Inner { int x; } inner;
+    };
+
+    void target(S& s) {
+      S* p = &s;
+      while (true) {
+        p = __builtin_bit_cast(S*, &p->inner);
+        POINT(inside_loop);
+      }
+    }
+  )");
+
+  EXPECT_THAT(Origin("p"), HasLoansTo({"$s.inner"}, "inside_loop"));
+}
+
+TEST_F(LifetimeAnalysisTest, DivergenceWithPlacementNew) {
+  SetupTest(R"(
+    typedef decltype(sizeof(0)) size_t;
+    void* operator new(size_t, void* p) { return p; }
+    
+    struct S {
+      struct Inner { int x; } inner;
+    };
+
+    void target(S& s) {
+      S* p = &s;
+      while (true) {
+        p = new (&p->inner) S;
+        POINT(inside_loop);
+      }
+    }
+  )");
+
+  EXPECT_THAT(Origin("p"), HasLoansTo({"$s.inner"}, "inside_loop"));
 }
 } // anonymous namespace
 } // namespace clang::lifetimes::internal


### PR DESCRIPTION
This patch completes the implementation of path-sensitive lifetime tracking by supporting container interior paths (`.*`) and deep-nested invalidation.

- Enables `PathElement::getInterior` generation in `FactsGenerator` for GSL Owners and Views (e.g. member functions, function parameters, lambda captures).
- Removes bypass checks in `FactsGenerator::handleInvalidatingCall` to track container invalidation on fields.
- Updates `Checker` to use strict prefix comparison (`isStrictPrefixOf`) for container invalidations, ensuring invalidation of container contents (interior) correctly invalidates iterators but not other sibling fields.
- Reorganizes tests in `invalidations.cpp` by resolving duplicates and distributing them logically.
- Updates unit tests and sema tests with correct expectations for interior paths.