### PR TITLE
[llvm-pdbutil] Print error on invalid YAML

### DIFF
--- a/llvm/test/tools/llvm-pdbutil/invalid-yaml.test
+++ b/llvm/test/tools/llvm-pdbutil/invalid-yaml.test
@@ -1,0 +1,10 @@
+## Test that we produce an error if the YAML input is invalid.
+# RUN: not llvm-pdbutil yaml2pdb %s --pdb=%t.pdb 2>&1 | FileCheck %s
+
+---
+- A list is not valid
+# CHECK: invalid-yaml.test:[[@LINE-1]]:1: error: not a mapping
+# CHECK-NEXT: - A list
+# CHECK-NEXT: ^
+# CHECK-NEXT: llvm-pdbutil: failed to parse YAML input: invalid argument
+...

--- a/llvm/test/tools/llvm-pdbutil/invalid-yaml.test
+++ b/llvm/test/tools/llvm-pdbutil/invalid-yaml.test
@@ -6,5 +6,5 @@
 # CHECK: invalid-yaml.test:[[@LINE-1]]:1: error: not a mapping
 # CHECK-NEXT: - A list
 # CHECK-NEXT: ^
-# CHECK-NEXT: llvm-pdbutil: failed to parse YAML input: invalid argument
+# CHECK-NEXT: llvm-pdbutil: failed to parse YAML input:
 ...

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
@@ -819,15 +819,23 @@ static void yamlToPdb(StringRef Path, unsigned DocNum) {
 
   std::unique_ptr<MemoryBuffer> &Buffer = ErrorOrBuffer.get();
 
-  llvm::yaml::Input In(Buffer->getBuffer());
+  llvm::yaml::Input In(
+      Buffer->getMemBufferRef(), nullptr,
+      [](const SMDiagnostic &Diag, void *) { Diag.print(nullptr, errs()); });
+
   for (unsigned CurrentDoc = 1; CurrentDoc < DocNum; ++CurrentDoc) {
     if (!In.nextDocument())
       ExitOnErr(createFileError(
           Path, createStringErrorV("cannot find the {0}{1} document", DocNum,
                                    getOrdinalSuffix(DocNum))));
   }
+
   pdb::yaml::PdbObject YamlObj(Allocator);
   In >> YamlObj;
+
+  if (std::error_code EC = In.error())
+    ExitOnErr(
+        createStringErrorV("failed to parse YAML input: {0}", EC.message()));
 
   PDBFileBuilder Builder(Allocator);
 


### PR DESCRIPTION
From https://github.com/llvm/llvm-project/pull/207058#discussion_r3522204565: We should print out an error if we encounter invalid YAML.

With this PR, the error is printed. I included the diagnostics here, because they provide better error messages and allow you to locate the error easier.