### PR TITLE
[InstCombine] Use byte type to preserve provenances

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -173,8 +173,9 @@ Instruction *InstCombinerImpl::SimplifyAnyMemTransfer(AnyMemTransferInst *MI) {
     if (*CopyDstAlign < Size || *CopySrcAlign < Size)
       return nullptr;
 
-  // Use an integer load+store unless we can find something better.
-  IntegerType* IntType = IntegerType::get(MI->getContext(), Size<<3);
+  // Use a byte load+store unless we can find something better.
+  // We don't use the integer type as it drops provenances.
+  ByteType *AccessType = ByteType::get(MI->getContext(), Size << 3);
 
   // If the memcpy has metadata describing the members, see if we can get the
   // TBAA, scope and noalias tags describing our copy.
@@ -182,7 +183,7 @@ Instruction *InstCombinerImpl::SimplifyAnyMemTransfer(AnyMemTransferInst *MI) {
 
   Value *Src = MI->getArgOperand(1);
   Value *Dest = MI->getArgOperand(0);
-  LoadInst *L = Builder.CreateLoad(IntType, Src);
+  LoadInst *L = Builder.CreateLoad(AccessType, Src);
   // Alignment from the mem intrinsic will be better, so use it.
   L->setAlignment(*CopySrcAlign);
   L->setAAMetadata(AACopyMD);

--- a/llvm/test/Transforms/Inline/byval-tail-call.ll
+++ b/llvm/test/Transforms/Inline/byval-tail-call.ll
@@ -23,8 +23,8 @@ define void @foo(ptr %x) {
 ; CHECK-LABEL: @foo(
 ; CHECK-NEXT:    [[X1:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[X1]])
-; CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[X:%.*]], align 1
-; CHECK-NEXT:    store i32 [[TMP2]], ptr [[X1]], align 4
+; CHECK-NEXT:    [[TMP1:%.*]] = load b32, ptr [[X:%.*]], align 1
+; CHECK-NEXT:    store b32 [[TMP1]], ptr [[X1]], align 4
 ; CHECK-NEXT:    call void @ext(ptr nonnull [[X1]])
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[X1]])
 ; CHECK-NEXT:    ret void
@@ -43,8 +43,8 @@ define void @frob(ptr %x) {
 ; CHECK-LABEL: @frob(
 ; CHECK-NEXT:    [[X1:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[X1]])
-; CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[X:%.*]], align 1
-; CHECK-NEXT:    store i32 [[TMP2]], ptr [[X1]], align 4
+; CHECK-NEXT:    [[TMP1:%.*]] = load b32, ptr [[X:%.*]], align 1
+; CHECK-NEXT:    store b32 [[TMP1]], ptr [[X1]], align 4
 ; CHECK-NEXT:    call void @ext(ptr nonnull [[X1]])
 ; CHECK-NEXT:    tail call void @ext(ptr null)
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[X1]])
@@ -72,8 +72,8 @@ define void @foobar(ptr %x) {
 ; CHECK-LABEL: @foobar(
 ; CHECK-NEXT:    [[X1:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[X1]])
-; CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[X:%.*]], align 1
-; CHECK-NEXT:    store i32 [[TMP2]], ptr [[X1]], align 4
+; CHECK-NEXT:    [[TMP1:%.*]] = load b32, ptr [[X:%.*]], align 1
+; CHECK-NEXT:    store b32 [[TMP1]], ptr [[X1]], align 4
 ; CHECK-NEXT:    tail call void @ext2(ptr nonnull byval(i32) [[X1]])
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[X1]])
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/InstCombine/alloca.ll
+++ b/llvm/test/Transforms/InstCombine/alloca.ll
@@ -189,24 +189,24 @@ define void @test9(ptr %a) {
 ; CHECK-LABEL: @test9(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[ARGMEM:%.*]] = alloca inalloca <{ [[STRUCT_TYPE:%.*]] }>, align 1
-; CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr [[A:%.*]], align 4
-; CHECK-NEXT:    store i64 [[TMP0]], ptr [[ARGMEM]], align 4
+; CHECK-NEXT:    [[TMP0:%.*]] = load b64, ptr [[A:%.*]], align 4
+; CHECK-NEXT:    store b64 [[TMP0]], ptr [[ARGMEM]], align 4
 ; CHECK-NEXT:    call void @test9_aux(ptr nonnull inalloca(<{ [[STRUCT_TYPE]] }>) [[ARGMEM]])
 ; CHECK-NEXT:    ret void
 ;
 ; P32-LABEL: @test9(
 ; P32-NEXT:  entry:
 ; P32-NEXT:    [[ARGMEM:%.*]] = alloca inalloca <{ [[STRUCT_TYPE:%.*]] }>, align 1
-; P32-NEXT:    [[TMP0:%.*]] = load i64, ptr [[A:%.*]], align 4
-; P32-NEXT:    store i64 [[TMP0]], ptr [[ARGMEM]], align 4
+; P32-NEXT:    [[TMP0:%.*]] = load b64, ptr [[A:%.*]], align 4
+; P32-NEXT:    store b64 [[TMP0]], ptr [[ARGMEM]], align 4
 ; P32-NEXT:    call void @test9_aux(ptr nonnull inalloca(<{ [[STRUCT_TYPE]] }>) [[ARGMEM]])
 ; P32-NEXT:    ret void
 ;
 ; NODL-LABEL: @test9(
 ; NODL-NEXT:  entry:
 ; NODL-NEXT:    [[ARGMEM:%.*]] = alloca inalloca <{ [[STRUCT_TYPE:%.*]] }>, align 8
-; NODL-NEXT:    [[TMP0:%.*]] = load i64, ptr [[A:%.*]], align 4
-; NODL-NEXT:    store i64 [[TMP0]], ptr [[ARGMEM]], align 8
+; NODL-NEXT:    [[TMP0:%.*]] = load b64, ptr [[A:%.*]], align 4
+; NODL-NEXT:    store b64 [[TMP0]], ptr [[ARGMEM]], align 8
 ; NODL-NEXT:    call void @test9_aux(ptr nonnull inalloca(<{ [[STRUCT_TYPE]] }>) [[ARGMEM]])
 ; NODL-NEXT:    ret void
 ;
@@ -251,8 +251,8 @@ entry:
 
 define void @test_inalloca_with_element_count(ptr %a) {
 ; ALL-LABEL: @test_inalloca_with_element_count(
-; ALL-NEXT:    [[ALLOCA1:%.*]] = alloca inalloca [10 x %struct_type], align 4
-; ALL-NEXT:    call void @test9_aux(ptr nonnull inalloca([[STRUCT_TYPE:%.*]]) [[ALLOCA1]])
+; ALL-NEXT:    [[ALLOCA1:%.*]] = alloca inalloca [10 x [[STRUCT_TYPE:%.*]]], align 4
+; ALL-NEXT:    call void @test9_aux(ptr nonnull inalloca([[STRUCT_TYPE]]) [[ALLOCA1]])
 ; ALL-NEXT:    ret void
 ;
   %alloca = alloca inalloca %struct_type, i32 10, align 4

--- a/llvm/test/Transforms/InstCombine/annotations.ll
+++ b/llvm/test/Transforms/InstCombine/annotations.ll
@@ -45,8 +45,8 @@ declare void @llvm.memcpy.p0.p0.i32(ptr nocapture, ptr nocapture, i32, i1) nounw
 
 define void @copy_1_byte(ptr %d, ptr %s) {
 ; CHECK-LABEL: define {{.+}} @copy_1_byte({{.+}}
-; CHECK-NEXT:    [[TMP1:%.*]] = load i8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
-; CHECK-NEXT:    store i8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    [[TMP1:%.*]] = load b8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    store b8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
 ; CHECK-NEXT:    ret void
 ;
   call void @llvm.memcpy.p0.p0.i32(ptr %d, ptr %s, i32 1, i1 false), !annotation !0
@@ -57,8 +57,8 @@ declare ptr @memcpy(ptr noalias returned, ptr noalias nocapture readonly, i64) n
 
 define void @libcallcopy_1_byte(ptr %d, ptr %s) {
 ; CHECK-LABEL: define {{.+}} @libcallcopy_1_byte({{.+}}
-; CHECK-NEXT:    [[TMP1:%.*]] = load i8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
-; CHECK-NEXT:    store i8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    [[TMP1:%.*]] = load b8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    store b8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
 ; CHECK-NEXT:    ret void
 ;
   call ptr @memcpy(ptr %d, ptr %s, i64 1), !annotation !0
@@ -69,8 +69,8 @@ declare ptr @__memcpy_chk(ptr, ptr, i64, i64) nofree nounwind
 
 define void @libcallcopy_1_byte_chk(ptr %d, ptr %s) {
 ; CHECK-LABEL: define {{.+}} @libcallcopy_1_byte_chk({{.+}}
-; CHECK-NEXT:    [[TMP1:%.*]] = load i8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
-; CHECK-NEXT:    store i8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    [[TMP1:%.*]] = load b8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    store b8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
 ; CHECK-NEXT:    ret void
 ;
   call ptr @__memcpy_chk(ptr %d, ptr %s, i64 1, i64 1), !annotation !0
@@ -81,8 +81,8 @@ declare void @llvm.memmove.p0.p0.i32(ptr nocapture, ptr nocapture readonly, i32,
 
 define void @move_1_byte(ptr %d, ptr %s) {
 ; CHECK-LABEL: define {{.+}} @move_1_byte({{.+}}
-; CHECK-NEXT:    [[TMP1:%.*]] = load i8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
-; CHECK-NEXT:    store i8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    [[TMP1:%.*]] = load b8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    store b8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
 ; CHECK-NEXT:    ret void
 ;
   call void @llvm.memmove.p0.p0.i32(ptr %d, ptr %s, i32 1, i1 false), !annotation !0
@@ -93,8 +93,8 @@ declare ptr @memmove(ptr returned, ptr nocapture readonly, i64) nofree nounwind
 
 define void @libcallmove_1_byte(ptr %d, ptr %s) {
 ; CHECK-LABEL: define {{.+}} @libcallmove_1_byte({{.+}}
-; CHECK-NEXT:    [[TMP1:%.*]] = load i8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
-; CHECK-NEXT:    store i8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    [[TMP1:%.*]] = load b8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    store b8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
 ; CHECK-NEXT:    ret void
 ;
   call ptr @memmove(ptr %d, ptr %s, i64 1), !annotation !0
@@ -105,8 +105,8 @@ declare ptr @__memmove_chk(ptr, ptr, i64, i64) nofree nounwind
 
 define void @libcallmove_1_byte_chk(ptr %d, ptr %s) {
 ; CHECK-LABEL: define {{.+}} @libcallmove_1_byte_chk({{.+}}
-; CHECK-NEXT:    [[TMP1:%.*]] = load i8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
-; CHECK-NEXT:    store i8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    [[TMP1:%.*]] = load b8, ptr [[S:%.*]], align 1, !annotation [[ANN]]
+; CHECK-NEXT:    store b8 [[TMP1]], ptr [[D:%.*]], align 1, !annotation [[ANN]]
 ; CHECK-NEXT:    ret void
 ;
   call ptr @__memmove_chk(ptr %d, ptr %s, i64 1, i64 1), !annotation !0

--- a/llvm/test/Transforms/InstCombine/bcopy.ll
+++ b/llvm/test/Transforms/InstCombine/bcopy.ll
@@ -5,8 +5,8 @@ declare void @bcopy(ptr nocapture readonly, ptr nocapture, i32)
 
 define void @bcopy_memmove(ptr nocapture readonly %a, ptr nocapture %b) {
 ; CHECK-LABEL: @bcopy_memmove(
-; CHECK-NEXT:    [[TMP1:%.*]] = load i64, ptr [[A:%.*]], align 1
-; CHECK-NEXT:    store i64 [[TMP1]], ptr [[B:%.*]], align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load b64, ptr [[A:%.*]], align 1
+; CHECK-NEXT:    store b64 [[TMP1]], ptr [[B:%.*]], align 1
 ; CHECK-NEXT:    ret void
 ;
   tail call void @bcopy(ptr %a, ptr %b, i32 8)

--- a/llvm/test/Transforms/InstCombine/element-atomic-memintrins.ll
+++ b/llvm/test/Transforms/InstCombine/element-atomic-memintrins.ll
@@ -143,8 +143,8 @@ define void @test_memmove_removed(ptr %srcdest, i32 %sz) {
 ; memmove with a small constant length is converted to a load/store pair
 define void @test_memmove_loadstore(ptr %dest, ptr %src) {
 ; CHECK-LABEL: @test_memmove_loadstore(
-; CHECK-NEXT:    [[TMP1:%.*]] = load atomic i8, ptr [[SRC:%.*]] unordered, align 1
-; CHECK-NEXT:    store atomic i8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load atomic b8, ptr [[SRC:%.*]] unordered, align 1
+; CHECK-NEXT:    store atomic b8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 1
 ; CHECK-NEXT:    call void @llvm.memmove.element.unordered.atomic.p0.p0.i32(ptr nonnull align 1 [[DEST]], ptr nonnull align 1 [[SRC]], i32 2, i32 1)
 ; CHECK-NEXT:    call void @llvm.memmove.element.unordered.atomic.p0.p0.i32(ptr nonnull align 1 [[DEST]], ptr nonnull align 1 [[SRC]], i32 4, i32 1)
 ; CHECK-NEXT:    call void @llvm.memmove.element.unordered.atomic.p0.p0.i32(ptr nonnull align 1 [[DEST]], ptr nonnull align 1 [[SRC]], i32 8, i32 1)
@@ -161,10 +161,10 @@ define void @test_memmove_loadstore(ptr %dest, ptr %src) {
 
 define void @test_memmove_loadstore_2(ptr %dest, ptr %src) {
 ; CHECK-LABEL: @test_memmove_loadstore_2(
-; CHECK-NEXT:    [[TMP1:%.*]] = load atomic i8, ptr [[SRC:%.*]] unordered, align 2
-; CHECK-NEXT:    store atomic i8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 2
-; CHECK-NEXT:    [[TMP2:%.*]] = load atomic i16, ptr [[SRC]] unordered, align 2
-; CHECK-NEXT:    store atomic i16 [[TMP2]], ptr [[DEST]] unordered, align 2
+; CHECK-NEXT:    [[TMP1:%.*]] = load atomic b8, ptr [[SRC:%.*]] unordered, align 2
+; CHECK-NEXT:    store atomic b8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 2
+; CHECK-NEXT:    [[TMP2:%.*]] = load atomic b16, ptr [[SRC]] unordered, align 2
+; CHECK-NEXT:    store atomic b16 [[TMP2]], ptr [[DEST]] unordered, align 2
 ; CHECK-NEXT:    call void @llvm.memmove.element.unordered.atomic.p0.p0.i32(ptr nonnull align 2 [[DEST]], ptr nonnull align 2 [[SRC]], i32 4, i32 2)
 ; CHECK-NEXT:    call void @llvm.memmove.element.unordered.atomic.p0.p0.i32(ptr nonnull align 2 [[DEST]], ptr nonnull align 2 [[SRC]], i32 8, i32 2)
 ; CHECK-NEXT:    call void @llvm.memmove.element.unordered.atomic.p0.p0.i32(ptr nonnull align 2 [[DEST]], ptr nonnull align 2 [[SRC]], i32 16, i32 2)
@@ -180,12 +180,12 @@ define void @test_memmove_loadstore_2(ptr %dest, ptr %src) {
 
 define void @test_memmove_loadstore_4(ptr %dest, ptr %src) {
 ; CHECK-LABEL: @test_memmove_loadstore_4(
-; CHECK-NEXT:    [[TMP1:%.*]] = load atomic i8, ptr [[SRC:%.*]] unordered, align 4
-; CHECK-NEXT:    store atomic i8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 4
-; CHECK-NEXT:    [[TMP2:%.*]] = load atomic i16, ptr [[SRC]] unordered, align 4
-; CHECK-NEXT:    store atomic i16 [[TMP2]], ptr [[DEST]] unordered, align 4
-; CHECK-NEXT:    [[TMP3:%.*]] = load atomic i32, ptr [[SRC]] unordered, align 4
-; CHECK-NEXT:    store atomic i32 [[TMP3]], ptr [[DEST]] unordered, align 4
+; CHECK-NEXT:    [[TMP1:%.*]] = load atomic b8, ptr [[SRC:%.*]] unordered, align 4
+; CHECK-NEXT:    store atomic b8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 4
+; CHECK-NEXT:    [[TMP2:%.*]] = load atomic b16, ptr [[SRC]] unordered, align 4
+; CHECK-NEXT:    store atomic b16 [[TMP2]], ptr [[DEST]] unordered, align 4
+; CHECK-NEXT:    [[TMP3:%.*]] = load atomic b32, ptr [[SRC]] unordered, align 4
+; CHECK-NEXT:    store atomic b32 [[TMP3]], ptr [[DEST]] unordered, align 4
 ; CHECK-NEXT:    call void @llvm.memmove.element.unordered.atomic.p0.p0.i32(ptr nonnull align 4 [[DEST]], ptr nonnull align 4 [[SRC]], i32 8, i32 4)
 ; CHECK-NEXT:    call void @llvm.memmove.element.unordered.atomic.p0.p0.i32(ptr nonnull align 4 [[DEST]], ptr nonnull align 4 [[SRC]], i32 16, i32 4)
 ; CHECK-NEXT:    ret void
@@ -200,14 +200,14 @@ define void @test_memmove_loadstore_4(ptr %dest, ptr %src) {
 
 define void @test_memmove_loadstore_8(ptr %dest, ptr %src) {
 ; CHECK-LABEL: @test_memmove_loadstore_8(
-; CHECK-NEXT:    [[TMP1:%.*]] = load atomic i8, ptr [[SRC:%.*]] unordered, align 8
-; CHECK-NEXT:    store atomic i8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 8
-; CHECK-NEXT:    [[TMP2:%.*]] = load atomic i16, ptr [[SRC]] unordered, align 8
-; CHECK-NEXT:    store atomic i16 [[TMP2]], ptr [[DEST]] unordered, align 8
-; CHECK-NEXT:    [[TMP3:%.*]] = load atomic i32, ptr [[SRC]] unordered, align 8
-; CHECK-NEXT:    store atomic i32 [[TMP3]], ptr [[DEST]] unordered, align 8
-; CHECK-NEXT:    [[TMP4:%.*]] = load atomic i64, ptr [[SRC]] unordered, align 8
-; CHECK-NEXT:    store atomic i64 [[TMP4]], ptr [[DEST]] unordered, align 8
+; CHECK-NEXT:    [[TMP1:%.*]] = load atomic b8, ptr [[SRC:%.*]] unordered, align 8
+; CHECK-NEXT:    store atomic b8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 8
+; CHECK-NEXT:    [[TMP2:%.*]] = load atomic b16, ptr [[SRC]] unordered, align 8
+; CHECK-NEXT:    store atomic b16 [[TMP2]], ptr [[DEST]] unordered, align 8
+; CHECK-NEXT:    [[TMP3:%.*]] = load atomic b32, ptr [[SRC]] unordered, align 8
+; CHECK-NEXT:    store atomic b32 [[TMP3]], ptr [[DEST]] unordered, align 8
+; CHECK-NEXT:    [[TMP4:%.*]] = load atomic b64, ptr [[SRC]] unordered, align 8
+; CHECK-NEXT:    store atomic b64 [[TMP4]], ptr [[DEST]] unordered, align 8
 ; CHECK-NEXT:    call void @llvm.memmove.element.unordered.atomic.p0.p0.i32(ptr nonnull align 8 [[DEST]], ptr nonnull align 8 [[SRC]], i32 16, i32 8)
 ; CHECK-NEXT:    ret void
 ;
@@ -221,14 +221,14 @@ define void @test_memmove_loadstore_8(ptr %dest, ptr %src) {
 
 define void @test_memmove_loadstore_16(ptr %dest, ptr %src) {
 ; CHECK-LABEL: @test_memmove_loadstore_16(
-; CHECK-NEXT:    [[TMP1:%.*]] = load atomic i8, ptr [[SRC:%.*]] unordered, align 16
-; CHECK-NEXT:    store atomic i8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 16
-; CHECK-NEXT:    [[TMP2:%.*]] = load atomic i16, ptr [[SRC]] unordered, align 16
-; CHECK-NEXT:    store atomic i16 [[TMP2]], ptr [[DEST]] unordered, align 16
-; CHECK-NEXT:    [[TMP3:%.*]] = load atomic i32, ptr [[SRC]] unordered, align 16
-; CHECK-NEXT:    store atomic i32 [[TMP3]], ptr [[DEST]] unordered, align 16
-; CHECK-NEXT:    [[TMP4:%.*]] = load atomic i64, ptr [[SRC]] unordered, align 16
-; CHECK-NEXT:    store atomic i64 [[TMP4]], ptr [[DEST]] unordered, align 16
+; CHECK-NEXT:    [[TMP1:%.*]] = load atomic b8, ptr [[SRC:%.*]] unordered, align 16
+; CHECK-NEXT:    store atomic b8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 16
+; CHECK-NEXT:    [[TMP2:%.*]] = load atomic b16, ptr [[SRC]] unordered, align 16
+; CHECK-NEXT:    store atomic b16 [[TMP2]], ptr [[DEST]] unordered, align 16
+; CHECK-NEXT:    [[TMP3:%.*]] = load atomic b32, ptr [[SRC]] unordered, align 16
+; CHECK-NEXT:    store atomic b32 [[TMP3]], ptr [[DEST]] unordered, align 16
+; CHECK-NEXT:    [[TMP4:%.*]] = load atomic b64, ptr [[SRC]] unordered, align 16
+; CHECK-NEXT:    store atomic b64 [[TMP4]], ptr [[DEST]] unordered, align 16
 ; CHECK-NEXT:    call void @llvm.memmove.element.unordered.atomic.p0.p0.i32(ptr nonnull align 16 [[DEST]], ptr nonnull align 16 [[SRC]], i32 16, i32 16)
 ; CHECK-NEXT:    ret void
 ;
@@ -273,8 +273,8 @@ define void @test_memcpy_removed(ptr %srcdest, i32 %sz) {
 ; memcpy with a small constant length is converted to a load/store pair
 define void @test_memcpy_loadstore(ptr %dest, ptr %src) {
 ; CHECK-LABEL: @test_memcpy_loadstore(
-; CHECK-NEXT:    [[TMP1:%.*]] = load atomic i8, ptr [[SRC:%.*]] unordered, align 1
-; CHECK-NEXT:    store atomic i8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load atomic b8, ptr [[SRC:%.*]] unordered, align 1
+; CHECK-NEXT:    store atomic b8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 1
 ; CHECK-NEXT:    call void @llvm.memcpy.element.unordered.atomic.p0.p0.i32(ptr nonnull align 1 [[DEST]], ptr nonnull align 1 [[SRC]], i32 2, i32 1)
 ; CHECK-NEXT:    call void @llvm.memcpy.element.unordered.atomic.p0.p0.i32(ptr nonnull align 1 [[DEST]], ptr nonnull align 1 [[SRC]], i32 4, i32 1)
 ; CHECK-NEXT:    call void @llvm.memcpy.element.unordered.atomic.p0.p0.i32(ptr nonnull align 1 [[DEST]], ptr nonnull align 1 [[SRC]], i32 8, i32 1)
@@ -291,10 +291,10 @@ define void @test_memcpy_loadstore(ptr %dest, ptr %src) {
 
 define void @test_memcpy_loadstore_2(ptr %dest, ptr %src) {
 ; CHECK-LABEL: @test_memcpy_loadstore_2(
-; CHECK-NEXT:    [[TMP1:%.*]] = load atomic i8, ptr [[SRC:%.*]] unordered, align 2
-; CHECK-NEXT:    store atomic i8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 2
-; CHECK-NEXT:    [[TMP2:%.*]] = load atomic i16, ptr [[SRC]] unordered, align 2
-; CHECK-NEXT:    store atomic i16 [[TMP2]], ptr [[DEST]] unordered, align 2
+; CHECK-NEXT:    [[TMP1:%.*]] = load atomic b8, ptr [[SRC:%.*]] unordered, align 2
+; CHECK-NEXT:    store atomic b8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 2
+; CHECK-NEXT:    [[TMP2:%.*]] = load atomic b16, ptr [[SRC]] unordered, align 2
+; CHECK-NEXT:    store atomic b16 [[TMP2]], ptr [[DEST]] unordered, align 2
 ; CHECK-NEXT:    call void @llvm.memcpy.element.unordered.atomic.p0.p0.i32(ptr nonnull align 2 [[DEST]], ptr nonnull align 2 [[SRC]], i32 4, i32 2)
 ; CHECK-NEXT:    call void @llvm.memcpy.element.unordered.atomic.p0.p0.i32(ptr nonnull align 2 [[DEST]], ptr nonnull align 2 [[SRC]], i32 8, i32 2)
 ; CHECK-NEXT:    call void @llvm.memcpy.element.unordered.atomic.p0.p0.i32(ptr nonnull align 2 [[DEST]], ptr nonnull align 2 [[SRC]], i32 16, i32 2)
@@ -310,12 +310,12 @@ define void @test_memcpy_loadstore_2(ptr %dest, ptr %src) {
 
 define void @test_memcpy_loadstore_4(ptr %dest, ptr %src) {
 ; CHECK-LABEL: @test_memcpy_loadstore_4(
-; CHECK-NEXT:    [[TMP1:%.*]] = load atomic i8, ptr [[SRC:%.*]] unordered, align 4
-; CHECK-NEXT:    store atomic i8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 4
-; CHECK-NEXT:    [[TMP2:%.*]] = load atomic i16, ptr [[SRC]] unordered, align 4
-; CHECK-NEXT:    store atomic i16 [[TMP2]], ptr [[DEST]] unordered, align 4
-; CHECK-NEXT:    [[TMP3:%.*]] = load atomic i32, ptr [[SRC]] unordered, align 4
-; CHECK-NEXT:    store atomic i32 [[TMP3]], ptr [[DEST]] unordered, align 4
+; CHECK-NEXT:    [[TMP1:%.*]] = load atomic b8, ptr [[SRC:%.*]] unordered, align 4
+; CHECK-NEXT:    store atomic b8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 4
+; CHECK-NEXT:    [[TMP2:%.*]] = load atomic b16, ptr [[SRC]] unordered, align 4
+; CHECK-NEXT:    store atomic b16 [[TMP2]], ptr [[DEST]] unordered, align 4
+; CHECK-NEXT:    [[TMP3:%.*]] = load atomic b32, ptr [[SRC]] unordered, align 4
+; CHECK-NEXT:    store atomic b32 [[TMP3]], ptr [[DEST]] unordered, align 4
 ; CHECK-NEXT:    call void @llvm.memcpy.element.unordered.atomic.p0.p0.i32(ptr nonnull align 4 [[DEST]], ptr nonnull align 4 [[SRC]], i32 8, i32 4)
 ; CHECK-NEXT:    call void @llvm.memcpy.element.unordered.atomic.p0.p0.i32(ptr nonnull align 4 [[DEST]], ptr nonnull align 4 [[SRC]], i32 16, i32 4)
 ; CHECK-NEXT:    ret void
@@ -330,14 +330,14 @@ define void @test_memcpy_loadstore_4(ptr %dest, ptr %src) {
 
 define void @test_memcpy_loadstore_8(ptr %dest, ptr %src) {
 ; CHECK-LABEL: @test_memcpy_loadstore_8(
-; CHECK-NEXT:    [[TMP1:%.*]] = load atomic i8, ptr [[SRC:%.*]] unordered, align 8
-; CHECK-NEXT:    store atomic i8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 8
-; CHECK-NEXT:    [[TMP2:%.*]] = load atomic i16, ptr [[SRC]] unordered, align 8
-; CHECK-NEXT:    store atomic i16 [[TMP2]], ptr [[DEST]] unordered, align 8
-; CHECK-NEXT:    [[TMP3:%.*]] = load atomic i32, ptr [[SRC]] unordered, align 8
-; CHECK-NEXT:    store atomic i32 [[TMP3]], ptr [[DEST]] unordered, align 8
-; CHECK-NEXT:    [[TMP4:%.*]] = load atomic i64, ptr [[SRC]] unordered, align 8
-; CHECK-NEXT:    store atomic i64 [[TMP4]], ptr [[DEST]] unordered, align 8
+; CHECK-NEXT:    [[TMP1:%.*]] = load atomic b8, ptr [[SRC:%.*]] unordered, align 8
+; CHECK-NEXT:    store atomic b8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 8
+; CHECK-NEXT:    [[TMP2:%.*]] = load atomic b16, ptr [[SRC]] unordered, align 8
+; CHECK-NEXT:    store atomic b16 [[TMP2]], ptr [[DEST]] unordered, align 8
+; CHECK-NEXT:    [[TMP3:%.*]] = load atomic b32, ptr [[SRC]] unordered, align 8
+; CHECK-NEXT:    store atomic b32 [[TMP3]], ptr [[DEST]] unordered, align 8
+; CHECK-NEXT:    [[TMP4:%.*]] = load atomic b64, ptr [[SRC]] unordered, align 8
+; CHECK-NEXT:    store atomic b64 [[TMP4]], ptr [[DEST]] unordered, align 8
 ; CHECK-NEXT:    call void @llvm.memcpy.element.unordered.atomic.p0.p0.i32(ptr nonnull align 8 [[DEST]], ptr nonnull align 8 [[SRC]], i32 16, i32 8)
 ; CHECK-NEXT:    ret void
 ;
@@ -351,14 +351,14 @@ define void @test_memcpy_loadstore_8(ptr %dest, ptr %src) {
 
 define void @test_memcpy_loadstore_16(ptr %dest, ptr %src) {
 ; CHECK-LABEL: @test_memcpy_loadstore_16(
-; CHECK-NEXT:    [[TMP1:%.*]] = load atomic i8, ptr [[SRC:%.*]] unordered, align 16
-; CHECK-NEXT:    store atomic i8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 16
-; CHECK-NEXT:    [[TMP2:%.*]] = load atomic i16, ptr [[SRC]] unordered, align 16
-; CHECK-NEXT:    store atomic i16 [[TMP2]], ptr [[DEST]] unordered, align 16
-; CHECK-NEXT:    [[TMP3:%.*]] = load atomic i32, ptr [[SRC]] unordered, align 16
-; CHECK-NEXT:    store atomic i32 [[TMP3]], ptr [[DEST]] unordered, align 16
-; CHECK-NEXT:    [[TMP4:%.*]] = load atomic i64, ptr [[SRC]] unordered, align 16
-; CHECK-NEXT:    store atomic i64 [[TMP4]], ptr [[DEST]] unordered, align 16
+; CHECK-NEXT:    [[TMP1:%.*]] = load atomic b8, ptr [[SRC:%.*]] unordered, align 16
+; CHECK-NEXT:    store atomic b8 [[TMP1]], ptr [[DEST:%.*]] unordered, align 16
+; CHECK-NEXT:    [[TMP2:%.*]] = load atomic b16, ptr [[SRC]] unordered, align 16
+; CHECK-NEXT:    store atomic b16 [[TMP2]], ptr [[DEST]] unordered, align 16
+; CHECK-NEXT:    [[TMP3:%.*]] = load atomic b32, ptr [[SRC]] unordered, align 16
+; CHECK-NEXT:    store atomic b32 [[TMP3]], ptr [[DEST]] unordered, align 16
+; CHECK-NEXT:    [[TMP4:%.*]] = load atomic b64, ptr [[SRC]] unordered, align 16
+; CHECK-NEXT:    store atomic b64 [[TMP4]], ptr [[DEST]] unordered, align 16
 ; CHECK-NEXT:    call void @llvm.memcpy.element.unordered.atomic.p0.p0.i32(ptr nonnull align 16 [[DEST]], ptr nonnull align 16 [[SRC]], i32 16, i32 16)
 ; CHECK-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/InstCombine/mem-par-metadata-memcpy.ll
+++ b/llvm/test/Transforms/InstCombine/mem-par-metadata-memcpy.ll
@@ -25,8 +25,8 @@ define void @_Z4testPcl(ptr %out, i64 %size) {
 ; CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds nuw i8, ptr [[OUT:%.*]], i64 [[I_0]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[OUT]], i64 [[I_0]]
 ; CHECK-NEXT:    [[ARRAYIDX1:%.*]] = getelementptr i8, ptr [[TMP0]], i64 [[SIZE]]
-; CHECK-NEXT:    [[TMP1:%.*]] = load i16, ptr [[ARRAYIDX1]], align 1, !llvm.access.group [[ACC_GRP0:![0-9]+]]
-; CHECK-NEXT:    store i16 [[TMP1]], ptr [[ARRAYIDX]], align 1, !llvm.access.group [[ACC_GRP0]]
+; CHECK-NEXT:    [[TMP1:%.*]] = load b16, ptr [[ARRAYIDX1]], align 1, !llvm.access.group [[ACC_GRP0:![0-9]+]]
+; CHECK-NEXT:    store b16 [[TMP1]], ptr [[ARRAYIDX]], align 1, !llvm.access.group [[ACC_GRP0]]
 ; CHECK-NEXT:    br label [[FOR_INC]]
 ; CHECK:       for.inc:
 ; CHECK-NEXT:    [[ADD2]] = add nuw nsw i64 [[I_0]], 2

--- a/llvm/test/Transforms/InstCombine/memcpy-to-load.ll
+++ b/llvm/test/Transforms/InstCombine/memcpy-to-load.ll
@@ -10,8 +10,8 @@ declare void @llvm.memcpy.p0.p0.i32(ptr nocapture, ptr nocapture, i32, i1) nounw
 
 define void @copy_1_byte(ptr %d, ptr %s) {
 ; CHECK-LABEL: @copy_1_byte(
-; CHECK-NEXT:    [[TMP1:%.*]] = load i8, ptr [[S:%.*]], align 1
-; CHECK-NEXT:    store i8 [[TMP1]], ptr [[D:%.*]], align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load b8, ptr [[S:%.*]], align 1
+; CHECK-NEXT:    store b8 [[TMP1]], ptr [[D:%.*]], align 1
 ; CHECK-NEXT:    ret void
 ;
   call void @llvm.memcpy.p0.p0.i32(ptr %d, ptr %s, i32 1, i1 false)
@@ -20,8 +20,8 @@ define void @copy_1_byte(ptr %d, ptr %s) {
 
 define void @copy_2_bytes(ptr %d, ptr %s) {
 ; CHECK-LABEL: @copy_2_bytes(
-; CHECK-NEXT:    [[TMP1:%.*]] = load i16, ptr [[S:%.*]], align 1
-; CHECK-NEXT:    store i16 [[TMP1]], ptr [[D:%.*]], align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load b16, ptr [[S:%.*]], align 1
+; CHECK-NEXT:    store b16 [[TMP1]], ptr [[D:%.*]], align 1
 ; CHECK-NEXT:    ret void
 ;
   call void @llvm.memcpy.p0.p0.i32(ptr %d, ptr %s, i32 2, i1 false)
@@ -41,8 +41,8 @@ define void @copy_3_bytes(ptr %d, ptr %s) {
 
 define void @copy_4_bytes(ptr %d, ptr %s) {
 ; CHECK-LABEL: @copy_4_bytes(
-; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[S:%.*]], align 1
-; CHECK-NEXT:    store i32 [[TMP1]], ptr [[D:%.*]], align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load b32, ptr [[S:%.*]], align 1
+; CHECK-NEXT:    store b32 [[TMP1]], ptr [[D:%.*]], align 1
 ; CHECK-NEXT:    ret void
 ;
   call void @llvm.memcpy.p0.p0.i32(ptr %d, ptr %s, i32 4, i1 false)
@@ -62,8 +62,8 @@ define void @copy_5_bytes(ptr %d, ptr %s) {
 
 define void @copy_8_bytes(ptr %d, ptr %s) {
 ; CHECK-LABEL: @copy_8_bytes(
-; CHECK-NEXT:    [[TMP1:%.*]] = load i64, ptr [[S:%.*]], align 1
-; CHECK-NEXT:    store i64 [[TMP1]], ptr [[D:%.*]], align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load b64, ptr [[S:%.*]], align 1
+; CHECK-NEXT:    store b64 [[TMP1]], ptr [[D:%.*]], align 1
 ; CHECK-NEXT:    ret void
 ;
   call void @llvm.memcpy.p0.p0.i32(ptr %d, ptr %s, i32 8, i1 false)
@@ -81,8 +81,8 @@ define void @copy_16_bytes(ptr %d, ptr %s) {
 
 define void @copy_8_bytes_noalias(ptr %d, ptr %s) {
 ; CHECK-LABEL: @copy_8_bytes_noalias(
-; CHECK-NEXT:    [[TMP1:%.*]] = load i64, ptr [[S:%.*]], align 1, !alias.scope [[META0:![0-9]+]], !noalias [[META3:![0-9]+]]
-; CHECK-NEXT:    store i64 [[TMP1]], ptr [[D:%.*]], align 1, !alias.scope [[META0]], !noalias [[META3]]
+; CHECK-NEXT:    [[TMP1:%.*]] = load b64, ptr [[S:%.*]], align 1, !alias.scope [[META0:![0-9]+]], !noalias [[META3:![0-9]+]]
+; CHECK-NEXT:    store b64 [[TMP1]], ptr [[D:%.*]], align 1, !alias.scope [[META0]], !noalias [[META3]]
 ; CHECK-NEXT:    ret void
 ;
   call void @llvm.memcpy.p0.p0.i32(ptr %d, ptr %s, i32 8, i1 false), !alias.scope !4, !noalias !5

--- a/llvm/test/Transforms/InstCombine/mempcpy.ll
+++ b/llvm/test/Transforms/InstCombine/mempcpy.ll
@@ -32,8 +32,8 @@ define void @memcpy_nonconst_n_unused_retval(ptr %d, ptr nocapture readonly %s, 
 
 define ptr @memcpy_small_const_n(ptr %d, ptr nocapture readonly %s) {
 ; CHECK-LABEL: @memcpy_small_const_n(
-; CHECK-NEXT:    [[TMP1:%.*]] = load i64, ptr [[S:%.*]], align 1
-; CHECK-NEXT:    store i64 [[TMP1]], ptr [[D:%.*]], align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load b64, ptr [[S:%.*]], align 1
+; CHECK-NEXT:    store b64 [[TMP1]], ptr [[D:%.*]], align 1
 ; CHECK-NEXT:    [[R:%.*]] = getelementptr inbounds nuw i8, ptr [[D]], i64 8
 ; CHECK-NEXT:    ret ptr [[R]]
 ;

--- a/llvm/test/Transforms/InstCombine/struct-assign-tbaa-2.ll
+++ b/llvm/test/Transforms/InstCombine/struct-assign-tbaa-2.ll
@@ -12,11 +12,11 @@ define void @test1(ptr %a1, ptr %a2) {
 ; CHECK-LABEL: @test1(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[B:%.*]] = getelementptr inbounds nuw i8, ptr [[A2:%.*]], i64 2
-; CHECK-NEXT:    [[TMP0:%.*]] = load i16, ptr [[A2]], align 2, !tbaa [[TBAA0:![0-9]+]]
-; CHECK-NEXT:    store i16 [[TMP0]], ptr [[A1:%.*]], align 2, !tbaa [[TBAA0]]
+; CHECK-NEXT:    [[TMP0:%.*]] = load b16, ptr [[A2]], align 2, !tbaa [[TBAA0:![0-9]+]]
+; CHECK-NEXT:    store b16 [[TMP0]], ptr [[A1:%.*]], align 2, !tbaa [[TBAA0]]
 ; CHECK-NEXT:    [[B2:%.*]] = getelementptr inbounds nuw i8, ptr [[A1]], i64 2
-; CHECK-NEXT:    [[TMP1:%.*]] = load i16, ptr [[B]], align 2, !tbaa [[TBAA6:![0-9]+]]
-; CHECK-NEXT:    store i16 [[TMP1]], ptr [[B2]], align 2, !tbaa [[TBAA6]]
+; CHECK-NEXT:    [[TMP1:%.*]] = load b16, ptr [[B]], align 2, !tbaa [[TBAA6:![0-9]+]]
+; CHECK-NEXT:    store b16 [[TMP1]], ptr [[B2]], align 2, !tbaa [[TBAA6]]
 ; CHECK-NEXT:    ret void
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/struct-assign-tbaa-new.ll
+++ b/llvm/test/Transforms/InstCombine/struct-assign-tbaa-new.ll
@@ -13,8 +13,8 @@ declare void @llvm.memcpy.p0.p0.i64(ptr nocapture, ptr nocapture, i64, i1) nounw
 define void @test1(ptr %a1, ptr %a2) {
 ; CHECK-LABEL: @test1(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[A2:%.*]], align 4, !tbaa [[TBAA0:![0-9]+]]
-; CHECK-NEXT:    store i32 [[TMP0]], ptr [[A1:%.*]], align 4, !tbaa [[TBAA0]]
+; CHECK-NEXT:    [[TMP0:%.*]] = load b32, ptr [[A2:%.*]], align 4, !tbaa [[TBAA0:![0-9]+]]
+; CHECK-NEXT:    store b32 [[TMP0]], ptr [[A1:%.*]], align 4, !tbaa [[TBAA0]]
 ; CHECK-NEXT:    ret void
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/struct-assign-tbaa.ll
+++ b/llvm/test/Transforms/InstCombine/struct-assign-tbaa.ll
@@ -14,8 +14,8 @@ define void @test1(ptr nocapture %a, ptr nocapture %b) {
 ; CHECK-LABEL: define void @test1(
 ; CHECK-SAME: ptr captures(none) [[A:%.*]], ptr captures(none) [[B:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[B]], align 4, !tbaa [[FLOAT_TBAA0:![0-9]+]]
-; CHECK-NEXT:    store i32 [[TMP0]], ptr [[A]], align 4, !tbaa [[FLOAT_TBAA0]]
+; CHECK-NEXT:    [[TMP0:%.*]] = load b32, ptr [[B]], align 4, !tbaa [[FLOAT_TBAA0:![0-9]+]]
+; CHECK-NEXT:    store b32 [[TMP0]], ptr [[A]], align 4, !tbaa [[FLOAT_TBAA0]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -40,8 +40,8 @@ define void @test3_multiple_fields(ptr nocapture %a, ptr nocapture %b) {
 ; CHECK-LABEL: define void @test3_multiple_fields(
 ; CHECK-SAME: ptr captures(none) [[A:%.*]], ptr captures(none) [[B:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr [[B]], align 4
-; CHECK-NEXT:    store i64 [[TMP0]], ptr [[A]], align 4
+; CHECK-NEXT:    [[TMP0:%.*]] = load b64, ptr [[B]], align 4
+; CHECK-NEXT:    store b64 [[TMP0]], ptr [[A]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -53,8 +53,8 @@ define void @test4_multiple_copy_first_field(ptr nocapture %a, ptr nocapture %b)
 ; CHECK-LABEL: define void @test4_multiple_copy_first_field(
 ; CHECK-SAME: ptr captures(none) [[A:%.*]], ptr captures(none) [[B:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[B]], align 4, !tbaa [[FLOAT_TBAA0]]
-; CHECK-NEXT:    store i32 [[TMP0]], ptr [[A]], align 4, !tbaa [[FLOAT_TBAA0]]
+; CHECK-NEXT:    [[TMP0:%.*]] = load b32, ptr [[B]], align 4, !tbaa [[FLOAT_TBAA0]]
+; CHECK-NEXT:    store b32 [[TMP0]], ptr [[A]], align 4, !tbaa [[FLOAT_TBAA0]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -66,8 +66,8 @@ define void @test5_multiple_copy_more_than_first_field(ptr nocapture %a, ptr noc
 ; CHECK-LABEL: define void @test5_multiple_copy_more_than_first_field(
 ; CHECK-SAME: ptr captures(none) [[A:%.*]], ptr captures(none) [[B:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[B]], align 4
-; CHECK-NEXT:    store i32 [[TMP0]], ptr [[A]], align 4
+; CHECK-NEXT:    [[TMP0:%.*]] = load b32, ptr [[B]], align 4
+; CHECK-NEXT:    store b32 [[TMP0]], ptr [[A]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:

--- a/llvm/test/Transforms/PhaseOrdering/AArch64/memcpy-constant-size.ll
+++ b/llvm/test/Transforms/PhaseOrdering/AArch64/memcpy-constant-size.ll
@@ -54,8 +54,8 @@ define void @callee_memset(ptr %dst, i64 %size) {
 define void @caller_memcpy(ptr %dst, ptr %src) {
 ; CHECK-LABEL: define void @caller_memcpy
 ; CHECK-SAME: (ptr [[DST:%.*]], ptr nofree readonly captures(none) [[SRC:%.*]]) local_unnamed_addr #[[ATTR0]] {
-; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[SRC]], align 1
-; CHECK-NEXT:    store i32 [[TMP1]], ptr [[DST]], align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load b32, ptr [[SRC]], align 1
+; CHECK-NEXT:    store b32 [[TMP1]], ptr [[DST]], align 1
 ; CHECK-NEXT:    ret void
 ;
   call void @callee_memcpy(ptr %dst, ptr %src, i64 4)
@@ -65,8 +65,8 @@ define void @caller_memcpy(ptr %dst, ptr %src) {
 define void @caller_memmove(ptr %dst, ptr %src) {
 ; CHECK-LABEL: define void @caller_memmove
 ; CHECK-SAME: (ptr [[DST:%.*]], ptr [[SRC:%.*]]) local_unnamed_addr #[[ATTR1]] {
-; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[SRC]], align 1
-; CHECK-NEXT:    store i32 [[TMP1]], ptr [[DST]], align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load b32, ptr [[SRC]], align 1
+; CHECK-NEXT:    store b32 [[TMP1]], ptr [[DST]], align 1
 ; CHECK-NEXT:    ret void
 ;
   call void @callee_memmove(ptr %dst, ptr %src, i64 4)
@@ -76,8 +76,8 @@ define void @caller_memmove(ptr %dst, ptr %src) {
 define void @caller_mempcpy(ptr %dst, ptr %src) {
 ; CHECK-LABEL: define void @caller_mempcpy
 ; CHECK-SAME: (ptr [[DST:%.*]], ptr [[SRC:%.*]]) local_unnamed_addr #[[ATTR1]] {
-; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[SRC]], align 1
-; CHECK-NEXT:    store i32 [[TMP1]], ptr [[DST]], align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load b32, ptr [[SRC]], align 1
+; CHECK-NEXT:    store b32 [[TMP1]], ptr [[DST]], align 1
 ; CHECK-NEXT:    ret void
 ;
   call void @callee_mempcpy(ptr %dst, ptr %src, i64 4)

--- a/llvm/test/Transforms/PhaseOrdering/X86/SROA-after-final-loop-unrolling-2.ll
+++ b/llvm/test/Transforms/PhaseOrdering/X86/SROA-after-final-loop-unrolling-2.ll
@@ -29,27 +29,30 @@ define dso_local void @foo(i32 noundef %arg, ptr noundef nonnull align 4 derefer
 ; CHECK-NEXT:    [[TMP0:%.*]] = icmp ult i32 [[ARG_OFF]], 255
 ; CHECK-NEXT:    br i1 [[TMP0]], label %[[BB12:.*]], label %[[BB13:.*]]
 ; CHECK:       [[BB12_LOOPEXIT:.*]]:
-; CHECK-NEXT:    [[I3_SROA_8_0_INSERT_EXT:%.*]] = zext i32 [[I21_3:%.*]] to i64
-; CHECK-NEXT:    [[I3_SROA_8_0_INSERT_SHIFT:%.*]] = shl nuw i64 [[I3_SROA_8_0_INSERT_EXT]], 32
-; CHECK-NEXT:    [[I3_SROA_0_0_INSERT_EXT:%.*]] = zext i32 [[I21_2:%.*]] to i64
-; CHECK-NEXT:    [[I3_SROA_0_0_INSERT_INSERT:%.*]] = or disjoint i64 [[I3_SROA_8_0_INSERT_SHIFT]], [[I3_SROA_0_0_INSERT_EXT]]
+; CHECK-NEXT:    [[TMP2:%.*]] = bitcast i64 [[I3_SROA_0_4_INSERT_INSERT24:%.*]] to b64
 ; CHECK-NEXT:    br label %[[BB12]]
 ; CHECK:       [[BB12]]:
-; CHECK-NEXT:    [[TMP1:%.*]] = phi i64 [ [[I3_SROA_0_0_INSERT_INSERT]], %[[BB12_LOOPEXIT]] ], [ 180388626456, %[[BB]] ]
-; CHECK-NEXT:    store i64 [[TMP1]], ptr [[ARG1]], align 4, !tbaa [[CHAR_TBAA5:![0-9]+]]
+; CHECK-NEXT:    [[TMP1:%.*]] = phi b64 [ [[TMP2]], %[[BB12_LOOPEXIT]] ], [ 180388626456, %[[BB]] ]
+; CHECK-NEXT:    store b64 [[TMP1]], ptr [[ARG1]], align 4, !tbaa [[CHAR_TBAA5:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ; CHECK:       [[BB13]]:
-; CHECK-NEXT:    [[I3_SROA_8_0:%.*]] = phi i32 [ [[I21_3]], %[[BB13]] ], [ 42, %[[BB]] ]
-; CHECK-NEXT:    [[I3_SROA_0_0:%.*]] = phi i32 [ [[I21_2]], %[[BB13]] ], [ 24, %[[BB]] ]
-; CHECK-NEXT:    [[I4_05:%.*]] = phi i32 [ [[I24_3:%.*]], %[[BB13]] ], [ 0, %[[BB]] ]
+; CHECK-NEXT:    [[I3_SROA_0_1:%.*]] = phi i64 [ [[I3_SROA_0_4_INSERT_INSERT24]], %[[BB13]] ], [ 180388626456, %[[BB]] ]
+; CHECK-NEXT:    [[I3_SROA_0_0:%.*]] = phi i32 [ [[I24_3:%.*]], %[[BB13]] ], [ 0, %[[BB]] ]
+; CHECK-NEXT:    [[I4_05:%.*]] = trunc i64 [[I3_SROA_0_1]] to i32
 ; CHECK-NEXT:    [[I21:%.*]] = mul nsw i32 [[I3_SROA_0_0]], [[I4_05]]
-; CHECK-NEXT:    [[I24:%.*]] = or disjoint i32 [[I4_05]], 1
+; CHECK-NEXT:    [[I3_SROA_8_0:%.*]] = or disjoint i32 [[I3_SROA_0_0]], 1
+; CHECK-NEXT:    [[I3_SROA_0_4_EXTRACT_SHIFT:%.*]] = lshr i64 [[I3_SROA_0_1]], 32
+; CHECK-NEXT:    [[I24:%.*]] = trunc nuw i64 [[I3_SROA_0_4_EXTRACT_SHIFT]] to i32
 ; CHECK-NEXT:    [[I21_1:%.*]] = mul nsw i32 [[I3_SROA_8_0]], [[I24]]
-; CHECK-NEXT:    [[I24_1:%.*]] = or disjoint i32 [[I4_05]], 2
-; CHECK-NEXT:    [[I21_2]] = mul nsw i32 [[I21]], [[I24_1]]
-; CHECK-NEXT:    [[I24_2:%.*]] = or disjoint i32 [[I4_05]], 3
-; CHECK-NEXT:    [[I21_3]] = mul nsw i32 [[I21_1]], [[I24_2]]
-; CHECK-NEXT:    [[I24_3]] = add nuw nsw i32 [[I4_05]], 4
+; CHECK-NEXT:    [[I24_1:%.*]] = or disjoint i32 [[I3_SROA_0_0]], 2
+; CHECK-NEXT:    [[I21_2:%.*]] = mul nsw i32 [[I21]], [[I24_1]]
+; CHECK-NEXT:    [[I3_SROA_0_0_INSERT_EXT12:%.*]] = zext i32 [[I21_2]] to i64
+; CHECK-NEXT:    [[I24_2:%.*]] = or disjoint i32 [[I3_SROA_0_0]], 3
+; CHECK-NEXT:    [[I21_3:%.*]] = mul nsw i32 [[I21_1]], [[I24_2]]
+; CHECK-NEXT:    [[I3_SROA_0_4_INSERT_EXT21:%.*]] = zext i32 [[I21_3]] to i64
+; CHECK-NEXT:    [[I3_SROA_0_4_INSERT_SHIFT22:%.*]] = shl nuw i64 [[I3_SROA_0_4_INSERT_EXT21]], 32
+; CHECK-NEXT:    [[I3_SROA_0_4_INSERT_INSERT24]] = or disjoint i64 [[I3_SROA_0_4_INSERT_SHIFT22]], [[I3_SROA_0_0_INSERT_EXT12]]
+; CHECK-NEXT:    [[I24_3]] = add nuw nsw i32 [[I3_SROA_0_0]], 4
 ; CHECK-NEXT:    [[I11_NOT_3:%.*]] = icmp eq i32 [[I24_3]], [[I10]]
 ; CHECK-NEXT:    br i1 [[I11_NOT_3]], label %[[BB12_LOOPEXIT]], label %[[BB13]], !llvm.loop [[LOOP8:![0-9]+]]
 ;

--- a/llvm/test/Transforms/PhaseOrdering/swap-promotion.ll
+++ b/llvm/test/Transforms/PhaseOrdering/swap-promotion.ll
@@ -5,10 +5,10 @@
 
 define void @swap(ptr %p1, ptr %p2) {
 ; CHECK-LABEL: @swap(
-; CHECK-NEXT:    [[TMP1:%.*]] = load i64, ptr [[P1:%.*]], align 1
-; CHECK-NEXT:    [[TMP2:%.*]] = load i64, ptr [[P2:%.*]], align 1
-; CHECK-NEXT:    store i64 [[TMP2]], ptr [[P1]], align 1
-; CHECK-NEXT:    store i64 [[TMP1]], ptr [[P2]], align 1
+; CHECK-NEXT:    [[TMP1:%.*]] = load b64, ptr [[P1:%.*]], align 1
+; CHECK-NEXT:    [[TMP2:%.*]] = load b64, ptr [[P2:%.*]], align 1
+; CHECK-NEXT:    store b64 [[TMP2]], ptr [[P1]], align 1
+; CHECK-NEXT:    store b64 [[TMP1]], ptr [[P2]], align 1
 ; CHECK-NEXT:    ret void
 ;
   %tmp = alloca [2 x i32]
@@ -22,13 +22,18 @@ define i32 @test(i32 %n) {
 ; CHECK-LABEL: @test(
 ; CHECK-NEXT:    br label [[LOOP:%.*]]
 ; CHECK:       loop:
-; CHECK-NEXT:    [[P1_SROA_5_0:%.*]] = phi i32 [ 1, [[TMP0:%.*]] ], [ [[V2_NEXT:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[P1_SROA_0_0:%.*]] = phi i32 [ 0, [[TMP0]] ], [ [[V1_INC:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[V1_INC]] = add i32 [[P1_SROA_0_0]], 1
-; CHECK-NEXT:    [[V2_NEXT]] = shl i32 [[P1_SROA_5_0]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = phi i64 [ 4294967296, [[TMP0:%.*]] ], [ [[P1_SROA_0_4_INSERT_INSERT6:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[P1_SROA_0_0:%.*]] = trunc i64 [[TMP1]] to i32
+; CHECK-NEXT:    [[V1_INC:%.*]] = add i32 [[P1_SROA_0_0]], 1
+; CHECK-NEXT:    [[P1_SROA_0_0_INSERT_EXT:%.*]] = zext i32 [[V1_INC]] to i64
+; CHECK-NEXT:    [[TMP2:%.*]] = shl i64 [[TMP1]], 1
+; CHECK-NEXT:    [[P1_SROA_0_4_INSERT_SHIFT:%.*]] = and i64 [[TMP2]], -8589934592
+; CHECK-NEXT:    [[P1_SROA_0_4_INSERT_INSERT6]] = or disjoint i64 [[P1_SROA_0_4_INSERT_SHIFT]], [[P1_SROA_0_0_INSERT_EXT]]
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[V1_INC]], [[N:%.*]]
 ; CHECK-NEXT:    br i1 [[C]], label [[EXIT:%.*]], label [[LOOP]]
 ; CHECK:       exit:
+; CHECK-NEXT:    [[P2_SROA_0_4_EXTRACT_SHIFT:%.*]] = lshr exact i64 [[P1_SROA_0_4_INSERT_SHIFT]], 32
+; CHECK-NEXT:    [[V2_NEXT:%.*]] = trunc nuw i64 [[P2_SROA_0_4_EXTRACT_SHIFT]] to i32
 ; CHECK-NEXT:    ret i32 [[V2_NEXT]]
 ;
   %p1 = alloca [2 x i32]

--- a/llvm/test/Transforms/SROA/struct-to-vector.ll
+++ b/llvm/test/Transforms/SROA/struct-to-vector.ll
@@ -274,8 +274,8 @@ define dso_local void @foo_i1(ptr noundef %x, i64 %dummy0, i64 %dummy1,
 ; CHECK-NEXT:    store i32 0, ptr [[ZERO]], align 1
 ; CHECK-NEXT:    [[TOBOOL_I1_NOT:%.*]] = icmp eq i32 [[COND]], 0
 ; CHECK-NEXT:    [[ZERO_TEMP:%.*]] = select i1 [[TOBOOL_I1_NOT]], ptr [[ZERO]], ptr [[TEMP]]
-; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[ZERO_TEMP]], align 1
-; CHECK-NEXT:    store i32 [[TMP0]], ptr [[X]], align 1
+; CHECK-NEXT:    [[TMP0:%.*]] = load b32, ptr [[ZERO_TEMP]], align 1
+; CHECK-NEXT:    store b32 [[TMP0]], ptr [[X]], align 1
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[ZERO]])
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr nonnull [[TEMP]])
 ; CHECK-NEXT:    ret void


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/207477.

I will mark it as ready after llvm 23 is released and major issues are addressed.

Original commit: https://github.com/pedroclobo/llvm-project/commit/22909426074ad1ebec42716059dceebb45dadb0e

Co-authored-by: George Mitenkov <georgemitenk0v@gmail.com>
Co-authored-by: Pedro Lobo <pedro.lobo@tecnico.ulisboa.pt>

