### PR TITLE
[Support][NFC] Use single predecessor array in DomTreeConstr

### DIFF
--- a/llvm/include/llvm/Support/GenericDomTreeConstruction.h
+++ b/llvm/include/llvm/Support/GenericDomTreeConstruction.h
@@ -66,7 +66,7 @@ template <typename DomTreeT> struct SemiNCAInfo {
     unsigned Semi = 0;
     unsigned Label = 0;
     NodePtr IDom = nullptr;
-    SmallVector<unsigned, 4> ReverseChildren;
+    unsigned ReverseChildrenStart = 0; ///< Index in ReverseChildren vector.
   };
 
   // Number to node mapping is 1-based. Initialize the mapping to start with
@@ -77,6 +77,10 @@ template <typename DomTreeT> struct SemiNCAInfo {
   std::conditional_t<GraphHasNodeNumbers<NodePtr>, SmallVector<InfoRec, 64>,
                      DenseMap<NodePtr, InfoRec>>
       NodeInfos;
+
+  /// Reverse children of nodes; pairs of (DFSNum (predecessor), next-or-zero);
+  /// forms a linked list in this vector; first entry is sentinel.
+  SmallVector<std::pair<unsigned, unsigned>> ReverseChildren = {{0, 0}};
 
   using UpdateT = typename DomTreeT::UpdateType;
   using UpdateKind = typename DomTreeT::UpdateKind;
@@ -209,7 +213,8 @@ template <typename DomTreeT> struct SemiNCAInfo {
     while (!WorkList.empty()) {
       const auto [BB, ParentNum] = WorkList.pop_back_val();
       auto &BBInfo = getNodeInfo(BB);
-      BBInfo.ReverseChildren.push_back(ParentNum);
+      ReverseChildren.emplace_back(ParentNum, BBInfo.ReverseChildrenStart);
+      BBInfo.ReverseChildrenStart = ReverseChildren.size() - 1;
 
       // Visited nodes always have positive DFS numbers.
       if (BBInfo.DFSNum != 0)
@@ -314,8 +319,12 @@ template <typename DomTreeT> struct SemiNCAInfo {
 
       // Initialize the semi dominator to point to the parent node.
       WInfo.Semi = WInfo.Parent;
-      for (unsigned N : WInfo.ReverseChildren) {
-        unsigned SemiU = NumToInfo[eval(N, i + 1, EvalStack, NumToInfo)]->Semi;
+      unsigned RCIdx = WInfo.ReverseChildrenStart;
+      while (RCIdx != 0) {
+        const auto &Entry = ReverseChildren[RCIdx];
+        RCIdx = Entry.second;
+        unsigned SemiU =
+            NumToInfo[eval(Entry.first, i + 1, EvalStack, NumToInfo)]->Semi;
         if (SemiU < WInfo.Semi)
           WInfo.Semi = SemiU;
       }

--- a/llvm/include/llvm/Support/GenericDomTreeConstruction.h
+++ b/llvm/include/llvm/Support/GenericDomTreeConstruction.h
@@ -80,7 +80,7 @@ template <typename DomTreeT> struct SemiNCAInfo {
 
   /// Reverse children of nodes; pairs of (DFSNum (predecessor), next-or-zero);
   /// forms a linked list in this vector; first entry is sentinel.
-  SmallVector<std::pair<unsigned, unsigned>> ReverseChildren = {{0, 0}};
+  SmallVector<std::pair<unsigned, unsigned>, 32> ReverseChildren = {{0, 0}};
 
   using UpdateT = typename DomTreeT::UpdateType;
   using UpdateKind = typename DomTreeT::UpdateKind;
@@ -319,8 +319,7 @@ template <typename DomTreeT> struct SemiNCAInfo {
 
       // Initialize the semi dominator to point to the parent node.
       WInfo.Semi = WInfo.Parent;
-      unsigned RCIdx = WInfo.ReverseChildrenStart;
-      while (RCIdx != 0) {
+      for (unsigned RCIdx = WInfo.ReverseChildrenStart; RCIdx != 0;) {
         const auto &Entry = ReverseChildren[RCIdx];
         RCIdx = Entry.second;
         unsigned SemiU =


### PR DESCRIPTION
Storing many small vectors of predecessors is bad for performance, as
each of these has to be non-trivially initialized when growing the
NodeInfos vector. Therefore, store all predecessors in a separate
vector, in which predecessors form a linked list.
