### PR TITLE
[clang-format] Improve requires clause parsing

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -3860,6 +3860,7 @@ void UnwrappedLineParser::parseConstraintExpression() {
       case tok::exclaim:     // The same as above, but unary.
       case tok::kw_requires: // Initial identifier of a requires clause.
       case tok::equal:       // Initial identifier of a concept declaration.
+      case tok::kw_template: // A dependent template.
         break;
       default:
         return;

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1711,6 +1711,16 @@ TEST_F(TokenAnnotatorTest, UnderstandsRequiresExpressions) {
   EXPECT_TOKEN(Tokens[3], tok::kw_requires, TT_RequiresExpression);
   EXPECT_TOKEN(Tokens[4], tok::l_paren, TT_RequiresExpressionLParen);
   EXPECT_TOKEN(Tokens[13], tok::l_brace, TT_RequiresExpressionLBrace);
+
+  Tokens = annotate("template <typename T>\n"
+                    "struct S {\n"
+                    "  template <typename Foo>\n"
+                    "    requires T::template Has<Foo>\n"
+                    "  void func(Foo);\n"
+                    "};");
+  ASSERT_EQ(Tokens.size(), 30u) << Tokens;
+  EXPECT_TOKEN(Tokens[20], tok::greater, TT_TemplateCloser);
+  EXPECT_TRUE(Tokens[20]->ClosesRequiresClause);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsPragmaRegion) {


### PR DESCRIPTION
We did not consider dependent templates and thus ended the parsing after template and forcing a line break there. The tests was formatted as:

template <typename T> struct S {
  template <typename Foo>
    requires T::template
  Has<Foo> void func(Foo);
};