### PR TITLE
[NFC][LLVM][NVPTX] Use namespace qualifiers to define functions

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.cpp
@@ -23,8 +23,7 @@ using namespace llvm;
 
 #define DEBUG_TYPE "nvptx-reg-info"
 
-namespace llvm {
-StringRef getNVPTXRegClassName(TargetRegisterClass const *RC) {
+StringRef llvm::getNVPTXRegClassName(TargetRegisterClass const *RC) {
   if (RC == &NVPTX::B128RegClass)
     return ".b128";
   if (RC == &NVPTX::B64RegClass)
@@ -58,7 +57,7 @@ StringRef getNVPTXRegClassName(TargetRegisterClass const *RC) {
   return "INTERNAL";
 }
 
-StringRef getNVPTXRegClassStr(TargetRegisterClass const *RC) {
+StringRef llvm::getNVPTXRegClassStr(TargetRegisterClass const *RC) {
   if (RC == &NVPTX::B128RegClass)
     return "%rq";
   if (RC == &NVPTX::B64RegClass)
@@ -73,7 +72,6 @@ StringRef getNVPTXRegClassStr(TargetRegisterClass const *RC) {
     return "!Special!";
   return "INTERNAL";
 }
-} // namespace llvm
 
 NVPTXRegisterInfo::NVPTXRegisterInfo()
     : NVPTXGenRegisterInfo(0), StrPool(StrAlloc) {}

--- a/llvm/lib/Target/NVPTX/NVPTXUtilities.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXUtilities.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Support/CommandLine.h"
 #include <algorithm>
 
-namespace llvm {
+using namespace llvm;
 
 static cl::opt<bool> ForceMinByValParamAlign(
     "nvptx-force-min-byval-param-align", cl::Hidden,
@@ -29,12 +29,12 @@ static cl::opt<bool> ForceMinByValParamAlign(
              " params of device functions."),
     cl::init(false));
 
-Function *getMaybeBitcastedCallee(const CallBase *CB) {
+Function *llvm::getMaybeBitcastedCallee(const CallBase *CB) {
   return dyn_cast<Function>(CB->getCalledOperand()->stripPointerCasts());
 }
 
-Align getPTXPromotedParamTypeAlign(const Function *F, Type *ArgTy,
-                                   const DataLayout &DL) {
+Align llvm::getPTXPromotedParamTypeAlign(const Function *F, Type *ArgTy,
+                                         const DataLayout &DL) {
   // Capping the alignment to 128 bytes as that is the maximum alignment
   // supported by PTX.
   const Align ABITypeAlign = std::min(Align(128), DL.getABITypeAlign(ArgTy));
@@ -54,8 +54,8 @@ Align getPTXPromotedParamTypeAlign(const Function *F, Type *ArgTy,
   return std::max(OptimizedAlign, ABITypeAlign);
 }
 
-Align getDeviceByValParamAlign(const Function *F, Type *ArgTy,
-                               Align InitialAlign, const DataLayout &DL) {
+Align llvm::getDeviceByValParamAlign(const Function *F, Type *ArgTy,
+                                     Align InitialAlign, const DataLayout &DL) {
   const Align OptimizedAlign = getPTXPromotedParamTypeAlign(F, ArgTy, DL);
 
   // Old ptx versions have a bug. When PTX code takes address of
@@ -74,8 +74,8 @@ Align getDeviceByValParamAlign(const Function *F, Type *ArgTy,
   return std::max({InitialAlign, OptimizedAlign, AlignFloor});
 }
 
-Align getPTXParamAlign(const Function *F, Type *Ty, unsigned AttrIdx,
-                       const DataLayout &DL) {
+Align llvm::getPTXParamAlign(const Function *F, Type *Ty, unsigned AttrIdx,
+                             const DataLayout &DL) {
   if (F)
     if (MaybeAlign StackAlign = getStackAlign(*F, AttrIdx))
       return StackAlign.value();
@@ -89,8 +89,8 @@ Align getPTXParamAlign(const Function *F, Type *Ty, unsigned AttrIdx,
   return TypeAlign;
 }
 
-Align getPTXParamAlign(const CallBase *CB, Type *Ty, unsigned Idx,
-                       const DataLayout &DL) {
+Align llvm::getPTXParamAlign(const CallBase *CB, Type *Ty, unsigned Idx,
+                             const DataLayout &DL) {
   const Function *DirectCallee = CB ? CB->getCalledFunction() : nullptr;
 
   if (!DirectCallee && CB) {
@@ -103,7 +103,7 @@ Align getPTXParamAlign(const CallBase *CB, Type *Ty, unsigned Idx,
   return getPTXParamAlign(DirectCallee, Ty, Idx, DL);
 }
 
-bool shouldEmitPTXNoReturn(const Value *V, const TargetMachine &TM) {
+bool llvm::shouldEmitPTXNoReturn(const Value *V, const TargetMachine &TM) {
   const auto &ST =
       *static_cast<const NVPTXTargetMachine &>(TM).getSubtargetImpl();
   if (!ST.hasNoReturn())
@@ -121,5 +121,3 @@ bool shouldEmitPTXNoReturn(const Value *V, const TargetMachine &TM) {
          F->getFunctionType()->getReturnType()->isVoidTy() &&
          !isKernelFunction(*F);
 }
-
-} // namespace llvm

--- a/llvm/lib/Target/NVPTX/NVVMProperties.cpp
+++ b/llvm/lib/Target/NVPTX/NVVMProperties.cpp
@@ -32,7 +32,7 @@
 #include <string>
 #include <vector>
 
-namespace llvm {
+using namespace llvm;
 
 namespace {
 using AnnotationValues = std::map<std::string, std::vector<unsigned>>;
@@ -43,11 +43,12 @@ struct AnnotationCache {
   std::map<const Module *, AnnotationMap> Cache;
 };
 
-AnnotationCache &getAnnotationCache() {
+} // namespace
+
+static AnnotationCache &getAnnotationCache() {
   static AnnotationCache AC;
   return AC;
 }
-} // namespace
 
 // TODO: Replace these legacy nvvm.annotations metadata names with proper
 // function/parameter attributes (like the NVVMAttr:: constants).
@@ -61,7 +62,7 @@ constexpr StringLiteral ReadWriteImage("rdwrimage");
 constexpr StringLiteral Managed("managed");
 } // namespace NVVMMetadata
 
-void clearAnnotationCache(const Module *Mod) {
+void llvm::clearAnnotationCache(const Module *Mod) {
   auto &AC = getAnnotationCache();
   std::lock_guard<sys::Mutex> Guard(AC.Lock);
   AC.Cache.erase(Mod);
@@ -209,7 +210,7 @@ static std::optional<uint64_t> getVectorProduct(ArrayRef<unsigned> V) {
                          std::multiplies<uint64_t>{});
 }
 
-PTXOpaqueType getPTXOpaqueType(const GlobalVariable &GV) {
+PTXOpaqueType llvm::getPTXOpaqueType(const GlobalVariable &GV) {
   if (findOneNVVMAnnotation(&GV, NVVMMetadata::Texture))
     return PTXOpaqueType::Texture;
   if (findOneNVVMAnnotation(&GV, NVVMMetadata::Surface))
@@ -219,7 +220,7 @@ PTXOpaqueType getPTXOpaqueType(const GlobalVariable &GV) {
   return PTXOpaqueType::None;
 }
 
-PTXOpaqueType getPTXOpaqueType(const Argument &Arg) {
+PTXOpaqueType llvm::getPTXOpaqueType(const Argument &Arg) {
   if (argHasNVVMAnnotation(Arg, NVVMMetadata::Sampler))
     return PTXOpaqueType::Sampler;
   if (argHasNVVMAnnotation(Arg, NVVMMetadata::ReadOnlyImage))
@@ -230,7 +231,7 @@ PTXOpaqueType getPTXOpaqueType(const Argument &Arg) {
   return PTXOpaqueType::None;
 }
 
-PTXOpaqueType getPTXOpaqueType(const Value &V) {
+PTXOpaqueType llvm::getPTXOpaqueType(const Value &V) {
   if (const auto *GV = dyn_cast<GlobalVariable>(&V))
     return getPTXOpaqueType(*GV);
   if (const auto *Arg = dyn_cast<Argument>(&V))
@@ -238,23 +239,23 @@ PTXOpaqueType getPTXOpaqueType(const Value &V) {
   return PTXOpaqueType::None;
 }
 
-bool isManaged(const Value &V) {
+bool llvm::isManaged(const Value &V) {
   return globalHasNVVMAnnotation(V, NVVMMetadata::Managed);
 }
 
-SmallVector<unsigned, 3> getMaxNTID(const Function &F) {
+SmallVector<unsigned, 3> llvm::getMaxNTID(const Function &F) {
   return getFnAttrParsedVector(F, NVVMAttr::MaxNTID);
 }
 
-SmallVector<unsigned, 3> getReqNTID(const Function &F) {
+SmallVector<unsigned, 3> llvm::getReqNTID(const Function &F) {
   return getFnAttrParsedVector(F, NVVMAttr::ReqNTID);
 }
 
-SmallVector<unsigned, 3> getClusterDim(const Function &F) {
+SmallVector<unsigned, 3> llvm::getClusterDim(const Function &F) {
   return getFnAttrParsedVector(F, NVVMAttr::ClusterDim);
 }
 
-std::optional<uint64_t> getOverallMaxNTID(const Function &F) {
+std::optional<uint64_t> llvm::getOverallMaxNTID(const Function &F) {
   // Note: The semantics here are a bit strange. The PTX ISA states the
   // following (11.4.2. Performance-Tuning Directives: .maxntid):
   //
@@ -264,12 +265,12 @@ std::optional<uint64_t> getOverallMaxNTID(const Function &F) {
   return getVectorProduct(getMaxNTID(F));
 }
 
-std::optional<uint64_t> getOverallReqNTID(const Function &F) {
+std::optional<uint64_t> llvm::getOverallReqNTID(const Function &F) {
   // Note: The semantics here are a bit strange. See getOverallMaxNTID.
   return getVectorProduct(getReqNTID(F));
 }
 
-std::optional<uint64_t> getOverallClusterRank(const Function &F) {
+std::optional<uint64_t> llvm::getOverallClusterRank(const Function &F) {
   // maxclusterrank and cluster_dim are mutually exclusive.
   if (const auto ClusterRank = getMaxClusterRank(F))
     return ClusterRank;
@@ -278,23 +279,23 @@ std::optional<uint64_t> getOverallClusterRank(const Function &F) {
   return getVectorProduct(getClusterDim(F));
 }
 
-std::optional<unsigned> getMaxClusterRank(const Function &F) {
+std::optional<unsigned> llvm::getMaxClusterRank(const Function &F) {
   return getFnAttrParsedInt(F, NVVMAttr::MaxClusterRank);
 }
 
-std::optional<unsigned> getMinCTASm(const Function &F) {
+std::optional<unsigned> llvm::getMinCTASm(const Function &F) {
   return getFnAttrParsedInt(F, NVVMAttr::MinCTASm);
 }
 
-std::optional<unsigned> getMaxNReg(const Function &F) {
+std::optional<unsigned> llvm::getMaxNReg(const Function &F) {
   return getFnAttrParsedInt(F, NVVMAttr::MaxNReg);
 }
 
-bool hasBlocksAreClusters(const Function &F) {
+bool llvm::hasBlocksAreClusters(const Function &F) {
   return F.hasFnAttribute(NVVMAttr::BlocksAreClusters);
 }
 
-bool isParamGridConstant(const Argument &Arg) {
+bool llvm::isParamGridConstant(const Argument &Arg) {
   assert(isKernelFunction(*Arg.getParent()) &&
          "only kernel arguments can be grid_constant");
 
@@ -317,7 +318,7 @@ bool isParamGridConstant(const Argument &Arg) {
   return Arg.hasAttribute(NVVMAttr::GridConstant);
 }
 
-MaybeAlign getStackAlign(const CallBase &I, unsigned Index) {
+MaybeAlign llvm::getStackAlign(const CallBase &I, unsigned Index) {
   // First check the alignstack metadata.
   if (MaybeAlign StackAlign =
           I.getAttributes().getAttributes(Index).getStackAlignment())
@@ -338,5 +339,3 @@ MaybeAlign getStackAlign(const CallBase &I, unsigned Index) {
   }
   return std::nullopt;
 }
-
-} // namespace llvm


### PR DESCRIPTION
Use namespace qualifiers to define functions in `llvm` namespace, per https://llvm.org/docs/CodingStandards.html#use-namespace-qualifiers-to-define-previously-declared-symbols.