### PR TITLE
[NFC][LLVM][NVPTX] Initialize pass-ids to zero

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXLowerAlloca.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXLowerAlloca.cpp
@@ -46,7 +46,7 @@ public:
 };
 } // namespace
 
-char NVPTXLowerAlloca::ID = 1;
+char NVPTXLowerAlloca::ID = 0;
 
 INITIALIZE_PASS(NVPTXLowerAlloca, "nvptx-lower-alloca", "Lower Alloca", false,
                 false)

--- a/llvm/lib/Target/NVPTX/NVPTXLowerArgs.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXLowerArgs.cpp
@@ -83,7 +83,7 @@ public:
 };
 } // namespace
 
-char NVPTXLowerArgsLegacyPass::ID = 1;
+char NVPTXLowerArgsLegacyPass::ID = 0;
 
 INITIALIZE_PASS_BEGIN(NVPTXLowerArgsLegacyPass, "nvptx-lower-args",
                       "Lower arguments (NVPTX)", false, false)

--- a/llvm/lib/Target/NVPTX/NVPTXLowerUnreachable.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXLowerUnreachable.cpp
@@ -96,7 +96,7 @@ private:
 };
 } // namespace
 
-char NVPTXLowerUnreachable::ID = 1;
+char NVPTXLowerUnreachable::ID = 0;
 
 INITIALIZE_PASS(NVPTXLowerUnreachable, "nvptx-lower-unreachable",
                 "Lower Unreachable", false, false)


### PR DESCRIPTION
Initialize pass::ID values for various passes to canonical zero instead of 1.