### PR TITLE
[NewPM] Port StaticDataProfileInfo and wire into x86 AsmPrinter

### DIFF
--- a/llvm/include/llvm/Analysis/StaticDataProfileInfo.h
+++ b/llvm/include/llvm/Analysis/StaticDataProfileInfo.h
@@ -118,7 +118,7 @@ private:
 class LLVM_ABI StaticDataProfileInfoAnalysis
     : public AnalysisInfoMixin<StaticDataProfileInfoAnalysis> {
 public:
-  LLVM_ABI static AnalysisKey Key;
+  static AnalysisKey Key;
 
   class Result {
     std::unique_ptr<StaticDataProfileInfo> HeldInfo;

--- a/llvm/include/llvm/Analysis/StaticDataProfileInfo.h
+++ b/llvm/include/llvm/Analysis/StaticDataProfileInfo.h
@@ -4,9 +4,12 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Analysis/ProfileSummaryInfo.h"
+#include "llvm/IR/Analysis.h"
 #include "llvm/IR/Constant.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/Compiler.h"
+#include <memory>
 
 namespace llvm {
 
@@ -110,6 +113,31 @@ public:
 
 private:
   std::unique_ptr<StaticDataProfileInfo> Info;
+};
+
+class LLVM_ABI StaticDataProfileInfoAnalysis
+    : public AnalysisInfoMixin<StaticDataProfileInfoAnalysis> {
+public:
+  LLVM_ABI static AnalysisKey Key;
+
+  class Result {
+    std::unique_ptr<StaticDataProfileInfo> HeldInfo;
+    Result(std::unique_ptr<StaticDataProfileInfo> &&Info)
+        : HeldInfo(std::move(Info)) {}
+    friend class StaticDataProfileInfoAnalysis;
+
+  public:
+    const StaticDataProfileInfo &getStaticDataProfileInfo() const {
+      return *HeldInfo;
+    }
+
+    bool invalidate(Module &, const PreservedAnalyses &,
+                    ModuleAnalysisManager::Invalidator &) {
+      return false;
+    }
+  };
+
+  Result run(Module &M, ModuleAnalysisManager &);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Analysis/StaticDataProfileInfo.h
+++ b/llvm/include/llvm/Analysis/StaticDataProfileInfo.h
@@ -127,7 +127,7 @@ public:
     friend class StaticDataProfileInfoAnalysis;
 
   public:
-    const StaticDataProfileInfo &getStaticDataProfileInfo() const {
+    StaticDataProfileInfo &getStaticDataProfileInfo() {
       return *HeldInfo;
     }
 

--- a/llvm/lib/Analysis/StaticDataProfileInfo.cpp
+++ b/llvm/lib/Analysis/StaticDataProfileInfo.cpp
@@ -4,6 +4,7 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/ProfileData/InstrProf.h"
 
@@ -188,12 +189,17 @@ StringRef StaticDataProfileInfo::getConstantSectionPrefix(
   return hotnessToStr(getConstantHotnessUsingProfileCount(C, PSI, *Count));
 }
 
-bool StaticDataProfileInfoWrapperPass::doInitialization(Module &M) {
+static std::unique_ptr<StaticDataProfileInfo>
+computeStaticDataProfileInfo(Module &M) {
   bool EnableDataAccessProf = false;
   if (auto *MD = mdconst::extract_or_null<ConstantInt>(
           M.getModuleFlag("EnableDataAccessProf")))
     EnableDataAccessProf = MD->getZExtValue();
-  Info.reset(new StaticDataProfileInfo(EnableDataAccessProf));
+  return std::make_unique<StaticDataProfileInfo>(EnableDataAccessProf);
+}
+
+bool StaticDataProfileInfoWrapperPass::doInitialization(Module &M) {
+  Info = computeStaticDataProfileInfo(M);
   return false;
 }
 
@@ -209,3 +215,10 @@ StaticDataProfileInfoWrapperPass::StaticDataProfileInfoWrapperPass()
     : ImmutablePass(ID) {}
 
 char StaticDataProfileInfoWrapperPass::ID = 0;
+
+StaticDataProfileInfoAnalysis::Result
+StaticDataProfileInfoAnalysis::run(Module &M, ModuleAnalysisManager &) {
+  return StaticDataProfileInfoAnalysis::Result(computeStaticDataProfileInfo(M));
+}
+
+AnalysisKey llvm::StaticDataProfileInfoAnalysis::Key;

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -74,6 +74,7 @@
 #include "llvm/Analysis/ScopedNoAliasAA.h"
 #include "llvm/Analysis/StackLifetime.h"
 #include "llvm/Analysis/StackSafetyAnalysis.h"
+#include "llvm/Analysis/StaticDataProfileInfo.h"
 #include "llvm/Analysis/StructuralHash.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -38,6 +38,7 @@ MODULE_ANALYSIS("profile-summary", ProfileSummaryAnalysis())
 MODULE_ANALYSIS("reg-usage", PhysicalRegisterUsageAnalysis())
 MODULE_ANALYSIS("runtime-libcall-info", RuntimeLibraryAnalysis())
 MODULE_ANALYSIS("stack-safety", StackSafetyGlobalAnalysis())
+MODULE_ANALYSIS("static-data-profile-info", StaticDataProfileInfoAnalysis())
 MODULE_ANALYSIS("verify", VerifierAnalysis())
 
 #ifndef MODULE_ALIAS_ANALYSIS

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -27,6 +27,7 @@
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/CodeGen/MachineConstantPool.h"
 #include "llvm/CodeGen/MachineModuleInfoImpls.h"
+#include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
 #include "llvm/CodeGenTypes/MachineValueType.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -1162,7 +1163,10 @@ PreservedAnalyses X86AsmPrinterBeginPass::run(Module &M,
   AsmPrinter.GetPSI = [&MAM](Module &M) {
     return &MAM.getResult<ProfileSummaryAnalysis>(M);
   };
-  AsmPrinter.GetSDPI = [](Module &M) { return nullptr; };
+  AsmPrinter.GetSDPI = [&MAM](Module &M) {
+    return &MAM.getResult<StaticDataProfileInfoAnalysis>(M)
+                .getStaticDataProfileInfo();
+  };
   setupModuleAsmPrinter(M, MAM, AsmPrinter);
   AsmPrinter.doInitialization(M);
   return PreservedAnalyses::all();
@@ -1178,7 +1182,12 @@ PreservedAnalyses X86AsmPrinterPass::run(MachineFunction &MF,
     return MFAM.getResult<ModuleAnalysisManagerMachineFunctionProxy>(MF)
         .getCachedResult<ProfileSummaryAnalysis>(M);
   };
-  AsmPrinter.GetSDPI = [](Module &M) { return nullptr; };
+  AsmPrinter.GetSDPI = [&MFAM, &MF](Module &M) {
+    return &MFAM.getResult<ModuleAnalysisManagerMachineFunctionProxy>(MF)
+                .getCachedResult<StaticDataProfileInfoAnalysis>(
+                    *MF.getFunction().getParent())
+                ->getStaticDataProfileInfo();
+  };
   setupMachineFunctionAsmPrinter(MFAM, MF, AsmPrinter);
   AsmPrinter.runOnMachineFunction(MF);
   return PreservedAnalyses::all();
@@ -1191,7 +1200,10 @@ PreservedAnalyses X86AsmPrinterEndPass::run(Module &M,
   AsmPrinter.GetPSI = [&MAM](Module &M) {
     return &MAM.getResult<ProfileSummaryAnalysis>(M);
   };
-  AsmPrinter.GetSDPI = [](Module &M) { return nullptr; };
+  AsmPrinter.GetSDPI = [&MAM](Module &M) {
+    return &MAM.getResult<StaticDataProfileInfoAnalysis>(M)
+                .getStaticDataProfileInfo();
+  };
   setupModuleAsmPrinter(M, MAM, AsmPrinter);
   AsmPrinter.doFinalization(M);
   return PreservedAnalyses::all();

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -1158,6 +1158,9 @@ extern "C" LLVM_C_ABI void LLVMInitializeX86AsmPrinter() {
 
 PreservedAnalyses X86AsmPrinterBeginPass::run(Module &M,
                                               ModuleAnalysisManager &MAM) {
+  // Force the computation of SDPI so that it is available for the
+  // actual pass, where it cannot be explicitly requested.
+  MAM.getResult<StaticDataProfileInfoAnalysis>(M);
   X86AsmPrinter &AsmPrinter = static_cast<X86AsmPrinter &>(
       MAM.getResult<AsmPrinterAnalysis>(M).getPrinter());
   AsmPrinter.GetPSI = [&MAM](Module &M) {

--- a/llvm/lib/Target/X86/X86AsmPrinter.h
+++ b/llvm/lib/Target/X86/X86AsmPrinter.h
@@ -202,7 +202,7 @@ public:
   }
 
   std::function<ProfileSummaryInfo *(Module &)> GetPSI;
-  std::function<StaticDataProfileInfo *(Module &)> GetSDPI;
+  std::function<const StaticDataProfileInfo *(Module &)> GetSDPI;
 };
 
 class X86AsmPrinterBeginPass


### PR DESCRIPTION
Ports the analysis to the NewPM and wires it into the NewPM x86
AsmPrinter where we are currently just returning nullptr.
