### PR TITLE
[libc++] Remove _LIBCPP_SHORT_WCHAR

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -43,7 +43,6 @@
 #  endif
 
 #  if defined(_WIN32)
-#    define _LIBCPP_SHORT_WCHAR 1
 #    if defined(_MSC_VER) && !defined(__MINGW32__)
 #      define _LIBCPP_MSVCRT // Using Microsoft's C Runtime library
 #    endif
@@ -51,11 +50,6 @@
 #  else
 #    define _LIBCPP_HAS_OPEN_WITH_WCHAR 0
 #  endif // defined(_WIN32)
-
-#  if defined(_AIX) && !defined(__64BIT__)
-// The size of wchar is 2 byte on 32-bit mode on AIX.
-#    define _LIBCPP_SHORT_WCHAR 1
-#  endif
 
 // Libc++ supports various implementations of std::random_device.
 //

--- a/libcxx/include/__cxx03/__config
+++ b/libcxx/include/__cxx03/__config
@@ -221,7 +221,6 @@ _LIBCPP_HARDENING_MODE_DEBUG
 
 #  if defined(_WIN32)
 #    define _LIBCPP_WIN32API
-#    define _LIBCPP_SHORT_WCHAR 1
 // Both MinGW and native MSVC provide a "MSVC"-like environment
 #    define _LIBCPP_MSVCRT_LIKE
 // If mingw not explicitly detected, assume using MS C runtime only if
@@ -231,11 +230,6 @@ _LIBCPP_HARDENING_MODE_DEBUG
 #    endif
 #    define _LIBCPP_HAS_OPEN_WITH_WCHAR
 #  endif // defined(_WIN32)
-
-#  if defined(_AIX) && !defined(__64BIT__)
-// The size of wchar is 2 byte on 32-bit mode on AIX.
-#    define _LIBCPP_SHORT_WCHAR 1
-#  endif
 
 // Libc++ supports various implementations of std::random_device.
 //

--- a/libcxx/include/print
+++ b/libcxx/include/print
@@ -89,27 +89,20 @@ namespace __unicode {
 // The names of these concepts are modelled after P2728R0, but the
 // implementation is not. char16_t may contain 32-bits so depending on the
 // number of bits is an issue.
-#      ifdef _LIBCPP_SHORT_WCHAR
 template <class _Tp>
 concept __utf16_code_unit =
     same_as<_Tp, char16_t>
-#        if _LIBCPP_HAS_WIDE_CHARACTERS
-    || same_as<_Tp, wchar_t>
-#        endif
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
+    || (sizeof(wchar_t) == sizeof(char16_t) && same_as<_Tp, wchar_t>)
+#      endif
     ;
-template <class _Tp>
-concept __utf32_code_unit = same_as<_Tp, char32_t>;
-#      else // _LIBCPP_SHORT_WCHAR
-template <class _Tp>
-concept __utf16_code_unit = same_as<_Tp, char16_t>;
 template <class _Tp>
 concept __utf32_code_unit =
     same_as<_Tp, char32_t>
-#        if _LIBCPP_HAS_WIDE_CHARACTERS
-    || same_as<_Tp, wchar_t>
-#        endif
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
+    || (sizeof(wchar_t) == sizeof(char32_t) && same_as<_Tp, wchar_t>)
+#      endif
     ;
-#      endif // _LIBCPP_SHORT_WCHAR
 
 // Pass by reference since an output_iterator may not be copyable.
 template <class _OutIt>

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -2912,6 +2912,28 @@ int codecvt<char32_t, char8_t, mbstate_t>::do_max_length() const noexcept { retu
 // __codecvt_utf8<wchar_t>
 
 #if _LIBCPP_HAS_WIDE_CHARACTERS
+
+constexpr bool is_short_wchar = sizeof(wchar_t) == sizeof(uint16_t);
+using underlying_wchar_t      = conditional_t<is_short_wchar, uint16_t, uint32_t>;
+static_assert(sizeof(underlying_wchar_t) == sizeof(wchar_t));
+
+template <auto callable>
+struct call {
+  template <class... Args>
+  static auto operator()(Args&&... args) -> decltype(callable(std::forward<Args>(args)...)) {
+    return callable(std::forward<Args>(args)...);
+  }
+};
+
+template <auto... Args, class... Args2>
+auto overload(Args2&&... args) {
+  struct overload_t : call<Args>... {
+    using call<Args>::operator()...;
+  };
+
+  return overload_t{}(std::forward<Args2>(args)...);
+}
+
 __codecvt_utf8<wchar_t>::result __codecvt_utf8<wchar_t>::do_out(
     state_type&,
     const intern_type* frm,
@@ -2920,25 +2942,15 @@ __codecvt_utf8<wchar_t>::result __codecvt_utf8<wchar_t>::do_out(
     extern_type* to,
     extern_type* to_end,
     extern_type*& to_nxt) const {
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  const uint16_t* _frm     = reinterpret_cast<const uint16_t*>(frm);
-  const uint16_t* _frm_end = reinterpret_cast<const uint16_t*>(frm_end);
-  const uint16_t* _frm_nxt = _frm;
-#  else
-  const uint32_t* _frm     = reinterpret_cast<const uint32_t*>(frm);
-  const uint32_t* _frm_end = reinterpret_cast<const uint32_t*>(frm_end);
-  const uint32_t* _frm_nxt = _frm;
-#  endif
-  uint8_t* _to     = reinterpret_cast<uint8_t*>(to);
-  uint8_t* _to_end = reinterpret_cast<uint8_t*>(to_end);
-  uint8_t* _to_nxt = _to;
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  result r = ucs2_to_utf8(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  else
-  result r = ucs4_to_utf8(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  endif
-  frm_nxt = frm + (_frm_nxt - _frm);
-  to_nxt  = to + (_to_nxt - _to);
+  const auto* _frm     = reinterpret_cast<const underlying_wchar_t*>(frm);
+  const auto* _frm_end = reinterpret_cast<const underlying_wchar_t*>(frm_end);
+  const auto* _frm_nxt = _frm;
+  uint8_t* _to         = reinterpret_cast<uint8_t*>(to);
+  uint8_t* _to_end     = reinterpret_cast<uint8_t*>(to_end);
+  uint8_t* _to_nxt     = _to;
+  result r = overload<ucs2_to_utf8, ucs4_to_utf8>(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
+  frm_nxt  = frm + (_frm_nxt - _frm);
+  to_nxt   = to + (_to_nxt - _to);
   return r;
 }
 
@@ -2953,19 +2965,12 @@ __codecvt_utf8<wchar_t>::result __codecvt_utf8<wchar_t>::do_in(
   const uint8_t* _frm     = reinterpret_cast<const uint8_t*>(frm);
   const uint8_t* _frm_end = reinterpret_cast<const uint8_t*>(frm_end);
   const uint8_t* _frm_nxt = _frm;
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  uint16_t* _to     = reinterpret_cast<uint16_t*>(to);
-  uint16_t* _to_end = reinterpret_cast<uint16_t*>(to_end);
-  uint16_t* _to_nxt = _to;
-  result r          = utf8_to_ucs2(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  else
-  uint32_t* _to     = reinterpret_cast<uint32_t*>(to);
-  uint32_t* _to_end = reinterpret_cast<uint32_t*>(to_end);
-  uint32_t* _to_nxt = _to;
-  result r          = utf8_to_ucs4(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  endif
-  frm_nxt = frm + (_frm_nxt - _frm);
-  to_nxt  = to + (_to_nxt - _to);
+  auto* _to               = reinterpret_cast<underlying_wchar_t*>(to);
+  auto* _to_end           = reinterpret_cast<underlying_wchar_t*>(to_end);
+  auto* _to_nxt           = _to;
+  result r = overload<utf8_to_ucs2, utf8_to_ucs4>(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
+  frm_nxt  = frm + (_frm_nxt - _frm);
+  to_nxt   = to + (_to_nxt - _to);
   return r;
 }
 
@@ -2983,24 +2988,18 @@ int __codecvt_utf8<wchar_t>::do_length(
     state_type&, const extern_type* frm, const extern_type* frm_end, size_t mx) const {
   const uint8_t* _frm     = reinterpret_cast<const uint8_t*>(frm);
   const uint8_t* _frm_end = reinterpret_cast<const uint8_t*>(frm_end);
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  return utf8_to_ucs2_length(_frm, _frm_end, mx, __maxcode_, __mode_);
-#  else
-  return utf8_to_ucs4_length(_frm, _frm_end, mx, __maxcode_, __mode_);
-#  endif
+  if constexpr (is_short_wchar)
+    return utf8_to_ucs2_length(_frm, _frm_end, mx, __maxcode_, __mode_);
+  else
+    return utf8_to_ucs4_length(_frm, _frm_end, mx, __maxcode_, __mode_);
 }
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 int __codecvt_utf8<wchar_t>::do_max_length() const noexcept {
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  if (__mode_ & consume_header)
-    return 6;
-  return 3;
-#  else
-  if (__mode_ & consume_header)
-    return 7;
-  return 4;
-#  endif
+  if constexpr (is_short_wchar)
+    return (__mode_ & consume_header) ? 6 : 3;
+  else
+    return (__mode_ & consume_header) ? 7 : 4;
 }
 #endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
@@ -3149,23 +3148,14 @@ __codecvt_utf16<wchar_t, false>::result __codecvt_utf16<wchar_t, false>::do_out(
     extern_type* to,
     extern_type* to_end,
     extern_type*& to_nxt) const {
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  const uint16_t* _frm     = reinterpret_cast<const uint16_t*>(frm);
-  const uint16_t* _frm_end = reinterpret_cast<const uint16_t*>(frm_end);
-  const uint16_t* _frm_nxt = _frm;
-#  else
-  const uint32_t* _frm     = reinterpret_cast<const uint32_t*>(frm);
-  const uint32_t* _frm_end = reinterpret_cast<const uint32_t*>(frm_end);
-  const uint32_t* _frm_nxt = _frm;
-#  endif
-  uint8_t* _to     = reinterpret_cast<uint8_t*>(to);
-  uint8_t* _to_end = reinterpret_cast<uint8_t*>(to_end);
-  uint8_t* _to_nxt = _to;
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  result r = ucs2_to_utf16be(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  else
-  result r = ucs4_to_utf16be(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  endif
+  const auto* _frm     = reinterpret_cast<const underlying_wchar_t*>(frm);
+  const auto* _frm_end = reinterpret_cast<const underlying_wchar_t*>(frm_end);
+  const auto* _frm_nxt = _frm;
+  uint8_t* _to         = reinterpret_cast<uint8_t*>(to);
+  uint8_t* _to_end     = reinterpret_cast<uint8_t*>(to_end);
+  uint8_t* _to_nxt     = _to;
+  result r =
+      overload<ucs2_to_utf16be, ucs4_to_utf16be>(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
   frm_nxt = frm + (_frm_nxt - _frm);
   to_nxt  = to + (_to_nxt - _to);
   return r;
@@ -3182,17 +3172,11 @@ __codecvt_utf16<wchar_t, false>::result __codecvt_utf16<wchar_t, false>::do_in(
   const uint8_t* _frm     = reinterpret_cast<const uint8_t*>(frm);
   const uint8_t* _frm_end = reinterpret_cast<const uint8_t*>(frm_end);
   const uint8_t* _frm_nxt = _frm;
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  uint16_t* _to     = reinterpret_cast<uint16_t*>(to);
-  uint16_t* _to_end = reinterpret_cast<uint16_t*>(to_end);
-  uint16_t* _to_nxt = _to;
-  result r          = utf16be_to_ucs2(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  else
-  uint32_t* _to     = reinterpret_cast<uint32_t*>(to);
-  uint32_t* _to_end = reinterpret_cast<uint32_t*>(to_end);
-  uint32_t* _to_nxt = _to;
-  result r          = utf16be_to_ucs4(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  endif
+  auto* _to               = reinterpret_cast<underlying_wchar_t*>(to);
+  auto* _to_end           = reinterpret_cast<underlying_wchar_t*>(to_end);
+  auto* _to_nxt           = _to;
+  result r =
+      overload<utf16be_to_ucs2, utf16be_to_ucs4>(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
   frm_nxt = frm + (_frm_nxt - _frm);
   to_nxt  = to + (_to_nxt - _to);
   return r;
@@ -3212,23 +3196,17 @@ int __codecvt_utf16<wchar_t, false>::do_length(
     state_type&, const extern_type* frm, const extern_type* frm_end, size_t mx) const {
   const uint8_t* _frm     = reinterpret_cast<const uint8_t*>(frm);
   const uint8_t* _frm_end = reinterpret_cast<const uint8_t*>(frm_end);
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  return utf16be_to_ucs2_length(_frm, _frm_end, mx, __maxcode_, __mode_);
-#  else
-  return utf16be_to_ucs4_length(_frm, _frm_end, mx, __maxcode_, __mode_);
-#  endif
+  if constexpr (is_short_wchar)
+    return utf16be_to_ucs2_length(_frm, _frm_end, mx, __maxcode_, __mode_);
+  else
+    return utf16be_to_ucs4_length(_frm, _frm_end, mx, __maxcode_, __mode_);
 }
 
 int __codecvt_utf16<wchar_t, false>::do_max_length() const noexcept {
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  if (__mode_ & consume_header)
-    return 4;
-  return 2;
-#  else
-  if (__mode_ & consume_header)
-    return 6;
-  return 4;
-#  endif
+  if constexpr (is_short_wchar)
+    return (__mode_ & consume_header) ? 4 : 2;
+  else
+    return (__mode_ & consume_header) ? 6 : 4;
 }
 
 // __codecvt_utf16<wchar_t, true>
@@ -3241,23 +3219,14 @@ __codecvt_utf16<wchar_t, true>::result __codecvt_utf16<wchar_t, true>::do_out(
     extern_type* to,
     extern_type* to_end,
     extern_type*& to_nxt) const {
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  const uint16_t* _frm     = reinterpret_cast<const uint16_t*>(frm);
-  const uint16_t* _frm_end = reinterpret_cast<const uint16_t*>(frm_end);
-  const uint16_t* _frm_nxt = _frm;
-#  else
-  const uint32_t* _frm     = reinterpret_cast<const uint32_t*>(frm);
-  const uint32_t* _frm_end = reinterpret_cast<const uint32_t*>(frm_end);
-  const uint32_t* _frm_nxt = _frm;
-#  endif
-  uint8_t* _to     = reinterpret_cast<uint8_t*>(to);
-  uint8_t* _to_end = reinterpret_cast<uint8_t*>(to_end);
-  uint8_t* _to_nxt = _to;
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  result r = ucs2_to_utf16le(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  else
-  result r = ucs4_to_utf16le(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  endif
+  const auto* _frm     = reinterpret_cast<const underlying_wchar_t*>(frm);
+  const auto* _frm_end = reinterpret_cast<const underlying_wchar_t*>(frm_end);
+  const auto* _frm_nxt = _frm;
+  uint8_t* _to         = reinterpret_cast<uint8_t*>(to);
+  uint8_t* _to_end     = reinterpret_cast<uint8_t*>(to_end);
+  uint8_t* _to_nxt     = _to;
+  result r =
+      overload<ucs2_to_utf16le, ucs4_to_utf16le>(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
   frm_nxt = frm + (_frm_nxt - _frm);
   to_nxt  = to + (_to_nxt - _to);
   return r;
@@ -3274,17 +3243,11 @@ __codecvt_utf16<wchar_t, true>::result __codecvt_utf16<wchar_t, true>::do_in(
   const uint8_t* _frm     = reinterpret_cast<const uint8_t*>(frm);
   const uint8_t* _frm_end = reinterpret_cast<const uint8_t*>(frm_end);
   const uint8_t* _frm_nxt = _frm;
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  uint16_t* _to     = reinterpret_cast<uint16_t*>(to);
-  uint16_t* _to_end = reinterpret_cast<uint16_t*>(to_end);
-  uint16_t* _to_nxt = _to;
-  result r          = utf16le_to_ucs2(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  else
-  uint32_t* _to     = reinterpret_cast<uint32_t*>(to);
-  uint32_t* _to_end = reinterpret_cast<uint32_t*>(to_end);
-  uint32_t* _to_nxt = _to;
-  result r          = utf16le_to_ucs4(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-#  endif
+  auto* _to               = reinterpret_cast<underlying_wchar_t*>(to);
+  auto* _to_end           = reinterpret_cast<underlying_wchar_t*>(to_end);
+  auto* _to_nxt           = _to;
+  result r =
+      overload<utf16le_to_ucs2, utf16le_to_ucs4>(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
   frm_nxt = frm + (_frm_nxt - _frm);
   to_nxt  = to + (_to_nxt - _to);
   return r;
@@ -3304,23 +3267,17 @@ int __codecvt_utf16<wchar_t, true>::do_length(
     state_type&, const extern_type* frm, const extern_type* frm_end, size_t mx) const {
   const uint8_t* _frm     = reinterpret_cast<const uint8_t*>(frm);
   const uint8_t* _frm_end = reinterpret_cast<const uint8_t*>(frm_end);
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  return utf16le_to_ucs2_length(_frm, _frm_end, mx, __maxcode_, __mode_);
-#  else
-  return utf16le_to_ucs4_length(_frm, _frm_end, mx, __maxcode_, __mode_);
-#  endif
+  if constexpr (is_short_wchar)
+    return utf16le_to_ucs2_length(_frm, _frm_end, mx, __maxcode_, __mode_);
+  else
+    return utf16le_to_ucs4_length(_frm, _frm_end, mx, __maxcode_, __mode_);
 }
 
 int __codecvt_utf16<wchar_t, true>::do_max_length() const noexcept {
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  if (__mode_ & consume_header)
-    return 4;
-  return 2;
-#  else
-  if (__mode_ & consume_header)
-    return 6;
-  return 4;
-#  endif
+  if constexpr (is_short_wchar)
+    return (__mode_ & consume_header) ? 4 : 2;
+  else
+    return (__mode_ & consume_header) ? 6 : 4;
 }
 #endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
@@ -3603,15 +3560,9 @@ __codecvt_utf8_utf16<wchar_t>::result __codecvt_utf8_utf16<wchar_t>::do_out(
     extern_type* to,
     extern_type* to_end,
     extern_type*& to_nxt) const {
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  const uint16_t* _frm     = reinterpret_cast<const uint16_t*>(frm);
-  const uint16_t* _frm_end = reinterpret_cast<const uint16_t*>(frm_end);
-  const uint16_t* _frm_nxt = _frm;
-#  else
-  const uint32_t* _frm     = reinterpret_cast<const uint32_t*>(frm);
-  const uint32_t* _frm_end = reinterpret_cast<const uint32_t*>(frm_end);
-  const uint32_t* _frm_nxt = _frm;
-#  endif
+  const auto* _frm     = reinterpret_cast<const underlying_wchar_t*>(frm);
+  const auto* _frm_end = reinterpret_cast<const underlying_wchar_t*>(frm_end);
+  const auto* _frm_nxt = _frm;
   uint8_t* _to     = reinterpret_cast<uint8_t*>(to);
   uint8_t* _to_end = reinterpret_cast<uint8_t*>(to_end);
   uint8_t* _to_nxt = _to;
@@ -3632,18 +3583,12 @@ __codecvt_utf8_utf16<wchar_t>::result __codecvt_utf8_utf16<wchar_t>::do_in(
   const uint8_t* _frm     = reinterpret_cast<const uint8_t*>(frm);
   const uint8_t* _frm_end = reinterpret_cast<const uint8_t*>(frm_end);
   const uint8_t* _frm_nxt = _frm;
-#  if defined(_LIBCPP_SHORT_WCHAR)
-  uint16_t* _to     = reinterpret_cast<uint16_t*>(to);
-  uint16_t* _to_end = reinterpret_cast<uint16_t*>(to_end);
-  uint16_t* _to_nxt = _to;
-#  else
-  uint32_t* _to     = reinterpret_cast<uint32_t*>(to);
-  uint32_t* _to_end = reinterpret_cast<uint32_t*>(to_end);
-  uint32_t* _to_nxt = _to;
-#  endif
-  result r = utf8_to_utf16(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
-  frm_nxt  = frm + (_frm_nxt - _frm);
-  to_nxt   = to + (_to_nxt - _to);
+  auto* _to               = reinterpret_cast<underlying_wchar_t*>(to);
+  auto* _to_end           = reinterpret_cast<underlying_wchar_t*>(to_end);
+  auto* _to_nxt           = _to;
+  result r                = utf8_to_utf16(_frm, _frm_end, _frm_nxt, _to, _to_end, _to_nxt, __maxcode_, __mode_);
+  frm_nxt                 = frm + (_frm_nxt - _frm);
+  to_nxt                  = to + (_to_nxt - _to);
   return r;
 }
 

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -535,7 +535,7 @@ inline Tp const& DoNotOptimize(Tp const& value) {
 #  define TEST_NO_UNIQUE_ADDRESS
 #endif
 
-#ifdef _LIBCPP_SHORT_WCHAR
+#if defined(_WIN32) || defined(__SIZEOF_WCHAR_T__) && __SIZEOF_WCHAR_T__ == 2
 #  define TEST_SHORT_WCHAR
 #endif
 


### PR DESCRIPTION
We can just check for `sizeof(wchar_t)` in most places instead. The only place that seems problematic is `test_macros.h`, where we can use `__SIZEOF_WCHAR_T__` instead.

__Edit by @ldionne since the title is a bit misleading: Just to clarify, this patch is NFC -- it only refactors a macro internal to libc++ but doesn't change the behavior of the library with respect to `-fshort-wchar`__