### PR TITLE
[VPlan] Move consecutive vector pointer construction to VPBuilder (NFC).

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -511,6 +511,13 @@ public:
         new VPVectorPointerRecipe(Ptr, SourceElementTy, Stride, GEPFlags, DL));
   }
 
+  /// Create a vector pointer recipe for a consecutive memory access to \p Ptr
+  /// with element type \p SourceElementTy.
+  VPSingleDefRecipe *createConsecutiveVectorPointer(VPValue *Ptr,
+                                                    Type *SourceElementTy,
+                                                    bool Reverse, bool FoldTail,
+                                                    DebugLoc DL);
+
   VPWidenMemIntrinsicRecipe *createWidenMemIntrinsic(
       Intrinsic::ID VectorIntrinsicID, ArrayRef<VPValue *> CallArguments,
       Type *Ty, Align Alignment, const VPIRMetadata &MD, DebugLoc DL) {

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -6189,29 +6189,10 @@ VPRecipeBase *VPRecipeBuilder::tryToWidenMemory(VPInstruction *VPI,
   VPValue *Ptr = VPI->getOpcode() == Instruction::Load ? VPI->getOperand(0)
                                                        : VPI->getOperand(1);
   if (Consecutive) {
-    GEPNoWrapFlags Flags = vputils::getGEPFlagsForPtr(Ptr);
-    VPSingleDefRecipe *VectorPtr;
-    if (Reverse) {
-      // When folding the tail, we may compute an address that we don't in the
-      // original scalar loop: drop the GEP no-wrap flags in this case.
-      // Otherwise preserve existing flags without no-unsigned-wrap, as we will
-      // emit negative indices.
-      GEPNoWrapFlags ReverseFlags = CM.foldTailByMasking()
-                                        ? GEPNoWrapFlags::none()
-                                        : Flags.withoutNoUnsignedWrap();
-      VectorPtr = new VPVectorEndPointerRecipe(
-          Ptr, &Plan.getVF(), getLoadStoreType(I),
-          /*Stride*/ -1, ReverseFlags, VPI->getDebugLoc());
-    } else {
-      const DataLayout &DL = I->getDataLayout();
-      auto *StrideTy = DL.getIndexType(Ptr->getUnderlyingValue()->getType());
-      VPValue *StrideOne = Plan.getConstantInt(StrideTy, 1);
-      VectorPtr = new VPVectorPointerRecipe(Ptr, getLoadStoreType(I), StrideOne,
-                                            Flags, VPI->getDebugLoc());
-    }
     Builder.setInsertPoint(VPI);
-    Builder.insert(VectorPtr);
-    Ptr = VectorPtr;
+    Ptr = Builder.createConsecutiveVectorPointer(
+        Ptr, getLoadStoreType(I), Reverse, CM.foldTailByMasking(),
+        VPI->getDebugLoc());
   }
 
   if (Reverse && Mask)

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1657,6 +1657,27 @@ bool LoopVectorizationPlanner::getDecisionAndClampRange(
   return PredicateAtRangeStart;
 }
 
+VPSingleDefRecipe *
+VPBuilder::createConsecutiveVectorPointer(VPValue *Ptr, Type *SourceElementTy,
+                                          bool Reverse, bool FoldTail,
+                                          DebugLoc DL) {
+  VPlan &Plan = getPlan();
+  GEPNoWrapFlags Flags = vputils::getGEPFlagsForPtr(Ptr);
+  if (Reverse) {
+    // When folding the tail, we may compute an address that we don't in the
+    // original scalar loop: drop the GEP no-wrap flags in this case. Otherwise
+    // preserve existing flags without no-unsigned-wrap, as we will emit
+    // negative indices.
+    GEPNoWrapFlags ReverseFlags =
+        FoldTail ? GEPNoWrapFlags::none() : Flags.withoutNoUnsignedWrap();
+    return tryInsertInstruction(new VPVectorEndPointerRecipe(
+        Ptr, &Plan.getVF(), SourceElementTy, /*Stride=*/-1, ReverseFlags, DL));
+  }
+  Type *StrideTy = Plan.getDataLayout().getIndexType(Ptr->getScalarType());
+  VPValue *StrideOne = Plan.getConstantInt(StrideTy, 1);
+  return createVectorPointer(Ptr, SourceElementTy, StrideOne, Flags, DL);
+}
+
 VPlan &LoopVectorizationPlanner::getPlanFor(ElementCount VF) const {
   assert(count_if(VPlans,
                   [VF](const VPlanPtr &Plan) { return Plan->hasVF(VF); }) ==


### PR DESCRIPTION
Introduce VPBuilder::createConsecutiveVectorPointer to create vector pointers for consecutive accesses. This enables re-use in follow-up changes.