### PR TITLE
[libc++] Clean up windows macros

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -43,12 +43,7 @@
 #  endif
 
 #  if defined(_WIN32)
-#    define _LIBCPP_WIN32API
 #    define _LIBCPP_SHORT_WCHAR 1
-// Both MinGW and native MSVC provide a "MSVC"-like environment
-#    define _LIBCPP_MSVCRT_LIKE
-// If mingw not explicitly detected, assume using MS C runtime only if
-// a MS compatibility version is specified.
 #    if defined(_MSC_VER) && !defined(__MINGW32__)
 #      define _LIBCPP_MSVCRT // Using Microsoft's C Runtime library
 #    endif
@@ -100,7 +95,7 @@
 #    define _LIBCPP_USING_GETENTROPY
 #  elif defined(__Fuchsia__)
 #    define _LIBCPP_USING_FUCHSIA_CPRNG
-#  elif defined(_LIBCPP_WIN32API)
+#  elif defined(_WIN32)
 #    define _LIBCPP_USING_WIN32_RANDOM
 #  else
 #    define _LIBCPP_USING_DEV_RANDOM
@@ -227,7 +222,7 @@ typedef __char32_t char32_t;
 // TODO(44575): Switch to C11 thread API when possible.
 #      undef _LIBCPP_HAS_THREAD_API_PTHREAD
 #      define _LIBCPP_HAS_THREAD_API_PTHREAD 1
-#    elif defined(_LIBCPP_WIN32API)
+#    elif defined(_WIN32)
 #      undef _LIBCPP_HAS_THREAD_API_WIN32
 #      define _LIBCPP_HAS_THREAD_API_WIN32 1
 #    else

--- a/libcxx/include/__filesystem/path.h
+++ b/libcxx/include/__filesystem/path.h
@@ -80,7 +80,7 @@ struct __can_convert_char<char32_t> {
 
 template <class _ECharT, __enable_if_t<__can_convert_char<_ECharT>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI bool __is_separator(_ECharT __e) {
-#  if defined(_LIBCPP_WIN32API)
+#  ifdef _WIN32
   return __e == _ECharT('/') || __e == _ECharT('\\');
 #  else
   return __e == _ECharT('/');
@@ -181,7 +181,7 @@ struct __is_pathable<_Tp, false, true, false> : __is_pathable_char_array<_Tp> {}
 template <class _Tp>
 struct __is_pathable<_Tp, false, false, true> : __is_pathable_iter<_Tp> {};
 
-#  if defined(_LIBCPP_WIN32API)
+#  ifdef _WIN32
 typedef wstring __path_string;
 typedef wchar_t __path_value;
 #  else
@@ -189,7 +189,7 @@ typedef string __path_string;
 typedef char __path_value;
 #  endif
 
-#  if defined(_LIBCPP_WIN32API)
+#  ifdef _WIN32
 _LIBCPP_EXPORTED_FROM_ABI size_t __wide_to_char(const wstring&, char*, size_t);
 _LIBCPP_EXPORTED_FROM_ABI size_t __char_to_wide(const string&, wchar_t*, size_t);
 #  endif
@@ -203,12 +203,12 @@ struct _PathCVT {
   static_assert(__can_convert_char<_ECharT>::value, "Char type not convertible");
 
   typedef __narrow_to_utf8<sizeof(_ECharT) * __CHAR_BIT__> _Narrower;
-#    if defined(_LIBCPP_WIN32API)
+#    ifdef _WIN32
   typedef __widen_from_utf8<sizeof(wchar_t) * __CHAR_BIT__> _Widener;
 #    endif
 
   _LIBCPP_HIDE_FROM_ABI static void __append_range(__path_string& __dest, _ECharT const* __b, _ECharT const* __e) {
-#    if defined(_LIBCPP_WIN32API)
+#    ifdef _WIN32
     string __utf8;
     _Narrower()(back_inserter(__utf8), __b, __e);
     _Widener()(back_inserter(__dest), __utf8.data(), __utf8.data() + __utf8.size());
@@ -223,7 +223,7 @@ struct _PathCVT {
     if (__b == __e)
       return;
     basic_string<_ECharT> __tmp(__b, __e);
-#    if defined(_LIBCPP_WIN32API)
+#    ifdef _WIN32
     string __utf8;
     _Narrower()(back_inserter(__utf8), __tmp.data(), __tmp.data() + __tmp.length());
     _Widener()(back_inserter(__dest), __utf8.data(), __utf8.data() + __utf8.size());
@@ -241,7 +241,7 @@ struct _PathCVT {
     basic_string<_ECharT> __tmp;
     for (; *__b != __sentinel; ++__b)
       __tmp.push_back(*__b);
-#    if defined(_LIBCPP_WIN32API)
+#    ifdef _WIN32
     string __utf8;
     _Narrower()(back_inserter(__utf8), __tmp.data(), __tmp.data() + __tmp.length());
     _Widener()(back_inserter(__dest), __utf8.data(), __utf8.data() + __utf8.size());
@@ -284,7 +284,7 @@ struct _PathCVT<__path_value> {
   }
 };
 
-#  if defined(_LIBCPP_WIN32API)
+#  ifdef _WIN32
 template <>
 struct _PathCVT<char> {
   _LIBCPP_HIDE_FROM_ABI static void __append_string(__path_string& __dest, const basic_string<char>& __str) {
@@ -369,7 +369,7 @@ struct _PathExport<char8_t> {
 };
 #      endif // _LIBCPP_HAS_CHAR8_T
 #    endif   // _LIBCPP_HAS_LOCALIZATION
-#  endif     // _LIBCPP_WIN32API
+#  endif     // _WIN32
 
 class _LIBCPP_EXPORTED_FROM_ABI path {
   template <class _SourceOrIter, class _Tp = path&>
@@ -382,7 +382,7 @@ class _LIBCPP_EXPORTED_FROM_ABI path {
   using _SourceCVT _LIBCPP_NODEBUG = _PathCVT<_SourceChar<_Tp> >;
 
 public:
-#  if defined(_LIBCPP_WIN32API)
+#  ifdef _WIN32
   typedef wchar_t value_type;
   static constexpr value_type preferred_separator = L'\\';
 #  else
@@ -468,7 +468,7 @@ public:
 
 public:
   // appends
-#  if defined(_LIBCPP_WIN32API)
+#  ifdef _WIN32
   _LIBCPP_HIDE_FROM_ABI path& operator/=(const path& __p) {
     auto __p_root_name      = __p.__root_name();
     auto __p_root_name_size = __p_root_name.size();
@@ -602,7 +602,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI void clear() noexcept { __pn_.clear(); }
 
   _LIBCPP_HIDE_FROM_ABI path& make_preferred() _LIBCPP_LIFETIMEBOUND {
-#  if defined(_LIBCPP_WIN32API)
+#  ifdef _WIN32
     std::replace(__pn_.begin(), __pn_.end(), L'/', L'\\');
 #  endif
     return *this;
@@ -667,7 +667,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI operator string_type() const { return __pn_; }
 
-#  if defined(_LIBCPP_WIN32API)
+#  ifdef _WIN32
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::wstring wstring() const { return __pn_; }
 
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::wstring generic_wstring() const {
@@ -722,7 +722,7 @@ public:
     return __s;
   }
 #    endif // _LIBCPP_HAS_LOCALIZATION
-#  else    /* _LIBCPP_WIN32API */
+#  else    // _WIN32
 
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::string string() const { return __pn_; }
 #    if _LIBCPP_HAS_CHAR8_T
@@ -775,7 +775,7 @@ public:
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u16string generic_u16string() const { return string<char16_t>(); }
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI std::u32string generic_u32string() const { return string<char32_t>(); }
 #    endif // _LIBCPP_HAS_LOCALIZATION
-#  endif   /* !_LIBCPP_WIN32API */
+#  endif   // _WIN32
 
 private:
   int __compare(__string_view) const;
@@ -799,7 +799,7 @@ public:
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path root_name() const { return string_type(__root_name()); }
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path root_directory() const { return string_type(__root_directory()); }
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI path root_path() const {
-#  if defined(_LIBCPP_WIN32API)
+#  ifdef _WIN32
     return string_type(__root_path_raw());
 #  else
     return root_name().append(string_type(__root_directory()));
@@ -824,7 +824,7 @@ public:
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool has_extension() const { return !__extension().empty(); }
 
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_absolute() const {
-#  if defined(_LIBCPP_WIN32API)
+#  ifdef _WIN32
     __string_view __root_name_str = __root_name();
     __string_view __root_dir      = __root_directory();
     if (__root_name_str.size() == 2 && __root_name_str[1] == ':') {

--- a/libcxx/include/__filesystem/u8path.h
+++ b/libcxx/include/__filesystem/u8path.h
@@ -24,7 +24,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 
-#  if !defined(_LIBCPP_WIN32API) || _LIBCPP_HAS_LOCALIZATION
+#  if !defined(_WIN32) || _LIBCPP_HAS_LOCALIZATION
 template <class _InputIt, __enable_if_t<__is_pathable<_InputIt>::value, int> = 0>
 [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(_InputIt __f, _InputIt __l) {
   static_assert(
@@ -34,7 +34,7 @@ template <class _InputIt, __enable_if_t<__is_pathable<_InputIt>::value, int> = 0
           is_same<typename __is_pathable<_InputIt>::__char_type, char>::value,
       "u8path(Iter, Iter) requires Iter have a value_type of type 'char'"
       " or 'char8_t'");
-#    if defined(_LIBCPP_WIN32API)
+#    if defined(_WIN32)
   string __tmp(__f, __l);
   using _CVT = __widen_from_utf8<sizeof(wchar_t) * __CHAR_BIT__>;
   std::wstring __w;
@@ -43,11 +43,11 @@ template <class _InputIt, __enable_if_t<__is_pathable<_InputIt>::value, int> = 0
   return path(__w);
 #    else
   return path(__f, __l);
-#    endif // defined(_LIBCPP_WIN32API)
+#    endif // defined(_WIN32)
 }
-#  endif // !defined(_LIBCPP_WIN32API) || _LIBCPP_HAS_LOCALIZATION
+#  endif // !defined(_WIN32) || _LIBCPP_HAS_LOCALIZATION
 
-#  if defined(_LIBCPP_WIN32API) && _LIBCPP_HAS_LOCALIZATION
+#  if defined(_WIN32) && _LIBCPP_HAS_LOCALIZATION
 template <class _InputIt, __enable_if_t<__is_pathable<_InputIt>::value, int> = 0>
 [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(_InputIt __f, _NullSentinel) {
   static_assert(
@@ -67,7 +67,7 @@ template <class _InputIt, __enable_if_t<__is_pathable<_InputIt>::value, int> = 0
   _CVT()(back_inserter(__w), __tmp.data(), __tmp.data() + __tmp.size());
   return path(__w);
 }
-#  endif // defined(_LIBCPP_WIN32API) && _LIBCPP_HAS_LOCALIZATION
+#  endif // defined(_WIN32) && _LIBCPP_HAS_LOCALIZATION
 
 template <class _Source, __enable_if_t<__is_pathable<_Source>::value, int> = 0>
 [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_DEPRECATED_WITH_CHAR8_T path u8path(const _Source& __s) {
@@ -78,7 +78,7 @@ template <class _Source, __enable_if_t<__is_pathable<_Source>::value, int> = 0>
           is_same<typename __is_pathable<_Source>::__char_type, char>::value,
       "u8path(Source const&) requires Source have a character type of type "
       "'char' or 'char8_t'");
-#  if defined(_LIBCPP_WIN32API)
+#  if defined(_WIN32)
   using _Traits = __is_pathable<_Source>;
   return u8path(std::__unwrap_iter(_Traits::__range_begin(__s)), std::__unwrap_iter(_Traits::__range_end(__s)));
 #  else

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -352,7 +352,7 @@ public:
 #    else
   static const mask __regex_word = 0x80;
 #    endif
-#  elif defined(_LIBCPP_MSVCRT_LIKE)
+#  elif defined(_WIN32)
   typedef unsigned short mask;
   static const mask space        = _SPACE;
   static const mask print        = _BLANK | _PUNCT | _ALPHA | _DIGIT;

--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -116,7 +116,7 @@
 #    include <__locale_dir/support/netbsd.h>
 #  elif defined(__OpenBSD__)
 #    include <__locale_dir/support/openbsd.h>
-#  elif defined(_LIBCPP_MSVCRT_LIKE)
+#  elif defined(_WIN32)
 #    include <__locale_dir/support/windows.h>
 #  elif defined(__Fuchsia__)
 #    include <__locale_dir/support/fuchsia.h>

--- a/libcxx/include/__math/gamma.h
+++ b/libcxx/include/__math/gamma.h
@@ -62,7 +62,7 @@ inline _LIBCPP_HIDE_FROM_ABI double tgamma(_A1 __x) _NOEXCEPT {
 // declare it differently in the first place: instead use `asm` to get the compiler to call the right
 // function.
 
-#if defined(_LIBCPP_MSVCRT_LIKE) // reentrant version is not available on Windows
+#ifdef _WIN32 // reentrant version is not available on Windows
 
 inline _LIBCPP_HIDE_FROM_ABI double __lgamma_r(double __d) _NOEXCEPT { return __builtin_lgamma(__d); }
 

--- a/libcxx/include/__ostream/print.h
+++ b/libcxx/include/__ostream/print.h
@@ -89,7 +89,7 @@ _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
 #    if _LIBCPP_HAS_UNICODE
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI void __vprint_unicode(ostream& __os, string_view __fmt, format_args __args, bool __write_nl) {
-#      ifndef _LIBCPP_WIN32API
+#      ifndef _WIN32
   return std::__vprint_nonunicode(__os, __fmt, __args, __write_nl);
 #      else
   FILE* __file = std::__get_ostream_file(__os);
@@ -123,7 +123,7 @@ _LIBCPP_HIDE_FROM_ABI void __vprint_unicode(ostream& __os, string_view __fmt, fo
     __os.__set_badbit_and_consider_rethrow();
   }
 #        endif // _LIBCPP_HAS_EXCEPTIONS
-#      endif   // _LIBCPP_WIN32API
+#      endif   // _WIN32
 }
 
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -222,7 +222,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 
-#    if _LIBCPP_STD_VER >= 23 && defined(_LIBCPP_WIN32API)
+#    if _LIBCPP_STD_VER >= 23 && defined(_WIN32)
 _LIBCPP_EXPORTED_FROM_ABI void* __filebuf_windows_native_handle(FILE* __file) noexcept;
 #    endif
 
@@ -236,7 +236,7 @@ public:
   typedef typename traits_type::off_type off_type;
   typedef typename traits_type::state_type state_type;
 #    if _LIBCPP_STD_VER >= 26
-#      if defined(_LIBCPP_WIN32API)
+#      if defined(_WIN32)
   using native_handle_type = void*; // HANDLE
 #      elif __has_include(<unistd.h>)
   using native_handle_type = int; // POSIX file descriptor
@@ -272,7 +272,7 @@ public:
 #    if _LIBCPP_STD_VER >= 26
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI native_handle_type native_handle() const noexcept {
     _LIBCPP_ASSERT_UNCATEGORIZED(this->is_open(), "File must be opened");
-#      if defined(_LIBCPP_WIN32API)
+#      if defined(_WIN32)
     return std::__filebuf_windows_native_handle(__file_);
 #      elif __has_include(<unistd.h>)
     return fileno(__file_);
@@ -1020,7 +1020,7 @@ basic_filebuf<_CharT, _Traits>::seekoff(off_type __off, ios_base::seekdir __way,
 
 template <class _CharT, class _Traits>
 int basic_filebuf<_CharT, _Traits>::__fseek(FILE* __file, pos_type __offset, int __whence) {
-#    if defined(_LIBCPP_MSVCRT_LIKE)
+#    ifdef _WIN32
   return _fseeki64(__file, __offset, __whence);
 #    elif _LIBCPP_LIBC_NEWLIB
   return fseek(__file, __offset, __whence);
@@ -1031,7 +1031,7 @@ int basic_filebuf<_CharT, _Traits>::__fseek(FILE* __file, pos_type __offset, int
 
 template <class _CharT, class _Traits>
 typename basic_filebuf<_CharT, _Traits>::pos_type basic_filebuf<_CharT, _Traits>::__ftell(FILE* __file) {
-#    if defined(_LIBCPP_MSVCRT_LIKE)
+#    ifdef _WIN32
   return _ftelli64(__file);
 #    elif _LIBCPP_LIBC_NEWLIB
   return ftell(__file);

--- a/libcxx/include/print
+++ b/libcxx/include/print
@@ -56,7 +56,7 @@ namespace std {
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#    ifdef _LIBCPP_WIN32API
+#    ifdef _WIN32
 _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 _LIBCPP_EXPORTED_FROM_ABI bool __is_windows_terminal(FILE* __stream);
 
@@ -73,7 +73,7 @@ _LIBCPP_EXPORTED_FROM_ABI bool __is_windows_terminal(FILE* __stream);
 _LIBCPP_EXPORTED_FROM_ABI void __write_to_windows_console(FILE* __stream, wstring_view __view);
 #      endif // _LIBCPP_HAS_WIDE_CHARACTERS
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
-#    endif   // _LIBCPP_WIN32API
+#    endif   // _WIN32
 
 #    if _LIBCPP_HAS_UNICODE
 // This is the code to transcode UTF-8 to UTF-16. This is used on
@@ -197,7 +197,7 @@ inline constexpr bool __use_unicode_execution_charset = _MSVC_EXECUTION_CHARACTE
 inline constexpr bool __use_unicode_execution_charset = true;
 #    endif
 
-#    ifdef _LIBCPP_WIN32API
+#    ifdef _WIN32
 _LIBCPP_HIDE_FROM_ABI inline bool __is_terminal([[maybe_unused]] FILE* __stream) {
   // The macro _LIBCPP_TESTING_PRINT_IS_TERMINAL is used to change
   // the behavior in the test. This is not part of the public API.
@@ -207,7 +207,7 @@ _LIBCPP_HIDE_FROM_ABI inline bool __is_terminal([[maybe_unused]] FILE* __stream)
   return std::__is_windows_terminal(__stream);
 #      endif
 }
-#    endif // _LIBCPP_WIN32API
+#    endif // _WIN32
 
 [[noreturn]] _LIBCPP_HIDE_FROM_ABI inline void __handle_output_error(FILE* __stream) {
   if (std::feof(__stream))
@@ -251,7 +251,7 @@ _LIBCPP_HIDE_FROM_ABI inline void __output_unicode_windows([[maybe_unused]] FILE
   // the behavior in the test. This is not part of the public API.
 #        ifdef _LIBCPP_TESTING_PRINT_WRITE_TO_WINDOWS_CONSOLE_FUNCTION
   _LIBCPP_TESTING_PRINT_WRITE_TO_WINDOWS_CONSOLE_FUNCTION(__stream, __view);
-#        elif defined(_LIBCPP_WIN32API)
+#        elif defined(_WIN32)
   std::__write_to_windows_console(__stream, __view);
 #        else
   std::__throw_runtime_error("No defintion of _LIBCPP_TESTING_PRINT_WRITE_TO_WINDOWS_CONSOLE_FUNCTION and "
@@ -282,7 +282,7 @@ _LIBCPP_HIDE_FROM_ABI inline void __output_unicode([[maybe_unused]] FILE* __stre
   // so there the call can be forwarded to the non_unicode API. On
   // Windows there is a different API. This API requires transcoding.
 
-#      ifndef _LIBCPP_WIN32API
+#      ifndef _WIN32
   __print::__output_nonunicode(__stream, __text);
 #      elif _LIBCPP_HAS_WIDE_CHARACTERS
   if (__print::__is_terminal(__stream)) {

--- a/libcxx/include/text_encoding
+++ b/libcxx/include/text_encoding
@@ -598,7 +598,7 @@ public:
 
 #    if _LIBCPP_HAS_LOCALIZATION
   [[nodiscard]] _LIBCPP_AVAILABILITY_TEXT_ENCODING_ENVIRONMENT static text_encoding environment() {
-#      if defined(_LIBCPP_WIN32API)
+#      ifdef _WIN32
     return __get_locale_encoding(nullptr);
 #      else
     return __get_locale_encoding("");

--- a/libcxx/include/wchar.h
+++ b/libcxx/include/wchar.h
@@ -195,7 +195,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD wchar_t* wmemchr(wchar_t
 }
 #      endif
 
-#      if defined(__cplusplus) && (defined(_LIBCPP_MSVCRT_LIKE) || defined(__MVS__))
+#      if defined(__cplusplus) && (defined(_WIN32) || defined(__MVS__))
 extern "C" {
 size_t mbsnrtowcs(
     wchar_t* __restrict __dst, const char** __restrict __src, size_t __nmc, size_t __len, mbstate_t* __restrict __ps);

--- a/libcxx/src/chrono.cpp
+++ b/libcxx/src/chrono.cpp
@@ -41,14 +41,14 @@
 #  define _LIBCPP_HAS_CLOCK_GETTIME
 #endif
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  define VC_EXTRA_LEAN
 #  include <windows.h>
 #  if _WIN32_WINNT >= _WIN32_WINNT_WIN8
 #    include <winapifamily.h>
 #  endif
-#endif // defined(_LIBCPP_WIN32API)
+#endif // _WIN32
 
 #if defined(__Fuchsia__)
 #  include <zircon/syscalls.h>
@@ -71,7 +71,7 @@ namespace chrono {
 // system_clock
 //
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 
 #  if _WIN32_WINNT < _WIN32_WINNT_WIN8
 
@@ -184,7 +184,7 @@ static steady_clock::time_point __libcpp_steady_clock_now() {
   return steady_clock::time_point(seconds(tp.tv_sec) + nanoseconds(tp.tv_nsec));
 }
 
-#  elif defined(_LIBCPP_WIN32API)
+#  elif defined(_WIN32)
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms644905(v=vs.85).aspx says:
 //    If the function fails, the return value is zero. <snip>

--- a/libcxx/src/filesystem/directory_iterator.cpp
+++ b/libcxx/src/filesystem/directory_iterator.cpp
@@ -17,7 +17,7 @@
 #include "error.h"
 #include "file_descriptor.h"
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX
 #  include <windows.h>
@@ -30,7 +30,7 @@ _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 
 using detail::ErrorHandler;
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 class __dir_stream {
 public:
   __dir_stream()                               = delete;

--- a/libcxx/src/filesystem/error.h
+++ b/libcxx/src/filesystem/error.h
@@ -23,7 +23,7 @@
 
 #include "format_string.h"
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX
 #  include <windows.h> // ERROR_* macros
@@ -42,7 +42,7 @@ inline error_code capture_errno() {
 }
 
 inline error_code get_last_error() {
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
   return std::error_code(GetLastError(), std::system_category());
 #else
   return capture_errno();

--- a/libcxx/src/filesystem/file_descriptor.h
+++ b/libcxx/src/filesystem/file_descriptor.h
@@ -20,7 +20,7 @@
 #include "posix_compat.h"
 #include "time_utils.h"
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX
 #  include <windows.h>
@@ -30,13 +30,13 @@
 #  include <sys/stat.h>
 #  include <sys/statvfs.h>
 #  include <unistd.h>
-#endif // defined(_LIBCPP_WIN32API)
+#endif // _WIN32
 
 _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 
 namespace detail {
 
-#if !defined(_LIBCPP_WIN32API)
+#ifndef _WIN32
 
 #  if defined(DT_BLK)
 template <class DirEntT, class = decltype(DirEntT::d_type)>
@@ -84,7 +84,7 @@ inline pair<string_view, file_type> posix_readdir(DIR* dir_stream, error_code& e
   }
 }
 
-#else // _LIBCPP_WIN32API
+#else // _WIN32
 
 inline file_type get_file_type(const WIN32_FIND_DATAW& data) {
   if (data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT && data.dwReserved0 == IO_REPARSE_TAG_SYMLINK)
@@ -111,7 +111,7 @@ inline perms get_file_perm(const WIN32_FIND_DATAW& data) {
   return static_cast<perms>(st_mode) & perms::mask;
 }
 
-#endif // !_LIBCPP_WIN32API
+#endif // _WIN32
 
 //                       POSIX HELPERS
 
@@ -128,7 +128,7 @@ struct FileDescriptor {
   static FileDescriptor create(const path* p, error_code& ec, Args... args) {
     ec.clear();
     int fd;
-#ifdef _LIBCPP_WIN32API
+#ifdef _WIN32
     // TODO: most of the filesystem implementation uses native Win32 calls
     // (mostly via posix_compat.h). However, here we use the C-runtime APIs to
     // open a file, because we subsequently pass the C-runtime fd to
@@ -171,7 +171,7 @@ struct FileDescriptor {
 
   void close() noexcept {
     if (fd != -1) {
-#ifdef _LIBCPP_WIN32API
+#ifdef _WIN32
       ::_close(fd);
 #else
       ::close(fd);

--- a/libcxx/src/filesystem/filesystem_clock.cpp
+++ b/libcxx/src/filesystem/filesystem_clock.cpp
@@ -14,11 +14,11 @@
 #include <ratio>
 #include <time.h>
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  include "time_utils.h"
 #endif
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX
 #  include <windows.h>
@@ -51,7 +51,7 @@ _LIBCPP_DIAGNOSTIC_POP
 
 _FilesystemClock::time_point _FilesystemClock::now() noexcept {
   typedef chrono::duration<rep> __secs;
-#if defined(_LIBCPP_WIN32API)
+#if defined(_WIN32)
   typedef chrono::duration<rep, nano> __nsecs;
   FILETIME time;
   GetSystemTimeAsFileTime(&time);

--- a/libcxx/src/filesystem/format_string.h
+++ b/libcxx/src/filesystem/format_string.h
@@ -18,7 +18,7 @@
 #include <cstdio>
 #include <string>
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  define PATHSTR(x) (L##x)
 #  define PATH_CSTR_FMT "\"%ls\""
 #else

--- a/libcxx/src/filesystem/operations.cpp
+++ b/libcxx/src/filesystem/operations.cpp
@@ -26,7 +26,7 @@
 #include "posix_compat.h"
 #include "time_utils.h"
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX
 #  include <windows.h>
@@ -100,7 +100,7 @@ path __canonical(path const& orig_p, error_code* ec) {
   ErrorHandler<path> err("canonical", ec, &orig_p, &cwd);
 
   path p = __do_absolute(orig_p, &cwd, ec);
-#if (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112) || defined(_LIBCPP_WIN32API)
+#if (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112) || defined(_WIN32)
   std::unique_ptr<path::value_type, decltype(&::free)> hold(detail::realpath(p.c_str(), nullptr), &::free);
   if (hold.get() == nullptr)
     return err.report(detail::get_last_error());
@@ -460,7 +460,7 @@ void __copy_symlink(const path& existing_symlink, const path& new_symlink, error
   if (ec && *ec) {
     return;
   }
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
   error_code local_ec;
   if (is_directory(real_path, local_ec))
     __create_directory_symlink(real_path, new_symlink, ec);
@@ -564,7 +564,7 @@ void __create_symlink(path const& from, path const& to, error_code* ec) {
 path __current_path(error_code* ec) {
   ErrorHandler<path> err("current_path", ec);
 
-#if defined(_LIBCPP_WIN32API) || defined(__GLIBC__) || defined(__APPLE__)
+#if defined(_WIN32) || defined(__GLIBC__) || defined(__APPLE__)
   // Common extension outside of POSIX getcwd() spec, without needing to
   // preallocate a buffer. Also supported by a number of other POSIX libcs.
   int size              = 0;
@@ -691,7 +691,7 @@ void __last_write_time(const path& p, file_time_type new_time, error_code* ec) {
   using detail::fs_time;
   ErrorHandler<void> err("last_write_time", ec, &p);
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
   TimeSpec ts;
   if (!fs_time::convert_to_timespec(ts, new_time))
     return err.report(errc::value_too_large);
@@ -819,7 +819,7 @@ bool __remove(const path& p, error_code* ec) {
 //
 // The second implementation is used on platforms where `openat()` & friends are available,
 // and it threads file descriptors through recursive calls to avoid such race conditions.
-#if defined(_LIBCPP_WIN32API) || defined(__MVS__)
+#if defined(_WIN32) || defined(__MVS__)
 #  define REMOVE_ALL_USE_DIRECTORY_ITERATOR
 #endif
 
@@ -996,7 +996,7 @@ file_status __symlink_status(const path& p, error_code* ec) { return detail::pos
 path __temp_directory_path(error_code* ec) {
   ErrorHandler<path> err("temp_directory_path", ec);
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
   wchar_t buf[MAX_PATH];
   DWORD retval = GetTempPathW(MAX_PATH, buf);
   if (!retval)

--- a/libcxx/src/filesystem/path.cpp
+++ b/libcxx/src/filesystem/path.cpp
@@ -417,7 +417,7 @@ path::iterator& path::iterator::__decrement() {
   return *this;
 }
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 ////////////////////////////////////////////////////////////////////////////
 // Windows path conversions
 size_t __wide_to_char(const wstring& str, char* out, size_t outlen) {

--- a/libcxx/src/filesystem/path_parser.h
+++ b/libcxx/src/filesystem/path_parser.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 inline bool isSeparator(path::value_type C) {
   if (C == '/')
     return true;
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
   if (C == '\\')
     return true;
 #endif
@@ -324,7 +324,7 @@ private:
   }
 
   PosPtr consumeRootName(PosPtr P, PosPtr End) const noexcept {
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
     if (PosPtr Ret = consumeDriveLetter(P, End))
       return Ret;
     if (PosPtr Ret = consumeNetworkRoot(P, End))

--- a/libcxx/src/filesystem/posix_compat.h
+++ b/libcxx/src/filesystem/posix_compat.h
@@ -31,7 +31,7 @@
 #include "error.h"
 #include "time_utils.h"
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX
 #  include <io.h>
@@ -47,7 +47,7 @@
 #include <stdlib.h>
 #include <time.h>
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 // This struct isn't defined in the normal Windows SDK, but only in the
 // Windows Driver Kit.
 struct LIBCPP_REPARSE_DATA_BUFFER {
@@ -81,7 +81,7 @@ _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 
 namespace detail {
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 
 // Various C runtime header sets provide more or less of these. As we
 // provide our own implementation, undef all potential defines from the

--- a/libcxx/src/filesystem/time_utils.h
+++ b/libcxx/src/filesystem/time_utils.h
@@ -22,7 +22,7 @@
 #include "error.h"
 #include "format_string.h"
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX
 #  include <windows.h>
@@ -41,7 +41,7 @@ _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 
 namespace detail {
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 // Various C runtime versions (UCRT, or the legacy msvcrt.dll used by
 // some mingw toolchains) provide different stat function implementations,
 // with a number of limitations with respect to what we want from the
@@ -267,7 +267,7 @@ public:
   }
 };
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 using fs_time = time_util<file_time_type, int64_t, TimeSpec>;
 #else
 using fs_time = time_util<file_time_type, time_t, TimeSpec>;
@@ -301,7 +301,7 @@ inline TimeSpec extract_atime(StatT const& st) { return st.st_atim; }
 
 #if _LIBCPP_HAS_FILESYSTEM
 
-#  if !defined(_LIBCPP_WIN32API)
+#  ifndef _WIN32
 inline bool posix_utimes(const path& p, std::array<TimeSpec, 2> const& TS, error_code& ec) {
   TimeVal ConvertedTS[2] = {make_timeval(TS[0]), make_timeval(TS[1])};
   if (::utimes(p.c_str(), ConvertedTS) == -1) {
@@ -329,7 +329,7 @@ inline bool set_file_times(const path& p, std::array<TimeSpec, 2> const& TS, err
 #    endif
 }
 
-#  endif // !_LIBCPP_WIN32API
+#  endif // _WIN32
 
 inline file_time_type __extract_last_write_time(const path& p, const StatT& st, error_code* ec) {
   using detail::fs_time;

--- a/libcxx/src/fstream.cpp
+++ b/libcxx/src/fstream.cpp
@@ -10,7 +10,7 @@
 #include <cstdio>
 #include <fstream>
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX
 #  include <io.h>
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 
 // Confirm that `HANDLE` is `void*` as implemented in `basic_filebuf`
 static_assert(std::same_as<HANDLE, void*>);

--- a/libcxx/src/include/aligned_alloc.h
+++ b/libcxx/src/include/aligned_alloc.h
@@ -27,7 +27,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 //
 // Returns the allocated memory, or `nullptr` on failure.
 inline _LIBCPP_HIDE_FROM_ABI void* __libcpp_aligned_alloc(std::size_t __alignment, std::size_t __size) {
-#  if defined(_LIBCPP_MSVCRT_LIKE)
+#  ifdef _WIN32
   return ::_aligned_malloc(__size, __alignment);
 
 // Android only provides aligned_alloc when targeting API 28 or higher.
@@ -51,7 +51,7 @@ inline _LIBCPP_HIDE_FROM_ABI void* __libcpp_aligned_alloc(std::size_t __alignmen
 }
 
 inline _LIBCPP_HIDE_FROM_ABI void __libcpp_aligned_free(void* __ptr) {
-#  if defined(_LIBCPP_MSVCRT_LIKE)
+#  ifdef _WIN32
   ::_aligned_free(__ptr);
 #  else
   ::free(__ptr);

--- a/libcxx/src/include/config_elast.h
+++ b/libcxx/src/include/config_elast.h
@@ -11,7 +11,7 @@
 
 #include <__config>
 
-#if defined(_LIBCPP_MSVCRT_LIKE)
+#ifdef _WIN32
 #  include <stdlib.h>
 #else
 #  include <errno.h>
@@ -39,7 +39,7 @@
 // No _LIBCPP_ELAST needed on Apple
 #elif defined(__MVS__)
 #  define _LIBCPP_ELAST 1160
-#elif defined(_LIBCPP_MSVCRT_LIKE)
+#elif defined(_WIN32)
 #  define _LIBCPP_ELAST (_sys_nerr - 1)
 #elif defined(_AIX)
 #  define _LIBCPP_ELAST 127

--- a/libcxx/src/iostream.cpp
+++ b/libcxx/src/iostream.cpp
@@ -95,7 +95,7 @@ STREAM(basic_ostream, __stdoutbuf, wchar_t, wclog);
 // the standard streams, otherwise it may not be alive during program termination
 // when we flush the streams.
 static void force_locale_initialization() {
-#if defined(_LIBCPP_MSVCRT_LIKE)
+#ifdef _WIN32
   static bool once = []() {
     auto loc = __locale::__newlocale(_LIBCPP_ALL_MASK, "C", 0);
     {

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -905,7 +905,7 @@ const ctype<char>::mask* ctype<char>::classic_table() noexcept {
   return _C_ctype_tab_ + 1;
 #  elif defined(__GLIBC__)
   return _LIBCPP_GET_C_LOCALE->__ctype_b;
-#  elif defined(_LIBCPP_MSVCRT) || defined(__MINGW32__)
+#  elif defined(_WIN32)
   return __pctype_func();
 #  elif defined(__EMSCRIPTEN__)
   return *__ctype_b_loc();
@@ -5360,19 +5360,19 @@ void moneypunct_byname<char, true>::init(const char* nm) {
     __frac_digits_ = lc->int_frac_digits;
   else
     __frac_digits_ = base::do_frac_digits();
-#if defined(_LIBCPP_MSVCRT) || defined(__MINGW32__)
+#ifdef _WIN32
   if (lc->p_sign_posn == 0)
-#else  // _LIBCPP_MSVCRT
+#else
   if (lc->int_p_sign_posn == 0)
-#endif // !_LIBCPP_MSVCRT
+#endif
     __positive_sign_ = "()";
   else
     __positive_sign_ = lc->positive_sign;
-#if defined(_LIBCPP_MSVCRT) || defined(__MINGW32__)
+#ifdef _WIN32
   if (lc->n_sign_posn == 0)
-#else  // _LIBCPP_MSVCRT
+#else
   if (lc->int_n_sign_posn == 0)
-#endif // !_LIBCPP_MSVCRT
+#endif
     __negative_sign_ = "()";
   else
     __negative_sign_ = lc->negative_sign;
@@ -5380,10 +5380,10 @@ void moneypunct_byname<char, true>::init(const char* nm) {
   // the same places in curr_symbol since there's no way to
   // represent anything else.
   string_type __dummy_curr_symbol = __curr_symbol_;
-#if defined(_LIBCPP_MSVCRT) || defined(__MINGW32__)
+#ifdef _WIN32
   __init_pat(__pos_format_, __dummy_curr_symbol, true, lc->p_cs_precedes, lc->p_sep_by_space, lc->p_sign_posn, ' ');
   __init_pat(__neg_format_, __curr_symbol_, true, lc->n_cs_precedes, lc->n_sep_by_space, lc->n_sign_posn, ' ');
-#else  // _LIBCPP_MSVCRT
+#else  // _WIN32
   __init_pat(
       __pos_format_,
       __dummy_curr_symbol,
@@ -5394,7 +5394,7 @@ void moneypunct_byname<char, true>::init(const char* nm) {
       ' ');
   __init_pat(
       __neg_format_, __curr_symbol_, true, lc->int_n_cs_precedes, lc->int_n_sep_by_space, lc->int_n_sign_posn, ' ');
-#endif // !_LIBCPP_MSVCRT
+#endif // _WIN32
 }
 
 #if _LIBCPP_HAS_WIDE_CHARACTERS
@@ -5477,11 +5477,11 @@ void moneypunct_byname<wchar_t, true>::init(const char* nm) {
     __frac_digits_ = lc->int_frac_digits;
   else
     __frac_digits_ = base::do_frac_digits();
-#  if defined(_LIBCPP_MSVCRT) || defined(__MINGW32__)
+#  ifdef _WIN32
   if (lc->p_sign_posn == 0)
-#  else  // _LIBCPP_MSVCRT
+#  else
   if (lc->int_p_sign_posn == 0)
-#  endif // !_LIBCPP_MSVCRT
+#  endif
     __positive_sign_ = L"()";
   else {
     mb = mbstate_t();
@@ -5492,11 +5492,11 @@ void moneypunct_byname<wchar_t, true>::init(const char* nm) {
     wbe = wbuf + j;
     __positive_sign_.assign(wbuf, wbe);
   }
-#  if defined(_LIBCPP_MSVCRT) || defined(__MINGW32__)
+#  ifdef _WIN32
   if (lc->n_sign_posn == 0)
-#  else  // _LIBCPP_MSVCRT
+#  else
   if (lc->int_n_sign_posn == 0)
-#  endif // !_LIBCPP_MSVCRT
+#  endif
     __negative_sign_ = L"()";
   else {
     mb = mbstate_t();
@@ -5511,10 +5511,10 @@ void moneypunct_byname<wchar_t, true>::init(const char* nm) {
   // the same places in curr_symbol since there's no way to
   // represent anything else.
   string_type __dummy_curr_symbol = __curr_symbol_;
-#  if defined(_LIBCPP_MSVCRT) || defined(__MINGW32__)
+#  ifdef _WIN32
   __init_pat(__pos_format_, __dummy_curr_symbol, true, lc->p_cs_precedes, lc->p_sep_by_space, lc->p_sign_posn, L' ');
   __init_pat(__neg_format_, __curr_symbol_, true, lc->n_cs_precedes, lc->n_sep_by_space, lc->n_sign_posn, L' ');
-#  else  // _LIBCPP_MSVCRT
+#  else  // _WIN32
   __init_pat(
       __pos_format_,
       __dummy_curr_symbol,
@@ -5525,7 +5525,7 @@ void moneypunct_byname<wchar_t, true>::init(const char* nm) {
       L' ');
   __init_pat(
       __neg_format_, __curr_symbol_, true, lc->int_n_cs_precedes, lc->int_n_sep_by_space, lc->int_n_sign_posn, L' ');
-#  endif // !_LIBCPP_MSVCRT
+#  endif // _WIN32
 }
 #endif // _LIBCPP_HAS_WIDE_CHARACTERS
 

--- a/libcxx/src/print.cpp
+++ b/libcxx/src/print.cpp
@@ -15,7 +15,7 @@
 
 #include "filesystem/error.h"
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  define NOMINMAX
 #  include <io.h>
@@ -35,7 +35,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 
 _LIBCPP_EXPORTED_FROM_ABI bool __is_windows_terminal(FILE* __stream) {
   // Note the Standard does this in one call, but it's unclear whether
@@ -65,13 +65,13 @@ __write_to_windows_console([[maybe_unused]] FILE* __stream, [[maybe_unused]] wst
 }
 #  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
-#elif defined(HAS_FILENO_AND_ISATTY) && _LIBCPP_AVAILABILITY_MINIMUM_HEADER_VERSION < 23 // !_LIBCPP_WIN32API
+#elif defined(HAS_FILENO_AND_ISATTY) && _LIBCPP_AVAILABILITY_MINIMUM_HEADER_VERSION < 23
 
 _LIBCPP_DIAGNOSTIC_PUSH
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wmissing-prototypes")
 _LIBCPP_EXPORTED_FROM_ABI bool __is_posix_terminal(FILE* __stream) { return isatty(fileno(__stream)); }
 _LIBCPP_DIAGNOSTIC_POP
-#endif
+#endif // _WIN32
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/src/std_stream.h
+++ b/libcxx/src/std_stream.h
@@ -57,7 +57,7 @@ private:
   bool __last_consumed_is_next_;
   bool __always_noconv_;
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
   static constexpr bool __is_win32api_wide_char = !is_same_v<_CharT, char>;
 #else
   static constexpr bool __is_win32api_wide_char = false;
@@ -262,7 +262,7 @@ private:
   state_type* __st_;
   bool __always_noconv_;
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
   static constexpr bool __is_win32api_wide_char = !is_same_v<_CharT, char>;
 #else
   static constexpr bool __is_win32api_wide_char = false;

--- a/libcxx/src/system_error.cpp
+++ b/libcxx/src/system_error.cpp
@@ -21,7 +21,7 @@
 
 #include "include/config_elast.h"
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  include <windows.h>
 #  include <winerror.h>
 #endif
@@ -29,7 +29,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 
 namespace {
 std::optional<errc> __win_err_to_errc(int err) {
@@ -149,7 +149,7 @@ constexpr size_t strerror_buff_size = 1024;
 
 string do_strerror_r(int ev);
 
-#  if defined(_LIBCPP_MSVCRT_LIKE)
+#  ifdef _WIN32
 string do_strerror_r(int ev) {
   char buffer[strerror_buff_size];
   if (::strerror_s(buffer, strerror_buff_size, ev) == 0)
@@ -272,7 +272,7 @@ public:
 const char* __system_error_category::name() const noexcept { return "system"; }
 
 string __system_error_category::message(int ev) const {
-#ifdef _LIBCPP_WIN32API
+#ifdef _WIN32
   std::string result;
   char* str               = nullptr;
   unsigned long num_chars = ::FormatMessageA(
@@ -304,7 +304,7 @@ string __system_error_category::message(int ev) const {
 }
 
 error_condition __system_error_category::default_error_condition(int ev) const noexcept {
-#ifdef _LIBCPP_WIN32API
+#ifdef _WIN32
   // Remap windows error codes to generic error codes if possible.
   if (ev == 0)
     return error_condition(0, generic_category());

--- a/libcxx/src/thread.cpp
+++ b/libcxx/src/thread.cpp
@@ -24,7 +24,7 @@
 #  pragma weak pthread_create // Do not create libpthread dependency
 #endif
 
-#if defined(_LIBCPP_WIN32API)
+#ifdef _WIN32
 #  include <windows.h>
 #endif
 
@@ -74,7 +74,7 @@ unsigned thread::hardware_concurrency() noexcept {
   if (result < 0)
     return 0;
   return static_cast<unsigned>(result);
-#elif defined(_LIBCPP_WIN32API)
+#elif defined(_WIN32)
   return static_cast<unsigned>(GetActiveProcessorCount(ALL_PROCESSOR_GROUPS));
 #else // defined(CTL_HW) && defined(HW_NCPU)
   // TODO: grovel through /proc or check cpuid on x86 and similar

--- a/libcxx/test/support/count_new.h
+++ b/libcxx/test/support/count_new.h
@@ -450,7 +450,7 @@ void operator delete[](void* p, std::nothrow_t const&) TEST_NOEXCEPT {
 }
 
 #  ifndef TEST_HAS_NO_ALIGNED_ALLOCATION
-#    if defined(_LIBCPP_MSVCRT_LIKE) || (!defined(_LIBCPP_VERSION) && defined(_WIN32))
+#    ifdef _WIN32
 #      define USE_ALIGNED_ALLOC
 #    endif
 


### PR DESCRIPTION
We have multiple macros for different Windows. However, most of them don't actually define different things. We can condense the macros to
- `_WIN32` directly if it only depends on windows, or
- `_LIBCPP_MSVCRT`

This patch drops `_LIBCPP_MSVCRT_LIKE` and `_LIBCPP_WIN32API`, since they are equivalent to `_WIN32`.

