### PR TITLE
[M68k] Add Imm source for MOVE to CCR/SR

### DIFF
--- a/llvm/lib/Target/M68k/M68kInstrData.td
+++ b/llvm/lib/Target/M68k/M68kInstrData.td
@@ -415,8 +415,8 @@ foreach AM = MxMoveSrcAMs in {
   def MOV8c # AM  : MxMoveToCCRPseudo<!cast<MxOpBundle>("MxOp8AddrMode_"#AM).Op>;
 } // foreach AM
 
-// Only data register is allowed.
 def MOV16cd : MxMoveToCCR<MxOp16AddrMode_d.Op, MxMoveSrcOpEnc_d>;
+def MOV16ci : MxMoveToCCR<MxOp16AddrMode_i.Op, MxEncAddrMode_i<"src", 16>>;
 
 /// Move from CCR
 /// --------------------------------------------------
@@ -456,7 +456,6 @@ foreach AM = MxMoveDstAMs in {
     : MxMoveFromCCRPseudo<!cast<MxOpBundle>("MxOp8AddrMode_"#AM).Op>;
 } // foreach AM
 
-// Only data register is allowed.
 def MOV16dc : MxMoveFromCCR_R;
 
 /// Move to SR
@@ -483,6 +482,7 @@ foreach AM = MxMoveSrcAMs in {
 } // foreach AM
 
 def MOV16sd : MxMoveToSR<MxOp16AddrMode_d.Op, MxMoveSrcOpEnc_d>;
+def MOV16si : MxMoveToSR<MxOp16AddrMode_i.Op, MxEncAddrMode_i<"src", 16>>;
 
 /// Move from SR
 /// --------------------------------------------------

--- a/llvm/test/CodeGen/M68k/inline-asm.ll
+++ b/llvm/test/CodeGen/M68k/inline-asm.ll
@@ -152,3 +152,19 @@ entry:
   ret void
 }
 
+define void @move_immediate_to_status_registers() {
+; CHECK-LABEL: move_immediate_to_status_registers:
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0: ; %entry
+; CHECK-NEXT:    ;APP
+; CHECK-NEXT:    move.w #9984, %sr
+; CHECK-NEXT:    ;NO_APP
+; CHECK-NEXT:    ;APP
+; CHECK-NEXT:    move.w #1235, %ccr
+; CHECK-NEXT:    ;NO_APP
+; CHECK-NEXT:    rts
+entry:
+  call void asm sideeffect "move.w #0x2700,%sr", ""()
+  call void asm sideeffect "move.w #1235,%ccr", ""()
+  ret void
+}

--- a/llvm/test/MC/M68k/Data/Classes/MxMoveCCR.s
+++ b/llvm/test/MC/M68k/Data/Classes/MxMoveCCR.s
@@ -4,6 +4,10 @@
 ; CHECK-SAME: encoding: [0x44,0xc1]
 move.w	%d1, %ccr
 
+; CHECK:      move.w  #1235, %ccr
+; CHECK-SAME: encoding: [0x44,0xfc,0x04,0xd3]
+move.w	#1235, %ccr
+
 ; CHECK:      move.w  %ccr, %d1
 ; CHECK-SAME: encoding: [0x42,0xc1]
 move.w	%ccr, %d1

--- a/llvm/test/MC/M68k/Data/Classes/MxMoveSR.s
+++ b/llvm/test/MC/M68k/Data/Classes/MxMoveSR.s
@@ -4,6 +4,10 @@
 ; CHECK-SAME: encoding: [0x46,0xc1]
 move.w	%d1, %sr
 
+; CHECK:      move.w  #9984, %sr
+; CHECK-SAME: encoding: [0x46,0xfc,0x27,0x00]
+move.w	#0x2700, %sr
+
 ; CHECK:      move.w  %sr, %d1
 ; CHECK-SAME: encoding: [0x40,0xc1]
 move.w	%sr, %d1


### PR DESCRIPTION
closes #165077, just adds the imm addressing mode to MOVE to SR/CCR

I used codex/gpt5.5 while making this, verified the encoding looks right against the manual