### PR TITLE
[M68K][GlobalISel] Remove dependency on legal ruleset

### DIFF
--- a/llvm/lib/Target/M68k/GISel/M68kLegalizerInfo.cpp
+++ b/llvm/lib/Target/M68k/GISel/M68kLegalizerInfo.cpp
@@ -47,4 +47,6 @@ M68kLegalizerInfo::M68kLegalizerInfo(const M68kSubtarget &ST) {
       .clampScalar(0, s8, s32);
 
   getActionDefinitionsBuilder(G_PTR_ADD).legalFor({{p0, s32}});
+
+  getActionDefinitionsBuilder(G_TRUNC).alwaysLegal();
 }


### PR DESCRIPTION
This fills in always legal rules, to remove the dependency on the legacy
ruleset. This is not guaranteed to be all the rules, just the ones that appear
in tests.

See #197308