### PR TITLE
[RISCV][MC] Improve diagnostics for Zclsd RV32 GPR pair operands

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZclsd.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZclsd.td
@@ -20,6 +20,8 @@ def GPRPairNoX0RV32Operand : AsmOperandClass {
   let ParserMethod = "parseGPRPair<false>";
   let PredicateMethod = "isGPRPairNoX0";
   let RenderMethod = "addRegOperands";
+  let DiagnosticType = "InvalidGPRPairNoX0RV32";
+  let DiagnosticString = "register pair must start with an even GPR other than x0";
 }
 
 def GPRPairNoX0RV32 : RegisterOperand<GPRPairNoX0> {
@@ -31,6 +33,8 @@ def GPRPairCRV32Operand : AsmOperandClass {
   let ParserMethod = "parseGPRPair<false>";
   let PredicateMethod = "isGPRPairC";
   let RenderMethod = "addRegOperands";
+  let DiagnosticType = "InvalidGPRPairCRV32";
+  let DiagnosticString = "register pair must start with x8, x10, x12, or x14";
 }
 
 def GPRPairCRV32 : RegisterOperand<GPRPairC> {

--- a/llvm/test/MC/RISCV/rv32zclsd-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zclsd-invalid.s
@@ -4,23 +4,23 @@
 c.ld t1, 4(sp)
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-2]]:6: note: register must be a GPR from x8 to x15
-# CHECK: :[[@LINE-3]]:6: note: invalid operand for instruction
+# CHECK: :[[@LINE-3]]:6: note: register pair must start with x8, x10, x12, or x14
 
 c.sd s2, 4(sp)
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-2]]:6: note: register must be a GPR from x8 to x15
-# CHECK: :[[@LINE-3]]:6: note: invalid operand for instruction
+# CHECK: :[[@LINE-3]]:6: note: register pair must start with x8, x10, x12, or x14
 
 ## GPRPairNoX0
 c.ldsp  x0, 4(sp)
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-2]]:9: note: register must be a GPR excluding zero (x0)
-# CHECK: :[[@LINE-3]]:9: note: invalid operand for instruction
+# CHECK: :[[@LINE-3]]:9: note: register pair must start with an even GPR other than x0
 
 c.ldsp  zero, 4(sp)
 # CHECK: :[[@LINE-1]]:1: error: invalid instruction, any one of the following would fix this:
 # CHECK: :[[@LINE-2]]:9: note: register must be a GPR excluding zero (x0)
-# CHECK: :[[@LINE-3]]:9: note: invalid operand for instruction
+# CHECK: :[[@LINE-3]]:9: note: register pair must start with an even GPR other than x0
 
 ## uimm9_lsb000
 c.ldsp t1, 512(sp) # CHECK: :[[@LINE]]:12: error: immediate must be a multiple of 8 bytes in the range [0, 504]


### PR DESCRIPTION
Add dedicated assembler diagnostics for the RV32 GPR pair operands used by
Zclsd compressed load/store pair instructions.

After the RISC-V asm parser started reporting multiple near-miss reasons, these
operands still fell back to the generic "invalid operand for instruction" note.
Give them explicit diagnostic types and messages so invalid register pairs report
the expected pair constraints.