### PR TITLE
[clang][Sema] Fix crash on nested CTAD with InjectedClassNameType

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -100,6 +100,25 @@ public:
 
   TypeSourceInfo *transform(TypeSourceInfo *TSI) { return TransformType(TSI); }
 
+  QualType TransformInjectedClassNameType(TypeLocBuilder &TLB,
+                                          InjectedClassNameTypeLoc TL) {
+    if (!OuterInstantiationArgs)
+      return Base::TransformInjectedClassNameType(TLB, TL);
+
+    ASTContext &Context = SemaRef.getASTContext();
+    const InjectedClassNameType *ICNT = TL.getTypePtr();
+
+    QualType TST =
+        ICNT->getDecl()->getCanonicalTemplateSpecializationType(Context);
+    QualType Result = SemaRef.SubstType(TST, *OuterInstantiationArgs,
+                                        TL.getNameLoc(), DeclarationName());
+    if (Result.isNull())
+      return QualType();
+
+    TLB.pushTrivial(Context, Result, TL.getNameLoc());
+    return Result;
+  }
+
   /// Returns true if it's safe to substitute \p Typedef with
   /// \p OuterInstantiationArgs.
   bool mightReferToOuterTemplateParameters(TypedefNameDecl *Typedef) {

--- a/clang/test/SemaTemplate/GH136813.cpp
+++ b/clang/test/SemaTemplate/GH136813.cpp
@@ -1,0 +1,75 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+namespace GH136813 {
+
+template <typename, typename>
+class C {
+public:
+  template <typename>
+  class C2 { // expected-note {{candidate template ignored}} \
+             // expected-note {{implicit deduction guide declared as}}
+  public:
+    C2(C &) {} // expected-note {{candidate template ignored}} \
+                // expected-note {{implicit deduction guide declared as}}
+  };
+
+  void f() {
+    C2(*this); // expected-error {{no viable constructor or deduction guide}}
+  }
+};
+
+void test_original() {
+  C<int, int>().f(); // expected-note {{in instantiation of member function}}
+}
+
+namespace DeducibleCases {
+
+template <class T>
+struct Outer1 {
+  template <class U>
+  struct Inner {
+    Inner(Outer1, U) {}
+  };
+
+  void f() { Inner(*this, 42); }
+};
+
+template <class T>
+struct Outer2 {
+  template <class U>
+  struct Inner {
+    Inner(Outer2 *, U) {}
+  };
+
+  void f() { Inner(this, 42); }
+};
+
+template <class T>
+struct Outer3 {
+  template <class U>
+  struct Inner {
+    Inner(const Outer3 &, U) {}
+  };
+
+  void f() { Inner(*this, 42); }
+};
+
+template <class T>
+struct Outer4 {
+  template <class U>
+  struct Inner {
+    Inner(Outer4 &&, U) {}
+  };
+
+  void f() { Inner(Outer4{}, 42); }
+};
+
+void test() {
+  Outer1<int>().f();
+  Outer2<int>().f();
+  Outer3<int>().f();
+  Outer4<int>().f();
+}
+
+} // namespace DeducibleCases
+} // namespace GH136813


### PR DESCRIPTION
When generating implicit deduction guides for a nested class template,
an InjectedClassNameType in a constructor parameter can retain template
parameters from the enclosing class.

Expand the injected-class-name to its canonical
TemplateSpecializationType and substitute the outer instantiation
arguments before rebuilding the deduction guide type.

This prevents dangling outer template parameters from reaching
MarkUsedTemplateParameters and causing an out-of-bounds SmallBitVector
access.

Fixes #136813.

Assisted-by: ChatGPT (OpenAI)