### PR TITLE
[clang][bytecode][NFC] Remove unnecessary loop variable

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -3822,7 +3822,7 @@ bool Compiler<Emitter>::VisitCXXScalarValueInitExpr(
     PrimType ElemT = classifyPrim(ElemQT);
 
     // Initialize all fields to 0.
-    for (unsigned I = 0, N = NumElems; I != N; ++I) {
+    for (unsigned I = 0; I != NumElems; ++I) {
       if (!this->visitZeroInitializer(ElemT, ElemQT, E))
         return false;
       if (!this->emitInitElem(ElemT, I, E))


### PR DESCRIPTION
No reason to have the extra `N`.