### PR TITLE
[AMDGPU] Do not copy the range attribute onto a widened kernarg load

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
@@ -319,7 +319,7 @@ static bool lowerKernelArguments(Function &F, const TargetMachine &TM,
     if (Arg.hasAttribute(Attribute::NoUndef))
       Load->setMetadata(LLVMContext::MD_noundef, MDNode::get(Ctx, {}));
 
-    if (Arg.hasAttribute(Attribute::Range)) {
+    if (Arg.hasAttribute(Attribute::Range) && AdjustedArgTy == ArgTy) {
       const ConstantRange &Range =
           Arg.getAttribute(Attribute::Range).getValueAsConstantRange();
       Load->setMetadata(LLVMContext::MD_range,

--- a/llvm/test/CodeGen/AMDGPU/lower-kernargs.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-kernargs.ll
@@ -274,6 +274,27 @@ define amdgpu_kernel void @kern_range_noundef_i32(i32 noundef range(i32 0, 8) %a
   ret void
 }
 
+define amdgpu_kernel void @kern_range_i8(i8 range(i8 0, 4) %arg0) {
+; HSA-LABEL: @kern_range_i8(
+; HSA-NEXT:    [[KERN_RANGE_I8_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
+; HSA-NEXT:    [[ARG0_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_RANGE_I8_KERNARG_SEGMENT]], i64 0
+; HSA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG0_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META0]]
+; HSA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i8
+; HSA-NEXT:    call void (...) @llvm.fake.use(i8 [[TMP2]])
+; HSA-NEXT:    ret void
+;
+; MESA-LABEL: @kern_range_i8(
+; MESA-NEXT:    [[KERN_RANGE_I8_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(260) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
+; MESA-NEXT:    [[ARG0_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_RANGE_I8_KERNARG_SEGMENT]], i64 36
+; MESA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG0_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META0]]
+; MESA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i8
+; MESA-NEXT:    call void (...) @llvm.fake.use(i8 [[TMP2]])
+; MESA-NEXT:    ret void
+;
+  call void (...) @llvm.fake.use(i8 %arg0)
+  ret void
+}
+
 define amdgpu_kernel void @kern_f32(float %arg0) {
 ; HSA-LABEL: @kern_f32(
 ; HSA-NEXT:    [[KERN_F32_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()


### PR DESCRIPTION
Sub-dword args (e.g. i8) are loaded as a full i32 and truncated. Copying the i8 range onto the i32 load is invalid IR, and its bounds are wrong since the upper bytes hold other args

Only copy the range when the load type matches the argument type