### PR TITLE
[libc++] Use _LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23 in <future>

### DIFF
--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -2079,7 +2079,7 @@ _LIBCPP_POP_MACROS
 #    include <thread>
 #  endif
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#  if defined(_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23) && _LIBCPP_STD_VER <= 23
 #    include <sstream>
 #  endif
 


### PR DESCRIPTION
`_LIBCPP_REMOVE_TRANSITIVE_INCLUDES` was used accidentally.
