### PR TITLE
[ELF,test] Fix FileCheck RUN line in gc-sections-keep-shared-start.s

### DIFF
--- a/lld/test/ELF/gc-sections-keep-shared-start.s
+++ b/lld/test/ELF/gc-sections-keep-shared-start.s
@@ -2,12 +2,12 @@
 
 # RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t
 # RUN: ld.lld -shared --gc-sections -o %t1 %t
-# RUN: llvm-readelf --file-headers --symbols %t1
-#   | FileCheck %s
-# CHECK: Entry point address:               0x1000
-# CHECK: 0000000000001000     0 FUNC    LOCAL  HIDDEN     4 _start
-# CHECK: 0000000000001006     0 FUNC    LOCAL  HIDDEN     4 internal
-# CHECK: 0000000000001005     0 FUNC    GLOBAL DEFAULT    4 foobar
+# RUN: llvm-readelf --file-headers --symbols %t1 \
+# RUN:   | FileCheck %s
+# CHECK: Entry point address:               0x1238
+# CHECK: 0000000000001238     0 FUNC    LOCAL  HIDDEN     5 _start
+# CHECK: 000000000000123e     0 FUNC    LOCAL  HIDDEN     5 internal
+# CHECK: 000000000000123d     0 FUNC    GLOBAL DEFAULT    5 foobar
 
 .section .text.start,"ax"
 .globl _start

--- a/lld/test/ELF/gc-sections-keep-shared-start.s
+++ b/lld/test/ELF/gc-sections-keep-shared-start.s
@@ -1,13 +1,12 @@
 # REQUIRES: x86
 
 # RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t
-# RUN: ld.lld -shared --gc-sections -o %t1 %t
-# RUN: llvm-readelf --file-headers --symbols %t1 \
-# RUN:   | FileCheck %s
-# CHECK: Entry point address:               0x1238
-# CHECK: 0000000000001238     0 FUNC    LOCAL  HIDDEN     5 _start
-# CHECK: 000000000000123e     0 FUNC    LOCAL  HIDDEN     5 internal
-# CHECK: 000000000000123d     0 FUNC    GLOBAL DEFAULT    5 foobar
+# RUN: ld.lld -shared --gc-sections -Ttext 0x1000 -o %t1 %t
+# RUN: llvm-readelf -h -s %t1 | FileCheck %s
+# CHECK: Entry point address:               0x1000
+# CHECK: 0000000000001000     0 FUNC    LOCAL  HIDDEN  [[#]] _start
+# CHECK: 0000000000001006     0 FUNC    LOCAL  HIDDEN  [[#]] internal
+# CHECK: 0000000000001005     0 FUNC    GLOBAL DEFAULT [[#]] foobar
 
 .section .text.start,"ax"
 .globl _start


### PR DESCRIPTION
Fix a malformed multiline RUN line. The test previously executed llvm-readelf
but did not pipe its output to FileCheck, so the CHECK lines were not verified.

After enabling FileCheck, update the expected entry point, symbol addresses, and
section index for the current output.