### PR TITLE
[Clang] Require X86 backend for some coroutine tests

### DIFF
--- a/clang/test/CodeGenCoroutines/coro-elide.cpp
+++ b/clang/test/CodeGenCoroutines/coro-elide.cpp
@@ -1,5 +1,8 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O2 -emit-llvm %s -o - | FileCheck %s
 
+// FIXME: Generate wrappers with correct target features.
+// REQUIRES: x86-registered-target
+
 #include "Inputs/coroutine.h"
 
 namespace {

--- a/clang/test/CodeGenCoroutines/coro-halo.cpp
+++ b/clang/test/CodeGenCoroutines/coro-halo.cpp
@@ -3,6 +3,9 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O2 -emit-llvm %s \
 // RUN:   -fcxx-exceptions -fexceptions -o - | FileCheck %s
 
+// FIXME: Generate wrappers with correct target features.
+// REQUIRES: x86-registered-target
+
 #include "Inputs/coroutine.h"
 #include "Inputs/numeric.h"
 

--- a/clang/test/CodeGenCoroutines/pr65018.cpp
+++ b/clang/test/CodeGenCoroutines/pr65018.cpp
@@ -1,6 +1,9 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 \
 // RUN:      -O1 -emit-llvm %s -o - | FileCheck %s
 
+// FIXME: Generate wrappers with correct target features.
+// REQUIRES: x86-registered-target
+
 #include "Inputs/coroutine.h"
 
 // A simple awaiter type with an await_suspend method that can't be


### PR DESCRIPTION
The wrapper functions are generated without target features.
They can still be inlined based on target-specific logic, but this
requires the target to be available.

We should fix this by properly generating the target features,
but for now add a REQUIRES to unbreak the tests.