### PR TITLE
[mlir] Add missing materialization function diag for dialect convertion

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -3387,7 +3387,7 @@ legalizeUnresolvedMaterialization(RewriterBase &rewriter,
         info.getMaterializationKind() == MaterializationKind::Target ? "target"
                                                                      : "source";
     InFlightDiagnostic diag = op.emitError()
-                              << "miss " << direction
+                              << "mismatch " << direction
                               << " materialization function from ("
                               << inputOperands.getTypes() << ") to ("
                               << op.getResultTypes() << ")";
@@ -3396,12 +3396,12 @@ legalizeUnresolvedMaterialization(RewriterBase &rewriter,
     return failure();
   }
 
-  InFlightDiagnostic diag = op->emitError()
-                            << "failed to legalize unresolved materialization "
-                               "from ("
-                            << inputOperands.getTypes() << ") to ("
-                            << op.getResultTypes()
-                            << ") that remained live after conversion";
+  InFlightDiagnostic diag =
+      op->emitError()
+      << "failed to legalize unresolved materialization "
+         "from ("
+      << inputOperands.getTypes() << ") to (" << op.getResultTypes()
+      << ") that remained live after conversion (no type converter specified)";
   diag.attachNote(op->getUsers().begin()->getLoc())
       << "see existing live user here: " << *op->getUsers().begin();
   return failure();

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -3383,6 +3383,17 @@ legalizeUnresolvedMaterialization(RewriterBase &rewriter,
       rewriter.replaceOp(op, newMaterialization);
       return success();
     }
+    StringRef direction =
+        info.getMaterializationKind() == MaterializationKind::Target ? "target"
+                                                                     : "source";
+    InFlightDiagnostic diag = op.emitError()
+                              << "miss " << direction
+                              << " materialization function from ("
+                              << inputOperands.getTypes() << ") to ("
+                              << op.getResultTypes() << ")";
+    diag.attachNote(op->getUsers().begin()->getLoc())
+        << "require this materialization is here";
+    return failure();
   }
 
   InFlightDiagnostic diag = op->emitError()

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -3386,13 +3386,14 @@ legalizeUnresolvedMaterialization(RewriterBase &rewriter,
     StringRef direction =
         info.getMaterializationKind() == MaterializationKind::Target ? "target"
                                                                      : "source";
-    InFlightDiagnostic diag = op.emitError()
-                              << "mismatch " << direction
-                              << " materialization function from ("
-                              << inputOperands.getTypes() << ") to ("
-                              << op.getResultTypes() << ")";
+    InFlightDiagnostic diag =
+        op.emitError()
+        << "failed to legalize unresolved " << direction
+        << " materialization from (" << inputOperands.getTypes() << ") to ("
+        << op.getResultTypes()
+        << ") that remained live after conversion (no matching callback)";
     diag.attachNote(op->getUsers().begin()->getLoc())
-        << "require this materialization is here";
+        << "see existing live user here: " << *op->getUsers().begin();
     return failure();
   }
 

--- a/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
+++ b/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
@@ -45,9 +45,9 @@ func.func @unsupported_argument_type(%arg0: vector<4xi128>) -> vector<4xi64> {
 
 // Ensure this case not crash
 func.func @unsupported_vector(%arg0: vector<2xi1>) {
-  // expected-error@+1 {{failed to legalize unresolved materialization from ('vector<2x2xi32>') to ('vector<2xi64>') that remained live after conversion}}
+  // expected-error@+1 {{miss source materialization function from ('vector<2x2xi32>') to ('vector<2xi64>')}}
   %cst_0 = arith.constant dense<0> : vector<2xi64>
-  // expected-note@+1 {{see existing live user here}}
+  // expected-note@+1 {{require this materialization is here}}
   %0 = vector.mask %arg0 { vector.multi_reduction <xor>, %cst_0, %cst_0 [] : vector<2xi64> to vector<2xi64> } : vector<2xi1> -> vector<2xi64>
   return
 }

--- a/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
+++ b/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
@@ -45,7 +45,7 @@ func.func @unsupported_argument_type(%arg0: vector<4xi128>) -> vector<4xi64> {
 
 // Ensure this case not crash
 func.func @unsupported_vector(%arg0: vector<2xi1>) {
-  // expected-error@+1 {{miss source materialization function from ('vector<2x2xi32>') to ('vector<2xi64>')}}
+  // expected-error@+1 {{mismatch source materialization function from ('vector<2x2xi32>') to ('vector<2xi64>')}}
   %cst_0 = arith.constant dense<0> : vector<2xi64>
   // expected-note@+1 {{require this materialization is here}}
   %0 = vector.mask %arg0 { vector.multi_reduction <xor>, %cst_0, %cst_0 [] : vector<2xi64> to vector<2xi64> } : vector<2xi1> -> vector<2xi64>

--- a/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
+++ b/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
@@ -45,9 +45,9 @@ func.func @unsupported_argument_type(%arg0: vector<4xi128>) -> vector<4xi64> {
 
 // Ensure this case not crash
 func.func @unsupported_vector(%arg0: vector<2xi1>) {
-  // expected-error@+1 {{mismatch source materialization function from ('vector<2x2xi32>') to ('vector<2xi64>')}}
+  // expected-error@+1 {{failed to legalize unresolved source materialization from ('vector<2x2xi32>') to ('vector<2xi64>') that remained live after conversion (no matching callback)}}
   %cst_0 = arith.constant dense<0> : vector<2xi64>
-  // expected-note@+1 {{require this materialization is here}}
+  // expected-note@+1 {{see existing live user here}}
   %0 = vector.mask %arg0 { vector.multi_reduction <xor>, %cst_0, %cst_0 [] : vector<2xi64> to vector<2xi64> } : vector<2xi1> -> vector<2xi64>
   return
 }

--- a/mlir/test/Transforms/test-legalize-type-conversion.mlir
+++ b/mlir/test/Transforms/test-legalize-type-conversion.mlir
@@ -2,7 +2,7 @@
 
 
 func.func @test_invalid_arg_materialization(
-  // expected-error@below {{miss source materialization function from () to ('i16')}}
+  // expected-error@below {{mismatch source materialization function from () to ('i16')}}
   %arg0: i16) {
   // expected-note@below{{require this materialization is here}}
   "foo.return"(%arg0) : (i16) -> ()
@@ -21,7 +21,7 @@ func.func @test_valid_arg_materialization(%arg0: i64) {
 // -----
 
 func.func @test_invalid_result_materialization() {
-  // expected-error@below {{miss source materialization function from ('f64') to ('f16')}}
+  // expected-error@below {{mismatch source materialization function from ('f64') to ('f16')}}
   %result = "test.type_producer"() : () -> f16
   // expected-note@below{{require this materialization is here}}
   "foo.return"(%result) : (f16) -> ()
@@ -30,7 +30,7 @@ func.func @test_invalid_result_materialization() {
 // -----
 
 func.func @test_invalid_result_materialization() {
-  // expected-error@below {{miss source materialization function from ('f64') to ('f16')}}
+  // expected-error@below {{mismatch source materialization function from ('f64') to ('f16')}}
   %result = "test.type_producer"() : () -> f16
   // expected-note@below{{require this materialization is here}}
   "foo.return"(%result) : (f16) -> ()
@@ -50,7 +50,7 @@ func.func @test_transitive_use_materialization() {
 // -----
 
 func.func @test_transitive_use_invalid_materialization() {
-  // expected-error@below {{miss source materialization function from ('f64') to ('f16')}}
+  // expected-error@below {{mismatch source materialization function from ('f64') to ('f16')}}
   %result = "test.another_type_producer"() : () -> f16
   // expected-note@below{{require this materialization is here}}
   "foo.return"(%result) : (f16) -> ()
@@ -102,7 +102,7 @@ func.func @test_block_argument_not_converted() {
 // Make sure argument type changes aren't implicitly forwarded.
 func.func @test_signature_conversion_no_converter() {
   "test.signature_conversion_no_converter"() ({
-  // expected-error@below {{failed to legalize unresolved materialization from ('f64') to ('f32') that remained live after conversion}}
+  // expected-error@below {{failed to legalize unresolved materialization from ('f64') to ('f32') that remained live after conversion (no type converter specified)}}
   ^bb0(%arg0: f32):
     // expected-note@below{{see existing live user here}}
     "test.type_consumer"(%arg0) : (f32) -> ()
@@ -194,7 +194,7 @@ gpu.module @cuda_events {
 // hashes and could differ with LLVM_ENABLE_REVERSE_ITERATION.
 
 func.func @test_deterministic_materialization_order() {
-  // expected-error@below {{miss source materialization function from ('f64') to ('f16')}}
+  // expected-error@below {{mismatch source materialization function from ('f64') to ('f16')}}
   %a = "test.type_producer"() : () -> f16
   %b = "test.type_producer"() : () -> f16
   // expected-note@below {{require this materialization is here}}

--- a/mlir/test/Transforms/test-legalize-type-conversion.mlir
+++ b/mlir/test/Transforms/test-legalize-type-conversion.mlir
@@ -2,9 +2,9 @@
 
 
 func.func @test_invalid_arg_materialization(
-  // expected-error@below {{failed to legalize unresolved materialization from () to ('i16') that remained live after conversion}}
+  // expected-error@below {{miss source materialization function from () to ('i16')}}
   %arg0: i16) {
-  // expected-note@below{{see existing live user here}}
+  // expected-note@below{{require this materialization is here}}
   "foo.return"(%arg0) : (i16) -> ()
 }
 
@@ -21,18 +21,18 @@ func.func @test_valid_arg_materialization(%arg0: i64) {
 // -----
 
 func.func @test_invalid_result_materialization() {
-  // expected-error@below {{failed to legalize unresolved materialization from ('f64') to ('f16') that remained live after conversion}}
+  // expected-error@below {{miss source materialization function from ('f64') to ('f16')}}
   %result = "test.type_producer"() : () -> f16
-  // expected-note@below{{see existing live user here}}
+  // expected-note@below{{require this materialization is here}}
   "foo.return"(%result) : (f16) -> ()
 }
 
 // -----
 
 func.func @test_invalid_result_materialization() {
-  // expected-error@below {{failed to legalize unresolved materialization from ('f64') to ('f16') that remained live after conversion}}
+  // expected-error@below {{miss source materialization function from ('f64') to ('f16')}}
   %result = "test.type_producer"() : () -> f16
-  // expected-note@below{{see existing live user here}}
+  // expected-note@below{{require this materialization is here}}
   "foo.return"(%result) : (f16) -> ()
 }
 
@@ -50,9 +50,9 @@ func.func @test_transitive_use_materialization() {
 // -----
 
 func.func @test_transitive_use_invalid_materialization() {
-  // expected-error@below {{failed to legalize unresolved materialization from ('f64') to ('f16') that remained live after conversion}}
+  // expected-error@below {{miss source materialization function from ('f64') to ('f16')}}
   %result = "test.another_type_producer"() : () -> f16
-  // expected-note@below{{see existing live user here}}
+  // expected-note@below{{require this materialization is here}}
   "foo.return"(%result) : (f16) -> ()
 }
 
@@ -194,9 +194,9 @@ gpu.module @cuda_events {
 // hashes and could differ with LLVM_ENABLE_REVERSE_ITERATION.
 
 func.func @test_deterministic_materialization_order() {
-  // expected-error@below {{failed to legalize unresolved materialization from ('f64') to ('f16') that remained live after conversion}}
+  // expected-error@below {{miss source materialization function from ('f64') to ('f16')}}
   %a = "test.type_producer"() : () -> f16
   %b = "test.type_producer"() : () -> f16
-  // expected-note@below {{see existing live user here}}
+  // expected-note@below {{require this materialization is here}}
   "foo.return"(%a, %b) : (f16, f16) -> ()
 }

--- a/mlir/test/Transforms/test-legalize-type-conversion.mlir
+++ b/mlir/test/Transforms/test-legalize-type-conversion.mlir
@@ -2,9 +2,9 @@
 
 
 func.func @test_invalid_arg_materialization(
-  // expected-error@below {{mismatch source materialization function from () to ('i16')}}
+  // expected-error@below {{failed to legalize unresolved source materialization from () to ('i16') that remained live after conversion (no matching callback)}}
   %arg0: i16) {
-  // expected-note@below{{require this materialization is here}}
+  // expected-note@below{{see existing live user here}}
   "foo.return"(%arg0) : (i16) -> ()
 }
 
@@ -21,18 +21,18 @@ func.func @test_valid_arg_materialization(%arg0: i64) {
 // -----
 
 func.func @test_invalid_result_materialization() {
-  // expected-error@below {{mismatch source materialization function from ('f64') to ('f16')}}
+  // expected-error@below {{failed to legalize unresolved source materialization from ('f64') to ('f16') that remained live after conversion (no matching callback)}}
   %result = "test.type_producer"() : () -> f16
-  // expected-note@below{{require this materialization is here}}
+  // expected-note@below{{see existing live user here}}
   "foo.return"(%result) : (f16) -> ()
 }
 
 // -----
 
 func.func @test_invalid_result_materialization() {
-  // expected-error@below {{mismatch source materialization function from ('f64') to ('f16')}}
+  // expected-error@below {{failed to legalize unresolved source materialization from ('f64') to ('f16') that remained live after conversion (no matching callback)}}
   %result = "test.type_producer"() : () -> f16
-  // expected-note@below{{require this materialization is here}}
+  // expected-note@below{{see existing live user here}}
   "foo.return"(%result) : (f16) -> ()
 }
 
@@ -50,9 +50,9 @@ func.func @test_transitive_use_materialization() {
 // -----
 
 func.func @test_transitive_use_invalid_materialization() {
-  // expected-error@below {{mismatch source materialization function from ('f64') to ('f16')}}
+  // expected-error@below {{failed to legalize unresolved source materialization from ('f64') to ('f16') that remained live after conversion (no matching callback)}}
   %result = "test.another_type_producer"() : () -> f16
-  // expected-note@below{{require this materialization is here}}
+  // expected-note@below{{see existing live user here}}
   "foo.return"(%result) : (f16) -> ()
 }
 
@@ -194,9 +194,9 @@ gpu.module @cuda_events {
 // hashes and could differ with LLVM_ENABLE_REVERSE_ITERATION.
 
 func.func @test_deterministic_materialization_order() {
-  // expected-error@below {{mismatch source materialization function from ('f64') to ('f16')}}
+  // expected-error@below {{failed to legalize unresolved source materialization from ('f64') to ('f16') that remained live after conversion (no matching callback)}}
   %a = "test.type_producer"() : () -> f16
   %b = "test.type_producer"() : () -> f16
-  // expected-note@below {{require this materialization is here}}
+  // expected-note@below {{see existing live user here}}
   "foo.return"(%a, %b) : (f16, f16) -> ()
 }

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -316,7 +316,7 @@ def testConversionPattern():
             apply_partial_conversion(module, target, frozen)
         except MLIRError as e:
             # CHECK: caught exception: partial conversion failed
-            # CHECK: miss target materialization function
+            # CHECK: mismatch target materialization function
             print("caught exception:", e)
 
         t1 = converter.convert_type(IntegerType.get_signless(64))

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -316,7 +316,7 @@ def testConversionPattern():
             apply_partial_conversion(module, target, frozen)
         except MLIRError as e:
             # CHECK: caught exception: partial conversion failed
-            # CHECK: failed to legalize unresolved materialization
+            # CHECK: miss target materialization function
             print("caught exception:", e)
 
         t1 = converter.convert_type(IntegerType.get_signless(64))

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -316,7 +316,7 @@ def testConversionPattern():
             apply_partial_conversion(module, target, frozen)
         except MLIRError as e:
             # CHECK: caught exception: partial conversion failed
-            # CHECK: mismatch target materialization function
+            # CHECK: failed to legalize unresolved target materialization
             print("caught exception:", e)
 
         t1 = converter.convert_type(IntegerType.get_signless(64))


### PR DESCRIPTION
This Patch adds more precise diagnostics for when a pass is missing a target/source materialization function, making it easier to locate the issue in the pass.