### PR TITLE
[CodeGen] Set target features in StartFunction()

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1124,6 +1124,10 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
         getLLVMContext(), VScaleRange->first, VScaleRange->second));
   }
 
+  llvm::AttrBuilder Attrs(getLLVMContext());
+  CGM.GetCPUAndFeaturesAttributes(GD, Attrs);
+  Fn->addFnAttrs(Attrs);
+
   llvm::BasicBlock *EntryBB = createBasicBlock("entry", CurFn);
 
   // Create a marker to make it easy to insert allocas into the entryblock

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -1992,9 +1992,12 @@ private:
   void UpdateMultiVersionNames(GlobalDecl GD, const FunctionDecl *FD,
                                StringRef &CurName);
 
+public:
   bool GetCPUAndFeaturesAttributes(GlobalDecl GD,
                                    llvm::AttrBuilder &AttrBuilder,
                                    bool SetTargetFeatures = true);
+
+private:
   void setNonAliasAttributes(GlobalDecl GD, llvm::GlobalObject *GO);
 
   /// Set function attributes for a function declaration.

--- a/clang/test/CodeGenCoroutines/coro-elide.cpp
+++ b/clang/test/CodeGenCoroutines/coro-elide.cpp
@@ -1,8 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O2 -emit-llvm %s -o - | FileCheck %s
 
-// FIXME: Generate wrappers with correct target features.
-// REQUIRES: x86-registered-target
-
 #include "Inputs/coroutine.h"
 
 namespace {

--- a/clang/test/CodeGenCoroutines/coro-halo.cpp
+++ b/clang/test/CodeGenCoroutines/coro-halo.cpp
@@ -3,9 +3,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O2 -emit-llvm %s \
 // RUN:   -fcxx-exceptions -fexceptions -o - | FileCheck %s
 
-// FIXME: Generate wrappers with correct target features.
-// REQUIRES: x86-registered-target
-
 #include "Inputs/coroutine.h"
 #include "Inputs/numeric.h"
 

--- a/clang/test/CodeGenCoroutines/pr65018.cpp
+++ b/clang/test/CodeGenCoroutines/pr65018.cpp
@@ -1,9 +1,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 \
 // RUN:      -O1 -emit-llvm %s -o - | FileCheck %s
 
-// FIXME: Generate wrappers with correct target features.
-// REQUIRES: x86-registered-target
-
 #include "Inputs/coroutine.h"
 
 // A simple awaiter type with an await_suspend method that can't be


### PR DESCRIPTION
Set target features in StartFunction(), which is in particular used by generateAwaitSuspendWrapper(). This ensures that inlining works without having to rely on target-specific feature compatibility logic (after https://github.com/llvm/llvm-project/pull/205113).

TBH I'm very confused by Clang's attribute assignment logic for functions -- there are *so many* different APIs for setting attributes, and it feels like the attribute assignment is split randomly across them. I don't understand what the layering here is supposed to be.

I initially wanted to move this case from ConstructAttributeList() to StartFunction() entirely, as target-features should only be assigned to definitions, not declarations (as we currently do), but then it turns out that some places only use SetLLVMFunctionAttributes() but not StartFunction(), so that doesn't work.

Or maybe the right fix is to not change StartFunction() at all and instead call SetLLVMFunctionAttributes() from the coro code? But if you're supposed to do that, then why does StartFunction() set any attributes at all?