### PR TITLE
[Clang] Add `std:c++26preview` for MSVC compat

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -963,6 +963,8 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
   automatically enables V3 unwind info (`-fwinx64-eh-unwind=v3`) if no
   explicit unwind version was specified.
 
+- Clang now supports `-std:c++26preview` for compatibility with MSVC. This enables C++26 features.
+
 #### LoongArch Support
 
 - DWARF fission is now compatible with linker relaxations, allowing `-gsplit-dwarf` and `-mrelax`

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -5188,7 +5188,7 @@ Execute ``clang-cl /?`` to see a list of supported options:
       /showIncludes:user      Like /showIncludes but omit system headers
       /showIncludes           Print info about included files to stderr
       /source-charset:<value> Set source encoding, supports only UTF-8
-      /std:<value>            Set language version (c++14,c++17,c++20,c++23preview,c++latest,c11,c17)
+      /std:<value>            Set language version (c++14,c++17,c++20,c++23preview,c++26preview,c++latest,c11,c17)
       /TC                     Treat all source files as C
       /Tc <file>              Treat <file> as C source file
       /TP                     Treat all source files as C++

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9297,7 +9297,7 @@ def _SLASH_execution_charset : CLCompileJoined<"execution-charset:">,
   HelpText<"Set runtime encoding, supports only UTF-8">,
   Alias<fexec_charset_EQ>;
 def _SLASH_std : CLCompileJoined<"std:">,
-  HelpText<"Set language version (c++14,c++17,c++20,c++23preview,c++latest,c11,c17)">;
+  HelpText<"Set language version (c++14,c++17,c++20,c++23preview,c++26preview,c++latest,c11,c17)">;
 def _SLASH_U : CLJoinedOrSeparate<"U">, HelpText<"Undefine macro">,
   MetaVarName<"<macro>">, Alias<U>;
 def _SLASH_validate_charset : CLFlag<"validate-charset">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7693,6 +7693,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                              // TODO add c++23, c++26, c++29 when MSVC supports
                              // it.
                              .Case("c++23preview", "-std=c++23")
+                             .Case("c++26preview", "-std=c++26")
                              .Case("c++latest", "-std=c++2d")
                              .Default("");
       if (IsSYCL) {
@@ -7783,9 +7784,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
        Std->containsValue("c++23") || Std->containsValue("gnu++23") ||
        Std->containsValue("c++23preview") || Std->containsValue("c++2c") ||
        Std->containsValue("gnu++2c") || Std->containsValue("c++26") ||
-       Std->containsValue("gnu++26") || Std->containsValue("c++2d") ||
-       Std->containsValue("gnu++2d") || Std->containsValue("c++latest") ||
-       Std->containsValue("gnu++latest"));
+       Std->containsValue("gnu++26") || Std->containsValue("c++26preview") ||
+       Std->containsValue("c++2d") || Std->containsValue("gnu++2d") ||
+       Std->containsValue("c++latest") || Std->containsValue("gnu++latest"));
   bool HaveModules =
       RenderModulesOptions(C, D, Args, Input, Output, HaveCxx20, CmdArgs);
 

--- a/clang/lib/Tooling/InterpolatingCompilationDatabase.cpp
+++ b/clang/lib/Tooling/InterpolatingCompilationDatabase.cpp
@@ -279,6 +279,8 @@ struct TransferableCommand {
       if (ClangCLMode) {
         if (Std == LangStandard::lang_cxx23)
           Spelling = "c++23preview";
+        else if (Std == LangStandard::lang_cxx26)
+          Spelling = "c++26preview";
         else if (Std == latestLangStandardC())
           Spelling = "clatest";
         else if (Std == latestLangStandardCXX())
@@ -350,6 +352,8 @@ private:
         // Keep in sync with OPT__SLASH_std handling in Clang::ConstructJob().
         if (StringRef(Arg.getValue()) == "c++23preview")
           return LangStandard::lang_cxx23;
+        if (StringRef(Arg.getValue()) == "c++26preview")
+          return LangStandard::lang_cxx26;
         if (StringRef(Arg.getValue()) == "clatest")
           return latestLangStandardC();
         if (StringRef(Arg.getValue()) == "c++latest")

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -624,6 +624,9 @@
 // RUN: %clang_cl -fmsc-version=1900 -TP -std:c++23preview -### -- %s 2>&1 | FileCheck -check-prefix=STDCXX23PREVIEW %s
 // STDCXX23PREVIEW: -std=c++23
 
+// RUN: %clang_cl -fmsc-version=1900 -TP -std:c++26preview -### -- %s 2>&1 | FileCheck -check-prefix=STDCXX26PREVIEW %s
+// STDCXX26PREVIEW: -std=c++26
+
 // RUN: %clang_cl -fmsc-version=1900 -TP -std:c++latest -### -- %s 2>&1 | FileCheck -check-prefix=STDCXXLATEST %s
 // STDCXXLATEST: -std=c++2d
 
@@ -847,7 +850,7 @@
 // EXTERNAL_W0: "-Wno-system-headers"
 // EXTERNAL_Wn: "-Wsystem-headers"
 
-// RUN: %clang_cl -vctoolsdir "" /arm64EC /c -### -- %s 2>&1 | FileCheck --check-prefix=ARM64EC %s 
+// RUN: %clang_cl -vctoolsdir "" /arm64EC /c -### -- %s 2>&1 | FileCheck --check-prefix=ARM64EC %s
 // ARM64EC-NOT: /arm64EC has been overridden by specified target
 // ARM64EC: "-triple" "arm64ec-pc-windows-msvc19.33.0"
 // ARM64EC-SAME: "--dependent-lib=softintrin"


### PR DESCRIPTION
As discussed here https://github.com/llvm/llvm-project/pull/203992#discussion_r3438454092