### PR TITLE
[lldb] Reintroduce ConstString stats

### DIFF
--- a/lldb/include/lldb/Utility/ConstString.h
+++ b/lldb/include/lldb/Utility/ConstString.h
@@ -393,7 +393,10 @@ public:
 
   struct MemoryStats {
     size_t GetBytesTotal() const { return bytes_total; }
+    size_t GetBytesUsed() const { return bytes_used; }
+    size_t GetBytesUnused() const { return bytes_total - bytes_used; }
     size_t bytes_total = 0;
+    size_t bytes_used = 0;
   };
 
   static MemoryStats GetMemoryStats();

--- a/lldb/source/Target/Statistics.cpp
+++ b/lldb/source/Target/Statistics.cpp
@@ -111,6 +111,8 @@ json::Value ModuleStats::ToJSON() const {
 llvm::json::Value ConstStringStats::ToJSON() const {
   json::Object obj;
   obj.try_emplace<int64_t>("bytesTotal", stats.GetBytesTotal());
+  obj.try_emplace<int64_t>("bytesUsed", stats.GetBytesUsed());
+  obj.try_emplace<int64_t>("bytesUnused", stats.GetBytesUnused());
   return obj;
 }
 

--- a/lldb/source/Utility/ConstString.cpp
+++ b/lldb/source/Utility/ConstString.cpp
@@ -139,6 +139,7 @@ public:
       }
 
       std::lock_guard<PoolMutex> lock(pool.m_mutex);
+      pool.used_bytes += string_ref.size();
       StringPoolEntryType &entry =
           *pool.m_string_map
                .insert(std::make_pair(string_ref, nullptr), string_hash)
@@ -160,13 +161,15 @@ public:
 
       // Make or update string pool entry with the mangled counterpart
       StringPool &map = pool.m_string_map;
-      StringPoolEntryType &entry =
-          *map.try_emplace_with_hash(demangled, demangled_hash).first;
+      auto [entry, inserted] =
+          map.try_emplace_with_hash(demangled, demangled_hash);
+      if (inserted)
+        pool.used_bytes += demangled.size();
 
-      entry.second = mangled_ccstr;
+      entry->second = mangled_ccstr;
 
       // Extract the const version of the demangled_cstr
-      demangled_ccstr = entry.getKeyData();
+      demangled_ccstr = entry->getKeyData();
     }
 
     {
@@ -196,6 +199,7 @@ public:
       std::shared_lock<PoolMutex> lock(pool.m_mutex);
       const Allocator &alloc = pool.m_string_map.getAllocator();
       stats.bytes_total += alloc.getTotalMemory();
+      stats.bytes_used += pool.used_bytes;
     }
     return stats;
   }
@@ -204,6 +208,9 @@ protected:
   struct PoolEntry {
     mutable PoolMutex m_mutex;
     StringPool m_string_map;
+    /// The exact number of bytes used by this pool.
+    /// This excludes alignment, padding and redzones.
+    std::size_t used_bytes = 0;
   };
 
   std::array<PoolEntry, 256> m_string_pools;

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -348,6 +348,8 @@ class TestCase(TestBase):
         strings = memory["strings"]
         strings_keys = [
             "bytesTotal",
+            "bytesUsed",
+            "bytesUnused",
         ]
         self.verify_keys(strings, '"strings"', strings_keys, None)
 


### PR DESCRIPTION
These stats were removed in ca59c69132eef55cc42bf8854706590dfddf5584 . This patch restores the stats in their original form by tracking the removed value in our own LLDB-specific counter.