### PR TITLE
[compiler-rt][sanitizer_common] Fix -Wunused-template in test helpers…

### DIFF
--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_mutex_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_mutex_test.cpp
@@ -118,12 +118,6 @@ static void *read_write_thread(void *param) {
   return 0;
 }
 
-template<typename MutexType>
-static void check_locked(MutexType *mtx) {
-  GenericScopedLock<MutexType> l(mtx);
-  mtx->CheckLocked();
-}
-
 TEST(SanitizerCommon, SpinMutex) {
   SpinMutex mtx;
   mtx.Init();

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_test_utils.h
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_test_utils.h
@@ -72,9 +72,8 @@ inline void break_optimization(void *arg) {
 
 // This function returns its parameter but in such a way that compiler
 // can not prove it.
-template<class T>
-NOINLINE
-static T Ident(T t) {
+template <class T>
+NOINLINE T Ident(T t) {
   T ret = t;
   break_optimization(&ret);
   return ret;


### PR DESCRIPTION
`Ident` is a static function template in a test header, so any test TU that never calls it trips `-Wunused-template`. Drop static.

`check_locked` in `sanitizer_mutex_test.cpp` has no callers.

Part of #202945.