### PR TITLE
[libc][bazel] Append '/' to TEST_UNDECLARED_OUTPUTS_DIR

### DIFF
--- a/libc/test/UnitTest/BazelFilePath.cpp
+++ b/libc/test/UnitTest/BazelFilePath.cpp
@@ -23,9 +23,9 @@ CString libc_make_test_file_path_func(const char *file_name) {
   // Do something sensible if not run under bazel, otherwise this may segfault
   // when constructing the string.
   if (UNDECLARED_OUTPUTS_PATH == nullptr)
-    UNDECLARED_OUTPUTS_PATH = "";
+    return cpp::string(file_name);
 
-  return cpp::string(UNDECLARED_OUTPUTS_PATH) + file_name;
+  return cpp::string(UNDECLARED_OUTPUTS_PATH) + "/" + file_name;
 }
 
 } // namespace testing


### PR DESCRIPTION
The environment variable does not end with a slash, so we need to add one. Without this, the tests work, but don't achieve the intended effect of writing to the undeclared outputs dir.