### PR TITLE
[orc-rt] Add SPSSequence serialization from iterator_range.

### DIFF
--- a/orc-rt/include/orc-rt/SimplePackedSerialization.h
+++ b/orc-rt/include/orc-rt/SimplePackedSerialization.h
@@ -37,6 +37,7 @@
 #include "orc-rt/Error.h"
 #include "orc-rt/ExecutorAddress.h"
 #include "orc-rt/bit.h"
+#include "orc-rt/iterator_range.h"
 #include "orc-rt/span.h"
 
 #include <cstring>
@@ -384,6 +385,33 @@ public:
       if (!TBSD::append(S, std::move(E)))
         return false;
     }
+    return true;
+  }
+};
+
+/// Serialization (but no deserialization) from iterator range.
+template <typename SPSElementTagT, typename IteratorT>
+class SPSSerializationTraits<SPSSequence<SPSElementTagT>,
+                             iterator_range<IteratorT>> {
+  static uint64_t rangeSize(const iterator_range<IteratorT> &R) {
+    return std::distance(R.begin(), R.end());
+  }
+
+public:
+  static size_t size(const iterator_range<IteratorT> &R) {
+    size_t Size = SPSArgList<uint64_t>::size(rangeSize(R));
+    for (const auto &E : R)
+      Size += SPSArgList<SPSElementTagT>::size(E);
+    return Size;
+  }
+
+  static bool serialize(SPSOutputBuffer &OB,
+                        const iterator_range<IteratorT> &R) {
+    if (!SPSArgList<uint64_t>::serialize(OB, rangeSize(R)))
+      return false;
+    for (const auto &E : R)
+      if (!SPSArgList<SPSElementTagT>::serialize(OB, E))
+        return false;
     return true;
   }
 };

--- a/orc-rt/unittests/SimplePackedSerializationTest.cpp
+++ b/orc-rt/unittests/SimplePackedSerializationTest.cpp
@@ -113,6 +113,46 @@ TEST(SimplePackedSerializationTest, SequenceSerialization) {
   blobSerializationRoundTrip<SPSSequence<int32_t>, std::vector<int32_t>>(V);
 }
 
+TEST(SimplePackedSerializationTest, IteratorRangeSequenceSerialization) {
+  // iterator_range only supports serialization (no deserialization), and it
+  // shares SPSSequence's wire format. Verify this by serializing from a range
+  // and deserializing into a std::vector.
+  using WireSerialization = SPSArgList<SPSSequence<int32_t>>;
+
+  // Serialize a range, deserialize into a vector, and return the result.
+  auto SerializeRangeToVector = [](const auto &R) {
+    size_t Size = WireSerialization::size(R);
+    auto Buffer = std::make_unique<char[]>(Size);
+    SPSOutputBuffer OB(Buffer.get(), Size);
+    EXPECT_TRUE(WireSerialization::serialize(OB, R));
+
+    SPSInputBuffer IB(Buffer.get(), Size);
+    std::vector<int32_t> DSValue;
+    EXPECT_TRUE(WireSerialization::deserialize(IB, DSValue));
+    return DSValue;
+  };
+
+  std::vector<int32_t> V({1, 2, -47, 139});
+
+  // A full range round-trips to the original, and its serialized size matches
+  // the equivalent vector's.
+  auto R = iterator_range(V);
+  EXPECT_EQ(WireSerialization::size(R), WireSerialization::size(V));
+  EXPECT_EQ(SerializeRangeToVector(R), V);
+
+  // A sub-range serializes only the covered elements (the distinguishing
+  // feature vs. serializing the whole container).
+  EXPECT_EQ(
+      SerializeRangeToVector(iterator_range(V.begin() + 1, V.begin() + 3)),
+      (std::vector<int32_t>{2, -47}));
+
+  // A pointer-backed range (raw pointers have no nested value_type) must also
+  // work, guarding the std::iterator_traits-based element type deduction.
+  int32_t Arr[] = {5, 6, 7};
+  EXPECT_EQ(SerializeRangeToVector(iterator_range(Arr)),
+            (std::vector<int32_t>{5, 6, 7}));
+}
+
 TEST(SimplePackedSerializationTest, ExecutorAddr) {
   int X = 42;
   auto A = ExecutorAddr::fromPtr(&X);


### PR DESCRIPTION
Adds an SPSSerializationTraits specialization that serializes an iterator_range<IteratorT> as an SPSSequence<SPSElementTagT>, matching the wire format of the existing container and span sequence serializers. The element type is deduced via std::iterator_traits, so both class-type iterators and raw pointers are supported.

This lets callers serialize an arbitrary [begin, end) sub-range directly, without first copying the elements into a temporary container. Only serialization is provided: a bare iterator pair has no meaningful deserialization target, so decode into a std::vector (or other sequence type) as usual.

Please enter the commit message for your changes. Lines starting