### PR TITLE
[lldb][Linux] Show si_addr for SIGBUS signals

### DIFF
--- a/lldb/source/Plugins/Process/Utility/LinuxSignals.cpp
+++ b/lldb/source/Plugins/Process/Utility/LinuxSignals.cpp
@@ -119,9 +119,9 @@ void LinuxSignals::Reset() {
   ADD_LINUX_SIGNAL(6,      "SIGABRT",      false,    true,   true,   "abort()/IOT trap", "SIGIOT");
 
   ADD_LINUX_SIGNAL(7,      "SIGBUS",       false,    true,   true,   "bus error");
-  ADD_SIGCODE(SIGBUS, 7, BUS_ADRALN, 1, "illegal alignment");
-  ADD_SIGCODE(SIGBUS, 7, BUS_ADRERR, 2, "illegal address");
-  ADD_SIGCODE(SIGBUS, 7, BUS_OBJERR, 3, "hardware error");
+  ADD_SIGCODE(SIGBUS, 7, BUS_ADRALN, 1, "illegal alignment", SignalCodePrintOption::Address);
+  ADD_SIGCODE(SIGBUS, 7, BUS_ADRERR, 2, "illegal address", SignalCodePrintOption::Address);
+  ADD_SIGCODE(SIGBUS, 7, BUS_OBJERR, 3, "hardware error", SignalCodePrintOption::Address);
 
   ADD_LINUX_SIGNAL(8,      "SIGFPE",       false,    true,   true,   "floating point exception");
   ADD_SIGCODE(SIGFPE, 8, FPE_INTDIV, 1, "integer divide by zero");


### PR DESCRIPTION
The general rule is if si_addr is the same as the PC, we don't show it because it doesn't add any new information.

SIGBUS signals are caused by an instruction trying to do something, but si_addr is not the address of the instruction. It's some virtual address, which is the important bit so add it to the description.

https://man7.org/linux/man-pages/man7/signal.7.html
> SIGBUS <...> Bus error (bad memory access)

Before:
```
* thread #1, name = 'test.o', stop reason = signal SIGBUS: illegal address
  * frame #0: 0x0000aaaaaaaa0b80 test.o`main at test.c:42:13
```
After:
```
* thread #1, name = 'test.o', stop reason = signal SIGBUS: illegal address (fault address=0xfffff7ff6000)
  * frame #0: 0x0000aaaaaaaa0b80 test.o`main at test.c:42:13
```
I am not adding test cases for this because:
* They would be architecture specific.
* Reliably generating BUS_OBJERR seems difficult.
* Signal reporting has good coverage as it is, so we know that si_code/si_addr are handled correctly.