### PR TITLE
[AArch64][InstCombine] Fold zext of all-active SVE cmpne-zero

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -2181,7 +2181,6 @@ static std::optional<Instruction *> instCombineZExtSVECmpNE(InstCombiner &IC,
       !match(II.getOperand(2), m_Zero()))
     return std::nullopt;
 
-  bool Changed = false;
   for (auto *U : II.users()) {
     if (match(U, m_ZExt(m_Specific(&II)))) {
       auto *User = cast<Instruction>(U);
@@ -2194,12 +2193,10 @@ static std::optional<Instruction *> instCombineZExtSVECmpNE(InstCombiner &IC,
           {II.getOperand(0), II.getOperand(1), ConstantInt::get(Ty, 1)});
       IC.replaceInstUsesWith(*User, UMin);
       IC.eraseInstFromFunction(*User);
-      Changed = true;
-    } else
-      continue;
+      return &II;
+    }
   }
-
-  return Changed ? std::optional<Instruction *>(&II) : std::nullopt;
+  return std::nullopt;
 }
 
 static std::optional<Instruction *> instCombineSVECmpNE(InstCombiner &IC,

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -2174,31 +2174,32 @@ static std::optional<Instruction *> instCombineXorSVECmpNE(InstCombiner &IC,
 }
 
 // zext(cmpne(ptrue, %v, 0))
-// -> umin(ptrue, %v, 1)
+// -> umin(%pg, %v, 1)
 static std::optional<Instruction *> instCombineZExtSVECmpNE(InstCombiner &IC,
                                                             IntrinsicInst &II) {
-  if (!isAllActivePredicate(II.getOperand(0)) || !II.hasOneUse())
+  if (!isAllActivePredicate(II.getOperand(0)) ||
+      !match(II.getOperand(2), m_Zero()))
     return std::nullopt;
 
-  Value *Zero = II.getOperand(1);
-  Value *Op = II.getOperand(2);
-  if (!match(Zero, m_Zero())) {
-    std::swap(Zero, Op);
-    if (!match(Zero, m_Zero()))
-      return std::nullopt;
+  bool Changed = false;
+  for (auto *U : II.users()) {
+    if (match(U, m_ZExt(m_Specific(&II)))) {
+      auto *User = cast<Instruction>(U);
+      Type *Ty = II.getOperand(1)->getType();
+      if (User->getType() != Ty)
+        continue;
+      IC.Builder.SetInsertPoint(User);
+      Value *UMin = IC.Builder.CreateIntrinsic(
+          Intrinsic::aarch64_sve_umin, Ty,
+          {II.getOperand(0), II.getOperand(1), ConstantInt::get(Ty, 1)});
+      IC.replaceInstUsesWith(*User, UMin);
+      IC.eraseInstFromFunction(*User);
+      Changed = true;
+    } else
+      continue;
   }
 
-  auto *User = cast<Instruction>(*II.user_begin());
-  if (!match(User, m_ZExt(m_Specific(&II))))
-    return std::nullopt;
-
-  IC.Builder.SetInsertPoint(User);
-  Value *UMin =
-      IC.Builder.CreateIntrinsic(Intrinsic::umin, {Op->getType()},
-                                 {Op, ConstantInt::get(Op->getType(), 1)});
-  IC.replaceInstUsesWith(*User, UMin);
-  IC.eraseInstFromFunction(*User);
-  return &II;
+  return Changed ? std::optional<Instruction *>(&II) : std::nullopt;
 }
 
 static std::optional<Instruction *> instCombineSVECmpNE(InstCombiner &IC,

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -2177,20 +2177,26 @@ static std::optional<Instruction *> instCombineXorSVECmpNE(InstCombiner &IC,
 // -> umin(ptrue, %v, 1)
 static std::optional<Instruction *> instCombineZExtSVECmpNE(InstCombiner &IC,
                                                             IntrinsicInst &II) {
-  if (!isAllActivePredicate(II.getOperand(0)) ||
-      !match(II.getOperand(2), m_Zero()) || !II.hasOneUse())
+  if (!isAllActivePredicate(II.getOperand(0)) || !II.hasOneUse())
     return std::nullopt;
+
+  Value *Zero = II.getOperand(1);
+  Value *Op = II.getOperand(2);
+  if (!match(Zero, m_Zero())) {
+    std::swap(Zero, Op);
+    if (!match(Zero, m_Zero()))
+      return std::nullopt;
+  }
 
   auto *User = cast<Instruction>(*II.user_begin());
   if (!match(User, m_ZExt(m_Specific(&II))))
     return std::nullopt;
 
   IC.Builder.SetInsertPoint(User);
-  Value *UMIN = IC.Builder.CreateIntrinsic(
-      Intrinsic::aarch64_sve_umin, II.getOperand(1)->getType(),
-      {II.getOperand(0), II.getOperand(1),
-       ConstantInt::get(II.getOperand(1)->getType(), 1)});
-  IC.replaceInstUsesWith(*User, UMIN);
+  Value *UMin =
+      IC.Builder.CreateIntrinsic(Intrinsic::umin, {Op->getType()},
+                                 {Op, ConstantInt::get(Op->getType(), 1)});
+  IC.replaceInstUsesWith(*User, UMin);
   IC.eraseInstFromFunction(*User);
   return &II;
 }

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -2173,11 +2173,36 @@ static std::optional<Instruction *> instCombineXorSVECmpNE(InstCombiner &IC,
   return &II;
 }
 
+// zext(cmpne(ptrue, %v, 0))
+// -> umin(ptrue, %v, 1)
+static std::optional<Instruction *> instCombineZExtSVECmpNE(InstCombiner &IC,
+                                                            IntrinsicInst &II) {
+  if (!isAllActivePredicate(II.getOperand(0)) ||
+      !match(II.getOperand(2), m_Zero()) || !II.hasOneUse())
+    return std::nullopt;
+
+  auto *User = cast<Instruction>(*II.user_begin());
+  if (!match(User, m_ZExt(m_Specific(&II))))
+    return std::nullopt;
+
+  IC.Builder.SetInsertPoint(User);
+  Value *UMIN = IC.Builder.CreateIntrinsic(
+      Intrinsic::aarch64_sve_umin, II.getOperand(1)->getType(),
+      {II.getOperand(0), II.getOperand(1),
+       ConstantInt::get(II.getOperand(1)->getType(), 1)});
+  IC.replaceInstUsesWith(*User, UMIN);
+  IC.eraseInstFromFunction(*User);
+  return &II;
+}
+
 static std::optional<Instruction *> instCombineSVECmpNE(InstCombiner &IC,
                                                         IntrinsicInst &II) {
   LLVMContext &Ctx = II.getContext();
 
   if (auto Res = instCombineXorSVECmpNE(IC, II))
+    return Res;
+
+  if (auto Res = instCombineZExtSVECmpNE(IC, II))
     return Res;
 
   if (!isAllActivePredicate(II.getArgOperand(0)))

--- a/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-opts-cmpne.ll
+++ b/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-opts-cmpne.ll
@@ -264,8 +264,7 @@ define <vscale x 16 x i1> @not_cmpne_wrong_xor_operand(<vscale x 16 x i8> %vec_a
 define <vscale x 16 x i8> @zext_cmpne_i8(<vscale x 16 x i8> %vec) #0 {
 ; CHECK-LABEL: define <vscale x 16 x i8> @zext_cmpne_i8(
 ; CHECK-SAME: <vscale x 16 x i8> [[VEC:%.*]]) #[[ATTR0]] {
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <vscale x 16 x i8> [[VEC]], zeroinitializer
-; CHECK-NEXT:    [[ZEXT:%.*]] = zext <vscale x 16 x i1> [[TMP1]] to <vscale x 16 x i8>
+; CHECK-NEXT:    [[ZEXT:%.*]] = call <vscale x 16 x i8> @llvm.aarch64.sve.umin.u.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> [[VEC]], <vscale x 16 x i8> splat (i8 1))
 ; CHECK-NEXT:    ret <vscale x 16 x i8> [[ZEXT]]
 ;
   %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> %vec, <vscale x 16 x i8> zeroinitializer)
@@ -276,7 +275,7 @@ define <vscale x 16 x i8> @zext_cmpne_i8(<vscale x 16 x i8> %vec) #0 {
 define <vscale x 16 x i8> @zext_cmpne_zero_lhs_i8(<vscale x 16 x i8> %vec) #0 {
 ; CHECK-LABEL: define <vscale x 16 x i8> @zext_cmpne_zero_lhs_i8(
 ; CHECK-SAME: <vscale x 16 x i8> [[VEC:%.*]]) #[[ATTR0]] {
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <vscale x 16 x i8> [[VEC]], zeroinitializer
+; CHECK-NEXT:    [[TMP1:%.*]] = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> zeroinitializer, <vscale x 16 x i8> [[VEC]])
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <vscale x 16 x i1> [[TMP1]] to <vscale x 16 x i8>
 ; CHECK-NEXT:    ret <vscale x 16 x i8> [[ZEXT]]
 ;
@@ -288,8 +287,7 @@ define <vscale x 16 x i8> @zext_cmpne_zero_lhs_i8(<vscale x 16 x i8> %vec) #0 {
 define <vscale x 4 x i32> @zext_cmpne_wide_i32(<vscale x 4 x i32> %vec) #0 {
 ; CHECK-LABEL: define <vscale x 4 x i32> @zext_cmpne_wide_i32(
 ; CHECK-SAME: <vscale x 4 x i32> [[VEC:%.*]]) #[[ATTR0]] {
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <vscale x 4 x i32> [[VEC]], zeroinitializer
-; CHECK-NEXT:    [[ZEXT:%.*]] = zext <vscale x 4 x i1> [[TMP1]] to <vscale x 4 x i32>
+; CHECK-NEXT:    [[ZEXT:%.*]] = call <vscale x 4 x i32> @llvm.aarch64.sve.umin.u.nxv4i32(<vscale x 4 x i1> splat (i1 true), <vscale x 4 x i32> [[VEC]], <vscale x 4 x i32> splat (i32 1))
 ; CHECK-NEXT:    ret <vscale x 4 x i32> [[ZEXT]]
 ;
   %cmp = call <vscale x 4 x i1> @llvm.aarch64.sve.cmpne.wide.nxv4i32(<vscale x 4 x i1> splat (i1 true), <vscale x 4 x i32> %vec, <vscale x 2 x i64> zeroinitializer)
@@ -321,18 +319,28 @@ define <vscale x 16 x i8> @zext_cmpne_nonzero_rhs(<vscale x 16 x i8> %vec) #0 {
   ret <vscale x 16 x i8> %zext
 }
 
-define <vscale x 16 x i8> @zext_cmpne_multiple_uses(<vscale x 16 x i8> %vec) #0 {
+define <vscale x 16 x i8> @zext_cmpne_multiple_uses(<vscale x 16 x i8> %vec, <vscale x 16 x i1> %pg) #0 {
 ; CHECK-LABEL: define <vscale x 16 x i8> @zext_cmpne_multiple_uses(
-; CHECK-SAME: <vscale x 16 x i8> [[VEC:%.*]]) #[[ATTR0]] {
+; CHECK-SAME: <vscale x 16 x i8> [[VEC:%.*]], <vscale x 16 x i1> [[PG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[CMP:%.*]] = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> [[VEC]], <vscale x 16 x i8> zeroinitializer)
-; CHECK-NEXT:    call void (...) @llvm.fake.use(<vscale x 16 x i1> [[CMP]])
-; CHECK-NEXT:    [[ZEXT:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+; CHECK-NEXT:    [[AND_1:%.*]] = and <vscale x 16 x i1> [[CMP]], [[PG]]
+; CHECK-NEXT:    call void (...) @llvm.fake.use(<vscale x 16 x i1> [[AND_1]])
+; CHECK-NEXT:    [[ZEXT:%.*]] = call <vscale x 16 x i8> @llvm.aarch64.sve.umin.u.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> [[VEC]], <vscale x 16 x i8> splat (i8 1))
+; CHECK-NEXT:    [[ZEXT_1:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i32>
+; CHECK-NEXT:    call void (...) @llvm.fake.use(<vscale x 16 x i32> [[ZEXT_1]])
 ; CHECK-NEXT:    ret <vscale x 16 x i8> [[ZEXT]]
 ;
   %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> %vec, <vscale x 16 x i8> zeroinitializer)
-  call void (...) @llvm.fake.use(<vscale x 16 x i1> %cmp)
-  %zext = zext <vscale x 16 x i1> %cmp to <vscale x 16 x i8>
-  ret <vscale x 16 x i8> %zext
+
+  %and.1 = and <vscale x 16 x i1> %cmp, %pg
+  call void (...) @llvm.fake.use(<vscale x 16 x i1> %and.1)
+
+  %zext.0 = zext <vscale x 16 x i1> %cmp to <vscale x 16 x i8>
+
+  %zext.1 = zext <vscale x 16 x i1> %cmp to <vscale x 16 x i32>
+  call void (...) @llvm.fake.use(<vscale x 16 x i32> %zext.1)
+
+  ret <vscale x 16 x i8> %zext.0
 }
 
 ; Cases that cannot be converted

--- a/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-opts-cmpne.ll
+++ b/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-opts-cmpne.ll
@@ -264,7 +264,8 @@ define <vscale x 16 x i1> @not_cmpne_wrong_xor_operand(<vscale x 16 x i8> %vec_a
 define <vscale x 16 x i8> @zext_cmpne_i8(<vscale x 16 x i8> %vec) #0 {
 ; CHECK-LABEL: define <vscale x 16 x i8> @zext_cmpne_i8(
 ; CHECK-SAME: <vscale x 16 x i8> [[VEC:%.*]]) #[[ATTR0]] {
-; CHECK-NEXT:    [[ZEXT:%.*]] = call <vscale x 16 x i8> @llvm.aarch64.sve.umin.u.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> [[VEC]], <vscale x 16 x i8> splat (i8 1))
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <vscale x 16 x i8> [[VEC]], zeroinitializer
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext <vscale x 16 x i1> [[TMP1]] to <vscale x 16 x i8>
 ; CHECK-NEXT:    ret <vscale x 16 x i8> [[ZEXT]]
 ;
   %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> %vec, <vscale x 16 x i8> zeroinitializer)
@@ -272,10 +273,23 @@ define <vscale x 16 x i8> @zext_cmpne_i8(<vscale x 16 x i8> %vec) #0 {
   ret <vscale x 16 x i8> %zext
 }
 
+define <vscale x 16 x i8> @zext_cmpne_zero_lhs_i8(<vscale x 16 x i8> %vec) #0 {
+; CHECK-LABEL: define <vscale x 16 x i8> @zext_cmpne_zero_lhs_i8(
+; CHECK-SAME: <vscale x 16 x i8> [[VEC:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <vscale x 16 x i8> [[VEC]], zeroinitializer
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext <vscale x 16 x i1> [[TMP1]] to <vscale x 16 x i8>
+; CHECK-NEXT:    ret <vscale x 16 x i8> [[ZEXT]]
+;
+  %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> zeroinitializer, <vscale x 16 x i8> %vec)
+  %zext = zext <vscale x 16 x i1> %cmp to <vscale x 16 x i8>
+  ret <vscale x 16 x i8> %zext
+}
+
 define <vscale x 4 x i32> @zext_cmpne_wide_i32(<vscale x 4 x i32> %vec) #0 {
 ; CHECK-LABEL: define <vscale x 4 x i32> @zext_cmpne_wide_i32(
 ; CHECK-SAME: <vscale x 4 x i32> [[VEC:%.*]]) #[[ATTR0]] {
-; CHECK-NEXT:    [[ZEXT:%.*]] = call <vscale x 4 x i32> @llvm.aarch64.sve.umin.u.nxv4i32(<vscale x 4 x i1> splat (i1 true), <vscale x 4 x i32> [[VEC]], <vscale x 4 x i32> splat (i32 1))
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <vscale x 4 x i32> [[VEC]], zeroinitializer
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext <vscale x 4 x i1> [[TMP1]] to <vscale x 4 x i32>
 ; CHECK-NEXT:    ret <vscale x 4 x i32> [[ZEXT]]
 ;
   %cmp = call <vscale x 4 x i1> @llvm.aarch64.sve.cmpne.wide.nxv4i32(<vscale x 4 x i1> splat (i1 true), <vscale x 4 x i32> %vec, <vscale x 2 x i64> zeroinitializer)

--- a/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-opts-cmpne.ll
+++ b/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-opts-cmpne.ll
@@ -261,6 +261,66 @@ define <vscale x 16 x i1> @not_cmpne_wrong_xor_operand(<vscale x 16 x i8> %vec_a
   ret <vscale x 16 x i1> %not
 }
 
+define <vscale x 16 x i8> @zext_cmpne_i8(<vscale x 16 x i8> %vec) #0 {
+; CHECK-LABEL: define <vscale x 16 x i8> @zext_cmpne_i8(
+; CHECK-SAME: <vscale x 16 x i8> [[VEC:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[ZEXT:%.*]] = call <vscale x 16 x i8> @llvm.aarch64.sve.umin.u.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> [[VEC]], <vscale x 16 x i8> splat (i8 1))
+; CHECK-NEXT:    ret <vscale x 16 x i8> [[ZEXT]]
+;
+  %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> %vec, <vscale x 16 x i8> zeroinitializer)
+  %zext = zext <vscale x 16 x i1> %cmp to <vscale x 16 x i8>
+  ret <vscale x 16 x i8> %zext
+}
+
+define <vscale x 4 x i32> @zext_cmpne_wide_i32(<vscale x 4 x i32> %vec) #0 {
+; CHECK-LABEL: define <vscale x 4 x i32> @zext_cmpne_wide_i32(
+; CHECK-SAME: <vscale x 4 x i32> [[VEC:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[ZEXT:%.*]] = call <vscale x 4 x i32> @llvm.aarch64.sve.umin.u.nxv4i32(<vscale x 4 x i1> splat (i1 true), <vscale x 4 x i32> [[VEC]], <vscale x 4 x i32> splat (i32 1))
+; CHECK-NEXT:    ret <vscale x 4 x i32> [[ZEXT]]
+;
+  %cmp = call <vscale x 4 x i1> @llvm.aarch64.sve.cmpne.wide.nxv4i32(<vscale x 4 x i1> splat (i1 true), <vscale x 4 x i32> %vec, <vscale x 2 x i64> zeroinitializer)
+  %zext = zext <vscale x 4 x i1> %cmp to <vscale x 4 x i32>
+  ret <vscale x 4 x i32> %zext
+}
+
+define <vscale x 16 x i8> @zext_cmpne_non_ptrue(<vscale x 16 x i8> %vec, <vscale x 16 x i1> %pg) #0 {
+; CHECK-LABEL: define <vscale x 16 x i8> @zext_cmpne_non_ptrue(
+; CHECK-SAME: <vscale x 16 x i8> [[VEC:%.*]], <vscale x 16 x i1> [[PG:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[CMP:%.*]] = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> [[PG]], <vscale x 16 x i8> [[VEC]], <vscale x 16 x i8> zeroinitializer)
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+; CHECK-NEXT:    ret <vscale x 16 x i8> [[ZEXT]]
+;
+  %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> %pg, <vscale x 16 x i8> %vec, <vscale x 16 x i8> zeroinitializer)
+  %zext = zext <vscale x 16 x i1> %cmp to <vscale x 16 x i8>
+  ret <vscale x 16 x i8> %zext
+}
+
+define <vscale x 16 x i8> @zext_cmpne_nonzero_rhs(<vscale x 16 x i8> %vec) #0 {
+; CHECK-LABEL: define <vscale x 16 x i8> @zext_cmpne_nonzero_rhs(
+; CHECK-SAME: <vscale x 16 x i8> [[VEC:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[CMP:%.*]] = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> [[VEC]], <vscale x 16 x i8> splat (i8 1))
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+; CHECK-NEXT:    ret <vscale x 16 x i8> [[ZEXT]]
+;
+  %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> %vec, <vscale x 16 x i8> splat (i8 1))
+  %zext = zext <vscale x 16 x i1> %cmp to <vscale x 16 x i8>
+  ret <vscale x 16 x i8> %zext
+}
+
+define <vscale x 16 x i8> @zext_cmpne_multiple_uses(<vscale x 16 x i8> %vec) #0 {
+; CHECK-LABEL: define <vscale x 16 x i8> @zext_cmpne_multiple_uses(
+; CHECK-SAME: <vscale x 16 x i8> [[VEC:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[CMP:%.*]] = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> [[VEC]], <vscale x 16 x i8> zeroinitializer)
+; CHECK-NEXT:    call void (...) @llvm.fake.use(<vscale x 16 x i1> [[CMP]])
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext <vscale x 16 x i1> [[CMP]] to <vscale x 16 x i8>
+; CHECK-NEXT:    ret <vscale x 16 x i8> [[ZEXT]]
+;
+  %cmp = call <vscale x 16 x i1> @llvm.aarch64.sve.cmpne.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> %vec, <vscale x 16 x i8> zeroinitializer)
+  call void (...) @llvm.fake.use(<vscale x 16 x i1> %cmp)
+  %zext = zext <vscale x 16 x i1> %cmp to <vscale x 16 x i8>
+  ret <vscale x 16 x i8> %zext
+}
+
 ; Cases that cannot be converted
 
 define <vscale x 2 x i1> @dupq_neg1() #0 {


### PR DESCRIPTION
Fold zext(cmpne(ptrue, x, 0)) to umin(ptrue, x, 1).

Do not fold non-ptrue predicates, since cmpne zeros inactive lanes and umin merges inactive lanes