### PR TITLE
[PowerPC] Fix combineSignExtendSetCC() for large/small types

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -16164,7 +16164,7 @@ SDValue PPCTargetLowering::combineSignExtendSetCC(SDNode *N,
     return SDValue();
 
   EVT VT = N->getValueType(0);
-  if (VT != MVT::i32 && VT != MVT::i64)
+  if (VT != MVT::i32 && (VT != MVT::i64 || !Subtarget.isPPC64()))
     return SDValue();
 
   SDValue N0 = N->getOperand(0);
@@ -16184,17 +16184,14 @@ SDValue PPCTargetLowering::combineSignExtendSetCC(SDNode *N,
   SDValue X = isNullConstant(LHS) ? RHS : LHS;
   EVT XVT = X.getValueType(); // The type of x in the setcc x, 0, eq.
 
-  if ((XVT == MVT::i64 || VT == MVT::i64) && !Subtarget.isPPC64())
+  // The type that ADDC/SUBE operate on. Reject larger types and zero-extend
+  // smaller ones.
+  MVT OpVT = Subtarget.isPPC64() ? MVT::i64 : MVT::i32;
+  if (XVT.bitsGT(OpVT))
     return SDValue();
 
-  // On PPC64, i32 carry operations use the full 64-bit XER register,
-  // so we must use i64 operations to avoid incorrect results.
-  // Use i64 operations and truncate the result if needed.
-  if (XVT != MVT::i64 && Subtarget.isPPC64())
-    // Zero-extend if input type is not 64bits.
-    X = DAG.getNode(ISD::ZERO_EXTEND, dl, MVT::i64, X);
-
-  EVT OpVT = Subtarget.isPPC64() ? MVT::i64 : MVT::i32;
+  if (XVT.bitsLT(OpVT))
+    X = DAG.getNode(ISD::ZERO_EXTEND, dl, OpVT, X);
 
   // Generate: SUBFE(ADDC(X, -1)).
   SDValue MinusOne = DAG.getAllOnesConstant(dl, OpVT);

--- a/llvm/test/CodeGen/PowerPC/test-issue-98598.ll
+++ b/llvm/test/CodeGen/PowerPC/test-issue-98598.ll
@@ -24,6 +24,46 @@ entry:
   ret i8 %conv2
 }
 
+define i32 @compare8(i8 %conv1) {
+; CHECK-32BIT-LABEL: compare8:
+; CHECK-32BIT:       # %bb.0: # %entry
+; CHECK-32BIT-NEXT:    clrlwi r3, r3, 24
+; CHECK-32BIT-NEXT:    addic r3, r3, -1
+; CHECK-32BIT-NEXT:    subfe r3, r3, r3
+; CHECK-32BIT-NEXT:    blr
+;
+; CHECK-64BIT-LABEL: compare8:
+; CHECK-64BIT:       # %bb.0: # %entry
+; CHECK-64BIT-NEXT:    clrldi r3, r3, 56
+; CHECK-64BIT-NEXT:    addic r3, r3, -1
+; CHECK-64BIT-NEXT:    subfe r3, r3, r3
+; CHECK-64BIT-NEXT:    blr
+entry:
+  %tobool2.not = icmp eq i8 %conv1, 0
+  %cond = sext i1 %tobool2.not to i32
+  ret i32 %cond
+}
+
+define i32 @compare16(i16 %conv1) {
+; CHECK-32BIT-LABEL: compare16:
+; CHECK-32BIT:       # %bb.0: # %entry
+; CHECK-32BIT-NEXT:    clrlwi r3, r3, 16
+; CHECK-32BIT-NEXT:    addic r3, r3, -1
+; CHECK-32BIT-NEXT:    subfe r3, r3, r3
+; CHECK-32BIT-NEXT:    blr
+;
+; CHECK-64BIT-LABEL: compare16:
+; CHECK-64BIT:       # %bb.0: # %entry
+; CHECK-64BIT-NEXT:    clrldi r3, r3, 48
+; CHECK-64BIT-NEXT:    addic r3, r3, -1
+; CHECK-64BIT-NEXT:    subfe r3, r3, r3
+; CHECK-64BIT-NEXT:    blr
+entry:
+  %tobool2.not = icmp eq i16 %conv1, 0
+  %cond = sext i1 %tobool2.not to i32
+  ret i32 %cond
+}
+
 define i32 @compare32(i64 %conv1) {
 ; CHECK-32BIT-LABEL: compare32:
 ; CHECK-32BIT:       # %bb.0: # %entry
@@ -59,6 +99,29 @@ define i64 @compare64(i32 %conv1) {
 ; CHECK-64BIT-NEXT:    blr
 entry:
   %tobool2.not = icmp eq i32 %conv1, 0
+  %cond = sext i1 %tobool2.not to i64
+  ret i64 %cond
+}
+
+define i64 @compare128(i128 %conv1) {
+; CHECK-32BIT-LABEL: compare128:
+; CHECK-32BIT:       # %bb.0: # %entry
+; CHECK-32BIT-NEXT:    or r3, r5, r3
+; CHECK-32BIT-NEXT:    or r4, r6, r4
+; CHECK-32BIT-NEXT:    or r3, r4, r3
+; CHECK-32BIT-NEXT:    addic r3, r3, -1
+; CHECK-32BIT-NEXT:    subfe r3, r3, r3
+; CHECK-32BIT-NEXT:    mr r4, r3
+; CHECK-32BIT-NEXT:    blr
+;
+; CHECK-64BIT-LABEL: compare128:
+; CHECK-64BIT:       # %bb.0: # %entry
+; CHECK-64BIT-NEXT:    or r3, r3, r4
+; CHECK-64BIT-NEXT:    addic r3, r3, -1
+; CHECK-64BIT-NEXT:    subfe r3, r3, r3
+; CHECK-64BIT-NEXT:    blr
+entry:
+  %tobool2.not = icmp eq i128 %conv1, 0
   %cond = sext i1 %tobool2.not to i64
   ret i64 %cond
 }


### PR DESCRIPTION
The code should reject larger types (like i128) and zero-extend smaller types (like i8 and i16). Consolidate the handling based on being smaller/larger than OpVT to reduce the number of PPC64 conditions.