### PR TITLE
[AArch64] Add missing TB(N)Z achors to arith+CBZ clustering

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64MacroFusion.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MacroFusion.cpp
@@ -73,7 +73,11 @@ static bool isArithmeticCbzPair(const MachineInstr *FirstMI,
   if (SecondMI.getOpcode() != AArch64::CBZW &&
       SecondMI.getOpcode() != AArch64::CBZX &&
       SecondMI.getOpcode() != AArch64::CBNZW &&
-      SecondMI.getOpcode() != AArch64::CBNZX)
+      SecondMI.getOpcode() != AArch64::CBNZX &&
+      SecondMI.getOpcode() != AArch64::TBZW &&
+      SecondMI.getOpcode() != AArch64::TBZX &&
+      SecondMI.getOpcode() != AArch64::TBNZW &&
+      SecondMI.getOpcode() != AArch64::TBNZX)
     return false;
 
   // Assume the 1st instr to be a wildcard if it is unspecified.

--- a/llvm/test/CodeGen/AArch64/misched-fusion-arith-cbz.ll
+++ b/llvm/test/CodeGen/AArch64/misched-fusion-arith-cbz.ll
@@ -41,6 +41,42 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: addwri_tbz:
+; CHECK:      add  [[R:w[0-9]+]], {{w[0-9]+}}, #13
+; CHECK-NEXT: tbz  [[R]], #8, {{.?LBB[0-9_]+}}
+define void @addwri_tbz(i32 %a) {
+entry:
+  %v0 = add i32 %a, 13
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp ne i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: addwri_tbnz:
+; CHECK:      add  [[R:w[0-9]+]], {{w[0-9]+}}, #13
+; CHECK-NEXT: tbnz [[R]], #8, {{.?LBB[0-9_]+}}
+define void @addwri_tbnz(i32 %a) {
+entry:
+  %v0 = add i32 %a, 13
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp eq i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
 ; CHECK-LABEL: addwrr_cbz:
 ; CHECK:      add  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -66,6 +102,42 @@ entry:
   %v0 = add i32 %a, %b
   %v1 = add i32 %a, 7
   %cond = icmp eq i32 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: addwrr_tbz:
+; CHECK:      add  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #8, {{.?LBB[0-9_]+}}
+define void @addwrr_tbz(i32 %a, i32 %b) {
+entry:
+  %v0 = add i32 %a, %b
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp ne i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: addwrr_tbnz:
+; CHECK:      add  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #8, {{.?LBB[0-9_]+}}
+define void @addwrr_tbnz(i32 %a, i32 %b) {
+entry:
+  %v0 = add i32 %a, %b
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp eq i32 %t, 0
   br i1 %cond, label %if, label %exit
 if:
   call void @fi32(i32 %v1, i32 %v0)
@@ -109,6 +181,10 @@ exit:
   ret void
 }
 
+; NOTE: no andwri_tbz/andwri_tbnz: a single-bit test of an immediate-AND result folds
+; through the AND, so no fused ANDri+TB(N)Z pair is expressible at the IR level.
+; The .mir test covers ANDWri + TB(N)Z directly.
+
 ; CHECK-LABEL: andwrr_cbz:
 ; CHECK:      and  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -134,6 +210,42 @@ entry:
   %v0 = and i32 %a, %b
   %v1 = add i32 %a, 7
   %cond = icmp eq i32 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: andwrr_tbz:
+; CHECK:      and  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #8, {{.?LBB[0-9_]+}}
+define void @andwrr_tbz(i32 %a, i32 %b) {
+entry:
+  %v0 = and i32 %a, %b
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp ne i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: andwrr_tbnz:
+; CHECK:      and  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #8, {{.?LBB[0-9_]+}}
+define void @andwrr_tbnz(i32 %a, i32 %b) {
+entry:
+  %v0 = and i32 %a, %b
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp eq i32 %t, 0
   br i1 %cond, label %if, label %exit
 if:
   call void @fi32(i32 %v1, i32 %v0)
@@ -177,6 +289,42 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: eorwri_tbz:
+; CHECK:      eor  [[R:w[0-9]+]], {{w[0-9]+}}, #0xff
+; CHECK-NEXT: tbz  [[R]], #8, {{.?LBB[0-9_]+}}
+define void @eorwri_tbz(i32 %a) {
+entry:
+  %v0 = xor i32 %a, 255
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp ne i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: eorwri_tbnz:
+; CHECK:      eor  [[R:w[0-9]+]], {{w[0-9]+}}, #0xff
+; CHECK-NEXT: tbnz [[R]], #8, {{.?LBB[0-9_]+}}
+define void @eorwri_tbnz(i32 %a) {
+entry:
+  %v0 = xor i32 %a, 255
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp eq i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
 ; CHECK-LABEL: eorwrr_cbz:
 ; CHECK:      eor  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -202,6 +350,42 @@ entry:
   %v0 = xor i32 %a, %b
   %v1 = add i32 %a, 7
   %cond = icmp eq i32 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: eorwrr_tbz:
+; CHECK:      eor  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #8, {{.?LBB[0-9_]+}}
+define void @eorwrr_tbz(i32 %a, i32 %b) {
+entry:
+  %v0 = xor i32 %a, %b
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp ne i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: eorwrr_tbnz:
+; CHECK:      eor  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #8, {{.?LBB[0-9_]+}}
+define void @eorwrr_tbnz(i32 %a, i32 %b) {
+entry:
+  %v0 = xor i32 %a, %b
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp eq i32 %t, 0
   br i1 %cond, label %if, label %exit
 if:
   call void @fi32(i32 %v1, i32 %v0)
@@ -245,6 +429,42 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: orrwri_tbz:
+; CHECK:      orr  [[R:w[0-9]+]], {{w[0-9]+}}, #0xff
+; CHECK-NEXT: tbz  [[R]], #8, {{.?LBB[0-9_]+}}
+define void @orrwri_tbz(i32 %a) {
+entry:
+  %v0 = or i32 %a, 255
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp ne i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: orrwri_tbnz:
+; CHECK:      orr  [[R:w[0-9]+]], {{w[0-9]+}}, #0xff
+; CHECK-NEXT: tbnz [[R]], #8, {{.?LBB[0-9_]+}}
+define void @orrwri_tbnz(i32 %a) {
+entry:
+  %v0 = or i32 %a, 255
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp eq i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
 ; CHECK-LABEL: orrwrr_cbz:
 ; CHECK:      orr  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -270,6 +490,42 @@ entry:
   %v0 = or i32 %a, %b
   %v1 = add i32 %a, 7
   %cond = icmp eq i32 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: orrwrr_tbz:
+; CHECK:      orr  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #8, {{.?LBB[0-9_]+}}
+define void @orrwrr_tbz(i32 %a, i32 %b) {
+entry:
+  %v0 = or i32 %a, %b
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp ne i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: orrwrr_tbnz:
+; CHECK:      orr  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #8, {{.?LBB[0-9_]+}}
+define void @orrwrr_tbnz(i32 %a, i32 %b) {
+entry:
+  %v0 = or i32 %a, %b
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp eq i32 %t, 0
   br i1 %cond, label %if, label %exit
 if:
   call void @fi32(i32 %v1, i32 %v0)
@@ -315,6 +571,44 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: ornwrr_tbz:
+; CHECK:      orn  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #8, {{.?LBB[0-9_]+}}
+define void @ornwrr_tbz(i32 %a, i32 %b) {
+entry:
+  %n = xor i32 %b, -1
+  %v0 = or i32 %a, %n
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp ne i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: ornwrr_tbnz:
+; CHECK:      orn  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #8, {{.?LBB[0-9_]+}}
+define void @ornwrr_tbnz(i32 %a, i32 %b) {
+entry:
+  %n = xor i32 %b, -1
+  %v0 = or i32 %a, %n
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp eq i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
 ; CHECK-LABEL: bicwrr_cbz:
 ; CHECK:      bic  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -342,6 +636,44 @@ entry:
   %v0 = and i32 %a, %n
   %v1 = add i32 %a, 7
   %cond = icmp eq i32 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: bicwrr_tbz:
+; CHECK:      bic  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #8, {{.?LBB[0-9_]+}}
+define void @bicwrr_tbz(i32 %a, i32 %b) {
+entry:
+  %n = xor i32 %b, -1
+  %v0 = and i32 %a, %n
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp ne i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: bicwrr_tbnz:
+; CHECK:      bic  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #8, {{.?LBB[0-9_]+}}
+define void @bicwrr_tbnz(i32 %a, i32 %b) {
+entry:
+  %n = xor i32 %b, -1
+  %v0 = and i32 %a, %n
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp eq i32 %t, 0
   br i1 %cond, label %if, label %exit
 if:
   call void @fi32(i32 %v1, i32 %v0)
@@ -385,6 +717,42 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: subwri_tbz:
+; CHECK:      sub  [[R:w[0-9]+]], {{w[0-9]+}}, #13
+; CHECK-NEXT: tbz  [[R]], #8, {{.?LBB[0-9_]+}}
+define void @subwri_tbz(i32 %a) {
+entry:
+  %v0 = sub i32 %a, 13
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp ne i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: subwri_tbnz:
+; CHECK:      sub  [[R:w[0-9]+]], {{w[0-9]+}}, #13
+; CHECK-NEXT: tbnz [[R]], #8, {{.?LBB[0-9_]+}}
+define void @subwri_tbnz(i32 %a) {
+entry:
+  %v0 = sub i32 %a, 13
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp eq i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
 ; CHECK-LABEL: subwrr_cbz:
 ; CHECK:      sub  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -410,6 +778,42 @@ entry:
   %v0 = sub i32 %a, %b
   %v1 = add i32 %a, 7
   %cond = icmp eq i32 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: subwrr_tbz:
+; CHECK:      sub  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #8, {{.?LBB[0-9_]+}}
+define void @subwrr_tbz(i32 %a, i32 %b) {
+entry:
+  %v0 = sub i32 %a, %b
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp ne i32 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: subwrr_tbnz:
+; CHECK:      sub  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #8, {{.?LBB[0-9_]+}}
+define void @subwrr_tbnz(i32 %a, i32 %b) {
+entry:
+  %v0 = sub i32 %a, %b
+  %v1 = add i32 %a, 7
+  %t = and i32 %v0, 256
+  %cond = icmp eq i32 %t, 0
   br i1 %cond, label %if, label %exit
 if:
   call void @fi32(i32 %v1, i32 %v0)
@@ -453,6 +857,42 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: addxri_tbz:
+; CHECK:      add  [[R:x[0-9]+]], {{x[0-9]+}}, #13
+; CHECK-NEXT: tbz  [[R]], #32, {{.?LBB[0-9_]+}}
+define void @addxri_tbz(i64 %a) {
+entry:
+  %v0 = add i64 %a, 13
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp ne i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: addxri_tbnz:
+; CHECK:      add  [[R:x[0-9]+]], {{x[0-9]+}}, #13
+; CHECK-NEXT: tbnz [[R]], #32, {{.?LBB[0-9_]+}}
+define void @addxri_tbnz(i64 %a) {
+entry:
+  %v0 = add i64 %a, 13
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp eq i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
 ; CHECK-LABEL: addxrr_cbz:
 ; CHECK:      add  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -478,6 +918,42 @@ entry:
   %v0 = add i64 %a, %b
   %v1 = add i64 %a, 7
   %cond = icmp eq i64 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: addxrr_tbz:
+; CHECK:      add  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #32, {{.?LBB[0-9_]+}}
+define void @addxrr_tbz(i64 %a, i64 %b) {
+entry:
+  %v0 = add i64 %a, %b
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp ne i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: addxrr_tbnz:
+; CHECK:      add  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #32, {{.?LBB[0-9_]+}}
+define void @addxrr_tbnz(i64 %a, i64 %b) {
+entry:
+  %v0 = add i64 %a, %b
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp eq i64 %t, 0
   br i1 %cond, label %if, label %exit
 if:
   call void @fi64(i64 %v1, i64 %v0)
@@ -521,6 +997,10 @@ exit:
   ret void
 }
 
+; NOTE: no andxri_tbz/andxri_tbnz: a single-bit test of an immediate-AND result folds
+; through the AND, so no fused ANDri+TB(N)Z pair is expressible at the IR level.
+; The .mir test covers ANDXri + TB(N)Z directly.
+
 ; CHECK-LABEL: andxrr_cbz:
 ; CHECK:      and  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -546,6 +1026,42 @@ entry:
   %v0 = and i64 %a, %b
   %v1 = add i64 %a, 7
   %cond = icmp eq i64 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: andxrr_tbz:
+; CHECK:      and  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #32, {{.?LBB[0-9_]+}}
+define void @andxrr_tbz(i64 %a, i64 %b) {
+entry:
+  %v0 = and i64 %a, %b
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp ne i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: andxrr_tbnz:
+; CHECK:      and  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #32, {{.?LBB[0-9_]+}}
+define void @andxrr_tbnz(i64 %a, i64 %b) {
+entry:
+  %v0 = and i64 %a, %b
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp eq i64 %t, 0
   br i1 %cond, label %if, label %exit
 if:
   call void @fi64(i64 %v1, i64 %v0)
@@ -589,6 +1105,42 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: eorxri_tbz:
+; CHECK:      eor  [[R:x[0-9]+]], {{x[0-9]+}}, #0xff
+; CHECK-NEXT: tbz  [[R]], #32, {{.?LBB[0-9_]+}}
+define void @eorxri_tbz(i64 %a) {
+entry:
+  %v0 = xor i64 %a, 255
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp ne i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: eorxri_tbnz:
+; CHECK:      eor  [[R:x[0-9]+]], {{x[0-9]+}}, #0xff
+; CHECK-NEXT: tbnz [[R]], #32, {{.?LBB[0-9_]+}}
+define void @eorxri_tbnz(i64 %a) {
+entry:
+  %v0 = xor i64 %a, 255
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp eq i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
 ; CHECK-LABEL: eorxrr_cbz:
 ; CHECK:      eor  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -614,6 +1166,42 @@ entry:
   %v0 = xor i64 %a, %b
   %v1 = add i64 %a, 7
   %cond = icmp eq i64 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: eorxrr_tbz:
+; CHECK:      eor  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #32, {{.?LBB[0-9_]+}}
+define void @eorxrr_tbz(i64 %a, i64 %b) {
+entry:
+  %v0 = xor i64 %a, %b
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp ne i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: eorxrr_tbnz:
+; CHECK:      eor  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #32, {{.?LBB[0-9_]+}}
+define void @eorxrr_tbnz(i64 %a, i64 %b) {
+entry:
+  %v0 = xor i64 %a, %b
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp eq i64 %t, 0
   br i1 %cond, label %if, label %exit
 if:
   call void @fi64(i64 %v1, i64 %v0)
@@ -657,6 +1245,42 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: orrxri_tbz:
+; CHECK:      orr  [[R:x[0-9]+]], {{x[0-9]+}}, #0xff
+; CHECK-NEXT: tbz  [[R]], #32, {{.?LBB[0-9_]+}}
+define void @orrxri_tbz(i64 %a) {
+entry:
+  %v0 = or i64 %a, 255
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp ne i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: orrxri_tbnz:
+; CHECK:      orr  [[R:x[0-9]+]], {{x[0-9]+}}, #0xff
+; CHECK-NEXT: tbnz [[R]], #32, {{.?LBB[0-9_]+}}
+define void @orrxri_tbnz(i64 %a) {
+entry:
+  %v0 = or i64 %a, 255
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp eq i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
 ; CHECK-LABEL: orrxrr_cbz:
 ; CHECK:      orr  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -682,6 +1306,42 @@ entry:
   %v0 = or i64 %a, %b
   %v1 = add i64 %a, 7
   %cond = icmp eq i64 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: orrxrr_tbz:
+; CHECK:      orr  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #32, {{.?LBB[0-9_]+}}
+define void @orrxrr_tbz(i64 %a, i64 %b) {
+entry:
+  %v0 = or i64 %a, %b
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp ne i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: orrxrr_tbnz:
+; CHECK:      orr  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #32, {{.?LBB[0-9_]+}}
+define void @orrxrr_tbnz(i64 %a, i64 %b) {
+entry:
+  %v0 = or i64 %a, %b
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp eq i64 %t, 0
   br i1 %cond, label %if, label %exit
 if:
   call void @fi64(i64 %v1, i64 %v0)
@@ -727,6 +1387,44 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: ornxrr_tbz:
+; CHECK:      orn  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #32, {{.?LBB[0-9_]+}}
+define void @ornxrr_tbz(i64 %a, i64 %b) {
+entry:
+  %n = xor i64 %b, -1
+  %v0 = or i64 %a, %n
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp ne i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: ornxrr_tbnz:
+; CHECK:      orn  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #32, {{.?LBB[0-9_]+}}
+define void @ornxrr_tbnz(i64 %a, i64 %b) {
+entry:
+  %n = xor i64 %b, -1
+  %v0 = or i64 %a, %n
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp eq i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
 ; CHECK-LABEL: bicxrr_cbz:
 ; CHECK:      bic  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -754,6 +1452,44 @@ entry:
   %v0 = and i64 %a, %n
   %v1 = add i64 %a, 7
   %cond = icmp eq i64 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: bicxrr_tbz:
+; CHECK:      bic  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #32, {{.?LBB[0-9_]+}}
+define void @bicxrr_tbz(i64 %a, i64 %b) {
+entry:
+  %n = xor i64 %b, -1
+  %v0 = and i64 %a, %n
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp ne i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: bicxrr_tbnz:
+; CHECK:      bic  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #32, {{.?LBB[0-9_]+}}
+define void @bicxrr_tbnz(i64 %a, i64 %b) {
+entry:
+  %n = xor i64 %b, -1
+  %v0 = and i64 %a, %n
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp eq i64 %t, 0
   br i1 %cond, label %if, label %exit
 if:
   call void @fi64(i64 %v1, i64 %v0)
@@ -797,6 +1533,42 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: subxri_tbz:
+; CHECK:      sub  [[R:x[0-9]+]], {{x[0-9]+}}, #13
+; CHECK-NEXT: tbz  [[R]], #32, {{.?LBB[0-9_]+}}
+define void @subxri_tbz(i64 %a) {
+entry:
+  %v0 = sub i64 %a, 13
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp ne i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: subxri_tbnz:
+; CHECK:      sub  [[R:x[0-9]+]], {{x[0-9]+}}, #13
+; CHECK-NEXT: tbnz [[R]], #32, {{.?LBB[0-9_]+}}
+define void @subxri_tbnz(i64 %a) {
+entry:
+  %v0 = sub i64 %a, 13
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp eq i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
 ; CHECK-LABEL: subxrr_cbz:
 ; CHECK:      sub  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -831,3 +1603,38 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: subxrr_tbz:
+; CHECK:      sub  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbz  [[R]], #32, {{.?LBB[0-9_]+}}
+define void @subxrr_tbz(i64 %a, i64 %b) {
+entry:
+  %v0 = sub i64 %a, %b
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp ne i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: subxrr_tbnz:
+; CHECK:      sub  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: tbnz [[R]], #32, {{.?LBB[0-9_]+}}
+define void @subxrr_tbnz(i64 %a, i64 %b) {
+entry:
+  %v0 = sub i64 %a, %b
+  %v1 = add i64 %a, 7
+  %t = and i64 %v0, 4294967296
+  %cond = icmp eq i64 %t, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}

--- a/llvm/test/CodeGen/AArch64/misched-fusion-arith-cbz.mir
+++ b/llvm/test/CodeGen/AArch64/misched-fusion-arith-cbz.mir
@@ -49,6 +49,51 @@ body: |
   bb.2:
     RET undef $lr
 ...
+# CHECK-LABEL: addwri_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = ADDWri $w0, 13, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: addwri_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ADDWri $w0, 13, 0
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: addwri_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ADDWri $w0, 13, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: addwri_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ADDWri $w0, 13, 0
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
 
 # CHECK-LABEL: addwrr_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = ADDWrr $w0, $w1
@@ -96,6 +141,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: addwrr_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = ADDWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: addwrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ADDWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: addwrr_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ADDWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: addwrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ADDWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: addwrs_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = ADDWrs $w0, $w1, 0
 # CHECK: Successors:
@@ -136,6 +227,52 @@ body: |
     $w0 = ADDWrs $w0, $w1, 0
     $w3 = ORRWri $w2, 4096
     CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: addwrs_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = ADDWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: addwrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ADDWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: addwrs_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ADDWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: addwrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ADDWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -211,6 +348,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: andwri_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = ANDWri $w0, 4096
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: andwri_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ANDWri $w0, 4096
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: andwri_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ANDWri $w0, 4096
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: andwri_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ANDWri $w0, 4096
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: andwrr_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = ANDWrr $w0, $w1
 # CHECK: Successors:
@@ -257,6 +440,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: andwrr_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = ANDWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: andwrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ANDWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: andwrr_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ANDWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: andwrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ANDWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: andwrs_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = ANDWrs $w0, $w1, 0
 # CHECK: Successors:
@@ -297,6 +526,52 @@ body: |
     $w0 = ANDWrs $w0, $w1, 0
     $w3 = ORRWri $w2, 4096
     CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: andwrs_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = ANDWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: andwrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ANDWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: andwrs_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ANDWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: andwrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ANDWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -372,6 +647,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: eorwri_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = EORWri $w0, 4096
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: eorwri_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = EORWri $w0, 4096
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: eorwri_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = EORWri $w0, 4096
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: eorwri_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = EORWri $w0, 4096
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: eorwrr_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = EORWrr $w0, $w1
 # CHECK: Successors:
@@ -418,6 +739,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: eorwrr_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = EORWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: eorwrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = EORWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: eorwrr_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = EORWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: eorwrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = EORWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: eorwrs_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = EORWrs $w0, $w1, 0
 # CHECK: Successors:
@@ -458,6 +825,52 @@ body: |
     $w0 = EORWrs $w0, $w1, 0
     $w3 = ORRWri $w2, 4096
     CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: eorwrs_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = EORWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: eorwrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = EORWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: eorwrs_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = EORWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: eorwrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = EORWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -533,6 +946,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: ornwrr_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = ORNWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: ornwrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORNWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornwrr_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ORNWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: ornwrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORNWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: ornwrs_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = ORNWrs $w0, $w1, 0
 # CHECK: Successors:
@@ -573,6 +1032,52 @@ body: |
     $w0 = ORNWrs $w0, $w1, 0
     $w3 = ORRWri $w2, 4096
     CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornwrs_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = ORNWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: ornwrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORNWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornwrs_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ORNWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: ornwrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORNWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -648,6 +1153,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: orrwri_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = ORRWri $w0, 4096
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: orrwri_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORRWri $w0, 4096
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrwri_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ORRWri $w0, 4096
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: orrwri_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORRWri $w0, 4096
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: orrwrr_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = ORRWrr $w0, $w1
 # CHECK: Successors:
@@ -694,6 +1245,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: orrwrr_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = ORRWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: orrwrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORRWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrwrr_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ORRWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: orrwrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORRWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: orrwrs_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = ORRWrs $w0, $w1, 0
 # CHECK: Successors:
@@ -734,6 +1331,52 @@ body: |
     $w0 = ORRWrs $w0, $w1, 0
     $w3 = ORRWri $w2, 4096
     CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrwrs_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = ORRWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: orrwrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORRWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrwrs_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ORRWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: orrwrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORRWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -809,6 +1452,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: subwri_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = SUBWri $w0, 13, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: subwri_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = SUBWri $w0, 13, 0
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: subwri_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = SUBWri $w0, 13, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: subwri_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = SUBWri $w0, 13, 0
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: subwrr_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = SUBWrr $w0, $w1
 # CHECK: Successors:
@@ -855,6 +1544,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: subwrr_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = SUBWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: subwrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = SUBWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: subwrr_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = SUBWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: subwrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = SUBWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: subwrs_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = SUBWrs $w0, $w1, 0
 # CHECK: Successors:
@@ -895,6 +1630,52 @@ body: |
     $w0 = SUBWrs $w0, $w1, 0
     $w3 = ORRWri $w2, 4096
     CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: subwrs_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = SUBWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: subwrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = SUBWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: subwrs_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = SUBWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: subwrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = SUBWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -970,6 +1751,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: bicwrr_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = BICWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: bicwrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = BICWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: bicwrr_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = BICWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: bicwrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = BICWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: bicwrs_cbz
 # CHECK: SU({{[0-9]+}}): $w0 = BICWrs $w0, $w1, 0
 # CHECK: Successors:
@@ -1010,6 +1837,52 @@ body: |
     $w0 = BICWrs $w0, $w1, 0
     $w3 = ORRWri $w2, 4096
     CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: bicwrs_tbz
+# CHECK: SU({{[0-9]+}}): $w0 = BICWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZW
+---
+name: bicwrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = BICWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBZW $w0, 8, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: bicwrs_tbnz
+# CHECK: SU({{[0-9]+}}): $w0 = BICWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZW
+---
+name: bicwrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = BICWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    TBNZW $w0, 8, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -1085,6 +1958,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: addxri_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = ADDXri $x0, 13, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: addxri_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ADDXri $x0, 13, 0
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: addxri_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ADDXri $x0, 13, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: addxri_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ADDXri $x0, 13, 0
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: addxrr_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = ADDXrr $x0, $x1
 # CHECK: Successors:
@@ -1131,6 +2050,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: addxrr_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = ADDXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: addxrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ADDXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: addxrr_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ADDXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: addxrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ADDXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: addxrs_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = ADDXrs $x0, $x1, 0
 # CHECK: Successors:
@@ -1171,6 +2136,52 @@ body: |
     $x0 = ADDXrs $x0, $x1, 0
     $x3 = ORRXri $x2, 8192
     CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: addxrs_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = ADDXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: addxrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ADDXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: addxrs_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ADDXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: addxrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ADDXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -1246,6 +2257,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: andxri_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = ANDXri $x0, 8192
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: andxri_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ANDXri $x0, 8192
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: andxri_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ANDXri $x0, 8192
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: andxri_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ANDXri $x0, 8192
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: andxrr_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = ANDXrr $x0, $x1
 # CHECK: Successors:
@@ -1292,6 +2349,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: andxrr_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = ANDXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: andxrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ANDXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: andxrr_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ANDXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: andxrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ANDXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: andxrs_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = ANDXrs $x0, $x1, 0
 # CHECK: Successors:
@@ -1332,6 +2435,52 @@ body: |
     $x0 = ANDXrs $x0, $x1, 0
     $x3 = ORRXri $x2, 8192
     CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: andxrs_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = ANDXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: andxrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ANDXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: andxrs_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ANDXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: andxrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ANDXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -1407,6 +2556,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: eorxri_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = EORXri $x0, 8192
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: eorxri_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = EORXri $x0, 8192
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: eorxri_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = EORXri $x0, 8192
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: eorxri_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = EORXri $x0, 8192
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: eorxrr_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = EORXrr $x0, $x1
 # CHECK: Successors:
@@ -1453,6 +2648,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: eorxrr_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = EORXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: eorxrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = EORXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: eorxrr_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = EORXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: eorxrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = EORXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: eorxrs_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = EORXrs $x0, $x1, 0
 # CHECK: Successors:
@@ -1493,6 +2734,52 @@ body: |
     $x0 = EORXrs $x0, $x1, 0
     $x3 = ORRXri $x2, 8192
     CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: eorxrs_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = EORXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: eorxrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = EORXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: eorxrs_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = EORXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: eorxrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = EORXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -1568,6 +2855,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: ornxrr_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = ORNXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: ornxrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORNXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornxrr_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ORNXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: ornxrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORNXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: ornxrs_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = ORNXrs $x0, $x1, 0
 # CHECK: Successors:
@@ -1608,6 +2941,52 @@ body: |
     $x0 = ORNXrs $x0, $x1, 0
     $x3 = ORRXri $x2, 8192
     CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornxrs_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = ORNXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: ornxrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORNXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornxrs_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ORNXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: ornxrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORNXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -1683,6 +3062,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: orrxri_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = ORRXri $x0, 8192
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: orrxri_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORRXri $x0, 8192
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrxri_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ORRXri $x0, 8192
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: orrxri_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORRXri $x0, 8192
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: orrxrr_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = ORRXrr $x0, $x1
 # CHECK: Successors:
@@ -1729,6 +3154,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: orrxrr_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = ORRXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: orrxrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORRXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrxrr_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ORRXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: orrxrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORRXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: orrxrs_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = ORRXrs $x0, $x1, 0
 # CHECK: Successors:
@@ -1769,6 +3240,52 @@ body: |
     $x0 = ORRXrs $x0, $x1, 0
     $x3 = ORRXri $x2, 8192
     CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrxrs_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = ORRXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: orrxrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORRXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrxrs_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ORRXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: orrxrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORRXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -1844,6 +3361,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: subxri_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = SUBXri $x0, 13, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: subxri_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = SUBXri $x0, 13, 0
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: subxri_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = SUBXri $x0, 13, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: subxri_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = SUBXri $x0, 13, 0
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: subxrr_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = SUBXrr $x0, $x1
 # CHECK: Successors:
@@ -1890,6 +3453,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: subxrr_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = SUBXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: subxrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = SUBXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: subxrr_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = SUBXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: subxrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = SUBXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: subxrs_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = SUBXrs $x0, $x1, 0
 # CHECK: Successors:
@@ -1930,6 +3539,52 @@ body: |
     $x0 = SUBXrs $x0, $x1, 0
     $x3 = ORRXri $x2, 8192
     CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: subxrs_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = SUBXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: subxrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = SUBXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: subxrs_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = SUBXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: subxrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = SUBXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
   bb.1:
     RET undef $lr
   bb.2:
@@ -2005,6 +3660,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: bicxrr_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = BICXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: bicxrr_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = BICXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: bicxrr_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = BICXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: bicxrr_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = BICXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: bicxrs_cbz
 # CHECK: SU({{[0-9]+}}): $x0 = BICXrs $x0, $x1, 0
 # CHECK: Successors:
@@ -2045,6 +3746,52 @@ body: |
     $x0 = BICXrs $x0, $x1, 0
     $x3 = ORRXri $x2, 8192
     CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: bicxrs_tbz
+# CHECK: SU({{[0-9]+}}): $x0 = BICXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBZX
+---
+name: bicxrs_tbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = BICXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBZX $x0, 32, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: bicxrs_tbnz
+# CHECK: SU({{[0-9]+}}): $x0 = BICXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: TBNZX
+---
+name: bicxrs_tbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = BICXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    TBNZX $x0, 32, %bb.2
   bb.1:
     RET undef $lr
   bb.2:


### PR DESCRIPTION
This patch adds missing TBZ+TBNZ anchors for arith+CBZ clustering. They have similar nature to CBZ as specific kinds of it, so this patch classifies them under the same subtarget feature name compactly. This is better for Apple CPU. They can be reasonably expected to behave similarly on AArch64 targets.