### PR TITLE
[clang][analyzer] Fixed 'if_nameindex' in MallocChecker

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -547,7 +547,7 @@ private:
       {{CDM::CLibrary, {"strdup"}, 1}, &MallocChecker::checkStrdup},
       {{CDM::CLibrary, {"_strdup"}, 1}, &MallocChecker::checkStrdup},
       {{CDM::CLibrary, {"kmalloc"}, 2}, &MallocChecker::checkKernelMalloc},
-      {{CDM::CLibrary, {"if_nameindex"}, 1}, &MallocChecker::checkIfNameIndex},
+      {{CDM::CLibrary, {"if_nameindex"}, 0}, &MallocChecker::checkIfNameIndex},
       {{CDM::CLibrary, {"wcsdup"}, 1}, &MallocChecker::checkStrdup},
       {{CDM::CLibrary, {"_wcsdup"}, 1}, &MallocChecker::checkStrdup},
       {{CDM::CLibrary, {"g_malloc"}, 1}, &MallocChecker::checkBasicAlloc},

--- a/clang/test/Analysis/malloc-failure.c
+++ b/clang/test/Analysis/malloc-failure.c
@@ -71,6 +71,6 @@ void test_strdup() {
 
 void test_ifnameindex() {
   struct if_nameindex *p = if_nameindex();
-  p->x = 1; //FIXME: if_nameindex is not recognized by the checker
+  p->x = 1; //expected-warning{{dereference of a null pointer}}
   if_freenameindex(p);
 }

--- a/clang/test/Analysis/malloc.c
+++ b/clang/test/Analysis/malloc.c
@@ -1019,6 +1019,20 @@ void testWinWcsdupContentIsDefined(const wchar_t *s, unsigned validIndex) {
   free(s2);
 }
 
+struct if_nameindex { char x; };
+struct if_nameindex *if_nameindex(void);
+void if_freenameindex(struct if_nameindex *ptr);
+
+char testIfnameindex() {
+  struct if_nameindex *i = if_nameindex();
+  return i->x; // expected-warning {{Potential leak of memory pointed to by}}
+}
+
+void testIffreenameindex() {
+  struct if_nameindex *i = if_nameindex();
+  if_freenameindex(i);
+} // no warning
+
 // ----------------------------------------------------------------------------
 // Test the system library functions to which the pointer can escape.
 // This tests false positive suppression.

--- a/clang/test/Analysis/malloc.c
+++ b/clang/test/Analysis/malloc.c
@@ -1030,6 +1030,7 @@ char testIfnameindex() {
 
 void testIffreenameindex() {
   struct if_nameindex *i = if_nameindex();
+  char x = i->x;
   if_freenameindex(i);
 } // no warning
 


### PR DESCRIPTION
The function `if_nameindex` has 0 arguments but `MallocChecker` expected it to have 1 argument and was not recognized by the checker correctly.