### PR TITLE
[libc] Add a proxy header for sa_family_t

### DIFF
--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -572,6 +572,14 @@ add_proxy_header_library(
     libc.include.netinet_udp
 )
 
+add_proxy_header_library(
+  sa_family_t
+  HDRS
+    sa_family_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.sa_family_t
+    libc.include.sys_socket
+)
 
 add_proxy_header_library(
   socklen_t

--- a/libc/hdr/types/sa_family_t.h
+++ b/libc/hdr/types/sa_family_t.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Proxy for sa_family_t.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_SA_FAMILY_T_H
+#define LLVM_LIBC_HDR_TYPES_SA_FAMILY_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/sa_family_t.h"
+
+#else
+
+#include <sys/socket.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_SA_FAMILY_T_H

--- a/libc/test/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/test/src/sys/socket/linux/CMakeLists.txt
@@ -41,6 +41,7 @@ add_libc_unittest(
     libc.include.sys_socket
     libc.hdr.netinet_in_macros
     libc.hdr.sys_socket_macros
+    libc.hdr.types.sa_family_t
     libc.hdr.types.struct_sockaddr_in
     libc.hdr.types.struct_sockaddr_in6
     libc.hdr.types.struct_sockaddr_un
@@ -67,7 +68,9 @@ add_libc_unittest(
     libc.include.sys_socket
     libc.hdr.fcntl_macros
     libc.hdr.sys_socket_macros
+    libc.hdr.types.sa_family_t
     libc.hdr.types.size_t
+    libc.hdr.types.socklen_t
     libc.hdr.types.struct_sockaddr_un
     libc.src.errno.errno
     libc.src.fcntl.fcntl
@@ -177,6 +180,8 @@ add_libc_unittest(
     .socket_test_support
     libc.include.sys_socket
     libc.hdr.sys_socket_macros
+    libc.hdr.types.sa_family_t
+    libc.hdr.types.socklen_t
     libc.hdr.types.struct_sockaddr_un
     libc.src.errno.errno
     libc.src.sys.socket.accept
@@ -303,6 +308,8 @@ add_libc_unittest(
     sockaddr_storage_test.cpp
     sockaddr_storage_helper.cpp
   DEPENDS
+    libc.hdr.sys_socket_macros
+    libc.hdr.types.sa_family_t
     libc.hdr.types.struct_sockaddr_storage
     libc.hdr.types.struct_sockaddr_un
 )

--- a/libc/test/src/sys/socket/linux/bind_test.cpp
+++ b/libc/test/src/sys/socket/linux/bind_test.cpp
@@ -20,6 +20,7 @@
 
 #include "hdr/netinet_in_macros.h"
 #include "hdr/sys_socket_macros.h"
+#include "hdr/types/sa_family_t.h"
 #include "hdr/types/struct_sockaddr_in.h"
 #include "hdr/types/struct_sockaddr_in6.h"
 #include "hdr/types/struct_sockaddr_un.h"

--- a/libc/test/src/sys/socket/linux/connect_accept_test.cpp
+++ b/libc/test/src/sys/socket/linux/connect_accept_test.cpp
@@ -8,7 +8,9 @@
 
 #include "hdr/fcntl_macros.h"
 #include "hdr/sys_socket_macros.h"
+#include "hdr/types/sa_family_t.h"
 #include "hdr/types/size_t.h"
+#include "hdr/types/socklen_t.h"
 #include "hdr/types/struct_sockaddr_un.h"
 #include "src/fcntl/fcntl.h"
 #include "src/stdio/remove.h"

--- a/libc/test/src/sys/socket/linux/sockaddr_storage_helper.cpp
+++ b/libc/test/src/sys/socket/linux/sockaddr_storage_helper.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/sys_socket_macros.h"
+#include "hdr/types/sa_family_t.h"
 #include "hdr/types/struct_sockaddr_storage.h"
 #include "hdr/types/struct_sockaddr_un.h"
-#include "include/llvm-libc-types/sa_family_t.h"
 
 // POSIX requires (and many applications make use of this) the ability to cast
 // one sockaddr pointer to another. This verifies that the compiler does not

--- a/libc/test/src/sys/socket/linux/sockaddr_storage_test.cpp
+++ b/libc/test/src/sys/socket/linux/sockaddr_storage_test.cpp
@@ -6,12 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/sys_socket_macros.h"
+#include "hdr/types/sa_family_t.h"
 #include "hdr/types/struct_sockaddr_storage.h"
 #include "hdr/types/struct_sockaddr_un.h"
-
 #include "test/UnitTest/LibcTest.h"
-
-#include <sys/socket.h> // For AF_UNIX
 
 using LlvmLibcSockaddrStorageTest = LIBC_NAMESPACE::testing::Test;
 

--- a/libc/test/src/sys/socket/linux/sockname_test.cpp
+++ b/libc/test/src/sys/socket/linux/sockname_test.cpp
@@ -12,6 +12,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/sys_socket_macros.h"
+#include "hdr/types/sa_family_t.h"
+#include "hdr/types/socklen_t.h"
 #include "hdr/types/struct_sockaddr_un.h"
 #include "src/__support/CPP/scope.h"
 #include "src/stdio/remove.h"


### PR DESCRIPTION
This patch adds `hdr/types/sa_family_t.h` and updates socket tests and helpers to use it instead of directly including `<sys/socket.h>` or `include/llvm-libc-types/sa_family_t.h`.

The patch also adds a couple of includes of `hdr/types/socklen_t.h` for files that are using the type, but not including it directly.

Assisted by Gemini.