### PR TITLE
[CIR] Fix lit tests after explicit target feature for module asm

### DIFF
--- a/clang/test/CIR/CodeGen/inline-asm.c
+++ b/clang/test/CIR/CodeGen/inline-asm.c
@@ -9,9 +9,10 @@ __asm__ ("foo1");
 __asm__ ("foo2");
 __asm__ ("foo3");
 // CIR: module{{.*}} cir.module_asm = ["foo1", "foo2", "foo3"]
-// LLVM: module asm "foo1"
-// LLVM-NEXT: module asm "foo2"
-// LLVM-NEXT: module asm "foo3"
+// LLVM: module asm
+// LLVM-NEXT: "foo1"
+// LLVM-NEXT: "foo2"
+// LLVM-NEXT: "foo3"
 
 //      CIR: cir.func{{.*}}@empty1
 //      CIR: cir.asm(x86_att, 

--- a/clang/test/CIR/Lowering/module-asm.cir
+++ b/clang/test/CIR/Lowering/module-asm.cir
@@ -5,7 +5,8 @@
 // RUN: FileCheck -check-prefix=LLVM --input-file=%t.ll %s
 
 // CHECK: llvm.module_asm =  [".globl bar", ".globl foo"]
-// LLVM: module asm ".globl bar"
-// LLVM: module asm ".globl foo"
+// LLVM: module asm
+// LLVM-NEXT: ".globl bar"
+// LLVM-NEXT: ".globl foo"
 module attributes {cir.module_asm = [".globl bar", ".globl foo"]} {
 }


### PR DESCRIPTION
- Fix lit tests after the module-level inline assembly is enhanced to support specifying target features explicitly in fcfc9167b628a2fae8fe1d662989ff7752d905ad.