### PR TITLE
[lldb] Make SBType::FindDirectNestedType work with dynamic types

### DIFF
--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -1215,7 +1215,7 @@ bool TypeImpl::GetDescription(lldb_private::Stream &strm,
 CompilerType TypeImpl::FindDirectNestedType(llvm::StringRef name) {
   if (name.empty())
     return CompilerType();
-  return GetCompilerType(/*prefer_dynamic=*/false)
+  return GetCompilerType(/*prefer_dynamic=*/true)
       .GetDirectNestedTypeWithName(name);
 }
 

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -300,6 +300,30 @@ class TypeAndTypeListTestCase(TestBase):
         self.assertTrue(the_typedef)
         self.assertEqual(the_typedef.GetTypedefedType().GetName(), "int")
 
+    @expectedFailureWindows  # Dynamic type resolution not implemented
+    def test_dynamic_values(self):
+        """Test FindDirectNestedType on dynamic values"""
+
+        self.build()
+        lldbutil.run_to_line_breakpoint(self, lldb.SBFileSpec(self.source), self.line)
+        polymorphic = (
+            self.frame()
+            .FindVariable("polymorphic")
+            .GetDynamicValue(lldb.eDynamicDontRunTarget)
+        )
+        self.DebugSBValue(polymorphic)
+        polymorphic_type = polymorphic.GetType().GetPointeeType()
+        self.DebugSBType(polymorphic_type)
+        nested = polymorphic_type.FindDirectNestedType("Nested")
+        self.DebugSBType(nested)
+        self.assertEqual(nested.GetName(), "PolymorphicDerived::Nested")
+
+        static = polymorphic.GetStaticValue()
+        self.DebugSBValue(static)
+        static_type = static.GetType().GetPointeeType()
+        self.DebugSBType(static_type)
+        self.assertFalse(static_type.FindDirectNestedType("Nested"))
+
     def test_GetByteAlign(self):
         """Exercise SBType::GetByteAlign"""
         self.build()

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -317,12 +317,16 @@ class TypeAndTypeListTestCase(TestBase):
         nested = polymorphic_type.FindDirectNestedType("Nested")
         self.DebugSBType(nested)
         self.assertEqual(nested.GetName(), "PolymorphicDerived::Nested")
+        self.assertEqual(nested.GetTypedefedType().GetName(), "float")
 
         static = polymorphic.GetStaticValue()
         self.DebugSBValue(static)
         static_type = static.GetType().GetPointeeType()
         self.DebugSBType(static_type)
-        self.assertFalse(static_type.FindDirectNestedType("Nested"))
+        nested = static_type.FindDirectNestedType("Nested")
+        self.DebugSBType(nested)
+        self.assertEqual(nested.GetName(), "PolymorphicBase::Nested")
+        self.assertEqual(nested.GetTypedefedType().GetName(), "int")
 
     def test_GetByteAlign(self):
         """Exercise SBType::GetByteAlign"""

--- a/lldb/test/API/python_api/type/main.cpp
+++ b/lldb/test/API/python_api/type/main.cpp
@@ -63,6 +63,15 @@ struct WithNestedTypedef {
 };
 WithNestedTypedef::TheTypedef typedefed_value;
 
+struct PolymorphicBase {
+  virtual void foo() {}
+};
+
+struct PolymorphicDerived : PolymorphicBase {
+  struct Nested {};
+  Nested get() { return {}; }
+};
+
 int main (int argc, char const *argv[])
 {
     Task *task_head = new Task(-1, NULL);
@@ -99,6 +108,8 @@ int main (int argc, char const *argv[])
     Pointer<3> pointer;
     PointerInfo<3>::Masks1 mask1 = PointerInfo<3>::Masks1::pointer_mask;
     PointerInfo<3>::Masks2 mask2 = PointerInfo<3>::Masks2::pointer_mask;
+
+    PolymorphicBase *polymorphic = new PolymorphicDerived();
 
     return 0; // Break at this line
 }

--- a/lldb/test/API/python_api/type/main.cpp
+++ b/lldb/test/API/python_api/type/main.cpp
@@ -64,11 +64,13 @@ struct WithNestedTypedef {
 WithNestedTypedef::TheTypedef typedefed_value;
 
 struct PolymorphicBase {
+  using Nested = int;
+  Nested get() { return {}; }
   virtual void foo() {}
 };
 
 struct PolymorphicDerived : PolymorphicBase {
-  struct Nested {};
+  using Nested = float;
   Nested get() { return {}; }
 };
 


### PR DESCRIPTION
This makes it possible to find the nested type just by knowing the
dynamic type of the value. To get the previous behavior, get the type
from a static view of the value (SBValue::GetStaticValue).