### PR TITLE
[docs][AMDGPU] Correct spelling of DW_AT_LLVM_memory_space

### DIFF
--- a/llvm/docs/AMDGPUDwarfExtensionsForHeterogeneousDebugging.rst
+++ b/llvm/docs/AMDGPUDwarfExtensionsForHeterogeneousDebugging.rst
@@ -3687,9 +3687,9 @@ constant may have the following attributes:
 
 3.  ``DW_AT_LLVM_memory_space``
 
-    A ``DW_AT_memory_space`` attribute with a constant value representing a source
+    A ``DW_AT_LLVM_memory_space`` attribute with a constant value representing a source
     language specific DWARF memory space (see 2.14 "Memory Spaces"). If omitted,
-    defaults to ``DW_MSPACE_none``.
+    defaults to ``DW_MSPACE_LLVM_none``.
 
 
 A.4.2 Common Block Entries


### PR DESCRIPTION
Change-Id: I4408a73bd8fd6d47a32a19916c8267843b833960