### PR TITLE
[openmp][arm64ec] Fix arm64x when PER_TARGET_RUNTIME_DIR=On

### DIFF
--- a/openmp/runtime/cmake/arm64x.cmake
+++ b/openmp/runtime/cmake/arm64x.cmake
@@ -11,7 +11,7 @@ set(arm64ReproDir "${LLVM_BINARY_DIR}/runtimes/repros-arm64ec")
 
 # Don't install the runtime if we are doing an arm64ec build for arm64x.
 # The hybrid arm64x runtime will get installed by the host (default) runtime build
-if (LIBOMP_ARCH STREQUAL "arm64ec")
+if (LIBOMP_ARCH STREQUAL "arm64ec" AND NOT LLVM_ENABLE_PER_TARGET_RUNTIME_DIR)
   set(CMAKE_SKIP_INSTALL_RULES On)
 endif()
 

--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -413,7 +413,10 @@ set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS omp)
 # We want to install libomp in ${DESTDIR}/${CMAKE_INSTALL_FULL_LIBDIR}
 # We want to install headers in ${DESTDIR}/${CMAKE_INSTALL_FULL_INCLUDEDIR}
 if(WIN32)
-  install(TARGETS omp ${export_to_llvmexports} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT openmp)
+  # Do not install arm64ec openmp library if building for arm64x; we need to only install the arm64x one.
+  if(NOT LIBOMP_ENABLE_ARM64X OR LIBOMP_ARCH STREQUAL "aarch64")
+    install(TARGETS omp ${export_to_llvmexports} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT openmp)
+  endif()
   install(TARGETS ${LIBOMP_IMP_LIB_TARGET} ARCHIVE DESTINATION "${OPENMP_INSTALL_LIBDIR}" COMPONENT openmp)
   # Create aliases (regular copies) of the library for backwards compatibility
   set(LIBOMP_ALIASES "libiomp5md")


### PR DESCRIPTION
This patch fixes an issue where the combination of LIBOMP_ENABLE_ARM64X and LLVM_PER_TARGET_RUNTIME_DIR=On led to only the arm64 library being installed. With this fix, the arm64ec and arm64 .lib files are both installed, and the arm64x dll is the one installed to the binary dir.