### PR TITLE
[TableGen][CC][NFC] Emit idiomatic guards for CallingConv.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.cpp
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.cpp
@@ -223,4 +223,5 @@ static bool CC_AArch64_Custom_Block(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
 
 // TableGen provides definitions of the calling convention analysis entry
 // points.
+#define GET_CALLING_CONV_IMPL
 #include "AArch64GenCallingConv.inc"

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -30,6 +30,7 @@
 
 using namespace llvm;
 
+#define GET_CALLING_CONV_IMPL
 #include "AMDGPUGenCallingConv.inc"
 
 static cl::opt<bool> AMDGPUBypassSlowDiv(

--- a/llvm/lib/Target/AMDGPU/R600ISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/R600ISelLowering.cpp
@@ -26,6 +26,7 @@
 
 using namespace llvm;
 
+#define GET_CALLING_CONV_IMPL
 #include "R600GenCallingConv.inc"
 
 R600TargetLowering::R600TargetLowering(const TargetMachine &TM,

--- a/llvm/lib/Target/ARC/ARCISelLowering.cpp
+++ b/llvm/lib/Target/ARC/ARCISelLowering.cpp
@@ -236,6 +236,7 @@ SDValue ARCTargetLowering::LowerJumpTable(SDValue Op, SelectionDAG &DAG) const {
   return DAG.getNode(ARCISD::GAWRAPPER, SDLoc(N), MVT::i32, GA);
 }
 
+#define GET_CALLING_CONV_IMPL
 #include "ARCGenCallingConv.inc"
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/ARM/ARMCallingConv.cpp
+++ b/llvm/lib/Target/ARM/ARMCallingConv.cpp
@@ -330,4 +330,5 @@ static bool CC_ARM_AAPCS_Common_Custom_f16_Stack(unsigned ValNo, MVT ValVT,
 }
 
 // Include the table generated calling convention implementations.
+#define GET_CALLING_CONV_IMPL
 #include "ARMGenCallingConv.inc"

--- a/llvm/lib/Target/AVR/AVRISelLowering.cpp
+++ b/llvm/lib/Target/AVR/AVRISelLowering.cpp
@@ -1151,6 +1151,7 @@ bool AVRTargetLowering::isOffsetFoldingLegal(
 //             Formal Arguments Calling Convention Implementation
 //===----------------------------------------------------------------------===//
 
+#define GET_CALLING_CONV_IMPL
 #include "AVRGenCallingConv.inc"
 
 /// Registers for calling conventions, ordered in reverse as required by ABI.

--- a/llvm/lib/Target/BPF/BPFISelLowering.cpp
+++ b/llvm/lib/Target/BPF/BPFISelLowering.cpp
@@ -387,6 +387,7 @@ SDValue BPFTargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const {
 }
 
 // Calling Convention Implementation
+#define GET_CALLING_CONV_IMPL
 #include "BPFGenCallingConv.inc"
 
 // Apply AssertSext/AssertZext and truncate based on VA's LocInfo.

--- a/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
+++ b/llvm/lib/Target/CSKY/CSKYISelLowering.cpp
@@ -29,6 +29,7 @@ using namespace llvm;
 
 STATISTIC(NumTailCalls, "Number of tail calls");
 
+#define GET_CALLING_CONV_IMPL
 #include "CSKYGenCallingConv.inc"
 
 static const MCPhysReg GPRArgRegs[] = {CSKY::R0, CSKY::R1, CSKY::R2, CSKY::R3};

--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -113,6 +113,7 @@ static bool CC_SkipOdd(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
   return false;
 }
 
+#define GET_CALLING_CONV_IMPL
 #include "HexagonGenCallingConv.inc"
 
 unsigned HexagonTargetLowering::getVectorTypeBreakdownForCallingConv(

--- a/llvm/lib/Target/Lanai/LanaiISelLowering.cpp
+++ b/llvm/lib/Target/Lanai/LanaiISelLowering.cpp
@@ -351,6 +351,7 @@ void LanaiTargetLowering::LowerAsmOperandForConstraint(
 //                      Calling Convention Implementation
 //===----------------------------------------------------------------------===//
 
+#define GET_CALLING_CONV_IMPL
 #include "LanaiGenCallingConv.inc"
 
 static bool CC_Lanai32_VarArg(unsigned ValNo, MVT ValVT, MVT LocVT,

--- a/llvm/lib/Target/M68k/M68kISelLowering.cpp
+++ b/llvm/lib/Target/M68k/M68kISelLowering.cpp
@@ -230,6 +230,7 @@ MVT M68kTargetLowering::getScalarShiftAmountTy(const DataLayout &DL,
   return MVT::getIntegerVT(DL.getPointerSizeInBits(0));
 }
 
+#define GET_CALLING_CONV_IMPL
 #include "M68kGenCallingConv.inc"
 
 enum StructReturnType { NotStructReturn, RegStructReturn, StackStructReturn };

--- a/llvm/lib/Target/MSP430/MSP430ISelLowering.cpp
+++ b/llvm/lib/Target/MSP430/MSP430ISelLowering.cpp
@@ -230,6 +230,7 @@ MSP430TargetLowering::getRegForInlineAsmConstraint(
 //                      Calling Convention Implementation
 //===----------------------------------------------------------------------===//
 
+#define GET_CALLING_CONV_IMPL
 #include "MSP430GenCallingConv.inc"
 
 /// For each argument in a function store the number of pieces it is composed

--- a/llvm/lib/Target/Mips/MipsFastISel.cpp
+++ b/llvm/lib/Target/Mips/MipsFastISel.cpp
@@ -285,6 +285,7 @@ static bool CC_MipsO32_FP64(unsigned ValNo, MVT ValVT, MVT LocVT,
   llvm_unreachable("should not be called");
 }
 
+#define GET_CALLING_CONV_IMPL
 #include "MipsGenCallingConv.inc"
 
 CCAssignFn *MipsFastISel::CCAssignFnForCall(CallingConv::ID CC) const {

--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -3139,6 +3139,7 @@ static bool CC_MipsO32_FP64(unsigned ValNo, MVT ValVT, MVT LocVT,
                                         ISD::ArgFlagsTy ArgFlags, Type *OrigTy,
                                         CCState &State);
 
+#define GET_CALLING_CONV_IMPL
 #include "MipsGenCallingConv.inc"
 
  CCAssignFn *MipsTargetLowering::CCAssignFnForCall() const{

--- a/llvm/lib/Target/PowerPC/PPCCallingConv.cpp
+++ b/llvm/lib/Target/PowerPC/PPCCallingConv.cpp
@@ -193,4 +193,5 @@ static bool CC_PPC32_SPE_RetF64(unsigned &ValNo, MVT &ValVT,
   return true;
 }
 
+#define GET_CALLING_CONV_IMPL
 #include "PPCGenCallingConv.inc"

--- a/llvm/lib/Target/Sparc/SparcISelLowering.cpp
+++ b/llvm/lib/Target/Sparc/SparcISelLowering.cpp
@@ -223,6 +223,7 @@ static bool RetCC_Sparc64_Half(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
                                  State);
 }
 
+#define GET_CALLING_CONV_IMPL
 #include "SparcGenCallingConv.inc"
 
 // The calling conventions in SparcCallingConv.td are described in terms of the

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -1855,6 +1855,7 @@ void SystemZTargetLowering::LowerAsmOperandForConstraint(
 // Calling conventions
 //===----------------------------------------------------------------------===//
 
+#define GET_CALLING_CONV_IMPL
 #include "SystemZGenCallingConv.inc"
 
 const MCPhysReg *SystemZTargetLowering::getScratchRegisters(

--- a/llvm/lib/Target/VE/VEISelLowering.cpp
+++ b/llvm/lib/Target/VE/VEISelLowering.cpp
@@ -42,6 +42,7 @@ using namespace llvm;
 // Calling Convention Implementation
 //===----------------------------------------------------------------------===//
 
+#define GET_CALLING_CONV_IMPL
 #include "VEGenCallingConv.inc"
 
 CCAssignFn *getReturnCC(CallingConv::ID CallConv) {

--- a/llvm/lib/Target/X86/X86CallingConv.cpp
+++ b/llvm/lib/Target/X86/X86CallingConv.cpp
@@ -406,4 +406,5 @@ static bool CC_X86_32_I128_FP128(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
 }
 
 // Provides entry points of CC_X86 and RetCC_X86.
+#define GET_CALLING_CONV_IMPL
 #include "X86GenCallingConv.inc"

--- a/llvm/lib/Target/XCore/XCoreISelLowering.cpp
+++ b/llvm/lib/Target/XCore/XCoreISelLowering.cpp
@@ -892,6 +892,7 @@ LowerATOMIC_FENCE(SDValue Op, SelectionDAG &DAG) const {
 //                      Calling Convention Implementation
 //===----------------------------------------------------------------------===//
 
+#define GET_CALLING_CONV_IMPL
 #include "XCoreGenCallingConv.inc"
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/Xtensa/XtensaISelLowering.cpp
+++ b/llvm/lib/Target/Xtensa/XtensaISelLowering.cpp
@@ -353,6 +353,7 @@ void XtensaTargetLowering::LowerAsmOperandForConstraint(
 // Calling conventions
 //===----------------------------------------------------------------------===//
 
+#define GET_CALLING_CONV_IMPL
 #include "XtensaGenCallingConv.inc"
 
 static const MCPhysReg IntRegs[] = {Xtensa::A2, Xtensa::A3, Xtensa::A4,

--- a/llvm/utils/TableGen/CallingConvEmitter.cpp
+++ b/llvm/utils/TableGen/CallingConvEmitter.cpp
@@ -79,17 +79,19 @@ void CallingConvEmitter::run(raw_ostream &O) {
   // Emit prototypes for all of the non-custom CC's so that they can forward ref
   // each other.
   Records.getTimer().startTimer("Emit prototypes");
-  IfGuardEmitter IfGuard(O, "!defined(GET_CC_REGISTER_LISTS)");
-  for (const Record *CC : CCs) {
-    if (!CC->getValueAsBit("Custom"))
-      emitCCHeader(O, CC, ";\n");
-  }
+  {
+    IfDefEmitter IfGuard(O, "GET_CALLING_CONV_IMPL");
+    for (const Record *CC : CCs) {
+      if (!CC->getValueAsBit("Custom"))
+        emitCCHeader(O, CC, ";\n");
+    }
 
-  // Emit each non-custom calling convention description in full.
-  Records.getTimer().startTimer("Emit full descriptions");
-  for (const Record *CC : CCs) {
-    if (!CC->getValueAsBit("Custom"))
-      emitCallingConv(CC, O);
+    // Emit each non-custom calling convention description in full.
+    Records.getTimer().startTimer("Emit full descriptions");
+    for (const Record *CC : CCs) {
+      if (!CC->getValueAsBit("Custom"))
+        emitCallingConv(CC, O);
+    }
   }
 
   emitArgRegisterLists(O);
@@ -365,7 +367,7 @@ void CallingConvEmitter::emitArgRegisterLists(raw_ostream &O) {
   if (AssignedRegsMap.empty())
     return;
 
-  O << "\n#else\n\n";
+  IfDefEmitter IfGuard(O, "GET_CC_REGISTER_LISTS");
 
   for (const auto &[RegName, Registers] : AssignedRegsMap) {
     if (RegName.empty())


### PR DESCRIPTION
Emit independent guards for the two existing sections rather than the if-else done today. This is in preparation for adding other sections that must be includable exclusive of the other sections.

This also eliminates the current asymmetry between the automatic IfGuardEmitter for the "if" portion vs the manually emitted "else" section.