### PR TITLE
[SPIRV][Matrix] Change Matrix Shader legalization to largest common divisor

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -811,11 +811,9 @@ static bool allUsesAreShuffleScatter(MachineRegisterInfo &MRI,
 }
 
 // Splits SrcReg into NumChunks separate ChunkTy-typed registers.
-static SmallVector<Register> unmergeIntoChunks(MachineIRBuilder &MIRBuilder,
-                                               MachineRegisterInfo &MRI,
-                                               Register SrcReg,
-                                               unsigned NumChunks,
-                                               LLT ChunkTy) {
+static SmallVector<Register>
+unmergeIntoChunks(MachineIRBuilder &MIRBuilder, MachineRegisterInfo &MRI,
+                  Register SrcReg, unsigned NumChunks, LLT ChunkTy) {
   assert(NumChunks >= 2 && "ShuffleChunkable should have handled this case");
   SmallVector<Register> Regs;
   for (unsigned I = 0; I < NumChunks; ++I)
@@ -902,8 +900,8 @@ static bool legalizeShuffleVector(LegalizerHelper &Helper, MachineInstr &MI) {
 
   const SPIRVSubtarget &ST = MI.getMF()->getSubtarget<SPIRVSubtarget>();
   unsigned MaxVectorSize = ST.isShader() ? 4 : 16;
-  unsigned VectorSplitWidth = getVectorSplitWidth(
-      DstTy.getNumElements(), MaxVectorSize, ST.isShader());
+  unsigned VectorSplitWidth =
+      getVectorSplitWidth(DstTy.getNumElements(), MaxVectorSize, ST.isShader());
   LLT ChunkTy = LLT::fixed_vector(VectorSplitWidth, EltTy);
   unsigned NumSrcChunks = SrcTy.getNumElements() / VectorSplitWidth;
   unsigned NumDstChunks = DstTy.getNumElements() / VectorSplitWidth;

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -775,6 +775,112 @@ static bool legalizeStore(LegalizerHelper &Helper, MachineInstr &MI,
   return true;
 }
 
+// Returns true if a G_UNMERGE_VALUES use scalarizes DstReg without ever
+// feeding a G_BUILD_VECTOR (directly or through its scalar defs). Such an
+// unmerge is just scattering DstReg's lanes out to individual scalars.
+static bool unmergeOnlyScatters(MachineRegisterInfo &MRI,
+                                const MachineInstr &Unmerge) {
+  if (!MRI.getType(Unmerge.getOperand(0).getReg()).isScalar())
+    return false;
+  for (const MachineOperand &Def : Unmerge.defs())
+    for (MachineInstr &U : MRI.use_nodbg_instructions(Def.getReg()))
+      if (U.getOpcode() == TargetOpcode::G_BUILD_VECTOR ||
+          U.getOpcode() == TargetOpcode::G_BUILD_VECTOR_TRUNC)
+        return false;
+  return true;
+}
+
+// Returns true if every use of DstReg just scatters it out (feeds a G_STORE,
+// or a G_UNMERGE_VALUES that doesn't feed a G_BUILD_VECTOR). In that case
+// chunk-vectorizing the shuffle only adds overhead, so the caller should fall
+// back to the generic scalarizing lowering instead.
+static bool allUsesAreShuffleScatter(MachineRegisterInfo &MRI,
+                                     Register DstReg) {
+  if (MRI.use_nodbg_empty(DstReg))
+    return false;
+  auto IsScatterUse = [&](MachineInstr &Use) {
+    if (Use.getOpcode() == TargetOpcode::G_STORE)
+      return true;
+    return Use.getOpcode() == TargetOpcode::G_UNMERGE_VALUES &&
+           unmergeOnlyScatters(MRI, Use);
+  };
+  for (MachineInstr &Use : MRI.use_nodbg_instructions(DstReg))
+    if (!IsScatterUse(Use))
+      return false;
+  return true;
+}
+
+// Splits SrcReg into NumChunks separate ChunkTy-typed registers.
+static SmallVector<Register> unmergeIntoChunks(MachineIRBuilder &MIRBuilder,
+                                               MachineRegisterInfo &MRI,
+                                               Register SrcReg,
+                                               unsigned NumChunks,
+                                               LLT ChunkTy) {
+  assert(NumChunks >= 2 && "ShuffleChunkable should have handled this case");
+  SmallVector<Register> Regs;
+  for (unsigned I = 0; I < NumChunks; ++I)
+    Regs.push_back(MRI.createGenericVirtualRegister(ChunkTy));
+  MIRBuilder.buildUnmerge(Regs, SrcReg);
+  return Regs;
+}
+
+// Builds one legal-width dst chunk of a chunked shuffle. ChunkMask indexes
+// lanes of the logical concatenation and chains legal-width OpVectorShuffles
+// folding in one contributing source chunk's lanes at each step.
+static Register buildShuffleChunk(MachineIRBuilder &MIRBuilder,
+                                  MachineRegisterInfo &MRI, LLT ChunkTy,
+                                  unsigned VectorSplitWidth,
+                                  ArrayRef<int> ChunkMask,
+                                  ArrayRef<Register> SrcChunks) {
+  SmallVector<int> LaneSrcChunk(VectorSplitWidth, -1);
+  SmallVector<int> LaneInChunk(VectorSplitWidth, -1);
+  SmallVector<unsigned> UsedChunks;
+  for (unsigned J = 0; J < VectorSplitWidth; ++J) {
+    int ChunkElementMask = ChunkMask[J];
+    if (ChunkElementMask < 0)
+      continue;
+    unsigned SrcChunk = ChunkElementMask / VectorSplitWidth;
+    LaneSrcChunk[J] = SrcChunk;
+    LaneInChunk[J] = ChunkElementMask % VectorSplitWidth;
+    if (!is_contained(UsedChunks, SrcChunk))
+      UsedChunks.push_back(SrcChunk);
+  }
+
+  if (UsedChunks.empty()) {
+    Register Undef = MRI.createGenericVirtualRegister(ChunkTy);
+    MIRBuilder.buildUndef(Undef);
+    return Undef;
+  }
+
+  Register Partial;
+  SmallVector<bool> Resolved(VectorSplitWidth, false);
+  for (unsigned Step = 0; Step < UsedChunks.size(); ++Step) {
+    unsigned SC = UsedChunks[Step];
+    Register SrcChunk = SrcChunks[SC];
+    SmallVector<int> ShufMask(VectorSplitWidth, -1);
+    Register Res = MRI.createGenericVirtualRegister(ChunkTy);
+    if (Step == 0) {
+      for (unsigned J = 0; J < VectorSplitWidth; ++J)
+        if (LaneSrcChunk[J] == static_cast<int>(SC))
+          ShufMask[J] = LaneInChunk[J];
+      MIRBuilder.buildShuffleVector(Res, SrcChunk, SrcChunk, ShufMask);
+    } else {
+      for (unsigned J = 0; J < VectorSplitWidth; ++J) {
+        if (LaneSrcChunk[J] == static_cast<int>(SC))
+          ShufMask[J] = static_cast<int>(VectorSplitWidth) + LaneInChunk[J];
+        else if (Resolved[J])
+          ShufMask[J] = static_cast<int>(J);
+      }
+      MIRBuilder.buildShuffleVector(Res, Partial, SrcChunk, ShufMask);
+    }
+    for (unsigned J = 0; J < VectorSplitWidth; ++J)
+      if (LaneSrcChunk[J] == static_cast<int>(SC))
+        Resolved[J] = true;
+    Partial = Res;
+  }
+  return Partial;
+}
+
 // Lowers wide G_SHUFFLE_VECTORs into legal-width chunked OpVectorShuffles
 // instead of scalarizing. Unmerge/concat artifacts fold away naturally.
 // Requires shader targets and matching chunk widths (see shuffleChunkable).
@@ -783,34 +889,8 @@ static bool legalizeShuffleVector(LegalizerHelper &Helper, MachineInstr &MI) {
   MachineIRBuilder &MIRBuilder = Helper.MIRBuilder;
   Register DstReg = MI.getOperand(0).getReg();
 
-  // Chunk-vectorize wide shuffles unless feeding a G_STORE or scalar
-  // G_UNMERGE_VALUES. Exception: Keep vectorizing if the unmerge directly
-  // feeds a G_BUILD_VECTOR.
-  if (!MRI.use_nodbg_empty(DstReg)) {
-    auto IsScatterUse = [&](MachineInstr &Use) {
-      if (Use.getOpcode() == TargetOpcode::G_STORE)
-        return true;
-      if (Use.getOpcode() == TargetOpcode::G_UNMERGE_VALUES &&
-          MRI.getType(Use.getOperand(0).getReg()).isScalar()) {
-        for (const MachineOperand &Def : Use.defs())
-          for (MachineInstr &U : MRI.use_nodbg_instructions(Def.getReg()))
-            if (U.getOpcode() == TargetOpcode::G_BUILD_VECTOR ||
-                U.getOpcode() == TargetOpcode::G_BUILD_VECTOR_TRUNC)
-              return false;
-        return true;
-      }
-      return false;
-    };
-    bool AllScatter = true;
-    for (MachineInstr &Use : MRI.use_nodbg_instructions(DstReg)) {
-      if (!IsScatterUse(Use)) {
-        AllScatter = false;
-        break;
-      }
-    }
-    if (AllScatter)
-      return Helper.lower(MI, 0, LLT()) == LegalizerHelper::Legalized;
-  }
+  if (allUsesAreShuffleScatter(MRI, DstReg))
+    return Helper.lower(MI, 0, LLT()) == LegalizerHelper::Legalized;
 
   Register Src1Reg = MI.getOperand(1).getReg();
   Register Src2Reg = MI.getOperand(2).getReg();
@@ -822,83 +902,26 @@ static bool legalizeShuffleVector(LegalizerHelper &Helper, MachineInstr &MI) {
 
   const SPIRVSubtarget &ST = MI.getMF()->getSubtarget<SPIRVSubtarget>();
   unsigned MaxVectorSize = ST.isShader() ? 4 : 16;
-  unsigned DstN = DstTy.getNumElements();
-  unsigned SrcN = SrcTy.getNumElements();
-  unsigned VectorSplitWidth =
-      getVectorSplitWidth(DstN, MaxVectorSize, ST.isShader());
-
+  unsigned VectorSplitWidth = getVectorSplitWidth(
+      DstTy.getNumElements(), MaxVectorSize, ST.isShader());
   LLT ChunkTy = LLT::fixed_vector(VectorSplitWidth, EltTy);
-  unsigned NumSrcChunks = SrcN / VectorSplitWidth; // per source operand
-  unsigned NumDstChunks = DstN / VectorSplitWidth;
+  unsigned NumSrcChunks = SrcTy.getNumElements() / VectorSplitWidth;
+  unsigned NumDstChunks = DstTy.getNumElements() / VectorSplitWidth;
 
-  // Split both sources into W-wide chunks. The G_SHUFFLE_VECTOR mask indexes a
-  // logical concatenation of the two sources, so lay the chunks out the same
-  // way: global chunk indices [0, NumSrcChunks) are Src1, the next NumSrcChunks
-  // are Src2. A source lane L lives in chunk L / W at lane L % W.
-  SmallVector<Register> SrcChunks;
-  auto UnmergeInto = [&](Register SrcReg) {
-    assert(NumSrcChunks >= 2 &&
-           "ShuffleChunkable should have handled this case");
-    SmallVector<Register> Regs;
-    for (unsigned I = 0; I < NumSrcChunks; ++I)
-      Regs.push_back(MRI.createGenericVirtualRegister(ChunkTy));
-    MIRBuilder.buildUnmerge(Regs, SrcReg);
-    SrcChunks.append(Regs.begin(), Regs.end());
-  };
-  UnmergeInto(Src1Reg);
-  UnmergeInto(Src2Reg);
+  // The G_SHUFFLE_VECTOR mask indexes a logical concatenation of the two
+  // sources, so lay the chunks out the same way: global chunk indices
+  // [0, NumSrcChunks) are Src1, the next NumSrcChunks are Src2.
+  SmallVector<Register> SrcChunks =
+      unmergeIntoChunks(MIRBuilder, MRI, Src1Reg, NumSrcChunks, ChunkTy);
+  SmallVector<Register> Src2Chunks =
+      unmergeIntoChunks(MIRBuilder, MRI, Src2Reg, NumSrcChunks, ChunkTy);
+  SrcChunks.append(Src2Chunks.begin(), Src2Chunks.end());
 
   SmallVector<Register> DstChunks;
-  for (unsigned D = 0; D < NumDstChunks; ++D) {
-    SmallVector<int> LaneSrcChunk(VectorSplitWidth, -1);
-    SmallVector<int> LaneInChunk(VectorSplitWidth, -1);
-    SmallVector<unsigned> UsedChunks;
-    for (unsigned J = 0; J < VectorSplitWidth; ++J) {
-      int ChunkElementMask = Mask[D * VectorSplitWidth + J];
-      if (ChunkElementMask < 0)
-        continue;
-      int SrcChunk = ChunkElementMask / VectorSplitWidth;
-      LaneSrcChunk[J] = SrcChunk;
-      LaneInChunk[J] = ChunkElementMask % VectorSplitWidth;
-      if (!is_contained(UsedChunks, SrcChunk))
-        UsedChunks.push_back(SrcChunk);
-    }
-
-    Register Partial;
-    if (UsedChunks.empty()) {
-      Partial = MRI.createGenericVirtualRegister(ChunkTy);
-      MIRBuilder.buildUndef(Partial);
-    } else {
-      // Build the chunk by chaining legal-width shuffles to accumulate
-      // lanes from each source chunk.
-      SmallVector<bool> Resolved(VectorSplitWidth, false);
-      for (unsigned Step = 0; Step < UsedChunks.size(); ++Step) {
-        unsigned SC = UsedChunks[Step];
-        Register SrcChunk = SrcChunks[SC];
-        SmallVector<int> ShufMask(VectorSplitWidth, -1);
-        Register Res = MRI.createGenericVirtualRegister(ChunkTy);
-        if (Step == 0) {
-          for (unsigned J = 0; J < VectorSplitWidth; ++J)
-            if (LaneSrcChunk[J] == static_cast<int>(SC))
-              ShufMask[J] = LaneInChunk[J];
-          MIRBuilder.buildShuffleVector(Res, SrcChunk, SrcChunk, ShufMask);
-        } else {
-          for (unsigned J = 0; J < VectorSplitWidth; ++J) {
-            if (LaneSrcChunk[J] == static_cast<int>(SC))
-              ShufMask[J] = static_cast<int>(VectorSplitWidth) + LaneInChunk[J];
-            else if (Resolved[J])
-              ShufMask[J] = static_cast<int>(J);
-          }
-          MIRBuilder.buildShuffleVector(Res, Partial, SrcChunk, ShufMask);
-        }
-        for (unsigned J = 0; J < VectorSplitWidth; ++J)
-          if (LaneSrcChunk[J] == static_cast<int>(SC))
-            Resolved[J] = true;
-        Partial = Res;
-      }
-    }
-    DstChunks.push_back(Partial);
-  }
+  for (unsigned D = 0; D < NumDstChunks; ++D)
+    DstChunks.push_back(buildShuffleChunk(
+        MIRBuilder, MRI, ChunkTy, VectorSplitWidth,
+        Mask.slice(D * VectorSplitWidth, VectorSplitWidth), SrcChunks));
 
   // A single-chunk result is already the final legal-width value.
   if (DstChunks.size() == 1)

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -38,6 +38,19 @@ LegalityPredicate typeOfExtendedScalars(unsigned TypeIdx, bool IsExtendedInts) {
   };
 }
 
+// Split a wider vector into a legal vector. For shader targets, pick the
+// largest divisor in [2, MaxVectorSize] (9 -> 3, 12 -> 4). Returns 1 for
+// prime widths (scalarize). Non-shader targets are 2/3/4/8/16
+static unsigned getVectorSplitWidth(unsigned NumElts, unsigned MaxVectorSize,
+                                    bool IsShader) {
+  if (!IsShader)
+    return MaxVectorSize;
+  for (unsigned D = std::min(NumElts, MaxVectorSize); D >= 2; --D)
+    if (NumElts % D == 0)
+      return D;
+  return 1;
+}
+
 SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
   using namespace TargetOpcode;
 
@@ -191,6 +204,17 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
   uint32_t MaxVectorSize = ST.isShader() ? 4 : 16;
   LLVM_DEBUG(dbgs() << "MaxVectorSize: " << MaxVectorSize << "\n");
 
+  // The following lambda is used to split wide vectors into legal vectors.
+  // Informed by getVectorSplitWidth.
+  auto SplitWideVectorToDivisor =
+      [MaxVectorSize, IsShader = ST.isShader()](const LegalityQuery &Query) {
+        const LLT Ty = Query.Types[0];
+        unsigned Target =
+            getVectorSplitWidth(Ty.getNumElements(), MaxVectorSize, IsShader);
+        return std::make_pair(
+            0u, Ty.changeElementCount(ElementCount::getFixed(Target)));
+      };
+
   for (auto Opc : getTypeFoldingSupportedOpcodes()) {
     switch (Opc) {
     case G_EXTRACT_VECTOR_ELT:
@@ -233,8 +257,30 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
 
   getActionDefinitionsBuilder(G_INTRINSIC_W_SIDE_EFFECTS).custom();
 
+  // Lower wide G_SHUFFLE_VECTORs into per-chunk shuffles.
+  // Note: Only applies to shader targets, not kernels.
+  auto ShuffleChunkable =
+      [MaxVectorSize, IsShader = ST.isShader()](const LegalityQuery &Query) {
+        const LLT DstTy = Query.Types[0];
+        const LLT SrcTy = Query.Types[1];
+        if (!IsShader || !DstTy.isVector() || !SrcTy.isVector())
+          return false;
+        unsigned DstN = DstTy.getNumElements();
+        unsigned SrcN = SrcTy.getNumElements();
+        if (DstN <= MaxVectorSize || SrcN <= MaxVectorSize)
+          return false;
+        // Power-of-two shuffles  can use generic lowering handles
+        if (isPowerOf2_32(DstN) || isPowerOf2_32(SrcN))
+          return false;
+        // past this point is non-power-of-two matrix eg (6, 9, 12)
+        unsigned Wd = getVectorSplitWidth(DstN, MaxVectorSize, IsShader);
+        unsigned Ws = getVectorSplitWidth(SrcN, MaxVectorSize, IsShader);
+        return Wd >= 2 && Wd == Ws;
+      };
+
   getActionDefinitionsBuilder(G_SHUFFLE_VECTOR)
       .legalForCartesianProduct(allowedVectorTypes, allowedVectorTypes)
+      .customIf(ShuffleChunkable)
       .moreElementsToNextPow2(0)
       .lowerIf(vectorElementCountIsGreaterThan(0, MaxVectorSize))
       .moreElementsToNextPow2(1)
@@ -351,10 +397,15 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
       .legalForCartesianProduct(allIntScalarsAndVectors)
       .legalIf(extendedScalarsAndVectorsProduct);
 
-  // Extensions.
+  // Vulkan Shaders limits vectors to 2-4 components. Split wider vectors into
+  // <= MaxVectorSize chunks for independent extend/truncate operations.
+  // NOTE: Intentionally not using moreElementsToNextPow2 here; padding rebuilds
+  // illegal wide vectors, whereas direct splitting safely handles remainders.
   getActionDefinitionsBuilder({G_TRUNC, G_ZEXT, G_SEXT, G_ANYEXT})
       .legalForCartesianProduct(allScalarsAndVectors)
-      .legalIf(extendedScalarsAndVectorsProduct);
+      .legalIf(extendedScalarsAndVectorsProduct)
+      .fewerElementsIf(vectorElementCountIsGreaterThan(0, MaxVectorSize),
+                       SplitWideVectorToDivisor);
 
   // Lower G_SEXT_INREG to the canonical shl/ashr pair, which map to
   // OpShiftLeftLogical + OpShiftRightArithmetic.
@@ -718,6 +769,143 @@ static bool legalizeStore(LegalizerHelper &Helper, MachineInstr &MI,
   return true;
 }
 
+// Lowers wide G_SHUFFLE_VECTORs into legal-width chunked OpVectorShuffles
+// instead of scalarizing. Unmerge/concat artifacts fold away naturally.
+// Requires shader targets and matching chunk widths (see shuffleChunkable).
+static bool legalizeShuffleVector(LegalizerHelper &Helper, MachineInstr &MI,
+                                  SPIRVGlobalRegistry *GR) {
+  MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
+  MachineIRBuilder &MIRBuilder = Helper.MIRBuilder;
+  Register DstReg = MI.getOperand(0).getReg();
+
+  // Chunk-vectorize wide shuffles unless feeding a G_STORE or scalar
+  // G_UNMERGE_VALUES. Exception: Keep vectorizing if the unmerge directly
+  // feeds a G_BUILD_VECTOR.
+  if (!MRI.use_nodbg_empty(DstReg)) {
+    auto IsScatterUse = [&](MachineInstr &Use) {
+      if (Use.getOpcode() == TargetOpcode::G_STORE)
+        return true;
+      if (Use.getOpcode() == TargetOpcode::G_UNMERGE_VALUES &&
+          MRI.getType(Use.getOperand(0).getReg()).isScalar()) {
+        for (const MachineOperand &Def : Use.defs())
+          for (MachineInstr &U : MRI.use_nodbg_instructions(Def.getReg()))
+            if (U.getOpcode() == TargetOpcode::G_BUILD_VECTOR ||
+                U.getOpcode() == TargetOpcode::G_BUILD_VECTOR_TRUNC)
+              return false;
+        return true;
+      }
+      return false;
+    };
+    bool AllScatter = true;
+    for (MachineInstr &Use : MRI.use_nodbg_instructions(DstReg)) {
+      if (!IsScatterUse(Use)) {
+        AllScatter = false;
+        break;
+      }
+    }
+    if (AllScatter)
+      return Helper.lower(MI, 0, LLT()) == LegalizerHelper::Legalized;
+  }
+
+  Register Src1Reg = MI.getOperand(1).getReg();
+  Register Src2Reg = MI.getOperand(2).getReg();
+  ArrayRef<int> Mask = MI.getOperand(3).getShuffleMask();
+
+  LLT DstTy = MRI.getType(DstReg);
+  LLT SrcTy = MRI.getType(Src1Reg);
+  LLT EltTy = SrcTy.getElementType();
+
+  const SPIRVSubtarget &ST = MI.getMF()->getSubtarget<SPIRVSubtarget>();
+  unsigned MaxVectorSize = ST.isShader() ? 4 : 16;
+  unsigned DstN = DstTy.getNumElements();
+  unsigned SrcN = SrcTy.getNumElements();
+  unsigned W = getVectorSplitWidth(DstN, MaxVectorSize, ST.isShader());
+
+  LLT ChunkTy = LLT::fixed_vector(W, EltTy);
+  unsigned NumSrcChunks = SrcN / W; // per source operand
+  unsigned NumDstChunks = DstN / W;
+
+  // Split both sources into W-wide chunks. The G_SHUFFLE_VECTOR mask indexes a
+  // logical concatenation of the two sources, so lay the chunks out the same
+  // way: global chunk indices [0, NumSrcChunks) are Src1, the next NumSrcChunks
+  // are Src2. A source lane L lives in chunk L / W at lane L % W.
+  SmallVector<Register, 8> SrcChunks;
+  auto unmergeInto = [&](Register SrcReg) {
+    // A source that is already a single legal chunk needs no unmerge.
+    if (NumSrcChunks == 1) {
+      SrcChunks.push_back(SrcReg);
+      return;
+    }
+    SmallVector<Register, 4> Regs;
+    for (unsigned I = 0; I < NumSrcChunks; ++I)
+      Regs.push_back(MRI.createGenericVirtualRegister(ChunkTy));
+    MIRBuilder.buildUnmerge(Regs, SrcReg);
+    SrcChunks.append(Regs.begin(), Regs.end());
+  };
+  unmergeInto(Src1Reg);
+  unmergeInto(Src2Reg);
+
+  SmallVector<Register, 4> DstChunks;
+  for (unsigned D = 0; D < NumDstChunks; ++D) {
+    SmallVector<int, 8> LaneSrcChunk(W, -1);
+    SmallVector<int, 8> LaneInChunk(W, -1);
+    SmallVector<unsigned, 4> UsedChunks;
+    for (unsigned J = 0; J < W; ++J) {
+      int M = Mask[D * W + J];
+      if (M < 0)
+        continue;
+      unsigned SC = static_cast<unsigned>(M) / W;
+      LaneSrcChunk[J] = static_cast<int>(SC);
+      LaneInChunk[J] = static_cast<int>(static_cast<unsigned>(M) % W);
+      if (!is_contained(UsedChunks, SC))
+        UsedChunks.push_back(SC);
+    }
+
+    Register Partial;
+    if (UsedChunks.empty()) {
+      Partial = MRI.createGenericVirtualRegister(ChunkTy);
+      MIRBuilder.buildUndef(Partial);
+    } else {
+      // Build the chunk by chaining legal-width shuffles to accumulate
+      // lanes from each source chunk.
+      SmallVector<bool, 8> Resolved(W, false);
+      for (unsigned Step = 0; Step < UsedChunks.size(); ++Step) {
+        unsigned SC = UsedChunks[Step];
+        Register SrcChunk = SrcChunks[SC];
+        SmallVector<int, 8> ShufMask(W, -1);
+        Register Res = MRI.createGenericVirtualRegister(ChunkTy);
+        if (Step == 0) {
+          for (unsigned J = 0; J < W; ++J)
+            if (LaneSrcChunk[J] == static_cast<int>(SC))
+              ShufMask[J] = LaneInChunk[J];
+          MIRBuilder.buildShuffleVector(Res, SrcChunk, SrcChunk, ShufMask);
+        } else {
+          for (unsigned J = 0; J < W; ++J) {
+            if (LaneSrcChunk[J] == static_cast<int>(SC))
+              ShufMask[J] = static_cast<int>(W) + LaneInChunk[J];
+            else if (Resolved[J])
+              ShufMask[J] = static_cast<int>(J);
+          }
+          MIRBuilder.buildShuffleVector(Res, Partial, SrcChunk, ShufMask);
+        }
+        for (unsigned J = 0; J < W; ++J)
+          if (LaneSrcChunk[J] == static_cast<int>(SC))
+            Resolved[J] = true;
+        Partial = Res;
+      }
+    }
+    DstChunks.push_back(Partial);
+  }
+
+  // A single-chunk result is already the final legal-width value.
+  if (DstChunks.size() == 1)
+    MIRBuilder.buildCopy(DstReg, DstChunks[0]);
+  else
+    MIRBuilder.buildConcatVectors(DstReg, DstChunks);
+  MI.eraseFromParent();
+  return true;
+}
+
 bool SPIRVLegalizerInfo::legalizeCustom(
     LegalizerHelper &Helper, MachineInstr &MI,
     LostDebugLocObserver &LocObserver) const {
@@ -761,6 +949,8 @@ bool SPIRVLegalizerInfo::legalizeCustom(
     return legalizeLoad(Helper, MI, GR);
   case TargetOpcode::G_STORE:
     return legalizeStore(Helper, MI, GR);
+  case TargetOpcode::G_SHUFFLE_VECTOR:
+    return legalizeShuffleVector(Helper, MI, GR);
   }
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -269,7 +269,7 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
         unsigned SrcN = SrcTy.getNumElements();
         if (DstN <= MaxVectorSize || SrcN <= MaxVectorSize)
           return false;
-        // Power-of-two shuffles  can use generic lowering handles
+        // Power-of-two shuffles can use generic lowering handles
         if (isPowerOf2_32(DstN) || isPowerOf2_32(SrcN))
           return false;
         // past this point is non-power-of-two matrix eg (6, 9, 12)
@@ -772,8 +772,7 @@ static bool legalizeStore(LegalizerHelper &Helper, MachineInstr &MI,
 // Lowers wide G_SHUFFLE_VECTORs into legal-width chunked OpVectorShuffles
 // instead of scalarizing. Unmerge/concat artifacts fold away naturally.
 // Requires shader targets and matching chunk widths (see shuffleChunkable).
-static bool legalizeShuffleVector(LegalizerHelper &Helper, MachineInstr &MI,
-                                  SPIRVGlobalRegistry *GR) {
+static bool legalizeShuffleVector(LegalizerHelper &Helper, MachineInstr &MI) {
   MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
   MachineIRBuilder &MIRBuilder = Helper.MIRBuilder;
   Register DstReg = MI.getOperand(0).getReg();
@@ -819,46 +818,42 @@ static bool legalizeShuffleVector(LegalizerHelper &Helper, MachineInstr &MI,
   unsigned MaxVectorSize = ST.isShader() ? 4 : 16;
   unsigned DstN = DstTy.getNumElements();
   unsigned SrcN = SrcTy.getNumElements();
-  unsigned W = getVectorSplitWidth(DstN, MaxVectorSize, ST.isShader());
+  unsigned VectorSplitWidth = getVectorSplitWidth(DstN, MaxVectorSize, ST.isShader());
 
-  LLT ChunkTy = LLT::fixed_vector(W, EltTy);
-  unsigned NumSrcChunks = SrcN / W; // per source operand
-  unsigned NumDstChunks = DstN / W;
+  LLT ChunkTy = LLT::fixed_vector(VectorSplitWidth, EltTy);
+  unsigned NumSrcChunks = SrcN / VectorSplitWidth; // per source operand
+  unsigned NumDstChunks = DstN / VectorSplitWidth;
 
   // Split both sources into W-wide chunks. The G_SHUFFLE_VECTOR mask indexes a
   // logical concatenation of the two sources, so lay the chunks out the same
   // way: global chunk indices [0, NumSrcChunks) are Src1, the next NumSrcChunks
   // are Src2. A source lane L lives in chunk L / W at lane L % W.
-  SmallVector<Register, 8> SrcChunks;
-  auto unmergeInto = [&](Register SrcReg) {
-    // A source that is already a single legal chunk needs no unmerge.
-    if (NumSrcChunks == 1) {
-      SrcChunks.push_back(SrcReg);
-      return;
-    }
-    SmallVector<Register, 4> Regs;
+  SmallVector<Register> SrcChunks;
+  auto UnmergeInto = [&](Register SrcReg) {
+    assert (NumSrcChunks >= 2 && "ShuffleChunkable should have handled this case");
+    SmallVector<Register> Regs;
     for (unsigned I = 0; I < NumSrcChunks; ++I)
       Regs.push_back(MRI.createGenericVirtualRegister(ChunkTy));
     MIRBuilder.buildUnmerge(Regs, SrcReg);
     SrcChunks.append(Regs.begin(), Regs.end());
   };
-  unmergeInto(Src1Reg);
-  unmergeInto(Src2Reg);
+  UnmergeInto(Src1Reg);
+  UnmergeInto(Src2Reg);
 
-  SmallVector<Register, 4> DstChunks;
+  SmallVector<Register> DstChunks;
   for (unsigned D = 0; D < NumDstChunks; ++D) {
-    SmallVector<int, 8> LaneSrcChunk(W, -1);
-    SmallVector<int, 8> LaneInChunk(W, -1);
-    SmallVector<unsigned, 4> UsedChunks;
-    for (unsigned J = 0; J < W; ++J) {
-      int M = Mask[D * W + J];
-      if (M < 0)
+    SmallVector<int> LaneSrcChunk(VectorSplitWidth, -1);
+    SmallVector<int> LaneInChunk(VectorSplitWidth, -1);
+    SmallVector<unsigned> UsedChunks;
+    for (unsigned J = 0; J < VectorSplitWidth; ++J) {
+      int ChunkElementMask = Mask[D * VectorSplitWidth + J];
+      if (ChunkElementMask < 0)
         continue;
-      unsigned SC = static_cast<unsigned>(M) / W;
-      LaneSrcChunk[J] = static_cast<int>(SC);
-      LaneInChunk[J] = static_cast<int>(static_cast<unsigned>(M) % W);
-      if (!is_contained(UsedChunks, SC))
-        UsedChunks.push_back(SC);
+      int SrcChunk = ChunkElementMask / VectorSplitWidth;
+      LaneSrcChunk[J] = SrcChunk;
+      LaneInChunk[J] = ChunkElementMask % VectorSplitWidth;
+      if (!is_contained(UsedChunks, SrcChunk))
+        UsedChunks.push_back(SrcChunk);
     }
 
     Register Partial;
@@ -868,27 +863,27 @@ static bool legalizeShuffleVector(LegalizerHelper &Helper, MachineInstr &MI,
     } else {
       // Build the chunk by chaining legal-width shuffles to accumulate
       // lanes from each source chunk.
-      SmallVector<bool, 8> Resolved(W, false);
+      SmallVector<bool> Resolved(VectorSplitWidth, false);
       for (unsigned Step = 0; Step < UsedChunks.size(); ++Step) {
         unsigned SC = UsedChunks[Step];
         Register SrcChunk = SrcChunks[SC];
-        SmallVector<int, 8> ShufMask(W, -1);
+        SmallVector<int> ShufMask(VectorSplitWidth, -1);
         Register Res = MRI.createGenericVirtualRegister(ChunkTy);
         if (Step == 0) {
-          for (unsigned J = 0; J < W; ++J)
+          for (unsigned J = 0; J < VectorSplitWidth; ++J)
             if (LaneSrcChunk[J] == static_cast<int>(SC))
               ShufMask[J] = LaneInChunk[J];
           MIRBuilder.buildShuffleVector(Res, SrcChunk, SrcChunk, ShufMask);
         } else {
-          for (unsigned J = 0; J < W; ++J) {
+          for (unsigned J = 0; J < VectorSplitWidth; ++J) {
             if (LaneSrcChunk[J] == static_cast<int>(SC))
-              ShufMask[J] = static_cast<int>(W) + LaneInChunk[J];
+              ShufMask[J] = static_cast<int>(VectorSplitWidth) + LaneInChunk[J];
             else if (Resolved[J])
               ShufMask[J] = static_cast<int>(J);
           }
           MIRBuilder.buildShuffleVector(Res, Partial, SrcChunk, ShufMask);
         }
-        for (unsigned J = 0; J < W; ++J)
+        for (unsigned J = 0; J < VectorSplitWidth; ++J)
           if (LaneSrcChunk[J] == static_cast<int>(SC))
             Resolved[J] = true;
         Partial = Res;
@@ -950,7 +945,7 @@ bool SPIRVLegalizerInfo::legalizeCustom(
   case TargetOpcode::G_STORE:
     return legalizeStore(Helper, MI, GR);
   case TargetOpcode::G_SHUFFLE_VECTOR:
-    return legalizeShuffleVector(Helper, MI, GR);
+    return legalizeShuffleVector(Helper, MI);
   }
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -408,8 +408,14 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
                        SplitWideVectorToDivisor);
 
   // Lower G_SEXT_INREG to the canonical shl/ashr pair, which map to
-  // OpShiftLeftLogical + OpShiftRightArithmetic.
-  getActionDefinitionsBuilder(G_SEXT_INREG).lower();
+  // OpShiftLeftLogical + OpShiftRightArithmetic. Split wide vectors the same
+  // GCD-divisor way as G_TRUNC/G_ZEXT/G_SEXT above (rather than falling back
+  // to the generic pow2/MaxVectorSize padding split) so sign-extension of a
+  // wide non-power-of-two vector doesn't needlessly pad with undef lanes.
+  getActionDefinitionsBuilder(G_SEXT_INREG)
+      .fewerElementsIf(vectorElementCountIsGreaterThan(0, MaxVectorSize),
+                       SplitWideVectorToDivisor)
+      .lower();
 
   getActionDefinitionsBuilder(G_PHI)
       .legalFor(allPtrsScalarsAndVectors)
@@ -818,7 +824,8 @@ static bool legalizeShuffleVector(LegalizerHelper &Helper, MachineInstr &MI) {
   unsigned MaxVectorSize = ST.isShader() ? 4 : 16;
   unsigned DstN = DstTy.getNumElements();
   unsigned SrcN = SrcTy.getNumElements();
-  unsigned VectorSplitWidth = getVectorSplitWidth(DstN, MaxVectorSize, ST.isShader());
+  unsigned VectorSplitWidth =
+      getVectorSplitWidth(DstN, MaxVectorSize, ST.isShader());
 
   LLT ChunkTy = LLT::fixed_vector(VectorSplitWidth, EltTy);
   unsigned NumSrcChunks = SrcN / VectorSplitWidth; // per source operand
@@ -830,7 +837,8 @@ static bool legalizeShuffleVector(LegalizerHelper &Helper, MachineInstr &MI) {
   // are Src2. A source lane L lives in chunk L / W at lane L % W.
   SmallVector<Register> SrcChunks;
   auto UnmergeInto = [&](Register SrcReg) {
-    assert (NumSrcChunks >= 2 && "ShuffleChunkable should have handled this case");
+    assert(NumSrcChunks >= 2 &&
+           "ShuffleChunkable should have handled this case");
     SmallVector<Register> Regs;
     for (unsigned I = 0; I < NumSrcChunks; ++I)
       Regs.push_back(MRI.createGenericVirtualRegister(ChunkTy));

--- a/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
@@ -49,7 +49,12 @@ static SPIRVTypeInst deduceIntTypeFromResult(Register ResVReg,
                                              MachineIRBuilder &MIB,
                                              SPIRVGlobalRegistry *GR) {
   const LLT &Ty = MIB.getMRI()->getType(ResVReg);
-  return GR->getOrCreateSPIRVIntegerType(Ty.getScalarSizeInBits(), MIB);
+  SPIRVTypeInst ScalarType =
+      GR->getOrCreateSPIRVIntegerType(Ty.getScalarSizeInBits(), MIB);
+  if (Ty.isVector())
+    return GR->getOrCreateSPIRVVectorType(ScalarType, Ty.getNumElements(), MIB,
+                                          false);
+  return ScalarType;
 }
 
 static SPIRVTypeInst deduceTypeFromSingleOperand(MachineInstr *I,

--- a/llvm/test/CodeGen/SPIRV/legalization/matrix-wide-vector-shader.ll
+++ b/llvm/test/CodeGen/SPIRV/legalization/matrix-wide-vector-shader.ll
@@ -14,19 +14,13 @@
 @out9  = internal addrspace(10) global [9 x i32] poison
 
 ; CHECK-DAG: %[[#Int:]] = OpTypeInt 32 0
-; CHECK-DAG: %[[#Bool:]] = OpTypeBool
 ; CHECK-DAG: %[[#V4Int:]] = OpTypeVector %[[#Int]] 4
 ; CHECK-DAG: %[[#V3Int:]] = OpTypeVector %[[#Int]] 3
-; CHECK-DAG: %[[#V4Bool:]] = OpTypeVector %[[#Bool]] 4
-; CHECK-DAG: %[[#V3Bool:]] = OpTypeVector %[[#Bool]] 3
 
 ; No vector wider than 4 components may ever be produced for shader targets.
 ; CHECK-NOT: OpTypeVector %[[#Int]] 12
 ; CHECK-NOT: OpTypeVector %[[#Int]] 9
 ; CHECK-NOT: OpTypeVector %[[#Int]] 8
-; CHECK-NOT: OpTypeVector %[[#Bool]] 12
-; CHECK-NOT: OpTypeVector %[[#Bool]] 9
-; CHECK-NOT: OpTypeVector %[[#Bool]] 8
 
 ;===----------------------------------------------------------------------===;
 ; Pure load + store (no extend) of the flattened matrix.
@@ -107,15 +101,21 @@ define internal void @trunc_zext_4x3() {
 
 ;===----------------------------------------------------------------------===;
 ; Truncation to i1 then sign-extend back to i32.
-; sext(trunc(x)->i1) lowers to (x & 1) != 0 ? -1 : 0, i.e. BitwiseAnd +
-; INotEqual + Select. Both widths stay vectorized: the 12-lane case as three
-; <4 x> chunks, the 9-lane case as three <3 x> chunks.
+; sext(trunc(x)->i1) canonicalizes to G_SEXT_INREG, which this target lowers
+; to the canonical shl/ashr pair (shift left then arithmetic shift right by
+; the bit-width minus one), so no boolean type is ever materialized. Both
+; widths split the same GCD-divisor way as trunc_zext above: the 12-lane case
+; as three <4 x i32> chunks, the 9-lane case as three <3 x i32> chunks.
 ;===----------------------------------------------------------------------===;
 
 ; CHECK-LABEL: ; -- Begin function trunc_sext_3x4
-; CHECK-COUNT-3: OpINotEqual %[[#V4Bool]]
-; CHECK-NOT: OpINotEqual %[[#V4Bool]]
-; CHECK-COUNT-3: OpSelect %[[#V4Int]]
+; CHECK: OpShiftLeftLogical %[[#V4Int]]
+; CHECK-NEXT: OpShiftRightArithmetic %[[#V4Int]]
+; CHECK: OpShiftLeftLogical %[[#V4Int]]
+; CHECK-NEXT: OpShiftRightArithmetic %[[#V4Int]]
+; CHECK: OpShiftLeftLogical %[[#V4Int]]
+; CHECK-NEXT: OpShiftRightArithmetic %[[#V4Int]]
+; CHECK-NOT: OpShiftLeftLogical %[[#V4Int]]
 define internal void @trunc_sext_3x4() {
   %v = load <12 x i32>, ptr addrspace(10) @in12
   %b = trunc <12 x i32> %v to <12 x i1>
@@ -124,10 +124,16 @@ define internal void @trunc_sext_3x4() {
   ret void
 }
 
+; The 9-lane width shares divisor 3 with the max vector size, so it splits
+; into three <3 x i32> chunks (not scalarized), same as trunc_zext_3x3.
 ; CHECK-LABEL: ; -- Begin function trunc_sext_3x3
-; CHECK-COUNT-3: OpINotEqual %[[#V3Bool]]
-; CHECK-NOT: OpINotEqual %[[#V3Bool]]
-; CHECK-COUNT-3: OpSelect %[[#V3Int]]
+; CHECK: OpShiftLeftLogical %[[#V3Int]]
+; CHECK-NEXT: OpShiftRightArithmetic %[[#V3Int]]
+; CHECK: OpShiftLeftLogical %[[#V3Int]]
+; CHECK-NEXT: OpShiftRightArithmetic %[[#V3Int]]
+; CHECK: OpShiftLeftLogical %[[#V3Int]]
+; CHECK-NEXT: OpShiftRightArithmetic %[[#V3Int]]
+; CHECK-NOT: OpShiftLeftLogical %[[#V3Int]]
 define internal void @trunc_sext_3x3() {
   %v = load <9 x i32>, ptr addrspace(10) @in9
   %b = trunc <9 x i32> %v to <9 x i1>
@@ -138,9 +144,13 @@ define internal void @trunc_sext_3x3() {
 
 ; A 4x3 matrix is 12 elements, so it stays vectorized as three <4 x> chunks.
 ; CHECK-LABEL: ; -- Begin function trunc_sext_4x3
-; CHECK-COUNT-3: OpINotEqual %[[#V4Bool]]
-; CHECK-NOT: OpINotEqual %[[#V4Bool]]
-; CHECK-COUNT-3: OpSelect %[[#V4Int]]
+; CHECK: OpShiftLeftLogical %[[#V4Int]]
+; CHECK-NEXT: OpShiftRightArithmetic %[[#V4Int]]
+; CHECK: OpShiftLeftLogical %[[#V4Int]]
+; CHECK-NEXT: OpShiftRightArithmetic %[[#V4Int]]
+; CHECK: OpShiftLeftLogical %[[#V4Int]]
+; CHECK-NEXT: OpShiftRightArithmetic %[[#V4Int]]
+; CHECK-NOT: OpShiftLeftLogical %[[#V4Int]]
 define internal void @trunc_sext_4x3() {
   %v = load <12 x i32>, ptr addrspace(10) @in12
   %b = trunc <12 x i32> %v to <12 x i1>

--- a/llvm/test/CodeGen/SPIRV/legalization/matrix-wide-vector-shader.ll
+++ b/llvm/test/CodeGen/SPIRV/legalization/matrix-wide-vector-shader.ll
@@ -1,0 +1,156 @@
+; RUN: llc -O0 -mtriple=spirv1.6-unknown-vulkan1.3 %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv1.6-unknown-vulkan1.3 %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; Wide/non-standard-width vector legalization for LLVM matrix types on
+; shader/Vulkan targets, where SPIR-V vectors are limited to 4 components.
+; A bool3x4 flattens to a 12-element vector and a bool3x3 to a 9-element
+; vector; loads, stores, truncations, zero/sign extends of those must be split
+; into <= 4 lane chunks and never materialize a vector wider than 4.
+;
+
+@in12  = internal addrspace(10) global [12 x i32] poison
+@out12 = internal addrspace(10) global [12 x i32] poison
+@in9   = internal addrspace(10) global [9 x i32] poison
+@out9  = internal addrspace(10) global [9 x i32] poison
+
+; CHECK-DAG: %[[#Int:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#Bool:]] = OpTypeBool
+; CHECK-DAG: %[[#V4Int:]] = OpTypeVector %[[#Int]] 4
+; CHECK-DAG: %[[#V3Int:]] = OpTypeVector %[[#Int]] 3
+; CHECK-DAG: %[[#V4Bool:]] = OpTypeVector %[[#Bool]] 4
+; CHECK-DAG: %[[#V3Bool:]] = OpTypeVector %[[#Bool]] 3
+
+; No vector wider than 4 components may ever be produced for shader targets.
+; CHECK-NOT: OpTypeVector %[[#Int]] 12
+; CHECK-NOT: OpTypeVector %[[#Int]] 9
+; CHECK-NOT: OpTypeVector %[[#Int]] 8
+; CHECK-NOT: OpTypeVector %[[#Bool]] 12
+; CHECK-NOT: OpTypeVector %[[#Bool]] 9
+; CHECK-NOT: OpTypeVector %[[#Bool]] 8
+
+;===----------------------------------------------------------------------===;
+; Pure load + store (no extend) of the flattened matrix.
+;===----------------------------------------------------------------------===;
+
+; CHECK-LABEL: ; -- Begin function load_store_3x4
+; The wide load/store is scalarized into twelve per-element scalar accesses.
+; CHECK-COUNT-12: OpLoad %[[#Int]]
+; CHECK-COUNT-12: OpStore
+define internal void @load_store_3x4() {
+  %v = load <12 x i32>, ptr addrspace(10) @in12
+  store <12 x i32> %v, ptr addrspace(10) @out12
+  ret void
+}
+
+; CHECK-LABEL: ; -- Begin function load_store_3x3
+; CHECK-COUNT-9: OpLoad %[[#Int]]
+; CHECK-COUNT-9: OpStore
+define internal void @load_store_3x3() {
+  %v = load <9 x i32>, ptr addrspace(10) @in9
+  store <9 x i32> %v, ptr addrspace(10) @out9
+  ret void
+}
+
+; A 4x3 matrix flattens to the same 12-element width as 3x4, so it legalizes
+; identically: twelve per-element scalar load/stores.
+; CHECK-LABEL: ; -- Begin function load_store_4x3
+; CHECK-COUNT-12: OpLoad %[[#Int]]
+; CHECK-COUNT-12: OpStore
+define internal void @load_store_4x3() {
+  %v = load <12 x i32>, ptr addrspace(10) @in12
+  store <12 x i32> %v, ptr addrspace(10) @out12
+  ret void
+}
+
+;===----------------------------------------------------------------------===;
+; Truncation to i1 (bool matrix element) then zero-extend back to i32.
+; trunc(x)->i1 followed by zext(->i32) folds to (x & 1), so no INotEqual is
+; produced. Both flattened widths split into uniform vector chunks: the 12-lane
+; case as three <4 x i32> chunks, the 9-lane case as three <3 x i32> chunks.
+;===----------------------------------------------------------------------===;
+
+; CHECK-LABEL: ; -- Begin function trunc_zext_3x4
+; CHECK-COUNT-3: OpBitwiseAnd %[[#V4Int]]
+; CHECK-NOT: OpBitwiseAnd %[[#V4Int]]
+define internal void @trunc_zext_3x4() {
+  %v = load <12 x i32>, ptr addrspace(10) @in12
+  %b = trunc <12 x i32> %v to <12 x i1>
+  %e = zext <12 x i1> %b to <12 x i32>
+  store <12 x i32> %e, ptr addrspace(10) @out12
+  ret void
+}
+
+; The 9-lane width shares divisor 3 with the max vector size, so it splits into
+; three <3 x i32> chunks (not scalarized).
+; CHECK-LABEL: ; -- Begin function trunc_zext_3x3
+; CHECK-COUNT-3: OpBitwiseAnd %[[#V3Int]]
+; CHECK-NOT: OpBitwiseAnd %[[#V3Int]]
+define internal void @trunc_zext_3x3() {
+  %v = load <9 x i32>, ptr addrspace(10) @in9
+  %b = trunc <9 x i32> %v to <9 x i1>
+  %e = zext <9 x i1> %b to <9 x i32>
+  store <9 x i32> %e, ptr addrspace(10) @out9
+  ret void
+}
+
+; A 4x3 matrix is 12 elements, so it splits into three <4 x i32> chunks like 3x4.
+; CHECK-LABEL: ; -- Begin function trunc_zext_4x3
+; CHECK-COUNT-3: OpBitwiseAnd %[[#V4Int]]
+; CHECK-NOT: OpBitwiseAnd %[[#V4Int]]
+define internal void @trunc_zext_4x3() {
+  %v = load <12 x i32>, ptr addrspace(10) @in12
+  %b = trunc <12 x i32> %v to <12 x i1>
+  %e = zext <12 x i1> %b to <12 x i32>
+  store <12 x i32> %e, ptr addrspace(10) @out12
+  ret void
+}
+
+;===----------------------------------------------------------------------===;
+; Truncation to i1 then sign-extend back to i32.
+; sext(trunc(x)->i1) lowers to (x & 1) != 0 ? -1 : 0, i.e. BitwiseAnd +
+; INotEqual + Select. Both widths stay vectorized: the 12-lane case as three
+; <4 x> chunks, the 9-lane case as three <3 x> chunks.
+;===----------------------------------------------------------------------===;
+
+; CHECK-LABEL: ; -- Begin function trunc_sext_3x4
+; CHECK-COUNT-3: OpINotEqual %[[#V4Bool]]
+; CHECK-NOT: OpINotEqual %[[#V4Bool]]
+; CHECK-COUNT-3: OpSelect %[[#V4Int]]
+define internal void @trunc_sext_3x4() {
+  %v = load <12 x i32>, ptr addrspace(10) @in12
+  %b = trunc <12 x i32> %v to <12 x i1>
+  %e = sext <12 x i1> %b to <12 x i32>
+  store <12 x i32> %e, ptr addrspace(10) @out12
+  ret void
+}
+
+; CHECK-LABEL: ; -- Begin function trunc_sext_3x3
+; CHECK-COUNT-3: OpINotEqual %[[#V3Bool]]
+; CHECK-NOT: OpINotEqual %[[#V3Bool]]
+; CHECK-COUNT-3: OpSelect %[[#V3Int]]
+define internal void @trunc_sext_3x3() {
+  %v = load <9 x i32>, ptr addrspace(10) @in9
+  %b = trunc <9 x i32> %v to <9 x i1>
+  %e = sext <9 x i1> %b to <9 x i32>
+  store <9 x i32> %e, ptr addrspace(10) @out9
+  ret void
+}
+
+; A 4x3 matrix is 12 elements, so it stays vectorized as three <4 x> chunks.
+; CHECK-LABEL: ; -- Begin function trunc_sext_4x3
+; CHECK-COUNT-3: OpINotEqual %[[#V4Bool]]
+; CHECK-NOT: OpINotEqual %[[#V4Bool]]
+; CHECK-COUNT-3: OpSelect %[[#V4Int]]
+define internal void @trunc_sext_4x3() {
+  %v = load <12 x i32>, ptr addrspace(10) @in12
+  %b = trunc <12 x i32> %v to <12 x i1>
+  %e = sext <12 x i1> %b to <12 x i32>
+  store <12 x i32> %e, ptr addrspace(10) @out12
+  ret void
+}
+
+define void @main() #0 {
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/legalization/vector-legalization-shader.ll
+++ b/llvm/test/CodeGen/SPIRV/legalization/vector-legalization-shader.ll
@@ -87,7 +87,8 @@ entry:
   ret void
 }
 
-; Test splitting a vector of size 6. It must be expanded to 8, and then split.
+; The <6 x i32> is reassembled as two <3 x i32> chunks, and the two
+; deinterleave shuffles stay vectorized as chained <3 x> OpVectorShuffles
 define internal void @test_bitcast_expand() {
 entry:
   ; CHECK: %[[#load:]] = OpLoad %[[#v3double]] %[[#GVec3]]
@@ -101,19 +102,16 @@ entry:
   ; CHECK: %[[#v4i0:]] = OpBitcast %[[#v4int]] %[[#v2d0]]
   ; CHECK: %[[#v4i1:]] = OpBitcast %[[#v4int]] %[[#v2d1]]
   %1 = bitcast <3 x double> %0 to <6 x i32>
-  
-  ; CHECK: %[[#l0:]] = OpCompositeExtract %[[#int]] %[[#v4i0]] 0
-  ; CHECK: %[[#l1:]] = OpCompositeExtract %[[#int]] %[[#v4i0]] 2
-  ; CHECK: %[[#l2:]] = OpCompositeExtract %[[#int]] %[[#v4i1]] 0
-  ; CHECK: %[[#res_low:]] = OpCompositeConstruct %[[#v3int]] %[[#l0]] %[[#l1]] %[[#l2]]
+  ; (mask "0 1 4" for the low lanes, "0 3 5" for the high lanes) instead of
+  ; being scalarized into per-element extract/construct sequences.
+  ; CHECK: %[[#c0:]] = OpCompositeConstruct %[[#v3int]] %[[#]] %[[#]] %[[#]]
+  ; CHECK: %[[#c1:]] = OpCompositeConstruct %[[#v3int]] %[[#]] %[[#]] %[[#]]
   %2 = shufflevector <6 x i32> %1, <6 x i32> poison, <3 x i32> <i32 0, i32 2, i32 4>
-  
-  ; CHECK: %[[#h0:]] = OpCompositeExtract %[[#int]] %[[#v4i0]] 1
-  ; CHECK: %[[#h1:]] = OpCompositeExtract %[[#int]] %[[#v4i0]] 3
-  ; CHECK: %[[#h2:]] = OpCompositeExtract %[[#int]] %[[#v4i1]] 1
-  ; CHECK: %[[#res_high:]] = OpCompositeConstruct %[[#v3int]] %[[#h0]] %[[#h1]] %[[#h2]]
+  ; CHECK: %[[#low0:]] = OpVectorShuffle %[[#v3int]] %[[#c0]] %[[#c0]] 0 2 {{.*}}
+  ; CHECK: %[[#res_low:]] = OpVectorShuffle %[[#v3int]] %[[#low0]] %[[#c1]] 0 1 4
+  ; CHECK: %[[#high0:]] = OpVectorShuffle %[[#v3int]] %[[#]] %[[#]] 1 {{.*}} {{.*}}
+  ; CHECK: %[[#res_high:]] = OpVectorShuffle %[[#v3int]] %[[#high0]] %[[#]] 0 3 5
   %3 = shufflevector <6 x i32> %1, <6 x i32> poison, <3 x i32> <i32 1, i32 3, i32 5>
-
   ; CHECK: OpStore %[[#Lows3]] %[[#res_low]]
   store <3 x i32> %2, ptr addrspace(10) @Lows3, align 16
 

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/matrix-multiply.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/matrix-multiply.ll
@@ -88,15 +88,17 @@ define internal void @test_matrix_multiply_i32_2x2_2x2() {
 
 ; Test Matrix Multiply 2x3 * 3x2 float (Result 2x2 float)
 ; CHECK-LABEL: ; -- Begin function test_matrix_multiply_f32_2x3_3x2
-; CHECK:       %[[Col0B:[0-9]+]] = OpCompositeConstruct %[[V3F32_ID]] {{.*}} {{.*}} {{.*}}
-; CHECK:       %[[Col1B:[0-9]+]] = OpCompositeConstruct %[[V3F32_ID]] {{.*}} {{.*}} {{.*}}
-; CHECK:       %[[Row0A:[0-9]+]] = OpCompositeConstruct %[[V3F32_ID]] {{.*}} {{.*}} {{.*}}
-; CHECK:       %[[Row1A:[0-9]+]] = OpCompositeConstruct %[[V3F32_ID]] {{.*}} {{.*}} {{.*}}
-;
-; CHECK-DAG:   %[[C00:[0-9]+]] = OpDot %[[Float_ID]] %[[Row0A]] %[[Col0B]]
-; CHECK-DAG:   %[[C10:[0-9]+]] = OpDot %[[Float_ID]] %[[Row1A]] %[[Col0B]]
-; CHECK-DAG:   %[[C01:[0-9]+]] = OpDot %[[Float_ID]] %[[Row0A]] %[[Col1B]]
-; CHECK-DAG:   %[[C11:[0-9]+]] = OpDot %[[Float_ID]] %[[Row1A]] %[[Col1B]]
+; The A rows are gathered from the column-major layout by the transpose shuffle,
+; which stays vectorized on the legal <3 x float> chunk width (chained
+; OpVectorShuffle) rather than being scalarized.
+; CHECK:       %[[Row0A:[0-9]+]] = OpVectorShuffle %[[V3F32_ID]] {{.*}} 0 1 4
+; CHECK:       %[[Row1A:[0-9]+]] = OpVectorShuffle %[[V3F32_ID]] {{.*}} 0 3 5
+; The B columns are contiguous OpCompositeConstruct vectors; capture each as the
+; second dot operand (Col0B on the first dot that uses it, Col1B likewise).
+; CHECK:       %[[C00:[0-9]+]] = OpDot %[[Float_ID]] %[[Row0A]] %[[Col0B:[0-9]+]]
+; CHECK:       %[[C10:[0-9]+]] = OpDot %[[Float_ID]] %[[Row1A]] %[[Col0B]]
+; CHECK:       %[[C01:[0-9]+]] = OpDot %[[Float_ID]] %[[Row0A]] %[[Col1B:[0-9]+]]
+; CHECK:       %[[C11:[0-9]+]] = OpDot %[[Float_ID]] %[[Row1A]] %[[Col1B]]
 ; CHECK:       OpCompositeConstruct %[[V4F32_ID]] %[[C00]] %[[C10]] %[[C01]] %[[C11]]
 define internal void @test_matrix_multiply_f32_2x3_3x2() {
   %1 = load <6 x float>, ptr addrspace(10) @private_v6f32

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/matrix-transpose-bool.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/matrix-transpose-bool.ll
@@ -1,0 +1,113 @@
+; RUN: llc -O0 -mtriple=spirv1.6-unknown-vulkan1.3 %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv1.6-unknown-vulkan1.3 %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; Regression test for https://github.com/llvm/llvm-project/issues/186864
+;
+; Transposing a boolean matrix (e.g. bool3x4 / bool3x3 in HLSL) flattens the
+; matrix to a wide <N x i1> vector and pairs it with a trunc/zext to/from
+; <N x i32>. On shader/Vulkan targets SPIR-V vectors are limited to 4
+; components, so the wide G_TRUNC / G_ZEXT are split into <= 4 lane chunks by
+; the legalizer. This test makes sure:
+;   * no OpTypeVector wider than 4 components is ever materialized,
+;   * the boolean trunc chunks are lowered with a *vector* bool result type
+;     (OpINotEqual %<N x bool>), not a scalar bool, and
+;   * the transpose shuffle stays vectorized (OpVectorShuffle on the legal
+;     chunk width) so the post-transpose zext also stays vectorized
+;     (OpSelect %<N x int>), rather than being scalarized to one select per
+;     matrix element.
+
+@in12 = internal addrspace(10) global [12 x i32] poison
+@out12 = internal addrspace(10) global [12 x i32] poison
+@in9 = internal addrspace(10) global [9 x i32] poison
+@out9 = internal addrspace(10) global [9 x i32] poison
+
+; CHECK-DAG: %[[#Int:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#Bool:]] = OpTypeBool
+; CHECK-DAG: %[[#V4Int:]] = OpTypeVector %[[#Int]] 4
+; CHECK-DAG: %[[#V4Bool:]] = OpTypeVector %[[#Bool]] 4
+; CHECK-DAG: %[[#V3Int:]] = OpTypeVector %[[#Int]] 3
+; CHECK-DAG: %[[#V3Bool:]] = OpTypeVector %[[#Bool]] 3
+
+; No vector wider than 4 components may be produced for shader targets.
+; CHECK-NOT: OpTypeVector %[[#Int]] 12
+; CHECK-NOT: OpTypeVector %[[#Bool]] 12
+; CHECK-NOT: OpTypeVector %[[#Int]] 9
+; CHECK-NOT: OpTypeVector %[[#Bool]] 9
+
+; Test transpose of a bool 3x4 matrix (12 elements -> three <4 x i1> chunks).
+; CHECK-LABEL: ; -- Begin function test_transpose_bool_3x4
+; The wide trunc splits into exactly three <4 x i1> chunks: three vector
+; INotEqual, each with a <4 x bool> result type (never scalar or wider).
+; CHECK-COUNT-3: OpINotEqual %[[#V4Bool]]
+; CHECK-NOT: OpINotEqual %[[#V4Bool]]
+; The transpose is lowered as vector shuffles on the <4 x bool> chunks instead
+; of being scalarized (nine OpVectorShuffle: three per <4 x> result chunk).
+; CHECK-COUNT-9: OpVectorShuffle %[[#V4Bool]]
+; CHECK-NOT: OpVectorShuffle %[[#V4Bool]]
+; The post-transpose zext therefore stays vectorized: three <4 x int> selects.
+; CHECK-COUNT-3: OpSelect %[[#V4Int]]
+; CHECK-NOT: OpSelect
+define internal void @test_transpose_bool_3x4() {
+  %src = load <12 x i32>, ptr addrspace(10) @in12
+  %b = trunc <12 x i32> %src to <12 x i1>
+  %t = call <12 x i1> @llvm.matrix.transpose.v12i1(<12 x i1> %b, i32 3, i32 4)
+  %ext = zext <12 x i1> %t to <12 x i32>
+  store <12 x i32> %ext, ptr addrspace(10) @out12
+  ret void
+}
+
+; Test transpose of a bool 3x3 matrix (9 elements -> three <3 x i1> chunks).
+; The odd width shares no divisor > 1 with 4, but 3 is itself a legal SPIR-V
+; vector size, so it splits into three <3 x> vectors rather than scalarizing.
+; CHECK-LABEL: ; -- Begin function test_transpose_bool_3x3
+; Three vector INotEqual, each with a <3 x bool> result type.
+; CHECK-COUNT-3: OpINotEqual %[[#V3Bool]]
+; CHECK-NOT: OpINotEqual %[[#V3Bool]]
+; The transpose stays vectorized on the <3 x bool> chunks (nine OpVectorShuffle:
+; three per <3 x> result chunk).
+; CHECK-COUNT-9: OpVectorShuffle %[[#V3Bool]]
+; CHECK-NOT: OpVectorShuffle %[[#V3Bool]]
+; The post-transpose zext stays vectorized: three <3 x int> selects.
+; CHECK-COUNT-3: OpSelect %[[#V3Int]]
+; CHECK-NOT: OpSelect
+define internal void @test_transpose_bool_3x3() {
+  %src = load <9 x i32>, ptr addrspace(10) @in9
+  %b = trunc <9 x i32> %src to <9 x i1>
+  %t = call <9 x i1> @llvm.matrix.transpose.v9i1(<9 x i1> %b, i32 3, i32 3)
+  %ext = zext <9 x i1> %t to <9 x i32>
+  store <9 x i32> %ext, ptr addrspace(10) @out9
+  ret void
+}
+
+; Test transpose of a bool 4x3 matrix (12 elements -> three <4 x i1> chunks).
+; A 4x3 matrix has the same flattened width as 3x4, so it splits identically;
+; only the transpose shuffle masks differ.
+; CHECK-LABEL: ; -- Begin function test_transpose_bool_4x3
+; The wide trunc splits into exactly three <4 x i1> chunks: three vector
+; INotEqual, each with a <4 x bool> result type (never scalar or wider).
+; CHECK-COUNT-3: OpINotEqual %[[#V4Bool]]
+; CHECK-NOT: OpINotEqual %[[#V4Bool]]
+; The transpose stays vectorized on the <4 x bool> chunks (nine OpVectorShuffle:
+; three per <4 x> result chunk).
+; CHECK-COUNT-9: OpVectorShuffle %[[#V4Bool]]
+; CHECK-NOT: OpVectorShuffle %[[#V4Bool]]
+; The post-transpose zext stays vectorized: three <4 x int> selects.
+; CHECK-COUNT-3: OpSelect %[[#V4Int]]
+; CHECK-NOT: OpSelect
+define internal void @test_transpose_bool_4x3() {
+  %src = load <12 x i32>, ptr addrspace(10) @in12
+  %b = trunc <12 x i32> %src to <12 x i1>
+  %t = call <12 x i1> @llvm.matrix.transpose.v12i1(<12 x i1> %b, i32 4, i32 3)
+  %ext = zext <12 x i1> %t to <12 x i32>
+  store <12 x i32> %ext, ptr addrspace(10) @out12
+  ret void
+}
+
+define void @main() #0 {
+  ret void
+}
+
+declare <12 x i1> @llvm.matrix.transpose.v12i1(<12 x i1>, i32, i32)
+declare <9 x i1> @llvm.matrix.transpose.v9i1(<9 x i1>, i32, i32)
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/matrix-transpose.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/matrix-transpose.ll
@@ -37,22 +37,20 @@ define internal void @test_transpose_f32_2x3() {
 ; CHECK: %[[AccessChain6:[0-9]+]] = OpAccessChain %[[_ptr_Float_ID]] %[[private_v6f32]] %[[int_5:[0-9]+]]
 ; CHECK: %[[Load6:[0-9]+]] = OpLoad %[[Float_ID]] %[[AccessChain6]]
 ;
-; -- Construct intermediate vectors
+; -- Construct an intermediate vector and immediately extract the transposed element
 ; CHECK: %[[Construct1:[0-9]+]] = OpCompositeConstruct %[[V4F32_ID]] %[[Load1]] %[[Load2]] %[[Load3]] %[[Load4]]
-; CHECK: %[[Construct2:[0-9]+]] = OpCompositeConstruct %[[V4F32_ID]] %[[Load1]] %[[Load2]] %[[Load3]] %[[Load4]]
-; CHECK: %[[Construct3:[0-9]+]] = OpCompositeConstruct %[[V4F32_ID]] %[[Load5]] %[[Load6]] {{.*}} {{.*}}
-; CHECK: %[[Construct4:[0-9]+]] = OpCompositeConstruct %[[V4F32_ID]] %[[Load1]] %[[Load2]] %[[Load3]] %[[Load4]]
-; CHECK: %[[Construct5:[0-9]+]] = OpCompositeConstruct %[[V4F32_ID]] %[[Load1]] %[[Load2]] %[[Load3]] %[[Load4]]
-; CHECK: %[[Construct6:[0-9]+]] = OpCompositeConstruct %[[V4F32_ID]] %[[Load5]] %[[Load6]] {{.*}} {{.*}}
-  %1 = load <6 x float>, ptr addrspace(10) @private_v6f32
-
-; -- Extract elements for transposition
 ; CHECK: %[[Extract1:[0-9]+]] = OpCompositeExtract %[[Float_ID]] %[[Construct1]] 0
+; CHECK: %[[Construct2:[0-9]+]] = OpCompositeConstruct %[[V4F32_ID]] %[[Load1]] %[[Load2]] %[[Load3]] %[[Load4]]
 ; CHECK: %[[Extract2:[0-9]+]] = OpCompositeExtract %[[Float_ID]] %[[Construct2]] 2
+; CHECK: %[[Construct3:[0-9]+]] = OpCompositeConstruct %[[V4F32_ID]] %[[Load5]] %[[Load6]] {{.*}} {{.*}}
 ; CHECK: %[[Extract3:[0-9]+]] = OpCompositeExtract %[[Float_ID]] %[[Construct3]] 0
+; CHECK: %[[Construct4:[0-9]+]] = OpCompositeConstruct %[[V4F32_ID]] %[[Load1]] %[[Load2]] %[[Load3]] %[[Load4]]
 ; CHECK: %[[Extract4:[0-9]+]] = OpCompositeExtract %[[Float_ID]] %[[Construct4]] 1
+; CHECK: %[[Construct5:[0-9]+]] = OpCompositeConstruct %[[V4F32_ID]] %[[Load1]] %[[Load2]] %[[Load3]] %[[Load4]]
 ; CHECK: %[[Extract5:[0-9]+]] = OpCompositeExtract %[[Float_ID]] %[[Construct5]] 3
+; CHECK: %[[Construct6:[0-9]+]] = OpCompositeConstruct %[[V4F32_ID]] %[[Load5]] %[[Load6]] {{.*}} {{.*}}
 ; CHECK: %[[Extract6:[0-9]+]] = OpCompositeExtract %[[Float_ID]] %[[Construct6]] 1
+  %1 = load <6 x float>, ptr addrspace(10) @private_v6f32
   %2 = call <6 x float> @llvm.matrix.transpose.v6f32.i32(<6 x float> %1, i32 2, i32 3)
 
 ; -- Store output 3x2 matrix elements


### PR DESCRIPTION
fixes #186864

New process for matrix legalization documented here: https://github.com/llvm/wg-hlsl/pull/446

The current Matrix legalization strategy is to take a vector of and expanded to a larger power of 2 vector and then split it into vectors of size 4. For example a vector of size 6 is expanded to 8, and then split.

This creates  uniform 4-lane chunks but requires padding. For example `<12>`-->`<16>`, `<6>`-->`<8>`, `<9>`-->`<16>`. These forces an illegal wide `G_BUILD_VECTOR` with undef lanes. This padding wastes lanes and
  adds undef bookkeeping the backend must then clean up.

Instead This PR splits both operands into `W`-lane chunks, where `W` is the largest divisor of the element count in `[2, MaxVectorSize]` shared by source and destination (`<12>`-->3×`<4>`, `<6>`-->2×`<3>`, `<9>`-->3×`<3>`), and emit chained per-chunk `OpVectorShuffle`s. This keeps every chunk a legal SPIR-V vector with no undef padding and preserves vectorized `OpDot`/`OpSelect` downstream.

Assisted with Claude Opus 4.8 via Co-pilot