### PR TITLE
[clang-tidy] Fixed a false positive for pointer parameters used as placement-new storage

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
@@ -29,7 +29,7 @@ void NonConstParameterCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       stmt(anyOf(unaryOperator(hasAnyOperatorName("++", "--")),
                  binaryOperator(), callExpr(), returnStmt(), cxxConstructExpr(),
-                 cxxUnresolvedConstructExpr()))
+                 cxxUnresolvedConstructExpr(), cxxNewExpr()))
           .bind("Mark"),
       this);
   Finder->addMatcher(varDecl(hasInitializer(anything())).bind("Mark"), this);
@@ -94,6 +94,9 @@ void NonConstParameterCheck::check(const MatchFinder::MatchResult &Result) {
           markCanNotBeConst(Arg->IgnoreParenCasts(), false);
         }
       }
+    } else if (const auto *NE = dyn_cast<CXXNewExpr>(S)) {
+      for (const auto *Arg : NE->placement_arguments())
+        markCanNotBeConst(Arg->IgnoreParenCasts(), true);
     } else if (const auto *CE = dyn_cast<CXXUnresolvedConstructExpr>(S)) {
       markCanNotBeConst(CE, true);
     } else if (const auto *R = dyn_cast<ReturnStmt>(S)) {

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -715,6 +715,8 @@ Changes in existing checks
   - Fixed a false positive in array subscript expressions where the types are
     not yet resolved.
 
+  - Fixed a false positive for pointer parameters used as placement-new storage.
+
 - Improved :doc:`readability-redundant-casting
   <clang-tidy/checks/readability/redundant-casting>` check by adding the
   `IgnoreImplicitCasts` option (default `false`) to flag casts as redundant

--- a/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/std/new
+++ b/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/std/new
@@ -1,0 +1,9 @@
+#ifndef _NEW_
+#define _NEW_
+
+#include "stddef.h"
+
+void* operator new(size_t, void* p) noexcept;
+void* operator new[](size_t, void* p) noexcept;
+
+#endif // _NEW_

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -7,6 +7,8 @@
 //
 // It does not warn about pointers to records or function pointers.
 
+#include <new>
+
 // Some external function where first argument is nonconst and second is const.
 char *strcpy1(char *dest, const char *src);
 unsigned my_strcpy(char *buf, const char *s);
@@ -433,9 +435,6 @@ void dependentInitInGenericLambdaMultiArg() {
     DependentCtor2<T> s(p, p);
   };
 }
-
-namespace std { typedef decltype(sizeof(int)) size_t; }
-void* operator new(std::size_t, void*) noexcept;
 
 void placementNew1(char *buffer) {
   new (buffer) int();

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -433,3 +433,22 @@ void dependentInitInGenericLambdaMultiArg() {
     DependentCtor2<T> s(p, p);
   };
 }
+
+namespace std { typedef decltype(sizeof(int)) size_t; }
+void* operator new(std::size_t, void*) noexcept;
+
+void placementNew1(char *buffer) {
+  new (buffer) int();
+}
+
+void placementNew2(int *p) {
+  new (p) float();
+}
+
+void placementNew3(void *buffer) {
+  new (buffer) int();
+}
+
+void placementNew4(char *buffer) {
+  new (buffer + 4) int();
+}


### PR DESCRIPTION
Fixes #206613