### PR TITLE
[lldb] Change Python site-packages path

### DIFF
--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -80,17 +80,12 @@ if (LLDB_ENABLE_PYTHON)
     set(stable_abi "--stable-abi")
   endif()
 
-  if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
-    set(dynamic_scriptinterpreters "--dynamic-scriptinterpreters")
-  endif()
-
   foreach(var LLDB_PYTHON_RELATIVE_PATH LLDB_PYTHON_EXE_RELATIVE_PATH LLDB_PYTHON_EXT_SUFFIX)
     if(NOT DEFINED ${var} AND NOT CMAKE_CROSSCOMPILING)
       execute_process(
         COMMAND ${Python3_EXECUTABLE}
           ${CMAKE_CURRENT_SOURCE_DIR}/bindings/python/get-python-config.py
           ${stable_abi}
-          ${dynamic_scriptinterpreters}
           ${var}
         OUTPUT_VARIABLE value
         OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -80,12 +80,17 @@ if (LLDB_ENABLE_PYTHON)
     set(stable_abi "--stable-abi")
   endif()
 
+  if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
+    set(dynamic_scriptinterpreters "--dynamic-scriptinterpreters")
+  endif()
+
   foreach(var LLDB_PYTHON_RELATIVE_PATH LLDB_PYTHON_EXE_RELATIVE_PATH LLDB_PYTHON_EXT_SUFFIX)
     if(NOT DEFINED ${var} AND NOT CMAKE_CROSSCOMPILING)
       execute_process(
         COMMAND ${Python3_EXECUTABLE}
           ${CMAKE_CURRENT_SOURCE_DIR}/bindings/python/get-python-config.py
           ${stable_abi}
+          ${dynamic_scriptinterpreters}
           ${var}
         OUTPUT_VARIABLE value
         OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/lldb/bindings/python/get-python-config.py
+++ b/lldb/bindings/python/get-python-config.py
@@ -21,10 +21,6 @@ def main():
     parser.add_argument(
         "--stable-abi", action="store_true", help="Target the Stable C ABI"
     )
-    parser.add_argument(
-        "--dynamic-scriptinterpreters", action="store_true",
-        help="Scriptinterpreter plugins were built as shared libraries"
-    )
     args = parser.parse_args()
     if args.variable_name == "LLDB_PYTHON_RELATIVE_PATH":
         # LLDB_PYTHON_RELATIVE_PATH is the relative path from lldb's prefix

--- a/lldb/bindings/python/get-python-config.py
+++ b/lldb/bindings/python/get-python-config.py
@@ -21,6 +21,10 @@ def main():
     parser.add_argument(
         "--stable-abi", action="store_true", help="Target the Stable C ABI"
     )
+    parser.add_argument(
+        "--dynamic-scriptinterpreters", action="store_true",
+        help="Scriptinterpreter plugins were built as shared libraries"
+    )
     args = parser.parse_args()
     if args.variable_name == "LLDB_PYTHON_RELATIVE_PATH":
         # LLDB_PYTHON_RELATIVE_PATH is the relative path from lldb's prefix
@@ -34,17 +38,29 @@ def main():
         # lldb's python lib will be put in the correct place for python to find it.
         # If not, you'll have to use lldb -P or lldb -print-script-interpreter-info
         # to figure out where it is.
-        try:
-            print(relpath_nodots(sysconfig.get_path("platlib"), sys.prefix))
-        except ValueError:
-            # Try to fall back to something reasonable if sysconfig's platlib
-            # is outside of sys.prefix
+        #
+        # If LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS is set, instead always
+        # use lib/site-packages
+        if args.dynamic_scriptinterpreters:
             if os.name == "posix":
-                print("lib/python%d.%d/site-packages" % sys.version_info[:2])
+                print("lib/site-packages")
             elif os.name == "nt":
                 print("Lib\\site-packages")
             else:
                 raise
+        else:
+            try:
+                print(relpath_nodots(sysconfig.get_path("platlib"), sys.prefix))
+            except ValueError:
+                # Try to fall back to something reasonable if sysconfig's
+                # platlib is outside of sys.prefix
+                if os.name == "posix":
+                    print("lib/python%d.%d/site-packages" %
+                        sys.version_info[:2])
+                elif os.name == "nt":
+                    print("Lib\\site-packages")
+                else:
+                    raise
     elif args.variable_name == "LLDB_PYTHON_EXE_RELATIVE_PATH":
         tried = list()
         exe = sys.executable

--- a/lldb/bindings/python/get-python-config.py
+++ b/lldb/bindings/python/get-python-config.py
@@ -30,37 +30,13 @@ def main():
         # LLDB_PYTHON_RELATIVE_PATH is the relative path from lldb's prefix
         # to where lldb's python libraries will be installed.
         #
-        # The way we're going to compute this is to take the relative path from
-        # PYTHON'S prefix to where python libraries are supposed to be
-        # installed.
-        #
-        # The result is if LLDB and python are give the same prefix, then
-        # lldb's python lib will be put in the correct place for python to find it.
-        # If not, you'll have to use lldb -P or lldb -print-script-interpreter-info
-        # to figure out where it is.
-        #
-        # If LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS is set, instead always
-        # use lib/site-packages
-        if args.dynamic_scriptinterpreters:
-            if os.name == "posix":
-                print("lib/site-packages")
-            elif os.name == "nt":
-                print("Lib\\site-packages")
-            else:
-                raise
+        # This will always be lib/site-packages or lib\site-packages.
+        if os.name == "posix":
+            print("lib/site-packages")
+        elif os.name == "nt":
+            print("Lib\\site-packages")
         else:
-            try:
-                print(relpath_nodots(sysconfig.get_path("platlib"), sys.prefix))
-            except ValueError:
-                # Try to fall back to something reasonable if sysconfig's
-                # platlib is outside of sys.prefix
-                if os.name == "posix":
-                    print("lib/python%d.%d/site-packages" %
-                        sys.version_info[:2])
-                elif os.name == "nt":
-                    print("Lib\\site-packages")
-                else:
-                    raise
+            raise
     elif args.variable_name == "LLDB_PYTHON_EXE_RELATIVE_PATH":
         tried = list()
         exe = sys.executable

--- a/lldb/bindings/python/get-python-config.py
+++ b/lldb/bindings/python/get-python-config.py
@@ -26,7 +26,7 @@ def main():
         # LLDB_PYTHON_RELATIVE_PATH is the relative path from lldb's prefix
         # to where lldb's python libraries will be installed.
         #
-        # This will always be lib/site-packages or lib\site-packages.
+        # This will always be lib/site-packages (or lib\site-packages).
         if os.name == "posix":
             print("lib/site-packages")
         elif os.name == "nt":


### PR DESCRIPTION
On POSIX systems, traditionally the lldb Python module is in
lib/pythonx.x/site-packages. We only ever have 1 Python in a given build, so
we don't need to specify the version.

On Windows, we've always had the Python module in lib\site-packages.

Change the behavior on POSIX to match the Windows behavior, and put the lldb
Python module in lib/site-packages.
