### PR TITLE
[AMDGPU] Fix printf %s buffer slot oversized when strlen % 4 == 0

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
@@ -211,8 +211,12 @@ bool AMDGPUPrintfRuntimeBindingImpl::lowerPrintfForGpu(Module &M) {
             ArgSize = 4;
         }
       }
-      if (shouldPrintAsStr(OpConvSpecifiers[ArgCount - 1], ArgType))
-        ArgSize = alignTo(getAsConstantStr(Arg).size() + 1, 4);
+      if (shouldPrintAsStr(OpConvSpecifiers[ArgCount - 1], ArgType)) {
+        // Match the store loop below: ceil(len / 4) dwords, or one dword
+        // for the empty string. The trailing NUL is not stored.
+        StringRef Str = getAsConstantStr(Arg);
+        ArgSize = Str.empty() ? 4 : alignTo(Str.size(), 4);
+      }
 
       LLVM_DEBUG(dbgs() << "Printf ArgSize (in buffer) = " << ArgSize
                         << " for type: " << *ArgType << '\n');

--- a/llvm/test/CodeGen/AMDGPU/opencl-printf.ll
+++ b/llvm/test/CodeGen/AMDGPU/opencl-printf.ll
@@ -1106,7 +1106,7 @@ entry:
 define amdgpu_kernel void @test_print_string_literal_size4_nonull_term(i32 %n) {
 ; GCN-LABEL: @test_print_string_literal_size4_nonull_term(
 ; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
 ; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
 ; GCN:       entry.split:
 ; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
@@ -1131,7 +1131,7 @@ entry:
 define amdgpu_kernel void @test_print_string_literal_size5(i32 %n) {
 ; GCN-LABEL: @test_print_string_literal_size5(
 ; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
 ; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
 ; GCN:       entry.split:
 ; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
@@ -1237,7 +1237,7 @@ entry:
 define amdgpu_kernel void @test_print_string_literal_size9(i32 %n) {
 ; GCN-LABEL: @test_print_string_literal_size9(
 ; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 20)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
 ; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
 ; GCN:       entry.split:
 ; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
@@ -1295,7 +1295,7 @@ entry:
 define amdgpu_kernel void @test_print_string_literal_size17(i32 %n) {
 ; GCN-LABEL: @test_print_string_literal_size17(
 ; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 28)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 24)
 ; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
 ; GCN:       entry.split:
 ; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
@@ -1448,7 +1448,7 @@ entry:
 define amdgpu_kernel void @test_print_string_literal_v4i8(i32 %n) {
 ; GCN-LABEL: @test_print_string_literal_v4i8(
 ; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
 ; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
 ; GCN:       entry.split:
 ; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
@@ -1723,7 +1723,7 @@ entry:
 define amdgpu_kernel void @test_print_string_indexed(i32 %n) {
 ; GCN-LABEL: @test_print_string_indexed(
 ; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 28)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 24)
 ; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
 ; GCN:       entry.split:
 ; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null


### PR DESCRIPTION
The metadata slot for a constant string %s used alignTo(strlen + 1, 4), but the store loop only writes ceil(strlen / 4) dwords (no trailing NUL), so every following argument was read from offset shifted by +4