### PR TITLE
[OpenMP][OMPT] Emit `dispatch` callback for serial loops

### DIFF
--- a/openmp/runtime/src/kmp_sched.cpp
+++ b/openmp/runtime/src/kmp_sched.cpp
@@ -134,8 +134,28 @@ static void __kmp_for_static_init(ident_t *loc, kmp_int32 global_tid,
         ompt_work_type, ompt_scope_begin, &(team_info->parallel_data),         \
         &(task_info->task_data), count, codeptr);                              \
   }
+#define OMPT_DISPATCH_CHUNK(lb, ub, incr)                                      \
+  if (ompt_enabled.ompt_callback_dispatch) {                                   \
+    ompt_dispatch_t dispatch_type;                                             \
+    ompt_data_t instance = ompt_data_none;                                     \
+    ompt_dispatch_chunk_t dispatch_chunk;                                      \
+    if (ompt_work_type == ompt_work_sections) {                                \
+      dispatch_type = ompt_dispatch_section;                                   \
+      instance.ptr = codeptr;                                                  \
+    } else {                                                                   \
+      OMPT_GET_DISPATCH_CHUNK(dispatch_chunk, lb, ub, incr);                   \
+      dispatch_type = (ompt_work_type == ompt_work_distribute)                 \
+                          ? ompt_dispatch_distribute_chunk                     \
+                          : ompt_dispatch_ws_loop_chunk;                       \
+      instance.ptr = &dispatch_chunk;                                          \
+    }                                                                          \
+    ompt_callbacks.ompt_callback(ompt_callback_dispatch)(                      \
+        &(team_info->parallel_data), &(task_info->task_data), dispatch_type,   \
+        instance);                                                             \
+  }
 #else
 #define OMPT_LOOP_BEGIN(count) // no-op
+#define OMPT_DISPATCH_CHUNK(lb, ub, incr) // no-op
 #endif
 
   KMP_DEBUG_ASSERT(plastiter && plower && pupper && pstride);
@@ -238,6 +258,7 @@ static void __kmp_for_static_init(ident_t *loc, kmp_int32 global_tid,
     KE_TRACE(10, ("__kmpc_for_static_init: T#%d return\n", global_tid));
 
     OMPT_LOOP_BEGIN(*pstride);
+    OMPT_DISPATCH_CHUNK(*plower, *pupper, incr);
     KMP_STATS_LOOP_END(OMP_loop_static_iterations);
     return;
   }
@@ -262,6 +283,7 @@ static void __kmp_for_static_init(ident_t *loc, kmp_int32 global_tid,
     KE_TRACE(10, ("__kmpc_for_static_init: T#%d return\n", global_tid));
 
     OMPT_LOOP_BEGIN(*pstride);
+    OMPT_DISPATCH_CHUNK(*plower, *pupper, incr);
     KMP_STATS_LOOP_END(OMP_loop_static_iterations);
     return;
   }
@@ -436,26 +458,7 @@ static void __kmp_for_static_init(ident_t *loc, kmp_int32 global_tid,
   KE_TRACE(10, ("__kmpc_for_static_init: T#%d return\n", global_tid));
 
   OMPT_LOOP_BEGIN(trip_count);
-#if OMPT_SUPPORT && OMPT_OPTIONAL
-  if (ompt_enabled.ompt_callback_dispatch) {
-    ompt_dispatch_t dispatch_type;
-    ompt_data_t instance = ompt_data_none;
-    ompt_dispatch_chunk_t dispatch_chunk;
-    if (ompt_work_type == ompt_work_sections) {
-      dispatch_type = ompt_dispatch_section;
-      instance.ptr = codeptr;
-    } else {
-      OMPT_GET_DISPATCH_CHUNK(dispatch_chunk, *plower, *pupper, incr);
-      dispatch_type = (ompt_work_type == ompt_work_distribute)
-                          ? ompt_dispatch_distribute_chunk
-                          : ompt_dispatch_ws_loop_chunk;
-      instance.ptr = &dispatch_chunk;
-    }
-    ompt_callbacks.ompt_callback(ompt_callback_dispatch)(
-        &(team_info->parallel_data), &(task_info->task_data), dispatch_type,
-        instance);
-  }
-#endif
+  OMPT_DISPATCH_CHUNK(*plower, *pupper, incr);
 
   KMP_STATS_LOOP_END(OMP_loop_static_iterations);
   return;

--- a/openmp/runtime/test/ompt/worksharing/for/auto.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto.c
@@ -1,5 +1,6 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for auto = static schedule
 // XFAIL: gcc
@@ -9,4 +10,5 @@
 // The runtime uses guided schedule for auto,
 // which is a reason choice
 #define SCHED_OUTPUT "guided"
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base.h"

--- a/openmp/runtime/test/ompt/worksharing/for/auto_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto_serialized.c
@@ -1,5 +1,6 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_serialized.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base_serialized.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for auto = static schedule
 // XFAIL: gcc
@@ -9,4 +10,5 @@
 // The runtime uses static schedule for serialized loop,
 // which is a reason choice
 #define SCHED_OUTPUT "static"
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/auto_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto_split.c
@@ -1,6 +1,7 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_split.h
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base_split.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for auto = static schedule
 // XFAIL: gcc
@@ -10,4 +11,5 @@
 // The runtime uses guided schedule for auto,
 // which is a reason choice
 #define SCHED_OUTPUT "guided"
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/base.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base.h
@@ -7,10 +7,14 @@
 #ifndef SCHED_OUTPUT
 #define SCHED_OUTPUT STR(SCHEDULE)
 #endif
+#ifndef DIST_OUTPUT
+#define DIST_OUTPUT STR(DIST)
+#endif
 
 int main() {
   unsigned int i;
   printf("0: Schedule: " SCHED_OUTPUT "\n");
+  printf("0: Dist-Flag: " DIST_OUTPUT "\n");
 
 #pragma omp parallel for num_threads(4) schedule(SCHEDULE)
   for (i = 0; i < 64; i++) {
@@ -46,6 +50,10 @@ int main() {
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+
+
+  // CHECK-DIST: 0: Dist-Flag: [[DISTFLAG:[a-z_]+]]
+  // CHECK-DIST: {{^}}{{[0-9]+}}: ompt_event_[[DISTFLAG]]_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/worksharing/for/base_serialized.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base_serialized.h
@@ -7,10 +7,14 @@
 #ifndef SCHED_OUTPUT
 #define SCHED_OUTPUT STR(SCHEDULE)
 #endif
+#ifndef DIST_OUTPUT
+#define DIST_OUTPUT STR(DIST)
+#endif
 
 int main() {
   unsigned int i;
   printf("0: Schedule: " SCHED_OUTPUT "\n");
+  printf("0: Dist-Flag: " DIST_OUTPUT "\n");
 
 #pragma omp parallel for num_threads(1) schedule(SCHEDULE)
   for (i = 0; i < 64; i++) {
@@ -32,6 +36,10 @@ int main() {
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra={{(0x)?[0-f]+}}
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[PARALLEL_ID,0]}}, task_id=[[IMPLICIT_TASK_ID]]
+
+
+  // CHECK-DIST: 0: Dist-Flag: [[DISTFLAG:[a-z_]+]]
+  // CHECK-DIST: {{^}}{{[0-9]+}}: ompt_event_[[DISTFLAG]]_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/worksharing/for/base_split.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base_split.h
@@ -7,6 +7,9 @@
 #ifndef SCHED_OUTPUT
 #define SCHED_OUTPUT STR(SCHEDULE)
 #endif
+#ifndef DIST_OUTPUT
+#define DIST_OUTPUT STR(DIST)
+#endif
 
 /* With the combined parallel-for construct (base.h), the return-addresses are
    hard to compare. With the separate parallel and for-nowait construct, the
@@ -18,6 +21,7 @@
 int main() {
   unsigned int i;
   printf("0: Schedule: " SCHED_OUTPUT "\n");
+  printf("0: Dist-Flag: " DIST_OUTPUT "\n");
 
 #pragma omp parallel num_threads(4)
   {
@@ -71,6 +75,12 @@ int main() {
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]
+
+
+  // Depending on the schedule, libomp might decide to run all iterations on a single thread.
+  // Hence, check the flag for the dispatch callback independently.
+  // CHECK-DIST: 0: Dist-Flag: [[DISTFLAG:[a-z_]+]]
+  // CHECK-DIST: {{^}}{{[0-9]+}}: ompt_event_[[DISTFLAG]]_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/worksharing/for/dynamic.c
+++ b/openmp/runtime/test/ompt/worksharing/for/dynamic.c
@@ -1,7 +1,9 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base.h
 // REQUIRES: ompt
 // clang-format on
 
 #define SCHEDULE dynamic
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base.h"

--- a/openmp/runtime/test/ompt/worksharing/for/dynamic_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/dynamic_serialized.c
@@ -1,7 +1,9 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_serialized.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base_serialized.h
 // REQUIRES: ompt
 // clang-format on
 
 #define SCHEDULE dynamic
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/dynamic_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/dynamic_split.c
@@ -1,9 +1,11 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_split.h
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base_split.h
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
 // clang-format on
 
 #define SCHEDULE dynamic
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/guided.c
+++ b/openmp/runtime/test/ompt/worksharing/for/guided.c
@@ -1,7 +1,9 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base.h
 // REQUIRES: ompt
 // clang-format on
 
 #define SCHEDULE guided
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base.h"

--- a/openmp/runtime/test/ompt/worksharing/for/guided_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/guided_serialized.c
@@ -1,5 +1,6 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_serialized.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base_serialized.h
 // REQUIRES: ompt
 // clang-format on
 
@@ -7,4 +8,5 @@
 // The runtime uses static schedule for serialized loop,
 // which is a reason choice
 #define SCHED_OUTPUT "static"
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/guided_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/guided_split.c
@@ -1,9 +1,11 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_split.h
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base_split.h
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
 // clang-format on
 
 #define SCHEDULE guided
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/runtime.c
+++ b/openmp/runtime/test/ompt/worksharing/for/runtime.c
@@ -1,5 +1,6 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base.h
 // REQUIRES: ompt
 // clang-format on
 
@@ -7,4 +8,5 @@
 // Without any schedule specified, the runtime uses static schedule,
 // which is a reason choice
 #define SCHED_OUTPUT "static"
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base.h"

--- a/openmp/runtime/test/ompt/worksharing/for/runtime_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/runtime_serialized.c
@@ -1,5 +1,6 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_serialized.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base_serialized.h
 // REQUIRES: ompt
 // clang-format on
 
@@ -7,4 +8,5 @@
 // Without any schedule specified, the runtime uses static schedule,
 // which is a reason choice
 #define SCHED_OUTPUT "static"
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/runtime_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/runtime_split.c
@@ -1,6 +1,7 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_split.h
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base_split.h
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
 // clang-format on
@@ -9,4 +10,5 @@
 // Without any schedule specified, the runtime uses static schedule,
 // which is a reason choice
 #define SCHED_OUTPUT "static"
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/static.c
+++ b/openmp/runtime/test/ompt/worksharing/for/static.c
@@ -1,9 +1,11 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for static schedule
 // XFAIL: gcc
 // clang-format on
 
 #define SCHEDULE static
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base.h"

--- a/openmp/runtime/test/ompt/worksharing/for/static_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/static_serialized.c
@@ -1,9 +1,11 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_serialized.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base_serialized.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for static schedule
 // XFAIL: gcc
 // clang-format on
 
 #define SCHEDULE static
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/static_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/static_split.c
@@ -1,10 +1,12 @@
 // clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_split.h
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
+// RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-DIST %S/base_split.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for static schedule
 // XFAIL: gcc
 // clang-format on
 
 #define SCHEDULE static
+#define DIST_OUTPUT "ws_loop_chunk"
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/serial_sections.c
+++ b/openmp/runtime/test/ompt/worksharing/serial_sections.c
@@ -1,0 +1,37 @@
+// clang-format off
+// RUN: %libomp-compile-and-run | FileCheck %s
+// REQUIRES: ompt
+// UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
+#include "callback.h"
+
+int main(void) {
+#pragma omp parallel num_threads(1)
+#pragma omp sections
+  {
+#pragma omp section
+    {
+    }
+  }
+}
+
+// clang-format off
+// Check if libomp supports the callbacks for this test.
+// CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_begin'
+// CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_end'
+// CHECK-NOT: {{^}}0: Could not register callback 'ompt_event_implicit_task_begin'
+// CHECK-NOT: {{^}}0: Could not register callback 'ompt_event_implicit_task_end'
+// CHECK-NOT: {{^}}0: Could not register callback 'ompt_event_work'
+// CHECK-NOT: {{^}}0: Could not register callback 'ompt_event_dispatch'
+
+// CHECK: 0: NULL_POINTER=[[NULL:.*$]]
+
+// CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=1, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+// CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
+// CHECK: {{^}}[[MASTER_ID]]: ompt_event_sections_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
+// CHECK: {{^}}[[MASTER_ID]]: ompt_event_section_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
+// CHECK: {{^}}[[MASTER_ID]]: ompt_event_sections_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
+// CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id=0, task_id=[[IMPLICIT_TASK_ID]]
+// CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]], codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
+
+// clang-format on


### PR DESCRIPTION
While `__kmp_for_static_init` implemented handling for the dispatch callback,
the callback was only emitted when a static loop was neither serialized. In
this case, only a work callback was emitted, with the `dispatch` callback
being ignored entirely.

To fix this, add the same handling done for generic static loops to
serialized loops as well. Add a test to ensure that the correct callbacks
are dispatched for sections, and expand existing tests for checking static,
guided and dynamic schedules.

Closes https://github.com/llvm/llvm-project/issues/96698

Signed-off-by: Jan André Reuter <jan@zyten.de>