### PR TITLE
[AMDGPU] Clear DS aggregate in inverted sched_barrier mask when LDSDMA allowed

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -2796,37 +2796,24 @@ IGroupLPDAGMutation::invertSchedBarrierMask(SchedGroupMask Mask) const {
   // allowed past the SCHED_BARRIER.
   SchedGroupMask InvertedMask = ~Mask;
 
-  // ALU implies VALU, SALU, MFMA, TRANS.
-  if ((InvertedMask & SchedGroupMask::ALU) == SchedGroupMask::NONE)
-    InvertedMask &= ~SchedGroupMask::VALU & ~SchedGroupMask::SALU &
-                    ~SchedGroupMask::MFMA & ~SchedGroupMask::TRANS;
-  // VALU, SALU, MFMA, TRANS implies ALU.
-  else if ((InvertedMask & SchedGroupMask::VALU) == SchedGroupMask::NONE ||
-           (InvertedMask & SchedGroupMask::SALU) == SchedGroupMask::NONE ||
-           (InvertedMask & SchedGroupMask::MFMA) == SchedGroupMask::NONE ||
-           (InvertedMask & SchedGroupMask::TRANS) == SchedGroupMask::NONE)
-    InvertedMask &= ~SchedGroupMask::ALU;
+  static constexpr std::pair<SchedGroupMask, SchedGroupMask> ImpliedGroups[] = {
+      {SchedGroupMask::ALU, SchedGroupMask::VALU | SchedGroupMask::SALU |
+                                SchedGroupMask::MFMA | SchedGroupMask::TRANS},
+      {SchedGroupMask::VMEM, SchedGroupMask::VMEM_READ |
+                                 SchedGroupMask::VMEM_WRITE |
+                                 SchedGroupMask::LDSDMA},
+      {SchedGroupMask::DS, SchedGroupMask::DS_READ | SchedGroupMask::DS_WRITE |
+                               SchedGroupMask::LDSDMA},
+  };
 
-  // VMEM implies VMEM_READ, VMEM_WRITE, LDSDMA.
-  if ((InvertedMask & SchedGroupMask::VMEM) == SchedGroupMask::NONE)
-    InvertedMask &= ~SchedGroupMask::VMEM_READ & ~SchedGroupMask::VMEM_WRITE &
-                    ~SchedGroupMask::LDSDMA;
-  // VMEM_READ, VMEM_WRITE, LDSDMA implies VMEM.
-  else if ((InvertedMask & SchedGroupMask::VMEM_READ) == SchedGroupMask::NONE ||
-           (InvertedMask & SchedGroupMask::VMEM_WRITE) ==
-               SchedGroupMask::NONE ||
-           (InvertedMask & SchedGroupMask::LDSDMA) == SchedGroupMask::NONE)
-    InvertedMask &= ~SchedGroupMask::VMEM;
-
-  // DS implies DS_READ, DS_WRITE, LDSDMA.
-  if ((InvertedMask & SchedGroupMask::DS) == SchedGroupMask::NONE)
-    InvertedMask &= ~SchedGroupMask::DS_READ & ~SchedGroupMask::DS_WRITE &
-                    ~SchedGroupMask::LDSDMA;
-  // DS_READ, DS_WRITE, LDSDMA implies DS.
-  else if ((InvertedMask & SchedGroupMask::DS_READ) == SchedGroupMask::NONE ||
-           (InvertedMask & SchedGroupMask::DS_WRITE) == SchedGroupMask::NONE ||
-           (InvertedMask & SchedGroupMask::LDSDMA) == SchedGroupMask::NONE)
-    InvertedMask &= ~SchedGroupMask::DS;
+  for (auto [Aggregate, Members] : ImpliedGroups) {
+    // Aggregate allowed past the barrier implies all its members are too.
+    if ((InvertedMask & Aggregate) == SchedGroupMask::NONE)
+      InvertedMask &= ~Members;
+    // Any member allowed past the barrier implies the aggregate is too.
+    else if ((InvertedMask & Members) != Members)
+      InvertedMask &= ~Aggregate;
+  }
 
   LLVM_DEBUG(dbgs() << "After Inverting, SchedGroup Mask: " << (int)InvertedMask
                     << "\n");

--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -2822,9 +2822,10 @@ IGroupLPDAGMutation::invertSchedBarrierMask(SchedGroupMask Mask) const {
   if ((InvertedMask & SchedGroupMask::DS) == SchedGroupMask::NONE)
     InvertedMask &= ~SchedGroupMask::DS_READ & ~SchedGroupMask::DS_WRITE &
                     ~SchedGroupMask::LDSDMA;
-  // DS_READ, DS_WRITE implies DS.
+  // DS_READ, DS_WRITE, LDSDMA implies DS.
   else if ((InvertedMask & SchedGroupMask::DS_READ) == SchedGroupMask::NONE ||
-           (InvertedMask & SchedGroupMask::DS_WRITE) == SchedGroupMask::NONE)
+           (InvertedMask & SchedGroupMask::DS_WRITE) == SchedGroupMask::NONE ||
+           (InvertedMask & SchedGroupMask::LDSDMA) == SchedGroupMask::NONE)
     InvertedMask &= ~SchedGroupMask::DS;
 
   LLVM_DEBUG(dbgs() << "After Inverting, SchedGroup Mask: " << (int)InvertedMask

--- a/llvm/test/CodeGen/AMDGPU/sched.barrier.inverted.mask.ll
+++ b/llvm/test/CodeGen/AMDGPU/sched.barrier.inverted.mask.ll
@@ -41,8 +41,8 @@ entry:
   ret void
 }
 
-; Inverted 1935: 011110001111
-; GCN:       After Inverting, SchedGroup Mask: 1935
+; Inverted 1807: 011100001111
+; GCN:       After Inverting, SchedGroup Mask: 1807
 define amdgpu_kernel void @invert16() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 16) #1
@@ -104,8 +104,8 @@ entry:
   ret void
 }
 
-; Inverted 2031: 011111101111
-; GCN:       After Inverting, SchedGroup Mask: 2031
+; Inverted 1903: 011101101111
+; GCN:       After Inverting, SchedGroup Mask: 1903
 define amdgpu_kernel void @invert2048() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 2048) #1

--- a/llvm/test/CodeGen/AMDGPU/sched.barrier.inverted.mask.ll
+++ b/llvm/test/CodeGen/AMDGPU/sched.barrier.inverted.mask.ll
@@ -2,112 +2,32 @@
 
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx600 < %s -debug-only=igrouplp 2>&1 | FileCheck --check-prefixes=GCN %s
 
-
-
-
-; Inverted 3056: 101111110000
+; Barriers are processed in reverse order
+; GCN: After Inverting, SchedGroup Mask: 1903
+; GCN: After Inverting, SchedGroup Mask: 3070
+; GCN: After Inverting, SchedGroup Mask: 3455
+; GCN: After Inverting, SchedGroup Mask: 3711
+; GCN: After Inverting, SchedGroup Mask: 1151
+; GCN: After Inverting, SchedGroup Mask: 4015
+; GCN: After Inverting, SchedGroup Mask: 4047
+; GCN: After Inverting, SchedGroup Mask: 1807
+; GCN: After Inverting, SchedGroup Mask: 4086
+; GCN: After Inverting, SchedGroup Mask: 4090
+; GCN: After Inverting, SchedGroup Mask: 4092
 ; GCN: After Inverting, SchedGroup Mask: 3056
-define amdgpu_kernel void @invert1() #0 {
+define amdgpu_kernel void @invert() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 1) #1
-  call void @llvm.amdgcn.s.nop(i16 0) #1
-  ret void
-}
-
-; Inverted 4092: 111111111100
-; GCN:       After Inverting, SchedGroup Mask: 4092
-define amdgpu_kernel void @invert2() #0 {
-entry:
   call void @llvm.amdgcn.sched.barrier(i32 2) #1
-  call void @llvm.amdgcn.s.nop(i16 0) #1
-  ret void
-}
-
-; Inverted 4090: 111111111010
-; GCN:       After Inverting, SchedGroup Mask: 4090
-define amdgpu_kernel void @invert4() #0 {
-entry:
   call void @llvm.amdgcn.sched.barrier(i32 4) #1
-  call void @llvm.amdgcn.s.nop(i16 0) #1
-  ret void
-}
-
-; Inverted 4086: 111111110110
-; GCN:       After Inverting, SchedGroup Mask: 4086
-define amdgpu_kernel void @invert8() #0 {
-entry:
   call void @llvm.amdgcn.sched.barrier(i32 8) #1
-  call void @llvm.amdgcn.s.nop(i16 0) #1
-  ret void
-}
-
-; Inverted 1807: 011100001111
-; GCN:       After Inverting, SchedGroup Mask: 1807
-define amdgpu_kernel void @invert16() #0 {
-entry:
   call void @llvm.amdgcn.sched.barrier(i32 16) #1
-  call void @llvm.amdgcn.s.nop(i16 0) #1
-  ret void
-}
-
-; Inverted 4047: 111111001111
-; GCN:       After Inverting, SchedGroup Mask: 4047
-define amdgpu_kernel void @invert32() #0 {
-entry:
   call void @llvm.amdgcn.sched.barrier(i32 32) #1
-  call void @llvm.amdgcn.s.nop(i16 0) #1
-  ret void
-}
-
-; Inverted 4015: 111110101111
-; GCN:       After Inverting, SchedGroup Mask: 4015
-define amdgpu_kernel void @invert64() #0 {
-entry:
   call void @llvm.amdgcn.sched.barrier(i32 64) #1
-  call void @llvm.amdgcn.s.nop(i16 0) #1
-  ret void
-}
-
-; Inverted 3199: 110001111111
-; GCN:       After Inverting, SchedGroup Mask: 1151
-define amdgpu_kernel void @invert128() #0 {
-entry:
   call void @llvm.amdgcn.sched.barrier(i32 128) #1
-  call void @llvm.amdgcn.s.nop(i16 0) #1
-  ret void
-}
-
-; Inverted 3711: 111001111111
-; GCN:       After Inverting, SchedGroup Mask: 3711
-define amdgpu_kernel void @invert256() #0 {
-entry:
   call void @llvm.amdgcn.sched.barrier(i32 256) #1
-  call void @llvm.amdgcn.s.nop(i16 0) #1
-  ret void
-}
-
-; Inverted 3455: 110101111111
-; GCN:       After Inverting, SchedGroup Mask: 3455
-define amdgpu_kernel void @invert512() #0 {
-entry:
   call void @llvm.amdgcn.sched.barrier(i32 512) #1
-  call void @llvm.amdgcn.s.nop(i16 0) #1
-  ret void
-}
-
-; Inverted 3070: 101111111110
-; GCN:       After Inverting, SchedGroup Mask: 3070
-define amdgpu_kernel void @invert1024() #0 {
-entry:
   call void @llvm.amdgcn.sched.barrier(i32 1024) #1
-  call void @llvm.amdgcn.s.nop(i16 0) #1
-  ret void
-}
-
-; Inverted 1903: 011101101111
-; GCN:       After Inverting, SchedGroup Mask: 1903
-define amdgpu_kernel void @invert2048() #0 {
-entry:
   call void @llvm.amdgcn.sched.barrier(i32 2048) #1
   call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void

--- a/llvm/test/CodeGen/AMDGPU/sched.barrier.inverted.mask.ll
+++ b/llvm/test/CodeGen/AMDGPU/sched.barrier.inverted.mask.ll
@@ -2,32 +2,112 @@
 
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx600 < %s -debug-only=igrouplp 2>&1 | FileCheck --check-prefixes=GCN %s
 
-; Barriers are processed in reverse order
-; GCN: After Inverting, SchedGroup Mask: 1903
-; GCN: After Inverting, SchedGroup Mask: 3070
-; GCN: After Inverting, SchedGroup Mask: 3455
-; GCN: After Inverting, SchedGroup Mask: 3711
-; GCN: After Inverting, SchedGroup Mask: 1151
-; GCN: After Inverting, SchedGroup Mask: 4015
-; GCN: After Inverting, SchedGroup Mask: 4047
-; GCN: After Inverting, SchedGroup Mask: 1807
-; GCN: After Inverting, SchedGroup Mask: 4086
-; GCN: After Inverting, SchedGroup Mask: 4090
-; GCN: After Inverting, SchedGroup Mask: 4092
+
+
+
+; Inverted 3056: 101111110000
 ; GCN: After Inverting, SchedGroup Mask: 3056
-define amdgpu_kernel void @invert() #0 {
+define amdgpu_kernel void @invert1() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 1) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
+  ret void
+}
+
+; Inverted 4092: 111111111100
+; GCN:       After Inverting, SchedGroup Mask: 4092
+define amdgpu_kernel void @invert2() #0 {
+entry:
   call void @llvm.amdgcn.sched.barrier(i32 2) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
+  ret void
+}
+
+; Inverted 4090: 111111111010
+; GCN:       After Inverting, SchedGroup Mask: 4090
+define amdgpu_kernel void @invert4() #0 {
+entry:
   call void @llvm.amdgcn.sched.barrier(i32 4) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
+  ret void
+}
+
+; Inverted 4086: 111111110110
+; GCN:       After Inverting, SchedGroup Mask: 4086
+define amdgpu_kernel void @invert8() #0 {
+entry:
   call void @llvm.amdgcn.sched.barrier(i32 8) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
+  ret void
+}
+
+; Inverted 1807: 011100001111
+; GCN:       After Inverting, SchedGroup Mask: 1807
+define amdgpu_kernel void @invert16() #0 {
+entry:
   call void @llvm.amdgcn.sched.barrier(i32 16) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
+  ret void
+}
+
+; Inverted 4047: 111111001111
+; GCN:       After Inverting, SchedGroup Mask: 4047
+define amdgpu_kernel void @invert32() #0 {
+entry:
   call void @llvm.amdgcn.sched.barrier(i32 32) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
+  ret void
+}
+
+; Inverted 4015: 111110101111
+; GCN:       After Inverting, SchedGroup Mask: 4015
+define amdgpu_kernel void @invert64() #0 {
+entry:
   call void @llvm.amdgcn.sched.barrier(i32 64) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
+  ret void
+}
+
+; Inverted 3199: 110001111111
+; GCN:       After Inverting, SchedGroup Mask: 1151
+define amdgpu_kernel void @invert128() #0 {
+entry:
   call void @llvm.amdgcn.sched.barrier(i32 128) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
+  ret void
+}
+
+; Inverted 3711: 111001111111
+; GCN:       After Inverting, SchedGroup Mask: 3711
+define amdgpu_kernel void @invert256() #0 {
+entry:
   call void @llvm.amdgcn.sched.barrier(i32 256) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
+  ret void
+}
+
+; Inverted 3455: 110101111111
+; GCN:       After Inverting, SchedGroup Mask: 3455
+define amdgpu_kernel void @invert512() #0 {
+entry:
   call void @llvm.amdgcn.sched.barrier(i32 512) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
+  ret void
+}
+
+; Inverted 3070: 101111111110
+; GCN:       After Inverting, SchedGroup Mask: 3070
+define amdgpu_kernel void @invert1024() #0 {
+entry:
   call void @llvm.amdgcn.sched.barrier(i32 1024) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
+  ret void
+}
+
+; Inverted 1903: 011101101111
+; GCN:       After Inverting, SchedGroup Mask: 1903
+define amdgpu_kernel void @invert2048() #0 {
+entry:
   call void @llvm.amdgcn.sched.barrier(i32 2048) #1
   call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void


### PR DESCRIPTION
The DS clause was missing the LDSDMA check that the VMEM clause has