### PR TITLE
[libc++] Run the libcxx-run-benchmarks action on macOS in addition to Linux

### DIFF
--- a/.github/workflows/libcxx-run-benchmarks.yml
+++ b/.github/workflows/libcxx-run-benchmarks.yml
@@ -18,10 +18,6 @@ on:
       - created
       - edited
 
-env:
-  CC: clang-22
-  CXX: clang++-22
-
 jobs:
   permission-check:
     if: >-
@@ -45,12 +41,12 @@ jobs:
           LLVM_TOKEN_GENERATOR_CLIENT_ID: ${{ secrets.LLVM_TOKEN_GENERATOR_CLIENT_ID }}
           LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
 
-  run-benchmarks:
-    permissions:
-      pull-requests: write
-    runs-on: llvm-premerge-libcxx-next-runners # TODO: This should run on a dedicated set of machines
+  extract-info:
+    runs-on: ubuntu-24.04
     needs:
       - permission-check
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -78,9 +74,7 @@ jobs:
           BENCHMARKS=$(echo "$COMMENT_BODY" | sed -nE 's/\/libcxx-bot benchmark (.+)/\1/p')
           echo "benchmarks=${BENCHMARKS}" >> ${GITHUB_OUTPUT}
 
-      - name: Update comment with link to the job
-        env:
-          JOB_CHECK_RUN_ID: ${{ job.check_run_id }}
+      - name: Update comment with link to the run
         run: |
           source .venv/bin/activate
           cat <<EOF | python
@@ -88,26 +82,61 @@ jobs:
           repo = github.Github(auth=github.Auth.Token("${{ github.token }}")).get_repo("${{ github.repository }}")
           pr = repo.get_pull(${{ github.event.issue.number }})
           comment = pr.get_issue_comment(${{ github.event.comment.id }})
-          add_text = "> _Running benchmarks in ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${JOB_CHECK_RUN_ID}_"
+          add_text = "> _Running benchmarks in ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}_"
           comment.edit('\n\n'.join([comment.body, add_text]))
           EOF
+    outputs:
+      pr_base: ${{ steps.vars.outputs.pr_base }}
+      pr_head: ${{ steps.vars.outputs.pr_head }}
+      benchmarks: ${{ steps.vars.outputs.benchmarks }}
 
+  run-benchmarks:
+    strategy:
+      matrix:
+        include:
+          - platform: macOS 26.5 arm64
+            runner: ["self-hosted", "macOS", "ARM64", "26", "26.5"]
+            cc: clang
+            cxx: clang++
+          - platform: Linux x86_64
+            runner: llvm-premerge-libcxx-next-runners
+            cc: clang-22
+            cxx: clang++-22
+      fail-fast: false
+    permissions:
+      pull-requests: write
+    runs-on: ${{ matrix.runner }}
+    needs:
+      - extract-info
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+    steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ steps.vars.outputs.pr_head }}
+          ref: ${{ needs.extract-info.outputs.pr_head }}
           fetch-depth: 0
           fetch-tags: true # This job requires access to all the Git branches so it can diff against (usually) main
-          path: repo # Avoid nuking the workspace, where we have the Python virtualenv
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+
+      - name: Setup virtual environment
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -m pip install -r libcxx/utils/requirements.txt
+          python -m pip install pygithub==2.8.1
 
       - name: Build and run baseline
         env:
-          BENCHMARKS: ${{ steps.vars.outputs.benchmarks }}
-          PR_HEAD: ${{ steps.vars.outputs.pr_head }}
-          PR_BASE: ${{ steps.vars.outputs.pr_base }}
+          BENCHMARKS: ${{ needs.extract-info.outputs.benchmarks }}
+          PR_HEAD: ${{ needs.extract-info.outputs.pr_head }}
+          PR_BASE: ${{ needs.extract-info.outputs.pr_base }}
         run: |
-          source .venv/bin/activate && cd repo
-          python -m pip install -r libcxx/utils/requirements.txt
+          source .venv/bin/activate
           baseline_commit=$(git merge-base $PR_BASE $PR_HEAD)
           ./libcxx/utils/build-at-commit --commit ${baseline_commit} --install-dir install/baseline -- -DCMAKE_BUILD_TYPE=RelWithDebInfo
           ./libcxx/utils/test-at-commit --libcxx-installation install/baseline -B benchmarks/baseline -- -sv -j1 --param optimization=speed "$BENCHMARKS"
@@ -115,22 +144,22 @@ jobs:
 
       - name: Build and run candidate
         env:
-          BENCHMARKS: ${{ steps.vars.outputs.benchmarks }}
-          PR_HEAD: ${{ steps.vars.outputs.pr_head }}
+          BENCHMARKS: ${{ needs.extract-info.outputs.benchmarks }}
+          PR_HEAD: ${{ needs.extract-info.outputs.pr_head }}
         run: |
-          source .venv/bin/activate && cd repo
+          source .venv/bin/activate
           ./libcxx/utils/build-at-commit --commit $PR_HEAD --install-dir install/candidate -- -DCMAKE_BUILD_TYPE=RelWithDebInfo
           ./libcxx/utils/test-at-commit --libcxx-installation install/candidate -B benchmarks/candidate -- -sv -j1 --param optimization=speed "$BENCHMARKS"
           ./libcxx/utils/consolidate-benchmarks benchmarks/candidate | tee candidate.lnt
 
       - name: Compare baseline and candidate runs
         run: |
-          source .venv/bin/activate && cd repo
+          source .venv/bin/activate
           ./libcxx/utils/compare-benchmarks baseline.lnt candidate.lnt | tee results.txt
 
       - name: Update comment with results
         run: |
-          source .venv/bin/activate && cd repo
+          source .venv/bin/activate
           cat <<EOF | python
           import github
           repo = github.Github(auth=github.Auth.Token("${{ github.token }}")).get_repo("${{ github.repository }}")
@@ -144,7 +173,7 @@ jobs:
 
           <details>
           <summary>
-          Benchmark results:
+          Benchmark results for ${{ matrix.platform }}:
           </summary>
 
           \`\`\`


### PR DESCRIPTION
The libcxx-run-benchmarks action is triggered when a specially formatted comment is posted on a PR, requesting benchmarks to be run against that PR. This patch expands the Github action so it also runs benchmarks on the macOS CI resources that were added recently.