### PR TITLE
[CodeGen] Fix IntrusiveBackList::deleteNode

### DIFF
--- a/llvm/include/llvm/CodeGen/DIE.h
+++ b/llvm/include/llvm/CodeGen/DIE.h
@@ -567,6 +567,34 @@ struct IntrusiveBackListBase {
       Last = &N;
     }
   }
+
+  /// Delete node \p N by walking through the list until \p N's predecessor is
+  /// found. Remove \p N from the list by updating the predecessor's next
+  /// pointer and reset \p N's next pointer to itself.
+  bool deleteNode(Node &N) {
+    if (!Last)
+      return false;
+
+    Node *Cur = Last;
+    while (Cur->Next.getPointer() != &N) {
+      Cur = Cur->Next.getPointer();
+      if (Cur->Next.getInt())
+        return false;
+    }
+
+    Node *Target = Cur->Next.getPointer();
+    if (Target == Cur) {
+      Last = nullptr;
+    } else if (Target == Last) {
+      Cur->Next.setPointerAndInt(Target->Next.getPointer(), true);
+      Last = Cur;
+    } else {
+      Cur->Next.setPointer(Target->Next.getPointer());
+    }
+
+    Target->Next.setPointerAndInt(Target, true);
+    return true;
+  }
 };
 
 template <class T> class IntrusiveBackList : IntrusiveBackListBase {
@@ -604,24 +632,8 @@ public:
     Other.Last = nullptr;
   }
 
-  bool deleteNode(T &N) {
-    if (Last == &N) {
-      Last = Last->Next.getPointer();
-      Last->Next.setInt(true);
-      return true;
-    }
-
-    Node *cur = Last;
-    while (cur && cur->Next.getPointer()) {
-      if (cur->Next.getPointer() == &N) {
-        cur->Next.setPointer(cur->Next.getPointer()->Next.getPointer());
-        return true;
-      }
-      cur = cur->Next.getPointer();
-    }
-
-    return false;
-  }
+  /// Deletes node \p N from the list. Note this runs in O(N).
+  bool deleteNode(Node &N) { return IntrusiveBackListBase::deleteNode(N); }
 
   class const_iterator;
   class iterator

--- a/llvm/unittests/CodeGen/DIETest.cpp
+++ b/llvm/unittests/CodeGen/DIETest.cpp
@@ -172,4 +172,54 @@ INSTANTIATE_TEST_SUITE_P(
         DIETestParams{4, dwarf::DWARF64, dwarf::DW_FORM_data8, 8u},
         DIETestParams{4, dwarf::DWARF64, dwarf::DW_FORM_sec_offset, 8u}));
 
+TEST(DIEValueListTest, DeleteValue) {
+  SmallVector<dwarf::Attribute, 4> Expected = {
+      dwarf::DW_AT_name, dwarf::DW_AT_type, dwarf::DW_AT_location,
+      dwarf::DW_AT_ranges};
+  SmallVector<dwarf::Attribute, 4> Result;
+
+  BumpPtrAllocator Alloc;
+  DIEValueList List;
+  for (auto [I, Attr] : enumerate(Expected))
+    List.addValue(Alloc, Attr, dwarf::DW_FORM_data1, DIEInteger(I));
+
+  auto readResult = [&List, &Result] {
+    Result.clear();
+    for (const DIEValue &V : List.values())
+      Result.push_back(V.getAttribute());
+  };
+
+  // Delete non-existing
+  EXPECT_FALSE(List.deleteValue(dwarf::DW_AT_high_pc));
+  readResult();
+  EXPECT_EQ(Result, Expected);
+
+  // Delete back
+  EXPECT_TRUE(List.deleteValue(dwarf::DW_AT_ranges));
+  Expected.pop_back();
+  readResult();
+  EXPECT_EQ(Result, Expected);
+
+  // Delete middle
+  EXPECT_TRUE(List.deleteValue(dwarf::DW_AT_type));
+  Expected.erase(Expected.begin() + 1);
+  readResult();
+  EXPECT_EQ(Result, Expected);
+
+  // Delete front
+  EXPECT_TRUE(List.deleteValue(dwarf::DW_AT_name));
+  Expected.erase(Expected.begin());
+  readResult();
+  EXPECT_EQ(Result, Expected);
+
+  // Delete last
+  EXPECT_TRUE(List.deleteValue(dwarf::DW_AT_location));
+  Expected.pop_back();
+  readResult();
+  EXPECT_EQ(Result, Expected);
+
+  // Delete empty
+  EXPECT_FALSE(List.deleteValue(dwarf::DW_AT_high_pc));
+}
+
 } // end namespace


### PR DESCRIPTION
Issue #207411 reported that IntrusiveBackList::deleteNode does not delete the correct node if the deleted node is the last node of the list. Fix by not short circuiting on `Last == &N`.

Additionally, fix three other minor defects: (1) Do not loop infinitely if node is not in list. Check for sentinel edge. (2) Reset intrusive list on deleted node to point to itself with sentinel edge. (3) Avoid multiple template instantiations of the implementation of deleteNode by moving it to its base class.

Closes #207411.