### PR TITLE
[libc++] Don't install custom Python on self-hosted macOS runners

### DIFF
--- a/.github/workflows/libcxx-run-benchmarks.yml
+++ b/.github/workflows/libcxx-run-benchmarks.yml
@@ -98,10 +98,12 @@ jobs:
             runner: ["self-hosted", "macOS", "ARM64", "26", "26.5"]
             cc: clang
             cxx: clang++
+            install-python: false
           - platform: Linux x86_64
             runner: llvm-premerge-libcxx-next-runners
             cc: clang-22
             cxx: clang++-22
+            install-python: true
       fail-fast: false
     permissions:
       pull-requests: write
@@ -119,7 +121,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true # This job requires access to all the Git branches so it can diff against (usually) main
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Install Python
+        if: ${{ matrix.install-python }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
 


### PR DESCRIPTION
That shouldn't be necessary, since they already come with Python 3, and it doesn't work anyway because it requires special setup that the macOS runners don't currently perform.