### PR TITLE
[cmake] FindLibXml2: fall back to xmlversion.h when pkg-config has no…

### DIFF
--- a/llvm/cmake/modules/FindLibXml2.cmake
+++ b/llvm/cmake/modules/FindLibXml2.cmake
@@ -42,6 +42,23 @@ find_library(LIBXML2_STATIC_LIBRARY NAMES
 )
 
 include(FindPackageHandleStandardArgs)
+
+# When pkg-config is unavailable or has no .pc file for libxml2 (e.g. when
+# linking against a static libxml2-pic.a that ships no libxml-2.0.pc),
+# PC_LIBXML_VERSION is left empty.  Fall back to reading the version from the
+# xmlversion.h header so that the >=2.8 version check in
+# find_package_handle_standard_args succeeds.
+if(NOT PC_LIBXML_VERSION AND LIBXML2_INCLUDE_DIR AND
+   EXISTS "${LIBXML2_INCLUDE_DIR}/libxml/xmlversion.h")
+  file(STRINGS "${LIBXML2_INCLUDE_DIR}/libxml/xmlversion.h"
+       _libxml2_version_str REGEX "^#define[\t ]+LIBXML_DOTTED_VERSION[\t ]+\".*\"")
+  if(_libxml2_version_str)
+    string(REGEX REPLACE "^#define[\t ]+LIBXML_DOTTED_VERSION[\t ]+\"([^\"]*)\".*" "\\1"
+           PC_LIBXML_VERSION "${_libxml2_version_str}")
+  endif()
+  unset(_libxml2_version_str)
+endif()
+
 find_package_handle_standard_args(LibXml2
   REQUIRED_VARS LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR
   VERSION_VAR PC_LIBXML_VERSION


### PR DESCRIPTION
… version

LLVM's cmake/modules/FindLibXml2.cmake uses PC_LIBXML_VERSION (from pkg-config) as the VERSION_VAR in find_package_handle_standard_args. When pkg-config has no libxml-2.0.pc file (e.g. when linking against a static libxml2-pic.a that ships no .pc file), PC_LIBXML_VERSION is left empty after pkg_check_modules fails and the >=2.8 version check reports 'Found unsuitable version ""', causing LLDB_ENABLE_LIBXML2 to be set to FALSE.

Fix: before calling find_package_handle_standard_args, check whether PC_LIBXML_VERSION is still empty and if so read LIBXML_DOTTED_VERSION from the xmlversion.h header. This mirrors the version-detection logic in the system CMake FindLibXml2 module and ensures LLDB is built with libxml2 support on installations that use a static libxml2 without a .pc file.