### PR TITLE
[lldb] Fix TestFrameProviderCircularDependency.py on Arm

### DIFF
--- a/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
@@ -46,7 +46,6 @@ class FrameProviderCircularDependencyTestCase(TestBase):
 
         return target, thread
 
-    @expectedFailureAll(oslist=["linux"], archs=["arm$"])
     def test_circular_dependency_with_function_replacement(self):
         """
         Test the circular dependency fix with a provider that replaces function names.


### PR DESCRIPTION
After #206987 this test started passing on Windows and 32-bit Linux on
Arm. Remove the expected failure annotation to fix lldb-arm-ubuntu
buildbot.
