### PR TITLE
[RISCV] Fix Predicates in SFB to MVccI

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -378,22 +378,22 @@ bool RISCVExpandPseudo::expandCCOpToCMov(MachineBasicBlock &MBB,
     CMovImmOpcode = RISCV::QC_MVGEUI;
     break;
   case RISCV::QC_BEQI:
-    CMovImmOpcode = RISCV::QC_MVEQI;
-    break;
-  case RISCV::QC_BNEI:
     CMovImmOpcode = RISCV::QC_MVNEI;
     break;
-  case RISCV::QC_BLTI:
-    CMovImmOpcode = RISCV::QC_MVLTI;
+  case RISCV::QC_BNEI:
+    CMovImmOpcode = RISCV::QC_MVEQI;
     break;
-  case RISCV::QC_BGEI:
+  case RISCV::QC_BLTI:
     CMovImmOpcode = RISCV::QC_MVGEI;
     break;
+  case RISCV::QC_BGEI:
+    CMovImmOpcode = RISCV::QC_MVLTI;
+    break;
   case RISCV::QC_BLTUI:
-    CMovImmOpcode = RISCV::QC_MVLTUI;
+    CMovImmOpcode = RISCV::QC_MVGEUI;
     break;
   case RISCV::QC_BGEUI:
-    CMovImmOpcode = RISCV::QC_MVGEUI;
+    CMovImmOpcode = RISCV::QC_MVLTUI;
     break;
   }
 

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_eq.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_eq.ll
@@ -15,7 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.mveqi a0, a2, 2, a1
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mvnei a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp eq i32 %d, 2

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_ne.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_ne.ll
@@ -15,7 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.mvnei a0, a2, 2, a1
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mveqi a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp ne i32 %d, 2

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_sge.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_sge.ll
@@ -15,7 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.mvgei a0, a2, 2, a1
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mvlti a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp sge i32 %d, 2

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_slt.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_slt.ll
@@ -15,7 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.mvlti a0, a2, 2, a1
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mvgei a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp slt i32 %d, 2

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_uge.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_uge.ll
@@ -15,7 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.mvgeui a0, a2, 2, a1
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mvltui a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp uge i32 %d, 2

--- a/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_ult.ll
+++ b/llvm/test/CodeGen/RISCV/short-forward-branch-opt-with-branch-with-immediates_32_ult.ll
@@ -15,7 +15,7 @@ define i32 @branch_with_immSFB_mv(i32 %a, i32 %c, i32 %d) {
 ;
 ; RV32I-SFB-WITH-IMM-LABEL: branch_with_immSFB_mv:
 ; RV32I-SFB-WITH-IMM:       # %bb.0: # %entry
-; RV32I-SFB-WITH-IMM-NEXT:    qc.mvltui a0, a2, 2, a1
+; RV32I-SFB-WITH-IMM-NEXT:    qc.mvgeui a0, a2, 2, a1
 ; RV32I-SFB-WITH-IMM-NEXT:    ret
 entry:
   %x = icmp ult i32 %d, 2


### PR DESCRIPTION
The `CMovImmOpcode` predicate should have been the inversion of the predicate for `BCC`, as for the non-immediate cases.

As reported on #186555.