### PR TITLE
[TableGen] Separate string when digit follows octal escape

### DIFF
--- a/llvm/lib/TableGen/StringToOffsetTable.cpp
+++ b/llvm/lib/TableGen/StringToOffsetTable.cpp
@@ -118,6 +118,12 @@ void StringToOffsetTable::EmitString(raw_ostream &O) const {
       O << EscapedStr[++i];
       O << EscapedStr[++i];
       CharsPrinted += 3;
+      if (i + 1 < EscapedStr.size() && isDigit(EscapedStr[i + 1])) {
+        // If a digit follows after an octal literal, separate the string
+        // literals to silence MSVC warning C4125.
+        O << "\" \"";
+        CharsPrinted += 3;
+      }
     } else {
       O << EscapedStr[++i];
       ++CharsPrinted;


### PR DESCRIPTION
Silence MSVC warning C4125 by separating the string literals when an
octal escape sequence is followed by a decimal char.
