### PR TITLE
[Clang] Fix aggregate emitter assertion for Atomic cast

### DIFF
--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -1056,8 +1056,9 @@ void AggExprEmitter::VisitCastExpr(CastExpr *E) {
   case CK_NoOp:
   case CK_UserDefinedConversion:
   case CK_ConstructorConversion:
-    assert(CGF.getContext().hasSameUnqualifiedType(E->getSubExpr()->getType(),
-                                                   E->getType()) &&
+    assert(CGF.getContext().hasSameUnqualifiedType(
+               E->getSubExpr()->getType().getAtomicUnqualifiedType(),
+               E->getType().getAtomicUnqualifiedType()) &&
            "Implicit cast types must be compatible");
     Visit(E->getSubExpr());
     break;

--- a/clang/test/CodeGen/agg-atomic-cast.cpp
+++ b/clang/test/CodeGen/agg-atomic-cast.cpp
@@ -1,0 +1,27 @@
+// RUN: %clang_cc1 %s -triple=x86_64-linux -emit-llvm -o - | FileCheck %s
+
+struct S {
+    char a;
+};
+
+void static_cast_non_atomic_to_atomic() {
+  _Atomic struct S sa;
+  S s;
+  sa = static_cast<_Atomic(struct S)>(s);
+}
+
+// CHECK: %[[SA_ADDR:.*]] = alloca %struct.S, align 1
+// CHECK: %[[S_ADDR:.*]] = alloca %struct.S, align 1
+// CHECK: %[[TMP_ADDR:.*]] = alloca %struct.S, align 1
+// CHECK: call void @llvm.memcpy.p0.p0.i64(ptr align 1 %[[TMP_ADDR]], ptr align 1 %[[S_ADDR]], i64 1, i1 false)
+// CHECK: %[[TMP:.*]] = load i8, ptr %[[TMP_ADDR]], align 1
+// CHECK: store atomic i8 %[[TMP]], ptr %[[SA_ADDR]] seq_cst, align 1
+
+void non_atomic_to_atomic_cast() {
+  S s;
+  _Atomic(S) sa = (_Atomic(S)) s;
+}
+
+// CHECK: %[[S_ADDR:.*]] = alloca %struct.S, align 1
+// CHECK: %[[SA_ADDR:.*]] = alloca %struct.S, align 1
+// CHECK: call void @llvm.memcpy.p0.p0.i64(ptr align 1 %[[SA_ADDR]], ptr align 1 %[[S_ADDR]], i64 1, i1 false)


### PR DESCRIPTION
Change the expected type to reflect the emitted AST after Clang 17, which will not emit the two extra ImplicitCastExpr to make the type totally equal to the subexpr type


Issue #115664