### PR TITLE
[docs] Disable sphinx's numfig option

### DIFF
--- a/llvm/docs/VectorizationPlan.rst
+++ b/llvm/docs/VectorizationPlan.rst
@@ -36,7 +36,7 @@ the vectorization process [10]_. Those include transformations to
 3. Apply unroll- and vectorization-factor specific optimizations, e.g. removing
    the backedge to reiterate the vector loop based on VF & UF.
 
-Refer to :numref:`fig-vplan-transform-pipeline` for an overview of the current
+Refer to :ref:`fig-vplan-transform-pipeline` for an overview of the current
 transformation pipeline.
 
 Note that some legality checks are already done in VPlan, including checking if
@@ -52,7 +52,7 @@ bails out marking the VPlan as invalid.
 
 
 VPlan currently models the complete vector loop, as well as additional parts of
-the vectorization skeleton. Refer to :numref:`fig-vplan-scope` for an overview
+the vectorization skeleton. Refer to :ref:`fig-vplan-scope` for an overview
 of the scope covered by VPlan.
 
 .. _fig-vplan-scope:

--- a/llvm/docs/conf.py
+++ b/llvm/docs/conf.py
@@ -197,10 +197,6 @@ latex_documents = [
 # If false, no module index is generated.
 # latex_domain_indices = True
 
-# If true, figures, tables and code-blocks are automatically numbered if they
-# have a caption. 
-numfig = True
-
 # -- Options for manual page output --------------------------------------------
 
 # One entry per manual page. List of tuples

--- a/utils/docs/llvm_sphinx/__init__.py
+++ b/utils/docs/llvm_sphinx/__init__.py
@@ -56,6 +56,12 @@ def common_conf(tags: Tags, markdown=Markdown.ALWAYS) -> Dict[str, Any]:
     myst_heading_slug_func = "llvm_sphinx.make_slug"
     templates_path = ["_templates"]
     master_doc = "index"
+    # The sphinx implementation of numfig seems to be incredibly slow for
+    # larger projects, and has an outsized impact on no-op builds or builds
+    # with just a single file changed (i.e. the cases which most impact the
+    # documentation writer's experience). There were only every 2 uses in 1
+    # document, so we just forbid using it until the performance can be fixed.
+    numfig = False
 
     return locals()
 


### PR DESCRIPTION
Benchmarking shows a speedup of about 1.6x for a single file edit:

```bash

source .venv/bin/activate

hyperfine \
    --ignore-failure \
    --warmup 1 \
    --setup 'rm -rf /dev/shm/sphinx-build && cm c -b /dev/shm/sphinx-build' \
    --prepare 'touch llvm/docs/AMDGPUDwarfExtensionsForHeterogeneousDebugging.rst' \
    'cm b -b /dev/shm/sphinx-build docs-llvm-html'

 # main:
 # Benchmark 1: cm b -b /dev/shm/sphinx-build docs-llvm-html
 #   Time (mean ± σ):     41.424 s ±  1.652 s    [User: 39.534 s, System: 1.876 s]
 #   Range (min … max):   40.696 s … 46.110 s    10 runs

 # no-numfig:
 # Benchmark 1: cm b -b /dev/shm/sphinx-build docs-llvm-html
 #   Time (mean ± σ):     25.808 s ±  2.051 s    [User: 24.106 s, System: 1.692 s]
 #   Range (min … max):   24.287 s … 30.132 s    10 runs
```

There are only two uses of the feature, both in VectorizationPlan, and the net result of disabling it just changes them from looking like this:

    Refer to [Fig. 1] for an overview of the current transformation pipeline.

To looking like this:

    Refer to [VPlan Transformation Pipeline in 2024] for an overview of the
    current transformation pipeline.

Where "[...]" denotes the hyperlink to the figure.

See
https://github.com/zephyrproject-rtos/zephyr/pull/37572#discussion_r1102411281 for another project's discussion of the same issue.

Change-Id: Id22481811dd2e1936c92767888d6b61a9780c4f6