### PR TITLE
[LLDB][FreeBSD] Fix build from FileSpec change

### DIFF
--- a/lldb/source/Host/freebsd/Host.cpp
+++ b/lldb/source/Host/freebsd/Host.cpp
@@ -74,7 +74,7 @@ GetFreeBSDProcessArgs(const ProcessInstanceInfoMatch *match_info_ptr,
     process_info.GetExecutableFile().SetFile(cstr, FileSpec::Style::native);
 
   if (!(match_info_ptr == NULL ||
-        NameMatches(process_info.GetExecutableFile().GetFilename().GetCString(),
+        NameMatches(process_info.GetExecutableFile().GetFilename(),
                     match_info_ptr->GetNameMatchType(),
                     match_info_ptr->GetProcessInfo().GetName())))
     return false;


### PR DESCRIPTION
FileSpec now returns llvm::StringRef instead of ConstString. As a result, we don't need to use GetCString to get the raw string. Remove it to fix build failure.

Fixes: f9b5264523b1 (#206802)