### PR TITLE
[flang][OpenMP][NFC] Share SetSymbolDSA between semantics and lowering

### DIFF
--- a/flang/include/flang/Semantics/openmp-dsa.h
+++ b/flang/include/flang/Semantics/openmp-dsa.h
@@ -13,7 +13,11 @@
 
 namespace Fortran::semantics {
 
+Symbol::Flags GetDataSharingAttributeFlags();
+
 Symbol::Flags GetSymbolDSA(const Symbol &symbol);
+
+void SetSymbolDSA(Symbol &symbol, Symbol::Flags flags);
 
 } // namespace Fortran::semantics
 

--- a/flang/lib/Semantics/openmp-dsa.cpp
+++ b/flang/lib/Semantics/openmp-dsa.cpp
@@ -10,12 +10,14 @@
 
 namespace Fortran::semantics {
 
-Symbol::Flags GetSymbolDSA(const Symbol &symbol) {
-  Symbol::Flags dsaFlags{Symbol::Flag::OmpPrivate,
+Symbol::Flags GetDataSharingAttributeFlags() {
+  return Symbol::Flags{Symbol::Flag::OmpShared, Symbol::Flag::OmpPrivate,
       Symbol::Flag::OmpFirstPrivate, Symbol::Flag::OmpLastPrivate,
-      Symbol::Flag::OmpShared, Symbol::Flag::OmpLinear,
-      Symbol::Flag::OmpReduction};
-  Symbol::Flags dsa{symbol.flags() & dsaFlags};
+      Symbol::Flag::OmpReduction, Symbol::Flag::OmpLinear};
+}
+
+Symbol::Flags GetSymbolDSA(const Symbol &symbol) {
+  Symbol::Flags dsa{symbol.flags() & GetDataSharingAttributeFlags()};
   if (dsa.any()) {
     return dsa;
   }
@@ -24,6 +26,16 @@ Symbol::Flags GetSymbolDSA(const Symbol &symbol) {
     return GetSymbolDSA(details->symbol());
   }
   return {};
+}
+
+// Clear any previous data-sharing attribute flags and set the new ones.
+// Needed when setting PreDetermined DSAs, that take precedence over Implicit
+// ones.
+void SetSymbolDSA(Symbol &symbol, Symbol::Flags flags) {
+  symbol.flags() &= ~(GetDataSharingAttributeFlags() |
+      Symbol::Flags{Symbol::Flag::OmpExplicit, Symbol::Flag::OmpImplicit,
+          Symbol::Flag::OmpPreDetermined});
+  symbol.flags() |= flags;
 }
 
 } // namespace Fortran::semantics

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -982,10 +982,7 @@ public:
   }
 
 private:
-  Symbol::Flags dataSharingAttributeFlags{Symbol::Flag::OmpShared,
-      Symbol::Flag::OmpPrivate, Symbol::Flag::OmpFirstPrivate,
-      Symbol::Flag::OmpLastPrivate, Symbol::Flag::OmpReduction,
-      Symbol::Flag::OmpLinear};
+  Symbol::Flags dataSharingAttributeFlags{GetDataSharingAttributeFlags()};
 
   Symbol::Flags dataMappingAttributeFlags{Symbol::Flag::OmpMapTo,
       Symbol::Flag::OmpMapFrom, Symbol::Flag::OmpMapToFrom,
@@ -1054,16 +1051,6 @@ private:
     if (dataSharingAttributeFlags.test(flag)) {
       symbol.set(Symbol::Flag::OmpExplicit);
     }
-  }
-
-  // Clear any previous data-sharing attribute flags and set the new ones.
-  // Needed when setting PreDetermined DSAs, that take precedence over
-  // Implicit ones.
-  void SetSymbolDSA(Symbol &symbol, Symbol::Flags flags) {
-    symbol.flags() &= ~(dataSharingAttributeFlags |
-        Symbol::Flags{Symbol::Flag::OmpExplicit, Symbol::Flag::OmpImplicit,
-            Symbol::Flag::OmpPreDetermined});
-    symbol.flags() |= flags;
   }
 };
 


### PR DESCRIPTION
Move the DSA helper from the private OmpAttributeVisitor::SetSymbolDSA into the public openmp-dsa header next to GetSymbolDSA, and share the DSA flag set through a single GetDataSharingAttributeFlags().

This lets an upcoming metadirective lowering change reuse the helper to set the predetermined DSA of the loop induction variables of a selected variant. A loop-associated variant is resolved during lowering, so the usual semantic DSA resolution never runs on its loop nest and lowering must set those flags itself.

Assisted with Copilot.