### PR TITLE
[SPIRV] Support atomic exchange of pointers

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -2444,6 +2444,71 @@ bool SPIRVInstructionSelector::selectAtomicRMW(Register ResVReg,
     ValueReg = TmpReg;
   }
 
+  if (ResType.isTypePtr()) {
+    if (NewOpcode != SPIRV::OpAtomicExchange)
+      return diagnoseUnsupported(
+          I, "Lowering to SPIR-V of this atomic operation is not "
+             "allowed for pointer types");
+    if (!STI.isPhysicalSPIRV())
+      return diagnoseUnsupported(
+          I, "Lowering to SPIR-V of atomic exchange is only "
+             "allowed for pointer types for physical addressing model");
+    // If the exchanged value is a pointer type we convert the value operand to
+    // an integer type of the same size as the pointer size using
+    // OpConvertPtrToU, bitcast the Ptr parameter to pointer to integer type and
+    // then generate OpAtomicExchange on integers. The integer result is
+    // converted back to a pointer type using OpConvertUToPtr, similar to atomic
+    // load and store.
+    MachineIRBuilder MIRBuilder(I);
+    unsigned PtrSize = GR.getPointerSize();
+    SPIRVTypeInst PtrAsIntSpirvType =
+        GR.getOrCreateSPIRVIntegerType(PtrSize, MIRBuilder);
+
+    Register ValueAsIntReg =
+        MRI->createGenericVirtualRegister(LLT::scalar(PtrSize));
+    MRI->setRegClass(ValueAsIntReg, GR.getRegClass(PtrAsIntSpirvType));
+    GR.assignSPIRVTypeToVReg(PtrAsIntSpirvType, ValueAsIntReg,
+                             MIRBuilder.getMF());
+    MIRBuilder.buildInstr(SPIRV::OpConvertPtrToU)
+        .addDef(ValueAsIntReg)
+        .addUse(GR.getSPIRVTypeID(PtrAsIntSpirvType)) // Result type
+        .addUse(ValueReg)                             // Pointer operand
+        .constrainAllUses(TII, TRI, RBI);
+
+    SPIRVTypeInst PtrType = GR.getOrCreateSPIRVPointerType(
+        PtrAsIntSpirvType, MIRBuilder, GR.getPointerStorageClass(Ptr));
+    Register PtrCastedToMatchValReg =
+        MRI->createGenericVirtualRegister(LLT::scalar(PtrSize));
+    MRI->setRegClass(PtrCastedToMatchValReg, GR.getRegClass(PtrType));
+    GR.assignSPIRVTypeToVReg(PtrType, PtrCastedToMatchValReg,
+                             MIRBuilder.getMF());
+    MIRBuilder.buildInstr(SPIRV::OpBitcast)
+        .addDef(PtrCastedToMatchValReg)
+        .addUse(GR.getSPIRVTypeID(PtrType))
+        .addUse(Ptr)
+        .constrainAllUses(TII, TRI, RBI);
+
+    Register ExchangeResReg =
+        MRI->createGenericVirtualRegister(LLT::scalar(PtrSize));
+    MRI->setRegClass(ExchangeResReg, GR.getRegClass(PtrAsIntSpirvType));
+    GR.assignSPIRVTypeToVReg(PtrAsIntSpirvType, ExchangeResReg,
+                             MIRBuilder.getMF());
+    MIRBuilder.buildInstr(SPIRV::OpAtomicExchange)
+        .addDef(ExchangeResReg)
+        .addUse(GR.getSPIRVTypeID(PtrAsIntSpirvType))
+        .addUse(PtrCastedToMatchValReg)
+        .addUse(ScopeReg)
+        .addUse(MemSemReg)
+        .addUse(ValueAsIntReg)
+        .constrainAllUses(TII, TRI, RBI);
+    MIRBuilder.buildInstr(SPIRV::OpConvertUToPtr)
+        .addDef(ResVReg)
+        .addUse(GR.getSPIRVTypeID(ResType))
+        .addUse(ExchangeResReg)
+        .constrainAllUses(TII, TRI, RBI);
+    return true;
+  }
+
   BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(NewOpcode))
       .addDef(ResVReg)
       .addUse(GR.getSPIRVTypeID(ResType))

--- a/llvm/test/CodeGen/SPIRV/instructions/atomic-ptr.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/atomic-ptr.ll
@@ -1,14 +1,17 @@
-; The goal of the test case is to ensure that the Backend doesn't crash on the stage
-; of type inference. Result SPIR-V is not expected to be valid from the perspective
-; of spirv-val in this case, because there is a difference of accepted return types
-; between atomicrmw and OpAtomicExchange.
+; When the exchanged value is a pointer, 'atomicrmw xchg' is lowered to
+; OpAtomicExchange on integers: the value operand is converted to an integer of
+; the pointer size, the pointer operand is bitcast to a pointer to that integer
+; type, and the integer result is converted back to a pointer.
 
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK,SPIRV64
+; RUN: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK,SPIRV32
+; RUN: %if spirv-tools %{ llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-DAG: %[[#LongTy:]] = OpTypeInt 64 0
 ; CHECK-DAG: %[[#PtrLongTy:]] = OpTypePointer CrossWorkgroup %[[#LongTy]]
 ; CHECK-DAG: %[[#IntTy:]] = OpTypeInt 32 0
+; SPIRV32-DAG: %[[#PtrIntTy:]] = OpTypePointer CrossWorkgroup %[[#IntTy]]
 ; CHECK-DAG: %[[#Scope:]] = OpConstantNull %[[#IntTy]]
 ; CHECK-DAG: %[[#MemSem:]] = OpConstant %[[#IntTy]] 520
 ; CHECK-DAG: %[[#PtrPtrLongTy:]] = OpTypePointer CrossWorkgroup %[[#PtrLongTy]]
@@ -16,7 +19,13 @@
 ; CHECK: OpFunction
 ; CHECK: %[[#Arg1:]] = OpFunctionParameter %[[#PtrPtrLongTy]]
 ; CHECK: %[[#Arg2:]] = OpFunctionParameter %[[#PtrLongTy]]
-; CHECK: OpAtomicExchange %[[#PtrLongTy]] %[[#Arg1]] %[[#Scope]] %[[#MemSem]] %[[#Arg2]]
+; SPIRV64: %[[#CastVal:]] = OpConvertPtrToU %[[#LongTy]] %[[#Arg2]]
+; SPIRV64: %[[#CastPtr:]] = OpBitcast %[[#PtrLongTy]] %[[#Arg1]]
+; SPIRV64: %[[#Res:]] = OpAtomicExchange %[[#LongTy]] %[[#CastPtr]] %[[#Scope]] %[[#MemSem]] %[[#CastVal]]
+; SPIRV32: %[[#CastVal:]] = OpConvertPtrToU %[[#IntTy]] %[[#Arg2]]
+; SPIRV32: %[[#CastPtr:]] = OpBitcast %[[#PtrIntTy]] %[[#Arg1]]
+; SPIRV32: %[[#Res:]] = OpAtomicExchange %[[#IntTy]] %[[#CastPtr]] %[[#Scope]] %[[#MemSem]] %[[#CastVal]]
+; CHECK: OpConvertUToPtr %[[#PtrLongTy]] %[[#Res]]
 ; CHECK: OpFunctionEnd
 
 define dso_local spir_func void @test1(ptr addrspace(1) %arg1, ptr addrspace(1) byval(i64) %arg_ptr) {

--- a/llvm/test/CodeGen/SPIRV/transcoding/atomic-load-store-exchange-unsupported.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/atomic-load-store-exchange-unsupported.ll
@@ -1,4 +1,6 @@
-; Verify that atomic load/store of vectors correctly fail to select.
+; Verify that unsupported atomic operations correctly fail to select: atomic
+; load/store of vectors, and atomic load/store/exchange of pointers under the
+; logical addressing model.
 
 ; RUN: split-file %s %t
 
@@ -10,10 +12,13 @@
 
 ; RUN: not llc -O0 -mtriple=spirv %t/load-ptr-vulkan.ll -o /dev/null 2>&1 | FileCheck --check-prefix=FAIL-LOAD-PTR %s
 
+; RUN: not llc -O0 -mtriple=spirv %t/xchg-ptr-vulkan.ll -o /dev/null 2>&1 | FileCheck --check-prefix=FAIL-XCHG-PTR %s
+
 ; FAIL-LOAD-VEC: error:{{.*}}atomic load is only allowed for integer, floating point or pointer types
 ; FAIL-STORE-VEC: error:{{.*}}atomic store is only allowed for integer or floating point types
 ; FAIL-STORE-PTR: error:{{.*}}atomic store is only allowed for pointer types for physical addressing model
 ; FAIL-LOAD-PTR: error:{{.*}}atomic load is only allowed for pointer types for physical addressing model
+; FAIL-XCHG-PTR: error:{{.*}}atomic exchange is only allowed for pointer types for physical addressing model
 
 ;--- load-vector.ll
 define <2 x i32> @load_vector_acquire(ptr addrspace(1) %ptr) {
@@ -37,4 +42,10 @@ define void @store_ptr_release(ptr addrspace(1) %ptr, ptr addrspace(1) %val) {
 define ptr addrspace(1) @load_ptr_release(ptr addrspace(1) %ptr) {
   %val = load atomic ptr addrspace(1), ptr addrspace(1) %ptr monotonic, align 8
   ret ptr addrspace(1) %val
+}
+
+;--- xchg-ptr-vulkan.ll
+define ptr addrspace(1) @xchg_ptr_monotonic(ptr addrspace(1) %ptr, ptr addrspace(1) %val) {
+  %res = atomicrmw xchg ptr addrspace(1) %ptr, ptr addrspace(1) %val monotonic, align 8
+  ret ptr addrspace(1) %res
 }


### PR DESCRIPTION
Similar to what we do for atomic loads and stores,  support pointers by converting the exchange value to an equally-sized int, the pointer to a pointer to that equally-sized int, and convert the result back to the original pointer type.

This was found enabling support for SPIR-V in libc.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>