### PR TITLE
[Attributor] Distinguish COHERENT accesses in addition to exact ones

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -6243,12 +6243,21 @@ struct AAPointerInfo : public AbstractAttribute {
   virtual bool reachesReturn() const = 0;
   virtual void addReturnedOffsetsTo(OffsetInfo &) const = 0;
 
+  enum AccessOverlapTy {
+    UNKNOWN,  /// No known overlap.
+    COHERENT, /// Matches the size and has sufficient alignment to be not broken
+              /// apart but stay a coherent value if it matches the target
+              /// range.
+    EXACT,    /// Matches the exact location and size of the access.
+  };
+
   /// Call \p CB on all accesses that might interfere with \p Range and return
   /// true if all such accesses were known and the callback returned true for
   /// all of them, false otherwise. An access interferes with an offset-size
   /// pair if it might read or write that memory region.
   virtual bool forallInterferingAccesses(
-      AA::RangeTy Range, function_ref<bool(const Access &, bool)> CB) const = 0;
+      AA::RangeTy Range,
+      function_ref<bool(const Access &, AccessOverlapTy)> CB) const = 0;
 
   /// Call \p CB on all accesses that might interfere with \p I and
   /// return true if all such accesses were known and the callback returned true
@@ -6262,8 +6271,8 @@ struct AAPointerInfo : public AbstractAttribute {
   virtual bool forallInterferingAccesses(
       Attributor &A, const AbstractAttribute &QueryingAA, Instruction &I,
       bool FindInterferingWrites, bool FindInterferingReads,
-      function_ref<bool(const Access &, bool)> CB, bool &HasBeenWrittenTo,
-      AA::RangeTy &Range,
+      function_ref<bool(const Access &, AccessOverlapTy)> CB,
+      bool &HasBeenWrittenTo, AA::RangeTy &Range,
       function_ref<bool(const Access &)> SkipCB = nullptr) const = 0;
 
   /// This function should return true if the type of the \p AA is AAPointerInfo

--- a/llvm/lib/Transforms/IPO/Attributor.cpp
+++ b/llvm/lib/Transforms/IPO/Attributor.cpp
@@ -487,13 +487,13 @@ static bool getPotentialCopiesOfMemoryValue(
     bool NullOnly = true;
     bool NullRequired = false;
     auto CheckForNullOnlyAndUndef = [&](std::optional<Value *> V,
-                                        bool IsExact) {
+                                        AAPointerInfo::AccessOverlapTy AOTy) {
       if (!V || *V == nullptr)
         NullOnly = false;
       else if (isa<UndefValue>(*V))
         /* No op */;
       else if (isa<Constant>(*V) && cast<Constant>(*V)->isNullValue())
-        NullRequired = !IsExact;
+        NullRequired = AOTy == AAPointerInfo::AccessOverlapTy::UNKNOWN;
       else
         NullOnly = false;
     };
@@ -534,14 +534,15 @@ static bool getPotentialCopiesOfMemoryValue(
       return false;
     };
 
-    auto CheckAccess = [&](const AAPointerInfo::Access &Acc, bool IsExact) {
+    auto CheckAccess = [&](const AAPointerInfo::Access &Acc,
+                           AAPointerInfo::AccessOverlapTy AOTy) {
       if ((IsLoad && !Acc.isWriteOrAssumption()) || (!IsLoad && !Acc.isRead()))
         return true;
       if (IsLoad && Acc.isWrittenValueYetUndetermined())
         return true;
-      CheckForNullOnlyAndUndef(Acc.getContent(), IsExact);
-      if (OnlyExact && !IsExact && !NullOnly &&
-          !isa_and_nonnull<UndefValue>(Acc.getWrittenValue())) {
+      CheckForNullOnlyAndUndef(Acc.getContent(), AOTy);
+      if (OnlyExact && AOTy == AAPointerInfo::AccessOverlapTy::UNKNOWN &&
+          !NullOnly && !isa_and_nonnull<UndefValue>(Acc.getWrittenValue())) {
         LLVM_DEBUG(dbgs() << "Non exact access " << *Acc.getRemoteInst()
                           << ", abort!\n");
         return false;
@@ -618,7 +619,8 @@ static bool getPotentialCopiesOfMemoryValue(
                              "underlying object, abort!\n");
         return false;
       }
-      CheckForNullOnlyAndUndef(InitialValue, /* IsExact */ true);
+      CheckForNullOnlyAndUndef(InitialValue,
+                               AAPointerInfo::AccessOverlapTy::EXACT);
       if (NullRequired && !NullOnly) {
         LLVM_DEBUG(dbgs() << "Non exact access but initial value that is not "
                              "null or undef, abort!\n");

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -887,9 +887,39 @@ protected:
   /// invalidation.
   AAPointerInfo::OffsetInfo ReturnedOffsets;
 
+  /// Return the \p Size and \p Alignment of \p I. Unchanged if unknown.
+  static void getSizeAndAlignment(Instruction &I, const DataLayout &DL,
+                                  uint32_t &Size, Align &Alignment) {
+    if (auto *LI = dyn_cast<LoadInst>(&I)) {
+      Size = DL.getTypeStoreSize(LI->getType());
+      Alignment = LI->getAlign();
+    } else if (auto *SI = dyn_cast<StoreInst>(&I)) {
+      Size = DL.getTypeStoreSize(SI->getPointerOperandType());
+      Alignment = SI->getAlign();
+    } else if (auto *AI = dyn_cast<AtomicRMWInst>(&I)) {
+      Size = DL.getTypeStoreSize(AI->getPointerOperand()->getType());
+      Alignment = AI->getAlign();
+    } else if (auto *AI = dyn_cast<AtomicCmpXchgInst>(&I)) {
+      Size = DL.getTypeStoreSize(AI->getPointerOperand()->getType());
+      Alignment = AI->getAlign();
+    } else if (auto *MI = dyn_cast<MemSetInst>(&I)) {
+      std::optional<APInt> Length = MI->getLengthInBytes();
+      if (Length && Length->getActiveBits() <= 32)
+        Size = Length->getZExtValue();
+      Alignment = MI->getDestAlign().valueOrOne();
+    } else if (auto *MI = dyn_cast<MemTransferInst>(&I)) {
+      std::optional<APInt> Length = MI->getLengthInBytes();
+      if (Length && Length->getActiveBits() <= 32)
+        Size = Length->getZExtValue();
+      Alignment = std::min(MI->getSourceAlign().valueOrOne(),
+                           MI->getDestAlign().valueOrOne());
+    }
+  }
+
   /// See AAPointerInfo::forallInterferingAccesses.
   template <typename F>
-  bool forallInterferingAccesses(AA::RangeTy Range, F CB) const {
+  bool forallInterferingAccesses(AA::RangeTy Range, F CB, uint32_t Size = 0,
+                                 Align Alignment = Align(0)) const {
     if (!isValidState() || !ReturnedOffsets.isUnassigned())
       return false;
 
@@ -898,9 +928,22 @@ protected:
       if (!Range.mayOverlap(ItRange))
         continue;
       bool IsExact = Range == ItRange && !Range.offsetOrSizeAreUnknown();
+      bool IsCoherent = false;
       for (auto Index : It.getSecond()) {
         auto &Access = AccessList[Index];
-        if (!CB(Access, IsExact))
+        if (!IsExact) {
+          auto *AccI = Access.getRemoteInst();
+          uint32_t AccSize = 0;
+          Align AccAlignment(1);
+          const DataLayout &DL = AccI->getDataLayout();
+          getSizeAndAlignment(*AccI, DL, AccSize, AccAlignment);
+          if (AccSize && AccSize == Size && Alignment >= Size &&
+              AccAlignment >= AccSize)
+            IsCoherent = true;
+        }
+        if (!CB(Access, IsExact      ? AAPointerInfo::EXACT
+                        : IsCoherent ? AAPointerInfo::COHERENT
+                                     : AAPointerInfo::UNKNOWN))
           return false;
       }
     }
@@ -926,7 +969,11 @@ protected:
           break;
       }
     }
-    return forallInterferingAccesses(Range, CB);
+    uint32_t Size = 0;
+    Align Alignment(1);
+    const DataLayout &DL = I.getDataLayout();
+    getSizeAndAlignment(I, DL, Size, Alignment);
+    return forallInterferingAccesses(Range, CB, Size, Alignment);
   }
 
 private:
@@ -1078,7 +1125,7 @@ struct AAPointerInfoImpl
 
   bool forallInterferingAccesses(
       AA::RangeTy Range,
-      function_ref<bool(const AAPointerInfo::Access &, bool)> CB)
+      function_ref<bool(const AAPointerInfo::Access &, AccessOverlapTy)> CB)
       const override {
     return State::forallInterferingAccesses(Range, CB);
   }
@@ -1086,13 +1133,14 @@ struct AAPointerInfoImpl
   bool forallInterferingAccesses(
       Attributor &A, const AbstractAttribute &QueryingAA, Instruction &I,
       bool FindInterferingWrites, bool FindInterferingReads,
-      function_ref<bool(const Access &, bool)> UserCB, bool &HasBeenWrittenTo,
-      AA::RangeTy &Range,
+      function_ref<bool(const Access &, AccessOverlapTy)> UserCB,
+      bool &HasBeenWrittenTo, AA::RangeTy &Range,
       function_ref<bool(const Access &)> SkipCB) const override {
     HasBeenWrittenTo = false;
 
     SmallPtrSet<const Access *, 8> DominatingWrites;
-    SmallVector<std::pair<const Access *, bool>, 8> InterferingAccesses;
+    SmallVector<std::pair<const Access *, AccessOverlapTy>, 8>
+        InterferingAccesses;
 
     Function &Scope = *I.getFunction();
     bool IsKnownNoSync;
@@ -1221,7 +1269,8 @@ struct AAPointerInfoImpl
     // therefore blockers in the reachability traversal.
     AA::InstExclusionSetTy ExclusionSet;
 
-    auto AccessCB = [&](const Access &Acc, bool Exact) {
+    auto AccessCB = [&](const Access &Acc, AccessOverlapTy AOTy) {
+      bool Exact = AOTy == AccessOverlapTy::EXACT;
       Function *AccScope = Acc.getRemoteInst()->getFunction();
       bool AccInSameScope = AccScope == &Scope;
 
@@ -1250,7 +1299,7 @@ struct AAPointerInfoImpl
       // the given instruction.
       AllInSameNoSyncFn &= Acc.getRemoteInst()->getFunction() == &Scope;
 
-      InterferingAccesses.push_back({&Acc, Exact});
+      InterferingAccesses.push_back({&Acc, AOTy});
       return true;
     };
     if (!State::forallInterferingAccesses(I, AccessCB, Range))
@@ -1270,7 +1319,7 @@ struct AAPointerInfoImpl
     }
 
     // Helper to determine if we can skip a specific write access.
-    auto CanSkipAccess = [&](const Access &Acc, bool Exact) {
+    auto CanSkipAccess = [&](const Access &Acc, AccessOverlapTy AOTy) {
       if (SkipCB && SkipCB(Acc))
         return true;
       if (!CanIgnoreThreading(Acc))

--- a/llvm/test/Transforms/Attributor/multiple-offsets-pointer-info.ll
+++ b/llvm/test/Transforms/Attributor/multiple-offsets-pointer-info.ll
@@ -402,24 +402,57 @@ join:
   ret i8 %i
 }
 
-define i8 @phi_gep_not_simplifiable_1(i1 %cnd1, i1 %cnd2) {
+define i64 @phi_gep_not_simplifiable_1(i1 %cnd1, i1 %cnd2) {
 ; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
 ; CHECK-LABEL: define {{[^@]+}}@phi_gep_not_simplifiable_1
 ; CHECK-SAME: (i1 noundef [[CND1:%.*]], i1 [[CND2:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[BYTES:%.*]] = alloca [1024 x i8], align 16
-; CHECK-NEXT:    [[GEP23:%.*]] = getelementptr inbounds [1024 x i8], ptr [[BYTES]], i64 0, i64 23
+; CHECK-NEXT:    [[BYTES:%.*]] = alloca [1024 x i64], align 16
+; CHECK-NEXT:    [[GEP23:%.*]] = getelementptr inbounds i8, ptr [[BYTES]], i64 23
 ; CHECK-NEXT:    br i1 [[CND1]], label [[THEN:%.*]], label [[ELSE:%.*]]
 ; CHECK:       then:
 ; CHECK-NEXT:    br label [[JOIN:%.*]]
 ; CHECK:       else:
-; CHECK-NEXT:    [[GEP31:%.*]] = getelementptr inbounds [1024 x i8], ptr [[BYTES]], i64 0, i64 31
+; CHECK-NEXT:    [[GEP31:%.*]] = getelementptr inbounds i8, ptr [[BYTES]], i64 31
 ; CHECK-NEXT:    br label [[JOIN]]
 ; CHECK:       join:
 ; CHECK-NEXT:    [[PHI_PTR:%.*]] = phi ptr [ [[GEP23]], [[THEN]] ], [ [[GEP31]], [[ELSE]] ]
-; CHECK-NEXT:    store i8 42, ptr [[GEP23]], align 4
-; CHECK-NEXT:    [[I:%.*]] = load i8, ptr [[PHI_PTR]], align 4
-; CHECK-NEXT:    ret i8 [[I]]
+; CHECK-NEXT:    store i64 42, ptr [[GEP23]], align 1
+; CHECK-NEXT:    [[I:%.*]] = load i64, ptr [[PHI_PTR]], align 1
+; CHECK-NEXT:    ret i64 [[I]]
+;
+entry:
+  %Bytes = alloca [1024 x i64], align 16
+  %gep23 = getelementptr inbounds i8, ptr %Bytes, i64 23
+  br i1 %cnd1, label %then, label %else
+
+then:
+  br label %join
+
+else:
+  %gep31 = getelementptr inbounds i8, ptr %Bytes, i64 31
+  br label %join
+
+join:
+  %phi.ptr = phi ptr [%gep23, %then], [%gep31, %else]
+  ;; This store cannot be eliminated
+  store i64 42, ptr %gep23, align 1
+  %i = load i64, ptr %phi.ptr, align 1
+  ret i64 %i
+}
+
+define i8 @phi_gep_simplifiable_3(i1 %cnd1, i1 %cnd2) {
+; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; CHECK-LABEL: define {{[^@]+}}@phi_gep_simplifiable_3
+; CHECK-SAME: (i1 noundef [[CND1:%.*]], i1 [[CND2:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br i1 [[CND1]], label [[THEN:%.*]], label [[ELSE:%.*]]
+; CHECK:       then:
+; CHECK-NEXT:    br label [[JOIN:%.*]]
+; CHECK:       else:
+; CHECK-NEXT:    br label [[JOIN]]
+; CHECK:       join:
+; CHECK-NEXT:    ret i8 42
 ;
 entry:
   %Bytes = alloca [1024 x i8], align 16
@@ -435,7 +468,6 @@ else:
 
 join:
   %phi.ptr = phi ptr [%gep23, %then], [%gep31, %else]
-  ;; This store cannot be eliminated
   store i8 42, ptr %gep23, align 4
   %i = load i8, ptr %phi.ptr, align 4
   ret i8 %i

--- a/llvm/test/Transforms/Attributor/nocapture-2.ll
+++ b/llvm/test/Transforms/Attributor/nocapture-2.ll
@@ -373,16 +373,16 @@ define void @test_not_captured_but_returned_calls(ptr %a) #0 {
 ; TUNIT-LABEL: define void @test_not_captured_but_returned_calls
 ; TUNIT-SAME: (ptr nofree writeonly align 8 captures(none) [[A:%.*]]) #[[ATTR4]] {
 ; TUNIT-NEXT:  entry:
-; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @not_captured_but_returned_0(ptr nofree noundef writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR12:[0-9]+]]
-; TUNIT-NEXT:    [[CALL1:%.*]] = call ptr @not_captured_but_returned_1(ptr nofree writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR12]]
+; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @not_captured_but_returned_0(ptr nofree noundef writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR14:[0-9]+]]
+; TUNIT-NEXT:    [[CALL1:%.*]] = call ptr @not_captured_but_returned_1(ptr nofree writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR14]]
 ; TUNIT-NEXT:    ret void
 ;
 ; CGSCC: Function Attrs: mustprogress nofree noinline nosync nounwind willreturn memory(argmem: write) uwtable
 ; CGSCC-LABEL: define void @test_not_captured_but_returned_calls
 ; CGSCC-SAME: (ptr nofree noundef nonnull writeonly align 8 dereferenceable(16) [[A:%.*]]) #[[ATTR5:[0-9]+]] {
 ; CGSCC-NEXT:  entry:
-; CGSCC-NEXT:    [[CALL:%.*]] = call ptr @not_captured_but_returned_0(ptr nofree noundef nonnull writeonly align 8 dereferenceable(16) [[A]]) #[[ATTR14:[0-9]+]]
-; CGSCC-NEXT:    [[CALL1:%.*]] = call ptr @not_captured_but_returned_1(ptr nofree noundef nonnull writeonly align 8 dereferenceable(16) [[A]]) #[[ATTR14]]
+; CGSCC-NEXT:    [[CALL:%.*]] = call ptr @not_captured_but_returned_0(ptr nofree noundef nonnull writeonly align 8 dereferenceable(16) [[A]]) #[[ATTR16:[0-9]+]]
+; CGSCC-NEXT:    [[CALL1:%.*]] = call ptr @not_captured_but_returned_1(ptr nofree noundef nonnull writeonly align 8 dereferenceable(16) [[A]]) #[[ATTR16]]
 ; CGSCC-NEXT:    ret void
 ;
 entry:
@@ -403,14 +403,14 @@ define ptr @negative_test_not_captured_but_returned_call_0a(ptr %a) #0 {
 ; TUNIT-LABEL: define align 8 ptr @negative_test_not_captured_but_returned_call_0a
 ; TUNIT-SAME: (ptr nofree returned writeonly align 8 "no-capture-maybe-returned" [[A:%.*]]) #[[ATTR4]] {
 ; TUNIT-NEXT:  entry:
-; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @not_captured_but_returned_0(ptr nofree noundef writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR12]]
+; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @not_captured_but_returned_0(ptr nofree noundef writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR14]]
 ; TUNIT-NEXT:    ret ptr [[A]]
 ;
 ; CGSCC: Function Attrs: mustprogress nofree noinline nosync nounwind willreturn memory(argmem: write) uwtable
 ; CGSCC-LABEL: define noundef nonnull align 8 dereferenceable(8) ptr @negative_test_not_captured_but_returned_call_0a
 ; CGSCC-SAME: (ptr nofree noundef nonnull writeonly align 8 dereferenceable(8) [[A:%.*]]) #[[ATTR5]] {
 ; CGSCC-NEXT:  entry:
-; CGSCC-NEXT:    [[CALL:%.*]] = call noundef nonnull align 8 dereferenceable(8) ptr @not_captured_but_returned_0(ptr nofree noundef nonnull writeonly align 8 dereferenceable(8) [[A]]) #[[ATTR14]]
+; CGSCC-NEXT:    [[CALL:%.*]] = call noundef nonnull align 8 dereferenceable(8) ptr @not_captured_but_returned_0(ptr nofree noundef nonnull writeonly align 8 dereferenceable(8) [[A]]) #[[ATTR16]]
 ; CGSCC-NEXT:    ret ptr [[CALL]]
 ;
 entry:
@@ -430,7 +430,7 @@ define void @negative_test_not_captured_but_returned_call_0b(ptr %a) #0 {
 ; TUNIT-LABEL: define void @negative_test_not_captured_but_returned_call_0b
 ; TUNIT-SAME: (ptr nofree writeonly align 8 [[A:%.*]]) #[[ATTR4]] {
 ; TUNIT-NEXT:  entry:
-; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @not_captured_but_returned_0(ptr nofree noundef writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR12]]
+; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @not_captured_but_returned_0(ptr nofree noundef writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR14]]
 ; TUNIT-NEXT:    [[TMP0:%.*]] = ptrtoint ptr [[A]] to i64
 ; TUNIT-NEXT:    store i64 [[TMP0]], ptr [[A]], align 8
 ; TUNIT-NEXT:    ret void
@@ -439,7 +439,7 @@ define void @negative_test_not_captured_but_returned_call_0b(ptr %a) #0 {
 ; CGSCC-LABEL: define void @negative_test_not_captured_but_returned_call_0b
 ; CGSCC-SAME: (ptr nofree noundef nonnull writeonly align 8 dereferenceable(8) [[A:%.*]]) #[[ATTR5]] {
 ; CGSCC-NEXT:  entry:
-; CGSCC-NEXT:    [[CALL:%.*]] = call ptr @not_captured_but_returned_0(ptr nofree noundef nonnull writeonly align 8 dereferenceable(8) [[A]]) #[[ATTR14]]
+; CGSCC-NEXT:    [[CALL:%.*]] = call ptr @not_captured_but_returned_0(ptr nofree noundef nonnull writeonly align 8 dereferenceable(8) [[A]]) #[[ATTR16]]
 ; CGSCC-NEXT:    [[TMP0:%.*]] = ptrtoint ptr [[CALL]] to i64
 ; CGSCC-NEXT:    store i64 [[TMP0]], ptr [[A]], align 8
 ; CGSCC-NEXT:    ret void
@@ -463,14 +463,14 @@ define ptr @negative_test_not_captured_but_returned_call_1a(ptr %a) #0 {
 ; TUNIT-LABEL: define noundef nonnull align 8 dereferenceable(8) ptr @negative_test_not_captured_but_returned_call_1a
 ; TUNIT-SAME: (ptr nofree writeonly align 8 "no-capture-maybe-returned" [[A:%.*]]) #[[ATTR4]] {
 ; TUNIT-NEXT:  entry:
-; TUNIT-NEXT:    [[CALL:%.*]] = call noundef nonnull align 8 dereferenceable(8) ptr @not_captured_but_returned_1(ptr nofree writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR12]]
+; TUNIT-NEXT:    [[CALL:%.*]] = call noundef nonnull align 8 dereferenceable(8) ptr @not_captured_but_returned_1(ptr nofree writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR14]]
 ; TUNIT-NEXT:    ret ptr [[CALL]]
 ;
 ; CGSCC: Function Attrs: mustprogress nofree noinline nosync nounwind willreturn memory(argmem: write) uwtable
 ; CGSCC-LABEL: define noundef nonnull align 8 dereferenceable(8) ptr @negative_test_not_captured_but_returned_call_1a
 ; CGSCC-SAME: (ptr nofree noundef nonnull writeonly align 8 dereferenceable(16) [[A:%.*]]) #[[ATTR5]] {
 ; CGSCC-NEXT:  entry:
-; CGSCC-NEXT:    [[CALL:%.*]] = call noundef nonnull align 8 dereferenceable(8) ptr @not_captured_but_returned_1(ptr nofree noundef nonnull writeonly align 8 dereferenceable(16) [[A]]) #[[ATTR14]]
+; CGSCC-NEXT:    [[CALL:%.*]] = call noundef nonnull align 8 dereferenceable(8) ptr @not_captured_but_returned_1(ptr nofree noundef nonnull writeonly align 8 dereferenceable(16) [[A]]) #[[ATTR16]]
 ; CGSCC-NEXT:    ret ptr [[CALL]]
 ;
 entry:
@@ -490,7 +490,7 @@ define void @negative_test_not_captured_but_returned_call_1b(ptr %a) #0 {
 ; TUNIT-LABEL: define void @negative_test_not_captured_but_returned_call_1b
 ; TUNIT-SAME: (ptr nofree writeonly align 8 [[A:%.*]]) #[[ATTR5:[0-9]+]] {
 ; TUNIT-NEXT:  entry:
-; TUNIT-NEXT:    [[CALL:%.*]] = call align 8 ptr @not_captured_but_returned_1(ptr nofree writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR12]]
+; TUNIT-NEXT:    [[CALL:%.*]] = call align 8 ptr @not_captured_but_returned_1(ptr nofree writeonly align 8 "no-capture-maybe-returned" [[A]]) #[[ATTR14]]
 ; TUNIT-NEXT:    [[TMP0:%.*]] = ptrtoint ptr [[CALL]] to i64
 ; TUNIT-NEXT:    store i64 [[TMP0]], ptr [[CALL]], align 8
 ; TUNIT-NEXT:    ret void
@@ -499,7 +499,7 @@ define void @negative_test_not_captured_but_returned_call_1b(ptr %a) #0 {
 ; CGSCC-LABEL: define void @negative_test_not_captured_but_returned_call_1b
 ; CGSCC-SAME: (ptr nofree noundef nonnull writeonly align 8 dereferenceable(16) [[A:%.*]]) #[[ATTR6:[0-9]+]] {
 ; CGSCC-NEXT:  entry:
-; CGSCC-NEXT:    [[CALL:%.*]] = call align 8 ptr @not_captured_but_returned_1(ptr nofree noundef nonnull writeonly align 8 dereferenceable(16) [[A]]) #[[ATTR14]]
+; CGSCC-NEXT:    [[CALL:%.*]] = call align 8 ptr @not_captured_but_returned_1(ptr nofree noundef nonnull writeonly align 8 dereferenceable(16) [[A]]) #[[ATTR16]]
 ; CGSCC-NEXT:    [[TMP0:%.*]] = ptrtoint ptr [[CALL]] to i64
 ; CGSCC-NEXT:    store i64 [[TMP0]], ptr [[CALL]], align 8
 ; CGSCC-NEXT:    ret void
@@ -589,14 +589,14 @@ define void @not_captured_by_readonly_call(ptr %b) #0 {
 ; TUNIT-LABEL: define void @not_captured_by_readonly_call
 ; TUNIT-SAME: (ptr readonly captures(none) [[B:%.*]]) #[[ATTR7:[0-9]+]] {
 ; TUNIT-NEXT:  entry:
-; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @readonly_unknown(ptr readonly [[B]], ptr readonly [[B]]) #[[ATTR13:[0-9]+]]
+; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @readonly_unknown(ptr readonly [[B]], ptr readonly [[B]]) #[[ATTR15:[0-9]+]]
 ; TUNIT-NEXT:    ret void
 ;
 ; CGSCC: Function Attrs: noinline nosync nounwind memory(read) uwtable
 ; CGSCC-LABEL: define void @not_captured_by_readonly_call
 ; CGSCC-SAME: (ptr readonly captures(none) [[B:%.*]]) #[[ATTR8:[0-9]+]] {
 ; CGSCC-NEXT:  entry:
-; CGSCC-NEXT:    [[CALL:%.*]] = call ptr @readonly_unknown(ptr readonly [[B]], ptr readonly [[B]]) #[[ATTR15:[0-9]+]]
+; CGSCC-NEXT:    [[CALL:%.*]] = call ptr @readonly_unknown(ptr readonly [[B]], ptr readonly [[B]]) #[[ATTR17:[0-9]+]]
 ; CGSCC-NEXT:    ret void
 ;
 entry:
@@ -676,14 +676,14 @@ define ptr @not_captured_by_readonly_call_not_returned_either4(ptr %b, ptr %r) n
 ; TUNIT-LABEL: define ptr @not_captured_by_readonly_call_not_returned_either4
 ; TUNIT-SAME: (ptr readonly [[B:%.*]], ptr readonly [[R:%.*]]) #[[ATTR8]] {
 ; TUNIT-NEXT:  entry:
-; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @readonly_unknown_r1a(ptr readonly [[B]], ptr readonly [[R]]) #[[ATTR13]]
+; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @readonly_unknown_r1a(ptr readonly [[B]], ptr readonly [[R]]) #[[ATTR15]]
 ; TUNIT-NEXT:    ret ptr [[CALL]]
 ;
 ; CGSCC: Function Attrs: nosync nounwind memory(read)
 ; CGSCC-LABEL: define ptr @not_captured_by_readonly_call_not_returned_either4
 ; CGSCC-SAME: (ptr readonly [[B:%.*]], ptr readonly [[R:%.*]]) #[[ATTR9]] {
 ; CGSCC-NEXT:  entry:
-; CGSCC-NEXT:    [[CALL:%.*]] = call ptr @readonly_unknown_r1a(ptr readonly [[B]], ptr readonly [[R]]) #[[ATTR15]]
+; CGSCC-NEXT:    [[CALL:%.*]] = call ptr @readonly_unknown_r1a(ptr readonly [[B]], ptr readonly [[R]]) #[[ATTR17]]
 ; CGSCC-NEXT:    ret ptr [[CALL]]
 ;
 entry:
@@ -713,7 +713,7 @@ define void @nocapture_is_not_subsumed_2(ptr nocapture %b) {
 ; TUNIT-LABEL: define void @nocapture_is_not_subsumed_2
 ; TUNIT-SAME: (ptr captures(none) [[B:%.*]]) #[[ATTR10:[0-9]+]] {
 ; TUNIT-NEXT:  entry:
-; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @readonly_i32p(ptr readonly [[B]]) #[[ATTR13]]
+; TUNIT-NEXT:    [[CALL:%.*]] = call ptr @readonly_i32p(ptr readonly [[B]]) #[[ATTR15]]
 ; TUNIT-NEXT:    store i32 0, ptr [[CALL]], align 4
 ; TUNIT-NEXT:    ret void
 ;
@@ -721,7 +721,7 @@ define void @nocapture_is_not_subsumed_2(ptr nocapture %b) {
 ; CGSCC-LABEL: define void @nocapture_is_not_subsumed_2
 ; CGSCC-SAME: (ptr captures(none) [[B:%.*]]) #[[ATTR11:[0-9]+]] {
 ; CGSCC-NEXT:  entry:
-; CGSCC-NEXT:    [[CALL:%.*]] = call ptr @readonly_i32p(ptr readonly [[B]]) #[[ATTR15]]
+; CGSCC-NEXT:    [[CALL:%.*]] = call ptr @readonly_i32p(ptr readonly [[B]]) #[[ATTR17]]
 ; CGSCC-NEXT:    store i32 0, ptr [[CALL]], align 4
 ; CGSCC-NEXT:    ret void
 ;
@@ -802,6 +802,180 @@ define void @b64613_positive(ptr noundef %p, i32 %i) {
   %q = call ptr @b64613_b(ptr %r, i32 %i)
   ret void
 }
+define ptr @b64613_c(ptr noundef %p, i32 %i) {
+; TUNIT: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; TUNIT-LABEL: define ptr @b64613_c
+; TUNIT-SAME: (ptr nofree noundef readnone returned "no-capture-maybe-returned" [[P:%.*]], i32 [[I:%.*]]) #[[ATTR11]] {
+; TUNIT-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; TUNIT-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; TUNIT-NEXT:    store ptr [[P]], ptr [[G]], align 8
+; TUNIT-NEXT:    ret ptr [[P]]
+;
+; CGSCC: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; CGSCC-LABEL: define ptr @b64613_c
+; CGSCC-SAME: (ptr nofree noundef readnone returned "no-capture-maybe-returned" [[P:%.*]], i32 [[I:%.*]]) #[[ATTR12]] {
+; CGSCC-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; CGSCC-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; CGSCC-NEXT:    store ptr [[P]], ptr [[G]], align 8
+; CGSCC-NEXT:    ret ptr [[P]]
+;
+  %p.addr = alloca <2 x ptr>, align 8
+  %g = getelementptr i8, ptr %p.addr, i32 %i
+  store ptr %p, ptr %g, align 8
+  %r = load ptr, ptr %p.addr, align 8
+  ret ptr %r
+}
+define ptr @b64613_d(ptr noundef %p, i32 %i) {
+; TUNIT: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; TUNIT-LABEL: define ptr @b64613_d
+; TUNIT-SAME: (ptr nofree noundef [[P:%.*]], i32 [[I:%.*]]) #[[ATTR11]] {
+; TUNIT-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; TUNIT-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; TUNIT-NEXT:    store ptr [[P]], ptr [[G]], align 4
+; TUNIT-NEXT:    [[R:%.*]] = load ptr, ptr [[P_ADDR]], align 8
+; TUNIT-NEXT:    ret ptr [[R]]
+;
+; CGSCC: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; CGSCC-LABEL: define ptr @b64613_d
+; CGSCC-SAME: (ptr nofree noundef [[P:%.*]], i32 [[I:%.*]]) #[[ATTR12]] {
+; CGSCC-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; CGSCC-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; CGSCC-NEXT:    store ptr [[P]], ptr [[G]], align 4
+; CGSCC-NEXT:    [[R:%.*]] = load ptr, ptr [[P_ADDR]], align 8
+; CGSCC-NEXT:    ret ptr [[R]]
+;
+  %p.addr = alloca <2 x ptr>, align 8
+  %g = getelementptr i8, ptr %p.addr, i32 %i
+  store ptr %p, ptr %g, align 4
+  %r = load ptr, ptr %p.addr, align 8
+  ret ptr %r
+}
+define ptr @b64613_e(ptr noundef %p, i32 %i) {
+; TUNIT: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; TUNIT-LABEL: define ptr @b64613_e
+; TUNIT-SAME: (ptr nofree noundef [[P:%.*]], i32 [[I:%.*]]) #[[ATTR11]] {
+; TUNIT-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; TUNIT-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; TUNIT-NEXT:    store ptr [[P]], ptr [[G]], align 8
+; TUNIT-NEXT:    [[R:%.*]] = load ptr, ptr [[P_ADDR]], align 8
+; TUNIT-NEXT:    ret ptr [[R]]
+;
+; CGSCC: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; CGSCC-LABEL: define ptr @b64613_e
+; CGSCC-SAME: (ptr nofree noundef [[P:%.*]], i32 [[I:%.*]]) #[[ATTR12]] {
+; CGSCC-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; CGSCC-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; CGSCC-NEXT:    store ptr [[P]], ptr [[G]], align 8
+; CGSCC-NEXT:    [[R:%.*]] = load ptr, ptr [[P_ADDR]], align 8
+; CGSCC-NEXT:    ret ptr [[R]]
+;
+  %p.addr = alloca <2 x ptr>, align 8
+  %g = getelementptr i8, ptr %p.addr, i32 %i
+  store ptr %p, ptr %g, align 8
+  %r = load ptr, ptr %p.addr, align 4
+  ret ptr %r
+}
+define ptr @b64613_f(ptr noundef %p, i32 %i) {
+; TUNIT: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; TUNIT-LABEL: define ptr @b64613_f
+; TUNIT-SAME: (ptr nofree noundef readnone returned "no-capture-maybe-returned" [[P:%.*]], i32 [[I:%.*]]) #[[ATTR11]] {
+; TUNIT-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; TUNIT-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; TUNIT-NEXT:    store ptr [[P]], ptr [[G]], align 8
+; TUNIT-NEXT:    ret ptr [[P]]
+;
+; CGSCC: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; CGSCC-LABEL: define ptr @b64613_f
+; CGSCC-SAME: (ptr nofree noundef readnone returned "no-capture-maybe-returned" [[P:%.*]], i32 [[I:%.*]]) #[[ATTR12]] {
+; CGSCC-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; CGSCC-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; CGSCC-NEXT:    store ptr [[P]], ptr [[G]], align 8
+; CGSCC-NEXT:    ret ptr [[P]]
+;
+  %p.addr = alloca <2 x ptr>, align 8
+  %g = getelementptr i8, ptr %p.addr, i32 %i
+  store ptr %p, ptr %g, align 8
+  %r = load ptr, ptr %p.addr, align 16
+  ret ptr %r
+}
+define ptr @b64613_g(ptr noundef %p, i32 %i) {
+; TUNIT: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; TUNIT-LABEL: define ptr @b64613_g
+; TUNIT-SAME: (ptr nofree noundef readnone returned "no-capture-maybe-returned" [[P:%.*]], i32 [[I:%.*]]) #[[ATTR11]] {
+; TUNIT-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; TUNIT-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; TUNIT-NEXT:    store ptr [[P]], ptr [[G]], align 16
+; TUNIT-NEXT:    ret ptr [[P]]
+;
+; CGSCC: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; CGSCC-LABEL: define ptr @b64613_g
+; CGSCC-SAME: (ptr nofree noundef readnone returned "no-capture-maybe-returned" [[P:%.*]], i32 [[I:%.*]]) #[[ATTR12]] {
+; CGSCC-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; CGSCC-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; CGSCC-NEXT:    store ptr [[P]], ptr [[G]], align 16
+; CGSCC-NEXT:    ret ptr [[P]]
+;
+  %p.addr = alloca <2 x ptr>, align 8
+  %g = getelementptr i8, ptr %p.addr, i32 %i
+  store ptr %p, ptr %g, align 16
+  %r = load ptr, ptr %p.addr, align 8
+  ret ptr %r
+}
+define ptr @b64613_h(ptr noundef %p, i32 %i) {
+; TUNIT: Function Attrs: norecurse nounwind memory(none)
+; TUNIT-LABEL: define ptr @b64613_h
+; TUNIT-SAME: (ptr nofree noundef readnone returned "no-capture-maybe-returned" [[P:%.*]], i32 [[I:%.*]]) #[[ATTR12:[0-9]+]] {
+; TUNIT-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; TUNIT-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; TUNIT-NEXT:    store atomic volatile ptr [[P]], ptr [[G]] release, align 8
+; TUNIT-NEXT:    ret ptr [[P]]
+;
+; CGSCC: Function Attrs: norecurse nounwind memory(none)
+; CGSCC-LABEL: define ptr @b64613_h
+; CGSCC-SAME: (ptr nofree noundef readnone returned "no-capture-maybe-returned" [[P:%.*]], i32 [[I:%.*]]) #[[ATTR14:[0-9]+]] {
+; CGSCC-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; CGSCC-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; CGSCC-NEXT:    store atomic volatile ptr [[P]], ptr [[G]] release, align 8
+; CGSCC-NEXT:    ret ptr [[P]]
+;
+  %p.addr = alloca <2 x ptr>, align 8
+  %g = getelementptr i8, ptr %p.addr, i32 %i
+  store atomic volatile ptr %p, ptr %g release, align 8
+  %r = load atomic ptr, ptr %p.addr unordered, align 8
+  ret ptr %r
+}
+define ptr @b64613_l(ptr noundef %p, i32 %i) {
+; TUNIT: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; TUNIT-LABEL: define ptr @b64613_l
+; TUNIT-SAME: (ptr nofree noundef [[P:%.*]], i32 [[I:%.*]]) #[[ATTR11]] {
+; TUNIT-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; TUNIT-NEXT:    [[P_LOCL:%.*]] = alloca ptr, align 8
+; TUNIT-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; TUNIT-NEXT:    store ptr [[P]], ptr [[P_LOCL]], align 8
+; TUNIT-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr nofree writeonly align 8 captures(none) [[G]], ptr noalias nofree noundef nonnull readonly align 8 captures(none) dereferenceable(8) [[P_LOCL]], i64 noundef 8, i1 noundef false) #[[ATTR16:[0-9]+]]
+; TUNIT-NEXT:    [[R:%.*]] = load ptr, ptr [[P_ADDR]], align 8
+; TUNIT-NEXT:    ret ptr [[R]]
+;
+; CGSCC: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
+; CGSCC-LABEL: define ptr @b64613_l
+; CGSCC-SAME: (ptr nofree noundef [[P:%.*]], i32 [[I:%.*]]) #[[ATTR12]] {
+; CGSCC-NEXT:    [[P_ADDR:%.*]] = alloca <2 x ptr>, align 8
+; CGSCC-NEXT:    [[P_LOCL:%.*]] = alloca ptr, align 8
+; CGSCC-NEXT:    [[G:%.*]] = getelementptr i8, ptr [[P_ADDR]], i32 [[I]]
+; CGSCC-NEXT:    store ptr [[P]], ptr [[P_LOCL]], align 8
+; CGSCC-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr nofree writeonly align 8 captures(none) [[G]], ptr noalias nofree noundef nonnull readonly align 8 captures(none) dereferenceable(8) [[P_LOCL]], i64 noundef 8, i1 noundef false) #[[ATTR18:[0-9]+]]
+; CGSCC-NEXT:    [[R:%.*]] = load ptr, ptr [[P_ADDR]], align 8
+; CGSCC-NEXT:    ret ptr [[R]]
+;
+  %p.addr = alloca <2 x ptr>, align 8
+  %p.locl = alloca ptr, align 8
+  %g = getelementptr i8, ptr %p.addr, i32 %i
+  store ptr %p, ptr %p.locl, align 8
+  ; TODO: Underlying object written through a non-store instruction not supported yet
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %g, ptr align 8 %p.locl, i64 8, i1 false)
+  %r = load ptr, ptr %p.addr, align 8
+  ret ptr %r
+}
 
 attributes #0 = { noinline nounwind uwtable }
 ;.
@@ -817,8 +991,11 @@ attributes #0 = { noinline nounwind uwtable }
 ; TUNIT: attributes #[[ATTR9:[0-9]+]] = { nounwind memory(read) }
 ; TUNIT: attributes #[[ATTR10]] = { nosync }
 ; TUNIT: attributes #[[ATTR11]] = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-; TUNIT: attributes #[[ATTR12]] = { nofree nosync nounwind willreturn memory(write) }
-; TUNIT: attributes #[[ATTR13]] = { nosync memory(read) }
+; TUNIT: attributes #[[ATTR12]] = { norecurse nounwind memory(none) }
+; TUNIT: attributes #[[ATTR13:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+; TUNIT: attributes #[[ATTR14]] = { nofree nosync nounwind willreturn memory(write) }
+; TUNIT: attributes #[[ATTR15]] = { nosync memory(read) }
+; TUNIT: attributes #[[ATTR16]] = { nofree willreturn }
 ;.
 ; CGSCC: attributes #[[ATTR0]] = { mustprogress nofree noinline norecurse nosync nounwind willreturn memory(none) uwtable }
 ; CGSCC: attributes #[[ATTR1]] = { mustprogress nofree noinline nosync nounwind willreturn memory(none) uwtable }
@@ -834,6 +1011,9 @@ attributes #0 = { noinline nounwind uwtable }
 ; CGSCC: attributes #[[ATTR11]] = { nosync }
 ; CGSCC: attributes #[[ATTR12]] = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
 ; CGSCC: attributes #[[ATTR13]] = { mustprogress nofree nosync nounwind willreturn memory(none) }
-; CGSCC: attributes #[[ATTR14]] = { nofree nounwind willreturn memory(write) }
-; CGSCC: attributes #[[ATTR15]] = { nosync memory(read) }
+; CGSCC: attributes #[[ATTR14]] = { norecurse nounwind memory(none) }
+; CGSCC: attributes #[[ATTR15:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+; CGSCC: attributes #[[ATTR16]] = { nofree nounwind willreturn memory(write) }
+; CGSCC: attributes #[[ATTR17]] = { nosync memory(read) }
+; CGSCC: attributes #[[ATTR18]] = { nofree willreturn }
 ;.


### PR DESCRIPTION
When we find overlapping accesses, an access is exact when it will hit the same memory. Otherwise we treated it like an unknown access that could overwrite any part of the overlapping value. Using size and alignment we can introduce a new category, COHERENT, which means the access might not be at the exact address but if it is affecting the initial range it will do so with the proper value, e.g., it will not write part of the range but all or nothing.