### PR TITLE
[mlir][python] Set a static version in the standalone example pyproject.toml

### DIFF
--- a/mlir/examples/standalone/pyproject.toml
+++ b/mlir/examples/standalone/pyproject.toml
@@ -5,7 +5,7 @@
 
 [project]
 name = "standalone-python-bindings"
-dynamic = ["version"]
+version = "0.0.1"
 requires-python = ">=3.8"
 dependencies = [
     "numpy>=1.19.5, <=2.1.2",


### PR DESCRIPTION
The standalone example's pyproject.toml declares `dynamic = ["version"]` but does not configure a `tool.scikit-build metadata.version.provider`. Newer versions of scikit-build-core reject this combination with:

```
AssertionError: project.version is not specified, must be statically present or tool.scikit-build metadata.version.provider configured when dynamic
```

Just pin a static placeholder version instead of adding a "provider".

Assisted by: Claude