### PR TITLE
[libc][RISC-V] Temporarily disable dirent

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1151,11 +1151,12 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.compiler.__stack_chk_fail
 
     # dirent.h entrypoints
-    libc.src.dirent.closedir
-    libc.src.dirent.dirfd
-    libc.src.dirent.opendir
-    libc.src.dirent.readdir
-    libc.src.dirent.fdopendir
+    # SYS_fcntl isn't available on RISC-V 32 QEMU.
+    # libc.src.dirent.closedir
+    # libc.src.dirent.dirfd
+    # libc.src.dirent.opendir
+    # libc.src.dirent.readdir
+    # libc.src.dirent.fdopendir
 
     # arpa/inet.h entrypoints
     libc.src.arpa.inet.htonl


### PR DESCRIPTION
The RISC-V 32 QEMU buildbot is failing due to missing SYS_fcntl, which
is needed for fdopendir. Since that syscall is referenced in the shared
dir code it's easiest to just disable all the dirent functions for now.
