### PR TITLE
[lld/ELF] Fix GD TLS DTPMOD64/DTPOFF64 mismatch

### DIFF
--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -1370,10 +1370,11 @@ void elf::postScanRelocations(Ctx &ctx) {
         ctx.in.relaDyn->addSymbolReloc(ctx.target->tlsModuleIndexRel, *got, off,
                                        sym);
 
-      // If the symbol is preemptible we need the dynamic linker to write
-      // the offset too.
+      // If the symbol is preemptible (or weak global across DSOs) we need the
+      // dynamic linker to write the offset too.
       uint64_t offsetOff = off + ctx.arg.wordsize;
-      if (sym.isPreemptible)
+      if (sym.isPreemptible || (sym.binding == STB_WEAK &&
+                                sym.visibility() == STV_DEFAULT))
         ctx.in.relaDyn->addSymbolReloc(ctx.target->tlsOffsetRel, *got,
                                        offsetOff, sym);
       else

--- a/lld/test/ELF/x86-64-tls-gd-weak.s
+++ b/lld/test/ELF/x86-64-tls-gd-weak.s
@@ -1,0 +1,39 @@
+// REQUIRES: x86
+// RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t.o
+// RUN: ld.lld -shared -Bsymbolic %t.o -o %t.so
+// RUN: llvm-readobj -r %t.so | FileCheck %s
+
+        .byte   0x66
+        leaq    foo@tlsgd(%rip), %rdi
+        .value  0x6666
+        rex64
+        call    __tls_get_addr@PLT
+
+        .byte   0x66
+        leaq    bar@tlsgd(%rip), %rdi
+        .value  0x6666
+        rex64
+        call    __tls_get_addr@PLT
+
+        .section        .tbss,"awT",@nobits
+        .weak   foo
+foo:
+        .zero   4
+
+        .hidden bar
+        .weak   bar
+bar:
+        .zero   4
+
+// CHECK:      Relocations [
+// CHECK-NEXT:   Section ({{.*}}) .rela.dyn {
+//
+// Hidden weak TLS variables are non-preemptible. Only emit DTPMOD
+// to resolve the runtime module ID; the offset is a link-time constant.
+// CHECK-NEXT:     R_X86_64_DTPMOD64 - 0x0
+//
+// Global weak TLS variables are preemptible. Emit both DTPMOD and
+// DTPOFF to resolve them together to the prevailing definition at runtime.
+// CHECK-NEXT:     R_X86_64_DTPMOD64 foo 0x0
+// CHECK-NEXT:     R_X86_64_DTPOFF64 foo 0x0
+// CHECK-NEXT:   }


### PR DESCRIPTION
When we reference a weak default TLS global variable in a shared library, previously lld would emit the DTPMOD64 relocation (since we don't know which module we are) but eagerly resolve DTPOFF64 to the current linkage unit's TLS offset for that global variable. However, this breaks if the loader ends up resolving the DTPMOD64 to a different linkage unit's copy since we'd be using the wrong offset into the other TLS block.