### PR TITLE
[ORC] Fix reinterpret_cast warning.

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/InProcessEPCTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/InProcessEPCTest.cpp
@@ -615,7 +615,7 @@ TEST(InProcessEPCTest, JITDispatchUnknownHandler) {
       });
 
   auto SentCallId =
-      IPCA.callJITDispatch(reinterpret_cast<void *>(0xdeadbeef),
+      IPCA.callJITDispatch(ExecutorAddr(0xdeadbeef).toPtr<void *>(),
                            shared::WrapperFunctionBuffer::copyFrom("x", 1));
   ASSERT_TRUE(SentCallId);
 
@@ -640,7 +640,7 @@ TEST(InProcessEPCTest, JITDispatchAfterDisconnectIsDropped) {
   cantFail(Fix.EPCPtr->disconnect());
 
   auto SentCallId =
-      IPCA.callJITDispatch(reinterpret_cast<void *>(0xdeadbeef),
+      IPCA.callJITDispatch(ExecutorAddr(0xdeadbeef).toPtr<void *>(),
                            shared::WrapperFunctionBuffer::copyFrom("x", 1));
 
   EXPECT_FALSE(SentCallId)


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/206725#issuecomment-4896222897 reported warnings on windows builds due to reinterpret_cast:

warning C4312: 'reinterpret_cast': conversion from 'unsigned int' to 'void *' of greater size

This commit fixes the issue by using ExecutorAddr::toPtr for conversion instead of reinterpret_cast.