### PR TITLE
[clang][test][darwin] Driver/clang-offload-bundler-zstd.c fails on macOS

### DIFF
--- a/clang/test/OffloadTools/clang-offload-bundler/zstd.c
+++ b/clang/test/OffloadTools/clang-offload-bundler/zstd.c
@@ -1,5 +1,5 @@
 // REQUIRES: zstd
-// UNSUPPORTED: target={{.*}}-darwin{{.*}}, target={{.*}}-aix{{.*}}, target={{.*}}-zos{{.*}}
+// UNSUPPORTED: target={{.*}}-macosx{{.*}}, target={{.*}}-darwin{{.*}}, target={{.*}}-aix{{.*}}, target={{.*}}-zos{{.*}}
 
 //
 // Generate the host binary to be bundled.


### PR DESCRIPTION
Driver/clang-offload-bundler-zstd.c isn't supported on Darwin, but neglected to list the macosx target.