### PR TITLE
[CIR][test] Use global instcombine RUN line in AArch64 neon subtracti…

### DIFF
--- a/clang/test/CodeGen/AArch64/neon/subtraction.c
+++ b/clang/test/CodeGen/AArch64/neon/subtraction.c
@@ -1,11 +1,8 @@
 // REQUIRES: aarch64-registered-target || arm-registered-target
 
-// RUN:                   %clang_cc1_cg_arm64_neon           -emit-llvm %s -disable-O0-optnone | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM
-// RUN: %if cir-enabled %{%clang_cc1_cg_arm64_neon -fclangir -emit-llvm %s -disable-O0-optnone | opt -S -passes=mem2reg,sroa | FileCheck %s --check-prefixes=LLVM %}
+// RUN:                   %clang_cc1_cg_arm64_neon           -emit-llvm %s -disable-O0-optnone | opt -S -passes=mem2reg,sroa,instcombine | FileCheck %s --check-prefixes=LLVM
+// RUN: %if cir-enabled %{%clang_cc1_cg_arm64_neon -fclangir -emit-llvm %s -disable-O0-optnone | opt -S -passes=mem2reg,sroa,instcombine | FileCheck %s --check-prefixes=LLVM %}
 // RUN: %if cir-enabled %{%clang_cc1_cg_arm64_neon -fclangir -emit-cir  %s -disable-O0-optnone |                               FileCheck %s --check-prefixes=CIR %}
-// Narrowing-subtraction checks use instcombine to fold no-op bitcasts (LLVM-IC prefix).
-// RUN:                   %clang_cc1_cg_arm64_neon           -emit-llvm %s -disable-O0-optnone | opt -S -passes=mem2reg,sroa,instcombine | FileCheck %s --check-prefixes=LLVM-IC
-// RUN: %if cir-enabled %{%clang_cc1_cg_arm64_neon -fclangir -emit-llvm %s -disable-O0-optnone | opt -S -passes=mem2reg,sroa,instcombine | FileCheck %s --check-prefixes=LLVM-IC %}
 
 //=============================================================================
 // NOTES
@@ -283,7 +280,7 @@ int16x8_t test_vsubl_s8(int8x8_t a, int8x8_t b) {
 // LLVM-SAME: <8 x i8> {{.*}} [[A:%.*]], <8 x i8> {{.*}} [[B:%.*]])
 // LLVM: [[VMOVL0:%.*]] = sext <8 x i8> [[A]] to <8 x i16>
 // LLVM: [[VMOVL1:%.*]] = sext <8 x i8> [[B]] to <8 x i16>
-// LLVM: [[SUB_I:%.*]] = sub <8 x i16> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[SUB_I:%.*]] = sub nsw <8 x i16> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <8 x i16> [[SUB_I]]
   return vsubl_s8(a, b);
 }
@@ -296,13 +293,9 @@ int32x4_t test_vsubl_s16(int16x4_t a, int16x4_t b) {
 // CIR: {{%.*}} = cir.sub [[VMOVL0]], [[VMOVL1]] : !cir.vector<4 x !s32i>
 
 // LLVM-SAME: <4 x i16> {{.*}} [[A:%.*]], <4 x i16> {{.*}} [[B:%.*]])
-// LLVM: [[TMP0:%.*]] = bitcast <4 x i16> [[A]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
-// LLVM: [[VMOVL0:%.*]] = sext <4 x i16> [[TMP1]] to <4 x i32>
-// LLVM: [[TMP2:%.*]] = bitcast <4 x i16> [[B]] to <8 x i8>
-// LLVM: [[TMP3:%.*]] = bitcast <8 x i8> [[TMP2]] to <4 x i16>
-// LLVM: [[VMOVL1:%.*]] = sext <4 x i16> [[TMP3]] to <4 x i32>
-// LLVM: [[SUB_I:%.*]] = sub <4 x i32> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[VMOVL0:%.*]] = sext <4 x i16> [[A]] to <4 x i32>
+// LLVM: [[VMOVL1:%.*]] = sext <4 x i16> [[B]] to <4 x i32>
+// LLVM: [[SUB_I:%.*]] = sub nsw <4 x i32> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <4 x i32> [[SUB_I]]
   return vsubl_s16(a, b);
 }
@@ -315,13 +308,9 @@ int64x2_t test_vsubl_s32(int32x2_t a, int32x2_t b) {
 // CIR: {{%.*}} = cir.sub [[VMOVL0]], [[VMOVL1]] : !cir.vector<2 x !s64i>
 
 // LLVM-SAME: <2 x i32> {{.*}} [[A:%.*]], <2 x i32> {{.*}} [[B:%.*]])
-// LLVM: [[TMP0:%.*]] = bitcast <2 x i32> [[A]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <2 x i32>
-// LLVM: [[VMOVL0:%.*]] = sext <2 x i32> [[TMP1]] to <2 x i64>
-// LLVM: [[TMP2:%.*]] = bitcast <2 x i32> [[B]] to <8 x i8>
-// LLVM: [[TMP3:%.*]] = bitcast <8 x i8> [[TMP2]] to <2 x i32>
-// LLVM: [[VMOVL1:%.*]] = sext <2 x i32> [[TMP3]] to <2 x i64>
-// LLVM: [[SUB_I:%.*]] = sub <2 x i64> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[VMOVL0:%.*]] = sext <2 x i32> [[A]] to <2 x i64>
+// LLVM: [[VMOVL1:%.*]] = sext <2 x i32> [[B]] to <2 x i64>
+// LLVM: [[SUB_I:%.*]] = sub nsw <2 x i64> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <2 x i64> [[SUB_I]]
   return vsubl_s32(a, b);
 }
@@ -336,7 +325,7 @@ uint16x8_t test_vsubl_u8(uint8x8_t a, uint8x8_t b) {
 // LLVM-SAME: <8 x i8> {{.*}} [[A:%.*]], <8 x i8> {{.*}} [[B:%.*]])
 // LLVM: [[VMOVL0:%.*]] = zext <8 x i8> [[A]] to <8 x i16>
 // LLVM: [[VMOVL1:%.*]] = zext <8 x i8> [[B]] to <8 x i16>
-// LLVM: [[SUB_I:%.*]] = sub <8 x i16> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[SUB_I:%.*]] = sub nsw <8 x i16> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <8 x i16> [[SUB_I]]
   return vsubl_u8(a, b);
 }
@@ -349,13 +338,9 @@ uint32x4_t test_vsubl_u16(uint16x4_t a, uint16x4_t b) {
 // CIR: {{%.*}} = cir.sub [[VMOVL0]], [[VMOVL1]] : !cir.vector<4 x !u32i>
 
 // LLVM-SAME: <4 x i16> {{.*}} [[A:%.*]], <4 x i16> {{.*}} [[B:%.*]])
-// LLVM: [[TMP0:%.*]] = bitcast <4 x i16> [[A]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
-// LLVM: [[VMOVL0:%.*]] = zext <4 x i16> [[TMP1]] to <4 x i32>
-// LLVM: [[TMP2:%.*]] = bitcast <4 x i16> [[B]] to <8 x i8>
-// LLVM: [[TMP3:%.*]] = bitcast <8 x i8> [[TMP2]] to <4 x i16>
-// LLVM: [[VMOVL1:%.*]] = zext <4 x i16> [[TMP3]] to <4 x i32>
-// LLVM: [[SUB_I:%.*]] = sub <4 x i32> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[VMOVL0:%.*]] = zext <4 x i16> [[A]] to <4 x i32>
+// LLVM: [[VMOVL1:%.*]] = zext <4 x i16> [[B]] to <4 x i32>
+// LLVM: [[SUB_I:%.*]] = sub nsw <4 x i32> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <4 x i32> [[SUB_I]]
   return vsubl_u16(a, b);
 }
@@ -368,13 +353,9 @@ uint64x2_t test_vsubl_u32(uint32x2_t a, uint32x2_t b) {
 // CIR: {{%.*}} = cir.sub [[VMOVL0]], [[VMOVL1]] : !cir.vector<2 x !u64i>
 
 // LLVM-SAME: <2 x i32> {{.*}} [[A:%.*]], <2 x i32> {{.*}} [[B:%.*]])
-// LLVM: [[TMP0:%.*]] = bitcast <2 x i32> [[A]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <2 x i32>
-// LLVM: [[VMOVL0:%.*]] = zext <2 x i32> [[TMP1]] to <2 x i64>
-// LLVM: [[TMP2:%.*]] = bitcast <2 x i32> [[B]] to <8 x i8>
-// LLVM: [[TMP3:%.*]] = bitcast <8 x i8> [[TMP2]] to <2 x i32>
-// LLVM: [[VMOVL1:%.*]] = zext <2 x i32> [[TMP3]] to <2 x i64>
-// LLVM: [[SUB_I:%.*]] = sub <2 x i64> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[VMOVL0:%.*]] = zext <2 x i32> [[A]] to <2 x i64>
+// LLVM: [[VMOVL1:%.*]] = zext <2 x i32> [[B]] to <2 x i64>
+// LLVM: [[SUB_I:%.*]] = sub nsw <2 x i64> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <2 x i64> [[SUB_I]]
   return vsubl_u32(a, b);
 }
@@ -399,9 +380,7 @@ int32x4_t test_vsubw_s16(int32x4_t a, int16x4_t b) {
 // CIR: {{%.*}} = cir.sub {{%.*}}, [[VMOVL_I]] : !cir.vector<4 x !s32i>
 
 // LLVM-SAME: <4 x i32> {{.*}} [[A:%.*]], <4 x i16> {{.*}} [[B:%.*]])
-// LLVM: [[TMP0:%.*]] = bitcast <4 x i16> [[B]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
-// LLVM: [[VMOVL_I:%.*]] = sext <4 x i16> [[TMP1]] to <4 x i32>
+// LLVM: [[VMOVL_I:%.*]] = sext <4 x i16> [[B]] to <4 x i32>
 // LLVM: [[SUB_I:%.*]] = sub <4 x i32> [[A]], [[VMOVL_I]]
 // LLVM: ret <4 x i32> [[SUB_I]]
   return vsubw_s16(a, b);
@@ -414,9 +393,7 @@ int64x2_t test_vsubw_s32(int64x2_t a, int32x2_t b) {
 // CIR: {{%.*}} = cir.sub {{%.*}}, [[VMOVL_I]] : !cir.vector<2 x !s64i>
 
 // LLVM-SAME: <2 x i64> {{.*}} [[A:%.*]], <2 x i32> {{.*}} [[B:%.*]])
-// LLVM: [[TMP0:%.*]] = bitcast <2 x i32> [[B]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <2 x i32>
-// LLVM: [[VMOVL_I:%.*]] = sext <2 x i32> [[TMP1]] to <2 x i64>
+// LLVM: [[VMOVL_I:%.*]] = sext <2 x i32> [[B]] to <2 x i64>
 // LLVM: [[SUB_I:%.*]] = sub <2 x i64> [[A]], [[VMOVL_I]]
 // LLVM: ret <2 x i64> [[SUB_I]]
   return vsubw_s32(a, b);
@@ -442,9 +419,7 @@ uint32x4_t test_vsubw_u16(uint32x4_t a, uint16x4_t b) {
 // CIR: {{%.*}} = cir.sub {{%.*}}, [[VMOVL_I]] : !cir.vector<4 x !u32i>
 
 // LLVM-SAME: <4 x i32> {{.*}} [[A:%.*]], <4 x i16> {{.*}} [[B:%.*]])
-// LLVM: [[TMP0:%.*]] = bitcast <4 x i16> [[B]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
-// LLVM: [[VMOVL_I:%.*]] = zext <4 x i16> [[TMP1]] to <4 x i32>
+// LLVM: [[VMOVL_I:%.*]] = zext <4 x i16> [[B]] to <4 x i32>
 // LLVM: [[SUB_I:%.*]] = sub <4 x i32> [[A]], [[VMOVL_I]]
 // LLVM: ret <4 x i32> [[SUB_I]]
   return vsubw_u16(a, b);
@@ -457,9 +432,7 @@ uint64x2_t test_vsubw_u32(uint64x2_t a, uint32x2_t b) {
 // CIR: {{%.*}} = cir.sub {{%.*}}, [[VMOVL_I]] : !cir.vector<2 x !u64i>
 
 // LLVM-SAME: <2 x i64> {{.*}} [[A:%.*]], <2 x i32> {{.*}} [[B:%.*]])
-// LLVM: [[TMP0:%.*]] = bitcast <2 x i32> [[B]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <2 x i32>
-// LLVM: [[VMOVL_I:%.*]] = zext <2 x i32> [[TMP1]] to <2 x i64>
+// LLVM: [[VMOVL_I:%.*]] = zext <2 x i32> [[B]] to <2 x i64>
 // LLVM: [[SUB_I:%.*]] = sub <2 x i64> [[A]], [[VMOVL_I]]
 // LLVM: ret <2 x i64> [[SUB_I]]
   return vsubw_u32(a, b);
@@ -473,11 +446,11 @@ int16x8_t test_vsubl_high_s8(int8x16_t a, int8x16_t b) {
 // CIR: {{%.*}} = cir.sub [[VMOVL0]], [[VMOVL1]] : !cir.vector<8 x !s16i>
 
 // LLVM-SAME: <16 x i8> {{.*}} [[A:%.*]], <16 x i8> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE0:%.*]] = shufflevector <16 x i8> [[A]], <16 x i8> [[A]], <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// LLVM: [[SHUFFLE0:%.*]] = shufflevector <16 x i8> [[A]], <16 x i8> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 // LLVM: [[VMOVL0:%.*]] = sext <8 x i8> [[SHUFFLE0]] to <8 x i16>
-// LLVM: [[SHUFFLE1:%.*]] = shufflevector <16 x i8> [[B]], <16 x i8> [[B]], <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// LLVM: [[SHUFFLE1:%.*]] = shufflevector <16 x i8> [[B]], <16 x i8> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 // LLVM: [[VMOVL1:%.*]] = sext <8 x i8> [[SHUFFLE1]] to <8 x i16>
-// LLVM: [[SUB_I:%.*]] = sub <8 x i16> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[SUB_I:%.*]] = sub nsw <8 x i16> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <8 x i16> [[SUB_I]]
   return vsubl_high_s8(a, b);
 }
@@ -490,15 +463,11 @@ int32x4_t test_vsubl_high_s16(int16x8_t a, int16x8_t b) {
 // CIR: {{%.*}} = cir.sub [[VMOVL0]], [[VMOVL1]] : !cir.vector<4 x !s32i>
 
 // LLVM-SAME: <8 x i16> {{.*}} [[A:%.*]], <8 x i16> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE0:%.*]] = shufflevector <8 x i16> [[A]], <8 x i16> [[A]], <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-// LLVM: [[TMP0:%.*]] = bitcast <4 x i16> [[SHUFFLE0]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
-// LLVM: [[VMOVL0:%.*]] = sext <4 x i16> [[TMP1]] to <4 x i32>
-// LLVM: [[SHUFFLE1:%.*]] = shufflevector <8 x i16> [[B]], <8 x i16> [[B]], <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-// LLVM: [[TMP2:%.*]] = bitcast <4 x i16> [[SHUFFLE1]] to <8 x i8>
-// LLVM: [[TMP3:%.*]] = bitcast <8 x i8> [[TMP2]] to <4 x i16>
-// LLVM: [[VMOVL1:%.*]] = sext <4 x i16> [[TMP3]] to <4 x i32>
-// LLVM: [[SUB_I:%.*]] = sub <4 x i32> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[SHUFFLE0:%.*]] = shufflevector <8 x i16> [[A]], <8 x i16> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+// LLVM: [[VMOVL0:%.*]] = sext <4 x i16> [[SHUFFLE0]] to <4 x i32>
+// LLVM: [[SHUFFLE1:%.*]] = shufflevector <8 x i16> [[B]], <8 x i16> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+// LLVM: [[VMOVL1:%.*]] = sext <4 x i16> [[SHUFFLE1]] to <4 x i32>
+// LLVM: [[SUB_I:%.*]] = sub nsw <4 x i32> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <4 x i32> [[SUB_I]]
   return vsubl_high_s16(a, b);
 }
@@ -511,15 +480,11 @@ int64x2_t test_vsubl_high_s32(int32x4_t a, int32x4_t b) {
 // CIR: {{%.*}} = cir.sub [[VMOVL0]], [[VMOVL1]] : !cir.vector<2 x !s64i>
 
 // LLVM-SAME: <4 x i32> {{.*}} [[A:%.*]], <4 x i32> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE0:%.*]] = shufflevector <4 x i32> [[A]], <4 x i32> [[A]], <2 x i32> <i32 2, i32 3>
-// LLVM: [[TMP0:%.*]] = bitcast <2 x i32> [[SHUFFLE0]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <2 x i32>
-// LLVM: [[VMOVL0:%.*]] = sext <2 x i32> [[TMP1]] to <2 x i64>
-// LLVM: [[SHUFFLE1:%.*]] = shufflevector <4 x i32> [[B]], <4 x i32> [[B]], <2 x i32> <i32 2, i32 3>
-// LLVM: [[TMP2:%.*]] = bitcast <2 x i32> [[SHUFFLE1]] to <8 x i8>
-// LLVM: [[TMP3:%.*]] = bitcast <8 x i8> [[TMP2]] to <2 x i32>
-// LLVM: [[VMOVL1:%.*]] = sext <2 x i32> [[TMP3]] to <2 x i64>
-// LLVM: [[SUB_I:%.*]] = sub <2 x i64> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[SHUFFLE0:%.*]] = shufflevector <4 x i32> [[A]], <4 x i32> poison, <2 x i32> <i32 2, i32 3>
+// LLVM: [[VMOVL0:%.*]] = sext <2 x i32> [[SHUFFLE0]] to <2 x i64>
+// LLVM: [[SHUFFLE1:%.*]] = shufflevector <4 x i32> [[B]], <4 x i32> poison, <2 x i32> <i32 2, i32 3>
+// LLVM: [[VMOVL1:%.*]] = sext <2 x i32> [[SHUFFLE1]] to <2 x i64>
+// LLVM: [[SUB_I:%.*]] = sub nsw <2 x i64> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <2 x i64> [[SUB_I]]
   return vsubl_high_s32(a, b);
 }
@@ -532,11 +497,11 @@ uint16x8_t test_vsubl_high_u8(uint8x16_t a, uint8x16_t b) {
 // CIR: {{%.*}} = cir.sub [[VMOVL0]], [[VMOVL1]] : !cir.vector<8 x !u16i>
 
 // LLVM-SAME: <16 x i8> {{.*}} [[A:%.*]], <16 x i8> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE0:%.*]] = shufflevector <16 x i8> [[A]], <16 x i8> [[A]], <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// LLVM: [[SHUFFLE0:%.*]] = shufflevector <16 x i8> [[A]], <16 x i8> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 // LLVM: [[VMOVL0:%.*]] = zext <8 x i8> [[SHUFFLE0]] to <8 x i16>
-// LLVM: [[SHUFFLE1:%.*]] = shufflevector <16 x i8> [[B]], <16 x i8> [[B]], <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// LLVM: [[SHUFFLE1:%.*]] = shufflevector <16 x i8> [[B]], <16 x i8> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 // LLVM: [[VMOVL1:%.*]] = zext <8 x i8> [[SHUFFLE1]] to <8 x i16>
-// LLVM: [[SUB_I:%.*]] = sub <8 x i16> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[SUB_I:%.*]] = sub nsw <8 x i16> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <8 x i16> [[SUB_I]]
   return vsubl_high_u8(a, b);
 }
@@ -549,15 +514,11 @@ uint32x4_t test_vsubl_high_u16(uint16x8_t a, uint16x8_t b) {
 // CIR: {{%.*}} = cir.sub [[VMOVL0]], [[VMOVL1]] : !cir.vector<4 x !u32i>
 
 // LLVM-SAME: <8 x i16> {{.*}} [[A:%.*]], <8 x i16> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE0:%.*]] = shufflevector <8 x i16> [[A]], <8 x i16> [[A]], <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-// LLVM: [[TMP0:%.*]] = bitcast <4 x i16> [[SHUFFLE0]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
-// LLVM: [[VMOVL0:%.*]] = zext <4 x i16> [[TMP1]] to <4 x i32>
-// LLVM: [[SHUFFLE1:%.*]] = shufflevector <8 x i16> [[B]], <8 x i16> [[B]], <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-// LLVM: [[TMP2:%.*]] = bitcast <4 x i16> [[SHUFFLE1]] to <8 x i8>
-// LLVM: [[TMP3:%.*]] = bitcast <8 x i8> [[TMP2]] to <4 x i16>
-// LLVM: [[VMOVL1:%.*]] = zext <4 x i16> [[TMP3]] to <4 x i32>
-// LLVM: [[SUB_I:%.*]] = sub <4 x i32> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[SHUFFLE0:%.*]] = shufflevector <8 x i16> [[A]], <8 x i16> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+// LLVM: [[VMOVL0:%.*]] = zext <4 x i16> [[SHUFFLE0]] to <4 x i32>
+// LLVM: [[SHUFFLE1:%.*]] = shufflevector <8 x i16> [[B]], <8 x i16> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+// LLVM: [[VMOVL1:%.*]] = zext <4 x i16> [[SHUFFLE1]] to <4 x i32>
+// LLVM: [[SUB_I:%.*]] = sub nsw <4 x i32> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <4 x i32> [[SUB_I]]
   return vsubl_high_u16(a, b);
 }
@@ -570,15 +531,11 @@ uint64x2_t test_vsubl_high_u32(uint32x4_t a, uint32x4_t b) {
 // CIR: {{%.*}} = cir.sub [[VMOVL0]], [[VMOVL1]] : !cir.vector<2 x !u64i>
 
 // LLVM-SAME: <4 x i32> {{.*}} [[A:%.*]], <4 x i32> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE0:%.*]] = shufflevector <4 x i32> [[A]], <4 x i32> [[A]], <2 x i32> <i32 2, i32 3>
-// LLVM: [[TMP0:%.*]] = bitcast <2 x i32> [[SHUFFLE0]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <2 x i32>
-// LLVM: [[VMOVL0:%.*]] = zext <2 x i32> [[TMP1]] to <2 x i64>
-// LLVM: [[SHUFFLE1:%.*]] = shufflevector <4 x i32> [[B]], <4 x i32> [[B]], <2 x i32> <i32 2, i32 3>
-// LLVM: [[TMP2:%.*]] = bitcast <2 x i32> [[SHUFFLE1]] to <8 x i8>
-// LLVM: [[TMP3:%.*]] = bitcast <8 x i8> [[TMP2]] to <2 x i32>
-// LLVM: [[VMOVL1:%.*]] = zext <2 x i32> [[TMP3]] to <2 x i64>
-// LLVM: [[SUB_I:%.*]] = sub <2 x i64> [[VMOVL0]], [[VMOVL1]]
+// LLVM: [[SHUFFLE0:%.*]] = shufflevector <4 x i32> [[A]], <4 x i32> poison, <2 x i32> <i32 2, i32 3>
+// LLVM: [[VMOVL0:%.*]] = zext <2 x i32> [[SHUFFLE0]] to <2 x i64>
+// LLVM: [[SHUFFLE1:%.*]] = shufflevector <4 x i32> [[B]], <4 x i32> poison, <2 x i32> <i32 2, i32 3>
+// LLVM: [[VMOVL1:%.*]] = zext <2 x i32> [[SHUFFLE1]] to <2 x i64>
+// LLVM: [[SUB_I:%.*]] = sub nsw <2 x i64> [[VMOVL0]], [[VMOVL1]]
 // LLVM: ret <2 x i64> [[SUB_I]]
   return vsubl_high_u32(a, b);
 }
@@ -590,7 +547,7 @@ int16x8_t test_vsubw_high_s8(int16x8_t a, int8x16_t b) {
 // CIR: {{%.*}} = cir.sub {{%.*}}, [[VMOVL_I]] : !cir.vector<8 x !s16i>
 
 // LLVM-SAME: <8 x i16> {{.*}} [[A:%.*]], <16 x i8> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <16 x i8> [[B]], <16 x i8> [[B]], <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <16 x i8> [[B]], <16 x i8> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 // LLVM: [[VMOVL_I:%.*]] = sext <8 x i8> [[SHUFFLE_I]] to <8 x i16>
 // LLVM: [[SUB_I:%.*]] = sub <8 x i16> [[A]], [[VMOVL_I]]
 // LLVM: ret <8 x i16> [[SUB_I]]
@@ -604,10 +561,8 @@ int32x4_t test_vsubw_high_s16(int32x4_t a, int16x8_t b) {
 // CIR: {{%.*}} = cir.sub {{%.*}}, [[VMOVL_I]] : !cir.vector<4 x !s32i>
 
 // LLVM-SAME: <4 x i32> {{.*}} [[A:%.*]], <8 x i16> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <8 x i16> [[B]], <8 x i16> [[B]], <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-// LLVM: [[TMP0:%.*]] = bitcast <4 x i16> [[SHUFFLE_I]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
-// LLVM: [[VMOVL_I:%.*]] = sext <4 x i16> [[TMP1]] to <4 x i32>
+// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <8 x i16> [[B]], <8 x i16> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+// LLVM: [[VMOVL_I:%.*]] = sext <4 x i16> [[SHUFFLE_I]] to <4 x i32>
 // LLVM: [[SUB_I:%.*]] = sub <4 x i32> [[A]], [[VMOVL_I]]
 // LLVM: ret <4 x i32> [[SUB_I]]
   return vsubw_high_s16(a, b);
@@ -620,10 +575,8 @@ int64x2_t test_vsubw_high_s32(int64x2_t a, int32x4_t b) {
 // CIR: {{%.*}} = cir.sub {{%.*}}, [[VMOVL_I]] : !cir.vector<2 x !s64i>
 
 // LLVM-SAME: <2 x i64> {{.*}} [[A:%.*]], <4 x i32> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <4 x i32> [[B]], <4 x i32> [[B]], <2 x i32> <i32 2, i32 3>
-// LLVM: [[TMP0:%.*]] = bitcast <2 x i32> [[SHUFFLE_I]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <2 x i32>
-// LLVM: [[VMOVL_I:%.*]] = sext <2 x i32> [[TMP1]] to <2 x i64>
+// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <4 x i32> [[B]], <4 x i32> poison, <2 x i32> <i32 2, i32 3>
+// LLVM: [[VMOVL_I:%.*]] = sext <2 x i32> [[SHUFFLE_I]] to <2 x i64>
 // LLVM: [[SUB_I:%.*]] = sub <2 x i64> [[A]], [[VMOVL_I]]
 // LLVM: ret <2 x i64> [[SUB_I]]
   return vsubw_high_s32(a, b);
@@ -636,7 +589,7 @@ uint16x8_t test_vsubw_high_u8(uint16x8_t a, uint8x16_t b) {
 // CIR: {{%.*}} = cir.sub {{%.*}}, [[VMOVL_I]] : !cir.vector<8 x !u16i>
 
 // LLVM-SAME: <8 x i16> {{.*}} [[A:%.*]], <16 x i8> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <16 x i8> [[B]], <16 x i8> [[B]], <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <16 x i8> [[B]], <16 x i8> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
 // LLVM: [[VMOVL_I:%.*]] = zext <8 x i8> [[SHUFFLE_I]] to <8 x i16>
 // LLVM: [[SUB_I:%.*]] = sub <8 x i16> [[A]], [[VMOVL_I]]
 // LLVM: ret <8 x i16> [[SUB_I]]
@@ -650,10 +603,8 @@ uint32x4_t test_vsubw_high_u16(uint32x4_t a, uint16x8_t b) {
 // CIR: {{%.*}} = cir.sub {{%.*}}, [[VMOVL_I]] : !cir.vector<4 x !u32i>
 
 // LLVM-SAME: <4 x i32> {{.*}} [[A:%.*]], <8 x i16> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <8 x i16> [[B]], <8 x i16> [[B]], <4 x i32> <i32 4, i32 5, i32 6, i32 7>
-// LLVM: [[TMP0:%.*]] = bitcast <4 x i16> [[SHUFFLE_I]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <4 x i16>
-// LLVM: [[VMOVL_I:%.*]] = zext <4 x i16> [[TMP1]] to <4 x i32>
+// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <8 x i16> [[B]], <8 x i16> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+// LLVM: [[VMOVL_I:%.*]] = zext <4 x i16> [[SHUFFLE_I]] to <4 x i32>
 // LLVM: [[SUB_I:%.*]] = sub <4 x i32> [[A]], [[VMOVL_I]]
 // LLVM: ret <4 x i32> [[SUB_I]]
   return vsubw_high_u16(a, b);
@@ -666,10 +617,8 @@ uint64x2_t test_vsubw_high_u32(uint64x2_t a, uint32x4_t b) {
 // CIR: {{%.*}} = cir.sub {{%.*}}, [[VMOVL_I]] : !cir.vector<2 x !u64i>
 
 // LLVM-SAME: <2 x i64> {{.*}} [[A:%.*]], <4 x i32> {{.*}} [[B:%.*]])
-// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <4 x i32> [[B]], <4 x i32> [[B]], <2 x i32> <i32 2, i32 3>
-// LLVM: [[TMP0:%.*]] = bitcast <2 x i32> [[SHUFFLE_I]] to <8 x i8>
-// LLVM: [[TMP1:%.*]] = bitcast <8 x i8> [[TMP0]] to <2 x i32>
-// LLVM: [[VMOVL_I:%.*]] = zext <2 x i32> [[TMP1]] to <2 x i64>
+// LLVM: [[SHUFFLE_I:%.*]] = shufflevector <4 x i32> [[B]], <4 x i32> poison, <2 x i32> <i32 2, i32 3>
+// LLVM: [[VMOVL_I:%.*]] = zext <2 x i32> [[SHUFFLE_I]] to <2 x i64>
 // LLVM: [[SUB_I:%.*]] = sub <2 x i64> [[A]], [[VMOVL_I]]
 // LLVM: ret <2 x i64> [[SUB_I]]
   return vsubw_high_u32(a, b);
@@ -680,458 +629,458 @@ uint64x2_t test_vsubw_high_u32(uint64x2_t a, uint32x4_t b) {
 // https://arm-software.github.io/acle/neon_intrinsics/advsimd.html#narrowing-subtraction
 //===----------------------------------------------------------------------===//
 
-// LLVM-IC-LABEL: @test_vhsub_s8(
+// LLVM-LABEL: @test_vhsub_s8(
 // CIR-LABEL: @vhsub_s8(
 int8x8_t test_vhsub_s8(int8x8_t v1, int8x8_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.shsub"
 
-  // LLVM-IC-SAME: <8 x i8> {{.*}}[[V1:%.*]], <8 x i8> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <8 x i8> @llvm.aarch64.neon.shsub.v8i8(<8 x i8> [[V1]], <8 x i8> [[V2]])
-  // LLVM-IC: ret <8 x i8> [[RES]]
+  // LLVM-SAME: <8 x i8> {{.*}}[[V1:%.*]], <8 x i8> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <8 x i8> @llvm.aarch64.neon.shsub.v8i8(<8 x i8> [[V1]], <8 x i8> [[V2]])
+  // LLVM: ret <8 x i8> [[RES]]
   return vhsub_s8(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vhsub_s16(
+// LLVM-LABEL: @test_vhsub_s16(
 // CIR-LABEL: @vhsub_s16(
 int16x4_t test_vhsub_s16(int16x4_t v1, int16x4_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.shsub"
 
-  // LLVM-IC-SAME: <4 x i16> {{.*}}[[V1:%.*]], <4 x i16> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <4 x i16> @llvm.aarch64.neon.shsub.v4i16(<4 x i16> [[V1]], <4 x i16> [[V2]])
-  // LLVM-IC: ret <4 x i16> [[RES]]
+  // LLVM-SAME: <4 x i16> {{.*}}[[V1:%.*]], <4 x i16> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <4 x i16> @llvm.aarch64.neon.shsub.v4i16(<4 x i16> [[V1]], <4 x i16> [[V2]])
+  // LLVM: ret <4 x i16> [[RES]]
   return vhsub_s16(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vhsub_s32(
+// LLVM-LABEL: @test_vhsub_s32(
 // CIR-LABEL: @vhsub_s32(
 int32x2_t test_vhsub_s32(int32x2_t v1, int32x2_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.shsub"
 
-  // LLVM-IC-SAME: <2 x i32> {{.*}}[[V1:%.*]], <2 x i32> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <2 x i32> @llvm.aarch64.neon.shsub.v2i32(<2 x i32> [[V1]], <2 x i32> [[V2]])
-  // LLVM-IC: ret <2 x i32> [[RES]]
+  // LLVM-SAME: <2 x i32> {{.*}}[[V1:%.*]], <2 x i32> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <2 x i32> @llvm.aarch64.neon.shsub.v2i32(<2 x i32> [[V1]], <2 x i32> [[V2]])
+  // LLVM: ret <2 x i32> [[RES]]
   return vhsub_s32(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vhsub_u8(
+// LLVM-LABEL: @test_vhsub_u8(
 // CIR-LABEL: @vhsub_u8(
 uint8x8_t test_vhsub_u8(uint8x8_t v1, uint8x8_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.uhsub"
 
-  // LLVM-IC-SAME: <8 x i8> {{.*}}[[V1:%.*]], <8 x i8> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <8 x i8> @llvm.aarch64.neon.uhsub.v8i8(<8 x i8> [[V1]], <8 x i8> [[V2]])
-  // LLVM-IC: ret <8 x i8> [[RES]]
+  // LLVM-SAME: <8 x i8> {{.*}}[[V1:%.*]], <8 x i8> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <8 x i8> @llvm.aarch64.neon.uhsub.v8i8(<8 x i8> [[V1]], <8 x i8> [[V2]])
+  // LLVM: ret <8 x i8> [[RES]]
   return vhsub_u8(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vhsub_u16(
+// LLVM-LABEL: @test_vhsub_u16(
 // CIR-LABEL: @vhsub_u16(
 uint16x4_t test_vhsub_u16(uint16x4_t v1, uint16x4_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.uhsub"
 
-  // LLVM-IC-SAME: <4 x i16> {{.*}}[[V1:%.*]], <4 x i16> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <4 x i16> @llvm.aarch64.neon.uhsub.v4i16(<4 x i16> [[V1]], <4 x i16> [[V2]])
-  // LLVM-IC: ret <4 x i16> [[RES]]
+  // LLVM-SAME: <4 x i16> {{.*}}[[V1:%.*]], <4 x i16> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <4 x i16> @llvm.aarch64.neon.uhsub.v4i16(<4 x i16> [[V1]], <4 x i16> [[V2]])
+  // LLVM: ret <4 x i16> [[RES]]
   return vhsub_u16(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vhsub_u32(
+// LLVM-LABEL: @test_vhsub_u32(
 // CIR-LABEL: @vhsub_u32(
 uint32x2_t test_vhsub_u32(uint32x2_t v1, uint32x2_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.uhsub"
 
-  // LLVM-IC-SAME: <2 x i32> {{.*}}[[V1:%.*]], <2 x i32> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <2 x i32> @llvm.aarch64.neon.uhsub.v2i32(<2 x i32> [[V1]], <2 x i32> [[V2]])
-  // LLVM-IC: ret <2 x i32> [[RES]]
+  // LLVM-SAME: <2 x i32> {{.*}}[[V1:%.*]], <2 x i32> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <2 x i32> @llvm.aarch64.neon.uhsub.v2i32(<2 x i32> [[V1]], <2 x i32> [[V2]])
+  // LLVM: ret <2 x i32> [[RES]]
   return vhsub_u32(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vhsubq_s8(
+// LLVM-LABEL: @test_vhsubq_s8(
 // CIR-LABEL: @vhsubq_s8(
 int8x16_t test_vhsubq_s8(int8x16_t v1, int8x16_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.shsub"
 
-  // LLVM-IC-SAME: <16 x i8> {{.*}}[[V1:%.*]], <16 x i8> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <16 x i8> @llvm.aarch64.neon.shsub.v16i8(<16 x i8> [[V1]], <16 x i8> [[V2]])
-  // LLVM-IC: ret <16 x i8> [[RES]]
+  // LLVM-SAME: <16 x i8> {{.*}}[[V1:%.*]], <16 x i8> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <16 x i8> @llvm.aarch64.neon.shsub.v16i8(<16 x i8> [[V1]], <16 x i8> [[V2]])
+  // LLVM: ret <16 x i8> [[RES]]
   return vhsubq_s8(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vhsubq_s16(
+// LLVM-LABEL: @test_vhsubq_s16(
 // CIR-LABEL: @vhsubq_s16(
 int16x8_t test_vhsubq_s16(int16x8_t v1, int16x8_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.shsub"
 
-  // LLVM-IC-SAME: <8 x i16> {{.*}}[[V1:%.*]], <8 x i16> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <8 x i16> @llvm.aarch64.neon.shsub.v8i16(<8 x i16> [[V1]], <8 x i16> [[V2]])
-  // LLVM-IC: ret <8 x i16> [[RES]]
+  // LLVM-SAME: <8 x i16> {{.*}}[[V1:%.*]], <8 x i16> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <8 x i16> @llvm.aarch64.neon.shsub.v8i16(<8 x i16> [[V1]], <8 x i16> [[V2]])
+  // LLVM: ret <8 x i16> [[RES]]
   return vhsubq_s16(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vhsubq_s32(
+// LLVM-LABEL: @test_vhsubq_s32(
 // CIR-LABEL: @vhsubq_s32(
 int32x4_t test_vhsubq_s32(int32x4_t v1, int32x4_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.shsub"
 
-  // LLVM-IC-SAME: <4 x i32> {{.*}}[[V1:%.*]], <4 x i32> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <4 x i32> @llvm.aarch64.neon.shsub.v4i32(<4 x i32> [[V1]], <4 x i32> [[V2]])
-  // LLVM-IC: ret <4 x i32> [[RES]]
+  // LLVM-SAME: <4 x i32> {{.*}}[[V1:%.*]], <4 x i32> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <4 x i32> @llvm.aarch64.neon.shsub.v4i32(<4 x i32> [[V1]], <4 x i32> [[V2]])
+  // LLVM: ret <4 x i32> [[RES]]
   return vhsubq_s32(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vhsubq_u8(
+// LLVM-LABEL: @test_vhsubq_u8(
 // CIR-LABEL: @vhsubq_u8(
 uint8x16_t test_vhsubq_u8(uint8x16_t v1, uint8x16_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.uhsub"
 
-  // LLVM-IC-SAME: <16 x i8> {{.*}}[[V1:%.*]], <16 x i8> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <16 x i8> @llvm.aarch64.neon.uhsub.v16i8(<16 x i8> [[V1]], <16 x i8> [[V2]])
-  // LLVM-IC: ret <16 x i8> [[RES]]
+  // LLVM-SAME: <16 x i8> {{.*}}[[V1:%.*]], <16 x i8> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <16 x i8> @llvm.aarch64.neon.uhsub.v16i8(<16 x i8> [[V1]], <16 x i8> [[V2]])
+  // LLVM: ret <16 x i8> [[RES]]
   return vhsubq_u8(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vhsubq_u16(
+// LLVM-LABEL: @test_vhsubq_u16(
 // CIR-LABEL: @vhsubq_u16(
 uint16x8_t test_vhsubq_u16(uint16x8_t v1, uint16x8_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.uhsub"
 
-  // LLVM-IC-SAME: <8 x i16> {{.*}}[[V1:%.*]], <8 x i16> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <8 x i16> @llvm.aarch64.neon.uhsub.v8i16(<8 x i16> [[V1]], <8 x i16> [[V2]])
-  // LLVM-IC: ret <8 x i16> [[RES]]
+  // LLVM-SAME: <8 x i16> {{.*}}[[V1:%.*]], <8 x i16> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <8 x i16> @llvm.aarch64.neon.uhsub.v8i16(<8 x i16> [[V1]], <8 x i16> [[V2]])
+  // LLVM: ret <8 x i16> [[RES]]
   return vhsubq_u16(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vhsubq_u32(
+// LLVM-LABEL: @test_vhsubq_u32(
 // CIR-LABEL: @vhsubq_u32(
 uint32x4_t test_vhsubq_u32(uint32x4_t v1, uint32x4_t v2) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.uhsub"
 
-  // LLVM-IC-SAME: <4 x i32> {{.*}}[[V1:%.*]], <4 x i32> {{.*}}[[V2:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <4 x i32> @llvm.aarch64.neon.uhsub.v4i32(<4 x i32> [[V1]], <4 x i32> [[V2]])
-  // LLVM-IC: ret <4 x i32> [[RES]]
+  // LLVM-SAME: <4 x i32> {{.*}}[[V1:%.*]], <4 x i32> {{.*}}[[V2:%.*]])
+  // LLVM: [[RES:%.*]] = call <4 x i32> @llvm.aarch64.neon.uhsub.v4i32(<4 x i32> [[V1]], <4 x i32> [[V2]])
+  // LLVM: ret <4 x i32> [[RES]]
   return vhsubq_u32(v1, v2);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_s16(
+// LLVM-LABEL: @test_vsubhn_s16(
 // CIR-LABEL: @vsubhn_s16(
 int8x8_t test_vsubhn_s16(int16x8_t a, int16x8_t b) {
   // CIR: cir.sub
   // CIR: cir.shift(right
   // CIR: cir.cast integral
 
-  // LLVM-IC-SAME: <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <8 x i16> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <8 x i16> [[SUB]], splat (i16 8)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <8 x i16> [[SH]] to <8 x i8>
-  // LLVM-IC: ret <8 x i8> [[TR]]
+  // LLVM-SAME: <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <8 x i16> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <8 x i16> [[SUB]], splat (i16 8)
+  // LLVM: [[TR:%.*]] = trunc nuw <8 x i16> [[SH]] to <8 x i8>
+  // LLVM: ret <8 x i8> [[TR]]
   return vsubhn_s16(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_s32(
+// LLVM-LABEL: @test_vsubhn_s32(
 // CIR-LABEL: @vsubhn_s32(
 int16x4_t test_vsubhn_s32(int32x4_t a, int32x4_t b) {
   // CIR: cir.sub
   // CIR: cir.shift(right
   // CIR: cir.cast integral
 
-  // LLVM-IC-SAME: <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <4 x i32> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <4 x i32> [[SUB]], splat (i32 16)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <4 x i32> [[SH]] to <4 x i16>
-  // LLVM-IC: ret <4 x i16> [[TR]]
+  // LLVM-SAME: <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <4 x i32> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <4 x i32> [[SUB]], splat (i32 16)
+  // LLVM: [[TR:%.*]] = trunc nuw <4 x i32> [[SH]] to <4 x i16>
+  // LLVM: ret <4 x i16> [[TR]]
   return vsubhn_s32(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_s64(
+// LLVM-LABEL: @test_vsubhn_s64(
 // CIR-LABEL: @vsubhn_s64(
 int32x2_t test_vsubhn_s64(int64x2_t a, int64x2_t b) {
   // CIR: cir.sub
   // CIR: cir.shift(right
   // CIR: cir.cast integral
 
-  // LLVM-IC-SAME: <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <2 x i64> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <2 x i64> [[SUB]], splat (i64 32)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <2 x i64> [[SH]] to <2 x i32>
-  // LLVM-IC: ret <2 x i32> [[TR]]
+  // LLVM-SAME: <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <2 x i64> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <2 x i64> [[SUB]], splat (i64 32)
+  // LLVM: [[TR:%.*]] = trunc nuw <2 x i64> [[SH]] to <2 x i32>
+  // LLVM: ret <2 x i32> [[TR]]
   return vsubhn_s64(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_u16(
+// LLVM-LABEL: @test_vsubhn_u16(
 // CIR-LABEL: @vsubhn_u16(
 uint8x8_t test_vsubhn_u16(uint16x8_t a, uint16x8_t b) {
   // CIR: cir.sub
   // CIR: cir.shift(right
   // CIR: cir.cast integral
 
-  // LLVM-IC-SAME: <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <8 x i16> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <8 x i16> [[SUB]], splat (i16 8)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <8 x i16> [[SH]] to <8 x i8>
-  // LLVM-IC: ret <8 x i8> [[TR]]
+  // LLVM-SAME: <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <8 x i16> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <8 x i16> [[SUB]], splat (i16 8)
+  // LLVM: [[TR:%.*]] = trunc nuw <8 x i16> [[SH]] to <8 x i8>
+  // LLVM: ret <8 x i8> [[TR]]
   return vsubhn_u16(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_u32(
+// LLVM-LABEL: @test_vsubhn_u32(
 // CIR-LABEL: @vsubhn_u32(
 uint16x4_t test_vsubhn_u32(uint32x4_t a, uint32x4_t b) {
   // CIR: cir.sub
   // CIR: cir.shift(right
   // CIR: cir.cast integral
 
-  // LLVM-IC-SAME: <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <4 x i32> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <4 x i32> [[SUB]], splat (i32 16)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <4 x i32> [[SH]] to <4 x i16>
-  // LLVM-IC: ret <4 x i16> [[TR]]
+  // LLVM-SAME: <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <4 x i32> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <4 x i32> [[SUB]], splat (i32 16)
+  // LLVM: [[TR:%.*]] = trunc nuw <4 x i32> [[SH]] to <4 x i16>
+  // LLVM: ret <4 x i16> [[TR]]
   return vsubhn_u32(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_u64(
+// LLVM-LABEL: @test_vsubhn_u64(
 // CIR-LABEL: @vsubhn_u64(
 uint32x2_t test_vsubhn_u64(uint64x2_t a, uint64x2_t b) {
   // CIR: cir.sub
   // CIR: cir.shift(right
   // CIR: cir.cast integral
 
-  // LLVM-IC-SAME: <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <2 x i64> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <2 x i64> [[SUB]], splat (i64 32)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <2 x i64> [[SH]] to <2 x i32>
-  // LLVM-IC: ret <2 x i32> [[TR]]
+  // LLVM-SAME: <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <2 x i64> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <2 x i64> [[SUB]], splat (i64 32)
+  // LLVM: [[TR:%.*]] = trunc nuw <2 x i64> [[SH]] to <2 x i32>
+  // LLVM: ret <2 x i32> [[TR]]
   return vsubhn_u64(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_high_s16(
+// LLVM-LABEL: @test_vsubhn_high_s16(
 // CIR-LABEL: @vsubhn_high_s16(
 int8x16_t test_vsubhn_high_s16(int8x8_t r, int16x8_t a, int16x8_t b) {
   // CIR: cir.call @vsubhn_s16(
   // CIR: cir.call @vcombine_s8(
 
-  // LLVM-IC-SAME: <8 x i8> {{.*}}[[R:%.*]], <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <8 x i16> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <8 x i16> [[SUB]], splat (i16 8)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <8 x i16> [[SH]] to <8 x i8>
-  // LLVM-IC: [[RES:%.*]] = shufflevector <8 x i8> [[R]], <8 x i8> [[TR]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  // LLVM-IC: ret <16 x i8> [[RES]]
+  // LLVM-SAME: <8 x i8> {{.*}}[[R:%.*]], <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <8 x i16> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <8 x i16> [[SUB]], splat (i16 8)
+  // LLVM: [[TR:%.*]] = trunc nuw <8 x i16> [[SH]] to <8 x i8>
+  // LLVM: [[RES:%.*]] = shufflevector <8 x i8> [[R]], <8 x i8> [[TR]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  // LLVM: ret <16 x i8> [[RES]]
   return vsubhn_high_s16(r, a, b);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_high_s32(
+// LLVM-LABEL: @test_vsubhn_high_s32(
 // CIR-LABEL: @vsubhn_high_s32(
 int16x8_t test_vsubhn_high_s32(int16x4_t r, int32x4_t a, int32x4_t b) {
   // CIR: cir.call @vsubhn_s32(
   // CIR: cir.call @vcombine_s16(
 
-  // LLVM-IC-SAME: <4 x i16> {{.*}}[[R:%.*]], <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <4 x i32> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <4 x i32> [[SUB]], splat (i32 16)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <4 x i32> [[SH]] to <4 x i16>
-  // LLVM-IC: [[RES:%.*]] = shufflevector <4 x i16> [[R]], <4 x i16> [[TR]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  // LLVM-IC: ret <8 x i16> [[RES]]
+  // LLVM-SAME: <4 x i16> {{.*}}[[R:%.*]], <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <4 x i32> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <4 x i32> [[SUB]], splat (i32 16)
+  // LLVM: [[TR:%.*]] = trunc nuw <4 x i32> [[SH]] to <4 x i16>
+  // LLVM: [[RES:%.*]] = shufflevector <4 x i16> [[R]], <4 x i16> [[TR]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  // LLVM: ret <8 x i16> [[RES]]
   return vsubhn_high_s32(r, a, b);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_high_s64(
+// LLVM-LABEL: @test_vsubhn_high_s64(
 // CIR-LABEL: @vsubhn_high_s64(
 int32x4_t test_vsubhn_high_s64(int32x2_t r, int64x2_t a, int64x2_t b) {
   // CIR: cir.call @vsubhn_s64(
   // CIR: cir.call @vcombine_s32(
 
-  // LLVM-IC-SAME: <2 x i32> {{.*}}[[R:%.*]], <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <2 x i64> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <2 x i64> [[SUB]], splat (i64 32)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <2 x i64> [[SH]] to <2 x i32>
-  // LLVM-IC: [[RES:%.*]] = shufflevector <2 x i32> [[R]], <2 x i32> [[TR]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  // LLVM-IC: ret <4 x i32> [[RES]]
+  // LLVM-SAME: <2 x i32> {{.*}}[[R:%.*]], <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <2 x i64> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <2 x i64> [[SUB]], splat (i64 32)
+  // LLVM: [[TR:%.*]] = trunc nuw <2 x i64> [[SH]] to <2 x i32>
+  // LLVM: [[RES:%.*]] = shufflevector <2 x i32> [[R]], <2 x i32> [[TR]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  // LLVM: ret <4 x i32> [[RES]]
   return vsubhn_high_s64(r, a, b);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_high_u16(
+// LLVM-LABEL: @test_vsubhn_high_u16(
 // CIR-LABEL: @vsubhn_high_u16(
 uint8x16_t test_vsubhn_high_u16(uint8x8_t r, uint16x8_t a, uint16x8_t b) {
   // CIR: cir.call @vsubhn_u16(
   // CIR: cir.call @vcombine_u8(
 
-  // LLVM-IC-SAME: <8 x i8> {{.*}}[[R:%.*]], <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <8 x i16> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <8 x i16> [[SUB]], splat (i16 8)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <8 x i16> [[SH]] to <8 x i8>
-  // LLVM-IC: [[RES:%.*]] = shufflevector <8 x i8> [[R]], <8 x i8> [[TR]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  // LLVM-IC: ret <16 x i8> [[RES]]
+  // LLVM-SAME: <8 x i8> {{.*}}[[R:%.*]], <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <8 x i16> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <8 x i16> [[SUB]], splat (i16 8)
+  // LLVM: [[TR:%.*]] = trunc nuw <8 x i16> [[SH]] to <8 x i8>
+  // LLVM: [[RES:%.*]] = shufflevector <8 x i8> [[R]], <8 x i8> [[TR]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  // LLVM: ret <16 x i8> [[RES]]
   return vsubhn_high_u16(r, a, b);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_high_u32(
+// LLVM-LABEL: @test_vsubhn_high_u32(
 // CIR-LABEL: @vsubhn_high_u32(
 uint16x8_t test_vsubhn_high_u32(uint16x4_t r, uint32x4_t a, uint32x4_t b) {
   // CIR: cir.call @vsubhn_u32(
   // CIR: cir.call @vcombine_u16(
 
-  // LLVM-IC-SAME: <4 x i16> {{.*}}[[R:%.*]], <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <4 x i32> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <4 x i32> [[SUB]], splat (i32 16)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <4 x i32> [[SH]] to <4 x i16>
-  // LLVM-IC: [[RES:%.*]] = shufflevector <4 x i16> [[R]], <4 x i16> [[TR]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  // LLVM-IC: ret <8 x i16> [[RES]]
+  // LLVM-SAME: <4 x i16> {{.*}}[[R:%.*]], <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <4 x i32> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <4 x i32> [[SUB]], splat (i32 16)
+  // LLVM: [[TR:%.*]] = trunc nuw <4 x i32> [[SH]] to <4 x i16>
+  // LLVM: [[RES:%.*]] = shufflevector <4 x i16> [[R]], <4 x i16> [[TR]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  // LLVM: ret <8 x i16> [[RES]]
   return vsubhn_high_u32(r, a, b);
 }
 
-// LLVM-IC-LABEL: @test_vsubhn_high_u64(
+// LLVM-LABEL: @test_vsubhn_high_u64(
 // CIR-LABEL: @vsubhn_high_u64(
 uint32x4_t test_vsubhn_high_u64(uint32x2_t r, uint64x2_t a, uint64x2_t b) {
   // CIR: cir.call @vsubhn_u64(
   // CIR: cir.call @vcombine_u32(
 
-  // LLVM-IC-SAME: <2 x i32> {{.*}}[[R:%.*]], <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[SUB:%.*]] = sub <2 x i64> [[A]], [[B]]
-  // LLVM-IC: [[SH:%.*]] = lshr <2 x i64> [[SUB]], splat (i64 32)
-  // LLVM-IC: [[TR:%.*]] = trunc nuw <2 x i64> [[SH]] to <2 x i32>
-  // LLVM-IC: [[RES:%.*]] = shufflevector <2 x i32> [[R]], <2 x i32> [[TR]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  // LLVM-IC: ret <4 x i32> [[RES]]
+  // LLVM-SAME: <2 x i32> {{.*}}[[R:%.*]], <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
+  // LLVM: [[SUB:%.*]] = sub <2 x i64> [[A]], [[B]]
+  // LLVM: [[SH:%.*]] = lshr <2 x i64> [[SUB]], splat (i64 32)
+  // LLVM: [[TR:%.*]] = trunc nuw <2 x i64> [[SH]] to <2 x i32>
+  // LLVM: [[RES:%.*]] = shufflevector <2 x i32> [[R]], <2 x i32> [[TR]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  // LLVM: ret <4 x i32> [[RES]]
   return vsubhn_high_u64(r, a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_s16(
+// LLVM-LABEL: @test_vrsubhn_s16(
 // CIR-LABEL: @vrsubhn_s16(
 int8x8_t test_vrsubhn_s16(int16x8_t a, int16x8_t b) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.rsubhn"
 
-  // LLVM-IC-SAME: <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <8 x i8> @llvm.aarch64.neon.rsubhn.v8i8(<8 x i16> [[A]], <8 x i16> [[B]])
-  // LLVM-IC: ret <8 x i8> [[RES]]
+  // LLVM-SAME: <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
+  // LLVM: [[RES:%.*]] = call <8 x i8> @llvm.aarch64.neon.rsubhn.v8i8(<8 x i16> [[A]], <8 x i16> [[B]])
+  // LLVM: ret <8 x i8> [[RES]]
   return vrsubhn_s16(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_s32(
+// LLVM-LABEL: @test_vrsubhn_s32(
 // CIR-LABEL: @vrsubhn_s32(
 int16x4_t test_vrsubhn_s32(int32x4_t a, int32x4_t b) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.rsubhn"
 
-  // LLVM-IC-SAME: <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <4 x i16> @llvm.aarch64.neon.rsubhn.v4i16(<4 x i32> [[A]], <4 x i32> [[B]])
-  // LLVM-IC: ret <4 x i16> [[RES]]
+  // LLVM-SAME: <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
+  // LLVM: [[RES:%.*]] = call <4 x i16> @llvm.aarch64.neon.rsubhn.v4i16(<4 x i32> [[A]], <4 x i32> [[B]])
+  // LLVM: ret <4 x i16> [[RES]]
   return vrsubhn_s32(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_s64(
+// LLVM-LABEL: @test_vrsubhn_s64(
 // CIR-LABEL: @vrsubhn_s64(
 int32x2_t test_vrsubhn_s64(int64x2_t a, int64x2_t b) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.rsubhn"
 
-  // LLVM-IC-SAME: <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <2 x i32> @llvm.aarch64.neon.rsubhn.v2i32(<2 x i64> [[A]], <2 x i64> [[B]])
-  // LLVM-IC: ret <2 x i32> [[RES]]
+  // LLVM-SAME: <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
+  // LLVM: [[RES:%.*]] = call <2 x i32> @llvm.aarch64.neon.rsubhn.v2i32(<2 x i64> [[A]], <2 x i64> [[B]])
+  // LLVM: ret <2 x i32> [[RES]]
   return vrsubhn_s64(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_u16(
+// LLVM-LABEL: @test_vrsubhn_u16(
 // CIR-LABEL: @vrsubhn_u16(
 uint8x8_t test_vrsubhn_u16(uint16x8_t a, uint16x8_t b) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.rsubhn"
 
-  // LLVM-IC-SAME: <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <8 x i8> @llvm.aarch64.neon.rsubhn.v8i8(<8 x i16> [[A]], <8 x i16> [[B]])
-  // LLVM-IC: ret <8 x i8> [[RES]]
+  // LLVM-SAME: <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
+  // LLVM: [[RES:%.*]] = call <8 x i8> @llvm.aarch64.neon.rsubhn.v8i8(<8 x i16> [[A]], <8 x i16> [[B]])
+  // LLVM: ret <8 x i8> [[RES]]
   return vrsubhn_u16(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_u32(
+// LLVM-LABEL: @test_vrsubhn_u32(
 // CIR-LABEL: @vrsubhn_u32(
 uint16x4_t test_vrsubhn_u32(uint32x4_t a, uint32x4_t b) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.rsubhn"
 
-  // LLVM-IC-SAME: <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <4 x i16> @llvm.aarch64.neon.rsubhn.v4i16(<4 x i32> [[A]], <4 x i32> [[B]])
-  // LLVM-IC: ret <4 x i16> [[RES]]
+  // LLVM-SAME: <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
+  // LLVM: [[RES:%.*]] = call <4 x i16> @llvm.aarch64.neon.rsubhn.v4i16(<4 x i32> [[A]], <4 x i32> [[B]])
+  // LLVM: ret <4 x i16> [[RES]]
   return vrsubhn_u32(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_u64(
+// LLVM-LABEL: @test_vrsubhn_u64(
 // CIR-LABEL: @vrsubhn_u64(
 uint32x2_t test_vrsubhn_u64(uint64x2_t a, uint64x2_t b) {
   // CIR: cir.call_llvm_intrinsic "aarch64.neon.rsubhn"
 
-  // LLVM-IC-SAME: <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[RES:%.*]] = call <2 x i32> @llvm.aarch64.neon.rsubhn.v2i32(<2 x i64> [[A]], <2 x i64> [[B]])
-  // LLVM-IC: ret <2 x i32> [[RES]]
+  // LLVM-SAME: <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
+  // LLVM: [[RES:%.*]] = call <2 x i32> @llvm.aarch64.neon.rsubhn.v2i32(<2 x i64> [[A]], <2 x i64> [[B]])
+  // LLVM: ret <2 x i32> [[RES]]
   return vrsubhn_u64(a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_high_s16(
+// LLVM-LABEL: @test_vrsubhn_high_s16(
 // CIR-LABEL: @vrsubhn_high_s16(
 int8x16_t test_vrsubhn_high_s16(int8x8_t r, int16x8_t a, int16x8_t b) {
   // CIR: cir.call @vrsubhn_s16(
   // CIR: cir.call @vcombine_s8(
 
-  // LLVM-IC-SAME: <8 x i8> {{.*}}[[R:%.*]], <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[TMP:%.*]] = call <8 x i8> @llvm.aarch64.neon.rsubhn.v8i8(<8 x i16> [[A]], <8 x i16> [[B]])
-  // LLVM-IC: [[RES:%.*]] = shufflevector <8 x i8> [[R]], <8 x i8> [[TMP]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  // LLVM-IC: ret <16 x i8> [[RES]]
+  // LLVM-SAME: <8 x i8> {{.*}}[[R:%.*]], <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
+  // LLVM: [[TMP:%.*]] = call <8 x i8> @llvm.aarch64.neon.rsubhn.v8i8(<8 x i16> [[A]], <8 x i16> [[B]])
+  // LLVM: [[RES:%.*]] = shufflevector <8 x i8> [[R]], <8 x i8> [[TMP]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  // LLVM: ret <16 x i8> [[RES]]
   return vrsubhn_high_s16(r, a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_high_s32(
+// LLVM-LABEL: @test_vrsubhn_high_s32(
 // CIR-LABEL: @vrsubhn_high_s32(
 int16x8_t test_vrsubhn_high_s32(int16x4_t r, int32x4_t a, int32x4_t b) {
   // CIR: cir.call @vrsubhn_s32(
   // CIR: cir.call @vcombine_s16(
 
-  // LLVM-IC-SAME: <4 x i16> {{.*}}[[R:%.*]], <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[TMP:%.*]] = call <4 x i16> @llvm.aarch64.neon.rsubhn.v4i16(<4 x i32> [[A]], <4 x i32> [[B]])
-  // LLVM-IC: [[RES:%.*]] = shufflevector <4 x i16> [[R]], <4 x i16> [[TMP]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  // LLVM-IC: ret <8 x i16> [[RES]]
+  // LLVM-SAME: <4 x i16> {{.*}}[[R:%.*]], <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
+  // LLVM: [[TMP:%.*]] = call <4 x i16> @llvm.aarch64.neon.rsubhn.v4i16(<4 x i32> [[A]], <4 x i32> [[B]])
+  // LLVM: [[RES:%.*]] = shufflevector <4 x i16> [[R]], <4 x i16> [[TMP]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  // LLVM: ret <8 x i16> [[RES]]
   return vrsubhn_high_s32(r, a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_high_s64(
+// LLVM-LABEL: @test_vrsubhn_high_s64(
 // CIR-LABEL: @vrsubhn_high_s64(
 int32x4_t test_vrsubhn_high_s64(int32x2_t r, int64x2_t a, int64x2_t b) {
   // CIR: cir.call @vrsubhn_s64(
   // CIR: cir.call @vcombine_s32(
 
-  // LLVM-IC-SAME: <2 x i32> {{.*}}[[R:%.*]], <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[TMP:%.*]] = call <2 x i32> @llvm.aarch64.neon.rsubhn.v2i32(<2 x i64> [[A]], <2 x i64> [[B]])
-  // LLVM-IC: [[RES:%.*]] = shufflevector <2 x i32> [[R]], <2 x i32> [[TMP]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  // LLVM-IC: ret <4 x i32> [[RES]]
+  // LLVM-SAME: <2 x i32> {{.*}}[[R:%.*]], <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
+  // LLVM: [[TMP:%.*]] = call <2 x i32> @llvm.aarch64.neon.rsubhn.v2i32(<2 x i64> [[A]], <2 x i64> [[B]])
+  // LLVM: [[RES:%.*]] = shufflevector <2 x i32> [[R]], <2 x i32> [[TMP]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  // LLVM: ret <4 x i32> [[RES]]
   return vrsubhn_high_s64(r, a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_high_u16(
+// LLVM-LABEL: @test_vrsubhn_high_u16(
 // CIR-LABEL: @vrsubhn_high_u16(
 uint8x16_t test_vrsubhn_high_u16(uint8x8_t r, uint16x8_t a, uint16x8_t b) {
   // CIR: cir.call @vrsubhn_u16(
   // CIR: cir.call @vcombine_u8(
 
-  // LLVM-IC-SAME: <8 x i8> {{.*}}[[R:%.*]], <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[TMP:%.*]] = call <8 x i8> @llvm.aarch64.neon.rsubhn.v8i8(<8 x i16> [[A]], <8 x i16> [[B]])
-  // LLVM-IC: [[RES:%.*]] = shufflevector <8 x i8> [[R]], <8 x i8> [[TMP]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-  // LLVM-IC: ret <16 x i8> [[RES]]
+  // LLVM-SAME: <8 x i8> {{.*}}[[R:%.*]], <8 x i16> {{.*}}[[A:%.*]], <8 x i16> {{.*}}[[B:%.*]])
+  // LLVM: [[TMP:%.*]] = call <8 x i8> @llvm.aarch64.neon.rsubhn.v8i8(<8 x i16> [[A]], <8 x i16> [[B]])
+  // LLVM: [[RES:%.*]] = shufflevector <8 x i8> [[R]], <8 x i8> [[TMP]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  // LLVM: ret <16 x i8> [[RES]]
   return vrsubhn_high_u16(r, a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_high_u32(
+// LLVM-LABEL: @test_vrsubhn_high_u32(
 // CIR-LABEL: @vrsubhn_high_u32(
 uint16x8_t test_vrsubhn_high_u32(uint16x4_t r, uint32x4_t a, uint32x4_t b) {
   // CIR: cir.call @vrsubhn_u32(
   // CIR: cir.call @vcombine_u16(
 
-  // LLVM-IC-SAME: <4 x i16> {{.*}}[[R:%.*]], <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[TMP:%.*]] = call <4 x i16> @llvm.aarch64.neon.rsubhn.v4i16(<4 x i32> [[A]], <4 x i32> [[B]])
-  // LLVM-IC: [[RES:%.*]] = shufflevector <4 x i16> [[R]], <4 x i16> [[TMP]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-  // LLVM-IC: ret <8 x i16> [[RES]]
+  // LLVM-SAME: <4 x i16> {{.*}}[[R:%.*]], <4 x i32> {{.*}}[[A:%.*]], <4 x i32> {{.*}}[[B:%.*]])
+  // LLVM: [[TMP:%.*]] = call <4 x i16> @llvm.aarch64.neon.rsubhn.v4i16(<4 x i32> [[A]], <4 x i32> [[B]])
+  // LLVM: [[RES:%.*]] = shufflevector <4 x i16> [[R]], <4 x i16> [[TMP]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  // LLVM: ret <8 x i16> [[RES]]
   return vrsubhn_high_u32(r, a, b);
 }
 
-// LLVM-IC-LABEL: @test_vrsubhn_high_u64(
+// LLVM-LABEL: @test_vrsubhn_high_u64(
 // CIR-LABEL: @vrsubhn_high_u64(
 uint32x4_t test_vrsubhn_high_u64(uint32x2_t r, uint64x2_t a, uint64x2_t b) {
   // CIR: cir.call @vrsubhn_u64(
   // CIR: cir.call @vcombine_u32(
 
-  // LLVM-IC-SAME: <2 x i32> {{.*}}[[R:%.*]], <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
-  // LLVM-IC: [[TMP:%.*]] = call <2 x i32> @llvm.aarch64.neon.rsubhn.v2i32(<2 x i64> [[A]], <2 x i64> [[B]])
-  // LLVM-IC: [[RES:%.*]] = shufflevector <2 x i32> [[R]], <2 x i32> [[TMP]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  // LLVM-IC: ret <4 x i32> [[RES]]
+  // LLVM-SAME: <2 x i32> {{.*}}[[R:%.*]], <2 x i64> {{.*}}[[A:%.*]], <2 x i64> {{.*}}[[B:%.*]])
+  // LLVM: [[TMP:%.*]] = call <2 x i32> @llvm.aarch64.neon.rsubhn.v2i32(<2 x i64> [[A]], <2 x i64> [[B]])
+  // LLVM: [[RES:%.*]] = shufflevector <2 x i32> [[R]], <2 x i32> [[TMP]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  // LLVM: ret <4 x i32> [[RES]]
   return vrsubhn_high_u64(r, a, b);
 }


### PR DESCRIPTION
Related to https://github.com/llvm/llvm-project/issues/185382

Follow-up to https://github.com/llvm/llvm-project/pull/207115

Include `instcombine` into the global LLVM RUN line and remove the separate `LLVM-IC` prefix that only covered the narrowing-subtraction tests in `clang/test/CodeGen/AArch64/neon/subtraction.c`.

Update LLVM CHECK to match the `instcombine` output: bitcast checks are dropped, the inferred `nsw` flags are added on the widening subs, and unused shuffle operands are canonicalized to `poison`.
