### PR TITLE
[BOLT] Give BinaryBasicBlock a GraphTraits block number

### DIFF
--- a/bolt/include/bolt/Core/BinaryBasicBlock.h
+++ b/bolt/include/bolt/Core/BinaryBasicBlock.h
@@ -980,7 +980,13 @@ template <> struct GraphTraits<bolt::BinaryBasicBlock *> {
     return N->succ_begin();
   }
   static inline ChildIteratorType child_end(NodeRef N) { return N->succ_end(); }
+  static unsigned getNumber(const bolt::BinaryBasicBlock *BB) {
+    return BB->getIndex();
+  }
 };
+
+static_assert(GraphHasNodeNumbers<bolt::BinaryBasicBlock *>,
+              "GraphTraits getNumber() not detected");
 
 template <> struct GraphTraits<const bolt::BinaryBasicBlock *> {
   using NodeRef = const bolt::BinaryBasicBlock *;
@@ -991,7 +997,13 @@ template <> struct GraphTraits<const bolt::BinaryBasicBlock *> {
     return N->succ_begin();
   }
   static inline ChildIteratorType child_end(NodeRef N) { return N->succ_end(); }
+  static unsigned getNumber(const bolt::BinaryBasicBlock *BB) {
+    return BB->getIndex();
+  }
 };
+
+static_assert(GraphHasNodeNumbers<const bolt::BinaryBasicBlock *>,
+              "GraphTraits getNumber() not detected");
 
 template <> struct GraphTraits<Inverse<bolt::BinaryBasicBlock *>> {
   using NodeRef = bolt::BinaryBasicBlock *;
@@ -1003,7 +1015,13 @@ template <> struct GraphTraits<Inverse<bolt::BinaryBasicBlock *>> {
     return N->pred_begin();
   }
   static inline ChildIteratorType child_end(NodeRef N) { return N->pred_end(); }
+  static unsigned getNumber(const bolt::BinaryBasicBlock *BB) {
+    return BB->getIndex();
+  }
 };
+
+static_assert(GraphHasNodeNumbers<Inverse<bolt::BinaryBasicBlock *>>,
+              "GraphTraits getNumber() not detected");
 
 template <> struct GraphTraits<Inverse<const bolt::BinaryBasicBlock *>> {
   using NodeRef = const bolt::BinaryBasicBlock *;
@@ -1015,7 +1033,13 @@ template <> struct GraphTraits<Inverse<const bolt::BinaryBasicBlock *>> {
     return N->pred_begin();
   }
   static inline ChildIteratorType child_end(NodeRef N) { return N->pred_end(); }
+  static unsigned getNumber(const bolt::BinaryBasicBlock *BB) {
+    return BB->getIndex();
+  }
 };
+
+static_assert(GraphHasNodeNumbers<Inverse<const bolt::BinaryBasicBlock *>>,
+              "GraphTraits getNumber() not detected");
 
 } // namespace llvm
 

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -279,6 +279,10 @@ private:
   std::unique_ptr<BinaryLoopInfo> BLI;
   std::unique_ptr<BinaryDominatorTree> BDT;
 
+  /// Epoch for basic block indices, bumped by updateBBIndices(). See
+  /// getBlockNumberEpoch().
+  unsigned BlockNumberEpoch = 0;
+
   /// All labels in the function that are referenced via relocations from
   /// data objects. Typically these are jump table destinations and computed
   /// goto labels.
@@ -827,6 +831,11 @@ public:
         BinaryBasicBlock &front()        { return *BasicBlocks.front(); }
   const BinaryBasicBlock & back() const  { return *BasicBlocks.back(); }
         BinaryBasicBlock & back()        { return *BasicBlocks.back(); }
+
+  /// Epoch bumped whenever basic block indices are reassigned by
+  /// updateBBIndices(), so number-indexed structures (LoopInfo, DominatorTree)
+  /// can detect stale block numbers. See BinaryBasicBlock::getIndex().
+  unsigned getBlockNumberEpoch() const { return BlockNumberEpoch; }
   inline iterator_range<iterator> blocks() {
     return iterator_range<iterator>(begin(), end());
   }
@@ -2646,6 +2655,12 @@ struct GraphTraits<bolt::BinaryFunction *>
     return nodes_iterator(F->end());
   }
   static size_t size(bolt::BinaryFunction *F) { return F->size(); }
+  static unsigned getMaxNumber(const bolt::BinaryFunction *F) {
+    return F->size();
+  }
+  static unsigned getNumberEpoch(const bolt::BinaryFunction *F) {
+    return F->getBlockNumberEpoch();
+  }
 };
 
 template <>
@@ -2666,6 +2681,12 @@ struct GraphTraits<const bolt::BinaryFunction *>
     return nodes_iterator(F->end());
   }
   static size_t size(const bolt::BinaryFunction *F) { return F->size(); }
+  static unsigned getMaxNumber(const bolt::BinaryFunction *F) {
+    return F->size();
+  }
+  static unsigned getNumberEpoch(const bolt::BinaryFunction *F) {
+    return F->getBlockNumberEpoch();
+  }
 };
 
 template <>
@@ -2674,6 +2695,12 @@ struct GraphTraits<Inverse<bolt::BinaryFunction *>>
   static NodeRef getEntryNode(Inverse<bolt::BinaryFunction *> G) {
     return G.Graph->getLayout().block_front();
   }
+  static unsigned getMaxNumber(const bolt::BinaryFunction *F) {
+    return F->size();
+  }
+  static unsigned getNumberEpoch(const bolt::BinaryFunction *F) {
+    return F->getBlockNumberEpoch();
+  }
 };
 
 template <>
@@ -2681,6 +2708,12 @@ struct GraphTraits<Inverse<const bolt::BinaryFunction *>>
     : public GraphTraits<Inverse<const bolt::BinaryBasicBlock *>> {
   static NodeRef getEntryNode(Inverse<const bolt::BinaryFunction *> G) {
     return G.Graph->getLayout().block_front();
+  }
+  static unsigned getMaxNumber(const bolt::BinaryFunction *F) {
+    return F->size();
+  }
+  static unsigned getNumberEpoch(const bolt::BinaryFunction *F) {
+    return F->getBlockNumberEpoch();
   }
 };
 

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -4120,6 +4120,7 @@ BinaryFunction::iterator BinaryFunction::insertBasicBlocks(
 void BinaryFunction::updateBBIndices(const unsigned StartIndex) {
   for (unsigned I = StartIndex; I < BasicBlocks.size(); ++I)
     BasicBlocks[I]->Index = I;
+  ++BlockNumberEpoch;
 }
 
 void BinaryFunction::updateCFIState(BinaryBasicBlock *Start,


### PR DESCRIPTION
LoopInfoBase (and DominatorTreeBase) keep a DenseMap fallback for block
types whose GraphTraits lacks getNumber() (#103400); BOLT's
BinaryLoopInfo is one of the last two users.

BinaryBasicBlock already carries a dense [0, size) index (getIndex(),
assigned by updateBBIndices()). Expose it as the GraphTraits node number,
mirroring llvm::BasicBlock/Function.

This makes `GraphHasNodeNumbers<BinaryBasicBlock *>` true, moving BOLT's
LoopInfo and DominatorTree onto the number-indexed (SmallVector) path.
Prerequisite for requiring GraphHasNodeNumbers in LoopInfoBase.

Aided by Claude Opus 4.8
