### PR TITLE
[Clang] Renumber TokenKey enum values to close gap left by KEYNOZOS removal

### DIFF
--- a/clang/include/clang/Basic/IdentifierTable.h
+++ b/clang/include/clang/Basic/IdentifierTable.h
@@ -74,20 +74,14 @@ enum TokenKey : unsigned {
   KEYSYCL = 0x800000,
   KEYCUDA = 0x1000000,
   KEYZOS = 0x2000000,
-  // 0x4000000 was KEYNOZOS, which was unused. The value is kept reserved
-  // so that KEYALL's bit-mask computation remains correct: keywords like
-  // 'volatile' (KEYALL|KEYNOHLSL) go through the per-bit loop in
-  // getKeywordStatus, and every bit set in KEYALL must map to a valid
-  // TokenKey with a handler in getKeywordStatusHelper.
-  KEYHLSL = 0x8000000,
-  KEYFIXEDPOINT = 0x10000000,
-  KEYDEFERTS = 0x20000000,
-  KEYNOHLSL = 0x40000000,
+  KEYHLSL = 0x4000000,
+  KEYFIXEDPOINT = 0x8000000,
+  KEYDEFERTS = 0x10000000,
+  KEYNOHLSL = 0x20000000,
   KEYMAX = KEYNOHLSL, // The maximum key
   KEYALLCXX = KEYCXX | KEYCXX11 | KEYCXX20,
-  KEYALL = (KEYMAX | (KEYMAX - 1)) & ~KEYNOMS18 & ~KEYNOOPENCL & ~0x4000000u &
-           ~KEYNOHLSL // KEYNOMS18, KEYNOOPENCL, 0x4000000 (reserved),
-                      // KEYNOHLSL excluded.
+  KEYALL = (KEYMAX | (KEYMAX - 1)) & ~KEYNOMS18 & ~KEYNOOPENCL &
+           ~KEYNOHLSL // KEYNOMS18, KEYNOOPENCL, KEYNOHLSL excluded.
 };
 
 /// How a keyword is treated in the selected standard. This enum is ordered


### PR DESCRIPTION
The previous commit (#207132) removed the unused KEYNOZOS flag (0x4000000) but left a gap between KEYZOS (0x2000000) and KEYHLSL (0x8000000). This patch renumbers the subsequent TokenKey values to close the gap:

  KEYHLSL:       0x8000000  -> 0x4000000
  KEYFIXEDPOINT: 0x10000000 -> 0x8000000
  KEYDEFERTS:    0x20000000 -> 0x10000000
  KEYNOHLSL:     0x40000000 -> 0x20000000

The ~0x4000000u exclusion in KEYALL and the associated reserved-bit comment are removed, since the renumbering eliminates the orphaned bit.

This is a follow-up to #207132, as suggested by @perry-ca.

AI assistance was used for code review analysis and CI failure debugging.