### PR TITLE
[libc] Add auxiliary vector and note macros to elf.h

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -539,6 +539,7 @@ add_header_macro(
   elf.h
   DEPENDS
     .llvm-libc-macros.elf_macros
+    .llvm-libc-macros.sys_auxv_macros
     .llvm-libc-types.Elf32_Addr
     .llvm-libc-types.Elf32_Chdr
     .llvm-libc-types.Elf32_Dyn

--- a/libc/include/elf.yaml
+++ b/libc/include/elf.yaml
@@ -430,18 +430,42 @@ macros:
   - macro_name: DF_STATIC_TLS
     macro_value: '0x10'
   # Notes used in ET_CORE.
+  - macro_name: NN_PRSTATUS
+    macro_value: '"CORE"'
   - macro_name: NT_PRSTATUS
     macro_value: 1
+  - macro_name: NN_PRFPREG
+    macro_value: '"CORE"'
   - macro_name: NT_PRFPREG
     macro_value: 2
+  - macro_name: NT_FPREGSET
+    macro_value: 2
+  - macro_name: NN_PRPSINFO
+    macro_value: '"CORE"'
   - macro_name: NT_PRPSINFO
     macro_value: 3
+  - macro_name: NN_TASKSTRUCT
+    macro_value: '"CORE"'
   - macro_name: NT_TASKSTRUCT
+    macro_value: 4
+  - macro_name: NT_PRXREG
     macro_value: 4
   - macro_name: NT_PLATFORM
     macro_value: 5
+  - macro_name: NN_AUXV
+    macro_value: '"CORE"'
   - macro_name: NT_AUXV
     macro_value: 6
+  - macro_name: NN_SIGINFO
+    macro_value: '"CORE"'
+  - macro_name: NT_SIGINFO
+    macro_value: '0x53494749'
+  - macro_name: NN_FILE
+    macro_value: '"CORE"'
+  - macro_name: NT_FILE
+    macro_value: '0x46494c45'
+  - macro_name: NT_PRFPXREG
+    macro_value: 20
   # Notes used by GNU toolchain.
   - macro_name: NT_GNU_ABI_TAG
     macro_value: 1
@@ -524,6 +548,74 @@ macros:
     macro_header: elf-macros.h
   - macro_name: ELF64_R_INFO
     macro_header: elf-macros.h
+  - macro_name: PT_AARCH64_MEMTAG_MTE
+    macro_value: '0x70000002'
+  - macro_name: PN_XNUM
+    macro_value: '0xffff'
+  - macro_name: ELFCLASSNUM
+    macro_value: 3
+  - macro_name: EV_NUM
+    macro_value: 2
+  - macro_name: AT_NULL
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_IGNORE
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_EXECFD
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_PHDR
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_PHENT
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_PHNUM
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_PAGESZ
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_BASE
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_FLAGS
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_ENTRY
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_NOTELF
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_UID
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_EUID
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_GID
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_EGID
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_PLATFORM
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_HWCAP
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_CLKTCK
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_SECURE
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_BASE_PLATFORM
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_RANDOM
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_HWCAP2
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_RSEQ_FEATURE_SIZE
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_RSEQ_ALIGN
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_HWCAP3
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_HWCAP4
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_EXECFN
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_SYSINFO
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_SYSINFO_EHDR
+    macro_header: sys-auxv-macros.h
+  - macro_name: AT_MINSIGSTKSZ
+    macro_header: sys-auxv-macros.h
 types:
   - type_name: Elf32_Addr
   - type_name: Elf32_Chdr

--- a/libc/include/llvm-libc-macros/sys-auxv-macros.h
+++ b/libc/include/llvm-libc-macros/sys-auxv-macros.h
@@ -33,6 +33,8 @@
 #define AT_BASE_PLATFORM 24
 #define AT_RANDOM 25
 #define AT_HWCAP2 26
+#define AT_RSEQ_FEATURE_SIZE 27
+#define AT_RSEQ_ALIGN 28
 #define AT_HWCAP3 29
 #define AT_HWCAP4 30
 


### PR DESCRIPTION
Added missing macros to elf.h:

* sys-auxv-macros.h: Added AT_RSEQ_FEATURE_SIZE and AT_RSEQ_ALIGN.
* elf.yaml: Added PT_AARCH64_MEMTAG_MTE, PN_XNUM, ELFCLASSNUM, EV_NUM, and AT_* macros (via sys-auxv-macros.h). Also added NN_* and NT_* note macros (including NT_FPREGSET and NT_SIGINFO) to match system headers.
* CMakeLists.txt: Added sys_auxv_macros dependency to elf target.

Assisted-by: Automated tooling, human reviewed.