### PR TITLE
[Clang] Fix null-pointer assertion reading CtorClosureDefaultArgs

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -2345,7 +2345,7 @@ void ASTDeclReader::VisitCXXConstructorDecl(CXXConstructorDecl *D) {
     CXXDefaultArgExpr **Args =
         new (Reader.getContext()) CXXDefaultArgExpr *[NumArgs];
     for (unsigned I = 0; I != NumArgs; I++)
-      Args[I] = cast<CXXDefaultArgExpr>(Record.readStmt());
+      Args[I] = cast_or_null<CXXDefaultArgExpr>(Record.readStmt());
     D->setCtorClosureDefaultArgs(ArrayRef(Args, NumArgs));
   }
 

--- a/clang/test/PCH/dllexport-ctor-closure-copy.cpp
+++ b/clang/test/PCH/dllexport-ctor-closure-copy.cpp
@@ -9,7 +9,7 @@
 //
 // Test with pch.
 // #207949: this cannot check for ??_ODefault copy-ctor closure:
-// ASTContext::CopyConstructorForExceptionObject is serialized into the PCH.
+// ASTContext::CopyConstructorForExceptionObject is not serialized into the PCH.
 // RUN: %clang_cc1 -fcxx-exceptions -fms-extensions -triple i386-pc-win32 -std=c++20 -emit-pch -o %t %s
 // RUN: %clang_cc1 -fcxx-exceptions -fms-extensions -triple i386-pc-win32 -std=c++20 -include-pch %t -emit-llvm -o - %s | FileCheck %s
 

--- a/clang/test/PCH/dllexport-ctor-closure-copy.cpp
+++ b/clang/test/PCH/dllexport-ctor-closure-copy.cpp
@@ -5,9 +5,11 @@
 // that argument).
 //
 // Test this without pch.
-// RUN: %clang_cc1 -fcxx-exceptions -fms-extensions -triple i386-pc-win32 -std=c++20 -include %s -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -fcxx-exceptions -fms-extensions -triple i386-pc-win32 -std=c++20 -include %s -emit-llvm -o - %s | FileCheck --check-prefixes=CHECK,CHECK-NOPCH %s
 //
 // Test with pch.
+// #207949: this cannot check for ??_ODefault copy-ctor closure:
+// ASTContext::CopyConstructorForExceptionObject is serialized into the PCH.
 // RUN: %clang_cc1 -fcxx-exceptions -fms-extensions -triple i386-pc-win32 -std=c++20 -emit-pch -o %t %s
 // RUN: %clang_cc1 -fcxx-exceptions -fms-extensions -triple i386-pc-win32 -std=c++20 -include-pch %t -emit-llvm -o - %s | FileCheck %s
 
@@ -23,6 +25,8 @@ void h(Default &d) {
 }
 
 // CHECK-LABEL: define {{.*}} void @"?h@@YAXAAUDefault@@@Z"
+// CHECK-NOPCH-LABEL: define linkonce_odr {{.*}} void @"??_ODefault@@QAEXAAU0@@Z"
+// CHECK-NOPCH: call {{.*}} @"??0Default@@QAE@AAU0@H@Z"({{.*}}, i32 noundef 42)
 
 #else
 

--- a/clang/test/PCH/dllexport-ctor-closure-copy.cpp
+++ b/clang/test/PCH/dllexport-ctor-closure-copy.cpp
@@ -1,0 +1,29 @@
+// Test that MS ABI copy-constructor closures (built when throwing a class by
+// value whose copy constructor has default arguments) survive a PCH
+// round-trip. BuildCtorClosureDefaultArgs deliberately leaves the first
+// default-arg slot null for a copy ctor closure (the closure itself supplies
+// that argument).
+//
+// Test this without pch.
+// RUN: %clang_cc1 -fcxx-exceptions -fms-extensions -triple i386-pc-win32 -std=c++20 -include %s -emit-llvm -o - %s | FileCheck %s
+//
+// Test with pch.
+// RUN: %clang_cc1 -fcxx-exceptions -fms-extensions -triple i386-pc-win32 -std=c++20 -emit-pch -o %t %s
+// RUN: %clang_cc1 -fcxx-exceptions -fms-extensions -triple i386-pc-win32 -std=c++20 -include-pch %t -emit-llvm -o - %s | FileCheck %s
+
+#ifndef HEADER
+#define HEADER
+
+struct Default {
+  Default(Default &, int = 42);
+};
+
+void h(Default &d) {
+  throw d;
+}
+
+// CHECK-LABEL: define {{.*}} void @"?h@@YAXAAUDefault@@@Z"
+
+#else
+
+#endif


### PR DESCRIPTION
BuildCtorClosureDefaultArgs deliberately leaves the first default-arg slot null for MS ABI copy-constructor closures (the closure itself supplies that argument), and ASTWriterDecl.cpp serializes the null. But e7924d50db0a deserialized it with cast<>, which asserts on null. This only triggers under the MS C++ ABI, e.g. when throwing a class with a non-trivial copy constructor by value across a PCH boundary, as in test
https://github.com/intel/llvm/blob/cb9b7b7/clang-tools-extra/clangd/test/sycl.test

Assisted by: Claude