### PR TITLE
[Support] Teach llvm::thread about thread-id handling in LLVM-libc.

### DIFF
--- a/llvm/include/llvm/Support/thread.h
+++ b/llvm/include/llvm/Support/thread.h
@@ -51,7 +51,9 @@ class thread {
 public:
 #ifdef LLVM_ON_UNIX
   using native_handle_type = pthread_t;
-#ifdef __MVS__
+#if defined(__LLVM_LIBC__)
+  using id = pthread_id_np_t;
+#elif defined(__MVS__)
   using id = unsigned long long;
 #else
   using id = pthread_t;

--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -115,7 +115,14 @@ void llvm_thread_join_impl(pthread_t Thread) {
 }
 
 llvm::thread::id llvm_thread_get_id_impl(pthread_t Thread) {
-#ifdef __MVS__
+#if defined(__LLVM_LIBC__)
+  llvm::thread::id Id;
+  int errnum;
+  if ((errnum = ::pthread_getunique_np(&Thread, &Id)) != 0) {
+    ReportErrnumFatal("pthread_getunique_np failed", errnum);
+  }
+  return Id;
+#elif defined(__MVS__)
   return Thread.__;
 #else
   return Thread;
@@ -123,7 +130,11 @@ llvm::thread::id llvm_thread_get_id_impl(pthread_t Thread) {
 }
 
 llvm::thread::id llvm_thread_get_current_id_impl() {
+#if defined(__LLVM_LIBC__)
+  return ::pthread_getthreadid_np();
+#else
   return llvm_thread_get_id_impl(::pthread_self());
+#endif
 }
 
 } // namespace llvm


### PR DESCRIPTION
This PR matches the libc++ update from https://github.com/llvm/llvm-project/pull/198595 and applies similar changes to `llvm::thread` class. Please see the discussion in that PR (and linked references to other PRs) for more background / discussions.

`llvm::thread` has methods for extracting integer IDs from running threads, and as such it needs to know what types are used to represent those integer IDs - something that e.g. pthreads or C11 threads don't specify. It assumes that `pthread_t` can be used both as a handle and as a thread-id on most platforms, with the exception of zOS, where the custom code is written. In LLVM-libc `pthread_t` is not an integral type, but today it provides `pthread_id_np_t` type and `pthread_getunique_np` / `pthread_getthreadid_np` methods as extensions to extract the integer IDs. Use these methods when building against LLVM-libc.

This is one of few remaining blockers for building LLVM+Clang on top of LLVM-libc (https://github.com/llvm/llvm-project/issues/97191).