### PR TITLE
[AMDGPU] Employ MemorySSA when rewriting out arguments (NFCI)

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteOutArguments.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteOutArguments.cpp
@@ -44,7 +44,8 @@
 #include "AMDGPU.h"
 #include "Utils/AMDGPUBaseInfo.h"
 #include "llvm/ADT/Statistic.h"
-#include "llvm/Analysis/MemoryDependenceAnalysis.h"
+#include "llvm/Analysis/MemorySSA.h"
+#include "llvm/Analysis/MemorySSAUpdater.h"
 #include "llvm/IR/AttributeMask.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
@@ -81,7 +82,9 @@ namespace {
 class AMDGPURewriteOutArguments : public FunctionPass {
 private:
   const DataLayout *DL = nullptr;
-  MemoryDependenceResults *MDA = nullptr;
+  MemorySSA *MSSA = nullptr;
+  MemorySSAUpdater *MSSAU = nullptr;
+  AAResults *AA = nullptr;
 
   Type *getStoredType(Value &Arg) const;
   Type *getOutArgumentType(Argument &Arg) const;
@@ -92,7 +95,8 @@ public:
   AMDGPURewriteOutArguments() : FunctionPass(ID) {}
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
-    AU.addRequired<MemoryDependenceWrapperPass>();
+    AU.addRequired<MemorySSAWrapperPass>();
+    AU.addRequired<AAResultsWrapperPass>();
     FunctionPass::getAnalysisUsage(AU);
   }
 
@@ -104,7 +108,7 @@ public:
 
 INITIALIZE_PASS_BEGIN(AMDGPURewriteOutArguments, DEBUG_TYPE,
                       "AMDGPU Rewrite Out Arguments", false, false)
-INITIALIZE_PASS_DEPENDENCY(MemoryDependenceWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(MemorySSAWrapperPass)
 INITIALIZE_PASS_END(AMDGPURewriteOutArguments, DEBUG_TYPE,
                     "AMDGPU Rewrite Out Arguments", false, false)
 
@@ -170,6 +174,49 @@ bool AMDGPURewriteOutArguments::doInitialization(Module &M) {
   return false;
 }
 
+static StoreInst *findStoreForOutArgument(BasicBlock *BB, Argument *OutArg,
+                                          MemorySSA &MSSA,
+                                          BatchAAResults &BAA) {
+  MemoryLocation ArgLoc = MemoryLocation::getBeforeOrAfter(OutArg);
+  const auto *Accesses = MSSA.getBlockAccesses(BB);
+  if (!Accesses)
+    return nullptr;
+
+  for (const MemoryAccess &Access : reverse(*Accesses)) {
+    const auto *UseOrDef = dyn_cast<MemoryUseOrDef>(&Access);
+    if (!UseOrDef)
+      continue;
+
+    Instruction *I = UseOrDef->getMemoryInst();
+
+    // Return the must-alias store to the out argument.
+    if (auto *Store = dyn_cast<StoreInst>(I))
+      if (Store->getPointerOperand() == OutArg)
+        return Store;
+
+    if (auto *FI = dyn_cast<FenceInst>(I))
+      if (FI->getOrdering() == AtomicOrdering::Release)
+        continue;
+
+    if (auto *LI = dyn_cast<LoadInst>(I)) {
+      if (LI->isAtomic()) {
+        // May-alias reads with monotonic ordering are ignored.
+        if (isStrongerThan(LI->getOrdering(), AtomicOrdering::Monotonic))
+          return nullptr;
+        continue;
+      }
+    }
+
+    // Any other memory access that writes the location prevents the
+    // rewrite.
+    // FIXME: should handle aliasing reads too.
+    if (isModSet(BAA.getModRefInfo(I, ArgLoc)))
+      return nullptr;
+  }
+
+  return nullptr;
+}
+
 bool AMDGPURewriteOutArguments::runOnFunction(Function &F) {
   if (skipFunction(F))
     return false;
@@ -178,8 +225,6 @@ bool AMDGPURewriteOutArguments::runOnFunction(Function &F) {
   if (F.isVarArg() || F.hasStructRetAttr() ||
       AMDGPU::isEntryFunctionCC(F.getCallingConv()))
     return false;
-
-  MDA = &getAnalysis<MemoryDependenceWrapperPass>().getMemDep();
 
   unsigned ReturnNumRegs = 0;
   // Maps an out-argument number to its field index in the return struct.
@@ -222,6 +267,13 @@ bool AMDGPURewriteOutArguments::runOnFunction(Function &F) {
   if (Returns.empty())
     return false;
 
+  AA = &getAnalysis<AAResultsWrapperPass>().getAAResults();
+  MSSA = &getAnalysis<MemorySSAWrapperPass>().getMSSA();
+
+  BatchAAResults BatchAA(*AA);
+  MemorySSAUpdater MSSAUpdater(MSSA);
+  MSSAU = &MSSAUpdater;
+
   bool Changing;
 
   do {
@@ -254,17 +306,7 @@ bool AMDGPURewriteOutArguments::runOnFunction(Function &F) {
       for (ReturnInst *RI : Returns) {
         BasicBlock *BB = RI->getParent();
 
-        MemDepResult Q = MDA->getPointerDependencyFrom(
-            MemoryLocation::getBeforeOrAfter(OutArg), true, BB->end(), BB, RI);
-        StoreInst *SI = nullptr;
-        if (Q.isDef())
-          SI = dyn_cast<StoreInst>(Q.getInst());
-
-        // MDA stops at the first may-aliasing store, which need not be to this
-        // argument; only fold a store whose pointer is exactly OutArg.
-        if (SI && SI->getPointerOperand() != OutArg)
-          SI = nullptr;
-
+        StoreInst *SI = findStoreForOutArgument(BB, OutArg, *MSSA, BatchAA);
         if (SI) {
           LLVM_DEBUG(dbgs() << "Found out argument store: " << *SI << '\n');
           ReplaceableStores.emplace_back(RI, SI);
@@ -291,6 +333,7 @@ bool AMDGPURewriteOutArguments::runOnFunction(Function &F) {
         }
 
         ValVec.emplace_back(OutArg, ReplVal);
+        MSSAU->removeMemoryAccess(Store.second);
         Store.second->eraseFromParent();
       }
 


### PR DESCRIPTION
While transitioning away from MemoryDependenceAnalysis, replace MDA `getPointerDependencyFrom` query with a reverse traversal of the memory accesses of the return basic block (MemoryDefs and MemoryUses), looking for the must-aliasing store to the out argument. The existing behaviour is meant to be preserved.

---

Unlike MemorySSA APIs, MDA getPointerDependencyFrom() takes a QueryInst as its last argument, which, among other things, is used when deciding whether an intervening atomic load may be a dependency. In our case, QueryInst is always a return instruction, which doesn’t read or write memory; thus, atomic loads with monotonic ordering are treated as non-clobbering wrt the out argument, per the following logic:

https://github.com/llvm/llvm-project/blob/0075a8fbcc9928ef5a04a30233b08f67219a4310/llvm/lib/Analysis/MemoryDependenceAnalysis.cpp#L492-L499

Besides, may-alias reads are also walked past, since getPointerDependencyFrom() `isLoad` parameter is set. Conversely, MSSA (via AA) is more conservative and says ModRef for any load stronger than unordered (regardless of query context):  

https://github.com/llvm/llvm-project/blob/2cbaca8fe5f33069d764c6cada16ea4305a6efc5/llvm/lib/Analysis/AliasAnalysis.cpp#L502-L504


Hence the dedicated handling for atomic loads and fences to preserve the behavior.

The precommitted tests extend coverage for these paths, although I'm unclear whether they occur in practice or map cleanly to AMDGPU semantics (at least, they seem to preserve equivalence for now).

An alternative (simpler) approach would be a backward scan of BB looking for the last store to the out argument:   https://github.com/antoniofrighetto/llvm-project/commit/bfd8550bae7356857ec9983a9f595314d954e5ad.

Left a TODO in the code as I’m also unsure whether the pass is (meant to be) semantics-preserving. In the following case: https://llvm.godbolt.org/z/7fP35jfsx, when both arguments passed to `@callee` alias the same slot, `%out` ends up holding 0 in the original program. After the rewrite, the store into `%val` has been sunk past the load in the stub, thus `%other` observes the pre-call value and `%out` ends up holding 1.

@arsenm Does this make sense?