### PR TITLE
[NFC][SPIRV] Remove dead helper `addStringImm(const StringRef &Str, IRBuilder<> &B, std::vector<Value *> &Args)`

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -187,15 +187,6 @@ void addStringImm(const StringRef &Str, MachineInstrBuilder &MIB) {
   }
 }
 
-void addStringImm(const StringRef &Str, IRBuilder<> &B,
-                  std::vector<Value *> &Args) {
-  const size_t PaddedLen = getPaddedLen(Str);
-  for (unsigned i = 0; i < PaddedLen; i += 4) {
-    // Add a vector element for the 32-bits of chars or padding.
-    Args.push_back(B.getInt32(convertCharsToWord(Str, i)));
-  }
-}
-
 std::string getStringImm(const MachineInstr &MI, unsigned StartIndex) {
   return getSPIRVStringOperand(MI, StartIndex);
 }

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -177,8 +177,6 @@ StringRef getOriginalAsmConstraints(const CallBase &CB);
 // little-endian words.
 void addStringImm(const StringRef &Str, MCInst &Inst);
 void addStringImm(const StringRef &Str, MachineInstrBuilder &MIB);
-void addStringImm(const StringRef &Str, IRBuilder<> &B,
-                  std::vector<Value *> &Args);
 
 // Read the series of integer operands back as a null-terminated string using
 // the reverse of the logic in addStringImm.


### PR DESCRIPTION
The helper was unused.