### PR TITLE
[AMDGPU] Save entry EXEC in whole-wave prologue with no WWM spills

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
@@ -1268,8 +1268,12 @@ void SIFrameLowering::emitCSRSpillStores(
   StoreWWMRegisters(WWMCalleeSavedRegs);
   if (FuncInfo->isWholeWaveFunction()) {
     // If we have already saved some WWM CSR registers, then the EXEC is already
-    // -1 and we don't need to do anything else. Otherwise, set EXEC to -1 here.
-    if (!ScratchExecCopy || WWMCalleeSavedRegs.empty())
+    // -1 and we don't need to do anything else. Otherwise, save the original
+    // EXEC into the setup register and set EXEC to -1 here.
+    if (!ScratchExecCopy)
+      buildScratchExecCopy(LiveUnits, MF, MBB, MBBI, DL, /*IsProlog*/ true,
+                           /*EnableInactiveLanes*/ false);
+    else if (WWMCalleeSavedRegs.empty())
       EnableAllLanes();
   } else if (ScratchExecCopy) {
     // FIXME: Split block and make terminator.

--- a/llvm/test/CodeGen/AMDGPU/whole-wave-functions-pei.mir
+++ b/llvm/test/CodeGen/AMDGPU/whole-wave-functions-pei.mir
@@ -416,7 +416,7 @@ body:             |
     ; CHECK-NEXT: frame-setup CFI_INSTRUCTION llvm_def_aspace_cfa $sgpr32, 0, 6
     ; CHECK-NEXT: frame-setup CFI_INSTRUCTION llvm_register_pair $pc_reg, $sgpr30, 32, $sgpr31, 32
     ; CHECK-NEXT: frame-setup CFI_INSTRUCTION undefined $sgpr0
-    ; CHECK-NEXT: $exec_lo = S_MOV_B32 -1
+    ; CHECK-NEXT: $sgpr0 = S_OR_SAVEEXEC_B32 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
     ; CHECK-NEXT: S_NOP 0, implicit $vgpr0, implicit $vgpr20, implicit $vgpr40
     ; CHECK-NEXT: $exec_lo = S_MOV_B32 $sgpr0
     ; CHECK-NEXT: SI_RETURN implicit killed $vgpr0

--- a/llvm/test/CodeGen/AMDGPU/whole-wave-functions.ll
+++ b/llvm/test/CodeGen/AMDGPU/whole-wave-functions.ll
@@ -779,7 +779,7 @@ define amdgpu_gfx_whole_wave void @realign_stack(i1 %active, i32 %x) #0 {
 ; DAGISEL-NEXT:    s_add_co_i32 s33, s32, 0x3ff
 ; DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; DAGISEL-NEXT:    s_and_b32 s33, s33, 0xfffffc00
-; DAGISEL-NEXT:    s_mov_b32 exec_lo, -1
+; DAGISEL-NEXT:    s_or_saveexec_b32 s0, -1
 ; DAGISEL-NEXT:    s_mov_b32 s2, s34
 ; DAGISEL-NEXT:    s_mov_b32 s34, s32
 ; DAGISEL-NEXT:    s_addk_co_i32 s32, 0x800
@@ -805,7 +805,7 @@ define amdgpu_gfx_whole_wave void @realign_stack(i1 %active, i32 %x) #0 {
 ; GISEL-NEXT:    s_add_co_i32 s33, s32, 0x3ff
 ; GISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GISEL-NEXT:    s_and_b32 s33, s33, 0xfffffc00
-; GISEL-NEXT:    s_mov_b32 exec_lo, -1
+; GISEL-NEXT:    s_or_saveexec_b32 s0, -1
 ; GISEL-NEXT:    s_mov_b32 s2, s34
 ; GISEL-NEXT:    s_mov_b32 s34, s32
 ; GISEL-NEXT:    s_addk_co_i32 s32, 0x800
@@ -831,7 +831,7 @@ define amdgpu_gfx_whole_wave void @realign_stack(i1 %active, i32 %x) #0 {
 ; DAGISEL64-NEXT:    s_add_co_i32 s33, s32, 0x3ff
 ; DAGISEL64-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; DAGISEL64-NEXT:    s_and_b32 s33, s33, 0xfffffc00
-; DAGISEL64-NEXT:    s_mov_b64 exec, -1
+; DAGISEL64-NEXT:    s_or_saveexec_b64 s[0:1], -1
 ; DAGISEL64-NEXT:    s_mov_b32 s3, s34
 ; DAGISEL64-NEXT:    s_mov_b32 s34, s32
 ; DAGISEL64-NEXT:    s_addk_co_i32 s32, 0x800
@@ -857,7 +857,7 @@ define amdgpu_gfx_whole_wave void @realign_stack(i1 %active, i32 %x) #0 {
 ; GISEL64-NEXT:    s_add_co_i32 s33, s32, 0x3ff
 ; GISEL64-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GISEL64-NEXT:    s_and_b32 s33, s33, 0xfffffc00
-; GISEL64-NEXT:    s_mov_b64 exec, -1
+; GISEL64-NEXT:    s_or_saveexec_b64 s[0:1], -1
 ; GISEL64-NEXT:    s_mov_b32 s3, s34
 ; GISEL64-NEXT:    s_mov_b32 s34, s32
 ; GISEL64-NEXT:    s_addk_co_i32 s32, 0x800
@@ -880,7 +880,7 @@ define amdgpu_gfx_whole_wave void @realign_stack(i1 %active, i32 %x) #0 {
 ; GFX1250-DAGISEL-NEXT:    s_add_co_i32 s33, s32, 0x3ff
 ; GFX1250-DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX1250-DAGISEL-NEXT:    s_and_b32 s33, s33, 0xfffffc00
-; GFX1250-DAGISEL-NEXT:    s_mov_b32 exec_lo, -1
+; GFX1250-DAGISEL-NEXT:    s_or_saveexec_b32 s0, -1
 ; GFX1250-DAGISEL-NEXT:    s_mov_b32 s2, s34
 ; GFX1250-DAGISEL-NEXT:    s_mov_b32 s34, s32
 ; GFX1250-DAGISEL-NEXT:    s_addk_co_i32 s32, 0x800


### PR DESCRIPTION
PR #207781 replaced the prologue S_XOR_SAVEEXEC (which set EXEC to ~entryEXEC) with a plain S_MOV EXEC, -1, but dropped the save of the entry EXEC that the return restores from, leaving an undefined register read

se S_OR_SAVEEXEC to both save entry EXEC and set EXEC to -1