### PR TITLE
[InstCombine] Fold sub of sign-mask complemented or

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -2601,6 +2601,16 @@ Instruction *InstCombinerImpl::visitSub(BinaryOperator &I) {
     if (match(Op1, m_Not(m_Value(X))))
       return BinaryOperator::CreateAdd(X, InstCombiner::AddOne(C));
 
+    Constant *C2;
+    if (!I.hasNoUnsignedWrap() && !I.hasNoSignedWrap() && Op1->hasOneUse() &&
+        match(Op1, m_c_Or(m_Value(X), m_ImmConstant(C2))) &&
+        C2->isElementWiseEqual(C)) {
+      Constant *NotC = ConstantExpr::getNot(C2);
+      // If C is signed max, then C - (X | C) is just the sign bit of X.
+      if (match(NotC, m_SignMask()))
+        return BinaryOperator::CreateAnd(X, NotC);
+    }
+
     // Try to fold constant sub into select arguments.
     if (SelectInst *SI = dyn_cast<SelectInst>(Op1))
       if (Instruction *R = FoldOpIntoSelect(I, SI))
@@ -2610,8 +2620,6 @@ Instruction *InstCombinerImpl::visitSub(BinaryOperator &I) {
     if (PHINode *PN = dyn_cast<PHINode>(Op1))
       if (Instruction *R = foldOpIntoPhi(I, PN))
         return R;
-
-    Constant *C2;
 
     // C-(C2-X) --> X+(C-C2)
     if (match(Op1, m_Sub(m_ImmConstant(C2), m_Value(X))))

--- a/llvm/test/Transforms/InstCombine/sub.ll
+++ b/llvm/test/Transforms/InstCombine/sub.ll
@@ -2948,3 +2948,90 @@ define i32 @sub_const_or_no_disjoint(i32 %x) {
   %r = sub i32 100, %a
   ret i32 %r
 }
+
+define i32 @sub_const_or_same_signmask_complement_i32(i32 %x) {
+; CHECK-LABEL: @sub_const_or_same_signmask_complement_i32(
+; CHECK-NEXT:    [[R:%.*]] = and i32 [[X:%.*]], -2147483648
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = or i32 %x, 2147483647
+  %r = sub i32 2147483647, %a
+  ret i32 %r
+}
+
+define i8 @sub_const_or_same_signmask_complement_i8(i8 %x) {
+; CHECK-LABEL: @sub_const_or_same_signmask_complement_i8(
+; CHECK-NEXT:    [[R:%.*]] = and i8 [[X:%.*]], -128
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %a = or i8 %x, 127
+  %r = sub i8 127, %a
+  ret i8 %r
+}
+
+define <2 x i32> @sub_const_or_same_signmask_complement_splat_vec(<2 x i32> %x) {
+; CHECK-LABEL: @sub_const_or_same_signmask_complement_splat_vec(
+; CHECK-NEXT:    [[R:%.*]] = and <2 x i32> [[X:%.*]], splat (i32 -2147483648)
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %a = or <2 x i32> %x, splat (i32 2147483647)
+  %r = sub <2 x i32> splat (i32 2147483647), %a
+  ret <2 x i32> %r
+}
+
+define i32 @sub_const_or_same_not_signmask(i32 %x) {
+; CHECK-LABEL: @sub_const_or_same_not_signmask(
+; CHECK-NEXT:    [[A:%.*]] = or i32 [[X:%.*]], 42
+; CHECK-NEXT:    [[R:%.*]] = sub i32 42, [[A]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = or i32 %x, 42
+  %r = sub i32 42, %a
+  ret i32 %r
+}
+
+define i32 @sub_const_or_different_constant(i32 %x) {
+; CHECK-LABEL: @sub_const_or_different_constant(
+; CHECK-NEXT:    [[A:%.*]] = or i32 [[X:%.*]], 2147483647
+; CHECK-NEXT:    [[R:%.*]] = sub nsw i32 2147483646, [[A]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = or i32 %x, 2147483647
+  %r = sub i32 2147483646, %a
+  ret i32 %r
+}
+
+define i8 @sub_const_or_same_extra_use(i8 %x) {
+; CHECK-LABEL: @sub_const_or_same_extra_use(
+; CHECK-NEXT:    [[A:%.*]] = or i8 [[X:%.*]], 127
+; CHECK-NEXT:    [[R:%.*]] = sub i8 127, [[A]]
+; CHECK-NEXT:    call void @use8(i8 [[A]])
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %a = or i8 %x, 127
+  %r = sub i8 127, %a
+  call void @use8(i8 %a)
+  ret i8 %r
+}
+
+define i8 @sub_nsw_const_or_same_signmask_complement(i8 %x) {
+; CHECK-LABEL: @sub_nsw_const_or_same_signmask_complement(
+; CHECK-NEXT:    [[A:%.*]] = or i8 [[X:%.*]], 127
+; CHECK-NEXT:    [[R:%.*]] = sub nsw i8 127, [[A]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %a = or i8 %x, 127
+  %r = sub nsw i8 127, %a
+  ret i8 %r
+}
+
+define i8 @sub_nuw_const_or_same_signmask_complement(i8 %x) {
+; CHECK-LABEL: @sub_nuw_const_or_same_signmask_complement(
+; CHECK-NEXT:    [[A:%.*]] = or i8 [[X:%.*]], 127
+; CHECK-NEXT:    [[R:%.*]] = sub nuw i8 127, [[A]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %a = or i8 %x, 127
+  %r = sub nuw i8 127, %a
+  ret i8 %r
+}


### PR DESCRIPTION
## Summary

Fold the profitable sign-bit case of:

```llvm
sub C, (or X, C)
```

When `~C` is a sign mask and the `or` has one use, this is equivalent to:

```llvm
and X, ~C
```

The general identity is `C - (X | C) == -(X & ~C)`. This patch intentionally
only handles the case where negating the masked value is an identity, avoiding a
broader same-cost `neg(and)` canonicalization.

The transform also rejects `nuw`/`nsw` subtraction. With nowrap flags, the
original `sub` may produce poison for sign-bit-set values, while the replacement
`and` would not.

Fixes #202249.

## Tests

Added InstCombine coverage for:

- the i32 issue pattern
- an i8 equivalent
- a vector splat equivalent
- non-sign-mask complement negative case
- different-constant negative case
- extra-use negative case
- `nsw` and `nuw` negative cases

Local verification:

```bash
ninja -C ../build -j20 opt
llvm/utils/update_test_checks.py --opt-binary ../build/bin/opt llvm/test/Transforms/InstCombine/sub.ll
../build/bin/llvm-lit -sv llvm/test/Transforms/InstCombine/sub.ll
../build/bin/llvm-lit -sv llvm/test/Transforms/InstCombine
git diff --check
```

## AI Tool Disclosure

Assisted-by: OpenAI Codex

Codex was used for code navigation, testcase exploration, implementation
drafting, and local verification command execution. I manually reviewed the
implementation, tests, and generated code before submission.
