### PR TITLE
[InstCombine] Fold one shifted by a boolean value

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
@@ -1334,6 +1334,16 @@ Instruction *InstCombinerImpl::visitShl(BinaryOperator &I) {
     }
   }
 
+  // 1 << X --> X + 1 if X is known to be 0 or 1. Require more than 2 bits so
+  // the new add can be marked nsw.
+  if (match(Op0, m_One()) && BitWidth > 2 &&
+      llvm::computeKnownBits(Op1, Q).countMaxActiveBits() <= 1) {
+    auto *Add = BinaryOperator::CreateAdd(Op1, Op0);
+    Add->setHasNoUnsignedWrap();
+    Add->setHasNoSignedWrap();
+    return Add;
+  }
+
   if (setShiftFlags(I, Q))
     return &I;
 

--- a/llvm/test/Transforms/InstCombine/shift.ll
+++ b/llvm/test/Transforms/InstCombine/shift.ll
@@ -2045,6 +2045,76 @@ define i32 @ashr_sdiv_extra_use(i32 %x) {
   ret i32 %r
 }
 
+define i32 @shl1_range01_assume(i32 %a) {
+; CHECK-LABEL: @shl1_range01_assume(
+; CHECK-NEXT:    [[COND:%.*]] = icmp ult i32 [[A:%.*]], 2
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    [[SHL:%.*]] = add nuw nsw i32 [[A]], 1
+; CHECK-NEXT:    ret i32 [[SHL]]
+;
+  %cond = icmp ult i32 %a, 2
+  call void @llvm.assume(i1 %cond)
+  %shl = shl i32 1, %a
+  ret i32 %shl
+}
+
+define i32 @shl1_range01_assume_flags(i32 %a) {
+; CHECK-LABEL: @shl1_range01_assume_flags(
+; CHECK-NEXT:    [[COND:%.*]] = icmp ult i32 [[A:%.*]], 2
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    [[SHL:%.*]] = add nuw nsw i32 [[A]], 1
+; CHECK-NEXT:    ret i32 [[SHL]]
+;
+  %cond = icmp ult i32 %a, 2
+  call void @llvm.assume(i1 %cond)
+  %shl = shl nuw nsw i32 1, %a
+  ret i32 %shl
+}
+
+define i8 @shl1_known01_mask(i8 %x) {
+; CHECK-LABEL: @shl1_known01_mask(
+; CHECK-NEXT:    [[AMT:%.*]] = and i8 [[X:%.*]], 1
+; CHECK-NEXT:    [[SHL:%.*]] = add nuw nsw i8 [[AMT]], 1
+; CHECK-NEXT:    ret i8 [[SHL]]
+;
+  %amt = and i8 %x, 1
+  %shl = shl i8 1, %amt
+  ret i8 %shl
+}
+
+define <2 x i8> @shl1_known01_mask_vec(<2 x i8> %x) {
+; CHECK-LABEL: @shl1_known01_mask_vec(
+; CHECK-NEXT:    [[AMT:%.*]] = and <2 x i8> [[X:%.*]], splat (i8 1)
+; CHECK-NEXT:    [[SHL:%.*]] = add nuw nsw <2 x i8> [[AMT]], splat (i8 1)
+; CHECK-NEXT:    ret <2 x i8> [[SHL]]
+;
+  %amt = and <2 x i8> %x, splat (i8 1)
+  %shl = shl <2 x i8> splat (i8 1), %amt
+  ret <2 x i8> %shl
+}
+
+define i2 @shl1_known01_i2(i2 %x) {
+; CHECK-LABEL: @shl1_known01_i2(
+; CHECK-NEXT:    [[AMT:%.*]] = and i2 [[X:%.*]], 1
+; CHECK-NEXT:    [[SHL:%.*]] = shl nuw i2 1, [[AMT]]
+; CHECK-NEXT:    ret i2 [[SHL]]
+;
+  %amt = and i2 %x, 1
+  %shl = shl i2 1, %amt
+  ret i2 %shl
+}
+
+define i8 @shl1_known03_mask(i8 %x) {
+; CHECK-LABEL: @shl1_known03_mask(
+; CHECK-NEXT:    [[AMT:%.*]] = and i8 [[X:%.*]], 3
+; CHECK-NEXT:    [[SHL:%.*]] = shl nuw nsw i8 1, [[AMT]]
+; CHECK-NEXT:    ret i8 [[SHL]]
+;
+  %amt = and i8 %x, 3
+  %shl = shl i8 1, %amt
+  ret i8 %shl
+}
+
 define i32 @shl1_cttz(i32 %x) {
 ; CHECK-LABEL: @shl1_cttz(
 ; CHECK-NEXT:    [[NEG:%.*]] = sub i32 0, [[X:%.*]]


### PR DESCRIPTION
## Summary

Fold:

```llvm
shl 1, X
```

to:

```llvm
add nuw nsw X, 1
```

when known bits prove that `X` is either 0 or 1 and the scalar element bitwidth
is greater than 2.

This handles cases where the 0/1 range comes from `llvm.assume`, as in
#206577, and cases where the shift amount is masked with `1`.

The bitwidth guard keeps the transform out of i1 and i2. i1 has shift-by-1
poison, and i2 cannot always represent `1 + 1` without signed overflow. With a
bitwidth greater than 2, the replacement add can be marked both `nuw` and `nsw`.

Fixes #206577.

## Tests

Added InstCombine coverage for:

- issue-style `llvm.assume(a < 2)` scalar case
- same case with original `shl nuw nsw`
- scalar mask-known 0/1 shift amount
- vector mask-known 0/1 shift amount
- i2 negative case
- known 0..3 negative case

Local verification:

```bash
ninja -C ../build -j20 opt
llvm/utils/update_test_checks.py --opt-binary ../build/bin/opt llvm/test/Transforms/InstCombine/shift.ll
../build/bin/llvm-lit -sv llvm/test/Transforms/InstCombine/shift.ll
../build/bin/llvm-lit -sv llvm/test/Transforms/InstCombine
git diff --check
```

## AI Tool Disclosure

Assisted-by: OpenAI Codex

Codex was used for code navigation, testcase exploration, implementation
drafting, and local verification command execution. I manually reviewed the
implementation, tests, and generated code before submission.
