### PR TITLE
[flang][MIF] Fix ucobounds given in mif.alloc_coarray #207858

### DIFF
--- a/flang/lib/Lower/MultiImageFortran.cpp
+++ b/flang/lib/Lower/MultiImageFortran.cpp
@@ -330,7 +330,7 @@ Fortran::lower::genUpperCoBounds(Fortran::lower::AbstractConverter &converter,
     ucobounds = builder.createTemporary(loc, arrayType);
     mlir::Value ucovalue;
     for (size_t i = 0; i < corank - 1; i++) {
-      if (auto ub = object->coshape()[i].lbound().GetExplicit()) {
+      if (auto ub = object->coshape()[i].ubound().GetExplicit()) {
         auto ubExpr = ignoreEvConvert(*ub);
         ucovalue = fir::getBase(converter.genExprValue(loc, ubExpr, stmtCtx));
       } else {


### PR DESCRIPTION
This PR provide a manior fix to issue #207858  when the `ucobound` array is passed to mif.alloc_coarray. This array was built from the values in `lcobound`.
