### PR TITLE
[SPIR-V] Avoid crash on malformed mangled builtin name length

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -586,10 +586,10 @@ std::string getOclOrSpirvBuiltinDemangledName(StringRef Name) {
     DemangledNameLenStart = NameSpaceStart + 11;
   }
   Start = Name.find_first_not_of("0123456789", DemangledNameLenStart);
-  [[maybe_unused]] bool Error =
-      Name.substr(DemangledNameLenStart, Start - DemangledNameLenStart)
-          .getAsInteger(10, Len);
-  assert(!Error && "Failed to parse demangled name length");
+  bool Error = Name.substr(DemangledNameLenStart, Start - DemangledNameLenStart)
+                   .getAsInteger(10, Len);
+  if (Error)
+    return std::string();
   return Name.substr(Start, Len).str();
 }
 

--- a/llvm/test/CodeGen/SPIRV/malformed-mangled-builtin-name.ll
+++ b/llvm/test/CodeGen/SPIRV/malformed-mangled-builtin-name.ll
@@ -1,0 +1,15 @@
+; A call target with a malformed mangled name must not crash the demangler.
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o /dev/null
+
+declare spir_func i64 @"_Z&3gmt_global_idj"(i32)
+
+define spir_kernel void @fuzz_kernel(ptr addrspace(1) %in, ptr addrspace(1) %out, i32 %n) {
+entry:
+  %id = call spir_func i64 @"_Z&3gmt_global_idj"(i32 0)
+  %idx = trunc i64 %id to i32
+  %gep = getelementptr i32, ptr addrspace(1) %in, i32 %idx
+  %v = load i32, ptr addrspace(1) %gep, align 4
+  store i32 %v, ptr addrspace(1) %out, align 4
+  ret void
+}


### PR DESCRIPTION
Replace the assert on invalid length parsing with a graceful bail-out since malformed names can potentially come from outside, it is not necessarily always an error

All usages of `getOclOrSpirvBuiltinDemangledName` are being checked for emptiness where it is needed anyway