### PR TITLE
[libcxxabi] Don't enable -fvisibility=hidden on Windows

### DIFF
--- a/libcxxabi/src/CMakeLists.txt
+++ b/libcxxabi/src/CMakeLists.txt
@@ -196,7 +196,11 @@ if (LIBCXXABI_SUPPORTS_SHARED_LIBRARY)
   # TODO(LLVM 21): This can be dropped once we only support Clang >= 19.
   target_add_compile_flags_if_supported(cxxabi_shared_objects PRIVATE -fsized-deallocation)
   if (NOT WIN32)
-    # We use dllexport on Windows, and that is mutually exclusive with visibility attributes.
+    # Building libcxxabi with -fvisibility=hidden on Windows, if dllexport is
+    # used, can trigger a Clang error (if Clang is built with asserts enabled),
+    # https://github.com/llvm/llvm-project/issues/207963
+    # Once fixed, we could consider allowing -fvisibility=hidden on
+    # Windows too (as it can be beneficial for static libraries).
     target_add_compile_flags_if_supported(cxxabi_shared_objects PRIVATE -fvisibility=hidden)
   endif()
 
@@ -290,7 +294,11 @@ target_compile_options(cxxabi_static_objects PRIVATE "${LIBCXXABI_ADDITIONAL_COM
 # TODO(LLVM 21): This can be dropped once we only support Clang >= 19.
 target_add_compile_flags_if_supported(cxxabi_static_objects PRIVATE -fsized-deallocation)
 if (NOT WIN32)
-  # We use dllexport on Windows, and that is mutually exclusive with visibility attributes.
+  # Building libcxxabi with -fvisibility=hidden on Windows, if dllexport is
+  # used, can trigger a Clang error (if Clang is built with asserts enabled),
+  # https://github.com/llvm/llvm-project/issues/207963
+  # Once fixed, we could consider allowing -fvisibility=hidden on
+  # Windows too (as it can be beneficial for static libraries).
   target_add_compile_flags_if_supported(cxxabi_static_objects PRIVATE -fvisibility=hidden)
 endif()
 

--- a/libcxxabi/src/CMakeLists.txt
+++ b/libcxxabi/src/CMakeLists.txt
@@ -195,7 +195,10 @@ if (LIBCXXABI_SUPPORTS_SHARED_LIBRARY)
   # Build with -fsized-deallocation, which is default in recent versions of Clang.
   # TODO(LLVM 21): This can be dropped once we only support Clang >= 19.
   target_add_compile_flags_if_supported(cxxabi_shared_objects PRIVATE -fsized-deallocation)
-  target_add_compile_flags_if_supported(cxxabi_shared_objects PRIVATE -fvisibility=hidden)
+  if (NOT WIN32)
+    # We use dllexport on Windows, and that is mutually exclusive with visibility attributes.
+    target_add_compile_flags_if_supported(cxxabi_shared_objects PRIVATE -fvisibility=hidden)
+  endif()
 
   add_library(cxxabi_shared SHARED)
   set_target_properties(cxxabi_shared
@@ -286,7 +289,10 @@ target_compile_options(cxxabi_static_objects PRIVATE "${LIBCXXABI_ADDITIONAL_COM
 # Build with -fsized-deallocation, which is default in recent versions of Clang.
 # TODO(LLVM 21): This can be dropped once we only support Clang >= 19.
 target_add_compile_flags_if_supported(cxxabi_static_objects PRIVATE -fsized-deallocation)
-target_add_compile_flags_if_supported(cxxabi_static_objects PRIVATE -fvisibility=hidden)
+if (NOT WIN32)
+  # We use dllexport on Windows, and that is mutually exclusive with visibility attributes.
+  target_add_compile_flags_if_supported(cxxabi_static_objects PRIVATE -fvisibility=hidden)
+endif()
 
 if(LIBCXXABI_HERMETIC_STATIC_LIBRARY)
   # If the hermetic library doesn't define the operator new/delete functions


### PR DESCRIPTION
This option is supported (and hence gets added by the target_add_compile_flags_if_supported function) on Windows, but if using dllexport, there's no point in using hidden visibility. (However if building both static and shared libraries at the same time, it could be beneficial to have hidden visibilty in the static libraries.)

In asserts enabled builds of Clang, building with -fvisibility=hidden caused errors like this:

    dllexport GlobalValue must have default or protected visibility
    ptr @_ZTIv
    [...]
    fatal error: error in backend: Broken module found, compilation aborted!

Normally, combining -fvisibility=hidden with dllexport is not a problem, but specifically for `__cxxabiv1:: __fundamental_type_info` it does make Clang trigger an inconsistency, visible in asserts enabled builds of Clang - see https://github.com/llvm/llvm-project/issues/207963.

This fixes Windows builds with Clang with asserts enabled, after cb942d009a5ed029ce20d9b75b3604f551f0cb56.