### PR TITLE
[clang][bytecode] Fix getting typeid pointers of struct fields

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -2744,7 +2744,7 @@ bool GetTypeidPtr(InterpState &S, CodePtr OpPC, const Type *TypeInfoType) {
   }
 
   // Pick the most-derived type.
-  CanQualType T = P.getDeclPtr().getType()->getCanonicalTypeUnqualified();
+  CanQualType T = P.stripBaseCasts().getType()->getCanonicalTypeUnqualified();
   // ... unless we're currently constructing this object.
   // FIXME: We have a similar check to this in more places.
   if (S.Current->getFunction()) {

--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -801,7 +801,7 @@ bool Pointer::hasSameBase(const Pointer &A, const Pointer &B) {
   if (A.isFunctionPointer() && B.isFunctionPointer())
     return true;
   if (A.isTypeidPointer() && B.isTypeidPointer())
-    return true;
+    return A.asTypeidPointer().TypePtr == B.asTypeidPointer().TypePtr;
 
   if (A.StorageKind != B.StorageKind)
     return false;

--- a/clang/test/AST/ByteCode/typeid.cpp
+++ b/clang/test/AST/ByteCode/typeid.cpp
@@ -93,3 +93,16 @@ namespace MissingInitalizer {
   constexpr auto &x = items[0].ti; // both-error {{must be initialized by a constant expression}} \
                                    // both-note {{initializer of 'items' is unknown}}
 }
+
+namespace TypeIdInOtherStruct {
+  struct X {
+    virtual constexpr ~X() {}
+  };
+  struct Y : X {};
+  struct Z {
+    mutable Y y;
+  };
+  constexpr Z z;
+  auto &zti = typeid(z.y);
+  static_assert(&zti == &typeid(Y));
+}


### PR DESCRIPTION
`getDeclPtr()` will return the declaration pointer, which might be unrelated to the pointer we actually care about.