### PR TITLE
[NFC][SPIRV] Make `getVacantFunctionName` static

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -896,7 +896,7 @@ MachineInstr *getVRegDef(MachineRegisterInfo &MRI, Register Reg) {
   return MaybeDef;
 }
 
-bool getVacantFunctionName(Module &M, std::string &Name) {
+static bool getVacantFunctionName(Module &M, std::string &Name) {
   // It's a bit of paranoia, but still we don't want to have even a chance that
   // the loop will work for too long.
   constexpr unsigned MaxIters = 1024;

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -538,8 +538,6 @@ MachineInstr *getVRegDef(MachineRegisterInfo &MRI, Register Reg);
 #define SPIRV_BACKEND_SERVICE_FUN_NAME "__spirv_backend_service_fun"
 #define SPIRV_WAS_AVAILABLE_EXTERNALLY_ATTR "spv.was-available-externally"
 
-bool getVacantFunctionName(Module &M, std::string &Name);
-
 void setRegClassType(Register Reg, const Type *Ty, SPIRVGlobalRegistry *GR,
                      MachineIRBuilder &MIRBuilder,
                      SPIRV::AccessQualifier::AccessQualifier AccessQual,


### PR DESCRIPTION
The function is only used inside `SPIRVUtils.cpp`.