### PR TITLE
[SPIR-V] Emit UniformId decoration as OpDecorateId with a Scope id operand

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -398,7 +398,7 @@ void SPIRVInstPrinter::printOpDecorate(const MCInst *MI, raw_ostream &O) {
       printSymbolicOperand<OperandCategory::BuiltInOperand>(MI, NumFixedOps, O);
       break;
     case Decoration::UniformId:
-      printSymbolicOperand<OperandCategory::ScopeOperand>(MI, NumFixedOps, O);
+      printOperand(MI, NumFixedOps, O);
       break;
     case Decoration::FuncParamAttr:
       printSymbolicOperand<OperandCategory::FunctionParameterAttributeOperand>(

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -324,9 +324,8 @@ void buildOpSpirvDecorations(Register Reg, MachineIRBuilder &MIRBuilder,
           OpMD->getNumOperands() == 2
               ? mdconst::dyn_extract<ConstantInt>(OpMD->getOperand(1))
               : nullptr;
-      if (!ScopeV || !isUInt<32>(ScopeV->getZExtValue()))
-        report_fatal_error("Expect Scope <id> operand of the UniformId "
-                           "decoration");
+      assert(ScopeV && isUInt<32>(ScopeV->getZExtValue()) &&
+             "Expect Scope <id> operand of the UniformId decoration");
       SPIRVGlobalRegistry *GR = ST.getSPIRVGlobalRegistry();
       SPIRVTypeInst SpvTypeInt32 =
           GR->getOrCreateSPIRVIntegerType(32, MIRBuilder);

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -321,7 +321,7 @@ void buildOpSpirvDecorations(Register Reg, MachineIRBuilder &MIRBuilder,
     uint32_t Dec = static_cast<uint32_t>(DecorationId->getZExtValue());
     if (Dec == static_cast<uint32_t>(SPIRV::Decoration::UniformId)) {
       ConstantInt *ScopeV =
-          OpMD->getNumOperands() > 1
+          OpMD->getNumOperands() == 2
               ? mdconst::dyn_extract<ConstantInt>(OpMD->getOperand(1))
               : nullptr;
       if (!ScopeV || !isUInt<32>(ScopeV->getZExtValue()))

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -318,9 +318,27 @@ void buildOpSpirvDecorations(Register Reg, MachineIRBuilder &MIRBuilder,
             static_cast<uint32_t>(SPIRV::Decoration::FPFastMathMode)) {
       continue; // Ignored.
     }
-    auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                   .addUse(Reg)
-                   .addImm(static_cast<uint32_t>(DecorationId->getZExtValue()));
+    uint32_t Dec = static_cast<uint32_t>(DecorationId->getZExtValue());
+    if (Dec == static_cast<uint32_t>(SPIRV::Decoration::UniformId)) {
+      ConstantInt *ScopeV =
+          OpMD->getNumOperands() > 1
+              ? mdconst::dyn_extract<ConstantInt>(OpMD->getOperand(1))
+              : nullptr;
+      if (!ScopeV || !isUInt<32>(ScopeV->getZExtValue()))
+        report_fatal_error("Expect Scope <id> operand of the UniformId "
+                           "decoration");
+      SPIRVGlobalRegistry *GR = ST.getSPIRVGlobalRegistry();
+      SPIRVTypeInst SpvTypeInt32 =
+          GR->getOrCreateSPIRVIntegerType(32, MIRBuilder);
+      Register ScopeReg = GR->buildConstantInt(
+          ScopeV->getZExtValue(), MIRBuilder, SpvTypeInt32, /*EmitIR=*/false);
+      MIRBuilder.buildInstr(SPIRV::OpDecorateId)
+          .addUse(Reg)
+          .addImm(Dec)
+          .addUse(ScopeReg);
+      continue;
+    }
+    auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate).addUse(Reg).addImm(Dec);
     for (unsigned OpI = 1, OpE = OpMD->getNumOperands(); OpI != OpE; ++OpI) {
       if (ConstantInt *OpV =
               mdconst::dyn_extract<ConstantInt>(OpMD->getOperand(OpI)))

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/vk-ext-builtin-input.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/vk-ext-builtin-input.ll
@@ -3,6 +3,7 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-DAG:        OpDecorate %[[#WorkgroupId:]] BuiltIn WorkgroupId
+; CHECK-DAG:        OpDecorateId %[[#UniformVar:]] UniformId %[[#Scope:]]
 
 ; CHECK-DAG:             %[[#uint:]] = OpTypeInt 32 0
 ; CHECK-DAG:           %[[#uint_0:]] = OpConstant %[[#uint]] 0
@@ -10,7 +11,9 @@
 ; CHECK-DAG:   %[[#ptr_Input_uint:]] = OpTypePointer Input %[[#uint]]
 ; CHECK-DAG: %[[#ptr_Input_v3uint:]] = OpTypePointer Input %[[#v3uint]]
 ; CHECK-DAG:      %[[#WorkgroupId:]] = OpVariable %[[#ptr_Input_v3uint]] Input
+; CHECK-DAG:            %[[#Scope]] = OpConstant %[[#uint]] 2
 @var = external local_unnamed_addr addrspace(7) externally_initialized constant <3 x i32>, align 16, !spirv.Decorations !0
+@uvar = external local_unnamed_addr addrspace(7) externally_initialized constant i32, !spirv.Decorations !2
 
 define i32 @foo() {
 entry:
@@ -21,5 +24,13 @@ entry:
   ret i32 %0
 }
 
+define i32 @bar() {
+entry:
+  %0 = load i32, ptr addrspace(7) @uvar
+  ret i32 %0
+}
+
 !0 = !{!1}
 !1 = !{i32 11, i32 26}
+!2 = !{!3}
+!3 = !{i32 27, i32 2} ; 27 is UniformId decoration, 2 is Workgroup scope


### PR DESCRIPTION
Per spec, UniformId operand is a Scope `<id>`, not a literal

Previously it was printed via `printSymbolicOperand<ScopeOperand>`, which asserts on a real id operand, and never emitted correctly