### PR TITLE
[CodeGen] Set attributes on coroutine wrapper functions

### DIFF
--- a/clang/lib/CodeGen/CGCoroutine.cpp
+++ b/clang/lib/CodeGen/CGCoroutine.cpp
@@ -437,6 +437,7 @@ CodeGenFunction::generateAwaitSuspendWrapper(Twine const &CoroName,
 
   llvm::Function *Fn = llvm::Function::Create(
       LTy, llvm::GlobalValue::InternalLinkage, FuncName, &CGM.getModule());
+  CGM.SetInternalFunctionAttributes(GlobalDecl(), Fn, FI);
 
   Fn->addParamAttr(0, llvm::Attribute::AttrKind::NonNull);
   Fn->addParamAttr(0, llvm::Attribute::AttrKind::NoUndef);
@@ -444,6 +445,7 @@ CodeGenFunction::generateAwaitSuspendWrapper(Twine const &CoroName,
   Fn->addParamAttr(1, llvm::Attribute::AttrKind::NoUndef);
 
   Fn->setMustProgress();
+  Fn->removeFnAttr(llvm::Attribute::AttrKind::NoInline);
   Fn->addFnAttr(llvm::Attribute::AttrKind::AlwaysInline);
   Fn->addFnAttr("sample-profile-suffix-elision-policy", "selected");
 

--- a/clang/test/CodeGenCoroutines/coro-elide.cpp
+++ b/clang/test/CodeGenCoroutines/coro-elide.cpp
@@ -1,8 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O2 -emit-llvm %s -o - | FileCheck %s
 
-// FIXME: Generate wrappers with correct target features.
-// REQUIRES: x86-registered-target
-
 #include "Inputs/coroutine.h"
 
 namespace {

--- a/clang/test/CodeGenCoroutines/coro-halo.cpp
+++ b/clang/test/CodeGenCoroutines/coro-halo.cpp
@@ -3,9 +3,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 -O2 -emit-llvm %s \
 // RUN:   -fcxx-exceptions -fexceptions -o - | FileCheck %s
 
-// FIXME: Generate wrappers with correct target features.
-// REQUIRES: x86-registered-target
-
 #include "Inputs/coroutine.h"
 #include "Inputs/numeric.h"
 

--- a/clang/test/CodeGenCoroutines/pr65018.cpp
+++ b/clang/test/CodeGenCoroutines/pr65018.cpp
@@ -1,9 +1,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++20 \
 // RUN:      -O1 -emit-llvm %s -o - | FileCheck %s
 
-// FIXME: Generate wrappers with correct target features.
-// REQUIRES: x86-registered-target
-
 #include "Inputs/coroutine.h"
 
 // A simple awaiter type with an await_suspend method that can't be


### PR DESCRIPTION
Call SetInternalFunctionAttributes() so that target feature attributes get set. This ensures that inlining works without having to reason about target-specific inline compatibility logic.