### PR TITLE
[AArch64][GlobalISel] Use integer types in applySimplifyUADDO

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64PreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PreLegalizerCombiner.cpp
@@ -721,9 +721,9 @@ void applySimplifyUADDO(MachineInstr &MI, MachineRegisterInfo &MRI,
   Register CondBit = MRI.cloneVirtualRegister(Op0Wide);
   B.buildAnd(
       CondBit, AddDst,
-      B.buildConstant(LLT::scalar(32), OpTySize == 8 ? 1 << 8 : 1 << 16));
+      B.buildConstant(LLT::integer(32), OpTySize == 8 ? 1 << 8 : 1 << 16));
   B.buildICmp(CmpInst::ICMP_NE, ResStatus, CondBit,
-              B.buildConstant(LLT::scalar(32), 0));
+              B.buildConstant(LLT::integer(32), 0));
 
   // Update ZEXts users of the result value. Because all uses are in the
   // no-overflow case, we know that the top bits are 0 and we can ignore ZExts.

--- a/llvm/test/CodeGen/AArch64/GlobalISel/uaddo-8-16-bits.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/uaddo-8-16-bits.mir
@@ -16,9 +16,9 @@ body:             |
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
   ; CHECK-NEXT:   [[ASSERT_ZEXT1:%[0-9]+]]:_(i32) = G_ASSERT_ZEXT [[COPY1]], 8
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(i32) = G_ADD [[ASSERT_ZEXT]], [[ASSERT_ZEXT1]]
-  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 256
+  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 256
   ; CHECK-NEXT:   [[AND:%[0-9]+]]:_(i32) = G_AND [[ADD]], [[C]]
-  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
   ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[AND]](i32), [[C1]]
   ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2
   ; CHECK-NEXT:   G_BR %bb.1
@@ -70,9 +70,9 @@ body:             |
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
   ; CHECK-NEXT:   [[ASSERT_ZEXT1:%[0-9]+]]:_(i32) = G_ASSERT_ZEXT [[COPY1]], 16
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(i32) = G_ADD [[ASSERT_ZEXT]], [[ASSERT_ZEXT1]]
-  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65536
+  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 65536
   ; CHECK-NEXT:   [[AND:%[0-9]+]]:_(i32) = G_AND [[ADD]], [[C]]
-  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
   ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[AND]](i32), [[C1]]
   ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2
   ; CHECK-NEXT:   G_BR %bb.1
@@ -124,9 +124,9 @@ body:             |
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
   ; CHECK-NEXT:   [[ASSERT_ZEXT1:%[0-9]+]]:_(i32) = G_ASSERT_ZEXT [[COPY1]], 16
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(i32) = G_ADD [[ASSERT_ZEXT]], [[ASSERT_ZEXT1]]
-  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65536
+  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 65536
   ; CHECK-NEXT:   [[AND:%[0-9]+]]:_(i32) = G_AND [[ADD]], [[C]]
-  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
   ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[AND]](i32), [[C1]]
   ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2
   ; CHECK-NEXT:   G_BR %bb.1
@@ -196,9 +196,9 @@ body:             |
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
   ; CHECK-NEXT:   [[ASSERT_ZEXT1:%[0-9]+]]:_(i32) = G_ASSERT_ZEXT [[COPY1]], 16
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(i32) = G_ADD [[ASSERT_ZEXT]], [[ASSERT_ZEXT1]]
-  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65536
+  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 65536
   ; CHECK-NEXT:   [[AND:%[0-9]+]]:_(i32) = G_AND [[ADD]], [[C]]
-  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
   ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[AND]](i32), [[C1]]
   ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2
   ; CHECK-NEXT:   G_BR %bb.1
@@ -250,9 +250,9 @@ body:             |
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
   ; CHECK-NEXT:   [[ASSERT_ZEXT1:%[0-9]+]]:_(i32) = G_ASSERT_ZEXT [[COPY1]], 16
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(i32) = G_ADD [[ASSERT_ZEXT]], [[ASSERT_ZEXT1]]
-  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65536
+  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 65536
   ; CHECK-NEXT:   [[AND:%[0-9]+]]:_(i32) = G_AND [[ADD]], [[C]]
-  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
   ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[AND]](i32), [[C1]]
   ; CHECK-NEXT:   DBG_VALUE [[ICMP]](i1)
   ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2
@@ -306,9 +306,9 @@ body:             |
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(i32) = COPY $w1
   ; CHECK-NEXT:   [[ASSERT_ZEXT1:%[0-9]+]]:_(i32) = G_ASSERT_ZEXT [[COPY1]], 16
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(i32) = G_ADD [[ASSERT_ZEXT]], [[ASSERT_ZEXT1]]
-  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65536
+  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(i32) = G_CONSTANT i32 65536
   ; CHECK-NEXT:   [[AND:%[0-9]+]]:_(i32) = G_AND [[ADD]], [[C]]
-  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(i32) = G_CONSTANT i32 0
   ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(i1) = G_ICMP intpred(eq), [[AND]](i32), [[C1]]
   ; CHECK-NEXT:   DBG_VALUE %6:_(i16)
   ; CHECK-NEXT:   G_BRCOND [[ICMP]](i1), %bb.2


### PR DESCRIPTION
This avoids creating some scalar types in the IR, using integer types for constants from a uaddo combine instead.