### PR TITLE
[Hexagon] Don't use reserved identifiers

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonPostRAHandleQFP.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonPostRAHandleQFP.cpp
@@ -254,9 +254,9 @@ private:
 // default
 class XqfPostRADiagnosis {
 public:
-  XqfPostRADiagnosis(DataFlowGraph &_G, Liveness &_L,
-                     const HexagonInstrInfo *_HII)
-      : G(&_G), L(&_L), HII(_HII) {}
+  XqfPostRADiagnosis(DataFlowGraph &G_, Liveness &L_,
+                     const HexagonInstrInfo *HII_)
+      : G(&G_), L(&L_), HII(HII_) {}
   // Deleting default constructor to handle misconstruction
   XqfPostRADiagnosis() = delete;
 

--- a/llvm/lib/Target/Hexagon/HexagonPostRAHandleQFP.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonPostRAHandleQFP.cpp
@@ -254,8 +254,7 @@ private:
 // default
 class XqfPostRADiagnosis {
 public:
-  XqfPostRADiagnosis(DataFlowGraph &G, Liveness &L,
-                     const HexagonInstrInfo *HII)
+  XqfPostRADiagnosis(DataFlowGraph &G, Liveness &L, const HexagonInstrInfo *HII)
       : G(&G), L(&L), HII(HII) {}
   // Deleting default constructor to handle misconstruction
   XqfPostRADiagnosis() = delete;

--- a/llvm/lib/Target/Hexagon/HexagonPostRAHandleQFP.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonPostRAHandleQFP.cpp
@@ -254,9 +254,9 @@ private:
 // default
 class XqfPostRADiagnosis {
 public:
-  XqfPostRADiagnosis(DataFlowGraph &G_, Liveness &L_,
-                     const HexagonInstrInfo *HII_)
-      : G(&G_), L(&L_), HII(HII_) {}
+  XqfPostRADiagnosis(DataFlowGraph &G, Liveness &L,
+                     const HexagonInstrInfo *HII)
+      : G(&G), L(&L), HII(HII) {}
   // Deleting default constructor to handle misconstruction
   XqfPostRADiagnosis() = delete;
 


### PR DESCRIPTION
All identifiers that begin with an underscore followed by a capital letter or by another underscore are reserved.