### PR TITLE
[JITLink][ORC] Add ppc64 to generic stub API; use it in DLLImportDefinitionGenerator

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/ppc64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ppc64.h
@@ -155,6 +155,19 @@ inline Symbol &createAnonymousPointerJumpStub(LinkGraph &G,
   return G.addAnonymousSymbol(B, 0, StubInfo.Content.size(), true, false);
 }
 
+// LongBranchSaveR2 is the default for external calls: saves the TOC
+// pointer (r2) before branching, as required when the callee sets its
+// own TOC. Callers needing a different stub kind (e.g. LongBranchNoTOC)
+// should call createAnonymousPointerJumpStub directly with the desired
+// PLTCallStubKind.
+template <llvm::endianness Endianness>
+inline Symbol &createDefaultAnonymousPointerJumpStub(LinkGraph &G,
+                                                     Section &StubSection,
+                                                     Symbol &PointerSymbol) {
+  return createAnonymousPointerJumpStub<Endianness>(
+      G, StubSection, PointerSymbol, LongBranchSaveR2);
+}
+
 template <llvm::endianness Endianness>
 class TOCTableManager : public TableManager<TOCTableManager<Endianness>> {
 public:

--- a/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ExecutionEngine/JITLink/XCOFF.h"
 #include "llvm/ExecutionEngine/JITLink/aarch64.h"
 #include "llvm/ExecutionEngine/JITLink/loongarch.h"
+#include "llvm/ExecutionEngine/JITLink/ppc64.h"
 #include "llvm/ExecutionEngine/JITLink/systemz.h"
 #include "llvm/ExecutionEngine/JITLink/x86.h"
 #include "llvm/ExecutionEngine/JITLink/x86_64.h"
@@ -482,6 +483,9 @@ AnonymousPointerCreator getAnonymousPointerCreator(const Triple &TT) {
     return loongarch::createAnonymousPointer;
   case Triple::systemz:
     return systemz::createAnonymousPointer;
+  case Triple::ppc64:
+  case Triple::ppc64le:
+    return ppc64::createAnonymousPointer;
   default:
     return nullptr;
   }
@@ -500,6 +504,11 @@ PointerJumpStubCreator getPointerJumpStubCreator(const Triple &TT) {
     return loongarch::createAnonymousPointerJumpStub;
   case Triple::systemz:
     return systemz::createAnonymousPointerJumpStub;
+  case Triple::ppc64:
+    return ppc64::createDefaultAnonymousPointerJumpStub<llvm::endianness::big>;
+  case Triple::ppc64le:
+    return ppc64::createDefaultAnonymousPointerJumpStub<
+        llvm::endianness::little>;
   default:
     return nullptr;
   }

--- a/llvm/lib/ExecutionEngine/Orc/ExecutionUtils.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ExecutionUtils.cpp
@@ -553,9 +553,23 @@ Error DLLImportDefinitionGenerator::tryToGenerate(
 
 Expected<std::unique_ptr<jitlink::LinkGraph>>
 DLLImportDefinitionGenerator::createStubsGraph(const SymbolMap &Resolved) {
+  Triple TT = ES.getTargetTriple();
+
+  auto CreatePointer = jitlink::getAnonymousPointerCreator(TT);
+  if (!CreatePointer)
+    return make_error<StringError>(
+        "DLLImportDefinitionGenerator: no pointer creator for " + TT.str(),
+        inconvertibleErrorCode());
+
+  auto CreateStub = jitlink::getPointerJumpStubCreator(TT);
+  if (!CreateStub)
+    return make_error<StringError>(
+        "DLLImportDefinitionGenerator: no stub creator for " + TT.str(),
+        inconvertibleErrorCode());
+
   auto G = std::make_unique<jitlink::LinkGraph>(
-      "<DLLIMPORT_STUBS>", ES.getSymbolStringPool(), ES.getTargetTriple(),
-      SubtargetFeatures(), jitlink::getGenericEdgeKindName);
+      "<DLLIMPORT_STUBS>", ES.getSymbolStringPool(), TT, SubtargetFeatures(),
+      jitlink::getGenericEdgeKindName);
   jitlink::Section &Sec =
       G->createSection(getSectionName(), MemProt::Read | MemProt::Exec);
 
@@ -565,19 +579,17 @@ DLLImportDefinitionGenerator::createStubsGraph(const SymbolMap &Resolved) {
         jitlink::Linkage::Strong, jitlink::Scope::Local, false);
 
     // Create __imp_ symbol
-    jitlink::Symbol &Ptr =
-        jitlink::x86_64::createAnonymousPointer(*G, Sec, &Target);
+    jitlink::Symbol &Ptr = CreatePointer(*G, Sec, &Target, 0);
     Ptr.setName(G->intern((Twine(getImpPrefix()) + *KV.first).str()));
     Ptr.setLinkage(jitlink::Linkage::Strong);
     Ptr.setScope(jitlink::Scope::Default);
 
     // Create PLT stub
     // FIXME: check PLT stub of data symbol is not accessed
-    jitlink::Block &StubBlock =
-        jitlink::x86_64::createPointerJumpStubBlock(*G, Sec, Ptr);
-    G->addDefinedSymbol(StubBlock, 0, *KV.first, StubBlock.getSize(),
-                        jitlink::Linkage::Strong, jitlink::Scope::Default, true,
-                        false);
+    jitlink::Symbol &Stub = CreateStub(*G, Sec, Ptr);
+    Stub.setName(G->intern(*KV.first));
+    Stub.setLinkage(jitlink::Linkage::Strong);
+    Stub.setScope(jitlink::Scope::Default);
   }
 
   return std::move(G);


### PR DESCRIPTION
`getAnonymousPointerCreator` and `getPointerJumpStubCreator` provide arch-neutral factory functions for pointer slots and PLT jump stubs, but ppc64/ppc64le were missing from both switch tables.

Add ppc64 support: `createAnonymousPointer` maps directly, while `createAnonymousPointerJumpStub` requires a lambda wrapper to fix the endianness template parameter and supply _LongBranchSaveR2_ as the stub kind (the correct default for external calls that must preserve the TOC pointer). Callers needing a different stub kind can construct a `PointerJumpStubCreator` lambda directly.  Update `DLLImportDefinitionGenerator::createStubsGraph` to use these arch-neutral factories instead of calling jitlink::x86_64:: directly, completing part of the work tracked in issue https://github.com/llvm/llvm-project/issues/57162