### PR TITLE
[ORC] Add opt-in per-JITDylib colocating slab allocator

### DIFF
--- a/llvm/docs/ORCv2.md
+++ b/llvm/docs/ORCv2.md
@@ -147,6 +147,36 @@ auto JIT = LLLazyJITBuilder()
 For users wanting to get started with LLJIT a minimal example program can be
 found at `llvm/examples/HowToUseLLJIT`.
 
+By default LLJIT allocates each linked object independently, so two objects that
+belong to the same JITDylib are not guaranteed to land within range of one
+another in the executor's address space. This matters under a small code model:
+the compiler emits direct, range-limited relocations for references within a
+program (such as the x86-64 REL32 relocation, which only reaches +/-2GB), so
+when a referenced object is allocated too far away JITLink has to route the
+reference through a stub instead. (References that cross JITDylibs or bind to
+external libraries are resolved indirectly regardless, so they are unaffected.)
+
+The `setColocatingSlabAllocator` builder option opts in to a slab-based memory
+manager that reserves a large region of address space per JITDylib and
+sub-allocates that JITDylib's objects from it, keeping them close enough to stay
+within range of one another:
+
+```c++
+// Use an in-process, per-JITDylib colocating slab allocator.
+auto JIT = LLJITBuilder()
+             .setColocatingSlabAllocator()
+             .create();
+```
+
+This option only affects the JITLink linking path. Targets that still default to
+RuntimeDyld (e.g. COFF today) are unaffected unless JITLink is also enabled (for
+example via `setObjectLinkingLayerCreator`).
+
+By default each JITDylib is restricted to a single slab, so an allocation that
+does not fit is rejected rather than silently spilling into another, possibly
+out-of-range, slab. A custom growth policy can be supplied as a second argument
+to `setColocatingSlabAllocator`.
+
 ## Design Overview
 
 ORC's JIT program model aims to emulate the linking and symbol resolution

--- a/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
@@ -23,6 +23,7 @@
 #include "llvm/ExecutionEngine/Orc/IRPartitionLayer.h"
 #include "llvm/ExecutionEngine/Orc/IRTransformLayer.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
+#include "llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
@@ -422,6 +423,42 @@ public:
   SetterImpl &setMemoryManagerCreator(
       LLJITBuilderState::MemoryManagerCreator CreateMemoryManager) {
     impl().CreateMemoryManager = std::move(CreateMemoryManager);
+    return impl();
+  }
+
+  /// Use an in-process, per-JITDylib-colocating slab allocator as the JIT's
+  /// memory manager (see createColocatingInProcessMemoryManager). Keeping a
+  /// JITDylib's objects colocated lets them reference each other with direct
+  /// (e.g. 32-bit PC-relative) edges. If ReservationGranularity is not given,
+  /// MapperJITLinkMemoryManager::defaultSlabSize() is used. If Policy is not
+  /// given, each JITDylib is restricted to a single slab (see
+  /// MapperJITLinkMemoryManager::denySlabGrowth).
+  ///
+  /// Note: this only takes effect on the JITLink path. On targets that still
+  /// default to RuntimeDyld (e.g. COFF today) it has no effect unless JITLink
+  /// is also enabled (e.g. via setObjectLinkingLayerCreator).
+  SetterImpl &setColocatingSlabAllocator(
+      std::optional<size_t> ReservationGranularity = std::nullopt,
+      std::optional<MapperJITLinkMemoryManager::SlabGrowthPolicy> Policy =
+          std::nullopt) {
+    auto SharedPolicy =
+        Policy ? std::make_shared<MapperJITLinkMemoryManager::SlabGrowthPolicy>(
+                     std::move(*Policy))
+               : nullptr;
+    impl().CreateMemoryManager = [ReservationGranularity,
+                                  SharedPolicy](ExecutionSession &)
+        -> Expected<std::unique_ptr<jitlink::JITLinkMemoryManager>> {
+      auto MM = createColocatingInProcessMemoryManager(ReservationGranularity);
+      if (!MM)
+        return MM.takeError();
+      if (SharedPolicy)
+        (*MM)->setSlabPolicy(std::move(*SharedPolicy));
+      else
+        (*MM)->denySlabGrowth();
+      // Expected<unique_ptr<Derived>> does not implicitly convert to
+      // Expected<unique_ptr<Base>>, so up-cast the pointer explicitly.
+      return std::unique_ptr<jitlink::JITLinkMemoryManager>(std::move(*MM));
+    };
     return impl();
   }
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h
@@ -13,10 +13,12 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MAPPERJITLINKMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_MAPPERJITLINKMEMORYMANAGER_H
 
+#include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/MemoryMapper.h"
 #include "llvm/Support/Compiler.h"
+#include <optional>
 
 namespace llvm {
 namespace orc {
@@ -24,8 +26,13 @@ namespace orc {
 class LLVM_ABI MapperJITLinkMemoryManager
     : public jitlink::JITLinkMemoryManager {
 public:
+  /// If ColocatePerJITDylib is true each JITDylib draws from its own pool of
+  /// reservations, so all of a JITDylib's objects are colocated (kept within
+  /// range of each other for direct, e.g. 32-bit PC-relative, references). If
+  /// false (the default) a single shared pool is used for all JITDylibs.
   MapperJITLinkMemoryManager(size_t ReservationGranularity,
-                             std::unique_ptr<MemoryMapper> Mapper);
+                             std::unique_ptr<MemoryMapper> Mapper,
+                             bool ColocatePerJITDylib = false);
 
   template <class MemoryMapperType, class... Args>
   static Expected<std::unique_ptr<MapperJITLinkMemoryManager>>
@@ -38,6 +45,20 @@ public:
                                                         std::move(*Mapper));
   }
 
+  /// The default per-slab reservation size used by
+  /// createColocatingInProcessMemoryManager: 1 GiB on 64-bit hosts, 10 MiB on
+  /// 32-bit hosts. This is address space that is reserved, not committed.
+  static constexpr size_t defaultSlabSize() {
+    if constexpr (sizeof(void *) >= 8)
+      return size_t(1) << 30; // 1 GiB on 64-bit hosts.
+    else
+      return size_t(10) << 20; // 10 MiB on 32-bit hosts.
+  }
+
+  /// The reservation granularity passed to the constructor: each slab
+  /// reserved from the executor address space is a multiple of this.
+  size_t reservationUnits() const { return ReservationUnits; }
+
   void allocate(const jitlink::JITLinkDylib *JD, jitlink::LinkGraph &G,
                 OnAllocatedFunction OnAllocated) override;
   // synchronous overload
@@ -48,24 +69,96 @@ public:
   // synchronous overload
   using JITLinkMemoryManager::deallocate;
 
+  /// Policy invoked before reserving an additional slab for a JITDylib (i.e.
+  /// when its existing reservations can't satisfy a request). JD and
+  /// RequestedSize identify the JITDylib and reservation size behind the
+  /// request, for use in diagnostics. Returning an Error fails the
+  /// triggering allocation.
+  using SlabGrowthPolicy = unique_function<Error(
+      const jitlink::JITLinkDylib *JD, size_t RequestedSize)>;
+
+  /// Restrict each JITDylib to a single reservation ("slab"). Once a
+  /// JITDylib's slab is full, further allocations for it fail rather than
+  /// silently spilling into another, possibly out-of-range, slab.
+  void denySlabGrowth();
+
+  /// Allow each JITDylib to grow into additional reservations on demand (the
+  /// default). Objects in different slabs of the same JITDylib are not
+  /// guaranteed to be within range of each other.
+  ///
+  /// Note: LLJITBuilder::setColocatingSlabAllocator() overrides this default
+  /// to denySlabGrowth() when no SlabGrowthPolicy is given.
+  void allowSlabGrowth();
+
+  /// Set a custom slab-growth policy. See SlabGrowthPolicy above.
+  void setSlabPolicy(SlabGrowthPolicy Policy);
+
+  /// Called when a registered JITDylib is destroyed (see
+  /// jitlink::JITLinkDylib::notifyOnDestruction). Frees its pool so a new
+  /// JITDylib at the same (reused) address doesn't inherit stale state.
+  void notifyDestroying(jitlink::JITLinkDylib &JD) override;
+
 private:
   class InFlightAlloc;
+
+  using AvailableMemoryMap = IntervalMap<ExecutorAddr, bool>;
+
+  // Returns the pool of reserved-but-not-yet-allocated ranges for the given
+  // key, creating it on first use. The key is the JITDylib when colocating
+  // per-JITDylib, otherwise nullptr (a single shared pool). Must be called with
+  // Mutex held.
+  AvailableMemoryMap &getAvailableMemory(const jitlink::JITLinkDylib *Key);
 
   std::mutex Mutex;
 
   // We reserve multiples of this from the executor address space
   size_t ReservationUnits;
 
-  // Ranges that have been reserved in executor but not yet allocated
-  using AvailableMemoryMap = IntervalMap<ExecutorAddr, bool>;
-  AvailableMemoryMap::Allocator AMAllocator;
-  IntervalMap<ExecutorAddr, bool> AvailableMemory;
+  // When true, each JITDylib gets its own pool of reservations (so a
+  // JITDylib's objects are colocated); when false a single nullptr-keyed pool
+  // is shared by all JITDylibs.
+  bool ColocatePerJITDylib;
 
-  // Ranges that have been reserved in executor and already allocated
+  // Policy consulted before reserving an additional slab for a pool (i.e. when
+  // a pool already owns a reservation but none of its free ranges fit the
+  // request). Returning an Error fails the allocation. Defaults to allowing
+  // additional slabs (preserving the historical behavior).
+  SlabGrowthPolicy OnSlabGrow = [](const jitlink::JITLinkDylib *,
+                                   size_t) -> Error {
+    return Error::success();
+  };
+
+  AvailableMemoryMap::Allocator AMAllocator;
+
+  // Per-key pool state: the reserved-but-not-yet-allocated ranges available
+  // for reuse, and whether the pool already owns at least one reservation
+  // (used to detect when a further reservation would be another slab for it).
+  // Both live in one map, keyed the same way, so they can't get out of sync
+  // with each other.
+  struct PoolInfo {
+    // The unique_ptr keeps each IntervalMap at a stable address as the map
+    // grows, so references returned by getAvailableMemory() stay valid.
+    std::unique_ptr<AvailableMemoryMap> AvailPool;
+    bool Reserved = false;
+  };
+  DenseMap<const jitlink::JITLinkDylib *, PoolInfo> Pools;
+
+  // Ranges that have been reserved and already allocated: base address -> size.
   DenseMap<ExecutorAddr, ExecutorAddrDiff> UsedMemory;
+
+  // Base address -> the pool key the allocation was drawn from, so that
+  // deallocate() can return the range to the right pool.
+  DenseMap<ExecutorAddr, const jitlink::JITLinkDylib *> AllocPoolKey;
 
   std::unique_ptr<MemoryMapper> Mapper;
 };
+
+/// Create an in-process slab allocator that colocates each JITDylib's objects
+/// within its own reservation(s). If ReservationGranularity is not given,
+/// MapperJITLinkMemoryManager::defaultSlabSize() is used.
+LLVM_ABI Expected<std::unique_ptr<MapperJITLinkMemoryManager>>
+createColocatingInProcessMemoryManager(
+    std::optional<size_t> ReservationGranularity = std::nullopt);
 
 } // end namespace orc
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h
@@ -13,10 +13,12 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_MAPPERJITLINKMEMORYMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_MAPPERJITLINKMEMORYMANAGER_H
 
+#include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/MemoryMapper.h"
 #include "llvm/Support/Compiler.h"
+#include <optional>
 
 namespace llvm {
 namespace orc {
@@ -24,8 +26,13 @@ namespace orc {
 class LLVM_ABI MapperJITLinkMemoryManager
     : public jitlink::JITLinkMemoryManager {
 public:
+  /// If ColocatePerJITDylib is true each JITDylib draws from its own pool of
+  /// reservations, so all of a JITDylib's objects are colocated (kept within
+  /// range of each other for direct, e.g. 32-bit PC-relative, references). If
+  /// false (the default) a single shared pool is used for all JITDylibs.
   MapperJITLinkMemoryManager(size_t ReservationGranularity,
-                             std::unique_ptr<MemoryMapper> Mapper);
+                             std::unique_ptr<MemoryMapper> Mapper,
+                             bool ColocatePerJITDylib = false);
 
   template <class MemoryMapperType, class... Args>
   static Expected<std::unique_ptr<MapperJITLinkMemoryManager>>
@@ -38,6 +45,20 @@ public:
                                                         std::move(*Mapper));
   }
 
+  /// The default per-slab reservation size used by
+  /// createColocatingInProcessMemoryManager: 1 GiB on 64-bit hosts, 10 MiB on
+  /// 32-bit hosts. This is address space that is reserved, not committed.
+  static constexpr size_t defaultSlabSize() {
+    if constexpr (sizeof(void *) >= 8)
+      return size_t(1) << 30; // 1 GiB on 64-bit hosts.
+    else
+      return size_t(10) << 20; // 10 MiB on 32-bit hosts.
+  }
+
+  /// The reservation granularity passed to the constructor: each slab
+  /// reserved from the executor address space is a multiple of this.
+  size_t reservationUnits() const { return ReservationUnits; }
+
   void allocate(const jitlink::JITLinkDylib *JD, jitlink::LinkGraph &G,
                 OnAllocatedFunction OnAllocated) override;
   // synchronous overload
@@ -48,24 +69,91 @@ public:
   // synchronous overload
   using JITLinkMemoryManager::deallocate;
 
+  /// Policy invoked before reserving an additional slab for a JITDylib (i.e.
+  /// when its existing reservations can't satisfy a request). JD and
+  /// RequestedSize identify the JITDylib and reservation size behind the
+  /// request, for use in diagnostics. Returning an Error fails the
+  /// triggering allocation.
+  using SlabGrowthPolicy = unique_function<Error(
+      const jitlink::JITLinkDylib *JD, size_t RequestedSize)>;
+
+  /// Restrict each JITDylib to a single reservation ("slab"). Once a
+  /// JITDylib's slab is full, further allocations for it fail rather than
+  /// silently spilling into another, possibly out-of-range, slab.
+  void denySlabGrowth();
+
+  /// Allow each JITDylib to grow into additional reservations on demand (the
+  /// default). Objects in different slabs of the same JITDylib are not
+  /// guaranteed to be within range of each other.
+  ///
+  /// Note: LLJITBuilder::setColocatingSlabAllocator() overrides this default
+  /// to denySlabGrowth() when no SlabGrowthPolicy is given.
+  void allowSlabGrowth();
+
+  /// Set a custom slab-growth policy. See SlabGrowthPolicy above.
+  void setSlabPolicy(SlabGrowthPolicy Policy);
+
 private:
   class InFlightAlloc;
+
+  using AvailableMemoryMap = IntervalMap<ExecutorAddr, bool>;
+
+  // Returns the pool of reserved-but-not-yet-allocated ranges for the given
+  // key, creating it on first use. The key is the JITDylib when colocating
+  // per-JITDylib, otherwise nullptr (a single shared pool). Must be called with
+  // Mutex held.
+  AvailableMemoryMap &getAvailableMemory(const jitlink::JITLinkDylib *Key);
 
   std::mutex Mutex;
 
   // We reserve multiples of this from the executor address space
   size_t ReservationUnits;
 
-  // Ranges that have been reserved in executor but not yet allocated
-  using AvailableMemoryMap = IntervalMap<ExecutorAddr, bool>;
-  AvailableMemoryMap::Allocator AMAllocator;
-  IntervalMap<ExecutorAddr, bool> AvailableMemory;
+  // When true, each JITDylib gets its own pool of reservations (so a
+  // JITDylib's objects are colocated); when false a single nullptr-keyed pool
+  // is shared by all JITDylibs.
+  bool ColocatePerJITDylib;
 
-  // Ranges that have been reserved in executor and already allocated
+  // Policy consulted before reserving an additional slab for a pool (i.e. when
+  // a pool already owns a reservation but none of its free ranges fit the
+  // request). Returning an Error fails the allocation. Defaults to allowing
+  // additional slabs (preserving the historical behavior).
+  SlabGrowthPolicy OnSlabGrow = [](const jitlink::JITLinkDylib *,
+                                   size_t) -> Error {
+    return Error::success();
+  };
+
+  AvailableMemoryMap::Allocator AMAllocator;
+
+  // Per-key pool state: the reserved-but-not-yet-allocated ranges available
+  // for reuse, and whether the pool already owns at least one reservation
+  // (used to detect when a further reservation would be another slab for it).
+  // Both live in one map, keyed the same way, so they can't get out of sync
+  // with each other.
+  struct PoolInfo {
+    // The unique_ptr keeps each IntervalMap at a stable address as the map
+    // grows, so references returned by getAvailableMemory() stay valid.
+    std::unique_ptr<AvailableMemoryMap> AvailPool;
+    bool Reserved = false;
+  };
+  DenseMap<const jitlink::JITLinkDylib *, PoolInfo> Pools;
+
+  // Ranges that have been reserved and already allocated: base address -> size.
   DenseMap<ExecutorAddr, ExecutorAddrDiff> UsedMemory;
+
+  // Base address -> the pool key the allocation was drawn from, so that
+  // deallocate() can return the range to the right pool.
+  DenseMap<ExecutorAddr, const jitlink::JITLinkDylib *> AllocPoolKey;
 
   std::unique_ptr<MemoryMapper> Mapper;
 };
+
+/// Create an in-process slab allocator that colocates each JITDylib's objects
+/// within its own reservation(s). If ReservationGranularity is not given,
+/// MapperJITLinkMemoryManager::defaultSlabSize() is used.
+LLVM_ABI Expected<std::unique_ptr<MapperJITLinkMemoryManager>>
+createColocatingInProcessMemoryManager(
+    std::optional<size_t> ReservationGranularity = std::nullopt);
 
 } // end namespace orc
 } // end namespace llvm

--- a/llvm/lib/ExecutionEngine/Orc/MapperJITLinkMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MapperJITLinkMemoryManager.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h"
 
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/Process.h"
 
 using namespace llvm::jitlink;
@@ -54,9 +55,66 @@ private:
 };
 
 MapperJITLinkMemoryManager::MapperJITLinkMemoryManager(
-    size_t ReservationGranularity, std::unique_ptr<MemoryMapper> Mapper)
-    : ReservationUnits(ReservationGranularity), AvailableMemory(AMAllocator),
-      Mapper(std::move(Mapper)) {}
+    size_t ReservationGranularity, std::unique_ptr<MemoryMapper> Mapper,
+    bool ColocatePerJITDylib)
+    : ReservationUnits(ReservationGranularity),
+      ColocatePerJITDylib(ColocatePerJITDylib), Mapper(std::move(Mapper)) {}
+
+// Lazily creates and stores Key's pool on first access. Pools are
+// heap-allocated behind unique_ptr so the returned reference survives map
+// rehashing, and AMAllocator (declared before the pools) outlives them. Also
+// registers for a destruction notification the first time a JITDylib is
+// seen, so its pool can be freed in notifyDestroying().
+MapperJITLinkMemoryManager::AvailableMemoryMap &
+MapperJITLinkMemoryManager::getAvailableMemory(const JITLinkDylib *Key) {
+  auto [It, Inserted] = Pools.try_emplace(Key);
+  if (Inserted && Key)
+    const_cast<JITLinkDylib *>(Key)->notifyOnDestruction(*this);
+  auto &Pool = It->second.AvailPool;
+  if (!Pool)
+    Pool = std::make_unique<AvailableMemoryMap>(AMAllocator);
+  return *Pool;
+}
+
+void MapperJITLinkMemoryManager::notifyDestroying(JITLinkDylib &JD) {
+  std::lock_guard<std::mutex> Lock(Mutex);
+  Pools.erase(&JD);
+}
+
+void MapperJITLinkMemoryManager::denySlabGrowth() {
+  std::lock_guard<std::mutex> Lock(Mutex);
+  OnSlabGrow = [](const JITLinkDylib *JD, size_t RequestedSize) -> Error {
+    return createStringError(
+        "JITDylib '%s' slab exhausted (single-slab mode); enable slab "
+        "growth to allow further reservations (%zu bytes requested)",
+        JD ? JD->getName().c_str() : "<unnamed>", RequestedSize);
+  };
+}
+
+void MapperJITLinkMemoryManager::allowSlabGrowth() {
+  std::lock_guard<std::mutex> Lock(Mutex);
+  OnSlabGrow = [](const JITLinkDylib *, size_t) -> Error {
+    return Error::success();
+  };
+}
+
+void MapperJITLinkMemoryManager::setSlabPolicy(SlabGrowthPolicy Policy) {
+  std::lock_guard<std::mutex> Lock(Mutex);
+  OnSlabGrow = std::move(Policy);
+}
+
+Expected<std::unique_ptr<MapperJITLinkMemoryManager>>
+createColocatingInProcessMemoryManager(
+    std::optional<size_t> ReservationGranularity) {
+  auto Mapper = InProcessMemoryMapper::Create();
+  if (!Mapper)
+    return Mapper.takeError();
+  return std::make_unique<MapperJITLinkMemoryManager>(
+      ReservationGranularity.value_or(
+          MapperJITLinkMemoryManager::defaultSlabSize()),
+      std::move(*Mapper),
+      /*ColocatePerJITDylib=*/true);
+}
 
 void MapperJITLinkMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
                                           OnAllocatedFunction OnAllocated) {
@@ -71,7 +129,11 @@ void MapperJITLinkMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
 
   auto TotalSize = SegsSizes->total();
 
-  auto CompleteAllocation = [this, &G, BL = std::move(BL),
+  // Which pool to draw from: the JITDylib's own pool when colocating
+  // per-JITDylib, otherwise a single shared (nullptr) pool.
+  const JITLinkDylib *PoolKey = ColocatePerJITDylib ? JD : nullptr;
+
+  auto CompleteAllocation = [this, PoolKey, &G, BL = std::move(BL),
                              OnAllocated = std::move(OnAllocated)](
                                 Expected<ExecutorAddrRange> Result) mutable {
     if (!Result) {
@@ -105,10 +167,12 @@ void MapperJITLinkMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
     }
 
     UsedMemory.insert({Result->Start, NextSegAddr - Result->Start});
+    AllocPoolKey[Result->Start] = PoolKey;
 
     if (NextSegAddr < Result->End) {
-      // Save the remaining memory for reuse in next allocation(s)
-      AvailableMemory.insert(NextSegAddr, Result->End - 1, true);
+      // Save the remaining memory for reuse by later allocations from the same
+      // pool.
+      getAvailableMemory(PoolKey).insert(NextSegAddr, Result->End - 1, true);
     }
     Mutex.unlock();
 
@@ -123,11 +187,12 @@ void MapperJITLinkMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
 
   Mutex.lock();
 
-  // find an already reserved range that is large enough
+  // find an already reserved range in this pool that is large enough
   ExecutorAddrRange SelectedRange{};
 
-  for (AvailableMemoryMap::iterator It = AvailableMemory.begin();
-       It != AvailableMemory.end(); It++) {
+  AvailableMemoryMap &Avail = getAvailableMemory(PoolKey);
+  for (AvailableMemoryMap::iterator It = Avail.begin(); It != Avail.end();
+       It++) {
     if (It.stop() - It.start() + 1 >= TotalSize) {
       SelectedRange = ExecutorAddrRange(It.start(), It.stop() + 1);
       It.erase();
@@ -136,8 +201,29 @@ void MapperJITLinkMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
   }
 
   if (SelectedRange.empty()) { // no already reserved range was found
+    // A reservation is needed. If this pool already owns one, reserving
+    // another (possibly out-of-range) slab may place its objects out of range,
+    // so consult the growth policy first.
+    bool IsFirstReservation = !Pools[PoolKey].Reserved;
+    Pools[PoolKey].Reserved = true;
     auto TotalAllocation = alignTo(TotalSize, ReservationUnits);
-    Mapper->reserve(TotalAllocation, std::move(CompleteAllocation));
+    if (!IsFirstReservation) {
+      if (auto Err = OnSlabGrow(JD, TotalAllocation))
+        return CompleteAllocation(std::move(Err));
+    }
+    Mapper->reserve(TotalAllocation,
+                    [this, PoolKey, IsFirstReservation,
+                     CompleteAllocation = std::move(CompleteAllocation)](
+                        Expected<ExecutorAddrRange> Result) mutable {
+                      // If this was the pool's first reservation attempt and it
+                      // failed, undo the Reserved flag so a later attempt is
+                      // treated as the first one again, rather than
+                      // incorrectly triggering the growth policy for a pool
+                      // that never got a slab.
+                      if (!Result && IsFirstReservation)
+                        Pools[PoolKey].Reserved = false;
+                      CompleteAllocation(std::move(Result));
+                    });
   } else {
     CompleteAllocation(SelectedRange);
   }
@@ -174,7 +260,11 @@ void MapperJITLinkMemoryManager::deallocate(
         ExecutorAddrDiff Size = UsedMemory[Addr];
 
         UsedMemory.erase(Addr);
-        AvailableMemory.insert(Addr, Addr + Size - 1, true);
+
+        // Return the range to the pool it was allocated from.
+        const JITLinkDylib *PoolKey = AllocPoolKey.lookup(Addr);
+        AllocPoolKey.erase(Addr);
+        getAvailableMemory(PoolKey).insert(Addr, Addr + Size - 1, true);
 
         FA.release();
       }

--- a/llvm/lib/ExecutionEngine/Orc/MapperJITLinkMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MapperJITLinkMemoryManager.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h"
 
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/Process.h"
 
 using namespace llvm::jitlink;
@@ -54,9 +55,56 @@ private:
 };
 
 MapperJITLinkMemoryManager::MapperJITLinkMemoryManager(
-    size_t ReservationGranularity, std::unique_ptr<MemoryMapper> Mapper)
-    : ReservationUnits(ReservationGranularity), AvailableMemory(AMAllocator),
-      Mapper(std::move(Mapper)) {}
+    size_t ReservationGranularity, std::unique_ptr<MemoryMapper> Mapper,
+    bool ColocatePerJITDylib)
+    : ReservationUnits(ReservationGranularity),
+      ColocatePerJITDylib(ColocatePerJITDylib), Mapper(std::move(Mapper)) {}
+
+// Lazily creates and stores Key's pool on first access. Pools are
+// heap-allocated behind unique_ptr so the returned reference survives map
+// rehashing, and AMAllocator (declared before the pools) outlives them.
+MapperJITLinkMemoryManager::AvailableMemoryMap &
+MapperJITLinkMemoryManager::getAvailableMemory(const JITLinkDylib *Key) {
+  auto &Pool = Pools[Key].AvailPool;
+  if (!Pool)
+    Pool = std::make_unique<AvailableMemoryMap>(AMAllocator);
+  return *Pool;
+}
+
+void MapperJITLinkMemoryManager::denySlabGrowth() {
+  std::lock_guard<std::mutex> Lock(Mutex);
+  OnSlabGrow = [](const JITLinkDylib *JD, size_t RequestedSize) -> Error {
+    return createStringError(
+        "JITDylib '%s' slab exhausted (single-slab mode); enable slab "
+        "growth to allow further reservations (%zu bytes requested)",
+        JD ? JD->getName().c_str() : "<unnamed>", RequestedSize);
+  };
+}
+
+void MapperJITLinkMemoryManager::allowSlabGrowth() {
+  std::lock_guard<std::mutex> Lock(Mutex);
+  OnSlabGrow = [](const JITLinkDylib *, size_t) -> Error {
+    return Error::success();
+  };
+}
+
+void MapperJITLinkMemoryManager::setSlabPolicy(SlabGrowthPolicy Policy) {
+  std::lock_guard<std::mutex> Lock(Mutex);
+  OnSlabGrow = std::move(Policy);
+}
+
+Expected<std::unique_ptr<MapperJITLinkMemoryManager>>
+createColocatingInProcessMemoryManager(
+    std::optional<size_t> ReservationGranularity) {
+  auto Mapper = InProcessMemoryMapper::Create();
+  if (!Mapper)
+    return Mapper.takeError();
+  return std::make_unique<MapperJITLinkMemoryManager>(
+      ReservationGranularity.value_or(
+          MapperJITLinkMemoryManager::defaultSlabSize()),
+      std::move(*Mapper),
+      /*ColocatePerJITDylib=*/true);
+}
 
 void MapperJITLinkMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
                                           OnAllocatedFunction OnAllocated) {
@@ -71,7 +119,11 @@ void MapperJITLinkMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
 
   auto TotalSize = SegsSizes->total();
 
-  auto CompleteAllocation = [this, &G, BL = std::move(BL),
+  // Which pool to draw from: the JITDylib's own pool when colocating
+  // per-JITDylib, otherwise a single shared (nullptr) pool.
+  const JITLinkDylib *PoolKey = ColocatePerJITDylib ? JD : nullptr;
+
+  auto CompleteAllocation = [this, PoolKey, &G, BL = std::move(BL),
                              OnAllocated = std::move(OnAllocated)](
                                 Expected<ExecutorAddrRange> Result) mutable {
     if (!Result) {
@@ -105,10 +157,12 @@ void MapperJITLinkMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
     }
 
     UsedMemory.insert({Result->Start, NextSegAddr - Result->Start});
+    AllocPoolKey[Result->Start] = PoolKey;
 
     if (NextSegAddr < Result->End) {
-      // Save the remaining memory for reuse in next allocation(s)
-      AvailableMemory.insert(NextSegAddr, Result->End - 1, true);
+      // Save the remaining memory for reuse by later allocations from the same
+      // pool.
+      getAvailableMemory(PoolKey).insert(NextSegAddr, Result->End - 1, true);
     }
     Mutex.unlock();
 
@@ -123,11 +177,12 @@ void MapperJITLinkMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
 
   Mutex.lock();
 
-  // find an already reserved range that is large enough
+  // find an already reserved range in this pool that is large enough
   ExecutorAddrRange SelectedRange{};
 
-  for (AvailableMemoryMap::iterator It = AvailableMemory.begin();
-       It != AvailableMemory.end(); It++) {
+  AvailableMemoryMap &Avail = getAvailableMemory(PoolKey);
+  for (AvailableMemoryMap::iterator It = Avail.begin(); It != Avail.end();
+       It++) {
     if (It.stop() - It.start() + 1 >= TotalSize) {
       SelectedRange = ExecutorAddrRange(It.start(), It.stop() + 1);
       It.erase();
@@ -136,8 +191,29 @@ void MapperJITLinkMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
   }
 
   if (SelectedRange.empty()) { // no already reserved range was found
+    // A reservation is needed. If this pool already owns one, reserving
+    // another (possibly out-of-range) slab may place its objects out of range,
+    // so consult the growth policy first.
+    bool IsFirstReservation = !Pools[PoolKey].Reserved;
+    Pools[PoolKey].Reserved = true;
     auto TotalAllocation = alignTo(TotalSize, ReservationUnits);
-    Mapper->reserve(TotalAllocation, std::move(CompleteAllocation));
+    if (!IsFirstReservation) {
+      if (auto Err = OnSlabGrow(JD, TotalAllocation))
+        return CompleteAllocation(std::move(Err));
+    }
+    Mapper->reserve(TotalAllocation,
+                    [this, PoolKey, IsFirstReservation,
+                     CompleteAllocation = std::move(CompleteAllocation)](
+                        Expected<ExecutorAddrRange> Result) mutable {
+                      // If this was the pool's first reservation attempt and it
+                      // failed, undo the Reserved flag so a later attempt is
+                      // treated as the first one again, rather than
+                      // incorrectly triggering the growth policy for a pool
+                      // that never got a slab.
+                      if (!Result && IsFirstReservation)
+                        Pools[PoolKey].Reserved = false;
+                      CompleteAllocation(std::move(Result));
+                    });
   } else {
     CompleteAllocation(SelectedRange);
   }
@@ -174,7 +250,11 @@ void MapperJITLinkMemoryManager::deallocate(
         ExecutorAddrDiff Size = UsedMemory[Addr];
 
         UsedMemory.erase(Addr);
-        AvailableMemory.insert(Addr, Addr + Size - 1, true);
+
+        // Return the range to the pool it was allocated from.
+        const JITLinkDylib *PoolKey = AllocPoolKey.lookup(Addr);
+        AllocPoolKey.erase(Addr);
+        getAvailableMemory(PoolKey).insert(Addr, Addr + Size - 1, true);
 
         FA.release();
       }

--- a/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
@@ -31,6 +31,7 @@ add_llvm_unittest(OrcJITTests
   LazyCallThroughAndReexportsTest.cpp
   LibraryResolverTest.cpp
   LinkGraphLinkingLayerTest.cpp
+  LLJITTest.cpp
   LookupAndApplyTest.cpp
   MachOBuilderTest.cpp
   MangleAndInternerTest.cpp

--- a/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
@@ -32,6 +32,7 @@ add_llvm_unittest(OrcJITTests
   LazyCallThroughAndReexportsTest.cpp
   LibraryResolverTest.cpp
   LinkGraphLinkingLayerTest.cpp
+  LLJITTest.cpp
   LookupAndRecordAddrsTest.cpp
   MachOBuilderTest.cpp
   MachOPlatformTest.cpp

--- a/llvm/unittests/ExecutionEngine/Orc/LLJITTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/LLJITTest.cpp
@@ -1,0 +1,103 @@
+//===------------------------- LLJITTest.cpp -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+#include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::orc;
+
+namespace {
+
+// Compile and run a trivial module through J and check it returns 42. The
+// function is marked nounwind so the Win64 backend does not emit .pdata/.xdata
+// unwind info: that info carries image-base-relative (ADDR32NB) relocations
+// which would require __ImageBase to be defined -- something a bare
+// ObjectLinkingLayer (no COFFPlatform) does not provide.
+static void compileRunAndCheck42(LLJIT &J) {
+  auto Ctx = std::make_unique<LLVMContext>();
+  auto M = std::make_unique<Module>("<test>", *Ctx);
+  M->setDataLayout(J.getDataLayout());
+
+  // int f() { return 42; }
+  auto *Int32Ty = Type::getInt32Ty(*Ctx);
+  auto *F = Function::Create(FunctionType::get(Int32Ty, false),
+                             Function::ExternalLinkage, "f", M.get());
+  F->setDoesNotThrow();
+  IRBuilder<> B(BasicBlock::Create(*Ctx, "entry", F));
+  B.CreateRet(ConstantInt::get(Int32Ty, 42));
+
+  ASSERT_THAT_ERROR(
+      J.addIRModule(ThreadSafeModule(std::move(M), std::move(Ctx))),
+      Succeeded());
+
+  auto FSym = J.lookup("f");
+  ASSERT_THAT_EXPECTED(FSym, Succeeded());
+
+  auto *FPtr = FSym->toPtr<int (*)()>();
+  EXPECT_EQ(FPtr(), 42);
+}
+
+// Build an LLJIT that uses the per-JITDylib-colocating slab allocator with the
+// host's default linker, then compile and run a trivial module through it. On
+// hosts where JITLink is the default (ELF/MachO) this exercises the slab
+// allocator end to end; on hosts that still default to RuntimeDyld (COFF today)
+// the allocator is constructed but unused, so this confirms the opt-in does no
+// harm there.
+TEST(LLJITTest, ColocatingSlabAllocator) {
+  InitializeNativeTarget();
+  InitializeNativeTargetAsmPrinter();
+
+  auto J = LLJITBuilder().setColocatingSlabAllocator().create();
+  if (!J) {
+    // No JIT support for the host (or native target not built in).
+    consumeError(J.takeError());
+    GTEST_SKIP() << "Could not create an LLJIT for the host";
+  }
+
+  compileRunAndCheck42(**J);
+}
+
+// Force the JITLink ObjectLinkingLayer regardless of the host's default linker,
+// so that on COFF (which otherwise uses RuntimeDyld and would ignore a
+// JITLinkMemoryManager) the colocating slab allocator is actually used. This is
+// the configuration that the eventual COFF-defaults-to-JITLink flip will make
+// the default.
+TEST(LLJITTest, ColocatingSlabAllocatorForcesJITLink) {
+  InitializeNativeTarget();
+  InitializeNativeTargetAsmPrinter();
+
+  auto J =
+      LLJITBuilder()
+          .setColocatingSlabAllocator()
+          .setObjectLinkingLayerCreator(
+              [](ExecutionSession &ES, jitlink::JITLinkMemoryManager &MemMgr)
+                  -> Expected<std::unique_ptr<ObjectLayer>> {
+                return std::make_unique<ObjectLinkingLayer>(ES, MemMgr);
+              })
+          .create();
+  if (!J) {
+    consumeError(J.takeError());
+    GTEST_SKIP() << "Could not create a JITLink-based LLJIT for the host";
+  }
+
+  compileRunAndCheck42(**J);
+}
+
+} // namespace

--- a/llvm/unittests/ExecutionEngine/Orc/MapperJITLinkMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/MapperJITLinkMemoryManagerTest.cpp
@@ -13,6 +13,8 @@
 #include "llvm/ExecutionEngine/Orc/MemoryMapper.h"
 #include "llvm/Testing/Support/Error.h"
 
+#include <new>
+
 using namespace llvm;
 using namespace llvm::jitlink;
 using namespace llvm::orc;
@@ -177,6 +179,252 @@ TEST(MapperJITLinkMemoryManagerTest, Coalescing) {
 
   auto Err4 = MemMgr->deallocate(std::move(*FA3));
   EXPECT_THAT_ERROR(std::move(Err4), Succeeded());
+}
+
+// A colocating (slab) allocator places all objects inside a single reservation,
+// so any two of them are close enough for a 32-bit PC-relative cross-object
+// reference: an x86-64 REL32 is a signed 32-bit displacement, i.e. the target
+// must be within +/-2GB of the reference. The default InProcessMemoryManager
+// does NOT guarantee this -- it allocates each object independently, so two
+// objects can land more than 2GB apart and a direct cross-object call/branch
+// would fail to relocate ("out of range"). This test verifies that the
+// Mapper-based slab allocator keeps separately-allocated objects within REL32
+// range.
+TEST(MapperJITLinkMemoryManagerTest, Colocation) {
+  auto Mapper = cantFail(InProcessMemoryMapper::Create());
+  auto MemMgr = std::make_unique<MapperJITLinkMemoryManager>(16 * 1024 * 1024,
+                                                             std::move(Mapper));
+  auto SSP = std::make_shared<SymbolStringPool>();
+
+  // Allocate several "objects", the way separate input files would be added.
+  constexpr unsigned NumObjects = 8;
+  SmallVector<JITLinkMemoryManager::FinalizedAlloc> Allocs;
+  uint64_t MinAddr = ~uint64_t(0), MaxAddr = 0;
+
+  for (unsigned I = 0; I != NumObjects; ++I) {
+    auto SSA = jitlink::SimpleSegmentAlloc::Create(
+        *MemMgr, SSP, Triple("x86_64-apple-darwin"), nullptr,
+        {{MemProt::Read, {4096, Align(16)}}});
+    EXPECT_THAT_EXPECTED(SSA, Succeeded());
+
+    uint64_t Addr =
+        ExecutorAddr(SSA->getSegInfo(MemProt::Read).Addr).getValue();
+    if (Addr < MinAddr)
+      MinAddr = Addr;
+    if (Addr > MaxAddr)
+      MaxAddr = Addr;
+
+    auto FA = SSA->finalize();
+    EXPECT_THAT_EXPECTED(FA, Succeeded());
+    Allocs.push_back(std::move(*FA));
+  }
+
+  // All objects sit inside the one ~16MB reservation, so the span between the
+  // lowest and highest is far below the 2GB REL32 limit.
+  constexpr uint64_t REL32Limit = uint64_t(1) << 31; // 2GB
+  EXPECT_LT(MaxAddr - MinAddr, REL32Limit);
+
+  for (auto &FA : Allocs)
+    EXPECT_THAT_ERROR(MemMgr->deallocate(std::move(FA)), Succeeded());
+}
+
+// With per-JITDylib colocation enabled, each JITDylib draws from its own pool
+// of reservations: a second JITDylib's allocation does NOT reuse the first
+// JITDylib's leftover space, so it triggers a fresh reservation. With the
+// default (single shared pool) the second JITDylib reuses the first's leftover,
+// so only one reservation is made. Counting reservations is a deterministic way
+// to observe that objects are being grouped per-JITDylib.
+TEST(MapperJITLinkMemoryManagerTest, ColocationPerJITDylib) {
+  auto SSP = std::make_shared<SymbolStringPool>();
+
+  // Allocate a small object in the given JITDylib and finalize it.
+  auto AllocSmall = [&](MapperJITLinkMemoryManager &MemMgr,
+                        const JITLinkDylib *JD) {
+    auto SSA = jitlink::SimpleSegmentAlloc::Create(
+        MemMgr, SSP, Triple("x86_64-apple-darwin"), JD,
+        {{MemProt::Read, {4096, Align(16)}}});
+    EXPECT_THAT_EXPECTED(SSA, Succeeded());
+    auto FA = SSA->finalize();
+    EXPECT_THAT_EXPECTED(FA, Succeeded());
+    return cantFail(std::move(FA));
+  };
+
+  // Per-JITDylib colocation ON: JD B cannot reuse JD A's reservation, so a
+  // second reservation is made.
+  {
+    auto Mapper = std::make_unique<CounterMapper>(
+        cantFail(InProcessMemoryMapper::Create()));
+    auto *Counter = static_cast<CounterMapper *>(Mapper.get());
+    MapperJITLinkMemoryManager MemMgr(16 * 1024 * 1024, std::move(Mapper),
+                                      /*ColocatePerJITDylib=*/true);
+    // Declared after MemMgr so they're destroyed first: MemMgr must outlive
+    // any JITLinkDylib it's used with.
+    JITLinkDylib JDA("A"), JDB("B");
+
+    auto FA_A = AllocSmall(MemMgr, &JDA);
+    EXPECT_EQ(Counter->ReserveCount, 1);
+    auto FA_B = AllocSmall(MemMgr, &JDB);
+    EXPECT_EQ(Counter->ReserveCount, 2); // separate reservation for JD B
+
+    // The two JITDylibs draw from separate reservations, so their objects
+    // should be at least one reservation unit apart.
+    ExecutorAddr AddrA = FA_A.getAddress(), AddrB = FA_B.getAddress();
+    EXPECT_GE(AddrA > AddrB ? AddrA - AddrB : AddrB - AddrA,
+              MemMgr.reservationUnits());
+
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(FA_A)), Succeeded());
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(FA_B)), Succeeded());
+  }
+
+  // Default (single shared pool): JD B reuses JD A's leftover, so only one
+  // reservation is made.
+  {
+    auto Mapper = std::make_unique<CounterMapper>(
+        cantFail(InProcessMemoryMapper::Create()));
+    auto *Counter = static_cast<CounterMapper *>(Mapper.get());
+    MapperJITLinkMemoryManager MemMgr(16 * 1024 * 1024, std::move(Mapper));
+    // Same ordering requirement as above: destroyed before MemMgr.
+    JITLinkDylib JDA("A"), JDB("B");
+
+    auto FA_A = AllocSmall(MemMgr, &JDA);
+    EXPECT_EQ(Counter->ReserveCount, 1);
+    auto FA_B = AllocSmall(MemMgr, &JDB);
+    EXPECT_EQ(Counter->ReserveCount, 1); // reused JD A's reservation
+
+    // The two JITDylibs share the same reservation, so their objects should
+    // be within one reservation unit of one another.
+    ExecutorAddr AddrA = FA_A.getAddress(), AddrB = FA_B.getAddress();
+    EXPECT_LT(AddrA > AddrB ? AddrA - AddrB : AddrB - AddrA,
+              MemMgr.reservationUnits());
+
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(FA_A)), Succeeded());
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(FA_B)), Succeeded());
+  }
+}
+
+// A destroyed JITDylib's pool should be freed, so a new JITDylib reusing the
+// same address gets its own reservation instead of inheriting the old one's
+// leftover space. Uses placement new to force that address reuse.
+TEST(MapperJITLinkMemoryManagerTest, PoolFreedOnJITDylibDestruction) {
+  constexpr size_t SlabSize = 64 * 1024;
+  auto SSP = std::make_shared<SymbolStringPool>();
+
+  auto Mapper = std::make_unique<CounterMapper>(
+      cantFail(InProcessMemoryMapper::Create()));
+  auto *Counter = static_cast<CounterMapper *>(Mapper.get());
+  MapperJITLinkMemoryManager MemMgr(SlabSize, std::move(Mapper),
+                                    /*ColocatePerJITDylib=*/true);
+
+  auto AllocSlabSized = [&](const JITLinkDylib *JD) {
+    return jitlink::SimpleSegmentAlloc::Create(
+        MemMgr, SSP, Triple("x86_64-apple-darwin"), JD,
+        {{MemProt::Read, {SlabSize, Align(1)}}});
+  };
+
+  alignas(JITLinkDylib) unsigned char Storage[sizeof(JITLinkDylib)];
+
+  auto *JD1 = new (Storage) JITLinkDylib("first");
+  auto SSA1 = AllocSlabSized(JD1);
+  EXPECT_THAT_EXPECTED(SSA1, Succeeded());
+  auto FA1 = SSA1->finalize();
+  EXPECT_THAT_EXPECTED(FA1, Succeeded());
+  EXPECT_EQ(Counter->ReserveCount, 1);
+  // Freeing it leaves the whole slab as free space in JD1's pool.
+  EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(*FA1)), Succeeded());
+
+  // JD1's destruction should drop that free space too.
+  JD1->~JITLinkDylib();
+
+  // JD2 occupies the exact address JD1 used to.
+  auto *JD2 = new (Storage) JITLinkDylib("second");
+  ASSERT_EQ(static_cast<void *>(JD1), static_cast<void *>(JD2));
+
+  auto SSA2 = AllocSlabSized(JD2);
+  EXPECT_THAT_EXPECTED(SSA2, Succeeded());
+  auto FA2 = SSA2->finalize();
+  EXPECT_THAT_EXPECTED(FA2, Succeeded());
+  // If JD1's pool wasn't freed, JD2 would reuse its leftover slab instead of
+  // reserving its own.
+  EXPECT_EQ(Counter->ReserveCount, 2);
+
+  EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(*FA2)), Succeeded());
+  JD2->~JITLinkDylib();
+}
+
+// denySlabGrowth() restricts each pool to a single reservation: once the first
+// slab is full, an allocation that needs fresh memory fails instead of spilling
+// into another (possibly out-of-range) slab. The default allows the growth.
+TEST(MapperJITLinkMemoryManagerTest, SingleSlab) {
+  constexpr size_t SlabSize = 64 * 1024;
+  auto SSP = std::make_shared<SymbolStringPool>();
+
+  // Allocate an object that fills a whole slab (so the next allocation cannot
+  // reuse leftover space and must reserve again).
+  auto AllocSlabSized = [&](MapperJITLinkMemoryManager &MemMgr) {
+    return jitlink::SimpleSegmentAlloc::Create(
+        MemMgr, SSP, Triple("x86_64-apple-darwin"), nullptr,
+        {{MemProt::Read, {SlabSize, Align(1)}}});
+  };
+
+  // Single-slab: the second allocation is rejected.
+  {
+    MapperJITLinkMemoryManager MemMgr(
+        SlabSize, cantFail(InProcessMemoryMapper::Create()));
+    MemMgr.denySlabGrowth();
+
+    auto SSA1 = AllocSlabSized(MemMgr);
+    EXPECT_THAT_EXPECTED(SSA1, Succeeded());
+    auto FA1 = SSA1->finalize();
+    EXPECT_THAT_EXPECTED(FA1, Succeeded());
+
+    EXPECT_THAT_EXPECTED(AllocSlabSized(MemMgr), Failed());
+
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(*FA1)), Succeeded());
+  }
+
+  // Default (multiple slabs allowed): the same second allocation succeeds by
+  // reserving another slab.
+  {
+    MapperJITLinkMemoryManager MemMgr(
+        SlabSize, cantFail(InProcessMemoryMapper::Create()));
+
+    auto SSA1 = AllocSlabSized(MemMgr);
+    EXPECT_THAT_EXPECTED(SSA1, Succeeded());
+    auto FA1 = SSA1->finalize();
+    EXPECT_THAT_EXPECTED(FA1, Succeeded());
+
+    auto SSA2 = AllocSlabSized(MemMgr);
+    EXPECT_THAT_EXPECTED(SSA2, Succeeded());
+    auto FA2 = SSA2->finalize();
+    EXPECT_THAT_EXPECTED(FA2, Succeeded());
+
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(*FA1)), Succeeded());
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(*FA2)), Succeeded());
+  }
+}
+
+// createColocatingInProcessMemoryManager() builds a working per-JITDylib-
+// colocating in-process allocator, and defaultSlabSize() reflects the host
+// pointer width.
+TEST(MapperJITLinkMemoryManagerTest, CreateColocatingInProcessMemoryManager) {
+  // Use a small explicit slab so the test doesn't reserve the 1GB default.
+  constexpr size_t ReservationGranularity = 64 * 1024;
+  auto MemMgr = createColocatingInProcessMemoryManager(ReservationGranularity);
+  ASSERT_THAT_EXPECTED(MemMgr, Succeeded());
+
+  auto SSP = std::make_shared<SymbolStringPool>();
+  auto SSA = jitlink::SimpleSegmentAlloc::Create(
+      **MemMgr, SSP, Triple("x86_64-apple-darwin"), nullptr,
+      {{MemProt::Read, {4096, Align(16)}}});
+  ASSERT_THAT_EXPECTED(SSA, Succeeded());
+  auto FA = SSA->finalize();
+  ASSERT_THAT_EXPECTED(FA, Succeeded());
+  EXPECT_THAT_ERROR((*MemMgr)->deallocate(std::move(*FA)), Succeeded());
+
+  if constexpr (sizeof(void *) >= 8)
+    EXPECT_EQ(MapperJITLinkMemoryManager::defaultSlabSize(), size_t(1) << 30);
+  else
+    EXPECT_EQ(MapperJITLinkMemoryManager::defaultSlabSize(), size_t(10) << 20);
 }
 
 } // namespace

--- a/llvm/unittests/ExecutionEngine/Orc/MapperJITLinkMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/MapperJITLinkMemoryManagerTest.cpp
@@ -179,4 +179,197 @@ TEST(MapperJITLinkMemoryManagerTest, Coalescing) {
   EXPECT_THAT_ERROR(std::move(Err4), Succeeded());
 }
 
+// A colocating (slab) allocator places all objects inside a single reservation,
+// so any two of them are close enough for a 32-bit PC-relative cross-object
+// reference: an x86-64 REL32 is a signed 32-bit displacement, i.e. the target
+// must be within +/-2GB of the reference. The default InProcessMemoryManager
+// does NOT guarantee this -- it allocates each object independently, so two
+// objects can land more than 2GB apart and a direct cross-object call/branch
+// would fail to relocate ("out of range"). This test verifies that the
+// Mapper-based slab allocator keeps separately-allocated objects within REL32
+// range.
+TEST(MapperJITLinkMemoryManagerTest, Colocation) {
+  auto Mapper = cantFail(InProcessMemoryMapper::Create());
+  auto MemMgr = std::make_unique<MapperJITLinkMemoryManager>(16 * 1024 * 1024,
+                                                             std::move(Mapper));
+  auto SSP = std::make_shared<SymbolStringPool>();
+
+  // Allocate several "objects", the way separate input files would be added.
+  constexpr unsigned NumObjects = 8;
+  SmallVector<JITLinkMemoryManager::FinalizedAlloc> Allocs;
+  uint64_t MinAddr = ~uint64_t(0), MaxAddr = 0;
+
+  for (unsigned I = 0; I != NumObjects; ++I) {
+    auto SSA = jitlink::SimpleSegmentAlloc::Create(
+        *MemMgr, SSP, Triple("x86_64-apple-darwin"), nullptr,
+        {{MemProt::Read, {4096, Align(16)}}});
+    EXPECT_THAT_EXPECTED(SSA, Succeeded());
+
+    uint64_t Addr =
+        ExecutorAddr(SSA->getSegInfo(MemProt::Read).Addr).getValue();
+    if (Addr < MinAddr)
+      MinAddr = Addr;
+    if (Addr > MaxAddr)
+      MaxAddr = Addr;
+
+    auto FA = SSA->finalize();
+    EXPECT_THAT_EXPECTED(FA, Succeeded());
+    Allocs.push_back(std::move(*FA));
+  }
+
+  // All objects sit inside the one ~16MB reservation, so the span between the
+  // lowest and highest is far below the 2GB REL32 limit.
+  constexpr uint64_t REL32Limit = uint64_t(1) << 31; // 2GB
+  EXPECT_LT(MaxAddr - MinAddr, REL32Limit);
+
+  for (auto &FA : Allocs)
+    EXPECT_THAT_ERROR(MemMgr->deallocate(std::move(FA)), Succeeded());
+}
+
+// With per-JITDylib colocation enabled, each JITDylib draws from its own pool
+// of reservations: a second JITDylib's allocation does NOT reuse the first
+// JITDylib's leftover space, so it triggers a fresh reservation. With the
+// default (single shared pool) the second JITDylib reuses the first's leftover,
+// so only one reservation is made. Counting reservations is a deterministic way
+// to observe that objects are being grouped per-JITDylib.
+TEST(MapperJITLinkMemoryManagerTest, ColocationPerJITDylib) {
+  JITLinkDylib JDA("A"), JDB("B");
+  auto SSP = std::make_shared<SymbolStringPool>();
+
+  // Allocate a small object in the given JITDylib and finalize it.
+  auto AllocSmall = [&](MapperJITLinkMemoryManager &MemMgr,
+                        const JITLinkDylib *JD) {
+    auto SSA = jitlink::SimpleSegmentAlloc::Create(
+        MemMgr, SSP, Triple("x86_64-apple-darwin"), JD,
+        {{MemProt::Read, {4096, Align(16)}}});
+    EXPECT_THAT_EXPECTED(SSA, Succeeded());
+    auto FA = SSA->finalize();
+    EXPECT_THAT_EXPECTED(FA, Succeeded());
+    return cantFail(std::move(FA));
+  };
+
+  // Per-JITDylib colocation ON: JD B cannot reuse JD A's reservation, so a
+  // second reservation is made.
+  {
+    auto Mapper = std::make_unique<CounterMapper>(
+        cantFail(InProcessMemoryMapper::Create()));
+    auto *Counter = static_cast<CounterMapper *>(Mapper.get());
+    MapperJITLinkMemoryManager MemMgr(16 * 1024 * 1024, std::move(Mapper),
+                                      /*ColocatePerJITDylib=*/true);
+
+    auto FA_A = AllocSmall(MemMgr, &JDA);
+    EXPECT_EQ(Counter->ReserveCount, 1);
+    auto FA_B = AllocSmall(MemMgr, &JDB);
+    EXPECT_EQ(Counter->ReserveCount, 2); // separate reservation for JD B
+
+    // The two JITDylibs draw from separate reservations, so their objects
+    // should be at least one reservation unit apart.
+    ExecutorAddr AddrA = FA_A.getAddress(), AddrB = FA_B.getAddress();
+    EXPECT_GE(AddrA > AddrB ? AddrA - AddrB : AddrB - AddrA,
+              MemMgr.reservationUnits());
+
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(FA_A)), Succeeded());
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(FA_B)), Succeeded());
+  }
+
+  // Default (single shared pool): JD B reuses JD A's leftover, so only one
+  // reservation is made.
+  {
+    auto Mapper = std::make_unique<CounterMapper>(
+        cantFail(InProcessMemoryMapper::Create()));
+    auto *Counter = static_cast<CounterMapper *>(Mapper.get());
+    MapperJITLinkMemoryManager MemMgr(16 * 1024 * 1024, std::move(Mapper));
+
+    auto FA_A = AllocSmall(MemMgr, &JDA);
+    EXPECT_EQ(Counter->ReserveCount, 1);
+    auto FA_B = AllocSmall(MemMgr, &JDB);
+    EXPECT_EQ(Counter->ReserveCount, 1); // reused JD A's reservation
+
+    // The two JITDylibs share the same reservation, so their objects should
+    // be within one reservation unit of one another.
+    ExecutorAddr AddrA = FA_A.getAddress(), AddrB = FA_B.getAddress();
+    EXPECT_LT(AddrA > AddrB ? AddrA - AddrB : AddrB - AddrA,
+              MemMgr.reservationUnits());
+
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(FA_A)), Succeeded());
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(FA_B)), Succeeded());
+  }
+}
+
+// denySlabGrowth() restricts each pool to a single reservation: once the first
+// slab is full, an allocation that needs fresh memory fails instead of spilling
+// into another (possibly out-of-range) slab. The default allows the growth.
+TEST(MapperJITLinkMemoryManagerTest, SingleSlab) {
+  constexpr size_t SlabSize = 64 * 1024;
+  auto SSP = std::make_shared<SymbolStringPool>();
+
+  // Allocate an object that fills a whole slab (so the next allocation cannot
+  // reuse leftover space and must reserve again).
+  auto AllocSlabSized = [&](MapperJITLinkMemoryManager &MemMgr) {
+    return jitlink::SimpleSegmentAlloc::Create(
+        MemMgr, SSP, Triple("x86_64-apple-darwin"), nullptr,
+        {{MemProt::Read, {SlabSize, Align(1)}}});
+  };
+
+  // Single-slab: the second allocation is rejected.
+  {
+    MapperJITLinkMemoryManager MemMgr(
+        SlabSize, cantFail(InProcessMemoryMapper::Create()));
+    MemMgr.denySlabGrowth();
+
+    auto SSA1 = AllocSlabSized(MemMgr);
+    EXPECT_THAT_EXPECTED(SSA1, Succeeded());
+    auto FA1 = SSA1->finalize();
+    EXPECT_THAT_EXPECTED(FA1, Succeeded());
+
+    EXPECT_THAT_EXPECTED(AllocSlabSized(MemMgr), Failed());
+
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(*FA1)), Succeeded());
+  }
+
+  // Default (multiple slabs allowed): the same second allocation succeeds by
+  // reserving another slab.
+  {
+    MapperJITLinkMemoryManager MemMgr(
+        SlabSize, cantFail(InProcessMemoryMapper::Create()));
+
+    auto SSA1 = AllocSlabSized(MemMgr);
+    EXPECT_THAT_EXPECTED(SSA1, Succeeded());
+    auto FA1 = SSA1->finalize();
+    EXPECT_THAT_EXPECTED(FA1, Succeeded());
+
+    auto SSA2 = AllocSlabSized(MemMgr);
+    EXPECT_THAT_EXPECTED(SSA2, Succeeded());
+    auto FA2 = SSA2->finalize();
+    EXPECT_THAT_EXPECTED(FA2, Succeeded());
+
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(*FA1)), Succeeded());
+    EXPECT_THAT_ERROR(MemMgr.deallocate(std::move(*FA2)), Succeeded());
+  }
+}
+
+// createColocatingInProcessMemoryManager() builds a working per-JITDylib-
+// colocating in-process allocator, and defaultSlabSize() reflects the host
+// pointer width.
+TEST(MapperJITLinkMemoryManagerTest, CreateColocatingInProcessMemoryManager) {
+  // Use a small explicit slab so the test doesn't reserve the 1GB default.
+  constexpr size_t ReservationGranularity = 64 * 1024;
+  auto MemMgr = createColocatingInProcessMemoryManager(ReservationGranularity);
+  ASSERT_THAT_EXPECTED(MemMgr, Succeeded());
+
+  auto SSP = std::make_shared<SymbolStringPool>();
+  auto SSA = jitlink::SimpleSegmentAlloc::Create(
+      **MemMgr, SSP, Triple("x86_64-apple-darwin"), nullptr,
+      {{MemProt::Read, {4096, Align(16)}}});
+  ASSERT_THAT_EXPECTED(SSA, Succeeded());
+  auto FA = SSA->finalize();
+  ASSERT_THAT_EXPECTED(FA, Succeeded());
+  EXPECT_THAT_ERROR((*MemMgr)->deallocate(std::move(*FA)), Succeeded());
+
+  if constexpr (sizeof(void *) >= 8)
+    EXPECT_EQ(MapperJITLinkMemoryManager::defaultSlabSize(), size_t(1) << 30);
+  else
+    EXPECT_EQ(MapperJITLinkMemoryManager::defaultSlabSize(), size_t(10) << 20);
+}
+
 } // namespace


### PR DESCRIPTION
MapperJITLinkMemoryManager can now keep each JITDylib's objects within a single reserved slab, so they stay within range of one another for direct (e.g. x86-64 REL32, +/-2GB) references instead of needing GOT/stub indirection.
Adds:

- ColocatePerJITDylib mode (per-JITDylib reservation pools).

- A growth policy (allowSingleSlab/allowMultipleSlabs/setOnSecondSlab) consulted before reserving a second slab for a pool.

- CreateColocatingInProcess() and defaultSlabSize() (1 GiB on 64-bit, 10 MiB on 32-bit).

- LLJITBuilder::setColocatingSlabAllocator() to opt in.

This is opt-in only; the default memory manager is unchanged.

Makes a per-JITDylib colocating slab allocator available in ORC, as an opt-in. When enabled, MapperJITLinkMemoryManager draws each JITDylib's allocations from its own large reservation, keeping that JITDylib's objects close enough to reference one another with direct, range-limited relocations (e.g. x86-64 REL32) rather than GOT/stub indirection.

What's new:

- Per-JITDylib reservation pools (ColocatePerJITDylib).

- Growth policy: by default a JITDylib may grow into additional slabs; `allowSingleSlab()` makes a full slab fail instead, and `setOnSecondSlab()` takes a custom policy.

- CreateColocatingInProcess() factory + defaultSlabSize() (1 GiB / 10 MiB).

- LLJITBuilder::setColocatingSlabAllocator() opt-in; the default memory manager is unchanged.

Tests: extends `MapperJITLinkMemoryManagerTest` (colocation, per-JITDylib pools, single-slab growth, factory) and adds LLJITTest covering the builder opt-in on both the default and a forced-JITLink configuration. Docs added to ORCv2.rst.

Follows the maintainer guidance on the RFC: opt-in now (Windows-first), with the builder wrapper structured so flipping to the default later is a small change in `LLJIT::createMemoryManager`.

Partly implements github issue: https://github.com/llvm/llvm-project/issues/190122
In the comment section of the github issue there is this comment https://github.com/llvm/llvm-project/issues/190122#issuecomment-4617328036
This PR implements point 1 Slab allocator.