### PR TITLE
[FIRToSCF] propagate acc.par_dims during fir.do_loop conversion

### DIFF
--- a/flang/lib/Optimizer/Transforms/FIRToSCF.cpp
+++ b/flang/lib/Optimizer/Transforms/FIRToSCF.cpp
@@ -8,6 +8,7 @@
 
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Transforms/Passes.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Transforms/WalkPatternRewriteDriver.h"
 
@@ -127,6 +128,11 @@ struct DoLoopConversion : public mlir::OpRewritePattern<fir::DoLoopOp> {
     // Copy loop annotations from the fir.do_loop to scf loop op.
     if (auto ann = doLoopOp.getLoopAnnotation())
       scfLoopOp->setAttr("loop_annotation", *ann);
+
+    // Copy any OpenACC parallel dimensions from the fir.do_loop to the scf loop
+    // op.
+    if (auto parDims = doLoopOp->getAttr(mlir::acc::GPUParallelDimsAttr::name))
+      scfLoopOp->setAttr(mlir::acc::GPUParallelDimsAttr::name, parDims);
 
     rewriter.replaceOp(doLoopOp, scfLoopOp);
     return mlir::success();

--- a/flang/test/Fir/FirToSCF/do-loop.fir
+++ b/flang/test/Fir/FirToSCF/do-loop.fir
@@ -329,3 +329,14 @@ func.func @nested_loop(%arg0: !fir.ref<!fir.array<100x100xi32>>) {
   }
   return
 }
+
+// CHECK-LABEL: func.func @propagate_par_dims
+// CHECK:         scf.for {{.*}} {
+// CHECK:         } {acc.par_dims = #acc<par_dims[sequential]>}
+func.func @propagate_par_dims() {
+  %c1 = arith.constant 1 : index
+  %c100 = arith.constant 100 : index
+  fir.do_loop %arg1 = %c1 to %c100 step %c1 attributes {acc.par_dims = #acc<par_dims[sequential]>} {
+  }
+  return
+}


### PR DESCRIPTION
Copy any OpenACC parallel dimensions from the fir.do_loop to the scf op