### PR TITLE
[flang-rt] Fix -Wunused-template in time intrinsics and test helpers (NFC)

### DIFF
--- a/flang-rt/lib/runtime/time-intrinsic.cpp
+++ b/flang-rt/lib/runtime/time-intrinsic.cpp
@@ -54,7 +54,8 @@ using fallback_implementation = double;
 using preferred_implementation = int;
 
 // This is the fallback implementation, which should work everywhere.
-template <typename Unused = void> double GetCpuTime(fallback_implementation) {
+template <typename Unused = void>
+[[maybe_unused]] double GetCpuTime(fallback_implementation) {
   std::clock_t timestamp{std::clock()};
   if (timestamp != static_cast<std::clock_t>(-1)) {
     return static_cast<double>(timestamp) / CLOCKS_PER_SEC;
@@ -106,7 +107,7 @@ template <typename Unused = void> double GetCpuTime(fallback_implementation) {
 // POSIX implementation using clock_gettime. This is only enabled where
 // clock_gettime is available.
 template <typename T = int, typename U = struct timespec>
-double GetCpuTime(preferred_implementation,
+[[maybe_unused]] double GetCpuTime(preferred_implementation,
     // We need some dummy parameters to pass to decltype(clock_gettime).
     T ClockId = 0, U *Timespec = nullptr,
     decltype(clock_gettime(ClockId, Timespec)) *Enabled = nullptr) {
@@ -165,7 +166,8 @@ static count_t ConvertTimevalToCount(int kind, const struct timeval &tval) {
 }
 
 template <typename Unused = void>
-static count_t GetSystemClockCount(int kind, fallback_implementation) {
+[[maybe_unused]] static count_t GetSystemClockCount(
+    int kind, fallback_implementation) {
   struct timeval tval;
 
   if (gettimeofday(&tval, /*timezone=*/nullptr) != 0) {
@@ -192,7 +194,8 @@ count_t ConvertTimeSpecToCount(int kind, const struct timespec &tspec) {
 #ifndef _AIX
 // More accurate version with nanosecond accuracy
 template <typename Unused = void>
-static count_t GetSystemClockCount(int kind, fallback_implementation) {
+[[maybe_unused]] static count_t GetSystemClockCount(
+    int kind, fallback_implementation) {
   struct timespec tspec;
 
   if (timespec_get(&tspec, TIME_UTC) < 0) {
@@ -208,12 +211,14 @@ static count_t GetSystemClockCount(int kind, fallback_implementation) {
 #endif // !NO_TIMESPEC
 
 template <typename Unused = void>
-static count_t GetSystemClockCountRate(int kind, fallback_implementation) {
+[[maybe_unused]] static count_t GetSystemClockCountRate(
+    int kind, fallback_implementation) {
   return kind >= 8 ? NS_PER_SEC : kind >= 2 ? MS_PER_SEC : DS_PER_SEC;
 }
 
 template <typename Unused = void>
-static count_t GetSystemClockCountMax(int kind, fallback_implementation) {
+[[maybe_unused]] static count_t GetSystemClockCountMax(
+    int kind, fallback_implementation) {
   unsigned_count_t maxCount{GetHUGE(kind)};
   return maxCount;
 }
@@ -221,7 +226,8 @@ static count_t GetSystemClockCountMax(int kind, fallback_implementation) {
 #ifndef NO_TIMESPEC
 #ifdef CLOCKID_ELAPSED_TIME
 template <typename T = int, typename U = struct timespec>
-static count_t GetSystemClockCount(int kind, preferred_implementation,
+[[maybe_unused]] static count_t GetSystemClockCount(int kind,
+    preferred_implementation,
     // We need some dummy parameters to pass to decltype(clock_gettime).
     T ClockId = 0, U *Timespec = nullptr,
     decltype(clock_gettime(ClockId, Timespec)) *Enabled = nullptr) {
@@ -238,7 +244,8 @@ static count_t GetSystemClockCount(int kind, preferred_implementation,
 #endif // CLOCKID_ELAPSED_TIME
 
 template <typename T = int, typename U = struct timespec>
-static count_t GetSystemClockCountRate(int kind, preferred_implementation,
+[[maybe_unused]] static count_t GetSystemClockCountRate(int kind,
+    preferred_implementation,
     // We need some dummy parameters to pass to decltype(clock_gettime).
     T ClockId = 0, U *Timespec = nullptr,
     decltype(clock_gettime(ClockId, Timespec)) *Enabled = nullptr) {
@@ -246,7 +253,8 @@ static count_t GetSystemClockCountRate(int kind, preferred_implementation,
 }
 
 template <typename T = int, typename U = struct timespec>
-static count_t GetSystemClockCountMax(int kind, preferred_implementation,
+[[maybe_unused]] static count_t GetSystemClockCountMax(int kind,
+    preferred_implementation,
     // We need some dummy parameters to pass to decltype(clock_gettime).
     T ClockId = 0, U *Timespec = nullptr,
     decltype(clock_gettime(ClockId, Timespec)) *Enabled = nullptr) {
@@ -361,14 +369,16 @@ static std::size_t getUTCOffsetToBuffer(
 // SFINAE helper to return the struct tm.tm_gmtoff which is not a POSIX standard
 // field.
 template <int KIND, typename TM = struct tm>
-Fortran::runtime::CppTypeFor<Fortran::common::TypeCategory::Integer, KIND>
+[[maybe_unused]] Fortran::runtime::CppTypeFor<
+    Fortran::common::TypeCategory::Integer, KIND>
 GetGmtOffset(const TM &tm, preferred_implementation,
     decltype(tm.tm_gmtoff) *Enabled = nullptr) {
   // Returns the GMT offset in minutes.
   return tm.tm_gmtoff / 60;
 }
 template <int KIND, typename TM = struct tm>
-Fortran::runtime::CppTypeFor<Fortran::common::TypeCategory::Integer, KIND>
+[[maybe_unused]] Fortran::runtime::CppTypeFor<
+    Fortran::common::TypeCategory::Integer, KIND>
 GetGmtOffset(const TM &tm, fallback_implementation) {
   // tm.tm_gmtoff is not available, there may be platform dependent alternatives
   // (such as using timezone from <time.h> when available), but so far just

--- a/flang-rt/unittests/Runtime/tools.h
+++ b/flang-rt/unittests/Runtime/tools.h
@@ -21,19 +21,19 @@
 namespace Fortran::runtime {
 
 template <typename A>
-static void StoreElement(void *p, const A &x, std::size_t bytes) {
+void StoreElement(void *p, const A &x, std::size_t bytes) {
   std::memcpy(p, &x, bytes);
 }
 
 template <typename CHAR>
-static void StoreElement(
+void StoreElement(
     void *p, const std::basic_string<CHAR> &str, std::size_t bytes) {
   ASSERT_LE(bytes, sizeof(CHAR) * str.size());
   std::memcpy(p, str.data(), bytes);
 }
 
 template <TypeCategory CAT, int KIND, typename A>
-static OwningPtr<Descriptor> MakeArray(const std::vector<int> &shape,
+OwningPtr<Descriptor> MakeArray(const std::vector<int> &shape,
     const std::vector<A> &data,
     std::size_t elemLen = CAT == TypeCategory::Complex ? 2 * KIND : KIND) {
   auto rank{static_cast<int>(shape.size())};


### PR DESCRIPTION
`time-intrinsic.cpp` implements the timing intrinsics as SFINAE overload sets (preferred/fallback per platform), so on any given platform some overloads are intentionally never instantiated and trip -Wunused-template. Mark all variants [[maybe_unused]].

`StoreElement` and `MakeArray` in `unittests/Runtime/tools.h` are static function templates in a header, so any test TU that includes it without using all of them trips the warning.

Part of #202945