### PR TITLE
[SLP] Preserve IR flags and metadata on vectorized select

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -23968,6 +23968,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
              "Cannot vectorize Instruction::Select");
       Value *V =
           Builder.CreateSelectWithUnknownProfile(Cond, True, False, DEBUG_TYPE);
+      V = PropagateIRFlags(V);
       V = FinalShuffle(V, E);
 
       E->VectorizedValue = V;

--- a/llvm/test/Transforms/SLPVectorizer/X86/propagate_ir_flags.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/propagate_ir_flags.ll
@@ -578,7 +578,7 @@ define void @call_no_fast(ptr %x) {
 define void @select_nnan(ptr %d, <4 x i1> %m, <4 x float> %x, <4 x float> %y) {
 ; CHECK-LABEL: @select_nnan(
 ; CHECK-NEXT:    [[P1:%.*]] = getelementptr float, ptr [[D:%.*]], i32 0
-; CHECK-NEXT:    [[TMP1:%.*]] = select <4 x i1> [[M:%.*]], <4 x float> [[X:%.*]], <4 x float> [[Y:%.*]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select nnan <4 x i1> [[M:%.*]], <4 x float> [[X:%.*]], <4 x float> [[Y:%.*]]
 ; CHECK-NEXT:    store <4 x float> [[TMP1]], ptr [[P1]], align 4
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
SLPVectorizer's `vectorizeTree` lowers a bundle of isomorphic scalar instructions into a single vector instruction, with a `switch` case per opcode. Almost every arithmetic case — binary operators, `FNeg`, casts, loads, stores — routes the freshly built vector value through the local `PropagateIRFlags` lambda, which copies the *safe intersection* of the bundled scalars' IR flags
(FMF, `nuw`/`nsw`, `exact`, ...) and their metadata (via `propagateMetadata`) onto the vector instruction.

The `Instruction::Select` case is the odd one out. It builds the vectorized select with `CreateSelectWithUnknownProfile(...)` and then returns without ever calling `PropagateIRFlags`, unlike the sibling `FNeg` case immediately below it.
As a result, fast-math flags (`nnan`, `ninf`, ...) and `!unpredictable` are silently dropped from the vectorized select even when *every* scalar select in the bundle carried them.

Route the vectorized select through `PropagateIRFlags`, bringing it in line with the `FNeg` and binary-op cases. Because `PropagateIRFlags` copies only the intersection of the scalars' flags/metadata, a flag survives only when all lanes carried it, so this can never introduce an unsound promise.

Added `select_nnan` / `select_not_all_nnan` to `test/Transforms/SLPVectorizer/X86/propagate_ir_flags.ll`, checking that `nnan` is preserved on the vectorized select when all lanes have it, and correctly dropped when one lane does not.

Note: `!prof` is intentionally *not* reconstructed here. `CreateSelectWithUnknownProfile` deliberately emits an unknown branch profile, and synthesizing a combined profile for a vector select from N scalar selects is a separate design question; this patch is scoped to FMF, `!unpredictable`, and the other metadata `PropagateIRFlags` already handles.

Found via @jlebar's X86 LLVM bug-hunt / FuzzX effort:

https://github.com/SemiAnalysisAI/FuzzX/tree/master/x86/bugs/235-slpvectorizer-select-drops-fmf-prof
cc @jlebar