### PR TITLE
[OpenMP] Remove internal linkage from __kmp_wait template (NFC)

### DIFF
--- a/openmp/runtime/src/kmp_dispatch.h
+++ b/openmp/runtime/src/kmp_dispatch.h
@@ -291,8 +291,8 @@ template <typename T> kmp_uint32 __kmp_eq(T value, T checker) {
     TODO: make inline function (move to header file for icl)
 */
 template <typename UT>
-static UT __kmp_wait(volatile UT *spinner, UT checker,
-                     kmp_uint32 (*pred)(UT, UT) USE_ITT_BUILD_ARG(void *obj)) {
+UT __kmp_wait(volatile UT *spinner, UT checker,
+              kmp_uint32 (*pred)(UT, UT) USE_ITT_BUILD_ARG(void *obj)) {
   // note: we may not belong to a team at this point
   volatile UT *spin = spinner;
   UT check = checker;


### PR DESCRIPTION
__kmp_wait in kmp_dispatch.h is a static function template in a header, so any TU that includes it without instantiating it trips -Wunused-template (kmp_runtime.cpp, kmp_affinity.cpp, kmp_global.cpp, kmp_settings.cpp). It is used by kmp_dispatch.cpp and kmp_dispatch_hier.h. Drop static, which the comment above it already suggests.

Part of #202945