### PR TITLE
[libc] Fix build failure with ASSUME_ROUND_NEAREST_ONLY

### DIFF
--- a/libc/src/stdio/printf_core/float_hex_converter.h
+++ b/libc/src/stdio/printf_core/float_hex_converter.h
@@ -115,9 +115,9 @@ LIBC_INLINE int convert_float_hex_exp(Writer<write_mode> *writer,
 #ifdef LIBC_MATH_HAS_ASSUME_ROUND_NEAREST_ONLY
     // Round to nearest, if it's exactly halfway then round to even.
     if (truncated_bits > halfway_const)
-      ++mantissa;
+      ++properties.mantissa;
     else if (truncated_bits == halfway_const)
-      mantissa = mantissa + (mantissa & 1);
+      properties.mantissa = properties.mantissa + (properties.mantissa & 1);
 #else
     switch (fputil::quick_get_round()) {
     case FE_TONEAREST:


### PR DESCRIPTION
Commit 03c62ca40d19ba0 moved some local variables of `convert_float_hex_exp` into a struct called `properties`, but didn't edit the #ifdef branch for `LIBC_MATH_HAS_ASSUME_ROUND_NEAREST_ONLY`, so builds with that definition failed.