### PR TITLE
[mlir][tosa] Fix regression in  mlir StableHLO tests due to PR #203583

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.h
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.h
@@ -92,7 +92,7 @@ public:
   }
 };
 
-LogicalResult verifyBlockScaledTensorType(Operation &op, mlir::Type type);
+LogicalResult verifyBlockScaledTensorType(mlir::Type type);
 
 } // namespace tosa
 } // namespace OpTrait

--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaTypesBase.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaTypesBase.td
@@ -159,7 +159,7 @@ def AtLeastRankOne : And<[
 
 def IsValidBlockScaledTensorType
     : CPred<"::mlir::succeeded(::mlir::OpTrait::tosa::"
-            "verifyBlockScaledTensorType($_op, $_self))">;
+            "verifyBlockScaledTensorType($_self))">;
 
 class TosaTensorOf<list<Type> allowedTypes,
                    string summary = "tosa-conformant tensor">

--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -740,8 +740,7 @@ LogicalResult mlir::tosa::mxint8Type::convertFromAttribute(
 // TOSA block scaling utilities.
 //===----------------------------------------------------------------------===//
 
-LogicalResult OpTrait::tosa::verifyBlockScaledTensorType(Operation &op,
-                                                         mlir::Type type) {
+LogicalResult OpTrait::tosa::verifyBlockScaledTensorType(mlir::Type type) {
   const auto tensorType = llvm::cast<ShapedType>(type);
   const BlockScaledType elemType =
       llvm::dyn_cast<BlockScaledType>(tensorType.getElementType());
@@ -752,9 +751,7 @@ LogicalResult OpTrait::tosa::verifyBlockScaledTensorType(Operation &op,
     return success();
 
   if (tensorType.getRank() == 0)
-    return op.emitError()
-           << "tensor type " << type
-           << " does not support block scaling on scalar tensors";
+    return failure();
 
   const int64_t blockedDimension = tensorType.getShape().back();
   if (ShapedType::isDynamic(blockedDimension))
@@ -763,10 +760,7 @@ LogicalResult OpTrait::tosa::verifyBlockScaledTensorType(Operation &op,
   const uint32_t blockSize =
       BlockShapeAttr::getBlockShapeValue(elemType.getBlockShape());
   if (blockedDimension % blockSize != 0)
-    return op.emitError()
-           << "tensor type " << type
-           << " blocked dimension must be a multiple of block size, got "
-           << blockedDimension << " and block size " << blockSize;
+    return failure();
 
   return success();
 }

--- a/mlir/test/Dialect/Tosa/verifier.mlir
+++ b/mlir/test/Dialect/Tosa/verifier.mlir
@@ -1675,7 +1675,6 @@ func.func @test_cast_between_block_scaled(%arg0: tensor<4x32x!tosa.block_scaled<
 // -----
 
 func.func @test_block_scaled_cast_invalid_block_shape(%arg0: tensor<1x16x31x!tosa.block_scaled<BLOCK_SHAPE_32:f8E8M0FNU:f8E4M3FN>>) -> tensor<1x16x31xf32> {
-  // expected-error@+2 {{tensor type 'tensor<1x16x31x!tosa.block_scaled<BLOCK_SHAPE_32:f8E8M0FNU:f8E4M3FN>>' blocked dimension must be a multiple of block size, got 31 and block size 32}}
   // expected-error@+1 {{'tosa.cast' op operand #0 must be tosa-conformant tensor of number values, but got 'tensor<1x16x31x!tosa.block_scaled<BLOCK_SHAPE_32:f8E8M0FNU:f8E4M3FN>>'}}
   %0 = tosa.cast %arg0 : (tensor<1x16x31x!tosa.block_scaled<BLOCK_SHAPE_32:f8E8M0FNU:f8E4M3FN>>) -> tensor<1x16x31xf32>
   return %0 : tensor<1x16x31xf32>
@@ -1684,7 +1683,6 @@ func.func @test_block_scaled_cast_invalid_block_shape(%arg0: tensor<1x16x31x!tos
 // -----
 
 func.func @test_block_scaled_cast_scalar(%arg0: tensor<!tosa.block_scaled<BLOCK_SHAPE_32:f8E8M0FNU:f8E4M3FN>>) -> tensor<f32> {
-  // expected-error@+2 {{tensor type 'tensor<!tosa.block_scaled<BLOCK_SHAPE_32:f8E8M0FNU:f8E4M3FN>>' does not support block scaling on scalar tensors}}
   // expected-error@+1 {{'tosa.cast' op operand #0 must be tosa-conformant tensor of number values, but got 'tensor<!tosa.block_scaled<BLOCK_SHAPE_32:f8E8M0FNU:f8E4M3FN>>'}}
   %0 = tosa.cast %arg0 : (tensor<!tosa.block_scaled<BLOCK_SHAPE_32:f8E8M0FNU:f8E4M3FN>>) -> tensor<f32>
   return %0 : tensor<f32>


### PR DESCRIPTION
StableHLO tests have regression due to use of additional op parameter in verifyBlockScaledTensorType

This adjusts  https://github.com/llvm/llvm-project/pull/203583  and fixes many of stablehlo/tests
