### PR TITLE
[PPC] Constrain register in VSPLT of XXSLDWI transform

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
+++ b/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
@@ -890,7 +890,7 @@ bool PPCMIPeephole::simplifyCode() {
                               << " to " << NewElem << " in instruction: ");
             LLVM_DEBUG(MI.dump());
             if (!MRI->constrainRegClass(ShiftOp1, &PPC::VRRCRegClass))
-              llvm_unreachable("vrrc is subset of vsrc");
+              llvm_unreachable("Can't fail because vrrc is subset of vsrc");
             addRegToUpdate(MI.getOperand(OpNo).getReg());
             addRegToUpdate(ShiftOp1);
             MI.getOperand(OpNo).setReg(ShiftOp1);

--- a/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
+++ b/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
@@ -889,6 +889,8 @@ bool PPCMIPeephole::simplifyCode() {
             LLVM_DEBUG(dbgs() << "Changing splat immediate from " << SplatImm
                               << " to " << NewElem << " in instruction: ");
             LLVM_DEBUG(MI.dump());
+            if (!MRI->constrainRegClass(ShiftOp1, &PPC::VRRCRegClass))
+              llvm_unreachable("vrrc is subset of vsrc");
             addRegToUpdate(MI.getOperand(OpNo).getReg());
             addRegToUpdate(ShiftOp1);
             MI.getOperand(OpNo).setReg(ShiftOp1);

--- a/llvm/test/CodeGen/PowerPC/splat-after-xxsldwi.ll
+++ b/llvm/test/CodeGen/PowerPC/splat-after-xxsldwi.ll
@@ -20,3 +20,24 @@ entry:
   %foldExtExtBinop = and <4 x i8> %shift, %conv4
   ret <4 x i8> %foldExtExtBinop
 }
+
+define <4 x i8> @backsmith_pure_load(ptr %p) {
+; CHECK-LABEL: backsmith_pure_load:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    addi r3, r3, 16
+; CHECK-NEXT:    lxvw4x vs34, 0, r3
+; CHECK-NEXT:    ld r3, L..C1(r2) # %const.0
+; CHECK-NEXT:    lxvw4x vs36, 0, r3
+; CHECK-NEXT:    xxsldwi vs35, vs34, vs34, 1
+; CHECK-NEXT:    vspltb v2, v2, 3
+; CHECK-NEXT:    vperm v3, v3, v3, v4
+; CHECK-NEXT:    xxland vs34, vs34, vs35
+; CHECK-NEXT:    blr
+entry:
+  %v = load <8 x i32>, ptr %p
+  %shuffle = shufflevector <8 x i32> %v, <8 x i32> zeroinitializer, <4 x i32> <i32 5, i32 6, i32 7, i32 4>
+  %conv4 = trunc <4 x i32> %shuffle to <4 x i8>
+  %shift = shufflevector <4 x i8> %conv4, <4 x i8> zeroinitializer, <4 x i32> <i32 3, i32 poison, i32 poison, i32 poison>
+  %foldExtExtBinop = and <4 x i8> %shift, %conv4
+  ret <4 x i8> %foldExtExtBinop
+}


### PR DESCRIPTION
XXSLDWI takes a vsrc register, but the VSPLT opcodes only take vrrc. vrrc is a subset of vsrc, so fix this by constraining the register class.

Note: I'm not very familiar with this part of the backend, so I'm not fully confident just constraining the register class this way is the right thing to do. The alternative would be to emit a COPY I guess.