### PR TITLE
[Clang] No longer reject call expression whose type is a not-yet-deduced auto type.

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -815,6 +815,7 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 - Fixed a preprocessor assertion failure triggered when parsing an invalid template-id starting with `::template operator`. (#GH186582)
 - Fixed a crash when a function template is defined as a non-template friend with a global scope qualifier. (#GH185341)
 - Clang now rejects constant template parameters with block pointer types, since these are not implemented anyway and would lead to crashes. (#GH189247)
+- Clang no longer reject call expressions whose type is a not-yet-deduced auto type. (#GH207565)
 - Fixed a crash on error recovery when dealing with invalid templates. (#GH183075)
 - Fixed a crash when instantiating `requires` expressions involving substitution failures in C++ concepts. (#GH176402)
 - Concepts appearing in the require-clause of a member function no longer have access to non-public members of that class,

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -6828,7 +6828,7 @@ static bool MayBeFunctionType(const ASTContext &Context, const Expr *E) {
       T == Context.BuiltinFnTy || T == Context.OverloadTy ||
       T->isFunctionType() || T->isFunctionReferenceType() ||
       T->isMemberFunctionPointerType() || T->isFunctionPointerType() ||
-      T->isBlockPointerType() || T->isRecordType())
+      T->isBlockPointerType() || T->isRecordType() || T->isUndeducedType())
     return true;
 
   return isa<CallExpr, DeclRefExpr, MemberExpr, CXXPseudoDestructorExpr,

--- a/clang/test/SemaTemplate/fun-template-def.cpp
+++ b/clang/test/SemaTemplate/fun-template-def.cpp
@@ -109,6 +109,19 @@ auto k = c_<1>; // expected-note {{in instantiation of variable}}
 
 }
 
+namespace GH207565 {
+    template <auto... Cs> struct S {
+    static constexpr auto cl  = [](auto... args) { return (..., (Cs(), args)); };
+    static constexpr auto cl2 = []() { return (..., Cs()); }; // expected-error {{called object type 'int' is not a function or function pointer}} \
+                                                             // expected-note {{while substituting into a lambda expression here}}
+};
+
+template struct S<>;
+template struct S<1>; // expected-note {{in instantiation}}
+
+}
+
+
 #endif
 #if __cplusplus >= 201702L
 


### PR DESCRIPTION
This fixes a regression introduced in #139246

Fixes #207565