### PR TITLE
[CIR] Implement MSVC bitscan builtins

### DIFF
--- a/clang/lib/CodeGen/TargetBuiltins/X86.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/X86.cpp
@@ -20,6 +20,7 @@ using namespace clang;
 using namespace CodeGen;
 using namespace llvm;
 
+// TODO: Implement this for MSVC CIR support
 static std::optional<CodeGenFunction::MSVCIntrin>
 translateX86ToMsvcIntrin(unsigned BuiltinID) {
   using MSVCIntrin = CodeGenFunction::MSVCIntrin;
@@ -780,7 +781,7 @@ Value *CodeGenFunction::EmitX86CpuInit() {
   return Builder.CreateCall(Func);
 }
 
-
+// TODO: Implement this for MSVC CIR codegen
 Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
                                            const CallExpr *E) {
   if (BuiltinID == Builtin::BI__builtin_cpu_is)


### PR DESCRIPTION
Towards implementing X86 MSVC bitscan builtins for ClangIR CodeGen (part of #167765) to match those of `clang/lib/CodeGen/TargetBuiltins/X86.cpp`.

**Current Status**
- Early draft PR (work-in-progress) to get feedback on approach before implementation.
- Start by surveying `translateX86ToMsvcIntrin` in classic Clang CodeGen and assess how it might be implemented in CIR CodeGen.
- Identify any other unimplemented blockers as additional work items.

cc @andykaylor