### PR TITLE
AArch64: Fix mishandling subregister in orr peephole

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64MIPeepholeOpt.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MIPeepholeOpt.cpp
@@ -298,6 +298,9 @@ bool AArch64MIPeepholeOptImpl::visitORR(MachineInstr &MI) {
   if (MI.getOperand(1).getReg() != AArch64::WZR)
     return false;
 
+  if (MI.getOperand(2).getSubReg())
+    return false;
+
   MachineInstr *SrcMI = MRI->getUniqueVRegDef(MI.getOperand(2).getReg());
   if (!SrcMI)
     return false;

--- a/llvm/test/CodeGen/AArch64/redundant-orrwrs-from-zero-extend.mir
+++ b/llvm/test/CodeGen/AArch64/redundant-orrwrs-from-zero-extend.mir
@@ -68,3 +68,24 @@ body:             |
     $x0 = COPY %3
     RET_ReallyLR implicit $x0
 ...
+
+# CHECK-LABEL: name: test3
+# The ORRWrs source is a sub_32 subregister of a 64-bit value defined by a
+# 64-bit-form instruction (SBFMXri), which does not zero the upper 32 bits.
+# The zero-extend is therefore not redundant and must not be removed.
+---
+name:            test3
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0
+
+    ; CHECK: ORRWrs $wzr, %1.sub_32, 0
+    ; The ORRWrs should not be removed.
+    %0:gpr64 = COPY $x0
+    %1:gpr64 = SBFMXri %0, 32, 47
+    %3:gpr32 = ORRWrs $wzr, %1.sub_32, 0
+    %4:gpr64all = SUBREG_TO_REG %3, %subreg.sub_32
+    $x0 = COPY %4
+    RET_ReallyLR implicit $x0
+...


### PR DESCRIPTION
Avoids verifier failure regressions in a future change.