### PR TITLE
[libc++] Use a median-of-3 for the A/B comparison benchmarking job

### DIFF
--- a/.github/workflows/libcxx-run-benchmarks.yml
+++ b/.github/workflows/libcxx-run-benchmarks.yml
@@ -141,27 +141,36 @@ jobs:
           python -m pip install -r libcxx/utils/requirements.txt
           python -m pip install pygithub==2.8.1
 
-      - name: Build and run baseline
+      - name: Build the baseline and the candidate
         env:
-          BENCHMARKS: ${{ needs.extract-info.outputs.benchmarks }}
           PR_HEAD: ${{ needs.extract-info.outputs.pr_head }}
           PR_BASE: ${{ needs.extract-info.outputs.pr_base }}
         run: |
           source .venv/bin/activate
           baseline_commit=$(git merge-base $PR_BASE $PR_HEAD)
           ./libcxx/utils/build-at-commit --commit ${baseline_commit} --install-dir install/baseline -- -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          ./libcxx/utils/test-at-commit --libcxx-installation install/baseline -B benchmarks/baseline -- -sv -j1 --param optimization=speed "$BENCHMARKS"
-          ./libcxx/utils/consolidate-benchmarks benchmarks/baseline | tee baseline.lnt
+          ./libcxx/utils/build-at-commit --commit $PR_HEAD --install-dir install/candidate -- -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
-      - name: Build and run candidate
+      - name: Run baseline and candidate interleaved
         env:
           BENCHMARKS: ${{ needs.extract-info.outputs.benchmarks }}
-          PR_HEAD: ${{ needs.extract-info.outputs.pr_head }}
         run: |
           source .venv/bin/activate
-          ./libcxx/utils/build-at-commit --commit $PR_HEAD --install-dir install/candidate -- -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          # Run 3 times so we can pick the median, and interleave to reduce effects like thermal throttling
+          ./libcxx/utils/test-at-commit --libcxx-installation install/baseline -B benchmarks/baseline -- -sv -j1 --param optimization=speed "$BENCHMARKS"
+          ./libcxx/utils/consolidate-benchmarks benchmarks/baseline | tee baseline.lnt
           ./libcxx/utils/test-at-commit --libcxx-installation install/candidate -B benchmarks/candidate -- -sv -j1 --param optimization=speed "$BENCHMARKS"
           ./libcxx/utils/consolidate-benchmarks benchmarks/candidate | tee candidate.lnt
+
+          ./libcxx/utils/test-at-commit --libcxx-installation install/baseline -B benchmarks/baseline -- -sv -j1 --param optimization=speed "$BENCHMARKS"
+          ./libcxx/utils/consolidate-benchmarks benchmarks/baseline | tee -a baseline.lnt
+          ./libcxx/utils/test-at-commit --libcxx-installation install/candidate -B benchmarks/candidate -- -sv -j1 --param optimization=speed "$BENCHMARKS"
+          ./libcxx/utils/consolidate-benchmarks benchmarks/candidate | tee -a candidate.lnt
+
+          ./libcxx/utils/test-at-commit --libcxx-installation install/baseline -B benchmarks/baseline -- -sv -j1 --param optimization=speed "$BENCHMARKS"
+          ./libcxx/utils/consolidate-benchmarks benchmarks/baseline | tee -a baseline.lnt
+          ./libcxx/utils/test-at-commit --libcxx-installation install/candidate -B benchmarks/candidate -- -sv -j1 --param optimization=speed "$BENCHMARKS"
+          ./libcxx/utils/consolidate-benchmarks benchmarks/candidate | tee -a candidate.lnt
 
       - name: Compare baseline and candidate runs
         run: |

--- a/.github/workflows/libcxx-run-benchmarks.yml
+++ b/.github/workflows/libcxx-run-benchmarks.yml
@@ -156,7 +156,7 @@ jobs:
           BENCHMARKS: ${{ needs.extract-info.outputs.benchmarks }}
         run: |
           source .venv/bin/activate
-          # Run 3 times so we can pick the median, and interleave to reduce effects like thermal throttling
+          # Run 3 times so we can pick the median, and interleave to mitigate the impact of environmental noise
           ./libcxx/utils/test-at-commit --libcxx-installation install/baseline -B benchmarks/baseline -- -sv -j1 --param optimization=speed "$BENCHMARKS"
           ./libcxx/utils/consolidate-benchmarks benchmarks/baseline | tee baseline.lnt
           ./libcxx/utils/test-at-commit --libcxx-installation install/candidate -B benchmarks/candidate -- -sv -j1 --param optimization=speed "$BENCHMARKS"


### PR DESCRIPTION
After a bit of testing, I think this provides a good tradeoff between resource utilization and noise reduction. Furthermore, the comparison script (which produces the output) will be augmented to surface the variability of the results in a separate PR.