### PR TITLE
[SPIR-V] Fix crash on switch with odd-width condition type

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
@@ -64,13 +64,8 @@ public:
   // the standard.
   void finalizeLowering(MachineFunction &MF) const override;
 
-  // Return a width no larger than the condition so CodeGenPrepare never widens
-  // it. Odd-width integers are extended EVTs, so getSimpleVT would fail, so
-  // falling back to i1.
   MVT getPreferredSwitchConditionType(LLVMContext &Context,
                                       EVT ConditionVT) const override {
-    if (ConditionVT.isSimple())
-      return ConditionVT.getSimpleVT();
     return MVT::i1;
   }
 

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
@@ -64,9 +64,14 @@ public:
   // the standard.
   void finalizeLowering(MachineFunction &MF) const override;
 
+  // Return a width no larger than the condition so CodeGenPrepare never widens
+  // it. Odd-width integers are extended EVTs, so getSimpleVT would fail, so
+  // falling back to i1.
   MVT getPreferredSwitchConditionType(LLVMContext &Context,
                                       EVT ConditionVT) const override {
-    return ConditionVT.getSimpleVT();
+    if (ConditionVT.isSimple())
+      return ConditionVT.getSimpleVT();
+    return MVT::i1;
   }
 
   bool enforcePtrTypeCompatibility(MachineInstr &I, unsigned PtrOpIdx,

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/i128-switch-condition-type.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/i128-switch-condition-type.ll
@@ -1,0 +1,32 @@
+; The fix for the crash on odd-width switch condition types is orthogonal to
+; the arbitrary precision integers extension: with the extension enabled, an
+; odd-width type still lowers to itself rather than being widened.
+
+; RUN: llc -verify-machineinstrs -O2 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_ALTERA_arbitrary_precision_integers %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O2 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_ALTERA_arbitrary_precision_integers %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: %[[#I128:]] = OpTypeInt 128 0
+; CHECK: %[[#COND:]] = OpFunctionParameter %[[#I128]]
+; CHECK: OpSwitch %[[#COND]] %[[#]] 0 0 0 0 %[[#]] 1 0 0 0 %[[#]] 2 0 0 0 %[[#]]
+
+define spir_func void @apint_switch(i128 %n, ptr %out) {
+entry:
+  switch i128 %n, label %d [
+    i128 0, label %a
+    i128 1, label %b
+    i128 2, label %c
+  ]
+a:
+  br label %m
+b:
+  br label %m
+c:
+  br label %m
+d:
+  br label %m
+m:
+  %r = phi i128 [ 40, %d ], [ 20, %a ], [ 30, %b ], [ 50, %c ]
+  %add = add i128 %r, %n
+  store i128 %add, ptr %out
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/switch-odd-width-condition.ll
+++ b/llvm/test/CodeGen/SPIRV/switch-odd-width-condition.ll
@@ -7,7 +7,7 @@
 ; CHECK: %[[#COND:]] = OpFunctionParameter %[[#I32]]
 ; CHECK: OpSwitch %[[#COND]] %[[#]] 0 %[[#]] 1 %[[#]] 2 %[[#]]
 
-define spir_kernel void @fuzz_kernel(ptr addrspace(1) %in, ptr addrspace(1) %out, i31 %n) {
+define spir_func void @fuzz_kernel(ptr addrspace(1) %in, ptr addrspace(1) %out, i31 %n) {
 entry:
   switch i31 %n, label %d [
     i31 0, label %m
@@ -31,7 +31,7 @@ m:
 ; CHECK: %[[#COND2:]] = OpFunctionParameter %[[#I32]]
 ; CHECK: OpSwitch %[[#COND2]] %[[#]] 0 %[[#]] 1 %[[#]] 2 %[[#]]
 
-define spir_kernel void @cond_used_elsewhere(ptr addrspace(1) %out, i31 %n) {
+define spir_func void @cond_used_elsewhere(ptr addrspace(1) %out, i31 %n) {
 entry:
   switch i31 %n, label %d [
     i31 0, label %a

--- a/llvm/test/CodeGen/SPIRV/switch-odd-width-condition.ll
+++ b/llvm/test/CodeGen/SPIRV/switch-odd-width-condition.ll
@@ -25,3 +25,30 @@ m:
   store i31 %r, ptr addrspace(1) %out, align 4
   ret void
 }
+
+; The switch condition is also used by another instruction.
+
+; CHECK: %[[#COND2:]] = OpFunctionParameter %[[#I32]]
+; CHECK: OpSwitch %[[#COND2]] %[[#]] 0 %[[#]] 1 %[[#]] 2 %[[#]]
+
+define spir_kernel void @cond_used_elsewhere(ptr addrspace(1) %out, i31 %n) {
+entry:
+  switch i31 %n, label %d [
+    i31 0, label %a
+    i31 1, label %b
+    i31 2, label %c
+  ]
+a:
+  br label %m
+b:
+  br label %m
+c:
+  br label %m
+d:
+  br label %m
+m:
+  %r = phi i31 [ 40, %d ], [ 20, %a ], [ 30, %b ], [ 50, %c ]
+  %add = add i31 %r, %n
+  store i31 %add, ptr addrspace(1) %out, align 4
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/switch-odd-width-condition.ll
+++ b/llvm/test/CodeGen/SPIRV/switch-odd-width-condition.ll
@@ -1,0 +1,27 @@
+; A switch on an odd-width integer type.
+
+; RUN: llc -verify-machineinstrs -O2 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O2 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: %[[#I32:]] = OpTypeInt 32 0
+; CHECK: %[[#COND:]] = OpFunctionParameter %[[#I32]]
+; CHECK: OpSwitch %[[#COND]] %[[#]] 0 %[[#]] 1 %[[#]] 2 %[[#]]
+
+define spir_kernel void @fuzz_kernel(ptr addrspace(1) %in, ptr addrspace(1) %out, i31 %n) {
+entry:
+  switch i31 %n, label %d [
+    i31 0, label %m
+    i31 1, label %b
+    i31 2, label %c
+  ]
+b:
+  br label %m
+c:
+  br label %m
+d:
+  br label %m
+m:
+  %r = phi i31 [ 40, %d ], [ 20, %b ], [ 30, %c ], [ 1, %entry ]
+  store i31 %r, ptr addrspace(1) %out, align 4
+  ret void
+}


### PR DESCRIPTION
getPreferredSwitchConditionType called getSimpleVT unconditionally, which asserts on extended EVTs like i31

Return i1 for non-simple types to keep CodeGenPrepare from widening the condition