### PR TITLE
[SLP] Drop nsw when mul by INT_MIN is converted to shl

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -23478,6 +23478,20 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
           });
         }))
       I->setHasNoSignedWrap(/*b=*/false);
+    // mul nsw X, INT_MIN is not equivalent to shl nsw X, BW-1, because shl nsw
+    // poisons when the sign bit is shifted out of a positive value. When a mul
+    // lane is converted to shl with shift amount BW-1, nsw must be dropped.
+    if (!MinBWs.contains(E) && Opcode == Instruction::Shl &&
+        any_of(UniqueInsts, [&](Value *V) {
+          auto *SI = cast<Instruction>(V);
+          if (SI->getOpcode() != Instruction::Mul)
+            return false;
+          return any_of(SI->operands(), [](Value *Op) {
+            const auto *CI = dyn_cast<ConstantInt>(Op);
+            return CI && CI->getValue().isMinSignedValue();
+          });
+        }))
+      I->setHasNoSignedWrap(/*b=*/false);
     if (auto *ICmp = dyn_cast<ICmpInst>(I); ICmp && It == MinBWs.end())
       ICmp->setSameSign(/*B=*/false);
     return I;

--- a/llvm/test/Transforms/SLPVectorizer/X86/mul-shl-nsw-intmin.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/mul-shl-nsw-intmin.ll
@@ -8,7 +8,7 @@ define void @mul_intmin_converted_to_shl(ptr %p, i32 %x, i32 %y) {
 ; CHECK-LABEL: @mul_intmin_converted_to_shl(
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <2 x i32> poison, i32 [[X:%.*]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <2 x i32> [[TMP1]], i32 [[Y:%.*]], i32 1
-; CHECK-NEXT:    [[TMP3:%.*]] = shl nsw <2 x i32> [[TMP2]], <i32 1, i32 31>
+; CHECK-NEXT:    [[TMP3:%.*]] = shl <2 x i32> [[TMP2]], <i32 1, i32 31>
 ; CHECK-NEXT:    store <2 x i32> [[TMP3]], ptr [[P:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
mul nsw X, INT_MIN is valid, but shl X, BW-1 is not nsw-safe. Drop nsw on
the vector shl when a mul lane with INT_MIN is unified into shl during
opcode interchange.

Fixes #207990
