### PR TITLE
PPC: Remove manual run of machine verifier

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
+++ b/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
@@ -174,13 +174,7 @@ public:
            "TOC pointer used in a function using PC-Relative addressing!");
     if (skipFunction(MF.getFunction()))
       return false;
-    bool Changed = simplifyCode();
-#ifndef NDEBUG
-    if (Changed)
-      MF.verify(this, "Error in PowerPC MI Peephole optimization, compile with "
-                      "-mllvm -disable-ppc-peephole");
-#endif
-    return Changed;
+    return simplifyCode();
   }
 };
 


### PR DESCRIPTION
This is redundant with using the standard -verify-machineinstrs.
It's also confusing / worse, since the error is not produced to
stderr.