### PR TITLE
PPC: Fix EXTSW elimination promoting a subregister operand

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -5487,6 +5487,13 @@ void PPCInstrInfo::promoteInstr32To64ForElimEXTSW(const Register &Reg,
     if (!OperandReg.isVirtual())
       continue;
 
+    // An operand that reads the sub_32 subregister of a 64-bit register already
+    // holds the value in a full 64-bit register.
+    if (Operand.getSubReg() == PPC::sub_32) {
+      PromoteRegs[i] = OperandReg;
+      continue;
+    }
+
     const TargetRegisterClass *NewUsedRegRC =
         RI.getRegClass(MCID.operands()[i].RegClass);
     const TargetRegisterClass *OrgRC = MRI->getRegClass(OperandReg);

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -5487,16 +5487,21 @@ void PPCInstrInfo::promoteInstr32To64ForElimEXTSW(const Register &Reg,
     if (!OperandReg.isVirtual())
       continue;
 
+    const TargetRegisterClass *NewUsedRegRC =
+        RI.getRegClass(MCID.operands()[i].RegClass);
+    const TargetRegisterClass *OrgRC = MRI->getRegClass(OperandReg);
+
     // An operand that reads the sub_32 subregister of a 64-bit register already
-    // holds the value in a full 64-bit register.
+    // holds the value in a full 64-bit register, so it can be used directly by
+    // the promoted instruction.
     if (Operand.getSubReg() == PPC::sub_32) {
+      assert(NewUsedRegRC->hasSubClassEq(OrgRC) &&
+             "sub_32 source register class is incompatible with the promoted "
+             "operand register class");
       PromoteRegs[i] = OperandReg;
       continue;
     }
 
-    const TargetRegisterClass *NewUsedRegRC =
-        RI.getRegClass(MCID.operands()[i].RegClass);
-    const TargetRegisterClass *OrgRC = MRI->getRegClass(OperandReg);
     if (NewUsedRegRC != OrgRC && (OrgRC == &PPC::GPRCRegClass ||
                                   OrgRC == &PPC::GPRC_and_GPRC_NOR0RegClass)) {
       // Promote the used 32-bit register to 64-bit register.

--- a/llvm/test/CodeGen/PowerPC/sext_elimination.mir
+++ b/llvm/test/CodeGen/PowerPC/sext_elimination.mir
@@ -7,7 +7,12 @@
   entry:
     ret ptr %a
   }
-  
+
+  define void @elim_extsw_subreg_src() {
+  entry:
+    ret void
+  }
+
 ...
 ---
 name:            func
@@ -69,5 +74,40 @@ body:             |
     %12:g8rc = IMPLICIT_DEF
     %13:g8rc = INSERT_SUBREG %12:g8rc, %1:gprc, %subreg.sub_32
     %14:g8rc = RLDICL %13:g8rc, 0, 32
+
+...
+
+# Make sure the verifier does not fail if there is an existing
+# subregister use. When EXTSW_32_64 is eliminated because its source
+# register is already sign-extended, the full %0 value should be used
+# instead of re-extending the subregister, and incorrectly preserving
+# the original subregister.
+---
+name:            elim_extsw_subreg_src
+tracksRegLiveness: true
+liveins:
+  - { reg: '$x3', virtual-reg: '%0' }
+body:             |
+  bb.0:
+    liveins: $x3
+
+    ; CHECK-LABEL: name: elim_extsw_subreg_src
+    ; CHECK: liveins: $x3
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:g8rc = COPY killed $x3
+    ; CHECK-NEXT: [[SRAWI8_:%[0-9]+]]:g8rc = SRAWI8 [[COPY]], 31, implicit-def $carry, implicit-def dead $carry
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gprc = COPY killed [[SRAWI8_]].sub_32
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:g8rc = IMPLICIT_DEF
+    ; CHECK-NEXT: [[INSERT_SUBREG:%[0-9]+]]:g8rc = INSERT_SUBREG [[DEF]], [[COPY1]], %subreg.sub_32
+    ; CHECK-NEXT: [[XORI8_:%[0-9]+]]:g8rc = XORI8 killed [[INSERT_SUBREG]], 32767
+    ; CHECK-NEXT: $x3 = COPY killed [[XORI8_]]
+    ; CHECK-NEXT: BLR8 implicit $lr8, implicit $rm, implicit killed $x3
+
+    %0:g8rc = COPY $x3
+    %2:gprc = SRAWI %0.sub_32, 31, implicit-def dead $carry
+    %3:g8rc = EXTSW_32_64 killed %2
+    %4:g8rc = XORI8 killed %3, 32767
+    $x3 = COPY %4
+    BLR8 implicit $lr8, implicit $rm, implicit $x3
 
 ...


### PR DESCRIPTION
promoteInstr32To64ForElimEXTSW copies operands from the 32-bit
instruction verbatim into its promoted 64-bit form. When an operand
reads the sub_32 subregister of a 64-bit register, the promoted
instruction (which takes a full register) ended up with an illegal
subregister use and failed the machine verifier.

Drop the sub_32 subregister and use the original full register, which
provides the low 32 bits the promoted instruction operates on. This
avoids  verifier error regressions in a future change.

Co-Authored-By: Claude <noreply@anthropic.com> (Claude Opus 4.8, claude-opus-4-8)