### PR TITLE
[libc] Baremetal target builds should be static

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -223,7 +223,9 @@ function(_get_common_compile_options output_var flags)
   set(compile_options ${LIBC_COMPILE_OPTIONS_DEFAULT} ${compile_flags} ${config_flags} ${arch_flags})
 
   if(LLVM_LIBC_COMPILER_IS_GCC_COMPATIBLE)
-    list(APPEND compile_options "-fpie")
+    if(NOT LIBC_TARGET_OS_IS_BAREMETAL)
+      list(APPEND compile_options "-fpie")
+    endif()
 
     if(LLVM_LIBC_FULL_BUILD)
       # Only add -ffreestanding flag in non-GPU full build mode.


### PR DESCRIPTION
We are noticing that the baremetal target builds produce GOT relocations
since we set `-fpie`. Excluding baremetal builds from setting this flag
as they are typically just static builds.
