### PR TITLE
[AIX] diagnose invalid feature strings on the target attribute

### DIFF
--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -714,6 +714,14 @@ ParsedTargetAttr PPCTargetInfo::parseTargetAttr(StringRef Features) const {
   return Ret;
 }
 
+bool PPCTargetInfo::isValidFeatureName(StringRef Name) const {
+  // we have some target features that are spelled differently on the command
+  // line versus what's in PPC.td. We need to continue accepting them.
+  if (Name == "pcrel" || Name == "prefixed")
+    return true;
+  return llvm::PPC::isValidFeatureName(Name);
+}
+
 llvm::APInt PPCTargetInfo::getFMVPriority(ArrayRef<StringRef> Features) const {
   if (Features.empty())
     return llvm::APInt(32, 0);

--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -202,6 +202,8 @@ public:
 
   ParsedTargetAttr parseTargetAttr(StringRef Str) const override;
 
+  bool isValidFeatureName(StringRef Name) const override;
+
   llvm::APInt getFMVPriority(ArrayRef<StringRef> Features) const override;
 
   ArrayRef<const char *> getGCCRegNames() const override;

--- a/clang/test/Sema/attr-target.c
+++ b/clang/test/Sema/attr-target.c
@@ -67,7 +67,7 @@ int __attribute__((target("branch-protection=none"))) birch_tree(void) { return 
 
 #elifdef __powerpc__
 
-int __attribute__((target("float128,arch=pwr9"))) foo(void) { return 4; }
+int __attribute__((target("float128,cpu=pwr9"))) foo(void) { return 4; }
 //expected-error@+1 {{'target' attribute takes one argument}}
 int __attribute__((target())) bar(void) { return 4; }
 // no warning, tune is supported for PPC
@@ -84,7 +84,7 @@ int __attribute__((target("cpu=hiss,cpu=woof"))) pine_tree(void) { return 4; }
 int __attribute__((target("cpu=pwr9,cpu=pwr10"))) oak_tree(void) { return 4; }
 //expected-warning@+1 {{unknown tune CPU 'hiss' in the 'target' attribute string; 'target' attribute ignored}}
 int __attribute__((target("tune=hiss,tune=woof"))) apple_tree(void) { return 4; }
-// no warning for invalid target features
+//expected-warning@+1 {{unsupported 'woof' in the 'target' attribute string; 'target' attribute ignored}}
 int __attribute__((target("woof"))) cherry_tree(void) { return 4; }
 
 #else

--- a/llvm/include/llvm/TargetParser/PPCTargetParser.h
+++ b/llvm/include/llvm/TargetParser/PPCTargetParser.h
@@ -43,6 +43,7 @@ LLVM_ABI StringRef normalizeCPUName(StringRef CPUName);
 LLVM_ABI std::optional<llvm::StringMap<bool>>
 getPPCDefaultTargetFeatures(const Triple &T, StringRef CPUName);
 
+LLVM_ABI bool isValidFeatureName(StringRef Name);
 } // namespace PPC
 } // namespace llvm
 

--- a/llvm/include/llvm/TargetParser/TargetParser.h
+++ b/llvm/include/llvm/TargetParser/TargetParser.h
@@ -27,6 +27,9 @@ struct BasicSubtargetFeatureKV {
   const char *Key;         ///< K-V key string
   unsigned Value;          ///< K-V integer value
   FeatureBitArray Implies; ///< K-V bit mask
+
+  /// Compare routine for std::lower_bound
+  bool operator<(StringRef S) const { return StringRef(Key) < S; }
 };
 
 /// Used to provide key value pairs for feature and CPU bit flags.

--- a/llvm/lib/TargetParser/PPCTargetParser.cpp
+++ b/llvm/lib/TargetParser/PPCTargetParser.cpp
@@ -145,5 +145,12 @@ std::optional<StringMap<bool>> getPPCDefaultTargetFeatures(const Triple &T,
   }
   return Features;
 }
+
+bool isValidFeatureName(StringRef Name) {
+  ArrayRef<BasicSubtargetFeatureKV> A = BasicPPCFeatureKV;
+  // Binary search the array
+  const BasicSubtargetFeatureKV *F = llvm::lower_bound(A, Name);
+  return F != A.end() && StringRef(F->Key) == Name;
+}
 } // namespace PPC
 } // namespace llvm


### PR DESCRIPTION
Currently, Sema calls `getTargetInfo().isValidFeatureName(S)` to validate string inputs on the `target` attribute. `PPCTargetInfo` doesn't override the function and the base class implementation returns true unconditionally. This results in the FE accepting invalid feature strings on `target` attribute, and generates invalid target-feature values in the IR.