### PR TITLE
[lldb] Give Wasm stack frames a synthetic call frame address

### DIFF
--- a/lldb/source/Plugins/Process/wasm/UnwindWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/UnwindWasm.cpp
@@ -19,6 +19,11 @@ using namespace lldb_private;
 using namespace process_gdb_remote;
 using namespace wasm;
 
+/// Base for synthesized Wasm frame call frame addresses. It sits above any
+/// call depth a Wasm stack can reach and clear of zero and the invalid-address
+/// sentinel, so the derived addresses stay distinct and valid.
+static constexpr lldb::addr_t kWasmSyntheticCFABase = 0x40000000;
+
 lldb::RegisterContextSP
 UnwindWasm::DoCreateRegisterContextForFrame(lldb_private::StackFrame *frame) {
   if (m_frames.size() <= frame->GetFrameIndex())
@@ -65,7 +70,13 @@ bool UnwindWasm::DoGetFrameInfoAtIndex(uint32_t frame_idx, lldb::addr_t &cfa,
     return false;
 
   behaves_like_zeroth_frame = (frame_idx == 0);
-  cfa = 0;
+  // StackID orders frames by call frame address, expecting a younger frame to
+  // sit below its caller. Wasm has no in-memory frame address to read, so
+  // derive one from the frame's distance to the outermost frame, which stays
+  // fixed as frames are pushed and popped above it, inverted so younger frames
+  // compare lower.
+  const size_t depth_from_outermost = m_frames.size() - 1 - frame_idx;
+  cfa = kWasmSyntheticCFABase - depth_from_outermost;
   pc = m_frames[frame_idx];
   return true;
 }

--- a/lldb/test/API/functionalities/gdb_remote_client/TestWasm.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestWasm.py
@@ -368,6 +368,15 @@ class TestWasm(GDBRemoteTestBase):
         self.assertEqual(frame1.GetPC(), LOAD_ADDRESS | 0x01E5)
         self.assertIn("main", frame1.GetFunctionName())
 
+        frame2 = thread.GetFrameAtIndex(2)
+        self.assertTrue(frame2.IsValid())
+
+        # Wasm frames need distinct, ordered call frame addresses for StackID to
+        # tell an inner frame from an outer one. Without them every frame shares
+        # one address and stepping mistakes a step in for a step out.
+        self.assertLess(frame0.GetCFA(), frame1.GetCFA())
+        self.assertLess(frame1.GetCFA(), frame2.GetCFA())
+
         # Check that we can resolve local variables.
         a = frame0.FindVariable("a")
         self.assertTrue(a.IsValid())


### PR DESCRIPTION
UnwindWasm reported a call frame address of zero for every Wasm frame. StackID orders frames by their CFA, assuming the stack grows downward so that a younger frame compares below its caller. With every CFA equal to zero that ordering collapsed, and CompareCurrentFrameToStartFrame treated a step into a function as a step out, which silently disabled step-in avoid-regexp and confused other thread plans.

WebAssembly keeps its call stack inside the engine and exposes no linear-memory frame address, so synthesize a CFA from each frame's distance to the outermost frame. That distance is invariant as frames are pushed and popped above it, so a given frame keeps a stable, ordered CFA across steps.