### PR TITLE
[NVVM][MLIR] Fixed valgrind leak in MMAOp

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -3477,17 +3477,10 @@ def NVVM_MmaOp : NVVM_Op<"mma.sync", [AttrSizedOperandSegments]> {
 
   string llvmBuilder = [{
     auto operands = moduleTranslation.lookupValues(opInst.getOperands());
-    // `intOverflowBehavior` is optional; an omitted attribute selects the
-    // default `wrapped` behavior. Resolve it to a fully-initialized value here
-    // so the intrinsic selector always inspects an engaged optional and never
-    // reads an empty optional's uninitialized payload (a benign read the
-    // optimizer can hoist out of the guarding `has_value()` check under -O2).
-    // An empty std::optional still reserves storage for its payload but leaves
-    // it uninitialized, and at -O2 the optimizer may if-convert the selector's
-    // `has_value() ? ... *sat ... : true` guard and speculatively load `*sat`
-    // before the guard discards it. This is not UB -- the read touches validly
-    // allocated storage and its result is never used -- but Valgrind still
-    // reports the load of uninitialized bytes.
+    // `intOverflowBehavior` is optional and defaults to `wrapped` when omitted.
+    // We initialize it to a concrete value so that the intrinsic selector never
+    // speculatively reads an empty optional's uninitialized payload (benign,
+    // but flagged by Valgrind).
     std::optional<mlir::NVVM::MMAIntOverflow> intOverflow = mlir::NVVM::MMAIntOverflow::wrapped;
     if (mlir::NVVM::MMAIntOverflowAttr satAttr = op.getIntOverflowBehaviorAttr())
       intOverflow = satAttr.getValue();

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -3384,9 +3384,9 @@ def NVVM_MmaOp : NVVM_Op<"mma.sync", [AttrSizedOperandSegments]> {
     `intOverflowBehavior` is only relevant when the `multiplicandType` attribute
     is one of `u8, s8, u4, s4`, this attribute describes how overflow is handled
     in the accumulator. When the attribute is `satfinite`, the accumulator values
-    are clamped in the int32 range on overflow. This is the default behavior.
-    Alternatively, accumulator behavior `wrapped` can also be specified, in
-    which case overflow wraps from one end of the range to the other.
+    are clamped in the int32 range on overflow. Alternatively, accumulator
+    behavior `wrapped` can be specified (this is the default), in which case
+    overflow wraps from one end of the range to the other.
 
     `layoutA` and `layoutB` are required and should generally be set to
     `#nvvm.mma_layout<row>` and `#nvvm.mma_layout<col>` respectively, but other
@@ -3477,9 +3477,23 @@ def NVVM_MmaOp : NVVM_Op<"mma.sync", [AttrSizedOperandSegments]> {
 
   string llvmBuilder = [{
     auto operands = moduleTranslation.lookupValues(opInst.getOperands());
+    // `intOverflowBehavior` is optional; an omitted attribute selects the
+    // default `wrapped` behavior. Resolve it to a fully-initialized value here
+    // so the intrinsic selector always inspects an engaged optional and never
+    // reads an empty optional's uninitialized payload (a benign read the
+    // optimizer can hoist out of the guarding `has_value()` check under -O2).
+    // An empty std::optional still reserves storage for its payload but leaves
+    // it uninitialized, and at -O2 the optimizer may if-convert the selector's
+    // `has_value() ? ... *sat ... : true` guard and speculatively load `*sat`
+    // before the guard discards it. This is not UB -- the read touches validly
+    // allocated storage and its result is never used -- but Valgrind still
+    // reports the load of uninitialized bytes.
+    std::optional<mlir::NVVM::MMAIntOverflow> intOverflow = mlir::NVVM::MMAIntOverflow::wrapped;
+    if (mlir::NVVM::MMAIntOverflowAttr satAttr = op.getIntOverflowBehaviorAttr())
+      intOverflow = satAttr.getValue();
     auto intId = mlir::NVVM::MmaOp::getIntrinsicID(
         $shape.getM(), $shape.getN(), $shape.getK(),
-        $b1Op, $intOverflowBehavior,
+        $b1Op, intOverflow,
         $layoutA, $layoutB,
         *$multiplicandAPtxType,
         *$multiplicandBPtxType,


### PR DESCRIPTION
MmaOp::getIntrinsicID triggers an uninitialized-read warning under Valgrind. `intOverflowBehavior` is optional; in the generated selector its `has_value()` guarded access can be speculatively loaded before the guard, reading the empty std::optional's uninitialized payload.

The read is benign: the payload is correctly stack-allocated but uninitialized while empty, and the loaded value is discarded by the guard, so this is not incorrect / undefined behavior.

This MR keeps the attribute as optional, but the lowering now resolves it to a concrete value (wrapped when omitted) before calling getIntrinsicID, so the selector always reads an initialized value. `wrapped` matches the PTX spec and the existing lowering, where an omitted attribute already selected the non-satfinite intrinsic; intrinsic selection and printed IR are unchanged. Documentation updated to correct the stale default.