### PR TITLE
[Support] Add missing include for MacOS defines

### DIFF
--- a/llvm/lib/Support/CrashRecoveryContext.cpp
+++ b/llvm/lib/Support/CrashRecoveryContext.cpp
@@ -15,6 +15,9 @@
 #include <cassert>
 #include <mutex>
 #include <setjmp.h>
+#ifdef __APPLE__
+#include <sys/resource.h>
+#endif
 
 using namespace llvm;
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/142733 removed several includes, including
llvm/Support/ProgramStack.h. This was indirectly including headers that defined
PRIO_DARWIN_THREAD and PRIO_DARWIN_BG.

Add back sys/resource.h to define them locally.