### PR TITLE
[lldb] Remove GDBRemoteDynamicRegisterInfo

### DIFF
--- a/lldb/include/lldb/Target/DynamicRegisterInfo.h
+++ b/lldb/include/lldb/Target/DynamicRegisterInfo.h
@@ -22,10 +22,6 @@ namespace lldb_private {
 class Stream;
 
 class DynamicRegisterInfo {
-protected:
-  DynamicRegisterInfo(DynamicRegisterInfo &) = default;
-  DynamicRegisterInfo &operator=(DynamicRegisterInfo &) = default;
-
 public:
   struct Register {
     ConstString name;
@@ -47,6 +43,9 @@ public:
   };
 
   DynamicRegisterInfo() = default;
+  DynamicRegisterInfo(DynamicRegisterInfo &) = default;
+  DynamicRegisterInfo &operator=(DynamicRegisterInfo &) = default;
+
 
   static std::unique_ptr<DynamicRegisterInfo>
   Create(const StructuredData::Dictionary &dict, const ArchSpec &arch);

--- a/lldb/include/lldb/lldb-forward.h
+++ b/lldb/include/lldb/lldb-forward.h
@@ -80,6 +80,7 @@ class Disassembler;
 class DumpValueObjectOptions;
 class DynamicCheckerFunctions;
 class DynamicLoader;
+class DynamicRegisterInfo;
 class Editline;
 class EmulateInstruction;
 class Environment;
@@ -351,6 +352,8 @@ typedef std::shared_ptr<lldb_private::Disassembler> DisassemblerSP;
 typedef std::unique_ptr<lldb_private::DynamicCheckerFunctions>
     DynamicCheckerFunctionsUP;
 typedef std::unique_ptr<lldb_private::DynamicLoader> DynamicLoaderUP;
+typedef std::shared_ptr<lldb_private::DynamicRegisterInfo>
+    DynamicRegisterInfoSP;
 typedef std::shared_ptr<lldb_private::Event> EventSP;
 typedef std::shared_ptr<lldb_private::EventData> EventDataSP;
 typedef std::shared_ptr<lldb_private::EventDataStructuredData>

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteRegisterContext.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteRegisterContext.cpp
@@ -32,7 +32,7 @@ using namespace lldb_private::process_gdb_remote;
 // GDBRemoteRegisterContext constructor
 GDBRemoteRegisterContext::GDBRemoteRegisterContext(
     ThreadGDBRemote &thread, uint32_t concrete_frame_idx,
-    GDBRemoteDynamicRegisterInfoSP reg_info_sp, bool read_all_at_once,
+    DynamicRegisterInfoSP reg_info_sp, bool read_all_at_once,
     bool write_all_at_once)
     : RegisterContext(thread, concrete_frame_idx),
       m_reg_info_sp(std::move(reg_info_sp)), m_reg_valid(), m_reg_data(),

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteRegisterContext.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteRegisterContext.h
@@ -27,25 +27,11 @@ namespace process_gdb_remote {
 
 class ThreadGDBRemote;
 class ProcessGDBRemote;
-class GDBRemoteDynamicRegisterInfo;
-
-typedef std::shared_ptr<GDBRemoteDynamicRegisterInfo>
-    GDBRemoteDynamicRegisterInfoSP;
-
-class GDBRemoteDynamicRegisterInfo final : public DynamicRegisterInfo {
-public:
-  GDBRemoteDynamicRegisterInfo() : DynamicRegisterInfo() {}
-
-  ~GDBRemoteDynamicRegisterInfo() override = default;
-
-  void UpdateARM64SVERegistersInfos(uint64_t vg);
-  void UpdateARM64SMERegistersInfos(uint64_t svg);
-};
 
 class GDBRemoteRegisterContext : public RegisterContext {
 public:
   GDBRemoteRegisterContext(ThreadGDBRemote &thread, uint32_t concrete_frame_idx,
-                           GDBRemoteDynamicRegisterInfoSP reg_info_sp,
+                           lldb::DynamicRegisterInfoSP reg_info_sp,
                            bool read_all_at_once, bool write_all_at_once);
 
   ~GDBRemoteRegisterContext() override;
@@ -128,7 +114,7 @@ protected:
     SetRegisterIsValidState(reg, eLazyBoolCalculate);
   }
 
-  GDBRemoteDynamicRegisterInfoSP m_reg_info_sp;
+  lldb::DynamicRegisterInfoSP m_reg_info_sp;
 
   /// eLazyBoolYes - we have the bytes for this register locally.
   /// eLazyBoolCalculate - we have not yet tried to get the bytes.

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -434,7 +434,7 @@ void ProcessGDBRemote::BuildDynamicRegisterInfo(bool force) {
   if (!force && m_register_info_sp)
     return;
 
-  m_register_info_sp = std::make_shared<GDBRemoteDynamicRegisterInfo>();
+  m_register_info_sp = std::make_shared<DynamicRegisterInfo>();
 
   // Check if qHostInfo specified a specific packet timeout for this
   // connection. If so then lets update our setting so the user knows what the

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -288,7 +288,7 @@ protected:
   std::optional<StringExtractorGDBRemote> m_last_stop_packet;
   std::recursive_mutex m_last_stop_packet_mutex;
 
-  GDBRemoteDynamicRegisterInfoSP m_register_info_sp;
+  lldb::DynamicRegisterInfoSP m_register_info_sp;
   Broadcaster m_async_broadcaster;
   lldb::ListenerSP m_async_listener_sp;
   HostThread m_async_thread;

--- a/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.cpp
@@ -48,8 +48,8 @@ ThreadGDBRemote::ThreadGDBRemote(Process &process, lldb::tid_t tid)
   if (!gdb_process.m_register_info_sp->IsReconfigurable())
     m_reg_info_sp = gdb_process.m_register_info_sp;
   else
-    m_reg_info_sp = std::make_shared<GDBRemoteDynamicRegisterInfo>(
-        *gdb_process.m_register_info_sp);
+    m_reg_info_sp =
+        std::make_shared<DynamicRegisterInfo>(*gdb_process.m_register_info_sp);
 }
 
 ThreadGDBRemote::~ThreadGDBRemote() {

--- a/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.h
@@ -109,7 +109,7 @@ protected:
       m_queue_serial_number; // Queue info from stop reply/stop info for thread
   lldb_private::LazyBool m_associated_with_libdispatch_queue;
 
-  GDBRemoteDynamicRegisterInfoSP m_reg_info_sp;
+  lldb::DynamicRegisterInfoSP m_reg_info_sp;
 
   std::vector<lldb::addr_t> m_added_binaries;
   lldb_private::StructuredData::ObjectSP m_detailed_binaries_info;

--- a/lldb/source/Plugins/Process/wasm/ProcessWasm.h
+++ b/lldb/source/Plugins/Process/wasm/ProcessWasm.h
@@ -87,9 +87,7 @@ private:
   friend class UnwindWasm;
   friend class ThreadWasm;
 
-  process_gdb_remote::GDBRemoteDynamicRegisterInfoSP &GetRegisterInfo() {
-    return m_register_info_sp;
-  }
+  lldb::DynamicRegisterInfoSP &GetRegisterInfo() { return m_register_info_sp; }
 
   ProcessWasm(const ProcessWasm &);
   const ProcessWasm &operator=(const ProcessWasm &) = delete;

--- a/lldb/source/Plugins/Process/wasm/RegisterContextWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/RegisterContextWasm.cpp
@@ -21,9 +21,9 @@ using namespace lldb_private;
 using namespace lldb_private::process_gdb_remote;
 using namespace lldb_private::wasm;
 
-RegisterContextWasm::RegisterContextWasm(
-    ThreadGDBRemote &thread, uint32_t concrete_frame_idx,
-    GDBRemoteDynamicRegisterInfoSP reg_info_sp)
+RegisterContextWasm::RegisterContextWasm(ThreadGDBRemote &thread,
+                                         uint32_t concrete_frame_idx,
+                                         DynamicRegisterInfoSP reg_info_sp)
     : GDBRemoteRegisterContext(thread, concrete_frame_idx, reg_info_sp, false,
                                false) {}
 

--- a/lldb/source/Plugins/Process/wasm/RegisterContextWasm.h
+++ b/lldb/source/Plugins/Process/wasm/RegisterContextWasm.h
@@ -34,9 +34,9 @@ struct WasmVirtualRegisterInfo : public RegisterInfo {
 class RegisterContextWasm
     : public process_gdb_remote::GDBRemoteRegisterContext {
 public:
-  RegisterContextWasm(
-      process_gdb_remote::ThreadGDBRemote &thread, uint32_t concrete_frame_idx,
-      process_gdb_remote::GDBRemoteDynamicRegisterInfoSP reg_info_sp);
+  RegisterContextWasm(process_gdb_remote::ThreadGDBRemote &thread,
+                      uint32_t concrete_frame_idx,
+                      lldb::DynamicRegisterInfoSP reg_info_sp);
 
   ~RegisterContextWasm() override;
 


### PR DESCRIPTION
At this point, GDBRemoteDynamicRegisterInfo is an idempotent wrapper around DynamicRegisterInfo. Its remaining methods are unimplemented as of 3f5fd4b3c1d670649b59f3631287b6f54c6b85ee, so the only functional difference is that it provides public copy and copy-assign constructors.

I propose that GDBRemoteDynamicRegisterInfo be removed in favor of DynamicRegisterInfo.