### PR TITLE
[AMDGPU] Guard block-count upgrade against volatile/atomic grid-size …

### DIFF
--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -2045,6 +2045,22 @@ inline OneOps_match<OpTy, Instruction::Load> m_Load(const OpTy &Op) {
   return OneOps_match<OpTy, Instruction::Load>(Op);
 }
 
+/// Matches a simple (non-volatile, non-atomic) LoadInst.
+template <typename OpTy> struct SimpleLoad_match {
+  OneOps_match<OpTy, Instruction::Load> Base;
+
+  SimpleLoad_match(const OpTy &Op) : Base(Op) {}
+
+  template <typename ITy> bool match(ITy *V) const {
+    return Base.match(V) && cast<LoadInst>(V)->isSimple();
+  }
+};
+
+template <typename OpTy>
+inline SimpleLoad_match<OpTy> m_SimpleLoad(const OpTy &Op) {
+  return SimpleLoad_match<OpTy>(Op);
+}
+
 /// Matches StoreInst.
 template <typename ValueOpTy, typename PointerOpTy>
 inline TwoOps_match<ValueOpTy, PointerOpTy, Instruction::Store>

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -2046,10 +2046,10 @@ inline OneOps_match<OpTy, Instruction::Load> m_Load(const OpTy &Op) {
 }
 
 /// Matches a simple (non-volatile, non-atomic) LoadInst.
-template <typename OpTy> struct SimpleLoad_match {
+template <typename OpTy> struct LoadSimple_match {
   OneOps_match<OpTy, Instruction::Load> Base;
 
-  SimpleLoad_match(const OpTy &Op) : Base(Op) {}
+  LoadSimple_match(const OpTy &Op) : Base(Op) {}
 
   template <typename ITy> bool match(ITy *V) const {
     return Base.match(V) && cast<LoadInst>(V)->isSimple();
@@ -2057,8 +2057,8 @@ template <typename OpTy> struct SimpleLoad_match {
 };
 
 template <typename OpTy>
-inline SimpleLoad_match<OpTy> m_SimpleLoad(const OpTy &Op) {
-  return SimpleLoad_match<OpTy>(Op);
+inline LoadSimple_match<OpTy> m_LoadSimple(const OpTy &Op) {
+  return LoadSimple_match<OpTy>(Op);
 }
 
 /// Matches StoreInst.

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
@@ -420,7 +420,7 @@ static bool processUse(CallInst *CI, bool IsV5OrAbove) {
         using namespace llvm::PatternMatch;
         if (!match(
                 Inst,
-                m_UDiv(m_ZExtOrSelf(m_SimpleLoad(m_GEP(
+                m_UDiv(m_ZExtOrSelf(m_LoadSimple(m_GEP(
                            m_Intrinsic<Intrinsic::amdgcn_dispatch_ptr>(),
                            m_SpecificInt(GRID_SIZE_X + I * sizeof(uint32_t))))),
                        m_Value())))

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
@@ -418,12 +418,20 @@ static bool processUse(CallInst *CI, bool IsV5OrAbove) {
           Inst = cast<Instruction>(*Inst->user_begin());
 
         using namespace llvm::PatternMatch;
-        if (!match(
-                Inst,
-                m_UDiv(m_ZExtOrSelf(m_Load(m_GEP(
-                           m_Intrinsic<Intrinsic::amdgcn_dispatch_ptr>(),
-                           m_SpecificInt(GRID_SIZE_X + I * sizeof(uint32_t))))),
-                       m_Value())))
+        Value *GridSizeLoad = nullptr;
+        if (!match(Inst,
+                   m_UDiv(m_ZExtOrSelf(m_CombineAnd(
+                              m_Load(m_GEP(
+                                  m_Intrinsic<Intrinsic::amdgcn_dispatch_ptr>(),
+                                  m_SpecificInt(GRID_SIZE_X +
+                                                I * sizeof(uint32_t)))),
+                              m_Value(GridSizeLoad))),
+                          m_Value())))
+          continue;
+
+        // Do not replace volatile or atomic loads -- they have observable
+        // side effects that must not be silently dropped.
+        if (!cast<LoadInst>(GridSizeLoad)->isSimple())
           continue;
 
         IRBuilder<> Builder(Inst);

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
@@ -418,20 +418,12 @@ static bool processUse(CallInst *CI, bool IsV5OrAbove) {
           Inst = cast<Instruction>(*Inst->user_begin());
 
         using namespace llvm::PatternMatch;
-        Value *GridSizeLoad = nullptr;
-        if (!match(Inst,
-                   m_UDiv(m_ZExtOrSelf(m_CombineAnd(
-                              m_Load(m_GEP(
-                                  m_Intrinsic<Intrinsic::amdgcn_dispatch_ptr>(),
-                                  m_SpecificInt(GRID_SIZE_X +
-                                                I * sizeof(uint32_t)))),
-                              m_Value(GridSizeLoad))),
-                          m_Value())))
-          continue;
-
-        // Do not replace volatile or atomic loads -- they have observable
-        // side effects that must not be silently dropped.
-        if (!cast<LoadInst>(GridSizeLoad)->isSimple())
+        if (!match(
+                Inst,
+                m_UDiv(m_ZExtOrSelf(m_SimpleLoad(m_GEP(
+                           m_Intrinsic<Intrinsic::amdgcn_dispatch_ptr>(),
+                           m_SpecificInt(GRID_SIZE_X + I * sizeof(uint32_t))))),
+                       m_Value())))
           continue;
 
         IRBuilder<> Builder(Inst);

--- a/llvm/test/CodeGen/AMDGPU/implicit-arg-block-count.ll
+++ b/llvm/test/CodeGen/AMDGPU/implicit-arg-block-count.ll
@@ -317,6 +317,33 @@ entry:
   %sum = add i32 %count_x_1, %count_x_2
   ret i32 %sum
 }
+
+; A volatile grid_size load must NOT be silently replaced by a block_count
+; load: volatile loads have observable side effects.
+define i32 @num_blocks_x_volatile_grid_size() {
+; CHECK-LABEL: define i32 @num_blocks_x_volatile_grid_size() {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[DISPATCH:%.*]] = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
+; CHECK-NEXT:    [[D_GEP_X:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[DISPATCH]], i64 12
+; CHECK-NEXT:    [[GRID_SIZE_X:%.*]] = load volatile i32, ptr addrspace(4) [[D_GEP_X]], align 4
+; CHECK-NEXT:    [[IMPLICITARG:%.*]] = call dereferenceable(256) ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; CHECK-NEXT:    [[I_GEP_X:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[IMPLICITARG]], i64 12
+; CHECK-NEXT:    [[WG_SIZE_X:%.*]] = load i16, ptr addrspace(4) [[I_GEP_X]], align 2, !range [[RNG1]]
+; CHECK-NEXT:    [[CONV_X:%.*]] = zext nneg i16 [[WG_SIZE_X]] to i32
+; CHECK-NEXT:    [[COUNT_X:%.*]] = udiv i32 [[GRID_SIZE_X]], [[CONV_X]]
+; CHECK-NEXT:    ret i32 [[COUNT_X]]
+;
+entry:
+  %dispatch = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
+  %d_gep_x = getelementptr i8, ptr addrspace(4) %dispatch, i32 12
+  %grid_size_x = load volatile i32, ptr addrspace(4) %d_gep_x, align 4
+  %implicitarg = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+  %i_gep_x = getelementptr i8, ptr addrspace(4) %implicitarg, i32 12
+  %wg_size_x = load i16, ptr addrspace(4) %i_gep_x, align 2
+  %conv_x = zext i16 %wg_size_x to i32
+  %count_x = udiv i32 %grid_size_x, %conv_x
+  ret i32 %count_x
+}
 ;.
 ; CHECK: [[META0]] = !{}
 ; CHECK: [[RNG1]] = !{i16 1, i16 1025}

--- a/llvm/test/CodeGen/AMDGPU/implicit-arg-block-count.ll
+++ b/llvm/test/CodeGen/AMDGPU/implicit-arg-block-count.ll
@@ -344,6 +344,33 @@ entry:
   %count_x = udiv i32 %grid_size_x, %conv_x
   ret i32 %count_x
 }
+
+; An atomic grid_size load must NOT be silently replaced by a block_count
+; load: atomic loads have observable memory ordering semantics.
+define i32 @num_blocks_x_atomic_grid_size() {
+; CHECK-LABEL: define i32 @num_blocks_x_atomic_grid_size() {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[DISPATCH:%.*]] = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
+; CHECK-NEXT:    [[D_GEP_X:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[DISPATCH]], i64 12
+; CHECK-NEXT:    [[GRID_SIZE_X:%.*]] = load atomic i32, ptr addrspace(4) [[D_GEP_X]] monotonic, align 4
+; CHECK-NEXT:    [[IMPLICITARG:%.*]] = call dereferenceable(256) ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; CHECK-NEXT:    [[I_GEP_X:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(4) [[IMPLICITARG]], i64 12
+; CHECK-NEXT:    [[WG_SIZE_X:%.*]] = load i16, ptr addrspace(4) [[I_GEP_X]], align 2, !range [[RNG1]]
+; CHECK-NEXT:    [[CONV_X:%.*]] = zext nneg i16 [[WG_SIZE_X]] to i32
+; CHECK-NEXT:    [[COUNT_X:%.*]] = udiv i32 [[GRID_SIZE_X]], [[CONV_X]]
+; CHECK-NEXT:    ret i32 [[COUNT_X]]
+;
+entry:
+  %dispatch = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
+  %d_gep_x = getelementptr i8, ptr addrspace(4) %dispatch, i32 12
+  %grid_size_x = load atomic i32, ptr addrspace(4) %d_gep_x monotonic, align 4
+  %implicitarg = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+  %i_gep_x = getelementptr i8, ptr addrspace(4) %implicitarg, i32 12
+  %wg_size_x = load i16, ptr addrspace(4) %i_gep_x, align 2
+  %conv_x = zext i16 %wg_size_x to i32
+  %count_x = udiv i32 %grid_size_x, %conv_x
+  ret i32 %count_x
+}
 ;.
 ; CHECK: [[META0]] = !{}
 ; CHECK: [[RNG1]] = !{i16 1, i16 1025}


### PR DESCRIPTION
…loads

AMDGPULowerKernelAttributes upgrades the pre-COV5 pattern
  udiv(grid_size_x, group_size_x)
to a direct load of hidden_block_count_x from the implicit args. The m_Load() pattern matcher does not check whether the matched load is volatile or atomic, so a volatile or atomic grid_size load would have been silently deleted and replaced -- dropping its observable side effects in violation of the LangRef.

Fix: after the pattern match succeeds, cast the matched value to LoadInst and bail out if !isSimple() (i.e., volatile or atomic).

Add a test case num_blocks_x_volatile_grid_size in implicit-arg-block-count.ll to verify the volatile load and udiv are preserved unchanged.