### PR TITLE
[libc++][NFC] Rename workflow file for libc++ A/B performance comparisons

### DIFF
--- a/.github/workflows/libcxx-pr-benchmark.yml
+++ b/.github/workflows/libcxx-pr-benchmark.yml
@@ -7,7 +7,7 @@
 # That will cause the specified benchmarks to be run on the PR and on the pull-request target, and
 # their results to be compared.
 
-name: Benchmark libc++
+name: Benchmark libc++ PR
 
 permissions:
   contents: read


### PR DESCRIPTION
I want to introduce another workflow that allows running benchmarks on historical commits of libc++ for LNT submission, so having an unambiguous name is desirable.