### PR TITLE
[libc][cpp::string] Fix off-by-one bug in resize and a memory leak

### DIFF
--- a/libc/src/__support/CPP/string.h
+++ b/libc/src/__support/CPP/string.h
@@ -93,6 +93,9 @@ public:
   }
 
   LIBC_INLINE string &operator=(string &&other) {
+    if (buffer_ != get_empty_string())
+      ::free(buffer_);
+
     buffer_ = other.buffer_;
     size_ = other.size_;
     capacity_ = other.capacity_;
@@ -155,7 +158,12 @@ public:
   }
 
   LIBC_INLINE void resize(size_t size) {
-    if (size > capacity_) {
+    // Avoid growing out of the static empty string during `resize(0)`,
+    // which may happen in string constructors.
+    if (size == size_)
+      return;
+
+    if (size >= capacity_) {
       reserve(size);
       const size_t size_extension = size - size_;
       inline_memset(data() + size_, '\0', size_extension);

--- a/libc/test/src/__support/CPP/string_test.cpp
+++ b/libc/test/src/__support/CPP/string_test.cpp
@@ -188,6 +188,15 @@ TEST(LlvmLibcStringTest, ResizeCapacityAndNullTermination) {
     ASSERT_EQ(a[i], '\0');
 }
 
+TEST(LlvmLibcStringTest, ResizeWithCapacityPlus1) {
+  string a;
+  a.resize(32);
+
+  size_t previous_capacity = a.capacity();
+  a.resize(previous_capacity);
+  ASSERT_GT(a.capacity(), previous_capacity);
+}
+
 TEST(LlvmLibcStringTest, ConcatWithCString) {
   ASSERT_STREQ((string("a") + string("b")).c_str(), "ab");
   ASSERT_STREQ((string("a") + "b").c_str(), "ab");


### PR DESCRIPTION
AFAICT, `cpp::string` is only used in tests, so these bugs were mostly inconsequential.