### PR TITLE
[mlir] Make the Python binding type casters well-formed under C++23

### DIFF
--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -996,7 +996,7 @@ public:
       PyGlobals::get().registerTypeCaster(
           DerivedTy::getTypeIdFunction(),
           nanobind::cast<nanobind::callable>(nanobind::cpp_function(
-              [](PyType pyType) -> DerivedTy { return pyType; })),
+              [](PyType pyType) -> DerivedTy { return DerivedTy(pyType); })),
           /*replace*/ true);
     }
 
@@ -1137,7 +1137,7 @@ public:
           DerivedTy::getTypeIdFunction(),
           nanobind::cast<nanobind::callable>(
               nanobind::cpp_function([](PyAttribute pyAttribute) -> DerivedTy {
-                return pyAttribute;
+                return DerivedTy(pyAttribute);
               })),
           /*replace*/ true);
     }
@@ -1223,7 +1223,7 @@ public:
       PyGlobals::get().registerTypeCaster(
           DerivedTy::getTypeIdFunction(),
           nanobind::cast<nanobind::callable>(nanobind::cpp_function(
-              [](PyLocation pyLoc) -> DerivedTy { return pyLoc; })),
+              [](PyLocation pyLoc) -> DerivedTy { return DerivedTy(pyLoc); })),
           /*replace*/ true);
     }
     DerivedTy::bindDerived(cls);
@@ -1700,7 +1700,7 @@ public:
       PyGlobals::get().registerValueCaster(
           DerivedTy::getTypeIdFunction(),
           nanobind::cast<nanobind::callable>(nanobind::cpp_function(
-              [](PyValue pyValue) -> DerivedTy { return pyValue; })),
+              [](PyValue pyValue) -> DerivedTy { return DerivedTy(pyValue); })),
           /*replace*/ true);
     }
 


### PR DESCRIPTION
The nanobind type/attr/loc/value casters in IRCore.h return a by-value PyType/PyAttribute/PyLocation/PyValue as their DerivedTy result. 

Under pre-C++23 rules, this was a rvalue that would decay to a lvalue when passed to the DerivedTy constructor. 

Under C++23's P2266 (implicit move on return), that return operand is an xvalue, which cannot bind the PyConcrete* constructors that take a non-const lvalue reference.

This patch constructs the derived type explicitly (return DerivedTy(arg);) using the lvalue constructor; this preserves the pre-C++23 behavior on C++23 builds.