### PR TITLE
[LLD] Add support for MIPS COFF base relocations

### DIFF
--- a/lld/COFF/Chunks.cpp
+++ b/lld/COFF/Chunks.cpp
@@ -368,6 +368,46 @@ void SectionChunk::applyRelARM64(uint8_t *off, uint16_t type, OutputSection *os,
   }
 }
 
+static void applyMipsBranch(uint8_t *off, int64_t v) {
+  if (v & 3)
+    error("misaligned jmp offset");
+  add32(off, (v >> 2) & 0x03FFFFFC);
+}
+
+void SectionChunk::applyRelMIPS(uint8_t *off, uint16_t type, OutputSection *os,
+                                uint64_t s, uint64_t p,
+                                uint64_t imageBase) const {
+  switch (type) {
+  case IMAGE_REL_MIPS_REFWORD:
+    add32(off, s + imageBase);
+    break;
+  case IMAGE_REL_MIPS_JMPADDR:
+    applyMipsBranch(off, s + imageBase);
+    break;
+  case IMAGE_REL_MIPS_REFHI:
+    add16(off, (s + imageBase) >> 16);
+    break;
+  case IMAGE_REL_MIPS_REFLO:
+    add16(off, s + imageBase);
+    break;
+  case IMAGE_REL_MIPS_PAIR:
+    // Nothing to do
+    break;
+  case IMAGE_REL_MIPS_REFWORDNB:
+    add32(off, s);
+    break;
+  case IMAGE_REL_MIPS_SECTION:
+    applySecIdx(off, os, file->symtab.ctx.outputSections.size());
+    break;
+  case IMAGE_REL_MIPS_SECREL:
+    applySecRel(this, off, os, s);
+    break;
+  default:
+    error("unsupported relocation type 0x" + Twine::utohexstr(type) + " in " +
+          toString(file));
+  }
+}
+
 static void maybeReportRelocationToDiscarded(const SectionChunk *fromChunk,
                                              Defined *sym,
                                              const coff_relocation &rel,
@@ -466,6 +506,9 @@ void SectionChunk::applyRelocation(uint8_t *off,
   case Triple::aarch64:
     applyRelARM64(off, rel.Type, os, s, p, imageBase);
     break;
+  case Triple::mipsel:
+    applyRelMIPS(off, rel.Type, os, s, p, imageBase);
+    break;
   default:
     llvm_unreachable("unknown machine type");
   }
@@ -551,6 +594,8 @@ static uint8_t getBaserelType(const coff_relocation &rel,
   case Triple::aarch64:
     if (rel.Type == IMAGE_REL_ARM64_ADDR64)
       return IMAGE_REL_BASED_DIR64;
+    return IMAGE_REL_BASED_ABSOLUTE;
+  case Triple::mipsel:
     return IMAGE_REL_BASED_ABSOLUTE;
   default:
     llvm_unreachable("unknown machine type");

--- a/lld/COFF/Chunks.cpp
+++ b/lld/COFF/Chunks.cpp
@@ -596,7 +596,20 @@ static uint8_t getBaserelType(const coff_relocation &rel,
       return IMAGE_REL_BASED_DIR64;
     return IMAGE_REL_BASED_ABSOLUTE;
   case Triple::mipsel:
-    return IMAGE_REL_BASED_ABSOLUTE;
+    switch (rel.Type) {
+    case IMAGE_REL_MIPS_REFHALF:
+      return IMAGE_REL_BASED_HIGH;
+    case IMAGE_REL_MIPS_REFWORD:
+      return IMAGE_REL_BASED_HIGHLOW;
+    case IMAGE_REL_MIPS_REFHI:
+      return IMAGE_REL_BASED_HIGHADJ;
+    case IMAGE_REL_MIPS_REFLO:
+      return IMAGE_REL_BASED_LOW;
+    case IMAGE_REL_MIPS_JMPADDR:
+      return IMAGE_REL_BASED_MIPS_JMPADDR;
+    default:
+      return IMAGE_REL_BASED_ABSOLUTE;
+    }
   default:
     llvm_unreachable("unknown machine type");
   }

--- a/lld/COFF/Chunks.h
+++ b/lld/COFF/Chunks.h
@@ -283,6 +283,8 @@ public:
                    uint64_t p, uint64_t imageBase) const;
   void applyRelARM64(uint8_t *off, uint16_t type, OutputSection *os, uint64_t s,
                      uint64_t p, uint64_t imageBase) const;
+  void applyRelMIPS(uint8_t *off, uint16_t type, OutputSection *os, uint64_t s,
+                    uint64_t p, uint64_t imageBase) const;
 
   void getRuntimePseudoRelocs(std::vector<RuntimePseudoReloc> &res);
 

--- a/lld/test/COFF/reloc-mips.test
+++ b/lld/test/COFF/reloc-mips.test
@@ -1,0 +1,56 @@
+# REQUIRES: mips
+
+# RUN: llvm-mc -filetype=obj -triple=mipsel-windows %s -o %t.obj
+# RUN: lld-link %t.obj /out:%t.exe /subsystem:console,4 /entry:_start /base:0x30000 && llvm-objdump -sS %t.exe | FileCheck %s --check-prefix=CHECK-LOW
+# RUN: lld-link %t.obj /out:%t.exe /subsystem:console,4 /entry:_start /base:0x10000000 && llvm-objdump -sS %t.exe | FileCheck %s --check-prefix=CHECK-HIGH
+
+# CHECK-LOW: Contents of section .text:
+# CHECK-LOW:  31000 00000000 00000000 00000000 02c40008  ................
+# CHECK-LOW:  31010 00000000 00000000                    ........
+# CHECK-LOW: Contents of section data_img:
+# CHECK-LOW:  32000 00000000 04200300 01000000 0000      ..... ........
+# CHECK-LOW: Contents of section text_ref:
+# CHECK-LOW:  33000 0300013c 002020ac                    ...<.  .
+
+# CHECK-LOW: Disassembly of section .text:
+# CHECK-LOW: 3100c: 02 c4 00 08  	j	0x31008 <.text+0x8>
+# CHECK-LOW: Disassembly of section text_ref:
+# CHECK-LOW: 33000: 03 00 01 3c  	lui	$1, 0x3
+# CHECK-LOW: 33004: 00 20 20 ac  	sw	$zero, 0x2000($1)
+
+# CHECK-HIGH: Contents of section .text:
+# CHECK-HIGH:  10001000 00000000 00000000 00000000 02040008  ................
+# CHECK-HIGH:  10001010 00000000 00000000                    ........
+# CHECK-HIGH: Contents of section data_img:
+# CHECK-HIGH:  10002000 00000000 04200010 01000000 0000      ..... ........
+# CHECK-HIGH: Contents of section text_ref:
+# CHECK-HIGH:  10003000 0010013c 002020ac                    ...<.  .
+
+# CHECK-HIGH: Disassembly of section .text:
+# CHECK-HIGH: 1000100c: 02 04 00 08  	j	0x1008 <.text+0x8>
+# CHECK-HIGH: Disassembly of section text_ref:
+# CHECK-HIGH: 10003000: 00 10 01 3c  	lui	$1, 0x1000 <.text>
+# CHECK-HIGH: 10003004: 00 20 20 ac  	sw	$zero, 0x2000($1)
+
+.section "data_imgrel","ax"
+i:
+.long 0
+.Lfoo:
+.rva .Lfoo
+.secidx .Ljmp_target
+.secrel32 .Ljmp_target
+
+.section .text
+.globl _start
+_start:
+  nop
+  nop
+.Ljmp_target:
+  nop
+  j .Ljmp_target
+  nop
+
+.section "text_ref","ax"
+  .set noat
+  lui $1, %hi(i)
+	sw $zero, %lo(i)($1)

--- a/lld/test/COFF/reloc-mips.test
+++ b/lld/test/COFF/reloc-mips.test
@@ -1,8 +1,8 @@
 # REQUIRES: mips
 
 # RUN: llvm-mc -filetype=obj -triple=mipsel-windows %s -o %t.obj
-# RUN: lld-link %t.obj /out:%t.exe /subsystem:console,4 /entry:_start /base:0x30000 && llvm-objdump -sS %t.exe | FileCheck %s --check-prefix=CHECK-LOW
-# RUN: lld-link %t.obj /out:%t.exe /subsystem:console,4 /entry:_start /base:0x10000000 && llvm-objdump -sS %t.exe | FileCheck %s --check-prefix=CHECK-HIGH
+# RUN: lld-link %t.obj /out:%t.exe /subsystem:console,4 /entry:_start /base:0x30000 /fixed:no && llvm-objdump -sS %t.exe | FileCheck %s --check-prefix=CHECK-LOW
+# RUN: lld-link %t.obj /out:%t.exe /subsystem:console,4 /entry:_start /base:0x10000000 /fixed:no && llvm-objdump -sS %t.exe | FileCheck %s --check-prefix=CHECK-HIGH
 
 # CHECK-LOW: Contents of section .text:
 # CHECK-LOW:  31000 00000000 00000000 00000000 02c40008  ................
@@ -11,6 +11,10 @@
 # CHECK-LOW:  32000 00000000 04200300 01000000 0000      ..... ........
 # CHECK-LOW: Contents of section text_ref:
 # CHECK-LOW:  33000 0300013c 002020ac                    ...<.  .
+# CHECK-LOW: Contents of section .reloc:
+# CHECK-LOW:  34000 00100000 0c000000 0c500000 00200000  .........P... ..
+# CHECK-LOW:  34010 0c000000 04300000 00300000 0c000000  .....0...0......
+# CHECK-LOW:  34020 00400420                             .@.
 
 # CHECK-LOW: Disassembly of section .text:
 # CHECK-LOW: 3100c: 02 c4 00 08  	j	0x31008 <.text+0x8>
@@ -25,6 +29,10 @@
 # CHECK-HIGH:  10002000 00000000 04200010 01000000 0000      ..... ........
 # CHECK-HIGH: Contents of section text_ref:
 # CHECK-HIGH:  10003000 0010013c 002020ac                    ...<.  .
+# CHECK-HIGH: Contents of section .reloc:
+# CHECK-HIGH:  10004000 00100000 0c000000 0c500000 00200000  .........P... ..
+# CHECK-HIGH:  10004010 0c000000 04300000 00300000 0c000000  .....0...0......
+# CHECK-HIGH:  10004020 00400420                             .@.
 
 # CHECK-HIGH: Disassembly of section .text:
 # CHECK-HIGH: 1000100c: 02 04 00 08  	j	0x1008 <.text+0x8>


### PR DESCRIPTION
Base relocations are required when executable (or library) is not loaded at its preferred address.

Note that IMAGE_REL_BASED_HIGHADJ is correctly emitted, but incorrectly handled in LLD framework.
This specific base relocation should occupy two slots in resulting file.