### PR TITLE
[SelectionDAG][X86] Replace OriginalDemandedBits with DemandedBits in SimplifyDemandedBits ISD::PDEP handling.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -2467,7 +2467,7 @@ bool TargetLowering::SimplifyDemandedBits(
     SDValue Op0 = Op.getOperand(0);
     SDValue Op1 = Op.getOperand(1);
 
-    unsigned DemandedBitsLZ = OriginalDemandedBits.countl_zero();
+    unsigned DemandedBitsLZ = DemandedBits.countl_zero();
     APInt LoMask = APInt::getLowBitsSet(BitWidth, BitWidth - DemandedBitsLZ);
 
     // If the demanded bits has leading zeroes, we don't demand those from the

--- a/llvm/test/CodeGen/X86/bmi2.ll
+++ b/llvm/test/CodeGen/X86/bmi2.ll
@@ -283,23 +283,22 @@ define i32 @pdep32_knownbits(i32 %x) {
 define i32 @pdep32_knownbits2(i32 %x, i32 %y) {
 ; X86-LABEL: pdep32_knownbits2:
 ; X86:       # %bb.0:
-; X86-NEXT:    movzwl {{[0-9]+}}(%esp), %eax
-; X86-NEXT:    shll $8, %eax
+; X86-NEXT:    movl $-256, %eax
+; X86-NEXT:    andl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    pdepl {{[0-9]+}}(%esp), %eax, %eax
 ; X86-NEXT:    imull %eax, %eax
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: pdep32_knownbits2:
 ; X64:       # %bb.0:
-; X64-NEXT:    andl $16776960, %edi # imm = 0xFFFF00
+; X64-NEXT:    andl $-256, %edi
 ; X64-NEXT:    pdepl %esi, %edi, %eax
 ; X64-NEXT:    imull %eax, %eax
 ; X64-NEXT:    retq
 ;
 ; EGPR-LABEL: pdep32_knownbits2:
 ; EGPR:       # %bb.0:
-; EGPR-NEXT:    andl $16776960, %edi # encoding: [0x81,0xe7,0x00,0xff,0xff,0x00]
-; EGPR-NEXT:    # imm = 0xFFFF00
+; EGPR-NEXT:    andl $-256, %edi # encoding: [0x81,0xe7,0x00,0xff,0xff,0xff]
 ; EGPR-NEXT:    pdepl %esi, %edi, %eax # EVEX TO VEX Compression encoding: [0xc4,0xe2,0x43,0xf5,0xc6]
 ; EGPR-NEXT:    imull %eax, %eax # encoding: [0x0f,0xaf,0xc0]
 ; EGPR-NEXT:    retq # encoding: [0xc3]


### PR DESCRIPTION
DemandedBits is set to all 1s if the node has multiple uses.

Fixes regression from #204144. The changed test case reverts back to the output before that change.