### PR TITLE
[mlir] Fix crash in WrittenToAnalysis on untagged stores

### DIFF
--- a/mlir/test/Analysis/DataFlow/test-written-to.mlir
+++ b/mlir/test/Analysis/DataFlow/test-written-to.mlir
@@ -379,3 +379,13 @@ func.func private @private2(%arg0: i32) {
   %0 = arith.index_cast %arg0 {tag = "in_private2"} : i32 to index
   return
 }
+
+// -----
+
+// CHECK-LABEL: test_tag: untagged
+// CHECK: result #0: [memref.store]
+func.func @test_untagged_store(%m0: memref<i32>) {
+  %c0 = arith.constant {tag = "untagged"} 0 : i32
+  memref.store %c0, %m0[] : memref<i32>
+  return
+}

--- a/mlir/test/lib/Analysis/DataFlow/TestSparseBackwardDataFlowAnalysis.cpp
+++ b/mlir/test/lib/Analysis/DataFlow/TestSparseBackwardDataFlowAnalysis.cpp
@@ -102,9 +102,13 @@ private:
 LogicalResult
 WrittenToAnalysis::visitOperation(Operation *op, ArrayRef<WrittenTo *> operands,
                                   ArrayRef<const WrittenTo *> results) {
-  if (auto store = dyn_cast<memref::StoreOp>(op)) {
+  if (isa<memref::StoreOp>(op)) {
     SetVector<StringAttr> newWrites;
-    newWrites.insert(op->getAttrOfType<StringAttr>("tag_name"));
+    StringAttr name = op->getAttrOfType<StringAttr>("tag_name");
+    if (!name) {
+      name = StringAttr::get(op->getContext(), op->getName().getStringRef());
+    }
+    newWrites.insert(name);
     propagateIfChanged(operands[0],
                        operands[0]->getValue().addWrites(newWrites));
     return success();


### PR DESCRIPTION
Fixes #206914

`WrittenToAnalysis::visitOperation` could crash on a valid IR when a `memref.store` had no `tag_name` attribute. This PR fixes the crash by falling back to the operation name similar to what has been done in `WrittenToAnalysis::visitExternalCall`.