### PR TITLE
Revert "[clang][AST] Inline StmtVisitor fallback methods" for STMT macro in debug builds

### DIFF
--- a/clang/include/clang/AST/StmtVisitor.h
+++ b/clang/include/clang/AST/StmtVisitor.h
@@ -115,8 +115,10 @@ public:
 
   // If the implementation chooses not to implement a certain visit method, fall
   // back on VisitExpr or whatever else is the superclass.
+  // Note: In debug builds, avoid ALWAYS_INLINE to prevent stack overflow with
+  // deeply nested expressions (e.g., 2000+ logical operators).
 #define STMT(CLASS, PARENT)                                                    \
-  LLVM_ATTRIBUTE_ALWAYS_INLINE                                                 \
+  LLVM_ATTRIBUTE_ALWAYS_INLINE_UNLESS_DEBUG                                    \
   RetTy Visit##CLASS(PTR(CLASS) S, ParamTys... P) { DISPATCH(PARENT, PARENT); }
 #include "clang/AST/StmtNodes.inc"
 

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -358,6 +358,14 @@
 #define LLVM_ATTRIBUTE_ALWAYS_INLINE inline
 #endif
 
+/// LLVM_ATTRIBUTE_ALWAYS_INLINE_UNLESS_DEBUG - Like LLVM_ATTRIBUTE_ALWAYS_INLINE
+/// but disabled in debug builds to avoid stack overflow with deep recursion.
+#if defined(NDEBUG)
+#define LLVM_ATTRIBUTE_ALWAYS_INLINE_UNLESS_DEBUG LLVM_ATTRIBUTE_ALWAYS_INLINE
+#else
+#define LLVM_ATTRIBUTE_ALWAYS_INLINE_UNLESS_DEBUG inline
+#endif
+
 /// LLVM_ATTRIBUTE_NO_DEBUG - On compilers where we have a directive to do
 /// so, mark a method "no debug" because debug info makes the debugger
 /// experience worse.

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -358,8 +358,9 @@
 #define LLVM_ATTRIBUTE_ALWAYS_INLINE inline
 #endif
 
-/// LLVM_ATTRIBUTE_ALWAYS_INLINE_UNLESS_DEBUG - Like LLVM_ATTRIBUTE_ALWAYS_INLINE
-/// but disabled in debug builds to avoid stack overflow with deep recursion.
+/// LLVM_ATTRIBUTE_ALWAYS_INLINE_UNLESS_DEBUG - Like
+/// LLVM_ATTRIBUTE_ALWAYS_INLINE but disabled in debug builds to avoid stack
+/// overflow with deep recursion.
 #if defined(NDEBUG)
 #define LLVM_ATTRIBUTE_ALWAYS_INLINE_UNLESS_DEBUG LLVM_ATTRIBUTE_ALWAYS_INLINE
 #else


### PR DESCRIPTION
This partially reverts commit 8b50847a31f927d258cf22953035db206d42fc5d.

The LLVM_ATTRIBUTE_ALWAYS_INLINE on STMT macro fallback methods caused
stack overflow in debug builds when processing deeply nested expressions.
The test many-logical-ops.c with 2000+ logical AND operators would crash
in SequenceChecker due to excessive stack consumption.

Introduce LLVM_ATTRIBUTE_ALWAYS_INLINE_UNLESS_DEBUG which expands to
LLVM_ATTRIBUTE_ALWAYS_INLINE in release builds (preserving the binary
size optimization) but to plain `inline` in debug builds (avoiding stack
overflow).

Apply this to the STMT macro while keeping LLVM_ATTRIBUTE_ALWAYS_INLINE
on BINOP_FALLBACK, CAO_FALLBACK, and UNARYOP_FALLBACK.

Fixes regressions in debug builds only:
   Clang :: C/C99/n590.c
   Clang :: Index/index-many-logical-ops.c
   Clang :: Sema/deep_recursion.c
   Clang :: Sema/many-logical-ops.c

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
