### PR TITLE
[ORC] Link LLVMOrcShared against libsocket on QNX

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/Shared/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/CMakeLists.txt
@@ -1,3 +1,10 @@
+if("${CMAKE_SYSTEM_NAME}" MATCHES "QNX")
+  # On QNX the socket APIs (shutdown, used by FDSimpleRemoteEPCTransport in
+  # SimpleRemoteEPCUtils.cpp) live in libsocket rather than libc. On SunOS and
+  # Haiku the equivalent library is already pulled in transitively via Support.
+  set(ORC_SHARED_EXTRA_LIBS socket)
+endif()
+
 add_llvm_component_library(LLVMOrcShared
   AllocationActions.cpp
   MachOObjectFormat.cpp
@@ -15,6 +22,7 @@ add_llvm_component_library(LLVMOrcShared
 
   LINK_LIBS
   ${LLVM_PTHREAD_LIB}
+  ${ORC_SHARED_EXTRA_LIBS}
 
   LINK_COMPONENTS
   Support


### PR DESCRIPTION
## Summary

`SimpleRemoteEPCUtils.cpp` (compiled into `LLVMOrcShared`) calls `::shutdown()` in `FDSimpleRemoteEPCTransport`. On QNX the socket APIs live in `libsocket` rather than libc, so any tool that links `OrcShared` (`lli`, `lli-child-target`, ...) fails the QNX cross-compile (`aarch64-unknown-nto-qnx8.0.0`) at link time:

```
aarch64-unknown-nto-qnx8.0.0-ld: libLLVMOrcShared.a(SimpleRemoteEPCUtils.cpp.o):
  in function `llvm::orc::FDSimpleRemoteEPCTransport::disconnect()':
  undefined reference to `shutdown'
```

Add `libsocket` to `LLVMOrcShared`'s `LINK_LIBS` on QNX, so the dependency lives on the library that actually needs it and propagates to every consumer rather than being patched onto each executable.

On SunOS and Haiku the equivalent library is already pulled in transitively via `Support` (`llvm/lib/Support/CMakeLists.txt` links `socket` on SunOS and `network` on Haiku, and `OrcShared` links `Support`), so only QNX needs handling here. This mirrors the existing per-tool QNX socket handling in `llvm-jitlink` (#206290), but placed at the library root.

## Test plan
- [ ] Cross-compile LLVM for QNX (aarch64-unknown-nto-qnx8.0.0) and confirm `lli` and `lli-child-target` link successfully.

---

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>