### PR TITLE
[HLSL] Reject unbounded resource array and noinline function resource parameters

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13825,6 +13825,8 @@ def note_hlsl_resource_range_here: Note<"overlapping resource range here">;
 
 def err_hlsl_incomplete_resource_array_in_function_param: Error<
   "incomplete resource array in a function parameter">;
+def err_hlsl_resource_param_in_noinline_function: Error<
+  "resource type %0 cannot be used as a parameter of a noinline function">;
 def err_hlsl_assign_to_global_resource: Error<
   "assignment to global resource variable %0 is not allowed">;
 def warn_hlsl_assigning_local_resource_is_not_unique

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15770,11 +15770,21 @@ Decl *Sema::ActOnParamDeclarator(Scope *S, Declarator &D,
   }
 
   // Incomplete resource arrays are not allowed as function parameters in HLSL
-  if (getLangOpts().HLSL && parmDeclType->isIncompleteArrayType() &&
-      parmDeclType->isHLSLResourceRecordArray()) {
-    Diag(D.getIdentifierLoc(),
-         diag::err_hlsl_incomplete_resource_array_in_function_param);
-    D.setInvalidType(true);
+  if (getLangOpts().HLSL && parmDeclType->isIncompleteArrayType()) {
+    // The `isHLSLResourceRecordArray` check uses the record's fields to
+    // determine whether the element is a resource, so the element type must be
+    // complete first. We use `isCompleteType` to force its completion in case
+    // this parameter is the first use of the resource type in the translation
+    // unit.
+    QualType EltTy = Context.getBaseElementType(parmDeclType);
+    if (!EltTy->isDependentType())
+      isCompleteType(D.getIdentifierLoc(), EltTy);
+
+    if (parmDeclType->isHLSLResourceRecordArray()) {
+      Diag(D.getIdentifierLoc(),
+           diag::err_hlsl_incomplete_resource_array_in_function_param);
+      D.setInvalidType(true);
+    }
   }
 
   // Temporarily put parameter variables in the translation unit, not

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -11052,8 +11052,9 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
       for (const ParmVarDecl *PVD : NewFD->parameters()) {
         QualType ParamTy = PVD->getType().getNonReferenceType();
         QualType EltTy = Context.getBaseElementType(ParamTy);
-        // `isCompleteType` forces completion of the element type so the
-        // resource parameter check is valid.
+        // `isCompleteType` forces completion of the element type without
+        // reporting an error (diagnosed elsewhere) so the resource parameter
+        // check is valid.
         if (!EltTy->isDependentType() &&
             isCompleteType(PVD->getLocation(), EltTy) &&
             ParamTy->isHLSLIntangibleType()) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -11046,6 +11046,24 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
 
     if (NewFD->hasAttr<HLSLShaderAttr>())
       HLSL().CheckEntryPoint(NewFD);
+
+    // Resources cannot be passed to functions that are not inlined.
+    if (const NoInlineAttr *NoInline = NewFD->getAttr<NoInlineAttr>()) {
+      for (const ParmVarDecl *PVD : NewFD->parameters()) {
+        QualType ParamTy = PVD->getType().getNonReferenceType();
+        QualType EltTy = Context.getBaseElementType(ParamTy);
+        // `isCompleteType` forces completion of the element type so the
+        // resource parameter check is valid.
+        if (!EltTy->isDependentType() &&
+            isCompleteType(PVD->getLocation(), EltTy) &&
+            ParamTy->isHLSLIntangibleType()) {
+          Diag(PVD->getLocation(),
+               diag::err_hlsl_resource_param_in_noinline_function)
+              << ParamTy;
+          Diag(NoInline->getLocation(), diag::note_attribute);
+        }
+      }
+    }
   }
 
   // If this is the first declaration of a library builtin function, add
@@ -15771,16 +15789,12 @@ Decl *Sema::ActOnParamDeclarator(Scope *S, Declarator &D,
 
   // Incomplete resource arrays are not allowed as function parameters in HLSL
   if (getLangOpts().HLSL && parmDeclType->isIncompleteArrayType()) {
-    // The `isHLSLResourceRecordArray` check uses the record's fields to
-    // determine whether the element is a resource, so the element type must be
-    // complete first. We use `isCompleteType` to force its completion in case
-    // this parameter is the first use of the resource type in the translation
-    // unit.
     QualType EltTy = Context.getBaseElementType(parmDeclType);
-    if (!EltTy->isDependentType())
-      isCompleteType(D.getIdentifierLoc(), EltTy);
-
-    if (parmDeclType->isHLSLResourceRecordArray()) {
+    // `isCompleteType` forces completion of the element type so the resource
+    // check is valid.
+    if (!EltTy->isDependentType() &&
+        isCompleteType(D.getIdentifierLoc(), EltTy) &&
+        parmDeclType->isHLSLResourceRecordArray()) {
       Diag(D.getIdentifierLoc(),
            diag::err_hlsl_incomplete_resource_array_in_function_param);
       D.setInvalidType(true);

--- a/clang/test/SemaHLSL/Resources/resource_params_noinline.hlsl
+++ b/clang/test/SemaHLSL/Resources/resource_params_noinline.hlsl
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -fsyntax-only -finclude-default-header %s -verify
+
+// expected-error@+2 {{resource type 'RWBuffer<float>' cannot be used as a parameter of a noinline function}}
+// expected-note@+1 {{attribute is here}}
+__attribute__((noinline)) float resource_param(RWBuffer<float> A) {}
+
+// expected-error@+2 {{resource type 'RWBuffer<float>[4]' cannot be used as a parameter of a noinline function}}
+// expected-note@+1 {{attribute is here}}
+__attribute__((noinline)) float resource_array_param(RWBuffer<float> A[4]) {}
+
+struct MyStruct {
+  RWBuffer<float> A;
+};
+// expected-error@+2 {{resource type 'MyStruct' cannot be used as a parameter of a noinline function}}
+// expected-note@+1 {{attribute is here}}
+__attribute__((noinline)) float resource_struct_param(MyStruct S) {}
+
+// expected-error@+2 {{resource type 'RWByteAddressBuffer' cannot be used as a parameter of a noinline function}}
+// expected-note@+1 {{attribute is here}}
+__attribute__((noinline)) void no_prior_use(RWByteAddressBuffer A) {}

--- a/clang/test/SemaHLSL/Resources/unbounded_resource_arrays.hlsl
+++ b/clang/test/SemaHLSL/Resources/unbounded_resource_arrays.hlsl
@@ -1,10 +1,18 @@
-// RUN: not %clang_cc1 -triple dxil-pc-shadermodel6.3-compute -finclude-default-header --o - %s -verify
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-compute -x hlsl -fsyntax-only -finclude-default-header %s -verify
+
+// unbounded resource array parameter whose resource type has not been used earlier
+// expected-error@+1 {{incomplete resource array in a function parameter}}
+void no_prior_use(RWByteAddressBuffer bf[]) {}
 
 // unbounded resource array at a global scope
-RWBuffer<float> unbounded_array[]; // no_error
+RWBuffer<float> unbounded_array[]; // no error
 
 // expected-error@+1 {{incomplete resource array in a function parameter}}
 void foo(RWBuffer<float> array_arg[]) {}
+
+// a non-resource incomplete-array parameter should not error
+struct Fwd;
+void non_resource(Fwd a[]); // no error
 
 RWBuffer<float> A, B;
 
@@ -13,7 +21,7 @@ void main() {
   // expected-error@+1{{definition of variable with array type needs an explicit size or an initializer}}
   RWBuffer<float> res_local_array1[]; 
 
-  // expected-error@+1{{array initializer must be an initialzer list}}
+  // expected-error@+1{{array initializer must be an initializer list}}
   RWBuffer<float> res_local_array2[] = unbounded_array;
 
   // local incomplete resource array with initializer

--- a/clang/test/SemaHLSL/Resources/unbounded_resource_arrays.hlsl
+++ b/clang/test/SemaHLSL/Resources/unbounded_resource_arrays.hlsl
@@ -2,7 +2,7 @@
 
 // unbounded resource array parameter whose resource type has not been used earlier
 // expected-error@+1 {{incomplete resource array in a function parameter}}
-void no_prior_use(RWByteAddressBuffer bf[]) {}
+void no_prior_use(RWByteAddressBuffer array_arg[]) {}
 
 // unbounded resource array at a global scope
 RWBuffer<float> unbounded_array[]; // no error
@@ -11,8 +11,8 @@ RWBuffer<float> unbounded_array[]; // no error
 void foo(RWBuffer<float> array_arg[]) {}
 
 // a non-resource incomplete-array parameter should not error
-struct Fwd;
-void non_resource(Fwd a[]); // no error
+struct S;
+void non_resource(S array_arg[]); // no error
 
 RWBuffer<float> A, B;
 


### PR DESCRIPTION
Fixes #180808.

This issue involved two bugs:
- `noinline` functions accepted resource parameters in the frontend, which crashed the backend since valid DXIL cannot be generated for resources passed across a function call. This change adds a new check in `SemaDecl.cpp` that rejects resource parameters on `noinline` functions, as well as a new `resource_params_noinline.hlsl` test.
- The check for incomplete resource array parameters queried the array's element type to decide if it was a resource. When the parameter was the first use of the resource type, the element was still incomplete and wouldn't register as a resource, so the check would be skipped and the compiler would later crash. This change fixes the check to now force element completion with `isCompleteType` before querying the type, and updates `unbounded_resource_arrays.hlsl` to test this.

This change also fixes the `unbounded_resource_arrays.hlsl` test in general; the `not` in the RUN command was inverting the result and hiding an actual failure (one of the expected error messages was misspelled).

Assisted by: Github Copilot