### PR TITLE
[offload] Decouple PluginManager from the OpenMP offload policy handling

### DIFF
--- a/offload/include/PluginManager.h
+++ b/offload/include/PluginManager.h
@@ -50,7 +50,7 @@ struct PluginManager {
 
   PluginManager() {}
 
-  void init();
+  void initPlugins();
 
   void deinit();
 
@@ -183,10 +183,10 @@ private:
   __tgt_bin_desc *upgradeLegacyEntries(__tgt_bin_desc *Desc);
 };
 
-/// Initialize the plugin manager and OpenMP runtime.
-void initRuntime();
+/// Initialize the plugin manager.
+void initRuntime(bool InitializePlugins);
 
-/// Deinitialize the plugin and delete it.
+/// Deinitialize the plugin manager and delete it.
 void deinitRuntime();
 
 extern PluginManager *PM;

--- a/offload/include/omptarget.h
+++ b/offload/include/omptarget.h
@@ -328,7 +328,7 @@ void *llvm_omp_target_dynamic_shared_alloc();
 void __tgt_register_requires(int64_t Flags);
 
 /// Initializes the runtime library.
-void __tgt_rtl_init();
+void __tgt_rtl_init(bool OffloadEnabled);
 
 /// Deinitializes the runtime library.
 void __tgt_rtl_deinit();

--- a/offload/libomptarget/OffloadRTL.cpp
+++ b/offload/libomptarget/OffloadRTL.cpp
@@ -23,47 +23,47 @@ using namespace llvm::omp::target::debug;
 
 static std::mutex PluginMtx;
 static uint32_t RefCount = 0;
+static bool PluginsInitialized = 0;
 std::atomic<bool> RTLAlive{false};
 std::atomic<int> RTLOngoingSyncs{0};
 
-/// Check deleted and deprecated features, such as environment variables.
-static void checkRuntimeEnvironment() {
-  const char *ShmemEnvarName = "LIBOMPTARGET_SHARED_MEMORY_SIZE";
-  if (std::getenv(ShmemEnvarName))
-    MESSAGE("Warning: %s is no longer valid. Please use OpenMP clause "
-            "'dyn_groupprivate' instead.\n",
-            ShmemEnvarName);
-}
-
-void initRuntime() {
+void initRuntime(bool InitializePlugins) {
   std::scoped_lock<decltype(PluginMtx)> Lock(PluginMtx);
   Profiler::get();
   TIMESCOPE();
 
-  checkRuntimeEnvironment();
-
-  if (PM == nullptr)
-    PM = new PluginManager();
-
   RefCount++;
   if (RefCount == 1) {
+    assert(PM == nullptr);
+    PM = new PluginManager();
+
     ODBG(ODT_Init) << "Init offload library!";
 #ifdef OMPT_SUPPORT
     // Initialize OMPT first
     llvm::omp::target::ompt::connectLibrary();
 #endif
 
-    PM->init();
-    PM->registerDelayedLibraries();
+    if (!InitializePlugins)
+      ODBG(ODT_Init) << "Offload is disabled. Skipping plugin initialization";
 
     // RTL initialization is complete
     RTLAlive = true;
+  }
+
+  // Initialize the plugins at the first call to this function with
+  // InitializePlugins == true
+  if (!PluginsInitialized && InitializePlugins) {
+    ODBG(ODT_Init) << "Offload is enabled. Initializating plugins";
+    PM->initPlugins();
+    PM->registerDelayedLibraries();
+    PluginsInitialized = true;
   }
 }
 
 void deinitRuntime() {
   std::scoped_lock<decltype(PluginMtx)> Lock(PluginMtx);
   assert(PM && "Runtime not initialized");
+  assert(RefCount != 0 && "Unmatched init and deinit");
 
   if (RefCount == 1) {
     ODBG(ODT_Deinit) << "Deinit offload library!";
@@ -77,6 +77,7 @@ void deinitRuntime() {
     PM->deinit();
     delete PM;
     PM = nullptr;
+    PluginsInitialized = false;
   }
 
   RefCount--;

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -30,13 +30,8 @@ PluginManager *PM = nullptr;
 #define PLUGIN_TARGET(Name) extern "C" GenericPluginTy *createPlugin_##Name();
 #include "Shared/Targets.def"
 
-void PluginManager::init() {
+void PluginManager::initPlugins() {
   TIMESCOPE();
-  if (OffloadPolicy::isOffloadDisabled()) {
-    ODBG(ODT_Init) << "Offload is disabled. Skipping plugin initialization";
-    return;
-  }
-
   ODBG(ODT_Init) << "Loading RTLs";
 
   // Attempt to create an instance of each supported plugin.

--- a/offload/libomptarget/interface.cpp
+++ b/offload/libomptarget/interface.cpp
@@ -75,6 +75,15 @@ bool checkDevice(int64_t &DeviceID, ident_t *Loc) {
   return false;
 }
 
+/// Check deleted and deprecated features, such as environment variables.
+static void checkRuntimeEnvironment() {
+  const char *ShmemEnvarName = "LIBOMPTARGET_SHARED_MEMORY_SIZE";
+  if (std::getenv(ShmemEnvarName))
+    MESSAGE("Warning: %s is no longer valid. Please use OpenMP clause "
+            "'dyn_groupprivate' instead.\n",
+            ShmemEnvarName);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// adds requires flags
 EXTERN void __tgt_register_requires(int64_t Flags) {
@@ -83,13 +92,14 @@ EXTERN void __tgt_register_requires(int64_t Flags) {
           __PRETTY_FUNCTION__);
 }
 
-EXTERN void __tgt_rtl_init() { initRuntime(); }
+EXTERN void __tgt_rtl_init(bool OffloadEnabled) { initRuntime(OffloadEnabled); }
 EXTERN void __tgt_rtl_deinit() { deinitRuntime(); }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// adds a target shared library to the target execution image
 EXTERN void __tgt_register_lib(__tgt_bin_desc *Desc) {
-  initRuntime();
+  checkRuntimeEnvironment();
+  initRuntime(!OffloadPolicy::isOffloadDisabled());
   if (PM->delayRegisterLib(Desc))
     return;
 

--- a/offload/test/offloading/runtime_init.c
+++ b/offload/test/offloading/runtime_init.c
@@ -1,29 +1,56 @@
-// RUN: %libomptarget-compile-generic
-// RUN:   env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
+// RUN: %clang %flags %flags_clang -lomptarget %s -o %t.a.out
+// RUN:   env LIBOMPTARGET_DEBUG=1 %t.a.out 2>&1 | \
 // RUN: %fcheck-generic
 
 // REQUIRES: libomptarget-debug
 
 #include <omp.h>
+#include <stdbool.h>
 #include <stdio.h>
 
-extern void __tgt_rtl_init(void);
+extern void __tgt_rtl_init(bool OffloadEnabled);
 extern void __tgt_rtl_deinit(void);
 
 // Sanity checks to make sure that this works and is thread safe.
 int main() {
   // CHECK: Init offload library!
-  // CHECK: Deinit offload library!
-  __tgt_rtl_init();
+  // CHECK: Offload is disabled. Skipping plugin initialization
+  __tgt_rtl_init(false);
 #pragma omp parallel num_threads(8)
   {
-    __tgt_rtl_init();
+    __tgt_rtl_init(false);
     __tgt_rtl_deinit();
   }
+  // CHECK-NOT: Offload is enabled. Initializating plugins
+  // CHECK: Deinit offload library!
   __tgt_rtl_deinit();
 
-  __tgt_rtl_init();
+  // CHECK: Init offload library!
+  // CHECK: Offload is enabled. Initializating plugins
+  __tgt_rtl_init(true);
+  // CHECK: Deinit offload library!
   __tgt_rtl_deinit();
+
+  // CHECK: Init offload library!
+  // CHECK: Offload is disabled. Skipping plugin initialization
+  __tgt_rtl_init(false);
+  // CHECK: Offload is enabled. Initializating plugins
+  __tgt_rtl_init(true);
+  __tgt_rtl_deinit();
+  // CHECK: Deinit offload library!
+  __tgt_rtl_deinit();
+
+  // CHECK: Init offload library!
+  // CHECK: Offload is enabled. Initializating plugins
+  __tgt_rtl_init(true);
+  // CHECK-NOT: Offload is disabled. Skipping plugin initialization
+  __tgt_rtl_init(false);
+  __tgt_rtl_deinit();
+  // CHECK: Deinit offload library!
+  __tgt_rtl_deinit();
+
+  // CHECK-NOT: Init offload library!
+  // CHECK-NOT: Deinit offload library!
 
   // CHECK: PASS
   printf("PASS\n");


### PR DESCRIPTION
This patch refactors libomptarget to decouple OpenMP specific handling from PluginManager. This is to prepare PluginManager to be split off into a separate library to be used for both the OpenMP and OpenACC runtime.

The plugin initialization logic is necessary so that even if OpenMP has offloading disabled, OpenACC can come along and initialize the plugins for itself regardless of OpenMP's offloading policy.