### PR TITLE
[llvm-readobj][llvm-ar][COFF] Use exclude for .obj.arm64ec section in tests (NFC)

### DIFF
--- a/llvm/test/tools/llvm-ar/arm64x-hybridobj.yaml
+++ b/llvm/test/tools/llvm-ar/arm64x-hybridobj.yaml
@@ -1,7 +1,7 @@
 ## Create a hybrid ARM64/ARM64EC object file and verify that it is split when added to an archive.
 # RUN: yaml2obj -DMACHINE=IMAGE_FILE_MACHINE_ARM64 %s -o %t-aarch64.o
 # RUN: yaml2obj -DMACHINE=IMAGE_FILE_MACHINE_ARM64EC %s -o %t-arm64ec.o
-# RUN: llvm-objcopy --add-section=.obj.arm64ec=%t-arm64ec.o --set-section-flags=.obj.arm64ec=debug %t-aarch64.o %t.o
+# RUN: llvm-objcopy --add-section=.obj.arm64ec=%t-arm64ec.o --set-section-flags=.obj.arm64ec=exclude %t-aarch64.o %t.o
 # RUN: rm -f %t.lib %t-s.lib
 # RUN: llvm-ar rc %t.lib %t.o
 # RUN: llvm-nm --print-armap %t.lib | FileCheck %s

--- a/llvm/test/tools/llvm-lib/arm64x-hybridobj.yaml
+++ b/llvm/test/tools/llvm-lib/arm64x-hybridobj.yaml
@@ -1,6 +1,6 @@
 # RUN: yaml2obj -DMACHINE=IMAGE_FILE_MACHINE_ARM64 %s -o %t-aarch64.o
 # RUN: yaml2obj -DMACHINE=IMAGE_FILE_MACHINE_ARM64EC %s -o %t-arm64ec.o
-# RUN: llvm-objcopy --add-section=.obj.arm64ec=%t-arm64ec.o --set-section-flags=.obj.arm64ec=debug %t-aarch64.o %t.o
+# RUN: llvm-objcopy --add-section=.obj.arm64ec=%t-arm64ec.o --set-section-flags=.obj.arm64ec=exclude %t-aarch64.o %t.o
 # RUN: llvm-lib -machine:arm64x -out:%t.lib %t.o
 # RUN: llvm-nm --print-armap %t.lib | FileCheck %s
 

--- a/llvm/test/tools/llvm-readobj/COFF/arm64x-hybridobj.yaml
+++ b/llvm/test/tools/llvm-readobj/COFF/arm64x-hybridobj.yaml
@@ -1,6 +1,6 @@
 # RUN: yaml2obj -DMACHINE=IMAGE_FILE_MACHINE_ARM64 %s -o %t-aarch64.o
 # RUN: yaml2obj -DMACHINE=IMAGE_FILE_MACHINE_ARM64EC %s -o %t-arm64ec.o
-# RUN: llvm-objcopy --add-section=.obj.arm64ec=%t-arm64ec.o --set-section-flags=.obj.arm64ec=debug %t-aarch64.o %t.o
+# RUN: llvm-objcopy --add-section=.obj.arm64ec=%t-arm64ec.o --set-section-flags=.obj.arm64ec=exclude %t-aarch64.o %t.o
 # RUN: llvm-readobj --sections %t.o | FileCheck %s
 
 # CHECK:      Format: COFF-ARM64
@@ -36,9 +36,8 @@
 # CHECK-NEXT:     PointerToLineNumbers: 0x0
 # CHECK-NEXT:     RelocationCount: 0
 # CHECK-NEXT:     LineNumberCount: 0
-# CHECK-NEXT:     Characteristics [ (0xC2000040)
-# CHECK-NEXT:       IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
-# CHECK-NEXT:       IMAGE_SCN_MEM_DISCARDABLE (0x2000000)
+# CHECK-NEXT:     Characteristics [ (0xC0000800)
+# CHECK-NEXT:       IMAGE_SCN_LNK_REMOVE (0x800)
 # CHECK-NEXT:       IMAGE_SCN_MEM_READ (0x40000000)
 # CHECK-NEXT:       IMAGE_SCN_MEM_WRITE (0x80000000)
 # CHECK-NEXT:     ]


### PR DESCRIPTION
For consistency with #207612.