### PR TITLE
[lldb] TypeCategoryMap: Replace ConstString with StringRef

### DIFF
--- a/lldb/include/lldb/DataFormatters/TypeCategoryMap.h
+++ b/lldb/include/lldb/DataFormatters/TypeCategoryMap.h
@@ -21,6 +21,8 @@
 #include "lldb/DataFormatters/FormattersContainer.h"
 #include "lldb/DataFormatters/TypeCategory.h"
 
+#include "llvm/ADT/StringMap.h"
+
 namespace lldb_private {
 class TypeCategoryMap {
 private:
@@ -28,8 +30,7 @@ private:
   typedef ActiveCategoriesList::iterator ActiveCategoriesIterator;
 
 public:
-  typedef ConstString KeyType;
-  typedef std::map<KeyType, lldb::TypeCategoryImplSP> MapType;
+  typedef llvm::StringMap<lldb::TypeCategoryImplSP> MapType;
   typedef MapType::iterator MapIterator;
   typedef std::function<bool(const lldb::TypeCategoryImplSP &)> ForEachCallback;
 
@@ -41,13 +42,13 @@ public:
 
   TypeCategoryMap(IFormatChangeListener *lst);
 
-  void Add(KeyType name, const lldb::TypeCategoryImplSP &entry);
+  void Add(llvm::StringRef name, const lldb::TypeCategoryImplSP &entry);
 
-  bool Delete(KeyType name);
+  bool Delete(llvm::StringRef name);
 
-  bool Enable(KeyType category_name, Position pos = Default);
+  bool Enable(llvm::StringRef category_name, Position pos = Default);
 
-  bool Disable(KeyType category_name);
+  bool Disable(llvm::StringRef category_name);
 
   bool Enable(lldb::TypeCategoryImplSP category, Position pos = Default);
 
@@ -59,7 +60,7 @@ public:
 
   void Clear();
 
-  bool Get(KeyType name, lldb::TypeCategoryImplSP &entry);
+  bool Get(llvm::StringRef name, lldb::TypeCategoryImplSP &entry);
 
   void ForEach(ForEachCallback callback);
 

--- a/lldb/source/DataFormatters/TypeCategoryMap.cpp
+++ b/lldb/source/DataFormatters/TypeCategoryMap.cpp
@@ -17,14 +17,15 @@ using namespace lldb_private;
 
 TypeCategoryMap::TypeCategoryMap(IFormatChangeListener *lst)
     : m_map_mutex(), listener(lst), m_map(), m_active_categories() {
-  ConstString default_cs("default");
-  lldb::TypeCategoryImplSP default_sp =
-      std::make_shared<TypeCategoryImpl>(listener, default_cs);
-  Add(default_cs, default_sp);
-  Enable(default_cs, First);
+  constexpr llvm::StringRef default_category_name("default");
+  lldb::TypeCategoryImplSP default_sp = std::make_shared<TypeCategoryImpl>(
+      listener, ConstString(default_category_name));
+  Add(default_category_name, default_sp);
+  Enable(default_category_name, First);
 }
 
-void TypeCategoryMap::Add(KeyType name, const TypeCategoryImplSP &entry) {
+void TypeCategoryMap::Add(llvm::StringRef name,
+                          const TypeCategoryImplSP &entry) {
   {
     std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
     m_map[name] = entry;
@@ -37,7 +38,7 @@ void TypeCategoryMap::Add(KeyType name, const TypeCategoryImplSP &entry) {
     listener->Changed();
 }
 
-bool TypeCategoryMap::Delete(KeyType name) {
+bool TypeCategoryMap::Delete(llvm::StringRef name) {
   {
     std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
     MapIterator iter = m_map.find(name);
@@ -55,7 +56,7 @@ bool TypeCategoryMap::Delete(KeyType name) {
   return true;
 }
 
-bool TypeCategoryMap::Enable(KeyType category_name, Position pos) {
+bool TypeCategoryMap::Enable(llvm::StringRef category_name, Position pos) {
   std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
   TypeCategoryImplSP category;
   if (!Get(category_name, category))
@@ -63,7 +64,7 @@ bool TypeCategoryMap::Enable(KeyType category_name, Position pos) {
   return Enable(category, pos);
 }
 
-bool TypeCategoryMap::Disable(KeyType category_name) {
+bool TypeCategoryMap::Disable(llvm::StringRef category_name) {
   std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
   TypeCategoryImplSP category;
   if (!Get(category_name, category))
@@ -149,7 +150,7 @@ void TypeCategoryMap::Clear() {
     listener->Changed();
 }
 
-bool TypeCategoryMap::Get(KeyType name, TypeCategoryImplSP &entry) {
+bool TypeCategoryMap::Get(llvm::StringRef name, TypeCategoryImplSP &entry) {
   std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
   MapIterator iter = m_map.find(name);
   if (iter == m_map.end())


### PR DESCRIPTION
I plan on removing ConstStrings from DataFormatters where possible. There's a lot of entangled classes in DataFormatters but TypeCategoryMap feels approachable to start with.