### PR TITLE
[AggressiveInstCombine] Factor out the common part of tryToRecognizeTableBasedCttz and tryToRecognizeTableBasedLog2. NFC

### DIFF
--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
@@ -954,31 +954,14 @@ static bool isCTTZTable(Constant *Table, const APInt &Mul, const APInt &Shift,
 // %0 = load i8, i8* %arrayidx, align 1, !tbaa !8
 //
 // All these can be lowered to @llvm.cttz.i32/64 intrinsics.
-static bool tryToRecognizeTableBasedCttz(Instruction &I, const DataLayout &DL) {
-  LoadInst *LI = dyn_cast<LoadInst>(&I);
-  if (!LI)
-    return false;
-
-  Type *AccessType = LI->getType();
-  if (!AccessType->isIntegerTy())
-    return false;
-
-  GetElementPtrInst *GEP = dyn_cast<GetElementPtrInst>(LI->getPointerOperand());
-  if (!GEP || !GEP->hasNoUnsignedSignedWrap())
-    return false;
-
-  GlobalVariable *GVTable = dyn_cast<GlobalVariable>(GEP->getPointerOperand());
-  if (!GVTable || !GVTable->hasInitializer() || !GVTable->isConstant())
-    return false;
-
-  unsigned BW = DL.getIndexTypeSizeInBits(GEP->getType());
-  APInt ModOffset(BW, 0);
-  SmallMapVector<Value *, APInt, 4> VarOffsets;
-  if (!GEP->collectOffset(DL, BW, VarOffsets, ModOffset) ||
-      VarOffsets.size() != 1 || ModOffset != 0)
-    return false;
-  auto [GepIdx, GEPScale] = VarOffsets.front();
-
+//
+// This shares its initial match (load from a GEP into a constant table with
+// a single variable index) with tryToRecognizeTableBasedLog2() below; see
+// tryToRecognizeTableBasedCttzOrLog2().
+static bool tryToRecognizeTableBasedCttz(LoadInst *LI, Type *AccessType,
+                                         GlobalVariable *GVTable, Value *GepIdx,
+                                         const APInt &GEPScale,
+                                         const DataLayout &DL) {
   Value *X1;
   const APInt *MulConst, *ShiftConst, *AndCst = nullptr;
   // Check that the gep variable index is ((x & -x) * MulConst) >> ShiftConst.
@@ -1122,32 +1105,15 @@ static bool isLog2Table(Constant *Table, const APInt &Mul, const APInt &Shift,
 // %0 = load i8, ptr %arrayidx, align 1
 //
 // All these can be lowered to @llvm.ctlz.i32/64 intrinsics and a subtract.
-static bool tryToRecognizeTableBasedLog2(Instruction &I, const DataLayout &DL,
+//
+// This shares its initial match (load from a GEP into a constant table with
+// a single variable index) with tryToRecognizeTableBasedCttz() above; see
+// tryToRecognizeTableBasedCttzOrLog2().
+static bool tryToRecognizeTableBasedLog2(LoadInst *LI, Type *AccessType,
+                                         GlobalVariable *GVTable, Value *GepIdx,
+                                         const APInt &GEPScale,
+                                         const DataLayout &DL,
                                          TargetTransformInfo &TTI) {
-  LoadInst *LI = dyn_cast<LoadInst>(&I);
-  if (!LI)
-    return false;
-
-  Type *AccessType = LI->getType();
-  if (!AccessType->isIntegerTy())
-    return false;
-
-  GetElementPtrInst *GEP = dyn_cast<GetElementPtrInst>(LI->getPointerOperand());
-  if (!GEP || !GEP->hasNoUnsignedSignedWrap())
-    return false;
-
-  GlobalVariable *GVTable = dyn_cast<GlobalVariable>(GEP->getPointerOperand());
-  if (!GVTable || !GVTable->hasInitializer() || !GVTable->isConstant())
-    return false;
-
-  unsigned BW = DL.getIndexTypeSizeInBits(GEP->getType());
-  APInt ModOffset(BW, 0);
-  SmallMapVector<Value *, APInt, 4> VarOffsets;
-  if (!GEP->collectOffset(DL, BW, VarOffsets, ModOffset) ||
-      VarOffsets.size() != 1 || ModOffset != 0)
-    return false;
-  auto [GepIdx, GEPScale] = VarOffsets.front();
-
   Value *X;
   const APInt *MulConst, *ShiftConst;
   // Check that the gep variable index is (x * MulConst) >> ShiftConst.
@@ -1220,6 +1186,44 @@ static bool tryToRecognizeTableBasedLog2(Instruction &I, const DataLayout &DL,
   LI->replaceAllUsesWith(ZExtOrTrunc);
 
   return true;
+}
+
+// Match a table-based cttz or log2 implementation. These patterns share a
+// load from a global table pattern that we match first. Then we try the
+// specific matches for the cttz and log2 patterns.
+static bool tryToRecognizeTableBasedCttzOrLog2(Instruction &I,
+                                               const DataLayout &DL,
+                                               TargetTransformInfo &TTI) {
+  LoadInst *LI = dyn_cast<LoadInst>(&I);
+  if (!LI)
+    return false;
+
+  Type *AccessType = LI->getType();
+  if (!AccessType->isIntegerTy())
+    return false;
+
+  GetElementPtrInst *GEP = dyn_cast<GetElementPtrInst>(LI->getPointerOperand());
+  if (!GEP || !GEP->hasNoUnsignedSignedWrap())
+    return false;
+
+  GlobalVariable *GVTable = dyn_cast<GlobalVariable>(GEP->getPointerOperand());
+  if (!GVTable || !GVTable->hasInitializer() || !GVTable->isConstant())
+    return false;
+
+  unsigned BW = DL.getIndexTypeSizeInBits(GEP->getType());
+  APInt ModOffset(BW, 0);
+  SmallMapVector<Value *, APInt, 4> VarOffsets;
+  if (!GEP->collectOffset(DL, BW, VarOffsets, ModOffset) ||
+      VarOffsets.size() != 1 || ModOffset != 0)
+    return false;
+  auto [GepIdx, GEPScale] = VarOffsets.front();
+
+  if (tryToRecognizeTableBasedCttz(LI, AccessType, GVTable, GepIdx, GEPScale,
+                                   DL))
+    return true;
+
+  return tryToRecognizeTableBasedLog2(LI, AccessType, GVTable, GepIdx, GEPScale,
+                                      DL, TTI);
 }
 
 /// This is used by foldLoadsRecursive() to capture a Root Load node which is
@@ -2427,8 +2431,7 @@ static bool foldUnusualPatterns(Function &F, DominatorTree &DT,
       MadeChange |= tryToRecognizePopCount1(I);
       MadeChange |= tryToRecognizePopCount2n3(I);
       MadeChange |= tryToFPToSat(I, TTI);
-      MadeChange |= tryToRecognizeTableBasedCttz(I, DL);
-      MadeChange |= tryToRecognizeTableBasedLog2(I, DL, TTI);
+      MadeChange |= tryToRecognizeTableBasedCttzOrLog2(I, DL, TTI);
       MadeChange |= foldConsecutiveLoads(I, DL, TTI, AA, DT);
       MadeChange |= foldPatternedLoads(I, DL);
       MadeChange |= foldICmpOrChain(I, DL, TTI, AA, DT);


### PR DESCRIPTION
They both start with the same GEP+load matching.

Assisted-by: Claude