### PR TITLE
[libc++] Implement LWG4472: std::atomic_ref<const T> can be constructed from temporaries

### DIFF
--- a/libcxx/docs/Status/Cxx26Issues.csv
+++ b/libcxx/docs/Status/Cxx26Issues.csv
@@ -295,7 +295,7 @@
 "`LWG4467 <https://wg21.link/LWG4467>`__","``hive::splice`` can throw ``bad_alloc``","2026-03 (Croydon)","","","`#189837 <https://github.com/llvm/llvm-project/issues/189837>`__",""
 "`LWG4468 <https://wg21.link/LWG4468>`__","§[const.wrap.class] ""``operator decltype(auto)``"" is ill-formed","2026-03 (Croydon)","|Complete|","23","`#189838 <https://github.com/llvm/llvm-project/issues/189838>`__",""
 "`LWG4469 <https://wg21.link/LWG4469>`__","Names of parameters of addressable function shall remain unspecified","2026-03 (Croydon)","","","`#189839 <https://github.com/llvm/llvm-project/issues/189839>`__",""
-"`LWG4472 <https://wg21.link/LWG4472>`__","``std::atomic_ref<const T>`` can be constructed from temporaries","2026-03 (Croydon)","","","`#189840 <https://github.com/llvm/llvm-project/issues/189840>`__",""
+"`LWG4472 <https://wg21.link/LWG4472>`__","``std::atomic_ref<const T>`` can be constructed from temporaries","2026-03 (Croydon)","|Complete|","23","`#189840 <https://github.com/llvm/llvm-project/issues/189840>`__",""
 "`LWG4474 <https://wg21.link/LWG4474>`__","""``round_to_nearest``"" rounding mode is unclear","2026-03 (Croydon)","","","`#189841 <https://github.com/llvm/llvm-project/issues/189841>`__",""
 "`LWG4476 <https://wg21.link/LWG4476>`__","``run_loop`` should not have a ``set_error`` completion","2026-03 (Croydon)","","","`#189842 <https://github.com/llvm/llvm-project/issues/189842>`__",""
 "`LWG4477 <https://wg21.link/LWG4477>`__","Placement ``operator delete`` should be constexpr","2026-03 (Croydon)","|Complete|","23","`#189843 <https://github.com/llvm/llvm-project/issues/189843>`__",""

--- a/libcxx/include/__atomic/atomic_ref.h
+++ b/libcxx/include/__atomic/atomic_ref.h
@@ -259,6 +259,8 @@ struct atomic_ref : public __atomic_ref_base<_Tp> {
         "atomic_ref ctor: referenced object must be aligned to required_alignment");
   }
 
+  _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp&&) = delete;
+
   _LIBCPP_HIDE_FROM_ABI atomic_ref(const atomic_ref&) noexcept = default;
 
   _LIBCPP_HIDE_FROM_ABI _Tp operator=(_Tp __desired) const noexcept { return __base::operator=(__desired); }
@@ -278,6 +280,8 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
         std::__is_sufficiently_aligned<__base::required_alignment>(std::addressof(__obj)),
         "atomic_ref ctor: referenced object must be aligned to required_alignment");
   }
+
+  _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp&&) = delete;
 
   _LIBCPP_HIDE_FROM_ABI atomic_ref(const atomic_ref&) noexcept = default;
 
@@ -325,6 +329,8 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
         "atomic_ref ctor: referenced object must be aligned to required_alignment");
   }
 
+  _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp&&) = delete;
+
   _LIBCPP_HIDE_FROM_ABI atomic_ref(const atomic_ref&) noexcept = default;
 
   _LIBCPP_HIDE_FROM_ABI _Tp operator=(_Tp __desired) const noexcept { return __base::operator=(__desired); }
@@ -367,6 +373,8 @@ struct atomic_ref<_Tp*> : public __atomic_ref_base<_Tp*> {
   using difference_type = ptrdiff_t;
 
   _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp*& __ptr) : __base(__ptr) {}
+
+  _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp*&&) = delete;
 
   _LIBCPP_HIDE_FROM_ABI _Tp* operator=(_Tp* __desired) const noexcept { return __base::operator=(__desired); }
 

--- a/libcxx/test/std/atomics/atomics.ref/ctor.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/ctor.pass.cpp
@@ -11,6 +11,7 @@
 // <atomic>
 
 // explicit atomic_ref(T&);
+// explicit atomic_ref(T&&) = delete;
 
 #include <atomic>
 #include <type_traits>
@@ -21,9 +22,12 @@
 template <typename T>
 struct TestCtor {
   void operator()() const {
-    // check that the constructor is explicit
     static_assert(!std::is_convertible_v<T, std::atomic_ref<T>>);
     static_assert(std::is_constructible_v<std::atomic_ref<T>, T&>);
+
+    static_assert(!std::is_constructible_v<std::atomic_ref<T>, T&&>);
+    static_assert(!std::is_constructible_v<std::atomic_ref<const T>, T&&>);
+    static_assert(!std::is_constructible_v<std::atomic_ref<const T>, const T&&>);
 
     alignas(std::atomic_ref<T>::required_alignment) T x(T(0));
     std::atomic_ref<T> a(x);

--- a/libcxx/test/std/atomics/atomics.ref/ctor.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/ctor.pass.cpp
@@ -22,6 +22,7 @@
 template <typename T>
 struct TestCtor {
   void operator()() const {
+    // check that the constructor is explicit
     static_assert(!std::is_convertible_v<T, std::atomic_ref<T>>);
     static_assert(std::is_constructible_v<std::atomic_ref<T>, T&>);
 


### PR DESCRIPTION
## Summary
- Implements LWG4472, i.e., adds a deleted `atomic_ref(T&&)` overload to the primary template and three partial specializations of `atomic_ref`.


## Test
- Added `static_assert`s in `ctor.pass.cpp` asserting `atomic_ref<T>`/`atomic_ref<const T>` reject construction from `T&&`/`const T&&`.

Resolve #189840