### PR TITLE
[libc++] Mark LWG3133 as Complete and add valarray operator[] safety tests

### DIFF
--- a/libcxx/docs/Status/Cxx20Issues.csv
+++ b/libcxx/docs/Status/Cxx20Issues.csv
@@ -136,7 +136,7 @@
 "`LWG3101 <https://wg21.link/LWG3101>`__","``span``\ 's ``Container``\  constructors need another constraint","2019-02 (Kona)","|Complete|","","`#103837 <https://github.com/llvm/llvm-project/issues/103837>`__",""
 "`LWG3112 <https://wg21.link/LWG3112>`__","``system_error``\  and ``filesystem_error``\  constructors taking a ``string``\  may not be able to meet their postconditions","2019-02 (Kona)","|Nothing To Do|","","`#100253 <https://github.com/llvm/llvm-project/issues/100253>`__",""
 "`LWG3119 <https://wg21.link/LWG3119>`__","Program-definedness of closure types","2019-02 (Kona)","|Nothing To Do|","","`#103838 <https://github.com/llvm/llvm-project/issues/103838>`__",""
-"`LWG3133 <https://wg21.link/LWG3133>`__","Modernizing numeric type requirements","2019-02 (Kona)","","","`#100254 <https://github.com/llvm/llvm-project/issues/100254>`__",""
+"`LWG3133 <https://wg21.link/LWG3133>`__","Modernizing numeric type requirements","2019-02 (Kona)","|Complete|","","`#100254 <https://github.com/llvm/llvm-project/issues/100254>`__",""
 "`LWG3144 <https://wg21.link/LWG3144>`__","``span``\  does not have a ``const_pointer``\  typedef","2019-02 (Kona)","|Complete|","","`#103839 <https://github.com/llvm/llvm-project/issues/103839>`__",""
 "`LWG3173 <https://wg21.link/LWG3173>`__","Enable CTAD for ``ref-view``\ ","2019-02 (Kona)","|Complete|","15","`#103840 <https://github.com/llvm/llvm-project/issues/103840>`__",""
 "`LWG3179 <https://wg21.link/LWG3179>`__","``subrange``\  should always model ``Range``\ ","2019-02 (Kona)","|Nothing To Do|","","`#103842 <https://github.com/llvm/llvm-project/issues/103842>`__",""

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.access/access.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.access/access.pass.cpp
@@ -15,6 +15,7 @@
 #include <valarray>
 #include <cassert>
 
+#include "operator_hijacker.h"
 #include "test_macros.h"
 
 int main(int, char**)
@@ -30,6 +31,11 @@ int main(int, char**)
             v[i] = i;
             assert(v[i] == static_cast<int>(i));
         }
+    }
+    {
+      std::valarray<operator_hijacker> v(1);
+      operator_hijacker& r = v[0];
+      (void)r;
     }
 
   return 0;

--- a/libcxx/test/std/numerics/numarray/template.valarray/valarray.access/const_access.pass.cpp
+++ b/libcxx/test/std/numerics/numarray/template.valarray/valarray.access/const_access.pass.cpp
@@ -15,6 +15,7 @@
 #include <valarray>
 #include <cassert>
 
+#include "operator_hijacker.h"
 #include "test_macros.h"
 
 int main(int, char**)
@@ -28,6 +29,11 @@ int main(int, char**)
         {
             assert(v[i] == a[i]);
         }
+    }
+    {
+      const std::valarray<operator_hijacker> v(1);
+      const operator_hijacker& r = v[0];
+      (void)r;
     }
 
   return 0;


### PR DESCRIPTION
This verifies that libc++ has implemented the resolution of LWG3133, which modernizes the requirements on `T` for `std::complex<T>` and `std::valarray<T>` in [numeric.requirements].
- No code changes were needed for `std::valarray<T>`: its `operator[]` already indexes through a raw pointer and never relies on a user-overloadable `operator&`, so it already conforms to the revised wording.
- Added o`perator_hijacker`-based tests to `valarray`'s `access.pass.cpp`/`const_access.pass.cpp`, confirming `operator[]` doesn't rely on a user-overloadable `operator&`.

Fixes #100254