### PR TITLE
[RISCV] Fix RISCVFoldMemOffset to report when it makes changes

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFoldMemOffset.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFoldMemOffset.cpp
@@ -278,6 +278,7 @@ bool RISCVFoldMemOffset::runOnMachineFunction(MachineFunction &MF) {
       MRI.replaceRegWith(MI.getOperand(0).getReg(), MI.getOperand(1).getReg());
       MRI.clearKillFlags(MI.getOperand(1).getReg());
       MI.eraseFromParent();
+      MadeChange = true;
     }
   }
 


### PR DESCRIPTION
runOnMachineFunction initialized MadeChange to false and returned it, but never set it to true even though the fold path rewrites memory offsets, replaces registers, and erases the ADDI. As a result the pass always reported that it made no changes, so the pass manager could keep stale analyses valid after the function had actually been modified.

Set MadeChange to true after folding an ADDI.