### PR TITLE
[Clang] Fix assertion failure in getASTRecordLayout for invalid declarations

### DIFF
--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -3395,16 +3395,15 @@ ASTContext::getASTRecordLayout(const RecordDecl *D) const {
 
     // Create a minimal safe layout for error recovery
     // Use 1-byte size and alignment to avoid division by zero or other issues
-    ASTRecordLayout *NewEntry = new (*this)
-        ASTRecordLayout(*this,
-                /*Size=*/CharUnits::One(),
-                /*Alignment=*/CharUnits::One(),
-                /*PreferredAlignment=*/CharUnits::One(),
-                /*UnadjustedAlignment=*/CharUnits::One(),
-                /*RequiredAlignment=*/CharUnits::One(),
-                /*DataSize=*/CharUnits::One(),
-                /*FieldOffsets=*/ArrayRef<uint64_t>()
-         );
+    ASTRecordLayout *NewEntry =
+        new (*this) ASTRecordLayout(*this,
+                                    /*Size=*/CharUnits::One(),
+                                    /*Alignment=*/CharUnits::One(),
+                                    /*PreferredAlignment=*/CharUnits::One(),
+                                    /*UnadjustedAlignment=*/CharUnits::One(),
+                                    /*RequiredAlignment=*/CharUnits::One(),
+                                    /*DataSize=*/CharUnits::One(),
+                                    /*FieldOffsets=*/ArrayRef<uint64_t>());
 
     ASTRecordLayouts[D] = NewEntry;
     return *NewEntry;

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -3397,14 +3397,14 @@ ASTContext::getASTRecordLayout(const RecordDecl *D) const {
     // Use 1-byte size and alignment to avoid division by zero or other issues
     ASTRecordLayout *NewEntry = new (*this)
         ASTRecordLayout(*this,
-                        CharUnits::One(),    // Size = 1 byte
-                        CharUnits::One(),    // Alignment = 1 byte
-                        CharUnits::One(),    // PreferredAlignment = 1 byte
-                        CharUnits::One(),    // UnadjustedAlignment = 1 byte
-                        CharUnits::One(),    // RequiredAlignment = 1 byte
-                        CharUnits::One(),    // DataSize = 1 byte
-                        ArrayRef<uint64_t>() // Empty field offsets
-        );
+                /*Size=*/CharUnits::One(),
+                /*Alignment=*/CharUnits::One(),
+                /*PreferredAlignment=*/CharUnits::One(),
+                /*UnadjustedAlignment=*/CharUnits::One(),
+                /*RequiredAlignment=*/CharUnits::One(),
+                /*DataSize=*/CharUnits::One(),
+                /*FieldOffsets=*/ArrayRef<uint64_t>()
+         );
 
     ASTRecordLayouts[D] = NewEntry;
     return *NewEntry;

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -3384,6 +3384,32 @@ ASTContext::getASTRecordLayout(const RecordDecl *D) const {
   // not a complete definition (which is what isCompleteDefinition() tests)
   // until we *finish* parsing the definition.
   D = D->getDefinition();
+
+  // Handle invalid declarations gracefully during error recovery
+  // This can happen when there are template specialization errors
+  if (!D || D->isInvalidDecl() || !D->isCompleteDefinition()) {
+    // Check if we already have a cached layout
+    const ASTRecordLayout *Entry = ASTRecordLayouts[D];
+    if (Entry)
+      return *Entry;
+
+    // Create a minimal safe layout for error recovery
+    // Use 1-byte size and alignment to avoid division by zero or other issues
+    ASTRecordLayout *NewEntry = new (*this)
+        ASTRecordLayout(*this,
+                        CharUnits::One(),    // Size = 1 byte
+                        CharUnits::One(),    // Alignment = 1 byte
+                        CharUnits::One(),    // PreferredAlignment = 1 byte
+                        CharUnits::One(),    // UnadjustedAlignment = 1 byte
+                        CharUnits::One(),    // RequiredAlignment = 1 byte
+                        CharUnits::One(),    // DataSize = 1 byte
+                        ArrayRef<uint64_t>() // Empty field offsets
+        );
+
+    ASTRecordLayouts[D] = NewEntry;
+    return *NewEntry;
+  }
+
   assert(D && "Cannot get layout of forward declarations!");
   assert(!D->isInvalidDecl() && "Cannot get layout of invalid decl!");
   assert(D->isCompleteDefinition() && "Cannot layout type before complete!");

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -3410,10 +3410,6 @@ ASTContext::getASTRecordLayout(const RecordDecl *D) const {
     return *NewEntry;
   }
 
-  assert(D && "Cannot get layout of forward declarations!");
-  assert(!D->isInvalidDecl() && "Cannot get layout of invalid decl!");
-  assert(D->isCompleteDefinition() && "Cannot layout type before complete!");
-
   // Look up this layout, if already laid out, return what we have.
   // Note that we can't save a reference to the entry because this function
   // is recursive.

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -388,8 +388,9 @@ EmptySubobjectMap::CanPlaceFieldSubobjectAtOffset(const CXXRecordDecl *RD,
     return false;
 
   // For invalid declarations, be permissive during error recovery.
-  // Return true to allow placement and avoid triggering assert in getASTRecordLayout.
-  // Layout constraints don't matter for types that are already marked invalid.
+  // Return true to allow placement and avoid triggering assert in
+  // getASTRecordLayout. Layout constraints don't matter for types that are
+  // already marked invalid.
   if (RD->isInvalidDecl())
     return true;
 

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -189,6 +189,10 @@ void EmptySubobjectMap::ComputeEmptySubobjectSizes() {
     const CXXRecordDecl *BaseDecl = Base.getType()->getAsCXXRecordDecl();
     assert(BaseDecl != Class && "Class cannot inherit from itself.");
 
+    // Skip invalid base declarations to avoid assert in getASTRecordLayout
+    if (BaseDecl->isInvalidDecl())
+      continue;
+
     CharUnits EmptySize;
     const ASTRecordLayout &Layout = Context.getASTRecordLayout(BaseDecl);
     if (BaseDecl->isEmpty()) {
@@ -209,6 +213,10 @@ void EmptySubobjectMap::ComputeEmptySubobjectSizes() {
     const auto *MemberDecl =
         Context.getBaseElementType(FD->getType())->getAsCXXRecordDecl();
     if (!MemberDecl)
+      continue;
+
+    // Skip invalid member declarations to avoid assert in getASTRecordLayout
+    if (MemberDecl->isInvalidDecl())
       continue;
 
     CharUnits EmptySize;
@@ -378,6 +386,12 @@ EmptySubobjectMap::CanPlaceFieldSubobjectAtOffset(const CXXRecordDecl *RD,
 
   if (!CanPlaceSubobjectAtOffset(RD, Offset))
     return false;
+
+  // For invalid declarations, be permissive during error recovery.
+  // Return true to allow placement and avoid triggering assert in getASTRecordLayout.
+  // Layout constraints don't matter for types that are already marked invalid.
+  if (RD->isInvalidDecl())
+    return true;
 
   const ASTRecordLayout &Layout = Context.getASTRecordLayout(RD);
 
@@ -3384,30 +3398,9 @@ ASTContext::getASTRecordLayout(const RecordDecl *D) const {
   // not a complete definition (which is what isCompleteDefinition() tests)
   // until we *finish* parsing the definition.
   D = D->getDefinition();
-
-  // Handle invalid declarations gracefully during error recovery
-  // This can happen when there are template specialization errors
-  if (!D || D->isInvalidDecl() || !D->isCompleteDefinition()) {
-    // Check if we already have a cached layout
-    const ASTRecordLayout *Entry = ASTRecordLayouts[D];
-    if (Entry)
-      return *Entry;
-
-    // Create a minimal safe layout for error recovery
-    // Use 1-byte size and alignment to avoid division by zero or other issues
-    ASTRecordLayout *NewEntry =
-        new (*this) ASTRecordLayout(*this,
-                                    /*Size=*/CharUnits::One(),
-                                    /*Alignment=*/CharUnits::One(),
-                                    /*PreferredAlignment=*/CharUnits::One(),
-                                    /*UnadjustedAlignment=*/CharUnits::One(),
-                                    /*RequiredAlignment=*/CharUnits::One(),
-                                    /*DataSize=*/CharUnits::One(),
-                                    /*FieldOffsets=*/ArrayRef<uint64_t>());
-
-    ASTRecordLayouts[D] = NewEntry;
-    return *NewEntry;
-  }
+  assert(D && "Cannot get layout of forward declarations!");
+  assert(!D->isInvalidDecl() && "Cannot get layout of invalid decl!");
+  assert(D->isCompleteDefinition() && "Cannot layout type before complete!");
 
   // Look up this layout, if already laid out, return what we have.
   // Note that we can't save a reference to the entry because this function

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4616,10 +4616,10 @@ void Sema::CheckConstructorCall(FunctionDecl *FDecl, QualType ThisType,
                                   : VariadicCallType::DoesNotApply;
 
   auto *Ctor = cast<CXXConstructorDecl>(FDecl);
-  bool InvalidThisType = false;                                                                                                                                     
-  if (const auto *RT = ThisType->getAs<RecordType>())                                                                                                                           
+  bool InvalidThisType = false;
+  if (const auto *RT = ThisType->getAs<RecordType>())
     InvalidThisType = RT->getDecl()->isInvalidDecl();
-  if (!InvalidThisType){
+  if (!InvalidThisType) {
     CheckArgAlignment(
         Loc, FDecl, "'this'", Context.getPointerType(ThisType),
         Context.getPointerType(Ctor->getFunctionObjectParameterType()));

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4616,10 +4616,14 @@ void Sema::CheckConstructorCall(FunctionDecl *FDecl, QualType ThisType,
                                   : VariadicCallType::DoesNotApply;
 
   auto *Ctor = cast<CXXConstructorDecl>(FDecl);
-  CheckArgAlignment(
-      Loc, FDecl, "'this'", Context.getPointerType(ThisType),
-      Context.getPointerType(Ctor->getFunctionObjectParameterType()));
-
+  bool InvalidThisType = false;                                                                                                                                     
+  if (const auto *RT = ThisType->getAs<RecordType>())                                                                                                                           
+    InvalidThisType = RT->getDecl()->isInvalidDecl();
+  if (!InvalidThisType){
+    CheckArgAlignment(
+        Loc, FDecl, "'this'", Context.getPointerType(ThisType),
+        Context.getPointerType(Ctor->getFunctionObjectParameterType()));
+  }
   checkCall(FDecl, Proto, /*ThisArg=*/nullptr, Args, /*IsMemberFunction=*/true,
             Loc, SourceRange(), CallType);
 }

--- a/clang/test/SemaCXX/explicit-specialization-after-instantiation-crash.cpp
+++ b/clang/test/SemaCXX/explicit-specialization-after-instantiation-crash.cpp
@@ -2,19 +2,6 @@
 //
 // Test that explicit template specialization after instantiation
 // is handled gracefully without assertion failure.
-//
-// Before the fix, this code triggered an assertion failure:
-//   Assertion failed: !D->isInvalidDecl() && "Cannot get layout of invalid decl!"
-//   Location: clang/lib/AST/RecordLayoutBuilder.cpp:3388
-//   Exit code: 134 (SIGABRT)
-//
-// After the fix:
-//   Clean error messages are reported
-//   Exit code: 1
-//
-// The fix adds error handling in getASTRecordLayout() to return a minimal
-// safe layout (1-byte size/alignment) for invalid declarations, allowing
-// error recovery to continue and report all errors.
 
 template <typename T>
 struct X {

--- a/clang/test/SemaCXX/explicit-specialization-after-instantiation-crash.cpp
+++ b/clang/test/SemaCXX/explicit-specialization-after-instantiation-crash.cpp
@@ -1,0 +1,42 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+//
+// Test that explicit template specialization after instantiation
+// is handled gracefully without assertion failure.
+//
+// Before the fix, this code triggered an assertion failure:
+//   Assertion failed: !D->isInvalidDecl() && "Cannot get layout of invalid decl!"
+//   Location: clang/lib/AST/RecordLayoutBuilder.cpp:3388
+//   Exit code: 134 (SIGABRT)
+//
+// After the fix:
+//   Clean error messages are reported
+//   Exit code: 1
+//
+// The fix adds error handling in getASTRecordLayout() to return a minimal
+// safe layout (1-byte size/alignment) for invalid declarations, allowing
+// error recovery to continue and report all errors.
+
+template <typename T>
+struct X {
+    struct Y {
+        Y() : v(0) {}
+        int v;
+        int getValue();
+    } y;
+};
+
+template <typename T>
+int X<T>::Y::getValue() {
+    return ++v;
+}
+
+// expected-error@+1 {{explicit specialization of 'Y' after instantiation}}
+template <> struct X<int>::Y { int getValue() { return 55; } };
+// expected-note@-10 {{implicit instantiation first required here}}
+
+extern template class X<int>::Y;
+
+int main() {
+    X<int> x;
+    return x.y.getValue(); // expected-error {{no member named 'getValue' in 'X<int>::Y'}}
+}


### PR DESCRIPTION
When encountering invalid declarations during error recovery (e.g., explicit template specialization after instantiation), `getASTRecordLayout()` would assert and crash instead of handling the error gracefully.

This patch handles the invalid declarations at the callers by checking `isInvalidDecl()` before requesting the layout. Invalid bases/fields are skipped, and the relevant layout checks return early. `getASTRecordLayout()` itself is left unchanged, including its existing assertions.

Before this fix:
- Assertion failed: `!D->isInvalidDecl()`
- Exit code: 134 (SIGABRT)

After this fix:
- Clean error messages
- Exit code: 1

Test updated: `clang/test/SemaCXX/explicit-specialization-after-instantiation-crash.cpp`
Addresses this issue : https://github.com/llvm/llvm-project/issues/207953