### PR TITLE
[clang-tidy] Don't warn on misplaced-widening-cast for provably non-overflowing constexpr values

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/MisplacedWideningCastCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MisplacedWideningCastCheck.cpp
@@ -17,11 +17,15 @@ namespace clang::tidy::bugprone {
 MisplacedWideningCastCheck::MisplacedWideningCastCheck(
     StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      CheckImplicitCasts(Options.get("CheckImplicitCasts", false)) {}
+      CheckImplicitCasts(Options.get("CheckImplicitCasts", false)),
+      IgnoreConstexprOverflowProven(
+          Options.get("IgnoreConstexprOverflowProven", false)) {}
 
 void MisplacedWideningCastCheck::storeOptions(
     ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "CheckImplicitCasts", CheckImplicitCasts);
+  Options.store(Opts, "IgnoreConstexprOverflowProven",
+                IgnoreConstexprOverflowProven);
 }
 
 void MisplacedWideningCastCheck::registerMatchers(MatchFinder *Finder) {
@@ -54,13 +58,15 @@ void MisplacedWideningCastCheck::registerMatchers(MatchFinder *Finder) {
       binaryOperator(isComparisonOperator(), hasEitherOperand(Cast)), this);
 }
 
-static unsigned getMaxCalculationWidth(const ASTContext &Context,
-                                       const Expr *E) {
+static unsigned getMaxCalculationWidth(const ASTContext &Context, const Expr *E,
+                                       bool IgnoreConstexprOverflowProven) {
   E = E->IgnoreParenImpCasts();
 
   if (const auto *Bop = dyn_cast<BinaryOperator>(E)) {
-    const unsigned LHSWidth = getMaxCalculationWidth(Context, Bop->getLHS());
-    const unsigned RHSWidth = getMaxCalculationWidth(Context, Bop->getRHS());
+    const unsigned LHSWidth = getMaxCalculationWidth(
+        Context, Bop->getLHS(), IgnoreConstexprOverflowProven);
+    const unsigned RHSWidth = getMaxCalculationWidth(
+        Context, Bop->getRHS(), IgnoreConstexprOverflowProven);
     if (Bop->getOpcode() == BO_Mul)
       return LHSWidth + RHSWidth;
     if (Bop->getOpcode() == BO_Add)
@@ -90,8 +96,18 @@ static unsigned getMaxCalculationWidth(const ASTContext &Context,
     return T->isIntegerType() ? Context.getIntWidth(T) : 1024U;
   } else if (const auto *I = dyn_cast<IntegerLiteral>(E)) {
     return I->getValue().getActiveBits();
+  } else if (IgnoreConstexprOverflowProven) {
+    if (const auto *DRE = dyn_cast<DeclRefExpr>(E)) {
+      if (const auto *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
+        if (VD->isConstexpr()) {
+          Expr::EvalResult Result;
+          if (E->EvaluateAsInt(Result, Context) &&
+              !Result.Val.getInt().isNegative())
+            return Result.Val.getInt().getActiveBits();
+        }
+      }
+    }
   }
-
   return Context.getIntWidth(E->getType());
 }
 
@@ -235,7 +251,8 @@ void MisplacedWideningCastCheck::check(const MatchFinder::MatchResult &Result) {
 
   // Don't write a warning if we can easily see that the result is not
   // truncated.
-  if (Context.getIntWidth(CalcType) >= getMaxCalculationWidth(Context, Calc))
+  if (Context.getIntWidth(CalcType) >=
+      getMaxCalculationWidth(Context, Calc, IgnoreConstexprOverflowProven))
     return;
 
   diag(Cast->getBeginLoc(), "either cast from %0 to %1 is ineffective, or "

--- a/clang-tools-extra/clang-tidy/bugprone/MisplacedWideningCastCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/MisplacedWideningCastCheck.h
@@ -34,6 +34,7 @@ public:
 
 private:
   const bool CheckImplicitCasts;
+  const bool IgnoreConstexprOverflowProven;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -417,6 +417,14 @@ Changes in existing checks
   positive on bit field assignments when the `CheckImplicitCasts` option is
   enabled. The check now uses the actual bit field width instead of the
   declared type to determine if widening occurs.
+  
+- Improved :doc:`bugprone-misplaced-widening-cast
+  <clang-tidy/checks/bugprone/misplaced-widening-cast>` check by adding the
+  :option:`IgnoreConstexprOverflowProven` option to suppress false positives
+  when the calculation operand is a ``constexpr`` variable whose compile-time
+  value provably fits inside the narrower type without overflow. The check
+  still warns when the operand is a non-``constexpr`` ``const``, or when the
+  ``constexpr`` value is negative or overflows.
 
 - Improved :doc:`bugprone-move-forwarding-reference
   <clang-tidy/checks/bugprone/move-forwarding-reference>` check by fixing some

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/misplaced-widening-cast.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/misplaced-widening-cast.rst
@@ -57,9 +57,51 @@ written for this code:
         return (double)(x * 10.0f);
     }
 
+Constexpr operands
+------------------
+
+If :option:`IgnoreConstexprOverflowProven` is set to `true` and the calculation
+operand is a ``constexpr`` variable, the check evaluates its compile-time value.
+If the value provably does not overflow the narrower type and is non-negative,
+no warning is issued, since the cast is then not actually masking any loss of
+precision:
+
+.. code-block:: c++
+
+    void bar(std::size_t);
+
+    void f() {
+        constexpr int x = 256;
+        bar(static_cast<std::size_t>(x * 2)); // No warning: x * 2 == 512,
+                                               // which safely fits in int.
+    }
+
+A plain ``const`` (not ``constexpr``) variable does not get this exception,
+since the check does not evaluate non-``constexpr`` values as compile-time
+constants.
+
+A ``constexpr`` value that results in a negative value or signed integer
+overflow will still be diagnosed:
+
+.. code-block:: c++
+
+    void bar(std::size_t);
+
+    void f() {
+        constexpr int x = 2147483647;         // INT_MAX
+        bar(static_cast<std::size_t>(x * 2)); // Still warns: calculation overflows int.
+    }
+
 Options
 -------
 
 .. option:: CheckImplicitCasts
 
    If `true`, enables detection of implicit casts. Default is `false`.
+
+.. option:: IgnoreConstexprOverflowProven
+
+   When set to `true`, the check evaluates the compile-time value of ``constexpr``
+   calculation operands. If the value provably does not overflow the narrower
+   type and is non-negative, the warning is suppressed because the widening cast
+   is not masking an unintended truncation. Default is `false`.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/misplaced-widening-cast-explicit-only.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/misplaced-widening-cast-explicit-only.cpp
@@ -1,4 +1,5 @@
-// RUN: %check_clang_tidy %s bugprone-misplaced-widening-cast %t -- -config="{CheckOptions: {bugprone-misplaced-widening-cast.CheckImplicitCasts: false}}" --
+// RUN: %check_clang_tidy -check-suffix=DEFAULT %s bugprone-misplaced-widening-cast %t -- -config="{CheckOptions: {bugprone-misplaced-widening-cast.CheckImplicitCasts: false}}" --
+// RUN: %check_clang_tidy -check-suffix=APPROVED %s bugprone-misplaced-widening-cast %t -- -config="{CheckOptions: {bugprone-misplaced-widening-cast.CheckImplicitCasts: false, bugprone-misplaced-widening-cast.IgnoreConstexprOverflowProven: true}}" --
 
 void func(long arg) {}
 
@@ -79,4 +80,26 @@ void nextDay(DaysEnum day) {
     day = (DaysEnum)(day + 1);
   if (day < SUN)
     day = static_cast<DaysEnum>(day + 1);
+}
+
+// Constexpr values that are provably non-overflowing should not warn
+// when IgnoreConstexprOverflowProven is true.
+void constexprNoOverflow() {
+  constexpr int x = 256;
+  long l = static_cast<long>(x * 2);
+  // CHECK-MESSAGES-DEFAULT: :[[@LINE-1]]:12: warning: either cast from 'int' to 'long' is ineffective, or there is loss of precision before the conversion [bugprone-misplaced-widening-cast]
+}
+
+// A non-constexpr const does NOT get this exception.
+void constNotConstexprStillWarns() {
+  const int x = 256;
+  long l = static_cast<long>(x * 2);
+  // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: either cast from 'int' to 'long'
+}
+
+// A constexpr value that DOES overflow the narrow type must still warn.
+void constexprOverflowStillWarns() {
+  constexpr int x = -1;
+  long l = static_cast<long>(x * 2);
+  // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: either cast from 'int' to 'long'
 }


### PR DESCRIPTION
Fixes #208078.

The `bugprone-misplaced-widening-cast` check currently warns on casts like `static_cast<std::size_t>(x * 2)` even when `x` is a `constexpr` variable and the multiplication provably does not overflow the narrower type. This is pointless churn, since the compiler can prove the cast is safe as written.

This PR teaches `getMaxCalculationWidth` to evaluate `constexpr` operands at compile time and use their actual bit-width instead of the declared type's full width, when the value is non-negative (so overflow cases still warn). Non-`constexpr` `const` values are unaffected and still warn, matching existing check semantics.

See the linked issue for the original discussion, including the counter-examples this PR is designed to preserve (non-constexpr const, and constexpr values that do overflow).