### PR TITLE
[lldb] Reland stop-on-fork and stop-on-vfork settings

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -110,6 +110,8 @@ public:
   bool GetWarningsOptimization() const;
   bool GetWarningsUnsupportedLanguage() const;
   bool GetStopOnExec() const;
+  bool GetStopOnFork() const;
+  bool GetStopOnVFork() const;
   std::chrono::seconds GetUtilityExpressionTimeout() const;
   std::chrono::seconds GetInterruptTimeout() const;
   bool GetOSPluginReportsAllThreads() const;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -343,6 +343,18 @@ bool ProcessProperties::GetUseDelayedBreakpoints() const {
       idx, g_process_properties[idx].default_uint_value != 0);
 }
 
+bool ProcessProperties::GetStopOnFork() const {
+  const uint32_t idx = ePropertyStopOnFork;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_process_properties[idx].default_uint_value != 0);
+}
+
+bool ProcessProperties::GetStopOnVFork() const {
+  const uint32_t idx = ePropertyStopOnVFork;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_process_properties[idx].default_uint_value != 0);
+}
+
 std::chrono::seconds ProcessProperties::GetUtilityExpressionTimeout() const {
   const uint32_t idx = ePropertyUtilityExpressionTimeout;
   uint64_t value = GetPropertyAtIndexAs<uint64_t>(

--- a/lldb/source/Target/StopInfo.cpp
+++ b/lldb/source/Target/StopInfo.cpp
@@ -1544,8 +1544,8 @@ public:
   bool ShouldStop(Event *event_ptr) override {
     // During expression evaluation, return true so that the fork event
     // reaches RunThreadPlan as a real stop (not auto-restarted by
-    // DoOnRemoval). RunThreadPlan decides whether to stop or continue
-    // based on the stop-on-fork option.
+    // DoOnRemoval) or target.process.stop-on-fork is true. RunThreadPlan
+    // decides whether to stop or continue based on the stop-on-fork option.
     //
     // We check per-thread (not just process-wide IsRunningExpression)
     // because other threads may fork concurrently after the
@@ -1553,8 +1553,9 @@ public:
     ThreadSP thread_sp(m_thread_wp.lock());
     if (thread_sp) {
       ProcessSP process_sp = thread_sp->GetProcess();
-      if (process_sp && process_sp->GetModIDRef().IsRunningExpression() &&
-          thread_sp->IsRunningCallFunctionPlan())
+      if (process_sp && ((process_sp->GetModIDRef().IsRunningExpression() &&
+                          thread_sp->IsRunningCallFunctionPlan()) ||
+                         process_sp->GetStopOnFork()))
         return true;
     }
     return false;
@@ -1609,8 +1610,9 @@ public:
     ThreadSP thread_sp(m_thread_wp.lock());
     if (thread_sp) {
       ProcessSP process_sp = thread_sp->GetProcess();
-      if (process_sp && process_sp->GetModIDRef().IsRunningExpression() &&
-          thread_sp->IsRunningCallFunctionPlan())
+      if (process_sp && ((process_sp->GetModIDRef().IsRunningExpression() &&
+                          thread_sp->IsRunningCallFunctionPlan()) ||
+                         process_sp->GetStopOnVFork()))
         return true;
     }
     return false;

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -286,6 +286,14 @@ let Definition = "process", Path = "target.process" in {
     Global,
     DefaultTrue,
     Desc<"If true, stop when the inferior exec's.">;
+  def StopOnFork: Property<"stop-on-fork", "Boolean">,
+    Global,
+    DefaultFalse,
+    Desc<"If true, stop when the inferior forks. The stop location depends on target.process.follow-fork-mode: 'child' stops in the child process, while 'parent' stops in the original process.">;
+  def StopOnVFork: Property<"stop-on-vfork", "Boolean">,
+    Global,
+    DefaultFalse,
+    Desc<"If true, stop when the inferior vforks. The stop location depends on target.process.follow-fork-mode: 'child' stops in the child process, while 'parent' stops in the original process.">;
   def UtilityExpressionTimeout: Property<"utility-expression-timeout", "UInt64">,
 #ifdef LLDB_SANITIZED
     DefaultUnsignedValue<60>,

--- a/lldb/test/API/functionalities/fork/stop/Makefile
+++ b/lldb/test/API/functionalities/fork/stop/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/fork/stop/TestStopOnForkAndVFork.py
+++ b/lldb/test/API/functionalities/fork/stop/TestStopOnForkAndVFork.py
@@ -1,0 +1,70 @@
+"""
+Make sure that we stop on fork and follow mode works.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+@skipIfWindows
+@skipIfDarwin
+@skipIfWasm  # no fork() on WebAssembly
+class TestStopOnForkAndVFork(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def do_test(self, mode, fork):
+        self.build()
+
+        args = [fork]
+        launch_info = lldb.SBLaunchInfo(args)
+        launch_info.SetWorkingDirectory(self.get_process_working_directory())
+
+        (_, process, _, _) = lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.c"), launch_info
+        )
+        self.runCmd(f"settings set target.process.stop-on-{fork} true")
+        self.runCmd(f"settings set target.process.follow-fork-mode {mode}")
+
+        pid = process.GetProcessID()
+
+        process.Continue()
+        self.assertState(
+            process.GetState(),
+            lldb.eStateStopped,
+            f"Process should be stopped at {fork}",
+        )
+        threads = lldbutil.get_stopped_threads(
+            process, lldb.eStopReasonVFork if fork == "vfork" else lldb.eStopReasonFork
+        )
+        self.assertEqual(len(threads), 1, f"We got a thread stopped for {fork}.")
+
+        if mode == "parent":
+            self.assertEqual(
+                self.dbg.GetSelectedTarget().GetProcess().GetProcessID(), pid
+            )
+            self.expect(
+                "continue",
+                substrs=[f"exited with status = 0"],
+            )
+        else:  # child
+            self.assertNotEqual(
+                self.dbg.GetSelectedTarget().GetProcess().GetProcessID(), pid
+            )
+            self.expect(
+                "continue",
+                substrs=[f"exited with status = 47"],
+            )
+
+    def test_stop_on_fork_and_follow_parent(self):
+        self.do_test("parent", "fork")
+
+    def test_stop_on_fork_and_follow_child(self):
+        self.do_test("child", "fork")
+
+    def test_stop_on_vfork_and_follow_parent(self):
+        self.do_test("parent", "vfork")
+
+    def test_stop_on_vfork_and_follow_child(self):
+        self.do_test("child", "vfork")

--- a/lldb/test/API/functionalities/fork/stop/main.c
+++ b/lldb/test/API/functionalities/fork/stop/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    _exit(1);
+  }
+  // break here
+  pid_t pid = strcmp(argv[1], "fork") == 0 ? fork() : vfork();
+  if (pid == 0) {
+    // child
+    _exit(47);
+  }
+  // parent
+  _exit(0);
+}

--- a/lldb/test/Shell/Subprocess/stop-on-fork.test
+++ b/lldb/test/Shell/Subprocess/stop-on-fork.test
@@ -1,0 +1,12 @@
+# REQUIRES: native
+# UNSUPPORTED: system-darwin
+# UNSUPPORTED: system-windows
+# RUN: %clangxx_host %p/Inputs/fork.cpp -DTEST_FORK=fork -o %t
+# RUN: %lldb -b -s %s %t | FileCheck %s
+settings set target.process.stop-on-fork true
+process launch
+# CHECK-NOT: function run in parent
+# CHECK: stop reason = fork
+continue
+# CHECK: function run in parent
+# CHECK: function run in exec'd child

--- a/lldb/test/Shell/Subprocess/stop-on-vfork.test
+++ b/lldb/test/Shell/Subprocess/stop-on-vfork.test
@@ -1,0 +1,12 @@
+# REQUIRES: native
+# UNSUPPORTED: system-darwin
+# UNSUPPORTED: system-windows
+# RUN: %clangxx_host %p/Inputs/fork.cpp -DTEST_FORK=vfork -o %t
+# RUN: %lldb -b -s %s %t | FileCheck %s
+settings set target.process.stop-on-vfork true
+process launch
+# CHECK-NOT: function run in parent
+# CHECK: stop reason = vfork
+continue
+# CHECK: function run in parent
+# CHECK: function run in exec'd child


### PR DESCRIPTION
Added support for new `target.process.stop-on-fork` and `target.process.stop-on-vfork` settings. GDB already has ability to set [catchpoints](https://www.sourceware.org/gdb/current/onlinedocs/gdb.html/Set-Catchpoints.html) on `fork` and `vfork`, so having this feature in LLDB might be useful (e.g. use it to get pid of new process and attach to the new process from different console).