### PR TITLE
[InstCombine] Preserve store metadata when unpacking aggregate stores

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/Local.h
+++ b/llvm/include/llvm/Transforms/Utils/Local.h
@@ -434,6 +434,20 @@ LLVM_ABI void combineAAMetadata(Instruction *K, const Instruction *J);
 /// replacement for the source instruction).
 LLVM_ABI void copyMetadataForLoad(LoadInst &Dest, const LoadInst &Source);
 
+/// Copy metadata from memory-access instruction \p Source to \p Dest, where
+/// \p Dest accesses a sub-range of \p Source's memory: an access of type
+/// \p AccessTy starting at byte \p Offset into \p Source's access. This happens
+/// when a wide or aggregate load/store is split into narrower per-field
+/// accesses (e.g. InstCombine's aggregate load/store unpacking and SROA's slice
+/// rewriting). Metadata that stays valid for a sub-access is copied directly,
+/// and the AA metadata (\c !tbaa etc.) is narrowed to the sub-access via
+/// AAMDNodes::adjustForAccess. Note: \c !DIAssignID is not handled here; a 1:N
+/// split needs a distinct ID per new access (see SROA's migrateDebugInfo).
+LLVM_ABI void copyMetadataForSubAccess(Instruction &Dest,
+                                       const Instruction &Source,
+                                       uint64_t Offset, Type *AccessTy,
+                                       const DataLayout &DL);
+
 /// Patch the replacement so that it is not more restrictive than the value
 /// being replaced. It assumes that the replacement does not get moved from
 /// its original position.

--- a/llvm/lib/Analysis/TypeBasedAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/TypeBasedAliasAnalysis.cpp
@@ -815,8 +815,15 @@ AAMDNodes AAMDNodes::adjustForAccess(unsigned AccessSize) {
       M->getOperand(1) && mdconst::hasa<ConstantInt>(M->getOperand(1)) &&
       mdconst::extract<ConstantInt>(M->getOperand(1))->getValue() ==
           AccessSize &&
-      M->getOperand(2) && isa<MDNode>(M->getOperand(2)))
-    New.TBAA = cast<MDNode>(M->getOperand(2));
+      M->getOperand(2) && isa<MDNode>(M->getOperand(2))) {
+    // Only promote the field to a !tbaa tag if it is a well-formed struct-path
+    // access tag (operand 0 is a type node and it has at least 3 operands, as
+    // required by the verifier). A !tbaa.struct field can otherwise hold a bare
+    // type node, which is not a valid !tbaa tag.
+    MDNode *Tag = cast<MDNode>(M->getOperand(2));
+    if (Tag->getNumOperands() >= 3 && isa<MDNode>(Tag->getOperand(0)))
+      New.TBAA = Tag;
+  }
 
   New.TBAAStruct = nullptr;
   return New;

--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -1377,7 +1377,9 @@ static bool unpackStoreToAggregate(InstCombinerImpl &IC, StoreInst &SI) {
       auto EltAlign =
           commonAlignment(Align, SL->getElementOffset(i).getKnownMinValue());
       llvm::Instruction *NS = IC.Builder.CreateAlignedStore(Val, Ptr, EltAlign);
-      NS->setAAMetadata(SI.getAAMetadata());
+      copyMetadataForSubAccess(*NS, SI,
+                               SL->getElementOffset(i).getKnownMinValue(),
+                               Val->getType(), DL);
     }
 
     return true;
@@ -1423,7 +1425,8 @@ static bool unpackStoreToAggregate(InstCombinerImpl &IC, StoreInst &SI) {
       auto *Val = IC.Builder.CreateExtractValue(V, i, EltName);
       auto EltAlign = commonAlignment(Align, Offset.getKnownMinValue());
       Instruction *NS = IC.Builder.CreateAlignedStore(Val, Ptr, EltAlign);
-      NS->setAAMetadata(SI.getAAMetadata());
+      copyMetadataForSubAccess(*NS, SI, Offset.getKnownMinValue(),
+                               Val->getType(), DL);
       Offset += EltSize;
     }
 

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -3467,8 +3467,7 @@ private:
     return !LI.isVolatile() && !IsPtrAdjusted;
   }
 
-  bool rewriteVectorizedStoreInst(Value *V, StoreInst &SI, Value *OldOp,
-                                  AAMDNodes AATags) {
+  bool rewriteVectorizedStoreInst(Value *V, StoreInst &SI, Value *OldOp) {
     // Capture V for the purpose of debug-info accounting once it's converted
     // to a vector store.
     Value *OrigV = V;
@@ -3491,11 +3490,8 @@ private:
       V = insertVector(IRB, Old, V, BeginIndex, "vec");
     }
     StoreInst *Store = IRB.CreateAlignedStore(V, &NewAI, NewAI.getAlign());
-    Store->copyMetadata(SI, {LLVMContext::MD_mem_parallel_loop_access,
-                             LLVMContext::MD_access_group});
-    if (AATags)
-      Store->setAAMetadata(AATags.adjustForAccess(NewBeginOffset - BeginOffset,
-                                                  V->getType(), DL));
+    copyMetadataForSubAccess(*Store, SI, NewBeginOffset - BeginOffset,
+                             V->getType(), DL);
     Pass.DeadInsts.push_back(&SI);
 
     // NOTE: Careful to use OrigV rather than V.
@@ -3505,7 +3501,7 @@ private:
     return true;
   }
 
-  bool rewriteIntegerStore(Value *V, StoreInst &SI, AAMDNodes AATags) {
+  bool rewriteIntegerStore(Value *V, StoreInst &SI) {
     assert(IntTy && "We cannot extract an integer from the alloca");
     assert(!SI.isVolatile());
     if (DL.getTypeSizeInBits(V->getType()).getFixedValue() !=
@@ -3519,11 +3515,8 @@ private:
     }
     V = IRB.CreateBitPreservingCastChain(DL, V, NewAllocaTy);
     StoreInst *Store = IRB.CreateAlignedStore(V, &NewAI, NewAI.getAlign());
-    Store->copyMetadata(SI, {LLVMContext::MD_mem_parallel_loop_access,
-                             LLVMContext::MD_access_group});
-    if (AATags)
-      Store->setAAMetadata(AATags.adjustForAccess(NewBeginOffset - BeginOffset,
-                                                  V->getType(), DL));
+    copyMetadataForSubAccess(*Store, SI, NewBeginOffset - BeginOffset,
+                             V->getType(), DL);
 
     migrateDebugInfo(&OldAI, IsSplit, NewBeginOffset * 8, SliceSize * 8, &SI,
                      Store, Store->getPointerOperand(),
@@ -3539,7 +3532,6 @@ private:
     Value *OldOp = SI.getOperand(1);
     assert(OldOp == OldPtr);
 
-    AAMDNodes AATags = SI.getAAMetadata();
     Value *V = SI.getValueOperand();
 
     // Strip all inbounds GEPs and pointer casts to try to dig out any root
@@ -3561,9 +3553,9 @@ private:
     }
 
     if (VecTy)
-      return rewriteVectorizedStoreInst(V, SI, OldOp, AATags);
+      return rewriteVectorizedStoreInst(V, SI, OldOp);
     if (IntTy && V->getType()->isIntegerTy())
-      return rewriteIntegerStore(V, SI, AATags);
+      return rewriteIntegerStore(V, SI);
 
     StoreInst *NewSI;
     if (NewBeginOffset == NewAllocaBeginOffset &&
@@ -3581,11 +3573,8 @@ private:
       NewSI =
           IRB.CreateAlignedStore(V, NewPtr, getSliceAlign(), SI.isVolatile());
     }
-    NewSI->copyMetadata(SI, {LLVMContext::MD_mem_parallel_loop_access,
-                             LLVMContext::MD_access_group});
-    if (AATags)
-      NewSI->setAAMetadata(AATags.adjustForAccess(NewBeginOffset - BeginOffset,
-                                                  V->getType(), DL));
+    copyMetadataForSubAccess(*NewSI, SI, NewBeginOffset - BeginOffset,
+                             V->getType(), DL);
     if (SI.isVolatile())
       NewSI->setAtomic(SI.getOrdering(), SI.getSyncScopeID());
     if (NewSI->isAtomic())

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3174,6 +3174,22 @@ void llvm::copyMetadataForLoad(LoadInst &Dest, const LoadInst &Source) {
   }
 }
 
+void llvm::copyMetadataForSubAccess(Instruction &Dest,
+                                    const Instruction &Source, uint64_t Offset,
+                                    Type *AccessTy, const DataLayout &DL) {
+  // Metadata that describes a property of the memory access itself (not the
+  // exact bytes touched) remains valid for a narrower sub-access, so copy it
+  // directly.
+  Dest.copyMetadata(Source, {LLVMContext::MD_mem_parallel_loop_access,
+                             LLVMContext::MD_access_group,
+                             LLVMContext::MD_nontemporal});
+  // The AA metadata (!tbaa, !tbaa.struct, !alias.scope, !noalias) describes the
+  // bytes accessed, so it must be narrowed to the sub-access rather than copied
+  // verbatim.
+  if (AAMDNodes AATags = Source.getAAMetadata())
+    Dest.setAAMetadata(AATags.adjustForAccess(Offset, AccessTy, DL));
+}
+
 void llvm::patchReplacementInstruction(Instruction *I, Value *Repl) {
   auto *ReplInst = dyn_cast<Instruction>(Repl);
   if (!ReplInst)

--- a/llvm/test/Transforms/InstCombine/unpack-fca.ll
+++ b/llvm/test/Transforms/InstCombine/unpack-fca.ll
@@ -73,14 +73,14 @@ define void @storeStructOfArrayOfA(ptr %saa.ptr) {
 
 define void @storeArrayOfB(ptr %ab.ptr, [2 x %B] %ab) {
 ; CHECK-LABEL: @storeArrayOfB(
-; CHECK-NEXT:    [[AB_ELT:%.*]] = extractvalue [2 x %B] [[AB:%.*]], 0
-; CHECK-NEXT:    [[AB_ELT_ELT:%.*]] = extractvalue [[B:%.*]] [[AB_ELT]], 0
+; CHECK-NEXT:    [[AB_ELT:%.*]] = extractvalue [2 x [[B:%.*]]] [[AB:%.*]], 0
+; CHECK-NEXT:    [[AB_ELT_ELT:%.*]] = extractvalue [[B]] [[AB_ELT]], 0
 ; CHECK-NEXT:    store ptr [[AB_ELT_ELT]], ptr [[AB_PTR:%.*]], align 8
 ; CHECK-NEXT:    [[AB_PTR_REPACK3:%.*]] = getelementptr inbounds nuw i8, ptr [[AB_PTR]], i64 8
 ; CHECK-NEXT:    [[AB_ELT_ELT4:%.*]] = extractvalue [[B]] [[AB_ELT]], 1
 ; CHECK-NEXT:    store i64 [[AB_ELT_ELT4]], ptr [[AB_PTR_REPACK3]], align 8
 ; CHECK-NEXT:    [[AB_PTR_REPACK1:%.*]] = getelementptr inbounds nuw i8, ptr [[AB_PTR]], i64 16
-; CHECK-NEXT:    [[AB_ELT2:%.*]] = extractvalue [2 x %B] [[AB]], 1
+; CHECK-NEXT:    [[AB_ELT2:%.*]] = extractvalue [2 x [[B]]] [[AB]], 1
 ; CHECK-NEXT:    [[AB_ELT2_ELT:%.*]] = extractvalue [[B]] [[AB_ELT2]], 0
 ; CHECK-NEXT:    store ptr [[AB_ELT2_ELT]], ptr [[AB_PTR_REPACK1]], align 8
 ; CHECK-NEXT:    [[AB_PTR_REPACK1_REPACK5:%.*]] = getelementptr inbounds nuw i8, ptr [[AB_PTR]], i64 24
@@ -130,8 +130,8 @@ define [1 x %A] @loadArrayOfA(ptr %aa.ptr) {
 ; CHECK-LABEL: @loadArrayOfA(
 ; CHECK-NEXT:    [[DOTUNPACK_UNPACK:%.*]] = load ptr, ptr [[AA_PTR:%.*]], align 8
 ; CHECK-NEXT:    [[DOTUNPACK1:%.*]] = insertvalue [[A:%.*]] poison, ptr [[DOTUNPACK_UNPACK]], 0
-; CHECK-NEXT:    [[TMP1:%.*]] = insertvalue [1 x %A] poison, [[A]] [[DOTUNPACK1]], 0
-; CHECK-NEXT:    ret [1 x %A] [[TMP1]]
+; CHECK-NEXT:    [[TMP1:%.*]] = insertvalue [1 x [[A]]] poison, [[A]] [[DOTUNPACK1]], 0
+; CHECK-NEXT:    ret [1 x [[A]]] [[TMP1]]
 ;
   %1 = load [1 x %A], ptr %aa.ptr, align 8
   ret [1 x %A] %1
@@ -141,9 +141,9 @@ define { [1 x %A] } @loadStructOfArrayOfA(ptr %saa.ptr) {
 ; CHECK-LABEL: @loadStructOfArrayOfA(
 ; CHECK-NEXT:    [[DOTUNPACK_UNPACK_UNPACK:%.*]] = load ptr, ptr [[SAA_PTR:%.*]], align 8
 ; CHECK-NEXT:    [[DOTUNPACK_UNPACK2:%.*]] = insertvalue [[A:%.*]] poison, ptr [[DOTUNPACK_UNPACK_UNPACK]], 0
-; CHECK-NEXT:    [[DOTUNPACK1:%.*]] = insertvalue [1 x %A] poison, [[A]] [[DOTUNPACK_UNPACK2]], 0
-; CHECK-NEXT:    [[TMP1:%.*]] = insertvalue { [1 x %A] } poison, [1 x %A] [[DOTUNPACK1]], 0
-; CHECK-NEXT:    ret { [1 x %A] } [[TMP1]]
+; CHECK-NEXT:    [[DOTUNPACK1:%.*]] = insertvalue [1 x [[A]]] poison, [[A]] [[DOTUNPACK_UNPACK2]], 0
+; CHECK-NEXT:    [[TMP1:%.*]] = insertvalue { [1 x [[A]]] } poison, [1 x [[A]]] [[DOTUNPACK1]], 0
+; CHECK-NEXT:    ret { [1 x [[A]]] } [[TMP1]]
 ;
   %1 = load { [1 x %A] }, ptr %saa.ptr, align 8
   ret { [1 x %A] } %1
@@ -178,15 +178,15 @@ define [2 x %B] @loadArrayOfB(ptr %ab.ptr) {
 ; CHECK-NEXT:    [[DOTUNPACK_ELT3:%.*]] = getelementptr inbounds nuw i8, ptr [[AB_PTR]], i64 8
 ; CHECK-NEXT:    [[DOTUNPACK_UNPACK4:%.*]] = load i64, ptr [[DOTUNPACK_ELT3]], align 8
 ; CHECK-NEXT:    [[DOTUNPACK5:%.*]] = insertvalue [[B]] [[TMP1]], i64 [[DOTUNPACK_UNPACK4]], 1
-; CHECK-NEXT:    [[TMP2:%.*]] = insertvalue [2 x %B] poison, [[B]] [[DOTUNPACK5]], 0
+; CHECK-NEXT:    [[TMP2:%.*]] = insertvalue [2 x [[B]]] poison, [[B]] [[DOTUNPACK5]], 0
 ; CHECK-NEXT:    [[DOTELT1:%.*]] = getelementptr inbounds nuw i8, ptr [[AB_PTR]], i64 16
 ; CHECK-NEXT:    [[DOTUNPACK2_UNPACK:%.*]] = load ptr, ptr [[DOTELT1]], align 8
 ; CHECK-NEXT:    [[TMP3:%.*]] = insertvalue [[B]] poison, ptr [[DOTUNPACK2_UNPACK]], 0
 ; CHECK-NEXT:    [[DOTUNPACK2_ELT6:%.*]] = getelementptr inbounds nuw i8, ptr [[AB_PTR]], i64 24
 ; CHECK-NEXT:    [[DOTUNPACK2_UNPACK7:%.*]] = load i64, ptr [[DOTUNPACK2_ELT6]], align 8
 ; CHECK-NEXT:    [[DOTUNPACK28:%.*]] = insertvalue [[B]] [[TMP3]], i64 [[DOTUNPACK2_UNPACK7]], 1
-; CHECK-NEXT:    [[TMP4:%.*]] = insertvalue [2 x %B] [[TMP2]], [[B]] [[DOTUNPACK28]], 1
-; CHECK-NEXT:    ret [2 x %B] [[TMP4]]
+; CHECK-NEXT:    [[TMP4:%.*]] = insertvalue [2 x [[B]]] [[TMP2]], [[B]] [[DOTUNPACK28]], 1
+; CHECK-NEXT:    ret [2 x [[B]]] [[TMP4]]
 ;
   %1 = load [2 x %B], ptr %ab.ptr, align 8
   ret [2 x %B] %1
@@ -194,8 +194,8 @@ define [2 x %B] @loadArrayOfB(ptr %ab.ptr) {
 
 define [2000 x %B] @loadLargeArrayOfB(ptr %ab.ptr) {
 ; CHECK-LABEL: @loadLargeArrayOfB(
-; CHECK-NEXT:    [[TMP1:%.*]] = load [2000 x %B], ptr [[AB_PTR:%.*]], align 8
-; CHECK-NEXT:    ret [2000 x %B] [[TMP1]]
+; CHECK-NEXT:    [[TMP1:%.*]] = load [2000 x [[B:%.*]]], ptr [[AB_PTR:%.*]], align 8
+; CHECK-NEXT:    ret [2000 x [[B]]] [[TMP1]]
 ;
   %1 = load [2000 x %B], ptr %ab.ptr, align 8
   ret [2000 x %B] %1
@@ -261,3 +261,70 @@ define void @check_alignment(ptr %u, ptr %v) {
   store %struct.U %1, ptr %v
   ret void
 }
+
+; When unpacking a multi-element struct store, the "whole access" metadata
+; (!nontemporal, !llvm.mem.parallel_loop_access) is carried onto every per-field
+; store, while the AA metadata (here !tbaa.struct) is narrowed to each field via
+; AAMDNodes::adjustForAccess, so each store gets the scalar !tbaa for its field
+; rather than the whole aggregate descriptor. The field types
+; (i32/float/double/i64/ptr) must also be preserved.
+define void @storeStructWithMetadata(ptr %p, { i32, float, double, i64, ptr } %v) {
+; CHECK-LABEL: @storeStructWithMetadata(
+; CHECK-NEXT:    [[V_ELT:%.*]] = extractvalue { i32, float, double, i64, ptr } [[V:%.*]], 0
+; CHECK-NEXT:    store i32 [[V_ELT]], ptr [[P:%.*]], align 8, !tbaa [[TBAA0:![0-9]+]], !nontemporal [[META4:![0-9]+]], !llvm.mem.parallel_loop_access [[META5:![0-9]+]]
+; CHECK-NEXT:    [[P_REPACK1:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 4
+; CHECK-NEXT:    [[V_ELT2:%.*]] = extractvalue { i32, float, double, i64, ptr } [[V]], 1
+; CHECK-NEXT:    store float [[V_ELT2]], ptr [[P_REPACK1]], align 4, !tbaa [[TBAA7:![0-9]+]], !nontemporal [[META4]], !llvm.mem.parallel_loop_access [[META5]]
+; CHECK-NEXT:    [[P_REPACK3:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 8
+; CHECK-NEXT:    [[V_ELT4:%.*]] = extractvalue { i32, float, double, i64, ptr } [[V]], 2
+; CHECK-NEXT:    store double [[V_ELT4]], ptr [[P_REPACK3]], align 8, !tbaa [[TBAA9:![0-9]+]], !nontemporal [[META4]], !llvm.mem.parallel_loop_access [[META5]]
+; CHECK-NEXT:    [[P_REPACK5:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 16
+; CHECK-NEXT:    [[V_ELT6:%.*]] = extractvalue { i32, float, double, i64, ptr } [[V]], 3
+; CHECK-NEXT:    store i64 [[V_ELT6]], ptr [[P_REPACK5]], align 8, !tbaa [[TBAA11:![0-9]+]], !nontemporal [[META4]], !llvm.mem.parallel_loop_access [[META5]]
+; CHECK-NEXT:    [[P_REPACK7:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 24
+; CHECK-NEXT:    [[V_ELT8:%.*]] = extractvalue { i32, float, double, i64, ptr } [[V]], 4
+; CHECK-NEXT:    store ptr [[V_ELT8]], ptr [[P_REPACK7]], align 8, !tbaa [[TBAA13:![0-9]+]], !nontemporal [[META4]], !llvm.mem.parallel_loop_access [[META5]]
+; CHECK-NEXT:    ret void
+;
+  store { i32, float, double, i64, ptr } %v, ptr %p, align 8, !tbaa.struct !0, !nontemporal !12, !llvm.mem.parallel_loop_access !13
+  ret void
+}
+
+; Same for a multi-element array store: !tbaa.struct is sliced to a per-element
+; scalar !tbaa while the whole-access metadata is copied to each store.
+define void @storeArrayWithMetadata(ptr %p, [4 x i32] %v) {
+; CHECK-LABEL: @storeArrayWithMetadata(
+; CHECK-NEXT:    [[V_ELT:%.*]] = extractvalue [4 x i32] [[V:%.*]], 0
+; CHECK-NEXT:    store i32 [[V_ELT]], ptr [[P:%.*]], align 4, !tbaa [[TBAA0]], !nontemporal [[META4]], !llvm.mem.parallel_loop_access [[META5]]
+; CHECK-NEXT:    [[P_REPACK1:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 4
+; CHECK-NEXT:    [[V_ELT2:%.*]] = extractvalue [4 x i32] [[V]], 1
+; CHECK-NEXT:    store i32 [[V_ELT2]], ptr [[P_REPACK1]], align 4, !tbaa [[TBAA0]], !nontemporal [[META4]], !llvm.mem.parallel_loop_access [[META5]]
+; CHECK-NEXT:    [[P_REPACK3:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 8
+; CHECK-NEXT:    [[V_ELT4:%.*]] = extractvalue [4 x i32] [[V]], 2
+; CHECK-NEXT:    store i32 [[V_ELT4]], ptr [[P_REPACK3]], align 4, !tbaa [[TBAA0]], !nontemporal [[META4]], !llvm.mem.parallel_loop_access [[META5]]
+; CHECK-NEXT:    [[P_REPACK5:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 12
+; CHECK-NEXT:    [[V_ELT6:%.*]] = extractvalue [4 x i32] [[V]], 3
+; CHECK-NEXT:    store i32 [[V_ELT6]], ptr [[P_REPACK5]], align 4, !tbaa [[TBAA0]], !nontemporal [[META4]], !llvm.mem.parallel_loop_access [[META5]]
+; CHECK-NEXT:    ret void
+;
+  store [4 x i32] %v, ptr %p, align 4, !tbaa.struct !14, !nontemporal !12, !llvm.mem.parallel_loop_access !13
+  ret void
+}
+
+!0 = !{i64 0, i64 4, !1, i64 4, i64 4, !4, i64 8, i64 8, !6, i64 16, i64 8, !8, i64 24, i64 8, !10}
+!1 = !{!2, !2, i64 0}
+!2 = !{!"int", !3, i64 0}
+!3 = !{!"omnipotent char", !15, i64 0}
+!4 = !{!5, !5, i64 0}
+!5 = !{!"float", !3, i64 0}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"double", !3, i64 0}
+!8 = !{!9, !9, i64 0}
+!9 = !{!"long", !3, i64 0}
+!10 = !{!11, !11, i64 0}
+!11 = !{!"any pointer", !3, i64 0}
+!12 = !{i32 1}
+!13 = !{!16}
+!14 = !{i64 0, i64 4, !1, i64 4, i64 4, !1, i64 8, i64 4, !1, i64 12, i64 4, !1}
+!15 = !{!"Simple C++ TBAA"}
+!16 = distinct !{}

--- a/llvm/test/Transforms/InstCombine/unpack-fca.ll
+++ b/llvm/test/Transforms/InstCombine/unpack-fca.ll
@@ -311,6 +311,23 @@ define void @storeArrayWithMetadata(ptr %p, [4 x i32] %v) {
   ret void
 }
 
+; A malformed !tbaa.struct whose fields are bare type nodes (not struct-path
+; access tags) must not be promoted to an invalid old-style !tbaa on the split
+; stores. The AA metadata is conservatively dropped rather than producing IR the
+; verifier would reject.
+define void @storeMalformedTBAAStruct(ptr %p, { i32, i32 } %v) {
+; CHECK-LABEL: @storeMalformedTBAAStruct(
+; CHECK-NEXT:    [[V_ELT:%.*]] = extractvalue { i32, i32 } [[V:%.*]], 0
+; CHECK-NEXT:    store i32 [[V_ELT]], ptr [[P:%.*]], align 4
+; CHECK-NEXT:    [[P_REPACK1:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 4
+; CHECK-NEXT:    [[V_ELT2:%.*]] = extractvalue { i32, i32 } [[V]], 1
+; CHECK-NEXT:    store i32 [[V_ELT2]], ptr [[P_REPACK1]], align 4
+; CHECK-NEXT:    ret void
+;
+  store { i32, i32 } %v, ptr %p, align 4, !tbaa.struct !17
+  ret void
+}
+
 !0 = !{i64 0, i64 4, !1, i64 4, i64 4, !4, i64 8, i64 8, !6, i64 16, i64 8, !8, i64 24, i64 8, !10}
 !1 = !{!2, !2, i64 0}
 !2 = !{!"int", !3, i64 0}
@@ -328,3 +345,5 @@ define void @storeArrayWithMetadata(ptr %p, [4 x i32] %v) {
 !14 = !{i64 0, i64 4, !1, i64 4, i64 4, !1, i64 8, i64 4, !1, i64 12, i64 4, !1}
 !15 = !{!"Simple C++ TBAA"}
 !16 = distinct !{}
+; Fields are bare type nodes (operand 0 is a string), not struct-path tags.
+!17 = !{i64 0, i64 4, !2, i64 4, i64 4, !2}


### PR DESCRIPTION
### Description

`unpackStoreToAggregate` splits a store of a struct or array into one scalar store per field using `extractvalue`. For example:

```llvm
store { i64, i64 } %v, ptr %p
    =>
%v.elt  = extractvalue { i64, i64 } %v, 0
store i64 %v.elt, ptr %p
%v.elt2 = extractvalue { i64, i64 } %v, 1
store i64 %v.elt2, ptr %p.repack1
```

When creating each per-field store, the multi-element struct and array paths currently copy only AA metadata:

```cpp
NS->setAAMetadata(SI.getAAMetadata());
```

This preserves only `!tbaa`, `!tbaa.struct`, `!alias.scope`, and `!noalias`. Other store metadata is silently dropped, including `!nontemporal`, `!llvm.mem.parallel_loop_access`, `!llvm.access.group`, etc.

Each per-field store writes the same bytes (at the corresponding offset) as the original aggregate store, so the original store metadata remains applicable. The sibling transform `combineStoreToNewValue` already reflects the intended behavior by preserving all relevant store metadata.

Introduce a `copyMetadataForUnpackedStore` helper, mirroring the store metadata preserved by `combineStoreToNewValue`, and use it in both the struct and array unpacking paths instead of `setAAMetadata()`.

`!DIAssignID` is intentionally **not** copied. Unpacking splits one store into multiple stores, and assignment tracking requires each store to have its own distinct `!DIAssignID` (as done by SROA's `migrateDebugInfo`). Reusing the same ID across multiple stores would corrupt assignment tracking.

This is a missed optimization rather than a correctness issue—the loss of metadata is the conservative direction—but it is observable. For example, dropping `!nontemporal` causes the X86 backend to emit cached `mov` instructions instead of streaming `movnt` stores, while dropping `!llvm.mem.parallel_loop_access` can inhibit loop vectorization.

Add tests to `test/Transforms/InstCombine/unpack-fca.ll` covering multi-field struct and array stores. The checks verify that each unpacked store preserves `!tbaa`, `!nontemporal`, and `!llvm.mem.parallel_loop_access`, while maintaining the correct field types.

Found via @jlebar's X86 LLVM bug-hunt / FuzzX effort:

* https://github.com/SemiAnalysisAI/FuzzX/tree/master/x86/bugs/245-instcombine-unpack-aggregate-drops-nontemporal-extra

cc @jlebar
