### PR TITLE
[Clang] Disable verifier passes by default in NewPM CodeGen

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1301,6 +1301,7 @@ void EmitAssemblyHelper::RunCodegenPipelineNewPM(
   CGSCCAnalysisManager CGAM;
   ModuleAnalysisManager MAM;
   CGPassBuilderOption Opt = getCGPassBuilderOption();
+  Opt.DisableVerify = !CodeGenOpts.VerifyModule;
   MachineModuleInfo MMI(TM.get());
   PassInstrumentationCallbacks PIC;
   PipelineTuningOptions PTOptions;


### PR DESCRIPTION
By default, we shouldn't add expensive verifier passes to the pipeline.
This causes a substantial perf regression compared to the legacy PM.
