### PR TITLE
[bazel][libc] Add htons function family and tests

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3304,6 +3304,52 @@ libc_support_library(
     ],
 )
 
+############################### arpa/inet targets ##############################
+
+libc_function(
+    name = "htonl",
+    srcs = ["src/arpa/inet/htonl.cpp"],
+    hdrs = ["src/arpa/inet/htonl.h"],
+    deps = [
+        ":__support_common",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
+    ],
+)
+
+libc_function(
+    name = "htons",
+    srcs = ["src/arpa/inet/htons.cpp"],
+    hdrs = ["src/arpa/inet/htons.h"],
+    deps = [
+        ":__support_common",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
+    ],
+)
+
+libc_function(
+    name = "ntohl",
+    srcs = ["src/arpa/inet/ntohl.cpp"],
+    hdrs = ["src/arpa/inet/ntohl.h"],
+    deps = [
+        ":__support_common",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
+    ],
+)
+
+libc_function(
+    name = "ntohs",
+    srcs = ["src/arpa/inet/ntohs.cpp"],
+    hdrs = ["src/arpa/inet/ntohs.h"],
+    deps = [
+        ":__support_common",
+        ":__support_macros_config",
+        ":hdr_stdint_proxy",
+    ],
+)
+
 ################################# ctype targets ################################
 
 libc_function(

--- a/utils/bazel/llvm-project-overlay/libc/test/src/arpa/inet/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/arpa/inet/BUILD.bazel
@@ -1,0 +1,51 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Tests for LLVM libc arpa/inet.h functions.
+
+load("//libc/test:libc_test_rules.bzl", "libc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+libc_test(
+    name = "htonl_test",
+    srcs = ["htonl_test.cpp"],
+    deps = [
+        "//libc:__support_common",
+        "//libc:htonl",
+        "//libc:ntohl",
+    ],
+)
+
+libc_test(
+    name = "htons_test",
+    srcs = ["htons_test.cpp"],
+    deps = [
+        "//libc:__support_common",
+        "//libc:htons",
+        "//libc:ntohs",
+    ],
+)
+
+libc_test(
+    name = "ntohl_test",
+    srcs = ["ntohl_test.cpp"],
+    deps = [
+        "//libc:__support_common",
+        "//libc:htonl",
+        "//libc:ntohl",
+    ],
+)
+
+libc_test(
+    name = "ntohs_test",
+    srcs = ["ntohs_test.cpp"],
+    deps = [
+        "//libc:__support_common",
+        "//libc:htons",
+        "//libc:ntohs",
+    ],
+)


### PR DESCRIPTION
Add bazel build targets for the arpa/inet byte order functions (htonl, htons, ntohl, ntohs) and their corresponding unittests.

Assisted by Gemini.