### PR TITLE
[orc-rt] Add an ORC_RT_C_FORMAT_PRINTF macro for format-string checking

### DIFF
--- a/orc-rt/include/orc-rt-c/Compiler.h
+++ b/orc-rt/include/orc-rt-c/Compiler.h
@@ -57,4 +57,15 @@
 #define ORC_RT_C_NOTHROW
 #endif
 
+/* ORC_RT_C_FORMAT_PRINTF(FmtIdx, FirstArg) marks a function as taking a
+   printf-style format string at argument position FmtIdx, with the variadic
+   arguments beginning at FirstArg, so the compiler can check the format string
+   against its arguments. Indices are 1-based. */
+#if defined(__GNUC__) || defined(__clang__)
+#define ORC_RT_C_FORMAT_PRINTF(FmtIdx, FirstArg)                               \
+  __attribute__((format(printf, FmtIdx, FirstArg)))
+#else
+#define ORC_RT_C_FORMAT_PRINTF(FmtIdx, FirstArg)
+#endif
+
 #endif /* ORC_RT_C_COMPILER_H */


### PR DESCRIPTION
Add a macro to annotate a function that takes a printf-style format string, so that supporting compilers can check the format string against the function's arguments at compile time.

This will be used by the upcoming logging API to type-check log format strings, including at call sites that are compiled out.