### PR TITLE
[orc-rt] Add a configurable logging API with a no-op backend

### DIFF
--- a/orc-rt/CMakeLists.txt
+++ b/orc-rt/CMakeLists.txt
@@ -70,6 +70,46 @@ else()
   list(APPEND ORC_RT_COMPILE_FLAGS -fno-exceptions)
 endif()
 
+# --- Logging ---
+# User-settable options (everything below them is validation and derivation):
+#   ORC_RT_LOG_BACKEND  none (default) | printf | os_log
+#   ORC_RT_LOG_LEVEL    error | warning | info (default) | debug
+set(orc_rt_log_level_default "info")
+set(ORC_RT_LOG_LEVEL "${orc_rt_log_level_default}" CACHE STRING
+  "Lowest log level compiled in: error, warning, info, or debug")
+set(orc_rt_log_levels error warning info debug)
+set_property(CACHE ORC_RT_LOG_LEVEL PROPERTY STRINGS ${orc_rt_log_levels})
+
+set(ORC_RT_LOG_BACKEND "none" CACHE STRING
+  "ORC-RT logging backend: none, printf, os_log")
+set(orc_rt_log_backends none printf os_log)
+set_property(CACHE ORC_RT_LOG_BACKEND PROPERTY STRINGS ${orc_rt_log_backends})
+
+# Validate the level and derive its config.h macro symbol.
+if(NOT ORC_RT_LOG_LEVEL IN_LIST orc_rt_log_levels)
+  message(FATAL_ERROR "ORC_RT_LOG_LEVEL must be one of: ${orc_rt_log_levels}")
+endif()
+string(TOUPPER "ORC_RT_LOG_LEVEL_${ORC_RT_LOG_LEVEL}" ORC_RT_LOG_LEVEL_VALUE)
+
+# Validate the backend (os_log is Apple-only) and derive its config.h macro symbol.
+if(NOT ORC_RT_LOG_BACKEND IN_LIST orc_rt_log_backends)
+  message(FATAL_ERROR "ORC_RT_LOG_BACKEND must be one of: ${orc_rt_log_backends}")
+endif()
+if(ORC_RT_LOG_BACKEND STREQUAL "os_log" AND NOT APPLE)
+  message(FATAL_ERROR "ORC_RT_LOG_BACKEND=os_log is only supported on Apple platforms.")
+endif()
+string(TOUPPER "ORC_RT_LOG_BACKEND_${ORC_RT_LOG_BACKEND}" ORC_RT_LOG_BACKEND_VALUE)
+
+# The "none" backend compiles all logging out, so the level has no effect. Warn
+# if the user picked a non-default level under it, as their choice is ignored.
+if(ORC_RT_LOG_BACKEND STREQUAL "none" AND
+   NOT ORC_RT_LOG_LEVEL STREQUAL orc_rt_log_level_default)
+  message(WARNING
+    "ORC_RT_LOG_LEVEL is set to '${ORC_RT_LOG_LEVEL}', but ORC_RT_LOG_BACKEND is "
+    "'none', so no logging is compiled in and the level has no effect. Select a "
+    "backend (printf or os_log) to enable logging.")
+endif()
+
 # --- Generated config header ---
 # Keep this last in the section so it captures every value derived above.
 configure_file(

--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -2,6 +2,7 @@ set(ORC_RT_HEADERS
     orc-rt-c/CoreTyspe.h
     orc-rt-c/Error.h
     orc-rt-c/Compiler.h
+    orc-rt-c/Logging.h
     orc-rt-c/WrapperFunction.h
     orc-rt-c/orc-rt.h
     orc-rt/AllocAction.h

--- a/orc-rt/include/orc-rt-c/Logging.h
+++ b/orc-rt/include/orc-rt-c/Logging.h
@@ -1,0 +1,103 @@
+/*===------------ Logging.h - ORC Runtime logging support ---------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+|*===----------------------------------------------------------------------===*|
+|*                                                                            *|
+|* Configurable logging for the ORC runtime.                                  *|
+|*                                                                            *|
+|* Log a message with:                                                        *|
+|*                                                                            *|
+|*   ORC_RT_LOG(Level, Category, Fmt, ...)                                    *|
+|*                                                                            *|
+|* where Level is one of Error, Warning, Info, Debug; Category is one of the  *|
+|* orc_rt_LogCategory tokens (without the leading "orc_rt_LogCategory_");     *|
+|* and Fmt, ... are a printf-style format string and arguments, e.g.          *|
+|*                                                                            *|
+|*   ORC_RT_LOG(Error, General, "failed to map %zu bytes", Size);             *|
+|*                                                                            *|
+|* Level and Category must be compile-time tokens (not runtime values): the   *|
+|* os_log backend selects its record type from the level at compile time, and *|
+|* the category enum gives typo-safe, filterable subsystems.                  *|
+|*                                                                            *|
+|* The backend is selected at build time via ORC_RT_LOG_BACKEND. The default  *|
+|* "none" backend emits no code (but still type-checks the format string and  *|
+|* arguments at every call site).                                             *|
+|*                                                                            *|
+|* IMPORTANT: log arguments should be free of observable side effects.        *|
+|* Whether they are evaluated is backend- and level-dependent, so they must   *|
+|* not be relied upon to run.                                                 *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef ORC_RT_C_LOGGING_H
+#define ORC_RT_C_LOGGING_H
+
+#include "orc-rt-c/Compiler.h"
+#include "orc-rt-c/config.h"
+
+ORC_RT_C_EXTERN_C_BEGIN
+
+/**
+ * Logging categories.
+ *
+ * Each category identifies a runtime subsystem. On the os_log backend a
+ * category maps to an os_log category (filterable in Console / the `log`
+ * tool); on the printf backend it appears in the line prefix. Add new
+ * categories here as call sites require them.
+ */
+typedef enum {
+  orc_rt_LogCategory_General,
+} orc_rt_LogCategory;
+
+/**
+ * Declared but never defined: referenced only in unevaluated (sizeof) contexts
+ * to type-check a printf-style format string against its arguments without
+ * evaluating them or emitting any code.
+ */
+int orc_rt_log_format_check(const char *Fmt, ...) ORC_RT_C_FORMAT_PRINTF(1, 2);
+
+ORC_RT_C_EXTERN_C_END
+
+/*
+ * A disabled log site. Validates the category token, format string, and
+ * arguments at compile time, but evaluates nothing and generates no code:
+ * both operands sit in unevaluated sizeof contexts.
+ */
+#define ORC_RT_LOG_DISABLED(Category, ...)                                     \
+  ((void)sizeof(Category), (void)sizeof(orc_rt_log_format_check(__VA_ARGS__)))
+
+/*
+ * ORC_RT_LOG dispatches on the level token to a per-level macro, which each
+ * backend defines below to either emit a message or, when the level is
+ * compiled out, to ORC_RT_LOG_DISABLED. Fmt is the first variadic argument, so
+ * __VA_ARGS__ is always non-empty and no GNU comma-swallowing extension is
+ * needed.
+ */
+#define ORC_RT_LOG(Level, Category, ...)                                       \
+  ORC_RT_LOG_##Level(orc_rt_LogCategory_##Category, __VA_ARGS__)
+
+#if ORC_RT_LOG_BACKEND == ORC_RT_LOG_BACKEND_NONE
+
+/* The none backend compiles every level out, regardless of ORC_RT_LOG_LEVEL. */
+#define ORC_RT_LOG_Error(Category, ...)                                        \
+  ORC_RT_LOG_DISABLED(Category, __VA_ARGS__)
+#define ORC_RT_LOG_Warning(Category, ...)                                      \
+  ORC_RT_LOG_DISABLED(Category, __VA_ARGS__)
+#define ORC_RT_LOG_Info(Category, ...)                                         \
+  ORC_RT_LOG_DISABLED(Category, __VA_ARGS__)
+#define ORC_RT_LOG_Debug(Category, ...)                                        \
+  ORC_RT_LOG_DISABLED(Category, __VA_ARGS__)
+
+#elif ORC_RT_LOG_BACKEND == ORC_RT_LOG_BACKEND_PRINTF
+#error "The printf logging backend is not yet implemented."
+#elif ORC_RT_LOG_BACKEND == ORC_RT_LOG_BACKEND_OS_LOG
+#error "The os_log logging backend is not yet implemented."
+#else
+#error "Unknown ORC_RT_LOG_BACKEND."
+#endif
+
+#endif /* ORC_RT_C_LOGGING_H */

--- a/orc-rt/include/orc-rt-c/config.h.in
+++ b/orc-rt/include/orc-rt-c/config.h.in
@@ -16,4 +16,24 @@
 /* Define to 1 if exceptions are enabled */
 #cmakedefine01 ORC_RT_ENABLE_EXCEPTIONS
 
+/* Logging: available levels, and the minimum level compiled in. */
+#define ORC_RT_LOG_LEVEL_DEBUG   0
+#define ORC_RT_LOG_LEVEL_INFO    1
+#define ORC_RT_LOG_LEVEL_WARNING 2
+#define ORC_RT_LOG_LEVEL_ERROR   3
+/* Fail loudly if CMake derived a symbol that isn't defined above. */
+#ifndef @ORC_RT_LOG_LEVEL_VALUE@
+#error "Invalid ORC_RT_LOG_LEVEL"
+#endif
+#define ORC_RT_LOG_LEVEL @ORC_RT_LOG_LEVEL_VALUE@
+
+/* Logging: available backends, and the backend compiled in. */
+#define ORC_RT_LOG_BACKEND_NONE   0
+#define ORC_RT_LOG_BACKEND_PRINTF 1
+#define ORC_RT_LOG_BACKEND_OS_LOG 2
+#ifndef @ORC_RT_LOG_BACKEND_VALUE@
+#error "Invalid ORC_RT_LOG_BACKEND"
+#endif
+#define ORC_RT_LOG_BACKEND @ORC_RT_LOG_BACKEND_VALUE@
+
 #endif /* ORC_RT_C_CONFIG_H */

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_orc_rt_unittest(CoreTests
   IntervalMapTest.cpp
   IntervalSetTest.cpp
   LockedAccessTest.cpp
+  LoggingTest.cpp
   MacroUtilsTest.cpp
   MathTest.cpp
   MemoryAccessSPSCITest.cpp

--- a/orc-rt/unittests/LoggingTest.cpp
+++ b/orc-rt/unittests/LoggingTest.cpp
@@ -1,0 +1,55 @@
+//===- LoggingTest.cpp ----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Unit tests for the ORC runtime logging API (orc-rt-c/Logging.h).
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt-c/Logging.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+
+// Every level and category must compile and be usable as a plain statement,
+// with any number of printf-style arguments. This holds for all backends.
+TEST(LoggingTest, CompilesAtEveryLevel) {
+  ORC_RT_LOG(Error, General, "no format args");
+  ORC_RT_LOG(Warning, General, "one arg: %d", 42);
+  ORC_RT_LOG(Info, General, "two args: %s = %d", "answer", 42);
+  ORC_RT_LOG(Debug, General, "wide arg: %llu", (unsigned long long)1 << 40);
+  SUCCEED();
+}
+
+#if ORC_RT_LOG_BACKEND == ORC_RT_LOG_BACKEND_NONE
+
+// Increments Count and returns a printable value, so a test can observe whether
+// a log macro evaluated it.
+static const char *bumpAndReturn(int &Count) {
+  ++Count;
+  return "arg";
+}
+
+// The none backend compiles log sites out entirely, so their arguments must
+// never be evaluated.
+TEST(LoggingTest, NoneBackendDoesNotEvaluateArguments) {
+  int NumEvals = 0;
+
+  // Sanity check: a direct call is evaluated and bumps the counter.
+  bumpAndReturn(NumEvals);
+  ASSERT_EQ(NumEvals, 1);
+
+  // The log argument, by contrast, must not run under the none backend.
+  NumEvals = 0;
+  ORC_RT_LOG(Error, General, "%s", bumpAndReturn(NumEvals));
+  EXPECT_EQ(NumEvals, 0) << "the none backend must not evaluate log arguments";
+}
+
+#endif
+
+} // namespace


### PR DESCRIPTION
Adds ORC_RT_LOG(Level, Category, Fmt, ...), a compile-time-configurable logging facility for the ORC runtime, along with the default "none" backend.

The backend is chosen at build time via the ORC_RT_LOG_BACKEND CMake option (none, printf, os_log), and the lowest level to be compiled in via ORC_RT_LOG_LEVEL.

The "none" backend implemented here compiles every log site out to nothing (but still type-checks the format string and arguments in an unevaluated context so disabled sites cannot bit-rot). Levels are Error, Warning, Info, and Debug; categories are a typo-safe enum.

The printf and os_log backends are stubbed with #error and will follow.