### PR TITLE
AMDGPU: Do not report inline immediates as legal for generic operands

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -4729,7 +4729,7 @@ bool SIInstrInfo::isInlineConstant(int64_t Imm, uint8_t OperandType) const {
   case MCOI::OPERAND_GENERIC_4:
   case MCOI::OPERAND_GENERIC_5:
     // Just ignore anything else.
-    return true;
+    return false;
   default:
     llvm_unreachable("invalid operand type");
   }

--- a/llvm/test/CodeGen/AMDGPU/fold-sgpr-multi-imm.mir
+++ b/llvm/test/CodeGen/AMDGPU/fold-sgpr-multi-imm.mir
@@ -272,7 +272,7 @@ body: |
 
 # Ignore regmask operands
 # GCN-LABEL: name: test_si_cs_chain_fold_with_regmask{{$}}
-# GCN: SI_CS_CHAIN_TC_W32 %0, 0, 0, 1234, amdgpu_allvgprs, implicit $sgpr0, implicit $vgpr8
+# GCN: SI_CS_CHAIN_TC_W32 %0, 0, 0, %1, amdgpu_allvgprs, implicit $sgpr0, implicit $vgpr8
 ---
 name: test_si_cs_chain_fold_with_regmask
 tracksRegLiveness: true
@@ -280,7 +280,7 @@ body: |
   bb.0:
     liveins: $sgpr0, $sgpr2_sgpr3, $vgpr8
 
-    %1:ccr_sgpr_64 = COPY $sgpr2_sgpr3
-    %2:sreg_32 = S_MOV_B32 1234
-    SI_CS_CHAIN_TC_W32 %1:ccr_sgpr_64, 0, 0, %2:sreg_32, amdgpu_allvgprs, implicit $sgpr0, implicit $vgpr8
+    %0:ccr_sgpr_64 = COPY $sgpr2_sgpr3
+    %1:sreg_32 = S_MOV_B32 1234
+    SI_CS_CHAIN_TC_W32 %0:ccr_sgpr_64, 0, 0, %1:sreg_32, amdgpu_allvgprs, implicit $sgpr0, implicit $vgpr8
 ...


### PR DESCRIPTION
This has one test change in an SI_CS_CHAIN_TC* test. Either this is fine
or the instruction definition should be changed.