### PR TITLE
[SPIR-V] Support printing OpConstantF literals wider than 64 bits

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -14,6 +14,7 @@
 #include "SPIRV.h"
 #include "SPIRVBaseInfo.h"
 #include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
@@ -67,6 +68,23 @@ void SPIRVInstPrinter::printOpConstantVarOps(const MCInst *MI,
     APInt ActualVal = Val.trunc(Bitwidth);
     O << ' ';
     ActualVal.print(O, /*isSigned=*/false);
+    return;
+  }
+
+  if (MI->getOpcode() == SPIRV::OpConstantF && NumVarOps > 2) {
+    // Wide floating-point literals (e.g. fp128) are encoded via more than two
+    // 32-bit words. Reconstruct the value and print it exactly.
+    const unsigned TotalBits = NumVarOps * 32;
+    APInt Val(TotalBits, 0);
+    for (unsigned I = 0; I < NumVarOps; ++I) {
+      uint64_t Word = MI->getOperand(StartIndex + I).getImm();
+      Val |= APInt(TotalBits, Word) << (I * 32);
+    }
+    assert(TotalBits == 128 && "Unsupported floating-point literal width");
+    APFloat FP(APFloat::IEEEquad(), Val);
+    SmallString<40> Str;
+    FP.toString(Str);
+    O << ' ' << Str;
     return;
   }
 

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -71,16 +71,14 @@ void SPIRVInstPrinter::printOpConstantVarOps(const MCInst *MI,
     return;
   }
 
-  if (MI->getOpcode() == SPIRV::OpConstantF && NumVarOps > 2) {
-    // Wide floating-point literals (e.g. fp128) are encoded via more than two
-    // 32-bit words. Reconstruct the value and print it exactly.
+  if (MI->getOpcode() == SPIRV::OpConstantF && NumVarOps == 4) {
+    // fp128 literals
     const unsigned TotalBits = NumVarOps * 32;
     APInt Val(TotalBits, 0);
     for (unsigned I = 0; I < NumVarOps; ++I) {
       uint64_t Word = MI->getOperand(StartIndex + I).getImm();
       Val |= APInt(TotalBits, Word) << (I * 32);
     }
-    assert(TotalBits == 128 && "Unsupported floating-point literal width");
     APFloat FP(APFloat::IEEEquad(), Val);
     SmallString<40> Str;
     FP.toString(Str);

--- a/llvm/test/CodeGen/SPIRV/constant/wide-float-literal-printer.mir
+++ b/llvm/test/CodeGen/SPIRV/constant/wide-float-literal-printer.mir
@@ -1,0 +1,29 @@
+# RUN: llc -O0 -mtriple=spirv32-unknown-unknown -start-after=finalize-isel -verify-machineinstrs %s -o - | FileCheck %s
+
+# Exercises the SPIRVInstPrinter's OpConstantF path for literals wider than
+# 64 bits (e.g. fp128), independent of how the OpConstantF instruction with
+# more than two literal words was produced.
+
+--- |
+  define fp128 @getConstantFP128() {
+    ret fp128 0xL00000000000000004001000000000000
+  }
+...
+---
+name:            getConstantFP128
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.1 (%ir-block.0):
+    %0:type = OpTypeFloat 128
+    %1:fid = OpConstantF %0, 0, 0, 0, 1073807360
+    %2:type = OpTypeFunction %0, %0
+    %3:iid = OpFunction %0, 0, %2
+    OpFunctionEnd
+    OpReturnValue %1
+
+# CHECK: %[[#FP128:]] = OpTypeFloat 128
+# CHECK: %[[#CST_FP128:]] = OpConstant %[[#FP128]] 4
+# CHECK: OpReturnValue %[[#CST_FP128]]


### PR DESCRIPTION
printOpConstantVarOps asserted for OpConstantF with more than two 32-bit literal words (e.g. fp128), which the fixed createConstFP now produces

Reconstruct the APFloat and print it exactly