### PR TITLE
[lldb] Fix assert when `target frame-provider register` succeeds

### DIFF
--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -6175,6 +6175,7 @@ protected:
     result.AppendMessageWithFormatv(
         "successfully registered scripted frame provider '{0}' for target",
         m_class_options.GetName().c_str());
+    result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 
   OptionGroupPythonClassWithDict m_class_options;

--- a/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/Makefile
+++ b/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/Makefile
@@ -1,0 +1,2 @@
+C_SOURCES := main.c
+include Makefile.rules

--- a/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/TestFrameProviderRegisterCommandStatus.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/TestFrameProviderRegisterCommandStatus.py
@@ -1,0 +1,39 @@
+"""
+Test that `target frame-provider register` succeeds without asserting.
+
+DoExecute never called CommandReturnObject::SetStatus() on its success
+path. AppendMessage()/AppendMessageWithFormatv() don't touch the status
+the way AppendError()/SetError() do, so it stayed eReturnStatusInvalid
+and tripped CommandObject.cpp's DoExecuteStatusCheck assert.
+
+Every other scripted_frame_provider test goes through
+SBTarget::RegisterScriptedFrameProvider directly instead of this
+command, which is how this slipped through.
+"""
+
+import os
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class TestFrameProviderRegisterCommandStatus(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_register_command_succeeds(self):
+        """
+        `target frame-provider register` should complete successfully
+        (and not assert) when given a valid scripted frame provider class.
+        """
+        self.build()
+
+        lldbutil.run_to_name_breakpoint(self, "frame3")
+
+        provider_path = os.path.join(self.getSourceDir(), "frame_provider.py")
+        self.runCmd("command script import " + provider_path)
+
+        self.expect(
+            "target frame-provider register -C frame_provider.MinimalProvider",
+            substrs=["successfully registered scripted frame provider"],
+        )

--- a/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/frame_provider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/frame_provider.py
@@ -1,0 +1,16 @@
+"""
+Minimal scripted frame provider used only to exercise `target
+frame-provider register`. get_frame_at_index is never invoked by this
+test: registration alone is enough to trigger the bug under test.
+"""
+
+from lldb.plugins.scripted_frame_provider import ScriptedFrameProvider
+
+
+class MinimalProvider(ScriptedFrameProvider):
+    @staticmethod
+    def get_description():
+        return "minimal provider"
+
+    def get_frame_at_index(self, index):
+        return None

--- a/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/main.c
+++ b/lldb/test/API/functionalities/scripted_frame_provider/register_command_status/main.c
@@ -1,0 +1,7 @@
+int frame3() { return 3; }
+
+int frame2() { return frame3(); }
+
+int frame1() { return frame2(); }
+
+int main() { return frame1(); }


### PR DESCRIPTION
`CommandObjectTargetFrameProviderRegister::DoExecute` never called `CommandReturnObject::SetStatus()` on its success path. `CommandObject.cpp` has a `DoExecuteStatusCheck` RAII guard that resets the result's status to `eReturnStatusInvalid` before `DoExecute` runs, and asserts on exit that `DoExecute` changed it. `AppendMessage()`/`AppendMessageWithFormatv()` don't touch status (unlike AppendError()/SetError(), which call `SetStatus(eReturnStatusFailed)`), so on the success path the status stayed eReturnStatusInvalid, tripping the assert.

This went unnoticed because every existing `scripted_frame_provider` test uses `SBTarget::RegisterScriptedFrameProvider` directly, bypassing the `target frame-provider register` command entirely. Add a regression test that exercises the command instead.

Assisted-by: Claude