### PR TITLE
[ids-check] Add support for ignoring symbols

### DIFF
--- a/llvm/include/llvm/Plugins/PassPlugin.h
+++ b/llvm/include/llvm/Plugins/PassPlugin.h
@@ -133,8 +133,9 @@ private:
 ///   };
 /// }
 /// ```
-extern "C" LLVM_ABI ::llvm::PassPluginLibraryInfo LLVM_ATTRIBUTE_WEAK
-llvmGetPassPluginInfo();
+extern "C" LLVM_ABI_NOT_EXPORTED ::llvm::PassPluginLibraryInfo
+    LLVM_ATTRIBUTE_WEAK
+    llvmGetPassPluginInfo();
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/llvm/utils/git/ids-check-helper.py
+++ b/llvm/utils/git/ids-check-helper.py
@@ -34,6 +34,14 @@ place of the matching command-line arguments.
 """
 
 
+# Symbols that are ignored by the idt check.
+IGNORED_SYMBOLS = [
+    # The entry point for the pass plugin. It is meant to be defined in another
+    # library and is not exported by LLVM.
+    "llvmGetPassPluginInfo",
+]
+
+
 # Headers we skip outright. Each entry is matched against the changed-file
 # path with `startswith`, so it can be either a directory prefix (trailing /)
 # or a specific file path.
@@ -429,6 +437,7 @@ View the diff from {self.name} here.
                 fwd(cdb_dir),
                 f"--main-file={donor_path}",
                 f"--export-macro={EXPORT_MACRO[category]}",
+                f"--ignore={','.join(IGNORED_SYMBOLS)}",
                 "--apply-fixits",
                 "--inplace",
             ]


### PR DESCRIPTION
`llvmGetPassPluginInfo()` is not exported from the LLVM dylib. It is meant to be the entry point for a pass plugin in another dylib. As it is, the ids-check workflow would automatically add the `LLVM_ABI` annotation to it, which is incorrect.

This fixes the issue by explicitly marking the symbol as ignored.

The effort to build LLVM as a DLL is tracked in #109483.