### PR TITLE
BPF: Remove unnecessary isReg check on phi operand

### DIFF
--- a/llvm/lib/Target/BPF/BPFMIPeephole.cpp
+++ b/llvm/lib/Target/BPF/BPFMIPeephole.cpp
@@ -121,9 +121,6 @@ bool BPFMIPeephole::isPhiFrom32Def(MachineInstr *PhiMI)
   for (unsigned i = 1, e = PhiMI->getNumOperands(); i < e; i += 2) {
     MachineOperand &opnd = PhiMI->getOperand(i);
 
-    if (!opnd.isReg())
-      return false;
-
     MachineInstr *PhiDef = MRI->getVRegDef(opnd.getReg());
     if (!PhiDef)
       return false;


### PR DESCRIPTION
These must be a register. This pass has quite a lot of
defensive code against invalid MIR that should be deleted.