### PR TITLE
[PowerPC] Use INT64_MAX instead of LONG_MAX.

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -2810,9 +2810,9 @@ uint64_t PPCFrameLowering::getStackThreshold() const {
   // when extending the stack and is positive when releasing the stack frame.
   // To make `stux` and `add` paired, the absolute value of the number contained
   // in the scratch register should be the same. Thus the maximum stack size
-  // is (2^63)-1, i.e., LONG_MAX.
+  // is (2^63)-1, i.e., INT64_MAX.
   if (Subtarget.isPPC64())
-    return LONG_MAX;
+    return INT64_MAX;
 
   return TargetFrameLowering::getStackThreshold();
 }


### PR DESCRIPTION
The value of LONG_MAX is dependent on the host environment used to build the compiler. For example X86-64 Windows has a different value than X86-64 Linux. Using LONG_MAX would give inconsistent results when cross compiling.

I wonder if the test added in #65559 is generating a warning on X86-64 Windows, but the CHECK-NOT doesn't fail because the warning would say 2147483647 instead of 4294967295.