### PR TITLE
[libc++] Improve diagnostic for libcxxabi missing from the runtimes

### DIFF
--- a/libcxx/cmake/Modules/HandleLibCXXABI.cmake
+++ b/libcxx/cmake/Modules/HandleLibCXXABI.cmake
@@ -148,6 +148,12 @@ elseif ("${LIBCXX_CXX_ABI}" STREQUAL "libcxxabi")
     add_library(libcxx-abi-static-objects ALIAS cxxabi_static_objects)
   endif()
 
+  if (NOT TARGET cxxabi_static AND NOT TARGET cxxabi_shared
+      AND NOT TARGET cxxabi_static_objects AND NOT TARGET cxxabi_shared_objects)
+    message(FATAL_ERROR "Can't find any libc++abi target but LIBCXX_CXX_ABI is set to libcxxabi, "
+                        "did you forget to include libcxxabi in LLVM_ENABLE_RUNTIMES?")
+  endif()
+
 # Link against a system-provided libc++abi
 elseif ("${LIBCXX_CXX_ABI}" STREQUAL "system-libcxxabi")
   if(NOT LIBCXX_CXX_ABI_INCLUDE_PATHS)

--- a/libcxx/cmake/Modules/HandleLibCXXABI.cmake
+++ b/libcxx/cmake/Modules/HandleLibCXXABI.cmake
@@ -151,7 +151,8 @@ elseif ("${LIBCXX_CXX_ABI}" STREQUAL "libcxxabi")
   if (NOT TARGET cxxabi_static AND NOT TARGET cxxabi_shared
       AND NOT TARGET cxxabi_static_objects AND NOT TARGET cxxabi_shared_objects)
     message(FATAL_ERROR "Can't find any libc++abi target but LIBCXX_CXX_ABI is set to libcxxabi, "
-                        "did you forget to include libcxxabi in LLVM_ENABLE_RUNTIMES?")
+                        "did you forget to include libcxxabi in LLVM_ENABLE_RUNTIMES, or did you "
+                        "intend to use LIBCXX_CXX_ABI=system-libcxxabi instead?")
   endif()
 
 # Link against a system-provided libc++abi


### PR DESCRIPTION
When libc++ is configured to use libc++abi as an ABI library but libcxxabi is not part of the runtimes, we'd end up with a confusing build error about a missing <cxxabi.h> header. Instead, diagnose at CMake configuration time.

Closes #136480