### PR TITLE
[X86][Disassembler] Reject instructions longer than 15 bytes

### DIFF
--- a/llvm/lib/Target/X86/Disassembler/X86Disassembler.cpp
+++ b/llvm/lib/Target/X86/Disassembler/X86Disassembler.cpp
@@ -1835,8 +1835,10 @@ MCDisassembler::DecodeStatus X86GenericDisassembler::getInstruction(
   Insn.operands = x86OperandSets[Insn.spec->operands];
   Insn.length = Insn.readerCursor - Insn.startLocation;
   Size = Insn.length;
-  if (Size > 15)
+  if (Size > 15) {
     LLVM_DEBUG(dbgs() << "Instruction exceeds 15-byte limit");
+    return Fail;
+  }
 
   bool Ret = translateInstruction(Instr, Insn, this);
   if (!Ret) {

--- a/llvm/test/MC/Disassembler/X86/x86-64-instruction-length.txt
+++ b/llvm/test/MC/Disassembler/X86/x86-64-instruction-length.txt
@@ -1,14 +1,5 @@
-# RUN: rm -rf %t && split-file %s %t
-# RUN: llvm-mc --disassemble %t/at-limit.txt -triple=x86_64 2>&1 | FileCheck %s --check-prefix=LIMIT --implicit-check-not=warning:
-# RUN: llvm-mc --disassemble %t/too-long.txt -triple=x86_64 2>&1 | FileCheck %s --check-prefix=TOOLONG --implicit-check-not=nop
+# RUN: llvm-mc --disassemble %s -triple=x86_64 2>&1 | FileCheck %s
 
-#--- at-limit.txt
-## 14 redundant operand-size (0x66) prefixes + NOP = 15 bytes: exactly the
-## limit.
-0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x90
-# LIMIT: nop
-
-#--- too-long.txt
-## One more prefix (16 bytes): too long.
+## 15 redundant operand-size (0x66) prefixes + NOP = 16 bytes, over the limit.
+# CHECK: warning: invalid instruction encoding
 0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x90
-# TOOLONG: warning: invalid instruction encoding

--- a/llvm/test/MC/Disassembler/X86/x86-64-instruction-length.txt
+++ b/llvm/test/MC/Disassembler/X86/x86-64-instruction-length.txt
@@ -1,0 +1,14 @@
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc --disassemble %t/at-limit.txt -triple=x86_64 2>&1 | FileCheck %s --check-prefix=LIMIT --implicit-check-not=warning:
+# RUN: llvm-mc --disassemble %t/too-long.txt -triple=x86_64 2>&1 | FileCheck %s --check-prefix=TOOLONG --implicit-check-not=nop
+
+#--- at-limit.txt
+## 14 redundant operand-size (0x66) prefixes + NOP = 15 bytes: exactly the
+## limit.
+0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x90
+# LIMIT: nop
+
+#--- too-long.txt
+## One more prefix (16 bytes): too long.
+0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x66,0x90
+# TOOLONG: warning: invalid instruction encoding


### PR DESCRIPTION
An x86 instruction can be at most 15 bytes. The decoder already checks for overruns but only emits an `LLVM_DEBUG` message and still returns `Success`. This patch returns `Fail` instead, so `getInstruction()` never reports a size
that isn't a valid instruction length.