### PR TITLE
[LLVM][Verifier] Fix buffer overflow when verifying gc.statepoint

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -4372,9 +4372,15 @@ void AssemblyWriter::printInstructionLine(const Instruction &I) {
 /// intrinsic indicating base and derived pointer names.
 void AssemblyWriter::printGCRelocateComment(const GCRelocateInst &Relocate) {
   Out << " ; (";
-  writeOperand(Relocate.getBasePtr(), false);
+  if (Value *BasePtr = Relocate.getBasePtr())
+    writeOperand(BasePtr, false);
+  else
+    Out << "invalid";
   Out << ", ";
-  writeOperand(Relocate.getDerivedPtr(), false);
+  if (Value *DerivedPtr = Relocate.getDerivedPtr())
+    writeOperand(DerivedPtr, false);
+  else
+    Out << "invalid";
   Out << ")";
 }
 

--- a/llvm/lib/IR/IntrinsicInst.cpp
+++ b/llvm/lib/IR/IntrinsicInst.cpp
@@ -867,10 +867,16 @@ Value *GCRelocateInst::getBasePtr() const {
   auto Statepoint = getStatepoint();
   if (isa<UndefValue>(Statepoint))
     return UndefValue::get(Statepoint->getType());
-
+  // Handle too few (bundle) arguments to avoid crashes when printing invalid
+  // IR, e.g. in the verifier.
   auto *GCInst = cast<GCStatepointInst>(Statepoint);
-  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live))
+  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live)) {
+    if (getBasePtrIndex() > Opt->Inputs.size())
+      return nullptr;
     return *(Opt->Inputs.begin() + getBasePtrIndex());
+  }
+  if (getBasePtrIndex() > GCInst->arg_size())
+    return nullptr;
   return *(GCInst->arg_begin() + getBasePtrIndex());
 }
 
@@ -879,9 +885,16 @@ Value *GCRelocateInst::getDerivedPtr() const {
   if (isa<UndefValue>(Statepoint))
     return UndefValue::get(Statepoint->getType());
 
+  // Handle too few (bundle) arguments to avoid crashes when printing invalid
+  // IR, e.g. in the verifier.
   auto *GCInst = cast<GCStatepointInst>(Statepoint);
-  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live))
+  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live)) {
+    if (getDerivedPtrIndex() > Opt->Inputs.size())
+      return nullptr;
     return *(Opt->Inputs.begin() + getDerivedPtrIndex());
+  }
+  if (getDerivedPtrIndex() > GCInst->arg_size())
+    return nullptr;
   return *(GCInst->arg_begin() + getDerivedPtrIndex());
 }
 

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -6421,10 +6421,12 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
       break;
     if (auto Opt = cast<GCStatepointInst>(StatepointCall)
                        .getOperandBundle(LLVMContext::OB_gc_live)) {
+      // Avoid printing extra information as that would cause the Base or
+      // Derived pointers to get read, causing an out-of-bounds access.
       Check(BaseIndex < Opt->Inputs.size(),
-            "gc.relocate: statepoint base index out of bounds", Call);
+            "gc.relocate: statepoint base index out of bounds");
       Check(DerivedIndex < Opt->Inputs.size(),
-            "gc.relocate: statepoint derived index out of bounds", Call);
+            "gc.relocate: statepoint derived index out of bounds");
     }
 
     // Relocated value must be either a pointer type or vector-of-pointer type,

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -6421,12 +6421,10 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
       break;
     if (auto Opt = cast<GCStatepointInst>(StatepointCall)
                        .getOperandBundle(LLVMContext::OB_gc_live)) {
-      // Avoid printing extra information as that would cause the Base or
-      // Derived pointers to get read, causing an out-of-bounds access.
       Check(BaseIndex < Opt->Inputs.size(),
-            "gc.relocate: statepoint base index out of bounds");
+            "gc.relocate: statepoint base index out of bounds", Call);
       Check(DerivedIndex < Opt->Inputs.size(),
-            "gc.relocate: statepoint derived index out of bounds");
+            "gc.relocate: statepoint derived index out of bounds", Call);
     }
 
     // Relocated value must be either a pointer type or vector-of-pointer type,

--- a/llvm/test/Verifier/gc_relocate_out_of_bounds.ll
+++ b/llvm/test/Verifier/gc_relocate_out_of_bounds.ll
@@ -17,3 +17,19 @@ entry:
   %reloc = call ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token %safepoint_token,  i32 0, i32 1)
   ret ptr addrspace(1) %reloc
 }
+
+; CHECK: gc.relocate: statepoint base index out of bounds
+define ptr addrspace(1) @test3(ptr addrspace(1) %a) gc "statepoint-example" {
+entry:
+  %safepoint_token = tail call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 0, i32 0, ptr elementtype(void ()) @foo, i32 0, i32 0, i32 0, i32 0) ["gc-live" (ptr addrspace(1) %a)]
+  %reloc = call ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token %safepoint_token,  i32 -1, i32 0)
+  ret ptr addrspace(1) %reloc
+}
+
+; CHECK: gc.relocate: statepoint derived index out of bounds
+define ptr addrspace(1) @test4(ptr addrspace(1) %a) gc "statepoint-example" {
+entry:
+  %safepoint_token = tail call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 0, i32 0, ptr elementtype(void ()) @foo, i32 0, i32 0, i32 0, i32 0) ["gc-live" (ptr addrspace(1) %a)]
+  %reloc = call ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token %safepoint_token,  i32 0, i32 -1)
+  ret ptr addrspace(1) %reloc
+}


### PR DESCRIPTION
When a negative base index is passed, the verification detects the out-of-bounds value and start printing information that helps to identify what caused the error. In order to print all the information, it tries to dereference the Base pointer at
GCRelocateInst::getBasePtr(), causing the buffer overflow. Add a bounds check to getBasePTR() and getDerivedPtr() in order to avoid this.

Improve the test in order to validate negative values passed as indexes. They're based on the reproducer from issue #199191.

Fixes #199191