### PR TITLE
[libc++] Add missing <string> include

### DIFF
--- a/libcxx/test/std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp
@@ -16,10 +16,11 @@
 // XFAIL: FROZEN-CXX03-HEADERS-FIXME
 
 #include <locale>
-#include <ios>
 #include <cassert>
+#include <ios>
 #include <limits>
 #include <streambuf>
+#include <string>
 #include "test_macros.h"
 #include "test_iterators.h"
 


### PR DESCRIPTION
Fixes #182390