### PR TITLE
[libc++] Fix assign_range test for forward_list

### DIFF
--- a/libcxx/test/std/containers/sequences/forwardlist/forwardlist.modifiers/assign_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/forwardlist.modifiers/assign_range.pass.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
 // template<container-compatible-range<T> R>
-//   constexpr void prepend_range(R&& rg); // C++23; constexpr since C++26
+//   constexpr void assign_range(R&& rg); // C++23; constexpr since C++26
 
 #include <forward_list>
 
@@ -17,23 +17,23 @@
 #include "test_macros.h"
 
 // Tested cases:
-// - different kinds of insertions (prepending an {empty/one-element/mid-sized/long range} into an
+// - different kinds of assignments (assigning an {empty/one-element/mid-sized/long range} to an
 //   {empty/one-element/full} container);
-// - prepending move-only elements;
+// - assigning move-only elements;
 // - an exception is thrown when copying the elements or when allocating new elements.
 TEST_CONSTEXPR_CXX26 bool test() {
   static_assert(test_constraints_assign_range<std::forward_list, int, double>());
 
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {
-    test_sequence_prepend_range<std::forward_list<int, Alloc>, Iter, Sent>([](auto&&) {
+    test_sequence_assign_range<std::forward_list<int, Alloc>, Iter, Sent>([](auto&&) {
       // No additional validation to do.
     });
   });
-  test_sequence_prepend_range_move_only<std::forward_list>();
+  test_sequence_assign_range_move_only<std::forward_list>();
 
   if (!TEST_IS_CONSTANT_EVALUATED) {
-    test_prepend_range_exception_safety_throwing_copy<std::forward_list>();
-    test_prepend_range_exception_safety_throwing_allocator<std::forward_list, int>();
+    test_assign_range_exception_safety_throwing_copy<std::forward_list>();
+    test_assign_range_exception_safety_throwing_allocator<std::forward_list, int>();
   }
 
   return true;


### PR DESCRIPTION
That test was checking prepend_range instead of assign_range due to a copy-paste error.

Fixes #74536