### PR TITLE
[WebAssembly] Don't use passive segments for bss in coop threads

### DIFF
--- a/lld/test/wasm/cooperative-threading.s
+++ b/lld/test/wasm/cooperative-threading.s
@@ -43,6 +43,20 @@ tls2:
   .int32  2
   .size tls2, 4
 
+.section  .data.bar,"",@
+.globl  bar
+.p2align  2
+bar:
+  .int32  42
+  .size bar, 4
+
+.section  .bss.foo,"",@
+.globl  foo
+.p2align  2
+foo:
+  .int32  0
+  .size foo, 4
+
 .section  .custom_section.target_features,"",@
   .int8 2
   .int8 43
@@ -58,6 +72,24 @@ tls2:
 # CHECK-NEXT:     - Minimum:         0x2
 # CHECK-NOT:       Shared
 
+# Only TLS needs a passive data segment; .data stays active and .bss gets no
+# segment at all since memory is only instantiated once and starts zeroed.
+# CHECK:        - Type:            DATACOUNT
+# CHECK-NEXT:     Count:           2
+
+# CHECK:        - Type:            DATA{{$}}
+# CHECK-NEXT:     Segments:
+# CHECK-NEXT:       - SectionOffset:   3
+# CHECK-NEXT:         InitFlags:       1
+# CHECK-NEXT:         Content:         '0100000002000000'
+# CHECK-NEXT:       - SectionOffset:   18
+# CHECK-NEXT:         InitFlags:       0
+# CHECK-NEXT:         Offset:
+# CHECK-NEXT:           Opcode:          I32_CONST
+# CHECK-NEXT:           Value:           {{[0-9]+}}
+# CHECK-NEXT:         Content:         2A000000
+# CHECK-NEXT:   - Type:            CUSTOM
+
 # Globals should use the libcall ABI naming, not the global ABI.
 # CHECK:      GlobalNames:
 # CHECK-NEXT:      - Index:           0
@@ -70,6 +102,9 @@ tls2:
 # CHECK-NEXT:        Name:            __tls_align
 
 # DIS-LABEL: <__wasm_init_memory>:
+# DIS:         memory.init     0, 0
+# DIS-NOT:     memory.fill
+# DIS-NOT:     memory.init
 
 # DIS-LABEL: <_start>:
 # DIS-EMPTY:

--- a/lld/wasm/Writer.cpp
+++ b/lld/wasm/Writer.cpp
@@ -1058,14 +1058,11 @@ OutputSegment *Writer::createOutputSegment(StringRef name) {
   OutputSegment *s = make<OutputSegment>(name);
   // In the shared memory case, all data segments must be passive since they
   // will be initialized once by the main thread and then shared with other
-  // threads. In the cooperative threading case, TLS segments must be passive
-  // so they can be re-initialized per-thread via memory.init, and .bss
-  // segments are passive to avoid serializing their zero bytes into the binary;
-  // they are still present as passive segment entries and zero-filled via
-  // memory.fill in __wasm_init_memory.
+  // threads. In the cooperative threading case, TLS segments need to exist to
+  // be able to run TLS initialization on spawned threads, so that's managed
+  // here by flagging TLS as passive as well.
   bool needsPassiveInit =
-      ctx.arg.sharedMemory || (ctx.arg.cooperativeThreading &&
-                               (s->isTLS() || s->name.starts_with(".bss")));
+      ctx.arg.sharedMemory || (ctx.arg.cooperativeThreading && s->isTLS());
   if (needsPassiveInit)
     s->initFlags = WASM_DATA_SEGMENT_IS_PASSIVE;
   if (!ctx.arg.relocatable && name.starts_with(".bss"))


### PR DESCRIPTION
This commit is an update to `wasm-ld`'s behavior with bss data segments with `--cooperative-threading`. Previously bss segments were forced to become passive data segments meaning that a `start` function was emitted with a `memory.fill` that set the required region of memory to 0. This isn't required for coop threads though because the module is only instantiated once and the default pattern for memory is 0, so only special treatment of TLS segments are required.