### PR TITLE
[lldb] Remove unused AnyMatches functions from DataFormatters

### DIFF
--- a/lldb/include/lldb/DataFormatters/DataVisualization.h
+++ b/lldb/include/lldb/DataFormatters/DataVisualization.h
@@ -50,13 +50,6 @@ public:
   static lldb::SyntheticChildrenSP
   GetSyntheticChildren(ValueObject &valobj, lldb::DynamicValueType use_dynamic);
 
-  static bool
-  AnyMatches(const FormattersMatchCandidate &candidate_type,
-             TypeCategoryImpl::FormatCategoryItems items =
-                 TypeCategoryImpl::ALL_ITEM_TYPES,
-             bool only_enabled = true, const char **matching_category = nullptr,
-             TypeCategoryImpl::FormatCategoryItems *matching_type = nullptr);
-
   class NamedSummaryFormats {
   public:
     static bool GetSummaryFormat(ConstString type,

--- a/lldb/include/lldb/DataFormatters/FormatManager.h
+++ b/lldb/include/lldb/DataFormatters/FormatManager.h
@@ -120,16 +120,6 @@ public:
   lldb::SyntheticChildrenSP
   GetSyntheticChildren(ValueObject &valobj, lldb::DynamicValueType use_dynamic);
 
-  bool
-  AnyMatches(const FormattersMatchCandidate &candidate_type,
-             TypeCategoryImpl::FormatCategoryItems items =
-                 TypeCategoryImpl::ALL_ITEM_TYPES,
-             bool only_enabled = true, const char **matching_category = nullptr,
-             TypeCategoryImpl::FormatCategoryItems *matching_type = nullptr) {
-    return m_categories_map.AnyMatches(candidate_type, items, only_enabled,
-                                       matching_category, matching_type);
-  }
-
   static bool GetFormatFromCString(const char *format_cstr,
                                    lldb::Format &format);
 

--- a/lldb/include/lldb/DataFormatters/TypeCategoryMap.h
+++ b/lldb/include/lldb/DataFormatters/TypeCategoryMap.h
@@ -65,13 +65,6 @@ public:
 
   lldb::TypeCategoryImplSP GetAtIndex(uint32_t);
 
-  bool
-  AnyMatches(const FormattersMatchCandidate &candidate_type,
-             TypeCategoryImpl::FormatCategoryItems items =
-                 TypeCategoryImpl::ALL_ITEM_TYPES,
-             bool only_enabled = true, const char **matching_category = nullptr,
-             TypeCategoryImpl::FormatCategoryItems *matching_type = nullptr);
-
   uint32_t GetCount() { return m_map.size(); }
 
   template <typename ImplSP> void Get(FormattersMatchData &, ImplSP &);

--- a/lldb/source/DataFormatters/DataVisualization.cpp
+++ b/lldb/source/DataFormatters/DataVisualization.cpp
@@ -65,15 +65,6 @@ DataVisualization::GetSyntheticForType(lldb::TypeNameSpecifierImplSP type_sp) {
   return GetFormatManager().GetSyntheticForType(type_sp);
 }
 
-bool DataVisualization::AnyMatches(
-    const FormattersMatchCandidate &candidate_type,
-    TypeCategoryImpl::FormatCategoryItems items, bool only_enabled,
-    const char **matching_category,
-    TypeCategoryImpl::FormatCategoryItems *matching_type) {
-  return GetFormatManager().AnyMatches(candidate_type, items, only_enabled,
-                                       matching_category, matching_type);
-}
-
 bool DataVisualization::Categories::GetCategory(ConstString category,
                                                 lldb::TypeCategoryImplSP &entry,
                                                 bool allow_create) {

--- a/lldb/source/DataFormatters/TypeCategoryMap.cpp
+++ b/lldb/source/DataFormatters/TypeCategoryMap.cpp
@@ -158,22 +158,6 @@ bool TypeCategoryMap::Get(KeyType name, TypeCategoryImplSP &entry) {
   return true;
 }
 
-bool TypeCategoryMap::AnyMatches(
-    const FormattersMatchCandidate &candidate_type,
-    TypeCategoryImpl::FormatCategoryItems items, bool only_enabled,
-    const char **matching_category,
-    TypeCategoryImpl::FormatCategoryItems *matching_type) {
-  std::lock_guard<std::recursive_mutex> guard(m_map_mutex);
-
-  MapIterator pos, end = m_map.end();
-  for (pos = m_map.begin(); pos != end; pos++) {
-    if (pos->second->AnyMatches(candidate_type, items, only_enabled,
-                                matching_category, matching_type))
-      return true;
-  }
-  return false;
-}
-
 template <typename ImplSP>
 void TypeCategoryMap::Get(FormattersMatchData &match_data, ImplSP &retval) {
   std::lock_guard<std::recursive_mutex> guard(m_map_mutex);


### PR DESCRIPTION
The only `AnyMatches` function actually used is in TypeCategoryImpl and TieredFormatterContainer.