### PR TITLE
[MLIR] Add missing MLIRPass dep when DMLIR_ENABLE_PDL_IN_PATTERNMATCH=OFF used (NFC)

### DIFF
--- a/mlir/lib/Transforms/Utils/CMakeLists.txt
+++ b/mlir/lib/Transforms/Utils/CMakeLists.txt
@@ -24,4 +24,5 @@ add_mlir_library(MLIRTransformUtils
   MLIRSideEffectInterfaces
   MLIRSubsetOpInterface
   MLIRRewrite
+  MLIRPass
   )


### PR DESCRIPTION
When  PDL dialect is disabled during build stage (`DMLIR_ENABLE_PDL_IN_PATTERNMATCH=OFF`) we got a compiler errors due to some of pdl deps transitively includes `MLIRPass` but without PDL this dep missing and lead to compile errors