### PR TITLE
[AMDGPU][SDAG] Expand divergent s_bitreplicate to VALU

### DIFF
--- a/clang/include/clang/Basic/BuiltinsAMDGPUDocs.td
+++ b/clang/include/clang/Basic/BuiltinsAMDGPUDocs.td
@@ -707,7 +707,7 @@ def DocSBitReplicate : Documentation {
   let Content = [{
 Replicates each bit of the 32-bit ``src`` operand into two adjacent bits of a
 64-bit result. Bit ``i`` of the input is copied to bits ``2*i`` and ``2*i+1``
-of the output. The operand must be uniform across the wavefront. A divergent
-value gives an undefined result.
+of the output. A uniform operand lowers to ``s_bitreplicate_b64_b32``. A
+divergent operand is expanded to an equivalent VALU sequence.
 }];
 }

--- a/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
+++ b/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
@@ -2473,8 +2473,8 @@ def int_amdgcn_inverse_ballot :
   Intrinsic<[llvm_i1_ty], [llvm_anyint_ty],
             [IntrNoMem, IntrConvergent, IntrWillReturn, IntrNoCallback, IntrNoFree, IntrNoCreateUndefOrPoison]>;
 
-// Lowers to S_BITREPLICATE_B64_B32.
-// The argument must be uniform; otherwise, the result is undefined.
+// Lowers to S_BITREPLICATE_B64_B32 for a uniform argument. A divergent
+// argument is expanded to an equivalent VALU sequence.
 def int_amdgcn_s_bitreplicate :
   ClangBuiltin<"__builtin_amdgcn_s_bitreplicate">,
   DefaultAttrsIntrinsic<[llvm_i64_ty], [llvm_i32_ty], [IntrNoMem, IntrConvergent]>;

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -11352,6 +11352,64 @@ SDValue SITargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
   }
   case Intrinsic::amdgcn_wave_shuffle:
     return lowerWaveShuffle(*this, Op.getNode(), DAG);
+  case Intrinsic::amdgcn_s_bitreplicate: {
+    // A uniform argument selects the scalar SOP1 instruction. Expand a
+    // divergent argument to VALU so each lane gets its own result.
+    if (!Op->isDivergent())
+      return SDValue();
+
+    const SIInstrInfo *TII = getSubtarget()->getInstrInfo();
+    if (TII->pseudoToMCOpcode(AMDGPU::V_PERM_B32_e64) == -1)
+      return SDValue();
+
+    // Lower divergent s_bitreplicate (bit i -> bits 2i, 2i+1) to VALU by
+    // splitting into two 16-bit halves and spreading bits via:
+    //   lo = v_perm_b32(0, src, 0x0C010C00)   // [00][B1][00][B0]
+    //   hi = v_perm_b32(0, src, 0x0C030C02)   // [00][B3][00][B2]
+    //   M4 = (x | (x << 4)) & 0x0F0F0F0F      // 4-bit spread
+    //   M2 = (M4 | (M4 << 2)) & 0x33333333    // 2-bit spread
+    //   M1 = (M2 | (M2 << 1)) & 0x55555555    // 1-bit spread
+    //   R  = M1 | (M1 << 1)                   // duplicate each bit
+    SDValue Src = Op.getOperand(1);
+    SDValue Zero = DAG.getConstant(0, DL, MVT::i32);
+    // v_perm_b32 splits the input into 16-bit halves and spreads each half's
+    // bytes with zero-byte gaps in one instruction. Selector byte values:
+    // 0x00 to 0x03 = src byte N, 0x0C = zero byte
+    // e.g. 0x134C3A92 -> Hi: [0013][004C], Lo: [003A][0092]
+    SDValue LoByteSpread =
+        DAG.getNode(AMDGPUISD::PERM, DL, MVT::i32, Zero, Src,
+                    DAG.getConstant(0x0C010C00, DL, MVT::i32));
+    SDValue HiByteSpread =
+        DAG.getNode(AMDGPUISD::PERM, DL, MVT::i32, Zero, Src,
+                    DAG.getConstant(0x0C030C02, DL, MVT::i32));
+
+    // Spread masks: each keeps the low N bits of every 2N-bit group, clearing
+    // the garbage left by the shift+OR.
+    auto Spread = [&](SDValue In) -> SDValue {
+      auto SpreadStep = [&](SDValue X, unsigned ShAmt, uint32_t Mask) {
+        SDValue Sh = DAG.getNode(ISD::SHL, DL, MVT::i32, X,
+                                 DAG.getConstant(ShAmt, DL, MVT::i32));
+        SDValue Or = DAG.getNode(ISD::OR, DL, MVT::i32, X, Sh);
+        return DAG.getNode(ISD::AND, DL, MVT::i32, Or,
+                           DAG.getConstant(Mask, DL, MVT::i32));
+      };
+      // 4-bit spread: separate each byte into its two 4-bit halves.
+      // e.g. [003A][0092] -> [03][0A][09][02]
+      SDValue M4 = SpreadStep(In, 4, 0x0F0F0F0F);
+      // 2-bit spread: separate each 4-bit group into two 2-bit pairs.
+      SDValue M2 = SpreadStep(M4, 2, 0x33333333);
+      // 1-bit spread: separate each 2-bit pair into individual bits.
+      SDValue M1 = SpreadStep(M2, 1, 0x55555555);
+      // Duplicate: double each isolated bit.
+      SDValue Dup = DAG.getNode(ISD::SHL, DL, MVT::i32, M1,
+                                DAG.getConstant(1, DL, MVT::i32));
+      return DAG.getNode(ISD::OR, DL, MVT::i32, M1, Dup);
+    };
+
+    SDValue Lo = Spread(LoByteSpread);
+    SDValue Hi = Spread(HiByteSpread);
+    return DAG.getNode(ISD::BUILD_PAIR, DL, MVT::i64, Lo, Hi);
+  }
   default:
     if (const AMDGPU::ImageDimIntrinsicInfo *ImageDimIntr =
             AMDGPU::getImageDimIntrinsicInfo(IntrinsicID))

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.bitreplicate.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.bitreplicate.ll
@@ -79,11 +79,83 @@ define i64 @test_s_bitreplicate_vgpr(i32 %mask) {
 ; GFX11-LABEL: test_s_bitreplicate_vgpr:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX11-NEXT:    s_bitreplicate_b64_b32 s[0:1], s0
-; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX11-NEXT:    v_perm_b32 v1, 0, v0, 0xc010c00
+; GFX11-NEXT:    v_perm_b32 v0, 0, v0, 0xc030c02
+; GFX11-NEXT:    v_lshl_or_b32 v1, v1, 4, v1
+; GFX11-NEXT:    v_lshl_or_b32 v0, v0, 4, v0
+; GFX11-NEXT:    v_and_b32_e32 v1, 0xf0f0f0f, v1
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xf0f0f0f, v0
+; GFX11-NEXT:    v_lshl_or_b32 v1, v1, 2, v1
+; GFX11-NEXT:    v_lshl_or_b32 v0, v0, 2, v0
+; GFX11-NEXT:    v_and_b32_e32 v1, 0x33333333, v1
+; GFX11-NEXT:    v_and_b32_e32 v0, 0x33333333, v0
+; GFX11-NEXT:    v_lshl_or_b32 v1, v1, 1, v1
+; GFX11-NEXT:    v_lshl_or_b32 v0, v0, 1, v0
+; GFX11-NEXT:    v_and_b32_e32 v1, 0x55555555, v1
+; GFX11-NEXT:    v_and_b32_e32 v2, 0x55555555, v0
+; GFX11-NEXT:    v_lshl_or_b32 v0, v1, 1, v1
+; GFX11-NEXT:    v_lshl_or_b32 v1, v2, 1, v2
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 entry:
   %br = call i64 @llvm.amdgcn.s.bitreplicate(i32 %mask)
   ret i64 %br
+}
+
+define amdgpu_cs void @test_s_bitreplicate_vgpr_store(i32 %mask, ptr addrspace(1) %out) {
+; GFX11-LABEL: test_s_bitreplicate_vgpr_store:
+; GFX11:       ; %bb.0: ; %entry
+; GFX11-NEXT:    v_perm_b32 v3, 0, v0, 0xc030c02
+; GFX11-NEXT:    v_perm_b32 v0, 0, v0, 0xc010c00
+; GFX11-NEXT:    v_lshl_or_b32 v3, v3, 4, v3
+; GFX11-NEXT:    v_lshl_or_b32 v0, v0, 4, v0
+; GFX11-NEXT:    v_and_b32_e32 v3, 0xf0f0f0f, v3
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xf0f0f0f, v0
+; GFX11-NEXT:    v_lshl_or_b32 v3, v3, 2, v3
+; GFX11-NEXT:    v_lshl_or_b32 v0, v0, 2, v0
+; GFX11-NEXT:    v_and_b32_e32 v3, 0x33333333, v3
+; GFX11-NEXT:    v_and_b32_e32 v0, 0x33333333, v0
+; GFX11-NEXT:    v_lshl_or_b32 v3, v3, 1, v3
+; GFX11-NEXT:    v_lshl_or_b32 v0, v0, 1, v0
+; GFX11-NEXT:    v_and_b32_e32 v3, 0x55555555, v3
+; GFX11-NEXT:    v_and_b32_e32 v0, 0x55555555, v0
+; GFX11-NEXT:    v_lshl_or_b32 v4, v3, 1, v3
+; GFX11-NEXT:    v_lshl_or_b32 v3, v0, 1, v0
+; GFX11-NEXT:    global_store_b64 v[1:2], v[3:4], off
+; GFX11-NEXT:    s_endpgm
+entry:
+  %br = call i64 @llvm.amdgcn.s.bitreplicate(i32 %mask)
+  store i64 %br, ptr addrspace(1) %out
+  ret void
+}
+
+define i64 @test_s_bitreplicate_vgpr_multi_use(i32 %mask) {
+; GFX11-LABEL: test_s_bitreplicate_vgpr_multi_use:
+; GFX11:       ; %bb.0: ; %entry
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_perm_b32 v1, 0, v0, 0xc030c02
+; GFX11-NEXT:    v_perm_b32 v0, 0, v0, 0xc010c00
+; GFX11-NEXT:    v_lshl_or_b32 v1, v1, 4, v1
+; GFX11-NEXT:    v_lshl_or_b32 v0, v0, 4, v0
+; GFX11-NEXT:    v_and_b32_e32 v1, 0xf0f0f0f, v1
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xf0f0f0f, v0
+; GFX11-NEXT:    v_lshl_or_b32 v1, v1, 2, v1
+; GFX11-NEXT:    v_lshl_or_b32 v0, v0, 2, v0
+; GFX11-NEXT:    v_and_b32_e32 v1, 0x33333333, v1
+; GFX11-NEXT:    v_and_b32_e32 v0, 0x33333333, v0
+; GFX11-NEXT:    v_lshl_or_b32 v1, v1, 1, v1
+; GFX11-NEXT:    v_lshl_or_b32 v0, v0, 1, v0
+; GFX11-NEXT:    v_and_b32_e32 v1, 0x55555555, v1
+; GFX11-NEXT:    v_and_b32_e32 v0, 0x55555555, v0
+; GFX11-NEXT:    v_lshl_or_b32 v1, v1, 1, v1
+; GFX11-NEXT:    v_lshl_or_b32 v0, v0, 1, v0
+; GFX11-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_add_nc_u32 v0, v0, v1
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+entry:
+  %br = call i64 @llvm.amdgcn.s.bitreplicate(i32 %mask)
+  %lo = trunc i64 %br to i32
+  %hi = lshr i64 %br, 32
+  %hi32 = trunc i64 %hi to i32
+  %sum = add i32 %lo, %hi32
+  %result = zext i32 %sum to i64
+  ret i64 %result
 }


### PR DESCRIPTION
Expand divergent s_bitreplicate to a series of VALU instructions. Based on https://github.com/llvm/llvm-project/pull/189138. Execution test case: https://github.com/llvm/llvm-test-suite/pull/435

Assisted by: Claude Opus 4.8