### PR TITLE
[BOLT] Match instrument-funcs-file entries against restored names

### DIFF
--- a/bolt/docs/CommandLineArgumentReference.md
+++ b/bolt/docs/CommandLineArgumentReference.md
@@ -244,6 +244,13 @@
 
   Run retpoline insertion pass
 
+- `--instrument-funcs-file-no-regex`
+
+  File with list of functions to instrument (non-regex). If local function is
+  specified with original mangled name, i.e., no suffix of `/n` or `/file/n`
+  is added, BOLT will instrument all the local functions whose original mangled
+  names match the specified name.
+
 - `--keep-aranges`
 
   Keep or generate .debug_aranges section if .gdb_index is written

--- a/bolt/lib/Passes/Instrumentation.cpp
+++ b/bolt/lib/Passes/Instrumentation.cpp
@@ -79,11 +79,9 @@ cl::opt<bool> InstrumentationWaitForks(
              "(use with instrumentation-sleep-time option)"),
     cl::init(false), cl::Optional, cl::cat(BoltInstrCategory));
 
-cl::opt<std::string> InstrumentFuncsFile(
-    "instrument-funcs-file",
-    cl::desc("file with list of function names (one per line) to instrument; "
-             "only functions whose name exactly matches a line in this file "
-             "will be instrumented"),
+cl::opt<std::string> InstrumentFuncsFileNR(
+    "instrument-funcs-file-no-regex",
+    cl::desc("file with list of functions to instrument (non-regex)"),
     cl::Optional, cl::cat(BoltInstrCategory));
 
 cl::opt<bool>
@@ -653,14 +651,14 @@ Error Instrumentation::runOnFunctions(BinaryContext &BC) {
 
   createAuxiliaryFunctions(BC);
 
-  const bool HasInstrumentFuncsFilter = !opts::InstrumentFuncsFile.empty();
+  const bool HasInstrumentFuncsFilter = !opts::InstrumentFuncsFileNR.empty();
   StringSet<> InstrumentFuncsSet;
   if (HasInstrumentFuncsFilter) {
-    std::ifstream FuncsFile(opts::InstrumentFuncsFile, std::ios::in);
+    std::ifstream FuncsFile(opts::InstrumentFuncsFileNR, std::ios::in);
     if (!FuncsFile)
-      return createFatalBOLTError(Twine("instrument-funcs-file \"") +
-                                  Twine(opts::InstrumentFuncsFile) +
-                                  Twine("\" can't be opened."));
+      return createFatalBOLTError(
+          Twine("instrument-funcs-file-no-regex \"") +
+          Twine(opts::InstrumentFuncsFileNR) + Twine("\" can't be opened."));
     std::string FuncName;
     while (std::getline(FuncsFile, FuncName))
       if (!FuncName.empty())

--- a/bolt/lib/Passes/Instrumentation.cpp
+++ b/bolt/lib/Passes/Instrumentation.cpp
@@ -656,9 +656,9 @@ Error Instrumentation::runOnFunctions(BinaryContext &BC) {
   if (HasInstrumentFuncsFilter) {
     std::ifstream FuncsFile(opts::InstrumentFuncsFileNR, std::ios::in);
     if (!FuncsFile)
-      return createFatalBOLTError(
-          Twine("instrument-funcs-file-no-regex \"") +
-          Twine(opts::InstrumentFuncsFileNR) + Twine("\" can't be opened."));
+      return createFatalBOLTError(Twine("instrument-funcs-file-no-regex \"") +
+                                  Twine(opts::InstrumentFuncsFileNR) +
+                                  Twine("\" can't be opened."));
     std::string FuncName;
     while (std::getline(FuncsFile, FuncName))
       if (!FuncName.empty())

--- a/bolt/lib/Passes/Instrumentation.cpp
+++ b/bolt/lib/Passes/Instrumentation.cpp
@@ -14,6 +14,7 @@
 #include "bolt/Core/ParallelUtilities.h"
 #include "bolt/RuntimeLibs/InstrumentationRuntimeLibrary.h"
 #include "bolt/Utils/CommandLineOpts.h"
+#include "bolt/Utils/NameResolver.h"
 #include "bolt/Utils/Utils.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/CommandLine.h"
@@ -674,7 +675,12 @@ Error Instrumentation::runOnFunctions(BinaryContext &BC) {
     if (HasInstrumentFuncsFilter) {
       bool Found = false;
       for (const StringRef Name : BF.getNames()) {
-        if (InstrumentFuncsSet.contains(Name)) {
+        // instrument-funcs-file could specify original mangled function names
+        // and BOLT will append a "/<id>" (or "/<file>/<id2>") suffix to a local
+        // function name. Match against restored (suffix-stripped) name too, so
+        // local functions specified in the file won't be silently skipped.
+        if (InstrumentFuncsSet.contains(Name) ||
+            InstrumentFuncsSet.contains(NameResolver::restore(Name))) {
           Found = true;
           break;
         }

--- a/bolt/test/X86/instrument-funcs-file.s
+++ b/bolt/test/X86/instrument-funcs-file.s
@@ -1,9 +1,11 @@
-# Test --instrument-funcs-file, alone and combined with --instrument-hot-only.
+# Test --instrument-funcs-file-no-regex, alone and combined with
+# --instrument-hot-only.
 #
 # The binary defines three functions (foo, bar, baz). We attach a profile that
-# only marks foo as hot. With --instrument-funcs-file listing foo and bar, only
-# those two are instrumented. Adding --instrument-hot-only further restricts
-# instrumentation to foo (the only function that is both listed and hot).
+# only marks foo as hot. With --instrument-funcs-file-no-regex listing foo and
+# bar, only those two are instrumented. Adding --instrument-hot-only further
+# restricts instrumentation to foo (the only function that is both listed and
+# hot).
 
 # REQUIRES: system-linux,bolt-runtime,target=x86_64-{{.*}}
 
@@ -14,29 +16,31 @@
 # RUN: echo "foo" > %t.funcs
 # RUN: echo "bar" >> %t.funcs
 
-# Test A: only --instrument-funcs-file. Both foo and bar get instrumented.
-# RUN: llvm-bolt --instrument --instrument-funcs-file=%t.funcs \
+# Test A: only --instrument-funcs-file-no-regex. Both foo and bar get
+# instrumented.
+# RUN: llvm-bolt --instrument --instrument-funcs-file-no-regex=%t.funcs \
 # RUN:     -o %t.a.out %t.exe 2>&1 | FileCheck %s --check-prefix=CHECK-A
 
-# Test B: --instrument-funcs-file combined with --instrument-hot-only. Profile
-# marks only foo as hot, so bar is filtered out by --instrument-hot-only.
-# RUN: llvm-bolt --instrument --instrument-funcs-file=%t.funcs \
+# Test B: --instrument-funcs-file-no-regex combined with --instrument-hot-only.
+# Profile marks only foo as hot, so bar is filtered out by
+# --instrument-hot-only.
+# RUN: llvm-bolt --instrument --instrument-funcs-file-no-regex=%t.funcs \
 # RUN:     --instrument-hot-only --data %t.fdata \
 # RUN:     -o %t.b.out %t.exe 2>&1 | FileCheck %s --check-prefix=CHECK-B
 
 # Test C: empty file means "no functions match", so nothing is instrumented.
 # RUN: rm -f %t.empty && touch %t.empty
-# RUN: llvm-bolt --instrument --instrument-funcs-file=%t.empty \
+# RUN: llvm-bolt --instrument --instrument-funcs-file-no-regex=%t.empty \
 # RUN:     -o %t.c.out %t.exe 2>&1 | FileCheck %s --check-prefix=CHECK-C
 
 # Test D: missing file produces a fatal error.
-# RUN: not llvm-bolt --instrument --instrument-funcs-file=%t.missing \
+# RUN: not llvm-bolt --instrument --instrument-funcs-file-no-regex=%t.missing \
 # RUN:     -o %t.d.out %t.exe 2>&1 | FileCheck %s --check-prefix=CHECK-D
 
 # CHECK-A: BOLT-INSTRUMENTER: Number of function descriptors: 2
 # CHECK-B: BOLT-INSTRUMENTER: Number of function descriptors: 1
 # CHECK-C: BOLT-INSTRUMENTER: Number of function descriptors: 0
-# CHECK-D: instrument-funcs-file {{.*}}.missing{{.*}} can't be opened
+# CHECK-D: instrument-funcs-file-no-regex {{.*}}.missing{{.*}} can't be opened
 
     .text
     .globl _start


### PR DESCRIPTION
Local symbols are uniquified with a "/<id>" suffix, but instrument-funcs-file usually contains original mangled names. To avoid skipping local functions for instrumentation, we now also match restored names which have suffix (if any) stripped.