### PR TITLE
[lldb] Tighten interface for TypeCategoryImpl::AnyMatches

### DIFF
--- a/lldb/include/lldb/DataFormatters/TypeCategory.h
+++ b/lldb/include/lldb/DataFormatters/TypeCategory.h
@@ -347,10 +347,7 @@ public:
   std::string GetDescription();
 
   bool AnyMatches(const FormattersMatchCandidate &candidate_type,
-                  FormatCategoryItems items = ALL_ITEM_TYPES,
-                  bool only_enabled = true,
-                  const char **matching_category = nullptr,
-                  FormatCategoryItems *matching_type = nullptr);
+                  FormatCategoryItems items = ALL_ITEM_TYPES);
 
   void AutoComplete(CompletionRequest &request, FormatCategoryItems items);
 

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -2259,8 +2259,7 @@ bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
     // name-based lookup here to try to prevent conflicts.
     FormattersMatchCandidate candidate_type(type_name, nullptr, TypeImpl(),
                                             FormattersMatchCandidate::Flags());
-    if (category->AnyMatches(candidate_type, eFormatCategoryItemFilter,
-                             false)) {
+    if (category->AnyMatches(candidate_type, eFormatCategoryItemFilter)) {
       if (error)
         *error = Status::FromErrorStringWithFormatv(
             "cannot add synthetic for type {0} when "
@@ -2401,8 +2400,7 @@ private:
       FormattersMatchCandidate candidate_type(
           type_name, nullptr, TypeImpl(), FormattersMatchCandidate::Flags());
       lldb::SyntheticChildrenSP entry;
-      if (category->AnyMatches(candidate_type, eFormatCategoryItemSynth,
-                               false)) {
+      if (category->AnyMatches(candidate_type, eFormatCategoryItemSynth)) {
         if (error)
           *error = Status::FromErrorStringWithFormatv(
               "cannot add filter for type {0} when "

--- a/lldb/source/DataFormatters/TypeCategory.cpp
+++ b/lldb/source/DataFormatters/TypeCategory.cpp
@@ -185,48 +185,27 @@ uint32_t TypeCategoryImpl::GetCount(FormatCategoryItems items) {
 }
 
 bool TypeCategoryImpl::AnyMatches(
-    const FormattersMatchCandidate &candidate_type, FormatCategoryItems items,
-    bool only_enabled, const char **matching_category,
-    FormatCategoryItems *matching_type) {
-  if (!IsEnabled() && only_enabled)
-    return false;
-
+    const FormattersMatchCandidate &candidate_type, FormatCategoryItems items) {
   if (items & eFormatCategoryItemFormat) {
     if (m_format_cont.AnyMatches(candidate_type)) {
-      if (matching_category)
-        *matching_category = m_name.GetCString();
-      if (matching_type)
-        *matching_type = eFormatCategoryItemFormat;
       return true;
     }
   }
 
   if (items & eFormatCategoryItemSummary) {
     if (m_summary_cont.AnyMatches(candidate_type)) {
-      if (matching_category)
-        *matching_category = m_name.GetCString();
-      if (matching_type)
-        *matching_type = eFormatCategoryItemSummary;
       return true;
     }
   }
 
   if (items & eFormatCategoryItemFilter) {
     if (m_filter_cont.AnyMatches(candidate_type)) {
-      if (matching_category)
-        *matching_category = m_name.GetCString();
-      if (matching_type)
-        *matching_type = eFormatCategoryItemFilter;
       return true;
     }
   }
 
   if (items & eFormatCategoryItemSynth) {
     if (m_synth_cont.AnyMatches(candidate_type)) {
-      if (matching_category)
-        *matching_category = m_name.GetCString();
-      if (matching_type)
-        *matching_type = eFormatCategoryItemSynth;
       return true;
     }
   }


### PR DESCRIPTION
The last 2 parameters are never actually used by any caller so they can be removed. `only_enabled` defaults to `true` but all callers explicitly set this to false. I removed that and rewrote the body to assume it will always be false.