### PR TITLE
[docs] Enable colon_fence myst extension, fix admonitions

### DIFF
--- a/utils/docs/llvm_sphinx/__init__.py
+++ b/utils/docs/llvm_sphinx/__init__.py
@@ -50,7 +50,7 @@ def common_conf(tags: Tags, markdown=Markdown.ALWAYS) -> Dict[str, Any]:
         else:
             extensions.append("myst_parser")
             source_suffix[".md"] = "markdown"
-    myst_enable_extensions = ["substitution"]
+    myst_enable_extensions = ["substitution", "colon_fence"]
     myst_heading_anchors = 6
     myst_heading_slug_func = "llvm_sphinx.make_slug"
     templates_path = ["_templates"]


### PR DESCRIPTION
The colon_fence myst extension enables triple-colon fences for admonitions, as in:

:::{note}
**Regular** _markdown_ text, not code.
:::

Using triple colon fences for admonition blocks helps markdown editors treat the body as markdown text, rather than fixed-width code with a syntax highlight.

This change fixes a live doc bug in MyFirstTypoFix.md, which uses this admonition style:
https://llvm.org/docs/MyFirstTypoFix.html

Currently ":::{note} The code changes presented" leaks through in the HTML, and this one line change fixes it.