### PR TITLE
[clang-format] Fix OverEmptyLines aligning trailing comments across block boundaries

### DIFF
--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -1033,6 +1033,14 @@ void WhitespaceManager::alignTrailingComments() {
         Newlines = 0;
       }
     }
+    if (NewLineThreshold > 1 && C.Tok->is(BK_Block)) {
+      alignTrailingComments(StartOfSequence, I, MinColumn);
+      MinColumn = 0;
+      MaxColumn = INT_MAX;
+      StartOfSequence = I + 1;
+      Newlines = 0;
+      continue;
+    }
     if (!C.IsTrailingComment)
       continue;
 

--- a/clang/unittests/Format/FormatTestComments.cpp
+++ b/clang/unittests/Format/FormatTestComments.cpp
@@ -3007,6 +3007,42 @@ TEST_F(FormatTestComments, AlignTrailingCommentsAcrossEmptyLines) {
                Style);
 }
 
+TEST_F(FormatTestComments, OverEmptyLinesBreaksAlignmentAtBlockBoundaries) {
+  auto Style = getLLVMStyle();
+  EXPECT_EQ(Style.AlignTrailingComments.Kind, FormatStyle::TCAS_Always);
+  Style.AlignTrailingComments.OverEmptyLines = 3;
+  Style.AllowShortFunctionsOnASingleLine = {};
+
+  verifyNoChange("void f() {\n"
+                 "  int a; /* e */\n"
+                 "}\n"
+                 "/* c */\n"
+                 "void g() {\n"
+                 "  int b;    /* f */\n"
+                 "  int abcd; /* g */\n"
+                 "}",
+                 Style);
+
+  verifyFormat("void f() {\n"
+               "  int a; /* e */\n"
+               "}\n"
+               "void g() {\n"
+               "  int b;    /* f */\n"
+               "  int abcd; /* g */\n"
+               "}",
+               Style);
+
+  verifyFormat("struct A {\n"
+               "  int a; /* e */\n"
+               "};\n"
+               "int i; /* comment */\n"
+               "struct M {\n"
+               "  int b;    /* f */\n"
+               "  int abcd; /* g */\n"
+               "};",
+               Style);
+}
+
 TEST_F(FormatTestComments, AlignTrailingCommentsLeave) {
   FormatStyle Style = getLLVMStyle();
   Style.AlignTrailingComments.Kind = FormatStyle::TCAS_Leave;


### PR DESCRIPTION
Fix `AlignTrailingComments` with `OverEmptyLines` aligning trailing comments across block boundaries (e.g., between two functions or structs). The alignment sequence now breaks at block-type braces (`BK_Block`).

This is an `OverEmptyLines` bug exposed by bae9ddca423145baf0c35e31898b723aa273f85c (#206393).
Fixes https://github.com/llvm/llvm-project/issues/208266 (https://github.com/llvm/llvm-project/issues/208266).

Commit created with the help of kiro-cli.
