### PR TITLE
[RISCV] Don't require splats to have a single use in performReverseEVLCombine.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -19909,14 +19909,14 @@ static SDValue performReverseEVLCombine(SDNode *N,
   SmallVector<SDValue> Worklist = {Op};
   while (!Worklist.empty()) {
     SDValue X = Worklist.pop_back_val();
+    if (DAG.isSplatValue(X))
+      continue;
     if (!X.hasOneUser())
       return SDValue();
     if (auto *VPL = dyn_cast<VPLoadSDNode>(X)) {
       if (VPLoad && VPLoad != VPL)
         return SDValue();
       VPLoad = VPL;
-    } else if (DAG.isSplatValue(X)) {
-      continue;
     } else if (DAG.getTargetLoweringInfo().isBinOp(X.getOpcode()) &&
                X->getNumValues() == 1) {
       append_range(Worklist, X->op_values());

--- a/llvm/test/CodeGen/RISCV/rvv/vp-combine-reverse-load.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vp-combine-reverse-load.ll
@@ -321,20 +321,18 @@ define <vscale x 2 x float> @binop_multiuse(ptr %ptr, i32 zeroext %evl) {
 define <vscale x 2 x float> @binop_shared_splat(ptr %ptr, <vscale x 2 x float> %x, i32 zeroext %evl) {
 ; CHECK-LABEL: binop_shared_splat:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lui a2, 260096
-; CHECK-NEXT:    fmv.w.x fa5, a2
+; CHECK-NEXT:    slli a2, a1, 2
+; CHECK-NEXT:    add a0, a2, a0
+; CHECK-NEXT:    li a2, -4
+; CHECK-NEXT:    addi a0, a0, -4
 ; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
-; CHECK-NEXT:    vid.v v9
-; CHECK-NEXT:    vle32.v v10, (a0)
-; CHECK-NEXT:    addi a0, a1, -1
-; CHECK-NEXT:    vsetvli a2, zero, e32, m1, ta, ma
-; CHECK-NEXT:    vfadd.vf v10, v10, fa5
-; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
-; CHECK-NEXT:    vrsub.vx v9, v9, a0
-; CHECK-NEXT:    vrgather.vv v11, v10, v9
+; CHECK-NEXT:    vlse32.v v9, (a0), a2
+; CHECK-NEXT:    lui a0, 260096
+; CHECK-NEXT:    fmv.w.x fa5, a0
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m1, ta, ma
+; CHECK-NEXT:    vfadd.vf v9, v9, fa5
 ; CHECK-NEXT:    vfadd.vf v8, v8, fa5
-; CHECK-NEXT:    vfadd.vv v8, v11, v8
+; CHECK-NEXT:    vfadd.vv v8, v9, v8
 ; CHECK-NEXT:    ret
   %load = call <vscale x 2 x float> @llvm.vp.load(ptr %ptr, <vscale x 2 x i1> splat (i1 true), i32 %evl)
   %fadd = fadd <vscale x 2 x float> %load, splat (float 1.0)

--- a/llvm/test/CodeGen/RISCV/rvv/vp-combine-reverse-load.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vp-combine-reverse-load.ll
@@ -313,3 +313,35 @@ define <vscale x 2 x float> @binop_multiuse(ptr %ptr, i32 zeroext %evl) {
   %rev = call <vscale x 2 x float> @llvm.experimental.vp.reverse(<vscale x 2 x float> %fadd, <vscale x 2 x i1> splat (i1 true), i32 %evl)
   ret <vscale x 2 x float> %rev
 }
+
+; The splat leaf of the binop feeding vp.reverse is the same constant used by
+; an unrelated binop elsewhere in the function, so the splat_vector node ends
+; up with more than one use. That must not prevent the combine: a shared
+; splat constant is not mutated by the fold, so it should still succeed.
+define <vscale x 2 x float> @binop_shared_splat(ptr %ptr, <vscale x 2 x float> %x, i32 zeroext %evl) {
+; CHECK-LABEL: binop_shared_splat:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a2, 260096
+; CHECK-NEXT:    fmv.w.x fa5, a2
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
+; CHECK-NEXT:    vid.v v9
+; CHECK-NEXT:    vle32.v v10, (a0)
+; CHECK-NEXT:    addi a0, a1, -1
+; CHECK-NEXT:    vsetvli a2, zero, e32, m1, ta, ma
+; CHECK-NEXT:    vfadd.vf v10, v10, fa5
+; CHECK-NEXT:    vsetvli zero, a1, e32, m1, ta, ma
+; CHECK-NEXT:    vrsub.vx v9, v9, a0
+; CHECK-NEXT:    vrgather.vv v11, v10, v9
+; CHECK-NEXT:    vsetvli a0, zero, e32, m1, ta, ma
+; CHECK-NEXT:    vfadd.vf v8, v8, fa5
+; CHECK-NEXT:    vfadd.vv v8, v11, v8
+; CHECK-NEXT:    ret
+  %load = call <vscale x 2 x float> @llvm.vp.load(ptr %ptr, <vscale x 2 x i1> splat (i1 true), i32 %evl)
+  %fadd = fadd <vscale x 2 x float> %load, splat (float 1.0)
+  %rev = call <vscale x 2 x float> @llvm.experimental.vp.reverse(<vscale x 2 x float> %fadd, <vscale x 2 x i1> splat (i1 true), i32 %evl)
+
+  %other = fadd <vscale x 2 x float> %x, splat (float 1.0)
+
+  %sum = fadd <vscale x 2 x float> %rev, %other
+  ret <vscale x 2 x float> %sum
+}


### PR DESCRIPTION
Test was written by Claude