### PR TITLE
[libc][baremetal] expose `malloc_usable_size` from freelist heap

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -254,6 +254,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.llabs
     libc.src.stdlib.lldiv
     libc.src.stdlib.malloc
+    libc.src.stdlib.malloc_usable_size
     libc.src.stdlib.memalignment
     libc.src.stdlib.qsort
     libc.src.stdlib.qsort_r

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -254,6 +254,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.llabs
     libc.src.stdlib.lldiv
     libc.src.stdlib.malloc
+    libc.src.stdlib.malloc_usable_size
     libc.src.stdlib.memalignment
     libc.src.stdlib.qsort
     libc.src.stdlib.qsort_r

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -251,6 +251,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.llabs
     libc.src.stdlib.lldiv
     libc.src.stdlib.malloc
+    libc.src.stdlib.malloc_usable_size
     libc.src.stdlib.memalignment
     libc.src.stdlib.qsort
     libc.src.stdlib.qsort_r

--- a/libc/src/__support/freelist_heap.h
+++ b/libc/src/__support/freelist_heap.h
@@ -50,6 +50,7 @@ public:
   void free(void *ptr);
   void *realloc(void *ptr, size_t size);
   void *calloc(size_t num, size_t size);
+  size_t allocation_size(const void *ptr) const;
 
   cpp::span<cpp::byte> region() const { return {begin, end}; }
 
@@ -64,7 +65,7 @@ private:
 
   bool shrink_in_place(BlockRef block, size_t size);
 
-  bool is_valid_ptr(void *ptr) { return ptr >= begin && ptr < end; }
+  bool is_valid_ptr(const void *ptr) const { return ptr >= begin && ptr < end; }
 
   cpp::byte *begin;
   cpp::byte *end;
@@ -163,6 +164,15 @@ LIBC_INLINE void FreeListHeap::free(void *ptr) {
   }
   // Add back to the freelist
   free_store.insert(block);
+}
+
+LIBC_INLINE size_t FreeListHeap::allocation_size(const void *ptr) const {
+  if (!is_valid_ptr(ptr))
+    return 0;
+  BlockRef block = BlockRef::from_usable_space(ptr);
+  if (!block.used())
+    return 0;
+  return block.inner_size();
 }
 
 LIBC_INLINE bool FreeListHeap::shrink_in_place(BlockRef block, size_t size) {

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -710,6 +710,12 @@ if(LIBC_TARGET_OS_IS_BAREMETAL OR LIBC_TARGET_OS_IS_GPU)
       .${LIBC_TARGET_OS}.malloc
   )
   add_entrypoint_object(
+    malloc_usable_size
+    ALIAS
+    DEPENDS
+      .${LIBC_TARGET_OS}.malloc_usable_size
+  )
+  add_entrypoint_object(
     free
     ALIAS
     DEPENDS

--- a/libc/src/stdlib/baremetal/CMakeLists.txt
+++ b/libc/src/stdlib/baremetal/CMakeLists.txt
@@ -53,3 +53,13 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.freelist_heap
 )
+
+add_entrypoint_object(
+  malloc_usable_size
+  SRCS
+    malloc_usable_size.cpp
+  HDRS
+    ../malloc_usable_size.h
+  DEPENDS
+    libc.src.__support.freelist_heap
+)

--- a/libc/src/stdlib/baremetal/malloc_usable_size.cpp
+++ b/libc/src/stdlib/baremetal/malloc_usable_size.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation for freelist_malloc_usable_size.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/stdlib/malloc_usable_size.h"
+#include "src/__support/freelist_heap.h"
+#include "src/__support/macros/config.h"
+
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(size_t, malloc_usable_size, (void *ptr)) {
+  return freelist_heap->allocation_size(ptr);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/malloc_usable_size.h
+++ b/libc/src/stdlib/malloc_usable_size.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for malloc_usable_size.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+#ifndef LLVM_LIBC_SRC_STDLIB_MALLOC_USABLE_SIZE_H
+#define LLVM_LIBC_SRC_STDLIB_MALLOC_USABLE_SIZE_H
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t malloc_usable_size(void *ptr);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDLIB_MALLOC_USABLE_SIZE_H

--- a/libc/test/src/__support/freelist_heap_test.cpp
+++ b/libc/test/src/__support/freelist_heap_test.cpp
@@ -346,3 +346,23 @@ TEST_FOR_EACH_ALLOCATOR(InvalidAlignedAllocAlignment, 2048) {
   ptr = allocator.aligned_allocate(0, 8);
   EXPECT_EQ(ptr, static_cast<void *>(nullptr));
 }
+
+TEST_FOR_EACH_ALLOCATOR(AllocationSize, 2048) {
+  constexpr size_t ALLOC_SIZE = 256;
+
+  // 1. Null pointer returns 0.
+  EXPECT_EQ(allocator.allocation_size(nullptr), size_t(0));
+
+  // 2. Invalid pointer (outside heap) returns 0.
+  int dummy = 0;
+  EXPECT_EQ(allocator.allocation_size(&dummy), size_t(0));
+
+  // 3. Valid pointer returns >= allocation size.
+  void *ptr = allocator.allocate(ALLOC_SIZE);
+  ASSERT_NE(ptr, static_cast<void *>(nullptr));
+  EXPECT_GE(allocator.allocation_size(ptr), ALLOC_SIZE);
+
+  // 4. Freed pointer returns 0.
+  allocator.free(ptr);
+  EXPECT_EQ(allocator.allocation_size(ptr), size_t(0));
+}


### PR DESCRIPTION
Expose the `malloc_usable_size` API by reconstruct the `BlockRef` from a pointer to the head of user payload. The operation is cheap as we only do a query to the block header to obtain the metadata.

Assisted-by: Gemini based automation tools (human-in-the-loop)