### PR TITLE
[SSAF] Replace std::set with SetVector for deterministic order of contributor Decls

### DIFF
--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
@@ -12,7 +12,7 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/ExprCXX.h"
-#include <set>
+#include "llvm/ADT/SetVector.h"
 
 using namespace clang;
 
@@ -32,7 +32,7 @@ namespace {
 // Traverses the AST and finds contributors.
 class ContributorFinder : public DynamicRecursiveASTVisitor {
 public:
-  std::set<const NamedDecl *> Contributors;
+  llvm::SetVector<const NamedDecl *> Contributors;
 
   ContributorFinder() {
     ShouldVisitTemplateInstantiations = true;

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.h
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.h
@@ -110,9 +110,9 @@ void extractAndAddSummaries(TUSummaryExtractor &Extractor,
   findContributors(Ctx, Contributors);
   for (const auto &[Cano, Decls] : Contributors) {
     assert(!Decls.empty() &&
-           "'findContributors' guarantess that 'Decls' are non-empty");
+           "'findContributors' guarantees that 'Decls' are non-empty");
     assert(!Decls[0]->isImplicit() &&
-           "'findContributors' guarantess that 'Decls' are non-implicit");
+           "'findContributors' guarantees that 'Decls' are non-implicit");
 
     // Templates are skipped, but their instantiations are handled. The idea
     // is that we can conclude facts about a template through all of its


### PR DESCRIPTION
The container `std::set<const NamedDecl *>` created a non-deterministic traversal order for a contributor's `Decls`, making the resulting representative `Decls[0]` non-deterministic as well.

Also fix typos in assertion messages.

Follow-up to #204482.