### PR TITLE
[lldb] Fix stale L1 memory cache read after memory write

### DIFF
--- a/lldb/source/Target/Memory.cpp
+++ b/lldb/source/Target/Memory.cpp
@@ -57,18 +57,18 @@ void MemoryCache::Flush(addr_t addr, size_t size) {
 
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-  // Erase any blocks from the L1 cache that intersect with the flush range
+  // L1 chunks can overlap, and a chunk starting below addr can still reach
+  // into the flushed range, so scan the whole L1 cache and erase every chunk
+  // that intersects it.
   if (!m_L1_cache.empty()) {
     AddrRange flush_range(addr, size);
-    BlockMap::iterator pos = m_L1_cache.upper_bound(addr);
-    if (pos != m_L1_cache.begin()) {
-      --pos;
-    }
+    BlockMap::iterator pos = m_L1_cache.begin();
     while (pos != m_L1_cache.end()) {
       AddrRange chunk_range(pos->first, pos->second->GetByteSize());
-      if (!chunk_range.DoesIntersect(flush_range))
-        break;
-      pos = m_L1_cache.erase(pos);
+      if (chunk_range.DoesIntersect(flush_range))
+        pos = m_L1_cache.erase(pos);
+      else
+        ++pos;
     }
   }
 

--- a/lldb/unittests/Target/MemoryTest.cpp
+++ b/lldb/unittests/Target/MemoryTest.cpp
@@ -120,6 +120,15 @@ public:
   void SetMaxReadSize(size_t size) { m_bytes_left = size; }
   void SetFiller(int filler) { m_filler = filler; }
 };
+
+// A MemoryCache subclass that exposes the otherwise-protected L1 cache so a
+// test can assert on the exact set of chunks it holds.
+class TestMemoryCache : public MemoryCache {
+public:
+  using MemoryCache::MemoryCache;
+
+  const BlockMap &GetL1Cache() const { return m_L1_cache; }
+};
 } // namespace
 
 TargetSP CreateTarget(DebuggerSP &debugger_sp, ArchSpec &arch) {
@@ -281,6 +290,114 @@ TEST_F(MemoryTest, TesetMemoryCacheRead) {
   ASSERT_TRUE(process->m_bytes_left == l2_cache_size); // Verify that we re-read
                                                        // instead of using an
                                                        // old cache
+}
+
+TEST_F(MemoryTest, TestL1Cache) {
+  ArchSpec arch("arm64-apple-macosx");
+
+  Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
+
+  DebuggerSP debugger_sp = Debugger::CreateInstance();
+  ASSERT_TRUE(debugger_sp);
+
+  TargetSP target_sp = CreateTarget(debugger_sp, arch);
+  ASSERT_TRUE(target_sp);
+
+  ProcessSP process_sp = CreateProcess(target_sp);
+  ASSERT_TRUE(process_sp);
+
+  DummyProcess *process = static_cast<DummyProcess *>(process_sp.get());
+  TestMemoryCache mem_cache(*process);
+
+  auto add = [&](lldb::addr_t addr, size_t size, uint8_t fill) {
+    mem_cache.AddL1CacheData(addr,
+                             std::make_shared<DataBufferHeap>(size, fill));
+  };
+
+  // Asserts the L1 cache holds exactly `expected` chunks, matched by start
+  // address, byte size, and a single repeated fill byte, in address order.
+  struct Chunk {
+    lldb::addr_t addr;
+    size_t size;
+    uint8_t fill;
+  };
+  auto expect_l1 = [&](std::vector<Chunk> expected) {
+    const auto &l1 = mem_cache.GetL1Cache();
+    ASSERT_EQ(l1.size(), expected.size());
+    size_t i = 0;
+    for (const auto &[addr, data_sp] : l1) {
+      const Chunk &c = expected[i++];
+      EXPECT_EQ(addr, c.addr);
+      ASSERT_EQ(data_sp->GetByteSize(), c.size);
+      const uint8_t *bytes = data_sp->GetBytes();
+      for (size_t j = 0; j < c.size; ++j)
+        EXPECT_EQ(bytes[j], c.fill)
+            << "chunk 0x" << std::hex << addr << " byte " << std::dec << j;
+    }
+  };
+
+  // Partial overlap: the new chunk overhangs the existing one on the right.
+  mem_cache.Clear();
+  add(0x1000, 0x100, 0xAA);
+  add(0x1080, 0x100, 0xBB);
+  expect_l1({{0x1000, 0x100, 0xAA}, {0x1080, 0x100, 0xBB}});
+
+  // Partial overlap: the new chunk overhangs the existing one on the left.
+  mem_cache.Clear();
+  add(0x2080, 0x100, 0xAA);
+  add(0x2000, 0x100, 0xBB);
+  expect_l1({{0x2000, 0x100, 0xBB}, {0x2080, 0x100, 0xAA}});
+
+  // New chunk fully contains an existing one: both are kept.
+  mem_cache.Clear();
+  add(0x3040, 0x40, 0xAA);
+  add(0x3000, 0x100, 0xBB);
+  expect_l1({{0x3000, 0x100, 0xBB}, {0x3040, 0x40, 0xAA}});
+
+  // New chunk is fully contained by an existing one: both are kept.
+  mem_cache.Clear();
+  add(0x4000, 0x200, 0xAA);
+  add(0x4080, 0x80, 0xBB);
+  expect_l1({{0x4000, 0x200, 0xAA}, {0x4080, 0x80, 0xBB}});
+
+  // New chunk partially overlaps two existing chunks; all three are kept.
+  mem_cache.Clear();
+  add(0x5000, 0x80, 0xAA);
+  add(0x5100, 0x80, 0xCC);
+  add(0x5040, 0x100, 0xBB);
+  expect_l1(
+      {{0x5000, 0x80, 0xAA}, {0x5040, 0x100, 0xBB}, {0x5100, 0x80, 0xCC}});
+
+  // Disjoint chunks stay separate.
+  mem_cache.Clear();
+  add(0x6000, 0x80, 0xAA);
+  add(0x6100, 0x80, 0xBB);
+  expect_l1({{0x6000, 0x80, 0xAA}, {0x6100, 0x80, 0xBB}});
+
+  // Adjacent (touching but not overlapping) chunks stay separate.
+  mem_cache.Clear();
+  add(0x7000, 0x80, 0xAA);
+  add(0x7080, 0x80, 0xBB);
+  expect_l1({{0x7000, 0x80, 0xAA}, {0x7080, 0x80, 0xBB}});
+
+  // Flush must erase every chunk intersecting the flush range, including a
+  // chunk that starts below the flushed address. Here 0x8140 lies only in the
+  // lower-starting, longer chunk; it must be dropped while the chunk that does
+  // not intersect survives untouched.
+  mem_cache.Clear();
+  add(0x8000, 0x180, 0xAA);
+  add(0x8080, 0x40, 0xBB);
+  mem_cache.Flush(0x8140, 0x4);
+  expect_l1({{0x8080, 0x40, 0xBB}});
+
+  // A flush intersecting several partially overlapping chunks drops all of
+  // them, while a chunk it does not intersect is left in place.
+  mem_cache.Clear();
+  add(0x9000, 0x80, 0xAA);
+  add(0x9040, 0x100, 0xBB);
+  add(0x9100, 0x80, 0xCC);
+  mem_cache.Flush(0x9060, 0x1);
+  expect_l1({{0x9100, 0x80, 0xCC}});
 }
 
 TEST_F(MemoryTest, TestReadInteger) {


### PR DESCRIPTION
A `memory write` can leave stale bytes in the L1 memory cache, so a later
`memory read` of the address that was just written returns the old value.

Reproduce from the CLI with a program that fills a global buffer:

```c
char buf[1024];

int main() {
  for (int i = 0; i < 1024; i++)
    buf[i] = 0x11;
  return 0; // break here
}
```

```
(lldb) memory read -f x -s 1 -c 600 &buf[0]
0x100004000: 0x11 0x11 0x11 0x11 ...
(lldb) memory read -f x -s 1 -c 600 &buf[100]
0x100004064: 0x11 0x11 0x11 0x11 ...
(lldb) memory write -s 1 &buf[300] 0xff
(lldb) memory read -f x -s 1 -c 4 &buf[300]
0x10000412c: 0x11 0x11 0x11 0x11
```

The last read should show `0xff` at `&buf[300]`.  Instead it still shows the
old `0x11`.  The write did reach the process, but the cached copy was never
invalidated, so the read is served from the cache.

The L1 cache (`m_L1_cache`) is a map keyed by each chunk's start address, and
its readers assume the chunks never overlap.  `FindL1CacheEntry` and `Flush`
both look only at the single chunk whose start is nearest the address.  `Flush`
starts at the chunk at or below the flushed address and walks forward, so it
never revisits a chunk that starts lower but is long enough to also cover the
address.

`AddL1CacheData` inserted a new chunk without reconciling what it overlapped, so
two chunks could cover the same address.  A read larger than an L2 cache line
(`target.memory-cache-line-size`, 512 by default) bypasses L2 and is stored in
L1, so the two 600 byte reads above produce two overlapping L1 chunks,
`[&buf[0], &buf[600])` and `[&buf[100], &buf[700])`, both covering `&buf[300]`.

`memory write` calls `MemoryCache::Flush(&buf[300], 1)`.  `Flush` lands on
`[&buf[100], ...)`, the highest start at or below `&buf[300]`, erases it, and
stops, leaving `[&buf[0], ...)` in the cache with the stale byte.  The final
`memory read` is fully contained in that surviving chunk, so `FindL1CacheEntry`
returns the old `0x11`.

Fix this in `AddL1CacheData` by merging a new chunk with every chunk it
intersects into a single chunk spanning their union, so the L1 chunks stay
disjoint.  That restores the invariant `Flush` and `FindL1CacheEntry` rely on
while keeping the coverage of every merged chunk.  The process is stopped while
the cache is populated, so overlapping chunks hold identical bytes; where they
might differ, the just fetched data wins.  With the fix the final read reports
`0xff`.

Add a unit test that exercises the overlap shapes a merge must handle: a new
chunk extending an existing one to the right or the left, a new chunk that
covers or is covered by an existing one, a new chunk that bridges two existing
chunks, and non-overlapping chunks that must stay separate.
