### PR TITLE
[libc][baremetal] add an opt-in feature for precise size tracking

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -254,6 +254,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.llabs
     libc.src.stdlib.lldiv
     libc.src.stdlib.malloc
+    libc.src.stdlib.malloc_usable_size
     libc.src.stdlib.memalignment
     libc.src.stdlib.qsort
     libc.src.stdlib.qsort_r

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -254,6 +254,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.llabs
     libc.src.stdlib.lldiv
     libc.src.stdlib.malloc
+    libc.src.stdlib.malloc_usable_size
     libc.src.stdlib.memalignment
     libc.src.stdlib.qsort
     libc.src.stdlib.qsort_r

--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -78,5 +78,11 @@
     "LIBC_CONF_CTYPE_SMALLER_ASCII": {
       "value": true
     }
+  },
+  "freelist_heap": {
+    "LIBC_CONF_FREELISTHEAP_PRECISE_ALLOC_SIZE": {
+      "value": false,
+      "doc": "When enabled, FreeListHeap returns the exact requested allocation size in usable_size / allocation_size rather than the rounded block inner size."
+    }
   }
 }

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -251,6 +251,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.llabs
     libc.src.stdlib.lldiv
     libc.src.stdlib.malloc
+    libc.src.stdlib.malloc_usable_size
     libc.src.stdlib.memalignment
     libc.src.stdlib.qsort
     libc.src.stdlib.qsort_r

--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -190,5 +190,11 @@
       "value": false,
       "doc": "Use the system assert macro for LIBC_ASSERT."
     }
+  },
+  "freelist_heap": {
+    "LIBC_CONF_FREELISTHEAP_PRECISE_ALLOC_SIZE": {
+      "value": false,
+      "doc": "When enabled, FreeListHeap returns the exact requested allocation size in usable_size / allocation_size rather than the rounded block inner size."
+    }
   }
 }

--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -60,6 +60,10 @@ add_header_library(
 )
 
 libc_set_definition(libc_freelist_malloc_size "LIBC_FREELIST_MALLOC_SIZE=${LIBC_CONF_FREELIST_MALLOC_BUFFER_SIZE}")
+set(libc_freelist_compile_options ${libc_freelist_malloc_size})
+if(LIBC_CONF_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+  list(APPEND libc_freelist_compile_options "-DLIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE")
+endif()
 add_object_library(
   freelist_heap
   SRCS
@@ -67,7 +71,7 @@ add_object_library(
   HDRS
     freelist_heap.h
   COMPILE_OPTIONS
-    ${libc_freelist_malloc_size}
+    ${libc_freelist_compile_options}
   DEPENDS
     .block
     .freelist

--- a/libc/src/__support/block.h
+++ b/libc/src/__support/block.h
@@ -102,7 +102,11 @@ class BlockRef {
   // Masks for the contents of the next field.
   static constexpr size_t PREV_FREE_MASK = 1 << 0;
   static constexpr size_t LAST_MASK = 1 << 1;
-  static constexpr size_t SIZE_MASK = ~(PREV_FREE_MASK | LAST_MASK);
+  static constexpr size_t FLAG_MASK = PREV_FREE_MASK | LAST_MASK;
+  static constexpr size_t SIZE_MASK = ~FLAG_MASK;
+#if defined(LIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+  static constexpr size_t SIZE_SHIFT = 2;
+#endif
 
   // Header field offsets. The value at PREV_OFFSET is only meaningful when the
   // PREV_FREE_MASK bit is set in the next field.
@@ -110,6 +114,7 @@ class BlockRef {
   static constexpr size_t NEXT_OFFSET = PREV_OFFSET + sizeof(size_t);
 
 public:
+  static constexpr size_t PREV_FIELD_SIZE = sizeof(size_t);
   static constexpr size_t HEADER_SIZE = NEXT_OFFSET + sizeof(size_t);
 
   // To ensure block sizes have two lower unused bits, ensure usable space is
@@ -158,11 +163,17 @@ public:
   }
 
   /// @returns The total size of the block in bytes, including the header.
-  LIBC_INLINE size_t outer_size() const { return load_next() & SIZE_MASK; }
+  LIBC_INLINE size_t outer_size() const {
+    size_t sz = get_next_size();
+#if defined(LIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+    sz = align_up(sz, MIN_ALIGN);
+#endif
+    return sz;
+  }
 
   LIBC_INLINE static constexpr size_t outer_size(size_t inner_size) {
     // The usable region includes the prev field of the next block.
-    return inner_size - PREV_FIELD_SIZE + HEADER_SIZE;
+    return inner_size + (HEADER_SIZE - PREV_FIELD_SIZE);
   }
 
   /// @returns The number of usable bytes inside the block were it to be
@@ -170,14 +181,18 @@ public:
   LIBC_INLINE size_t inner_size() const {
     if (!next())
       return 0;
+#if defined(LIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+    return inner_size(get_next_size());
+#else
     return inner_size(outer_size());
+#endif
   }
 
   /// @returns The number of usable bytes inside a block with the given outer
   /// size were it to be allocated.
   LIBC_INLINE static constexpr size_t inner_size(size_t outer_size) {
     // The usable region includes the prev field of the next block.
-    return inner_size_free(outer_size) + PREV_FIELD_SIZE;
+    return outer_size - (HEADER_SIZE - PREV_FIELD_SIZE);
   }
 
   /// @returns The number of usable bytes inside the block if it remains free.
@@ -224,17 +239,25 @@ public:
   /// @returns The block immediately after this one, or a null block if this is
   /// the last block.
   LIBC_INLINE BlockRef next() const {
-    size_t next_value = load_next();
-    if (next_value & LAST_MASK)
+    size_t raw_val = load_next_raw();
+    if (raw_val & LAST_MASK)
       return BlockRef();
-    return BlockRef(nonnull_header_ptr() + (next_value & SIZE_MASK));
+    size_t sz = get_next_size();
+#if defined(LIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+    sz = align_up(sz, MIN_ALIGN);
+#endif
+    return BlockRef(nonnull_header_ptr() + sz);
   }
 
   /// @returns The free block immediately before this one, otherwise null.
   LIBC_INLINE BlockRef prev_free() const {
-    if (!(load_next() & PREV_FREE_MASK))
+    if (!(load_next_raw() & PREV_FREE_MASK))
       return BlockRef();
-    return BlockRef(nonnull_header_ptr() - load_prev());
+    size_t sz = get_prev_size();
+#if defined(LIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+    sz = align_up(sz, MIN_ALIGN);
+#endif
+    return BlockRef(nonnull_header_ptr() - sz);
   }
 
   /// @returns Whether the block is unavailable for allocation.
@@ -244,16 +267,46 @@ public:
   LIBC_INLINE void mark_used() const {
     LIBC_ASSERT(next() && "last block is always considered used");
     BlockRef next_block = next();
-    next_block.store_next(next_block.load_next() & ~PREV_FREE_MASK);
+    next_block.store_next_raw(next_block.load_next_raw() & ~PREV_FREE_MASK);
   }
 
   /// Marks this block as free.
   LIBC_INLINE void mark_free() const {
     LIBC_ASSERT(next() && "last block is always considered used");
     BlockRef next_block = next();
-    next_block.store_next(next_block.load_next() | PREV_FREE_MASK);
-    next_block.store_prev(outer_size());
+    next_block.store_next_raw(next_block.load_next_raw() | PREV_FREE_MASK);
+#if defined(LIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+    size_t phys_size = align_up(outer_size(), MIN_ALIGN);
+    set_next_size(phys_size);
+    next_block.set_prev_size(phys_size);
+#else
+    next_block.set_prev_size(outer_size());
+#endif
   }
+
+#if defined(LIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+  LIBC_INLINE void set_next_size(size_t sz) const {
+    store_next_raw((load_next_raw() & FLAG_MASK) | (sz << SIZE_SHIFT));
+  }
+  LIBC_INLINE size_t get_next_size() const {
+    return load_next_raw() >> SIZE_SHIFT;
+  }
+  LIBC_INLINE void set_prev_size(size_t sz) const {
+    store_prev_raw(sz << SIZE_SHIFT);
+  }
+  LIBC_INLINE size_t get_prev_size() const {
+    return load_prev_raw() >> SIZE_SHIFT;
+  }
+#else
+  LIBC_INLINE void set_next_size(size_t sz) const {
+    store_next_raw((load_next_raw() & FLAG_MASK) | sz);
+  }
+  LIBC_INLINE size_t get_next_size() const {
+    return load_next_raw() & SIZE_MASK;
+  }
+  LIBC_INLINE void set_prev_size(size_t sz) const { store_prev_raw(sz); }
+  LIBC_INLINE size_t get_prev_size() const { return load_prev_raw(); }
+#endif
 
   LIBC_INLINE bool is_usable_space_aligned(size_t alignment) const {
     return reinterpret_cast<uintptr_t>(usable_space()) % alignment == 0;
@@ -316,9 +369,6 @@ public:
     return align_down(ptr, usable_space_alignment) - HEADER_SIZE;
   }
 
-  /// Only for testing.
-  static constexpr size_t PREV_FIELD_SIZE = sizeof(size_t);
-
 private:
   /// Construct a block to represent a span of bytes. Overwrites only enough
   /// memory for the block header; the rest of the span is left alone.
@@ -329,7 +379,8 @@ private:
     LIBC_ASSERT(bytes.size() % MIN_ALIGN == 0 &&
                 "block size must be aligned to MIN_ALIGN");
     BlockRef block(bytes.data());
-    block.store_next(bytes.size());
+    block.store_next_raw(0);
+    block.set_next_size(bytes.size());
     return block;
   }
 
@@ -337,7 +388,8 @@ private:
     LIBC_ASSERT(reinterpret_cast<uintptr_t>(start) % alignof(size_t) == 0 &&
                 "block start must be suitably aligned");
     BlockRef last(start);
-    last.store_next(HEADER_SIZE | LAST_MASK);
+    last.store_next_raw(LAST_MASK);
+    last.set_next_size(HEADER_SIZE);
   }
 
   LIBC_INLINE cpp::byte *field_ptr(size_t offset) const {
@@ -373,12 +425,13 @@ private:
   ///   previous block is free.
   /// * If the `last` flag is set, the block is the sentinel last block. It is
   ///   summarily considered used and has no next block.
-  LIBC_INLINE size_t load_next() const { return load_field(NEXT_OFFSET); }
+  LIBC_INLINE size_t load_next_raw() const { return load_field(NEXT_OFFSET); }
+  LIBC_INLINE size_t load_prev_raw() const { return load_field(PREV_OFFSET); }
 
-  LIBC_INLINE void store_prev(size_t value) const {
+  LIBC_INLINE void store_prev_raw(size_t value) const {
     store_field(PREV_OFFSET, value);
   }
-  LIBC_INLINE void store_next(size_t value) const {
+  LIBC_INLINE void store_next_raw(size_t value) const {
     store_field(NEXT_OFFSET, value);
   }
 
@@ -507,7 +560,7 @@ optional<BlockRef> BlockRef::split(size_t new_inner_size,
   bool was_free = !used();
 
   ByteSpan new_region = region().subspan(new_outer_size);
-  store_next((load_next() & ~SIZE_MASK) | new_outer_size);
+  set_next_size(new_outer_size);
 
   BlockRef new_block = as_block(new_region);
   new_block.mark_free();
@@ -525,8 +578,8 @@ bool BlockRef::merge_next() const {
   if (used() || next_block.used())
     return false;
   size_t new_size = outer_size() + next_block.outer_size();
-  store_next((load_next() & ~SIZE_MASK) | new_size);
-  next().store_prev(new_size);
+  set_next_size(new_size);
+  next().set_prev_size(new_size);
   return true;
 }
 

--- a/libc/src/__support/freelist_heap.h
+++ b/libc/src/__support/freelist_heap.h
@@ -50,6 +50,7 @@ public:
   void free(void *ptr);
   void *realloc(void *ptr, size_t size);
   void *calloc(size_t num, size_t size);
+  size_t allocation_size(const void *ptr) const;
 
   cpp::span<cpp::byte> region() const { return {begin, end}; }
 
@@ -64,7 +65,7 @@ private:
 
   bool shrink_in_place(BlockRef block, size_t size);
 
-  bool is_valid_ptr(void *ptr) { return ptr >= begin && ptr < end; }
+  bool is_valid_ptr(const void *ptr) const { return ptr >= begin && ptr < end; }
 
   cpp::byte *begin;
   cpp::byte *end;
@@ -163,6 +164,15 @@ LIBC_INLINE void FreeListHeap::free(void *ptr) {
   }
   // Add back to the freelist
   free_store.insert(block);
+}
+
+LIBC_INLINE size_t FreeListHeap::allocation_size(const void *ptr) const {
+  if (!is_valid_ptr(ptr))
+    return 0;
+  BlockRef block = BlockRef::from_usable_space(ptr);
+  if (!block.used())
+    return 0;
+  return block.inner_size();
 }
 
 LIBC_INLINE bool FreeListHeap::shrink_in_place(BlockRef block, size_t size) {

--- a/libc/src/__support/freelist_heap.h
+++ b/libc/src/__support/freelist_heap.h
@@ -111,6 +111,9 @@ LIBC_INLINE void *FreeListHeap::allocate_impl(size_t alignment, size_t size) {
   if (block_info.prev)
     free_store.insert(block_info.prev);
 
+#if defined(LIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+  block_info.block.set_next_size(BlockRef::outer_size(size));
+#endif
   block_info.block.mark_used();
   return block_info.block.usable_space();
 }

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -710,6 +710,12 @@ if(LIBC_TARGET_OS_IS_BAREMETAL OR LIBC_TARGET_OS_IS_GPU)
       .${LIBC_TARGET_OS}.malloc
   )
   add_entrypoint_object(
+    malloc_usable_size
+    ALIAS
+    DEPENDS
+      .${LIBC_TARGET_OS}.malloc_usable_size
+  )
+  add_entrypoint_object(
     free
     ALIAS
     DEPENDS

--- a/libc/src/stdlib/baremetal/CMakeLists.txt
+++ b/libc/src/stdlib/baremetal/CMakeLists.txt
@@ -53,3 +53,13 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.freelist_heap
 )
+
+add_entrypoint_object(
+  malloc_usable_size
+  SRCS
+    malloc_usable_size.cpp
+  HDRS
+    ../malloc_usable_size.h
+  DEPENDS
+    libc.src.__support.freelist_heap
+)

--- a/libc/src/stdlib/baremetal/CMakeLists.txt
+++ b/libc/src/stdlib/baremetal/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(freelist_entrypoint_compile_options "")
+if(LIBC_CONF_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+  list(APPEND freelist_entrypoint_compile_options "-DLIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE")
+endif()
+
 add_header_library(
   abort_utils
   HDRS
@@ -10,6 +15,8 @@ add_entrypoint_object(
     malloc.cpp
   HDRS
     ../malloc.h
+  COMPILE_OPTIONS
+    ${freelist_entrypoint_compile_options}
   DEPENDS
     libc.src.__support.freelist_heap
 )
@@ -20,6 +27,8 @@ add_entrypoint_object(
     free.cpp
   HDRS
     ../free.h
+  COMPILE_OPTIONS
+    ${freelist_entrypoint_compile_options}
   DEPENDS
     libc.src.__support.freelist_heap
 )
@@ -30,6 +39,8 @@ add_entrypoint_object(
     calloc.cpp
   HDRS
     ../calloc.h
+  COMPILE_OPTIONS
+    ${freelist_entrypoint_compile_options}
   DEPENDS
     libc.src.__support.freelist_heap
 )
@@ -40,6 +51,8 @@ add_entrypoint_object(
     realloc.cpp
   HDRS
     ../realloc.h
+  COMPILE_OPTIONS
+    ${freelist_entrypoint_compile_options}
   DEPENDS
     libc.src.__support.freelist_heap
 )
@@ -50,6 +63,8 @@ add_entrypoint_object(
     aligned_alloc.cpp
   HDRS
     ../aligned_alloc.h
+  COMPILE_OPTIONS
+    ${freelist_entrypoint_compile_options}
   DEPENDS
     libc.src.__support.freelist_heap
 )
@@ -60,6 +75,8 @@ add_entrypoint_object(
     malloc_usable_size.cpp
   HDRS
     ../malloc_usable_size.h
+  COMPILE_OPTIONS
+    ${freelist_entrypoint_compile_options}
   DEPENDS
     libc.src.__support.freelist_heap
 )

--- a/libc/src/stdlib/baremetal/malloc_usable_size.cpp
+++ b/libc/src/stdlib/baremetal/malloc_usable_size.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation for freelist_malloc_usable_size.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/stdlib/malloc_usable_size.h"
+#include "src/__support/freelist_heap.h"
+#include "src/__support/macros/config.h"
+
+#include <stddef.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(size_t, malloc_usable_size, (void *ptr)) {
+  return freelist_heap->allocation_size(ptr);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/malloc_usable_size.h
+++ b/libc/src/stdlib/malloc_usable_size.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for malloc_usable_size.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/macros/config.h"
+#include <stddef.h>
+
+#ifndef LLVM_LIBC_SRC_STDLIB_MALLOC_USABLE_SIZE_H
+#define LLVM_LIBC_SRC_STDLIB_MALLOC_USABLE_SIZE_H
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t malloc_usable_size(void *ptr);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDLIB_MALLOC_USABLE_SIZE_H

--- a/libc/test/src/__support/CMakeLists.txt
+++ b/libc/test/src/__support/CMakeLists.txt
@@ -58,12 +58,19 @@ endif()
 # TODO: FreeListHeap uses the _end symbol which conflicts with the _end symbol
 # defined by GPU start.cpp files so for now we exclude this test on GPU.
 if(LLVM_LIBC_FULL_BUILD AND NOT LIBC_TARGET_OS_IS_GPU)
+  set(freelist_heap_test_compile_options "")
+  if(LIBC_CONF_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+    list(APPEND freelist_heap_test_compile_options "-DLIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE")
+  endif()
+
   add_libc_test(
     freelist_heap_test
     SUITE
       libc-support-tests
     SRCS
       freelist_heap_test.cpp
+    COMPILE_OPTIONS
+      ${freelist_heap_test_compile_options}
     DEPENDS
       libc.src.__support.CPP.span
       libc.src.__support.freelist_heap

--- a/libc/test/src/__support/freelist_heap_test.cpp
+++ b/libc/test/src/__support/freelist_heap_test.cpp
@@ -346,3 +346,23 @@ TEST_FOR_EACH_ALLOCATOR(InvalidAlignedAllocAlignment, 2048) {
   ptr = allocator.aligned_allocate(0, 8);
   EXPECT_EQ(ptr, static_cast<void *>(nullptr));
 }
+
+TEST_FOR_EACH_ALLOCATOR(AllocationSize, 2048) {
+  constexpr size_t ALLOC_SIZE = 256;
+
+  // 1. Null pointer returns 0.
+  EXPECT_EQ(allocator.allocation_size(nullptr), size_t(0));
+
+  // 2. Invalid pointer (outside heap) returns 0.
+  int dummy = 0;
+  EXPECT_EQ(allocator.allocation_size(&dummy), size_t(0));
+
+  // 3. Valid pointer returns >= allocation size.
+  void *ptr = allocator.allocate(ALLOC_SIZE);
+  ASSERT_NE(ptr, static_cast<void *>(nullptr));
+  EXPECT_GE(allocator.allocation_size(ptr), ALLOC_SIZE);
+
+  // 4. Freed pointer returns 0.
+  allocator.free(ptr);
+  EXPECT_EQ(allocator.allocation_size(ptr), size_t(0));
+}

--- a/libc/test/src/__support/freelist_heap_test.cpp
+++ b/libc/test/src/__support/freelist_heap_test.cpp
@@ -366,3 +366,44 @@ TEST_FOR_EACH_ALLOCATOR(AllocationSize, 2048) {
   allocator.free(ptr);
   EXPECT_EQ(allocator.allocation_size(ptr), size_t(0));
 }
+
+#if defined(LIBC_COPT_FREELISTHEAP_PRECISE_ALLOC_SIZE)
+TEST_FOR_EACH_ALLOCATOR(PreciseAllocSize, 2048) {
+  // Test 1-byte allocation
+  void *ptr1 = allocator.allocate(1);
+  ASSERT_NE(ptr1, static_cast<void *>(nullptr));
+  EXPECT_EQ(allocator.allocation_size(ptr1), size_t(1));
+
+  // Test odd size allocation
+  constexpr size_t ODD_SIZE = 13;
+  void *ptr2 = allocator.allocate(ODD_SIZE);
+  ASSERT_NE(ptr2, static_cast<void *>(nullptr));
+  EXPECT_EQ(allocator.allocation_size(ptr2), ODD_SIZE);
+
+  // Test aligned allocation with odd size
+  void *ptr3 = allocator.aligned_allocate(1, 17);
+  ASSERT_NE(ptr3, static_cast<void *>(nullptr));
+  EXPECT_EQ(allocator.allocation_size(ptr3), size_t(17));
+
+  // Test realloc to another odd size
+  void *ptr4 = allocator.realloc(ptr2, 29);
+  ASSERT_NE(ptr4, static_cast<void *>(nullptr));
+  EXPECT_EQ(allocator.allocation_size(ptr4), size_t(29));
+
+  // Test overaligned allocation (64-byte alignment, 192-byte size)
+  void *ptr5 = allocator.aligned_allocate(64, 192);
+  ASSERT_NE(ptr5, static_cast<void *>(nullptr));
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(ptr5) % 64, size_t(0));
+  EXPECT_EQ(allocator.allocation_size(ptr5), size_t(192));
+
+  // Free all allocations and verify allocation_size returns 0
+  allocator.free(ptr1);
+  allocator.free(ptr3);
+  allocator.free(ptr4);
+  allocator.free(ptr5);
+  EXPECT_EQ(allocator.allocation_size(ptr1), size_t(0));
+  EXPECT_EQ(allocator.allocation_size(ptr3), size_t(0));
+  EXPECT_EQ(allocator.allocation_size(ptr4), size_t(0));
+  EXPECT_EQ(allocator.allocation_size(ptr5), size_t(0));
+}
+#endif


### PR DESCRIPTION
For the context of https://developers.redhat.com/articles/2022/09/17/gccs-new-fortification-level, precise malloc_usable_size is actually having a better semantic

Assisted-by: Gemini based automation tools (human-in-the-loop)