### PR TITLE
Make ios_base::xalloc non-atomic with LIBCXX_ENABLE_THREADS=OFF.

### DIFF
--- a/libcxx/src/ios.cpp
+++ b/libcxx/src/ios.cpp
@@ -122,7 +122,14 @@ static size_t __ios_new_cap(size_t __req_size, size_t __current_cap) { // Precon
 }
 
 int ios_base::xalloc() {
+#if _LIBCPP_HAS_THREADS
   constinit static atomic<int> xindex = 0;
+#else
+  // If we don't have atomics, fall back to single-threaded implementation.
+  // FIXME: Should "single-threaded" be a separate option from
+  // _LIBCPP_HAS_THREADS?
+  static int xindex = 0;
+#endif // _LIBCPP_HAS_THREADS
   return xindex++;
 }
 


### PR DESCRIPTION
762b77a moved the definition of "xindex" out of the header, and in the process dropped the _LIBCPP_HAS_THREADS check.  Re-add the check to maintain the status quo.

The discussion on https://github.com/llvm/llvm-project/pull/198994 indicates it's not clear whether LIBCXX_ENABLE_THREADS=OFF is actually supposed to mean single-threaded.  But it clearly does in practice: atomic_support.h uses non-atomic ops when threads are disabled, and a few other APIs have explicit non-atomic fallback paths.

My team ran into this trying to run libc++ tests for a RISC-V core without the "a" extension.