### PR TITLE
[CodeGen][NPM] Disable Machine verifier at the end of default pipelines

### DIFF
--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -618,9 +618,6 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::buildPipeline(
   if (auto Err = derived().addMachinePasses(PMW))
     return std::move(Err);
 
-  if (!Opt.DisableVerify)
-    addMachineFunctionPass(MachineVerifierPass(), PMW);
-
   if (PrintAsm) {
     derived().addAsmPrinter(PMW);
     flushFPMsToMPM(PMW, /*FreeMachineFunctions=*/true);

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -618,6 +618,9 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::buildPipeline(
   if (auto Err = derived().addMachinePasses(PMW))
     return std::move(Err);
 
+  if (!Opt.DisableVerify && TM.Options.EnableDefaultMachineVerifier)
+    addMachineFunctionPass(MachineVerifierPass(), PMW);
+
   if (PrintAsm) {
     derived().addAsmPrinter(PMW);
     flushFPMsToMPM(PMW, /*FreeMachineFunctions=*/true);

--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -312,6 +312,9 @@ public:
   void setSupportsDebugEntryValues(bool Enable) {
     Options.SupportsDebugEntryValues = Enable;
   }
+  void setEnableDefaultMachineVerifier(bool Enable) {
+    Options.EnableDefaultMachineVerifier = Enable;
+  }
 
   void setCFIFixup(bool Enable) { Options.EnableCFIFixup = Enable; }
 

--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -132,11 +132,11 @@ public:
         EmitStackSizeSection(false), EnableMachineOutliner(false),
         EnableMachineFunctionSplitter(false),
         EnableStaticDataPartitioning(false), SupportsDefaultOutlining(false),
-        EmitAddrsig(false), BBAddrMap(false), EmitCallGraphSection(false),
-        EmitCallSiteInfo(false), SupportsDebugEntryValues(false),
-        EnableDebugEntryValues(false), ValueTrackingVariableLocations(false),
-        ForceDwarfFrameSection(false), XRayFunctionIndex(true),
-        DebugStrictDwarf(false), Hotpatch(false),
+        EnableDefaultMachineVerifier(true), EmitAddrsig(false),
+        BBAddrMap(false), EmitCallGraphSection(false), EmitCallSiteInfo(false),
+        SupportsDebugEntryValues(false), EnableDebugEntryValues(false),
+        ValueTrackingVariableLocations(false), ForceDwarfFrameSection(false),
+        XRayFunctionIndex(true), DebugStrictDwarf(false), Hotpatch(false),
         PPCGenScalarMASSEntries(false), JMCInstrument(false),
         EnableCFIFixup(false), MisExpect(false), XCOFFReadOnlyPointers(false),
         VerifyArgABICompliance(true) {}
@@ -272,6 +272,10 @@ public:
 
   /// Set if the target supports default outlining behaviour.
   unsigned SupportsDefaultOutlining : 1;
+
+  /// Enable Machine verifier at the end of default codegen pipelines. (Only
+  /// used with NPM)
+  unsigned EnableDefaultMachineVerifier : 1;
 
   /// Emit address-significance table.
   unsigned EmitAddrsig : 1;

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -1249,7 +1249,9 @@ GCNTargetMachine::GCNTargetMachine(const Target &T, const Triple &TT,
                                    std::optional<Reloc::Model> RM,
                                    std::optional<CodeModel::Model> CM,
                                    CodeGenOptLevel OL, bool JIT)
-    : AMDGPUTargetMachine(T, TT, CPU, FS, Options, RM, CM, OL) {}
+    : AMDGPUTargetMachine(T, TT, CPU, FS, Options, RM, CM, OL) {
+  setEnableDefaultMachineVerifier(false);
+}
 
 enum class OOBFlagValue {
   Any = 0,

--- a/llvm/test/CodeGen/AMDGPU/llc-pipeline-npm.ll
+++ b/llvm/test/CodeGen/AMDGPU/llc-pipeline-npm.ll
@@ -103,7 +103,6 @@
 ; GCN-O0-NEXT:       machine-sanmd
 ; GCN-O0-NEXT:       amdgpu-preload-kern-arg-prolog
 ; GCN-O0-NEXT:       stack-frame-layout
-; GCN-O0-NEXT:       verify
 ; GCN-O0-NEXT:       amdgpu-asm-printer
 ; GCN-O0-NEXT:     free-machine-function 
 ; GCN-O0-NEXT: amdgpu-asm-printer-end
@@ -292,7 +291,6 @@
 ; GCN-O2-NEXT:       machine-sanmd
 ; GCN-O2-NEXT:       amdgpu-preload-kern-arg-prolog
 ; GCN-O2-NEXT:       stack-frame-layout
-; GCN-O2-NEXT:       verify
 ; GCN-O2-NEXT:       amdgpu-asm-printer
 ; GCN-O2-NEXT:     free-machine-function
 ; GCN-O2-NEXT: amdgpu-asm-printer-end
@@ -481,7 +479,6 @@
 ; GCN-O3-NEXT:       machine-sanmd
 ; GCN-O3-NEXT:       amdgpu-preload-kern-arg-prolog
 ; GCN-O3-NEXT:       stack-frame-layout
-; GCN-O3-NEXT:       verify
 ; GCN-O3-NEXT:       amdgpu-asm-printer
 ; GCN-O3-NEXT:     free-machine-function
 ; GCN-O3-NEXT: amdgpu-asm-printer-end


### PR DESCRIPTION
keeping discussions in https://github.com/llvm/llvm-project/pull/176693. Adds target option to disable machine verifier at the end of default pilelines (O0,O1..). Also ref. https://github.com/llvm/llvm-project/pull/201004 for discussions regarding why this is required (temporarily atleast) so that NPM migration is unblocked. should be removed once we have fixed all the latent verifier issues.