### PR TITLE
[mlir][IR] Avoid Clang 21 crash during SFINAE overload resolution

### DIFF
--- a/mlir/include/mlir/IR/StorageUniquerSupport.h
+++ b/mlir/include/mlir/IR/StorageUniquerSupport.h
@@ -194,9 +194,16 @@ public:
   /// Get or create a new ConcreteT instance within the ctx. If the arguments
   /// provided are invalid, errors are emitted using the provided `emitError`
   /// and a null object is returned.
-  template <typename... Args>
+  ///
+  /// Workaround: We use Arg1 && instead of MLIRContext * in the parameter list
+  /// to work around a bug in Clang 21.1.8 where Clang segfaults during SFINAE
+  /// overload resolution when attempting to match non-pointer arguments
+  /// against an unconstrained MLIRContext * parameter.
+  template <typename Arg1, typename... Args,
+            typename = std::enable_if_t<std::is_convertible<
+                llvm::remove_cvref_t<Arg1>, MLIRContext *>::value>>
   static ConcreteT getChecked(function_ref<InFlightDiagnostic()> emitErrorFn,
-                              MLIRContext *ctx, Args... args) {
+                              Arg1 &&ctx, Args... args) {
     // If the construction invariants fail then we return a null attribute.
     if (failed(ConcreteT::verifyInvariants(emitErrorFn, args...)))
       return ConcreteT();

--- a/mlir/include/mlir/IR/StorageUniquerSupport.h
+++ b/mlir/include/mlir/IR/StorageUniquerSupport.h
@@ -200,8 +200,8 @@ public:
   /// overload resolution when attempting to match non-pointer arguments
   /// against an unconstrained MLIRContext * parameter.
   template <typename Arg1, typename... Args,
-            typename = std::enable_if_t<std::is_convertible<
-                llvm::remove_cvref_t<Arg1>, MLIRContext *>::value>>
+            typename = std::enable_if_t<std::is_convertible_v<
+                llvm::remove_cvref_t<Arg1>, MLIRContext *>>>
   static ConcreteT getChecked(function_ref<InFlightDiagnostic()> emitErrorFn,
                               Arg1 &&ctx, Args... args) {
     // If the construction invariants fail then we return a null attribute.


### PR DESCRIPTION
Clang 21.1.8 segfaults during SFINAE overload resolution for T::getChecked
when matching non-pointer arguments against an unconstrained MLIRContext*
parameter.

This patch avoids the crash by adding an explicit SFINAE constraint to
the second overload of StorageUserBase::getChecked, ensuring that it is
only considered when the second argument is convertible to MLIRContext*.

Assisted-by: Antigravity
