### PR TITLE
[RISCV] Remove duplicate addRequired in RISCVDeadRegisterDefinitions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVDeadRegisterDefinitions.cpp
+++ b/llvm/lib/Target/RISCV/RISCVDeadRegisterDefinitions.cpp
@@ -35,7 +35,6 @@ public:
     AU.setPreservesCFG();
     AU.addRequired<LiveIntervalsWrapperPass>();
     AU.addPreserved<LiveIntervalsWrapperPass>();
-    AU.addRequired<LiveIntervalsWrapperPass>();
     AU.addPreserved<SlotIndexesWrapperPass>();
     AU.addPreserved<LiveDebugVariablesWrapperLegacy>();
     AU.addPreserved<LiveStacksWrapperLegacy>();


### PR DESCRIPTION
getAnalysisUsage called AU.addRequired<LiveIntervalsWrapperPass>() twice. 
Drop the redundant second call.