### PR TITLE
[SandboxVec][Scheduler] Use SchedulingPoint for pointing to scheduling front

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -25,6 +25,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h"
 #include <queue>
+#include <variant>
 
 namespace llvm::sandboxir {
 
@@ -170,6 +171,109 @@ public:
 #endif
 };
 
+/// The scheduling point in the context of the Scheduler points to the
+/// top-of-schedule (i.e., the top-most instruction of the top bundle) during
+/// bottom-up scheduling or the bottom of the schedule (i.e., the bottom-most
+/// instruction of the bottom bundle) during top-down.
+///
+/// This class can be thought of as an extended BB::iterator, one that can
+/// not only point to after the last instruction in a BB (i.e., BB.end()), but
+/// also before the first instruction (i.e., something equivalent to
+/// prev(BB.begin()), which is not a legal BasicBlock::iterator).
+///
+/// This is needed for symmetric implementations of top-down and bottom-up
+/// scheduling. More specifically, if this is the first scheduling attempt we
+/// need the scheduling front to still point to a hypothetical last scheduling
+/// point. In bottom-up this can be at BB.end() but in top-down this can be
+/// before BB.begin(). This is why a BasicBlock::iterator is not suitable for
+/// this.
+class SchedulingPoint {
+  /// If Where contains a Block, then we are pointing before BB.begin(),
+  /// otherwise if it contains an iterator then we point to anywhere in the BB
+  /// or at BB.end().
+  std::variant<BasicBlock::iterator, BasicBlock *> Where;
+
+  /// Creates a scheduling point pointing before the beginning of BB.
+  SchedulingPoint(BasicBlock &BB) : Where(&BB) {}
+
+public:
+  /// Creates a scheduling point pointing at \p It, meaning any instruction in a
+  /// BB or BB.end().
+  SchedulingPoint(BasicBlock::iterator It) : Where(It) {}
+  /// Returns a SchedulingPoint that points to \p It.
+  static SchedulingPoint createAt(BasicBlock::iterator It) {
+    return SchedulingPoint(It);
+  }
+  /// Returns a SchedulingPoint that points to one element before \p It.
+  static SchedulingPoint createBefore(BasicBlock::iterator It) {
+    BasicBlock &BB = *It.getNodeParent();
+    if (It == BB.begin())
+      return SchedulingPoint(BB);
+    return SchedulingPoint(std::prev(It));
+  }
+  /// Returns a SchedulingPoint that points to one element after \p It.
+  static SchedulingPoint createAfter(BasicBlock::iterator It) {
+    assert(It != It.getNodeParent()->end() && "Already at end!");
+    return SchedulingPoint(std::next(It));
+  }
+
+  /// If the SchedulingPoint points to before the beginning of a BB, then this
+  /// returns that BB, else returns nullptr.
+  BasicBlock *atBeforeBeginOrNull() const {
+    if (std::holds_alternative<BasicBlock::iterator>(Where))
+      return nullptr;
+    return std::get<BasicBlock *>(Where);
+  }
+  /// If the SchedulingPoint points after the last instruction in the BB then
+  /// this returns the corresponding BasicBlock, nullptr otherwise.
+  BasicBlock *atEndOrNull() const {
+    if (std::holds_alternative<BasicBlock *>(Where))
+      return nullptr;
+    auto It = std::get<BasicBlock::iterator>(Where);
+    return It == It.getNodeParent()->end() ? It.getNodeParent() : nullptr;
+  }
+  /// Returns the instruction pointed to by this SchedulingPoint or null if we
+  /// are before/after BB.
+  Instruction *atInstrOrNull() const {
+    if (atBeforeBeginOrNull() || atEndOrNull())
+      return nullptr;
+    return &*std::get<BasicBlock::iterator>(Where);
+  }
+  /// Cast to Instruction *. Asserts that we are pointing to an instruction and
+  /// not before/after the beginning/end of a BB.
+  operator Instruction *() const { return atInstrOrNull(); }
+  /// Returns the corresponding BB::iterator. Asserts that we are not pointing
+  /// before BB begin.
+  BasicBlock::iterator getIterator() const {
+    assert(!atBeforeBeginOrNull() && "Expected in/after BB!");
+    return std::get<BasicBlock::iterator>(Where);
+  }
+  operator BasicBlock::iterator() const { return getIterator(); }
+  /// Returns the SchedulingPoint pointing after this.
+  SchedulingPoint getNext() const {
+    assert(!atEndOrNull() && "Expected before/in BB!");
+    if (BasicBlock *BB = atBeforeBeginOrNull())
+      return BB->begin();
+    return std::next(getIterator());
+  }
+  /// Returns the SchedulingPoint pointing before this.
+  SchedulingPoint getPrev() const {
+    assert(!atBeforeBeginOrNull() && "Expected in/after BB!");
+    auto It = getIterator();
+    auto *BB = It.getNodeParent();
+    if (It == BB->begin())
+      return *BB;
+    return std::prev(It);
+  }
+  bool operator==(const SchedulingPoint &Other) const {
+    return Where == Other.Where;
+  }
+#ifndef NDEBUG
+  void print(raw_ostream &OS) const;
+  LLVM_DUMP_METHOD void dump() const;
+#endif
+};
+
 /// The list scheduler.
 class Scheduler {
   /// This is a list-scheduler and this is the list containing the instructions
@@ -181,10 +285,12 @@ class Scheduler {
   DependencyGraph DAG;
   friend class SchedulerInternalsAttorney; // For DAG.
   Context &Ctx;
-  /// This is the top of the schedule, i.e. the location where the scheduler
-  /// is about to place the scheduled instructions. It gets updated as we
-  /// schedule.
-  std::optional<BasicBlock::iterator> ScheduleTopItOpt;
+  /// This is the top of the schedule during bottom-up scheduling and the bottom
+  /// of the schedule during top-down. It points to the position of the last
+  /// top-most/bottom-most instruction scheduled. It may get updated after every
+  /// trySchedule() attempt, regardless of whether scheduling succeeded or not.
+  /// It is nullopt if we have not scheduled before.
+  std::optional<SchedulingPoint> ScheduleTopItOpt;
   // TODO: This is wasting memory in exchange for fast removal using a raw ptr.
   DenseMap<SchedBundle *, std::unique_ptr<SchedBundle>> Bndls;
   /// The BB that we are currently scheduling.

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -76,13 +76,28 @@ void ReadyListContainer::dump() const {
   dump(dbgs());
   dbgs() << "\n";
 }
+
+void SchedulingPoint::print(raw_ostream &OS) const {
+  if (BasicBlock *BB = atBeforeBeginOrNull())
+    OS << "Before begin of BB " << BB->getName();
+  else if (BasicBlock *BB = atEndOrNull())
+    OS << "At end of BB " << BB->getName();
+  else
+    OS << "At instr: " << *atInstrOrNull();
+}
+
+void SchedulingPoint::dump() const {
+  print(dbgs());
+  dbgs() << "\n";
+}
 #endif // NDEBUG
 
 void Scheduler::scheduleAndUpdateReadyList(SchedBundle &Bndl) {
   // Find where we should schedule the instructions.
   assert(ScheduleTopItOpt && "Should have been set by now!");
-  auto Where = Dir == SchedDirection::BottomUp ? *ScheduleTopItOpt
-                                               : std::next(*ScheduleTopItOpt);
+  auto Where = Dir == SchedDirection::BottomUp
+                   ? ScheduleTopItOpt->getIterator()
+                   : ScheduleTopItOpt->getNext().getIterator();
   // Move all instructions in `Bndl` to `Where`.
   Bndl.cluster(Where);
   // Update the last scheduled bundle.
@@ -124,7 +139,7 @@ void Scheduler::notifyCreateInstr(Instruction *I) {
   // If the instruction is inserted below the top-of-schedule then we mark it as
   // "scheduled".
   bool IsScheduled = ScheduleTopItOpt &&
-                     *ScheduleTopItOpt != I->getParent()->end() &&
+                     ScheduleTopItOpt->getIterator() != I->getParent()->end() &&
                      ((Dir == SchedDirection::BottomUp &&
                        (*ScheduleTopItOpt.value()).comesBefore(I)) ||
                       (Dir == SchedDirection::TopDown &&
@@ -358,12 +373,15 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
              [this](Instruction *I) { return I->getParent() != ScheduledBB; }))
     return false;
 
-  auto GetSchedPoint = [](SchedDirection Dir, const auto &Instrs) {
+  auto GetSchedPoint = [](SchedDirection Dir,
+                          const auto &Instrs) -> SchedulingPoint {
     switch (Dir) {
     case SchedDirection::BottomUp:
-      return std::next(VecUtils::getLowest(Instrs)->getIterator());
+      return SchedulingPoint(VecUtils::getLowest(Instrs)->getIterator())
+          .getNext();
     case SchedDirection::TopDown:
-      return VecUtils::getHighest(Instrs)->getIterator();
+      return SchedulingPoint(VecUtils::getHighest(Instrs)->getIterator())
+          .getPrev();
     }
     llvm_unreachable("Unhandled Dir!");
   };

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -993,3 +993,91 @@ bb1:
   EXPECT_EQ(ReadyList.pop(), S0N);
   EXPECT_EQ(ReadyList.pop(), RetN);
 }
+
+TEST_F(SchedulerTest, SchedulingPoint) {
+  parseIR(C, R"IR(
+define void @foo(ptr %ptr, i8 %v0) {
+  store i8 %v0, ptr %ptr
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *S0 = cast<sandboxir::StoreInst>(&*It++);
+  auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
+
+  // Check at each instruction.
+  for (auto &I : *BB) {
+    sandboxir::SchedulingPoint SP(I.getIterator());
+    // Check atBeforeBeginOrNull(), I can't be before begin.
+    EXPECT_EQ(SP.atBeforeBeginOrNull(), nullptr);
+    // Check atEndOrNull(), I can't be at end.
+    EXPECT_EQ(SP.atEndOrNull(), nullptr);
+
+    // Check atInstrOrNull().
+    EXPECT_EQ(SP.atInstrOrNull(), &I);
+    // Check cast to Instruction *.
+    EXPECT_EQ((sandboxir::Instruction *)SP, &I);
+    // Check getIterator().
+    EXPECT_EQ(SP.getIterator(), I.getIterator());
+    // Check getIterator() const.
+    EXPECT_EQ(((const sandboxir::SchedulingPoint &)SP).getIterator(),
+              I.getIterator());
+    // Check getNext().
+    EXPECT_EQ(SP.getNext().getIterator(), std::next(I.getIterator()));
+    // Check getPrev().
+    EXPECT_EQ(SP.getNext().getPrev().getIterator(), I.getIterator());
+    // Check operator==() and createAt().
+    EXPECT_EQ(sandboxir::SchedulingPoint::createAt(I.getIterator()), SP);
+  }
+  // Check createBefore().
+  EXPECT_EQ(sandboxir::SchedulingPoint::createBefore(Ret->getIterator()),
+            sandboxir::SchedulingPoint::createAt(S0->getIterator()));
+  // Check createAfter().
+  EXPECT_EQ(sandboxir::SchedulingPoint::createAfter(S0->getIterator()),
+            sandboxir::SchedulingPoint::createAt(Ret->getIterator()));
+  // Check atBeforeBeginOrNull().
+  EXPECT_EQ(sandboxir::SchedulingPoint::createBefore(BB->begin())
+                .atBeforeBeginOrNull(),
+            BB);
+  EXPECT_EQ(sandboxir::SchedulingPoint::createAt(S0->getIterator())
+                .atBeforeBeginOrNull(),
+            nullptr);
+  EXPECT_EQ(
+      sandboxir::SchedulingPoint::createAt(BB->end()).atBeforeBeginOrNull(),
+      nullptr);
+  // Check atEndOrNull().
+  EXPECT_EQ(sandboxir::SchedulingPoint::createAt(BB->end()).atEndOrNull(), BB);
+  EXPECT_EQ(sandboxir::SchedulingPoint::createBefore(BB->end()).atEndOrNull(),
+            nullptr);
+  EXPECT_EQ(sandboxir::SchedulingPoint::createBefore(BB->begin()).atEndOrNull(),
+            nullptr);
+  // Check atInstrOrNull().
+  EXPECT_EQ(
+      sandboxir::SchedulingPoint::createBefore(BB->begin()).atInstrOrNull(),
+      nullptr);
+  EXPECT_EQ(sandboxir::SchedulingPoint::createAt(BB->begin()).atInstrOrNull(),
+            &BB->front());
+  EXPECT_EQ(sandboxir::SchedulingPoint::createAt(BB->end()).atInstrOrNull(),
+            nullptr);
+
+#ifndef NDEBUG
+  // Check assertion when trying to createAfter() at BB.end().
+  EXPECT_DEATH(sandboxir::SchedulingPoint::createAfter(BB->end()),
+               ".*at end.*");
+  // Check assertion when trying to get out of bounds getPrev().
+  sandboxir::SchedulingPoint BeforeBegin =
+      sandboxir::SchedulingPoint::createBefore(BB->begin());
+  EXPECT_DEATH(BeforeBegin.getPrev(), ".*Expected.*");
+  // Check assertion when trying to get out of bounds getNext().
+  sandboxir::SchedulingPoint AtEnd =
+      sandboxir::SchedulingPoint::createAt(BB->end());
+  EXPECT_DEATH(AtEnd.getNext(), ".*Expected.*");
+
+  // Check assertion before begin.
+  EXPECT_DEATH(BeforeBegin.getIterator(), ".*Expected.*");
+#endif
+}


### PR DESCRIPTION
The scheduling point is the last instruction scheduled. If this is the first time scheduling and we are scheduling top-down then we may need to point before the beginning of the basic block. This is why a BasicBlock::iterator does not work well here.

Until now we were using the first top-most instruction for this, which is inconsistent.