### PR TITLE
[asan][test] Fix Posix/new_array_cookie_with_new_from_class.cpp to work for arm targets

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/new_array_cookie_with_new_from_class.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/new_array_cookie_with_new_from_class.cpp
@@ -1,16 +1,19 @@
 // Test that we do not poison the array cookie if the operator new is defined
 // inside the class.
 // RUN: %clangxx_asan  %s -o %t && %run %t
-//
-// XFAIL: target=arm{{.*}}
-
-// UNSUPPORTED: darwin-remote
 
 #include <new>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <assert.h>
+
+#if defined(__arm__) || (defined(__aarch64__) && defined(__APPLE__))
+constexpr size_t kArrayCookieSize = 2 * sizeof(void *);
+#else
+constexpr size_t kArrayCookieSize = sizeof(void *);
+#endif
+
 struct Foo {
   void *operator new(size_t s) { return Allocate(s); }
   void *operator new[] (size_t s) { return Allocate(s); }
@@ -34,7 +37,7 @@ int main() {
   fprintf(stderr, "foo  : %p\n", foo);
   fprintf(stderr, "alloc: %p\n", Foo::allocated);
   assert(reinterpret_cast<uintptr_t>(foo) ==
-         reinterpret_cast<uintptr_t>(Foo::allocated) + sizeof(void*));
+         reinterpret_cast<uintptr_t>(Foo::allocated) + kArrayCookieSize);
   *reinterpret_cast<uintptr_t*>(Foo::allocated) = 42;
   return 0;
 }


### PR DESCRIPTION
arm targets, and arm64 targets on Darwin, use a 2-pointer array cookie size. Update the test to support that.

Assisted-by: Claude Code

rdar://181775880