### PR TITLE
coro.retcon: Fix return type and buffer poisoning in elided coroutines

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -242,6 +242,23 @@ static void replaceFallthroughCoroEnd(AnyCoroEndInst *End,
   case coro::ABI::RetconOnce: {
     maybeFreeRetconStorage(Builder, Shape, FramePtr, CG);
     auto *CoroEnd = cast<CoroEndInst>(End);
+
+    if (InRamp) {
+      auto *RetTy = End->getFunction()->getReturnType();
+      Value *ReturnValue;
+      if (auto *RetStructTy = dyn_cast<StructType>(RetTy)) {
+        ReturnValue = Builder.CreateInsertValue(
+            PoisonValue::get(RetStructTy),
+            ConstantPointerNull::get(
+                cast<PointerType>(RetStructTy->getElementType(0))),
+            0);
+      } else {
+        ReturnValue = ConstantPointerNull::get(cast<PointerType>(RetTy));
+      }
+      Builder.CreateRet(ReturnValue);
+      break;
+    }
+
     auto *RetTy = Shape.getResumeFunctionType()->getReturnType();
 
     if (!CoroEnd->hasResults()) {

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -1181,9 +1181,11 @@ static void handleNoSuspendCoroutine(coro::Shape &Shape) {
     break;
   }
   case coro::ABI::Async:
+    CoroBegin->replaceAllUsesWith(PoisonValue::get(CoroBegin->getType()));
+    break;
   case coro::ABI::Retcon:
   case coro::ABI::RetconOnce:
-    CoroBegin->replaceAllUsesWith(PoisonValue::get(CoroBegin->getType()));
+    CoroBegin->replaceAllUsesWith(Shape.getRetconCoroId()->getStorage());
     break;
   }
 

--- a/llvm/test/Transforms/Coroutines/coro-retcon-elide-ub.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-elide-ub.ll
@@ -1,0 +1,79 @@
+; RUN: opt < %s -passes='module(coro-early),cgscc(coro-split),module(coro-cleanup)' -S | FileCheck %s
+; RUN: opt < %s -passes='default<O2>' -S | FileCheck --check-prefix=CHECK-O2 %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare token @llvm.coro.id.retcon(i32, i32, ptr, ptr, ptr, ptr)
+declare token @llvm.coro.id.retcon.once(i32, i32, ptr, ptr, ptr, ptr)
+declare ptr @llvm.coro.begin(token, ptr)
+declare void @llvm.coro.end(ptr, i1, token)
+
+declare noalias ptr @malloc(i64)
+declare void @free(ptr)
+
+define ptr @prototype(ptr dereferenceable(8) %buf, i1 %unwind) {
+  ret ptr null
+}
+
+define void @prototype_once(ptr dereferenceable(8) %buf, i1 %unwind) {
+  ret void
+}
+
+; CHECK-LABEL: define ptr @f_retcon(ptr dereferenceable(8) %buf)
+; CHECK-NEXT:  entry:
+; CHECK:         %val_ptr = getelementptr inbounds i32, ptr %buf, i64 1
+; CHECK-NEXT:    store i32 42, ptr %val_ptr, align 4
+; CHECK-NEXT:    %val = load i32, ptr %val_ptr, align 4
+; CHECK-NEXT:    ret ptr null
+
+; CHECK-O2-LABEL: define ptr @f_retcon(ptr dereferenceable(8) %buf)
+; CHECK-O2-NEXT:  entry:
+; CHECK-O2-NEXT:    %val_ptr = getelementptr inbounds {{.*}} ptr %buf, i64 4
+; CHECK-O2-NEXT:    store i32 42, ptr %val_ptr, align 4
+; CHECK-O2-NEXT:    ret ptr null
+
+define ptr @f_retcon(ptr dereferenceable(8) %buf) {
+entry:
+  ; We can set size to 0 and align to 1 because this coroutine has 0 suspends,
+  ; meaning it will always be elided and requires no frame storage.
+  %id = call token @llvm.coro.id.retcon(i32 0, i32 1, ptr %buf, ptr @prototype, ptr @malloc, ptr @free)
+  %hdl = call ptr @llvm.coro.begin(token %id, ptr %buf)
+  
+  ; Access the frame (buffer) via handle.
+  %val_ptr = getelementptr inbounds i32, ptr %hdl, i64 1
+  store i32 42, ptr %val_ptr, align 4
+  %val = load i32, ptr %val_ptr, align 4
+  
+  call void @llvm.coro.end(ptr %hdl, i1 false, token none)
+  ret ptr null
+}
+
+; CHECK-LABEL: define ptr @f_retcon_once(ptr dereferenceable(8) %buf)
+; CHECK-NEXT:  entry:
+; CHECK:         %val_ptr = getelementptr inbounds i32, ptr %buf, i64 1
+; CHECK-NEXT:    store i32 42, ptr %val_ptr, align 4
+; CHECK-NEXT:    %val = load i32, ptr %val_ptr, align 4
+; CHECK-NEXT:    ret ptr null
+
+; CHECK-O2-LABEL: define ptr @f_retcon_once(ptr dereferenceable(8) %buf)
+; CHECK-O2-NEXT:  entry:
+; CHECK-O2-NEXT:    %val_ptr = getelementptr inbounds {{.*}} ptr %buf, i64 4
+; CHECK-O2-NEXT:    store i32 42, ptr %val_ptr, align 4
+; CHECK-O2-NEXT:    ret ptr null
+
+define ptr @f_retcon_once(ptr dereferenceable(8) %buf) {
+entry:
+  ; We can set size to 0 and align to 1 because this coroutine has 0 suspends,
+  ; meaning it will always be elided and requires no frame storage.
+  %id = call token @llvm.coro.id.retcon.once(i32 0, i32 1, ptr %buf, ptr @prototype_once, ptr @malloc, ptr @free)
+  %hdl = call ptr @llvm.coro.begin(token %id, ptr %buf)
+  
+  ; Access the frame (buffer) via handle.
+  %val_ptr = getelementptr inbounds i32, ptr %hdl, i64 1
+  store i32 42, ptr %val_ptr, align 4
+  %val = load i32, ptr %val_ptr, align 4
+  
+  call void @llvm.coro.end(ptr %hdl, i1 false, token none)
+  ret ptr null
+}

--- a/llvm/test/Transforms/Coroutines/coro-retcon-once-value.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-once-value.ll
@@ -93,6 +93,14 @@ entry:
 ;   Unfortunately, we don't seem to fully optimize this right now due
 ;   to some sort of phase-ordering thing.
 
+define ptr @nosuspend(ptr %buffer) {
+entry:
+  %id = call token @llvm.coro.id.retcon.once(i32 8, i32 8, ptr %buffer, ptr @prototype, ptr @allocate, ptr @deallocate)
+  %hdl = call ptr @llvm.coro.begin(token %id, ptr null)
+  call void @llvm.coro.end(ptr %hdl, i1 0, token none)
+  ret ptr %hdl
+}
+
 declare token @llvm.coro.id.retcon.once(i32, i32, ptr, ptr, ptr, ptr)
 declare ptr @llvm.coro.begin(token, ptr)
 declare i1 @llvm.coro.suspend.retcon.i1(...)
@@ -220,4 +228,9 @@ declare void @print(i32)
 ; CHECK-NEXT:    [[VALUE2:%.*]] = extractvalue { ptr, i32, ptr } [[NORMAL_RESULT]], 1
 ; CHECK-NEXT:    call void @print(i32 [[VALUE2]])
 ; CHECK-NEXT:    ret void
+;
+;
+; CHECK-LABEL: @nosuspend(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    ret ptr null
 ;


### PR DESCRIPTION
Fix #208304

Return type on retcon.once ramp function is wrong. Let's set it `ptr` to align with the specification.

Also retcon/retcon.once bodies without suspension should not mask the buffer as poisoned. If the language front-end like Rust would like to manage the coro frame exclusively, the coro frame buffer may have already contained valid bits before the coroutine section begins. At least our dialect documentation does not specify the validity of the frame buffer in case that the coroutine is trivial/elided.