### PR TITLE
[Clang] Implement CWG 2282

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -279,6 +279,8 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
   to resolve that core issue.
 - Clang now uses non-reference types for structured bindings whose initializer
   returns a prvalue. This resolves [CWG3135](https://wg21.link/cwg3135).
+- Clang now falls back to alignment-aware allocation functions for
+  non-overaligned types, implementing [CWG2282](https://wg21.link/cwg2282).
 
 ### C Language Changes
 

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2716,22 +2716,22 @@ bool Sema::CheckAllocatedType(QualType AllocType, SourceLocation Loc,
 
 static void diagnoseNoViableFunctionForAllocationOverloadResolution(
     Sema &S, LookupResult &R, SourceRange Range, ArrayRef<Expr *> Args,
-    OverloadCandidateSet &Candidates, OverloadCandidateSet *AlignedCandidates,
-    Expr *AlignArg) {
+    bool ArgsIncludeAlignArg, OverloadCandidateSet &Candidates,
+    OverloadCandidateSet *PrimaryCandidates, Expr *AlignArg) {
   // If this is an allocation of the form 'new (p) X' for some object
   // pointer p (or an expression that will decay to such a pointer),
   // diagnose the reason for the error.
-  if (!R.isClassLookup() && Args.size() == 2 &&
-      (Args[1]->getType()->isObjectPointerType() ||
-       Args[1]->getType()->isArrayType())) {
-    const QualType Arg1Type = Args[1]->getType();
+  if (!R.isClassLookup() && Args.size() == (ArgsIncludeAlignArg ? 3 : 2) &&
+      (Args.back()->getType()->isObjectPointerType() ||
+       Args.back()->getType()->isArrayType())) {
+    const QualType Arg1Type = Args.back()->getType();
     QualType UnderlyingType = S.Context.getBaseElementType(Arg1Type);
     if (UnderlyingType->isPointerType())
       UnderlyingType = UnderlyingType->getPointeeType();
     if (UnderlyingType.isConstQualified()) {
-      S.Diag(Args[1]->getExprLoc(),
+      S.Diag(Args.back()->getExprLoc(),
              diag::err_placement_new_into_const_qualified_storage)
-          << Arg1Type << Args[1]->getSourceRange();
+          << Arg1Type << Args.back()->getSourceRange();
       return;
     }
     S.Diag(R.getNameLoc(), diag::err_need_header_before_placement_new)
@@ -2747,25 +2747,34 @@ static void diagnoseNoViableFunctionForAllocationOverloadResolution(
   // For an aligned allocation, separately check the aligned and unaligned
   // candidates with their respective argument lists.
   SmallVector<OverloadCandidate *, 32> Cands;
-  SmallVector<OverloadCandidate *, 32> AlignedCands;
-  llvm::SmallVector<Expr *, 4> AlignedArgs;
-  if (AlignedCandidates) {
+  SmallVector<OverloadCandidate *, 32> PrimaryCands;
+  llvm::SmallVector<Expr *, 4> PrimaryArgs;
+  if (PrimaryCandidates) {
     auto IsAligned = [](OverloadCandidate &C) {
       const unsigned AlignArgOffset = 1;
       return C.Function->getNumParams() > AlignArgOffset &&
              C.Function->getParamDecl(AlignArgOffset)->getType()->isAlignValT();
     };
-    auto IsUnaligned = [&](OverloadCandidate &C) { return !IsAligned(C); };
+    auto IsPrimary = [&](OverloadCandidate &C) {
+      return ArgsIncludeAlignArg ? !IsAligned(C) : IsAligned(C);
+    };
+    auto IsFallback = [&](OverloadCandidate &C) {
+      return ArgsIncludeAlignArg ? IsAligned(C) : !IsAligned(C);
+    };
 
-    AlignedArgs.reserve(Args.size() + 1);
-    AlignedArgs.push_back(Args[0]);
-    AlignedArgs.push_back(AlignArg);
-    AlignedArgs.append(Args.begin() + 1, Args.end());
-    AlignedCands = AlignedCandidates->CompleteCandidates(
-        S, OCD_AllCandidates, AlignedArgs, R.getNameLoc(), IsAligned);
+    PrimaryArgs.reserve(Args.size() + 1);
+    PrimaryArgs.push_back(Args[0]);
+    if (ArgsIncludeAlignArg) {
+      PrimaryArgs.append(Args.begin() + 2, Args.end());
+    } else {
+      PrimaryArgs.push_back(AlignArg);
+      PrimaryArgs.append(Args.begin() + 1, Args.end());
+    }
+    PrimaryCands = PrimaryCandidates->CompleteCandidates(
+        S, OCD_AllCandidates, PrimaryArgs, R.getNameLoc(), IsPrimary);
 
     Cands = Candidates.CompleteCandidates(S, OCD_AllCandidates, Args,
-                                          R.getNameLoc(), IsUnaligned);
+                                          R.getNameLoc(), IsFallback);
   } else {
     Cands = Candidates.CompleteCandidates(S, OCD_AllCandidates, Args,
                                           R.getNameLoc());
@@ -2773,8 +2782,8 @@ static void diagnoseNoViableFunctionForAllocationOverloadResolution(
 
   S.Diag(R.getNameLoc(), diag::err_ovl_no_viable_function_in_call)
       << R.getLookupName() << Range;
-  if (AlignedCandidates)
-    AlignedCandidates->NoteCandidates(S, AlignedArgs, AlignedCands, "",
+  if (PrimaryCandidates)
+    PrimaryCandidates->NoteCandidates(S, PrimaryArgs, PrimaryCands, "",
                                       R.getNameLoc());
   Candidates.NoteCandidates(S, Args, Cands, "", R.getNameLoc());
 }
@@ -2783,7 +2792,7 @@ enum class ResolveMode { Typed, Untyped };
 static bool resolveAllocationOverloadInterior(
     Sema &S, LookupResult &R, SourceRange Range, ResolveMode Mode,
     SmallVectorImpl<Expr *> &Args, AlignedAllocationMode &PassAlignment,
-    FunctionDecl *&Operator, OverloadCandidateSet *AlignedCandidates,
+    FunctionDecl *&Operator, OverloadCandidateSet *PrimaryCandidates,
     Expr *AlignArg, bool Diagnose) {
   unsigned NonTypeArgumentOffset = 0;
   if (Mode == ResolveMode::Typed) {
@@ -2829,17 +2838,30 @@ static bool resolveAllocationOverloadInterior(
   }
 
   case OR_No_Viable_Function:
-    // C++17 [expr.new]p13:
-    //   If no matching function is found and the allocated object type has
-    //   new-extended alignment, the alignment argument is removed from the
-    //   argument list, and overload resolution is performed again.
-    if (isAlignedAllocation(PassAlignment)) {
-      PassAlignment = AlignedAllocationMode::No;
-      AlignArg = Args[NonTypeArgumentOffset + 1];
-      Args.erase(Args.begin() + NonTypeArgumentOffset + 1);
-      return resolveAllocationOverloadInterior(S, R, Range, Mode, Args,
-                                               PassAlignment, Operator,
-                                               &Candidates, AlignArg, Diagnose);
+    // C++20 [expr.new]p18:
+    //   If no matching function is found then
+    //     — if the allocated object type has new-extended alignment, the
+    //       alignment argument is removed from the argument list;
+    //     — otherwise, an argument that is the type’s alignment and has type
+    //       std::align_val_t is added into the argument list immediately after
+    //       the first argument;
+    //   and then overload resolution is performed again.
+    if (!PrimaryCandidates) {
+      if (isAlignedAllocation(PassAlignment)) {
+        PassAlignment = AlignedAllocationMode::No;
+        AlignArg = Args[NonTypeArgumentOffset + 1];
+        Args.erase(Args.begin() + NonTypeArgumentOffset + 1);
+        return resolveAllocationOverloadInterior(
+            S, R, Range, Mode, Args, PassAlignment, Operator, &Candidates,
+            AlignArg, Diagnose);
+      }
+      if (AlignArg) {
+        PassAlignment = AlignedAllocationMode::Yes;
+        Args.insert(Args.begin() + NonTypeArgumentOffset + 1, AlignArg);
+        return resolveAllocationOverloadInterior(
+            S, R, Range, Mode, Args, PassAlignment, Operator, &Candidates,
+            AlignArg, Diagnose);
+      }
     }
 
     // MSVC will fall back on trying to find a matching global operator new
@@ -2853,10 +2875,15 @@ static bool resolveAllocationOverloadInterior(
       R.clear();
       R.setLookupName(S.Context.DeclarationNames.getCXXOperatorName(OO_New));
       S.LookupQualifiedName(R, S.Context.getTranslationUnitDecl());
+      // Only try this fallback without the alignment argument.
+      if (isAlignedAllocation(PassAlignment)) {
+        PassAlignment = AlignedAllocationMode::No;
+        Args.erase(Args.begin() + NonTypeArgumentOffset + 1);
+      }
       // FIXME: This will give bad diagnostics pointing at the wrong functions.
       return resolveAllocationOverloadInterior(S, R, Range, Mode, Args,
                                                PassAlignment, Operator,
-                                               /*Candidates=*/nullptr,
+                                               /*PrimaryCandidates=*/nullptr,
                                                /*AlignArg=*/nullptr, Diagnose);
     }
     if (Mode == ResolveMode::Typed) {
@@ -2867,7 +2894,8 @@ static bool resolveAllocationOverloadInterior(
     }
     if (Diagnose)
       diagnoseNoViableFunctionForAllocationOverloadResolution(
-          S, R, Range, Args, Candidates, AlignedCandidates, AlignArg);
+          S, R, Range, Args, isAlignedAllocation(PassAlignment), Candidates,
+          PrimaryCandidates, AlignArg);
     return true;
 
   case OR_Ambiguous:
@@ -2910,10 +2938,12 @@ static void LookupGlobalDeallocationFunctions(Sema &S, SourceLocation Loc,
   }
 }
 
-static bool resolveAllocationOverload(
-    Sema &S, LookupResult &R, SourceRange Range, SmallVectorImpl<Expr *> &Args,
-    ImplicitAllocationParameters &IAP, FunctionDecl *&Operator,
-    OverloadCandidateSet *AlignedCandidates, Expr *AlignArg, bool Diagnose) {
+static bool resolveAllocationOverload(Sema &S, LookupResult &R,
+                                      SourceRange Range,
+                                      SmallVectorImpl<Expr *> &Args,
+                                      ImplicitAllocationParameters &IAP,
+                                      FunctionDecl *&Operator, Expr *AlignArg,
+                                      bool Diagnose) {
   Operator = nullptr;
   if (isTypeAwareAllocation(IAP.PassTypeIdentity)) {
     assert(S.isStdTypeIdentity(Args[0]->getType(), nullptr));
@@ -2935,7 +2965,7 @@ static bool resolveAllocationOverload(
     IAP.PassAlignment = AlignedAllocationMode::Yes;
     if (resolveAllocationOverloadInterior(
             S, R, Range, ResolveMode::Typed, Args, IAP.PassAlignment, Operator,
-            AlignedCandidates, AlignArg, Diagnose))
+            /*PrimaryCandidates=*/nullptr, AlignArg, Diagnose))
       return true;
     if (Operator)
       return false;
@@ -2950,7 +2980,7 @@ static bool resolveAllocationOverload(
   assert(!S.isStdTypeIdentity(Args[0]->getType(), nullptr));
   return resolveAllocationOverloadInterior(
       S, R, Range, ResolveMode::Untyped, Args, IAP.PassAlignment, Operator,
-      AlignedCandidates, AlignArg, Diagnose);
+      /*PrimaryCandidates=*/nullptr, AlignArg, Diagnose);
 }
 
 bool Sema::FindAllocationFunctions(
@@ -3017,14 +3047,15 @@ bool Sema::FindAllocationFunctions(
   AllocArgs.push_back(&Size);
 
   QualType AlignValT = Context.VoidTy;
-  bool IncludeAlignParam = isAlignedAllocation(IAP.PassAlignment) ||
-                           isTypeAwareAllocation(IAP.PassTypeIdentity);
-  if (IncludeAlignParam) {
+  if (getLangOpts().AlignedAllocation ||
+      isTypeAwareAllocation(IAP.PassTypeIdentity)) {
     DeclareGlobalNewDelete();
-    AlignValT = Context.getCanonicalTagType(getStdAlignValT());
+    if (EnumDecl *StdAlignValT = getStdAlignValT())
+      AlignValT = Context.getCanonicalTagType(StdAlignValT);
   }
   CXXScalarValueInitExpr Align(AlignValT, nullptr, SourceLocation());
-  if (IncludeAlignParam)
+  if (isAlignedAllocation(IAP.PassAlignment) ||
+      isTypeAwareAllocation(IAP.PassTypeIdentity))
     AllocArgs.push_back(&Align);
 
   llvm::append_range(AllocArgs, PlaceArgs);
@@ -3072,9 +3103,11 @@ bool Sema::FindAllocationFunctions(
     // We do our own custom access checks below.
     R.suppressDiagnostics();
 
-    if (resolveAllocationOverload(*this, R, Range, AllocArgs, IAP, OperatorNew,
-                                  /*Candidates=*/nullptr,
-                                  /*AlignArg=*/nullptr, Diagnose))
+    if (resolveAllocationOverload(
+            *this, R, Range, AllocArgs, IAP, OperatorNew,
+            (getLangOpts().AlignedAllocation && getStdAlignValT()) ? &Align
+                                                                   : nullptr,
+            Diagnose))
       return true;
   }
 

--- a/clang/test/CXX/drs/cwg22xx.cpp
+++ b/clang/test/CXX/drs/cwg22xx.cpp
@@ -6,6 +6,12 @@
 // RUN: %clang_cc1 -std=c++23 -triple x86_64-unknown-unknown %s -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,since-cxx11,since-cxx17
 // RUN: %clang_cc1 -std=c++2c -triple x86_64-unknown-unknown %s -fexceptions -fcxx-exceptions -pedantic-errors -verify-directives -verify=expected,since-cxx11,since-cxx17
 
+__extension__ typedef __SIZE_TYPE__ size_t;
+#if __cplusplus >= 201703L
+namespace std {
+  enum class align_val_t : size_t {};
+} // namespace std
+#endif
 
 namespace cwg2211 { // cwg2211: 8
 #if __cplusplus >= 201103L
@@ -195,6 +201,24 @@ void g() {
 }
 #endif
 } // namespace cwg2277
+
+namespace cwg2282 { // cwg2282: 23
+#if __cplusplus >= 201703L
+struct A {
+  void *operator new(size_t, std::align_val_t) = delete; // #cwg2282-A-operator-new-aligned
+  void *operator new(size_t, std::align_val_t, double) = delete; // #cwg2282-A-operator-new-aligned-placement
+};
+
+void f() {
+  (void)new A; // since-cxx17-error {{call to deleted function 'operator new'}}
+  // since-cxx17-note@#cwg2282-A-operator-new-aligned {{candidate function has been explicitly deleted}}
+  // since-cxx17-note@#cwg2282-A-operator-new-aligned-placement {{candidate function not viable: requires 3 arguments, but 2 were provided}}
+  (void)new (1.5) A; // since-cxx17-error {{call to deleted function 'operator new'}}
+  // since-cxx17-note@#cwg2282-A-operator-new-aligned-placement {{candidate function has been explicitly deleted}}
+  // since-cxx17-note@#cwg2282-A-operator-new-aligned {{candidate function not viable: requires 2 arguments, but 3 were provided}}
+}
+#endif
+} // namespace cwg2282
 
 namespace cwg2285 { // cwg2285: 4
 // Note: Clang 4 implements this DR but it set a wrong value of `__cplusplus`

--- a/clang/test/CXX/drs/cwg22xx.cpp
+++ b/clang/test/CXX/drs/cwg22xx.cpp
@@ -210,7 +210,8 @@ struct A {
 };
 
 void f() {
-  (void)new A; // since-cxx17-error {{call to deleted function 'operator new'}}
+  (void)new A;
+  // since-cxx17-error@-1 {{call to deleted function 'operator new'}}
   // since-cxx17-note@#cwg2282-A-operator-new-aligned {{candidate function has been explicitly deleted}}
   // since-cxx17-note@#cwg2282-A-operator-new-aligned-placement {{candidate function not viable: requires 3 arguments, but 2 were provided}}
   (void)new (1.5) A; // since-cxx17-error {{call to deleted function 'operator new'}}

--- a/clang/test/CXX/drs/cwg22xx.cpp
+++ b/clang/test/CXX/drs/cwg22xx.cpp
@@ -213,10 +213,11 @@ void f() {
   (void)new A;
   // since-cxx17-error@-1 {{call to deleted function 'operator new'}}
   //   since-cxx17-note@#cwg2282-A-operator-new-aligned {{candidate function has been explicitly deleted}}
-  // since-cxx17-note@#cwg2282-A-operator-new-aligned-placement {{candidate function not viable: requires 3 arguments, but 2 were provided}}
-  (void)new (1.5) A; // since-cxx17-error {{call to deleted function 'operator new'}}
-  // since-cxx17-note@#cwg2282-A-operator-new-aligned-placement {{candidate function has been explicitly deleted}}
-  // since-cxx17-note@#cwg2282-A-operator-new-aligned {{candidate function not viable: requires 2 arguments, but 3 were provided}}
+  //   since-cxx17-note@#cwg2282-A-operator-new-aligned-placement {{candidate function not viable: requires 3 arguments, but 2 were provided}}
+  (void)new (1.5) A;
+  // since-cxx17-error@-1 {{call to deleted function 'operator new'}}
+  //   since-cxx17-note@#cwg2282-A-operator-new-aligned-placement {{candidate function has been explicitly deleted}}
+  //   since-cxx17-note@#cwg2282-A-operator-new-aligned {{candidate function not viable: requires 2 arguments, but 3 were provided}}
 }
 #endif
 } // namespace cwg2282

--- a/clang/test/CXX/drs/cwg22xx.cpp
+++ b/clang/test/CXX/drs/cwg22xx.cpp
@@ -205,19 +205,19 @@ void g() {
 namespace cwg2282 { // cwg2282: 23
 #if __cplusplus >= 201703L
 struct A {
-  void *operator new(size_t, std::align_val_t) = delete; // #cwg2282-A-operator-new-aligned
-  void *operator new(size_t, std::align_val_t, double) = delete; // #cwg2282-A-operator-new-aligned-placement
+  void *operator new(size_t, std::align_val_t) = delete; // #cwg2282-new-align
+  void *operator new(size_t, std::align_val_t, double) = delete; // #cwg2282-new-align-placement
 };
 
 void f() {
   (void)new A;
   // since-cxx17-error@-1 {{call to deleted function 'operator new'}}
-  //   since-cxx17-note@#cwg2282-A-operator-new-aligned {{candidate function has been explicitly deleted}}
-  //   since-cxx17-note@#cwg2282-A-operator-new-aligned-placement {{candidate function not viable: requires 3 arguments, but 2 were provided}}
+  //   since-cxx17-note@#cwg2282-new-align {{candidate function has been explicitly deleted}}
+  //   since-cxx17-note@#cwg2282-new-align-placement {{candidate function not viable: requires 3 arguments, but 2 were provided}}
   (void)new (1.5) A;
   // since-cxx17-error@-1 {{call to deleted function 'operator new'}}
-  //   since-cxx17-note@#cwg2282-A-operator-new-aligned-placement {{candidate function has been explicitly deleted}}
-  //   since-cxx17-note@#cwg2282-A-operator-new-aligned {{candidate function not viable: requires 2 arguments, but 3 were provided}}
+  //   since-cxx17-note@#cwg2282-new-align-placement {{candidate function has been explicitly deleted}}
+  //   since-cxx17-note@#cwg2282-new-align {{candidate function not viable: requires 2 arguments, but 3 were provided}}
 }
 #endif
 } // namespace cwg2282

--- a/clang/test/CXX/drs/cwg22xx.cpp
+++ b/clang/test/CXX/drs/cwg22xx.cpp
@@ -212,7 +212,7 @@ struct A {
 void f() {
   (void)new A;
   // since-cxx17-error@-1 {{call to deleted function 'operator new'}}
-  // since-cxx17-note@#cwg2282-A-operator-new-aligned {{candidate function has been explicitly deleted}}
+  //   since-cxx17-note@#cwg2282-A-operator-new-aligned {{candidate function has been explicitly deleted}}
   // since-cxx17-note@#cwg2282-A-operator-new-aligned-placement {{candidate function not viable: requires 3 arguments, but 2 were provided}}
   (void)new (1.5) A; // since-cxx17-error {{call to deleted function 'operator new'}}
   // since-cxx17-note@#cwg2282-A-operator-new-aligned-placement {{candidate function has been explicitly deleted}}

--- a/clang/test/CXX/drs/cwg5xx.cpp
+++ b/clang/test/CXX/drs/cwg5xx.cpp
@@ -679,8 +679,8 @@ namespace cwg553 {
   // "is looked up in global scope", where it is not visible.
   void *p = new (c) int;
   // expected-error@-1 {{no matching function for call to 'operator new'}}
-  //   since-cxx17-note@#cwg5xx-global-operator-new-aligned {{candidate function not viable: no known conversion from 'cwg553_class' to 'std::align_val_t' for 2nd argument}}
   //   expected-note@#cwg5xx-global-operator-new {{candidate function not viable: requires 1 argument, but 2 were provided}}
+  //   since-cxx17-note@#cwg5xx-global-operator-new-aligned {{candidate function not viable: requires 2 arguments, but 3 were provided}}
 
   struct namespace_scope {
     friend void *operator new(size_t, namespace_scope);

--- a/clang/test/CXX/expr/expr.unary/expr.new/p14.cpp
+++ b/clang/test/CXX/expr/expr.unary/expr.new/p14.cpp
@@ -6,7 +6,7 @@ namespace std { enum class align_val_t : size_t {}; }
 struct Arg {} arg;
 
 // If the type is aligned, first try with an alignment argument and then
-// without. If not, never consider supplying an alignment.
+// without. If not, try in the reverse order.
 
 template<unsigned Align, typename ...Ts>
 struct alignas(Align) Unaligned {
@@ -19,11 +19,11 @@ auto *ubp = new (arg) Unaligned<__STDCPP_DEFAULT_NEW_ALIGNMENT__ * 2, Arg>; // e
 
 template<unsigned Align, typename ...Ts>
 struct alignas(Align) Aligned {
-  void *operator new(size_t, std::align_val_t, Ts...) = delete; // expected-note 2{{deleted}} expected-note 2{{not viable}}
+  void *operator new(size_t, std::align_val_t, Ts...) = delete; // expected-note 4{{deleted}}
 };
-auto *aa = new Aligned<__STDCPP_DEFAULT_NEW_ALIGNMENT__>; // expected-error {{no matching}}
+auto *aa = new Aligned<__STDCPP_DEFAULT_NEW_ALIGNMENT__>; // expected-error {{deleted}}
 auto *ab = new Aligned<__STDCPP_DEFAULT_NEW_ALIGNMENT__ * 2>; // expected-error {{deleted}}
-auto *aap = new (arg) Aligned<__STDCPP_DEFAULT_NEW_ALIGNMENT__, Arg>; // expected-error {{no matching}}
+auto *aap = new (arg) Aligned<__STDCPP_DEFAULT_NEW_ALIGNMENT__, Arg>; // expected-error {{deleted}}
 auto *abp = new (arg) Aligned<__STDCPP_DEFAULT_NEW_ALIGNMENT__ * 2, Arg>; // expected-error {{deleted}}
 
 // If both are available, we prefer the aligned version for an overaligned

--- a/clang/test/SemaCXX/new-delete.cpp
+++ b/clang/test/SemaCXX/new-delete.cpp
@@ -15,7 +15,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify=expected,since-cxx26,cxx17,cxx20 %s -triple=i686-pc-linux-gnu -Wno-new-returns-null -std=c++2c -fexperimental-new-constant-interpreter -DNEW_INTERP
 
 // FIXME Location is (frontend)
-// cxx17-note@*:* {{candidate function not viable: requires 2 arguments, but 3 were provided}}
+// cxx17-note@*:* {{candidate function not viable: requires 2 arguments, but 4 were provided}}
 
 #include <stddef.h>
 

--- a/clang/test/SemaCXX/std-align-val-t-in-operator-new.cpp
+++ b/clang/test/SemaCXX/std-align-val-t-in-operator-new.cpp
@@ -62,9 +62,14 @@ void *operator new(std::size_t, std::align_val_t, X); // #3
 // FIXME: Consider improving notes 1 and 3 here to say that these are aligned
 // allocation functions and the type is not over-aligned.
 X *p = new (123) X; // expected-error {{no matching function}}
+#if __cpp_aligned_new
+// expected-note@#1 {{requires 2 arguments, but 3 were provided}}
+// expected-note@#3 {{no known conversion from 'int' to 'X' for 3rd argument}}
+#else
 // expected-note@#1 {{no known conversion from 'int' to 'std::align_val_t' for 2nd argument}}
-// expected-note@#2 {{no known conversion from 'int' to 'X' for 2nd argument}}
 // expected-note@#3 {{requires 3 arguments}}
+#endif
+// expected-note@#2 {{no known conversion from 'int' to 'X' for 2nd argument}}
 // expected-note@* {{requires 1 argument, but 2 were provided}} (builtin)
 
 #ifdef __cpp_aligned_new
@@ -77,7 +82,12 @@ Y *q = new (123) Y; // expected-error {{no matching function}}
 #endif
 
 X *r = new (std::align_val_t(32), 123) X; // expected-error {{no matching function}}
+#ifdef __cpp_aligned_new
+// expected-note@#1 {{requires 2 arguments, but 4 were provided}}
+// expected-note@#3 {{requires 3 arguments, but 4 were provided}}
+#else
 // expected-note@#1 {{requires 2 arguments, but 3 were provided}}
-// expected-note@#2 {{requires 2 arguments, but 3 were provided}}
 // expected-note@#3 {{no known conversion from 'int' to 'X' for 3rd argument}}
+#endif
+// expected-note@#2 {{requires 2 arguments, but 3 were provided}}
 // expected-note@* {{requires 1 argument, but 3 were provided}} (builtin)

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -15763,7 +15763,7 @@
     <td>[<a href="https://wg21.link/expr.new">expr.new</a>]</td>
     <td>C++20</td>
     <td>Consistency with mismatched aligned/non-over-aligned allocation/deallocation functions</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="unreleased" align="center">Clang 23</td>
   </tr>
   <tr id="2283">
     <td><a href="https://cplusplus.github.io/CWG/issues/2283.html">2283</a></td>


### PR DESCRIPTION
Link: https://wg21.link/cwg2282

For non-over-aligned types, overload resolution now falls back to aligned allocation functions.

This reimplements #203832 without depending on #203824.