### PR TITLE
[clang][driver] Add a -target-variant alias for -darwin-target-variant

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -6723,6 +6723,7 @@ def target : Joined<["--"], "target=">, Flags<[NoXarchOption]>,
 def darwin_target_variant : Separate<["-"], "darwin-target-variant">,
   Flags<[NoXarchOption]>, Visibility<[ClangOption, CLOption]>,
   HelpText<"Generate code for an additional runtime variant of the deployment target">;
+def target_variant : Separate<["-"], "target-variant">, Alias<darwin_target_variant>;
 
 //===----------------------------------------------------------------------===//
 // Print CPU info options (clang, clang-cl, flang)

--- a/clang/test/Driver/darwin-target-variant-sdk-version.c
+++ b/clang/test/Driver/darwin-target-variant-sdk-version.c
@@ -7,6 +7,10 @@
 // RUN: %clang -target x86_64-apple-ios13.1-macabi -isysroot %S/Inputs/MacOSX10.15.sdk -c -### %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-MACCATALYST %s
 
+// Check that the -target-variant alias for -darwin-target-variant behaves identically.
+// RUN: %clang -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13.1-macabi -isysroot %S/Inputs/MacOSX10.15.sdk -c -### %s 2>&1 \
+// RUN:   | FileCheck %s
+
 // CHECK: "-target-sdk-version=10.15" "-darwin-target-variant-sdk-version=13.1"
 // CHECK-SWAPPED: "-target-sdk-version=13.1" "-darwin-target-variant-sdk-version=10.15"
 // CHECK-MACCATALYST: "-target-sdk-version=13.1"


### PR DESCRIPTION
Swift Build uses the `-target-variant` argument which is an alias for -darwin-target-variant that's only present in the Xcode version of clang. Upstream it for general support and parity with swiftc.