### PR TITLE
[SPIR-V] Reject fp128 and ppc_fp128 types with a diagnostic

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -395,10 +395,9 @@ Register SPIRVGlobalRegistry::createConstFP(const ConstantFP *CF,
           MIB = MIRBuilder.buildInstr(SPIRV::OpConstantF)
                     .addDef(Res)
                     .addUse(getSPIRVTypeID(SpvType));
-          APInt RawBits = CF->getValueAPF().bitcastToAPInt();
-          uint64_t ImmBits =
-              RawBits.getBitWidth() <= 64 ? RawBits.getZExtValue() : 0;
-          addNumImm(APInt(BitWidth, ImmBits), MIB);
+          addNumImm(APInt(BitWidth,
+                          CF->getValueAPF().bitcastToAPInt().getZExtValue()),
+                    MIB);
         }
         const auto &ST = CurMF->getSubtarget();
         constrainSelectedInstRegOperands(*MIB, *ST.getInstrInfo(),
@@ -1205,12 +1204,8 @@ SPIRVTypeInst SPIRVGlobalRegistry::createSPIRVType(
                       : getOpTypeInt(Width, MIRBuilder, false);
   }
   if (Ty->isFloatingPointTy()) {
-    if (Ty->isFP128Ty() || Ty->isPPC_FP128Ty()) {
-      Function &F = MIRBuilder.getMF().getFunction();
-      F.getContext().diagnose(DiagnosticInfoUnsupported(
-          F, "fp128 is not supported in SPIR-V", DebugLoc(), DS_Error));
-      return getOpTypeFloat(64, MIRBuilder);
-    }
+    if (Ty->isFP128Ty() || Ty->isPPC_FP128Ty())
+      llvm::reportFatalUsageError("fp128 is not supported in SPIR-V");
     if (Ty->isBFloatTy()) {
       return getOpTypeFloat(Ty->getPrimitiveSizeInBits(), MIRBuilder,
                             SPIRV::FPEncoding::BFloat16KHR);

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -395,9 +395,10 @@ Register SPIRVGlobalRegistry::createConstFP(const ConstantFP *CF,
           MIB = MIRBuilder.buildInstr(SPIRV::OpConstantF)
                     .addDef(Res)
                     .addUse(getSPIRVTypeID(SpvType));
-          addNumImm(APInt(BitWidth,
-                          CF->getValueAPF().bitcastToAPInt().getZExtValue()),
-                    MIB);
+          APInt RawBits = CF->getValueAPF().bitcastToAPInt();
+          uint64_t ImmBits =
+              RawBits.getBitWidth() <= 64 ? RawBits.getZExtValue() : 0;
+          addNumImm(APInt(BitWidth, ImmBits), MIB);
         }
         const auto &ST = CurMF->getSubtarget();
         constrainSelectedInstRegOperands(*MIB, *ST.getInstrInfo(),

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -1204,6 +1204,12 @@ SPIRVTypeInst SPIRVGlobalRegistry::createSPIRVType(
                       : getOpTypeInt(Width, MIRBuilder, false);
   }
   if (Ty->isFloatingPointTy()) {
+    if (Ty->isFP128Ty() || Ty->isPPC_FP128Ty()) {
+      Function &F = MIRBuilder.getMF().getFunction();
+      F.getContext().diagnose(DiagnosticInfoUnsupported(
+          F, "fp128 is not supported in SPIR-V", DebugLoc(), DS_Error));
+      return getOpTypeFloat(64, MIRBuilder);
+    }
     if (Ty->isBFloatTy()) {
       return getOpTypeFloat(Ty->getPrimitiveSizeInBits(), MIRBuilder,
                             SPIRV::FPEncoding::BFloat16KHR);

--- a/llvm/test/CodeGen/SPIRV/constant/fp128-unsupported.ll
+++ b/llvm/test/CodeGen/SPIRV/constant/fp128-unsupported.ll
@@ -3,7 +3,7 @@
 
 ; RUN: not llc -O0 -mtriple=spirv32-unknown-unknown %s -o /dev/null 2>&1 | FileCheck %s
 
-; CHECK: error:{{.*}}fp128 is not supported in SPIR-V
+; CHECK: LLVM ERROR: fp128 is not supported in SPIR-V
 
 define fp128 @getConstantFP128() {
   ret fp128 0xL00000000000000004001000000000000

--- a/llvm/test/CodeGen/SPIRV/constant/fp128-unsupported.ll
+++ b/llvm/test/CodeGen/SPIRV/constant/fp128-unsupported.ll
@@ -1,0 +1,10 @@
+; Test that fp128 and ppc_fp128, which are not valid standard SPIR-V types,
+; produce an error instead of being silently miscompiled.
+
+; RUN: not llc -O0 -mtriple=spirv32-unknown-unknown %s -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: error:{{.*}}fp128 is not supported in SPIR-V
+
+define fp128 @getConstantFP128() {
+  ret fp128 0xL00000000000000004001000000000000
+}


### PR DESCRIPTION
Introduced as a part of discussion in https://github.com/llvm/llvm-project/pull/208219 