### PR TITLE
[orc-rt] Add regression test-tool infrastructure

### DIFF
--- a/orc-rt/test/CMakeLists.txt
+++ b/orc-rt/test/CMakeLists.txt
@@ -8,8 +8,12 @@ if (ORC_RT_LLVM_TOOLS_AVAILABLE)
     ${CMAKE_CURRENT_SOURCE_DIR}/regression/lit.cfg.py
   )
 
+  # Build the regression test-support tools.
+  add_subdirectory(tools)
+
   list(APPEND ORC_RT_TEST_DEPS
     orc-executor
+    orc-rt-smoke-check
   )
 
   add_custom_target(orc-rt-test-depends DEPENDS ${ORC_RT_TEST_DEPS})

--- a/orc-rt/test/regression/lit.cfg.py
+++ b/orc-rt/test/regression/lit.cfg.py
@@ -21,4 +21,10 @@ llvm_config.with_environment(
     os.path.join(config.orc_rt_obj_root, "tools", "orc-executor"),
     append_path=True)
 
+# Regression test-support tools live under test/tools.
+llvm_config.with_environment(
+    "PATH",
+    os.path.join(config.orc_rt_obj_root, "test", "tools"),
+    append_path=True)
+
 llvm_config.use_default_substitutions()

--- a/orc-rt/test/regression/lit.cfg.py
+++ b/orc-rt/test/regression/lit.cfg.py
@@ -23,8 +23,7 @@ llvm_config.with_environment(
 
 # Regression test-support tools live under test/tools.
 llvm_config.with_environment(
-    "PATH",
-    os.path.join(config.orc_rt_obj_root, "test", "tools"),
-    append_path=True)
+    "PATH", os.path.join(config.orc_rt_obj_root, "test", "tools"), append_path=True
+)
 
 llvm_config.use_default_substitutions()

--- a/orc-rt/test/regression/smoke-check.test
+++ b/orc-rt/test/regression/smoke-check.test
@@ -1,0 +1,5 @@
+# Smoke-check the regression test-tool infrastructure: that a tool under
+# test/tools is built, is on lit's PATH, and that its output can be matched.
+RUN: orc-rt-smoke-check | FileCheck %s
+
+CHECK: smoke check

--- a/orc-rt/test/tools/CMakeLists.txt
+++ b/orc-rt/test/tools/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Tools used by the ORC-RT regression tests. These are test-support binaries
+# built into the test tree; they are not installed with the runtime.
+
+add_executable(orc-rt-smoke-check orc-rt-smoke-check.cpp)

--- a/orc-rt/test/tools/orc-rt-smoke-check.cpp
+++ b/orc-rt/test/tools/orc-rt-smoke-check.cpp
@@ -1,0 +1,21 @@
+//===- orc-rt-smoke-check.cpp ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A minimal regression-test tool. It exists only to smoke-check that the ORC
+// runtime regression test-tool infrastructure works end to end: that a tool
+// under test/tools is built, placed where lit can find it, and that its output
+// can be matched by a regression test.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdio>
+
+int main() {
+  std::puts("smoke check");
+  return 0;
+}


### PR DESCRIPTION
Set up the infrastructure for regression tests that build and run a helper tool, in preparation for testing the logging backends.

- Add test/tools/ for test-support binaries, with a first tool, orc-rt-smoke-check, wired into ORC_RT_TEST_DEPS and onto lit's PATH.
- Add test/regression/smoke-check.test, which runs the tool and matches its output with FileCheck, exercising the tool-build and lit plumbing end to end.