### PR TITLE
[LLVM][NFC] Remove some global constructors

### DIFF
--- a/llvm/include/llvm/ADT/PointerIntPair.h
+++ b/llvm/include/llvm/ADT/PointerIntPair.h
@@ -34,7 +34,8 @@ template <typename Ptr> struct PunnedPointer {
   static_assert(std::is_trivially_copy_constructible<Ptr>::value, "");
   static_assert(std::is_trivially_move_constructible<Ptr>::value, "");
 
-  explicit constexpr PunnedPointer(intptr_t i = 0) { *this = i; }
+  explicit constexpr PunnedPointer() : Data{} {}
+  explicit PunnedPointer(intptr_t i) { *this = i; }
 
   constexpr intptr_t asInt() const {
     intptr_t R = 0;
@@ -44,7 +45,7 @@ template <typename Ptr> struct PunnedPointer {
 
   constexpr operator intptr_t() const { return asInt(); }
 
-  constexpr PunnedPointer &operator=(intptr_t V) {
+  PunnedPointer &operator=(intptr_t V) {
     std::memcpy(Data, &V, sizeof(Data));
     return *this;
   }

--- a/llvm/include/llvm/Analysis/DOTGraphTraitsPass.h
+++ b/llvm/include/llvm/Analysis/DOTGraphTraitsPass.h
@@ -18,8 +18,6 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/GraphWriter.h"
 
-static llvm::StringSet<> nameObj;
-
 namespace llvm {
 
 /// Default traits class for extracting a graph from an analysis pass.
@@ -91,6 +89,7 @@ static inline void shortenFileName(std::string &FN, unsigned char len = 250) {
     FN.resize(len);
   auto strLen = FN.length();
   while (strLen > 0) {
+    static llvm::StringSet<> nameObj;
     if (nameObj.insert(FN).second)
       break;
     FN.resize(--len);

--- a/llvm/include/llvm/CGData/CodeGenData.h
+++ b/llvm/include/llvm/CGData/CodeGenData.h
@@ -119,11 +119,10 @@ class CodeGenData {
   /// Or, it can be mutated with -fcodegen-data-thinlto-two-rounds.
   bool EmitCGData;
 
-  /// This is a singleton instance which is thread-safe. Unlike profile data
+  /// There is a singleton instance which is thread-safe. Unlike profile data
   /// which is largely function-based, codegen data describes the whole module.
   /// Therefore, this can be initialized once, and can be used across modules
   /// instead of constructing the same one for each codegen backend.
-  static std::unique_ptr<CodeGenData> Instance;
   static std::once_flag OnceFlag;
 
   CodeGenData() = default;

--- a/llvm/include/llvm/CodeGen/LiveInterval.h
+++ b/llvm/include/llvm/CodeGen/LiveInterval.h
@@ -62,7 +62,7 @@ namespace llvm {
     SlotIndex def;
 
     /// VNInfo constructor.
-    VNInfo(unsigned i, SlotIndex d) : id(i), def(d) {}
+    constexpr VNInfo(unsigned i, SlotIndex d) : id(i), def(d) {}
 
     /// VNInfo constructor, copies values from orig, except for the value number.
     VNInfo(unsigned i, const VNInfo &orig) : id(i), def(orig.def) {}

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -79,7 +79,7 @@ struct MBBSectionID {
 
 private:
   // This is only used to construct the special cold and exception sections.
-  MBBSectionID(SectionType T) : Type(T), Number(0) {}
+  constexpr MBBSectionID(SectionType T) : Type(T), Number(0) {}
 };
 
 template <> struct DenseMapInfo<MBBSectionID> {

--- a/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h
@@ -30,7 +30,7 @@ class ContinuationRecordBuilder {
   AppendingBinaryByteStream Buffer;
   BinaryStreamWriter SegmentWriter;
   TypeRecordMapping Mapping;
-  ArrayRef<uint8_t> InjectedSegmentBytes;
+  SmallVector<uint8_t, 12> InjectedSegmentBytes;
 
   uint32_t getCurrentSegmentLength() const;
 

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeHashing.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeHashing.h
@@ -183,8 +183,6 @@ static_assert(std::is_trivially_copyable<GloballyHashedType>::value,
 } // namespace codeview
 
 template <> struct DenseMapInfo<codeview::LocallyHashedType> {
-  LLVM_ABI static codeview::LocallyHashedType Empty;
-
   static unsigned getHashValue(codeview::LocallyHashedType Val) {
     return Val.Hash;
   }
@@ -198,8 +196,6 @@ template <> struct DenseMapInfo<codeview::LocallyHashedType> {
 };
 
 template <> struct DenseMapInfo<codeview::GloballyHashedType> {
-  LLVM_ABI static codeview::GloballyHashedType Empty;
-
   static unsigned getHashValue(codeview::GloballyHashedType Val) {
     return *reinterpret_cast<const unsigned *>(Val.Hash.data());
   }

--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -997,9 +997,6 @@ public:
         std::vector<CallsiteInfo>(), std::vector<AllocInfo>());
   }
 
-  /// A dummy node to reference external functions that aren't in the index
-  LLVM_ABI static FunctionSummary ExternalNode;
-
 private:
   /// Number of instructions (ignoring debug instructions, e.g.) computed
   /// during the initial compile step when the summary index is first built.
@@ -2130,9 +2127,7 @@ template <> struct GraphTraits<ValueInfo> {
 
   static ChildIteratorType child_begin(NodeRef N) {
     if (!N.getSummaryList().size()) // handle external function
-      return ChildIteratorType(
-          FunctionSummary::ExternalNode.CallGraphEdgeList.begin(),
-          &valueInfoFromEdge);
+      return ChildIteratorType(ChildEdgeIteratorType(), &valueInfoFromEdge);
     FunctionSummary *F =
         cast<FunctionSummary>(N.getSummaryList().front()->getBaseObject());
     return ChildIteratorType(F->CallGraphEdgeList.begin(), &valueInfoFromEdge);
@@ -2140,9 +2135,7 @@ template <> struct GraphTraits<ValueInfo> {
 
   static ChildIteratorType child_end(NodeRef N) {
     if (!N.getSummaryList().size()) // handle external function
-      return ChildIteratorType(
-          FunctionSummary::ExternalNode.CallGraphEdgeList.end(),
-          &valueInfoFromEdge);
+      return ChildIteratorType(ChildEdgeIteratorType(), &valueInfoFromEdge);
     FunctionSummary *F =
         cast<FunctionSummary>(N.getSummaryList().front()->getBaseObject());
     return ChildIteratorType(F->CallGraphEdgeList.end(), &valueInfoFromEdge);
@@ -2150,7 +2143,7 @@ template <> struct GraphTraits<ValueInfo> {
 
   static ChildEdgeIteratorType child_edge_begin(NodeRef N) {
     if (!N.getSummaryList().size()) // handle external function
-      return FunctionSummary::ExternalNode.CallGraphEdgeList.begin();
+      return ChildEdgeIteratorType();
 
     FunctionSummary *F =
         cast<FunctionSummary>(N.getSummaryList().front()->getBaseObject());
@@ -2159,7 +2152,7 @@ template <> struct GraphTraits<ValueInfo> {
 
   static ChildEdgeIteratorType child_edge_end(NodeRef N) {
     if (!N.getSummaryList().size()) // handle external function
-      return FunctionSummary::ExternalNode.CallGraphEdgeList.end();
+      return ChildEdgeIteratorType();
 
     FunctionSummary *F =
         cast<FunctionSummary>(N.getSummaryList().front()->getBaseObject());

--- a/llvm/include/llvm/IR/ProfileSummary.h
+++ b/llvm/include/llvm/IR/ProfileSummary.h
@@ -35,8 +35,8 @@ struct ProfileSummaryEntry {
   const uint64_t MinCount;  ///< The minimum count for this percentile.
   const uint64_t NumCounts; ///< Number of counts >= the minimum count.
 
-  ProfileSummaryEntry(uint32_t TheCutoff, uint64_t TheMinCount,
-                      uint64_t TheNumCounts)
+  constexpr ProfileSummaryEntry(uint32_t TheCutoff, uint64_t TheMinCount,
+                                uint64_t TheNumCounts)
       : Cutoff(TheCutoff), MinCount(TheMinCount), NumCounts(TheNumCounts) {}
 };
 

--- a/llvm/include/llvm/Passes/OptimizationLevel.h
+++ b/llvm/include/llvm/Passes/OptimizationLevel.h
@@ -22,7 +22,7 @@ namespace llvm {
 
 class OptimizationLevel final {
   unsigned SpeedLevel = 2;
-  OptimizationLevel(unsigned SpeedLevel) : SpeedLevel(SpeedLevel) {
+  constexpr OptimizationLevel(unsigned SpeedLevel) : SpeedLevel(SpeedLevel) {
     // Check that only valid values are passed.
     assert(SpeedLevel <= 3 &&
            "Optimization level for speed should be 0, 1, 2, or 3");

--- a/llvm/include/llvm/Support/Alignment.h
+++ b/llvm/include/llvm/Support/Alignment.h
@@ -65,10 +65,10 @@ public:
   constexpr Align &operator=(const Align &Other) = default;
   constexpr Align &operator=(Align &&Other) = default;
 
-  explicit Align(uint64_t Value) {
+  explicit constexpr Align(uint64_t Value) {
     assert(Value > 0 && "Value must not be 0");
     assert(llvm::isPowerOf2_64(Value) && "Alignment is not a power of 2");
-    ShiftValue = Log2_64(Value);
+    ShiftValue = 63 - llvm::countl_zero_constexpr(Value);
     assert(ShiftValue < 64 && "Broken invariant");
   }
 

--- a/llvm/lib/CGData/CodeGenData.cpp
+++ b/llvm/lib/CGData/CodeGenData.cpp
@@ -141,10 +141,10 @@ std::string getCodeGenDataSectionName(CGDataSectKind CGSK,
   return SectName;
 }
 
-std::unique_ptr<CodeGenData> CodeGenData::Instance = nullptr;
 std::once_flag CodeGenData::OnceFlag;
 
 CodeGenData &CodeGenData::getInstance() {
+  static std::unique_ptr<CodeGenData> Instance = nullptr;
   std::call_once(CodeGenData::OnceFlag, []() {
     Instance = std::unique_ptr<CodeGenData>(new CodeGenData());
 

--- a/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
@@ -48,7 +48,7 @@ static cl::opt<std::string>
                    cl::desc("Record GlobalISel rule coverage files of this "
                             "prefix if instrumentation was generated"));
 #else
-static const std::string CoveragePrefix;
+static constexpr StringRef CoveragePrefix;
 #endif
 
 char InstructionSelect::ID = 0;

--- a/llvm/lib/CodeGen/InterferenceCache.cpp
+++ b/llvm/lib/CodeGen/InterferenceCache.cpp
@@ -27,7 +27,7 @@ using namespace llvm;
 #define DEBUG_TYPE "regalloc"
 
 // Static member used for null interference cursors.
-const InterferenceCache::BlockInterference
+constexpr InterferenceCache::BlockInterference
     InterferenceCache::Cursor::NoInterference;
 
 // Initializes PhysRegEntries (instead of a SmallVector, PhysRegEntries is a

--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
@@ -155,7 +155,7 @@ static cl::opt<unsigned>
                          cl::desc("livedebugvalues-stack-ws-limit"),
                          cl::init(250));
 
-DbgOpID DbgOpID::UndefID = DbgOpID(0xffffffff);
+constexpr DbgOpID DbgOpID::UndefID = DbgOpID(0xffffffff);
 
 /// Tracker for converting machine value locations and variable values into
 /// variable locations (the output of LiveDebugValues), recorded as DBG_VALUEs
@@ -487,7 +487,7 @@ public:
     for (auto Location : MTracker->locations()) {
       LocIdx Idx = Location.Idx;
       ValueIDNum &VNum = MLocs[Idx.asU64()];
-      if (VNum == ValueIDNum::EmptyValue)
+      if (VNum == ValueIDNum())
         continue;
       VarLocs.push_back(VNum);
 
@@ -832,7 +832,7 @@ public:
     if (ActiveMLocIt == ActiveMLocs.end())
       return;
 
-    VarLocs[MLoc.asU64()] = ValueIDNum::EmptyValue;
+    VarLocs[MLoc.asU64()] = ValueIDNum();
 
     // Examine the remaining variable locations: if we can find the same value
     // again, we can recover the location.
@@ -957,7 +957,7 @@ public:
     // XXX XXX XXX "pretend to be old LDV" means dropping all tracking data
     // about the old location.
     if (EmulateOldLDV)
-      VarLocs[Src.asU64()] = ValueIDNum::EmptyValue;
+      VarLocs[Src.asU64()] = ValueIDNum();
   }
 
   MachineInstrBuilder emitMOLoc(const MachineOperand &MO,
@@ -981,8 +981,6 @@ public:
 //===----------------------------------------------------------------------===//
 //            Implementation
 //===----------------------------------------------------------------------===//
-
-ValueIDNum ValueIDNum::EmptyValue = {UINT_MAX, UINT_MAX, UINT_MAX};
 
 #ifndef NDEBUG
 void ResolvedDbgOp::dump(const MLocTracker *MTrack) const {
@@ -1032,8 +1030,8 @@ void DbgValue::dump(const MLocTracker *MTrack,
 MLocTracker::MLocTracker(MachineFunction &MF, const TargetInstrInfo &TII,
                          const TargetRegisterInfo &TRI,
                          const TargetLowering &TLI)
-    : MF(MF), TII(TII), TRI(TRI), TLI(TLI),
-      LocIdxToIDNum(ValueIDNum::EmptyValue), LocIdxToLocID(0) {
+    : MF(MF), TII(TII), TRI(TRI), TLI(TLI), LocIdxToIDNum(ValueIDNum()),
+      LocIdxToLocID(0) {
   NumRegs = TRI.getNumRegs();
   reset();
   LocIDToLocIdx.resize(NumRegs, LocIdx::MakeIllegalLoc());
@@ -3784,7 +3782,7 @@ bool InstrRefBasedLDV::ExtendRanges(MachineFunction &MF,
     // If there is no resolved value for this live-in then it is not directly
     // reachable from the entry block -- model it as a PHI on entry to this
     // block, which means we leave the ValueIDNum unchanged.
-    if (ResolvedValue != ValueIDNum::EmptyValue)
+    if (ResolvedValue != ValueIDNum())
       Num = ResolvedValue;
   }
   // Later, we'll be looking up ranges of instruction numbers.

--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.h
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.h
@@ -153,9 +153,10 @@ class ValueIDNum {
   static_assert(sizeof(u) == 8, "Badly packed ValueIDNum?");
 
 public:
-  // Default-initialize to EmptyValue. This is necessary to make IndexedMaps
+  // Default-initialize to an empty value. This is necessary to make IndexedMaps
   // of values to work.
-  ValueIDNum() { u.Value = EmptyValue.asU64(); }
+  constexpr ValueIDNum()
+      : u{{(1u << 20) - 1, (1u << 20) - 1, (1u << NUM_LOC_BITS) - 1}} {}
 
   ValueIDNum(uint64_t Block, uint64_t Inst, uint64_t Loc) {
     u.s = {Block, Inst, Loc};
@@ -199,8 +200,6 @@ public:
                                             .concat(Twine("}")))))
         .str();
   }
-
-  LLVM_ABI_FOR_TEST static ValueIDNum EmptyValue;
 };
 
 } // End namespace LiveDebugValues
@@ -238,8 +237,7 @@ struct FuncValueTable {
   FuncValueTable(int NumBBs, int NumLocs) {
     Storage.reserve(NumBBs);
     for (int i = 0; i != NumBBs; ++i)
-      Storage.push_back(
-          std::make_unique<ValueTable>(NumLocs, ValueIDNum::EmptyValue));
+      Storage.push_back(std::make_unique<ValueTable>(NumLocs, ValueIDNum()));
   }
 
   /// Returns the ValueTable associated with MBB.
@@ -350,11 +348,11 @@ struct DbgOp {
   };
   bool IsConst;
 
-  DbgOp() : ID(ValueIDNum::EmptyValue), IsConst(false) {}
+  DbgOp() : ID(), IsConst(false) {}
   DbgOp(ValueIDNum ID) : ID(ID), IsConst(false) {}
   DbgOp(MachineOperand MO) : MO(MO), IsConst(true) {}
 
-  bool isUndef() const { return !IsConst && ID == ValueIDNum::EmptyValue; }
+  bool isUndef() const { return !IsConst && ID == ValueIDNum(); }
 
 #ifndef NDEBUG
   void dump(const MLocTracker *MTrack) const;
@@ -409,10 +407,10 @@ struct DbgOpID {
   DbgOpID() : RawID(UndefID.RawID) {
     static_assert(sizeof(DbgOpID) == 4, "DbgOpID should fit within 4 bytes.");
   }
-  DbgOpID(uint32_t RawID) : RawID(RawID) {}
+  constexpr DbgOpID(uint32_t RawID) : RawID(RawID) {}
   DbgOpID(bool IsConst, uint32_t Index) : ID({IsConst, Index}) {}
 
-  LLVM_ABI_FOR_TEST static DbgOpID UndefID;
+  LLVM_ABI_FOR_TEST static const DbgOpID UndefID;
 
   bool operator==(const DbgOpID &Other) const { return RawID == Other.RawID; }
   bool operator!=(const DbgOpID &Other) const { return !(*this == Other); }
@@ -583,8 +581,8 @@ public:
   ArrayRef<DbgOpID> getDbgOpIDs() const { return {DbgOps, OpCount}; }
 
   // Returns either DbgOps[Index] if this DbgValue has Debug Operands, or
-  // the ID for ValueIDNum::EmptyValue otherwise (i.e. if this is an Undef,
-  // NoVal, or an unjoined VPHI).
+  // the ID for ValueIDNum() otherwise (i.e. if this is an Undef, NoVal, or an
+  // unjoined VPHI).
   DbgOpID getDbgOpID(unsigned Index) const {
     if (!OpCount)
       return DbgOpID::UndefID;
@@ -937,7 +935,7 @@ public:
   void wipeRegister(Register R) {
     unsigned ID = getLocID(R);
     LocIdx Idx = LocIDToLocIdx[ID];
-    LocIdxToIDNum[Idx] = ValueIDNum::EmptyValue;
+    LocIdxToIDNum[Idx] = ValueIDNum();
   }
 
   /// Determine the LocIdx of an existing register.

--- a/llvm/lib/CodeGen/LiveIntervalCalc.cpp
+++ b/llvm/lib/CodeGen/LiveIntervalCalc.cpp
@@ -25,9 +25,6 @@ using namespace llvm;
 
 #define DEBUG_TYPE "regalloc"
 
-// Reserve an address that indicates a value that is known to be "undef".
-static VNInfo UndefVNI(0xbad, SlotIndex());
-
 static void createDeadDef(SlotIndexes &Indexes, VNInfo::Allocator &Alloc,
                           LiveRange &LR, const MachineOperand &MO) {
   const MachineInstr &MI = *MO.getParent();

--- a/llvm/lib/CodeGen/LiveRangeCalc.cpp
+++ b/llvm/lib/CodeGen/LiveRangeCalc.cpp
@@ -34,7 +34,7 @@ using namespace llvm;
 #define DEBUG_TYPE "regalloc"
 
 // Reserve an address that indicates a value that is known to be "undef".
-static VNInfo UndefVNI(0xbad, SlotIndex());
+static constexpr VNInfo UndefVNI(0xbad, SlotIndex());
 
 void LiveRangeCalc::resetLiveOutMap() {
   unsigned NumBlocks = MF->getNumBlockIDs();
@@ -250,7 +250,7 @@ bool LiveRangeCalc::findReachingDefs(LiveRange &LR, MachineBasicBlock &UseMBB,
        auto EP = LR.extendInBlock(Undefs, Start, End);
        VNInfo *VNI = EP.first;
        FoundUndef |= EP.second;
-       setLiveOutValue(Pred, EP.second ? &UndefVNI : VNI);
+       setLiveOutValue(Pred, EP.second ? const_cast<VNInfo *>(&UndefVNI) : VNI);
        if (VNI) {
          if (TheVNI && TheVNI != VNI)
            UniqueVNI = false;

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -1850,6 +1850,7 @@ void MachineBasicBlock::removePHIsIncomingValuesForPredecessor(
     Phi.removePHIIncomingValueFor(PredMBB);
 }
 
-const MBBSectionID MBBSectionID::ColdSectionID(MBBSectionID::SectionType::Cold);
-const MBBSectionID
+constexpr MBBSectionID
+    MBBSectionID::ColdSectionID(MBBSectionID::SectionType::Cold);
+constexpr MBBSectionID
     MBBSectionID::ExceptionSectionID(MBBSectionID::SectionType::Exception);

--- a/llvm/lib/DebugInfo/CodeView/ContinuationRecordBuilder.cpp
+++ b/llvm/lib/DebugInfo/CodeView/ContinuationRecordBuilder.cpp
@@ -31,9 +31,6 @@ static void addPadding(BinaryStreamWriter &Writer) {
   }
 }
 
-static SegmentInjection InjectFieldList(TypeLeafKind::LF_FIELDLIST);
-static SegmentInjection InjectMethodOverloadList(TypeLeafKind::LF_METHODLIST);
-
 static constexpr uint32_t ContinuationLength = sizeof(ContinuationRecord);
 static constexpr uint32_t MaxSegmentLength =
     MaxRecordLength - ContinuationLength;
@@ -58,11 +55,10 @@ void ContinuationRecordBuilder::begin(ContinuationRecordKind RecordKind) {
   assert(SegmentWriter.getOffset() == 0);
   assert(SegmentWriter.getLength() == 0);
 
-  const SegmentInjection *FLI =
-      (RecordKind == ContinuationRecordKind::FieldList)
-          ? &InjectFieldList
-          : &InjectMethodOverloadList;
-  const uint8_t *FLIB = reinterpret_cast<const uint8_t *>(FLI);
+  SegmentInjection FLI(RecordKind == ContinuationRecordKind::FieldList
+                           ? TypeLeafKind::LF_FIELDLIST
+                           : TypeLeafKind::LF_METHODLIST);
+  const uint8_t *FLIB = reinterpret_cast<const uint8_t *>(&FLI);
   InjectedSegmentBytes =
       ArrayRef<uint8_t>(FLIB, FLIB + sizeof(SegmentInjection));
 

--- a/llvm/lib/DebugInfo/CodeView/ContinuationRecordBuilder.cpp
+++ b/llvm/lib/DebugInfo/CodeView/ContinuationRecordBuilder.cpp
@@ -55,12 +55,9 @@ void ContinuationRecordBuilder::begin(ContinuationRecordKind RecordKind) {
   assert(SegmentWriter.getOffset() == 0);
   assert(SegmentWriter.getLength() == 0);
 
-  SegmentInjection FLI(RecordKind == ContinuationRecordKind::FieldList
-                           ? TypeLeafKind::LF_FIELDLIST
-                           : TypeLeafKind::LF_METHODLIST);
+  SegmentInjection FLI(getTypeLeafKind(RecordKind));
   const uint8_t *FLIB = reinterpret_cast<const uint8_t *>(&FLI);
-  InjectedSegmentBytes =
-      ArrayRef<uint8_t>(FLIB, FLIB + sizeof(SegmentInjection));
+  InjectedSegmentBytes.assign(FLIB, FLIB + sizeof(SegmentInjection));
 
   // Seed the first record with an appropriate record prefix.
   RecordPrefix Prefix(getTypeLeafKind(RecordKind));

--- a/llvm/lib/DebugInfo/CodeView/TypeHashing.cpp
+++ b/llvm/lib/DebugInfo/CodeView/TypeHashing.cpp
@@ -14,13 +14,6 @@
 using namespace llvm;
 using namespace llvm::codeview;
 
-LocallyHashedType DenseMapInfo<LocallyHashedType>::Empty{0, {}};
-
-static std::array<uint8_t, 8> EmptyHash = {
-    {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-GloballyHashedType DenseMapInfo<GloballyHashedType>::Empty{EmptyHash};
-
 LocallyHashedType LocallyHashedType::hashType(ArrayRef<uint8_t> RecordData) {
   return {llvm::hash_value(RecordData), RecordData};
 }

--- a/llvm/lib/DebugInfo/CodeView/TypeStreamMerger.cpp
+++ b/llvm/lib/DebugInfo/CodeView/TypeStreamMerger.cpp
@@ -72,8 +72,6 @@ public:
     CurIndex += SourceToDest.size();
   }
 
-  static const TypeIndex Untranslated;
-
   // Local hashing entry points
   Error mergeTypesAndIds(MergingTypeTableBuilder &DestIds,
                          MergingTypeTableBuilder &DestTypes,
@@ -152,7 +150,8 @@ private:
     // successfully. If it refers to a type later in the stream or a record we
     // had to defer, defer it until later pass.
     unsigned MapPos = slotForIndex(Idx);
-    if (LLVM_UNLIKELY(MapPos >= Map.size() || Map[MapPos] == Untranslated))
+    if (LLVM_UNLIKELY(MapPos >= Map.size() ||
+                      Map[MapPos] == TypeIndex(SimpleTypeKind::NotTranslated)))
       return false;
 
     Idx = Map[MapPos];
@@ -202,8 +201,6 @@ private:
 
 } // end anonymous namespace
 
-const TypeIndex TypeStreamMerger::Untranslated(SimpleTypeKind::NotTranslated);
-
 void TypeStreamMerger::addMapping(TypeIndex Idx) {
   if (!IsSecondPass) {
     assert(IndexMap.size() == slotForIndex(CurIndex) &&
@@ -234,7 +231,7 @@ bool TypeStreamMerger::remapIndexFallback(TypeIndex &Idx,
 
   // This type index is invalid. Remap this to "not translated by cvpack",
   // and return failure.
-  Idx = Untranslated;
+  Idx = TypeIndex(SimpleTypeKind::NotTranslated);
   return false;
 }
 
@@ -353,7 +350,7 @@ Error TypeStreamMerger::remapType(const CVType &Type) {
   if (!R)
     return R.takeError();
 
-  TypeIndex DestIdx = Untranslated;
+  TypeIndex DestIdx = TypeIndex(SimpleTypeKind::NotTranslated);
   if (*R) {
     auto DoSerialize =
         [this, Type](MutableArrayRef<uint8_t> Storage) -> ArrayRef<uint8_t> {

--- a/llvm/lib/IR/ModuleSummaryIndex.cpp
+++ b/llvm/lib/IR/ModuleSummaryIndex.cpp
@@ -41,10 +41,6 @@ static cl::opt<bool> ImportConstantsWithRefs(
     "import-constants-with-refs", cl::init(true), cl::Hidden,
     cl::desc("Import constant global variables with references"));
 
-FunctionSummary FunctionSummary::ExternalNode =
-    FunctionSummary::makeDummyFunctionSummary(
-        SmallVector<FunctionSummary::EdgeTy, 0>());
-
 GlobalValue::VisibilityTypes ValueInfo::getELFVisibility() const {
   bool HasProtected = false;
   for (const auto &S : make_pointee_range(getSummaryList())) {

--- a/llvm/lib/Object/MachOUniversalWriter.cpp
+++ b/llvm/lib/Object/MachOUniversalWriter.cpp
@@ -244,17 +244,15 @@ template <typename FatArchTy> struct FatArchTraits {
 
 template <> struct FatArchTraits<MachO::fat_arch> {
   static const uint64_t OffsetLimit = UINT32_MAX;
-  static const std::string StructName;
+  static constexpr char StructName[] = "fat_arch";
   static const uint8_t BitCount = 32;
 };
-const std::string FatArchTraits<MachO::fat_arch>::StructName = "fat_arch";
 
 template <> struct FatArchTraits<MachO::fat_arch_64> {
   static const uint64_t OffsetLimit = UINT64_MAX;
-  static const std::string StructName;
+  static constexpr char StructName[] = "fat_arch_64";
   static const uint8_t BitCount = 64;
 };
-const std::string FatArchTraits<MachO::fat_arch_64>::StructName = "fat_arch_64";
 
 template <typename FatArchTy>
 static Expected<SmallVector<FatArchTy, 2>>

--- a/llvm/lib/Passes/OptimizationLevel.cpp
+++ b/llvm/lib/Passes/OptimizationLevel.cpp
@@ -10,7 +10,7 @@
 
 using namespace llvm;
 
-const OptimizationLevel OptimizationLevel::O0 = {0};
-const OptimizationLevel OptimizationLevel::O1 = {1};
-const OptimizationLevel OptimizationLevel::O2 = {2};
-const OptimizationLevel OptimizationLevel::O3 = {3};
+constexpr OptimizationLevel OptimizationLevel::O0 = {0};
+constexpr OptimizationLevel OptimizationLevel::O1 = {1};
+constexpr OptimizationLevel OptimizationLevel::O2 = {2};
+constexpr OptimizationLevel OptimizationLevel::O3 = {3};

--- a/llvm/lib/ProfileData/ProfileSummaryBuilder.cpp
+++ b/llvm/lib/ProfileData/ProfileSummaryBuilder.cpp
@@ -81,7 +81,7 @@ const ArrayRef<uint32_t> ProfileSummaryBuilder::DefaultCutoffs =
 // thresholds when -profile-summary-cutoff-hot/cold is 0.  If the hot cutoff is
 // 0, no sample counts are treated as hot.  If the cold cutoff is 0, all sample
 // counts are treated as cold.  Assumes there is no UINT64_MAX sample counts.
-static const ProfileSummaryEntry ZeroCutoffEntry = {0, UINT64_MAX, 0};
+static constexpr ProfileSummaryEntry ZeroCutoffEntry = {0, UINT64_MAX, 0};
 
 const ProfileSummaryEntry &
 ProfileSummaryBuilder::getEntryForPercentile(const SummaryEntryVector &DS,

--- a/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
+++ b/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
@@ -88,7 +88,7 @@ static cl::opt<StackTaggingRecordStackHistoryMode> ClRecordStackHistory(
                                 "storing into the stack ring buffer")),
     cl::Hidden, cl::init(none));
 
-static const Align kTagGranuleSize = Align(16);
+static constexpr Align kTagGranuleSize = Align(16);
 
 namespace {
 

--- a/llvm/lib/Target/ARM/Thumb1FrameLowering.cpp
+++ b/llvm/lib/Target/ARM/Thumb1FrameLowering.cpp
@@ -800,13 +800,13 @@ bool Thumb1FrameLowering::emitPopSpecialFixUp(MachineBasicBlock &MBB,
   return true;
 }
 
-static const SmallVector<Register> OrderedLowRegs = {ARM::R4, ARM::R5, ARM::R6,
-                                                     ARM::R7, ARM::LR};
-static const SmallVector<Register> OrderedHighRegs = {ARM::R8, ARM::R9,
-                                                      ARM::R10, ARM::R11};
-static const SmallVector<Register> OrderedCopyRegs = {
-    ARM::R0, ARM::R1, ARM::R2, ARM::R3, ARM::R4,
-    ARM::R5, ARM::R6, ARM::R7, ARM::LR};
+static constexpr std::array<Register, 5> OrderedLowRegs = {
+    {ARM::R4, ARM::R5, ARM::R6, ARM::R7, ARM::LR}};
+static constexpr std::array<Register, 5> OrderedHighRegs = {
+    {ARM::R8, ARM::R9, ARM::R10, ARM::R11}};
+static constexpr std::array<Register, 9> OrderedCopyRegs = {
+    {ARM::R0, ARM::R1, ARM::R2, ARM::R3, ARM::R4, ARM::R5, ARM::R6, ARM::R7,
+     ARM::LR}};
 
 static void splitLowAndHighRegs(const std::set<Register> &Regs,
                                 std::set<Register> &LowRegs,

--- a/llvm/lib/Target/X86/X86LoadValueInjectionLoadHardening.cpp
+++ b/llvm/lib/Target/X86/X86LoadValueInjectionLoadHardening.cpp
@@ -102,12 +102,6 @@ static cl::opt<bool> EmitDotVerify(
              "potential LVI gadgets, used for testing purposes only"),
     cl::init(false), cl::Hidden);
 
-static llvm::sys::DynamicLibrary OptimizeDL;
-typedef int (*OptimizeCutT)(unsigned int *Nodes, unsigned int NodesSize,
-                            unsigned int *Edges, int *EdgeValues,
-                            int *CutEdges /* out */, unsigned int EdgesSize);
-static OptimizeCutT OptimizeCut = nullptr;
-
 namespace {
 
 struct MachineGadgetGraph : ImmutableGraph<MachineInstr *, int> {
@@ -161,6 +155,9 @@ private:
   using Node = MachineGadgetGraph::Node;
   using EdgeSet = MachineGadgetGraph::EdgeSet;
   using NodeSet = MachineGadgetGraph::NodeSet;
+  using OptimizeCutT = int (*)(unsigned int *Nodes, unsigned int NodesSize,
+                               unsigned int *Edges, int *EdgeValues,
+                               int *CutEdges /* out */, unsigned int EdgesSize);
 
   const X86Subtarget *STI = nullptr;
   const TargetInstrInfo *TII = nullptr;
@@ -170,7 +167,7 @@ private:
   getGadgetGraph(MachineFunction &MF, const MachineLoopInfo &MLI,
                  const MachineDominatorTree &MDT,
                  const MachineDominanceFrontier &MDF) const;
-  int hardenLoadsWithPlugin(MachineFunction &MF,
+  int hardenLoadsWithPlugin(OptimizeCutT OptimizeCut, MachineFunction &MF,
                             std::unique_ptr<MachineGadgetGraph> Graph) const;
   int hardenLoadsWithHeuristic(MachineFunction &MF,
                                std::unique_ptr<MachineGadgetGraph> Graph) const;
@@ -297,6 +294,8 @@ bool X86LoadValueInjectionLoadHardeningImpl::run(
 
   int FencesInserted;
   if (!OptimizePluginPath.empty()) {
+    static llvm::sys::DynamicLibrary OptimizeDL;
+    static OptimizeCutT OptimizeCut = nullptr;
     if (!OptimizeDL.isValid()) {
       std::string ErrorMsg;
       OptimizeDL = llvm::sys::DynamicLibrary::getPermanentLibrary(
@@ -308,7 +307,7 @@ bool X86LoadValueInjectionLoadHardeningImpl::run(
       if (!OptimizeCut)
         report_fatal_error("Invalid optimization plugin");
     }
-    FencesInserted = hardenLoadsWithPlugin(MF, std::move(Graph));
+    FencesInserted = hardenLoadsWithPlugin(OptimizeCut, MF, std::move(Graph));
   } else { // Use the default greedy heuristic
     FencesInserted = hardenLoadsWithHeuristic(MF, std::move(Graph));
   }
@@ -605,7 +604,8 @@ X86LoadValueInjectionLoadHardeningImpl::trimMitigatedEdges(
 }
 
 int X86LoadValueInjectionLoadHardeningImpl::hardenLoadsWithPlugin(
-    MachineFunction &MF, std::unique_ptr<MachineGadgetGraph> Graph) const {
+    OptimizeCutT OptimizeCut, MachineFunction &MF,
+    std::unique_ptr<MachineGadgetGraph> Graph) const {
   int FencesInserted = 0;
 
   do {

--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -2296,7 +2296,7 @@ uint64_t IndexCallsiteContextGraph::getLastStackId(IndexCall &Call) {
   return Index.getStackIdAtIndex(CallsiteContext.back());
 }
 
-static const std::string MemProfCloneSuffix = ".memprof.";
+static const char MemProfCloneSuffix[] = ".memprof.";
 
 static std::string getMemProfFuncName(Twine Base, unsigned CloneNo) {
   // We use CloneNo == 0 to refer to the original version, which doesn't get

--- a/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
@@ -120,9 +120,9 @@
 using namespace llvm;
 
 // This must be consistent with ShadowWidthBits.
-static const Align ShadowTLSAlignment = Align(2);
+static constexpr Align ShadowTLSAlignment = Align(2);
 
-static const Align MinOriginAlignment = Align(4);
+static constexpr Align MinOriginAlignment = Align(4);
 
 // The size of TLS variables. These constants must be kept in sync with the ones
 // in dfsan.cpp.

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -222,8 +222,8 @@ DEBUG_COUNTER(DebugInstrumentInstruction, "msan-instrument-instruction",
               "Controls which instruction to instrument");
 
 static const unsigned kOriginSize = 4;
-static const Align kMinOriginAlignment = Align(4);
-static const Align kShadowTLSAlignment = Align(8);
+static constexpr Align kMinOriginAlignment = Align(4);
+static constexpr Align kShadowTLSAlignment = Align(8);
 
 // These constants must be kept in sync with the ones in msan.h.
 // TODO: increase size to match SVE/SVE2/SME/SME2 limits

--- a/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
+++ b/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
@@ -227,7 +227,7 @@ public:
   void initValueArray(FuncValueTable &Nums, unsigned Blks, unsigned Locs) {
     for (unsigned int I = 0; I < Blks; ++I)
       for (unsigned int J = 0; J < Locs; ++J)
-        Nums[I][J] = ValueIDNum::EmptyValue;
+        Nums[I][J] = ValueIDNum();
   }
 
   void setupSingleBlock() {
@@ -843,7 +843,7 @@ TEST_F(InstrRefLDVTest, MTransferSubregSpills) {
     EXPECT_EQ(DefNum, SpillValue);
   }
 
-  // Stack slot for $rax should be a different value, today it's EmptyValue.
+  // Stack slot for $rax should be a different value, today it's an empty value.
   ValueIDNum SpillValue = MTracker->readMLoc(Spill64Loc);
   EXPECT_EQ(SpillValue, DefAtSpill64);
 
@@ -1178,7 +1178,7 @@ TEST_F(InstrRefLDVTest, MLocDiamondSpills) {
   EXPECT_EQ(MInLocs[3][HAXStackLoc.asU64()], HAXPHI);
   EXPECT_EQ(MInLocs[3][RAXStackLoc.asU64()], RAXPHI);
   // AH should be left untouched,
-  EXPECT_EQ(MInLocs[3][AHStackLoc.asU64()], ValueIDNum::EmptyValue);
+  EXPECT_EQ(MInLocs[3][AHStackLoc.asU64()], ValueIDNum());
 }
 
 TEST_F(InstrRefLDVTest, MLocSimpleLoop) {


### PR DESCRIPTION
Largely by converting relevant functions or variables to constexpr,
changing the type, converting to static locals, or by outright removal.

PunnedPointer assignment can never be constexpr, because std::memcpy is
not constexpr and type punning is not permitted in a constant-evaluated
context.
