### PR TITLE
[NFC][lldb] Simplify Typelist::GetTypeAtIndex

### DIFF
--- a/lldb/include/lldb/Symbol/TypeList.h
+++ b/lldb/include/lldb/Symbol/TypeList.h
@@ -34,7 +34,7 @@ public:
 
   bool Empty() const { return !GetSize(); }
 
-  lldb::TypeSP GetTypeAtIndex(uint32_t idx);
+  lldb::TypeSP GetTypeAtIndex(uint32_t idx) const;
 
   typedef std::vector<lldb::TypeSP> collection;
   typedef llvm::iterator_range<collection::const_iterator> TypeIterable;

--- a/lldb/source/Symbol/TypeList.cpp
+++ b/lldb/source/Symbol/TypeList.cpp
@@ -39,36 +39,32 @@ uint32_t TypeList::GetSize() const { return m_types.size(); }
 // type lists that are returned for "image dump -t TYPENAME" commands and other
 // simple symbol queries that grab the first result...
 
-TypeSP TypeList::GetTypeAtIndex(uint32_t idx) {
-  iterator pos, end;
-  uint32_t i = idx;
-  assert(i < GetSize() && "Accessing past the end of a TypeList");
-  for (pos = m_types.begin(), end = m_types.end(); pos != end; ++pos) {
-    if (i == 0)
-      return *pos;
-    --i;
-  }
-  return TypeSP();
+TypeSP TypeList::GetTypeAtIndex(uint32_t idx) const {
+  assert(idx < GetSize() && "Accessing past the end of a TypeList");
+
+  if (idx < m_types.size())
+    return m_types[idx];
+  return {};
 }
 
 void TypeList::ForEach(
     std::function<bool(const lldb::TypeSP &type_sp)> const &callback) const {
-  for (auto pos = m_types.begin(), end = m_types.end(); pos != end; ++pos) {
-    if (!callback(*pos))
+  for (const auto &type : m_types) {
+    if (!callback(type))
       break;
   }
 }
 
 void TypeList::ForEach(
     std::function<bool(lldb::TypeSP &type_sp)> const &callback) {
-  for (auto pos = m_types.begin(), end = m_types.end(); pos != end; ++pos) {
-    if (!callback(*pos))
+  for (auto &type : m_types) {
+    if (!callback(type))
       break;
   }
 }
 
 void TypeList::Dump(Stream *s, bool show_context) {
-  for (iterator pos = m_types.begin(), end = m_types.end(); pos != end; ++pos)
-    if (Type *t = pos->get())
-      t->Dump(s, show_context);
+  for (auto &type : m_types)
+    if (type)
+      type->Dump(s, show_context);
 }


### PR DESCRIPTION
Access the index value at constant time and use for range for the `ForEach` functions.