### PR TITLE
[libc++] Remove benchmark::DoNotOptimize from custom predicates in benchmarks

### DIFF
--- a/libcxx/test/benchmarks/algorithms/modifying/remove.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/remove.bench.cpp
@@ -22,10 +22,7 @@
 int main(int argc, char** argv) {
   auto std_remove    = [](auto first, auto last, auto const& value) { return std::remove(first, last, value); };
   auto std_remove_if = [](auto first, auto last, auto const& value) {
-    return std::remove_if(first, last, [&](auto element) {
-      benchmark::DoNotOptimize(element);
-      return element == value;
-    });
+    return std::remove_if(first, last, [&](auto element) { return element == value; });
   };
 
   // Benchmark {std,ranges}::{remove,remove_if} on a sequence of the form xxxxxxxxxxyyyyyyyyyy

--- a/libcxx/test/benchmarks/algorithms/modifying/replace.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/replace.bench.cpp
@@ -22,10 +22,7 @@
 int main(int argc, char** argv) {
   auto std_replace    = [](auto first, auto last, auto old, auto new_) { return std::replace(first, last, old, new_); };
   auto std_replace_if = [](auto first, auto last, auto old, auto new_) {
-    auto pred = [&](auto element) {
-      benchmark::DoNotOptimize(element);
-      return element == old;
-    };
+    auto pred = [&](auto element) { return element == old; };
     return std::replace_if(first, last, pred, new_);
   };
 

--- a/libcxx/test/benchmarks/algorithms/modifying/transform.binary.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/transform.binary.bench.cpp
@@ -38,11 +38,7 @@ int main(int argc, char** argv) {
 
             std::vector<ValueType> out(size);
 
-            auto f = [](auto x, auto y) {
-              benchmark::DoNotOptimize(x);
-              benchmark::DoNotOptimize(y);
-              return x + y;
-            };
+            auto f = [](auto x, auto y) { return x + y; };
 
             for ([[maybe_unused]] auto _ : st) {
               benchmark::DoNotOptimize(c1);

--- a/libcxx/test/benchmarks/algorithms/modifying/transform.unary.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/transform.unary.bench.cpp
@@ -35,10 +35,7 @@ int main(int argc, char** argv) {
 
             std::vector<ValueType> out(size);
 
-            auto f = [](auto element) {
-              benchmark::DoNotOptimize(element);
-              return element;
-            };
+            auto f = [](auto element) { return element; };
 
             for ([[maybe_unused]] auto _ : st) {
               benchmark::DoNotOptimize(c);

--- a/libcxx/test/benchmarks/algorithms/modifying/unique.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/unique.bench.cpp
@@ -22,11 +22,7 @@
 int main(int argc, char** argv) {
   auto std_unique      = [](auto first, auto last) { return std::unique(first, last); };
   auto std_unique_pred = [](auto first, auto last) {
-    return std::unique(first, last, [](auto a, auto b) {
-      benchmark::DoNotOptimize(a);
-      benchmark::DoNotOptimize(b);
-      return a == b;
-    });
+    return std::unique(first, last, [](auto a, auto b) { return a == b; });
   };
 
   // Create a sequence of the form xxxxxxxxxxyyyyyyyyyy and unique the

--- a/libcxx/test/benchmarks/algorithms/modifying/unique_copy.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/unique_copy.bench.cpp
@@ -22,11 +22,7 @@
 int main(int argc, char** argv) {
   auto std_unique_copy      = [](auto first, auto last, auto out) { return std::unique_copy(first, last, out); };
   auto std_unique_copy_pred = [](auto first, auto last, auto out) {
-    return std::unique_copy(first, last, out, [](auto a, auto b) {
-      benchmark::DoNotOptimize(a);
-      benchmark::DoNotOptimize(b);
-      return a == b;
-    });
+    return std::unique_copy(first, last, out, [](auto a, auto b) { return a == b; });
   };
 
   // Create a sequence of the form xxxxxxxxxxyyyyyyyyyy and unique the

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/adjacent_find.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/adjacent_find.bench.cpp
@@ -21,11 +21,7 @@
 int main(int argc, char** argv) {
   auto std_adjacent_find      = [](auto first, auto last) { return std::adjacent_find(first, last); };
   auto std_adjacent_find_pred = [](auto first, auto last) {
-    return std::adjacent_find(first, last, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::adjacent_find(first, last, [](auto x, auto y) { return x == y; });
   };
 
   // Benchmark {std,ranges}::adjacent_find on a sequence of the form xyxyxyxyxyxyxyxyxyxy,

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/any_all_none_of.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/any_all_none_of.bench.cpp
@@ -45,10 +45,7 @@ int main(int argc, char** argv) {
 
             for ([[maybe_unused]] auto _ : st) {
               benchmark::DoNotOptimize(c);
-              auto result = any_of(c.begin(), c.end(), [&](auto element) {
-                benchmark::DoNotOptimize(element);
-                return element == y;
-              });
+              auto result = any_of(c.begin(), c.end(), [&](auto element) { return element == y; });
               benchmark::DoNotOptimize(result);
             }
           })

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/count.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/count.bench.cpp
@@ -21,10 +21,7 @@
 int main(int argc, char** argv) {
   auto std_count    = [](auto first, auto last, auto const& value) { return std::count(first, last, value); };
   auto std_count_if = [](auto first, auto last, auto const& value) {
-    return std::count_if(first, last, [&](auto element) {
-      benchmark::DoNotOptimize(element);
-      return element == value;
-    });
+    return std::count_if(first, last, [&](auto element) { return element == value; });
   };
 
   // Benchmark {std,ranges}::{count,count_if} on a sequence where every other element is counted.

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/ends_with.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/ends_with.bench.cpp
@@ -22,11 +22,7 @@
 
 int main(int argc, char** argv) {
   auto ranges_ends_with_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::ranges::ends_with(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::ranges::ends_with(first1, last1, first2, last2, [](auto x, auto y) { return x == y; });
   };
 
   // Benchmark ranges::ends_with where we find the mismatching element at the very end.

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/equal.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/equal.bench.cpp
@@ -24,18 +24,10 @@ int main(int argc, char** argv) {
     return std::equal(first1, last1, first2, last2);
   };
   auto std_equal_3leg_pred = [](auto first1, auto last1, auto first2, auto) {
-    return std::equal(first1, last1, first2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::equal(first1, last1, first2, [](auto x, auto y) { return x == y; });
   };
   auto std_equal_4leg_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::equal(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::equal(first1, last1, first2, last2, [](auto x, auto y) { return x == y; });
   };
 
   // Benchmark {std,ranges}::equal where we determine inequality at the very end (worst case).

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/find_end.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/find_end.bench.cpp
@@ -25,11 +25,7 @@ int main(int argc, char** argv) {
     return std::find_end(first1, last1, first2, last2);
   };
   auto std_find_end_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::find_end(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::find_end(first1, last1, first2, last2, [](auto x, auto y) { return x == y; });
   };
 
   auto register_benchmarks = [&](auto bm, std::string comment) {

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/find_first_of.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/find_first_of.bench.cpp
@@ -24,11 +24,7 @@ int main(int argc, char** argv) {
     return std::find_first_of(first1, last1, first2, last2);
   };
   auto std_find_first_of_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::find_first_of(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::find_first_of(first1, last1, first2, last2, [](auto x, auto y) { return x == y; });
   };
 
   // Benchmark {std,ranges}::find_first_of where we never find a match in the needle, and the needle is small.

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/find_last.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/find_last.bench.cpp
@@ -21,16 +21,10 @@
 
 int main(int argc, char** argv) {
   auto ranges_find_last_if = [](auto first, auto last, auto const& value) {
-    return std::ranges::find_last_if(first, last, [&](auto element) {
-      benchmark::DoNotOptimize(element);
-      return element == value;
-    });
+    return std::ranges::find_last_if(first, last, [&](auto element) { return element == value; });
   };
   auto ranges_find_last_if_not = [](auto first, auto last, auto const& value) {
-    return std::ranges::find_last_if_not(first, last, [&](auto element) {
-      benchmark::DoNotOptimize(element);
-      return element != value;
-    });
+    return std::ranges::find_last_if_not(first, last, [&](auto element) { return element != value; });
   };
 
   // Benchmark ranges::{find_last,find_last_if,find_last_if_not} where the last element

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/fold.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/fold.bench.cpp
@@ -50,11 +50,7 @@ int main(int argc, char** argv) {
             ValueType init = c.back();
             c.pop_back();
 
-            auto f = [](auto x, auto y) {
-              benchmark::DoNotOptimize(x);
-              benchmark::DoNotOptimize(y);
-              return x + y;
-            };
+            auto f = [](auto x, auto y) { return x + y; };
 
             for ([[maybe_unused]] auto _ : st) {
               benchmark::DoNotOptimize(c);

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/is_permutation.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/is_permutation.bench.cpp
@@ -27,18 +27,10 @@ int main(int argc, char** argv) {
     return std::is_permutation(first1, last1, first2, last2);
   };
   auto std_is_permutation_3leg_pred = [](auto first1, auto last1, auto first2, auto) {
-    return std::is_permutation(first1, last1, first2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::is_permutation(first1, last1, first2, [](auto x, auto y) { return x == y; });
   };
   auto std_is_permutation_4leg_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::is_permutation(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::is_permutation(first1, last1, first2, last2, [](auto x, auto y) { return x == y; });
   };
 
   auto register_benchmarks = [&](auto bm, std::string comment) {

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/mismatch.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/mismatch.bench.cpp
@@ -26,18 +26,10 @@ int main(int argc, char** argv) {
     return std::mismatch(first1, last1, first2, last2);
   };
   auto std_mismatch_3leg_pred = [](auto first1, auto last1, auto first2, auto) {
-    return std::mismatch(first1, last1, first2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::mismatch(first1, last1, first2, [](auto x, auto y) { return x == y; });
   };
   auto std_mismatch_4leg_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::mismatch(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::mismatch(first1, last1, first2, last2, [](auto x, auto y) { return x == y; });
   };
 
   // Benchmark {std,ranges}::mismatch where we find the mismatching element at the very end (worst case).

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/search.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/search.bench.cpp
@@ -24,11 +24,7 @@ int main(int argc, char** argv) {
     return std::search(first1, last1, first2, last2);
   };
   auto std_search_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::search(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::search(first1, last1, first2, last2, [](auto x, auto y) { return x == y; });
   };
 
   // Benchmark {std,ranges}::search where the needle is never found (worst case).

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/search_n.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/search_n.bench.cpp
@@ -24,11 +24,7 @@ int main(int argc, char** argv) {
     return std::search_n(first, last, n, value);
   };
   auto std_search_n_pred = [](auto first, auto last, auto n, auto const& value) {
-    return std::search_n(first, last, n, value, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::search_n(first, last, n, value, [](auto x, auto y) { return x == y; });
   };
 
   // Benchmark {std,ranges}::search_n where the needle almost matches a lot.

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/starts_with.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/starts_with.bench.cpp
@@ -20,11 +20,7 @@
 
 int main(int argc, char** argv) {
   auto ranges_starts_with_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::ranges::starts_with(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
+    return std::ranges::starts_with(first1, last1, first2, last2, [](auto x, auto y) { return x == y; });
   };
 
   // Benchmark ranges::starts_with where we find the mismatching element at the very end (worst case).

--- a/libcxx/test/benchmarks/algorithms/sorting/is_sorted.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/sorting/is_sorted.bench.cpp
@@ -22,11 +22,7 @@
 int main(int argc, char** argv) {
   auto std_is_sorted      = [](auto first, auto last) { return std::is_sorted(first, last); };
   auto std_is_sorted_pred = [](auto first, auto last) {
-    return std::is_sorted(first, last, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x < y;
-    });
+    return std::is_sorted(first, last, [](auto x, auto y) { return x < y; });
   };
 
   // Benchmark {std,ranges}::is_sorted on a sorted sequence (the worst case).

--- a/libcxx/test/benchmarks/algorithms/sorting/is_sorted_until.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/sorting/is_sorted_until.bench.cpp
@@ -22,11 +22,7 @@
 int main(int argc, char** argv) {
   auto std_is_sorted_until      = [](auto first, auto last) { return std::is_sorted_until(first, last); };
   auto std_is_sorted_until_pred = [](auto first, auto last) {
-    return std::is_sorted_until(first, last, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x < y;
-    });
+    return std::is_sorted_until(first, last, [](auto x, auto y) { return x < y; });
   };
 
   // Benchmark {std,ranges}::is_sorted_until on a sorted sequence (the worst case).


### PR DESCRIPTION
The point of the custom predicates is to defeat any detection of special predicates within the library. There isn't much point in adding `benchmark::DoNotOptimize` on top of that. It can actually hurt, since it may hide performance changes due to how much/which information we provide to the compiler.
