### PR TITLE
[AArch64] stilp for 128-bit SC stores with RCPC3

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -7804,8 +7804,7 @@ SDValue AArch64TargetLowering::LowerStore128(SDValue Op,
   assert(StoreNode->getMemoryVT() == MVT::i128);
   assert(StoreNode->isVolatile() || StoreNode->isAtomic());
 
-  bool IsStoreRelease =
-      StoreNode->getMergedOrdering() == AtomicOrdering::Release;
+  bool IsStoreRelease = isReleaseOrStronger(StoreNode->getMergedOrdering());
   if (StoreNode->isAtomic())
     assert((Subtarget->hasFeature(AArch64::FeatureLSE2) &&
             Subtarget->hasFeature(AArch64::FeatureRCPC3) && IsStoreRelease) ||
@@ -32030,7 +32029,7 @@ bool AArch64TargetLowering::isOpSuitableForRCPC3(const Instruction *I) const {
   if (auto SI = dyn_cast<StoreInst>(I))
     return SI->getValueOperand()->getType()->getPrimitiveSizeInBits() == 128 &&
            SI->getAlign() >= Align(16) &&
-           SI->getOrdering() == AtomicOrdering::Release;
+           isReleaseOrStronger(SI->getOrdering());
 
   return false;
 }

--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
@@ -28,6 +28,7 @@
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/IntrinsicsAArch64.h"
 #include "llvm/IR/Type.h"
+#include "llvm/Support/AtomicOrdering.h"
 #include "llvm/Support/MathExtras.h"
 #include <initializer_list>
 
@@ -2177,7 +2178,7 @@ bool AArch64LegalizerInfo::legalizeLoadStore(
     AtomicOrdering Ordering = (*MI.memoperands_begin())->getSuccessOrdering();
     bool IsLoad = MI.getOpcode() == TargetOpcode::G_LOAD;
     bool IsLoadAcquire = IsLoad && Ordering == AtomicOrdering::Acquire;
-    bool IsStoreRelease = !IsLoad && Ordering == AtomicOrdering::Release;
+    bool IsStoreRelease = !IsLoad && isReleaseOrStronger(Ordering);
     bool IsRcpC3 =
         ST->hasLSE2() && ST->hasRCPC3() && (IsLoadAcquire || IsStoreRelease);
 

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-rcpc3.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-rcpc3.ll
@@ -138,9 +138,7 @@ define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) 
 
 define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) {
 ; CHECK-LABEL: store_atomic_i128_aligned_seq_cst:
-; CHECK:    dmb ish
-; CHECK:    stp x0, x1, [x2]
-; CHECK:    dmb ish
+; CHECK:    stilp x0, x1, [x2]
     store atomic i128 %value, ptr %ptr seq_cst, align 16
     ret void
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-store-rcpc3.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-store-rcpc3.ll
@@ -138,9 +138,7 @@ define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) 
 
 define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) {
 ; CHECK-LABEL: store_atomic_i128_aligned_seq_cst:
-; CHECK:    dmb ish
-; CHECK:    stp x0, x1, [x2]
-; CHECK:    dmb ish
+; CHECK:    stilp x0, x1, [x2]
     store atomic i128 %value, ptr %ptr seq_cst, align 16
     ret void
 }


### PR DESCRIPTION
This is what atomicsabi64.pdf suggests.
https://github.com/ARM-software/abi-aa/releases
I don't think the current version is wrong, just unnecessarily strict.

Patch series:
- https://github.com/llvm/llvm-project/pull/206936
- https://github.com/llvm/llvm-project/pull/208417
- https://github.com/llvm/llvm-project/pull/208443
- https://github.com/llvm/llvm-project/pull/208452