### PR TITLE
[lldb] Fix SymbolFilePDBTests after FileSpec change f9b5264523b1

### DIFF
--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -94,7 +94,7 @@ protected:
     if (!left.FileEquals(right))
       return false;
     // If BOTH have a directory, also compare the directories.
-    if (left.GetDirectory() && right.GetDirectory())
+    if (!left.GetDirectory().empty() && !right.GetDirectory().empty())
       return left.DirectoryEquals(right);
 
     // If one has a directory but not the other, they match.


### PR DESCRIPTION
GetDirectory() returns a StringRef now which doesn't convert to bool implicitly. This breaks compilation of the check-lldb target: `binary '&&': no operator found which takes a left-hand operand of type 'llvm::StringRef'`