### PR TITLE
[lldb-dap] Log the adapter's stdio during cleanup

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb_dap/lldb_dap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb_dap/lldb_dap_testcase.py
@@ -153,6 +153,13 @@ class DAPTestCaseBase(Base, metaclass=LLDBTestCaseFactory):
         def cleanup_adapter():
             if adapter.is_alive:
                 adapter.kill()
+            # The debug adapter may have a reason the test failed.
+            if stderr := adapter.process.stderr:
+                if err_str := stderr.read().decode():
+                    self.logger.debug("The adapter stderr: \n%s", err_str)
+            if stdout := adapter.process.stdout:
+                if err_str := stdout.read().decode():
+                    self.logger.debug("The adapter stdout: \n%s", err_str)
 
         self.addTearDownHook(cleanup_adapter)
         return adapter

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb_dap/utils.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb_dap/utils.py
@@ -156,6 +156,7 @@ class DebugAdapter:
             self._process.wait(timeout=2.0)
         except subprocess.TimeoutExpired:
             self._process.kill()
+            self._process.wait()
 
     def _read_listening_uri(self) -> str:
         # lldb-dap will print the listening address once the listener is


### PR DESCRIPTION
The adapter may crash for any reason especially if it is built with sanitizers. Log the adapter's stdout and stderr.