### PR TITLE
[lldb] Fix DW_OP_convert type handling

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
@@ -724,6 +724,9 @@ DWARFUnit::GetDIEBitSizeAndSign(uint64_t relative_die_offset) const {
   DWARFDIE die = const_cast<DWARFUnit *>(this)->GetDIE(abs_die_offset);
   if (!die)
     return llvm::createStringError("cannot resolve DW_OP_convert type DIE");
+  if (die.Tag() != DW_TAG_base_type)
+    return llvm::createStringError(
+        "DW_OP_convert type DIE is not a DW_TAG_base_type");
   uint64_t encoding =
       die.GetAttributeValueAsUnsigned(DW_AT_encoding, DW_ATE_hi_user);
   uint64_t bit_size = die.GetAttributeValueAsUnsigned(DW_AT_byte_size, 0) * 8;

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -445,6 +445,14 @@ DWARF:
               Form:            DW_FORM_data1
             - Attribute:       DW_AT_byte_size
               Form:            DW_FORM_data1
+        - Code:            0x00000003
+          Tag:             DW_TAG_enumeration_type
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_encoding
+              Form:            DW_FORM_data1
+            - Attribute:       DW_AT_byte_size
+              Form:            DW_FORM_data1
   debug_info:
     - Version:         4
       AddrSize:        8
@@ -493,15 +501,21 @@ DWARF:
           Values:
             - Value:           0x000000000000000b # DW_ATE_numeric_string
             - Value:           0x0000000000000001
+        # 0x00000020:
+        - AbbrCode:        0x00000003
+          Values:
+            - Value:           0x0000000000000007 # DW_ATE_unsigned
+            - Value:           0x0000000000000004
         - AbbrCode:        0x00000000
 
 )";
-  // Compile unit relative offsets to each DW_TAG_base_type
+  // Compile unit relative offsets to type DIEs.
   uint8_t offs_uint32_t = 0x0000000e;
   uint8_t offs_uint64_t = 0x00000011;
   uint8_t offs_sint64_t = 0x00000014;
   uint8_t offs_uchar = 0x00000017;
   uint8_t offs_schar = 0x0000001a;
+  uint8_t offs_enum = 0x00000020;
 
   DWARFExpressionTester t(yamldata, /*cu_index=*/1);
   ASSERT_TRUE((bool)t.GetDwarfUnit());
@@ -574,6 +588,12 @@ DWARF:
   EXPECT_THAT_ERROR(
       t.Eval({DW_OP_const1s, 'X', DW_OP_convert, 0x1d}).takeError(),
       llvm::Failed());
+
+  // Not a DW_TAG_base_type.
+  EXPECT_THAT_ERROR(
+      t.Eval({DW_OP_const1s, 'X', DW_OP_convert, offs_enum}).takeError(),
+      llvm::FailedWithMessage(
+          "DW_OP_convert type DIE is not a DW_TAG_base_type"));
 
   // A non-zero DIE offset with no DWARF unit.
   EXPECT_THAT_ERROR(


### PR DESCRIPTION
This PR fixes  #208197

A nonzero DW_OP_convert operand must reference a DW_TAG_base_type DIE. LLDB previously accepted any DIE that happened to carry base-type-like size and encoding attributes. This patch rejects non-base-type DIEs before using them as DW_OP_convert target types.

## Tests

Extended DWARFExpression.DW_OP_convert coverage to verify:

- non-DW_TAG_base_type DIEs are rejected as DW_OP_convert target types;
