### PR TITLE
[lldb][test] Add a new test for char types

### DIFF
--- a/lldb/test/API/lang/cpp/builtin_types/char/Makefile
+++ b/lldb/test/API/lang/cpp/builtin_types/char/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/builtin_types/char/TestCharTypes.py
+++ b/lldb/test/API/lang/cpp/builtin_types/char/TestCharTypes.py
@@ -1,0 +1,33 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        self.build_and_run()
+
+        self.expect_var_path("the_char", type="char", value="'a'")
+        self.expect_expr("the_char", result_type="char", result_value="'a'")
+
+        self.expect_var_path("the_signed_char", type="signed char", value="'B'")
+        self.expect_expr(
+            "the_signed_char", result_type="signed char", result_value="'B'"
+        )
+
+        self.expect_var_path("the_unsigned_char", type="unsigned char", value="'Z'")
+        self.expect_expr(
+            "the_unsigned_char", result_type="unsigned char", result_value="'Z'"
+        )
+
+        # Check edge-case values: smallest, largest, zero and -1.
+        self.expect_var_path("char_zero", type="char", value="'\\0'")
+        self.expect_var_path("char_neg_one", type="char", value="'\\xff'")
+        self.expect_var_path("char_high_bit", type="char", value="'\\x80'")
+        self.expect_var_path("char_low_max", type="char", value="'\\x7f'")
+        self.expect_var_path("schar_neg_one", type="signed char", value="'\\xff'")
+        self.expect_var_path("schar_min", type="signed char", value="'\\x80'")
+        self.expect_var_path("schar_max", type="signed char", value="'\\x7f'")
+        self.expect_var_path("uchar_zero", type="unsigned char", value="'\\0'")
+        self.expect_var_path("uchar_max", type="unsigned char", value="'\\xff'")

--- a/lldb/test/API/lang/cpp/builtin_types/char/main.cpp
+++ b/lldb/test/API/lang/cpp/builtin_types/char/main.cpp
@@ -1,0 +1,19 @@
+int main() {
+  char the_char = 'a';
+  signed char the_signed_char = 'B';
+  unsigned char the_unsigned_char = 'Z';
+
+  // Edge-cases.
+  char char_zero = 0;
+  char char_neg_one = -1;
+  char char_high_bit = (char)0x80;
+  char char_low_max = (char)0x7f;
+
+  signed char schar_neg_one = -1;
+  signed char schar_min = -128;
+  signed char schar_max = 127;
+  unsigned char uchar_zero = 0;
+  unsigned char uchar_max = 255;
+
+  return 0; // break here
+}


### PR DESCRIPTION
This is a new modern test for char types that replaces the test logic from `API/types` test that is about to be deleted.

See also #208402

assisted-by: claude