### PR TITLE
[lldb][Windows] mark TestPlatformProcessConnect as XFAIL

### DIFF
--- a/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
+++ b/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
+
 @skipIfWasm  # no remote platform to connect to
 class TestPlatformProcessConnect(TestBase):
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
+++ b/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
@@ -4,7 +4,6 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
-@expectedFailureWindows  # process modules not loaded
 @skipIfWasm  # no remote platform to connect to
 class TestPlatformProcessConnect(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
@@ -13,6 +12,7 @@ class TestPlatformProcessConnect(TestBase):
     @skipIfRemote
     @expectedFailureAll(hostoslist=["windows"], triple=".*-android")
     @skipIfDarwin  # lldb-server not found correctly
+    @expectedFailureWindows  # process modules not loaded
     # lldb-server platform times out waiting for the gdbserver port number to be
     # written to the pipe, yet it seems the gdbserver already has written it.
     @expectedFailureAll(
@@ -43,6 +43,7 @@ class TestPlatformProcessConnect(TestBase):
     @skipIfRemote
     @expectedFailureAll(hostoslist=["windows"], triple=".*-android")
     @skipIfDarwin  # lldb-server not found correctly
+    @expectedFailureWindows  # process modules not loaded
     # lldb-server platform times out waiting for the gdbserver port number to be
     # written to the pipe, yet it seems the gdbserver already has written it.
     @expectedFailureAll(

--- a/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
+++ b/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
@@ -4,7 +4,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
-
+@expectedFailureWindows  # process modules not loaded
 @skipIfWasm  # no remote platform to connect to
 class TestPlatformProcessConnect(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
@@ -13,7 +13,6 @@ class TestPlatformProcessConnect(TestBase):
     @skipIfRemote
     @expectedFailureAll(hostoslist=["windows"], triple=".*-android")
     @skipIfDarwin  # lldb-server not found correctly
-    @expectedFailureWindowsAndNoLLDBServer()  # process modules not loaded
     # lldb-server platform times out waiting for the gdbserver port number to be
     # written to the pipe, yet it seems the gdbserver already has written it.
     @expectedFailureAll(
@@ -44,7 +43,6 @@ class TestPlatformProcessConnect(TestBase):
     @skipIfRemote
     @expectedFailureAll(hostoslist=["windows"], triple=".*-android")
     @skipIfDarwin  # lldb-server not found correctly
-    @expectedFailureWindows  # process modules not loaded
     # lldb-server platform times out waiting for the gdbserver port number to be
     # written to the pipe, yet it seems the gdbserver already has written it.
     @expectedFailureAll(


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/202688 incorrectly marked `TestPlatformProcessConnect.py` as PASS on Windows with `lldb-server`. They do not work and are failing just like with the in process plugin.

Re-mark both of them as XFAIL.

rdar://181797532