### PR TITLE
[mlir][tosa] Fix reduce-transpose sub-byte handling

### DIFF
--- a/mlir/lib/Dialect/Tosa/Transforms/TosaReduceTransposes.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaReduceTransposes.cpp
@@ -233,8 +233,7 @@ TosaReduceTransposes::transposeDenseAttribute(DenseElementsAttr input,
   // perms: dim 0→2, dim 1→0, dim 2→1, giving source position
   // calculated as 1*inputStrides[2] + 1*inputStrides[0] + 2*inputStrides[1]
   // = 1*1 + 1*12 + 2*4 = 21
-
-  size_t elementSize = oldType.getElementTypeBitWidth() / 8;
+  size_t elementSize = llvm::divideCeil(oldType.getElementTypeBitWidth(), 8);
   int64_t numElements = oldType.getNumElements();
 
   SmallVector<char> outputBuffer(numElements * elementSize);

--- a/mlir/test/Dialect/Tosa/tosa-reduce-transposes.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-reduce-transposes.mlir
@@ -597,3 +597,21 @@ func.func @test_unimplemented_static_diverges_to_one_nullifying_one_non_nullifyi
   %result = tosa.transpose %add {perms = array<i32: 0, 3, 1, 2>}: (tensor<1x3x4x2xi32>) -> tensor<1x2x3x4xi32>
   return %result : tensor<1x2x3x4xi32>
 }
+
+// CHECK-LABEL: @test_transpose_bool
+// CHECK: %{{.*}} = "tosa.const"()
+// CHECK-SAME{LITERAL}: dense<[[true, false], [false, false], [false, true]]>
+func.func @test_transpose_bool() -> tensor<3x2xi1> {
+  %0 = "tosa.const"() <{values = dense<[[true, false, false], [false, false, true]]> : tensor<2x3xi1>}> : () -> tensor<2x3xi1>
+  %1 = tosa.transpose %0 {perms = array<i32: 1, 0>} : (tensor<2x3xi1>) -> tensor<3x2xi1>
+  return %1 : tensor<3x2xi1>
+}
+
+// CHECK-LABEL: @test_transpose_i4
+// CHECK: %{{.*}} = "tosa.const"()
+// CHECK-SAME{LITERAL}: dense<[[1, 4], [2, 5], [3, 6]]>
+func.func @test_transpose_i4() -> tensor<3x2xi4> {
+  %0 = "tosa.const"() <{values = dense<[[1, 2, 3], [4, 5, 6]]> : tensor<2x3xi4>}> : () -> tensor<2x3xi4>
+  %1 = tosa.transpose %0 {perms = array<i32: 1, 0>} : (tensor<2x3xi4>) -> tensor<3x2xi4>
+  return %1 : tensor<3x2xi4>
+}


### PR DESCRIPTION
- Fix element size calculation when processing sub-byte types
- Add tests for i1 and i4

Signed-off-by: Iliyan Georgiev  <Iliyan.Georgiev@arm.com>
