### PR TITLE
[BOLT] fix DIE traversal incorrect loop termination condition.

### DIFF
--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -590,8 +590,8 @@ static SmallVector<SmallVector<DWARFUnit *>> partitionCUs(DWARFContext &DwCtx,
     const uint64_t NextCUOffset = CU->getNextUnitOffset();
     DWARFDataExtractor DebugInfoData = CU->getDebugInfoExtractor();
     DWARFDebugInfoEntry DIEEntry;
-    // extractFast() here only attributes are inspected here, so ParentIdx is passed
-    // as a dummy value.
+    // extractFast() here only attributes are inspected here, so ParentIdx is
+    // passed as a dummy value.
     while (DIEOffset < NextCUOffset) {
       if (!DIEEntry.extractFast(*CU, &DIEOffset, DebugInfoData, NextCUOffset,
                                 /*ParentIdx=*/0))

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -591,6 +591,8 @@ static SmallVector<SmallVector<DWARFUnit *>> partitionCUs(DWARFContext &DwCtx,
     DWARFDataExtractor DebugInfoData = CU->getDebugInfoExtractor();
     DWARFDebugInfoEntry DIEEntry;
     SmallVector<uint32_t, 8> ParentIndex;
+    // The initial entry is an artificial root. The unit's terminating null DIE
+    // only pops back to this root, so stop before reading past NextCUOffset.
     ParentIndex.push_back(UINT32_MAX);
     do {
       if (!DIEEntry.extractFast(*CU, &DIEOffset, DebugInfoData, NextCUOffset,
@@ -622,7 +624,7 @@ static SmallVector<SmallVector<DWARFUnit *>> partitionCUs(DWARFContext &DwCtx,
       } else {
         ParentIndex.pop_back();
       }
-    } while (!ParentIndex.empty());
+    } while (DIEOffset < NextCUOffset);
   }
 
   DenseMap<DWARFUnit *, SmallVector<DWARFUnit *>> MembersByLeader;

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -590,13 +590,11 @@ static SmallVector<SmallVector<DWARFUnit *>> partitionCUs(DWARFContext &DwCtx,
     const uint64_t NextCUOffset = CU->getNextUnitOffset();
     DWARFDataExtractor DebugInfoData = CU->getDebugInfoExtractor();
     DWARFDebugInfoEntry DIEEntry;
-    SmallVector<uint32_t, 8> ParentIndex;
-    // The initial entry is an artificial root. The unit's terminating null DIE
-    // only pops back to this root, so stop before reading past NextCUOffset.
-    ParentIndex.push_back(UINT32_MAX);
-    do {
+    // extractFast() here only attributes are inspected here, so ParentIdx is passed
+    // as a dummy value.
+    while (DIEOffset < NextCUOffset) {
       if (!DIEEntry.extractFast(*CU, &DIEOffset, DebugInfoData, NextCUOffset,
-                                ParentIndex.back()))
+                                /*ParentIdx=*/0))
         break;
       const DWARFAbbreviationDeclaration *Abbrev =
           DIEEntry.getAbbreviationDeclarationPtr();
@@ -619,12 +617,8 @@ static SmallVector<SmallVector<DWARFUnit *>> partitionCUs(DWARFContext &DwCtx,
             EC.unionSets(CU, TargetCU);
           }
         }
-        if (Abbrev->hasChildren())
-          ParentIndex.push_back(0);
-      } else {
-        ParentIndex.pop_back();
       }
-    } while (DIEOffset < NextCUOffset);
+    }
   }
 
   DenseMap<DWARFUnit *, SmallVector<DWARFUnit *>> MembersByLeader;

--- a/bolt/test/X86/dwarf4-cross-cu-ranges.test
+++ b/bolt/test/X86/dwarf4-cross-cu-ranges.test
@@ -2,12 +2,14 @@
 
 ; RUN: llvm-mc -dwarf-version=4 -filetype=obj -triple x86_64-unknown-linux %p/Inputs/dwarf4-cross-cu-with-loclist.s -o %t.o
 ; RUN: %clang %cflags -nostdlib -no-pie %t.o -o %t.exe
-; RUN: llvm-bolt %t.exe -o %t.exe.bolt --update-debug-sections --always-convert-to-ranges --debug-thread-count=4
+; RUN: llvm-bolt %t.exe -o %t.exe.bolt --update-debug-sections --always-convert-to-ranges --debug-thread-count=4 2>&1 | FileCheck %s --check-prefix=BOLT
 ; RUN: llvm-objdump --disassemble %t.exe.bolt > %t.txt
 ; RUN: llvm-dwarfdump --show-form --verbose --debug-info --debug-ranges %t.exe.bolt >> %t.txt
 ; RUN: FileCheck %s --input-file=%t.txt
 
 ;; Test that two cross-referenced CUs processed in the same bucket keep their own .debug_ranges entries.
+
+; BOLT-NOT: warning: DWARF unit from offset {{.*}} incl. to offset {{.*}} excl. tries to read DIEs at offset {{.*}}
 
 ; CHECK: <main>:
 ; CHECK-NEXT: [[#%.6x,MAIN:]]

--- a/bolt/test/X86/dwarf5-debug-names-cross-cu.s
+++ b/bolt/test/X86/dwarf5-debug-names-cross-cu.s
@@ -3,11 +3,13 @@
 
 # RUN: llvm-mc -dwarf-version=5 -filetype=obj -triple x86_64-unknown-linux %s -o %tmain.o
 # RUN: %clang %cflags -dwarf-5 %tmain.o -o %t.exe -Wl,-q
-# RUN: llvm-bolt %t.exe -o %t.bolt --update-debug-sections
+# RUN: llvm-bolt %t.exe -o %t.bolt --update-debug-sections 2>&1 | FileCheck %s --check-prefix=BOLT
 # RUN: llvm-dwarfdump --debug-info -r 0 --debug-names %t.bolt > %t.txt
 # RUN: cat %t.txt | FileCheck --check-prefix=CHECK %s
 
 ## This test checks that BOLT generates Entries for DW_AT_abstract_origin when it has cross cu reference.
+
+# BOLT-NOT: warning: DWARF unit from offset {{.*}} incl. to offset {{.*}} excl. tries to read DIEs at offset {{.*}}
 
 # CHECK: [[OFFSET1:0x[0-9a-f]*]]: Compile Unit
 # CHECK: [[OFFSET2:0x[0-9a-f]*]]: Compile Unit


### PR DESCRIPTION
The DIE traversal loop in partitionCUs() used an incorrect termination condition, causing it to read past the end of the CU. Fix the loop to stop at NextCUOffset so traversal no longer runs beyond the unit's boundary.

Fixed [#208440](https://github.com/llvm/llvm-project/issues/208440).