### PR TITLE
[AArch64] acquire fence for 128-bit SC loads with LSE2

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -32112,9 +32112,13 @@ Instruction *AArch64TargetLowering::emitLeadingFence(IRBuilderBase &Builder,
 Instruction *AArch64TargetLowering::emitTrailingFence(
     IRBuilderBase &Builder, Instruction *Inst, AtomicOrdering Ord) const {
   if (auto *LI = dyn_cast<LoadInst>(Inst);
-      LI && Ord == AtomicOrdering::SequentiallyConsistent &&
-      isOpSuitableForRCPC3(LI))
-    return nullptr;
+      LI && Ord == AtomicOrdering::SequentiallyConsistent) {
+    if (isOpSuitableForRCPC3(LI))
+      return nullptr;
+
+    if (isOpSuitableForLDPSTP(LI))
+      return Builder.CreateFence(AtomicOrdering::Acquire);
+  }
 
   return TargetLoweringBase::emitTrailingFence(Builder, Inst, Ord);
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-load-lse2.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-load-lse2.ll
@@ -275,12 +275,12 @@ define dso_local i128 @load_atomic_i128_aligned_seq_cst(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x0, x1, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x0, x1, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }
@@ -289,12 +289,12 @@ define dso_local i128 @load_atomic_i128_aligned_seq_cst_const(ptr readonly %ptr)
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst_const:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x0, x1, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst_const:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x0, x1, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }
@@ -583,12 +583,12 @@ define dso_local fp128 @load_atomic_fp128_aligned_seq_cst(ptr %ptr) {
 ; -O0-LABEL: load_atomic_fp128_aligned_seq_cst:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x9, x8, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_fp128_aligned_seq_cst:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x8, x9, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic fp128, ptr %ptr seq_cst, align 16
     ret fp128 %r
 }
@@ -597,12 +597,12 @@ define dso_local fp128 @load_atomic_fp128_aligned_seq_cst_const(ptr readonly %pt
 ; -O0-LABEL: load_atomic_fp128_aligned_seq_cst_const:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x9, x8, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_fp128_aligned_seq_cst_const:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x8, x9, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic fp128, ptr %ptr seq_cst, align 16
     ret fp128 %r
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-load-lse2_lse128.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-load-lse2_lse128.ll
@@ -275,12 +275,12 @@ define dso_local i128 @load_atomic_i128_aligned_seq_cst(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x0, x1, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x0, x1, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }
@@ -289,12 +289,12 @@ define dso_local i128 @load_atomic_i128_aligned_seq_cst_const(ptr readonly %ptr)
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst_const:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x0, x1, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst_const:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x0, x1, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }
@@ -583,12 +583,12 @@ define dso_local fp128 @load_atomic_fp128_aligned_seq_cst(ptr %ptr) {
 ; -O0-LABEL: load_atomic_fp128_aligned_seq_cst:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x9, x8, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_fp128_aligned_seq_cst:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x8, x9, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic fp128, ptr %ptr seq_cst, align 16
     ret fp128 %r
 }
@@ -597,12 +597,12 @@ define dso_local fp128 @load_atomic_fp128_aligned_seq_cst_const(ptr readonly %pt
 ; -O0-LABEL: load_atomic_fp128_aligned_seq_cst_const:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x9, x8, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_fp128_aligned_seq_cst_const:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x8, x9, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic fp128, ptr %ptr seq_cst, align 16
     ret fp128 %r
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-load-lse2.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-load-lse2.ll
@@ -275,12 +275,12 @@ define dso_local i128 @load_atomic_i128_aligned_seq_cst(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x0, x1, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x0, x1, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }
@@ -289,12 +289,12 @@ define dso_local i128 @load_atomic_i128_aligned_seq_cst_const(ptr readonly %ptr)
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst_const:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x0, x1, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst_const:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x0, x1, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }
@@ -583,12 +583,12 @@ define dso_local fp128 @load_atomic_fp128_aligned_seq_cst(ptr %ptr) {
 ; -O0-LABEL: load_atomic_fp128_aligned_seq_cst:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x8, x9, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_fp128_aligned_seq_cst:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x8, x9, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic fp128, ptr %ptr seq_cst, align 16
     ret fp128 %r
 }
@@ -597,12 +597,12 @@ define dso_local fp128 @load_atomic_fp128_aligned_seq_cst_const(ptr readonly %pt
 ; -O0-LABEL: load_atomic_fp128_aligned_seq_cst_const:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x8, x9, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_fp128_aligned_seq_cst_const:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x8, x9, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic fp128, ptr %ptr seq_cst, align 16
     ret fp128 %r
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-load-lse2_lse128.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomic-load-lse2_lse128.ll
@@ -275,12 +275,12 @@ define dso_local i128 @load_atomic_i128_aligned_seq_cst(ptr %ptr) {
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x0, x1, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x0, x1, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }
@@ -289,12 +289,12 @@ define dso_local i128 @load_atomic_i128_aligned_seq_cst_const(ptr readonly %ptr)
 ; -O0-LABEL: load_atomic_i128_aligned_seq_cst_const:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x0, x1, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_i128_aligned_seq_cst_const:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x0, x1, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic i128, ptr %ptr seq_cst, align 16
     ret i128 %r
 }
@@ -583,12 +583,12 @@ define dso_local fp128 @load_atomic_fp128_aligned_seq_cst(ptr %ptr) {
 ; -O0-LABEL: load_atomic_fp128_aligned_seq_cst:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x8, x9, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_fp128_aligned_seq_cst:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x8, x9, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic fp128, ptr %ptr seq_cst, align 16
     ret fp128 %r
 }
@@ -597,12 +597,12 @@ define dso_local fp128 @load_atomic_fp128_aligned_seq_cst_const(ptr readonly %pt
 ; -O0-LABEL: load_atomic_fp128_aligned_seq_cst_const:
 ; -O0:    ldar x8, [x0]
 ; -O0:    ldp x8, x9, [x0]
-; -O0:    dmb ish
+; -O0:    dmb ishld
 ;
 ; -O1-LABEL: load_atomic_fp128_aligned_seq_cst_const:
 ; -O1:    ldar xzr, [x0]
 ; -O1:    ldp x8, x9, [x0]
-; -O1:    dmb ish
+; -O1:    dmb ishld
     %r = load atomic fp128, ptr %ptr seq_cst, align 16
     ret fp128 %r
 }


### PR DESCRIPTION
This is what atomicsabi64.pdf suggests.
https://github.com/ARM-software/abi-aa/releases
I don't think the current version is wrong, just unnecessarily strict.

Patch series:
- https://github.com/llvm/llvm-project/pull/206936
- https://github.com/llvm/llvm-project/pull/208417
- https://github.com/llvm/llvm-project/pull/208443
- https://github.com/llvm/llvm-project/pull/208452