### PR TITLE
[X86][AArch64][SPIRV] add more tests for `ldexp`/`frexp`

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -35,6 +35,9 @@ SPIRVTargetLowering::SPIRVTargetLowering(const TargetMachine &TM,
   // consider 128-bit OpTypeInt as valid either.
   setMaxAtomicSizeInBitsSupported(64);
   setMinCmpXchgSizeInBits(8);
+
+  for (MVT VT : {MVT::f16, MVT::f32, MVT::f64})
+    setOperationAction(ISD::FFREXP, VT, Legal);
 }
 
 // Returns true of the types logically match, as defined in

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -35,9 +35,6 @@ SPIRVTargetLowering::SPIRVTargetLowering(const TargetMachine &TM,
   // consider 128-bit OpTypeInt as valid either.
   setMaxAtomicSizeInBitsSupported(64);
   setMinCmpXchgSizeInBits(8);
-
-  for (MVT VT : {MVT::f16, MVT::f32, MVT::f64})
-    setOperationAction(ISD::FFREXP, VT, Legal);
 }
 
 // Returns true of the types logically match, as defined in

--- a/llvm/test/CodeGen/AArch64/ldexp-arm64ec.ll
+++ b/llvm/test/CodeGen/AArch64/ldexp-arm64ec.ll
@@ -11,6 +11,14 @@ define half @ldexp_f16(half %val, i32 %a) {
   ret half %call
 }
 
+; ARM64EC-LABEL: ldexp_bf16 =
+; ARM64EC: fcvt d0, s0
+; ARM64EC: bl "#ldexp"
+define bfloat @ldexp_bf16(bfloat %val, i32 %a) {
+  %call = call bfloat @llvm.ldexp.bf16(bfloat %val, i32 %a)
+  ret bfloat %call
+}
+
 ; ARM64EC-LABEL: ldexp_f32 =
 ; ARM64EC: fcvt d0, s0
 ; ARM64EC: bl "#ldexp"

--- a/llvm/test/CodeGen/AArch64/ldexp.ll
+++ b/llvm/test/CodeGen/AArch64/ldexp.ll
@@ -4,7 +4,6 @@
 ; RUN: llc -mtriple=aarch64-windows-msvc -mattr=+sve < %s -o - | FileCheck -check-prefixes=SVE,SVEWINDOWS %s
 ; RUN: llc -mtriple=aarch64-windows-msvc < %s -o - | FileCheck -check-prefixes=WINDOWS %s
 
-
 define double @testExp(double %val, i32 %a) {
 ; SVE-LABEL: testExp:
 ; SVE:       // %bb.0: // %entry

--- a/llvm/test/CodeGen/AArch64/llvm.frexp.ll
+++ b/llvm/test/CodeGen/AArch64/llvm.frexp.ll
@@ -316,6 +316,54 @@ define <2 x i32> @test_frexp_v2f16_v2i32_only_use_exp(<2 x half> %a) nounwind {
   ret <2 x i32> %result.1
 }
 
+define { bfloat, i32 } @test_frexp_bf16_i32(bfloat %a) nounwind {
+; CHECK-LABEL: test_frexp_bf16_i32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; CHECK-NEXT:    // kill: def $h0 killed $h0 def $d0
+; CHECK-NEXT:    add x0, sp, #12
+; CHECK-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-NEXT:    // kill: def $s0 killed $s0 killed $q0
+; CHECK-NEXT:    bl frexpf
+; CHECK-NEXT:    fmov w9, s0
+; CHECK-NEXT:    mov w8, #32767 // =0x7fff
+; CHECK-NEXT:    fcmp s0, s0
+; CHECK-NEXT:    ldr w0, [sp, #12]
+; CHECK-NEXT:    ubfx w10, w9, #16, #1
+; CHECK-NEXT:    add w8, w9, w8
+; CHECK-NEXT:    orr w9, w9, #0x400000
+; CHECK-NEXT:    add w8, w10, w8
+; CHECK-NEXT:    csel w8, w9, w8, vs
+; CHECK-NEXT:    lsr w8, w8, #16
+; CHECK-NEXT:    fmov s0, w8
+; CHECK-NEXT:    // kill: def $h0 killed $h0 killed $s0
+; CHECK-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; CHECK-NEXT:    ret
+;
+; WINDOWS-LABEL: test_frexp_bf16_i32:
+; WINDOWS:       // %bb.0:
+; WINDOWS-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; WINDOWS-NEXT:    // kill: def $h0 killed $h0 def $d0
+; WINDOWS-NEXT:    add x0, sp, #12
+; WINDOWS-NEXT:    shll v0.4s, v0.4h, #16
+; WINDOWS-NEXT:    fcvt d0, s0
+; WINDOWS-NEXT:    bl frexp
+; WINDOWS-NEXT:    fcvtxn s0, d0
+; WINDOWS-NEXT:    mov w8, #32767 // =0x7fff
+; WINDOWS-NEXT:    ldr w0, [sp, #12]
+; WINDOWS-NEXT:    fmov w9, s0
+; WINDOWS-NEXT:    ubfx w10, w9, #16, #1
+; WINDOWS-NEXT:    add w8, w9, w8
+; WINDOWS-NEXT:    add w8, w10, w8
+; WINDOWS-NEXT:    lsr w8, w8, #16
+; WINDOWS-NEXT:    fmov s0, w8
+; WINDOWS-NEXT:    // kill: def $h0 killed $h0 killed $s0
+; WINDOWS-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; WINDOWS-NEXT:    ret
+  %result = call { bfloat, i32 } @llvm.frexp.bf16.i32(bfloat %a)
+  ret { bfloat, i32 } %result
+}
+
 define { <3 x float>, <3 x i32> } @test_frexp_v3f32_v3i32(<3 x float> %a) nounwind {
 ; CHECK-LABEL: test_frexp_v3f32_v3i32:
 ; CHECK:       // %bb.0:
@@ -1132,18 +1180,5 @@ define <2 x i32> @test_frexp_v2f64_v2i32_only_use_exp(<2 x double> %a) nounwind 
   %result.1 = extractvalue { <2 x double>, <2 x i32> } %result, 1
   ret <2 x i32> %result.1
 }
-
-declare { float, i32 } @llvm.frexp.f32.i32(float) #0
-declare { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float>) #0
-declare { <4 x float>, <4 x i32> } @llvm.frexp.v4f32.v4i32(<4 x float>) #0
-
-declare { half, i32 } @llvm.frexp.f16.i32(half) #0
-declare { <2 x half>, <2 x i32> } @llvm.frexp.v2f16.v2i32(<2 x half>) #0
-
-declare { double, i32 } @llvm.frexp.f64.i32(double) #0
-declare { <2 x double>, <2 x i32> } @llvm.frexp.v2f64.v2i32(<2 x double>) #0
-
-declare { half, i16 } @llvm.frexp.f16.i16(half) #0
-declare { <2 x half>, <2 x i16> } @llvm.frexp.v2f16.v2i16(<2 x half>) #0
 
 attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/frexp.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/frexp.ll
@@ -18,6 +18,19 @@
 ; CHECK-DAG: %[[#const_composite2:]] = OpConstantComposite %[[#vec4_float_type]] %[[#const_16:]] %[[#const_neg32:]] %[[#const_0:]] %[[#const_9999:]]
 ; CHECK-DAG: %[[#float_64_type:]] = OpTypeFloat 64
 ; CHECK-DAG: %[[#vec2_double_type:]] = OpTypeVector %[[#float_64_type]] 2
+; CHECK-DAG: %[[#void_type:]] = OpTypeVoid
+; CHECK-DAG: %[[#const_1:]] = OpConstant %[[#int_32_type]] 1
+; CHECK-DAG: %[[#int_null:]] = OpConstantNull %[[#int_32_type]]
+; CHECK-DAG: %[[#float_16_type:]] = OpTypeFloat 16
+; CHECK-DAG: %[[#struct_f16_i32:]] = OpTypeStruct %[[#float_16_type]] %[[#int_32_type]]
+; CHECK-DAG: %[[#fn_ptr_type_struct_f16:]] = OpTypePointer Function %[[#struct_f16_i32]]
+; CHECK-DAG: %[[#fn_ptr_type_f16:]] = OpTypePointer Function %[[#float_16_type]]
+; CHECK-DAG: %[[#struct_f32_i32:]] = OpTypeStruct %[[#float_32_type]] %[[#int_32_type]]
+; CHECK-DAG: %[[#fn_ptr_type_struct_f32:]] = OpTypePointer Function %[[#struct_f32_i32]]
+; CHECK-DAG: %[[#fn_ptr_type_f32:]] = OpTypePointer Function %[[#float_32_type]]
+; CHECK-DAG: %[[#struct_f64_i32:]] = OpTypeStruct %[[#float_64_type]] %[[#int_32_type]]
+; CHECK-DAG: %[[#fn_ptr_type_struct_f64:]] = OpTypePointer Function %[[#struct_f64_i32]]
+; CHECK-DAG: %[[#fn_ptr_type_f64:]] = OpTypePointer Function %[[#float_64_type]]
 
 ; CHECK: %[[#]] = OpFunctionParameter %[[#float_32_type]]
 ; CHECK: %[[#var1:]] = OpVariable %[[#fn_ptr_type_i32]] Function
@@ -106,9 +119,71 @@ define <2 x double> @frexp_frexp_vector(<2 x double> %x) {
   ret <2 x double> %f_part
 }
 
-declare { float, i32 } @llvm.frexp.f32.i32(float)
-declare { double, i32 } @llvm.frexp.f64.i32(double)
-declare { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float>)
-declare { <4 x float>, <4 x i32> } @llvm.frexp.v4f32.v4i32(<4 x float>)
-declare { <2 x double>, <2 x i32> } @llvm.frexp.v2f64.v2i32(<2 x double>)
-declare  { float, i8 } @llvm.frexp.f32.i8(float)
+; CHECK: %[[#out_param_f16:]] = OpFunctionParameter %[[#fn_ptr_type_struct_f16]]
+; CHECK: %[[#x_var_f16:]] = OpFunctionParameter %[[#float_16_type]]
+; CHECK: %[[#var_f16:]] = OpVariable %[[#fn_ptr_type_i32]] Function
+; CHECK: %[[#extinst_f16:]] = OpExtInst %[[#float_16_type]] %[[#extinst_id]] frexp %[[#x_var_f16]] %[[#var_f16]]
+; CHECK: %[[#exp_load_f16:]] = OpLoad %[[#int_32_type]] %[[#var_f16]]
+; CHECK: %[[#mantissa_ptr_f16:]] = OpInBoundsPtrAccessChain %[[#fn_ptr_type_f16]] %[[#out_param_f16]] %[[#int_null]] %[[#int_null]]
+; CHECK: %[[#exp_ptr_f16:]] = OpInBoundsPtrAccessChain %[[#fn_ptr_type_i32]] %[[#out_param_f16]] %[[#int_null]] %[[#const_1]]
+; CHECK: OpStore %[[#mantissa_ptr_f16]] %[[#extinst_f16]] Aligned 2
+; CHECK: OpStore %[[#exp_ptr_f16]] %[[#exp_load_f16]] Aligned 4
+; CHECK: OpReturn
+define void @frexp_f16(ptr %out, half %x) {
+  %ret = call { half, i32 } @llvm.frexp.f16.i32(half %x)
+
+  %mantissa.ptr = getelementptr inbounds { half, i32 }, ptr %out, i32 0, i32 0
+  %exp.ptr      = getelementptr inbounds { half, i32 }, ptr %out, i32 0, i32 1
+  %mantissa = extractvalue { half, i32 } %ret, 0
+  %exp      = extractvalue { half, i32 } %ret, 1
+
+  store half %mantissa, ptr %mantissa.ptr
+  store i32 %exp, ptr %exp.ptr
+  ret void
+}
+
+; CHECK: %[[#out_param_f32:]] = OpFunctionParameter %[[#fn_ptr_type_struct_f32]]
+; CHECK: %[[#x_var_f32:]] = OpFunctionParameter %[[#float_32_type]]
+; CHECK: %[[#var_f32:]] = OpVariable %[[#fn_ptr_type_i32]] Function
+; CHECK: %[[#extinst_f32:]] = OpExtInst %[[#float_32_type]] %[[#extinst_id]] frexp %[[#x_var_f32]] %[[#var_f32]]
+; CHECK: %[[#exp_load_f32:]] = OpLoad %[[#int_32_type]] %[[#var_f32]]
+; CHECK: %[[#mantissa_ptr_f32:]] = OpInBoundsPtrAccessChain %[[#fn_ptr_type_f32]] %[[#out_param_f32]] %[[#int_null]] %[[#int_null]]
+; CHECK: %[[#exp_ptr_f32:]] = OpInBoundsPtrAccessChain %[[#fn_ptr_type_i32]] %[[#out_param_f32]] %[[#int_null]] %[[#const_1]]
+; CHECK: OpStore %[[#mantissa_ptr_f32]] %[[#extinst_f32]] Aligned 4
+; CHECK: OpStore %[[#exp_ptr_f32]] %[[#exp_load_f32]] Aligned 4
+; CHECK: OpReturn
+define void @frexp_f32(ptr %out, float %x) {
+  %ret = call { float, i32 } @llvm.frexp.f32.i32(float %x)
+
+  %mantissa.ptr = getelementptr inbounds { float, i32 }, ptr %out, i32 0, i32 0
+  %exp.ptr      = getelementptr inbounds { float, i32 }, ptr %out, i32 0, i32 1
+  %mantissa = extractvalue { float, i32 } %ret, 0
+  %exp      = extractvalue { float, i32 } %ret, 1
+
+  store float %mantissa, ptr %mantissa.ptr
+  store i32 %exp, ptr %exp.ptr
+  ret void
+}
+
+; CHECK: %[[#out_param_f64:]] = OpFunctionParameter %[[#fn_ptr_type_struct_f64]]
+; CHECK: %[[#x_var_f64:]] = OpFunctionParameter %[[#float_64_type]]
+; CHECK: %[[#var_f64:]] = OpVariable %[[#fn_ptr_type_i32]] Function
+; CHECK: %[[#extinst_f64:]] = OpExtInst %[[#float_64_type]] %[[#extinst_id]] frexp %[[#x_var_f64]] %[[#var_f64]]
+; CHECK: %[[#exp_load_f64:]] = OpLoad %[[#int_32_type]] %[[#var_f64]]
+; CHECK: %[[#mantissa_ptr_f64:]] = OpInBoundsPtrAccessChain %[[#fn_ptr_type_f64]] %[[#out_param_f64]] %[[#int_null]] %[[#int_null]]
+; CHECK: %[[#exp_ptr_f64:]] = OpInBoundsPtrAccessChain %[[#fn_ptr_type_i32]] %[[#out_param_f64]] %[[#int_null]] %[[#const_1]]
+; CHECK: OpStore %[[#mantissa_ptr_f64]] %[[#extinst_f64]] Aligned 8
+; CHECK: OpStore %[[#exp_ptr_f64]] %[[#exp_load_f64]] Aligned 4
+; CHECK: OpReturn
+define void @frexp_f64(ptr %out, double %x) {
+  %ret = call { double, i32 } @llvm.frexp.f64.i32(double %x)
+
+  %mantissa.ptr = getelementptr inbounds { double, i32 }, ptr %out, i32 0, i32 0
+  %exp.ptr      = getelementptr inbounds { double, i32 }, ptr %out, i32 0, i32 1
+  %mantissa = extractvalue { double, i32 } %ret, 0
+  %exp      = extractvalue { double, i32 } %ret, 1
+
+  store double %mantissa, ptr %mantissa.ptr
+  store i32 %exp, ptr %exp.ptr
+  ret void
+}

--- a/llvm/test/CodeGen/X86/ldexp.ll
+++ b/llvm/test/CodeGen/X86/ldexp.ll
@@ -3,6 +3,89 @@
 ; RUN: llc -mtriple=x86_64-pc-win32 -verify-machineinstrs < %s | FileCheck -check-prefixes=WIN64 %s
 ; RUN: llc -mtriple=i386-pc-win32 -verify-machineinstrs < %s | FileCheck -check-prefix=WIN32 %s
 
+define half @ldexp_f16(i8 zeroext %x) nounwind {
+; X64-LABEL: ldexp_f16:
+; X64:       # %bb.0:
+; X64-NEXT:    pushq %rax
+; X64-NEXT:    movss {{.*#+}} xmm0 = [1.0E+0,0.0E+0,0.0E+0,0.0E+0]
+; X64-NEXT:    callq ldexpf@PLT
+; X64-NEXT:    callq __truncsfhf2@PLT
+; X64-NEXT:    popq %rax
+; X64-NEXT:    retq
+;
+; WIN64-LABEL: ldexp_f16:
+; WIN64:       # %bb.0:
+; WIN64-NEXT:    subq $40, %rsp
+; WIN64-NEXT:    movzbl %cl, %edx
+; WIN64-NEXT:    movsd {{.*#+}} xmm0 = [1.0E+0,0.0E+0]
+; WIN64-NEXT:    callq ldexp
+; WIN64-NEXT:    callq __truncdfhf2
+; WIN64-NEXT:    addq $40, %rsp
+; WIN64-NEXT:    retq
+;
+; WIN32-LABEL: ldexp_f16:
+; WIN32:       # %bb.0:
+; WIN32-NEXT:    subl $16, %esp
+; WIN32-NEXT:    movzbl {{[0-9]+}}(%esp), %eax
+; WIN32-NEXT:    movl %eax, {{[0-9]+}}(%esp)
+; WIN32-NEXT:    fld1
+; WIN32-NEXT:    fstpl (%esp)
+; WIN32-NEXT:    calll _ldexp
+; WIN32-NEXT:    fstps {{[0-9]+}}(%esp)
+; WIN32-NEXT:    flds {{[0-9]+}}(%esp)
+; WIN32-NEXT:    fstps (%esp)
+; WIN32-NEXT:    calll ___truncsfhf2
+; WIN32-NEXT:    addl $16, %esp
+; WIN32-NEXT:    retl
+  %zext = zext i8 %x to i32
+  %ldexp = call half @llvm.ldexp.f16.i32(half 1.000000e+00, i32 %zext)
+  ret half %ldexp
+}
+
+define bfloat @ldexp_bf16(i8 zeroext %x) nounwind {
+; X64-LABEL: ldexp_bf16:
+; X64:       # %bb.0:
+; X64-NEXT:    pushq %rax
+; X64-NEXT:    movss {{.*#+}} xmm0 = [1.0E+0,0.0E+0,0.0E+0,0.0E+0]
+; X64-NEXT:    callq ldexpf@PLT
+; X64-NEXT:    callq __truncsfbf2@PLT
+; X64-NEXT:    popq %rax
+; X64-NEXT:    retq
+;
+; WIN64-LABEL: ldexp_bf16:
+; WIN64:       # %bb.0:
+; WIN64-NEXT:    subq $40, %rsp
+; WIN64-NEXT:    movzbl %cl, %edx
+; WIN64-NEXT:    movsd {{.*#+}} xmm0 = [1.0E+0,0.0E+0]
+; WIN64-NEXT:    callq ldexp
+; WIN64-NEXT:    cvtsd2ss %xmm0, %xmm0
+; WIN64-NEXT:    callq __truncsfbf2
+; WIN64-NEXT:    addq $40, %rsp
+; WIN64-NEXT:    retq
+;
+; WIN32-LABEL: ldexp_bf16:
+; WIN32:       # %bb.0:
+; WIN32-NEXT:    subl $20, %esp
+; WIN32-NEXT:    movzbl {{[0-9]+}}(%esp), %eax
+; WIN32-NEXT:    movl %eax, {{[0-9]+}}(%esp)
+; WIN32-NEXT:    fld1
+; WIN32-NEXT:    fstpl (%esp)
+; WIN32-NEXT:    calll _ldexp
+; WIN32-NEXT:    fstps {{[0-9]+}}(%esp)
+; WIN32-NEXT:    flds {{[0-9]+}}(%esp)
+; WIN32-NEXT:    fstps (%esp)
+; WIN32-NEXT:    calll ___truncsfbf2
+; WIN32-NEXT:    # kill: def $ax killed $ax def $eax
+; WIN32-NEXT:    shll $16, %eax
+; WIN32-NEXT:    movl %eax, {{[0-9]+}}(%esp)
+; WIN32-NEXT:    flds {{[0-9]+}}(%esp)
+; WIN32-NEXT:    addl $20, %esp
+; WIN32-NEXT:    retl
+  %zext = zext i8 %x to i32
+  %ldexp = call bfloat @llvm.ldexp.bf16.i32(bfloat 1.000000e+00, i32 %zext)
+  ret bfloat %ldexp
+}
+
 define float @ldexp_f32(i8 zeroext %x) nounwind {
 ; X64-LABEL: ldexp_f32:
 ; X64:       # %bb.0:
@@ -508,62 +591,6 @@ define <4 x double> @ldexp_v4f64(<4 x double> %val, <4 x i32> %exp) nounwind {
   %1 = call <4 x double> @llvm.ldexp.v4f64.v4i32(<4 x double> %val, <4 x i32> %exp)
   ret <4 x double> %1
 }
-
-define half @ldexp_f16(half %arg0, i32 %arg1) nounwind {
-; X64-LABEL: ldexp_f16:
-; X64:       # %bb.0:
-; X64-NEXT:    pushq %rbx
-; X64-NEXT:    movl %edi, %ebx
-; X64-NEXT:    callq __extendhfsf2@PLT
-; X64-NEXT:    movl %ebx, %edi
-; X64-NEXT:    callq ldexpf@PLT
-; X64-NEXT:    callq __truncsfhf2@PLT
-; X64-NEXT:    popq %rbx
-; X64-NEXT:    retq
-;
-; WIN64-LABEL: ldexp_f16:
-; WIN64:       # %bb.0:
-; WIN64-NEXT:    pushq %rsi
-; WIN64-NEXT:    subq $32, %rsp
-; WIN64-NEXT:    movl %edx, %esi
-; WIN64-NEXT:    callq __extendhfsf2
-; WIN64-NEXT:    cvtss2sd %xmm0, %xmm0
-; WIN64-NEXT:    movl %esi, %edx
-; WIN64-NEXT:    callq ldexp
-; WIN64-NEXT:    callq __truncdfhf2
-; WIN64-NEXT:    addq $32, %rsp
-; WIN64-NEXT:    popq %rsi
-; WIN64-NEXT:    retq
-;
-; WIN32-LABEL: ldexp_f16:
-; WIN32:       # %bb.0:
-; WIN32-NEXT:    pushl %esi
-; WIN32-NEXT:    subl $16, %esp
-; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %esi
-; WIN32-NEXT:    movzwl {{[0-9]+}}(%esp), %eax
-; WIN32-NEXT:    movl %eax, (%esp)
-; WIN32-NEXT:    calll ___extendhfsf2
-; WIN32-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; WIN32-NEXT:    fstpl (%esp)
-; WIN32-NEXT:    calll _ldexp
-; WIN32-NEXT:    fstps {{[0-9]+}}(%esp)
-; WIN32-NEXT:    flds {{[0-9]+}}(%esp)
-; WIN32-NEXT:    fstps (%esp)
-; WIN32-NEXT:    calll ___truncsfhf2
-; WIN32-NEXT:    addl $16, %esp
-; WIN32-NEXT:    popl %esi
-; WIN32-NEXT:    retl
-  %ldexp = call half @llvm.ldexp.f16.i32(half %arg0, i32 %arg1)
-  ret half %ldexp
-}
-
-declare double @llvm.ldexp.f64.i32(double, i32) #0
-declare float @llvm.ldexp.f32.i32(float, i32) #0
-declare <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float>, <2 x i32>) #0
-declare <4 x float> @llvm.ldexp.v4f32.v4i32(<4 x float>, <4 x i32>) #0
-declare <2 x double> @llvm.ldexp.v2f64.v2i32(<2 x double>, <2 x i32>) #0
-declare <4 x double> @llvm.ldexp.v4f64.v4i32(<4 x double>, <4 x i32>) #0
-declare half @llvm.ldexp.f16.i32(half, i32) #0
 
 attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }

--- a/llvm/test/CodeGen/X86/llvm.frexp.ll
+++ b/llvm/test/CodeGen/X86/llvm.frexp.ll
@@ -172,6 +172,52 @@ define i32 @test_frexp_f16_i32_only_use_exp(half %a) nounwind {
 ;   ret <2 x i32> %result.1
 ; }
 
+define { bfloat, i32 } @test_frexp_bf16_i32(bfloat %a) nounwind {
+; X64-LABEL: test_frexp_bf16_i32:
+; X64:       # %bb.0:
+; X64-NEXT:    pushq %rax
+; X64-NEXT:    pextrw $0, %xmm0, %eax
+; X64-NEXT:    shll $16, %eax
+; X64-NEXT:    movd %eax, %xmm0
+; X64-NEXT:    leaq {{[0-9]+}}(%rsp), %rdi
+; X64-NEXT:    callq frexpf@PLT
+; X64-NEXT:    callq __truncsfbf2@PLT
+; X64-NEXT:    movl {{[0-9]+}}(%rsp), %eax
+; X64-NEXT:    popq %rcx
+; X64-NEXT:    retq
+;
+; WIN32-LABEL: test_frexp_bf16_i32:
+; WIN32:       # %bb.0:
+; WIN32-NEXT:    pushl %esi
+; WIN32-NEXT:    subl $28, %esp
+; WIN32-NEXT:    flds {{[0-9]+}}(%esp)
+; WIN32-NEXT:    fstps (%esp)
+; WIN32-NEXT:    calll ___truncsfbf2
+; WIN32-NEXT:    # kill: def $ax killed $ax def $eax
+; WIN32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+; WIN32-NEXT:    movl %ecx, {{[0-9]+}}(%esp)
+; WIN32-NEXT:    shll $16, %eax
+; WIN32-NEXT:    movl %eax, {{[0-9]+}}(%esp)
+; WIN32-NEXT:    flds {{[0-9]+}}(%esp)
+; WIN32-NEXT:    fstpl (%esp)
+; WIN32-NEXT:    calll _frexp
+; WIN32-NEXT:    fstps {{[0-9]+}}(%esp)
+; WIN32-NEXT:    flds {{[0-9]+}}(%esp)
+; WIN32-NEXT:    fstps (%esp)
+; WIN32-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; WIN32-NEXT:    calll ___truncsfbf2
+; WIN32-NEXT:    # kill: def $ax killed $ax def $eax
+; WIN32-NEXT:    shll $16, %eax
+; WIN32-NEXT:    movl %eax, {{[0-9]+}}(%esp)
+; WIN32-NEXT:    flds {{[0-9]+}}(%esp)
+; WIN32-NEXT:    movl %esi, %eax
+; WIN32-NEXT:    addl $28, %esp
+; WIN32-NEXT:    popl %esi
+; WIN32-NEXT:    retl
+  %result = call { bfloat, i32 } @llvm.frexp.bf16.i32(bfloat %a)
+  ret { bfloat, i32 } %result
+}
+
 define { float, i32 } @test_frexp_f32_i32(float %a) nounwind {
 ; X64-LABEL: test_frexp_f32_i32:
 ; X64:       # %bb.0:
@@ -615,18 +661,5 @@ define { float, i32 } @pr160981() {
 ;   %result.1 = extractvalue { <2 x double>, <2 x i32> } %result, 1
 ;   ret <2 x i32> %result.1
 ; }
-
-declare { float, i32 } @llvm.frexp.f32.i32(float) #0
-declare { <2 x float>, <2 x i32> } @llvm.frexp.v2f32.v2i32(<2 x float>) #0
-declare { <4 x float>, <4 x i32> } @llvm.frexp.v4f32.v4i32(<4 x float>) #0
-
-declare { half, i32 } @llvm.frexp.f16.i32(half) #0
-declare { <2 x half>, <2 x i32> } @llvm.frexp.v2f16.v2i32(<2 x half>) #0
-
-declare { double, i32 } @llvm.frexp.f64.i32(double) #0
-declare { <2 x double>, <2 x i32> } @llvm.frexp.v2f64.v2i32(<2 x double>) #0
-
-declare { half, i16 } @llvm.frexp.f16.i16(half) #0
-declare { <2 x half>, <2 x i16> } @llvm.frexp.v2f16.v2i16(<2 x half>) #0
 
 attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }


### PR DESCRIPTION
In preparation of moving the implementation from `LegalizeDAG` into `ExpandIRInsts`.