### PR TITLE
[libc++][NFC] Fix comment about size-based vector

### DIFF
--- a/libcxx/include/__vector/layout.h
+++ b/libcxx/include/__vector/layout.h
@@ -459,7 +459,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __vector_layout<_Tp, _Alloc>::__invariants() 
     return false;
   return __end_ <= __capacity_;
 }
-#endif // _LIBCPP_ABI_SIZE_BASED_VECTOR
+#endif // _LIBCPP_ABI_VECTOR_LAYOUT_SIZE_BASED
 
 _LIBCPP_END_NAMESPACE_STD
 


### PR DESCRIPTION
The closing #endif comment was using _LIBCPP_ABI_SIZE_BASED_VECTOR, which was the name of the macro in previous iterations of the size-based vector patch. We ended up landing on _LIBCPP_ABI_VECTOR_LAYOUT_SIZE_BASED instead.