### PR TITLE
[DTLTO] terminology - use extraction rather than serialization 

### DIFF
--- a/cross-project-tests/dtlto/cache-extraction.test
+++ b/cross-project-tests/dtlto/cache-extraction.test
@@ -1,16 +1,16 @@
 REQUIRES: ld.lld
 
-# Show that DTLTO input file serialization interacts correctly with the
+# Show that DTLTO input file extraction interacts correctly with the
 # ThinLTO cache.
 #
 # To handle bitcode inputs that are not in individual files on disk, such as
-# members of non-thin archives, DTLTO serializes such input bitcode to a
-# temporary individual file on disk. This serialization should only be
+# members of non-thin archives, DTLTO extracts such input bitcode to a
+# temporary individual file on disk. This extraction should only be
 # performed if the backend compilation is required. A backend compilation is
 # only required if there is a miss in the ThinLTO cache for that module, or a
 # module is imported by a module that has missed in the ThinLTO cache.
 #
-# Test DTLTO input serialization across three cases:
+# Test DTLTO input extraction across three cases:
 #   1. None of the backend compilations hit in the ThinLTO cache.
 #   2. All of the backend compilations hit in the ThinLTO cache.
 #   3. Some backend compilations hit in the ThinLTO cache and some miss.
@@ -33,11 +33,11 @@ DEFINE:     -Wl,--save-temps
 
 # 1. None of the backend compilations hit in the ThinLTO cache.
 #
-# Both f1.o and f2.o require backend compilation, so both should be serialized.
+# Both f1.o and f2.o require backend compilation, so both should be extracted.
 # Each backend compilation should produce:
 #   * a native object
 #   * a thinlto.bc file
-#   * a serialized temporary bitcode file (an extracted archive member)
+#   * a temporary bitcode file (extracted archive member)
 RUN: mkdir none
 RUN: %{link} -Wl,--whole-archive f1.a f2.a -o none/out.elf
 RUN: ls none | sort | FileCheck %s --check-prefix=NONE
@@ -54,7 +54,7 @@ NONE-NOT:  {{^f[1-3]}}
 #
 # Both f1.o and f2.o are satisfied from the ThinLTO cache. No backend
 # compilation runs, so there should be no .native.o files, no .thinlto.bc files,
-# and no serialized archive-member bitcode files.
+# and no extracted archive-member bitcode files.
 RUN: mkdir all
 RUN: %{link} -Wl,--whole-archive f1.a f2.a -o all/out.elf
 RUN: ls all | sort | FileCheck %s --check-prefix=ALL
@@ -64,9 +64,9 @@ ALL-NOT: {{^f[1-3]}}
 #
 # f1.o and f2.o are cached, but the new f3.o misses the cache and imports
 # from f1.o:
-#   * f3.o must be compiled and serialized
-#   * cached f1.o must be serialized because f3.o imports from it.
-#   * cached f2.o should not be serialized or compiled.
+#   * f3.o must be compiled and extracted
+#   * cached f1.o must be extracted because f3.o imports from it.
+#   * cached f2.o should not be extracted or compiled.
 RUN: %clang --target=x86_64-linux-gnu -O2 -flto=thin -c f3.c
 RUN: llvm-ar rcs f3.a f3.o
 RUN: mkdir some

--- a/lld/test/ELF/dtlto/timetrace.test
+++ b/lld/test/ELF/dtlto/timetrace.test
@@ -32,14 +32,14 @@ RUN: %python filter_order_and_pprint.py %t.json | FileCheck %s
 ## Check that DTLTO add input file events are recorded.
 CHECK:      "name": "Add input for DTLTO"
 CHECK:      "name": "Add input for DTLTO"
-CHECK:      "name": "Remove DTLTO temporary files"
-CHECK:      "name": "Serialize bitcode input for DTLTO"
+CHECK:      "name": "Extract bitcode input for DTLTO"
 CHECK-SAME:   "detail": "t1.a(t1.bc at [[#ARCHIVE_OFFSET:]]).1.[[PID:[A-F0-9]+]].o"
+CHECK:      "name": "Remove DTLTO temporary files"
 CHECK:      "name": "Total Add input for DTLTO"
 CHECK-SAME:   "count": 2,
-CHECK:      "name": "Total Remove DTLTO temporary files"
+CHECK:      "name": "Total Extract bitcode input for DTLTO"
 CHECK-SAME:   "count": 1,
-CHECK:      "name": "Total Serialize bitcode input for DTLTO"
+CHECK:      "name": "Total Remove DTLTO temporary files"
 CHECK-SAME:   "count": 1,
 
 #--- t1.ll

--- a/llvm/include/llvm/DTLTO/DTLTO.h
+++ b/llvm/include/llvm/DTLTO/DTLTO.h
@@ -28,22 +28,19 @@
 namespace llvm {
 namespace lto {
 
-/// Prepares inputs for Distributed ThinLTO so that backend compilations can use
+/// Prepares inputs for Distributed ThinLTO so that backend compilations use
 /// individual bitcode paths and consistent module IDs.
 ///
 /// Each input must exist as an individual bitcode file on disk and be loadable
-/// via its ModuleID. Archive members and FatLTO objects do not satisfy that by
-/// default; this class writes bitcode out when needed and updates ModuleID.
-/// On Windows, module IDs are normalized to remove short 8.3 path components
+/// via its ModuleID. Archive members and FatLTO objects do not satisfy this
+/// requirement. For these inputs, this class extracts the individual bitcode
+/// to an individual temporary file, and updates ModuleID to that path. On
+/// Windows, module IDs are normalized to remove short 8.3 path components
 /// that are machine-local and break distribution; other normalization is left
 /// to DTLTO distributors.
 ///
-/// Input files are kept until the pipeline has determined per-module ThinLTO
-/// participation and cache status. addInput() performs: (1) register the
-/// input; (2) on Windows, normalize module ID for standalone bitcode; (3) for
-/// thin archive members, set module ID to the on-disk member path; (4) for
-/// other archives and FatLTO, set module ID to a unique path whose content is
-/// serialized later by serializeLTOInputs().
+/// Input files are kept alive until the pipeline has determined per-module
+/// ThinLTO participation and cache status, see addInput() for details.
 class LLVM_ABI DTLTO : public LTO {
   using Base = LTO;
 
@@ -83,8 +80,7 @@ public:
   ///    (normalized on Windows) to the member file on disk.
   /// 4. For archive members and FatLTO objects, overwrite the module ID with a
   ///    unique path (normalized on Windows) naming a file that will contain the
-  ///    member content. The file is created and populated later (see
-  ///    serializeInputs()).
+  ///    content. The file is created/populated later (see extractLTOInputs()).
   Expected<std::shared_ptr<InputFile>>
   addInput(std::unique_ptr<InputFile> InputPtr) override;
 
@@ -101,7 +97,7 @@ public:
 private:
   /// DTLTO archive support.
   ///
-  /// Save the contents of ThinLTO-enabled input files that must be serialized
+  /// Save the contents of ThinLTO-enabled input files that must be extracted
   /// for distribution, such as archive members and FatLTO objects, to
   /// individual bitcode files named after the module ID.
   ///
@@ -109,7 +105,7 @@ private:
   /// but before optimization begins. Existing files are overwritten because
   /// they are likely leftovers from a previously terminated linker process and
   /// can be safely replaced.
-  LLVM_ABI Error serializeLTOInputs();
+  LLVM_ABI Error extractLTOInputs();
 
   // Remove temporary files created to enable distribution.
   void cleanup() override;
@@ -165,8 +161,8 @@ public:
 private:
   // Backend compilation jobs, one per module.
   SmallVector<Job> Jobs;
-  // Input module IDs that must be serialized to individual files.
-  DenseSet<StringRef> InputModuleIDsToSerialize;
+  // Input module IDs that must be extracted to individual files.
+  DenseSet<StringRef> InputModuleIDsToExtract;
   // Task index offset for first ThinLTO job.
   unsigned ThinLTOTaskOffset;
   // Optional cache for native objects.
@@ -214,7 +210,7 @@ private:
   ///    distributor will skip this job. On a cache miss, J.CacheAddStream is
   ///    set for later use when storing the compiled object.
   ///
-  /// 4. Records the module ID and imported module IDs that must be serialized
+  /// 4. Records the module ID and imported module IDs that must be extracted
   ///    to individual files.
   ///
   /// 5. Writes the per-module summary index to disk only on cache miss. The

--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -134,11 +134,12 @@ private:
 
   MemoryBufferRef MbRef;
   bool IsFatLTOObject = false;
-  // For distributed compilation, each input must exist as an individual bitcode
-  // file on disk and be identified by its ModuleID. Archive members and FatLTO
-  // objects violate this. So, in these cases we flag that the bitcode must be
-  // written out to a new standalone file.
-  bool SerializeForDistribution = false;
+  // For distributed compilation, each input must exist as an individual
+  // bitcode file on disk identified by its ModuleID. For archive members and
+  // FatLTO objects, the input bitcode is a sub-section of a larger file. In
+  // these cases we flag that the bitcode must be written to a temporary
+  // standalone file. Effectively, extracted from its container.
+  bool ExtractForDistribution = false;
   bool IsThinLTO = false;
   StringRef ArchivePath;
   StringRef MemberName;
@@ -212,12 +213,12 @@ public:
   LLVM_ABI BitcodeModule &getPrimaryBitcodeModule();
   // Returns the memory buffer reference for this input file.
   MemoryBufferRef getFileBuffer() const { return MbRef; }
-  // Returns true if this input should be serialized to disk for distribution.
-  // See the comment on SerializeForDistribution for details.
-  bool getSerializeForDistribution() const { return SerializeForDistribution; }
-  // Mark whether this input should be serialized to disk for distribution.
-  // See the comment on SerializeForDistribution for details.
-  void setSerializeForDistribution(bool SFD) { SerializeForDistribution = SFD; }
+  // Returns true if this input should be extracted to disk for distribution.
+  // See the comment on ExtractForDistribution for details.
+  bool getExtractForDistribution() const { return ExtractForDistribution; }
+  // Mark whether this input should be extracted to disk for distribution.
+  // See the comment on ExtractForDistribution for details.
+  void setExtractForDistribution(bool EFD) { ExtractForDistribution = EFD; }
   // Returns true if this bitcode came from a FatLTO object.
   bool isFatLTOObject() const { return IsFatLTOObject; }
   // Mark this bitcode as coming from a FatLTO object.

--- a/llvm/lib/DTLTO/DTLTO.cpp
+++ b/llvm/lib/DTLTO/DTLTO.cpp
@@ -90,7 +90,7 @@ LLVM_ABI Error lto::DTLTO::run(AddStreamFn AddStream, FileCache CacheParam) {
 
   if (Error Err = prepareDtltoJobs())
     return Err;
-  if (Error Err = serializeLTOInputs())
+  if (Error Err = extractLTOInputs())
     return Err;
   if (Error Err = performCodegen())
     return Err;
@@ -154,9 +154,9 @@ Error lto::DTLTO::prepareDtltoJob(StringRef ModulePath, unsigned Task) {
   if (Error Err = checkCacheHit(J))
     return Err;
   if (!J.Cached) {
-    InputModuleIDsToSerialize.insert(J.ModuleID);
+    InputModuleIDsToExtract.insert(J.ModuleID);
     for (StringRef ImportPath : J.ImportsFilesList)
-      InputModuleIDsToSerialize.insert(ImportPath);
+      InputModuleIDsToExtract.insert(ImportPath);
 
     TimeTraceScope JobScope("Emit individual index for DTLTO",
                             J.SummaryIndexPath);
@@ -229,7 +229,7 @@ Error lto::DTLTO::prepareDtltoJobs() {
   auto &ModuleMap =
       ThinLTO.ModulesToCompile ? *ThinLTO.ModulesToCompile : ThinLTO.ModuleMap;
 
-  InputModuleIDsToSerialize.clear();
+  InputModuleIDsToExtract.clear();
 
   if (ModuleMap.empty())
     return Error::success();

--- a/llvm/lib/DTLTO/DTLTOInputFiles.cpp
+++ b/llvm/lib/DTLTO/DTLTOInputFiles.cpp
@@ -163,8 +163,7 @@ lto::DTLTO::addInput(std::unique_ptr<InputFile> InputPtr) {
   }
 
   // For a member of a thin archive that is not a FatLTO object, there is an
-  // existing file on disk that can be used, so we can avoid having to
-  // serialize.
+  // existing file on disk that can be used, so we can avoid having to extract.
   Expected<bool> UseThinMember =
       Input->isFatLTOObject() ? false : isThinArchive(ArchivePath);
   if (!UseThinMember)
@@ -179,7 +178,7 @@ lto::DTLTO::addInput(std::unique_ptr<InputFile> InputPtr) {
   }
 
   // A new file on disk will be needed for archive members and FatLTO objects.
-  Input->setSerializeForDistribution(true);
+  Input->setExtractForDistribution(true);
 
   // Get the normalized output directory, if we haven't already.
   if (LinkerOutputDir.empty()) {
@@ -201,18 +200,18 @@ lto::DTLTO::addInput(std::unique_ptr<InputFile> InputPtr) {
   return Input;
 }
 
-// Save the contents of ThinLTO-enabled input files that must be serialized for
+// Save the contents of ThinLTO-enabled input files that must be extracted for
 // distribution.
-Error lto::DTLTO::serializeLTOInputs() {
+Error lto::DTLTO::extractLTOInputs() {
   for (auto &Input : InputFiles) {
-    if (!Input->isThinLTO() || !Input->getSerializeForDistribution())
+    if (!Input->isThinLTO() || !Input->getExtractForDistribution())
       continue;
 
     // Save the content of the input file to a file named after the module ID.
     StringRef ModuleID = Input->getName();
-    if (!InputModuleIDsToSerialize.contains(ModuleID))
+    if (!InputModuleIDsToExtract.contains(ModuleID))
       continue;
-    TimeTraceScope TimeScope("Serialize bitcode input for DTLTO", ModuleID);
+    TimeTraceScope TimeScope("Extract bitcode input for DTLTO", ModuleID);
     MemoryBufferRef Buf = Input->getFileBuffer();
     if (Error Err = save(Buf.getBuffer(), ModuleID))
       return Err;


### PR DESCRIPTION
Change the terminology used for DTLTO from "serialization" to "extraction" for improved clarity.

Update the DTLTO time-trace scope and tests to match the new wording, and rename/update related LLD and cross-project DTLTO cache tests.

I have also improved some unrelated wording in the comments and removed a redundant comment block from the DTLTO class comment.

This terminology improvement was agreed in https://github.com/llvm/llvm-project/pull/204104. Note that the documentation already uses this terminology, see: https://llvm.org/docs/DTLTO.html.