### PR TITLE
[lldb] Avoid data race when clearing an OptionValue

### DIFF
--- a/lldb/include/lldb/Interpreter/OptionValue.h
+++ b/lldb/include/lldb/Interpreter/OptionValue.h
@@ -102,7 +102,10 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign);
 
-  virtual void Clear() = 0;
+  void Clear() {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    ClearImpl();
+  }
 
   virtual lldb::OptionValueSP
   DeepCopy(const lldb::OptionValueSP &new_parent) const;
@@ -349,6 +352,8 @@ protected:
   // Must be overriden by a derived class for correct downcasting the result of
   // DeepCopy to it. Inherit from Cloneable to avoid doing this manually.
   virtual lldb::OptionValueSP Clone() const = 0;
+
+  virtual void ClearImpl() = 0;
 
   class DefaultValueFormat {
   public:

--- a/lldb/include/lldb/Interpreter/OptionValue.h
+++ b/lldb/include/lldb/Interpreter/OptionValue.h
@@ -377,6 +377,10 @@ protected:
                                 // set from the command line or as a setting,
                                 // versus if we just have the default value that
                                 // was already populated in the option value.
+
+  // This a recursive mutex because, some of the derived classes
+  // methods may be invoked from other methods such as
+  // OptionValueFileSpecList's Clear() in SetValueFromString().
   mutable std::recursive_mutex m_mutex;
 
 private:

--- a/lldb/include/lldb/Interpreter/OptionValue.h
+++ b/lldb/include/lldb/Interpreter/OptionValue.h
@@ -372,6 +372,8 @@ protected:
                                 // set from the command line or as a setting,
                                 // versus if we just have the default value that
                                 // was already populated in the option value.
+  mutable std::recursive_mutex m_mutex;
+
 private:
   std::optional<ArchSpec> GetArchSpecValue() const;
   bool SetArchSpecValue(ArchSpec arch_spec);
@@ -412,8 +414,6 @@ private:
   bool SetFormatEntityValue(const FormatEntity::Entry &entry);
 
   const RegularExpression *GetRegexValue() const;
-
-  mutable std::mutex m_mutex;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Interpreter/OptionValue.h
+++ b/lldb/include/lldb/Interpreter/OptionValue.h
@@ -103,7 +103,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign);
 
   void Clear() {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     ClearImpl();
   }
 
@@ -381,7 +381,7 @@ protected:
   // This a recursive mutex because, some of the derived classes
   // methods may be invoked from other methods such as
   // OptionValueFileSpecList's Clear() in SetValueFromString().
-  mutable std::recursive_mutex m_mutex;
+  mutable std::mutex m_mutex;
 
 private:
   std::optional<ArchSpec> GetArchSpecValue() const;

--- a/lldb/include/lldb/Interpreter/OptionValue.h
+++ b/lldb/include/lldb/Interpreter/OptionValue.h
@@ -377,10 +377,6 @@ protected:
                                 // set from the command line or as a setting,
                                 // versus if we just have the default value that
                                 // was already populated in the option value.
-
-  // This a recursive mutex because, some of the derived classes
-  // methods may be invoked from other methods such as
-  // OptionValueFileSpecList's Clear() in SetValueFromString().
   mutable std::mutex m_mutex;
 
 private:

--- a/lldb/include/lldb/Interpreter/OptionValueArch.h
+++ b/lldb/include/lldb/Interpreter/OptionValueArch.h
@@ -45,12 +45,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   void AutoComplete(CommandInterpreter &interpreter,
@@ -73,6 +67,11 @@ public:
   void SetDefaultValue(const ArchSpec &value) { m_default_value = value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   ArchSpec m_current_value;
   ArchSpec m_default_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueArch.h
+++ b/lldb/include/lldb/Interpreter/OptionValueArch.h
@@ -12,6 +12,7 @@
 #include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/CompletionRequest.h"
+#include <mutex>
 
 namespace lldb_private {
 
@@ -45,6 +46,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value = m_default_value;
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueArray.h
+++ b/lldb/include/lldb/Interpreter/OptionValueArray.h
@@ -35,12 +35,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_values.clear();
-    m_value_was_set = false;
-  }
-
   lldb::OptionValueSP
   DeepCopy(const lldb::OptionValueSP &new_parent) const override;
 
@@ -116,6 +110,11 @@ public:
   Status SetArgs(const Args &args, VarSetOperationType op);
 
 protected:
+  void ClearImpl() override {
+    m_values.clear();
+    m_value_was_set = false;
+  }
+
   typedef std::vector<lldb::OptionValueSP> collection;
 
   uint32_t m_type_mask;

--- a/lldb/include/lldb/Interpreter/OptionValueArray.h
+++ b/lldb/include/lldb/Interpreter/OptionValueArray.h
@@ -36,6 +36,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_values.clear();
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueBoolean.h
+++ b/lldb/include/lldb/Interpreter/OptionValueBoolean.h
@@ -37,12 +37,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   void AutoComplete(CommandInterpreter &interpreter,
                     CompletionRequest &request) override;
 
@@ -79,6 +73,11 @@ public:
   void SetDefaultValue(bool value) { m_default_value = value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   bool m_current_value;
   bool m_default_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueBoolean.h
+++ b/lldb/include/lldb/Interpreter/OptionValueBoolean.h
@@ -38,6 +38,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value = m_default_value;
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueChar.h
+++ b/lldb/include/lldb/Interpreter/OptionValueChar.h
@@ -38,12 +38,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -62,6 +56,11 @@ public:
   void SetDefaultValue(char value) { m_default_value = value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   char m_current_value;
   char m_default_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueChar.h
+++ b/lldb/include/lldb/Interpreter/OptionValueChar.h
@@ -39,6 +39,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value = m_default_value;
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueDictionary.h
+++ b/lldb/include/lldb/Interpreter/OptionValueDictionary.h
@@ -40,12 +40,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_values.clear();
-    m_value_was_set = false;
-  }
-
   lldb::OptionValueSP
   DeepCopy(const lldb::OptionValueSP &new_parent) const override;
 
@@ -78,6 +72,11 @@ public:
   Status SetArgs(const Args &args, VarSetOperationType op);
 
 protected:
+  void ClearImpl() override {
+    m_values.clear();
+    m_value_was_set = false;
+  }
+
   uint32_t m_type_mask;
   OptionEnumValues m_enum_values;
   llvm::StringMap<lldb::OptionValueSP> m_values;

--- a/lldb/include/lldb/Interpreter/OptionValueDictionary.h
+++ b/lldb/include/lldb/Interpreter/OptionValueDictionary.h
@@ -41,6 +41,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_values.clear();
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
+++ b/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
@@ -47,12 +47,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   void AutoComplete(CommandInterpreter &interpreter,
@@ -76,6 +70,11 @@ public:
 protected:
   void SetEnumerations(const OptionEnumValues &enumerators);
   void DumpEnum(Stream &strm, enum_type value);
+
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
 
   enum_type m_current_value;
   enum_type m_default_value;

--- a/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
+++ b/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
@@ -48,6 +48,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value = m_default_value;
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueFileColonLine.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileColonLine.h
@@ -35,13 +35,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_file_spec.Clear();
-    m_line_number = LLDB_INVALID_LINE_NUMBER;
-    m_column_number = LLDB_INVALID_COLUMN_NUMBER;
-  }
-
   void SetFile(const FileSpec &file_spec) { m_file_spec = file_spec; }
   void SetLine(uint32_t line) { m_line_number = line; }
   void SetColumn(uint32_t column) { m_column_number = column; }
@@ -56,6 +49,12 @@ public:
   void SetCompletionMask(uint32_t mask) { m_completion_mask = mask; }
 
 protected:
+  void ClearImpl() override {
+    m_file_spec.Clear();
+    m_line_number = LLDB_INVALID_LINE_NUMBER;
+    m_column_number = LLDB_INVALID_COLUMN_NUMBER;
+  }
+
   FileSpec m_file_spec;
   uint32_t m_line_number = LLDB_INVALID_LINE_NUMBER;
   uint32_t m_column_number = LLDB_INVALID_COLUMN_NUMBER;

--- a/lldb/include/lldb/Interpreter/OptionValueFileColonLine.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileColonLine.h
@@ -36,6 +36,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_file_spec.Clear();
     m_line_number = LLDB_INVALID_LINE_NUMBER;
     m_column_number = LLDB_INVALID_COLUMN_NUMBER;

--- a/lldb/include/lldb/Interpreter/OptionValueFileSpec.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpec.h
@@ -43,14 +43,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-    m_data_sp.reset();
-    m_data_mod_time = llvm::sys::TimePoint<>();
-  }
-
   void AutoComplete(CommandInterpreter &interpreter,
                     CompletionRequest &request) override;
 
@@ -78,6 +70,13 @@ public:
   void SetCompletionMask(uint32_t mask) { m_completion_mask = mask; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+    m_data_sp.reset();
+    m_data_mod_time = llvm::sys::TimePoint<>();
+  }
+
   FileSpec m_current_value;
   FileSpec m_default_value;
   lldb::DataBufferSP m_data_sp;

--- a/lldb/include/lldb/Interpreter/OptionValueFileSpec.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpec.h
@@ -44,6 +44,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value = m_default_value;
     m_value_was_set = false;
     m_data_sp.reset();

--- a/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
@@ -39,12 +39,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value.Clear();
-    m_value_was_set = false;
-  }
-
   bool IsAggregateValue() const override { return true; }
 
   // Subclass specific functions
@@ -66,6 +60,11 @@ public:
 
 protected:
   lldb::OptionValueSP Clone() const override;
+
+  void ClearImpl() override {
+    m_current_value.Clear();
+    m_value_was_set = false;
+  }
 
   FileSpecList m_current_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
@@ -67,7 +67,6 @@ public:
 protected:
   lldb::OptionValueSP Clone() const override;
 
-  mutable std::recursive_mutex m_mutex;
   FileSpecList m_current_value;
 };
 

--- a/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
@@ -65,6 +65,8 @@ protected:
     m_current_value.Clear();
     m_value_was_set = false;
   }
+  // FIXME: This could use the existing m_mutex from the OptionValue
+  // parent class, but needs clean up in callsites to avoid deadlock.
   mutable std::recursive_mutex m_rmutex;
   FileSpecList m_current_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
@@ -44,17 +44,17 @@ public:
   // Subclass specific functions
 
   FileSpecList GetCurrentValue() const {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_rmutex);
     return m_current_value;
   }
 
   void SetCurrentValue(const FileSpecList &value) {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_rmutex);
     m_current_value = value;
   }
 
   void AppendCurrentValue(const FileSpec &value) {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_rmutex);
     m_current_value.Append(value);
   }
 
@@ -65,7 +65,7 @@ protected:
     m_current_value.Clear();
     m_value_was_set = false;
   }
-
+  mutable std::recursive_mutex m_rmutex;
   FileSpecList m_current_value;
 };
 

--- a/lldb/include/lldb/Interpreter/OptionValueFormat.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFormat.h
@@ -37,12 +37,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -56,6 +50,11 @@ public:
   void SetDefaultValue(lldb::Format value) { m_default_value = value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   lldb::Format m_current_value;
   lldb::Format m_default_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueFormat.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFormat.h
@@ -38,6 +38,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value = m_default_value;
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueFormatEntity.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFormatEntity.h
@@ -32,8 +32,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override;
-
   bool IsDefault() const override {
     return m_current_format == m_default_format;
   }
@@ -50,6 +48,8 @@ public:
   const FormatEntity::Entry &GetDefaultValue() const { return m_default_entry; }
 
 protected:
+  void ClearImpl() override;
+
   std::string m_current_format;
   std::string m_default_format;
   FormatEntity::Entry m_current_entry;

--- a/lldb/include/lldb/Interpreter/OptionValueLanguage.h
+++ b/lldb/include/lldb/Interpreter/OptionValueLanguage.h
@@ -39,12 +39,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -58,6 +52,11 @@ public:
   void SetDefaultValue(lldb::LanguageType value) { m_default_value = value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   lldb::LanguageType m_current_value;
   lldb::LanguageType m_default_value;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueLanguage.h
+++ b/lldb/include/lldb/Interpreter/OptionValueLanguage.h
@@ -40,6 +40,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value = m_default_value;
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValuePathMappings.h
+++ b/lldb/include/lldb/Interpreter/OptionValuePathMappings.h
@@ -35,12 +35,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_path_mappings.Clear(m_notify_changes);
-    m_value_was_set = false;
-  }
-
   bool IsAggregateValue() const override { return true; }
 
   // Subclass specific functions
@@ -50,6 +44,11 @@ public:
   const PathMappingList &GetCurrentValue() const { return m_path_mappings; }
 
 protected:
+  void ClearImpl() override {
+    m_path_mappings.Clear(m_notify_changes);
+    m_value_was_set = false;
+  }
+
   PathMappingList m_path_mappings;
   bool m_notify_changes;
 };

--- a/lldb/include/lldb/Interpreter/OptionValuePathMappings.h
+++ b/lldb/include/lldb/Interpreter/OptionValuePathMappings.h
@@ -36,6 +36,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_path_mappings.Clear(m_notify_changes);
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueProperties.h
+++ b/lldb/include/lldb/Interpreter/OptionValueProperties.h
@@ -31,8 +31,6 @@ public:
 
   Type GetType() const override { return eTypeProperties; }
 
-  void Clear() override;
-
   static lldb::OptionValuePropertiesSP
   CreateLocalCopy(const Properties &global_properties);
 
@@ -180,6 +178,8 @@ protected:
   }
 
   bool VerifyPath();
+
+  void ClearImpl() override;
 
   std::string m_name;
   std::vector<Property> m_properties;

--- a/lldb/include/lldb/Interpreter/OptionValueRegex.h
+++ b/lldb/include/lldb/Interpreter/OptionValueRegex.h
@@ -36,12 +36,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_regex = RegularExpression(m_default_regex_str);
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override {
     return m_regex.GetText() == m_default_regex_str;
   }
@@ -61,6 +55,11 @@ public:
   bool IsValid() const { return m_regex.IsValid(); }
 
 protected:
+  void ClearImpl() override {
+    m_regex = RegularExpression(m_default_regex_str);
+    m_value_was_set = false;
+  }
+
   RegularExpression m_regex;
   std::string m_default_regex_str;
 };

--- a/lldb/include/lldb/Interpreter/OptionValueRegex.h
+++ b/lldb/include/lldb/Interpreter/OptionValueRegex.h
@@ -37,6 +37,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_regex = RegularExpression(m_default_regex_str);
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueSInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionValueSInt64.h
@@ -43,12 +43,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -86,6 +80,11 @@ public:
   int64_t GetMaximumValue() const { return m_max_value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   int64_t m_current_value = 0;
   int64_t m_default_value = 0;
   int64_t m_min_value = std::numeric_limits<int64_t>::min();

--- a/lldb/include/lldb/Interpreter/OptionValueSInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionValueSInt64.h
@@ -44,6 +44,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value = m_default_value;
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueString.h
+++ b/lldb/include/lldb/Interpreter/OptionValueString.h
@@ -77,12 +77,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -123,6 +117,11 @@ public:
   }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   std::string m_current_value;
   std::string m_default_value;
   Flags m_options;

--- a/lldb/include/lldb/Interpreter/OptionValueString.h
+++ b/lldb/include/lldb/Interpreter/OptionValueString.h
@@ -78,6 +78,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value = m_default_value;
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueUInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionValueUInt64.h
@@ -46,12 +46,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_current_value = m_default_value;
-    m_value_was_set = false;
-  }
-
   bool IsDefault() const override { return m_current_value == m_default_value; }
 
   // Subclass specific functions
@@ -91,6 +85,11 @@ public:
   uint64_t GetMaximumValue() const { return m_max_value; }
 
 protected:
+  void ClearImpl() override {
+    m_current_value = m_default_value;
+    m_value_was_set = false;
+  }
+
   uint64_t m_current_value = 0;
   uint64_t m_default_value = 0;
   uint64_t m_min_value = std::numeric_limits<uint64_t>::min();

--- a/lldb/include/lldb/Interpreter/OptionValueUInt64.h
+++ b/lldb/include/lldb/Interpreter/OptionValueUInt64.h
@@ -47,6 +47,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_current_value = m_default_value;
     m_value_was_set = false;
   }

--- a/lldb/include/lldb/Interpreter/OptionValueUUID.h
+++ b/lldb/include/lldb/Interpreter/OptionValueUUID.h
@@ -37,12 +37,6 @@ public:
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
-  void Clear() override {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    m_uuid.Clear();
-    m_value_was_set = false;
-  }
-
   // Subclass specific functions
 
   UUID &GetCurrentValue() { return m_uuid; }
@@ -55,6 +49,11 @@ public:
                     CompletionRequest &request) override;
 
 protected:
+  void ClearImpl() override {
+    m_uuid.Clear();
+    m_value_was_set = false;
+  }
+
   UUID m_uuid;
 };
 

--- a/lldb/include/lldb/Interpreter/OptionValueUUID.h
+++ b/lldb/include/lldb/Interpreter/OptionValueUUID.h
@@ -38,6 +38,7 @@ public:
                      VarSetOperationType op = eVarSetOperationAssign) override;
 
   void Clear() override {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_uuid.Clear();
     m_value_was_set = false;
   }

--- a/lldb/source/Interpreter/OptionValue.cpp
+++ b/lldb/source/Interpreter/OptionValue.cpp
@@ -467,7 +467,7 @@ std::optional<ArchSpec> OptionValue::GetArchSpecValue() const {
 }
 
 bool OptionValue::SetArchSpecValue(ArchSpec arch_spec) {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueArch *option_value = GetAsArch()) {
     option_value->SetCurrentValue(arch_spec, false);
     return true;

--- a/lldb/source/Interpreter/OptionValue.cpp
+++ b/lldb/source/Interpreter/OptionValue.cpp
@@ -16,7 +16,7 @@ using namespace lldb;
 using namespace lldb_private;
 
 OptionValue::OptionValue(const OptionValue &other) {
-  std::lock_guard<std::mutex> lock(other.m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(other.m_mutex);
 
   m_parent_wp = other.m_parent_wp;
   m_callback = other.m_callback;
@@ -24,8 +24,9 @@ OptionValue::OptionValue(const OptionValue &other) {
 
 }
 
-OptionValue& OptionValue::operator=(const OptionValue &other) {
-  std::scoped_lock<std::mutex, std::mutex> lock(m_mutex, other.m_mutex);
+OptionValue &OptionValue::operator=(const OptionValue &other) {
+  std::scoped_lock<std::recursive_mutex, std::recursive_mutex> lock(
+      m_mutex, other.m_mutex);
 
   m_parent_wp = other.m_parent_wp;
   m_callback = other.m_callback;
@@ -269,14 +270,14 @@ const OptionValueUUID *OptionValue::GetAsUUID() const {
 }
 
 std::optional<bool> OptionValue::GetBooleanValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueBoolean *option_value = GetAsBoolean())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetBooleanValue(bool new_value) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueBoolean *option_value = GetAsBoolean()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -285,14 +286,14 @@ bool OptionValue::SetBooleanValue(bool new_value) {
 }
 
 std::optional<char> OptionValue::GetCharValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueChar *option_value = GetAsChar())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetCharValue(char new_value) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueChar *option_value = GetAsChar()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -301,14 +302,14 @@ bool OptionValue::SetCharValue(char new_value) {
 }
 
 std::optional<int64_t> OptionValue::GetEnumerationValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueEnumeration *option_value = GetAsEnumeration())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetEnumerationValue(int64_t value) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueEnumeration *option_value = GetAsEnumeration()) {
     option_value->SetCurrentValue(value);
     return true;
@@ -317,14 +318,14 @@ bool OptionValue::SetEnumerationValue(int64_t value) {
 }
 
 std::optional<FileSpec> OptionValue::GetFileSpecValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueFileSpec *option_value = GetAsFileSpec())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetFileSpecValue(FileSpec file_spec) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueFileSpec *option_value = GetAsFileSpec()) {
     option_value->SetCurrentValue(file_spec, false);
     return true;
@@ -333,7 +334,7 @@ bool OptionValue::SetFileSpecValue(FileSpec file_spec) {
 }
 
 bool OptionValue::AppendFileSpecValue(FileSpec file_spec) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueFileSpecList *option_value = GetAsFileSpecList()) {
     option_value->AppendCurrentValue(file_spec);
     return true;
@@ -342,21 +343,21 @@ bool OptionValue::AppendFileSpecValue(FileSpec file_spec) {
 }
 
 std::optional<FileSpecList> OptionValue::GetFileSpecListValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueFileSpecList *option_value = GetAsFileSpecList())
     return option_value->GetCurrentValue();
   return {};
 }
 
 std::optional<lldb::Format> OptionValue::GetFormatValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueFormat *option_value = GetAsFormat())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetFormatValue(lldb::Format new_value) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueFormat *option_value = GetAsFormat()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -365,14 +366,14 @@ bool OptionValue::SetFormatValue(lldb::Format new_value) {
 }
 
 std::optional<lldb::LanguageType> OptionValue::GetLanguageValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueLanguage *option_value = GetAsLanguage())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetLanguageValue(lldb::LanguageType new_language) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueLanguage *option_value = GetAsLanguage()) {
     option_value->SetCurrentValue(new_language);
     return true;
@@ -381,28 +382,28 @@ bool OptionValue::SetLanguageValue(lldb::LanguageType new_language) {
 }
 
 FormatEntity::Entry OptionValue::GetFormatEntityValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueFormatEntity *option_value = GetAsFormatEntity())
     return option_value->GetCurrentValue();
   return {};
 }
 
 const RegularExpression *OptionValue::GetRegexValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueRegex *option_value = GetAsRegex())
     return option_value->GetCurrentValue();
   return nullptr;
 }
 
 std::optional<int64_t> OptionValue::GetSInt64Value() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueSInt64 *option_value = GetAsSInt64())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetSInt64Value(int64_t new_value) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueSInt64 *option_value = GetAsSInt64()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -411,14 +412,14 @@ bool OptionValue::SetSInt64Value(int64_t new_value) {
 }
 
 std::optional<llvm::StringRef> OptionValue::GetStringValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueString *option_value = GetAsString())
     return option_value->GetCurrentValueAsRef();
   return {};
 }
 
 bool OptionValue::SetStringValue(llvm::StringRef new_value) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueString *option_value = GetAsString()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -427,14 +428,14 @@ bool OptionValue::SetStringValue(llvm::StringRef new_value) {
 }
 
 std::optional<uint64_t> OptionValue::GetUInt64Value() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueUInt64 *option_value = GetAsUInt64())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetUInt64Value(uint64_t new_value) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueUInt64 *option_value = GetAsUInt64()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -443,14 +444,14 @@ bool OptionValue::SetUInt64Value(uint64_t new_value) {
 }
 
 std::optional<UUID> OptionValue::GetUUIDValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueUUID *option_value = GetAsUUID())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetUUIDValue(const UUID &uuid) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueUUID *option_value = GetAsUUID()) {
     option_value->SetCurrentValue(uuid);
     return true;
@@ -459,14 +460,14 @@ bool OptionValue::SetUUIDValue(const UUID &uuid) {
 }
 
 std::optional<ArchSpec> OptionValue::GetArchSpecValue() const {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (const OptionValueArch *option_value = GetAsArch())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetArchSpecValue(ArchSpec arch_spec) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueArch *option_value = GetAsArch()) {
     option_value->SetCurrentValue(arch_spec, false);
     return true;
@@ -475,7 +476,7 @@ bool OptionValue::SetArchSpecValue(ArchSpec arch_spec) {
 }
 
 bool OptionValue::SetFormatEntityValue(const FormatEntity::Entry &entry) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (OptionValueFormatEntity *option_value = GetAsFormatEntity()) {
     option_value->SetCurrentValue(entry);
     return true;

--- a/lldb/source/Interpreter/OptionValue.cpp
+++ b/lldb/source/Interpreter/OptionValue.cpp
@@ -16,7 +16,7 @@ using namespace lldb;
 using namespace lldb_private;
 
 OptionValue::OptionValue(const OptionValue &other) {
-  std::lock_guard<std::recursive_mutex> lock(other.m_mutex);
+  std::lock_guard<std::mutex> lock(other.m_mutex);
 
   m_parent_wp = other.m_parent_wp;
   m_callback = other.m_callback;
@@ -25,8 +25,7 @@ OptionValue::OptionValue(const OptionValue &other) {
 }
 
 OptionValue &OptionValue::operator=(const OptionValue &other) {
-  std::scoped_lock<std::recursive_mutex, std::recursive_mutex> lock(
-      m_mutex, other.m_mutex);
+  std::scoped_lock<std::mutex, std::mutex> lock(m_mutex, other.m_mutex);
 
   m_parent_wp = other.m_parent_wp;
   m_callback = other.m_callback;
@@ -270,14 +269,14 @@ const OptionValueUUID *OptionValue::GetAsUUID() const {
 }
 
 std::optional<bool> OptionValue::GetBooleanValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueBoolean *option_value = GetAsBoolean())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetBooleanValue(bool new_value) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueBoolean *option_value = GetAsBoolean()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -286,14 +285,14 @@ bool OptionValue::SetBooleanValue(bool new_value) {
 }
 
 std::optional<char> OptionValue::GetCharValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueChar *option_value = GetAsChar())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetCharValue(char new_value) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueChar *option_value = GetAsChar()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -302,14 +301,14 @@ bool OptionValue::SetCharValue(char new_value) {
 }
 
 std::optional<int64_t> OptionValue::GetEnumerationValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueEnumeration *option_value = GetAsEnumeration())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetEnumerationValue(int64_t value) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueEnumeration *option_value = GetAsEnumeration()) {
     option_value->SetCurrentValue(value);
     return true;
@@ -318,14 +317,14 @@ bool OptionValue::SetEnumerationValue(int64_t value) {
 }
 
 std::optional<FileSpec> OptionValue::GetFileSpecValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueFileSpec *option_value = GetAsFileSpec())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetFileSpecValue(FileSpec file_spec) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueFileSpec *option_value = GetAsFileSpec()) {
     option_value->SetCurrentValue(file_spec, false);
     return true;
@@ -334,7 +333,7 @@ bool OptionValue::SetFileSpecValue(FileSpec file_spec) {
 }
 
 bool OptionValue::AppendFileSpecValue(FileSpec file_spec) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueFileSpecList *option_value = GetAsFileSpecList()) {
     option_value->AppendCurrentValue(file_spec);
     return true;
@@ -343,21 +342,21 @@ bool OptionValue::AppendFileSpecValue(FileSpec file_spec) {
 }
 
 std::optional<FileSpecList> OptionValue::GetFileSpecListValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueFileSpecList *option_value = GetAsFileSpecList())
     return option_value->GetCurrentValue();
   return {};
 }
 
 std::optional<lldb::Format> OptionValue::GetFormatValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueFormat *option_value = GetAsFormat())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetFormatValue(lldb::Format new_value) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueFormat *option_value = GetAsFormat()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -366,14 +365,14 @@ bool OptionValue::SetFormatValue(lldb::Format new_value) {
 }
 
 std::optional<lldb::LanguageType> OptionValue::GetLanguageValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueLanguage *option_value = GetAsLanguage())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetLanguageValue(lldb::LanguageType new_language) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueLanguage *option_value = GetAsLanguage()) {
     option_value->SetCurrentValue(new_language);
     return true;
@@ -382,28 +381,28 @@ bool OptionValue::SetLanguageValue(lldb::LanguageType new_language) {
 }
 
 FormatEntity::Entry OptionValue::GetFormatEntityValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueFormatEntity *option_value = GetAsFormatEntity())
     return option_value->GetCurrentValue();
   return {};
 }
 
 const RegularExpression *OptionValue::GetRegexValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueRegex *option_value = GetAsRegex())
     return option_value->GetCurrentValue();
   return nullptr;
 }
 
 std::optional<int64_t> OptionValue::GetSInt64Value() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueSInt64 *option_value = GetAsSInt64())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetSInt64Value(int64_t new_value) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueSInt64 *option_value = GetAsSInt64()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -412,14 +411,14 @@ bool OptionValue::SetSInt64Value(int64_t new_value) {
 }
 
 std::optional<llvm::StringRef> OptionValue::GetStringValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueString *option_value = GetAsString())
     return option_value->GetCurrentValueAsRef();
   return {};
 }
 
 bool OptionValue::SetStringValue(llvm::StringRef new_value) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueString *option_value = GetAsString()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -428,14 +427,14 @@ bool OptionValue::SetStringValue(llvm::StringRef new_value) {
 }
 
 std::optional<uint64_t> OptionValue::GetUInt64Value() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueUInt64 *option_value = GetAsUInt64())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetUInt64Value(uint64_t new_value) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueUInt64 *option_value = GetAsUInt64()) {
     option_value->SetCurrentValue(new_value);
     return true;
@@ -444,14 +443,14 @@ bool OptionValue::SetUInt64Value(uint64_t new_value) {
 }
 
 std::optional<UUID> OptionValue::GetUUIDValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueUUID *option_value = GetAsUUID())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetUUIDValue(const UUID &uuid) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueUUID *option_value = GetAsUUID()) {
     option_value->SetCurrentValue(uuid);
     return true;
@@ -460,14 +459,14 @@ bool OptionValue::SetUUIDValue(const UUID &uuid) {
 }
 
 std::optional<ArchSpec> OptionValue::GetArchSpecValue() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (const OptionValueArch *option_value = GetAsArch())
     return option_value->GetCurrentValue();
   return {};
 }
 
 bool OptionValue::SetArchSpecValue(ArchSpec arch_spec) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueArch *option_value = GetAsArch()) {
     option_value->SetCurrentValue(arch_spec, false);
     return true;
@@ -476,7 +475,7 @@ bool OptionValue::SetArchSpecValue(ArchSpec arch_spec) {
 }
 
 bool OptionValue::SetFormatEntityValue(const FormatEntity::Entry &entry) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (OptionValueFormatEntity *option_value = GetAsFormatEntity()) {
     option_value->SetCurrentValue(entry);
     return true;

--- a/lldb/source/Interpreter/OptionValueBoolean.cpp
+++ b/lldb/source/Interpreter/OptionValueBoolean.cpp
@@ -50,7 +50,7 @@ Status OptionValueBoolean::SetValueFromString(llvm::StringRef value_str,
     bool success = false;
     bool value = OptionArgParser::ToBoolean(value_str, false, &success);
     if (success) {
-      OptionWasSet();
+      SetOptionWasSet();
       SetValueAs(value);
       NotifyValueChanged();
     } else {

--- a/lldb/source/Interpreter/OptionValueBoolean.cpp
+++ b/lldb/source/Interpreter/OptionValueBoolean.cpp
@@ -50,8 +50,8 @@ Status OptionValueBoolean::SetValueFromString(llvm::StringRef value_str,
     bool success = false;
     bool value = OptionArgParser::ToBoolean(value_str, false, &success);
     if (success) {
-      m_value_was_set = true;
-      m_current_value = value;
+      OptionWasSet();
+      SetValueAs(value);
       NotifyValueChanged();
     } else {
       if (value_str.size() == 0)

--- a/lldb/source/Interpreter/OptionValueFileSpecList.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpecList.cpp
@@ -17,7 +17,7 @@ using namespace lldb_private;
 
 void OptionValueFileSpecList::DumpValue(const ExecutionContext *exe_ctx,
                                         Stream &strm, uint32_t dump_mask) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_rmutex);
   if (dump_mask & eDumpOptionType)
     strm.Printf("(%s)", GetTypeAsCString());
   if (dump_mask & eDumpOptionValue) {
@@ -50,7 +50,7 @@ void OptionValueFileSpecList::DumpValue(const ExecutionContext *exe_ctx,
 
 llvm::json::Value
 OptionValueFileSpecList::ToJSON(const ExecutionContext *exe_ctx) const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_rmutex);
   llvm::json::Array array;
   for (const auto &file_spec : m_current_value)
     array.emplace_back(file_spec.ToJSON());
@@ -59,7 +59,7 @@ OptionValueFileSpecList::ToJSON(const ExecutionContext *exe_ctx) const {
 
 Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
                                                    VarSetOperationType op) {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_rmutex);
   Status error;
   Args args(value.str());
   const size_t argc = args.GetArgumentCount();
@@ -180,6 +180,6 @@ Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
 }
 
 OptionValueSP OptionValueFileSpecList::Clone() const {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_rmutex);
   return Cloneable::Clone();
 }

--- a/lldb/source/Interpreter/OptionValueFormatEntity.cpp
+++ b/lldb/source/Interpreter/OptionValueFormatEntity.cpp
@@ -28,8 +28,7 @@ OptionValueFormatEntity::OptionValueFormatEntity(const char *default_format) {
   }
 }
 
-void OptionValueFormatEntity::Clear() {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+void OptionValueFormatEntity::ClearImpl() {
   m_current_entry = m_default_entry;
   m_current_format = m_default_format;
   m_value_was_set = false;

--- a/lldb/source/Interpreter/OptionValueFormatEntity.cpp
+++ b/lldb/source/Interpreter/OptionValueFormatEntity.cpp
@@ -29,6 +29,7 @@ OptionValueFormatEntity::OptionValueFormatEntity(const char *default_format) {
 }
 
 void OptionValueFormatEntity::Clear() {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   m_current_entry = m_default_entry;
   m_current_format = m_default_format;
   m_value_was_set = false;

--- a/lldb/source/Interpreter/OptionValueProperties.cpp
+++ b/lldb/source/Interpreter/OptionValueProperties.cpp
@@ -303,8 +303,7 @@ OptionValueString *OptionValueProperties::GetPropertyAtIndexAsOptionValueString(
   return nullptr;
 }
 
-void OptionValueProperties::Clear() {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+void OptionValueProperties::ClearImpl() {
   const size_t num_properties = m_properties.size();
   for (size_t i = 0; i < num_properties; ++i)
     m_properties[i].GetValue()->Clear();

--- a/lldb/source/Interpreter/OptionValueProperties.cpp
+++ b/lldb/source/Interpreter/OptionValueProperties.cpp
@@ -304,6 +304,7 @@ OptionValueString *OptionValueProperties::GetPropertyAtIndexAsOptionValueString(
 }
 
 void OptionValueProperties::Clear() {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   const size_t num_properties = m_properties.size();
   for (size_t i = 0; i < num_properties; ++i)
     m_properties[i].GetValue()->Clear();


### PR DESCRIPTION
The clear function guarded by the internal mutex.
This happens when we have to threads one trying to set a value and the other reseting the value.

The derived classes are forced to implement the `ClearImpl`. and base `OptionValue` hold the mutex and calls `ClearImpl` on clear. 