### PR TITLE
[lldb] Don't add the same module to a target twice

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2659,8 +2659,10 @@ ModuleSP Target::GetOrCreateModule(const ModuleSpec &orig_module_spec,
           }
         }
 
-        if (replaced_modules.empty())
-          m_images.AppendIfNeeded(module_sp, notify);
+        if (replaced_modules.empty()) {
+          if (!m_images.AppendIfNeeded(module_sp, notify) && notify)
+            NotifyModuleAdded(m_images, module_sp);
+        }
 
         for (ModuleSP &old_module_sp : replaced_modules) {
           auto old_module_wp = old_module_sp->weak_from_this();

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2660,7 +2660,7 @@ ModuleSP Target::GetOrCreateModule(const ModuleSpec &orig_module_spec,
         }
 
         if (replaced_modules.empty())
-          m_images.Append(module_sp, notify);
+          m_images.AppendIfNeeded(module_sp, notify);
 
         for (ModuleSP &old_module_sp : replaced_modules) {
           auto old_module_wp = old_module_sp->weak_from_this();


### PR DESCRIPTION
`Target::GetOrCreateModule` uses `Append`, so a module already in the target could be added again. Then `RemoveModule` dropped only one, keeping the module (and its memory-mapped file) alive.
On Windows that mapped file can't be deleted, causing `TestReplaceDLL.py` to fail with `LLDB_USE_LLDB_SERVER=1`.

This patch uses `AppendIfNeeded` instead.

rdar://181797592