### PR TITLE
[lldb] Prefer DW_AT_bit_size for DW_OP_convert type width

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
@@ -729,9 +729,9 @@ DWARFUnit::GetDIEBitSizeAndSign(uint64_t relative_die_offset) const {
         "DW_OP_convert type DIE is not a DW_TAG_base_type");
   uint64_t encoding =
       die.GetAttributeValueAsUnsigned(DW_AT_encoding, DW_ATE_hi_user);
-  uint64_t bit_size = die.GetAttributeValueAsUnsigned(DW_AT_byte_size, 0) * 8;
+  uint64_t bit_size = die.GetAttributeValueAsUnsigned(DW_AT_bit_size, 0);
   if (!bit_size)
-    bit_size = die.GetAttributeValueAsUnsigned(DW_AT_bit_size, 0);
+    bit_size = die.GetAttributeValueAsUnsigned(DW_AT_byte_size, 0) * 8;
   if (!bit_size)
     return llvm::createStringError("unsupported type size");
   bool sign;

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -453,6 +453,16 @@ DWARF:
               Form:            DW_FORM_data1
             - Attribute:       DW_AT_byte_size
               Form:            DW_FORM_data1
+        - Code:            0x00000004
+          Tag:             DW_TAG_base_type
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_encoding
+              Form:            DW_FORM_data1
+            - Attribute:       DW_AT_byte_size
+              Form:            DW_FORM_data1
+            - Attribute:       DW_AT_bit_size
+              Form:            DW_FORM_data1
   debug_info:
     - Version:         4
       AddrSize:        8
@@ -506,6 +516,12 @@ DWARF:
           Values:
             - Value:           0x0000000000000007 # DW_ATE_unsigned
             - Value:           0x0000000000000004
+        # 0x00000023:
+        - AbbrCode:        0x00000004
+          Values:
+            - Value:           0x0000000000000005 # DW_ATE_signed
+            - Value:           0x0000000000000004
+            - Value:           0x000000000000001f
         - AbbrCode:        0x00000000
 
 )";
@@ -516,6 +532,7 @@ DWARF:
   uint8_t offs_uchar = 0x00000017;
   uint8_t offs_schar = 0x0000001a;
   uint8_t offs_enum = 0x00000020;
+  uint8_t offs_sint31_t = 0x00000023;
 
   DWARFExpressionTester t(yamldata, /*cu_index=*/1);
   ASSERT_TRUE((bool)t.GetDwarfUnit());
@@ -568,6 +585,18 @@ DWARF:
   EXPECT_THAT_EXPECTED(t.Eval({DW_OP_const4s, 'A', 'B', 'C', 'D', DW_OP_convert,
                                offs_schar, DW_OP_stack_value}),
                        ExpectScalar(8, 'A', is_signed));
+
+  // Prefer DW_AT_bit_size over DW_AT_byte_size when both are present.
+  EXPECT_THAT_EXPECTED(
+      t.Eval({DW_OP_const4u, 0x00, 0x00, 0x00, 0x40, DW_OP_convert,
+              offs_sint31_t, DW_OP_stack_value}),
+      ExpectScalar(31, 0x40000000, is_signed));
+
+  // Truncate the high bit when the value crosses the 31-bit boundary.
+  EXPECT_THAT_EXPECTED(
+      t.Eval({DW_OP_const4u, 0x00, 0x00, 0x00, 0xc0, DW_OP_convert,
+              offs_sint31_t, DW_OP_stack_value}),
+      ExpectScalar(31, 0x40000000, is_signed));
 
   //
   // Errors.


### PR DESCRIPTION
This PR fixes a DW_OP_convert issue where LLDB derives the conversion width from DW_AT_byte_size * 8 before considering DW_AT_bit_size, #208203

For base types that carry both DW_AT_byte_size and DW_AT_bit_size, such as C _BitInt(31), DW_AT_bit_size describes the actual value width. LLDB should therefore prefer DW_AT_bit_size when it is present, and only fall back to DW_AT_byte_size otherwise.


## Tests

Extended DWARFExpression.DW_OP_convert coverage with a base type that has both DW_AT_byte_size and DW_AT_bit_size, and verifies that the conversion uses the DW_AT_bit_size width.