### PR TITLE
[RISCV][P-ext] Improve the codegen for pzip

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -6325,19 +6325,17 @@ static SDValue lowerVECTOR_SHUFFLEAsPZip(ShuffleVectorSDNode *SVN,
   unsigned NumElts = VT.getVectorNumElements();
   ArrayRef<int> Mask = SVN->getMask();
 
-  if ((VT != MVT::v8i8 && VT != MVT::v4i16) ||
-      V1.getSimpleValueType() != VT || V2.getSimpleValueType() != VT)
+  if (VT != MVT::v8i8 && VT != MVT::v4i16)
     return SDValue();
 
   SmallVector<unsigned, 2> StartIndexes;
   if (!V2.isUndef() &&
-      ShuffleVectorInst::isInterleaveMask(Mask, 2, NumElts * 2,
-                                          StartIndexes)) {
-    int EvenSrc = StartIndexes[0];
-    int OddSrc = StartIndexes[1];
-    if (EvenSrc == 0 && OddSrc == (int)NumElts)
+      ShuffleVectorInst::isInterleaveMask(Mask, 2, NumElts * 2, StartIndexes)) {
+    unsigned EvenSrc = StartIndexes[0];
+    unsigned OddSrc = StartIndexes[1];
+    if (EvenSrc == 0 && OddSrc == NumElts)
       return DAG.getNode(RISCVISD::PZIP, DL, VT, V1, V2);
-    if (EvenSrc == (int)NumElts && OddSrc == 0)
+    if (EvenSrc == NumElts && OddSrc == 0)
       return DAG.getNode(RISCVISD::PZIP, DL, VT, V2, V1);
   }
 

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -6314,6 +6314,36 @@ static SDValue tryWidenMaskForShuffle(SDValue Op, SelectionDAG &DAG) {
   return DAG.getBitcast(VT, DAG.getVectorShuffle(NewVT, DL, V0, V1, NewMask));
 }
 
+// Match an interleave shuffle that forms a P-extension packed zip:
+//   <a0, b0, a1, b1, ...> -> zip*p/wzip*p
+static SDValue lowerVECTOR_SHUFFLEAsPZip(ShuffleVectorSDNode *SVN,
+                                         SelectionDAG &DAG) {
+  SDValue V1 = SVN->getOperand(0);
+  SDValue V2 = SVN->getOperand(1);
+  SDLoc DL(SVN);
+  MVT VT = SVN->getSimpleValueType(0);
+  unsigned NumElts = VT.getVectorNumElements();
+  ArrayRef<int> Mask = SVN->getMask();
+
+  if ((VT != MVT::v8i8 && VT != MVT::v4i16) ||
+      V1.getSimpleValueType() != VT || V2.getSimpleValueType() != VT)
+    return SDValue();
+
+  SmallVector<unsigned, 2> StartIndexes;
+  if (!V2.isUndef() &&
+      ShuffleVectorInst::isInterleaveMask(Mask, 2, NumElts * 2,
+                                          StartIndexes)) {
+    int EvenSrc = StartIndexes[0];
+    int OddSrc = StartIndexes[1];
+    if (EvenSrc == 0 && OddSrc == (int)NumElts)
+      return DAG.getNode(RISCVISD::PZIP, DL, VT, V1, V2);
+    if (EvenSrc == (int)NumElts && OddSrc == 0)
+      return DAG.getNode(RISCVISD::PZIP, DL, VT, V2, V1);
+  }
+
+  return SDValue();
+}
+
 SDValue RISCVTargetLowering::lowerVECTOR_SHUFFLE(SDValue Op,
                                                  SelectionDAG &DAG) const {
   SDValue V1 = Op.getOperand(0);
@@ -6348,6 +6378,9 @@ SDValue RISCVTargetLowering::lowerVECTOR_SHUFFLE(SDValue Op,
                       DAG.getConstant(VT.getSizeInBits() / 2, DL, MVT::i64));
       return DAG.getBitcast(VT, Srl);
     }
+
+    if (SDValue V = lowerVECTOR_SHUFFLEAsPZip(SVN, DAG))
+      return V;
     return SDValue();
   }
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1908,6 +1908,12 @@ def SDT_RISCVPackedUnary : SDTypeProfile<1, 1, [SDTCisVec<0>,
                                                 SDTCisSameAs<0, 1>]>;
 def riscv_psabs : RVSDNode<"PSABS", SDT_RISCVPackedUnary>;
 
+// Interleave two packed vectors.
+def SDT_RISCVPZip : SDTypeProfile<1, 2, [SDTCisVec<0>,
+                                          SDTCisSameAs<0, 1>,
+                                          SDTCisSameAs<0, 2>]>;
+def riscv_pzip : RVSDNode<"PZIP", SDT_RISCVPZip>;
+
 // Add one to the immediate. Used by RISCVISD::SATI.
 def IncImm : SDNodeXForm<imm, [{
     return CurDAG->getTargetConstant(N->getZExtValue() + 1, SDLoc(N),
@@ -2263,6 +2269,16 @@ let append Predicates = [IsRV32] in {
   // Zero-extend patterns using wzip*p with zero
   def : Pat<(v4i16 (zext (v4i8 GPR:$rs))), (WZIP8P GPR:$rs, (v4i8 X0))>;
   def : Pat<(v2i32 (zext (v2i16 GPR:$rs))), (WZIP16P GPR:$rs, (v2i16 X0))>;
+
+  // Packed zip.
+  def : Pat<(v8i8 (riscv_pzip (v8i8 GPRPair:$rs1),
+                               (v8i8 GPRPair:$rs2))),
+            (WZIP8P (i32 (EXTRACT_SUBREG GPRPair:$rs1, sub_gpr_even)),
+                    (i32 (EXTRACT_SUBREG GPRPair:$rs2, sub_gpr_even)))>;
+  def : Pat<(v4i16 (riscv_pzip (v4i16 GPRPair:$rs1),
+                                (v4i16 GPRPair:$rs2))),
+            (WZIP16P (i32 (EXTRACT_SUBREG GPRPair:$rs1, sub_gpr_even)),
+                     (i32 (EXTRACT_SUBREG GPRPair:$rs2, sub_gpr_even)))>;
 
   // Sign-extend patterns using pwadd with zero
   def : Pat<(v4i16 (sext (v4i8 GPR:$rs))), (PWADD_B GPR:$rs, (v4i8 X0))>;
@@ -2749,6 +2765,11 @@ let append Predicates = [IsRV64] in {
   def : Pat<(v4i16 (zext_invec (v8i8 GPR:$rs))), (ZIP8P GPR:$rs, (v8i8 X0))>;
   def : Pat<(v2i32 (zext_invec (v4i16 GPR:$rs))), (ZIP16P GPR:$rs, (v4i16 X0))>;
 
+  // Packed zip.
+  def : Pat<(v8i8 (riscv_pzip (v8i8 GPR:$rs1), (v8i8 GPR:$rs2))),
+            (ZIP8P GPR:$rs1, GPR:$rs2)>;
+  def : Pat<(v4i16 (riscv_pzip (v4i16 GPR:$rs1), (v4i16 GPR:$rs2))),
+            (ZIP16P GPR:$rs1, GPR:$rs2)>;
   // Sign extend inreg patterns using psext. sext_invec is lowered to
   // zext_invec+sext_inreg.
   def : Pat<(v4i16 (sext_inreg GPR:$rs1, v4i8)), (PSEXT_H_B GPR:$rs1)>;

--- a/llvm/test/CodeGen/RISCV/rvp-zip.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-zip.ll
@@ -9,35 +9,12 @@
 define <8 x i8> @test_pzip_v8i8(<4 x i8> %a, <4 x i8> %b) {
 ; RV32-LABEL: test_pzip_v8i8:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    srli a2, a1, 24
-; RV32-NEXT:    srli a3, a0, 24
-; RV32-NEXT:    srli a4, a1, 16
-; RV32-NEXT:    srli a5, a0, 16
-; RV32-NEXT:    ppaire.b a2, a3, a2
-; RV32-NEXT:    ppaire.b a3, a5, a4
-; RV32-NEXT:    srli a4, a1, 8
-; RV32-NEXT:    srli a5, a0, 8
-; RV32-NEXT:    ppaire.b a0, a0, a1
-; RV32-NEXT:    ppaire.b a4, a5, a4
-; RV32-NEXT:    pack a1, a3, a2
-; RV32-NEXT:    pack a0, a0, a4
+; RV32-NEXT:    wzip8p a0, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: test_pzip_v8i8:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    srli a2, a1, 24
-; RV64-NEXT:    srli a3, a0, 24
-; RV64-NEXT:    srli a4, a1, 16
-; RV64-NEXT:    srli a5, a0, 16
-; RV64-NEXT:    ppaire.b a2, a3, a2
-; RV64-NEXT:    ppaire.b a3, a5, a4
-; RV64-NEXT:    srli a4, a1, 8
-; RV64-NEXT:    srli a5, a0, 8
-; RV64-NEXT:    ppaire.b a0, a0, a1
-; RV64-NEXT:    ppaire.b a1, a5, a4
-; RV64-NEXT:    ppaire.h a2, a3, a2
-; RV64-NEXT:    ppaire.h a0, a0, a1
-; RV64-NEXT:    pack a0, a0, a2
+; RV64-NEXT:    zip8p a0, a0, a1
 ; RV64-NEXT:    ret
   %r = shufflevector <4 x i8> %a, <4 x i8> %b, <8 x i32> <i32 0, i32 4, i32 1, i32 5, i32 2, i32 6, i32 3, i32 7>
   ret <8 x i8> %r
@@ -46,19 +23,12 @@ define <8 x i8> @test_pzip_v8i8(<4 x i8> %a, <4 x i8> %b) {
 define <4 x i16> @test_pzip_v4i16(<2 x i16> %a, <2 x i16> %b) {
 ; RV32-LABEL: test_pzip_v4i16:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    srli a2, a1, 16
-; RV32-NEXT:    srli a3, a0, 16
-; RV32-NEXT:    pack a0, a0, a1
-; RV32-NEXT:    pack a1, a3, a2
+; RV32-NEXT:    wzip16p a0, a0, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: test_pzip_v4i16:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    srli a2, a1, 16
-; RV64-NEXT:    srli a3, a0, 16
-; RV64-NEXT:    ppaire.h a0, a0, a1
-; RV64-NEXT:    ppaire.h a1, a3, a2
-; RV64-NEXT:    pack a0, a0, a1
+; RV64-NEXT:    zip16p a0, a0, a1
 ; RV64-NEXT:    ret
   %r = shufflevector <2 x i16> %a, <2 x i16> %b, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
   ret <4 x i16> %r


### PR DESCRIPTION
This patch recognizes interleaved shuffle (as packed zip intrinsics use) and selects the corresponding instructions.