### PR TITLE
[MLIR][XeGPU] Disable test execution, allow compilation

### DIFF
--- a/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm.mlir
+++ b/mlir/test/Integration/Dialect/XeGPU/WG/simple_mxfp_gemm.mlir
@@ -1,14 +1,13 @@
 // RUN: mlir-opt %s --gpu-lower-to-xevm-pipeline="xegpu-op-level=workgroup zebin-chip=cri" \
-// RUN: | mlir-runner \
-// RUN:   --shared-libs=%mlir_levelzero_runtime \
-// RUN:   --shared-libs=%mlir_runner_utils \
-// RUN:   --shared-libs=%mlir_c_runner_utils \
-// RUN:   --entry-point-result=void \
-// RUN: | FileCheck %s
+// RUN-DISABLED: | mlir-runner \
+// RUN-DISABLED:   --shared-libs=%mlir_levelzero_runtime \
+// RUN-DISABLED:   --shared-libs=%mlir_runner_utils \
+// RUN-DISABLED:   --shared-libs=%mlir_c_runner_utils \
+// RUN-DISABLED:   --entry-point-result=void \
+// RUN-DISABLED: | FileCheck %s
 
-// XFAIL: *
 // Note: layouts used by dpas_mx need to match HW constaint. Otherwise dpas_mx is not unrolled.
-#a = #xegpu.layout<sg_layout = [2, 2], sg_data = [16, 1024], inst_data = [8, 64], lane_layout = [1, 16], lane_data = [1, 1]>
+#a = #xegpu.layout<sg_layout = [2, 2], sg_data = [16, 1024], inst_data = [8, 64], lane_layout = [1, 16], lane_data = [1, 4]>
 #b_packed = #xegpu.layout<sg_layout = [2, 2], sg_data = [512, 16], inst_data = [32, 16], lane_layout = [1, 16], lane_data = [4, 1]>
 #b = #xegpu.layout<sg_layout = [2, 2], sg_data = [1024, 16], inst_data = [64, 16], lane_layout = [1, 16], lane_data = [8, 1]>
 #c = #xegpu.layout<sg_layout = [2, 2], sg_data = [16, 16], inst_data = [8, 16], lane_layout = [1, 16], lane_data = [1, 1]>


### PR DESCRIPTION
This PR follows the https://github.com/llvm/llvm-project/pull/207158 for a different test. 
So far, we want to verify at least the test compilation, not execution.