### PR TITLE
[llvm-mc] Remove unused MCRegisterInfo/MCAsmInfo in Disassembler (NFC)

### DIFF
--- a/llvm/tools/llvm-mc/Disassembler.cpp
+++ b/llvm/tools/llvm-mc/Disassembler.cpp
@@ -13,12 +13,9 @@
 
 #include "Disassembler.h"
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDisassembler/MCDisassembler.h"
 #include "llvm/MC/MCInst.h"
-#include "llvm/MC/MCObjectFileInfo.h"
-#include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/TargetRegistry.h"
@@ -167,22 +164,9 @@ static bool byteArrayFromString(ByteArrayTy &ByteArray, StringRef &Str,
 
 int Disassembler::disassemble(const Target &T, MCSubtargetInfo &STI,
                               MCStreamer &Streamer, MemoryBuffer &Buffer,
-                              SourceMgr &SM, MCContext &Ctx,
-                              const MCTargetOptions &MCOptions, bool HexBytes,
+                              SourceMgr &SM, MCContext &Ctx, bool HexBytes,
                               unsigned NumBenchmarkRuns) {
   const Triple &TheTriple = STI.getTargetTriple();
-  std::unique_ptr<const MCRegisterInfo> MRI(T.createMCRegInfo(TheTriple));
-  if (!MRI) {
-    errs() << "error: no register info for target " << TheTriple.str() << '\n';
-    return -1;
-  }
-
-  std::unique_ptr<const MCAsmInfo> MAI(
-      T.createMCAsmInfo(*MRI, TheTriple, MCOptions));
-  if (!MAI) {
-    errs() << "error: no assembly info for target " << TheTriple.str() << '\n';
-    return -1;
-  }
 
   std::unique_ptr<const MCDisassembler> DisAsm(
     T.createMCDisassembler(STI, Ctx));

--- a/llvm/tools/llvm-mc/Disassembler.h
+++ b/llvm/tools/llvm-mc/Disassembler.h
@@ -23,14 +23,12 @@ class SourceMgr;
 class MCContext;
 class MCSubtargetInfo;
 class MCStreamer;
-class MCTargetOptions;
 
 class Disassembler {
 public:
   static int disassemble(const Target &T, MCSubtargetInfo &STI,
                          MCStreamer &Streamer, MemoryBuffer &Buffer,
-                         SourceMgr &SM, MCContext &Ctx,
-                         const MCTargetOptions &MCOptions, bool HexBytes,
+                         SourceMgr &SM, MCContext &Ctx, bool HexBytes,
                          unsigned NumBenchmarkRuns);
 };
 

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -672,7 +672,7 @@ int main(int argc, char **argv) {
   }
   if (disassemble)
     Res = Disassembler::disassemble(*TheTarget, *STI, *Str, *Buffer, SrcMgr,
-                                    Ctx, MCOptions, HexBytes, NumBenchmarkRuns);
+                                    Ctx, HexBytes, NumBenchmarkRuns);
 
   // Keep output if no errors.
   if (Res == 0) {


### PR DESCRIPTION
Disassembler::disassemble() creates MCRegisterInfo and MCAsmInfo instances that are no longer used.

Initially, they were introduced in a1bc0f5 to construct MCContext after MCDisassembler began requiring one, but became dead in 2cb2707.

llvm-mc's main() already creates both objects and passes them into the MCContext that disassemble() receives, so the error paths here are unreachable.

Removing these objects also makes the MCTargetOptions parameter unused, so drop it as well.