### PR TITLE
[lldb] Fix data race when setting a breakpoint in mulitple debuggers.

### DIFF
--- a/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
@@ -12,6 +12,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/Function.h"
+#include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
@@ -301,13 +302,15 @@ Searcher::CallbackReturn BreakpointResolverFileLine::SearchCallback(
   Target &target = GetBreakpoint()->GetTarget();
   RealpathPrefixes realpath_prefixes = target.GetSourceRealpathPrefixes();
 
-  const size_t num_comp_units = context.module_sp->GetNumCompileUnits();
-  for (size_t i = 0; i < num_comp_units; i++) {
-    CompUnitSP cu_sp(context.module_sp->GetCompileUnitAtIndex(i));
-    if (cu_sp) {
-      if (filter.CompUnitPasses(*cu_sp))
+  if (const auto sym_file = context.module_sp->GetSymbolFileLocked()) {
+    const size_t num_comp_units = sym_file->GetNumCompileUnits();
+    for (size_t i = 0; i < num_comp_units; i++) {
+
+      if (const auto cu_sp = sym_file->GetCompileUnitAtIndex(i);
+          cu_sp && filter.CompUnitPasses(*cu_sp)) {
         cu_sp->ResolveSymbolContext(m_location_spec, eSymbolContextEverything,
                                     sc_list, &realpath_prefixes);
+      }
     }
   }
 


### PR DESCRIPTION
When you have two SBDebugger with a target for the same `a.out` and you try to add a breakpoint at the same location.

The data race happens in `CompileUnit::GetSupportFiles()` one debugger sees the there is no support files. it sets the parsed flag and parses the support file. The other debugger sees the parsed flag is set and will not set the breakpoint since the support file is still parsing and and will assume the symbol file does not have support files.


The pattern of looping through the compile units with a raw loop is quite common. and may suffer from the same problem. I wonder if it is better to add `Module::ForEachCompileUnit` function since the `GetCompileUnitAtIndex` and `GetNumOfCompileUnits` both lock internally but freed when leaving the function. 