### PR TITLE
[Hexagon] Fix wrong operand in XQFloat qf32 multiply normalization

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonXQFloatGenerator.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonXQFloatGenerator.cpp
@@ -1394,8 +1394,8 @@ bool HexagonXQFloatGenerator::convertNormalizeMultOp32(
         .addReg(R_mpy)
         .addReg(VR2);
     BuildMI(MBB, MI, DL, HII->get(Hexagon::V6_vmpy_qf32), Dest)
-        .addReg(input_mpy2)
-        .addReg(Reg2);
+        .addReg(Reg1)
+        .addReg(input_mpy2);
   } else {
     // we do nothing if the inputs are not fromadder/subtracter/multiplier unit
     return false;

--- a/llvm/test/CodeGen/Hexagon/autohvx/xqf-mult-normalize-second-operand.mir
+++ b/llvm/test/CodeGen/Hexagon/autohvx/xqf-mult-normalize-second-operand.mir
@@ -1,0 +1,32 @@
+# Tests qf32 multiply normalization when only the second operand needs
+# converting: the vmpy must keep the first operand and use the normalized
+# second operand.
+
+# RUN: llc -mtriple=hexagon-unknown-elf -mattr=+hvxv79,+hvx-length128b,+hvx-qfloat \
+# RUN:   -run-pass=hexagon-xqfloat-generator -hexagon-qfloat-mode=strict-ieee \
+# RUN:   -enable-xqf-gen=true %s -o - | FileCheck %s
+
+--- |
+  define void @mul_secondconv() { ret void }
+...
+---
+name:            mul_secondconv
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $v0, $v1, $v2
+    ; CHECK-LABEL: name: mul_secondconv
+    ; The second operand (from the adder) is converted to IEEE and normalized
+    ; through a vadd_qf32_mix; the multiply must consume that normalized value
+    ; together with the untouched first operand %1 - not the raw adder result.
+    ; CHECK: [[CONV:%[0-9]+]]:hvxvr = V6_vconv_sf_qf32 %3
+    ; CHECK: [[NORM:%[0-9]+]]:hvxvr = V6_vadd_qf32_mix %{{[0-9]+}}, [[CONV]]
+    ; CHECK: %4:hvxvr = V6_vmpy_qf32 %1, [[NORM]]
+    %0:hvxvr = COPY $v0
+    %1:hvxvr = COPY $v1
+    %2:hvxvr = COPY $v2
+    %3:hvxvr = V6_vadd_qf32 %0, %2
+    %4:hvxvr = V6_vmpy_qf32 %1, %3
+    $v0 = COPY %4
+    PS_jmpret $r31, implicit-def dead $pc, implicit $v0
+...


### PR DESCRIPTION
In convertNormalizeMultOp32, when only the second operand of a V6_vmpy_qf32 comes from an add/sub/mul unit (secondconvert), the generated multiply incorrectly used the raw second operand (Reg2) instead of the first operand (Reg1). This dropped the first operand and multiplied the normalized second operand by the un-normalized second operand.

This patch fixed the multiply to use Reg1 and the normalized input_mpy2, matching the correct arrangement used elsewhere. The bug was not observed on v81 (which takes the V81normalizeMultF32 path); it only affected the v79 fallback.

Co-authored-by: Santanu Das <quic_santdas@qti.qualcomm.com>