### PR TITLE
[offload] Fix -Wunused-template errors in plugin templates (NFC)

### DIFF
--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -126,8 +126,8 @@ static hsa_status_t iterate(IterFuncTy Func, IterFuncArgTy FuncArg,
 /// use this function directly but the specialized ones below instead.
 template <typename Elem1Ty, typename Elem2Ty, typename IterFuncTy,
           typename IterFuncArgTy, typename CallbackTy>
-static hsa_status_t iterate(IterFuncTy Func, IterFuncArgTy FuncArg,
-                            CallbackTy Cb) {
+[[maybe_unused]] static hsa_status_t
+iterate(IterFuncTy Func, IterFuncArgTy FuncArg, CallbackTy Cb) {
   auto L = [](Elem1Ty Elem1, Elem2Ty Elem2, void *Data) -> hsa_status_t {
     CallbackTy *Unwrapped = static_cast<CallbackTy *>(Data);
     return (*Unwrapped)(Elem1, Elem2);

--- a/offload/plugins-nextgen/common/include/DLWrap.h
+++ b/offload/plugins-nextgen/common/include/DLWrap.h
@@ -126,7 +126,7 @@ template <size_t N> struct symbol;
 } // namespace type
 
 template <size_t N, size_t... Is>
-constexpr std::array<const char *, N> static getSymbolArray(
+[[maybe_unused]] constexpr std::array<const char *, N> static getSymbolArray(
     std::index_sequence<Is...>) {
   return {{dlwrap::type::symbol<Is>::call()...}};
 }

--- a/offload/plugins-nextgen/common/include/OffloadError.h
+++ b/offload/plugins-nextgen/common/include/OffloadError.h
@@ -49,8 +49,8 @@ public:
 
 /// Create an Offload error.
 template <typename... ArgsTy>
-static llvm::Error createOffloadError(error::ErrorCode Code, const char *ErrFmt,
-                                      ArgsTy... Args) {
+llvm::Error createOffloadError(error::ErrorCode Code, const char *ErrFmt,
+                               ArgsTy... Args) {
   std::string Buffer;
   llvm::raw_string_ostream(Buffer) << llvm::format(ErrFmt, Args...);
   return llvm::make_error<error::OffloadError>(Code, Buffer);

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -76,7 +76,7 @@ static inline Error success() { return Error::success(); }
 
 /// Create an Offload error.
 template <typename... ArgsTy>
-static Error error(error::ErrorCode Code, const char *ErrFmt, ArgsTy... Args) {
+Error error(error::ErrorCode Code, const char *ErrFmt, ArgsTy... Args) {
   return error::createOffloadError(Code, ErrFmt, Args...);
 }
 
@@ -98,7 +98,8 @@ inline Error error(error::ErrorCode Code, Error &&OtherError,
 /// the plugin-specific code.
 /// TODO: Refactor this, must be defined individually by each plugin.
 template <typename... ArgsTy>
-static Error check(int32_t ErrorCode, const char *ErrFmt, ArgsTy... Args);
+[[maybe_unused]] static Error check(int32_t ErrorCode, const char *ErrFmt,
+                                    ArgsTy... Args);
 } // namespace Plugin
 
 /// Class that wraps the __tgt_async_info to simply its usage. In case the


### PR DESCRIPTION
Recent builds of offload with `-Wunused-template` (turned on under `-Wall` in #202945) fires on a few internal-linkage function templates in the plugins.

- `error::createOffloadError` and `Plugin::error`: drop `static`. Each sits right above an `inline` non-template overload, so external linkage on the template is fine
- `Plugin::check`: keep `static`, add `[[maybe_unused]]`. That `static` is required here as header only declares `check` and every plugin defines its own copy, so the internal linkage is necessary
- `dlwrap::getSymbolArray`: `[[maybe_unused]]` with `static` left in place
- `hsa_utils::iterate` two-element overload in amdgpu: nothing calls it, so `[[maybe_unused]]`

NFC. Part of #202945.
