### PR TITLE
[Github] Add ids container

### DIFF
--- a/.github/workflows/build-ci-container-tooling.yml
+++ b/.github/workflows/build-ci-container-tooling.yml
@@ -45,6 +45,9 @@ jobs:
             test-command: 'true'
             target: github-automation
             context: llvm/utils/git/
+          - container-name: ids-checks
+            test-command: 'idt --help'
+            target: ids-checks
 
     steps:
       - name: Checkout LLVM

--- a/.github/workflows/containers/github-action-ci-tooling/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-tooling/Dockerfile
@@ -128,3 +128,51 @@ RUN apt-get update && \
 USER gha
 
 ADD github-automation.py /usr/local/bin/
+
+FROM docker.io/library/ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS ids-builder
+ARG LLVM_VERSION_MAJOR
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y wget gpg python3 python3-pip git cmake
+
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION_MAJOR} main" | tee /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && \
+    apt-get install -y clang-${LLVM_VERSION_MAJOR} lld-${LLVM_VERSION_MAJOR} ninja-build libclang-${LLVM_VERSION_MAJOR}-dev
+
+COPY llvm/utils/git/requirements_formatting.txt requirements_formatting.txt
+RUN pip install --require-hashes -r requirements_formatting.txt --break-system-packages && \
+    rm requirements_formatting.txt
+
+RUN git clone https://github.com/compnerd/ids && cd ids && \
+    git checkout 6d9b77c89107743159fccaea109e8feb81959844
+
+RUN cd ids && \
+    cmake -B ./build \
+      -S .\
+      -D CMAKE_BUILD_TYPE=Release \
+      -D CMAKE_C_COMPILER=clang-${LLVM_VERSION_MAJOR} \
+      -D CMAKE_CXX_COMPILER=clang++-${LLVM_VERSION_MAJOR} \
+      -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
+      -D LLVM_DIR=/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/cmake/llvm/ \
+      -D Clang_DIR=/usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/cmake/clang/ \
+      -D FILECHECK_EXECUTABLE=$(which FileCheck-${LLVM_VERSION_MAJOR}) \
+      -D LIT_EXECUTABLE=$(which lit) \
+      -G Ninja && \
+    ninja -C ./build
+
+FROM ci-container-build-tools AS ci-container-ids-checks
+ARG LLVM_VERSION_MAJOR
+
+COPY llvm/utils/git/requirements.txt requirements.txt
+RUN pip install --require-hashes -r requirements.txt --break-system-packages && \
+    rm requirements.txt
+
+RUN apt-get update && apt-get install -y libz3-4
+
+COPY --from=ids-builder /ids/build/bin/idt \
+                        /usr/bin/idt
+# Copy over the LLVM SO since getting ids to statically link against the distro
+# provided libLLVM is difficult for now.
+# TODO(boomanaiden154): Get static linking working and remove this.
+COPY --from=ids-builder /usr/lib/llvm-${LLVM_VERSION_MAJOR}/lib/libLLVM.so.${LLVM_VERSION_MAJOR}.1 \
+                        /usr/lib/libLLVM.so.${LLVM_VERSION_MAJOR}.1

--- a/.github/workflows/containers/github-action-ci-tooling/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-tooling/Dockerfile
@@ -167,7 +167,10 @@ COPY llvm/utils/git/requirements.txt requirements.txt
 RUN pip install --require-hashes -r requirements.txt --break-system-packages && \
     rm requirements.txt
 
-RUN apt-get update && apt-get install -y libz3-4
+RUN apt-get update && \
+    apt-get install -y libz3-4 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=ids-builder /ids/build/bin/idt \
                         /usr/bin/idt


### PR DESCRIPTION
This will be used for the ids check workflow. This will enable us to use a PGO optimized compiler that we also use elsewhere, which should help speed up the builds on top of reducing redundant work like needing to configure/build ids for every job. This also makes things a bit more hermetic.

This is a bit of a hack with how the ids build is setup now (e.g., copying over libLLVM.so), but that's something that can be rectified pretty easily later.