### PR TITLE
lit: Handle permission errors in runCommandCached

### DIFF
--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -459,7 +459,7 @@ def memoize(f):
 def runCommandCached(lit_config, cmd, allow_failure, **kwargs):
     """
     Run a command with subprocess.run, with a cache global to this llvm-lit invocation
-    If allow_failure is True, lit_config.fatal will be invoked if the command fails.
+    If allow_failure is False, lit_config.fatal will be invoked if the command fails.
     All additional kwargs are passed to subprocess.run
     """
     try:
@@ -467,7 +467,7 @@ def runCommandCached(lit_config, cmd, allow_failure, **kwargs):
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, **kwargs
         )
         return result.stdout
-    except FileNotFoundError as e:
+    except (FileNotFoundError, PermissionError) as e:
         msg = f"Failed to run {cmd}: {e}"
     except subprocess.CalledProcessError as e:
         msg = f"Failed to run {cmd}\nrc:{e.returncode}\nstdout:{e.stdout}\ne.stderr{e.stderr}"


### PR DESCRIPTION
The downstream swift CI is getting PermissionError instead of FileNotFoundError for a [couple of tests](https://ci.swift.org/job/pr-apple-llvm-project-llvm-linux/1819/consoleFull#-556494529d6fdb6cb-f376-4f2e-8bce-d31c7304698b). I have no idea what is wrong with our CI, but we should be handling those errors the same way anyway.

Also fix documentation typo.