### PR TITLE
[IR][NFC] Add parentheses around logical AND

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5938,8 +5938,8 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
               "bits",
               Call);
         Check(OBU.Inputs.size() < 3 ||
-                  GetTypeAt(2)->isIntegerTy() &&
-                      GetTypeAt(2)->getIntegerBitWidth() <= 64,
+                  (GetTypeAt(2)->isIntegerTy() &&
+                   GetTypeAt(2)->getIntegerBitWidth() <= 64),
               "third argument should be an integer with a maximum width of 64 "
               "bits if present",
               Call);


### PR DESCRIPTION
Fixes a warning with -Wparentheses

```
llvm-project/llvm/lib/IR/Verifier.cpp: In member function ‘void {anonymous}::Verifier::visitIntrinsicCall(llvm::Intrinsic::ID, llvm::CallBase&)’:
llvm-project/llvm/lib/IR/Verifier.cpp:5941:47: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
 5941 |                   GetTypeAt(2)->isIntegerTy() &&
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
 5942 |                       GetTypeAt(2)->getIntegerBitWidth() <= 64,
```