### PR TITLE
[Github] Remove undef deprecator message

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -10,8 +10,6 @@
 
 import argparse
 import os
-import re
-import shlex
 import subprocess
 import sys
 from typing import List, Optional
@@ -348,125 +346,7 @@ class DarkerFormatHelper(FormatHelper):
             return None
 
 
-class UndefGetFormatHelper(FormatHelper):
-    name = "undef deprecator"
-    friendly_name = "undef deprecator"
-
-    @property
-    def instructions(self) -> str:
-        return " ".join(shlex.quote(c) for c in self.cmd)
-
-    def filter_changed_files(self, changed_files: List[str]) -> List[str]:
-        filtered_files = []
-        for path in changed_files:
-            _, ext = os.path.splitext(path)
-            if ext in (".cpp", ".c", ".h", ".hpp", ".hxx", ".cxx", ".inc", ".cppm", ".ll"):
-                filtered_files.append(path)
-        return filtered_files
-
-    def has_tool(self) -> bool:
-        return True
-
-    def pr_comment_text_for_diff(self, diff: str) -> str:
-        return f"""
-:warning: {self.name} found issues in your code. :warning:
-
-<details>
-<summary>
-You can test this locally with the following command:
-</summary>
-
-``````````bash
-{self.instructions}
-``````````
-
-</details>
-
-{diff}
-"""
-
-    def format_run(self, changed_files: List[str], args: FormatArgs) -> Optional[str]:
-        files = self.filter_changed_files(changed_files)
-        if not files:
-            return None
-
-        # Use git to find files that have had a change in the number of undefs
-        regex = "([^a-zA-Z0-9#_-]undef([^a-zA-Z0-9_-]|$)|UndefValue::get)"
-        cmd = ["git", "diff", "-U0", "--pickaxe-regex", "-S", regex]
-
-        if args.start_rev and args.end_rev:
-            cmd.append(args.start_rev)
-            cmd.append(args.end_rev)
-
-        cmd += files
-        self.cmd = cmd
-
-        if args.verbose:
-            print(f"Running: {self.instructions}")
-
-        proc = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8"
-        )
-        sys.stdout.write(proc.stderr)
-        stdout = proc.stdout
-
-        if not stdout:
-            return None
-
-        files = []
-
-        # Split the diff so we have one array entry per file.
-        # Each file is prefixed like:
-        # diff --git a/file b/file
-        for file in re.split("^diff --git ", stdout, 0, re.MULTILINE):
-            lines = file.splitlines()
-            match = re.match("a/([^ ]+)", lines[0] if lines else "")
-            filename = match[1] if match else ""
-            if filename.endswith(".ll"):
-                undef_regex = r"(?<!%)\bundef\b"
-            else:
-                undef_regex = r"UndefValue::get"
-            # search for additions of undef
-            if re.search(r"^[+].*" + undef_regex, file, re.MULTILINE):
-                files.append(filename)
-
-        if not files:
-            return None
-
-        files = "\n".join(" - " + f for f in files)
-        report = f"""
-The following files introduce new uses of undef:
-{files}
-
-[Undef](https://llvm.org/docs/LangRef.html#undefined-values) is now deprecated and should only be used in the rare cases where no replacement is possible. For example, a load of uninitialized memory yields `undef`. You should use `poison` values for placeholders instead.
-
-In tests, avoid using `undef` and having tests that trigger undefined behavior. If you need an operand with some unimportant value, you can add a new argument to the function and use that instead.
-
-For example, this is considered a bad practice:
-```llvm
-define void @fn() {{
-  ...
-  br i1 undef, ...
-}}
-```
-
-Please use the following instead:
-```llvm
-define void @fn(i1 %cond) {{
-  ...
-  br i1 %cond, ...
-}}
-```
-
-Please refer to the [Undefined Behavior Manual](https://llvm.org/docs/UndefinedBehavior.html) for more information.
-"""
-        if args.verbose:
-            print(f"error: {self.name} failed")
-            print(report)
-        return report
-
-
-ALL_FORMATTERS = (DarkerFormatHelper(), ClangFormatHelper(), UndefGetFormatHelper())
+ALL_FORMATTERS = (DarkerFormatHelper(), ClangFormatHelper())
 
 
 def hook_main():


### PR DESCRIPTION
This has a very high false positive rate. I do not think I've seen any cases where this check has caught a use of undef in a test that legimiately should be changed to something else, but there have been plenty of false positives around when one actually needs undef, or due to check lines containing undef autogenerated by one of the update scripts.

Given the FP rate, and the fact that I don't think this meaningfully prevents much cleanup for the eventual undef deprecation, I think we should just remove it for now and focus on removing undef.