### PR TITLE
Reapply "[VPlan] Refine hasEarlyExit check." (#207838)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -5171,15 +5171,25 @@ public:
   /// and deleted once the VPlan is destroyed.
   LLVM_ABI_FOR_TEST VPIRBasicBlock *createVPIRBasicBlock(BasicBlock *IRBB);
 
-  /// Returns true if the VPlan is based on a loop with an early exit. That is
-  /// the case if the VPlan has either more than one exit block or a single exit
-  /// block with multiple predecessors (one for the exit via the latch and one
-  /// via the other early exit).
+  /// Returns true if the VPlan is based on a loop with an early exit.
   bool hasEarlyExit() const {
-    return count_if(ExitBlocks,
-                    [](VPIRBasicBlock *EB) { return EB->hasPredecessors(); }) >
-               1 ||
-           (ExitBlocks.size() == 1 && ExitBlocks[0]->getNumPredecessors() > 1);
+    unsigned NumExitPredecessors =
+        sum_of(map_range(ExitBlocks, [](VPIRBasicBlock *EB) {
+          return EB->getNumPredecessors();
+        }));
+
+    // If the scalar preheader executes unconditionally, there's no branch from
+    // middle block to any exit. If there is any edge to an exit block
+    // remaining, it must be an early exit.
+    VPBasicBlock *ScalarPH = getScalarPreheader();
+    VPBlockBase *ScalarPHPred =
+        ScalarPH ? ScalarPH->getSinglePredecessor() : nullptr;
+    if (ScalarPHPred && ScalarPHPred->getNumSuccessors() == 1)
+      return NumExitPredecessors >= 1;
+
+    // Otherwise there must be at least 2 edges to exit blocks (from the middle
+    // block and the early exiting edge).
+    return NumExitPredecessors > 1;
   }
 
   /// Returns true if the scalar tail may execute after the vector loop, i.e.

--- a/llvm/test/Transforms/LoopVectorize/early_exit_with_outer_loop.ll
+++ b/llvm/test/Transforms/LoopVectorize/early_exit_with_outer_loop.ll
@@ -92,6 +92,39 @@ loop.outer.latch:
   br label %loop.outer
 }
 
+; Test LoopInfo is fixed up to remove the early-exit dispatch block from the
+; outer loop, even though the fully vectorized inner loop's countable exit
+; becomes an exit block without predecessors.
+define void @early_exit_dispatch_in_outer_loop(i1 %c) {
+; CHECK-LABEL: Loop info for function 'early_exit_dispatch_in_outer_loop':
+; CHECK: Loop at depth 1 containing: %outer.header<header>,%inner.header<exiting>,%inner.search<exiting>,%inner.latch,%outer.header.loopexit<latch>,%scalar.ph,%vector.ph,%vector.body<exiting>,%vector.body.interim,%middle.block
+; CHECK:    Loop at depth 2 containing: %inner.header<header><exiting>,%inner.search<exiting>,%inner.latch<latch><exiting>
+; CHECK:    Loop at depth 2 containing: %vector.body<header><exiting>,%vector.body.interim<latch><exiting>
+entry:
+  br label %outer.header
+
+outer.header:
+  br label %inner.header
+
+inner.header:
+  %iv = phi i64 [ %iv.next, %inner.latch ], [ 0, %outer.header ]
+  %iv.next = add i64 %iv, 1
+  br i1 %c, label %exit, label %inner.search
+
+inner.search:
+  %lo = icmp ult i64 %iv, 1
+  %hi = icmp ugt i64 %iv, 100
+  %early = or i1 %lo, %hi
+  br i1 %early, label %inner.latch, label %exit
+
+inner.latch:
+  %outer.cond = icmp ugt i64 %iv, 200
+  br i1 %outer.cond, label %outer.header, label %inner.header
+
+exit:
+  ret void
+}
+
 define i32 @early_exit_branch_to_outer_header() {
 ; CHECK-LABEL: Loop info for function 'early_exit_branch_to_outer_header':
 ; CHECK-NEXT:  Loop at depth 1 containing: %outer.header<header>,%outer.header.loopexit<latch>,%vector.ph,%vector.body,%vector.body.interim<exiting>,%vector.early.exit


### PR DESCRIPTION
This reverts commit b69ec1023d6604106cb64f9a6a6b04e9c3e5d533.

Recommit with small fix for potential nullptr dereference.

Original message:
Currently hasEarlyExit misses cases where we have things like dead exit blocks or simplified the middle block.

Update to check by counting the predecessors.

This fixes a case where we missed properly updating LoopInfo due to incorrect results.

Fixes https://github.com/llvm/llvm-project/issues/206007.