### PR TITLE
[AArch64] Stop determineCalleeSaves double counting registers with saved supers

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -2651,8 +2651,16 @@ void AArch64FrameLowering::determineCalleeSaves(MachineFunction &MF,
       ZPRCSStackSize += SpillSize;
     else if (IsPPR)
       PPRCSStackSize += SpillSize;
-    else
-      CSStackSize += SpillSize;
+    else {
+      // A register and its super-register can both appear in SavedRegs.
+      // Only the widest register is actually spilled, so skip such
+      // sub-registers here to avoid double-counting the overlap.
+      bool SavedSuper = any_of(TRI->superregs(Reg), [&](MCPhysReg SuperReg) {
+        return SavedRegs.test(SuperReg);
+      });
+      if (!SavedSuper)
+        CSStackSize += SpillSize;
+    }
   }
 
   // Save number of saved regs, so we can easily update CSStackSize later to

--- a/llvm/test/CodeGen/AArch64/framelayout-fpr128-csr.ll
+++ b/llvm/test/CodeGen/AArch64/framelayout-fpr128-csr.ll
@@ -3,18 +3,18 @@
 ; RUN: llc -verify-machineinstrs -mtriple=aarch64-windows-msvc < %s | FileCheck %s --check-prefix=CHECK-WINDOWS
 
 ; The purpose of this test is to verify q8 is assigned a 16-byte aligned offset
-; after the x10 is assigned an offset. The CSRs (on Linux) are assigned offsets
-; in the order GPRs then FPRs. The stack size of this function is 32
-; (alignTo((16 + 8), 16)), so after x8 is given the offset 24, q8 originally
-; would be assigned offset 8, which is not 16-byte aligned.
+; when a GPR (x10) is also callee-saved. The CSRs (on Linux) are assigned
+; offsets in the order GPRs then FPRs. The stack size of this function is 32
+; (alignTo((16 + 8), 16)); q8 must be assigned the 16-byte aligned offset 0,
+; with x10 in the 8-byte slot above it and the alignment padding at the top.
 define preserve_allcc void @d(ptr %ptr) nounwind {
 ; CHECK-LABEL: d:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    str q8, [sp, #-32]! // 16-byte Folded Spill
-; CHECK-NEXT:    str x10, [sp, #24] // 8-byte Spill
+; CHECK-NEXT:    str x10, [sp, #16] // 8-byte Spill
 ; CHECK-NEXT:    //APP
 ; CHECK-NEXT:    //NO_APP
-; CHECK-NEXT:    ldr x10, [sp, #24] // 8-byte Reload
+; CHECK-NEXT:    ldr x10, [sp, #16] // 8-byte Reload
 ; CHECK-NEXT:    ldr q8, [sp], #32 // 16-byte Folded Reload
 ; CHECK-NEXT:    ret
 ;
@@ -29,5 +29,33 @@ define preserve_allcc void @d(ptr %ptr) nounwind {
 ; CHECK-WINDOWS-NEXT:    ret
 entry:
   tail call void asm sideeffect "", "~{x10},~{q8}"()
+  ret void
+}
+
+; A GPR pair (x10, x11) plus q8 fills the frame exactly (16 + 8 + 8 = 32) with
+; no padding. q8 must still be assigned a 16-byte aligned offset, and the
+; d8/q8 sub/super-register overlap must not inflate the callee-save size.
+define preserve_allcc void @e(ptr %ptr) nounwind {
+; CHECK-LABEL: e:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    str q8, [sp, #-32]! // 16-byte Folded Spill
+; CHECK-NEXT:    stp x11, x10, [sp, #16] // 16-byte Folded Spill
+; CHECK-NEXT:    //APP
+; CHECK-NEXT:    //NO_APP
+; CHECK-NEXT:    ldp x11, x10, [sp, #16] // 16-byte Folded Reload
+; CHECK-NEXT:    ldr q8, [sp], #32 // 16-byte Folded Reload
+; CHECK-NEXT:    ret
+;
+; CHECK-WINDOWS-LABEL: e:
+; CHECK-WINDOWS:       // %bb.0: // %entry
+; CHECK-WINDOWS-NEXT:    stp x10, x11, [sp, #-32]! // 16-byte Folded Spill
+; CHECK-WINDOWS-NEXT:    str q8, [sp, #16] // 16-byte Spill
+; CHECK-WINDOWS-NEXT:    //APP
+; CHECK-WINDOWS-NEXT:    //NO_APP
+; CHECK-WINDOWS-NEXT:    ldr q8, [sp, #16] // 16-byte Reload
+; CHECK-WINDOWS-NEXT:    ldp x10, x11, [sp], #32 // 16-byte Folded Reload
+; CHECK-WINDOWS-NEXT:    ret
+entry:
+  tail call void asm sideeffect "", "~{x10},~{x11},~{q8}"()
   ret void
 }

--- a/llvm/test/CodeGen/AArch64/framelayout-fpr128-spill.mir
+++ b/llvm/test/CodeGen/AArch64/framelayout-fpr128-spill.mir
@@ -15,10 +15,10 @@ body: |
     ; CHECK: liveins: $q8, $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: early-clobber $sp = frame-setup STRQpre killed $q8, $sp, -32 :: (store (s128) into %stack.1)
-    ; CHECK-NEXT: frame-setup STRXui killed $x10, $sp, 3 :: (store (s64) into %stack.0)
+    ; CHECK-NEXT: frame-setup STRXui killed $x10, $sp, 2 :: (store (s64) into %stack.0)
     ; CHECK-NEXT: $q8 = IMPLICIT_DEF
     ; CHECK-NEXT: $x10 = IMPLICIT_DEF
-    ; CHECK-NEXT: $x10 = frame-destroy LDRXui $sp, 3 :: (load (s64) from %stack.0)
+    ; CHECK-NEXT: $x10 = frame-destroy LDRXui $sp, 2 :: (load (s64) from %stack.0)
     ; CHECK-NEXT: early-clobber $sp, $q8 = frame-destroy LDRQpost $sp, 32 :: (load (s128) from %stack.1)
     ; CHECK-NEXT: RET_ReallyLR
     ;


### PR DESCRIPTION
`determineCalleeSaves()` in `AArch64FrameLowering` double counts the D8-D15/Q8-Q1 overlap - fixed by skipping sub-registers whose super is saved.

Fixes #204564