### PR TITLE
runtimes: Don't set CMAKE_SYSTEM_NAME=Android

### DIFF
--- a/cmake/Modules/GetTripleCMakeSystemName.cmake
+++ b/cmake/Modules/GetTripleCMakeSystemName.cmake
@@ -34,9 +34,12 @@ function(get_triple_cmake_system_name triple out_var)
 
   # Check the special environment components first, since it can
   # override the usual OS mapping.
-  if("${_env}" MATCHES "^android")
-    set(${out_var} "Android" PARENT_SCOPE)
-  elseif("${_env}" MATCHES "^cygnus")
+  #
+  # FIXME: Not mapping the android environment to
+  # CMAKE_SYSTEM_NAME=Android, which would then make cmake require an
+  # NDK. Existing android cross builds seem to rely on an assumed
+  # linux host.
+  if("${_env}" MATCHES "^cygnus")
     set(${out_var} "CYGWIN" PARENT_SCOPE)
   elseif("${_os}" MATCHES "^darwin|^macos")
     set(${out_var} "Darwin" PARENT_SCOPE)


### PR DESCRIPTION
Cmake requires an NDK for android. Prior to 00b2f814182,
the default system name would be the host system. Take the
normal linux path, which is a more realistic approximation of
the old behavior.