### PR TITLE
[flang][OpenACC] Bind DO CONCURRENT construct index for nested acc loops

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -1812,6 +1812,7 @@ static void processDoConcurrentLocalitySpecs(
 // for both DO CONCURRENT and regular do loops
 static void processDoLoopBounds(
     Fortran::lower::AbstractConverter &converter,
+    Fortran::semantics::SemanticsContext &semanticsContext,
     mlir::Location currentLocation, Fortran::lower::StatementContext &stmtCtx,
     fir::FirOpBuilder &builder,
     const Fortran::parser::DoConstruct &outerDoConstruct,
@@ -1872,6 +1873,25 @@ static void processDoLoopBounds(
       const auto &name = std::get<Fortran::parser::Name>(control.t);
       privatizeIv(converter, *name.symbol, currentLocation, ivTypes, ivLocs,
                   privateOperands, ivPrivate, isDoConcurrent);
+
+      // A DO CONCURRENT index-name is a construct entity living in the
+      // construct's own (Forall-kind) scope, distinct from any like-named
+      // variable in the enclosing subprogram scope. `privatizeIv` above binds
+      // the symbol referenced by the loop control (which, inside an OpenACC
+      // compute construct, is the enclosing-scope variable). References to the
+      // index from within a *nested* explicit `!$acc loop` construct instead
+      // resolve to the construct entity, which would otherwise never be bound
+      // and trip the "lowering symbol to HLFIR" TODO. Bind that construct
+      // entity to the same privatized storage so such references resolve.
+      if (name.symbol) {
+        const Fortran::semantics::Scope &constructScope =
+            semanticsContext.FindScope(name.source);
+        auto iter = constructScope.find(name.source);
+        if (iter != constructScope.end() && &*iter->second != &*name.symbol)
+          localSymPairs.emplace_back(
+              Fortran::semantics::SymbolRef(*iter->second),
+              Fortran::semantics::SymbolRef(*name.symbol));
+      }
 
       inclusiveBounds.push_back(true);
     }
@@ -2128,11 +2148,12 @@ buildACCLoopOp(Fortran::lower::AbstractConverter &converter,
   // this loop is lowered in an unstructured fashion, in which case bounds are
   // not represented on acc.loop and explicit control flow is used inside body.
   if (!eval.lowerAsUnstructured()) {
-    processDoLoopBounds(
-        converter, currentLocation, stmtCtx, builder, outerDoConstruct, eval,
-        lowerbounds, upperbounds, steps, privateOperands, ivPrivate, ivTypes,
-        ivLocs, inclusiveBounds, locs, loopsToProcess, reductionOperands,
-        firstprivateOperands, dataMap, localSymPairs);
+    processDoLoopBounds(converter, semanticsContext, currentLocation, stmtCtx,
+                        builder, outerDoConstruct, eval, lowerbounds,
+                        upperbounds, steps, privateOperands, ivPrivate, ivTypes,
+                        ivLocs, inclusiveBounds, locs, loopsToProcess,
+                        reductionOperands, firstprivateOperands, dataMap,
+                        localSymPairs);
   } else {
     // When the loop contains early exits, privatize induction variables, but do
     // not create acc.loop bounds. The control flow of the loop will be

--- a/flang/test/Lower/OpenACC/acc-loop-nested-in-do-concurrent.f90
+++ b/flang/test/Lower/OpenACC/acc-loop-nested-in-do-concurrent.f90
@@ -1,0 +1,185 @@
+! Test lowering of an explicit `!$acc loop` construct nested inside a
+! DO CONCURRENT that is itself associated with an `!$acc loop`, where the
+! nested loop body references an index of the outer DO CONCURRENT.
+!
+! A DO CONCURRENT index-name is a construct entity in the construct's own
+! scope, distinct from a like-named variable in the enclosing subprogram
+! scope. Inside the nested acc loop, the reference to the outer index resolves
+! to that construct entity; lowering must bind it to the same privatized
+! storage as the loop control so the reference can be lowered.
+
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+! CHECK-LABEL: func.func @_QPnested_acc_loop_in_do_concurrent
+subroutine nested_acc_loop_in_do_concurrent(a, n)
+  integer :: n, i, l
+  real(8) :: a(n)
+  !$acc parallel
+  !$acc loop
+  do concurrent(i = 1:n)
+    !$acc loop seq
+    do l = 1, n
+      a(i) = a(i) + real(l, 8)
+    end do
+  end do
+  !$acc end parallel
+end subroutine
+
+! The outer acc.loop privatizes the DO CONCURRENT index `i`.
+! CHECK: acc.loop private({{.*}}) control(%[[IARG:[a-z0-9_]+]] : i32)
+! CHECK: %[[IDECL:[0-9]+]]:2 = hlfir.declare %{{[a-z0-9_]+}} {uniq_name = "_QFnested_acc_loop_in_do_concurrentEi"}
+! CHECK: fir.store %[[IARG]] to %[[IDECL]]#0 : !fir.ref<i32>
+
+! The nested acc.loop body reads the outer index from that same storage.
+! CHECK: acc.loop private({{.*}}) control(%{{[a-z0-9_]+}} : i32)
+! CHECK: %[[ILOAD:[0-9]+]] = fir.load %[[IDECL]]#0 : !fir.ref<i32>
+! CHECK: %[[ICONV:[0-9]+]] = fir.convert %[[ILOAD]] : (i32) -> i64
+! CHECK: hlfir.designate %{{.*}} (%[[ICONV]])
+
+! -----------------------------------------------------------------------------
+! Multi-index DO CONCURRENT; the nested acc loop references both indices.
+! -----------------------------------------------------------------------------
+! CHECK-LABEL: func.func @_QPmulti_index
+subroutine multi_index(a, n, m)
+  integer :: n, m, i, j, l
+  real(8) :: a(n, m)
+  !$acc parallel
+  !$acc loop
+  do concurrent(i = 1:n, j = 1:m)
+    !$acc loop seq
+    do l = 1, n
+      a(i, j) = a(i, j) + real(l, 8)
+    end do
+  end do
+  !$acc end parallel
+end subroutine
+
+! The outer acc.loop privatizes both indices; the nested loop reads both.
+! CHECK: acc.loop private({{.*}}) control(%{{[a-z0-9_]+}} : i32, %{{[a-z0-9_]+}} : i32)
+! CHECK: %[[MI:[0-9]+]]:2 = hlfir.declare %{{[a-z0-9_]+}} {uniq_name = "_QFmulti_indexEi"}
+! CHECK: %[[MJ:[0-9]+]]:2 = hlfir.declare %{{[a-z0-9_]+}} {uniq_name = "_QFmulti_indexEj"}
+! CHECK: acc.loop private({{.*}}) control(%{{[a-z0-9_]+}} : i32)
+! CHECK: fir.load %[[MI]]#0 : !fir.ref<i32>
+! CHECK: fir.load %[[MJ]]#0 : !fir.ref<i32>
+
+! -----------------------------------------------------------------------------
+! The nested acc loop's BOUNDS (not just its body) reference the outer index.
+! -----------------------------------------------------------------------------
+! CHECK-LABEL: func.func @_QPouter_index_in_bounds
+subroutine outer_index_in_bounds(a, n)
+  integer :: n, i, l
+  real(8) :: a(n)
+  !$acc parallel
+  !$acc loop
+  do concurrent(i = 1:n)
+    !$acc loop seq
+    do l = i, n
+      a(l) = a(l) + 1.0_8
+    end do
+  end do
+  !$acc end parallel
+end subroutine
+
+! The nested loop's lower bound is loaded from the outer index's privatized
+! storage (the declare inside the outer acc.loop, not the host-level one).
+! CHECK: acc.loop private({{.*}}) control(%{{[a-z0-9_]+}} : i32)
+! CHECK: %[[BI:[0-9]+]]:2 = hlfir.declare %{{[a-z0-9_]+}} {uniq_name = "_QFouter_index_in_boundsEi"}
+! CHECK: %[[LB:[0-9]+]] = fir.load %[[BI]]#0 : !fir.ref<i32>
+! CHECK: acc.loop private({{.*}}) control(%{{[a-z0-9_]+}} : i32) = (%[[LB]] : i32)
+
+! -----------------------------------------------------------------------------
+! Same nested shape under acc serial, acc kernels, and combined parallel loop.
+! -----------------------------------------------------------------------------
+! CHECK-LABEL: func.func @_QPnested_in_serial
+subroutine nested_in_serial(a, n)
+  integer :: n, i, l
+  real(8) :: a(n)
+  !$acc serial
+  !$acc loop
+  do concurrent(i = 1:n)
+    !$acc loop seq
+    do l = 1, n
+      a(i) = a(i) + real(l, 8)
+    end do
+  end do
+  !$acc end serial
+end subroutine
+
+! CHECK: acc.serial
+! CHECK: %[[SI:[0-9]+]]:2 = hlfir.declare %{{[a-z0-9_]+}} {uniq_name = "_QFnested_in_serialEi"}
+! CHECK: acc.loop
+! CHECK: fir.load %[[SI]]#0 : !fir.ref<i32>
+
+! CHECK-LABEL: func.func @_QPnested_in_kernels
+subroutine nested_in_kernels(a, n)
+  integer :: n, i, l
+  real(8) :: a(n)
+  !$acc kernels
+  !$acc loop
+  do concurrent(i = 1:n)
+    !$acc loop seq
+    do l = 1, n
+      a(i) = a(i) + real(l, 8)
+    end do
+  end do
+  !$acc end kernels
+end subroutine
+
+! CHECK: acc.kernels
+! CHECK: %[[KI:[0-9]+]]:2 = hlfir.declare %{{[a-z0-9_]+}} {uniq_name = "_QFnested_in_kernelsEi"}
+! CHECK: acc.loop
+! CHECK: fir.load %[[KI]]#0 : !fir.ref<i32>
+
+! CHECK-LABEL: func.func @_QPnested_in_combined
+subroutine nested_in_combined(a, n)
+  integer :: n, i, l
+  real(8) :: a(n)
+  !$acc parallel loop
+  do concurrent(i = 1:n)
+    !$acc loop seq
+    do l = 1, n
+      a(i) = a(i) + real(l, 8)
+    end do
+  end do
+end subroutine
+
+! CHECK: acc.parallel combined(loop)
+! CHECK: %[[CI:[0-9]+]]:2 = hlfir.declare %{{[a-z0-9_]+}} {uniq_name = "_QFnested_in_combinedEi"}
+! CHECK: acc.loop
+! CHECK: fir.load %[[CI]]#0 : !fir.ref<i32>
+
+! -----------------------------------------------------------------------------
+! Two sibling nested acc loops inside one DO CONCURRENT. The first nested loop
+! is a shadowing DO CONCURRENT over the same name `i`; the second references
+! the OUTER index `i`. That reference must resolve to the outer loop's
+! privatized storage (which dominates both siblings), not to anything created
+! inside the first sibling's region.
+! -----------------------------------------------------------------------------
+! CHECK-LABEL: func.func @_QPtwo_sibling_nested
+subroutine two_sibling_nested(a, b, n)
+  integer :: n, i, l
+  real(8) :: a(n, n), b(n)
+  !$acc parallel
+  !$acc loop
+  do concurrent(i = 1:n)
+    !$acc loop seq
+    do concurrent(i = 1:n)
+      a(i, i) = 1.0_8
+    end do
+    !$acc loop seq
+    do l = 1, n
+      b(i) = b(i) + real(l, 8)   ! outer i, referenced from 2nd nested region
+    end do
+  end do
+  !$acc end parallel
+end subroutine
+
+! Outer acc.loop privatizes i; capture that (dominating) declare.
+! CHECK: acc.loop private({{.*}}) control(%{{[a-z0-9_]+}} : i32)
+! CHECK: %[[OUTERI:[0-9]+]]:2 = hlfir.declare %{{[a-z0-9_]+}} {uniq_name = "_QFtwo_sibling_nestedEi"}
+! First sibling: the shadowing DO CONCURRENT declares its own i.
+! CHECK: acc.loop
+! CHECK: hlfir.declare %{{[a-z0-9_]+}} {uniq_name = "_QFtwo_sibling_nestedEi"}
+! Second sibling: b(i) reads the OUTER index storage, not the shadow.
+! CHECK: acc.loop
+! CHECK: fir.load %[[OUTERI]]#0 : !fir.ref<i32>


### PR DESCRIPTION
A DO CONCURRENT index-name is a construct entity that lives in the construct's own scope, distinct from a like-named variable in the enclosing subprogram scope. When a DO CONCURRENT is associated with an `!$acc loop`, lowering privatizes the symbol referenced by the loop control, which inside an OpenACC compute construct is the enclosing-scope variable. However, a reference to that index from within a *nested* explicit `!$acc loop` construct resolves to the construct entity instead. That entity was never bound in the symbol map, so lowering the reference hit the "lowering symbol to HLFIR" TODO and aborted.

Bind the construct entity to the same privatized storage as the loop control so such references lower correctly.