### PR TITLE
[ORC] Fail pending symbols on MaterializationResponsibility drop

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
@@ -2778,6 +2778,25 @@ void ExecutionSession::OL_completeLookupFlags(
 void ExecutionSession::OL_destroyMaterializationResponsibility(
     MaterializationResponsibility &MR) {
 
+  // Clients are required to emit or explicitly fail every symbol a
+  // MaterializationResponsibility tracks before destroying it; the assert below
+  // enforces that contract in debug builds. That assert is compiled out in
+  // release builds, so a responsibility destroyed with symbols still pending --
+  // e.g. if a client drops the MR (via unique_ptr reset) or a
+  // MaterializationUnit returns early without calling
+  // resolve/emit/failMaterialization -- would silently strand the outstanding
+  // queries: their completion callbacks never run, and any state those
+  // callbacks reference can be destroyed underneath them at session teardown.
+  // As defense-in-depth, fail any still-pending symbols here so a contract
+  // violation degrades to a cleanly-failed query instead of a stranded query or
+  // use-after-free, while the debug assert is retained so the violation stays
+  // loud in debug builds. This mirrors
+  // MaterializationTask::~MaterializationTask, which fails materialization for
+  // a task that was never run. OL_notifyFailed is a no-op on an empty set, so
+  // the ordinary emit-then-destroy path is untouched.
+  if (!MR.SymbolFlags.empty())
+    OL_notifyFailed(MR);
+
   assert(MR.SymbolFlags.empty() &&
          "All symbols should have been explicitly materialized or failed");
   MR.JD.unlinkMaterializationResponsibility(MR);

--- a/llvm/unittests/ExecutionEngine/Orc/CoreAPIsTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/CoreAPIsTest.cpp
@@ -958,6 +958,64 @@ TEST_F(CoreAPIsStandardTest, FailMaterializerWithUnqueriedSymbols) {
       << "Expected lookup for Bar to fail.";
 }
 
+TEST_F(CoreAPIsStandardTest, DropMaterializationResponsibilityFailsQuery) {
+  // Destroying a MaterializationResponsibility while it still owns
+  // un-materialized / un-failed symbols must fail the outstanding query rather
+  // than stranding it. The empty-symbols invariant is only checked by a
+  // debug-mode assert in ~MaterializationResponsibility; in a release build a
+  // responsibility can be destroyed with symbols still pending -- e.g. if a
+  // client drops the MR without calling resolve/emit/failMaterialization, or a
+  // MaterializationUnit returns early. Before the fix the query was never
+  // completed and its completion state could be destroyed underneath it at
+  // teardown. This test exercises the path without exceptions: it simply drops
+  // the MR via unique_ptr reset.
+
+  bool OnCompletionRun = false;
+  bool LookupFailed = false;
+
+  auto OnCompletion = [&](Expected<SymbolMap> Result) {
+    OnCompletionRun = true;
+    // We expect failure, not a resolved SymbolMap. Consume the error here so
+    // there is no unchecked Error escaping the callback.
+    if (Result) {
+      ADD_FAILURE() << "Lookup unexpectedly succeeded";
+    } else {
+      LookupFailed = true;
+      consumeError(Result.takeError());
+    }
+  };
+
+  std::unique_ptr<MaterializationResponsibility> FooMR;
+
+  cantFail(JD.define(std::make_unique<SimpleMaterializationUnit>(
+      SymbolFlagsMap({{Foo, FooSym.getFlags()}}),
+      [&](std::unique_ptr<MaterializationResponsibility> R) {
+        FooMR = std::move(R);
+      })));
+
+  ES.lookup(LookupKind::Static, makeJITDylibSearchOrder(&JD),
+            SymbolLookupSet(Foo), SymbolState::Ready, OnCompletion,
+            NoDependenciesToRegister);
+
+  EXPECT_FALSE(OnCompletionRun) << "Query should still be outstanding";
+
+  // Drop the MR with SymbolFlags still populated (no resolve / emit / fail).
+  // OL_destroyMaterializationResponsibility must fail the query here.
+  FooMR.reset();
+
+  EXPECT_TRUE(OnCompletionRun)
+      << "Dropping an MR with outstanding symbols must fail the query, not "
+         "strand it";
+  EXPECT_TRUE(LookupFailed) << "Query completion must carry a failure error";
+
+  // A subsequent lookup of the same symbol must also report failure (the symbol
+  // is now in the error state), mirroring
+  // MaterializationSideEffectsOnlyFailuresPersist.
+  EXPECT_THAT_EXPECTED(
+      ES.lookup(makeJITDylibSearchOrder(&JD), SymbolLookupSet({Foo})),
+      Failed());
+}
+
 TEST_F(CoreAPIsStandardTest, DropMaterializerWhenEmpty) {
   bool DestructorRun = false;
 


### PR DESCRIPTION

## Summary

Destroying a `MaterializationResponsibility` while it still owns
un-materialized / un-failed symbols is a client-contract violation: clients
are required to `emit` or explicitly `failMaterialization` every symbol they
track before the responsibility is destroyed. `ExecutionSession::OL_destroyMaterializationResponsibility`
currently enforces that contract only with an assert:

```cpp
assert(MR.SymbolFlags.empty() &&
       "All symbols should have been explicitly materialized or failed");
MR.JD.unlinkMaterializationResponsibility(MR);
```

That assert is compiled out in release builds (`NDEBUG`). When the contract is
violated in a release build, the outstanding queries against those symbols are
never completed: their completion callbacks never run, and any state those
callbacks reference can be destroyed underneath them at session teardown —
turning a client mistake into a stranded query and a potential use-after-free.

This is not exotic. It happens whenever an MR is dropped with symbols still
pending, e.g. a client drops the MR (via `unique_ptr` reset) or a
`MaterializationUnit::materialize` early-returns on an error path without
calling `failMaterialization`.

## Fix

This is **defense-in-depth**, not a change to the client contract. Fail any
still-pending symbols before unlinking, so a contract violation degrades to a
cleanly-failed query instead of undefined behavior:

```cpp
if (!MR.SymbolFlags.empty())
  OL_notifyFailed(MR);
```

The existing debug assert is deliberately **retained** immediately below, so
the violation is still surfaced loudly in debug builds — this hardens the
release path without hiding the client bug from developers.

This mirrors `MaterializationTask::~MaterializationTask`, which already fails
materialization for a task that was never run (`failMaterialization` is a thin
wrapper over the same `OL_notifyFailed`). `OL_notifyFailed` is a no-op on an
empty symbol set, so the ordinary emit-then-destroy path is completely
unaffected and the retained assert holds as a guaranteed no-op.

## Test

Adds `CoreAPIsStandardTest.DropMaterializationResponsibilityFailsQuery`, a
concrete, in-tree reproducer: it defines a symbol, issues an async lookup, then
drops the owning MR with the symbol still pending (a plain `unique_ptr` reset —
no exceptions involved) and verifies the query is *failed* rather than
stranded, and that a subsequent lookup of the same symbol also reports failure
(the symbol is left in a persistent error state).

Build-config behaviour without the fix:

- **Assertions-on build:** dropping the MR trips the existing `~MR` assert
  (abort) — the invariant is caught, as designed today.
- **Release / `NDEBUG` build:** the query is silently stranded and its
  completion state can be freed at teardown — the case this fix protects.

With the fix, both configurations fail the query cleanly. The full `OrcJITTests`
suite passes with the change.
