### PR TITLE
[ORC] Fail pending symbols on MaterializationResponsibility drop

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
@@ -2778,6 +2778,15 @@ void ExecutionSession::OL_completeLookupFlags(
 void ExecutionSession::OL_destroyMaterializationResponsibility(
     MaterializationResponsibility &MR) {
 
+  // Destroying an MR with symbols still pending only trips the assert below,
+  // which is compiled out in release builds. There the outstanding queries are
+  // stranded: their callbacks never run and the state they reference can be
+  // freed at session teardown. Fail those symbols here so the queries reach a
+  // terminal state, mirroring MaterializationTask::~MaterializationTask.
+  // OL_notifyFailed is a no-op on an empty set.
+  if (!MR.SymbolFlags.empty())
+    OL_notifyFailed(MR);
+
   assert(MR.SymbolFlags.empty() &&
          "All symbols should have been explicitly materialized or failed");
   MR.JD.unlinkMaterializationResponsibility(MR);

--- a/llvm/unittests/ExecutionEngine/Orc/CoreAPIsTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/CoreAPIsTest.cpp
@@ -958,6 +958,52 @@ TEST_F(CoreAPIsStandardTest, FailMaterializerWithUnqueriedSymbols) {
       << "Expected lookup for Bar to fail.";
 }
 
+TEST_F(CoreAPIsStandardTest, DropMaterializationResponsibilityFailsQuery) {
+  // Dropping an MR that still owns pending symbols must fail the outstanding
+  // query, not strand it (the empty-symbols invariant is otherwise only checked
+  // by a debug-mode assert). Dropped via unique_ptr reset; no exceptions.
+
+  bool OnCompletionRun = false;
+  bool LookupFailed = false;
+
+  auto OnCompletion = [&](Expected<SymbolMap> Result) {
+    OnCompletionRun = true;
+    if (Result) {
+      ADD_FAILURE() << "Lookup unexpectedly succeeded";
+    } else {
+      LookupFailed = true;
+      consumeError(Result.takeError());
+    }
+  };
+
+  std::unique_ptr<MaterializationResponsibility> FooMR;
+
+  cantFail(JD.define(std::make_unique<SimpleMaterializationUnit>(
+      SymbolFlagsMap({{Foo, FooSym.getFlags()}}),
+      [&](std::unique_ptr<MaterializationResponsibility> R) {
+        FooMR = std::move(R);
+      })));
+
+  ES.lookup(LookupKind::Static, makeJITDylibSearchOrder(&JD),
+            SymbolLookupSet(Foo), SymbolState::Ready, OnCompletion,
+            NoDependenciesToRegister);
+
+  EXPECT_FALSE(OnCompletionRun) << "Query should still be outstanding";
+
+  // Drop the MR with symbols still pending; this must fail the query.
+  FooMR.reset();
+
+  EXPECT_TRUE(OnCompletionRun)
+      << "Dropping an MR with outstanding symbols must fail the query, not "
+         "strand it";
+  EXPECT_TRUE(LookupFailed) << "Query completion must carry a failure error";
+
+  // The symbol is now in the error state, so a later lookup also fails.
+  EXPECT_THAT_EXPECTED(
+      ES.lookup(makeJITDylibSearchOrder(&JD), SymbolLookupSet({Foo})),
+      Failed());
+}
+
 TEST_F(CoreAPIsStandardTest, DropMaterializerWhenEmpty) {
   bool DestructorRun = false;
 


### PR DESCRIPTION

## Summary

Destroying a `MaterializationResponsibility` while it still owns
un-materialized / un-failed symbols is a client-contract violation: clients
are required to `emit` or explicitly `failMaterialization` every symbol they
track before the responsibility is destroyed. `ExecutionSession::OL_destroyMaterializationResponsibility`
currently enforces that contract only with an assert:

```cpp
assert(MR.SymbolFlags.empty() &&
       "All symbols should have been explicitly materialized or failed");
MR.JD.unlinkMaterializationResponsibility(MR);
```

That assert is compiled out in release builds (`NDEBUG`). When the contract is
violated in a release build, the outstanding queries against those symbols are
never completed: their completion callbacks never run, and any state those
callbacks reference can be destroyed underneath them at session teardown —
turning a client mistake into a stranded query and a potential use-after-free.

This is not exotic. It happens whenever an MR is dropped with symbols still
pending, e.g. a client drops the MR (via `unique_ptr` reset) or a
`MaterializationUnit::materialize` early-returns on an error path without
calling `failMaterialization`.

## Fix

This is **defense-in-depth**, not a change to the client contract. Fail any
still-pending symbols before unlinking, so a contract violation degrades to a
cleanly-failed query instead of undefined behavior:

```cpp
if (!MR.SymbolFlags.empty())
  OL_notifyFailed(MR);
```

The existing debug assert is deliberately **retained** immediately below, so
the violation is still surfaced loudly in debug builds — this hardens the
release path without hiding the client bug from developers.

This mirrors `MaterializationTask::~MaterializationTask`, which already fails
materialization for a task that was never run (`failMaterialization` is a thin
wrapper over the same `OL_notifyFailed`). `OL_notifyFailed` is a no-op on an
empty symbol set, so the ordinary emit-then-destroy path is completely
unaffected and the retained assert holds as a guaranteed no-op.

## Test

Adds `CoreAPIsStandardTest.DropMaterializationResponsibilityFailsQuery`, a
concrete, in-tree reproducer: it defines a symbol, issues an async lookup, then
drops the owning MR with the symbol still pending (a plain `unique_ptr` reset —
no exceptions involved) and verifies the query is *failed* rather than
stranded, and that a subsequent lookup of the same symbol also reports failure
(the symbol is left in a persistent error state).

Build-config behaviour without the fix:

- **Assertions-on build:** dropping the MR trips the existing `~MR` assert
  (abort) — the invariant is caught, as designed today.
- **Release / `NDEBUG` build:** the query is silently stranded and its
  completion state can be freed at teardown — the case this fix protects.

With the fix, both configurations fail the query cleanly. The full `OrcJITTests`
suite passes with the change.
