### PR TITLE
[InstCombine] Optimize GEP comparisons with constant offsets

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -815,14 +815,32 @@ Instruction *InstCombinerImpl::foldGEPICmp(GEPOperator *GEPLHS, Value *RHS,
       }
     }
 
-    if (Base.Ptr && CanFold(Base.LHSNW & Base.RHSNW) && !Base.isExpensive()) {
+    if (Base.Ptr && !Base.isExpensive()) {
       // ((gep Ptr, OFFSET1) cmp (gep Ptr, OFFSET2)  --->  (OFFSET1 cmp OFFSET2)
-      Type *IdxTy = DL.getIndexType(GEPLHS->getType());
-      Value *L =
-          EmitGEPOffsets(Base.LHSGEPs, Base.LHSNW, IdxTy, /*RewriteGEP=*/true);
-      Value *R =
-          EmitGEPOffsets(Base.RHSGEPs, Base.RHSNW, IdxTy, /*RewriteGEP=*/true);
-      return NewICmp(Base.LHSNW & Base.RHSNW, L, R);
+      bool DoFold = CanFold(Base.LHSNW & Base.RHSNW);
+
+      if (!DoFold) {
+        unsigned BW = DL.getIndexTypeSizeInBits(GEPLHS->getType());
+        APInt Alignment = APInt(BW, Base.Ptr->getPointerAlignment(DL).value());
+        APInt LOff(BW, 0);
+        APInt ROff(BW, 0);
+        if (GEPLHS->stripAndAccumulateConstantOffsets(
+                DL, LOff, /*AllowNonInbounds=*/true) == Base.Ptr &&
+            RHS->stripAndAccumulateConstantOffsets(
+                DL, ROff, /*AllowNonInbounds=*/true) == Base.Ptr)
+          DoFold =
+              APIntOps::RoundingSDiv(LOff, Alignment, APInt::Rounding::DOWN) ==
+              APIntOps::RoundingSDiv(ROff, Alignment, APInt::Rounding::DOWN);
+      }
+
+      if (DoFold) {
+        Type *IdxTy = DL.getIndexType(GEPLHS->getType());
+        Value *L =
+            EmitGEPOffsets(Base.LHSGEPs, Base.LHSNW, IdxTy, /*RewriteGEP=*/true);
+        Value *R =
+            EmitGEPOffsets(Base.RHSGEPs, Base.RHSNW, IdxTy, /*RewriteGEP=*/true);
+        return NewICmp(Base.LHSNW & Base.RHSNW, L, R);
+      }
     }
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -835,10 +835,10 @@ Instruction *InstCombinerImpl::foldGEPICmp(GEPOperator *GEPLHS, Value *RHS,
 
       if (DoFold) {
         Type *IdxTy = DL.getIndexType(GEPLHS->getType());
-        Value *L =
-            EmitGEPOffsets(Base.LHSGEPs, Base.LHSNW, IdxTy, /*RewriteGEP=*/true);
-        Value *R =
-            EmitGEPOffsets(Base.RHSGEPs, Base.RHSNW, IdxTy, /*RewriteGEP=*/true);
+        Value *L = EmitGEPOffsets(Base.LHSGEPs, Base.LHSNW, IdxTy,
+                                  /*RewriteGEP=*/true);
+        Value *R = EmitGEPOffsets(Base.RHSGEPs, Base.RHSNW, IdxTy,
+                                  /*RewriteGEP=*/true);
         return NewICmp(Base.LHSNW & Base.RHSNW, L, R);
       }
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -819,7 +819,7 @@ Instruction *InstCombinerImpl::foldGEPICmp(GEPOperator *GEPLHS, Value *RHS,
       // ((gep Ptr, OFFSET1) cmp (gep Ptr, OFFSET2)  --->  (OFFSET1 cmp OFFSET2)
       bool DoFold = CanFold(Base.LHSNW & Base.RHSNW);
 
-      if (!DoFold) {
+      if (!DoFold && Base.Ptr->getType()->isPointerTy()) {
         // Without the flags, we can still fold if the offsets are constant and
         // they cross the base's alignment boundary the same number of times, so
         // either both arguments will wrap, or none of them will.

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -820,6 +820,9 @@ Instruction *InstCombinerImpl::foldGEPICmp(GEPOperator *GEPLHS, Value *RHS,
       bool DoFold = CanFold(Base.LHSNW & Base.RHSNW);
 
       if (!DoFold) {
+        // Without the flags, we can still fold if the offsets are constant and
+        // they cross the base's alignment boundary the same number of times, so
+        // either both arguments will wrap, or none of them will.
         unsigned BW = DL.getIndexTypeSizeInBits(GEPLHS->getType());
         APInt Alignment = APInt(BW, Base.Ptr->getPointerAlignment(DL).value());
         APInt LOff(BW, 0);

--- a/llvm/test/Transforms/InstCombine/icmp-gep.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-gep.ll
@@ -1127,10 +1127,7 @@ define i1 @gep_gep_multiple_ult_nuw_multi_use(ptr %base, i64 %idx1, i64 %idx2, i
 
 define i1 @gep_const_same_block(ptr align 16 %foo) {
 ; CHECK-LABEL: @gep_const_same_block(
-; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 4
-; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 8
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %gep1 = getelementptr i8, ptr %foo, i64 4
   %gep2 = getelementptr i8, ptr %foo, i64 8
@@ -1140,10 +1137,7 @@ define i1 @gep_const_same_block(ptr align 16 %foo) {
 
 define i1 @gep_const_same_negative_block(ptr align 16 %foo) {
 ; CHECK-LABEL: @gep_const_same_negative_block(
-; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 -12
-; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 -8
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %gep1 = getelementptr i8, ptr %foo, i64 -12
   %gep2 = getelementptr i8, ptr %foo, i64 -8
@@ -1179,10 +1173,7 @@ define i1 @gep_const_different_block_2(ptr align 16 %foo) {
 
 define i1 @gep_const_edge_case_1(ptr align 16 %foo) {
 ; CHECK-LABEL: @gep_const_edge_case_1(
-; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 14
-; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 15
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %gep1 = getelementptr i8, ptr %foo, i64 14
   %gep2 = getelementptr i8, ptr %foo, i64 15
@@ -1205,10 +1196,7 @@ define i1 @gep_const_edge_case_2(ptr align 16 %foo) {
 
 define i1 @gep_const_edge_case_3(ptr align 16 %foo) {
 ; CHECK-LABEL: @gep_const_edge_case_3(
-; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 16
-; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 17
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %gep1 = getelementptr i8, ptr %foo, i64 16
   %gep2 = getelementptr i8, ptr %foo, i64 17
@@ -1233,8 +1221,7 @@ define i1 @gep_variable_offsets(ptr align 16 %foo, i64 %i, i64 %j) {
 @g16 = global [4 x i32] zeroinitializer, align 16
 define i1 @gep_global_offsets() {
 ; CHECK-LABEL: @gep_global_offsets(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ule ptr getelementptr (i8, ptr @g16, i64 20), getelementptr inbounds nuw (i8, ptr @g16, i64 16)
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 false
 ;
   %cmp = icmp ule ptr getelementptr (i8, ptr @g16, i64 20), getelementptr inbounds nuw (i8, ptr @g16, i64 16)
   ret i1 %cmp

--- a/llvm/test/Transforms/InstCombine/icmp-gep.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-gep.ll
@@ -1204,6 +1204,29 @@ define i1 @gep_const_edge_case_3(ptr align 16 %foo) {
   ret i1 %cmp
 }
 
+define i1 @gep_const_edge_case_4(ptr align 16 %foo) {
+; CHECK-LABEL: @gep_const_edge_case_4(
+; CHECK-NEXT:    ret i1 false
+;
+  %gep1 = getelementptr i8, ptr %foo, i64 -15
+  %gep2 = getelementptr i8, ptr %foo, i64 -16
+  %cmp = icmp ult ptr %gep1, %gep2
+  ret i1 %cmp
+}
+
+define i1 @gep_const_edge_case_5(ptr align 16 %foo) {
+; CHECK-LABEL: @gep_const_edge_case_5(
+; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 -16
+; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 -17
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %gep1 = getelementptr i8, ptr %foo, i64 -16
+  %gep2 = getelementptr i8, ptr %foo, i64 -17
+  %cmp = icmp ult ptr %gep1, %gep2
+  ret i1 %cmp
+}
+
 define i1 @gep_variable_offsets(ptr align 16 %foo, i64 %i, i64 %j) {
 ; CHECK-LABEL: @gep_variable_offsets(
 ; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 [[I:%.*]]

--- a/llvm/test/Transforms/InstCombine/icmp-gep.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-gep.ll
@@ -1124,3 +1124,118 @@ define i1 @gep_gep_multiple_ult_nuw_multi_use(ptr %base, i64 %idx1, i64 %idx2, i
   %cmp = icmp ult ptr %gep2, %gep4
   ret i1 %cmp
 }
+
+define i1 @gep_const_same_block(ptr align 16 %foo) {
+; CHECK-LABEL: @gep_const_same_block(
+; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 4
+; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 8
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %gep1 = getelementptr i8, ptr %foo, i64 4
+  %gep2 = getelementptr i8, ptr %foo, i64 8
+  %cmp = icmp ult ptr %gep1, %gep2
+  ret i1 %cmp
+}
+
+define i1 @gep_const_same_negative_block(ptr align 16 %foo) {
+; CHECK-LABEL: @gep_const_same_negative_block(
+; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 -12
+; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 -8
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %gep1 = getelementptr i8, ptr %foo, i64 -12
+  %gep2 = getelementptr i8, ptr %foo, i64 -8
+  %cmp = icmp ult ptr %gep1, %gep2
+  ret i1 %cmp
+}
+
+define i1 @gep_const_different_block_1(ptr align 4 %foo) {
+; CHECK-LABEL: @gep_const_different_block_1(
+; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 4
+; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 8
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %gep1 = getelementptr i8, ptr %foo, i64 4
+  %gep2 = getelementptr i8, ptr %foo, i64 8
+  %cmp = icmp ult ptr %gep1, %gep2
+  ret i1 %cmp
+}
+
+define i1 @gep_const_different_block_2(ptr align 16 %foo) {
+; CHECK-LABEL: @gep_const_different_block_2(
+; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 -4
+; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %gep1 = getelementptr i8, ptr %foo, i64 -4
+  %gep2 = getelementptr i8, ptr %foo, i64 4
+  %cmp = icmp ult ptr %gep1, %gep2
+  ret i1 %cmp
+}
+
+define i1 @gep_const_edge_case_1(ptr align 16 %foo) {
+; CHECK-LABEL: @gep_const_edge_case_1(
+; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 14
+; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 15
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %gep1 = getelementptr i8, ptr %foo, i64 14
+  %gep2 = getelementptr i8, ptr %foo, i64 15
+  %cmp = icmp ult ptr %gep1, %gep2
+  ret i1 %cmp
+}
+
+define i1 @gep_const_edge_case_2(ptr align 16 %foo) {
+; CHECK-LABEL: @gep_const_edge_case_2(
+; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 15
+; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 16
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %gep1 = getelementptr i8, ptr %foo, i64 15
+  %gep2 = getelementptr i8, ptr %foo, i64 16
+  %cmp = icmp ult ptr %gep1, %gep2
+  ret i1 %cmp
+}
+
+define i1 @gep_const_edge_case_3(ptr align 16 %foo) {
+; CHECK-LABEL: @gep_const_edge_case_3(
+; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 16
+; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 17
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %gep1 = getelementptr i8, ptr %foo, i64 16
+  %gep2 = getelementptr i8, ptr %foo, i64 17
+  %cmp = icmp ult ptr %gep1, %gep2
+  ret i1 %cmp
+}
+
+define i1 @gep_variable_offsets(ptr align 16 %foo, i64 %i, i64 %j) {
+; CHECK-LABEL: @gep_variable_offsets(
+; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, ptr [[FOO:%.*]], i64 [[I:%.*]]
+; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, ptr [[FOO]], i64 [[J:%.*]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult ptr [[GEP1]], [[GEP2]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %gep1 = getelementptr i8, ptr %foo, i64 %i
+  %gep2 = getelementptr i8, ptr %foo, i64 %j
+  %cmp = icmp ult ptr %gep1, %gep2
+  ret i1 %cmp
+}
+
+; Similar to tests above, but extracted from an actual program.
+@g16 = global [4 x i32] zeroinitializer, align 16
+define i1 @gep_global_offsets() {
+; CHECK-LABEL: @gep_global_offsets(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ule ptr getelementptr (i8, ptr @g16, i64 20), getelementptr inbounds nuw (i8, ptr @g16, i64 16)
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %cmp = icmp ule ptr getelementptr (i8, ptr @g16, i64 20), getelementptr inbounds nuw (i8, ptr @g16, i64 16)
+  ret i1 %cmp
+}

--- a/llvm/test/Transforms/InstCombine/icmp-gep.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-gep.ll
@@ -1249,3 +1249,18 @@ define i1 @gep_global_offsets() {
   %cmp = icmp ule ptr getelementptr (i8, ptr @g16, i64 20), getelementptr inbounds nuw (i8, ptr @g16, i64 16)
   ret i1 %cmp
 }
+
+; Regression test: when checking for folding opportunities check for pointer
+; base before using trying to get the pointer alignment.
+define <2 x i1> @vec_gep_cmp(<2 x ptr> %base, <2 x i64> %i, <2 x i64> %j) {
+; CHECK-LABEL: @vec_gep_cmp(
+; CHECK-NEXT:    [[GEP1:%.*]] = getelementptr i8, <2 x ptr> [[BASE:%.*]], <2 x i64> [[I:%.*]]
+; CHECK-NEXT:    [[GEP2:%.*]] = getelementptr i8, <2 x ptr> [[BASE]], <2 x i64> [[J:%.*]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult <2 x ptr> [[GEP1]], [[GEP2]]
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+  %gep1 = getelementptr i8, <2 x ptr> %base, <2 x i64> %i
+  %gep2 = getelementptr i8, <2 x ptr> %base, <2 x i64> %j
+  %cmp = icmp ult <2 x ptr> %gep1, %gep2
+  ret <2 x i1> %cmp
+}


### PR DESCRIPTION
https://alive2.llvm.org/ce/z/dCmoVn

In a GEP comparison with the same base like

    %1 = gep i8, @base, i64 a
    %2 = gep i8, @base, i64 b
    %cmp = icmp ... %1, %2

When we know that the offsets cross the base's alignment boundary the same
number of times, it means that either both of them will overflow, or none of
them will. In these cases we can turn the comparison into offset comparison:

    %cmp = icmp ... a, b