### PR TITLE
[test] A few tests fail in debug and need to be marked UNSUPPORTED

### DIFF
--- a/clang-tools-extra/clangd/unittests/ClangdTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ClangdTests.cpp
@@ -1181,6 +1181,9 @@ TEST(ClangdServerTest, CustomAction) {
 // test as a workaround.
 #if !defined(__has_feature) || !__has_feature(address_sanitizer)
 TEST(ClangdServerTest, TestStackOverflow) {
+#ifndef NDEBUG
+  GTEST_SKIP() << "debug increases stack usage to the point of overflow";
+#endif
   MockFS FS;
   ErrorCheckingCallbacks DiagConsumer;
   MockCompilationDatabase CDB;

--- a/clang/test/C/C99/n590.c
+++ b/clang/test/C/C99/n590.c
@@ -1,5 +1,8 @@
 // RUN: %clang_cc1 -verify -Wno-unused -I %S/Inputs %s
 
+// debug increases stack usage to the point of overflow.
+// UNSUPPORTED: debug
+
 /* WG14 N590: Clang 3.2
  * Increase minimum translation limits
  *

--- a/clang/test/CodeGenCXX/cxx2b-deducing-this.cpp
+++ b/clang/test/CodeGenCXX/cxx2b-deducing-this.cpp
@@ -1,5 +1,8 @@
 // RUN: %clang_cc1 -std=c++2b %s -emit-llvm -triple x86_64-linux -o - | FileCheck %s
 
+// debug increases stack usage to the point of overflow.
+// UNSUPPORTED: debug
+
 struct TrivialStruct {
     void explicit_object_function(this TrivialStruct) {}
 };

--- a/clang/test/Index/index-many-logical-ops.c
+++ b/clang/test/Index/index-many-logical-ops.c
@@ -3,8 +3,8 @@
 // Check that we don't get stack overflow trying to index a huge number of
 // logical operators.
 
-// UBSan increases stack usage.
-// UNSUPPORTED: ubsan
+// UBSan and debug increase stack usage.
+// UNSUPPORTED: ubsan, debug
 
 // CHECK: [indexDeclaration]: kind: function | name: foo
 int foo(int x) {

--- a/clang/test/Sema/deep_recursion.c
+++ b/clang/test/Sema/deep_recursion.c
@@ -1,5 +1,9 @@
 // RUN: %clang_cc1 -verify -Wno-unused -I %S/Inputs %s
 // expected-no-diagnostics
+
+// debug increases stack usage to the point of overflow.
+// UNSUPPORTED: debug
+
 void func(void) {
   (void)0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,\
   5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,\

--- a/clang/test/Sema/many-logical-ops.c
+++ b/clang/test/Sema/many-logical-ops.c
@@ -1,6 +1,9 @@
 // RUN: %clang_cc1 -fsyntax-only -Wconstant-conversion -verify %s
 // expected-no-diagnostics
 
+// debug increases stack usage to the point of overflow.
+// UNSUPPORTED: debug
+
 // Check that we don't get stack overflow trying to evaluate a huge number of
 // logical operators.
 

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -419,6 +419,7 @@ def calculate_arch_features(arch_string):
 llvm_config.feature_config(
     [
         ("--assertion-mode", {"ON": "asserts"}),
+        ("--build-mode", {"[Dd][Ee][Bb][Uu][Gg]": "debug"}),
         ("--cxxflags", {r"-D_GLIBCXX_DEBUG\b": "libstdcxx-safe-mode"}),
         ("--targets-built", calculate_arch_features),
     ]


### PR DESCRIPTION
A few clang tests stack overflow with a debug clang. Copy the debug lit feature from LLVM and mark the crashing tests unsupported in debug.

One unit test needs similar treatment.

Assisted-by: Claude Code