### PR TITLE
[VPlan] Remove FoldTail argument for createConsecutiveVecPtr (NFC).

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -527,8 +527,7 @@ public:
   /// with element type \p SourceElementTy.
   VPSingleDefRecipe *createConsecutiveVectorPointer(VPValue *Ptr,
                                                     Type *SourceElementTy,
-                                                    bool Reverse, bool FoldTail,
-                                                    DebugLoc DL);
+                                                    bool Reverse, DebugLoc DL);
 
   VPWidenMemIntrinsicRecipe *createWidenMemIntrinsic(
       Intrinsic::ID VectorIntrinsicID, ArrayRef<VPValue *> CallArguments,

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -6199,8 +6199,7 @@ VPRecipeBase *VPRecipeBuilder::tryToWidenMemory(VPInstruction *VPI,
   if (Consecutive) {
     Builder.setInsertPoint(VPI);
     Ptr = Builder.createConsecutiveVectorPointer(Ptr, getLoadStoreType(I),
-                                                 Reverse, Plan.hasTailFolded(),
-                                                 VPI->getDebugLoc());
+                                                 Reverse, VPI->getDebugLoc());
   }
 
   if (Reverse && Mask)

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1667,8 +1667,7 @@ bool LoopVectorizationPlanner::getDecisionAndClampRange(
 
 VPSingleDefRecipe *
 VPBuilder::createConsecutiveVectorPointer(VPValue *Ptr, Type *SourceElementTy,
-                                          bool Reverse, bool FoldTail,
-                                          DebugLoc DL) {
+                                          bool Reverse, DebugLoc DL) {
   VPlan &Plan = getPlan();
   GEPNoWrapFlags Flags = vputils::getGEPFlagsForPtr(Ptr);
   if (Reverse) {
@@ -1676,8 +1675,9 @@ VPBuilder::createConsecutiveVectorPointer(VPValue *Ptr, Type *SourceElementTy,
     // original scalar loop: drop the GEP no-wrap flags in this case. Otherwise
     // preserve existing flags without no-unsigned-wrap, as we will emit
     // negative indices.
-    GEPNoWrapFlags ReverseFlags =
-        FoldTail ? GEPNoWrapFlags::none() : Flags.withoutNoUnsignedWrap();
+    GEPNoWrapFlags ReverseFlags = Plan.hasTailFolded()
+                                      ? GEPNoWrapFlags::none()
+                                      : Flags.withoutNoUnsignedWrap();
     return tryInsertInstruction(new VPVectorEndPointerRecipe(
         Ptr, &Plan.getVF(), SourceElementTy, /*Stride=*/-1, ReverseFlags, DL));
   }


### PR DESCRIPTION
The argument is no longer needed now that we can look up the information directly from VPlan.