### PR TITLE
[SPARC] Keep absolute hi/lo relocations direct

### DIFF
--- a/llvm/lib/Target/Sparc/AsmParser/SparcAsmParser.cpp
+++ b/llvm/lib/Target/Sparc/AsmParser/SparcAsmParser.cpp
@@ -1686,7 +1686,9 @@ SparcAsmParser::adjustPICRelocation(uint16_t RelType, const MCExpr *subExpr) {
   // actually a %pc10 or %pc22 relocation. Otherwise, they are interpreted
   // as %got10 or %got22 relocation.
 
-  if (getContext().getObjectFileInfo()->isPositionIndependent()) {
+  int64_t AbsoluteValue;
+  if (getContext().getObjectFileInfo()->isPositionIndependent() &&
+      !subExpr->evaluateAsAbsolute(AbsoluteValue)) {
     switch (RelType) {
     default: break;
     case ELF::R_SPARC_LO10:

--- a/llvm/test/MC/Sparc/Relocations/absolute-hi-lo-pic.s
+++ b/llvm/test/MC/Sparc/Relocations/absolute-hi-lo-pic.s
@@ -1,0 +1,17 @@
+! RUN: llvm-mc %s -triple=sparcv9 --position-independent -filetype=obj | llvm-objdump -d - | FileCheck %s
+
+! CHECK-LABEL: <abs_hi_lo>:
+! CHECK-NEXT:  sethi 0x16a09e, %l5
+! CHECK-NEXT:  or %l5, 0x199, %l5
+! CHECK-NEXT:  sethi 0x3fb72e, %o0
+! CHECK-NEXT:  xor %o0, 0x298, %o0
+
+        .text
+        .globl abs_hi_lo
+        .type abs_hi_lo,@function
+abs = 0xfedcba98
+abs_hi_lo:
+        sethi %hi(0x5a827999), %l5
+        or %l5, %lo(0x5a827999), %l5
+        sethi %hi(abs), %o0
+        xor %o0, %lo(abs), %o0


### PR DESCRIPTION
Do not rewrite absolute %hi/%lo operands to GOT relocations in PIC assembly mode. Clang cc1as defaults to PIC, so literal constants were encoded as relocation forms instead of direct HI22/LO10 values.