### PR TITLE
[ARM] Add strict uint to FP conversion handling during operation legalization

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -880,6 +880,12 @@ ARMTargetLowering::ARMTargetLowering(const TargetMachine &TM_,
     setOperationAction(ISD::STRICT_FP_ROUND,   MVT::f32, Custom);
   }
 
+  // STRICT_(U/S)INT_TO_FP specifically use the input MVT to register with
+  // setOperationAction() as opposed to other opcodes that use the output MVT
+  // All inputs should be i32 due to type legalization
+  setOperationAction(ISD::STRICT_UINT_TO_FP, MVT::i32, Custom);
+  setOperationAction(ISD::STRICT_SINT_TO_FP, MVT::i32, Custom);
+
   setOperationAction(ISD::STRICT_FP_TO_SINT, MVT::i32, Custom);
   setOperationAction(ISD::STRICT_FP_TO_UINT, MVT::i32, Custom);
 
@@ -5742,16 +5748,6 @@ SDValue ARMTargetLowering::LowerFP_TO_INT(SDValue Op, SelectionDAG &DAG) const {
     return IsStrict ? DAG.getMergeValues({Result, Chain}, Loc) : Result;
   }
 
-  // FIXME: Remove this when we have strict fp instruction selection patterns
-  if (IsStrict) {
-    SDLoc Loc(Op);
-    SDValue Result =
-        DAG.getNode(Op.getOpcode() == ISD::STRICT_FP_TO_SINT ? ISD::FP_TO_SINT
-                                                             : ISD::FP_TO_UINT,
-                    Loc, Op.getValueType(), SrcVal);
-    return DAG.getMergeValues({Result, Op.getOperand(0)}, Loc);
-  }
-
   return Op;
 }
 
@@ -5840,17 +5836,24 @@ SDValue ARMTargetLowering::LowerINT_TO_FP(SDValue Op, SelectionDAG &DAG) const {
   EVT VT = Op.getValueType();
   if (VT.isVector())
     return LowerVectorINT_TO_FP(Op, DAG);
+
+  bool IsStrict = Op->isStrictFPOpcode();
+  SDValue SrcVal = Op.getOperand(IsStrict ? 1 : 0);
+
   if (isUnsupportedFloatingType(VT)) {
     RTLIB::Libcall LC;
-    if (Op.getOpcode() == ISD::SINT_TO_FP)
-      LC = RTLIB::getSINTTOFP(Op.getOperand(0).getValueType(),
-                              Op.getValueType());
+    if (Op.getOpcode() == ISD::SINT_TO_FP ||
+        Op.getOpcode() == ISD::STRICT_SINT_TO_FP)
+      LC = RTLIB::getSINTTOFP(SrcVal.getValueType(), Op.getValueType());
     else
-      LC = RTLIB::getUINTTOFP(Op.getOperand(0).getValueType(),
-                              Op.getValueType());
+      LC = RTLIB::getUINTTOFP(SrcVal.getValueType(), Op.getValueType());
+    SDLoc Loc(Op);
     MakeLibCallOptions CallOptions;
-    return makeLibCall(DAG, LC, Op.getValueType(), Op.getOperand(0),
-                       CallOptions, SDLoc(Op)).first;
+    SDValue Chain = IsStrict ? Op.getOperand(0) : SDValue();
+    SDValue Result;
+    std::tie(Result, Chain) = makeLibCall(DAG, LC, Op.getValueType(), SrcVal,
+                                          CallOptions, Loc, Chain);
+    return IsStrict ? DAG.getMergeValues({Result, Chain}, Loc) : Result;
   }
 
   return Op;
@@ -10516,6 +10519,8 @@ SDValue ARMTargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const {
   case ISD::VASTART:       return LowerVASTART(Op, DAG);
   case ISD::ATOMIC_FENCE:  return LowerATOMIC_FENCE(Op, DAG, Subtarget);
   case ISD::PREFETCH:      return LowerPREFETCH(Op, DAG, Subtarget);
+  case ISD::STRICT_UINT_TO_FP:
+  case ISD::STRICT_SINT_TO_FP:
   case ISD::SINT_TO_FP:
   case ISD::UINT_TO_FP:    return LowerINT_TO_FP(Op, DAG);
   case ISD::STRICT_FP_TO_SINT:

--- a/llvm/test/CodeGen/ARM/fp-intrinsics-vector.ll
+++ b/llvm/test/CodeGen/ARM/fp-intrinsics-vector.ll
@@ -187,43 +187,12 @@ define <4 x i64> @fptoui_v4i64_v4f32(<4 x float> %x) #0 {
 define <4 x float> @sitofp_v4f32_v4i32(<4 x i32> %x) #0 {
 ; CHECK-LABEL: sitofp_v4f32_v4i32:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    .pad #32
-; CHECK-NEXT:    sub sp, sp, #32
-; CHECK-NEXT:    vmov r12, r1, d0
-; CHECK-NEXT:    movw r0, #0
-; CHECK-NEXT:    vmov r2, r3, d1
-; CHECK-NEXT:    movt r0, #17200
-; CHECK-NEXT:    str r0, [sp, #20]
-; CHECK-NEXT:    vldr d16, .LCPI9_0
-; CHECK-NEXT:    eor r1, r1, #-2147483648
-; CHECK-NEXT:    str r1, [sp, #16]
-; CHECK-NEXT:    str r0, [sp, #12]
-; CHECK-NEXT:    eor r1, r2, #-2147483648
-; CHECK-NEXT:    vldr d17, [sp, #16]
-; CHECK-NEXT:    stmib sp, {r0, r1}
-; CHECK-NEXT:    eor r1, r3, #-2147483648
-; CHECK-NEXT:    vsub.f64 d17, d17, d16
-; CHECK-NEXT:    vldr d18, [sp, #8]
-; CHECK-NEXT:    str r1, [sp]
-; CHECK-NEXT:    str r0, [sp, #28]
-; CHECK-NEXT:    eor r0, r12, #-2147483648
-; CHECK-NEXT:    vldr d19, [sp]
-; CHECK-NEXT:    str r0, [sp, #24]
-; CHECK-NEXT:    vsub.f64 d18, d18, d16
-; CHECK-NEXT:    vsub.f64 d19, d19, d16
-; CHECK-NEXT:    vldr d20, [sp, #24]
-; CHECK-NEXT:    vcvt.f32.f64 s3, d19
-; CHECK-NEXT:    vsub.f64 d16, d20, d16
-; CHECK-NEXT:    vcvt.f32.f64 s2, d18
-; CHECK-NEXT:    vcvt.f32.f64 s1, d17
-; CHECK-NEXT:    vcvt.f32.f64 s0, d16
-; CHECK-NEXT:    add sp, sp, #32
+; CHECK-NEXT:    vcvt.f32.s32 s7, s3
+; CHECK-NEXT:    vcvt.f32.s32 s6, s2
+; CHECK-NEXT:    vcvt.f32.s32 s5, s1
+; CHECK-NEXT:    vcvt.f32.s32 s4, s0
+; CHECK-NEXT:    vorr q0, q1, q1
 ; CHECK-NEXT:    bx lr
-; CHECK-NEXT:    .p2align 3
-; CHECK-NEXT:  @ %bb.1:
-; CHECK-NEXT:  .LCPI9_0:
-; CHECK-NEXT:    .long 2147483648 @ double 4503601774854144
-; CHECK-NEXT:    .long 1127219200
   %val = call <4 x float> @llvm.experimental.constrained.sitofp.v4f32.v4i32(<4 x i32> %x, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
   ret <4 x float> %val
 }
@@ -231,39 +200,12 @@ define <4 x float> @sitofp_v4f32_v4i32(<4 x i32> %x) #0 {
 define <4 x float> @uitofp_v4f32_v4i32(<4 x i32> %x) #0 {
 ; CHECK-LABEL: uitofp_v4f32_v4i32:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    .pad #32
-; CHECK-NEXT:    sub sp, sp, #32
-; CHECK-NEXT:    vmov r0, r1, d1
-; CHECK-NEXT:    movw r2, #0
-; CHECK-NEXT:    vmov r12, r3, d0
-; CHECK-NEXT:    movt r2, #17200
-; CHECK-NEXT:    stm sp, {r1, r2}
-; CHECK-NEXT:    vldr d17, [sp]
-; CHECK-NEXT:    vldr d16, .LCPI10_0
-; CHECK-NEXT:    str r2, [sp, #12]
-; CHECK-NEXT:    vsub.f64 d17, d17, d16
-; CHECK-NEXT:    vcvt.f32.f64 s3, d17
-; CHECK-NEXT:    str r0, [sp, #8]
-; CHECK-NEXT:    vldr d18, [sp, #8]
-; CHECK-NEXT:    str r2, [sp, #20]
-; CHECK-NEXT:    str r3, [sp, #16]
-; CHECK-NEXT:    vsub.f64 d18, d18, d16
-; CHECK-NEXT:    vldr d19, [sp, #16]
-; CHECK-NEXT:    str r2, [sp, #28]
-; CHECK-NEXT:    vcvt.f32.f64 s2, d18
-; CHECK-NEXT:    str r12, [sp, #24]
-; CHECK-NEXT:    vldr d20, [sp, #24]
-; CHECK-NEXT:    vsub.f64 d19, d19, d16
-; CHECK-NEXT:    vsub.f64 d16, d20, d16
-; CHECK-NEXT:    vcvt.f32.f64 s1, d19
-; CHECK-NEXT:    vcvt.f32.f64 s0, d16
-; CHECK-NEXT:    add sp, sp, #32
+; CHECK-NEXT:    vcvt.f32.u32 s7, s3
+; CHECK-NEXT:    vcvt.f32.u32 s6, s2
+; CHECK-NEXT:    vcvt.f32.u32 s5, s1
+; CHECK-NEXT:    vcvt.f32.u32 s4, s0
+; CHECK-NEXT:    vorr q0, q1, q1
 ; CHECK-NEXT:    bx lr
-; CHECK-NEXT:    .p2align 3
-; CHECK-NEXT:  @ %bb.1:
-; CHECK-NEXT:  .LCPI10_0:
-; CHECK-NEXT:    .long 0 @ double 4503599627370496
-; CHECK-NEXT:    .long 1127219200
   %val = call <4 x float> @llvm.experimental.constrained.uitofp.v4f32.v4i32(<4 x i32> %x, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
   ret <4 x float> %val
 }
@@ -812,30 +754,13 @@ define <2 x i64> @fptoui_v2i64_v2f64(<2 x double> %x) #0 {
 define <2 x double> @sitofp_v2f64_v2i32(<2 x i32> %x) #0 {
 ; CHECK-LABEL: sitofp_v2f64_v2i32:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    .pad #16
-; CHECK-NEXT:    sub sp, sp, #16
 ; CHECK-NEXT:    vmov.32 r0, d0[1]
-; CHECK-NEXT:    movw r2, #0
 ; CHECK-NEXT:    vmov.32 r1, d0[0]
-; CHECK-NEXT:    movt r2, #17200
-; CHECK-NEXT:    str r2, [sp, #4]
-; CHECK-NEXT:    vldr d16, .LCPI34_0
-; CHECK-NEXT:    eor r0, r0, #-2147483648
-; CHECK-NEXT:    str r0, [sp]
-; CHECK-NEXT:    str r2, [sp, #12]
-; CHECK-NEXT:    eor r0, r1, #-2147483648
-; CHECK-NEXT:    vldr d17, [sp]
-; CHECK-NEXT:    str r0, [sp, #8]
-; CHECK-NEXT:    vldr d18, [sp, #8]
-; CHECK-NEXT:    vsub.f64 d1, d17, d16
-; CHECK-NEXT:    vsub.f64 d0, d18, d16
-; CHECK-NEXT:    add sp, sp, #16
+; CHECK-NEXT:    vmov s0, r0
+; CHECK-NEXT:    vmov s4, r1
+; CHECK-NEXT:    vcvt.f64.s32 d1, s0
+; CHECK-NEXT:    vcvt.f64.s32 d0, s4
 ; CHECK-NEXT:    bx lr
-; CHECK-NEXT:    .p2align 3
-; CHECK-NEXT:  @ %bb.1:
-; CHECK-NEXT:  .LCPI34_0:
-; CHECK-NEXT:    .long 2147483648 @ double 4503601774854144
-; CHECK-NEXT:    .long 1127219200
   %val = call <2 x double> @llvm.experimental.constrained.sitofp.v2f64.v2i32(<2 x i32> %x, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
   ret <2 x double> %val
 }
@@ -843,28 +768,13 @@ define <2 x double> @sitofp_v2f64_v2i32(<2 x i32> %x) #0 {
 define <2 x double> @uitofp_v2f64_v2i32(<2 x i32> %x) #0 {
 ; CHECK-LABEL: uitofp_v2f64_v2i32:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    .pad #16
-; CHECK-NEXT:    sub sp, sp, #16
-; CHECK-NEXT:    movw r0, #0
-; CHECK-NEXT:    mov r1, sp
-; CHECK-NEXT:    movt r0, #17200
-; CHECK-NEXT:    vst1.32 {d0[1]}, [r1:32]
-; CHECK-NEXT:    add r1, sp, #8
-; CHECK-NEXT:    str r0, [sp, #4]
-; CHECK-NEXT:    vldr d17, [sp]
-; CHECK-NEXT:    vst1.32 {d0[0]}, [r1:32]
-; CHECK-NEXT:    vldr d16, .LCPI35_0
-; CHECK-NEXT:    str r0, [sp, #12]
-; CHECK-NEXT:    vldr d18, [sp, #8]
-; CHECK-NEXT:    vsub.f64 d1, d17, d16
-; CHECK-NEXT:    vsub.f64 d0, d18, d16
-; CHECK-NEXT:    add sp, sp, #16
+; CHECK-NEXT:    vmov.32 r0, d0[1]
+; CHECK-NEXT:    vmov.32 r1, d0[0]
+; CHECK-NEXT:    vmov s0, r0
+; CHECK-NEXT:    vmov s4, r1
+; CHECK-NEXT:    vcvt.f64.u32 d1, s0
+; CHECK-NEXT:    vcvt.f64.u32 d0, s4
 ; CHECK-NEXT:    bx lr
-; CHECK-NEXT:    .p2align 3
-; CHECK-NEXT:  @ %bb.1:
-; CHECK-NEXT:  .LCPI35_0:
-; CHECK-NEXT:    .long 0 @ double 4503599627370496
-; CHECK-NEXT:    .long 1127219200
   %val = call <2 x double> @llvm.experimental.constrained.uitofp.v2f64.v2i32(<2 x i32> %x, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
   ret <2 x double> %val
 }
@@ -1266,23 +1176,9 @@ define <1 x i64> @fptoui_v1i64_v1f64(<1 x double> %x) #0 {
 define <1 x double> @sitofp_v1f64_v1i32(<1 x i32> %x) #0 {
 ; CHECK-LABEL: sitofp_v1f64_v1i32:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    .pad #8
-; CHECK-NEXT:    sub sp, sp, #8
-; CHECK-NEXT:    movw r1, #0
-; CHECK-NEXT:    eor r0, r0, #-2147483648
-; CHECK-NEXT:    movt r1, #17200
-; CHECK-NEXT:    str r0, [sp]
-; CHECK-NEXT:    str r1, [sp, #4]
-; CHECK-NEXT:    vldr d16, .LCPI59_0
-; CHECK-NEXT:    vldr d17, [sp]
-; CHECK-NEXT:    vsub.f64 d0, d17, d16
-; CHECK-NEXT:    add sp, sp, #8
+; CHECK-NEXT:    vmov s0, r0
+; CHECK-NEXT:    vcvt.f64.s32 d0, s0
 ; CHECK-NEXT:    bx lr
-; CHECK-NEXT:    .p2align 3
-; CHECK-NEXT:  @ %bb.1:
-; CHECK-NEXT:  .LCPI59_0:
-; CHECK-NEXT:    .long 2147483648 @ double 4503601774854144
-; CHECK-NEXT:    .long 1127219200
   %val = call <1 x double> @llvm.experimental.constrained.sitofp.v1f64.v1i32(<1 x i32> %x, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
   ret <1 x double> %val
 }
@@ -1290,22 +1186,9 @@ define <1 x double> @sitofp_v1f64_v1i32(<1 x i32> %x) #0 {
 define <1 x double> @uitofp_v1f64_v1i32(<1 x i32> %x) #0 {
 ; CHECK-LABEL: uitofp_v1f64_v1i32:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    .pad #8
-; CHECK-NEXT:    sub sp, sp, #8
-; CHECK-NEXT:    movw r1, #0
-; CHECK-NEXT:    str r0, [sp]
-; CHECK-NEXT:    movt r1, #17200
-; CHECK-NEXT:    vldr d16, .LCPI60_0
-; CHECK-NEXT:    str r1, [sp, #4]
-; CHECK-NEXT:    vldr d17, [sp]
-; CHECK-NEXT:    vsub.f64 d0, d17, d16
-; CHECK-NEXT:    add sp, sp, #8
+; CHECK-NEXT:    vmov s0, r0
+; CHECK-NEXT:    vcvt.f64.u32 d0, s0
 ; CHECK-NEXT:    bx lr
-; CHECK-NEXT:    .p2align 3
-; CHECK-NEXT:  @ %bb.1:
-; CHECK-NEXT:  .LCPI60_0:
-; CHECK-NEXT:    .long 0 @ double 4503599627370496
-; CHECK-NEXT:    .long 1127219200
   %val = call <1 x double> @llvm.experimental.constrained.uitofp.v1f64.v1i32(<1 x i32> %x, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
   ret <1 x double> %val
 }

--- a/llvm/test/CodeGen/ARM/fp16-fullfp16.ll
+++ b/llvm/test/CodeGen/ARM/fp16-fullfp16.ll
@@ -746,45 +746,18 @@ define i64 @fptoui_i64_f16(half %x) #0 {
 
 define half @sitofp_f16_i32(i32 %x) #0 {
 ; CHECK-LABEL: sitofp_f16_i32:
-; CHECK:         .pad #8
-; CHECK-NEXT:    sub sp, sp, #8
-; CHECK-NEXT:    movw r1, #0
-; CHECK-NEXT:    eor r0, r0, #-2147483648
-; CHECK-NEXT:    movt r1, #17200
-; CHECK-NEXT:    str r0, [sp]
-; CHECK-NEXT:    str r1, [sp, #4]
-; CHECK-NEXT:    vldr d16, .LCPI57_0
-; CHECK-NEXT:    vldr d17, [sp]
-; CHECK-NEXT:    vsub.f64 d16, d17, d16
-; CHECK-NEXT:    vcvtb.f16.f64 s0, d16
-; CHECK-NEXT:    add sp, sp, #8
+; CHECK:         vmov s0, r0
+; CHECK-NEXT:    vcvt.f16.s32 s0, s0
 ; CHECK-NEXT:    bx lr
-; CHECK-NEXT:    .p2align 3
-; CHECK-NEXT:  .LCPI57_0:
-; CHECK-NEXT:    .long 2147483648
-; CHECK-NEXT:    .long 1127219200
   %val = call half @llvm.experimental.constrained.sitofp.f16.i32(i32 %x, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
   ret half %val
 }
 
 define half @uitofp_f16_i32(i32 %x) #0 {
 ; CHECK-LABEL: uitofp_f16_i32:
-; CHECK:         .pad #8
-; CHECK-NEXT:    sub sp, sp, #8
-; CHECK-NEXT:    movw r1, #0
-; CHECK-NEXT:    str r0, [sp]
-; CHECK-NEXT:    movt r1, #17200
-; CHECK-NEXT:    vldr d16, .LCPI58_0
-; CHECK-NEXT:    str r1, [sp, #4]
-; CHECK-NEXT:    vldr d17, [sp]
-; CHECK-NEXT:    vsub.f64 d16, d17, d16
-; CHECK-NEXT:    vcvtb.f16.f64 s0, d16
-; CHECK-NEXT:    add sp, sp, #8
+; CHECK:         vmov s0, r0
+; CHECK-NEXT:    vcvt.f16.u32 s0, s0
 ; CHECK-NEXT:    bx lr
-; CHECK-NEXT:    .p2align 3
-; CHECK-NEXT:  .LCPI58_0:
-; CHECK-NEXT:    .long 0
-; CHECK-NEXT:    .long 1127219200
   %val = call half @llvm.experimental.constrained.uitofp.f16.i32(i32 %x, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
   ret half %val
 }

--- a/llvm/test/CodeGen/ARM/strict-fp-int-promote.ll
+++ b/llvm/test/CodeGen/ARM/strict-fp-int-promote.ll
@@ -10,66 +10,31 @@ declare float @llvm.experimental.constrained.uitofp.f32.i16(i16, metadata, metad
 define i32 @test(i32 %a, i16 %b) #0 {
 ; CHECK-LABEL: test:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    sub sp, sp, #16
-; CHECK-NEXT:    mov r2, r0
-; CHECK-NEXT:    sxth r0, r1
-; CHECK-NEXT:    movw r1, #0
-; CHECK-NEXT:    movt r1, #17200
-; CHECK-NEXT:    str r1, [sp, #4]
-; CHECK-NEXT:    eor r2, r2, #-2147483648
-; CHECK-NEXT:    str r2, [sp]
-; CHECK-NEXT:    vldr d16, [sp]
-; CHECK-NEXT:    vldr d17, .LCPI0_0
-; CHECK-NEXT:    vsub.f64 d16, d16, d17
-; CHECK-NEXT:    vcvt.f32.f64 s0, d16
-; CHECK-NEXT:    str r1, [sp, #12]
-; CHECK-NEXT:    eor r0, r0, #-2147483648
-; CHECK-NEXT:    str r0, [sp, #8]
-; CHECK-NEXT:    vldr d16, [sp, #8]
-; CHECK-NEXT:    vsub.f64 d16, d16, d17
-; CHECK-NEXT:    vcvt.f32.f64 s2, d16
+; CHECK-NEXT:    mov r2, r1
+; CHECK-NEXT:    mov r1, r0
+; CHECK-NEXT:    sxth r0, r2
+; CHECK-NEXT:    vmov s0, r1
+; CHECK-NEXT:    vcvt.f32.s32 s0, s0
+; CHECK-NEXT:    vmov s2, r0
+; CHECK-NEXT:    vcvt.f32.s32 s2, s2
 ; CHECK-NEXT:    vcmp.f32 s0, s2
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    movweq r0, #1
-; CHECK-NEXT:    add sp, sp, #16
 ; CHECK-NEXT:    bx lr
-; CHECK-NEXT:    .p2align 3
-; CHECK-NEXT:  @ %bb.1:
-; CHECK-NEXT:  .LCPI0_0:
-; CHECK-NEXT:    .long 2147483648 @ double 4503601774854144
-; CHECK-NEXT:    .long 1127219200
 ;
 ; CHECK-O3-LABEL: test:
 ; CHECK-O3:       @ %bb.0: @ %entry
-; CHECK-O3-NEXT:    sub sp, sp, #16
 ; CHECK-O3-NEXT:    sxth r1, r1
-; CHECK-O3-NEXT:    movw r2, #0
-; CHECK-O3-NEXT:    movt r2, #17200
-; CHECK-O3-NEXT:    str r2, [sp, #4]
-; CHECK-O3-NEXT:    eor r0, r0, #-2147483648
-; CHECK-O3-NEXT:    str r0, [sp]
-; CHECK-O3-NEXT:    vldr d16, [sp]
-; CHECK-O3-NEXT:    vldr d17, .LCPI0_0
-; CHECK-O3-NEXT:    vsub.f64 d16, d16, d17
-; CHECK-O3-NEXT:    vcvt.f32.f64 s0, d16
-; CHECK-O3-NEXT:    str r2, [sp, #12]
-; CHECK-O3-NEXT:    eor r0, r1, #-2147483648
-; CHECK-O3-NEXT:    str r0, [sp, #8]
-; CHECK-O3-NEXT:    vldr d16, [sp, #8]
-; CHECK-O3-NEXT:    vsub.f64 d16, d16, d17
-; CHECK-O3-NEXT:    vcvt.f32.f64 s2, d16
+; CHECK-O3-NEXT:    vmov s0, r0
+; CHECK-O3-NEXT:    vcvt.f32.s32 s0, s0
+; CHECK-O3-NEXT:    vmov s2, r1
+; CHECK-O3-NEXT:    vcvt.f32.s32 s2, s2
 ; CHECK-O3-NEXT:    vcmp.f32 s0, s2
 ; CHECK-O3-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-O3-NEXT:    mov r0, #0
 ; CHECK-O3-NEXT:    movweq r0, #1
-; CHECK-O3-NEXT:    add sp, sp, #16
 ; CHECK-O3-NEXT:    bx lr
-; CHECK-O3-NEXT:    .p2align 3
-; CHECK-O3-NEXT:  @ %bb.1:
-; CHECK-O3-NEXT:  .LCPI0_0:
-; CHECK-O3-NEXT:    .long 2147483648 @ double 4503601774854144
-; CHECK-O3-NEXT:    .long 1127219200
 entry:
   %conv = call float @llvm.experimental.constrained.sitofp.f32.i32(i32 %a, metadata !"round.tonearest", metadata !"fpexcept.strict") #1
   %conv1 = call float @llvm.experimental.constrained.sitofp.f32.i16(i16 %b, metadata !"round.tonearest", metadata !"fpexcept.strict") #1
@@ -81,72 +46,31 @@ entry:
 define i32 @test2(i32 %a, i16 %b) #0 {
 ; CHECK-LABEL: test2:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    sub sp, sp, #16
-; CHECK-NEXT:    mov r2, r0
-; CHECK-NEXT:    uxth r0, r1
-; CHECK-NEXT:    movw r1, #0
-; CHECK-NEXT:    movt r1, #17200
-; CHECK-NEXT:    str r1, [sp, #4]
-; CHECK-NEXT:    eor r2, r2, #-2147483648
-; CHECK-NEXT:    str r2, [sp]
-; CHECK-NEXT:    vldr d16, [sp]
-; CHECK-NEXT:    vldr d17, .LCPI1_0
-; CHECK-NEXT:    vsub.f64 d16, d16, d17
-; CHECK-NEXT:    vcvt.f32.f64 s0, d16
-; CHECK-NEXT:    str r1, [sp, #12]
-; CHECK-NEXT:    str r0, [sp, #8]
-; CHECK-NEXT:    vldr d16, [sp, #8]
-; CHECK-NEXT:    vldr d17, .LCPI1_1
-; CHECK-NEXT:    vsub.f64 d16, d16, d17
-; CHECK-NEXT:    vcvt.f32.f64 s2, d16
+; CHECK-NEXT:    mov r2, r1
+; CHECK-NEXT:    mov r1, r0
+; CHECK-NEXT:    uxth r0, r2
+; CHECK-NEXT:    vmov s0, r1
+; CHECK-NEXT:    vcvt.f32.s32 s0, s0
+; CHECK-NEXT:    vmov s2, r0
+; CHECK-NEXT:    vcvt.f32.u32 s2, s2
 ; CHECK-NEXT:    vcmp.f32 s0, s2
 ; CHECK-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-NEXT:    mov r0, #0
 ; CHECK-NEXT:    movweq r0, #1
-; CHECK-NEXT:    add sp, sp, #16
 ; CHECK-NEXT:    bx lr
-; CHECK-NEXT:    .p2align 3
-; CHECK-NEXT:  @ %bb.1:
-; CHECK-NEXT:  .LCPI1_0:
-; CHECK-NEXT:    .long 2147483648 @ double 4503601774854144
-; CHECK-NEXT:    .long 1127219200
-; CHECK-NEXT:  .LCPI1_1:
-; CHECK-NEXT:    .long 0 @ double 4503599627370496
-; CHECK-NEXT:    .long 1127219200
 ;
 ; CHECK-O3-LABEL: test2:
 ; CHECK-O3:       @ %bb.0: @ %entry
-; CHECK-O3-NEXT:    sub sp, sp, #16
 ; CHECK-O3-NEXT:    uxth r1, r1
-; CHECK-O3-NEXT:    movw r2, #0
-; CHECK-O3-NEXT:    movt r2, #17200
-; CHECK-O3-NEXT:    str r2, [sp, #4]
-; CHECK-O3-NEXT:    eor r0, r0, #-2147483648
-; CHECK-O3-NEXT:    str r0, [sp]
-; CHECK-O3-NEXT:    vldr d16, [sp]
-; CHECK-O3-NEXT:    vldr d17, .LCPI1_0
-; CHECK-O3-NEXT:    vsub.f64 d16, d16, d17
-; CHECK-O3-NEXT:    vcvt.f32.f64 s0, d16
-; CHECK-O3-NEXT:    str r2, [sp, #12]
-; CHECK-O3-NEXT:    str r1, [sp, #8]
-; CHECK-O3-NEXT:    vldr d16, [sp, #8]
-; CHECK-O3-NEXT:    vldr d17, .LCPI1_1
-; CHECK-O3-NEXT:    vsub.f64 d16, d16, d17
-; CHECK-O3-NEXT:    vcvt.f32.f64 s2, d16
+; CHECK-O3-NEXT:    vmov s0, r0
+; CHECK-O3-NEXT:    vcvt.f32.s32 s0, s0
+; CHECK-O3-NEXT:    vmov s2, r1
+; CHECK-O3-NEXT:    vcvt.f32.u32 s2, s2
 ; CHECK-O3-NEXT:    vcmp.f32 s0, s2
 ; CHECK-O3-NEXT:    vmrs APSR_nzcv, fpscr
 ; CHECK-O3-NEXT:    mov r0, #0
 ; CHECK-O3-NEXT:    movweq r0, #1
-; CHECK-O3-NEXT:    add sp, sp, #16
 ; CHECK-O3-NEXT:    bx lr
-; CHECK-O3-NEXT:    .p2align 3
-; CHECK-O3-NEXT:  @ %bb.1:
-; CHECK-O3-NEXT:  .LCPI1_0:
-; CHECK-O3-NEXT:    .long 2147483648 @ double 4503601774854144
-; CHECK-O3-NEXT:    .long 1127219200
-; CHECK-O3-NEXT:  .LCPI1_1:
-; CHECK-O3-NEXT:    .long 0 @ double 4503599627370496
-; CHECK-O3-NEXT:    .long 1127219200
 entry:
   %conv = call float @llvm.experimental.constrained.sitofp.f32.i32(i32 %a, metadata !"round.tonearest", metadata !"fpexcept.strict") #1
   %conv1 = call float @llvm.experimental.constrained.uitofp.f32.i16(i16 %b, metadata !"round.tonearest", metadata !"fpexcept.strict") #1


### PR DESCRIPTION
Currently, strict uint to FP conversions for the ARM backend end up falling through to software emulation.

This commit allows them to be correctly handled using the corresponding vcvt instruction.