### PR TITLE
[Sema] Properly space namespace comments

### DIFF
--- a/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
+++ b/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
@@ -915,7 +915,7 @@ namespace FuncTemplateInClass {
     requires C<Ts>
     auto TplClass<0>::buggy() -> void {}
     // expected-error@-1 {{out-of-line definition of 'buggy' does not match any declaration}}
-  } //namespace t1
+  } // namespace t1
   namespace t2 {
     template <int> struct TplClass { // expected-note {{defined here}}
       template <int Ts, int Us>
@@ -928,7 +928,7 @@ namespace FuncTemplateInClass {
     requires C<Us>
     auto TplClass<0>::buggy() -> void {}
     // expected-error@-1 {{out-of-line definition of 'buggy' does not match any declaration}}
-  } //namespace t2
+  } // namespace t2
 } // namespace FuncTemplateInClass
 
 namespace GH139476 {


### PR DESCRIPTION
// namespace instead of //namespace.

This is consistent with the LLVM coding standards. We took focus on this specific case as it was tripping up some of our internal tooling.