### PR TITLE
[NFC][InstCombine] Initialize potentially uninitialized local pointers

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -426,7 +426,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
     // bits to zero.  We can just knock out bits from the 'and' and the 'xor',
     // simplifying both of them.
     if (Instruction *LHSInst = dyn_cast<Instruction>(I->getOperand(0))) {
-      ConstantInt *AndRHS, *XorRHS;
+      ConstantInt *AndRHS = nullptr, *XorRHS = nullptr;
       if (LHSInst->getOpcode() == Instruction::And && LHSInst->hasOneUse() &&
           match(I->getOperand(1), m_ConstantInt(XorRHS)) &&
           match(LHSInst->getOperand(1), m_ConstantInt(AndRHS)) &&

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1164,7 +1164,7 @@ Value *InstCombinerImpl::tryFactorizationFolds(BinaryOperator &I) {
   BinaryOperator *Op0 = dyn_cast<BinaryOperator>(LHS);
   BinaryOperator *Op1 = dyn_cast<BinaryOperator>(RHS);
   Instruction::BinaryOps TopLevelOpcode = I.getOpcode();
-  Value *A, *B, *C, *D;
+  Value *A = nullptr, *B = nullptr, *C = nullptr, *D = nullptr;
   Instruction::BinaryOps LHSOpcode, RHSOpcode;
 
   if (Op0)


### PR DESCRIPTION
These variables are always assigned before use in practice, but MSVC issues C4703 ("potentially uninitialized local pointer variable") warnings for them. Initializing to nullptr silences the warnings and is defensive against undefined behavior in edge cases.

Part of a series fixing MSVC C4703 warnings across the LLVM tree:

- #208566 (CodeGen)
- #208564(Transforms)
- #208565 (misc)
- #208469 (AMDGPU)
