### PR TITLE
[NFC][Transforms] Initialize potentially uninitialized local pointers

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -512,7 +512,7 @@ void coro::BaseCloner::replaceRetconOrAsyncSuspendUses() {
 }
 
 void coro::BaseCloner::replaceCoroSuspends() {
-  Value *SuspendResult;
+  Value *SuspendResult = nullptr;
 
   switch (Shape.ABI) {
   // In switch lowering, replace coro.suspend with the appropriate value

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -1826,7 +1826,7 @@ static void rewriteMemOpOfSelect(SelectInst &SI, T &I,
   Spec = {}; // Do not use `Spec` beyond this point.
   BasicBlock *Tail = I.getParent();
   Tail->setName(Head->getName() + ".cont");
-  PHINode *PN;
+  PHINode *PN = nullptr;
   if (isa<LoadInst>(I))
     PN = PHINode::Create(I.getType(), 2, "", I.getIterator());
   for (BasicBlock *SuccBB : successors(Head)) {

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -7471,7 +7471,7 @@ static bool simplifySwitchLookup(SwitchInst *SI, IRBuilder<> &Builder,
     return false;
 
   // Compute the table index value.
-  Value *TableIndex;
+  Value *TableIndex = nullptr;
   if (UseSwitchConditionAsTableIndex) {
     TableIndex = SI->getCondition();
     if (HasDefaultResults) {


### PR DESCRIPTION
These variables are always assigned before use in practice, but MSVC issues C4703 ("potentially uninitialized local pointer variable") warnings for them. Initializing to nullptr silences the warnings and is defensive against undefined behavior in edge cases.

Part of a series fixing MSVC C4703 warnings across the LLVM tree:

- #208563 (InstCombine)
- #208566 (CodeGen)
- #208565 (misc)
- #208469 (AMDGPU)