### PR TITLE
[GISel] Don't return false when an intrinsic is not supported

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -2882,7 +2882,6 @@ bool IRTranslator::translateCall(const User &U, MachineIRBuilder &MIRBuilder) {
     const Function &Fn = MF->getFunction();
     Fn.getContext().diagnose(
         DiagnosticInfoUnsupportedTargetIntrinsic(Fn, ID, CI.getDebugLoc()));
-    return false;
   }
 
   if (translateKnownIntrinsic(CI, ID, MIRBuilder))
@@ -2902,7 +2901,6 @@ bool IRTranslator::translateIntrinsic(
     const Function &F = MF->getFunction();
     F.getContext().diagnose(
         DiagnosticInfoUnsupportedTargetIntrinsic(F, ID, CB.getDebugLoc()));
-    return false;
   }
 
   ArrayRef<Register> ResultRegs;

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.permlane16.swap.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.permlane16.swap.ll
@@ -5,7 +5,7 @@
 ; RUN: llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1250 < %s | FileCheck -check-prefix=GFX1250 %s
 
 ; RUN: not llc -global-isel=0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -filetype=null %s 2>&1 | FileCheck -check-prefix=ERR %s
-; RUN: not llc -global-isel=1 -global-isel-abort=0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -filetype=null %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: not llc -global-isel=1 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -filetype=null %s 2>&1 | FileCheck -check-prefix=ERR %s
 
 ; ERR: error: {{.*}}: in function {{@?}}v_permlane16_swap_b32_vv{{.*}}: llvm.amdgcn.permlane16.swap requires target feature 'permlane16-swap'
 


### PR DESCRIPTION
This will abort immediately by default, which is not ideal.
