### PR TITLE
[libc] Disable baremetal modular printf

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -13,6 +13,9 @@
     "LIBC_CONF_PRINTF_DISABLE_FIXED_POINT": {
       "value": true
     },
+    "LIBC_CONF_PRINTF_DISABLE_FLOAT": {
+      "value": true
+    },
     "LIBC_CONF_PRINTF_DISABLE_INDEX_MODE": {
       "value": true
     },
@@ -29,12 +32,6 @@
       "value": true
     },
     "LIBC_COPT_PRINTF_DISABLE_BITINT": {
-      "value": true
-    },
-    "LIBC_CONF_PRINTF_MODULAR": {
-      "value": true
-    },
-    "LIBC_CONF_PRINTF_FLOAT_TO_STR_USE_FLOAT320": {
       "value": true
     }
   },


### PR DESCRIPTION
This reverts commit a14d084bbb1a7261d8a71c56120159abb6af330b.
Though the modular printf works as intented, we noticed a few challenges
using this feature. Without diagnostic help it is difficult to
understand which "modules" got linked in and why. Disabling this to be
the default setting until this is sorted.
