### PR TITLE
[orc-rt] Apply orc_rt_log_* naming convention to Logging.h. NFC.

### DIFF
--- a/orc-rt/include/orc-rt-c/Logging.h
+++ b/orc-rt/include/orc-rt-c/Logging.h
@@ -14,7 +14,7 @@
 |*   ORC_RT_LOG(Level, Category, Fmt, ...)                                    *|
 |*                                                                            *|
 |* where Level is one of Error, Warning, Info, Debug; Category is one of the  *|
-|* orc_rt_LogCategory tokens (without the leading "orc_rt_LogCategory_");     *|
+|* orc_rt_log_Category tokens (without the leading "orc_rt_log_Category_");   *|
 |* and Fmt, ... are a printf-style format string and arguments, e.g.          *|
 |*                                                                            *|
 |*   ORC_RT_LOG(Error, General, "failed to map %zu bytes", Size);             *|
@@ -50,15 +50,15 @@ ORC_RT_C_EXTERN_C_BEGIN
  * categories here as call sites require them.
  */
 typedef enum {
-  orc_rt_LogCategory_General,
-} orc_rt_LogCategory;
+  orc_rt_log_Category_General,
+} orc_rt_log_Category;
 
 /**
  * Declared but never defined: referenced only in unevaluated (sizeof) contexts
  * to type-check a printf-style format string against its arguments without
  * evaluating them or emitting any code.
  */
-int orc_rt_log_format_check(const char *Fmt, ...) ORC_RT_C_FORMAT_PRINTF(1, 2);
+int orc_rt_log_formatCheck(const char *Fmt, ...) ORC_RT_C_FORMAT_PRINTF(1, 2);
 
 /*
  * A disabled log site. Validates the category token, format string, and
@@ -66,7 +66,7 @@ int orc_rt_log_format_check(const char *Fmt, ...) ORC_RT_C_FORMAT_PRINTF(1, 2);
  * both operands sit in unevaluated sizeof contexts.
  */
 #define ORC_RT_LOG_DISABLED(Category, ...)                                     \
-  ((void)sizeof(Category), (void)sizeof(orc_rt_log_format_check(__VA_ARGS__)))
+  ((void)sizeof(Category), (void)sizeof(orc_rt_log_formatCheck(__VA_ARGS__)))
 
 /*
  * ORC_RT_LOG dispatches on the level token to a per-level macro, which each
@@ -76,7 +76,7 @@ int orc_rt_log_format_check(const char *Fmt, ...) ORC_RT_C_FORMAT_PRINTF(1, 2);
  * needed.
  */
 #define ORC_RT_LOG(Level, Category, ...)                                       \
-  ORC_RT_LOG_##Level(orc_rt_LogCategory_##Category, __VA_ARGS__)
+  ORC_RT_LOG_##Level(orc_rt_log_Category_##Category, __VA_ARGS__)
 
 #if ORC_RT_LOG_BACKEND == ORC_RT_LOG_BACKEND_NONE
 


### PR DESCRIPTION
orc_rt_ is the top-level C namespace and orc_rt_log_ a nested namespace for logging. Following the C API convention, types, values, and variables are PascalCase and functions are camelCase (as in LLVM).