### PR TITLE
[mlir][emitc] Fix hasSideEffects of emitc.cast

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -404,7 +404,7 @@ def EmitC_CastOp : EmitC_Op<"cast",
     bool hasSideEffects() {
       // Use the "pure" attribute to see whether this CastOp has side effects.
       // Note that by default, `pure` is not set.
-      return getPure();
+      return !getPure();
     }
   }];
 }

--- a/mlir/test/Target/Cpp/expressions.mlir
+++ b/mlir/test/Target/Cpp/expressions.mlir
@@ -89,11 +89,14 @@ func.func @do_not_inline(%arg0: i32, %arg1: i32, %arg2 : i32) -> i32 {
 }
 
 // CPP-DEFAULT:      float parentheses_for_low_precedence(int32_t [[VAL_1:v[0-9]+]], int32_t [[VAL_2:v[0-9]+]], int32_t [[VAL_3:v[0-9]+]]) {
-// CPP-DEFAULT-NEXT:   return (float) (([[VAL_1]] + [[VAL_2]]) * [[VAL_3]]);
+// CPP-DEFAULT-NEXT:   float [[VAL_4:v[0-9]+]] = (float) (([[VAL_1]] + [[VAL_2]]) * [[VAL_3]]);
+// CPP-DEFAULT-NEXT:   return [[VAL_4]];
 // CPP-DEFAULT-NEXT: }
 
 // CPP-DECLTOP:      float parentheses_for_low_precedence(int32_t [[VAL_1:v[0-9]+]], int32_t [[VAL_2:v[0-9]+]], int32_t [[VAL_3:v[0-9]+]]) {
-// CPP-DECLTOP-NEXT:   return (float) (([[VAL_1]] + [[VAL_2]]) * [[VAL_3]]);
+// CPP-DECLTOP-NEXT:   float [[VAL_4:v[0-9]+]];
+// CPP-DECLTOP-NEXT:   [[VAL_4]] = (float) (([[VAL_1]] + [[VAL_2]]) * [[VAL_3]]);
+// CPP-DECLTOP-NEXT:   return [[VAL_4]];
 // CPP-DECLTOP-NEXT: }
 
 func.func @parentheses_for_low_precedence(%arg0: i32, %arg1: i32, %arg2: i32) -> f32 {

--- a/mlir/test/Target/Cpp/expressions.mlir
+++ b/mlir/test/Target/Cpp/expressions.mlir
@@ -109,6 +109,41 @@ func.func @parentheses_for_low_precedence(%arg0: i32, %arg1: i32, %arg2: i32) ->
   return %e : f32
 }
 
+// CPP-DEFAULT:      float inline_cast_pure(int32_t [[VAL_1:v[0-9]+]]) {
+// CPP-DEFAULT-NEXT:   return (float) [[VAL_1]];
+// CPP-DEFAULT-NEXT: }
+
+// CPP-DECLTOP:      float inline_cast_pure(int32_t [[VAL_1:v[0-9]+]]) {
+// CPP-DECLTOP-NEXT:   return (float) [[VAL_1]];
+// CPP-DECLTOP-NEXT: }
+
+func.func @inline_cast_pure(%arg0: i32) -> f32 {
+  %0 = emitc.expression : f32 {
+    %1 = cast %arg0 {pure} : i32 to f32
+    yield %1 : f32
+  }
+  return %0 : f32
+}
+
+// CPP-DEFAULT:      float do_not_inline_cast_without_pure(int32_t [[VAL_1:v[0-9]+]]) {
+// CPP-DEFAULT-NEXT:   float [[VAL_2:v[0-9]+]] = (float) [[VAL_1]]
+// CPP-DEFAULT-NEXT:   return [[VAL_2]];
+// CPP-DEFAULT-NEXT: }
+
+// CPP-DECLTOP:      float do_not_inline_cast_without_pure(int32_t [[VAL_1:v[0-9]+]]) {
+// CPP-DECLTOP-NEXT:   float [[VAL_2:v[0-9]+]];
+// CPP-DECLTOP-NEXT:   [[VAL_2]] = (float) [[VAL_1]];
+// CPP-DECLTOP-NEXT:   return [[VAL_2]];
+// CPP-DECLTOP-NEXT: }
+
+func.func @do_not_inline_cast_without_pure(%arg0: i32) -> f32 {
+  %0 = emitc.expression : f32 {
+    %1 = cast %arg0 : i32 to f32
+    yield %1 : f32
+  }
+  return %0 : f32
+}
+
 // CPP-DEFAULT:      int32_t parentheses_for_same_precedence(int32_t [[VAL_1:v[0-9]+]], int32_t [[VAL_2:v[0-9]+]], int32_t [[VAL_3:v[0-9]+]]) {
 // CPP-DEFAULT-NEXT:   return [[VAL_3]] / ([[VAL_1]] * [[VAL_2]]);
 // CPP-DEFAULT-NEXT: }

--- a/mlir/test/Target/Cpp/expressions.mlir
+++ b/mlir/test/Target/Cpp/expressions.mlir
@@ -118,7 +118,7 @@ func.func @parentheses_for_low_precedence(%arg0: i32, %arg1: i32, %arg2: i32) ->
 // CPP-DECLTOP-NEXT: }
 
 func.func @inline_cast_pure(%arg0: i32) -> f32 {
-  %0 = emitc.expression : f32 {
+  %0 = emitc.expression %arg0 : (i32) -> f32 {
     %1 = cast %arg0 {pure} : i32 to f32
     yield %1 : f32
   }
@@ -126,7 +126,7 @@ func.func @inline_cast_pure(%arg0: i32) -> f32 {
 }
 
 // CPP-DEFAULT:      float do_not_inline_cast_without_pure(int32_t [[VAL_1:v[0-9]+]]) {
-// CPP-DEFAULT-NEXT:   float [[VAL_2:v[0-9]+]] = (float) [[VAL_1]]
+// CPP-DEFAULT-NEXT:   float [[VAL_2:v[0-9]+]] = (float) [[VAL_1]];
 // CPP-DEFAULT-NEXT:   return [[VAL_2]];
 // CPP-DEFAULT-NEXT: }
 
@@ -137,7 +137,7 @@ func.func @inline_cast_pure(%arg0: i32) -> f32 {
 // CPP-DECLTOP-NEXT: }
 
 func.func @do_not_inline_cast_without_pure(%arg0: i32) -> f32 {
-  %0 = emitc.expression : f32 {
+  %0 = emitc.expression %arg0 : (i32) -> f32 {
     %1 = cast %arg0 : i32 to f32
     yield %1 : f32
   }


### PR DESCRIPTION
When `pure` attribute is set, the cast op is side-effect-free, so we should return false in `hasSideEffects` method.