### PR TITLE
[LegalizeTypes] Improve promotion of variable rotates.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -1635,6 +1635,45 @@ SDValue DAGTypeLegalizer::PromoteIntRes_SRL(SDNode *N) {
 }
 
 SDValue DAGTypeLegalizer::PromoteIntRes_Rotate(SDNode *N) {
+  EVT OldVT = N->getValueType(0);
+  EVT VT = TLI.getTypeToTransformTo(*DAG.getContext(), OldVT);
+  SDValue Amt = N->getOperand(1);
+  unsigned Opcode = N->getOpcode();
+  unsigned OldBits = OldVT.getScalarSizeInBits();
+  unsigned NewBits = VT.getScalarSizeInBits();
+
+  // If the promoted type is twice the size (or more), then we can concatenate
+  // the value with itself and treat this similar to a funnel shift. This isn't
+  // necessary if the rotate amount is constant or if shl/srl of the original
+  // type are custom lowered.
+  // rotl(x,amt) -> (((aext(x) << bw) | zext(x)) << (amt % bw)) >> bw.
+  // rotr(x,amt) -> (((aext(x) << bw) | zext(x)) >> (amt % bw)).
+  if (NewBits >= (2 * OldBits) && !isa<ConstantSDNode>(Amt) &&
+      !TLI.isOperationLegalOrCustom(Opcode, VT) &&
+      TLI.getOperationAction(ISD::SHL, OldVT) != TargetLowering::Custom &&
+      TLI.getOperationAction(ISD::SRL, OldVT) != TargetLowering::Custom) {
+    SDValue Op0 = GetPromotedInteger(N->getOperand(0));
+    if (getTypeAction(Amt.getValueType()) == TargetLowering::TypePromoteInteger)
+      Amt = ZExtPromotedInteger(Amt);
+    EVT AmtVT = Amt.getValueType();
+
+    SDLoc DL(N);
+    // Amount has to be interpreted modulo the old bit width.
+    Amt = DAG.getNode(ISD::UREM, DL, AmtVT, Amt,
+                      DAG.getConstant(OldBits, DL, AmtVT));
+    SDValue HiShift = DAG.getShiftAmountConstant(OldBits, VT, DL);
+    SDValue Hi = DAG.getNode(ISD::SHL, DL, VT, Op0, HiShift);
+    SDValue Lo = DAG.getZeroExtendInReg(Op0, DL, OldVT);
+    SDValue Res = DAG.getNode(ISD::OR, DL, VT, Hi, Lo);
+    bool IsROTR = N->getOpcode() == ISD::ROTR;
+    Res = DAG.getNode(IsROTR ? ISD::SRL : ISD::SHL, DL, VT, Res, Amt);
+    // FIXME: We can avoid this by using ROTL when the promoted type is exactly
+    // twice the size.
+    if (!IsROTR)
+      Res = DAG.getNode(ISD::SRL, DL, VT, Res, HiShift);
+    return Res;
+  }
+
   // Lower the rotate to shifts and ORs which can be promoted.
   SDValue Res = TLI.expandROT(N, true /*AllowVectorOps*/, DAG);
   ReplaceValueWith(SDValue(N, 0), Res);

--- a/llvm/test/CodeGen/AArch64/expand-vector-rot.ll
+++ b/llvm/test/CodeGen/AArch64/expand-vector-rot.ll
@@ -7,15 +7,10 @@ define <2 x i16>  @rotlv2_16(<2 x i16> %vec2_16, <2 x i16> %shift) {
 ; CHECK-LABEL: rotlv2_16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    movi v2.2s, #15
-; CHECK-NEXT:    neg v3.2s, v1.2s
-; CHECK-NEXT:    movi d4, #0x00ffff0000ffff
-; CHECK-NEXT:    and v3.8b, v3.8b, v2.8b
-; CHECK-NEXT:    and v4.8b, v0.8b, v4.8b
+; CHECK-NEXT:    sli v0.2s, v0.2s, #16
 ; CHECK-NEXT:    and v1.8b, v1.8b, v2.8b
-; CHECK-NEXT:    neg v3.2s, v3.2s
 ; CHECK-NEXT:    ushl v0.2s, v0.2s, v1.2s
-; CHECK-NEXT:    ushl v2.2s, v4.2s, v3.2s
-; CHECK-NEXT:    orr v0.8b, v0.8b, v2.8b
+; CHECK-NEXT:    ushr v0.2s, v0.2s, #16
 ; CHECK-NEXT:    ret
   %1 = call <2 x i16> @llvm.fshl.v2i16(<2 x i16> %vec2_16, <2 x i16> %vec2_16, <2 x i16> %shift)
   ret <2 x i16> %1

--- a/llvm/test/CodeGen/AArch64/fsh.ll
+++ b/llvm/test/CodeGen/AArch64/fsh.ll
@@ -5,13 +5,10 @@
 define i8 @rotl_i8(i8 %a, i8 %c) {
 ; CHECK-SD-LABEL: rotl_i8:
 ; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    neg w8, w1
-; CHECK-SD-NEXT:    and w9, w0, #0xff
-; CHECK-SD-NEXT:    and w10, w1, #0x7
-; CHECK-SD-NEXT:    and w8, w8, #0x7
-; CHECK-SD-NEXT:    lsl w10, w0, w10
-; CHECK-SD-NEXT:    lsr w8, w9, w8
-; CHECK-SD-NEXT:    orr w0, w10, w8
+; CHECK-SD-NEXT:    bfi w0, w0, #8, #24
+; CHECK-SD-NEXT:    and w8, w1, #0x7
+; CHECK-SD-NEXT:    lsl w8, w0, w8
+; CHECK-SD-NEXT:    lsr w0, w8, #8
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: rotl_i8:
@@ -63,13 +60,10 @@ entry:
 define i16 @rotl_i16(i16 %a, i16 %c) {
 ; CHECK-SD-LABEL: rotl_i16:
 ; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    neg w8, w1
-; CHECK-SD-NEXT:    and w9, w0, #0xffff
-; CHECK-SD-NEXT:    and w10, w1, #0xf
-; CHECK-SD-NEXT:    and w8, w8, #0xf
-; CHECK-SD-NEXT:    lsl w10, w0, w10
-; CHECK-SD-NEXT:    lsr w8, w9, w8
-; CHECK-SD-NEXT:    orr w0, w10, w8
+; CHECK-SD-NEXT:    bfi w0, w0, #16, #16
+; CHECK-SD-NEXT:    and w8, w1, #0xf
+; CHECK-SD-NEXT:    lsl w8, w0, w8
+; CHECK-SD-NEXT:    lsr w0, w8, #16
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: rotl_i16:

--- a/llvm/test/CodeGen/AArch64/funnel-shift-rot.ll
+++ b/llvm/test/CodeGen/AArch64/funnel-shift-rot.ll
@@ -39,13 +39,10 @@ define i64 @rotl_i64_const_shift(i64 %x) {
 define i16 @rotl_i16(i16 %x, i16 %z) {
 ; CHECK-LABEL: rotl_i16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    neg w8, w1
-; CHECK-NEXT:    and w9, w0, #0xffff
-; CHECK-NEXT:    and w10, w1, #0xf
-; CHECK-NEXT:    and w8, w8, #0xf
-; CHECK-NEXT:    lsl w10, w0, w10
-; CHECK-NEXT:    lsr w8, w9, w8
-; CHECK-NEXT:    orr w0, w10, w8
+; CHECK-NEXT:    bfi w0, w0, #16, #16
+; CHECK-NEXT:    and w8, w1, #0xf
+; CHECK-NEXT:    lsl w8, w0, w8
+; CHECK-NEXT:    lsr w0, w8, #16
 ; CHECK-NEXT:    ret
   %f = call i16 @llvm.fshl.i16(i16 %x, i16 %x, i16 %z)
   ret i16 %f

--- a/llvm/test/CodeGen/AMDGPU/rotl.ll
+++ b/llvm/test/CodeGen/AMDGPU/rotl.ll
@@ -361,34 +361,31 @@ define void @test_rotl_i16(ptr addrspace(1) nocapture readonly %sourceA, ptr add
 ; R600-NEXT:    TEX 0 @8
 ; R600-NEXT:    ALU 0, @13, KC0[CB0:0-32], KC1[]
 ; R600-NEXT:    TEX 0 @10
-; R600-NEXT:    ALU 21, @14, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    ALU 18, @14, KC0[CB0:0-32], KC1[]
 ; R600-NEXT:    MEM_RAT MSKOR T0.XW, T1.X
 ; R600-NEXT:    CF_END
 ; R600-NEXT:    PAD
 ; R600-NEXT:    Fetch clause starting at 8:
-; R600-NEXT:     VTX_READ_16 T0.X, T0.X, 48, #1
+; R600-NEXT:     VTX_READ_16 T0.X, T0.X, 32, #1
 ; R600-NEXT:    Fetch clause starting at 10:
-; R600-NEXT:     VTX_READ_16 T1.X, T1.X, 32, #1
+; R600-NEXT:     VTX_READ_16 T1.X, T1.X, 48, #1
 ; R600-NEXT:    ALU clause starting at 12:
-; R600-NEXT:     MOV * T0.X, KC0[2].Z,
+; R600-NEXT:     MOV * T0.X, KC0[2].Y,
 ; R600-NEXT:    ALU clause starting at 13:
-; R600-NEXT:     MOV * T1.X, KC0[2].Y,
+; R600-NEXT:     MOV * T1.X, KC0[2].Z,
 ; R600-NEXT:    ALU clause starting at 14:
-; R600-NEXT:     SUB_INT T0.W, 0.0, T0.X,
-; R600-NEXT:     AND_INT * T1.W, T0.X, literal.x,
-; R600-NEXT:    15(2.101948e-44), 0(0.000000e+00)
-; R600-NEXT:     AND_INT * T0.W, PV.W, literal.x,
-; R600-NEXT:    15(2.101948e-44), 0(0.000000e+00)
-; R600-NEXT:     LSHR T0.Z, T1.X, PV.W,
-; R600-NEXT:     LSHL T0.W, T1.X, T1.W,
-; R600-NEXT:     ADD_INT * T1.W, KC0[2].W, literal.x,
-; R600-NEXT:    8(1.121039e-44), 0(0.000000e+00)
+; R600-NEXT:     LSHL * T0.W, T0.X, literal.x,
+; R600-NEXT:    16(2.242078e-44), 0(0.000000e+00)
+; R600-NEXT:     OR_INT T0.Z, PV.W, T0.X,
+; R600-NEXT:     AND_INT T0.W, T1.X, literal.x,
+; R600-NEXT:     ADD_INT * T1.W, KC0[2].W, literal.y,
+; R600-NEXT:    15(2.101948e-44), 8(1.121039e-44)
 ; R600-NEXT:     AND_INT T2.W, PS, literal.x,
-; R600-NEXT:     OR_INT * T0.W, PV.W, PV.Z,
+; R600-NEXT:     LSHL * T0.W, PV.Z, PV.W,
 ; R600-NEXT:    3(4.203895e-45), 0(0.000000e+00)
-; R600-NEXT:     AND_INT T0.W, PS, literal.x,
+; R600-NEXT:     LSHR T0.W, PS, literal.x,
 ; R600-NEXT:     LSHL * T2.W, PV.W, literal.y,
-; R600-NEXT:    65535(9.183409e-41), 3(4.203895e-45)
+; R600-NEXT:    16(2.242078e-44), 3(4.203895e-45)
 ; R600-NEXT:     LSHL T0.X, PV.W, PS,
 ; R600-NEXT:     LSHL * T0.W, literal.x, PS,
 ; R600-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
@@ -404,16 +401,15 @@ define void @test_rotl_i16(ptr addrspace(1) nocapture readonly %sourceA, ptr add
 ; SI-NEXT:    s_mov_b32 s7, 0xf000
 ; SI-NEXT:    s_mov_b32 s4, s6
 ; SI-NEXT:    s_mov_b32 s5, s6
-; SI-NEXT:    buffer_load_ushort v2, v[2:3], s[4:7], 0 addr64 offset:48
 ; SI-NEXT:    buffer_load_ushort v0, v[0:1], s[4:7], 0 addr64 offset:32
+; SI-NEXT:    buffer_load_ushort v1, v[2:3], s[4:7], 0 addr64 offset:48
 ; SI-NEXT:    s_waitcnt vmcnt(1)
-; SI-NEXT:    v_and_b32_e32 v1, 15, v2
-; SI-NEXT:    v_sub_i32_e32 v2, vcc, 0, v2
-; SI-NEXT:    v_and_b32_e32 v2, 15, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v0
+; SI-NEXT:    v_or_b32_e32 v0, v2, v0
 ; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_lshlrev_b32_e32 v1, v1, v0
-; SI-NEXT:    v_lshrrev_b32_e32 v0, v2, v0
-; SI-NEXT:    v_or_b32_e32 v0, v1, v0
+; SI-NEXT:    v_and_b32_e32 v1, 15, v1
+; SI-NEXT:    v_lshlrev_b32_e32 v0, v1, v0
+; SI-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
 ; SI-NEXT:    buffer_store_short v0, v[4:5], s[4:7], 0 addr64 offset:8
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/AMDGPU/rotr.ll
+++ b/llvm/test/CodeGen/AMDGPU/rotr.ll
@@ -537,34 +537,29 @@ define void @test_rotr_i16(ptr addrspace(1) nocapture readonly %sourceA, ptr add
 ; R600-NEXT:    TEX 0 @8
 ; R600-NEXT:    ALU 0, @13, KC0[CB0:0-32], KC1[]
 ; R600-NEXT:    TEX 0 @10
-; R600-NEXT:    ALU 21, @14, KC0[CB0:0-32], KC1[]
+; R600-NEXT:    ALU 16, @14, KC0[CB0:0-32], KC1[]
 ; R600-NEXT:    MEM_RAT MSKOR T0.XW, T1.X
 ; R600-NEXT:    CF_END
 ; R600-NEXT:    PAD
 ; R600-NEXT:    Fetch clause starting at 8:
-; R600-NEXT:     VTX_READ_16 T0.X, T0.X, 48, #1
+; R600-NEXT:     VTX_READ_16 T0.X, T0.X, 32, #1
 ; R600-NEXT:    Fetch clause starting at 10:
-; R600-NEXT:     VTX_READ_16 T1.X, T1.X, 32, #1
+; R600-NEXT:     VTX_READ_16 T1.X, T1.X, 48, #1
 ; R600-NEXT:    ALU clause starting at 12:
-; R600-NEXT:     MOV * T0.X, KC0[2].Z,
+; R600-NEXT:     MOV * T0.X, KC0[2].Y,
 ; R600-NEXT:    ALU clause starting at 13:
-; R600-NEXT:     MOV * T1.X, KC0[2].Y,
+; R600-NEXT:     MOV * T1.X, KC0[2].Z,
 ; R600-NEXT:    ALU clause starting at 14:
-; R600-NEXT:     SUB_INT T0.W, 0.0, T0.X,
-; R600-NEXT:     AND_INT * T1.W, T0.X, literal.x,
-; R600-NEXT:    15(2.101948e-44), 0(0.000000e+00)
-; R600-NEXT:     AND_INT * T0.W, PV.W, literal.x,
-; R600-NEXT:    15(2.101948e-44), 0(0.000000e+00)
-; R600-NEXT:     LSHL T0.Z, T1.X, PV.W,
-; R600-NEXT:     LSHR T0.W, T1.X, T1.W,
-; R600-NEXT:     ADD_INT * T1.W, KC0[2].W, literal.x,
-; R600-NEXT:    8(1.121039e-44), 0(0.000000e+00)
-; R600-NEXT:     AND_INT T2.W, PS, literal.x,
-; R600-NEXT:     OR_INT * T0.W, PV.W, PV.Z,
-; R600-NEXT:    3(4.203895e-45), 0(0.000000e+00)
-; R600-NEXT:     AND_INT T0.W, PS, literal.x,
-; R600-NEXT:     LSHL * T2.W, PV.W, literal.y,
-; R600-NEXT:    65535(9.183409e-41), 3(4.203895e-45)
+; R600-NEXT:     LSHL T0.W, T0.X, literal.x,
+; R600-NEXT:     ADD_INT * T1.W, KC0[2].W, literal.y,
+; R600-NEXT:    16(2.242078e-44), 8(1.121039e-44)
+; R600-NEXT:     AND_INT T0.Z, PS, literal.x,
+; R600-NEXT:     OR_INT T0.W, PV.W, T0.X,
+; R600-NEXT:     AND_INT * T2.W, T1.X, literal.y,
+; R600-NEXT:    3(4.203895e-45), 15(2.101948e-44)
+; R600-NEXT:     BFE_UINT T0.W, PV.W, PS, literal.x,
+; R600-NEXT:     LSHL * T2.W, PV.Z, literal.y,
+; R600-NEXT:    16(2.242078e-44), 3(4.203895e-45)
 ; R600-NEXT:     LSHL T0.X, PV.W, PS,
 ; R600-NEXT:     LSHL * T0.W, literal.x, PS,
 ; R600-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
@@ -580,16 +575,14 @@ define void @test_rotr_i16(ptr addrspace(1) nocapture readonly %sourceA, ptr add
 ; SI-NEXT:    s_mov_b32 s7, 0xf000
 ; SI-NEXT:    s_mov_b32 s4, s6
 ; SI-NEXT:    s_mov_b32 s5, s6
-; SI-NEXT:    buffer_load_ushort v2, v[2:3], s[4:7], 0 addr64 offset:48
 ; SI-NEXT:    buffer_load_ushort v0, v[0:1], s[4:7], 0 addr64 offset:32
+; SI-NEXT:    buffer_load_ushort v1, v[2:3], s[4:7], 0 addr64 offset:48
 ; SI-NEXT:    s_waitcnt vmcnt(1)
-; SI-NEXT:    v_and_b32_e32 v1, 15, v2
-; SI-NEXT:    v_sub_i32_e32 v2, vcc, 0, v2
-; SI-NEXT:    v_and_b32_e32 v2, 15, v2
+; SI-NEXT:    v_lshlrev_b32_e32 v2, 16, v0
+; SI-NEXT:    v_or_b32_e32 v0, v2, v0
 ; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v1, v1, v0
-; SI-NEXT:    v_lshlrev_b32_e32 v0, v2, v0
-; SI-NEXT:    v_or_b32_e32 v0, v1, v0
+; SI-NEXT:    v_and_b32_e32 v1, 15, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v0, v1, v0
 ; SI-NEXT:    buffer_store_short v0, v[4:5], s[4:7], 0 addr64 offset:8
 ; SI-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; SI-NEXT:    s_setpc_b64 s[30:31]

--- a/llvm/test/CodeGen/ARM/funnel-shift-rot.ll
+++ b/llvm/test/CodeGen/ARM/funnel-shift-rot.ll
@@ -45,12 +45,10 @@ define i64 @rotl_i64_const_shift(i64 %x) {
 define i16 @rotl_i16(i16 %x, i16 %z) {
 ; CHECK-LABEL: rotl_i16:
 ; CHECK:       @ %bb.0:
-; CHECK-NEXT:    and r2, r1, #15
-; CHECK-NEXT:    rsb r1, r1, #0
 ; CHECK-NEXT:    and r1, r1, #15
-; CHECK-NEXT:    lsl r2, r0, r2
-; CHECK-NEXT:    uxth r0, r0
-; CHECK-NEXT:    orr r0, r2, r0, lsr r1
+; CHECK-NEXT:    pkhbt r0, r0, r0, lsl #16
+; CHECK-NEXT:    lsl r0, r0, r1
+; CHECK-NEXT:    lsr r0, r0, #16
 ; CHECK-NEXT:    bx lr
   %f = call i16 @llvm.fshl.i16(i16 %x, i16 %x, i16 %z)
   ret i16 %f

--- a/llvm/test/CodeGen/Mips/funnel-shift-rot.ll
+++ b/llvm/test/CodeGen/Mips/funnel-shift-rot.ll
@@ -47,14 +47,13 @@ define i64 @rotl_i64_const_shift(i64 %x) {
 define i16 @rotl_i16(i16 %x, i16 %z) {
 ; CHECK-LABEL: rotl_i16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi $1, $5, 15
-; CHECK-NEXT:    sllv $1, $4, $1
-; CHECK-NEXT:    negu $2, $5
-; CHECK-NEXT:    andi $2, $2, 15
-; CHECK-NEXT:    andi $3, $4, 65535
-; CHECK-NEXT:    srlv $2, $3, $2
+; CHECK-NEXT:    andi $1, $4, 65535
+; CHECK-NEXT:    sll $2, $4, 16
+; CHECK-NEXT:    or $1, $2, $1
+; CHECK-NEXT:    andi $2, $5, 15
+; CHECK-NEXT:    sllv $1, $1, $2
 ; CHECK-NEXT:    jr $ra
-; CHECK-NEXT:    or $2, $1, $2
+; CHECK-NEXT:    srl $2, $1, 16
   %f = call i16 @llvm.fshl.i16(i16 %x, i16 %x, i16 %z)
   ret i16 %f
 }
@@ -195,14 +194,12 @@ define i32 @rotr_i32_const_shift(i32 %x) {
 define i16 @rotr_i16(i16 %x, i16 %z) {
 ; CHECK-LABEL: rotr_i16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi $1, $5, 15
-; CHECK-NEXT:    andi $2, $4, 65535
-; CHECK-NEXT:    srlv $1, $2, $1
-; CHECK-NEXT:    negu $2, $5
-; CHECK-NEXT:    andi $2, $2, 15
-; CHECK-NEXT:    sllv $2, $4, $2
+; CHECK-NEXT:    andi $1, $4, 65535
+; CHECK-NEXT:    sll $2, $4, 16
+; CHECK-NEXT:    or $1, $2, $1
+; CHECK-NEXT:    andi $2, $5, 15
 ; CHECK-NEXT:    jr $ra
-; CHECK-NEXT:    or $2, $1, $2
+; CHECK-NEXT:    srlv $2, $1, $2
   %f = call i16 @llvm.fshr.i16(i16 %x, i16 %x, i16 %z)
   ret i16 %f
 }

--- a/llvm/test/CodeGen/PowerPC/funnel-shift-rot.ll
+++ b/llvm/test/CodeGen/PowerPC/funnel-shift-rot.ll
@@ -238,24 +238,16 @@ define i32 @rotr_i32_const_shift(i32 %x) {
 define i16 @rotr_i16(i16 %x, i16 %z) {
 ; CHECK-LABEL: rotr_i16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    clrlwi 6, 4, 28
-; CHECK-NEXT:    neg 4, 4
-; CHECK-NEXT:    clrlwi 5, 3, 16
 ; CHECK-NEXT:    clrlwi 4, 4, 28
-; CHECK-NEXT:    srw 5, 5, 6
-; CHECK-NEXT:    slw 3, 3, 4
-; CHECK-NEXT:    or 3, 5, 3
+; CHECK-NEXT:    rlwimi 3, 3, 16, 0, 15
+; CHECK-NEXT:    srw 3, 3, 4
 ; CHECK-NEXT:    blr
 ;
 ; FUTURE-LABEL: rotr_i16:
 ; FUTURE:       # %bb.0:
-; FUTURE-NEXT:    clrlwi 6, 4, 28
-; FUTURE-NEXT:    neg 4, 4
-; FUTURE-NEXT:    clrlwi 5, 3, 16
 ; FUTURE-NEXT:    clrlwi 4, 4, 28
-; FUTURE-NEXT:    srw 5, 5, 6
-; FUTURE-NEXT:    slw 3, 3, 4
-; FUTURE-NEXT:    or 3, 5, 3
+; FUTURE-NEXT:    rlwimi 3, 3, 16, 0, 15
+; FUTURE-NEXT:    srw 3, 3, 4
 ; FUTURE-NEXT:    blr
   %f = call i16 @llvm.fshr.i16(i16 %x, i16 %x, i16 %z)
   ret i16 %f

--- a/llvm/test/CodeGen/PowerPC/urem-seteq-illegal-types.ll
+++ b/llvm/test/CodeGen/PowerPC/urem-seteq-illegal-types.ll
@@ -158,6 +158,7 @@ define <3 x i1> @test_urem_vec(<3 x i11> %X) nounwind {
 ; PPC64LE-NEXT:    addi 3, 3, .LCPI4_0@toc@l
 ; PPC64LE-NEXT:    mtvsrwz 36, 5
 ; PPC64LE-NEXT:    vspltisw 5, -11
+; PPC64LE-NEXT:    vspltisw 0, 11
 ; PPC64LE-NEXT:    lxvd2x 2, 0, 3
 ; PPC64LE-NEXT:    addis 3, 2, .LCPI4_1@toc@ha
 ; PPC64LE-NEXT:    addi 3, 3, .LCPI4_1@toc@l
@@ -172,24 +173,20 @@ define <3 x i1> @test_urem_vec(<3 x i11> %X) nounwind {
 ; PPC64LE-NEXT:    addis 3, 2, .LCPI4_3@toc@ha
 ; PPC64LE-NEXT:    addi 3, 3, .LCPI4_3@toc@l
 ; PPC64LE-NEXT:    vsubuwm 2, 2, 3
+; PPC64LE-NEXT:    vsrw 3, 5, 5
 ; PPC64LE-NEXT:    xxswapd 36, 0
 ; PPC64LE-NEXT:    lxvd2x 0, 0, 3
 ; PPC64LE-NEXT:    addis 3, 2, .LCPI4_4@toc@ha
 ; PPC64LE-NEXT:    addi 3, 3, .LCPI4_4@toc@l
 ; PPC64LE-NEXT:    vmuluwm 2, 2, 4
-; PPC64LE-NEXT:    vsrw 4, 5, 5
-; PPC64LE-NEXT:    xxswapd 32, 0
-; PPC64LE-NEXT:    lxvd2x 0, 0, 3
-; PPC64LE-NEXT:    addis 3, 2, .LCPI4_5@toc@ha
-; PPC64LE-NEXT:    addi 3, 3, .LCPI4_5@toc@l
-; PPC64LE-NEXT:    vslw 3, 2, 0
-; PPC64LE-NEXT:    xxland 34, 34, 36
 ; PPC64LE-NEXT:    xxswapd 33, 0
 ; PPC64LE-NEXT:    lxvd2x 0, 0, 3
-; PPC64LE-NEXT:    vsrw 2, 2, 1
 ; PPC64LE-NEXT:    xxswapd 38, 0
-; PPC64LE-NEXT:    xxlor 0, 34, 35
-; PPC64LE-NEXT:    xxland 34, 0, 36
+; PPC64LE-NEXT:    xxland 0, 34, 35
+; PPC64LE-NEXT:    vslw 2, 2, 0
+; PPC64LE-NEXT:    xxlor 34, 34, 0
+; PPC64LE-NEXT:    vsrw 2, 2, 1
+; PPC64LE-NEXT:    xxland 34, 34, 35
 ; PPC64LE-NEXT:    vcmpgtuw 2, 2, 6
 ; PPC64LE-NEXT:    mfvsrwz 5, 34
 ; PPC64LE-NEXT:    xxswapd 0, 34

--- a/llvm/test/CodeGen/RISCV/rotl-rotr.ll
+++ b/llvm/test/CodeGen/RISCV/rotl-rotr.ll
@@ -2605,3 +2605,287 @@ define i64 @rotr_64_zext(i64 %x, i32 %y) nounwind {
   %d = or i64 %b, %c
   ret i64 %d
 }
+
+define i8 @rotr_i8(i8 %x, i8 %z) {
+; RV32I-LABEL: rotr_i8:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    zext.b a2, a0
+; RV32I-NEXT:    neg a3, a1
+; RV32I-NEXT:    andi a1, a1, 7
+; RV32I-NEXT:    andi a3, a3, 7
+; RV32I-NEXT:    srl a1, a2, a1
+; RV32I-NEXT:    sll a0, a0, a3
+; RV32I-NEXT:    or a0, a1, a0
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: rotr_i8:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    zext.b a2, a0
+; RV64I-NEXT:    neg a3, a1
+; RV64I-NEXT:    andi a1, a1, 7
+; RV64I-NEXT:    andi a3, a3, 7
+; RV64I-NEXT:    srl a1, a2, a1
+; RV64I-NEXT:    sll a0, a0, a3
+; RV64I-NEXT:    or a0, a1, a0
+; RV64I-NEXT:    ret
+;
+; RV32ZBB-LABEL: rotr_i8:
+; RV32ZBB:       # %bb.0:
+; RV32ZBB-NEXT:    zext.b a2, a0
+; RV32ZBB-NEXT:    neg a3, a1
+; RV32ZBB-NEXT:    andi a1, a1, 7
+; RV32ZBB-NEXT:    andi a3, a3, 7
+; RV32ZBB-NEXT:    srl a1, a2, a1
+; RV32ZBB-NEXT:    sll a0, a0, a3
+; RV32ZBB-NEXT:    or a0, a1, a0
+; RV32ZBB-NEXT:    ret
+;
+; RV64ZBB-LABEL: rotr_i8:
+; RV64ZBB:       # %bb.0:
+; RV64ZBB-NEXT:    zext.b a2, a0
+; RV64ZBB-NEXT:    neg a3, a1
+; RV64ZBB-NEXT:    andi a1, a1, 7
+; RV64ZBB-NEXT:    andi a3, a3, 7
+; RV64ZBB-NEXT:    srl a1, a2, a1
+; RV64ZBB-NEXT:    sll a0, a0, a3
+; RV64ZBB-NEXT:    or a0, a1, a0
+; RV64ZBB-NEXT:    ret
+;
+; RV32XTHEADBB-LABEL: rotr_i8:
+; RV32XTHEADBB:       # %bb.0:
+; RV32XTHEADBB-NEXT:    zext.b a2, a0
+; RV32XTHEADBB-NEXT:    neg a3, a1
+; RV32XTHEADBB-NEXT:    andi a1, a1, 7
+; RV32XTHEADBB-NEXT:    andi a3, a3, 7
+; RV32XTHEADBB-NEXT:    srl a1, a2, a1
+; RV32XTHEADBB-NEXT:    sll a0, a0, a3
+; RV32XTHEADBB-NEXT:    or a0, a1, a0
+; RV32XTHEADBB-NEXT:    ret
+;
+; RV64XTHEADBB-LABEL: rotr_i8:
+; RV64XTHEADBB:       # %bb.0:
+; RV64XTHEADBB-NEXT:    zext.b a2, a0
+; RV64XTHEADBB-NEXT:    neg a3, a1
+; RV64XTHEADBB-NEXT:    andi a1, a1, 7
+; RV64XTHEADBB-NEXT:    andi a3, a3, 7
+; RV64XTHEADBB-NEXT:    srl a1, a2, a1
+; RV64XTHEADBB-NEXT:    sll a0, a0, a3
+; RV64XTHEADBB-NEXT:    or a0, a1, a0
+; RV64XTHEADBB-NEXT:    ret
+  %f = call i8 @llvm.fshr.i8(i8 %x, i8 %x, i8 %z)
+  ret i8 %f
+}
+
+define i16 @rotr_i16(i16 %x, i16 %z) {
+; RV32I-LABEL: rotr_i16:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    slli a2, a0, 16
+; RV32I-NEXT:    neg a3, a1
+; RV32I-NEXT:    srli a2, a2, 16
+; RV32I-NEXT:    andi a3, a3, 15
+; RV32I-NEXT:    andi a1, a1, 15
+; RV32I-NEXT:    sll a0, a0, a3
+; RV32I-NEXT:    srl a1, a2, a1
+; RV32I-NEXT:    or a0, a1, a0
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: rotr_i16:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    slli a2, a0, 48
+; RV64I-NEXT:    neg a3, a1
+; RV64I-NEXT:    srli a2, a2, 48
+; RV64I-NEXT:    andi a3, a3, 15
+; RV64I-NEXT:    andi a1, a1, 15
+; RV64I-NEXT:    sll a0, a0, a3
+; RV64I-NEXT:    srl a1, a2, a1
+; RV64I-NEXT:    or a0, a1, a0
+; RV64I-NEXT:    ret
+;
+; RV32ZBB-LABEL: rotr_i16:
+; RV32ZBB:       # %bb.0:
+; RV32ZBB-NEXT:    zext.h a2, a0
+; RV32ZBB-NEXT:    neg a3, a1
+; RV32ZBB-NEXT:    andi a1, a1, 15
+; RV32ZBB-NEXT:    andi a3, a3, 15
+; RV32ZBB-NEXT:    srl a1, a2, a1
+; RV32ZBB-NEXT:    sll a0, a0, a3
+; RV32ZBB-NEXT:    or a0, a1, a0
+; RV32ZBB-NEXT:    ret
+;
+; RV64ZBB-LABEL: rotr_i16:
+; RV64ZBB:       # %bb.0:
+; RV64ZBB-NEXT:    zext.h a2, a0
+; RV64ZBB-NEXT:    neg a3, a1
+; RV64ZBB-NEXT:    andi a1, a1, 15
+; RV64ZBB-NEXT:    andi a3, a3, 15
+; RV64ZBB-NEXT:    srl a1, a2, a1
+; RV64ZBB-NEXT:    sll a0, a0, a3
+; RV64ZBB-NEXT:    or a0, a1, a0
+; RV64ZBB-NEXT:    ret
+;
+; RV32XTHEADBB-LABEL: rotr_i16:
+; RV32XTHEADBB:       # %bb.0:
+; RV32XTHEADBB-NEXT:    th.extu a2, a0, 15, 0
+; RV32XTHEADBB-NEXT:    neg a3, a1
+; RV32XTHEADBB-NEXT:    andi a1, a1, 15
+; RV32XTHEADBB-NEXT:    andi a3, a3, 15
+; RV32XTHEADBB-NEXT:    srl a1, a2, a1
+; RV32XTHEADBB-NEXT:    sll a0, a0, a3
+; RV32XTHEADBB-NEXT:    or a0, a1, a0
+; RV32XTHEADBB-NEXT:    ret
+;
+; RV64XTHEADBB-LABEL: rotr_i16:
+; RV64XTHEADBB:       # %bb.0:
+; RV64XTHEADBB-NEXT:    th.extu a2, a0, 15, 0
+; RV64XTHEADBB-NEXT:    neg a3, a1
+; RV64XTHEADBB-NEXT:    andi a1, a1, 15
+; RV64XTHEADBB-NEXT:    andi a3, a3, 15
+; RV64XTHEADBB-NEXT:    srl a1, a2, a1
+; RV64XTHEADBB-NEXT:    sll a0, a0, a3
+; RV64XTHEADBB-NEXT:    or a0, a1, a0
+; RV64XTHEADBB-NEXT:    ret
+  %f = call i16 @llvm.fshr.i16(i16 %x, i16 %x, i16 %z)
+  ret i16 %f
+}
+
+define i8 @rotl_i8(i8 %x, i8 %z) {
+; RV32I-LABEL: rotl_i8:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    zext.b a2, a0
+; RV32I-NEXT:    neg a3, a1
+; RV32I-NEXT:    andi a1, a1, 7
+; RV32I-NEXT:    andi a3, a3, 7
+; RV32I-NEXT:    sll a0, a0, a1
+; RV32I-NEXT:    srl a1, a2, a3
+; RV32I-NEXT:    or a0, a0, a1
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: rotl_i8:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    zext.b a2, a0
+; RV64I-NEXT:    neg a3, a1
+; RV64I-NEXT:    andi a1, a1, 7
+; RV64I-NEXT:    andi a3, a3, 7
+; RV64I-NEXT:    sll a0, a0, a1
+; RV64I-NEXT:    srl a1, a2, a3
+; RV64I-NEXT:    or a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV32ZBB-LABEL: rotl_i8:
+; RV32ZBB:       # %bb.0:
+; RV32ZBB-NEXT:    zext.b a2, a0
+; RV32ZBB-NEXT:    neg a3, a1
+; RV32ZBB-NEXT:    andi a1, a1, 7
+; RV32ZBB-NEXT:    andi a3, a3, 7
+; RV32ZBB-NEXT:    sll a0, a0, a1
+; RV32ZBB-NEXT:    srl a1, a2, a3
+; RV32ZBB-NEXT:    or a0, a0, a1
+; RV32ZBB-NEXT:    ret
+;
+; RV64ZBB-LABEL: rotl_i8:
+; RV64ZBB:       # %bb.0:
+; RV64ZBB-NEXT:    zext.b a2, a0
+; RV64ZBB-NEXT:    neg a3, a1
+; RV64ZBB-NEXT:    andi a1, a1, 7
+; RV64ZBB-NEXT:    andi a3, a3, 7
+; RV64ZBB-NEXT:    sll a0, a0, a1
+; RV64ZBB-NEXT:    srl a1, a2, a3
+; RV64ZBB-NEXT:    or a0, a0, a1
+; RV64ZBB-NEXT:    ret
+;
+; RV32XTHEADBB-LABEL: rotl_i8:
+; RV32XTHEADBB:       # %bb.0:
+; RV32XTHEADBB-NEXT:    zext.b a2, a0
+; RV32XTHEADBB-NEXT:    neg a3, a1
+; RV32XTHEADBB-NEXT:    andi a1, a1, 7
+; RV32XTHEADBB-NEXT:    andi a3, a3, 7
+; RV32XTHEADBB-NEXT:    sll a0, a0, a1
+; RV32XTHEADBB-NEXT:    srl a1, a2, a3
+; RV32XTHEADBB-NEXT:    or a0, a0, a1
+; RV32XTHEADBB-NEXT:    ret
+;
+; RV64XTHEADBB-LABEL: rotl_i8:
+; RV64XTHEADBB:       # %bb.0:
+; RV64XTHEADBB-NEXT:    zext.b a2, a0
+; RV64XTHEADBB-NEXT:    neg a3, a1
+; RV64XTHEADBB-NEXT:    andi a1, a1, 7
+; RV64XTHEADBB-NEXT:    andi a3, a3, 7
+; RV64XTHEADBB-NEXT:    sll a0, a0, a1
+; RV64XTHEADBB-NEXT:    srl a1, a2, a3
+; RV64XTHEADBB-NEXT:    or a0, a0, a1
+; RV64XTHEADBB-NEXT:    ret
+  %f = call i8 @llvm.fshl.i8(i8 %x, i8 %x, i8 %z)
+  ret i8 %f
+}
+
+define i16 @rotl_i16(i16 %x, i16 %z) {
+; RV32I-LABEL: rotl_i16:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    slli a2, a0, 16
+; RV32I-NEXT:    neg a3, a1
+; RV32I-NEXT:    srli a2, a2, 16
+; RV32I-NEXT:    andi a1, a1, 15
+; RV32I-NEXT:    andi a3, a3, 15
+; RV32I-NEXT:    sll a0, a0, a1
+; RV32I-NEXT:    srl a1, a2, a3
+; RV32I-NEXT:    or a0, a0, a1
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: rotl_i16:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    slli a2, a0, 48
+; RV64I-NEXT:    neg a3, a1
+; RV64I-NEXT:    srli a2, a2, 48
+; RV64I-NEXT:    andi a1, a1, 15
+; RV64I-NEXT:    andi a3, a3, 15
+; RV64I-NEXT:    sll a0, a0, a1
+; RV64I-NEXT:    srl a1, a2, a3
+; RV64I-NEXT:    or a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV32ZBB-LABEL: rotl_i16:
+; RV32ZBB:       # %bb.0:
+; RV32ZBB-NEXT:    zext.h a2, a0
+; RV32ZBB-NEXT:    neg a3, a1
+; RV32ZBB-NEXT:    andi a1, a1, 15
+; RV32ZBB-NEXT:    andi a3, a3, 15
+; RV32ZBB-NEXT:    sll a0, a0, a1
+; RV32ZBB-NEXT:    srl a1, a2, a3
+; RV32ZBB-NEXT:    or a0, a0, a1
+; RV32ZBB-NEXT:    ret
+;
+; RV64ZBB-LABEL: rotl_i16:
+; RV64ZBB:       # %bb.0:
+; RV64ZBB-NEXT:    zext.h a2, a0
+; RV64ZBB-NEXT:    neg a3, a1
+; RV64ZBB-NEXT:    andi a1, a1, 15
+; RV64ZBB-NEXT:    andi a3, a3, 15
+; RV64ZBB-NEXT:    sll a0, a0, a1
+; RV64ZBB-NEXT:    srl a1, a2, a3
+; RV64ZBB-NEXT:    or a0, a0, a1
+; RV64ZBB-NEXT:    ret
+;
+; RV32XTHEADBB-LABEL: rotl_i16:
+; RV32XTHEADBB:       # %bb.0:
+; RV32XTHEADBB-NEXT:    th.extu a2, a0, 15, 0
+; RV32XTHEADBB-NEXT:    neg a3, a1
+; RV32XTHEADBB-NEXT:    andi a1, a1, 15
+; RV32XTHEADBB-NEXT:    andi a3, a3, 15
+; RV32XTHEADBB-NEXT:    sll a0, a0, a1
+; RV32XTHEADBB-NEXT:    srl a1, a2, a3
+; RV32XTHEADBB-NEXT:    or a0, a0, a1
+; RV32XTHEADBB-NEXT:    ret
+;
+; RV64XTHEADBB-LABEL: rotl_i16:
+; RV64XTHEADBB:       # %bb.0:
+; RV64XTHEADBB-NEXT:    th.extu a2, a0, 15, 0
+; RV64XTHEADBB-NEXT:    neg a3, a1
+; RV64XTHEADBB-NEXT:    andi a1, a1, 15
+; RV64XTHEADBB-NEXT:    andi a3, a3, 15
+; RV64XTHEADBB-NEXT:    sll a0, a0, a1
+; RV64XTHEADBB-NEXT:    srl a1, a2, a3
+; RV64XTHEADBB-NEXT:    or a0, a0, a1
+; RV64XTHEADBB-NEXT:    ret
+  %f = call i16 @llvm.fshl.i16(i16 %x, i16 %x, i16 %z)
+  ret i16 %f
+}

--- a/llvm/test/CodeGen/RISCV/rotl-rotr.ll
+++ b/llvm/test/CodeGen/RISCV/rotl-rotr.ll
@@ -2610,23 +2610,19 @@ define i8 @rotr_i8(i8 %x, i8 %z) {
 ; RV32I-LABEL: rotr_i8:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    zext.b a2, a0
-; RV32I-NEXT:    neg a3, a1
+; RV32I-NEXT:    slli a0, a0, 8
+; RV32I-NEXT:    or a0, a0, a2
 ; RV32I-NEXT:    andi a1, a1, 7
-; RV32I-NEXT:    andi a3, a3, 7
-; RV32I-NEXT:    srl a1, a2, a1
-; RV32I-NEXT:    sll a0, a0, a3
-; RV32I-NEXT:    or a0, a1, a0
+; RV32I-NEXT:    srl a0, a0, a1
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: rotr_i8:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    zext.b a2, a0
-; RV64I-NEXT:    neg a3, a1
+; RV64I-NEXT:    slli a0, a0, 8
+; RV64I-NEXT:    or a0, a0, a2
 ; RV64I-NEXT:    andi a1, a1, 7
-; RV64I-NEXT:    andi a3, a3, 7
-; RV64I-NEXT:    srl a1, a2, a1
-; RV64I-NEXT:    sll a0, a0, a3
-; RV64I-NEXT:    or a0, a1, a0
+; RV64I-NEXT:    srl a0, a0, a1
 ; RV64I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: rotr_i8:
@@ -2679,26 +2675,21 @@ define i8 @rotr_i8(i8 %x, i8 %z) {
 define i16 @rotr_i16(i16 %x, i16 %z) {
 ; RV32I-LABEL: rotr_i16:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    slli a2, a0, 16
-; RV32I-NEXT:    neg a3, a1
-; RV32I-NEXT:    srli a2, a2, 16
-; RV32I-NEXT:    andi a3, a3, 15
+; RV32I-NEXT:    slli a0, a0, 16
+; RV32I-NEXT:    srli a2, a0, 16
+; RV32I-NEXT:    or a0, a0, a2
 ; RV32I-NEXT:    andi a1, a1, 15
-; RV32I-NEXT:    sll a0, a0, a3
-; RV32I-NEXT:    srl a1, a2, a1
-; RV32I-NEXT:    or a0, a1, a0
+; RV32I-NEXT:    srl a0, a0, a1
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: rotr_i16:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    slli a2, a0, 48
-; RV64I-NEXT:    neg a3, a1
+; RV64I-NEXT:    slli a0, a0, 16
 ; RV64I-NEXT:    srli a2, a2, 48
-; RV64I-NEXT:    andi a3, a3, 15
+; RV64I-NEXT:    or a0, a0, a2
 ; RV64I-NEXT:    andi a1, a1, 15
-; RV64I-NEXT:    sll a0, a0, a3
-; RV64I-NEXT:    srl a1, a2, a1
-; RV64I-NEXT:    or a0, a1, a0
+; RV64I-NEXT:    srl a0, a0, a1
 ; RV64I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: rotr_i16:
@@ -2752,23 +2743,21 @@ define i8 @rotl_i8(i8 %x, i8 %z) {
 ; RV32I-LABEL: rotl_i8:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    zext.b a2, a0
-; RV32I-NEXT:    neg a3, a1
+; RV32I-NEXT:    slli a0, a0, 8
+; RV32I-NEXT:    or a0, a0, a2
 ; RV32I-NEXT:    andi a1, a1, 7
-; RV32I-NEXT:    andi a3, a3, 7
 ; RV32I-NEXT:    sll a0, a0, a1
-; RV32I-NEXT:    srl a1, a2, a3
-; RV32I-NEXT:    or a0, a0, a1
+; RV32I-NEXT:    srli a0, a0, 8
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: rotl_i8:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    zext.b a2, a0
-; RV64I-NEXT:    neg a3, a1
+; RV64I-NEXT:    slli a0, a0, 8
+; RV64I-NEXT:    or a0, a0, a2
 ; RV64I-NEXT:    andi a1, a1, 7
-; RV64I-NEXT:    andi a3, a3, 7
 ; RV64I-NEXT:    sll a0, a0, a1
-; RV64I-NEXT:    srl a1, a2, a3
-; RV64I-NEXT:    or a0, a0, a1
+; RV64I-NEXT:    srli a0, a0, 8
 ; RV64I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: rotl_i8:
@@ -2821,26 +2810,23 @@ define i8 @rotl_i8(i8 %x, i8 %z) {
 define i16 @rotl_i16(i16 %x, i16 %z) {
 ; RV32I-LABEL: rotl_i16:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    slli a2, a0, 16
-; RV32I-NEXT:    neg a3, a1
-; RV32I-NEXT:    srli a2, a2, 16
+; RV32I-NEXT:    slli a0, a0, 16
+; RV32I-NEXT:    srli a2, a0, 16
+; RV32I-NEXT:    or a0, a0, a2
 ; RV32I-NEXT:    andi a1, a1, 15
-; RV32I-NEXT:    andi a3, a3, 15
 ; RV32I-NEXT:    sll a0, a0, a1
-; RV32I-NEXT:    srl a1, a2, a3
-; RV32I-NEXT:    or a0, a0, a1
+; RV32I-NEXT:    srli a0, a0, 16
 ; RV32I-NEXT:    ret
 ;
 ; RV64I-LABEL: rotl_i16:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    slli a2, a0, 48
-; RV64I-NEXT:    neg a3, a1
+; RV64I-NEXT:    slli a0, a0, 16
 ; RV64I-NEXT:    srli a2, a2, 48
+; RV64I-NEXT:    or a0, a0, a2
 ; RV64I-NEXT:    andi a1, a1, 15
-; RV64I-NEXT:    andi a3, a3, 15
 ; RV64I-NEXT:    sll a0, a0, a1
-; RV64I-NEXT:    srl a1, a2, a3
-; RV64I-NEXT:    or a0, a0, a1
+; RV64I-NEXT:    srli a0, a0, 16
 ; RV64I-NEXT:    ret
 ;
 ; RV32ZBB-LABEL: rotl_i16:


### PR DESCRIPTION
If the promoted type is at least 2x the original type, we can
concat the value with itself into the promoted bits and use a
shl/srl. This is easier than negating the shift amount for the
(or (shl), (srl)) expansion. This is what we do for promoting
funnel shifts and really a rotate is a special case of funnel shift.