### PR TITLE
[Hexagon] Add S2_pstorerf{t,f}_io to isValidOffset (PR196966)

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
@@ -2961,6 +2961,8 @@ bool HexagonInstrInfo::isValidOffset(unsigned Opcode, int Offset,
   case Hexagon::L2_ploadruhf_io:
   case Hexagon::S2_pstorerht_io:
   case Hexagon::S2_pstorerhf_io:
+  case Hexagon::S2_pstorerft_io:
+  case Hexagon::S2_pstorerff_io:
     return isShiftedUInt<6,1>(Offset);
 
   case Hexagon::L2_ploadrit_io:

--- a/llvm/test/CodeGen/Hexagon/pr196966.ll
+++ b/llvm/test/CodeGen/Hexagon/pr196966.ll
@@ -1,0 +1,31 @@
+; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+
+; Add S2_pstorerft_io and S2_pstorerff_io to isValidOffset.
+; Ensure that llc compiles this test cleanly and emits the predicated .h stores.
+
+; CHECK-LABEL: pr196966:
+; CHECK: if (!{{p[0-9]+(\.new)?}}) memh({{r[0-9]+}}+#{{[0-9]+}}) = {{r[0-9]+}}.h
+
+declare <16 x i16> @helper()
+declare void @llvm.masked.scatter.v16i16.v16p0(<16 x i16>, <16 x ptr>, <16 x i1>)
+
+define void @pr196966(ptr %base) {
+entry:
+  %mb = icmp ne ptr %base, null
+  br i1 %mb, label %then, label %common.ret
+
+common.ret:
+  ret void
+
+then:
+  %p4 = getelementptr i8, ptr %base, i64 20
+  %call = call <16 x i16> @helper()
+  %pv4 = insertelement <16 x ptr> poison, ptr %p4, i64 4
+  %ptrs.raw = freeze <16 x ptr> %pv4
+  %p2 = getelementptr i8, ptr %base, i64 6
+  %pv2 = insertelement <16 x ptr> poison, ptr %p2, i64 2
+  %ptrs = shufflevector <16 x ptr> %ptrs.raw, <16 x ptr> %pv2, <16 x i32> <i32 poison, i32 21, i32 12, i32 poison, i32 29, i32 4, i32 poison, i32 poison, i32 27, i32 25, i32 poison, i32 poison, i32 20, i32 18, i32 poison, i32 8>
+  %mask = freeze <16 x i1> poison
+  call void @llvm.masked.scatter.v16i16.v16p0(<16 x i16> %call, <16 x ptr> align 2 %ptrs, <16 x i1> %mask)
+  br label %common.ret
+}


### PR DESCRIPTION
The predicated store-high-halfword opcodes S2_pstorerft_io and S2_pstorerff_io share the memh(Rs32+#u6:1) encoding with S2_pstorerh{t,f}_io but were missing from HexagonInstrInfo::isValidOffset. This caused an llvm_unreachable in HexagonOptAddrMode when it queried the offset range for these opcodes.
Fixes #196966