### PR TITLE
[clang-tidy] Add IgnoreMacros option to readability-trivial-switch

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/TrivialSwitchCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/TrivialSwitchCheck.cpp
@@ -12,12 +12,24 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy::readability {
 
+TrivialSwitchCheck::TrivialSwitchCheck(StringRef Name,
+                                       ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+      IgnoreMacros(Options.get("IgnoreMacros", true)) {}
+
+void TrivialSwitchCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "IgnoreMacros", IgnoreMacros);
+}
+
 void TrivialSwitchCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(switchStmt().bind("switch"), this);
 }
 
 void TrivialSwitchCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *Switch = Result.Nodes.getNodeAs<SwitchStmt>("switch");
+  if (IgnoreMacros && Switch->getBeginLoc().isMacroID())
+    return;
+
   std::size_t CaseCount = 0;
   bool HasDefault = false;
 

--- a/clang-tools-extra/clang-tidy/readability/TrivialSwitchCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/TrivialSwitchCheck.h
@@ -19,13 +19,16 @@ namespace clang::tidy::readability {
 /// https://clang.llvm.org/extra/clang-tidy/checks/readability/trivial-switch.html
 class TrivialSwitchCheck : public ClangTidyCheck {
 public:
-  TrivialSwitchCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+  TrivialSwitchCheck(StringRef Name, ClangTidyContext *Context);
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   std::optional<TraversalKind> getCheckTraversalKind() const override {
     return TK_IgnoreUnlessSpelledInSource;
   }
+
+private:
+  const bool IgnoreMacros;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -900,6 +900,11 @@ Changes in existing checks
   <clang-tidy/checks/readability/suspicious-call-argument>` check by avoiding a
   crash from invalid ``Abbreviations`` option.
 
+- Improved :doc:`readability-trivial-switch
+  <clang-tidy/checks/readability/trivial-switch>` check by adding an
+  `IgnoreMacros` option. When enabled, the check will ignore switch
+  statements originating from macros.
+
 - Improved :doc:`readability-use-anyofallof
   <clang-tidy/checks/readability/use-anyofallof>` check by emitting a diagnostic
   note to suggest materializing the temporary range when iterating over temporary

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/trivial-switch.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/trivial-switch.rst
@@ -34,3 +34,11 @@ Otherwise, the ``switch`` can be better expressed with an ``if`` statement.
   // The switch without any labels will be diagnosed.
   int i = 42;
   switch (i) {}
+
+Options
+-------
+
+.. option:: IgnoreMacros
+
+   If set to `true`, the check will not give warnings inside macros. Default
+   is `true`.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/trivial-switch.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/trivial-switch.cpp
@@ -1,4 +1,7 @@
 // RUN: %check_clang_tidy -std=c++98-or-later %s readability-trivial-switch %t
+// RUN: %check_clang_tidy -std=c++98-or-later -check-suffixes=,MACROS %s \
+// RUN:   readability-trivial-switch %t -- \
+// RUN:   -config="{CheckOptions: {readability-trivial-switch.IgnoreMacros: false}}"
 
 void bad(int I) {
   switch (I) {
@@ -41,4 +44,15 @@ void good(int I) {
   default:
     break;
   }
+}
+
+#define SINGLE_CASE_SWITCH(I)                                                  \
+  switch (I) {                                                                 \
+  case 0:                                                                      \
+    break;                                                                     \
+  }
+
+void macro(int I) {
+  SINGLE_CASE_SWITCH(I)
+  // CHECK-MESSAGES-MACROS: :[[@LINE-1]]:3: warning: switch with only one case; use an if statement
 }


### PR DESCRIPTION
AI Usage: Assisted by Codex 5.6
Closes https://github.com/llvm/llvm-project/issues/208474