### PR TITLE
COFF: Start error message with lowercase letter

### DIFF
--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -457,7 +457,7 @@ void ELFWriter::writeSymbol(SymbolTableWriter &Writer, uint32_t StringIndex,
   if (ESize) {
     int64_t Res;
     if (!ESize->evaluateKnownAbsolute(Res, Asm))
-      report_fatal_error("Size expression must be absolute.");
+      report_fatal_error("size expression must be absolute");
     Size = Res;
   }
 

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -1060,7 +1060,7 @@ uint64_t MachObjectWriter::writeObject() {
     if (Data.End)
       End = getSymbolAddress(*Data.End);
     else
-      report_fatal_error("Data region not terminated");
+      report_fatal_error("data region not terminated");
 
     LLVM_DEBUG(dbgs() << "data in code region-- kind: " << Data.Kind
                       << "  start: " << Start << "(" << Data.Start->getName()

--- a/llvm/lib/Object/COFFObjectFile.cpp
+++ b/llvm/lib/Object/COFFObjectFile.cpp
@@ -396,7 +396,7 @@ relocation_iterator COFFObjectFile::section_rel_begin(DataRefImpl Ref) const {
   const coff_section *Sec = toSec(Ref);
   const coff_relocation *begin = getFirstReloc(Sec, Data, base());
   if (begin && Sec->VirtualAddress != 0)
-    report_fatal_error("Sections with relocations should have an address of 0");
+    report_fatal_error("sections with relocations should have an address of 0");
   DataRefImpl Ret;
   Ret.p = reinterpret_cast<uintptr_t>(begin);
   return relocation_iterator(RelocationRef(Ret, this));

--- a/llvm/test/MC/ELF/size-expression-must-be-absolute.s
+++ b/llvm/test/MC/ELF/size-expression-must-be-absolute.s
@@ -1,0 +1,6 @@
+// RUN: not --crash llvm-mc -triple=x86_64 -filetype=obj -o /dev/null %s 2>&1 | FileCheck %s
+
+a: b:
+.size a, b
+
+// CHECK: LLVM ERROR: size expression must be absolute

--- a/llvm/test/MC/X86/check-end-of-data-region.s
+++ b/llvm/test/MC/X86/check-end-of-data-region.s
@@ -5,4 +5,4 @@
 foo:
      .long 0
 
-// CHECK-ERROR: LLVM ERROR: Data region not terminated
+// CHECK-ERROR: LLVM ERROR: data region not terminated

--- a/llvm/test/Object/coff-invalid.test
+++ b/llvm/test/Object/coff-invalid.test
@@ -10,4 +10,4 @@ SECTIONS-NEXT:   VirtualAddress: 0x1000000
 RUN: not --crash llvm-readobj -r %p/Inputs/invalid-bad-section-address.coff 2>&1 | \
 RUN: FileCheck %s
 
-CHECK: Sections with relocations should have an address of 0
+CHECK: sections with relocations should have an address of 0


### PR DESCRIPTION
Follow style guideline for error messages.