### PR TITLE
[Hexagon] Enable init-array by default for picolibc

### DIFF
--- a/clang/lib/Driver/ToolChains/Hexagon.cpp
+++ b/clang/lib/Driver/ToolChains/Hexagon.cpp
@@ -833,7 +833,9 @@ void HexagonToolChain::addClangTargetOptions(const ArgList &DriverArgs,
                                              BoundArch BA,
                                              Action::OffloadKind) const {
 
-  bool UseInitArrayDefault = getTriple().isMusl();
+  bool UseInitArrayDefault =
+      getTriple().isMusl() ||
+      GetCStdlibType(DriverArgs) == ToolChain::CST_Picolibc;
 
   if (!DriverArgs.hasFlag(options::OPT_fuse_init_array,
                           options::OPT_fno_use_init_array,

--- a/clang/test/Driver/hexagon-toolchain-picolibc.c
+++ b/clang/test/Driver/hexagon-toolchain-picolibc.c
@@ -252,6 +252,15 @@
 // RUN:   -mcpu=hexagonv68 -G0 -### %s 2>&1 | FileCheck -check-prefix=CHECK-H2-LIBPATHS-G0 %s
 // CHECK-H2-LIBPATHS-G0: "-L{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}lib{{/|\\\\}}v68-G0"
 
+// -----------------------------------------------------------------------------
+// --cstdlib=picolibc enables init-array (not legacy .init/.fini)
+// -----------------------------------------------------------------------------
+// RUN: %clang --target=hexagon-none-elf --cstdlib=picolibc -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-INIT-ARRAY
+// CHECK-INIT-ARRAY-NOT: "-fno-use-init-array"
+
+// RUN: %clang --target=hexagon-h2-elf --cstdlib=picolibc -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-H2-INIT-ARRAY
+// CHECK-H2-INIT-ARRAY-NOT: "-fno-use-init-array"
+
 // =============================================================================
 // --sysroot tests: verify includes, library paths, and start files when an
 // explicit sysroot is provided together with --cstdlib=picolibc.


### PR DESCRIPTION
Picolibc uses the modern .init_array/.fini_array mechanism rather than legacy .init/.fini sections. Extend UseInitArrayDefault in HexagonToolChain::addClangTargetOptions to also return true when --cstdlib=picolibc is selected, preventing -fno-use-init-array from being passed to cc1.