### PR TITLE
[lldb] Implement LLDB_REGNUM_GENERIC_TP conversion for Aarch64

### DIFF
--- a/lldb/source/Plugins/ABI/AArch64/ABIAArch64.cpp
+++ b/lldb/source/Plugins/ABI/AArch64/ABIAArch64.cpp
@@ -88,6 +88,7 @@ uint32_t ABIAArch64::GetGenericNum(llvm::StringRef name) {
       .Cases({"sp", "x31"}, LLDB_REGNUM_GENERIC_SP)
       .Cases({"fp", "x29"}, LLDB_REGNUM_GENERIC_FP)
       .Case("cpsr", LLDB_REGNUM_GENERIC_FLAGS)
+      .Case("tpidr", LLDB_REGNUM_GENERIC_TP)
       .Case("x0", LLDB_REGNUM_GENERIC_ARG1)
       .Case("x1", LLDB_REGNUM_GENERIC_ARG2)
       .Case("x2", LLDB_REGNUM_GENERIC_ARG3)

--- a/lldb/unittests/ABI/AArch64/ABIAArch64Test.cpp
+++ b/lldb/unittests/ABI/AArch64/ABIAArch64Test.cpp
@@ -66,6 +66,23 @@ TEST_P(ABIAArch64TestFixture, AugmentRegisterInfo) {
   EXPECT_EQ(new_pc.regnum_dwarf, arm64_dwarf::pc);
 }
 
+TEST_P(ABIAArch64TestFixture, AugmentRegisterInfoThreadPointer) {
+  ABISP abi_sp = ABI::FindPlugin(ProcessSP(), ArchSpec(GetParam()));
+  ASSERT_TRUE(abi_sp);
+  using Register = DynamicRegisterInfo::Register;
+
+  Register tpidr;
+  tpidr.name = ConstString("tpidr");
+  tpidr.set_name = ConstString("GPR");
+  std::vector<Register> regs{tpidr};
+
+  abi_sp->AugmentRegisterInfo(regs);
+
+  ASSERT_EQ(regs.size(), 1U);
+  EXPECT_EQ(regs[0].regnum_generic,
+            static_cast<uint32_t>(LLDB_REGNUM_GENERIC_TP));
+}
+
 INSTANTIATE_TEST_SUITE_P(ABIAArch64Tests, ABIAArch64TestFixture,
                          testing::Values("aarch64-pc-linux",
                                          "arm64-apple-macosx"));


### PR DESCRIPTION
LLDB currently fails to find TLS variables on Linux, and this is part of the problem.