### PR TITLE
[PDB][Tests] Fix Expected return in TpiStreamTest (GCC 7.5.0)

### DIFF
--- a/llvm/unittests/DebugInfo/PDB/TpiStreamTest.cpp
+++ b/llvm/unittests/DebugInfo/PDB/TpiStreamTest.cpp
@@ -49,7 +49,7 @@ openSimplePdb(BumpPtrAllocator &Allocator) {
     return Err;
   if (Error Err = File->parseStreamData())
     return Err;
-  return File;
+  return std::move(File);
 }
 
 TEST(TpiStreamTest, getType) {


### PR DESCRIPTION
Use return std::move(File); in openSimplePdb so std::unique_ptr<PDBFile> is returned as Expected<std::unique_ptr<PDBFile>>. This fixes the compile failure seen with GCC 7.5.0.