### PR TITLE
[OpenMP] Use secure_getenv when read OMPT library path

### DIFF
--- a/openmp/runtime/src/ompt-general.cpp
+++ b/openmp/runtime/src/ompt-general.cpp
@@ -60,6 +60,12 @@
 static FILE *verbose_file;
 static int verbose_init;
 
+#if defined(__GLIBC__)
+#define OMPT_GETENV secure_getenv
+#else
+#define OMPT_GETENV getenv
+#endif
+
 /*****************************************************************************
  * types
  ****************************************************************************/
@@ -281,7 +287,7 @@ ompt_try_start_tool(unsigned int omp_version, const char *runtime_version) {
 
   // Try tool-libraries-var ICV
   OMPT_VERBOSE_INIT_CONTINUED_PRINT("Failed.\n");
-  const char *tool_libs = getenv("OMP_TOOL_LIBRARIES");
+  const char *tool_libs = OMPT_GETENV("OMP_TOOL_LIBRARIES");
   if (tool_libs) {
     OMPT_VERBOSE_INIT_PRINT("Searching tool libraries...\n");
     OMPT_VERBOSE_INIT_PRINT("OMP_TOOL_LIBRARIES = %s\n", tool_libs);


### PR DESCRIPTION
An internal review flagged the use of `getenv` when reading the OMPT tool library path from the environment and passing it to the loader as a potential vuln.

This patch replaces the use of getenv in question with the use of secure_getenv on glibc platforms.
On non glibc platforms, no change is implemented.