### PR TITLE
[libc++abi] Use the same .clang-format as libc++

### DIFF
--- a/libcxx/.clang-format
+++ b/libcxx/.clang-format
@@ -3,6 +3,8 @@ BasedOnStyle: LLVM
 # detected as Cpp, but others are detected as ObjC and we want this formatting
 # to apply to all types of files.
 
+# libcxx/.clang-format and libcxxabi/.clang-format are identical. Both of them should by modified in sync.
+
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: Consecutive
 AlignConsecutiveBitFields: Consecutive

--- a/libcxxabi/.clang-format
+++ b/libcxxabi/.clang-format
@@ -1,14 +1,83 @@
 BasedOnStyle: LLVM
+# Note that we don't specify the language in this file because some files are
+# detected as Cpp, but others are detected as ObjC and we want this formatting
+# to apply to all types of files.
 
-Language: Cpp
+# libcxx/.clang-format and libcxxabi/.clang-format are identical. Both of them should by modified in sync.
+
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveBitFields: Consecutive
+AlignEscapedNewlines: Right
+AlignOperands: AlignAfterOperator
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortFunctionsOnASingleLine: true
+AllowShortLambdasOnASingleLine: All
+AttributeMacros: [
+                  '_ALIGNAS_TYPE',
+                  '_ALIGNAS',
+                  '_LIBCPP_ACQUIRE_CAPABILITY',
+                  '_LIBCPP_ACQUIRE_SHARED_CAPABILITY',
+                  '_LIBCPP_ALIGNOF',
+                  '_LIBCPP_ALWAYS_INLINE',
+                  '_LIBCPP_CAPABILITY',
+                  '_LIBCPP_CONSTEXPR_SINCE_CXX14',
+                  '_LIBCPP_CONSTEXPR_SINCE_CXX17',
+                  '_LIBCPP_CONSTEXPR_SINCE_CXX20',
+                  '_LIBCPP_CONSTEXPR_SINCE_CXX23',
+                  '_LIBCPP_CONSTEXPR',
+                  '_LIBCPP_DEPRECATED_IN_CXX11',
+                  '_LIBCPP_DEPRECATED_IN_CXX14',
+                  '_LIBCPP_DEPRECATED_IN_CXX17',
+                  '_LIBCPP_DEPRECATED_IN_CXX20',
+                  '_LIBCPP_DEPRECATED_IN_CXX23',
+                  '_LIBCPP_DEPRECATED',
+                  '_LIBCPP_DIAGNOSE_NULLPTR_IF',
+                  '_LIBCPP_EXCLUDE_FROM_EXPLICIT_INSTANTIATION',
+                  '_LIBCPP_EXPORTED_FROM_ABI',
+                  '_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS',
+                  '_LIBCPP_FALLTHROUGH',
+                  '_LIBCPP_HIDDEN',
+                  '_LIBCPP_HIDE_FROM_ABI_AFTER_V1',
+                  '_LIBCPP_HIDE_FROM_ABI',
+                  '_LIBCPP_NO_SANITIZE',
+                  '_LIBCPP_NO_UNIQUE_ADDRESS',
+                  '_LIBCPP_NOALIAS',
+                  '_LIBCPP_OVERRIDABLE_FUNC_VIS',
+                  '_LIBCPP_RELEASE_CAPABILITY',
+                  '_LIBCPP_REQUIRES_CAPABILITY',
+                  '_LIBCPP_SCOPED_LOCKABLE',
+                  '_LIBCPP_STANDALONE_DEBUG',
+                  '_LIBCPP_TEMPLATE_DATA_VIS',
+                  '_LIBCPP_TRY_ACQUIRE_CAPABILITY',
+                  '_LIBCPP_TRY_ACQUIRE_SHARED_CAPABILITY',
+                  '_LIBCPP_USING_IF_EXISTS',
+                 ]
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeConceptDeclarations: true
+BreakInheritanceList: BeforeColon
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: Always
+IndentWrappedFunctionNames: false
+IndentRequires: true
+InsertTrailingCommas: Wrapped
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+PackConstructorInitializers: NextLine
+
+PenaltyIndentedWhitespace: 2
+
+Standard: c++20
+SpacesInAngles: Leave
 
 AlwaysBreakTemplateDeclarations: true
 PointerAlignment: Left
 
-# Disable formatting options which may break tests.
-SortIncludes: false
-ReflowComments: false
 
+# libc++'s preferred indentions of preprocessor statements.
 IndentPPDirectives: AfterHash
 
 # libc++ has some long names so we need more than the 80 column limit imposed by LLVM style, for sensible formatting


### PR DESCRIPTION
libc++abi is very close to libc++, and even shares some amount of code. We should keep the formatting style the same between the two libraries.
