### PR TITLE
[flang][FIR] implement asm alias interface for fir.type under option

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -15,6 +15,7 @@
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
+include "mlir/IR/OpAsmInterface.td"
 include "flang/Optimizer/Dialect/FIRDialect.td"
 
 //===----------------------------------------------------------------------===//
@@ -316,7 +317,9 @@ def fir_PointerType : FIR_Type<"Pointer", "ptr"> {
   }];
 }
 
-def fir_RecordType : FIR_Type<"Record", "type", [MemRefElementTypeInterface]> {
+def fir_RecordType : FIR_Type<"Record", "type",
+    [DeclareTypeInterfaceMethods<OpAsmTypeInterface, ["getAlias"]>,
+     MemRefElementTypeInterface]> {
   let summary = "FIR derived type";
 
   let description = [{

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -24,12 +24,18 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
 
 #define GET_TYPEDEF_CLASSES
 #include "flang/Optimizer/Dialect/FIROpsTypes.cpp.inc"
 
 using namespace fir;
+
+static llvm::cl::opt<bool> enableFirTypeAliases(
+    "enable-fir-type-aliases",
+    llvm::cl::desc("Enable MLIR type aliases for FIR derived types"),
+    llvm::cl::init(false), llvm::cl::Hidden);
 
 namespace {
 
@@ -1122,7 +1128,7 @@ void fir::RecordType::print(mlir::AsmPrinter &printer) const {
       char ch = '(';
       for (auto p : getLenParamList()) {
         printer << ch << p.first << ':';
-        p.second.print(printer.getStream());
+        printer.printType(p.second);
         ch = ',';
       }
       printer << ')';
@@ -1134,7 +1140,7 @@ void fir::RecordType::print(mlir::AsmPrinter &printer) const {
       char ch = '{';
       for (auto p : getTypeList()) {
         printer << ch << p.first << ':';
-        p.second.print(printer.getStream());
+        printer.printType(p.second);
         ch = ',';
       }
       printer << '}';
@@ -1145,6 +1151,18 @@ void fir::RecordType::print(mlir::AsmPrinter &printer) const {
     recordTypeVisited.erase(uniqueKey());
   }
   printer << '>';
+}
+
+mlir::OpAsmAliasResult fir::RecordType::getAlias(llvm::raw_ostream &os) const {
+  if (!enableFirTypeAliases)
+    return mlir::OpAsmAliasResult::NoAlias;
+  // Derived type names may contain "." that are forbidden in MLIR type
+  // alias. Replace them by a capital 'X' that cannot be found in user
+  // defined derived type and is also used as a replacement before generating
+  // llvm assembly.
+  for (char ch : getName())
+    os << (ch == '.' ? 'X' : ch);
+  return mlir::OpAsmAliasResult::OverridableAlias;
 }
 
 void fir::RecordType::finalize(llvm::ArrayRef<TypePair> lenPList,

--- a/flang/test/Fir/derived-type-aliases.fir
+++ b/flang/test/Fir/derived-type-aliases.fir
@@ -1,0 +1,24 @@
+// RUN: fir-opt %s | FileCheck %s --check-prefix=DEFAULT
+// RUN: fir-opt -enable-fir-type-aliases %s | FileCheck %s --check-prefix=ALIASES
+
+module {
+  func.func @use_aliases(
+      %arg0: !fir.ref<!fir.type<outer{inner:!fir.type<inner{p:!fir.box<!fir.ptr<f32>>}>}>>,
+      %arg1: !fir.ref<!fir.type<a.b{x:i32}>>,
+      %arg2: !fir.ref<!fir.type<a_b{x:i64}>>,
+      %arg3: !fir.ref<!fir.type<recursive{next:!fir.box<!fir.heap<!fir.type<recursive>>>}>>) {
+    return
+  }
+}
+
+// DEFAULT-NOT: !outer =
+// DEFAULT-NOT: !aXb =
+// DEFAULT-NOT: !a_b =
+// DEFAULT: func.func @use_aliases(%{{.*}}: !fir.ref<!fir.type<outer{inner:!fir.type<inner{p:!fir.box<!fir.ptr<f32>>}>}>>, %{{.*}}: !fir.ref<!fir.type<a.b{x:i32}>>, %{{.*}}: !fir.ref<!fir.type<a_b{x:i64}>>, %{{.*}}: !fir.ref<!fir.type<recursive{next:!fir.box<!fir.heap<!fir.type<recursive>>>}>>)
+
+// ALIASES-DAG: !aXb = !fir.type<a.b{x:i32}>
+// ALIASES-DAG: !a_b = !fir.type<a_b{x:i64}>
+// ALIASES-DAG: !inner = !fir.type<inner{p:!fir.box<!fir.ptr<f32>>}>
+// ALIASES-DAG: !outer = !fir.type<outer{inner:!inner}>
+// ALIASES-DAG: !recursive = !fir.type<recursive{next:!fir.box<!fir.heap<!fir.type<recursive>>>}>
+// ALIASES: func.func @use_aliases(%{{.*}}: !fir.ref<!outer>, %{{.*}}: !fir.ref<!aXb>, %{{.*}}: !fir.ref<!a_b>, %{{.*}}: !fir.ref<!recursive>)


### PR DESCRIPTION
FIR is extremely verbose with derived types because the type lists all the component names and types, so in case of nested derived type, the type length in the assembly may grow over thousands of characters.

This patch implements the  `getAlias` that allows using the fir.type name as the MLIR type alias. This significantly reduce the IR size in application with derived type.

I am planning to enable this by default, but there will be some churn in the lit test, so I am first adding it under a developer option.

Assisted-by: Cursor