### PR TITLE
[StackColoring] Change TotalStackSize from unsigned to int64_t

### DIFF
--- a/llvm/lib/CodeGen/StackColoring.cpp
+++ b/llvm/lib/CodeGen/StackColoring.cpp
@@ -1224,7 +1224,7 @@ bool StackColoring::run(MachineFunction &Func, bool OnlyRemoveMarkers) {
 
   unsigned NumMarkers = collectMarkers(NumSlots);
 
-  unsigned TotalSize = 0;
+  int64_t TotalSize = 0;
   LLVM_DEBUG(dbgs() << "Found " << NumMarkers << " markers and " << NumSlots
                     << " slots\n");
   LLVM_DEBUG(dbgs() << "Slot structure:\n");
@@ -1270,7 +1270,7 @@ bool StackColoring::run(MachineFunction &Func, bool OnlyRemoveMarkers) {
   // Maps old slots to new slots.
   DenseMap<int, int> SlotRemap;
   unsigned RemovedSlots = 0;
-  unsigned ReducedSize = 0;
+  int64_t ReducedSize = 0;
 
   // Do not bother looking at empty intervals.
   for (unsigned I = 0; I < NumSlots; ++I) {

--- a/llvm/test/CodeGen/RISCV/stack-coloring-large-stack.ll
+++ b/llvm/test/CodeGen/RISCV/stack-coloring-large-stack.ll
@@ -1,0 +1,17 @@
+; REQUIRES: asserts
+; RUN: llc < %s -O3 -mtriple=riscv64 -debug-only=stack-coloring 2>&1 | FileCheck %s
+
+declare void @foo(...)
+
+; CHECK: Slot #0 - 33179869176 bytes.
+; CHECK: Slot #1 - 147483648 bytes.
+; CHECK: Total Stack size: 33327352824 bytes
+define dso_local void @stack_bigger_than_32bit_unsigned() {
+entry:
+  %a = alloca [4147483647 x i64], align 8
+  %b = alloca [147483648 x i8], align 1
+  %arraydecay = getelementptr inbounds [4147483647 x i64], ptr %a, i64 0, i64 0
+  %arraydecay1 = getelementptr inbounds [147483648 x i8], ptr %b, i64 0, i64 0
+  call void @foo(ptr noundef %arraydecay, ptr noundef %arraydecay1)
+  ret void
+}


### PR DESCRIPTION
StackColoring tracks the total size of the stack as `unsigned int`. This will wrap around, even on 64-bit systems, if the stack is greater than that resulting in a wrong size. This can happen on both PPC and RISCV64.