### PR TITLE
[GlobalISel][AArch64] Improve legalization of shift amounts

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
@@ -252,6 +252,7 @@ AArch64LegalizerInfo::AArch64LegalizerInfo(const AArch64Subtarget &ST)
           {v4i32, v4i32},
           {v2i64, v2i64},
       })
+      .widenScalarToNextPow2(1)
       .widenScalarToNextPow2(0)
       .clampScalar(1, s32, s64)
       .clampScalar(0, s32, s64)

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-shift.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-shift.mir
@@ -552,3 +552,27 @@ body:             |
     $w0 = COPY %d2(s32)
 
 ...
+---
+name: test_lshr_i48
+body:             |
+  bb.1.entry:
+    liveins: $x0
+
+    ; CHECK-LABEL: name: test_lshr_i48
+    ; CHECK: liveins: $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(i64) = COPY $x0
+    ; CHECK-NEXT: [[TRUNC:%[0-9]+]]:_(i32) = G_TRUNC [[COPY]](i64)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(i64) = G_CONSTANT i64 1
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(i32) = G_LSHR [[TRUNC]], [[C]](i64)
+    ; CHECK-NEXT: $w0 = COPY [[LSHR]](i32)
+    ; CHECK-NEXT: RET_ReallyLR implicit $w0
+    %1:_(i64) = COPY $x0
+    %0:_(i48) = G_TRUNC %1(i64)
+    %6:_(i32) = G_TRUNC %0(i48)
+    %2:_(i48) = G_CONSTANT i48 1
+    %7:_(i32) = G_LSHR %6, %2(i48)
+    $w0 = COPY %7(i32)
+    RET_ReallyLR implicit $w0
+
+...


### PR DESCRIPTION
Fixes crashes when the shift amount type is already between s32 and s64,
but not s32 or s64.

The shift amount should have the same type with the shifted value for
the shift instructions, so add the same `widenScalarToNextPow2`
legalization that we apply to the shifted value, to the shift amount.

Fixes crashes in programs like:

    define i8 @test(i48 %a) {
    entry:
      %b = lshr i48 %a, 15
      %c = trunc i48 %b to i8
      ret i8 %c
    }

The new test crashes before this PR.