### PR TITLE
[clang][bytecode] Don't diagnose definition without body

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1110,8 +1110,10 @@ static bool diagnoseCallableDecl(InterpState &S, CodePtr OpPC,
              diag::note_constexpr_invalid_function, 1)
         << DiagDecl->isConstexpr() << (bool)CD << DiagDecl;
 
-    if (DiagDecl->getDefinition())
-      S.Note(DiagDecl->getDefinition()->getLocation(), diag::note_declared_at);
+    const FunctionDecl *Definition;
+    const Stmt *Body = DiagDecl->getBody(Definition);
+    if (Body && Definition)
+      S.Note(Definition->getLocation(), diag::note_declared_at);
     else
       S.Note(DiagDecl->getLocation(), diag::note_declared_at);
   }

--- a/clang/test/AST/ByteCode/invalid.cpp
+++ b/clang/test/AST/ByteCode/invalid.cpp
@@ -218,3 +218,12 @@ namespace InvalidVirtualCast {
   static_assert((X *)(Y *)&z, ""); // both-error {{not an integral constant expression}} \
                                    // both-note {{cast that performs the conversions of a reinterpret_cast is not allowed in a constant expression}}
 }
+
+namespace DefinitionInBody {
+  int foo(); // both-note {{declared here}}
+  int foo() {
+    static_assert(foo() == 1); // both-error {{not an integral constant expression}} \
+                               // both-note {{non-constexpr function 'foo' cannot be used in a constant expression}}
+    return 5;
+  }
+}


### PR DESCRIPTION
Let the declared_at note point to the declaration in that case.