### PR TITLE
[lldb][docs] Make it clear that we require SWIG >= 4

### DIFF
--- a/lldb/docs/resources/build.md
+++ b/lldb/docs/resources/build.md
@@ -54,6 +54,7 @@ CMake configuration error.
 | Libxml2  | XML                                                        | `LLDB_ENABLE_LIBXML2` |
 | Python   | Python scripting. 3.8 or later (3.11 or later on Windows). | `LLDB_ENABLE_PYTHON`  |
 | Lua      | Lua scripting. Lua 5.3 and 5.4 are supported.              | `LLDB_ENABLE_LUA`     |
+| SWIG     | Required for Python or LUA support. Version 4 or later.    | N/A                   |
 
 Depending on your platform and package manager, one might run any of the
 commands below.
@@ -65,13 +66,6 @@ $ pkg install swig python libxml2
 $ pkgin install swig python38 cmake ninja-build
 $ brew install swig cmake ninja
 ```
-
-:::{note}
-There is an [incompatibility](https://github.com/swig/swig/issues/1321) between Python version 3.7 and later
-and swig versions older than 4.0.0 which makes builds of LLDB using debug
-versions of python unusable. This primarily affects Windows, as debug builds of
-LLDB must use debug python as well.
-:::
 
 :::{note}
 Installing multiple versions of Curses, particularly when only one is built with


### PR DESCRIPTION
We said this in "Preliminaries", but later had a note about SWIG < 4. So if you hadn't read
the first part properly, it looked like we allow < 4.

We do not, so I've removed the note about < 4 and
added SWIG to the "Optional Dependencies" table
for extra emphasis.