### PR TITLE
[VPlan] Use zext instead of sext for Index in VPDerivedIVRecipe expansion. nfc

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -4092,7 +4092,7 @@ static void expandVPDerivedIV(VPDerivedIVRecipe *R) {
   Type *StepTy = Step->getScalarType();
   Type *IndexTy = Index->getScalarType();
   Index = StepTy->isIntegerTy()
-              ? Builder.createScalarSExtOrTrunc(
+              ? Builder.createScalarZExtOrTrunc(
                     Index, StepTy, IndexTy, DebugLoc::getCompilerGenerated())
               : Builder.createScalarCast(Instruction::SIToFP, Index, StepTy,
                                          DebugLoc::getCompilerGenerated());


### PR DESCRIPTION
expandVPDerivedIV extends/truncates the index to the step's integer type before computing the derived IV. The index always non-negative since it represents an trip count,. Therefore, extending it should use createScalarZExtOrTrunc rather than createScalarSExtOrTrunc, which better reflects its actual unsigned semantics.