### PR TITLE
[clang] Don't crash in invalid #module directive

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -883,6 +883,7 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 - Correctly diagnose invalid non-dependent calls in dependent contexts. (#GH135694)
 - Fix initialization of GRO when GRO-return type mismatches, as part of CWG2563. (#GH98744)
 - Fix an error using an initializer list with array new for a type that is not default-constructible. (#GH81157)
+- Fixed a crash in invalid ``#module`` preprocessing directive. (#GH179220)
 - We no longer consider conversion operators when copy-initializing from the same type. This was non
   conforming and could lead to recursive constraint satisfaction checking. (#GH149443)
 - Fixed a crash in Itanium C++ name mangling for a lambda in a local class field initializer inside a constructor/destructor. (#GH176395)

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -1455,10 +1455,11 @@ void Preprocessor::HandleDirective(Token &Result) {
       return HandlePragmaDirective({PIK_HashPragma, Introducer.getLocation()});
     case tok::pp_module:
     case tok::pp___preprocessed_module:
-      return HandleCXXModuleDirective(Result);
+      if (Introducer.isModuleContextualKeyword())
+        return HandleCXXModuleDirective(Result);
+      break;
     case tok::pp___preprocessed_import:
       return HandleCXXImportDirective(Result);
-    // GNU Extensions.
     case tok::pp_import:
       switch (Introducer.getKind()) {
       case tok::hash:
@@ -1470,6 +1471,8 @@ void Preprocessor::HandleDirective(Token &Result) {
       default:
         llvm_unreachable("not a valid import directive");
       }
+
+    // GNU Extensions.
     case tok::pp_include_next:
       return HandleIncludeNextDirective(Introducer.getLocation(), Result);
 

--- a/clang/test/Lexer/invalid-directive.cpp
+++ b/clang/test/Lexer/invalid-directive.cpp
@@ -1,0 +1,3 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++20 %s
+
+#module // expected-error {{invalid preprocessing directive}}


### PR DESCRIPTION
The following preprocessing directive is not a C++ module directive, don't handle it in C++ module subroutine.

```cpp
#module
```

Fixes https://github.com/llvm/llvm-project/issues/179220.