### PR TITLE
[orc-rt] Add backend-independent category and level APIs to Logging.h

### DIFF
--- a/orc-rt/include/orc-rt-c/Logging.h
+++ b/orc-rt/include/orc-rt-c/Logging.h
@@ -51,7 +51,41 @@ ORC_RT_C_EXTERN_C_BEGIN
  */
 typedef enum {
   orc_rt_log_Category_General,
+
+  /*
+   * Count is the number of defined categories; it is not itself a valid
+   * category.
+   */
+  orc_rt_log_Category_Count
 } orc_rt_log_Category;
+
+/**
+ * Logging levels are integers. Valid values are ORC_RT_LOG_LEVEL_DEBUG,
+ * ORC_RT_LOG_LEVEL_INFO, ORC_RT_LOG_LEVEL_WARNING, ORC_RT_LOG_LEVEL_ERROR, and
+ * ORC_RT_LOG_LEVEL_NONE.
+ */
+typedef int orc_rt_log_Level;
+
+/**
+ * Returns the display name for the given category, or null if the category is
+ * unrecognized.
+ */
+const char *
+orc_rt_log_Category_getName(orc_rt_log_Category Cat) ORC_RT_C_NOTHROW;
+
+/**
+ * Returns the display name for the given log level, or null if the log level
+ * is unrecognized.
+ */
+const char *orc_rt_log_Level_getName(orc_rt_log_Level L) ORC_RT_C_NOTHROW;
+
+/**
+ * Returns the level corresponding to the given level name, or -1 if the level
+ * name is unrecognized.
+ *
+ * Comparison is case-insensitive.
+ */
+orc_rt_log_Level orc_rt_log_Level_parse(const char *Str) ORC_RT_C_NOTHROW;
 
 /**
  * Declared but never defined: referenced only in unevaluated (sizeof) contexts

--- a/orc-rt/include/orc-rt-c/config.h.in
+++ b/orc-rt/include/orc-rt-c/config.h.in
@@ -21,6 +21,8 @@
 #define ORC_RT_LOG_LEVEL_INFO    1
 #define ORC_RT_LOG_LEVEL_WARNING 2
 #define ORC_RT_LOG_LEVEL_ERROR   3
+#define ORC_RT_LOG_LEVEL_NONE    4
+#define ORC_RT_LOG_LEVEL_COUNT   (ORC_RT_LOG_LEVEL_NONE + 1)
 /* Fail loudly if CMake derived a symbol that isn't defined above. */
 #ifndef @ORC_RT_LOG_LEVEL_VALUE@
 #error "Invalid ORC_RT_LOG_LEVEL"

--- a/orc-rt/lib/executor/CMakeLists.txt
+++ b/orc-rt/lib/executor/CMakeLists.txt
@@ -5,6 +5,7 @@ set(files
   Error.cpp
   ExecutorProcessInfo.cpp
   InProcessControllerAccess.cpp
+  Logging.cpp
   NativeDylibManager.cpp
   RTTI.cpp
   Service.cpp

--- a/orc-rt/lib/executor/Logging.cpp
+++ b/orc-rt/lib/executor/Logging.cpp
@@ -1,0 +1,57 @@
+//===- Logging.cpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the implementation of APIs in the orc-rt-c/Logging.h header.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt-c/Logging.h"
+
+#include <cassert>
+#include <cctype>
+#include <cstring>
+
+static const char *CategoryNames[orc_rt_log_Category_Count] = {"General"};
+
+static const char *LevelNames[ORC_RT_LOG_LEVEL_COUNT] = {
+    "debug", "info", "warning", "error", "none",
+};
+
+const char *orc_rt_log_Category_getName(orc_rt_log_Category Cat) noexcept {
+  if (Cat < 0 || Cat >= orc_rt_log_Category_Count)
+    return nullptr;
+  return CategoryNames[Cat];
+}
+
+const char *orc_rt_log_Level_getName(orc_rt_log_Level L) noexcept {
+  if (L < 0 || L >= ORC_RT_LOG_LEVEL_COUNT)
+    return nullptr;
+  return LevelNames[L];
+}
+
+orc_rt_log_Level orc_rt_log_Level_parse(const char *Str) noexcept {
+
+  auto StrMatches = [&](const char *LevelName) {
+    size_t Size = strlen(LevelName) + 1; // include null terminator.
+
+    for (size_t I = 0; I != Size; ++I) {
+      unsigned char P = LevelName[I];
+      unsigned char Q = Str[I];
+      assert((!P || std::islower(P)) && "Level name is not all lowercase");
+      if (std::tolower(Q) != P)
+        return false;
+    }
+    return true;
+  };
+
+  for (int I = 0; I != ORC_RT_LOG_LEVEL_COUNT; ++I)
+    if (StrMatches(LevelNames[I]))
+      return I;
+
+  return -1;
+}

--- a/orc-rt/test/unit/LoggingTest.cpp
+++ b/orc-rt/test/unit/LoggingTest.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Unit tests for the ORC runtime logging API (orc-rt-c/Logging.h).
+// Unit tests for the logging-backend-independent parts of orc-rt-c/Logging.h.
 //
 //===----------------------------------------------------------------------===//
 
@@ -24,6 +24,58 @@ TEST(LoggingTest, CompilesAtEveryLevel) {
   ORC_RT_LOG(Info, General, "two args: %s = %d", "answer", 42);
   ORC_RT_LOG(Debug, General, "wide arg: %llu", (unsigned long long)1 << 40);
   SUCCEED();
+}
+
+TEST(LoggingTest, LevelGetName) {
+  EXPECT_STREQ("debug", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_DEBUG));
+  EXPECT_STREQ("info", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_INFO));
+  EXPECT_STREQ("warning", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_WARNING));
+  EXPECT_STREQ("error", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_ERROR));
+  EXPECT_STREQ("none", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_NONE));
+
+  // Out-of-range levels have no name.
+  EXPECT_EQ(nullptr, orc_rt_log_Level_getName(-1));
+  EXPECT_EQ(nullptr, orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_COUNT));
+  EXPECT_EQ(nullptr, orc_rt_log_Level_getName(100));
+}
+
+TEST(LoggingTest, LevelParse) {
+  EXPECT_EQ(ORC_RT_LOG_LEVEL_DEBUG, orc_rt_log_Level_parse("debug"));
+  EXPECT_EQ(ORC_RT_LOG_LEVEL_INFO, orc_rt_log_Level_parse("info"));
+  EXPECT_EQ(ORC_RT_LOG_LEVEL_WARNING, orc_rt_log_Level_parse("warning"));
+  EXPECT_EQ(ORC_RT_LOG_LEVEL_ERROR, orc_rt_log_Level_parse("error"));
+  EXPECT_EQ(ORC_RT_LOG_LEVEL_NONE, orc_rt_log_Level_parse("none"));
+
+  // Parsing is case-insensitive.
+  EXPECT_EQ(ORC_RT_LOG_LEVEL_INFO, orc_rt_log_Level_parse("INFO"));
+  EXPECT_EQ(ORC_RT_LOG_LEVEL_WARNING, orc_rt_log_Level_parse("WaRnInG"));
+
+  // Unrecognized names, including prefixes/superstrings of valid ones and the
+  // empty string, return -1.
+  EXPECT_EQ(-1, orc_rt_log_Level_parse(""));
+  EXPECT_EQ(-1, orc_rt_log_Level_parse("inf"));
+  EXPECT_EQ(-1, orc_rt_log_Level_parse("infox"));
+  EXPECT_EQ(-1, orc_rt_log_Level_parse("bogus"));
+}
+
+TEST(LoggingTest, LevelParseGetNameRoundTrip) {
+  // Every level's canonical name parses back to that level.
+  for (orc_rt_log_Level Level = ORC_RT_LOG_LEVEL_DEBUG;
+       Level != ORC_RT_LOG_LEVEL_COUNT; ++Level) {
+    const char *Name = orc_rt_log_Level_getName(Level);
+    ASSERT_NE(nullptr, Name) << "level " << Level << " has no name";
+    EXPECT_EQ(Level, orc_rt_log_Level_parse(Name)) << "round trip for " << Name;
+  }
+}
+
+TEST(LoggingTest, CategoryGetName) {
+  EXPECT_STREQ("General",
+               orc_rt_log_Category_getName(orc_rt_log_Category_General));
+
+  // The Count sentinel is not a real category, and out-of-range values have no
+  // name.
+  EXPECT_EQ(nullptr, orc_rt_log_Category_getName(orc_rt_log_Category_Count));
+  EXPECT_EQ(nullptr, orc_rt_log_Category_getName((orc_rt_log_Category)-1));
 }
 
 #if ORC_RT_LOG_BACKEND == ORC_RT_LOG_BACKEND_NONE


### PR DESCRIPTION
Add orc_rt_log_Category_getName, orc_rt_log_Level_getName, and orc_rt_log_Level_parse. These are independent of the logging backend and will be used by the printf backend and by upcoming test tools.