### PR TITLE
[orc-rt] Rename the "disable logging" level from "none" to "off"

### DIFF
--- a/orc-rt/include/orc-rt-c/Logging.h
+++ b/orc-rt/include/orc-rt-c/Logging.h
@@ -62,7 +62,7 @@ typedef enum {
 /**
  * Logging levels are integers. Valid values are ORC_RT_LOG_LEVEL_DEBUG,
  * ORC_RT_LOG_LEVEL_INFO, ORC_RT_LOG_LEVEL_WARNING, ORC_RT_LOG_LEVEL_ERROR, and
- * ORC_RT_LOG_LEVEL_NONE.
+ * ORC_RT_LOG_LEVEL_OFF.
  */
 typedef int orc_rt_log_Level;
 

--- a/orc-rt/include/orc-rt-c/config.h.in
+++ b/orc-rt/include/orc-rt-c/config.h.in
@@ -21,8 +21,8 @@
 #define ORC_RT_LOG_LEVEL_INFO    1
 #define ORC_RT_LOG_LEVEL_WARNING 2
 #define ORC_RT_LOG_LEVEL_ERROR   3
-#define ORC_RT_LOG_LEVEL_NONE    4
-#define ORC_RT_LOG_LEVEL_COUNT   (ORC_RT_LOG_LEVEL_NONE + 1)
+#define ORC_RT_LOG_LEVEL_OFF     4
+#define ORC_RT_LOG_LEVEL_COUNT   (ORC_RT_LOG_LEVEL_OFF + 1)
 /* Fail loudly if CMake derived a symbol that isn't defined above. */
 #ifndef @ORC_RT_LOG_LEVEL_VALUE@
 #error "Invalid ORC_RT_LOG_LEVEL"

--- a/orc-rt/lib/executor/Logging.cpp
+++ b/orc-rt/lib/executor/Logging.cpp
@@ -19,7 +19,7 @@
 static const char *CategoryNames[orc_rt_log_Category_Count] = {"General"};
 
 static const char *LevelNames[ORC_RT_LOG_LEVEL_COUNT] = {
-    "debug", "info", "warning", "error", "none",
+    "debug", "info", "warning", "error", "off",
 };
 
 const char *orc_rt_log_Category_getName(orc_rt_log_Category Cat) noexcept {

--- a/orc-rt/test/unit/LoggingTest.cpp
+++ b/orc-rt/test/unit/LoggingTest.cpp
@@ -31,7 +31,7 @@ TEST(LoggingTest, LevelGetName) {
   EXPECT_STREQ("info", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_INFO));
   EXPECT_STREQ("warning", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_WARNING));
   EXPECT_STREQ("error", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_ERROR));
-  EXPECT_STREQ("none", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_NONE));
+  EXPECT_STREQ("off", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_OFF));
 
   // Out-of-range levels have no name.
   EXPECT_EQ(nullptr, orc_rt_log_Level_getName(-1));
@@ -44,7 +44,7 @@ TEST(LoggingTest, LevelParse) {
   EXPECT_EQ(ORC_RT_LOG_LEVEL_INFO, orc_rt_log_Level_parse("info"));
   EXPECT_EQ(ORC_RT_LOG_LEVEL_WARNING, orc_rt_log_Level_parse("warning"));
   EXPECT_EQ(ORC_RT_LOG_LEVEL_ERROR, orc_rt_log_Level_parse("error"));
-  EXPECT_EQ(ORC_RT_LOG_LEVEL_NONE, orc_rt_log_Level_parse("none"));
+  EXPECT_EQ(ORC_RT_LOG_LEVEL_OFF, orc_rt_log_Level_parse("off"));
 
   // Parsing is case-insensitive.
   EXPECT_EQ(ORC_RT_LOG_LEVEL_INFO, orc_rt_log_Level_parse("INFO"));


### PR DESCRIPTION
Rename ORC_RT_LOG_LEVEL_NONE to ORC_RT_LOG_LEVEL_OFF. The old name collided with the "none" backend (a different mechanism) and could be misread as "no filtering" rather than "no output"; "off" avoids both issues.