### PR TITLE
[LangRef] State that the memory model is an axiomatic one

### DIFF
--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -4014,6 +4014,8 @@ The LLVM IR does not define any way to start parallel threads of
 execution or to register signal handlers. Nonetheless, there are
 platform-specific ways to create them, and we define LLVM IR's behavior
 in their presence. This model is inspired by the C++ memory model.
+The memory model is defined axiomatically: it provides constraints that valid
+executions of multi-threaded LLVM IR programs must satisfy.
 
 For a more informal introduction to this model, see the {doc}`Atomics`.
 

--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -4014,8 +4014,10 @@ The LLVM IR does not define any way to start parallel threads of
 execution or to register signal handlers. Nonetheless, there are
 platform-specific ways to create them, and we define LLVM IR's behavior
 in their presence. This model is inspired by the C++ memory model.
-The memory model is defined axiomatically: it provides constraints that valid
-executions of multi-threaded LLVM IR programs must satisfy.
+The memory model is defined axiomatically: we consider a set of candidate
+executions where every read can (in principle) read from every write
+to the same location (including "later" writes), and provide constraints that
+reduce this candidate set to the set of actually valid executions.
 
 For a more informal introduction to this model, see the {doc}`Atomics`.
 


### PR DESCRIPTION
Currently, one could read large parts of the memory model without learning for
sure whether it is meant as an operational model that describes how individual
operations change some notion of state or if it is an axiomatic model (like the
C++ memory model) that lists constraints that a candidate execution must
satisfy to be allowed.

While the description of what a read returns sounds somewhat operational,
aspects like the definition of fence instructions, the monotonic modification
order, and the total order of sequentially consistent operations place it in
the realm of axiomatic models.

This is an attempt to make the nature of the model more explicit (and maybe a
place to discuss the nature of the model), as suggested by RalfJung in the
reviews for #204329.