### PR TITLE
[lldb][test] Make expect_expr/var_path non-fatal by default

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2979,6 +2979,7 @@ FileCheck output:
         result_type=None,
         result_children=None,
         options=None,
+        stop_on_fail=False,
     ):
         """
         Evaluates the given expression and verifies the result.
@@ -2989,6 +2990,10 @@ FileCheck output:
         :param result_children: The expected children of the expression result
                                 as a list of ValueChecks. None if the children shouldn't be checked.
         :param options: Expression evaluation options. None if a default set of options should be used.
+        :param stop_on_fail: If True, a failing check aborts the whole test.
+                             If False (the default), a failing check is recorded
+                             as a test failure but the rest of the test keeps
+                             running.
         """
         self.assertTrue(
             expr.strip() == expr,
@@ -3023,11 +3028,23 @@ FileCheck output:
             summary=result_summary,
             children=result_children,
         )
-        value_check.check_value(self, eval_result)
+        if stop_on_fail:
+            value_check.check_value(self, eval_result)
+        else:
+            # Run the checks in a subtest so that a failing check is reported
+            # as a test failure but doesn't abort the rest of the test.
+            with self.subTest(expr=expr):
+                value_check.check_value(self, eval_result)
         return eval_result
 
     def expect_var_path(
-        self, var_path, summary=None, value=None, type=None, children=None
+        self,
+        var_path,
+        summary=None,
+        value=None,
+        type=None,
+        children=None,
+        stop_on_fail=False,
     ):
         """
         Evaluates the given variable path and verifies the result.
@@ -3038,6 +3055,10 @@ FileCheck output:
         :param type: The type that the variable result should have. None if the type should not be checked.
         :param children: The expected children of the variable  as a list of ValueChecks.
                          None if the children shouldn't be checked.
+        :param stop_on_fail: If True, a failing check aborts the whole test.
+                             If False (the default), a failing check is recorded
+                             as a test failure but the rest of the test keeps
+                             running.
         """
         self.assertTrue(
             var_path.strip() == var_path,
@@ -3050,7 +3071,13 @@ FileCheck output:
         value_check = ValueCheck(
             type=type, value=value, summary=summary, children=children
         )
-        value_check.check_value(self, eval_result)
+        if stop_on_fail:
+            value_check.check_value(self, eval_result)
+        else:
+            # Run the checks in a subtest so that a failing check is reported
+            # as a test failure but doesn't abort the rest of the test.
+            with self.subTest(var_path=var_path):
+                value_check.check_value(self, eval_result)
         return eval_result
 
     """Assert that an lldb.SBError is in the "success" state."""

--- a/lldb/test/API/commands/expression/import-std-module/shared_ptr-dbg-info-content/TestSharedPtrDbgInfoContentFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/shared_ptr-dbg-info-content/TestSharedPtrDbgInfoContentFromStdModule.py
@@ -27,7 +27,9 @@ class TestSharedPtrDbgInfoContent(TestBase):
             result_children=[ValueCheck(name="pointer")],
         )
         self.expect_expr("s->a", result_type="int", result_value="3")
-        self.expect_expr("s->a = 5", result_type="int", result_value="5")
+        self.expect_expr(
+            "s->a = 5", result_type="int", result_value="5", stop_on_fail=True
+        )
         self.expect_expr("s->a", result_type="int", result_value="5")
         self.expect_expr("(bool)s", result_type="bool", result_value="true")
         self.expect("expr s.reset()")

--- a/lldb/test/API/commands/expression/import-std-module/shared_ptr/TestSharedPtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/shared_ptr/TestSharedPtrFromStdModule.py
@@ -30,7 +30,9 @@ class TestSharedPtr(TestBase):
             result_children=[ValueCheck(name="pointer")],
         )
         self.expect_expr("*s", result_type="element_type", result_value="3")
-        self.expect_expr("*s = 5", result_type="element_type", result_value="5")
+        self.expect_expr(
+            "*s = 5", result_type="element_type", result_value="5", stop_on_fail=True
+        )
         self.expect_expr("*s", result_type="element_type", result_value="5")
         self.expect_expr("(bool)s", result_type="bool", result_value="true")
         self.expect("expr s.reset()")

--- a/lldb/test/API/commands/expression/import-std-module/unique_ptr-dbg-info-content/TestUniquePtrDbgInfoContent.py
+++ b/lldb/test/API/commands/expression/import-std-module/unique_ptr-dbg-info-content/TestUniquePtrDbgInfoContent.py
@@ -36,7 +36,9 @@ class TestUniquePtrDbgInfoContent(TestBase):
             result_children=[ValueCheck(children=[ValueCheck(value="3")])],
         )
         self.expect_expr("s->a", result_type="int", result_value="3")
-        self.expect_expr("s->a = 5", result_type="int", result_value="5")
+        self.expect_expr(
+            "s->a = 5", result_type="int", result_value="5", stop_on_fail=True
+        )
         self.expect_expr("(int)s->a", result_type="int", result_value="5")
         self.expect_expr("(bool)s", result_type="bool", result_value="true")
         self.expect("expr s.reset()")

--- a/lldb/test/API/commands/expression/import-std-module/unique_ptr/TestUniquePtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/unique_ptr/TestUniquePtrFromStdModule.py
@@ -37,7 +37,9 @@ class TestUniquePtr(TestBase):
             result_children=[ValueCheck(name="pointer")],
         )
         self.expect_expr("*s", result_type="int", result_value="3")
-        self.expect_expr("*s = 5", result_type="int", result_value="5")
+        self.expect_expr(
+            "*s = 5", result_type="int", result_value="5", stop_on_fail=True
+        )
         self.expect_expr("*s", result_type="int", result_value="5")
         self.expect_expr("(bool)s", result_type="bool", result_value="true")
         self.expect("expr s.reset()")

--- a/lldb/test/API/commands/expression/import-std-module/weak_ptr-dbg-info-content/TestDbgInfoContentWeakPtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/weak_ptr-dbg-info-content/TestDbgInfoContentWeakPtrFromStdModule.py
@@ -29,7 +29,9 @@ class TestDbgInfoContentWeakPtr(TestBase):
         )
         self.expect_expr("*w.lock()", result_type="element_type")
         self.expect_expr("w.lock()->a", result_type="int", result_value="3")
-        self.expect_expr("w.lock()->a = 5", result_type="int", result_value="5")
+        self.expect_expr(
+            "w.lock()->a = 5", result_type="int", result_value="5", stop_on_fail=True
+        )
         self.expect_expr("w.lock()->a", result_type="int", result_value="5")
         self.expect_expr("w.use_count()", result_type="long", result_value="1")
         self.expect("expr w.reset()")

--- a/lldb/test/API/commands/expression/import-std-module/weak_ptr/TestWeakPtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/weak_ptr/TestWeakPtrFromStdModule.py
@@ -30,7 +30,12 @@ class TestSharedPtr(TestBase):
             result_children=[ValueCheck(name="pointer")],
         )
         self.expect_expr("*w.lock()", result_type="element_type", result_value="3")
-        self.expect_expr("*w.lock() = 5", result_type="element_type", result_value="5")
+        self.expect_expr(
+            "*w.lock() = 5",
+            result_type="element_type",
+            result_value="5",
+            stop_on_fail=True,
+        )
         self.expect_expr("*w.lock()", result_type="element_type", result_value="5")
         self.expect_expr("w.use_count()", result_type="long", result_value="1")
         self.expect("expr w.reset()")

--- a/lldb/test/API/functionalities/postmortem/elf-core/expr/TestExpr.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/expr/TestExpr.py
@@ -44,7 +44,7 @@ class CoreExprTestCase(TestBase):
     def test_context_object(self):
         """Test expression evaluation in context of an object."""
 
-        val_outer = self.expect_expr("outer", result_type="Outer")
+        val_outer = self.expect_expr("outer", result_type="Outer", stop_on_fail=True)
 
         val_inner = val_outer.EvaluateExpression("inner")
         self.assertTrue(val_inner.IsValid())

--- a/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
+++ b/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
@@ -36,7 +36,7 @@ class AbiTagStructorsTestCase(TestBase):
             result_type="Tagged",
             result_children=[ValueCheck(name="x", value="-17")],
         )
-        self.expect_expr("t1 = t2", result_type="Tagged")
+        self.expect_expr("t1 = t2", result_type="Tagged", stop_on_fail=True)
 
         self.expect("expr Tagged t3(t1)", error=False)
         self.expect("expr t1.~Tagged()", error=False)

--- a/lldb/test/API/lang/cpp/dereferencing_references/TestCPPDereferencingReferences.py
+++ b/lldb/test/API/lang/cpp/dereferencing_references/TestCPPDereferencingReferences.py
@@ -15,13 +15,15 @@ class TestCase(TestBase):
         # Take an lvalue reference and call `Dereference` on the SBValue.
         # The result should be `TTT` (and *not* for example the underlying type
         # 'int').
-        lref_val = self.expect_var_path("l_ref", type="TTT &")
+        lref_val = self.expect_var_path("l_ref", type="TTT &", stop_on_fail=True)
         self.assertEqual(lref_val.Dereference().GetType().GetName(), "TTT")
 
         # Same as above for rvalue references.
-        rref_val = self.expect_var_path("r_ref", type="TTT &&")
+        rref_val = self.expect_var_path("r_ref", type="TTT &&", stop_on_fail=True)
         self.assertEqual(rref_val.Dereference().GetType().GetName(), "TTT")
 
         # Typedef to a reference should dereference to the underlying type.
-        td_val = self.expect_var_path("td_to_ref_type", type="td_int_ref")
+        td_val = self.expect_var_path(
+            "td_to_ref_type", type="td_int_ref", stop_on_fail=True
+        )
         self.assertEqual(td_val.Dereference().GetType().GetName(), "int")

--- a/lldb/test/API/lang/cpp/this_class_type_mixing/TestThisClassTypeMixing.py
+++ b/lldb/test/API/lang/cpp/this_class_type_mixing/TestThisClassTypeMixing.py
@@ -25,7 +25,7 @@ class TestCase(TestBase):
 
         # Evaluate an expression in a member function. Store the type of the
         # 'this' pointer in a persistent variable.
-        self.expect_expr("A $p = *this; $p", result_type="A")
+        self.expect_expr("A $p = *this; $p", result_type="A", stop_on_fail=True)
 
         breakpoint = self.target().BreakpointCreateBySourceRegex(
             "// break in main", lldb.SBFileSpec("main.cpp")


### PR DESCRIPTION
This makes expect_expr and expect_var_path's checks non-fatal by default. This allows the test to continue and run additional checks before being marked as fail.

The motivation for this is that most (if not all) of our expect_expr and expect_var_path calls are independent checks for different properties. If I make a change and run a test, I usually want to see everything I broke and not just the first failure in the test.

I added an additional flag that allows preserving the current behavior. That flag is turned on for the few expect_expr/var_path calls where stopping on failure makes sense (e.g., because they have a side effect).