### PR TITLE
[AMDGPU] Remove option to disable SGPR hazard waits

### DIFF
--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -2644,9 +2644,6 @@ The AMDGPU backend supports the following LLVM IR attributes.
 
                                                       This is only relevant on targets with AGPRs which support accum_offset (gfx90a+).
 
-     "amdgpu-sgpr-hazard-wait"                        Disabled SGPR hazard wait insertion if set to 0.
-                                                      Exists for testing performance impact of SGPR hazard waits only.
-
      "amdgpu-sgpr-hazard-boundary-cull"               Enable insertion of SGPR hazard cull sequences at function call boundaries.
                                                       Cull sequence reduces future hazard waits, but has a performance cost.
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaitSGPRHazards.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaitSGPRHazards.cpp
@@ -23,10 +23,6 @@ using namespace llvm;
 
 #define DEBUG_TYPE "amdgpu-wait-sgpr-hazards"
 
-static cl::opt<bool> GlobalEnableSGPRHazardWaits(
-    "amdgpu-sgpr-hazard-wait", cl::init(true), cl::Hidden,
-    cl::desc("Enable required s_wait_alu on SGPR hazards"));
-
 static cl::opt<bool> GlobalCullSGPRHazardsOnFunctionBoundary(
     "amdgpu-sgpr-hazard-boundary-cull", cl::init(false), cl::Hidden,
     cl::desc("Cull hazards on function boundaries"));
@@ -51,7 +47,6 @@ public:
   const MachineRegisterInfo *MRI;
   unsigned DsNopCount;
 
-  bool EnableSGPRHazardWaits;
   bool CullSGPRHazardsOnFunctionBoundary;
   bool CullSGPRHazardsAtMemWait;
   unsigned CullSGPRHazardsMemWaitThreshold;
@@ -448,14 +443,10 @@ public:
       return false;
 
     // Parse settings
-    EnableSGPRHazardWaits = GlobalEnableSGPRHazardWaits;
     CullSGPRHazardsOnFunctionBoundary = GlobalCullSGPRHazardsOnFunctionBoundary;
     CullSGPRHazardsAtMemWait = GlobalCullSGPRHazardsAtMemWait;
     CullSGPRHazardsMemWaitThreshold = GlobalCullSGPRHazardsMemWaitThreshold;
 
-    if (!GlobalEnableSGPRHazardWaits.getNumOccurrences())
-      EnableSGPRHazardWaits = MF.getFunction().getFnAttributeAsParsedInteger(
-          "amdgpu-sgpr-hazard-wait", EnableSGPRHazardWaits);
     if (!GlobalCullSGPRHazardsOnFunctionBoundary.getNumOccurrences())
       CullSGPRHazardsOnFunctionBoundary =
           MF.getFunction().hasFnAttribute("amdgpu-sgpr-hazard-boundary-cull");
@@ -467,10 +458,6 @@ public:
           MF.getFunction().getFnAttributeAsParsedInteger(
               "amdgpu-sgpr-hazard-mem-wait-cull-threshold",
               CullSGPRHazardsMemWaitThreshold);
-
-    // Bail if disabled
-    if (!EnableSGPRHazardWaits)
-      return false;
 
     TII = ST->getInstrInfo();
     TRI = ST->getRegisterInfo();

--- a/llvm/test/CodeGen/AMDGPU/valu-read-sgpr-hazard-attrs.mir
+++ b/llvm/test/CodeGen/AMDGPU/valu-read-sgpr-hazard-attrs.mir
@@ -2,8 +2,6 @@
 # RUN: llc -mtriple=amdgcn -mcpu=gfx1200 -run-pass post-RA-hazard-rec,amdgpu-wait-sgpr-hazards -o - %s | FileCheck -check-prefix=GCN %s
 
 --- |
-  define amdgpu_gs void @hazard_disable() #0 { ret void }
-  define amdgpu_gs void @hazard_enable() #1 { ret void }
   define amdgpu_cs void @hazard_calls() #2 { ret void }
   define void @hazard_callee1() #2 { ret void }
   define void @hazard_callee2() #2 { ret void }
@@ -15,42 +13,9 @@
   define amdgpu_cs void @hazard_cull_global() #3 { ret void }
   define amdgpu_cs void @hazard_nocull_flat() #3 { ret void }
 
-  attributes #0 = { "amdgpu-sgpr-hazard-wait"="0" }
-  attributes #1 = { "amdgpu-sgpr-hazard-wait"="1" }
   attributes #2 = { "amdgpu-sgpr-hazard-boundary-cull" }
   attributes #3 = { "amdgpu-sgpr-hazard-mem-wait-cull" "amdgpu-sgpr-hazard-mem-wait-cull-threshold"="1" }
   attributes #4 = { "amdgpu-sgpr-hazard-mem-wait-cull" "amdgpu-sgpr-hazard-mem-wait-cull-threshold"="2" }
-...
-
----
-name:            hazard_disable
-body:            |
-  bb.0:
-    ; GCN-LABEL: name: hazard_disable
-    ; GCN: $vgpr1 = V_CNDMASK_B32_e64 0, $vgpr1, 0, $vgpr2, $sgpr0, implicit $exec
-    ; GCN-NEXT: $sgpr0_sgpr1 = S_GETPC_B64
-    ; GCN-NEXT: $sgpr3 = S_ADD_U32 $sgpr0, 0, implicit-def $scc
-    ; GCN-NEXT: S_ENDPGM 0
-    $vgpr1 = V_CNDMASK_B32_e64 0, $vgpr1, 0, $vgpr2, $sgpr0, implicit $exec
-    $sgpr0_sgpr1 = S_GETPC_B64
-    $sgpr3 = S_ADD_U32 $sgpr0, 0, implicit-def $scc
-    S_ENDPGM 0
-...
-
----
-name:            hazard_enable
-body:            |
-  bb.0:
-    ; GCN-LABEL: name: hazard_enable
-    ; GCN: $vgpr1 = V_CNDMASK_B32_e64 0, $vgpr1, 0, $vgpr2, $sgpr0, implicit $exec
-    ; GCN-NEXT: $sgpr0_sgpr1 = S_GETPC_B64
-    ; GCN-NEXT: S_WAITCNT_DEPCTR .SaSdst_0
-    ; GCN-NEXT: $sgpr3 = S_ADD_U32 $sgpr0, 0, implicit-def $scc
-    ; GCN-NEXT: S_ENDPGM 0
-    $vgpr1 = V_CNDMASK_B32_e64 0, $vgpr1, 0, $vgpr2, $sgpr0, implicit $exec
-    $sgpr0_sgpr1 = S_GETPC_B64
-    $sgpr3 = S_ADD_U32 $sgpr0, 0, implicit-def $scc
-    S_ENDPGM 0
 ...
 
 ---


### PR DESCRIPTION
This was useful when initially implemented, but probably be removed now.