### PR TITLE
Triple: Move OS/vendor/environment names into a def file

### DIFF
--- a/llvm/include/llvm/TargetParser/TripleName.def
+++ b/llvm/include/llvm/TargetParser/TripleName.def
@@ -1,0 +1,198 @@
+//===- TripleName.def - Triple component name table -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// NOTE: NO INCLUDE GUARD DESIRED!
+
+//===----------------------------------------------------------------------===//
+// OS names.
+//
+// TRIPLE_OS(Enum, Name)
+//   Enum - the Triple::OSType enumerator
+//   Name - the canonical string
+//
+// TRIPLE_OS_ALIAS(Enum, AliasName)
+//   An additional prefix maps to an OSType.
+//
+// Order is significant: parsing uses prefix matching, so a name that is a
+// prefix of another must come AFTER it (wasip1/2/3 before wasi).
+// ===----------------------------------------------------------------------===//
+
+#ifndef TRIPLE_OS
+#define TRIPLE_OS(Enum, Name)
+#endif
+#ifndef TRIPLE_OS_ALIAS
+#define TRIPLE_OS_ALIAS(Enum, AliasName)
+#endif
+
+TRIPLE_OS(Darwin, "darwin")
+TRIPLE_OS(DragonFly, "dragonfly")
+TRIPLE_OS(FreeBSD, "freebsd")
+TRIPLE_OS(Fuchsia, "fuchsia")
+TRIPLE_OS(IOS, "ios")
+TRIPLE_OS(KFreeBSD, "kfreebsd")
+TRIPLE_OS(Linux, "linux")
+TRIPLE_OS(Lv2, "lv2")
+TRIPLE_OS(MacOSX, "macosx")
+TRIPLE_OS_ALIAS(MacOSX, "macos")
+TRIPLE_OS(Managarm, "managarm")
+TRIPLE_OS(NetBSD, "netbsd")
+TRIPLE_OS(OpenBSD, "openbsd")
+TRIPLE_OS(Solaris, "solaris")
+TRIPLE_OS(UEFI, "uefi")
+TRIPLE_OS(Win32, "windows")
+TRIPLE_OS_ALIAS(Win32, "win32")
+TRIPLE_OS(ZOS, "zos")
+TRIPLE_OS(Haiku, "haiku")
+TRIPLE_OS(RTEMS, "rtems")
+TRIPLE_OS(AIX, "aix")
+TRIPLE_OS(CUDA, "cuda")
+TRIPLE_OS(NVCL, "nvcl")
+TRIPLE_OS(AMDHSA, "amdhsa")
+TRIPLE_OS(PS4, "ps4")
+TRIPLE_OS(PS5, "ps5")
+TRIPLE_OS(ELFIAMCU, "elfiamcu")
+TRIPLE_OS(TvOS, "tvos")
+TRIPLE_OS(WatchOS, "watchos")
+TRIPLE_OS(BridgeOS, "bridgeos")
+TRIPLE_OS(DriverKit, "driverkit")
+TRIPLE_OS(XROS, "xros")
+TRIPLE_OS_ALIAS(XROS, "visionos")
+TRIPLE_OS(Mesa3D, "mesa3d")
+TRIPLE_OS(AMDPAL, "amdpal")
+TRIPLE_OS(HermitCore, "hermit")
+TRIPLE_OS(Hurd, "hurd")
+TRIPLE_OS(WASIp1, "wasip1")
+TRIPLE_OS(WASIp2, "wasip2")
+TRIPLE_OS(WASIp3, "wasip3")
+TRIPLE_OS(WASI, "wasi")
+TRIPLE_OS(Emscripten, "emscripten")
+TRIPLE_OS(ShaderModel, "shadermodel")
+TRIPLE_OS(LiteOS, "liteos")
+TRIPLE_OS(Serenity, "serenity")
+TRIPLE_OS(Vulkan, "vulkan")
+TRIPLE_OS(CheriotRTOS, "cheriotrtos")
+TRIPLE_OS(OpenCL, "opencl")
+TRIPLE_OS(ChipStar, "chipstar")
+TRIPLE_OS(Firmware, "firmware")
+TRIPLE_OS(QURT, "qurt")
+TRIPLE_OS(H2, "h2")
+
+#undef TRIPLE_OS
+#undef TRIPLE_OS_ALIAS
+
+//===----------------------------------------------------------------------===//
+// Environment names.
+//
+// TRIPLE_ENV(Enum, Name)
+//   Enum - the Triple::EnvironmentType enumerator.
+//   Name - the canonical string
+//
+// Order is significant for the same prefix-matching reason as OS (eabihf before
+// eabi; the gnu*/musl* variants before gnu/musl).
+//===----------------------------------------------------------------------===//
+
+#ifndef TRIPLE_ENV
+#define TRIPLE_ENV(Enum, Name)
+#endif
+
+TRIPLE_ENV(EABIHF, "eabihf")
+TRIPLE_ENV(EABI, "eabi")
+TRIPLE_ENV(GNUABIN32, "gnuabin32")
+TRIPLE_ENV(GNUABI64, "gnuabi64")
+TRIPLE_ENV(GNUEABIHFT64, "gnueabihft64")
+TRIPLE_ENV(GNUEABIHF, "gnueabihf")
+TRIPLE_ENV(GNUEABIT64, "gnueabit64")
+TRIPLE_ENV(GNUEABI, "gnueabi")
+TRIPLE_ENV(GNUF32, "gnuf32")
+TRIPLE_ENV(GNUF64, "gnuf64")
+TRIPLE_ENV(GNUSF, "gnusf")
+TRIPLE_ENV(GNUX32, "gnux32")
+TRIPLE_ENV(GNUILP32, "gnu_ilp32")
+TRIPLE_ENV(CODE16, "code16")
+TRIPLE_ENV(GNUT64, "gnut64")
+TRIPLE_ENV(GNU, "gnu")
+TRIPLE_ENV(Android, "android")
+TRIPLE_ENV(MuslABIN32, "muslabin32")
+TRIPLE_ENV(MuslABI64, "muslabi64")
+TRIPLE_ENV(MuslEABIHF, "musleabihf")
+TRIPLE_ENV(MuslEABI, "musleabi")
+TRIPLE_ENV(MuslF32, "muslf32")
+TRIPLE_ENV(MuslSF, "muslsf")
+TRIPLE_ENV(MuslX32, "muslx32")
+TRIPLE_ENV(MuslWALI, "muslwali")
+TRIPLE_ENV(Musl, "musl")
+TRIPLE_ENV(MSVC, "msvc")
+TRIPLE_ENV(Itanium, "itanium")
+TRIPLE_ENV(Cygnus, "cygnus")
+TRIPLE_ENV(CoreCLR, "coreclr")
+TRIPLE_ENV(Simulator, "simulator")
+TRIPLE_ENV(MacABI, "macabi")
+TRIPLE_ENV(Pixel, "pixel")
+TRIPLE_ENV(Vertex, "vertex")
+TRIPLE_ENV(Geometry, "geometry")
+TRIPLE_ENV(Hull, "hull")
+TRIPLE_ENV(Domain, "domain")
+TRIPLE_ENV(Compute, "compute")
+TRIPLE_ENV(Library, "library")
+TRIPLE_ENV(RayGeneration, "raygeneration")
+TRIPLE_ENV(Intersection, "intersection")
+TRIPLE_ENV(AnyHit, "anyhit")
+TRIPLE_ENV(ClosestHit, "closesthit")
+TRIPLE_ENV(Miss, "miss")
+TRIPLE_ENV(Callable, "callable")
+TRIPLE_ENV(Mesh, "mesh")
+TRIPLE_ENV(Amplification, "amplification")
+TRIPLE_ENV(RootSignature, "rootsignature")
+TRIPLE_ENV(OpenHOS, "ohos")
+TRIPLE_ENV(PAuthTest, "pauthtest")
+TRIPLE_ENV(LLVM, "llvm")
+TRIPLE_ENV(Mlibc, "mlibc")
+TRIPLE_ENV(MTIA, "mtia")
+
+#undef TRIPLE_ENV
+
+//===----------------------------------------------------------------------===//
+// Vendor names.
+//
+// TRIPLE_VENDOR(Enum, Name)
+//   Enum - the Triple::VendorType enumerator.
+//   Name - the canonical string
+//
+// TRIPLE_VENDOR_ALIAS(Enum, AliasName)
+//   An additional string that maps to a VendorType.
+//
+// Unlike OS and environment names, vendors are matched exactly,
+// so entry order is insignificant.
+//===----------------------------------------------------------------------===//
+
+#ifndef TRIPLE_VENDOR
+#define TRIPLE_VENDOR(Enum, Name)
+#endif
+#ifndef TRIPLE_VENDOR_ALIAS
+#define TRIPLE_VENDOR_ALIAS(Enum, AliasName)
+#endif
+
+TRIPLE_VENDOR(AMD, "amd")
+TRIPLE_VENDOR(Apple, "apple")
+TRIPLE_VENDOR(CSR, "csr")
+TRIPLE_VENDOR(Freescale, "fsl")
+TRIPLE_VENDOR(IBM, "ibm")
+TRIPLE_VENDOR(ImaginationTechnologies, "img")
+TRIPLE_VENDOR(Intel, "intel")
+TRIPLE_VENDOR(Mesa, "mesa")
+TRIPLE_VENDOR(MipsTechnologies, "mti")
+TRIPLE_VENDOR(NVIDIA, "nvidia")
+TRIPLE_VENDOR(OpenEmbedded, "oe")
+TRIPLE_VENDOR(PC, "pc")
+TRIPLE_VENDOR(SCEI, "scei")
+TRIPLE_VENDOR_ALIAS(SCEI, "sie")
+TRIPLE_VENDOR(SUSE, "suse")
+TRIPLE_VENDOR(Meta, "meta")
+
+#undef TRIPLE_VENDOR
+#undef TRIPLE_VENDOR_ALIAS

--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -427,6 +427,7 @@ module LLVM_Utils {
     textual header "llvm/TargetParser/X86TargetParser.def"
     textual header "llvm/TargetParser/LoongArchTargetParser.def"
     textual header "llvm/TargetParser/PPCTargetParser.def"
+    textual header "llvm/TargetParser/TripleName.def"
     textual header "llvm/TargetParser/XtensaTargetParser.def"
   }
 

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -422,37 +422,10 @@ StringRef Triple::getVendorTypeName(VendorType Kind) {
   switch (Kind) {
   case UnknownVendor:
     return "unknown";
-
-  case AMD:
-    return "amd";
-  case Apple:
-    return "apple";
-  case CSR:
-    return "csr";
-  case Freescale:
-    return "fsl";
-  case IBM:
-    return "ibm";
-  case ImaginationTechnologies:
-    return "img";
-  case Intel:
-    return "intel";
-  case Mesa:
-    return "mesa";
-  case MipsTechnologies:
-    return "mti";
-  case NVIDIA:
-    return "nvidia";
-  case OpenEmbedded:
-    return "oe";
-  case PC:
-    return "pc";
-  case SCEI:
-    return "scei";
-  case SUSE:
-    return "suse";
-  case Meta:
-    return "meta";
+#define TRIPLE_VENDOR(Enum, Name)                                              \
+  case Enum:                                                                   \
+    return Name;
+#include "llvm/TargetParser/TripleName.def"
   }
 
   llvm_unreachable("Invalid VendorType!");
@@ -462,105 +435,10 @@ StringRef Triple::getOSTypeName(OSType Kind) {
   switch (Kind) {
   case UnknownOS:
     return "unknown";
-
-  case AIX:
-    return "aix";
-  case AMDHSA:
-    return "amdhsa";
-  case AMDPAL:
-    return "amdpal";
-  case BridgeOS:
-    return "bridgeos";
-  case CUDA:
-    return "cuda";
-  case Darwin:
-    return "darwin";
-  case DragonFly:
-    return "dragonfly";
-  case DriverKit:
-    return "driverkit";
-  case ELFIAMCU:
-    return "elfiamcu";
-  case Emscripten:
-    return "emscripten";
-  case FreeBSD:
-    return "freebsd";
-  case Fuchsia:
-    return "fuchsia";
-  case Haiku:
-    return "haiku";
-  case HermitCore:
-    return "hermit";
-  case Hurd:
-    return "hurd";
-  case IOS:
-    return "ios";
-  case KFreeBSD:
-    return "kfreebsd";
-  case Linux:
-    return "linux";
-  case Lv2:
-    return "lv2";
-  case MacOSX:
-    return "macosx";
-  case Managarm:
-    return "managarm";
-  case Mesa3D:
-    return "mesa3d";
-  case NVCL:
-    return "nvcl";
-  case NetBSD:
-    return "netbsd";
-  case OpenBSD:
-    return "openbsd";
-  case PS4:
-    return "ps4";
-  case PS5:
-    return "ps5";
-  case RTEMS:
-    return "rtems";
-  case Solaris:
-    return "solaris";
-  case Serenity:
-    return "serenity";
-  case TvOS:
-    return "tvos";
-  case UEFI:
-    return "uefi";
-  case WASI:
-    return "wasi";
-  case WASIp1:
-    return "wasip1";
-  case WASIp2:
-    return "wasip2";
-  case WASIp3:
-    return "wasip3";
-  case WatchOS:
-    return "watchos";
-  case Win32:
-    return "windows";
-  case ZOS:
-    return "zos";
-  case ShaderModel:
-    return "shadermodel";
-  case LiteOS:
-    return "liteos";
-  case XROS:
-    return "xros";
-  case Vulkan:
-    return "vulkan";
-  case CheriotRTOS:
-    return "cheriotrtos";
-  case OpenCL:
-    return "opencl";
-  case ChipStar:
-    return "chipstar";
-  case Firmware:
-    return "firmware";
-  case QURT:
-    return "qurt";
-  case H2:
-    return "h2";
+#define TRIPLE_OS(Enum, Name)                                                  \
+  case Enum:                                                                   \
+    return Name;
+#include "llvm/TargetParser/TripleName.def"
   }
 
   llvm_unreachable("Invalid OSType");
@@ -570,112 +448,10 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
   switch (Kind) {
   case UnknownEnvironment:
     return "unknown";
-  case Android:
-    return "android";
-  case CODE16:
-    return "code16";
-  case CoreCLR:
-    return "coreclr";
-  case Cygnus:
-    return "cygnus";
-  case EABI:
-    return "eabi";
-  case EABIHF:
-    return "eabihf";
-  case GNU:
-    return "gnu";
-  case GNUT64:
-    return "gnut64";
-  case GNUABI64:
-    return "gnuabi64";
-  case GNUABIN32:
-    return "gnuabin32";
-  case GNUEABI:
-    return "gnueabi";
-  case GNUEABIT64:
-    return "gnueabit64";
-  case GNUEABIHF:
-    return "gnueabihf";
-  case GNUEABIHFT64:
-    return "gnueabihft64";
-  case GNUF32:
-    return "gnuf32";
-  case GNUF64:
-    return "gnuf64";
-  case GNUSF:
-    return "gnusf";
-  case GNUX32:
-    return "gnux32";
-  case GNUILP32:
-    return "gnu_ilp32";
-  case Itanium:
-    return "itanium";
-  case MSVC:
-    return "msvc";
-  case MacABI:
-    return "macabi";
-  case Musl:
-    return "musl";
-  case MuslABIN32:
-    return "muslabin32";
-  case MuslABI64:
-    return "muslabi64";
-  case MuslEABI:
-    return "musleabi";
-  case MuslEABIHF:
-    return "musleabihf";
-  case MuslF32:
-    return "muslf32";
-  case MuslSF:
-    return "muslsf";
-  case MuslX32:
-    return "muslx32";
-  case MuslWALI:
-    return "muslwali";
-  case Simulator:
-    return "simulator";
-  case Pixel:
-    return "pixel";
-  case Vertex:
-    return "vertex";
-  case Geometry:
-    return "geometry";
-  case Hull:
-    return "hull";
-  case Domain:
-    return "domain";
-  case Compute:
-    return "compute";
-  case Library:
-    return "library";
-  case RayGeneration:
-    return "raygeneration";
-  case Intersection:
-    return "intersection";
-  case AnyHit:
-    return "anyhit";
-  case ClosestHit:
-    return "closesthit";
-  case Miss:
-    return "miss";
-  case Callable:
-    return "callable";
-  case Mesh:
-    return "mesh";
-  case Amplification:
-    return "amplification";
-  case RootSignature:
-    return "rootsignature";
-  case OpenHOS:
-    return "ohos";
-  case PAuthTest:
-    return "pauthtest";
-  case MTIA:
-    return "mtia";
-  case LLVM:
-    return "llvm";
-  case Mlibc:
-    return "mlibc";
+#define TRIPLE_ENV(Enum, Name)                                                 \
+  case Enum:                                                                   \
+    return Name;
+#include "llvm/TargetParser/TripleName.def"
   }
 
   llvm_unreachable("Invalid EnvironmentType!");
@@ -962,136 +738,24 @@ Triple::ArchType Triple::parseArch(StringRef ArchName) {
 
 static Triple::VendorType parseVendor(StringRef VendorName) {
   return StringSwitch<Triple::VendorType>(VendorName)
-      .Case("apple", Triple::Apple)
-      .Case("pc", Triple::PC)
-      .Case("scei", Triple::SCEI)
-      .Case("sie", Triple::SCEI)
-      .Case("fsl", Triple::Freescale)
-      .Case("ibm", Triple::IBM)
-      .Case("img", Triple::ImaginationTechnologies)
-      .Case("mti", Triple::MipsTechnologies)
-      .Case("nvidia", Triple::NVIDIA)
-      .Case("csr", Triple::CSR)
-      .Case("amd", Triple::AMD)
-      .Case("mesa", Triple::Mesa)
-      .Case("suse", Triple::SUSE)
-      .Case("oe", Triple::OpenEmbedded)
-      .Case("intel", Triple::Intel)
-      .Case("meta", Triple::Meta)
+#define TRIPLE_VENDOR(Enum, Name) .Case(Name, Triple::Enum)
+#define TRIPLE_VENDOR_ALIAS(Enum, AliasName) .Case(AliasName, Triple::Enum)
+#include "llvm/TargetParser/TripleName.def"
       .Default(Triple::UnknownVendor);
 }
 
 static Triple::OSType parseOS(StringRef OSName) {
   return StringSwitch<Triple::OSType>(OSName)
-      .StartsWith("darwin", Triple::Darwin)
-      .StartsWith("dragonfly", Triple::DragonFly)
-      .StartsWith("freebsd", Triple::FreeBSD)
-      .StartsWith("fuchsia", Triple::Fuchsia)
-      .StartsWith("ios", Triple::IOS)
-      .StartsWith("kfreebsd", Triple::KFreeBSD)
-      .StartsWith("linux", Triple::Linux)
-      .StartsWith("lv2", Triple::Lv2)
-      .StartsWith("macos", Triple::MacOSX)
-      .StartsWith("managarm", Triple::Managarm)
-      .StartsWith("netbsd", Triple::NetBSD)
-      .StartsWith("openbsd", Triple::OpenBSD)
-      .StartsWith("solaris", Triple::Solaris)
-      .StartsWith("uefi", Triple::UEFI)
-      .StartsWith("win32", Triple::Win32)
-      .StartsWith("windows", Triple::Win32)
-      .StartsWith("zos", Triple::ZOS)
-      .StartsWith("haiku", Triple::Haiku)
-      .StartsWith("rtems", Triple::RTEMS)
-      .StartsWith("aix", Triple::AIX)
-      .StartsWith("cuda", Triple::CUDA)
-      .StartsWith("nvcl", Triple::NVCL)
-      .StartsWith("amdhsa", Triple::AMDHSA)
-      .StartsWith("ps4", Triple::PS4)
-      .StartsWith("ps5", Triple::PS5)
-      .StartsWith("elfiamcu", Triple::ELFIAMCU)
-      .StartsWith("tvos", Triple::TvOS)
-      .StartsWith("watchos", Triple::WatchOS)
-      .StartsWith("bridgeos", Triple::BridgeOS)
-      .StartsWith("driverkit", Triple::DriverKit)
-      .StartsWith("xros", Triple::XROS)
-      .StartsWith("visionos", Triple::XROS)
-      .StartsWith("mesa3d", Triple::Mesa3D)
-      .StartsWith("amdpal", Triple::AMDPAL)
-      .StartsWith("hermit", Triple::HermitCore)
-      .StartsWith("hurd", Triple::Hurd)
-      .StartsWith("wasip1", Triple::WASIp1)
-      .StartsWith("wasip2", Triple::WASIp2)
-      .StartsWith("wasip3", Triple::WASIp3)
-      .StartsWith("wasi", Triple::WASI)
-      .StartsWith("emscripten", Triple::Emscripten)
-      .StartsWith("shadermodel", Triple::ShaderModel)
-      .StartsWith("liteos", Triple::LiteOS)
-      .StartsWith("serenity", Triple::Serenity)
-      .StartsWith("vulkan", Triple::Vulkan)
-      .StartsWith("cheriotrtos", Triple::CheriotRTOS)
-      .StartsWith("opencl", Triple::OpenCL)
-      .StartsWith("chipstar", Triple::ChipStar)
-      .StartsWith("firmware", Triple::Firmware)
-      .StartsWith("qurt", Triple::QURT)
-      .StartsWith("h2", Triple::H2)
+#define TRIPLE_OS(Enum, Name) .StartsWith(Name, Triple::Enum)
+#define TRIPLE_OS_ALIAS(Enum, AliasName) .StartsWith(AliasName, Triple::Enum)
+#include "llvm/TargetParser/TripleName.def"
       .Default(Triple::UnknownOS);
 }
 
 static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
   return StringSwitch<Triple::EnvironmentType>(EnvironmentName)
-      .StartsWith("eabihf", Triple::EABIHF)
-      .StartsWith("eabi", Triple::EABI)
-      .StartsWith("gnuabin32", Triple::GNUABIN32)
-      .StartsWith("gnuabi64", Triple::GNUABI64)
-      .StartsWith("gnueabihft64", Triple::GNUEABIHFT64)
-      .StartsWith("gnueabihf", Triple::GNUEABIHF)
-      .StartsWith("gnueabit64", Triple::GNUEABIT64)
-      .StartsWith("gnueabi", Triple::GNUEABI)
-      .StartsWith("gnuf32", Triple::GNUF32)
-      .StartsWith("gnuf64", Triple::GNUF64)
-      .StartsWith("gnusf", Triple::GNUSF)
-      .StartsWith("gnux32", Triple::GNUX32)
-      .StartsWith("gnu_ilp32", Triple::GNUILP32)
-      .StartsWith("code16", Triple::CODE16)
-      .StartsWith("gnut64", Triple::GNUT64)
-      .StartsWith("gnu", Triple::GNU)
-      .StartsWith("android", Triple::Android)
-      .StartsWith("muslabin32", Triple::MuslABIN32)
-      .StartsWith("muslabi64", Triple::MuslABI64)
-      .StartsWith("musleabihf", Triple::MuslEABIHF)
-      .StartsWith("musleabi", Triple::MuslEABI)
-      .StartsWith("muslf32", Triple::MuslF32)
-      .StartsWith("muslsf", Triple::MuslSF)
-      .StartsWith("muslx32", Triple::MuslX32)
-      .StartsWith("muslwali", Triple::MuslWALI)
-      .StartsWith("musl", Triple::Musl)
-      .StartsWith("msvc", Triple::MSVC)
-      .StartsWith("itanium", Triple::Itanium)
-      .StartsWith("cygnus", Triple::Cygnus)
-      .StartsWith("coreclr", Triple::CoreCLR)
-      .StartsWith("simulator", Triple::Simulator)
-      .StartsWith("macabi", Triple::MacABI)
-      .StartsWith("pixel", Triple::Pixel)
-      .StartsWith("vertex", Triple::Vertex)
-      .StartsWith("geometry", Triple::Geometry)
-      .StartsWith("hull", Triple::Hull)
-      .StartsWith("domain", Triple::Domain)
-      .StartsWith("compute", Triple::Compute)
-      .StartsWith("library", Triple::Library)
-      .StartsWith("raygeneration", Triple::RayGeneration)
-      .StartsWith("intersection", Triple::Intersection)
-      .StartsWith("anyhit", Triple::AnyHit)
-      .StartsWith("closesthit", Triple::ClosestHit)
-      .StartsWith("miss", Triple::Miss)
-      .StartsWith("callable", Triple::Callable)
-      .StartsWith("mesh", Triple::Mesh)
-      .StartsWith("amplification", Triple::Amplification)
-      .StartsWith("rootsignature", Triple::RootSignature)
-      .StartsWith("ohos", Triple::OpenHOS)
-      .StartsWith("pauthtest", Triple::PAuthTest)
-      .StartsWith("llvm", Triple::LLVM)
-      .StartsWith("mlibc", Triple::Mlibc)
-      .StartsWith("mtia", Triple::MTIA)
+#define TRIPLE_ENV(Enum, Name) .StartsWith(Name, Triple::Enum)
+#include "llvm/TargetParser/TripleName.def"
       .Default(Triple::UnknownEnvironment);
 }
 


### PR DESCRIPTION
Extract the component name lists into a macro .def file, similar
to how many targets do for CPU names. The arch/subarch names are
left alone because they have trickier manual parsing logic.

Co-Authored-By: Claude (Opus 4.8) <noreply@anthropic.com>