### PR TITLE
[LangRef] select: describe behavior for undef and poison

### DIFF
--- a/llvm/docs/LangRef.md
+++ b/llvm/docs/LangRef.md
@@ -13392,7 +13392,8 @@ values indicating the condition, and two values of the same {ref}`first class <t
 
 If the condition is an i1 and it evaluates to 1, the instruction returns
 the first value argument; otherwise, it returns the second value
-argument.
+argument. If the condition evaluates to `poison`, the instruction returns `poison`.
+If it evaluates to `undef`, the result is an `undef` representing the union of two value arguments (i.e., each use of this value can pick either value argument).
 
 If the condition is a vector of i1, then the value arguments must be
 vectors of the same size, and the selection is done element by element.


### PR DESCRIPTION
The poison semantics is based on https://llvm.org/docs/UndefinedBehavior.html#propagation-of-poison-through-select. IMO this definitely should appear in the "semantics" section of the `select` instruction. If this isn't part of the `select` semantics I don't know what is.

The undef semantics are a wild guess. Does `select` even have consistent semantics for undef? Part of the problem with `undef` was that this is all inconsistent, right?

Cc @nunoplopes @nikic 

@dtcxzyw what does llubi do?

Fixes https://github.com/llvm/llvm-project/issues/208761