### PR TITLE
[clang][dataflow] Fix bug in transfer function of CK_BaseToDerived

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -371,12 +371,12 @@ public:
         } else {
           Loc->addChild(*Field, &Env.createStorageLocation(FieldType));
         }
+      }
 
-        for (const auto &Entry :
-             Env.getDataflowAnalysisContext().getSyntheticFields(Derived)) {
-          Loc->addSyntheticField(Entry.getKey(),
-                                 Env.createStorageLocation(Entry.getValue()));
-        }
+      for (const auto &Entry :
+           Env.getDataflowAnalysisContext().getSyntheticFields(Derived)) {
+        Loc->addSyntheticField(Entry.getKey(),
+                               Env.createStorageLocation(Entry.getValue()));
       }
       Env.initializeFieldsWithValues(*Loc, Derived);
 

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -3859,6 +3859,33 @@ TEST(TransferTest, StaticCastBaseToDerivedUnknown) {
       });
 }
 
+TEST(TransferTest, StaticCastBaseToDerivedWithSyntheticFieldsNoModeledFields) {
+  std::string Code = R"cc(
+    struct Base {};
+    struct Derived : public Base {};
+    void target(Base* BPtr) {
+      Derived* DPtr = static_cast<Derived*>(BPtr);
+      (void)DPtr;
+      // [[p]]
+    }
+  )cc";
+  ASSERT_THAT_ERROR(
+      checkDataflowWithNoopAnalysis(
+          Code, ast_matchers::hasName("target"),
+          [](const llvm::StringMap<DataflowAnalysisState<NoopLattice>> &Results,
+             ASTContext &ASTCtx) {
+            ASSERT_THAT(Results.keys(), UnorderedElementsAre("p"));
+          },
+          {BuiltinOptions()}, LangStandard::lang_cxx17,
+          [](QualType Ty) -> llvm::StringMap<QualType> {
+            RecordDecl *RD = Ty->getAsRecordDecl();
+            if (RD != nullptr && RD->getName() == "Derived")
+              return {{"synth", RD->getASTContext().IntTy}};
+            return {};
+          }),
+      llvm::Succeeded());
+}
+
 TEST(TransferTest, MultipleConstructionsFromStaticCastsBaseToDerived) {
   std::string Code = R"cc(
  struct Base {};


### PR DESCRIPTION
Bug fix. In the transfer function (one of the cast cases), the loop adding
synthetic fields to the derived record storage location was incorrectly nested
inside the loop that iterates over modeled fields (`getModeledFields`).

If the derived class has 0 modeled fields, `getModeledFields(Derived)` is
empty. Consequently, synthetic fields were never added to the storage location,
causing an assertion failure in `StorageLocation::getSyntheticField` when
initializing field values.

This patch moves the synthetic fields loop outside of the modeled fields loop
and adds a regression unit test in `TransferTest.cpp`.
