### PR TITLE
[MC] Use DenseMap for ConstantPool::CachedEntries. NFC.

### DIFF
--- a/llvm/include/llvm/MC/ConstantPools.h
+++ b/llvm/include/llvm/MC/ConstantPools.h
@@ -17,7 +17,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/SMLoc.h"
 #include <cstdint>
-#include <map>
 
 namespace llvm {
 
@@ -46,7 +45,7 @@ class ConstantPool {
 
   // Caches of entries that already exist, indexed by their contents
   // and also the size of the constant.
-  std::map<std::pair<int64_t, unsigned>, const MCSymbolRefExpr *>
+  DenseMap<std::pair<int64_t, unsigned>, const MCSymbolRefExpr *>
       CachedConstantEntries;
   DenseMap<std::pair<const MCSymbol *, unsigned>, const MCSymbolRefExpr *>
       CachedSymbolEntries;


### PR DESCRIPTION
This is mostly just a revert of:
3d0f9507d5e3 "[MC] Fix constant pools with DenseMap sentinel values"
although the key type has changed in the mean time. DenseMap no longer
uses sentinels so the reasons for avoiding it no longer apply.
