### PR TITLE
[CodeGen] Use natural type for StackMaps::ConstPool. NFC.

### DIFF
--- a/llvm/include/llvm/CodeGen/StackMaps.h
+++ b/llvm/include/llvm/CodeGen/StackMaps.h
@@ -308,7 +308,7 @@ public:
 
   using LocationVec = SmallVector<Location, 8>;
   using LiveOutVec = SmallVector<LiveOutReg, 8>;
-  using ConstantPool = MapVector<uint64_t, uint64_t>;
+  using ConstantPool = MapVector<int64_t, int64_t>;
 
   struct FunctionInfo {
     uint64_t StackSize = 0;

--- a/llvm/lib/CodeGen/StackMaps.cpp
+++ b/llvm/lib/CodeGen/StackMaps.cpp
@@ -240,11 +240,6 @@ StackMaps::parseOperand(MachineInstr::const_mop_iterator MOI,
       if (isInt<32>(Imm)) {
         Locs.emplace_back(Location::Constant, sizeof(int64_t), 0, Imm);
       } else {
-        // ConstPool is intentionally a MapVector of 'uint64_t's (as
-        // opposed to 'int64_t's).  We should never be in a situation
-        // where we have to insert the empty key into a map, and for a
-        // DenseMap<uint64_t, T> this is (uint64_t)-1.  It can be and is
-        // represented using 32 bit integers.
         auto Result = ConstPool.insert(std::make_pair(Imm, Imm));
         Locs.emplace_back(Location::ConstantIndex, sizeof(int64_t), 0,
                           Result.first - ConstPool.begin());


### PR DESCRIPTION
This is mostly just a revert of e839965faa22 which switched to using
unsigned types to work around problems with DenseMap sentinel values.
Since DenseMaps no longer have sentinels we can use signed types to
match the values that are stored in the map.
