### PR TITLE
[AMDGPU] Print max-BB inline rejections

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -1570,7 +1570,14 @@ bool GCNTTIImpl::areInlineCompatible(const Function *Caller,
     if (Callee->size() == 1)
       return true;
     size_t BBSize = Caller->size() + Callee->size() - 1;
-    return BBSize <= InlineMaxBB;
+    if (BBSize > InlineMaxBB) {
+      LLVM_DEBUG(dbgs() << "AMDGPU inline max-BB rejected inlining "
+                        << Callee->getName() << " into " << Caller->getName()
+                        << ": caller BBs=" << Caller->size() << ", callee BBs="
+                        << Callee->size() << ", combined BBs=" << BBSize
+                        << ", max BBs=" << InlineMaxBB << '\n');
+      return false;
+    }
   }
 
   return true;

--- a/llvm/test/Transforms/Inline/AMDGPU/inline-max-bb-debug.ll
+++ b/llvm/test/Transforms/Inline/AMDGPU/inline-max-bb-debug.ll
@@ -1,0 +1,34 @@
+; REQUIRES: asserts
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -passes=inline -disable-output -amdgpu-inline-max-bb=3 -debug-only=AMDGPUtti < %s 2>&1 | FileCheck %s
+
+; CHECK: AMDGPU inline max-BB rejected inlining callee into caller: caller BBs=3, callee BBs=4, combined BBs=6, max BBs=3
+
+define i32 @callee(i32 %x) {
+entry:
+  %cmp = icmp eq i32 %x, 0
+  br i1 %cmp, label %then, label %else
+
+then:
+  br label %exit
+
+else:
+  br label %exit
+
+exit:
+  %value = phi i32 [ 1, %then ], [ 2, %else ]
+  ret i32 %value
+}
+
+define amdgpu_kernel void @caller(ptr addrspace(1) %out, i32 %x) {
+entry:
+  %cmp = icmp slt i32 %x, 0
+  br i1 %cmp, label %call, label %exit
+
+call:
+  %value = call i32 @callee(i32 %x)
+  store i32 %value, ptr addrspace(1) %out, align 4
+  br label %exit
+
+exit:
+  ret void
+}


### PR DESCRIPTION
[AMDGPU] Print max-BB inline rejections

Developers sometimes need to understand why a function was not inlined.
The normal inline debug output can explain cost-model decisions, but it
is missing when AMDGPU rejects an inline candidate because the combined
caller and callee size exceeds the target max-BB guard.

Print the caller, callee, combined block count, and limit under
`-debug-only=AMDGPUtti` when the max-BB guard rejects an inline candidate.
This makes it clear when raising the normal inline threshold cannot affect
the decision.

