### PR TITLE
[llvm][cmake] Remove GNUInstallDirs include from LLVMInstallSymlink

### DIFF
--- a/llvm/cmake/modules/LLVMInstallSymlink.cmake
+++ b/llvm/cmake/modules/LLVMInstallSymlink.cmake
@@ -2,11 +2,6 @@
 # DESTDIR environment variable may be unset at configuration time.
 # See PR8397.
 
-# Set to an arbitrary directory to silence GNUInstallDirs warnings
-# regarding being unable to determine libdir.
-set(CMAKE_INSTALL_LIBDIR "lib")
-include(GNUInstallDirs)
-
 function(install_symlink name target outdir link_or_copy)
   # link_or_copy is the "command" to pass to cmake -E.
   # It should be either "create_symlink" or "copy".


### PR DESCRIPTION
This include with its workaround causes warnings on newer CMake versions
(4.1.0+). Initially tried to update the workaround by setting additional
variables, but further investigation revealed that GNUInstallDirs is not
actually needed here - the install_symlink() function only uses
CMAKE_INSTALL_PREFIX and parameters passed by the caller.

Remove the include entirely instead of patching the workaround.