### PR TITLE
[clang-tidy] Support parentheses around subscript operators in readability-redundant-parentheses

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
@@ -73,7 +73,10 @@ void RedundantParenthesesCheck::registerMatchers(MatchFinder *Finder) {
                     parenExpr(), ConstantExpr,
                     declRefExpr(to(namedDecl(unless(
                         matchers::matchesAnyListedRegexName(AllowedDecls))))),
-                    memberExpr(), callExpr(unless(cxxOperatorCallExpr())))),
+                    memberExpr(),
+                    callExpr(unless(cxxOperatorCallExpr(
+                        unless(hasAnyOperatorName("()", "[]"))))),
+                    arraySubscriptExpr())),
                 unless(anyOf(isInMacro(),
                              // sizeof(...) is common used.
                              hasParent(unaryExprOrTypeTraitExpr()))))

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -881,6 +881,8 @@ Changes in existing checks
   - Fixed a bug where clients that apply fix-its without :program:`clang-tidy`'s
     cleanup could produce invalid code by joining adjacent tokens.
 
+  - Added support for parentheses around subscript operators (``(E1[E2])`` -> ``E1[E2]``).
+
 - Improved :doc:`readability-redundant-preprocessor
   <clang-tidy/checks/readability/redundant-preprocessor>` check by fixing a
   false positive for nested ``#if`` directives using different builtin

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-parentheses.cpp
@@ -97,6 +97,9 @@ struct Foo
     Y y{};
     return y;
   }
+
+  bool operator()(int);
+  bool operator[](int);
 };
 
 void memberExpr() {
@@ -120,6 +123,24 @@ void memberExpr() {
    // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: redundant parentheses around expression [readability-redundant-parentheses]
    // CHECK-FIXES:    if (foo.fooBar().z) {
   }
+}
+
+void call(bool (&func)(), Foo f) {
+  if ((func())) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: redundant parentheses around expression [readability-redundant-parentheses]
+  // CHECK-FIXES:    if (func()) {}
+  if ((f(1))) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: redundant parentheses around expression [readability-redundant-parentheses]
+  // CHECK-FIXES:    if (f(1)) {}
+}
+
+void subscript(bool *arr, Foo f) {
+  if ((arr[1])) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: redundant parentheses around expression [readability-redundant-parentheses]
+  // CHECK-FIXES:    if (arr[1]) {}
+  if ((f[1])) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: redundant parentheses around expression [readability-redundant-parentheses]
+  // CHECK-FIXES:    if (f[1]) {}
 }
 
 enum class FoldLevel {


### PR DESCRIPTION
Subscript operators have the same operator procedure as function calls.

Treat overloaded `()` as built-in operators as a drive-by. I missed this case when reviewing #192254.