### PR TITLE
[SystemZ] Use zos_mapped_names to get the symbol name for ppa1

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1555,9 +1555,8 @@ static void emitPPA1Flags(std::unique_ptr<MCStreamer> &OutStreamer, bool VarArg,
 
 static void emitPPA1Name(std::unique_ptr<MCStreamer> &OutStreamer,
                          StringRef OutName) {
+  assert(OutName.size() > 0 && "PPA1 name is empty");
   size_t NameSize = OutName.size();
-  if (NameSize == 0)
-    return;
   uint16_t OutSize;
   if (NameSize < UINT16_MAX) {
     OutSize = static_cast<uint16_t>(NameSize);

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1298,7 +1298,7 @@ void SystemZAsmPrinter::emitEndOfAsmFile(Module &M) {
   if (TT.isOSzOS()) {
     OutStreamer->switchSection(getObjFileLowering().getTextSection());
     for (auto &Info : DeferredPPA1)
-      emitPPA1(Info);
+      emitPPA1(M, Info);
     emitADASection();
     emitIDRLSection(M);
     // On z/OS, we need to associate an external data reference with an ED
@@ -1556,6 +1556,8 @@ static void emitPPA1Flags(std::unique_ptr<MCStreamer> &OutStreamer, bool VarArg,
 static void emitPPA1Name(std::unique_ptr<MCStreamer> &OutStreamer,
                          StringRef OutName) {
   size_t NameSize = OutName.size();
+  if (NameSize == 0)
+    return;
   uint16_t OutSize;
   if (NameSize < UINT16_MAX) {
     OutSize = static_cast<uint16_t>(NameSize);
@@ -1577,7 +1579,7 @@ static void emitPPA1Name(std::unique_ptr<MCStreamer> &OutStreamer,
   OutStreamer->emitZeros(ExtraZeros);
 }
 
-void SystemZAsmPrinter::emitPPA1(PPA1Info &Info) {
+void SystemZAsmPrinter::emitPPA1(Module &M, PPA1Info &Info) {
   assert(PPA2Sym != nullptr && "PPA2 Symbol not defined");
 
   // Optional Argument Area Length.
@@ -1697,10 +1699,28 @@ void SystemZAsmPrinter::emitPPA1(PPA1Info &Info) {
 
   // Emit name length and name optional section (0x01 of flags 4)
   if (Info.Name.size())
-    emitPPA1Name(OutStreamer, Info.Name);
+    emitPPA1Name(OutStreamer, getPPA1Name(M, Info.Name));
 
   // Emit offset to entry point optional section (0x80 of flags 4).
   OutStreamer->emitAbsoluteSymbolDiff(Info.EPMarker, Info.PPA1, 4);
+}
+
+StringRef SystemZAsmPrinter::getPPA1Name(Module &M, StringRef MappedName) {
+  if (MappedName2OrigName.empty()) {
+    if (auto *MD = M.getNamedMetadata("zos_mapped_names")) {
+      for (unsigned I = 0, E = MD->getNumOperands(); I < E; ++I) {
+        MDNode *Map = MD->getOperand(I);
+        StringRef Name = dyn_cast<MDString>(Map->getOperand(0))->getString();
+        StringRef OrigName =
+            dyn_cast<MDString>(Map->getOperand(1))->getString();
+        MappedName2OrigName[Name] = OrigName;
+      }
+    }
+  }
+  auto It = MappedName2OrigName.find(MappedName);
+  if (It != MappedName2OrigName.end())
+    return It->second;
+  return MappedName;
 }
 
 // Determine the end of the prolog and the instructions which updates the stack

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
@@ -30,6 +30,7 @@ public:
 
 private:
   MCSymbol *PPA2Sym;
+  DenseMap<StringRef, StringRef> MappedName2OrigName;
 
   SystemZTargetStreamer *getTargetStreamer() {
     MCTargetStreamer *TS = OutStreamer->getTargetStreamer();
@@ -125,7 +126,7 @@ private:
   SmallVector<PPA1Info, 0> DeferredPPA1;
 
   void calculatePPA1();
-  void emitPPA1(PPA1Info &Info);
+  void emitPPA1(Module &M, PPA1Info &Info);
   void emitPPA2(Module &M);
   void emitADASection();
   void emitIDRLSection(Module &M);
@@ -178,6 +179,7 @@ private:
   void lowerLOAD_GLOBAL_STACKGUARD_ADDR(const MachineInstr &MI,
                                         SystemZMCInstLower &Lower);
   void emitAttributes(Module &M);
+  StringRef getPPA1Name(Module &M, StringRef MappedName);
 };
 } // end namespace llvm
 

--- a/llvm/test/CodeGen/SystemZ/zos-mapped-name.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-mapped-name.ll
@@ -1,0 +1,48 @@
+; RUN: llc -mtriple s390x-ibm-zos -mcpu=z15 -asm-verbose=false < %s | FileCheck %s
+
+; This tests needs updating when the new external name is emitted into asm output.
+
+; CHECK: L#EPM_sourcename_0 DS 0H
+; CHECK-NEXT: DC XL7'00C300C500C500'
+; CHECK-NEXT: DC XL1'F1'
+; CHECK-NEXT: DC AD(L#PPA1_sourcename_0-L#EPM_sourcename_0)
+; CHECK-NEXT: DC XL4'00000008'
+; CHECK-NEXT: ENTRY sourcename
+; CHECK:sourcename DS 0H
+;CHECK-NEXT:  b 2(7)
+;CHECK-NEXT: L#sourcename_end_0 DS 0H
+;CHECK-NEXT: L#func_end0 DS 0H
+
+define void @sourcename() {
+entry:
+  ret void
+}
+
+; CHECK:var CSECT
+; CHECK-NEXT:C_WSA64 CATTR ALIGN(2),FILL(0)
+; CHECK:var XATTR LINKAGE(XPLINK),REFERENCE(DATA),SCOPE(LIBRARY)
+; CHECK-NEXT: DS 0B
+; CHECK-NEXT: DC XL4'00000000'
+
+@var = hidden global i32 0, align 4
+
+!zos_mapped_names = !{!2, !3}
+!2 = !{!"var", !"other"}
+!3 = !{!"sourcename", !"name"}
+
+; CHECK:L#PPA1_sourcename_0 DS 0H
+; CHECK-NEXT: DC XL1'02'
+; CHECK-NEXT: DC XL1'CE'
+; CHECK-NEXT: DC XL2'0000'
+; CHECK-NEXT: DC AD(L#PPA2-L#PPA1_sourcename_0)
+; CHECK-NEXT: DC XL1'80'
+; CHECK-NEXT: DC XL1'80'
+; CHECK-NEXT: DC XL1'00'
+; CHECK-NEXT: DC XL1'81'
+; CHECK-NEXT: DC XL2'0000'
+; CHECK-NEXT: DC XL1'00'
+; CHECK-NEXT: DC XL1'0'
+; CHECK-NEXT: DC AD(L#sourcename_end_0-L#EPM_sourcename_0)
+; CHECK-NEXT: DC XL2'0004'
+; CHECK-NEXT: DC XL4'95819485'
+; CHECK-NEXT: DC AD(L#EPM_sourcename_0-L#PPA1_sourcename_0)


### PR DESCRIPTION
The symbol name added to the PPA1 table should be the name of the function in the source code, not the one given to the symbol via asm label or the upcoming `#pragma map`.  

The full functionality in clang will be:
- for asm label generate the IR using the asm label (business as usual).  The `#pragma map` will do the same
- if either of these are seen create the zos_mapped_name meta data in IR to map the symbol name back to the name used in the source code.

The `zos_mapped_names` meta data will look like:
```
!zos_mapped_names = !{ !0, ... }
!0 = !{ !"asm_label", !"decl" }
...
```