### PR TITLE
[clang-tidy] Fix trailing semicolon and lost comment in readability-use-std-min-max

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/UseStdMinMaxCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/UseStdMinMaxCheck.cpp
@@ -167,7 +167,7 @@ void UseStdMinMaxCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *BinaryOp = Result.Nodes.getNodeAs<BinaryOperator>("binaryOp");
   const BinaryOperatorKind BinaryOpcode = BinaryOp->getOpcode();
   const SourceLocation IfLocation = If->getIfLoc();
-  const SourceLocation ThenLocation = If->getEndLoc();
+  SourceLocation ThenLocation = If->getEndLoc();
 
   auto ReplaceAndDiagnose = [&](const StringRef FunctionName) {
     const SourceManager &Source = *Result.SourceManager;
@@ -218,6 +218,12 @@ void UseStdMinMaxCheck::check(const MatchFinder::MatchResult &Result) {
       if (Semi != StringRef::npos && PostInner.take_front(Semi).trim().empty())
         PostInner = PostInner.drop_front(Semi + 1);
       AppendNormalized(PostInner);
+    } else if (const auto SemiTok =
+                   Lexer::findNextToken(ThenLocation, Source, LO);
+               SemiTok && SemiTok->is(tok::semi)) {
+      AppendNormalized(
+          GetSourceText(ThenLocation, SemiTok->getLocation()).rtrim());
+      ThenLocation = SemiTok->getLocation();
     }
 
     diag(IfLocation, "use `%0` instead of `%1`")

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -121,6 +121,10 @@ Changes in existing checks
   exclusively for overload resolution. Added the :option:`IgnoredTypes`
   option to allow customizing the set of ignored types.
 
+- Improved :doc:`readability-use-std-min-max
+  <clang-tidy/checks/readability/use-std-min-max>` check by fixing spurious
+  trailing semicolons and lost comments when the ``if`` body has no braces.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/use-std-min-max.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/use-std-min-max.cpp
@@ -253,6 +253,18 @@ void testVectorSizeType() {
     value = v.size();
 }
 
+namespace gh208708 {
+void f(int &n) {
+  // CHECK-MESSAGES: :[[@LINE+2]]:3: warning: use `std::max` instead of `<`
+  // CHECK-FIXES: n = std::max(n, -1);
+  if (n < -1) n = -1 ;
+
+  // CHECK-MESSAGES: :[[@LINE+2]]:3: warning: use `std::min` instead of `>`
+  // CHECK-FIXES: n = std::min(n, 1); /*use clamp when c++17 or later is enabled*/
+  if (n > 1) n = 1/*use clamp when c++17 or later is enabled*/;
+}
+} // namespace gh208708
+
 namespace gh121676 {
 
 void useLeft() {


### PR DESCRIPTION
Fix two bugs in readability-use-std-min-max when the if body has no braces.

For brace-less if bodies, If->getEndLoc() points to the expression end rather than the trailing semicolon, truncating replacements and losing comments. We find the semicolon via findNextToken and extend the range consistent with compound statement logic.

Before:
  if (n < -1) n = -1 ;          ->  n = std::max(n, -1); ;
  if (n > 1) n = 1/*comment*/;  ->  n = std::min(n, 1);;

After:
  if (n < -1) n = -1 ;          ->  n = std::max(n, -1);
  if (n > 1) n = 1/*comment*/;  ->  n = std::min(n, 1); /*comment*/

Fixes #208708.

AI Usage: This patch is AI-assisted, reviewed and verified by me.