### PR TITLE
clang/AMDGPU: Forward host system includes in offload compiles

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -959,6 +959,13 @@ void AMDGPUToolChain::addClangWarningOptions(ArgStringList &CC1Args) const {
 
 void AMDGPUToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
                                                 ArgStringList &CC1Args) const {
+  // In an offloading compilation the device toolchain must pick up the host's
+  // system include paths, even when compiling device code.
+  if (HostTC) {
+    HostTC->AddClangSystemIncludeArgs(DriverArgs, CC1Args);
+    return;
+  }
+
   if (DriverArgs.hasArg(options::OPT_nostdinc) ||
       DriverArgs.hasArg(options::OPT_nostdlibinc))
     return;

--- a/clang/test/Driver/hip-include-path.hip
+++ b/clang/test/Driver/hip-include-path.hip
@@ -49,3 +49,13 @@
 // ROCM35-NOT: "-include" "__clang_hip_runtime_wrapper.h"
 // skip check of standard C++ include path
 // ROCM35-SAME: "-internal-isystem" "[[RESOURCE_DIR]]/include"
+
+// The device compilation must pick up the host toolchain's system include paths
+// so host C++ library headers are usable.
+// RUN: %clang -c -### --target=x86_64-unknown-linux-gnu --cuda-gpu-arch=gfx900 \
+// RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm -nogpulib \
+// RUN:   --sysroot=%S/Inputs/basic_linux_tree %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=HOSTINC %s
+
+// HOSTINC-LABEL: "{{[^"]*}}clang{{[^"]*}}" "-cc1" "-triple" "amdgcn-amd-amdhsa"
+// HOSTINC: "-internal-externc-isystem" "{{[^"]*}}Inputs/basic_linux_tree/usr/include"


### PR DESCRIPTION
Commit 640079288c5e merged the AMDGPU toolchain subclasses but dropped the
HIPAMDToolChain::AddClangSystemIncludeArgs override, which forwarded to the
host toolchain.

Co-authored-by: Claude (Opus 4.8) <noreply@anthropic.com>