### PR TITLE
[GettingStarted] Clarify Python requirement.

### DIFF
--- a/llvm/docs/GettingStarted.md
+++ b/llvm/docs/GettingStarted.md
@@ -280,15 +280,12 @@ uses the package and provides other details.
 | Package | Version | Notes |
 | --- | --- | --- |
 | [CMake](http://cmake.org/) | >=3.20.0 | Makefile/workspace generator |
-| [python](http://www.python.org/) | >=3.8 | Automated test suite{sup}`1` |
-| [zlib](http://zlib.net) | >=1.2.3.4 | Compression library{sup}`2` |
-| [GNU Make](http://savannah.gnu.org/projects/make) | 3.79, 3.79.1 | Makefile/build processor{sup}`3` |
-| [PyYAML](https://pypi.org/project/PyYAML/) | >=5.1 | Header generator{sup}`4` |
+| [python](http://www.python.org/) | >=3.8 | Build system support, automated testing, misc utilities |
+| [zlib](http://zlib.net) | >=1.2.3.4 | Compression library{sup}`1` |
+| [GNU Make](http://savannah.gnu.org/projects/make) | 3.79, 3.79.1 | Makefile/build processor{sup}`2` |
+| [PyYAML](https://pypi.org/project/PyYAML/) | >=5.1 | Header generator{sup}`3` |
 
 ```{note}
-1. Only needed if you want to run the automated test suite in the
-   `llvm/test` directory, or if you plan to utilize any Python libraries,
-   utilities, or bindings.
 1. Optional, adds compression/uncompression capabilities to selected LLVM
    tools.
 1. Optional, you can use any other build tool supported by CMake.


### PR DESCRIPTION
We don't support building LLVM without python in any configuration; clarify that it's a hard requirement.