### PR TITLE
[CMake] Remove special-casing of LLVM_ENABLE_PIC on z/OS

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -739,9 +739,7 @@ set(LLVM_TARGETS_TO_BUILD
    ${LLVM_EXPERIMENTAL_TARGETS_TO_BUILD})
 list(REMOVE_DUPLICATES LLVM_TARGETS_TO_BUILD)
 
-if (NOT CMAKE_SYSTEM_NAME MATCHES "OS390")
-  option(LLVM_ENABLE_PIC "Build Position-Independent Code" ON)
-endif()
+option(LLVM_ENABLE_PIC "Build Position-Independent Code" ON)
 option(LLVM_ENABLE_MODULES "Compile with C++ modules enabled." OFF)
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
   option(LLVM_ENABLE_MODULE_DEBUGGING "Compile with -gmodules." ON)


### PR DESCRIPTION
Define LLVM_ENABLE_PIC unconditionally instead of excluding z/OS through a platform-specific conditional.

This removes an unnecessary special case from the top-level CMake configuration and makes the option definition consistent across platforms. The default value remains unchanged.