### PR TITLE
[clang][bytecode] Lazily evaluate static variables

### DIFF
--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -4897,8 +4897,15 @@ ExpectedDecl ASTNodeImporter::VisitVarDecl(VarDecl *D) {
   if (Error Err = ImportInitializer(D, ToVar))
     return std::move(Err);
 
-  if (D->isConstexpr())
+  if (D->isConstexpr()) {
     ToVar->setConstexpr(true);
+    // Tell the bytecode interpreter that a new constexpr variable has appeared.
+    if (ToVar->getASTContext().getLangOpts().EnableNewConstInterp) {
+      if (const Expr *Init = ToVar->getInit();
+          Init && !Init->isValueDependent())
+        ToVar->evaluateValue();
+    }
+  }
 
   addDeclToContexts(D, ToVar);
 

--- a/clang/test/ASTMerge/class-template-partial-spec/test.cpp
+++ b/clang/test/ASTMerge/class-template-partial-spec/test.cpp
@@ -2,6 +2,10 @@
 // RUN: %clang_cc1 -emit-pch -std=c++1z -o %t.2.ast %S/Inputs/class-template-partial-spec2.cpp
 // RUN: %clang_cc1 -std=c++1z -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 | FileCheck %s
 
+// RUN: %clang_cc1 -emit-pch -std=c++1z -o %t.1.ast %S/Inputs/class-template-partial-spec1.cpp -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -emit-pch -std=c++1z -o %t.2.ast %S/Inputs/class-template-partial-spec2.cpp -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -std=c++1z -ast-merge %t.1.ast -ast-merge %t.2.ast -fsyntax-only %s 2>&1 -fexperimental-new-constant-interpreter | FileCheck %s
+
 static_assert(sizeof(**SingleSource.member) == sizeof(**SingleDest.member));
 static_assert(sizeof(SecondDoubleSource.member) == sizeof(SecondDoubleDest.member));
 static_assert(NumberSource.val == 42);


### PR DESCRIPTION
They usually go through `evaluateAsInitializer()`, which is where we register them as global variables. But if they're imported, they don't. Just try to evaluate them in `VisitMemberExpr()`.