### PR TITLE
Fix Bazel build for 5ddad72

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -98,11 +98,15 @@ cc_library(
     srcs = [
         "source/Version/Version.cpp",
         ":vcs_version_gen",
-        ":version_inc_gen",
     ],
-    hdrs = ["include/lldb/Version/Version.h"],
+    hdrs = [
+        "include/lldb/Version/Version.h",
+    ],
     features = ["-layering_check"],  # Version.inc breaks this unintentionally
     includes = ["include"],
+    textual_hdrs = [
+        ":version_inc_gen",
+    ],
     deps = ["//clang:basic"],
 )
 
@@ -839,6 +843,7 @@ cc_library(
         ":Host",
         ":ProtocolHeaders",
         ":Utility",
+        ":Version",
         "//llvm:Support",
     ],
 )


### PR DESCRIPTION
Buildkite error link: https://buildkite.com/llvm-project/upstream-bazel/builds?commit=5ddad72b154e4c4ddc2547b6cd17abd7b9a6ae53