### PR TITLE
[Clang][Driver][NFC] Fix offload-parallel-device-cc1.cu failing in read-only runfiles sandbox

### DIFF
--- a/clang/test/Driver/offload-parallel-device-cc1.cu
+++ b/clang/test/Driver/offload-parallel-device-cc1.cu
@@ -1,12 +1,13 @@
 // REQUIRES: x86-registered-target, amdgpu-registered-target
 // REQUIRES: nvptx-registered-target, lld
 
+// RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang -x hip --target=x86_64-unknown-linux-gnu \
 // RUN:   -nostdinc -nogpuinc -nohipwrapperinc -nogpulib \
 // RUN:   --offload-arch=gfx900 --offload-arch=gfx906 --offload-jobs=2 \
 // RUN:   -O3 -c %s -o %t.o
 
-// RUN: %clang -x cuda --target=x86_64-unknown-linux-gnu \
+// RUN: cd %t && %clang -x cuda --target=x86_64-unknown-linux-gnu \
 // RUN:   -nocudainc -nocudalib \
 // RUN:   --cuda-gpu-arch=sm_70 --cuda-gpu-arch=sm_80 --offload-jobs=2 \
 // RUN:   --cuda-device-only -S -Werror %s


### PR DESCRIPTION
When running offload-parallel-device-cc1.cu with multiple --cuda-gpu-arch
flags and --cuda-device-only -S, Clang generates multiple .s outputs in the
current working directory (.). In sandboxed test environments, . is read-only,
causing compilation to fail with "Permission denied".
Fix by executing the CUDA compilation step inside a temporary directory (%t).

This pattern is being used in other tests like in clang/test/Driver/ftime-trace-offload.cpp and clang/test/Driver/unix-conformance.c.
