### PR TITLE
[libc++] Fix usage of constructive interference when we meant destructive

### DIFF
--- a/libcxx/src/atomic.cpp
+++ b/libcxx/src/atomic.cpp
@@ -425,7 +425,7 @@ static constexpr hash<void const*> __contention_hasher;
 // cache line, we would end up in a "false-sharing" situation. However, in practice, it would require
 // both native and non-native atomics to be used concurrently, and to fall in the same bucket, which
 // is expected to be unlikely.
-struct alignas(std::hardware_constructive_interference_size) /*  aim to avoid false sharing */ __contention_state {
+struct alignas(std::hardware_destructive_interference_size) /* aim to avoid false sharing */ __contention_state {
   __cxx_atomic_contention_t __waiter_count_native;
   __cxx_atomic_contention_t __waiter_count_global;
   __cxx_atomic_contention_t __platform_state;


### PR DESCRIPTION
We maintain a contention table to implement atomic wait/notify inside atomic.cpp. Entries in that table are padded to avoid false sharing, since they are expected to be accessed from multiple threads concurrently.

However, we used std::hardware_constructive_interference_size for that, when in reality std::hardware_destructive_interference_size is the one we need. The semantics of constructive interference are to promote true sharing for data that should stay colocated, while destructive interference is to prevent false sharing.

Note that on platforms such as macOS arm64, destructive interference size is larger than constructive interference size, which means that this patch may regress the size of the dylib on some platforms. However, that is required for performance purposes.

Fixes #208305