### PR TITLE
[flang][OpenACC] Fix acc.present in acc.data translation

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenACC/OpenACCToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenACC/OpenACCToLLVMIRTranslation.cpp
@@ -517,10 +517,11 @@ LogicalResult OpenACCDialectLLVMIRTranslationInterface::convertOperation(
         return success();
       })
       .Case<acc::CreateOp, acc::CopyinOp, acc::CopyoutOp, acc::DeleteOp,
-            acc::UpdateDeviceOp, acc::GetDevicePtrOp, acc::PresentOp>([](auto op) {
-        // NOP
-        return success();
-      })
+            acc::UpdateDeviceOp, acc::GetDevicePtrOp, acc::PresentOp>(
+          [](auto op) {
+            // NOP
+            return success();
+          })
       .Default([&](Operation *op) {
         return op->emitError("unsupported OpenACC operation: ")
                << op->getName();

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenACC/OpenACCToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenACC/OpenACCToLLVMIRTranslation.cpp
@@ -317,7 +317,7 @@ static LogicalResult convertDataOp(acc::DataOp &op,
       create.push_back(createOp.getVarPtr());
     } else if (auto presentOp = mlir::dyn_cast_or_null<acc::PresentOp>(
                    dataOp.getDefiningOp())) {
-      present.push_back(createOp.getVarPtr());
+      present.push_back(presentOp.getVarPtr());
     }
   }
 
@@ -517,7 +517,7 @@ LogicalResult OpenACCDialectLLVMIRTranslationInterface::convertOperation(
         return success();
       })
       .Case<acc::CreateOp, acc::CopyinOp, acc::CopyoutOp, acc::DeleteOp,
-            acc::UpdateDeviceOp, acc::GetDevicePtrOp>([](auto op) {
+            acc::UpdateDeviceOp, acc::GetDevicePtrOp, acc::PresentOp>([](auto op) {
         // NOP
         return success();
       })

--- a/mlir/test/Target/LLVMIR/openacc-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openacc-llvm.mlir
@@ -189,3 +189,19 @@ llvm.func @testdataop(%arg0: !llvm.ptr, %arg1: !llvm.ptr, %arg2: !llvm.ptr) {
 
 // CHECK: declare void @__tgt_target_data_begin_mapper(ptr, i64, i32, ptr, ptr, ptr, ptr, ptr, ptr)
 // CHECK: declare void @__tgt_target_data_end_mapper(ptr, i64, i32, ptr, ptr, ptr, ptr, ptr, ptr)
+
+// -----
+
+// Test acc.present in acc.data
+llvm.func @test_present_in_data(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
+  %0 = acc.copyin varPtr(%arg0 : !llvm.ptr) varType(f32) -> !llvm.ptr
+  %1 = acc.present varPtr(%arg1 : !llvm.ptr) varType(f32) -> !llvm.ptr
+  acc.data dataOperands(%0, %1 : !llvm.ptr, !llvm.ptr) {
+    acc.terminator
+  }
+  llvm.return
+}
+
+// Verify present flag: 12288 = 0x3000 = kHoldFlag + kPresentFlag
+// CHECK: constant [{{[0-9]*}} x i64] [i64 8193, i64 12288]
+// CHECK: call void @__tgt_target_data_begin_mapper


### PR DESCRIPTION
1. convertDataOp used wrong variable pointer (createOp.getVarPtr() instead of presentOp.getVarPtr())
2. add PresentOp to Case handler ,and add translation check.