### PR TITLE
[lldb] Make PolicyStack::Get() out-of-line

### DIFF
--- a/lldb/include/lldb/Utility/Policy.h
+++ b/lldb/include/lldb/Utility/Policy.h
@@ -95,10 +95,7 @@ struct Policy {
 /// thread's stack when the task starts.
 class PolicyStack {
 public:
-  static PolicyStack &Get() {
-    static thread_local PolicyStack s_stack;
-    return s_stack;
-  }
+  static PolicyStack &Get();
 
   Policy Current() const;
 

--- a/lldb/source/Utility/Policy.cpp
+++ b/lldb/source/Utility/Policy.cpp
@@ -15,6 +15,14 @@
 
 using namespace lldb_private;
 
+// Declared out-of-line so every shared library resolves to the same
+// instance: a function-local static in an inline function is not
+// shared across shared library boundaries under hidden visibility.
+PolicyStack &PolicyStack::Get() {
+  static thread_local PolicyStack s_stack;
+  return s_stack;
+}
+
 Policy PolicyStack::Current() const {
   Policy p = m_stack.back();
   if (Log *log = GetLog(LLDBLog::Process)) {

--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -94,7 +94,7 @@ protected:
     if (!left.FileEquals(right))
       return false;
     // If BOTH have a directory, also compare the directories.
-    if (left.GetDirectory() && right.GetDirectory())
+    if (!left.GetDirectory().empty() && !right.GetDirectory().empty())
       return left.DirectoryEquals(right);
 
     // If one has a directory but not the other, they match.


### PR DESCRIPTION
LLDB builds with hidden visibility by default, so a function-local static in an inline function is not shared across shared library boundaries: each dylib that includes this header and calls an inline Get() gets its own private copy of the thread_local stack, silently splitting one logical per-thread stack into several. Declaring it out-of-line ensures every dylib resolves to the single instance defined in Policy.cpp.

Nothing currently pushes a policy from outside liblldb, so this has no observable effect yet, but any future capability that needs to be set in one shared library and read in another depends on this.