### PR TITLE
[compiler-rt][hexagon][test] Guard __hexagon_fmadf5 unit test with __hexagon__ define

### DIFF
--- a/compiler-rt/test/builtins/Unit/hexagon_fmadf5_test.c
+++ b/compiler-rt/test/builtins/Unit/hexagon_fmadf5_test.c
@@ -230,9 +230,8 @@ int main(void) {
   if (test(-0.0, 5.0, 0.0, POS_ZERO_REP))
     return 1; // -0 in nearest -> +0
 
-  return 0;
 #else
   printf("skipped\n");
-  return 0;
 #endif
+  return 0;
 }

--- a/compiler-rt/test/builtins/Unit/hexagon_fmadf5_test.c
+++ b/compiler-rt/test/builtins/Unit/hexagon_fmadf5_test.c
@@ -8,6 +8,7 @@
 
 #include "fp_test.h"
 
+#if defined(__hexagon__)
 // Fused multiply-add: computes a*b + c with a single rounding, in the
 // current rounding mode.
 COMPILER_RT_ABI double __hexagon_fmadf5(double a, double b, double c);
@@ -66,8 +67,10 @@ static int test_all_modes(double a, double b, double c, uint64_t expected) {
   ret |= test_rm(a, b, c, FE_TOWARDZERO, expected);
   return ret;
 }
+#endif
 
 int main(void) {
+#if defined(__hexagon__)
   double qnan = fromRep64(QNAN_REP);
   double inf = fromRep64(POS_INF_REP);
   double ninf = fromRep64(NEG_INF_REP);
@@ -228,4 +231,8 @@ int main(void) {
     return 1; // -0 in nearest -> +0
 
   return 0;
+#else
+  printf("skipped\n");
+  return 0;
+#endif
 }


### PR DESCRIPTION
When `compiler-rt/test/builtins/Unit/` C test files are compiled outside of a standard `lit` pipeline (such as direct standalone compilation or downstream test harnesses where each `.c` file is built and run as an independent executable against `libclang_rt.builtins.a`), `hexagon_fmadf5_test.c` unconditionally referenced `__hexagon_fmadf5`. Because `__hexagon_fmadf5` is only provided in `libclang_rt.builtins-hexagon.a`, non-Hexagon builds failed at link time.

This change is consistent with other architecture-specific builtin unit tests (such as `divdf3vfp_test.c`, `adddf3vfp_test.c`, and ARM/PPC builtin tests), this change wraps Hexagon-specific declarations, helpers, and test logic inside `#if defined(__hexagon__)`. On non-Hexagon targets, `main()` prints `"skipped\n"` and returns `0`.

Introduced by https://github.com/llvm/llvm-project/pull/207373
