### PR TITLE
[Github] Bump runner version to 2.335.1

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -93,7 +93,7 @@ RUN powershell -Command \
     New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" \
     -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 
-ARG RUNNER_VERSION=2.335.0
+ARG RUNNER_VERSION=2.335.1
 ENV RUNNER_VERSION=$RUNNER_VERSION
 
 RUN powershell -Command \

--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -100,7 +100,7 @@ WORKDIR /home/gha
 
 FROM ci-container AS ci-container-agent
 
-ENV GITHUB_RUNNER_VERSION=2.335.0
+ENV GITHUB_RUNNER_VERSION=2.335.1
 
 RUN mkdir actions-runner && \
     cd actions-runner && \


### PR DESCRIPTION
To stay ahead of the 6-month deprecation window.