### PR TITLE
[OpenMP][Offload] Fix flang offload test

### DIFF
--- a/offload/test/offloading/fortran/declare-target-common-block-main.f90
+++ b/offload/test/offloading/fortran/declare-target-common-block-main.f90
@@ -5,7 +5,7 @@
 ! larger Fortran applications like Nekbone and SPEC benchmarks.
 ! REQUIRES: flang, amdgpu
 
-! RUN: %flang -c -fopenmp --offload-arch=gfx90a \
+! RUN: %flang -c -fopenmp -fopenmp-targets=%target_triple --offload-arch=gfx90a \
 ! RUN:   %S/../../Inputs/declare-target-common-block-sub.f90 -o declare-target-common-block-sub.o
 ! RUN: %libomptarget-compile-fortran-generic declare-target-common-block-sub.o
 ! RUN: %t | %fcheck-generic


### PR DESCRIPTION
This PR attempts to address the remaining flang offload test failure after https://github.com/llvm/llvm-project/pull/208617. Bot: https://lab.llvm.org/buildbot/#/builders/67/builds/8412

The problem with is test is that `foo__l8` kernel was not linked into device image without explicitly use the amdgpu-amd-amdhsa triple in the compilation. It only happened to this specific test.

Local test results after fix:
```
Testing Time: 146.44s

 Total Discovered Tests: 3478
   Skipped          :   77 (2.21%)
   Unsupported      :  341 (9.80%)
   Passed           : 3055 (87.84%)
   Expectedly Failed:    5 (0.14%)
``` 