### PR TITLE
[clangd][remote] Fix SmallVector assertion in uriToRelativePath for Windows paths

### DIFF
--- a/clang-tools-extra/clangd/index/remote/marshalling/Marshalling.cpp
+++ b/clang-tools-extra/clangd/index/remote/marshalling/Marshalling.cpp
@@ -397,7 +397,7 @@ llvm::Expected<std::string> Marshaller::uriToRelativePath(llvm::StringRef URI) {
   llvm::StringRef Path(Result);
   // Check for Windows paths (URI=file:///X:/path => Body=/X:/path)
   if (is_absolute(Path.substr(1), Style::windows))
-    Result = Path.drop_front();
+    Result = Path.drop_front().str();
   if (!replace_path_prefix(Result, RemoteIndexRoot, ""))
     return error("File path '{0}' doesn't start with '{1}'.", Result.str(),
                  RemoteIndexRoot);


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/207202 buildbot has detected a new failure.
Assertion happens in newly created test:
```
ClangdTests: /vol/worker/clangd-ubuntu-clang/clangd-ubuntu-tsan/llvm-project/llvm/include/llvm/ADT/SmallVector.h:196: void llvm::SmallVectorTemplateCommon<char>::assertSafeToReferenceAfterResize(const void *, size_t) [T = char]: Assertion `isSafeToReferenceAfterResize(Elt, NewSize) && "Attempting to reference an element of the vector in an operation " "that invalidates it"' failed.
```
The root cause is that `Path` is a `StringRef` aliasing `Result`s buffer. Assigning `Result` to `Path.drop_front()` triggers `SmallVector`s `assertSafeToReferenceAfterResize` assertion (that assertion checks if we are passing an iterator that points  into the own buffer).

With this patch we convert `Path.drop_front()` to `std::string` to break the aliasing before assignment.