### PR TITLE
[clang-doc] Update include guards in header files

### DIFF
--- a/clang-tools-extra/clang-doc/support/File.h
+++ b/clang-tools-extra/clang-doc/support/File.h
@@ -11,8 +11,8 @@
 /// such as creating directories and writing output files.
 ///
 //===----------------------------------------------------------------------===//
-#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILE_H
-#define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILE_H
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_SUPPORT_FILE_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_SUPPORT_FILE_H
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Error.h"
@@ -28,4 +28,4 @@ llvm::SmallString<128> computeRelativePath(llvm::StringRef Destination,
 } // namespace doc
 } // namespace clang
 
-#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILE_H
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_SUPPORT_FILE_H

--- a/clang-tools-extra/clang-doc/support/Utils.h
+++ b/clang-tools-extra/clang-doc/support/Utils.h
@@ -13,8 +13,8 @@
 /// data model.
 ///
 //===----------------------------------------------------------------------===//
-#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILE_H
-#define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILE_H
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_SUPPORT_UTILS_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_SUPPORT_UTILS_H
 
 #include "../Representation.h"
 #include "llvm/ADT/SmallString.h"
@@ -33,4 +33,4 @@ void getHtmlFiles(llvm::StringRef AssetsPath,
 
 void getMdFiles(llvm::StringRef AssetsPath, clang::doc::ClangDocContext &CDCtx);
 
-#endif
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_SUPPORT_UTILS_H


### PR DESCRIPTION
These do not follow the style guide, and Utils.h has the wrong macro definition.