### PR TITLE
[alpha.webkit.UncheckedLocalVarsChecker] Improve the warning text

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/DiagOutputUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/DiagOutputUtils.h
@@ -11,6 +11,7 @@
 
 #include "clang/AST/Decl.h"
 #include "llvm/Support/raw_ostream.h"
+#include "ASTUtils.h"
 
 namespace clang {
 
@@ -29,6 +30,23 @@ void printQuotedName(llvm::raw_ostream &Os, const NamedDeclDerivedT &D) {
   D->getNameForDiagnostic(Os, D->getASTContext().getPrintingPolicy(),
                           /*Qualified=*/false);
   Os << "'";
+}
+
+inline void printTypeName(llvm::raw_ostream &Os, const QualType QT) {
+  auto *Type = QT.getTypePtr();
+  assert(Type);
+  if (auto *CXXRD = Type->getPointeeCXXRecordDecl()) {
+    printQuotedQualifiedName(Os, CXXRD);
+    return;
+  }
+  if (auto *ObjCDecl = getObjCDeclFromObjCPtr(Type)) {
+    printQuotedQualifiedName(Os, ObjCDecl);
+    return;
+  }
+  if (!Type->isPointerOrReferenceType()) {
+    if (auto *RD = Type->getAsRecordDecl())
+      printQuotedQualifiedName(Os, RD);
+  }
 }
 
 } // namespace clang

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/DiagOutputUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/DiagOutputUtils.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_CLANG_ANALYZER_WEBKIT_DIAGPRINTUTILS_H
 #define LLVM_CLANG_ANALYZER_WEBKIT_DIAGPRINTUTILS_H
 
+#include "ASTUtils.h"
 #include "clang/AST/Decl.h"
 #include "llvm/Support/raw_ostream.h"
-#include "ASTUtils.h"
 
 namespace clang {
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -417,7 +417,8 @@ public:
         printQuotedQualifiedName(Os, Typedef->getDecl());
       }
     } else {
-      printType(Os, CallArg->getType());
+      Os << " ";
+      printTypeName(Os, CallArg->getType());
     }
 
     bool usesDefaultArgValue = isa<CXXDefaultArgExpr>(CallArg) && Param;
@@ -447,8 +448,8 @@ public:
       Os << " to ";
       printQuotedQualifiedName(Os, Callee);
     }
-    Os << ") is a raw pointer to " << typeName();
-    printType(Os, CallArg->getType());
+    Os << ") is a raw pointer to " << typeName() << " ";
+    printTypeName(Os, CallArg->getType());
 
     PathDiagnosticLocation BSLoc(SrcLocToReport, BR->getSourceManager());
     auto Report = std::make_unique<BasicBugReport>(Bug, Os.str(), BSLoc);
@@ -472,8 +473,8 @@ public:
       printQuotedQualifiedName(Os, Callee);
       Os << ")";
     }
-    Os << " is a raw pointer to " << typeName();
-    printType(Os, CallArg->getType());
+    Os << " is a raw pointer to " << typeName() << " ";
+    printTypeName(Os, CallArg->getType());
 
     PathDiagnosticLocation BSLoc(SrcLocToReport, BR->getSourceManager());
     auto Report = std::make_unique<BasicBugReport>(Bug, Os.str(), BSLoc);
@@ -505,22 +506,6 @@ public:
     bool IsPtr = isa<PointerType, ObjCObjectPointerType>(T);
     Os << "raw " << (IsPtr ? "pointer" : "reference") << " to " << typeName();
     return PrintDeclKind::Pointee;
-  }
-
-  void printType(llvm::raw_svector_ostream &Os, const QualType QT) const {
-    auto *ArgType = QT.getTypePtr();
-    if (auto *CXXRD = ArgType->getPointeeCXXRecordDecl()) {
-      Os << " ";
-      printQuotedQualifiedName(Os, CXXRD);
-    } else if (auto *ObjCDecl = getObjCDeclFromObjCPtr(ArgType)) {
-      Os << " ";
-      printQuotedQualifiedName(Os, ObjCDecl);
-    } else if (!ArgType->isPointerOrReferenceType()) {
-      if (auto *RD = ArgType->getAsRecordDecl()) {
-        Os << " ";
-        printQuotedQualifiedName(Os, RD);
-      }
-    }
   }
 };
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -207,7 +207,7 @@ public:
   virtual bool isSafePtrType(const QualType) const = 0;
   virtual bool isSafeExpr(const Expr *) const { return false; }
   virtual bool isSafeDecl(const Decl *) const { return false; }
-  virtual const char *ptrKind() const = 0;
+  virtual const char *typeName() const = 0;
 
   void checkASTDecl(const TranslationUnitDecl *TUD, AnalysisManager &MGR,
                     BugReporter &BRArg) const {
@@ -414,9 +414,10 @@ public:
     llvm::raw_svector_ostream Os(Buf);
 
     if (isa<ParmVarDecl>(V)) {
-      Os << "Assignment to an " << ptrKind() << " parameter ";
+      Os << "Parameter ";
       printQuotedQualifiedName(Os, V);
-      Os << " is unsafe.";
+      Os << " is a ";
+      printPointerTypeAndType(Os, V->getType());
 
       PathDiagnosticLocation BSLoc(Value->getExprLoc(), BR->getSourceManager());
       auto Report = std::make_unique<BasicBugReport>(Bug, Os.str(), BSLoc);
@@ -435,13 +436,36 @@ public:
         Os << "'" << safeGetName(BindingDecl) << "'";
       else
         printQuotedQualifiedName(Os, V);
-      Os << " is " << ptrKind() << " and unsafe.";
+      Os << " is a ";
+      printPointerTypeAndType(Os, V->getType());
 
       PathDiagnosticLocation BSLoc(V->getLocation(), BR->getSourceManager());
       auto Report = std::make_unique<BasicBugReport>(Bug, Os.str(), BSLoc);
       Report->addRange(V->getSourceRange());
       Report->setDeclWithIssue(DeclWithIssue);
       BR->emitReport(std::move(Report));
+    }
+  }
+
+  void printPointerTypeAndType(llvm::raw_svector_ostream &Os,
+                               QualType QT) const {
+    auto *VarType = QT.getTypePtr();
+    if (RTC && isa<TypedefType>(VarType)) {
+      Os << typeName() << " ";
+      assert(RTC);
+      if (auto *Decl = RTC->getCanonicalDecl(QT)) {
+        printQuotedQualifiedName(Os, Decl);
+      } else {
+        auto Typedef = VarType->getAs<TypedefType>();
+        assert(Typedef);
+        printQuotedQualifiedName(Os, Typedef->getDecl());
+      }
+    } else {
+      auto *DesugaredType = VarType->getUnqualifiedDesugaredType();
+      bool IsPtr = isa<PointerType, ObjCObjectPointerType>(DesugaredType);
+      Os << "raw " << (IsPtr ? "pointer" : "reference") << " to ";
+      Os << typeName() << " ";
+      printTypeName(Os, QT);
     }
   }
 };
@@ -460,7 +484,7 @@ public:
   bool isSafePtrType(const QualType type) const final {
     return isRefOrCheckedPtrType(type);
   }
-  const char *ptrKind() const final { return "uncounted"; }
+  const char *typeName() const final { return "RefPtr-capable type"; }
 };
 
 class UncheckedLocalVarsChecker final : public RawPtrRefLocalVarsChecker {
@@ -480,7 +504,7 @@ public:
   bool isSafeExpr(const Expr *E) const final {
     return isExprToGetCheckedPtrCapableMember(E);
   }
-  const char *ptrKind() const final { return "unchecked"; }
+  const char *typeName() const final { return "CheckedPtr-capable type"; }
 };
 
 class UnretainedLocalVarsChecker final : public RawPtrRefLocalVarsChecker {
@@ -505,7 +529,7 @@ public:
     // Treat NS/CF globals in system header as immortal.
     return BR->getSourceManager().isInSystemHeader(D->getLocation());
   }
-  const char *ptrKind() const final { return "unretained"; }
+  const char *typeName() const final { return "RetainPtr-capable type"; }
 };
 
 } // namespace

--- a/clang/test/Analysis/Checkers/WebKit/local-vars-checked-const-member.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/local-vars-checked-const-member.cpp
@@ -46,12 +46,12 @@ void Foo::bar() {
   auto* obj1 = m_obj1.get();
   obj1->method();
   auto* obj2 = m_obj2.get();
-  // expected-warning@-1{{Local variable 'obj2' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'obj2' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   obj2->method();
   auto& obj3 = ensureObj3();
   obj3.method();
   auto& obj4 = ensureObj4();
-  // expected-warning@-1{{Local variable 'obj4' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'obj4' is a raw reference to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   obj4.method();
   auto* obj5 = ensureObj5();
 }
@@ -74,7 +74,7 @@ void Foo::bar() {
   auto& obj1 = m_obj1.get();
   obj1.method();
   auto& obj2 = m_obj2.get();
-  // expected-warning@-1{{Local variable 'obj2' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'obj2' is a raw reference to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   obj2.method();
 }
 
@@ -96,7 +96,7 @@ void Foo::bar() {
   auto* obj1 = m_obj1.get();
   obj1->method();
   auto* obj2 = m_obj2.get();
-  // expected-warning@-1{{Local variable 'obj2' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'obj2' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   obj2->method();
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/local-vars-counted-const-member.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/local-vars-counted-const-member.cpp
@@ -46,12 +46,12 @@ void Foo::bar() {
   auto* obj1 = m_obj1.get();
   obj1->method();
   auto* obj2 = m_obj2.get();
-  // expected-warning@-1{{Local variable 'obj2' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'obj2' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   obj2->method();
   auto& obj3 = ensureObj3();
   obj3.method();
   auto& obj4 = ensureObj4();
-  // expected-warning@-1{{Local variable 'obj4' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'obj4' is a raw reference to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   obj4.method();
   auto* obj5 = ensureObj5();
 }
@@ -74,7 +74,7 @@ void Foo::bar() {
   auto& obj1 = m_obj1.get();
   obj1.method();
   auto& obj2 = m_obj2.get();
-  // expected-warning@-1{{Local variable 'obj2' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'obj2' is a raw reference to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   obj2.method();
 }
 
@@ -96,7 +96,7 @@ void Foo::bar() {
   auto* obj1 = m_obj1.get();
   obj1->method();
   auto* obj2 = m_obj2.get();
-  // expected-warning@-1{{Local variable 'obj2' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'obj2' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   obj2->method();
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/member-function-pointer-crash.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/member-function-pointer-crash.cpp
@@ -18,7 +18,7 @@ private:
     bool canInterpolate(const RenderStyle& from) const
     {
         auto* fromLayer = &(from.*m_layersGetter)();
-        // expected-warning@-1{{Local variable 'fromLayer' is uncounted and unsafe}}
+        // expected-warning@-1{{Local variable 'fromLayer' is a raw pointer to RefPtr-capable type 'FillLayer'}}
         return true;
     }
 

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-local-vars.cpp
@@ -14,7 +14,7 @@ void bar(CheckedObj *) {}
 
 void baz() {
   CheckedObj *bar;
-  // expected-warning@-1{{Local variable 'bar' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   someFunction();
 }
 } // namespace raw_ptr
@@ -23,7 +23,7 @@ namespace reference {
 void foo_ref() {
   CheckedObj automatic;
   CheckedObj &bar = automatic;
-  // expected-warning@-1{{Local variable 'bar' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw reference to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   someFunction();
   bar.method();
 }
@@ -46,7 +46,7 @@ void foo2() {
   CheckedPtr<CheckedObj> foo;
   // missing embedded scope here
   CheckedObj *bar = foo.get();
-  // expected-warning@-1{{Local variable 'bar' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   someFunction();
   bar->method();
 }
@@ -74,7 +74,7 @@ void foo5() {
 void foo6() {
   CheckedPtr<CheckedObj> foo;
   auto* bar = foo.get();
-  // expected-warning@-1{{Local variable 'bar' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   bar->method();
 }
 
@@ -96,17 +96,17 @@ class Foo {
 
   void evil_func() {
     CheckedObj *bar = provide_ref_ctnbl();
-    // expected-warning@-1{{Local variable 'bar' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
     auto *baz = provide_ref_ctnbl();
-    // expected-warning@-1{{Local variable 'baz' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'baz' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
     auto *baz2 = this->provide_ref_ctnbl();
-    // expected-warning@-1{{Local variable 'baz2' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'baz2' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
     [[clang::suppress]] auto *baz_suppressed = provide_ref_ctnbl(); // no-warning
   }
 
   void func() {
     CheckedObj *bar = provide_ref_ctnbl();
-    // expected-warning@-1{{Local variable 'bar' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
     if (bar)
       bar->method();
   }
@@ -167,26 +167,26 @@ void foo() {
 
 void bar() {
   if (CheckedObj *a = provide_ref_ctnbl()) {
-    // expected-warning@-1{{Local variable 'a' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'a' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
     a->method();    
   }
   for (CheckedObj *b = provide_ref_ctnbl(); b != nullptr;) {
-    // expected-warning@-1{{Local variable 'b' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'b' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
     b->method();
   }
   CheckedObj *array[1];
   for (CheckedObj *c : array) {
-    // expected-warning@-1{{Local variable 'c' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'c' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
     c->method();
   }
 
   while (CheckedObj *d = provide_ref_ctnbl()) {
-    // expected-warning@-1{{Local variable 'd' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'd' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
     d->method();
   }
   do {
     CheckedObj *e = provide_ref_ctnbl();
-    // expected-warning@-1{{Local variable 'e' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'e' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
     e->method();
   } while (1);
   someFunction();
@@ -210,7 +210,7 @@ bool bar();
 
 void foo() {
   CheckedObj *a = bar() ? nullptr : provide_checkable();
-  // expected-warning@-1{{Local variable 'a' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'a' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   CheckedPtr<CheckedObj> b = provide_checkable();
   {
     CheckedObj* c = bar() ? nullptr : b.get();
@@ -228,14 +228,14 @@ CheckedObj *provide_checkable();
 
 void foo(CheckedObj* a) {
   CheckedObj* b = a;
-  // expected-warning@-1{{Local variable 'b' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'b' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   if (b->trivial())
     b = provide_checkable();
 }
 
 void bar(CheckedObj* a) {
   CheckedObj* b;
-  // expected-warning@-1{{Local variable 'b' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'b' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   b = provide_checkable();
 }
 
@@ -243,7 +243,7 @@ void baz() {
   CheckedPtr a = provide_checkable();
   {
     CheckedObj* b = a.get();
-    // expected-warning@-1{{Local variable 'b' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'b' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
     b = provide_checkable();
   }
 }
@@ -257,7 +257,7 @@ void someFunction();
 
 void foo(CheckedObj* a) {
   a = provide_checkable();
-  // expected-warning@-1{{Assignment to an unchecked parameter 'a' is unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Parameter 'a' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   someFunction();
   a->method();
 }
@@ -271,7 +271,7 @@ void someFunction();
 
 void foo() {
   static CheckedObj* a = nullptr;
-  // expected-warning@-1{{Static local variable 'a' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Static local variable 'a' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
   a = provide_checkable();
   someFunction();
   a->method();
@@ -285,7 +285,7 @@ CheckedObj *provide_ref_cntbl();
 void someFunction();
 
 CheckedObj* g_a = nullptr;
-// expected-warning@-1{{Global variable 'local_assignment_to_global::g_a' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+// expected-warning@-1{{Global variable 'local_assignment_to_global::g_a' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
 
 void foo() {
   g_a = provide_ref_cntbl();
@@ -304,13 +304,13 @@ namespace member_var {
       auto *a = &checked;
       a->method();
       auto *b = &checkedRef;
-      // expected-warning@-1{{Local variable 'b' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+      // expected-warning@-1{{Local variable 'b' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
       b->method();
     }
 
     void bar(WrapperObj& wrapper) {
       CheckedObj* ptr = &wrapper.checked;
-      // expected-warning@-1{{Local variable 'ptr' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+      // expected-warning@-1{{Local variable 'ptr' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLocalVarsChecker]}}
       ptr->method();
     }
   };
@@ -323,7 +323,7 @@ RefCountableAndCheckable* provide_obj();
 
 void local_raw_ptr() {
   RefCountableAndCheckable* a = nullptr;
-  // expected-warning@-1{{Local variable 'a' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'a' is a raw pointer to CheckedPtr-capable type 'RefCountableAndCheckable' [alpha.webkit.UncheckedLocalVarsChecker]}}
   a = provide_obj();
   a->method();
 }
@@ -346,7 +346,7 @@ void local_var_with_guardian_checked_ptr_with_assignment() {
   RefPtr<RefCountableAndCheckable> a = provide_obj();
   {
     RefCountableAndCheckable* b = a.get();
-    // expected-warning@-1{{Local variable 'b' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'b' is a raw pointer to CheckedPtr-capable type 'RefCountableAndCheckable' [alpha.webkit.UncheckedLocalVarsChecker]}}
     b = provide_obj();
     b->method();
   }
@@ -362,7 +362,7 @@ void local_var_with_guardian_checked_ref() {
 
 void static_var() {
   static RefCountableAndCheckable* a = nullptr;
-  // expected-warning@-1{{Static local variable 'a' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  // expected-warning@-1{{Static local variable 'a' is a raw pointer to CheckedPtr-capable type 'RefCountableAndCheckable' [alpha.webkit.UncheckedLocalVarsChecker]}}
   a = provide_obj();
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -14,7 +14,7 @@ void bar(RefCountable *) {}
 
 void baz() {
   RefCountable *bar;
-  // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   someFunction();
 }
 } // namespace raw_ptr
@@ -23,7 +23,7 @@ namespace reference {
 void foo_ref() {
   RefCountable automatic;
   RefCountable &bar = automatic;
-  // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw reference to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   someFunction();
   bar.method();
 }
@@ -31,7 +31,7 @@ void foo_ref() {
 void foo_ref_trivial() {
   RefCountable automatic;
   RefCountable &bar = automatic;
-  // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw reference to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
 }
 
 void bar_ref(RefCountable &) {}
@@ -47,7 +47,7 @@ void foo2() {
   RefPtr<RefCountable> foo;
   // missing embedded scope here
   RefCountable *bar = foo.get();
-  // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   someFunction();
   bar->method();
 }
@@ -69,7 +69,7 @@ void foo4() {
 void foo5() {
   RefPtr<RefCountable> foo;
   auto* bar = foo.get();
-  // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   bar->trivial();
   {
     auto* baz = foo.get();
@@ -80,7 +80,7 @@ void foo5() {
 void foo6() {
   RefPtr<RefCountable> foo;
   auto* bar = foo.get();
-  // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   bar->method();
 }
 
@@ -98,14 +98,14 @@ void foo8(RefCountable* obj) {
   RefPtr<RefCountable> foo;
   {
     RefCountable *bar = foo.get();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     foo = nullptr;
     bar->method();
   }
   RefPtr<RefCountable> baz;
   {
     RefCountable *bar = baz.get();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     baz = obj;
     bar->method();
   }
@@ -118,19 +118,19 @@ void foo8(RefCountable* obj) {
   foo = obj;
   {
     RefCountable *bar = foo.get();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     foo.releaseNonNull();
     bar->method();
   }
   {
     RefCountable *bar = foo.get();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     foo = obj ? obj : nullptr;
     bar->method();
   }
   {
     RefCountable *bar = foo->trivial() ? foo.get() : nullptr;
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     foo = nullptr;
     foo = (RefCountable *)0;
     bar->method();
@@ -149,38 +149,38 @@ void foo9(RefCountable& o) {
   Ref<RefCountable> guardian(o);
   {
     RefCountable &bar = guardian.get();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw reference to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     guardian = o; // We don't detect that we're setting it to the same value.
     bar.method();
   }
   {
     RefCountable *bar = guardian.ptr();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     Ref<RefCountable> other(*bar); // We don't detect other has the same value as guardian.
     guardian.swap(other);
     bar->method();
   }
   {
     RefCountable *bar = guardian.ptr();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     Ref<RefCountable> other(static_cast<Ref<RefCountable>&&>(guardian));
     bar->method();
   }
   {
     RefCountable *bar = guardian.ptr();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     guardian.leakRef();
     bar->method();
   }
   {
     RefCountable *bar = guardian.ptr();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     guardian = o.trivial() ? o : *bar;
     bar->method();
   }
   {
     RefCountable *bar = guardian.ptr();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     {
       Ref<RefCountable> oldGuardian = std::exchange(guardian, nullptr);
     }
@@ -188,26 +188,26 @@ void foo9(RefCountable& o) {
   }
   {
     RefCountable *bar = guardian.ptr();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     consumeRef(guardian);
     bar->method();
   }
   {
     RefCountable *bar = guardian.ptr();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     Consumer consumer(guardian);
     bar->method();
   }
   {
     RefCountable *bar = guardian.ptr();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     Consumer consumer;
     consumer.mutate(guardian);
     bar->method();
   }
   {
     RefCountable *bar = guardian.ptr();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     Consumer consumer;
     consumer << guardian;
     bar->method();
@@ -222,17 +222,17 @@ class Foo {
 
   void evil_func() {
     RefCountable *bar = provide_ref_ctnbl();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     auto *baz = provide_ref_ctnbl();
-    // expected-warning@-1{{Local variable 'baz' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'baz' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     auto *baz2 = this->provide_ref_ctnbl();
-    // expected-warning@-1{{Local variable 'baz2' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'baz2' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     [[clang::suppress]] auto *baz_suppressed = provide_ref_ctnbl(); // no-warning
   }
 
   void func() {
     RefCountable *bar = provide_ref_ctnbl();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     if (bar)
       bar->method();
   }
@@ -307,26 +307,26 @@ void foo() {
 
 void bar() {
   if (RefCountable *a = provide_ref_ctnbl()) {
-    // expected-warning@-1{{Local variable 'a' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
-    a->method();    
+    // expected-warning@-1{{Local variable 'a' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
+    a->method();
   }
   for (RefCountable *b = provide_ref_ctnbl(); b != nullptr;) {
-    // expected-warning@-1{{Local variable 'b' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'b' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     b->method();
   }
   RefCountable *array[1];
   for (RefCountable *c : array) {
-    // expected-warning@-1{{Local variable 'c' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'c' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     c->method();
   }
 
   while (RefCountable *d = provide_ref_ctnbl()) {
-    // expected-warning@-1{{Local variable 'd' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'd' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     d->method();
   }
   do {
     RefCountable *e = provide_ref_ctnbl();
-    // expected-warning@-1{{Local variable 'e' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'e' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     e->method();
   } while (1);
   someFunction();
@@ -350,7 +350,7 @@ bool bar();
 
 void foo() {
   RefCountable *a = bar() ? nullptr : provide_ref_ctnbl();
-  // expected-warning@-1{{Local variable 'a' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'a' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   RefPtr<RefCountable> b = provide_ref_ctnbl();
   {
     RefCountable* c = bar() ? nullptr : b.get();
@@ -368,14 +368,14 @@ RefCountable *provide_ref_cntbl();
 
 void foo(RefCountable* a) {
   RefCountable* b = a;
-  // expected-warning@-1{{Local variable 'b' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'b' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   if (b->trivial())
     b = provide_ref_cntbl();
 }
 
 void bar(RefCountable* a) {
   RefCountable* b;
-  // expected-warning@-1{{Local variable 'b' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'b' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   b = provide_ref_cntbl();
 }
 
@@ -383,7 +383,7 @@ void baz() {
   RefPtr a = provide_ref_cntbl();
   {
     RefCountable* b = a.get();
-    // expected-warning@-1{{Local variable 'b' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'b' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     b = provide_ref_cntbl();
   }
 }
@@ -396,7 +396,7 @@ RefCountable *provide_ref_cntbl();
 
 void foo(RefPtr<RefCountable>& arg) {
   RefCountable* ptr = arg.get();
-  // expected-warning@-1{{Local variable 'ptr' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'ptr' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   arg = nullptr;
   ptr->method();
 }
@@ -410,7 +410,7 @@ void someFunction();
 
 void foo(RefCountable* a) {
   a = provide_ref_cntbl();
-  // expected-warning@-1{{Assignment to an uncounted parameter 'a' is unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Parameter 'a' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   someFunction();
   a->method();
 }
@@ -424,7 +424,7 @@ void someFunction();
 
 void foo() {
   static RefCountable* a = nullptr;
-  // expected-warning@-1{{Static local variable 'a' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Static local variable 'a' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   a = provide_ref_cntbl();
   someFunction();
   a->method();
@@ -438,7 +438,7 @@ RefCountable *provide_ref_cntbl();
 void someFunction();
 
 RefCountable* g_a = nullptr;
-// expected-warning@-1{{Global variable 'local_assignment_to_global::g_a' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+// expected-warning@-1{{Global variable 'local_assignment_to_global::g_a' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
 
 void foo() {
   g_a = provide_ref_cntbl();
@@ -454,7 +454,7 @@ RefCountableAndCheckable* provide_obj();
 
 void local_raw_ptr() {
   RefCountableAndCheckable* a = nullptr;
-  // expected-warning@-1{{Local variable 'a' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'a' is a raw pointer to RefPtr-capable type 'RefCountableAndCheckable' [alpha.webkit.UncountedLocalVarsChecker]}}
   a = provide_obj();
   a->method();
 }
@@ -477,7 +477,7 @@ void local_var_with_guardian_checked_ptr_with_assignment() {
   CheckedPtr<RefCountableAndCheckable> a = provide_obj();
   {
     RefCountableAndCheckable* b = a.get();
-    // expected-warning@-1{{Local variable 'b' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'b' is a raw pointer to RefPtr-capable type 'RefCountableAndCheckable' [alpha.webkit.UncountedLocalVarsChecker]}}
     b = provide_obj();
     b->method();
   }
@@ -493,7 +493,7 @@ void local_var_with_guardian_checked_ref() {
 
 void static_var() {
   static RefCountableAndCheckable* a = nullptr;
-  // expected-warning@-1{{Static local variable 'a' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  // expected-warning@-1{{Static local variable 'a' is a raw pointer to RefPtr-capable type 'RefCountableAndCheckable' [alpha.webkit.UncountedLocalVarsChecker]}}
   a = provide_obj();
 }
 
@@ -531,7 +531,7 @@ int TreeNode::recursiveCost() {
 int TreeNode::recursiveWeight() {
   unsigned totalCost = weight();
   for (TreeNode* node = firstChild; node; node = node->nextSibling)
-    // expected-warning@-1{{Local variable 'node' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'node' is a raw pointer to RefPtr-capable type 'local_var_in_recursive_function::TreeNode' [alpha.webkit.UncountedLocalVarsChecker]}}
     totalCost += recursiveWeight();
   return totalCost;
 }
@@ -554,9 +554,9 @@ namespace virtual_function {
   };
   void foo(SomeObject* obj) {
     auto* bar = obj->provide();
-    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     auto* baz = &*obj;
-    // expected-warning@-1{{Local variable 'baz' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'baz' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
   }
 }
 
@@ -570,7 +570,7 @@ namespace vardecl_in_if_condition {
   }
 
   RefCountable* get_non_trivial_then() {
-    if (auto* obj = provide()) // expected-warning{{Local variable 'obj' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    if (auto* obj = provide()) // expected-warning{{Local variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
       return obj->next();
     return nullptr;
   }
@@ -592,12 +592,12 @@ namespace vardecl_in_if_condition {
 
   RefCountable* get_non_trivial_condition() {
     if (auto* obj = provide(); obj && obj->next())
-      return obj; // expected-warning@-1{{Local variable 'obj' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+      return obj; // expected-warning@-1{{Local variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
     return nullptr;
   }
 
   RefCountable* get_non_trivial_else2() {
-    if (auto* obj = provide(); !obj) // expected-warning{{Local variable 'obj' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    if (auto* obj = provide(); !obj) // expected-warning{{Local variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [alpha.webkit.UncountedLocalVarsChecker]}}
       return nullptr;
     else
       return obj->next();
@@ -651,8 +651,8 @@ namespace binding_raw_ptr {
 
   void bind_return_value() {
     auto [a, b] = providePair();
-    // expected-warning@-1{{Local variable 'a' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
-    // expected-warning@-2{{Local variable 'b' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'a' is a raw reference to RefPtr-capable type 'binding_raw_ptr::pair<RefCountable *, RefCountable *>' [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-2{{Local variable 'b' is a raw reference to RefPtr-capable type 'binding_raw_ptr::pair<RefCountable *, RefCountable *>' [alpha.webkit.UncountedLocalVarsChecker]}}
     a->method();
   }
 
@@ -663,8 +663,8 @@ namespace binding_raw_ptr {
 
   void bind_temp() {
     auto [a, b] = pair<RefCountable*, RefCountable*> { provide(), provide() };
-    // expected-warning@-1{{Local variable 'a' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
-    // expected-warning@-2{{Local variable 'b' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'a' is a raw reference to RefPtr-capable type 'binding_raw_ptr::pair<RefCountable *, RefCountable *>' [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-2{{Local variable 'b' is a raw reference to RefPtr-capable type 'binding_raw_ptr::pair<RefCountable *, RefCountable *>' [alpha.webkit.UncountedLocalVarsChecker]}}
     a->method();
   }
 
@@ -681,15 +681,15 @@ namespace binding_raw_ptr {
   void bind_local_vars() {
     RefCountable* s[] = { provide(), provide(), provide() };
     auto [a, b, c] = s;
-    // expected-warning@-1{{Local variable 'a' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
-    // expected-warning@-2{{Local variable 'b' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
-    // expected-warning@-3{{Local variable 'c' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'a' is a raw reference to RefPtr-capable type}}
+    // expected-warning@-2{{Local variable 'b' is a raw reference to RefPtr-capable type}}
+    // expected-warning@-3{{Local variable 'c' is a raw reference to RefPtr-capable type}}
     a->method();
   }
 
   void bind_temp_with_safe_ptr() {
     auto [a, b] = pair<RefCountable*, RefPtr<RefCountable>> { provide(), provide() };
-    // expected-warning@-1{{Local variable 'a' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'a' is a raw reference to RefPtr-capable type 'binding_raw_ptr::pair<RefCountable *, RefPtr<RefCountable>>' [alpha.webkit.UncountedLocalVarsChecker]}}
     a->method();
   }
 
@@ -701,7 +701,7 @@ namespace binding_raw_ptr {
 
   void bind_temp_struct() {
     auto [a, b] = provide_ptr_container();
-    // expected-warning@-1{{Local variable 'b' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'b' is a raw reference to RefPtr-capable type 'binding_raw_ptr::ptr_container' [alpha.webkit.UncountedLocalVarsChecker]}}
     a->method();
   }
 

--- a/clang/test/Analysis/Checkers/WebKit/unretained-local-vars-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-local-vars-arc.mm
@@ -20,7 +20,7 @@ void foo2() {
 void foo3() {
   SomeObj *bar = provide();
   IOSurfaceRef surface;
-  // expected-warning@-1{{Local variable 'surface' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'surface' is a RetainPtr-capable type 'IOSurfaceRef' [alpha.webkit.UnretainedLocalVarsChecker]}}
 }
 
 void foo4() {
@@ -29,7 +29,7 @@ void foo4() {
 
 void bar() {
   CFMutableArrayRef array = CFArrayCreateMutable(kCFAllocatorDefault, 10);
-  // expected-warning@-1{{Local variable 'array' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'array' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLocalVarsChecker]}}
   CFArrayAppendValue(array, nullptr);
 }
 
@@ -56,7 +56,7 @@ dispatch_queue_t provide_dispatch();
 void use_const_local() {
   NSString * const str = provide_str();
   CFDictionaryRef dict = provide_dict();
-  // expected-warning@-1{{Local variable 'dict' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'dict' is a RetainPtr-capable type 'CFDictionaryRef' [alpha.webkit.UnretainedLocalVarsChecker]}}
   auto dispatch = provide_dispatch();
   doWork(str, dict, dispatch);
 }
@@ -78,7 +78,7 @@ void use_const_local() {
 
 - (void)bar {
   CFMutableArrayRef array = CFArrayCreateMutable(kCFAllocatorDefault, 10);
-  // expected-warning@-1{{Local variable 'array' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'array' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLocalVarsChecker]}}
   CFArrayAppendValue(array, nullptr);
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
@@ -20,7 +20,7 @@ namespace pointer {
 SomeObj *provide();
 void foo_ref() {
   SomeObj *bar = provide();
-  // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
   [bar doWork];
 }
 
@@ -30,14 +30,14 @@ bool bar_ref(SomeObj *obj) {
 
 void cf_ptr() {
   CFMutableArrayRef array = CFArrayCreateMutable(kCFAllocatorDefault, 10);
-  // expected-warning@-1{{Local variable 'array' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'array' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLocalVarsChecker]}}
   CFArrayAppendValue(array, nullptr);
 }
 
 dispatch_queue_t provide_os();
 void os_ptr() {
   auto queue = provide_os();
-  // expected-warning@-1{{Local variable 'queue' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'queue' is a raw pointer to RetainPtr-capable type 'NSObject' [alpha.webkit.UnretainedLocalVarsChecker]}}
   dispatch_queue_get_label(queue);
 }
 
@@ -56,7 +56,7 @@ void foo2() {
   RetainPtr<SomeObj> foo = provide();
   // missing embedded scope here
   SomeObj *bar = foo.get();
-  // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
   [bar doWork];
 }
 
@@ -82,7 +82,7 @@ void foo5() {
     CFArrayAppendValue(bar, nullptr);
   }
   CFMutableArrayRef baz = foo.get();
-  // expected-warning@-1{{Local variable 'baz' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'baz' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLocalVarsChecker]}}
   CFArrayAppendValue(baz, nullptr);
 }
 
@@ -94,7 +94,7 @@ void foo6() {
     dispatch_queue_get_label(bar);
   }
   dispatch_queue_t baz = queue.get();
-  // expected-warning@-1{{Local variable 'baz' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'baz' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLocalVarsChecker]}}
   dispatch_queue_get_label(baz);
 }
 
@@ -113,14 +113,14 @@ void foo8(SomeObj* obj) {
 
   {
     SomeObj *bar = foo.get();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     foo = nullptr;
     [bar doWork];
   }
   RetainPtr<SomeObj> baz;
   {
     SomeObj *bar = baz.get();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     baz = obj;
     [bar doWork];
   }
@@ -134,19 +134,19 @@ void foo8(SomeObj* obj) {
   foo = obj;
   {
     SomeObj *bar = foo.get();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     foo.clear();
     [bar doWork];
   }
   {
     SomeObj *bar = foo.get();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     foo = obj ? obj : nullptr;
     [bar doWork];
   }
   {
     SomeObj *bar = [foo.get() other] ? foo.get() : nullptr;
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     foo = nullptr;
     [bar doWork];
   }
@@ -156,32 +156,32 @@ void foo9(SomeObj* o) {
   RetainPtr<SomeObj> guardian(o);
   {
     SomeObj *bar = guardian.get();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     guardian = o; // We don't detect that we're setting it to the same value.
     [bar doWork];
   }
   {
     SomeObj *bar = guardian.get();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     RetainPtr<SomeObj> other(bar); // We don't detect other has the same value as guardian.
     guardian.swap(other);
     [bar doWork];
   }
   {
     SomeObj *bar = guardian.get();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     RetainPtr<SomeObj> other(static_cast<RetainPtr<SomeObj>&&>(guardian));
     [bar doWork];
   }
   {
     SomeObj *bar = guardian.get();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     guardian.clear();
     [bar doWork];
   }
   {
     SomeObj *bar = guardian.get();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     guardian = [o other] ? o : bar;
     [bar doWork];
   }
@@ -196,7 +196,7 @@ void foo10() {
   }
   {
     CFMutableArrayRef arrayRef = array.get();
-    // expected-warning@-1{{Local variable 'arrayRef' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'arrayRef' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLocalVarsChecker]}}
     array = nullptr;
     CFArrayAppendValue(arrayRef, nullptr);
   }
@@ -216,7 +216,7 @@ void foo11() {
   }
   {
     dispatch_queue_t queuePtr = queue.get();
-    // expected-warning@-1{{Local variable 'queuePtr' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'queuePtr' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLocalVarsChecker]}}
     queue = nullptr;
     dispatch_queue_get_label(queuePtr);
   }
@@ -239,24 +239,24 @@ class Foo {
 
   void evil_func() {
     SomeObj *bar = provide_obj();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     auto *baz = provide_obj();
-    // expected-warning@-1{{Local variable 'baz' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'baz' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     auto *baz2 = this->provide_obj();
-    // expected-warning@-1{{Local variable 'baz2' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'baz2' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     [[clang::suppress]] auto *baz_suppressed = provide_obj(); // no-warning
   }
 
   void func() {
     SomeObj *bar = provide_obj();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     if (bar)
       [bar doWork];
   }
 
   void bar() {
     auto bar = provide_cf_array();
-    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'bar' is a raw pointer to RetainPtr-capable type '__CFArray' [alpha.webkit.UnretainedLocalVarsChecker]}}
     doWork(bar);
     [[clang::suppress]] auto baz = provide_cf_array(); // no-warning
     doWork(baz);
@@ -264,7 +264,7 @@ class Foo {
 
   void baz() {
     auto value1 = provide_queue();
-    // expected-warning@-1{{Local variable 'value1' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'value1' is a raw pointer to RetainPtr-capable type 'NSObject' [alpha.webkit.UnretainedLocalVarsChecker]}}
     doWork(value1);
     [[clang::suppress]] auto value2 = provide_queue(); // no-warning
     doWork(value2);
@@ -305,7 +305,7 @@ bool bar();
 
 void foo() {
   SomeObj *a = bar() ? nullptr : provide_obj();
-  // expected-warning@-1{{Local variable 'a' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'a' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
   RetainPtr<SomeObj> b = provide_obj();
   {
     SomeObj* c = bar() ? nullptr : b.get();
@@ -323,14 +323,14 @@ SomeObj *provide_obj();
 
 void foo(SomeObj* a) {
   SomeObj* b = a;
-  // expected-warning@-1{{Local variable 'b' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'b' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
   if ([b other])
     b = provide_obj();
 }
 
 void bar(SomeObj* a) {
   SomeObj* b;
-  // expected-warning@-1{{Local variable 'b' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'b' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
   b = provide_obj();
 }
 
@@ -338,7 +338,7 @@ void baz() {
   RetainPtr<SomeObj> a = provide_obj();
   {
     SomeObj* b = a.get();
-    // expected-warning@-1{{Local variable 'b' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    // expected-warning@-1{{Local variable 'b' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
     b = provide_obj();
   }
 }
@@ -352,7 +352,7 @@ void someFunction();
 
 void foo(SomeObj* a) {
   a = provide_obj();
-  // expected-warning@-1{{Assignment to an unretained parameter 'a' is unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Parameter 'a' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
   someFunction();
   [a doWork];
 }
@@ -362,7 +362,7 @@ void doWork(CFMutableArrayRef);
 
 void bar(CFMutableArrayRef a) {
   a = provide_cf_array();
-  // expected-warning@-1{{Assignment to an unretained parameter 'a' is unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Parameter 'a' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLocalVarsChecker]}}
   doWork(a);
 }
 
@@ -371,7 +371,7 @@ void doWork(dispatch_queue_t);
 
 void baz(dispatch_queue_t a) {
   a = provide_queue();
-  // expected-warning@-1{{Assignment to an unretained parameter 'a' is unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Parameter 'a' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLocalVarsChecker]}}
   doWork(a);
 }
 
@@ -384,7 +384,7 @@ void someFunction();
 
 void foo() {
   static SomeObj* a = nullptr;
-  // expected-warning@-1{{Static local variable 'a' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Static local variable 'a' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
   a = provide_obj();
   someFunction();
   [a doWork];
@@ -395,7 +395,7 @@ void doWork(CFMutableArrayRef);
 
 void bar() {
   static CFMutableArrayRef a = nullptr;
-  // expected-warning@-1{{Static local variable 'a' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Static local variable 'a' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLocalVarsChecker]}}
   a = provide_cf_array();
   doWork(a);
 }
@@ -405,7 +405,7 @@ void doWork(dispatch_queue_t);
 
 void baz() {
   static dispatch_queue_t a = nullptr;
-  // expected-warning@-1{{Static local variable 'a' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Static local variable 'a' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLocalVarsChecker]}}
   a = provide_queue();
   doWork(a);
 }
@@ -418,7 +418,7 @@ SomeObj *provide_obj();
 void someFunction();
 
 SomeObj* g_a = nullptr;
-// expected-warning@-1{{Global variable 'local_assignment_to_global::g_a' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+// expected-warning@-1{{Global variable 'local_assignment_to_global::g_a' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
 
 void foo() {
   g_a = provide_obj();
@@ -430,7 +430,7 @@ CFMutableArrayRef provide_cf_array();
 void doWork(CFMutableArrayRef);
 
 CFMutableArrayRef g_b = nullptr;
-// expected-warning@-1{{Global variable 'local_assignment_to_global::g_b' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+// expected-warning@-1{{Global variable 'local_assignment_to_global::g_b' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLocalVarsChecker]}}
 
 void bar() {
   g_b = provide_cf_array();
@@ -440,7 +440,7 @@ void bar() {
 dispatch_queue_t provide_queue();
 void doWork(dispatch_queue_t);
 dispatch_queue_t g_c = nullptr;
-// expected-warning@-1{{Global variable 'local_assignment_to_global::g_c' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+// expected-warning@-1{{Global variable 'local_assignment_to_global::g_c' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLocalVarsChecker]}}
 
 void baz() {
   g_c = provide_queue();
@@ -510,11 +510,11 @@ CFDictionaryRef provide_dict();
 dispatch_queue_t provide_queue();
 void use_const_local() {
   NSString * const str = provide_str();
-  // expected-warning@-1{{Local variable 'str' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'str' is a raw pointer to RetainPtr-capable type 'NSString' [alpha.webkit.UnretainedLocalVarsChecker]}}
   CFDictionaryRef dict = provide_dict();
-  // expected-warning@-1{{Local variable 'dict' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'dict' is a RetainPtr-capable type 'CFDictionaryRef' [alpha.webkit.UnretainedLocalVarsChecker]}}
   dispatch_queue_t queue = provide_queue();
-  // expected-warning@-1{{Local variable 'queue' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'queue' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLocalVarsChecker]}}
   doWork(str, dict, queue);
 }
 
@@ -559,7 +559,7 @@ void cf() {
   auto *str = kCFURLTagNamesKey;
   consumeCFString(str);
   auto *localStr = LocalGlobalCFString;
-  // expected-warning@-1{{Local variable 'localStr' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'localStr' is a raw pointer to RetainPtr-capable type '__CFString' [alpha.webkit.UnretainedLocalVarsChecker]}}
   consumeCFString(localStr);
 }
 
@@ -567,7 +567,7 @@ void ns() {
   auto *str = NSApplicationDidBecomeActiveNotification;
   consumeNSString(str);
   auto *localStr = LocalGlobalNSString;
-  // expected-warning@-1{{Local variable 'localStr' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'localStr' is a raw pointer to RetainPtr-capable type 'NSString' [alpha.webkit.UnretainedLocalVarsChecker]}}
   consumeNSString(localStr);
 }
 
@@ -592,7 +592,7 @@ SomeObj* provide();
 
 - (void)storeSomeObj {
   auto *obj = [self getSomeObj];
-  // expected-warning@-1{{Local variable 'obj' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'obj' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
   [obj doWork];
   auto *obj2 = [SomeObj sharedInstance];
   [obj2 doWork];
@@ -600,7 +600,7 @@ SomeObj* provide();
 
 - (void)assignToGuardianArg:(RetainPtr<SomeObj>&)obj {
   SomeObj* ptr = obj.get();
-  // expected-warning@-1{{Local variable 'ptr' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  // expected-warning@-1{{Local variable 'ptr' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLocalVarsChecker]}}
   obj = nullptr;
   [ptr doWork];
 }


### PR DESCRIPTION
This PR aligns UncheckedLocalVarsChecker and its variant's warning message with the new warning format in https://github.com/llvm/llvm-project/pull/202724.