### PR TITLE
[lldb] Fix SymbolFilePDBTests build for StringRef FileSpec getters

### DIFF
--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -94,7 +94,7 @@ protected:
     if (!left.FileEquals(right))
       return false;
     // If BOTH have a directory, also compare the directories.
-    if (left.GetDirectory() && right.GetDirectory())
+    if (!left.GetDirectory().empty() && !right.GetDirectory().empty())
       return left.DirectoryEquals(right);
 
     // If one has a directory but not the other, they match.


### PR DESCRIPTION
f9b5264523b1 changed FileSpec::GetDirectory() to return llvm::StringRef instead of ConstString. ConstString had an operator bool, so the guard

```
if (left.GetDirectory() && right.GetDirectory())
```

compiled. StringRef has neither a bool conversion nor operator&&, so the test no longer builds. Check for a non-empty directory instead, which preserves the original "if BOTH have a directory" intent.