### PR TITLE
[Darwin] Mark scalbn tests unsupported on macOS 26.4

### DIFF
--- a/compiler-rt/test/builtins/Unit/compiler_rt_scalbn_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_scalbn_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// UNSUPPORTED: osx-broken-scalbn-rounding
 
 #define DOUBLE_PRECISION
 #include <fenv.h>

--- a/compiler-rt/test/builtins/Unit/compiler_rt_scalbnf_test.c
+++ b/compiler-rt/test/builtins/Unit/compiler_rt_scalbnf_test.c
@@ -1,4 +1,5 @@
 // RUN: %clang_builtins %s %librt -o %t && %run %t
+// UNSUPPORTED: osx-broken-scalbn-rounding
 
 #define SINGLE_PRECISION
 #include <fenv.h>

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -594,6 +594,8 @@ if config.target_os == "Darwin":
         config.available_features.add("osx-ld64-live_support")
     if darwin_os_version >= (13, 1):
         config.available_features.add("jit-compatible-osx-swift-runtime")
+    if darwin_os_version >= (26, 4) and darwin_os_version < (27, 0):
+        config.available_features.add("osx-broken-scalbn-rounding")
 
     config.darwin_os_version = darwin_os_version
 


### PR DESCRIPTION
Introduce a new lit feature to mark these tests unsupported on macOS versions where they are broken due to a OS bug: osx-broken-scalbn-rounding

rdar://181950294