### PR TITLE
[Clang] Fix APSInt width of template argument in FinishCXXExpansionStmt()

### DIFF
--- a/clang/lib/Sema/SemaExpand.cpp
+++ b/clang/lib/Sema/SemaExpand.cpp
@@ -558,9 +558,13 @@ StmtResult Sema::FinishCXXExpansionStmt(Stmt *Exp, Stmt *Body) {
   // Expand the body for each instantiation.
   SmallVector<Stmt *, 4> Instantiations;
   CXXExpansionStmtDecl *ESD = Expansion->getDecl();
+  QualType PtrDiffT = Context.getPointerDiffType();
+  unsigned PtrDiffTWidth = Context.getIntWidth(PtrDiffT);
+  bool PtrDiffTIsSigned = PtrDiffT->isSignedIntegerType();
   for (uint64_t I = 0; I < *NumInstantiations; ++I) {
-    TemplateArgument Arg{Context, llvm::APSInt::get(I),
-                         Context.getPointerDiffType()};
+    llvm::APInt IVal{PtrDiffTWidth, I};
+    TemplateArgument Arg{
+        Context, llvm::APSInt{std::move(IVal), PtrDiffTIsSigned}, PtrDiffT};
     MultiLevelTemplateArgumentList MTArgList(ESD, Arg, true);
     MTArgList.addOuterRetainedLevels(
         Expansion->getDecl()->getIndexTemplateParm()->getDepth());

--- a/clang/lib/Sema/SemaExpand.cpp
+++ b/clang/lib/Sema/SemaExpand.cpp
@@ -560,11 +560,11 @@ StmtResult Sema::FinishCXXExpansionStmt(Stmt *Exp, Stmt *Body) {
   CXXExpansionStmtDecl *ESD = Expansion->getDecl();
   QualType PtrDiffT = Context.getPointerDiffType();
   unsigned PtrDiffTWidth = Context.getIntWidth(PtrDiffT);
-  bool PtrDiffTIsSigned = PtrDiffT->isSignedIntegerType();
+  bool PtrDiffTIsUnsigned = PtrDiffT->isUnsignedIntegerType();
   for (uint64_t I = 0; I < *NumInstantiations; ++I) {
     llvm::APInt IVal{PtrDiffTWidth, I};
     TemplateArgument Arg{
-        Context, llvm::APSInt{std::move(IVal), PtrDiffTIsSigned}, PtrDiffT};
+        Context, llvm::APSInt{std::move(IVal), PtrDiffTIsUnsigned}, PtrDiffT};
     MultiLevelTemplateArgumentList MTArgList(ESD, Arg, true);
     MTArgList.addOuterRetainedLevels(
         Expansion->getDecl()->getIndexTemplateParm()->getDepth());


### PR DESCRIPTION
After merging #169680, we started getting assertions in IntegerLiteral::Create() on some ARM systems:

```
Assertion `V.getBitWidth() == C.getIntWidth(type) &&
"Integer type is not the correct size for constant."'
```

The expansion statements patch doesn't ever create an IntegerLiteral directly, but there is one place where we create a TemplateArgument of type 'ptrdiff_t', but we unconditionally set the bit width of its APSInt to 64 bits.

Presumably, the assertion is due to 'ptrdiff_t' not being a 64-bit type on these systems, so make sure that we query its bit width and use that as the width of the APSInt.

I don't have a way of verifying if this patch is correct since pre-commit CI doesn't run on the affected system and I don't have an ARM machine, but I'm merging this anyway since this issue is breaking CI.