### PR TITLE
Exclude libc math C++ builtins from compiler-rt Bazel overlay

### DIFF
--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
@@ -470,6 +470,11 @@ filegroup(
     ),
 )
 
+BUILTINS_LIBC_MATH_EXCLUDES = [
+    # Sources requiring COMPILER_RT_USE_LIBC_MATH (e.g. LIBC_NAMESPACE::shared::*).
+    "lib/builtins/addtf3.cpp",
+]
+
 # Source files for portable components of the compiler builtins library.
 filegroup(
     name = "builtins_generic_srcs",
@@ -487,7 +492,8 @@ filegroup(
             BUILTINS_TF_EXCLUDES +
             BUILTINS_TF_SRCS_PATTERNS +
             BUILTNS_ATOMICS_SRCS +
-            BUILTINS_MACOS_ATOMIC_SRCS_PATTERNS
+            BUILTINS_MACOS_ATOMIC_SRCS_PATTERNS +
+            BUILTINS_LIBC_MATH_EXCLUDES
         ),
     ),
 )


### PR DESCRIPTION
In CMake, addtf3.cpp is only compiled when COMPILER_RT_USE_LIBC_MATH is ON, replacing addtf3.c. In the Bazel overlay, builtins_generic_srcs globbed all lib/builtins/*.cpp without excluding addtf3.cpp, causing compile failures when not using libc math.

Assisted-by: Gemini via Antigravity