### PR TITLE
[clang][NFC] Skip macro source-location check for names that can't warn

### DIFF
--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -396,16 +396,16 @@ bool Preprocessor::CheckMacroName(Token &MacroNameTok, MacroUse isDefineUndef,
   // Macro names with reserved identifiers are accepted if built-in or passed
   // through the command line (the later may be present if -dD was used to
   // generate the preprocessed file).
-  // NB: isInPredefinedFile() is relatively expensive, so keep it at the end
-  // of the condition.
-  if (!SourceMgr.isInSystemHeader(MacroNameLoc) &&
+  // NB: isInPredefinedFile() (via getPresumedLoc) is relatively expensive, so
+  // only run it for names that can actually warn.
+  MacroDiag D = MD_NoWarn;
+  if (isDefineUndef == MU_Define) {
+    D = shouldWarnOnMacroDef(*this, II);
+  }
+  else if (isDefineUndef == MU_Undef)
+    D = shouldWarnOnMacroUndef(*this, II);
+  if (D != MD_NoWarn && !SourceMgr.isInSystemHeader(MacroNameLoc) &&
       !SourceMgr.isInPredefinedFile(MacroNameLoc)) {
-    MacroDiag D = MD_NoWarn;
-    if (isDefineUndef == MU_Define) {
-      D = shouldWarnOnMacroDef(*this, II);
-    }
-    else if (isDefineUndef == MU_Undef)
-      D = shouldWarnOnMacroUndef(*this, II);
     if (D == MD_KeywordDef) {
       // We do not want to warn on some patterns widely used in configuration
       // scripts.  This requires analyzing next tokens, so do not issue warnings

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -401,8 +401,7 @@ bool Preprocessor::CheckMacroName(Token &MacroNameTok, MacroUse isDefineUndef,
   MacroDiag D = MD_NoWarn;
   if (isDefineUndef == MU_Define) {
     D = shouldWarnOnMacroDef(*this, II);
-  }
-  else if (isDefineUndef == MU_Undef)
+  } else if (isDefineUndef == MU_Undef)
     D = shouldWarnOnMacroUndef(*this, II);
   if (D != MD_NoWarn && !SourceMgr.isInSystemHeader(MacroNameLoc) &&
       !SourceMgr.isInPredefinedFile(MacroNameLoc)) {


### PR DESCRIPTION
While profiling Linux headers, I noticed that `Preprocessor::CheckMacroName` performs expensive source-location queries for every macro, even when no diagnostic is possible. We can avoid this overhead by only performing these checks when the macro name is actually a reserved identifier or keyword, skipping them entirely for ordinary macros.

|  | basket Ir |
| --- | --- |
| before | 10,690,004,315 |
| after | 10,649,181,540 |
| **Δ** | **−40.8M (−0.38%)** |

this is a follow up to #137306 and #139492
