### PR TITLE
[libc++] Mark LWG3403 as complete

### DIFF
--- a/libcxx/docs/Status/Cxx20Papers.csv
+++ b/libcxx/docs/Status/Cxx20Papers.csv
@@ -175,7 +175,7 @@
 "`P1957R2 <https://wg21.link/P1957R2>`__","Converting from ``T*``\  to bool should be considered narrowing (re: US 212)","2020-02 (Prague)","|Complete|","18","`#104205 <https://github.com/llvm/llvm-project/issues/104205>`__",""
 "`P1963R0 <https://wg21.link/P1963R0>`__","P1963R0: Fixing US 313","2020-02 (Prague)","|Nothing To Do|","","`#100039 <https://github.com/llvm/llvm-project/issues/100039>`__",""
 "`P1964R2 <https://wg21.link/P1964R2>`__","Wording for boolean-testable","2020-02 (Prague)","|Complete|","13","`#104206 <https://github.com/llvm/llvm-project/issues/104206>`__",""
-"`P1970R2 <https://wg21.link/P1970R2>`__","Consistency for size() functions: Add ranges::ssize","2020-02 (Prague)","|Complete|","15","`#104207 <https://github.com/llvm/llvm-project/issues/104207>`__",""
+"`P1970R2 <https://wg21.link/P1970R2>`__","Consistency for size() functions: Add ranges::ssize","2020-02 (Prague)","|Complete|","13","`#104207 <https://github.com/llvm/llvm-project/issues/104207>`__",""
 "`P1973R1 <https://wg21.link/P1973R1>`__","Rename ""_default_init"" Functions, Rev1","2020-02 (Prague)","|Complete|","16","`#104208 <https://github.com/llvm/llvm-project/issues/104208>`__","The feature-test macro was not set until LLVM 20."
 "`P1976R2 <https://wg21.link/P1976R2>`__","Fixed-size span construction from dynamic range","2020-02 (Prague)","|Complete|","11","`#104209 <https://github.com/llvm/llvm-project/issues/104209>`__",""
 "`P1981R0 <https://wg21.link/P1981R0>`__","Rename leap to leap_second","2020-02 (Prague)","|Complete|","19","`#104210 <https://github.com/llvm/llvm-project/issues/104210>`__",""

--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -19,7 +19,7 @@
 "`LWG3036 <https://wg21.link/LWG3036>`__","``polymorphic_allocator::destroy`` is extraneous","2020-11 (Virtual)","|Nothing To Do|","","`#104276 <https://github.com/llvm/llvm-project/issues/104276>`__","Reverted by P2875R4"
 "`LWG3171 <https://wg21.link/LWG3171>`__","LWG2989 breaks ``directory_entry`` stream insertion","2020-11 (Virtual)","|Complete|","14","`#104277 <https://github.com/llvm/llvm-project/issues/104277>`__",""
 "`LWG3306 <https://wg21.link/LWG3306>`__","``ranges::advance`` violates its preconditions","2020-11 (Virtual)","|Complete|","14","`#104279 <https://github.com/llvm/llvm-project/issues/104279>`__",""
-"`LWG3403 <https://wg21.link/LWG3403>`__","Domain of ``ranges::ssize(E)`` doesn't ``match ranges::size(E)``","2020-11 (Virtual)","|Complete|","15","`#104280 <https://github.com/llvm/llvm-project/issues/104280>`__",""
+"`LWG3403 <https://wg21.link/LWG3403>`__","Domain of ``ranges::ssize(E)`` doesn't ``match ranges::size(E)``","2020-11 (Virtual)","|Complete|","13","`#104280 <https://github.com/llvm/llvm-project/issues/104280>`__",""
 "`LWG3404 <https://wg21.link/LWG3404>`__","Finish removing subrange's conversions from pair-like","2020-11 (Virtual)","|Complete|","13","`#104282 <https://github.com/llvm/llvm-project/issues/104282>`__",""
 "`LWG3405 <https://wg21.link/LWG3405>`__","``common_view``'s converting constructor is bad, too","2020-11 (Virtual)","|Complete|","14","`#104283 <https://github.com/llvm/llvm-project/issues/104283>`__",""
 "`LWG3406 <https://wg21.link/LWG3406>`__","``elements_view::begin()`` and ``elements_view::end()`` have incompatible constraints","2020-11 (Virtual)","|Complete|","16","`#104284 <https://github.com/llvm/llvm-project/issues/104284>`__",""

--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -19,7 +19,7 @@
 "`LWG3036 <https://wg21.link/LWG3036>`__","``polymorphic_allocator::destroy`` is extraneous","2020-11 (Virtual)","|Nothing To Do|","","`#104276 <https://github.com/llvm/llvm-project/issues/104276>`__","Reverted by P2875R4"
 "`LWG3171 <https://wg21.link/LWG3171>`__","LWG2989 breaks ``directory_entry`` stream insertion","2020-11 (Virtual)","|Complete|","14","`#104277 <https://github.com/llvm/llvm-project/issues/104277>`__",""
 "`LWG3306 <https://wg21.link/LWG3306>`__","``ranges::advance`` violates its preconditions","2020-11 (Virtual)","|Complete|","14","`#104279 <https://github.com/llvm/llvm-project/issues/104279>`__",""
-"`LWG3403 <https://wg21.link/LWG3403>`__","Domain of ``ranges::ssize(E)`` doesn't ``match ranges::size(E)``","2020-11 (Virtual)","","","`#104280 <https://github.com/llvm/llvm-project/issues/104280>`__",""
+"`LWG3403 <https://wg21.link/LWG3403>`__","Domain of ``ranges::ssize(E)`` doesn't ``match ranges::size(E)``","2020-11 (Virtual)","|Nothing To Do|","","`#104280 <https://github.com/llvm/llvm-project/issues/104280>`__",""
 "`LWG3404 <https://wg21.link/LWG3404>`__","Finish removing subrange's conversions from pair-like","2020-11 (Virtual)","|Complete|","13","`#104282 <https://github.com/llvm/llvm-project/issues/104282>`__",""
 "`LWG3405 <https://wg21.link/LWG3405>`__","``common_view``'s converting constructor is bad, too","2020-11 (Virtual)","|Complete|","14","`#104283 <https://github.com/llvm/llvm-project/issues/104283>`__",""
 "`LWG3406 <https://wg21.link/LWG3406>`__","``elements_view::begin()`` and ``elements_view::end()`` have incompatible constraints","2020-11 (Virtual)","|Complete|","16","`#104284 <https://github.com/llvm/llvm-project/issues/104284>`__",""

--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -19,7 +19,7 @@
 "`LWG3036 <https://wg21.link/LWG3036>`__","``polymorphic_allocator::destroy`` is extraneous","2020-11 (Virtual)","|Nothing To Do|","","`#104276 <https://github.com/llvm/llvm-project/issues/104276>`__","Reverted by P2875R4"
 "`LWG3171 <https://wg21.link/LWG3171>`__","LWG2989 breaks ``directory_entry`` stream insertion","2020-11 (Virtual)","|Complete|","14","`#104277 <https://github.com/llvm/llvm-project/issues/104277>`__",""
 "`LWG3306 <https://wg21.link/LWG3306>`__","``ranges::advance`` violates its preconditions","2020-11 (Virtual)","|Complete|","14","`#104279 <https://github.com/llvm/llvm-project/issues/104279>`__",""
-"`LWG3403 <https://wg21.link/LWG3403>`__","Domain of ``ranges::ssize(E)`` doesn't ``match ranges::size(E)``","2020-11 (Virtual)","|Nothing To Do|","","`#104280 <https://github.com/llvm/llvm-project/issues/104280>`__",""
+"`LWG3403 <https://wg21.link/LWG3403>`__","Domain of ``ranges::ssize(E)`` doesn't ``match ranges::size(E)``","2020-11 (Virtual)","|Complete|","15","`#104280 <https://github.com/llvm/llvm-project/issues/104280>`__",""
 "`LWG3404 <https://wg21.link/LWG3404>`__","Finish removing subrange's conversions from pair-like","2020-11 (Virtual)","|Complete|","13","`#104282 <https://github.com/llvm/llvm-project/issues/104282>`__",""
 "`LWG3405 <https://wg21.link/LWG3405>`__","``common_view``'s converting constructor is bad, too","2020-11 (Virtual)","|Complete|","14","`#104283 <https://github.com/llvm/llvm-project/issues/104283>`__",""
 "`LWG3406 <https://wg21.link/LWG3406>`__","``elements_view::begin()`` and ``elements_view::end()`` have incompatible constraints","2020-11 (Virtual)","|Complete|","16","`#104284 <https://github.com/llvm/llvm-project/issues/104284>`__",""


### PR DESCRIPTION
[LWG3403](https://wg21.link/LWG3403) specifies that `ranges::ssize` should work on non-range objects for which `ranges::size` is valid. This has been true in libc++ since 6f1b10d, which first implemented `ranges::ssize` for libc++13. The tests introduced by that commit are sufficient to verify compliance since they test calling `ranges::ssize` with various non-range arguments.

In addition to marking LWG3403 as complete, this also updates the status page entry for [P1970R2](https://wg21.link/P1970R2), the paper that added `ranges::ssize`. P1970R2 was previously marked complete in libc++15 as an approximation; however, it was actually complete in libc++13. This change corrects P1970R2's entry to show its actual release version. Since LWG3403 is a correction to P1970R2, the update to the entry for P1970R2 is necessary to keep the order of the entries consistent.

Resolves #104280.