### PR TITLE
Change zos-ppa1-name attr to be the name used in ppa1

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1204,7 +1204,7 @@ void CodeGenFunction::StartFunction(GlobalDecl GD, QualType RetTy,
   }
 
   if (!CGM.getCodeGenOpts().ZOSPPA1Name)
-    Fn->addFnAttr("zos-ppa1-name", "none");
+    Fn->addFnAttr("zos-ppa1-name", "");
 
   if (CGM.getCodeGenOpts().WarnStackSize != UINT_MAX &&
       !CGM.getDiags().isIgnored(diag::warn_fe_backend_frame_larger_than, Loc))

--- a/clang/test/CodeGen/SystemZ/zos-ppa1-name.c
+++ b/clang/test/CodeGen/SystemZ/zos-ppa1-name.c
@@ -10,8 +10,8 @@
 // RUN: %clang_cc1 -triple s390x-ibm-zos -mno-zos-ppa1-name -emit-llvm %s -o -\
 // RUN:   | FileCheck %s -check-prefix=NOEMIT
 
-// EMIT-NOT: attributes #0 = {{{.*}}"zos-ppa1-name"="none"{{.*}}}
-// NOEMIT: attributes #0 = {{{.*}}"zos-ppa1-name"="none"{{.*}}}
+// EMIT-NOT: attributes #0 = {{{.*}}"zos-ppa1-name"{{.*}}}
+// NOEMIT: attributes #0 = {{{.*}}"zos-ppa1-name"{{.*}}}
 
 int main() {
   return 0;

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1867,8 +1867,10 @@ void SystemZAsmPrinter::calculatePPA1() {
 
   // Save the calculated values.
   if (MF->getFunction().hasName() &&
-      MF->getFunction().getFnAttribute("zos-ppa1-name").getValueAsString() !=
-          "none")
+      MF->getFunction().hasFnAttribute("zos-ppa1-name")) {
+    Info.Name =
+        MF->getFunction().getFnAttribute("zos-ppa1-name").getValueAsString();
+  } else
     Info.Name = MF->getFunction().getName();
   Info.PPA1 = OutContext.createTempSymbol(Twine("PPA1_").concat(N), true);
   Info.EPMarker = OutContext.createTempSymbol(Twine("EPM_").concat(N), true);

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1866,12 +1866,12 @@ void SystemZAsmPrinter::calculatePPA1() {
   determinePrologueStackUpdateSym(MF, EndOfPrologSym, StackUpdateSym);
 
   // Save the calculated values.
-  if (MF->getFunction().hasName() &&
-      MF->getFunction().hasFnAttribute("zos-ppa1-name")) {
+  if (MF->getFunction().hasFnAttribute("zos-ppa1-name"))
     Info.Name =
         MF->getFunction().getFnAttribute("zos-ppa1-name").getValueAsString();
-  } else
+  else if (MF->getFunction().hasName())
     Info.Name = MF->getFunction().getName();
+
   Info.PPA1 = OutContext.createTempSymbol(Twine("PPA1_").concat(N), true);
   Info.EPMarker = OutContext.createTempSymbol(Twine("EPM_").concat(N), true);
   Info.FnEnd = OutContext.createTempSymbol(Twine(N).concat("end_"));

--- a/llvm/test/CodeGen/SystemZ/zos-ppa1-name.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ppa1-name.ll
@@ -1,0 +1,37 @@
+; RUN: llc -mtriple s390x-ibm-zos -mcpu=z15 -asm-verbose=false < %s | FileCheck %s
+
+; This tests needs updating when the new external name is emitted into asm output.
+
+; CHECK: L#EPM_sourcename_0 DS 0H
+; CHECK-NEXT: DC XL7'00C300C500C500'
+; CHECK-NEXT: DC XL1'F1'
+; CHECK-NEXT: DC AD(L#PPA1_sourcename_0-L#EPM_sourcename_0)
+; CHECK-NEXT: DC XL4'00000008'
+; CHECK-NEXT: ENTRY sourcename
+; CHECK:sourcename DS 0H
+;CHECK-NEXT:  b 2(7)
+;CHECK-NEXT: L#sourcename_end_0 DS 0H
+;CHECK-NEXT: L#func_end0 DS 0H
+
+define void @sourcename() #0 {
+entry:
+  ret void
+}
+attributes #0 = { "zos-ppa1-name"="name" }
+
+; CHECK:L#PPA1_sourcename_0 DS 0H
+; CHECK-NEXT: DC XL1'02'
+; CHECK-NEXT: DC XL1'CE'
+; CHECK-NEXT: DC XL2'0000'
+; CHECK-NEXT: DC AD(L#PPA2-L#PPA1_sourcename_0)
+; CHECK-NEXT: DC XL1'80'
+; CHECK-NEXT: DC XL1'80'
+; CHECK-NEXT: DC XL1'00'
+; CHECK-NEXT: DC XL1'81'
+; CHECK-NEXT: DC XL2'0000'
+; CHECK-NEXT: DC XL1'00'
+; CHECK-NEXT: DC XL1'0'
+; CHECK-NEXT: DC AD(L#sourcename_end_0-L#EPM_sourcename_0)
+; CHECK-NEXT: DC XL2'0004'
+; CHECK-NEXT: DC XL4'95819485'
+; CHECK-NEXT: DC AD(L#EPM_sourcename_0-L#PPA1_sourcename_0)

--- a/llvm/test/CodeGen/SystemZ/zos-ppa1.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ppa1.ll
@@ -207,7 +207,7 @@ declare i32 @other(ptr, i32)
 ; CHECK-NEXT:  DC XL10'A689A388819393968381'
 ; CHECK-NEXT:  DC AD(L#EPM_withalloca_0-L#PPA1_withalloca_0)
 
-; Attribute "zos-ppa1-name"="none" removes the function name from PPA1.
+; Attribute "zos-ppa1-name"="" removes the function name from PPA1.
 ; CHECK: * PPA1
 ; CHECK-NEXT: L#PPA1_no_name_0 DS 0H
 ; CHECK:      * PPA1 Flags 4
@@ -227,4 +227,4 @@ define void @no_name() #0 {
 entry:
   ret void
 }
-attributes #0 = { "zos-ppa1-name"="none" }
+attributes #0 = { "zos-ppa1-name" }


### PR DESCRIPTION
Change the meaning of the `zos-ppa1-name` attribute to pass the name of the function to use in the PPA1.  The symbol name used in the PAA1 will be:
- if the function has the `zos-ppa1-name` attribute, use that value.  An empty string will be mean don't add the name to the PPA1
- otherwise  use the function name.

The behaviour for asm labels and `#pragma map` (PR coming shortly) is to use the function name used in the source code in the PPA1.  A follow on PR for clang will set `zos-ppa1-name` to the mangled name ignoring asm label to implement the non-empty string part of the first bullet.