### PR TITLE
[Clang] [Docs] Add release note for expansion statements

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -258,6 +258,9 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 
 - Clang now propagates `constinit` and `constexpr` in structured bindings with tuple-like initializers.
 
+- Clang now has partial support for `P1306R5 <https://wg21.link/P1306R5>`_ Expansion Statements. Iterating expansion
+  statements currently cannot be expanded and will result in a diagnostic, but other types of expansion statements work.
+
 #### C++23 Feature Support
 
 - Partially implement Itanium mangling for pack indexing. Partially substituted packs are not yet supported. (#GH112003)

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -258,7 +258,7 @@ latest release, please see the [Clang Web Site](https://clang.llvm.org) or the
 
 - Clang now propagates `constinit` and `constexpr` in structured bindings with tuple-like initializers.
 
-- Clang now has partial support for `P1306R5 <https://wg21.link/P1306R5>`_ Expansion Statements. Iterating expansion
+- Clang now has partial support for [P1306R5](https://wg21.link/P1306R5) Expansion Statements. Iterating expansion
   statements currently cannot be expanded and will result in a diagnostic, but other types of expansion statements work.
 
 #### C++23 Feature Support


### PR DESCRIPTION
This was supposed to be part of the original patch, but we lost it because I didn't pay enough attention when I was merging the release notes after the migration from RST -> MD (I deleted the RST file but forgot to move the release note to the MD file...)