### PR TITLE
[orc-rt] Hold log level names as uppercase

### DIFF
--- a/orc-rt/lib/executor/Logging.cpp
+++ b/orc-rt/lib/executor/Logging.cpp
@@ -19,7 +19,7 @@
 static const char *CategoryNames[orc_rt_log_Category_Count] = {"General"};
 
 static const char *LevelNames[ORC_RT_LOG_LEVEL_COUNT] = {
-    "debug", "info", "warning", "error", "off",
+    "DEBUG", "INFO", "WARNING", "ERROR", "OFF",
 };
 
 const char *orc_rt_log_Category_getName(orc_rt_log_Category Cat) noexcept {
@@ -42,8 +42,8 @@ orc_rt_log_Level orc_rt_log_Level_parse(const char *Str) noexcept {
     for (size_t I = 0; I != Size; ++I) {
       unsigned char P = LevelName[I];
       unsigned char Q = Str[I];
-      assert((!P || std::islower(P)) && "Level name is not all lowercase");
-      if (std::tolower(Q) != P)
+      assert((!P || std::isupper(P)) && "Level name is not all uppercase");
+      if (std::toupper(Q) != P)
         return false;
     }
     return true;

--- a/orc-rt/test/unit/LoggingTest.cpp
+++ b/orc-rt/test/unit/LoggingTest.cpp
@@ -27,11 +27,11 @@ TEST(LoggingTest, CompilesAtEveryLevel) {
 }
 
 TEST(LoggingTest, LevelGetName) {
-  EXPECT_STREQ("debug", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_DEBUG));
-  EXPECT_STREQ("info", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_INFO));
-  EXPECT_STREQ("warning", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_WARNING));
-  EXPECT_STREQ("error", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_ERROR));
-  EXPECT_STREQ("off", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_OFF));
+  EXPECT_STREQ("DEBUG", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_DEBUG));
+  EXPECT_STREQ("INFO", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_INFO));
+  EXPECT_STREQ("WARNING", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_WARNING));
+  EXPECT_STREQ("ERROR", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_ERROR));
+  EXPECT_STREQ("OFF", orc_rt_log_Level_getName(ORC_RT_LOG_LEVEL_OFF));
 
   // Out-of-range levels have no name.
   EXPECT_EQ(nullptr, orc_rt_log_Level_getName(-1));


### PR DESCRIPTION
orc_rt_log_Level_getName is used primarily in text prefixes (e.g. the upcoming printf backend's "[orc-rt:General:LEVEL]"), where uppercase is the intended rendering. Storing the names as uppercase lets the backend use them directly without case conversion. orc_rt_log_Level_parse performs a case-insensitive parse, so ORC_RT_LOG=info and similar still work.

[orc-rt] Hold log level names as uppercase.

orc_rt_log_Level_getName is expected to be primarily used in text-prefixes (e.g. in the upcoming printf backend), where it should be printed as uppercase. Storing as uppercase in the first place will save us a toupper conversion on each log call.