### PR TITLE
[ELF] Apply version script patterns to name-versioned definitions by node

### DIFF
--- a/lld/ELF/SymbolTable.cpp
+++ b/lld/ELF/SymbolTable.cpp
@@ -223,11 +223,10 @@ bool SymbolTable::assignExactVersion(SymbolVersion ver, uint16_t versionId,
 
   // Assign the version.
   for (Symbol *sym : syms) {
-    // For a non-local versionId, skip symbols containing version info because
-    // symbol versions specified by symbol names take precedence over version
-    // scripts. See parseSymbolVersion(ctx).
-    if (!includeNonDefault && versionId != VER_NDX_LOCAL &&
-        sym->getName().contains('@'))
+    // Skip symbols containing version info because symbol versions specified
+    // by symbol names take precedence over version scripts. See
+    // parseSymbolVersion(ctx).
+    if (!includeNonDefault && sym->hasVersionSuffix)
       continue;
 
     // If the version has not been assigned, assign versionId to the symbol.

--- a/lld/ELF/SymbolTable.cpp
+++ b/lld/ELF/SymbolTable.cpp
@@ -207,9 +207,7 @@ void SymbolTable::handleDynamicList() {
 
 // Set symbol versions to symbols. This function handles patterns containing no
 // wildcard characters. Return false if no symbol definition matches ver.
-bool SymbolTable::assignExactVersion(SymbolVersion ver, uint16_t versionId,
-                                     StringRef versionName,
-                                     bool includeNonDefault) {
+bool SymbolTable::assignExactVersion(SymbolVersion ver, uint16_t versionId) {
   // Get a list of symbols which we need to assign the version to.
   SmallVector<Symbol *, 0> syms = findByVersion(ver);
 
@@ -226,7 +224,7 @@ bool SymbolTable::assignExactVersion(SymbolVersion ver, uint16_t versionId,
     // Skip symbols containing version info because symbol versions specified
     // by symbol names take precedence over version scripts. See
     // parseSymbolVersion(ctx).
-    if (!includeNonDefault && sym->hasVersionSuffix)
+    if (sym->hasVersionSuffix)
       continue;
 
     // If the version has not been assigned, assign versionId to the symbol.
@@ -243,12 +241,11 @@ bool SymbolTable::assignExactVersion(SymbolVersion ver, uint16_t versionId,
   return !syms.empty();
 }
 
-void SymbolTable::assignWildcardVersion(SymbolVersion ver, uint16_t versionId,
-                                        bool includeNonDefault) {
+void SymbolTable::assignWildcardVersion(SymbolVersion ver, uint16_t versionId) {
   // Exact matching takes precedence over fuzzy matching,
   // so we set a version to a symbol only if no version has been assigned
   // to the symbol. This behavior is compatible with GNU.
-  for (Symbol *sym : findAllByVersion(ver, includeNonDefault))
+  for (Symbol *sym : findAllByVersion(ver, /*includeNonDefault=*/false))
     if (!sym->versionScriptAssigned) {
       sym->versionScriptAssigned = true;
       sym->versionId = versionId;
@@ -266,12 +263,14 @@ void SymbolTable::scanVersionScript() {
   // i.e. version definitions not containing any glob meta-characters.
   for (VersionDefinition &v : ctx.arg.versionDefinitions) {
     auto assignExact = [&](SymbolVersion pat, uint16_t id, StringRef ver) {
-      bool found =
-          assignExactVersion(pat, id, ver, /*includeNonDefault=*/false);
+      bool found = assignExactVersion(pat, id);
+      // A definition foo@v1 is keyed by "foo@v1"; look it up so that the
+      // pattern is not reported as undefined. Its version is governed by
+      // parseSymbolVersion instead.
       buf.clear();
-      found |= assignExactVersion({(pat.name + "@" + v.name).toStringRef(buf),
-                                   pat.isExternCpp, /*hasWildCard=*/false},
-                                  id, ver, /*includeNonDefault=*/true);
+      found |= !findByVersion({(pat.name + "@" + v.name).toStringRef(buf),
+                               pat.isExternCpp, /*hasWildCard=*/false})
+                    .empty();
       if (!found && !ctx.arg.undefinedVersion)
         Err(ctx) << "version script assignment of '" << ver << "' to symbol '"
                  << pat.name << "' failed: symbol not defined";
@@ -287,21 +286,13 @@ void SymbolTable::scanVersionScript() {
   // Next, assign versions to wildcards that are not "*". Note that because the
   // last match takes precedence over previous matches, we iterate over the
   // definitions in the reverse order.
-  auto assignWildcard = [&](SymbolVersion pat, uint16_t id, StringRef ver) {
-    assignWildcardVersion(pat, id, /*includeNonDefault=*/false);
-    buf.clear();
-    assignWildcardVersion({(pat.name + "@" + ver).toStringRef(buf),
-                           pat.isExternCpp, /*hasWildCard=*/true},
-                          id,
-                          /*includeNonDefault=*/true);
-  };
   for (VersionDefinition &v : llvm::reverse(ctx.arg.versionDefinitions)) {
     for (SymbolVersion &pat : v.nonLocalPatterns)
       if (pat.hasWildcard && pat.name != "*")
-        assignWildcard(pat, v.id, v.name);
+        assignWildcardVersion(pat, v.id);
     for (SymbolVersion &pat : v.localPatterns)
       if (pat.hasWildcard && pat.name != "*")
-        assignWildcard(pat, VER_NDX_LOCAL, v.name);
+        assignWildcardVersion(pat, VER_NDX_LOCAL);
   }
 
   // Then, assign versions to "*". In GNU linkers they have lower priority than
@@ -336,7 +327,7 @@ void SymbolTable::scanVersionScript() {
         globalAsteriskFound = !isLocal;
       }
     }
-    assignWildcard(pat, isLocal ? (uint16_t)VER_NDX_LOCAL : ver->id, ver->name);
+    assignWildcardVersion(pat, isLocal ? (uint16_t)VER_NDX_LOCAL : ver->id);
   };
   for (VersionDefinition &v : llvm::reverse(ctx.arg.versionDefinitions)) {
     for (SymbolVersion &pat : v.nonLocalPatterns)

--- a/lld/ELF/SymbolTable.h
+++ b/lld/ELF/SymbolTable.h
@@ -87,10 +87,8 @@ private:
                                             bool includeNonDefault);
 
   llvm::StringMap<SmallVector<Symbol *, 0>> &getDemangledSyms();
-  bool assignExactVersion(SymbolVersion ver, uint16_t versionId,
-                          StringRef versionName, bool includeNonDefault);
-  void assignWildcardVersion(SymbolVersion ver, uint16_t versionId,
-                             bool includeNonDefault);
+  bool assignExactVersion(SymbolVersion ver, uint16_t versionId);
+  void assignWildcardVersion(SymbolVersion ver, uint16_t versionId);
 
   Ctx &ctx;
 

--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -243,12 +243,9 @@ void Symbol::parseSymbolVersion(Ctx &ctx) {
     if (ver.name != verstr)
       continue;
 
-    if (!isDefault) {
-      versionId = ver.id | VERSYM_HIDDEN;
-      return;
-    }
-    // Like GNU ld, localize a default version foo@@v1 if a local: pattern in
-    // its own node v1 matches foo and no global: pattern does.
+    // Like GNU ld, localize a versioned symbol (foo@v1 or foo@@v1) if a
+    // local: pattern in its own node v1 matches foo and no global: pattern
+    // does.
     StringRef base = s.take_front(pos);
     std::string demangled = demangle(base);
     auto matches = [&](ArrayRef<SymbolVersion> pats) {
@@ -260,9 +257,10 @@ void Symbol::parseSymbolVersion(Ctx &ctx) {
       }
       return false;
     };
-    versionId = !matches(ver.nonLocalPatterns) && matches(ver.localPatterns)
-                    ? VER_NDX_LOCAL
-                    : ver.id;
+    if (!matches(ver.nonLocalPatterns) && matches(ver.localPatterns))
+      versionId = VER_NDX_LOCAL;
+    else
+      versionId = isDefault ? ver.id : ver.id | VERSYM_HIDDEN;
     return;
   }
 

--- a/lld/ELF/Symbols.cpp
+++ b/lld/ELF/Symbols.cpp
@@ -15,6 +15,7 @@
 #include "SyntheticSections.h"
 #include "Target.h"
 #include "Writer.h"
+#include "lld/Common/Strings.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/Support/Compiler.h"
 #include <cstring>
@@ -242,10 +243,26 @@ void Symbol::parseSymbolVersion(Ctx &ctx) {
     if (ver.name != verstr)
       continue;
 
-    if (isDefault)
-      versionId = ver.id;
-    else
+    if (!isDefault) {
       versionId = ver.id | VERSYM_HIDDEN;
+      return;
+    }
+    // Like GNU ld, localize a default version foo@@v1 if a local: pattern in
+    // its own node v1 matches foo and no global: pattern does.
+    StringRef base = s.take_front(pos);
+    std::string demangled = demangle(base);
+    auto matches = [&](ArrayRef<SymbolVersion> pats) {
+      for (const SymbolVersion &pat : pats) {
+        StringRef name = pat.isExternCpp ? StringRef(demangled) : base;
+        if (pat.hasWildcard ? SingleStringMatcher(pat.name).match(name)
+                            : pat.name == name)
+          return true;
+      }
+      return false;
+    };
+    versionId = !matches(ver.nonLocalPatterns) && matches(ver.localPatterns)
+                    ? VER_NDX_LOCAL
+                    : ver.id;
     return;
   }
 

--- a/lld/test/ELF/version-script-symver-extern.s
+++ b/lld/test/ELF/version-script-symver-extern.s
@@ -18,7 +18,8 @@
 # MIX1-NEXT: [[#]] _Z4foo4i@@v2
 # MIX1-NOT:  {{.}}
 
-# RUN: echo 'v1 { local: extern "C++" {foo*;}; }; v2 { global: extern "C++" {"foo2()";}; };' > %t3.script
+## v1's foo* and "foo4(int)" do not localize _Z4foo4i@@v2, whose node is v2.
+# RUN: echo 'v1 { local: extern "C++" {foo*; "foo4(int)";}; }; v2 { global: extern "C++" {"foo2()";}; };' > %t3.script
 # RUN: ld.lld --version-script %t3.script -shared %t.o -o %t3.so
 # RUN: llvm-readelf --dyn-syms %t3.so | FileCheck --check-prefix=MIX2 %s
 # MIX2:      UND

--- a/lld/test/ELF/version-script-symver-extern.s
+++ b/lld/test/ELF/version-script-symver-extern.s
@@ -9,12 +9,14 @@
 # EXACT-NEXT: [[#]] _start{{$}}
 # EXACT-NOT:  {{.}}
 
+## v1's global: * keeps _Z4foo3i@v1 exported despite local: foo*.
 # RUN: echo 'v1 { global: *; local: extern "C++" {foo*;}; }; v2 { global: extern "C++" {"foo2()";}; };' > %t2.script
 # RUN: ld.lld --version-script %t2.script -shared %t.o -o %t2.so
 # RUN: llvm-readelf --dyn-syms %t2.so | FileCheck --check-prefix=MIX1 %s
 # MIX1:      UND
 # MIX1-NEXT: [[#]] _Z4foo2v@@v2
 # MIX1-NEXT: [[#]] _start@@v1
+# MIX1-NEXT: [[#]] _Z4foo3i@v1
 # MIX1-NEXT: [[#]] _Z4foo4i@@v2
 # MIX1-NOT:  {{.}}
 

--- a/lld/test/ELF/version-script-symver.s
+++ b/lld/test/ELF/version-script-symver.s
@@ -45,14 +45,16 @@
 # STAR-NEXT: [[#]] foo3@v1
 # STAR-NOT:  {{.}}
 
-## In foo4@@v2's node, global: foo4* beats local: foo4: no exact-over-wildcard
-## precedence.
-# RUN: echo 'v1 { global: *; local: foo*; }; v2 { global: foo4*; local: foo4; };' > %t3.script
+## In a versioned symbol's own node, global: beats local: with no
+## exact-over-wildcard precedence: global: * keeps foo3@v1 exported and
+## global: foo4* keeps foo4@@v2 exported.
+# RUN: echo 'v1 { global: *; local: foo*; foo3; }; v2 { global: foo4*; local: foo4; };' > %t3.script
 # RUN: ld.lld --version-script %t3.script -shared %t.o -o %t3.so
 # RUN: llvm-readelf --dyn-syms %t3.so | FileCheck --check-prefix=MIX1 %s
 # MIX1:      UND
 # MIX1-NEXT: [[#]] foo4@@v2
 # MIX1-NEXT: [[#]] _start@@v1
+# MIX1-NEXT: [[#]] foo3@v1
 # MIX1-NOT:  {{.}}
 
 # RUN: echo 'v1 { global: foo*; local: *; }; v2 { global: foo4; local: *; };' > %t4.script

--- a/lld/test/ELF/version-script-symver.s
+++ b/lld/test/ELF/version-script-symver.s
@@ -4,7 +4,9 @@
 # RUN: echo 'call foo3; call foo4' > %tref.s
 # RUN: llvm-mc -filetype=obj -triple=x86_64 %tref.s -o %tref.o
 
-# RUN: echo 'v1 { local: foo1; }; v2 { local: foo2; };' > %t1.script
+## v1's local: foo4 does not localize foo4@@v2: a default version is governed
+## only by its own version node.
+# RUN: echo 'v1 { local: foo1; foo4; }; v2 { local: foo2; };' > %t1.script
 # RUN: ld.lld --version-script %t1.script -shared %t.o -o %t1.so
 # RUN: llvm-readelf --dyn-syms %t1.so | FileCheck --check-prefix=EXACT %s
 # EXACT:      UND
@@ -21,7 +23,31 @@
 # WC-NEXT: [[#]] _start{{$}}
 # WC-NOT:  {{.}}
 
-# RUN: echo 'v1 { global: *; local: foo*; }; v2 {};' > %t3.script
+## Exact and wildcard local: patterns in foo4@@v2's own node localize it.
+# RUN: echo 'v1 {}; v2 { local: foo4; };' > %town.script
+# RUN: ld.lld --version-script %town.script -shared %t.o -o %town.so
+# RUN: llvm-readelf --dyn-syms %town.so | FileCheck --check-prefix=OWN %s
+# RUN: echo 'v1 {}; v2 { local: foo4*; };' > %twc2.script
+# RUN: ld.lld --version-script %twc2.script -shared %t.o -o %twc2.so
+# RUN: llvm-readelf --dyn-syms %twc2.so | FileCheck --check-prefix=OWN %s
+# OWN:      UND
+# OWN-NEXT: [[#]] foo1{{$}}
+# OWN-NEXT: [[#]] foo2{{$}}
+# OWN-NEXT: [[#]] _start{{$}}
+# OWN-NEXT: [[#]] foo3@v1
+# OWN-NOT:  {{.}}
+
+## Same for "local: *".
+# RUN: echo 'v1 {}; v2 { local: *; };' > %tstar.script
+# RUN: ld.lld --version-script %tstar.script -shared %t.o -o %tstar.so
+# RUN: llvm-readelf --dyn-syms %tstar.so | FileCheck --check-prefix=STAR %s
+# STAR:      UND
+# STAR-NEXT: [[#]] foo3@v1
+# STAR-NOT:  {{.}}
+
+## In foo4@@v2's node, global: foo4* beats local: foo4: no exact-over-wildcard
+## precedence.
+# RUN: echo 'v1 { global: *; local: foo*; }; v2 { global: foo4*; local: foo4; };' > %t3.script
 # RUN: ld.lld --version-script %t3.script -shared %t.o -o %t3.so
 # RUN: llvm-readelf --dyn-syms %t3.so | FileCheck --check-prefix=MIX1 %s
 # MIX1:      UND


### PR DESCRIPTION
Like GNU ld, a definition whose name specifies a version (foo@@v1 or
foo@v1) should be governed solely by its own version node, with global
patterns checked before local ones and no exact-over-wildcard
precedence. Also fix #202259 (`local: foo*` does not localize defined
`foo@@v1`)

```
                                           old        new (= GNU ld)
  symbol foo@@v1
  v1 { local: foo; }        (own node)     localized  localized
  v2 { local: foo; }        (other node)   localized  exported
  v1 { local: foo*; }       (own node)     exported   localized
  v1 { local: *; }          (own node)     exported   localized
  v1 { global: foo*; local: foo; }         localized  exported
  symbol foo3@v1
  v1 { global: foo3*; local: foo3; }       localized  exported
  v1 { global: *; local: foo3*; }          localized  exported
```

assignExactVersion now skips name-versioned symbols, and the
synthesized "pat@v1" patterns and includeNonDefault parameters are
removed. Instead, parseSymbolVersion matches the version-less name
(demangled for extern "C++" patterns) against the symbol's own node,
localizing the symbol if a local: pattern matches and no global:
pattern does. An exact pattern still performs a "pat@v1" lookup so that
a pattern matching only foo@v1 is not reported as undefined. "attempt
to reassign" diagnostics no longer apply to name-versioned symbols.