### PR TITLE
[libcxx][NFC] Move release notes for MSVC's implementation of exception_ptr

### DIFF
--- a/libcxx/docs/ReleaseNotes/22.rst
+++ b/libcxx/docs/ReleaseNotes/22.rst
@@ -128,9 +128,6 @@ Potentially breaking changes
   ``_LIBCPP_ABI_NO_ITERATOR_BASES``. If you are using this flag and care about ABI stability, you should set
   ``_LIBCPP_ABI_NO_REVERSE_ITERATOR_SECOND_MEMBER`` as well.
 
-- ``std::exception_ptr`` on Windows no longer relies on STL and is now implemented entirely within libc++.
-  The implementation was donated by Microsoft and has been refactored to follow libc++ standards and conventions.
-
 Announcements About Future Releases
 -----------------------------------
 
@@ -156,9 +153,6 @@ ABI Affecting Changes
 - ``bitset::operator[]`` now returns ``bool``, making libc++ conforming. The behaviour can be reverted by defining
   ``_LIBCPP_DEPRECATED_ABI_BITSET_CONST_SUBSCRIPT_RETURN_REF``. Please inform the libc++ team if you need this flag,
   since it will be removed in LLVM 24 if there is no evidence that it's required.
-
-- ``std::exception_ptr`` now uses the same layout on Windows as on other platforms, changing the size from two to one
-  pointer.
 
 Build System Changes
 --------------------

--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -131,6 +131,5 @@ ABI Affecting Changes
 - ``std::exception_ptr`` now uses the same layout in MSVC mode as on other platforms, changing the size from two to one
   pointer.
 
-
 Build System Changes
 --------------------

--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -98,6 +98,9 @@ Potentially breaking changes
 - The output of ``ostream << std::thread::id`` and ``std::format("...", std::thread:id)`` changes on some platforms from
   hexadecimal to decimal. This is done to have consistent formatting across all platforms libc++ supports.
 
+- ``std::exception_ptr`` on Windows no longer relies on STL and is now implemented entirely within libc++.
+  The implementation was donated by Microsoft and has been refactored to follow libc++ standards and conventions.
+
 Announcements About Future Releases
 -----------------------------------
 
@@ -124,6 +127,10 @@ ABI Affecting Changes
   layouts.  The ``iterator`` member type is also changed to store ``FancyPtr<const FancyPtr<T>>`` because the internal
   map is never modified via an ``iterator``. This is necessary for reducing undefined behavior and for adding
   ``constexpr`` support for ``deque`` in C++26, so we do not provide any way to opt-out of that behavior.
+
+- ``std::exception_ptr`` now uses the same layout in MSVC mode as on other platforms, changing the size from two to one
+  pointer.
+
 
 Build System Changes
 --------------------


### PR DESCRIPTION
These were accidentally placed in LLVM 22 rather than 23 file.