### PR TITLE
[NFC] Rename misleading `msvcrt` comment in `Windows/DynamicLibrary.inc`

### DIFF
--- a/llvm/lib/Support/Windows/DynamicLibrary.inc
+++ b/llvm/lib/Support/Windows/DynamicLibrary.inc
@@ -131,10 +131,10 @@ void *DynamicLibrary::HandleSet::DLSym(void *Handle, const char *Symbol) {
 
   if (Handles.size() > 1) {
     // This is different behaviour than what Posix dlsym(dlopen(NULL)) does.
-    // Doing that here is causing real problems for the JIT where msvc.dll
+    // Doing that here is causing real problems for the JIT where msvcrt.dll
     // and ucrt.dll can define the same symbols. The runtime linker will choose
     // symbols from ucrt.dll first, but iterating NOT in reverse here would
-    // mean that the msvc.dll versions would be returned.
+    // mean that the msvcrt.dll versions would be returned.
 
     for (auto I = Handles.rbegin(), E = Handles.rend() - 1; I != E; ++I) {
       if (FARPROC Ptr = GetProcAddress(HMODULE(*I), Symbol))


### PR DESCRIPTION
The comment in function `DynamicLibrary::HandleSet::DLSym` referred to the mysterious `msvc.dll` windows standard dynamic library which simply doesn't exist and `msvcrt.dll` was likely meant, so fix the comments.