### PR TITLE
[clang][test] Fix emulated-tls.cpp failure on LoongArch

### DIFF
--- a/clang/test/Interpreter/emulated-tls.cpp
+++ b/clang/test/Interpreter/emulated-tls.cpp
@@ -1,6 +1,9 @@
 // REQUIRES: host-supports-jit
 // UNSUPPORTED: system-windows
 //
+// Emulated TLS is not supported by the LoongArch backend.
+// UNSUPPORTED: target=loongarch{{.*}}
+//
 // An inline function that odr-uses a non-zero-initialized thread_local is
 // emitted as a weak (linkonce_odr) definition into every PartialTranslationUnit
 // that references it. With emulated TLS that set includes an __emutls_t.<var>


### PR DESCRIPTION
The LoongArch backend does not support emulated TLS, so
mark the test as unsupported to fix the LoongArch buildbot
failure.

Failure: https://lab.llvm.org/staging/#/builders/20/builds/28875
