### PR TITLE
[libcxx] avoid include Uppercase windows headers

### DIFF
--- a/libcxx/src/support/runtime/exception_pointer_msvc.ipp
+++ b/libcxx/src/support/runtime/exception_pointer_msvc.ipp
@@ -14,8 +14,8 @@ _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wmultichar")
 #include <cstdlib>
 #include <cstring>
 
-#include <Unknwn.h>
-#include <Windows.h>
+#include <unknwn.h>
+#include <windows.h>
 struct _ThrowInfo;
 #include <eh.h>
 #include <ehdata.h>


### PR DESCRIPTION
We should use unknwn.h and windows.h instead of Unknwn.h and Windows.h because Linux and other non‑Windows systems treat filenames as case‑sensitive. Windows does not, so mixed‑case includes work there but break elsewhere. Both mingw‑w64‑crt and windows‑msvc‑sysroot provide all Windows headers in fully lowercase, so using the lowercase forms ensures consistent cross‑platform builds.

Fixes #208901