### PR TITLE
[ADT] Fuse the two post-mutation tree walks in ImutAVLFactory

### DIFF
--- a/llvm/benchmarks/CMakeLists.txt
+++ b/llvm/benchmarks/CMakeLists.txt
@@ -16,6 +16,7 @@ add_benchmark(SpecialCaseListBM SpecialCaseListBM.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(DWARFVerifierBM DWARFVerifierBM.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(PointerUnionBM PointerUnionBM.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(ImmutableSetIteratorBM ImmutableSetIteratorBM.cpp PARTIAL_SOURCES_INTENDED)
+add_benchmark(ImmutableSetBuildBM ImmutableSetBuildBM.cpp PARTIAL_SOURCES_INTENDED)
 
 add_benchmark(RuntimeLibcallsBench RuntimeLibcalls.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(writeToOutputInParallelBench writeToOutputInParallel.cpp PARTIAL_SOURCES_INTENDED)

--- a/llvm/benchmarks/ImmutableSetBuildBM.cpp
+++ b/llvm/benchmarks/ImmutableSetBuildBM.cpp
@@ -1,0 +1,75 @@
+//===- ImmutableSetBuildBM.cpp - Benchmark ImmutableSet construction ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Benchmarks the mutating operations of ImmutableSet -- add and remove -- which
+// exercise the ImutAVLFactory node bookkeeping (createNode / recoverNodes) that
+// the iterator benchmark deliberately keeps out of its timed region. Run the
+// binary before and after a change and compare the two reports (e.g. with
+// llvm/utils/compare.py).
+//
+//   * Build       - build an N-element set from empty (N add calls).
+//   * BuildRemove - build an N-element set, then remove every element.
+//
+//===----------------------------------------------------------------------===//
+
+#include "benchmark/benchmark.h"
+#include "llvm/ADT/ImmutableSet.h"
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <vector>
+
+using namespace llvm;
+
+namespace {
+
+// A shuffled [0, N) key sequence, so the tree is built in random order.
+static std::vector<int> shuffledKeys(size_t N) {
+  std::vector<int> Vals(N);
+  std::iota(Vals.begin(), Vals.end(), 0);
+  std::mt19937 Rng(0xC0FFEE);
+  std::shuffle(Vals.begin(), Vals.end(), Rng);
+  return Vals;
+}
+
+static void BM_Build(benchmark::State &State) {
+  const size_t N = State.range(0);
+  std::vector<int> Vals = shuffledKeys(N);
+  for (auto _ : State) {
+    ImmutableSet<int>::Factory F(/*canonicalize=*/false);
+    ImmutableSet<int> S = F.getEmptySet();
+    for (int V : Vals)
+      S = F.add(S, V);
+    benchmark::DoNotOptimize(S.getRootWithoutRetain());
+  }
+  State.SetItemsProcessed(State.iterations() * N);
+}
+
+static void BM_BuildRemove(benchmark::State &State) {
+  const size_t N = State.range(0);
+  std::vector<int> Vals = shuffledKeys(N);
+  for (auto _ : State) {
+    ImmutableSet<int>::Factory F(/*canonicalize=*/false);
+    ImmutableSet<int> S = F.getEmptySet();
+    for (int V : Vals)
+      S = F.add(S, V);
+    for (int V : Vals)
+      S = F.remove(S, V);
+    benchmark::DoNotOptimize(S.getRootWithoutRetain());
+  }
+  State.SetItemsProcessed(State.iterations() * N * 2);
+}
+
+} // namespace
+
+#define BUILD_SIZES Arg(256)->Arg(4096)->Arg(65536)
+
+BENCHMARK(BM_Build)->Name("Build")->BUILD_SIZES;
+BENCHMARK(BM_BuildRemove)->Name("BuildRemove")->BUILD_SIZES;
+
+BENCHMARK_MAIN();

--- a/llvm/include/llvm/ADT/ImmutableSet.h
+++ b/llvm/include/llvm/ADT/ImmutableSet.h
@@ -17,6 +17,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/Support/Allocator.h"
@@ -393,15 +394,13 @@ public:
 
   TreeTy* add(TreeTy* T, value_type_ref V) {
     T = add_internal(V,T);
-    markImmutable(T);
-    recoverNodes();
+    recoverNodes(T);
     return T;
   }
 
   TreeTy* remove(TreeTy* T, key_type_ref V) {
     T = remove_internal(V,T);
-    markImmutable(T);
-    recoverNodes();
+    recoverNodes(T);
     return T;
   }
 
@@ -460,11 +459,20 @@ protected:
     return createNode(newLeft, getValue(oldTree), newRight);
   }
 
-  void recoverNodes() {
-    for (unsigned i = 0, n = createdNodes.size(); i < n; ++i) {
-      TreeTy *N = createdNodes[i];
-      if (N->isMutable() && N->refCount == 0)
+  void recoverNodes(TreeTy *Result) {
+    // Mark Result's nodes immutable and reclaim the intermediates discarded
+    // during balancing, in one pass. Nodes are built bottom-up, so a node
+    // precedes its parents in createdNodes; visiting in reverse thus reaches
+    // each node only once its reference count is final. Unreferenced nodes are
+    // unreachable and destroyed; the rest belong to Result. Result is kept
+    // despite its zero count -- the caller has not taken ownership yet.
+    for (TreeTy *N : llvm::reverse(createdNodes)) {
+      if (!N->isMutable())
+        continue; // Already reclaimed while destroying an unreachable parent.
+      if (N != Result && N->refCount == 0)
         N->destroy();
+      else
+        N->markImmutable();
     }
     createdNodes.clear();
   }
@@ -592,15 +600,6 @@ protected:
     }
     return balanceTree(removeMinBinding(getLeft(T), Noderemoved),
                        getValue(T), getRight(T));
-  }
-
-  /// Clears the mutable bits of a root and all of its descendants.
-  void markImmutable(TreeTy* T) {
-    if (!T || !T->isMutable())
-      return;
-    T->markImmutable();
-    markImmutable(getLeft(T));
-    markImmutable(getRight(T));
   }
 
 public:


### PR DESCRIPTION
Every ImmutableSet/ImmutableMap add and remove made two passes over the freshly built tree: a recursive markImmutable() walk to freeze the kept nodes, followed by a recoverNodes() loop to reclaim the intermediates discarded during balancing. Fold them into a single reverse pass over createdNodes. Nodes are built bottom-up, so a node precedes its parents in the list; visiting in reverse reaches each node only once its reference count is final, so it can be frozen or reclaimed in that pass. The recursive markImmutable() helper is removed.

ImmutableSetBuildBM microbenchmark (non-canonicalizing factory, -O2):

| Benchmark         | Before  | After   | Speedup |
|-------------------|--------:|--------:|:-------:|
| Build/256         | 24.3 us | 20.4 us | 1.20x   |
| Build/4096        |  962 us |  785 us | 1.22x   |
| Build/65536       | 23.1 ms | 18.7 ms | 1.24x   |
| BuildRemove/256   | 48.8 us | 37.0 us | 1.32x   |
| BuildRemove/4096  | 1.84 ms | 1.45 ms | 1.26x   |
| BuildRemove/65536 | 42.8 ms | 34.4 ms | 1.24x   |

Assisted by: Claude Opus 4.8