### PR TITLE
[Basic] Fix crash computing the spelling index of an unknown scoped attribute

### DIFF
--- a/clang/lib/Basic/Attributes.cpp
+++ b/clang/lib/Basic/Attributes.cpp
@@ -240,6 +240,15 @@ getScopeFromNormalizedScopeName(StringRef ScopeName) {
 }
 
 unsigned AttributeCommonInfo::calculateAttributeSpellingListIndex() const {
+  // An unknown attribute (getParsedKind() == UnknownAttribute) has no entry in
+  // the generated spelling tables. The name/scope StringSwitches below assume a
+  // known attribute and intentionally have no default, so computing an index
+  // for an unknown *scoped* attribute such as [[ns::foo]] would fall off the
+  // end (getScopeFromNormalizedScopeName aborts). It has a single no-spelling,
+  // so report index 0 instead.
+  if (getParsedKind() == AttributeCommonInfo::UnknownAttribute)
+    return 0;
+
   // Both variables will be used in tablegen generated
   // attribute spell list index matching code.
   auto Syntax = static_cast<AttributeCommonInfo::Syntax>(getSyntax());

--- a/clang/unittests/AST/AttrTest.cpp
+++ b/clang/unittests/AST/AttrTest.cpp
@@ -7,9 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/AST/Attr.h"
+#include "clang/AST/ASTContext.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Basic/AttrKinds.h"
+#include "clang/Basic/AttributeScopeInfo.h"
+#include "clang/Basic/IdentifierTable.h"
 #include "clang/Tooling/Tooling.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -247,6 +250,26 @@ TEST(Attr, RegularKeywordAttribute) {
   auto Streaming = clang::ArmStreamingAttr::CreateImplicit(Ctx);
   EXPECT_EQ(Streaming->getSyntax(), clang::AttributeCommonInfo::AS_Keyword);
   ASSERT_TRUE(Streaming->isRegularKeywordAttribute());
+}
+
+// getAttributeSpellingListIndex() must not crash for an unknown *scoped*
+// attribute such as [[ns::foo]]. Such an attribute has no entry in the
+// generated spelling tables, and the name/scope string-switches used to compute
+// the index have no default case; the computation must short-circuit for an
+// unknown attribute and report the single no-spelling instead of falling off
+// the end.
+TEST(Attr, UnknownScopedAttributeSpellingIndex) {
+  auto AST = clang::tooling::buildASTFromCode("");
+  auto &Ctx = AST->getASTContext();
+  const clang::IdentifierInfo *Name = &Ctx.Idents.get("foo");
+  const clang::IdentifierInfo *Scope = &Ctx.Idents.get("ns");
+
+  clang::AttributeCommonInfo CI(
+      Name, clang::AttributeScopeInfo(Scope, clang::SourceLocation()),
+      clang::SourceRange(), clang::AttributeCommonInfo::Form::CXX11());
+
+  ASSERT_EQ(CI.getParsedKind(), clang::AttributeCommonInfo::UnknownAttribute);
+  EXPECT_EQ(CI.getAttributeSpellingListIndex(), 0u);
 }
 
 } // namespace


### PR DESCRIPTION
AttributeCommonInfo::getAttributeSpellingListIndex() aborts for an unknown attribute that has a scope, such as [[ns::foo]]. It calls calculateAttributeSpellingListIndex(), which runs name/scope string-switches generated for the known attributes. Those switches intentionally have no default: getScopeFromNormalizedScopeName() falls off the end and hits llvm_unreachable ("Fell off the end of a string-switch") for the unknown scope.

Any caller that asks a scoped unknown attribute for its spelling index therefore crashes. An unrecognized attribute has no entry in those tables and carries a single no-spelling, so short-circuit calculateAttributeSpellingListIndex() for UnknownAttribute and return index 0 before the switches run.

Add a unit test that constructs an unknown scoped AttributeCommonInfo and asks for its spelling index; it aborts without the fix.