### PR TITLE
[InstCombine] Fold zext(icmp ne X, C) to X - C when X is in (C, C+1)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1408,17 +1408,20 @@ Instruction *InstCombinerImpl::transformZExtICmp(ICmpInst *Cmp,
       }
     }
 
-    ConstantRange CR = computeConstantRange(Cmp->getOperand(0), false, SQ);
+    // zext (X != CST) --> X - CST  if X in {CST, CST + 1}
 
-    if (Cmp->isEquality() && !CR.isSizeLargerThan(2) && CR.contains(*Op1CV)) {
+    if (Cmp->getPredicate() == ICmpInst::ICMP_NE) {
 
-      Value *In = Cmp->getOperand(0);
-      bool SkipTransform = In->getType() != Zext.getType() && !Cmp->hasOneUse();
+      Value *LHS = Cmp->getOperand(0);
+      ConstantRange CR = computeConstantRange(LHS, false, SQ);
+      bool SkipTransform =
+          LHS->getType() != Zext.getType() && !Cmp->hasOneUse();
 
-      if (CR.getLower().eq(*Op1CV) &&
-          Cmp->getPredicate() == ICmpInst::ICMP_NE && !SkipTransform) {
+      if (!CR.isSizeLargerThan(2) && CR.contains(*Op1CV) &&
+          CR.getLower().eq(*Op1CV) && !SkipTransform) {
 
-        In = Builder.CreateSub(In, ConstantInt::get(In->getType(), *Op1CV));
+        Value *In =
+            Builder.CreateSub(LHS, ConstantInt::get(LHS->getType(), *Op1CV));
 
         if (In->getType() == Zext.getType())
           return replaceInstUsesWith(Zext, In);

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1407,6 +1407,28 @@ Instruction *InstCombinerImpl::transformZExtICmp(ICmpInst *Cmp,
         return replaceInstUsesWith(Zext, IntCast);
       }
     }
+
+    ConstantRange CR = computeConstantRange(Cmp->getOperand(0), false, SQ);
+
+    if (Cmp->isEquality() && !CR.isSizeLargerThan(2) && CR.contains(*Op1CV)) {
+
+      Value *In = Cmp->getOperand(0);
+      bool SkipTransform = In->getType() != Zext.getType() && !Cmp->hasOneUse();
+
+      if (CR.getLower().eq(*Op1CV) &&
+          Cmp->getPredicate() == ICmpInst::ICMP_NE && !SkipTransform) {
+
+        In = Builder.CreateSub(In, ConstantInt::get(In->getType(), *Op1CV));
+
+        if (In->getType() == Zext.getType())
+          return replaceInstUsesWith(Zext, In);
+
+        if (Cmp->hasOneUse()) {
+          Value *IntCast = Builder.CreateIntCast(In, Zext.getType(), false);
+          return replaceInstUsesWith(Zext, IntCast);
+        }
+      }
+    }
   }
 
   if (Cmp->isEquality()) {

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -1085,8 +1085,7 @@ define <2 x i8> @zext_or_trunc_nuw_vec(<2 x i8> %x, <2 x i4> %y) {
 
 define i32 @zext_ne_lower_cst_sub(i32 range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_lower_cst_sub(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[X:%.*]], 7
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[CMP]] to i32
+; CHECK-NEXT:    [[TMP2:%.*]] = add nsw i32 [[X:%.*]], -7
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
   %cmp = icmp ne i32 %x, 7
@@ -1105,8 +1104,7 @@ define i32 @zext_ne_lower_cst_sub_zero(i32 range(i32 0, 2) %x) {
 
 define <4 x i32> @zext_ne_lower_cst_sub_vec(<4 x i32> range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_lower_cst_sub_vec(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <4 x i32> [[X:%.*]], splat (i32 7)
-; CHECK-NEXT:    [[TMP2:%.*]] = zext <4 x i1> [[CMP]] to <4 x i32>
+; CHECK-NEXT:    [[TMP2:%.*]] = add nsw <4 x i32> [[X:%.*]], splat (i32 -7)
 ; CHECK-NEXT:    ret <4 x i32> [[TMP2]]
 ;
   %cmp = icmp ne <4 x i32> %x, splat(i32 7)
@@ -1116,8 +1114,8 @@ define <4 x i32> @zext_ne_lower_cst_sub_vec(<4 x i32> range(i32 7, 9) %x) {
 
 define i64 @zext_ne_lower_cst_sub_widen(i32 range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_lower_cst_sub_widen(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[X:%.*]], 7
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[CMP]] to i64
+; CHECK-NEXT:    [[TMP1:%.*]] = add nsw i32 [[X:%.*]], -7
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i32 [[TMP1]] to i64
 ; CHECK-NEXT:    ret i64 [[TMP2]]
 ;
   %cmp = icmp ne i32 %x, 7
@@ -1129,7 +1127,7 @@ define i32 @zext_ne_multiuse_icmp(i32 range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_multiuse_icmp(
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], 7
 ; CHECK-NEXT:    call void @use1(i1 [[TMP1]])
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
+; CHECK-NEXT:    [[TMP2:%.*]] = add nsw i32 [[X]], -7
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
   %cmp = icmp ne i32 %x, 7
@@ -1140,8 +1138,7 @@ define i32 @zext_ne_multiuse_icmp(i32 range(i32 7, 9) %x) {
 
 define i32 @zext_ne_lower_wrapped(i32 range(i32 -1, 1) %x) {
 ; CHECK-LABEL: @zext_ne_lower_wrapped(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[X:%.*]], -1
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[CMP]] to i32
+; CHECK-NEXT:    [[TMP2:%.*]] = add nsw i32 [[X:%.*]], 1
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
   %cmp = icmp ne i32 %x, -1

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -1094,6 +1094,15 @@ define i32 @zext_ne_lower_cst_sub(i32 range(i32 7, 9) %x) {
   ret i32 %zext
 }
 
+define i32 @zext_ne_lower_cst_sub_zero(i32 range(i32 0, 2) %x) {
+; CHECK-LABEL: @zext_ne_lower_cst_sub_zero(
+; CHECK-NEXT:    ret i32 [[X:%.*]]
+;
+  %cmp = icmp ne i32 %x, 0
+  %zext = zext i1 %cmp to i32
+  ret i32 %zext
+}
+
 define <4 x i32> @zext_ne_lower_cst_sub_vec(<4 x i32> range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_lower_cst_sub_vec(
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <4 x i32> [[X:%.*]], splat (i32 7)

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -1085,56 +1085,59 @@ define <2 x i8> @zext_or_trunc_nuw_vec(<2 x i8> %x, <2 x i4> %y) {
 
 define i32 @zext_ne_lower_cst_sub(i32 range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_lower_cst_sub(
-; CHECK-NEXT:    [[TMP2:%.*]] = add nsw i32 [[X:%.*]], -7
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[X:%.*]], 7
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[CMP]] to i32
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
-  %1 = icmp ne i32 %x, 7
-  %2 = zext i1 %1 to i32
-  ret i32 %2
+  %cmp = icmp ne i32 %x, 7
+  %zext = zext i1 %cmp to i32
+  ret i32 %zext
 }
 
 define <4 x i32> @zext_ne_lower_cst_sub_vec(<4 x i32> range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_lower_cst_sub_vec(
-; CHECK-NEXT:    [[TMP2:%.*]] = add nsw <4 x i32> [[X:%.*]], splat (i32 -7)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne <4 x i32> [[X:%.*]], splat (i32 7)
+; CHECK-NEXT:    [[TMP2:%.*]] = zext <4 x i1> [[CMP]] to <4 x i32>
 ; CHECK-NEXT:    ret <4 x i32> [[TMP2]]
 ;
-  %1 = icmp ne <4 x i32> %x, splat(i32 7)
-  %2 = zext <4 x i1> %1 to <4 x i32>
-  ret <4 x i32> %2
+  %cmp = icmp ne <4 x i32> %x, splat(i32 7)
+  %zext = zext <4 x i1> %cmp to <4 x i32>
+  ret <4 x i32> %zext
 }
 
 define i64 @zext_ne_lower_cst_sub_widen(i32 range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_lower_cst_sub_widen(
-; CHECK-NEXT:    [[TMP1:%.*]] = add nsw i32 [[X:%.*]], -7
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i32 [[TMP1]] to i64
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[X:%.*]], 7
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[CMP]] to i64
 ; CHECK-NEXT:    ret i64 [[TMP2]]
 ;
-  %1 = icmp ne i32 %x, 7
-  %2 = zext i1 %1 to i64
-  ret i64 %2
+  %cmp = icmp ne i32 %x, 7
+  %zext = zext i1 %cmp to i64
+  ret i64 %zext
 }
 
 define i32 @zext_ne_multiuse_icmp(i32 range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_multiuse_icmp(
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], 7
 ; CHECK-NEXT:    call void @use1(i1 [[TMP1]])
-; CHECK-NEXT:    [[TMP2:%.*]] = add nsw i32 [[X]], -7
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
-  %1 = icmp ne i32 %x, 7
-  call void @use1(i1 %1)
-  %2 = zext i1 %1 to i32
-  ret i32 %2
+  %cmp = icmp ne i32 %x, 7
+  call void @use1(i1 %cmp)
+  %zext = zext i1 %cmp to i32
+  ret i32 %zext
 }
 
 define i32 @zext_ne_lower_wrapped(i32 range(i32 -1, 1) %x) {
 ; CHECK-LABEL: @zext_ne_lower_wrapped(
-; CHECK-NEXT:    [[TMP2:%.*]] = add nsw i32 [[X:%.*]], 1
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[X:%.*]], -1
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[CMP]] to i32
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
-  %1 = icmp ne i32 %x, -1
-  %2 = zext i1 %1 to i32
-  ret i32 %2
+  %cmp = icmp ne i32 %x, -1
+  %zext = zext i1 %cmp to i32
+  ret i32 %zext
 }
 
 ; Negative cases
@@ -1145,9 +1148,9 @@ define i32 @neg_zext_ne_range_too_wide(i32 range(i32 7, 10) %x) {
 ; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
-  %1 = icmp ne i32 %x, 7
-  %2 = zext i1 %1 to i32
-  ret i32 %2
+  %cmp = icmp ne i32 %x, 7
+  %zext = zext i1 %cmp to i32
+  ret i32 %zext
 }
 
 define i32 @neg_zext_ne_no_range(i32 %x) {
@@ -1156,9 +1159,9 @@ define i32 @neg_zext_ne_no_range(i32 %x) {
 ; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
-  %1 = icmp ne i32 %x, 7
-  %2 = zext i1 %1 to i32
-  ret i32 %2
+  %cmp = icmp ne i32 %x, 7
+  %zext = zext i1 %cmp to i32
+  ret i32 %zext
 }
 
 define i64 @neg_zext_ne_widen_multiuse_icmp(i32 range(i32 7, 9) %x) {
@@ -1168,8 +1171,8 @@ define i64 @neg_zext_ne_widen_multiuse_icmp(i32 range(i32 7, 9) %x) {
 ; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i64
 ; CHECK-NEXT:    ret i64 [[TMP2]]
 ;
-  %1 = icmp ne i32 %x, 7
-  call void @use1(i1 %1)
-  %2 = zext i1 %1 to i64
-  ret i64 %2
+  %cmp = icmp ne i32 %x, 7
+  call void @use1(i1 %cmp)
+  %zext = zext i1 %cmp to i64
+  ret i64 %zext
 }

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -1080,3 +1080,99 @@ define <2 x i8> @zext_or_trunc_nuw_vec(<2 x i8> %x, <2 x i4> %y) {
   %zext = zext <2 x i4> %or to <2 x i8>
   ret <2 x i8> %zext
 }
+
+; zext (X != CST) --> X - CST        if X in {CST, CST + 1}
+
+define i32 @zext_ne_lower_cst_sub(i32 range(i32 7, 9) %x) {
+; CHECK-LABEL: @zext_ne_lower_cst_sub(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], 7
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
+; CHECK-NEXT:    ret i32 [[TMP2]]
+;
+  %1 = icmp ne i32 %x, 7
+  %2 = zext i1 %1 to i32
+  ret i32 %2
+}
+
+define <4 x i32> @zext_ne_lower_cst_sub_vec(<4 x i32> range(i32 7, 9) %x) {
+; CHECK-LABEL: @zext_ne_lower_cst_sub_vec(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <4 x i32> [[X:%.*]], splat (i32 7)
+; CHECK-NEXT:    [[TMP2:%.*]] = zext <4 x i1> [[TMP1]] to <4 x i32>
+; CHECK-NEXT:    ret <4 x i32> [[TMP2]]
+;
+  %1 = icmp ne <4 x i32> %x, splat(i32 7)
+  %2 = zext <4 x i1> %1 to <4 x i32>
+  ret <4 x i32> %2
+}
+
+define i64 @zext_ne_lower_cst_sub_widen(i32 range(i32 7, 9) %x) {
+; CHECK-LABEL: @zext_ne_lower_cst_sub_widen(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], 7
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i64
+; CHECK-NEXT:    ret i64 [[TMP2]]
+;
+  %1 = icmp ne i32 %x, 7
+  %2 = zext i1 %1 to i64
+  ret i64 %2
+}
+
+define i32 @zext_ne_multiuse_icmp(i32 range(i32 7, 9) %x) {
+; CHECK-LABEL: @zext_ne_multiuse_icmp(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], 7
+; CHECK-NEXT:    call void @use1(i1 [[TMP1]])
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
+; CHECK-NEXT:    ret i32 [[TMP2]]
+;
+  %1 = icmp ne i32 %x, 7
+  call void @use1(i1 %1)
+  %2 = zext i1 %1 to i32
+  ret i32 %2
+}
+
+define i32 @zext_ne_lower_wrapped(i32 range(i32 -1, 1) %x) {
+; CHECK-LABEL: @zext_ne_lower_wrapped(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], -1
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
+; CHECK-NEXT:    ret i32 [[TMP2]]
+;
+  %1 = icmp ne i32 %x, -1
+  %2 = zext i1 %1 to i32
+  ret i32 %2
+}
+
+; Negative cases
+
+define i32 @neg_zext_ne_range_too_wide(i32 range(i32 7, 10) %x) {
+; CHECK-LABEL: @neg_zext_ne_range_too_wide(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], 7
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
+; CHECK-NEXT:    ret i32 [[TMP2]]
+;
+  %1 = icmp ne i32 %x, 7
+  %2 = zext i1 %1 to i32
+  ret i32 %2
+}
+
+define i32 @neg_zext_ne_no_range(i32 %x) {
+; CHECK-LABEL: @neg_zext_ne_no_range(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], 7
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
+; CHECK-NEXT:    ret i32 [[TMP2]]
+;
+  %1 = icmp ne i32 %x, 7
+  %2 = zext i1 %1 to i32
+  ret i32 %2
+}
+
+define i64 @neg_zext_ne_widen_multiuse_icmp(i32 range(i32 7, 9) %x) {
+; CHECK-LABEL: @neg_zext_ne_widen_multiuse_icmp(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], 7
+; CHECK-NEXT:    call void @use1(i1 [[TMP1]])
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i64
+; CHECK-NEXT:    ret i64 [[TMP2]]
+;
+  %1 = icmp ne i32 %x, 7
+  call void @use1(i1 %1)
+  %2 = zext i1 %1 to i64
+  ret i64 %2
+}

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -1085,8 +1085,7 @@ define <2 x i8> @zext_or_trunc_nuw_vec(<2 x i8> %x, <2 x i4> %y) {
 
 define i32 @zext_ne_lower_cst_sub(i32 range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_lower_cst_sub(
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], 7
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
+; CHECK-NEXT:    [[TMP2:%.*]] = add nsw i32 [[X:%.*]], -7
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
   %1 = icmp ne i32 %x, 7
@@ -1096,8 +1095,7 @@ define i32 @zext_ne_lower_cst_sub(i32 range(i32 7, 9) %x) {
 
 define <4 x i32> @zext_ne_lower_cst_sub_vec(<4 x i32> range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_lower_cst_sub_vec(
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne <4 x i32> [[X:%.*]], splat (i32 7)
-; CHECK-NEXT:    [[TMP2:%.*]] = zext <4 x i1> [[TMP1]] to <4 x i32>
+; CHECK-NEXT:    [[TMP2:%.*]] = add nsw <4 x i32> [[X:%.*]], splat (i32 -7)
 ; CHECK-NEXT:    ret <4 x i32> [[TMP2]]
 ;
   %1 = icmp ne <4 x i32> %x, splat(i32 7)
@@ -1107,8 +1105,8 @@ define <4 x i32> @zext_ne_lower_cst_sub_vec(<4 x i32> range(i32 7, 9) %x) {
 
 define i64 @zext_ne_lower_cst_sub_widen(i32 range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_lower_cst_sub_widen(
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], 7
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i64
+; CHECK-NEXT:    [[TMP1:%.*]] = add nsw i32 [[X:%.*]], -7
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i32 [[TMP1]] to i64
 ; CHECK-NEXT:    ret i64 [[TMP2]]
 ;
   %1 = icmp ne i32 %x, 7
@@ -1120,7 +1118,7 @@ define i32 @zext_ne_multiuse_icmp(i32 range(i32 7, 9) %x) {
 ; CHECK-LABEL: @zext_ne_multiuse_icmp(
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], 7
 ; CHECK-NEXT:    call void @use1(i1 [[TMP1]])
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
+; CHECK-NEXT:    [[TMP2:%.*]] = add nsw i32 [[X]], -7
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
   %1 = icmp ne i32 %x, 7
@@ -1131,8 +1129,7 @@ define i32 @zext_ne_multiuse_icmp(i32 range(i32 7, 9) %x) {
 
 define i32 @zext_ne_lower_wrapped(i32 range(i32 -1, 1) %x) {
 ; CHECK-LABEL: @zext_ne_lower_wrapped(
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ne i32 [[X:%.*]], -1
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i32
+; CHECK-NEXT:    [[TMP2:%.*]] = add nsw i32 [[X:%.*]], 1
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
   %1 = icmp ne i32 %x, -1


### PR DESCRIPTION
partially implements #207218

generalized alive2 proof:
https://alive2.llvm.org/ce/z/C6EKoy

When the value of `X` is in `(CST, CST + 1)`, `zext(X != CST)` 
is equivalent to `X - CST`. This fold removes the icmp zext pair, 
and replaces it with a single sub. If the zext widens the original input, the fold is made if the comparison is single use and otherwise is not(since this increases instruction count).

This PR only implements the first case from the issue (`src_zext_ne_lower_cst`), while 
the remaining three are left as follow-up.

Added test coverage for scalar/vector cases, widening zext, multi-use 
icmp, wrapped ranges, and negative cases.

AI tool use;
Claude was used to draft test names and format PR description, other than that all code and design decisions are mine