### PR TITLE
Allow SortIncludes to override DisableFormat when both are explicitly set to true

### DIFF
--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2940,7 +2940,11 @@ struct FormatStyle {
 
   /// Disables formatting completely.
   /// \version 3.7
-  bool DisableFormat;
+  enum struct DisableFormatOptions {
+    DF_Disabled,
+    DF_SortIncludesOnly,
+    DF_Enabled
+  } DisableFormat;
 
   /// Different styles for empty line after access modifiers.
   /// ``EmptyLineBeforeAccessModifier`` configuration handles the number of

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2938,13 +2938,24 @@ struct FormatStyle {
   /// \version 3.7
   bool DerivePointerAlignment;
 
+  struct DisableFormatOptions {
+    
+    bool DisableSortIncludes;
+
+    bool DisablePostPreprocessorFormatting;
+
+    bool operator==(const DisableFormatOptions &R) const {
+      return DisableSortIncludes == R.DisableSortIncludes &&
+             DisablePostPreprocessorFormatting == R.DisablePostPreprocessorFormatting;
+    }
+    bool operator!=(const DisableFormatOptions &R) const {
+      return !(*this == R);
+    }
+  };
+
   /// Disables formatting completely.
   /// \version 3.7
-  enum struct DisableFormatOptions {
-    DF_Disabled,
-    DF_SortIncludesOnly,
-    DF_Enabled
-  } DisableFormat;
+  DisableFormatOptions DisableFormat;
 
   /// Different styles for empty line after access modifiers.
   /// ``EmptyLineBeforeAccessModifier`` configuration handles the number of

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1355,8 +1355,6 @@ template <> struct MappingTraits<FormatStyle> {
     IO.mapOptional("Cpp11BracedListStyle", Style.Cpp11BracedListStyle);
     IO.mapOptional("DerivePointerAlignment", Style.DerivePointerAlignment);
     IO.mapOptional("DisableFormat", Style.DisableFormat);
-    if (Style.DisableFormat)
-      Style.SortIncludes.Enabled = false;
     IO.mapOptional("EmptyLineAfterAccessModifier",
                    Style.EmptyLineAfterAccessModifier);
     IO.mapOptional("EmptyLineBeforeAccessModifier",

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1355,6 +1355,8 @@ template <> struct MappingTraits<FormatStyle> {
     IO.mapOptional("Cpp11BracedListStyle", Style.Cpp11BracedListStyle);
     IO.mapOptional("DerivePointerAlignment", Style.DerivePointerAlignment);
     IO.mapOptional("DisableFormat", Style.DisableFormat);
+    if (Style.DisableFormat)
+      Style.SortIncludes.Enabled = false;
     IO.mapOptional("EmptyLineAfterAccessModifier",
                    Style.EmptyLineAfterAccessModifier);
     IO.mapOptional("EmptyLineBeforeAccessModifier",
@@ -4034,7 +4036,7 @@ tooling::Replacements sortIncludes(const FormatStyle &Style, StringRef Code,
                                    ArrayRef<tooling::Range> Ranges,
                                    StringRef FileName, unsigned *Cursor) {
   tooling::Replacements Replaces;
-  if (!Style.SortIncludes.Enabled || Style.DisableFormat)
+  if (!Style.SortIncludes.Enabled)
     return Replaces;
   if (isLikelyXml(Code))
     return Replaces;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1619,7 +1619,7 @@ template <> struct MappingTraits<FormatStyle> {
       Style.SpacesInParens = FormatStyle::SIPO_Custom;
     }
 
-    if (Style.DisableFormat.DisableIncludeSorting)
+    if (Style.DisableFormat.DisableSortIncludes)
       Style.SortIncludes.Enabled = false;
   }
 };
@@ -1937,7 +1937,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.ContinuationIndentWidth = 4;
   LLVMStyle.Cpp11BracedListStyle = FormatStyle::BLS_AlignFirstComment;
   LLVMStyle.DerivePointerAlignment = false;
-  LLVMStyle.DisableFormat = {/*DisableIncludeSorting=*/false, /*DisablePostPreprocessorFormatting=*/false};
+  LLVMStyle.DisableFormat = {/*DisableSortIncludes=*/false, /*DisablePostPreprocessorFormatting=*/false};
   LLVMStyle.EmptyLineAfterAccessModifier = FormatStyle::ELAAMS_Never;
   LLVMStyle.EmptyLineBeforeAccessModifier = FormatStyle::ELBAMS_LogicalBlock;
   LLVMStyle.EnumTrailingComma = FormatStyle::ETC_Leave;
@@ -2412,7 +2412,7 @@ FormatStyle getClangFormatStyle() {
 
 FormatStyle getNoStyle() {
   FormatStyle NoStyle = getLLVMStyle();
-  NoStyle.DisableFormat = {/*DisableIncludeSorting=*/true, /*DisablePostPreprocessorFormatting=*/true};
+  NoStyle.DisableFormat = {/*DisableSortIncludes=*/true, /*DisablePostPreprocessorFormatting=*/true};
   NoStyle.SortIncludes = {};
   NoStyle.SortUsingDeclarations = FormatStyle::SUD_Never;
   return NoStyle;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -838,6 +838,20 @@ template <> struct ScalarEnumerationTraits<FormatStyle::ShortRecordStyle> {
   }
 };
 
+template <> struct MappingTraits<FormatStyle::DisableFormatOptions> {
+  static void enumInput(IO &IO, FormatStyle::DisableFormatOptions &Value) {
+    IO.enumCase(Value, "false", FormatStyle::DisableFormatOptions{/*DisableSortIncludes=*/false,
+                                                                  /*DisablePostPreprocessorFormatting=*/false});
+    IO.enumCase(Value, "true", FormatStyle::DisableFormatOptions{/*DisableSortIncludes=*/true,
+                                                                 /*DisablePostPreprocessorFormatting=*/true});
+  }
+
+  static void mapping(IO &IO, FormatStyle::DisableFormatOptions &Value) {
+    IO.mapOptional("DisableIncludeSorting", Value.DisableSortIncludes);
+    IO.mapOptional("DisablePostPreprocessorFormatting", Value.DisablePostPreprocessorFormatting);
+  }
+};
+
 template <> struct MappingTraits<FormatStyle::SortIncludesOptions> {
   static void enumInput(IO &IO, FormatStyle::SortIncludesOptions &Value) {
     IO.enumCase(Value, "Never", FormatStyle::SortIncludesOptions{});
@@ -1604,6 +1618,9 @@ template <> struct MappingTraits<FormatStyle> {
       }
       Style.SpacesInParens = FormatStyle::SIPO_Custom;
     }
+
+    if (Style.DisableFormat.DisableIncludeSorting)
+      Style.SortIncludes.Enabled = false;
   }
 };
 
@@ -1920,7 +1937,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.ContinuationIndentWidth = 4;
   LLVMStyle.Cpp11BracedListStyle = FormatStyle::BLS_AlignFirstComment;
   LLVMStyle.DerivePointerAlignment = false;
-  LLVMStyle.DisableFormat = false;
+  LLVMStyle.DisableFormat = {/*DisableIncludeSorting=*/false, /*DisablePostPreprocessorFormatting=*/false};
   LLVMStyle.EmptyLineAfterAccessModifier = FormatStyle::ELAAMS_Never;
   LLVMStyle.EmptyLineBeforeAccessModifier = FormatStyle::ELBAMS_LogicalBlock;
   LLVMStyle.EnumTrailingComma = FormatStyle::ETC_Leave;
@@ -2395,7 +2412,7 @@ FormatStyle getClangFormatStyle() {
 
 FormatStyle getNoStyle() {
   FormatStyle NoStyle = getLLVMStyle();
-  NoStyle.DisableFormat = true;
+  NoStyle.DisableFormat = {/*DisableIncludeSorting=*/true, /*DisablePostPreprocessorFormatting=*/true};
   NoStyle.SortIncludes = {};
   NoStyle.SortUsingDeclarations = FormatStyle::SUD_Never;
   return NoStyle;
@@ -4227,7 +4244,7 @@ reformat(const FormatStyle &Style, StringRef Code,
   if (Expanded.BraceWrapping.AfterEnum)
     Expanded.AllowShortEnumsOnASingleLine = false;
 
-  if (Expanded.DisableFormat)
+  if (Expanded.DisableFormat.DisablePostPreprocessorFormatting)
     return {tooling::Replacements(), 0};
   if (isLikelyXml(Code))
     return {tooling::Replacements(), 0};

--- a/clang/tools/clang-format/ClangFormat.cpp
+++ b/clang/tools/clang-format/ClangFormat.cpp
@@ -484,7 +484,7 @@ static bool format(StringRef FileName, bool ErrorOnIncompleteFormat = false) {
 
   // To format JSON insert a variable to trick the code into thinking its
   // JavaScript.
-  if (IsJson && !FormatStyle->DisableFormat) {
+  if (IsJson && !FormatStyle->DisableFormat.DisablePostPreprocessorFormatting) {
     auto Err =
         Replaces.add(tooling::Replacement(AssumedFileName, 0, 0, "x = "));
     if (Err)

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -188,7 +188,8 @@ TEST(ConfigParseTest, ParsesConfigurationBools) {
   CHECK_PARSE_BOOL(CompactNamespaces);
   CHECK_PARSE_BOOL(DerivePointerAlignment);
   CHECK_PARSE_BOOL_FIELD(DerivePointerAlignment, "DerivePointerBinding");
-  CHECK_PARSE_BOOL(DisableFormat);
+  CHECK_PARSE_NESTED_BOOL(DisableFormat, DisableSortIncludes);
+  CHECK_PARSE_NESTED_BOOL(DisableFormat, DisablePostPreprocessorFormatting);
   CHECK_PARSE_BOOL(IndentAccessModifiers);
   CHECK_PARSE_BOOL(IndentCaseBlocks);
   CHECK_PARSE_BOOL(IndentCaseLabels);

--- a/clang/unittests/Format/FormatTestJson.cpp
+++ b/clang/unittests/Format/FormatTestJson.cpp
@@ -27,7 +27,7 @@ protected:
 
     // Mock up what ClangFormat.cpp will do for JSON by adding a variable
     // to trick JSON into being JavaScript
-    if (Style.isJson() && !Style.DisableFormat) {
+    if (Style.isJson() && !Style.DisableFormat.DisablePostPreprocessorFormatting) {
       auto Err = Replaces.add(
           tooling::Replacement(tooling::Replacement("", 0, 0, "x = ")));
       if (Err)
@@ -227,7 +227,7 @@ TEST_F(FormatTestJson, DisableJsonFormat) {
   // Since we have to disable formatting to run this test, we shall refrain from
   // calling test::messUp lest we change the unformatted code and cannot format
   // it back to how it started.
-  Style.DisableFormat = true;
+  Style.DisableFormat.DisablePostPreprocessorFormatting = true;
   verifyFormatStable("{}", Style);
   verifyFormatStable("{\n"
                      "  \"name\": 1\n"

--- a/clang/unittests/Format/SortIncludesTest.cpp
+++ b/clang/unittests/Format/SortIncludesTest.cpp
@@ -1323,7 +1323,7 @@ TEST_F(SortIncludesTest, DisableFormatDisablesIncludeSorting) {
   StringRef Unsorted = "#include <b.h>\n"
                        "#include <a.h>\n";
   verifyFormat(Sorted, sort(Unsorted));
-  FmtStyle.DisableFormat = true;
+  FmtStyle.DisableFormat.DisableSortIncludes = true;
   verifyFormat(Unsorted, sort(Unsorted, "input.cpp", 0));
 }
 


### PR DESCRIPTION
Linking @TheShermanTanker who originally requested for this feature here.

As https://github.com/llvm/llvm-project/issues/201422 mentions, after the commit that addressed https://github.com/llvm/llvm-project/issues/34447 it became impossible to only sort includes with clang format, as DisableFormat is now hardcoded into the include sorter to disable it when true. Prior discussion to the patch that changed this logic mentioned that there aren't many approaches that are acceptable to allowing only includes to be sorted again, but raised the suggestion that having DisableFormat turn off SortIncludes normally, but letting SortIncludes enable itself again if it is explicitly specified might be acceptable. In light of this, reimplement how DisableFormat disables include sorting by having the enabled flag for SortIncludes be disabled at the moment DisableFormat is set, to allow the actual SortIncludes setting to override it later, which implements the proposed behaviour of DisableFormat turning off SortIncludes when SortIncludes isn't requested, but allowing include sorting to happen when SortIncludes is set explicitly together with DisableFormat.