### PR TITLE
[BOLT] fix next-instruction offset in memory-access profile.

### DIFF
--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -295,7 +295,7 @@ Error DataReader::readProfilePreCFG(BinaryContext &BC) {
       if (NextII == Function.Instructions.end())
         MemAccessProfile.NextInstrOffset = Function.getSize();
       else
-        MemAccessProfile.NextInstrOffset = II->first;
+        MemAccessProfile.NextInstrOffset = NextII->first;
     }
     Function.HasMemoryProfile = true;
   }


### PR DESCRIPTION
NextInstrOffset stored the current instruction's own offset instead of the following one. It feeds the RIP-relative jump-table base in memory-profile-guided ICP (IndirectCallPromotion), so the base was short by the access instruction's size.