### PR TITLE
[libcxx] Bump runner set

### DIFF
--- a/libcxx/utils/ci/images/libcxx_runners.txt
+++ b/libcxx/utils/ci/images/libcxx_runners.txt
@@ -1,1 +1,1 @@
-ghcr.io/llvm/libcxx-linux-builder:d76111a9650d8d7540677af5ecfa8b958ab59851
+ghcr.io/llvm/libcxx-linux-builder:6d3cf7f436a01f4622fb660e413a4020209777b8


### PR DESCRIPTION
This pulls in 6d3cf7f436a01f4622fb660e413a4020209777b8, and 8ece73c9f8b54fea6a98e9e4c55f9a2e6ccc9b3c.