### PR TITLE
[mlir-c] Add TypeConverter materialization; use a status enum for the type conversion callback

### DIFF
--- a/mlir/include/mlir-c/Rewrite.h
+++ b/mlir/include/mlir-c/Rewrite.h
@@ -588,12 +588,29 @@ MLIR_CAPI_EXPORTED MlirTypeConverter mlirTypeConverterCreate(void);
 MLIR_CAPI_EXPORTED void
 mlirTypeConverterDestroy(MlirTypeConverter typeConverter);
 
-/// Callback type for type conversion functions.
-/// Returns failure or sets convertedType to MlirType{NULL} to indicate failure.
-/// If failure is returned, the converter is allowed to try another
-/// conversion function to perform the conversion.
-typedef MlirLogicalResult (*MlirTypeConverterConversionCallback)(
-    MlirType type, MlirType *convertedType, void *userData);
+/// Outcome of a type conversion callback. Mirrors the three states of the
+/// underlying C++ `std::optional<LogicalResult>` conversion result.
+typedef enum MlirTypeConverterConversionStatus {
+  /// The type was converted successfully.
+  MlirTypeConverterConversionStatusSuccess = 0,
+  /// The conversion failed; no further conversion function will be tried.
+  MlirTypeConverterConversionStatusFailure = 1,
+  /// The conversion was declined; another registered conversion function may be
+  /// tried.
+  MlirTypeConverterConversionStatusDeclined = 2,
+} MlirTypeConverterConversionStatus;
+
+/// Callback type for type conversion functions. On success the callback sets
+/// `*convertedType` to the converted type and returns
+/// MlirTypeConverterConversionStatusSuccess. Returning
+/// MlirTypeConverterConversionStatusDeclined leaves the type unconverted and
+/// allows another registered conversion function to be tried; returning
+/// MlirTypeConverterConversionStatusFailure fails the conversion without trying
+/// any further function.
+typedef MlirTypeConverterConversionStatus (
+    *MlirTypeConverterConversionCallback)(MlirType type,
+                                          MlirType *convertedType,
+                                          void *userData);
 
 /// Add a type conversion function to the given TypeConverter.
 MLIR_CAPI_EXPORTED void

--- a/mlir/include/mlir-c/Rewrite.h
+++ b/mlir/include/mlir-c/Rewrite.h
@@ -621,6 +621,13 @@ MLIR_CAPI_EXPORTED void mlirTypeConverterAddSourceMaterialization(
     MlirTypeConverter typeConverter,
     MlirTypeConverterMaterializationCallback callback, void *userData);
 
+/// Register a target materialization with the given TypeConverter. This is
+/// invoked when a value must be converted to a target type according to a
+/// pattern's type converter.
+MLIR_CAPI_EXPORTED void mlirTypeConverterAddTargetMaterialization(
+    MlirTypeConverter typeConverter,
+    MlirTypeConverterMaterializationCallback callback, void *userData);
+
 //===----------------------------------------------------------------------===//
 /// ConversionPattern API
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir-c/Rewrite.h
+++ b/mlir/include/mlir-c/Rewrite.h
@@ -605,6 +605,22 @@ mlirTypeConverterAddConversion(MlirTypeConverter typeConverter,
 MLIR_CAPI_EXPORTED MlirType
 mlirTypeConverterConvertType(MlirTypeConverter typeConverter, MlirType type);
 
+/// Callback type for type materializations. Given a builder (passed as a
+/// rewriter), the desired output type, the input values, and a location, the
+/// callback must build a cast-like operation that produces a single value of
+/// `outputType` and return it. Returning a null MlirValue indicates failure, in
+/// which case another registered materialization may be attempted.
+typedef MlirValue (*MlirTypeConverterMaterializationCallback)(
+    MlirRewriterBase rewriter, MlirType outputType, intptr_t nInputs,
+    MlirValue *inputs, MlirLocation loc, void *userData);
+
+/// Register a source materialization with the given TypeConverter. This is
+/// invoked when a replacement value must be converted back to its original
+/// source type because some uses persist beyond the main conversion.
+MLIR_CAPI_EXPORTED void mlirTypeConverterAddSourceMaterialization(
+    MlirTypeConverter typeConverter,
+    MlirTypeConverterMaterializationCallback callback, void *userData);
+
 //===----------------------------------------------------------------------===//
 /// ConversionPattern API
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -178,15 +178,15 @@ public:
     mlirTypeConverterAddConversion(
         typeConverter,
         [](MlirType type, MlirType *converted,
-           void *userData) -> MlirLogicalResult {
+           void *userData) -> MlirTypeConverterConversionStatus {
           nb::handle f = nb::handle(static_cast<PyObject *>(userData));
           auto ctx = PyMlirContext::forContext(mlirTypeGetContext(type));
           nb::object res = f(PyType(ctx, type).maybeDownCast());
           if (res.is_none())
-            return mlirLogicalResultFailure();
+            return MlirTypeConverterConversionStatusDeclined;
 
           *converted = nb::cast<PyType>(res).get();
-          return mlirLogicalResultSuccess();
+          return MlirTypeConverterConversionStatusSuccess;
         },
         convert.ptr());
   }

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -669,6 +669,38 @@ MlirType mlirTypeConverterConvertType(MlirTypeConverter typeConverter,
   return wrap(unwrap(typeConverter)->convertType(unwrap(type)));
 }
 
+namespace {
+/// Wraps a C materialization callback as a C++ materialization callback of the
+/// form `Value(OpBuilder &, Type, ValueRange, Location)`, shared by both source
+/// and target materializations. The builder is always a RewriterBase in the
+/// conversion driver, so it is safe to expose it as an MlirRewriterBase.
+std::function<Value(OpBuilder &, Type, ValueRange, Location)>
+wrapMaterializationCallback(MlirTypeConverterMaterializationCallback callback,
+                            void *userData) {
+  return [callback, userData](OpBuilder &builder, Type type, ValueRange inputs,
+                              Location loc) -> Value {
+    SmallVector<MlirValue> wrappedInputs;
+    wrappedInputs.reserve(inputs.size());
+    for (Value v : inputs)
+      wrappedInputs.push_back(wrap(v));
+    MlirValue result =
+        callback(wrap(static_cast<RewriterBase *>(&builder)), wrap(type),
+                 static_cast<intptr_t>(wrappedInputs.size()),
+                 wrappedInputs.data(), wrap(loc), userData);
+    return mlirValueIsNull(result) ? Value() : unwrap(result);
+  };
+}
+} // namespace
+
+void mlirTypeConverterAddSourceMaterialization(
+    MlirTypeConverter typeConverter,
+    MlirTypeConverterMaterializationCallback callback, void *userData) {
+  assert(callback && "expected non-null materialization callback");
+  unwrap(typeConverter)
+      ->addSourceMaterialization(
+          wrapMaterializationCallback(callback, userData));
+}
+
 //===----------------------------------------------------------------------===//
 /// ConversionPattern API
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -652,15 +652,24 @@ void mlirTypeConverterAddConversion(
     MlirTypeConverterConversionCallback convertType, void *userData) {
   unwrap(typeConverter)
       ->addConversion(
-          [convertType, userData](Type type) -> std::optional<Type> {
+          [convertType, userData](Type type, SmallVectorImpl<Type> &results)
+              -> std::optional<LogicalResult> {
             MlirType converted{nullptr};
-            MlirLogicalResult result =
+            MlirTypeConverterConversionStatus status =
                 convertType(wrap(type), &converted, userData);
-            if (mlirLogicalResultIsFailure(result))
-              return std::nullopt; // allowed to try another conversion function
-            if (mlirTypeIsNull(converted))
-              return nullptr;
-            return unwrap(converted);
+            switch (status) {
+            case MlirTypeConverterConversionStatusSuccess:
+              results.push_back(unwrap(converted));
+              return success();
+            case MlirTypeConverterConversionStatusFailure:
+              // Failure: fail the conversion without trying another
+              // registered conversion function.
+              return failure();
+            case MlirTypeConverterConversionStatusDeclined:
+              // Declined: allow the driver to try another conversion function.
+              return std::nullopt;
+            }
+            llvm_unreachable("unknown MlirTypeConverterConversionStatus");
           });
 }
 

--- a/mlir/lib/CAPI/Transforms/Rewrite.cpp
+++ b/mlir/lib/CAPI/Transforms/Rewrite.cpp
@@ -701,6 +701,15 @@ void mlirTypeConverterAddSourceMaterialization(
           wrapMaterializationCallback(callback, userData));
 }
 
+void mlirTypeConverterAddTargetMaterialization(
+    MlirTypeConverter typeConverter,
+    MlirTypeConverterMaterializationCallback callback, void *userData) {
+  assert(callback && "expected non-null materialization callback");
+  unwrap(typeConverter)
+      ->addTargetMaterialization(
+          wrapMaterializationCallback(callback, userData));
+}
+
 //===----------------------------------------------------------------------===//
 /// ConversionPattern API
 //===----------------------------------------------------------------------===//

--- a/mlir/test/CAPI/rewrite.c
+++ b/mlir/test/CAPI/rewrite.c
@@ -911,9 +911,11 @@ void testTypeConverterSourceMaterialization(MlirContext ctx) {
 
   mlirOperationDump(moduleOp);
   // clang-format off
-  // CHECK: %[[v:.*]] = "test.source_i64"() : () -> i64
-  // CHECK: %[[c:.*]] = "test.cast"(%[[v]]) : (i64) -> i32
-  // CHECK: "test.user"(%[[c]]) : (i32) -> ()
+  // CHECK:      module {
+  // CHECK-NEXT:   %[[v:.*]] = "test.source_i64"() : () -> i64
+  // CHECK-NEXT:   %[[c:.*]] = "test.cast"(%[[v]]) : (i64) -> i32
+  // CHECK-NEXT:   "test.user"(%[[c]]) : (i32) -> ()
+  // CHECK-NEXT: }
   // clang-format on
 
   mlirConversionConfigDestroy(config);
@@ -1000,9 +1002,11 @@ void testTypeConverterTargetMaterialization(MlirContext ctx) {
 
   mlirOperationDump(moduleOp);
   // clang-format off
-  // CHECK: %[[v:.*]] = "test.producer"() : () -> i32
-  // CHECK: %[[c:.*]] = "test.cast"(%[[v]]) : (i32) -> i64
-  // CHECK: "test.consumer_legal"(%[[c]]) : (i64) -> ()
+  // CHECK:      module {
+  // CHECK-NEXT:   %[[v:.*]] = "test.producer"() : () -> i32
+  // CHECK-NEXT:   %[[c:.*]] = "test.cast"(%[[v]]) : (i32) -> i64
+  // CHECK-NEXT:   "test.consumer_legal"(%[[c]]) : (i64) -> ()
+  // CHECK-NEXT: }
   // clang-format on
 
   mlirConversionConfigDestroy(config);

--- a/mlir/test/CAPI/rewrite.c
+++ b/mlir/test/CAPI/rewrite.c
@@ -804,19 +804,40 @@ void testConversionTargetDynamicLegality(MlirContext ctx) {
 
 // Type conversion callback: maps i32 -> i64 and leaves every other type
 // unchanged (identity). Used by the materialization tests below.
-static MlirLogicalResult widenI32ToI64(MlirType type, MlirType *result,
-                                       void *userData) {
+static MlirTypeConverterConversionStatus
+widenI32ToI64(MlirType type, MlirType *result, void *userData) {
   (void)userData;
   if (mlirTypeIsAInteger(type) && mlirIntegerTypeGetWidth(type) == 32)
     *result = mlirIntegerTypeGet(mlirTypeGetContext(type), 64);
   else
     *result = type;
-  return mlirLogicalResultSuccess();
+  return MlirTypeConverterConversionStatusSuccess;
 }
 
-// Materialization callback: builds a `test.cast` op that produces a single
-// value of `outputType` from the given inputs, and records that it ran by
-// bumping the counter passed as userData.
+// Type conversion callback that declines i32 (returns Declined) and is the
+// identity on every other type. A declining callback lets the converter fall
+// through to another registered conversion function.
+static MlirTypeConverterConversionStatus
+declineI32(MlirType type, MlirType *result, void *userData) {
+  (void)userData;
+  if (mlirTypeIsAInteger(type) && mlirIntegerTypeGetWidth(type) == 32)
+    return MlirTypeConverterConversionStatusDeclined;
+  *result = type;
+  return MlirTypeConverterConversionStatusSuccess;
+}
+
+// Type conversion callback that fails on i32 (returns Failure) and is the
+// identity on every other type. A failure aborts the conversion without
+// trying any earlier-registered conversion function.
+static MlirTypeConverterConversionStatus
+failI32(MlirType type, MlirType *result, void *userData) {
+  (void)userData;
+  if (mlirTypeIsAInteger(type) && mlirIntegerTypeGetWidth(type) == 32)
+    return MlirTypeConverterConversionStatusFailure;
+  *result = type;
+  return MlirTypeConverterConversionStatusSuccess;
+}
+
 static MlirValue buildCastMaterialization(MlirRewriterBase rewriter,
                                           MlirType outputType, intptr_t nInputs,
                                           MlirValue *inputs, MlirLocation loc,
@@ -1019,6 +1040,50 @@ void testTypeConverterTargetMaterialization(MlirContext ctx) {
   fprintf(stderr, "testTypeConverterTargetMaterialization: PASSED\n");
 }
 
+// Unit test for the three MlirTypeConverterConversionStatus values, exercised
+// directly through mlirTypeConverterConvertType (no conversion driver needed).
+// Conversion functions are consulted most-recently-registered first, so the
+// second-registered callback is tried before the first (`widenI32ToI64`).
+void testTypeConverterConversionStatus(MlirContext ctx) {
+  // CHECK-LABEL: @testTypeConverterConversionStatus
+  fprintf(stderr, "@testTypeConverterConversionStatus\n");
+
+  MlirType i32 = mlirIntegerTypeGet(ctx, 32);
+  MlirType i64 = mlirIntegerTypeGet(ctx, 64);
+
+  // Success: the sole conversion widens i32 -> i64.
+  MlirTypeConverter success = mlirTypeConverterCreate();
+  mlirTypeConverterAddConversion(success, widenI32ToI64, NULL);
+  MlirType successResult = mlirTypeConverterConvertType(success, i32);
+  assert(!mlirTypeIsNull(successResult) && mlirTypeEqual(successResult, i64) &&
+         "Success must yield the converted type");
+  mlirTypeConverterDestroy(success);
+
+  // Declined: `declineI32` is tried first and declines, so the converter falls
+  // through to `widenI32ToI64`, which converts i32 -> i64.
+  MlirTypeConverter declined = mlirTypeConverterCreate();
+  mlirTypeConverterAddConversion(declined, widenI32ToI64, NULL);
+  mlirTypeConverterAddConversion(declined, declineI32, NULL);
+  MlirType declinedResult = mlirTypeConverterConvertType(declined, i32);
+  assert(!mlirTypeIsNull(declinedResult) &&
+         mlirTypeEqual(declinedResult, i64) &&
+         "Declined must fall through to the next conversion function");
+  mlirTypeConverterDestroy(declined);
+
+  // Failure: `failI32` is tried first and fails, which aborts the
+  // conversion without consulting `widenI32ToI64`; convertType returns null.
+  MlirTypeConverter failure = mlirTypeConverterCreate();
+  mlirTypeConverterAddConversion(failure, widenI32ToI64, NULL);
+  mlirTypeConverterAddConversion(failure, failI32, NULL);
+  MlirType failureResult = mlirTypeConverterConvertType(failure, i32);
+  assert(mlirTypeIsNull(failureResult) &&
+         "Failure must abort without trying another conversion function");
+  mlirTypeConverterDestroy(failure);
+
+  // CHECK: testTypeConverterConversionStatus: PASSED
+  fprintf(stderr, "testTypeConverterConversionStatus: PASSED\n");
+}
+
 int main(void) {
   MlirContext ctx = mlirContextCreate();
   mlirContextSetAllowUnregisteredDialects(ctx, true);
@@ -1037,6 +1102,7 @@ int main(void) {
   testConversionTargetDynamicLegality(ctx);
   testTypeConverterSourceMaterialization(ctx);
   testTypeConverterTargetMaterialization(ctx);
+  testTypeConverterConversionStatus(ctx);
 
   mlirContextDestroy(ctx);
   return 0;

--- a/mlir/test/CAPI/rewrite.c
+++ b/mlir/test/CAPI/rewrite.c
@@ -926,6 +926,95 @@ void testTypeConverterSourceMaterialization(MlirContext ctx) {
   fprintf(stderr, "testTypeConverterSourceMaterialization: PASSED\n");
 }
 
+// Conversion pattern for `test.consumer`: replaces it with a
+// `test.consumer_legal` op that consumes the (already remapped) operands. The
+// operand of the original op has type i32 but its producer is not converted, so
+// the framework inserts a target materialization to i64 before invoking this
+// pattern -- the remapped `operands` are therefore the i64 cast results.
+static MlirLogicalResult convertConsumer(MlirConversionPattern pattern,
+                                         MlirOperation op, intptr_t nOperands,
+                                         MlirValue *operands,
+                                         MlirConversionPatternRewriter rewriter,
+                                         void *userData) {
+  (void)pattern;
+  (void)userData;
+  MlirLocation loc = mlirOperationGetLocation(op);
+  MlirOperationState state = mlirOperationStateGet(
+      mlirStringRefCreateFromCString("test.consumer_legal"), loc);
+  mlirOperationStateAddOperands(&state, nOperands, operands);
+  MlirOperation newOp = mlirOperationCreate(&state);
+
+  MlirRewriterBase base = mlirPatternRewriterAsBase(
+      mlirConversionPatternRewriterAsPatternRewriter(rewriter));
+  mlirRewriterBaseInsert(base, newOp);
+  mlirRewriterBaseEraseOp(base, op);
+  return mlirLogicalResultSuccess();
+}
+
+void testTypeConverterTargetMaterialization(MlirContext ctx) {
+  // CHECK-LABEL: @testTypeConverterTargetMaterialization
+  fprintf(stderr, "@testTypeConverterTargetMaterialization\n");
+
+  // `test.consumer` takes an i32 from the (legal, unconverted) `test.producer`.
+  // Converting `test.consumer` requires its operand as i64, which triggers a
+  // target materialization from i32 to i64.
+  const char *moduleString = "%0 = \"test.producer\"() : () -> i32\n"
+                             "\"test.consumer\"(%0) : (i32) -> ()\n";
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(moduleString));
+  MlirOperation moduleOp = mlirModuleGetOperation(module);
+
+  MlirTypeConverter converter = mlirTypeConverterCreate();
+  mlirTypeConverterAddConversion(converter, widenI32ToI64, NULL);
+  intptr_t materializationCounter = 0;
+  mlirTypeConverterAddTargetMaterialization(converter, buildCastMaterialization,
+                                            &materializationCounter);
+
+  MlirRewritePatternSet patterns = mlirRewritePatternSetCreate(ctx);
+  MlirConversionPatternCallbacks callbacks = {NULL, NULL, convertConsumer};
+  MlirConversionPattern pattern = mlirOpConversionPatternCreate(
+      mlirStringRefCreateFromCString("test.consumer"), 1, ctx, converter,
+      callbacks, NULL, 0, NULL);
+  mlirRewritePatternSetAdd(patterns,
+                           mlirConversionPatternAsRewritePattern(pattern));
+  MlirFrozenRewritePatternSet frozen = mlirFreezeRewritePattern(patterns);
+
+  MlirConversionTarget target = mlirConversionTargetCreate(ctx);
+  mlirConversionTargetAddIllegalOp(
+      target, mlirStringRefCreateFromCString("test.consumer"));
+  mlirConversionTargetAddLegalOp(
+      target, mlirStringRefCreateFromCString("test.producer"));
+  mlirConversionTargetAddLegalOp(
+      target, mlirStringRefCreateFromCString("test.consumer_legal"));
+  mlirConversionTargetAddLegalOp(target,
+                                 mlirStringRefCreateFromCString("test.cast"));
+  mlirConversionTargetAddLegalOp(
+      target, mlirStringRefCreateFromCString("builtin.module"));
+
+  MlirConversionConfig config = mlirConversionConfigCreate();
+  MlirLogicalResult result =
+      mlirApplyPartialConversion(moduleOp, target, frozen, config);
+  assert(mlirLogicalResultIsSuccess(result));
+  assert(materializationCounter > 0 &&
+         "target materialization callback must be invoked");
+
+  mlirOperationDump(moduleOp);
+  // clang-format off
+  // CHECK: %[[v:.*]] = "test.producer"() : () -> i32
+  // CHECK: %[[c:.*]] = "test.cast"(%[[v]]) : (i32) -> i64
+  // CHECK: "test.consumer_legal"(%[[c]]) : (i64) -> ()
+  // clang-format on
+
+  mlirConversionConfigDestroy(config);
+  mlirConversionTargetDestroy(target);
+  mlirFrozenRewritePatternSetDestroy(frozen);
+  mlirTypeConverterDestroy(converter);
+  mlirModuleDestroy(module);
+
+  // CHECK: testTypeConverterTargetMaterialization: PASSED
+  fprintf(stderr, "testTypeConverterTargetMaterialization: PASSED\n");
+}
+
 int main(void) {
   MlirContext ctx = mlirContextCreate();
   mlirContextSetAllowUnregisteredDialects(ctx, true);
@@ -943,6 +1032,7 @@ int main(void) {
   testCloneWithMapping(ctx);
   testConversionTargetDynamicLegality(ctx);
   testTypeConverterSourceMaterialization(ctx);
+  testTypeConverterTargetMaterialization(ctx);
 
   mlirContextDestroy(ctx);
   return 0;

--- a/mlir/test/CAPI/rewrite.c
+++ b/mlir/test/CAPI/rewrite.c
@@ -627,7 +627,7 @@ static MlirConversionTargetLegality dynamicLegalityAlwaysLegal(MlirOperation op,
                                                                void *userData) {
   (void)op;
   intptr_t *counter = (intptr_t *)userData;
-  (*counter)++;
+  ++(*counter);
   return MLIR_CONVERSION_TARGET_LEGALITY_LEGAL;
 }
 
@@ -635,7 +635,7 @@ static MlirConversionTargetLegality
 dynamicLegalityAlwaysIllegal(MlirOperation op, void *userData) {
   (void)op;
   intptr_t *counter = (intptr_t *)userData;
-  (*counter)++;
+  ++(*counter);
   return MLIR_CONVERSION_TARGET_LEGALITY_ILLEGAL;
 }
 
@@ -643,7 +643,7 @@ static MlirConversionTargetLegality dynamicLegalityNoOpinion(MlirOperation op,
                                                              void *userData) {
   (void)op;
   intptr_t *counter = (intptr_t *)userData;
-  (*counter)++;
+  ++(*counter);
   return MLIR_CONVERSION_TARGET_LEGALITY_NO_OPINION;
 }
 
@@ -823,7 +823,7 @@ static MlirValue buildCastMaterialization(MlirRewriterBase rewriter,
                                           void *userData) {
   intptr_t *counter = (intptr_t *)userData;
   if (counter)
-    (*counter)++;
+    ++(*counter);
   MlirOperationState state =
       mlirOperationStateGet(mlirStringRefCreateFromCString("test.cast"), loc);
   mlirOperationStateAddOperands(&state, nInputs, inputs);

--- a/mlir/test/CAPI/rewrite.c
+++ b/mlir/test/CAPI/rewrite.c
@@ -802,6 +802,130 @@ void testConversionTargetDynamicLegality(MlirContext ctx) {
   fprintf(stderr, "testConversionTargetDynamicLegality: PASSED\n");
 }
 
+// Type conversion callback: maps i32 -> i64 and leaves every other type
+// unchanged (identity). Used by the materialization tests below.
+static MlirLogicalResult widenI32ToI64(MlirType type, MlirType *result,
+                                       void *userData) {
+  (void)userData;
+  if (mlirTypeIsAInteger(type) && mlirIntegerTypeGetWidth(type) == 32)
+    *result = mlirIntegerTypeGet(mlirTypeGetContext(type), 64);
+  else
+    *result = type;
+  return mlirLogicalResultSuccess();
+}
+
+// Materialization callback: builds a `test.cast` op that produces a single
+// value of `outputType` from the given inputs, and records that it ran by
+// bumping the counter passed as userData.
+static MlirValue buildCastMaterialization(MlirRewriterBase rewriter,
+                                          MlirType outputType, intptr_t nInputs,
+                                          MlirValue *inputs, MlirLocation loc,
+                                          void *userData) {
+  intptr_t *counter = (intptr_t *)userData;
+  if (counter)
+    (*counter)++;
+  MlirOperationState state =
+      mlirOperationStateGet(mlirStringRefCreateFromCString("test.cast"), loc);
+  mlirOperationStateAddOperands(&state, nInputs, inputs);
+  mlirOperationStateAddResults(&state, 1, &outputType);
+  MlirOperation castOp = mlirOperationCreate(&state);
+  mlirRewriterBaseInsert(rewriter, castOp);
+  return mlirOperationGetResult(castOp, 0);
+}
+
+// Conversion pattern for `test.source`: replaces it with a `test.source_i64`
+// op whose result has the widened (i64) type. Because the original result type
+// (i32) differs from the replacement type (i64), persisting uses force the
+// framework to insert a source materialization.
+static MlirLogicalResult convertSource(MlirConversionPattern pattern,
+                                       MlirOperation op, intptr_t nOperands,
+                                       MlirValue *operands,
+                                       MlirConversionPatternRewriter rewriter,
+                                       void *userData) {
+  (void)pattern;
+  (void)nOperands;
+  (void)operands;
+  (void)userData;
+  MlirContext ctx = mlirOperationGetContext(op);
+  MlirLocation loc = mlirOperationGetLocation(op);
+  MlirType i64 = mlirIntegerTypeGet(ctx, 64);
+  MlirOperationState state = mlirOperationStateGet(
+      mlirStringRefCreateFromCString("test.source_i64"), loc);
+  mlirOperationStateAddResults(&state, 1, &i64);
+  MlirOperation newOp = mlirOperationCreate(&state);
+
+  MlirRewriterBase base = mlirPatternRewriterAsBase(
+      mlirConversionPatternRewriterAsPatternRewriter(rewriter));
+  mlirRewriterBaseInsert(base, newOp);
+  MlirValue newVal = mlirOperationGetResult(newOp, 0);
+  mlirRewriterBaseReplaceOpWithValues(base, op, 1, &newVal);
+  return mlirLogicalResultSuccess();
+}
+
+void testTypeConverterSourceMaterialization(MlirContext ctx) {
+  // CHECK-LABEL: @testTypeConverterSourceMaterialization
+  fprintf(stderr, "@testTypeConverterSourceMaterialization\n");
+
+  // `test.source` produces an i32 that is consumed by the (legal) `test.user`.
+  // Converting `test.source` to an i64-producing op leaves `test.user` wanting
+  // the original i32, which triggers a source materialization back to i32.
+  const char *moduleString = "%0 = \"test.source\"() : () -> i32\n"
+                             "\"test.user\"(%0) : (i32) -> ()\n";
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(moduleString));
+  MlirOperation moduleOp = mlirModuleGetOperation(module);
+
+  MlirTypeConverter converter = mlirTypeConverterCreate();
+  mlirTypeConverterAddConversion(converter, widenI32ToI64, NULL);
+  intptr_t materializationCounter = 0;
+  mlirTypeConverterAddSourceMaterialization(converter, buildCastMaterialization,
+                                            &materializationCounter);
+
+  MlirRewritePatternSet patterns = mlirRewritePatternSetCreate(ctx);
+  MlirConversionPatternCallbacks callbacks = {NULL, NULL, convertSource};
+  MlirConversionPattern pattern = mlirOpConversionPatternCreate(
+      mlirStringRefCreateFromCString("test.source"), 1, ctx, converter,
+      callbacks, NULL, 0, NULL);
+  mlirRewritePatternSetAdd(patterns,
+                           mlirConversionPatternAsRewritePattern(pattern));
+  MlirFrozenRewritePatternSet frozen = mlirFreezeRewritePattern(patterns);
+
+  MlirConversionTarget target = mlirConversionTargetCreate(ctx);
+  mlirConversionTargetAddIllegalOp(
+      target, mlirStringRefCreateFromCString("test.source"));
+  mlirConversionTargetAddLegalOp(
+      target, mlirStringRefCreateFromCString("test.source_i64"));
+  mlirConversionTargetAddLegalOp(target,
+                                 mlirStringRefCreateFromCString("test.cast"));
+  mlirConversionTargetAddLegalOp(target,
+                                 mlirStringRefCreateFromCString("test.user"));
+  mlirConversionTargetAddLegalOp(
+      target, mlirStringRefCreateFromCString("builtin.module"));
+
+  MlirConversionConfig config = mlirConversionConfigCreate();
+  MlirLogicalResult result =
+      mlirApplyPartialConversion(moduleOp, target, frozen, config);
+  assert(mlirLogicalResultIsSuccess(result));
+  assert(materializationCounter > 0 &&
+         "source materialization callback must be invoked");
+
+  mlirOperationDump(moduleOp);
+  // clang-format off
+  // CHECK: %[[v:.*]] = "test.source_i64"() : () -> i64
+  // CHECK: %[[c:.*]] = "test.cast"(%[[v]]) : (i64) -> i32
+  // CHECK: "test.user"(%[[c]]) : (i32) -> ()
+  // clang-format on
+
+  mlirConversionConfigDestroy(config);
+  mlirConversionTargetDestroy(target);
+  mlirFrozenRewritePatternSetDestroy(frozen);
+  mlirTypeConverterDestroy(converter);
+  mlirModuleDestroy(module);
+
+  // CHECK: testTypeConverterSourceMaterialization: PASSED
+  fprintf(stderr, "testTypeConverterSourceMaterialization: PASSED\n");
+}
+
 int main(void) {
   MlirContext ctx = mlirContextCreate();
   mlirContextSetAllowUnregisteredDialects(ctx, true);
@@ -818,6 +942,7 @@ int main(void) {
   testGreedyRewriteDriverConfig(ctx);
   testCloneWithMapping(ctx);
   testConversionTargetDynamicLegality(ctx);
+  testTypeConverterSourceMaterialization(ctx);
 
   mlirContextDestroy(ctx);
   return 0;


### PR DESCRIPTION
Continues the buildout of the dialect-conversion C bindings (follows #206146 and #206161).

- Exposes `TypeConverter::addSourceMaterialization` and `addTargetMaterialization` through the MLIR C API.
- Introduces `MlirTypeConverterConversionStatus` (`Success`/`Failure`/`Declined`) and switches `MlirTypeConverterConversionCallback` to return it, replacing the old `MlirLogicalResult` + `MlirType{NULL}` dual sentinel. The old convention could not distinguish the C++ decline (`std::nullopt`, try the next conversion) and hard-failure (`failure()`, stop) states; the enum maps cleanly to all three. The Python binding and C API test are updated accordingly.

Assisted by: Claude
