### PR TITLE
[libcxx] Avoid including deprecated ClangTidyModuleRegistry.h

### DIFF
--- a/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "abi_tag_on_virtual.hpp"
 

--- a/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
@@ -8,9 +8,9 @@
 
 #include "clang-tidy/ClangTidyCheck.h"
 #if CLANG_VERSION_MAJOR > 23
-#include "clang-tidy/ClangTidyModule.h"
+#  include "clang-tidy/ClangTidyModule.h"
 #else
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#  include "clang-tidy/ClangTidyModuleRegistry.h"
 #endif
 
 #include "abi_tag_on_virtual.hpp"

--- a/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
@@ -7,7 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+#if CLANG_VERSION_MAJOR > 23
 #include "clang-tidy/ClangTidyModule.h"
+#else
+#include "clang-tidy/ClangTidyModuleRegistry.h"
+#endif
 
 #include "abi_tag_on_virtual.hpp"
 

--- a/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/abi_tag_on_virtual.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
+// TODO(LLVM 25): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/empty_namespaces.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/empty_namespaces.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/empty_namespaces.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/empty_namespaces.cpp
@@ -8,9 +8,9 @@
 
 #include "clang-tidy/ClangTidyCheck.h"
 #if CLANG_VERSION_MAJOR > 23
-#include "clang-tidy/ClangTidyModule.h"
+#  include "clang-tidy/ClangTidyModule.h"
 #else
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#  include "clang-tidy/ClangTidyModuleRegistry.h"
 #endif
 
 #include "empty_namespaces.hpp"

--- a/libcxx/test/tools/clang_tidy_checks/empty_namespaces.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/empty_namespaces.cpp
@@ -7,7 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+#if CLANG_VERSION_MAJOR > 23
 #include "clang-tidy/ClangTidyModule.h"
+#else
+#include "clang-tidy/ClangTidyModuleRegistry.h"
+#endif
 
 #include "empty_namespaces.hpp"
 

--- a/libcxx/test/tools/clang_tidy_checks/empty_namespaces.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/empty_namespaces.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
+// TODO(LLVM 25): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/empty_namespaces.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/empty_namespaces.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "empty_namespaces.hpp"
 

--- a/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "llvm/ADT/ArrayRef.h"
 

--- a/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
@@ -8,9 +8,9 @@
 
 #include "clang-tidy/ClangTidyCheck.h"
 #if CLANG_VERSION_MAJOR > 23
-#include "clang-tidy/ClangTidyModule.h"
+#  include "clang-tidy/ClangTidyModule.h"
 #else
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#  include "clang-tidy/ClangTidyModuleRegistry.h"
 #endif
 
 #include "llvm/ADT/ArrayRef.h"

--- a/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
@@ -7,7 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+#if CLANG_VERSION_MAJOR > 23
 #include "clang-tidy/ClangTidyModule.h"
+#else
+#include "clang-tidy/ClangTidyModuleRegistry.h"
+#endif
 
 #include "llvm/ADT/ArrayRef.h"
 

--- a/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
+// TODO(LLVM 25): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "hide_from_abi.hpp"
 

--- a/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
@@ -8,9 +8,9 @@
 
 #include "clang-tidy/ClangTidyCheck.h"
 #if CLANG_VERSION_MAJOR > 23
-#include "clang-tidy/ClangTidyModule.h"
+#  include "clang-tidy/ClangTidyModule.h"
 #else
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#  include "clang-tidy/ClangTidyModuleRegistry.h"
 #endif
 
 #include "hide_from_abi.hpp"

--- a/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
@@ -7,7 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+#if CLANG_VERSION_MAJOR > 23
 #include "clang-tidy/ClangTidyModule.h"
+#else
+#include "clang-tidy/ClangTidyModuleRegistry.h"
+#endif
 
 #include "hide_from_abi.hpp"
 

--- a/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/hide_from_abi.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
+// TODO(LLVM 25): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyModule.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "abi_tag_on_virtual.hpp"
 #include "empty_namespaces.hpp"

--- a/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyModule.h"
-// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
+// TODO(LLVM 25): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR < 23
 #  include "clang-tidy/ClangTidyModuleRegistry.h"
 #endif

--- a/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
@@ -8,7 +8,7 @@
 
 #include "clang-tidy/ClangTidyModule.h"
 #if CLANG_VERSION_MAJOR < 23
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#  include "clang-tidy/ClangTidyModuleRegistry.h"
 #endif
 
 #include "abi_tag_on_virtual.hpp"

--- a/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyModule.h"
+// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR < 23
 #  include "clang-tidy/ClangTidyModuleRegistry.h"
 #endif

--- a/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyModule.h"
-#include "clang-tidy/ClangTidyModule.h"
+#if CLANG_VERSION_MAJOR < 23
+#include "clang-tidy/ClangTidyModuleRegistry.h"
+#endif
 
 #include "abi_tag_on_virtual.hpp"
 #include "empty_namespaces.hpp"

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "robust_against_adl.hpp"
 

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
@@ -8,9 +8,9 @@
 
 #include "clang-tidy/ClangTidyCheck.h"
 #if CLANG_VERSION_MAJOR > 23
-#include "clang-tidy/ClangTidyModule.h"
+#  include "clang-tidy/ClangTidyModule.h"
 #else
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#  include "clang-tidy/ClangTidyModuleRegistry.h"
 #endif
 
 #include "robust_against_adl.hpp"

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
+// TODO(LLVM 25): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_adl.cpp
@@ -7,7 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+#if CLANG_VERSION_MAJOR > 23
 #include "clang-tidy/ClangTidyModule.h"
+#else
+#include "clang-tidy/ClangTidyModuleRegistry.h"
+#endif
 
 #include "robust_against_adl.hpp"
 

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Tooling/FixIt.h"
 

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
@@ -7,7 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+#if CLANG_VERSION_MAJOR > 23
 #include "clang-tidy/ClangTidyModule.h"
+#else
+#include "clang-tidy/ClangTidyModuleRegistry.h"
+#endif
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Tooling/FixIt.h"
 

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
@@ -8,9 +8,9 @@
 
 #include "clang-tidy/ClangTidyCheck.h"
 #if CLANG_VERSION_MAJOR > 23
-#include "clang-tidy/ClangTidyModule.h"
+#  include "clang-tidy/ClangTidyModule.h"
 #else
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#  include "clang-tidy/ClangTidyModuleRegistry.h"
 #endif
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Tooling/FixIt.h"

--- a/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/robust_against_operator_ampersand.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
+// TODO(LLVM 25): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#include "clang-tidy/ClangTidyModule.h"
 
 #include "uglify_attributes.hpp"
 #include "utilities.hpp"

--- a/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else

--- a/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
@@ -7,7 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
+#if CLANG_VERSION_MAJOR > 23
 #include "clang-tidy/ClangTidyModule.h"
+#else
+#include "clang-tidy/ClangTidyModuleRegistry.h"
+#endif
 
 #include "uglify_attributes.hpp"
 #include "utilities.hpp"

--- a/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
@@ -8,9 +8,9 @@
 
 #include "clang-tidy/ClangTidyCheck.h"
 #if CLANG_VERSION_MAJOR > 23
-#include "clang-tidy/ClangTidyModule.h"
+#  include "clang-tidy/ClangTidyModule.h"
 #else
-#include "clang-tidy/ClangTidyModuleRegistry.h"
+#  include "clang-tidy/ClangTidyModuleRegistry.h"
 #endif
 
 #include "uglify_attributes.hpp"

--- a/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/uglify_attributes.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-tidy/ClangTidyCheck.h"
-// TODO(boomanaiden154): Remove this compatibility check when LLVM 25 branches.
+// TODO(LLVM 25): Remove this compatibility check when LLVM 25 branches.
 #if CLANG_VERSION_MAJOR > 23
 #  include "clang-tidy/ClangTidyModule.h"
 #else


### PR DESCRIPTION
Deprecated in 1bcf74006bcf528d14377173dba459759d35c961. Causes warnings during compilation and will presumably become an error.