### PR TITLE
[ThinLTO] Error on missing ValueInfo for function definition

### DIFF
--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -516,6 +516,20 @@ bool LLParser::validateEndOfIndex() {
                  "use of undefined type id summary '^" +
                      Twine(ForwardRefTypeIds.begin()->first) + "'");
 
+  // Verify that we have ValueInfo for all function definitions, which are
+  // assumed to be available by downstream consumers.
+  if (M) {
+    for (const Function &F : *M) {
+      if (F.isDeclaration())
+        continue;
+      GlobalValue::GUID GUID = F.getGUIDOrFallback();
+      ValueInfo VI = Index->getValueInfo(GUID);
+      if (!VI || VI.getSummaryList().empty())
+        return error(SMLoc(), "expected function definition " + F.getName() +
+                                  " to have an associated value info.");
+    }
+  }
+
   return false;
 }
 

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -516,20 +516,6 @@ bool LLParser::validateEndOfIndex() {
                  "use of undefined type id summary '^" +
                      Twine(ForwardRefTypeIds.begin()->first) + "'");
 
-  // Verify that we have ValueInfo for all function definitions, which are
-  // assumed to be available by downstream consumers.
-  if (M) {
-    for (const Function &F : *M) {
-      if (F.isDeclaration())
-        continue;
-      GlobalValue::GUID GUID = F.getGUIDOrFallback();
-      ValueInfo VI = Index->getValueInfo(GUID);
-      if (!VI || VI.getSummaryList().empty())
-        return error(SMLoc(), "expected function definition " + F.getName() +
-                                  " to have an associated value info.");
-    }
-  }
-
   return false;
 }
 

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -4924,7 +4924,9 @@ void ModuleBitcodeWriterBase::writePerModuleGlobalValueSummary() {
     if (!VI || VI.getSummaryList().empty()) {
       // Only declarations should not have a summary (a declaration might
       // however have a summary if the def was in module level asm).
-      assert(F.isDeclaration());
+      if (!F.isDeclaration())
+        reportFatalUsageError("expected function definition " + F.getName() +
+                              " to have an associated value info.");
       continue;
     }
     auto *Summary = VI.getSummaryList()[0].get();

--- a/llvm/test/Assembler/thinlto-bad-summary-5.ll
+++ b/llvm/test/Assembler/thinlto-bad-summary-5.ll
@@ -3,7 +3,7 @@
 
 ; RUN: not llvm-as %s 2>&1 | FileCheck %s
 
-; CHECK: error: expected function definition foo to have an associated value info.
+; CHECK: LLVM ERROR: expected function definition foo to have an associated value info.
 
 define void @foo() {
   ret void

--- a/llvm/test/Assembler/thinlto-bad-summary-5.ll
+++ b/llvm/test/Assembler/thinlto-bad-summary-5.ll
@@ -1,0 +1,11 @@
+; Test that we get an appropriate error when parsing a summary that does
+; not have value info associated with a function definition.
+
+; RUN: not llvm-as %s 2>&1 | FileCheck %s
+
+; CHECK: error: expected function definition foo to have an associated value info.
+
+define void @foo() {
+  ret void
+}
+^1 = gv: (name: "foo")


### PR DESCRIPTION
We assume that these are available inside of BitcodeWriter
https://github.com/llvm/llvm-project/blob/09796808802f99c30a23bc0f2cd68243764e84ab/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp#L4927,
but do not currently validate this in input IR. This means that when
doing reductions with automated tooling in a non-asserts build, it is
pretty easy to end up with invalid IR that is not caught as invalid.
