### PR TITLE
[clang-format] Add FilesBeforeFolders option to SortIncludes

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.md
+++ b/clang/docs/ClangFormatStyleOptions.md
@@ -6989,13 +6989,13 @@ the configuration (without a prefix: `Auto`).
     #include "A10.h"           #include "A2.h"
     ```
 
-  - ``bool FilesBeforeFolders`` When ``true``, sort includes so that files in a directory appear
+  - `bool FilesBeforeFolders` When `true`, sort includes so that files in a directory appear
     before subdirectories at each level, recursively. Within a level,
     files and folders are each sorted alphabetically.
-    When ``false`` (default), sorts includes purely alphabetically.
+    When `false` (default), sorts includes purely alphabetically.
 
-    This option is a secondary sort key within each ``Priority`` group
-    defined by ``IncludeCategories``. Includes in different ``Priority``
+    This option is a secondary sort key within each `Priority` group
+    defined by `IncludeCategories`. Includes in different `Priority`
     groups are still separated by that primary ordering.
 
     ```c++
@@ -7010,7 +7010,8 @@ the configuration (without a prefix: `Auto`).
     #include "bar/alpha/f.h"          #include "x.h"
     #include "bar/beta/d.h"           #include "y.h"
     #include "foo/a.h"                #include "z.h"
-    ``
+    ```
+
 
 (sortjavastaticimport)=
 

--- a/clang/docs/ClangFormatStyleOptions.md
+++ b/clang/docs/ClangFormatStyleOptions.md
@@ -6989,6 +6989,28 @@ the configuration (without a prefix: `Auto`).
     #include "A10.h"           #include "A2.h"
     ```
 
+  - ``bool FilesBeforeFolders`` When ``true``, sort includes so that files in a directory appear
+    before subdirectories at each level, recursively. Within a level,
+    files and folders are each sorted alphabetically.
+    When ``false`` (default), sorts includes purely alphabetically.
+
+    This option is a secondary sort key within each ``Priority`` group
+    defined by ``IncludeCategories``. Includes in different ``Priority``
+    groups are still separated by that primary ordering.
+
+    ```c++
+    true:                             false (default):
+    #include "x.h"             vs.    #include "bar/alpha/e.h"
+    #include "y.h"                    #include "bar/alpha/f.h"
+    #include "z.h"                    #include "bar/beta/d.h"
+    #include "bar/g.h"                #include "bar/g.h"
+    #include "bar/h.h"                #include "bar/h.h"
+    #include "bar/i.h"                #include "bar/i.h"
+    #include "bar/alpha/e.h"          #include "foo/a.h"
+    #include "bar/alpha/f.h"          #include "x.h"
+    #include "bar/beta/d.h"           #include "y.h"
+    #include "foo/a.h"                #include "z.h"
+    ``
 
 (sortjavastaticimport)=
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5106,13 +5106,13 @@ struct FormatStyle {
     ///    #include "A10.h"           #include "A2.h"
     /// \endcode
     bool Natural;
-    /// When ``true``, sort includes so that files in a directory appear
+    /// When `true`, sort includes so that files in a directory appear
     /// before subdirectories at each level, recursively. Within a level,
     /// files and folders are each sorted alphabetically.
-    /// When ``false`` (default), sorts includes purely alphabetically.
+    /// When `false` (default), sorts includes purely alphabetically.
     ///
-    /// This option is a secondary sort key within each ``Priority`` group
-    /// defined by ``IncludeCategories``. Includes in different ``Priority``
+    /// This option is a secondary sort key within each `Priority` group
+    /// defined by `IncludeCategories`. Includes in different `Priority`
     /// groups are still separated by that primary ordering.
     /// \code
     ///    true:                             false (default):

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5106,9 +5106,32 @@ struct FormatStyle {
     ///    #include "A10.h"           #include "A2.h"
     /// \endcode
     bool Natural;
+    /// When ``true``, sort includes so that files in a directory appear
+    /// before subdirectories at each level, recursively. Within a level,
+    /// files and folders are each sorted alphabetically.
+    /// When ``false`` (default), sorts includes purely alphabetically.
+    ///
+    /// This option is a secondary sort key within each ``Priority`` group
+    /// defined by ``IncludeCategories``. Includes in different ``Priority``
+    /// groups are still separated by that primary ordering.
+    /// \code
+    ///    true:                             false (default):
+    ///    #include "x.h"             vs.    #include "bar/alpha/e.h"
+    ///    #include "y.h"                    #include "bar/alpha/f.h"
+    ///    #include "z.h"                    #include "bar/beta/d.h"
+    ///    #include "bar/g.h"                #include "bar/g.h"
+    ///    #include "bar/h.h"                #include "bar/h.h"
+    ///    #include "bar/i.h"                #include "bar/i.h"
+    ///    #include "bar/alpha/e.h"          #include "foo/a.h"
+    ///    #include "bar/alpha/f.h"          #include "x.h"
+    ///    #include "bar/beta/d.h"           #include "y.h"
+    ///    #include "foo/a.h"                #include "z.h"
+    /// \endcode
+    bool FilesBeforeFolders;
     bool operator==(const SortIncludesOptions &R) const {
       return Enabled == R.Enabled && IgnoreCase == R.IgnoreCase &&
-             IgnoreExtension == R.IgnoreExtension && Natural == R.Natural;
+             IgnoreExtension == R.IgnoreExtension && Natural == R.Natural &&
+             FilesBeforeFolders == R.FilesBeforeFolders;
     }
     bool operator!=(const SortIncludesOptions &R) const {
       return !(*this == R);

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -849,17 +849,20 @@ template <> struct MappingTraits<FormatStyle::SortIncludesOptions> {
                 FormatStyle::SortIncludesOptions{/*Enabled=*/true,
                                                  /*IgnoreCase=*/true,
                                                  /*IgnoreExtension=*/false,
-                                                 /*Natural=*/false});
+                                                 /*Natural=*/false,
+                                                 /*FilesBeforeFolders=*/false});
     IO.enumCase(Value, "CaseSensitive",
                 FormatStyle::SortIncludesOptions{/*Enabled=*/true,
                                                  /*IgnoreCase=*/false,
                                                  /*IgnoreExtension=*/false,
-                                                 /*Natural=*/false});
+                                                 /*Natural=*/false,
+                                                 /*FilesBeforeFolders=*/false});
     IO.enumCase(Value, "Natural",
                 FormatStyle::SortIncludesOptions{/*Enabled=*/true,
                                                  /*IgnoreCase=*/false,
                                                  /*IgnoreExtension=*/false,
-                                                 /*Natural=*/true});
+                                                 /*Natural=*/true,
+                                                 /*FilesBeforeFolders=*/false});
 
     // For backward compatibility.
     IO.enumCase(Value, "false", FormatStyle::SortIncludesOptions{});
@@ -867,14 +870,15 @@ template <> struct MappingTraits<FormatStyle::SortIncludesOptions> {
                 FormatStyle::SortIncludesOptions{/*Enabled=*/true,
                                                  /*IgnoreCase=*/false,
                                                  /*IgnoreExtension=*/false,
-                                                 /*Natural=*/false});
+                                                 /*Natural=*/false,
+                                                 /*FilesBeforeFolders=*/false});
   }
-
   static void mapping(IO &IO, FormatStyle::SortIncludesOptions &Value) {
     IO.mapOptional("Enabled", Value.Enabled);
     IO.mapOptional("IgnoreCase", Value.IgnoreCase);
     IO.mapOptional("IgnoreExtension", Value.IgnoreExtension);
     IO.mapOptional("Natural", Value.Natural);
+    IO.mapOptional("FilesBeforeFolders", Value.FilesBeforeFolders);
   }
 };
 
@@ -2023,7 +2027,8 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.ShortNamespaceLines = 1;
   LLVMStyle.SkipMacroDefinitionBody = false;
   LLVMStyle.SortIncludes = {/*Enabled=*/true, /*IgnoreCase=*/false,
-                            /*IgnoreExtension=*/false, /*Natural=*/false};
+                            /*IgnoreExtension=*/false, /*Natural=*/false,
+                            /*FilesBeforeFolders=*/false};
   LLVMStyle.SortJavaStaticImport = FormatStyle::SJSIO_Before;
   LLVMStyle.SortUsingDeclarations = FormatStyle::SUD_LexicographicNumeric;
   LLVMStyle.SpaceAfterCStyleCast = false;
@@ -3690,6 +3695,37 @@ static void sortCppIncludes(const FormatStyle &Style,
       const auto Compare = Style.SortIncludes.Natural
                                ? &StringRef::compare_numeric
                                : &StringRef::compare;
+
+      while (Style.SortIncludes.FilesBeforeFolders) {
+        auto [LHead, LTail] = LHSStem.split('/');
+        auto [RHead, RTail] = RHSStem.split('/');
+
+        bool LIsFile = LTail.empty();
+        bool RIsFile = RTail.empty();
+
+        // A file at this level sorts before a subdirectory at this level.
+        if (LIsFile != RIsFile)
+          return LIsFile;
+
+        // Both are leaf filenames — they are equal at this level, so we
+        // can break out of the loop and compare the full filenames later.
+        if (LIsFile)
+          break;
+
+        // Both are directory components at this level — compare them.
+        if (Style.SortIncludes.IgnoreCase) {
+          int Cmp = std::invoke(Compare, StringRef(LHead.lower()),
+                                StringRef(RHead.lower()));
+          if (Cmp != 0)
+            return Cmp < 0;
+        }
+        if (int Cmp = std::invoke(Compare, LHead, RHead); Cmp != 0)
+          return Cmp < 0;
+
+        // Directory components are equal; descend into the next level.
+        LHSStem = LTail;
+        RHSStem = RTail;
+      }
 
       if (Style.SortIncludes.IgnoreCase) {
         int Cmp = std::invoke(Compare, StringRef(LHSStemLower), RHSStemLower);

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -273,6 +273,7 @@ TEST(ConfigParseTest, ParsesConfigurationBools) {
   CHECK_PARSE_NESTED_BOOL(SpacesInParensOptions, InEmptyParentheses);
   CHECK_PARSE_NESTED_BOOL(SpacesInParensOptions, Other);
   CHECK_PARSE_NESTED_BOOL(SortIncludes, Enabled);
+  CHECK_PARSE_NESTED_BOOL(SortIncludes, FilesBeforeFolders);
   CHECK_PARSE_NESTED_BOOL(SortIncludes, IgnoreCase);
   CHECK_PARSE_NESTED_BOOL(SortIncludes, IgnoreExtension);
 }
@@ -1171,21 +1172,25 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("SortIncludes: true", SortIncludes,
               FormatStyle::SortIncludesOptions(
                   {/*Enabled=*/true, /*IgnoreCase=*/false,
-                   /*IgnoreExtension=*/false, /*Natural=*/false}));
+                   /*IgnoreExtension=*/false, /*Natural=*/false,
+                   /*FilesBeforeFolders=*/false}));
   CHECK_PARSE("SortIncludes: false", SortIncludes,
               FormatStyle::SortIncludesOptions{});
   CHECK_PARSE("SortIncludes: CaseInsensitive", SortIncludes,
               FormatStyle::SortIncludesOptions(
                   {/*Enabled=*/true, /*IgnoreCase=*/true,
-                   /*IgnoreExtension=*/false, /*Natural=*/false}));
+                   /*IgnoreExtension=*/false, /*Natural=*/false,
+                   /*FilesBeforeFolders=*/false}));
   CHECK_PARSE("SortIncludes: CaseSensitive", SortIncludes,
               FormatStyle::SortIncludesOptions(
                   {/*Enabled=*/true, /*IgnoreCase=*/false,
-                   /*IgnoreExtension=*/false, /*Natural=*/false}));
+                   /*IgnoreExtension=*/false, /*Natural=*/false,
+                   /*FilesBeforeFolders=*/false}));
   CHECK_PARSE("SortIncludes: Natural", SortIncludes,
               FormatStyle::SortIncludesOptions(
                   {/*Enabled=*/true, /*IgnoreCase=*/false,
-                   /*IgnoreExtension=*/false, /*Natural=*/true}));
+                   /*IgnoreExtension=*/false, /*Natural=*/true,
+                   /*FilesBeforeFolders=*/false}));
   CHECK_PARSE("SortIncludes: Never", SortIncludes,
               FormatStyle::SortIncludesOptions{});
 

--- a/clang/unittests/Format/SortIncludesTest.cpp
+++ b/clang/unittests/Format/SortIncludesTest.cpp
@@ -1537,6 +1537,164 @@ TEST_F(SortIncludesTest, IgnoreExtension) {
                     "input.h"));
 }
 
+TEST_F(SortIncludesTest, FilesBeforeFolders) {
+  // When false (default), sorting is purely alphabetical: "bar/" starts with
+  // 'b', which sorts before 'f' (foo/) and 'x'/'y'/'z', so subdirectories
+  // interleave with files based on the directory name alone.
+  //
+  //   false (default):           true:
+  //   #include "bar/alpha/e.h"   #include "x.h"
+  //   #include "bar/alpha/f.h"   #include "y.h"
+  //   #include "bar/beta/d.h"    #include "z.h"
+  //   #include "bar/g.h"         #include "bar/g.h"
+  //   #include "bar/h.h"         #include "bar/h.h"
+  //   #include "bar/i.h"         #include "bar/i.h"
+  //   #include "foo/a.h"         #include "bar/alpha/e.h"
+  //   #include "x.h"             #include "bar/alpha/f.h"
+  //   #include "y.h"             #include "bar/beta/d.h"
+  //   #include "z.h"             #include "foo/a.h"
+  FmtStyle.SortIncludes.FilesBeforeFolders = false;
+  verifyFormat("#include \"bar/alpha/e.h\"\n"
+               "#include \"bar/alpha/f.h\"\n"
+               "#include \"bar/beta/d.h\"\n"
+               "#include \"bar/g.h\"\n"
+               "#include \"bar/h.h\"\n"
+               "#include \"bar/i.h\"\n"
+               "#include \"foo/a.h\"\n"
+               "#include \"x.h\"\n"
+               "#include \"y.h\"\n"
+               "#include \"z.h\"",
+               sort("#include \"z.h\"\n"
+                    "#include \"bar/alpha/f.h\"\n"
+                    "#include \"foo/a.h\"\n"
+                    "#include \"bar/g.h\"\n"
+                    "#include \"x.h\"\n"
+                    "#include \"bar/beta/d.h\"\n"
+                    "#include \"bar/i.h\"\n"
+                    "#include \"y.h\"\n"
+                    "#include \"bar/h.h\"\n"
+                    "#include \"bar/alpha/e.h\"",
+                    "input.h"));
+
+  // When true, all files at the current directory level sort before any
+  // subdirectory. Within a level, files and folders are each sorted
+  // alphabetically. This applies recursively: inside "bar/", the direct
+  // files (g.h, h.h, i.h) sort before the subdirectories (alpha/, beta/).
+  FmtStyle.SortIncludes.FilesBeforeFolders = true;
+  verifyFormat("#include \"x.h\"\n"
+               "#include \"y.h\"\n"
+               "#include \"z.h\"\n"
+               "#include \"bar/g.h\"\n"
+               "#include \"bar/h.h\"\n"
+               "#include \"bar/i.h\"\n"
+               "#include \"bar/alpha/e.h\"\n"
+               "#include \"bar/alpha/f.h\"\n"
+               "#include \"bar/beta/d.h\"\n"
+               "#include \"foo/a.h\"",
+               sort("#include \"z.h\"\n"
+                    "#include \"bar/alpha/f.h\"\n"
+                    "#include \"foo/a.h\"\n"
+                    "#include \"bar/g.h\"\n"
+                    "#include \"x.h\"\n"
+                    "#include \"bar/beta/d.h\"\n"
+                    "#include \"bar/i.h\"\n"
+                    "#include \"y.h\"\n"
+                    "#include \"bar/h.h\"\n"
+                    "#include \"bar/alpha/e.h\"",
+                    "input.h"));
+
+  // Recursion: files in a subdir sort before nested subdirs.
+  verifyFormat("#include \"dir/a.h\"\n"
+               "#include \"dir/b.h\"\n"
+               "#include \"dir/sub/a.h\"\n"
+               "#include \"dir/sub/b.h\"",
+               sort("#include \"dir/sub/b.h\"\n"
+                    "#include \"dir/a.h\"\n"
+                    "#include \"dir/sub/a.h\"\n"
+                    "#include \"dir/b.h\"",
+                    "input.h"));
+
+  // FilesBeforeFolders combined with IgnoreCase.
+  FmtStyle.SortIncludes.IgnoreCase = true;
+  verifyFormat("#include \"A.h\"\n"
+               "#include \"b.h\"\n"
+               "#include \"Bar/a.h\"\n"
+               "#include \"foo/B.h\"",
+               sort("#include \"foo/B.h\"\n"
+                    "#include \"Bar/a.h\"\n"
+                    "#include \"b.h\"\n"
+                    "#include \"A.h\"",
+                    "input.h"));
+  // Case-sensitive comparison is the tiebreaker when directory components are
+  // case-insensitively equal: "Bar" (0x42) < "bar" (0x62).
+  verifyFormat("#include \"Bar/a.h\"\n"
+               "#include \"bar/a.h\"",
+               sort("#include \"bar/a.h\"\n"
+                    "#include \"Bar/a.h\"",
+                    "input.h"));
+  FmtStyle.SortIncludes.IgnoreCase = false;
+
+  // FilesBeforeFolders combined with IgnoreExtension.
+  FmtStyle.SortIncludes.IgnoreExtension = true;
+  verifyFormat("#include \"a.h\"\n"
+               "#include \"a.inc\"\n"
+               "#include \"a-util.h\"\n"
+               "#include \"bar/a.h\"\n"
+               "#include \"bar/b.h\"",
+               sort("#include \"bar/b.h\"\n"
+                    "#include \"a-util.h\"\n"
+                    "#include \"bar/a.h\"\n"
+                    "#include \"a.inc\"\n"
+                    "#include \"a.h\"",
+                    "input.h"));
+  FmtStyle.SortIncludes.IgnoreExtension = false;
+
+  // Mixing "" and <> includes in the same block: FilesBeforeFolders applies
+  // equally to both quote and angle-bracket includes, but the delimiter itself
+  // participates in the plain alphabetical comparison when the flag is false:
+  // '"' (0x22) < '<' (0x3C), so quote-delimited includes sort before
+  // angle-bracket ones regardless of path content.
+  //
+  // This example uses a quote include that is a folder path ("beta/x.hpp") and
+  // an angle-bracket include that is a root-level file (<alpha.hpp>).
+  //
+  //   false (alphabetical, delimiter wins):
+  //     "beta/x.hpp" sorts first because '"' < '<'
+  //   true (files-before-folders, structural comparison):
+  //     <alpha.hpp> sorts first because it is a root-level file while
+  //     "beta/x.hpp" lives inside a subdirectory
+  FmtStyle.IncludeStyle.IncludeCategories.clear();
+  FmtStyle.SortIncludes.FilesBeforeFolders = false;
+  verifyFormat("#include \"beta/x.hpp\"\n"
+               "#include <alpha.hpp>",
+               sort("#include <alpha.hpp>\n"
+                    "#include \"beta/x.hpp\"",
+                    "input.h"));
+  FmtStyle.SortIncludes.FilesBeforeFolders = true;
+  verifyFormat("#include <alpha.hpp>\n"
+               "#include \"beta/x.hpp\"",
+               sort("#include \"beta/x.hpp\"\n"
+                    "#include <alpha.hpp>",
+                    "input.h"));
+}
+
+TEST_F(SortIncludesTest, FilesBeforeFoldersWithPriority) {
+  // FilesBeforeFolders is a secondary sort key: Priority groups stay separate
+  // and FilesBeforeFolders only reorders includes within the same group.
+  Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
+  Style.IncludeCategories = {{"^<", 1, 0, false}, {"^\"", 2, 0, false}};
+  FmtStyle.SortIncludes.FilesBeforeFolders = true;
+  verifyFormat("#include <stdio.h>\n"
+               "#include <sys/stat.h>\n"
+               "\n"
+               "#include \"utils.h\"\n"
+               "#include \"foo/bar.h\"",
+               sort("#include <sys/stat.h>\n"
+                    "#include \"foo/bar.h\"\n"
+                    "#include <stdio.h>\n"
+                    "#include \"utils.h\""));
+}
+
 } // end namespace
 } // end namespace format
 } // end namespace clang

--- a/clang/unittests/Format/SortIncludesTest.cpp
+++ b/clang/unittests/Format/SortIncludesTest.cpp
@@ -1538,21 +1538,6 @@ TEST_F(SortIncludesTest, IgnoreExtension) {
 }
 
 TEST_F(SortIncludesTest, FilesBeforeFolders) {
-  // When false (default), sorting is purely alphabetical: "bar/" starts with
-  // 'b', which sorts before 'f' (foo/) and 'x'/'y'/'z', so subdirectories
-  // interleave with files based on the directory name alone.
-  //
-  //   false (default):           true:
-  //   #include "bar/alpha/e.h"   #include "x.h"
-  //   #include "bar/alpha/f.h"   #include "y.h"
-  //   #include "bar/beta/d.h"    #include "z.h"
-  //   #include "bar/g.h"         #include "bar/g.h"
-  //   #include "bar/h.h"         #include "bar/h.h"
-  //   #include "bar/i.h"         #include "bar/i.h"
-  //   #include "foo/a.h"         #include "bar/alpha/e.h"
-  //   #include "x.h"             #include "bar/alpha/f.h"
-  //   #include "y.h"             #include "bar/beta/d.h"
-  //   #include "z.h"             #include "foo/a.h"
   FmtStyle.SortIncludes.FilesBeforeFolders = false;
   verifyFormat("#include \"bar/alpha/e.h\"\n"
                "#include \"bar/alpha/f.h\"\n"
@@ -1576,10 +1561,6 @@ TEST_F(SortIncludesTest, FilesBeforeFolders) {
                     "#include \"bar/alpha/e.h\"",
                     "input.h"));
 
-  // When true, all files at the current directory level sort before any
-  // subdirectory. Within a level, files and folders are each sorted
-  // alphabetically. This applies recursively: inside "bar/", the direct
-  // files (g.h, h.h, i.h) sort before the subdirectories (alpha/, beta/).
   FmtStyle.SortIncludes.FilesBeforeFolders = true;
   verifyFormat("#include \"x.h\"\n"
                "#include \"y.h\"\n"
@@ -1603,7 +1584,6 @@ TEST_F(SortIncludesTest, FilesBeforeFolders) {
                     "#include \"bar/alpha/e.h\"",
                     "input.h"));
 
-  // Recursion: files in a subdir sort before nested subdirs.
   verifyFormat("#include \"dir/a.h\"\n"
                "#include \"dir/b.h\"\n"
                "#include \"dir/sub/a.h\"\n"
@@ -1614,7 +1594,6 @@ TEST_F(SortIncludesTest, FilesBeforeFolders) {
                     "#include \"dir/b.h\"",
                     "input.h"));
 
-  // FilesBeforeFolders combined with IgnoreCase.
   FmtStyle.SortIncludes.IgnoreCase = true;
   verifyFormat("#include \"A.h\"\n"
                "#include \"b.h\"\n"
@@ -1625,8 +1604,6 @@ TEST_F(SortIncludesTest, FilesBeforeFolders) {
                     "#include \"b.h\"\n"
                     "#include \"A.h\"",
                     "input.h"));
-  // Case-sensitive comparison is the tiebreaker when directory components are
-  // case-insensitively equal: "Bar" (0x42) < "bar" (0x62).
   verifyFormat("#include \"Bar/a.h\"\n"
                "#include \"bar/a.h\"",
                sort("#include \"bar/a.h\"\n"
@@ -1634,7 +1611,6 @@ TEST_F(SortIncludesTest, FilesBeforeFolders) {
                     "input.h"));
   FmtStyle.SortIncludes.IgnoreCase = false;
 
-  // FilesBeforeFolders combined with IgnoreExtension.
   FmtStyle.SortIncludes.IgnoreExtension = true;
   verifyFormat("#include \"a.h\"\n"
                "#include \"a.inc\"\n"
@@ -1649,20 +1625,6 @@ TEST_F(SortIncludesTest, FilesBeforeFolders) {
                     "input.h"));
   FmtStyle.SortIncludes.IgnoreExtension = false;
 
-  // Mixing "" and <> includes in the same block: FilesBeforeFolders applies
-  // equally to both quote and angle-bracket includes, but the delimiter itself
-  // participates in the plain alphabetical comparison when the flag is false:
-  // '"' (0x22) < '<' (0x3C), so quote-delimited includes sort before
-  // angle-bracket ones regardless of path content.
-  //
-  // This example uses a quote include that is a folder path ("beta/x.hpp") and
-  // an angle-bracket include that is a root-level file (<alpha.hpp>).
-  //
-  //   false (alphabetical, delimiter wins):
-  //     "beta/x.hpp" sorts first because '"' < '<'
-  //   true (files-before-folders, structural comparison):
-  //     <alpha.hpp> sorts first because it is a root-level file while
-  //     "beta/x.hpp" lives inside a subdirectory
   FmtStyle.IncludeStyle.IncludeCategories.clear();
   FmtStyle.SortIncludes.FilesBeforeFolders = false;
   verifyFormat("#include \"beta/x.hpp\"\n"
@@ -1679,8 +1641,6 @@ TEST_F(SortIncludesTest, FilesBeforeFolders) {
 }
 
 TEST_F(SortIncludesTest, FilesBeforeFoldersWithPriority) {
-  // FilesBeforeFolders is a secondary sort key: Priority groups stay separate
-  // and FilesBeforeFolders only reorders includes within the same group.
   Style.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;
   Style.IncludeCategories = {{"^<", 1, 0, false}, {"^\"", 2, 0, false}};
   FmtStyle.SortIncludes.FilesBeforeFolders = true;


### PR DESCRIPTION
Add a new `SortIncludes.FilesBeforeFolders` boolean option that, when enabled, sorts includes so that files in a directory appear before subdirectories at each level, recursively. Within a level, files and subdirectories are each sorted alphabetically.

For example:

```
       true:                             false (default):
       #include "x.h"             vs.    #include "bar/alpha/e.h"
       #include "y.h"                    #include "bar/alpha/f.h"
       #include "z.h"                    #include "bar/beta/d.h"
       #include "bar/g.h"                #include "bar/g.h"
       #include "bar/h.h"                #include "bar/h.h"
       #include "bar/i.h"                #include "bar/i.h"
       #include "bar/alpha/e.h"          #include "foo/a.h"
       #include "bar/alpha/f.h"          #include "x.h"
       #include "bar/beta/d.h"           #include "y.h"
       #include "foo/a.h"                #include "z.h"
```

Assisted-by: Github Copilot CLI