### PR TITLE
[mlir][sparse] Handle dense iterators in sparse iteration lowering

### DIFF
--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseIterationToScf.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseIterationToScf.cpp
@@ -134,8 +134,11 @@ static ValueRange genLoopWithIterator(
         });
     {
       OpBuilder::InsertionGuard guard(rewriter);
-      it->linkNewScope(forOp.getInductionVar());
       rewriter.setInsertionPointToStart(forOp.getBody());
+      if (it->randomAccessible())
+        it->locate(rewriter, loc, forOp.getInductionVar());
+      else
+        it->linkNewScope(forOp.getInductionVar());
       SmallVector<Value> ret = bodyBuilder(rewriter, loc, forOp.getBodyRegion(),
                                            it, forOp.getRegionIterArgs());
 

--- a/mlir/test/Dialect/SparseTensor/sparse_iteration_to_scf.mlir
+++ b/mlir/test/Dialect/SparseTensor/sparse_iteration_to_scf.mlir
@@ -50,3 +50,18 @@ func.func @sparse_iteration_to_scf(%sp : tensor<4x8xf32, #COO>) -> index {
   }
   return %r1 : index
 }
+
+#DenseCompressed = #sparse_tensor.encoding<{
+  map = (d0, d1) -> (d0 : dense, d1 : compressed)
+}>
+
+// CHECK-LABEL:   @sparse_iteration_dense_level
+// CHECK:           scf.for
+func.func @sparse_iteration_dense_level(%sp: tensor<?x?xf64, #DenseCompressed>) {
+  %0 = sparse_tensor.extract_iteration_space %sp lvls = 0
+      : tensor<?x?xf64, #DenseCompressed> -> !sparse_tensor.iter_space<#DenseCompressed, lvls = 0>
+  sparse_tensor.iterate %it in %0 at(%i)
+      : !sparse_tensor.iter_space<#DenseCompressed, lvls = 0> {
+  }
+  return
+}


### PR DESCRIPTION
Fixes #205980.

`lower-sparse-iteration-to-scf` always called `linkNewScope()` when lowering
  iterators handled by `scf.for`. Dense levels are random-access iterators, and
  `linkNewScope()` asserts for random-access iterators because those should be
  traversed by coordinate.

  Use `locate()` for random-access iterators and keep `linkNewScope()` for
  non-random-access iterators.

  Verification:
  - `cmake --build /tmp/mlir-208198 --target mlir-opt`
  - `/tmp/mlir-208198/bin/mlir-opt -lower-sparse-iteration-to-scf /tmp/issue-
  205980.mlir`
  - `/tmp/mlir-208198/bin/llvm-lit -sv mlir/test/Dialect/SparseTensor/
  sparse_iteration_to_scf.mlir mlir/test/Dialect/SparseTensor/
  sparse_kernels_to_iterator.mlir mlir/test/Dialect/SparseTensor/
  sparse_space_collapse.mlir`