### PR TITLE
[ProfileData] Make FunctionSamples profile-format flags atomic

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -30,6 +30,7 @@
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/MathExtras.h"
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <list>
 #include <map>
@@ -1333,24 +1334,26 @@ public:
                       const HashKeyMap<DenseMap, FunctionId, FunctionId>
                           *FuncNameToProfNameMap = nullptr) const;
 
-  LLVM_ABI static bool ProfileIsProbeBased;
-
-  LLVM_ABI static bool ProfileIsCS;
-
-  LLVM_ABI static bool ProfileIsPreInlined;
-
   SampleContext &getContext() const { return Context; }
 
   void setContext(const SampleContext &FContext) { Context = FContext; }
 
+  // These boolean variables are atomic so that parallel in-process ThinLTO
+  // backends writing the same value do not race.
+  LLVM_ABI static std::atomic<bool> ProfileIsProbeBased;
+
+  LLVM_ABI static std::atomic<bool> ProfileIsCS;
+
+  LLVM_ABI static std::atomic<bool> ProfileIsPreInlined;
+
   /// Whether the profile uses MD5 to represent string.
-  LLVM_ABI static bool UseMD5;
+  LLVM_ABI static std::atomic<bool> UseMD5;
 
   /// Whether the profile contains any ".__uniq." suffix in a name.
-  LLVM_ABI static bool HasUniqSuffix;
+  LLVM_ABI static std::atomic<bool> HasUniqSuffix;
 
   /// If this profile uses flow sensitive discriminators.
-  LLVM_ABI static bool ProfileIsFS;
+  LLVM_ABI static std::atomic<bool> ProfileIsFS;
 
   /// GUIDToFuncNameMap saves the mapping from GUID to the symbol name, for
   /// all the function symbols defined or declared in current module.

--- a/llvm/lib/ProfileData/SampleProf.cpp
+++ b/llvm/lib/ProfileData/SampleProf.cpp
@@ -43,12 +43,12 @@ static cl::opt<bool> GenerateMergedBaseProfiles(
 
 namespace llvm {
 namespace sampleprof {
-bool FunctionSamples::ProfileIsProbeBased = false;
-bool FunctionSamples::ProfileIsCS = false;
-bool FunctionSamples::ProfileIsPreInlined = false;
-bool FunctionSamples::UseMD5 = false;
-bool FunctionSamples::HasUniqSuffix = true;
-bool FunctionSamples::ProfileIsFS = false;
+std::atomic<bool> FunctionSamples::ProfileIsProbeBased;
+std::atomic<bool> FunctionSamples::ProfileIsCS;
+std::atomic<bool> FunctionSamples::ProfileIsPreInlined;
+std::atomic<bool> FunctionSamples::UseMD5;
+std::atomic<bool> FunctionSamples::HasUniqSuffix = true;
+std::atomic<bool> FunctionSamples::ProfileIsFS;
 
 std::error_code
 serializeTypeMap(const TypeCountMap &Map,


### PR DESCRIPTION
`lld/test/ELF/lto/sample-profile.ll` is failing in ThreadSanitizer
build.

In a parallel in-process ThinLTO link, each backend thread reads the
sample profile in SampleProfileLoader::doInitialization and writes these
globals.

Make the variables std::atomic<bool> so the same-value writes are
well-defined. An architectural ideal solution that holds these states in
a container seems very intrusive.
