### PR TITLE
[CIR][NFC] Update fpclass mask checks

### DIFF
--- a/clang/test/CIR/CodeGenBuiltins/builtin-fpclassify.c
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-fpclassify.c
@@ -30,22 +30,22 @@ void test_fpclassify_nan(){
 // CIR: cir.select if %[[IS_NORMAL]] then %[[NORMAL_VAL]] else %[[SUBNORMAL_VAL]] : (!cir.bool, !s32i, !s32i) -> !s32i
 
 // LLVM: %[[VAL:.*]] = load float, ptr
-// LLVM-NEXT: %[[IS_ZERO:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 96)
+// LLVM-NEXT: %[[IS_ZERO:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (zero) */ i32 96)
 // LLVM-NEXT: br i1 %[[IS_ZERO]], label %[[BB_ZERO:.*]], label %[[BB_NOT_ZERO:.*]]
 // LLVM: [[BB_ZERO]]:
 // LLVM-NEXT: br label %[[BB_RET:.*]]
 // LLVM: [[BB_NOT_ZERO]]:
-// LLVM-NEXT: %[[IS_NAN:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 3)
+// LLVM-NEXT: %[[IS_NAN:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (nan) */ i32 3)
 // LLVM-NEXT: br i1 %[[IS_NAN]], label %[[BB_NAN:.*]], label %[[BB_NOT_NAN:.*]]
 // LLVM: [[BB_NAN]]:
 // LLVM-NEXT: br label %[[BB_MERGE1:.*]]
 // LLVM: [[BB_NOT_NAN]]:
-// LLVM-NEXT: %[[IS_INF:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 516)
+// LLVM-NEXT: %[[IS_INF:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (inf) */ i32 516)
 // LLVM-NEXT: br i1 %[[IS_INF]], label %[[BB_INF:.*]], label %[[BB_NOT_INF:.*]]
 // LLVM: [[BB_INF]]:
 // LLVM-NEXT: br label %[[BB_MERGE2:.*]]
 // LLVM: [[BB_NOT_INF]]:
-// LLVM-NEXT: %[[IS_NORMAL:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 264)
+// LLVM-NEXT: %[[IS_NORMAL:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (norm) */ i32 264)
 // LLVM-NEXT: %[[NORMAL_OR_SUBNORMAL:.*]] = select i1 %[[IS_NORMAL]], i32 264, i32 144
 // LLVM-NEXT: br label %[[BB_MERGE2]]
 // LLVM: [[BB_MERGE2]]:
@@ -99,22 +99,22 @@ void test_fpclassify_inf(){
 // CIR: cir.select if %[[IS_NORMAL]] then %[[NORMAL_VAL]] else %[[SUBNORMAL_VAL]] : (!cir.bool, !s32i, !s32i) -> !s32i
 
 // LLVM: %[[VAL:.+]] = load float, ptr
-// LLVM-NEXT: %[[IS_ZERO:.+]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 96)
+// LLVM-NEXT: %[[IS_ZERO:.+]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (zero) */ i32 96)
 // LLVM-NEXT: br i1 %[[IS_ZERO]], label %[[BB_ZERO:.+]], label %[[BB_NOT_ZERO:.+]]
 // LLVM: [[BB_ZERO]]:
 // LLVM-NEXT: br label %[[BB_RET:.+]]
 // LLVM: [[BB_NOT_ZERO]]:
-// LLVM-NEXT: %[[IS_NAN:.+]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 3)
+// LLVM-NEXT: %[[IS_NAN:.+]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (nan) */ i32 3)
 // LLVM-NEXT: br i1 %[[IS_NAN]], label %[[BB_NAN:.+]], label %[[BB_NOT_NAN:.+]]
 // LLVM: [[BB_NAN]]:
 // LLVM-NEXT: br label %[[BB_MERGE1:.+]]
 // LLVM: [[BB_NOT_NAN]]:
-// LLVM-NEXT: %[[IS_INF:.+]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 516)
+// LLVM-NEXT: %[[IS_INF:.+]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (inf) */ i32 516)
 // LLVM-NEXT: br i1 %[[IS_INF]], label %[[BB_INF:.+]], label %[[BB_NOT_INF:.+]]
 // LLVM: [[BB_INF]]:
 // LLVM-NEXT: br label %[[BB_MERGE2:.+]]
 // LLVM: [[BB_NOT_INF]]:
-// LLVM-NEXT: %[[IS_NORMAL:.+]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 264)
+// LLVM-NEXT: %[[IS_NORMAL:.+]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (norm) */ i32 264)
 // LLVM-NEXT: %[[SEL:.+]] = select i1 %[[IS_NORMAL]], i32 264, i32 144
 // LLVM-NEXT: br label %[[BB_MERGE2]]
 // LLVM: [[BB_MERGE2]]:
@@ -167,22 +167,22 @@ void test_fpclassify_normal(){
 // CIR: cir.select if %[[IS_NORMAL]] then %[[NORMAL_VAL]] else %[[SUBNORMAL_VAL]] : (!cir.bool, !s32i, !s32i) -> !s32i
 
 // LLVM: %[[VAL:.*]] = load float, ptr
-// LLVM-NEXT: %[[IS_ZERO:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 96)
+// LLVM-NEXT: %[[IS_ZERO:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (zero) */ i32 96)
 // LLVM-NEXT: br i1 %[[IS_ZERO]], label %[[BB_ZERO:.*]], label %[[BB_NOT_ZERO:.*]]
 // LLVM: [[BB_ZERO]]:
 // LLVM-NEXT: br label %[[BB_RET:.*]]
 // LLVM: [[BB_NOT_ZERO]]:
-// LLVM-NEXT: %[[IS_NAN:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 3)
+// LLVM-NEXT: %[[IS_NAN:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (nan) */ i32 3)
 // LLVM-NEXT: br i1 %[[IS_NAN]], label %[[BB_NAN:.*]], label %[[BB_NOT_NAN:.*]]
 // LLVM: [[BB_NAN]]:
 // LLVM-NEXT: br label %[[BB_MERGE1:.*]]
 // LLVM: [[BB_NOT_NAN]]:
-// LLVM-NEXT: %[[IS_INF:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 516)
+// LLVM-NEXT: %[[IS_INF:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (inf) */ i32 516)
 // LLVM-NEXT: br i1 %[[IS_INF]], label %[[BB_INF:.*]], label %[[BB_NOT_INF:.*]]
 // LLVM: [[BB_INF]]:
 // LLVM-NEXT: br label %[[BB_MERGE2:.*]]
 // LLVM: [[BB_NOT_INF]]:
-// LLVM-NEXT: %[[IS_NORMAL:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 264)
+// LLVM-NEXT: %[[IS_NORMAL:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (norm) */ i32 264)
 // LLVM-NEXT: %[[NORMAL_OR_SUBNORMAL:.*]] = select i1 %[[IS_NORMAL]], i32 264, i32 144
 // LLVM-NEXT: br label %[[BB_MERGE2]]
 // LLVM: [[BB_MERGE2]]:
@@ -236,22 +236,22 @@ void test_fpclassify_subnormal(){
 // CIR: cir.select if %[[IS_NORMAL]] then %[[NORMAL_VAL]] else %[[SUBNORMAL_VAL]] : (!cir.bool, !s32i, !s32i) -> !s32i
 
 // LLVM: %[[VAL:.*]] = load float, ptr
-// LLVM-NEXT: %[[IS_ZERO:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 96)
+// LLVM-NEXT: %[[IS_ZERO:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (zero) */ i32 96)
 // LLVM-NEXT: br i1 %[[IS_ZERO]], label %[[BB_ZERO:.*]], label %[[BB_NOT_ZERO:.*]]
 // LLVM: [[BB_ZERO]]:
 // LLVM-NEXT: br label %[[BB_RET:.*]]
 // LLVM: [[BB_NOT_ZERO]]:
-// LLVM-NEXT: %[[IS_NAN:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 3)
+// LLVM-NEXT: %[[IS_NAN:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (nan) */ i32 3)
 // LLVM-NEXT: br i1 %[[IS_NAN]], label %[[BB_NAN:.*]], label %[[BB_NOT_NAN:.*]]
 // LLVM: [[BB_NAN]]:
 // LLVM-NEXT: br label %[[BB_MERGE1:.*]]
 // LLVM: [[BB_NOT_NAN]]:
-// LLVM-NEXT: %[[IS_INF:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 516)
+// LLVM-NEXT: %[[IS_INF:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (inf) */ i32 516)
 // LLVM-NEXT: br i1 %[[IS_INF]], label %[[BB_INF:.*]], label %[[BB_NOT_INF:.*]]
 // LLVM: [[BB_INF]]:
 // LLVM-NEXT: br label %[[BB_MERGE2:.*]]
 // LLVM: [[BB_NOT_INF]]:
-// LLVM-NEXT: %[[IS_NORMAL:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 264)
+// LLVM-NEXT: %[[IS_NORMAL:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (norm) */ i32 264)
 // LLVM-NEXT: %[[NORMAL_OR_SUBNORMAL:.*]] = select i1 %[[IS_NORMAL]], i32 264, i32 144
 // LLVM-NEXT: br label %[[BB_MERGE2]]
 // LLVM: [[BB_MERGE2]]:
@@ -305,22 +305,22 @@ void test_fpclassify_zero(){
 // CIR: cir.select if %[[IS_NORMAL]] then %[[NORMAL_VAL]] else %[[SUBNORMAL_VAL]] : (!cir.bool, !s32i, !s32i) -> !s32i
 
 // LLVM: %[[VAL:.*]] = load float, ptr
-// LLVM-NEXT: %[[IS_ZERO:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 96)
+// LLVM-NEXT: %[[IS_ZERO:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (zero) */ i32 96)
 // LLVM-NEXT: br i1 %[[IS_ZERO]], label %[[BB_ZERO:.*]], label %[[BB_NOT_ZERO:.*]]
 // LLVM: [[BB_ZERO]]:
 // LLVM-NEXT: br label %[[BB_RET:.*]]
 // LLVM: [[BB_NOT_ZERO]]:
-// LLVM-NEXT: %[[IS_NAN:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 3)
+// LLVM-NEXT: %[[IS_NAN:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (nan) */ i32 3)
 // LLVM-NEXT: br i1 %[[IS_NAN]], label %[[BB_NAN:.*]], label %[[BB_NOT_NAN:.*]]
 // LLVM: [[BB_NAN]]:
 // LLVM-NEXT: br label %[[BB_MERGE1:.*]]
 // LLVM: [[BB_NOT_NAN]]:
-// LLVM-NEXT: %[[IS_INF:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 516)
+// LLVM-NEXT: %[[IS_INF:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (inf) */ i32 516)
 // LLVM-NEXT: br i1 %[[IS_INF]], label %[[BB_INF:.*]], label %[[BB_NOT_INF:.*]]
 // LLVM: [[BB_INF]]:
 // LLVM-NEXT: br label %[[BB_MERGE2:.*]]
 // LLVM: [[BB_NOT_INF]]:
-// LLVM-NEXT: %[[IS_NORMAL:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], i32 264)
+// LLVM-NEXT: %[[IS_NORMAL:.*]] = call i1 @llvm.is.fpclass.f32(float %[[VAL]], /* (norm) */ i32 264)
 // LLVM-NEXT: %[[NORMAL_OR_SUBNORMAL:.*]] = select i1 %[[IS_NORMAL]], i32 264, i32 144
 // LLVM-NEXT: br label %[[BB_MERGE2]]
 // LLVM: [[BB_MERGE2]]:

--- a/clang/test/CIR/CodeGenBuiltins/builtin-isfpclass.c
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-isfpclass.c
@@ -11,60 +11,60 @@ void test_is_finite(__fp16 *H, float F, double D, long double LD) {
     volatile int res;
     res = __builtin_isinf(*H);
     // CIR: cir.is_fp_class %{{.*}}, "fcInf" : (!cir.f16) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f16(half {{.*}}, i32 516)
-    // OGCG: call i1 @llvm.is.fpclass.f16(half {{.*}}, i32 516)
+    // LLVM: call i1 @llvm.is.fpclass.f16(half {{.*}}, /* (inf) */ i32 516)
+    // OGCG: call i1 @llvm.is.fpclass.f16(half {{.*}}, /* (inf) */ i32 516)
 
     res = __builtin_isinf(F);
     // CIR: cir.is_fp_class %{{.*}}, "fcInf" : (!cir.float) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 516)
-    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 516)
+    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (inf) */ i32 516)
+    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (inf) */ i32 516)
 
     res = __builtin_isinf(D);
     // CIR: cir.is_fp_class %{{.*}}, "fcInf" : (!cir.double) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f64(double {{.*}}, i32 516)
-    // OGCG: call i1 @llvm.is.fpclass.f64(double {{.*}}, i32 516)
+    // LLVM: call i1 @llvm.is.fpclass.f64(double {{.*}}, /* (inf) */ i32 516)
+    // OGCG: call i1 @llvm.is.fpclass.f64(double {{.*}}, /* (inf) */ i32 516)
 
     res = __builtin_isinf(LD);
     // CIR: cir.is_fp_class %{{.*}}, "fcInf" : (!cir.long_double<!cir.f80>) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f80(x86_fp80 {{.*}}, i32 516)
-    // OGCG: call i1 @llvm.is.fpclass.f80(x86_fp80 {{.*}}, i32 516)
+    // LLVM: call i1 @llvm.is.fpclass.f80(x86_fp80 {{.*}}, /* (inf) */ i32 516)
+    // OGCG: call i1 @llvm.is.fpclass.f80(x86_fp80 {{.*}}, /* (inf) */ i32 516)
 
     res = __builtin_isfinite(*H);
     // CIR: cir.is_fp_class %{{.*}}, "fcFinite" : (!cir.f16) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f16(half {{.*}}, i32 504)
-    // OGCG: call i1 @llvm.is.fpclass.f16(half {{.*}}, i32 504)
+    // LLVM: call i1 @llvm.is.fpclass.f16(half {{.*}}, /* (zero sub norm) */ i32 504)
+    // OGCG: call i1 @llvm.is.fpclass.f16(half {{.*}}, /* (zero sub norm) */ i32 504)
 
     res = __builtin_isfinite(F);
     // CIR: cir.is_fp_class %{{.*}}, "fcFinite" : (!cir.float) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 504)
-    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 504)
+    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (zero sub norm) */ i32 504)
+    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (zero sub norm) */ i32 504)
 
     res = finite(D);
     // CIR: cir.is_fp_class %{{.*}}, "fcFinite" : (!cir.double) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f64(double {{.*}}, i32 504)
-    // OGCG: call i1 @llvm.is.fpclass.f64(double %20, i32 504)
+    // LLVM: call i1 @llvm.is.fpclass.f64(double {{.*}}, /* (zero sub norm) */ i32 504)
+    // OGCG: call i1 @llvm.is.fpclass.f64(double %20, /* (zero sub norm) */ i32 504)
     res = __builtin_isnormal(*H);
     // CIR: cir.is_fp_class %{{.*}}, "fcNormal" : (!cir.f16) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f16(half {{.*}}, i32 264)
-    // OGCG: call i1 @llvm.is.fpclass.f16(half {{.*}}, i32 264)
+    // LLVM: call i1 @llvm.is.fpclass.f16(half {{.*}}, /* (norm) */ i32 264)
+    // OGCG: call i1 @llvm.is.fpclass.f16(half {{.*}}, /* (norm) */ i32 264)
 
     res = __builtin_isnormal(F);
     // CIR: cir.is_fp_class %{{.*}}, "fcNormal" : (!cir.float) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 264)
-    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 264)
+    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (norm) */ i32 264)
+    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (norm) */ i32 264)
 
     res = __builtin_issubnormal(F);
     // CIR: cir.is_fp_class %{{.*}}, "fcSubnormal" : (!cir.float) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 144)
-    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 144)
+    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (sub) */ i32 144)
+    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (sub) */ i32 144)
     res = __builtin_iszero(F);
     // CIR: cir.is_fp_class %{{.*}}, "fcZero" : (!cir.float) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 96)
-    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 96)
+    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (zero) */ i32 96)
+    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (zero) */ i32 96)
     res = __builtin_issignaling(F);
     // CIR: cir.is_fp_class %{{.*}}, fcSNan : (!cir.float) -> !cir.bool
-    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 1)
-    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 1)
+    // LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (snan) */ i32 1)
+    // OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (snan) */ i32 1)
 }
 
 _Bool check_isfpclass_finite(float x) {
@@ -74,9 +74,9 @@ _Bool check_isfpclass_finite(float x) {
 // CIR: cir.func {{.*}}@check_isfpclass_finite
 // CIR: cir.is_fp_class %{{.*}}, "fcFinite" : (!cir.float)
 // LLVM: @check_isfpclass_finite
-// LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 504)
+// LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (zero sub norm) */ i32 504)
 // OGCG: @check_isfpclass_finite
-// OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 504)
+// OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (zero sub norm) */ i32 504)
 
 _Bool check_isfpclass_nan_f32(float x) {
   return __builtin_isfpclass(x, 3 /*NaN*/);
@@ -85,9 +85,9 @@ _Bool check_isfpclass_nan_f32(float x) {
 // CIR: cir.func {{.*}}@check_isfpclass_nan_f32
 // CIR: cir.is_fp_class %{{.*}}, "fcNan" : (!cir.float)
 // LLVM: @check_isfpclass_nan_f32
-// LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 3)
+// LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (nan) */ i32 3)
 // OGCG: @check_isfpclass_nan_f32
-// OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 3)
+// OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (nan) */ i32 3)
 
 
 _Bool check_isfpclass_snan_f64(double x) {
@@ -97,9 +97,9 @@ _Bool check_isfpclass_snan_f64(double x) {
 // CIR: cir.func {{.*}}@check_isfpclass_snan_f64
 // CIR: cir.is_fp_class %{{.*}}, fcSNan : (!cir.double)
 // LLVM: @check_isfpclass_snan_f64
-// LLVM: call i1 @llvm.is.fpclass.f64(double {{.*}}, i32 1)
+// LLVM: call i1 @llvm.is.fpclass.f64(double {{.*}}, /* (snan) */ i32 1)
 // OGCG: @check_isfpclass_snan_f64
-// OGCG: call i1 @llvm.is.fpclass.f64(double {{.*}}, i32 1)
+// OGCG: call i1 @llvm.is.fpclass.f64(double {{.*}}, /* (snan) */ i32 1)
 
 
 _Bool check_isfpclass_zero_f16(_Float16 x) {
@@ -109,9 +109,9 @@ _Bool check_isfpclass_zero_f16(_Float16 x) {
 // CIR: cir.func {{.*}}@check_isfpclass_zero_f16
 // CIR: cir.is_fp_class %{{.*}}, "fcZero" : (!cir.f16)
 // LLVM: @check_isfpclass_zero_f16
-// LLVM: call i1 @llvm.is.fpclass.f16(half {{.*}}, i32 96)
+// LLVM: call i1 @llvm.is.fpclass.f16(half {{.*}}, /* (zero) */ i32 96)
 // OGCG: @check_isfpclass_zero_f16
-// OGCG: call i1 @llvm.is.fpclass.f16(half {{.*}}, i32 96)
+// OGCG: call i1 @llvm.is.fpclass.f16(half {{.*}}, /* (zero) */ i32 96)
 
 _Bool check_isfpclass_snan_neginf(double x) {
   return __builtin_isfpclass(x, 5 /*fcSNan|fcNegInf*/);
@@ -120,9 +120,9 @@ _Bool check_isfpclass_snan_neginf(double x) {
 // CIR: cir.func {{.*}}@check_isfpclass_snan_neginf
 // CIR: cir.is_fp_class %{{.*}}, "fcSNan|fcNegInf" : (!cir.double)
 // LLVM: @check_isfpclass_snan_neginf
-// LLVM: call i1 @llvm.is.fpclass.f64(double {{.*}}, i32 5)
+// LLVM: call i1 @llvm.is.fpclass.f64(double {{.*}}, /* (snan ninf) */ i32 5)
 // OGCG: @check_isfpclass_snan_neginf
-// OGCG: call i1 @llvm.is.fpclass.f64(double {{.*}}, i32 5)
+// OGCG: call i1 @llvm.is.fpclass.f64(double {{.*}}, /* (snan ninf) */ i32 5)
 
 _Bool check_isfpclass_multi(float x) {
   return __builtin_isfpclass(x, 1022 /*all but fcSNan (fcQNan still set)*/);
@@ -131,9 +131,9 @@ _Bool check_isfpclass_multi(float x) {
 // CIR: cir.func {{.*}}@check_isfpclass_multi
 // CIR: cir.is_fp_class %{{.*}}, "fcNegative|fcPositive|fcQNan" : (!cir.float)
 // LLVM: @check_isfpclass_multi
-// LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 1022)
+// LLVM: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (qnan inf zero sub norm) */ i32 1022)
 // OGCG: @check_isfpclass_multi
-// OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, i32 1022)
+// OGCG: call i1 @llvm.is.fpclass.f32(float {{.*}}, /* (qnan inf zero sub norm) */ i32 1022)
 
 // Update when we support FP pragma in functions and can convert BoolType in prvalue to i1.
 

--- a/clang/test/CIR/CodeGenBuiltins/builtin-isinf-sign.c
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-isinf-sign.c
@@ -19,7 +19,7 @@ int test_float_isinf_sign(float x) {
 
   // LLVM-LABEL: test_float_isinf_sign
   // LLVM: %[[ARG:.*]] = load float, ptr %{{.*}}
-  // LLVM: %[[IS_INF:.*]] = call i1 @llvm.is.fpclass.f32(float %[[ARG]], i32 516)
+  // LLVM: %[[IS_INF:.*]] = call i1 @llvm.is.fpclass.f32(float %[[ARG]], /* (inf) */ i32 516)
   // LLVM: %[[BITCAST:.*]] = bitcast float %[[ARG]] to i32
   // LLVM: %[[IS_NEG:.*]] = icmp slt i32 %[[BITCAST]], 0
   // LLVM: %[[SIGN:.*]] = select i1 %[[IS_NEG]], i32 -1, i32 1


### PR DESCRIPTION
I updated the CIR checks to match the formatted `llvm.is.fpclass` masks introduced by #207653. This fixes the three CIR test failures that became visible after #208919 restored the CIR build.