### PR TITLE
[SelectionDAG] Add GET_ACTIVE_LANE_MASK to ComputeNumSignBits

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5225,6 +5225,12 @@ unsigned SelectionDAG::ComputeNumSignBits(SDValue Op, const APInt &DemandedElts,
       return VTBits;
     break;
   }
+  case ISD::GET_ACTIVE_LANE_MASK:
+    // Semantically similar to icmp ult.
+    if (TLI->getBooleanContents(VT.isVector(), /*isFloat=*/false) ==
+        TargetLowering::ZeroOrNegativeOneBooleanContent)
+      return VTBits;
+    break;
   case ISD::ROTL:
   case ISD::ROTR:
     Tmp = ComputeNumSignBits(Op.getOperand(0), DemandedElts, Depth + 1);

--- a/llvm/test/CodeGen/AArch64/fold-sext-in-reg-predicate-fixed-length.ll
+++ b/llvm/test/CodeGen/AArch64/fold-sext-in-reg-predicate-fixed-length.ll
@@ -18,7 +18,7 @@ entry:
   ret <16 x i8> %data
 }
 
-define void @active_lane_mask_mstore_vscaleX2(ptr %p, i64 %n) #0 {
+define void @active_lane_mask_mstore_vscaleX2(ptr %p, i64 %n) vscale_range(2,2) {
 ; CHECK-LABEL: active_lane_mask_mstore_vscaleX2:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    whilelo p0.b, xzr, x1
@@ -32,7 +32,7 @@ entry:
   ret void
 }
 
-define void @active_lane_mask_mstore_vscaleX4(ptr %p, i64 %n) #1 {
+define void @active_lane_mask_mstore_vscaleX4(ptr %p, i64 %n) vscale_range(4,4) {
 ; CHECK-LABEL: active_lane_mask_mstore_vscaleX4:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    whilelo p0.b, xzr, x1
@@ -45,6 +45,3 @@ define void @active_lane_mask_mstore_vscaleX4(ptr %p, i64 %n) #1 {
   call void @llvm.masked.store.v16i32.p0(<16 x i32> splat(i32 123), ptr %p, <16 x i1> %mask)
   ret void
 }
-
-attributes #0 = { vscale_range(2,2) }
-attributes #1 = { vscale_range(4,4) }

--- a/llvm/test/CodeGen/AArch64/fold-sext-in-reg-predicate-fixed-length.ll
+++ b/llvm/test/CodeGen/AArch64/fold-sext-in-reg-predicate-fixed-length.ll
@@ -17,3 +17,44 @@ entry:
   %data = call <16 x i8> @llvm.masked.load.v16i8.p0(ptr %p, i32 1, <16 x i1> %mask, <16 x i8> zeroinitializer)
   ret <16 x i8> %data
 }
+
+define void @active_lane_mask_mstore_vscaleX2(ptr %p, i64 %n) #0 {
+; CHECK-LABEL: active_lane_mask_mstore_vscaleX2:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    whilelo p0.b, xzr, x1
+; CHECK-NEXT:    mov z0.b, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    ptrue p0.h
+; CHECK-NEXT:    uunpklo z0.h, z0.b
+; CHECK-NEXT:    lsl z0.h, z0.h, #15
+; CHECK-NEXT:    asr z0.h, z0.h, #15
+; CHECK-NEXT:    cmpne p1.h, p0/z, z0.h, #0
+; CHECK-NEXT:    mov z0.h, #123 // =0x7b
+; CHECK-NEXT:    st1h { z0.h }, p1, [x0]
+; CHECK-NEXT:    ret
+entry:
+  %mask = call <16 x i1> @llvm.get.active.lane.mask.v16i1(i64 0, i64 %n)
+  call void @llvm.masked.store.v16i16.p0(<16 x i16> splat(i16 123), ptr %p, <16 x i1> %mask)
+  ret void
+}
+
+define void @active_lane_mask_mstore_vscaleX4(ptr %p, i64 %n) #1 {
+; CHECK-LABEL: active_lane_mask_mstore_vscaleX4:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    whilelo p0.b, xzr, x1
+; CHECK-NEXT:    mov z0.b, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    uunpklo z0.h, z0.b
+; CHECK-NEXT:    uunpklo z0.s, z0.h
+; CHECK-NEXT:    lsl z0.s, z0.s, #31
+; CHECK-NEXT:    asr z0.s, z0.s, #31
+; CHECK-NEXT:    cmpne p1.s, p0/z, z0.s, #0
+; CHECK-NEXT:    mov z0.s, #123 // =0x7b
+; CHECK-NEXT:    st1w { z0.s }, p1, [x0]
+; CHECK-NEXT:    ret
+  %mask =  call <16 x i1> @llvm.get.active.lane.mask.v16i1.i64(i64 0, i64 %n)
+  call void @llvm.masked.store.v16i32.p0(<16 x i32> splat(i32 123), ptr %p, <16 x i1> %mask)
+  ret void
+}
+
+attributes #0 = { vscale_range(2,2) }
+attributes #1 = { vscale_range(4,4) }

--- a/llvm/test/CodeGen/AArch64/fold-sext-in-reg-predicate-fixed-length.ll
+++ b/llvm/test/CodeGen/AArch64/fold-sext-in-reg-predicate-fixed-length.ll
@@ -22,14 +22,9 @@ define void @active_lane_mask_mstore_vscaleX2(ptr %p, i64 %n) #0 {
 ; CHECK-LABEL: active_lane_mask_mstore_vscaleX2:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    whilelo p0.b, xzr, x1
-; CHECK-NEXT:    mov z0.b, p0/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    ptrue p0.h
-; CHECK-NEXT:    uunpklo z0.h, z0.b
-; CHECK-NEXT:    lsl z0.h, z0.h, #15
-; CHECK-NEXT:    asr z0.h, z0.h, #15
-; CHECK-NEXT:    cmpne p1.h, p0/z, z0.h, #0
 ; CHECK-NEXT:    mov z0.h, #123 // =0x7b
-; CHECK-NEXT:    st1h { z0.h }, p1, [x0]
+; CHECK-NEXT:    punpklo p0.h, p0.b
+; CHECK-NEXT:    st1h { z0.h }, p0, [x0]
 ; CHECK-NEXT:    ret
 entry:
   %mask = call <16 x i1> @llvm.get.active.lane.mask.v16i1(i64 0, i64 %n)
@@ -41,15 +36,10 @@ define void @active_lane_mask_mstore_vscaleX4(ptr %p, i64 %n) #1 {
 ; CHECK-LABEL: active_lane_mask_mstore_vscaleX4:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    whilelo p0.b, xzr, x1
-; CHECK-NEXT:    mov z0.b, p0/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    uunpklo z0.h, z0.b
-; CHECK-NEXT:    uunpklo z0.s, z0.h
-; CHECK-NEXT:    lsl z0.s, z0.s, #31
-; CHECK-NEXT:    asr z0.s, z0.s, #31
-; CHECK-NEXT:    cmpne p1.s, p0/z, z0.s, #0
 ; CHECK-NEXT:    mov z0.s, #123 // =0x7b
-; CHECK-NEXT:    st1w { z0.s }, p1, [x0]
+; CHECK-NEXT:    punpklo p0.h, p0.b
+; CHECK-NEXT:    punpklo p0.h, p0.b
+; CHECK-NEXT:    st1w { z0.s }, p0, [x0]
 ; CHECK-NEXT:    ret
   %mask =  call <16 x i1> @llvm.get.active.lane.mask.v16i1.i64(i64 0, i64 %n)
   call void @llvm.masked.store.v16i32.p0(<16 x i32> splat(i32 123), ptr %p, <16 x i1> %mask)

--- a/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
@@ -134,11 +134,11 @@ TEST_F(AArch64SelectionDAGTest, ComputeNumSignBits_GET_ACTIVE_LANE_MASK) {
   // bits.
   SDLoc Loc;
   const TargetLowering &TLI = DAG->getTargetLoweringInfo();
-  auto MaskVT =
+  EVT MaskVT =
       TLI.getSetCCResultType(DAG->getDataLayout(), Context, MVT::v8i16);
-  auto Base = DAG->getConstant(0, Loc, MVT::i64);
-  auto TripCount = DAG->getConstant(8, Loc, MVT::i64);
-  auto Op =
+  SDValue Base = DAG->getConstant(0, Loc, MVT::i64);
+  SDValue TripCount = DAG->getConstant(8, Loc, MVT::i64);
+  SDValue Op =
       DAG->getNode(ISD::GET_ACTIVE_LANE_MASK, Loc, MaskVT, Base, TripCount);
   EXPECT_EQ(DAG->ComputeNumSignBits(Op), 16u);
 }
@@ -146,17 +146,17 @@ TEST_F(AArch64SelectionDAGTest, ComputeNumSignBits_GET_ACTIVE_LANE_MASK) {
 TEST_F(AArch64SelectionDAGTest, ComputeNumSignBitsSVE_GET_ACTIVE_LANE_MASK) {
   SDLoc Loc;
   const TargetLowering &TLI = DAG->getTargetLoweringInfo();
-  auto MaskVT =
+  EVT MaskVT =
       TLI.getSetCCResultType(DAG->getDataLayout(), Context, MVT::nxv8i16);
-  auto Base = DAG->getConstant(0, Loc, MVT::i64);
-  auto TripCount = DAG->getConstant(8, Loc, MVT::i64);
-  auto Op =
+  SDValue Base = DAG->getConstant(0, Loc, MVT::i64);
+  SDValue TripCount = DAG->getConstant(8, Loc, MVT::i64);
+  SDValue Op =
       DAG->getNode(ISD::GET_ACTIVE_LANE_MASK, Loc, MaskVT, Base, TripCount);
   EXPECT_EQ(DAG->ComputeNumSignBits(Op), 1u);
 
   // Test for extended (although illegal) mask type.
-  auto OpIllegal = DAG->getNode(ISD::GET_ACTIVE_LANE_MASK, Loc, MVT::nxv8i16,
-                                Base, TripCount);
+  SDValue OpIllegal = DAG->getNode(ISD::GET_ACTIVE_LANE_MASK, Loc, MVT::nxv8i16,
+                                   Base, TripCount);
   EXPECT_EQ(DAG->ComputeNumSignBits(OpIllegal), 16u);
 }
 

--- a/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
@@ -133,24 +133,31 @@ TEST_F(AArch64SelectionDAGTest, ComputeNumSignBits_GET_ACTIVE_LANE_MASK) {
   // than i1 (e.g. v8i8) should report that all bits of each lane are sign
   // bits.
   SDLoc Loc;
-  auto Int64VT = EVT::getIntegerVT(Context, 64);
-  auto MaskVT = MVT::v8i8;
-  auto Base = DAG->getConstant(0, Loc, Int64VT);
-  auto TripCount = DAG->getConstant(8, Loc, Int64VT);
+  const TargetLowering &TLI = DAG->getTargetLoweringInfo();
+  auto MaskVT =
+      TLI.getSetCCResultType(DAG->getDataLayout(), Context, MVT::v8i16);
+  auto Base = DAG->getConstant(0, Loc, MVT::i64);
+  auto TripCount = DAG->getConstant(8, Loc, MVT::i64);
   auto Op =
       DAG->getNode(ISD::GET_ACTIVE_LANE_MASK, Loc, MaskVT, Base, TripCount);
-  EXPECT_EQ(DAG->ComputeNumSignBits(Op), 8u);
+  EXPECT_EQ(DAG->ComputeNumSignBits(Op), 16u);
 }
 
 TEST_F(AArch64SelectionDAGTest, ComputeNumSignBitsSVE_GET_ACTIVE_LANE_MASK) {
   SDLoc Loc;
-  auto Int64VT = EVT::getIntegerVT(Context, 64);
-  auto MaskVT = MVT::nxv8i16;
-  auto Base = DAG->getConstant(0, Loc, Int64VT);
-  auto TripCount = DAG->getConstant(8, Loc, Int64VT);
+  const TargetLowering &TLI = DAG->getTargetLoweringInfo();
+  auto MaskVT =
+      TLI.getSetCCResultType(DAG->getDataLayout(), Context, MVT::nxv8i16);
+  auto Base = DAG->getConstant(0, Loc, MVT::i64);
+  auto TripCount = DAG->getConstant(8, Loc, MVT::i64);
   auto Op =
       DAG->getNode(ISD::GET_ACTIVE_LANE_MASK, Loc, MaskVT, Base, TripCount);
-  EXPECT_EQ(DAG->ComputeNumSignBits(Op), 16u);
+  EXPECT_EQ(DAG->ComputeNumSignBits(Op), 1u);
+
+  // Test for extended (although illegal) mask type.
+  auto OpIllegal = DAG->getNode(ISD::GET_ACTIVE_LANE_MASK, Loc, MVT::nxv8i16,
+                                Base, TripCount);
+  EXPECT_EQ(DAG->ComputeNumSignBits(OpIllegal), 16u);
 }
 
 TEST_F(AArch64SelectionDAGTest, ComputeNumSignBits_SIGN_EXTEND_VECTOR_INREG) {

--- a/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
@@ -128,6 +128,31 @@ TEST_F(AArch64SelectionDAGTest, computeKnownBits_EXTRACT_SUBVECTOR) {
   EXPECT_TRUE(Known.isZero());
 }
 
+TEST_F(AArch64SelectionDAGTest, ComputeNumSignBits_GET_ACTIVE_LANE_MASK) {
+  // GET_ACTIVE_LANE_MASK promoted/widened to a vector integer type wider
+  // than i1 (e.g. v8i8) should report that all bits of each lane are sign
+  // bits.
+  SDLoc Loc;
+  auto Int64VT = EVT::getIntegerVT(Context, 64);
+  auto MaskVT = MVT::v8i8;
+  auto Base = DAG->getConstant(0, Loc, Int64VT);
+  auto TripCount = DAG->getConstant(8, Loc, Int64VT);
+  auto Op =
+      DAG->getNode(ISD::GET_ACTIVE_LANE_MASK, Loc, MaskVT, Base, TripCount);
+  EXPECT_EQ(DAG->ComputeNumSignBits(Op), 1u);
+}
+
+TEST_F(AArch64SelectionDAGTest, ComputeNumSignBitsSVE_GET_ACTIVE_LANE_MASK) {
+  SDLoc Loc;
+  auto Int64VT = EVT::getIntegerVT(Context, 64);
+  auto MaskVT = MVT::nxv8i16;
+  auto Base = DAG->getConstant(0, Loc, Int64VT);
+  auto TripCount = DAG->getConstant(8, Loc, Int64VT);
+  auto Op =
+      DAG->getNode(ISD::GET_ACTIVE_LANE_MASK, Loc, MaskVT, Base, TripCount);
+  EXPECT_EQ(DAG->ComputeNumSignBits(Op), 1u);
+}
+
 TEST_F(AArch64SelectionDAGTest, ComputeNumSignBits_SIGN_EXTEND_VECTOR_INREG) {
   SDLoc Loc;
   auto Int8VT = EVT::getIntegerVT(Context, 8);

--- a/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SelectionDAGTest.cpp
@@ -139,7 +139,7 @@ TEST_F(AArch64SelectionDAGTest, ComputeNumSignBits_GET_ACTIVE_LANE_MASK) {
   auto TripCount = DAG->getConstant(8, Loc, Int64VT);
   auto Op =
       DAG->getNode(ISD::GET_ACTIVE_LANE_MASK, Loc, MaskVT, Base, TripCount);
-  EXPECT_EQ(DAG->ComputeNumSignBits(Op), 1u);
+  EXPECT_EQ(DAG->ComputeNumSignBits(Op), 8u);
 }
 
 TEST_F(AArch64SelectionDAGTest, ComputeNumSignBitsSVE_GET_ACTIVE_LANE_MASK) {
@@ -150,7 +150,7 @@ TEST_F(AArch64SelectionDAGTest, ComputeNumSignBitsSVE_GET_ACTIVE_LANE_MASK) {
   auto TripCount = DAG->getConstant(8, Loc, Int64VT);
   auto Op =
       DAG->getNode(ISD::GET_ACTIVE_LANE_MASK, Loc, MaskVT, Base, TripCount);
-  EXPECT_EQ(DAG->ComputeNumSignBits(Op), 1u);
+  EXPECT_EQ(DAG->ComputeNumSignBits(Op), 16u);
 }
 
 TEST_F(AArch64SelectionDAGTest, ComputeNumSignBits_SIGN_EXTEND_VECTOR_INREG) {


### PR DESCRIPTION
`GET_ACTIVE_LANE_MASK ` acts like `icmp ult` so code is similar to `SETCC`.