### PR TITLE
[RISCV][P-ext] Replace RISCVISD::PPAIRE_DB with RISCVISD::PPAIRE. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -2074,15 +2074,12 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
     // Fall through to regular ADDD selection.
     [[fallthrough]];
   case RISCVISD::SUBD:
-  case RISCVISD::PPAIRE_DB:
   case RISCVISD::WADDAU:
   case RISCVISD::WSUBAU:
   case RISCVISD::WADDA:
   case RISCVISD::WSUBA: {
-    assert(!Subtarget->is64Bit() && "Unexpected opcode");
-    assert(
-        (Node->getOpcode() != RISCVISD::PPAIRE_DB || Subtarget->hasStdExtP()) &&
-        "Unexpected opcode");
+    assert(!Subtarget->is64Bit() && Subtarget->hasStdExtP() &&
+           "Unexpected opcode");
 
     SDValue Op0Lo = Node->getOperand(0);
     SDValue Op0Hi = Node->getOperand(1);
@@ -2132,9 +2129,6 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
         break;
       case RISCVISD::SUBD:
         Opc = RISCV::SUBD;
-        break;
-      case RISCVISD::PPAIRE_DB:
-        Opc = RISCV::PPAIRE_DB;
         break;
       }
       New = CurDAG->getMachineNode(Opc, DL, MVT::Untyped, Op0, Op1);

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -4768,11 +4768,10 @@ static SDValue lowerBUILD_VECTOR(SDValue Op, SelectionDAG &DAG,
       SDValue Lo = DAG.getExtractSubvector(DL, MVT::v4i8, PPairE, 0);
       SDValue Hi = DAG.getExtractSubvector(DL, MVT::v4i8, PPairE, 4);
 
-      return DAG.getBitcast(
-          MVT::v4i8,
-          DAG.getNode(RISCVISD::PPAIRE, DL, MVT::v2i16,
-                      DAG.getBitcast(MVT::v2i16, Lo),
-                      DAG.getBitcast(MVT::v2i16, Hi)));
+      return DAG.getBitcast(MVT::v4i8,
+                            DAG.getNode(RISCVISD::PPAIRE, DL, MVT::v2i16,
+                                        DAG.getBitcast(MVT::v2i16, Lo),
+                                        DAG.getBitcast(MVT::v2i16, Hi)));
     }
 
     llvm_unreachable("Unexpected RV32 P BUILD_VECTOR type");

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -4758,15 +4758,21 @@ static SDValue lowerBUILD_VECTOR(SDValue Op, SelectionDAG &DAG,
           DAG.getNode(ISD::SCALAR_TO_VECTOR, DL, MVT::v4i8, Op->getOperand(2));
       SDValue Val3 =
           DAG.getNode(ISD::SCALAR_TO_VECTOR, DL, MVT::v4i8, Op->getOperand(3));
-      SDValue PPairDB =
-          DAG.getNode(RISCVISD::PPAIRE_DB, DL, {MVT::v4i8, MVT::v4i8},
-                      {Val0, Val2, Val1, Val3});
+      SDValue Concat1 =
+          DAG.getNode(ISD::CONCAT_VECTORS, DL, MVT::v8i8, Val0, Val2);
+      SDValue Concat2 =
+          DAG.getNode(ISD::CONCAT_VECTORS, DL, MVT::v8i8, Val1, Val3);
+      SDValue PPairE =
+          DAG.getNode(RISCVISD::PPAIRE, DL, MVT::v8i8, Concat1, Concat2);
+
+      SDValue Lo = DAG.getExtractSubvector(DL, MVT::v4i8, PPairE, 0);
+      SDValue Hi = DAG.getExtractSubvector(DL, MVT::v4i8, PPairE, 4);
 
       return DAG.getBitcast(
           MVT::v4i8,
           DAG.getNode(RISCVISD::PPAIRE, DL, MVT::v2i16,
-                      DAG.getBitcast(MVT::v2i16, PPairDB.getValue(0)),
-                      DAG.getBitcast(MVT::v2i16, PPairDB.getValue(1))));
+                      DAG.getBitcast(MVT::v2i16, Lo),
+                      DAG.getBitcast(MVT::v2i16, Hi)));
     }
 
     llvm_unreachable("Unexpected RV32 P BUILD_VECTOR type");

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1905,15 +1905,6 @@ def SDT_RISCVMERGE : SDTypeProfile<1, 3, [SDTCisInt<0>,
                                           SDTCisSameAs<0, 3>]>;
 def riscv_merge : RVSDNode<"MERGE", SDT_RISCVMERGE>;
 
-// (rdlo, rdhi) PPAIRE_DB (rs1plo, rs1phi, rs2plo, rs2phi)
-def SDT_RISCVPPairE_DB : SDTypeProfile<2, 4, [SDTCisVT<0, v4i8>,
-                                              SDTCisSameAs<0, 1>,
-                                              SDTCisSameAs<0, 2>,
-                                              SDTCisSameAs<0, 3>,
-                                              SDTCisSameAs<0, 4>,
-                                              SDTCisSameAs<0, 5>]>;
-def riscv_ppaire_db : RVSDNode<"PPAIRE_DB", SDT_RISCVPPairE_DB>;
-
 // signed-saturating abs of each lane; an INT_MIN lane maps to INT_MAX.
 def SDT_RISCVPackedUnary : SDTypeProfile<1, 1, [SDTCisVec<0>,
                                                 SDTCisSameAs<0, 1>]>;
@@ -1921,8 +1912,8 @@ def riscv_psabs : RVSDNode<"PSABS", SDT_RISCVPackedUnary>;
 
 // Interleave two packed vectors.
 def SDT_RISCVPZip : SDTypeProfile<1, 2, [SDTCisVec<0>,
-                                          SDTCisSameAs<0, 1>,
-                                          SDTCisSameAs<0, 2>]>;
+                                         SDTCisSameAs<0, 1>,
+                                         SDTCisSameAs<0, 2>]>;
 def riscv_pzip : RVSDNode<"PZIP", SDT_RISCVPZip>;
 
 // Deinterleave the even/odd lanes of two packed vectors.
@@ -2550,6 +2541,9 @@ let append Predicates = [IsRV32] in {
 
   def : Pat<(v2i32 (build_vector (XLenVT GPR:$a), (XLenVT GPR:$b))),
             (BuildGPRPair GPR:$a, GPR:$b)>;
+
+  def : Pat<(v8i8 (riscv_ppaire GPRPair:$rs1, GPRPair:$rs2)),
+            (PPAIRE_DB GPRPair:$rs1, GPRPair:$rs2)>;
 
   // Concat vector patterns
   def : Pat<(v8i8 (concat_vectors (v4i8 GPR:$a), (v4i8 GPR:$b))),


### PR DESCRIPTION
This replaces RISCVISD::PPAIRE_DB with the RISCVISD::PPAIRE added by #208763.

This adds two CONCAT_VECTORS and two EXTRACT_SUBVECTORs during lowering instead of waiting until isel to form the GPR pairs.