### PR TITLE
[clang][bytecode] Remove EvalEmitter::OpPC

### DIFF
--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -219,7 +219,7 @@ bool EvalEmitter::speculate(const CallExpr *E, const LabelTy &EndLabel) {
 
     if (S.inConstantContext() || Arg->HasSideEffects(S.getASTContext()))
       return this->emitBool(false, E);
-    return Invalid(S, OpPC);
+    return Invalid(S, CodePtr());
   }
 
   PrimType T = Ctx.classify(Arg->getType()).value_or(PT_Ptr);
@@ -244,13 +244,14 @@ template <PrimType OpType> bool EvalEmitter::emitRet(SourceInfo Info) {
 }
 
 template <> bool EvalEmitter::emitRet<PT_Ptr>(SourceInfo Info) {
+  // llvm::errs()<< __PRETTY_FUNCTION__ << "Ret\n";
   if (!isActive())
     return true;
 
   const Pointer &Ptr = S.Stk.pop<Pointer>();
   // If we're returning a raw pointer, call our callback.
   if (this->PtrCB)
-    return (*this->PtrCB)(S, OpPC, Ptr);
+    return (*this->PtrCB)(S, CodePtr(), Ptr);
 
   if (!EvalResult.checkDynamicAllocations(S, Ctx, Ptr, Info))
     return false;
@@ -271,7 +272,7 @@ template <> bool EvalEmitter::emitRet<PT_Ptr>(SourceInfo Info) {
     if (Ptr.pointsToStringLiteral() && Ptr.isArrayRoot())
       return false;
 
-    if (!Ptr.isZero() && !CheckFinalLoad(S, OpPC, Ptr))
+    if (!Ptr.isZero() && !CheckFinalLoad(S, CodePtr(), Ptr))
       return false;
 
     // Never allow reading from a non-const pointer, unless the memory
@@ -351,7 +352,7 @@ bool EvalEmitter::emitGetRefLocal(uint32_t I, SourceInfo Info) {
     return true;
 
   Block *B = getLocal(I);
-  return handleReference(S, OpPC, B);
+  return handleReference(S, CodePtr(), B);
 }
 
 template <PrimType OpType>
@@ -363,7 +364,7 @@ bool EvalEmitter::emitGetLocal(uint32_t I, SourceInfo Info) {
 
   Block *B = getLocal(I);
 
-  if (!CheckLocalLoad(S, OpPC, B))
+  if (!CheckLocalLoad(S, CodePtr(), B))
     return false;
 
   S.Stk.push<T>(B->deref<T>());

--- a/clang/lib/AST/ByteCode/EvalEmitter.h
+++ b/clang/lib/AST/ByteCode/EvalEmitter.h
@@ -137,9 +137,6 @@ private:
 
   void updateGlobalTemporaries();
 
-  // The emitter always tracks the current instruction and sets OpPC to a token
-  // value which is mapped to the location of the opcode being evaluated.
-  CodePtr OpPC;
   /// Location of the current instruction.
   SourceInfo CurrentSource;
 

--- a/clang/utils/TableGen/ClangOpcodesEmitter.cpp
+++ b/clang/utils/TableGen/ClangOpcodesEmitter.cpp
@@ -444,7 +444,7 @@ void ClangOpcodesEmitter::EmitEval(raw_ostream &OS, StringRef N,
                 PrintTypes(OS, TS);
                 OS << "(S";
                 if (PassOpPC)
-                  OS << ", OpPC";
+                  OS << ", CodePtr()";
                 for (size_t I = 0, N = Args.size(); I < N; ++I)
                   OS << ", A" << I;
                 OS << ");\n";


### PR DESCRIPTION
We pass this when evaluting opcodes in EvalEmitter, but we never set it to anything, so the underlying pointer is always null and we later and up using the source location of the expression we're evaluating.

This seems to only cause problems when Statement expressions are involved so far.