### PR TITLE
[SPARC] Support the .seg directive

### DIFF
--- a/llvm/lib/Target/Sparc/AsmParser/SparcAsmParser.cpp
+++ b/llvm/lib/Target/Sparc/AsmParser/SparcAsmParser.cpp
@@ -39,6 +39,7 @@
 #include <cassert>
 #include <cstdint>
 #include <memory>
+#include <string>
 
 using namespace llvm;
 
@@ -1042,6 +1043,27 @@ ParseStatus SparcAsmParser::parseDirective(AsmToken DirectiveID) {
     // For compatibility, ignore this directive.
     // (It's supposed to be an "optimization" in the Sun assembler)
     Parser.eatToEndOfStatement();
+    return ParseStatus::Success;
+  }
+  if (IDVal == ".seg") {
+    std::string Name;
+    if (Parser.parseEscapedString(Name) || Parser.parseEOL())
+      return ParseStatus::Failure;
+
+    MCSection *Section;
+    uint32_t Subsection = 0;
+    const MCObjectFileInfo *MCOFI = getContext().getObjectFileInfo();
+    if (Name == "text") {
+      Section = MCOFI->getTextSection();
+    } else if (Name == "data" || Name == "data1") {
+      Section = MCOFI->getDataSection();
+      Subsection = Name == "data1" ? 1 : 0;
+    } else if (Name == "bss") {
+      Section = MCOFI->getBSSSection();
+    } else {
+      return Error(DirectiveID.getLoc(), "unknown segment type");
+    }
+    getStreamer().switchSection(Section, Subsection);
     return ParseStatus::Success;
   }
 

--- a/llvm/test/MC/Sparc/Directives/seg.s
+++ b/llvm/test/MC/Sparc/Directives/seg.s
@@ -1,0 +1,36 @@
+! RUN: llvm-mc -triple=sparc -filetype=obj %s -o - \
+! RUN:   | llvm-readobj -S --sd - | FileCheck %s
+! RUN: llvm-mc -triple=sparcv9 -filetype=obj %s -o - \
+! RUN:   | llvm-readobj -S --sd - | FileCheck %s
+! RUN: not llvm-mc -triple=sparc --defsym ERR=1 %s -o /dev/null 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=ERR --implicit-check-not=error:
+
+! CHECK:      Name: .text
+! CHECK:      SectionData (
+! CHECK-NEXT:   0000: 01
+
+! CHECK:      Name: .data
+! CHECK:      SectionData (
+! CHECK-NEXT:   0000: 02030405
+
+! CHECK:      Name: .bss
+! CHECK-NEXT: Type: SHT_NOBITS
+! CHECK:      Size: 6
+
+.seg "data1"
+.byte 4
+.seg "data"
+.byte 2
+.seg "text"
+.byte 1
+.seg "data1"
+.byte 5
+.seg "data"
+.byte 3
+.seg "bss"
+.zero 6
+
+.ifdef ERR
+! ERR: :[[#@LINE+1]]:1: error: unknown segment type
+.seg "rodata"
+.endif


### PR DESCRIPTION
Support the legacy .seg directive used by SunOS SPARC assembly. Map "text", "data", "data1", and "bss" to their corresponding MC sections, using subsection 1 for "data1".