### PR TITLE
Revert "[VPlan] Re-use VPSlotTracker when printing recipes for costs (NFC)."

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -3161,8 +3161,7 @@ void LoopVectorizationPlanner::emitInvalidCostRemarks(
         continue;
 
       VPCostContext CostCtx(CM.TTI, *CM.TLI, *Plan, CM, Config.CostKind, CM.PSE,
-                            OrigLoop,
-                            std::make_unique<VPSlotTracker>(Plan.get()));
+                            OrigLoop);
       precomputeCosts(*Plan, VF, CostCtx);
       auto Iter = vp_depth_first_deep(Plan->getVectorLoopRegion()->getEntry());
       for (VPBasicBlock *VPBB : VPBlockUtils::blocksOnly<VPBasicBlock>(Iter)) {
@@ -5756,7 +5755,7 @@ LoopVectorizationPlanner::precomputeCosts(VPlan &Plan, ElementCount VF,
 InstructionCost LoopVectorizationPlanner::cost(VPlan &Plan, ElementCount VF,
                                                VPRegisterUsage *RU) const {
   VPCostContext CostCtx(CM.TTI, *CM.TLI, Plan, CM, Config.CostKind, PSE,
-                        OrigLoop, std::make_unique<VPSlotTracker>(&Plan));
+                        OrigLoop);
   InstructionCost Cost = precomputeCosts(Plan, VF, CostCtx);
 
   // Now compute and add the VPlan-based cost.
@@ -8116,8 +8115,7 @@ bool LoopVectorizePass::processLoop(Loop *L) {
     bool ForceVectorization =
         Hints.getForce() == LoopVectorizeHints::FK_Enabled;
     VPCostContext CostCtx(CM.TTI, *CM.TLI, *BestPlanPtr, CM, Config.CostKind,
-                          CM.PSE, L,
-                          std::make_unique<VPSlotTracker>(BestPlanPtr));
+                          CM.PSE, L);
     if (!ForceVectorization &&
         !isOutsideLoopWorkProfitable(Checks, VF, L, PSE, CostCtx, *BestPlanPtr,
                                      SEL, Config.getVScaleForTuning())) {

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -40,7 +40,6 @@ class Type;
 class VPBasicBlock;
 class VPRegionBlock;
 class VPlan;
-class VPSlotTracker;
 class Value;
 
 namespace Intrinsic {
@@ -336,16 +335,9 @@ struct VPCostContext {
   VPCostContext(const TargetTransformInfo &TTI, const TargetLibraryInfo &TLI,
                 const VPlan &Plan, LoopVectorizationCostModel &CM,
                 TargetTransformInfo::TargetCostKind CostKind,
-                PredicatedScalarEvolution &PSE, const Loop *L,
-                std::unique_ptr<VPSlotTracker> SlotTracker = nullptr)
+                PredicatedScalarEvolution &PSE, const Loop *L)
       : TTI(TTI), TLI(TLI), LLVMCtx(Plan.getContext()), CM(CM),
-        CostKind(CostKind), PSE(PSE), L(L)
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-        ,
-        SlotTracker(std::move(SlotTracker))
-#endif
-  {
-  }
+        CostKind(CostKind), PSE(PSE), L(L) {}
 
   /// Return the cost for \p UI with \p VF using the legacy cost model as
   /// fallback until computing the cost of all recipes migrates to VPlan.
@@ -390,15 +382,6 @@ struct VPCostContext {
   /// Returns true if \p ID is a pseudo intrinsic that is dropped via
   /// scalarization rather than widened.
   static bool isFreeScalarIntrinsic(Intrinsic::ID ID);
-
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  /// Return SlotTracker to re-use for printing, if set.
-  VPSlotTracker *getSlotTracker() const { return SlotTracker.get(); }
-
-private:
-  /// SlotTracker to re-use when printing.
-  const std::unique_ptr<VPSlotTracker> SlotTracker;
-#endif
 };
 
 /// This class can be used to assign names to VPValues. For VPValues without

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -331,12 +331,7 @@ InstructionCost VPRecipeBase::cost(ElementCount VF, VPCostContext &Ctx) {
 
   LLVM_DEBUG({
     dbgs() << "Cost of " << RecipeCost << " for VF " << VF << ": ";
-    if (auto SlotTracker = Ctx.getSlotTracker()) {
-      print(dbgs(), "", *SlotTracker);
-      dbgs() << "\n";
-    } else {
-      dump();
-    }
+    dump();
   });
   return RecipeCost;
 }


### PR DESCRIPTION
Reverts llvm/llvm-project#203386.

This causes a large compile-time regression.