### PR TITLE
[orc-rt] Add printf logging backend

### DIFF
--- a/orc-rt/include/orc-rt-c/Logging.h
+++ b/orc-rt/include/orc-rt-c/Logging.h
@@ -24,8 +24,10 @@
 |* the category enum gives typo-safe, filterable subsystems.                  *|
 |*                                                                            *|
 |* The backend is selected at build time via ORC_RT_LOG_BACKEND. The default  *|
-|* "none" backend emits no code (but still type-checks the format string and  *|
-|* arguments at every call site).                                             *|
+|* "none" backend emits no code (but still type-checks every call site). The  *|
+|* "printf" backend writes each message to stderr, or to the file named by    *|
+|* the ORC_RT_LOG_OUTPUT environment variable; the ORC_RT_LOG variable sets a *|
+|* runtime level threshold (error, warning, info, debug, or off).             *|
 |*                                                                            *|
 |* IMPORTANT: log arguments should be free of observable side effects.        *|
 |* Whether they are evaluated is backend- and level-dependent, so they must   *|
@@ -125,7 +127,53 @@ int orc_rt_log_formatCheck(const char *Fmt, ...) ORC_RT_C_FORMAT_PRINTF(1, 2);
   ORC_RT_LOG_DISABLED(Category, __VA_ARGS__)
 
 #elif ORC_RT_LOG_BACKEND == ORC_RT_LOG_BACKEND_PRINTF
-#error "The printf logging backend is not yet implemented."
+
+/**
+ * printf-backend log sink. Formats the message and writes it, prefixed with its
+ * category and level, to the logging output (stderr, or the file named by the
+ * ORC_RT_LOG_OUTPUT environment variable). Not called directly: use ORC_RT_LOG.
+ */
+void orc_rt_log_printf(orc_rt_log_Level Level, orc_rt_log_Category Category,
+                       const char *Fmt, ...) ORC_RT_C_NOTHROW
+    ORC_RT_C_FORMAT_PRINTF(3, 4);
+
+/*
+ * Each level is compiled in only if it is at or above the ORC_RT_LOG_LEVEL
+ * floor; a below-floor level expands to ORC_RT_LOG_DISABLED so it
+ * vanishes from the binary while remaining type-checked.
+ */
+#if ORC_RT_LOG_LEVEL_ERROR >= ORC_RT_LOG_LEVEL
+#define ORC_RT_LOG_Error(Category, ...)                                        \
+  orc_rt_log_printf(ORC_RT_LOG_LEVEL_ERROR, Category, __VA_ARGS__)
+#else
+#define ORC_RT_LOG_Error(Category, ...)                                        \
+  ORC_RT_LOG_DISABLED(Category, __VA_ARGS__)
+#endif
+
+#if ORC_RT_LOG_LEVEL_WARNING >= ORC_RT_LOG_LEVEL
+#define ORC_RT_LOG_Warning(Category, ...)                                      \
+  orc_rt_log_printf(ORC_RT_LOG_LEVEL_WARNING, Category, __VA_ARGS__)
+#else
+#define ORC_RT_LOG_Warning(Category, ...)                                      \
+  ORC_RT_LOG_DISABLED(Category, __VA_ARGS__)
+#endif
+
+#if ORC_RT_LOG_LEVEL_INFO >= ORC_RT_LOG_LEVEL
+#define ORC_RT_LOG_Info(Category, ...)                                         \
+  orc_rt_log_printf(ORC_RT_LOG_LEVEL_INFO, Category, __VA_ARGS__)
+#else
+#define ORC_RT_LOG_Info(Category, ...)                                         \
+  ORC_RT_LOG_DISABLED(Category, __VA_ARGS__)
+#endif
+
+#if ORC_RT_LOG_LEVEL_DEBUG >= ORC_RT_LOG_LEVEL
+#define ORC_RT_LOG_Debug(Category, ...)                                        \
+  orc_rt_log_printf(ORC_RT_LOG_LEVEL_DEBUG, Category, __VA_ARGS__)
+#else
+#define ORC_RT_LOG_Debug(Category, ...)                                        \
+  ORC_RT_LOG_DISABLED(Category, __VA_ARGS__)
+#endif
+
 #elif ORC_RT_LOG_BACKEND == ORC_RT_LOG_BACKEND_OS_LOG
 #error "The os_log logging backend is not yet implemented."
 #else

--- a/orc-rt/lib/executor/CMakeLists.txt
+++ b/orc-rt/lib/executor/CMakeLists.txt
@@ -21,6 +21,12 @@ set(files
   sps-ci/StandaloneMachOUnwindInfoRegistrarSPSCI.cpp
   )
 
+# The printf logging backend needs a runtime implementation; the none backend
+# is header-only and the os_log backend is not yet implemented.
+if(ORC_RT_LOG_BACKEND STREQUAL "printf")
+  list(APPEND files Logging_printf.cpp)
+endif()
+
 add_library(orc-rt-executor STATIC ${files})
 target_link_libraries(orc-rt-executor
   PUBLIC orc-rt-headers

--- a/orc-rt/lib/executor/Logging_printf.cpp
+++ b/orc-rt/lib/executor/Logging_printf.cpp
@@ -1,0 +1,122 @@
+//===- Logging_printf.cpp -------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementation of the printf logging backend declared in orc-rt-c/Logging.h.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt-c/Logging.h"
+
+#include <algorithm>
+#include <cstdarg>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+// The output sink, resolved once on first use: stderr, unless ORC_RT_LOG_OUTPUT
+// names a file that can be opened for appending.
+FILE *sink() {
+  static FILE *Sink = []() -> FILE * {
+    // TODO: Use a setuid/setgid-safe secure getenv (ORC runtime utility, TBD).
+    const char *Path = std::getenv("ORC_RT_LOG_OUTPUT");
+    if (!Path || !*Path)
+      return stderr;
+    FILE *F = std::fopen(Path, "a");
+    if (!F) {
+      std::fprintf(stderr,
+                   "[orc-rt:General:ERROR] could not open ORC_RT_LOG_OUTPUT "
+                   "'%s' for logging; using stderr\n",
+                   Path);
+      return stderr;
+    }
+    // Line-buffer: every message ends in a newline, so this flushes each
+    // message promptly without the cost of a fully unbuffered stream.
+    std::setvbuf(F, nullptr, _IOLBF, 0);
+    return F;
+  }();
+  return Sink;
+}
+
+// The runtime level threshold, resolved once on first use from ORC_RT_LOG. A
+// message is emitted only if its level is at or above this value. When
+// ORC_RT_LOG is unset the threshold is WARNING: warnings and errors are shown
+// by default, and info and debug are opt-in. An unrecognized value, or a level
+// below the compile-time ORC_RT_LOG_LEVEL floor, falls back to the floor,
+// but never more verbose than INFO.
+orc_rt_log_Level runtimeLevel() {
+  static orc_rt_log_Level Level = []() -> orc_rt_log_Level {
+    // TODO: Use a setuid/setgid-safe secure getenv (ORC runtime utility, TBD).
+    const char *S = std::getenv("ORC_RT_LOG");
+    if (!S || !*S)
+      return ORC_RT_LOG_LEVEL_WARNING;
+    orc_rt_log_Level L = orc_rt_log_Level_parse(S);
+
+    // Fallback for an unavailable or unrecognized request: the compile-time
+    // floor, but never more verbose than INFO.
+    constexpr orc_rt_log_Level Fallback =
+        std::max(ORC_RT_LOG_LEVEL, ORC_RT_LOG_LEVEL_INFO);
+    if (L < 0) {
+      std::fprintf(sink(),
+                   "[orc-rt:General:ERROR] ignoring unrecognized ORC_RT_LOG "
+                   "value '%s'\n",
+                   S);
+      return Fallback;
+    } else if (L < ORC_RT_LOG_LEVEL) {
+      std::fprintf(sink(),
+                   "[orc-rt:General:ERROR] requested ORC_RT_LOG = %s is "
+                   "unavailable, using lowest available level ORC_RT_LOG = "
+                   "%s\n",
+                   S, orc_rt_log_Level_getName(Fallback));
+      return Fallback;
+    }
+    return L;
+  }();
+  return Level;
+}
+
+constexpr size_t LogBufferSize = 1024;
+
+} // namespace
+
+extern "C" void orc_rt_log_printf(orc_rt_log_Level Level,
+                                  orc_rt_log_Category Category, const char *Fmt,
+                                  ...) noexcept {
+  if (Level < runtimeLevel())
+    return;
+
+  char Buf[LogBufferSize];
+  int P = std::snprintf(Buf, sizeof(Buf), "[orc-rt:%s:%s] ",
+                        orc_rt_log_Category_getName(Category),
+                        orc_rt_log_Level_getName(Level));
+  if (P < 0)
+    return;
+  size_t Len = (size_t)P < sizeof(Buf) ? (size_t)P : sizeof(Buf) - 1;
+
+  va_list Ap;
+  va_start(Ap, Fmt);
+  int B = std::vsnprintf(Buf + Len, sizeof(Buf) - Len, Fmt, Ap);
+  va_end(Ap);
+  if (B > 0) {
+    Len += (size_t)B;
+    if (Len > sizeof(Buf) - 1)
+      Len = sizeof(Buf) - 1; // message was truncated to fit the buffer
+  }
+
+  // Guarantee a trailing newline, overwriting the last byte when the buffer is
+  // full so that adjacent messages never run together.
+  if (Len == sizeof(Buf) - 1)
+    Buf[Len - 1] = '\n';
+  else
+    Buf[Len++] = '\n';
+
+  // A single stdio call: stdio locks the stream per call, so the whole line is
+  // written atomically with respect to other threads logging to the same sink.
+  std::fwrite(Buf, 1, Len, sink());
+}

--- a/orc-rt/test/CMakeLists.txt
+++ b/orc-rt/test/CMakeLists.txt
@@ -13,6 +13,7 @@ if (ORC_RT_LLVM_TOOLS_AVAILABLE)
 
   list(APPEND ORC_RT_TEST_DEPS
     orc-executor
+    orc-rt-log-check
     orc-rt-smoke-check
   )
 

--- a/orc-rt/test/regression/lit.cfg.py
+++ b/orc-rt/test/regression/lit.cfg.py
@@ -27,6 +27,7 @@ llvm_config.with_environment("PATH", test_tools_dir, append_path=True)
 
 llvm_config.use_default_substitutions()
 
+
 def run_test_tool(name, *args):
     """Run a test-support tool from test/tools and return its stdout.
 

--- a/orc-rt/test/regression/lit.cfg.py
+++ b/orc-rt/test/regression/lit.cfg.py
@@ -16,14 +16,52 @@ config.suffixes = [
     ".test"
 ]
 
+# Regression test-support tools live under test/tools.
+test_tools_dir = os.path.join(config.orc_rt_obj_root, "test", "tools")
+
 llvm_config.with_environment(
     "PATH",
     os.path.join(config.orc_rt_obj_root, "tools", "orc-executor"),
     append_path=True)
-
-# Regression test-support tools live under test/tools.
-llvm_config.with_environment(
-    "PATH", os.path.join(config.orc_rt_obj_root, "test", "tools"), append_path=True
-)
+llvm_config.with_environment("PATH", test_tools_dir, append_path=True)
 
 llvm_config.use_default_substitutions()
+
+def run_test_tool(name, *args):
+    """Run a test-support tool from test/tools and return its stdout.
+
+    Returns None if the tool has not been built yet (so feature probing degrades
+    gracefully). Raises if the tool exits with a non-zero status.
+    """
+    tool = lit.util.which(name, test_tools_dir)
+    if tool is None:
+        return None
+    out, err, exit_code = lit.util.executeCommand([tool, *args])
+    if exit_code != 0:
+        raise RuntimeError(
+            "{} {} failed (exit {}):\n{}".format(name, " ".join(args), exit_code, err)
+        )
+    return out
+
+
+# Probe the compiled-in logging configuration from orc-rt-log-check and
+# expose it as lit features, so logging tests can gate on the build's backend
+# and on which levels are actually emitted:
+#   orc-rt-log-backend-<none|printf|os_log>
+#   orc-rt-log-level-<error|warning|info|debug>   (one per compiled-in level)
+def add_logging_features():
+    backend = run_test_tool("orc-rt-log-check", "--print-backend")
+    if backend is None:
+        return  # tool not built yet; skip feature probing
+    config.available_features.add("orc-rt-log-backend-" + backend.strip())
+    levels = run_test_tool("orc-rt-log-check", "--print-enabled-levels")
+    for level in levels.split():
+        config.available_features.add("orc-rt-log-level-" + level.lower())
+
+
+add_logging_features()
+
+# Give logging tests a deterministic baseline: clear any logging environment
+# inherited from the developer's shell. Tests opt in with `env ORC_RT_LOG=...`.
+for var in ("ORC_RT_LOG", "ORC_RT_LOG_OUTPUT"):
+    config.environment.pop(var, None)

--- a/orc-rt/test/regression/logging/lit.local.cfg
+++ b/orc-rt/test/regression/logging/lit.local.cfg
@@ -1,0 +1,5 @@
+# These tests require a logging backend, which is selected at build time.
+# Skip the whole directory if no logging backend is compiled in.
+
+if "orc-rt-log-backend-none" in config.available_features:
+    config.unsupported = True

--- a/orc-rt/test/regression/logging/printf-backend/bad-level.test
+++ b/orc-rt/test/regression/logging/printf-backend/bad-level.test
@@ -1,0 +1,8 @@
+# Check that an unrecognized ORC_RT_LOG value is reported once and then ignored
+# (logging proceeds at the default threshold).
+#
+# REQUIRES: orc-rt-log-level-error
+# RUN: env ORC_RT_LOG=bogus orc-rt-log-check 2>&1 | FileCheck %s
+
+# CHECK:      [orc-rt:General:ERROR] ignoring unrecognized ORC_RT_LOG value 'bogus'
+# CHECK-NEXT: [orc-rt:General:ERROR] error message

--- a/orc-rt/test/regression/logging/printf-backend/debug-compiled-out.test
+++ b/orc-rt/test/regression/logging/printf-backend/debug-compiled-out.test
@@ -1,0 +1,12 @@
+# Check the compile-time ceiling: on a build whose ceiling is above debug, the
+# debug level is compiled out entirely, and the runtime ORC_RT_LOG variable
+# cannot resurrect it (runtime narrowing only removes levels, never adds them).
+#
+# REQUIRES: orc-rt-log-level-error, !orc-rt-log-level-debug
+# RUN: env ORC_RT_LOG=debug orc-rt-log-check 2>&1 | FileCheck %s
+
+# Even with ORC_RT_LOG=debug requested, no debug record is emitted; error (which
+# is always compiled in) still is, so the "no debug" check is not vacuous.
+# CHECK-NOT: [orc-rt:General:DEBUG]
+# CHECK: [orc-rt:General:ERROR] error message
+# CHECK-NOT: [orc-rt:General:DEBUG]

--- a/orc-rt/test/regression/logging/printf-backend/debug-level.test
+++ b/orc-rt/test/regression/logging/printf-backend/debug-level.test
@@ -1,0 +1,13 @@
+# Check the debug level on a build whose ceiling compiles it in: it is emitted
+# when explicitly requested, and suppressed by a higher runtime threshold.
+#
+# REQUIRES: orc-rt-log-level-debug
+# RUN: env ORC_RT_LOG=debug orc-rt-log-check 2>&1 | FileCheck %s
+# RUN: env ORC_RT_LOG=info orc-rt-log-check 2>&1 | FileCheck %s --check-prefix=NARROWED
+
+# CHECK: [orc-rt:General:DEBUG] debug message
+
+# ORC_RT_LOG=info narrows to info and above, so debug must not appear (but info,
+# checked here to keep the assertion non-vacuous, must).
+# NARROWED: [orc-rt:General:INFO] info message
+# NARROWED-NOT: [orc-rt:General:DEBUG] debug message

--- a/orc-rt/test/regression/logging/printf-backend/format.test
+++ b/orc-rt/test/regression/logging/printf-backend/format.test
@@ -1,0 +1,9 @@
+# Check the printf backend's message-line format:
+# "[orc-rt:<category>:<level>] <message>".
+# The format is the same for every level, so checking the error level is
+# sufficient.
+#
+# REQUIRES: orc-rt-log-level-error
+# RUN: orc-rt-log-check 2>&1 | FileCheck %s
+
+# CHECK: [orc-rt:General:ERROR] error message

--- a/orc-rt/test/regression/logging/printf-backend/level-off.test
+++ b/orc-rt/test/regression/logging/printf-backend/level-off.test
@@ -1,0 +1,6 @@
+# Check that ORC_RT_LOG=off silences all output.
+#
+# REQUIRES: orc-rt-log-level-error
+# RUN: env ORC_RT_LOG=off orc-rt-log-check 2>&1 | FileCheck %s --allow-empty
+
+# CHECK-NOT: orc-rt

--- a/orc-rt/test/regression/logging/printf-backend/lit.local.cfg
+++ b/orc-rt/test/regression/logging/printf-backend/lit.local.cfg
@@ -1,0 +1,5 @@
+# These tests exercise the printf logging backend, which is selected at
+# build time. Skip the whole directory unless that backend is compiled in.
+
+if "orc-rt-log-backend-printf" not in config.available_features:
+    config.unsupported = True

--- a/orc-rt/test/regression/logging/printf-backend/output-redirect.test
+++ b/orc-rt/test/regression/logging/printf-backend/output-redirect.test
@@ -1,0 +1,10 @@
+# Check that ORC_RT_LOG_OUTPUT redirects log records to the named file.
+# Redirection is level-independent, so checking the error line suffices (error
+# is shown at the default threshold).
+#
+# REQUIRES: orc-rt-log-level-error
+# RUN: rm -f %t.log
+# RUN: env ORC_RT_LOG_OUTPUT=%t.log orc-rt-log-check
+# RUN: FileCheck %s < %t.log
+
+# CHECK: [orc-rt:General:ERROR] error message

--- a/orc-rt/test/regression/logging/printf-backend/runtime-level.test
+++ b/orc-rt/test/regression/logging/printf-backend/runtime-level.test
@@ -1,0 +1,12 @@
+# Check that ORC_RT_LOG narrows output at runtime to levels at or above the
+# requested threshold.
+#
+# REQUIRES: orc-rt-log-level-warning
+# RUN: env ORC_RT_LOG=error orc-rt-log-check 2>&1 | FileCheck %s
+
+# With the threshold raised to error, warning must not appear; error must.
+# warning is compiled in (orc-rt-log-level-warning), so its absence proves runtime
+# narrowing rather than a compiled-out level.
+# CHECK-NOT:  [orc-rt:General:WARNING]
+# CHECK:      [orc-rt:General:ERROR] error message
+# CHECK-NOT:  [orc-rt:General:WARNING]

--- a/orc-rt/test/tools/CMakeLists.txt
+++ b/orc-rt/test/tools/CMakeLists.txt
@@ -1,4 +1,10 @@
 # Tools used by the ORC-RT regression tests. These are test-support binaries
 # built into the test tree; they are not installed with the runtime.
 
+# --- smoke-check test tool ---
 add_executable(orc-rt-smoke-check orc-rt-smoke-check.cpp)
+
+# -- logging-check test tool ---
+add_executable(orc-rt-log-check orc-rt-log-check.cpp)
+target_compile_options(orc-rt-log-check PRIVATE ${ORC_RT_COMPILE_FLAGS})
+target_link_libraries(orc-rt-log-check PRIVATE orc-rt-executor)

--- a/orc-rt/test/tools/orc-rt-log-check.cpp
+++ b/orc-rt/test/tools/orc-rt-log-check.cpp
@@ -1,0 +1,105 @@
+//===- orc-rt-log-check.cpp -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Regression-test helper for the ORC runtime logging backends.
+//
+// With no arguments it emits one log record at each level (all in the General
+// category), so a lit test can check message formatting and level/output
+// filtering by running it under different ORC_RT_LOG / ORC_RT_LOG_OUTPUT
+// environments.
+//
+// The query options let the lit config gate tests on the build's logging
+// configuration:
+//   --print-backend         print the compiled-in backend (none/printf/os_log).
+//   --print-enabled-levels  print, one per line, the levels that are actually
+//                           compiled in (empty for the none backend). This
+//                           reflects both the ORC_RT_LOG_LEVEL floor and the
+//                           backend, i.e. exactly which ORC_RT_LOG calls emit.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt-c/Logging.h"
+
+#include "orc-rt-utils/CommandLine.h"
+
+#include <iostream>
+
+namespace {
+
+const char *getLoggingBackend() {
+#if ORC_RT_LOG_BACKEND == ORC_RT_LOG_BACKEND_NONE
+  return "none";
+#elif ORC_RT_LOG_BACKEND == ORC_RT_LOG_BACKEND_PRINTF
+  return "printf";
+#elif ORC_RT_LOG_BACKEND == ORC_RT_LOG_BACKEND_OS_LOG
+  return "os_log";
+#else
+#error "Unrecognized ORC_RT_LOG_BACKEND"
+#endif
+}
+
+void printEnabledLevels() {
+#if ORC_RT_LOG_BACKEND != ORC_RT_LOG_BACKEND_NONE
+  // Stop before OFF: it is the disable sentinel, not an emittable level.
+  for (orc_rt_log_Level L = ORC_RT_LOG_LEVEL; L != ORC_RT_LOG_LEVEL_OFF; ++L)
+    std::cout << orc_rt_log_Level_getName(L) << "\n";
+#endif
+}
+
+void emitAllLevels() {
+  ORC_RT_LOG(Error, General, "error message");
+  ORC_RT_LOG(Warning, General, "warning message");
+  ORC_RT_LOG(Info, General, "info message");
+  ORC_RT_LOG(Debug, General, "debug message");
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+
+  bool PrintBackend = false;
+  bool PrintEnabledLevels = false;
+  bool PrintHelp = false;
+
+  {
+    orc_rt::CommandLineParser P;
+    P.addFlag("print-backend", "Print log backend", false, PrintBackend)
+        .addFlag("print-enabled-levels", "Print enabled log levels", false,
+                 PrintEnabledLevels)
+        .addFlag("help", "Print help", false, PrintHelp);
+
+    if (auto Err = P.parse(argc, argv)) {
+      std::cerr << "error: " << orc_rt::toString(std::move(Err)) << "\n";
+      P.printHelp(std::cerr, argv[0]);
+      return 1;
+    }
+
+    if ((PrintBackend && PrintEnabledLevels) || !P.positionals().empty()) {
+      P.printHelp(std::cerr, argv[0]);
+      return 1;
+    }
+
+    if (PrintHelp) {
+      P.printHelp(std::cerr, argv[0]);
+      return 0;
+    }
+  }
+
+  if (PrintBackend)
+    std::cout << getLoggingBackend() << "\n";
+
+  if (PrintEnabledLevels)
+    printEnabledLevels();
+
+  if (PrintBackend || PrintEnabledLevels)
+    return 0;
+
+  emitAllLevels();
+
+  return 0;
+}


### PR DESCRIPTION
Implement the printf backend, selected at configure-time with ORC_RT_LOG_BACKEND=printf. Messages are written to stderr, or to the file named by the ORC_RT_LOG_OUTPUT environment variable.

The ORC_RT_LOG environment variable sets the runtime level floor (error, warning, info, debug, or off) -- only messages at or above it are shown. When unset it defaults to warning, so warnings and errors are shown and info and debug are opt-in. The runtime floor cannot go below the compile-time ORC_RT_LOG_LEVEL floor (the lowest level built in).

Also add regression tests, driven by a new orc-rt-log-check tool that reports the compiled-in backend and levels (which lit exposes as features) and emits a message at each level.