### PR TITLE
[InstCombine] Use constant 64-bit indices for InsertElement

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -3004,8 +3004,7 @@ static Value *optimizeIntegerToVectorInsertions(BitCastInst &CI,
   for (unsigned i = 0, e = Elements.size(); i != e; ++i) {
     if (!Elements[i]) continue;  // Unset element.
 
-    Result = IC.Builder.CreateInsertElement(Result, Elements[i],
-                                            IC.Builder.getInt32(i));
+    Result = IC.Builder.CreateInsertElement(Result, Elements[i], i);
   }
 
   return Result;


### PR DESCRIPTION
The canonical form preferred by instCombine is to use 64-bit values for constant index in InsertElement see
https://github.com/llvm/llvm-project/blob/9d5d8834793da9efe297620db3ef39633688f830/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp#L401-L411

missed one insertElement in https://github.com/llvm/llvm-project/pull/208306