### PR TITLE
[SimplifyLibCalls] Use constant 64-bit indices for ExtractElement

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -2984,10 +2984,8 @@ static bool insertSinCosCall(IRBuilderBase &B, Function *OrigCallee, Value *Arg,
     Sin = B.CreateExtractValue(SinCos, 0, "sinpi");
     Cos = B.CreateExtractValue(SinCos, 1, "cospi");
   } else {
-    Sin = B.CreateExtractElement(SinCos, ConstantInt::get(B.getInt32Ty(), 0),
-                                 "sinpi");
-    Cos = B.CreateExtractElement(SinCos, ConstantInt::get(B.getInt32Ty(), 1),
-                                 "cospi");
+    Sin = B.CreateExtractElement(SinCos, uint64_t{0}, "sinpi");
+    Cos = B.CreateExtractElement(SinCos, uint64_t{1}, "cospi");
   }
 
   return true;


### PR DESCRIPTION
The canonical form preferred by instCombine is to use 64-bit values for constant index in ExtractElement see
https://github.com/llvm/llvm-project/blob/9d5d8834793da9efe297620db3ef39633688f830/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp#L401-L411