### PR TITLE
[NFC][clang] Adjust PPMemoryAllocationsTest threshold for ASan

### DIFF
--- a/clang/unittests/Lex/PPMemoryAllocationsTest.cpp
+++ b/clang/unittests/Lex/PPMemoryAllocationsTest.cpp
@@ -19,6 +19,7 @@
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Lex/PreprocessorOptions.h"
 #include "gtest/gtest.h"
+#include "llvm/Support/Compiler.h"
 
 using namespace clang;
 
@@ -89,7 +90,11 @@ TEST_F(PPMemoryAllocationsTest, PPMacroDefinesAllocations) {
   // Assume a reasonable upper bound based on that number that we don't want
   // to exceed when storing information about a macro #define with 1 or 3
   // tokens.
+#if LLVM_ADDRESS_SANITIZER_BUILD
+  EXPECT_LT(BytesPerDefine, 145.0f);
+#else
   EXPECT_LT(BytesPerDefine, 130.0f);
+#endif
 }
 
 } // anonymous namespace

--- a/clang/unittests/Lex/PPMemoryAllocationsTest.cpp
+++ b/clang/unittests/Lex/PPMemoryAllocationsTest.cpp
@@ -18,8 +18,8 @@
 #include "clang/Lex/ModuleLoader.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Lex/PreprocessorOptions.h"
-#include "gtest/gtest.h"
 #include "llvm/Support/Compiler.h"
+#include "gtest/gtest.h"
 
 using namespace clang;
 


### PR DESCRIPTION
PPMemoryAllocationsTest.PPMacroDefinesAllocations measures the memory
footprint of the preprocessor allocator and asserts a strict threshold
of 130.0 bytes per define.

When built with ASan, the allocator adds redzones to allocations,
which increases the total memory reported by `getTotalMemory()` and
causes the test to fail (reporting ~136.8 bytes per define).

Adjust the threshold to 145.0 bytes per define when built with ASan
(detected via `LLVM_ADDRESS_SANITIZER_BUILD`) to account for this
overhead while maintaining the strict limit for standard builds.

Assisted-by: Gemini
