### PR TITLE
[flang][docs] Document multi-image support status

### DIFF
--- a/flang/docs/FortranStandardsSupport.md
+++ b/flang/docs/FortranStandardsSupport.md
@@ -50,9 +50,9 @@ status of all important Fortran 2023 features. The table entries are based on th
 | The at edit descriptor                                     | N      | |
 | Control over leading zeros in output of real values        | Y      | |
 | Extensions for Namelist                                    | N      | |
-| Allow an object of a type with a coarray ultimate component to be an array or allocatable | N | |
-| Put with Notify                                            | N      | |
-| Error conditions in collectives                            | N      | |
+| Allow an object of a type with a coarray ultimate component to be an array or allocatable | N | Multi-image/Coarray feature |
+| Put with Notify                                            | N      | Multi-image/Coarray feature |
+| Error conditions in collectives                            | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
 | Simple procedures                                          | N      | |
 | Using integer arrays to specify subscripts                 | N      | |
 | Using integer arrays to specify rank and bound of an array | N      | |
@@ -68,19 +68,19 @@ the multi-image execution. The table entries are based on the document [The new 
 |------------------------------------------------------------|--------|---------------------------------------------------------|
 | Asynchronous communication                                 | P      | Syntax is accepted |
 | Collective subroutines                                     | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md), missing co_reduce |
-| Teams                                                      | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Intrinsic function coshape                                 | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
 | Form team statement                                        | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
-| Change team construct                                      | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
-| Sync team construct                                        | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Change team construct                                      | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md), missing coarray association |
+| Sync team statement                                        | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
 | Intrinsic functions get_team and team_number               | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
-| Image failure and stat= specifiers                         | P      | Multi-image/Coarray feature. stat_failed_image is added |
+| Team arguments to other intrinsics                         | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
 | Coarrays allocated in teams                                | N      | Multi-image/Coarray feature |
 | Critical construct                                         | N      | Multi-image/Coarray feature |
 | Events                                                     | N      | Multi-image/Coarray feature |
 | Intrinsic move_alloc extensions                            | P      | Multi-image/Coarray feature |
 | Detecting failed and stopped images                        | N      | Multi-image/Coarray feature |
 | New and enhanced atomic subroutines                        | N      | Multi-image/Coarray feature |
-| Intrinsic function coshape                                 | N      | Multi-image/Coarray feature |
+| Image failure and stat= specifiers                         | P      | Multi-image/Coarray feature. stat_failed_image is added |
 
 ## Fortran 2008
 All features except those listed in the following table are supported.
@@ -90,9 +90,12 @@ All features except those listed in the following table are supported.
 | do concurrent                                              | P      | Sequential execution works. Parallel support in progress|
 | Internal procedure as an actual argument or pointer target | Y      | Current implementation requires stack to be executable. See [FAQ](FAQ.md#why-do-i-get-a-warning-or-an-error-about-an-executable-stack) and [Proposal](InternalProcedureTrampolines.md) |
 | Intrinsic functions this_image, num_images                 | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
-| Coarrays                                                   | N      | Lowering and runtime support is not implemented         |
-| Intrinsic function image_index                             | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Sync all, sync images, sync memory statements              | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Non-allocatable save coarrays of intrinsic type            | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Other coarray data objects                                 | N      | Multi-image/Coarray feature |
+| Intrinsic functions image_index, ucobound, lcobound        | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
 | Image selectors (coindexed access)                         | N      | Multi-image/Coarray feature |
+| Atomic subroutines                                         | N      | Multi-image/Coarray feature |
 | Lock and unlock statements                                 | N      | Multi-image/Coarray feature |
 
 ## Fortran 2003

--- a/flang/docs/FortranStandardsSupport.md
+++ b/flang/docs/FortranStandardsSupport.md
@@ -73,15 +73,10 @@ the multi-image execution. The table entries are based on the document [The new 
 | Change team construct                                      | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
 | Sync team construct                                        | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
 | Intrinsic functions get_team and team_number               | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
-| Intrinsic function image_index                             | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
-| Intrinsic function num_images                              | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
-| Intrinsic function this_image                              | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
 | Image failure and stat= specifiers                         | P      | Multi-image/Coarray feature. stat_failed_image is added |
 | Coarrays allocated in teams                                | N      | Multi-image/Coarray feature |
 | Critical construct                                         | N      | Multi-image/Coarray feature |
-| Lock and unlock statements                                 | N      | Multi-image/Coarray feature |
 | Events                                                     | N      | Multi-image/Coarray feature |
-| Image selectors                                            | N      | Multi-image/Coarray feature |
 | Intrinsic move_alloc extensions                            | P      | Multi-image/Coarray feature |
 | Detecting failed and stopped images                        | N      | Multi-image/Coarray feature |
 | New and enhanced atomic subroutines                        | N      | Multi-image/Coarray feature |
@@ -92,9 +87,13 @@ All features except those listed in the following table are supported.
 
 | Feature                                                    | Status | Comments                                                |
 |------------------------------------------------------------|--------|---------------------------------------------------------|
-| Coarrays                                                   | N      | Lowering and runtime support is not implemented         |
 | do concurrent                                              | P      | Sequential execution works. Parallel support in progress|
 | Internal procedure as an actual argument or pointer target | Y      | Current implementation requires stack to be executable. See [FAQ](FAQ.md#why-do-i-get-a-warning-or-an-error-about-an-executable-stack) and [Proposal](InternalProcedureTrampolines.md) |
+| Intrinsic functions this_image, num_images                 | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Coarrays                                                   | N      | Lowering and runtime support is not implemented         |
+| Intrinsic function image_index                             | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Image selectors (coindexed access)                         | N      | Multi-image/Coarray feature |
+| Lock and unlock statements                                 | N      | Multi-image/Coarray feature |
 
 ## Fortran 2003
 All features except those listed in the following table are supported.


### PR DESCRIPTION
Update `flang/docs/FortranStandardsSupport.md` to reflect the current state of multi-image (coarray) feature support.

The previous list of multi-image features was incomplete, and several multi-image features added in F2008 were inaccurately listed in the F2018 section.

Recent PRs adding functionality now reflected in this document include:
* #205847
* #192944
* #182110

Older (pre-22) PRs adding functionality that was not previously mentioned include:
* #154081
* #154166


