### PR TITLE
[lld] Report missing --irpgo-profile file instead of asserting

### DIFF
--- a/lld/include/lld/Common/BPSectionOrdererBase.inc
+++ b/lld/include/lld/Common/BPSectionOrdererBase.inc
@@ -177,7 +177,10 @@ auto BPOrderer<D>::computeOrder(
   if (!profilePath.empty()) {
     auto fs = vfs::getRealFileSystem();
     auto readerOrErr = InstrProfReader::create(profilePath, *fs);
-    lld::checkError(readerOrErr.takeError());
+    if (!readerOrErr) {
+      lld::error(toString(readerOrErr.takeError()));
+      return DenseMap<const Section *, int>{};
+    }
 
     reader = std::move(readerOrErr.get());
     for (auto &entry : *reader) {

--- a/lld/test/ELF/bp-section-orderer.s
+++ b/lld/test/ELF/bp-section-orderer.s
@@ -29,6 +29,10 @@
 
 # RUN: llvm-mc -filetype=obj -triple=aarch64 a.s -o a.o
 # RUN: llvm-profdata merge a.proftext -o a.profdata
+
+# RUN: not ld.lld a.o --irpgo-profile=missing.profdata --bp-startup-sort=function -o /dev/null 2>&1 | FileCheck %s --check-prefix=MISSING -DMSG=%errc_ENOENT
+# MISSING: error: [[MSG]]
+
 # RUN: ld.lld a.o --irpgo-profile=a.profdata --bp-startup-sort=function --verbose-bp-section-orderer --icf=all --gc-sections 2>&1 | FileCheck %s --check-prefix=STARTUP-FUNC-ORDER
 
 # STARTUP-FUNC-ORDER: Ordered 4 sections ([[#]] bytes) using balanced partitioning

--- a/lld/test/MachO/bp-section-orderer-errs.s
+++ b/lld/test/MachO/bp-section-orderer-errs.s
@@ -1,3 +1,4 @@
+# RUN: rm -rf %t && mkdir %t && cd %t
 # RUN: not %no-fatal-warnings-lld -o /dev/null --irpgo-profile-sort %s --call-graph-profile-sort 2>&1 | FileCheck %s --check-prefix=IRPGO-ERR
 # RUN: not %no-fatal-warnings-lld -o /dev/null --irpgo-profile-sort=%s --call-graph-profile-sort 2>&1 | FileCheck %s --check-prefix=IRPGO-ERR
 # IRPGO-ERR: --irpgo-profile-sort is incompatible with --call-graph-profile-sort
@@ -32,3 +33,11 @@
 
 # RUN: not %lld -o /dev/null --bp-startup-sort=function 2>&1 | FileCheck %s --check-prefix=STARTUP-COMPRESSION
 # STARTUP-COMPRESSION: --bp-startup-sort=function must be used with --irpgo-profile
+
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %s -o a.o
+# RUN: not %lld -arch arm64 -lSystem -o /dev/null a.o --irpgo-profile=missing.profdata --bp-startup-sort=function 2>&1 | FileCheck %s --check-prefix=MISSING -DMSG=%errc_ENOENT
+# MISSING: error: [[MSG]]
+
+.globl _main
+_main:
+  ret


### PR DESCRIPTION
When --irpgo-profile names a missing file, takeError() asserts

```
ld.lld: error: No such file or directory
ld.lld: Error.h:686: ... Assertion `!HasError && "Cannot get value when an error exists!"' failed.
```

Check the Expected before use. Fixes #203761

Co-authored-by: Peter Chen J. <peter941221@gmail.com>