### PR TITLE
[DWARFCFIChecker] Changing register initial status as undefined 

### DIFF
--- a/llvm/lib/DWARFCFIChecker/DWARFCFIAnalysis.cpp
+++ b/llvm/lib/DWARFCFIChecker/DWARFCFIAnalysis.cpp
@@ -91,31 +91,21 @@ DWARFCFIAnalysis::DWARFCFIAnalysis(MCContext *Context, MCInstrInfo const &MCII,
       continue;
 
     DWARFRegNum Reg = MCRI->getDwarfRegNum(LLVMReg, IsEH);
-    // TODO: this should be `undefined` instead of `same_value`, but because
-    // initial frame state doesn't have any directives about callee saved
-    // registers, every register is tracked. After initial frame state is
-    // corrected, this should be changed.
-    State.update(MCCFIInstruction::createSameValue(nullptr, Reg));
+    // Based on dwarf documentation, the default rule for all columns before
+    // interpretation of the initial instructions is the undefined rule.
+
+    // For now, this tool depends on the user to write a prologue that
+    // establishes the rules required for proper validation of the rest of the
+    // function.
+    State.update(MCCFIInstruction::createUndefined(nullptr, Reg));
   }
 
-  // TODO: Ignoring PC should be in the initial frame state.
   State.update(MCCFIInstruction::createUndefined(
       nullptr, MCRI->getDwarfRegNum(MCRI->getProgramCounter(), IsEH)));
 
   for (auto &&InitialFrameStateCFIDirective :
        Context->getAsmInfo().getInitialFrameState())
     State.update(InitialFrameStateCFIDirective);
-
-  auto MaybeCurrentRow = State.getCurrentUnwindRow();
-  assert(MaybeCurrentRow && "there should be at least one row");
-  auto MaybeCFA = getCFARegOffsetInfo(*MaybeCurrentRow);
-  assert(MaybeCFA &&
-         "the CFA information should be describable in [reg + offset] in here");
-  auto CFA = *MaybeCFA;
-
-  // TODO: CFA register callee value is CFA's value, this should be in initial
-  // frame state.
-  State.update(MCCFIInstruction::createOffset(nullptr, CFA.Reg, 0));
 
   // Applying the prologue after default assumptions to overwrite them.
   for (auto &&Directive : Prologue)

--- a/llvm/test/DWARFCFIChecker/X86/cfa-corner-cases.s
+++ b/llvm/test/DWARFCFIChecker/X86/cfa-corner-cases.s
@@ -6,10 +6,6 @@
         .type   f, @function
 f:
         .cfi_startproc
-        
-        ## TODO: Remove these lines when the initial frame directives set the callee saved registers
-        .cfi_undefined %rax
-        .cfi_undefined %flags
 
         .cfi_val_offset %rbp, -8 
 

--- a/llvm/test/DWARFCFIChecker/X86/nested-frames.s
+++ b/llvm/test/DWARFCFIChecker/X86/nested-frames.s
@@ -4,8 +4,8 @@
 .pushsection A
 f: 
 .cfi_startproc
-## TODO: Remove this line when the initial frame directives set the callee saved registers
-.cfi_undefined %flags
+.cfi_same_value %rbp
+.cfi_same_value %rsi
 addq $10, %rbp
 # CHECK: error: changed register RBP, that register RBP's unwinding rule uses, but there is no CFI directives about it
 nop
@@ -14,8 +14,7 @@ nop
 .pushsection B
 g: 
 .cfi_startproc
-## TODO: Remove this line when the initial frame directives set the callee saved registers
-.cfi_undefined %flags
+.cfi_same_value %rbp
 addq $10, %rbp
 # CHECK: error: changed register RBP, that register RBP's unwinding rule uses, but there is no CFI directives about it
 nop

--- a/llvm/test/DWARFCFIChecker/X86/single-func-cfa-mistake.s
+++ b/llvm/test/DWARFCFIChecker/X86/single-func-cfa-mistake.s
@@ -7,10 +7,6 @@
 f:
         .cfi_startproc
 
-        ## TODO: Remove these lines when the initial frame directives set the callee saved registers
-        .cfi_undefined %rax
-        .cfi_undefined %flags
-
         pushq   %rbp
         # CHECK: warning: CFA offset is changed from 8 to 17, and CFA register RSP is modified, but validating the modification amount is not implemented yet
         # CHECK: warning: validating changes happening to register RBP unwinding rule structure is not implemented yet

--- a/llvm/test/DWARFCFIChecker/X86/single-func-missed-cfi-directive.s
+++ b/llvm/test/DWARFCFIChecker/X86/single-func-missed-cfi-directive.s
@@ -7,8 +7,8 @@
 f:
         .cfi_startproc
         
-        .cfi_undefined %rax
-        
+        .cfi_same_value %rbp
+
         pushq   %rbp
         .cfi_def_cfa_offset 16
         

--- a/llvm/test/DWARFCFIChecker/X86/single-func.s
+++ b/llvm/test/DWARFCFIChecker/X86/single-func.s
@@ -7,10 +7,6 @@
 f:
         .cfi_startproc
         
-        ## TODO: Remove these lines when the initial frame directives set the callee saved registers
-        .cfi_undefined %rax
-        .cfi_undefined %flags
-        
         pushq   %rbp
         # CHECK: warning: CFA offset is changed from 8 to 16, and CFA register RSP is modified, but validating the modification amount is not implemented yet
         # CHECK:  warning: validating changes happening to register RBP unwinding rule structure is not implemented yet


### PR DESCRIPTION
As per DWARF spec 6.4.1. Users can overwrite this default assumption inside the prologue.