### PR TITLE
[ELF] Move markUsedLocalSymbols from Writer to markLive. NFC

### DIFF
--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -339,6 +339,21 @@ void MarkLive<ELFT, TrackWhyLive>::markSymbol(Symbol *sym, StringRef reason) {
       enqueue(isec, d->value, sym, {std::nullopt, reason});
 }
 
+template <class ELFT> static void markUsedLocalSymbols(InputSectionBase &sec) {
+  auto mark = [&](const auto &rel) {
+    Symbol &sym = sec.file->getRelocTargetSym(rel);
+    if (sym.isLocal())
+      sym.setFlags(USED);
+  };
+  const RelsOrRelas<ELFT> rels = sec.template relsOrRelas<ELFT>();
+  for (const typename ELFT::Rel &rel : rels.rels)
+    mark(rel);
+  for (const typename ELFT::Rela &rel : rels.relas)
+    mark(rel);
+  for (const typename ELFT::Crel &rel : rels.crels)
+    mark(rel);
+}
+
 // This is the main function of the garbage collector.
 // Starting from GC-root sections, this function visits all reachable
 // sections to set their "Live" bits.
@@ -582,6 +597,15 @@ template <class ELFT> void elf::markLive(Ctx &ctx) {
       if (auto *s = dyn_cast<SharedSymbol>(sym))
         if (s->isUsedInRegularObj && !s->isWeak())
           cast<SharedFile>(s->file)->isNeeded = true;
+    // If -r or --emit-relocs, ensure referenced local symbols are preserved so
+    // that they won't be discarded by --discard-{locals,all} (see
+    // shouldKeepInSymtab).
+    if (ctx.arg.copyRelocs && ctx.arg.discard != DiscardPolicy::None)
+      parallelForEach(ctx.objectFiles, [](ELFFileBase *file) {
+        for (InputSectionBase *sec : file->getSections())
+          if (sec)
+            markUsedLocalSymbols<ELFT>(*sec);
+      });
     return;
   }
 

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -375,46 +375,6 @@ template <class ELFT> void Writer<ELFT>::run() {
   }
 }
 
-template <class ELFT, class RelTy>
-static void markUsedLocalSymbolsImpl(ObjFile<ELFT> *file,
-                                     llvm::ArrayRef<RelTy> rels) {
-  for (const RelTy &rel : rels) {
-    Symbol &sym = file->getRelocTargetSym(rel);
-    if (sym.isLocal())
-      sym.setFlags(USED);
-  }
-}
-
-// The function ensures that the USED flag of local symbols reflects the fact
-// that the symbol is used in a relocation from a live section.
-template <class ELFT> static void markUsedLocalSymbols(Ctx &ctx) {
-  // With --gc-sections, the field is already filled.
-  // See MarkLive<ELFT>::resolveReloc().
-  if (ctx.arg.gcSections)
-    return;
-  for (ELFFileBase *file : ctx.objectFiles) {
-    ObjFile<ELFT> *f = cast<ObjFile<ELFT>>(file);
-    for (InputSectionBase *s : f->getSections()) {
-      InputSection *isec = dyn_cast_or_null<InputSection>(s);
-      if (!isec)
-        continue;
-      if (isec->type == SHT_REL) {
-        markUsedLocalSymbolsImpl(f, isec->getDataAs<typename ELFT::Rel>());
-      } else if (isec->type == SHT_RELA) {
-        markUsedLocalSymbolsImpl(f, isec->getDataAs<typename ELFT::Rela>());
-      } else if (isec->type == SHT_CREL) {
-        // The is64=true variant also works with ELF32 since only the r_symidx
-        // member is used.
-        for (Elf_Crel_Impl<true> r : RelocsCrel<true>(isec->content_)) {
-          Symbol &sym = file->getSymbol(r.r_symidx);
-          if (sym.isLocal())
-            sym.setFlags(USED);
-        }
-      }
-    }
-  }
-}
-
 static bool shouldKeepInSymtab(Ctx &ctx, const Defined &sym) {
   if (sym.isSection())
     return false;
@@ -1897,8 +1857,6 @@ template <class ELFT> void Writer<ELFT>::finalizeSections() {
 
   demoteSymbolsAndComputeIsPreemptible(ctx);
 
-  if (ctx.arg.copyRelocs && ctx.arg.discard != DiscardPolicy::None)
-    markUsedLocalSymbols<ELFT>(ctx);
   demoteAndCopyLocalSymbols(ctx);
 
   if (ctx.arg.copyRelocs)


### PR DESCRIPTION
markUsedLocalSymbols (https://reviews.llvm.org/D77807) sets the USED
flag on local symbols referenced by relocations so that -r/--emit-relocs
with --discard-{locals,all} preserves them in the symbol table.

Move the scan into markLive's !gcSections branch to be closer to
MarkLive::resolveReloc. The scan now iterates sections via relsOrRelas,
handling CREL uniformly, and runs in parallel.

This is a step toward fixing #160789