### PR TITLE
[llvm][HTTP] Increase request handler sleep

### DIFF
--- a/llvm/test/tools/llvm-debuginfod-find/Inputs/delay_req.py
+++ b/llvm/test/tools/llvm-debuginfod-find/Inputs/delay_req.py
@@ -9,7 +9,7 @@ import time
 class DelayingHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         # The test sets DEBUGINFOD_TIMEOUT=1
-        time.sleep(2)
+        time.sleep(5)
         self.send_response(501)
 
 


### PR DESCRIPTION
Fixup for https://github.com/llvm/llvm-project/pull/188969#issuecomment-4952185708. The issue is likely the same as I described in https://github.com/llvm/llvm-project/pull/192061#issuecomment-4926882131 where WinHTTP doesn't time out immediately but adds some delay. The fix here is to increase the sleep in the mock server. 