### PR TITLE
[SLP] Fix miscompile from unsafe operand-order normalization

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -12831,6 +12831,13 @@ public:
       // commutative (e.g. 0 - X is not X - 0, so `sub` must be
       // excluded).
       if (IsCommutative) {
+        // IsCommutative can hold for MainOp (e.g. a Sub/FSub feeding only
+        // fabs/icmp-eq-0) without every lane sharing that property, so
+        // re-check the specific lane before swapping it.
+        auto CanSwap = [&](Value *V) {
+          return isCommutative(S.getMatchingMainOpOrAltOp(cast<Instruction>(V)),
+                               V);
+        };
         // Count (ID0, ID1) pair frequencies for operand normalization.
         // Pairs and their inverses are tracked under a canonical key
         // so that (Load, Add) and (Add, Load) contribute to the same
@@ -12891,7 +12898,7 @@ public:
           if (BestCount > 0) {
             unsigned ID0 = Operands[0][Idx]->getValueID();
             unsigned ID1 = Operands[1][Idx]->getValueID();
-            if (ID0 == MajID1 && ID1 == MajID0)
+            if (ID0 == MajID1 && ID1 == MajID0 && CanSwap(V))
               std::swap(Operands[0][Idx], Operands[1][Idx]);
           }
           ++TotalNC;
@@ -12905,7 +12912,7 @@ public:
             if (S.isCopyableElement(V) || isa<PoisonValue>(V))
               continue;
             if (!isa<LoadInst>(Operands[0][Idx]) &&
-                isa<LoadInst>(Operands[1][Idx]))
+                isa<LoadInst>(Operands[1][Idx]) && CanSwap(V))
               std::swap(Operands[0][Idx], Operands[1][Idx]);
           }
         }

--- a/llvm/test/Transforms/SLPVectorizer/X86/copyable-addsub-reorder.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/copyable-addsub-reorder.ll
@@ -6,30 +6,32 @@ define i32 @fadd_fsub_constant_lhs_mix(float %s) {
 ; CHECK-LABEL: define i32 @fadd_fsub_constant_lhs_mix(
 ; CHECK-SAME: float [[S:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT:    [[TMP0:%.*]] = insertelement <4 x float> poison, float [[S]], i64 0
-; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <4 x float> [[TMP0]], <4 x float> poison, <4 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP2:%.*]] = fmul <4 x float> [[TMP1]], <float 2.000000e+00, float 1.000000e+00, float 1.125000e+00, float 1.000000e+00>
-; CHECK-NEXT:    [[TMP3:%.*]] = fsub <4 x float> <float -0.000000e+00, float 2.000000e+00, float 0.000000e+00, float -1.000000e+00>, [[TMP2]]
-; CHECK-NEXT:    [[TMP4:%.*]] = call <4 x float> @llvm.fabs.v4f32(<4 x float> [[TMP3]])
-; CHECK-NEXT:    [[TMP5:%.*]] = fcmp ueq <4 x float> [[TMP4]], splat (float +inf)
-; CHECK-NEXT:    [[CA:%.*]] = extractelement <4 x i1> [[TMP5]], i64 3
+; CHECK-NEXT:    [[A:%.*]] = fadd float [[S]], 1.000000e+00
+; CHECK-NEXT:    [[FA:%.*]] = tail call float @llvm.fabs.f32(float [[A]])
+; CHECK-NEXT:    [[CA:%.*]] = fcmp ueq float [[FA]], +inf
+; CHECK-NEXT:    [[MULB:%.*]] = fmul float [[S]], 1.125000e+00
+; CHECK-NEXT:    [[B:%.*]] = fsub float 0.000000e+00, [[MULB]]
+; CHECK-NEXT:    [[FB:%.*]] = tail call float @llvm.fabs.f32(float [[B]])
+; CHECK-NEXT:    [[CB:%.*]] = fcmp ueq float [[FB]], +inf
+; CHECK-NEXT:    [[D:%.*]] = fsub float 2.000000e+00, [[S]]
+; CHECK-NEXT:    [[FD:%.*]] = tail call float @llvm.fabs.f32(float [[D]])
+; CHECK-NEXT:    [[CD:%.*]] = fcmp ueq float [[FD]], +inf
+; CHECK-NEXT:    [[MULE:%.*]] = fmul float [[S]], 2.000000e+00
+; CHECK-NEXT:    [[E:%.*]] = fadd float [[MULE]], 0.000000e+00
+; CHECK-NEXT:    [[FE:%.*]] = tail call float @llvm.fabs.f32(float [[E]])
+; CHECK-NEXT:    [[CE:%.*]] = fcmp ueq float [[FE]], +inf
 ; CHECK-NEXT:    br i1 [[CA]], label %[[ABORT:.*]], label %[[SPLIT:.*]]
 ; CHECK:       [[SPLIT]]:
-; CHECK-NEXT:    [[CB:%.*]] = extractelement <4 x i1> [[TMP5]], i64 2
 ; CHECK-NEXT:    br i1 [[CB]], label %[[ABORT]], label %[[SPLIT2:.*]]
 ; CHECK:       [[SPLIT2]]:
-; CHECK-NEXT:    [[CD:%.*]] = extractelement <4 x i1> [[TMP5]], i64 1
 ; CHECK-NEXT:    br i1 [[CD]], label %[[ABORT]], label %[[SPLIT3:.*]]
 ; CHECK:       [[SPLIT3]]:
-; CHECK-NEXT:    [[CE:%.*]] = extractelement <4 x i1> [[TMP5]], i64 0
 ; CHECK-NEXT:    br i1 [[CE]], label %[[ABORT]], label %[[CONT:.*]]
 ; CHECK:       [[ABORT]]:
 ; CHECK-NEXT:    tail call void @abort()
 ; CHECK-NEXT:    unreachable
 ; CHECK:       [[CONT]]:
-; CHECK-NEXT:    [[E:%.*]] = extractelement <4 x float> [[TMP3]], i64 0
 ; CHECK-NEXT:    [[EI:%.*]] = fptosi float [[E]] to i32
-; CHECK-NEXT:    [[B:%.*]] = extractelement <4 x float> [[TMP3]], i64 2
 ; CHECK-NEXT:    [[BI:%.*]] = fptosi float [[B]] to i32
 ; CHECK-NEXT:    [[SUM:%.*]] = add i32 [[EI]], [[BI]]
 ; CHECK-NEXT:    ret i32 [[SUM]]
@@ -139,10 +141,11 @@ define i32 @add_sub_constant_lhs_mix(i32 %s) {
 ; THRESH-LABEL: define i32 @add_sub_constant_lhs_mix(
 ; THRESH-SAME: i32 [[S:%.*]]) {
 ; THRESH-NEXT:  [[ENTRY:.*:]]
-; THRESH-NEXT:    [[TMP0:%.*]] = insertelement <4 x i32> poison, i32 [[S]], i64 0
-; THRESH-NEXT:    [[TMP1:%.*]] = shufflevector <4 x i32> [[TMP0]], <4 x i32> poison, <4 x i32> zeroinitializer
-; THRESH-NEXT:    [[TMP2:%.*]] = mul <4 x i32> [[TMP1]], <i32 2, i32 1, i32 1, i32 3>
-; THRESH-NEXT:    [[TMP4:%.*]] = sub <4 x i32> <i32 -2, i32 -1, i32 10, i32 5>, [[TMP2]]
+; THRESH-NEXT:    [[TMP0:%.*]] = insertelement <4 x i32> <i32 1, i32 1, i32 1, i32 poison>, i32 [[S]], i64 3
+; THRESH-NEXT:    [[TMP1:%.*]] = mul <4 x i32> [[TMP0]], <i32 -2, i32 -1, i32 10, i32 3>
+; THRESH-NEXT:    [[TMP2:%.*]] = shufflevector <4 x i32> [[TMP0]], <4 x i32> <i32 poison, i32 1, i32 poison, i32 poison>, <4 x i32> <i32 3, i32 3, i32 3, i32 5>
+; THRESH-NEXT:    [[TMP3:%.*]] = mul <4 x i32> <i32 2, i32 1, i32 1, i32 5>, [[TMP2]]
+; THRESH-NEXT:    [[TMP4:%.*]] = sub <4 x i32> [[TMP3]], [[TMP1]]
 ; THRESH-NEXT:    [[TMP5:%.*]] = icmp eq <4 x i32> [[TMP4]], zeroinitializer
 ; THRESH-NEXT:    [[TMP6:%.*]] = extractelement <4 x i1> [[TMP5]], i64 1
 ; THRESH-NEXT:    br i1 [[TMP6]], label %[[ABORT:.*]], label %[[SPLIT:.*]]


### PR DESCRIPTION
IsCommutative(MainOp) is also true for a Sub/FSub feeding only
fabs/icmp-eq-0, but that doesn't make every lane swappable: a
converted Add/FAdd lane's operand order is fixed to preserve its
value, and swapping it into a native Sub/FSub's layout negates it.
Re-check each lane before swapping instead of trusting MainOp's.

Fixes #208944
