### PR TITLE
[SLP] Drop nuw when add/sub interchange negates a nonzero constant

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -23673,24 +23673,28 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
            return !SI || isCommutative(SI);
          })))
       I->setHasNoUnsignedWrap(/*b=*/false);
-    // add nsw X, INT_MIN is not equivalent to sub nsw X, INT_MIN, because
-    // negating INT_MIN overflows. When an add/sub lane is converted to the
-    // opposite opcode its constant is negated, so nsw no longer holds and must
-    // be dropped.
+    // Interchanging add/sub negates the constant: nsw only survives if the
+    // constant isn't INT_MIN (negating it would overflow); nuw never
+    // survives a nonzero constant, since that flips the valid range from
+    // X >= C to X < C.
     if (!MinBWs.contains(E) &&
-        (Opcode == Instruction::Add || Opcode == Instruction::Sub) &&
-        any_of(UniqueInsts, [&](Value *V) {
-          auto *SI = cast<Instruction>(V);
-          if (SI->getOpcode() == Opcode ||
-              !is_contained({Instruction::Add, Instruction::Sub},
-                            SI->getOpcode()))
-            return false;
-          return any_of(SI->operands(), [](Value *Op) {
-            const auto *CI = dyn_cast<ConstantInt>(Op);
-            return CI && CI->getValue().isMinSignedValue();
-          });
-        }))
-      I->setHasNoSignedWrap(/*b=*/false);
+        (Opcode == Instruction::Add || Opcode == Instruction::Sub)) {
+      for (Value *V : UniqueInsts) {
+        auto *SI = cast<Instruction>(V);
+        if (SI->getOpcode() == Opcode ||
+            !is_contained({Instruction::Add, Instruction::Sub},
+                          SI->getOpcode()))
+          continue;
+        for (Value *Op : SI->operands()) {
+          const auto *CI = dyn_cast<ConstantInt>(Op);
+          if (!CI || CI->isZero())
+            continue;
+          I->setHasNoUnsignedWrap(/*b=*/false);
+          if (CI->getValue().isMinSignedValue())
+            I->setHasNoSignedWrap(/*b=*/false);
+        }
+      }
+    }
     // mul nsw X, INT_MIN is not equivalent to shl nsw X, BW-1, because shl nsw
     // poisons when the sign bit is shifted out of a positive value. When a mul
     // lane is converted to shl with shift amount BW-1, nsw must be dropped.

--- a/llvm/test/Transforms/SLPVectorizer/X86/add-sub-nuw.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/add-sub-nuw.ll
@@ -5,7 +5,7 @@ define void @issue209023(ptr %p) {
 ; CHECK-LABEL: @issue209023(
 ; CHECK-NEXT:    [[P0:%.*]] = getelementptr inbounds i32, ptr [[P:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP1:%.*]] = load <4 x i32>, ptr [[P0]], align 4
-; CHECK-NEXT:    [[TMP2:%.*]] = add nuw <4 x i32> [[TMP1]], <i32 3, i32 7, i32 1, i32 -5>
+; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i32> [[TMP1]], <i32 3, i32 7, i32 1, i32 -5>
 ; CHECK-NEXT:    store <4 x i32> [[TMP2]], ptr [[P0]], align 4
 ; CHECK-NEXT:    ret void
 ;
@@ -48,7 +48,7 @@ define void @sub_converted_to_add_drops_nuw(ptr %p, i32 %x, i32 %y) {
 ; CHECK-LABEL: @sub_converted_to_add_drops_nuw(
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <2 x i32> poison, i32 [[X:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <2 x i32> [[TMP1]], i32 [[Y:%.*]], i64 1
-; CHECK-NEXT:    [[TMP3:%.*]] = add nuw <2 x i32> [[TMP2]], <i32 -5, i32 7>
+; CHECK-NEXT:    [[TMP3:%.*]] = add <2 x i32> [[TMP2]], <i32 -5, i32 7>
 ; CHECK-NEXT:    store <2 x i32> [[TMP3]], ptr [[P:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
sub nuw X, C requires X u>= C, but add nuw X, -C requires X u< C, so
nuw must always be dropped on interchange.

Fixes #209023
