### PR TITLE
[ELF,test] Modernize --retain-symbols-file tests

### DIFF
--- a/lld/test/ELF/retain-symbols-file.s
+++ b/lld/test/ELF/retain-symbols-file.s
@@ -1,74 +1,59 @@
 # REQUIRES: x86
-# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %s -o %t
-# RUN: echo "bar" > %t_retain.txt
-# RUN: echo "foo" >> %t_retain.txt
-# RUN: ld.lld --hash-style=sysv -shared --retain-symbols-file=%t_retain.txt %t -o %t2
-# RUN: llvm-readobj --dyn-symbols %t2 | FileCheck %s
+## --retain-symbols-file removes unlisted symbols from .dynsym.
 
-## Check separate form.
-# RUN: ld.lld --hash-style=sysv -shared --retain-symbols-file %t_retain.txt %t -o %t2
-# RUN: llvm-readobj --dyn-symbols %t2 | FileCheck %s
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t.o
+# RUN: echo foo > %t.retain
+# RUN: echo bar >> %t.retain
 
-# CHECK:      DynamicSymbols [
-# CHECK-NEXT:   Symbol {
-# CHECK-NEXT:     Name:
-# CHECK-NEXT:     Value:
-# CHECK-NEXT:     Size:
-# CHECK-NEXT:     Binding:
-# CHECK-NEXT:     Type:
-# CHECK-NEXT:     Other:
-# CHECK-NEXT:     Section:
-# CHECK-NEXT:   }
-# CHECK-NEXT:   Symbol {
-# CHECK-NEXT:     Name: und
-# CHECK-NEXT:     Value:
-# CHECK-NEXT:     Size:
-# CHECK-NEXT:     Binding: Global
-# CHECK-NEXT:     Type:
-# CHECK-NEXT:     Other:
-# CHECK-NEXT:     Section: Undefined
-# CHECK-NEXT:   }
-# CHECK-NEXT:   Symbol {
-# CHECK-NEXT:     Name: foo
-# CHECK-NEXT:     Value:
-# CHECK-NEXT:     Size:
-# CHECK-NEXT:     Binding: Global
-# CHECK-NEXT:     Type:
-# CHECK-NEXT:     Other:
-# CHECK-NEXT:     Section: .text
-# CHECK-NEXT:   }
-# CHECK-NEXT:   Symbol {
-# CHECK-NEXT:     Name: bar
-# CHECK-NEXT:     Value:
-# CHECK-NEXT:     Size:
-# CHECK-NEXT:     Binding: Global
-# CHECK-NEXT:     Type:
-# CHECK-NEXT:     Other:
-# CHECK-NEXT:     Section: .text
-# CHECK-NEXT:   }
-# CHECK-NEXT: ]
+# RUN: ld.lld -shared --retain-symbols-file=%t.retain %t.o -o %t.so
+# RUN: llvm-readelf --dyn-syms %t.so | FileCheck %s --check-prefix=DYN
+
+## Separate-argument form.
+# RUN: ld.lld -shared --retain-symbols-file %t.retain %t.o -o %t2.so
+# RUN: cmp %t.so %t2.so
+
+# DYN:      Symbol table '.dynsym'
+# DYN-DAG:  NOTYPE GLOBAL DEFAULT UND und
+# DYN-DAG:  FUNC GLOBAL DEFAULT {{.*}} foo
+# DYN-DAG:  FUNC GLOBAL DEFAULT {{.*}} bar
+# DYN-NOT:  zed
+# DYN-NOT:  _start
+
+## --emit-relocs/-r preserves symbols referenced by emitted relocations.
+# RUN: ld.lld -shared --emit-relocs --discard-none --retain-symbols-file=%t.retain %t.o -o %t.dn.so
+# RUN: llvm-readelf -r %t.dn.so | FileCheck %s --check-prefix=REL
+# REL-DAG:  R_X86_64_PLT32 {{.*}} zed - 4
+# REL-DAG:  R_X86_64_PLT32 {{.*}} und - 4
+
+## An empty file lists nothing, localizing every defined symbol out of .dynsym.
+# RUN: ld.lld -shared --retain-symbols-file=/dev/null %t.o -o %t.empty.so
+# RUN: llvm-readelf --dyn-syms %t.empty.so | FileCheck %s --check-prefix=EMPTY
+# EMPTY:      Symbol table '.dynsym'
+# EMPTY-NOT:  foo
+# EMPTY-NOT:  bar
+# EMPTY-NOT:  zed
 
 .text
 .globl _start
 _start:
-call zed@PLT
-call und@PLT
+  call zed@PLT
+  call und@PLT
 
 .globl foo
 .type foo,@function
 foo:
-retq
+  retq
 
 .globl bar
 .type bar,@function
 bar:
-retq
+  retq
 
 .globl zed
 .type zed,@function
 zed:
-retq
+  retq
 
 .type loc,@function
 loc:
-retq
+  retq

--- a/lld/test/ELF/retain-und.s
+++ b/lld/test/ELF/retain-und.s
@@ -1,17 +1,17 @@
 # REQUIRES: x86
-# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %s -o %t.o
-# RUN: echo  > %t.retain
-# RUN: echo "{ local: *; }; " > %t.script
+## An empty --retain-symbols-file behaves like a `{ local: *; }` version script,
+## keeping the R_X86_64_64 dynamic relocation to the weak undefined foo.
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t.o
+# RUN: echo > %t.retain
+# RUN: echo '{ local: *; };' > %t.script
 # RUN: ld.lld -shared --version-script %t.script %t.o -o %t1.so
 # RUN: ld.lld -shared --retain-symbols-file %t.retain %t.o -o %t2.so
-# RUN: llvm-readobj -r %t1.so | FileCheck %s
-# RUN: llvm-readobj -r %t2.so | FileCheck %s
+# RUN: llvm-readelf -r %t1.so | FileCheck %s
+# RUN: llvm-readelf -r %t2.so | FileCheck %s
 
-# CHECK:      Relocations [
-# CHECK-NEXT:   Section ({{.*}}) .rela.dyn {
-# CHECK-NEXT:     0x{{.*}} R_X86_64_64 foo 0x0
-# CHECK-NEXT:   }
-# CHECK-NEXT: ]
+# CHECK:      Relocation section '.rela.dyn' {{.+}} contains 1
+# CHECK:      R_X86_64_64 {{.*}} foo + 0
 
 .data
 .quad foo


### PR DESCRIPTION
Switch to llvm-readelf, compact FileCheck directives, and
split-file-style naming. Prepares for a --retain-symbols-file behavior
change.