### PR TITLE
[lldb][RISCV] Fix x8 register aliasing for gdb-remote targets

### DIFF
--- a/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
+++ b/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
@@ -820,7 +820,7 @@ static uint32_t GetGenericNum(llvm::StringRef name) {
       .Case("pc", LLDB_REGNUM_GENERIC_PC)
       .Cases({"ra", "x1"}, LLDB_REGNUM_GENERIC_RA)
       .Cases({"sp", "x2"}, LLDB_REGNUM_GENERIC_SP)
-      .Cases({"fp", "s0"}, LLDB_REGNUM_GENERIC_FP)
+      .Cases({"fp", "s0", "x8"}, LLDB_REGNUM_GENERIC_FP)
       .Cases({"tp", "x4"}, LLDB_REGNUM_GENERIC_TP)
       .Case("a0", LLDB_REGNUM_GENERIC_ARG1)
       .Case("a1", LLDB_REGNUM_GENERIC_ARG2)
@@ -847,9 +847,10 @@ void ABISysV_riscv::AugmentRegisterInfo(
       it.value().alt_name.SetCString("x2");
     else if (it.value().name == "gp")
       it.value().alt_name.SetCString("x3");
-    else if (it.value().name == "fp")
-      it.value().alt_name.SetCString("s0");
-    else if (it.value().name == "tp")
+    else if (it.value().name == "fp") {
+      it.value().name.SetCString("s0");
+      it.value().alt_name.SetCString("x8");
+    } else if (it.value().name == "tp")
       it.value().alt_name.SetCString("x4");
     else if (it.value().name == "s0")
       it.value().alt_name.SetCString("x8");

--- a/lldb/test/API/functionalities/gdb_remote_client/TestGDBServerTargetXML.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGDBServerTargetXML.py
@@ -668,7 +668,7 @@ class TestGDBServerTargetXML(GDBRemoteTestBase):
                 "0102030405060708"  # t0
                 "0102030405060708"  # t1
                 "0102030405060708"  # t2
-                "0102030405060708"  # fp
+                "0102030405060708"  # fp/s0
                 "0102030405060708"  # s1
                 "0102030405060708"  # a0
                 "0102030405060708"  # a1
@@ -780,9 +780,9 @@ class TestGDBServerTargetXML(GDBRemoteTestBase):
         self.match("register read x5", ["t0 = 0x0807060504030201"])
         self.match("register read x6", ["t1 = 0x0807060504030201"])
         self.match("register read x7", ["t2 = 0x0807060504030201"])
-        # Register x8 is probably not working because it has two aliases fp, s0
-        # See issue #127900
-        # self.match("register read x8", ["fp = 0x0807060504030201"])
+        self.match("register read fp", ["s0 = 0x0807060504030201"])
+        self.match("register read s0", ["s0 = 0x0807060504030201"])
+        self.match("register read x8", ["s0 = 0x0807060504030201"])
         self.match("register read x9", ["s1 = 0x0807060504030201"])
         self.match("register read x10", ["a0 = 0x0807060504030201"])
         self.match("register read x11", ["a1 = 0x0807060504030201"])


### PR DESCRIPTION
GDB remote target descriptions can expose the RISC-V `x8` register as `fp`. LLDB previously used `fp` as the primary name and `s0` as the alternate name, leaving no register name for `x8`.

This commit changes `s0` as the primary name, `x8` as the alternate name, and mark the register as the generic frame pointer. Allowing `fp`, `s0`, and `x8` to resolve to the same register.

Fixes #127900