### PR TITLE
[clang][Driver] Remove duplicate KernelAddress sanitizer kind. NFC.

### DIFF
--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -705,7 +705,7 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
       std::make_pair(SanitizerKind::Type,
                      SanitizerKind::Address | SanitizerKind::KernelAddress |
                          SanitizerKind::Memory | SanitizerKind::Leak |
-                         SanitizerKind::Thread | SanitizerKind::KernelAddress),
+                         SanitizerKind::Thread),
       std::make_pair(SanitizerKind::Thread, SanitizerKind::Memory),
       std::make_pair(SanitizerKind::Leak,
                      SanitizerKind::Thread | SanitizerKind::Memory),


### PR DESCRIPTION
Remove the duplicate `SanitizerKind::KernelAddress` entry from the list of sanitizers incompatible with `TypeSanitizer`.

Found using clang-tidy, with check `misc-redundant-expression`