### PR TITLE
[clang][OpenMP][test] Use -fopenmp=libomp explicitly in clang driver test

### DIFF
--- a/clang/test/Driver/amdgpu-openmp-gpu-max-threads-per-block.c
+++ b/clang/test/Driver/amdgpu-openmp-gpu-max-threads-per-block.c
@@ -1,5 +1,5 @@
 // Test that --gpu-max-threads-per-block is not ignored by openmp.
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa \
 // RUN:   --offload-arch=gfx906 -nogpulib --gpu-max-threads-per-block=256 %s 2>&1 | FileCheck %s
 
 // CHECK: "-cc1" "-triple" "amdgcn-amd-amdhsa"


### PR DESCRIPTION
Explicitly pass -fopenmp=libomp in the test to make it robust against downstream configurations where the default OpenMP runtime is set to something else (e.g., libgomp). Seems this is in alignment with other tests in `clang/test/Driver`. 