### PR TITLE
[lldb][test] Fix TestStatusline path resolution in symlinked environments

### DIFF
--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -132,9 +132,7 @@ class TestStatusline(PExpectTest):
         self.resize()
         self.expect("settings set show-statusline true", ["no target"])
 
-        flood = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "statusline_flood.py"
-        )
+        flood = self.getSourcePath("statusline_flood.py")
         self.expect('command script import "{}"'.format(flood))
 
         tee = CaptureTee()


### PR DESCRIPTION
Fixes a test timeout in TestStatusline.py introduced in commit a35565161078 (#208609) when running in environments with symlinked source paths.