### PR TITLE
[GitHub] Install libedit, libxml2 and liblzma to be used in Linux LLDB builds

### DIFF
--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -46,13 +46,17 @@ COPY --from=stage1-toolchain $LLVM_SYSROOT $LLVM_SYSROOT
 # Need perl-modules for clang analyzer tests.
 # Need git for SPIRV-Tools tests.
 # Need binutils-dev instead of binutils to build the linker LTO plugin.
+# Need libedit, libxml2 and lzma for LLDB.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     binutils-dev \
     cmake \
     curl \
     git \
+    libedit-dev \
+    liblzma-dev \
     libstdc++-11-dev \
+    libxml2-dev \
     ninja-build \
     nodejs \
     perl-modules \


### PR DESCRIPTION
In #188049 we missed some test failures because GitHub CI does not have libxml2 installed. I checked the logs and found a couple of other things missing.

In this change I'm adding to the Linux container:
* libedit
* libxml2
* liblzma

I am not adding ncurses because this would enable text user interface tests that are often unstable. They do run post-commit, and don't change that often anyway.

I am not adding Lua or TreeSitter because they are more obscure and are tested somewhere post-commit (in Green Dragon I think).