### PR TITLE
[libc++] Remove {Pause,Resume}Timing from fast push_back benchmarks

### DIFF
--- a/libcxx/test/benchmarks/containers/sequence/sequence_container_benchmarks.h
+++ b/libcxx/test/benchmarks/containers/sequence/sequence_container_benchmarks.h
@@ -372,9 +372,7 @@ void sequence_container_benchmarks(std::string container) {
             }
             DoNotOptimizeData(c);
 
-            st.PauseTiming();
             c.erase(c.end() - BatchSize, c.end());
-            st.ResumeTiming();
           }
         });
     }
@@ -396,7 +394,7 @@ void sequence_container_benchmarks(std::string container) {
           DoNotOptimizeData(c);
 
           st.PauseTiming();
-          c.clear();
+          c = Container();
           st.ResumeTiming();
         }
       });


### PR DESCRIPTION
These benchmarks are expected to run for a very short time, and `{Pause,Resume}Timing` should only be used when operations are expected to take a long time. Removing them reduces the amount of noise in these benchmarks.

Fixes #208719