### PR TITLE
[offload][test] Add fallback to legacy AMDGPU triple library dir

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -247,9 +247,16 @@ if config.libomptarget_current_target in host_targets:
     config.available_features.add('host')
 
 def get_target_library_dir():
-    return os.path.join(
-        config.llvm_library_dir,
-        remove_suffix_if_present(config.libomptarget_current_target))
+    target = remove_suffix_if_present(config.libomptarget_current_target)
+    library_dir = os.path.join(config.llvm_library_dir, target)
+    # The AMDGPU offload triple was renamed amdgcn-amd-amdhsa ->
+    # amdgpu-amd-amdhsa. Fall back to the legacy directory when the runtime was
+    # built under the old triple name.
+    if target == amdgpu_target and not os.path.isdir(library_dir):
+        legacy_dir = os.path.join(config.llvm_library_dir, legacy_amdgpu_target)
+        if os.path.isdir(legacy_dir):
+            return legacy_dir
+    return library_dir
 
 if "gpu" in config.available_features and "intelgpu" not in config.available_features:
     config.test_flags += " -Xoffload-linker -L" + get_target_library_dir()


### PR DESCRIPTION
After the amdgcn-amd-amdhsa -> amdgpu-amd-amdhsa rename, look up the device runtime libraries in the legacy directory when the runtime was built under the old triple name.

Claude assisted with this patch.