### PR TITLE
[orc-rt] Rename orc-executor to ogre

### DIFF
--- a/orc-rt/test/CMakeLists.txt
+++ b/orc-rt/test/CMakeLists.txt
@@ -12,7 +12,7 @@ if (ORC_RT_LLVM_TOOLS_AVAILABLE)
   add_subdirectory(tools)
 
   list(APPEND ORC_RT_TEST_DEPS
-    orc-executor
+    ogre
     orc-rt-log-check
     orc-rt-smoke-check
   )

--- a/orc-rt/test/regression/init.test
+++ b/orc-rt/test/regression/init.test
@@ -1,1 +1,1 @@
-RUN: orc-executor %s %s
+RUN: ogre %s %s

--- a/orc-rt/test/regression/lit.cfg.py
+++ b/orc-rt/test/regression/lit.cfg.py
@@ -22,7 +22,7 @@ test_tools_dir = os.path.join(config.orc_rt_obj_root, "test", "tools")
 
 llvm_config.with_environment(
     "PATH",
-    os.path.join(config.orc_rt_obj_root, "tools", "orc-executor"),
+    os.path.join(config.orc_rt_obj_root, "tools", "ogre"),
     append_path=True)
 llvm_config.with_environment("PATH", test_tools_dir, append_path=True)
 

--- a/orc-rt/tools/CMakeLists.txt
+++ b/orc-rt/tools/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_subdirectory(orc-executor)
+add_subdirectory(ogre)

--- a/orc-rt/tools/ogre/CMakeLists.txt
+++ b/orc-rt/tools/ogre/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(ogre ogre.cpp)
+target_link_libraries(ogre PRIVATE orc-rt-executor)

--- a/orc-rt/tools/ogre/ogre.cpp
+++ b/orc-rt/tools/ogre/ogre.cpp
@@ -1,4 +1,4 @@
-//===- orc-executor.cpp - Placeholder implementation for orc-rt ----------===//
+//===- ogre.cpp - ORC Generic Runtime Environment -------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Placeholder implementation file for initial orc-rt checkin.
+// The ORC Generic Runtime Environment (OGRE) is intended as a canonical
+// "blank executor".
 //
 //===----------------------------------------------------------------------===//
 

--- a/orc-rt/tools/orc-executor/CMakeLists.txt
+++ b/orc-rt/tools/orc-executor/CMakeLists.txt
@@ -1,2 +1,0 @@
-add_executable(orc-executor orc-executor.cpp)
-target_link_libraries(orc-executor PRIVATE orc-rt-executor)


### PR DESCRIPTION
The ORC Generic Runtime Environment (OGRE) will serve as our canonical "blank executor" program: A program that simply listens for an ORC controller connection, then runs whatever program is provided to it by the controller.