### PR TITLE
[orc-rt] Remove redundant [[nodiscard]] from runFinalizeActions. NFC.

### DIFF
--- a/orc-rt/include/orc-rt/AllocAction.h
+++ b/orc-rt/include/orc-rt/AllocAction.h
@@ -74,7 +74,7 @@ struct AllocActionPair {
 ///
 /// Both finalize and dealloc actions are permitted to be null (i.e. have a
 /// null action function) in which case they are ignored.
-[[nodiscard]] Expected<std::vector<AllocAction>>
+Expected<std::vector<AllocAction>>
 runFinalizeActions(std::vector<AllocActionPair> AAPs);
 
 /// Run the given deallocation actions in revwerse order.


### PR DESCRIPTION
runFinalizeActions returns an Expected, which already carries a nodiscard attribute.