### PR TITLE
[orc-rt] Replace ORC_RT_NODISCARD with [[nodiscard]]. NFCI.

### DIFF
--- a/orc-rt/include/orc-rt/Compiler.h
+++ b/orc-rt/include/orc-rt/Compiler.h
@@ -39,22 +39,6 @@
 #endif
 #endif
 
-// Use the 'nodiscard' attribute in C++17 or newer mode.
-#if defined(__cplusplus) && __cplusplus > 201402L &&                           \
-    ORC_RT_HAS_CPP_ATTRIBUTE(nodiscard)
-#define ORC_RT_NODISCARD [[nodiscard]]
-#elif ORC_RT_HAS_CPP_ATTRIBUTE(clang::warn_unused_result)
-#define ORC_RT_NODISCARD [[clang::warn_unused_result]]
-// Clang in C++14 mode claims that it has the 'nodiscard' attribute, but also
-// warns in the pedantic mode that 'nodiscard' is a C++17 extension (PR33518).
-// Use the 'nodiscard' attribute in C++14 mode only with GCC.
-// TODO: remove this workaround when PR33518 is resolved.
-#elif defined(__GNUC__) && ORC_RT_HAS_CPP_ATTRIBUTE(nodiscard)
-#define ORC_RT_NODISCARD [[nodiscard]]
-#else
-#define ORC_RT_NODISCARD
-#endif
-
 #if __has_builtin(__builtin_expect)
 #define ORC_RT_LIKELY(EXPR) __builtin_expect((bool)(EXPR), true)
 #define ORC_RT_UNLIKELY(EXPR) __builtin_expect((bool)(EXPR), false)

--- a/orc-rt/include/orc-rt/Error.h
+++ b/orc-rt/include/orc-rt/Error.h
@@ -82,7 +82,7 @@ template <typename ThisT, typename ParentT>
 char ErrorExtends<ThisT, ParentT>::ID = 0;
 
 /// Represents an environmental error.
-class ORC_RT_NODISCARD Error {
+class [[nodiscard]] Error {
 
   template <typename T> friend class Expected;
 
@@ -356,7 +356,7 @@ private:
 /// Expected constructor for details.
 struct ForceExpectedSuccessValue {};
 
-template <typename T> class ORC_RT_NODISCARD Expected {
+template <typename T> class [[nodiscard]] Expected {
 
   template <class OtherT> friend class Expected;
 


### PR DESCRIPTION
The ORC runtime requires C++17, so we can use the C++17 [[nodiscard]] attribute directly, rather than going through a macro.