### PR TITLE
[compiler-rt][test] Use configured Python for lit page-size probe

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -978,7 +978,7 @@ def target_page_size():
         return 4096
     try:
         proc = subprocess.Popen(
-            f"{emulator or ''} python3",
+            f"{emulator or ''} {shlex.quote(config.python_executable)}",
             shell=True,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
Use the same Python executable configured for the test suite, rather than relying on python3 being on PATH.