### PR TITLE
[orc-rt] Add ReportErrorsViaSession utility.

### DIFF
--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -527,6 +527,17 @@ private:
   NotificationService &Notifiers;
 };
 
+/// Helper function object to report errors via the given Session's
+/// reportError method.
+class ReportErrorsViaSession {
+public:
+  explicit ReportErrorsViaSession(Session &S) : S(S) {}
+  void operator()(Error Err) const { S.reportError(std::move(Err)); }
+
+private:
+  Session &S;
+};
+
 } // namespace orc_rt
 
 #endif // ORC_RT_SESSION_H

--- a/orc-rt/test/unit/SessionTest.cpp
+++ b/orc-rt/test/unit/SessionTest.cpp
@@ -316,6 +316,21 @@ TEST(SessionTest, ReportError) {
     ADD_FAILURE() << "Missing error value";
 }
 
+TEST(SessionTest, ReportErrorsViaSession) {
+  Error E = Error::success();
+  cantFail(std::move(E)); // Force error into checked state.
+
+  // Check that the ReportErrorsViaSession utility works as advertised.
+  Session S(mockExecutorProcessInfo(), noDispatch,
+            [&](Error Err) { E = std::move(Err); });
+  (ReportErrorsViaSession(S))(make_error<StringError>("foo"));
+
+  if (E)
+    EXPECT_EQ(toString(std::move(E)), "foo");
+  else
+    ADD_FAILURE() << "Missing error value";
+}
+
 TEST(SessionTest, SingleService) {
   size_t OpIdx = 0;
   std::optional<size_t> DetachOpIdx;


### PR DESCRIPTION
ReportErrorsViaSession is a function object constructed from a Session& that forwards Errors to that Session's reportError method. It will be used in upcoming patches to simplify some error reporting plumbing.