### PR TITLE
[analyzer] Fix stale z3 analyzer-constraints name in test z3-logicalexpr-eval.c

### DIFF
--- a/clang/test/Analysis/z3/z3-logicalexpr-eval.c
+++ b/clang/test/Analysis/z3/z3-logicalexpr-eval.c
@@ -1,5 +1,5 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection \
-// RUN:   -analyzer-constraints=z3 -verify %s
+// RUN:   -analyzer-constraints=unsupported-z3 -verify %s
 // REQUIRES: z3
 
 void clang_analyzer_eval(int);


### PR DESCRIPTION
z3 was recently renamed to unsupported-z3.

Change the analyzer-constraints to unsupported-z3 in the test file z3-logicalexpr-eval.c