### PR TITLE
[ExtractAPI] Include availability attributes for anonymous typedefs

### DIFF
--- a/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
+++ b/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
@@ -602,16 +602,20 @@ bool ExtractAPIVisitorBase<Derived>::VisitRecordDecl(const RecordDecl *Decl) {
   DeclarationFragments SubHeading =
       DeclarationFragmentsBuilder::getSubHeading(Decl);
 
+  AvailabilityInfo Availability = AvailabilityInfo::createFromDecl(Decl);
+  if (const auto *TypedefDecl = Decl->getTypedefNameForAnonDecl())
+    Availability.mergeWith(AvailabilityInfo::createFromDecl(TypedefDecl));
+
   if (Decl->isUnion())
     API.createRecord<UnionRecord>(
-        USR, Name, createHierarchyInformationForDecl(*Decl), Loc,
-        AvailabilityInfo::createFromDecl(Decl), Comment, Declaration,
-        SubHeading, isInSystemHeader(Decl), isEmbeddedInVarDeclarator(*Decl));
+        USR, Name, createHierarchyInformationForDecl(*Decl), Loc, Availability,
+        Comment, Declaration, SubHeading, isInSystemHeader(Decl),
+        isEmbeddedInVarDeclarator(*Decl));
   else
     API.createRecord<StructRecord>(
-        USR, Name, createHierarchyInformationForDecl(*Decl), Loc,
-        AvailabilityInfo::createFromDecl(Decl), Comment, Declaration,
-        SubHeading, isInSystemHeader(Decl), isEmbeddedInVarDeclarator(*Decl));
+        USR, Name, createHierarchyInformationForDecl(*Decl), Loc, Availability,
+        Comment, Declaration, SubHeading, isInSystemHeader(Decl),
+        isEmbeddedInVarDeclarator(*Decl));
 
   return true;
 }

--- a/clang/test/ExtractAPI/availability_typedef_anonymous_record.c
+++ b/clang/test/ExtractAPI/availability_typedef_anonymous_record.c
@@ -1,0 +1,24 @@
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -extract-api --pretty-sgf --emit-sgf-symbol-labels-for-testing -triple arm64-apple-macosx \
+// RUN:   -x c-header %s -o %t/output.symbols.json -verify
+
+// RUN: FileCheck %s --input-file %t/output.symbols.json --check-prefix STRUCT
+
+typedef struct {
+  int x;
+} MyStruct __attribute__((availability(macos, introduced=12.0)));
+
+// STRUCT-LABEL: "!testLabel": "c:@SA@MyStruct"
+// STRUCT:      "availability": [
+// STRUCT-NEXT:   {
+// STRUCT-NEXT:     "domain": "macos",
+// STRUCT-NEXT:     "introduced": {
+// STRUCT-NEXT:       "major": 12,
+// STRUCT-NEXT:       "minor": 0,
+// STRUCT-NEXT:       "patch": 0
+// STRUCT-NEXT:     }
+// STRUCT-NEXT:   }
+// STRUCT-NEXT: ]
+// STRUCT:      "title": "MyStruct"
+
+// expected-no-diagnostics


### PR DESCRIPTION
When an anonymous type is defined and has availability attributes, the attributes are attached to the typedef rather than the type being defined. This patch updates the anonymous type handling logic to merge the availability from the typedef in order to correctly include it in the symbol graph.

rdar://125497949