### PR TITLE
[webkit.UncountedLambdaCapturesChecker] Improve the warning text

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
@@ -562,20 +562,6 @@ public:
     BR->emitReport(std::move(Report));
   }
 
-  ObjCInterfaceDecl *getObjCDecl(const Type *TypePtr) const {
-    auto *PointeeType = TypePtr->getPointeeType().getTypePtrOrNull();
-    if (!PointeeType)
-      return nullptr;
-    auto *Desugared = PointeeType->getUnqualifiedDesugaredType();
-    if (!Desugared)
-      return nullptr;
-    if (auto *ObjCType = dyn_cast<ObjCInterfaceType>(Desugared))
-      return ObjCType->getDecl();
-    if (auto *ObjCType = dyn_cast<ObjCObjectType>(Desugared))
-      return ObjCType->getInterface();
-    return nullptr;
-  }
-
   void reportBugOnThisPtr(const LambdaCapture &Capture,
                           const QualType T) const {
     SmallString<100> Buf;
@@ -608,7 +594,7 @@ public:
     if (auto *RD = T->getPointeeType()->getAsRecordDecl()) {
       Os << " ";
       printQuotedQualifiedName(Os, RD);
-    } else if (auto *ObjCDecl = getObjCDecl(T)) {
+    } else if (auto *ObjCDecl = getObjCDeclFromObjCPtr(T)) {
       Os << " ";
       printQuotedQualifiedName(Os, ObjCDecl);
     }
@@ -629,7 +615,7 @@ public:
     return isRefType(Name);
   }
 
-  const char *typeName() const final { return "ref-countable type"; }
+  const char *typeName() const final { return "RefPtr-capable type"; }
 };
 
 class UncheckedLambdaCapturesChecker : public RawPtrRefLambdaCapturesChecker {
@@ -646,7 +632,7 @@ public:
     return isCheckedPtr(Name);
   }
 
-  const char *typeName() const final { return "CheckedPtr capable type"; }
+  const char *typeName() const final { return "CheckedPtr-capable type"; }
 };
 
 class UnretainedLambdaCapturesChecker : public RawPtrRefLambdaCapturesChecker {
@@ -667,7 +653,7 @@ public:
     return isRetainPtrOrOSPtr(Name);
   }
 
-  const char *typeName() const final { return "retainable type"; }
+  const char *typeName() const final { return "RetainPtr-capable type"; }
 
   void printPointer(llvm::raw_svector_ostream &Os, const Type *T) const final {
     if (auto *ObjCPtr = dyn_cast<ObjCObjectPointerType>(T)) {

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-lambda-captures.cpp
@@ -18,22 +18,22 @@ void callAsync(const WTF::Function<void()>&);
 void raw_ptr() {
   CheckedObj* checked_ptr_capable = make_obj();
   auto foo1 = [checked_ptr_capable](){
-    // expected-warning@-1{{Captured variable 'checked_ptr_capable' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'checked_ptr_capable' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
     checked_ptr_capable->method();
   };
   auto foo2 = [&checked_ptr_capable](){
-    // expected-warning@-1{{Captured variable 'checked_ptr_capable' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'checked_ptr_capable' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
     checked_ptr_capable->method();
   };
   auto foo3 = [&](){
     checked_ptr_capable->method();
-    // expected-warning@-1{{Implicitly captured variable 'checked_ptr_capable' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'checked_ptr_capable' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
     checked_ptr_capable = nullptr;
   };
 
   auto foo4 = [=](){
     checked_ptr_capable->method();
-    // expected-warning@-1{{Implicitly captured variable 'checked_ptr_capable' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'checked_ptr_capable' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   };
 
   call(foo1);
@@ -53,9 +53,9 @@ void references() {
   CheckedObj& checked_ptr_capable_ref = automatic;
   auto foo1 = [checked_ptr_capable_ref](){ checked_ptr_capable_ref.constMethod(); };
   auto foo2 = [&checked_ptr_capable_ref](){ checked_ptr_capable_ref.method(); };
-  // expected-warning@-1{{Captured variable 'checked_ptr_capable_ref' is a raw reference to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+  // expected-warning@-1{{Captured variable 'checked_ptr_capable_ref' is a raw reference to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   auto foo3 = [&](){ checked_ptr_capable_ref.method(); };
-  // expected-warning@-1{{Implicitly captured variable 'checked_ptr_capable_ref' is a raw reference to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+  // expected-warning@-1{{Implicitly captured variable 'checked_ptr_capable_ref' is a raw reference to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   auto foo4 = [=](){ checked_ptr_capable_ref.constMethod(); };
 
   call(foo1);
@@ -109,7 +109,7 @@ void noescape_lambda() {
     otherObj->method();
   }, [&](CheckedObj& obj) {
     otherObj->method();
-    // expected-warning@-1{{Implicitly captured variable 'otherObj' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'otherObj' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   });
   ([&] {
     someObj->method();
@@ -139,7 +139,7 @@ struct CheckedObjWithLambdaCapturingThis {
   void method_captures_this_unsafe() {
     auto lambda = [&]() {
       nonTrivial();
-      // expected-warning@-1{{Implicitly captured variable 'this' is a raw pointer to CheckedPtr capable type 'CheckedObjWithLambdaCapturingThis' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Implicitly captured variable 'this' is a raw pointer to CheckedPtr-capable type 'CheckedObjWithLambdaCapturingThis' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
     };
     call(lambda);
   }
@@ -147,7 +147,7 @@ struct CheckedObjWithLambdaCapturingThis {
   void method_captures_this_unsafe_capture_local_var_explicitly() {
     CheckedObj* x = make_obj();
     call([this, protectedThis = CheckedPtr { this }, x]() {
-      // expected-warning@-1{{Captured variable 'x' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'x' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
       nonTrivial();
       x->method();
     });
@@ -156,7 +156,7 @@ struct CheckedObjWithLambdaCapturingThis {
   void method_captures_this_with_other_protected_var() {
     CheckedObj* x = make_obj();
     call([this, protectedX = CheckedPtr { x }]() {
-      // expected-warning@-1{{Captured variable 'this' is a raw pointer to CheckedPtr capable type 'CheckedObjWithLambdaCapturingThis' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'this' is a raw pointer to CheckedPtr-capable type 'CheckedObjWithLambdaCapturingThis' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
       nonTrivial();
       protectedX->method();
     });
@@ -165,7 +165,7 @@ struct CheckedObjWithLambdaCapturingThis {
   void method_captures_this_unsafe_capture_local_var_explicitly_with_deref() {
     CheckedObj* x = make_obj();
     call([this, protectedThis = CheckedRef { *this }, x]() {
-      // expected-warning@-1{{Captured variable 'x' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'x' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
       nonTrivial();
       x->method();
     });
@@ -174,7 +174,7 @@ struct CheckedObjWithLambdaCapturingThis {
   void method_captures_this_unsafe_local_var_via_vardecl() {
     CheckedObj* x = make_obj();
     auto lambda = [this, protectedThis = CheckedRef { *this }, x]() {
-      // expected-warning@-1{{Captured variable 'x' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'x' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
       nonTrivial();
       x->method();
     };
@@ -252,7 +252,7 @@ struct CheckedObjWithLambdaCapturingThis {
   void method_nested_lambda3() {
     callAsync([this, protectedThis = CheckedPtr { this }] {
       callAsync([this] {
-        // expected-warning@-1{{Captured variable 'this' is a raw pointer to CheckedPtr capable type 'CheckedObjWithLambdaCapturingThis' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+        // expected-warning@-1{{Captured variable 'this' is a raw pointer to CheckedPtr-capable type 'CheckedObjWithLambdaCapturingThis' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
         nonTrivial();
       });
     });
@@ -321,11 +321,11 @@ void lambda_converted_to_function(CheckedObj* obj)
 {
   callFunction([&]() {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   });
   callFunctionOpaque([&]() {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   });
 }
 
@@ -335,7 +335,7 @@ void capture_copy_in_lambda(CheckedObj& checked) {
   });
   auto* ptr = &checked;
   callFunctionOpaque([ptr]() mutable {
-    // expected-warning@-1{{Captured variable 'ptr' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'ptr' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
     ptr->method();
   });
 }
@@ -436,7 +436,7 @@ void doWhateverWith(WTF::ScopeExit& obj);
 void scope_exit_with_side_effect(CheckedObj* obj) {
   auto scope = WTF::makeScopeExit([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   });
   doWhateverWith(scope);
 }
@@ -444,14 +444,14 @@ void scope_exit_with_side_effect(CheckedObj* obj) {
 void scope_exit_static(CheckedObj* obj) {
   static auto scope = WTF::makeScopeExit([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   });
 }
 
 WTF::Function<void()> scope_exit_take_lambda(CheckedObj* obj) {
   auto scope = WTF::makeScopeExit([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   });
   return scope.take();
 }
@@ -460,7 +460,7 @@ WTF::Function<void()> scope_exit_take_lambda(CheckedObj* obj) {
 void scope_exit_release(CheckedObj* obj) {
   auto scope = WTF::makeScopeExit([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   });
   scope.release();
 }
@@ -486,7 +486,7 @@ void bad_visit(Visitor&, ObjectType*) {
 void static_visitor(CheckedObj* obj) {
   static auto visitor = WTF::makeVisitor([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   });
 }
 
@@ -494,10 +494,10 @@ void make_visitor_with_multiple_lambdas(CheckedObj* obj) {
   auto* otherObj = make_obj();
   auto visitor = WTF::makeVisitor([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   }, [&] {
     otherObj->method();
-    // expected-warning@-1{{Implicitly captured variable 'otherObj' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'otherObj' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   });
   bad_visit(visitor, obj);
 }
@@ -505,7 +505,7 @@ void make_visitor_with_multiple_lambdas(CheckedObj* obj) {
 void bad_use_visitor(CheckedObj* obj) {
   auto visitor = WTF::makeVisitor([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to CheckedPtr-capable type 'CheckedObj' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
   });
   bad_visit(visitor, obj);
 }
@@ -514,14 +514,14 @@ class LambdaInConstructorDestructor {
 public:
   LambdaInConstructorDestructor() {
     call([this]() {
-      // expected-warning@-1{{Captured variable 'this' is a raw pointer to CheckedPtr capable type 'LambdaInConstructorDestructor' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'this' is a raw pointer to CheckedPtr-capable type 'LambdaInConstructorDestructor' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
       doWork();
     });
   }
 
   ~LambdaInConstructorDestructor() {
     call([this]() {
-      // expected-warning@-1{{Captured variable 'this' is a raw pointer to CheckedPtr capable type 'LambdaInConstructorDestructor' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'this' is a raw pointer to CheckedPtr-capable type 'LambdaInConstructorDestructor' [alpha.webkit.UncheckedLambdaCapturesChecker]}}
       doWork();
     });
   }

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures-decl-protects-this-crash.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures-decl-protects-this-crash.cpp
@@ -28,9 +28,9 @@ struct Obj {
 
   void foo(Foo foo) {
     bar([this](auto baz) {
-      // expected-warning@-1{{Captured variable 'this' is a raw pointer to ref-countable type 'Obj' [webkit.UncountedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'this' is a raw pointer to RefPtr-capable type 'Obj' [webkit.UncountedLambdaCapturesChecker]}}
       bar([this, foo = *baz, foo2 = !baz](auto&&) {
-        // expected-warning@-1{{Captured variable 'this' is a raw pointer to ref-countable type 'Obj' [webkit.UncountedLambdaCapturesChecker]}}
+        // expected-warning@-1{{Captured variable 'this' is a raw pointer to RefPtr-capable type 'Obj' [webkit.UncountedLambdaCapturesChecker]}}
         someFunction();
       });
     });

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -18,22 +18,22 @@ void callAsync(const WTF::Function<void()>&);
 void raw_ptr() {
   RefCountable* ref_countable = make_obj();
   auto foo1 = [ref_countable](){
-    // expected-warning@-1{{Captured variable 'ref_countable' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'ref_countable' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
     ref_countable->method();
   };
   auto foo2 = [&ref_countable](){
-    // expected-warning@-1{{Captured variable 'ref_countable' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'ref_countable' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
     ref_countable->method();
   };
   auto foo3 = [&](){
     ref_countable->method();
-    // expected-warning@-1{{Implicitly captured variable 'ref_countable' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'ref_countable' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
     ref_countable = nullptr;
   };
 
   auto foo4 = [=](){
     ref_countable->method();
-    // expected-warning@-1{{Implicitly captured variable 'ref_countable' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'ref_countable' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   };
 
   call(foo1);
@@ -53,9 +53,9 @@ void references() {
   RefCountable& ref_countable_ref = automatic;
   auto foo1 = [ref_countable_ref](){ ref_countable_ref.constMethod(); };
   auto foo2 = [&ref_countable_ref](){ ref_countable_ref.method(); };
-  // expected-warning@-1{{Captured variable 'ref_countable_ref' is a raw reference to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+  // expected-warning@-1{{Captured variable 'ref_countable_ref' is a raw reference to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   auto foo3 = [&](){ ref_countable_ref.method(); };
-  // expected-warning@-1{{Implicitly captured variable 'ref_countable_ref' is a raw reference to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+  // expected-warning@-1{{Implicitly captured variable 'ref_countable_ref' is a raw reference to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   auto foo4 = [=](){ ref_countable_ref.constMethod(); };
 
   call(foo1);
@@ -109,7 +109,7 @@ void noescape_lambda() {
     otherObj->method();
   }, [&](RefCountable& obj) {
     otherObj->method();
-    // expected-warning@-1{{Implicitly captured variable 'otherObj' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'otherObj' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   });
   ([&] {
     someObj->method();
@@ -139,7 +139,7 @@ struct RefCountableWithLambdaCapturingThis {
   void method_captures_this_unsafe() {
     auto lambda = [&]() {
       nonTrivial();
-      // expected-warning@-1{{Implicitly captured variable 'this' is a raw pointer to ref-countable type 'RefCountableWithLambdaCapturingThis' [webkit.UncountedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Implicitly captured variable 'this' is a raw pointer to RefPtr-capable type 'RefCountableWithLambdaCapturingThis' [webkit.UncountedLambdaCapturesChecker]}}
     };
     call(lambda);
   }
@@ -147,7 +147,7 @@ struct RefCountableWithLambdaCapturingThis {
   void method_captures_this_unsafe_capture_local_var_explicitly() {
     RefCountable* x = make_obj();
     call([this, protectedThis = RefPtr { this }, x]() {
-      // expected-warning@-1{{Captured variable 'x' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'x' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
       nonTrivial();
       x->method();
     });
@@ -156,7 +156,7 @@ struct RefCountableWithLambdaCapturingThis {
   void method_captures_this_with_other_protected_var() {
     RefCountable* x = make_obj();
     call([this, protectedX = RefPtr { x }]() {
-      // expected-warning@-1{{Captured variable 'this' is a raw pointer to ref-countable type 'RefCountableWithLambdaCapturingThis' [webkit.UncountedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'this' is a raw pointer to RefPtr-capable type 'RefCountableWithLambdaCapturingThis' [webkit.UncountedLambdaCapturesChecker]}}
       nonTrivial();
       protectedX->method();
     });
@@ -165,7 +165,7 @@ struct RefCountableWithLambdaCapturingThis {
   void method_captures_this_unsafe_capture_local_var_explicitly_with_deref() {
     RefCountable* x = make_obj();
     call([this, protectedThis = Ref { *this }, x]() {
-      // expected-warning@-1{{Captured variable 'x' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'x' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
       nonTrivial();
       x->method();
     });
@@ -174,7 +174,7 @@ struct RefCountableWithLambdaCapturingThis {
   void method_captures_this_unsafe_local_var_via_vardecl() {
     RefCountable* x = make_obj();
     auto lambda = [this, protectedThis = Ref { *this }, x]() {
-      // expected-warning@-1{{Captured variable 'x' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'x' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
       nonTrivial();
       x->method();
     };
@@ -252,7 +252,7 @@ struct RefCountableWithLambdaCapturingThis {
   void method_nested_lambda3() {
     callAsync([this, protectedThis = RefPtr { this }] {
       callAsync([this] {
-        // expected-warning@-1{{Captured variable 'this' is a raw pointer to ref-countable type 'RefCountableWithLambdaCapturingThis' [webkit.UncountedLambdaCapturesChecker]}}
+        // expected-warning@-1{{Captured variable 'this' is a raw pointer to RefPtr-capable type 'RefCountableWithLambdaCapturingThis' [webkit.UncountedLambdaCapturesChecker]}}
         nonTrivial();
       });
     });
@@ -321,11 +321,11 @@ void lambda_converted_to_function(RefCountable* obj)
 {
   callFunction([&]() {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   });
   callFunctionOpaque([&]() {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   });
 }
 
@@ -425,7 +425,7 @@ void doWhateverWith(WTF::ScopeExit& obj);
 void scope_exit_with_side_effect(RefCountable* obj) {
   auto scope = WTF::makeScopeExit([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   });
   doWhateverWith(scope);
 }
@@ -433,14 +433,14 @@ void scope_exit_with_side_effect(RefCountable* obj) {
 void scope_exit_static(RefCountable* obj) {
   static auto scope = WTF::makeScopeExit([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   });
 }
 
 WTF::Function<void()> scope_exit_take_lambda(RefCountable* obj) {
   auto scope = WTF::makeScopeExit([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   });
   return scope.take();
 }
@@ -449,7 +449,7 @@ WTF::Function<void()> scope_exit_take_lambda(RefCountable* obj) {
 void scope_exit_release(RefCountable* obj) {
   auto scope = WTF::makeScopeExit([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   });
   scope.release();
 }
@@ -475,7 +475,7 @@ void bad_visit(Visitor&, ObjectType*) {
 void static_visitor(RefCountable* obj) {
   static auto visitor = WTF::makeVisitor([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   });
 }
 
@@ -483,10 +483,10 @@ void make_visitor_with_multiple_lambdas(RefCountable* obj) {
   auto* otherObj = make_obj();
   auto visitor = WTF::makeVisitor([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   }, [&] {
     otherObj->method();
-    // expected-warning@-1{{Implicitly captured variable 'otherObj' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'otherObj' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   });
   bad_visit(visitor, obj);
 }
@@ -494,7 +494,7 @@ void make_visitor_with_multiple_lambdas(RefCountable* obj) {
 void bad_use_visitor(RefCountable* obj) {
   auto visitor = WTF::makeVisitor([&] {
     obj->method();
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to ref-countable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RefPtr-capable type 'RefCountable' [webkit.UncountedLambdaCapturesChecker]}}
   });
   bad_visit(visitor, obj);
 }
@@ -503,14 +503,14 @@ class LambdaInConstructorDestructor {
 public:
   LambdaInConstructorDestructor() {
     call([this]() {
-      // expected-warning@-1{{Captured variable 'this' is a raw pointer to ref-countable type 'LambdaInConstructorDestructor' [webkit.UncountedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'this' is a raw pointer to RefPtr-capable type 'LambdaInConstructorDestructor' [webkit.UncountedLambdaCapturesChecker]}}
       doWork();
     });
   }
 
   ~LambdaInConstructorDestructor() {
     call([this]() {
-      // expected-warning@-1{{Captured variable 'this' is a raw pointer to ref-countable type 'LambdaInConstructorDestructor' [webkit.UncountedLambdaCapturesChecker]}}
+      // expected-warning@-1{{Captured variable 'this' is a raw pointer to RefPtr-capable type 'LambdaInConstructorDestructor' [webkit.UncountedLambdaCapturesChecker]}}
       doWork();
     });
   }

--- a/clang/test/Analysis/Checkers/WebKit/unretained-lambda-captures-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-lambda-captures-arc.mm
@@ -139,21 +139,21 @@ void raw_ptr() {
   
   auto cf = make_cf();
   auto bar1 = [cf](){
-    // expected-warning@-1{{Captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     CFArrayAppendValue(cf, nullptr);
   };
   auto bar2 = [&cf](){
-    // expected-warning@-1{{Captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     CFArrayAppendValue(cf, nullptr);
   };
   auto bar3 = [&](){
     CFArrayAppendValue(cf, nullptr);
-    // expected-warning@-1{{Implicitly captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     cf = nullptr;
   };
   auto bar4 = [=](){
     CFArrayAppendValue(cf, nullptr);
-    // expected-warning@-1{{Implicitly captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
   };
 
   auto os = make_os();
@@ -255,7 +255,7 @@ void noescape_lambda() {
     CFArrayAppendValue(someCF, nullptr);
   }, [&](CFIndex count) {
     CFArrayAppendValue(someCF, nullptr);
-    // expected-warning@-1{{Implicitly captured variable 'someCF' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'someCF' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
   });
 
   dispatch_queue_t someOS = make_os();
@@ -277,13 +277,13 @@ void lambda_converted_to_function(SomeObj* obj, CFMutableArrayRef cf, dispatch_q
   callFunction([&]() {
     [obj doWork];
     CFArrayAppendValue(cf, nullptr);
-    // expected-warning@-1{{Implicitly captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     dispatch_queue_get_label(os);
   });
   callFunctionOpaque([&]() {
     [obj doWork];
     CFArrayAppendValue(cf, nullptr);
-    // expected-warning@-1{{Implicitly captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     dispatch_queue_get_label(os);
   });
 }

--- a/clang/test/Analysis/Checkers/WebKit/unretained-lambda-captures.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-lambda-captures.mm
@@ -21,61 +21,61 @@ void callAsync(const WTF::Function<void()>&);
 void raw_ptr() {
   SomeObj* obj = make_obj();
   auto foo1 = [obj](){
-    // expected-warning@-1{{Captured variable 'obj' is a raw pointer to retainable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'obj' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     [obj doWork];
   };
   call(foo1);
 
   auto foo2 = [&obj](){
-    // expected-warning@-1{{Captured variable 'obj' is a raw pointer to retainable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'obj' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     [obj doWork];
   };
   auto foo3 = [&](){
     [obj doWork];
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to retainable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     obj = nullptr;
   };
   auto foo4 = [=](){
     [obj doWork];
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to retainable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
   };
   
   auto cf = make_cf();
   auto bar1 = [cf](){
-    // expected-warning@-1{{Captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     CFArrayAppendValue(cf, nullptr);
   };
   auto bar2 = [&cf](){
-    // expected-warning@-1{{Captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     CFArrayAppendValue(cf, nullptr);
   };
   auto bar3 = [&](){
     CFArrayAppendValue(cf, nullptr);
-    // expected-warning@-1{{Implicitly captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     cf = nullptr;
   };
   auto bar4 = [=](){
     CFArrayAppendValue(cf, nullptr);
-    // expected-warning@-1{{Implicitly captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
   };
 
   auto os = make_os();
   auto baz1 = [os](){
-    // expected-warning@-1{{Captured variable 'os' is a retainable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'os' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     dispatch_queue_get_label(os);
   };
   auto baz2 = [&os](){
-    // expected-warning@-1{{Captured variable 'os' is a retainable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Captured variable 'os' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     dispatch_queue_get_label(os);
   };
   auto baz3 = [&](){
     dispatch_queue_get_label(os);
-    // expected-warning@-1{{Implicitly captured variable 'os' is a retainable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'os' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     os = nullptr;
   };
   auto baz4 = [=](){
     dispatch_queue_get_label(os);
-    // expected-warning@-1{{Implicitly captured variable 'os' is a retainable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'os' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
   };
 
   call(foo1);
@@ -177,7 +177,7 @@ void noescape_lambda() {
     [otherObj doWork];
   }, [&](SomeObj *obj) {
     [otherObj doWork];
-    // expected-warning@-1{{Implicitly captured variable 'otherObj' is a raw pointer to retainable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'otherObj' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
   });
   ([&] {
     [someObj doWork];
@@ -188,7 +188,7 @@ void noescape_lambda() {
     CFArrayAppendValue(someCF, nullptr);
   }, [&](CFIndex count) {
     CFArrayAppendValue(someCF, nullptr);
-    // expected-warning@-1{{Implicitly captured variable 'someCF' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'someCF' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
   });
 
   dispatch_queue_t someOS = make_os();
@@ -196,7 +196,7 @@ void noescape_lambda() {
     dispatch_queue_get_label(someOS);
   }, [&](const char* label) {
     dispatch_queue_get_label(someOS);
-    // expected-warning@-1{{Implicitly captured variable 'someOS' is a retainable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'someOS' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
   });
 }
 
@@ -210,19 +210,19 @@ void lambda_converted_to_function(SomeObj* obj, CFMutableArrayRef cf, dispatch_q
 {
   callFunction([&]() {
     [obj doWork];
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to retainable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     CFArrayAppendValue(cf, nullptr);
-    // expected-warning@-1{{Implicitly captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     dispatch_queue_get_label(os);
-    // expected-warning@-1{{Implicitly captured variable 'os' is a retainable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'os' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
   });
   callFunctionOpaque([&]() {
     [obj doWork];
-    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to retainable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'obj' is a raw pointer to RetainPtr-capable type 'SomeObj' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     CFArrayAppendValue(cf, nullptr);
-    // expected-warning@-1{{Implicitly captured variable 'cf' is a retainable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'cf' is a RetainPtr-capable type 'CFMutableArrayRef' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     dispatch_queue_get_label(os);
-    // expected-warning@-1{{Implicitly captured variable 'os' is a retainable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'os' is a RetainPtr-capable type 'dispatch_queue_t' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
   });
 }
 
@@ -238,12 +238,12 @@ void lambda_converted_to_function(SomeObj* obj, CFMutableArrayRef cf, dispatch_q
 @implementation ObjWithSelf
 -(void)doWork {
   auto doWork = [&] {
-    // expected-warning@-1{{Implicitly captured variable 'self' is a raw pointer to retainable type 'ObjWithSelf' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'self' is a raw pointer to RetainPtr-capable type 'ObjWithSelf' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     someFunction();
     [delegate doWork];
   };
   auto doMoreWork = [=] {
-    // expected-warning@-1{{Implicitly captured variable 'self' is a raw pointer to retainable type 'ObjWithSelf' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'self' is a raw pointer to RetainPtr-capable type 'ObjWithSelf' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
     someFunction();
     [delegate doWork];
   };
@@ -255,7 +255,7 @@ void lambda_converted_to_function(SomeObj* obj, CFMutableArrayRef cf, dispatch_q
   auto doAdditionalWork = [&] {
     someFunction();
     dispatch_queue_get_label(queuePtr);
-    // expected-warning@-1{{Implicitly captured variable 'queuePtr' is a retainable type 'OS_dispatch_queue' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
+    // expected-warning@-1{{Implicitly captured variable 'queuePtr' is a RetainPtr-capable type 'OS_dispatch_queue' [alpha.webkit.UnretainedLambdaCapturesChecker]}}
   };
   callFunctionOpaque(doWork);
   callFunctionOpaque(doMoreWork);


### PR DESCRIPTION
This PR aligns webkit.UncountedLambdaCapturesChecker and its variant's warning message with the new warning format in other checkers.