### PR TITLE
[clang-format] Fix `check-format-depends` CMake for Windows

### DIFF
--- a/clang/lib/Format/CMakeLists.txt
+++ b/clang/lib/Format/CMakeLists.txt
@@ -43,12 +43,15 @@ file(GLOB_RECURSE files
 
 set(check_format_depends clang-format)
 find_program(DIFF_EXE diff)
-if(DIFF_EXE)
+find_program(TOUCH_EXE touch)
+if(DIFF_EXE AND TOUCH_EXE)
+  file(TO_NATIVE_PATH "${DIFF_EXE}" DIFF_EXE_NATIVE_PATH)
+  file(TO_NATIVE_PATH "${TOUCH_EXE}" TOUCH_EXE_NATIVE_PATH)
   set(i 0)
   foreach(file IN LISTS files)
     add_custom_command(OUTPUT check_format_depend_${i}
-      COMMAND clang-format ${file} | diff -u ${file} - &&
-              touch check_format_depend_${i}
+      COMMAND clang-format ${file} | ${DIFF_EXE_NATIVE_PATH} -u ${file} - &&
+              ${TOUCH_EXE_NATIVE_PATH} check_format_depend_${i}
       VERBATIM
       COMMENT "Checking format of ${file}"
       DEPENDS clang-format


### PR DESCRIPTION
Add `find_program` for `touch`. Convert found program paths to native form and use these paths in the command invocation.