### PR TITLE
[AArch64][GlobalISel] Legalization for bf16 fptosi/fptoui.

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
@@ -934,7 +934,12 @@ AArch64LegalizerInfo::AArch64LegalizerInfo(const AArch64Subtarget &ST)
       .moreElementsToNextPow2(0)
       .widenScalarOrEltToNextPow2OrMinSize(0)
       .minScalar(0, s32)
-      .widenScalarOrEltToNextPow2OrMinSize(1, /*MinSize=*/HasFP16 ? 16 : 32)
+      .widenScalarIf(
+          [HasFP16](const LegalityQuery &Query) {
+            return (!HasFP16 && Query.Types[1].getScalarType().isFloat16()) ||
+                   Query.Types[1].getScalarType().isBFloat16();
+          },
+          changeElementTo(1, f32))
       .widenScalarIf(
           [=](const LegalityQuery &Query) {
             return Query.Types[0].getScalarSizeInBits() <= 64 &&

--- a/llvm/test/CodeGen/AArch64/bf16-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-instructions.ll
@@ -4,11 +4,7 @@
 ; RUN: llc < %s -mtriple aarch64 -mattr=-bf16 -global-isel -global-isel-abort=2 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-CVT,CHECK-CVT-GI
 ; RUN: llc < %s -mtriple aarch64 -mattr=+bf16 -global-isel -global-isel-abort=2 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-BF16,CHECK-BF16-GI
 
-; CHECK-CVT-GI:       warning: Instruction selection used fallback path for test_fptosi_i32
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i64
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i32
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i64
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i8
+; CHECK-CVT-GI:       warning: Instruction selection used fallback path for test_fptosi_sat_i8
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i16
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i32
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i64
@@ -25,11 +21,7 @@
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fpext_double
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fpext_double_fast
 ;
-; CHECK-BF16-GI:       warning: Instruction selection used fallback path for test_fptosi_i32
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i64
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i32
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i64
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i8
+; CHECK-BF16-GI:       warning: Instruction selection used fallback path for test_fptosi_sat_i8
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i16
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i32
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i64
@@ -45,10 +37,6 @@
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_sitofp_i32_fadd
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fpext_double
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fpext_double_fast
-;
-;
-;
-;
 
 define bfloat @test_fadd(bfloat %a, bfloat %b) #0 {
 ; CHECK-CVT-SD-LABEL: test_fadd:

--- a/llvm/test/CodeGen/AArch64/bf16-v4-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-v4-instructions.ll
@@ -4,15 +4,7 @@
 ; RUN: llc < %s -mtriple aarch64 -mattr=-bf16 -global-isel -global-isel-abort=2 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-CVT,CHECK-CVT-GI
 ; RUN: llc < %s -mtriple aarch64 -mattr=+bf16 -global-isel -global-isel-abort=2 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-BF16,CHECK-BF16-GI
 
-; CHECK-CVT-GI:       warning: Instruction selection used fallback path for test_fptosi_i8
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i16
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i32
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i64
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i8
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i16
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i32
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i64
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i8
+; CHECK-CVT-GI:       warning: Instruction selection used fallback path for test_fptosi_sat_i8
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i16
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i32
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i64
@@ -29,15 +21,7 @@
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_uitofp_i32
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_uitofp_i64
 ;
-; CHECK-BF16-GI:       warning: Instruction selection used fallback path for test_fptosi_i8
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i16
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i32
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i64
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i8
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i16
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i32
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i64
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i8
+; CHECK-BF16-GI:       warning: Instruction selection used fallback path for test_fptosi_sat_i8
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i16
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i32
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i64
@@ -53,9 +37,6 @@
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_uitofp_i16
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_uitofp_i32
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_uitofp_i64
-;
-;
-;
 
 define <4 x bfloat> @test_build(<4 x bfloat> %a) {
 ; CHECK-CVT-SD-LABEL: test_build:
@@ -1202,37 +1183,96 @@ define <4 x i32> @test_fptosi_i32(<4 x bfloat> %a) #0 {
 }
 
 define <4 x i64> @test_fptosi_i64(<4 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptosi_i64:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-NEXT:    mov h1, v0.h[2]
-; CHECK-NEXT:    mov h2, v0.h[1]
-; CHECK-NEXT:    mov h3, v0.h[3]
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-NEXT:    shll v2.4s, v2.4h, #16
-; CHECK-NEXT:    shll v3.4s, v3.4h, #16
-; CHECK-NEXT:    fcvtzs x8, s0
-; CHECK-NEXT:    fcvtzs x9, s1
-; CHECK-NEXT:    fcvtzs x10, s2
-; CHECK-NEXT:    fcvtzs x11, s3
-; CHECK-NEXT:    fmov d0, x8
-; CHECK-NEXT:    fmov d1, x9
-; CHECK-NEXT:    mov v0.d[1], x10
-; CHECK-NEXT:    mov v1.d[1], x11
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptosi_i64:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-CVT-SD-NEXT:    mov h1, v0.h[2]
+; CHECK-CVT-SD-NEXT:    mov h2, v0.h[1]
+; CHECK-CVT-SD-NEXT:    mov h3, v0.h[3]
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v2.4s, v2.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v3.4s, v3.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzs x8, s0
+; CHECK-CVT-SD-NEXT:    fcvtzs x9, s1
+; CHECK-CVT-SD-NEXT:    fcvtzs x10, s2
+; CHECK-CVT-SD-NEXT:    fcvtzs x11, s3
+; CHECK-CVT-SD-NEXT:    fmov d0, x8
+; CHECK-CVT-SD-NEXT:    fmov d1, x9
+; CHECK-CVT-SD-NEXT:    mov v0.d[1], x10
+; CHECK-CVT-SD-NEXT:    mov v1.d[1], x11
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptosi_i64:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-BF16-SD-NEXT:    mov h1, v0.h[2]
+; CHECK-BF16-SD-NEXT:    mov h2, v0.h[1]
+; CHECK-BF16-SD-NEXT:    mov h3, v0.h[3]
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v2.4s, v2.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v3.4s, v3.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzs x8, s0
+; CHECK-BF16-SD-NEXT:    fcvtzs x9, s1
+; CHECK-BF16-SD-NEXT:    fcvtzs x10, s2
+; CHECK-BF16-SD-NEXT:    fcvtzs x11, s3
+; CHECK-BF16-SD-NEXT:    fmov d0, x8
+; CHECK-BF16-SD-NEXT:    fmov d1, x9
+; CHECK-BF16-SD-NEXT:    mov v0.d[1], x10
+; CHECK-BF16-SD-NEXT:    mov v1.d[1], x11
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptosi_i64:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    fcvtl v1.2d, v0.2s
+; CHECK-CVT-GI-NEXT:    fcvtl2 v2.2d, v0.4s
+; CHECK-CVT-GI-NEXT:    fcvtzs v0.2d, v1.2d
+; CHECK-CVT-GI-NEXT:    fcvtzs v1.2d, v2.2d
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptosi_i64:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    fcvtl v1.2d, v0.2s
+; CHECK-BF16-GI-NEXT:    fcvtl2 v2.2d, v0.4s
+; CHECK-BF16-GI-NEXT:    fcvtzs v0.2d, v1.2d
+; CHECK-BF16-GI-NEXT:    fcvtzs v1.2d, v2.2d
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptosi <4 x bfloat> %a to <4 x i64>
   ret <4 x i64> %1
 }
 
 ; NOTE: fcvtzs selected here because the xtn shaves the sign bit
 define <4 x i8> @test_fptoui_i8(<4 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptoui_i8:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NEXT:    xtn v0.4h, v0.4s
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptoui_i8:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptoui_i8:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16-SD-NEXT:    xtn v0.4h, v0.4s
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptoui_i8:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-CVT-GI-NEXT:    xtn v0.4h, v0.4s
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptoui_i8:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16-GI-NEXT:    xtn v0.4h, v0.4s
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptoui <4 x bfloat> %a to <4 x i8>
   ret <4 x i8> %1
 }
@@ -1259,25 +1299,63 @@ define <4 x i32> @test_fptoui_i32(<4 x bfloat> %a) #0 {
 }
 
 define <4 x i64> @test_fptoui_i64(<4 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptoui_i64:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-NEXT:    mov h1, v0.h[2]
-; CHECK-NEXT:    mov h2, v0.h[1]
-; CHECK-NEXT:    mov h3, v0.h[3]
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-NEXT:    shll v2.4s, v2.4h, #16
-; CHECK-NEXT:    shll v3.4s, v3.4h, #16
-; CHECK-NEXT:    fcvtzu x8, s0
-; CHECK-NEXT:    fcvtzu x9, s1
-; CHECK-NEXT:    fcvtzu x10, s2
-; CHECK-NEXT:    fcvtzu x11, s3
-; CHECK-NEXT:    fmov d0, x8
-; CHECK-NEXT:    fmov d1, x9
-; CHECK-NEXT:    mov v0.d[1], x10
-; CHECK-NEXT:    mov v1.d[1], x11
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptoui_i64:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-CVT-SD-NEXT:    mov h1, v0.h[2]
+; CHECK-CVT-SD-NEXT:    mov h2, v0.h[1]
+; CHECK-CVT-SD-NEXT:    mov h3, v0.h[3]
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v2.4s, v2.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v3.4s, v3.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzu x8, s0
+; CHECK-CVT-SD-NEXT:    fcvtzu x9, s1
+; CHECK-CVT-SD-NEXT:    fcvtzu x10, s2
+; CHECK-CVT-SD-NEXT:    fcvtzu x11, s3
+; CHECK-CVT-SD-NEXT:    fmov d0, x8
+; CHECK-CVT-SD-NEXT:    fmov d1, x9
+; CHECK-CVT-SD-NEXT:    mov v0.d[1], x10
+; CHECK-CVT-SD-NEXT:    mov v1.d[1], x11
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptoui_i64:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-BF16-SD-NEXT:    mov h1, v0.h[2]
+; CHECK-BF16-SD-NEXT:    mov h2, v0.h[1]
+; CHECK-BF16-SD-NEXT:    mov h3, v0.h[3]
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v2.4s, v2.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v3.4s, v3.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzu x8, s0
+; CHECK-BF16-SD-NEXT:    fcvtzu x9, s1
+; CHECK-BF16-SD-NEXT:    fcvtzu x10, s2
+; CHECK-BF16-SD-NEXT:    fcvtzu x11, s3
+; CHECK-BF16-SD-NEXT:    fmov d0, x8
+; CHECK-BF16-SD-NEXT:    fmov d1, x9
+; CHECK-BF16-SD-NEXT:    mov v0.d[1], x10
+; CHECK-BF16-SD-NEXT:    mov v1.d[1], x11
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptoui_i64:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    fcvtl v1.2d, v0.2s
+; CHECK-CVT-GI-NEXT:    fcvtl2 v2.2d, v0.4s
+; CHECK-CVT-GI-NEXT:    fcvtzu v0.2d, v1.2d
+; CHECK-CVT-GI-NEXT:    fcvtzu v1.2d, v2.2d
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptoui_i64:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    fcvtl v1.2d, v0.2s
+; CHECK-BF16-GI-NEXT:    fcvtl2 v2.2d, v0.4s
+; CHECK-BF16-GI-NEXT:    fcvtzu v0.2d, v1.2d
+; CHECK-BF16-GI-NEXT:    fcvtzu v1.2d, v2.2d
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptoui <4 x bfloat> %a to <4 x i64>
   ret <4 x i64> %1
 }

--- a/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
@@ -5,17 +5,7 @@
 ; RUN: llc < %s -mtriple aarch64 -mattr=-bf16 -global-isel -global-isel-abort=2 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-CVT,CHECK-CVT-GI
 ; RUN: llc < %s -mtriple aarch64 -mattr=+bf16 -global-isel -global-isel-abort=2 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-BF16,CHECK-BF16-GI
 
-; CHECK-CVT-GI:       warning: Instruction selection used fallback path for test_fptosi_i8
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_v16i8
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i16
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i32
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i64
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i8
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_v16i8
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i16
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i32
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i64
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i8
+; CHECK-CVT-GI:       warning: Instruction selection used fallback path for test_fptosi_sat_i8
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i16
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i32
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i64
@@ -34,17 +24,7 @@
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_uitofp_i32
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_uitofp_i64
 ;
-; CHECK-BF16-GI:       warning: Instruction selection used fallback path for test_fptosi_i8
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_v16i8
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i16
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i32
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i64
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i8
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_v16i8
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i16
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i32
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptoui_i64
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i8
+; CHECK-BF16-GI:       warning: Instruction selection used fallback path for test_fptosi_sat_i8
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i16
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i32
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_sat_i64
@@ -62,9 +42,6 @@
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_uitofp_i16
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_uitofp_i32
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_uitofp_i64
-;
-;
-;
 
 define <8 x bfloat> @test_build(<8 x bfloat> %a) {
 ; CHECK-CVT-SD-LABEL: test_build:
@@ -2352,196 +2329,728 @@ define <8 x i1> @test_fcmp_ord(<8 x bfloat> %a, <8 x bfloat> %b) #0 {
 }
 
 define <8 x i8> @test_fptosi_i8(<8 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptosi_i8:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    shll2 v1.4s, v0.8h, #16
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    fcvtzs v1.4s, v1.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
-; CHECK-NEXT:    xtn v0.8b, v0.8h
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptosi_i8:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-CVT-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-CVT-SD-NEXT:    xtn v0.8b, v0.8h
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptosi_i8:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-BF16-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-BF16-SD-NEXT:    xtn v0.8b, v0.8h
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fptosi_i8:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16SVE-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-BF16SVE-SD-NEXT:    xtn v0.8b, v0.8h
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptosi_i8:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-CVT-GI-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-CVT-GI-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-CVT-GI-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
+; CHECK-CVT-GI-NEXT:    xtn v0.8b, v0.8h
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptosi_i8:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-BF16-GI-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-BF16-GI-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16-GI-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
+; CHECK-BF16-GI-NEXT:    xtn v0.8b, v0.8h
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptosi <8 x bfloat> %a to <8 x i8>
   ret <8 x i8> %1
 }
 
 define <16 x i8> @test_fptosi_v16i8(<16 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptosi_v16i8:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    shll2 v2.4s, v1.8h, #16
-; CHECK-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-NEXT:    shll2 v3.4s, v0.8h, #16
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    fcvtzs v2.4s, v2.4s
-; CHECK-NEXT:    fcvtzs v1.4s, v1.4s
-; CHECK-NEXT:    fcvtzs v3.4s, v3.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NEXT:    uzp1 v1.8h, v1.8h, v2.8h
-; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v3.8h
-; CHECK-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptosi_v16i8:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    shll2 v2.4s, v1.8h, #16
+; CHECK-CVT-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-CVT-SD-NEXT:    shll2 v3.4s, v0.8h, #16
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzs v2.4s, v2.4s
+; CHECK-CVT-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    fcvtzs v3.4s, v3.4s
+; CHECK-CVT-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-CVT-SD-NEXT:    uzp1 v1.8h, v1.8h, v2.8h
+; CHECK-CVT-SD-NEXT:    uzp1 v0.8h, v0.8h, v3.8h
+; CHECK-CVT-SD-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptosi_v16i8:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    shll2 v2.4s, v1.8h, #16
+; CHECK-BF16-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-BF16-SD-NEXT:    shll2 v3.4s, v0.8h, #16
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzs v2.4s, v2.4s
+; CHECK-BF16-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-BF16-SD-NEXT:    fcvtzs v3.4s, v3.4s
+; CHECK-BF16-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16-SD-NEXT:    uzp1 v1.8h, v1.8h, v2.8h
+; CHECK-BF16-SD-NEXT:    uzp1 v0.8h, v0.8h, v3.8h
+; CHECK-BF16-SD-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fptosi_v16i8:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    shll2 v2.4s, v1.8h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll2 v3.4s, v0.8h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs v2.4s, v2.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs v3.4s, v3.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16SVE-SD-NEXT:    uzp1 v1.8h, v1.8h, v2.8h
+; CHECK-BF16SVE-SD-NEXT:    uzp1 v0.8h, v0.8h, v3.8h
+; CHECK-BF16SVE-SD-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptosi_v16i8:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v2.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-CVT-GI-NEXT:    shll v3.4s, v1.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v1.4s, v1.8h, #16
+; CHECK-CVT-GI-NEXT:    fcvtzs v2.4s, v2.4s
+; CHECK-CVT-GI-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-CVT-GI-NEXT:    fcvtzs v3.4s, v3.4s
+; CHECK-CVT-GI-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-CVT-GI-NEXT:    uzp1 v0.8h, v2.8h, v0.8h
+; CHECK-CVT-GI-NEXT:    uzp1 v1.8h, v3.8h, v1.8h
+; CHECK-CVT-GI-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptosi_v16i8:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v2.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-BF16-GI-NEXT:    shll v3.4s, v1.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v1.4s, v1.8h, #16
+; CHECK-BF16-GI-NEXT:    fcvtzs v2.4s, v2.4s
+; CHECK-BF16-GI-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16-GI-NEXT:    fcvtzs v3.4s, v3.4s
+; CHECK-BF16-GI-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-BF16-GI-NEXT:    uzp1 v0.8h, v2.8h, v0.8h
+; CHECK-BF16-GI-NEXT:    uzp1 v1.8h, v3.8h, v1.8h
+; CHECK-BF16-GI-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptosi <16 x bfloat> %a to <16 x i8>
   ret <16 x i8> %1
 }
 
 define <8 x i16> @test_fptosi_i16(<8 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptosi_i16:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    shll2 v1.4s, v0.8h, #16
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    fcvtzs v1.4s, v1.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptosi_i16:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-CVT-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptosi_i16:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-BF16-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fptosi_i16:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16SVE-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptosi_i16:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-CVT-GI-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-CVT-GI-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-CVT-GI-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptosi_i16:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-BF16-GI-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-BF16-GI-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16-GI-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptosi <8 x bfloat> %a to <8 x i16>
   ret <8 x i16> %1
 }
 
 define <8 x i32> @test_fptosi_i32(<8 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptosi_i32:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    shll2 v1.4s, v0.8h, #16
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    fcvtzs v1.4s, v1.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptosi_i32:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptosi_i32:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-BF16-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fptosi_i32:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs v1.4s, v1.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptosi_i32:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v2.4s, v0.8h, #16
+; CHECK-CVT-GI-NEXT:    fcvtzs v0.4s, v1.4s
+; CHECK-CVT-GI-NEXT:    fcvtzs v1.4s, v2.4s
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptosi_i32:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v2.4s, v0.8h, #16
+; CHECK-BF16-GI-NEXT:    fcvtzs v0.4s, v1.4s
+; CHECK-BF16-GI-NEXT:    fcvtzs v1.4s, v2.4s
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptosi <8 x bfloat> %a to <8 x i32>
   ret <8 x i32> %1
 }
 
 define <8 x i64> @test_fptosi_i64(<8 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptosi_i64:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov d1, v0.d[1]
-; CHECK-NEXT:    mov h4, v0.h[2]
-; CHECK-NEXT:    mov h3, v0.h[1]
-; CHECK-NEXT:    mov h7, v0.h[3]
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    mov h2, v1.h[2]
-; CHECK-NEXT:    mov h5, v1.h[1]
-; CHECK-NEXT:    mov h6, v1.h[3]
-; CHECK-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-NEXT:    shll v4.4s, v4.4h, #16
-; CHECK-NEXT:    shll v3.4s, v3.4h, #16
-; CHECK-NEXT:    shll v7.4s, v7.4h, #16
-; CHECK-NEXT:    fcvtzs x9, s0
-; CHECK-NEXT:    shll v2.4s, v2.4h, #16
-; CHECK-NEXT:    shll v5.4s, v5.4h, #16
-; CHECK-NEXT:    shll v6.4s, v6.4h, #16
-; CHECK-NEXT:    fcvtzs x8, s1
-; CHECK-NEXT:    fcvtzs x12, s4
-; CHECK-NEXT:    fcvtzs x11, s3
-; CHECK-NEXT:    fcvtzs x15, s7
-; CHECK-NEXT:    fmov d0, x9
-; CHECK-NEXT:    fcvtzs x10, s2
-; CHECK-NEXT:    fcvtzs x13, s5
-; CHECK-NEXT:    fcvtzs x14, s6
-; CHECK-NEXT:    fmov d2, x8
-; CHECK-NEXT:    fmov d1, x12
-; CHECK-NEXT:    mov v0.d[1], x11
-; CHECK-NEXT:    fmov d3, x10
-; CHECK-NEXT:    mov v2.d[1], x13
-; CHECK-NEXT:    mov v1.d[1], x15
-; CHECK-NEXT:    mov v3.d[1], x14
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptosi_i64:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    mov d1, v0.d[1]
+; CHECK-CVT-SD-NEXT:    mov h4, v0.h[2]
+; CHECK-CVT-SD-NEXT:    mov h3, v0.h[1]
+; CHECK-CVT-SD-NEXT:    mov h7, v0.h[3]
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    mov h2, v1.h[2]
+; CHECK-CVT-SD-NEXT:    mov h5, v1.h[1]
+; CHECK-CVT-SD-NEXT:    mov h6, v1.h[3]
+; CHECK-CVT-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v4.4s, v4.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v3.4s, v3.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v7.4s, v7.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzs x9, s0
+; CHECK-CVT-SD-NEXT:    shll v2.4s, v2.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v5.4s, v5.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v6.4s, v6.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzs x8, s1
+; CHECK-CVT-SD-NEXT:    fcvtzs x12, s4
+; CHECK-CVT-SD-NEXT:    fcvtzs x11, s3
+; CHECK-CVT-SD-NEXT:    fcvtzs x15, s7
+; CHECK-CVT-SD-NEXT:    fmov d0, x9
+; CHECK-CVT-SD-NEXT:    fcvtzs x10, s2
+; CHECK-CVT-SD-NEXT:    fcvtzs x13, s5
+; CHECK-CVT-SD-NEXT:    fcvtzs x14, s6
+; CHECK-CVT-SD-NEXT:    fmov d2, x8
+; CHECK-CVT-SD-NEXT:    fmov d1, x12
+; CHECK-CVT-SD-NEXT:    mov v0.d[1], x11
+; CHECK-CVT-SD-NEXT:    fmov d3, x10
+; CHECK-CVT-SD-NEXT:    mov v2.d[1], x13
+; CHECK-CVT-SD-NEXT:    mov v1.d[1], x15
+; CHECK-CVT-SD-NEXT:    mov v3.d[1], x14
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptosi_i64:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    mov d1, v0.d[1]
+; CHECK-BF16-SD-NEXT:    mov h4, v0.h[2]
+; CHECK-BF16-SD-NEXT:    mov h3, v0.h[1]
+; CHECK-BF16-SD-NEXT:    mov h7, v0.h[3]
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    mov h2, v1.h[2]
+; CHECK-BF16-SD-NEXT:    mov h5, v1.h[1]
+; CHECK-BF16-SD-NEXT:    mov h6, v1.h[3]
+; CHECK-BF16-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v4.4s, v4.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v3.4s, v3.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v7.4s, v7.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzs x9, s0
+; CHECK-BF16-SD-NEXT:    shll v2.4s, v2.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v5.4s, v5.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v6.4s, v6.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzs x8, s1
+; CHECK-BF16-SD-NEXT:    fcvtzs x12, s4
+; CHECK-BF16-SD-NEXT:    fcvtzs x11, s3
+; CHECK-BF16-SD-NEXT:    fcvtzs x15, s7
+; CHECK-BF16-SD-NEXT:    fmov d0, x9
+; CHECK-BF16-SD-NEXT:    fcvtzs x10, s2
+; CHECK-BF16-SD-NEXT:    fcvtzs x13, s5
+; CHECK-BF16-SD-NEXT:    fcvtzs x14, s6
+; CHECK-BF16-SD-NEXT:    fmov d2, x8
+; CHECK-BF16-SD-NEXT:    fmov d1, x12
+; CHECK-BF16-SD-NEXT:    mov v0.d[1], x11
+; CHECK-BF16-SD-NEXT:    fmov d3, x10
+; CHECK-BF16-SD-NEXT:    mov v2.d[1], x13
+; CHECK-BF16-SD-NEXT:    mov v1.d[1], x15
+; CHECK-BF16-SD-NEXT:    mov v3.d[1], x14
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fptosi_i64:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    mov d1, v0.d[1]
+; CHECK-BF16SVE-SD-NEXT:    mov h4, v0.h[2]
+; CHECK-BF16SVE-SD-NEXT:    mov h3, v0.h[1]
+; CHECK-BF16SVE-SD-NEXT:    mov h7, v0.h[3]
+; CHECK-BF16SVE-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    mov h2, v1.h[2]
+; CHECK-BF16SVE-SD-NEXT:    mov h5, v1.h[1]
+; CHECK-BF16SVE-SD-NEXT:    mov h6, v1.h[3]
+; CHECK-BF16SVE-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v4.4s, v4.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v3.4s, v3.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v7.4s, v7.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs x9, s0
+; CHECK-BF16SVE-SD-NEXT:    shll v2.4s, v2.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v5.4s, v5.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v6.4s, v6.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs x8, s1
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs x12, s4
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs x11, s3
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs x15, s7
+; CHECK-BF16SVE-SD-NEXT:    fmov d0, x9
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs x10, s2
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs x13, s5
+; CHECK-BF16SVE-SD-NEXT:    fcvtzs x14, s6
+; CHECK-BF16SVE-SD-NEXT:    fmov d2, x8
+; CHECK-BF16SVE-SD-NEXT:    fmov d1, x12
+; CHECK-BF16SVE-SD-NEXT:    mov v0.d[1], x11
+; CHECK-BF16SVE-SD-NEXT:    fmov d3, x10
+; CHECK-BF16SVE-SD-NEXT:    mov v2.d[1], x13
+; CHECK-BF16SVE-SD-NEXT:    mov v1.d[1], x15
+; CHECK-BF16SVE-SD-NEXT:    mov v3.d[1], x14
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptosi_i64:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-CVT-GI-NEXT:    fcvtl v2.2d, v1.2s
+; CHECK-CVT-GI-NEXT:    fcvtl2 v1.2d, v1.4s
+; CHECK-CVT-GI-NEXT:    fcvtl v3.2d, v0.2s
+; CHECK-CVT-GI-NEXT:    fcvtl2 v4.2d, v0.4s
+; CHECK-CVT-GI-NEXT:    fcvtzs v0.2d, v2.2d
+; CHECK-CVT-GI-NEXT:    fcvtzs v1.2d, v1.2d
+; CHECK-CVT-GI-NEXT:    fcvtzs v2.2d, v3.2d
+; CHECK-CVT-GI-NEXT:    fcvtzs v3.2d, v4.2d
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptosi_i64:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-BF16-GI-NEXT:    fcvtl v2.2d, v1.2s
+; CHECK-BF16-GI-NEXT:    fcvtl2 v1.2d, v1.4s
+; CHECK-BF16-GI-NEXT:    fcvtl v3.2d, v0.2s
+; CHECK-BF16-GI-NEXT:    fcvtl2 v4.2d, v0.4s
+; CHECK-BF16-GI-NEXT:    fcvtzs v0.2d, v2.2d
+; CHECK-BF16-GI-NEXT:    fcvtzs v1.2d, v1.2d
+; CHECK-BF16-GI-NEXT:    fcvtzs v2.2d, v3.2d
+; CHECK-BF16-GI-NEXT:    fcvtzs v3.2d, v4.2d
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptosi <8 x bfloat> %a to <8 x i64>
   ret <8 x i64> %1
 }
 
 ; NOTE: fcvtzs selected here because the xtn shaves the sign bit
 define <8 x i8> @test_fptoui_i8(<8 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptoui_i8:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    shll2 v1.4s, v0.8h, #16
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    fcvtzu v1.4s, v1.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
-; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
-; CHECK-NEXT:    xtn v0.8b, v0.8h
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptoui_i8:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-CVT-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-CVT-SD-NEXT:    xtn v0.8b, v0.8h
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptoui_i8:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-BF16-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-BF16-SD-NEXT:    xtn v0.8b, v0.8h
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fptoui_i8:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16SVE-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-BF16SVE-SD-NEXT:    xtn v0.8b, v0.8h
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptoui_i8:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-CVT-GI-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-CVT-GI-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-CVT-GI-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
+; CHECK-CVT-GI-NEXT:    xtn v0.8b, v0.8h
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptoui_i8:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-BF16-GI-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-BF16-GI-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16-GI-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
+; CHECK-BF16-GI-NEXT:    xtn v0.8b, v0.8h
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptoui <8 x bfloat> %a to <8 x i8>
   ret <8 x i8> %1
 }
 
 define <16 x i8> @test_fptoui_v16i8(<16 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptoui_v16i8:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    shll2 v2.4s, v1.8h, #16
-; CHECK-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-NEXT:    shll2 v3.4s, v0.8h, #16
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    fcvtzu v2.4s, v2.4s
-; CHECK-NEXT:    fcvtzu v1.4s, v1.4s
-; CHECK-NEXT:    fcvtzu v3.4s, v3.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
-; CHECK-NEXT:    uzp1 v1.8h, v1.8h, v2.8h
-; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v3.8h
-; CHECK-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptoui_v16i8:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    shll2 v2.4s, v1.8h, #16
+; CHECK-CVT-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-CVT-SD-NEXT:    shll2 v3.4s, v0.8h, #16
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzu v2.4s, v2.4s
+; CHECK-CVT-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    fcvtzu v3.4s, v3.4s
+; CHECK-CVT-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-CVT-SD-NEXT:    uzp1 v1.8h, v1.8h, v2.8h
+; CHECK-CVT-SD-NEXT:    uzp1 v0.8h, v0.8h, v3.8h
+; CHECK-CVT-SD-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptoui_v16i8:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    shll2 v2.4s, v1.8h, #16
+; CHECK-BF16-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-BF16-SD-NEXT:    shll2 v3.4s, v0.8h, #16
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzu v2.4s, v2.4s
+; CHECK-BF16-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-BF16-SD-NEXT:    fcvtzu v3.4s, v3.4s
+; CHECK-BF16-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16-SD-NEXT:    uzp1 v1.8h, v1.8h, v2.8h
+; CHECK-BF16-SD-NEXT:    uzp1 v0.8h, v0.8h, v3.8h
+; CHECK-BF16-SD-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fptoui_v16i8:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    shll2 v2.4s, v1.8h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll2 v3.4s, v0.8h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu v2.4s, v2.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu v3.4s, v3.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16SVE-SD-NEXT:    uzp1 v1.8h, v1.8h, v2.8h
+; CHECK-BF16SVE-SD-NEXT:    uzp1 v0.8h, v0.8h, v3.8h
+; CHECK-BF16SVE-SD-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptoui_v16i8:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v2.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-CVT-GI-NEXT:    shll v3.4s, v1.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v1.4s, v1.8h, #16
+; CHECK-CVT-GI-NEXT:    fcvtzu v2.4s, v2.4s
+; CHECK-CVT-GI-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-CVT-GI-NEXT:    fcvtzu v3.4s, v3.4s
+; CHECK-CVT-GI-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-CVT-GI-NEXT:    uzp1 v0.8h, v2.8h, v0.8h
+; CHECK-CVT-GI-NEXT:    uzp1 v1.8h, v3.8h, v1.8h
+; CHECK-CVT-GI-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptoui_v16i8:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v2.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-BF16-GI-NEXT:    shll v3.4s, v1.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v1.4s, v1.8h, #16
+; CHECK-BF16-GI-NEXT:    fcvtzu v2.4s, v2.4s
+; CHECK-BF16-GI-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16-GI-NEXT:    fcvtzu v3.4s, v3.4s
+; CHECK-BF16-GI-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-BF16-GI-NEXT:    uzp1 v0.8h, v2.8h, v0.8h
+; CHECK-BF16-GI-NEXT:    uzp1 v1.8h, v3.8h, v1.8h
+; CHECK-BF16-GI-NEXT:    uzp1 v0.16b, v0.16b, v1.16b
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptoui <16 x bfloat> %a to <16 x i8>
   ret <16 x i8> %1
 }
 
 define <8 x i16> @test_fptoui_i16(<8 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptoui_i16:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    shll2 v1.4s, v0.8h, #16
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    fcvtzu v1.4s, v1.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
-; CHECK-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptoui_i16:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-CVT-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptoui_i16:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-BF16-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fptoui_i16:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16SVE-SD-NEXT:    uzp1 v0.8h, v0.8h, v1.8h
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptoui_i16:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-CVT-GI-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-CVT-GI-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-CVT-GI-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptoui_i16:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-BF16-GI-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-BF16-GI-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16-GI-NEXT:    uzp1 v0.8h, v1.8h, v0.8h
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptoui <8 x bfloat> %a to <8 x i16>
   ret <8 x i16> %1
 }
 
 define <8 x i32> @test_fptoui_i32(<8 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptoui_i32:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    shll2 v1.4s, v0.8h, #16
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    fcvtzu v1.4s, v1.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptoui_i32:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptoui_i32:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-BF16-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fptoui_i32:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    shll2 v1.4s, v0.8h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu v1.4s, v1.4s
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptoui_i32:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v2.4s, v0.8h, #16
+; CHECK-CVT-GI-NEXT:    fcvtzu v0.4s, v1.4s
+; CHECK-CVT-GI-NEXT:    fcvtzu v1.4s, v2.4s
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptoui_i32:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v2.4s, v0.8h, #16
+; CHECK-BF16-GI-NEXT:    fcvtzu v0.4s, v1.4s
+; CHECK-BF16-GI-NEXT:    fcvtzu v1.4s, v2.4s
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptoui <8 x bfloat> %a to <8 x i32>
   ret <8 x i32> %1
 }
 
 define <8 x i64> @test_fptoui_i64(<8 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fptoui_i64:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov d1, v0.d[1]
-; CHECK-NEXT:    mov h4, v0.h[2]
-; CHECK-NEXT:    mov h3, v0.h[1]
-; CHECK-NEXT:    mov h7, v0.h[3]
-; CHECK-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-NEXT:    mov h2, v1.h[2]
-; CHECK-NEXT:    mov h5, v1.h[1]
-; CHECK-NEXT:    mov h6, v1.h[3]
-; CHECK-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-NEXT:    shll v4.4s, v4.4h, #16
-; CHECK-NEXT:    shll v3.4s, v3.4h, #16
-; CHECK-NEXT:    shll v7.4s, v7.4h, #16
-; CHECK-NEXT:    fcvtzu x9, s0
-; CHECK-NEXT:    shll v2.4s, v2.4h, #16
-; CHECK-NEXT:    shll v5.4s, v5.4h, #16
-; CHECK-NEXT:    shll v6.4s, v6.4h, #16
-; CHECK-NEXT:    fcvtzu x8, s1
-; CHECK-NEXT:    fcvtzu x12, s4
-; CHECK-NEXT:    fcvtzu x11, s3
-; CHECK-NEXT:    fcvtzu x15, s7
-; CHECK-NEXT:    fmov d0, x9
-; CHECK-NEXT:    fcvtzu x10, s2
-; CHECK-NEXT:    fcvtzu x13, s5
-; CHECK-NEXT:    fcvtzu x14, s6
-; CHECK-NEXT:    fmov d2, x8
-; CHECK-NEXT:    fmov d1, x12
-; CHECK-NEXT:    mov v0.d[1], x11
-; CHECK-NEXT:    fmov d3, x10
-; CHECK-NEXT:    mov v2.d[1], x13
-; CHECK-NEXT:    mov v1.d[1], x15
-; CHECK-NEXT:    mov v3.d[1], x14
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fptoui_i64:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    mov d1, v0.d[1]
+; CHECK-CVT-SD-NEXT:    mov h4, v0.h[2]
+; CHECK-CVT-SD-NEXT:    mov h3, v0.h[1]
+; CHECK-CVT-SD-NEXT:    mov h7, v0.h[3]
+; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-CVT-SD-NEXT:    mov h2, v1.h[2]
+; CHECK-CVT-SD-NEXT:    mov h5, v1.h[1]
+; CHECK-CVT-SD-NEXT:    mov h6, v1.h[3]
+; CHECK-CVT-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v4.4s, v4.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v3.4s, v3.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v7.4s, v7.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzu x9, s0
+; CHECK-CVT-SD-NEXT:    shll v2.4s, v2.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v5.4s, v5.4h, #16
+; CHECK-CVT-SD-NEXT:    shll v6.4s, v6.4h, #16
+; CHECK-CVT-SD-NEXT:    fcvtzu x8, s1
+; CHECK-CVT-SD-NEXT:    fcvtzu x12, s4
+; CHECK-CVT-SD-NEXT:    fcvtzu x11, s3
+; CHECK-CVT-SD-NEXT:    fcvtzu x15, s7
+; CHECK-CVT-SD-NEXT:    fmov d0, x9
+; CHECK-CVT-SD-NEXT:    fcvtzu x10, s2
+; CHECK-CVT-SD-NEXT:    fcvtzu x13, s5
+; CHECK-CVT-SD-NEXT:    fcvtzu x14, s6
+; CHECK-CVT-SD-NEXT:    fmov d2, x8
+; CHECK-CVT-SD-NEXT:    fmov d1, x12
+; CHECK-CVT-SD-NEXT:    mov v0.d[1], x11
+; CHECK-CVT-SD-NEXT:    fmov d3, x10
+; CHECK-CVT-SD-NEXT:    mov v2.d[1], x13
+; CHECK-CVT-SD-NEXT:    mov v1.d[1], x15
+; CHECK-CVT-SD-NEXT:    mov v3.d[1], x14
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fptoui_i64:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    mov d1, v0.d[1]
+; CHECK-BF16-SD-NEXT:    mov h4, v0.h[2]
+; CHECK-BF16-SD-NEXT:    mov h3, v0.h[1]
+; CHECK-BF16-SD-NEXT:    mov h7, v0.h[3]
+; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16-SD-NEXT:    mov h2, v1.h[2]
+; CHECK-BF16-SD-NEXT:    mov h5, v1.h[1]
+; CHECK-BF16-SD-NEXT:    mov h6, v1.h[3]
+; CHECK-BF16-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v4.4s, v4.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v3.4s, v3.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v7.4s, v7.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzu x9, s0
+; CHECK-BF16-SD-NEXT:    shll v2.4s, v2.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v5.4s, v5.4h, #16
+; CHECK-BF16-SD-NEXT:    shll v6.4s, v6.4h, #16
+; CHECK-BF16-SD-NEXT:    fcvtzu x8, s1
+; CHECK-BF16-SD-NEXT:    fcvtzu x12, s4
+; CHECK-BF16-SD-NEXT:    fcvtzu x11, s3
+; CHECK-BF16-SD-NEXT:    fcvtzu x15, s7
+; CHECK-BF16-SD-NEXT:    fmov d0, x9
+; CHECK-BF16-SD-NEXT:    fcvtzu x10, s2
+; CHECK-BF16-SD-NEXT:    fcvtzu x13, s5
+; CHECK-BF16-SD-NEXT:    fcvtzu x14, s6
+; CHECK-BF16-SD-NEXT:    fmov d2, x8
+; CHECK-BF16-SD-NEXT:    fmov d1, x12
+; CHECK-BF16-SD-NEXT:    mov v0.d[1], x11
+; CHECK-BF16-SD-NEXT:    fmov d3, x10
+; CHECK-BF16-SD-NEXT:    mov v2.d[1], x13
+; CHECK-BF16-SD-NEXT:    mov v1.d[1], x15
+; CHECK-BF16-SD-NEXT:    mov v3.d[1], x14
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fptoui_i64:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    mov d1, v0.d[1]
+; CHECK-BF16SVE-SD-NEXT:    mov h4, v0.h[2]
+; CHECK-BF16SVE-SD-NEXT:    mov h3, v0.h[1]
+; CHECK-BF16SVE-SD-NEXT:    mov h7, v0.h[3]
+; CHECK-BF16SVE-SD-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    mov h2, v1.h[2]
+; CHECK-BF16SVE-SD-NEXT:    mov h5, v1.h[1]
+; CHECK-BF16SVE-SD-NEXT:    mov h6, v1.h[3]
+; CHECK-BF16SVE-SD-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v4.4s, v4.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v3.4s, v3.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v7.4s, v7.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu x9, s0
+; CHECK-BF16SVE-SD-NEXT:    shll v2.4s, v2.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v5.4s, v5.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    shll v6.4s, v6.4h, #16
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu x8, s1
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu x12, s4
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu x11, s3
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu x15, s7
+; CHECK-BF16SVE-SD-NEXT:    fmov d0, x9
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu x10, s2
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu x13, s5
+; CHECK-BF16SVE-SD-NEXT:    fcvtzu x14, s6
+; CHECK-BF16SVE-SD-NEXT:    fmov d2, x8
+; CHECK-BF16SVE-SD-NEXT:    fmov d1, x12
+; CHECK-BF16SVE-SD-NEXT:    mov v0.d[1], x11
+; CHECK-BF16SVE-SD-NEXT:    fmov d3, x10
+; CHECK-BF16SVE-SD-NEXT:    mov v2.d[1], x13
+; CHECK-BF16SVE-SD-NEXT:    mov v1.d[1], x15
+; CHECK-BF16SVE-SD-NEXT:    mov v3.d[1], x14
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fptoui_i64:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-CVT-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-CVT-GI-NEXT:    fcvtl v2.2d, v1.2s
+; CHECK-CVT-GI-NEXT:    fcvtl2 v1.2d, v1.4s
+; CHECK-CVT-GI-NEXT:    fcvtl v3.2d, v0.2s
+; CHECK-CVT-GI-NEXT:    fcvtl2 v4.2d, v0.4s
+; CHECK-CVT-GI-NEXT:    fcvtzu v0.2d, v2.2d
+; CHECK-CVT-GI-NEXT:    fcvtzu v1.2d, v1.2d
+; CHECK-CVT-GI-NEXT:    fcvtzu v2.2d, v3.2d
+; CHECK-CVT-GI-NEXT:    fcvtzu v3.2d, v4.2d
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fptoui_i64:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    shll v1.4s, v0.4h, #16
+; CHECK-BF16-GI-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-BF16-GI-NEXT:    fcvtl v2.2d, v1.2s
+; CHECK-BF16-GI-NEXT:    fcvtl2 v1.2d, v1.4s
+; CHECK-BF16-GI-NEXT:    fcvtl v3.2d, v0.2s
+; CHECK-BF16-GI-NEXT:    fcvtl2 v4.2d, v0.4s
+; CHECK-BF16-GI-NEXT:    fcvtzu v0.2d, v2.2d
+; CHECK-BF16-GI-NEXT:    fcvtzu v1.2d, v1.2d
+; CHECK-BF16-GI-NEXT:    fcvtzu v2.2d, v3.2d
+; CHECK-BF16-GI-NEXT:    fcvtzu v3.2d, v4.2d
+; CHECK-BF16-GI-NEXT:    ret
   %1 = fptoui <8 x bfloat> %a to <8 x i64>
   ret <8 x i64> %1
 }


### PR DESCRIPTION
Similar to other operations, this makes sure we can widen bf16 fptosi/fptoui correctly, promoting the value to a f32. The vector variants have been proved by exhastive checking every input.