### PR TITLE
[TableGen] V is always a TypedInit, so use cast

### DIFF
--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -2750,9 +2750,7 @@ TGParser::resolveInitTypes(ArrayRef<const Init *> Inits, const Twine &ErrCtx) {
     if (isa<UnsetInit>(V))
       continue;
 
-    const RecTy *VTy = nullptr;
-    if (const auto *Vt = dyn_cast<TypedInit>(V))
-      VTy = Vt->getType();
+    const RecTy *VTy = cast<TypedInit>(V)->getType();
 
     if (!Type) {
       Type = VTy;


### PR DESCRIPTION
No need to dyn_cast.  It is functionally impossible for V to not be a TypedInit at this point.