### PR TITLE
[clang][UncheckedLocalVarsChecker][NFC] Add missing headers

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/DiagOutputUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/DiagOutputUtils.h
@@ -10,7 +10,10 @@
 #define LLVM_CLANG_ANALYZER_WEBKIT_DIAGPRINTUTILS_H
 
 #include "ASTUtils.h"
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclObjC.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace clang {


### PR DESCRIPTION
After #208855 this fails compiling headers standalone due to incomplete types, e.g. `error: member access into incomplete type 'ASTContext'`. It works fine building the `.cpp` files but is not a [standalone](https://llvm.org/docs/CodingStandards.html#self-contained-headers) header.