### PR TITLE
[flang] Replace FlangOMPContext with OmpVariantMatchContext.

### DIFF
--- a/flang/lib/Lower/OpenMP/Utils.cpp
+++ b/flang/lib/Lower/OpenMP/Utils.cpp
@@ -1417,7 +1417,8 @@ resolveDeclareVariantCallee(const semantics::Symbol &base,
   collectEnclosingConstructTraits(
       converter.getFirOpBuilder().getInsertionBlock()->getParentOp(),
       constructTraits);
-  FlangOMPContext ompCtx{converter.getModuleOp(), constructTraits};
+  semantics::omp::OmpVariantMatchContext ompCtx =
+      makeVariantMatchContext(converter.getModuleOp(), constructTraits);
 
   const int bestIdx{llvm::omp::getBestVariantMatchForContext(vmis, ompCtx)};
   // Return nullptr when no variant matches the current context; the caller


### PR DESCRIPTION
The `FlangOMPContext` got replaced in 8e8e4e50f501b.

This fixes build after https://github.com/llvm/llvm-project/pull/206988.