### PR TITLE
[CIR][AArc64] Add lowering for fp16 intrinsics (multiply extended)

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -456,6 +456,7 @@ static mlir::Value emitCommonNeonSISDBuiltinExpr(
   case NEON::BI__builtin_neon_vpmaxqd_f64:
   case NEON::BI__builtin_neon_vpmaxnms_f32:
   case NEON::BI__builtin_neon_vpmaxnmqd_f64:
+  case NEON::BI__builtin_neon_vmulxh_f16:
     break;
   }
 

--- a/clang/test/CodeGen/AArch64/neon/fullfp16.c
+++ b/clang/test/CodeGen/AArch64/neon/fullfp16.c
@@ -60,7 +60,7 @@ float16_t test_vsubh_f16(float16_t a, float16_t b) {
 }
 
 //===------------------------------------------------------===//
-// 2.5.9.1.  Multiplication
+// 2.5.1.9.1.  Multiplication
 //===------------------------------------------------------===//
 // ALL-LABEL: @test_vmulh_f16(
 float16_t test_vmulh_f16(float16_t a, float16_t b) {
@@ -355,4 +355,17 @@ float16_t test_vfmsh_f16(float16_t a, float16_t b, float16_t c) {
 // LLVM:  [[ADD:%.*]] = call half @llvm.fma.f16(half [[SUB]], half [[C]], half [[A]])
 // LLVM:  ret half [[ADD]]
   return vfmsh_f16(a, b, c);
+}
+
+//===------------------------------------------------------===//
+// 2.5.1.9.2  Multiply extended 
+//===------------------------------------------------------===//
+// ALL-LABEL: test_vmulxh_f16
+float16_t test_vmulxh_f16(float16_t a, float16_t b) {
+// CIR: cir.call_llvm_intrinsic "aarch64.neon.fmulx"
+
+// LLVM-SAME: half{{.*}} [[A:%.*]], half{{.*}} [[B:%.*]])
+// LLVM:  [[MUL:%.*]] = call half @llvm.aarch64.neon.fmulx.f16(half [[A]], half [[B]])
+// LLVM:  ret half [[MUL]]
+  return vmulxh_f16(a, b);
 }

--- a/clang/test/CodeGen/AArch64/v8.2a-fp16-intrinsics.c
+++ b/clang/test/CodeGen/AArch64/v8.2a-fp16-intrinsics.c
@@ -450,10 +450,3 @@ int32_t test_vcvth_n_u32_f16(float16_t a) {
 int64_t test_vcvth_n_u64_f16(float16_t a) {
   return vcvth_n_u64_f16(a, 1);
 }
-
-// CHECK-LABEL: test_vmulxh_f16
-// CHECK:  [[MUL:%.*]] = call half @llvm.aarch64.neon.fmulx.f16(half %a, half %b)
-// CHECK:  ret half [[MUL]]
-float16_t test_vmulxh_f16(float16_t a, float16_t b) {
-  return vmulxh_f16(a, b);
-}


### PR DESCRIPTION
This PR adds lowering for the following intrinsic groups:
* https://arm-software.github.io/acle/neon_intrinsics/advsimd.html#multiply-extended-1

It also moves the corresponding tests from:

* clang/test/CodeGen/AArch64/v8.2a-fp16-intrinsics.c

to:
* clang/test/CodeGen/AArch64/neon/fullfp16.c

The lowering follows the existing implementation in
CodeGen/TargetBuiltins/ARM.cpp.
