### PR TITLE
[clang][ssaf] Add --ssaf-include-local-entities flag

### DIFF
--- a/clang/include/clang/Frontend/SSAFOptions.h
+++ b/clang/include/clang/Frontend/SSAFOptions.h
@@ -41,9 +41,16 @@ public:
   LLVM_PREFERRED_TYPE(bool)
   unsigned ShowFormats : 1;
 
+  /// Include block-scope (function-local) declarations in extracted SSAF
+  /// summaries. Defaults to false to preserve the original behavior.
+  /// Controlled by: --ssaf-include-local-entities
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned IncludeLocalEntities : 1;
+
   SSAFOptions() {
     ShowExtractors = false;
     ShowFormats = false;
+    IncludeLocalEntities = false;
   };
 };
 

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -982,6 +982,14 @@ def _ssaf_compilation_unit_id :
     "produced SSAF TU summary. Required when '--ssaf-tu-summary-file=' is "
     "set.">,
   MarshallingInfoString<SSAFOpts<"CompilationUnitId">>;
+def _ssaf_include_local_entities :
+  Flag<["--"], "ssaf-include-local-entities">,
+  Group<SSAF_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<
+    "Include block-scope (function-local) declarations in extracted SSAF "
+    "summaries. By default they are omitted.">,
+  MarshallingInfoFlag<SSAFOpts<"IncludeLocalEntities">>;
 def Xarch__
     : JoinedAndSeparate<["-"], "Xarch_">,
       Flags<[NoXarchOption]>,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8077,6 +8077,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_extract_summaries);
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_tu_summary_file);
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_compilation_unit_id);
+  Args.AddLastArg(CmdArgs, options::OPT__ssaf_include_local_entities);
 
   // Handle serialized diagnostics.
   if (Arg *A = Args.getLastArg(options::OPT__serialize_diags)) {

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.cpp
@@ -12,9 +12,11 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/ExprCXX.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "llvm/ADT/SetVector.h"
 
 using namespace clang;
+using namespace ssaf;
 
 std::string ssaf::describeJSONValue(const llvm::json::Value &V) {
   return llvm::formatv("{0:2}", V).str();
@@ -33,8 +35,9 @@ namespace {
 class ContributorFinder : public DynamicRecursiveASTVisitor {
 public:
   llvm::SetVector<const NamedDecl *> Contributors;
+  const SSAFOptions &Opts;
 
-  ContributorFinder() {
+  ContributorFinder(const SSAFOptions &Opts) : Opts(Opts) {
     ShouldVisitTemplateInstantiations = true;
     ShouldVisitImplicitCode = false;
   }
@@ -53,7 +56,23 @@ public:
     DeclContext *DC = D->getDeclContext();
 
     // Collects Decl for global variables or static data members:
-    if (DC->isFileContext() || D->isStaticDataMember())
+    if (DC->isFileContext() || D->isStaticDataMember()) {
+      Contributors.insert(D);
+      return true;
+    }
+
+    // Optionally include block-scope (function-local) variables. Parameters
+    // are intentionally skipped: they are exposed via their parent function's
+    // USR + a parameter-index suffix in getEntityName, so registering them as
+    // independent contributors would be redundant.
+    //
+    // FIXME: clang::index::generateUSRForDecl can produce non-unique or empty
+    // USRs for some local declaration shapes (e.g., locals of certain template
+    // instantiations). The current addEntity path returns std::nullopt when
+    // that happens and downstream extractors skip gracefully, so this is
+    // tolerated for now.
+    if (Opts.IncludeLocalEntities && !D->isImplicit() && !isa<ParmVarDecl>(D) &&
+        DC->isFunctionOrMethod())
       Contributors.insert(D);
     return true;
   }
@@ -125,10 +144,10 @@ public:
 } // namespace
 
 void ssaf::findContributors(
-    ASTContext &Ctx,
+    ASTContext &Ctx, const SSAFOptions &Options,
     llvm::DenseMap<const NamedDecl *, std::vector<const NamedDecl *>>
         &Contributors) {
-  ContributorFinder Finder;
+  ContributorFinder Finder{Options};
   Finder.TraverseAST(Ctx);
   for (const NamedDecl *C : Finder.Contributors)
     Contributors[cast<NamedDecl>(C->getCanonicalDecl())].push_back(C);

--- a/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.h
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/SSAFAnalysesCommon.h
@@ -27,6 +27,8 @@
 #include <memory>
 
 namespace clang::ssaf {
+class SSAFOptions;
+
 ///\return a short descriptions of a json::Value
 std::string describeJSONValue(const llvm::json::Value &V);
 ///\return a short descriptions of a json::Array
@@ -75,8 +77,15 @@ inline void logWarningFromError(llvm::Error Err) {
 /// Find all contributors in an AST. The found contributors are organized as a
 /// map from the canonical declaration of each entity to all of its
 /// declarations.
+///
+/// \p Options controls which declarations qualify as contributors. By default
+/// the visitor preserves the original SSAF behavior of skipping block-scope
+/// (function-local) variable declarations; setting
+/// \c Options.IncludeLocalEntities to \c true also collects local variables
+/// (excluding function parameters, which are addressed via their parent
+/// function's USR).
 void findContributors(
-    ASTContext &Ctx,
+    ASTContext &Ctx, const SSAFOptions &Options,
     llvm::DenseMap<const NamedDecl *, std::vector<const NamedDecl *>>
         &Contributors);
 
@@ -107,7 +116,7 @@ void extractAndAddSummaries(TUSummaryExtractor &Extractor,
                             llvm::StringRef ExtractorName = "") {
   llvm::DenseMap<const NamedDecl *, std::vector<const NamedDecl *>>
       Contributors;
-  findContributors(Ctx, Contributors);
+  findContributors(Ctx, Extractor.getOptions(), Contributors);
   for (const auto &[Cano, Decls] : Contributors) {
     assert(!Decls.empty() &&
            "'findContributors' guarantees that 'Decls' are non-empty");

--- a/clang/test/Analysis/Scalable/command-line-interface.cpp
+++ b/clang/test/Analysis/Scalable/command-line-interface.cpp
@@ -13,6 +13,19 @@
 // RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=extractor1,extractor2 2>&1 | %{filecheck}=NO-EXTRACTORS-WITH-NAME
 // RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=extractor1,extractor2 2>&1 | %{filecheck}=NO-EXTRACTORS-WITH-NAME
 
+// Verify --ssaf-include-local-entities is accepted alongside summary extraction
+// in both the driver and CC1, and that without --ssaf-tu-summary-file= the
+// flag is silently ignored (same shape as --ssaf-list-extractors).
+// RUN: rm -rf %t.localents && mkdir %t.localents
+// RUN: %clang     -fsyntax-only %s --ssaf-include-local-entities
+// RUN: %clang_cc1 -fsyntax-only %s --ssaf-include-local-entities
+// RUN: %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.localents/a.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=CallGraph --ssaf-include-local-entities
+// RUN: %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.localents/b.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=CallGraph --ssaf-include-local-entities
+
+// Verify the driver forwards the flag to CC1.
+// RUN: %clang -### -fsyntax-only %s --ssaf-include-local-entities --ssaf-tu-summary-file=%t.localents/c.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=CallGraph 2>&1 | FileCheck %s --check-prefix=DRIVER-FORWARDS-FLAG
+// DRIVER-FORWARDS-FLAG: "-cc1"{{.+}}"--ssaf-include-local-entities"
+
 void empty() {}
 
 // NOT-MATCHING-THE-PATTERN: error: failed to parse the value of '--ssaf-tu-summary-file=foobar' the value must follow the '<path>.<format>' pattern [-Wscalable-static-analysis-framework]

--- a/clang/test/Analysis/Scalable/help.cpp
+++ b/clang/test/Analysis/Scalable/help.cpp
@@ -7,6 +7,8 @@
 // HELP-NEXT:    Stable identifier used as the CompilationUnit namespace name of every produced SSAF TU summary. Required when '--ssaf-tu-summary-file=' is set.
 // HELP-NEXT:  --ssaf-extract-summaries=<summary-names>
 // HELP-NEXT:    Comma-separated list of summary names to extract
+// HELP-NEXT:  --ssaf-include-local-entities
+// HELP-NEXT:    Include block-scope (function-local) declarations in extracted SSAF summaries. By default they are omitted.
 // HELP-NEXT:  --ssaf-list-extractors  Display the list of available SSAF summary extractors
 // HELP-NEXT:  --ssaf-list-formats     Display the list of available SSAF serialization formats
 // HELP-NEXT:  --ssaf-tu-summary-file=<path>.<format>


### PR DESCRIPTION
This option allows including local entities in summaries.
This means that ContributorFinder can optionally include block-scope
(function-local) variables.
Parameters are intentionally skipped: they are exposed via their parent
function's USR + a parameter-index suffix in getEntityName, so registering
them as independent contributors would be redundant.

Part §2 of rdar://179151023

Approved in #205351.