### PR TITLE
[clang][ssaf] Add FIXME that CallGraphExtractor does not honor IncludeLocalEntities

### DIFF
--- a/clang/lib/ScalableStaticAnalysis/Analyses/CallGraph/CallGraphExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysis/Analyses/CallGraph/CallGraphExtractor.cpp
@@ -35,6 +35,12 @@ private:
 } // namespace
 
 void CallGraphExtractor::HandleTranslationUnit(ASTContext &Ctx) {
+  // FIXME: Depending on the IncludeLocalEntities option, the extractor should
+  // include or exclude calls to function-local defined:
+  //   - lambda functions
+  //   - methods of local classes
+  // Currently, the extractor always includes these callees, even if
+  // IncludeLocalEntities is false.
   CallGraph CG;
   CG.addToCallGraph(
       const_cast<TranslationUnitDecl *>(Ctx.getTranslationUnitDecl()));

--- a/clang/test/Analysis/Scalable/call-graph-local-entities.cpp
+++ b/clang/test/Analysis/Scalable/call-graph-local-entities.cpp
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+
+// RUN: %clang_cc1 -fsyntax-only %s \
+// RUN:   --ssaf-extract-summaries=CallGraph \
+// RUN:   --ssaf-compilation-unit-id=test-cu \
+// RUN:   --ssaf-tu-summary-file=%t/cg.default.json
+// RUN: %clang_cc1 -fsyntax-only %s \
+// RUN:   --ssaf-extract-summaries=CallGraph \
+// RUN:   --ssaf-include-local-entities \
+// RUN:   --ssaf-compilation-unit-id=test-cu \
+// RUN:   --ssaf-tu-summary-file=%t/cg.with_locals.json
+
+// FIXME: The next line should assert 1 count because the lambda call operator
+//        should be included only if requested.
+// RUN: cat %t/cg.default.json     | grep '"entity_id":' | count 2
+// RUN: cat %t/cg.with_locals.json | grep '"entity_id":' | count 2
+
+void caller() {
+  auto local = []{};
+  local();
+}

--- a/clang/test/Analysis/Scalable/local-entities.cpp
+++ b/clang/test/Analysis/Scalable/local-entities.cpp
@@ -1,0 +1,56 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// PointerFlow:
+//  RUN: %clang_cc1 -fsyntax-only %t/local.cpp \
+//  RUN:   --ssaf-extract-summaries=PointerFlow \
+//  RUN:   --ssaf-compilation-unit-id=test-cu \
+//  RUN:   --ssaf-tu-summary-file=%t/pf.default.json
+//  RUN: %clang_cc1 -fsyntax-only %t/local.cpp \
+//  RUN:   --ssaf-extract-summaries=PointerFlow \
+//  RUN:   --ssaf-include-local-entities \
+//  RUN:   --ssaf-compilation-unit-id=test-cu \
+//  RUN:   --ssaf-tu-summary-file=%t/pf.with_locals.json
+
+// With the flag, summary_data must gain one additional entity_id entry for
+// the local pointer.
+// RUN: cat %t/pf.default.json     | grep '"entity_id":' | count 2
+// RUN: cat %t/pf.with_locals.json | grep '"entity_id":' | count 3
+
+// UnsafeBufferUsage:
+//  RUN: %clang_cc1 -fsyntax-only %t/local.cpp \
+//  RUN:   --ssaf-extract-summaries=UnsafeBufferUsage \
+//  RUN:   --ssaf-compilation-unit-id=test-cu \
+//  RUN:   --ssaf-tu-summary-file=%t/ubu.default.json
+//  RUN: %clang_cc1 -fsyntax-only %t/local.cpp \
+//  RUN:   --ssaf-extract-summaries=UnsafeBufferUsage \
+//  RUN:   --ssaf-include-local-entities \
+//  RUN:   --ssaf-compilation-unit-id=test-cu \
+//  RUN:   --ssaf-tu-summary-file=%t/ubu.with_locals.json
+
+// The unsafe subscript happens inside the local var's initializer scope so its
+// own summary is emitted under the flag.
+// RUN: cat %t/ubu.default.json     | grep '"entity_id":' | count 1
+// RUN: cat %t/ubu.with_locals.json | grep '"entity_id":' | count 2
+
+//--- local.cpp
+// Two externally visible entities: 'g_in', 'g_arr'.
+// One local pointer that aliases 'g_in' and is then unsafely subscripted
+// in the initializer of 'unsafe_local'.
+
+// Default run: summary_data has exactly 2 entries:
+// 'use' and the global pointer's initializer
+//
+// With-locals run: a third entity_id entry covers the local pointer's
+// own contributor scope.
+
+int g_arr[10];
+int *g_in = g_arr;
+
+void use(int *param) {
+  int *local_ptr = param;
+  int unsafe_local = local_ptr[3];
+  (void)unsafe_local;
+  (void)g_in;
+}


### PR DESCRIPTION
Currently, CallGraph extractor does not honor IncludeLocalEntities and
it emits entities for block-scope callees - irrespective of what the
option is set to, such as:

- function-local declared lambdas
- function-local declared classes and their member functions

The new test file ensures that PointerFlow and UnsafeBufferUsage honors
the IncludeLocalEntities option.

Part §3 and §5 of rdar://179151023

Depends on #209225 and #209227.
Approved in #205351.