### PR TITLE
Revert "[CMake] Use minimum python version of 3.8 everywhere"

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1077,8 +1077,13 @@ set(LLVM_PROFDATA_FILE "" CACHE FILEPATH
 set(LLVM_SPROFDATA_FILE "" CACHE FILEPATH
   "Sampling profiling data file to use when compiling in order to improve runtime performance.")
 
-# All LLVM Python files should be compatible down to this minimum version.
-set(LLVM_MINIMUM_PYTHON_VERSION 3.8)
+if(LLVM_INCLUDE_TESTS OR LLVM_ENABLE_SPHINX)
+  # All LLVM Python files should be compatible down to this minimum version.
+  set(LLVM_MINIMUM_PYTHON_VERSION 3.8)
+else()
+  # FIXME: it is unknown if this is the actual minimum bound
+  set(LLVM_MINIMUM_PYTHON_VERSION 3.0)
+endif()
 
 # Find python before including config-ix, since it needs to be able to search
 # for python modules.


### PR DESCRIPTION
Reverts llvm/llvm-project#208822.

We should avoid raising toolchain requirements immediately before branching. Revert this now so it can be reapplied after branching.