### PR TITLE
[lldb-server] Add type info for qMemoryinfo reponse

### DIFF
--- a/lldb/include/lldb/Target/MemoryRegionInfo.h
+++ b/lldb/include/lldb/Target/MemoryRegionInfo.h
@@ -142,7 +142,10 @@ public:
 
   LazyBool IsStackMemory() const { return m_is_stack_memory; }
 
-  void SetIsStackMemory(LazyBool val) { m_is_stack_memory = val; }
+  MemoryRegionInfo &SetIsStackMemory(LazyBool val) {
+    m_is_stack_memory = val;
+    return *this;
+  }
 
   void SetPageSize(int pagesize) { m_pagesize = pagesize; }
 

--- a/lldb/source/Plugins/Process/Utility/LinuxProcMaps.cpp
+++ b/lldb/source/Plugins/Process/Utility/LinuxProcMaps.cpp
@@ -123,7 +123,7 @@ ParseMemoryRegionInfoFromProcMapsLine(llvm::StringRef maps_line,
     else if (llvm::StringRef(name) == "[heap]")
       region.SetIsStackMemory(eLazyBoolNo);
     else
-     region.SetIsStackMemory(eLazyBoolDontKnow);
+      region.SetIsStackMemory(eLazyBoolDontKnow);
   }
 
   return region;

--- a/lldb/source/Plugins/Process/Utility/LinuxProcMaps.cpp
+++ b/lldb/source/Plugins/Process/Utility/LinuxProcMaps.cpp
@@ -122,6 +122,8 @@ ParseMemoryRegionInfoFromProcMapsLine(llvm::StringRef maps_line,
       region.SetIsStackMemory(eLazyBoolYes);
     else if (llvm::StringRef(name) == "[heap]")
       region.SetIsStackMemory(eLazyBoolNo);
+    else
+     region.SetIsStackMemory(eLazyBoolDontKnow);
   }
 
   return region;

--- a/lldb/source/Plugins/Process/Utility/LinuxProcMaps.cpp
+++ b/lldb/source/Plugins/Process/Utility/LinuxProcMaps.cpp
@@ -114,8 +114,15 @@ ParseMemoryRegionInfoFromProcMapsLine(llvm::StringRef maps_line,
 
   line_extractor.SkipSpaces();
   const char *name = line_extractor.Peek();
-  if (name)
+  if (name) {
     region.SetName(name);
+    // /proc/maps labels only the main thread's stack; thread stacks are
+    // anonymous and the default MemoryRegionInfo::eDontKnow is kept.
+    if (llvm::StringRef(name) == "[stack]")
+      region.SetIsStackMemory(eLazyBoolYes);
+    else if (llvm::StringRef(name) == "[heap]")
+      region.SetIsStackMemory(eLazyBoolNo);
+  }
 
   return region;
 }

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -2971,6 +2971,13 @@ GDBRemoteCommunicationServerLLGS::Handle_qMemoryRegionInfo(
 
     if (std::optional<unsigned> protection_key = region_info.GetProtectionKey())
       response.Printf("protection-key:%" PRIu32 ";", *protection_key);
+
+    // Type: stack/heap classification, when known.
+    LazyBool is_stack = region_info.IsStackMemory();
+    if (is_stack == eLazyBoolYes)
+      response.PutCString("type:stack;");
+    else if (is_stack == eLazyBoolNo)
+      response.PutCString("type:heap;");
   }
 
   return SendPacketNoLock(response.GetString());

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -2972,12 +2972,9 @@ GDBRemoteCommunicationServerLLGS::Handle_qMemoryRegionInfo(
     if (std::optional<unsigned> protection_key = region_info.GetProtectionKey())
       response.Printf("protection-key:%" PRIu32 ";", *protection_key);
 
-    // Type: stack/heap classification, when known.
     LazyBool is_stack = region_info.IsStackMemory();
-    if (is_stack == eLazyBoolYes)
-      response.PutCString("type:stack;");
-    else if (is_stack == eLazyBoolNo)
-      response.PutCString("type:heap;");
+    if (is_stack != eLazyBoolDontKnow)
+      response.Printf("type: %s", is_stack ? "stack" : "heap");
   }
 
   return SendPacketNoLock(response.GetString());

--- a/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
+++ b/lldb/unittests/Process/Utility/LinuxProcMapsTest.cpp
@@ -99,7 +99,18 @@ INSTANTIATE_TEST_SUITE_P(
                 MemoryRegionInfo(make_range(0x55a4512f7000, 0x55a451b68000),
                                  eLazyBoolYes, eLazyBoolYes, eLazyBoolNo,
                                  eLazyBoolNo, eLazyBoolYes,
-                                 ConstString("[heap]")),
+                                 ConstString("[heap]"))
+                    .SetIsStackMemory(eLazyBoolNo),
+            },
+            ""),
+        std::make_tuple(
+            "7ffcad8f7000-7ffcad918000 rw-p 00000000 00:00 0    [stack]",
+            MemoryRegionInfos{
+                MemoryRegionInfo(make_range(0x7ffcad8f7000, 0x7ffcad918000),
+                                 eLazyBoolYes, eLazyBoolYes, eLazyBoolNo,
+                                 eLazyBoolNo, eLazyBoolYes,
+                                 ConstString("[stack]"))
+                    .SetIsStackMemory(eLazyBoolYes),
             },
             ""),
         // Multiple entries


### PR DESCRIPTION
Use the name of the memory region to report the known cases where an address points to stack/heap: "[stack]" or "[heap"].

According to [1], the "[stack]" name is the main thread's stack region:
```
  [stack]
                     The initial process's (also known as the main
                     thread's) stack.
```

For other threads, we can't know their stack region because this field got removed in newer kernels:

```
 [stack:tid] (from Linux 3.4 to Linux 4.4)
        A thread's stack (where the tid is a thread ID).  It
        corresponds to the /proc/pid/task/tid/ path.  This
        field was removed in Linux 4.5, since providing this
        information for a process with large numbers of
        threads is expensive.
```

So we can only set "isStack" to Yes in some cases, and to "No" when the name is "[heap]". If there is no name, or the name is something else, we keep the "don't know" answer.

[1]: https://man7.org/linux/man-pages/man5/proc_pid_maps.5.html