### PR TITLE
[llvm][HTTP] Relax check for timeout error message

### DIFF
--- a/llvm/test/tools/llvm-debuginfod-find/timeout.test
+++ b/llvm/test/tools/llvm-debuginfod-find/timeout.test
@@ -9,4 +9,5 @@ RUN: env DEBUGINFOD_CACHE=%t/debuginfod-cache \
 RUN: env DEBUGINFOD_HEADERS_FILE=%S/Inputs/headers \
 RUN:   %python %S/Inputs/delay_req.py llvm-debuginfod-find --debuginfo 0 | FileCheck %s
 
-CHECK: Build ID 00: Timeout was reached
+CHECK: Build ID 00:
+CHECK-SAME: Timeout was reached


### PR DESCRIPTION
When LLVM used curl to do HTTP requests, the timeout test failed even though the request correctly timed out (https://github.com/llvm/llvm-project/pull/188969#issuecomment-4960193683).

On curl, we prepend the error with `curl_easy_perform() failed: ` whereas with WinHTTP, the error is fixed as "Timeout was reached".

This PR relaxes the check to allow for the prefix in the curl case.