### PR TITLE
[AArch64][llvm][clang] Rename 9.7 ACLE vmmlaq_f16_f16 to vmmlaq_f16

### DIFF
--- a/clang/include/clang/Basic/AArch64CodeGenUtils.h
+++ b/clang/include/clang/Basic/AArch64CodeGenUtils.h
@@ -263,7 +263,7 @@ const inline ARMNeonVectorIntrinsicInfo AArch64SIMDIntrinsicMap [] = {
   NEONMAP1(vld1q_x2_v, aarch64_neon_ld1x2, 0),
   NEONMAP1(vld1q_x3_v, aarch64_neon_ld1x3, 0),
   NEONMAP1(vld1q_x4_v, aarch64_neon_ld1x4, 0),
-  NEONMAP1(vmmlaq_f16_f16, aarch64_neon_fmmla, 0),
+  NEONMAP1(vmmlaq_f16, aarch64_neon_fmmla, 0),
   NEONMAP1(vmmlaq_f32_f16, aarch64_neon_fmmla, 0),
   NEONMAP1(vmmlaq_s32, aarch64_neon_smmla, 0),
   NEONMAP1(vmmlaq_u32, aarch64_neon_ummla, 0),

--- a/clang/include/clang/Basic/arm_neon.td
+++ b/clang/include/clang/Basic/arm_neon.td
@@ -1938,7 +1938,7 @@ let ArchGuard = "defined(__aarch64__)", TargetGuard = "f8f32mm,neon" in {
 }
 
 let ArchGuard = "defined(__aarch64__)", TargetGuard = "f16mm,neon" in {
-  def VMMLA_F16_F16 : SInst<"vmmla_f16", "....", "Qh">;
+  def VMMLA_F16_F16 : SInst<"vmmla", "....", "Qh">;
 }
 
 let ArchGuard = "defined(__aarch64__)", TargetGuard = "f16f32mm,neon" in {

--- a/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
@@ -1790,7 +1790,7 @@ Value *CodeGenFunction::EmitCommonNeonBuiltinExpr(
     llvm::Type *Tys[2] = { Ty, InputTy };
     return EmitNeonCall(CGM.getIntrinsic(LLVMIntrinsic, Tys), Ops, "vmmla");
   }
-  case NEON::BI__builtin_neon_vmmlaq_f16_f16:
+  case NEON::BI__builtin_neon_vmmlaq_f16:
   case NEON::BI__builtin_neon_vmmlaq_f32_f16: {
     auto *InputTy =
         llvm::FixedVectorType::get(HalfTy, Ty->getPrimitiveSizeInBits() / 16);

--- a/clang/test/CodeGen/AArch64/v9.7a-neon-mmla-intrinsics.c
+++ b/clang/test/CodeGen/AArch64/v9.7a-neon-mmla-intrinsics.c
@@ -6,7 +6,7 @@
 
 #include <arm_neon.h>
 
-// CHECK-LABEL: define dso_local <8 x half> @test_vmmlaq_f16_f16(
+// CHECK-LABEL: define dso_local <8 x half> @test_vmmlaq_f16(
 // CHECK-SAME: <8 x half> noundef [[ACC:%.*]], <8 x half> noundef [[A:%.*]], <8 x half> noundef [[B:%.*]]) #[[ATTR0:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = bitcast <8 x half> [[ACC]] to <8 x i16>
@@ -21,8 +21,8 @@
 // CHECK-NEXT:    [[FMMLA3_I:%.*]] = call <8 x half> @llvm.aarch64.neon.fmmla.v8f16.v8f16(<8 x half> [[FMMLA_I]], <8 x half> [[FMMLA1_I]], <8 x half> [[FMMLA2_I]])
 // CHECK-NEXT:    ret <8 x half> [[FMMLA3_I]]
 //
-float16x8_t test_vmmlaq_f16_f16(float16x8_t acc, float16x8_t a, float16x8_t b) {
-  return vmmlaq_f16_f16(acc, a, b);
+float16x8_t test_vmmlaq_f16(float16x8_t acc, float16x8_t a, float16x8_t b) {
+  return vmmlaq_f16(acc, a, b);
 }
 
 // CHECK-LABEL: define dso_local <4 x float> @test_vmmlaq_f32_f16(

--- a/clang/test/Sema/aarch64-neon-target.c
+++ b/clang/test/Sema/aarch64-neon-target.c
@@ -44,7 +44,7 @@ void bf16(uint32x2_t v2i32, uint32x4_t v4i32, uint16x8_t v8i16, uint8x16_t v16i8
 
 __attribute__((target("f16mm")))
 void f16mm(float16x8_t v8f16) {
-  vmmlaq_f16_f16(v8f16, v8f16, v8f16);
+  vmmlaq_f16(v8f16, v8f16, v8f16);
 }
 
 __attribute__((target("f16f32mm")))
@@ -96,7 +96,7 @@ void undefined(uint32x2_t v2i32, uint32x4_t v4i32, uint16x8_t v8i16, uint8x16_t 
   vcvt_f32_bf16(v4bf16); // expected-error {{always_inline function 'vcvt_f32_bf16' requires target feature 'bf16'}}
   vcvt_bf16_f32(v4f32); // expected-error {{always_inline function 'vcvt_bf16_f32' requires target feature 'bf16'}}
   // f16mm / f16f32mm
-  vmmlaq_f16_f16(v8f16, v8f16, v8f16); // expected-error {{always_inline function 'vmmlaq_f16_f16' requires target feature 'f16mm'}}
+  vmmlaq_f16(v8f16, v8f16, v8f16); // expected-error {{always_inline function 'vmmlaq_f16' requires target feature 'f16mm'}}
   vmmlaq_f32_f16(v4f32, v8f16, v8f16); // expected-error {{always_inline function 'vmmlaq_f32_f16' requires target feature 'f16f32mm'}}
   // v8.1 - qrdmla
   vqrdmlahq_s32(v4i32, v4i32, v4i32); // expected-error {{always_inline function 'vqrdmlahq_s32' requires target feature 'v8.1a'}}

--- a/clang/test/Sema/aarch64-neon-without-target-feature.cpp
+++ b/clang/test/Sema/aarch64-neon-without-target-feature.cpp
@@ -28,7 +28,7 @@ void undefined(uint32x2_t v2i32, uint32x4_t v4i32, uint16x8_t v8i16, uint8x16_t 
   vld1_bf16(0); // expected-error {{'__builtin_neon_vld1_v' needs target feature neon}}
   vcvt_f32_bf16(v4bf16); // expected-error {{always_inline function 'vcvt_f32_bf16' requires target feature 'neon'}}
   vcvt_bf16_f32(v4f32); // expected-error {{always_inline function 'vcvt_bf16_f32' requires target feature 'neon'}}
-  vmmlaq_f16_f16(v8f16, v8f16, v8f16); // expected-error {{always_inline function 'vmmlaq_f16_f16' requires target feature 'neon'}}
+  vmmlaq_f16(v8f16, v8f16, v8f16); // expected-error {{always_inline function 'vmmlaq_f16' requires target feature 'neon'}}
   vmmlaq_f32_f16(v4f32, v8f16, v8f16); // expected-error {{always_inline function 'vmmlaq_f32_f16' requires target feature 'neon'}}
   vmull_p64(poly64, poly64);  // expected-error {{always_inline function 'vmull_p64' requires target feature 'neon'}}
   vmull_high_p64(poly64x2, poly64x2);  // expected-error {{always_inline function 'vmull_high_p64' requires target feature 'neon'}}


### PR DESCRIPTION
Rename Armv9.7 ACLE intrinsic `vmmlaq_f16_f16` to `vmmlaq_f16`
as it matches convention better.

See https://github.com/ARM-software/acle/pull/443 for the ACLE change.