### PR TITLE
[Hexagon] Register MachineKCFILegacy pass in LLVMInitializeHexagonTarget

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
@@ -24,6 +24,7 @@
 #include "llvm/CodeGen/Passes.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
 #include "llvm/CodeGen/VLIWMachineScheduler.h"
+#include "llvm/InitializePasses.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/CommandLine.h"
@@ -250,6 +251,7 @@ LLVMInitializeHexagonTarget() {
   initializeHexagonQFPOptimizerPass(PR);
   initializeHexagonXQFloatGeneratorPass(PR);
   initializeHexagonPostRAHandleQFPPass(PR);
+  initializeMachineKCFILegacyPass(PR);
 }
 
 HexagonTargetMachine::HexagonTargetMachine(const Target &T, const Triple &TT,


### PR DESCRIPTION
Hexagon's target-init function never called
initializeMachineKCFILegacyPass(PR), unlike X86, ARM, AArch64, and RISCV. Since PassRegistry is process-wide and each target's init function registers passes as a side effect when linked into the same binary, whether test/CodeGen/Hexagon/kcfi.ll passed depended on whether some other target providing that registration was also built into llc, rather than on Hexagon's own configuration.