### PR TITLE
workflows: Fixes for release-binaries and upload-release-artifact

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -386,6 +386,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             .github/workflows/upload-release-artifact
+            .github/workflows/validate-release-version
             llvm/utils/release/github-upload-release.py
             llvm/utils/git/requirements.txt
           sparse-checkout-cone-mode: false

--- a/.github/workflows/validate-release-version/action.yml
+++ b/.github/workflows/validate-release-version/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - env:
-      RELEASE_VERSON: ${{ inputs.release-version }}
-
+        RELEASE_VERSION: ${{ inputs.release-version }}
+      shell: bash
       run: |
         grep -e '^[0-9]\+\.[0-9]\+\.[0-9]\+\(-rc[0-9]\+\)\?$' <<< "$RELEASE_VERSION"


### PR DESCRIPTION
There were some bugs in upload-release-artifact workflow and release-binaries was not including this action in its checkout.