### PR TITLE
[VPlan] Report PHI as opcode in getOpcodeOrIntrinsicID

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -1262,7 +1262,7 @@ getOpcodeOrIntrinsicID(const VPSingleDefRecipe *R) {
             VPReplicateRecipe>(
           [](auto *I) { return std::make_pair(false, I->getOpcode()); })
       .Case([](const VPWidenPHIRecipe *I) {
-        return std::make_pair(true, Instruction::PHI);
+        return std::make_pair(false, Instruction::PHI);
       })
       .Case<VPVectorPointerRecipe, VPPredInstPHIRecipe, VPScalarIVStepsRecipe>(
           [](auto *I) {


### PR DESCRIPTION
Avoid reporting Instruction::PHI as an intrinsic ID, fixing a bug exposed in downstream CHERIoT.

Reported-by: Owen Anderson <resistor@mac.com>