### PR TITLE
clang/AMDGPU: Remove StringSwitch over r600 aliases

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -697,19 +697,10 @@ void tools::AddTargetFeature(const ArgList &Args,
 }
 
 /// Get the (LLVM) name of the AMDGPU gpu we are targeting.
-static std::string getAMDGPUTargetGPU(const llvm::Triple &T,
-                                      const ArgList &Args) {
+static StringRef getAMDGPUTargetGPU(const llvm::Triple &T,
+                                    const ArgList &Args) {
   if (Arg *A = Args.getLastArg(options::OPT_mcpu_EQ)) {
-    auto GPUName = getProcessorFromTargetID(T, A->getValue());
-    return llvm::StringSwitch<std::string>(GPUName)
-        .Cases({"rv630", "rv635"}, "r600")
-        .Cases({"rv610", "rv620", "rs780"}, "rs880")
-        .Case("rv740", "rv770")
-        .Case("palm", "cedar")
-        .Cases({"sumo", "sumo2"}, "sumo")
-        .Case("hemlock", "cypress")
-        .Case("aruba", "cayman")
-        .Default(GPUName.str());
+    return getProcessorFromTargetID(T, A->getValue());
   }
   return "";
 }
@@ -835,7 +826,7 @@ std::string tools::getCPUName(const Driver &D, const ArgList &Args,
 
   case llvm::Triple::amdgpu:
   case llvm::Triple::r600:
-    return getAMDGPUTargetGPU(T, Args);
+    return getAMDGPUTargetGPU(T, Args).str();
 
   case llvm::Triple::wasm32:
   case llvm::Triple::wasm64:


### PR DESCRIPTION
This will route to getArchNameR600 which should already handle
all the aliases.