### PR TITLE
[lldb][Windows] Default to lldb-server when libxml2 is available

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -20,6 +20,7 @@
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Section.h"
+#include "lldb/Host/Config.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/HostNativeProcessBase.h"
@@ -97,11 +98,14 @@ ProcessSP ProcessWindows::CreateInstance(lldb::TargetSP target_sp,
 }
 
 static bool ShouldUseLLDBServer() {
-  llvm::StringRef use_lldb_server = ::getenv("LLDB_USE_LLDB_SERVER");
-  return use_lldb_server.equals_insensitive("on") ||
-         use_lldb_server.equals_insensitive("yes") ||
-         use_lldb_server.equals_insensitive("1") ||
-         use_lldb_server.equals_insensitive("true");
+  if (const char *env = ::getenv("LLDB_USE_LLDB_SERVER")) {
+    llvm::StringRef use_lldb_server(env);
+    return use_lldb_server.equals_insensitive("on") ||
+           use_lldb_server.equals_insensitive("yes") ||
+           use_lldb_server.equals_insensitive("1") ||
+           use_lldb_server.equals_insensitive("true");
+  }
+  return LLDB_ENABLE_LIBXML2;
 }
 
 void ProcessWindows::Initialize() {

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -405,8 +405,9 @@ if platform.system() == "Windows":
         if v in os.environ:
             config.environment[v] = os.environ[v]
 
-    if getattr(config, "lldb_use_lldb_server", False):
-        config.environment["LLDB_USE_LLDB_SERVER"] = "1"
+    config.environment["LLDB_USE_LLDB_SERVER"] = (
+        "1" if getattr(config, "lldb_use_lldb_server", False) else "0"
+    )
 
     # Use anonymous pipes instead of ConPTY for all tests. ConPTY injects VT
     # escape sequences into the output stream, which breaks tests that check

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -272,7 +272,16 @@ if (LLDB_ENABLE_ARM64E_DEBUGSERVER OR LLDB_USE_SYSTEM_DEBUGSERVER)
 endif()
 
 set(LLDB_TEST_SHELL_DISABLE_REMOTE OFF CACHE BOOL "Disable remote Shell tests execution")
-set(LLDB_TEST_USE_LLDB_SERVER OFF CACHE BOOL "If ON, run the test suites against the lldb-server backend on Windows")
+
+# On Windows, drive the tests through the lldb-server backend by default when
+# libxml2 is available (it is required to parse the gdb-remote target XML).
+# Without libxml2, fall back to the in-process Windows process plugin. This
+# mirrors the runtime default selected in ProcessWindows.cpp.
+set(LLDB_TEST_USE_LLDB_SERVER_DEFAULT OFF)
+if(WIN32 AND LLDB_ENABLE_LIBXML2)
+  set(LLDB_TEST_USE_LLDB_SERVER_DEFAULT ON)
+endif()
+set(LLDB_TEST_USE_LLDB_SERVER ${LLDB_TEST_USE_LLDB_SERVER_DEFAULT} CACHE BOOL "If ON, run the test suites against the lldb-server backend on Windows")
 
 # These values are not canonicalized within LLVM.
 llvm_canonicalize_cmake_booleans(

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -181,8 +181,9 @@ if config.have_dia_sdk:
     config.available_features.add("diasdk")
 
 if platform.system() == "Windows":
-    if getattr(config, "lldb_use_lldb_server", False):
-        config.environment["LLDB_USE_LLDB_SERVER"] = "1"
+    config.environment["LLDB_USE_LLDB_SERVER"] = (
+        "1" if getattr(config, "lldb_use_lldb_server", False) else "0"
+    )
     # Use anonymous pipes instead of ConPTY for all tests. ConPTY injects VT
     # escape sequences into the output stream, which breaks tests that check
     # for specific stdout/stderr content.


### PR DESCRIPTION
Select the debugging backend based on libxml2 availability, which is required to parse the gdb-remote target description XML.

At runtime, `ProcessWindows::ShouldUseLLDBServer()` now honors an explicit `LLDB_USE_LLDB_SERVER` environment variable if set, and otherwise defaults to lldb-server when `LLDB_ENABLE_LIBXML2` is on, falling back to the in-process Windows process plugin when it is not.

In the test suite, `LLDB_TEST_USE_LLDB_SERVER` now defaults to `ON` when building on Windows with libxml2 available. The lit configs set `LLDB_USE_LLDB_SERVER` explicitly to 1 or 0 so the test configuration is authoritative regardless of the compiled-in default.

rdar://174236280