### PR TITLE
Add text file support for z/OS back in

### DIFF
--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -65,18 +65,31 @@ def run(argv, stdin, stdout, stderr, cwd):
 
     for filename in filenames:
         path = filename
-        contents = None
         if not os.path.isabs(path):
             path = os.path.join(cwd, path)
+
+        contents = None
+        is_text = False
         try:
-            with open(path, "rb") as fileToCat:
-                contents = fileToCat.read()
-        except IOError as error:
-            error.filename = filename
-            stderr.write(str(error).encode())
-            return 1
+            fileToCat = open(filename, "r")
+            contents = fileToCat.read()
+            is_text = True
+        except:
+            pass
+
+        if contents is None:
+            try:
+                with open(path, "rb") as fileToCat:
+                    contents = fileToCat.read()
+            except IOError as error:
+                error.filename = filename
+                stderr.write(str(error).encode())
+                return 1
+
         if show_nonprinting:
             contents = convertToCaretAndMNotation(contents)
+        elif is_text:
+            contents = contents.encode()
         stdout.write(contents)
     return 0
 

--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -1,5 +1,6 @@
 import getopt
 import os
+import platform
 import sys
 from io import StringIO
 
@@ -70,12 +71,13 @@ def run(argv, stdin, stdout, stderr, cwd):
 
         contents = None
         is_text = False
-        try:
-            with open(path, "r") as fileToCat:
-                contents = fileToCat.read()
-                is_text = True
-        except:
-            pass
+        if platform.system() == "OS/390":
+            try:
+                with open(path, "r") as fileToCat:
+                    contents = fileToCat.read()
+                    is_text = True
+            except:
+                pass
 
         if contents is None:
             try:

--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -71,9 +71,9 @@ def run(argv, stdin, stdout, stderr, cwd):
         contents = None
         is_text = False
         try:
-            fileToCat = open(filename, "r")
-            contents = fileToCat.read()
-            is_text = True
+            with open(path, "r") as fileToCat:
+                contents = fileToCat.read()
+                is_text = True
         except:
             pass
 


### PR DESCRIPTION
Support for auto conversion of text files was added to cat.py in https://github.com/llvm/llvm-project/pull/90128.  That was accidently removed in https://github.com/llvm/llvm-project/pull/204711 while removing some old win32 code.  This adds the z/OS support back in.