### PR TITLE
[lldb-dap] Simplify DAPSessionManager GetInstance

### DIFF
--- a/lldb/tools/lldb-dap/DAPSessionManager.cpp
+++ b/lldb/tools/lldb-dap/DAPSessionManager.cpp
@@ -33,14 +33,8 @@ ManagedEventThread::~ManagedEventThread() {
 }
 
 DAPSessionManager &DAPSessionManager::GetInstance() {
-  static std::once_flag initialized;
-  static DAPSessionManager *instance =
-      nullptr; // NOTE: intentional leak to avoid issues with C++ destructor
-               // chain
-
-  std::call_once(initialized, []() { instance = new DAPSessionManager(); });
-
-  return *instance;
+  static DAPSessionManager instance;
+  return instance;
 }
 
 void DAPSessionManager::RegisterSession(lldb_private::MainLoop *loop,

--- a/lldb/tools/lldb-dap/DAPSessionManager.cpp
+++ b/lldb/tools/lldb-dap/DAPSessionManager.cpp
@@ -33,8 +33,10 @@ ManagedEventThread::~ManagedEventThread() {
 }
 
 DAPSessionManager &DAPSessionManager::GetInstance() {
-  static DAPSessionManager instance;
-  return instance;
+  // NOTE: Intentionally leaked. Detached client threads may still notify
+  // m_sessions_condition at exit, so it has to outlive them.
+  static auto *instance = new DAPSessionManager();
+  return *instance;
 }
 
 void DAPSessionManager::RegisterSession(lldb_private::MainLoop *loop,

--- a/lldb/tools/lldb-dap/DAPSessionManager.cpp
+++ b/lldb/tools/lldb-dap/DAPSessionManager.cpp
@@ -33,7 +33,7 @@ ManagedEventThread::~ManagedEventThread() {
 }
 
 DAPSessionManager &DAPSessionManager::GetInstance() {
-  // NOTE: Intentionally leaked. Detached client threads may still notify
+  // NOTE: Intentional leak. Detached client threads may still notify
   // m_sessions_condition at exit, so it has to outlive them.
   static auto *instance = new DAPSessionManager();
   return *instance;


### PR DESCRIPTION
We don't need the `std::call_once` as this guaranteed to be [thread safe and initialised once](https://en.cppreference.com/cpp/language/storage_duration#Static_block_variables) since c++11.
I also don't see any issue with the destructor chain since the class doesn't own any data that can be affected.