### PR TITLE
[libc++] Switch PR benchmark job to llvm-premerge-libcxx-runners

### DIFF
--- a/.github/workflows/libcxx-pr-benchmark.yml
+++ b/.github/workflows/libcxx-pr-benchmark.yml
@@ -101,7 +101,7 @@ jobs:
             install-python: false
             install-macos-dependencies: true
           - platform: Linux x86_64
-            runner: llvm-premerge-libcxx-next-runners
+            runner: llvm-premerge-libcxx-runners
             cc: clang-22
             cxx: clang++-22
             install-python: true


### PR DESCRIPTION
Like #208928 but for the PR benchmarking job.