### PR TITLE
[CIR][RFC] Implement strict floating-point handling in CIR

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -11,6 +11,7 @@
 
 #include "clang/AST/CharUnits.h"
 #include "clang/Basic/AddressSpaces.h"
+#include "clang/Basic/LangOptions.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
@@ -67,6 +68,12 @@ public:
   CIRBaseBuilderTy(mlir::MLIRContext &mlirContext)
       : mlir::OpBuilder(&mlirContext) {}
   CIRBaseBuilderTy(mlir::OpBuilder &builder) : mlir::OpBuilder(builder) {}
+
+  bool isFPConstrained = false;
+  clang::LangOptions::FPExceptionModeKind defaultConstrainedExcept =
+      clang::LangOptions::FPE_Ignore;
+  llvm::RoundingMode defaultConstrainedRounding =
+      llvm::RoundingMode::NearestTiesToEven;
 
   mlir::Value getConstAPInt(mlir::Location loc, mlir::Type typ,
                             const llvm::APInt &val) {
@@ -202,6 +209,97 @@ public:
 
   cir::BoolAttr getTrueAttr() { return getCIRBoolAttr(true); }
   cir::BoolAttr getFalseAttr() { return getCIRBoolAttr(false); }
+
+
+  //
+  // Floating point specific helpers
+  // -------------------------------
+  //
+
+  /// Enable/Disable use of constrained floating point math. When enabled the
+  /// CreateF<op>() calls instead create constrained floating point intrinsic
+  /// calls. Fast math flags are unaffected by this setting.
+  void setIsFPConstrained(bool isCon) { isFPConstrained = isCon; }
+
+  /// Query for the use of constrained floating point math
+  bool getIsFPConstrained() const { return isFPConstrained; }
+
+  /// Set the exception handling to be used with constrained floating point
+  void setDefaultConstrainedExcept(
+      clang::LangOptions::FPExceptionModeKind newExcept) {
+    defaultConstrainedExcept = newExcept;
+  }
+
+  /// Get the exception handling used with constrained floating point
+  clang::LangOptions::FPExceptionModeKind getDefaultConstrainedExcept() const {
+    return defaultConstrainedExcept;
+  }
+
+  /// Set the rounding mode handling to be used with constrained floating point
+  void setDefaultConstrainedRounding(llvm::RoundingMode newRounding) {
+    defaultConstrainedRounding = newRounding;
+  }
+
+  /// Get the rounding mode handling used with constrained floating point
+  llvm::RoundingMode getDefaultConstrainedRounding() const {
+    return defaultConstrainedRounding;
+  }
+
+  /// Build the `#cir.fenv` attribute describing the constrained floating-point
+  /// environment currently in effect. This is attached to floating-point
+  /// operations that support it to capture the rounding and exception
+  /// behavior. Returns a null attribute when constrained floating-point is not
+  /// enabled, in which case no attribute should be attached.
+  cir::FenvAttr getConstrainedFPAttr() {
+    if (!isFPConstrained)
+      return {};
+
+    cir::FPDynamicRoundingMode roundingMode;
+    switch (defaultConstrainedRounding) {
+    case llvm::RoundingMode::NearestTiesToEven:
+      roundingMode = cir::FPDynamicRoundingMode::ToNearest;
+      break;
+    case llvm::RoundingMode::TowardNegative:
+      roundingMode = cir::FPDynamicRoundingMode::Downward;
+      break;
+    case llvm::RoundingMode::TowardPositive:
+      roundingMode = cir::FPDynamicRoundingMode::Upward;
+      break;
+    case llvm::RoundingMode::TowardZero:
+      roundingMode = cir::FPDynamicRoundingMode::UpwardZero;
+      break;
+    case llvm::RoundingMode::NearestTiesToAway:
+      roundingMode = cir::FPDynamicRoundingMode::ToNearestAway;
+      break;
+    case llvm::RoundingMode::Dynamic:
+      roundingMode = cir::FPDynamicRoundingMode::Unknown;
+      break;
+    default:
+      llvm_unreachable("unexpected constrained rounding mode");
+    }
+
+    cir::FPExceptionMode exceptMode;
+    bool strictExcept;
+    switch (defaultConstrainedExcept) {
+    case clang::LangOptions::FPE_Ignore:
+      exceptMode = cir::FPExceptionMode::Masked;
+      strictExcept = false;
+      break;
+    case clang::LangOptions::FPE_MayTrap:
+      exceptMode = cir::FPExceptionMode::Unknown;
+      strictExcept = false;
+      break;
+    case clang::LangOptions::FPE_Strict:
+      exceptMode = cir::FPExceptionMode::Unknown;
+      strictExcept = true;
+      break;
+    default:
+      llvm_unreachable("unexpected constrained exception mode");
+    }
+
+    return cir::FenvAttr::get(getContext(), roundingMode, exceptMode,
+                              mlir::BoolAttr::get(getContext(), strictExcept));
+  }
 
   mlir::Value createComplexCreate(mlir::Location loc, mlir::Value real,
                                   mlir::Value imag) {
@@ -719,45 +817,41 @@ public:
 
   mlir::Value createFAdd(mlir::Location loc, mlir::Value lhs, mlir::Value rhs) {
     assert(!cir::MissingFeatures::metaDataNode());
-    assert(!cir::MissingFeatures::fpConstraints());
     assert(!cir::MissingFeatures::fastMathFlags());
-    return cir::FAddOp::create(*this, loc, lhs, rhs);
+    return cir::FAddOp::create(*this, loc, lhs, rhs, getConstrainedFPAttr());
   }
 
   mlir::Value createFSub(mlir::Location loc, mlir::Value lhs, mlir::Value rhs) {
     assert(!cir::MissingFeatures::metaDataNode());
-    assert(!cir::MissingFeatures::fpConstraints());
     assert(!cir::MissingFeatures::fastMathFlags());
-    return cir::FSubOp::create(*this, loc, lhs, rhs);
+    return cir::FSubOp::create(*this, loc, lhs, rhs, getConstrainedFPAttr());
   }
 
   mlir::Value createFMul(mlir::Location loc, mlir::Value lhs, mlir::Value rhs) {
     assert(!cir::MissingFeatures::metaDataNode());
-    assert(!cir::MissingFeatures::fpConstraints());
     assert(!cir::MissingFeatures::fastMathFlags());
-    return cir::FMulOp::create(*this, loc, lhs, rhs);
+    return cir::FMulOp::create(*this, loc, lhs, rhs, getConstrainedFPAttr());
   }
 
   mlir::Value createFDiv(mlir::Location loc, mlir::Value lhs, mlir::Value rhs) {
     assert(!cir::MissingFeatures::metaDataNode());
-    assert(!cir::MissingFeatures::fpConstraints());
     assert(!cir::MissingFeatures::fastMathFlags());
-    return cir::FDivOp::create(*this, loc, lhs, rhs);
+    return cir::FDivOp::create(*this, loc, lhs, rhs, getConstrainedFPAttr());
   }
 
   mlir::Value createFRem(mlir::Location loc, mlir::Value lhs, mlir::Value rhs) {
     assert(!cir::MissingFeatures::metaDataNode());
-    assert(!cir::MissingFeatures::fpConstraints());
     assert(!cir::MissingFeatures::fastMathFlags());
-    return cir::FRemOp::create(*this, loc, lhs, rhs);
+    return cir::FRemOp::create(*this, loc, lhs, rhs, getConstrainedFPAttr());
   }
 
   mlir::Value createFNeg(mlir::Location loc, mlir::Value operand) {
     assert(cir::isFPOrVectorOfFPType(operand.getType()) &&
            "expected floating-point or vector-of-float type");
     assert(!cir::MissingFeatures::metaDataNode());
-    assert(!cir::MissingFeatures::fpConstraints());
     assert(!cir::MissingFeatures::fastMathFlags());
+    // fneg does not raise FP exceptions or depend on the rounding mode, so it
+    // never carries an fenv attribute.
     return cir::FNegOp::create(*this, loc, operand);
   }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -759,6 +759,78 @@ def CIR_CmpThreeWayInfoAttr : CIR_Attr<"CmpThreeWayInfo", "cmp3way_info"> {
 }
 
 //===----------------------------------------------------------------------===//
+// FenvAttr
+//===----------------------------------------------------------------------===//
+
+def CIR_FPDynamicRoundingMode : CIR_I32EnumAttr<
+    "FPDynamicRoundingMode", "floating-point dynamic rounding mode", [
+  I32EnumAttrCase<"ToNearest", 0, "tonearest">,
+  I32EnumAttrCase<"Downward", 1, "downward">,
+  I32EnumAttrCase<"Upward", 2, "upward">,
+  I32EnumAttrCase<"UpwardZero", 3, "upwardzero">,
+  I32EnumAttrCase<"ToNearestAway", 4, "tonearestaway">,
+  I32EnumAttrCase<"Unknown", 7, "unknown">
+]> {
+  let description = [{
+    The known dynamic rounding mode at the point the instruction is executed.
+    If the actual dynamic rounding mode differs from this value, the behavior
+    is undefined.
+  }];
+  let genSpecializedAttr = 0;
+}
+
+def CIR_FPExceptionMode : CIR_I32EnumAttr<
+    "FPExceptionMode", "floating-point exception mode", [
+  I32EnumAttrCase<"Unknown", 0, "unknown">,
+  I32EnumAttrCase<"Masked", 1, "masked">,
+  I32EnumAttrCase<"Unmasked", 2, "unmasked">
+]> {
+  let description = [{
+    The known floating-point exception mode at the point the instruction is
+    executed. If the actual exception mode differs from this value, the
+    behavior is undefined.
+  }];
+  let genSpecializedAttr = 0;
+}
+
+def CIR_FenvAttr : CIR_Attr<"Fenv", "fenv"> {
+  let summary = "Describes floating-point environment constraints";
+  let description = [{
+    The `#cir.fenv` attribute describes constraints on the floating-point
+    handling of a floating-point operation. It is attached to floating-point
+    operations to capture rounding and exception behavior. All of its
+    parameters are optional.
+
+    - `dynamic_rounding_mode`: the known dynamic rounding mode at the point the
+      instruction is executed. Otherwise the behavior is undefined.
+    - `except_mode`: the known exception mode at the point the instruction is
+      executed. Otherwise the behavior is undefined.
+    - `strict_except`: if `false`, any case that would produce an FP exception
+      produces it non-deterministically instead (i.e. it may or may not occur).
+      This means the FP status is written non-deterministically, and, if
+      exceptions are unmasked, the instruction traps non-deterministically.
+
+    Example:
+    ```
+    #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown,
+              strict_except = true>
+    ```
+  }];
+
+  let parameters = (ins
+    OptionalParameter<
+        "std::optional<cir::FPDynamicRoundingMode>">:$dynamic_rounding_mode,
+    OptionalParameter<"std::optional<cir::FPExceptionMode>">:$except_mode,
+    OptionalParameter<"mlir::BoolAttr">:$strict_except);
+
+  let assemblyFormat = [{
+    `<` struct($dynamic_rounding_mode, $except_mode, $strict_except) `>`
+  }];
+
+  let canHaveIllegalCXXABIType = 0;
+}
+
+//===----------------------------------------------------------------------===//
 // GlobalViewAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -44,6 +44,7 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getReturnsTwiceAttrName() { return "returns_twice"; }
     static llvm::StringRef getColdAttrName() { return "cold"; }
     static llvm::StringRef getHotAttrName() { return "hot"; }
+    static llvm::StringRef getStrictFPAttrName() { return "strictfp"; }
     static llvm::StringRef getNoDuplicatesAttrName() { return "noduplicate"; }
     static llvm::StringRef getConvergentAttrName() { return "convergent"; }
     static llvm::StringRef getNoUnwindAttrName() { return "nounwind"; }

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -3165,6 +3165,11 @@ def CIR_GlobalOp : CIR_Op<"global", [
     function-local static variable that requires guarded initialization
     (e.g., C++ static local variables with non-constant initializers).
     It contains the mangled name of the guard variable.
+
+    The `strictfp` attribute indicates that the dynamic initialization emitted
+    into the `ctorRegion`/`dtorRegion` runs under a constrained floating-point
+    environment. LoweringPrepare forwards it to the `strictfp` attribute of the
+    generated `__cxx_global_var_init` function.
   }];
 
   // Note that both sym_name and sym_visibility are tied to Symbol trait.
@@ -3190,7 +3195,8 @@ def CIR_GlobalOp : CIR_Op<"global", [
                        OptionalAttr<ASTVarDeclInterface>:$ast,
                        OptionalAttr<StrAttr>:$section,
                        OptionalAttr<CIR_AnnotationArrayAttr>:$annotations,
-                       OptionalAttr<FlatSymbolRefAttr>:$aliasee
+                       OptionalAttr<FlatSymbolRefAttr>:$aliasee,
+                       UnitAttr:$strictfp
                        );
 
   let regions = (region AnyRegion:$ctorRegion,

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -73,8 +73,25 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 //
 // If you want fully customized LLVM IR lowering logic, simply exclude the
 // `llvmOp` field from your CIR operation definition.
+//
+// The `constrainedLLVMIntrinsic` field enables a specialized variant of this
+// generated lowering for floating-point operations that carry an optional
+// `fenv` attribute. When it is set (to the mnemonic of an experimental
+// constrained floating-point intrinsic, e.g. "fadd"), the generated pattern
+// lowers the operation to a plain `llvmOp` when it has no `fenv` attribute and
+// to a call to the corresponding constrained intrinsic when it does. Setting
+// `constrainedLLVMIntrinsic` requires `llvmOp` to be set as well.
+//
+// `constrainedLLVMIntrinsicHasRoundingMode` indicates whether the constrained
+// intrinsic takes a rounding-mode metadata argument in addition to the
+// exception-behavior metadata argument. Arithmetic and transcendental
+// intrinsics (e.g. constrained.fadd, constrained.sqrt) take a rounding mode,
+// while intrinsics whose rounding is implied by the operation (e.g.
+// constrained.ceil, constrained.maxnum) take only the exception behavior.
 class LLVMLoweringInfo {
   string llvmOp = "";
+  string constrainedLLVMIntrinsic = "";
+  bit constrainedLLVMIntrinsicHasRoundingMode = true;
 }
 
 class LoweringBuilders<dag p> {
@@ -2684,11 +2701,17 @@ def CIR_RemOp : CIR_BinaryOp<"rem", CIR_AnyIntOrVecOfIntType> {
 // and result must all be the same floating-point scalar or vector type.
 //
 // The optional `fenv` attribute describes constraints on the floating-point
-// handling of the operation.
+// handling of the operation. The LLVM lowering pattern is generated from the
+// `llvmOp` and `constrainedLLVMIntrinsic` fields: an operation without an
+// `fenv` attribute is lowered to the plain `llvmOp`, while an operation with an
+// `fenv` attribute is lowered to a call to the matching constrained
+// floating-point intrinsic (whose mnemonic matches this operation's mnemonic).
 class CIR_FPBinaryOp<string mnemonic, list<Trait> traits = []>
     : CIR_BinaryOp<mnemonic, CIR_AnyFloatOrVecOfFloatType,
                    !listconcat([Pure], traits)> {
   let arguments = !con(commonArgs, (ins OptionalAttr<CIR_FenvAttr>:$fenv));
+
+  let constrainedLLVMIntrinsic = mnemonic;
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$lhs, "mlir::Value":$rhs), [{
@@ -6834,6 +6857,14 @@ def CIR_PtrDiffOp : CIR_Op<"ptr_diff", [Pure, SameTypeOperands]> {
 // Floating Point Ops
 //===----------------------------------------------------------------------===//
 
+// The optional `fenv` attribute describes constraints on the floating-point
+// handling of the operation. When it is present, the operation is lowered to a
+// call to the constrained floating-point intrinsic whose mnemonic matches this
+// operation's mnemonic; otherwise it is lowered to the plain `llvmOp`. Rounding
+// mode is passed to the intrinsic by default; operations whose rounding is
+// implied (e.g. ceil, floor, trunc) set
+// `constrainedLLVMIntrinsicHasRoundingMode` to 0, and operations with no
+// constrained variant (e.g. fabs) clear `constrainedLLVMIntrinsic`.
 class CIR_UnaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
     : CIR_Op<mnemonic, [Pure, SameOperandsAndResultType]>
 {
@@ -6850,6 +6881,7 @@ class CIR_UnaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
   ];
 
   let llvmOp = llvmOpName;
+  let constrainedLLVMIntrinsic = mnemonic;
 }
 
 def CIR_SqrtOp : CIR_UnaryFPToFPBuiltinOp<"sqrt", "SqrtOp"> {
@@ -6911,6 +6943,8 @@ def CIR_CeilOp : CIR_UnaryFPToFPBuiltinOp<"ceil", "FCeilOp"> {
 
     Floating-point exceptions are ignored, and it does not set `errno`.
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_CosOp : CIR_UnaryFPToFPBuiltinOp<"cos", "CosOp"> {
@@ -7003,6 +7037,8 @@ def CIR_RoundOp : CIR_UnaryFPToFPBuiltinOp<"round", "RoundOp"> {
 
     Floating-point exceptions are ignored, and it does not set `errno`.
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_RoundEvenOp : CIR_UnaryFPToFPBuiltinOp<"roundeven", "RoundEvenOp"> {
@@ -7013,6 +7049,8 @@ def CIR_RoundEvenOp : CIR_UnaryFPToFPBuiltinOp<"roundeven", "RoundEvenOp"> {
 
     Floating-point exceptions are ignored, and it does not set `errno`.
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_SinOp : CIR_UnaryFPToFPBuiltinOp<"sin", "SinOp"> {
@@ -7043,6 +7081,8 @@ def CIR_TruncOp : CIR_UnaryFPToFPBuiltinOp<"trunc", "FTruncOp"> {
 
     Floating-point exceptions are ignored, and it does not set `errno`.
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_FAbsOp : CIR_UnaryFPToFPBuiltinOp<"fabs", "FAbsOp"> {
@@ -7053,6 +7093,11 @@ def CIR_FAbsOp : CIR_UnaryFPToFPBuiltinOp<"fabs", "FAbsOp"> {
 
     Floating-point exceptions are ignored, and it does not set `errno`.
   }];
+
+  // fabs is exact and has no constrained floating-point intrinsic, so it is
+  // always lowered to the plain llvm.fabs, even under a floating-point
+  // environment.
+  let constrainedLLVMIntrinsic = "";
 }
 
 def CIR_AbsOp : CIR_Op<"abs", [Pure, SameOperandsAndResultType]> {
@@ -7099,6 +7144,8 @@ def CIR_FloorOp : CIR_UnaryFPToFPBuiltinOp<"floor", "FFloorOp"> {
     %y = cir.floor %x : !cir.double
     ```
   }];
+
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 class CIR_UnaryFPToIntBuiltinOp<string mnemonic, string llvmOpName>
@@ -7186,6 +7233,10 @@ def CIR_CopysignOp : CIR_BinaryFPToFPBuiltinOp<"copysign", "CopySignOp"> {
     `cir.copysign` returns a value with the magnitude of the first operand
     and the sign of the second operand.
   }];
+
+  // copysign is exact and has no constrained floating-point intrinsic, so it is
+  // always lowered to the plain llvm.copysign, even under a floating-point
+  // environment.
 }
 
 def CIR_FMaxNumOp : CIR_BinaryFPToFPBuiltinOp<"fmaxnum", "MaxNumOp"> {
@@ -7204,6 +7255,9 @@ def CIR_FMaximumOp : CIR_BinaryFPToFPBuiltinOp<"fmaximum", "MaximumOp"> {
     `cir.fmaximum` returns the larger of its two operands according to
     IEEE 754-2019 semantics. If either operand is NaN, NaN is returned.
   }];
+
+  let constrainedLLVMIntrinsic = "maximum";
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_FMinNumOp : CIR_BinaryFPToFPBuiltinOp<"fminnum", "MinNumOp"> {
@@ -7222,6 +7276,9 @@ def CIR_FMinimumOp : CIR_BinaryFPToFPBuiltinOp<"fminimum", "MinimumOp"> {
     `cir.fminimum` returns the smaller of its two operands according to
     IEEE 754-2019 semantics. If either operand is NaN, NaN is returned.
   }];
+
+  let constrainedLLVMIntrinsic = "minimum";
+  let constrainedLLVMIntrinsicHasRoundingMode = 0;
 }
 
 def CIR_FModOp : CIR_BinaryFPToFPBuiltinOp<"fmod", "FRemOp"> {
@@ -7230,6 +7287,9 @@ def CIR_FModOp : CIR_BinaryFPToFPBuiltinOp<"fmod", "FRemOp"> {
     `cir.fmod` computes the floating-point remainder of dividing the first
     operand by the second operand.
   }];
+
+  // fmod maps to the constrained frem intrinsic.
+  let constrainedLLVMIntrinsic = "frem";
 }
 
 def CIR_PowOp : CIR_BinaryFPToFPBuiltinOp<"pow", "PowOp"> {
@@ -7238,6 +7298,8 @@ def CIR_PowOp : CIR_BinaryFPToFPBuiltinOp<"pow", "PowOp"> {
     `cir.pow` computes the first operand raised to the power of the second
     operand.
   }];
+
+  let constrainedLLVMIntrinsic = "pow";
 }
 
 def CIR_ATan2Op : CIR_BinaryFPToFPBuiltinOp<"atan2", "ATan2Op"> {
@@ -7246,6 +7308,8 @@ def CIR_ATan2Op : CIR_BinaryFPToFPBuiltinOp<"atan2", "ATan2Op"> {
     `cir.atan2` computes the arc tangent of the first operand divided by the
     second operand, using the signs of both to determine the quadrant.
   }];
+
+  let constrainedLLVMIntrinsic = "atan2";
 }
 
 def CIR_FrexpOp : CIR_Op<"frexp", [Pure]> {

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1882,7 +1882,9 @@ class CIR_UnaryOp<string mnemonic, Type type, list<Trait> traits = []>
         DeclareOpInterfaceMethods<CIR_UnaryOpInterface>
       ], traits)>
 {
-  let arguments = (ins type:$input);
+  dag commonArgs = (ins type:$input);
+
+  let arguments = commonArgs;
 
   let results = (outs type:$result);
 
@@ -2019,7 +2021,18 @@ def CIR_FNegOp : CIR_UnaryOp<"fneg", CIR_AnyFloatOrVecOfFloatType> {
     %3 = cir.fneg %2 : !cir.double
     %5 = cir.fneg %4 : !cir.vector<4 x !cir.float>
     ```
+
+    The optional `fenv` attribute describes constraints on the floating-point
+    handling of the operation.
   }];
+
+  let arguments = !con(commonArgs, (ins OptionalAttr<CIR_FenvAttr>:$fenv));
+
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$input), [{
+      build($_builder, $_state, input, cir::FenvAttr{});
+    }]>
+  ];
 
   let hasFolder = 1;
 
@@ -2487,10 +2500,12 @@ class CIR_BinaryOp<string mnemonic, Type type, list<Trait> traits = []>
         DeclareOpInterfaceMethods<CIR_BinaryOpInterface>
       ], traits)>
 {
-  let arguments = (ins
+  dag commonArgs = (ins
     type:$lhs,
     type:$rhs
   );
+
+  let arguments = commonArgs;
 
   let results = (outs type:$result);
 
@@ -2667,9 +2682,20 @@ def CIR_RemOp : CIR_BinaryOp<"rem", CIR_AnyIntOrVecOfIntType> {
 
 // Base class for floating-point binary arithmetic operations. The lhs, rhs,
 // and result must all be the same floating-point scalar or vector type.
+//
+// The optional `fenv` attribute describes constraints on the floating-point
+// handling of the operation.
 class CIR_FPBinaryOp<string mnemonic, list<Trait> traits = []>
     : CIR_BinaryOp<mnemonic, CIR_AnyFloatOrVecOfFloatType,
-                   !listconcat([Pure], traits)>;
+                   !listconcat([Pure], traits)> {
+  let arguments = !con(commonArgs, (ins OptionalAttr<CIR_FenvAttr>:$fenv));
+
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$lhs, "mlir::Value":$rhs), [{
+      build($_builder, $_state, lhs, rhs, cir::FenvAttr{});
+    }]>
+  ];
+}
 
 //===----------------------------------------------------------------------===//
 // FAddOp
@@ -6811,10 +6837,17 @@ def CIR_PtrDiffOp : CIR_Op<"ptr_diff", [Pure, SameTypeOperands]> {
 class CIR_UnaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
     : CIR_Op<mnemonic, [Pure, SameOperandsAndResultType]>
 {
-  let arguments = (ins CIR_AnyFloatOrVecOfFloatType:$src);
+  let arguments = (ins CIR_AnyFloatOrVecOfFloatType:$src,
+                       OptionalAttr<CIR_FenvAttr>:$fenv);
   let results = (outs CIR_AnyFloatOrVecOfFloatType:$result);
 
   let assemblyFormat = "$src `:` type($src) attr-dict";
+
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$src), [{
+      build($_builder, $_state, src, cir::FenvAttr{});
+    }]>
+  ];
 
   let llvmOp = llvmOpName;
 }
@@ -7127,7 +7160,8 @@ class CIR_BinaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
 
   let arguments = (ins
     CIR_AnyFloatOrVecOfFloatType:$lhs,
-    CIR_AnyFloatOrVecOfFloatType:$rhs
+    CIR_AnyFloatOrVecOfFloatType:$rhs,
+    OptionalAttr<CIR_FenvAttr>:$fenv
   );
 
   let results = (outs  CIR_AnyFloatOrVecOfFloatType:$result);
@@ -7135,6 +7169,13 @@ class CIR_BinaryFPToFPBuiltinOp<string mnemonic, string llvmOpName>
   let assemblyFormat = [{
     $lhs `,` $rhs `:` qualified(type($lhs)) attr-dict
   }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$result, "mlir::Value":$lhs,
+                   "mlir::Value":$rhs), [{
+      build($_builder, $_state, result, lhs, rhs, cir::FenvAttr{});
+    }]>
+  ];
 
   let llvmOp = llvmOpName;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -30,12 +30,6 @@ namespace clang::CIRGen {
 
 class CIRGenBuilderTy : public cir::CIRBaseBuilderTy {
   const CIRGenTypeCache &typeCache;
-  bool isFPConstrained = false;
-  LangOptions::FPExceptionModeKind defaultConstrainedExcept =
-      LangOptions::FPE_Ignore;
-  llvm::RoundingMode defaultConstrainedRounding =
-      llvm::RoundingMode::NearestTiesToEven;
-  bool defaultConstrainedStrictExcept = false;
 
   llvm::StringMap<unsigned> recordNames;
   llvm::StringMap<unsigned> globalsVersioning;
@@ -122,44 +116,6 @@ public:
 
     return baseName + "." + std::to_string(recordNames[baseName]++);
   }
-
-  //
-  // Floating point specific helpers
-  // -------------------------------
-  //
-
-  /// Enable/Disable use of constrained floating point math. When enabled the
-  /// CreateF<op>() calls instead create constrained floating point intrinsic
-  /// calls. Fast math flags are unaffected by this setting.
-  void setIsFPConstrained(bool isCon) { isFPConstrained = isCon; }
-
-  /// Query for the use of constrained floating point math
-  bool getIsFPConstrained() const { return isFPConstrained; }
-
-  /// Set the exception handling to be used with constrained floating point
-  void setDefaultConstrainedExcept(LangOptions::FPExceptionModeKind newExcept) {
-    defaultConstrainedExcept = newExcept;
-  }
-
-  /// Get the exception handling used with constrained floating point
-  LangOptions::FPExceptionModeKind getDefaultConstrainedExcept() const {
-    return defaultConstrainedExcept;
-  }
-
-  /// Set the rounding mode handling to be used with constrained floating point
-  void setDefaultConstrainedRounding(llvm::RoundingMode newRounding) {
-    defaultConstrainedRounding = newRounding;
-  }
-
-  /// Get the rounding mode handling used with constrained floating point
-  llvm::RoundingMode getDefaultConstrainedRounding() const {
-    return defaultConstrainedRounding;
-  }
-
-  void initializeDefaultFenv(llvm::RoundingMode rm, LangOptions::FPExceptionModeKind eb) {
-    // TODO(cir): implement this
-  }
-
 
   cir::LongDoubleType getLongDoubleTy(const llvm::fltSemantics &format) const {
     if (&format == &llvm::APFloat::IEEEdouble())

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -31,8 +31,11 @@ namespace clang::CIRGen {
 class CIRGenBuilderTy : public cir::CIRBaseBuilderTy {
   const CIRGenTypeCache &typeCache;
   bool isFPConstrained = false;
-  llvm::fp::ExceptionBehavior defaultConstrainedExcept = llvm::fp::ebStrict;
-  llvm::RoundingMode defaultConstrainedRounding = llvm::RoundingMode::Dynamic;
+  LangOptions::FPExceptionModeKind defaultConstrainedExcept =
+      LangOptions::FPE_Ignore;
+  llvm::RoundingMode defaultConstrainedRounding =
+      llvm::RoundingMode::NearestTiesToEven;
+  bool defaultConstrainedStrictExcept = false;
 
   llvm::StringMap<unsigned> recordNames;
   llvm::StringMap<unsigned> globalsVersioning;
@@ -134,21 +137,17 @@ public:
   bool getIsFPConstrained() const { return isFPConstrained; }
 
   /// Set the exception handling to be used with constrained floating point
-  void setDefaultConstrainedExcept(llvm::fp::ExceptionBehavior newExcept) {
-    assert(llvm::convertExceptionBehaviorToStr(newExcept) &&
-           "Garbage strict exception behavior!");
+  void setDefaultConstrainedExcept(LangOptions::FPExceptionModeKind newExcept) {
     defaultConstrainedExcept = newExcept;
   }
 
   /// Get the exception handling used with constrained floating point
-  llvm::fp::ExceptionBehavior getDefaultConstrainedExcept() const {
+  LangOptions::FPExceptionModeKind getDefaultConstrainedExcept() const {
     return defaultConstrainedExcept;
   }
 
   /// Set the rounding mode handling to be used with constrained floating point
   void setDefaultConstrainedRounding(llvm::RoundingMode newRounding) {
-    assert(llvm::convertRoundingModeToStr(newRounding) &&
-           "Garbage strict rounding mode!");
     defaultConstrainedRounding = newRounding;
   }
 
@@ -156,6 +155,11 @@ public:
   llvm::RoundingMode getDefaultConstrainedRounding() const {
     return defaultConstrainedRounding;
   }
+
+  void initializeDefaultFenv(llvm::RoundingMode rm, LangOptions::FPExceptionModeKind eb) {
+    // TODO(cir): implement this
+  }
+
 
   cir::LongDoubleType getLongDoubleTy(const llvm::fltSemantics &format) const {
     if (&format == &llvm::APFloat::IEEEdouble())

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -355,10 +355,9 @@ static RValue emitUnaryMaybeConstrainedFPBuiltin(CIRGenFunction &cgf,
   mlir::Value arg = cgf.emitScalarExpr(e.getArg(0));
 
   CIRGenFunction::CIRGenFPOptionsRAII FPOptsRAII(cgf, &e);
-  assert(!cir::MissingFeatures::fpConstraints());
 
-  auto call =
-      Operation::create(cgf.getBuilder(), arg.getLoc(), arg.getType(), arg);
+  auto call = Operation::create(cgf.getBuilder(), arg.getLoc(), arg.getType(),
+                                arg, cgf.getBuilder().getConstrainedFPAttr());
   return RValue::get(call->getResult(0));
 }
 
@@ -400,12 +399,13 @@ static mlir::Value emitBinaryMaybeConstrainedFPBuiltin(CIRGenFunction &cgf,
   mlir::Value arg0 = cgf.emitScalarExpr(e.getArg(0));
   mlir::Value arg1 = cgf.emitScalarExpr(e.getArg(1));
 
+  CIRGenFunction::CIRGenFPOptionsRAII FPOptsRAII(cgf, &e);
+
   mlir::Location loc = cgf.getLoc(e.getExprLoc());
   mlir::Type ty = cgf.convertType(e.getType());
 
-  assert(!cir::MissingFeatures::fpConstraints());
-
-  auto call = Op::create(cgf.getBuilder(), loc, ty, arg0, arg1);
+  auto call = Op::create(cgf.getBuilder(), loc, ty, arg0, arg1,
+                         cgf.getBuilder().getConstrainedFPAttr());
   return call->getResult(0);
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -352,6 +352,29 @@ void CIRGenModule::emitCXXGlobalVarDeclInit(const VarDecl *varDecl,
   CIRGenFunction::SourceLocRAIIObject fnLoc{cgf,
                                             getLoc(varDecl->getLocation())};
 
+  // Set up the constrained floating-point environment for the dynamic
+  // initializer, mirroring the handling in CIRGenFunction::startFunction for
+  // functions that have no FunctionDecl. Classic codegen emits the dynamic
+  // initializer into a __cxx_global_var_init function whose StartFunction call
+  // enables constrained floating-point (and adds the strictfp attribute) when
+  // the default rounding or exception mode is non-standard. Here the
+  // initializer is emitted into the global's ctor region, which LoweringPrepare
+  // later moves into that function, so we enable constrained FP on the builder
+  // while emitting the initializer (so its floating-point operations carry a
+  // #cir.fenv attribute) and record the strictfp requirement on the global for
+  // LoweringPrepare to forward to the generated function. The CIRGenFunction's
+  // ConstrainedFPRAII restores the builder state when it is destroyed.
+  llvm::RoundingMode rm = getLangOpts().getDefaultRoundingMode();
+  LangOptions::FPExceptionModeKind eb = getLangOpts().getDefaultExceptionMode();
+  builder.setDefaultConstrainedRounding(rm);
+  builder.setDefaultConstrainedExcept(eb);
+  builder.setIsFPConstrained(false);
+  if (eb != LangOptions::FPE_Ignore ||
+      rm != llvm::RoundingMode::NearestTiesToEven) {
+    builder.setIsFPConstrained(true);
+    addr.setStrictfp(true);
+  }
+
   emitCXXSpecialVarDeclInit(varDecl, addr, performInit, addr.getCtorRegion(),
                             addr.getDtorRegion());
 }

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1059,8 +1059,7 @@ public:
       result.compType = vecType->getElementType();
     result.opcode = e->getOpcode();
     result.loc = e->getSourceRange();
-    // TODO(cir): Result.FPFeatures
-    CIRGenFunction::CIRGenFPOptionsRAII FPOptsRAII(cgf, e);
+    result.fpFeatures = e->getFPFeaturesInEffect(cgf.getLangOpts());
     result.e = e;
     return result;
   }

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -30,7 +30,8 @@ namespace clang::CIRGen {
 
 CIRGenFunction::CIRGenFunction(CIRGenModule &cgm, CIRGenBuilderTy &builder,
                                bool suppressNewContext)
-    : CIRGenTypeCache(cgm), cgm{cgm}, builder(builder) {
+    : CIRGenTypeCache(cgm), cgm{cgm}, builder(builder),
+      curFPFeatures(cgm.getLangOpts()) {
   ehStack.setCGF(this);
 }
 
@@ -494,6 +495,7 @@ void CIRGenFunction::startFunction(GlobalDecl gd, QualType returnType,
   LangOptions::FPExceptionModeKind eb = getLangOpts().getDefaultExceptionMode();
   builder.setDefaultConstrainedRounding(rm);
   builder.setDefaultConstrainedExcept(eb);
+  builder.setIsFPConstrained(false);
   if ((fd && (fd->UsesFPIntrin() || fd->hasAttr<StrictFPAttr>())) ||
       (!fd && (eb != LangOptions::FPExceptionModeKind::FPE_Ignore ||
                rm != llvm::RoundingMode::NearestTiesToEven))) {
@@ -773,10 +775,6 @@ cir::FuncOp CIRGenFunction::generateCode(clang::GlobalDecl gd, cir::FuncOp fn,
 
     // Emit the standard function prologue.
     startFunction(gd, retTy, fn, funcType, args, loc, bodyRange.getBegin());
-    if (funcDecl->UsesFPIntrin() || funcDecl->hasAttr<StrictFPAttr>()) {
-      cgm.errorNYI(loc, "STDC FENV_ACCESS");
-      return fn;
-    }
 
     // Save parameters for coroutine function.
     if (body && isa_and_nonnull<CoroutineBodyStmt>(body))
@@ -1424,10 +1422,12 @@ void CIRGenFunction::CIRGenFPOptionsRAII::ConstructorHelper(
   // TODO(cir): create guard to restore fast math configurations.
   assert(!cir::MissingFeatures::fastMathGuard());
 
-  [[maybe_unused]] llvm::RoundingMode newRoundingMode =
-      fpFeatures.getRoundingMode();
-  [[maybe_unused]] LangOptions::FPExceptionModeKind newExceptionBehavior =
+  llvm::RoundingMode newRoundingMode = fpFeatures.getRoundingMode();
+  LangOptions::FPExceptionModeKind newExceptionBehavior =
       fpFeatures.getExceptionMode();
+
+  cgf.builder.setDefaultConstrainedRounding(newRoundingMode);
+  cgf.builder.setDefaultConstrainedExcept(newExceptionBehavior);
 
   // TODO(cir): override FP flags once FM configs are guarded.
   assert(!cir::MissingFeatures::fastMathFlags());

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -484,6 +484,23 @@ void CIRGenFunction::startFunction(GlobalDecl gd, QualType returnType,
   const auto *fd = dyn_cast_or_null<FunctionDecl>(d);
   curFuncDecl = (d ? d->getNonClosureContext() : nullptr);
 
+  // This is an artifact of the legacy handling of constrained floating-point
+  // modes. The rounding mode and exception behavior tracked in
+  // clang::LangOptions don't correspond directly to the representation we
+  // use in CIR, but the CIR settings can be derived from them. We track the
+  // default state using the legacy settings because it keeps the tracking in
+  // sync with classic codegen.
+  llvm::RoundingMode rm = getLangOpts().getDefaultRoundingMode();
+  LangOptions::FPExceptionModeKind eb = getLangOpts().getDefaultExceptionMode();
+  builder.setDefaultConstrainedRounding(rm);
+  builder.setDefaultConstrainedExcept(eb);
+  if ((fd && (fd->UsesFPIntrin() || fd->hasAttr<StrictFPAttr>())) ||
+      (!fd && (eb != LangOptions::FPExceptionModeKind::FPE_Ignore ||
+               rm != llvm::RoundingMode::NearestTiesToEven))) {
+    builder.setIsFPConstrained(true);
+    fn->setAttr(cir::CIRDialect::getStrictFPAttrName(),
+                mlir::UnitAttr::get(fn.getContext()));
+  }
   prologueCleanupDepth = ehStack.stable_begin();
 
   mlir::Block *entryBB = &fn.getBlocks().front();
@@ -998,23 +1015,6 @@ LValue CIRGenFunction::makeNaturalAlignAddrLValue(mlir::Value val,
   return makeAddrLValue(addr, ty, baseInfo);
 }
 
-// Map the LangOption for exception behavior into the corresponding enum in
-// the IR.
-static llvm::fp::ExceptionBehavior
-toConstrainedExceptMd(LangOptions::FPExceptionModeKind kind) {
-  switch (kind) {
-  case LangOptions::FPE_Ignore:
-    return llvm::fp::ebIgnore;
-  case LangOptions::FPE_MayTrap:
-    return llvm::fp::ebMayTrap;
-  case LangOptions::FPE_Strict:
-    return llvm::fp::ebStrict;
-  case LangOptions::FPE_Default:
-    llvm_unreachable("expected explicitly initialized exception behavior");
-  }
-  llvm_unreachable("unsupported FP exception behavior");
-}
-
 clang::QualType CIRGenFunction::buildFunctionArgList(clang::GlobalDecl gd,
                                                      FunctionArgList &args) {
   const auto *fd = cast<FunctionDecl>(gd.getDecl());
@@ -1424,13 +1424,10 @@ void CIRGenFunction::CIRGenFPOptionsRAII::ConstructorHelper(
   // TODO(cir): create guard to restore fast math configurations.
   assert(!cir::MissingFeatures::fastMathGuard());
 
-  [[maybe_unused]] llvm::RoundingMode newRoundingBehavior =
+  [[maybe_unused]] llvm::RoundingMode newRoundingMode =
       fpFeatures.getRoundingMode();
-  // TODO(cir): override rounding behaviour once FM configs are guarded.
-  [[maybe_unused]] llvm::fp::ExceptionBehavior newExceptionBehavior =
-      toConstrainedExceptMd(static_cast<LangOptions::FPExceptionModeKind>(
-          fpFeatures.getExceptionMode()));
-  // TODO(cir): override exception behaviour once FM configs are guarded.
+  [[maybe_unused]] LangOptions::FPExceptionModeKind newExceptionBehavior =
+      fpFeatures.getExceptionMode();
 
   // TODO(cir): override FP flags once FM configs are guarded.
   assert(!cir::MissingFeatures::fastMathFlags());
@@ -1438,8 +1435,8 @@ void CIRGenFunction::CIRGenFPOptionsRAII::ConstructorHelper(
   assert((cgf.curFuncDecl == nullptr || cgf.builder.getIsFPConstrained() ||
           isa<CXXConstructorDecl>(cgf.curFuncDecl) ||
           isa<CXXDestructorDecl>(cgf.curFuncDecl) ||
-          (newExceptionBehavior == llvm::fp::ebIgnore &&
-           newRoundingBehavior == llvm::RoundingMode::NearestTiesToEven)) &&
+          (newExceptionBehavior == LangOptions::FPE_Ignore &&
+           newRoundingMode == llvm::RoundingMode::NearestTiesToEven)) &&
          "FPConstrained should be enabled on entire function");
 
   // TODO(cir): mark CIR function with fast math attributes.

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -243,7 +243,7 @@ public:
     void ConstructorHelper(clang::FPOptions FPFeatures);
     CIRGenFunction &cgf;
     clang::FPOptions oldFPFeatures;
-    llvm::fp::ExceptionBehavior oldExcept;
+    LangOptions::FPExceptionModeKind oldExcept;
     llvm::RoundingMode oldRounding;
   };
   clang::FPOptions curFPFeatures;

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -63,6 +63,33 @@ private:
   /// is where the next operations will be introduced.
   CIRGenBuilderTy &builder;
 
+  /// Saves the builder's constrained floating-point configuration on
+  /// construction and restores it on destruction. The builder is shared
+  /// across all functions in the module, so its constrained-FP state must be
+  /// scoped to each function's emission.
+  ///
+  /// Note that the similarly named CIRGenFunction::CIRGenFPOptionsRAII
+  /// intentionally avoids restoring the "isFPConstrained" state because that
+  /// state is function-wide, but this object does restore the state so that
+  /// any CIRGenFunction instance created while we are in the process of
+  /// emitting another function cannot corrupt the prior functions state.
+  struct ConstrainedFPRAII {
+    CIRGenBuilderTy &builder;
+    bool savedIsFPConstrained;
+    LangOptions::FPExceptionModeKind savedExcept;
+    llvm::RoundingMode savedRounding;
+
+    explicit ConstrainedFPRAII(CIRGenBuilderTy &builder)
+        : builder(builder), savedIsFPConstrained(builder.getIsFPConstrained()),
+          savedExcept(builder.getDefaultConstrainedExcept()),
+          savedRounding(builder.getDefaultConstrainedRounding()) {}
+    ~ConstrainedFPRAII() {
+      builder.setIsFPConstrained(savedIsFPConstrained);
+      builder.setDefaultConstrainedExcept(savedExcept);
+      builder.setDefaultConstrainedRounding(savedRounding);
+    }
+  } constrainedFPState{builder};
+
 public:
   /// The GlobalDecl for the current function being compiled or the global
   /// variable currently being initialized.

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1172,6 +1172,17 @@ LoweringPreparePass::buildCXXGlobalVarDeclInitFunc(cir::GlobalOp op) {
   FuncOp f = buildRuntimeFunction(builder, fnName, op.getLoc(), fnType,
                                   cir::GlobalLinkageKind::InternalLinkage);
 
+  // Forward the constrained floating-point marker recorded on the global by
+  // CodeGen onto the generated initializer function, matching classic codegen
+  // which marks __cxx_global_var_init strictfp when the initializer runs under
+  // a constrained floating-point environment. The marker on the global is no
+  // longer meaningful once its regions have been moved out, so clear it.
+  if (op.getStrictfp()) {
+    f->setAttr(cir::CIRDialect::getStrictFPAttrName(),
+               mlir::UnitAttr::get(&getContext()));
+    op.setStrictfp(false);
+  }
+
   // Move over the initialization code of the ctor region.
   // The ctor region may have multiple blocks when exception handling
   // scaffolding creates extra blocks (e.g., unreachable/trap blocks).

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -402,6 +402,109 @@ static mlir::LLVM::CallIntrinsicOp replaceOpWithCallLLVMIntrinsicOp(
   return callIntrinOp;
 }
 
+// Return the LLVM metadata string that encodes the rounding mode described by
+// the given fenv attribute, in the form expected by the constrained
+// floating-point intrinsics (e.g. "round.tonearest"). An unknown dynamic
+// rounding mode maps to "round.dynamic". When no rounding mode is specified,
+// the default constant rounding mode ("round.tonearest") is used.
+static llvm::StringRef getConstrainedRoundingMetadata(cir::FenvAttr fenv) {
+  std::optional<cir::FPDynamicRoundingMode> rounding =
+      fenv.getDynamicRoundingMode();
+  if (!rounding)
+    return "round.tonearest";
+  switch (*rounding) {
+  case cir::FPDynamicRoundingMode::ToNearest:
+    return "round.tonearest";
+  case cir::FPDynamicRoundingMode::Downward:
+    return "round.downward";
+  case cir::FPDynamicRoundingMode::Upward:
+    return "round.upward";
+  case cir::FPDynamicRoundingMode::UpwardZero:
+    return "round.towardzero";
+  case cir::FPDynamicRoundingMode::ToNearestAway:
+    return "round.tonearestaway";
+  case cir::FPDynamicRoundingMode::Unknown:
+    return "round.dynamic";
+  }
+  llvm_unreachable("unknown FP dynamic rounding mode");
+}
+
+// Return the LLVM metadata string that encodes the exception behavior described
+// by the given fenv attribute, in the form expected by the constrained
+// floating-point intrinsics (e.g. "fpexcept.strict"). A strict exception
+// behavior maps to "fpexcept.strict"; a non-strict (non-deterministic)
+// exception behavior maps to "fpexcept.maytrap"; and the absence of an
+// exception behavior maps to "fpexcept.ignore".
+static llvm::StringRef getConstrainedExceptMetadata(cir::FenvAttr fenv) {
+  mlir::BoolAttr strictExcept = fenv.getStrictExcept();
+  if (!strictExcept)
+    return "fpexcept.ignore";
+  return strictExcept.getValue() ? "fpexcept.strict" : "fpexcept.maytrap";
+}
+
+// Materialize an !llvm.metadata SSA value wrapping the given metadata string so
+// that it can be passed as a metadata operand to a constrained
+// floating-point intrinsic call.
+static mlir::Value
+createFenvMetadataValue(mlir::ConversionPatternRewriter &rewriter,
+                        mlir::Location loc, llvm::StringRef str) {
+  auto mdString = mlir::LLVM::MDStringAttr::get(
+      rewriter.getContext(), mlir::StringAttr::get(rewriter.getContext(), str));
+  return mlir::LLVM::MetadataAsValueOp::create(rewriter, loc, mdString);
+}
+
+// Lower a floating-point operation with an fenv attribute to a call to the
+// matching experimental constrained floating-point intrinsic, using the generic
+// llvm.call_intrinsic form rather than a specialized LLVM dialect operation. The
+// value operands are followed by metadata operands describing the rounding mode
+// (only when `hasRoundingMode` is set) and the exception behavior, taken from
+// the fenv attribute. The overloaded type suffix (e.g. ".f32") is intentionally
+// omitted; it is resolved from the operand types when the LLVM dialect is
+// translated to LLVM IR.
+mlir::LogicalResult lowerToConstrainedFPIntrinsic(
+    mlir::Operation *op, mlir::ValueRange operands, cir::FenvAttr fenv,
+    mlir::Type llvmResTy, mlir::ConversionPatternRewriter &rewriter,
+    llvm::StringRef constrainedMnemonic, bool hasRoundingMode) {
+  mlir::Location loc = op->getLoc();
+  llvm::SmallVector<mlir::Value> callOperands(operands.begin(), operands.end());
+  if (hasRoundingMode)
+    callOperands.push_back(createFenvMetadataValue(
+        rewriter, loc, getConstrainedRoundingMetadata(fenv)));
+  callOperands.push_back(createFenvMetadataValue(
+      rewriter, loc, getConstrainedExceptMetadata(fenv)));
+
+  replaceOpWithCallLLVMIntrinsicOp(
+      rewriter, op, "llvm.experimental.constrained." + constrainedMnemonic,
+      llvmResTy, callOperands);
+  return mlir::success();
+}
+
+// Shared lowering for floating-point operations that carry an optional fenv
+// attribute. Without an fenv attribute the operation is lowered to the plain
+// LLVM operation `LLVMOp`. With an fenv attribute it is lowered to a call to the
+// matching experimental constrained floating-point intrinsic. This handles both
+// unary and binary operations: the value operands are passed through `operands`.
+template <typename LLVMOp>
+mlir::LogicalResult
+lowerConstrainableFPOp(mlir::Operation *op, mlir::ValueRange operands,
+                       cir::FenvAttr fenv,
+                       const mlir::TypeConverter &typeConverter,
+                       mlir::ConversionPatternRewriter &rewriter,
+                       llvm::StringRef constrainedMnemonic,
+                       bool hasRoundingMode) {
+  mlir::Type llvmResTy = typeConverter.convertType(op->getResultTypes()[0]);
+  if (!llvmResTy)
+    return op->emitError("expected LLVM result type for floating-point op");
+
+  if (!fenv) {
+    rewriter.replaceOpWithNewOp<LLVMOp>(op, llvmResTy, operands);
+    return mlir::success();
+  }
+
+  return lowerToConstrainedFPIntrinsic(op, operands, fenv, llvmResTy, rewriter,
+                                       constrainedMnemonic, hasRoundingMode);
+}
+
 mlir::LogicalResult CIRToLLVMLLVMIntrinsicCallOpLowering::matchAndRewrite(
     cir::LLVMIntrinsicCallOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
@@ -1778,6 +1881,11 @@ mlir::LogicalResult CIRToLLVMFMaxNumOpLowering::matchAndRewrite(
     cir::FMaxNumOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
   mlir::Type resTy = typeConverter->convertType(op.getType());
+  // constrained.maxnum takes only the exception-behavior metadata operand.
+  if (cir::FenvAttr fenv = op.getFenvAttr())
+    return lowerToConstrainedFPIntrinsic(op, adaptor.getOperands(), fenv, resTy,
+                                         rewriter, "maxnum",
+                                         /*hasRoundingMode=*/false);
   rewriter.replaceOpWithNewOp<mlir::LLVM::MaxNumOp>(
       op, resTy, adaptor.getLhs(), adaptor.getRhs(),
       mlir::LLVM::FastmathFlags::nsz);
@@ -1788,6 +1896,11 @@ mlir::LogicalResult CIRToLLVMFMinNumOpLowering::matchAndRewrite(
     cir::FMinNumOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
   mlir::Type resTy = typeConverter->convertType(op.getType());
+  // constrained.minnum takes only the exception-behavior metadata operand.
+  if (cir::FenvAttr fenv = op.getFenvAttr())
+    return lowerToConstrainedFPIntrinsic(op, adaptor.getOperands(), fenv, resTy,
+                                         rewriter, "minnum",
+                                         /*hasRoundingMode=*/false);
   rewriter.replaceOpWithNewOp<mlir::LLVM::MinNumOp>(
       op, resTy, adaptor.getLhs(), adaptor.getRhs(),
       mlir::LLVM::FastmathFlags::nsz);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2453,6 +2453,7 @@ void CIRToLLVMFuncOpLowering::lowerFuncAttributes(
         attr.getName() == func.getInlineKindAttrName() ||
         attr.getName() == func.getSideEffectAttrName() ||
         attr.getName() == CIRDialect::getNoReturnAttrName() ||
+        attr.getName() == CIRDialect::getStrictFPAttrName() ||
         attr.getName() == func.getAnnotationsAttrName() ||
         (filterArgAndResAttrs &&
          (attr.getName() == func.getArgAttrsAttrName() ||
@@ -2570,6 +2571,14 @@ mlir::LogicalResult CIRToLLVMFuncOpLowering::matchAndRewrite(
 
   if (op->hasAttr(CIRDialect::getNoReturnAttrName()))
     fn.setNoreturn(true);
+
+  // The LLVM dialect's LLVMFuncOp has no dedicated field for the `strictfp`
+  // function attribute, so route it through the `passthrough` array. The MLIR
+  // LLVM IR translator forwards `passthrough` entries to LLVM IR as function
+  // attributes.
+  if (op->hasAttr(CIRDialect::getStrictFPAttrName()))
+    fn.setPassthroughAttr(rewriter.getArrayAttr(
+        {rewriter.getStringAttr(CIRDialect::getStrictFPAttrName())}));
 
   if (std::optional<cir::InlineKind> inlineKind = op.getInlineKind()) {
     fn.setNoInline(*inlineKind == cir::InlineKind::NoInline);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -431,11 +431,17 @@ static llvm::StringRef getConstrainedRoundingMetadata(cir::FenvAttr fenv) {
 
 // Return the LLVM metadata string that encodes the exception behavior described
 // by the given fenv attribute, in the form expected by the constrained
-// floating-point intrinsics (e.g. "fpexcept.strict"). A strict exception
-// behavior maps to "fpexcept.strict"; a non-strict (non-deterministic)
-// exception behavior maps to "fpexcept.maytrap"; and the absence of an
-// exception behavior maps to "fpexcept.ignore".
+// floating-point intrinsics (e.g. "fpexcept.strict").
+//
+// Mapping from FenvAttr fields (as produced by getConstrainedFPAttr):
+// - except_mode = masked  -> "fpexcept.ignore"  (FPE_Ignore)
+// - strict_except = true  -> "fpexcept.strict"  (FPE_Strict)
+// - strict_except = false -> "fpexcept.maytrap" (FPE_MayTrap)
+// - strict_except absent  -> "fpexcept.ignore"
 static llvm::StringRef getConstrainedExceptMetadata(cir::FenvAttr fenv) {
+  std::optional<cir::FPExceptionMode> exceptMode = fenv.getExceptMode();
+  if (exceptMode && *exceptMode == cir::FPExceptionMode::Masked)
+    return "fpexcept.ignore";
   mlir::BoolAttr strictExcept = fenv.getStrictExcept();
   if (!strictExcept)
     return "fpexcept.ignore";

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -81,6 +81,32 @@ private:
   int32_t blockTagOpIndex;
 };
 
+// Lower a floating-point operation with an fenv attribute to a call to the
+// matching experimental constrained floating-point intrinsic. The value
+// operands are followed by metadata operands for the rounding mode (only when
+// `hasRoundingMode` is set) and the exception behavior. Used by the hand-written
+// lowering patterns whose no-fenv path needs custom handling (e.g. fmaxnum).
+mlir::LogicalResult lowerToConstrainedFPIntrinsic(
+    mlir::Operation *op, mlir::ValueRange operands, cir::FenvAttr fenv,
+    mlir::Type llvmResTy, mlir::ConversionPatternRewriter &rewriter,
+    llvm::StringRef constrainedMnemonic, bool hasRoundingMode);
+
+// Shared lowering for floating-point operations that carry an optional `fenv`
+// attribute. Without the attribute, the operation is lowered to the plain LLVM
+// operation `LLVMOp`. With the attribute, it is lowered to a call to the
+// matching experimental constrained floating-point intrinsic (identified by
+// `constrainedMnemonic`) using the generic `llvm.call_intrinsic` form. It
+// handles both unary and binary operations and is invoked by the table-generated
+// LLVM lowering patterns below.
+template <typename LLVMOp>
+mlir::LogicalResult
+lowerConstrainableFPOp(mlir::Operation *op, mlir::ValueRange operands,
+                       cir::FenvAttr fenv,
+                       const mlir::TypeConverter &typeConverter,
+                       mlir::ConversionPatternRewriter &rewriter,
+                       llvm::StringRef constrainedMnemonic,
+                       bool hasRoundingMode);
+
 #define GET_LLVM_LOWERING_PATTERNS
 #include "clang/CIR/Dialect/IR/CIRLowering.inc"
 #undef GET_LLVM_LOWERING_PATTERNS

--- a/clang/test/CIR/CodeGen/fenv-attr.c
+++ b/clang/test/CIR/CodeGen/fenv-attr.c
@@ -1,0 +1,270 @@
+// Verify that CIR attaches #cir.fenv to floating-point operations when
+// constrained FP mode is in effect, and that lowering to LLVM IR matches
+// classic codegen.
+
+// --- -ffp-model=strict (cc1 equivalent) ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir \
+// RUN:   -ffp-contract=off -frounding-math -ffp-exception-behavior=strict \
+// RUN:   %s -o %t-model.cir
+// RUN: FileCheck --check-prefixes=CIR,CIR-MODEL --input-file=%t-model.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm \
+// RUN:   -ffp-contract=off -frounding-math -ffp-exception-behavior=strict \
+// RUN:   %s -o %t-model-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-MODEL --input-file=%t-model-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm \
+// RUN:   -ffp-contract=off -frounding-math -ffp-exception-behavior=strict \
+// RUN:   %s -o %t-model.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-MODEL --input-file=%t-model.ll %s
+
+// --- -ffp-exception-behavior=strict ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir \
+// RUN:   -ffp-exception-behavior=strict %s -o %t-strict.cir
+// RUN: FileCheck --check-prefixes=CIR,CIR-STRICT --input-file=%t-strict.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm \
+// RUN:   -ffp-exception-behavior=strict %s -o %t-strict-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT --input-file=%t-strict-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm \
+// RUN:   -ffp-exception-behavior=strict %s -o %t-strict.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT --input-file=%t-strict.ll %s
+
+// --- -ffp-exception-behavior=maytrap ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir \
+// RUN:   -ffp-exception-behavior=maytrap %s -o %t-maytrap.cir
+// RUN: FileCheck --check-prefixes=CIR,CIR-MAYTRAP --input-file=%t-maytrap.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm \
+// RUN:   -ffp-exception-behavior=maytrap %s -o %t-maytrap-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-MAYTRAP --input-file=%t-maytrap-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm \
+// RUN:   -ffp-exception-behavior=maytrap %s -o %t-maytrap.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-MAYTRAP --input-file=%t-maytrap.ll %s
+
+// --- -frounding-math (dynamic rounding, ignored exceptions) ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir \
+// RUN:   -frounding-math %s -o %t-rnd.cir
+// RUN: FileCheck --check-prefixes=CIR,CIR-RND --input-file=%t-rnd.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm \
+// RUN:   -frounding-math %s -o %t-rnd-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-RND --input-file=%t-rnd-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm \
+// RUN:   -frounding-math %s -o %t-rnd.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-RND --input-file=%t-rnd.ll %s
+
+// --- pragma-only (no command-line constrained FP) ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir \
+// RUN:   -fexperimental-strict-floating-point %s -o %t-pragma.cir
+// RUN: FileCheck --check-prefixes=CIR,CIR-PRAGMA --input-file=%t-pragma.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm \
+// RUN:   -fexperimental-strict-floating-point %s -o %t-pragma-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-PRAGMA --input-file=%t-pragma-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm \
+// RUN:   -fexperimental-strict-floating-point %s -o %t-pragma.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-PRAGMA --input-file=%t-pragma.ll %s
+
+float add(float x, float y) {
+  return x + y;
+}
+
+// CIR-LABEL: @add
+// CIR-MODEL: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.fadd {{.*}} : !cir.float loc
+// LLVM-LABEL: @add
+// LLVM-MODEL: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: fadd float
+
+float sub(float x, float y) {
+  return x - y;
+}
+
+// CIR-LABEL: @sub
+// CIR-MODEL: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.fsub {{.*}} : !cir.float loc
+// LLVM-LABEL: @sub
+// LLVM-MODEL: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: fsub float
+
+float mul(float x, float y) {
+  return x * y;
+}
+
+// CIR-LABEL: @mul
+// CIR-MODEL: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.fmul {{.*}} : !cir.float loc
+// LLVM-LABEL: @mul
+// LLVM-MODEL: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: fmul float
+
+float div(float x, float y) {
+  return x / y;
+}
+
+// CIR-LABEL: @div
+// CIR-MODEL: cir.fdiv {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fdiv {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.fdiv {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.fdiv {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.fdiv {{.*}} : !cir.float loc
+// LLVM-LABEL: @div
+// LLVM-MODEL: call float @llvm.experimental.constrained.fdiv.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fdiv.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.fdiv.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.fdiv.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: fdiv float
+
+float use_sqrt(float x) {
+  return __builtin_sqrtf(x);
+}
+
+// CIR-LABEL: @use_sqrt
+// CIR-MODEL: cir.sqrt {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.sqrt {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.sqrt {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.sqrt {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.sqrt {{.*}} : !cir.float loc
+// LLVM-LABEL: @use_sqrt
+// LLVM-MODEL: call float @llvm.experimental.constrained.sqrt.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.sqrt.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.sqrt.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.sqrt.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: call float @llvm.sqrt.f32
+
+float use_cos(float x) {
+  return __builtin_cosf(x);
+}
+
+// CIR-LABEL: @use_cos
+// CIR-MODEL: cir.cos {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.cos {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.cos {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.cos {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.cos {{.*}} : !cir.float loc
+// LLVM-LABEL: @use_cos
+// LLVM-MODEL: call float @llvm.experimental.constrained.cos.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.cos.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.cos.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.cos.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: call float @llvm.cos.f32
+
+float use_sin(float x) {
+  return __builtin_sinf(x);
+}
+
+// CIR-LABEL: @use_sin
+// CIR-MODEL: cir.sin {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.sin {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.sin {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.sin {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.sin {{.*}} : !cir.float loc
+// LLVM-LABEL: @use_sin
+// LLVM-MODEL: call float @llvm.experimental.constrained.sin.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.sin.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.sin.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.sin.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: call float @llvm.sin.f32
+
+float use_pow(float x, float y) {
+  return __builtin_powf(x, y);
+}
+
+// CIR-LABEL: @use_pow
+// CIR-MODEL: cir.pow {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.pow {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.pow {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.pow {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.pow {{.*}} : !cir.float loc
+// LLVM-LABEL: @use_pow
+// LLVM-MODEL: call float @llvm.experimental.constrained.pow.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.pow.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.pow.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.pow.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: call float @llvm.pow.f32
+
+float sqrtf(float);
+float cosf(float);
+float sinf(float);
+float powf(float, float);
+
+float lib_sqrt(float x) {
+  return sqrtf(x);
+}
+
+// CIR-LABEL: @lib_sqrt
+// CIR-MODEL: cir.sqrt {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.sqrt {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.sqrt {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.sqrt {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.sqrt {{.*}} : !cir.float loc
+// LLVM-LABEL: @lib_sqrt
+// LLVM-MODEL: call float @llvm.experimental.constrained.sqrt.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.sqrt.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.sqrt.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.sqrt.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: call float @llvm.sqrt.f32
+
+float lib_cos(float x) {
+  return cosf(x);
+}
+
+// CIR-LABEL: @lib_cos
+// CIR-MODEL: cir.cos {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.cos {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.cos {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.cos {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.cos {{.*}} : !cir.float loc
+// LLVM-LABEL: @lib_cos
+// LLVM-MODEL: call float @llvm.experimental.constrained.cos.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.cos.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.cos.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.cos.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: call float @llvm.cos.f32
+
+float lib_sin(float x) {
+  return sinf(x);
+}
+
+// CIR-LABEL: @lib_sin
+// CIR-MODEL: cir.sin {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.sin {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.sin {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.sin {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.sin {{.*}} : !cir.float loc
+// LLVM-LABEL: @lib_sin
+// LLVM-MODEL: call float @llvm.experimental.constrained.sin.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.sin.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.sin.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.sin.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: call float @llvm.sin.f32
+
+float lib_pow(float x, float y) {
+  return powf(x, y);
+}
+
+// CIR-LABEL: @lib_pow
+// CIR-MODEL: cir.pow {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.pow {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: cir.pow {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR-RND: cir.pow {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-PRAGMA: cir.pow {{.*}} : !cir.float loc
+// LLVM-LABEL: @lib_pow
+// LLVM-MODEL: call float @llvm.experimental.constrained.pow.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.pow.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.pow.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-RND: call float @llvm.experimental.constrained.pow.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-PRAGMA: call float @llvm.pow.f32

--- a/clang/test/CIR/CodeGen/global-init-fenv.cpp
+++ b/clang/test/CIR/CodeGen/global-init-fenv.cpp
@@ -1,0 +1,190 @@
+// Verify that C++ dynamic global initializers run under a constrained
+// floating-point environment when the default rounding/exception mode is
+// non-standard. Each dynamic initializer is emitted into the corresponding
+// global's ctor region with #cir.fenv attached to its floating-point
+// operations, and the generated __cxx_global_var_init function is marked
+// strictfp. Lowering to LLVM IR should match classic codegen.
+//
+// The floating-point behavior of an initializer depends on the storage
+// duration of the object being initialized (C99 F.7.4 / [expr.const]). A
+// constant-expression initializer of an object with static storage duration is
+// evaluated at translation time with the default rounding mode and raises no
+// exceptions, so it is folded. A non-constant (dynamic) initializer is
+// evaluated during execution and is therefore subject to the operative
+// floating-point environment.
+
+// --- -ffp-exception-behavior=strict ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-rtti -fclangir \
+// RUN:   -ffp-exception-behavior=strict -emit-cir %s -o %t-strict.cir
+// RUN: FileCheck --check-prefixes=CIR,CIR-STRICT --input-file=%t-strict.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-rtti -fclangir \
+// RUN:   -ffp-exception-behavior=strict -emit-llvm %s -o %t-strict-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT --input-file=%t-strict-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-rtti \
+// RUN:   -ffp-exception-behavior=strict -emit-llvm %s -o %t-strict.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT --input-file=%t-strict.ll %s
+
+// --- -ffp-exception-behavior=maytrap ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-rtti -fclangir \
+// RUN:   -ffp-exception-behavior=maytrap -emit-cir %s -o %t-maytrap.cir
+// RUN: FileCheck --check-prefixes=CIR,CIR-MAYTRAP --input-file=%t-maytrap.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-rtti -fclangir \
+// RUN:   -ffp-exception-behavior=maytrap -emit-llvm %s -o %t-maytrap-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-MAYTRAP --input-file=%t-maytrap-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-rtti \
+// RUN:   -ffp-exception-behavior=maytrap -emit-llvm %s -o %t-maytrap.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-MAYTRAP --input-file=%t-maytrap.ll %s
+
+// --- default FP environment (no constrained FP) ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-rtti -fclangir \
+// RUN:   -emit-cir %s -o %t-default.cir
+// RUN: FileCheck --check-prefixes=CIR-DEFAULT --input-file=%t-default.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fno-rtti -fclangir \
+// RUN:   -emit-llvm %s -o %t-default-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM-DEFAULT --input-file=%t-default-cir.ll %s
+
+//===----------------------------------------------------------------------===//
+// Case 1: a global initialized from two other globals declared in this module
+// that are NOT constant. Their values are unknown at translation time, so the
+// initializer is always dynamic.
+//===----------------------------------------------------------------------===//
+float nc_x = 1.0f;
+float nc_y = 10.0f;
+float g_nonconst = nc_x / nc_y;
+
+//===----------------------------------------------------------------------===//
+// Case 2: a global initialized from two other globals declared in this module
+// that are const (but NOT constexpr). A const float is not usable in a constant
+// expression, so under a constrained FP environment the division is evaluated
+// at runtime; in the default environment it is folded to a static constant.
+//===----------------------------------------------------------------------===//
+const float c_x = 1.0f;
+const float c_y = 10.0f;
+float g_const = c_x / c_y;
+
+//===----------------------------------------------------------------------===//
+// Case 3: a global initialized from an expression using three other globals,
+// two of which are constexpr and one which is not. Under a constrained FP
+// environment none of the divisions are folded (folding would drop the
+// rounding/exception behavior), so both divisions are evaluated at runtime.
+//===----------------------------------------------------------------------===//
+constexpr float ce_x = 1.0f;
+constexpr float ce_y = 10.0f;
+float nc_z = 2.0f;
+float g_mixed = ce_x / ce_y / nc_z;
+
+//===----------------------------------------------------------------------===//
+// Constrained FP (strict / maytrap): every global is initialized dynamically.
+// Each __cxx_global_var_init function is marked strictfp, and each floating
+// point division carries a #cir.fenv attribute (strict_except differs between
+// the strict and maytrap exception modes). 1.0f / 10.0f is inexact, so the
+// division requires rounding and raises the inexact exception.
+//===----------------------------------------------------------------------===//
+
+// Case 1: g_nonconst = nc_x / nc_y
+// CIR-LABEL:   cir.func {{.*}} @__cxx_global_var_init()
+// CIR-STRICT-SAME:  attributes {strictfp}
+// CIR-MAYTRAP-SAME: attributes {strictfp}
+// CIR:         %[[G:.*]] = cir.get_global @g_nonconst : !cir.ptr<!cir.float>
+// CIR:         %[[XP:.*]] = cir.get_global @nc_x : !cir.ptr<!cir.float>
+// CIR:         %[[X:.*]] = cir.load {{.*}} %[[XP]]
+// CIR:         %[[YP:.*]] = cir.get_global @nc_y : !cir.ptr<!cir.float>
+// CIR:         %[[Y:.*]] = cir.load {{.*}} %[[YP]]
+// CIR-STRICT:  %[[R:.*]] = cir.fdiv %[[X]], %[[Y]] : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: %[[R:.*]] = cir.fdiv %[[X]], %[[Y]] : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR:         cir.store {{.*}} %[[R]], %[[G]] : !cir.float, !cir.ptr<!cir.float>
+
+// Case 2: g_const = c_x / c_y  (const operands loaded, not folded)
+// CIR-LABEL:   cir.func {{.*}} @__cxx_global_var_init.1()
+// CIR-STRICT-SAME:  attributes {strictfp}
+// CIR-MAYTRAP-SAME: attributes {strictfp}
+// CIR:         %[[G:.*]] = cir.get_global @g_const : !cir.ptr<!cir.float>
+// CIR:         %[[XP:.*]] = cir.get_global @_ZL3c_x : !cir.ptr<!cir.float>
+// CIR:         %[[X:.*]] = cir.load {{.*}} %[[XP]]
+// CIR:         %[[YP:.*]] = cir.get_global @_ZL3c_y : !cir.ptr<!cir.float>
+// CIR:         %[[Y:.*]] = cir.load {{.*}} %[[YP]]
+// CIR-STRICT:  %[[R:.*]] = cir.fdiv %[[X]], %[[Y]] : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: %[[R:.*]] = cir.fdiv %[[X]], %[[Y]] : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR:         cir.store {{.*}} %[[R]], %[[G]] : !cir.float, !cir.ptr<!cir.float>
+
+// Case 3: g_mixed = ce_x / ce_y / nc_z  (all operands loaded, two divisions)
+// CIR-LABEL:   cir.func {{.*}} @__cxx_global_var_init.2()
+// CIR-STRICT-SAME:  attributes {strictfp}
+// CIR-MAYTRAP-SAME: attributes {strictfp}
+// CIR:         %[[G:.*]] = cir.get_global @g_mixed : !cir.ptr<!cir.float>
+// CIR:         %[[AP:.*]] = cir.get_global @_ZL4ce_x : !cir.ptr<!cir.float>
+// CIR:         %[[A:.*]] = cir.load {{.*}} %[[AP]]
+// CIR:         %[[BP:.*]] = cir.get_global @_ZL4ce_y : !cir.ptr<!cir.float>
+// CIR:         %[[B:.*]] = cir.load {{.*}} %[[BP]]
+// CIR-STRICT:  %[[R0:.*]] = cir.fdiv %[[A]], %[[B]] : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: %[[R0:.*]] = cir.fdiv %[[A]], %[[B]] : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR:         %[[CP:.*]] = cir.get_global @nc_z : !cir.ptr<!cir.float>
+// CIR:         %[[C:.*]] = cir.load {{.*}} %[[CP]]
+// CIR-STRICT:  %[[R1:.*]] = cir.fdiv %[[R0]], %[[C]] : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-MAYTRAP: %[[R1:.*]] = cir.fdiv %[[R0]], %[[C]] : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = false>}
+// CIR:         cir.store {{.*}} %[[R1]], %[[G]] : !cir.float, !cir.ptr<!cir.float>
+
+//===----------------------------------------------------------------------===//
+// LLVM lowering (strict / maytrap): the same via -fclangir and classic codegen.
+// Each initializer function is strictfp and each division becomes a constrained
+// fdiv intrinsic. (The operand values differ between pipelines because CIR
+// loads const/constexpr operands from memory while classic codegen substitutes
+// their constant values, so the operands are wildcarded here.)
+//===----------------------------------------------------------------------===//
+
+// Case 1: g_nonconst
+// LLVM:         define {{.*}}void @__cxx_global_var_init() #[[ATTR:[0-9]+]]
+// LLVM-STRICT:  call float @llvm.experimental.constrained.fdiv.f32(float {{.*}}, float {{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.fdiv.f32(float {{.*}}, float {{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM:         store float {{.*}}, ptr @g_nonconst
+
+// Case 2: g_const
+// LLVM:         define {{.*}}void @__cxx_global_var_init.1() #[[ATTR]]
+// LLVM-STRICT:  call float @llvm.experimental.constrained.fdiv.f32(float {{.*}}, float {{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.fdiv.f32(float {{.*}}, float {{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM:         store float {{.*}}, ptr @g_const
+
+// Case 3: g_mixed (two constrained divisions)
+// LLVM:         define {{.*}}void @__cxx_global_var_init.2() #[[ATTR]]
+// LLVM-STRICT:  call float @llvm.experimental.constrained.fdiv.f32(float {{.*}}, float {{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT:  call float @llvm.experimental.constrained.fdiv.f32(float {{.*}}, float {{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.fdiv.f32(float {{.*}}, float {{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM-MAYTRAP: call float @llvm.experimental.constrained.fdiv.f32(float {{.*}}, float {{.*}}, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+// LLVM:         store float {{.*}}, ptr @g_mixed
+
+// LLVM:         attributes #[[ATTR]] = {{.*}}strictfp
+
+//===----------------------------------------------------------------------===//
+// Default FP environment: g_nonconst and g_mixed are still dynamic (they use
+// non-constant operands), but neither init function is strictfp and no fenv
+// attribute is attached. g_const IS a constant expression here, so it is folded
+// to a static constant and needs no initializer function -- which is why
+// g_mixed's initializer is numbered .1 (not .2): g_const never gets one.
+//===----------------------------------------------------------------------===//
+
+// Case 1 (default): g_nonconst, plain fdiv, no strictfp / no fenv.
+// CIR-DEFAULT-LABEL: cir.func internal private @__cxx_global_var_init() {
+// CIR-DEFAULT:   %[[G:.*]] = cir.get_global @g_nonconst : !cir.ptr<!cir.float>
+// CIR-DEFAULT:   %[[R:.*]] = cir.fdiv %{{.*}}, %{{.*}} : !cir.float loc
+// CIR-DEFAULT:   cir.store {{.*}} %[[R]], %[[G]] : !cir.float, !cir.ptr<!cir.float>
+
+// Case 2 (default): g_const folded to a static constant (1.0f / 10.0f = 0.1f).
+// CIR-DEFAULT: cir.global external @g_const = #cir.fp<1.000000e-01> : !cir.float
+
+// Case 3 (default): g_mixed, ce_x/ce_y still loaded and divided at runtime,
+// then divided by nc_z. Two plain fdivs, no strictfp / no fenv.
+// CIR-DEFAULT-LABEL: cir.func internal private @__cxx_global_var_init.1() {
+// CIR-DEFAULT:   %[[G2:.*]] = cir.get_global @g_mixed : !cir.ptr<!cir.float>
+// CIR-DEFAULT:   %[[R0:.*]] = cir.fdiv %{{.*}}, %{{.*}} : !cir.float loc
+// CIR-DEFAULT:   %[[R1:.*]] = cir.fdiv %[[R0]], %{{.*}} : !cir.float loc
+// CIR-DEFAULT:   cir.store {{.*}} %[[R1]], %[[G2]] : !cir.float, !cir.ptr<!cir.float>
+
+// LLVM (default): folded constant, plain fdivs, no constrained intrinsics.
+// LLVM-DEFAULT: @g_const = {{.*}}global float 1.000000e-01
+// LLVM-DEFAULT: define {{.*}}void @__cxx_global_var_init()
+// LLVM-DEFAULT: fdiv float
+// LLVM-DEFAULT: store float {{.*}}, ptr @g_nonconst
+// LLVM-DEFAULT: define {{.*}}void @__cxx_global_var_init.1()
+// LLVM-DEFAULT: store float {{.*}}, ptr @g_mixed
+// LLVM-DEFAULT-NOT: constrained
+// LLVM-DEFAULT-NOT: strictfp

--- a/clang/test/CIR/CodeGen/pragma-fenv_access.c
+++ b/clang/test/CIR/CodeGen/pragma-fenv_access.c
@@ -1,0 +1,511 @@
+// Verify #pragma STDC FENV_ACCESS / float_control / clang fp exception and
+// rounding pragmas produce the expected constrained FP behavior in CIR and in
+// LLVM IR (both via -fclangir and classic codegen).
+
+// --- STRICT: -ffp-exception-behavior=strict ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -fexperimental-strict-floating-point -ffp-exception-behavior=strict \
+// RUN:   -emit-cir %s -o %t-strict.cir
+// RUN: FileCheck --check-prefixes=CIR,CIR-STRICT --input-file=%t-strict.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -fexperimental-strict-floating-point -ffp-exception-behavior=strict \
+// RUN:   -emit-llvm %s -o %t-strict-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT \
+// RUN:   --input-file=%t-strict-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fexperimental-strict-floating-point -ffp-exception-behavior=strict \
+// RUN:   -emit-llvm %s -o %t-strict.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT \
+// RUN:   --input-file=%t-strict.ll %s
+
+// --- STRICT-RND: -frounding-math -ffp-exception-behavior=strict ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -fexperimental-strict-floating-point -frounding-math \
+// RUN:   -ffp-exception-behavior=strict -emit-cir %s -o %t-strict-rnd.cir
+// RUN: FileCheck --check-prefixes=CIR,CIR-STRICT-RND \
+// RUN:   --input-file=%t-strict-rnd.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -fexperimental-strict-floating-point -frounding-math \
+// RUN:   -ffp-exception-behavior=strict -emit-llvm %s -o %t-strict-rnd-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT-RND \
+// RUN:   --input-file=%t-strict-rnd-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fexperimental-strict-floating-point -frounding-math \
+// RUN:   -ffp-exception-behavior=strict -emit-llvm %s -o %t-strict-rnd.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT-RND \
+// RUN:   --input-file=%t-strict-rnd.ll %s
+
+// --- STRICT with MS fenv_access spelling ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -fexperimental-strict-floating-point -ffp-exception-behavior=strict \
+// RUN:   -fms-extensions -DMS -emit-llvm %s -o %t-strict-ms-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT \
+// RUN:   --input-file=%t-strict-ms-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fexperimental-strict-floating-point -ffp-exception-behavior=strict \
+// RUN:   -fms-extensions -DMS -emit-llvm %s -o %t-strict-ms.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT \
+// RUN:   --input-file=%t-strict-ms.ll %s
+
+// --- STRICT-RND with MS fenv_access spelling ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -fexperimental-strict-floating-point -frounding-math \
+// RUN:   -ffp-exception-behavior=strict -fms-extensions -DMS \
+// RUN:   -emit-llvm %s -o %t-strict-rnd-ms-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT-RND \
+// RUN:   --input-file=%t-strict-rnd-ms-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fexperimental-strict-floating-point -frounding-math \
+// RUN:   -ffp-exception-behavior=strict -fms-extensions -DMS \
+// RUN:   -emit-llvm %s -o %t-strict-rnd-ms.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-STRICT-RND \
+// RUN:   --input-file=%t-strict-rnd-ms.ll %s
+
+// --- DEFAULT: pragma-only constrained FP ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -fexperimental-strict-floating-point -emit-cir %s -o %t-default.cir
+// RUN: FileCheck --check-prefixes=CIR,CIR-DEFAULT --input-file=%t-default.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -fexperimental-strict-floating-point -emit-llvm %s -o %t-default-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-DEFAULT \
+// RUN:   --input-file=%t-default-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fexperimental-strict-floating-point -emit-llvm %s -o %t-default.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-DEFAULT \
+// RUN:   --input-file=%t-default.ll %s
+
+// --- DEFAULT-RND: -frounding-math, pragma-only exceptions ---
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -fexperimental-strict-floating-point -frounding-math \
+// RUN:   -emit-cir %s -o %t-default-rnd.cir
+// RUN: FileCheck --check-prefixes=CIR,CIR-DEFAULT-RND \
+// RUN:   --input-file=%t-default-rnd.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -fexperimental-strict-floating-point -frounding-math \
+// RUN:   -emit-llvm %s -o %t-default-rnd-cir.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-DEFAULT-RND \
+// RUN:   --input-file=%t-default-rnd-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fexperimental-strict-floating-point -frounding-math \
+// RUN:   -emit-llvm %s -o %t-default-rnd.ll
+// RUN: FileCheck --check-prefixes=LLVM,LLVM-DEFAULT-RND \
+// RUN:   --input-file=%t-default-rnd.ll %s
+
+float test_cmdline_defaults(float x, float y) {
+  return x + y;
+}
+
+// CIR-LABEL: @test_cmdline_defaults
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fadd {{.*}} : !cir.float loc
+// CIR-DEFAULT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// LLVM-LABEL: @test_cmdline_defaults
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: fadd float
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+
+// When #pragma float_control(except, on) is enabled in a nested scope,
+// operations outside the scope still carry an fenv attribute, but with
+// ignore-style exception settings derived from the ambient FP options.
+// Placed before any global-scope FENV_ACCESS pragma so -frounding-math is
+// not cleared by FENV_ACCESS OFF (setRoundingMathOverride(false)).
+float test_scoped_float_control(float x, float y) {
+  float a = x + y;
+  {
+#pragma float_control(except, on)
+    float b = x * y;
+    a = a + b;
+  }
+  return a - y;
+}
+
+// CIR-LABEL: @test_scoped_float_control
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT-RND: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT-RND: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = masked, strict_except = false>}
+// LLVM-LABEL: @test_scoped_float_control
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.ignore")
+
+#ifdef MS
+#pragma fenv_access (on)
+#else
+#pragma STDC FENV_ACCESS ON
+#endif
+
+float test_global_fenv_access_on(float x, float y) {
+  return x + y;
+}
+
+// CIR-LABEL: @test_global_fenv_access_on
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// LLVM-LABEL: @test_global_fenv_access_on
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+
+float test_except_off_fenv_access_off(float x, float y) {
+#pragma float_control(except, off)
+#pragma STDC FENV_ACCESS OFF
+  return x + y;
+}
+
+// CIR-LABEL: @test_except_off_fenv_access_off
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// LLVM-LABEL: @test_except_off_fenv_access_off
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+
+float test_fenv_access_on_after_local_off(float x, float y) {
+  return x + y;
+}
+
+// CIR-LABEL: @test_fenv_access_on_after_local_off
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// LLVM-LABEL: @test_fenv_access_on_after_local_off
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+
+#ifdef MS
+#pragma fenv_access (off)
+#else
+#pragma STDC FENV_ACCESS OFF
+#endif
+
+float test_float_control_except_off(float x, float y) {
+#pragma float_control(except, off)
+  return x + y;
+}
+
+// CIR-LABEL: @test_float_control_except_off
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT: cir.fadd {{.*}} : !cir.float loc
+// CIR-DEFAULT-RND: cir.fadd {{.*}} : !cir.float loc
+// LLVM-LABEL: @test_float_control_except_off
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT: fadd float
+// LLVM-DEFAULT-RND: fadd float
+
+float test_float_control_except_on(float x, float y) {
+#pragma float_control(except, on)
+  return x + y;
+}
+
+// CIR-LABEL: @test_float_control_except_on
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// LLVM-LABEL: @test_float_control_except_on
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+
+float test_local_fenv_access_on(float x, float y) {
+#pragma STDC FENV_ACCESS ON
+  return x + y;
+}
+
+// CIR-LABEL: @test_local_fenv_access_on
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// LLVM-LABEL: @test_local_fenv_access_on
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+
+float test_float_control_except_off_after_on(float x, float y) {
+#pragma float_control(except, off)
+  return x + y;
+}
+
+// CIR-LABEL: @test_float_control_except_off_after_on
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT: cir.fadd {{.*}} : !cir.float loc
+// CIR-DEFAULT-RND: cir.fadd {{.*}} : !cir.float loc
+// LLVM-LABEL: @test_float_control_except_off_after_on
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT: fadd float
+// LLVM-DEFAULT-RND: fadd float
+
+float test_scoped_fenv_access_on(float x, float y) {
+  x -= y;
+  if (x) {
+#pragma STDC FENV_ACCESS ON
+    y *= 2.0F;
+  }
+  return y + 4.0F;
+}
+
+// CIR-LABEL: @test_scoped_fenv_access_on
+// CIR-STRICT: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT-RND: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT-RND: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// LLVM-LABEL: @test_scoped_fenv_access_on
+// LLVM-STRICT: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+
+float test_fenv_round_upward(float x, float y) {
+#pragma STDC FENV_ROUND FE_UPWARD
+#pragma STDC FENV_ACCESS ON
+  return x + y;
+}
+
+// CIR-LABEL: @test_fenv_round_upward
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = upward, except_mode = unknown, strict_except = true>}
+// LLVM-LABEL: @test_fenv_round_upward
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.upward", metadata !"fpexcept.strict")
+
+float test_fenv_round_tonearest(float x, float y) {
+#pragma STDC FENV_ROUND FE_TONEAREST
+#pragma STDC FENV_ACCESS ON
+  return x + y;
+}
+
+// CIR-LABEL: @test_fenv_round_tonearest
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// LLVM-LABEL: @test_fenv_round_tonearest
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+
+float test_fenv_round_tonearest_except_ignore(float x, float y) {
+#pragma STDC FENV_ROUND FE_TONEAREST
+#pragma clang fp exceptions(ignore)
+#pragma STDC FENV_ACCESS ON
+  return x + y;
+}
+
+// CIR-LABEL: @test_fenv_round_tonearest_except_ignore
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// LLVM-LABEL: @test_fenv_round_tonearest_except_ignore
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+
+float test_fenv_round_tonearest_except_ignore_fenv_off(float x, float y) {
+#pragma STDC FENV_ROUND FE_TONEAREST
+#pragma clang fp exceptions(ignore)
+#pragma STDC FENV_ACCESS OFF
+  return x + y;
+}
+
+// CIR-LABEL: @test_fenv_round_tonearest_except_ignore_fenv_off
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT: cir.fadd {{.*}} : !cir.float loc
+// CIR-DEFAULT-RND: cir.fadd {{.*}} : !cir.float loc
+// LLVM-LABEL: @test_fenv_round_tonearest_except_ignore_fenv_off
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT: fadd float
+// LLVM-DEFAULT-RND: fadd float
+
+float test_fp_exceptions_maytrap(float x, float y) {
+#pragma clang fp exceptions(maytrap)
+#pragma STDC FENV_ACCESS ON
+  return x + y;
+}
+
+// CIR-LABEL: @test_fp_exceptions_maytrap
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = false>}
+// LLVM-LABEL: @test_fp_exceptions_maytrap
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.maytrap")
+
+float test_fp_exceptions_maytrap_round_upward(float x, float y) {
+#pragma clang fp exceptions(maytrap)
+#pragma STDC FENV_ROUND FE_UPWARD
+#pragma STDC FENV_ACCESS ON
+  return x + y;
+}
+
+// CIR-LABEL: @test_fp_exceptions_maytrap_round_upward
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = upward, except_mode = unknown, strict_except = false>}
+// LLVM-LABEL: @test_fp_exceptions_maytrap_round_upward
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.upward", metadata !"fpexcept.maytrap")
+
+float test_nested_fenv_access_off(float x, float y, float z) {
+#pragma STDC FENV_ACCESS ON
+  float res = x * y;
+  {
+#pragma STDC FENV_ACCESS OFF
+    return res + z;
+  }
+}
+
+// CIR-LABEL: @test_nested_fenv_access_off
+// CIR-STRICT: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT-RND: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// LLVM-LABEL: @test_nested_fenv_access_off
+// LLVM-STRICT: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+
+float test_fenv_round_towardzero_nested_fenv_off(float x, float y, float z) {
+#pragma STDC FENV_ROUND FE_TOWARDZERO
+#pragma STDC FENV_ACCESS ON
+  float res = x * y;
+  {
+#pragma STDC FENV_ACCESS OFF
+    return res + z;
+  }
+}
+
+// CIR-LABEL: @test_fenv_round_towardzero_nested_fenv_off
+// CIR-STRICT: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT-RND: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero, except_mode = masked, strict_except = false>}
+// LLVM-LABEL: @test_fenv_round_towardzero_nested_fenv_off
+// LLVM-STRICT: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.towardzero", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.towardzero", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.towardzero", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.towardzero", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.towardzero", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.towardzero", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.towardzero", metadata !"fpexcept.strict")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.towardzero", metadata !"fpexcept.ignore")
+
+float test_nested_fenv_round_then_fenv_access(float x, float y) {
+  x -= y;
+  {
+#pragma STDC FENV_ROUND FE_TONEAREST
+#pragma STDC FENV_ACCESS ON
+    y *= 2.0F;
+  }
+  {
+#pragma STDC FENV_ACCESS ON
+    return y + 4.0F;
+  }
+}
+
+// CIR-LABEL: @test_nested_fenv_round_then_fenv_access
+// CIR-STRICT: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT-RND: cir.fsub {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = masked, strict_except = false>}
+// CIR-DEFAULT-RND: cir.fmul {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// LLVM-LABEL: @test_nested_fenv_round_then_fenv_access
+// LLVM-STRICT: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fsub.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.ignore")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fmul.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-DEFAULT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+
+float test_fenv_round_dynamic_with_fenv_access(float x, float y) {
+#pragma STDC FENV_ROUND FE_DYNAMIC
+#pragma STDC FENV_ACCESS ON
+  return x + y;
+}
+
+// CIR-LABEL: @test_fenv_round_dynamic_with_fenv_access
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// LLVM-LABEL: @test_fenv_round_dynamic_with_fenv_access
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+
+float test_fenv_round_dynamic_without_fenv_access(float x, float y) {
+#pragma STDC FENV_ROUND FE_DYNAMIC
+  return x + y;
+}
+
+// CIR-LABEL: @test_fenv_round_dynamic_without_fenv_access
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fadd {{.*}} : !cir.float loc
+// CIR-DEFAULT-RND: cir.fadd {{.*}} : !cir.float loc
+// LLVM-LABEL: @test_fenv_round_dynamic_without_fenv_access
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: fadd float
+// LLVM-DEFAULT-RND: fadd float
+
+#pragma STDC FENV_ACCESS ON
+float test_file_scope_fenv_access_on(float x, float y) {
+  return x + y;
+}
+
+// CIR-LABEL: @test_file_scope_fenv_access_on
+// CIR: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = unknown, except_mode = unknown, strict_except = true>}
+// LLVM-LABEL: @test_file_scope_fenv_access_on
+// LLVM: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.dynamic", metadata !"fpexcept.strict")
+
+#pragma STDC FENV_ACCESS OFF
+float test_file_scope_fenv_access_off(float x, float y) {
+  return x + y;
+}
+
+// CIR-LABEL: @test_file_scope_fenv_access_off
+// CIR-STRICT: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-STRICT-RND: cir.fadd {{.*}} {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+// CIR-DEFAULT: cir.fadd {{.*}} : !cir.float loc
+// CIR-DEFAULT-RND: cir.fadd {{.*}} : !cir.float loc
+// LLVM-LABEL: @test_file_scope_fenv_access_off
+// LLVM-STRICT: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-STRICT-RND: call float @llvm.experimental.constrained.fadd.f32({{.*}}, metadata !"round.tonearest", metadata !"fpexcept.strict")
+// LLVM-DEFAULT: fadd float
+// LLVM-DEFAULT-RND: fadd float

--- a/clang/test/CIR/IR/fenv.cir
+++ b/clang/test/CIR/IR/fenv.cir
@@ -1,0 +1,68 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+
+// CHECK-LABEL: cir.func @fadd_fenv
+cir.func @fadd_fenv(%a: !cir.float, %b: !cir.float) {
+  // All fields present.
+  // CHECK: cir.fadd %{{.*}}, %{{.*}} : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+  %0 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+
+  // No fenv attribute at all.
+  // CHECK: cir.fadd %{{.*}}, %{{.*}} : !cir.float
+  // CHECK-NOT: fenv
+  %1 = cir.fadd %a, %b : !cir.float
+
+  // Empty fenv attribute.
+  // CHECK: cir.fadd %{{.*}}, %{{.*}} : !cir.float {fenv = #cir.fenv<>}
+  %2 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<>}
+  cir.return
+}
+
+// Roundtrip each binary floating-point op with a fenv attribute.
+// CHECK-LABEL: cir.func @fp_binops_fenv
+cir.func @fp_binops_fenv(%a: !cir.double, %b: !cir.double) {
+  // CHECK: cir.fadd %{{.*}}, %{{.*}} : !cir.double {fenv = #cir.fenv<dynamic_rounding_mode = tonearest>}
+  %0 = cir.fadd %a, %b : !cir.double {fenv = #cir.fenv<dynamic_rounding_mode = tonearest>}
+  // CHECK: cir.fsub %{{.*}}, %{{.*}} : !cir.double {fenv = #cir.fenv<dynamic_rounding_mode = downward>}
+  %1 = cir.fsub %a, %b : !cir.double {fenv = #cir.fenv<dynamic_rounding_mode = downward>}
+  // CHECK: cir.fmul %{{.*}}, %{{.*}} : !cir.double {fenv = #cir.fenv<dynamic_rounding_mode = upward>}
+  %2 = cir.fmul %a, %b : !cir.double {fenv = #cir.fenv<dynamic_rounding_mode = upward>}
+  // CHECK: cir.fdiv %{{.*}}, %{{.*}} : !cir.double {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero>}
+  %3 = cir.fdiv %a, %b : !cir.double {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero>}
+  // CHECK: cir.frem %{{.*}}, %{{.*}} : !cir.double {fenv = #cir.fenv<dynamic_rounding_mode = tonearestaway>}
+  %4 = cir.frem %a, %b : !cir.double {fenv = #cir.fenv<dynamic_rounding_mode = tonearestaway>}
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @fneg_fenv
+cir.func @fneg_fenv(%a: !cir.float, %v: !cir.vector<4 x !cir.float>) {
+  // CHECK: cir.fneg %{{.*}} : !cir.float {fenv = #cir.fenv<except_mode = masked>}
+  %0 = cir.fneg %a : !cir.float {fenv = #cir.fenv<except_mode = masked>}
+  // CHECK: cir.fneg %{{.*}} : !cir.vector<4 x !cir.float> {fenv = #cir.fenv<except_mode = unmasked, strict_except = false>}
+  %1 = cir.fneg %v : !cir.vector<4 x !cir.float> {fenv = #cir.fenv<except_mode = unmasked, strict_except = false>}
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @unary_fp_builtin_fenv
+cir.func @unary_fp_builtin_fenv(%a: !cir.float) {
+  // CHECK: cir.sqrt %{{.*}} : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = unknown>}
+  %0 = cir.sqrt %a : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = unknown>}
+  // CHECK: cir.cos %{{.*}} : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = downward>}
+  %1 = cir.cos %a : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = downward>}
+  // CHECK: cir.floor %{{.*}} : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero>}
+  %2 = cir.floor %a : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero>}
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @binary_fp_builtin_fenv
+cir.func @binary_fp_builtin_fenv(%a: !cir.float, %b: !cir.float) {
+  // CHECK: cir.copysign %{{.*}}, %{{.*}} : !cir.float {fenv = #cir.fenv<strict_except = true>}
+  %0 = cir.copysign %a, %b : !cir.float {fenv = #cir.fenv<strict_except = true>}
+  // CHECK: cir.pow %{{.*}}, %{{.*}} : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, strict_except = true>}
+  %1 = cir.pow %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, strict_except = true>}
+  // CHECK: cir.atan2 %{{.*}}, %{{.*}} : !cir.float
+  // CHECK-NOT: fenv
+  %2 = cir.atan2 %a, %b : !cir.float
+  cir.return
+}

--- a/clang/test/CIR/Lowering/fenv.cir
+++ b/clang/test/CIR/Lowering/fenv.cir
@@ -55,9 +55,11 @@ module {
     cir.return
   }
 
-  // The exception behavior is derived from the strict_except field: true maps to
-  // "fpexcept.strict", false maps to "fpexcept.maytrap", and an absent value
-  // maps to "fpexcept.ignore".
+  // Exception behavior mapping:
+  // - strict_except = true  -> "fpexcept.strict"
+  // - strict_except = false -> "fpexcept.maytrap" (unless except_mode = masked)
+  // - except_mode = masked  -> "fpexcept.ignore" (FPE_Ignore)
+  // - strict_except absent  -> "fpexcept.ignore"
   // CHECK-LABEL: llvm.func @exception_behaviors
   cir.func @exception_behaviors(%a: !cir.float, %b: !cir.float) {
     // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
@@ -68,7 +70,10 @@ module {
     %1 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<strict_except = false>}
     // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.ignore">
     // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
-    %2 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest>}
+    %2 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<except_mode = masked, strict_except = false>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.ignore">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %3 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest>}
     cir.return
   }
 

--- a/clang/test/CIR/Lowering/fenv.cir
+++ b/clang/test/CIR/Lowering/fenv.cir
@@ -1,0 +1,166 @@
+// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s
+
+// Lowering of floating-point operations that carry an `fenv` attribute. Such
+// operations are lowered to calls to the experimental constrained
+// floating-point intrinsics using the generic `llvm.call_intrinsic` form, with
+// the rounding mode and exception behavior passed as metadata operands. The
+// overloaded type suffix is intentionally omitted from the intrinsic name; it
+// is resolved from the operand types during translation to LLVM IR.
+
+module {
+  // An operation with a fully-specified fenv attribute lowers to a constrained
+  // intrinsic call. An operation without an fenv attribute keeps the plain LLVM
+  // binary operation. An empty fenv attribute lowers to a constrained call with
+  // the default rounding mode and ignored exceptions.
+  // CHECK-LABEL: llvm.func @fadd_variants
+  cir.func @fadd_variants(%a: !cir.float, %b: !cir.float) {
+    // CHECK: %[[RM:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"round.tonearest">
+    // CHECK: %[[EB:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"(%{{.*}}, %{{.*}}, %[[RM]], %[[EB]]) : (f32, f32, !llvm.metadata, !llvm.metadata) -> f32
+    %0 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest, except_mode = unknown, strict_except = true>}
+
+    // CHECK: llvm.fadd %{{.*}}, %{{.*}} : f32
+    // CHECK-NOT: constrained
+    %1 = cir.fadd %a, %b : !cir.float
+
+    // CHECK: %[[RM2:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"round.tonearest">
+    // CHECK: %[[EB2:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.ignore">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"(%{{.*}}, %{{.*}}, %[[RM2]], %[[EB2]]) : (f32, f32, !llvm.metadata, !llvm.metadata) -> f32
+    %2 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<>}
+    cir.return
+  }
+
+  // Each dynamic rounding mode maps to the corresponding LLVM metadata string.
+  // An unknown dynamic rounding mode maps to "round.dynamic".
+  // CHECK-LABEL: llvm.func @rounding_modes
+  cir.func @rounding_modes(%a: !cir.float, %b: !cir.float) {
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.tonearest">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %0 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.downward">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %1 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = downward>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.upward">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %2 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = upward>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.towardzero">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %3 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = upwardzero>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.tonearestaway">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %4 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearestaway>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"round.dynamic">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %5 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = unknown>}
+    cir.return
+  }
+
+  // The exception behavior is derived from the strict_except field: true maps to
+  // "fpexcept.strict", false maps to "fpexcept.maytrap", and an absent value
+  // maps to "fpexcept.ignore".
+  // CHECK-LABEL: llvm.func @exception_behaviors
+  cir.func @exception_behaviors(%a: !cir.float, %b: !cir.float) {
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %0 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.maytrap">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %1 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<strict_except = false>}
+    // CHECK: llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.ignore">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"
+    %2 = cir.fadd %a, %b : !cir.float {fenv = #cir.fenv<dynamic_rounding_mode = tonearest>}
+    cir.return
+  }
+
+  // Every floating-point binary op maps to the matching constrained intrinsic.
+  // CHECK-LABEL: llvm.func @all_binops
+  cir.func @all_binops(%a: !cir.double, %b: !cir.double) {
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %0 = cir.fadd %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fsub"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %1 = cir.fsub %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fmul"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %2 = cir.fmul %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fdiv"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %3 = cir.fdiv %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.frem"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %4 = cir.frem %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    cir.return
+  }
+
+  // Vector floating-point operations are lowered the same way; the vector type
+  // is carried through to the intrinsic call signature.
+  // CHECK-LABEL: llvm.func @vector_binop
+  cir.func @vector_binop(%a: !cir.vector<4 x !cir.float>,
+                         %b: !cir.vector<4 x !cir.float>) {
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.fadd"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (vector<4xf32>, vector<4xf32>, !llvm.metadata, !llvm.metadata) -> vector<4xf32>
+    %0 = cir.fadd %a, %b : !cir.vector<4 x !cir.float> {fenv = #cir.fenv<strict_except = true>}
+    cir.return
+  }
+
+  // Unary floating-point builtins with an fenv attribute lower to the matching
+  // constrained intrinsic. Transcendental/arithmetic builtins take a rounding
+  // mode operand; builtins whose rounding is implied (e.g. ceil) take only the
+  // exception-behavior operand. Builtins with no constrained variant (e.g.
+  // fabs) keep the plain LLVM operation.
+  // CHECK-LABEL: llvm.func @unary_fp_builtins
+  cir.func @unary_fp_builtins(%a: !cir.double) {
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.cos"(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, !llvm.metadata, !llvm.metadata) -> f64
+    %0 = cir.cos %a : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.sqrt"(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, !llvm.metadata, !llvm.metadata) -> f64
+    %1 = cir.sqrt %a : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // Rounding-implied builtin: no rounding-mode operand, only exception
+    // behavior.
+    // CHECK: %[[EB:.*]] = llvm.mlir.metadata_as_value #llvm.md_string<"fpexcept.strict">
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.ceil"(%{{.*}}, %[[EB]]) : (f64, !llvm.metadata) -> f64
+    %2 = cir.ceil %a : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // fabs has no constrained variant, so the fenv attribute is dropped.
+    // CHECK: llvm.intr.fabs(%{{.*}}) : (f64) -> f64
+    // CHECK-NOT: constrained
+    %3 = cir.fabs %a : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // Without an fenv attribute the plain builtin lowering is used.
+    // CHECK: llvm.intr.cos(%{{.*}}) : (f64) -> f64
+    %4 = cir.cos %a : !cir.double
+    cir.return
+  }
+
+  // Binary floating-point builtins behave analogously.
+  // CHECK-LABEL: llvm.func @binary_fp_builtins
+  cir.func @binary_fp_builtins(%a: !cir.double, %b: !cir.double) {
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.pow"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %0 = cir.pow %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.atan2"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %1 = cir.atan2 %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // fmod maps to the constrained frem intrinsic.
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.frem"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata, !llvm.metadata) -> f64
+    %2 = cir.fmod %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // fmaximum/fminimum are rounding-implied: only the exception-behavior
+    // operand is passed.
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.maximum"(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata) -> f64
+    %3 = cir.fmaximum %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.minimum"(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata) -> f64
+    %4 = cir.fminimum %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // copysign has no constrained variant, so the fenv attribute is dropped.
+    // CHECK: llvm.intr.copysign(%{{.*}}, %{{.*}}) : (f64, f64) -> f64
+    // CHECK-NOT: constrained
+    %5 = cir.copysign %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    cir.return
+  }
+
+  // fmaxnum/fminnum have a custom no-fenv lowering (llvm.intr.maxnum/minnum with
+  // the nsz fast-math flag). With an fenv attribute they lower to the
+  // constrained maxnum/minnum intrinsics (exception behavior only).
+  // CHECK-LABEL: llvm.func @minmax_num
+  cir.func @minmax_num(%a: !cir.double, %b: !cir.double) {
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.maxnum"(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata) -> f64
+    %0 = cir.fmaxnum %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.call_intrinsic "llvm.experimental.constrained.minnum"(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, !llvm.metadata) -> f64
+    %1 = cir.fminnum %a, %b : !cir.double {fenv = #cir.fenv<strict_except = true>}
+    // CHECK: llvm.intr.maxnum(%{{.*}}, %{{.*}}) {{.*}}: (f64, f64) -> f64
+    // CHECK-NOT: constrained
+    %2 = cir.fmaxnum %a, %b : !cir.double
+    // CHECK: llvm.intr.minnum(%{{.*}}, %{{.*}}) {{.*}}: (f64, f64) -> f64
+    %3 = cir.fminnum %a, %b : !cir.double
+    cir.return
+  }
+}

--- a/clang/test/CIR/Lowering/strictfp.cir
+++ b/clang/test/CIR/Lowering/strictfp.cir
@@ -1,0 +1,28 @@
+// RUN: cir-opt %s -cir-to-llvm -o - | FileCheck %s -check-prefix=MLIR
+// RUN: cir-translate %s -cir-to-llvmir --disable-cc-lowering | FileCheck %s -check-prefix=LLVM
+
+// Functions tagged with the `strictfp` CIR function attribute should be
+// lowered to `llvm.func` operations whose `passthrough` array contains
+// `"strictfp"`, and then translated to LLVM IR functions carrying the
+// `strictfp` attribute.
+
+module {
+  cir.func @strict_fn() attributes {strictfp} {
+    cir.return
+  }
+
+  cir.func @plain_fn() {
+    cir.return
+  }
+}
+
+// MLIR-LABEL: llvm.func @strict_fn()
+// MLIR-SAME:    passthrough = ["strictfp"]
+// MLIR-LABEL: llvm.func @plain_fn()
+// MLIR-NOT:     passthrough
+// MLIR-NOT:     strictfp
+
+// LLVM:       define void @strict_fn() #[[STRICT:[0-9]+]]
+// LLVM-LABEL: define void @plain_fn()
+// LLVM-NOT:     #[[STRICT]]
+// LLVM:       attributes #[[STRICT]] = {{.*}}strictfp

--- a/clang/utils/TableGen/CIRLoweringEmitter.cpp
+++ b/clang/utils/TableGen/CIRLoweringEmitter.cpp
@@ -138,7 +138,10 @@ void GenerateLLVMLoweringPattern(llvm::StringRef OpName,
                                  llvm::StringRef PatternName, bool IsRecursive,
                                  llvm::StringRef ExtraDecl,
                                  const Record *CustomCtorRec,
-                                 llvm::StringRef LLVMOp, bool HasZeroResult) {
+                                 llvm::StringRef LLVMOp,
+                                 llvm::StringRef ConstrainedLLVMIntrinsic,
+                                 bool ConstrainedHasRoundingMode,
+                                 bool HasZeroResult) {
   std::optional<CustomLoweringCtor> CustomCtor =
       parseCustomLoweringCtor(CustomCtorRec);
   std::string CodeBuffer;
@@ -182,7 +185,23 @@ void GenerateLLVMLoweringPattern(llvm::StringRef OpName,
 
   Code << "  }\n\n";
 
-  if (!LLVMOp.empty()) {
+  if (!ConstrainedLLVMIntrinsic.empty()) {
+    // Generate a matchAndRewrite body for a floating-point operation that
+    // carries an optional `fenv` attribute. The shared `lowerConstrainableFPOp`
+    // helper lowers to the plain `llvmOp` when no `fenv` attribute is present
+    // and to a call to the constrained floating-point intrinsic when one is.
+    Code
+        << "  mlir::LogicalResult matchAndRewrite(cir::" << OpName
+        << " op, OpAdaptor adaptor, mlir::ConversionPatternRewriter &rewriter) "
+           "const override {\n";
+    Code << "    return lowerConstrainableFPOp<mlir::LLVM::" << LLVMOp << ">(\n";
+    Code << "        op, adaptor.getOperands(), op.getFenvAttr(),\n";
+    Code << "        *getTypeConverter(), rewriter, \""
+         << ConstrainedLLVMIntrinsic << "\",\n";
+    Code << "        /*hasRoundingMode=*/"
+         << (ConstrainedHasRoundingMode ? "true" : "false") << ");\n";
+    Code << "  }\n";
+  } else if (!LLVMOp.empty()) {
     // Generate the matchAndRewrite body automatically.
     Code
         << "  mlir::LogicalResult matchAndRewrite(cir::" << OpName
@@ -234,6 +253,10 @@ void Generate(const Record *OpRecord) {
         OpRecord->getValueAsString("extraLLVMLoweringPatternDecl");
 
     llvm::StringRef LLVMOp = OpRecord->getValueAsString("llvmOp");
+    llvm::StringRef ConstrainedLLVMIntrinsic =
+        OpRecord->getValueAsString("constrainedLLVMIntrinsic");
+    bool ConstrainedHasRoundingMode =
+        OpRecord->getValueAsBit("constrainedLLVMIntrinsicHasRoundingMode");
 
     if (!LLVMOp.empty() && CustomCtor)
       PrintFatalError(OpRecord->getLoc(),
@@ -241,10 +264,17 @@ void Generate(const Record *OpRecord) {
                           "' has both llvmOp and a custom lowering "
                           "constructor, which is not supported");
 
+    if (!ConstrainedLLVMIntrinsic.empty() && LLVMOp.empty())
+      PrintFatalError(OpRecord->getLoc(),
+                      "op '" + OpName +
+                          "' has constrainedLLVMIntrinsic set but no llvmOp, "
+                          "which is not supported");
+
     const DagInit *ResultsDag = OpRecord->getValueAsDag("results");
     bool IsZeroResult = ResultsDag->getNumArgs() == 0;
     GenerateLLVMLoweringPattern(OpName, PatternName, IsRecursive, ExtraDecl,
-                                CustomCtor, LLVMOp, IsZeroResult);
+                                CustomCtor, LLVMOp, ConstrainedLLVMIntrinsic,
+                                ConstrainedHasRoundingMode, IsZeroResult);
     // Only automatically register patterns that use the default constructor.
     // Patterns with a custom constructor must be manually registered by the
     // lowering pass.


### PR DESCRIPTION
This is a proposed implementation of strict floating-point handling for CIR. If this direction is accepted, I will split the individual commits in this PR out for proper review. I have combined them here so that the entire design can be considered as a whole.

This is a follow-up to my prior [RFC on Discourse](https://discourse.llvm.org/t/rfc-mlir-new-representation-of-floating-point-constraints/91123) proposing a new MLIR representation of floating-point constraints. Based on the feedback I received in my [initial implementation](https://github.com/llvm/llvm-project/pull/205158), I am moving the floating-point environment attribute out to the CIR and Arith dialects and lowering these to existing operations in the LLVM dialect that continue to map directly to the current form of LLVM IR.

This PR shows the CIR implementation. I will post a separate PR for the Arith and Math dialect changes.

This CIR implementation is still incomplete. It does not yet handle floating-point casts or comparisons. I will add those later if this direction is accepted. This implementation is also incorrectly leaving CIR operations marked as Pure when floating-point constraints are set. I'll fix that before anything is committed.

Assisted-by: Cursor / various models