### PR TITLE
[clang] Enable -fstack-clash-protection by default for Android

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3836,8 +3836,10 @@ static void RenderSCPOptions(const ToolChain &TC, const ArgList &Args,
       !EffectiveTriple.isRISCV() && !EffectiveTriple.isLoongArch())
     return;
 
-  Args.addOptInFlag(CmdArgs, options::OPT_fstack_clash_protection,
-                    options::OPT_fno_stack_clash_protection);
+  if (Args.hasFlag(options::OPT_fstack_clash_protection,
+                   options::OPT_fno_stack_clash_protection,
+                   EffectiveTriple.isAndroid()))
+    CmdArgs.push_back("-fstack-clash-protection");
 }
 
 static void RenderTrivialAutoVarInitOptions(const Driver &D,

--- a/clang/test/Driver/stack-clash-protection.c
+++ b/clang/test/Driver/stack-clash-protection.c
@@ -1,29 +1,39 @@
-// RUN: %clang -target i386-unknown-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
-// RUN: %clang -target i386-unknown-linux -fno-stack-clash-protection -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
-// RUN: %clang -target i386-unknown-linux -fstack-clash-protection -fno-stack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=DISABLED --implicit-check-not='"-fstack-clash-protection"'
+// RUN: %clang --target=i386-unknown-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang --target=i386-unknown-linux -fno-stack-clash-protection -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang --target=i386-unknown-linux -fstack-clash-protection -fno-stack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=DISABLED --implicit-check-not='"-fstack-clash-protection"'
 
-// RUN: %clang -target x86_64-scei-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
-// RUN: %clang -target x86_64-unknown-freebsd -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang --target=x86_64-scei-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang --target=x86_64-unknown-freebsd -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
 
+// RUN: %clang --target=x86_64-unknown-linux -### %s 2>&1 | FileCheck %s --check-prefix=DISABLED --implicit-check-not='"-fstack-clash-protection"'
+
+// RUN: %clang --target=aarch64-linux-android -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// 32-bit Arm does not yet support stack clash protection; see
+// https://github.com/llvm/llvm-project/issues/192533.
+// RUN: %clang --target=armv7-linux-androideabi -### %s 2>&1 | FileCheck %s --check-prefix=DISABLED --implicit-check-not='"-fstack-clash-protection"'
+
+// --implicit-check-not needs a positive directive to attach to. "-cc1" also
+// proves a compilation job was emitted, so DISABLED cannot pass merely
+// because clang printed nothing.
 // ENABLED: "-fstack-clash-protection"
 // DISABLED: "-cc1"
 
-// RUN: %clang -target armv7k-apple-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=SCP-armv7 --implicit-check-not='"-fstack-clash-protection"'
+// RUN: %clang --target=armv7k-apple-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=SCP-armv7 --implicit-check-not='"-fstack-clash-protection"'
 // SCP-armv7: argument unused during compilation: '-fstack-clash-protection'
 
-// RUN: %clang -target x86_64-unknown-linux -fstack-clash-protection -S -emit-llvm -o %t.ll %s 2>&1 | FileCheck %s -check-prefix=SCP-warn
+// RUN: %clang --target=x86_64-unknown-linux -fstack-clash-protection -S -emit-llvm -o %t.ll %s 2>&1 | FileCheck %s -check-prefix=SCP-warn
 // SCP-warn: warning: unable to protect inline asm that clobbers stack pointer against stack clash
 
-// RUN: %clang -target x86_64-pc-unknown-linux -fstack-clash-protection -S -emit-llvm -o- %s | FileCheck %s -check-prefix=SCP-ll-linux64
+// RUN: %clang --target=x86_64-pc-unknown-linux -fstack-clash-protection -S -emit-llvm -o- %s | FileCheck %s -check-prefix=SCP-ll-linux64
 // SCP-ll-linux64: attributes {{.*}} "probe-stack"="inline-asm"
 
-// RUN: %clang -target x86_64-pc-windows-msvc -fstack-clash-protection -S -emit-llvm -o- %s 2>&1 | FileCheck %s -check-prefix=SCP-ll-win64
+// RUN: %clang --target=x86_64-pc-windows-msvc -fstack-clash-protection -S -emit-llvm -o- %s 2>&1 | FileCheck %s -check-prefix=SCP-ll-win64
 // SCP-ll-win64-NOT: attributes {{.*}} "probe-stack"="inline-asm"
 // SCP-ll-win64: argument unused during compilation: '-fstack-clash-protection'
 
-// RUN: %clang -target x86_64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
-// RUN: %clang -target aarch64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
-// RUN: %clang -target riscv64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang --target=x86_64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang --target=aarch64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang --target=riscv64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
 
 int foo(int c) {
   int r;

--- a/clang/test/Driver/stack-clash-protection.c
+++ b/clang/test/Driver/stack-clash-protection.c
@@ -1,15 +1,14 @@
-// RUN: %clang -target i386-unknown-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-i386
-// RUN: %clang -target i386-unknown-linux -fno-stack-clash-protection -fstack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-i386
-// RUN: %clang -target i386-unknown-linux -fstack-clash-protection -fno-stack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-i386-NO
-// SCP-i386: "-fstack-clash-protection"
-// SCP-i386-NO-NOT: "-fstack-clash-protection"
+// RUN: %clang -target i386-unknown-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang -target i386-unknown-linux -fno-stack-clash-protection -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang -target i386-unknown-linux -fstack-clash-protection -fno-stack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=DISABLED --implicit-check-not='"-fstack-clash-protection"'
 
-// RUN: %clang -target x86_64-scei-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-x86
-// RUN: %clang -target x86_64-unknown-freebsd -fstack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-x86
-// SCP-x86: "-fstack-clash-protection"
+// RUN: %clang -target x86_64-scei-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang -target x86_64-unknown-freebsd -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
 
-// RUN: %clang -target armv7k-apple-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-armv7
-// SCP-armv7-NOT: "-fstack-clash-protection"
+// ENABLED: "-fstack-clash-protection"
+// DISABLED: "-cc1"
+
+// RUN: %clang -target armv7k-apple-linux -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=SCP-armv7 --implicit-check-not='"-fstack-clash-protection"'
 // SCP-armv7: argument unused during compilation: '-fstack-clash-protection'
 
 // RUN: %clang -target x86_64-unknown-linux -fstack-clash-protection -S -emit-llvm -o %t.ll %s 2>&1 | FileCheck %s -check-prefix=SCP-warn
@@ -22,10 +21,9 @@
 // SCP-ll-win64-NOT: attributes {{.*}} "probe-stack"="inline-asm"
 // SCP-ll-win64: argument unused during compilation: '-fstack-clash-protection'
 
-// RUN: %clang -target x86_64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-FUCHSIA
-// RUN: %clang -target aarch64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-FUCHSIA
-// RUN: %clang -target riscv64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-FUCHSIA
-// SCP-FUCHSIA: "-fstack-clash-protection"
+// RUN: %clang -target x86_64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang -target aarch64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
+// RUN: %clang -target riscv64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s --check-prefix=ENABLED
 
 int foo(int c) {
   int r;


### PR DESCRIPTION
Enable -fstack-clash-protection by default for Android targets on architectures
where Clang already supports stack clash protection, as per the RFC:
https://discourse.llvm.org/t/rfc-enable-fstack-clash-protection-by-default-for-android-targets/91223

AI tools were used to assist with this change; the code and tests were reviewed by the author.