### PR TITLE
[ConstraintElim] Try to get induction step/start/flags from IR (NFC-ish)

### DIFF
--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -974,7 +974,7 @@ void State::addInfoForInductions(BasicBlock &BB) {
     return;
 
   BasicBlock *LoopPred = L->getLoopPredecessor();
-  if (!LoopPred || !L->isLoopInvariant(B) || !SE.isSCEVable(PN->getType()))
+  if (!LoopPred || !L->isLoopInvariant(B))
     return;
 
   Value *StartValue = PN->getIncomingValueForBlock(LoopPred);
@@ -982,25 +982,19 @@ void State::addInfoForInductions(BasicBlock &BB) {
                                ? PN->getIncomingBlock(1)
                                : PN->getIncomingBlock(0);
   Value *Backedge = PN->getIncomingValueForBlock(BackedgeBB);
-  const APInt *StepOffset;
-  // Monotonicity is only used if the step is non-negative, so it reduces to the
-  // induction wrap flags.
-  bool MonotonicallyIncreasingUnsigned, MonotonicallyIncreasingSigned;
+  const APInt *StepOffset = nullptr;
   const SCEV *StartSCEV = nullptr;
+  OverflowingBinaryOperator *Inc = nullptr;
   if (match(Backedge, m_c_Add(m_Specific(PN), m_APInt(StepOffset)))) {
-    auto *Inc = cast<OverflowingBinaryOperator>(Backedge);
-    MonotonicallyIncreasingUnsigned = Inc->hasNoUnsignedWrap();
-    MonotonicallyIncreasingSigned = Inc->hasNoSignedWrap();
+    if (StepOffset->isZero())
+      return;
+    Inc = cast<OverflowingBinaryOperator>(Backedge);
   } else {
     const SCEV *Expr = SE.getSCEV(PN);
     if (!match(Expr,
                m_scev_AffineAddRec(m_SCEV(StartSCEV), m_scev_APInt(StepOffset),
                                    m_SpecificLoop(L))))
       return;
-    MonotonicallyIncreasingUnsigned =
-        cast<SCEVAddRecExpr>(Expr)->hasNoUnsignedWrap();
-    MonotonicallyIncreasingSigned =
-        cast<SCEVAddRecExpr>(Expr)->hasNoSignedWrap();
   }
 
   DomTreeNode *DTN = DT.getNode(InLoopSucc);
@@ -1034,6 +1028,22 @@ void State::addInfoForInductions(BasicBlock &BB) {
         DTN, CmpInst::ICMP_SGT, PN, B,
         ConditionTy(CmpInst::ICMP_SLE, B, StartValue)));
     return;
+  }
+
+  // Monotonicity is only used if the step is non-negative. If Inc is set it
+  // reduces to the induction wrap flags. If that fails, try to refine via SCEV.
+  bool MonotonicallyIncreasingUnsigned = Inc && Inc->hasNoUnsignedWrap();
+  bool MonotonicallyIncreasingSigned = Inc && Inc->hasNoSignedWrap();
+  if (!(MonotonicallyIncreasingUnsigned && MonotonicallyIncreasingSigned)) {
+    const SCEVAddRecExpr *IndAR = cast<SCEVAddRecExpr>(SE.getSCEV(PN));
+    if (!MonotonicallyIncreasingUnsigned)
+      MonotonicallyIncreasingUnsigned =
+          SE.getMonotonicPredicateType(IndAR, CmpInst::ICMP_UGT) ==
+          ScalarEvolution::MonotonicallyIncreasing;
+    if (!MonotonicallyIncreasingSigned)
+      MonotonicallyIncreasingSigned =
+          SE.getMonotonicPredicateType(IndAR, CmpInst::ICMP_SGT) ==
+          ScalarEvolution::MonotonicallyIncreasing;
   }
 
   // If the induction is known not to wrap, PN >= StartValue can be added

--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/ScalarEvolutionExpressions.h"
+#include "llvm/Analysis/ScalarEvolutionPatternMatch.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/DataLayout.h"
@@ -48,6 +49,7 @@
 
 using namespace llvm;
 using namespace PatternMatch;
+using namespace SCEVPatternMatch;
 
 #define DEBUG_TYPE "constraint-elimination"
 
@@ -972,53 +974,46 @@ void State::addInfoForInductions(BasicBlock &BB) {
     return;
 
   BasicBlock *LoopPred = L->getLoopPredecessor();
-  if (!LoopPred || !L->isLoopInvariant(B))
+  if (!LoopPred || !L->isLoopInvariant(B) || !SE.isSCEVable(PN->getType()))
     return;
 
-  auto *AR = dyn_cast_or_null<SCEVAddRecExpr>(SE.getSCEV(PN));
-  if (!AR || AR->getLoop() != L)
-    return;
-
-  const SCEV *StartSCEV = AR->getStart();
-  Value *StartValue = nullptr;
-  if (auto *C = dyn_cast<SCEVConstant>(StartSCEV)) {
-    StartValue = C->getValue();
+  Value *StartValue = PN->getIncomingValueForBlock(LoopPred);
+  BasicBlock *BackedgeBB = PN->getIncomingBlock(0) == LoopPred
+                               ? PN->getIncomingBlock(1)
+                               : PN->getIncomingBlock(0);
+  Value *Backedge = PN->getIncomingValueForBlock(BackedgeBB);
+  const APInt *StepOffset;
+  // Monotonicity is only used if the step is non-negative, so it reduces to the
+  // induction wrap flags.
+  bool MonotonicallyIncreasingUnsigned, MonotonicallyIncreasingSigned;
+  const SCEV *StartSCEV = nullptr;
+  if (match(Backedge, m_c_Add(m_Specific(PN), m_APInt(StepOffset)))) {
+    auto *Inc = cast<OverflowingBinaryOperator>(Backedge);
+    MonotonicallyIncreasingUnsigned = Inc->hasNoUnsignedWrap();
+    MonotonicallyIncreasingSigned = Inc->hasNoSignedWrap();
   } else {
-    StartValue = PN->getIncomingValueForBlock(LoopPred);
-    assert(SE.getSCEV(StartValue) == StartSCEV && "inconsistent start value");
+    const SCEV *Expr = SE.getSCEV(PN);
+    if (!match(Expr,
+               m_scev_AffineAddRec(m_SCEV(StartSCEV), m_scev_APInt(StepOffset),
+                                   m_SpecificLoop(L))))
+      return;
+    MonotonicallyIncreasingUnsigned =
+        cast<SCEVAddRecExpr>(Expr)->hasNoUnsignedWrap();
+    MonotonicallyIncreasingSigned =
+        cast<SCEVAddRecExpr>(Expr)->hasNoSignedWrap();
   }
 
   DomTreeNode *DTN = DT.getNode(InLoopSucc);
-  auto IncUnsigned = SE.getMonotonicPredicateType(AR, CmpInst::ICMP_UGT);
-  auto IncSigned = SE.getMonotonicPredicateType(AR, CmpInst::ICMP_SGT);
-  bool MonotonicallyIncreasingUnsigned =
-      IncUnsigned == ScalarEvolution::MonotonicallyIncreasing;
-  bool MonotonicallyIncreasingSigned =
-      IncSigned == ScalarEvolution::MonotonicallyIncreasing;
-  // If SCEV guarantees that AR does not wrap, PN >= StartValue can be added
-  // unconditionally.
-  if (MonotonicallyIncreasingUnsigned)
-    WorkList.push_back(
-        FactOrCheck::getConditionFact(DTN, CmpInst::ICMP_UGE, PN, StartValue));
-  if (MonotonicallyIncreasingSigned)
-    WorkList.push_back(
-        FactOrCheck::getConditionFact(DTN, CmpInst::ICMP_SGE, PN, StartValue));
-
-  APInt StepOffset;
-  if (auto *C = dyn_cast<SCEVConstant>(AR->getStepRecurrence(SE)))
-    StepOffset = C->getAPInt();
-  else
-    return;
 
   // If we looked through `PN + C`, only derive facts when that add is
   // really the induction's post-increment.
-  if (IncStep && (*IncStep != StepOffset || StepOffset.isNegative()))
+  if (IncStep && (*IncStep != *StepOffset || StepOffset->isNegative()))
     return;
 
   // Handle negative steps.
-  if (StepOffset.isNegative()) {
+  if (StepOffset->isNegative()) {
     // TODO: Extend to allow steps > -1.
-    if (!(-StepOffset).isOne())
+    if (!(-*StepOffset).isOne())
       return;
 
     // AR may wrap.
@@ -1041,17 +1036,28 @@ void State::addInfoForInductions(BasicBlock &BB) {
     return;
   }
 
+  // If the induction is known not to wrap, PN >= StartValue can be added
+  // unconditionally.
+  if (MonotonicallyIncreasingUnsigned)
+    WorkList.push_back(
+        FactOrCheck::getConditionFact(DTN, CmpInst::ICMP_UGE, PN, StartValue));
+  if (MonotonicallyIncreasingSigned)
+    WorkList.push_back(
+        FactOrCheck::getConditionFact(DTN, CmpInst::ICMP_SGE, PN, StartValue));
+
   // Make sure AR either steps by 1 or that the value we compare against is a
   // GEP based on the same start value and all offsets are a multiple of the
   // step size, to guarantee that the induction will reach the value.
-  if (StepOffset.isZero() || StepOffset.isNegative())
+  if (StepOffset->isZero() || StepOffset->isNegative())
     return;
 
-  if (!StepOffset.isOne()) {
+  if (!StepOffset->isOne()) {
     // Check whether B-Start is known to be a multiple of StepOffset.
+    if (!StartSCEV)
+      StartSCEV = SE.getSCEV(StartValue);
     const SCEV *BMinusStart = SE.getMinusSCEV(SE.getSCEV(B), StartSCEV);
     if (isa<SCEVCouldNotCompute>(BMinusStart) ||
-        !SE.getConstantMultiple(BMinusStart).urem(StepOffset).isZero())
+        !SE.getConstantMultiple(BMinusStart).urem(*StepOffset).isZero())
       return;
   }
 
@@ -1062,7 +1068,7 @@ void State::addInfoForInductions(BasicBlock &BB) {
     if (!StartC)
       return;
     bool Overflow = false;
-    APInt Sum = StartC->getValue().uadd_ov(StepOffset, Overflow);
+    APInt Sum = StartC->getValue().uadd_ov(*StepOffset, Overflow);
     if (Overflow)
       return;
     LowerBound = ConstantInt::get(StartValue->getType(), Sum);
@@ -1092,7 +1098,7 @@ void State::addInfoForInductions(BasicBlock &BB) {
   // Try to add condition from header to the dedicated exit blocks. When exiting
   // either with EQ or NE in the header, we know that the induction value must
   // be u<= B, as other exits may only exit earlier.
-  assert(!StepOffset.isNegative() && "induction must be increasing");
+  assert(!StepOffset->isNegative() && "induction must be increasing");
   assert((Pred == CmpInst::ICMP_EQ || Pred == CmpInst::ICMP_NE) &&
          "unsupported predicate");
   ConditionTy Precond = {CmpInst::ICMP_ULE, LowerBound, B};

--- a/llvm/test/Transforms/ConstraintElimination/induction-nowrap-from-scev-not-ir.ll
+++ b/llvm/test/Transforms/ConstraintElimination/induction-nowrap-from-scev-not-ir.ll
@@ -64,4 +64,117 @@ exit:
   ret void
 }
 
+define void @zero_step_constant_start(i32 %n) {
+; CHECK-LABEL: define void @zero_step_constant_start(
+; CHECK-SAME: i32 [[N:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[LOOP:.*]]
+; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[IV_NEXT:%.*]], %[[LATCH:.*]] ]
+; CHECK-NEXT:    [[C:%.*]] = icmp ne i32 [[IV]], [[N]]
+; CHECK-NEXT:    br i1 [[C]], label %[[LATCH]], label %[[EXIT:.*]]
+; CHECK:       [[LATCH]]:
+; CHECK-NEXT:    [[IV_NEXT]] = add i32 [[IV]], 0
+; CHECK-NEXT:    br label %[[LOOP]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %latch ]
+  %c = icmp ne i32 %iv, %n
+  br i1 %c, label %latch, label %exit
+
+latch:
+  %iv.next = add i32 %iv, 0
+  br label %loop
+
+exit:
+  ret void
+}
+
+define void @zero_step_unknown_start(i32 %n, i32 %start) {
+; CHECK-LABEL: define void @zero_step_unknown_start(
+; CHECK-SAME: i32 [[N:%.*]], i32 [[START:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[LOOP:.*]]
+; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ [[START]], %[[ENTRY]] ], [ [[IV_NEXT:%.*]], %[[LATCH:.*]] ]
+; CHECK-NEXT:    [[C:%.*]] = icmp ne i32 [[IV]], [[N]]
+; CHECK-NEXT:    br i1 [[C]], label %[[LATCH]], label %[[EXIT:.*]]
+; CHECK:       [[LATCH]]:
+; CHECK-NEXT:    [[IV_NEXT]] = add i32 [[IV]], 0
+; CHECK-NEXT:    br label %[[LOOP]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i32 [ %start, %entry ], [ %iv.next, %latch ]
+  %c = icmp ne i32 %iv, %n
+  br i1 %c, label %latch, label %exit
+
+latch:
+  %iv.next = add i32 %iv, 0
+  br label %loop
+
+exit:
+  ret void
+}
+
+define void @zero_step_addrec_of_outer_loop(i32 %n) {
+; CHECK-LABEL: define void @zero_step_addrec_of_outer_loop(
+; CHECK-SAME: i32 [[N:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[OUTER:.*]]
+; CHECK:       [[OUTER]]:
+; CHECK-NEXT:    [[O:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[O_NEXT:%.*]], %[[OUTER_LATCH:.*]] ]
+; CHECK-NEXT:    br label %[[INNER:.*]]
+; CHECK:       [[INNER]]:
+; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ [[O]], %[[OUTER]] ], [ [[IV_NEXT:%.*]], %[[INNER_LATCH:.*]] ]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[IV]], [[N]]
+; CHECK-NEXT:    br i1 [[CMP]], label %[[INNER_LATCH]], label %[[OUTER_LATCH]]
+; CHECK:       [[INNER_LATCH]]:
+; CHECK-NEXT:    [[T:%.*]] = icmp uge i32 [[IV]], [[O]]
+; CHECK-NEXT:    call void @use(i1 [[T]])
+; CHECK-NEXT:    [[IV_NEXT]] = add i32 [[IV]], 0
+; CHECK-NEXT:    br label %[[INNER]]
+; CHECK:       [[OUTER_LATCH]]:
+; CHECK-NEXT:    [[O_NEXT]] = add i32 [[O]], 1
+; CHECK-NEXT:    [[CMP_O:%.*]] = icmp ne i32 [[O]], [[N]]
+; CHECK-NEXT:    br i1 [[CMP_O]], label %[[OUTER]], label %[[EXIT:.*]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br label %outer
+
+outer:
+  %o = phi i32 [ 0, %entry ], [ %o.next, %outer.latch ]
+  br label %inner
+
+inner:
+  %iv = phi i32 [ %o, %outer ], [ %iv.next, %inner.latch ]
+  %cmp = icmp ne i32 %iv, %n
+  br i1 %cmp, label %inner.latch, label %outer.latch
+
+inner.latch:
+  %t = icmp uge i32 %iv, %o
+  call void @use(i1 %t)
+  %iv.next = add i32 %iv, 0
+  br label %inner
+
+outer.latch:
+  %o.next = add i32 %o, 1
+  %cmp.o = icmp ne i32 %o, %n
+  br i1 %cmp.o, label %outer, label %exit
+
+exit:
+  ret void
+}
+
 declare void @use(i32)

--- a/llvm/test/Transforms/ConstraintElimination/monotonic-int-phis-wrapping.ll
+++ b/llvm/test/Transforms/ConstraintElimination/monotonic-int-phis-wrapping.ll
@@ -96,7 +96,8 @@ define void @test_iv_nuw_nsw_2_uge_start(i8 %len.n, i8 %a) {
 ; CHECK-NEXT:    [[C_2:%.*]] = call i1 @cond()
 ; CHECK-NEXT:    br i1 [[C_2]], label [[LOOP_LATCH]], label [[EXIT]]
 ; CHECK:       loop.latch:
-; CHECK-NEXT:    call void @use.i1(i1 true)
+; CHECK-NEXT:    [[T_1:%.*]] = icmp uge i8 [[IV]], -1
+; CHECK-NEXT:    call void @use.i1(i1 [[T_1]])
 ; CHECK-NEXT:    [[IV_NEXT]] = add nuw nsw i8 [[IV]], 1
 ; CHECK-NEXT:    br label [[LOOP_HEADER]]
 ; CHECK:       exit:


### PR DESCRIPTION
Handle the common integer inductions where the increment is plain add PN, C by looking at IR instead of querying SCEV. There's effectively no re-use between SCEV expression created in ConstraintElimination, and handling simple cases in IR can avoid unnecessary, expensive SCEV queries.

Should be NFC-ish. We miss trivial folding of the start value (see regressed test), but that should not happen in end-to-end pipeline.

Improves compile-time for some workloads, ClamAV, mafft: https://llvm-compile-time-tracker.com/compare.php?from=b8ba3c2b72cb53268129bbecfeb4ba7ec5b8d831&to=2bede223d3ec3ed6e2e9654b635258c50e4e90df&stat=instructions%3Au

I am working on follow-up changes that will handle more cases, where avoiding unnecessary queries will be more important.