### PR TITLE
[lldb] Add MCP tools to create and destroy debugger instances

### DIFF
--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
@@ -50,12 +50,20 @@ llvm::StringRef ProtocolServerMCP::GetPluginDescriptionStatic() {
   return "MCP Server.";
 }
 
-void ProtocolServerMCP::Extend(lldb_protocol::mcp::Server &server) const {
+void lldb_private::mcp::PopulateServer(lldb_protocol::mcp::Server &server) {
   server.AddTool(
       std::make_unique<CommandTool>("command", "Run an lldb command."));
   server.AddTool(std::make_unique<DebuggerListTool>(
       "debugger_list", "List debugger instances with their debugger_id."));
+  server.AddTool(std::make_unique<DebuggerCreateTool>(
+      "debugger_create", "Create a new debugger instance and return its URI."));
+  server.AddTool(std::make_unique<DebuggerDeleteTool>(
+      "debugger_delete", "Destroy a debugger instance by id or URI."));
   server.AddResourceProvider(std::make_unique<DebuggerResourceProvider>());
+}
+
+void ProtocolServerMCP::Extend(lldb_protocol::mcp::Server &server) const {
+  PopulateServer(server);
 }
 
 void ProtocolServerMCP::AcceptCallback(std::unique_ptr<Socket> socket) {

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
@@ -23,6 +23,11 @@
 
 namespace lldb_private::mcp {
 
+/// Installs the standard LLDB tool and resource-provider set on \p server.
+/// Sharing one installer keeps every MCP server consistent, whether it runs in
+/// the plugin or is hosted in-process by an embedder.
+void PopulateServer(lldb_protocol::mcp::Server &server);
+
 class ProtocolServerMCP : public ProtocolServer {
 
   using ServerUP = std::unique_ptr<lldb_protocol::mcp::Server>;

--- a/lldb/source/Plugins/Protocol/MCP/Tool.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Tool.cpp
@@ -8,9 +8,12 @@
 
 #include "Tool.h"
 #include "lldb/Core/Debugger.h"
+#include "lldb/Host/File.h"
+#include "lldb/Host/FileSystem.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "lldb/Protocol/MCP/Protocol.h"
+#include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/UriParser.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
@@ -146,4 +149,79 @@ DebuggerListTool::Call(const lldb_protocol::mcp::ToolArguments &args) {
   }
 
   return createTextResult(output);
+}
+
+/// Opens the platform null device with the given options, or nullptr on error.
+static lldb::FileSP openNull(File::OpenOptions options) {
+  llvm::Expected<lldb::FileUP> file =
+      FileSystem::Instance().Open(FileSpec(FileSystem::DEV_NULL), options);
+  if (!file) {
+    llvm::consumeError(file.takeError());
+    return nullptr;
+  }
+  return std::move(*file);
+}
+
+Expected<lldb_protocol::mcp::CallToolResult>
+DebuggerCreateTool::Call(const lldb_protocol::mcp::ToolArguments &) {
+  // Redirect the new debugger's stdio to the null device so its prompt and
+  // async output can't corrupt an MCP stream sharing the host's stdout. Command
+  // results flow through CommandReturnObject and are unaffected. Open the null
+  // files first so a failure can't leave a created debugger on the real stdio.
+  lldb::FileSP in = openNull(File::eOpenOptionReadOnly);
+  lldb::FileSP out = openNull(File::eOpenOptionWriteOnly);
+  lldb::FileSP err = openNull(File::eOpenOptionWriteOnly);
+  if (!in || !out || !err)
+    return createStringError(
+        "failed to open the null device for debugger stdio");
+
+  lldb::DebuggerSP debugger_sp = Debugger::CreateInstance();
+  if (!debugger_sp)
+    return createStringError("failed to create debugger");
+
+  debugger_sp->SetInputFile(in);
+  debugger_sp->SetOutputFile(out);
+  debugger_sp->SetErrorFile(err);
+
+  return createTextResult(to_uri(debugger_sp));
+}
+
+Expected<lldb_protocol::mcp::CallToolResult>
+DebuggerDeleteTool::Call(const lldb_protocol::mcp::ToolArguments &args) {
+  if (!std::holds_alternative<json::Value>(args))
+    return createStringError("DebuggerDeleteTool requires arguments");
+
+  const json::Object *arguments = std::get<json::Value>(args).getAsObject();
+  if (!arguments)
+    return createStringError("DebuggerDeleteTool requires arguments");
+
+  std::optional<StringRef> debugger = arguments->getString("debugger");
+  if (!debugger)
+    return createStringError("DebuggerDeleteTool requires a debugger");
+
+  StringRef specifier = *debugger;
+  specifier.consume_front(kSchemeAndHost);
+  uint32_t debugger_id = 0;
+  if (specifier.consumeInteger(10, debugger_id))
+    return createStringError(
+        formatv("malformed debugger specifier {0}", *debugger));
+
+  lldb::DebuggerSP debugger_sp = Debugger::FindDebuggerWithID(debugger_id);
+  if (!debugger_sp)
+    return createStringError("no debugger found");
+
+  Debugger::Destroy(debugger_sp);
+  return createTextResult(formatv("deleted {0}", *debugger).str());
+}
+
+std::optional<json::Value> DebuggerDeleteTool::GetSchema() const {
+  using namespace llvm::json;
+  Object properties{
+      {"debugger",
+       Object{{"type", "string"},
+              {"description", "The debugger ID or URI to destroy."}}}};
+  Object schema{{"type", "object"},
+                {"properties", std::move(properties)},
+                {"required", Array{"debugger"}}};
+  return schema;
 }

--- a/lldb/source/Plugins/Protocol/MCP/Tool.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Tool.cpp
@@ -168,10 +168,10 @@ DebuggerCreateTool::Call(const lldb_protocol::mcp::ToolArguments &) {
   // async output can't corrupt an MCP stream sharing the host's stdout. Command
   // results flow through CommandReturnObject and are unaffected. Open the null
   // files first so a failure can't leave a created debugger on the real stdio.
+  // The single write-only null file backs both stdout and stderr.
   lldb::FileSP in = openNull(File::eOpenOptionReadOnly);
   lldb::FileSP out = openNull(File::eOpenOptionWriteOnly);
-  lldb::FileSP err = openNull(File::eOpenOptionWriteOnly);
-  if (!in || !out || !err)
+  if (!in || !out)
     return createStringError(
         "failed to open the null device for debugger stdio");
 
@@ -181,7 +181,7 @@ DebuggerCreateTool::Call(const lldb_protocol::mcp::ToolArguments &) {
 
   debugger_sp->SetInputFile(in);
   debugger_sp->SetOutputFile(out);
-  debugger_sp->SetErrorFile(err);
+  debugger_sp->SetErrorFile(out);
 
   return createTextResult(to_uri(debugger_sp));
 }

--- a/lldb/source/Plugins/Protocol/MCP/Tool.h
+++ b/lldb/source/Plugins/Protocol/MCP/Tool.h
@@ -37,6 +37,26 @@ public:
   Call(const lldb_protocol::mcp::ToolArguments &args) override;
 };
 
+class DebuggerCreateTool : public lldb_protocol::mcp::Tool {
+public:
+  using lldb_protocol::mcp::Tool::Tool;
+  ~DebuggerCreateTool() = default;
+
+  llvm::Expected<lldb_protocol::mcp::CallToolResult>
+  Call(const lldb_protocol::mcp::ToolArguments &args) override;
+};
+
+class DebuggerDeleteTool : public lldb_protocol::mcp::Tool {
+public:
+  using lldb_protocol::mcp::Tool::Tool;
+  ~DebuggerDeleteTool() = default;
+
+  llvm::Expected<lldb_protocol::mcp::CallToolResult>
+  Call(const lldb_protocol::mcp::ToolArguments &args) override;
+
+  std::optional<llvm::json::Value> GetSchema() const override;
+};
+
 } // namespace lldb_private::mcp
 
 #endif

--- a/lldb/unittests/Protocol/MCPPluginTest.cpp
+++ b/lldb/unittests/Protocol/MCPPluginTest.cpp
@@ -387,6 +387,10 @@ TEST_F(MCPPluginTest, DebuggerCreateTool) {
   EXPECT_NE(created->GetOutputFileSP()->GetDescriptor(), fileno(stdout));
   EXPECT_NE(created->GetErrorFileSP()->GetDescriptor(), fileno(stderr));
 
+  // stdout and stderr are backed by the same write-only null file.
+  EXPECT_EQ(created->GetOutputFileSP()->GetDescriptor(),
+            created->GetErrorFileSP()->GetDescriptor());
+
   Debugger::Destroy(created); // Don't leak into other tests.
 }
 

--- a/lldb/unittests/Protocol/MCPPluginTest.cpp
+++ b/lldb/unittests/Protocol/MCPPluginTest.cpp
@@ -31,6 +31,7 @@
 #include "llvm/Testing/Support/Error.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <cstdio>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -355,6 +356,78 @@ TEST_F(MCPPluginTest, DebuggerListTool) {
 }
 
 //===----------------------------------------------------------------------===//
+// DebuggerCreateTool / DebuggerDeleteTool
+//===----------------------------------------------------------------------===//
+
+TEST_F(MCPPluginTest, DebuggerCreateTool) {
+  const size_t before = Debugger::GetNumDebuggers();
+
+  DebuggerCreateTool tool("debugger_create", "Create a debugger.");
+  ToolArguments args;
+  Expected<CallToolResult> result = tool.Call(args);
+  ASSERT_THAT_EXPECTED(result, Succeeded());
+  EXPECT_FALSE(result->isError);
+  ASSERT_EQ(result->content.size(), 1u);
+
+  StringRef uri = result->content[0].text;
+  EXPECT_TRUE(uri.consume_front("lldb-mcp://debugger/"));
+  uint32_t id = 0;
+  ASSERT_FALSE(uri.consumeInteger(10, id));
+  EXPECT_EQ(Debugger::GetNumDebuggers(), before + 1);
+
+  DebuggerSP created = Debugger::FindDebuggerWithID(id);
+  ASSERT_TRUE(created);
+
+  // The new debugger's stdio was detached from the host process's real streams
+  // so its output can't corrupt an MCP stream sharing that stdout.
+  ASSERT_TRUE(created->GetInputFileSP());
+  ASSERT_TRUE(created->GetOutputFileSP());
+  ASSERT_TRUE(created->GetErrorFileSP());
+  EXPECT_NE(created->GetInputFileSP()->GetDescriptor(), fileno(stdin));
+  EXPECT_NE(created->GetOutputFileSP()->GetDescriptor(), fileno(stdout));
+  EXPECT_NE(created->GetErrorFileSP()->GetDescriptor(), fileno(stderr));
+
+  Debugger::Destroy(created); // Don't leak into other tests.
+}
+
+TEST_F(MCPPluginTest, DebuggerDeleteTool) {
+  DebuggerSP victim = Debugger::CreateInstance();
+  ASSERT_TRUE(victim);
+  const user_id_t id = victim->GetID();
+  victim.reset(); // The debugger list keeps it alive.
+
+  DebuggerDeleteTool tool("debugger_delete", "Destroy a debugger.");
+  ToolArguments args = json::Value(
+      json::Object{{"debugger", formatv("lldb-mcp://debugger/{0}", id).str()}});
+  Expected<CallToolResult> result = tool.Call(args);
+  ASSERT_THAT_EXPECTED(result, Succeeded());
+  EXPECT_FALSE(result->isError);
+  EXPECT_FALSE(Debugger::FindDebuggerWithID(id));
+}
+
+TEST_F(MCPPluginTest, DebuggerDeleteToolRequiresDebugger) {
+  DebuggerDeleteTool tool("debugger_delete", "Destroy a debugger.");
+  ToolArguments args = json::Value(json::Object{});
+  EXPECT_THAT_EXPECTED(
+      tool.Call(args),
+      FailedWithMessage("DebuggerDeleteTool requires a debugger"));
+}
+
+TEST_F(MCPPluginTest, DebuggerDeleteToolUnknownDebugger) {
+  DebuggerDeleteTool tool("debugger_delete", "Destroy a debugger.");
+  ToolArguments args = json::Value(json::Object{{"debugger", "999999"}});
+  EXPECT_THAT_EXPECTED(tool.Call(args), FailedWithMessage("no debugger found"));
+}
+
+TEST_F(MCPPluginTest, DebuggerDeleteToolMalformedDebugger) {
+  DebuggerDeleteTool tool("debugger_delete", "Destroy a debugger.");
+  ToolArguments args = json::Value(json::Object{{"debugger", "notanumber"}});
+  EXPECT_THAT_EXPECTED(
+      tool.Call(args),
+      FailedWithMessage("malformed debugger specifier notanumber"));
+}
+
+//===----------------------------------------------------------------------===//
 // ProtocolServerMCP
 //===----------------------------------------------------------------------===//
 
@@ -369,8 +442,7 @@ public:
 TEST_F(MCPPluginTest, ProtocolServerExtend) {
   ExtendableProtocolServerMCP server;
   lldb_protocol::mcp::Server mcp_server("lldb-mcp", "0.1.0");
-  // Extend registers the "command" and "debugger_list" tools and the debugger
-  // resource provider on the server.
+  // Extend registers the MCP tools and resource providers on the server.
   server.Extend(mcp_server);
 }
 


### PR DESCRIPTION
Add debugger_create and debugger_delete tools to the MCP server so a client can manage debugger instances, not just command the ones that already exist. debugger_create detaches the new debugger's stdio from the host process (redirecting input/output/error to the null device) so its prompt and asynchronous output cannot corrupt an MCP stream that shares the host's stdout. Command results flow through CommandReturnObject and are unaffected.

Factor the tool and resource registration out of ProtocolServerMCP::Extend into a shared PopulateServer() so an embedded in-process server (e.g. in lldb-mcp) can install the same set.

Assisted-by: Claude

rdar://181722721