### PR TITLE
[libc] Define NAME_MAX in limits.h

### DIFF
--- a/libc/include/limits.yaml
+++ b/libc/include/limits.yaml
@@ -78,6 +78,8 @@ macros:
     macro_header: limits-macros.h
   - macro_name: _POSIX_PATH_MAX
     macro_header: limits-macros.h
+  - macro_name: NAME_MAX
+    macro_header: limits-macros.h
   - macro_name: PATH_MAX
     macro_header: limits-macros.h
   - macro_name: _POSIX_THREAD_DESTRUCTOR_ITERATIONS

--- a/libc/include/llvm-libc-macros/limits-macros.h
+++ b/libc/include/llvm-libc-macros/limits-macros.h
@@ -248,10 +248,16 @@
 #endif
 
 #ifdef __linux__
+
 #ifndef PATH_MAX
 #define PATH_MAX 4096
-#endif
-#endif
+#endif // PATH_MAX
+
+#ifndef NAME_MAX
+#define NAME_MAX 255
+#endif // NAME_MAX
+
+#endif // __linux__
 
 #ifndef _POSIX_ARG_MAX
 #define _POSIX_ARG_MAX 4096


### PR DESCRIPTION
Defines the POSIX macro `NAME_MAX`. Will be used by `realpath` tests.