### PR TITLE
[openmp] Apply a mingw/64 bit codepath to arm64ec too

### DIFF
--- a/openmp/runtime/src/kmp_utility.cpp
+++ b/openmp/runtime/src/kmp_utility.cpp
@@ -306,7 +306,8 @@ void __kmp_expand_file_name(char *result, size_t rlen, char *pattern) {
         case 'I':
         case 'i': {
           pid_t id = getpid();
-#if (KMP_ARCH_X86_64 || KMP_ARCH_AARCH64) && defined(__MINGW32__)
+#if (KMP_ARCH_X86_64 || KMP_ARCH_AARCH64 || KMP_ARCH_ARM64EC) &&               \
+    defined(__MINGW32__)
           snp_result = KMP_SNPRINTF(pos, end - pos + 1, "%0*lld", width, id);
 #else
           snp_result = KMP_SNPRINTF(pos, end - pos + 1, "%0*d", width, id);


### PR DESCRIPTION
When targeting arm64ec, neither KMP_ARCH_X86_64 nor KMP_ARCH_AARCH64 is defined.

This fixes a compilation warning when building openmp for mingw/arm64ec.