### PR TITLE
[ProfileData] Remove clear() from SampleProfileFuncOffsetTable (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -943,6 +943,12 @@ public:
       llvm::OnDiskIterableChainedHashTable<FuncOffsetHashTableInfo>;
 
   SampleProfileFuncOffsetTable() = delete;
+  SampleProfileFuncOffsetTable(const SampleProfileFuncOffsetTable &) = delete;
+  SampleProfileFuncOffsetTable &
+  operator=(const SampleProfileFuncOffsetTable &) = delete;
+  SampleProfileFuncOffsetTable(SampleProfileFuncOffsetTable &&) = delete;
+  SampleProfileFuncOffsetTable &
+  operator=(SampleProfileFuncOffsetTable &&) = delete;
 
   explicit SampleProfileFuncOffsetTable(InMemoryModeT,
                                         size_t InitialCapacity = 0) {

--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -942,6 +942,8 @@ public:
   using OnDiskTableType =
       llvm::OnDiskIterableChainedHashTable<FuncOffsetHashTableInfo>;
 
+  SampleProfileFuncOffsetTable() = delete;
+
   explicit SampleProfileFuncOffsetTable(InMemoryModeT,
                                         size_t InitialCapacity = 0) {
     InMemoryTable.reserve(InitialCapacity);
@@ -974,12 +976,6 @@ public:
         return Iter->second;
     }
     return std::nullopt;
-  }
-
-  /// Clear the in-memory map and release the on-disk table.
-  void clear() {
-    InMemoryTable.clear();
-    OnDiskTable.reset();
   }
 
 private:

--- a/llvm/unittests/ProfileData/SampleProfTest.cpp
+++ b/llvm/unittests/ProfileData/SampleProfTest.cpp
@@ -608,10 +608,6 @@ TEST_F(SampleProfTest, SampleProfileFuncOffsetTableInMemory) {
   EXPECT_EQ(Table.lookup(0x11112222ULL), 100);
   EXPECT_EQ(Table.lookup(0x33334444ULL), 200);
   EXPECT_EQ(Table.lookup(0x55556666ULL), std::nullopt);
-
-  // Test clear
-  Table.clear();
-  EXPECT_EQ(Table.lookup(0x11112222ULL), std::nullopt);
 }
 
 TEST_F(SampleProfTest, SampleProfileFuncOffsetTableOnDisk) {
@@ -651,10 +647,6 @@ TEST_F(SampleProfTest, SampleProfileFuncOffsetTableOnDisk) {
 
   // Test non-existent key
   EXPECT_EQ(Table.lookup(0x9999999999999999ULL), std::nullopt);
-
-  // Test clear
-  Table.clear();
-  EXPECT_EQ(Table.lookup(0x1111111122222222ULL), std::nullopt);
 }
 
 // Verify that requesting format version 103 results in a version 103 profile.


### PR DESCRIPTION
This patch deletes the default constructor of
SampleProfileFuncOffsetTable and removes its clear() method.

SampleProfileFuncOffsetTable is designed to lock its operational mode
(in-memory or on-disk) strictly at construction time and remain valid
throughout its lifetime. By deleting the default constructor and
removing clear(), we ensure that an instance never enters an
uninitialized or cleared state while kept alive.

When SampleProfileReader needs to discard or reload the table, it
resets and replaces the wrapping std::optional directly instead of
clearing the table in-place.

Assisted-by: Antigravity
