### PR TITLE
[libunwind][test][AIX] Add C API test for unwinding from AIX VAPI (non-signal-handler case)

### DIFF
--- a/libunwind/test/CMakeLists.txt
+++ b/libunwind/test/CMakeLists.txt
@@ -27,6 +27,7 @@ endforeach()
 
 pythonize_bool(HAVE_GETAUXVAL)
 pythonize_bool(HAVE_ELF_AUX_INFO)
+pythonize_bool(LIBUNWIND_ENABLE_ASSERTIONS)
 pythonize_bool(LIBUNWIND_ENABLE_CET)
 pythonize_bool(LIBUNWIND_ENABLE_GCS)
 pythonize_bool(LIBUNWIND_ENABLE_THREADS)

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -12,8 +12,10 @@
 // ADDITIONAL_COMPILE_FLAGS: -fno-inline -fno-exceptions
 
 // RUN: %{build}
-// RUN: %{exec} %t.exe \
-// RUN:     %if libunwind-assertions-enabled %{ 2>&1 | FileCheck %s %}
+// RUN: %{exec} %t.exe 2>&1 \
+// RUN: | FileCheck --check-prefix=CHECK \
+// RUN:       %if libunwind-assertions-enabled %{ --check-prefix=DEBUG %} \
+// RUN:       %s
 
 // Tests use of the libunwind C API to step up from a context where the VAPI is
 // active and to resume contexts where
@@ -62,20 +64,20 @@ extern "C" int cmp(const void *pa, const void *pb) {
   if (!llu_enabled)
     fprintf(stderr,
             "libunwind: the next return address=VAPI_NOT_ENABLED from VAPI\n");
-  // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=cmp
-  // CHECK: libunwind: the next return address=[[VAPI_RA:[^ ]*]] from VAPI
+  // DEBUG-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=cmp
+  // DEBUG: libunwind: the next return address=[[VAPI_RA:[^ ]*]] from VAPI
   bsearch_cursor = cursor;
   // Step from `bsearch` up to `bsearch_caller`.
   unw_step(&cursor);
   if (!llu_enabled)
     fprintf(stderr, "libunwind: return address=VAPI_NOT_ENABLED from VAPI\n");
-  // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=bsearch
-  // CHECK: libunwind: return address=[[VAPI_RA]] from VAPI
+  // DEBUG-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=bsearch
+  // DEBUG: libunwind: return address=[[VAPI_RA]] from VAPI
   bsearch_caller_cursor = cursor;
   // Step from `bsearch_caller` up to `main`.
   unw_step(&cursor);
-  // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=_Z14bsearch_callerv
-  // CHECK-NOT: VAPI
+  // DEBUG-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=_Z14bsearch_callerv
+  // DEBUG-NOT: VAPI
   main_cursor = cursor;
 
   // Test resuming context where VAPI is active.
@@ -85,7 +87,7 @@ extern "C" int cmp(const void *pa, const void *pb) {
   unw_resume(&bsearch_cursor);
   __builtin_unreachable();
   // CHECK-LABEL: Return to `bsearch`
-  // CHECK-NOT: VAPI: executing return glue
+  // DEBUG-NOT: VAPI: executing return glue
 }
 
 char bsearch_caller_ret;
@@ -119,9 +121,9 @@ void *bsearch_caller(void) {
     unw_resume(&bsearch_caller_cursor);
     __builtin_unreachable();
     // CHECK-LABEL: Return to `bsearch_caller` {{.*}}&buf[1]
-    // CHECK: libunwind: VAPI: executing return glue
+    // DEBUG: libunwind: VAPI: executing return glue
     // CHECK-LABEL: Return to `bsearch_caller` {{.*}}&buf[2]
-    // CHECK: libunwind: VAPI: executing return glue
+    // DEBUG: libunwind: VAPI: executing return glue
   }
 
   // Test resuming context where VAPI is not active, one frame up from the VAPI
@@ -135,7 +137,7 @@ void *bsearch_caller(void) {
   unw_resume(&main_cursor);
   __builtin_unreachable();
   // CHECK-LABEL: Return to `main`
-  // CHECK: libunwind: VAPI: executing return glue
+  // DEBUG: libunwind: VAPI: executing return glue
 }
 
 // VAPI glue addresses

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -101,7 +101,9 @@ void *bsearch_caller(void) {
   // Test resuming context where VAPI is not active. The VAPI return glue should
   // be used each time without regard for whether the VAPI is currently active.
 
-  // `state` is volatile to observe changes in the value between the multiple returns in `setjmp`/`longjmp`-like usage. We need to spell out the `volatile` accesses very explicitly thanks to changes in the C++ standard.
+  // `state` is volatile to observe changes in the value between the multiple
+  // returns in `setjmp`/`longjmp`-like usage. We need to spell out the
+  // `volatile` accesses very explicitly thanks to changes in the C++ standard.
   if ((state = state + 1, state) < 3) {
     fprintf(stderr,
             "Return to `bsearch_caller` at the invocation of "

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -100,7 +100,9 @@ void *bsearch_caller(void) {
 
   // Test resuming context where VAPI is not active. The VAPI return glue should
   // be used each time without regard for whether the VAPI is currently active.
-  if (++state < 3) {
+
+  // `state` is volatile to observe changes in the value between the multiple returns in `setjmp`/`longjmp`-like usage. We need to spell out the `volatile` accesses very explicitly thanks to changes in the C++ standard.
+  if ((state = state + 1, state) < 3) {
     fprintf(stderr,
             "Return to `bsearch_caller` at the invocation of "
             "`returns_twice_bsearch` (really `bsearch`) with r3 set to "

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -24,6 +24,7 @@
 // each time, without regard for whether the VAPI is currently active).
 
 #include <assert.h>
+#include <libunwind.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -32,6 +33,10 @@ extern "C" void *returns_twice_bsearch
                             int (*)(const void *,
                                     const void *)) __asm__("bsearch");
 
+static unw_cursor_t bsearch_cursor;
+static unw_cursor_t bsearch_caller_cursor;
+static unw_cursor_t main_cursor;
+
 extern "C" int cmp(const void *pa, const void *pb) {
   (void)pa;
   (void)pb;
@@ -39,12 +44,25 @@ extern "C" int cmp(const void *pa, const void *pb) {
   fprintf(
       stderr,
       "Populate global cursors for `bsearch`, `bsearch_caller`, and `main`.\n");
-  // TODO
+  unw_context_t context;
+  unw_cursor_t cursor;
+  unw_getcontext(&context);
+  unw_init_local(&cursor, &context);
+  // Step from `cmp` up to `bsearch`.
+  unw_step(&cursor);
+  bsearch_cursor = cursor;
+  // Step from `bsearch` up to `bsearch_caller`.
+  unw_step(&cursor);
+  bsearch_caller_cursor = cursor;
+  // Step from `bsearch_caller` up to `main`.
+  unw_step(&cursor);
+  main_cursor = cursor;
 
   // Test resuming context where VAPI is active.
   fprintf(stderr,
           "Return to `bsearch` with r3 set to 0 using the global cursor.\n");
-  // TODO
+  unw_set_reg(&bsearch_cursor, UNW_PPC64_R3, (unw_word_t)0);
+  unw_resume(&bsearch_cursor);
 }
 
 char bsearch_caller_ret;
@@ -63,14 +81,16 @@ void *bsearch_caller(void) {
             "`returns_twice_bsearch` (really `bsearch`) with r3 set to "
             "&buf[%d] using the global cursor.\n",
             state);
-    // TODO
+    unw_set_reg(&bsearch_caller_cursor, UNW_PPC64_R3, (unw_word_t)&buf[state]);
+    unw_resume(&bsearch_caller_cursor);
   }
 
   // Test resuming context where VAPI is not active, one frame up from the VAPI
   // caller.
   fprintf(stderr, "Return to `main` at the invocation of `bsearch_caller` with "
                   "r3 set to `&bsearch_caller_ret` using the global cursor.\n");
-  // TODO
+  unw_set_reg(&main_cursor, UNW_PPC64_R3, (unw_word_t)&bsearch_caller_ret);
+  unw_resume(&main_cursor);
 }
 
 int main(void) {

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -58,10 +58,12 @@ extern "C" int cmp(const void *pa, const void *pb) {
   // Step from `cmp` up to `bsearch`.
   unw_step(&cursor);
   // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=cmp
+  // CHECK: libunwind: the next return address=[[VAPI_RA:[^ ]*]] from VAPI
   bsearch_cursor = cursor;
   // Step from `bsearch` up to `bsearch_caller`.
   unw_step(&cursor);
   // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=bsearch
+  // CHECK: libunwind: return address=[[VAPI_RA]] from VAPI
   bsearch_caller_cursor = cursor;
   // Step from `bsearch_caller` up to `main`.
   unw_step(&cursor);

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -67,8 +67,7 @@ extern "C" int cmp(const void *pa, const void *pb) {
   // Step from `bsearch` up to `bsearch_caller`.
   unw_step(&cursor);
   if (!llu_enabled)
-    fprintf(stderr,
-            "libunwind: return address=VAPI_NOT_ENABLED from VAPI\n");
+    fprintf(stderr, "libunwind: return address=VAPI_NOT_ENABLED from VAPI\n");
   // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=bsearch
   // CHECK: libunwind: return address=[[VAPI_RA]] from VAPI
   bsearch_caller_cursor = cursor;
@@ -105,7 +104,8 @@ void *bsearch_caller(void) {
             "&buf[%d] using the global cursor.\n",
             state);
     if (!llu_enabled)
-      fprintf(stderr, "libunwind: VAPI: executing return glue VAPI_NOT_ENABLED\n");
+      fprintf(stderr,
+              "libunwind: VAPI: executing return glue VAPI_NOT_ENABLED\n");
     unw_set_reg(&bsearch_caller_cursor, R3, (unw_word_t)&buf[state]);
     unw_resume(&bsearch_caller_cursor);
     __builtin_unreachable();
@@ -120,7 +120,8 @@ void *bsearch_caller(void) {
   fprintf(stderr, "Return to `main` at the invocation of `bsearch_caller` with "
                   "r3 set to `&bsearch_caller_ret` using the global cursor.\n");
   if (!llu_enabled)
-    fprintf(stderr, "libunwind: VAPI: executing return glue VAPI_NOT_ENABLED\n");
+    fprintf(stderr,
+            "libunwind: VAPI: executing return glue VAPI_NOT_ENABLED\n");
   unw_set_reg(&main_cursor, R3, (unw_word_t)&bsearch_caller_ret);
   unw_resume(&main_cursor);
   __builtin_unreachable();
@@ -148,7 +149,8 @@ int main(void) {
   }
 
   FunctionDescriptor *fd = reinterpret_cast<FunctionDescriptor *>(bsearch);
-  llu_enabled = vapi_glue_addr_begin <= fd->entry && fd->entry < vapi_glue_addr_end;
+  llu_enabled =
+      vapi_glue_addr_begin <= fd->entry && fd->entry < vapi_glue_addr_end;
 
   assert(bsearch_caller() == &bsearch_caller_ret);
 }

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -12,10 +12,8 @@
 // ADDITIONAL_COMPILE_FLAGS: -fno-inline -fno-exceptions
 
 // RUN: %{build}
-// RUN: %{exec} %t.exe 2>&1 \
-// RUN: | FileCheck --check-prefix=CHECK \
-// RUN:       %if libunwind-assertions-enabled %{ --check-prefix=DEBUG %} \
-// RUN:       %s
+// RUN: %{exec} %t.exe \
+// RUN:     %if libunwind-assertions-enabled %{ 2>&1 | FileCheck %s %}
 
 // Tests use of the libunwind C API to step up from a context where the VAPI is
 // active and to resume contexts where
@@ -64,20 +62,20 @@ extern "C" int cmp(const void *pa, const void *pb) {
   if (!llu_enabled)
     fprintf(stderr,
             "libunwind: the next return address=VAPI_NOT_ENABLED from VAPI\n");
-  // DEBUG-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=cmp
-  // DEBUG: libunwind: the next return address=[[VAPI_RA:[^ ]*]] from VAPI
+  // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=cmp
+  // CHECK: libunwind: the next return address=[[VAPI_RA:[^ ]*]] from VAPI
   bsearch_cursor = cursor;
   // Step from `bsearch` up to `bsearch_caller`.
   unw_step(&cursor);
   if (!llu_enabled)
     fprintf(stderr, "libunwind: return address=VAPI_NOT_ENABLED from VAPI\n");
-  // DEBUG-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=bsearch
-  // DEBUG: libunwind: return address=[[VAPI_RA]] from VAPI
+  // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=bsearch
+  // CHECK: libunwind: return address=[[VAPI_RA]] from VAPI
   bsearch_caller_cursor = cursor;
   // Step from `bsearch_caller` up to `main`.
   unw_step(&cursor);
-  // DEBUG-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=_Z14bsearch_callerv
-  // DEBUG-NOT: VAPI
+  // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=_Z14bsearch_callerv
+  // CHECK-NOT: VAPI
   main_cursor = cursor;
 
   // Test resuming context where VAPI is active.
@@ -87,7 +85,7 @@ extern "C" int cmp(const void *pa, const void *pb) {
   unw_resume(&bsearch_cursor);
   __builtin_unreachable();
   // CHECK-LABEL: Return to `bsearch`
-  // DEBUG-NOT: VAPI: executing return glue
+  // CHECK-NOT: VAPI: executing return glue
 }
 
 char bsearch_caller_ret;
@@ -121,9 +119,9 @@ void *bsearch_caller(void) {
     unw_resume(&bsearch_caller_cursor);
     __builtin_unreachable();
     // CHECK-LABEL: Return to `bsearch_caller` {{.*}}&buf[1]
-    // DEBUG: libunwind: VAPI: executing return glue
+    // CHECK: libunwind: VAPI: executing return glue
     // CHECK-LABEL: Return to `bsearch_caller` {{.*}}&buf[2]
-    // DEBUG: libunwind: VAPI: executing return glue
+    // CHECK: libunwind: VAPI: executing return glue
   }
 
   // Test resuming context where VAPI is not active, one frame up from the VAPI
@@ -137,7 +135,7 @@ void *bsearch_caller(void) {
   unw_resume(&main_cursor);
   __builtin_unreachable();
   // CHECK-LABEL: Return to `main`
-  // DEBUG: libunwind: VAPI: executing return glue
+  // CHECK: libunwind: VAPI: executing return glue
 }
 
 // VAPI glue addresses

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -57,12 +57,15 @@ extern "C" int cmp(const void *pa, const void *pb) {
   unw_init_local(&cursor, &context);
   // Step from `cmp` up to `bsearch`.
   unw_step(&cursor);
+  // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=cmp
   bsearch_cursor = cursor;
   // Step from `bsearch` up to `bsearch_caller`.
   unw_step(&cursor);
+  // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=bsearch
   bsearch_caller_cursor = cursor;
   // Step from `bsearch_caller` up to `main`.
   unw_step(&cursor);
+  // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=_Z14bsearch_callerv
   main_cursor = cursor;
 
   // Test resuming context where VAPI is active.

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -28,6 +28,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef __64BIT__
+#define R3 UNW_PPC64_R3
+#else
+#define R3 UNW_PPC_R3
+#endif
+
 extern "C" void *returns_twice_bsearch
     [[gnu::returns_twice]] (const void *, const void *, size_t, size_t,
                             int (*)(const void *,
@@ -61,7 +67,7 @@ extern "C" int cmp(const void *pa, const void *pb) {
   // Test resuming context where VAPI is active.
   fprintf(stderr,
           "Return to `bsearch` with r3 set to 0 using the global cursor.\n");
-  unw_set_reg(&bsearch_cursor, UNW_PPC64_R3, (unw_word_t)0);
+  unw_set_reg(&bsearch_cursor, R3, (unw_word_t)0);
   unw_resume(&bsearch_cursor);
 }
 
@@ -81,7 +87,7 @@ void *bsearch_caller(void) {
             "`returns_twice_bsearch` (really `bsearch`) with r3 set to "
             "&buf[%d] using the global cursor.\n",
             state);
-    unw_set_reg(&bsearch_caller_cursor, UNW_PPC64_R3, (unw_word_t)&buf[state]);
+    unw_set_reg(&bsearch_caller_cursor, R3, (unw_word_t)&buf[state]);
     unw_resume(&bsearch_caller_cursor);
   }
 
@@ -89,7 +95,7 @@ void *bsearch_caller(void) {
   // caller.
   fprintf(stderr, "Return to `main` at the invocation of `bsearch_caller` with "
                   "r3 set to `&bsearch_caller_ret` using the global cursor.\n");
-  unw_set_reg(&main_cursor, UNW_PPC64_R3, (unw_word_t)&bsearch_caller_ret);
+  unw_set_reg(&main_cursor, R3, (unw_word_t)&bsearch_caller_ret);
   unw_resume(&main_cursor);
 }
 

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -93,7 +93,10 @@ void *bsearch_caller(void) {
 
   char c;
   char buf[3];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wuninitialized-const-pointer"
   assert(returns_twice_bsearch(&c, buf, 1, 1, cmp) == &buf[state]);
+#pragma clang diagnostic pop
 
   // Test resuming context where VAPI is not active. The VAPI return glue should
   // be used each time without regard for whether the VAPI is currently active.

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -95,8 +95,9 @@ void *bsearch_caller(void) {
   char buf[3];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wuninitialized-const-pointer"
-  assert(returns_twice_bsearch(&c, buf, 1, 1, cmp) == &buf[state]);
+  void *result = returns_twice_bsearch(&c, buf, 1, 1, cmp);
 #pragma clang diagnostic pop
+  assert(result == &buf[state]);
 
   // Test resuming context where VAPI is not active. The VAPI return glue should
   // be used each time without regard for whether the VAPI is currently active.

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -68,6 +68,7 @@ extern "C" int cmp(const void *pa, const void *pb) {
   // Step from `bsearch_caller` up to `main`.
   unw_step(&cursor);
   // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=_Z14bsearch_callerv
+  // CHECK-NOT: VAPI
   main_cursor = cursor;
 
   // Test resuming context where VAPI is active.

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -50,6 +50,7 @@ extern "C" int cmp(const void *pa, const void *pb) {
   fprintf(
       stderr,
       "Populate global cursors for `bsearch`, `bsearch_caller`, and `main`.\n");
+  // CHECK-LABEL: Populate global cursors
   unw_context_t context;
   unw_cursor_t cursor;
   unw_getcontext(&context);
@@ -69,6 +70,7 @@ extern "C" int cmp(const void *pa, const void *pb) {
           "Return to `bsearch` with r3 set to 0 using the global cursor.\n");
   unw_set_reg(&bsearch_cursor, R3, (unw_word_t)0);
   unw_resume(&bsearch_cursor);
+  // CHECK-LABEL: Return to `bsearch`
 }
 
 char bsearch_caller_ret;
@@ -89,6 +91,8 @@ void *bsearch_caller(void) {
             state);
     unw_set_reg(&bsearch_caller_cursor, R3, (unw_word_t)&buf[state]);
     unw_resume(&bsearch_caller_cursor);
+    // CHECK-LABEL: Return to `bsearch_caller` {{.*}}&buf[1]
+    // CHECK-LABEL: Return to `bsearch_caller` {{.*}}&buf[2]
   }
 
   // Test resuming context where VAPI is not active, one frame up from the VAPI
@@ -97,6 +101,7 @@ void *bsearch_caller(void) {
                   "r3 set to `&bsearch_caller_ret` using the global cursor.\n");
   unw_set_reg(&main_cursor, R3, (unw_word_t)&bsearch_caller_ret);
   unw_resume(&main_cursor);
+  // CHECK-LABEL: Return to `main`
 }
 
 int main(void) {

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -77,6 +77,7 @@ extern "C" int cmp(const void *pa, const void *pb) {
   unw_set_reg(&bsearch_cursor, R3, (unw_word_t)0);
   unw_resume(&bsearch_cursor);
   // CHECK-LABEL: Return to `bsearch`
+  // CHECK-NOT: VAPI: executing return glue
 }
 
 char bsearch_caller_ret;
@@ -98,7 +99,9 @@ void *bsearch_caller(void) {
     unw_set_reg(&bsearch_caller_cursor, R3, (unw_word_t)&buf[state]);
     unw_resume(&bsearch_caller_cursor);
     // CHECK-LABEL: Return to `bsearch_caller` {{.*}}&buf[1]
+    // CHECK: libunwind: VAPI: executing return glue
     // CHECK-LABEL: Return to `bsearch_caller` {{.*}}&buf[2]
+    // CHECK: libunwind: VAPI: executing return glue
   }
 
   // Test resuming context where VAPI is not active, one frame up from the VAPI
@@ -108,6 +111,7 @@ void *bsearch_caller(void) {
   unw_set_reg(&main_cursor, R3, (unw_word_t)&bsearch_caller_ret);
   unw_resume(&main_cursor);
   // CHECK-LABEL: Return to `main`
+  // CHECK: libunwind: VAPI: executing return glue
 }
 
 int main(void) {

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: target={{.+}}-aix{{.*}}
+// REQUIRES: has-filecheck
+
+// ADDITIONAL_COMPILE_FLAGS: -fno-inline -fno-exceptions
+
+// RUN: %{build}
+// RUN: %{exec} %t.exe 2>&1 | FileCheck %s
+
+// Tests use of the libunwind C API to step up from a context where the VAPI is
+// active and to resume contexts where
+// - the VAPI is active (and thus VAPI return glue is not called) and
+// - where the VAPI is not active (and thus VAPI return glue _is_ called).
+//
+// In the latter case, which applies not just to the caller of the Virtual API
+// but also to its ancestors, the return glue should always be called (i.e.,
+// each time, without regard for whether the VAPI is currently active).
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern "C" void *returns_twice_bsearch
+    [[gnu::returns_twice]] (const void *, const void *, size_t, size_t,
+                            int (*)(const void *,
+                                    const void *)) __asm__("bsearch");
+
+extern "C" int cmp(const void *pa, const void *pb) {
+  (void)pa;
+  (void)pb;
+
+  fprintf(
+      stderr,
+      "Populate global cursors for `bsearch`, `bsearch_caller`, and `main`.\n");
+  // TODO
+
+  // Test resuming context where VAPI is active.
+  fprintf(stderr,
+          "Return to `bsearch` with r3 set to 0 using the global cursor.\n");
+  // TODO
+}
+
+char bsearch_caller_ret;
+void *bsearch_caller(void) {
+  volatile int state = 0;
+
+  char c;
+  char buf[3];
+  assert(returns_twice_bsearch(&c, buf, 1, 1, cmp) == &buf[state]);
+
+  // Test resuming context where VAPI is not active. The VAPI return glue should
+  // be used each time without regard for whether the VAPI is currently active.
+  if (++state < 3) {
+    fprintf(stderr,
+            "Return to `bsearch_caller` at the invocation of "
+            "`returns_twice_bsearch` (really `bsearch`) with r3 set to "
+            "&buf[%d] using the global cursor.\n",
+            state);
+    // TODO
+  }
+
+  // Test resuming context where VAPI is not active, one frame up from the VAPI
+  // caller.
+  fprintf(stderr, "Return to `main` at the invocation of `bsearch_caller` with "
+                  "r3 set to `&bsearch_caller_ret` using the global cursor.\n");
+  // TODO
+}
+
+int main(void) {
+  if (setenv("LIBUNWIND_PRINT_UNWINDING", "1", true) != 0) {
+    perror("setenv");
+    abort();
+  }
+  assert(bsearch_caller() == &bsearch_caller_ret);
+}

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -12,7 +12,8 @@
 // ADDITIONAL_COMPILE_FLAGS: -fno-inline -fno-exceptions
 
 // RUN: %{build}
-// RUN: %{exec} %t.exe 2>&1 | FileCheck %s
+// RUN: %{exec} %t.exe \
+// RUN:     %if libunwind-assertions-enabled %{ 2>&1 | FileCheck %s %}
 
 // Tests use of the libunwind C API to step up from a context where the VAPI is
 // active and to resume contexts where

--- a/libunwind/test/aix_vapi_unw_resume.pass.cpp
+++ b/libunwind/test/aix_vapi_unw_resume.pass.cpp
@@ -39,6 +39,7 @@ extern "C" void *returns_twice_bsearch
                             int (*)(const void *,
                                     const void *)) __asm__("bsearch");
 
+static bool llu_enabled;
 static unw_cursor_t bsearch_cursor;
 static unw_cursor_t bsearch_caller_cursor;
 static unw_cursor_t main_cursor;
@@ -57,11 +58,17 @@ extern "C" int cmp(const void *pa, const void *pb) {
   unw_init_local(&cursor, &context);
   // Step from `cmp` up to `bsearch`.
   unw_step(&cursor);
+  if (!llu_enabled)
+    fprintf(stderr,
+            "libunwind: the next return address=VAPI_NOT_ENABLED from VAPI\n");
   // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=cmp
   // CHECK: libunwind: the next return address=[[VAPI_RA:[^ ]*]] from VAPI
   bsearch_cursor = cursor;
   // Step from `bsearch` up to `bsearch_caller`.
   unw_step(&cursor);
+  if (!llu_enabled)
+    fprintf(stderr,
+            "libunwind: return address=VAPI_NOT_ENABLED from VAPI\n");
   // CHECK-LABEL: libunwind: stepWithTBTable: Look up traceback table of func=bsearch
   // CHECK: libunwind: return address=[[VAPI_RA]] from VAPI
   bsearch_caller_cursor = cursor;
@@ -76,6 +83,7 @@ extern "C" int cmp(const void *pa, const void *pb) {
           "Return to `bsearch` with r3 set to 0 using the global cursor.\n");
   unw_set_reg(&bsearch_cursor, R3, (unw_word_t)0);
   unw_resume(&bsearch_cursor);
+  __builtin_unreachable();
   // CHECK-LABEL: Return to `bsearch`
   // CHECK-NOT: VAPI: executing return glue
 }
@@ -96,8 +104,11 @@ void *bsearch_caller(void) {
             "`returns_twice_bsearch` (really `bsearch`) with r3 set to "
             "&buf[%d] using the global cursor.\n",
             state);
+    if (!llu_enabled)
+      fprintf(stderr, "libunwind: VAPI: executing return glue VAPI_NOT_ENABLED\n");
     unw_set_reg(&bsearch_caller_cursor, R3, (unw_word_t)&buf[state]);
     unw_resume(&bsearch_caller_cursor);
+    __builtin_unreachable();
     // CHECK-LABEL: Return to `bsearch_caller` {{.*}}&buf[1]
     // CHECK: libunwind: VAPI: executing return glue
     // CHECK-LABEL: Return to `bsearch_caller` {{.*}}&buf[2]
@@ -108,16 +119,36 @@ void *bsearch_caller(void) {
   // caller.
   fprintf(stderr, "Return to `main` at the invocation of `bsearch_caller` with "
                   "r3 set to `&bsearch_caller_ret` using the global cursor.\n");
+  if (!llu_enabled)
+    fprintf(stderr, "libunwind: VAPI: executing return glue VAPI_NOT_ENABLED\n");
   unw_set_reg(&main_cursor, R3, (unw_word_t)&bsearch_caller_ret);
   unw_resume(&main_cursor);
+  __builtin_unreachable();
   // CHECK-LABEL: Return to `main`
   // CHECK: libunwind: VAPI: executing return glue
 }
+
+// VAPI glue addresses
+constexpr uintptr_t vapi_glue_addr_ext_32 = 0x8b80;
+constexpr uintptr_t vapi_addr_64 = 0x8e00;
+constexpr size_t vapi_size_64 = 0x0200;
+constexpr uintptr_t vapi_glue_addr_begin = vapi_glue_addr_ext_32;
+constexpr uintptr_t vapi_glue_addr_end = vapi_addr_64 + vapi_size_64;
+
+struct FunctionDescriptor {
+  uintptr_t entry;
+  uintptr_t toc;
+  uintptr_t env;
+};
 
 int main(void) {
   if (setenv("LIBUNWIND_PRINT_UNWINDING", "1", true) != 0) {
     perror("setenv");
     abort();
   }
+
+  FunctionDescriptor *fd = reinterpret_cast<FunctionDescriptor *>(bsearch);
+  llu_enabled = vapi_glue_addr_begin <= fd->entry && fd->entry < vapi_glue_addr_end;
+
   assert(bsearch_caller() == &bsearch_caller_ret);
 }

--- a/libunwind/test/configs/cmake-bridge.cfg.in
+++ b/libunwind/test/configs/cmake-bridge.cfg.in
@@ -27,6 +27,8 @@ config.test_exec_root = os.path.join('@LIBUNWIND_BINARY_DIR@', 'test')
 # Add a few features that are common to all the configurations
 if @LIBUNWIND_USES_ARM_EHABI@:
     config.available_features.add('libunwind-arm-ehabi')
+if @LIBUNWIND_ENABLE_ASSERTIONS@:
+    config.available_features.add('libunwind-assertions-enabled')
 if not @LIBUNWIND_ENABLE_THREADS@:
     config.available_features.add('libunwind-no-threads')
 


### PR DESCRIPTION
Test detection, during stepping, of the backchain mutation introduced by a VAPI call (see https://github.com/llvm/llvm-project/pull/209280). Further, test resumption of contexts using cursors obtained while a VAPI is active on the thread.

Testing is done via FileCheck inspection of trace output enabled by `LIBUNWIND_PRINT_UNWINDING=1`. When Live Library Update is not enabled, synthetic trace output is generated by the test program itself.

---------

Assisted-by: IBM Bob