### PR TITLE
[lldb] Expand ScriptedExtension coverage across scripted Python interfaces

### DIFF
--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -667,6 +667,7 @@ public:
   // Scripted Interface
   static bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,
                              ScriptedInterfaceCreateInstance create_callback,
+                             lldb::ScriptedExtension extension,
                              lldb::ScriptLanguage language,
                              ScriptedInterfaceUsages usages);
 
@@ -677,6 +678,9 @@ public:
   static llvm::StringRef GetScriptedInterfaceNameAtIndex(uint32_t idx);
 
   static llvm::StringRef GetScriptedInterfaceDescriptionAtIndex(uint32_t idx);
+
+  static lldb::ScriptedExtension
+  GetScriptedInterfaceExtensionAtIndex(uint32_t idx);
 
   static lldb::ScriptLanguage GetScriptedInterfaceLanguageAtIndex(uint32_t idx);
 

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -255,6 +255,21 @@ enum ScriptLanguage {
   eScriptLanguageDefault = eScriptLanguagePython
 };
 
+/// Scripting extension types.
+enum ScriptedExtension {
+  eScriptedExtensionInvalid = 0,
+  eScriptedExtensionOperatingSystem,
+  eScriptedExtensionScriptedPlatform,
+  eScriptedExtensionScriptedProcess,
+  eScriptedExtensionScriptedBreakpointResolver,
+  eScriptedExtensionScriptedThreadPlan,
+  eScriptedExtensionScriptedFrameProvider,
+  eScriptedExtensionScriptedHook,
+  eScriptedExtensionScriptedThread,
+  eScriptedExtensionScriptedFrame,
+  kLastScriptedExtension = eScriptedExtensionScriptedFrame
+};
+
 /// Register numbering types.
 // See RegisterContext::ConvertRegisterKindToRegisterNumber to convert any of
 // these to the lldb internal register numbering scheme (eRegisterKindLLDB).

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -13,6 +13,7 @@
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Interpreter/OptionValueProperties.h"
+#include "lldb/Interpreter/ScriptInterpreter.h"
 #include "lldb/Symbol/SaveCoreOptions.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Utility/FileSpec.h"
@@ -2058,12 +2059,14 @@ struct ScriptedInterfaceInstance
     : public PluginInstance<ScriptedInterfaceCreateInstance> {
   ScriptedInterfaceInstance(llvm::StringRef name, llvm::StringRef description,
                             ScriptedInterfaceCreateInstance create_callback,
+                            lldb::ScriptedExtension extension,
                             lldb::ScriptLanguage language,
                             ScriptedInterfaceUsages usages)
       : PluginInstance<ScriptedInterfaceCreateInstance>(name, description,
                                                         create_callback),
-        language(language), usages(usages) {}
+        extension(extension), language(language), usages(usages) {}
 
+  lldb::ScriptedExtension extension;
   lldb::ScriptLanguage language;
   ScriptedInterfaceUsages usages;
 };
@@ -2078,9 +2081,10 @@ static ScriptedInterfaceInstances &GetScriptedInterfaceInstances() {
 bool PluginManager::RegisterPlugin(
     llvm::StringRef name, llvm::StringRef description,
     ScriptedInterfaceCreateInstance create_callback,
-    lldb::ScriptLanguage language, ScriptedInterfaceUsages usages) {
+    lldb::ScriptedExtension extension, lldb::ScriptLanguage language,
+    ScriptedInterfaceUsages usages) {
   return GetScriptedInterfaceInstances().RegisterPlugin(
-      name, description, create_callback, language, usages);
+      name, description, create_callback, extension, language, usages);
 }
 
 bool PluginManager::UnregisterPlugin(
@@ -2099,6 +2103,13 @@ llvm::StringRef PluginManager::GetScriptedInterfaceNameAtIndex(uint32_t index) {
 llvm::StringRef
 PluginManager::GetScriptedInterfaceDescriptionAtIndex(uint32_t index) {
   return GetScriptedInterfaceInstances().GetDescriptionAtIndex(index);
+}
+
+lldb::ScriptedExtension
+PluginManager::GetScriptedInterfaceExtensionAtIndex(uint32_t index) {
+  if (auto instance = GetScriptedInterfaceInstances().GetInstanceAtIndex(index))
+    return instance->extension;
+  return ScriptedExtension::eScriptedExtensionInvalid;
 }
 
 lldb::ScriptLanguage

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.cpp
@@ -94,7 +94,8 @@ void OperatingSystemPythonInterface::Initialize() {
   const std::vector<llvm::StringRef> api_usages = {};
   PluginManager::RegisterPlugin(
       GetPluginNameStatic(), llvm::StringRef("Mock thread state"),
-      CreateInstance, eScriptLanguagePython, {ci_usages, api_usages});
+      CreateInstance, eScriptedExtensionOperatingSystem, eScriptLanguagePython,
+      {ci_usages, api_usages});
 }
 
 void OperatingSystemPythonInterface::Terminate() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.h
@@ -19,7 +19,7 @@ namespace lldb_private {
 class OperatingSystemPythonInterface
     : virtual public OperatingSystemInterface,
       virtual public ScriptedThreadPythonInterface,
-      public PluginInterface {
+      virtual public PluginInterface {
 public:
   OperatingSystemPythonInterface(ScriptInterpreterPythonImpl &interpreter);
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptInterpreterPythonInterfaces.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptInterpreterPythonInterfaces.cpp
@@ -27,6 +27,8 @@ void ScriptInterpreterPythonInterfaces::Initialize() {
   ScriptedBreakpointPythonInterface::Initialize();
   ScriptedThreadPlanPythonInterface::Initialize();
   ScriptedFrameProviderPythonInterface::Initialize();
+  ScriptedThreadPythonInterface::Initialize();
+  ScriptedFramePythonInterface::Initialize();
 }
 
 void ScriptInterpreterPythonInterfaces::Terminate() {
@@ -37,4 +39,6 @@ void ScriptInterpreterPythonInterfaces::Terminate() {
   ScriptedBreakpointPythonInterface::Terminate();
   ScriptedThreadPlanPythonInterface::Terminate();
   ScriptedFrameProviderPythonInterface::Terminate();
+  ScriptedThreadPythonInterface::Terminate();
+  ScriptedFramePythonInterface::Terminate();
 }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptInterpreterPythonInterfaces.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptInterpreterPythonInterfaces.h
@@ -20,6 +20,7 @@
 #include "ScriptedPlatformPythonInterface.h"
 #include "ScriptedProcessPythonInterface.h"
 #include "ScriptedThreadPlanPythonInterface.h"
+#include "ScriptedThreadPythonInterface.h"
 
 namespace lldb_private {
 class ScriptInterpreterPythonInterfaces : public PluginInterface {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedBreakpointPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedBreakpointPythonInterface.cpp
@@ -143,7 +143,8 @@ void ScriptedBreakpointPythonInterface::Initialize() {
       GetPluginNameStatic(),
       llvm::StringRef("Create a breakpoint that chooses locations based on "
                       "user-created callbacks"),
-      CreateInstance, eScriptLanguagePython, {ci_usages, api_usages});
+      CreateInstance, eScriptedExtensionScriptedBreakpointResolver,
+      eScriptLanguagePython, {ci_usages, api_usages});
 }
 
 void ScriptedBreakpointPythonInterface::Terminate() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFrameProviderPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFrameProviderPythonInterface.cpp
@@ -116,7 +116,8 @@ void ScriptedFrameProviderPythonInterface::Initialize() {
   PluginManager::RegisterPlugin(
       GetPluginNameStatic(),
       llvm::StringRef("Provide scripted stack frames for threads"),
-      CreateInstance, eScriptLanguagePython, {ci_usages, api_usages});
+      CreateInstance, eScriptedExtensionScriptedFrameProvider,
+      eScriptLanguagePython, {ci_usages, api_usages});
 }
 
 void ScriptedFrameProviderPythonInterface::Terminate() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.cpp
@@ -8,6 +8,7 @@
 
 #include "../lldb-python.h"
 
+#include "lldb/Core/PluginManager.h"
 #include "lldb/Host/Config.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Utility/Log.h"
@@ -193,4 +194,16 @@ ScriptedFramePythonInterface::GetValueObjectForVariableExpression(
   }
 
   return val;
+}
+
+void ScriptedFramePythonInterface::Initialize() {
+  PluginManager::RegisterPlugin(
+      GetPluginNameStatic(),
+      "Provide frame state for scripted threads and frame providers.",
+      CreateInstance, eScriptedExtensionScriptedFrame, eScriptLanguagePython,
+      {});
+}
+
+void ScriptedFramePythonInterface::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
 }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.h
@@ -15,7 +15,8 @@
 
 namespace lldb_private {
 class ScriptedFramePythonInterface : public ScriptedFrameInterface,
-                                     public ScriptedPythonInterface {
+                                     public ScriptedPythonInterface,
+                                     public PluginInterface {
 public:
   ScriptedFramePythonInterface(ScriptInterpreterPythonImpl &interpreter);
 
@@ -57,6 +58,16 @@ public:
   lldb::ValueObjectSP
   GetValueObjectForVariableExpression(llvm::StringRef expr, uint32_t options,
                                       Status &status) override;
+
+  static void Initialize();
+
+  static void Terminate();
+
+  static llvm::StringRef GetPluginNameStatic() {
+    return "ScriptedFramePythonInterface";
+  }
+
+  llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 };
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedHookPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedHookPythonInterface.cpp
@@ -99,7 +99,8 @@ void ScriptedHookPythonInterface::Initialize() {
       GetPluginNameStatic(),
       llvm::StringRef("Perform actions on target lifecycle events (module "
                       "load/unload, process stop)."),
-      CreateInstance, eScriptLanguagePython, {ci_usages, api_usages});
+      CreateInstance, eScriptedExtensionScriptedHook, eScriptLanguagePython,
+      {ci_usages, api_usages});
 }
 
 void ScriptedHookPythonInterface::Terminate() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPlatformPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPlatformPythonInterface.cpp
@@ -92,7 +92,8 @@ Status ScriptedPlatformPythonInterface::KillProcess(lldb::pid_t pid) {
 void ScriptedPlatformPythonInterface::Initialize() {
   PluginManager::RegisterPlugin(
       GetPluginNameStatic(), "Mock platform and interact with its processes.",
-      CreateInstance, eScriptLanguagePython, {});
+      CreateInstance, eScriptedExtensionScriptedPlatform, eScriptLanguagePython,
+      {});
 }
 
 void ScriptedPlatformPythonInterface::Terminate() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedProcessPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedProcessPythonInterface.cpp
@@ -218,7 +218,8 @@ void ScriptedProcessPythonInterface::Initialize() {
       "SBTarget.Launch"};
   PluginManager::RegisterPlugin(
       GetPluginNameStatic(), llvm::StringRef("Mock process state"),
-      CreateInstance, eScriptLanguagePython, {ci_usages, api_usages});
+      CreateInstance, eScriptedExtensionScriptedProcess, eScriptLanguagePython,
+      {ci_usages, api_usages});
 }
 
 void ScriptedProcessPythonInterface::Terminate() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.cpp
@@ -109,7 +109,8 @@ void ScriptedThreadPlanPythonInterface::Initialize() {
   PluginManager::RegisterPlugin(
       GetPluginNameStatic(),
       llvm::StringRef("Alter thread stepping logic and stop reason"),
-      CreateInstance, eScriptLanguagePython, {ci_usages, api_usages});
+      CreateInstance, eScriptedExtensionScriptedThreadPlan,
+      eScriptLanguagePython, {ci_usages, api_usages});
 }
 
 void ScriptedThreadPlanPythonInterface::Terminate() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPythonInterface.cpp
@@ -8,6 +8,7 @@
 
 #include "../lldb-python.h"
 
+#include "lldb/Core/PluginManager.h"
 #include "lldb/Host/Config.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Utility/Log.h"
@@ -156,4 +157,15 @@ ScriptedThreadPythonInterface::GetScriptedFramePluginName() {
 lldb::ScriptedFrameInterfaceSP
 ScriptedThreadPythonInterface::CreateScriptedFrameInterface() {
   return m_interpreter.CreateScriptedFrameInterface();
+}
+
+void ScriptedThreadPythonInterface::Initialize() {
+  PluginManager::RegisterPlugin(
+      GetPluginNameStatic(), "Provide thread state for a scripted process.",
+      CreateInstance, eScriptedExtensionScriptedThread, eScriptLanguagePython,
+      {});
+}
+
+void ScriptedThreadPythonInterface::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
 }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPythonInterface.h
@@ -15,7 +15,8 @@
 
 namespace lldb_private {
 class ScriptedThreadPythonInterface : public ScriptedThreadInterface,
-                                      public ScriptedPythonInterface {
+                                      public ScriptedPythonInterface,
+                                      virtual public PluginInterface {
 public:
   ScriptedThreadPythonInterface(ScriptInterpreterPythonImpl &interpreter);
 
@@ -49,6 +50,16 @@ public:
   StructuredData::ArraySP GetExtendedInfo() override;
 
   std::optional<std::string> GetScriptedFramePluginName() override;
+
+  static void Initialize();
+
+  static void Terminate();
+
+  static llvm::StringRef GetPluginNameStatic() {
+    return "ScriptedThreadPythonInterface";
+  }
+
+  llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 
 protected:
   lldb::ScriptedFrameInterfaceSP CreateScriptedFrameInterface() override;

--- a/lldb/test/Shell/Commands/command-scripting-extension-list.test
+++ b/lldb/test/Shell/Commands/command-scripting-extension-list.test
@@ -38,5 +38,17 @@ scripting extension list
 # CHECK-NEXT:  API Usages: SBThread.StepUsingScriptedThreadPlan
 # CHECK-NEXT:  Command Interpreter Usages: thread step-scripted -C <script-name> [-k key -v value ...]
 
+# CHECK:  Name: ScriptedThreadPythonInterface
+# CHECK-NEXT:  Language: Python
+# CHECK-NEXT:  Description: Provide thread state for a scripted process.
+# CHECK-NEXT:  API Usages: None
+# CHECK-NEXT:  Command Interpreter Usages: None
+
+# CHECK:  Name: ScriptedFramePythonInterface
+# CHECK-NEXT:  Language: Python
+# CHECK-NEXT:  Description: Provide frame state for scripted threads and frame providers.
+# CHECK-NEXT:  API Usages: None
+# CHECK-NEXT:  Command Interpreter Usages: None
+
 scripting extension list -l lua
 # CHECK: Available scripted extension templates: None


### PR DESCRIPTION
This patch introduces `lldb::ScriptedExtension`, a single enum that names every scriptable extension point, and threads it through `PluginManager`'s scripted-interface registration. `RegisterPlugin` now takes a `ScriptedExtension`, `GetScriptedInterfaceExtensionAtIndex` exposes it, and every existing call site is updated to pass the right value.

It also promotes `ScriptedThreadPythonInterface` and `ScriptedFramePythonInterface` to full plugins so they register under their own `ScriptedExtension` values and show up in `scripting extension list` alongside the other extensions.

Along the way, clean up an inheritance ambiguity this exposes in `OperatingSystemPythonInterface`.