### PR TITLE
Fix auto type-specifier conflict crash

### DIFF
--- a/clang/lib/Sema/DeclSpec.cpp
+++ b/clang/lib/Sema/DeclSpec.cpp
@@ -1349,6 +1349,7 @@ void DeclSpec::CheckTypeSpec(Sema &S, const PrintingPolicy &Policy) {
       }
       // Mark as error to prevent further processing
       TypeSpecType = TST_error;
+      TypeSpecOwned = false;
     } else if (!S.getLangOpts().CPlusPlus) {
       // For C, C23, etc., convert 'auto' to storage class specifier
       // (This is already handled above for C23, but keep for other C dialects)

--- a/clang/test/SemaCXX/auto-cxx0x.cpp
+++ b/clang/test/SemaCXX/auto-cxx0x.cpp
@@ -11,6 +11,9 @@ void f() {
   auto int arr[10]; // expected-error {{'auto' cannot be combined with a type specifier}}
 }
 
+struct PR209000 {
+} auto; // expected-error {{'auto' cannot be combined with a type specifier}}
+
 typedef auto PR25449(); // expected-error {{'auto' not allowed in typedef}}
 
 thread_local auto x; // expected-error {{requires an initializer}}


### PR DESCRIPTION
Clear owned type state when an invalid C++ auto/type-specifier conflict is converted to an error so invalid declarations cannot trip DeclSpec invariants.

Fixes https://github.com/llvm/llvm-project/issues/209000