### PR TITLE
[AMDGPU] Replace old reference to `amdgcn-amd-amdhsa' triple

### DIFF
--- a/clang/lib/Basic/OffloadArch.cpp
+++ b/clang/lib/Basic/OffloadArch.cpp
@@ -173,7 +173,8 @@ llvm::Triple OffloadArchToTriple(const llvm::Triple &DefaultToolchainTriple,
   }
 
   if (IsAMDOffloadArch(ID))
-    return llvm::Triple("amdgcn-amd-amdhsa");
+    return llvm::Triple(llvm::Triple::amdgpu, llvm::Triple::NoSubArch,
+                        llvm::Triple::AMD, llvm::Triple::AMDHSA);
 
   return {};
 }


### PR DESCRIPTION
Summary:
This made some cases use the wrong triple while we are migrating to
using `amdgpu` instead.

Now, this might have some side-effects if someone is still trying to use
`amdgcn`. Honestly, it might be best to just make CMake auto-update this
if we want this to be smooth.
