### PR TITLE
[AMDGPU] Check for a live interval before querying register kind in getLiveRegs

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -512,7 +512,8 @@ GCNRPTracker::LiveRegSet llvm::getLiveRegs(SlotIndex SI,
     // Check for a live interval before querying the register kind: getRegKind
     // reads the register class, which is unset for classless vregs (e.g. unused
     // GlobalISel InstructionSelect leftovers). Such vregs have no interval, so
-    // testing hasInterval first skips them without touching their (absent) class.
+    // testing hasInterval first skips them without touching their (absent)
+    // class.
     if (!LIS.hasInterval(Reg))
       continue;
     if (RegKind != GCNRegPressure::TOTAL_KINDS &&

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -509,10 +509,14 @@ GCNRPTracker::LiveRegSet llvm::getLiveRegs(SlotIndex SI,
   GCNRPTracker::LiveRegSet LiveRegs;
   for (unsigned I = 0, E = MRI.getNumVirtRegs(); I != E; ++I) {
     auto Reg = Register::index2VirtReg(I);
+    // Check for a live interval before querying the register kind: getRegKind
+    // reads the register class, which is unset for classless vregs (e.g. unused
+    // GlobalISel InstructionSelect leftovers). Such vregs have no interval, so
+    // testing hasInterval first skips them without touching their (absent) class.
+    if (!LIS.hasInterval(Reg))
+      continue;
     if (RegKind != GCNRegPressure::TOTAL_KINDS &&
         GCNRegPressure::getRegKind(Reg, MRI) != RegKind)
-      continue;
-    if (!LIS.hasInterval(Reg))
       continue;
     auto LiveMask = getLiveLaneMask(Reg, SI, LIS, MRI);
     if (LiveMask.any())


### PR DESCRIPTION


getLiveRegs iterates all virtual registers and, when filtering by RegKind, called GCNRegPressure::getRegKind before checking LiveIntervals::hasInterval. getRegKind reads the register's class via MachineRegisterInfo::getRegClass, which asserts "Register class not set" for a register that only has a size or bank and no concrete class (for example an unused GlobalISel InstructionSelect leftover). Such registers have no live interval, so testing hasInterval first skips them without touching their absent class.

This only reorders two independent guards: a register is included only when both pass, so the returned set is unchanged; the reorder merely avoids reading the class of an interval-less register.