### PR TITLE
[lldb/Host] Add `foreground` argument to `Host::OpenFileInExternalEditor`

### DIFF
--- a/lldb/include/lldb/Host/Host.h
+++ b/lldb/include/lldb/Host/Host.h
@@ -309,7 +309,8 @@ public:
 
   static llvm::Error OpenFileInExternalEditor(llvm::StringRef editor,
                                               const FileSpec &file_spec,
-                                              uint32_t line_no);
+                                              uint32_t line_no,
+                                              bool foreground = false);
 
   /// Open a URL with the host's default handler (Launch Services on macOS,
   /// xdg-open on other Unix). Returns an error if opening fails or the platform

--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -610,7 +610,7 @@ void Host::Kill(lldb::pid_t pid, int signo) { ::kill(pid, signo); }
 #if !defined(__APPLE__)
 llvm::Error Host::OpenFileInExternalEditor(llvm::StringRef editor,
                                            const FileSpec &file_spec,
-                                           uint32_t line_no) {
+                                           uint32_t line_no, bool foreground) {
   return llvm::errorCodeToError(
       std::error_code(ENOTSUP, std::system_category()));
 }

--- a/lldb/source/Host/macosx/objcxx/Host.mm
+++ b/lldb/source/Host/macosx/objcxx/Host.mm
@@ -341,7 +341,7 @@ LaunchInNewTerminalWithAppleScript(const char *exe_path,
 
 llvm::Error Host::OpenFileInExternalEditor(llvm::StringRef editor,
                                            const FileSpec &file_spec,
-                                           uint32_t line_no) {
+                                           uint32_t line_no, bool foreground) {
 #if !TARGET_OS_OSX
   return llvm::errorCodeToError(
       std::error_code(ENOTSUP, std::system_category()));
@@ -432,8 +432,9 @@ llvm::Error Host::OpenFileInExternalEditor(llvm::StringRef editor,
   // Build app launch parameters.
   LSApplicationParameters app_params;
   ::memset(&app_params, 0, sizeof(app_params));
-  app_params.flags =
-      kLSLaunchDefaults | kLSLaunchDontAddToRecents | kLSLaunchDontSwitch;
+  app_params.flags = kLSLaunchDefaults | kLSLaunchDontAddToRecents;
+  if (!foreground)
+    app_params.flags |= kLSLaunchDontSwitch;
   if (app_fsref)
     app_params.application = &(*app_fsref);
 


### PR DESCRIPTION
Add an optional `bool foreground` parameter to
`Host::OpenFileInExternalEditor` so callers can choose whether opening the file should bring the editor to the foreground.

The macOS implementation maps `foreground=true` to omitting `kLSLaunchDontSwitch` in the Launch Services flags, so the editor is brought forward on launch. On non-Apple platforms the stub still returns `ENOTSUP`; the new parameter is added to its signature so it matches the declaration.