### PR TITLE
[ProfileData] Remove clear() from SampleProfileNameTable (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -363,6 +363,12 @@ class SampleProfileNameTable {
   }
 
 public:
+  struct UseLazyT {};
+  static constexpr UseLazyT UseLazy{};
+
+  struct UseEagerT {};
+  static constexpr UseEagerT UseEager{};
+
   /// iterator is a lightweight, self-contained input iterator designed
   /// to stream FunctionId symbols from either the memory-mapped
   /// file buffer (lazy loading from the FixedMD5 layout) or from an eagerly
@@ -403,27 +409,30 @@ public:
 
   using const_iterator = iterator;
 
-  SampleProfileNameTable() = default;
+  SampleProfileNameTable() = delete;
+  SampleProfileNameTable(const SampleProfileNameTable &) = delete;
+  SampleProfileNameTable &operator=(const SampleProfileNameTable &) = delete;
+  SampleProfileNameTable(SampleProfileNameTable &&) = delete;
+  SampleProfileNameTable &operator=(SampleProfileNameTable &&) = delete;
 
-  void clear() {
-    Start = nullptr;
-    Size = 0;
-    Vec.clear();
+  /// Construct in lazy-loading mode, pointing directly to a contiguous
+  /// buffer of little-endian 64-bit MD5 hashes in the MemoryBuffer.
+  SampleProfileNameTable(UseLazyT, const uint8_t *Start, size_t Size)
+      : Start(Start), Size(Size) {
+    assert(Start && "Start pointer must not be null in lazy mode");
   }
 
-  /// Transitions the table to lazy-loading mode, pointing directly to a
-  /// contiguous buffer of little-endian 64-bit MD5 hashes.
-  void setLazy(const uint8_t *S, size_t Sz) {
-    clear();
-    Start = S;
-    Size = Sz;
+  /// Construct in eager-loading mode, reserving initial capacity for
+  /// the underlying vector.
+  explicit SampleProfileNameTable(UseEagerT, size_t InitialCapacity = 0) {
+    Vec.reserve(InitialCapacity);
   }
 
-  /// Transitions the table to eager-loading mode by clearing previous state and
-  /// returning a mutable reference to the underlying vector for population.
-  std::vector<FunctionId> &setToEager() {
-    clear();
-    return Vec;
+  /// Append a FunctionId into the eager vector during profile reading.
+  /// Enforces that the table must be in eager mode (Start == nullptr).
+  void push_back(FunctionId FId) {
+    assert(!Start && "Cannot push_back into a lazy-loaded name table");
+    Vec.push_back(FId);
   }
 
   size_t size() const { return Start ? Size : Vec.size(); }
@@ -768,7 +777,10 @@ public:
   /// or inline instance.
   llvm::iterator_range<SampleProfileNameTable::iterator>
   getNameTable() const override {
-    return {NameTable.begin(), NameTable.end()};
+    if (!NameTable)
+      return {SampleProfileNameTable::iterator(),
+              SampleProfileNameTable::iterator()};
+    return {NameTable->begin(), NameTable->end()};
   }
 
 protected:
@@ -838,7 +850,7 @@ protected:
   const uint8_t *End = nullptr;
 
   /// Function name table.
-  SampleProfileNameTable NameTable;
+  std::optional<SampleProfileNameTable> NameTable;
 
   /// CSNameTable is used to save full context vectors. It is the backing buffer
   /// for SampleContextFrames.

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -604,12 +604,12 @@ inline ErrorOr<size_t> SampleProfileReaderBinary::readStringIndex(T &Table) {
 
 ErrorOr<FunctionId>
 SampleProfileReaderBinary::readStringFromTable(size_t *RetIdx) {
-  auto Idx = readStringIndex(NameTable);
+  auto Idx = readStringIndex(*NameTable);
   if (std::error_code EC = Idx.getError())
     return EC;
   if (RetIdx)
     *RetIdx = *Idx;
-  return NameTable[*Idx];
+  return (*NameTable)[*Idx];
 }
 
 ErrorOr<SampleContextFrames>
@@ -1243,8 +1243,7 @@ std::error_code SampleProfileReaderBinary::readNameTable() {
   // because optimization passes can only handle either type.
   bool UseMD5 = useMD5();
 
-  auto &TableVec = NameTable.setToEager();
-  TableVec.reserve(*Size);
+  NameTable.emplace(SampleProfileNameTable::UseEager, *Size);
   if (!ProfileIsCS) {
     MD5SampleContextTable.clear();
     if (UseMD5)
@@ -1263,9 +1262,9 @@ std::error_code SampleProfileReaderBinary::readNameTable() {
       FunctionId FID(*Name);
       if (!ProfileIsCS)
         MD5SampleContextTable.emplace_back(FID.getHashCode());
-      TableVec.emplace_back(FID);
+      NameTable->push_back(FID);
     } else
-      TableVec.push_back(FunctionId(*Name));
+      NameTable->push_back(FunctionId(*Name));
   }
   if (!ProfileIsCS)
     MD5SampleContextStart = MD5SampleContextTable.data();
@@ -1289,15 +1288,14 @@ SampleProfileReaderExtBinaryBase::readNameTableSec(bool IsMD5,
       return sampleprof_error::truncated;
 
     if (LazyLoadNameTable) {
-      NameTable.setLazy(Data, *Size);
+      NameTable.emplace(SampleProfileNameTable::UseLazy, Data, *Size);
     } else {
-      auto &TableVec = NameTable.setToEager();
-      TableVec.reserve(*Size);
+      NameTable.emplace(SampleProfileNameTable::UseEager, *Size);
       for (size_t I = 0; I < *Size; ++I) {
         using namespace support;
         uint64_t FID = endian::read<uint64_t, unaligned>(
             Data + I * sizeof(uint64_t), endianness::little);
-        TableVec.emplace_back(FunctionId(FID));
+        NameTable->push_back(FunctionId(FID));
       }
     }
     if (!ProfileIsCS)
@@ -1312,8 +1310,7 @@ SampleProfileReaderExtBinaryBase::readNameTableSec(bool IsMD5,
     if (std::error_code EC = Size.getError())
       return EC;
 
-    auto &TableVec = NameTable.setToEager();
-    TableVec.reserve(*Size);
+    NameTable.emplace(SampleProfileNameTable::UseEager, *Size);
     if (!ProfileIsCS)
       MD5SampleContextTable.resize(*Size);
     for (size_t I = 0; I < *Size; ++I) {
@@ -1322,7 +1319,7 @@ SampleProfileReaderExtBinaryBase::readNameTableSec(bool IsMD5,
         return EC;
       if (!ProfileIsCS)
         support::endian::write64le(&MD5SampleContextTable[I], *FID);
-      TableVec.emplace_back(FunctionId(*FID));
+      NameTable->push_back(FunctionId(*FID));
     }
     if (!ProfileIsCS)
       MD5SampleContextStart = MD5SampleContextTable.data();


### PR DESCRIPTION
This patch deletes the default constructor and special member
functions of SampleProfileNameTable, and removes its clear(),
setLazy(), and setToEager() methods.

SampleProfileNameTable is designed to lock its operational mode (lazy
or eager) strictly at construction time and remain valid throughout
its lifetime. By deleting the default constructor and removing mode
transition methods, we ensure that an instance never enters an
uninitialized or cleared state while kept alive.

When SampleProfileReader needs to discard or reload the table, it
resets and replaces the wrapping std::optional directly instead of
clearing or mutating the table in-place.
