### PR TITLE
[OpenMP][AMDGPU][CI] Fix libc build

### DIFF
--- a/offload/ci/openmp-offload-amdgpu-libc-runtime.py
+++ b/offload/ci/openmp-offload-amdgpu-libc-runtime.py
@@ -29,6 +29,7 @@ with worker.run(
                 "-GNinja",
                 f"-DLLVM_LIT_ARGS=-vv --show-unsupported --show-xfail -j {w.jobs} --time-tests --timeout 100",
                 f"-DCMAKE_INSTALL_PREFIX={w.in_workdir(llvminstalldir)}",
+                f"-DRUNTIMES_amdgpu-amd-amdhsa_CMAKE_CROSSCOMPILING_EMULATOR={w.in_workdir(llvmbuilddir)}/bin/llvm-gpu-loader",
             ]
         )
 


### PR DESCRIPTION
This PR attempts to fix the error:
```
llvm-lit: /home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.src/llvm/utils/lit/lit/discovery.py:273: warning: input '/home/botworker/builds/openmp-offload-amdgpu-runtime-2/build/llvm.build/runtimes/runtimes-amdgpu-amd-amdhsa-bins/libc/test' contained no tests
error: did not discover any tests for provided path(s)
```

According to lib/test/CMakeList.txt, we need to set `CMAKE_CROSSCOMPILING_EMULATOR` to avoid early return in the cmake. It only changes the build script instead of the parent cmake cache file. Not sure if this is the optimal solution, but it works for us.