### PR TITLE
[mlir][acc] Fix leaks in cg unit tests

### DIFF
--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsCGTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsCGTest.cpp
@@ -458,6 +458,7 @@ TEST_F(OpenACCUtilsCGTest, getPrivatizeOpFromHandle) {
 
 TEST_F(OpenACCUtilsCGTest, getPrivatizeOpFromComputeRegionBlockArg) {
   OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  b.setInsertionPointToStart(module->getBody());
   GPUParallelDimsAttr gangDims = GPUParallelDimsAttr::get(
       &context, {GPUParallelDimAttr::blockXDim(&context)});
   auto c1 = arith::ConstantIndexOp::create(b, loc, 1);
@@ -540,6 +541,7 @@ TEST_F(OpenACCUtilsCGTest, collectPrivateLocalParDimsFromLaunchFallback) {
   // With no enclosing parallel loops, collectPrivateLocalParDims falls back to
   // the block-level launch dimensions.
   OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  b.setInsertionPointToStart(module->getBody());
   GPUParallelDimsAttr gangDims = GPUParallelDimsAttr::get(
       &context, {GPUParallelDimAttr::blockXDim(&context)});
   auto c1 = arith::ConstantIndexOp::create(b, loc, 1);
@@ -678,6 +680,7 @@ TEST_F(OpenACCUtilsCGTest, collectPrivateLocalParDimsFromReductionUsers) {
 
 TEST_F(OpenACCUtilsCGTest, isPrivateLocalSharedMemoryCandidateGangPrivate) {
   OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  b.setInsertionPointToStart(module->getBody());
   GPUParallelDimsAttr gangDims = GPUParallelDimsAttr::get(
       &context, {GPUParallelDimAttr::blockXDim(&context)});
   auto c1 = arith::ConstantIndexOp::create(b, loc, 1);
@@ -699,6 +702,7 @@ TEST_F(OpenACCUtilsCGTest, isPrivateLocalSharedMemoryCandidateGangPrivate) {
 
 TEST_F(OpenACCUtilsCGTest, isPrivateLocalSharedMemoryCandidateThreadXPrivate) {
   OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  b.setInsertionPointToStart(module->getBody());
   GPUParallelDimsAttr vectorDims = GPUParallelDimsAttr::get(
       &context, {GPUParallelDimAttr::threadXDim(&context)});
   auto c1 = arith::ConstantIndexOp::create(b, loc, 1);
@@ -721,6 +725,7 @@ TEST_F(OpenACCUtilsCGTest, isPrivateLocalSharedMemoryCandidateThreadXPrivate) {
 TEST_F(OpenACCUtilsCGTest,
        isPrivateLocalSharedMemoryCandidateWorkerPrivateConstant) {
   OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  b.setInsertionPointToStart(module->getBody());
   GPUParallelDimsAttr workerDims = GPUParallelDimsAttr::get(
       &context, {GPUParallelDimAttr::threadYDim(&context)});
   auto c1 = arith::ConstantIndexOp::create(b, loc, 1);
@@ -746,6 +751,7 @@ TEST_F(OpenACCUtilsCGTest,
 TEST_F(OpenACCUtilsCGTest,
        isPrivateLocalSharedMemoryCandidateWorkerPrivateDynamicFails) {
   OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  b.setInsertionPointToStart(module->getBody());
   GPUParallelDimsAttr workerDims = GPUParallelDimsAttr::get(
       &context, {GPUParallelDimAttr::threadYDim(&context)});
   auto c1 = arith::ConstantIndexOp::create(b, loc, 1);
@@ -777,6 +783,7 @@ TEST_F(OpenACCUtilsCGTest,
 
 TEST_F(OpenACCUtilsCGTest, getPrivateLocalSharedMemoryUpperBoundBytes) {
   OwningOpRef<ModuleOp> module = ModuleOp::create(b, loc);
+  b.setInsertionPointToStart(module->getBody());
   GPUParallelDimsAttr gangDims = GPUParallelDimsAttr::get(
       &context, {GPUParallelDimAttr::blockXDim(&context)});
   auto c1 = arith::ConstantIndexOp::create(b, loc, 1);

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsGPUTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsGPUTest.cpp
@@ -27,9 +27,15 @@ protected:
     context.loadDialect<arith::ArithDialect, gpu::GPUDialect>();
   }
 
+  void SetUp() override {
+    module = ModuleOp::create(b, loc);
+    b.setInsertionPointToStart(module->getBody());
+  }
+
   MLIRContext context;
   OpBuilder b;
   Location loc;
+  OwningOpRef<ModuleOp> module;
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsReductionTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsReductionTest.cpp
@@ -32,9 +32,15 @@ protected:
                         complex::ComplexDialect, memref::MemRefDialect>();
   }
 
+  void SetUp() override {
+    module = ModuleOp::create(b, loc);
+    b.setInsertionPointToStart(module->getBody());
+  }
+
   MLIRContext context;
   OpBuilder b;
   Location loc;
+  OwningOpRef<ModuleOp> module;
 };
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Newly added tests are failing valgrind --leak-check=full: https://github.com/llvm/llvm-project/pull/209313
https://github.com/llvm/llvm-project/pull/209316

This PR resolves the problem by ensuring that the insertion point is set into an operation that is owned and deleted by the test.