### PR TITLE
[InlineCost] Drop Requirements around ByVal Arguments

### DIFF
--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -3197,20 +3197,6 @@ std::optional<InlineResult> llvm::getAttributeBasedInliningDecision(
   if (Callee->isPresplitCoroutine())
     return InlineResult::failure("unsplited coroutine call");
 
-  // Never inline calls with byval arguments that does not have the alloca
-  // address space. Since byval arguments can be replaced with a copy to an
-  // alloca, the inlined code would need to be adjusted to handle that the
-  // argument is in the alloca address space (so it is a little bit complicated
-  // to solve).
-  unsigned AllocaAS = Callee->getDataLayout().getAllocaAddrSpace();
-  for (unsigned I = 0, E = Call.arg_size(); I != E; ++I)
-    if (Call.isByValArgument(I)) {
-      PointerType *PTy = cast<PointerType>(Call.getArgOperand(I)->getType());
-      if (PTy->getAddressSpace() != AllocaAS)
-        return InlineResult::failure("byval arguments without alloca"
-                                     " address space");
-    }
-
   // Inlining into a function with less target features is unsound, so enforce
   // this even if alwaysinline is used.
   Function *Caller = Call.getCaller();

--- a/llvm/test/Transforms/Inline/byval.ll
+++ b/llvm/test/Transforms/Inline/byval.ll
@@ -182,14 +182,6 @@ entry:
 @c = common addrspace(1) global i32 0, align 4
 
 define internal void @f5_as1(ptr addrspace(1) byval(%struct.S1) nocapture readonly align 4 %p) {
-; CHECK-LABEL: define internal void @f5_as1(
-; CHECK-SAME: ptr addrspace(1) readonly byval([[STRUCT_S1:%.*]]) align 4 captures(none) [[P:%.*]]) {
-; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i32 0, ptr addrspace(1) @d, align 4
-; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr addrspace(1) [[P]], align 4
-; CHECK-NEXT:    store i32 [[TMP0]], ptr addrspace(1) @c, align 4
-; CHECK-NEXT:    ret void
-;
 entry:
   store i32 0, ptr addrspace(1) @d, align 4
   %0 = load i32, ptr addrspace(1) %p, align 4
@@ -200,7 +192,13 @@ entry:
 define i32 @test5_as1() {
 ; CHECK-LABEL: define i32 @test5_as1() {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    tail call void @f5_as1(ptr addrspace(1) byval([[STRUCT_S1:%.*]]) align 4 @d)
+; CHECK-NEXT:    [[D:%.*]] = alloca [[STRUCT_S1:%.*]], align 8, addrspace(1)
+; CHECK-NEXT:    call void @llvm.lifetime.start.p1(ptr addrspace(1) [[D]])
+; CHECK-NEXT:    call void @llvm.memcpy.p1.p1.i64(ptr addrspace(1) align 8 [[D]], ptr addrspace(1) align 4 @d, i64 4, i1 false)
+; CHECK-NEXT:    store i32 0, ptr addrspace(1) @d, align 4
+; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(1) [[D]], align 4
+; CHECK-NEXT:    store i32 [[TMP1]], ptr addrspace(1) @c, align 4
+; CHECK-NEXT:    call void @llvm.lifetime.end.p1(ptr addrspace(1) [[D]])
 ; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr addrspace(1) @c, align 4
 ; CHECK-NEXT:    ret i32 [[TMP0]]
 ;


### PR DESCRIPTION
The underlying behavior was fixed in
e47359a925b88cd081ea85d10b55b0625d17b212, but given that the example
was marked alwaysinline, it bypassed any legality checks it would have
otherwise hit.

See
https://github.com/llvm/llvm-project/pull/97306#discussion_r1679306183
for discussion around which address space we should be using/legality.

This is necessary to preserve the behavior in
byval-with-non-alloca-addrspace.ll after we enable function attribute
compatibility checks in always-inline.
