### PR TITLE
[BPF][ProfCheck] Exclude sink-min-max.ll

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -1,4 +1,5 @@
 CodeGen/ARM/sjljeh-swifterror.ll
+CodeGen/BPF/sink-min-max.ll
 CodeGen/WinEH/wineh-comdat.ll
 CodeGen/WinEH/wineh-scope-statenumbering.ll
 CodeGen/WinEH/wineh-setjmp.ll


### PR DESCRIPTION
This was exposed by porting the pass to the NewPM, so just exclude it for now.