### PR TITLE
Write original source language when writing and reading AST

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -6663,6 +6663,7 @@ bool ASTReader::ParseLanguageOptions(const RecordData &Record,
                                      bool AllowCompatibleDifferences) {
   LangOptions LangOpts;
   unsigned Idx = 0;
+  LangOpts.LangStd = static_cast<LangStandard::Kind>(Record[Idx++]);
 #define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
   LangOpts.Name = Record[Idx++];
 #define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -1608,6 +1608,7 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, StringRef isysroot) {
   // Language options.
   Record.clear();
   const LangOptions &LangOpts = PP.getLangOpts();
+  Record.push_back(static_cast<unsigned>(LangOpts.LangStd));
   const uint64_t LanguageOptionValues[] = {
 #define LANGOPT(Name, Bits, Default, Compatibility, Description) LangOpts.Name,
 #define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \

--- a/clang/test/CodeGen/SystemZ/zos-check-lanuage.c
+++ b/clang/test/CodeGen/SystemZ/zos-check-lanuage.c
@@ -1,0 +1,29 @@
+// This chunk is based on Clang :: Frontend/ast-main.c,
+// but targeted for z/OS.  (Ensure we have no fatal error.)
+// We also duplicate for C++.
+// RUN: env SDKROOT="/" %clang -Xclang -source-date-epoch -Xclang 1783944000 -target s390x-none-zos -emit-llvm -S -o - -x c - < %s | grep -v DIFile > %t1.ll
+// RUN: env SDKROOT="/" %clang -target s390x-none-zos -emit-ast -o %t.ast %s
+// RUN: env SDKROOT="/" %clang -Xclang -source-date-epoch -Xclang 1783944000 -target s390x-none-zos -emit-llvm -S -o - -x ast - < %t.ast | grep -v DIFile > %t2.ll
+// make sure that the IR from the two runs are the same
+// RUN: diff %t1.ll %t2.ll
+
+// check that the langage attribute has come through
+// RUN: FileCheck --check-prefix CHECK-C %s < %t1.ll
+// CHECK-C: !"zos_cu_language", !"C"}
+
+
+// RUN: env SDKROOT="/" %clang -Xclang -source-date-epoch -Xclang 1783944000 -target s390x-none-zos -emit-llvm -S -o - -x c++ - < %s | grep -v DIFile > %t1.ll
+// RUN: env SDKROOT="/" %clang -target s390x-none-zos -emit-ast -o %t.ast -x c++ %s
+// RUN: env SDKROOT="/" %clang -Xclang -source-date-epoch -Xclang 1783944000 -target s390x-none-zos -emit-llvm -S -o - -x ast - < %t.ast | grep -v DIFile > %t2.ll
+// make sure that the IR from the two runs are the same
+// RUN: diff %t1.ll %t2.ll
+
+// check that the langage attribute has come through
+// RUN: FileCheck --check-prefix CHECK-CPP %s < %t1.ll
+// CHECK-CPP: !"zos_cu_language", !"C++"}
+
+
+
+int main(void) {
+  return 0;
+}

--- a/clang/test/CodeGen/SystemZ/zos-check-lanuage.c
+++ b/clang/test/CodeGen/SystemZ/zos-check-lanuage.c
@@ -1,27 +1,23 @@
-// REQUIRES: systemz-registered-target
 //
-// This chunk is based on Clang :: Frontend/ast-main.c,
-// but targeted for z/OS.  (Ensure we have no fatal error.)
-// We also duplicate for C++.
-// RUN: env SDKROOT="/" %clang -Xclang -source-date-epoch -Xclang 1783944000 -target s390x-none-zos -emit-llvm -S -o - -x c - < %s | grep -v DIFile > %t1.ll
-// RUN: env SDKROOT="/" %clang -target s390x-none-zos -emit-ast -o %t.ast %s
-// RUN: env SDKROOT="/" %clang -Xclang -source-date-epoch -Xclang 1783944000 -target s390x-none-zos -emit-llvm -S -o - -x ast - < %t.ast | grep -v DIFile > %t2.ll
-// make sure that the IR from the two runs are the same
-// RUN: diff %t1.ll %t2.ll
+// This is based on Clang :: Frontend/ast-main.c,
+// but targeted for z/OS, and checking only that the langauge comes through.
+// We do not check that the entire IR is identical.
+// We also check C++.
+
+// The %clang_cc1 -emit-pch does the same as %clang -emit-ast.
+// The -x ast in the second invocation of each pair confirms we are reading ast.
+
+// RUN: %clang_cc1 -triple s390x-none-zos -emit-pch -o %t.ast %s
+// RUN: %clang_cc1 -triple s390x-none-zos -emit-llvm -o - -x ast - < %t.ast | FileCheck --check-prefix=CHECK-C %s
 
 // check that the langage attribute has come through
-// RUN: FileCheck --check-prefix CHECK-C %s < %t1.ll
 // CHECK-C: !"zos_cu_language", !"C"}
 
 
-// RUN: env SDKROOT="/" %clang -Xclang -source-date-epoch -Xclang 1783944000 -target s390x-none-zos -emit-llvm -S -o - -x c++ - < %s | grep -v DIFile > %t1.ll
-// RUN: env SDKROOT="/" %clang -target s390x-none-zos -emit-ast -o %t.ast -x c++ %s
-// RUN: env SDKROOT="/" %clang -Xclang -source-date-epoch -Xclang 1783944000 -target s390x-none-zos -emit-llvm -S -o - -x ast - < %t.ast | grep -v DIFile > %t2.ll
-// make sure that the IR from the two runs are the same
-// RUN: diff %t1.ll %t2.ll
+// RUN: %clang_cc1 -triple s390x-none-zos -emit-pch -o %t.ast -x c++ %s
+// RUN: %clang_cc1 -triple s390x-none-zos -emit-llvm -o - -x ast - < %t.ast | FileCheck --check-prefix CHECK-CPP %s
 
 // check that the langage attribute has come through
-// RUN: FileCheck --check-prefix CHECK-CPP %s < %t1.ll
 // CHECK-CPP: !"zos_cu_language", !"C++"}
 
 

--- a/clang/test/CodeGen/SystemZ/zos-check-lanuage.c
+++ b/clang/test/CodeGen/SystemZ/zos-check-lanuage.c
@@ -1,3 +1,5 @@
+// REQUIRES: systemz-registered-target
+//
 // This chunk is based on Clang :: Frontend/ast-main.c,
 // but targeted for z/OS.  (Ensure we have no fatal error.)
 // We also duplicate for C++.


### PR DESCRIPTION
FAIL: Clang :: Frontend/ast-main.c
FAIL: Clang :: Frontend/ast-main.cpp

were failing on z/OS; this change fixes these lit failures.

The issue here is that on z/OS the original source code language needs to be passed through to the IR so that the backend can encode this information in the PPA2 in the object file. That means that it needs to be exported to the AST so that going from saved AST -> IR will carry the language through.
