### PR TITLE
[clang][Diagnostics] Fix check-point recording under default colors

### DIFF
--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -103,8 +103,7 @@ Preprocessor::Preprocessor(const PreprocessorOptions &PPOpts,
   OwnsHeaderSearch = OwnsHeaders;
 
   // Only record check points if we might highlight diagnostic snippets.
-  RecordCheckPoints = getDiagnostics().getDiagnosticOptions().getShowColors() !=
-                      ShowColorsKind::Off;
+  RecordCheckPoints = getDiagnostics().getShowColors();
 
   // Default to discarding comments.
   KeepComments = false;


### PR DESCRIPTION
`getShowColors() != ShowColorsKind::Off` is also true for the default Auto, so ordinary non-TTY compiles where colors are never actually emitted kept recording check points, leaving the original 718aac9f cost in place.
