### PR TITLE
[mlir][gpu][nvvm] Add gpu.subgroup_broadcast lowering

### DIFF
--- a/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
+++ b/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
@@ -64,6 +64,10 @@ static NVVM::ShflKind convertShflKind(gpu::ShuffleMode mode) {
   llvm_unreachable("unknown shuffle mode");
 }
 
+static bool isSupportedNvvmShflPayloadType(Type type) {
+  return type.isInteger(32) || isa<Float32Type>(type);
+}
+
 static std::optional<NVVM::ReductionKind>
 convertToNVVMReductionKind(gpu::AllReduceOperation mode) {
   switch (mode) {
@@ -245,6 +249,57 @@ struct GPUShuffleOpLowering : public ConvertOpToLLVMPattern<gpu::ShuffleOp> {
     } else {
       rewriter.replaceOp(op, {shfl, nullptr});
     }
+    return success();
+  }
+};
+
+struct GPUSubgroupBroadcastOpLowering
+    : public ConvertOpToLLVMPattern<gpu::SubgroupBroadcastOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(gpu::SubgroupBroadcastOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto i32Type = rewriter.getI32Type();
+    Location loc = op.getLoc();
+    Value fullMask = LLVM::ConstantOp::create(rewriter, loc, i32Type, -1);
+    Value maskAndClamp = LLVM::ConstantOp::create(rewriter, loc, i32Type, 31);
+    auto voteKind = NVVM::VoteSyncKindAttr::get(rewriter.getContext(),
+                                                NVVM::VoteSyncKind::ballot);
+    Value activeMask = NVVM::VoteSyncOp::create(
+        rewriter, loc, i32Type, fullMask,
+        LLVM::ConstantOp::create(rewriter, loc, rewriter.getI1Type(), true),
+        voteKind);
+
+    Value lane = adaptor.getLane();
+    if (adaptor.getBroadcastType() == gpu::BroadcastType::first_active_lane)
+      lane = LLVM::CountTrailingZerosOp::create(rewriter, loc, i32Type,
+                                                activeMask, false);
+
+    auto emitBroadcast = [&](Value payload) {
+      return NVVM::ShflOp::create(rewriter, loc, payload.getType(), activeMask,
+                                  payload, lane, maskAndClamp,
+                                  NVVM::ShflKind::idx, /*return*/ nullptr);
+    };
+
+    Value src = adaptor.getSrc();
+    if (isSupportedNvvmShflPayloadType(src.getType())) {
+      rewriter.replaceOp(op, emitBroadcast(src));
+      return success();
+    }
+
+    SmallVector<Value> decomposed;
+    if (failed(LLVM::decomposeValue(rewriter, loc, src, i32Type, decomposed,
+                                    /*permitVariablySizedScalars=*/true)))
+      return rewriter.notifyMatchFailure(op,
+                                         "unexpected decomposition failure");
+
+    SmallVector<Value> results;
+    results.reserve(decomposed.size());
+    for (Value v : decomposed)
+      results.push_back(emitBroadcast(v));
+    rewriter.replaceOp(op, LLVM::composeValue(rewriter, loc, results,
+                                              adaptor.getSrc().getType()));
     return success();
   }
 };
@@ -667,7 +722,8 @@ void mlir::populateGpuToNVVMConversionPatterns(
       gpu::GridDimOp, NVVM::GridDimXOp, NVVM::GridDimYOp, NVVM::GridDimZOp>>(
       converter, IndexKind::Grid, IntrType::Dim, benefit);
   patterns.add<GPULaneIdOpToNVVM, GPUBallotOpToNVVM, GPUShuffleOpLowering,
-               GPUReturnOpLowering>(converter, benefit);
+               GPUSubgroupBroadcastOpLowering, GPUReturnOpLowering>(converter,
+                                                                    benefit);
 
   patterns.add<GPUDynamicSharedMemoryOpLowering>(
       converter, NVVM::kSharedMemoryAlignmentBit, benefit);

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
@@ -182,6 +182,48 @@ gpu.module @test_module_4 {
   }
 }
 
+gpu.module @test_module_4b {
+  // CHECK-LABEL: func @gpu_subgroup_broadcast_specific_lane
+  // CHECK-SAME: (%[[BCAST_SRC:.+]]: i32, %[[BCAST_LANE:.+]]: i32)
+  func.func @gpu_subgroup_broadcast_specific_lane(%arg0 : i32,
+                                                  %arg1 : i32) -> i32 {
+    // CHECK: %[[BCAST_FULL_MASK:.+]] = llvm.mlir.constant(-1 : i32) : i32
+    // CHECK: %[[BCAST_CLAMP:.+]] = llvm.mlir.constant(31 : i32) : i32
+    // CHECK: %[[BCAST_TRUE:.+]] = llvm.mlir.constant(true) : i1
+    // CHECK: %[[BCAST_ACTIVE_MASK:.+]] = nvvm.vote.sync ballot %[[BCAST_FULL_MASK]], %[[BCAST_TRUE]] -> i32
+    // CHECK: nvvm.shfl.sync idx %[[BCAST_ACTIVE_MASK]], %[[BCAST_SRC]], %[[BCAST_LANE]], %[[BCAST_CLAMP]] : i32 -> i32
+    %0 = gpu.subgroup_broadcast %arg0, specific_lane %arg1 : i32
+    func.return %0 : i32
+  }
+
+  // CHECK-LABEL: func @gpu_subgroup_broadcast_first_active_lane
+  // CHECK-SAME: (%[[BCAST_SRC:.+]]: f32)
+  func.func @gpu_subgroup_broadcast_first_active_lane(%arg0 : f32) -> f32 {
+    // CHECK: %[[BCAST_FULL_MASK:.+]] = llvm.mlir.constant(-1 : i32) : i32
+    // CHECK: %[[BCAST_CLAMP:.+]] = llvm.mlir.constant(31 : i32) : i32
+    // CHECK: %[[BCAST_TRUE:.+]] = llvm.mlir.constant(true) : i1
+    // CHECK: %[[BCAST_ACTIVE_MASK:.+]] = nvvm.vote.sync ballot %[[BCAST_FULL_MASK]], %[[BCAST_TRUE]] -> i32
+    // CHECK: %[[BCAST_FIRST_LANE:.+]] = {{.*}}(%[[BCAST_ACTIVE_MASK]]) <{is_zero_poison = false}> : (i32) -> i32
+    // CHECK: nvvm.shfl.sync idx %[[BCAST_ACTIVE_MASK]], %[[BCAST_SRC]], %[[BCAST_FIRST_LANE]], %[[BCAST_CLAMP]] : f32 -> f32
+    %0 = gpu.subgroup_broadcast %arg0, first_active_lane : f32
+    func.return %0 : f32
+  }
+
+  // CHECK-LABEL: func @gpu_subgroup_broadcast_i48
+  // CHECK-SAME: (%[[BCAST_SRC:.+]]: i48)
+  func.func @gpu_subgroup_broadcast_i48(%arg0 : i48) -> i48 {
+    // CHECK: %[[BCAST_FULL_MASK:.+]] = llvm.mlir.constant(-1 : i32) : i32
+    // CHECK: %[[BCAST_CLAMP:.+]] = llvm.mlir.constant(31 : i32) : i32
+    // CHECK: %[[BCAST_TRUE:.+]] = llvm.mlir.constant(true) : i1
+    // CHECK: %[[BCAST_ACTIVE_MASK:.+]] = nvvm.vote.sync ballot %[[BCAST_FULL_MASK]], %[[BCAST_TRUE]] -> i32
+    // CHECK: %[[BCAST_FIRST_LANE:.+]] = {{.*}}(%[[BCAST_ACTIVE_MASK]]) <{is_zero_poison = false}> : (i32) -> i32
+    // CHECK: nvvm.shfl.sync idx %[[BCAST_ACTIVE_MASK]], %{{.*}}, %[[BCAST_FIRST_LANE]], %[[BCAST_CLAMP]] : i32 -> i32
+    // CHECK: nvvm.shfl.sync idx %[[BCAST_ACTIVE_MASK]], %{{.*}}, %[[BCAST_FIRST_LANE]], %[[BCAST_CLAMP]] : i32 -> i32
+    %0 = gpu.subgroup_broadcast %arg0, first_active_lane : i48
+    func.return %0 : i48
+  }
+}
+
 gpu.module @test_module_5 {
   // CHECK-LABEL: func @gpu_sync()
   func.func @gpu_sync() {


### PR DESCRIPTION
Tracking issue: #157937 

This patch adds NVVM lowering support for `gpu.subgroup_broadcast`, following the existing subgroup scalarization/decomposition tracker direction.

### Motivation

`gpu.subgroup_broadcast` was not lowered in GPUToNVVM, causing legalization failure under `-convert-gpu-to-nvvm` for broadcast cases.
This change closes that NVVM coverage gap while preserving native fast paths.

### What changed

- Added `gpu.subgroup_broadcast` lowering in:
  - `mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp`
- Preserved native fast-path behavior for NVVM-supported payloads (`i32`/`f32`).
- Added decomposition/scalarization for non-native payloads:
  - decompose to `i32` chunks
  - lower each chunk via `nvvm.shfl.sync idx`
  - compose back to original type
- Implemented both broadcast modes:
  - `specific_lane`
  - `first_active_lane`

### Tests

Updated:
- `mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir`

Added focused coverage for:
- `specific_lane` on `i32`
- `first_active_lane` on `f32`
- decomposition case on `i48`

### Validation

- `ninja mlir-opt`
- `./bin/llvm-lit ../mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir ../mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-32b.mlir ../mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-invalid-ballot.mlir`
- `./bin/llvm-lit ../mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir`

All passed.