### PR TITLE
[libc++][utils] Fix LIT `%if` substitution support

### DIFF
--- a/libcxx/test/selftest/if-else.sh.cpp
+++ b/libcxx/test/selftest/if-else.sh.cpp
@@ -8,4 +8,4 @@
 
 // Make sure that LIT `%if` substitutions are aware of the available features.
 
-// RUN: not %if libcpp-abi-version={{[0-9]+}} %{ not %} echo "hello world"
+// RUN: not %if target={{.+}} %{ not %} echo "hello world"

--- a/libcxx/test/selftest/if-else.sh.cpp
+++ b/libcxx/test/selftest/if-else.sh.cpp
@@ -1,0 +1,11 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Make sure that LIT `%if` substitutions are aware of the available features.
+
+// RUN: not %if libcpp-abi-version={{[0-9]+}} %{ not %} echo "hello world"

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -205,8 +205,9 @@ def parseScript(test, preamble):
         )
 
     # Perform substitutions in the script itself.
+    conditions = {feature: True for feature in test.config.available_features}
     script = lit.TestRunner.applySubstitutions(
-        script, substitutions, recursion_limit=test.config.recursiveExpansionLimit
+        script, substitutions, conditions, recursion_limit=test.config.recursiveExpansionLimit
     )
 
     return script

--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -207,7 +207,10 @@ def parseScript(test, preamble):
     # Perform substitutions in the script itself.
     conditions = {feature: True for feature in test.config.available_features}
     script = lit.TestRunner.applySubstitutions(
-        script, substitutions, conditions, recursion_limit=test.config.recursiveExpansionLimit
+        script,
+        substitutions,
+        conditions,
+        recursion_limit=test.config.recursiveExpansionLimit,
     )
 
     return script


### PR DESCRIPTION
Update the `applySubstitutions` call in `libcxx/utils/libcxx/test/format.py` to match the change to `llvm/utils/lit/lit/TestRunner.py` done in 1041a9642ba035fd2685f925911d705e8edf5bb0.

---------

Assisted-by: IBM Bob