### PR TITLE
[libunwind][test] Add .clang-format

### DIFF
--- a/libunwind/test/.clang-format
+++ b/libunwind/test/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: InheritParentConfig
+
+# Disable formatting options which may break tests.
+ReflowComments: false


### PR DESCRIPTION
Borrow from `libcxx/test/.clang-format` to avoid `clang-format` suggestions that are incompatible with `FileCheck`.