### PR TITLE
Revert "[compiler-rt] [sanitizer_common] Fix SIGSEGV in ForEachMappedRegion for DSOs with custom image base"

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_nolibc.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_nolibc.cpp
@@ -34,6 +34,4 @@ void ListOfModules::init() {}
 void InitializePlatformCommonFlags(CommonFlags *cf) {}
 #endif
 
-char* DladdrElfHeaderBase(void* ld, char* addr) { return addr; }
-
 }  // namespace __sanitizer

--- a/compiler-rt/lib/sanitizer_common/sanitizer_dl.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_dl.cpp
@@ -34,13 +34,4 @@ const char *DladdrSelfFName(void) {
   return nullptr;
 }
 
-char* DladdrElfHeaderBase(void* ld, char* addr) {
-#if SANITIZER_GLIBC
-  Dl_info info;
-  if (dladdr(ld, &info) && info.dli_fbase)
-    addr = (char*)info.dli_fbase;
-#endif  // SANITIZER_GLIBC
-  return addr;
-}
-
 }  // namespace __sanitizer

--- a/compiler-rt/lib/sanitizer_common/sanitizer_dl.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_dl.h
@@ -21,10 +21,6 @@ namespace __sanitizer {
 // - the main program itself, that contains the sanitizer.
 const char* DladdrSelfFName(void);
 
-// Returns the base address of the ELF header, taking custom base offsets
-// into account.
-char* DladdrElfHeaderBase(void* ld, char* addr);
-
 }  // namespace __sanitizer
 
 #endif  // SANITIZER_DL_H

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -17,7 +17,6 @@
     SANITIZER_SOLARIS || SANITIZER_HAIKU
 
 #  include "sanitizer_common.h"
-#  include "sanitizer_dl.h"
 #  include "sanitizer_flags.h"
 #  include "sanitizer_getauxval.h"
 #  include "sanitizer_internal_defs.h"
@@ -1404,7 +1403,7 @@ void ForEachMappedRegion(link_map *map, void (*cb)(const void *, uptr)) {
   typedef ElfW(Phdr) Elf_Phdr;
   typedef ElfW(Ehdr) Elf_Ehdr;
 #    endif  // !SANITIZER_FREEBSD
-  char* base = DladdrElfHeaderBase((void*)map->l_ld, (char*)map->l_addr);
+  char *base = (char *)map->l_addr;
   Elf_Ehdr *ehdr = (Elf_Ehdr *)base;
   char *phdrs = base + ehdr->e_phoff;
   char *phdrs_end = phdrs + ehdr->e_phnum * ehdr->e_phentsize;

--- a/compiler-rt/lib/tsan/go/buildgo.sh
+++ b/compiler-rt/lib/tsan/go/buildgo.sh
@@ -88,7 +88,6 @@ if [ "$GOOS" = "linux" ]; then
 	SRCS="
 		$SRCS
 		../rtl/tsan_platform_linux.cpp
-		../../sanitizer_common/sanitizer_dl.cpp
 		../../sanitizer_common/sanitizer_posix.cpp
 		../../sanitizer_common/sanitizer_posix_libcdep.cpp
 		../../sanitizer_common/sanitizer_procmaps_common.cpp
@@ -134,7 +133,6 @@ elif [ "$GOOS" = "freebsd" ]; then
 	SRCS="
 		$SRCS
 		../rtl/tsan_platform_linux.cpp
-		../../sanitizer_common/sanitizer_dl.cpp
 		../../sanitizer_common/sanitizer_posix.cpp
 		../../sanitizer_common/sanitizer_posix_libcdep.cpp
 		../../sanitizer_common/sanitizer_procmaps_bsd.cpp
@@ -155,7 +153,6 @@ elif [ "$GOOS" = "netbsd" ]; then
 	SRCS="
 		$SRCS
 		../rtl/tsan_platform_linux.cpp
-		../../sanitizer_common/sanitizer_dl.cpp
 		../../sanitizer_common/sanitizer_posix.cpp
 		../../sanitizer_common/sanitizer_posix_libcdep.cpp
 		../../sanitizer_common/sanitizer_procmaps_bsd.cpp

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/dlopen_image_base.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/dlopen_image_base.c
@@ -6,6 +6,7 @@
 // REQUIRES: glibc
 
 // Regression test for #84482 and #21068
+// XFAIL: msan, dfsan
 
 #ifndef BUILD_SO
 #  define _GNU_SOURCE


### PR DESCRIPTION
Reverts llvm/llvm-project#206299 due to buildbot breakage (https://github.com/llvm/llvm-project/pull/206299#issuecomment-4964804971)