### PR TITLE
[orc-rt] Statically check logging category/level name array sizes.

### DIFF
--- a/orc-rt/lib/executor/Logging.cpp
+++ b/orc-rt/lib/executor/Logging.cpp
@@ -12,15 +12,20 @@
 
 #include "orc-rt-c/Logging.h"
 
+#include <array>
 #include <cassert>
 #include <cctype>
 #include <cstring>
 
-static const char *CategoryNames[orc_rt_log_Category_Count] = {"General"};
+static const char *CategoryNames[] = {"General"};
+static_assert(std::size(CategoryNames) == orc_rt_log_Category_Count,
+              "CategoryNames array is the wrong size");
 
-static const char *LevelNames[ORC_RT_LOG_LEVEL_COUNT] = {
+static const char *LevelNames[] = {
     "DEBUG", "INFO", "WARNING", "ERROR", "OFF",
 };
+static_assert(std::size(LevelNames) == ORC_RT_LOG_LEVEL_COUNT,
+              "LevelNames array is the wrong size");
 
 const char *orc_rt_log_Category_getName(orc_rt_log_Category Cat) noexcept {
   if (Cat < 0 || Cat >= orc_rt_log_Category_Count)


### PR DESCRIPTION
Add static_asserts to trigger compilation failure if the sizes of these arrays don't match their respective enum/macro value ranges.