### PR TITLE
[orc-rt] Add new ControllerAccess logging category.

### DIFF
--- a/orc-rt/include/orc-rt-c/Logging.h
+++ b/orc-rt/include/orc-rt-c/Logging.h
@@ -60,6 +60,7 @@ ORC_RT_C_EXTERN_C_BEGIN
  */
 typedef enum {
   orc_rt_log_Category_General,
+  orc_rt_log_Category_ControllerAccess,
 
   /*
    * Count is the number of defined categories; it is not itself a valid

--- a/orc-rt/lib/executor/Logging.cpp
+++ b/orc-rt/lib/executor/Logging.cpp
@@ -17,7 +17,7 @@
 #include <cctype>
 #include <cstring>
 
-static const char *CategoryNames[] = {"General"};
+static const char *CategoryNames[] = {"General", "ControllerAccess"};
 static_assert(std::size(CategoryNames) == orc_rt_log_Category_Count,
               "CategoryNames array is the wrong size");
 

--- a/orc-rt/test/unit/LoggingTest.cpp
+++ b/orc-rt/test/unit/LoggingTest.cpp
@@ -14,6 +14,9 @@
 
 #include "gtest/gtest.h"
 
+#include <string>
+#include <unordered_set>
+
 namespace {
 
 // Every level and category must compile and be usable as a plain statement,
@@ -68,10 +71,20 @@ TEST(LoggingTest, LevelParseGetNameRoundTrip) {
   }
 }
 
-TEST(LoggingTest, CategoryGetName) {
-  EXPECT_STREQ("General",
-               orc_rt_log_Category_getName(orc_rt_log_Category_General));
+TEST(LoggingTest, CategoryNamesAreUniqueAndNonNull) {
+  // Check that every category has a unique, non-null name.
+  std::unordered_set<std::string> Seen;
+  for (int C = orc_rt_log_Category_General; C != orc_rt_log_Category_Count;
+       ++C) {
+    const char *Name =
+        orc_rt_log_Category_getName(static_cast<orc_rt_log_Category>(C));
+    ASSERT_NE(Name, nullptr) << "category " << C << " has no name";
+    EXPECT_TRUE(Seen.insert(Name).second)
+        << "category " << C << " has a duplicate name: " << Name;
+  }
+}
 
+TEST(LoggingTest, OutOfRangeCategoryNamesAreNull) {
   // The Count sentinel is not a real category, and out-of-range values have no
   // name.
   EXPECT_EQ(nullptr, orc_rt_log_Category_getName(orc_rt_log_Category_Count));


### PR DESCRIPTION
The orc_rt_log_Category_ControllerAccess category should be used to log messages from ControllerAccess implementations. E.g.

  ORC_RT_LOG(Error, ControllerAccess, "connect() failed with <error>");