### PR TITLE
[RISCV] Rename VLSU_MEM_LATENCY to Andes45VLSU_MEM_LATENCY in RISCVSchedAndes45.td

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
@@ -27,7 +27,7 @@ defvar Andes45VLSU_MEM_DW = Andes45BIU_DATA_WIDTH;
 defvar Andes45VLEN_VLSU_MEM_DW_RATIO = !div(Andes45VLEN, Andes45VLSU_MEM_DW);
 
 // There are various latency depending on its memory type and status.
-defvar VLSU_MEM_LATENCY = 13;
+defvar Andes45VLSU_MEM_LATENCY = 13;
 
 // The worst case LMUL is the largest LMUL.
 class Andes45IsWorstCaseMX<string mx, list<string> MxList> {
@@ -582,7 +582,7 @@ foreach mx = SchedMxList in {
   defvar Cycles = Andes45GetCyclesLoadStore<mx>.c;
   defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
 
-  let Latency = !add(4, VLSU_MEM_LATENCY), ReleaseAtCycles = [Cycles] in {
+  let Latency = !add(4, Andes45VLSU_MEM_LATENCY), ReleaseAtCycles = [Cycles] in {
     defm "" : LMULWriteResMX<"WriteVLDE", [Andes45VLSU], mx, IsWorstCase>;
     defm "" : LMULWriteResMX<"WriteVLDFF", [Andes45VLSU], mx, IsWorstCase>;
   }
@@ -590,7 +590,7 @@ foreach mx = SchedMxList in {
   defm "" : LMULWriteResMX<"WriteVSTE", [Andes45VLSU], mx, IsWorstCase>;
 
   // Mask loads and stores
-  let Latency = !add(4, VLSU_MEM_LATENCY), ReleaseAtCycles = [Cycles] in
+  let Latency = !add(4, Andes45VLSU_MEM_LATENCY), ReleaseAtCycles = [Cycles] in
   defm "" : LMULWriteResMX<"WriteVLDM", [Andes45VLSU], mx, IsWorstCase=!eq(mx, "M1")>;
   let ReleaseAtCycles = [Cycles] in
   defm "" : LMULWriteResMX<"WriteVSTM", [Andes45VLSU], mx, IsWorstCase=!eq(mx, "M1")>;
@@ -608,7 +608,7 @@ foreach mx = SchedMxList in {
   foreach eew = [8, 16, 32, 64] in {
     defvar Cycles = Andes45GetCyclesOnePerElement<mx, eew>.c;
 
-    let Latency = !add(4, !add(VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
+    let Latency = !add(4, !add(Andes45VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
         ReleaseAtCycles = [Cycles] in
       defm "" : LMULWriteResMX<"WriteVLDS"  # eew, [Andes45VLSU], mx, IsWorstCase>;
 
@@ -629,7 +629,7 @@ foreach mx = SchedMxList in {
   foreach eew = [8, 16, 32, 64] in {
     defvar Cycles = Andes45GetCyclesOnePerElement<mx, eew>.c;
 
-    let Latency = !add(5, !add(VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
+    let Latency = !add(5, !add(Andes45VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
         ReleaseAtCycles = [!add(Cycles, !sub(Andes45GetLMULValue<mx>.c, 1))] in {
       defm "" : LMULWriteResMX<"WriteVLDUX" # eew, [Andes45VLSU], mx, IsWorstCase>;
       defm "" : LMULWriteResMX<"WriteVLDOX" # eew, [Andes45VLSU], mx, IsWorstCase>;
@@ -653,7 +653,7 @@ foreach mx = SchedMxList in {
       defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
       defvar Size = !mul(Andes45GetLMULValue<mx>.c, nf);
 
-      let Latency = !add(4, !add(VLSU_MEM_LATENCY, !add(Size, 2))),
+      let Latency = !add(4, !add(Andes45VLSU_MEM_LATENCY, !add(Size, 2))),
           ReleaseAtCycles = [!mul(Cycles, nf)] in {
         defm "" : LMULWriteResMX<"WriteVLSEG" # nf # "e" # eew,
                                  [Andes45VLSU], mx, IsWorstCase>;
@@ -677,7 +677,7 @@ foreach mx = SchedMxList in {
       defvar Cycles = Andes45GetCyclesOnePerElement<mx, eew>.c;
       defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
 
-      let Latency = !add(5, !add(VLSU_MEM_LATENCY, !mul(!div(Andes45DLEN, eew), nf))),
+      let Latency = !add(5, !add(Andes45VLSU_MEM_LATENCY, !mul(!div(Andes45DLEN, eew), nf))),
           ReleaseAtCycles = [!mul(Cycles, nf)] in
         defm "" : LMULWriteResMX<"WriteVLSSEG" # nf # "e" # eew,
                                  [Andes45VLSU], mx, IsWorstCase>;
@@ -698,7 +698,7 @@ foreach mx = SchedMxList in {
       defvar Cycles = Andes45GetCyclesOnePerElement<mx, eew>.c;
       defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
 
-      let Latency = !add(6, !add(VLSU_MEM_LATENCY, !mul(!div(Andes45DLEN, eew), nf))),
+      let Latency = !add(6, !add(Andes45VLSU_MEM_LATENCY, !mul(!div(Andes45DLEN, eew), nf))),
           ReleaseAtCycles = [!add(!mul(Cycles, nf),
                                   !sub(Andes45GetLMULValue<mx>.c, 1))] in {
         defm "" : LMULWriteResMX<"WriteVLUXSEG" # nf # "e" # eew,


### PR DESCRIPTION
Prefix the defvar with the Andes45 scheduler name to match the other Andes45-local defvars (e.g. Andes45DLEN) and avoid a bare, generic name in the shared RISC-V TableGen namespace.