### PR TITLE
[LFI][libunwind] Omit unsuppported stg/za instructions for LFI target

### DIFF
--- a/libunwind/src/DwarfInstructions.hpp
+++ b/libunwind/src/DwarfInstructions.hpp
@@ -216,7 +216,7 @@ int DwarfInstructions<A, R>::stepWithDwarf(
       // __unw_step_stage2 is not used for cross unwinding, so we use
       // __aarch64__ rather than LIBUNWIND_TARGET_AARCH64 to make sure we are
       // building for AArch64 natively.
-#if defined(__aarch64__)
+#if defined(__aarch64__) && !defined(__LFI__)
       if (stage2 && cieInfo.mteTaggedFrame) {
         pint_t sp = registers.getSP();
         pint_t p = sp;

--- a/libunwind/src/UnwindRegistersSave.S
+++ b/libunwind/src/UnwindRegistersSave.S
@@ -854,6 +854,10 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
   .p2align 2
 DEFINE_LIBUNWIND_FUNCTION(__libunwind_Registers_arm64_za_disable)
   .variant_pcs __libunwind_Registers_arm64_za_disable
+#if defined(__LFI__)
+  mov x0, xzr
+  ret
+#else
 #if __has_feature(ptrauth_calls)
   pacibsp
 #endif
@@ -896,6 +900,7 @@ DEFINE_LIBUNWIND_FUNCTION(__libunwind_Registers_arm64_za_disable)
   retab
 #else
   ret
+#endif
 #endif
 
 #elif defined(__arm__) && !defined(__APPLE__)

--- a/libunwind/src/UnwindRegistersSave.S
+++ b/libunwind/src/UnwindRegistersSave.S
@@ -855,7 +855,7 @@ DEFINE_LIBUNWIND_FUNCTION(__unw_getcontext)
 DEFINE_LIBUNWIND_FUNCTION(__libunwind_Registers_arm64_za_disable)
   .variant_pcs __libunwind_Registers_arm64_za_disable
 #if defined(__LFI__)
-  mov x0, xzr
+  mov x0, #1
   ret
 #else
 #if __has_feature(ptrauth_calls)


### PR DESCRIPTION
Under the LFI target the SVE `za` are not currently supported, and neither is the `stg` instruction. When included in an LFI program they cause verification failures due to being unsupported instructions. This patch omits them from compilation when targeting LFI.