### PR TITLE
[mlir][affine] Add SimplifyAffineLoopWithConstant pattern to affine-simplify-with-bounds pass

### DIFF
--- a/mlir/lib/Dialect/Affine/Transforms/SimplifyAffineWithBounds.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/SimplifyAffineWithBounds.cpp
@@ -301,13 +301,122 @@ struct SimplifyAffineLoopBoundMap final : OpRewritePattern<AffineForOp> {
     return success();
   }
 };
+
+/// Computes a constant lower/upper bound for \p map applied to \p operands
+/// using ValueBoundsConstraintSet
+static FailureOr<int64_t> computeConstantBound(AffineMap map,
+                                               ValueRange operands,
+                                               presburger::BoundType type) {
+  ValueBoundsConstraintSet::Variable var(map, operands);
+  ValueBoundsOptions options;
+  options.closedUB = true;
+  return ValueBoundsConstraintSet::computeConstantBound(type, var, nullptr,
+                                                        options);
+}
+
+/// Evaluates the AffineMap \p map with the given \p operands by computing both
+/// its lower bound (LB) and upper bound (UB). If both bounds converge to the
+/// same value, returns that unique constant, otherwise, returns std::nullopt.
+std::optional<int64_t> getConstantBound(AffineMap map, ValueRange operands) {
+  std::optional<int64_t> result = std::nullopt;
+
+  // Compute the constant lower bound (LB) for the map-operand combination.
+  FailureOr<int64_t> min =
+      computeConstantBound(map, operands, presburger::BoundType::LB);
+  if (failed(min))
+    return std::nullopt;
+
+  // Compute the constant upper bound (UB) for the same map and operands.
+  FailureOr<int64_t> max =
+      computeConstantBound(map, operands, presburger::BoundType::UB);
+  if (failed(max))
+    return std::nullopt;
+
+  // The value is a fixed constant only if LB and UB converge perfectly.
+  if (min.value() != max.value())
+    return std::nullopt;
+
+  // Return the confirmed single constant value.
+  if (!result)
+    result = min.value();
+  return result;
+}
+
+/// A pattern that simplifies lower and upper bounds of `affine.for` loops
+/// into constant expressions leveraging `ValueBoundsConstraintSet`.
+struct SimplifyAffineLoopWithConstant final : OpRewritePattern<AffineForOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(AffineForOp forOp,
+                                PatternRewriter &rewriter) const override {
+
+    // Helper lambda to simplify a single bound map (either lower or upper)
+    auto simplifyBound = [&](AffineMap map,
+                             ValueRange operands) -> std::optional<AffineMap> {
+      bool changed = false;
+      SmallVector<AffineExpr> results;
+
+      for (size_t i = 0, e = map.getNumResults(); i < e; ++i) {
+        AffineExpr expr = map.getResult(i);
+
+        // 1. Fast path: If it is already a constant expression, keep it as-is
+        if (llvm::isa<AffineConstantExpr>(expr)) {
+          results.push_back(expr);
+          continue;
+        }
+
+        // 2. Slow path: Invoke value bounds analysis to resolve implicit
+        // constants
+        AffineMap subMap = map.getSubMap(i);
+        if (auto bound = getConstantBound(subMap, operands)) {
+          results.push_back(rewriter.getAffineConstantExpr(*bound));
+          changed = true;
+        } else {
+          results.push_back(expr);
+        }
+      }
+
+      if (!changed)
+        return std::nullopt;
+
+      return AffineMap::get(map.getNumDims(), map.getNumSymbols(), results,
+                            rewriter.getContext());
+    };
+
+    bool lbChanged = false;
+    bool ubChanged = false;
+
+    // 1. Try to simplify the lower bound map
+    if (auto newLbMap = simplifyBound(forOp.getLowerBoundMap(),
+                                      forOp.getLowerBoundOperands())) {
+      rewriter.modifyOpInPlace(forOp, [&]() {
+        forOp.setLowerBound(forOp.getLowerBoundOperands(), *newLbMap);
+      });
+      lbChanged = true;
+    }
+
+    // 2. Try to simplify the upper bound map
+    if (auto newUbMap = simplifyBound(forOp.getUpperBoundMap(),
+                                      forOp.getUpperBoundOperands())) {
+      rewriter.modifyOpInPlace(forOp, [&]() {
+        forOp.setUpperBound(forOp.getUpperBoundOperands(), *newUbMap);
+      });
+      ubChanged = true;
+    }
+
+    // Return success if either the lower or upper bound was successfully
+    // simplified
+    return success(lbChanged || ubChanged);
+  }
+};
+
 } // namespace
 
 void affine::populateSimplifyAffineWithBoundsPatterns(
     RewritePatternSet &patterns) {
-  patterns
-      .add<SimplifyDelinearizeOfLinearizeDisjoint, SimplifyAffineLoopBoundMap>(
-          patterns.getContext());
+  patterns.add<SimplifyDelinearizeOfLinearizeDisjoint,
+               SimplifyAffineLoopBoundMap, SimplifyAffineLoopWithConstant>(
+      patterns.getContext());
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/Affine/simplify-with-bounds.mlir
+++ b/mlir/test/Dialect/Affine/simplify-with-bounds.mlir
@@ -193,3 +193,30 @@ func.func @simplify_loop_bound() -> index{
 //     CHECK:   %[[SUM:.*]] = arith.addi %[[ARG]], %[[C1]] : index
 //     CHECK:   affine.yield %[[SUM]] : index
 //     CHECK:  }
+
+// -----
+
+// CHECK: #[[$MAP:.+]] = affine_map<()[s0] -> (s0, 2)>
+
+// CHECK-LABEL: func @simplify_loop_bound_with_constant
+func.func @simplify_loop_bound_with_constant() -> index {
+  %c0 = arith.constant 0 :index
+  %c1 = arith.constant 1 : index
+  %bound = test.value_with_bounds { min = 1 : index, max = 2 : index}
+  %bound1 = test.value_with_bounds { min = 2 : index, max = 2 : index}
+  %bound2 = test.value_with_bounds { min = 3 : index, max = 3 : index}
+  %bound3 = test.value_with_bounds { min = 4 : index, max = 4 : index}
+  %res = affine.for %iv = max affine_map<(d0, d1) -> (d0, d1, d1)>(%bound, %bound1) to min affine_map<(d0, d1) -> (d0, d1, d1)>(%bound2, %bound3) step 2 iter_args(%arg = %c0) -> index {
+      %sum = arith.addi %arg, %c1 : index
+      affine.yield %sum : index
+  }
+  return %res : index
+}
+
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[BOUND0:.*]] = test.value_with_bounds {max = 2 : index, min = 1 : index}
+// CHECK: affine.for %[[VAL_0:.*]] = max #[[$MAP]]()[%[[BOUND0]]] to 3 step 2 iter_args(%[[VAL_1:.*]] = %[[C0]]) -> (index) {
+// CHECK:   %[[ADDI_0:.*]] = arith.addi %[[VAL_1]], %[[C1]] : index
+// CHECK:   affine.yield %[[ADDI_0]] : index
+// CHECK: }


### PR DESCRIPTION
This patch introduces a new pattern `SimplifyAffineLoopWithConstant`. By leveraging `ValueBoundsConstraintSet`, it resolves implicit or complex loop bounds into explicit constants. Which benefits and unblocks further affine analysis and transformations.