### PR TITLE
[WebAssembly] Fix operands in relaxed_pmin/relaxed_pmax pattern

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -152,7 +152,7 @@ WebAssemblyTargetLowering::WebAssemblyTargetLowering(
     // Support minimum and maximum, which otherwise default to expand.
     setOperationAction(ISD::FMINIMUM, T, Legal);
     setOperationAction(ISD::FMAXIMUM, T, Legal);
-    if (MVT(T).isVector()) {
+    if (Subtarget->hasSIMD128() && MVT(T).isVector()) {
       setOperationAction(ISD::PSEUDO_FMIN, T, Legal);
       setOperationAction(ISD::PSEUDO_FMAX, T, Legal);
     }

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
@@ -1863,21 +1863,21 @@ def relaxed_fmax : SDNode<"WebAssemblyISD::RELAXED_FMAX", SDTFPBinOp>;
 def relaxed_pmin :
   PatFrag<(ops node:$lhs, node:$rhs), (pmin $lhs, $rhs), [{
   return (N->getFlags().hasNoNaNs() ||
-          (CurDAG->isKnownNeverNaN(N->getOperand(1)) &&
-           CurDAG->isKnownNeverNaN(N->getOperand(2)))) &&
+          (CurDAG->isKnownNeverNaN(N->getOperand(0)) &&
+           CurDAG->isKnownNeverNaN(N->getOperand(1)))) &&
          (N->getFlags().hasNoSignedZeros() ||
-          CurDAG->isKnownNeverLogicalZero(N->getOperand(1)) ||
-          CurDAG->isKnownNeverLogicalZero(N->getOperand(2)));
+          CurDAG->isKnownNeverLogicalZero(N->getOperand(0)) ||
+          CurDAG->isKnownNeverLogicalZero(N->getOperand(1)));
 }]>;
 
 def relaxed_pmax :
   PatFrag<(ops node:$lhs, node:$rhs), (pmax $lhs, $rhs), [{
   return (N->getFlags().hasNoNaNs() ||
-          ((CurDAG->isKnownNeverNaN(N->getOperand(1))) &&
-           CurDAG->isKnownNeverNaN(N->getOperand(2)))) &&
+          ((CurDAG->isKnownNeverNaN(N->getOperand(0))) &&
+           CurDAG->isKnownNeverNaN(N->getOperand(1)))) &&
          (N->getFlags().hasNoSignedZeros() ||
-          CurDAG->isKnownNeverLogicalZero(N->getOperand(1)) ||
-          CurDAG->isKnownNeverLogicalZero(N->getOperand(2)));
+          CurDAG->isKnownNeverLogicalZero(N->getOperand(0)) ||
+          CurDAG->isKnownNeverLogicalZero(N->getOperand(1)));
 }]>;
 
 let Predicates = [HasRelaxedSIMD] in {

--- a/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmax.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmax.ll
@@ -343,6 +343,19 @@ define <4 x float> @test_pmax_v4f32_ogt(<4 x float> %x, <4 x float> %y) {
   ret <4 x float> %a
 }
 
+define <4 x float> @test_pmax_v4f32_ogt_const(<4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_ogt_const:
+; CHECK:         .functype test_pmax_v4f32_ogt_const (v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    v128.const 0x1p0, 0x1p0, 0x1p0, 0x1p0
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ogt <4 x float> %y, splat(float 1.0)
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> splat(float 1.0)
+  ret <4 x float> %a
+}
+
 define <4 x float> @test_pmax_v4f32_oge(<4 x float> %x, <4 x float> %y) {
 ; CHECK-LABEL: test_pmax_v4f32_oge:
 ; CHECK:         .functype test_pmax_v4f32_oge (v128, v128) -> (v128)

--- a/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmin.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmin.ll
@@ -311,6 +311,19 @@ define <4 x float> @test_pmin_v4f32_olt(<4 x float> %x, <4 x float> %y) {
   ret <4 x float> %a
 }
 
+define <4 x float> @test_pmin_v4f32_olt_const(<4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_olt_const:
+; CHECK:         .functype test_pmin_v4f32_olt_const (v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    v128.const 0x1p0, 0x1p0, 0x1p0, 0x1p0
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp olt <4 x float> %y, splat (float 1.0)
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> splat (float 1.0)
+  ret <4 x float> %a
+}
+
 define <4 x float> @test_pmin_v4f32_ole(<4 x float> %x, <4 x float> %y) {
 ; CHECK-LABEL: test_pmin_v4f32_ole:
 ; CHECK:         .functype test_pmin_v4f32_ole (v128, v128) -> (v128)


### PR DESCRIPTION
After 56e62e539eb65ebe4ec9fc6de0328fea21ae86fd these should be
operands 0 and 1 instead of 1 and 2.

Also add an explicit SIMD128 check when marking these as legal.
It works fine without it (presumably because the types just aren't
legal), but this makes it more explicit when the operations are
available.