### PR TITLE
[ORC] Add LLLazyJIT destructor with call to endSession.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
@@ -296,6 +296,8 @@ public:
     IPLayer->setPartitionFunction(std::move(Partition));
   }
 
+  LLVM_ABI ~LLLazyJIT();
+
   /// Returns a reference to the on-demand layer.
   CompileOnDemandLayer &getCompileOnDemandLayer() { return *CODLayer; }
 

--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -1312,6 +1312,14 @@ Error LLLazyJIT::addLazyIRModule(JITDylib &JD, ThreadSafeModule TSM) {
   return CODLayer->add(JD, std::move(TSM));
 }
 
+// End the session before this class's members (CODLayer, IPLayer, LCTMgr) are
+// destroyed: endSession joins the compile threads, and those threads may still
+// be operating on the CompileOnDemandLayer's per-dylib IndirectStubsManagers.
+LLLazyJIT::~LLLazyJIT() {
+  if (auto Err = ES->endSession())
+    ES->reportError(std::move(Err));
+}
+
 LLLazyJIT::LLLazyJIT(LLLazyJITBuilderState &S, Error &Err) : LLJIT(S, Err) {
 
   // If LLJIT construction failed then bail out.


### PR DESCRIPTION
Add an LLLazyJIT destructor with a call to ExecutionSession::endSession. This ensures that the ExecutionSession's TaskDispatcher is shut down (and in-flight tasks completed) before LLLazyJIT class members are destroyed. Failure to do this could lead to use-after-free errors when using thread-based task dispatch. This was likely the cause of flakiness in test/ExecutionEngine/OrcLazy/multiple-compile-threads-basic.ll.

rdar://181982834