### PR TITLE
[lldb][Windows] Use extended path prefix for rmtree

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -825,25 +825,7 @@ class Base(unittest.TestCase):
         previous contents."""
         bdir = self.getBuildDir()
         if os.path.isdir(bdir) and not self.SHARED_BUILD_TESTCASE:
-            # Tolerate files vanishing mid-walk. Clang's implicit module
-            # build leaves behind `*.pcm.lock` lockfiles whose lifetime is
-            # tied to the holding process; a concurrent or just-exited
-            # clang can unlink one between rmtree's scandir and unlink,
-            # raising ENOENT. The dir is going away anyway, so treat
-            # already-gone entries as success.
-            def _ignore_enoent(func, path, exc_info):
-                if (
-                    isinstance(exc_info[1], OSError)
-                    and exc_info[1].errno == errno.ENOENT
-                ):
-                    return
-                raise exc_info[1]
-
-            # Delete via the \\?\ extended-length path form so rmtree can remove
-            # build artifacts whose full path exceeds MAX_PATH (260) on Windows.
-            shutil.rmtree(
-                lldbutil.get_extended_windows_path(bdir), onerror=_ignore_enoent
-            )
+            lldbutil.remove_tree(bdir)
         lldbutil.mkdir_p(bdir)
 
     def getBuildArtifact(self, name="a.out"):
@@ -2314,7 +2296,7 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
         with open(src, "w") as f:
             f.write(new_content)
 
-        self.addTearDownHook(lambda: os.remove(src))
+        self.addTearDownHook(lambda: os.remove(lldbutil.get_extended_windows_path(src)))
 
     def setUp(self):
         # Works with the test driver to conditionally skip tests via
@@ -3176,7 +3158,7 @@ FileCheck output:
 def remove_file(file, num_retries=1, sleep_duration=0.5):
     for i in range(num_retries + 1):
         try:
-            os.remove(file)
+            os.remove(lldbutil.get_extended_windows_path(file))
             return True
         except:
             time.sleep(sleep_duration)

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -824,13 +824,6 @@ class Base(unittest.TestCase):
         """Create the test-specific working directory, optionally deleting any
         previous contents."""
         bdir = self.getBuildDir()
-        if sys.platform == "win32" and len(bdir) > 256:
-            import warnings
-
-            warnings.warn(
-                "Test build directory path exceeds 256 characters (Windows "
-                "MAX_PATH limit): {}".format(bdir)
-            )
         if os.path.isdir(bdir) and not self.SHARED_BUILD_TESTCASE:
             # Tolerate files vanishing mid-walk. Clang's implicit module
             # build leaves behind `*.pcm.lock` lockfiles whose lifetime is
@@ -846,25 +839,16 @@ class Base(unittest.TestCase):
                     return
                 raise exc_info[1]
 
-            # Delete via the \\?\ extended length path prefix so rmtree can
-            # remove build artifacts whose full path exceeds MAX_PATH (260).
-            rmtree_target = bdir
-            if sys.platform == "win32":
-                rmtree_target = "\\\\?\\" + bdir
-            shutil.rmtree(rmtree_target, onerror=_ignore_enoent)
+            # Delete via the \\?\ extended-length path form so rmtree can remove
+            # build artifacts whose full path exceeds MAX_PATH (260) on Windows.
+            shutil.rmtree(
+                lldbutil.get_extended_windows_path(bdir), onerror=_ignore_enoent
+            )
         lldbutil.mkdir_p(bdir)
 
     def getBuildArtifact(self, name="a.out"):
         """Return absolute path to an artifact in the test's build directory."""
-        artifact_path = os.path.join(self.getBuildDir(), name)
-        if sys.platform == "win32" and len(artifact_path) > 256:
-            import warnings
-
-            warnings.warn(
-                "Test artifact path exceeds 256 characters (Windows "
-                "MAX_PATH limit): {}".format(artifact_path)
-            )
-        return artifact_path
+        return os.path.join(self.getBuildDir(), name)
 
     def getSourcePath(self, name):
         """Return absolute path to a file in the test's source directory."""

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -846,7 +846,12 @@ class Base(unittest.TestCase):
                     return
                 raise exc_info[1]
 
-            shutil.rmtree(bdir, onerror=_ignore_enoent)
+            # Delete via the \\?\ extended length path prefix so rmtree can
+            # remove build artifacts whose full path exceeds MAX_PATH (260).
+            rmtree_target = bdir
+            if sys.platform == "win32":
+                rmtree_target = "\\\\?\\" + bdir
+            shutil.rmtree(rmtree_target, onerror=_ignore_enoent)
         lldbutil.mkdir_p(bdir)
 
     def getBuildArtifact(self, name="a.out"):

--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -10,6 +10,7 @@ import io
 import json
 import os
 import re
+import shutil
 import socket
 import sys
 import subprocess
@@ -81,6 +82,89 @@ def get_extended_windows_path(path):
     if abs_path.startswith("\\\\"):
         return "\\\\?\\UNC\\" + abs_path[2:]
     return "\\\\?\\" + abs_path
+
+
+def remove_tree(path):
+    """Recursively delete the directory tree rooted at ``path``.
+
+    On Windows this drives the shell ``SHFileOperationW`` API directly rather
+    than ``shutil.rmtree``. It deletes the whole tree in a single native call,
+    which also clears read-only files.
+
+    This mirrors lit's builtin ``rm`` (see
+    ``llvm/utils/lit/lit/InprocBuiltins.py``).
+
+    On non-Windows platforms this is ``shutil.rmtree`` with a handler that
+    tolerates entries vanishing mid-walk (``FileNotFoundError``). clang's
+    implicit-module ``*.pcm.lock`` files, whose lifetime is tied to a concurrent
+    or just-exited clang process.
+    """
+    if sys.platform != "win32":
+
+        def _ignore_missing(func, failed_path, exc):
+            # `shutil.rmtree` passes the error as an instance on the `onexc` API
+            # (3.12+) or a `sys.exc_info()` tuple on the legacy `onerror` API.
+            if isinstance(exc, tuple):
+                exc = exc[1]
+            if isinstance(exc, FileNotFoundError):
+                return
+            raise exc
+
+        if sys.version_info >= (3, 12):
+            shutil.rmtree(path, onexc=_ignore_missing)
+        else:
+            shutil.rmtree(path, onerror=_ignore_missing)
+        return
+
+    # NOTE: use ctypes to access `SHFileOperationW` on Windows so we can delete
+    # trees using the wide-character Win32 API, which reaches long file paths
+    # that cannot be removed otherwise.
+    from ctypes import (
+        POINTER,
+        Structure,
+        WinError,
+        addressof,
+        byref,
+        c_void_p,
+        create_unicode_buffer,
+        windll,
+    )
+    from ctypes.wintypes import BOOL, HWND, LPCWSTR, UINT, WORD
+
+    class SHFILEOPSTRUCTW(Structure):
+        _fields_ = [
+            ("hWnd", HWND),
+            ("wFunc", UINT),
+            ("pFrom", LPCWSTR),
+            ("pTo", LPCWSTR),
+            ("fFlags", WORD),
+            ("fAnyOperationsAborted", BOOL),
+            ("hNameMappings", c_void_p),
+            ("lpszProgressTitle", LPCWSTR),
+        ]
+
+    FO_DELETE = 3
+
+    FOF_SILENT = 4
+    FOF_NOCONFIRMATION = 16
+    FOF_NOCONFIRMMKDIR = 512
+    FOF_NOERRORUI = 1024
+    FOF_NO_UI = FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI | FOF_NOCONFIRMMKDIR
+
+    SHFileOperationW = windll.shell32.SHFileOperationW
+    SHFileOperationW.argtypes = [POINTER(SHFILEOPSTRUCTW)]
+
+    path = os.path.abspath(path)
+    pFrom = create_unicode_buffer(path, len(path) + 2)
+    pFrom[len(path)] = pFrom[len(path) + 1] = "\0"
+    operation = SHFILEOPSTRUCTW(
+        wFunc=UINT(FO_DELETE),
+        pFrom=LPCWSTR(addressof(pFrom)),
+        fFlags=FOF_NO_UI,
+    )
+    result = SHFileOperationW(byref(operation))
+    if result:
+        raise WinError(result)
 
 
 # ============================

--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -59,6 +59,30 @@ def mkdir_p(path):
         raise OSError(errno.ENOTDIR, "%s is not a directory" % path)
 
 
+def get_extended_windows_path(path):
+    r"""Return ``path`` in the Windows extended-length ``\\?\`` form so it can be
+    handed to the Win32 API (and therefore to ``os``/``shutil``) even when it is
+    longer than MAX_PATH (260 characters). On non-Windows platforms ``path`` is
+    returned unchanged.
+
+    The ``\\?\`` prefix disables all path normalization normally performed by
+    Win32, so the path must be fully qualified, use backslash separators and
+    contain no ``.``/``..`` components. ``os.path.abspath`` guarantees all three.
+    """
+    if sys.platform != "win32":
+        return path
+    if path.startswith("\\\\?\\"):
+        return path
+    assert os.path.isabs(path), (
+        "cannot form a \\\\?\\ extended-length path from relative path: %s" % path
+    )
+    abs_path = os.path.abspath(path)
+    # UNC shares (\\server\share) use the \\?\UNC\ spelling.
+    if abs_path.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + abs_path[2:]
+    return "\\\\?\\" + abs_path
+
+
 # ============================
 # Dealing with SDK and triples
 # ============================

--- a/lldb/test/API/driver/longpath/TestLongPathDriver.py
+++ b/lldb/test/API/driver/longpath/TestLongPathDriver.py
@@ -10,6 +10,7 @@ import subprocess
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
 
 MAX_PATH = 260
 
@@ -19,7 +20,7 @@ class DriverLongPathTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     def _long_path(self, path):
-        return "\\\\?\\" + os.path.abspath(path)
+        return lldbutil.get_extended_windows_path(path)
 
     def _make_long_dir(self):
         components = [self.getBuildArtifact("deep")] + ["d" * 80] * 3

--- a/lldb/test/API/functionalities/longpath/TestLongPath.py
+++ b/lldb/test/API/functionalities/longpath/TestLongPath.py
@@ -19,7 +19,7 @@ class LongPathTargetTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     def _long_path(self, path):
-        return "\\\\?\\" + os.path.abspath(path)
+        return lldbutil.get_extended_windows_path(path)
 
     def _normalize(self, path):
         if path.startswith("\\\\?\\"):

--- a/lldb/test/API/tools/lldb-dap/longpath/TestDAP_launch_longPath.py
+++ b/lldb/test/API/tools/lldb-dap/longpath/TestDAP_launch_longPath.py
@@ -8,6 +8,7 @@ import shutil
 
 import lldbdap_testcase
 from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
 
 MAX_PATH = 260
 
@@ -15,7 +16,7 @@ MAX_PATH = 260
 @skipUnlessWindows
 class TestDAP_launch_longPath(lldbdap_testcase.DAPTestCaseBase):
     def _long_path(self, path):
-        return "\\\\?\\" + os.path.abspath(path)
+        return lldbutil.get_extended_windows_path(path)
 
     def _normalize(self, path):
         if path.startswith("\\\\?\\"):

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -55,13 +55,6 @@ class ShTestLldb(ShTest):
         super().__init__(execute_external, extra_substitutions, preamble_commands)
 
     def execute(self, test, litConfig):
-        exec_path = test.getExecPath()
-        if platform.system() == "Windows" and len(exec_path) > 256:
-            litConfig.warning(
-                "Test path exceeds 256 characters (Windows MAX_PATH limit): "
-                + exec_path
-            )
-
         # Run each Shell test in a separate directory (on remote).
 
         # Find directory change command in %lldb substitution.


### PR DESCRIPTION
The test suite previously only warned when a test build directory or artifact path exceeded Windows' `MAX_PATH (260)` limit, and `shutil.rmtree` could fail to clean up such directories. This replaces the warnings with actual long-path support.

This is a recurring problem in Swiftlang.