### PR TITLE
[libc] Fix non-relative includes of __llvm-libc-common.h

### DIFF
--- a/libc/include/llvm-libc-macros/gpu/signal-macros.h
+++ b/libc/include/llvm-libc-macros/gpu/signal-macros.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_MACROS_GPU_SIGNAL_MACROS_H
 #define LLVM_LIBC_MACROS_GPU_SIGNAL_MACROS_H
 
-#include "__llvm-libc-common.h"
+#include "../../__llvm-libc-common.h"
 
 #define SIGINT 2
 #define SIGILL 4

--- a/libc/include/llvm-libc-macros/linux/signal-macros.h
+++ b/libc/include/llvm-libc-macros/linux/signal-macros.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_MACROS_LINUX_SIGNAL_MACROS_H
 #define LLVM_LIBC_MACROS_LINUX_SIGNAL_MACROS_H
 
-#include "__llvm-libc-common.h"
+#include "../../__llvm-libc-common.h"
 
 #define SIGHUP 1
 #define SIGINT 2

--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_MACROS_NETINET_IN_MACROS_H
 #define LLVM_LIBC_MACROS_NETINET_IN_MACROS_H
 
-#include "../llvm-libc-types/in_addr_t.h"
 #include "../__llvm-libc-common.h"
+#include "../llvm-libc-types/in_addr_t.h"
 
 #define IPPROTO_IP 0
 #define IPPROTO_ICMP 1

--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -10,7 +10,7 @@
 #define LLVM_LIBC_MACROS_NETINET_IN_MACROS_H
 
 #include "../llvm-libc-types/in_addr_t.h"
-#include "__llvm-libc-common.h"
+#include "../__llvm-libc-common.h"
 
 #define IPPROTO_IP 0
 #define IPPROTO_ICMP 1

--- a/libc/include/llvm-libc-types/__futex_word.h
+++ b/libc/include/llvm-libc-types/__futex_word.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES___FUTEX_WORD_H
 #define LLVM_LIBC_TYPES___FUTEX_WORD_H
 
-#include "__llvm-libc-common.h"
+#include "../__llvm-libc-common.h"
 
 typedef struct {
   // Futex word should be aligned appropriately to allow target atomic

--- a/libc/include/sys/prctl.h.def
+++ b/libc/include/sys/prctl.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SYS_PRCTL_H
 #define LLVM_LIBC_SYS_PRCTL_H
 
-#include "__llvm-libc-common.h"
+#include "../__llvm-libc-common.h"
 
 // Process control is highly platform specific, so the platform usually defines
 // the macros itself.


### PR DESCRIPTION
This seems to work, but I ran into this problem when trying to expand hermetic tests.

The hdrgen-generated headers already use relative includes of this file.