### PR TITLE
[lldb][Windows] add release notes for lldb-server

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -479,8 +479,8 @@ Makes programs 10x faster by doing Special New Thing.
 * Python 3.11 or later is now recommended for building LLDB 23 on Windows. From LLDB 24, Python 3.11 or later will be required.
 * Messages from `OutputDebugString[A|W]` are now shown inline when using LLDB
   from the command-line and in the output window when using lldb-dap.
-* lldb-server.exe is now the default plugin, replacing and deprecating the
-  "in-process" plugin.
+* LLDB now uses `lldb-server.exe` to launch and manage the program being debugged,
+  instead of running it within LLDB's own process. To revert to the previous behavior, set the environment variable `LLDB_USE_LLDB_SERVER=0`.
 
 
 ### Changes to BOLT

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -479,6 +479,8 @@ Makes programs 10x faster by doing Special New Thing.
 * Python 3.11 or later is now recommended for building LLDB 23 on Windows. From LLDB 24, Python 3.11 or later will be required.
 * Messages from `OutputDebugString[A|W]` are now shown inline when using LLDB
   from the command-line and in the output window when using lldb-dap.
+* lldb-server.exe is now the default plugin, replacing and deprecating the
+  "in-process" plugin.
 
 
 ### Changes to BOLT


### PR DESCRIPTION
As of https://github.com/llvm/llvm-project/pull/209258, `lldb-server.exe` is now the default plugin if libxml2 is available at build time.

This patch adds a release note for this change.