### PR TITLE
[AArch64] Fixup possibly unused variable warning after #207199

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -5197,8 +5197,8 @@ AArch64TargetLowering::LowerVectorFP_TO_INT_SAT(SDValue Op,
   const EVT DstElementVT = DstVT.getVectorElementType();
   const EVT SatVT = cast<VTSDNode>(Op.getOperand(1))->getVT();
 
+  [[maybe_unused]] const uint64_t DstElementWidth = DstVT.getScalarSizeInBits();
   const uint64_t SrcElementWidth = SrcVT.getScalarSizeInBits();
-  const uint64_t DstElementWidth = DstVT.getScalarSizeInBits();
   const uint64_t SatWidth = SatVT.getScalarSizeInBits();
   assert(SatWidth <= DstElementWidth &&
          "Saturation width cannot exceed result width");


### PR DESCRIPTION
Using [[maybe_unused]] as the variable is only used in asserts which results in a diagnostic for no-assert builds.