### PR TITLE
[docker][Windows] install libxml2 using vcpkg

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -51,7 +51,11 @@ RUN choco install -y ninja --version 1.13.1 && \
 # Install libxml2 using vcpkg.
 RUN git clone --depth 1 --branch 2026.06.24 https://github.com/microsoft/vcpkg.git C:\vcpkg && \
     C:\vcpkg\bootstrap-vcpkg.bat -disableMetrics && \
-    C:\vcpkg\vcpkg.exe install libxml2:x64-windows
+    C:\vcpkg\vcpkg.exe install libxml2:x64-windows && \
+    rmdir /S /Q C:\vcpkg\buildtrees && \
+    rmdir /S /Q C:\vcpkg\packages && \
+    rmdir /S /Q C:\vcpkg\downloads && \
+    rmdir /S /Q C:\vcpkg\.git
 
 # Testing requires psutil
 RUN pip install psutil
@@ -71,6 +75,7 @@ ENV PYTHONIOENCODING=UTF-8
 RUN powershell -Command \
     [System.Environment]::SetEnvironmentVariable('PATH', \
     [System.Environment]::GetEnvironmentVariable('PATH', 'machine') + ';C:\Program Files\Git\usr\bin;C:\llvm-mingw\bin' \
+    + ';C:\vcpkg\installed\x64-windows\bin' \
     + ';C:\BuildTools\Common7\IDE\' \
     + ';C:\BuildTools\Common7\IDE\CommonExt ensions\Microsoft\TeamFoundation\Team Explorer' \
     + ';C:\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin' \

--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -48,7 +48,7 @@ RUN choco install -y ninja --version 1.13.1 && \
     choco install -y python3 --version 3.12.3 && \
     choco install -y make --version 4.4.1
 
-# Install libxml2 using vcpkg.
+# libxml2 is not available on choco. Install it using vcpkg.
 RUN git clone --depth 1 --branch 2026.06.24 https://github.com/microsoft/vcpkg.git C:\vcpkg && \
     C:\vcpkg\bootstrap-vcpkg.bat -disableMetrics && \
     C:\vcpkg\vcpkg.exe install libxml2:x64-windows && \

--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -48,6 +48,11 @@ RUN choco install -y ninja --version 1.13.1 && \
     choco install -y python3 --version 3.12.3 && \
     choco install -y make --version 4.4.1
 
+# Install libxml2 using vcpkg.
+RUN git clone --depth 1 --branch 2026.06.24 https://github.com/microsoft/vcpkg.git C:\vcpkg && \
+    C:\vcpkg\bootstrap-vcpkg.bat -disableMetrics && \
+    C:\vcpkg\vcpkg.exe install libxml2:x64-windows
+
 # Testing requires psutil
 RUN pip install psutil
 


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/209258, lldb uses `lldb-server.exe` by default if libxml2 is available at build time. This means that lldb-server requires installing libxml2 in the CI environments to test it.

This patch adds a step to install libxml2 in the docker container used for lldb pre-merge testing on Windows.