### PR TITLE
[clang][Analysis] Speed up LiveVariables set merge

### DIFF
--- a/clang/lib/Analysis/LiveVariables.cpp
+++ b/clang/lib/Analysis/LiveVariables.cpp
@@ -88,16 +88,18 @@ bool LiveVariables::LivenessValues::isLive(const VarDecl *D) const {
 }
 
 namespace {
-  template <typename SET>
-  SET mergeSets(SET A, SET B) {
-    if (A.isEmpty())
-      return B;
-
-    for (const auto *Elem : B) {
-      A = A.add(Elem);
-    }
+template <typename SET> SET mergeSets(SET A, SET B) {
+  if (A.getRootWithoutRetain() == B.getRootWithoutRetain())
     return A;
+
+  if (A.getHeight() < B.getHeight())
+    std::swap(A, B);
+
+  for (const auto *Elem : B) {
+    A = A.add(Elem);
   }
+  return A;
+}
 } // namespace
 
 void LiveVariables::Observer::anchor() { }


### PR DESCRIPTION
LiveVariables' mergeSets built the union by unconditionally inserting every element of B into A. Apply the two cheap tricks the lifetime-safety analysis uses in its dataflow join:

  * Return early when both operands are the same tree (an O(1) pointer comparison), skipping the merge entirely. Merged liveness values are canonicalized, so two predecessors with identical liveness share the same tree -- common at confluence points.
  * Insert the smaller set into the larger one, so the number of O(log n) insertions is min(|A|, |B|) rather than always |B|.

The result is unchanged: set union is commutative and order-independent.

On a pathological function (1000 simultaneously-live locals across 5000 control-flow merges of identical sets) the liveness computation is ~18% faster, essentially all from the identical-set short circuit. On real translation units the merge is a small fraction of the analysis, so the effect is within noise (measured neutral on DAGCombiner.cpp and X86ISelLowering.cpp); this mainly avoids redundant work at unchanged confluence points and brings the two dataflow analyses' merges into line.

Assisted by: Claude Opus 4.8