### PR TITLE
[flang] Fix function-attr-readonly test on PowerPC

### DIFF
--- a/flang/test/Driver/function-attr-readonly.f90
+++ b/flang/test/Driver/function-attr-readonly.f90
@@ -32,16 +32,16 @@ end module
 
 ! O0-LABEL: func.func @_QMreadonly_pipeline_modPreadonly_pipeline(
 ! O0-SAME:    %{{.*}}: !fir.ref<i32> {fir.bindc_name = "x", fir.read_only, llvm.noalias},
-! O0-SAME:    %{{.*}}: !fir.ref<i32> {fir.bindc_name = "y", llvm.noalias}) {
+! O0-SAME:    %{{.*}}: !fir.ref<i32> {fir.bindc_name = "y", llvm.noalias})
 
 ! O1-LABEL: func.func @_QMreadonly_pipeline_modPreadonly_pipeline(
 ! O1-SAME:    %{{.*}}: !fir.ref<i32> {fir.bindc_name = "x", fir.read_only, llvm.noalias, llvm.nocapture, llvm.readonly},
-! O1-SAME:    %{{.*}}: !fir.ref<i32> {fir.bindc_name = "y", llvm.noalias, llvm.nocapture}) {
+! O1-SAME:    %{{.*}}: !fir.ref<i32> {fir.bindc_name = "y", llvm.noalias, llvm.nocapture})
 
 ! LLVM-LABEL: define void @_QMreadonly_pipeline_modPreadonly_pipeline(
 ! LLVM-SAME:    ptr {{.*}}readonly{{.*}} %0,
 
-! O1-LABEL: func.func @_QMreadonly_pipeline_modPpointer_descriptor_readonly(%{{.*}}: !fir.ref<!fir.box<!fir.ptr<i32>>> {fir.bindc_name = "p", fir.read_only, llvm.nocapture, llvm.readonly}) {
+! O1-LABEL: func.func @_QMreadonly_pipeline_modPpointer_descriptor_readonly(%{{.*}}: !fir.ref<!fir.box<!fir.ptr<i32>>> {fir.bindc_name = "p", fir.read_only, llvm.nocapture, llvm.readonly})
 
 ! LLVM-LABEL: define void @_QMreadonly_pipeline_modPpointer_descriptor_readonly(
 ! LLVM-SAME:    ptr {{.*}}readonly{{.*}} %0


### PR DESCRIPTION
Follow-up fix for the newly added test, which was not exercised on all targets. PowerPC adds llvm.target_features between the function argument list and the body. Stop requiring the opening brace to immediately follow the argument list so that the checks remain target-independent.