### PR TITLE
[libc] Remove #include <signal.h>

### DIFF
--- a/libc/src/__support/StringUtil/CMakeLists.txt
+++ b/libc/src/__support/StringUtil/CMakeLists.txt
@@ -61,7 +61,7 @@ if(TARGET libc.include.signal)
     DEPENDS
       .message_mapper
       .platform_signals
-      libc.include.signal
+      libc.hdr.signal_macros
       libc.src.__support.common
       libc.src.__support.CPP.span
       libc.src.__support.CPP.string_view

--- a/libc/src/__support/StringUtil/signal_to_string.cpp
+++ b/libc/src/__support/StringUtil/signal_to_string.cpp
@@ -8,9 +8,9 @@
 
 #include "signal_to_string.h"
 
-#include <signal.h>
 #include <stddef.h>
 
+#include "hdr/signal_macros.h"
 #include "platform_signals.h"
 #include "src/__support/CPP/span.h"
 #include "src/__support/CPP/string_view.h"

--- a/libc/src/__support/StringUtil/tables/CMakeLists.txt
+++ b/libc/src/__support/StringUtil/tables/CMakeLists.txt
@@ -48,7 +48,7 @@ add_header_library(
   HDRS
     stdc_signals.h
   DEPENDS
-    libc.include.signal
+    libc.hdr.signal_macros
     libc.src.__support.StringUtil.message_mapper
 )
 
@@ -57,7 +57,7 @@ add_header_library(
   HDRS
     posix_signals.h
   DEPENDS
-    libc.include.signal
+    libc.hdr.signal_macros
     libc.src.__support.StringUtil.message_mapper
 )
 
@@ -66,7 +66,7 @@ add_header_library(
   HDRS
     linux_extension_signals.h
   DEPENDS
-    libc.include.signal
+    libc.hdr.signal_macros
     libc.src.__support.StringUtil.message_mapper
 )
 

--- a/libc/src/__support/StringUtil/tables/linux_extension_signals.h
+++ b/libc/src/__support/StringUtil/tables/linux_extension_signals.h
@@ -9,10 +9,9 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_STRINGUTIL_TABLES_LINUX_EXTENSION_SIGNALS_H
 #define LLVM_LIBC_SRC___SUPPORT_STRINGUTIL_TABLES_LINUX_EXTENSION_SIGNALS_H
 
+#include "hdr/signal_macros.h" // For signal numbers
 #include "src/__support/StringUtil/message_mapper.h"
 #include "src/__support/macros/config.h"
-
-#include <signal.h> // For signal numbers
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/__support/StringUtil/tables/posix_signals.h
+++ b/libc/src/__support/StringUtil/tables/posix_signals.h
@@ -9,11 +9,10 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_STRINGUTIL_TABLES_POSIX_SIGNALS_H
 #define LLVM_LIBC_SRC___SUPPORT_STRINGUTIL_TABLES_POSIX_SIGNALS_H
 
+#include "hdr/signal_macros.h" // For signal numbers
 #include "src/__support/CPP/array.h"
 #include "src/__support/StringUtil/message_mapper.h"
 #include "src/__support/macros/config.h"
-
-#include <signal.h> // For signal numbers
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/__support/StringUtil/tables/stdc_signals.h
+++ b/libc/src/__support/StringUtil/tables/stdc_signals.h
@@ -9,8 +9,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_STRINGUTIL_TABLES_STDC_SIGNALS_H
 #define LLVM_LIBC_SRC___SUPPORT_STRINGUTIL_TABLES_STDC_SIGNALS_H
 
-#include <signal.h> // For signal numbers
-
+#include "hdr/signal_macros.h" // For signal numbers
 #include "src/__support/StringUtil/message_mapper.h"
 #include "src/__support/macros/config.h"
 

--- a/libc/src/signal/kill.h
+++ b/libc/src/signal/kill.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SIGNAL_KILL_H
 #define LLVM_LIBC_SRC_SIGNAL_KILL_H
 
+#include "hdr/types/pid_t.h"
 #include "src/__support/macros/config.h"
-#include <signal.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/signal/linux/CMakeLists.txt
+++ b/libc/src/signal/linux/CMakeLists.txt
@@ -22,7 +22,7 @@ add_entrypoint_object(
   HDRS
     ../kill.h
   DEPENDS
-    libc.include.signal
+    libc.hdr.types.pid_t
     libc.src.errno.errno
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil

--- a/libc/src/signal/linux/kill.cpp
+++ b/libc/src/signal/linux/kill.cpp
@@ -14,7 +14,6 @@
 #include "src/__support/macros/config.h"
 #include "src/signal/linux/signal_utils.h"
 
-#include <signal.h>
 #include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/signal/linux/sigemptyset.cpp
+++ b/libc/src/signal/linux/sigemptyset.cpp
@@ -7,13 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/signal/sigemptyset.h"
+#include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/signal/linux/signal_utils.h"
-
-#include "src/__support/common.h"
-
-#include <signal.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/signal/raise.h
+++ b/libc/src/signal/raise.h
@@ -10,7 +10,6 @@
 #define LLVM_LIBC_SRC_SIGNAL_RAISE_H
 
 #include "src/__support/macros/config.h"
-#include <signal.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/spawn/linux/CMakeLists.txt
+++ b/libc/src/spawn/linux/CMakeLists.txt
@@ -7,9 +7,9 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.mode_t
     libc.hdr.fcntl_macros
+    libc.hdr.signal_macros
     libc.include.spawn
     libc.include.sys_syscall
-    libc.include.signal
     libc.src.__support.OSUtil.osutil
     libc.src.__support.OSUtil.linux.syscall_wrappers.dup2
     libc.src.__support.OSUtil.linux.syscall_wrappers.open

--- a/libc/src/spawn/linux/posix_spawn.cpp
+++ b/libc/src/spawn/linux/posix_spawn.cpp
@@ -15,9 +15,9 @@
 #include "src/spawn/file_actions.h"
 
 #include "hdr/fcntl_macros.h"
+#include "hdr/signal_macros.h" // For SIGCHLD
 #include "hdr/types/mode_t.h"
 #include "src/signal/linux/signal_utils.h"
-#include <signal.h> // For SIGCHLD
 #include <spawn.h>
 #include <sys/syscall.h> // For syscall numbers.
 

--- a/libc/src/sys/wait/linux/CMakeLists.txt
+++ b/libc/src/sys/wait/linux/CMakeLists.txt
@@ -5,6 +5,8 @@ add_entrypoint_object(
   HDRS
     ../wait.h
   DEPENDS
+    libc.hdr.signal_macros
+    libc.hdr.types.siginfo_t
     libc.include.sys_wait
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
@@ -18,6 +20,8 @@ add_entrypoint_object(
   HDRS
     ../wait4.h
   DEPENDS
+    libc.hdr.signal_macros
+    libc.hdr.types.siginfo_t
     libc.include.sys_wait
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
@@ -31,6 +35,8 @@ add_entrypoint_object(
   HDRS
     ../waitpid.h
   DEPENDS
+    libc.hdr.signal_macros
+    libc.hdr.types.siginfo_t
     libc.include.sys_wait
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil

--- a/libc/src/sys/wait/wait4Impl.h
+++ b/libc/src/sys/wait/wait4Impl.h
@@ -15,7 +15,8 @@
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
-#include <signal.h>
+#include "hdr/signal_macros.h"
+#include "hdr/types/siginfo_t.h"
 #include <sys/syscall.h> // For syscall numbers.
 #include <sys/wait.h>
 

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -138,6 +138,7 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.pid_t
     libc.hdr.fcntl_macros
+    libc.hdr.signal_macros
     libc.include.unistd
     libc.include.sys_syscall
     libc.src.__support.threads.fork_callbacks

--- a/libc/src/unistd/linux/fork.cpp
+++ b/libc/src/unistd/linux/fork.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/unistd/fork.h"
-
+#include "hdr/signal_macros.h"            // For SIGCHLD
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
@@ -16,7 +16,6 @@
 #include "src/__support/threads/thread.h" // For thread self object
 
 #include "src/__support/libc_errno.h"
-#include <signal.h>      // For SIGCHLD
 #include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/test/src/fenv/enabled_exceptions_test.cpp
+++ b/libc/test/src/fenv/enabled_exceptions_test.cpp
@@ -12,14 +12,13 @@
 #include "src/fenv/feraiseexcept.h"
 #include "src/fenv/fetestexcept.h"
 
+#include "hdr/fenv_macros.h"
+#include "hdr/signal_macros.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/macros/properties/architectures.h"
 #include "test/UnitTest/FEnvSafeTest.h"
 #include "test/UnitTest/FPExceptMatcher.h"
 #include "test/UnitTest/Test.h"
-
-#include "hdr/fenv_macros.h"
-#include <signal.h>
 
 #include "excepts.h"
 

--- a/libc/test/src/signal/kill_test.cpp
+++ b/libc/test/src/signal/kill_test.cpp
@@ -12,7 +12,7 @@
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
-#include <signal.h>
+#include "hdr/signal_macros.h"
 #include <sys/syscall.h> // For syscall numbers.
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;

--- a/libc/test/src/signal/pthread_sigmask_test.cpp
+++ b/libc/test/src/signal/pthread_sigmask_test.cpp
@@ -11,14 +11,14 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "hdr/signal_macros.h"
+#include "hdr/types/sigset_t.h"
 #include "src/signal/pthread_sigmask.h"
 #include "src/signal/raise.h"
 #include "src/signal/sigaddset.h"
 #include "src/signal/sigemptyset.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
-
-#include <signal.h>
 
 class LlvmLibcPthreadSigmaskTest
     : public LIBC_NAMESPACE::testing::ErrnoCheckingTest {

--- a/libc/test/src/signal/raise_test.cpp
+++ b/libc/test/src/signal/raise_test.cpp
@@ -6,11 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/signal_macros.h"
 #include "src/signal/raise.h"
-
 #include "test/UnitTest/Test.h"
-
-#include <signal.h>
 
 TEST(LlvmLibcSignalTest, Raise) {
   // SIGCONT is ingored unless stopped, so we can use it to check the return

--- a/libc/test/src/signal/sigaddset_test.cpp
+++ b/libc/test/src/signal/sigaddset_test.cpp
@@ -8,10 +8,10 @@
 
 #include "src/signal/sigaddset.h"
 
+#include "hdr/signal_macros.h"
+#include "hdr/types/sigset_t.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
-
-#include <signal.h>
 
 // This tests invalid inputs and ensures errno is properly set.
 TEST(LlvmLibcSignalTest, SigaddsetInvalid) {

--- a/libc/test/src/signal/sigdelset_test.cpp
+++ b/libc/test/src/signal/sigdelset_test.cpp
@@ -6,15 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/signal_macros.h"
+#include "hdr/types/sigset_t.h"
 #include "src/signal/raise.h"
 #include "src/signal/sigdelset.h"
 #include "src/signal/sigfillset.h"
 #include "src/signal/sigprocmask.h"
-
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
-
-#include <signal.h>
 
 TEST(LlvmLibcSigdelset, Invalid) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;

--- a/libc/test/src/signal/sigfillset_test.cpp
+++ b/libc/test/src/signal/sigfillset_test.cpp
@@ -6,14 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/signal_macros.h"
+#include "hdr/types/sigset_t.h"
 #include "src/signal/raise.h"
 #include "src/signal/sigfillset.h"
 #include "src/signal/sigprocmask.h"
-
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
-
-#include <signal.h>
 
 TEST(LlvmLibcSigfillset, Invalid) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;

--- a/libc/test/src/signal/signal_test.cpp
+++ b/libc/test/src/signal/signal_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/signal_macros.h"
 #include "src/signal/raise.h"
 #include "src/signal/signal.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"

--- a/libc/test/src/signal/sigprocmask_test.cpp
+++ b/libc/test/src/signal/sigprocmask_test.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/signal_macros.h"
+#include "hdr/types/sigset_t.h"
 #include "src/signal/raise.h"
 #include "src/signal/sigaddset.h"
 #include "src/signal/sigemptyset.h"
@@ -13,8 +15,6 @@
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
-
-#include <signal.h>
 
 class LlvmLibcSigprocmaskTest
     : public LIBC_NAMESPACE::testing::ErrnoCheckingTest {

--- a/libc/test/src/stdlib/abort_test.cpp
+++ b/libc/test/src/stdlib/abort_test.cpp
@@ -6,10 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/signal_macros.h"
 #include "src/stdlib/abort.h"
 #include "test/UnitTest/Test.h"
-
-#include <signal.h>
 
 TEST(LlvmLibcStdlib, abort) {
   // -1 matches against any signal, which is necessary for now until

--- a/libc/test/src/string/strsignal_test.cpp
+++ b/libc/test/src/string/strsignal_test.cpp
@@ -6,10 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/signal_macros.h"
 #include "src/string/strsignal.h"
 #include "test/UnitTest/Test.h"
-
-#include <signal.h>
 
 TEST(LlvmLibcStrSignalTest, KnownSignals) {
   ASSERT_STREQ(LIBC_NAMESPACE::strsignal(1), "Hangup");

--- a/libc/test/src/sys/mman/linux/mprotect_test.cpp
+++ b/libc/test/src/sys/mman/linux/mprotect_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/signal_macros.h"
 #include "hdr/sys_mman_macros.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/mprotect.h"
@@ -14,7 +15,6 @@
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
-#include <signal.h>
 #include <sys/mman.h>
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;


### PR DESCRIPTION
Replace it with granular includes of the appropriate type/macro proxy headers.

Assisted by Gemini.