### PR TITLE
[libc] Avoid C++23 f16 floating-point literals in erf headers

### DIFF
--- a/libc/src/__support/math/erfcf16.h
+++ b/libc/src/__support/math/erfcf16.h
@@ -88,12 +88,12 @@ LIBC_INLINE float16 erfcf16(float16 x) {
       return x;
     }
     // erfc(+Inf) = 0, erfc(-Inf) = 2
-    return xbits.is_neg() ? fputil::cast<float16>(2.0)
-                          : fputil::cast<float16>(0.0);
+    return xbits.is_neg() ? fputil::cast<float16>(2.0f)
+                          : fputil::cast<float16>(0.0f);
   }
 
   if (LIBC_UNLIKELY(x_abs == 0))
-    return 1.0f16;
+    return fputil::cast<float16>(1.0f);
 
   // Asymptotic behavior: erfc(x) rounds to 0 or 2 for |x| >= 4.0.
   if (LIBC_UNLIKELY(x_abs >= 0x4400U)) { // |x| >= 4.0
@@ -109,7 +109,7 @@ LIBC_INLINE float16 erfcf16(float16 x) {
     if (fputil::fenv_is_round_up())
       return FPBits::min_subnormal().get_val();
 #endif
-    return 0.0f16;
+    return fputil::cast<float16>(0.0f);
   }
 
   // Polynomial approximation:

--- a/libc/src/__support/math/erff16.h
+++ b/libc/src/__support/math/erff16.h
@@ -134,7 +134,8 @@ LIBC_INLINE float16 erff16(float16 x) {
         return x;
       }
       // Inf -> returns 1.0 or -1.0
-      return is_neg ? -1.0f16 : 1.0f16;
+      return is_neg ? fputil::cast<float16>(-1.0f)
+                   : fputil::cast<float16>(1.0f);
     }
 
     return fputil::cast<float16>(is_neg ? -1.0f - xf * 0x1.0p-28f
@@ -144,7 +145,8 @@ LIBC_INLINE float16 erff16(float16 x) {
   // Polynomial approximation:
   //   erf(x) ~ x * (c0 + c1 * x^2 + c2 * x^4 + ... + c7 * x^14)
 
-  int idx = static_cast<int>(xbits.abs().get_val() * 8.0f16);
+  int idx = static_cast<int>(xbits.abs().get_val() *
+                             fputil::cast<float16>(8.0f));
 
   float xsq = xf * xf;
   float x4 = xsq * xsq;


### PR DESCRIPTION
Replace C++23 `f16` floating-point literal suffixes with C++17-compatible alternatives in `erfcf16.h` and `erff16.h`.

This avoids warnings when building LLVM with `CMAKE_CXX_STANDARD=17`.

Fixes #207380.