### PR TITLE
[lldb][Windows] add release notes for the Python private API removal

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -106,6 +106,12 @@ Makes programs 10x faster by doing Special New Thing.
 
 ### Changes to LLDB
 
+#### Windows
+
+* LLDB no longer depends on the Python private API on Windows. Users are now free to
+  use any Python version they want, as long as it is 3.8 or later and LLDB can find it
+  (i.e. it is on their `PATH`).
+
 ### Changes to BOLT
 
 ### Changes to Sanitizers


### PR DESCRIPTION
The official lldb releases set `LLDB_EMBED_PYTHON_HOME` to `OFF` https://github.com/llvm/llvm-project/blob/9582f71a3b5f71e871bee0062e641f3587e0ae23/llvm/utils/release/build_llvm_release.bat#L213 meaning that lldb on Windows does not use the private Python API by default. Users are free to use any Python version they want. Add a release note for this.