### PR TITLE
[libc][bazel] Add recently added sys/socket functions and syscall wrappers

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -764,6 +764,11 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "types_sa_family_t",
+    hdrs = ["hdr/types/sa_family_t.h"],
+)
+
+libc_support_library(
     name = "types_socklen_t",
     hdrs = ["hdr/types/socklen_t.h"],
 )
@@ -771,6 +776,31 @@ libc_support_library(
 libc_support_library(
     name = "types_struct_sockaddr",
     hdrs = ["hdr/types/struct_sockaddr.h"],
+)
+
+libc_support_library(
+    name = "types_struct_sockaddr_storage",
+    hdrs = ["hdr/types/struct_sockaddr_storage.h"],
+)
+
+libc_support_library(
+    name = "types_struct_sockaddr_un",
+    hdrs = ["hdr/types/struct_sockaddr_un.h"],
+)
+
+libc_support_library(
+    name = "types_struct_linger",
+    hdrs = ["hdr/types/struct_linger.h"],
+)
+
+libc_support_library(
+    name = "types_struct_iovec",
+    hdrs = ["hdr/types/struct_iovec.h"],
+)
+
+libc_support_library(
+    name = "types_struct_mmsghdr",
+    hdrs = ["hdr/types/struct_mmsghdr.h"],
 )
 
 libc_support_library(
@@ -2702,6 +2732,70 @@ libc_support_library(
         ":__support_macros_config",
         ":__support_osutil_syscall",
         ":types_ssize_t",
+    ],
+)
+
+libc_support_library(
+    name = "__support_osutil_linux_syscall_wrappers_recvmmsg",
+    hdrs = ["src/__support/OSUtil/linux/syscall_wrappers/recvmmsg.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":__support_common",
+        ":__support_error_or",
+        ":__support_macros_config",
+        ":__support_osutil_syscall",
+        ":types_struct_mmsghdr",
+        ":types_struct_timespec",
+    ],
+)
+
+libc_support_library(
+    name = "__support_osutil_linux_syscall_wrappers_sendmmsg",
+    hdrs = ["src/__support/OSUtil/linux/syscall_wrappers/sendmmsg.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":__support_common",
+        ":__support_error_or",
+        ":__support_macros_config",
+        ":__support_osutil_syscall",
+        ":types_struct_mmsghdr",
+    ],
+)
+
+libc_support_library(
+    name = "__support_osutil_linux_syscall_wrappers_setsockopt",
+    hdrs = ["src/__support/OSUtil/linux/syscall_wrappers/setsockopt.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":__support_common",
+        ":__support_error_or",
+        ":__support_macros_config",
+        ":__support_osutil_syscall",
+        ":types_socklen_t",
+    ],
+)
+
+libc_support_library(
+    name = "__support_osutil_linux_syscall_wrappers_shutdown",
+    hdrs = ["src/__support/OSUtil/linux/syscall_wrappers/shutdown.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":__support_common",
+        ":__support_error_or",
+        ":__support_macros_config",
+        ":__support_osutil_syscall",
     ],
 )
 
@@ -15956,85 +16050,6 @@ libc_function(
 ############################## sys/socket targets ##############################
 
 libc_function(
-    name = "socket",
-    srcs = ["src/sys/socket/linux/socket.cpp"],
-    hdrs = ["src/sys/socket/socket.h"],
-    deps = [
-        ":__support_common",
-        ":__support_libc_errno",
-        ":__support_macros_config",
-        ":__support_osutil_linux_syscall_wrappers_socket",
-        ":__support_osutil_syscall",
-        ":errno",
-    ],
-)
-
-libc_function(
-    name = "socketpair",
-    srcs = ["src/sys/socket/linux/socketpair.cpp"],
-    hdrs = ["src/sys/socket/socketpair.h"],
-    deps = [
-        ":__support_common",
-        ":__support_libc_errno",
-        ":__support_macros_config",
-        ":__support_macros_sanitizer",
-        ":__support_osutil_linux_syscall_wrappers_socketpair",
-        ":__support_osutil_syscall",
-        ":errno",
-    ],
-)
-
-libc_function(
-    name = "send",
-    srcs = ["src/sys/socket/linux/send.cpp"],
-    hdrs = ["src/sys/socket/send.h"],
-    deps = [
-        ":__support_common",
-        ":__support_libc_errno",
-        ":__support_macros_config",
-        ":__support_osutil_linux_syscall_wrappers_sendto",
-        ":__support_osutil_syscall",
-        ":errno",
-        ":types_socklen_t",
-        ":types_ssize_t",
-        ":types_struct_sockaddr",
-    ],
-)
-
-libc_function(
-    name = "sendto",
-    srcs = ["src/sys/socket/linux/sendto.cpp"],
-    hdrs = ["src/sys/socket/sendto.h"],
-    deps = [
-        ":__support_common",
-        ":__support_libc_errno",
-        ":__support_macros_config",
-        ":__support_osutil_linux_syscall_wrappers_sendto",
-        ":__support_osutil_syscall",
-        ":errno",
-        ":types_socklen_t",
-        ":types_ssize_t",
-        ":types_struct_sockaddr",
-    ],
-)
-
-libc_function(
-    name = "sendmsg",
-    srcs = ["src/sys/socket/linux/sendmsg.cpp"],
-    hdrs = ["src/sys/socket/sendmsg.h"],
-    deps = [
-        ":__support_common",
-        ":__support_libc_errno",
-        ":__support_macros_config",
-        ":__support_osutil_linux_syscall_wrappers_sendmsg",
-        ":__support_osutil_syscall",
-        ":errno",
-        ":types_ssize_t",
-        ":types_struct_msghdr",
-    ],
-)
-
-libc_function(
     name = "getsockopt",
     srcs = ["src/sys/socket/linux/getsockopt.cpp"],
     hdrs = ["src/sys/socket/getsockopt.h"],
@@ -16043,6 +16058,7 @@ libc_function(
         ":__support_libc_errno",
         ":__support_macros_config",
         ":__support_osutil_linux_syscall_wrappers_getsockopt",
+        ":__support_osutil_syscall",
         ":errno",
         ":types_socklen_t",
     ],
@@ -16085,6 +16101,22 @@ libc_function(
 )
 
 libc_function(
+    name = "recvmmsg",
+    srcs = ["src/sys/socket/linux/recvmmsg.cpp"],
+    hdrs = ["src/sys/socket/recvmmsg.h"],
+    deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_osutil_linux_syscall_wrappers_recvmmsg",
+        ":__support_osutil_syscall",
+        ":errno",
+        ":types_struct_mmsghdr",
+        ":types_struct_timespec",
+    ],
+)
+
+libc_function(
     name = "recvmsg",
     srcs = ["src/sys/socket/linux/recvmsg.cpp"],
     hdrs = ["src/sys/socket/recvmsg.h"],
@@ -16098,6 +16130,129 @@ libc_function(
         ":errno",
         ":types_ssize_t",
         ":types_struct_msghdr",
+    ],
+)
+
+libc_function(
+    name = "send",
+    srcs = ["src/sys/socket/linux/send.cpp"],
+    hdrs = ["src/sys/socket/send.h"],
+    deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_osutil_linux_syscall_wrappers_sendto",
+        ":__support_osutil_syscall",
+        ":errno",
+        ":types_socklen_t",
+        ":types_ssize_t",
+        ":types_struct_sockaddr",
+    ],
+)
+
+libc_function(
+    name = "sendmmsg",
+    srcs = ["src/sys/socket/linux/sendmmsg.cpp"],
+    hdrs = ["src/sys/socket/sendmmsg.h"],
+    deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_osutil_linux_syscall_wrappers_sendmmsg",
+        ":__support_osutil_syscall",
+        ":errno",
+        ":types_struct_mmsghdr",
+    ],
+)
+
+libc_function(
+    name = "sendmsg",
+    srcs = ["src/sys/socket/linux/sendmsg.cpp"],
+    hdrs = ["src/sys/socket/sendmsg.h"],
+    deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_osutil_linux_syscall_wrappers_sendmsg",
+        ":__support_osutil_syscall",
+        ":errno",
+        ":types_ssize_t",
+        ":types_struct_msghdr",
+    ],
+)
+
+libc_function(
+    name = "sendto",
+    srcs = ["src/sys/socket/linux/sendto.cpp"],
+    hdrs = ["src/sys/socket/sendto.h"],
+    deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_osutil_linux_syscall_wrappers_sendto",
+        ":__support_osutil_syscall",
+        ":errno",
+        ":types_socklen_t",
+        ":types_ssize_t",
+        ":types_struct_sockaddr",
+    ],
+)
+
+libc_function(
+    name = "setsockopt",
+    srcs = ["src/sys/socket/linux/setsockopt.cpp"],
+    hdrs = ["src/sys/socket/setsockopt.h"],
+    deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_osutil_linux_syscall_wrappers_setsockopt",
+        ":__support_osutil_syscall",
+        ":errno",
+        ":types_socklen_t",
+    ],
+)
+
+libc_function(
+    name = "shutdown",
+    srcs = ["src/sys/socket/linux/shutdown.cpp"],
+    hdrs = ["src/sys/socket/shutdown.h"],
+    deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_osutil_linux_syscall_wrappers_shutdown",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "socket",
+    srcs = ["src/sys/socket/linux/socket.cpp"],
+    hdrs = ["src/sys/socket/socket.h"],
+    deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_osutil_linux_syscall_wrappers_socket",
+        ":__support_osutil_syscall",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "socketpair",
+    srcs = ["src/sys/socket/linux/socketpair.cpp"],
+    hdrs = ["src/sys/socket/socketpair.h"],
+    deps = [
+        ":__support_common",
+        ":__support_libc_errno",
+        ":__support_macros_config",
+        ":__support_macros_sanitizer",
+        ":__support_osutil_linux_syscall_wrappers_socketpair",
+        ":__support_osutil_syscall",
+        ":errno",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
@@ -11,26 +11,6 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])
 
 libc_test(
-    name = "socket_test",
-    srcs = ["linux/socket_test.cpp"],
-    deps = [
-        "//libc:__support_cpp_scope",
-        "//libc:close",
-        "//libc:socket",
-    ],
-)
-
-libc_test(
-    name = "socketpair_test",
-    srcs = ["linux/socketpair_test.cpp"],
-    deps = [
-        "//libc:__support_cpp_scope",
-        "//libc:close",
-        "//libc:socketpair",
-    ],
-)
-
-libc_test(
     name = "send_recv_test",
     srcs = ["linux/send_recv_test.cpp"],
     deps = [
@@ -39,18 +19,6 @@ libc_test(
         "//libc:hdr_sys_socket_macros",
         "//libc:recv",
         "//libc:send",
-        "//libc:socketpair",
-    ],
-)
-
-libc_test(
-    name = "sendto_recvfrom_test",
-    srcs = ["linux/sendto_recvfrom_test.cpp"],
-    deps = [
-        "//libc:__support_cpp_scope",
-        "//libc:close",
-        "//libc:recvfrom",
-        "//libc:sendto",
         "//libc:socketpair",
     ],
 )
@@ -72,5 +40,104 @@ libc_test(
         "//libc:sendmsg",
         "//libc:socketpair",
         "//libc:types_struct_cmsghdr",
+    ],
+)
+
+libc_test(
+    name = "sendrecvmmsg_test",
+    srcs = ["linux/sendrecvmmsg_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_scope",
+        "//libc:close",
+        "//libc:hdr_sys_socket_macros",
+        "//libc:recvmmsg",
+        "//libc:sendmmsg",
+        "//libc:socketpair",
+        "//libc:strlen",
+        "//libc:types_struct_iovec",
+        "//libc:types_struct_mmsghdr",
+        "//libc:types_struct_timespec",
+    ],
+)
+
+libc_test(
+    name = "sendto_recvfrom_test",
+    srcs = ["linux/sendto_recvfrom_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_scope",
+        "//libc:close",
+        "//libc:recvfrom",
+        "//libc:sendto",
+        "//libc:socketpair",
+    ],
+)
+
+libc_test(
+    name = "shutdown_test",
+    srcs = ["linux/shutdown_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_scope",
+        "//libc:close",
+        "//libc:hdr_sys_socket_macros",
+        "//libc:read",
+        "//libc:shutdown",
+        "//libc:socketpair",
+        "//libc:types_ssize_t",
+    ],
+)
+
+libc_test(
+    name = "sockaddr_storage_test",
+    srcs = [
+        "linux/sockaddr_storage_helper.cpp",
+        "linux/sockaddr_storage_test.cpp",
+    ],
+    deps = [
+        "//libc:hdr_sys_socket_macros",
+        "//libc:types_sa_family_t",
+        "//libc:types_struct_sockaddr_storage",
+        "//libc:types_struct_sockaddr_un",
+    ],
+)
+
+libc_test(
+    name = "socket_test",
+    srcs = ["linux/socket_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_scope",
+        "//libc:close",
+        "//libc:socket",
+    ],
+)
+
+libc_test(
+    name = "socketopt_test",
+    srcs = ["linux/socketopt_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_scope",
+        "//libc:__support_time_clock_gettime",
+        "//libc:close",
+        "//libc:getsockopt",
+        "//libc:hdr_sys_socket_macros",
+        "//libc:hdr_time_macros",
+        "//libc:pipe",
+        "//libc:recv",
+        "//libc:setsockopt",
+        "//libc:socket",
+        "//libc:socketpair",
+        "//libc:types_socklen_t",
+        "//libc:types_struct_linger",
+        "//libc:types_struct_timespec",
+        "//libc:types_struct_timeval",
+    ],
+)
+
+libc_test(
+    name = "socketpair_test",
+    srcs = ["linux/socketpair_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_scope",
+        "//libc:close",
+        "//libc:socketpair",
     ],
 )


### PR DESCRIPTION

This patch adds the missing functions to BUILD.bazel:
- recvmmsg
- sendmmsg
- setsockopt
- shutdown

I also add the corresponding syscall wrapper libraries that these functions depend on, along with a couple of additional type libraries.

I'm leaving the remaining sys/socket functions and test suites out for now since some of them require additional infrastructure or type definitions.

Assisted by Gemini.