### PR TITLE
[lldb][Windows] Only embed Python home in Debug config

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -198,7 +198,7 @@ endif()
 option(LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS "Build the script interpreter plugins as shared libraries" ${default_enable_dynamic_scriptinterpreters})
 
 if (LLDB_ENABLE_PYTHON)
-  if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+  if(CMAKE_SYSTEM_NAME MATCHES "Windows" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(default_embed_python_home ON)
   else()
     set(default_embed_python_home OFF)

--- a/lldb/docs/resources/build.md
+++ b/lldb/docs/resources/build.md
@@ -282,15 +282,15 @@ are commonly used on Windows.
   crash, rather than having to reproduce a failure or use a crash dump.
 - `PYTHON_HOME` (Required): Path to the folder where the Python distribution
   is installed. For example, `C:\Python35`.
-- `LLDB_EMBED_PYTHON_HOME` (Default=1 on Windows): When this is 1, LLDB will bind
-  statically to the location specified in the `PYTHON_HOME` CMake variable,
-  ignoring any value of `PYTHONHOME` set in the environment. This is most
-  useful for developers who simply want to run LLDB after they build it. If you
-  wish to move a build of LLDB to a different machine where Python will be in a
-  different location, setting `LLDB_EMBED_PYTHON_HOME` to 0 will cause
-  Python to use its default mechanism for finding the python installation at
-  runtime (looking for installed Pythons, or using the `PYTHONHOME`
-  environment variable if it is specified).
+- `LLDB_EMBED_PYTHON_HOME` (Default=1 on Windows in the Debug configuration):
+  When this is 1, LLDB will bind statically to the location specified in the
+  `PYTHON_HOME` CMake variable, ignoring any value of `PYTHONHOME` set in the
+  environment. This is most useful for developers who simply want to run LLDB
+  after they build it. If you wish to move a build of LLDB to a different
+  machine where Python will be in a different location, setting 
+  `LLDB_EMBED_PYTHON_HOME` to 0 will cause Python to use its default mechanism
+  for finding the python installation at runtime (looking for installed 
+  Pythons, or using the `PYTHONHOME` environment variable if it is specified).
 
 Sample command line:
 


### PR DESCRIPTION
On Windows, we used to embed `PYTHONHOME` by default on Windows. In the documentation, we say

> This is most useful for developers who simply want to run LLDB after they build it.

Since we use the limited/stable API now, we're less restricted in the Python version, so I think it's less of an issue that LLDB won't find Python. The only configuration where it might cause issues is the debug configuration, since, when installing Python, you usually don't include the debug libraries. Thus, you might not have the debug version (`python3_d.py`) of Python in your PATH.

