### PR TITLE
[libc++] Define behaviour for calling target() and target_type() on -fno-rtti std::functions

### DIFF
--- a/libcxx/include/__functional/function.h
+++ b/libcxx/include/__functional/function.h
@@ -28,6 +28,7 @@
 #include <__utility/forward.h>
 #include <__utility/move.h>
 #include <__utility/swap.h>
+#include <__utility/unreachable.h>
 #include <tuple>
 #include <typeinfo>
 
@@ -145,10 +146,14 @@ public:
   virtual void destroy() _NOEXCEPT            = 0;
   virtual void destroy_deallocate() _NOEXCEPT = 0;
   virtual _Rp operator()(_ArgTypes&&...)      = 0;
-#  if _LIBCPP_HAS_RTTI
-  virtual const void* target(const type_info&) const _NOEXCEPT = 0;
-  virtual const std::type_info& target_type() const _NOEXCEPT  = 0;
-#  endif // _LIBCPP_HAS_RTTI
+  _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual const void* target(const type_info&) const _NOEXCEPT {
+    _LIBCPP_ASSERT_NON_NULL(false, "Trying to access type_info of std::function created in -fno-rtti mode!");
+    std::__libcpp_unreachable();
+  }
+  _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual const std::type_info& target_type() const _NOEXCEPT {
+    _LIBCPP_ASSERT_NON_NULL(false, "Trying to access type_info of std::function created in -fno-rtti mode!");
+    std::__libcpp_unreachable();
+  }
 };
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
 
@@ -516,11 +521,19 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit operator bool() const _NOEXCEPT { return !__policy_->__is_null; }
 
 #  if _LIBCPP_HAS_RTTI
-  _LIBCPP_HIDE_FROM_ABI const std::type_info& target_type() const _NOEXCEPT { return *__policy_->__type_info; }
+  _LIBCPP_HIDE_FROM_ABI const std::type_info& target_type() const _NOEXCEPT {
+    _LIBCPP_ASSERT_NON_NULL(
+        __policy_->__type_info, "Trying to access type_info of std::functions created in -fno-rtti mode!");
+    return *__policy_->__type_info;
+  }
 
   template <typename _Tp>
   _LIBCPP_HIDE_FROM_ABI const _Tp* target() const _NOEXCEPT {
-    if (__policy_->__is_null || typeid(_Tp) != *__policy_->__type_info)
+    if (__policy_->__is_null)
+      return nullptr;
+    _LIBCPP_ASSERT_NON_NULL(
+        __policy_->__type_info, "Trying to access type_info of std::function created in -fno-rtti mode!");
+    if (typeid(_Tp) != *__policy_->__type_info)
       return nullptr;
     if (__policy_->__clone) // Out of line storage.
       return reinterpret_cast<const _Tp*>(__buf_.__large);

--- a/libcxx/test/extensions/libcxx/utilities/function.objects/func.wrap/func.wrap.func/rtti_mixing.assert.sh.cpp
+++ b/libcxx/test/extensions/libcxx/utilities/function.objects/func.wrap/func.wrap.func/rtti_mixing.assert.sh.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03
+// REQUIRES: can-test-hardening-assertions-extensive
+
+// Ensure that passing std::functions across -fno-rtti/-frtti boundaries is asserted on.
+
+#include <cassert>
+#include <functional>
+#include <typeinfo>
+
+// RUN: %{cxx} %s %{flags} %{compile_flags} -c -frtti -o %t.tu1.o
+// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DNO_RTTI -fno-rtti -o %t.tu2.o
+// RUN: %{cxx} %t.tu1.o %t.tu2.o %{flags} %{link_flags} -o %t.exe
+// RUN: %{exec} %t.exe
+
+std::function<void()> get_func();
+
+#ifdef NO_RTTI
+std::function<void()> get_func() { return get_func; }
+#else
+
+// This can only be included once.
+#  include "check_assertion.h"
+
+int main(int, char**) {
+  TEST_LIBCPP_ASSERT_FAILURE(
+      get_func().target<int>(), "Trying to access type_info of std::function created in -fno-rtti mode!");
+  TEST_LIBCPP_ASSERT_FAILURE(
+      get_func().target_type(), "Trying to access type_info of std::function created in -fno-rtti mode!");
+
+  return 0;
+}
+#endif


### PR DESCRIPTION
The main aim of this change is to have the same vtable between `-fno-rtti` and `-frtti`. Since it's very cheap to do, this also asserts if the `function` object was created in `-fno-rtti` mode.

The vtable can be extended, since the members are either never accessed in `-fno-rtti` mode, or are already expected to exist in `-frtti` mode. This means that we either define behaviour that wasn't before, or we add some extra bytes that are never accessed.
