### PR TITLE
[libc++][NFC] Remove unused <cassert> from algorithm benchmarks

### DIFF
--- a/libcxx/test/benchmarks/algorithms/min.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/min.bench.cpp
@@ -9,7 +9,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
 #include <algorithm>
-#include <cassert>
 #include <deque>
 #include <list>
 #include <vector>

--- a/libcxx/test/benchmarks/algorithms/minmax.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/minmax.bench.cpp
@@ -9,7 +9,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
 #include <algorithm>
-#include <cassert>
 #include <deque>
 #include <list>
 #include <vector>

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/search_n.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/search_n.bench.cpp
@@ -9,7 +9,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
 #include <algorithm>
-#include <cassert>
 #include <cstddef>
 #include <deque>
 #include <list>


### PR DESCRIPTION
A few benchmark files were including <cassert> but didn't use it.