### PR TITLE
[orc-rt] Make noDispatch test helper fail in -Asserts builds.

### DIFF
--- a/orc-rt/test/unit/CommonTestUtils.h
+++ b/orc-rt/test/unit/CommonTestUtils.h
@@ -24,6 +24,8 @@
 #include <string>
 #include <vector>
 
+#include "gtest/gtest.h"
+
 inline void noErrors(orc_rt::Error Err) { orc_rt::cantFail(std::move(Err)); }
 
 /// ReportError callback for tests that records the message of every reported
@@ -45,11 +47,18 @@ inline orc_rt::ExecutorProcessInfo mockExecutorProcessInfo() noexcept {
 }
 
 /// RunWrapperCall callback for tests that should never dispatch a wrapper
-/// call. Asserts on invocation.
-inline void noDispatch(orc_rt_SessionRef, uint64_t,
-                       orc_rt_WrapperFunctionReturn, orc_rt_WrapperFunction,
-                       orc_rt::WrapperFunctionBuffer) {
-  assert(false && "strictly no dispatching!");
+/// call. Records a test failure on invocation, then completes the call with an
+/// out-of-band error so that any caller awaiting the result unblocks and fails
+/// too (rather than hanging), even in -Asserts builds or when the dispatch
+/// arrives on a non-test thread.
+inline void noDispatch(orc_rt_SessionRef S, uint64_t CallId,
+                       orc_rt_WrapperFunctionReturn Return,
+                       orc_rt_WrapperFunction, orc_rt::WrapperFunctionBuffer) {
+  ADD_FAILURE() << "unexpected wrapper-call dispatch in a no-dispatch session";
+  Return(S, CallId,
+         orc_rt::WrapperFunctionBuffer::createOutOfBandError(
+             "unexpected wrapper-call dispatch in a no-dispatch session")
+             .release());
 }
 
 template <size_t Idx = 0> class OpCounter {


### PR DESCRIPTION
noDispatch guards Sessions that must never dispatch a wrapper call, but it did so with assert(false), which compiles out under NDEBUG.

Replace the assert with ADD_FAILURE(), which records a failure in every build mode, and then complete the call via its Return continuation with an out-of-band error. Completing the call means a caller awaiting the result unblocks and fails too, rather than hanging, even when the dispatch arrives on a non-test thread where ADD_FAILURE() alone may not be observed.