### PR TITLE
[mlir] fix builders by moving var into assert

### DIFF
--- a/mlir/lib/Conversion/NVGPUToNVVM/NVGPUToNVVM.cpp
+++ b/mlir/lib/Conversion/NVGPUToNVVM/NVGPUToNVVM.cpp
@@ -1807,8 +1807,8 @@ lookupConvOp(const TableEntry (&table)[N], Type srcElemType, Type dstElemType) {
 
 /// Extract a single element from a vector.
 static Value extractElement(ImplicitLocOpBuilder &b, Value srcVec, int idx) {
-  auto vecTy = cast<VectorType>(srcVec.getType());
-  assert(idx >= 0 && idx < vecTy.getNumElements() &&
+  assert(idx >= 0 &&
+         idx < cast<VectorType>(srcVec.getType()).getNumElements() &&
          "extractElement: index out of bounds");
   IntegerType i64Ty = b.getI64Type();
   return b.create<LLVM::ExtractElementOp>(


### PR DESCRIPTION
non-asserts builders are failing since `vecTy` is unused aside from this one assertion: https://lab.llvm.org/buildbot/#/builders/228/builds/4754

Since side-effects here are uninteresting, move the entire expr into the assert, per CodingStandards.md

Fix-forward for #199700