### PR TITLE
[lldb][bazel] Add the lldb-mcp binary to the Bazel overlay

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -1204,3 +1204,41 @@ cc_binary(
         "//llvm:config",
     ],
 )
+
+expand_template(
+    name = "lldb-mcp-plist",
+    out = "lldb-mcp-Info.plist",
+    substitutions = {
+        "${LLDB_VERSION}": PACKAGE_VERSION,
+    },
+    template = "tools/lldb-mcp/lldb-mcp-Info.plist.in",
+)
+
+cc_binary(
+    name = "lldb-mcp",
+    srcs = glob([
+        "tools/lldb-mcp/**/*.cpp",
+        "tools/lldb-mcp/**/*.h",
+    ]),
+    additional_linker_inputs = [
+        ":lldb-mcp-plist",
+    ],
+    includes = ["tools/lldb-mcp"],
+    linkopts = select({
+        "@platforms//os:macos": [
+            "-Wl,-sectcreate,__TEXT,__info_plist,$(location :lldb-mcp-plist)",
+        ],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//lldb:APIHeaders",
+        "//lldb:Headers",
+        "//lldb:Host",
+        "//lldb:ProtocolMCP",
+        "//lldb:Utility",
+        "//lldb:liblldb.wrapper",
+        "//llvm:Option",
+        "//llvm:Support",
+        "//llvm:config",
+    ],
+)

--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -1234,6 +1234,7 @@ cc_binary(
         "//lldb:APIHeaders",
         "//lldb:Headers",
         "//lldb:Host",
+        "//lldb:ProtocolHeaders",
         "//lldb:ProtocolMCP",
         "//lldb:Utility",
         "//lldb:liblldb.wrapper",


### PR DESCRIPTION
#143628 added the lldb-mcp tool (an MCP server multiplexer for LLDB), built by lldb/tools/lldb-mcp/CMakeLists.txt. The Bazel overlay already models the ProtocolMCP library and the MCP protocol-server plugin, but not the lldb-mcp executable itself, so it is missing from the Bazel build.

Add an lldb-mcp cc_binary modeled on the existing lldb-dap target: glob tools/lldb-mcp/**, expand the macOS Info.plist via expand_template, and depend on liblldb.wrapper, Host, Utility, ProtocolMCP, and the LLVM Option/Support libraries. lldb-mcp has no Options.td, so unlike lldb-dap no gentbl_cc_library is needed.

This properly translates into BUCk internally at Meta and then builds with buck2, but I cannot validate the bazel build of this new target directly.

bazel rule generation assisted with: claude