### PR TITLE
[llvm-reduce] Avoid invalid replacements with x86_amx type

### DIFF
--- a/llvm/test/tools/llvm-reduce/reduce-instructions-x86-amx.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-instructions-x86-amx.ll
@@ -1,0 +1,13 @@
+; RUN: llvm-reduce --abort-on-invalid-reduction --delta-passes=instructions --test FileCheck --test-arg --check-prefixes=CHECK,INTERESTING --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck -check-prefixes=CHECK,RESULT %s < %t
+
+; CHECK-LABEL: define <1024 x i8> @test(
+; INTERESTING: call <1024 x i8> @llvm.x86.cast.tile.to.vector
+
+; RESULT: %amx = call x86_amx @llvm.x86.cast.vector.to.tile.v1024i8(<1024 x i8> %vec)
+; RESULT: %vec2 = call <1024 x i8> @llvm.x86.cast.tile.to.vector.v1024i8(x86_amx %amx)
+define <1024 x i8> @test(<1024 x i8> %vec) {
+  %amx = call x86_amx @llvm.x86.cast.vector.to.tile.v1024i8(<1024 x i8> %vec)
+  %vec2 = call <1024 x i8> @llvm.x86.cast.tile.to.vector.v1024i8(x86_amx %amx)
+  ret <1024 x i8> %vec2
+}

--- a/llvm/test/tools/llvm-reduce/reduce-operands-x86-amx.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-operands-x86-amx.ll
@@ -1,0 +1,18 @@
+; RUN: llvm-reduce --abort-on-invalid-reduction --delta-passes=operands-zero --test FileCheck --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck --check-prefixes=CHECK,ZERO %s < %t
+
+; RUN: llvm-reduce --abort-on-invalid-reduction --delta-passes=operands-one --test FileCheck --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck --check-prefixes=CHECK,ONE %s < %t
+
+; RUN: llvm-reduce --abort-on-invalid-reduction --delta-passes=operands-poison --test FileCheck --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck --check-prefixes=CHECK,POISON %s < %t
+
+; CHECK-LABEL: @test(
+; ZERO: call <1024 x i8> @llvm.x86.cast.tile.to.vector.v1024i8(x86_amx %amx)
+; ONE: call <1024 x i8> @llvm.x86.cast.tile.to.vector.v1024i8(x86_amx %amx)
+; POISON: call <1024 x i8> @llvm.x86.cast.tile.to.vector.v1024i8(x86_amx %amx)
+define <1024 x i8> @test(<1024 x i8> %vec) {
+  %amx = call x86_amx @llvm.x86.cast.vector.to.tile.v1024i8(<1024 x i8> %vec)
+  %vec2 = call <1024 x i8> @llvm.x86.cast.tile.to.vector.v1024i8(x86_amx %amx)
+  ret <1024 x i8> %vec2
+}

--- a/llvm/tools/llvm-reduce/deltas/ReduceInstructions.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceInstructions.cpp
@@ -24,7 +24,8 @@ using namespace llvm;
 // TODO: Technically the verifier only enforces preallocated token usage and
 // there is a none token.
 static bool shouldAlwaysKeep(const Instruction &I) {
-  return I.isEHPad() || I.getType()->isTokenTy() || I.isSwiftError();
+  return I.isEHPad() || I.getType()->isTokenTy() ||
+         I.getType()->isX86_AMXTy() || I.isSwiftError();
 }
 
 /// Removes out-of-chunk arguments from functions, and modifies their calls

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
@@ -62,7 +62,7 @@ static bool isZeroOrOneFP(Value *Op) {
 
 static bool shouldReduceOperand(Use &Op) {
   Type *Ty = Op->getType();
-  if (Ty->isLabelTy() || Ty->isMetadataTy())
+  if (Ty->isLabelTy() || Ty->isMetadataTy() || Ty->isX86_AMXTy())
     return false;
   // TODO: be more precise about which GEP operands we can reduce (e.g. array
   // indexes)


### PR DESCRIPTION
It's not possible to create zero constants of this type, and even
poison constants result in a verifier error when used as an intrinsic
argument.