### PR TITLE
[clang][docs] Update CommandLineUsage and UsersManual with some flags

### DIFF
--- a/clang/docs/UsersManual.md
+++ b/clang/docs/UsersManual.md
@@ -334,11 +334,10 @@ effect on formatting a simple conversion diagnostic, follow:
   ```
 
 - **sarif**: Emit diagnostics as a [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) JSON
-  document. This is useful when diagnostics are consumed by tools, including AI
-  agents. SARIF diagnostics are written to standard error.
-  `-fno-caret-diagnostics` suppresses the final diagnostic summary so that
-  standard error contains a standalone JSON document. Suppress the existing
-  SARIF-stability warning too when capturing a standalone JSON document:
+  document. SARIF diagnostics are written to standard error.
+
+  `-Wno-sarif-format-unstable -fno-caret-diagnostics` can be added to disable extraeneous
+  prints if a standalone JSON file is desired.
 
   ```console
   clang -fdiagnostics-format=sarif -Wno-sarif-format-unstable -fno-caret-diagnostics t.c 2> diagnostics.sarif

--- a/clang/docs/UsersManual.md
+++ b/clang/docs/UsersManual.md
@@ -307,7 +307,7 @@ API to output colored diagnostics. This option is only used on Windows and
 defaults to off.
 :::
 
-:::{option} -fdiagnostics-format=clang/msvc/vi
+:::{option} -fdiagnostics-format=clang/msvc/vi/sarif
 
 Changes diagnostic output format to better match IDEs and command line tools.
 
@@ -332,6 +332,27 @@ effect on formatting a simple conversion diagnostic, follow:
   ```
   t.c +3:11: warning: conversion specifies type 'char *' but the argument has type 'int'
   ```
+
+- **sarif**: Emit diagnostics as a [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) JSON
+  document. This is useful when diagnostics are consumed by tools, including AI
+  agents. SARIF diagnostics are written to standard error.
+  `-fno-caret-diagnostics` suppresses the final diagnostic summary so that
+  standard error contains a standalone JSON document. Suppress the existing
+  SARIF-stability warning too when capturing a standalone JSON document:
+
+  ```console
+  clang -fdiagnostics-format=sarif -Wno-sarif-format-unstable -fno-caret-diagnostics t.c 2> diagnostics.sarif
+  ```
+
+  The SARIF diagnostic format is currently unstable.
+:::
+
+:::{option} -fdiagnostics-absolute-paths
+
+Print absolute paths in diagnostics.
+
+This option is useful when a diagnostic consumer does not share Clang's current
+working directory. It resolves symbolic links before printing paths.
 :::
 
 (opt_fdiagnostics-show-option)=
@@ -881,6 +902,22 @@ information can be included in the remarks (see
 
 These are options that report execution time and consumed memory of different
 compilations steps.
+
+:::{option} -ftime-trace[=<path>]
+
+Write a Chrome tracing-format JSON time trace for the compilation.
+Without a path, Clang derives the JSON filename from the compilation output.
+A path names the JSON file or a directory that will contain it.
+
+{option}`-ftime-trace-granularity` sets the minimum recorded duration in
+microseconds (500 by default).
+{option}`-ftime-trace-verbose` records additional event details, including
+source filenames, and can increase the trace size by two to three times.
+
+```console
+$ clang -c foo.c -ftime-trace=compile-trace.json -o foo.o
+```
+:::
 
 :::{option} -fproc-stat-report=
 

--- a/clang/docs/analyzer/user-docs/CommandLineUsage.rst
+++ b/clang/docs/analyzer/user-docs/CommandLineUsage.rst
@@ -257,3 +257,4 @@ Detailed Usage
 ~~~~~~~~~~~~~~
 
 For extended documentation please refer to the `official site of CodeChecker <https://github.com/Ericsson/codechecker/blob/master/docs/usage.md>`_!
+

--- a/clang/docs/analyzer/user-docs/CommandLineUsage.rst
+++ b/clang/docs/analyzer/user-docs/CommandLineUsage.rst
@@ -7,6 +7,24 @@ Both provide a way of driving the analyzer, detecting compilation flags, and gen
 CodeChecker is more actively maintained, provides heuristics for working with multiple versions of popular compilers and it also comes with a web-based GUI for viewing, filtering, categorizing and suppressing the results.
 Therefore CodeChecker is recommended in case you need any of the above features or just more customizability in general.
 
+Machine-readable output
+-----------------------
+
+For a direct analysis of a source file, the ``clang`` driver can write a SARIF report::
+
+  $ clang --analyze --analyzer-output sarif -o report.sarif source.c
+
+``--analyzer-output`` selects the report format.
+The available formats are ``html``, ``plist``, ``plist-multi-file``, ``plist-html``, ``sarif``, ``sarif-html``, and ``text``.
+``sarif`` writes a SARIF JSON report to the path specified by ``-o``; ``sarif-html`` also creates HTML files for interactive inspection.
+The default format is ``plist``.
+
+This direct form analyzes a translation unit.
+For project-wide analysis, use a tool such as scan-build or CodeChecker to drive the individual compiler invocations.
+``scan-build`` can emit a SARIF report for each analyzed translation unit with its ``-sarif`` option::
+
+  $ scan-build -sarif -o reports make
+
 Comparison of CodeChecker and scan-build
 ----------------------------------------
 
@@ -239,4 +257,3 @@ Detailed Usage
 ~~~~~~~~~~~~~~
 
 For extended documentation please refer to the `official site of CodeChecker <https://github.com/Ericsson/codechecker/blob/master/docs/usage.md>`_!
-


### PR DESCRIPTION
The current user-manual is missing implemented options that are useful for machine-readable output, such as fdiagnostics-format=sarif and fdiagnostics-absolute-paths.

This PR was assisted by AI tools to correlate the existing user manual with implemented/tested flags in the trunk. Output was human-reviewed and edited before creating the PR.