### PR TITLE
[AMDGPU][CodeGen] Fix `S_NOP` insertion during `S_SET_VGPR_MSB` placement

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerVGPREncoding.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerVGPREncoding.cpp
@@ -254,7 +254,7 @@ bool AMDGPULowerVGPREncoding::setMode(ModeTy NewMode,
   // current MSBs, but the next VALU needs different MSBs, so this
   // S_SET_VGPR_MSB would land right after the setreg. Insert S_NOP to
   // prevent it from being silently dropped.
-  if (needNopBeforeSetVGPRMSB(I))
+  if (needNopBeforeSetVGPRMSB(InsertPt))
     BuildMI(*MBB, InsertPt, {}, TII->get(AMDGPU::S_NOP)).addImm(0);
   MostRecentModeSet =
       BuildMI(*MBB, InsertPt, {}, TII->get(AMDGPU::S_SET_VGPR_MSB))

--- a/llvm/test/CodeGen/AMDGPU/vgpr-set-msb-coissue.mir
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-set-msb-coissue.mir
@@ -134,6 +134,7 @@ body:             |
     ; CHECK: S_SET_VGPR_MSB 65, implicit-def $mode
     ; CHECK-NEXT: $vgpr256 = V_MOV_B32_e32 $vgpr257, implicit $exec
     ; CHECK-NEXT: S_SETREG_IMM32_B32 23228, 30721, implicit-def $mode, implicit $mode
+    ; CHECK-NEXT: S_NOP 0
     ; CHECK-NEXT: S_SET_VGPR_MSB 16713, implicit-def $mode
     ; CHECK-NEXT: S_BARRIER_WAIT -1
     ; CHECK-NEXT: $vgpr256 = V_ADD_U32_e32 $vgpr257, $vgpr512, implicit $exec


### PR DESCRIPTION
The issue arises when co-issue optimizations move the initial insertion position for `S_SET_VGPR_MSB` to an earlier spot, creating a mismatch with the position used to determine whether a `S_NOP` is needed.