### PR TITLE
[lldb] Gate `PolicyStack::Current()` log behind verbose

### DIFF
--- a/lldb/source/Utility/Policy.cpp
+++ b/lldb/source/Utility/Policy.cpp
@@ -25,10 +25,15 @@ PolicyStack &PolicyStack::Get() {
 
 Policy PolicyStack::Current() const {
   Policy p = m_stack.back();
+  // `Current()` is called on every read of the current policy (e.g. every
+  // `Process::GetState()`, itself called on every prompt redraw), so log
+  // only when verbose is set to avoid drowning out the process log.
   if (Log *log = GetLog(LLDBLog::Process)) {
-    StreamString s;
-    p.Dump(s);
-    LLDB_LOG(log, "{0}", s.GetData());
+    if (log->GetVerbose()) {
+      StreamString s;
+      p.Dump(s);
+      LLDB_LOG(log, "{0}", s.GetData());
+    }
   }
   return p;
 }


### PR DESCRIPTION
`Process::GetState()` calls `PolicyStack::Get().Current()` on every prompt redraw, so the previous unconditional LLDB_LOG at the read site fired on every keypress once `log enable lldb process` was on, drowning out any other process log output. Keep the dump for when it's actually wanted, but only fire it if the log is set to verbose.