### PR TITLE
[clang][test][AIX] Set OBJECT_MODE=any for all clang test

### DIFF
--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -492,10 +492,10 @@ elif platform.system() == "AIX":
 # 32-bit and 64-bit objects by default, set the environment variable
 # "OBJECT_MODE" to "any" by default on AIX OS.
 
+# Tools that support OBJECT_MODE default to 32-bit on AIX. Set
+# OBJECT_MODE=any to handle both 32-bit and 64-bit objects.
 if "system-aix" in config.available_features:
-   config.substitutions.append(("llvm-nm", "env OBJECT_MODE=any llvm-nm"))
-   config.substitutions.append(("llvm-ar", "env OBJECT_MODE=any llvm-ar"))
-   config.substitutions.append(("llvm-ranlib", "env OBJECT_MODE=any llvm-ranlib"))
+   config.environment["OBJECT_MODE"] = "any"
 
 # It is not realistically possible to account for all options that could
 # possibly be present in system and user configuration files, so disable

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -491,11 +491,8 @@ elif platform.system() == "AIX":
 # objects only. In order to not affect most test cases, which expect to support
 # 32-bit and 64-bit objects by default, set the environment variable
 # "OBJECT_MODE" to "any" by default on AIX OS.
-
-# Tools that support OBJECT_MODE default to 32-bit on AIX. Set
-# OBJECT_MODE=any to handle both 32-bit and 64-bit objects.
 if "system-aix" in config.available_features:
-   config.environment["OBJECT_MODE"] = "any"
+    config.environment["OBJECT_MODE"] = "any"
 
 # It is not realistically possible to account for all options that could
 # possibly be present in system and user configuration files, so disable


### PR DESCRIPTION
This patch sets OBJECT_MODE=any to have tools able to handle 32-bit or 64-bit objects.