### PR TITLE
[1/2]: [AMDGPU] Add stackPtrOffsetReg to llvm/test/CodeGen/AMDGPU/misaligned-vgpr-regsequence.mir

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/misaligned-vgpr-regsequence.mir
+++ b/llvm/test/CodeGen/AMDGPU/misaligned-vgpr-regsequence.mir
@@ -15,6 +15,8 @@
 ---
 name: misaligned_regsequence
 tracksRegLiveness: true
+machineFunctionInfo:
+  stackPtrOffsetReg: '$sgpr32'
 body:             |
   bb.0:
     liveins: $sgpr4_sgpr5


### PR DESCRIPTION
Prepare for this being observable to the CFA generation code.

Change-Id: I56d00133148fd2c8f0e0ed41edca446553c664bc

---

**Stack**:
- #209534
- #209533⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
