### PR TITLE
[SPIR-V] Make Shader code always inlined

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -6925,6 +6925,16 @@ void CodeGenModule::EmitGlobalFunctionDefinition(GlobalDecl GD,
   if (getTriple().isOSAIX() && D->isTargetClonesMultiVersion())
     Fn->setLinkage(llvm::GlobalValue::InternalLinkage);
 
+  // When Targeting SPIR-V, make Non-entry, non-exported HLSL functions have
+  // internal linkage because they are always inlined and are never referenced
+  // from outside the module. once inlined if definitions are dead they can be
+  // removed by DCE. SPIR-V shader targets required this for correctness since a
+  // leftover definition may retain an illegal signature. DirectX runs its own
+  // DCE pass, so it doesn't need this.
+  if (getLangOpts().HLSL && getTriple().isSPIRV() && Fn->hasExternalLinkage() &&
+      !D->hasAttr<HLSLShaderAttr>() && !D->isInExportDeclContext())
+    Fn->setLinkage(llvm::GlobalValue::InternalLinkage);
+
   // FIXME: this is redundant with part of setFunctionDefinitionAttributes
   setGVProperties(Fn, GD);
 

--- a/clang/test/CodeGenHLSL/spirv-non-entry-internal-linkage.hlsl
+++ b/clang/test/CodeGenHLSL/spirv-non-entry-internal-linkage.hlsl
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -finclude-default-header -triple spirv-unknown-vulkan1.3-library %s \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefixes=CHECK,SPIRV
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefixes=CHECK,DX
+// RUN: %clang_cc1 -finclude-default-header -triple spirv-unknown-vulkan1.3-library %s \
+// RUN:   -emit-llvm -O1 -o - | FileCheck %s --check-prefix=SPIRV-OPT
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
+// RUN:   -emit-llvm -O1 -o - | FileCheck %s --check-prefix=DX-OPT
+
+// When Targeting SPIR-V Non-entry, non-exported HLSL functions are always 
+// inlined making unused definitions dead and removable by DCE.
+// On DX the function keeps external linkage with hidden visibility.
+
+// Exported functions must remain externally visible on all targets.
+// CHECK: define {{(spir_func )?}}noundef nofpclass(nan inf) float @_Z11exported_fnf(
+export float exported_fn(float x) { return x * 2.0; }
+
+// SPIRV: define internal spir_func noundef nofpclass(nan inf) float @_Z6helperf(
+// DX: define hidden noundef nofpclass(nan inf) float @_Z6helperf(
+float helper(float x) { return x * 3.0; }
+
+// The mangled entry implementation always has internal linkage.
+// CHECK: define internal {{(spir_func )?}}void @_Z4mainv()
+
+// The unmangled entry point wrapper is always externally visible.
+// CHECK: define void @main()
+[shader("compute")][numthreads(1,1,1)]
+void main() {}
+
+// The dead, internalized helper is removed on SPIR-V once passes run, while the
+// externally-visible exported function and entry point are retained.
+// SPIRV-OPT-NOT: @_Z6helperf
+// SPIRV-OPT: define spir_func noundef nofpclass(nan inf) float @_Z11exported_fnf(
+// SPIRV-OPT: define void @main()
+
+// For DirectX the helper is removed in the backend and so should persist here.
+// DX-OPT: define hidden noundef nofpclass(nan inf) float @_Z6helperf(


### PR DESCRIPTION
fixes #201712

The llvm offload test suite has layout keyword orientation failures. On first glance it looked like layout issues because the failures were in the SPIR-V legalizer because of the creation of vector sizes larger than 4 for our matrix types.

It turns out these failures are not a result of the orientation work but rather because dead function definitions are persistend in the SPIR-V backend. This is lkely because OpenCL uses SPIR-V as a target and has a linker that can cleanup these definitions.

However shaders do not have linkers and their functions are always inlined so we need to handle this in the frontend so that DCE which is a part of the opt pipeline can take care of this for us.

Tests generated with Claude Opus 4.8