### PR TITLE
[RISCV] Add macro fusion support for the Xqci extension instructions

### DIFF
--- a/llvm/include/llvm/TargetParser/SubtargetFeature.h
+++ b/llvm/include/llvm/TargetParser/SubtargetFeature.h
@@ -33,7 +33,7 @@ namespace llvm {
 class raw_ostream;
 class Triple;
 
-const unsigned MAX_SUBTARGET_WORDS = 6;
+const unsigned MAX_SUBTARGET_WORDS = 7;
 const unsigned MAX_SUBTARGET_FEATURES = MAX_SUBTARGET_WORDS * 64;
 
 /// Container class for subtarget features.

--- a/llvm/lib/Target/RISCV/RISCVMacroFusion.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusion.td
@@ -267,3 +267,7 @@ def TuneFusionShiftBitExtract
                        return false;
                    }]>,
                  ]>;
+
+
+// Xqci macro fusions.
+include "RISCVMacroFusionXQCI.td"

--- a/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
@@ -107,32 +107,6 @@ def TuneMOVIMMLongLogicalXciFusion
                  ]>,
                  CheckOpcode<LongLogicalXqciOp>>;
 
-// Fuse two adjacent moves.
-def TuneMOVIMMMovXqciFusion
-  : SimpleFusion<"xqci-mov-mov", "HasMovMovXqciFusion",
-                 "Enable Move + Move macrofusion",
-                 CheckAny<[
-                   CheckAll<[
-                     CheckOpcode<[ADDI]>,
-                     CheckRegOperand<1, X0>
-                   ]>,
-                   CheckAll<[
-                     CheckOpcode<[ADDI]>,
-                     CheckIsImmOperand<2>,
-                     CheckImmOperand<2, 0>
-                   ]>,
-                   CheckOpcode<LoadImmOp>,
-                 ]>,
-                 CheckAny<[
-                   CheckAll<[
-                     CheckOpcode<[ADDI]>,
-                     CheckIsImmOperand<2>,
-                     CheckImmOperand<2, 0>
-                   ]>,
-                   CheckOpcode<LoadImmOp>
-                 ]>
-                 >;
-
 // Fuse move followed by long logical operation.
 def TuneMovALUXqciFusion
   : FirstRdEqSecondRdFusion<"xqci-mov-longlogical", "HasMovALUXqciFusion",

--- a/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
@@ -14,8 +14,9 @@
 // instruction is the same as the destination register of the second
 // instruction.
 class FirstRdEqSecondRdFusion<string name, string fieldName, string desc,
-                   MCInstPredicate firstPred, MCInstPredicate secondPred,
-                   int secondOpIdx=0, int firstOpIdx=0>
+                              MCInstPredicate firstPred,
+                              MCInstPredicate secondPred,
+                              int secondOpIdx=0, int firstOpIdx=0>
   : Fusion<name, fieldName, desc,
            [
              SecondFusionPredicateWithMCInstPredicate<secondPred>,
@@ -24,17 +25,6 @@ class FirstRdEqSecondRdFusion<string name, string fieldName, string desc,
              TieReg<firstOpIdx, secondOpIdx>
            ]>;
 
-// Fuse two operations without tying any of their register operands.
-class XqciFusionNoTie<string name, string fieldName, string desc,
-                        MCInstPredicate firstPred, MCInstPredicate secondPred>
-  : Fusion<name, fieldName, desc,
-           [
-             SecondFusionPredicateWithMCInstPredicate<secondPred>,
-             WildcardTrue,
-             FirstFusionPredicateWithMCInstPredicate<firstPred>
-           ]>;
-
-defvar LoadAndMoveImmOp = [ADDI, LUI, QC_E_LI, QC_LI];
 defvar LoadImmOp = [LUI, QC_E_LI, QC_LI];
 // 48-bit load store
 defvar LongLoadStoreXqciOp = [QC_E_LB, QC_E_LBU, QC_E_LH, QC_E_LHU, QC_E_LW,
@@ -45,38 +35,60 @@ defvar LongLogicalXqciOp = [QC_E_XORAI, QC_E_ORAI, QC_E_ANDAI, QC_E_ADDAI];
 // Fuse load-immediate/move-immediate followed by arithmetic/logic.
 def TuneMOVIMMALUXqciFusion
   : SimpleFusion<"xqci-movimm-alu", "HasMOVIMMALUXqciFusion",
-                "Enable MOVIMM + ALU operations macrofusion",
-                CheckAny<[
-                  CheckOpcode<[AUIPC]>,
-                  CheckOpcode<LoadAndMoveImmOp>,
-                ]>,
-                CheckOpcode<[
-                  ADD, ADDI, SUB, MUL,
-                  AND, ANDI, OR, ORI, ORN, XOR, XORI, XNOR,
-                  QC_E_ANDI, QC_E_ORI, QC_E_XORI,
-                  SLLI, SRLI, SRAI, QC_LI, QC_E_LI,
-                  MAX, MAXU, MIN, MINU
-                ]>>;
+                 "Enable MOVIMM + ALU operations macrofusion",
+                 CheckAny<[
+                   CheckAll<[
+                     CheckOpcode<[ADDI]>,
+                     CheckRegOperand<1, X0>
+                   ]>,
+                   CheckOpcode<LoadImmOp>,
+                   CheckOpcode<[AUIPC]>,
+                 ]>,
+                 CheckOpcode<[
+                   ADD, ADDI, SUB, MUL,
+                   AND, ANDI, ANDN, OR, ORI, ORN, XOR, XORI, XNOR,
+                   QC_E_ANDI, QC_E_ORI, QC_E_XORI,
+                   SLLI, SRLI, SRAI, QC_LI, QC_E_LI,
+                   MAX, MAXU, MIN, MINU
+                 ]>>;
 
 // Fuse load-immediate/move-immediate followed by multiply.
 def TuneMOVIMMMULXqciFusion
   : SimpleFusion<"xqci-movimm-mul", "HasMOVIMMMULXqciFusion",
                  "Enable MOVIMM + multiply macrofusion",
-                 CheckOpcode<LoadAndMoveImmOp>,
+                 CheckAny<[
+                   CheckAll<[
+                     CheckOpcode<[ADDI]>,
+                     CheckRegOperand<1, X0>
+                   ]>,
+                   CheckOpcode<LoadImmOp>,
+                 ]>,
                  CheckOpcode<[MUL]>>;
 
 // Fuse load-immediate/move-immediate followed by long load/store.
 def TuneMOVIMMLoadStoreXqciFusion
   : SimpleFusion<"xqci-movimm-ldst", "HasMOVIMMLoadStoreXqciFusion",
                  "Enable MOVIMM + long Load/Store macrofusion",
-                 CheckOpcode<LoadAndMoveImmOp>,
+                 CheckAny<[
+                   CheckAll<[
+                     CheckOpcode<[ADDI]>,
+                     CheckRegOperand<1, X0>
+                   ]>,
+                   CheckOpcode<LoadImmOp>,
+                 ]>,
                  CheckOpcode<LongLoadStoreXqciOp>>;
 
 // Fuse load-immediate/move-immediate followed by a jump.
 def TuneMOVIMMJumpXqciFusion
   : SimpleFusion<"xqci-movimm-jump", "HasMOVIMMJumpXqciFusion",
                  "Enable MOVIMM + Jump macrofusion",
-                 CheckOpcode<LoadAndMoveImmOp>,
+                 CheckAny<[
+                   CheckAll<[
+                     CheckOpcode<[ADDI]>,
+                     CheckRegOperand<1, X0>
+                   ]>,
+                   CheckOpcode<LoadImmOp>,
+                 ]>,
                  CheckOpcode<[JALR]>>;
 
 // Fuse load-immediate/move-immediate followed by long logical operation.
@@ -86,14 +98,6 @@ def TuneMOVIMMLongLogicalXciFusion
   : FirstRdEqSecondRdFusion<"xqci-movimm-longlogical",
                  "HasMOVIMMLongLogicalXqciFusion",
                  "Enable MOVIMM + long logical operation macrofusion",
-                 CheckOpcode<LoadAndMoveImmOp>,
-                 CheckOpcode<LongLogicalXqciOp>
-                 >;
-
-// Fuse load-immediate/move-immediate followed by move.
-def TuneMOVIMMMovXqciFusion
-  : SimpleFusion<"xqci-movimm-mov", "HasMOVIMMMovXqciFusion",
-                 "Enable MOVIMM + Move macrofusion",
                  CheckAny<[
                    CheckAll<[
                      CheckOpcode<[ADDI]>,
@@ -101,21 +105,17 @@ def TuneMOVIMMMovXqciFusion
                    ]>,
                    CheckOpcode<LoadImmOp>,
                  ]>,
+                 CheckOpcode<LongLogicalXqciOp>>;
+
+// Fuse two adjacent moves.
+def TuneMOVIMMMovXqciFusion
+  : SimpleFusion<"xqci-mov-mov", "HasMovMovXqciFusion",
+                 "Enable Move + Move macrofusion",
                  CheckAny<[
                    CheckAll<[
                      CheckOpcode<[ADDI]>,
-                     CheckIsImmOperand<2>,
-                     CheckImmOperand<2, 0>
+                     CheckRegOperand<1, X0>
                    ]>,
-                   CheckOpcode<LoadImmOp>
-                 ]>
-                >;
-
-// Fuse two adjacent moves.
-def TuneMovMovXqciFusion
-  : XqciFusionNoTie<"xqci-mov-mov", "HasMovMovXqciFusion",
-                 "Enable move + move macrofusion",
-                 CheckAny<[
                    CheckAll<[
                      CheckOpcode<[ADDI]>,
                      CheckIsImmOperand<2>,

--- a/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
@@ -91,8 +91,7 @@ def TuneMOVIMMLongAccumXciFusion
                    CheckOpcode<LoadImmOp>,
                  ]>,
                  CheckOpcode<LongAccumXqciOp>,
-                 [],
-                 [TieReg<0, 0>]>;
+                 epilog=[TieReg<0, 0>]>;
 
 // Fuse move followed by long accumulate operation.
 def TuneMovALUXqciFusion
@@ -104,5 +103,4 @@ def TuneMovALUXqciFusion
                    CheckImmOperand<2, 0>
                  ]>,
                  CheckOpcode<LongAccumXqciOp>,
-                 [],
-                 [TieReg<0, 0>]>;
+                 epilog=[TieReg<0, 0>]>;

--- a/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
@@ -1,0 +1,146 @@
+//==---- RISCVMacroFusionXQCI.td - Macro Fusions for XQCI -----*- tablegen-*-=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// ===---------------------------------------------------------------------===//
+// The following definitions describe macro fusion predicators applicable to
+// Xqci instructions.
+
+// Fuse two instructions where the destination register of the first
+// instruction is the same as the destination register of the second
+// instruction.
+class FirstRdEqSecondRdFusion<string name, string fieldName, string desc,
+                   MCInstPredicate firstPred, MCInstPredicate secondPred,
+                   int secondOpIdx=0, int firstOpIdx=0>
+  : Fusion<name, fieldName, desc,
+           [
+             SecondFusionPredicateWithMCInstPredicate<secondPred>,
+             WildcardTrue,
+             FirstFusionPredicateWithMCInstPredicate<firstPred>,
+             TieReg<firstOpIdx, secondOpIdx>
+           ]>;
+
+// Fuse two operations without tying any of their register operands.
+class XqciFusionNoTie<string name, string fieldName, string desc,
+                        MCInstPredicate firstPred, MCInstPredicate secondPred>
+  : Fusion<name, fieldName, desc,
+           [
+             SecondFusionPredicateWithMCInstPredicate<secondPred>,
+             WildcardTrue,
+             FirstFusionPredicateWithMCInstPredicate<firstPred>
+           ]>;
+
+defvar LoadAndMoveImmOp = [ADDI, LUI, QC_E_LI, QC_LI];
+defvar LoadImmOp = [LUI, QC_E_LI, QC_LI];
+// 48-bit load store
+defvar LongLoadStoreXqciOp = [QC_E_LB, QC_E_LBU, QC_E_LH, QC_E_LHU, QC_E_LW,
+                              QC_E_SB, QC_E_SH, QC_E_SW];
+// 48-bit logical operations
+defvar LongLogicalXqciOp = [QC_E_XORAI, QC_E_ORAI, QC_E_ANDAI, QC_E_ADDAI];
+
+// Fuse load-immediate/move-immediate followed by arithmetic/logic.
+def TuneMOVIMMALUXqciFusion
+  : SimpleFusion<"xqci-movimm-alu", "HasMOVIMMALUXqciFusion",
+                "Enable MOVIMM + ALU operations macrofusion",
+                CheckAny<[
+                  CheckOpcode<[AUIPC]>,
+                  CheckOpcode<LoadAndMoveImmOp>,
+                ]>,
+                CheckOpcode<[
+                  ADD, ADDI, SUB, MUL,
+                  AND, ANDI, OR, ORI, ORN, XOR, XORI, XNOR,
+                  QC_E_ANDI, QC_E_ORI, QC_E_XORI,
+                  SLLI, SRLI, SRAI, QC_LI, QC_E_LI,
+                  MAX, MAXU, MIN, MINU
+                ]>>;
+
+// Fuse load-immediate/move-immediate followed by multiply.
+def TuneMOVIMMMULXqciFusion
+  : SimpleFusion<"xqci-movimm-mul", "HasMOVIMMMULXqciFusion",
+                 "Enable MOVIMM + multiply macrofusion",
+                 CheckOpcode<LoadAndMoveImmOp>,
+                 CheckOpcode<[MUL]>>;
+
+// Fuse load-immediate/move-immediate followed by long load/store.
+def TuneMOVIMMLoadStoreXqciFusion
+  : SimpleFusion<"xqci-movimm-ldst", "HasMOVIMMLoadStoreXqciFusion",
+                 "Enable MOVIMM + long Load/Store macrofusion",
+                 CheckOpcode<LoadAndMoveImmOp>,
+                 CheckOpcode<LongLoadStoreXqciOp>>;
+
+// Fuse load-immediate/move-immediate followed by a jump.
+def TuneMOVIMMJumpXqciFusion
+  : SimpleFusion<"xqci-movimm-jump", "HasMOVIMMJumpXqciFusion",
+                 "Enable MOVIMM + Jump macrofusion",
+                 CheckOpcode<LoadAndMoveImmOp>,
+                 CheckOpcode<[JALR]>>;
+
+// Fuse load-immediate/move-immediate followed by long logical operation.
+// The destination register of the first operation is the same as the
+// destination register of the second operation.
+def TuneMOVIMMLongLogicalXciFusion
+  : FirstRdEqSecondRdFusion<"xqci-movimm-longlogical",
+                 "HasMOVIMMLongLogicalXqciFusion",
+                 "Enable MOVIMM + long logical operation macrofusion",
+                 CheckOpcode<LoadAndMoveImmOp>,
+                 CheckOpcode<LongLogicalXqciOp>
+                 >;
+
+// Fuse load-immediate/move-immediate followed by move.
+def TuneMOVIMMMovXqciFusion
+  : SimpleFusion<"xqci-movimm-mov", "HasMOVIMMMovXqciFusion",
+                 "Enable MOVIMM + Move macrofusion",
+                 CheckAny<[
+                   CheckAll<[
+                     CheckOpcode<[ADDI]>,
+                     CheckRegOperand<1, X0>
+                   ]>,
+                   CheckOpcode<LoadImmOp>,
+                 ]>,
+                 CheckAny<[
+                   CheckAll<[
+                     CheckOpcode<[ADDI]>,
+                     CheckIsImmOperand<2>,
+                     CheckImmOperand<2, 0>
+                   ]>,
+                   CheckOpcode<LoadImmOp>
+                 ]>
+                >;
+
+// Fuse two adjacent moves.
+def TuneMovMovXqciFusion
+  : XqciFusionNoTie<"xqci-mov-mov", "HasMovMovXqciFusion",
+                 "Enable move + move macrofusion",
+                 CheckAny<[
+                   CheckAll<[
+                     CheckOpcode<[ADDI]>,
+                     CheckIsImmOperand<2>,
+                     CheckImmOperand<2, 0>
+                   ]>,
+                   CheckOpcode<LoadImmOp>,
+                 ]>,
+                 CheckAny<[
+                   CheckAll<[
+                     CheckOpcode<[ADDI]>,
+                     CheckIsImmOperand<2>,
+                     CheckImmOperand<2, 0>
+                   ]>,
+                   CheckOpcode<LoadImmOp>
+                 ]>
+                 >;
+
+// Fuse move followed by long logical operation.
+def TuneMovALUXqciFusion
+  : FirstRdEqSecondRdFusion<"xqci-mov-longlogical", "HasMovALUXqciFusion",
+                            "Enable MOV + long logical operation macrofusion",
+                            CheckAll<[
+                              CheckOpcode<[ADDI]>,
+                              CheckIsImmOperand<2>,
+                              CheckImmOperand<2, 0>
+                            ]>,
+                            CheckOpcode<LongLogicalXqciOp>
+                            >;

--- a/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
@@ -81,42 +81,28 @@ def TuneMOVIMMJumpXqciFusion
 
 // Fuse load-immediate/move-immediate followed by long accumulate operation.
 def TuneMOVIMMLongAccumXciFusion
-  : Fusion<"xqci-movimm-longlogical", "HasMOVIMMLongAccumXqciFusion",
-           "Enable MOVIMM + long accumulate macrofusion",
-           [
-             SecondFusionPredicateWithMCInstPredicate<
-               CheckOpcode<LongAccumXqciOp>
-             >,
-             WildcardTrue,
-             FirstFusionPredicateWithMCInstPredicate<
-               CheckAny<[
-                 CheckAll<[
-                   CheckOpcode<[ADDI]>,
-                   CheckRegOperand<1, X0>
+  : SimpleFusion<"xqci-movimm-longlogical", "HasMOVIMMLongAccumXqciFusion",
+                 "Enable MOVIMM + long accumulate macrofusion",
+                 CheckAny<[
+                   CheckAll<[
+                     CheckOpcode<[ADDI]>,
+                     CheckRegOperand<1, X0>
+                   ]>,
+                   CheckOpcode<LoadImmOp>,
                  ]>,
-                 CheckOpcode<LoadImmOp>,
-               ]>
-             >,
-             TieReg<0, 0>,
-             TieReg<0, 1>,
-           ]>;
+                 CheckOpcode<LongAccumXqciOp>,
+                 [],
+                 [TieReg<0, 0>]>;
 
 // Fuse move followed by long accumulate operation.
 def TuneMovALUXqciFusion
-  : Fusion<"xqci-mov-longlogical", "HasMovALUXqciFusion",
-           "Enable MOV + long accumulate macrofusion",
-           [
-             SecondFusionPredicateWithMCInstPredicate<
-               CheckOpcode<LongAccumXqciOp>
-             >,
-             WildcardTrue,
-             FirstFusionPredicateWithMCInstPredicate<
-               CheckAll<[
-                 CheckOpcode<[ADDI]>,
-                 CheckIsImmOperand<2>,
-                 CheckImmOperand<2, 0>
-               ]>
-             >,
-             TieReg<0, 0>,
-             TieReg<0, 1>
-           ]>;
+  : SimpleFusion<"xqci-mov-longlogical", "HasMovALUXqciFusion",
+                 "Enable MOV + long accumulate macrofusion",
+                 CheckAll<[
+                   CheckOpcode<[ADDI]>,
+                   CheckIsImmOperand<2>,
+                   CheckImmOperand<2, 0>
+                 ]>,
+                 CheckOpcode<LongAccumXqciOp>,
+                 [],
+                 [TieReg<0, 0>]>;

--- a/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
+++ b/llvm/lib/Target/RISCV/RISCVMacroFusionXQCI.td
@@ -10,27 +10,12 @@
 // The following definitions describe macro fusion predicators applicable to
 // Xqci instructions.
 
-// Fuse two instructions where the destination register of the first
-// instruction is the same as the destination register of the second
-// instruction.
-class FirstRdEqSecondRdFusion<string name, string fieldName, string desc,
-                              MCInstPredicate firstPred,
-                              MCInstPredicate secondPred,
-                              int secondOpIdx=0, int firstOpIdx=0>
-  : Fusion<name, fieldName, desc,
-           [
-             SecondFusionPredicateWithMCInstPredicate<secondPred>,
-             WildcardTrue,
-             FirstFusionPredicateWithMCInstPredicate<firstPred>,
-             TieReg<firstOpIdx, secondOpIdx>
-           ]>;
-
 defvar LoadImmOp = [LUI, QC_E_LI, QC_LI];
 // 48-bit load store
 defvar LongLoadStoreXqciOp = [QC_E_LB, QC_E_LBU, QC_E_LH, QC_E_LHU, QC_E_LW,
                               QC_E_SB, QC_E_SH, QC_E_SW];
 // 48-bit logical operations
-defvar LongLogicalXqciOp = [QC_E_XORAI, QC_E_ORAI, QC_E_ANDAI, QC_E_ADDAI];
+defvar LongAccumXqciOp = [QC_E_XORAI, QC_E_ORAI, QC_E_ANDAI, QC_E_ADDAI];
 
 // Fuse load-immediate/move-immediate followed by arithmetic/logic.
 def TuneMOVIMMALUXqciFusion
@@ -91,30 +76,47 @@ def TuneMOVIMMJumpXqciFusion
                  ]>,
                  CheckOpcode<[JALR]>>;
 
-// Fuse load-immediate/move-immediate followed by long logical operation.
 // The destination register of the first operation is the same as the
 // destination register of the second operation.
-def TuneMOVIMMLongLogicalXciFusion
-  : FirstRdEqSecondRdFusion<"xqci-movimm-longlogical",
-                 "HasMOVIMMLongLogicalXqciFusion",
-                 "Enable MOVIMM + long logical operation macrofusion",
-                 CheckAny<[
-                   CheckAll<[
-                     CheckOpcode<[ADDI]>,
-                     CheckRegOperand<1, X0>
-                   ]>,
-                   CheckOpcode<LoadImmOp>,
-                 ]>,
-                 CheckOpcode<LongLogicalXqciOp>>;
 
-// Fuse move followed by long logical operation.
+// Fuse load-immediate/move-immediate followed by long accumulate operation.
+def TuneMOVIMMLongAccumXciFusion
+  : Fusion<"xqci-movimm-longlogical", "HasMOVIMMLongAccumXqciFusion",
+           "Enable MOVIMM + long accumulate macrofusion",
+           [
+             SecondFusionPredicateWithMCInstPredicate<
+               CheckOpcode<LongAccumXqciOp>
+             >,
+             WildcardTrue,
+             FirstFusionPredicateWithMCInstPredicate<
+               CheckAny<[
+                 CheckAll<[
+                   CheckOpcode<[ADDI]>,
+                   CheckRegOperand<1, X0>
+                 ]>,
+                 CheckOpcode<LoadImmOp>,
+               ]>
+             >,
+             TieReg<0, 0>,
+             TieReg<0, 1>,
+           ]>;
+
+// Fuse move followed by long accumulate operation.
 def TuneMovALUXqciFusion
-  : FirstRdEqSecondRdFusion<"xqci-mov-longlogical", "HasMovALUXqciFusion",
-                            "Enable MOV + long logical operation macrofusion",
-                            CheckAll<[
-                              CheckOpcode<[ADDI]>,
-                              CheckIsImmOperand<2>,
-                              CheckImmOperand<2, 0>
-                            ]>,
-                            CheckOpcode<LongLogicalXqciOp>
-                            >;
+  : Fusion<"xqci-mov-longlogical", "HasMovALUXqciFusion",
+           "Enable MOV + long accumulate macrofusion",
+           [
+             SecondFusionPredicateWithMCInstPredicate<
+               CheckOpcode<LongAccumXqciOp>
+             >,
+             WildcardTrue,
+             FirstFusionPredicateWithMCInstPredicate<
+               CheckAll<[
+                 CheckOpcode<[ADDI]>,
+                 CheckIsImmOperand<2>,
+                 CheckImmOperand<2, 0>
+               ]>
+             >,
+             TieReg<0, 0>,
+             TieReg<0, 1>
+           ]>;

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -73,7 +73,6 @@
 ; CHECK-NEXT:   fusion-shifted-zextw             - Enable SLLI+SRLI to be fused when computing (shifted) word zero extension.
 ; CHECK-NEXT:   fusion-shxadd-load               - Enable SH(1|2|3)ADD(.UW) + load macrofusion.
 ; CHECK-NEXT:   fusion-xqci-mov-longlogical      - Enable MOV + long logical operation macrofusion.
-; CHECK-NEXT:   fusion-xqci-mov-mov              - Enable Move + Move macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-alu           - Enable MOVIMM + ALU operations macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-jump          - Enable MOVIMM + Jump macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-ldst          - Enable MOVIMM + long Load/Store macrofusion.

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -73,12 +73,11 @@
 ; CHECK-NEXT:   fusion-shifted-zextw             - Enable SLLI+SRLI to be fused when computing (shifted) word zero extension.
 ; CHECK-NEXT:   fusion-shxadd-load               - Enable SH(1|2|3)ADD(.UW) + load macrofusion.
 ; CHECK-NEXT:   fusion-xqci-mov-longlogical      - Enable MOV + long logical operation macrofusion.
-; CHECK-NEXT:   fusion-xqci-mov-mov              - Enable move + move macrofusion.
+; CHECK-NEXT:   fusion-xqci-mov-mov              - Enable Move + Move macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-alu           - Enable MOVIMM + ALU operations macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-jump          - Enable MOVIMM + Jump macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-ldst          - Enable MOVIMM + long Load/Store macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-longlogical   - Enable MOVIMM + long logical operation macrofusion.
-; CHECK-NEXT:   fusion-xqci-movimm-mov           - Enable MOVIMM + Move macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-mul           - Enable MOVIMM + multiply macrofusion.
 ; CHECK-NEXT:   fusion-zexth                     - Enable SLLI+SRLI to be fused to zero extension of halfword.
 ; CHECK-NEXT:   fusion-zextw                     - Enable SLLI+SRLI to be fused to zero extension of word.

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -72,6 +72,14 @@
 ; CHECK-NEXT:   fusion-shift-bit-extract         - Enable SLLI+SRLI/SRAI macrofusion.
 ; CHECK-NEXT:   fusion-shifted-zextw             - Enable SLLI+SRLI to be fused when computing (shifted) word zero extension.
 ; CHECK-NEXT:   fusion-shxadd-load               - Enable SH(1|2|3)ADD(.UW) + load macrofusion.
+; CHECK-NEXT:   fusion-xqci-mov-longlogical      - Enable MOV + long logical operation macrofusion.
+; CHECK-NEXT:   fusion-xqci-mov-mov              - Enable move + move macrofusion.
+; CHECK-NEXT:   fusion-xqci-movimm-alu           - Enable MOVIMM + ALU operations macrofusion.
+; CHECK-NEXT:   fusion-xqci-movimm-jump          - Enable MOVIMM + Jump macrofusion.
+; CHECK-NEXT:   fusion-xqci-movimm-ldst          - Enable MOVIMM + long Load/Store macrofusion.
+; CHECK-NEXT:   fusion-xqci-movimm-longlogical   - Enable MOVIMM + long logical operation macrofusion.
+; CHECK-NEXT:   fusion-xqci-movimm-mov           - Enable MOVIMM + Move macrofusion.
+; CHECK-NEXT:   fusion-xqci-movimm-mul           - Enable MOVIMM + multiply macrofusion.
 ; CHECK-NEXT:   fusion-zexth                     - Enable SLLI+SRLI to be fused to zero extension of halfword.
 ; CHECK-NEXT:   fusion-zextw                     - Enable SLLI+SRLI to be fused to zero extension of word.
 ; CHECK-NEXT:   h                                - 'H' (Hypervisor).

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -72,11 +72,11 @@
 ; CHECK-NEXT:   fusion-shift-bit-extract         - Enable SLLI+SRLI/SRAI macrofusion.
 ; CHECK-NEXT:   fusion-shifted-zextw             - Enable SLLI+SRLI to be fused when computing (shifted) word zero extension.
 ; CHECK-NEXT:   fusion-shxadd-load               - Enable SH(1|2|3)ADD(.UW) + load macrofusion.
-; CHECK-NEXT:   fusion-xqci-mov-longlogical      - Enable MOV + long logical operation macrofusion.
+; CHECK-NEXT:   fusion-xqci-mov-longlogical      - Enable MOV + long accumulate macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-alu           - Enable MOVIMM + ALU operations macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-jump          - Enable MOVIMM + Jump macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-ldst          - Enable MOVIMM + long Load/Store macrofusion.
-; CHECK-NEXT:   fusion-xqci-movimm-longlogical   - Enable MOVIMM + long logical operation macrofusion.
+; CHECK-NEXT:   fusion-xqci-movimm-longlogical   - Enable MOVIMM + long accumulate macrofusion.
 ; CHECK-NEXT:   fusion-xqci-movimm-mul           - Enable MOVIMM + multiply macrofusion.
 ; CHECK-NEXT:   fusion-zexth                     - Enable SLLI+SRLI to be fused to zero extension of halfword.
 ; CHECK-NEXT:   fusion-zextw                     - Enable SLLI+SRLI to be fused to zero extension of word.

--- a/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
@@ -1,0 +1,211 @@
+# REQUIRES: asserts
+# RUN: llc -mtriple=riscv32-linux-gnu -x=mir < %s \
+# RUN:   -debug-only=machine-scheduler -start-before=machine-scheduler 2>&1 \
+# RUN:   -mattr=+xqcilia,+xqcili,+xqcilo,+zmmul,+fusion-xqci-movimm-alu \
+# RUN:   -mattr=+fusion-xqci-movimm-mul,+fusion-xqci-movimm-ldst \
+# RUN:   -mattr=+fusion-xqci-movimm-jump \
+# RUN:   -mattr=+fusion-xqci-movimm-longlogical,+fusion-xqci-movimm-mov \
+# RUN:   -mattr=+fusion-xqci-mov-mov \
+# RUN:   -mattr=+fusion-xqci-mov-longlogical \
+# RUN:   | FileCheck %s
+
+# CHECK: movimm_alu_xqci:%bb.0
+# CHECK: Macro fuse: {{.*}}LUI - QC_E_ANDI
+---
+name: movimm_alu_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gprnox0 = COPY $x10
+    %2:gprnox0 = LUI 1
+    %3:gprnox0 = XORI %1, 2
+    %4:gprnox0 = QC_E_ANDI %2, 3
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: neg_movimm_alu_xqci:%bb.0
+# CHECK-NOT: Macro fuse: {{.*}}LUI - SUB
+name: neg_movimm_alu_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0
+    %0:gpr = COPY $x0
+    %1:gprnox0 = ADDI %0, 1
+    %2:gprnox0 = MUL  %1, %1
+    %3:gprnox0 = LUI 5
+    %4:gprnox0 = SUB  %1, %3
+    $x11 = COPY %2
+    $x12 = COPY %4
+    PseudoRET
+...
+
+
+# CHECK: movimm_mul_xqci:%bb.0
+# CHECK: Macro fuse: {{.*}}QC_LI - MUL
+name: movimm_mul_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gprnox0 = QC_LI 1
+    %3:gpr = XORI %1, 2
+    %4:gpr = MUL %2, %1
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: movimm_ldst_xqci:%bb.0
+# CHECK: Macro fuse: {{.*}}QC_LI - QC_E_LW
+name: movimm_ldst_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gprnox0 = QC_LI 100
+    %3:gpr = XORI %1, 2
+    %4:gpr = QC_E_LW %2, 0
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: movimm_jump_xqci:%bb.0
+# CHECK: Macro fuse: {{.*}}QC_E_LI - JALR
+name: movimm_jump_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gprnox0 = QC_E_LI 1
+    %3:gpr = XORI %1, 2
+    %4:gpr = JALR %2, 0
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: movimm_alujump_xqci:%bb.0
+# CHECK: Macro fuse: {{.*}}QC_LI - QC_E_XORAI
+name: movimm_alujump_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gprnox0 = QC_LI 1
+    %3:gpr = XORI %1, 2
+    %2:gprnox0 = QC_E_XORAI %2, 0
+    $x10 = COPY %3
+    $x11 = COPY %2
+    PseudoRET
+...
+
+# CHECK: movimm_mov_xqci:%bb.0
+# CHECK: Macro fuse: {{.*}}ADDI - ADDI
+name: movimm_mov_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %0:gpr = COPY $x10
+    %1:gpr = ADDI $x0, 5
+    %2:gpr = MUL  %0, %0
+    %3:gpr = ADDI %1, 0
+    %4:gpr = SUB  %2, %3
+    $x11 = COPY %3
+    $x12 = COPY %4
+    PseudoRET
+...
+
+
+# CHECK: neg_movimm_mov_xqci:%bb.0
+# CHECK-NOT: Macro fuse: {{.*}}ADDI - ADDI
+name: neg_movimm_mov_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0
+    %0:gpr = COPY $x0
+    %1:gpr = ADDI %0, 5
+    %2:gpr = MUL  %1, %1
+    %3:gpr = ADDI %2, 0
+    %4:gpr = SUB  %3, %1
+    $x11 = COPY %2
+    $x12 = COPY %4
+    PseudoRET
+...
+
+# CHECK: mov_mov1_xqci:%bb.0
+# CHECK-NOT: Macro fuse: {{.*}}ADDI - ADDI
+name: mov_mov1_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10, $x11, $x12
+    %0:gpr = COPY $x10
+    %1:gpr = COPY $x11
+    %2:gpr = COPY $x12
+    %3:gpr = ADDI %0, 0
+    %4:gpr = XORI %1, 2
+    %5:gpr = ADDI %2, 0
+    $x10 = COPY %3
+    $x11 = COPY %4
+    $x12 = COPY %5
+    PseudoRET
+...
+
+# CHECK: mov_mov2_xqci:%bb.0
+# CHECK: Macro fuse: {{.*}}ADDI - ADDI
+name: mov_mov2_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = ADDI %1, 0
+    %3:gpr = XORI %1, 2
+    %4:gpr = ADDI %2, 0
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: neg_mov_mov2_xqci:%bb.0
+# CHECK-NOT: Macro fuse: {{.*}}ADDI - QC_LI
+name: neg_mov_mov2_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %1:gpr = COPY $x10
+    %2:gpr = ADDI %1, 0
+    %3:gpr = XORI %1, 2
+    %4:gprnox0 = QC_LI 0
+    $x10 = COPY %3
+    $x11 = COPY %4
+    PseudoRET
+...
+
+# CHECK: mov_alu_xqci:%bb.0
+# CHECK: Macro fuse: {{.*}}ADDI - QC_E_XORAI
+name: mov_alu_xqci
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    %0:gpr = COPY $x10
+    %2:gprnox0 = ADDI %0, 0
+    %3:gpr = XORI %0, 2
+    %2:gprnox0 = QC_E_XORAI %2, 3
+    $x10 = COPY %2
+    $x11 = COPY %3
+    PseudoRET
+...

--- a/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
@@ -73,34 +73,31 @@ body:             |
     PseudoRET
 ...
 
-# CHECK: movimm_alujump_xqci:%bb.0
+# CHECK: movimm_longaccum_xqci:%bb.0
 # CHECK: Macro fuse: {{.*}}QC_LI - QC_E_XORAI
-name: movimm_alujump_xqci
+name: movimm_longaccum_xqci
 tracksRegLiveness: true
 body:             |
   bb.0.entry:
     liveins: $x10
-    %1:gpr = COPY $x10
-    %2:gprnox0 = QC_LI 1
-    %3:gpr = XORI %1, 2
-    %2:gprnox0 = QC_E_XORAI %2, 0
-    $x10 = COPY %3
-    $x11 = COPY %2
+    $x11 = QC_LI 1
+    $x12 = XORI $x10, 2
+    $x11 = QC_E_XORAI $x11, 3
+    $x13 = COPY $x12
+    $x10 = COPY $x11
     PseudoRET
 ...
 
-# CHECK: mov_alu_xqci:%bb.0
+# CHECK: mov_longaccum_xqci:%bb.0
 # CHECK: Macro fuse: {{.*}}ADDI - QC_E_XORAI
-name: mov_alu_xqci
+name: mov_longaccum_xqci
 tracksRegLiveness: true
 body:             |
   bb.0.entry:
     liveins: $x10
-    %0:gpr = COPY $x10
-    %2:gprnox0 = ADDI %0, 0
-    %3:gpr = XORI %0, 2
-    %2:gprnox0 = QC_E_XORAI %2, 3
-    $x10 = COPY %2
-    $x11 = COPY %3
-    PseudoRET
+    $x11 = ADDI $x10, 0
+    $x12 = XORI $x10, 2
+    $x11 = QC_E_XORAI $x11, 3
+    $x13 = COPY $x12
+    $x10 = COPY $x11
 ...

--- a/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
@@ -4,8 +4,7 @@
 # RUN:   -mattr=+xqcilia,+xqcili,+xqcilo,+zmmul,+fusion-xqci-movimm-alu \
 # RUN:   -mattr=+fusion-xqci-movimm-mul,+fusion-xqci-movimm-ldst \
 # RUN:   -mattr=+fusion-xqci-movimm-jump \
-# RUN:   -mattr=+fusion-xqci-movimm-longlogical,+fusion-xqci-movimm-mov \
-# RUN:   -mattr=+fusion-xqci-mov-mov \
+# RUN:   -mattr=+fusion-xqci-movimm-longlogical,+fusion-xqci-mov-mov \
 # RUN:   -mattr=+fusion-xqci-mov-longlogical \
 # RUN:   | FileCheck %s
 
@@ -25,24 +24,6 @@ body:             |
     $x11 = COPY %4
     PseudoRET
 ...
-
-# CHECK: neg_movimm_alu_xqci:%bb.0
-# CHECK-NOT: Macro fuse: {{.*}}LUI - SUB
-name: neg_movimm_alu_xqci
-tracksRegLiveness: true
-body:             |
-  bb.0.entry:
-    liveins: $x0
-    %0:gpr = COPY $x0
-    %1:gprnox0 = ADDI %0, 1
-    %2:gprnox0 = MUL  %1, %1
-    %3:gprnox0 = LUI 5
-    %4:gprnox0 = SUB  %1, %3
-    $x11 = COPY %2
-    $x12 = COPY %4
-    PseudoRET
-...
-
 
 # CHECK: movimm_mul_xqci:%bb.0
 # CHECK: Macro fuse: {{.*}}QC_LI - MUL
@@ -108,9 +89,9 @@ body:             |
     PseudoRET
 ...
 
-# CHECK: movimm_mov_xqci:%bb.0
+# CHECK: mov_mov1_xqci:%bb.0
 # CHECK: Macro fuse: {{.*}}ADDI - ADDI
-name: movimm_mov_xqci
+name: mov_mov1_xqci
 tracksRegLiveness: true
 body:             |
   bb.0.entry:
@@ -125,43 +106,6 @@ body:             |
     PseudoRET
 ...
 
-
-# CHECK: neg_movimm_mov_xqci:%bb.0
-# CHECK-NOT: Macro fuse: {{.*}}ADDI - ADDI
-name: neg_movimm_mov_xqci
-tracksRegLiveness: true
-body:             |
-  bb.0.entry:
-    liveins: $x0
-    %0:gpr = COPY $x0
-    %1:gpr = ADDI %0, 5
-    %2:gpr = MUL  %1, %1
-    %3:gpr = ADDI %2, 0
-    %4:gpr = SUB  %3, %1
-    $x11 = COPY %2
-    $x12 = COPY %4
-    PseudoRET
-...
-
-# CHECK: mov_mov1_xqci:%bb.0
-# CHECK-NOT: Macro fuse: {{.*}}ADDI - ADDI
-name: mov_mov1_xqci
-tracksRegLiveness: true
-body:             |
-  bb.0.entry:
-    liveins: $x10, $x11, $x12
-    %0:gpr = COPY $x10
-    %1:gpr = COPY $x11
-    %2:gpr = COPY $x12
-    %3:gpr = ADDI %0, 0
-    %4:gpr = XORI %1, 2
-    %5:gpr = ADDI %2, 0
-    $x10 = COPY %3
-    $x11 = COPY %4
-    $x12 = COPY %5
-    PseudoRET
-...
-
 # CHECK: mov_mov2_xqci:%bb.0
 # CHECK: Macro fuse: {{.*}}ADDI - ADDI
 name: mov_mov2_xqci
@@ -173,22 +117,6 @@ body:             |
     %2:gpr = ADDI %1, 0
     %3:gpr = XORI %1, 2
     %4:gpr = ADDI %2, 0
-    $x10 = COPY %3
-    $x11 = COPY %4
-    PseudoRET
-...
-
-# CHECK: neg_mov_mov2_xqci:%bb.0
-# CHECK-NOT: Macro fuse: {{.*}}ADDI - QC_LI
-name: neg_mov_mov2_xqci
-tracksRegLiveness: true
-body:             |
-  bb.0.entry:
-    liveins: $x10
-    %1:gpr = COPY $x10
-    %2:gpr = ADDI %1, 0
-    %3:gpr = XORI %1, 2
-    %4:gprnox0 = QC_LI 0
     $x10 = COPY %3
     $x11 = COPY %4
     PseudoRET

--- a/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
+++ b/llvm/test/CodeGen/RISCV/macro-fusions-xqci.mir
@@ -4,7 +4,7 @@
 # RUN:   -mattr=+xqcilia,+xqcili,+xqcilo,+zmmul,+fusion-xqci-movimm-alu \
 # RUN:   -mattr=+fusion-xqci-movimm-mul,+fusion-xqci-movimm-ldst \
 # RUN:   -mattr=+fusion-xqci-movimm-jump \
-# RUN:   -mattr=+fusion-xqci-movimm-longlogical,+fusion-xqci-mov-mov \
+# RUN:   -mattr=+fusion-xqci-movimm-longlogical \
 # RUN:   -mattr=+fusion-xqci-mov-longlogical \
 # RUN:   | FileCheck %s
 
@@ -86,39 +86,6 @@ body:             |
     %2:gprnox0 = QC_E_XORAI %2, 0
     $x10 = COPY %3
     $x11 = COPY %2
-    PseudoRET
-...
-
-# CHECK: mov_mov1_xqci:%bb.0
-# CHECK: Macro fuse: {{.*}}ADDI - ADDI
-name: mov_mov1_xqci
-tracksRegLiveness: true
-body:             |
-  bb.0.entry:
-    liveins: $x10
-    %0:gpr = COPY $x10
-    %1:gpr = ADDI $x0, 5
-    %2:gpr = MUL  %0, %0
-    %3:gpr = ADDI %1, 0
-    %4:gpr = SUB  %2, %3
-    $x11 = COPY %3
-    $x12 = COPY %4
-    PseudoRET
-...
-
-# CHECK: mov_mov2_xqci:%bb.0
-# CHECK: Macro fuse: {{.*}}ADDI - ADDI
-name: mov_mov2_xqci
-tracksRegLiveness: true
-body:             |
-  bb.0.entry:
-    liveins: $x10
-    %1:gpr = COPY $x10
-    %2:gpr = ADDI %1, 0
-    %3:gpr = XORI %1, 2
-    %4:gpr = ADDI %2, 0
-    $x10 = COPY %3
-    $x11 = COPY %4
     PseudoRET
 ...
 


### PR DESCRIPTION
Add macro fusion definitions for the Qualcomm Xqci extension covering movimm-alu, movimm-mul, movimm-ldst, movimm-jump, movimm-longlogical, movimm-mov, mov-mov, mov-longlogical fusions.

The fusion definitions live in a new RISCVMacroFusionXQCI.td which is included from RISCVMacroFusion.td. A MIR test and the feature list test are updated accordingly.

To accomodate additional features, increased MAX_SUBTARGET_FEATURES to 448 (from 384).