### PR TITLE
[DWARFLinker] Make synthetic type names deterministic under threading

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/SyntheticTypeNameBuilder.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/SyntheticTypeNameBuilder.cpp
@@ -405,10 +405,13 @@ Error SyntheticTypeNameBuilder::addDIETypeName(
   // Check if DIE already has a name.
   if (!TypeEntryPtr) {
     size_t NameStart = SyntheticName.size();
-    if (AssignNameToTypeDescriptor) {
-      if (Error Err = addParentName(*UnitEntryPair))
-        return Err;
-    }
+    // Prepend the parent scope so this name matches the key the type is
+    // stored under in the pool (the getKey() branch below). Otherwise the
+    // same type gets different names depending on whether it already has a
+    // pool entry, which races under parallel assignment and breaks
+    // deterministic deduplication.
+    if (Error Err = addParentName(*UnitEntryPair))
+      return Err;
     addTypePrefix(UnitEntryPair->DieEntry);
 
     if (ChildIndex) {


### PR DESCRIPTION
The parallel DWARF linker assigns type names concurrently across compile units. SyntheticTypeNameBuilder::addDIETypeName composes a type's name from its referenced types (e.g. template arguments).

For a referenced type it either appends that type's fully-qualified pool key, when the type has already been assigned a type entry, or recomputes the name inline. The inline path only prepended the parent scope when AssignNameToTypeDescriptor was set, so an embedded reference came out fully-qualified when the referenced type happened to be assigned already and unqualified otherwise.

Which branch runs depends on the order type names are assigned, and that order races during the parallel assignment phase. The same type then gets different synthetic names across runs, is entered into the type pool under different keys, and no longer deduplicates deterministically.

Two threaded runs of the same input:

```
  ...EventInstance:()<{1}CMEvent.{1}detail.{F}Group:()<...>>
  ...EventInstance:()<{F}Group:()<...>>
```

Always qualify with the parent scope regardless of AssignNameToTypeDescriptor so the inline path agrees with the stored key. Assignment to the type pool stays gated on the flag.