### PR TITLE
clang-linker-wrapper: Use AMDGPU::TargetID for image compatibilty (2)

### DIFF
--- a/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
+++ b/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
@@ -195,15 +195,17 @@ __attribute__((visibility("protected"), used)) int x;
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a:xnack-
 // RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-off.o -fembed-offload-object=%t-off.out
 // RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
-// RUN:   --linker-path=/usr/bin/ld %t-on.o %t-off.o %t-generic.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMD-GENERIC-MERGE
+// RUN:   --linker-path=/usr/bin/ld %t-on.o %t-off.o %t-generic.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMD-XNACK-SPLIT
 
-// AMD-GENERIC-MERGE-NOT: -mcpu=gfx90a -Wl,--no-undefined
-// AMD-GENERIC-MERGE: clang{{.*}} -o {{.*}}.img -dumpdir a.out.amdgcn.gfx90a:xnack+.img. --target=amdgcn-amd-amdhsa -mcpu=gfx90a:xnack+ -Wl,--no-undefined {{.*}}.o {{.*}}.o
-// AMD-GENERIC-MERGE: clang{{.*}} -o {{.*}}.img -dumpdir a.out.amdgcn.gfx90a:xnack-.img. --target=amdgcn-amd-amdhsa -mcpu=gfx90a:xnack- -Wl,--no-undefined {{.*}}.o {{.*}}.o
+// The three objects are distinct targets (xnack+, xnack-, and feature
+// unspecified) and are each linked into their own device image; a
+// feature-unspecified object is not merged into a feature-specific image.
+// AMD-XNACK-SPLIT-DAG: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx90a:xnack+ -Wl,--no-undefined {{.*}}.o
+// AMD-XNACK-SPLIT-DAG: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx90a:xnack- -Wl,--no-undefined {{.*}}.o
+// AMD-XNACK-SPLIT-DAG: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx90a -Wl,--no-undefined {{.*}}.o
 
-// A feature-unspecified (sramecc "any") object is compatible with an explicit
-// sramecc+ object and is linked into its image, producing a single sramecc+
-// image with no separate feature-unspecified image.
+// A feature-unspecified (sramecc "any") object and an explicit sramecc+ object
+// are distinct targets and are linked into separate device images.
 // RUN: llvm-offload-binary -o %t-secc-on.out \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a:sramecc+
 // RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-secc-on.o -fembed-offload-object=%t-secc-on.out
@@ -211,12 +213,13 @@ __attribute__((visibility("protected"), used)) int x;
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a
 // RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-secc-any.o -fembed-offload-object=%t-secc-any.out
 // RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
-// RUN:   --linker-path=/usr/bin/ld %t-secc-on.o %t-secc-any.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMD-SRAMECC-ANY-MERGE
+// RUN:   --linker-path=/usr/bin/ld %t-secc-on.o %t-secc-any.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMD-SRAMECC-ANY-SPLIT
 
-// AMD-SRAMECC-ANY-MERGE: clang{{.*}} -o {{.*}}.img -dumpdir a.out.amdgcn.gfx90a:sramecc+.img. --target=amdgcn-amd-amdhsa -mcpu=gfx90a:sramecc+ -Wl,--no-undefined {{.*}}.o {{.*}}.o
-// AMD-SRAMECC-ANY-MERGE-NOT: -mcpu=gfx90a -Wl,--no-undefined
+// AMD-SRAMECC-ANY-SPLIT-DAG: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx90a:sramecc+ -Wl,--no-undefined {{.*}}.o
+// AMD-SRAMECC-ANY-SPLIT-DAG: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx90a -Wl,--no-undefined {{.*}}.o
 
-// Objects with explicit conflicting sramecc settings form separate images.
+// Objects with explicit conflicting sramecc settings and a feature-unspecified
+// object are all distinct targets, each in its own device image.
 // RUN: llvm-offload-binary -o %t-generic.out \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a
 // RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-generic.o -fembed-offload-object=%t-generic.out
@@ -227,11 +230,11 @@ __attribute__((visibility("protected"), used)) int x;
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a:sramecc-
 // RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-secc-off.o -fembed-offload-object=%t-secc-off.out
 // RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
-// RUN:   --linker-path=/usr/bin/ld %t-secc-on.o %t-secc-off.o %t-generic.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMD-SRAMECC-MERGE
+// RUN:   --linker-path=/usr/bin/ld %t-secc-on.o %t-secc-off.o %t-generic.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMD-SRAMECC-SPLIT
 
-// AMD-SRAMECC-MERGE-NOT: -mcpu=gfx90a -Wl,--no-undefined
-// AMD-SRAMECC-MERGE: clang{{.*}} -o {{.*}}.img -dumpdir a.out.amdgcn.gfx90a:sramecc+.img. --target=amdgcn-amd-amdhsa -mcpu=gfx90a:sramecc+ -Wl,--no-undefined {{.*}}.o {{.*}}.o
-// AMD-SRAMECC-MERGE: clang{{.*}} -o {{.*}}.img -dumpdir a.out.amdgcn.gfx90a:sramecc-.img. --target=amdgcn-amd-amdhsa -mcpu=gfx90a:sramecc- -Wl,--no-undefined {{.*}}.o {{.*}}.o
+// AMD-SRAMECC-SPLIT-DAG: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx90a:sramecc+ -Wl,--no-undefined {{.*}}.o
+// AMD-SRAMECC-SPLIT-DAG: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx90a:sramecc- -Wl,--no-undefined {{.*}}.o
+// AMD-SRAMECC-SPLIT-DAG: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx90a -Wl,--no-undefined {{.*}}.o
 
 // Distinct processors, including a specific processor and a member of its
 // generic family (gfx900 and gfx9-generic), are separate compilation targets
@@ -266,6 +269,53 @@ __attribute__((visibility("protected"), used)) int x;
 // ARCH-ALL: clang{{.*}} -o {{.*}}.img -dumpdir a.out.amdgcn.gfx90a.img. --target=amdgcn-amd-amdhsa -mcpu=gfx90a -Wl,--no-undefined {{.*}}.o {{.*}}.o
 // ARCH-ALL: clang{{.*}} -o {{.*}}.img -dumpdir a.out.amdgcn.gfx908.img. --target=amdgcn-amd-amdhsa -mcpu=gfx908 -Wl,--no-undefined {{.*}}.o {{.*}}.o
 
+// A static-archive member whose target exactly matches an object group is
+// extracted into that group only once, not duplicated (the group is not treated
+// as a separate compatible target from the member itself).
+// RUN: llvm-offload-binary -o %t-exact-lib.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-exact-libobj.o -fembed-offload-object=%t-exact-lib.out
+// RUN: llvm-ar rcs %t-exact.a %t-exact-libobj.o
+// RUN: llvm-offload-binary -o %t-exact-obj.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-exact-obj.o -fembed-offload-object=%t-exact-obj.out
+// RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
+// RUN:   --linker-path=/usr/bin/ld %t-exact-obj.o %t-exact.a -o a.out 2>&1 | FileCheck %s --check-prefix=AMD-ARCHIVE-EXACT
+
+// AMD-ARCHIVE-EXACT: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx90a -Wl,--no-undefined {{[^ ]+}}.o {{[^ ]+}}.o{{$}}
+// AMD-ARCHIVE-EXACT-NOT: clang{{.*}} -mcpu=gfx90a{{.*}}.o {{.*}}.o {{.*}}.o
+
+// An object names the target as amdgpu9.0a-amd-amdhsa while a static-archive
+// member names the same target through the legacy triple plus arch=gfx90a.
+// RUN: llvm-offload-binary -o %t-subexact-lib.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-subexact-libobj.o -fembed-offload-object=%t-subexact-lib.out
+// RUN: llvm-ar rcs %t-subexact.a %t-subexact-libobj.o
+// RUN: llvm-offload-binary -o %t-subexact-obj.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9.0a-amd-amdhsa
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-subexact-obj.o -fembed-offload-object=%t-subexact-obj.out
+// RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
+// RUN:   --linker-path=/usr/bin/ld %t-subexact-obj.o %t-subexact.a -o a.out 2>&1 | FileCheck %s --check-prefix=AMD-ARCHIVE-SUBARCH-EXACT
+
+// AMD-ARCHIVE-SUBARCH-EXACT: clang{{.*}} --target=amdgpu9.0a-amd-amdhsa -Wl,--no-undefined {{[^ ]+}}.o {{[^ ]+}}.o{{$}}
+// AMD-ARCHIVE-SUBARCH-EXACT-NOT: clang{{.*}} --target={{.*}}-amd-amdhsa -Wl,--no-undefined {{.*}}.o {{.*}}.o {{.*}}.o
+
+// A generic (major-family) archive member provides for a specific member of its
+// family: an amdgpu9 (gfx9-generic) archive member is extracted into a specific
+// gfx900 object group.
+// RUN: llvm-offload-binary -o %t-genlib.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9-amd-amdhsa
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-genlibobj.o -fembed-offload-object=%t-genlib.out
+// RUN: llvm-ar rcs %t-gen.a %t-genlibobj.o
+// RUN: llvm-offload-binary -o %t-gen-obj.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx900
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-gen-obj.o -fembed-offload-object=%t-gen-obj.out
+// RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
+// RUN:   --linker-path=/usr/bin/ld %t-gen-obj.o %t-gen.a -o a.out 2>&1 | FileCheck %s --check-prefix=AMD-ARCHIVE-GENERIC
+
+// AMD-ARCHIVE-GENERIC: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx900 -Wl,--no-undefined {{[^ ]+}}.o {{[^ ]+}}.o{{$}}
+// AMD-ARCHIVE-GENERIC-NOT: clang{{.*}} --target=amdgpu9-amd-amdhsa
+
 // Two images with the same ISA but different triple spellings (the legacy
 // "amdgcn" alias and the canonical "amdgpu") must merge into a single device
 // link, not produce two separate device images.
@@ -295,8 +345,10 @@ __attribute__((visibility("protected"), used)) int x;
 // AMDGPU-SUBARCH-MERGE: clang{{.*}} --target=amdgpu9.0a-amd-amdhsa -Wl,--no-undefined {{.*}}.o {{.*}}.o
 // AMDGPU-SUBARCH-MERGE-NOT: clang{{.*}} --target=amdgpu9.0a-amd-amdhsa -Wl,--no-undefined
 
-// A major-family subarch triple (amdgpu9-amd-amdhsa) acts as a wildcard that
-// merges into a specific member of that family (amdgpu9.00-amd-amdhsa).
+// A major-family subarch triple (amdgpu9-amd-amdhsa) and a specific member of
+// that family (amdgpu9.00-amd-amdhsa) are distinct compilation targets: each
+// object carries its own device code, so they must be linked into separate
+// device images rather than merged (merging would duplicate symbols).
 // RUN: llvm-offload-binary -o %t-specific.out \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9.00-amd-amdhsa
 // RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-specific.o -fembed-offload-object=%t-specific.out
@@ -304,10 +356,10 @@ __attribute__((visibility("protected"), used)) int x;
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9-amd-amdhsa
 // RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-major.o -fembed-offload-object=%t-major.out
 // RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
-// RUN:   --linker-path=/usr/bin/ld %t-specific.o %t-major.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMDGPU-MAJOR-SUBARCH-MERGE
+// RUN:   --linker-path=/usr/bin/ld %t-specific.o %t-major.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMDGPU-MAJOR-SUBARCH-SPLIT
 
-// AMDGPU-MAJOR-SUBARCH-MERGE: clang{{.*}} --target=amdgpu9.00-amd-amdhsa -Wl,--no-undefined {{.*}}.o {{.*}}.o
-// AMDGPU-MAJOR-SUBARCH-MERGE-NOT: clang{{.*}} --target={{.*}}-amd-amdhsa -Wl,--no-undefined
+// AMDGPU-MAJOR-SUBARCH-SPLIT-DAG: clang{{.*}} --target=amdgpu9.00-amd-amdhsa -Wl,--no-undefined {{.*}}.o
+// AMDGPU-MAJOR-SUBARCH-SPLIT-DAG: clang{{.*}} --target=amdgpu9-amd-amdhsa -Wl,--no-undefined {{.*}}.o
 
 // Two distinct GPUs in the same major family are not interchangeable and must
 // not merge.

--- a/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
+++ b/clang/test/OffloadTools/clang-linker-wrapper/linker-wrapper.c
@@ -266,6 +266,63 @@ __attribute__((visibility("protected"), used)) int x;
 // ARCH-ALL: clang{{.*}} -o {{.*}}.img -dumpdir a.out.amdgcn.gfx90a.img. --target=amdgcn-amd-amdhsa -mcpu=gfx90a -Wl,--no-undefined {{.*}}.o {{.*}}.o
 // ARCH-ALL: clang{{.*}} -o {{.*}}.img -dumpdir a.out.amdgcn.gfx908.img. --target=amdgcn-amd-amdhsa -mcpu=gfx908 -Wl,--no-undefined {{.*}}.o {{.*}}.o
 
+// Two images with the same ISA but different triple spellings (the legacy
+// "amdgcn" alias and the canonical "amdgpu") must merge into a single device
+// link, not produce two separate device images.
+// RUN: llvm-offload-binary -o %t-legacy.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx90a
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-legacy.o -fembed-offload-object=%t-legacy.out
+// RUN: llvm-offload-binary -o %t-canon.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu-amd-amdhsa,arch=gfx90a
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-canon.o -fembed-offload-object=%t-canon.out
+// RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
+// RUN:   --linker-path=/usr/bin/ld %t-legacy.o %t-canon.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMDGPU-TRIPLE-MERGE
+
+// AMDGPU-TRIPLE-MERGE: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx90a -Wl,--no-undefined {{.*}}.o {{.*}}.o
+// AMDGPU-TRIPLE-MERGE-NOT: clang{{.*}} --target=amdgcn-amd-amdhsa -mcpu=gfx90a -Wl,--no-undefined
+
+// Two images whose triples encode the ISA in the subarch (amdgpu9.0a-amd-amdhsa)
+// and carry no separate arch must merge into a single device link.
+// RUN: llvm-offload-binary -o %t-sub1.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9.0a-amd-amdhsa
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-sub1.o -fembed-offload-object=%t-sub1.out
+// RUN: llvm-offload-binary -o %t-sub2.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9.0a-amd-amdhsa
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-sub2.o -fembed-offload-object=%t-sub2.out
+// RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
+// RUN:   --linker-path=/usr/bin/ld %t-sub1.o %t-sub2.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMDGPU-SUBARCH-MERGE
+
+// AMDGPU-SUBARCH-MERGE: clang{{.*}} --target=amdgpu9.0a-amd-amdhsa -Wl,--no-undefined {{.*}}.o {{.*}}.o
+// AMDGPU-SUBARCH-MERGE-NOT: clang{{.*}} --target=amdgpu9.0a-amd-amdhsa -Wl,--no-undefined
+
+// A major-family subarch triple (amdgpu9-amd-amdhsa) acts as a wildcard that
+// merges into a specific member of that family (amdgpu9.00-amd-amdhsa).
+// RUN: llvm-offload-binary -o %t-specific.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9.00-amd-amdhsa
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-specific.o -fembed-offload-object=%t-specific.out
+// RUN: llvm-offload-binary -o %t-major.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgpu9-amd-amdhsa
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-major.o -fembed-offload-object=%t-major.out
+// RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
+// RUN:   --linker-path=/usr/bin/ld %t-specific.o %t-major.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMDGPU-MAJOR-SUBARCH-MERGE
+
+// AMDGPU-MAJOR-SUBARCH-MERGE: clang{{.*}} --target=amdgpu9.00-amd-amdhsa -Wl,--no-undefined {{.*}}.o {{.*}}.o
+// AMDGPU-MAJOR-SUBARCH-MERGE-NOT: clang{{.*}} --target={{.*}}-amd-amdhsa -Wl,--no-undefined
+
+// Two distinct GPUs in the same major family are not interchangeable and must
+// not merge.
+// RUN: llvm-offload-binary -o %t-gfx900.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx900
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-gfx900.o -fembed-offload-object=%t-gfx900.out
+// RUN: llvm-offload-binary -o %t-gfx906.out \
+// RUN:   --image=file=%t.elf.o,kind=openmp,triple=amdgcn-amd-amdhsa,arch=gfx906
+// RUN: %clang -cc1 %s -triple x86_64-unknown-linux-gnu -emit-obj -o %t-gfx906.o -fembed-offload-object=%t-gfx906.out
+// RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
+// RUN:   --linker-path=/usr/bin/ld %t-gfx900.o %t-gfx906.o -o a.out 2>&1 | FileCheck %s --check-prefix=AMDGPU-SAME-MAJOR-NO-MERGE
+
+// AMDGPU-SAME-MAJOR-NO-MERGE-DAG: clang{{.*}} -mcpu=gfx900 -Wl,--no-undefined {{.*}}.o
+// AMDGPU-SAME-MAJOR-NO-MERGE-DAG: clang{{.*}} -mcpu=gfx906 -Wl,--no-undefined {{.*}}.o
+
 // RUN: llvm-offload-binary -o %t.out \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=x86_64-unknown-linux-gnu \
 // RUN:   --image=file=%t.elf.o,kind=openmp,triple=x86_64-unknown-linux-gnu

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1414,7 +1414,7 @@ getDeviceInput(const ArgList &Args) {
     OffloadFile::TargetID Target = Binary;
     SmallVector<OffloadFile::TargetID> CompatibleTargets;
     for (const auto &[ID, Input] : InputFiles)
-      if (Target == ID || object::areTargetsCompatible(Target, ID))
+      if (object::areTargetsEquivalent(Target, ID))
         CompatibleTargets.emplace_back(ID);
 
     // Seed a new image when no existing target can provide for this input.
@@ -1443,7 +1443,8 @@ getDeviceInput(const ArgList &Args) {
 
     SmallVector<OffloadFile::TargetID> CompatibleTargets = {Binary};
     for (const auto &[ID, Input] : InputFiles)
-      if (object::areTargetsCompatible(Binary, ID))
+      if (OffloadFile::TargetID(Binary) != ID &&
+          object::areTargetsCompatible(Binary, ID))
         CompatibleTargets.emplace_back(ID);
 
     for (const auto &[Index, ID] : llvm::enumerate(CompatibleTargets)) {

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1414,8 +1414,7 @@ getDeviceInput(const ArgList &Args) {
     OffloadFile::TargetID Target = Binary;
     SmallVector<OffloadFile::TargetID> CompatibleTargets;
     for (const auto &[ID, Input] : InputFiles)
-      if (Target.first == ID.first &&
-          clang::isCompatibleTargetID(Target.second, ID.second))
+      if (Target == ID || object::areTargetsCompatible(Target, ID))
         CompatibleTargets.emplace_back(ID);
 
     // Seed a new image when no existing target can provide for this input.

--- a/llvm/include/llvm/Object/OffloadBinary.h
+++ b/llvm/include/llvm/Object/OffloadBinary.h
@@ -249,16 +249,24 @@ LLVM_ABI OffloadKind getOffloadKind(StringRef Name);
 /// Convert an offload kind to its string representation.
 LLVM_ABI StringRef getOffloadKindName(OffloadKind Name);
 
-/// If the target is AMD we check the target IDs for mutual compatibility. A
-/// target id is a string conforming to the folowing BNF syntax:
+/// Returns true if an image built for target \p Provided can provide the device
+/// code for a request for target \p Requested. This is directional: a
+/// feature-unspecified or generic image serves a more specific request (e.g. a
+/// generic static-archive member pulled into a specific device-image group),
+/// but not vice versa. For AMDGPU a target id is a string conforming to the
+/// following BNF syntax:
 ///
 ///  target-id ::= '<arch> ( : <feature> ( '+' | '-' ) )*'
 ///
 /// The features 'xnack' and 'sramecc' are currently supported. These can be in
-/// the state of on, off, and any when unspecified. A target marked as any can
-/// bind with either on or off. This is used to link mutually compatible
-/// architectures together. Returns false in the case of an exact match.
-LLVM_ABI bool areTargetsCompatible(const OffloadFile::TargetID &LHS,
+/// the state of on, off, and any when unspecified. A provided target marked as
+/// any can bind with either on or off.
+LLVM_ABI bool areTargetsCompatible(const OffloadFile::TargetID &Provided,
+                                   const OffloadFile::TargetID &Requested);
+
+/// Returns true if \p LHS and \p RHS denote the same logical target, i.e. the
+/// same processor and features.
+LLVM_ABI bool areTargetsEquivalent(const OffloadFile::TargetID &LHS,
                                    const OffloadFile::TargetID &RHS);
 
 } // namespace object

--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -167,6 +167,10 @@ public:
   TargetID(GPUKind Arch, const Triple &TT, TargetIDSetting XnackSetting,
            TargetIDSetting SramEccSetting);
 
+  /// Construct a TargetID from a triple \p TT and the processor+features string
+  /// e.g. "gfx90a", "gfx90a:xnack+:sramecc-", "".
+  TargetID(const Triple &TT, StringRef TargetIDStr);
+
   ~TargetID() = default;
 
   /// \return True if the current xnack setting is not "Unsupported".
@@ -234,6 +238,10 @@ public:
 
   static std::optional<TargetID>
   parseTargetIDString(StringRef TargetIDDirective);
+
+  /// Returns true if a device image built for *this can satisfy a request for
+  /// \p Other (i.e. they are compatible and can be grouped together).
+  bool isCompatibleWith(const TargetID &Other) const;
 
   void print(raw_ostream &OS) const;
 

--- a/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
+++ b/llvm/include/llvm/TargetParser/AMDGPUTargetParser.h
@@ -239,9 +239,15 @@ public:
   static std::optional<TargetID>
   parseTargetIDString(StringRef TargetIDDirective);
 
-  /// Returns true if a device image built for *this can satisfy a request for
-  /// \p Other (i.e. they are compatible and can be grouped together).
-  bool isCompatibleWith(const TargetID &Other) const;
+  /// Returns true if \p Other denotes the same target as *this, i.e. the same
+  /// processor and xnack/sramecc settings on a compatible triple. This is a
+  /// semantic equality that looks through spelling differences.
+  bool isEquivalent(const TargetID &Other) const;
+
+  /// Returns true if a device image for *this can provide the device code for a
+  /// request for \p Other. This is directional and models logical-linking
+  /// compatibility.
+  bool providesFor(const TargetID &Other) const;
 
   void print(raw_ostream &OS) const;
 

--- a/llvm/lib/Object/OffloadBinary.cpp
+++ b/llvm/lib/Object/OffloadBinary.cpp
@@ -447,32 +447,42 @@ StringRef object::getImageKindName(ImageKind Kind) {
   }
 }
 
-bool object::areTargetsCompatible(const OffloadFile::TargetID &LHS,
+bool object::areTargetsEquivalent(const OffloadFile::TargetID &LHS,
                                   const OffloadFile::TargetID &RHS) {
-  // Exact matches are not considered compatible because they are the same
-  // target. We are interested in different targets that are compatible.
-  if (LHS == RHS)
-    return false;
-
   llvm::Triple LHSTT(LHS.first);
   llvm::Triple RHSTT(RHS.first);
 
-  // The AMDGPU target requires target-id aware checks (base processor plus
-  // xnack/sramecc features), which also handle the generic wildcard and the
-  // legacy "amdgcn"/"amdgpu" triple spellings.
+  // Check for logical AMDGPU target-id equivalence.
   if (LHSTT.isAMDGPU()) {
-    AMDGPU::TargetID LTID(LHSTT, LHS.second);
-    AMDGPU::TargetID RTID(RHSTT, RHS.second);
-    return LTID.isCompatibleWith(RTID);
+    AMDGPU::TargetID LHSID(LHSTT, LHS.second);
+    AMDGPU::TargetID RHSID(RHSTT, RHS.second);
+    return LHSID.isEquivalent(RHSID);
+  }
+
+  // For other targets the triples must be compatible and the arch must match.
+  return LHSTT.isCompatibleWith(RHSTT) && LHS.second == RHS.second;
+}
+
+bool object::areTargetsCompatible(const OffloadFile::TargetID &Provided,
+                                  const OffloadFile::TargetID &Requested) {
+  llvm::Triple ProvidedTT(Provided.first);
+  llvm::Triple RequestedTT(Requested.first);
+
+  // The AMDGPU target requires target-id aware checks (base processor plus
+  // xnack/sramecc features).
+  if (ProvidedTT.isAMDGPU()) {
+    AMDGPU::TargetID ProvidedID(ProvidedTT, Provided.second);
+    AMDGPU::TargetID RequestedID(RequestedTT, Requested.second);
+    return ProvidedID.providesFor(RequestedID);
   }
 
   // For other targets the triples must be compatible.
-  if (!LHSTT.isCompatibleWith(RHSTT))
+  if (!ProvidedTT.isCompatibleWith(RequestedTT))
     return false;
 
   // If the architecture is "generic" we assume it is always compatible.
-  if (LHS.second == "generic" || RHS.second == "generic")
+  if (Provided.second == "generic" || Requested.second == "generic")
     return true;
 
-  return LHS.second == RHS.second;
+  return Provided.second == Requested.second;
 }

--- a/llvm/lib/Object/OffloadBinary.cpp
+++ b/llvm/lib/Object/OffloadBinary.cpp
@@ -22,6 +22,7 @@
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/TargetParser/AMDGPUTargetParser.h"
 
 using namespace llvm;
 using namespace llvm::object;
@@ -453,31 +454,25 @@ bool object::areTargetsCompatible(const OffloadFile::TargetID &LHS,
   if (LHS == RHS)
     return false;
 
-  // The triples must match at all times.
-  if (LHS.first != RHS.first)
+  llvm::Triple LHSTT(LHS.first);
+  llvm::Triple RHSTT(RHS.first);
+
+  // The AMDGPU target requires target-id aware checks (base processor plus
+  // xnack/sramecc features), which also handle the generic wildcard and the
+  // legacy "amdgcn"/"amdgpu" triple spellings.
+  if (LHSTT.isAMDGPU()) {
+    AMDGPU::TargetID LTID(LHSTT, LHS.second);
+    AMDGPU::TargetID RTID(RHSTT, RHS.second);
+    return LTID.isCompatibleWith(RTID);
+  }
+
+  // For other targets the triples must be compatible.
+  if (!LHSTT.isCompatibleWith(RHSTT))
     return false;
 
-  // If the architecture is "all" we assume it is always compatible.
+  // If the architecture is "generic" we assume it is always compatible.
   if (LHS.second == "generic" || RHS.second == "generic")
     return true;
 
-  // Only The AMDGPU target requires additional checks.
-  llvm::Triple T(LHS.first);
-  if (!T.isAMDGPU())
-    return false;
-
-  // The base processor must always match.
-  if (LHS.second.split(":").first != RHS.second.split(":").first)
-    return false;
-
-  // Check combintions of on / off features that must match.
-  if (LHS.second.contains("xnack+") && RHS.second.contains("xnack-"))
-    return false;
-  if (LHS.second.contains("xnack-") && RHS.second.contains("xnack+"))
-    return false;
-  if (LHS.second.contains("sramecc-") && RHS.second.contains("sramecc+"))
-    return false;
-  if (LHS.second.contains("sramecc+") && RHS.second.contains("sramecc-"))
-    return false;
-  return true;
+  return LHS.second == RHS.second;
 }

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -1000,25 +1000,37 @@ bool TargetID::operator==(const TargetID &Other) const {
          TargetTripleString == Other.TargetTripleString;
 }
 
-static bool areFeatureSettingsCompatible(TargetIDSetting A, TargetIDSetting B) {
-  return A == TargetIDSetting::Any || B == TargetIDSetting::Any || A == B;
+static bool featureProvidesFor(TargetIDSetting Provided,
+                               TargetIDSetting Requested) {
+  return Provided == TargetIDSetting::Any ||
+         Provided == TargetIDSetting::Unsupported || Provided == Requested;
 }
 
-bool TargetID::isCompatibleWith(const TargetID &Other) const {
-  // The triples must be compatible.
-  if (!Triple(getTargetTripleString())
-           .isCompatibleWith(Triple(Other.getTargetTripleString())))
+bool TargetID::isEquivalent(const TargetID &Other) const {
+  // The processor and feature settings must match exactly
+  if (Arch != Other.Arch || XnackSetting != Other.XnackSetting ||
+      SramEccSetting != Other.SramEccSetting)
     return false;
 
-  // The processors must be compatible. A generic/major-family image (its
-  // subarch is the major-family subarch, or the GPU is unknown) acts as a
-  // wildcard that merges into a specific image group.
-  Triple::SubArchType SubA = getSubArch(Arch);
-  Triple::SubArchType SubB = getSubArch(Other.Arch);
-  if (!isSubArchCompatible(SubA, SubB))
+  return Triple(getTargetTripleString())
+      .isCompatibleWith(Triple(Other.getTargetTripleString()));
+}
+
+bool TargetID::providesFor(const TargetID &Other) const {
+  // A major-family/generic processor (e.g. amdgpu9) provides for a specific
+  // member of its family (e.g. gfx900), but not the reverse. Otherwise the
+  // processors must match.
+  if (Arch != Other.Arch && Arch != GK_NONE && Other.Arch != GK_NONE) {
+    Triple::SubArchType ThisSubArch = getSubArch(Arch);
+    if (ThisSubArch != getMajorSubArch(ThisSubArch) ||
+        ThisSubArch != getMajorSubArch(getSubArch(Other.Arch)))
+      return false;
+  }
+
+  if (!featureProvidesFor(XnackSetting, Other.XnackSetting) ||
+      !featureProvidesFor(SramEccSetting, Other.SramEccSetting))
     return false;
 
-  // The xnack/sramecc settings must not conflict.
-  return areFeatureSettingsCompatible(XnackSetting, Other.XnackSetting) &&
-         areFeatureSettingsCompatible(SramEccSetting, Other.SramEccSetting);
+  return Triple(getTargetTripleString())
+      .isCompatibleWith(Triple(Other.getTargetTripleString()));
 }

--- a/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
+++ b/llvm/lib/TargetParser/AMDGPUTargetParser.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/TargetParser/AMDGPUTargetParser.h"
-#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Twine.h"
@@ -917,6 +916,28 @@ getTargetIDSettingFromFeatureString(StringRef FeatureString) {
   llvm_unreachable("Malformed feature string");
 }
 
+// Derive the architecture from the processor name in \p TargetIDStr. "generic"
+// and the empty processor name act as a wildcard.
+static GPUKind getGPUKindFromTargetID(const Triple &TT, StringRef TargetIDStr) {
+  StringRef CPUName = TargetIDStr.split(':').first;
+  return (CPUName.empty() || CPUName == "generic")
+             ? getGPUKindFromSubArch(TT.getSubArch())
+             : parseArchAMDGCN(CPUName);
+}
+
+TargetID::TargetID(const Triple &TT, StringRef TargetIDStr)
+    : TargetID(getGPUKindFromTargetID(TT, TargetIDStr), TT,
+               TargetIDSetting::Unsupported, TargetIDSetting::Unsupported) {
+  // Default xnack/sramecc to the "Any" wildcard when the architecture supports
+  // them, then apply any explicit feature overrides from the target-id string.
+  unsigned ArchAttr = getArchAttrAMDGCN(Arch);
+  if (ArchAttr & FEATURE_XNACK)
+    XnackSetting = TargetIDSetting::Any;
+  if (ArchAttr & FEATURE_SRAMECC)
+    SramEccSetting = TargetIDSetting::Any;
+  setTargetIDFromTargetIDStream(TargetIDStr);
+}
+
 void TargetID::setTargetIDFromTargetIDStream(StringRef TargetID) {
   SmallVector<StringRef, 3> TargetIDSplit;
   TargetID.split(TargetIDSplit, ':');
@@ -942,40 +963,10 @@ TargetID::parseTargetIDString(StringRef TargetIDDirective) {
   if (!TT.isAMDGCN())
     return std::nullopt;
 
-  SmallVector<StringRef, 3> FeatureSplit;
-  Parts[4].split(FeatureSplit, ':');
-  if (FeatureSplit.empty())
-    return std::nullopt;
-
-  StringRef CPUName = FeatureSplit[0];
-
-  // Prefer the explicitly named processor so the parsed target id reflects it
-  // (e.g. for validation against the triple subarch). The processor field may
-  // be empty when the ISA is already encoded in the triple's subarch
-  // (e.g. "amdgpu12.50-amd-amdhsa-unknown-"), in which case derive the arch
-  // from the subarch.
-  GPUKind Arch = CPUName.empty() ? getGPUKindFromSubArch(TT.getSubArch())
-                                 : parseArchAMDGCN(CPUName);
-
-  unsigned ArchAttr = getArchAttrAMDGCN(Arch);
-
-  // Determine xnack/sramecc support based on the architecture attributes.
-  TargetIDSetting XnackSetting = (ArchAttr & FEATURE_XNACK)
-                                     ? TargetIDSetting::Any
-                                     : TargetIDSetting::Unsupported;
-  TargetIDSetting SramEccSetting = (ArchAttr & FEATURE_SRAMECC)
-                                       ? TargetIDSetting::Any
-                                       : TargetIDSetting::Unsupported;
-
-  for (StringRef FeatureString :
-       ArrayRef<StringRef>(FeatureSplit).drop_front(1)) {
-    if (FeatureString.starts_with("xnack"))
-      XnackSetting = getTargetIDSettingFromFeatureString(FeatureString);
-    else if (FeatureString.starts_with("sramecc"))
-      SramEccSetting = getTargetIDSettingFromFeatureString(FeatureString);
-  }
-
-  return TargetID(Arch, TT, XnackSetting, SramEccSetting);
+  // The processor+features field must be present, even if empty (the ISA can
+  // be encoded in the triple's subarch, e.g.
+  // "amdgpu12.50-amd-amdhsa-unknown-").
+  return TargetID(TT, Parts[4]);
 }
 
 void TargetID::print(raw_ostream &StreamRep) const {
@@ -1007,4 +998,27 @@ bool TargetID::operator==(const TargetID &Other) const {
   return Arch == Other.Arch && XnackSetting == Other.XnackSetting &&
          SramEccSetting == Other.SramEccSetting && IsAMDHSA == Other.IsAMDHSA &&
          TargetTripleString == Other.TargetTripleString;
+}
+
+static bool areFeatureSettingsCompatible(TargetIDSetting A, TargetIDSetting B) {
+  return A == TargetIDSetting::Any || B == TargetIDSetting::Any || A == B;
+}
+
+bool TargetID::isCompatibleWith(const TargetID &Other) const {
+  // The triples must be compatible.
+  if (!Triple(getTargetTripleString())
+           .isCompatibleWith(Triple(Other.getTargetTripleString())))
+    return false;
+
+  // The processors must be compatible. A generic/major-family image (its
+  // subarch is the major-family subarch, or the GPU is unknown) acts as a
+  // wildcard that merges into a specific image group.
+  Triple::SubArchType SubA = getSubArch(Arch);
+  Triple::SubArchType SubB = getSubArch(Other.Arch);
+  if (!isSubArchCompatible(SubA, SubB))
+    return false;
+
+  // The xnack/sramecc settings must not conflict.
+  return areFeatureSettingsCompatible(XnackSetting, Other.XnackSetting) &&
+         areFeatureSettingsCompatible(SramEccSetting, Other.SramEccSetting);
 }

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2828,52 +2828,170 @@ TEST(TargetParserTest, testAMDGPUgetIsaVersionFromSubArch) {
             (AMDGPU::IsaVersion{0, 0, 0}));
 }
 
-TEST(TargetParserTest, testAMDGPUTargetIDCompat) {
+TEST(TargetParserTest, testAMDGPUTargetIDProvidesFor) {
   using AMDGPU::TargetID;
   Triple AMDHSA("amdgcn-amd-amdhsa");
   Triple AMDHSACanon("amdgpu-amd-amdhsa");
 
-  auto Compatible = [](const TargetID &A, const TargetID &B) {
-    // Compatibility is symmetric for the cases exercised here.
-    EXPECT_EQ(A.isCompatibleWith(B), B.isCompatibleWith(A));
-    return A.isCompatibleWith(B);
-  };
+  // TargetID::providesFor is directional: it asks whether an image built
+  // for *this target can provide the device code for a request for the other
+  // target. An unspecified feature acts as a wildcard that can provide for a
+  // specific request, but not the other way around.
 
-  // Exact match is compatible.
+  // Exact match provides for itself.
   EXPECT_TRUE(
-      Compatible(TargetID(AMDHSA, "gfx90a"), TargetID(AMDHSA, "gfx90a")));
+      TargetID(AMDHSA, "gfx90a").providesFor(TargetID(AMDHSA, "gfx90a")));
 
-  // Different processors are not compatible.
+  // Different processors are never compatible.
   EXPECT_FALSE(
-      Compatible(TargetID(AMDHSA, "gfx90a"), TargetID(AMDHSA, "gfx908")));
+      TargetID(AMDHSA, "gfx90a").providesFor(TargetID(AMDHSA, "gfx908")));
 
-  // "generic" and empty act as a wildcard that merges into a specific image,
-  // in both directions.
+  // The pure "generic"/empty wildcard processor provides for any specific
+  // processor, in both directions (unknown arch acts as a wildcard).
   EXPECT_TRUE(
-      Compatible(TargetID(AMDHSA, "generic"), TargetID(AMDHSA, "gfx90a")));
-  EXPECT_TRUE(Compatible(TargetID(AMDHSA, ""), TargetID(AMDHSA, "gfx908")));
+      TargetID(AMDHSA, "generic").providesFor(TargetID(AMDHSA, "gfx90a")));
+  EXPECT_TRUE(
+      TargetID(AMDHSA, "gfx90a").providesFor(TargetID(AMDHSA, "generic")));
+  EXPECT_TRUE(TargetID(AMDHSA, "").providesFor(TargetID(AMDHSA, "gfx908")));
 
-  // Major-subarch wildcard triple merges into a specific processor.
+  // A major-family/generic processor provides for a specific member of its
+  // family (gfx900), but a specific processor does not provide for the generic
+  // family.
   Triple AMDHSAMajor9("amdgpu9-amd-amdhsa");
   EXPECT_TRUE(
-      Compatible(TargetID(AMDHSAMajor9, ""), TargetID(AMDHSA, "gfx900")));
-
-  // Explicit On vs Off features must not match.
-  EXPECT_FALSE(Compatible(TargetID(AMDHSA, "gfx90a:xnack+"),
-                          TargetID(AMDHSA, "gfx90a:xnack-")));
-  EXPECT_FALSE(Compatible(TargetID(AMDHSA, "gfx90a:sramecc+"),
-                          TargetID(AMDHSA, "gfx90a:sramecc-")));
-
-  // "Any"/"Unsupported" settings act as wildcards: a plain gfx90a (xnack "Any")
-  // merges with an explicit xnack+ or xnack- request.
-  EXPECT_TRUE(Compatible(TargetID(AMDHSA, "gfx90a"),
-                         TargetID(AMDHSA, "gfx90a:xnack+")));
-  EXPECT_TRUE(Compatible(TargetID(AMDHSA, "gfx90a"),
-                         TargetID(AMDHSA, "gfx90a:xnack-")));
-
-  // The legacy "amdgcn" and canonical "amdgpu" triple spellings merge.
+      TargetID(AMDHSAMajor9, "").providesFor(TargetID(AMDHSA, "gfx900")));
   EXPECT_TRUE(
-      Compatible(TargetID(AMDHSA, "gfx90a"), TargetID(AMDHSACanon, "gfx90a")));
+      TargetID(AMDHSAMajor9, "").providesFor(TargetID(AMDHSA, "gfx902")));
+
+  EXPECT_TRUE(TargetID(AMDHSAMajor9, "").providesFor(TargetID(AMDHSA, "")));
+  EXPECT_TRUE(
+      TargetID(AMDHSAMajor9, "").providesFor(TargetID(AMDHSA, "gfx9-generic")));
+  EXPECT_TRUE(
+      TargetID(AMDHSAMajor9, "").providesFor(TargetID(AMDHSA, "generic")));
+  EXPECT_TRUE(TargetID(AMDHSAMajor9, "gfx9-generic")
+                  .providesFor(TargetID(AMDHSA, "gfx9-generic")));
+
+  EXPECT_FALSE(
+      TargetID(AMDHSA, "gfx900").providesFor(TargetID(AMDHSAMajor9, "")));
+  // A specific processor and a member of a different major family do not
+  // provide for each other.
+  EXPECT_FALSE(
+      TargetID(AMDHSAMajor9, "").providesFor(TargetID(AMDHSA, "gfx1030")));
+
+  // xnack: an unspecified (wildcard) image provides for an explicit request,
+  // but an explicit image does not provide for a request that lacks it, and
+  // explicit On vs Off never match.
+  EXPECT_TRUE(TargetID(AMDHSA, "gfx90a")
+                  .providesFor(TargetID(AMDHSA, "gfx90a:xnack+")));
+  EXPECT_TRUE(TargetID(AMDHSA, "gfx90a")
+                  .providesFor(TargetID(AMDHSA, "gfx90a:xnack-")));
+  EXPECT_FALSE(TargetID(AMDHSA, "gfx90a:xnack+")
+                   .providesFor(TargetID(AMDHSA, "gfx90a")));
+  EXPECT_FALSE(TargetID(AMDHSA, "gfx90a:xnack-")
+                   .providesFor(TargetID(AMDHSA, "gfx90a")));
+  EXPECT_TRUE(TargetID(AMDHSA, "gfx90a:xnack+")
+                  .providesFor(TargetID(AMDHSA, "gfx90a:xnack+")));
+  EXPECT_FALSE(TargetID(AMDHSA, "gfx90a:xnack+")
+                   .providesFor(TargetID(AMDHSA, "gfx90a:xnack-")));
+  EXPECT_FALSE(TargetID(AMDHSA, "gfx90a:xnack-")
+                   .providesFor(TargetID(AMDHSA, "gfx90a:xnack+")));
+
+  // sramecc behaves the same way as xnack.
+  EXPECT_TRUE(TargetID(AMDHSA, "gfx90a")
+                  .providesFor(TargetID(AMDHSA, "gfx90a:sramecc+")));
+  EXPECT_TRUE(TargetID(AMDHSA, "gfx90a")
+                  .providesFor(TargetID(AMDHSA, "gfx90a:sramecc-")));
+  EXPECT_FALSE(TargetID(AMDHSA, "gfx90a:sramecc+")
+                   .providesFor(TargetID(AMDHSA, "gfx90a")));
+  EXPECT_FALSE(TargetID(AMDHSA, "gfx90a:sramecc-")
+                   .providesFor(TargetID(AMDHSA, "gfx90a")));
+  EXPECT_FALSE(TargetID(AMDHSA, "gfx90a:sramecc+")
+                   .providesFor(TargetID(AMDHSA, "gfx90a:sramecc-")));
+
+  // Both feature modifiers together: a wildcard provides for a fully-specified
+  // request, but a partially-specified image only provides when its explicit
+  // features match.
+  EXPECT_TRUE(TargetID(AMDHSA, "gfx90a")
+                  .providesFor(TargetID(AMDHSA, "gfx90a:sramecc+:xnack+")));
+  EXPECT_TRUE(TargetID(AMDHSA, "gfx90a:sramecc+")
+                  .providesFor(TargetID(AMDHSA, "gfx90a:sramecc+:xnack+")));
+  EXPECT_FALSE(TargetID(AMDHSA, "gfx90a:sramecc-")
+                   .providesFor(TargetID(AMDHSA, "gfx90a:sramecc+:xnack+")));
+
+  // The legacy "amdgcn" and canonical "amdgpu" triple spellings are unified.
+  EXPECT_TRUE(
+      TargetID(AMDHSA, "gfx90a").providesFor(TargetID(AMDHSACanon, "gfx90a")));
+  EXPECT_TRUE(
+      TargetID(AMDHSACanon, "gfx90a").providesFor(TargetID(AMDHSA, "gfx90a")));
+}
+
+TEST(TargetParserTest, testAMDGPUTargetIDEquivalent) {
+  using AMDGPU::TargetID;
+  Triple AMDHSA("amdgcn-amd-amdhsa");
+  Triple AMDHSACanon("amdgpu-amd-amdhsa");
+
+  // TargetID::isEquivalent is a symmetric semantic equality: same processor and
+  // features, looking through triple spelling differences.
+  auto Equivalent = [](const TargetID &A, const TargetID &B) {
+    EXPECT_EQ(A.isEquivalent(B), B.isEquivalent(A));
+    return A.isEquivalent(B);
+  };
+
+  // Same target is equivalent to itself.
+  EXPECT_TRUE(
+      Equivalent(TargetID(AMDHSA, "gfx90a"), TargetID(AMDHSA, "gfx90a")));
+
+  // Different processors are not equivalent.
+  EXPECT_FALSE(
+      Equivalent(TargetID(AMDHSA, "gfx90a"), TargetID(AMDHSA, "gfx908")));
+
+  // A specific processor and a member of its generic family are distinct and
+  // not equivalent (this is the over-merge that produced duplicate symbols).
+  EXPECT_FALSE(
+      Equivalent(TargetID(AMDHSA, "gfx900"), TargetID(AMDHSA, "gfx9-generic")));
+
+  // Legacy "amdgcn" and canonical "amdgpu" spellings are equivalent.
+  EXPECT_TRUE(
+      Equivalent(TargetID(AMDHSA, "gfx90a"), TargetID(AMDHSACanon, "gfx90a")));
+
+  // The same processor spelled via the triple subarch (with no processor name)
+  // and via the processor name (with a major-family subarch triple) are
+  // equivalent, e.g. amdgpu9-amd-amdhsa + "gfx900" and amdgpu9.00-amd-amdhsa.
+  Triple AMDHSAMajor9("amdgpu9-amd-amdhsa");
+  Triple AMDHSASub900("amdgpu9.00-amd-amdhsa");
+  EXPECT_TRUE(
+      Equivalent(TargetID(AMDHSAMajor9, "gfx900"), TargetID(AMDHSASub900, "")));
+  EXPECT_TRUE(
+      Equivalent(TargetID(AMDHSASub900, ""), TargetID(AMDHSA, "gfx900")));
+  EXPECT_TRUE(Equivalent(TargetID(AMDHSAMajor9, "gfx9-generic"),
+                         TargetID(AMDHSAMajor9, "")));
+
+  // The same processor with different feature settings is not equivalent.
+  EXPECT_FALSE(Equivalent(TargetID(AMDHSA, "gfx90a"),
+                          TargetID(AMDHSA, "gfx90a:xnack+")));
+  EXPECT_FALSE(Equivalent(TargetID(AMDHSA, "gfx90a:xnack+"),
+                          TargetID(AMDHSA, "gfx90a:xnack-")));
+  EXPECT_FALSE(Equivalent(TargetID(AMDHSA, "gfx90a:sramecc+"),
+                          TargetID(AMDHSA, "gfx90a:sramecc-")));
+  EXPECT_TRUE(Equivalent(TargetID(AMDHSA, "gfx90a:xnack+"),
+                         TargetID(AMDHSA, "gfx90a:xnack+")));
+
+  // Target IDs that set both xnack and sramecc are equivalent only when both
+  // settings match; a difference in either feature makes them distinct.
+  EXPECT_TRUE(Equivalent(TargetID(AMDHSA, "gfx90a:sramecc+:xnack+"),
+                         TargetID(AMDHSA, "gfx90a:sramecc+:xnack+")));
+  EXPECT_FALSE(Equivalent(TargetID(AMDHSA, "gfx90a:sramecc+:xnack+"),
+                          TargetID(AMDHSA, "gfx90a:sramecc+:xnack-")));
+  EXPECT_FALSE(Equivalent(TargetID(AMDHSA, "gfx90a:sramecc+:xnack+"),
+                          TargetID(AMDHSA, "gfx90a:sramecc-:xnack+")));
+  EXPECT_FALSE(Equivalent(TargetID(AMDHSA, "gfx90a:sramecc+:xnack+"),
+                          TargetID(AMDHSA, "gfx90a:sramecc-:xnack-")));
+  // A fully-specified target ID is not equivalent to one that leaves a feature
+  // unspecified, even if the specified features agree.
+  EXPECT_FALSE(Equivalent(TargetID(AMDHSA, "gfx90a:sramecc+:xnack+"),
+                          TargetID(AMDHSA, "gfx90a:sramecc+")));
+  EXPECT_FALSE(Equivalent(TargetID(AMDHSA, "gfx90a:sramecc+:xnack+"),
+                          TargetID(AMDHSA, "gfx90a")));
 }
 
 } // namespace

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2828,4 +2828,52 @@ TEST(TargetParserTest, testAMDGPUgetIsaVersionFromSubArch) {
             (AMDGPU::IsaVersion{0, 0, 0}));
 }
 
+TEST(TargetParserTest, testAMDGPUTargetIDCompat) {
+  using AMDGPU::TargetID;
+  Triple AMDHSA("amdgcn-amd-amdhsa");
+  Triple AMDHSACanon("amdgpu-amd-amdhsa");
+
+  auto Compatible = [](const TargetID &A, const TargetID &B) {
+    // Compatibility is symmetric for the cases exercised here.
+    EXPECT_EQ(A.isCompatibleWith(B), B.isCompatibleWith(A));
+    return A.isCompatibleWith(B);
+  };
+
+  // Exact match is compatible.
+  EXPECT_TRUE(
+      Compatible(TargetID(AMDHSA, "gfx90a"), TargetID(AMDHSA, "gfx90a")));
+
+  // Different processors are not compatible.
+  EXPECT_FALSE(
+      Compatible(TargetID(AMDHSA, "gfx90a"), TargetID(AMDHSA, "gfx908")));
+
+  // "generic" and empty act as a wildcard that merges into a specific image,
+  // in both directions.
+  EXPECT_TRUE(
+      Compatible(TargetID(AMDHSA, "generic"), TargetID(AMDHSA, "gfx90a")));
+  EXPECT_TRUE(Compatible(TargetID(AMDHSA, ""), TargetID(AMDHSA, "gfx908")));
+
+  // Major-subarch wildcard triple merges into a specific processor.
+  Triple AMDHSAMajor9("amdgpu9-amd-amdhsa");
+  EXPECT_TRUE(
+      Compatible(TargetID(AMDHSAMajor9, ""), TargetID(AMDHSA, "gfx900")));
+
+  // Explicit On vs Off features must not match.
+  EXPECT_FALSE(Compatible(TargetID(AMDHSA, "gfx90a:xnack+"),
+                          TargetID(AMDHSA, "gfx90a:xnack-")));
+  EXPECT_FALSE(Compatible(TargetID(AMDHSA, "gfx90a:sramecc+"),
+                          TargetID(AMDHSA, "gfx90a:sramecc-")));
+
+  // "Any"/"Unsupported" settings act as wildcards: a plain gfx90a (xnack "Any")
+  // merges with an explicit xnack+ or xnack- request.
+  EXPECT_TRUE(Compatible(TargetID(AMDHSA, "gfx90a"),
+                         TargetID(AMDHSA, "gfx90a:xnack+")));
+  EXPECT_TRUE(Compatible(TargetID(AMDHSA, "gfx90a"),
+                         TargetID(AMDHSA, "gfx90a:xnack-")));
+
+  // The legacy "amdgcn" and canonical "amdgpu" triple spellings merge.
+  EXPECT_TRUE(
+      Compatible(TargetID(AMDHSA, "gfx90a"), TargetID(AMDHSACanon, "gfx90a")));
+}
+
 } // namespace


### PR DESCRIPTION
This reverts commit aa5960600ac38fcd923e69777bad1293f56658d7.

Before the first attempt, clang-linker-wrapper inconsistently
applied linker reasoning to the target ID feature modifiers, but
not the base processor. e.g., gfx90a was considered mergable
with gfx90a:xnack+.

The first attempt at this changed introduced and used
TargetID::isCompatibleWith, which applied full linking
compatibility logic. This broke tests which combined
generic and covered non-generic targets in the build (e.g.,
gfx9-generic and gfx900). The archives would both be treated
as compatible, resulting in multiple definition errors.

Split the TargetID compatibility checks into 2 different kinds:
1 for exact target match used for archives, and 1 for logical
compatibility usable for objects. For archive purposes, this stops
treating xnack-any as the same target with an xnack specifier which
is a behavior change. It just so happens that clang would error if you
tried to compile xnack-any and xnack+/- in the same invocation, so this
behavior was only observable when directly using the binary tools.

Co-authored-by: Claude (Opus 4.8)