### PR TITLE
[CodeGen][ARM64EC] Copy first four arguments to FP registers in vararg exit thunks

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -10556,6 +10556,27 @@ AArch64TargetLowering::LowerCall(CallLoweringInfo &CLI,
         const TargetOptions &Options = DAG.getTarget().Options;
         if (Options.EmitCallSiteInfo)
           CSInfo.ArgRegPairs.emplace_back(VA.getLocReg(), i);
+        if (IsArm64ECVarArgExitThunk) {
+          Register FPReg;
+          switch (VA.getLocReg()) {
+          case AArch64::X0:
+            FPReg = AArch64::D0;
+            break;
+          case AArch64::X1:
+            FPReg = AArch64::D1;
+            break;
+          case AArch64::X2:
+            FPReg = AArch64::D2;
+            break;
+          case AArch64::X3:
+            FPReg = AArch64::D3;
+            break;
+          }
+          if (FPReg) {
+            RegsToPass.emplace_back(FPReg, Arg);
+            RegsUsed.insert(FPReg);
+          }
+        }
       }
     } else {
       assert(VA.isMemLoc());

--- a/llvm/test/CodeGen/AArch64/arm64ec-exit-thunks.ll
+++ b/llvm/test/CodeGen/AArch64/arm64ec-exit-thunks.ll
@@ -313,7 +313,11 @@ declare void @has_varargs(...) nounwind;
 ; CHECK-NEXT:     mov     x2, x5
 ; CHECK-NEXT:     bl      "#memcpy"
 ; CHECK-NEXT:     sub     sp, sp, #32
+; CHECK-NEXT:     fmov    d0, x22
+; CHECK-NEXT:     fmov    d1, x21
 ; CHECK-NEXT:     mov     x9, x26
+; CHECK-NEXT:     fmov    d2, x20
+; CHECK-NEXT:     fmov    d3, x19
 ; CHECK-NEXT:     mov     x0, x22
 ; CHECK-NEXT:     mov     x1, x21
 ; CHECK-NEXT:     mov     x2, x20
@@ -391,7 +395,11 @@ declare [2 x i8] @has_varargs_small_struct(...) nounwind;
 ; CHECK-NEXT:     mov     x2, x5
 ; CHECK-NEXT:     bl      "#memcpy"
 ; CHECK-NEXT:     sub     sp, sp, #32
+; CHECK-NEXT:     fmov    d0, x22
+; CHECK-NEXT:     fmov    d1, x21
 ; CHECK-NEXT:     mov     x9, x26
+; CHECK-NEXT:     fmov    d2, x20
+; CHECK-NEXT:     fmov    d3, x19
 ; CHECK-NEXT:     mov     x0, x22
 ; CHECK-NEXT:     mov     x1, x21
 ; CHECK-NEXT:     mov     x2, x20
@@ -566,7 +574,11 @@ declare void @has_varargs_sret(ptr sret([100 x i8]), ...) nounwind;
 ; CHECK-NEXT:     mov     x2, x4
 ; CHECK-NEXT:     bl      "#memcpy"
 ; CHECK-NEXT:     sub     sp, sp, #32
+; CHECK-NEXT:     fmov    d0, x22
+; CHECK-NEXT:     fmov    d1, x21
 ; CHECK-NEXT:     mov     x9, x26
+; CHECK-NEXT:     fmov    d2, x20
+; CHECK-NEXT:     fmov    d3, x19
 ; CHECK-NEXT:     mov     x0, x22
 ; CHECK-NEXT:     mov     x1, x21
 ; CHECK-NEXT:     mov     x2, x20


### PR DESCRIPTION
ARM64EC vararg functions receive all types of the first four arguments in x0-x3. Because x86_64 expects floating-point arguments in FP registers, always copy x0-x3 to d0-d3 in the exit thunks, matching MSVC's behavior.