### PR TITLE
[InstCombine] Canonicalize ashr shift amount to BitWidth-1 based on demanded bits

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -908,6 +908,16 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
     if (match(I->getOperand(1), m_APInt(SA))) {
       uint32_t ShiftAmt = SA->getLimitedValue(BitWidth-1);
 
+      // If the shifted value has enough known sign bits to cover every demanded
+      // bit, canonicalize the shift amount to BitWidth - 1.
+      if (ShiftAmt > 0 && ShiftAmt != BitWidth - 1 &&
+          SignBits + ShiftAmt >= NumHiDemandedBits) {
+        Instruction *NewVal = BinaryOperator::CreateAShr(
+            I->getOperand(0), ConstantInt::get(I->getType(), BitWidth - 1));
+        NewVal->takeName(I);
+        return InsertNewInstWith(NewVal, I->getIterator());
+      }
+
       // Signed shift right.
       APInt DemandedMaskIn(DemandedMask.shl(ShiftAmt));
       // If any of the bits being shifted in are demanded, then we should set

--- a/llvm/test/Transforms/InstCombine/abs-1.ll
+++ b/llvm/test/Transforms/InstCombine/abs-1.ll
@@ -992,9 +992,7 @@ define <2 x i32> @abs_unary_shuffle_ops(<2 x i32> %x) {
 
 define i32 @test_abs_branchless_ashr30(i32 %0) {
 ; CHECK-LABEL: @test_abs_branchless_ashr30(
-; CHECK-NEXT:    [[TMP4:%.*]] = ashr i32 [[TMP0:%.*]], 30
-; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP4]], 1
-; CHECK-NEXT:    [[TMP2:%.*]] = mul i32 [[TMP3]], [[TMP0]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.abs.i32(i32 [[TMP0:%.*]], i1 false)
 ; CHECK-NEXT:    ret i32 [[TMP2]]
 ;
   %2 = ashr i32 %0, 30

--- a/llvm/test/Transforms/InstCombine/abs-1.ll
+++ b/llvm/test/Transforms/InstCombine/abs-1.ll
@@ -989,3 +989,16 @@ define <2 x i32> @abs_unary_shuffle_ops(<2 x i32> %x) {
   %r = call <2 x i32> @llvm.abs(<2 x i32> %a, i1 false)
   ret <2 x i32> %r
 }
+
+define i32 @test_abs_branchless_ashr30(i32 %0) {
+; CHECK-LABEL: @test_abs_branchless_ashr30(
+; CHECK-NEXT:    [[TMP4:%.*]] = ashr i32 [[TMP0:%.*]], 30
+; CHECK-NEXT:    [[TMP3:%.*]] = or i32 [[TMP4]], 1
+; CHECK-NEXT:    [[TMP2:%.*]] = mul i32 [[TMP3]], [[TMP0]]
+; CHECK-NEXT:    ret i32 [[TMP2]]
+;
+  %2 = ashr i32 %0, 30
+  %3 = or i32 %2, 1
+  %4 = mul i32 %3, %0
+  ret i32 %4
+}

--- a/llvm/test/Transforms/InstCombine/ashr-or-mul-abs.ll
+++ b/llvm/test/Transforms/InstCombine/ashr-or-mul-abs.ll
@@ -3,6 +3,8 @@
 
 ; ((ashr X, 31) | 1 ) * X --> abs(X)
 ; X * ((ashr X, 31) | 1 ) --> abs(X)
+; ((ashr X, 30) | 1 ) * X --> abs(X)
+; X * ((ashr X, 30) | 1 ) --> abs(X)
 
 define i32 @ashr_or_mul_to_abs(i32 %X) {
 ; CHECK-LABEL: @ashr_or_mul_to_abs(
@@ -39,6 +41,16 @@ define i32 @ashr_or_mul_to_abs3(i32 %PX) {
   ret i32 %i2
 }
 
+define i32 @ashr_or_mul_to_abs4(i32 %X) {
+; CHECK-LABEL: @ashr_or_mul_to_abs4(
+; CHECK-NEXT:    [[I2:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 true)
+; CHECK-NEXT:    ret i32 [[I2]]
+;
+  %i = ashr i32 %X, 30
+  %i1 = or i32 %i, 1
+  %i2 = mul nsw i32 %i1, %X
+  ret i32 %i2
+}
 
 define <4 x i32> @ashr_or_mul_to_abs_vec(<4 x i32> %X) {
 ; CHECK-LABEL: @ashr_or_mul_to_abs_vec(
@@ -77,12 +89,12 @@ define <4 x i32> @ashr_or_mul_to_abs_vec3_poison(<4 x i32> %X) {
 
 define i32 @ashr_or_mul_to_abs_neg(i32 %X) {
 ; CHECK-LABEL: @ashr_or_mul_to_abs_neg(
-; CHECK-NEXT:    [[I:%.*]] = ashr i32 [[X:%.*]], 30
+; CHECK-NEXT:    [[I:%.*]] = ashr i32 [[X:%.*]], 29
 ; CHECK-NEXT:    [[I1:%.*]] = or i32 [[I]], 1
 ; CHECK-NEXT:    [[I2:%.*]] = mul nsw i32 [[I1]], [[X]]
 ; CHECK-NEXT:    ret i32 [[I2]]
 ;
-  %i = ashr i32 %X, 30
+  %i = ashr i32 %X, 29
   %i1 = or i32 %i, 1
   %i2 = mul nsw i32 %i1, %X
   ret i32 %i2

--- a/llvm/test/Transforms/InstCombine/shift-logic.ll
+++ b/llvm/test/Transforms/InstCombine/shift-logic.ll
@@ -175,7 +175,7 @@ define i32 @ashr_xor(i32 %x, i32 %py) {
 ; CHECK-LABEL: @ashr_xor(
 ; CHECK-NEXT:    [[Y:%.*]] = srem i32 [[PY:%.*]], 42
 ; CHECK-NEXT:    [[TMP1:%.*]] = ashr i32 [[X:%.*]], 12
-; CHECK-NEXT:    [[TMP2:%.*]] = ashr i32 [[Y]], 7
+; CHECK-NEXT:    [[TMP2:%.*]] = ashr i32 [[Y]], 31
 ; CHECK-NEXT:    [[SH1:%.*]] = xor i32 [[TMP1]], [[TMP2]]
 ; CHECK-NEXT:    ret i32 [[SH1]]
 ;
@@ -201,7 +201,7 @@ define i32 @shr_mismatch_xor(i32 %x, i32 %y) {
 
 define i32 @ashr_overshift_xor(i32 %x, i32 %y) {
 ; CHECK-LABEL: @ashr_overshift_xor(
-; CHECK-NEXT:    [[SH0:%.*]] = ashr i32 [[X:%.*]], 15
+; CHECK-NEXT:    [[SH0:%.*]] = ashr i32 [[X:%.*]], 31
 ; CHECK-NEXT:    [[R:%.*]] = xor i32 [[Y:%.*]], [[SH0]]
 ; CHECK-NEXT:    [[SH1:%.*]] = ashr i32 [[R]], 17
 ; CHECK-NEXT:    ret i32 [[SH1]]
@@ -246,10 +246,10 @@ define i32 @lshr_or_extra_use(i32 %x, i32 %y, ptr %p) {
 
 define i32 @PR44028(i32 %x) {
 ; CHECK-LABEL: @PR44028(
-; CHECK-NEXT:    [[SH1:%.*]] = ashr exact i32 [[X:%.*]], 16
+; CHECK-NEXT:    [[SH1:%.*]] = ashr i32 [[X:%.*]], 31
 ; CHECK-NEXT:    [[SH2:%.*]] = shl i32 ptrtoint (ptr @g to i32), 16
 ; CHECK-NEXT:    [[T0:%.*]] = xor i32 [[SH1]], [[SH2]]
-; CHECK-NEXT:    [[T27:%.*]] = ashr exact i32 [[T0]], 16
+; CHECK-NEXT:    [[T27:%.*]] = ashr i32 [[T0]], 16
 ; CHECK-NEXT:    ret i32 [[T27]]
 ;
   %sh1 = ashr exact i32 %x, 16

--- a/llvm/test/Transforms/InstCombine/shift.ll
+++ b/llvm/test/Transforms/InstCombine/shift.ll
@@ -2020,8 +2020,8 @@ define i18 @lshr_sdiv_neg(i18 %x) {
 
 define i8 @ashr_sdiv_not_full_shift(i8 %x) {
 ; CHECK-LABEL: @ashr_sdiv_not_full_shift(
-; CHECK-NEXT:    [[D:%.*]] = sdiv i8 [[X:%.*]], 42
-; CHECK-NEXT:    [[R:%.*]] = ashr i8 [[D]], 6
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp slt i8 [[X:%.*]], -41
+; CHECK-NEXT:    [[R:%.*]] = sext i1 [[TMP1]] to i8
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %d = sdiv i8 %x, 42


### PR DESCRIPTION
This patch enhances SimplifyDemandedUseBits for AShr to canonicalize the shift amount to BitWidth - 1 if all demanded bits fall within the sign-extended region of the shift.