### PR TITLE
[ThinLTO][test] Write unused test output to /dev/null

### DIFF
--- a/llvm/test/Assembler/thinlto-bad-summary-5.ll
+++ b/llvm/test/Assembler/thinlto-bad-summary-5.ll
@@ -1,7 +1,7 @@
 ; Test that we get an appropriate error when parsing a summary that does
 ; not have value info associated with a function definition.
 
-; RUN: not llvm-as %s 2>&1 | FileCheck %s
+; RUN: not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
 
 ; CHECK: LLVM ERROR: expected function definition foo to have an associated value info.
 


### PR DESCRIPTION
The test added in #208948 fails when run in non-writeable test environment because it tries to write to the current directory. Write to /dev/null to avoid this.