### PR TITLE
[Clang] Restrict CWG1504 devirtualization to pointer arithmetic on record types

### DIFF
--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -2602,6 +2602,57 @@ CXXMethodDecl *CXXMethodDecl::getDevirtualizedMethod(const Expr *Base,
     }
   }
 
+  // By CWG1504 / C++11 [expr.add]p6, accessing an object through non-zero
+  // pointer arithmetic (including array subscripting) on a base pointer into
+  // an array of derived objects is undefined behavior when the element type and
+  // pointee type are not similar. This means we can devirtualize calls on
+  // objects accessed through non-zero pointer arithmetic, including array
+  // subscripting, since the dynamic type must match the static type.
+  const Expr *Inner = Base->IgnoreParens();
+
+  // 1. Handle p[N].f() (dot syntax with array subscript).
+  // The expression must be an lvalue of record type.
+  if (const auto *ASE = dyn_cast<ArraySubscriptExpr>(Inner)) {
+    Expr::EvalResult Result;
+    if (ASE->getType()->isRecordType() &&
+        ASE->getIdx()->EvaluateAsInt(Result, getASTContext()) &&
+        !Result.Val.getInt().isZero())
+      return DevirtualizedMethod;
+  }
+
+  auto TryDevirtualizePointerArithmetic =
+      [&](const Expr *PtrExpr) -> CXXMethodDecl * {
+    if (const auto *BO = dyn_cast<BinaryOperator>(PtrExpr)) {
+      if (BO->getOpcode() == BO_Add || BO->getOpcode() == BO_Sub) {
+        if (const auto *PT = BO->getType()->getAs<PointerType>()) {
+          if (PT->getPointeeType()->isRecordType()) {
+            bool PointerOnLHS = BO->getLHS()->getType()->isPointerType();
+            const Expr *IdxExpr = PointerOnLHS ? BO->getRHS() : BO->getLHS();
+            Expr::EvalResult Result;
+            if (IdxExpr->EvaluateAsInt(Result, getASTContext()) &&
+                !Result.Val.getInt().isZero())
+              return DevirtualizedMethod;
+          }
+        }
+      }
+    }
+    return nullptr;
+  };
+
+  // 2. Handle (p + N)->f() (arrow syntax with pointer arithmetic).
+  if (CXXMethodDecl *MD = TryDevirtualizePointerArithmetic(Inner))
+    return MD;
+
+  // 3. Handle (*(p + N)).f() (pointer arithmetic with deref).
+  // Treat (*ptr).f() similarly to ptr->f() by examining the operand of a
+  // single dereference.
+  if (const auto *UO = dyn_cast<UnaryOperator>(Inner)) {
+    if (UO->getOpcode() == UO_Deref)
+      if (CXXMethodDecl *MD = TryDevirtualizePointerArithmetic(
+              UO->getSubExpr()->IgnoreParens()))
+        return MD;
+  }
+
   // We can't devirtualize the call.
   return nullptr;
 }

--- a/clang/test/CXX/drs/cwg15xx.cpp
+++ b/clang/test/CXX/drs/cwg15xx.cpp
@@ -11,6 +11,24 @@
 // cxx98-error@-1 {{variadic macros are a C99 feature}}
 #endif
 
+namespace cwg1504 { // cwg1504: 3.1
+#if __cplusplus >= 201103L
+  struct Base { int x; };
+  struct Derived : Base { int y; };
+  constexpr Derived arr[2] = {};
+
+  // Pointer arithmetic on a base pointer into a derived array is UB,
+  // and the constexpr evaluator must diagnose it.
+  constexpr int test(int n) {
+    return ((const Base*)arr)[n].x; // #cwg1504-x
+  }
+  constexpr int bad = test(1);
+  // since-cxx11-error@-1 {{constexpr variable 'bad' must be initialized by a constant expression}}
+  //   since-cxx11-note@#cwg1504-x {{cannot access field of pointer past the end of object}}
+  //   since-cxx11-note@-3 {{in call to 'test(1)'}}
+#endif
+} // namespace cwg1504
+
 namespace cwg1512 { // cwg1512: 4
   void f(char *p) {
     if (p > 0) {}

--- a/clang/test/CodeGenCXX/devirtualize-virtual-function-calls.cpp
+++ b/clang/test/CodeGenCXX/devirtualize-virtual-function-calls.cpp
@@ -92,10 +92,48 @@ void fd(D d, XD xd, D *p) {
   // CHECK: call void %
   p[0].f();
 
-  // FIXME: We can devirtualize this, by C++1z [expr.add]/6 (if the array
+  // We can devirtualize this, by CWG1504 / [expr.add]/6 (if the array
   // element type and the pointee type are not similar, behavior is undefined).
-  // CHECK: call void %
+  // CHECK: call void @_ZN1A1fEv
   p[1].f();
+
+  // Negative indices are also UB for the same reason.
+  // CHECK: call void @_ZN1A1fEv
+  p[-1].f();
+
+  // Pointer arithmetic with arrow syntax: (p + N)->f()
+  // CHECK: call void @_ZN1A1fEv
+  (p + 1)->f();
+
+  // Pointer subtraction with arrow syntax: (p - N)->f()
+  // CHECK: call void @_ZN1A1fEv
+  (p - 1)->f();
+
+  // Can't devirtualize with non-constant index; we can't prove N != 0.
+  int n = 1;
+  // CHECK: call void %
+  p[n].f();
+
+  // Zero through expression: p[1-1] evaluates to 0, can't devirtualize.
+  // CHECK: call void %
+  p[1-1].f();
+
+  // (p + 0)->f() also can't be devirtualized (same as *p).
+  // CHECK: call void %
+  (p + 0)->f();
+
+  // 1 + p is legal pointer arithmetic too.
+  // CHECK: call void @_ZN1A1fEv
+  (1 + p)->f();
+
+  // Constant variables are evaluated.
+  const int N = 1;
+  // CHECK: call void @_ZN1A1fEv
+  p[N].f();
+
+  // Pointer arithmetic with deref: *(p + 1)
+  // CHECK: call void @_ZN1A1fEv
+  (*(p + 1)).f();
 }
 
 struct B {
@@ -193,5 +231,21 @@ namespace test5 {
     // CHECK-NOT: call {{.*}} @_ZN5test51Q1fEv
     // CHECK: call void %
     q.f();
+  }
+}
+
+namespace test6 {
+  struct Thing {
+    virtual ~Thing();
+    virtual void f();
+  };
+
+  // CHECK-LABEL: define {{.*}} @_ZN5test63fooEPPNS_5ThingE
+  void foo(Thing **instances) {
+    // CHECK: call void %
+    instances[1]->f();
+    
+    // CHECK: call void %
+    delete instances[1];
   }
 }

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -10309,7 +10309,7 @@
     <td>[<a href="https://wg21.link/expr.add">expr.add</a>]</td>
     <td>CD3</td>
     <td>Pointer arithmetic after derived-base conversion</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.1</td>
   </tr>
   <tr id="1505">
     <td><a href="https://cplusplus.github.io/CWG/issues/1505.html">1505</a></td>


### PR DESCRIPTION
Fixes a regression introduced in PR #207540 where virtual calls (including destructor calls in delete expressions) were incorrectly devirtualized on pointers obtained from pointer arithmetic on pointers (e.g. array-of-pointers subscripts).