### PR TITLE
[lldb-dap][test] Fix stackTrace test in symlink environment

### DIFF
--- a/lldb/test/API/tools/lldb-dap/stackTrace/TestDAP_stackTrace.py
+++ b/lldb/test/API/tools/lldb-dap/stackTrace/TestDAP_stackTrace.py
@@ -74,7 +74,7 @@ class TestDAP_stackTrace(DAPTestCaseBase):
         session = self.build_and_create_session()
         source_file = self.getSourcePath("main.c")
         self.recourse_source = _RecurseSource(
-            path=self.getSourcePath(source_file),
+            path=source_file,
             end_line=line_number(source_file, "recurse end"),
             call_line=line_number(source_file, "recurse call"),
             invocation_line=line_number(source_file, "recurse invocation"),

--- a/lldb/test/API/tools/lldb-dap/stackTrace/TestDAP_stackTrace.py
+++ b/lldb/test/API/tools/lldb-dap/stackTrace/TestDAP_stackTrace.py
@@ -74,7 +74,7 @@ class TestDAP_stackTrace(DAPTestCaseBase):
         session = self.build_and_create_session()
         source_file = self.getSourcePath("main.c")
         self.recourse_source = _RecurseSource(
-            path=os.path.realpath(source_file),
+            path=self.getSourcePath(source_file),
             end_line=line_number(source_file, "recurse end"),
             call_line=line_number(source_file, "recurse call"),
             invocation_line=line_number(source_file, "recurse invocation"),


### PR DESCRIPTION
This test (edited in #209236) fails when run in an environment where source files are symlinks. Using `realpath` breaks that, as we use the path in assertions later. The var is already constructed as `source_file = self.getSourcePath("main.c")` which should be sufficient for `_RecurseSource()` to work.