### PR TITLE
[CodeGen] MachineCopyPropagation: keep COPYs that feed predicated defs

### DIFF
--- a/llvm/lib/CodeGen/MachineCopyPropagation.cpp
+++ b/llvm/lib/CodeGen/MachineCopyPropagation.cpp
@@ -1004,6 +1004,12 @@ void MachineCopyPropagation::forwardCopyPropagateBlock(MachineBasicBlock &MBB) {
         // Skip invalidating constant registers.
         if (!MRI->isConstantPhysReg(Reg)) {
           Defs.push_back(Reg.asMCReg());
+          // If this instruction is predicated, the def is conditional. When
+          // the predicate is false the register keeps its previous value, so
+          // it is implicitly read. Treat it as read to keep the COPY that
+          // defines it from being eliminated as dead.
+          if (TII->isPredicated(MI))
+            readRegister(Reg.asMCReg(), MI, RegularUse);
           continue;
         }
       } else if (MO.readsReg()) {
@@ -1115,6 +1121,13 @@ void MachineCopyPropagation::forwardCopyPropagateBlock(MachineBasicBlock &MBB) {
 
 void MachineCopyPropagation::propagateDefs(MachineInstr &MI) {
   if (!Tracker.hasAnyCopies())
+    return;
+
+  // If this instruction is predicated, the def is conditional. When the
+  // predicate is false the destination register keeps its previous value.
+  // Backward-propagating through a predicated def would rename the register
+  // and delete the COPY that provided that pass-through value.
+  if (TII->isPredicated(MI))
     return;
 
   for (unsigned OpIdx = 0, OpEnd = MI.getNumOperands(); OpIdx != OpEnd;

--- a/llvm/test/CodeGen/Hexagon/machine-cp-predicated.mir
+++ b/llvm/test/CodeGen/Hexagon/machine-cp-predicated.mir
@@ -1,0 +1,41 @@
+# RUN: llc -mtriple=hexagon -run-pass=machine-cp -o - %s | FileCheck %s
+
+# A predicated instruction conditionally defines its destination: when the
+# predicate is false the destination keeps its previous value, so it is
+# implicitly read. MachineCopyPropagation must not remove a COPY that supplies
+# that pass-through value, nor rename a predicated def into a COPY's
+# destination.
+
+# Forward propagation: the COPY feeding a predicated def must survive.
+---
+name: forward_predicated_def_keeps_copy
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $r0, $r1, $p0
+    ; CHECK-LABEL: name: forward_predicated_def_keeps_copy
+    ; CHECK: $r2 = COPY $r1
+    ; CHECK-NEXT: $r2 = A2_tfrt $p0, killed $r0
+    $r2 = COPY $r1
+    $r2 = A2_tfrt $p0, killed $r0
+    $r0 = COPY killed $r2
+    PS_jmpret $r31, implicit-def dead $pc, implicit $r0
+...
+
+# Backward propagation: propagateDefs must not rename a predicated def into the
+# COPY's destination, because on the predicate-false path that destination
+# would keep a stale value.
+---
+name: backward_predicated_def_keeps_copy
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $r0, $p0
+    ; CHECK-LABEL: name: backward_predicated_def_keeps_copy
+    ; CHECK: renamable $r1 = A2_tfrt $p0, killed $r0
+    ; CHECK-NEXT: $r2 = COPY killed renamable $r1
+    renamable $r1 = A2_tfrt $p0, killed $r0
+    $r2 = COPY killed renamable $r1
+    $r0 = COPY killed $r2
+    PS_jmpret $r31, implicit-def dead $pc, implicit $r0
+...


### PR DESCRIPTION
MachineCopyPropagation could delete a COPY whose destination register is redefined by a *predicated* instruction. A predicated def is conditional: when the predicate is false the destination keeps its previous value, so the instruction also implicitly reads the register. Two paths mishandled this:

  * forwardCopyPropagateBlock() treated the predicated def as an unconditional clobber and could eliminate the COPY that provides the value read on the predicate-false path. When the defining instruction is predicated, treat the register as read (RegularUse) so the COPY is preserved.

  * propagateDefs() backward-propagated through the predicated def, renaming the register and deleting the COPY -- but on the predicate-false path the renamed register holds a stale value. Skip propagateDefs() for predicated instructions.

This is only reachable on targets that combine predication with register renaming (TargetInstrInfo::isPredicated() returning true while the target sets AllowRegisterRenaming). Add a Hexagon MIR test exercising both paths.

**AI assistance disclosure** (per the LLVM AI Tool Use Policy): the MIR test and parts of this commit message were drafted with an AI tool (Claude, Anthropic). I have reviewed and verified all code and tests and take full responsibility for this contribution.