### PR TITLE
[lldb] Use std::atomic<bool> for Editline's pending-resize flag

### DIFF
--- a/lldb/include/lldb/Host/Editline.h
+++ b/lldb/include/lldb/Host/Editline.h
@@ -41,7 +41,7 @@
 #include <histedit.h>
 #endif
 
-#include <csignal>
+#include <atomic>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -418,7 +418,11 @@ private:
   std::string m_set_continuation_prompt;
   std::string m_current_prompt;
   bool m_needs_prompt_repaint = false;
-  volatile std::sig_atomic_t m_terminal_size_has_changed = 0;
+  /// Set from the signal thread on SIGWINCH and consumed on the thread that
+  /// owns libedit, which applies the resize in its read loop. el_resize() is
+  /// not safe to run off that thread, so this only records that a resize is
+  /// pending rather than performing it here.
+  std::atomic<bool> m_terminal_size_has_changed = false;
   std::string m_editor_name;
   FILE *m_input_file;
   lldb::LockableStreamFileSP m_output_stream_sp;

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -1553,13 +1553,13 @@ void Editline::SetContinuationPrompt(const char *continuation_prompt) {
       continuation_prompt == nullptr ? "" : continuation_prompt;
 }
 
-void Editline::TerminalSizeChanged() { m_terminal_size_has_changed = 1; }
+void Editline::TerminalSizeChanged() { m_terminal_size_has_changed = true; }
 
 void Editline::ApplyTerminalSizeChange() {
   if (!m_editline)
     return;
 
-  m_terminal_size_has_changed = 0;
+  m_terminal_size_has_changed = false;
   el_resize(m_editline);
   int columns;
   // This function is documenting as taking (const char *, void *) for the


### PR DESCRIPTION
TerminalSizeChanged() used a volatile std::sig_atomic_t to record that a resize is pending. That type was chosen because the SIGWINCH handler ran in async-signal context and could only touch an sig_atomic_t. Signals are now handled on a dedicated thread, so the flag is written from a normal thread and std::atomic<bool> is sufficient to handle that.

el_resize() still runs on the thread that owns libedit, in its read loop. I discovered that it is not safe to run elsewhere, because it resets libedit's display model without redrawing. Applying it off that thread seems to throw it off and makes it duplicate the prompt.