### PR TITLE
[compiler-rt][tsan] Fix -Wunused-template in tsan_interface_atomic.cpp (NFC)

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_interface_atomic.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface_atomic.cpp
@@ -350,12 +350,12 @@ struct OpFetchAdd {
 
 struct OpFetchSub {
   template <typename T>
-  static T NoTsanAtomic(morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T *a, T v) {
     return func_sub(a, v);
   }
 
   template <typename T>
-  static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
     return AtomicRMW<T, func_sub>(thr, pc, a, v, mo);
   }
 };
@@ -386,24 +386,24 @@ struct OpFetchOr {
 
 struct OpFetchXor {
   template <typename T>
-  static T NoTsanAtomic(morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T *a, T v) {
     return func_xor(a, v);
   }
 
   template <typename T>
-  static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
     return AtomicRMW<T, func_xor>(thr, pc, a, v, mo);
   }
 };
 
 struct OpFetchNand {
   template <typename T>
-  static T NoTsanAtomic(morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T *a, T v) {
     return func_nand(a, v);
   }
 
   template <typename T>
-  static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
     return AtomicRMW<T, func_nand>(thr, pc, a, v, mo);
   }
 };

--- a/compiler-rt/lib/tsan/rtl/tsan_interface_atomic.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface_atomic.cpp
@@ -350,12 +350,13 @@ struct OpFetchAdd {
 
 struct OpFetchSub {
   template <typename T>
-  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T* a, T v) {
     return func_sub(a, v);
   }
 
   template <typename T>
-  [[maybe_unused]] static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T Atomic(ThreadState* thr, uptr pc, morder mo,
+                                   volatile T* a, T v) {
     return AtomicRMW<T, func_sub>(thr, pc, a, v, mo);
   }
 };
@@ -386,24 +387,26 @@ struct OpFetchOr {
 
 struct OpFetchXor {
   template <typename T>
-  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T* a, T v) {
     return func_xor(a, v);
   }
 
   template <typename T>
-  [[maybe_unused]] static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T Atomic(ThreadState* thr, uptr pc, morder mo,
+                                   volatile T* a, T v) {
     return AtomicRMW<T, func_xor>(thr, pc, a, v, mo);
   }
 };
 
 struct OpFetchNand {
   template <typename T>
-  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T NoTsanAtomic(morder mo, volatile T* a, T v) {
     return func_nand(a, v);
   }
 
   template <typename T>
-  [[maybe_unused]] static T Atomic(ThreadState *thr, uptr pc, morder mo, volatile T *a, T v) {
+  [[maybe_unused]] static T Atomic(ThreadState* thr, uptr pc, morder mo,
+                                   volatile T* a, T v) {
     return AtomicRMW<T, func_nand>(thr, pc, a, v, mo);
   }
 };


### PR DESCRIPTION
This marks unused atomic operation templates in tsan_interface_atomic.cpp with
[[maybe_unused]] to silence Clang's -Wunused-template warnings when building
with SANITIZER_GO=1 (Go TSan).

Because the static template methods (NoTsanAtomic and Atomic) inside OpFetchSub, OpFetchXor, and OpFetchNand are never called when compiling the Go runtime, the compiler flags them as unused templates. 
The following are the helper structs that never get instantiated.

OpFetchSub: Go performs subtraction by passing negative numbers to the Add API. No Sub API exists in Go TSan.
OpFetchXor: Go does not support atomic XOR.
OpFetchNand: Go does not support atomic NAND.

I saw most PRs within non-header files for https://github.com/llvm/llvm-project/issues/202945 was to use [[maybe_unused]]