### PR TITLE
[lldb][bazel] Add ScriptedFrameProvider plugin to the Bazel overlay

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -2273,6 +2273,24 @@ cc_library(
 )
 
 cc_library(
+    name = "PluginScriptedFrameProvider",
+    srcs = glob(["SyntheticFrameProvider/ScriptedFrameProvider/*.cpp"]),
+    hdrs = glob(["SyntheticFrameProvider/ScriptedFrameProvider/*.h"]),
+    includes = [".."],
+    deps = [
+        ":PluginScriptedProcess",
+        "//lldb:Core",
+        "//lldb:CoreHeaders",
+        "//lldb:Headers",
+        "//lldb:InterpreterHeaders",
+        "//lldb:Target",
+        "//lldb:TargetHeaders",
+        "//lldb:Utility",
+        "//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "PluginProcessMachCore",
     srcs = glob(["Process/mach-core/*.cpp"]),
     hdrs = glob(["Process/mach-core/*.h"]),

--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
@@ -75,6 +75,7 @@ DEFAULT_PLUGINS = [
     "ProcessMinidump",
     "ProtocolServerMCP",
     "RegisterTypeBuilderClang",
+    "ScriptedFrameProvider",
     "ScriptedProcess",
     "StructuredDataDarwinLog",
     "SymbolFileBreakpad",


### PR DESCRIPTION
Adds the PluginScriptedFrameProvider cc_library for the new SyntheticFrameProvider/ScriptedFrameProvider category and registers it in DEFAULT_PLUGINS. Deps mirror the plugin's CMakeLists.txt (lldbCore, lldbInterpreter, lldbTarget, lldbUtility, Support) plus the :PluginScriptedProcess plugin dep it uses.

The ScriptedFrameProvider plugin was added upstream in PR #161870 ("[lldb] Introduce ScriptedFrameProvider for real threads"), relanded as PR #170236; this wires it into the Bazel overlay build.

bazel rule creation assisted with: claude

Can confirm this rule translates into a valid buck2 rule for Meta to build internally, but no bazel build locally; will await CI testing.