### PR TITLE
[mlir][DataLayout] Fix ABI alignment calculation for ComplexType

### DIFF
--- a/mlir/lib/Interfaces/DataLayoutInterfaces.cpp
+++ b/mlir/lib/Interfaces/DataLayoutInterfaces.cpp
@@ -155,8 +155,7 @@ uint64_t mlir::detail::getDefaultABIAlignment(
     return getIntegerTypeABIAlignment(intType, params);
 
   if (auto ctype = dyn_cast<ComplexType>(type))
-    return getDefaultABIAlignment(ctype.getElementType(), dataLayout, params);
-
+    return dataLayout.getTypeABIAlignment(ctype.getElementType());
   if (auto typeInterface = dyn_cast<DataLayoutTypeInterface>(type))
     return typeInterface.getABIAlignment(dataLayout, params);
 

--- a/mlir/test/Interfaces/DataLayoutInterfaces/query.mlir
+++ b/mlir/test/Interfaces/DataLayoutInterfaces/query.mlir
@@ -332,3 +332,21 @@ func.func @floats() {
     >} : () -> ()
   return
 }
+
+// CHECK-LABEL: @complex_floats
+func.func @complex_floats() {
+  "test.op_with_data_layout"() ({
+    // complex<f32>: f32 ABI alignment = 8 bytes (64 bits from entry)
+    // CHECK: alignment = 8
+    "test.data_layout_query"() : () -> complex<f32>
+    // complex<f128>: f128 ABI alignment = 8 bytes (64 bits from entry)
+    // Without fix this would return 16 (PowerOf2Ceil fallback)
+    // CHECK: alignment = 8
+    "test.data_layout_query"() : () -> complex<f128>
+    "test.maybe_terminator"() : () -> ()
+  }) { dlti.dl_spec = #dlti.dl_spec<
+      #dlti.dl_entry<f32,  dense<64>  : vector<1xi64>>,
+      #dlti.dl_entry<f128, dense<64>  : vector<1xi64>>
+    >} : () -> ()
+  return
+}


### PR DESCRIPTION
The current implementation of getDefaultABIAlignment for ComplexType forwards the ComplexType's own params to the recursive element type lookup. Since the LLVM data layout string format has no token for complex types, dlti.dl_spec never has an entry for ComplexType, so params is always empty. This means the element type's own data layout entry is never consulted and the generic PowerOf2Ceil(size) fallback is always used.

For example, complex<f128> on a target where f128 has ABI alignment of 8 bytes incorrectly returns 16 bytes (PowerOf2Ceil(sizeof(f128))) instead of the correct 8 bytes.

This patch updates ComplexType alignment retrieval to use dataLayout.getTypeABIAlignment(ctype.getElementType()), which bypasses the empty params and performs a fresh lookup for the element type, correctly finding its entry in dlti.dl_spec.


@uweigand @dominik-steenken 