### PR TITLE
[lldb] Allow generic operands in DWARF binary type check

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -1328,38 +1328,47 @@ static llvm::Error CheckScalarOperandsHaveSameType(const Scalar &lhs,
                                                    const Scalar &rhs,
                                                    LocationAtom opcode,
                                                    size_t address_size) {
+  auto mismatch = [&]() {
+    return llvm::createStringError("%s requires operands to have the same type",
+                                   DW_OP_value_to_name(opcode));
+  };
+
   // Scalar does not preserve the original DWARF DIE, but it does carry the
   // pieces of base-type information used by the evaluator: kind, size, and
   // integer signedness.
   if (lhs.GetType() != rhs.GetType())
-    return llvm::createStringError("%s requires operands to have the same type",
-                                   DW_OP_value_to_name(opcode));
+    return mismatch();
 
-  if (lhs.GetByteSize() != rhs.GetByteSize())
-    return llvm::createStringError("%s requires operands to have the same type",
-                                   DW_OP_value_to_name(opcode));
-
-  // Only integer scalars have signedness, so non-integer operands have no
-  // further scalar type information to compare after kind and size match.
-  if (lhs.GetType() != Scalar::e_int)
+  // Only integer scalars have signedness. Non-integer operands (e.g. floats)
+  // have no further scalar type information to compare once kind and size
+  // match.
+  if (lhs.GetType() != Scalar::e_int) {
+    if (lhs.GetByteSize() != rhs.GetByteSize())
+      return mismatch();
     return llvm::Error::success();
+  }
 
   // DWARF generic values are address-sized integers with unspecified
-  // signedness. LLDB does not explicitly preserve genericness on the expression
-  // stack, so treat integers at least as wide as the generic type as
-  // potentially generic to keep existing expressions compatible. For example,
-  // DW_OP_constu and DW_OP_consts currently do not always use to_generic due to
+  // signedness. LLDB does not explicitly preserve genericness on the
+  // expression stack, so treat integers at least as wide as the generic type
+  // as potentially generic and compatible with one another, regardless of
+  // exact width or signedness. This keeps common expressions working: e.g.
+  // DW_OP_breg produces a register-sized value while DW_OP_const* produces an
+  // address-sized one, yet both are meant to be generic. DW_OP_constu and
+  // DW_OP_consts also do not always use to_generic due to
   // https://github.com/llvm/llvm-project/issues/47431. A precise fix would
   // require tracking genericness directly, which is a larger type-system
-  // change, so do not use signedness to reject these operands here.
-  if (address_size != 0 && lhs.GetByteSize() >= address_size)
+  // change.
+  if (address_size != 0 && lhs.GetByteSize() >= address_size &&
+      rhs.GetByteSize() >= address_size)
     return llvm::Error::success();
 
-  // For non-generic integer operands, signedness is part of the base-type
-  // information preserved by Scalar, so require it to match.
+  // For non-generic integer operands, size and signedness are part of the
+  // base-type information preserved by Scalar, so require them to match.
+  if (lhs.GetByteSize() != rhs.GetByteSize())
+    return mismatch();
   if (lhs.IsSigned() != rhs.IsSigned())
-    return llvm::createStringError("%s requires operands to have the same type",
-                                   DW_OP_value_to_name(opcode));
+    return mismatch();
 
   return llvm::Error::success();
 }

--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -2210,8 +2210,8 @@ bool RegisterContextUnwind::ReadFrameAddress(
       UNWIND_LOG(log, "CFA value set by DWARF expression is {0:x}", address);
       return true;
     }
-    UNWIND_LOG(log, "Failed to set CFA value via DWARF expression: {0}",
-               fmt_consume(result.takeError()));
+    LLDB_LOG_ERROR(log, result.takeError(),
+                   "Failed to set CFA value via DWARF expression: {0}");
     break;
   }
   case UnwindPlan::Row::FAValue::isRaSearch: {
@@ -2273,9 +2273,8 @@ lldb::addr_t RegisterContextUnwind::GetReturnAddressHint(int32_t plan_offset) {
                 *next->m_sym_ctx.symbol))
       hint += *expected_size;
     else {
-      UNWIND_LOG_VERBOSE(GetLog(LLDBLog::Unwind),
-                         "Could not retrieve parameter size: {0}",
-                         fmt_consume(expected_size.takeError()));
+      LLDB_LOG_ERRORV(GetLog(LLDBLog::Unwind), expected_size.takeError(),
+                      "Could not retrieve parameter size: {0}");
       return LLDB_INVALID_ADDRESS;
     }
   }


### PR DESCRIPTION
fc298ccbc52a's CheckScalarOperandsHaveSameType also rejects legitimate generic-typed operands, breaking breakpad STACK WIN / raSearch unwinding on 32-bit targets. For `DW_OP_breg7 +0, DW_OP_consts +80, DW_OP_plus`, DW_OP_breg yields a register-sized (8-byte) scalar while DW_OP_const* yields an address-sized (4-byte) generic one. The strict size gate ran before the genericness escape, and the escape only checked the left operand, so the CFA expression was rejected and the unwind failed.

Reorder so two integers that are each at least as wide as the generic type are accepted before the size/signedness gate. The commit's own type-check unit tests still pass.

Also fix a latent crash the failure exposed: ReadFrameAddress and GetReturnAddressHint only consumed the error inside an UNWIND_LOG argument, which is skipped when the log is off, so the errored Expected was destroyed unchecked and aborted. Consume it via LLDB_LOG_ERROR / LLDB_LOG_ERRORV instead.