### PR TITLE
[lldb] Distinguish DWARF binary type-check error messages

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -1328,23 +1328,23 @@ static llvm::Error CheckScalarOperandsHaveSameType(const Scalar &lhs,
                                                    const Scalar &rhs,
                                                    LocationAtom opcode,
                                                    size_t address_size) {
-  auto mismatch = [&]() {
-    return llvm::createStringError("%s requires operands to have the same type",
-                                   DW_OP_value_to_name(opcode));
+  auto mismatch = [&](const char *what) {
+    return llvm::createStringError("%s requires operands to have the same %s",
+                                   DW_OP_value_to_name(opcode), what);
   };
 
   // Scalar does not preserve the original DWARF DIE, but it does carry the
   // pieces of base-type information used by the evaluator: kind, size, and
   // integer signedness.
   if (lhs.GetType() != rhs.GetType())
-    return mismatch();
+    return mismatch("type");
 
   // Only integer scalars have signedness. Non-integer operands (e.g. floats)
   // have no further scalar type information to compare once kind and size
   // match.
   if (lhs.GetType() != Scalar::e_int) {
     if (lhs.GetByteSize() != rhs.GetByteSize())
-      return mismatch();
+      return mismatch("size");
     return llvm::Error::success();
   }
 
@@ -1366,9 +1366,9 @@ static llvm::Error CheckScalarOperandsHaveSameType(const Scalar &lhs,
   // For non-generic integer operands, size and signedness are part of the
   // base-type information preserved by Scalar, so require them to match.
   if (lhs.GetByteSize() != rhs.GetByteSize())
-    return mismatch();
+    return mismatch("size");
   if (lhs.IsSigned() != rhs.IsSigned())
-    return mismatch();
+    return mismatch("signedness");
 
   return llvm::Error::success();
 }


### PR DESCRIPTION
CheckScalarOperandsHaveSameType reported every operand-check failure with the same "requires operands to have the same type" message, even though it rejects operands for three different reasons: mismatched type kind, mismatched size, and mismatched signedness. That made a failed check hard to diagnose from the error alone.

Parameterize the message so each check names what actually differs (type, size, or signedness).

Follow-up to Augusto's review of #209641.