### PR TITLE
[RISCV][MC][NFC] Cleanup Xqci Tests

### DIFF
--- a/llvm/test/MC/RISCV/xqcia-invalid.s
+++ b/llvm/test/MC/RISCV/xqcia-invalid.s
@@ -1,14 +1,15 @@
 # Xqcia - Qualcomm uC Arithmetic Extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcia < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcia < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+2]]:20: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.shlsat x10, x3, 17
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.shlsat x10, x3
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
@@ -31,7 +32,8 @@ qc.shlsat x10, x3, x17
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.shlusat x23, x25, 27
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.shlusat x23, x25
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
@@ -54,7 +56,8 @@ qc.shlusat x23, x25, x27
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.addsat x17, x14, 7
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.addsat x17, x14
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
@@ -77,7 +80,8 @@ qc.addsat x17, x14, x7
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.addusat x8, x18, 28
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.addusat x8, x18
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
@@ -100,7 +104,8 @@ qc.addusat x8, x18, x28
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.subsat x22, x2, 12
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.subsat x22, x2
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
@@ -123,7 +128,8 @@ qc.subsat x22, x2, x12
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.subusat x9, x14, 17
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.subusat x9, x14
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
@@ -146,7 +152,8 @@ qc.subusat x9, x14, x17
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.wrap x3, x30, 23
 
-# CHECK: :[[@LINE+1]]:{{16: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:16: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.wrap x3, x30
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
@@ -173,7 +180,8 @@ qc.wrapi x0, x12, 2047
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.wrapi x6, x0, 2047
 
-# CHECK: :[[@LINE+1]]:{{17: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:17: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.wrapi x6, x12
 
 # CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [0, 2047]
@@ -187,7 +195,8 @@ qc.wrapi x6, x12, 2047
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.norm x3, 7
 
-# CHECK: :[[@LINE+1]]:{{11: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:11: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.norm x3
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
@@ -206,7 +215,8 @@ qc.norm x3, x7
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.normu x11, 17
 
-# CHECK: :[[@LINE+1]]:{{13: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.normu x11
 
 # CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR excluding zero (x0)
@@ -225,7 +235,8 @@ qc.normu x11, x17
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.normeu x26, 31
 
-# CHECK: :[[@LINE+1]]:{{14: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.normeu x26
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)

--- a/llvm/test/MC/RISCV/xqciac-invalid.s
+++ b/llvm/test/MC/RISCV/xqciac-invalid.s
@@ -1,46 +1,49 @@
 # Xqciac - Qualcomm uC Load-Store Address Calculation Extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqciac < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-IMM %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqciac < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-EXT %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
-# CHECK-PLUS: :[[@LINE+2]]:14: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:14: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:14: error: register must be a GPR from x8 to x15
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.muliadd x5, x10, 4
 
-# CHECK: :[[@LINE+1]]:{{17: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:17: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.muliadd x15
 
-# CHECK-IMM: :[[@LINE+1]]:24: error: immediate must be an integer in the range [0, 31]
+# CHECK-PLUS: :[[@LINE+1]]:24: error: immediate must be an integer in the range [0, 31]
 qc.c.muliadd x10, x15, 32
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciac' (Qualcomm uC Load-Store Address Calculation Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciac' (Qualcomm uC Load-Store Address Calculation Extension)
 qc.c.muliadd x10, x15, 20
 
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:12: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:12: error: register must be a GPR excluding zero (x0)
 qc.muliadd x0, x10, 1048577
 
-# CHECK: :[[@LINE+1]]:{{15: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:15: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.muliadd x10
 
-# CHECK-IMM: :[[@LINE+1]]:22: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
+# CHECK-PLUS: :[[@LINE+1]]:22: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 qc.muliadd x10, x15, 8589934592
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciac' (Qualcomm uC Load-Store Address Calculation Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciac' (Qualcomm uC Load-Store Address Calculation Extension)
 qc.muliadd x10, x15, 577
 
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:11: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:11: error: register must be a GPR excluding zero (x0)
 qc.shladd 0, x10, 1048577
 
-# CHECK: :[[@LINE+1]]:{{14: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.shladd x10
 
-# CHECK-IMM: :[[@LINE+1]]:26: error: immediate must be an integer in the range [4, 31]
+# CHECK-PLUS: :[[@LINE+1]]:26: error: immediate must be an integer in the range [4, 31]
 qc.shladd x10, x15, x11, 2
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciac' (Qualcomm uC Load-Store Address Calculation Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciac' (Qualcomm uC Load-Store Address Calculation Extension)
 qc.shladd x10, x15, x11, 5

--- a/llvm/test/MC/RISCV/xqcibi-invalid.s
+++ b/llvm/test/MC/RISCV/xqcibi-invalid.s
@@ -1,14 +1,15 @@
 # Xqcibi - Qualcomm uC Branch Immediate Extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcibi < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcibi < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.beqi x0, 12, 346
 
-# CHECK: :[[@LINE+1]]:{{15: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:15: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.beqi x8, 12
 
 # CHECK-PLUS: :[[@LINE+1]]:13: error: immediate must be non-zero in the range [-16, 15]
@@ -25,7 +26,8 @@ qc.beqi x8, 12, 346
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.bnei x0, 15, 4094
 
-# CHECK: :[[@LINE+1]]:{{15: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:15: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.bnei x4, 15
 
 # CHECK-PLUS: :[[@LINE+1]]:13: error: immediate must be non-zero in the range [-16, 15]
@@ -42,7 +44,8 @@ qc.bnei x4, 15, 4094
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.bgei x0, 1, -4096
 
-# CHECK: :[[@LINE+1]]:{{15: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:15: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.bgei x10, 1
 
 # CHECK-PLUS: :[[@LINE+1]]:14: error: immediate must be non-zero in the range [-16, 15]
@@ -59,7 +62,8 @@ qc.bgei x10, 1, -4096
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.blti x0, 6, 2000
 
-# CHECK: :[[@LINE+1]]:{{14: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.blti x1, 6
 
 # CHECK-PLUS: :[[@LINE+1]]:13: error: immediate must be non-zero in the range [-16, 15]
@@ -76,7 +80,8 @@ qc.blti x1, 6, 2000
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.bgeui x0, 11, 128
 
-# CHECK: :[[@LINE+1]]:{{17: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:17: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.bgeui x12, 11
 
 # CHECK-PLUS: :[[@LINE+1]]:15: error: immediate must be an integer in the range [1, 31]
@@ -93,7 +98,8 @@ qc.bgeui x12, 11, 128
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.bltui x0, 7, 666
 
-# CHECK: :[[@LINE+1]]:{{15: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:15: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.bltui x2, 7
 
 # CHECK-PLUS: :[[@LINE+1]]:14: error: immediate must be an integer in the range [1, 31]
@@ -110,7 +116,8 @@ qc.bltui x2, 7, 666
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.beqi x0, 1, 2
 
-# CHECK: :[[@LINE+1]]:{{16: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:16: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.beqi x1, 1
 
 # CHECK-PLUS: :[[@LINE+1]]:15: error: immediate must be non-zero in the range [-32768, 32767]
@@ -127,7 +134,8 @@ qc.e.beqi x1, 1, 2
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.bnei x0, 115, 4094
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.bnei x4, 115
 
 # CHECK-PLUS: :[[@LINE+1]]:15: error: immediate must be non-zero in the range [-32768, 32767]
@@ -144,7 +152,8 @@ qc.e.bnei x4, 115, 4094
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.bgei x0, -32768, -4096
 
-# CHECK: :[[@LINE+1]]:{{22: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:22: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.bgei x10, -32768
 
 # CHECK-PLUS: :[[@LINE+1]]:16: error: immediate must be non-zero in the range [-32768, 32767]
@@ -161,7 +170,8 @@ qc.e.bgei x10, -32768, -4096
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.blti x0, 32767, 2000
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.blti x1, 32767
 
 # CHECK-PLUS: :[[@LINE+1]]:15: error: immediate must be non-zero in the range [-32768, 32767]
@@ -178,7 +188,8 @@ qc.e.blti x1, 32767, 2000
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.bgeui x0, 711, 128
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.bgeui x12, 711
 
 # CHECK-PLUS: :[[@LINE+1]]:17: error: immediate must be an integer in the range [1, 65535]
@@ -195,7 +206,8 @@ qc.e.bgeui x12, 711, 128
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.bltui x0, 7, 666
 
-# CHECK: :[[@LINE+1]]:{{17: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:17: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.bltui x2, 7
 
 # CHECK-PLUS: :[[@LINE+1]]:16: error: immediate must be an integer in the range [1, 65535]

--- a/llvm/test/MC/RISCV/xqcibm-invalid.s
+++ b/llvm/test/MC/RISCV/xqcibm-invalid.s
@@ -1,14 +1,15 @@
 # Xqcibm - Qualcomm uC Bit Manipulation Extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcibm < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS %s --implicit-check-not="error:"
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s --implicit-check-not="error:"
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcibm < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s --implicit-check-not="error:"
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s --implicit-check-not="error:"
 
 # CHECK-PLUS: :[[@LINE+2]]:18: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.compress2 x7, 5
 
-# CHECK: :[[@LINE+1]]:{{16: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:16: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.compress2 x7
 
 # CHECK-PLUS: :[[@LINE+2]]:14: error: register must be a GPR excluding zero (x0)
@@ -27,7 +28,8 @@ qc.compress2 x7, x5
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.compress3 x10, 22
 
-# CHECK: :[[@LINE+1]]:{{17: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:17: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.compress3 x10
 
 # CHECK-PLUS: :[[@LINE+2]]:14: error: register must be a GPR excluding zero (x0)
@@ -46,7 +48,8 @@ qc.compress3 x10, x22
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.expand2 x23, 23
 
-# CHECK: :[[@LINE+1]]:{{15: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:15: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.expand2 x23
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
@@ -65,7 +68,8 @@ qc.expand2 x23, x23
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.expand3 x2, 6
 
-# CHECK: :[[@LINE+1]]:{{14: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.expand3 x2
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
@@ -84,7 +88,8 @@ qc.expand3 x2, x6
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.clo x23, 24
 
-# CHECK: :[[@LINE+1]]:{{11: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:11: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.clo x23
 
 # CHECK-PLUS: :[[@LINE+2]]:8: error: register must be a GPR excluding zero (x0)
@@ -103,7 +108,8 @@ qc.clo x23, x24
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.cto x12, 13
 
-# CHECK: :[[@LINE+1]]:{{11: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:11: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.cto x12
 
 # CHECK-PLUS: :[[@LINE+2]]:8: error: register must be a GPR excluding zero (x0)
@@ -122,7 +128,8 @@ qc.cto x12, x13
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.brev32 x20, 24
 
-# CHECK: :[[@LINE+1]]:{{14: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.brev32 x20
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
@@ -149,7 +156,8 @@ qc.insbri x0, x20, -1024
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbri x10, x0, -1024
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbri x10, x20
 
 # CHECK-PLUS: :[[@LINE+2]]:21: error: immediate must be an integer in the range [-1024, 1023]
@@ -164,7 +172,8 @@ qc.insbri x10, x20, -1024
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbi x0, -10, 12, 15
 
-# CHECK: :[[@LINE+1]]:{{21: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:21: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbi x6, -10, 12
 
 # CHECK-PLUS: :[[@LINE+2]]:14: error: immediate must be an integer in the range [-16, 15]
@@ -183,10 +192,12 @@ qc.insbi x6, -10, 12, 65
 qc.insbi x6, -10, 12, 15
 
 
-# CHECK: :[[@LINE+1]]:{{14: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insb x10, 7, 6, 31
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insb x10, x7, 6
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
@@ -205,10 +216,12 @@ qc.insb x10, x7, 6, 61
 qc.insb x10, x7, 6, 31
 
 
-# CHECK: :[[@LINE+1]]:{{15: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:15: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbh x20, 12, 8, 12
 
-# CHECK: :[[@LINE+1]]:{{21: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:21: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbh x20, x12, 8
 
 # CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR excluding zero (x0)
@@ -231,7 +244,8 @@ qc.insbh x20, x12, 8, 12
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extu x15, 12, 20, 20
 
-# CHECK: :[[@LINE+1]]:{{21: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:21: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extu x15, x12, 20
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
@@ -258,7 +272,8 @@ qc.extu x15, x12, 20, 20
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.ext x27, 6, 31, 1
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.ext x27, x6, 31
 
 # CHECK-PLUS: :[[@LINE+2]]:8: error: register must be a GPR excluding zero (x0)
@@ -285,7 +300,8 @@ qc.ext x27, x6, 31, 1
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdu x1, 8, 8, 8
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdu x1, x8, 8
 
 # CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR excluding zero (x0)
@@ -308,7 +324,8 @@ qc.extdu x1, x8, 8, 8
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extd x13, 21, 10, 15
 
-# CHECK: :[[@LINE+1]]:{{21: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:21: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extd x13, x21, 10
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
@@ -331,7 +348,8 @@ qc.extd x13, x21, 10, 15
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbr x10, x19, 5
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbr x10, x20
 
 # CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR excluding zero (x0)
@@ -350,7 +368,8 @@ qc.insbr x10, x19, x5
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbhr x15, x4, 6
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbhr x15, x4
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
@@ -369,7 +388,8 @@ qc.insbhr x15, x4, x6
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbpr x21, x8, 9
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbpr x21, x8
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
@@ -388,7 +408,8 @@ qc.insbpr x21, x8, x9
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbprh x2, x3, 11
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.insbprh x2, x3
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
@@ -407,7 +428,8 @@ qc.insbprh x2, x3, x11
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdur x9, x19, 29
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdur x9, x19
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
@@ -430,7 +452,8 @@ qc.extdur x9, x19, x29
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdr x12, x29, 30
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdr x12, x29
 
 # CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR excluding zero (x0)
@@ -453,7 +476,8 @@ qc.extdr x12, x29, x30
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdupr x13, x23, 3
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdupr x13, x23
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
@@ -476,7 +500,8 @@ qc.extdupr x13, x23, x3
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extduprh x18, x8, 9
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extduprh x18, x8
 
 # CHECK-PLUS: :[[@LINE+2]]:13: error: register must be a GPR excluding zero (x0)
@@ -499,7 +524,8 @@ qc.extduprh x18, x8, x9
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdpr x1, x4, 15
 
-# CHECK: :[[@LINE+1]]:{{17: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:17: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdpr x1, x4
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
@@ -522,7 +548,8 @@ qc.extdpr x1, x4, x15
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdprh x6, x24, 25
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.extdprh x6, x24
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
@@ -545,7 +572,8 @@ qc.extdprh x6, x24, x25
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.bexti x1, 8
 
-# CHECK: :[[@LINE+1]]:{{15: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:15: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.bexti x15
 
 # CHECK-PLUS: :[[@LINE+2]]:17: error: immediate must be an integer in the range [1, 31]
@@ -560,7 +588,8 @@ qc.c.bexti x9, 8
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.bseti x2, 10
 
-# CHECK: :[[@LINE+1]]:{{15: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:15: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.bseti x12
 
 # CHECK-PLUS: :[[@LINE+2]]:17: error: immediate must be an integer in the range [1, 31]
@@ -575,7 +604,8 @@ qc.c.bseti x12, 30
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.extu x0, 10
 
-# CHECK: :[[@LINE+1]]:{{13: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.extu x5
 
 # CHECK-PLUS: :[[@LINE+2]]:16: error: immediate must be an integer in the range [6, 32]

--- a/llvm/test/MC/RISCV/xqcicli-invalid.s
+++ b/llvm/test/MC/RISCV/xqcicli-invalid.s
@@ -1,8 +1,8 @@
 # Xqcicli - Qualcomm uC Conditional Load Immediate Instructions
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcicli < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcicli < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
@@ -16,7 +16,8 @@ qc.lieq x2, x0, x6, 10
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lieq x2, x4, x0, 10
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lieq x2, x4, x6
 
 # CHECK-PLUS: :[[@LINE+1]]:21: error: immediate must be an integer in the range [-16, 15]
@@ -38,7 +39,8 @@ qc.lige x4, x0, x20, 2
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lige x4, x8, x0, 2
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lige x4, x8, x20
 
 # CHECK-PLUS: :[[@LINE+1]]:22: error: immediate must be an integer in the range [-16, 15]
@@ -60,7 +62,8 @@ qc.lilt x19, x0, x10, 3
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lilt x19, x9, x0, 3
 
-# CHECK: :[[@LINE+1]]:{{21: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:21: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lilt x19, x9, x10
 
 # CHECK-PLUS: :[[@LINE+1]]:23: error: immediate must be an integer in the range [-16, 15]
@@ -82,7 +85,8 @@ qc.line x18, x0, x6, 10
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.line x18, x14, x0, 10
 
-# CHECK: :[[@LINE+1]]:{{21: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:21: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.line x18, x14, x6
 
 # CHECK-PLUS: :[[@LINE+1]]:23: error: immediate must be an integer in the range [-16, 15]
@@ -104,7 +108,8 @@ qc.ligeu x2, x0, x6, 10
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.ligeu x2, x4, x0, 10
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.ligeu x2, x4, x6
 
 # CHECK-PLUS: :[[@LINE+1]]:22: error: immediate must be an integer in the range [-16, 15]
@@ -126,7 +131,8 @@ qc.liltu x1, x0, x12, 13
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.liltu x1, x19, x0, 13
 
-# CHECK: :[[@LINE+1]]:{{22: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:22: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.liltu x1, x19, x12
 
 # CHECK-PLUS: :[[@LINE+1]]:24: error: immediate must be an integer in the range [-16, 15]
@@ -144,7 +150,8 @@ qc.lieqi x0, x1, 15, 12
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lieqi x7, x0, 15, 12
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lieqi x7, x1, 15
 
 # CHECK-PLUS: :[[@LINE+1]]:18: error: immediate must be an integer in the range [-16, 15]
@@ -165,7 +172,8 @@ qc.ligei x0, x11, -4, 9
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.ligei x17, x0, -4, 9
 
-# CHECK: :[[@LINE+1]]:{{22: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:22: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.ligei x17, x11, -4
 
 # CHECK-PLUS: :[[@LINE+1]]:20: error: immediate must be an integer in the range [-16, 15]
@@ -186,7 +194,8 @@ qc.lilti x0, x11, -14, 2
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lilti x9, x0, -14, 2
 
-# CHECK: :[[@LINE+1]]:{{22: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:22: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lilti x9, x11, -14
 
 # CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
@@ -207,7 +216,8 @@ qc.linei x0, x1, 10, 12
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.linei x5, x0, 10, 12
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.linei x5, x1, 10
 
 # CHECK-PLUS: :[[@LINE+1]]:18: error: immediate must be an integer in the range [-16, 15]
@@ -228,7 +238,8 @@ qc.ligeui x0, x12, 7, -12
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.ligeui x2, x0, 7, -12
 
-# CHECK: :[[@LINE+1]]:{{21: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:21: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.ligeui x2, x12, 7
 
 # CHECK-PLUS: :[[@LINE+1]]:20: error: immediate must be an integer in the range [0, 31]
@@ -249,7 +260,8 @@ qc.liltui x0, x25, 31, 12
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.liltui x3, x0, 31, 12
 
-# CHECK: :[[@LINE+1]]:{{22: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:22: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.liltui x3, x25, 31
 
 # CHECK-PLUS: :[[@LINE+1]]:20: error: immediate must be an integer in the range [0, 31]

--- a/llvm/test/MC/RISCV/xqcicm-invalid.s
+++ b/llvm/test/MC/RISCV/xqcicm-invalid.s
@@ -1,165 +1,178 @@
 # Xqcicm - Qualcomm uC Conditional Move Extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcicm < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-IMM %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcicm < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-EXT %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
-# CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:12: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR from x8 to x15
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.mveqz 9, x10
 
-# CHECK: :[[@LINE+1]]:{{14: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.mveqz x9
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.c.mveqz x9, x10
 
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mveq 9, x10, x11, x12
 
-# CHECK: :[[@LINE+1]]:{{11: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:11: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mveq x9
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mveq x9, x10, x11, x12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvge 9, x10, x11, x12
 
-# CHECK: :[[@LINE+1]]:{{11: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:11: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvge x9
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mvge x9, x10, x11, x12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvgeu 9, x10, x11, x12
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvgeu x9
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mvgeu x9, x10, x11, x12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvlt 9, x10, x11, x12
 
-# CHECK: :[[@LINE+1]]:{{11: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:11: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvlt x9
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mvlt x9, x10, x11, x12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvltu 9, x10, x11, x12
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvltu x9
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mvltu x9, x10, x11, x12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvne 9, x10, x11, x12
 
-# CHECK: :[[@LINE+1]]:{{11: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:11: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvne x9
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mvne x9, x10, x11, x12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mveqi 9, x10, 5, x12
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mveqi x9
 
-# CHECK-IMM: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
 qc.mveqi x9, x10, 17, x12
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mveqi x9, x10, 5, x12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvgei 9, x10, 5, x12
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvgei x9
 
-# CHECK-IMM: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
 qc.mvgei x9, x10, 17, x12
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mvgei x9, x10, 5, x12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvlti 9, x10, 5, x12
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvlti x9
 
-# CHECK-IMM: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
 qc.mvlti x9, x10, 17, x12
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mvlti x9, x10, 5, x12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:10: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvnei 9, x10, 5, x12
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvnei x9
 
-# CHECK-IMM: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
 qc.mvnei x9, x10, 17, x12
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mvnei x9, x10, 5, x12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:11: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvltui 9, x10, 5, x12
 
-# CHECK: :[[@LINE+1]]:{{13: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvltui x9
 
-# CHECK-IMM: :[[@LINE+1]]:20: error: immediate must be an integer in the range [0, 31]
+# CHECK-PLUS: :[[@LINE+1]]:20: error: immediate must be an integer in the range [0, 31]
 qc.mvltui x9, x10, 37, x12
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mvltui x9, x10, 5, x12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:11: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvgeui 9, x10, 5, x12
 
-# CHECK: :[[@LINE+1]]:{{13: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.mvgeui x9
 
-# CHECK-IMM: :[[@LINE+1]]:20: error: immediate must be an integer in the range [0, 31]
+# CHECK-PLUS: :[[@LINE+1]]:20: error: immediate must be an integer in the range [0, 31]
 qc.mvgeui x9, x10, 37, x12
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicm' (Qualcomm uC Conditional Move Extension)
 qc.mvgeui x9, x10, 5, x12

--- a/llvm/test/MC/RISCV/xqcics-invalid.s
+++ b/llvm/test/MC/RISCV/xqcics-invalid.s
@@ -1,129 +1,137 @@
 # Xqcics - Qualcomm uC Conditional Select Extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcics < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-IMM %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcics < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-EXT %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+2]]:14: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:14: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selecteqi 9, 15, x4, x3
 
-# CHECK: :[[@LINE+1]]:{{24: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:24: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selecteqi x9, 15, x4
 
-# CHECK-IMM: :[[@LINE+1]]:18: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:18: error: immediate must be an integer in the range [-16, 15]
 qc.selecteqi x9, 16, x4, x3
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
 qc.selecteqi x9, 15, x4, x3
 
 
 # CHECK-PLUS: :[[@LINE+2]]:14: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:14: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectieq 8, x4, x3, 12
 
-# CHECK: :[[@LINE+1]]:{{24: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:24: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectieq x8, x4, x3
 
-# CHECK-IMM: :[[@LINE+1]]:26: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:26: error: immediate must be an integer in the range [-16, 15]
 qc.selectieq x8, x4, x3, 17
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
 qc.selectieq x8, x4, x3, 12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:15: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:15: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectieqi 9, 11, x3, 12
 
-# CHECK: :[[@LINE+1]]:{{25: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:25: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectieqi x9, 11, x3
 
-# CHECK-IMM: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
 qc.selectieqi x9, 16, x3, 12
 
-# CHECK-IMM: :[[@LINE+1]]:27: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:27: error: immediate must be an integer in the range [-16, 15]
 qc.selectieqi x9, 11, x3, 18
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
 qc.selectieqi x9, 11, x3, 12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:15: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:15: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectiieq 9, x3, 11, 12
 
-# CHECK: :[[@LINE+1]]:{{25: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:25: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectiieq x9, x3, 11
 
-# CHECK-IMM: :[[@LINE+1]]:23: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:23: error: immediate must be an integer in the range [-16, 15]
 qc.selectiieq x9, x3, 16, 12
 
-# CHECK-IMM: :[[@LINE+1]]:27: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:27: error: immediate must be an integer in the range [-16, 15]
 qc.selectiieq x9, x3, 11, 17
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
 qc.selectiieq x9, x3, 11, 12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:15: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:15: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectiine 8, x3, 10, 11
 
-# CHECK: :[[@LINE+1]]:{{25: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:25: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectiine x8, x3, 10
 
-# CHECK-IMM: :[[@LINE+1]]:23: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:23: error: immediate must be an integer in the range [-16, 15]
 qc.selectiine x8, x3, 16, 11
 
-# CHECK-IMM: :[[@LINE+1]]:27: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:27: error: immediate must be an integer in the range [-16, 15]
 qc.selectiine x8, x3, 12, 18
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
 qc.selectiine x8, x3, 10, 11
 
 
 # CHECK-PLUS: :[[@LINE+2]]:14: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:14: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectine 8, x3, x4, 11
 
-# CHECK: :[[@LINE+1]]:{{24: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:24: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectine x8, x3, x4
 
-# CHECK-IMM: :[[@LINE+1]]:26: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:26: error: immediate must be an integer in the range [-16, 15]
 qc.selectine x8, x3, x4, 16
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
 qc.selectine x8, x3, x4, 11
 
 
 # CHECK-PLUS: :[[@LINE+2]]:15: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:15: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectinei 8, 11, x3, 12
 
-# CHECK: :[[@LINE+1]]:{{25: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:25: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectinei x8, 11, x3
 
-# CHECK-IMM: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-16, 15]
 qc.selectinei x8, 16, x3, 12
 
-# CHECK-IMM: :[[@LINE+1]]:27: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:27: error: immediate must be an integer in the range [-16, 15]
 qc.selectinei x8, 11, x3, 18
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
 qc.selectinei x8, 11, x3, 12
 
 
 # CHECK-PLUS: :[[@LINE+2]]:14: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:14: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectnei 8, 11, x3, x5
 
-# CHECK: :[[@LINE+1]]:{{24: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:24: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.selectnei x8, 11, x3
 
-# CHECK-IMM: :[[@LINE+1]]:18: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+1]]:18: error: immediate must be an integer in the range [-16, 15]
 qc.selectnei x8, 16, x3, x5
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcics' (Qualcomm uC Conditional Select Extension)
 qc.selectnei x8, 11, x3, x5
 

--- a/llvm/test/MC/RISCV/xqcicsr-invalid.s
+++ b/llvm/test/MC/RISCV/xqcicsr-invalid.s
@@ -1,14 +1,15 @@
 # Xqcicsr - Qualcomm uC CSR Extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcicsr < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcicsr < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+2]]:20: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.csrrwr x10, x5, x0
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.csrrwr x10, x5
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicsr' (Qualcomm uC CSR Extension)
@@ -22,7 +23,8 @@ qc.csrrwri x20, 31, x0
 # CHECK-PLUS: :[[@LINE+1]]:17: error: immediate must be an integer in the range [0, 31]
 qc.csrrwri x20, 45, x12
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.csrrwri x20, 23
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcicsr' (Qualcomm uC CSR Extension)

--- a/llvm/test/MC/RISCV/xqciint-invalid.s
+++ b/llvm/test/MC/RISCV/xqciint-invalid.s
@@ -1,17 +1,19 @@
 # Xqciint - Qualcomm uC Interrupts extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqciint < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqciint < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: immediate must be an integer in the range [0, 1023]
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.setinti 1025
 
-# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:16: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.setinti 11, 12
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.setinti
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
@@ -21,10 +23,12 @@ qc.setinti   10
 # CHECK-PLUS: :[[@LINE+1]]:12: error: immediate must be an integer in the range [0, 1023]
 qc.clrinti 2000
 
-# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:16: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.clrinti 22, x4
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.clrinti
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
@@ -35,14 +39,16 @@ qc.clrinti 8
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.clrint 22
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.clrint
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.clrint x8
 
 
-# CHECK: :[[@LINE+1]]:{{9: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:9: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.di 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
@@ -53,14 +59,16 @@ qc.c.di
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.dir 22
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.dir
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.dir x8
 
 
-# CHECK: :[[@LINE+1]]:{{9: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:9: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.ei 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
@@ -71,28 +79,32 @@ qc.c.ei
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.eir 22
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.eir
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.eir x8
 
 
-# CHECK: :[[@LINE+1]]:{{19: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.mienter.nest 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.mienter.nest
 
 
-# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.mienter 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.mienter
 
 
-# CHECK: :[[@LINE+1]]:{{17: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:17: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.mileaveret 22
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
@@ -103,21 +115,24 @@ qc.c.mileaveret
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.setint 22
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.setint
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.setint x8
 
 
-# CHECK: :[[@LINE+1]]:{{11: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:11: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.mret x8
 
 # CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)
 qc.c.mret
 
 
-# CHECK: :[[@LINE+1]]:{{12: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.mnret 10
 
 # CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqciint' (Qualcomm uC Interrupts Extension)

--- a/llvm/test/MC/RISCV/xqcilb-invalid.s
+++ b/llvm/test/MC/RISCV/xqcilb-invalid.s
@@ -4,7 +4,8 @@
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcilb < %s 2>&1 \
 # RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.j
 
 # CHECK-PLUS: :[[@LINE+1]]:9: error: operand must be a multiple of 2 bytes in the range [-2147483648, 2147483646]
@@ -16,7 +17,8 @@ qc.e.j  -2147483648
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilb' (Qualcomm uC Long Branch Extension)
 qc.e.j  foo
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.jal
 
 # CHECK-PLUS: :[[@LINE+1]]:10: error: operand must be a multiple of 2 bytes in the range [-2147483648, 2147483646]

--- a/llvm/test/MC/RISCV/xqcili-invalid.s
+++ b/llvm/test/MC/RISCV/xqcili-invalid.s
@@ -1,22 +1,23 @@
 # Xqcili - Qualcomm uC Load Large Immediate Extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcili < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS,CHECK-IMM %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcili < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS,CHECK-EXT %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
 qc.e.li 9, 33554432
 
-# CHECK: :[[@LINE+1]]:{{11: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:11: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.li x9
 
-# CHECK-IMM: :[[@LINE+3]]:1: error: invalid instruction, any one of the following would fix this:
-# CHECK-IMM: :[[@LINE+2]]:13: note: immediate must be an integer in the range [-2147483648, 4294967295]
-# CHECK-IMM: :[[@LINE+1]]:13: note: immediate must be an integer in the range [-2147483648, 4294967295]
+# CHECK-PLUS: :[[@LINE+3]]:1: error: invalid instruction, any one of the following would fix this:
+# CHECK-PLUS: :[[@LINE+2]]:13: note: immediate must be an integer in the range [-2147483648, 4294967295]
+# CHECK-PLUS: :[[@LINE+1]]:13: note: immediate must be an integer in the range [-2147483648, 4294967295]
 qc.e.li x9, 4294967296
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcili' (Qualcomm uC Load Large Immediate Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcili' (Qualcomm uC Load Large Immediate Extension)
 qc.e.li x9, 4294967295
 
 
@@ -24,11 +25,12 @@ qc.e.li x9, 4294967295
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.li x0, 114514
 
-# CHECK: :[[@LINE+1]]:{{10: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:10: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.li x10
 
-# CHECK-IMM: :[[@LINE+1]]:12: error: operand must be a symbol with a %qc.abs20 specifier or an integer in the range [-524288, 524287]
+# CHECK-PLUS: :[[@LINE+1]]:12: error: operand must be a symbol with a %qc.abs20 specifier or an integer in the range [-524288, 524287]
 qc.li x10, 33554432
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcili' (Qualcomm uC Load Large Immediate Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcili' (Qualcomm uC Load Large Immediate Extension)
 qc.li x10, 114514

--- a/llvm/test/MC/RISCV/xqcilia-invalid.s
+++ b/llvm/test/MC/RISCV/xqcilia-invalid.s
@@ -1,20 +1,21 @@
 # Xqcilia - Qualcomm uC Large Immediate Arithmetic extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcilia < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS,CHECK-IMM %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcilia < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS,CHECK-EXT %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.addai 9, 33554432
 
-# CHECK: :[[@LINE+1]]:{{14: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.addai x9
 
-# CHECK-IMM: :[[@LINE+1]]:16: error: immediate must be an integer in the range [-2147483648, 4294967295]
+# CHECK-PLUS: :[[@LINE+1]]:16: error: immediate must be an integer in the range [-2147483648, 4294967295]
 qc.e.addai x9, 20485546494
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
 qc.e.addai x9, 33554432
 
 
@@ -22,13 +23,14 @@ qc.e.addai x9, 33554432
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.addi x10, 9, 554432
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.addi x10, x9
 
-# CHECK-IMM: :[[@LINE+1]]:20: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:20: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.addi x10, x9, 335544312
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
 qc.e.addi x10, x9, 554432
 
 
@@ -36,13 +38,14 @@ qc.e.addi x10, x9, 554432
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.andai 9, 33554432
 
-# CHECK: :[[@LINE+1]]:{{14: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.andai x9
 
-# CHECK-IMM: :[[@LINE+1]]:16: error: immediate must be an integer in the range [-2147483648, 4294967295]
+# CHECK-PLUS: :[[@LINE+1]]:16: error: immediate must be an integer in the range [-2147483648, 4294967295]
 qc.e.andai x9, 20494437494
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
 qc.e.andai x9, 33554432
 
 
@@ -50,13 +53,14 @@ qc.e.andai x9, 33554432
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.andi x10, 9, 554432
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.andi x10, x9
 
-# CHECK-IMM: :[[@LINE+1]]:20: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:20: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.andi x10, x9, 335544312
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
 qc.e.andi x10, x9, 554432
 
 
@@ -64,13 +68,14 @@ qc.e.andi x10, x9, 554432
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.orai 9, 33554432
 
-# CHECK: :[[@LINE+1]]:{{13: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.orai x9
 
-# CHECK-IMM: :[[@LINE+1]]:15: error: immediate must be an integer in the range [-2147483648, 4294967295]
+# CHECK-PLUS: :[[@LINE+1]]:15: error: immediate must be an integer in the range [-2147483648, 4294967295]
 qc.e.orai x9, 20494437494
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
 qc.e.orai x9, 33554432
 
 
@@ -78,13 +83,14 @@ qc.e.orai x9, 33554432
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.ori x10, 9, 554432
 
-# CHECK: :[[@LINE+1]]:{{17: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:17: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.ori x10, x9
 
-# CHECK-IMM: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.ori x10, x9, 335544312
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
 qc.e.ori x10, x9, 554432
 
 
@@ -93,13 +99,14 @@ qc.e.ori x10, x9, 554432
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.xorai 9, 33554432
 
-# CHECK: :[[@LINE+1]]:{{14: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.xorai x9
 
-# CHECK-IMM: :[[@LINE+1]]:16: error: immediate must be an integer in the range [-2147483648, 4294967295]
+# CHECK-PLUS: :[[@LINE+1]]:16: error: immediate must be an integer in the range [-2147483648, 4294967295]
 qc.e.xorai x9, 20494437494
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
 qc.e.xorai x9, 33554432
 
 
@@ -107,11 +114,12 @@ qc.e.xorai x9, 33554432
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.xori x10, 9, 554432
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.xori x10, x9
 
-# CHECK-IMM: :[[@LINE+1]]:20: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:20: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.xori x10, x9, 335544312
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilia' (Qualcomm uC Large Immediate Arithmetic Extension)
 qc.e.xori x10, x9, 554432

--- a/llvm/test/MC/RISCV/xqcilo-invalid.s
+++ b/llvm/test/MC/RISCV/xqcilo-invalid.s
@@ -1,108 +1,124 @@
 # Xqcilo - Qualcomm uC Extension Large Offset Load Store extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcilo < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-IMM %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcilo < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-EXT %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
-# CHECK: :[[@LINE+1]]:{{9: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
 qc.e.lb 11, 12(x10)
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.lb x11
 
-# CHECK-IMM: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.lb x11, 33445562212(x10)
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
 qc.e.lb x11, 12(x10)
 
 
-# CHECK: :[[@LINE+1]]:{{10: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:10: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
 qc.e.lbu 11, 12(x10)
 
-# CHECK: :[[@LINE+1]]:{{13: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.lbu x11
 
-# CHECK-IMM: :[[@LINE+1]]:15: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:15: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.lbu x11, 33445562212(x10)
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
 qc.e.lbu x11, 12(x10)
 
 
-# CHECK: :[[@LINE+1]]:{{9: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
 qc.e.lh 11, 12(x10)
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.lh x11
 
-# CHECK-IMM: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.lh x11, 33445562212(x10)
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
 qc.e.lh x11, 12(x10)
 
 
-# CHECK: :[[@LINE+1]]:{{10: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:10: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
 qc.e.lhu 11, 12(x10)
 
-# CHECK: :[[@LINE+1]]:{{13: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.lhu x11
 
-# CHECK-IMM: :[[@LINE+1]]:15: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:15: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.lhu x11, 33445562212(x10)
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
 qc.e.lhu x11, 12(x10)
 
 
-# CHECK: :[[@LINE+1]]:{{9: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
 qc.e.lw 11, 12(x10)
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.lw x11
 
-# CHECK-IMM: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.lw x11, 33445562212(x10)
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
 qc.e.lw x11, 12(x10)
 
 
-# CHECK: :[[@LINE+1]]:{{9: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
 qc.e.sb 11, 12(x10)
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.sb x11
 
-# CHECK-IMM: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.sb x11, 33445562212(x10)
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
 qc.e.sb x11, 12(x10)
 
 
-# CHECK: :[[@LINE+1]]:{{9: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
 qc.e.sh 11, 12(x10)
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.sh x11
 
-# CHECK-IMM: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.sh x11, 33445562212(x10)
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
 qc.e.sh x11, 12(x10)
 
 
-# CHECK: :[[@LINE+1]]:{{9: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:9: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
 qc.e.sw 11, 12(x10)
 
-# CHECK: :[[@LINE+1]]:{{12: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.e.sw x11
 
-# CHECK-IMM: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
+# CHECK-PLUS: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-33554432, 33554431]
 qc.e.sw x11, 33445562212(x10)
 
-# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
+# CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)
 qc.e.sw x11, 12(x10)

--- a/llvm/test/MC/RISCV/xqcilsm-invalid.s
+++ b/llvm/test/MC/RISCV/xqcilsm-invalid.s
@@ -15,7 +15,8 @@ qc.swm x0, x20, 12(x3)
 # CHECK-MINUS: :[[@LINE+1]]:12: error: register must be a GPR excluding zero (x0)
 qc.swm x5, x0, 12(x3)
 
-# CHECK: :[[@LINE+1]]:{{14: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.swm x5, x3
 
 # CHECK-PLUS: :[[@LINE+1]]:17: error: immediate must be a multiple of 4 bytes in the range [0, 124]
@@ -32,7 +33,8 @@ qc.swmi x10, 4, 20(4)
 # CHECK-MINUS: :[[@LINE+1]]:9: error: register must be a GPR excluding zero (x0)
 qc.swmi x0, 4, 20(x4)
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|17: error: invalid operand for instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:17: error: invalid operand for instruction
 qc.swmi x10, 4, 20
 
 # CHECK-PLUS: :[[@LINE+1]]:14: error: immediate must be an integer in the range [1, 31]
@@ -55,7 +57,8 @@ qc.setwm x4, x30, 124(2)
 # CHECK-MINUS: :[[@LINE+1]]:14: error: register must be a GPR excluding zero (x0)
 qc.setwm x4, x0, 124(x2)
 
-# CHECK: :[[@LINE+1]]:{{22: error: too few operands for instruction|19: error: invalid operand for instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:22: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:19: error: invalid operand for instruction
 qc.setwm x4, x30, 124
 
 # CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be a multiple of 4 bytes in the range [0, 124]
@@ -68,7 +71,8 @@ qc.setwm x4, x30, 124(x2)
 # CHECK: :[[@LINE+1]]:22: error: expected register
 qc.setwmi x5, 31, 12(12)
 
-# CHECK: :[[@LINE+1]]:{{21: error: too few operands for instruction|19: error: invalid operand for instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:21: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:19: error: invalid operand for instruction
 qc.setwmi x5, 31, 12
 
 # CHECK-PLUS: :[[@LINE+1]]:15: error: immediate must be an integer in the range [1, 31]
@@ -87,7 +91,8 @@ qc.setwmi x5, 31, 12(x12)
 # CHECK: :[[@LINE+1]]:19: error: expected register
 qc.lwm x7, x1, 24(20)
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|16: error: invalid operand for instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:16: error: invalid operand for instruction
 qc.lwm x7, x1, 24
 
 # CHECK-PLUS: :[[@LINE+2]]:8: error: register must be a GPR excluding zero (x0)
@@ -104,7 +109,8 @@ qc.lwm x7, x1, 24(x20)
 # CHECK: :[[@LINE+1]]:19: error: expected register
 qc.lwmi x13, 9, 4(23)
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|17: error: invalid operand for instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:17: error: invalid operand for instruction
 qc.lwmi x13, 9, 4
 
 # CHECK-PLUS: :[[@LINE+2]]:9: error: register must be a GPR excluding zero (x0)

--- a/llvm/test/MC/RISCV/xqcisim-invalid.s
+++ b/llvm/test/MC/RISCV/xqcisim-invalid.s
@@ -1,16 +1,16 @@
 # Xqcisim - Simulaton Hint Instructions
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcisim < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcisim < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+1]]:14: error: immediate must be an integer in the range [0, 1023]
 qc.psyscalli 1024
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.psyscalli
 
-# CHECK: :[[@LINE+1]]:{{18: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:18: error: unexpected extra operand for instruction
 qc.psyscalli 23, x0
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
@@ -20,105 +20,105 @@ qc.psyscalli       1023
 # CHECK-PLUS: :[[@LINE+1]]:11: error: immediate must be an integer in the range [0, 255]
 qc.pputci 256
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.pputci
 
-# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:16: error: unexpected extra operand for instruction
 qc.pputci 200, x8
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.pputci  255
 
 
-# CHECK: :[[@LINE+1]]:{{13: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:13: error: unexpected extra operand for instruction
 qc.c.ptrace x0
 
-# CHECK: :[[@LINE+1]]:{{13: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:13: error: unexpected extra operand for instruction
 qc.c.ptrace 1
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.c.ptrace
 
 
-# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:14: error: unexpected extra operand for instruction
 qc.pcoredump 12
 
-# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:14: error: unexpected extra operand for instruction
 qc.pcoredump x4
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.pcoredump
 
 
-# CHECK: :[[@LINE+1]]:{{11: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:11: error: unexpected extra operand for instruction
 qc.ppregs x1
 
-# CHECK: :[[@LINE+1]]:{{11: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:11: error: unexpected extra operand for instruction
 qc.ppregs 23
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.ppregs
 
 
-# CHECK: :[[@LINE+1]]:{{15: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:15: error: unexpected extra operand for instruction
 qc.ppreg x10, x2
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.ppreg
 
-# CHECK: :[[@LINE+1]]:{{10: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:10: error: invalid operand for instruction
 qc.ppreg 23
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.ppreg   a0
 
 
-# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:14: error: unexpected extra operand for instruction
 qc.pputc x7, x3
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.pputc
 
-# CHECK: :[[@LINE+1]]:{{10: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:10: error: invalid operand for instruction
 qc.pputc 34
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.pputc   t2
 
 
-# CHECK: :[[@LINE+1]]:{{15: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:15: error: unexpected extra operand for instruction
 qc.pputs x15, x18
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.pputs
 
-# CHECK: :[[@LINE+1]]:{{10: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:10: error: invalid operand for instruction
 qc.pputs 45
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.pputs   a5
 
 
-# CHECK: :[[@LINE+1]]:{{15: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:15: error: unexpected extra operand for instruction
 qc.pexit x26, x23
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.pexit
 
-# CHECK: :[[@LINE+1]]:{{10: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:10: error: invalid operand for instruction
 qc.pexit 78
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)
 qc.pexit   s10
 
 
-# CHECK: :[[@LINE+1]]:{{18: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:18: error: unexpected extra operand for instruction
 qc.psyscall x11, x5
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.psyscall
 
-# CHECK: :[[@LINE+1]]:{{13: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+1]]:13: error: invalid operand for instruction
 qc.psyscall 98
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisim' (Qualcomm uC Simulation Hint Extension)

--- a/llvm/test/MC/RISCV/xqcisls-invalid.s
+++ b/llvm/test/MC/RISCV/xqcisls-invalid.s
@@ -1,21 +1,23 @@
 # Xqcisls - Qualcomm uC Scaled Load Store Extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcisls < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcisls < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+2]]:16: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrb x5, x2, x0, 4
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrb x5, x2, x4
 
 # CHECK-PLUS: :[[@LINE+2]]:20: error: immediate must be an integer in the range [0, 7]
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrb x5, x2, x4, 12
 
-# CHECK: :[[@LINE+1]]:{{12: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrb x5, 2, x4, 4
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisls' (Qualcomm uC Scaled Load Store Extension)
@@ -26,14 +28,16 @@ qc.lrb x5, x2, x4, 4
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrh x1, x12, x0, 2
 
-# CHECK: :[[@LINE+1]]:{{19: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:19: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrh x1, x12, x6
 
 # CHECK-PLUS: :[[@LINE+2]]:21: error: immediate must be an integer in the range [0, 7]
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrh x1, x12, x6, 22
 
-# CHECK: :[[@LINE+1]]:{{12: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrh x1, 12, x6, 2
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisls' (Qualcomm uC Scaled Load Store Extension)
@@ -44,14 +48,16 @@ qc.lrh x1, x12, x6, 2
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrw x15, x7, x0, 1
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrw x15, x7, x14
 
 # CHECK-PLUS: :[[@LINE+2]]:22: error: immediate must be an integer in the range [0, 7]
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrw x15, x7, x14, 11
 
-# CHECK: :[[@LINE+1]]:{{13: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrw x15, 7, x14, 1
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisls' (Qualcomm uC Scaled Load Store Extension)
@@ -62,14 +68,16 @@ qc.lrw x15, x7, x14, 1
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrbu x9, x11, x0, 7
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrbu x9, x11, x4
 
 # CHECK-PLUS: :[[@LINE+2]]:22: error: immediate must be an integer in the range [0, 7]
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrbu x9, x11, x4, 37
 
-# CHECK: :[[@LINE+1]]:{{13: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrbu x9, 11, x4, 7
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisls' (Qualcomm uC Scaled Load Store Extension)
@@ -80,14 +88,16 @@ qc.lrbu x9, x11, x4, 7
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrhu x16, x6, x0, 4
 
-# CHECK: :[[@LINE+1]]:{{21: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:21: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrhu x16, x6, x10
 
 # CHECK-PLUS: :[[@LINE+2]]:23: error: immediate must be an integer in the range [0, 7]
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrhu x16, x6, x10, 44
 
-# CHECK: :[[@LINE+1]]:{{14: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.lrhu x16, 6, x10, 4
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisls' (Qualcomm uC Scaled Load Store Extension)
@@ -98,14 +108,16 @@ qc.lrhu x16, x6, x10, 4
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srb x0, x2, x0, 3
 
-# CHECK: :[[@LINE+1]]:{{18: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:18: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srb x0, x2, x8
 
 # CHECK-PLUS: :[[@LINE+2]]:20: error: immediate must be an integer in the range [0, 7]
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srb x0, x2, x8, 93
 
-# CHECK: :[[@LINE+1]]:{{12: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:12: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srb x0, 2, x8, 3
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisls' (Qualcomm uC Scaled Load Store Extension)
@@ -116,14 +128,16 @@ qc.srb x0, x2, x8, 3
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srh x13, x0, x0, 6
 
-# CHECK: :[[@LINE+1]]:{{20: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:20: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srh x13, x0, x20
 
 # CHECK-PLUS: :[[@LINE+2]]:22: error: immediate must be an integer in the range [0, 7]
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srh x13, x0, x20, 76
 
-# CHECK: :[[@LINE+1]]:{{13: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srh x13, 0, x20, 6
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisls' (Qualcomm uC Scaled Load Store Extension)
@@ -134,14 +148,16 @@ qc.srh x13, x0, x20, 6
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srw x17, x18, x0, 0
 
-# CHECK: :[[@LINE+1]]:{{21: error: too few operands for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:21: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srw x17, x18, x19
 
 # CHECK-PLUS: :[[@LINE+2]]:23: error: immediate must be an integer in the range [0, 7]
 # CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srw x17, x18, x19, 10
 
-# CHECK: :[[@LINE+1]]:{{13: error: invalid operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.srw x17, 18, x19, 0
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisls' (Qualcomm uC Scaled Load Store Extension)

--- a/llvm/test/MC/RISCV/xqcisync-invalid.s
+++ b/llvm/test/MC/RISCV/xqcisync-invalid.s
@@ -1,16 +1,18 @@
 # Xqcisync - Qualcomm uC Sync Delay Extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcisync < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-PLUS %s
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcisync < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK-MINUS %s
 
 # CHECK-PLUS: :[[@LINE+1]]:12: error: immediate must be an integer in the range [1, 31]
 qc.c.delay 34
 
-# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:16: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.delay 11, 12
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.delay
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Sync Delay Extension)
@@ -20,10 +22,12 @@ qc.c.delay   10
 # CHECK-PLUS: :[[@LINE+1]]:9: error: immediate must be an integer in the range [0, 31]
 qc.sync 45
 
-# CHECK: :[[@LINE+1]]:{{13: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:13: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.sync 22, x4
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.sync
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Sync Delay Extension)
@@ -33,10 +37,12 @@ qc.sync 8
 # CHECK-PLUS: :[[@LINE+1]]:10: error: immediate must be an integer in the range [0, 31]
 qc.syncr 56
 
-# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.syncr 31, 45
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.syncr
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Sync Delay Extension)
@@ -46,10 +52,12 @@ qc.syncr   23
 # CHECK-PLUS: :[[@LINE+1]]:11: error: immediate must be an integer in the range [0, 31]
 qc.syncwf 88
 
-# CHECK: :[[@LINE+1]]:{{14: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:14: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.syncwf 5, 44
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.syncwf
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Sync Delay Extension)
@@ -59,10 +67,12 @@ qc.syncwf  31
 # CHECK-PLUS: :[[@LINE+1]]:11: error: immediate must be an integer in the range [0, 31]
 qc.syncwl 99
 
-# CHECK: :[[@LINE+1]]:{{15: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:15: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.syncwl 11, x10
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.syncwl
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Sync Delay Extension)
@@ -72,10 +82,12 @@ qc.syncwl  1
 # CHECK-PLUS: :[[@LINE+1]]:11: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.sync 45
 
-# CHECK: :[[@LINE+1]]:{{15: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:15: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.sync 31, x4
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.sync
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Sync Delay Extension)
@@ -85,10 +97,12 @@ qc.c.sync 8
 # CHECK-PLUS: :[[@LINE+1]]:12: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.syncr 56
 
-# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:16: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.syncr 31, 45
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.syncr
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Sync Delay Extension)
@@ -98,10 +112,12 @@ qc.c.syncr   8
 # CHECK-PLUS: :[[@LINE+1]]:13: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.syncwf 88
 
-# CHECK: :[[@LINE+1]]:{{16: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:16: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.syncwf 8, 44
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.syncwf
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Sync Delay Extension)
@@ -111,10 +127,12 @@ qc.c.syncwf  31
 # CHECK-PLUS: :[[@LINE+1]]:13: error: immediate must be one of: 0, 1, 2, 4, 8, 15, 16, 31
 qc.c.syncwl 99
 
-# CHECK: :[[@LINE+1]]:{{17: error: unexpected extra operand for instruction|1: error: invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:17: error: unexpected extra operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.syncwl 15, x10
 
-# CHECK: :[[@LINE+1]]:1: error: {{too few operands for instruction|invalid instruction}}
+# CHECK-PLUS: :[[@LINE+2]]:1: error: too few operands for instruction
+# CHECK-MINUS: :[[@LINE+1]]:1: error: invalid instruction
 qc.c.syncwl
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Sync Delay Extension)


### PR DESCRIPTION
- Avoid `{{...|...}}` in CHECK lines, instead prefer CHECK-MINUS/CHECK-PLUS.
- Migrate from CHECK-IMM/CHECK-EXT to CHECK-MINUS/CHECK-PLUS.
- Remove unused CHECK prefixes.
- Fixup the few places where there were errors because FileCheck was using CHECK-IMM/CHECK-EXT when the check lines used CHECK-PLUS/CHECK-MINUS.

---

Prepared with the assistance of AI