### PR TITLE
[clang][analyzer] Fix assertion failure in StdLibraryFunctionsChecker with non-integral ssize_t

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
@@ -304,11 +304,7 @@ class StdLibraryFunctionsChecker
 
   protected:
     bool checkSpecificValidity(const FunctionDecl *FD) const override {
-      const bool ValidArg =
-          getArgType(FD, ArgN)->isIntegralType(FD->getASTContext());
-      assert(ValidArg &&
-             "This constraint should be applied on an integral type");
-      return ValidArg;
+      return getArgType(FD, ArgN)->isIntegralType(FD->getASTContext());
     }
 
   private:

--- a/clang/test/Analysis/std-c-library-functions-non-integral-ssize_t.cpp
+++ b/clang/test/Analysis/std-c-library-functions-non-integral-ssize_t.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_analyze_cc1 %s \
+// RUN:   -analyzer-checker=core \
+// RUN:   -analyzer-checker=unix.StdCLibraryFunctions \
+// RUN:   -analyzer-config unix.StdCLibraryFunctions:ModelPOSIX=true \
+// RUN:   -triple x86_64-unknown-linux -verify
+
+// expected-no-diagnostics
+
+// Regression test for https://github.com/llvm/llvm-project/issues/209436
+// When ssize_t is defined as a non-integral type (violating POSIX), the
+// checker should gracefully skip the summary rather than asserting.
+
+struct sockaddr;
+using socklen_t = unsigned;
+typedef decltype(sizeof(int)) size_t;
+typedef float ssize_t; // Non-POSIX-conforming definition.
+ssize_t recvfrom(int socket, void *buffer, size_t length, int flags,
+                 struct sockaddr *address, socklen_t *address_len);
+
+int bar(void);
+void foo() { bar(); }


### PR DESCRIPTION
In StdLibraryFunctionsCheckers' `RangeConstraint::checkSpecificValidity` asserted that the constrained argument type is integral. When user code typedefs `ssize_t` to a non-integral type (e.g. `float`) even though this violates POSIX.1-2017, which requires `ssize_t` to be a signed integer type, the signature still matches (same canonical type) and the assertion fires during constraint validation. Remove it and let `validateByConstraints` gracefully reject the summary by returning false.

Fixes #209436