### PR TITLE
[libcxx] Remove dependency on msvcprt/libcpmt

### DIFF
--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -741,23 +741,6 @@ function(cxx_link_system_libraries target)
   endif()
 
   if (MSVC)
-    if ((NOT CMAKE_MSVC_RUNTIME_LIBRARY AND uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
-        OR (CMAKE_MSVC_RUNTIME_LIBRARY MATCHES "Debug"))
-      set(LIB_SUFFIX "d")
-    else()
-      set(LIB_SUFFIX "")
-    endif()
-
-    if (NOT CMAKE_MSVC_RUNTIME_LIBRARY OR CMAKE_MSVC_RUNTIME_LIBRARY MATCHES "DLL$")
-      set(CRT_LIB "msvcrt")
-      set(CXX_LIB "msvcprt")
-    else()
-      set(CRT_LIB "libcmt")
-      set(CXX_LIB "libcpmt")
-    endif()
-
-    target_link_libraries(${target} PRIVATE ${CRT_LIB}${LIB_SUFFIX}) # C runtime startup files
-    target_link_libraries(${target} PRIVATE ${CXX_LIB}${LIB_SUFFIX}) # C++ standard library. Required for exception_ptr internals.
     # Required for standards-complaint wide character formatting functions
     # (e.g. `printfw`/`scanfw`)
     target_link_libraries(${target} PRIVATE iso_stdio_wide_specifiers)

--- a/libcxx/docs/ReleaseNotes/24.rst
+++ b/libcxx/docs/ReleaseNotes/24.rst
@@ -67,6 +67,8 @@ Potentially breaking changes
 - Unused objects of containers are now diagnosed. To ease the transition ``_LIBCPP_DISABLE_UNUSED_STRUCT_WARNINGS`` can
   be defined as an escape hatch. This escape hatch will be removed in LLVM 24.
 
+- libc++ no longer depends on msvcprt/libcpmt in the MSVC mode.
+
 Announcements About Future Releases
 -----------------------------------
 

--- a/libcxx/test/configs/llvm-libc++-shared-clangcl.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-shared-clangcl.cfg.in
@@ -5,22 +5,19 @@ dbg_include = ''
 runtime_library = '@CMAKE_MSVC_RUNTIME_LIBRARY@'
 if runtime_library == '' or runtime_library.endswith('DLL'):
     fms_runtime_lib = 'dll'
-    cxx_lib = 'msvcprt'
 else:
     fms_runtime_lib = 'static'
-    cxx_lib = 'libcpmt'
 
 if '@CMAKE_BUILD_TYPE@'.upper() == 'DEBUG':
     dbg_include = ' -D_DEBUG -include set_windows_crt_report_mode.h'
     fms_runtime_lib += '_dbg'
-    cxx_lib += 'd'
 
 config.substitutions.append(('%{flags}', '--driver-mode=g++'))
 config.substitutions.append(('%{compile_flags}',
     '-fms-runtime-lib=' + fms_runtime_lib + ' -nostdinc++ -I %{target-include-dir} -I %{include-dir} -I %{libcxx-dir}/test/support -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_STDIO_ISO_WIDE_SPECIFIERS -DNOMINMAX' + dbg_include
 ))
 config.substitutions.append(('%{link_flags}',
-    '-nostdlib -L %{lib-dir} -lc++ -l' + cxx_lib
+    '-nostdlib -L %{lib-dir} -lc++'
 ))
 config.substitutions.append(('%{exec}',
     '%{executor} --execdir %{temp} --prepend_env PATH=%{install-prefix}/bin -- '

--- a/libcxx/test/configs/llvm-libc++-shared-no-vcruntime-clangcl.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-shared-no-vcruntime-clangcl.cfg.in
@@ -6,22 +6,19 @@ dbg_include = ''
 runtime_library = '@CMAKE_MSVC_RUNTIME_LIBRARY@'
 if runtime_library == '' or runtime_library.endswith('DLL'):
     fms_runtime_lib = 'dll'
-    cxx_lib = 'msvcprt'
 else:
     fms_runtime_lib = 'static'
-    cxx_lib = 'libcpmt'
 
 if '@CMAKE_BUILD_TYPE@'.upper() == 'DEBUG':
     dbg_include = ' -D_DEBUG -include set_windows_crt_report_mode.h'
     fms_runtime_lib += '_dbg'
-    cxx_lib += 'd'
 
 config.substitutions.append(('%{flags}', '--driver-mode=g++'))
 config.substitutions.append(('%{compile_flags}',
     '-fms-runtime-lib=' + fms_runtime_lib + ' -nostdinc++ -I %{include-dir} -I %{target-include-dir} -I %{libcxx-dir}/test/support -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_STDIO_ISO_WIDE_SPECIFIERS -DNOMINMAX -D_HAS_EXCEPTIONS=0' + dbg_include
 ))
 config.substitutions.append(('%{link_flags}',
-    '-nostdlib -L %{lib-dir} -lc++ -l' + cxx_lib
+    '-nostdlib -L %{lib-dir} -lc++'
 ))
 config.substitutions.append(('%{exec}',
     '%{executor} --execdir %{temp} --prepend_env PATH=%{install-prefix}/bin -- '

--- a/libcxx/test/configs/llvm-libc++-static-clangcl.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-static-clangcl.cfg.in
@@ -5,22 +5,19 @@ dbg_include = ''
 runtime_library = '@CMAKE_MSVC_RUNTIME_LIBRARY@'
 if runtime_library == '' or runtime_library.endswith('DLL'):
     fms_runtime_lib = 'dll'
-    cxx_lib = 'msvcprt'
 else:
     fms_runtime_lib = 'static'
-    cxx_lib = 'libcpmt'
 
 if '@CMAKE_BUILD_TYPE@'.upper() == 'DEBUG':
     dbg_include = ' -D_DEBUG -include set_windows_crt_report_mode.h'
     fms_runtime_lib += '_dbg'
-    cxx_lib += 'd'
 
 config.substitutions.append(('%{flags}', '--driver-mode=g++'))
 config.substitutions.append(('%{compile_flags}',
     '-fms-runtime-lib=' + fms_runtime_lib + ' -nostdinc++ -I %{target-include-dir} -I %{include-dir} -I %{libcxx-dir}/test/support -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_STDIO_ISO_WIDE_SPECIFIERS -DNOMINMAX' + dbg_include
 ))
 config.substitutions.append(('%{link_flags}',
-    '-nostdlib -L %{lib-dir} -llibc++ -l' + cxx_lib
+    '-nostdlib -L %{lib-dir} -llibc++'
 ))
 config.substitutions.append(('%{exec}',
     '%{executor} --execdir %{temp} -- '


### PR DESCRIPTION
This is no longer needed in MSVC mode now after #94977 and #150182.