### PR TITLE
[mlir][func] Fix a crash in DuplicateFunctionEliminationPass

### DIFF
--- a/mlir/lib/Dialect/Func/Transforms/DuplicateFunctionElimination.cpp
+++ b/mlir/lib/Dialect/Func/Transforms/DuplicateFunctionElimination.cpp
@@ -101,12 +101,12 @@ struct DuplicateFunctionEliminationPass
 
     // Update all symbol uses to reference unique func op
     // representants and erase redundant func ops.
-    SymbolTableCollection symbolTable;
-    SymbolUserMap userMap(symbolTable, module);
     for (auto it : toBeErased) {
       StringAttr oldSymbol = it.getSymNameAttr();
       StringAttr newSymbol = getRepresentant[oldSymbol].getSymNameAttr();
-      userMap.replaceAllUsesWith(it, newSymbol);
+      if (failed(
+              SymbolTable::replaceAllSymbolUses(oldSymbol, newSymbol, module)))
+        return signalPassFailure();
       it.erase();
     }
   }

--- a/mlir/test/Dialect/Func/duplicate-function-elimination.mlir
+++ b/mlir/test/Dialect/Func/duplicate-function-elimination.mlir
@@ -412,3 +412,29 @@ func.func @user(%arg0: tensor<f32>) -> tensor<f32> {
 // CHECK:     @user
 // CHECK-2:     constant @identity
 // CHECK:       call @identity
+
+// -----
+
+func.func @callee0() {
+  return
+}
+
+func.func @caller0() {
+  call @callee1() : () -> ()
+  return
+}
+
+func.func @caller1() {
+  call @callee1() : () -> ()
+  return
+}
+
+func.func @callee1() {
+  return
+}
+
+// CHECK:     @callee0
+// CHECK:     @caller0
+// CHECK:       call @callee0()
+// CHECK-NOT: @caller1
+// CHECK-NOT: @callee1


### PR DESCRIPTION
Previously, we used `SymbolUserMap::replaceAllUsesWith` to replace symbols, but this could not update the symbol table cached by `SymbolUserMap` during traversal, leading to a crash. This PR switches to `SymbolTable::replaceAllSymbolUses`, which always operates on the latest symbol table and avoids the crash. Fixes #209648.